### PR TITLE
feat(hub,telemetry): add broadcast hub and snapshot model

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -1,0 +1,153 @@
+package hub
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var ErrClosed = errors.New("hub closed")
+
+type Option func(*options)
+
+type options struct {
+	buffer int
+}
+
+type Hub[T any] struct {
+	mu          sync.Mutex
+	subscribers map[*Subscription[T]]struct{}
+	buffer      int
+	last        T
+	hasLast     bool
+	closed      bool
+}
+
+type Subscription[T any] struct {
+	hub  *Hub[T]
+	ch   chan T
+	once sync.Once
+}
+
+func New[T any](opts ...Option) *Hub[T] {
+	cfg := options{buffer: 1}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+
+	return &Hub[T]{
+		subscribers: make(map[*Subscription[T]]struct{}),
+		buffer:      cfg.buffer,
+	}
+}
+
+func WithBuffer(size int) Option {
+	return func(cfg *options) {
+		if size > 0 {
+			cfg.buffer = size
+		}
+	}
+}
+
+func (h *Hub[T]) Subscribe(ctx context.Context) (*Subscription[T], error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	sub := &Subscription[T]{
+		hub: h,
+		ch:  make(chan T, h.buffer),
+	}
+
+	h.mu.Lock()
+	if h.closed {
+		h.mu.Unlock()
+		return nil, ErrClosed
+	}
+	h.subscribers[sub] = struct{}{}
+	if h.hasLast {
+		sendLatest(sub.ch, h.last)
+	}
+	h.mu.Unlock()
+
+	if done := ctx.Done(); done != nil {
+		go func() {
+			<-done
+			sub.Close()
+		}()
+	}
+
+	return sub, nil
+}
+
+func (h *Hub[T]) Publish(value T) error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed {
+		return ErrClosed
+	}
+
+	h.last = value
+	h.hasLast = true
+	for sub := range h.subscribers {
+		sendLatest(sub.ch, value)
+	}
+
+	return nil
+}
+
+func (h *Hub[T]) Close() {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed {
+		return
+	}
+
+	h.closed = true
+	for sub := range h.subscribers {
+		delete(h.subscribers, sub)
+		close(sub.ch)
+	}
+}
+
+func (s *Subscription[T]) C() <-chan T {
+	return s.ch
+}
+
+func (s *Subscription[T]) Close() {
+	s.once.Do(func() {
+		s.hub.unsubscribe(s)
+	})
+}
+
+func (h *Hub[T]) unsubscribe(sub *Subscription[T]) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if _, ok := h.subscribers[sub]; !ok {
+		return
+	}
+
+	delete(h.subscribers, sub)
+	close(sub.ch)
+}
+
+func sendLatest[T any](ch chan T, value T) {
+	select {
+	case ch <- value:
+	default:
+		select {
+		case <-ch:
+		default:
+		}
+		select {
+		case ch <- value:
+		default:
+		}
+	}
+}

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -24,9 +24,10 @@ type Hub[T any] struct {
 }
 
 type Subscription[T any] struct {
-	hub  *Hub[T]
-	ch   chan T
-	once sync.Once
+	hub       *Hub[T]
+	ch        chan T
+	done      chan struct{}
+	closeOnce sync.Once
 }
 
 func New[T any](opts ...Option) *Hub[T] {
@@ -58,8 +59,9 @@ func (h *Hub[T]) Subscribe(ctx context.Context) (*Subscription[T], error) {
 	}
 
 	sub := &Subscription[T]{
-		hub: h,
-		ch:  make(chan T, h.buffer),
+		hub:  h,
+		ch:   make(chan T, h.buffer),
+		done: make(chan struct{}),
 	}
 
 	h.mu.Lock()
@@ -75,8 +77,11 @@ func (h *Hub[T]) Subscribe(ctx context.Context) (*Subscription[T], error) {
 
 	if done := ctx.Done(); done != nil {
 		go func() {
-			<-done
-			sub.Close()
+			select {
+			case <-done:
+				sub.Close()
+			case <-sub.done:
+			}
 		}()
 	}
 
@@ -111,7 +116,7 @@ func (h *Hub[T]) Close() {
 	h.closed = true
 	for sub := range h.subscribers {
 		delete(h.subscribers, sub)
-		close(sub.ch)
+		sub.close()
 	}
 }
 
@@ -120,21 +125,23 @@ func (s *Subscription[T]) C() <-chan T {
 }
 
 func (s *Subscription[T]) Close() {
-	s.once.Do(func() {
-		s.hub.unsubscribe(s)
-	})
+	s.hub.unsubscribe(s)
 }
 
 func (h *Hub[T]) unsubscribe(sub *Subscription[T]) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
-	if _, ok := h.subscribers[sub]; !ok {
-		return
-	}
-
 	delete(h.subscribers, sub)
-	close(sub.ch)
+
+	sub.close()
+}
+
+func (s *Subscription[T]) close() {
+	s.closeOnce.Do(func() {
+		close(s.done)
+		close(s.ch)
+	})
 }
 
 func sendLatest[T any](ch chan T, value T) {

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -1,0 +1,193 @@
+package hub_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/hub"
+)
+
+func TestHubPublishFansOut(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[string]()
+
+	first, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	second, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	if err := events.Publish("ready"); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	for name, sub := range map[string]*hub.Subscription[string]{
+		"first":  first,
+		"second": second,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if got := receive(t, sub.C()); got != "ready" {
+				t.Fatalf("received %q, want ready", got)
+			}
+		})
+	}
+}
+
+func TestHubSubscribeReplaysLastEvent(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[int]()
+
+	if err := events.Publish(42); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	if got := receive(t, sub.C()); got != 42 {
+		t.Fatalf("replayed event = %d, want 42", got)
+	}
+}
+
+func TestHubDropsOldestForSlowSubscriber(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[string]()
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	if err := events.Publish("old"); err != nil {
+		t.Fatalf("Publish(old) error = %v", err)
+	}
+	if err := events.Publish("new"); err != nil {
+		t.Fatalf("Publish(new) error = %v", err)
+	}
+
+	if got := receive(t, sub.C()); got != "new" {
+		t.Fatalf("received %q, want new", got)
+	}
+}
+
+func TestHubWithBufferKeepsNewestBufferedEvents(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[string](hub.WithBuffer(2))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	for _, event := range []string{"old", "middle", "new"} {
+		if err := events.Publish(event); err != nil {
+			t.Fatalf("Publish(%q) error = %v", event, err)
+		}
+	}
+
+	if got := receive(t, sub.C()); got != "middle" {
+		t.Fatalf("first buffered event = %q, want middle", got)
+	}
+	if got := receive(t, sub.C()); got != "new" {
+		t.Fatalf("second buffered event = %q, want new", got)
+	}
+}
+
+func TestHubCloseClosesSubscribersAndRejectsOperations(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[string]()
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	events.Close()
+
+	if _, ok := <-sub.C(); ok {
+		t.Fatal("subscription channel is open after Close()")
+	}
+	if err := events.Publish("ignored"); !errors.Is(err, hub.ErrClosed) {
+		t.Fatalf("Publish() error = %v, want %v", err, hub.ErrClosed)
+	}
+	if _, err := events.Subscribe(context.Background()); !errors.Is(err, hub.ErrClosed) {
+		t.Fatalf("Subscribe() error = %v, want %v", err, hub.ErrClosed)
+	}
+}
+
+func TestHubSubscribeRejectsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	events := hub.New[string]()
+
+	if _, err := events.Subscribe(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Subscribe() error = %v, want %v", err, context.Canceled)
+	}
+}
+
+func TestSubscriptionClosesWhenContextIsCanceled(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	events := hub.New[string]()
+	sub, err := events.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	cancel()
+
+	select {
+	case _, ok := <-sub.C():
+		if ok {
+			t.Fatal("subscription channel is open after context cancellation")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for subscription channel to close")
+	}
+}
+
+func TestSubscriptionCloseRemovesSubscriber(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[string]()
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	sub.Close()
+
+	if _, ok := <-sub.C(); ok {
+		t.Fatal("subscription channel is open after subscription Close()")
+	}
+	if err := events.Publish("ready"); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+}
+
+func receive[T any](t *testing.T, ch <-chan T) T {
+	t.Helper()
+
+	select {
+	case got := <-ch:
+		return got
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for event")
+	}
+
+	var zero T
+	return zero
+}

--- a/internal/hub/subscription_test.go
+++ b/internal/hub/subscription_test.go
@@ -1,0 +1,45 @@
+package hub
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func TestSubscriptionCloseSignalsDone(t *testing.T) {
+	t.Parallel()
+
+	events := New[string]()
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	sub.Close()
+
+	assertClosed(t, sub.done)
+}
+
+func TestHubCloseSignalsSubscriptionDone(t *testing.T) {
+	t.Parallel()
+
+	events := New[string]()
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	events.Close()
+
+	assertClosed(t, sub.done)
+}
+
+func assertClosed(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for subscription done channel to close")
+	}
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -1,0 +1,124 @@
+package telemetry
+
+import "time"
+
+type Snapshot struct {
+	GeneratedAt time.Time   `json:"generated_at"`
+	Counts      Counts      `json:"counts"`
+	Running     []Running   `json:"running"`
+	Queue       []Queued    `json:"queue"`
+	Blocked     []Blocked   `json:"blocked"`
+	Completed   []Completed `json:"completed"`
+	Budget      Budget      `json:"budget"`
+	RateLimits  *RateLimits `json:"rate_limits"`
+	Tokens      Tokens      `json:"tokens"`
+}
+
+type Counts struct {
+	Running   int `json:"running"`
+	Queue     int `json:"queue"`
+	Blocked   int `json:"blocked"`
+	Completed int `json:"completed"`
+}
+
+type Issue struct {
+	ID          string `json:"issue_id"`
+	Identifier  string `json:"identifier,omitempty"`
+	URL         string `json:"url,omitempty"`
+	Title       string `json:"title,omitempty"`
+	Description string `json:"description,omitempty"`
+	State       string `json:"state,omitempty"`
+}
+
+type Running struct {
+	Issue
+	WorkerHost     string     `json:"worker_host,omitempty"`
+	WorkspacePath  string     `json:"workspace_path,omitempty"`
+	SessionID      string     `json:"session_id,omitempty"`
+	TurnCount      int        `json:"turn_count"`
+	StartedAt      time.Time  `json:"started_at"`
+	LastEventAt    *time.Time `json:"last_event_at,omitempty"`
+	LastEvent      string     `json:"last_event,omitempty"`
+	LastMessage    string     `json:"last_message,omitempty"`
+	RuntimeSeconds float64    `json:"runtime_seconds"`
+	Tokens         Tokens     `json:"tokens"`
+}
+
+type Queued struct {
+	Issue
+	Attempt        int        `json:"attempt"`
+	DueAt          *time.Time `json:"due_at,omitempty"`
+	DueInMillis    int64      `json:"due_in_ms,omitempty"`
+	Error          string     `json:"error,omitempty"`
+	WorkerHost     string     `json:"worker_host,omitempty"`
+	WorkspacePath  string     `json:"workspace_path,omitempty"`
+	ProjectedSpend float64    `json:"projected_spend_usd,omitempty"`
+}
+
+type Blocked struct {
+	Issue
+	WorkerHost    string     `json:"worker_host,omitempty"`
+	WorkspacePath string     `json:"workspace_path,omitempty"`
+	SessionID     string     `json:"session_id,omitempty"`
+	Error         string     `json:"error,omitempty"`
+	BlockedAt     *time.Time `json:"blocked_at,omitempty"`
+	LastEventAt   *time.Time `json:"last_event_at,omitempty"`
+	LastEvent     string     `json:"last_event,omitempty"`
+	LastMessage   string     `json:"last_message,omitempty"`
+}
+
+type Completed struct {
+	Issue
+	SessionID      string    `json:"session_id,omitempty"`
+	StartedAt      time.Time `json:"started_at"`
+	CompletedAt    time.Time `json:"completed_at"`
+	Turns          int       `json:"turns"`
+	RuntimeSeconds float64   `json:"runtime_seconds"`
+	FinalState     string    `json:"final_state,omitempty"`
+	Model          string    `json:"model,omitempty"`
+	Tokens         Tokens    `json:"tokens"`
+}
+
+type Budget struct {
+	Enabled          bool            `json:"enabled"`
+	PerDayMaxUSD     *float64        `json:"per_day_max_usd"`
+	PerIssueMaxUSD   *float64        `json:"per_issue_max_usd"`
+	CurrentSpendUSD  float64         `json:"current_spend_usd"`
+	ProjectedCostUSD float64         `json:"projected_cost_usd"`
+	Refusals         []BudgetRefusal `json:"refusals,omitempty"`
+}
+
+type BudgetRefusal struct {
+	IssueID          string     `json:"issue_id"`
+	Identifier       string     `json:"identifier,omitempty"`
+	Code             string     `json:"code"`
+	Message          string     `json:"message"`
+	CurrentSpendUSD  float64    `json:"current_spend_usd"`
+	ProjectedCostUSD float64    `json:"projected_cost_usd"`
+	MaxUSD           *float64   `json:"max_usd"`
+	ResetAt          *time.Time `json:"reset_at,omitempty"`
+	RefusedAt        time.Time  `json:"refused_at"`
+}
+
+type RateLimits struct {
+	LimitID   string           `json:"limit_id,omitempty"`
+	LimitName string           `json:"limit_name,omitempty"`
+	Primary   *RateLimitBucket `json:"primary,omitempty"`
+	Secondary *RateLimitBucket `json:"secondary,omitempty"`
+	Credits   *RateLimitBucket `json:"credits,omitempty"`
+}
+
+type RateLimitBucket struct {
+	Remaining      int64      `json:"remaining,omitempty"`
+	Used           int64      `json:"used,omitempty"`
+	Limit          int64      `json:"limit,omitempty"`
+	ResetAt        *time.Time `json:"reset_at,omitempty"`
+	ResetInSeconds int64      `json:"reset_in_seconds,omitempty"`
+}
+
+type Tokens struct {
+	Input          int64   `json:"input_tokens"`
+	Output         int64   `json:"output_tokens"`
+	Total          int64   `json:"total_tokens"`
+	RuntimeSeconds float64 `json:"seconds_running,omitempty"`
+}

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -1,0 +1,166 @@
+package telemetry_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+)
+
+func TestSnapshotJSONShape(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 5, 30, 22, 15, 0, 0, time.UTC)
+	startedAt := generatedAt.Add(-5 * time.Minute)
+	completedAt := generatedAt.Add(-time.Minute)
+	perDay := 50.0
+	perIssue := 5.0
+
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: generatedAt,
+		Counts: telemetry.Counts{
+			Running:   1,
+			Queue:     2,
+			Blocked:   3,
+			Completed: 4,
+		},
+		Running: []telemetry.Running{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-1",
+					Identifier: "DD-1",
+					State:      "In Progress",
+					Title:      "Port hub",
+					URL:        "https://example.com/issues/1",
+				},
+				SessionID:      "thread-1",
+				TurnCount:      2,
+				StartedAt:      startedAt,
+				RuntimeSeconds: 300,
+				Tokens: telemetry.Tokens{
+					Input:  10,
+					Output: 20,
+					Total:  30,
+				},
+			},
+		},
+		Queue: []telemetry.Queued{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-2",
+					Identifier: "DD-2",
+				},
+				Attempt: 2,
+				Error:   "no available orchestrator slots",
+			},
+		},
+		Blocked: []telemetry.Blocked{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-3",
+					Identifier: "DD-3",
+					State:      "Blocked",
+				},
+				Error: "dependency #2 is not merged",
+			},
+		},
+		Completed: []telemetry.Completed{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-4",
+					Identifier: "DD-4",
+				},
+				StartedAt:      startedAt,
+				CompletedAt:    completedAt,
+				Turns:          3,
+				RuntimeSeconds: 240,
+				FinalState:     "Done",
+				Model:          "gpt-5",
+				Tokens: telemetry.Tokens{
+					Input:  100,
+					Output: 200,
+					Total:  300,
+				},
+			},
+		},
+		Budget: telemetry.Budget{
+			Enabled:          true,
+			PerDayMaxUSD:     &perDay,
+			PerIssueMaxUSD:   &perIssue,
+			CurrentSpendUSD:  12.5,
+			ProjectedCostUSD: 0.75,
+		},
+		RateLimits: &telemetry.RateLimits{
+			LimitID: "codex-primary",
+			Primary: &telemetry.RateLimitBucket{
+				Remaining:      90,
+				Limit:          100,
+				ResetInSeconds: 60,
+			},
+		},
+		Tokens: telemetry.Tokens{
+			Input:          110,
+			Output:         220,
+			Total:          330,
+			RuntimeSeconds: 540,
+		},
+	}
+
+	data, err := json.Marshal(snapshot)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	for _, key := range []string{
+		"generated_at",
+		"counts",
+		"running",
+		"queue",
+		"blocked",
+		"completed",
+		"budget",
+		"rate_limits",
+		"tokens",
+	} {
+		if _, ok := got[key]; !ok {
+			t.Fatalf("snapshot JSON missing %q: %s", key, string(data))
+		}
+	}
+
+	counts := got["counts"].(map[string]any)
+	if counts["running"] != float64(1) || counts["queue"] != float64(2) || counts["blocked"] != float64(3) || counts["completed"] != float64(4) {
+		t.Fatalf("counts = %#v", counts)
+	}
+
+	running := got["running"].([]any)[0].(map[string]any)
+	if running["issue_id"] != "issue-1" || running["identifier"] != "DD-1" {
+		t.Fatalf("running row = %#v", running)
+	}
+	if _, ok := running["issue"]; ok {
+		t.Fatalf("running row has nested issue: %#v", running)
+	}
+
+	budget := got["budget"].(map[string]any)
+	if budget["per_day_max_usd"] != 50.0 || budget["per_issue_max_usd"] != 5.0 {
+		t.Fatalf("budget caps = %#v", budget)
+	}
+	if budget["projected_cost_usd"] != 0.75 {
+		t.Fatalf("budget projected cost = %#v", budget)
+	}
+
+	rateLimits := got["rate_limits"].(map[string]any)
+	if rateLimits["limit_id"] != "codex-primary" {
+		t.Fatalf("rate_limits = %#v", rateLimits)
+	}
+
+	tokens := got["tokens"].(map[string]any)
+	if tokens["input_tokens"] != float64(110) || tokens["output_tokens"] != float64(220) || tokens["total_tokens"] != float64(330) {
+		t.Fatalf("tokens = %#v", tokens)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a generic internal broadcast hub with subscribe, publish, close, replay-last, and drop-oldest behavior for slow subscribers.
- Add the internal telemetry Snapshot model for running, queue, blocked, completed, budget, rate-limit, and token state.
- Cover hub behavior and snapshot JSON shape with focused stdlib tests.

Fixes #9

## Test Plan
- go test ./internal/hub ./internal/telemetry
- go build ./... && go vet ./... && go test ./...
- go test -cover ./...