### PR TITLE
feat(orchestrator): add tick loop state

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -227,7 +227,7 @@ func (o *Orchestrator) dispatchDueRetries(
 		}
 		if !o.dispatchableForRetry(issue, state) {
 			if availableSlots(state) == 0 {
-				o.scheduleRetry(state, issue, retry.Attempt+1, now, "no available orchestrator slots", false)
+				o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false)
 				continue
 			}
 			if _, blocked := state.Blocked[issue.ID]; blocked {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1,0 +1,606 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"math"
+	"sort"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+const (
+	defaultPollInterval          = 30 * time.Second
+	defaultMaxConcurrentAgents   = 1
+	defaultMaxRetryBackoff       = 5 * time.Minute
+	defaultContinuationRetry     = time.Second
+	defaultFailureRetryBaseDelay = 10 * time.Second
+)
+
+var (
+	ErrMissingConnector = errors.New("orchestrator connector is required")
+	ErrStopped          = errors.New("orchestrator stopped")
+)
+
+type Config struct {
+	PollInterval               time.Duration
+	MaxConcurrentAgents        int
+	MaxConcurrentAgentsByState map[string]int
+	MaxRetryBackoff            time.Duration
+	ActiveStates               []string
+	TerminalStates             []string
+	ContinuationRetryDelay     time.Duration
+	FailureRetryBaseDelay      time.Duration
+}
+
+type Dependencies struct {
+	Connector connector.Connector
+	Runner    Runner
+	Logger    *slog.Logger
+}
+
+type Orchestrator struct {
+	cfg           Config
+	connector     connector.Connector
+	runner        Runner
+	logger        *slog.Logger
+	stateRequests chan stateRequest
+	runResults    chan runResultEvent
+	done          chan struct{}
+}
+
+type stateRequest struct {
+	reply chan State
+}
+
+type runResultEvent struct {
+	issueID     string
+	result      RunResult
+	err         error
+	completedAt time.Time
+}
+
+func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
+	return Config{
+		PollInterval:               durationFromMillis(cfg.Polling.IntervalMS),
+		MaxConcurrentAgents:        cfg.Agent.MaxConcurrentAgents,
+		MaxConcurrentAgentsByState: cloneStateLimits(cfg.Agent.MaxConcurrentAgentsByState),
+		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
+		ActiveStates:               append([]string(nil), cfg.Tracker.ActiveStates...),
+		TerminalStates:             append([]string(nil), cfg.Tracker.TerminalStates...),
+	}
+}
+
+func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
+	cfg = normalizeConfig(cfg)
+	if deps.Connector == nil {
+		return nil, ErrMissingConnector
+	}
+
+	runner := deps.Runner
+	if runner == nil {
+		runner = FakeRunner{}
+	}
+
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	return &Orchestrator{
+		cfg:           cfg,
+		connector:     deps.Connector,
+		runner:        runner,
+		logger:        logger,
+		stateRequests: make(chan stateRequest),
+		runResults:    make(chan runResultEvent),
+		done:          make(chan struct{}),
+	}, nil
+}
+
+func (o *Orchestrator) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	defer close(o.done)
+
+	ticker := time.NewTicker(o.cfg.PollInterval)
+	defer ticker.Stop()
+
+	state := newState(o.cfg)
+	o.tick(ctx, &state, time.Now())
+
+	for {
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case now := <-ticker.C:
+			o.tick(ctx, &state, now)
+		case result := <-o.runResults:
+			o.handleRunResult(&state, result)
+		case request := <-o.stateRequests:
+			request.reply <- state.clone()
+		}
+	}
+}
+
+func (o *Orchestrator) State(ctx context.Context) (State, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	request := stateRequest{reply: make(chan State, 1)}
+	select {
+	case <-ctx.Done():
+		return State{}, ctx.Err()
+	case <-o.done:
+		return State{}, ErrStopped
+	case o.stateRequests <- request:
+	}
+
+	select {
+	case <-ctx.Done():
+		return State{}, ctx.Err()
+	case <-o.done:
+		return State{}, ErrStopped
+	case state := <-request.reply:
+		return state, nil
+	}
+}
+
+func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
+	issues, err := o.connector.FetchCandidateIssues(ctx)
+	if err != nil {
+		o.logger.Warn("fetch candidate issues failed", "error", err)
+		return
+	}
+
+	issues = cloneIssues(issues)
+	sortIssuesForDispatch(issues)
+	o.trackBlockedCandidates(state, issues, now)
+	o.dispatchDueRetries(ctx, state, issues, now)
+	o.dispatchCandidates(ctx, state, issues, now)
+}
+
+func (o *Orchestrator) trackBlockedCandidates(state *State, issues []connector.Issue, now time.Time) {
+	seenBlocked := make(map[string]struct{})
+	for _, issue := range issues {
+		if issue.ID == "" {
+			continue
+		}
+		if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
+			seenBlocked[issue.ID] = struct{}{}
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     cloneIssue(issue),
+				Reason:    "blocked by non-terminal dependency",
+				BlockedAt: now,
+			}
+		}
+	}
+
+	for issueID, blocked := range state.Blocked {
+		if blocked.Reason != "blocked by non-terminal dependency" {
+			continue
+		}
+		if _, ok := seenBlocked[issueID]; !ok {
+			delete(state.Blocked, issueID)
+		}
+	}
+}
+
+func (o *Orchestrator) dispatchDueRetries(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) {
+	if len(state.Retry) == 0 {
+		return
+	}
+
+	byID := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		byID[issue.ID] = issue
+	}
+
+	retries := make([]Retry, 0, len(state.Retry))
+	for _, retry := range state.Retry {
+		if !retry.DueAt.After(now) {
+			retries = append(retries, retry)
+		}
+	}
+	sort.SliceStable(retries, func(i, j int) bool {
+		return retries[i].DueAt.Before(retries[j].DueAt)
+	})
+
+	for _, retry := range retries {
+		delete(state.Retry, retry.Issue.ID)
+
+		issue, ok := byID[retry.Issue.ID]
+		if !ok {
+			o.releaseIssue(state, retry.Issue.ID)
+			continue
+		}
+		if !o.dispatchableForRetry(issue, state) {
+			if availableSlots(state) == 0 {
+				o.scheduleRetry(state, issue, retry.Attempt+1, now, "no available orchestrator slots", false)
+				continue
+			}
+			if _, blocked := state.Blocked[issue.ID]; blocked {
+				o.releaseClaim(state, issue.ID)
+				continue
+			}
+
+			o.releaseIssue(state, issue.ID)
+			continue
+		}
+
+		o.dispatchIssue(ctx, state, issue, retry.Attempt, now)
+	}
+}
+
+func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
+	for _, issue := range issues {
+		if availableSlots(state) == 0 {
+			return
+		}
+		if !o.dispatchable(issue, state) {
+			continue
+		}
+
+		o.dispatchIssue(ctx, state, issue, 0, now)
+	}
+}
+
+func (o *Orchestrator) dispatchable(issue connector.Issue, state *State) bool {
+	return o.dispatchableIssue(issue, state, false)
+}
+
+func (o *Orchestrator) dispatchableForRetry(issue connector.Issue, state *State) bool {
+	return o.dispatchableIssue(issue, state, true)
+}
+
+func (o *Orchestrator) dispatchableIssue(issue connector.Issue, state *State, allowClaimed bool) bool {
+	if !validCandidate(issue) {
+		return false
+	}
+	if !stateIn(issue.State, o.cfg.ActiveStates) || stateIn(issue.State, o.cfg.TerminalStates) {
+		return false
+	}
+	if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
+		return false
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		return false
+	}
+	if _, ok := state.Claimed[issue.ID]; ok && !allowClaimed {
+		return false
+	}
+	if _, ok := state.Blocked[issue.ID]; ok {
+		return false
+	}
+	if availableSlots(state) == 0 {
+		return false
+	}
+
+	return o.stateSlotsAvailable(issue, state)
+}
+
+func (o *Orchestrator) stateSlotsAvailable(issue connector.Issue, state *State) bool {
+	limit := o.cfg.MaxConcurrentAgents
+	if stateLimit, ok := o.cfg.MaxConcurrentAgentsByState[normalizeState(issue.State)]; ok {
+		limit = stateLimit
+	}
+
+	used := 0
+	normalized := normalizeState(issue.State)
+	for _, running := range state.Running {
+		if normalizeState(running.Issue.State) == normalized {
+			used++
+		}
+	}
+
+	return used < limit
+}
+
+func (o *Orchestrator) dispatchIssue(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+) {
+	issue = cloneIssue(issue)
+	state.Running[issue.ID] = Running{
+		Issue:     issue,
+		Attempt:   attempt,
+		StartedAt: now,
+	}
+	state.Claimed[issue.ID] = Claimed{
+		Issue:     issue,
+		ClaimedAt: now,
+	}
+	delete(state.Retry, issue.ID)
+	delete(state.Blocked, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+
+	request := RunRequest{
+		Issue:     issue,
+		Attempt:   attempt,
+		StartedAt: now,
+	}
+	go func() {
+		result, err := o.runner.Run(ctx, request)
+		event := runResultEvent{
+			issueID:     request.Issue.ID,
+			result:      result,
+			err:         err,
+			completedAt: time.Now(),
+		}
+
+		select {
+		case o.runResults <- event:
+		case <-ctx.Done():
+		}
+	}()
+}
+
+func (o *Orchestrator) handleRunResult(state *State, event runResultEvent) {
+	running, ok := state.Running[event.issueID]
+	if !ok {
+		return
+	}
+	delete(state.Running, event.issueID)
+
+	if event.err != nil {
+		o.scheduleRetry(state, running.Issue, nextAttempt(running.Attempt), event.completedAt, event.err.Error(), false)
+		return
+	}
+
+	finalState := event.result.FinalState
+	if finalState == "" {
+		finalState = FinalStateCompleted
+	}
+
+	state.Completed[event.issueID] = Completed{
+		Issue:       cloneIssue(running.Issue),
+		StartedAt:   running.StartedAt,
+		CompletedAt: event.completedAt,
+		FinalState:  finalState,
+		Tokens:      event.result.Tokens,
+	}
+	state.CodexTotals = addCodexTotals(state.CodexTotals, event.result.Tokens)
+	if event.result.RateLimits != nil {
+		state.RateLimits = cloneRateLimits(event.result.RateLimits)
+	}
+	if diffStatsPresent(event.result.DiffStats) {
+		state.DiffStats[event.issueID] = event.result.DiffStats
+	}
+	if event.result.BudgetRefusal != nil {
+		refusal := *event.result.BudgetRefusal
+		refusal.Issue = cloneIssue(running.Issue)
+		state.BudgetRefusals[event.issueID] = refusal
+	}
+
+	o.scheduleRetry(state, running.Issue, 1, event.completedAt, "", true)
+}
+
+func (o *Orchestrator) scheduleRetry(
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	err string,
+	continuation bool,
+) {
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	delay := o.retryDelay(attempt, continuation)
+	issue = cloneIssue(issue)
+	state.Retry[issue.ID] = Retry{
+		Issue:   issue,
+		Attempt: attempt,
+		DueAt:   now.Add(delay),
+		Error:   err,
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		state.Claimed[issue.ID] = Claimed{
+			Issue:     issue,
+			ClaimedAt: now,
+		}
+	}
+}
+
+func (o *Orchestrator) retryDelay(attempt int, continuation bool) time.Duration {
+	if continuation {
+		return o.cfg.ContinuationRetryDelay
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	exponent := attempt - 1
+	if exponent > 30 {
+		exponent = 30
+	}
+
+	delay := o.cfg.FailureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
+	if delay > o.cfg.MaxRetryBackoff {
+		return o.cfg.MaxRetryBackoff
+	}
+	return delay
+}
+
+func (o *Orchestrator) releaseIssue(state *State, issueID string) {
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Blocked, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+}
+
+func (o *Orchestrator) releaseClaim(state *State, issueID string) {
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+}
+
+func normalizeConfig(cfg Config) Config {
+	if cfg.PollInterval <= 0 {
+		cfg.PollInterval = defaultPollInterval
+	}
+	if cfg.MaxConcurrentAgents <= 0 {
+		cfg.MaxConcurrentAgents = defaultMaxConcurrentAgents
+	}
+	if cfg.MaxRetryBackoff <= 0 {
+		cfg.MaxRetryBackoff = defaultMaxRetryBackoff
+	}
+	if cfg.ContinuationRetryDelay < 0 {
+		cfg.ContinuationRetryDelay = 0
+	}
+	if cfg.ContinuationRetryDelay == 0 {
+		cfg.ContinuationRetryDelay = defaultContinuationRetry
+	}
+	if cfg.FailureRetryBaseDelay <= 0 {
+		cfg.FailureRetryBaseDelay = defaultFailureRetryBaseDelay
+	}
+	if len(cfg.ActiveStates) == 0 {
+		cfg.ActiveStates = []string{"Todo", "In Progress"}
+	}
+	if len(cfg.TerminalStates) == 0 {
+		cfg.TerminalStates = []string{"Done", "Cancelled", "Canceled", "Closed"}
+	}
+
+	cfg.ActiveStates = normalizedStates(cfg.ActiveStates)
+	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
+	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
+
+	return cfg
+}
+
+func durationFromMillis(ms int) time.Duration {
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
+}
+
+func cloneStateLimits(limits map[string]int) map[string]int {
+	cloned := make(map[string]int, len(limits))
+	for state, limit := range limits {
+		if limit > 0 {
+			cloned[normalizeState(state)] = limit
+		}
+	}
+	return cloned
+}
+
+func cloneIssues(issues []connector.Issue) []connector.Issue {
+	cloned := make([]connector.Issue, len(issues))
+	for i, issue := range issues {
+		cloned[i] = cloneIssue(issue)
+	}
+	return cloned
+}
+
+func sortIssuesForDispatch(issues []connector.Issue) {
+	sort.SliceStable(issues, func(i, j int) bool {
+		left := issues[i]
+		right := issues[j]
+
+		if leftRank, rightRank := priorityRank(left.Priority), priorityRank(right.Priority); leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		if left.CreatedAt != nil && right.CreatedAt != nil && !left.CreatedAt.Equal(*right.CreatedAt) {
+			return left.CreatedAt.Before(*right.CreatedAt)
+		}
+		if left.CreatedAt != nil && right.CreatedAt == nil {
+			return true
+		}
+		if left.CreatedAt == nil && right.CreatedAt != nil {
+			return false
+		}
+
+		return left.Identifier < right.Identifier
+	})
+}
+
+func priorityRank(priority *int) int {
+	if priority == nil || *priority < 1 || *priority > 4 {
+		return 5
+	}
+	return *priority
+}
+
+func validCandidate(issue connector.Issue) bool {
+	return issue.ID != "" &&
+		issue.Identifier != "" &&
+		issue.Title != "" &&
+		issue.State != "" &&
+		issue.AssignedToWorker
+}
+
+func todoBlockedByNonTerminal(issue connector.Issue, terminalStates []string) bool {
+	if normalizeState(issue.State) != "todo" {
+		return false
+	}
+
+	for _, blocker := range issue.BlockedBy {
+		if blocker.State == "" || !stateIn(blocker.State, terminalStates) {
+			return true
+		}
+	}
+	return false
+}
+
+func availableSlots(state *State) int {
+	available := state.MaxConcurrentAgents - len(state.Running)
+	if available < 0 {
+		return 0
+	}
+	return available
+}
+
+func nextAttempt(attempt int) int {
+	if attempt < 1 {
+		return 1
+	}
+	return attempt + 1
+}
+
+func stateIn(state string, states []string) bool {
+	normalized := normalizeState(state)
+	for _, candidate := range states {
+		if normalized == candidate {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizedStates(states []string) []string {
+	normalized := make([]string, 0, len(states))
+	seen := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		state = normalizeState(state)
+		if state == "" {
+			continue
+		}
+		if _, ok := seen[state]; ok {
+			continue
+		}
+		seen[state] = struct{}{}
+		normalized = append(normalized, state)
+	}
+	return normalized
+}
+
+func normalizeState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,0 +1,498 @@
+package orchestrator_test
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/orchestrator"
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+)
+
+func TestRunDispatchesCandidateAndRecordsCompletion(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-1", "digitaldrywood/symphony-go#10", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := &staticRunner{
+		result: orchestrator.RunResult{
+			Tokens: orchestrator.CodexTotals{
+				InputTokens:    100,
+				OutputTokens:   25,
+				TotalTokens:    125,
+				RuntimeSeconds: 1.5,
+			},
+			DiffStats: orchestrator.DiffStats{
+				FilesChanged: 2,
+				AddedLines:   4,
+				RemovedLines: 1,
+				Status:       "ok",
+			},
+			RateLimits: &telemetry.RateLimits{
+				LimitID:   "codex",
+				LimitName: "Codex",
+			},
+			FinalState: "Human Review",
+		},
+	}
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, completed := state.Completed[issue.ID]
+		return completed
+	})
+
+	if got := runner.calls.Load(); got != 1 {
+		t.Fatalf("runner calls = %d, want 1", got)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing", issue.ID)
+	}
+	if got := state.Completed[issue.ID].FinalState; got != "Human Review" {
+		t.Fatalf("Completed[%q].FinalState = %q, want Human Review", issue.ID, got)
+	}
+	if got := state.Retry[issue.ID].Attempt; got != 1 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 1", issue.ID, got)
+	}
+	if got := state.CodexTotals.TotalTokens; got != 125 {
+		t.Fatalf("CodexTotals.TotalTokens = %d, want 125", got)
+	}
+	if got := state.DiffStats[issue.ID].AddedLines; got != 4 {
+		t.Fatalf("DiffStats[%q].AddedLines = %d, want 4", issue.ID, got)
+	}
+	if state.RateLimits == nil || state.RateLimits.LimitID != "codex" {
+		t.Fatalf("RateLimits = %#v, want codex rate limit", state.RateLimits)
+	}
+	if got := tracker.fetchCandidateCalls(); got == 0 {
+		t.Fatal("FetchCandidateIssues() calls = 0, want at least 1")
+	}
+}
+
+func TestRunReportsRunningStateWhileRunnerIsInFlight(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-2", "digitaldrywood/symphony-go#11", "In Progress")
+	tracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	started := receiveRunRequest(t, runner.started)
+	if started.Issue.ID != issue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", started.Issue.ID, issue.ID)
+	}
+
+	state, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if _, ok := state.Running[issue.ID]; !ok {
+		t.Fatalf("Running[%q] missing while runner is blocked", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing while runner is blocked", issue.ID)
+	}
+
+	close(runner.release)
+
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		_, completed := state.Completed[issue.ID]
+		return completed
+	})
+}
+
+func TestRunSchedulesRetryAfterRunnerError(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-3", "digitaldrywood/symphony-go#12", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := &staticRunner{err: errors.New("runner failed")}
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		retry, ok := state.Retry[issue.ID]
+		return ok && retry.Error != ""
+	})
+
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after runner error", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing after runner error", issue.ID)
+	}
+	if got := state.Retry[issue.ID].Attempt; got != 1 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 1", issue.ID, got)
+	}
+	if got := state.Retry[issue.ID].Error; got != "runner failed" {
+		t.Fatalf("Retry[%q].Error = %q, want runner failed", issue.ID, got)
+	}
+}
+
+func TestRunRedispatchesDueRetryWithExistingClaim(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-retry", "digitaldrywood/symphony-go#16", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := newRetryRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           5 * time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        5 * time.Millisecond,
+		FailureRetryBaseDelay:  5 * time.Millisecond,
+		ContinuationRetryDelay: time.Second,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	request := receiveRunRequest(t, runner.retryStarted)
+	if request.Issue.ID != issue.ID {
+		t.Fatalf("retry RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
+	}
+	if request.Attempt != 1 {
+		t.Fatalf("retry RunRequest.Attempt = %d, want 1", request.Attempt)
+	}
+
+	state, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if got := state.Running[issue.ID].Attempt; got != 1 {
+		t.Fatalf("Running[%q].Attempt = %d, want 1", issue.ID, got)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing during retry run", issue.ID)
+	}
+
+	close(runner.release)
+}
+
+func TestRunSkipsTodoBlockedByNonTerminalDependency(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-4", "digitaldrywood/symphony-go#13", "Todo")
+	issue.BlockedBy = []connector.BlockedRef{{
+		Identifier: "digitaldrywood/symphony-go#4",
+		State:      "In Progress",
+	}}
+	tracker := newFakeConnector(issue)
+	runner := &staticRunner{}
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, blocked := state.Blocked[issue.ID]
+		return blocked
+	})
+
+	if got := runner.calls.Load(); got != 0 {
+		t.Fatalf("runner calls = %d, want 0", got)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present for blocked issue", issue.ID)
+	}
+	if got := state.Blocked[issue.ID].Issue.BlockedBy[0].State; got != "In Progress" {
+		t.Fatalf("Blocked dependency state = %q, want In Progress", got)
+	}
+}
+
+func TestStateReturnsDefensiveCopies(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-5", "digitaldrywood/symphony-go#14", "In Progress")
+	tracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	receiveRunRequest(t, runner.started)
+
+	first, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	delete(first.Running, issue.ID)
+	first.Claimed[issue.ID] = orchestrator.Claimed{}
+
+	second, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if _, ok := second.Running[issue.ID]; !ok {
+		t.Fatalf("Running[%q] missing after mutating previous snapshot", issue.ID)
+	}
+	if second.Claimed[issue.ID].Issue.ID != issue.ID {
+		t.Fatalf("Claimed[%q].Issue.ID = %q, want %q", issue.ID, second.Claimed[issue.ID].Issue.ID, issue.ID)
+	}
+
+	close(runner.release)
+}
+
+func TestFakeRunnerCompletes(t *testing.T) {
+	t.Parallel()
+
+	result, err := orchestrator.FakeRunner{}.Run(context.Background(), orchestrator.RunRequest{
+		Issue: testIssue("issue-6", "digitaldrywood/symphony-go#15", "Todo"),
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.FinalState != orchestrator.FinalStateCompleted {
+		t.Fatalf("FinalState = %q, want %q", result.FinalState, orchestrator.FinalStateCompleted)
+	}
+}
+
+func newTestOrchestrator(t *testing.T, tracker connector.Connector, runner orchestrator.Runner) *orchestrator.Orchestrator {
+	t.Helper()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           5 * time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        50 * time.Millisecond,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	return orch
+}
+
+func runOrchestrator(t *testing.T, orch *orchestrator.Orchestrator) func() {
+	t.Helper()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- orch.Run(ctx)
+	}()
+
+	return func() {
+		cancel()
+		select {
+		case err := <-done:
+			if err != nil && !errors.Is(err, context.Canceled) {
+				t.Fatalf("Run() error = %v", err)
+			}
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for Run() to stop")
+		}
+	}
+}
+
+func waitForState(t *testing.T, orch *orchestrator.Orchestrator, ready func(orchestrator.State) bool) orchestrator.State {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		state, err := orch.State(ctx)
+		cancel()
+		if err == nil && ready(state) {
+			return state
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for orchestrator state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func receiveRunRequest(t *testing.T, requests <-chan orchestrator.RunRequest) orchestrator.RunRequest {
+	t.Helper()
+
+	select {
+	case request := <-requests:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner request")
+	}
+
+	return orchestrator.RunRequest{}
+}
+
+func testIssue(id, identifier, state string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = identifier
+	issue.Title = "Port orchestrator"
+	issue.State = state
+	issue.URL = "https://github.com/digitaldrywood/symphony-go/issues/10"
+	return issue
+}
+
+type fakeConnector struct {
+	mu                  sync.Mutex
+	candidates          []connector.Issue
+	fetchCandidateCount int
+}
+
+func newFakeConnector(issues ...connector.Issue) *fakeConnector {
+	return &fakeConnector{candidates: cloneIssues(issues)}
+}
+
+func (c *fakeConnector) Name() string {
+	return "fake"
+}
+
+func (c *fakeConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.fetchCandidateCount++
+	return cloneIssues(c.candidates), nil
+}
+
+func (c *fakeConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return cloneIssues(c.candidates), nil
+}
+
+func (c *fakeConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	byID := make(map[string]connector.Issue, len(c.candidates))
+	for _, issue := range c.candidates {
+		byID[issue.ID] = issue
+	}
+
+	issues := make([]connector.Issue, 0, len(ids))
+	for _, id := range ids {
+		if issue, ok := byID[id]; ok {
+			issues = append(issues, issue)
+		}
+	}
+
+	return cloneIssues(issues), nil
+}
+
+func (c *fakeConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *fakeConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c *fakeConnector) fetchCandidateCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.fetchCandidateCount
+}
+
+type staticRunner struct {
+	calls  atomic.Int64
+	result orchestrator.RunResult
+	err    error
+}
+
+func (r *staticRunner) Run(context.Context, orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	r.calls.Add(1)
+	return r.result, r.err
+}
+
+type blockingRunner struct {
+	started chan orchestrator.RunRequest
+	release chan struct{}
+}
+
+func newBlockingRunner() *blockingRunner {
+	return &blockingRunner{
+		started: make(chan orchestrator.RunRequest, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (r *blockingRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	select {
+	case r.started <- request:
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+
+	select {
+	case <-r.release:
+		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+}
+
+type retryRunner struct {
+	calls        atomic.Int64
+	retryStarted chan orchestrator.RunRequest
+	release      chan struct{}
+}
+
+func newRetryRunner() *retryRunner {
+	return &retryRunner{
+		retryStarted: make(chan orchestrator.RunRequest, 1),
+		release:      make(chan struct{}),
+	}
+}
+
+func (r *retryRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	call := r.calls.Add(1)
+	if call == 1 {
+		return orchestrator.RunResult{}, errors.New("runner failed")
+	}
+
+	select {
+	case r.retryStarted <- request:
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+
+	select {
+	case <-r.release:
+		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+}
+
+func cloneIssues(issues []connector.Issue) []connector.Issue {
+	cloned := make([]connector.Issue, len(issues))
+	for i, issue := range issues {
+		cloned[i] = issue
+		cloned[i].BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
+		cloned[i].Labels = append([]string(nil), issue.Labels...)
+	}
+	return cloned
+}

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -1,0 +1,60 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestDispatchDueRetriesKeepsAttemptWhenCapacityIsFull(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:   1,
+		MaxRetryBackoff:       time.Minute,
+		FailureRetryBaseDelay: time.Second,
+		ActiveStates:          []string{"Todo"},
+		TerminalStates:        []string{"Done"},
+	})
+	orch := Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	now := time.Now()
+	running := retryTestIssue("running", "digitaldrywood/symphony-go#20")
+	retrying := retryTestIssue("retrying", "digitaldrywood/symphony-go#21")
+
+	state.Running[running.ID] = Running{Issue: running, StartedAt: now}
+	state.Claimed[retrying.ID] = Claimed{Issue: retrying, ClaimedAt: now.Add(-time.Minute)}
+	state.Retry[retrying.ID] = Retry{
+		Issue:   retrying,
+		Attempt: 2,
+		DueAt:   now.Add(-time.Millisecond),
+		Error:   "previous failure",
+	}
+
+	orch.dispatchDueRetries(context.Background(), &state, []connector.Issue{retrying}, now)
+
+	retry, ok := state.Retry[retrying.ID]
+	if !ok {
+		t.Fatalf("Retry[%q] missing after capacity refusal", retrying.ID)
+	}
+	if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 2", retrying.ID, retry.Attempt)
+	}
+	if retry.Error != "no available orchestrator slots" {
+		t.Fatalf("Retry[%q].Error = %q, want no available orchestrator slots", retrying.ID, retry.Error)
+	}
+	if !retry.DueAt.After(now) {
+		t.Fatalf("Retry[%q].DueAt = %s, want after %s", retrying.ID, retry.DueAt, now)
+	}
+}
+
+func retryTestIssue(id, identifier string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = identifier
+	issue.Title = "Retry issue"
+	issue.State = "Todo"
+	return issue
+}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -1,0 +1,35 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+)
+
+const FinalStateCompleted = "completed"
+
+type Runner interface {
+	Run(context.Context, RunRequest) (RunResult, error)
+}
+
+type RunRequest struct {
+	Issue     connector.Issue
+	Attempt   int
+	StartedAt time.Time
+}
+
+type RunResult struct {
+	FinalState    string
+	Tokens        CodexTotals
+	DiffStats     DiffStats
+	RateLimits    *telemetry.RateLimits
+	BudgetRefusal *BudgetRefusal
+}
+
+type FakeRunner struct{}
+
+func (FakeRunner) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{FinalState: FinalStateCompleted}, nil
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -1,0 +1,207 @@
+package orchestrator
+
+import (
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+)
+
+type State struct {
+	PollInterval        time.Duration
+	MaxConcurrentAgents int
+	Running             map[string]Running
+	Claimed             map[string]Claimed
+	Blocked             map[string]Blocked
+	Completed           map[string]Completed
+	Retry               map[string]Retry
+	BudgetRefusals      map[string]BudgetRefusal
+	DiffStats           map[string]DiffStats
+	CodexTotals         CodexTotals
+	RateLimits          *telemetry.RateLimits
+}
+
+type Running struct {
+	Issue     connector.Issue
+	Attempt   int
+	StartedAt time.Time
+}
+
+type Claimed struct {
+	Issue     connector.Issue
+	ClaimedAt time.Time
+}
+
+type Blocked struct {
+	Issue     connector.Issue
+	Reason    string
+	BlockedAt time.Time
+}
+
+type Completed struct {
+	Issue       connector.Issue
+	StartedAt   time.Time
+	CompletedAt time.Time
+	FinalState  string
+	Tokens      CodexTotals
+}
+
+type Retry struct {
+	Issue   connector.Issue
+	Attempt int
+	DueAt   time.Time
+	Error   string
+}
+
+type BudgetRefusal struct {
+	Issue            connector.Issue
+	Code             string
+	Message          string
+	CurrentSpendUSD  float64
+	ProjectedCostUSD float64
+	MaxUSD           *float64
+	ResetAt          *time.Time
+	RefusedAt        time.Time
+}
+
+type DiffStats struct {
+	FilesChanged int
+	AddedLines   int
+	RemovedLines int
+	Status       string
+}
+
+type CodexTotals struct {
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	RuntimeSeconds float64
+}
+
+func newState(cfg Config) State {
+	return State{
+		PollInterval:        cfg.PollInterval,
+		MaxConcurrentAgents: cfg.MaxConcurrentAgents,
+		Running:             map[string]Running{},
+		Claimed:             map[string]Claimed{},
+		Blocked:             map[string]Blocked{},
+		Completed:           map[string]Completed{},
+		Retry:               map[string]Retry{},
+		BudgetRefusals:      map[string]BudgetRefusal{},
+		DiffStats:           map[string]DiffStats{},
+	}
+}
+
+func (s State) clone() State {
+	cloned := State{
+		PollInterval:        s.PollInterval,
+		MaxConcurrentAgents: s.MaxConcurrentAgents,
+		Running:             make(map[string]Running, len(s.Running)),
+		Claimed:             make(map[string]Claimed, len(s.Claimed)),
+		Blocked:             make(map[string]Blocked, len(s.Blocked)),
+		Completed:           make(map[string]Completed, len(s.Completed)),
+		Retry:               make(map[string]Retry, len(s.Retry)),
+		BudgetRefusals:      make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
+		DiffStats:           make(map[string]DiffStats, len(s.DiffStats)),
+		CodexTotals:         s.CodexTotals,
+		RateLimits:          cloneRateLimits(s.RateLimits),
+	}
+
+	for id, running := range s.Running {
+		running.Issue = cloneIssue(running.Issue)
+		cloned.Running[id] = running
+	}
+	for id, claimed := range s.Claimed {
+		claimed.Issue = cloneIssue(claimed.Issue)
+		cloned.Claimed[id] = claimed
+	}
+	for id, blocked := range s.Blocked {
+		blocked.Issue = cloneIssue(blocked.Issue)
+		cloned.Blocked[id] = blocked
+	}
+	for id, completed := range s.Completed {
+		completed.Issue = cloneIssue(completed.Issue)
+		cloned.Completed[id] = completed
+	}
+	for id, retry := range s.Retry {
+		retry.Issue = cloneIssue(retry.Issue)
+		cloned.Retry[id] = retry
+	}
+	for id, refusal := range s.BudgetRefusals {
+		refusal.Issue = cloneIssue(refusal.Issue)
+		if refusal.MaxUSD != nil {
+			maxUSD := *refusal.MaxUSD
+			refusal.MaxUSD = &maxUSD
+		}
+		if refusal.ResetAt != nil {
+			resetAt := *refusal.ResetAt
+			refusal.ResetAt = &resetAt
+		}
+		cloned.BudgetRefusals[id] = refusal
+	}
+	for id, diffStats := range s.DiffStats {
+		cloned.DiffStats[id] = diffStats
+	}
+
+	return cloned
+}
+
+func cloneIssue(issue connector.Issue) connector.Issue {
+	cloned := issue
+	if issue.Priority != nil {
+		priority := *issue.Priority
+		cloned.Priority = &priority
+	}
+	if issue.CreatedAt != nil {
+		createdAt := *issue.CreatedAt
+		cloned.CreatedAt = &createdAt
+	}
+	if issue.UpdatedAt != nil {
+		updatedAt := *issue.UpdatedAt
+		cloned.UpdatedAt = &updatedAt
+	}
+	cloned.BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
+	cloned.Labels = append([]string(nil), issue.Labels...)
+	return cloned
+}
+
+func cloneRateLimits(rateLimits *telemetry.RateLimits) *telemetry.RateLimits {
+	if rateLimits == nil {
+		return nil
+	}
+
+	cloned := *rateLimits
+	cloned.Primary = cloneRateLimitBucket(rateLimits.Primary)
+	cloned.Secondary = cloneRateLimitBucket(rateLimits.Secondary)
+	cloned.Credits = cloneRateLimitBucket(rateLimits.Credits)
+	return &cloned
+}
+
+func cloneRateLimitBucket(bucket *telemetry.RateLimitBucket) *telemetry.RateLimitBucket {
+	if bucket == nil {
+		return nil
+	}
+
+	cloned := *bucket
+	if bucket.ResetAt != nil {
+		resetAt := *bucket.ResetAt
+		cloned.ResetAt = &resetAt
+	}
+	return &cloned
+}
+
+func addCodexTotals(left, right CodexTotals) CodexTotals {
+	return CodexTotals{
+		InputTokens:    left.InputTokens + right.InputTokens,
+		OutputTokens:   left.OutputTokens + right.OutputTokens,
+		TotalTokens:    left.TotalTokens + right.TotalTokens,
+		RuntimeSeconds: left.RuntimeSeconds + right.RuntimeSeconds,
+	}
+}
+
+func diffStatsPresent(diffStats DiffStats) bool {
+	return diffStats.FilesChanged != 0 ||
+		diffStats.AddedLines != 0 ||
+		diffStats.RemovedLines != 0 ||
+		diffStats.Status != ""
+}


### PR DESCRIPTION
## Summary
- add an internal orchestrator event loop backed by a `time.Ticker`
- add loop-owned State for running, claimed, blocked, completed, retry, budget refusals, diff stats, Codex totals, and rate limits
- add Runner/RunRequest/RunResult with a fake runner default for this port stage
- cover dispatch, snapshot, retry, blocked dependency, and defensive-copy behavior

Fixes #10

## Test Plan
- `go test -race ./internal/orchestrator`
- `go test ./...`
- `make check`