### PR TITLE
feat(connector): add connector seam

### DIFF
--- a/internal/connector/backend.go
+++ b/internal/connector/backend.go
@@ -1,0 +1,15 @@
+package connector
+
+type Backend string
+
+const (
+	BackendMemory Backend = "memory"
+	BackendLinear Backend = "linear"
+	BackendGitHub Backend = "github"
+	BackendGitLab Backend = "gitlab"
+	BackendJira   Backend = "jira"
+)
+
+func (b Backend) String() string {
+	return string(b)
+}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -1,0 +1,25 @@
+package connector
+
+import (
+	"context"
+	"errors"
+)
+
+var ErrNotImplemented = errors.New("connector operation not implemented")
+
+type Connector interface {
+	Name() string
+	FetchCandidateIssues(context.Context) ([]Issue, error)
+	FetchIssuesByStates(context.Context, []string) ([]Issue, error)
+	FetchIssueStatesByIDs(context.Context, []string) ([]Issue, error)
+	CreateComment(context.Context, string, string) error
+	UpdateIssueState(context.Context, string, string) error
+}
+
+type Authenticator interface {
+	Authenticate(context.Context) error
+}
+
+type Provisioner interface {
+	Provision(context.Context) error
+}

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -1,0 +1,158 @@
+package connector
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+	"time"
+)
+
+type testConnector struct{}
+
+func (testConnector) Name() string {
+	return "test"
+}
+
+func (testConnector) FetchCandidateIssues(context.Context) ([]Issue, error) {
+	return nil, ErrNotImplemented
+}
+
+func (testConnector) FetchIssuesByStates(context.Context, []string) ([]Issue, error) {
+	return nil, ErrNotImplemented
+}
+
+func (testConnector) FetchIssueStatesByIDs(context.Context, []string) ([]Issue, error) {
+	return nil, ErrNotImplemented
+}
+
+func (testConnector) CreateComment(context.Context, string, string) error {
+	return ErrNotImplemented
+}
+
+func (testConnector) UpdateIssueState(context.Context, string, string) error {
+	return ErrNotImplemented
+}
+
+func TestConnectorInterface(t *testing.T) {
+	t.Parallel()
+
+	var c Connector = testConnector{}
+
+	if c.Name() != "test" {
+		t.Fatalf("Name() = %q, want test", c.Name())
+	}
+	if _, err := c.FetchCandidateIssues(context.Background()); !errors.Is(err, ErrNotImplemented) {
+		t.Fatalf("FetchCandidateIssues() error = %v, want ErrNotImplemented", err)
+	}
+}
+
+func TestBackendString(t *testing.T) {
+	t.Parallel()
+
+	if got := BackendGitHub.String(); got != "github" {
+		t.Fatalf("BackendGitHub.String() = %q, want github", got)
+	}
+}
+
+func TestIssueDefaults(t *testing.T) {
+	t.Parallel()
+
+	issue := NewIssue()
+
+	if !issue.AssignedToWorker {
+		t.Fatal("AssignedToWorker = false, want true")
+	}
+	if issue.ModelOverride != "" {
+		t.Fatalf("ModelOverride = %q, want empty string", issue.ModelOverride)
+	}
+	if len(issue.BlockedBy) != 0 {
+		t.Fatalf("BlockedBy len = %d, want 0", len(issue.BlockedBy))
+	}
+	if len(issue.Labels) != 0 {
+		t.Fatalf("Labels len = %d, want 0", len(issue.Labels))
+	}
+}
+
+func TestIssueJSONUsesElixirFieldNames(t *testing.T) {
+	t.Parallel()
+
+	priority := 2
+	createdAt := time.Date(2026, 5, 30, 17, 0, 0, 0, time.UTC)
+	updatedAt := createdAt.Add(time.Hour)
+	issue := Issue{
+		ID:               "issue-1",
+		Identifier:       "DIG-1",
+		Title:            "Port connector",
+		Description:      "Build the connector seam",
+		Priority:         &priority,
+		State:            "Todo",
+		BranchName:       "symphony/dig-1",
+		URL:              "https://example.com/issues/1",
+		AssigneeID:       "user-1",
+		BlockedBy:        []BlockedRef{{ID: "issue-0", Identifier: "DIG-0", State: "Done"}},
+		Labels:           []string{"backend", "stage:s1"},
+		AssignedToWorker: true,
+		CreatedAt:        &createdAt,
+		UpdatedAt:        &updatedAt,
+		ModelOverride:    "gpt-5-codex-high",
+	}
+
+	raw, err := json.Marshal(issue)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	for _, key := range []string{
+		"id",
+		"identifier",
+		"title",
+		"description",
+		"priority",
+		"state",
+		"branch_name",
+		"url",
+		"assignee_id",
+		"blocked_by",
+		"labels",
+		"assigned_to_worker",
+		"created_at",
+		"updated_at",
+		"model_override",
+	} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("JSON missing key %q in %s", key, raw)
+		}
+	}
+}
+
+func TestBlockedRefJSONUsesElixirFieldNames(t *testing.T) {
+	t.Parallel()
+
+	ref := BlockedRef{ID: "issue-2", Identifier: "digitaldrywood/symphony-go#2", State: "Done"}
+
+	raw, err := json.Marshal(ref)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got map[string]string
+	if err := json.Unmarshal(raw, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if got["id"] != "issue-2" {
+		t.Fatalf("id = %q, want issue-2", got["id"])
+	}
+	if got["identifier"] != "digitaldrywood/symphony-go#2" {
+		t.Fatalf("identifier = %q, want digitaldrywood/symphony-go#2", got["identifier"])
+	}
+	if got["state"] != "Done" {
+		t.Fatalf("state = %q, want Done", got["state"])
+	}
+}

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -1,0 +1,68 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+var (
+	ErrBackendNotReady    = errors.New("connector backend not ready")
+	ErrUnsupportedBackend = errors.New("unsupported connector backend")
+)
+
+type Config struct {
+	Kind string
+}
+
+func NewFromConfig(cfg Config) (connector.Connector, error) {
+	kind := normalizeKind(cfg.Kind)
+
+	switch connector.Backend(kind) {
+	case connector.BackendMemory, connector.BackendLinear, connector.BackendGitHub:
+		return unimplementedConnector{name: kind}, nil
+	case connector.BackendGitLab, connector.BackendJira:
+		return nil, fmt.Errorf("%w: %s", ErrBackendNotReady, kind)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, kind)
+	}
+}
+
+type unimplementedConnector struct {
+	name string
+}
+
+func (c unimplementedConnector) Name() string {
+	return c.name
+}
+
+func (unimplementedConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (unimplementedConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (unimplementedConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (unimplementedConnector) CreateComment(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (unimplementedConnector) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func normalizeKind(kind string) string {
+	normalized := strings.ToLower(strings.TrimSpace(kind))
+	if normalized == "" {
+		return connector.BackendMemory.String()
+	}
+	return normalized
+}

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -1,0 +1,85 @@
+package factory
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestNewFromConfigSupportedBackends(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		kind string
+		want string
+	}{
+		{name: "empty defaults to memory", kind: "", want: "memory"},
+		{name: "memory", kind: "memory", want: "memory"},
+		{name: "linear", kind: "linear", want: "linear"},
+		{name: "github", kind: "github", want: "github"},
+		{name: "normalizes whitespace and case", kind: " GitHub ", want: "github"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewFromConfig(Config{Kind: tt.kind})
+			if err != nil {
+				t.Fatalf("NewFromConfig() error = %v", err)
+			}
+			if got.Name() != tt.want {
+				t.Fatalf("Name() = %q, want %q", got.Name(), tt.want)
+			}
+		})
+	}
+}
+
+func TestNewFromConfigRejectsNotReadyBackends(t *testing.T) {
+	t.Parallel()
+
+	for _, kind := range []string{"gitlab", "jira"} {
+		t.Run(kind, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := NewFromConfig(Config{Kind: kind})
+			if got != nil {
+				t.Fatalf("connector = %T, want nil", got)
+			}
+			if !errors.Is(err, ErrBackendNotReady) {
+				t.Fatalf("error = %v, want ErrBackendNotReady", err)
+			}
+		})
+	}
+}
+
+func TestNewFromConfigRejectsUnknownBackend(t *testing.T) {
+	t.Parallel()
+
+	got, err := NewFromConfig(Config{Kind: "asana"})
+	if got != nil {
+		t.Fatalf("connector = %T, want nil", got)
+	}
+	if !errors.Is(err, ErrUnsupportedBackend) {
+		t.Fatalf("error = %v, want ErrUnsupportedBackend", err)
+	}
+}
+
+func TestFactoryConnectorOperationsAreExplicitlyUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromConfig(Config{Kind: "memory"})
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+
+	if _, err := c.FetchCandidateIssues(context.Background()); !errors.Is(err, connector.ErrNotImplemented) {
+		t.Fatalf("FetchCandidateIssues() error = %v, want ErrNotImplemented", err)
+	}
+	if err := c.CreateComment(context.Background(), "issue-1", "body"); !errors.Is(err, connector.ErrNotImplemented) {
+		t.Fatalf("CreateComment() error = %v, want ErrNotImplemented", err)
+	}
+}

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -1,0 +1,35 @@
+package connector
+
+import "time"
+
+type Issue struct {
+	ID               string       `json:"id,omitempty"`
+	Identifier       string       `json:"identifier,omitempty"`
+	Title            string       `json:"title,omitempty"`
+	Description      string       `json:"description,omitempty"`
+	Priority         *int         `json:"priority,omitempty"`
+	State            string       `json:"state,omitempty"`
+	BranchName       string       `json:"branch_name,omitempty"`
+	URL              string       `json:"url,omitempty"`
+	AssigneeID       string       `json:"assignee_id,omitempty"`
+	BlockedBy        []BlockedRef `json:"blocked_by"`
+	Labels           []string     `json:"labels"`
+	AssignedToWorker bool         `json:"assigned_to_worker"`
+	CreatedAt        *time.Time   `json:"created_at,omitempty"`
+	UpdatedAt        *time.Time   `json:"updated_at,omitempty"`
+	ModelOverride    string       `json:"model_override"`
+}
+
+type BlockedRef struct {
+	ID         string `json:"id,omitempty"`
+	Identifier string `json:"identifier"`
+	State      string `json:"state,omitempty"`
+}
+
+func NewIssue() Issue {
+	return Issue{
+		BlockedBy:        []BlockedRef{},
+		Labels:           []string{},
+		AssignedToWorker: true,
+	}
+}


### PR DESCRIPTION
## Summary
- add the connector interface, backend constants, issue model, blocked reference, and capability seams
- add a connector factory that recognizes memory, linear, and github while rejecting gitlab and jira as not ready
- cover the new interface, model JSON shape, defaults, and factory behavior with table-driven tests

Fixes #7

## Test Plan
- go test ./internal/connector/...
- go test -cover ./internal/connector/...
- go build ./...
- go vet ./...
- go test ./...
- go test -cover ./...