### PR TITLE
feat(config): add global config parser

### DIFF
--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -279,18 +279,22 @@ func defaultConfig(path string) Config {
 		Path:       path,
 		APIVersion: APIVersion,
 		Kind:       Kind,
-		Global: Settings{
-			MaxConcurrentAgents: 8,
-			Scheduling:          SchedulingWeighted,
-			FairShare: map[string]any{
-				"half_life": "1h",
-			},
-			Startup: map[string]any{
-				"jitter_seconds":       10,
-				"max_spawn_per_second": 2,
-			},
+		Global:     defaultSettings(),
+		Projects:   []Project{},
+	}
+}
+
+func defaultSettings() Settings {
+	return Settings{
+		MaxConcurrentAgents: 8,
+		Scheduling:          SchedulingWeighted,
+		FairShare: map[string]any{
+			"half_life": "1h",
 		},
-		Projects: []Project{},
+		Startup: map[string]any{
+			"jitter_seconds":       10,
+			"max_spawn_per_second": 2,
+		},
 	}
 }
 
@@ -633,12 +637,12 @@ func build(attrs map[string]any, path string, opts options) Config {
 }
 
 func buildSettings(attrs map[string]any) Settings {
-	return Settings{
-		MaxConcurrentAgents: mustInt(attrs["max_concurrent_agents"]),
-		Scheduling:          mustString(attrs["scheduling"]),
-		FairShare:           optionalMap(attrs["fair_share"]),
-		Startup:             optionalMap(attrs["startup"]),
-	}
+	settings := defaultSettings()
+	settings.MaxConcurrentAgents = mustInt(attrs["max_concurrent_agents"])
+	settings.Scheduling = mustString(attrs["scheduling"])
+	settings.FairShare = mergeMap(settings.FairShare, attrs["fair_share"])
+	settings.Startup = mergeMap(settings.Startup, attrs["startup"])
+	return settings
 }
 
 func buildProjects(projects []any, opts options) []Project {
@@ -667,13 +671,17 @@ func buildProjects(projects []any, opts options) []Project {
 	return out
 }
 
-func optionalMap(value any) map[string]any {
+func mergeMap(defaults map[string]any, value any) map[string]any {
+	out := make(map[string]any, len(defaults))
+	for key, nestedValue := range defaults {
+		out[key] = nestedValue
+	}
+
 	if value == nil {
-		return map[string]any{}
+		return out
 	}
 
 	source := mustMap(value)
-	out := make(map[string]any, len(source))
 	for key, nestedValue := range source {
 		out[key] = nestedValue
 	}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -1,0 +1,775 @@
+package global
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	APIVersion = "symphony/v1"
+	Kind       = "GlobalConfig"
+
+	SchedulingWeighted   = "weighted"
+	SchedulingStrict     = "strict"
+	SchedulingRoundRobin = "round_robin"
+	SchedulingFairShare  = "fair_share"
+)
+
+var schedulingModes = []string{
+	SchedulingWeighted,
+	SchedulingStrict,
+	SchedulingRoundRobin,
+	SchedulingFairShare,
+}
+
+type Config struct {
+	Path       string    `yaml:"-"`
+	APIVersion string    `yaml:"apiVersion"`
+	Kind       string    `yaml:"kind"`
+	Global     Settings  `yaml:"global"`
+	Projects   []Project `yaml:"projects"`
+}
+
+type Settings struct {
+	MaxConcurrentAgents int            `yaml:"max_concurrent_agents"`
+	Scheduling          string         `yaml:"scheduling"`
+	FairShare           map[string]any `yaml:"fair_share"`
+	Startup             map[string]any `yaml:"startup"`
+}
+
+type Project struct {
+	ID            string `yaml:"id"`
+	Workflow      string `yaml:"workflow"`
+	Workdir       string `yaml:"workdir"`
+	Weight        int    `yaml:"weight"`
+	Priority      int    `yaml:"priority"`
+	Paused        bool   `yaml:"paused"`
+	CredentialRef string `yaml:"credential_ref"`
+}
+
+type Option func(*options)
+
+type MissingFileError struct {
+	Path string
+	Err  error
+}
+
+type ParseError struct {
+	Path string
+	Err  error
+}
+
+type ValidationError struct {
+	Path     string
+	Problems []string
+}
+
+type options struct {
+	home       string
+	relativeTo string
+}
+
+func WithHome(home string) Option {
+	return func(opts *options) {
+		opts.home = home
+	}
+}
+
+func WithRelativeTo(path string) Option {
+	return func(opts *options) {
+		opts.relativeTo = path
+	}
+}
+
+func DefaultPath() (string, error) {
+	if symphonyHome := os.Getenv("SYMPHONY_HOME"); symphonyHome != "" {
+		opts := defaultOptions()
+		expanded, err := expandPath(symphonyHome, opts)
+		if err != nil {
+			return "", err
+		}
+		return filepath.Join(expanded, "global.yaml"), nil
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user home: %w", err)
+	}
+	return filepath.Join(home, ".symphony", "global.yaml"), nil
+}
+
+func Default() (Config, error) {
+	path, err := DefaultPath()
+	if err != nil {
+		return Config{}, err
+	}
+	return defaultConfig(path), nil
+}
+
+func Read(path string, opts ...Option) (Config, error) {
+	readOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&readOptions)
+	}
+
+	expandedPath, err := expandPath(path, readOptions)
+	if err != nil {
+		return Config{}, err
+	}
+
+	raw, err := os.ReadFile(expandedPath)
+	if err != nil {
+		return Config{}, MissingFileError{Path: expandedPath, Err: err}
+	}
+
+	return Parse(raw, expandedPath, opts...)
+}
+
+func ReadOrDefault(path string, opts ...Option) (Config, error) {
+	readOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&readOptions)
+	}
+
+	expandedPath, err := expandPath(path, readOptions)
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg, err := Read(expandedPath, opts...)
+	if err == nil {
+		return cfg, nil
+	}
+
+	var missing MissingFileError
+	if errors.As(err, &missing) && errors.Is(missing.Err, os.ErrNotExist) {
+		return defaultConfig(expandedPath), nil
+	}
+
+	return Config{}, err
+}
+
+func Parse(raw []byte, path string, opts ...Option) (Config, error) {
+	readOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&readOptions)
+	}
+
+	var decoded any
+	if err := yaml.Unmarshal(raw, &decoded); err != nil {
+		return Config{}, ParseError{Path: path, Err: err}
+	}
+
+	root, ok := normalizeYAML(decoded).(map[string]any)
+	if !ok {
+		return Config{}, ValidationError{Path: path, Problems: []string{"root: must be a mapping"}}
+	}
+
+	if problems := validateRaw(root, readOptions); len(problems) > 0 {
+		return Config{}, ValidationError{Path: path, Problems: problems}
+	}
+
+	cfg := build(root, path, readOptions)
+	if err := cfg.Validate(opts...); err != nil {
+		return Config{}, err
+	}
+
+	return cfg, nil
+}
+
+func (c Config) Validate(opts ...Option) error {
+	readOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&readOptions)
+	}
+
+	var problems []string
+	if strings.TrimSpace(c.APIVersion) == "" {
+		problems = append(problems, "apiVersion: is required")
+	} else if c.APIVersion != APIVersion {
+		problems = append(problems, "apiVersion: must equal "+APIVersion)
+	}
+	if strings.TrimSpace(c.Kind) == "" {
+		problems = append(problems, "kind: is required")
+	} else if c.Kind != Kind {
+		problems = append(problems, "kind: must equal "+Kind)
+	}
+
+	if c.Global.MaxConcurrentAgents <= 0 {
+		problems = append(problems, "global.max_concurrent_agents: must be a positive integer")
+	}
+	if !validSchedulingMode(c.Global.Scheduling) {
+		problems = append(problems, "global.scheduling: must be one of "+strings.Join(schedulingModes, ", "))
+	}
+	problems = append(problems, startupErrors(c.Global.Startup, "global.startup")...)
+
+	if c.Projects == nil {
+		problems = append(problems, "projects: is required")
+	}
+	for index, project := range c.Projects {
+		prefix := fmt.Sprintf("projects[%d]", index)
+		if strings.TrimSpace(project.ID) == "" {
+			problems = append(problems, prefix+".id: must not be blank")
+		}
+		problems = append(problems, projectPathErrors(project.Workflow, prefix+".workflow", readOptions, wantFile)...)
+		problems = append(problems, projectPathErrors(project.Workdir, prefix+".workdir", readOptions, wantDirectory)...)
+		if project.Weight <= 0 {
+			problems = append(problems, prefix+".weight: must be a positive integer")
+		}
+		if project.CredentialRef != "" && strings.TrimSpace(project.CredentialRef) == "" {
+			problems = append(problems, prefix+".credential_ref: must not be blank")
+		}
+	}
+	problems = append(problems, duplicateProjectIDErrorsFromProjects(c.Projects)...)
+
+	if len(problems) > 0 {
+		return ValidationError{Path: c.Path, Problems: problems}
+	}
+
+	return nil
+}
+
+func (e MissingFileError) Error() string {
+	return fmt.Sprintf("read global config %s: %v", e.Path, e.Err)
+}
+
+func (e MissingFileError) Unwrap() error {
+	return e.Err
+}
+
+func (e ParseError) Error() string {
+	return fmt.Sprintf("parse global config %s: %v", e.Path, e.Err)
+}
+
+func (e ParseError) Unwrap() error {
+	return e.Err
+}
+
+func (e ValidationError) Error() string {
+	if e.Path == "" {
+		return "invalid global config: " + strings.Join(e.Problems, "; ")
+	}
+	return "invalid global config at " + e.Path + ": " + strings.Join(e.Problems, "; ")
+}
+
+func defaultOptions() options {
+	cwd, err := os.Getwd()
+	if err != nil {
+		cwd = "."
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		home = ""
+	}
+
+	return options{
+		home:       home,
+		relativeTo: cwd,
+	}
+}
+
+func defaultConfig(path string) Config {
+	return Config{
+		Path:       path,
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Global: Settings{
+			MaxConcurrentAgents: 8,
+			Scheduling:          SchedulingWeighted,
+			FairShare: map[string]any{
+				"half_life": "1h",
+			},
+			Startup: map[string]any{
+				"jitter_seconds":       10,
+				"max_spawn_per_second": 2,
+			},
+		},
+		Projects: []Project{},
+	}
+}
+
+func validateRaw(attrs map[string]any, opts options) []string {
+	var problems []string
+
+	problems = append(problems, requiredErrors(attrs, []string{"apiVersion", "kind", "global", "projects"})...)
+	problems = append(problems, versionErrors(attrs["apiVersion"])...)
+	problems = append(problems, kindErrors(attrs["kind"])...)
+	problems = append(problems, globalErrors(attrs["global"])...)
+	problems = append(problems, projectsErrors(attrs["projects"], opts)...)
+
+	return problems
+}
+
+func requiredErrors(attrs map[string]any, fields []string) []string {
+	var problems []string
+	for _, field := range fields {
+		value, ok := attrs[field]
+		if !ok || value == nil {
+			problems = append(problems, field+": is required")
+		}
+	}
+	return problems
+}
+
+func versionErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	text, ok := value.(string)
+	if !ok || text != APIVersion {
+		return []string{"apiVersion: must equal " + APIVersion}
+	}
+	return nil
+}
+
+func kindErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	text, ok := value.(string)
+	if !ok || text != Kind {
+		return []string{"kind: must equal " + Kind}
+	}
+	return nil
+}
+
+func globalErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+
+	global, ok := value.(map[string]any)
+	if !ok {
+		return []string{"global: must be a mapping"}
+	}
+
+	var problems []string
+	problems = append(problems, prefixErrors(requiredErrors(global, []string{"max_concurrent_agents", "scheduling"}), "global")...)
+	problems = append(problems, positiveIntegerError(global["max_concurrent_agents"], "global.max_concurrent_agents")...)
+	problems = append(problems, schedulingErrors(global["scheduling"])...)
+	problems = append(problems, optionalMapErrors(global, "fair_share")...)
+	problems = append(problems, optionalMapErrors(global, "startup")...)
+
+	if startup, ok := global["startup"].(map[string]any); ok {
+		problems = append(problems, startupErrors(startup, "global.startup")...)
+	}
+
+	return problems
+}
+
+func schedulingErrors(value any) []string {
+	if value == nil {
+		return nil
+	}
+	mode, ok := value.(string)
+	if ok && validSchedulingMode(mode) {
+		return nil
+	}
+	return []string{"global.scheduling: must be one of " + strings.Join(schedulingModes, ", ")}
+}
+
+func validSchedulingMode(mode string) bool {
+	for _, candidate := range schedulingModes {
+		if mode == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func optionalMapErrors(attrs map[string]any, field string) []string {
+	value, ok := attrs[field]
+	if !ok {
+		return nil
+	}
+	if _, ok := value.(map[string]any); ok {
+		return nil
+	}
+	return []string{"global." + field + ": must be a mapping"}
+}
+
+func startupErrors(startup map[string]any, prefix string) []string {
+	if startup == nil {
+		return nil
+	}
+
+	var problems []string
+	if value, ok := startup["jitter_seconds"]; ok && !nonNegativeInteger(value) {
+		problems = append(problems, prefix+".jitter_seconds: must be an integer greater than or equal to 0")
+	}
+	if value, ok := startup["max_spawn_per_second"]; ok && !positiveInteger(value) {
+		problems = append(problems, prefix+".max_spawn_per_second: must be a positive integer")
+	}
+	return problems
+}
+
+func projectsErrors(value any, opts options) []string {
+	if value == nil {
+		return nil
+	}
+
+	projects, ok := value.([]any)
+	if !ok {
+		return []string{"projects: must be a list"}
+	}
+
+	var problems []string
+	for index, project := range projects {
+		problems = append(problems, projectErrors(project, index, opts)...)
+	}
+	problems = append(problems, duplicateProjectIDErrors(projects)...)
+	return problems
+}
+
+func projectErrors(value any, index int, opts options) []string {
+	project, ok := value.(map[string]any)
+	prefix := fmt.Sprintf("projects[%d]", index)
+	if !ok {
+		return []string{prefix + ": must be a mapping"}
+	}
+
+	var problems []string
+	problems = append(problems, prefixErrors(requiredErrors(project, []string{"id", "workflow", "workdir", "weight", "priority"}), prefix)...)
+	problems = append(problems, stringErrors(project, "id", prefix)...)
+	problems = append(problems, pathErrors(project, "workflow", prefix, opts, wantFile)...)
+	problems = append(problems, pathErrors(project, "workdir", prefix, opts, wantDirectory)...)
+	problems = append(problems, positiveIntegerError(project["weight"], prefix+".weight")...)
+	problems = append(problems, integerError(project["priority"], prefix+".priority")...)
+	problems = append(problems, pausedErrors(project, prefix)...)
+	problems = append(problems, credentialRefErrors(project, prefix)...)
+
+	return problems
+}
+
+func prefixErrors(errors []string, prefix string) []string {
+	out := make([]string, 0, len(errors))
+	for _, err := range errors {
+		out = append(out, prefix+"."+err)
+	}
+	return out
+}
+
+func stringErrors(attrs map[string]any, field string, prefix string) []string {
+	value, ok := attrs[field]
+	if !ok || value == nil {
+		return nil
+	}
+
+	text, ok := value.(string)
+	if !ok {
+		return []string{prefix + "." + field + ": must be a string"}
+	}
+	if strings.TrimSpace(text) == "" {
+		return []string{prefix + "." + field + ": must not be blank"}
+	}
+	return nil
+}
+
+type pathExpectation int
+
+const (
+	wantFile pathExpectation = iota
+	wantDirectory
+)
+
+func pathErrors(attrs map[string]any, field string, prefix string, opts options, expected pathExpectation) []string {
+	value, ok := attrs[field]
+	if !ok || value == nil {
+		return nil
+	}
+
+	text, ok := value.(string)
+	if !ok {
+		return []string{prefix + "." + field + ": must be a string"}
+	}
+	return projectPathErrors(text, prefix+"."+field, opts, expected)
+}
+
+func projectPathErrors(path string, field string, opts options, expected pathExpectation) []string {
+	if strings.TrimSpace(path) == "" {
+		return []string{field + ": must not be blank"}
+	}
+
+	expanded, err := expandPath(path, opts)
+	if err != nil {
+		return []string{field + ": path does not exist"}
+	}
+
+	info, err := os.Stat(expanded)
+	if err != nil {
+		return []string{field + ": path does not exist"}
+	}
+	if expected == wantFile && !info.Mode().IsRegular() {
+		return []string{field + ": path does not exist"}
+	}
+	if expected == wantDirectory && !info.IsDir() {
+		return []string{field + ": path does not exist"}
+	}
+	return nil
+}
+
+func positiveIntegerError(value any, field string) []string {
+	if value == nil {
+		return nil
+	}
+	if positiveInteger(value) {
+		return nil
+	}
+	return []string{field + ": must be a positive integer"}
+}
+
+func integerError(value any, field string) []string {
+	if value == nil {
+		return nil
+	}
+	if _, ok := value.(int); ok {
+		return nil
+	}
+	return []string{field + ": must be an integer"}
+}
+
+func positiveInteger(value any) bool {
+	number, ok := value.(int)
+	return ok && number > 0
+}
+
+func nonNegativeInteger(value any) bool {
+	number, ok := value.(int)
+	return ok && number >= 0
+}
+
+func pausedErrors(attrs map[string]any, prefix string) []string {
+	value, ok := attrs["paused"]
+	if !ok {
+		return nil
+	}
+	if _, ok := value.(bool); ok {
+		return nil
+	}
+	return []string{prefix + ".paused: must be a boolean"}
+}
+
+func credentialRefErrors(attrs map[string]any, prefix string) []string {
+	value, ok := attrs["credential_ref"]
+	if !ok || value == nil {
+		return nil
+	}
+
+	text, ok := value.(string)
+	if !ok {
+		return []string{prefix + ".credential_ref: must be a string"}
+	}
+	if strings.TrimSpace(text) == "" {
+		return []string{prefix + ".credential_ref: must not be blank"}
+	}
+	return nil
+}
+
+func duplicateProjectIDErrors(projects []any) []string {
+	counts := make(map[string]int)
+	for _, item := range projects {
+		project, ok := item.(map[string]any)
+		if !ok {
+			continue
+		}
+
+		id, ok := project["id"].(string)
+		if !ok {
+			continue
+		}
+
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		counts[id]++
+	}
+
+	var problems []string
+	for id, count := range counts {
+		if count > 1 {
+			problems = append(problems, "projects.id: duplicate id "+id)
+		}
+	}
+	return problems
+}
+
+func duplicateProjectIDErrorsFromProjects(projects []Project) []string {
+	counts := make(map[string]int)
+	for _, project := range projects {
+		id := strings.TrimSpace(project.ID)
+		if id == "" {
+			continue
+		}
+		counts[id]++
+	}
+
+	var problems []string
+	for id, count := range counts {
+		if count > 1 {
+			problems = append(problems, "projects.id: duplicate id "+id)
+		}
+	}
+	return problems
+}
+
+func build(attrs map[string]any, path string, opts options) Config {
+	global := mustMap(attrs["global"])
+	projects := mustList(attrs["projects"])
+
+	return Config{
+		Path:       path,
+		APIVersion: mustString(attrs["apiVersion"]),
+		Kind:       mustString(attrs["kind"]),
+		Global:     buildSettings(global),
+		Projects:   buildProjects(projects, opts),
+	}
+}
+
+func buildSettings(attrs map[string]any) Settings {
+	return Settings{
+		MaxConcurrentAgents: mustInt(attrs["max_concurrent_agents"]),
+		Scheduling:          mustString(attrs["scheduling"]),
+		FairShare:           optionalMap(attrs["fair_share"]),
+		Startup:             optionalMap(attrs["startup"]),
+	}
+}
+
+func buildProjects(projects []any, opts options) []Project {
+	out := make([]Project, 0, len(projects))
+	for _, item := range projects {
+		project := mustMap(item)
+		workflow, err := expandPath(mustString(project["workflow"]), opts)
+		if err != nil {
+			panic("validated global config workflow path did not expand")
+		}
+		workdir, err := expandPath(mustString(project["workdir"]), opts)
+		if err != nil {
+			panic("validated global config workdir path did not expand")
+		}
+
+		out = append(out, Project{
+			ID:            strings.TrimSpace(mustString(project["id"])),
+			Workflow:      workflow,
+			Workdir:       workdir,
+			Weight:        mustInt(project["weight"]),
+			Priority:      mustInt(project["priority"]),
+			Paused:        optionalBool(project["paused"]),
+			CredentialRef: optionalString(project["credential_ref"]),
+		})
+	}
+	return out
+}
+
+func optionalMap(value any) map[string]any {
+	if value == nil {
+		return map[string]any{}
+	}
+
+	source := mustMap(value)
+	out := make(map[string]any, len(source))
+	for key, nestedValue := range source {
+		out[key] = nestedValue
+	}
+	return out
+}
+
+func optionalBool(value any) bool {
+	if value == nil {
+		return false
+	}
+	paused, ok := value.(bool)
+	if !ok {
+		panic("validated global config paused value was not a boolean")
+	}
+	return paused
+}
+
+func optionalString(value any) string {
+	if value == nil {
+		return ""
+	}
+	return strings.TrimSpace(mustString(value))
+}
+
+func mustMap(value any) map[string]any {
+	typed, ok := value.(map[string]any)
+	if !ok {
+		panic("validated global config value was not a mapping")
+	}
+	return typed
+}
+
+func mustList(value any) []any {
+	typed, ok := value.([]any)
+	if !ok {
+		panic("validated global config value was not a list")
+	}
+	return typed
+}
+
+func mustString(value any) string {
+	typed, ok := value.(string)
+	if !ok {
+		panic("validated global config value was not a string")
+	}
+	return typed
+}
+
+func mustInt(value any) int {
+	typed, ok := value.(int)
+	if !ok {
+		panic("validated global config value was not an integer")
+	}
+	return typed
+}
+
+func expandPath(path string, opts options) (string, error) {
+	switch {
+	case path == "~" || path == "~/":
+		if opts.home == "" {
+			return "", errors.New("home directory is not available")
+		}
+		return filepath.Clean(opts.home), nil
+	case strings.HasPrefix(path, "~/"):
+		if opts.home == "" {
+			return "", errors.New("home directory is not available")
+		}
+		return filepath.Join(opts.home, strings.TrimPrefix(path, "~/")), nil
+	case filepath.IsAbs(path):
+		return filepath.Clean(path), nil
+	default:
+		return filepath.Abs(filepath.Join(opts.relativeTo, path))
+	}
+}
+
+func normalizeYAML(value any) any {
+	switch typed := value.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(typed))
+		for key, nestedValue := range typed {
+			out[key] = normalizeYAML(nestedValue)
+		}
+		return out
+	case map[any]any:
+		out := make(map[string]any, len(typed))
+		for key, nestedValue := range typed {
+			out[fmt.Sprint(key)] = normalizeYAML(nestedValue)
+		}
+		return out
+	case []any:
+		out := make([]any, 0, len(typed))
+		for _, nestedValue := range typed {
+			out = append(out, normalizeYAML(nestedValue))
+		}
+		return out
+	default:
+		return value
+	}
+}

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -3,6 +3,7 @@ package global
 import (
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 )
@@ -159,6 +160,63 @@ func TestReadValidConfig(t *testing.T) {
 	}
 	if project.CredentialRef != "github-default" {
 		t.Fatalf("Project.CredentialRef = %q, want github-default", project.CredentialRef)
+	}
+}
+
+func TestReadPreservesGlobalDefaultsForOptionalSections(t *testing.T) {
+	paths := createProjectFiles(t)
+
+	tests := []struct {
+		name          string
+		global        string
+		wantFairShare map[string]any
+		wantStartup   map[string]any
+	}{
+		{
+			name: "omitted sections",
+			global: `  max_concurrent_agents: 8
+  scheduling: weighted
+`,
+			wantFairShare: map[string]any{
+				"half_life": "1h",
+			},
+			wantStartup: map[string]any{
+				"jitter_seconds":       10,
+				"max_spawn_per_second": 2,
+			},
+		},
+		{
+			name: "partial sections",
+			global: `  max_concurrent_agents: 8
+  scheduling: weighted
+  fair_share: {ratio: 1.5}
+  startup:
+    max_spawn_per_second: 4
+`,
+			wantFairShare: map[string]any{
+				"half_life": "1h",
+				"ratio":     1.5,
+			},
+			wantStartup: map[string]any{
+				"jitter_seconds":       10,
+				"max_spawn_per_second": 4,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(paths.root, strings.ReplaceAll(tt.name, " ", "-")+".yaml")
+			writeFile(t, configPath, minimalYAML(paths, tt.global))
+
+			cfg, err := Read(configPath, WithHome(paths.home))
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+
+			assertMap(t, "Global.FairShare", cfg.Global.FairShare, tt.wantFairShare)
+			assertMap(t, "Global.Startup", cfg.Global.Startup, tt.wantStartup)
+		})
 	}
 }
 
@@ -362,6 +420,27 @@ func writeFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
+}
+
+func assertMap(t *testing.T, name string, got map[string]any, want map[string]any) {
+	t.Helper()
+
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("%s = %#v, want %#v", name, got, want)
+	}
+}
+
+func minimalYAML(paths projectPaths, global string) string {
+	return `apiVersion: symphony/v1
+kind: GlobalConfig
+global:
+` + global + `projects:
+  - id: symphony
+    workflow: ` + paths.workflow + `
+    workdir: ` + paths.workdir + `
+    weight: 5
+    priority: 50
+`
 }
 
 func validYAML(paths projectPaths, overrides map[string]string) string {

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -1,0 +1,392 @@
+package global
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultPath(t *testing.T) {
+	t.Setenv("SYMPHONY_HOME", "")
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("UserHomeDir() error = %v", err)
+	}
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath() error = %v", err)
+	}
+
+	want := filepath.Join(home, ".symphony", "global.yaml")
+	if got != want {
+		t.Fatalf("DefaultPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultPathHonorsSymphonyHome(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("SYMPHONY_HOME", home)
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath() error = %v", err)
+	}
+
+	want := filepath.Join(home, "global.yaml")
+	if got != want {
+		t.Fatalf("DefaultPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	t.Setenv("SYMPHONY_HOME", "")
+
+	cfg, err := Default()
+	if err != nil {
+		t.Fatalf("Default() error = %v", err)
+	}
+
+	if cfg.APIVersion != APIVersion {
+		t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersion)
+	}
+	if cfg.Kind != Kind {
+		t.Fatalf("Kind = %q, want %q", cfg.Kind, Kind)
+	}
+	if cfg.Global.MaxConcurrentAgents != 8 {
+		t.Fatalf("Global.MaxConcurrentAgents = %d, want 8", cfg.Global.MaxConcurrentAgents)
+	}
+	if cfg.Global.Scheduling != SchedulingWeighted {
+		t.Fatalf("Global.Scheduling = %q, want %q", cfg.Global.Scheduling, SchedulingWeighted)
+	}
+	if got := cfg.Global.FairShare["half_life"]; got != "1h" {
+		t.Fatalf("Global.FairShare[half_life] = %v, want 1h", got)
+	}
+	if got := cfg.Global.Startup["jitter_seconds"]; got != 10 {
+		t.Fatalf("Global.Startup[jitter_seconds] = %v, want 10", got)
+	}
+	if got := cfg.Global.Startup["max_spawn_per_second"]; got != 2 {
+		t.Fatalf("Global.Startup[max_spawn_per_second] = %v, want 2", got)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("Projects = %#v, want empty", cfg.Projects)
+	}
+}
+
+func TestReadOrDefaultUsesDefaultForMissingFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "missing", "global.yaml")
+
+	cfg, err := ReadOrDefault(path)
+	if err != nil {
+		t.Fatalf("ReadOrDefault() error = %v", err)
+	}
+
+	if cfg.Path != path {
+		t.Fatalf("Path = %q, want %q", cfg.Path, path)
+	}
+	if cfg.APIVersion != APIVersion {
+		t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersion)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("Projects = %#v, want empty", cfg.Projects)
+	}
+}
+
+func TestReadValidConfig(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+
+	writeFile(t, configPath, validYAML(paths, nil))
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if cfg.Path != configPath {
+		t.Fatalf("Path = %q, want %q", cfg.Path, configPath)
+	}
+	if cfg.APIVersion != APIVersion {
+		t.Fatalf("APIVersion = %q, want %q", cfg.APIVersion, APIVersion)
+	}
+	if cfg.Kind != Kind {
+		t.Fatalf("Kind = %q, want %q", cfg.Kind, Kind)
+	}
+	if cfg.Global.MaxConcurrentAgents != 8 {
+		t.Fatalf("Global.MaxConcurrentAgents = %d, want 8", cfg.Global.MaxConcurrentAgents)
+	}
+	if cfg.Global.Scheduling != SchedulingWeighted {
+		t.Fatalf("Global.Scheduling = %q, want %q", cfg.Global.Scheduling, SchedulingWeighted)
+	}
+	if got := cfg.Global.FairShare["ratio"]; got != 1.5 {
+		t.Fatalf("Global.FairShare[ratio] = %v, want 1.5", got)
+	}
+	if got := cfg.Global.Startup["max_spawn_per_second"]; got != 2 {
+		t.Fatalf("Global.Startup[max_spawn_per_second] = %v, want 2", got)
+	}
+
+	tags, ok := cfg.Global.Startup["tags"].([]any)
+	if !ok {
+		t.Fatalf("Global.Startup[tags] = %#v, want []any", cfg.Global.Startup["tags"])
+	}
+	if len(tags) != 2 || tags[0] != "fast" || tags[1] != "slow" {
+		t.Fatalf("Global.Startup[tags] = %#v, want [fast slow]", tags)
+	}
+
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("Projects length = %d, want 1", len(cfg.Projects))
+	}
+	project := cfg.Projects[0]
+	if project.ID != "symphony" {
+		t.Fatalf("Project.ID = %q, want symphony", project.ID)
+	}
+	if project.Workflow != paths.workflowPath {
+		t.Fatalf("Project.Workflow = %q, want %q", project.Workflow, paths.workflowPath)
+	}
+	if project.Workdir != paths.workdirPath {
+		t.Fatalf("Project.Workdir = %q, want %q", project.Workdir, paths.workdirPath)
+	}
+	if project.Weight != 5 {
+		t.Fatalf("Project.Weight = %d, want 5", project.Weight)
+	}
+	if project.Priority != 50 {
+		t.Fatalf("Project.Priority = %d, want 50", project.Priority)
+	}
+	if project.Paused {
+		t.Fatal("Project.Paused = true, want false")
+	}
+	if project.CredentialRef != "github-default" {
+		t.Fatalf("Project.CredentialRef = %q, want github-default", project.CredentialRef)
+	}
+}
+
+func TestReadAcceptsSchedulingModes(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+
+	for _, mode := range []string{SchedulingWeighted, SchedulingStrict, SchedulingRoundRobin, SchedulingFairShare} {
+		t.Run(mode, func(t *testing.T) {
+			writeFile(t, configPath, validYAML(paths, map[string]string{"scheduling": mode}))
+
+			cfg, err := Read(configPath, WithHome(paths.home))
+			if err != nil {
+				t.Fatalf("Read() error = %v", err)
+			}
+			if cfg.Global.Scheduling != mode {
+				t.Fatalf("Global.Scheduling = %q, want %q", cfg.Global.Scheduling, mode)
+			}
+		})
+	}
+}
+
+func TestReadReportsInvalidConfig(t *testing.T) {
+	paths := createProjectFiles(t)
+
+	tests := []struct {
+		name string
+		raw  string
+		want []string
+	}{
+		{
+			name: "malformed yaml",
+			raw:  "apiVersion: [\n",
+			want: []string{"parse global config"},
+		},
+		{
+			name: "root document shape",
+			raw:  "- nope\n",
+			want: []string{"root: must be a mapping"},
+		},
+		{
+			name: "missing required fields",
+			raw:  "{}\n",
+			want: []string{
+				"apiVersion: is required",
+				"kind: is required",
+				"global: is required",
+				"projects: is required",
+			},
+		},
+		{
+			name: "invalid shapes",
+			raw: `apiVersion: symphony/v2
+kind: SomethingElse
+global:
+  max_concurrent_agents: 0
+  scheduling: random
+  fair_share: []
+  startup:
+    jitter_seconds: -1
+    max_spawn_per_second: 0
+projects:
+  - id: 123
+    workflow: 456
+    workdir: 789
+    weight: 0
+    priority: high
+    paused: maybe
+    credential_ref: []
+`,
+			want: []string{
+				"apiVersion: must equal symphony/v1",
+				"kind: must equal GlobalConfig",
+				"global.max_concurrent_agents: must be a positive integer",
+				"global.scheduling: must be one of weighted, strict, round_robin, fair_share",
+				"global.fair_share: must be a mapping",
+				"global.startup.jitter_seconds: must be an integer greater than or equal to 0",
+				"global.startup.max_spawn_per_second: must be a positive integer",
+				"projects[0].id: must be a string",
+				"projects[0].workflow: must be a string",
+				"projects[0].workdir: must be a string",
+				"projects[0].weight: must be a positive integer",
+				"projects[0].priority: must be an integer",
+				"projects[0].paused: must be a boolean",
+				"projects[0].credential_ref: must be a string",
+			},
+		},
+		{
+			name: "missing project fields",
+			raw: `apiVersion: symphony/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects:
+  - {}
+`,
+			want: []string{
+				"projects[0].id: is required",
+				"projects[0].workflow: is required",
+				"projects[0].workdir: is required",
+				"projects[0].weight: is required",
+				"projects[0].priority: is required",
+			},
+		},
+		{
+			name: "missing paths and duplicate project ids",
+			raw: `apiVersion: symphony/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects:
+  - id: " symphony "
+    workflow: ~/missing/WORKFLOW.md
+    workdir: ~/missing
+    weight: 5
+    priority: 50
+  - id: symphony
+    workflow: ~/missing/WORKFLOW.md
+    workdir: ~/missing
+    weight: 10
+    priority: 0
+`,
+			want: []string{
+				"projects[0].workflow: path does not exist",
+				"projects[0].workdir: path does not exist",
+				"projects.id: duplicate id symphony",
+			},
+		},
+		{
+			name: "containers must have expected shapes",
+			raw: `apiVersion: symphony/v1
+kind: GlobalConfig
+global: []
+projects: {}
+`,
+			want: []string{
+				"global: must be a mapping",
+				"projects: must be a list",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			configPath := filepath.Join(paths.root, strings.ReplaceAll(tt.name, " ", "-")+".yaml")
+			writeFile(t, configPath, tt.raw)
+
+			_, err := Read(configPath, WithHome(paths.home))
+			if err == nil {
+				t.Fatal("Read() error = nil, want error")
+			}
+			for _, want := range tt.want {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("Read() error = %q, want substring %q", err, want)
+				}
+			}
+		})
+	}
+}
+
+type projectPaths struct {
+	root         string
+	home         string
+	workflow     string
+	workdir      string
+	workflowPath string
+	workdirPath  string
+}
+
+func createProjectFiles(t *testing.T) projectPaths {
+	t.Helper()
+
+	root := t.TempDir()
+	home := filepath.Join(root, "home")
+	workdir := filepath.Join(home, "projects", "digitaldrywood", "symphony-orchestration")
+	workflow := filepath.Join(workdir, "WORKFLOW.md")
+
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeFile(t, workflow, "# workflow\n")
+
+	return projectPaths{
+		root:         root,
+		home:         home,
+		workflow:     "~/projects/digitaldrywood/symphony-orchestration/WORKFLOW.md",
+		workdir:      "~/projects/digitaldrywood/symphony-orchestration",
+		workflowPath: workflow,
+		workdirPath:  workdir,
+	}
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func validYAML(paths projectPaths, overrides map[string]string) string {
+	scheduling := SchedulingWeighted
+	if overrides != nil && overrides["scheduling"] != "" {
+		scheduling = overrides["scheduling"]
+	}
+
+	return `apiVersion: symphony/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: ` + scheduling + `
+  fair_share: {half_life: 1h, ratio: 1.5}
+  startup:
+    jitter_seconds: 10
+    limits: {burst: 2}
+    max_spawn_per_second: 2
+    tags: [fast, slow]
+projects:
+  - id: " symphony "
+    workflow: ` + paths.workflow + `
+    workdir: ` + paths.workdir + `
+    weight: 5
+    priority: 50
+    credential_ref: " github-default "
+`
+}


### PR DESCRIPTION
## Summary
- add `internal/config/global` for host-level `global.yaml` defaults, read/read-or-default, YAML parsing, and aggregate validation
- validate multi-project entries, scheduling modes, startup jitter and spawn rate, weights, priorities, paused flags, credential refs, duplicate IDs, and project paths
- cover valid manifests, defaults, scheduling modes, and malformed/invalid YAML with table-driven tests

Fixes #29

## Test Plan
- `go test ./internal/config/global`
- `go test ./...`
- `make check`
