### PR TITLE
feat(connector): add memory adapter

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -11,6 +11,8 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
 )
 
 const (
@@ -43,21 +45,22 @@ type Config struct {
 }
 
 type Tracker struct {
-	Kind                    string      `yaml:"kind"`
-	Endpoint                string      `yaml:"endpoint"`
-	APIKey                  string      `yaml:"api_key"`
-	GitHubAppID             string      `yaml:"github_app_id"`
-	GitHubAppPrivateKey     string      `yaml:"github_app_private_key"`
-	GitHubAppPrivateKeyPath string      `yaml:"github_app_private_key_path"`
-	GitHubAppInstallationID string      `yaml:"github_app_installation_id"`
-	ProjectSlug             string      `yaml:"project_slug"`
-	Assignee                string      `yaml:"assignee"`
-	ActiveStates            []string    `yaml:"active_states"`
-	ObservedStates          []string    `yaml:"observed_states"`
-	TerminalStates          []string    `yaml:"terminal_states"`
-	StateMap                StringOrMap `yaml:"state_map"`
-	PriorityMap             StringOrMap `yaml:"priority_map"`
-	AutoProvision           bool        `yaml:"auto_provision"`
+	Kind                    string            `yaml:"kind"`
+	Endpoint                string            `yaml:"endpoint"`
+	APIKey                  string            `yaml:"api_key"`
+	GitHubAppID             string            `yaml:"github_app_id"`
+	GitHubAppPrivateKey     string            `yaml:"github_app_private_key"`
+	GitHubAppPrivateKeyPath string            `yaml:"github_app_private_key_path"`
+	GitHubAppInstallationID string            `yaml:"github_app_installation_id"`
+	ProjectSlug             string            `yaml:"project_slug"`
+	Assignee                string            `yaml:"assignee"`
+	ActiveStates            []string          `yaml:"active_states"`
+	ObservedStates          []string          `yaml:"observed_states"`
+	TerminalStates          []string          `yaml:"terminal_states"`
+	StateMap                StringOrMap       `yaml:"state_map"`
+	PriorityMap             StringOrMap       `yaml:"priority_map"`
+	AutoProvision           bool              `yaml:"auto_provision"`
+	Issues                  []connector.Issue `yaml:"issues"`
 }
 
 type Polling struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"strings"
 	"testing"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
 )
 
 func TestParseWorkflowFrontmatter(t *testing.T) {
@@ -176,6 +178,104 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Budget.PricingPath != "priv/pricing/models.yaml" {
 		t.Fatalf("Budget.PricingPath = %q", cfg.Budget.PricingPath)
+	}
+}
+
+func TestParseWorkflowMemoryTrackerIssues(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+  issues:
+    - id: issue-1
+      identifier: MT-1
+      title: Memory adapter
+      description: Load issues from config
+      priority: 2
+      state: Todo
+      branch_name: symphony/mt-1
+      url: https://example.com/issues/1
+      assignee_id: worker-1
+      blocked_by:
+        - id: issue-0
+          identifier: MT-0
+          state: Done
+      labels:
+        - stage:s1
+      assigned_to_worker: true
+      model_override: gpt-5-codex-high
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	got := workflow.Config.Tracker.Issues
+	if len(got) != 1 {
+		t.Fatalf("Tracker.Issues len = %d, want 1", len(got))
+	}
+	priority := 2
+	want := connector.Issue{
+		ID:               "issue-1",
+		Identifier:       "MT-1",
+		Title:            "Memory adapter",
+		Description:      "Load issues from config",
+		Priority:         &priority,
+		State:            "Todo",
+		BranchName:       "symphony/mt-1",
+		URL:              "https://example.com/issues/1",
+		AssigneeID:       "worker-1",
+		BlockedBy:        []connector.BlockedRef{{ID: "issue-0", Identifier: "MT-0", State: "Done"}},
+		Labels:           []string{"stage:s1"},
+		AssignedToWorker: true,
+		ModelOverride:    "gpt-5-codex-high",
+	}
+	if got[0].ID != want.ID ||
+		got[0].Identifier != want.Identifier ||
+		got[0].Title != want.Title ||
+		got[0].Description != want.Description ||
+		got[0].Priority == nil ||
+		*got[0].Priority != *want.Priority ||
+		got[0].State != want.State ||
+		got[0].BranchName != want.BranchName ||
+		got[0].URL != want.URL ||
+		got[0].AssigneeID != want.AssigneeID ||
+		len(got[0].BlockedBy) != 1 ||
+		got[0].BlockedBy[0] != want.BlockedBy[0] ||
+		len(got[0].Labels) != 1 ||
+		got[0].Labels[0] != want.Labels[0] ||
+		!got[0].AssignedToWorker ||
+		got[0].ModelOverride != want.ModelOverride {
+		t.Fatalf("Tracker.Issues[0] = %#v, want %#v", got[0], want)
+	}
+}
+
+func TestParseWorkflowMemoryTrackerIssueDefaults(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+  issues:
+    - id: issue-1
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	got := workflow.Config.Tracker.Issues[0]
+	if !got.AssignedToWorker {
+		t.Fatal("AssignedToWorker = false, want true")
+	}
+	if len(got.BlockedBy) != 0 {
+		t.Fatalf("BlockedBy len = %d, want 0", len(got.BlockedBy))
+	}
+	if len(got.Labels) != 0 {
+		t.Fatalf("Labels len = %d, want 0", len(got.Labels))
 	}
 }
 

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/connector/memory"
 )
 
 var (
@@ -15,14 +16,17 @@ var (
 )
 
 type Config struct {
-	Kind string
+	Kind   string
+	Memory memory.Config
 }
 
 func NewFromConfig(cfg Config) (connector.Connector, error) {
 	kind := normalizeKind(cfg.Kind)
 
 	switch connector.Backend(kind) {
-	case connector.BackendMemory, connector.BackendLinear, connector.BackendGitHub:
+	case connector.BackendMemory:
+		return memory.New(cfg.Memory), nil
+	case connector.BackendLinear, connector.BackendGitHub:
 		return unimplementedConnector{name: kind}, nil
 	case connector.BackendGitLab, connector.BackendJira:
 		return nil, fmt.Errorf("%w: %s", ErrBackendNotReady, kind)

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -3,9 +3,11 @@ package factory
 import (
 	"context"
 	"errors"
+	"reflect"
 	"testing"
 
 	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/connector/memory"
 )
 
 func TestNewFromConfigSupportedBackends(t *testing.T) {
@@ -68,10 +70,44 @@ func TestNewFromConfigRejectsUnknownBackend(t *testing.T) {
 	}
 }
 
-func TestFactoryConnectorOperationsAreExplicitlyUnimplemented(t *testing.T) {
+func TestFactoryMemoryConnectorUsesConfiguredIssues(t *testing.T) {
 	t.Parallel()
 
-	c, err := NewFromConfig(Config{Kind: "memory"})
+	issues := []connector.Issue{{ID: "issue-1", State: "Todo"}}
+	var events []memory.Event
+	c, err := NewFromConfig(Config{
+		Kind: "memory",
+		Memory: memory.Config{
+			Issues: issues,
+			EventSink: func(event memory.Event) {
+				events = append(events, event)
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if !reflect.DeepEqual(got, issues) {
+		t.Fatalf("FetchCandidateIssues() = %#v, want %#v", got, issues)
+	}
+
+	if err := c.CreateComment(context.Background(), "issue-1", "body"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	if !reflect.DeepEqual(events, []memory.Event{{Kind: memory.EventKindComment, IssueID: "issue-1", Body: "body"}}) {
+		t.Fatalf("events = %#v, want comment event", events)
+	}
+}
+
+func TestFactoryPlaceholderConnectorOperationsAreExplicitlyUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromConfig(Config{Kind: "github"})
 	if err != nil {
 		t.Fatalf("NewFromConfig() error = %v", err)
 	}

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -1,29 +1,33 @@
 package connector
 
-import "time"
+import (
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
 
 type Issue struct {
-	ID               string       `json:"id,omitempty"`
-	Identifier       string       `json:"identifier,omitempty"`
-	Title            string       `json:"title,omitempty"`
-	Description      string       `json:"description,omitempty"`
-	Priority         *int         `json:"priority,omitempty"`
-	State            string       `json:"state,omitempty"`
-	BranchName       string       `json:"branch_name,omitempty"`
-	URL              string       `json:"url,omitempty"`
-	AssigneeID       string       `json:"assignee_id,omitempty"`
-	BlockedBy        []BlockedRef `json:"blocked_by"`
-	Labels           []string     `json:"labels"`
-	AssignedToWorker bool         `json:"assigned_to_worker"`
-	CreatedAt        *time.Time   `json:"created_at,omitempty"`
-	UpdatedAt        *time.Time   `json:"updated_at,omitempty"`
-	ModelOverride    string       `json:"model_override"`
+	ID               string       `json:"id,omitempty" yaml:"id,omitempty"`
+	Identifier       string       `json:"identifier,omitempty" yaml:"identifier,omitempty"`
+	Title            string       `json:"title,omitempty" yaml:"title,omitempty"`
+	Description      string       `json:"description,omitempty" yaml:"description,omitempty"`
+	Priority         *int         `json:"priority,omitempty" yaml:"priority,omitempty"`
+	State            string       `json:"state,omitempty" yaml:"state,omitempty"`
+	BranchName       string       `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
+	URL              string       `json:"url,omitempty" yaml:"url,omitempty"`
+	AssigneeID       string       `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`
+	BlockedBy        []BlockedRef `json:"blocked_by" yaml:"blocked_by"`
+	Labels           []string     `json:"labels" yaml:"labels"`
+	AssignedToWorker bool         `json:"assigned_to_worker" yaml:"assigned_to_worker"`
+	CreatedAt        *time.Time   `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt        *time.Time   `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	ModelOverride    string       `json:"model_override" yaml:"model_override"`
 }
 
 type BlockedRef struct {
-	ID         string `json:"id,omitempty"`
-	Identifier string `json:"identifier"`
-	State      string `json:"state,omitempty"`
+	ID         string `json:"id,omitempty" yaml:"id,omitempty"`
+	Identifier string `json:"identifier" yaml:"identifier"`
+	State      string `json:"state,omitempty" yaml:"state,omitempty"`
 }
 
 func NewIssue() Issue {
@@ -32,4 +36,16 @@ func NewIssue() Issue {
 		Labels:           []string{},
 		AssignedToWorker: true,
 	}
+}
+
+func (i *Issue) UnmarshalYAML(value *yaml.Node) error {
+	type issue Issue
+
+	defaults := issue(NewIssue())
+	if err := value.Decode(&defaults); err != nil {
+		return err
+	}
+
+	*i = Issue(defaults)
+	return nil
 }

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -1,0 +1,140 @@
+package memory
+
+import (
+	"context"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+const (
+	EventKindComment     EventKind = "memory_tracker_comment"
+	EventKindStateUpdate EventKind = "memory_tracker_state_update"
+)
+
+type EventKind string
+
+type Event struct {
+	Kind    EventKind
+	IssueID string
+	Body    string
+	State   string
+}
+
+type EventSink func(Event)
+
+type Config struct {
+	Issues    []connector.Issue
+	EventSink EventSink
+}
+
+type Connector struct {
+	issues    []connector.Issue
+	eventSink EventSink
+}
+
+var _ connector.Connector = (*Connector)(nil)
+
+func New(cfg Config) *Connector {
+	return &Connector{
+		issues:    cloneIssues(cfg.Issues),
+		eventSink: cfg.EventSink,
+	}
+}
+
+func (c *Connector) Name() string {
+	return connector.BackendMemory.String()
+}
+
+func (c *Connector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return cloneIssues(c.issues), nil
+}
+
+func (c *Connector) FetchIssuesByStates(_ context.Context, stateNames []string) ([]connector.Issue, error) {
+	wantedStates := make(map[string]struct{}, len(stateNames))
+	for _, stateName := range stateNames {
+		wantedStates[normalizeState(stateName)] = struct{}{}
+	}
+
+	issues := make([]connector.Issue, 0, len(c.issues))
+	for _, issue := range c.issues {
+		if _, ok := wantedStates[normalizeState(issue.State)]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+
+	return issues, nil
+}
+
+func (c *Connector) FetchIssueStatesByIDs(_ context.Context, issueIDs []string) ([]connector.Issue, error) {
+	wantedIDs := make(map[string]struct{}, len(issueIDs))
+	for _, issueID := range issueIDs {
+		wantedIDs[issueID] = struct{}{}
+	}
+
+	issues := make([]connector.Issue, 0, len(c.issues))
+	for _, issue := range c.issues {
+		if _, ok := wantedIDs[issue.ID]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+
+	return issues, nil
+}
+
+func (c *Connector) CreateComment(_ context.Context, issueID string, body string) error {
+	c.send(Event{Kind: EventKindComment, IssueID: issueID, Body: body})
+	return nil
+}
+
+func (c *Connector) UpdateIssueState(_ context.Context, issueID string, stateName string) error {
+	c.send(Event{Kind: EventKindStateUpdate, IssueID: issueID, State: stateName})
+	return nil
+}
+
+func (c *Connector) send(event Event) {
+	if c.eventSink == nil {
+		return
+	}
+
+	c.eventSink(event)
+}
+
+func normalizeState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func cloneIssues(issues []connector.Issue) []connector.Issue {
+	out := make([]connector.Issue, len(issues))
+	for i, issue := range issues {
+		out[i] = cloneIssue(issue)
+	}
+	return out
+}
+
+func cloneIssue(issue connector.Issue) connector.Issue {
+	if issue.Priority != nil {
+		priority := *issue.Priority
+		issue.Priority = &priority
+	}
+	if issue.BlockedBy != nil {
+		issue.BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
+	}
+	if issue.Labels != nil {
+		issue.Labels = append([]string(nil), issue.Labels...)
+	}
+	issue.CreatedAt = cloneTime(issue.CreatedAt)
+	issue.UpdatedAt = cloneTime(issue.UpdatedAt)
+
+	return issue
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+
+	cloned := *value
+	return &cloned
+}

--- a/internal/connector/memory/memory_test.go
+++ b/internal/connector/memory/memory_test.go
@@ -1,0 +1,221 @@
+package memory
+
+import (
+	"context"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestConnectorFetchesConfiguredIssues(t *testing.T) {
+	t.Parallel()
+
+	priority := 2
+	createdAt := time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC)
+	issues := []connector.Issue{
+		{
+			ID:               "issue-1",
+			Identifier:       "MT-1",
+			Title:            "Memory adapter",
+			Description:      "Load issues from config",
+			Priority:         &priority,
+			State:            "Todo",
+			BranchName:       "symphony/mt-1",
+			URL:              "https://example.com/issues/1",
+			AssigneeID:       "worker-1",
+			BlockedBy:        []connector.BlockedRef{{ID: "issue-0", Identifier: "MT-0", State: "Done"}},
+			Labels:           []string{"stage:s1"},
+			AssignedToWorker: true,
+			CreatedAt:        &createdAt,
+			UpdatedAt:        &createdAt,
+			ModelOverride:    "gpt-5-codex-high",
+		},
+	}
+
+	c := New(Config{Issues: issues})
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(got, issues) {
+		t.Fatalf("FetchCandidateIssues() = %#v, want %#v", got, issues)
+	}
+}
+
+func TestConnectorReturnsDefensiveIssueCopies(t *testing.T) {
+	t.Parallel()
+
+	priority := 1
+	createdAt := time.Date(2026, 5, 31, 11, 0, 0, 0, time.UTC)
+	c := New(Config{Issues: []connector.Issue{{
+		ID:        "issue-1",
+		Priority:  &priority,
+		State:     "Todo",
+		BlockedBy: []connector.BlockedRef{{Identifier: "MT-0"}},
+		Labels:    []string{"stage:s1"},
+		CreatedAt: &createdAt,
+		UpdatedAt: &createdAt,
+	}}})
+	priority = 4
+	createdAt = createdAt.Add(time.Hour)
+
+	first, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() first error = %v", err)
+	}
+	*first[0].Priority = 3
+	first[0].BlockedBy[0].Identifier = "changed"
+	first[0].Labels[0] = "changed"
+	*first[0].CreatedAt = first[0].CreatedAt.Add(time.Hour)
+	*first[0].UpdatedAt = first[0].UpdatedAt.Add(time.Hour)
+
+	second, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() second error = %v", err)
+	}
+
+	if *second[0].Priority != 1 {
+		t.Fatalf("Priority = %d, want 1", *second[0].Priority)
+	}
+	if second[0].BlockedBy[0].Identifier != "MT-0" {
+		t.Fatalf("BlockedBy[0].Identifier = %q, want MT-0", second[0].BlockedBy[0].Identifier)
+	}
+	if second[0].Labels[0] != "stage:s1" {
+		t.Fatalf("Labels[0] = %q, want stage:s1", second[0].Labels[0])
+	}
+	if !second[0].CreatedAt.Equal(time.Date(2026, 5, 31, 11, 0, 0, 0, time.UTC)) {
+		t.Fatalf("CreatedAt = %v, want original time", second[0].CreatedAt)
+	}
+	if !second[0].UpdatedAt.Equal(time.Date(2026, 5, 31, 11, 0, 0, 0, time.UTC)) {
+		t.Fatalf("UpdatedAt = %v, want original time", second[0].UpdatedAt)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesMatchesElixirMemoryAdapter(t *testing.T) {
+	t.Parallel()
+
+	c := New(Config{Issues: []connector.Issue{
+		{ID: "issue-1", State: "Todo"},
+		{ID: "issue-2", State: " in progress "},
+		{ID: "issue-3", State: "Done"},
+		{ID: "issue-4"},
+	}})
+
+	tests := []struct {
+		name   string
+		states []string
+		want   []string
+	}{
+		{name: "matches state ignoring case and whitespace", states: []string{" todo ", "IN PROGRESS"}, want: []string{"issue-1", "issue-2"}},
+		{name: "empty state list matches no issues", states: []string{}, want: []string{}},
+		{name: "blank state matches blank issue state", states: []string{" "}, want: []string{"issue-4"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := c.FetchIssuesByStates(context.Background(), tt.states)
+			if err != nil {
+				t.Fatalf("FetchIssuesByStates() error = %v", err)
+			}
+
+			if ids := issueIDs(got); !reflect.DeepEqual(ids, tt.want) {
+				t.Fatalf("FetchIssuesByStates() ids = %#v, want %#v", ids, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectorFetchIssueStatesByIDsMatchesElixirMemoryAdapter(t *testing.T) {
+	t.Parallel()
+
+	c := New(Config{Issues: []connector.Issue{
+		{ID: "issue-1", State: "Todo"},
+		{ID: "issue-2", State: "Done"},
+		{ID: "", State: "No ID"},
+	}})
+
+	tests := []struct {
+		name string
+		ids  []string
+		want []string
+	}{
+		{name: "matches exact IDs in configured order", ids: []string{"issue-2", "issue-1"}, want: []string{"issue-1", "issue-2"}},
+		{name: "empty ID list matches no issues", ids: []string{}, want: []string{}},
+		{name: "blank ID matches blank issue ID", ids: []string{""}, want: []string{""}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := c.FetchIssueStatesByIDs(context.Background(), tt.ids)
+			if err != nil {
+				t.Fatalf("FetchIssueStatesByIDs() error = %v", err)
+			}
+
+			if ids := issueIDs(got); !reflect.DeepEqual(ids, tt.want) {
+				t.Fatalf("FetchIssueStatesByIDs() ids = %#v, want %#v", ids, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectorMutationsMatchElixirMemoryAdapter(t *testing.T) {
+	t.Parallel()
+
+	var events []Event
+	c := New(Config{
+		Issues: []connector.Issue{{ID: "issue-1", State: "Todo"}},
+		EventSink: func(event Event) {
+			events = append(events, event)
+		},
+	})
+
+	if err := c.CreateComment(context.Background(), "issue-1", "comment"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	if err := c.UpdateIssueState(context.Background(), "issue-1", "Done"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+	issues, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+
+	wantEvents := []Event{
+		{Kind: EventKindComment, IssueID: "issue-1", Body: "comment"},
+		{Kind: EventKindStateUpdate, IssueID: "issue-1", State: "Done"},
+	}
+	if !reflect.DeepEqual(events, wantEvents) {
+		t.Fatalf("events = %#v, want %#v", events, wantEvents)
+	}
+	if issues[0].State != "Todo" {
+		t.Fatalf("State after UpdateIssueState() = %q, want Todo", issues[0].State)
+	}
+}
+
+func TestConnectorMutationsNoopWithoutEventSink(t *testing.T) {
+	t.Parallel()
+
+	c := New(Config{})
+
+	if err := c.CreateComment(context.Background(), "issue-1", "comment"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	if err := c.UpdateIssueState(context.Background(), "issue-1", "Done"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+}
+
+func issueIDs(issues []connector.Issue) []string {
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		ids = append(ids, issue.ID)
+	}
+	return ids
+}


### PR DESCRIPTION
## Summary
- add `internal/connector/memory` with config-backed issues and Elixir memory adapter parity behavior
- wire the memory backend through the connector factory while keeping placeholder backends explicit
- allow `tracker.issues` to decode connector issues from workflow config with issue defaults

Fixes #8

## Test Plan
- `go test ./internal/connector/... ./internal/config`
- `go test -cover ./internal/connector/... ./internal/config`
- `make check`