### PR TITLE
feat(store): add stats store

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -17,6 +17,18 @@ SELECT *
 FROM symphony_runs
 WHERE id = ?;
 
+-- name: UpdateSymphonyRun :execrows
+UPDATE symphony_runs
+SET stopped_at = COALESCE(?, stopped_at),
+    restart_reason = COALESCE(?, restart_reason),
+    peak_concurrent_agents = ?,
+    sessions_launched = ?,
+    input_tokens = ?,
+    output_tokens = ?,
+    total_tokens = ?,
+    runtime_seconds = ?
+WHERE id = ?;
+
 -- name: CreateCodexSession :one
 INSERT INTO codex_sessions (
   run_id,
@@ -40,8 +52,32 @@ SELECT *
 FROM codex_sessions
 WHERE id = ?;
 
+-- name: FinishCodexSession :execrows
+UPDATE codex_sessions
+SET completed_at = ?,
+    turns = ?,
+    input_tokens = ?,
+    output_tokens = ?,
+    total_tokens = ?,
+    runtime_seconds = ?,
+    final_state = ?,
+    model = ?
+WHERE id = ?;
+
 -- name: ListRecentCodexSessions :many
 SELECT *
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?;
+
+-- name: DailyTokenSpend :many
+SELECT
+  CAST(COALESCE(model, '') AS TEXT) AS model,
+  CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COUNT(*) AS INTEGER) AS sessions
+FROM codex_sessions
+WHERE substr(completed_at, 1, 10) = ?
+GROUP BY COALESCE(model, '')
+ORDER BY COALESCE(model, '');

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -61,7 +61,7 @@ SET completed_at = ?,
     total_tokens = ?,
     runtime_seconds = ?,
     final_state = ?,
-    model = ?
+    model = COALESCE(?, model)
 WHERE id = ?;
 
 -- name: ListRecentCodexSessions :many

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -136,6 +136,99 @@ func (q *Queries) CreateSymphonyRun(ctx context.Context, arg CreateSymphonyRunPa
 	return i, err
 }
 
+const dailyTokenSpend = `-- name: DailyTokenSpend :many
+SELECT
+  CAST(COALESCE(model, '') AS TEXT) AS model,
+  CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COUNT(*) AS INTEGER) AS sessions
+FROM codex_sessions
+WHERE substr(completed_at, 1, 10) = ?
+GROUP BY COALESCE(model, '')
+ORDER BY COALESCE(model, '')
+`
+
+type DailyTokenSpendRow struct {
+	Model        string `json:"model"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	TotalTokens  int64  `json:"total_tokens"`
+	Sessions     int64  `json:"sessions"`
+}
+
+func (q *Queries) DailyTokenSpend(ctx context.Context, completedAt sql.NullString) ([]DailyTokenSpendRow, error) {
+	rows, err := q.db.QueryContext(ctx, dailyTokenSpend, completedAt)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []DailyTokenSpendRow{}
+	for rows.Next() {
+		var i DailyTokenSpendRow
+		if err := rows.Scan(
+			&i.Model,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.TotalTokens,
+			&i.Sessions,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const finishCodexSession = `-- name: FinishCodexSession :execrows
+UPDATE codex_sessions
+SET completed_at = ?,
+    turns = ?,
+    input_tokens = ?,
+    output_tokens = ?,
+    total_tokens = ?,
+    runtime_seconds = ?,
+    final_state = ?,
+    model = ?
+WHERE id = ?
+`
+
+type FinishCodexSessionParams struct {
+	CompletedAt    sql.NullString `json:"completed_at"`
+	Turns          int64          `json:"turns"`
+	InputTokens    int64          `json:"input_tokens"`
+	OutputTokens   int64          `json:"output_tokens"`
+	TotalTokens    int64          `json:"total_tokens"`
+	RuntimeSeconds int64          `json:"runtime_seconds"`
+	FinalState     sql.NullString `json:"final_state"`
+	Model          sql.NullString `json:"model"`
+	ID             int64          `json:"id"`
+}
+
+func (q *Queries) FinishCodexSession(ctx context.Context, arg FinishCodexSessionParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, finishCodexSession,
+		arg.CompletedAt,
+		arg.Turns,
+		arg.InputTokens,
+		arg.OutputTokens,
+		arg.TotalTokens,
+		arg.RuntimeSeconds,
+		arg.FinalState,
+		arg.Model,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const getCodexSession = `-- name: GetCodexSession :one
 SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model
 FROM codex_sessions
@@ -231,4 +324,47 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 		return nil, err
 	}
 	return items, nil
+}
+
+const updateSymphonyRun = `-- name: UpdateSymphonyRun :execrows
+UPDATE symphony_runs
+SET stopped_at = COALESCE(?, stopped_at),
+    restart_reason = COALESCE(?, restart_reason),
+    peak_concurrent_agents = ?,
+    sessions_launched = ?,
+    input_tokens = ?,
+    output_tokens = ?,
+    total_tokens = ?,
+    runtime_seconds = ?
+WHERE id = ?
+`
+
+type UpdateSymphonyRunParams struct {
+	StoppedAt            sql.NullString `json:"stopped_at"`
+	RestartReason        sql.NullString `json:"restart_reason"`
+	PeakConcurrentAgents int64          `json:"peak_concurrent_agents"`
+	SessionsLaunched     int64          `json:"sessions_launched"`
+	InputTokens          int64          `json:"input_tokens"`
+	OutputTokens         int64          `json:"output_tokens"`
+	TotalTokens          int64          `json:"total_tokens"`
+	RuntimeSeconds       int64          `json:"runtime_seconds"`
+	ID                   int64          `json:"id"`
+}
+
+func (q *Queries) UpdateSymphonyRun(ctx context.Context, arg UpdateSymphonyRunParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, updateSymphonyRun,
+		arg.StoppedAt,
+		arg.RestartReason,
+		arg.PeakConcurrentAgents,
+		arg.SessionsLaunched,
+		arg.InputTokens,
+		arg.OutputTokens,
+		arg.TotalTokens,
+		arg.RuntimeSeconds,
+		arg.ID,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
 }

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -195,7 +195,7 @@ SET completed_at = ?,
     total_tokens = ?,
     runtime_seconds = ?,
     final_state = ?,
-    model = ?
+    model = COALESCE(?, model)
 WHERE id = ?
 `
 

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
+	"time"
 
 	_ "modernc.org/sqlite"
 
@@ -55,6 +57,147 @@ func (s *sqliteStore) Close() error {
 	return s.db.Close()
 }
 
+func (s *sqliteStore) StartRun(ctx context.Context, attrs RunStart) (int64, error) {
+	startedAt, err := requiredTimestamp("started_at", attrs.StartedAt)
+	if err != nil {
+		return 0, err
+	}
+
+	run, err := s.queries.CreateSymphonyRun(ctx, sqlc.CreateSymphonyRunParams{
+		StartedAt:            startedAt,
+		StoppedAt:            sql.NullString{},
+		RestartReason:        sql.NullString{},
+		PeakConcurrentAgents: nonNegative(attrs.PeakConcurrentAgents),
+		SessionsLaunched:     nonNegative(attrs.SessionsLaunched),
+		InputTokens:          nonNegative(attrs.InputTokens),
+		OutputTokens:         nonNegative(attrs.OutputTokens),
+		TotalTokens:          nonNegative(attrs.TotalTokens),
+		RuntimeSeconds:       nonNegative(attrs.RuntimeSeconds),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("starting stats run: %w", err)
+	}
+	return run.ID, nil
+}
+
+func (s *sqliteStore) UpdateRun(ctx context.Context, runID int64, attrs RunUpdate) error {
+	rows, err := s.queries.UpdateSymphonyRun(ctx, sqlc.UpdateSymphonyRunParams{
+		StoppedAt:            sql.NullString{},
+		RestartReason:        sql.NullString{},
+		PeakConcurrentAgents: nonNegative(attrs.PeakConcurrentAgents),
+		SessionsLaunched:     nonNegative(attrs.SessionsLaunched),
+		InputTokens:          nonNegative(attrs.InputTokens),
+		OutputTokens:         nonNegative(attrs.OutputTokens),
+		TotalTokens:          nonNegative(attrs.TotalTokens),
+		RuntimeSeconds:       nonNegative(attrs.RuntimeSeconds),
+		ID:                   runID,
+	})
+	if err != nil {
+		return fmt.Errorf("updating stats run: %w", err)
+	}
+	return requireAffected(rows, "symphony run", runID)
+}
+
+func (s *sqliteStore) StopRun(ctx context.Context, runID int64, attrs RunStop) error {
+	stoppedAt, err := requiredTimestamp("stopped_at", attrs.StoppedAt)
+	if err != nil {
+		return err
+	}
+
+	rows, err := s.queries.UpdateSymphonyRun(ctx, sqlc.UpdateSymphonyRunParams{
+		StoppedAt:            sql.NullString{String: stoppedAt, Valid: true},
+		RestartReason:        nullString(attrs.RestartReason),
+		PeakConcurrentAgents: nonNegative(attrs.PeakConcurrentAgents),
+		SessionsLaunched:     nonNegative(attrs.SessionsLaunched),
+		InputTokens:          nonNegative(attrs.InputTokens),
+		OutputTokens:         nonNegative(attrs.OutputTokens),
+		TotalTokens:          nonNegative(attrs.TotalTokens),
+		RuntimeSeconds:       nonNegative(attrs.RuntimeSeconds),
+		ID:                   runID,
+	})
+	if err != nil {
+		return fmt.Errorf("stopping stats run: %w", err)
+	}
+	return requireAffected(rows, "symphony run", runID)
+}
+
+func (s *sqliteStore) StartSession(ctx context.Context, attrs SessionStart) (int64, error) {
+	startedAt, err := requiredTimestamp("started_at", attrs.StartedAt)
+	if err != nil {
+		return 0, err
+	}
+
+	session, err := s.queries.CreateCodexSession(ctx, sqlc.CreateCodexSessionParams{
+		RunID:       nullInt64(attrs.RunID),
+		IssueID:     nullString(attrs.IssueID),
+		Identifier:  nullString(attrs.Identifier),
+		IssueUrl:    nullString(attrs.IssueURL),
+		StartedAt:   sql.NullString{String: startedAt, Valid: true},
+		CompletedAt: sql.NullString{},
+		FinalState:  sql.NullString{},
+		Model:       nullString(attrs.Model),
+	})
+	if err != nil {
+		return 0, fmt.Errorf("starting codex session: %w", err)
+	}
+	return session.ID, nil
+}
+
+func (s *sqliteStore) FinishSession(ctx context.Context, sessionID int64, attrs SessionFinish) error {
+	completedAt, err := requiredTimestamp("completed_at", attrs.CompletedAt)
+	if err != nil {
+		return err
+	}
+
+	rows, err := s.queries.FinishCodexSession(ctx, sqlc.FinishCodexSessionParams{
+		CompletedAt:    sql.NullString{String: completedAt, Valid: true},
+		Turns:          nonNegative(attrs.Turns),
+		InputTokens:    nonNegative(attrs.InputTokens),
+		OutputTokens:   nonNegative(attrs.OutputTokens),
+		TotalTokens:    nonNegative(attrs.TotalTokens),
+		RuntimeSeconds: nonNegative(attrs.RuntimeSeconds),
+		FinalState:     nullString(attrs.FinalState),
+		Model:          nullString(attrs.Model),
+		ID:             sessionID,
+	})
+	if err != nil {
+		return fmt.Errorf("finishing codex session: %w", err)
+	}
+	return requireAffected(rows, "codex session", sessionID)
+}
+
+func (s *sqliteStore) DailyTokenSpend(ctx context.Context, day time.Time) (TokenSpend, error) {
+	date, err := dateString(day)
+	if err != nil {
+		return TokenSpend{}, err
+	}
+
+	rows, err := s.queries.DailyTokenSpend(ctx, sql.NullString{String: date, Valid: true})
+	if err != nil {
+		return TokenSpend{}, fmt.Errorf("reading daily token spend: %w", err)
+	}
+
+	spend := TokenSpend{
+		Date:    date,
+		ByModel: make([]ModelTokenSpend, 0, len(rows)),
+	}
+	for _, row := range rows {
+		modelSpend := ModelTokenSpend{
+			Model:        row.Model,
+			InputTokens:  row.InputTokens,
+			OutputTokens: row.OutputTokens,
+			TotalTokens:  row.TotalTokens,
+			Sessions:     row.Sessions,
+		}
+		spend.InputTokens += modelSpend.InputTokens
+		spend.OutputTokens += modelSpend.OutputTokens
+		spend.TotalTokens += modelSpend.TotalTokens
+		spend.Sessions += modelSpend.Sessions
+		spend.ByModel = append(spend.ByModel, modelSpend)
+	}
+	return spend, nil
+}
+
 func configureSQLite(ctx context.Context, db *sql.DB, busyTimeoutMillis int64) error {
 	if _, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA busy_timeout = %d", busyTimeoutMillis)); err != nil {
 		return fmt.Errorf("setting sqlite busy_timeout: %w", err)
@@ -67,6 +210,49 @@ func configureSQLite(ctx context.Context, db *sql.DB, busyTimeoutMillis int64) e
 	}
 	if err := db.PingContext(ctx); err != nil {
 		return fmt.Errorf("pinging sqlite database: %w", err)
+	}
+	return nil
+}
+
+func requiredTimestamp(name string, value time.Time) (string, error) {
+	if value.IsZero() {
+		return "", fmt.Errorf("%s is required", name)
+	}
+	return value.UTC().Truncate(time.Second).Format(time.RFC3339), nil
+}
+
+func dateString(value time.Time) (string, error) {
+	if value.IsZero() {
+		return "", errors.New("date is required")
+	}
+	return value.Format("2006-01-02"), nil
+}
+
+func nullString(value string) sql.NullString {
+	trimmed := strings.TrimSpace(value)
+	if trimmed == "" {
+		return sql.NullString{}
+	}
+	return sql.NullString{String: trimmed, Valid: true}
+}
+
+func nullInt64(value int64) sql.NullInt64 {
+	if value <= 0 {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: value, Valid: true}
+}
+
+func nonNegative(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func requireAffected(rows int64, name string, id int64) error {
+	if rows == 0 {
+		return fmt.Errorf("%w: %s %d", ErrNotFound, name, id)
 	}
 	return nil
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,6 +2,7 @@ package store
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"time"
 
@@ -14,6 +15,8 @@ const BackendSQLite Backend = "sqlite"
 
 const defaultBusyTimeout = 5 * time.Second
 
+var ErrNotFound = errors.New("store record not found")
+
 type Config struct {
 	Backend     Backend
 	Path        string
@@ -21,8 +24,85 @@ type Config struct {
 }
 
 type Store interface {
+	StatsStore
 	Queries() *sqlc.Queries
 	Close() error
+}
+
+type StatsStore interface {
+	StartRun(context.Context, RunStart) (int64, error)
+	UpdateRun(context.Context, int64, RunUpdate) error
+	StopRun(context.Context, int64, RunStop) error
+	StartSession(context.Context, SessionStart) (int64, error)
+	FinishSession(context.Context, int64, SessionFinish) error
+	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
+}
+
+type RunStart struct {
+	StartedAt            time.Time
+	PeakConcurrentAgents int64
+	SessionsLaunched     int64
+	InputTokens          int64
+	OutputTokens         int64
+	TotalTokens          int64
+	RuntimeSeconds       int64
+}
+
+type RunUpdate struct {
+	PeakConcurrentAgents int64
+	SessionsLaunched     int64
+	InputTokens          int64
+	OutputTokens         int64
+	TotalTokens          int64
+	RuntimeSeconds       int64
+}
+
+type RunStop struct {
+	StoppedAt            time.Time
+	RestartReason        string
+	PeakConcurrentAgents int64
+	SessionsLaunched     int64
+	InputTokens          int64
+	OutputTokens         int64
+	TotalTokens          int64
+	RuntimeSeconds       int64
+}
+
+type SessionStart struct {
+	RunID      int64
+	IssueID    string
+	Identifier string
+	IssueURL   string
+	StartedAt  time.Time
+	Model      string
+}
+
+type SessionFinish struct {
+	CompletedAt    time.Time
+	Turns          int64
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	RuntimeSeconds int64
+	FinalState     string
+	Model          string
+}
+
+type TokenSpend struct {
+	Date         string
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	Sessions     int64
+	ByModel      []ModelTokenSpend
+}
+
+type ModelTokenSpend struct {
+	Model        string
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	Sessions     int64
 }
 
 func Open(ctx context.Context, cfg Config) (Store, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -157,6 +157,7 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				Identifier: "digitaldrywood/symphony-go#6",
 				IssueURL:   "https://github.com/digitaldrywood/symphony-go/issues/6",
 				StartedAt:  time.Date(2026, 5, 30, 12, 1, 0, 0, time.UTC),
+				Model:      "gpt-5",
 			})
 			if err != nil {
 				t.Fatalf("StartSession() error = %v", err)
@@ -170,7 +171,6 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				TotalTokens:    125,
 				RuntimeSeconds: 240,
 				FinalState:     "Human Review",
-				Model:          "gpt-5",
 			}); err != nil {
 				t.Fatalf("FinishSession() error = %v", err)
 			}
@@ -214,6 +214,9 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 			}
 			if session.FinalState.String != "Human Review" {
 				t.Fatalf("session final_state = %q, want Human Review", session.FinalState.String)
+			}
+			if session.Model.String != "gpt-5" {
+				t.Fatalf("session model = %q, want gpt-5", session.Model.String)
 			}
 
 			spend, err := backend.DailyTokenSpend(ctx, time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC))

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -112,6 +112,124 @@ func TestSQLiteQueriesRoundTrip(t *testing.T) {
 	}
 }
 
+func TestStatsStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  RunStart
+	}{
+		{
+			name: "persists run and session stats",
+			run: RunStart{
+				StartedAt:            time.Date(2026, 5, 30, 12, 0, 0, 0, time.UTC),
+				PeakConcurrentAgents: 1,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			backend := openTestStore(t, ctx)
+
+			runID, err := backend.StartRun(ctx, tt.run)
+			if err != nil {
+				t.Fatalf("StartRun() error = %v", err)
+			}
+
+			if err := backend.UpdateRun(ctx, runID, RunUpdate{
+				PeakConcurrentAgents: 3,
+				SessionsLaunched:     1,
+				InputTokens:          100,
+				OutputTokens:         25,
+				TotalTokens:          125,
+				RuntimeSeconds:       240,
+			}); err != nil {
+				t.Fatalf("UpdateRun() error = %v", err)
+			}
+
+			sessionID, err := backend.StartSession(ctx, SessionStart{
+				RunID:      runID,
+				IssueID:    "I_kwDOSskuwc8AAAABD42c3Q",
+				Identifier: "digitaldrywood/symphony-go#6",
+				IssueURL:   "https://github.com/digitaldrywood/symphony-go/issues/6",
+				StartedAt:  time.Date(2026, 5, 30, 12, 1, 0, 0, time.UTC),
+			})
+			if err != nil {
+				t.Fatalf("StartSession() error = %v", err)
+			}
+
+			if err := backend.FinishSession(ctx, sessionID, SessionFinish{
+				CompletedAt:    time.Date(2026, 5, 30, 12, 5, 0, 0, time.UTC),
+				Turns:          2,
+				InputTokens:    100,
+				OutputTokens:   25,
+				TotalTokens:    125,
+				RuntimeSeconds: 240,
+				FinalState:     "Human Review",
+				Model:          "gpt-5",
+			}); err != nil {
+				t.Fatalf("FinishSession() error = %v", err)
+			}
+
+			if err := backend.StopRun(ctx, runID, RunStop{
+				StoppedAt:            time.Date(2026, 5, 30, 12, 5, 0, 0, time.UTC),
+				RestartReason:        "complete",
+				PeakConcurrentAgents: 3,
+				SessionsLaunched:     1,
+				InputTokens:          100,
+				OutputTokens:         25,
+				TotalTokens:          125,
+				RuntimeSeconds:       240,
+			}); err != nil {
+				t.Fatalf("StopRun() error = %v", err)
+			}
+
+			run, err := backend.Queries().GetSymphonyRun(ctx, runID)
+			if err != nil {
+				t.Fatalf("GetSymphonyRun() error = %v", err)
+			}
+			if run.StartedAt != "2026-05-30T12:00:00Z" {
+				t.Fatalf("run started_at = %q, want 2026-05-30T12:00:00Z", run.StartedAt)
+			}
+			if run.StoppedAt.String != "2026-05-30T12:05:00Z" {
+				t.Fatalf("run stopped_at = %q, want 2026-05-30T12:05:00Z", run.StoppedAt.String)
+			}
+			if run.TotalTokens != 125 {
+				t.Fatalf("run total_tokens = %d, want 125", run.TotalTokens)
+			}
+
+			session, err := backend.Queries().GetCodexSession(ctx, sessionID)
+			if err != nil {
+				t.Fatalf("GetCodexSession() error = %v", err)
+			}
+			if session.RunID.Int64 != runID {
+				t.Fatalf("session run_id = %d, want %d", session.RunID.Int64, runID)
+			}
+			if session.CompletedAt.String != "2026-05-30T12:05:00Z" {
+				t.Fatalf("session completed_at = %q, want 2026-05-30T12:05:00Z", session.CompletedAt.String)
+			}
+			if session.FinalState.String != "Human Review" {
+				t.Fatalf("session final_state = %q, want Human Review", session.FinalState.String)
+			}
+
+			spend, err := backend.DailyTokenSpend(ctx, time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC))
+			if err != nil {
+				t.Fatalf("DailyTokenSpend() error = %v", err)
+			}
+			if spend.InputTokens != 100 || spend.OutputTokens != 25 || spend.TotalTokens != 125 || spend.Sessions != 1 {
+				t.Fatalf("DailyTokenSpend() = %#v", spend)
+			}
+			if len(spend.ByModel) != 1 || spend.ByModel[0].Model != "gpt-5" {
+				t.Fatalf("DailyTokenSpend().ByModel = %#v", spend.ByModel)
+			}
+		})
+	}
+}
+
 func TestOpenRejectsUnsupportedBackend(t *testing.T) {
 	t.Parallel()
 
@@ -184,6 +302,24 @@ func TestBusyTimeoutMillis(t *testing.T) {
 			}
 		})
 	}
+}
+
+func openTestStore(t *testing.T, ctx context.Context) Store {
+	t.Helper()
+
+	backend, err := Open(ctx, Config{
+		Backend: BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "symphony.db"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	return backend
 }
 
 func queryString(t *testing.T, db *sql.DB, query string) string {


### PR DESCRIPTION
## Summary
- add a StatsStore interface implemented by the SQLite store
- add run/session lifecycle methods and daily token spend aggregation
- add table-driven round-trip coverage for run and session stats

Fixes #6

## Test Plan
- go test ./internal/store
- make check