### PR TITLE
chore(tooling): add dev tooling

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -1,0 +1,54 @@
+#:schema https://json.schemastore.org/any.json
+
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = []
+  bin = "./tmp/symphony"
+  cmd = "go build -o ./tmp/symphony ./cmd/symphony"
+  delay = 1000
+  exclude_dir = ["tmp", "vendor", "testdata", "node_modules", "internal/database/sqlc"]
+  exclude_file = ["go.sum"]
+  exclude_regex = ["_test\\.go", "_templ\\.go$"]
+  exclude_unchanged = false
+  follow_symlink = false
+  full_bin = "SYMPHONY_ENV=development SYMPHONY_LOG_LEVEL=debug ./tmp/symphony"
+  include_dir = []
+  include_ext = ["go", "templ", "sql", "css", "js", "html", "yaml", "yml", "toml"]
+  include_file = []
+  kill_delay = "500ms"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = ["mkdir -p tmp; lsof -ti:${PORT:-8080} | xargs kill -9 2>/dev/null || true; sleep 0.5", "go generate ./...", "go mod tidy"]
+  rerun = false
+  rerun_delay = 500
+  send_interrupt = true
+  stop_on_error = true
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  silent = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,11 +27,11 @@ jobs:
       - name: Download modules
         run: go mod download
 
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v9
-        with:
-          version: v2.1.6
-          args: --timeout=5m
+      - name: Install golangci-lint
+        run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+
+      - name: Run golangci-lint
+        run: golangci-lint run --timeout=5m
 
   test:
     name: Test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,91 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: golangci-lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.1.6
+          args: --timeout=5m
+
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: make test
+
+  test-race:
+    name: Test Race
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run race tests
+        run: make test-race
+
+  test-cover:
+    name: Test Coverage
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Check coverage
+        run: make test-cover
+
+  build:
+    name: Build
+    runs-on: ubuntu-latest
+    needs: [lint, test, test-race, test-cover]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Build
+        run: make build

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
+tmp/
 /symphony

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,89 @@
+version: "2"
+
+run:
+  timeout: 5m
+  tests: true
+  modules-download-mode: readonly
+
+linters:
+  default: none
+  enable:
+    - bodyclose
+    - errcheck
+    - gosec
+    - govet
+    - ineffassign
+    - misspell
+    - noctx
+    - sqlclosecheck
+    - staticcheck
+    - unconvert
+    - unused
+
+  settings:
+    errcheck:
+      check-blank: true
+      check-type-assertions: true
+      exclude-functions:
+        - fmt.Fprint
+        - fmt.Fprintf
+        - fmt.Fprintln
+        - fmt.Print
+        - fmt.Printf
+        - fmt.Println
+        - (net/http.ResponseWriter).Write
+        - (github.com/labstack/echo/v4.Context).String
+        - (github.com/labstack/echo/v4.Context).NoContent
+        - (*encoding/json.Encoder).Encode
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (*net/http.Response.Body).Close
+        - (*database/sql.DB).Close
+        - (*database/sql.Rows).Close
+        - (*database/sql.Stmt).Close
+        - (*database/sql.Tx).Rollback
+
+    govet:
+      enable-all: true
+      disable:
+        - fieldalignment
+        - shadow
+
+    gosec:
+      severity: medium
+      confidence: medium
+      excludes:
+        - G115
+        - G304
+        - G306
+        - G301
+        - G107
+
+  exclusions:
+    generated: strict
+    rules:
+      - path: _test\.go
+        linters:
+          - gosec
+          - errcheck
+      - path: _templ\.go$
+        linters:
+          - all
+      - path: internal/database/sqlc/
+        linters:
+          - all
+
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
+
+formatters:
+  enable:
+    - gofmt
+    - goimports
+  settings:
+    goimports:
+      local-prefixes:
+        - github.com/digitaldrywood/symphony-go
+  exclusions:
+    generated: strict

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,39 @@
+# CLAUDE.md
+
+## Project Conventions
+
+- Use English for code, comments, documentation, errors, tests, commits, and examples.
+- Target Go 1.26 and idiomatic standard-library-first Go.
+- Keep application code feature-packaged under `internal/` as the system grows.
+- Prefer constructor dependency injection over global state or wire/fx.
+- Use interfaces and factories only at backend/plugin boundaries where they remove real coupling.
+- Use `log/slog` for logging.
+- Use Echo for HTTP, sqlc with goose migrations for persistence, and `modernc.org/sqlite` for SQLite.
+- Use Templ, HTMX, and Tailwind v4 for server-rendered UI.
+- Use Air for local hot reload and golangci-lint v2 for linting.
+
+## Workflow
+
+- Work from a Symphony-created worktree branch, never directly on `main`.
+- Keep generated files and runtime output inside the current worktree.
+- Do not bind development or tests to `127.0.0.1:4000`; use ephemeral ports in tests.
+- Before implementation, confirm dependencies listed in the issue are merged into `origin/main`.
+- Keep changes scoped to the active issue.
+- Run `make check` before pushing or opening a PR.
+- Run `make generate` before committing when templates, sqlc queries, or CSS inputs change.
+- Commit only when explicitly requested by the workflow or human, and use conventional commit messages.
+
+## Validation
+
+- `make check` is the local pre-review gate.
+- `make check` runs build, golangci-lint, go vet, race tests, and a 70% coverage gate.
+- New or modified Go behavior requires focused table-driven tests using only the standard library.
+- Generated Go files such as `*_templ.go` and sqlc output do not need hand-written tests.
+
+## Tooling
+
+- `make dev` runs Air and rotates `tmp/air-combined.log`.
+- `make generate` runs `go generate`, Templ, sqlc, and Tailwind when their inputs exist.
+- `make setup` installs Air, Templ, sqlc, goose, and golangci-lint v2.
+- `make sqlc` uses `sqlc/sqlc.yaml` by default.
+- `make db-migrate` uses goose against `internal/database/migrations` by default.

--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,7 @@ setup:
 	go install github.com/a-h/templ/cmd/templ@latest
 	go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 	go install github.com/pressly/goose/v3/cmd/goose@latest
-	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$$(go env GOPATH)/bin" v2.1.6
+	go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
 	@if [ -f package.json ]; then npm install; fi
 
 clean:

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,122 @@
+SHELL := /bin/bash
+
+BINARY_NAME := symphony
+BINARY_PATH := tmp/$(BINARY_NAME)
+CMD_PACKAGE := ./cmd/symphony
+COVERPROFILE := tmp/coverage.out
+COVERAGE_THRESHOLD := 70.0
+TAILWIND_INPUT ?= static/css/input.css
+TAILWIND_OUTPUT ?= static/css/output.css
+SQLC_CONFIG ?= sqlc/sqlc.yaml
+MIGRATIONS_DIR ?= internal/database/migrations
+GOOSE_DRIVER ?= sqlite3
+DATABASE_URL ?= tmp/symphony.db
+
+.PHONY: dev generate css css-watch build test test-race test-cover lint vet check sqlc db-migrate setup clean help
+
+dev:
+	@mkdir -p tmp
+	@if [ -f tmp/air-combined.log ]; then \
+		mv tmp/air-combined.log tmp/air-combined-$$(date +%Y%m%d-%H%M%S).log; \
+	fi
+	@ls -t tmp/air-combined-*.log 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null || true
+	@air 2>&1 | tee tmp/air-combined.log
+
+generate:
+	@go generate ./...
+	@if [ -n "$$(git ls-files --others --exclude-standard -- '*.templ'; git ls-files -- '*.templ')" ]; then \
+		templ generate; \
+	else \
+		echo "No templ files found; skipping templ generate."; \
+	fi
+	@$(MAKE) sqlc
+	@$(MAKE) css
+
+css:
+	@if [ -f "$(TAILWIND_INPUT)" ]; then \
+		mkdir -p "$$(dirname "$(TAILWIND_OUTPUT)")"; \
+		npx @tailwindcss/cli -i "$(TAILWIND_INPUT)" -o "$(TAILWIND_OUTPUT)" --minify; \
+	else \
+		echo "No Tailwind input at $(TAILWIND_INPUT); skipping CSS build."; \
+	fi
+
+css-watch:
+	@if [ -f "$(TAILWIND_INPUT)" ]; then \
+		mkdir -p "$$(dirname "$(TAILWIND_OUTPUT)")"; \
+		npx @tailwindcss/cli -i "$(TAILWIND_INPUT)" -o "$(TAILWIND_OUTPUT)" --watch; \
+	else \
+		echo "No Tailwind input at $(TAILWIND_INPUT); skipping CSS watch."; \
+	fi
+
+build: generate
+	@mkdir -p tmp
+	go build -o $(BINARY_PATH) $(CMD_PACKAGE)
+
+test:
+	go test ./...
+
+test-race:
+	go test -race ./...
+
+test-cover:
+	@mkdir -p tmp
+	go test -coverprofile=$(COVERPROFILE) ./...
+	@coverage="$$(go tool cover -func=$(COVERPROFILE) | awk '/^total:/ { gsub(/%/, "", $$3); print $$3 }')"; \
+	awk -v coverage="$$coverage" -v threshold="$(COVERAGE_THRESHOLD)" 'BEGIN { \
+		if (coverage + 0 < threshold + 0) { \
+			printf "coverage %.1f%% is below %.1f%%\n", coverage, threshold; \
+			exit 1; \
+		} \
+		printf "coverage %.1f%% meets %.1f%% threshold\n", coverage, threshold; \
+	}'
+
+lint:
+	golangci-lint run --timeout=5m
+
+vet:
+	go vet ./...
+
+check: build lint vet test-race test-cover
+	@echo "All checks passed."
+
+sqlc:
+	@if [ -f "$(SQLC_CONFIG)" ]; then \
+		sqlc generate -f "$(SQLC_CONFIG)"; \
+	else \
+		echo "No sqlc config at $(SQLC_CONFIG); skipping sqlc generate."; \
+	fi
+
+db-migrate:
+	@if [ -d "$(MIGRATIONS_DIR)" ]; then \
+		mkdir -p "$$(dirname "$(DATABASE_URL)")"; \
+		goose -dir "$(MIGRATIONS_DIR)" "$(GOOSE_DRIVER)" "$(DATABASE_URL)" up; \
+	else \
+		echo "No migrations directory at $(MIGRATIONS_DIR); skipping database migration."; \
+	fi
+
+setup:
+	go install github.com/air-verse/air@latest
+	go install github.com/a-h/templ/cmd/templ@latest
+	go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
+	go install github.com/pressly/goose/v3/cmd/goose@latest
+	curl -sSfL https://raw.githubusercontent.com/golangci/golangci-lint/HEAD/install.sh | sh -s -- -b "$$(go env GOPATH)/bin" v2.1.6
+	@if [ -f package.json ]; then npm install; fi
+
+clean:
+	rm -rf tmp
+
+help:
+	@echo "Available targets:"
+	@echo "  dev          Run Air with combined log rotation"
+	@echo "  generate     Run go generate, templ, sqlc, and Tailwind"
+	@echo "  css          Build Tailwind CSS"
+	@echo "  css-watch    Watch and rebuild Tailwind CSS"
+	@echo "  build        Build $(BINARY_NAME)"
+	@echo "  test         Run Go tests"
+	@echo "  test-race    Run Go tests with the race detector"
+	@echo "  test-cover   Run Go coverage with a $(COVERAGE_THRESHOLD)% minimum"
+	@echo "  lint         Run golangci-lint"
+	@echo "  check        Run the local validation gate"
+	@echo "  sqlc         Generate sqlc output"
+	@echo "  db-migrate   Run goose migrations"
+	@echo "  setup        Install development tools"


### PR DESCRIPTION
## Summary
- Add Makefile targets for local dev, generation, CSS, build, test, race, coverage, lint, sqlc, migrations, setup, and check.
- Add Air, golangci-lint v2, CI, and project CLAUDE guidance.
- Keep build output and Air logs under tmp/ for worktree isolation.

Fixes #3

## Test Plan
- make check