### PR TITLE
chore(scaffold): add initial cobra CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/symphony

--- a/cmd/symphony/main.go
+++ b/cmd/symphony/main.go
@@ -1,0 +1,48 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/signal"
+	"syscall"
+
+	"github.com/spf13/cobra"
+)
+
+func main() {
+	setupLoggerFromEnv(os.Stderr)
+
+	ctx, stop := newSignalContext(context.Background())
+	defer stop()
+
+	if err := newRootCommand(ctx).ExecuteContext(ctx); err != nil {
+		if errors.Is(err, context.Canceled) {
+			slog.Info("shutdown requested")
+			return
+		}
+
+		slog.Error("command failed", "error", err)
+		os.Exit(1)
+	}
+}
+
+func newRootCommand(ctx context.Context) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "symphony",
+		Short:        "Symphony agent orchestrator",
+		Long:         "Symphony is an agent orchestrator for tracker-backed work queues.",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			return cmd.Help()
+		},
+	}
+	cmd.SetContext(ctx)
+
+	return cmd
+}
+
+func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
+}

--- a/cmd/symphony/main_test.go
+++ b/cmd/symphony/main_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRootCommandHelp(t *testing.T) {
+	cmd := newRootCommand(context.Background())
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{"symphony", "agent orchestrator", "Usage:"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestRootCommandWithoutArgsShowsHelp(t *testing.T) {
+	cmd := newRootCommand(context.Background())
+
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if !strings.Contains(stdout.String(), "Usage:") {
+		t.Fatalf("expected usage output, got:\n%s", stdout.String())
+	}
+}
+
+func TestSignalContextCancel(t *testing.T) {
+	ctx, cancel := newSignalContext(context.Background())
+	cancel()
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("signal context was not canceled")
+	}
+}

--- a/cmd/symphony/slog.go
+++ b/cmd/symphony/slog.go
@@ -1,0 +1,69 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/lmittmann/tint"
+)
+
+func setupLoggerFromEnv(w io.Writer) *slog.Logger {
+	return setupLogger(envValue("SYMPHONY_ENV", "ENV"), envValue("SYMPHONY_LOG_LEVEL", "LOG_LEVEL"), w)
+}
+
+func setupLogger(env string, level string, w io.Writer) *slog.Logger {
+	logger := slog.New(newLogHandler(env, level, w))
+	slog.SetDefault(logger)
+	return logger
+}
+
+func newLogHandler(env string, level string, w io.Writer) slog.Handler {
+	if w == nil {
+		w = io.Discard
+	}
+
+	logLevel := parseLogLevel(level)
+	if isDevelopment(env) {
+		return tint.NewHandler(w, &tint.Options{
+			Level:      logLevel,
+			TimeFormat: time.Kitchen,
+			AddSource:  logLevel == slog.LevelDebug,
+		})
+	}
+
+	return slog.NewJSONHandler(w, &slog.HandlerOptions{
+		Level: logLevel,
+	})
+}
+
+func parseLogLevel(level string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+func isDevelopment(env string) bool {
+	switch strings.ToLower(strings.TrimSpace(env)) {
+	case "dev", "development", "local":
+		return true
+	default:
+		return false
+	}
+}
+
+func envValue(primary string, fallback string) string {
+	if value := os.Getenv(primary); value != "" {
+		return value
+	}
+	return os.Getenv(fallback)
+}

--- a/cmd/symphony/slog_test.go
+++ b/cmd/symphony/slog_test.go
@@ -1,0 +1,103 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"log/slog"
+	"testing"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		level string
+		want  slog.Level
+	}{
+		{name: "debug", level: "debug", want: slog.LevelDebug},
+		{name: "info", level: "info", want: slog.LevelInfo},
+		{name: "warn", level: "warn", want: slog.LevelWarn},
+		{name: "error", level: "error", want: slog.LevelError},
+		{name: "default", level: "", want: slog.LevelInfo},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := parseLogLevel(tt.level); got != tt.want {
+				t.Fatalf("parseLogLevel(%q) = %v, want %v", tt.level, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSetupLoggerSetsDefault(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	logger := setupLogger("development", "debug", &bytes.Buffer{})
+
+	if slog.Default() != logger {
+		t.Fatal("setupLogger did not set the default slog logger")
+	}
+	if !logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("debug logger does not enable debug records")
+	}
+}
+
+func TestSetupLoggerFromEnvUsesSymphonyVariables(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	t.Setenv("SYMPHONY_ENV", "development")
+	t.Setenv("ENV", "production")
+	t.Setenv("SYMPHONY_LOG_LEVEL", "debug")
+	t.Setenv("LOG_LEVEL", "error")
+
+	logger := setupLoggerFromEnv(&bytes.Buffer{})
+
+	if !logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("expected SYMPHONY_LOG_LEVEL to enable debug records")
+	}
+}
+
+func TestProductionLoggerWritesJSON(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	var out bytes.Buffer
+	logger := setupLogger("production", "info", &out)
+	logger.Info("ready", "component", "test")
+
+	var record map[string]any
+	if err := json.Unmarshal(out.Bytes(), &record); err != nil {
+		t.Fatalf("log output is not JSON: %v\n%s", err, out.String())
+	}
+	if record["msg"] != "ready" {
+		t.Fatalf("msg = %v, want ready", record["msg"])
+	}
+	if record["component"] != "test" {
+		t.Fatalf("component = %v, want test", record["component"])
+	}
+}
+
+func TestNewLogHandlerAllowsNilWriter(t *testing.T) {
+	logger := slog.New(newLogHandler("production", "info", nil))
+	logger.Info("discarded")
+}
+
+func TestEnvValueFallback(t *testing.T) {
+	t.Setenv("SYMPHONY_TEST_FALLBACK", "fallback")
+
+	if got := envValue("SYMPHONY_TEST_PRIMARY", "SYMPHONY_TEST_FALLBACK"); got != "fallback" {
+		t.Fatalf("envValue fallback = %q, want fallback", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,13 @@
+module github.com/digitaldrywood/symphony-go
+
+go 1.26
+
+require (
+	github.com/lmittmann/tint v1.1.3
+	github.com/spf13/cobra v1.10.2
+)
+
+require (
+	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/spf13/pflag v1.0.9 // indirect
+)

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,12 @@
+github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
+github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
+github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
+github.com/lmittmann/tint v1.1.3 h1:Hv4EaHWXQr+GTFnOU4VKf8UvAtZgn0VuKT+G0wFlO3I=
+github.com/lmittmann/tint v1.1.3/go.mod h1:HIS3gSy7qNwGCj+5oRjAutErFBl4BzdQP6cJZ0NfMwE=
+github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
+github.com/spf13/cobra v1.10.2 h1:DMTTonx5m65Ic0GOoRY2c16WCbHxOOw6xxezuLaBpcU=
+github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiTUUS4=
+github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
+github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
+go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
## Summary
- Initialize the Go 1.26 module for github.com/digitaldrywood/symphony-go.
- Add the cmd/symphony Cobra root command with signal-aware execution.
- Add slog setup with tint for development and JSON output for production.
- Add focused tests for CLI help, signal cancellation, and logger behavior.

Fixes #2

## Test Plan
- go build ./...
- go vet ./...
- go test ./...
- go test -cover ./... (74.3%)
- go run ./cmd/symphony --help