### PR TITLE
feat(codex): add app-server lifecycle

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -14,6 +14,7 @@ const (
 	initializeRequestID  = 1
 	threadStartRequestID = 2
 	turnStartRequestID   = 3
+	methodNotFoundCode   = -32601
 
 	defaultClientName    = "symphony-orchestrator"
 	defaultClientTitle   = "Symphony Orchestrator"
@@ -350,6 +351,13 @@ func (s *AppServer) awaitResponse(
 			return msg.Result, nil
 		}
 
+		handled, err := handleServerRequest(ctx, transport, msg)
+		if err != nil {
+			return nil, err
+		}
+		if handled {
+			continue
+		}
 		if err := maybeEmitUpdate(msg, onUpdate); err != nil {
 			return nil, err
 		}
@@ -361,6 +369,14 @@ func (s *AppServer) streamTurn(ctx context.Context, transport Transport, onUpdat
 		msg, err := receiveWithTimeout(ctx, transport, s.turnTimeout)
 		if err != nil {
 			return fmt.Errorf("stream turn: %w", err)
+		}
+
+		handled, err := handleServerRequest(ctx, transport, msg)
+		if err != nil {
+			return err
+		}
+		if handled {
+			continue
 		}
 
 		update, ok, err := updateFromMessage(msg)
@@ -394,6 +410,55 @@ func sendRequest(ctx context.Context, transport Transport, id int, method string
 		Method: method,
 		Params: data,
 	})
+}
+
+func handleServerRequest(ctx context.Context, transport Transport, msg Message) (bool, error) {
+	if msg.Method == "" || len(msg.ID) == 0 {
+		return false, nil
+	}
+
+	response := Message{
+		ID: msg.ID,
+	}
+	result, ok, err := serverRequestResult(msg.Method)
+	if err != nil {
+		return true, err
+	}
+	if ok {
+		response.Result = result
+	} else {
+		response.Error = &RPCError{
+			Code:    methodNotFoundCode,
+			Message: fmt.Sprintf("unsupported server request: %s", msg.Method),
+		}
+	}
+
+	if err := transport.Send(ctx, response); err != nil {
+		return true, fmt.Errorf("respond to codex server request %s: %w", msg.Method, err)
+	}
+	return true, nil
+}
+
+func serverRequestResult(method string) (json.RawMessage, bool, error) {
+	var result any
+	switch method {
+	case "item/commandExecution/requestApproval", "item/fileChange/requestApproval":
+		result = map[string]string{"decision": "decline"}
+	case "item/permissions/requestApproval":
+		result = map[string]any{"permissions": map[string]any{}}
+	case "item/tool/requestUserInput":
+		result = map[string]any{"answers": map[string]any{}}
+	case "mcpServer/elicitation/request":
+		result = map[string]any{"action": "decline", "content": nil}
+	default:
+		return nil, false, nil
+	}
+
+	data, err := json.Marshal(result)
+	if err != nil {
+		return nil, true, fmt.Errorf("marshal %s server request response: %w", method, err)
+	}
+	return data, true, nil
 }
 
 func maybeEmitUpdate(msg Message, onUpdate UpdateHandler) error {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -1,0 +1,630 @@
+package codex
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strconv"
+	"time"
+)
+
+const (
+	initializeRequestID  = 1
+	threadStartRequestID = 2
+	turnStartRequestID   = 3
+
+	defaultClientName    = "symphony-orchestrator"
+	defaultClientTitle   = "Symphony Orchestrator"
+	defaultClientVersion = "0.1.0"
+
+	defaultReadTimeout = 5 * time.Second
+	defaultTurnTimeout = time.Hour
+)
+
+var (
+	ErrResponseError   = errors.New("codex response error")
+	ErrInvalidResponse = errors.New("invalid codex response")
+	ErrTurnFailed      = errors.New("codex turn failed")
+)
+
+type AppServer struct {
+	transportFactory TransportFactory
+	clientInfo       ClientInfo
+	readTimeout      time.Duration
+	turnTimeout      time.Duration
+}
+
+type AppServerOption func(*AppServer)
+
+type ClientInfo struct {
+	Name    string `json:"name"`
+	Title   string `json:"title,omitempty"`
+	Version string `json:"version"`
+}
+
+type RunTurnRequest struct {
+	Workspace         string
+	Prompt            string
+	ApprovalPolicy    any
+	ThreadSandbox     string
+	TurnSandboxPolicy any
+	Model             string
+	ModelProvider     string
+	ServiceTier       string
+}
+
+type RunTurnResult struct {
+	ThreadID  string
+	TurnID    string
+	SessionID string
+}
+
+type UpdateHandler func(Update) error
+
+type UpdateType string
+
+const (
+	UpdateAgentMessageDelta UpdateType = "agent_message_delta"
+	UpdateTokenUsage        UpdateType = "token_usage"
+	UpdateRateLimits        UpdateType = "rate_limits"
+	UpdateTurnCompleted     UpdateType = "turn_completed"
+)
+
+type Update struct {
+	Type       UpdateType
+	Method     string
+	ThreadID   string
+	TurnID     string
+	ItemID     string
+	Delta      string
+	Status     string
+	Tokens     TokenUsage
+	RateLimits *RateLimitSnapshot
+	Payload    json.RawMessage
+}
+
+type TokenUsage struct {
+	InputTokens           int64
+	CachedInputTokens     int64
+	OutputTokens          int64
+	ReasoningOutputTokens int64
+	TotalTokens           int64
+	ModelContextWindow    *int64
+}
+
+type RateLimitSnapshot struct {
+	LimitID              string
+	LimitName            string
+	Primary              *RateLimitWindow
+	Secondary            *RateLimitWindow
+	Credits              *CreditsSnapshot
+	RateLimitReachedType string
+}
+
+type RateLimitWindow struct {
+	UsedPercent        float64
+	WindowDurationMins *float64
+	ResetsAt           *int64
+}
+
+type CreditsSnapshot struct {
+	HasCredits bool
+	Unlimited  bool
+	Balance    string
+}
+
+func NewAppServer(factory TransportFactory, opts ...AppServerOption) (*AppServer, error) {
+	if factory == nil {
+		return nil, errors.New("transport factory is nil")
+	}
+
+	server := &AppServer{
+		transportFactory: factory,
+		clientInfo: ClientInfo{
+			Name:    defaultClientName,
+			Title:   defaultClientTitle,
+			Version: defaultClientVersion,
+		},
+		readTimeout: defaultReadTimeout,
+		turnTimeout: defaultTurnTimeout,
+	}
+
+	for _, opt := range opts {
+		opt(server)
+	}
+	if server.clientInfo.Name == "" {
+		server.clientInfo.Name = defaultClientName
+	}
+	if server.clientInfo.Version == "" {
+		server.clientInfo.Version = defaultClientVersion
+	}
+	if server.readTimeout <= 0 {
+		server.readTimeout = defaultReadTimeout
+	}
+	if server.turnTimeout <= 0 {
+		server.turnTimeout = defaultTurnTimeout
+	}
+
+	return server, nil
+}
+
+func WithClientInfo(info ClientInfo) AppServerOption {
+	return func(server *AppServer) {
+		server.clientInfo = info
+	}
+}
+
+func WithReadTimeout(timeout time.Duration) AppServerOption {
+	return func(server *AppServer) {
+		server.readTimeout = timeout
+	}
+}
+
+func WithTurnTimeout(timeout time.Duration) AppServerOption {
+	return func(server *AppServer) {
+		server.turnTimeout = timeout
+	}
+}
+
+func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate UpdateHandler) (result RunTurnResult, err error) {
+	ctx = contextOrBackground(ctx)
+
+	transport, err := s.transportFactory.NewTransport(ctx)
+	if err != nil {
+		return RunTurnResult{}, fmt.Errorf("start codex app-server transport: %w", err)
+	}
+	defer func() {
+		closeErr := closeTransport(transport, s.readTimeout)
+		if err == nil && closeErr != nil {
+			err = closeErr
+		}
+	}()
+
+	if err := s.initialize(ctx, transport, onUpdate); err != nil {
+		return RunTurnResult{}, err
+	}
+
+	threadID, err := s.startThread(ctx, transport, req, onUpdate)
+	if err != nil {
+		return RunTurnResult{}, err
+	}
+
+	turnID, err := s.startTurn(ctx, transport, req, threadID, onUpdate)
+	if err != nil {
+		return RunTurnResult{}, err
+	}
+
+	result = RunTurnResult{
+		ThreadID:  threadID,
+		TurnID:    turnID,
+		SessionID: threadID + "-" + turnID,
+	}
+
+	if err := s.streamTurn(ctx, transport, onUpdate); err != nil {
+		return RunTurnResult{}, err
+	}
+
+	return result, nil
+}
+
+func (s *AppServer) initialize(ctx context.Context, transport Transport, onUpdate UpdateHandler) error {
+	params := map[string]any{
+		"capabilities": map[string]any{
+			"experimentalApi": true,
+		},
+		"clientInfo": s.clientInfo,
+	}
+
+	if err := sendRequest(ctx, transport, initializeRequestID, "initialize", params); err != nil {
+		return err
+	}
+	if _, err := s.awaitResponse(ctx, transport, initializeRequestID, onUpdate); err != nil {
+		return err
+	}
+
+	return transport.Send(ctx, Message{
+		Method: "initialized",
+		Params: json.RawMessage(`{}`),
+	})
+}
+
+func (s *AppServer) startThread(
+	ctx context.Context,
+	transport Transport,
+	req RunTurnRequest,
+	onUpdate UpdateHandler,
+) (string, error) {
+	params := map[string]any{
+		"cwd": req.Workspace,
+	}
+	setOptional(params, "approvalPolicy", req.ApprovalPolicy)
+	if req.ThreadSandbox != "" {
+		params["sandbox"] = req.ThreadSandbox
+	}
+	if req.Model != "" {
+		params["model"] = req.Model
+	}
+	if req.ModelProvider != "" {
+		params["modelProvider"] = req.ModelProvider
+	}
+	if req.ServiceTier != "" {
+		params["serviceTier"] = req.ServiceTier
+	}
+
+	if err := sendRequest(ctx, transport, threadStartRequestID, "thread/start", params); err != nil {
+		return "", err
+	}
+
+	result, err := s.awaitResponse(ctx, transport, threadStartRequestID, onUpdate)
+	if err != nil {
+		return "", err
+	}
+
+	var response struct {
+		Thread struct {
+			ID string `json:"id"`
+		} `json:"thread"`
+	}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return "", fmt.Errorf("%w: decode thread/start result: %w", ErrInvalidResponse, err)
+	}
+	if response.Thread.ID == "" {
+		return "", fmt.Errorf("%w: thread/start result missing thread id", ErrInvalidResponse)
+	}
+
+	return response.Thread.ID, nil
+}
+
+func (s *AppServer) startTurn(
+	ctx context.Context,
+	transport Transport,
+	req RunTurnRequest,
+	threadID string,
+	onUpdate UpdateHandler,
+) (string, error) {
+	params := map[string]any{
+		"threadId": threadID,
+		"input": []map[string]any{
+			{
+				"type":          "text",
+				"text":          req.Prompt,
+				"text_elements": []any{},
+			},
+		},
+		"cwd": req.Workspace,
+	}
+	setOptional(params, "approvalPolicy", req.ApprovalPolicy)
+	setOptional(params, "sandboxPolicy", req.TurnSandboxPolicy)
+	if req.Model != "" {
+		params["model"] = req.Model
+	}
+	if req.ServiceTier != "" {
+		params["serviceTier"] = req.ServiceTier
+	}
+
+	if err := sendRequest(ctx, transport, turnStartRequestID, "turn/start", params); err != nil {
+		return "", err
+	}
+
+	result, err := s.awaitResponse(ctx, transport, turnStartRequestID, onUpdate)
+	if err != nil {
+		return "", err
+	}
+
+	var response struct {
+		Turn struct {
+			ID string `json:"id"`
+		} `json:"turn"`
+	}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return "", fmt.Errorf("%w: decode turn/start result: %w", ErrInvalidResponse, err)
+	}
+	if response.Turn.ID == "" {
+		return "", fmt.Errorf("%w: turn/start result missing turn id", ErrInvalidResponse)
+	}
+
+	return response.Turn.ID, nil
+}
+
+func (s *AppServer) awaitResponse(
+	ctx context.Context,
+	transport Transport,
+	requestID int,
+	onUpdate UpdateHandler,
+) (json.RawMessage, error) {
+	for {
+		msg, err := receiveWithTimeout(ctx, transport, s.readTimeout)
+		if err != nil {
+			return nil, fmt.Errorf("wait for %s response: %w", requestName(requestID), err)
+		}
+
+		if requestIDMatches(msg.ID, requestID) {
+			if msg.Error != nil {
+				return nil, fmt.Errorf("%w: %s: %s", ErrResponseError, requestName(requestID), msg.Error.Message)
+			}
+			if len(msg.Result) == 0 {
+				return nil, fmt.Errorf("%w: %s response missing result", ErrInvalidResponse, requestName(requestID))
+			}
+			return msg.Result, nil
+		}
+
+		if err := maybeEmitUpdate(msg, onUpdate); err != nil {
+			return nil, err
+		}
+	}
+}
+
+func (s *AppServer) streamTurn(ctx context.Context, transport Transport, onUpdate UpdateHandler) error {
+	for {
+		msg, err := receiveWithTimeout(ctx, transport, s.turnTimeout)
+		if err != nil {
+			return fmt.Errorf("stream turn: %w", err)
+		}
+
+		update, ok, err := updateFromMessage(msg)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			continue
+		}
+		if err := emitUpdate(update, onUpdate); err != nil {
+			return err
+		}
+		if update.Type != UpdateTurnCompleted {
+			continue
+		}
+		if update.Status == "" || update.Status == "completed" {
+			return nil
+		}
+		return fmt.Errorf("%w: status %s", ErrTurnFailed, update.Status)
+	}
+}
+
+func sendRequest(ctx context.Context, transport Transport, id int, method string, params any) error {
+	data, err := json.Marshal(params)
+	if err != nil {
+		return fmt.Errorf("marshal %s params: %w", method, err)
+	}
+
+	return transport.Send(ctx, Message{
+		ID:     requestID(id),
+		Method: method,
+		Params: data,
+	})
+}
+
+func maybeEmitUpdate(msg Message, onUpdate UpdateHandler) error {
+	update, ok, err := updateFromMessage(msg)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return nil
+	}
+	return emitUpdate(update, onUpdate)
+}
+
+func emitUpdate(update Update, onUpdate UpdateHandler) error {
+	if onUpdate == nil {
+		return nil
+	}
+	if err := onUpdate(update); err != nil {
+		return fmt.Errorf("handle codex update: %w", err)
+	}
+	return nil
+}
+
+func updateFromMessage(msg Message) (Update, bool, error) {
+	switch msg.Method {
+	case "item/agentMessage/delta":
+		var params struct {
+			ThreadID string `json:"threadId"`
+			TurnID   string `json:"turnId"`
+			ItemID   string `json:"itemId"`
+			Delta    string `json:"delta"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return Update{}, false, fmt.Errorf("%w: decode agent message delta: %w", ErrInvalidResponse, err)
+		}
+		return Update{
+			Type:     UpdateAgentMessageDelta,
+			Method:   msg.Method,
+			ThreadID: params.ThreadID,
+			TurnID:   params.TurnID,
+			ItemID:   params.ItemID,
+			Delta:    params.Delta,
+			Payload:  rawPayload(msg),
+		}, true, nil
+	case "thread/tokenUsage/updated":
+		var params struct {
+			ThreadID   string `json:"threadId"`
+			TurnID     string `json:"turnId"`
+			TokenUsage struct {
+				Total              tokenUsageBreakdown `json:"total"`
+				ModelContextWindow *int64              `json:"modelContextWindow"`
+			} `json:"tokenUsage"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return Update{}, false, fmt.Errorf("%w: decode token usage: %w", ErrInvalidResponse, err)
+		}
+		return Update{
+			Type:     UpdateTokenUsage,
+			Method:   msg.Method,
+			ThreadID: params.ThreadID,
+			TurnID:   params.TurnID,
+			Tokens: TokenUsage{
+				InputTokens:           params.TokenUsage.Total.InputTokens,
+				CachedInputTokens:     params.TokenUsage.Total.CachedInputTokens,
+				OutputTokens:          params.TokenUsage.Total.OutputTokens,
+				ReasoningOutputTokens: params.TokenUsage.Total.ReasoningOutputTokens,
+				TotalTokens:           params.TokenUsage.Total.TotalTokens,
+				ModelContextWindow:    params.TokenUsage.ModelContextWindow,
+			},
+			Payload: rawPayload(msg),
+		}, true, nil
+	case "account/rateLimits/updated":
+		var params struct {
+			RateLimits rateLimitSnapshotPayload `json:"rateLimits"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return Update{}, false, fmt.Errorf("%w: decode rate limits: %w", ErrInvalidResponse, err)
+		}
+		return Update{
+			Type:       UpdateRateLimits,
+			Method:     msg.Method,
+			RateLimits: params.RateLimits.snapshot(),
+			Payload:    rawPayload(msg),
+		}, true, nil
+	case "turn/completed":
+		var params struct {
+			ThreadID string `json:"threadId"`
+			Turn     struct {
+				ID     string `json:"id"`
+				Status string `json:"status"`
+			} `json:"turn"`
+		}
+		if len(msg.Params) > 0 {
+			if err := json.Unmarshal(msg.Params, &params); err != nil {
+				return Update{}, false, fmt.Errorf("%w: decode turn completed: %w", ErrInvalidResponse, err)
+			}
+		}
+		return Update{
+			Type:     UpdateTurnCompleted,
+			Method:   msg.Method,
+			ThreadID: params.ThreadID,
+			TurnID:   params.Turn.ID,
+			Status:   params.Turn.Status,
+			Payload:  rawPayload(msg),
+		}, true, nil
+	default:
+		return Update{}, false, nil
+	}
+}
+
+type tokenUsageBreakdown struct {
+	InputTokens           int64 `json:"inputTokens"`
+	CachedInputTokens     int64 `json:"cachedInputTokens"`
+	OutputTokens          int64 `json:"outputTokens"`
+	ReasoningOutputTokens int64 `json:"reasoningOutputTokens"`
+	TotalTokens           int64 `json:"totalTokens"`
+}
+
+type rateLimitSnapshotPayload struct {
+	LimitID              string                  `json:"limitId"`
+	LimitName            string                  `json:"limitName"`
+	Primary              *rateLimitWindowPayload `json:"primary"`
+	Secondary            *rateLimitWindowPayload `json:"secondary"`
+	Credits              *creditsSnapshotPayload `json:"credits"`
+	RateLimitReachedType string                  `json:"rateLimitReachedType"`
+}
+
+type rateLimitWindowPayload struct {
+	UsedPercent        float64  `json:"usedPercent"`
+	WindowDurationMins *float64 `json:"windowDurationMins"`
+	ResetsAt           *int64   `json:"resetsAt"`
+}
+
+type creditsSnapshotPayload struct {
+	HasCredits bool   `json:"hasCredits"`
+	Unlimited  bool   `json:"unlimited"`
+	Balance    string `json:"balance"`
+}
+
+func (p rateLimitSnapshotPayload) snapshot() *RateLimitSnapshot {
+	return &RateLimitSnapshot{
+		LimitID:              p.LimitID,
+		LimitName:            p.LimitName,
+		Primary:              p.Primary.window(),
+		Secondary:            p.Secondary.window(),
+		Credits:              p.Credits.credits(),
+		RateLimitReachedType: p.RateLimitReachedType,
+	}
+}
+
+func (p *rateLimitWindowPayload) window() *RateLimitWindow {
+	if p == nil {
+		return nil
+	}
+	return &RateLimitWindow{
+		UsedPercent:        p.UsedPercent,
+		WindowDurationMins: p.WindowDurationMins,
+		ResetsAt:           p.ResetsAt,
+	}
+}
+
+func (p *creditsSnapshotPayload) credits() *CreditsSnapshot {
+	if p == nil {
+		return nil
+	}
+	return &CreditsSnapshot{
+		HasCredits: p.HasCredits,
+		Unlimited:  p.Unlimited,
+		Balance:    p.Balance,
+	}
+}
+
+func receiveWithTimeout(ctx context.Context, transport Transport, timeout time.Duration) (Message, error) {
+	ctx = contextOrBackground(ctx)
+	if timeout <= 0 {
+		return transport.Receive(ctx)
+	}
+
+	receiveCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	return transport.Receive(receiveCtx)
+}
+
+func setOptional(params map[string]any, key string, value any) {
+	if value == nil {
+		return
+	}
+	if raw, ok := value.(json.RawMessage); ok && len(raw) == 0 {
+		return
+	}
+	params[key] = value
+}
+
+func requestID(id int) json.RawMessage {
+	return json.RawMessage(strconv.Itoa(id))
+}
+
+func requestIDMatches(raw json.RawMessage, id int) bool {
+	return bytes.Equal(bytes.TrimSpace(raw), requestID(id))
+}
+
+func requestName(id int) string {
+	switch id {
+	case initializeRequestID:
+		return "initialize"
+	case threadStartRequestID:
+		return "thread/start"
+	case turnStartRequestID:
+		return "turn/start"
+	default:
+		return strconv.Itoa(id)
+	}
+}
+
+func rawPayload(msg Message) json.RawMessage {
+	data, err := json.Marshal(msg)
+	if err != nil {
+		return nil
+	}
+	return data
+}
+
+func closeTransport(transport Transport, timeout time.Duration) error {
+	ctx := context.Background()
+	if timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, timeout)
+		defer cancel()
+	}
+	if err := transport.Close(ctx); err != nil {
+		return fmt.Errorf("close codex app-server transport: %w", err)
+	}
+	return nil
+}

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -154,6 +154,51 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	}
 }
 
+func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1"}}`),
+		serverRequestMessage(t, 40, "item/tool/requestUserInput", `{"threadId":"thread-1","turnId":"turn-1"}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		serverRequestMessage(t, 41, "item/commandExecution/requestApproval", `{"threadId":"thread-1","turnId":"turn-1"}`),
+		serverRequestMessage(t, 42, "item/fileChange/requestApproval", `{"threadId":"thread-1","turnId":"turn-1"}`),
+		serverRequestMessage(t, 43, "item/permissions/requestApproval", `{"threadId":"thread-1","turnId":"turn-1"}`),
+		serverRequestMessage(t, 44, "mcpServer/elicitation/request", `{"threadId":"thread-1","turnId":"turn-1"}`),
+		serverRequestMessage(t, 45, "custom/request", `{"threadId":"thread-1","turnId":"turn-1"}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: "/tmp/symphony-workspace",
+		Prompt:    "Ship issue #18",
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	sent := transport.sentMessages()
+	if len(sent) != 10 {
+		t.Fatalf("sent messages = %d, want 10: %#v", len(sent), sent)
+	}
+
+	assertResponseResultContains(t, sent[4], 40, "answers", map[string]any{})
+	assertResponseResultContains(t, sent[5], 41, "decision", "decline")
+	assertResponseResultContains(t, sent[6], 42, "decision", "decline")
+	assertResponseResultContains(t, sent[7], 43, "permissions", map[string]any{})
+	assertResponseResultContains(t, sent[8], 44, "action", "decline")
+	assertResponseResultContains(t, sent[8], 44, "content", nil)
+	assertErrorResponse(t, sent[9], 45, methodNotFoundCode, "unsupported server request: custom/request")
+}
+
 func TestAppServerRunTurnReportsResponseErrors(t *testing.T) {
 	t.Parallel()
 
@@ -249,6 +294,14 @@ func notificationMessage(t *testing.T, method string, params string) Message {
 	}
 }
 
+func serverRequestMessage(t *testing.T, id int, method string, params string) Message {
+	t.Helper()
+
+	msg := notificationMessage(t, method, params)
+	msg.ID = json.RawMessage(mustMarshalJSON(t, id))
+	return msg
+}
+
 func assertRequest(t *testing.T, msg Message, id int, method string) {
 	t.Helper()
 
@@ -260,6 +313,42 @@ func assertRequest(t *testing.T, msg Message, id int, method string) {
 	}
 	if len(msg.Params) == 0 {
 		t.Fatalf("Params empty for %s", method)
+	}
+}
+
+func assertResponseResultContains(t *testing.T, msg Message, id int, path string, want any) {
+	t.Helper()
+
+	assertResponseID(t, msg, id)
+	if msg.Error != nil {
+		t.Fatalf("Error = %#v, want result", msg.Error)
+	}
+	if len(msg.Result) == 0 {
+		t.Fatalf("Result empty for response %d", id)
+	}
+	assertJSONContains(t, msg.Result, path, want)
+}
+
+func assertErrorResponse(t *testing.T, msg Message, id int, code int, message string) {
+	t.Helper()
+
+	assertResponseID(t, msg, id)
+	if msg.Error == nil {
+		t.Fatalf("Error = nil, want code %d", code)
+	}
+	if msg.Error.Code != code || msg.Error.Message != message {
+		t.Fatalf("Error = %#v, want code %d message %q", msg.Error, code, message)
+	}
+}
+
+func assertResponseID(t *testing.T, msg Message, id int) {
+	t.Helper()
+
+	if msg.Method != "" {
+		t.Fatalf("Method = %q, want response", msg.Method)
+	}
+	if string(msg.ID) != mustMarshalJSON(t, id) {
+		t.Fatalf("ID = %s, want %d", msg.ID, id)
 	}
 }
 

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -1,0 +1,335 @@
+package codex
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		notificationMessage(t, "item/agentMessage/delta", `{
+			"threadId":"thread-1",
+			"turnId":"turn-1",
+			"itemId":"item-1",
+			"delta":"hello"
+		}`),
+		notificationMessage(t, "thread/tokenUsage/updated", `{
+			"threadId":"thread-1",
+			"turnId":"turn-1",
+			"tokenUsage":{
+				"total":{
+					"inputTokens":20,
+					"cachedInputTokens":5,
+					"outputTokens":7,
+					"reasoningOutputTokens":3,
+					"totalTokens":27
+				},
+				"last":{
+					"inputTokens":2,
+					"cachedInputTokens":1,
+					"outputTokens":3,
+					"reasoningOutputTokens":1,
+					"totalTokens":5
+				},
+				"modelContextWindow":200000
+			}
+		}`),
+		notificationMessage(t, "account/rateLimits/updated", `{
+			"rateLimits":{
+				"limitId":"codex-primary",
+				"limitName":"Codex primary",
+				"primary":{
+					"usedPercent":12.5,
+					"windowDurationMins":300,
+					"resetsAt":1780000000
+				},
+				"secondary":null,
+				"credits":{
+					"hasCredits":true,
+					"unlimited":false,
+					"balance":"7.25"
+				},
+				"planType":null,
+				"rateLimitReachedType":null
+			}
+		}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithClientInfo(ClientInfo{
+			Name:    "symphony-test",
+			Title:   "Symphony Test",
+			Version: "0.1.0",
+		}),
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	var updates []Update
+	result, err := server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace:         "/tmp/symphony-workspace",
+		Prompt:            "Ship issue #18",
+		ApprovalPolicy:    json.RawMessage(`"never"`),
+		ThreadSandbox:     "workspace-write",
+		TurnSandboxPolicy: json.RawMessage(`{"type":"workspaceWrite","networkAccess":true}`),
+	}, func(update Update) error {
+		updates = append(updates, update)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	if result.ThreadID != "thread-1" || result.TurnID != "turn-1" || result.SessionID != "thread-1-turn-1" {
+		t.Fatalf("RunTurn() result = %#v", result)
+	}
+
+	sent := transport.sentMessages()
+	if len(sent) != 4 {
+		t.Fatalf("sent messages = %d, want 4", len(sent))
+	}
+
+	assertRequest(t, sent[0], 1, "initialize")
+	assertJSONContains(t, sent[0].Params, "clientInfo.name", "symphony-test")
+	assertJSONContains(t, sent[0].Params, "capabilities.experimentalApi", true)
+
+	if sent[1].Method != "initialized" || len(sent[1].ID) != 0 {
+		t.Fatalf("sent[1] = %#v, want initialized notification", sent[1])
+	}
+
+	assertRequest(t, sent[2], 2, "thread/start")
+	assertJSONContains(t, sent[2].Params, "cwd", "/tmp/symphony-workspace")
+	assertJSONContains(t, sent[2].Params, "approvalPolicy", "never")
+	assertJSONContains(t, sent[2].Params, "sandbox", "workspace-write")
+
+	assertRequest(t, sent[3], 3, "turn/start")
+	assertJSONContains(t, sent[3].Params, "threadId", "thread-1")
+	assertJSONContains(t, sent[3].Params, "input.0.type", "text")
+	assertJSONContains(t, sent[3].Params, "input.0.text", "Ship issue #18")
+	assertJSONContains(t, sent[3].Params, "cwd", "/tmp/symphony-workspace")
+	assertJSONContains(t, sent[3].Params, "approvalPolicy", "never")
+	assertJSONContains(t, sent[3].Params, "sandboxPolicy.type", "workspaceWrite")
+
+	if len(updates) != 4 {
+		t.Fatalf("updates = %d, want 4: %#v", len(updates), updates)
+	}
+	if updates[0].Type != UpdateAgentMessageDelta || updates[0].Delta != "hello" {
+		t.Fatalf("updates[0] = %#v, want agent message delta", updates[0])
+	}
+	if updates[1].Type != UpdateTokenUsage || updates[1].Tokens.TotalTokens != 27 {
+		t.Fatalf("updates[1] = %#v, want token usage total 27", updates[1])
+	}
+	if updates[1].Tokens.CachedInputTokens != 5 || updates[1].Tokens.ReasoningOutputTokens != 3 {
+		t.Fatalf("updates[1].Tokens = %#v", updates[1].Tokens)
+	}
+	if updates[1].Tokens.ModelContextWindow == nil || *updates[1].Tokens.ModelContextWindow != 200000 {
+		t.Fatalf("updates[1].Tokens.ModelContextWindow = %#v", updates[1].Tokens.ModelContextWindow)
+	}
+	if updates[2].Type != UpdateRateLimits || updates[2].RateLimits == nil {
+		t.Fatalf("updates[2] = %#v, want rate limits", updates[2])
+	}
+	if updates[2].RateLimits.LimitID != "codex-primary" || updates[2].RateLimits.Primary == nil {
+		t.Fatalf("updates[2].RateLimits = %#v", updates[2].RateLimits)
+	}
+	if updates[2].RateLimits.Primary.UsedPercent != 12.5 {
+		t.Fatalf("Primary.UsedPercent = %f, want 12.5", updates[2].RateLimits.Primary.UsedPercent)
+	}
+	if updates[3].Type != UpdateTurnCompleted || updates[3].TurnID != "turn-1" {
+		t.Fatalf("updates[3] = %#v, want turn completed", updates[3])
+	}
+}
+
+func TestAppServerRunTurnReportsResponseErrors(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		errorResponseMessage(t, 1, -32000, "initialize failed"),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport})
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: "/tmp/symphony-workspace",
+		Prompt:    "Ship issue #18",
+	}, nil)
+	if err == nil {
+		t.Fatal("RunTurn() error = nil, want response error")
+	}
+	if !errors.Is(err, ErrResponseError) {
+		t.Fatalf("RunTurn() error = %v, want ErrResponseError", err)
+	}
+}
+
+type staticTransportFactory struct {
+	transport Transport
+}
+
+func (f staticTransportFactory) NewTransport(context.Context) (Transport, error) {
+	return f.transport, nil
+}
+
+type fakeAppServerTransport struct {
+	received []Message
+	sent     []Message
+}
+
+func newFakeAppServerTransport(received []Message) *fakeAppServerTransport {
+	return &fakeAppServerTransport{received: append([]Message(nil), received...)}
+}
+
+func (t *fakeAppServerTransport) Send(_ context.Context, msg Message) error {
+	t.sent = append(t.sent, msg)
+	return nil
+}
+
+func (t *fakeAppServerTransport) Receive(context.Context) (Message, error) {
+	if len(t.received) == 0 {
+		return Message{}, io.EOF
+	}
+	msg := t.received[0]
+	t.received = t.received[1:]
+	return msg, nil
+}
+
+func (t *fakeAppServerTransport) Close(context.Context) error {
+	return nil
+}
+
+func (t *fakeAppServerTransport) sentMessages() []Message {
+	return append([]Message(nil), t.sent...)
+}
+
+func responseMessage(t *testing.T, id int, result string) Message {
+	t.Helper()
+
+	return Message{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(mustMarshalJSON(t, id)),
+		Result:  json.RawMessage(result),
+	}
+}
+
+func errorResponseMessage(t *testing.T, id int, code int, message string) Message {
+	t.Helper()
+
+	return Message{
+		JSONRPC: JSONRPCVersion,
+		ID:      json.RawMessage(mustMarshalJSON(t, id)),
+		Error: &RPCError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+func notificationMessage(t *testing.T, method string, params string) Message {
+	t.Helper()
+
+	return Message{
+		JSONRPC: JSONRPCVersion,
+		Method:  method,
+		Params:  json.RawMessage(params),
+	}
+}
+
+func assertRequest(t *testing.T, msg Message, id int, method string) {
+	t.Helper()
+
+	if msg.Method != method {
+		t.Fatalf("Method = %q, want %q", msg.Method, method)
+	}
+	if string(msg.ID) != mustMarshalJSON(t, id) {
+		t.Fatalf("ID = %s, want %d", msg.ID, id)
+	}
+	if len(msg.Params) == 0 {
+		t.Fatalf("Params empty for %s", method)
+	}
+}
+
+func assertJSONContains(t *testing.T, data json.RawMessage, path string, want any) {
+	t.Helper()
+
+	var decoded any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal JSON: %v", err)
+	}
+
+	got := lookupJSONPath(t, decoded, path)
+	if !jsonValuesEqual(got, want) {
+		t.Fatalf("%s = %#v, want %#v in %s", path, got, want, string(data))
+	}
+}
+
+func lookupJSONPath(t *testing.T, value any, path string) any {
+	t.Helper()
+
+	parts := strings.Split(path, ".")
+	current := value
+	for _, part := range parts {
+		switch node := current.(type) {
+		case map[string]any:
+			var ok bool
+			current, ok = node[part]
+			if !ok {
+				t.Fatalf("path %q missing key %q in %#v", path, part, value)
+			}
+		case []any:
+			index, err := strconv.Atoi(part)
+			if err != nil || index < 0 || index >= len(node) {
+				t.Fatalf("path %q invalid index %q in %#v", path, part, value)
+			}
+			current = node[index]
+		default:
+			t.Fatalf("path %q hit non-container %#v", path, current)
+		}
+	}
+
+	return current
+}
+
+func jsonValuesEqual(got any, want any) bool {
+	gotData, err := json.Marshal(got)
+	if err != nil {
+		return false
+	}
+	wantData, err := json.Marshal(want)
+	if err != nil {
+		return false
+	}
+	var gotCanonical any
+	if err := json.Unmarshal(gotData, &gotCanonical); err != nil {
+		return false
+	}
+	var wantCanonical any
+	if err := json.Unmarshal(wantData, &wantCanonical); err != nil {
+		return false
+	}
+	return reflect.DeepEqual(gotCanonical, wantCanonical)
+}
+
+func mustMarshalJSON(t *testing.T, value any) string {
+	t.Helper()
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal JSON: %v", err)
+	}
+	return string(data)
+}


### PR DESCRIPTION
## Summary
- Add an internal Codex app-server lifecycle client around the existing transport factory.
- Send initialize, initialized, thread/start, and turn/start with the required request IDs.
- Stream agent message deltas, token usage totals, rate limit snapshots, and turn completion as Update values.

Fixes #18

## Test Plan
- go test ./internal/codex
- make check