### PR TITLE
feat(config): parse workflow frontmatter

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.26
 require (
 	github.com/lmittmann/tint v1.1.3
 	github.com/spf13/cobra v1.10.2
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -9,4 +9,7 @@ github.com/spf13/cobra v1.10.2/go.mod h1:7C1pvHqHw5A4vrJfjNwvOdzYu0Gml16OCs2GRiT
 github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -349,7 +349,7 @@ func (c Config) validateTracker(problems *[]string) {
 		validateRequired("tracker.api_key", c.Tracker.APIKey, " for linear", problems)
 		validateRequired("tracker.project_slug", c.Tracker.ProjectSlug, " for linear", problems)
 	case TrackerGitHub:
-		validateRequired("tracker.api_key", c.Tracker.APIKey, " for github", problems)
+		c.Tracker.validateGitHubAuth(problems)
 		validateRequired("tracker.project_slug", c.Tracker.ProjectSlug, " for github", problems)
 	case TrackerMemory:
 	default:
@@ -361,6 +361,32 @@ func (c Config) validateTracker(problems *[]string) {
 	validateStateList("tracker.terminal_states", c.Tracker.TerminalStates, problems)
 	validateStateMap("tracker.state_map", c.Tracker.StateMap, problems)
 	validatePriorityMap("tracker.priority_map", c.Tracker.PriorityMap, problems)
+}
+
+func (t Tracker) validateGitHubAuth(problems *[]string) {
+	if strings.TrimSpace(t.APIKey) != "" || t.hasGitHubAppCredentials() {
+		return
+	}
+
+	if strings.TrimSpace(t.GitHubAppID) == "" &&
+		strings.TrimSpace(t.GitHubAppInstallationID) == "" &&
+		strings.TrimSpace(t.GitHubAppPrivateKey) == "" &&
+		strings.TrimSpace(t.GitHubAppPrivateKeyPath) == "" {
+		*problems = append(*problems, "tracker.api_key or GitHub App credentials are required for github")
+		return
+	}
+
+	validateRequired("tracker.github_app_id", t.GitHubAppID, " for github app", problems)
+	validateRequired("tracker.github_app_installation_id", t.GitHubAppInstallationID, " for github app", problems)
+	if strings.TrimSpace(t.GitHubAppPrivateKey) == "" && strings.TrimSpace(t.GitHubAppPrivateKeyPath) == "" {
+		*problems = append(*problems, "tracker.github_app_private_key or tracker.github_app_private_key_path is required for github app")
+	}
+}
+
+func (t Tracker) hasGitHubAppCredentials() bool {
+	return strings.TrimSpace(t.GitHubAppID) != "" &&
+		strings.TrimSpace(t.GitHubAppInstallationID) != "" &&
+		(strings.TrimSpace(t.GitHubAppPrivateKey) != "" || strings.TrimSpace(t.GitHubAppPrivateKeyPath) != "")
 }
 
 func (a Agent) validate(prefix string, problems *[]string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,794 @@
+package config
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	TrackerGitHub = "github"
+	TrackerLinear = "linear"
+	TrackerMemory = "memory"
+
+	defaultLinearEndpoint = "https://api.linear.app/graphql"
+	defaultGitHubEndpoint = "https://api.github.com/graphql"
+)
+
+var windowsAbsPathPattern = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
+
+type Workflow struct {
+	Config Config
+	Prompt string
+}
+
+type Config struct {
+	Tracker       Tracker       `yaml:"tracker"`
+	Polling       Polling       `yaml:"polling"`
+	Workspace     Workspace     `yaml:"workspace"`
+	Worker        Worker        `yaml:"worker"`
+	Agent         Agent         `yaml:"agent"`
+	Codex         Codex         `yaml:"codex"`
+	Server        Server        `yaml:"server"`
+	Observability Observability `yaml:"observability"`
+	Budget        Budget        `yaml:"budget"`
+	Hooks         Hooks         `yaml:"hooks"`
+}
+
+type Tracker struct {
+	Kind                    string      `yaml:"kind"`
+	Endpoint                string      `yaml:"endpoint"`
+	APIKey                  string      `yaml:"api_key"`
+	GitHubAppID             string      `yaml:"github_app_id"`
+	GitHubAppPrivateKey     string      `yaml:"github_app_private_key"`
+	GitHubAppPrivateKeyPath string      `yaml:"github_app_private_key_path"`
+	GitHubAppInstallationID string      `yaml:"github_app_installation_id"`
+	ProjectSlug             string      `yaml:"project_slug"`
+	Assignee                string      `yaml:"assignee"`
+	ActiveStates            []string    `yaml:"active_states"`
+	ObservedStates          []string    `yaml:"observed_states"`
+	TerminalStates          []string    `yaml:"terminal_states"`
+	StateMap                StringOrMap `yaml:"state_map"`
+	PriorityMap             StringOrMap `yaml:"priority_map"`
+	AutoProvision           bool        `yaml:"auto_provision"`
+}
+
+type Polling struct {
+	IntervalMS int `yaml:"interval_ms"`
+}
+
+type Workspace struct {
+	Root       string `yaml:"root"`
+	AutoBranch bool   `yaml:"auto_branch"`
+}
+
+type Worker struct {
+	SSHHosts                   []string `yaml:"ssh_hosts"`
+	MaxConcurrentAgentsPerHost *int     `yaml:"max_concurrent_agents_per_host"`
+}
+
+type Agent struct {
+	MaxConcurrentAgents        int            `yaml:"max_concurrent_agents"`
+	MaxTurns                   int            `yaml:"max_turns"`
+	MaxRetryBackoffMS          int            `yaml:"max_retry_backoff_ms"`
+	MaxConcurrentAgentsByState map[string]int `yaml:"max_concurrent_agents_by_state"`
+	DispatchPriorityByState    []string       `yaml:"dispatch_priority_by_state"`
+	AutoPromote                AutoPromote    `yaml:"auto_promote"`
+	Budget                     Budget         `yaml:"budget"`
+	Lessons                    Lessons        `yaml:"lessons"`
+	Skills                     Skills         `yaml:"skills"`
+}
+
+type AutoPromote struct {
+	Enabled            bool     `yaml:"enabled"`
+	QuietSeconds       int      `yaml:"quiet_seconds"`
+	OptoutLabel        string   `yaml:"optout_label"`
+	AllowedIssueLabels []string `yaml:"allowed_issue_labels"`
+}
+
+type Lessons struct {
+	Enabled             bool   `yaml:"enabled"`
+	Path                string `yaml:"path"`
+	MaxEntries          int    `yaml:"max_entries"`
+	RecallN             int    `yaml:"recall_n"`
+	PostmortemMaxTokens int    `yaml:"postmortem_max_tokens"`
+}
+
+type Skills struct {
+	Enabled           bool   `yaml:"enabled"`
+	Path              string `yaml:"path"`
+	MaxSkillsInPrompt int    `yaml:"max_skills_in_prompt"`
+}
+
+type Budget struct {
+	Enabled                bool    `yaml:"enabled"`
+	PerDayMaxUSD           float64 `yaml:"per_day_max_usd"`
+	PerIssueMaxUSD         float64 `yaml:"per_issue_max_usd"`
+	RefusalCooldownSeconds int     `yaml:"refusal_cooldown_seconds"`
+	PricingPath            string  `yaml:"pricing_path"`
+}
+
+type Codex struct {
+	Command           string         `yaml:"command"`
+	ApprovalPolicy    StringOrMap    `yaml:"approval_policy"`
+	ThreadSandbox     string         `yaml:"thread_sandbox"`
+	TurnSandboxPolicy map[string]any `yaml:"turn_sandbox_policy"`
+	TurnTimeoutMS     int            `yaml:"turn_timeout_ms"`
+	ReadTimeoutMS     int            `yaml:"read_timeout_ms"`
+	StallTimeoutMS    int            `yaml:"stall_timeout_ms"`
+}
+
+type Server struct {
+	Port *int   `yaml:"port"`
+	Host string `yaml:"host"`
+}
+
+type Observability struct {
+	DashboardEnabled bool `yaml:"dashboard_enabled"`
+	RefreshMS        int  `yaml:"refresh_ms"`
+	RenderIntervalMS int  `yaml:"render_interval_ms"`
+}
+
+type Hooks struct {
+	AfterCreate  string `yaml:"after_create"`
+	BeforeRun    string `yaml:"before_run"`
+	AfterRun     string `yaml:"after_run"`
+	BeforeRemove string `yaml:"before_remove"`
+	TimeoutMS    int    `yaml:"timeout_ms"`
+}
+
+type StringOrMap struct {
+	IsString bool
+	String   string
+	IsMap    bool
+	Map      map[string]any
+}
+
+type ValidationError struct {
+	Problems []string
+}
+
+func LoadWorkflow(path string) (Workflow, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return Workflow{}, fmt.Errorf("read workflow file: %w", err)
+	}
+
+	return ParseWorkflow(raw)
+}
+
+func ParseWorkflow(raw []byte) (Workflow, error) {
+	frontmatter, prompt, err := splitFrontmatter(raw)
+	if err != nil {
+		return Workflow{}, err
+	}
+
+	cfg := Default()
+	if len(bytes.TrimSpace(frontmatter)) > 0 {
+		var doc yaml.Node
+		if err := yaml.Unmarshal(frontmatter, &doc); err != nil {
+			return Workflow{}, fmt.Errorf("parse YAML frontmatter: %w", err)
+		}
+
+		root, err := documentRoot(&doc)
+		if err != nil {
+			return Workflow{}, err
+		}
+		if root.Kind != yaml.MappingNode {
+			return Workflow{}, errors.New("workflow frontmatter must be a mapping")
+		}
+		normalizeTrackerIDFields(root)
+		if err := root.Decode(&cfg); err != nil {
+			return Workflow{}, fmt.Errorf("decode YAML frontmatter: %w", err)
+		}
+	}
+
+	cfg.normalize()
+
+	return Workflow{
+		Config: cfg,
+		Prompt: string(prompt),
+	}, nil
+}
+
+func Default() Config {
+	budget := defaultBudget()
+
+	return Config{
+		Tracker: Tracker{
+			Endpoint:       defaultLinearEndpoint,
+			ActiveStates:   []string{"Todo", "In Progress"},
+			ObservedStates: []string{"Backlog", "Human Review", "Blocked"},
+			TerminalStates: []string{"Closed", "Cancelled", "Canceled", "Duplicate", "Done"},
+			StateMap:       MapValue(map[string]any{}),
+			PriorityMap:    MapValue(defaultPriorityMap()),
+			AutoProvision:  true,
+		},
+		Polling: Polling{
+			IntervalMS: 30000,
+		},
+		Workspace: Workspace{
+			Root:       filepath.Join(os.TempDir(), "symphony_workspaces"),
+			AutoBranch: true,
+		},
+		Worker: Worker{
+			SSHHosts: []string{},
+		},
+		Agent: Agent{
+			MaxConcurrentAgents:        10,
+			MaxTurns:                   20,
+			MaxRetryBackoffMS:          300000,
+			MaxConcurrentAgentsByState: map[string]int{},
+			DispatchPriorityByState:    []string{},
+			AutoPromote: AutoPromote{
+				QuietSeconds:       600,
+				OptoutLabel:        "requires-human-review",
+				AllowedIssueLabels: []string{},
+			},
+			Budget:  budget,
+			Lessons: defaultLessons(),
+			Skills:  defaultSkills(),
+		},
+		Codex: Codex{
+			Command: "codex app-server",
+			ApprovalPolicy: MapValue(map[string]any{
+				"reject": map[string]any{
+					"sandbox_approval": true,
+					"rules":            true,
+					"mcp_elicitations": true,
+				},
+			}),
+			ThreadSandbox:  "workspace-write",
+			TurnTimeoutMS:  3600000,
+			ReadTimeoutMS:  5000,
+			StallTimeoutMS: 300000,
+		},
+		Server: Server{
+			Host: "127.0.0.1",
+		},
+		Observability: Observability{
+			DashboardEnabled: true,
+			RefreshMS:        1000,
+			RenderIntervalMS: 16,
+		},
+		Budget: budget,
+		Hooks: Hooks{
+			TimeoutMS: 60000,
+		},
+	}
+}
+
+func MapValue(value map[string]any) StringOrMap {
+	return StringOrMap{
+		IsMap: true,
+		Map:   value,
+	}
+}
+
+func StringValue(value string) StringOrMap {
+	return StringOrMap{
+		IsString: true,
+		String:   value,
+	}
+}
+
+func (c Config) Validate() error {
+	var problems []string
+
+	c.validateTracker(&problems)
+	validatePositive("polling.interval_ms", c.Polling.IntervalMS, &problems)
+	if c.Worker.MaxConcurrentAgentsPerHost != nil {
+		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
+	}
+	c.Agent.validate("agent", &problems)
+	c.Codex.validate(&problems)
+	c.Server.validate(&problems)
+	c.Observability.validate(&problems)
+	c.Budget.validate("budget", &problems)
+	c.Hooks.validate(&problems)
+
+	if len(problems) > 0 {
+		return ValidationError{Problems: problems}
+	}
+
+	return nil
+}
+
+func (e ValidationError) Error() string {
+	return strings.Join(e.Problems, "; ")
+}
+
+func (s *StringOrMap) UnmarshalYAML(value *yaml.Node) error {
+	if value.Kind == yaml.ScalarNode && value.Tag == "!!null" {
+		return nil
+	}
+
+	switch value.Kind {
+	case yaml.ScalarNode:
+		if value.Tag != "!!str" {
+			return fmt.Errorf("must be a string or mapping, got %s", yamlKindName(value))
+		}
+		*s = StringValue(value.Value)
+		return nil
+	case yaml.MappingNode:
+		decoded, err := decodeMapNode(value)
+		if err != nil {
+			return err
+		}
+		*s = MapValue(decoded)
+		return nil
+	default:
+		return fmt.Errorf("must be a string or mapping, got %s", yamlKindName(value))
+	}
+}
+
+func (c *Config) normalize() {
+	c.Tracker.Kind = strings.ToLower(strings.TrimSpace(c.Tracker.Kind))
+	if c.Tracker.Kind == TrackerGitHub && c.Tracker.Endpoint == defaultLinearEndpoint {
+		c.Tracker.Endpoint = defaultGitHubEndpoint
+	}
+
+	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
+	c.Agent.DispatchPriorityByState = normalizeStateList(c.Agent.DispatchPriorityByState)
+	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
+	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
+}
+
+func (c Config) validateTracker(problems *[]string) {
+	switch c.Tracker.Kind {
+	case "":
+		*problems = append(*problems, "tracker.kind is required")
+	case TrackerLinear:
+		validateRequired("tracker.api_key", c.Tracker.APIKey, " for linear", problems)
+		validateRequired("tracker.project_slug", c.Tracker.ProjectSlug, " for linear", problems)
+	case TrackerGitHub:
+		validateRequired("tracker.api_key", c.Tracker.APIKey, " for github", problems)
+		validateRequired("tracker.project_slug", c.Tracker.ProjectSlug, " for github", problems)
+	case TrackerMemory:
+	default:
+		*problems = append(*problems, "tracker.kind must be one of github, linear, memory")
+	}
+
+	validateStateList("tracker.active_states", c.Tracker.ActiveStates, problems)
+	validateStateList("tracker.observed_states", c.Tracker.ObservedStates, problems)
+	validateStateList("tracker.terminal_states", c.Tracker.TerminalStates, problems)
+	validateStateMap("tracker.state_map", c.Tracker.StateMap, problems)
+	validatePriorityMap("tracker.priority_map", c.Tracker.PriorityMap, problems)
+}
+
+func (a Agent) validate(prefix string, problems *[]string) {
+	validatePositive(prefix+".max_concurrent_agents", a.MaxConcurrentAgents, problems)
+	validatePositive(prefix+".max_turns", a.MaxTurns, problems)
+	validatePositive(prefix+".max_retry_backoff_ms", a.MaxRetryBackoffMS, problems)
+	validateStateLimits(prefix+".max_concurrent_agents_by_state", a.MaxConcurrentAgentsByState, problems)
+	validateStateList(prefix+".dispatch_priority_by_state", a.DispatchPriorityByState, problems)
+	a.AutoPromote.validate(prefix+".auto_promote", problems)
+	a.Budget.validate(prefix+".budget", problems)
+	a.Lessons.validate(prefix+".lessons", problems)
+	a.Skills.validate(prefix+".skills", problems)
+}
+
+func (a AutoPromote) validate(prefix string, problems *[]string) {
+	if a.QuietSeconds < 0 {
+		*problems = append(*problems, prefix+".quiet_seconds must be greater than or equal to 0")
+	}
+	if strings.TrimSpace(a.OptoutLabel) == "" {
+		*problems = append(*problems, prefix+".optout_label must not be blank")
+	}
+	for _, label := range a.AllowedIssueLabels {
+		if strings.TrimSpace(label) == "" {
+			*problems = append(*problems, prefix+".allowed_issue_labels labels must not be blank")
+			return
+		}
+	}
+}
+
+func (l Lessons) validate(prefix string, problems *[]string) {
+	validateWorkspaceRelativePath(prefix+".path", l.Path, problems)
+	validatePositive(prefix+".max_entries", l.MaxEntries, problems)
+	if l.RecallN < 0 {
+		*problems = append(*problems, prefix+".recall_n must be greater than or equal to 0")
+	}
+	validatePositive(prefix+".postmortem_max_tokens", l.PostmortemMaxTokens, problems)
+}
+
+func (s Skills) validate(prefix string, problems *[]string) {
+	validateWorkspaceRelativePath(prefix+".path", s.Path, problems)
+	validatePositive(prefix+".max_skills_in_prompt", s.MaxSkillsInPrompt, problems)
+}
+
+func (b Budget) validate(prefix string, problems *[]string) {
+	validatePositiveFloat(prefix+".per_day_max_usd", b.PerDayMaxUSD, problems)
+	validatePositiveFloat(prefix+".per_issue_max_usd", b.PerIssueMaxUSD, problems)
+	if b.RefusalCooldownSeconds < 0 {
+		*problems = append(*problems, prefix+".refusal_cooldown_seconds must be greater than or equal to 0")
+	}
+	if strings.TrimSpace(b.PricingPath) == "" {
+		*problems = append(*problems, prefix+".pricing_path is required")
+	}
+}
+
+func (c Codex) validate(problems *[]string) {
+	if strings.TrimSpace(c.Command) == "" {
+		*problems = append(*problems, "codex.command is required")
+	}
+	validatePositive("codex.turn_timeout_ms", c.TurnTimeoutMS, problems)
+	validatePositive("codex.read_timeout_ms", c.ReadTimeoutMS, problems)
+	if c.StallTimeoutMS < 0 {
+		*problems = append(*problems, "codex.stall_timeout_ms must be greater than or equal to 0")
+	}
+}
+
+func (s Server) validate(problems *[]string) {
+	if s.Port != nil && *s.Port < 0 {
+		*problems = append(*problems, "server.port must be greater than or equal to 0")
+	}
+	if strings.TrimSpace(s.Host) == "" {
+		*problems = append(*problems, "server.host is required")
+	}
+}
+
+func (o Observability) validate(problems *[]string) {
+	validatePositive("observability.refresh_ms", o.RefreshMS, problems)
+	validatePositive("observability.render_interval_ms", o.RenderIntervalMS, problems)
+}
+
+func (h Hooks) validate(problems *[]string) {
+	validatePositive("hooks.timeout_ms", h.TimeoutMS, problems)
+}
+
+func splitFrontmatter(raw []byte) ([]byte, []byte, error) {
+	normalized := strings.ReplaceAll(strings.TrimPrefix(string(raw), "\ufeff"), "\r\n", "\n")
+	if !strings.HasPrefix(normalized, "---\n") {
+		return nil, nil, errors.New("missing YAML frontmatter")
+	}
+
+	body := normalized[len("---\n"):]
+	if strings.HasPrefix(body, "---\n") {
+		return []byte{}, []byte(body[len("---\n"):]), nil
+	}
+	if body == "---" {
+		return []byte{}, []byte{}, nil
+	}
+
+	closeIndex := strings.Index(body, "\n---\n")
+	if closeIndex >= 0 {
+		return []byte(body[:closeIndex]), []byte(body[closeIndex+len("\n---\n"):]), nil
+	}
+
+	if strings.HasSuffix(body, "\n---") {
+		return []byte(strings.TrimSuffix(body, "\n---")), []byte{}, nil
+	}
+
+	return nil, nil, errors.New("unterminated YAML frontmatter")
+}
+
+func documentRoot(doc *yaml.Node) (*yaml.Node, error) {
+	if doc.Kind == 0 {
+		return &yaml.Node{Kind: yaml.MappingNode}, nil
+	}
+	if doc.Kind == yaml.DocumentNode {
+		if len(doc.Content) == 0 {
+			return &yaml.Node{Kind: yaml.MappingNode}, nil
+		}
+		return doc.Content[0], nil
+	}
+	return nil, errors.New("workflow frontmatter must be a YAML document")
+}
+
+func normalizeTrackerIDFields(root *yaml.Node) {
+	tracker := mappingValue(root, "tracker")
+	if tracker == nil || tracker.Kind != yaml.MappingNode {
+		return
+	}
+
+	normalizeScalarField(tracker, "github_app_id")
+	normalizeScalarField(tracker, "github_app_installation_id")
+}
+
+func mappingValue(node *yaml.Node, key string) *yaml.Node {
+	if node.Kind != yaml.MappingNode {
+		return nil
+	}
+
+	for i := 0; i < len(node.Content); i += 2 {
+		if node.Content[i].Value == key {
+			return node.Content[i+1]
+		}
+	}
+
+	return nil
+}
+
+func normalizeScalarField(node *yaml.Node, key string) {
+	value := mappingValue(node, key)
+	if value == nil || value.Kind != yaml.ScalarNode || value.Tag == "!!null" {
+		return
+	}
+
+	value.Tag = "!!str"
+}
+
+func decodeMapNode(node *yaml.Node) (map[string]any, error) {
+	out := make(map[string]any, len(node.Content)/2)
+	for i := 0; i < len(node.Content); i += 2 {
+		keyNode := node.Content[i]
+		if keyNode.Kind != yaml.ScalarNode {
+			return nil, fmt.Errorf("map keys must be scalars, got %s", yamlKindName(keyNode))
+		}
+
+		value, err := decodeAnyNode(node.Content[i+1])
+		if err != nil {
+			return nil, err
+		}
+		out[keyNode.Value] = value
+	}
+
+	return out, nil
+}
+
+func decodeAnyNode(node *yaml.Node) (any, error) {
+	switch node.Kind {
+	case yaml.ScalarNode:
+		return decodeScalarNode(node)
+	case yaml.SequenceNode:
+		out := make([]any, 0, len(node.Content))
+		for _, child := range node.Content {
+			value, err := decodeAnyNode(child)
+			if err != nil {
+				return nil, err
+			}
+			out = append(out, value)
+		}
+		return out, nil
+	case yaml.MappingNode:
+		return decodeMapNode(node)
+	default:
+		return nil, fmt.Errorf("unsupported YAML node %s", yamlKindName(node))
+	}
+}
+
+func decodeScalarNode(node *yaml.Node) (any, error) {
+	switch node.Tag {
+	case "!!null":
+		return nil, nil
+	case "!!bool":
+		return strconv.ParseBool(node.Value)
+	case "!!int":
+		value, err := strconv.ParseInt(strings.ReplaceAll(node.Value, "_", ""), 0, 64)
+		if err != nil {
+			return nil, err
+		}
+		return int(value), nil
+	case "!!float":
+		return strconv.ParseFloat(strings.ReplaceAll(node.Value, "_", ""), 64)
+	default:
+		return node.Value, nil
+	}
+}
+
+func yamlKindName(node *yaml.Node) string {
+	if node.Tag != "" {
+		return node.Tag
+	}
+
+	switch node.Kind {
+	case yaml.DocumentNode:
+		return "document"
+	case yaml.SequenceNode:
+		return "sequence"
+	case yaml.MappingNode:
+		return "mapping"
+	case yaml.ScalarNode:
+		return "scalar"
+	case yaml.AliasNode:
+		return "alias"
+	default:
+		return "unknown"
+	}
+}
+
+func defaultBudget() Budget {
+	return Budget{
+		PerDayMaxUSD:           50.0,
+		PerIssueMaxUSD:         5.0,
+		RefusalCooldownSeconds: 3600,
+		PricingPath:            "priv/pricing/models.yaml",
+	}
+}
+
+func defaultLessons() Lessons {
+	return Lessons{
+		Path:                ".symphony/lessons.md",
+		MaxEntries:          50,
+		RecallN:             10,
+		PostmortemMaxTokens: 1024,
+	}
+}
+
+func defaultSkills() Skills {
+	return Skills{
+		Enabled:           true,
+		Path:              ".symphony/skills",
+		MaxSkillsInPrompt: 50,
+	}
+}
+
+func defaultPriorityMap() map[string]any {
+	return map[string]any{
+		"Urgent":      1,
+		"High":        2,
+		"Medium":      3,
+		"Low":         4,
+		"No priority": nil,
+	}
+}
+
+func normalizeStateLimits(limits map[string]int) map[string]int {
+	if limits == nil {
+		return map[string]int{}
+	}
+
+	normalized := make(map[string]int, len(limits))
+	for state, limit := range limits {
+		normalized[normalizeIssueState(state)] = limit
+	}
+	return normalized
+}
+
+func normalizeStateList(states []string) []string {
+	if states == nil {
+		return []string{}
+	}
+
+	normalized := make([]string, 0, len(states))
+	for _, state := range states {
+		normalized = append(normalized, normalizeIssueState(state))
+	}
+	return normalized
+}
+
+func normalizeIssueState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func normalizeLabel(label string) string {
+	return strings.ToLower(strings.TrimSpace(label))
+}
+
+func normalizeLabels(labels []string) []string {
+	if labels == nil {
+		return []string{}
+	}
+
+	normalized := make([]string, 0, len(labels))
+	seen := map[string]struct{}{}
+	for _, label := range labels {
+		candidate := normalizeLabel(label)
+		if _, ok := seen[candidate]; ok {
+			continue
+		}
+		seen[candidate] = struct{}{}
+		normalized = append(normalized, candidate)
+	}
+	return normalized
+}
+
+func validateRequired(field string, value string, suffix string, problems *[]string) {
+	if strings.TrimSpace(value) == "" {
+		*problems = append(*problems, field+" is required"+suffix)
+	}
+}
+
+func validatePositive(field string, value int, problems *[]string) {
+	if value <= 0 {
+		*problems = append(*problems, field+" must be greater than 0")
+	}
+}
+
+func validatePositiveFloat(field string, value float64, problems *[]string) {
+	if value <= 0 {
+		*problems = append(*problems, field+" must be greater than 0")
+	}
+}
+
+func validateStateList(field string, states []string, problems *[]string) {
+	seen := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		if strings.TrimSpace(state) == "" {
+			*problems = append(*problems, field+" state names must not be blank")
+			return
+		}
+		if _, ok := seen[state]; ok {
+			*problems = append(*problems, field+" state names must be unique")
+			return
+		}
+		seen[state] = struct{}{}
+	}
+}
+
+func validateStateLimits(field string, limits map[string]int, problems *[]string) {
+	for state, limit := range limits {
+		if strings.TrimSpace(state) == "" {
+			*problems = append(*problems, field+" state names must not be blank")
+			return
+		}
+		if limit <= 0 {
+			*problems = append(*problems, field+" limits must be positive integers")
+			return
+		}
+	}
+}
+
+func validateStateMap(field string, value StringOrMap, problems *[]string) {
+	if !value.IsMap {
+		return
+	}
+	for state, mapped := range value.Map {
+		if strings.TrimSpace(state) == "" {
+			*problems = append(*problems, field+" state names must not be blank")
+			return
+		}
+		if _, ok := mapped.(string); !ok {
+			*problems = append(*problems, field+" values must be strings")
+			return
+		}
+	}
+}
+
+func validatePriorityMap(field string, value StringOrMap, problems *[]string) {
+	if !value.IsMap {
+		return
+	}
+	if len(value.Map) == 0 {
+		*problems = append(*problems, field+" must not be empty")
+		return
+	}
+
+	for name, rank := range value.Map {
+		if strings.TrimSpace(name) == "" {
+			*problems = append(*problems, field+" option names must not be blank")
+		}
+		if !validPriorityRank(rank) {
+			*problems = append(*problems, field+" ranks must be integers 1 through 4 or null")
+		}
+	}
+}
+
+func validPriorityRank(value any) bool {
+	switch rank := value.(type) {
+	case nil:
+		return true
+	case int:
+		return rank >= 1 && rank <= 4
+	default:
+		return false
+	}
+}
+
+func validateWorkspaceRelativePath(field string, path string, problems *[]string) {
+	trimmed := strings.TrimSpace(path)
+	if trimmed == "" || strings.HasPrefix(trimmed, "~") || filepath.IsAbs(trimmed) ||
+		strings.HasPrefix(trimmed, `\`) || windowsAbsPathPattern.MatchString(trimmed) ||
+		pathEscapesWorkspace(trimmed) {
+		*problems = append(*problems, field+" must be a relative path inside the workspace")
+	}
+}
+
+func pathEscapesWorkspace(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,386 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestParseWorkflowFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`---
+tracker:
+  kind: github
+  api_key: $GITHUB_TOKEN
+  project_slug: "PVT_project"
+  active_states:
+    - Todo
+    - In Progress
+  state_map:
+    Cancelled: Done
+  priority_map:
+    Urgent: 1
+    No priority: null
+polling:
+  interval_ms: 15000
+workspace:
+  root: ~/code/symphony-go-workspaces
+  auto_branch: false
+worker:
+  ssh_hosts:
+    - worker-1
+  max_concurrent_agents_per_host: 2
+agent:
+  max_concurrent_agents: 5
+  max_concurrent_agents_by_state:
+    Merging: 1
+  dispatch_priority_by_state:
+    - Merging
+    - Rework
+  auto_promote:
+    enabled: true
+    quiet_seconds: 0
+    optout_label: Requires-Human-Review
+    allowed_issue_labels:
+      - enhancement
+  lessons:
+    enabled: true
+    path: ".symphony/lessons.md"
+    max_entries: 5
+    recall_n: 2
+    postmortem_max_tokens: 256
+  skills:
+    enabled: true
+    path: ".symphony/skills"
+    max_skills_in_prompt: 20
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: danger-full-access
+  turn_sandbox_policy:
+    type: dangerFullAccess
+    networkAccess: true
+  turn_timeout_ms: 600000
+  read_timeout_ms: 1000
+  stall_timeout_ms: 0
+server:
+  host: 0.0.0.0
+  port: 4001
+observability:
+  dashboard_enabled: false
+  refresh_ms: 2000
+  render_interval_ms: 32
+budget:
+  enabled: true
+  per_day_max_usd: 25
+  per_issue_max_usd: 5
+  refusal_cooldown_seconds: 30
+  pricing_path: priv/pricing/models.yaml
+hooks:
+  after_create: git clone .
+  before_run: echo before
+  after_run: echo after
+  before_remove: echo remove
+  timeout_ms: 30000
+---
+Ticket prompt {{ issue.title }}
+`)
+
+	workflow, err := ParseWorkflow(raw)
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	cfg := workflow.Config
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	if workflow.Prompt != "Ticket prompt {{ issue.title }}\n" {
+		t.Fatalf("Prompt = %q", workflow.Prompt)
+	}
+	if cfg.Tracker.Kind != TrackerGitHub {
+		t.Fatalf("Tracker.Kind = %q, want %q", cfg.Tracker.Kind, TrackerGitHub)
+	}
+	if cfg.Tracker.Endpoint != "https://api.github.com/graphql" {
+		t.Fatalf("Tracker.Endpoint = %q", cfg.Tracker.Endpoint)
+	}
+	if got := cfg.Tracker.StateMap.Map["Cancelled"]; got != "Done" {
+		t.Fatalf("Tracker.StateMap[Cancelled] = %v, want Done", got)
+	}
+	if got := cfg.Tracker.PriorityMap.Map["No priority"]; got != nil {
+		t.Fatalf("Tracker.PriorityMap[No priority] = %v, want nil", got)
+	}
+	if got := cfg.Agent.MaxConcurrentAgentsByState["merging"]; got != 1 {
+		t.Fatalf("Agent.MaxConcurrentAgentsByState[merging] = %d, want 1", got)
+	}
+	if got := cfg.Agent.DispatchPriorityByState; len(got) != 2 || got[0] != "merging" || got[1] != "rework" {
+		t.Fatalf("Agent.DispatchPriorityByState = %#v", got)
+	}
+	if cfg.Agent.AutoPromote.OptoutLabel != "requires-human-review" {
+		t.Fatalf("Agent.AutoPromote.OptoutLabel = %q", cfg.Agent.AutoPromote.OptoutLabel)
+	}
+	if !cfg.Codex.ApprovalPolicy.IsString || cfg.Codex.ApprovalPolicy.String != "never" {
+		t.Fatalf("Codex.ApprovalPolicy = %#v, want string never", cfg.Codex.ApprovalPolicy)
+	}
+	if got := cfg.Codex.TurnSandboxPolicy["networkAccess"]; got != true {
+		t.Fatalf("Codex.TurnSandboxPolicy[networkAccess] = %v, want true", got)
+	}
+	if !cfg.Budget.Enabled {
+		t.Fatal("Budget.Enabled = false, want true")
+	}
+	if cfg.Hooks.AfterCreate != "git clone ." {
+		t.Fatalf("Hooks.AfterCreate = %q", cfg.Hooks.AfterCreate)
+	}
+}
+
+func TestParseWorkflowDefaults(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte("---\ntracker:\n  kind: memory\n---\nPrompt\n"))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	cfg := workflow.Config
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	if cfg.Tracker.Endpoint != "https://api.linear.app/graphql" {
+		t.Fatalf("Tracker.Endpoint = %q", cfg.Tracker.Endpoint)
+	}
+	if cfg.Polling.IntervalMS != 30000 {
+		t.Fatalf("Polling.IntervalMS = %d", cfg.Polling.IntervalMS)
+	}
+	if cfg.Workspace.AutoBranch != true {
+		t.Fatal("Workspace.AutoBranch = false, want true")
+	}
+	if cfg.Agent.MaxConcurrentAgents != 10 {
+		t.Fatalf("Agent.MaxConcurrentAgents = %d, want 10", cfg.Agent.MaxConcurrentAgents)
+	}
+	if cfg.Agent.Lessons.Path != ".symphony/lessons.md" {
+		t.Fatalf("Agent.Lessons.Path = %q", cfg.Agent.Lessons.Path)
+	}
+	if cfg.Agent.Skills.Path != ".symphony/skills" {
+		t.Fatalf("Agent.Skills.Path = %q", cfg.Agent.Skills.Path)
+	}
+	if !cfg.Codex.ApprovalPolicy.IsMap {
+		t.Fatalf("Codex.ApprovalPolicy = %#v, want map default", cfg.Codex.ApprovalPolicy)
+	}
+	if cfg.Server.Host != "127.0.0.1" {
+		t.Fatalf("Server.Host = %q", cfg.Server.Host)
+	}
+	if !cfg.Observability.DashboardEnabled {
+		t.Fatal("Observability.DashboardEnabled = false, want true")
+	}
+	if cfg.Budget.PricingPath != "priv/pricing/models.yaml" {
+		t.Fatalf("Budget.PricingPath = %q", cfg.Budget.PricingPath)
+	}
+}
+
+func TestParseWorkflowNormalizesGitHubAppIDs(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: github
+  api_key: token
+  project_slug: PVT_project
+  github_app_id: 12345
+  github_app_installation_id: 67890
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	if workflow.Config.Tracker.GitHubAppID != "12345" {
+		t.Fatalf("Tracker.GitHubAppID = %q, want 12345", workflow.Config.Tracker.GitHubAppID)
+	}
+	if workflow.Config.Tracker.GitHubAppInstallationID != "67890" {
+		t.Fatalf("Tracker.GitHubAppInstallationID = %q, want 67890", workflow.Config.Tracker.GitHubAppInstallationID)
+	}
+}
+
+func TestStringOrMapFieldsAcceptScalarOrMapping(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+  state_map: $STATE_MAP_JSON
+  priority_map:
+    P0: 1
+    P1: 2
+codex:
+  approval_policy:
+    allow:
+      - tool: shell
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	if !workflow.Config.Tracker.StateMap.IsString {
+		t.Fatalf("Tracker.StateMap = %#v, want string", workflow.Config.Tracker.StateMap)
+	}
+	if workflow.Config.Tracker.StateMap.String != "$STATE_MAP_JSON" {
+		t.Fatalf("Tracker.StateMap.String = %q", workflow.Config.Tracker.StateMap.String)
+	}
+	if got := workflow.Config.Tracker.PriorityMap.Map["P1"]; got != 2 {
+		t.Fatalf("Tracker.PriorityMap[P1] = %v, want 2", got)
+	}
+	if got := workflow.Config.Codex.ApprovalPolicy.Map["allow"].([]any)[0].(map[string]any)["tool"]; got != "shell" {
+		t.Fatalf("Codex.ApprovalPolicy allow tool = %v, want shell", got)
+	}
+}
+
+func TestConfigValidateReportsInvalidSettings(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "missing tracker kind",
+			raw:  "---\ntracker: {}\n---\nPrompt\n",
+			want: []string{"tracker.kind is required"},
+		},
+		{
+			name: "unsupported tracker kind",
+			raw:  "---\ntracker:\n  kind: jira\n---\nPrompt\n",
+			want: []string{"tracker.kind must be one of"},
+		},
+		{
+			name: "linear credentials",
+			raw:  "---\ntracker:\n  kind: linear\n---\nPrompt\n",
+			want: []string{"tracker.api_key is required for linear", "tracker.project_slug is required for linear"},
+		},
+		{
+			name: "github credentials",
+			raw:  "---\ntracker:\n  kind: github\n---\nPrompt\n",
+			want: []string{"tracker.api_key is required for github", "tracker.project_slug is required for github"},
+		},
+		{
+			name: "positive numbers and states",
+			raw: `---
+tracker:
+  kind: memory
+  active_states: ["Todo", ""]
+polling:
+  interval_ms: 0
+worker:
+  max_concurrent_agents_per_host: 0
+agent:
+  max_concurrent_agents: 0
+  max_concurrent_agents_by_state:
+    Todo: 0
+  dispatch_priority_by_state: ["Todo", "Todo"]
+codex:
+  turn_timeout_ms: 0
+hooks:
+  timeout_ms: 0
+observability:
+  refresh_ms: 0
+budget:
+  per_day_max_usd: 0
+server:
+  port: -1
+---
+Prompt
+`,
+			want: []string{
+				"tracker.active_states state names must not be blank",
+				"polling.interval_ms must be greater than 0",
+				"worker.max_concurrent_agents_per_host must be greater than 0",
+				"agent.max_concurrent_agents must be greater than 0",
+				"agent.max_concurrent_agents_by_state limits must be positive integers",
+				"agent.dispatch_priority_by_state state names must be unique",
+				"codex.turn_timeout_ms must be greater than 0",
+				"hooks.timeout_ms must be greater than 0",
+				"observability.refresh_ms must be greater than 0",
+				"budget.per_day_max_usd must be greater than 0",
+				"server.port must be greater than or equal to 0",
+			},
+		},
+		{
+			name: "invalid paths and priority map",
+			raw: `---
+tracker:
+  kind: memory
+  priority_map:
+    "": 1
+    Bad: 5
+agent:
+  lessons:
+    path: ../lessons.md
+  skills:
+    path: /tmp/skills
+---
+Prompt
+`,
+			want: []string{
+				"tracker.priority_map option names must not be blank",
+				"tracker.priority_map ranks must be integers 1 through 4 or null",
+				"agent.lessons.path must be a relative path inside the workspace",
+				"agent.skills.path must be a relative path inside the workspace",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflow, err := ParseWorkflow([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+
+			err = workflow.Config.Validate()
+			if err == nil {
+				t.Fatal("Validate() error = nil, want error")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("Validate() error = %q, want substring %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+func TestParseWorkflowReportsInvalidFrontmatter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{name: "missing frontmatter", raw: "Prompt only\n", want: "missing YAML frontmatter"},
+		{name: "unterminated frontmatter", raw: "---\ntracker:\n  kind: memory\n", want: "unterminated YAML frontmatter"},
+		{name: "invalid yaml", raw: "---\ntracker: [\n---\nPrompt\n", want: "parse YAML frontmatter"},
+		{name: "not a map", raw: "---\n- tracker\n---\nPrompt\n", want: "workflow frontmatter must be a mapping"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseWorkflow([]byte(tt.raw))
+			if err == nil {
+				t.Fatal("ParseWorkflow() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("ParseWorkflow() error = %q, want substring %q", err, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -204,6 +204,28 @@ Prompt
 	}
 }
 
+func TestConfigValidateAcceptsGitHubAppCredentials(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: github
+  project_slug: PVT_project
+  github_app_id: 12345
+  github_app_private_key_path: .symphony/github-app.pem
+  github_app_installation_id: 67890
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
 func TestStringOrMapFieldsAcceptScalarOrMapping(t *testing.T) {
 	t.Parallel()
 
@@ -265,7 +287,22 @@ func TestConfigValidateReportsInvalidSettings(t *testing.T) {
 		{
 			name: "github credentials",
 			raw:  "---\ntracker:\n  kind: github\n---\nPrompt\n",
-			want: []string{"tracker.api_key is required for github", "tracker.project_slug is required for github"},
+			want: []string{"tracker.api_key or GitHub App credentials are required for github", "tracker.project_slug is required for github"},
+		},
+		{
+			name: "partial github app credentials",
+			raw: `---
+tracker:
+  kind: github
+  project_slug: PVT_project
+  github_app_id: 12345
+---
+Prompt
+`,
+			want: []string{
+				"tracker.github_app_installation_id is required for github app",
+				"tracker.github_app_private_key or tracker.github_app_private_key_path is required for github app",
+			},
 		},
 		{
 			name: "positive numbers and states",


### PR DESCRIPTION
## Summary
- Add internal/config support for parsing WORKFLOW.md YAML frontmatter into typed Go config structs.
- Add StringOrMap support for state_map, priority_map, and Codex approval policy.
- Add Config.Validate coverage for tracker semantics, numeric bounds, state lists, budget, hooks, paths, server, and observability settings.

Fixes #4

## Test Plan
- go test ./internal/config
- go build ./... && go vet ./... && go test ./... && go test -cover ./...
- go run ./cmd/symphony --help