### PR TITLE
feat(workspace): add git worktree backend

### DIFF
--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -32,6 +32,7 @@ type localTransport struct {
 	stdin     io.WriteCloser
 	codec     *Codec
 	received  chan transportResult
+	readDone  chan struct{}
 	done      chan struct{}
 	sendLock  chan struct{}
 	waitErr   error
@@ -82,6 +83,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		stdin:    stdin,
 		codec:    NewCodec(stdout, stdin),
 		received: make(chan transportResult, 64),
+		readDone: make(chan struct{}),
 		done:     make(chan struct{}),
 		sendLock: make(chan struct{}, 1),
 	}
@@ -207,6 +209,7 @@ func (t *localTransport) closedError() error {
 }
 
 func (t *localTransport) readLoop() {
+	defer close(t.readDone)
 	defer close(t.received)
 
 	for {
@@ -221,6 +224,7 @@ func (t *localTransport) readLoop() {
 }
 
 func (t *localTransport) wait() {
+	<-t.readDone
 	err := t.cmd.Wait()
 	t.waitMu.Lock()
 	t.waitErr = err

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -214,7 +214,7 @@ func (l *LocalGit) Cleanup(ctx context.Context, identifier string) error {
 		_, pruneErr := l.runGit(ctx, "worktree", "prune")
 		return pruneErr
 	}
-	if isDir {
+	if isDir && l.isSourceWorktree(ctx, info.Path) {
 		if err := l.runHook(ctx, "before_remove", l.hooks.BeforeRemove, info, Issue{Identifier: identifier}); err != nil {
 			l.logger.Warn("workspace before_remove hook failed", slog.String("path", info.Path), slog.Any("error", err))
 		}
@@ -428,7 +428,7 @@ func (l *LocalGit) runHook(ctx context.Context, name string, command string, inf
 	}
 	defer cancel()
 
-	cmd := exec.CommandContext(hookCtx, "sh", "-lc", command)
+	cmd := exec.CommandContext(hookCtx, "sh", "-c", command)
 	cmd.Dir = info.Path
 	cmd.Env = hookEnv(info, issue)
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,0 +1,623 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"time"
+)
+
+const KindLocalGit = "local_git"
+
+const defaultHookTimeout = time.Minute
+
+var (
+	ErrHookFailed         = errors.New("workspace hook failed")
+	ErrUnsafePath         = errors.New("unsafe workspace path")
+	ErrUnsupportedBackend = errors.New("unsupported workspace backend")
+)
+
+var unsafeKeyPattern = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+
+type Backend interface {
+	Create(context.Context, Issue) (Info, error)
+	Cleanup(context.Context, string) error
+	BeforeRun(context.Context, Info, Issue) error
+	AfterRun(context.Context, Info, Issue)
+}
+
+type Issue struct {
+	ID         string
+	Identifier string
+	BranchName string
+}
+
+type Info struct {
+	Path    string
+	Key     string
+	Branch  string
+	Created bool
+}
+
+type Hooks struct {
+	AfterCreate  string
+	BeforeRun    string
+	AfterRun     string
+	BeforeRemove string
+	Timeout      time.Duration
+}
+
+type LocalGitOptions struct {
+	Root       string
+	SourceRoot string
+	AutoBranch bool
+	Hooks      Hooks
+	Logger     *slog.Logger
+}
+
+type LocalGit struct {
+	root       string
+	sourceRoot string
+	autoBranch bool
+	hooks      Hooks
+	logger     *slog.Logger
+}
+
+type PathError struct {
+	Path   string
+	Root   string
+	Reason string
+}
+
+func (e *PathError) Error() string {
+	return fmt.Sprintf("%s: %s is not safe under %s: %s", ErrUnsafePath, e.Path, e.Root, e.Reason)
+}
+
+func (e *PathError) Unwrap() error {
+	return ErrUnsafePath
+}
+
+type HookError struct {
+	Hook     string
+	ExitCode int
+	Output   string
+	Err      error
+}
+
+func (e *HookError) Error() string {
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s: %v", ErrHookFailed, e.Hook, e.Err)
+	}
+	return fmt.Sprintf("%s: %s exited with status %d", ErrHookFailed, e.Hook, e.ExitCode)
+}
+
+func (e *HookError) Unwrap() error {
+	if e.Err != nil {
+		return e.Err
+	}
+	return ErrHookFailed
+}
+
+func (e *HookError) Is(target error) bool {
+	return target == ErrHookFailed
+}
+
+type CommandError struct {
+	Command  string
+	Args     []string
+	ExitCode int
+	Output   string
+	Err      error
+}
+
+func (e *CommandError) Error() string {
+	return fmt.Sprintf("%s %s failed: %v", e.Command, strings.Join(e.Args, " "), e.Err)
+}
+
+func (e *CommandError) Unwrap() error {
+	return e.Err
+}
+
+func NewBackend(kind string, opts LocalGitOptions) (Backend, error) {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case KindLocalGit:
+		return NewLocalGit(opts)
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, kind)
+	}
+}
+
+func NewLocalGit(opts LocalGitOptions) (*LocalGit, error) {
+	root, err := prepareRoot(opts.Root)
+	if err != nil {
+		return nil, err
+	}
+
+	sourceRoot, err := canonicalExistingPath(opts.SourceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("source root: %w", err)
+	}
+
+	hooks := opts.Hooks
+	if hooks.Timeout == 0 {
+		hooks.Timeout = defaultHookTimeout
+	}
+	if hooks.Timeout < 0 {
+		return nil, errors.New("hooks timeout must be greater than or equal to 0")
+	}
+
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	return &LocalGit{
+		root:       root,
+		sourceRoot: sourceRoot,
+		autoBranch: opts.AutoBranch,
+		hooks:      hooks,
+		logger:     logger,
+	}, nil
+}
+
+func SafeKey(identifier string) string {
+	key := unsafeKeyPattern.ReplaceAllString(strings.TrimSpace(identifier), "_")
+	if key == "" || key == "." || key == ".." {
+		return "issue"
+	}
+	return key
+}
+
+func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {
+	info, err := l.infoForIssue(issue)
+	if err != nil {
+		return Info{}, err
+	}
+
+	created, err := l.ensureWorktree(ctx, info.Path, info.Branch)
+	if err != nil {
+		return Info{}, err
+	}
+	info.Created = created
+
+	if created {
+		if err := l.runHook(ctx, "after_create", l.hooks.AfterCreate, info, issue); err != nil {
+			if cleanupErr := l.removePath(ctx, info.Path); cleanupErr != nil {
+				l.logger.Warn("failed to clean workspace after after_create hook error", slog.String("path", info.Path), slog.Any("error", cleanupErr))
+			}
+			return Info{}, err
+		}
+	}
+
+	return info, nil
+}
+
+func (l *LocalGit) Cleanup(ctx context.Context, identifier string) error {
+	info, err := l.infoForIssue(Issue{Identifier: identifier})
+	if err != nil {
+		return err
+	}
+
+	exists, isDir, err := pathExists(info.Path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		_, pruneErr := l.runGit(ctx, "worktree", "prune")
+		return pruneErr
+	}
+	if isDir {
+		if err := l.runHook(ctx, "before_remove", l.hooks.BeforeRemove, info, Issue{Identifier: identifier}); err != nil {
+			l.logger.Warn("workspace before_remove hook failed", slog.String("path", info.Path), slog.Any("error", err))
+		}
+	}
+
+	if err := l.removePath(ctx, info.Path); err != nil {
+		return err
+	}
+	_, err = l.runGit(ctx, "worktree", "prune")
+	return err
+}
+
+func (l *LocalGit) BeforeRun(ctx context.Context, info Info, issue Issue) error {
+	normalized, err := l.normalizeInfo(info, issue)
+	if err != nil {
+		return err
+	}
+	return l.runHook(ctx, "before_run", l.hooks.BeforeRun, normalized, issue)
+}
+
+func (l *LocalGit) AfterRun(ctx context.Context, info Info, issue Issue) {
+	normalized, err := l.normalizeInfo(info, issue)
+	if err != nil {
+		l.logger.Warn("workspace after_run path validation failed", slog.String("path", info.Path), slog.Any("error", err))
+		return
+	}
+	if err := l.runHook(ctx, "after_run", l.hooks.AfterRun, normalized, issue); err != nil {
+		l.logger.Warn("workspace after_run hook failed", slog.String("path", normalized.Path), slog.Any("error", err))
+	}
+}
+
+func (l *LocalGit) infoForIssue(issue Issue) (Info, error) {
+	key := SafeKey(issue.Identifier)
+	path, err := l.workspacePath(key)
+	if err != nil {
+		return Info{}, err
+	}
+
+	return Info{
+		Path:   path,
+		Key:    key,
+		Branch: l.branchName(issue, key),
+	}, nil
+}
+
+func (l *LocalGit) normalizeInfo(info Info, issue Issue) (Info, error) {
+	key := info.Key
+	if key == "" {
+		key = SafeKey(issue.Identifier)
+	}
+	path := info.Path
+	if path == "" {
+		var err error
+		path, err = l.workspacePath(key)
+		if err != nil {
+			return Info{}, err
+		}
+	} else {
+		var err error
+		path, err = validateWorkspacePath(l.root, path)
+		if err != nil {
+			return Info{}, err
+		}
+	}
+	branch := info.Branch
+	if branch == "" {
+		branch = l.branchName(issue, key)
+	}
+
+	info.Path = path
+	info.Key = key
+	info.Branch = branch
+	return info, nil
+}
+
+func (l *LocalGit) workspacePath(key string) (string, error) {
+	return validateWorkspacePath(l.root, filepath.Join(l.root, key))
+}
+
+func (l *LocalGit) branchName(issue Issue, key string) string {
+	if !l.autoBranch {
+		return ""
+	}
+	if strings.TrimSpace(issue.BranchName) != "" {
+		return strings.TrimSpace(issue.BranchName)
+	}
+	return "symphony/" + strings.ToLower(key)
+}
+
+func (l *LocalGit) ensureWorktree(ctx context.Context, path string, branch string) (bool, error) {
+	exists, isDir, err := pathExists(path)
+	if err != nil {
+		return false, err
+	}
+	if exists {
+		if isDir {
+			if l.isSourceWorktree(ctx, path) {
+				return false, nil
+			}
+			if l.isGitWorkspace(ctx, path) {
+				return false, fmt.Errorf("workspace path is a git worktree not managed by source: %s", path)
+			}
+			empty, err := dirIsEmpty(path)
+			if err != nil {
+				return false, err
+			}
+			if !empty {
+				return false, fmt.Errorf("workspace path exists but is not a git worktree: %s", path)
+			}
+		}
+		if err := os.RemoveAll(path); err != nil {
+			return false, fmt.Errorf("remove stale workspace path: %w", err)
+		}
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return false, fmt.Errorf("create workspace parent: %w", err)
+	}
+
+	if l.autoBranch {
+		if err := l.addBranchedWorktree(ctx, path, branch); err != nil {
+			return false, err
+		}
+		return true, nil
+	}
+
+	_, err = l.runGit(ctx, "worktree", "add", "--detach", path, "HEAD")
+	return err == nil, err
+}
+
+func (l *LocalGit) addBranchedWorktree(ctx context.Context, path string, branch string) error {
+	exists, err := l.branchExists(ctx, branch)
+	if err != nil {
+		return err
+	}
+	if exists {
+		_, err = l.runGit(ctx, "worktree", "add", path, branch)
+		return err
+	}
+
+	_, err = l.runGit(ctx, "worktree", "add", "-b", branch, path, "HEAD")
+	return err
+}
+
+func (l *LocalGit) branchExists(ctx context.Context, branch string) (bool, error) {
+	_, err := l.runGit(ctx, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	if err == nil {
+		return true, nil
+	}
+
+	var cmdErr *CommandError
+	if errors.As(err, &cmdErr) && cmdErr.ExitCode == 1 {
+		return false, nil
+	}
+	return false, err
+}
+
+func (l *LocalGit) isGitWorkspace(ctx context.Context, path string) bool {
+	output, err := runGitAt(ctx, path, "rev-parse", "--is-inside-work-tree")
+	return err == nil && strings.TrimSpace(output) == "true"
+}
+
+func (l *LocalGit) isSourceWorktree(ctx context.Context, path string) bool {
+	workspaceCommon, err := gitCommonDir(ctx, path)
+	if err != nil {
+		return false
+	}
+	sourceCommon, err := gitCommonDir(ctx, l.sourceRoot)
+	if err != nil {
+		return false
+	}
+	return workspaceCommon == sourceCommon
+}
+
+func (l *LocalGit) removePath(ctx context.Context, path string) error {
+	exists, _, err := pathExists(path)
+	if err != nil {
+		return err
+	}
+	if !exists {
+		return nil
+	}
+
+	if _, err := l.runGit(ctx, "worktree", "remove", "--force", path); err != nil {
+		if l.isSourceWorktree(ctx, path) {
+			return err
+		}
+		if l.isGitWorkspace(ctx, path) {
+			return fmt.Errorf("refusing to remove git workspace not managed by source: %s", path)
+		}
+		if err := os.RemoveAll(path); err != nil {
+			return fmt.Errorf("remove workspace path: %w", err)
+		}
+	}
+	return nil
+}
+
+func (l *LocalGit) runHook(ctx context.Context, name string, command string, info Info, issue Issue) error {
+	if strings.TrimSpace(command) == "" {
+		return nil
+	}
+
+	timeout := l.hooks.Timeout
+	if timeout == 0 {
+		timeout = defaultHookTimeout
+	}
+
+	hookCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		hookCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	cmd := exec.CommandContext(hookCtx, "sh", "-lc", command)
+	cmd.Dir = info.Path
+	cmd.Env = hookEnv(info, issue)
+
+	l.logger.Info("running workspace hook", slog.String("hook", name), slog.String("path", info.Path))
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+
+	exitCode := -1
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+	if hookCtx.Err() != nil {
+		err = hookCtx.Err()
+	}
+
+	return &HookError{
+		Hook:     name,
+		ExitCode: exitCode,
+		Output:   string(output),
+		Err:      err,
+	}
+}
+
+func (l *LocalGit) runGit(ctx context.Context, args ...string) (string, error) {
+	return runGitAt(ctx, l.sourceRoot, args...)
+}
+
+func runGitAt(ctx context.Context, dir string, args ...string) (string, error) {
+	gitArgs := append([]string{"git", "-C", dir}, args...)
+	cmd := exec.CommandContext(ctx, "git")
+	cmd.Args = gitArgs
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return string(output), nil
+	}
+
+	exitCode := -1
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+	if ctx.Err() != nil {
+		err = ctx.Err()
+	}
+
+	return "", &CommandError{
+		Command:  "git",
+		Args:     gitArgs[1:],
+		ExitCode: exitCode,
+		Output:   string(output),
+		Err:      err,
+	}
+}
+
+func gitCommonDir(ctx context.Context, dir string) (string, error) {
+	output, err := runGitAt(ctx, dir, "rev-parse", "--git-common-dir")
+	if err != nil {
+		return "", err
+	}
+	commonDir := strings.TrimSpace(output)
+	if commonDir == "" {
+		return "", errors.New("git common dir is empty")
+	}
+	if !filepath.IsAbs(commonDir) {
+		commonDir = filepath.Join(dir, commonDir)
+	}
+	return canonicalExistingPath(commonDir)
+}
+
+func hookEnv(info Info, issue Issue) []string {
+	env := append([]string{}, os.Environ()...)
+	values := map[string]string{
+		"SYMPHONY_WORKSPACE":        info.Path,
+		"SYMPHONY_WORKSPACE_KEY":    info.Key,
+		"SYMPHONY_BRANCH":           info.Branch,
+		"SYMPHONY_ISSUE_ID":         issue.ID,
+		"SYMPHONY_ISSUE_IDENTIFIER": issue.Identifier,
+	}
+	for key, value := range values {
+		env = append(env, key+"="+value)
+	}
+	return env
+}
+
+func prepareRoot(path string) (string, error) {
+	expanded, err := expandPath(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(expanded) == "" {
+		return "", errors.New("workspace root is required")
+	}
+	if err := os.MkdirAll(expanded, 0o700); err != nil {
+		return "", fmt.Errorf("create workspace root: %w", err)
+	}
+	return canonicalExistingPath(expanded)
+}
+
+func canonicalExistingPath(path string) (string, error) {
+	expanded, err := expandPath(path)
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(expanded) == "" {
+		return "", errors.New("path is required")
+	}
+	abs, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", fmt.Errorf("absolute path: %w", err)
+	}
+	canonical, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		return "", fmt.Errorf("canonicalize %s: %w", abs, err)
+	}
+	return filepath.Clean(canonical), nil
+}
+
+func expandPath(path string) (string, error) {
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	return path, nil
+}
+
+func validateWorkspacePath(root string, path string) (string, error) {
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("absolute workspace path: %w", err)
+	}
+	clean := filepath.Clean(abs)
+
+	if info, err := os.Lstat(clean); err == nil {
+		if info.Mode()&os.ModeSymlink != 0 {
+			return "", &PathError{Path: clean, Root: root, Reason: "workspace path is a symlink"}
+		}
+		canonical, err := filepath.EvalSymlinks(clean)
+		if err != nil {
+			return "", fmt.Errorf("canonicalize workspace path: %w", err)
+		}
+		clean = filepath.Clean(canonical)
+	} else if !errors.Is(err, fs.ErrNotExist) {
+		return "", fmt.Errorf("inspect workspace path: %w", err)
+	}
+
+	if clean == root {
+		return "", &PathError{Path: clean, Root: root, Reason: "workspace path equals root"}
+	}
+
+	rel, err := filepath.Rel(root, clean)
+	if err != nil {
+		return "", fmt.Errorf("relative workspace path: %w", err)
+	}
+	if rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || filepath.IsAbs(rel) {
+		return "", &PathError{Path: clean, Root: root, Reason: "workspace path escapes root"}
+	}
+
+	return clean, nil
+}
+
+func pathExists(path string) (bool, bool, error) {
+	info, err := os.Lstat(path)
+	if err == nil {
+		return true, info.IsDir(), nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, false, nil
+	}
+	return false, false, fmt.Errorf("inspect path: %w", err)
+}
+
+func dirIsEmpty(path string) (bool, error) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return false, fmt.Errorf("read workspace directory: %w", err)
+	}
+	return len(entries) == 0, nil
+}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -77,6 +77,47 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 	}
 }
 
+func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "after-create.trace")
+	argsPath := filepath.Join(t.TempDir(), "shell-args.trace")
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	shellPath := filepath.Join(binDir, "sh")
+	shellScript := "#!/bin/sh\nprintf '%s\\n' \"$1\" > " + shellQuote(argsPath) + "\nexec /bin/sh \"$@\"\n"
+	if err := os.WriteFile(shellPath, []byte(shellScript), 0o700); err != nil {
+		t.Fatalf("write shell wrapper: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			AfterCreate: "printf 'ok\n' > " + shellQuote(tracePath),
+			Timeout:     time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	if _, err := backend.Create(context.Background(), Issue{Identifier: "DD-SHELL"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if got := readFile(t, argsPath); got != "-c\n" {
+		t.Fatalf("hook shell first arg = %q, want -c", got)
+	}
+	if got := readFile(t, tracePath); got != "ok\n" {
+		t.Fatalf("hook trace = %q, want ok", got)
+	}
+}
+
 func TestLocalGitCreateReusesExistingWorktreeWithoutAfterCreate(t *testing.T) {
 	t.Parallel()
 
@@ -245,6 +286,46 @@ func TestLocalGitCleanupRemovesOnlyTargetWorktree(t *testing.T) {
 	}
 	if got := runGit(t, source, "worktree", "list", "--porcelain"); strings.Contains(got, target.Path) {
 		t.Fatalf("git worktree list still contains removed path:\n%s", got)
+	}
+}
+
+func TestLocalGitCleanupRejectsForeignGitRepoWithoutBeforeRemove(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	foreign := filepath.Join(root, "DD-FOREIGN")
+	tracePath := filepath.Join(t.TempDir(), "cleanup.trace")
+	if err := os.MkdirAll(foreign, 0o700); err != nil {
+		t.Fatalf("mkdir foreign repo: %v", err)
+	}
+	runCommand(t, foreign, "git", "init", "-b", "main")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			BeforeRemove: "printf 'ran\n' > " + shellQuote(tracePath),
+			Timeout:      time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	err = backend.Cleanup(context.Background(), "DD-FOREIGN")
+	if err == nil {
+		t.Fatal("Cleanup() error = nil, want foreign repo error")
+	}
+	if !strings.Contains(err.Error(), "not managed by source") {
+		t.Fatalf("Cleanup() error = %v, want not managed by source", err)
+	}
+	if _, err := os.Stat(tracePath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("before_remove hook ran, stat error = %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(foreign, ".git")); err != nil {
+		t.Fatalf("foreign repo was removed, stat error = %v", err)
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1,0 +1,363 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "after-create.trace")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			AfterCreate: "printf '%s|%s|%s|%s|%s\n' \"$PWD\" \"$(git branch --show-current)\" \"$SYMPHONY_ISSUE_IDENTIFIER\" \"$SYMPHONY_WORKSPACE_KEY\" \"$SYMPHONY_BRANCH\" >> " + shellQuote(tracePath),
+			Timeout:     time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), Issue{ID: "issue-node", Identifier: "DD/19"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if !info.Created {
+		t.Fatal("Create() Created = false, want true")
+	}
+	if info.Key != "DD_19" {
+		t.Fatalf("Create() Key = %q, want DD_19", info.Key)
+	}
+	if filepath.Base(info.Path) != "DD_19" {
+		t.Fatalf("Create() Path = %q, want basename DD_19", info.Path)
+	}
+	if info.Branch != "symphony/dd_19" {
+		t.Fatalf("Create() Branch = %q, want symphony/dd_19", info.Branch)
+	}
+	if got := strings.TrimSpace(runGit(t, info.Path, "branch", "--show-current")); got != "symphony/dd_19" {
+		t.Fatalf("worktree branch = %q, want symphony/dd_19", got)
+	}
+	if got := readFile(t, filepath.Join(info.Path, "README.md")); got != "source repo\n" {
+		t.Fatalf("README.md = %q, want source repo", got)
+	}
+
+	trace := strings.TrimSpace(readFile(t, tracePath))
+	fields := strings.Split(trace, "|")
+	if len(fields) != 5 {
+		t.Fatalf("after_create trace = %q, want five fields", trace)
+	}
+	if fields[0] != info.Path {
+		t.Fatalf("after_create cwd = %q, want %q", fields[0], info.Path)
+	}
+	if fields[1] != "symphony/dd_19" {
+		t.Fatalf("after_create branch = %q, want symphony/dd_19", fields[1])
+	}
+	if fields[2] != "DD/19" {
+		t.Fatalf("SYMPHONY_ISSUE_IDENTIFIER = %q, want DD/19", fields[2])
+	}
+	if fields[3] != "DD_19" {
+		t.Fatalf("SYMPHONY_WORKSPACE_KEY = %q, want DD_19", fields[3])
+	}
+	if fields[4] != "symphony/dd_19" {
+		t.Fatalf("SYMPHONY_BRANCH = %q, want symphony/dd_19", fields[4])
+	}
+}
+
+func TestLocalGitCreateReusesExistingWorktreeWithoutAfterCreate(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "after-create.trace")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			AfterCreate: "printf 'after-create\n' >> " + shellQuote(tracePath),
+			Timeout:     time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	first, err := backend.Create(context.Background(), Issue{Identifier: "DD-REUSE"})
+	if err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(first.Path, "local-progress.txt"), []byte("keep\n"), 0o600); err != nil {
+		t.Fatalf("write local progress: %v", err)
+	}
+
+	second, err := backend.Create(context.Background(), Issue{Identifier: "DD-REUSE"})
+	if err != nil {
+		t.Fatalf("second Create() error = %v", err)
+	}
+
+	if second.Created {
+		t.Fatal("second Create() Created = true, want false")
+	}
+	if second.Path != first.Path {
+		t.Fatalf("second Create() Path = %q, want %q", second.Path, first.Path)
+	}
+	if got := readFile(t, filepath.Join(second.Path, "local-progress.txt")); got != "keep\n" {
+		t.Fatalf("local-progress.txt = %q, want keep", got)
+	}
+	if got := strings.Count(readFile(t, tracePath), "after-create"); got != 1 {
+		t.Fatalf("after_create runs = %d, want 1", got)
+	}
+}
+
+func TestLocalGitBeforeAndAfterRunHooks(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "run-hooks.trace")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			BeforeRun: "printf 'before:%s:%s\n' \"$PWD\" \"$SYMPHONY_WORKSPACE_KEY\" >> " + shellQuote(tracePath),
+			AfterRun:  "printf 'after:%s:%s\n' \"$PWD\" \"$SYMPHONY_WORKSPACE_KEY\" >> " + shellQuote(tracePath),
+			Timeout:   time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), Issue{Identifier: "DD-RUN"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := backend.BeforeRun(context.Background(), info, Issue{Identifier: "DD-RUN"}); err != nil {
+		t.Fatalf("BeforeRun() error = %v", err)
+	}
+	backend.AfterRun(context.Background(), info, Issue{Identifier: "DD-RUN"})
+
+	want := "before:" + info.Path + ":DD-RUN\nafter:" + info.Path + ":DD-RUN\n"
+	if got := readFile(t, tracePath); got != want {
+		t.Fatalf("hook trace = %q, want %q", got, want)
+	}
+}
+
+func TestLocalGitHookFailureSurfaces(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			AfterCreate: "echo nope && exit 17",
+			Timeout:     time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	_, err = backend.Create(context.Background(), Issue{Identifier: "DD-FAIL"})
+	if err == nil {
+		t.Fatal("Create() error = nil, want hook error")
+	}
+	var hookErr *HookError
+	if !errors.As(err, &hookErr) {
+		t.Fatalf("Create() error = %T, want *HookError", err)
+	}
+	if hookErr.Hook != "after_create" {
+		t.Fatalf("HookError.Hook = %q, want after_create", hookErr.Hook)
+	}
+	if hookErr.ExitCode != 17 {
+		t.Fatalf("HookError.ExitCode = %d, want 17", hookErr.ExitCode)
+	}
+	if !strings.Contains(hookErr.Output, "nope") {
+		t.Fatalf("HookError.Output = %q, want nope", hookErr.Output)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "DD-FAIL")); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("failed after_create workspace exists, stat error = %v", statErr)
+	}
+}
+
+func TestLocalGitCleanupRemovesOnlyTargetWorktree(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "cleanup.trace")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			BeforeRemove: "printf '%s\n' \"$SYMPHONY_WORKSPACE_KEY\" >> " + shellQuote(tracePath),
+			Timeout:      time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	target, err := backend.Create(context.Background(), Issue{Identifier: "DD-CLEAN"})
+	if err != nil {
+		t.Fatalf("target Create() error = %v", err)
+	}
+	other, err := backend.Create(context.Background(), Issue{Identifier: "DD-KEEP"})
+	if err != nil {
+		t.Fatalf("other Create() error = %v", err)
+	}
+
+	if err := backend.Cleanup(context.Background(), "DD-CLEAN"); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+
+	if _, err := os.Stat(target.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target workspace exists after cleanup, stat error = %v", err)
+	}
+	if _, err := os.Stat(other.Path); err != nil {
+		t.Fatalf("other workspace stat error = %v", err)
+	}
+	if got := strings.TrimSpace(readFile(t, tracePath)); got != "DD-CLEAN" {
+		t.Fatalf("before_remove trace = %q, want DD-CLEAN", got)
+	}
+	if got := runGit(t, source, "worktree", "list", "--porcelain"); strings.Contains(got, target.Path) {
+		t.Fatalf("git worktree list still contains removed path:\n%s", got)
+	}
+}
+
+func TestLocalGitRejectsSymlinkEscape(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	testRoot := t.TempDir()
+	root := filepath.Join(testRoot, "workspaces")
+	outside := filepath.Join(testRoot, "outside")
+	if err := os.MkdirAll(root, 0o700); err != nil {
+		t.Fatalf("mkdir root: %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(root, "DD-SYM")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	_, err = backend.Create(context.Background(), Issue{Identifier: "DD-SYM"})
+	if !errors.Is(err, ErrUnsafePath) {
+		t.Fatalf("Create() error = %v, want ErrUnsafePath", err)
+	}
+	if _, err := os.Lstat(filepath.Join(root, "DD-SYM")); err != nil {
+		t.Fatalf("symlink stat error = %v", err)
+	}
+}
+
+func TestLocalGitRejectsExistingGitRepoFromDifferentSource(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	foreign := filepath.Join(root, "DD-FOREIGN")
+	if err := os.MkdirAll(foreign, 0o700); err != nil {
+		t.Fatalf("mkdir foreign repo: %v", err)
+	}
+	runCommand(t, foreign, "git", "init", "-b", "main")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	_, err = backend.Create(context.Background(), Issue{Identifier: "DD-FOREIGN"})
+	if err == nil {
+		t.Fatal("Create() error = nil, want foreign repo error")
+	}
+	if !strings.Contains(err.Error(), "not managed by source") {
+		t.Fatalf("Create() error = %v, want not managed by source", err)
+	}
+	if _, err := os.Stat(filepath.Join(foreign, ".git")); err != nil {
+		t.Fatalf("foreign repo was removed, stat error = %v", err)
+	}
+}
+
+func initSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runCommand(t, dir, "git", "init", "-b", "main")
+	runGit(t, dir, "config", "user.name", "Test User")
+	runGit(t, dir, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("source repo\n"), 0o600); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runGit(t, dir, "add", "README.md")
+	runGit(t, dir, "commit", "-m", "initial")
+
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	return runCommand(t, dir, "git", args...)
+}
+
+func runCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func readFile(t *testing.T, path string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}


### PR DESCRIPTION
## Summary
- add an internal workspace backend interface and local Git worktree factory
- create deterministic safe worktree paths with symphony/<id> fallback branches
- run after_create, before_run, after_run, and before_remove hooks with workspace-scoped env
- clean up owned worktrees while rejecting symlink escapes and foreign Git repos

Fixes #19

## Test Plan
- go test ./internal/workspace
- make check