### PR TITLE
feat(connector/github): add auth client

### DIFF
--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -34,7 +34,6 @@ type localTransport struct {
 	received  chan transportResult
 	readDone  chan struct{}
 	done      chan struct{}
-	readDone  chan struct{}
 	sendLock  chan struct{}
 	waitErr   error
 	waitMu    sync.Mutex
@@ -86,7 +85,6 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		received: make(chan transportResult, 64),
 		readDone: make(chan struct{}),
 		done:     make(chan struct{}),
-		readDone: make(chan struct{}),
 		sendLock: make(chan struct{}, 1),
 	}
 	transport.sendLock <- struct{}{}
@@ -213,7 +211,6 @@ func (t *localTransport) closedError() error {
 func (t *localTransport) readLoop() {
 	defer close(t.readDone)
 	defer close(t.received)
-	defer close(t.readDone)
 
 	for {
 		msg, err := t.codec.ReadMessage()

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -34,6 +34,7 @@ type localTransport struct {
 	received  chan transportResult
 	readDone  chan struct{}
 	done      chan struct{}
+	readDone  chan struct{}
 	sendLock  chan struct{}
 	waitErr   error
 	waitMu    sync.Mutex
@@ -85,6 +86,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		received: make(chan transportResult, 64),
 		readDone: make(chan struct{}),
 		done:     make(chan struct{}),
+		readDone: make(chan struct{}),
 		sendLock: make(chan struct{}, 1),
 	}
 	transport.sendLock <- struct{}{}
@@ -211,6 +213,7 @@ func (t *localTransport) closedError() error {
 func (t *localTransport) readLoop() {
 	defer close(t.readDone)
 	defer close(t.received)
+	defer close(t.readDone)
 
 	for {
 		msg, err := t.codec.ReadMessage()

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/digitaldrywood/symphony-go/internal/connector"
+	githubconnector "github.com/digitaldrywood/symphony-go/internal/connector/github"
 	"github.com/digitaldrywood/symphony-go/internal/connector/memory"
 )
 
@@ -16,8 +17,15 @@ var (
 )
 
 type Config struct {
-	Kind   string
-	Memory memory.Config
+	Kind                    string
+	Memory                  memory.Config
+	Endpoint                string
+	APIKey                  string
+	GitHubAppID             string
+	GitHubAppPrivateKey     string
+	GitHubAppPrivateKeyPath string
+	GitHubAppInstallationID string
+	ProjectSlug             string
 }
 
 func NewFromConfig(cfg Config) (connector.Connector, error) {
@@ -26,8 +34,18 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 	switch connector.Backend(kind) {
 	case connector.BackendMemory:
 		return memory.New(cfg.Memory), nil
-	case connector.BackendLinear, connector.BackendGitHub:
+	case connector.BackendLinear:
 		return unimplementedConnector{name: kind}, nil
+	case connector.BackendGitHub:
+		return githubconnector.NewConnector(githubconnector.Config{
+			Endpoint:                cfg.Endpoint,
+			APIKey:                  cfg.APIKey,
+			GitHubAppID:             cfg.GitHubAppID,
+			GitHubAppPrivateKey:     cfg.GitHubAppPrivateKey,
+			GitHubAppPrivateKeyPath: cfg.GitHubAppPrivateKeyPath,
+			GitHubAppInstallationID: cfg.GitHubAppInstallationID,
+			ProjectSlug:             cfg.ProjectSlug,
+		})
 	case connector.BackendGitLab, connector.BackendJira:
 		return nil, fmt.Errorf("%w: %s", ErrBackendNotReady, kind)
 	default:

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -119,3 +119,15 @@ func TestFactoryPlaceholderConnectorOperationsAreExplicitlyUnimplemented(t *test
 		t.Fatalf("CreateComment() error = %v, want ErrNotImplemented", err)
 	}
 }
+
+func TestFactoryGitHubConnectorImplementsAuthenticator(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromConfig(Config{Kind: "github"})
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+	if _, ok := c.(connector.Authenticator); !ok {
+		t.Fatalf("connector = %T, want connector.Authenticator", c)
+	}
+}

--- a/internal/connector/github/app_token.go
+++ b/internal/connector/github/app_token.go
@@ -236,7 +236,7 @@ func installationTokenURL(endpoint string, installationID string) (string, error
 		return "", fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
 	}
 
-	basePath := parsed.Path
+	basePath := strings.TrimRight(parsed.Path, "/")
 	if parsed.Host == "api.github.com" {
 		basePath = ""
 	} else if strings.HasSuffix(basePath, "/api/graphql") {

--- a/internal/connector/github/app_token.go
+++ b/internal/connector/github/app_token.go
@@ -1,0 +1,296 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"crypto"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+const (
+	jwtBackdate        = 60 * time.Second
+	jwtLifetime        = 10 * time.Minute
+	tokenRefreshWindow = 5 * time.Minute
+)
+
+type InstallationTokenConfig struct {
+	Endpoint       string
+	AppID          string
+	InstallationID string
+	PrivateKey     string
+	PrivateKeyPath string
+	HTTPClient     HTTPClient
+	Now            func() time.Time
+	LookupEnv      func(string) string
+}
+
+type InstallationTokenSource struct {
+	endpoint       string
+	appID          string
+	installationID string
+	privateKey     string
+	httpClient     HTTPClient
+	now            func() time.Time
+	mu             sync.Mutex
+	cachedToken    string
+	expiresAt      time.Time
+}
+
+func NewInstallationTokenSource(cfg InstallationTokenConfig) (*InstallationTokenSource, error) {
+	lookupEnv := cfg.LookupEnv
+	if lookupEnv == nil {
+		lookupEnv = os.Getenv
+	}
+
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	if endpoint == "" {
+		endpoint = DefaultGraphQLEndpoint
+	}
+	if err := validateEndpoint(endpoint); err != nil {
+		return nil, err
+	}
+
+	appID := resolveSecretValue(cfg.AppID, lookupEnv)
+	installationID := resolveSecretValue(cfg.InstallationID, lookupEnv)
+	privateKey, err := privateKeyFromConfig(cfg, lookupEnv)
+	if err != nil {
+		return nil, err
+	}
+	if appID == "" || installationID == "" || privateKey == "" {
+		return nil, ErrMissingAppConfig
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+
+	return &InstallationTokenSource{
+		endpoint:       endpoint,
+		appID:          appID,
+		installationID: installationID,
+		privateKey:     normalizePrivateKey(privateKey),
+		httpClient:     httpClient,
+		now:            now,
+	}, nil
+}
+
+func (s *InstallationTokenSource) Token(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	now := s.now()
+	if s.cachedToken != "" && s.expiresAt.After(now.Add(tokenRefreshWindow)) {
+		return s.cachedToken, nil
+	}
+
+	jwt, err := s.jwt(now)
+	if err != nil {
+		return "", err
+	}
+
+	token, expiresAt, err := s.requestInstallationToken(ctx, jwt)
+	if err != nil {
+		return "", err
+	}
+	s.cachedToken = token
+	s.expiresAt = expiresAt
+
+	return token, nil
+}
+
+func (s *InstallationTokenSource) jwt(now time.Time) (string, error) {
+	header, err := jsonSegment(map[string]string{"alg": "RS256", "typ": "JWT"})
+	if err != nil {
+		return "", err
+	}
+	payload, err := jsonSegment(map[string]any{
+		"iat": now.Add(-jwtBackdate).Unix(),
+		"exp": now.Add(jwtLifetime).Unix(),
+		"iss": s.appID,
+	})
+	if err != nil {
+		return "", err
+	}
+
+	signingInput := header + "." + payload
+	signature, err := signJWT(signingInput, s.privateKey)
+	if err != nil {
+		return "", err
+	}
+
+	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
+}
+
+func (s *InstallationTokenSource) requestInstallationToken(ctx context.Context, jwt string) (string, time.Time, error) {
+	endpoint, err := installationTokenURL(s.endpoint, s.installationID)
+	if err != nil {
+		return "", time.Time{}, err
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte("{}")))
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+jwt)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", gitHubAPIVersion)
+
+	resp, err := s.httpClient.Do(req)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return "", time.Time{}, ctxErr
+		}
+		return "", time.Time{}, fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", time.Time{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
+	}
+
+	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
+		return "", time.Time{}, classifyStatus(resp.StatusCode, resp.Header, raw)
+	}
+
+	var decoded struct {
+		Token     string    `json:"token"`
+		ExpiresAt time.Time `json:"expires_at"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return "", time.Time{}, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
+	if strings.TrimSpace(decoded.Token) == "" || decoded.ExpiresAt.IsZero() {
+		return "", time.Time{}, ErrInvalidResponse
+	}
+
+	return decoded.Token, decoded.ExpiresAt, nil
+}
+
+func privateKeyFromConfig(cfg InstallationTokenConfig, lookupEnv func(string) string) (string, error) {
+	if privateKey := resolveSecretValue(cfg.PrivateKey, lookupEnv); privateKey != "" {
+		return privateKey, nil
+	}
+
+	path := resolveSecretValue(cfg.PrivateKeyPath, lookupEnv)
+	if path == "" {
+		return "", ErrMissingAppConfig
+	}
+
+	expanded, err := expandPath(path)
+	if err != nil {
+		return "", err
+	}
+	raw, err := os.ReadFile(expanded)
+	if err != nil {
+		return "", fmt.Errorf("%w: read private key: %w", ErrMissingAppConfig, err)
+	}
+	return string(raw), nil
+}
+
+func expandPath(path string) (string, error) {
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		path = filepath.Join(home, strings.TrimPrefix(path, "~/"))
+	}
+	return filepath.Abs(path)
+}
+
+func normalizePrivateKey(privateKey string) string {
+	return strings.ReplaceAll(privateKey, `\n`, "\n")
+}
+
+func installationTokenURL(endpoint string, installationID string) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+
+	basePath := parsed.Path
+	if parsed.Host == "api.github.com" {
+		basePath = ""
+	} else if strings.HasSuffix(basePath, "/api/graphql") {
+		basePath = strings.TrimSuffix(basePath, "/api/graphql") + "/api/v3"
+	} else if strings.HasSuffix(basePath, "/graphql") {
+		basePath = strings.TrimSuffix(basePath, "/graphql")
+	}
+
+	parsed.Path = strings.TrimRight(basePath, "/") + "/app/installations/" + url.PathEscape(installationID) + "/access_tokens"
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String(), nil
+}
+
+func jsonSegment(value any) (string, error) {
+	raw, err := json.Marshal(value)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(raw), nil
+}
+
+func signJWT(signingInput string, privateKey string) ([]byte, error) {
+	block, _ := pem.Decode([]byte(privateKey))
+	if block == nil {
+		return nil, ErrInvalidPrivateKey
+	}
+
+	key, err := parseRSAPrivateKey(block.Bytes)
+	if err != nil {
+		return nil, err
+	}
+
+	sum := sha256.Sum256([]byte(signingInput))
+	signature, err := rsa.SignPKCS1v15(rand.Reader, key, crypto.SHA256, sum[:])
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
+	}
+	return signature, nil
+}
+
+func parseRSAPrivateKey(raw []byte) (*rsa.PrivateKey, error) {
+	key, err := x509.ParsePKCS1PrivateKey(raw)
+	if err == nil {
+		return key, nil
+	}
+
+	parsed, err := x509.ParsePKCS8PrivateKey(raw)
+	if err != nil {
+		return nil, fmt.Errorf("%w: %w", ErrInvalidPrivateKey, err)
+	}
+	key, ok := parsed.(*rsa.PrivateKey)
+	if !ok {
+		return nil, ErrInvalidPrivateKey
+	}
+	return key, nil
+}

--- a/internal/connector/github/app_token_test.go
+++ b/internal/connector/github/app_token_test.go
@@ -1,0 +1,362 @@
+package github
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/json"
+	"encoding/pem"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestInstallationTokenSourceMintsAndCachesToken(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	privateKey := testPrivateKeyPEM(t)
+	var requests int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		atomic.AddInt64(&requests, 1)
+		if r.URL.Path != "/app/installations/987/access_tokens" {
+			t.Fatalf("path = %s, want installation token path", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); !strings.HasPrefix(got, "Bearer ") {
+			t.Fatalf("Authorization = %q, want JWT bearer", got)
+		}
+		jwt := strings.TrimPrefix(r.Header.Get("Authorization"), "Bearer ")
+		segments := strings.Split(jwt, ".")
+		if len(segments) != 3 {
+			t.Fatalf("JWT segments = %d, want 3", len(segments))
+		}
+		header := decodeJWTSegment(t, segments[0])
+		if header["alg"] != "RS256" {
+			t.Fatalf("JWT alg = %v, want RS256", header["alg"])
+		}
+		payload := decodeJWTSegment(t, segments[1])
+		if payload["iss"] != "123" {
+			t.Fatalf("JWT iss = %v, want 123", payload["iss"])
+		}
+		if payload["iat"] != float64(now.Unix()-60) {
+			t.Fatalf("JWT iat = %v, want %d", payload["iat"], now.Unix()-60)
+		}
+		if payload["exp"] != float64(now.Unix()+600) {
+			t.Fatalf("JWT exp = %v, want %d", payload["exp"], now.Unix()+600)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		response := map[string]string{
+			"token":      "installation-token",
+			"expires_at": now.Add(time.Hour).Format(time.RFC3339),
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	source, err := NewInstallationTokenSource(InstallationTokenConfig{
+		Endpoint:       server.URL + "/graphql",
+		AppID:          "123",
+		InstallationID: "987",
+		PrivateKey:     privateKey,
+		HTTPClient:     server.Client(),
+		Now:            func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewInstallationTokenSource() error = %v", err)
+	}
+
+	for i := 0; i < 2; i++ {
+		token, err := source.Token(context.Background())
+		if err != nil {
+			t.Fatalf("Token() error = %v", err)
+		}
+		if token != "installation-token" {
+			t.Fatalf("Token() = %q, want installation-token", token)
+		}
+	}
+
+	if got := atomic.LoadInt64(&requests); got != 1 {
+		t.Fatalf("requests = %d, want 1", got)
+	}
+}
+
+func TestInstallationTokenSourceRefreshesNearExpiry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	privateKey := testPrivateKeyPEM(t)
+	var requests int64
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		count := atomic.AddInt64(&requests, 1)
+		expiresAt := now.Add(5 * time.Minute)
+		if count > 1 {
+			expiresAt = now.Add(time.Hour)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		response := map[string]string{
+			"token":      "token-" + strconv.FormatInt(count, 10),
+			"expires_at": expiresAt.Format(time.RFC3339),
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	source, err := NewInstallationTokenSource(InstallationTokenConfig{
+		Endpoint:       server.URL + "/graphql",
+		AppID:          "123",
+		InstallationID: "987",
+		PrivateKey:     privateKey,
+		HTTPClient:     server.Client(),
+		Now:            func() time.Time { return now },
+	})
+	if err != nil {
+		t.Fatalf("NewInstallationTokenSource() error = %v", err)
+	}
+
+	first, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() first error = %v", err)
+	}
+	second, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() second error = %v", err)
+	}
+	if first != "token-1" || second != "token-2" {
+		t.Fatalf("tokens = %q, %q, want token-1, token-2", first, second)
+	}
+	if got := atomic.LoadInt64(&requests); got != 2 {
+		t.Fatalf("requests = %d, want 2", got)
+	}
+}
+
+func TestInstallationTokenSourceLoadsPrivateKeyPathAndGHESURL(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	privateKeyPath := filepath.Join(t.TempDir(), "app.pem")
+	if err := os.WriteFile(privateKeyPath, []byte(testPrivateKeyPEM(t)), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	requestPath := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestPath <- r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		response := map[string]string{
+			"token":      "path-token",
+			"expires_at": now.Add(time.Hour).Format(time.RFC3339),
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	source, err := NewInstallationTokenSource(InstallationTokenConfig{
+		Endpoint:       server.URL + "/api/graphql",
+		AppID:          "123",
+		InstallationID: "987",
+		PrivateKeyPath: "$PRIVATE_KEY_PATH",
+		HTTPClient:     server.Client(),
+		Now:            func() time.Time { return now },
+		LookupEnv: func(key string) string {
+			if key == "PRIVATE_KEY_PATH" {
+				return privateKeyPath
+			}
+			return ""
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewInstallationTokenSource() error = %v", err)
+	}
+
+	token, err := source.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "path-token" {
+		t.Fatalf("Token() = %q, want path-token", token)
+	}
+	if got := <-requestPath; got != "/api/v3/app/installations/987/access_tokens" {
+		t.Fatalf("request path = %q, want GHES REST path", got)
+	}
+}
+
+func TestInstallationTokenSourceReportsInvalidPrivateKey(t *testing.T) {
+	t.Parallel()
+
+	source, err := NewInstallationTokenSource(InstallationTokenConfig{
+		AppID:          "123",
+		InstallationID: "987",
+		PrivateKey:     "not a pem",
+	})
+	if err != nil {
+		t.Fatalf("NewInstallationTokenSource() error = %v", err)
+	}
+
+	_, err = source.Token(context.Background())
+	if !errors.Is(err, ErrInvalidPrivateKey) {
+		t.Fatalf("Token() error = %v, want ErrInvalidPrivateKey", err)
+	}
+}
+
+func TestTokenResolverUsesConfiguredGitHubApp(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	privateKey := testPrivateKeyPEM(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		response := map[string]string{
+			"token":      "app-token",
+			"expires_at": now.Add(time.Hour).Format(time.RFC3339),
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	resolver := NewTokenResolver(TokenResolverConfig{
+		Endpoint:                server.URL + "/graphql",
+		APIKey:                  "$GITHUB_TOKEN",
+		GitHubAppID:             "$APP_ID",
+		GitHubAppInstallationID: "$INSTALLATION_ID",
+		GitHubAppPrivateKey:     "$PRIVATE_KEY",
+		HTTPClient:              server.Client(),
+		Now:                     func() time.Time { return now },
+		LookupEnv: func(key string) string {
+			values := map[string]string{
+				"APP_ID":          "123",
+				"INSTALLATION_ID": "987",
+				"PRIVATE_KEY":     privateKey,
+				"GITHUB_TOKEN":    "pat-token",
+			}
+			return values[key]
+		},
+		GHToken: func(context.Context, string) (string, error) {
+			t.Fatal("gh token fallback should not run")
+			return "", nil
+		},
+	})
+
+	token, err := resolver.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "app-token" {
+		t.Fatalf("Token() = %q, want app-token", token)
+	}
+}
+
+func TestTokenResolverUsesGHTokenFallback(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewTokenResolver(TokenResolverConfig{
+		Endpoint: "https://api.github.com/graphql",
+		LookupEnv: func(string) string {
+			return ""
+		},
+		GHToken: func(_ context.Context, endpoint string) (string, error) {
+			if endpoint != "https://api.github.com/graphql" {
+				t.Fatalf("endpoint = %q, want default GitHub GraphQL endpoint", endpoint)
+			}
+			return "gh-token", nil
+		},
+	})
+
+	token, err := resolver.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "gh-token" {
+		t.Fatalf("Token() = %q, want gh-token", token)
+	}
+}
+
+func TestTokenResolverReportsMissingToken(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewTokenResolver(TokenResolverConfig{
+		LookupEnv: func(string) string {
+			return ""
+		},
+	})
+
+	_, err := resolver.Token(context.Background())
+	if !errors.Is(err, ErrMissingToken) {
+		t.Fatalf("Token() error = %v, want ErrMissingToken", err)
+	}
+}
+
+func TestTokenResolverFallsBackToPAT(t *testing.T) {
+	t.Parallel()
+
+	resolver := NewTokenResolver(TokenResolverConfig{
+		APIKey: "$GITHUB_TOKEN",
+		LookupEnv: func(key string) string {
+			if key == "GITHUB_TOKEN" {
+				return "pat-token"
+			}
+			return ""
+		},
+		GHToken: func(context.Context, string) (string, error) {
+			t.Fatal("gh token fallback should not run")
+			return "", nil
+		},
+	})
+
+	token, err := resolver.Token(context.Background())
+	if err != nil {
+		t.Fatalf("Token() error = %v", err)
+	}
+	if token != "pat-token" {
+		t.Fatalf("Token() = %q, want pat-token", token)
+	}
+}
+
+func testPrivateKeyPEM(t *testing.T) string {
+	t.Helper()
+
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	block := &pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)}
+	return string(pem.EncodeToMemory(block))
+}
+
+func decodeJWTSegment(t *testing.T, segment string) map[string]any {
+	t.Helper()
+
+	raw, err := base64.RawURLEncoding.DecodeString(segment)
+	if err != nil {
+		t.Fatalf("DecodeString() error = %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	return decoded
+}

--- a/internal/connector/github/app_token_test.go
+++ b/internal/connector/github/app_token_test.go
@@ -173,7 +173,7 @@ func TestInstallationTokenSourceLoadsPrivateKeyPathAndGHESURL(t *testing.T) {
 	t.Cleanup(server.Close)
 
 	source, err := NewInstallationTokenSource(InstallationTokenConfig{
-		Endpoint:       server.URL + "/api/graphql",
+		Endpoint:       server.URL + "/api/graphql/",
 		AppID:          "123",
 		InstallationID: "987",
 		PrivateKeyPath: "$PRIVATE_KEY_PATH",

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -1,0 +1,218 @@
+package github
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultGraphQLEndpoint = "https://api.github.com/graphql"
+	gitHubAPIVersion       = "2022-11-28"
+	maxErrorBodyBytes      = 1000
+)
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type ClientConfig struct {
+	Endpoint    string
+	TokenSource TokenSource
+	HTTPClient  HTTPClient
+	Logger      *slog.Logger
+}
+
+type Client struct {
+	endpoint    string
+	tokenSource TokenSource
+	httpClient  HTTPClient
+	logger      *slog.Logger
+}
+
+func NewClient(cfg ClientConfig) (*Client, error) {
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	if endpoint == "" {
+		endpoint = DefaultGraphQLEndpoint
+	}
+	if err := validateEndpoint(endpoint); err != nil {
+		return nil, err
+	}
+	if cfg.TokenSource == nil {
+		return nil, ErrMissingToken
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = &http.Client{Timeout: 30 * time.Second}
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	return &Client{
+		endpoint:    endpoint,
+		tokenSource: cfg.TokenSource,
+		httpClient:  httpClient,
+		logger:      logger,
+	}, nil
+}
+
+func (c *Client) GraphQL(ctx context.Context, query string, variables map[string]any, out any) error {
+	token, err := c.tokenSource.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve github token: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ErrMissingToken
+	}
+
+	payload := map[string]any{"query": query}
+	if variables != nil {
+		payload["variables"] = variables
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return fmt.Errorf("encode github graphql request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, &body)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-GitHub-Api-Version", gitHubAPIVersion)
+
+	c.logger.DebugContext(ctx, "github graphql request", "operation", firstLine(query))
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return classifyStatus(resp.StatusCode, resp.Header, raw)
+	}
+
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []GraphQLError  `json:"errors"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
+	if len(envelope.Errors) > 0 {
+		return classifyGraphQLErrors(envelope.Errors)
+	}
+	if out == nil {
+		return nil
+	}
+	if len(envelope.Data) == 0 {
+		return ErrInvalidResponse
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
+
+	return nil
+}
+
+func validateEndpoint(endpoint string) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	if parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%w: %s", ErrInvalidEndpoint, endpoint)
+	}
+	return nil
+}
+
+func classifyStatus(status int, headers http.Header, body []byte) error {
+	base := ErrUnexpectedStatus
+	switch {
+	case status == http.StatusUnauthorized:
+		base = ErrAuthenticationFailed
+	case status == http.StatusForbidden:
+		if headers.Get("X-RateLimit-Remaining") == "0" {
+			base = ErrRateLimited
+		} else {
+			base = ErrAuthenticationFailed
+		}
+	case status == http.StatusNotFound:
+		base = ErrNotFound
+	case status == http.StatusTooManyRequests:
+		base = ErrRateLimited
+	case status >= http.StatusInternalServerError:
+		base = ErrTransient
+	}
+
+	return &StatusError{
+		StatusCode: status,
+		Body:       summarizeBody(body),
+		Err:        base,
+	}
+}
+
+func classifyGraphQLErrors(errors []GraphQLError) error {
+	base := ErrGraphQLErrors
+	for _, err := range errors {
+		message := strings.ToLower(err.Message)
+		errorType := strings.ToUpper(err.Type)
+		switch {
+		case errorType == "RATE_LIMITED" || strings.Contains(message, "rate limit"):
+			base = ErrRateLimited
+		case errorType == "NOT_FOUND" || strings.Contains(message, "not found"):
+			base = ErrNotFound
+		case strings.Contains(message, "authentication") || strings.Contains(message, "bad credentials"):
+			base = ErrAuthenticationFailed
+		}
+	}
+
+	return &GraphQLErrorList{
+		Errors: errors,
+		Err:    base,
+	}
+}
+
+func summarizeBody(body []byte) string {
+	body = bytes.TrimSpace(body)
+	if len(body) <= maxErrorBodyBytes {
+		return string(body)
+	}
+	return string(body[:maxErrorBodyBytes]) + "...<truncated>"
+}
+
+func firstLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -1,0 +1,193 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestClientGraphQLSendsBearerRequest(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer test-token" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		if got := r.Header.Get("Accept"); got != "application/vnd.github+json" {
+			t.Fatalf("Accept = %q, want GitHub JSON media type", got)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("Content-Type = %q, want application/json", got)
+		}
+		if got := r.Header.Get("X-GitHub-Api-Version"); got != "2022-11-28" {
+			t.Fatalf("X-GitHub-Api-Version = %q, want 2022-11-28", got)
+		}
+
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		requests <- payload
+
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"octocat"}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var got struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+	}
+	err = client.GraphQL(context.Background(), "query Viewer($id: ID!) { viewer { login } }", map[string]any{"id": "PVT_1"}, &got)
+	if err != nil {
+		t.Fatalf("GraphQL() error = %v", err)
+	}
+	if got.Viewer.Login != "octocat" {
+		t.Fatalf("viewer.login = %q, want octocat", got.Viewer.Login)
+	}
+
+	payload := <-requests
+	if payload["query"] == "" {
+		t.Fatal("query payload is blank")
+	}
+	variables := payload["variables"].(map[string]any)
+	if variables["id"] != "PVT_1" {
+		t.Fatalf("variables.id = %v, want PVT_1", variables["id"])
+	}
+}
+
+func TestClientGraphQLClassifiesFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		statusCode int
+		headers    map[string]string
+		body       string
+		want       error
+	}{
+		{
+			name:       "unauthorized",
+			statusCode: http.StatusUnauthorized,
+			body:       `{"message":"bad credentials"}`,
+			want:       ErrAuthenticationFailed,
+		},
+		{
+			name:       "forbidden rate limit",
+			statusCode: http.StatusForbidden,
+			headers:    map[string]string{"X-RateLimit-Remaining": "0"},
+			body:       `{"message":"rate limit"}`,
+			want:       ErrRateLimited,
+		},
+		{
+			name:       "not found",
+			statusCode: http.StatusNotFound,
+			body:       `{"message":"not found"}`,
+			want:       ErrNotFound,
+		},
+		{
+			name:       "server error",
+			statusCode: http.StatusBadGateway,
+			body:       `{"message":"bad gateway"}`,
+			want:       ErrTransient,
+		},
+		{
+			name:       "graphql rate limit",
+			statusCode: http.StatusOK,
+			body:       `{"errors":[{"type":"RATE_LIMITED","message":"slow down"}]}`,
+			want:       ErrRateLimited,
+		},
+		{
+			name:       "graphql generic",
+			statusCode: http.StatusOK,
+			body:       `{"errors":[{"message":"field error"}]}`,
+			want:       ErrGraphQLErrors,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				for key, value := range tt.headers {
+					w.Header().Set(key, value)
+				}
+				w.WriteHeader(tt.statusCode)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := NewClient(ClientConfig{
+				Endpoint:    server.URL,
+				TokenSource: StaticTokenSource("test-token"),
+				HTTPClient:  server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			err = client.GraphQL(context.Background(), "query { viewer { login } }", nil, nil)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("GraphQL() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestClientGraphQLRejectsInvalidPayloads(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+	}{
+		{name: "invalid json", body: `{`},
+		{name: "missing data", body: `{}`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.WriteHeader(http.StatusOK)
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			client, err := NewClient(ClientConfig{
+				Endpoint:    server.URL,
+				TokenSource: StaticTokenSource("test-token"),
+				HTTPClient:  server.Client(),
+			})
+			if err != nil {
+				t.Fatalf("NewClient() error = %v", err)
+			}
+
+			var out map[string]any
+			err = client.GraphQL(context.Background(), "query { viewer { login } }", nil, &out)
+			if !errors.Is(err, ErrInvalidResponse) {
+				t.Fatalf("GraphQL() error = %v, want ErrInvalidResponse", err)
+			}
+		})
+	}
+}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -1,0 +1,128 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+const authenticateQuery = `
+query SymphonyGitHubAuthenticate($projectId: ID!) {
+  viewer { login }
+  node(id: $projectId) {
+    __typename
+    ... on ProjectV2 { id }
+  }
+}`
+
+type Config struct {
+	Endpoint                string
+	APIKey                  string
+	GitHubAppID             string
+	GitHubAppPrivateKey     string
+	GitHubAppPrivateKeyPath string
+	GitHubAppInstallationID string
+	ProjectSlug             string
+	TokenSource             TokenSource
+	HTTPClient              HTTPClient
+	Logger                  *slog.Logger
+	Now                     func() time.Time
+	LookupEnv               func(string) string
+	GHToken                 GHTokenFunc
+}
+
+type Connector struct {
+	client    *Client
+	projectID string
+}
+
+func NewConnector(cfg Config) (*Connector, error) {
+	tokenSource := cfg.TokenSource
+	if tokenSource == nil {
+		tokenSource = NewTokenResolver(TokenResolverConfig{
+			Endpoint:                cfg.Endpoint,
+			APIKey:                  cfg.APIKey,
+			GitHubAppID:             cfg.GitHubAppID,
+			GitHubAppPrivateKey:     cfg.GitHubAppPrivateKey,
+			GitHubAppPrivateKeyPath: cfg.GitHubAppPrivateKeyPath,
+			GitHubAppInstallationID: cfg.GitHubAppInstallationID,
+			HTTPClient:              cfg.HTTPClient,
+			Now:                     cfg.Now,
+			LookupEnv:               cfg.LookupEnv,
+			GHToken:                 cfg.GHToken,
+		})
+	}
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    cfg.Endpoint,
+		TokenSource: tokenSource,
+		HTTPClient:  cfg.HTTPClient,
+		Logger:      cfg.Logger,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &Connector{
+		client:    client,
+		projectID: strings.TrimSpace(cfg.ProjectSlug),
+	}, nil
+}
+
+func (c *Connector) Name() string {
+	return connector.BackendGitHub.String()
+}
+
+func (c *Connector) Authenticate(ctx context.Context) error {
+	if c.projectID == "" {
+		return ErrMissingProject
+	}
+
+	var response struct {
+		Viewer *struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+		Node *struct {
+			TypeName string `json:"__typename"`
+			ID       string `json:"id"`
+		} `json:"node"`
+	}
+	if err := c.client.GraphQL(ctx, authenticateQuery, map[string]any{"projectId": c.projectID}, &response); err != nil {
+		return fmt.Errorf("authenticate github connector: %w", err)
+	}
+	if response.Viewer == nil || strings.TrimSpace(response.Viewer.Login) == "" {
+		return ErrAuthenticationFailed
+	}
+	if response.Node == nil || response.Node.TypeName != "ProjectV2" || strings.TrimSpace(response.Node.ID) == "" {
+		return ErrProjectNotFound
+	}
+
+	return nil
+}
+
+func (*Connector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (*Connector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (*Connector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (*Connector) CreateComment(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (*Connector) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+var _ connector.Connector = (*Connector)(nil)
+var _ connector.Authenticator = (*Connector)(nil)

--- a/internal/connector/github/connector_test.go
+++ b/internal/connector/github/connector_test.go
@@ -1,0 +1,144 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestConnectorAuthenticateValidatesViewerAndProject(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan map[string]any, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		requests <- payload
+
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"octocat"},"node":{"__typename":"ProjectV2","id":"PVT_1"}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := NewConnector(Config{
+		Endpoint:    server.URL,
+		APIKey:      "token",
+		ProjectSlug: "PVT_1",
+		HTTPClient:  server.Client(),
+		GHToken: func(context.Context, string) (string, error) {
+			t.Fatal("gh token fallback should not run")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	if err := c.Authenticate(context.Background()); err != nil {
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+
+	payload := <-requests
+	variables := payload["variables"].(map[string]any)
+	if variables["projectId"] != "PVT_1" {
+		t.Fatalf("projectId = %v, want PVT_1", variables["projectId"])
+	}
+}
+
+func TestConnectorAuthenticateReportsProjectProblems(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		project string
+		body    string
+		want    error
+	}{
+		{
+			name:    "missing project",
+			project: "",
+			want:    ErrMissingProject,
+		},
+		{
+			name:    "project not found",
+			project: "PVT_missing",
+			body:    `{"data":{"viewer":{"login":"octocat"},"node":null}}`,
+			want:    ErrProjectNotFound,
+		},
+		{
+			name:    "wrong node type",
+			project: "I_kw1",
+			body:    `{"data":{"viewer":{"login":"octocat"},"node":{"__typename":"Issue","id":"I_kw1"}}}`,
+			want:    ErrProjectNotFound,
+		},
+		{
+			name:    "viewer missing",
+			project: "PVT_1",
+			body:    `{"data":{"viewer":null,"node":{"__typename":"ProjectV2","id":"PVT_1"}}}`,
+			want:    ErrAuthenticationFailed,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.body))
+			}))
+			t.Cleanup(server.Close)
+
+			c, err := NewConnector(Config{
+				Endpoint:    server.URL,
+				APIKey:      "token",
+				ProjectSlug: tt.project,
+				HTTPClient:  server.Client(),
+				GHToken: func(context.Context, string) (string, error) {
+					t.Fatal("gh token fallback should not run")
+					return "", nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewConnector() error = %v", err)
+			}
+
+			err = c.Authenticate(context.Background())
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Authenticate() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestConnectorOperationsRemainExplicitlyUnimplemented(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewConnector(Config{APIKey: "token"})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	if _, err := c.FetchCandidateIssues(context.Background()); !errors.Is(err, connector.ErrNotImplemented) {
+		t.Fatalf("FetchCandidateIssues() error = %v, want ErrNotImplemented", err)
+	}
+	if _, err := c.FetchIssuesByStates(context.Background(), []string{"Todo"}); !errors.Is(err, connector.ErrNotImplemented) {
+		t.Fatalf("FetchIssuesByStates() error = %v, want ErrNotImplemented", err)
+	}
+	if _, err := c.FetchIssueStatesByIDs(context.Background(), []string{"I_kw1"}); !errors.Is(err, connector.ErrNotImplemented) {
+		t.Fatalf("FetchIssueStatesByIDs() error = %v, want ErrNotImplemented", err)
+	}
+	if err := c.CreateComment(context.Background(), "I_kw1", "body"); !errors.Is(err, connector.ErrNotImplemented) {
+		t.Fatalf("CreateComment() error = %v, want ErrNotImplemented", err)
+	}
+	if err := c.UpdateIssueState(context.Background(), "I_kw1", "Done"); !errors.Is(err, connector.ErrNotImplemented) {
+		t.Fatalf("UpdateIssueState() error = %v, want ErrNotImplemented", err)
+	}
+}

--- a/internal/connector/github/errors.go
+++ b/internal/connector/github/errors.go
@@ -1,0 +1,72 @@
+package github
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrAuthenticationFailed = errors.New("github authentication failed")
+	ErrGraphQLErrors        = errors.New("github graphql errors")
+	ErrInvalidEndpoint      = errors.New("github endpoint is invalid")
+	ErrInvalidPrivateKey    = errors.New("github app private key is invalid")
+	ErrInvalidResponse      = errors.New("github response is invalid")
+	ErrMissingAppConfig     = errors.New("github app configuration is incomplete")
+	ErrMissingProject       = errors.New("github project is required")
+	ErrMissingToken         = errors.New("github token is required")
+	ErrNotFound             = errors.New("github resource not found")
+	ErrProjectNotFound      = errors.New("github project not found")
+	ErrRateLimited          = errors.New("github rate limited")
+	ErrTransient            = errors.New("github transient error")
+	ErrUnexpectedStatus     = errors.New("github unexpected status")
+)
+
+type GraphQLError struct {
+	Message string `json:"message"`
+	Type    string `json:"type"`
+}
+
+type GraphQLErrorList struct {
+	Errors []GraphQLError
+	Err    error
+}
+
+func (e *GraphQLErrorList) Error() string {
+	if len(e.Errors) == 0 {
+		return e.Err.Error()
+	}
+
+	messages := make([]string, 0, len(e.Errors))
+	for _, err := range e.Errors {
+		if strings.TrimSpace(err.Message) != "" {
+			messages = append(messages, err.Message)
+		}
+	}
+	if len(messages) == 0 {
+		return e.Err.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", e.Err, strings.Join(messages, "; "))
+}
+
+func (e *GraphQLErrorList) Unwrap() error {
+	return e.Err
+}
+
+type StatusError struct {
+	StatusCode int
+	Body       string
+	Err        error
+}
+
+func (e *StatusError) Error() string {
+	if strings.TrimSpace(e.Body) == "" {
+		return fmt.Sprintf("%s: status %d", e.Err, e.StatusCode)
+	}
+	return fmt.Sprintf("%s: status %d: %s", e.Err, e.StatusCode, e.Body)
+}
+
+func (e *StatusError) Unwrap() error {
+	return e.Err
+}

--- a/internal/connector/github/token.go
+++ b/internal/connector/github/token.go
@@ -1,0 +1,147 @@
+package github
+
+import (
+	"context"
+	"os"
+	"regexp"
+	"strings"
+	"sync"
+	"time"
+)
+
+var envNamePattern = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+type TokenSource interface {
+	Token(context.Context) (string, error)
+}
+
+type staticTokenSource string
+
+func StaticTokenSource(token string) TokenSource {
+	return staticTokenSource(token)
+}
+
+func (s staticTokenSource) Token(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	token := strings.TrimSpace(string(s))
+	if token == "" {
+		return "", ErrMissingToken
+	}
+	return token, nil
+}
+
+type GHTokenFunc func(context.Context, string) (string, error)
+
+type TokenResolverConfig struct {
+	Endpoint                string
+	APIKey                  string
+	GitHubAppID             string
+	GitHubAppPrivateKey     string
+	GitHubAppPrivateKeyPath string
+	GitHubAppInstallationID string
+	HTTPClient              HTTPClient
+	Now                     func() time.Time
+	LookupEnv               func(string) string
+	GHToken                 GHTokenFunc
+}
+
+type TokenResolver struct {
+	cfg       TokenResolverConfig
+	lookupEnv func(string) string
+	mu        sync.Mutex
+	app       *InstallationTokenSource
+}
+
+func NewTokenResolver(cfg TokenResolverConfig) *TokenResolver {
+	lookupEnv := cfg.LookupEnv
+	if lookupEnv == nil {
+		lookupEnv = os.Getenv
+	}
+	return &TokenResolver{
+		cfg:       cfg,
+		lookupEnv: lookupEnv,
+	}
+}
+
+func (r *TokenResolver) Token(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+
+	var appErr error
+	if r.hasGitHubAppCredentials() {
+		token, err := r.gitHubAppToken(ctx)
+		if err == nil && strings.TrimSpace(token) != "" {
+			return strings.TrimSpace(token), nil
+		}
+		appErr = err
+	}
+
+	if token := r.resolveSecret(r.cfg.APIKey); token != "" {
+		return token, nil
+	}
+	if token := strings.TrimSpace(r.lookupEnv("GITHUB_TOKEN")); token != "" {
+		return token, nil
+	}
+	if r.cfg.GHToken != nil {
+		token, err := r.cfg.GHToken(ctx, r.cfg.Endpoint)
+		if err == nil && strings.TrimSpace(token) != "" {
+			return strings.TrimSpace(token), nil
+		}
+	}
+
+	if appErr != nil {
+		return "", appErr
+	}
+	return "", ErrMissingToken
+}
+
+func (r *TokenResolver) gitHubAppToken(ctx context.Context) (string, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.app == nil {
+		app, err := NewInstallationTokenSource(InstallationTokenConfig{
+			Endpoint:       r.cfg.Endpoint,
+			AppID:          r.cfg.GitHubAppID,
+			InstallationID: r.cfg.GitHubAppInstallationID,
+			PrivateKey:     r.cfg.GitHubAppPrivateKey,
+			PrivateKeyPath: r.cfg.GitHubAppPrivateKeyPath,
+			HTTPClient:     r.cfg.HTTPClient,
+			Now:            r.cfg.Now,
+			LookupEnv:      r.lookupEnv,
+		})
+		if err != nil {
+			return "", err
+		}
+		r.app = app
+	}
+
+	return r.app.Token(ctx)
+}
+
+func (r *TokenResolver) hasGitHubAppCredentials() bool {
+	return r.resolveSecret(r.cfg.GitHubAppID) != "" &&
+		r.resolveSecret(r.cfg.GitHubAppInstallationID) != "" &&
+		(r.resolveSecret(r.cfg.GitHubAppPrivateKey) != "" || r.resolveSecret(r.cfg.GitHubAppPrivateKeyPath) != "")
+}
+
+func (r *TokenResolver) resolveSecret(value string) string {
+	return resolveSecretValue(value, r.lookupEnv)
+}
+
+func resolveSecretValue(value string, lookupEnv func(string) string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	if strings.HasPrefix(value, "$") {
+		name := strings.TrimPrefix(value, "$")
+		if envNamePattern.MatchString(name) {
+			return strings.TrimSpace(lookupEnv(name))
+		}
+	}
+	return value
+}


### PR DESCRIPTION
## Summary
- Add an internal GitHub Projects v2 GraphQL client with HTTP and GraphQL error classification.
- Add GitHub App installation token resolution with env-backed config, private-key path support, JWT signing, and token caching.
- Wire the factory to return a GitHub connector that implements Authenticate while keeping the five adapter operations explicitly unimplemented for #26.

Fixes #24

## Test Plan
- go test ./internal/connector/...
- make check