### PR TITLE
feat(codex): add json-rpc transport

### DIFF
--- a/internal/codex/jsonrpc.go
+++ b/internal/codex/jsonrpc.go
@@ -1,0 +1,134 @@
+package codex
+
+import (
+	"bufio"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+	"sync"
+)
+
+const (
+	JSONRPCVersion   = "2.0"
+	MaxScanTokenSize = 2 * 1024 * 1024
+)
+
+var ErrInvalidFrame = errors.New("invalid json-rpc frame")
+
+type Message struct {
+	JSONRPC string          `json:"jsonrpc,omitempty"`
+	ID      json.RawMessage `json:"id,omitempty"`
+	Method  string          `json:"method,omitempty"`
+	Params  json.RawMessage `json:"params,omitempty"`
+	Result  json.RawMessage `json:"result,omitempty"`
+	Error   *RPCError       `json:"error,omitempty"`
+}
+
+type RPCError struct {
+	Code    int             `json:"code"`
+	Message string          `json:"message"`
+	Data    json.RawMessage `json:"data,omitempty"`
+}
+
+type Codec struct {
+	scanner *bufio.Scanner
+	writer  *bufio.Writer
+	writeMu sync.Mutex
+}
+
+func NewCodec(r io.Reader, w io.Writer) *Codec {
+	if r == nil {
+		r = strings.NewReader("")
+	}
+	if w == nil {
+		w = io.Discard
+	}
+
+	scanner := bufio.NewScanner(r)
+	scanner.Buffer(make([]byte, 0, 64*1024), MaxScanTokenSize)
+
+	return &Codec{
+		scanner: scanner,
+		writer:  bufio.NewWriter(w),
+	}
+}
+
+func (c *Codec) ReadMessage() (Message, error) {
+	if !c.scanner.Scan() {
+		if err := c.scanner.Err(); err != nil {
+			return Message{}, fmt.Errorf("%w: scan: %w", ErrInvalidFrame, err)
+		}
+		return Message{}, io.EOF
+	}
+
+	line := strings.TrimSpace(string(c.scanner.Bytes()))
+	if line == "" {
+		return Message{}, fmt.Errorf("%w: empty frame", ErrInvalidFrame)
+	}
+
+	var msg Message
+	if err := json.Unmarshal([]byte(line), &msg); err != nil {
+		return Message{}, fmt.Errorf("%w: decode: %w", ErrInvalidFrame, err)
+	}
+	if err := validateMessage(msg); err != nil {
+		return Message{}, err
+	}
+
+	return msg, nil
+}
+
+func (c *Codec) WriteMessage(msg Message) error {
+	if msg.JSONRPC == "" {
+		msg.JSONRPC = JSONRPCVersion
+	}
+	if err := validateMessage(msg); err != nil {
+		return err
+	}
+
+	frame, err := json.Marshal(msg)
+	if err != nil {
+		return fmt.Errorf("marshal json-rpc message: %w", err)
+	}
+
+	c.writeMu.Lock()
+	defer c.writeMu.Unlock()
+
+	if _, err := c.writer.Write(frame); err != nil {
+		return fmt.Errorf("write json-rpc frame: %w", err)
+	}
+	if err := c.writer.WriteByte('\n'); err != nil {
+		return fmt.Errorf("write json-rpc frame newline: %w", err)
+	}
+	if err := c.writer.Flush(); err != nil {
+		return fmt.Errorf("flush json-rpc frame: %w", err)
+	}
+
+	return nil
+}
+
+func validateMessage(msg Message) error {
+	if msg.JSONRPC != "" && msg.JSONRPC != JSONRPCVersion {
+		return fmt.Errorf("%w: unsupported version %q", ErrInvalidFrame, msg.JSONRPC)
+	}
+
+	hasMethod := msg.Method != ""
+	hasResult := len(msg.Result) > 0
+	hasError := msg.Error != nil
+
+	switch {
+	case hasResult && hasError:
+		return fmt.Errorf("%w: response has result and error", ErrInvalidFrame)
+	case hasMethod && (hasResult || hasError):
+		return fmt.Errorf("%w: message cannot be both request and response", ErrInvalidFrame)
+	case !hasMethod && !hasResult && !hasError:
+		return fmt.Errorf("%w: missing method, result, or error", ErrInvalidFrame)
+	case !hasMethod && len(msg.ID) == 0:
+		return fmt.Errorf("%w: response missing id", ErrInvalidFrame)
+	case hasError && strings.TrimSpace(msg.Error.Message) == "":
+		return fmt.Errorf("%w: error response missing message", ErrInvalidFrame)
+	default:
+		return nil
+	}
+}

--- a/internal/codex/jsonrpc_test.go
+++ b/internal/codex/jsonrpc_test.go
@@ -1,0 +1,221 @@
+package codex
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestCodecWriteMessageFramesJSONLine(t *testing.T) {
+	t.Parallel()
+
+	var out bytes.Buffer
+	codec := NewCodec(strings.NewReader(""), &out)
+
+	msg := Message{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+		Params:  json.RawMessage(`{"client":"symphony"}`),
+	}
+
+	if err := codec.WriteMessage(msg); err != nil {
+		t.Fatalf("WriteMessage() error = %v", err)
+	}
+
+	got := out.String()
+	if !strings.HasSuffix(got, "\n") {
+		t.Fatalf("frame missing newline terminator: %q", got)
+	}
+	if strings.Count(got, "\n") != 1 {
+		t.Fatalf("frame contains extra newlines: %q", got)
+	}
+
+	var decoded Message
+	if err := json.Unmarshal(bytes.TrimSpace(out.Bytes()), &decoded); err != nil {
+		t.Fatalf("frame is not JSON: %v", err)
+	}
+	if decoded.JSONRPC != JSONRPCVersion {
+		t.Fatalf("JSONRPC = %q, want %q", decoded.JSONRPC, JSONRPCVersion)
+	}
+	if string(decoded.ID) != "1" {
+		t.Fatalf("ID = %s, want 1", decoded.ID)
+	}
+	if decoded.Method != "initialize" {
+		t.Fatalf("Method = %q, want initialize", decoded.Method)
+	}
+	assertJSONEqual(t, decoded.Params, json.RawMessage(`{"client":"symphony"}`))
+}
+
+func TestCodecReadMessage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want Message
+	}{
+		{
+			name: "request",
+			line: `{"jsonrpc":"2.0","id":7,"method":"thread/start","params":{"cwd":"/tmp/work"}}` + "\n",
+			want: Message{
+				JSONRPC: JSONRPCVersion,
+				ID:      json.RawMessage(`7`),
+				Method:  "thread/start",
+				Params:  json.RawMessage(`{"cwd":"/tmp/work"}`),
+			},
+		},
+		{
+			name: "notification",
+			line: `{"jsonrpc":"2.0","method":"turn/completed"}` + "\n",
+			want: Message{
+				JSONRPC: JSONRPCVersion,
+				Method:  "turn/completed",
+			},
+		},
+		{
+			name: "response",
+			line: `{"jsonrpc":"2.0","id":"abc","result":{"thread":{"id":"thread-1"}}}` + "\n",
+			want: Message{
+				JSONRPC: JSONRPCVersion,
+				ID:      json.RawMessage(`"abc"`),
+				Result:  json.RawMessage(`{"thread":{"id":"thread-1"}}`),
+			},
+		},
+		{
+			name: "codex lite without version",
+			line: `{"method":"initialized","params":{}}` + "\n",
+			want: Message{
+				Method: "initialized",
+				Params: json.RawMessage(`{}`),
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			codec := NewCodec(strings.NewReader(tt.line), io.Discard)
+
+			got, err := codec.ReadMessage()
+			if err != nil {
+				t.Fatalf("ReadMessage() error = %v", err)
+			}
+
+			if got.JSONRPC != tt.want.JSONRPC {
+				t.Fatalf("JSONRPC = %q, want %q", got.JSONRPC, tt.want.JSONRPC)
+			}
+			if string(got.ID) != string(tt.want.ID) {
+				t.Fatalf("ID = %s, want %s", got.ID, tt.want.ID)
+			}
+			if got.Method != tt.want.Method {
+				t.Fatalf("Method = %q, want %q", got.Method, tt.want.Method)
+			}
+			assertJSONEqual(t, got.Params, tt.want.Params)
+			assertJSONEqual(t, got.Result, tt.want.Result)
+		})
+	}
+}
+
+func TestCodecReadMessageRejectsMalformedFrames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+	}{
+		{name: "empty line", line: "\n"},
+		{name: "invalid json", line: "{not-json}\n"},
+		{name: "unsupported version", line: `{"jsonrpc":"1.0","method":"ping"}` + "\n"},
+		{name: "missing message shape", line: `{"jsonrpc":"2.0","params":{}}` + "\n"},
+		{name: "result and error", line: `{"jsonrpc":"2.0","id":1,"result":{},"error":{"code":-1,"message":"bad"}}` + "\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			codec := NewCodec(strings.NewReader(tt.line), io.Discard)
+
+			_, err := codec.ReadMessage()
+			if !errors.Is(err, ErrInvalidFrame) {
+				t.Fatalf("ReadMessage() error = %v, want ErrInvalidFrame", err)
+			}
+		})
+	}
+}
+
+func TestCodecReadMessageReturnsEOF(t *testing.T) {
+	t.Parallel()
+
+	codec := NewCodec(strings.NewReader(""), io.Discard)
+
+	_, err := codec.ReadMessage()
+	if !errors.Is(err, io.EOF) {
+		t.Fatalf("ReadMessage() error = %v, want EOF", err)
+	}
+}
+
+func TestCodecReadsLargeFrame(t *testing.T) {
+	t.Parallel()
+
+	if MaxScanTokenSize < 1024*1024 {
+		t.Fatalf("MaxScanTokenSize = %d, want at least 1 MiB", MaxScanTokenSize)
+	}
+
+	wantText := strings.Repeat("x", 1024*1024)
+	frame := `{"jsonrpc":"2.0","method":"item/agentMessage","params":{"text":"` + wantText + `"}}` + "\n"
+	codec := NewCodec(strings.NewReader(frame), io.Discard)
+
+	got, err := codec.ReadMessage()
+	if err != nil {
+		t.Fatalf("ReadMessage() error = %v", err)
+	}
+
+	var params struct {
+		Text string `json:"text"`
+	}
+	if err := json.Unmarshal(got.Params, &params); err != nil {
+		t.Fatalf("unmarshal params: %v", err)
+	}
+	if params.Text != wantText {
+		t.Fatalf("params text length = %d, want %d", len(params.Text), len(wantText))
+	}
+}
+
+func assertJSONEqual(t *testing.T, got json.RawMessage, want json.RawMessage) {
+	t.Helper()
+
+	if len(got) == 0 || len(want) == 0 {
+		if len(got) != len(want) {
+			t.Fatalf("JSON = %s, want %s", got, want)
+		}
+		return
+	}
+
+	var gotValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("got JSON is invalid: %v", err)
+	}
+
+	var wantValue any
+	if err := json.Unmarshal(want, &wantValue); err != nil {
+		t.Fatalf("want JSON is invalid: %v", err)
+	}
+
+	gotCanonical, err := json.Marshal(gotValue)
+	if err != nil {
+		t.Fatalf("marshal got JSON: %v", err)
+	}
+	wantCanonical, err := json.Marshal(wantValue)
+	if err != nil {
+		t.Fatalf("marshal want JSON: %v", err)
+	}
+	if !bytes.Equal(gotCanonical, wantCanonical) {
+		t.Fatalf("JSON = %s, want %s", gotCanonical, wantCanonical)
+	}
+}

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -1,0 +1,242 @@
+package codex
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"sync"
+	"time"
+)
+
+type Transport interface {
+	Send(context.Context, Message) error
+	Receive(context.Context) (Message, error)
+	Close(context.Context) error
+}
+
+type TransportFactory interface {
+	NewTransport(context.Context) (Transport, error)
+}
+
+type CommandFactory func(context.Context) *exec.Cmd
+
+type LocalTransportFactory struct {
+	newCommand CommandFactory
+}
+
+type localTransport struct {
+	cmd       *exec.Cmd
+	stdin     io.WriteCloser
+	codec     *Codec
+	received  chan transportResult
+	done      chan struct{}
+	sendLock  chan struct{}
+	waitErr   error
+	waitMu    sync.Mutex
+	closeOnce sync.Once
+	closeErr  error
+}
+
+type transportResult struct {
+	msg Message
+	err error
+}
+
+func NewLocalTransportFactory(newCommand CommandFactory) (*LocalTransportFactory, error) {
+	if newCommand == nil {
+		return nil, errors.New("command factory is nil")
+	}
+
+	return &LocalTransportFactory{newCommand: newCommand}, nil
+}
+
+func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, error) {
+	ctx = contextOrBackground(ctx)
+
+	cmd := f.newCommand(ctx)
+	if cmd == nil {
+		return nil, errors.New("command factory returned nil command")
+	}
+
+	stdin, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, fmt.Errorf("create stdin pipe: %w", err)
+	}
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("create stdout pipe: %w", err)
+	}
+
+	if err := cmd.Start(); err != nil {
+		_ = stdin.Close()
+		return nil, fmt.Errorf("start command: %w", err)
+	}
+
+	transport := &localTransport{
+		cmd:      cmd,
+		stdin:    stdin,
+		codec:    NewCodec(stdout, stdin),
+		received: make(chan transportResult, 64),
+		done:     make(chan struct{}),
+		sendLock: make(chan struct{}, 1),
+	}
+	transport.sendLock <- struct{}{}
+
+	go transport.readLoop()
+	go transport.wait()
+
+	return transport, nil
+}
+
+func (t *localTransport) Send(ctx context.Context, msg Message) error {
+	ctx = contextOrBackground(ctx)
+
+	if err := t.acquireSend(ctx); err != nil {
+		return err
+	}
+	defer t.releaseSend()
+
+	writeDone := make(chan error, 1)
+	go func() {
+		writeDone <- t.codec.WriteMessage(msg)
+	}()
+
+	select {
+	case err := <-writeDone:
+		return err
+	case <-ctx.Done():
+		select {
+		case err := <-writeDone:
+			return err
+		default:
+		}
+
+		closeErr := t.closeStdin()
+		<-writeDone
+		if closeErr != nil {
+			return fmt.Errorf("%w: close stdin: %v", ctx.Err(), closeErr)
+		}
+		return ctx.Err()
+	}
+}
+
+func (t *localTransport) Receive(ctx context.Context) (Message, error) {
+	ctx = contextOrBackground(ctx)
+
+	select {
+	case <-ctx.Done():
+		return Message{}, ctx.Err()
+	case result, ok := <-t.received:
+		if !ok {
+			return Message{}, io.EOF
+		}
+		return result.msg, result.err
+	}
+}
+
+func (t *localTransport) Close(ctx context.Context) error {
+	ctx = contextOrBackground(ctx)
+
+	closeErr := t.closeStdin()
+
+	select {
+	case <-t.done:
+		if closeErr != nil {
+			return fmt.Errorf("close stdin: %w", closeErr)
+		}
+		return t.waitError()
+	case <-ctx.Done():
+		var killErr error
+		if t.cmd.Process != nil {
+			killErr = t.cmd.Process.Kill()
+		}
+
+		select {
+		case <-t.done:
+		case <-time.After(time.Second):
+		}
+
+		if killErr != nil {
+			return fmt.Errorf("%w: kill process: %v", ctx.Err(), killErr)
+		}
+		return ctx.Err()
+	}
+}
+
+func (t *localTransport) acquireSend(ctx context.Context) error {
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-t.done:
+		return t.closedError()
+	case <-t.sendLock:
+		select {
+		case <-t.done:
+			t.releaseSend()
+			return t.closedError()
+		default:
+			return nil
+		}
+	}
+}
+
+func (t *localTransport) releaseSend() {
+	t.sendLock <- struct{}{}
+}
+
+func (t *localTransport) closeStdin() error {
+	t.closeOnce.Do(func() {
+		t.closeErr = t.stdin.Close()
+		if errors.Is(t.closeErr, os.ErrClosed) {
+			t.closeErr = nil
+		}
+	})
+	return t.closeErr
+}
+
+func (t *localTransport) closedError() error {
+	if err := t.waitError(); err != nil {
+		return fmt.Errorf("transport closed: %w", err)
+	}
+	return errors.New("transport closed")
+}
+
+func (t *localTransport) readLoop() {
+	defer close(t.received)
+
+	for {
+		msg, err := t.codec.ReadMessage()
+		if err != nil {
+			t.received <- transportResult{err: err}
+			return
+		}
+
+		t.received <- transportResult{msg: msg}
+	}
+}
+
+func (t *localTransport) wait() {
+	err := t.cmd.Wait()
+	t.waitMu.Lock()
+	t.waitErr = err
+	t.waitMu.Unlock()
+	close(t.done)
+}
+
+func (t *localTransport) waitError() error {
+	t.waitMu.Lock()
+	defer t.waitMu.Unlock()
+	return t.waitErr
+}
+
+func contextOrBackground(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -1,0 +1,256 @@
+package codex
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalTransportRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "roundtrip")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+
+	transport, err := factory.NewTransport(context.Background())
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := transport.Close(closeCtx); err != nil && !errors.Is(err, io.EOF) {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	request := Message{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(`42`),
+		Method:  "ping",
+		Params:  json.RawMessage(`{"value":"hello"}`),
+	}
+
+	if err := transport.Send(context.Background(), request); err != nil {
+		t.Fatalf("Send() error = %v", err)
+	}
+
+	response, err := transport.Receive(context.Background())
+	if err != nil {
+		t.Fatalf("Receive() error = %v", err)
+	}
+
+	if response.JSONRPC != JSONRPCVersion {
+		t.Fatalf("JSONRPC = %q, want %q", response.JSONRPC, JSONRPCVersion)
+	}
+	if string(response.ID) != "42" {
+		t.Fatalf("ID = %s, want 42", response.ID)
+	}
+	assertJSONEqual(t, response.Result, json.RawMessage(`{"echoedMethod":"ping","ok":true}`))
+}
+
+func TestLocalTransportReceiveHonorsContext(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "silent")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+
+	transport, err := factory.NewTransport(context.Background())
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := transport.Close(closeCtx); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	receiveCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	_, err = transport.Receive(receiveCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Receive() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestLocalTransportSendHonorsContextDuringBlockedWrite(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "block-send")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+
+	transport, err := factory.NewTransport(context.Background())
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	t.Cleanup(func() {
+		closeCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		defer cancel()
+		if err := transport.Close(closeCtx); err != nil && !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	params, err := json.Marshal(strings.Repeat("x", 2*MaxScanTokenSize))
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	sendCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err = transport.Send(sendCtx, Message{
+		ID:     json.RawMessage(`1`),
+		Method: "large",
+		Params: params,
+	})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Send() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestLocalTransportCloseKillsUnresponsiveProcess(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "ignore-close")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+
+	transport, err := factory.NewTransport(context.Background())
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	err = transport.Close(closeCtx)
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Close() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestLocalTransportFactoryRejectsInvalidCommandFactories(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		newCommand CommandFactory
+	}{
+		{name: "nil factory", newCommand: nil},
+		{name: "nil command", newCommand: func(context.Context) *exec.Cmd { return nil }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			factory, err := NewLocalTransportFactory(tt.newCommand)
+			if tt.newCommand == nil {
+				if err == nil {
+					t.Fatal("NewLocalTransportFactory() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("NewLocalTransportFactory() error = %v", err)
+			}
+
+			_, err = factory.NewTransport(context.Background())
+			if err == nil {
+				t.Fatal("NewTransport() error = nil, want error")
+			}
+		})
+	}
+}
+
+func TestLocalTransportHelperProcess(t *testing.T) {
+	if os.Getenv("SYMPHONY_CODEX_TRANSPORT_HELPER") != "1" {
+		return
+	}
+
+	mode := os.Getenv("SYMPHONY_CODEX_TRANSPORT_MODE")
+
+	switch mode {
+	case "roundtrip":
+		helperRoundTrip()
+	case "silent":
+		_, _ = io.Copy(io.Discard, os.Stdin)
+	case "block-send":
+		time.Sleep(time.Hour)
+	case "ignore-close":
+		time.Sleep(time.Hour)
+	default:
+		os.Exit(2)
+	}
+
+	os.Exit(0)
+}
+
+func helperCommand(ctx context.Context, mode string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=^TestLocalTransportHelperProcess$")
+	cmd.Env = append(os.Environ(),
+		"SYMPHONY_CODEX_TRANSPORT_HELPER=1",
+		"SYMPHONY_CODEX_TRANSPORT_MODE="+mode,
+	)
+	return cmd
+}
+
+func helperRoundTrip() {
+	scanner := bufio.NewScanner(os.Stdin)
+	scanner.Buffer(make([]byte, 0, 64*1024), MaxScanTokenSize)
+
+	if !scanner.Scan() {
+		os.Exit(3)
+	}
+
+	var request Message
+	if err := json.Unmarshal(scanner.Bytes(), &request); err != nil {
+		os.Exit(4)
+	}
+
+	result, err := json.Marshal(map[string]any{
+		"echoedMethod": request.Method,
+		"ok":           true,
+	})
+	if err != nil {
+		os.Exit(5)
+	}
+
+	response := Message{
+		JSONRPC: JSONRPCVersion,
+		ID:      request.ID,
+		Result:  result,
+	}
+
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetEscapeHTML(false)
+	if err := encoder.Encode(response); err != nil {
+		os.Exit(6)
+	}
+}


### PR DESCRIPTION
## Summary
- Add an internal Codex JSON-RPC message model with newline-delimited framing and a 2 MiB scanner token limit.
- Add a local exec.Cmd-backed transport factory with context-aware send, receive, and close behavior.
- Cover codec validation, large frames, subprocess round trips, receive deadlines, and forced close behavior.

Fixes #17

## Test Plan
- go test ./internal/codex
- make check