### PR TITLE
feat(budget): add dispatch caps

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -90,6 +90,8 @@ SELECT
   CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions
 FROM codex_sessions
-WHERE issue_id = ?
+WHERE issue_id = sqlc.arg(issue_id)
+   OR identifier = sqlc.arg(identifier)
+   OR issue_url = sqlc.arg(issue_url)
 GROUP BY COALESCE(model, '')
 ORDER BY COALESCE(model, '');

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -81,3 +81,15 @@ FROM codex_sessions
 WHERE substr(completed_at, 1, 10) = ?
 GROUP BY COALESCE(model, '')
 ORDER BY COALESCE(model, '');
+
+-- name: IssueTokenSpend :many
+SELECT
+  CAST(COALESCE(model, '') AS TEXT) AS model,
+  CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COUNT(*) AS INTEGER) AS sessions
+FROM codex_sessions
+WHERE issue_id = ?
+GROUP BY COALESCE(model, '')
+ORDER BY COALESCE(model, '');

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -1,0 +1,378 @@
+package budget
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/store"
+)
+
+type ReasonCode string
+
+const (
+	ReasonPerDayMaxUSD   ReasonCode = "per_day_max_usd"
+	ReasonPerIssueMaxUSD ReasonCode = "per_issue_max_usd"
+)
+
+var ErrMissingSpendStore = errors.New("budget spend store is required")
+
+type Config struct {
+	Enabled         bool
+	PerDayMaxUSD    float64
+	PerIssueMaxUSD  float64
+	RefusalCooldown time.Duration
+	PricingPath     string
+}
+
+type SpendStore interface {
+	DailyTokenSpend(context.Context, time.Time) (store.TokenSpend, error)
+	IssueTokenSpend(context.Context, string) (store.TokenSpend, error)
+}
+
+type Checker struct {
+	cfg     Config
+	spend   SpendStore
+	pricing PricingTable
+}
+
+type DispatchRequest struct {
+	IssueID    string
+	Identifier string
+	IssueURL   string
+	Model      string
+	Now        time.Time
+	Estimate   TokenEstimate
+}
+
+type TokenEstimate struct {
+	InputTokens  int64
+	OutputTokens int64
+	TotalTokens  int64
+	Sessions     int64
+}
+
+type Decision struct {
+	Allowed bool
+	Refusal *Refusal
+}
+
+type Refusal struct {
+	Code              ReasonCode
+	Message           string
+	IssueID           string
+	Identifier        string
+	IssueURL          string
+	Model             string
+	CurrentSpendUSD   float64
+	ProjectedCostUSD  float64
+	ProjectedSpendUSD float64
+	MaxUSD            *float64
+	ResetAt           *time.Time
+	RefusedAt         time.Time
+	CooldownUntil     time.Time
+	Cooldown          time.Duration
+}
+
+type TrackedRefusal struct {
+	Refusal Refusal
+	DueAt   time.Time
+}
+
+type RefusalTracker struct {
+	mu      sync.Mutex
+	entries map[string]TrackedRefusal
+}
+
+var defaultTokenEstimate = TokenEstimate{
+	InputTokens:  150_000,
+	OutputTokens: 20_000,
+	TotalTokens:  170_000,
+}
+
+func NewChecker(cfg Config, spend SpendStore, pricing PricingTable) *Checker {
+	if pricing == nil {
+		pricing = DefaultPricingTable()
+	}
+
+	return &Checker{
+		cfg:     cfg,
+		spend:   spend,
+		pricing: pricing,
+	}
+}
+
+func NewCheckerFromConfig(cfg Config, spend SpendStore) (*Checker, error) {
+	pricing, err := PricingForConfig(cfg)
+	if err != nil {
+		return nil, err
+	}
+	return NewChecker(cfg, spend, pricing), nil
+}
+
+func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decision, error) {
+	if !c.cfg.Enabled {
+		return Decision{Allowed: true}, nil
+	}
+
+	model := normalizeModel(req.Model)
+	modelPricing, ok := c.pricing.Lookup(model)
+	if !ok {
+		return Decision{Allowed: true}, nil
+	}
+
+	now := req.Now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	projectedCost := tokenCostUSD(req.Estimate.normalized(), modelPricing)
+	if capActive(c.cfg.PerDayMaxUSD) {
+		if missingSpendStore(c.spend) {
+			return Decision{}, ErrMissingSpendStore
+		}
+		dailySpend, err := c.spend.DailyTokenSpend(ctx, now)
+		if err != nil {
+			return Decision{}, fmt.Errorf("daily token spend: %w", err)
+		}
+		currentSpend := SpendUSD(dailySpend, c.pricing)
+		if currentSpend+projectedCost > c.cfg.PerDayMaxUSD {
+			return Decision{
+				Refusal: c.refusal(ReasonPerDayMaxUSD, req, now, currentSpend, projectedCost, c.cfg.PerDayMaxUSD, nextDailyReset(now)),
+			}, nil
+		}
+	}
+
+	if capActive(c.cfg.PerIssueMaxUSD) {
+		currentSpend := 0.0
+		if strings.TrimSpace(req.IssueID) != "" {
+			if missingSpendStore(c.spend) {
+				return Decision{}, ErrMissingSpendStore
+			}
+			issueSpend, err := c.spend.IssueTokenSpend(ctx, req.IssueID)
+			if err != nil {
+				return Decision{}, fmt.Errorf("issue token spend: %w", err)
+			}
+			currentSpend = SpendUSD(issueSpend, c.pricing)
+		}
+		if currentSpend+projectedCost > c.cfg.PerIssueMaxUSD {
+			return Decision{
+				Refusal: c.refusal(ReasonPerIssueMaxUSD, req, now, currentSpend, projectedCost, c.cfg.PerIssueMaxUSD, nil),
+			}, nil
+		}
+	}
+
+	return Decision{Allowed: true}, nil
+}
+
+func SpendUSD(spend store.TokenSpend, pricing PricingTable) float64 {
+	total := 0.0
+	for _, row := range spend.ByModel {
+		modelPricing, ok := pricing.Lookup(row.Model)
+		if !ok {
+			continue
+		}
+		total += tokenCostUSD(TokenEstimate{
+			InputTokens:  row.InputTokens,
+			OutputTokens: row.OutputTokens,
+			TotalTokens:  row.TotalTokens,
+			Sessions:     row.Sessions,
+		}, modelPricing)
+	}
+	return total
+}
+
+func FormatUSD(value float64) string {
+	return fmt.Sprintf("$%.2f", value)
+}
+
+func formatOptionalUSD(value *float64) string {
+	if value == nil {
+		return "n/a"
+	}
+	return FormatUSD(*value)
+}
+
+func NewRefusalTracker() *RefusalTracker {
+	return &RefusalTracker{
+		entries: map[string]TrackedRefusal{},
+	}
+}
+
+func (t *RefusalTracker) Record(refusal Refusal) (TrackedRefusal, bool) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.entries == nil {
+		t.entries = map[string]TrackedRefusal{}
+	}
+
+	key := refusalKey(refusal.IssueID, refusal.Identifier, refusal.IssueURL)
+	now := refusal.RefusedAt.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+		refusal.RefusedAt = now
+	}
+
+	if tracked, ok := t.entries[key]; ok && tracked.DueAt.After(now) {
+		return tracked, false
+	}
+
+	tracked := TrackedRefusal{
+		Refusal: refusal,
+		DueAt:   refusal.CooldownUntil.UTC(),
+	}
+	t.entries[key] = tracked
+	return tracked, true
+}
+
+func (t *RefusalTracker) CooldownActive(key string, now time.Time) bool {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if t.entries == nil {
+		return false
+	}
+
+	tracked, ok := t.entries[strings.TrimSpace(key)]
+	return ok && tracked.DueAt.After(now.UTC())
+}
+
+func (r Refusal) Comment() string {
+	max := formatOptionalUSD(r.MaxUSD)
+	projectedCost := FormatUSD(r.ProjectedCostUSD)
+	currentSpend := FormatUSD(r.CurrentSpendUSD)
+	projectedSpend := FormatUSD(r.ProjectedSpendUSD)
+	model := r.Model
+	if strings.TrimSpace(model) == "" {
+		model = "unknown"
+	}
+
+	switch r.Code {
+	case ReasonPerDayMaxUSD:
+		resetAt := "n/a"
+		if r.ResetAt != nil {
+			resetAt = r.ResetAt.UTC().Format(time.RFC3339)
+		}
+		return strings.TrimSpace(fmt.Sprintf(`
+Symphony refused to dispatch this issue because the projected dispatch would exceed the daily budget.
+
+Current daily spend: %s
+Projected dispatch cost: %s
+Projected daily spend: %s / %s
+Model: %s
+Daily budget resets at: %s
+This issue will be reconsidered after: %s
+`, currentSpend, projectedCost, projectedSpend, max, model, resetAt, r.CooldownUntil.UTC().Format(time.RFC3339)))
+	case ReasonPerIssueMaxUSD:
+		return strings.TrimSpace(fmt.Sprintf(`
+Symphony refused to dispatch this issue because the projected dispatch would exceed the per-issue budget.
+
+Current issue spend: %s
+Projected dispatch cost: %s
+Projected issue spend: %s / %s
+Model: %s
+The per-issue budget has no automatic reset.
+This issue will be reconsidered after: %s
+`, currentSpend, projectedCost, projectedSpend, max, model, r.CooldownUntil.UTC().Format(time.RFC3339)))
+	default:
+		return strings.TrimSpace(fmt.Sprintf(`
+Symphony refused to dispatch this issue because the budget check failed.
+
+Current spend: %s
+Projected dispatch cost: %s
+Projected spend: %s / %s
+Model: %s
+This issue will be reconsidered after: %s
+`, currentSpend, projectedCost, projectedSpend, max, model, r.CooldownUntil.UTC().Format(time.RFC3339)))
+	}
+}
+
+func (c *Checker) refusal(code ReasonCode, req DispatchRequest, now time.Time, currentSpend float64, projectedCost float64, cap float64, resetAt *time.Time) *Refusal {
+	message := "budget exceeded"
+	switch code {
+	case ReasonPerDayMaxUSD:
+		message = "daily budget exceeded"
+	case ReasonPerIssueMaxUSD:
+		message = "per-issue budget exceeded"
+	}
+
+	maxUSD := cap
+	projectedSpend := currentSpend + projectedCost
+	return &Refusal{
+		Code:              code,
+		Message:           message,
+		IssueID:           strings.TrimSpace(req.IssueID),
+		Identifier:        strings.TrimSpace(req.Identifier),
+		IssueURL:          strings.TrimSpace(req.IssueURL),
+		Model:             normalizeModel(req.Model),
+		CurrentSpendUSD:   currentSpend,
+		ProjectedCostUSD:  projectedCost,
+		ProjectedSpendUSD: projectedSpend,
+		MaxUSD:            &maxUSD,
+		ResetAt:           resetAt,
+		RefusedAt:         now,
+		CooldownUntil:     now.Add(c.cfg.RefusalCooldown),
+		Cooldown:          c.cfg.RefusalCooldown,
+	}
+}
+
+func (e TokenEstimate) normalized() TokenEstimate {
+	out := TokenEstimate{
+		InputTokens:  nonNegative(e.InputTokens),
+		OutputTokens: nonNegative(e.OutputTokens),
+		TotalTokens:  nonNegative(e.TotalTokens),
+		Sessions:     nonNegative(e.Sessions),
+	}
+	if out.InputTokens == 0 && out.OutputTokens == 0 && out.TotalTokens == 0 {
+		return defaultTokenEstimate
+	}
+	if out.TotalTokens == 0 {
+		out.TotalTokens = out.InputTokens + out.OutputTokens
+	}
+	return out
+}
+
+func tokenCostUSD(tokens TokenEstimate, pricing ModelPricing) float64 {
+	return float64(tokens.InputTokens)*pricing.USDPerInputToken +
+		float64(tokens.OutputTokens)*pricing.USDPerOutputToken
+}
+
+func capActive(cap float64) bool {
+	return cap > 0
+}
+
+func missingSpendStore(spend SpendStore) bool {
+	if spend == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(spend)
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}
+
+func nextDailyReset(now time.Time) *time.Time {
+	year, month, day := now.UTC().Date()
+	reset := time.Date(year, month, day+1, 0, 0, 0, 0, time.UTC)
+	return &reset
+}
+
+func nonNegative(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func refusalKey(values ...string) string {
+	for _, value := range values {
+		if trimmed := strings.TrimSpace(value); trimmed != "" {
+			return trimmed
+		}
+	}
+	return "unknown"
+}

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -31,7 +31,7 @@ type Config struct {
 
 type SpendStore interface {
 	DailyTokenSpend(context.Context, time.Time) (store.TokenSpend, error)
-	IssueTokenSpend(context.Context, string) (store.TokenSpend, error)
+	IssueTokenSpend(context.Context, store.IssueIdentity) (store.TokenSpend, error)
 }
 
 type Checker struct {
@@ -149,11 +149,16 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 
 	if capActive(c.cfg.PerIssueMaxUSD) {
 		currentSpend := 0.0
-		if strings.TrimSpace(req.IssueID) != "" {
+		identity := store.IssueIdentity{
+			IssueID:    req.IssueID,
+			Identifier: req.Identifier,
+			IssueURL:   req.IssueURL,
+		}
+		if issueIdentityPresent(identity) {
 			if missingSpendStore(c.spend) {
 				return Decision{}, ErrMissingSpendStore
 			}
-			issueSpend, err := c.spend.IssueTokenSpend(ctx, req.IssueID)
+			issueSpend, err := c.spend.IssueTokenSpend(ctx, identity)
 			if err != nil {
 				return Decision{}, fmt.Errorf("issue token spend: %w", err)
 			}
@@ -344,6 +349,12 @@ func tokenCostUSD(tokens TokenEstimate, pricing ModelPricing) float64 {
 
 func capActive(cap float64) bool {
 	return cap > 0
+}
+
+func issueIdentityPresent(identity store.IssueIdentity) bool {
+	return strings.TrimSpace(identity.IssueID) != "" ||
+		strings.TrimSpace(identity.Identifier) != "" ||
+		strings.TrimSpace(identity.IssueURL) != ""
 }
 
 func missingSpendStore(spend SpendStore) bool {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -1,0 +1,363 @@
+package budget
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/store"
+)
+
+func TestCheckerCheckDispatch(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	pricing := PricingTable{
+		"gpt-test": {
+			USDPerInputToken:  0.01,
+			USDPerOutputToken: 0.02,
+		},
+	}
+
+	tests := []struct {
+		name       string
+		cfg        Config
+		spend      *fakeSpendStore
+		req        DispatchRequest
+		wantCode   ReasonCode
+		wantSpend  float64
+		wantMax    float64
+		wantErr    string
+		wantAllow  bool
+		wantDaily  int
+		wantIssues int
+	}{
+		{
+			name:      "disabled budget allows without spend store",
+			cfg:       Config{},
+			req:       DispatchRequest{Model: "gpt-test", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
+			wantAllow: true,
+		},
+		{
+			name: "missing model pricing allows without spend lookup",
+			cfg: Config{
+				Enabled:      true,
+				PerDayMaxUSD: 0.01,
+			},
+			spend:     &fakeSpendStore{},
+			req:       DispatchRequest{Model: "missing-model", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
+			wantAllow: true,
+		},
+		{
+			name: "daily cap refuses when projection exceeds limit",
+			cfg: Config{
+				Enabled:         true,
+				PerDayMaxUSD:    1.0,
+				RefusalCooldown: time.Minute,
+			},
+			spend: &fakeSpendStore{
+				daily: store.TokenSpend{
+					ByModel: []store.ModelTokenSpend{
+						{Model: "gpt-test", InputTokens: 95},
+					},
+				},
+			},
+			req: DispatchRequest{
+				IssueID:    "issue-daily",
+				Identifier: "MT-DAILY",
+				Model:      "gpt-test",
+				Now:        now,
+				Estimate:   TokenEstimate{InputTokens: 10},
+			},
+			wantCode:  ReasonPerDayMaxUSD,
+			wantSpend: 1.05,
+			wantMax:   1.0,
+			wantDaily: 1,
+		},
+		{
+			name: "per issue cap refuses only matching issue spend",
+			cfg: Config{
+				Enabled:        true,
+				PerIssueMaxUSD: 0.5,
+			},
+			spend: &fakeSpendStore{
+				issues: map[string]store.TokenSpend{
+					"issue-expensive": {
+						ByModel: []store.ModelTokenSpend{
+							{Model: "gpt-test", InputTokens: 45},
+						},
+					},
+				},
+			},
+			req: DispatchRequest{
+				IssueID:  "issue-expensive",
+				Model:    "gpt-test",
+				Now:      now,
+				Estimate: TokenEstimate{InputTokens: 10},
+			},
+			wantCode:   ReasonPerIssueMaxUSD,
+			wantSpend:  0.55,
+			wantMax:    0.5,
+			wantIssues: 1,
+		},
+		{
+			name: "caps allow when projected spend is below limits",
+			cfg: Config{
+				Enabled:        true,
+				PerDayMaxUSD:   1.0,
+				PerIssueMaxUSD: 1.0,
+			},
+			spend: &fakeSpendStore{},
+			req: DispatchRequest{
+				IssueID:  "issue-under",
+				Model:    "gpt-test",
+				Now:      now,
+				Estimate: TokenEstimate{InputTokens: 10},
+			},
+			wantAllow:  true,
+			wantDaily:  1,
+			wantIssues: 1,
+		},
+		{
+			name: "enabled cap requires spend store",
+			cfg: Config{
+				Enabled:      true,
+				PerDayMaxUSD: 1.0,
+			},
+			req:     DispatchRequest{Model: "gpt-test", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
+			wantErr: "budget spend store is required",
+		},
+		{
+			name: "spend errors are wrapped",
+			cfg: Config{
+				Enabled:      true,
+				PerDayMaxUSD: 1.0,
+			},
+			spend: &fakeSpendStore{
+				dailyErr: errors.New("database unavailable"),
+			},
+			req:       DispatchRequest{Model: "gpt-test", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
+			wantErr:   "daily token spend",
+			wantDaily: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checker := NewChecker(tt.cfg, tt.spend, pricing)
+			decision, err := checker.CheckDispatch(ctx, tt.req)
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("CheckDispatch() error = %v, want containing %q", err, tt.wantErr)
+				}
+				if tt.spend != nil {
+					assertCallCounts(t, tt.spend, tt.wantDaily, tt.wantIssues)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("CheckDispatch() error = %v", err)
+			}
+
+			if decision.Allowed != tt.wantAllow {
+				t.Fatalf("Decision.Allowed = %v, want %v", decision.Allowed, tt.wantAllow)
+			}
+			if tt.wantCode == "" {
+				if decision.Refusal != nil {
+					t.Fatalf("Decision.Refusal = %#v, want nil", decision.Refusal)
+				}
+				if tt.spend != nil {
+					assertCallCounts(t, tt.spend, tt.wantDaily, tt.wantIssues)
+				}
+				return
+			}
+
+			if decision.Refusal == nil {
+				t.Fatal("Decision.Refusal = nil, want refusal")
+			}
+			refusal := *decision.Refusal
+			if refusal.Code != tt.wantCode {
+				t.Fatalf("Refusal.Code = %q, want %q", refusal.Code, tt.wantCode)
+			}
+			assertInDelta(t, refusal.ProjectedSpendUSD, tt.wantSpend)
+			if refusal.MaxUSD == nil {
+				t.Fatal("Refusal.MaxUSD = nil, want cap")
+			}
+			assertInDelta(t, *refusal.MaxUSD, tt.wantMax)
+			if refusal.RefusedAt != now {
+				t.Fatalf("Refusal.RefusedAt = %s, want %s", refusal.RefusedAt, now)
+			}
+			if refusal.CooldownUntil.Before(now) {
+				t.Fatalf("Refusal.CooldownUntil = %s, want at or after %s", refusal.CooldownUntil, now)
+			}
+
+			comment := refusal.Comment()
+			if !strings.Contains(comment, "Symphony refused to dispatch this issue") {
+				t.Fatalf("Refusal.Comment() = %q, want refusal explanation", comment)
+			}
+			if !strings.Contains(comment, FormatUSD(tt.wantSpend)) {
+				t.Fatalf("Refusal.Comment() = %q, want projected spend %s", comment, FormatUSD(tt.wantSpend))
+			}
+			if tt.spend != nil {
+				assertCallCounts(t, tt.spend, tt.wantDaily, tt.wantIssues)
+			}
+		})
+	}
+}
+
+func TestCheckerUsesDefaultEstimate(t *testing.T) {
+	t.Parallel()
+
+	checker := NewChecker(Config{
+		Enabled:      true,
+		PerDayMaxUSD: 0.01,
+	}, &fakeSpendStore{}, PricingTable{
+		"gpt-test": {
+			USDPerInputToken:  0.000001,
+			USDPerOutputToken: 0.000002,
+		},
+	})
+
+	decision, err := checker.CheckDispatch(context.Background(), DispatchRequest{
+		Model: "gpt-test",
+		Now:   time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC),
+	})
+	if err != nil {
+		t.Fatalf("CheckDispatch() error = %v", err)
+	}
+	if decision.Refusal == nil {
+		t.Fatal("Decision.Refusal = nil, want default estimate to exceed cap")
+	}
+	assertInDelta(t, decision.Refusal.ProjectedCostUSD, 0.19)
+}
+
+func TestRefusalTrackerRecordsOncePerCooldown(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 20, 12, 0, 0, 0, time.UTC)
+	tracker := NewRefusalTracker()
+	refusal := Refusal{
+		Code:          ReasonPerDayMaxUSD,
+		IssueID:       "issue-cooldown",
+		RefusedAt:     now,
+		CooldownUntil: now.Add(time.Hour),
+	}
+
+	first, shouldComment := tracker.Record(refusal)
+	if !shouldComment {
+		t.Fatal("first Record() shouldComment = false, want true")
+	}
+	if first.DueAt != now.Add(time.Hour) {
+		t.Fatalf("first DueAt = %s, want %s", first.DueAt, now.Add(time.Hour))
+	}
+	if !tracker.CooldownActive("issue-cooldown", now.Add(30*time.Minute)) {
+		t.Fatal("CooldownActive() = false, want true")
+	}
+
+	refusal.RefusedAt = now.Add(30 * time.Minute)
+	again, shouldComment := tracker.Record(refusal)
+	if shouldComment {
+		t.Fatal("second Record() shouldComment = true, want false")
+	}
+	if again.Refusal.RefusedAt != now {
+		t.Fatalf("second Record() RefusedAt = %s, want original %s", again.Refusal.RefusedAt, now)
+	}
+
+	refusal.RefusedAt = now.Add(time.Hour)
+	refusal.CooldownUntil = now.Add(2 * time.Hour)
+	third, shouldComment := tracker.Record(refusal)
+	if !shouldComment {
+		t.Fatal("third Record() shouldComment = false, want true after cooldown")
+	}
+	if third.DueAt != now.Add(2*time.Hour) {
+		t.Fatalf("third DueAt = %s, want %s", third.DueAt, now.Add(2*time.Hour))
+	}
+}
+
+func TestFormatUSD(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		value float64
+		want  string
+	}{
+		{value: 1, want: "$1.00"},
+		{value: 1.235, want: "$1.24"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+
+			if got := FormatUSD(tt.value); got != tt.want {
+				t.Fatalf("FormatUSD() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+
+	if got := formatOptionalUSD(nil); got != "n/a" {
+		t.Fatalf("formatOptionalUSD(nil) = %q, want n/a", got)
+	}
+}
+
+type fakeSpendStore struct {
+	daily        store.TokenSpend
+	dailyErr     error
+	issues       map[string]store.TokenSpend
+	issueErr     error
+	dailyCalls   int
+	issueCalls   int
+	issueLookups []string
+}
+
+func (s *fakeSpendStore) DailyTokenSpend(_ context.Context, day time.Time) (store.TokenSpend, error) {
+	s.dailyCalls++
+	if day.IsZero() {
+		return store.TokenSpend{}, errors.New("zero day")
+	}
+	if s.dailyErr != nil {
+		return store.TokenSpend{}, s.dailyErr
+	}
+	return s.daily, nil
+}
+
+func (s *fakeSpendStore) IssueTokenSpend(_ context.Context, issueID string) (store.TokenSpend, error) {
+	s.issueCalls++
+	s.issueLookups = append(s.issueLookups, issueID)
+	if s.issueErr != nil {
+		return store.TokenSpend{}, s.issueErr
+	}
+	if s.issues == nil {
+		return store.TokenSpend{}, nil
+	}
+	return s.issues[issueID], nil
+}
+
+func assertCallCounts(t *testing.T, spend *fakeSpendStore, wantDaily int, wantIssues int) {
+	t.Helper()
+
+	if spend.dailyCalls != wantDaily {
+		t.Fatalf("DailyTokenSpend calls = %d, want %d", spend.dailyCalls, wantDaily)
+	}
+	if spend.issueCalls != wantIssues {
+		t.Fatalf("IssueTokenSpend calls = %d, want %d", spend.issueCalls, wantIssues)
+	}
+}
+
+func assertInDelta(t *testing.T, got float64, want float64) {
+	t.Helper()
+
+	const tolerance = 0.000001
+	delta := got - want
+	if delta < 0 {
+		delta = -delta
+	}
+	if delta > tolerance {
+		t.Fatalf("value = %.12f, want %.12f", got, want)
+	}
+}

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -85,7 +85,7 @@ func TestCheckerCheckDispatch(t *testing.T) {
 			},
 			spend: &fakeSpendStore{
 				issues: map[string]store.TokenSpend{
-					"issue-expensive": {
+					"issue-expensive|MT-EXPENSIVE|https://example.com/issue-expensive": {
 						ByModel: []store.ModelTokenSpend{
 							{Model: "gpt-test", InputTokens: 45},
 						},
@@ -93,10 +93,38 @@ func TestCheckerCheckDispatch(t *testing.T) {
 				},
 			},
 			req: DispatchRequest{
-				IssueID:  "issue-expensive",
-				Model:    "gpt-test",
-				Now:      now,
-				Estimate: TokenEstimate{InputTokens: 10},
+				IssueID:    "issue-expensive",
+				Identifier: "MT-EXPENSIVE",
+				IssueURL:   "https://example.com/issue-expensive",
+				Model:      "gpt-test",
+				Now:        now,
+				Estimate:   TokenEstimate{InputTokens: 10},
+			},
+			wantCode:   ReasonPerIssueMaxUSD,
+			wantSpend:  0.55,
+			wantMax:    0.5,
+			wantIssues: 1,
+		},
+		{
+			name: "per issue cap uses identifier when issue id is missing",
+			cfg: Config{
+				Enabled:        true,
+				PerIssueMaxUSD: 0.5,
+			},
+			spend: &fakeSpendStore{
+				issues: map[string]store.TokenSpend{
+					"|MT-FALLBACK|": {
+						ByModel: []store.ModelTokenSpend{
+							{Model: "gpt-test", InputTokens: 45},
+						},
+					},
+				},
+			},
+			req: DispatchRequest{
+				Identifier: "MT-FALLBACK",
+				Model:      "gpt-test",
+				Now:        now,
+				Estimate:   TokenEstimate{InputTokens: 10},
 			},
 			wantCode:   ReasonPerIssueMaxUSD,
 			wantSpend:  0.55,
@@ -326,16 +354,16 @@ func (s *fakeSpendStore) DailyTokenSpend(_ context.Context, day time.Time) (stor
 	return s.daily, nil
 }
 
-func (s *fakeSpendStore) IssueTokenSpend(_ context.Context, issueID string) (store.TokenSpend, error) {
+func (s *fakeSpendStore) IssueTokenSpend(_ context.Context, identity store.IssueIdentity) (store.TokenSpend, error) {
 	s.issueCalls++
-	s.issueLookups = append(s.issueLookups, issueID)
+	s.issueLookups = append(s.issueLookups, issueKey(identity))
 	if s.issueErr != nil {
 		return store.TokenSpend{}, s.issueErr
 	}
 	if s.issues == nil {
 		return store.TokenSpend{}, nil
 	}
-	return s.issues[issueID], nil
+	return s.issues[issueKey(identity)], nil
 }
 
 func assertCallCounts(t *testing.T, spend *fakeSpendStore, wantDaily int, wantIssues int) {
@@ -360,4 +388,8 @@ func assertInDelta(t *testing.T, got float64, want float64) {
 	if delta > tolerance {
 		t.Fatalf("value = %.12f, want %.12f", got, want)
 	}
+}
+
+func issueKey(identity store.IssueIdentity) string {
+	return identity.IssueID + "|" + identity.Identifier + "|" + identity.IssueURL
 }

--- a/internal/budget/pricing.go
+++ b/internal/budget/pricing.go
@@ -1,0 +1,166 @@
+package budget
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const DefaultPricingPath = "priv/pricing/models.yaml"
+
+type ModelPricing struct {
+	USDPerInputToken  float64
+	USDPerOutputToken float64
+}
+
+type PricingTable map[string]ModelPricing
+
+func DefaultPricingTable() PricingTable {
+	return PricingTable{
+		"gpt-5.5": {
+			USDPerInputToken:  0.000005,
+			USDPerOutputToken: 0.000030,
+		},
+		"gpt-5.4": {
+			USDPerInputToken:  0.0000025,
+			USDPerOutputToken: 0.000015,
+		},
+		"gpt-5.4-mini": {
+			USDPerInputToken:  0.00000075,
+			USDPerOutputToken: 0.0000045,
+		},
+		"gpt-5.3-codex": {
+			USDPerInputToken:  0.00000175,
+			USDPerOutputToken: 0.000014,
+		},
+	}
+}
+
+func LoadPricing(path string) (PricingTable, error) {
+	if strings.TrimSpace(path) == "" {
+		return DefaultPricingTable(), nil
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read pricing file: %w", err)
+	}
+
+	pricing, err := DecodePricing(raw)
+	if err != nil {
+		return nil, fmt.Errorf("decode pricing file: %w", err)
+	}
+	return pricing, nil
+}
+
+func PricingForConfig(cfg Config) (PricingTable, error) {
+	path := strings.TrimSpace(cfg.PricingPath)
+	if path == "" || path == DefaultPricingPath {
+		return DefaultPricingTable(), nil
+	}
+	return LoadPricing(path)
+}
+
+func DecodePricing(raw []byte) (PricingTable, error) {
+	var decoded map[string]any
+	if err := yaml.Unmarshal(raw, &decoded); err != nil {
+		return nil, err
+	}
+
+	models := decoded
+	if value, ok := decoded["models"]; ok {
+		models = mapValue(value)
+	}
+
+	pricing := PricingTable{}
+	for model, row := range models {
+		model = normalizeModel(model)
+		if model == "" {
+			continue
+		}
+		modelPricing, ok := normalizePricingRow(row)
+		if !ok {
+			continue
+		}
+		pricing[model] = modelPricing
+	}
+	return pricing, nil
+}
+
+func (p PricingTable) Lookup(model string) (ModelPricing, bool) {
+	if p == nil {
+		p = DefaultPricingTable()
+	}
+
+	row, ok := p[normalizeModel(model)]
+	return row, ok
+}
+
+func normalizePricingRow(value any) (ModelPricing, bool) {
+	row := mapValue(value)
+	if row == nil {
+		return ModelPricing{}, false
+	}
+
+	input, inputOK := numericValue(row["usd_per_input_token"])
+	if !inputOK {
+		input, inputOK = perTokenFromMillion(row["input_usd_per_1m_tokens"])
+	}
+
+	output, outputOK := numericValue(row["usd_per_output_token"])
+	if !outputOK {
+		output, outputOK = perTokenFromMillion(row["output_usd_per_1m_tokens"])
+	}
+
+	if !inputOK || !outputOK || input < 0 || output < 0 {
+		return ModelPricing{}, false
+	}
+
+	return ModelPricing{
+		USDPerInputToken:  input,
+		USDPerOutputToken: output,
+	}, true
+}
+
+func perTokenFromMillion(value any) (float64, bool) {
+	number, ok := numericValue(value)
+	if !ok {
+		return 0, false
+	}
+	return number / 1_000_000, true
+}
+
+func mapValue(value any) map[string]any {
+	switch typed := value.(type) {
+	case map[string]any:
+		return typed
+	default:
+		return nil
+	}
+}
+
+func numericValue(value any) (float64, bool) {
+	switch typed := value.(type) {
+	case int:
+		return float64(typed), true
+	case int64:
+		return float64(typed), true
+	case float64:
+		return typed, true
+	case string:
+		number, err := strconv.ParseFloat(strings.TrimSpace(typed), 64)
+		if err != nil {
+			return 0, false
+		}
+		return number, true
+	default:
+		return 0, false
+	}
+}
+
+func normalizeModel(model string) string {
+	return strings.ToLower(strings.TrimSpace(model))
+}

--- a/internal/budget/pricing_test.go
+++ b/internal/budget/pricing_test.go
@@ -1,0 +1,106 @@
+package budget
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultPricingTable(t *testing.T) {
+	t.Parallel()
+
+	pricing := DefaultPricingTable()
+	row, ok := pricing.Lookup(" GPT-5.5 ")
+	if !ok {
+		t.Fatal("DefaultPricingTable().Lookup() ok = false, want true")
+	}
+	assertInDelta(t, row.USDPerInputToken, 0.000005)
+	assertInDelta(t, row.USDPerOutputToken, 0.000030)
+}
+
+func TestDecodePricing(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`
+models:
+  gpt-test:
+    input_usd_per_1m_tokens: "10000"
+    output_usd_per_1m_tokens: 20000
+  gpt-per-token:
+    usd_per_input_token: "0.01"
+    usd_per_output_token: 0.02
+  invalid-row: bad
+  missing-output:
+    usd_per_input_token: 0.01
+  negative:
+    usd_per_input_token: -0.01
+    usd_per_output_token: 0.02
+`)
+
+	pricing, err := DecodePricing(raw)
+	if err != nil {
+		t.Fatalf("DecodePricing() error = %v", err)
+	}
+
+	million, ok := pricing.Lookup("gpt-test")
+	if !ok {
+		t.Fatal("pricing.Lookup(gpt-test) ok = false, want true")
+	}
+	assertInDelta(t, million.USDPerInputToken, 0.01)
+	assertInDelta(t, million.USDPerOutputToken, 0.02)
+
+	perToken, ok := pricing.Lookup("GPT-PER-TOKEN")
+	if !ok {
+		t.Fatal("pricing.Lookup(GPT-PER-TOKEN) ok = false, want true")
+	}
+	assertInDelta(t, perToken.USDPerInputToken, 0.01)
+	assertInDelta(t, perToken.USDPerOutputToken, 0.02)
+
+	for _, model := range []string{"invalid-row", "missing-output", "negative"} {
+		if _, ok := pricing.Lookup(model); ok {
+			t.Fatalf("pricing.Lookup(%q) ok = true, want false", model)
+		}
+	}
+}
+
+func TestLoadPricing(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "models.yaml")
+	if err := os.WriteFile(path, []byte(`
+models:
+  gpt-file:
+    usd_per_input_token: 0.03
+    usd_per_output_token: 0.04
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	pricing, err := LoadPricing(path)
+	if err != nil {
+		t.Fatalf("LoadPricing() error = %v", err)
+	}
+	row, ok := pricing.Lookup("gpt-file")
+	if !ok {
+		t.Fatal("pricing.Lookup(gpt-file) ok = false, want true")
+	}
+	assertInDelta(t, row.USDPerInputToken, 0.03)
+	assertInDelta(t, row.USDPerOutputToken, 0.04)
+
+	if _, err := LoadPricing(filepath.Join(dir, "missing.yaml")); err == nil {
+		t.Fatal("LoadPricing(missing) error = nil, want error")
+	}
+}
+
+func TestPricingForConfigUsesEmbeddedDefaultPath(t *testing.T) {
+	t.Parallel()
+
+	pricing, err := PricingForConfig(Config{PricingPath: DefaultPricingPath})
+	if err != nil {
+		t.Fatalf("PricingForConfig() error = %v", err)
+	}
+	if _, ok := pricing.Lookup("gpt-5.5"); !ok {
+		t.Fatal("PricingForConfig(default).Lookup(gpt-5.5) ok = false, want true")
+	}
+}

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -281,6 +281,56 @@ func (q *Queries) GetSymphonyRun(ctx context.Context, id int64) (SymphonyRun, er
 	return i, err
 }
 
+const issueTokenSpend = `-- name: IssueTokenSpend :many
+SELECT
+  CAST(COALESCE(model, '') AS TEXT) AS model,
+  CAST(COALESCE(SUM(input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COUNT(*) AS INTEGER) AS sessions
+FROM codex_sessions
+WHERE issue_id = ?
+GROUP BY COALESCE(model, '')
+ORDER BY COALESCE(model, '')
+`
+
+type IssueTokenSpendRow struct {
+	Model        string `json:"model"`
+	InputTokens  int64  `json:"input_tokens"`
+	OutputTokens int64  `json:"output_tokens"`
+	TotalTokens  int64  `json:"total_tokens"`
+	Sessions     int64  `json:"sessions"`
+}
+
+func (q *Queries) IssueTokenSpend(ctx context.Context, issueID sql.NullString) ([]IssueTokenSpendRow, error) {
+	rows, err := q.db.QueryContext(ctx, issueTokenSpend, issueID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []IssueTokenSpendRow{}
+	for rows.Next() {
+		var i IssueTokenSpendRow
+		if err := rows.Scan(
+			&i.Model,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.TotalTokens,
+			&i.Sessions,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
 SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model
 FROM codex_sessions

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -289,10 +289,18 @@ SELECT
   CAST(COALESCE(SUM(total_tokens), 0) AS INTEGER) AS total_tokens,
   CAST(COUNT(*) AS INTEGER) AS sessions
 FROM codex_sessions
-WHERE issue_id = ?
+WHERE issue_id = ?1
+   OR identifier = ?2
+   OR issue_url = ?3
 GROUP BY COALESCE(model, '')
 ORDER BY COALESCE(model, '')
 `
+
+type IssueTokenSpendParams struct {
+	IssueID    sql.NullString `json:"issue_id"`
+	Identifier sql.NullString `json:"identifier"`
+	IssueUrl   sql.NullString `json:"issue_url"`
+}
 
 type IssueTokenSpendRow struct {
 	Model        string `json:"model"`
@@ -302,8 +310,8 @@ type IssueTokenSpendRow struct {
 	Sessions     int64  `json:"sessions"`
 }
 
-func (q *Queries) IssueTokenSpend(ctx context.Context, issueID sql.NullString) ([]IssueTokenSpendRow, error) {
-	rows, err := q.db.QueryContext(ctx, issueTokenSpend, issueID)
+func (q *Queries) IssueTokenSpend(ctx context.Context, arg IssueTokenSpendParams) ([]IssueTokenSpendRow, error) {
+	rows, err := q.db.QueryContext(ctx, issueTokenSpend, arg.IssueID, arg.Identifier, arg.IssueUrl)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -198,13 +198,17 @@ func (s *sqliteStore) DailyTokenSpend(ctx context.Context, day time.Time) (Token
 	return spend, nil
 }
 
-func (s *sqliteStore) IssueTokenSpend(ctx context.Context, issueID string) (TokenSpend, error) {
-	issueID = strings.TrimSpace(issueID)
-	if issueID == "" {
+func (s *sqliteStore) IssueTokenSpend(ctx context.Context, identity IssueIdentity) (TokenSpend, error) {
+	identity = normalizeIssueIdentity(identity)
+	if identity.IssueID == "" && identity.Identifier == "" && identity.IssueURL == "" {
 		return TokenSpend{ByModel: []ModelTokenSpend{}}, nil
 	}
 
-	rows, err := s.queries.IssueTokenSpend(ctx, sql.NullString{String: issueID, Valid: true})
+	rows, err := s.queries.IssueTokenSpend(ctx, sqlc.IssueTokenSpendParams{
+		IssueID:    nullString(identity.IssueID),
+		Identifier: nullString(identity.Identifier),
+		IssueUrl:   nullString(identity.IssueURL),
+	})
 	if err != nil {
 		return TokenSpend{}, fmt.Errorf("reading issue token spend: %w", err)
 	}
@@ -227,6 +231,14 @@ func (s *sqliteStore) IssueTokenSpend(ctx context.Context, issueID string) (Toke
 		spend.ByModel = append(spend.ByModel, modelSpend)
 	}
 	return spend, nil
+}
+
+func normalizeIssueIdentity(identity IssueIdentity) IssueIdentity {
+	return IssueIdentity{
+		IssueID:    strings.TrimSpace(identity.IssueID),
+		Identifier: strings.TrimSpace(identity.Identifier),
+		IssueURL:   strings.TrimSpace(identity.IssueURL),
+	}
 }
 
 func configureSQLite(ctx context.Context, db *sql.DB, busyTimeoutMillis int64) error {

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -198,6 +198,37 @@ func (s *sqliteStore) DailyTokenSpend(ctx context.Context, day time.Time) (Token
 	return spend, nil
 }
 
+func (s *sqliteStore) IssueTokenSpend(ctx context.Context, issueID string) (TokenSpend, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return TokenSpend{ByModel: []ModelTokenSpend{}}, nil
+	}
+
+	rows, err := s.queries.IssueTokenSpend(ctx, sql.NullString{String: issueID, Valid: true})
+	if err != nil {
+		return TokenSpend{}, fmt.Errorf("reading issue token spend: %w", err)
+	}
+
+	spend := TokenSpend{
+		ByModel: make([]ModelTokenSpend, 0, len(rows)),
+	}
+	for _, row := range rows {
+		modelSpend := ModelTokenSpend{
+			Model:        row.Model,
+			InputTokens:  row.InputTokens,
+			OutputTokens: row.OutputTokens,
+			TotalTokens:  row.TotalTokens,
+			Sessions:     row.Sessions,
+		}
+		spend.InputTokens += modelSpend.InputTokens
+		spend.OutputTokens += modelSpend.OutputTokens
+		spend.TotalTokens += modelSpend.TotalTokens
+		spend.Sessions += modelSpend.Sessions
+		spend.ByModel = append(spend.ByModel, modelSpend)
+	}
+	return spend, nil
+}
+
 func configureSQLite(ctx context.Context, db *sql.DB, busyTimeoutMillis int64) error {
 	if _, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA busy_timeout = %d", busyTimeoutMillis)); err != nil {
 		return fmt.Errorf("setting sqlite busy_timeout: %w", err)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -36,6 +36,7 @@ type StatsStore interface {
 	StartSession(context.Context, SessionStart) (int64, error)
 	FinishSession(context.Context, int64, SessionFinish) error
 	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
+	IssueTokenSpend(context.Context, string) (TokenSpend, error)
 }
 
 type RunStart struct {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -36,7 +36,7 @@ type StatsStore interface {
 	StartSession(context.Context, SessionStart) (int64, error)
 	FinishSession(context.Context, int64, SessionFinish) error
 	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
-	IssueTokenSpend(context.Context, string) (TokenSpend, error)
+	IssueTokenSpend(context.Context, IssueIdentity) (TokenSpend, error)
 }
 
 type RunStart struct {
@@ -87,6 +87,12 @@ type SessionFinish struct {
 	RuntimeSeconds int64
 	FinalState     string
 	Model          string
+}
+
+type IssueIdentity struct {
+	IssueID    string
+	Identifier string
+	IssueURL   string
 }
 
 type TokenSpend struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -230,7 +230,7 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				t.Fatalf("DailyTokenSpend().ByModel = %#v", spend.ByModel)
 			}
 
-			issueSpend, err := backend.IssueTokenSpend(ctx, "I_kwDOSskuwc8AAAABD42c3Q")
+			issueSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{IssueID: "I_kwDOSskuwc8AAAABD42c3Q"})
 			if err != nil {
 				t.Fatalf("IssueTokenSpend() error = %v", err)
 			}
@@ -239,6 +239,22 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 			}
 			if len(issueSpend.ByModel) != 1 || issueSpend.ByModel[0].Model != "gpt-5" {
 				t.Fatalf("IssueTokenSpend().ByModel = %#v", issueSpend.ByModel)
+			}
+
+			identifierSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{Identifier: "digitaldrywood/symphony-go#6"})
+			if err != nil {
+				t.Fatalf("IssueTokenSpend(identifier) error = %v", err)
+			}
+			if identifierSpend.TotalTokens != 125 {
+				t.Fatalf("IssueTokenSpend(identifier).TotalTokens = %d, want 125", identifierSpend.TotalTokens)
+			}
+
+			urlSpend, err := backend.IssueTokenSpend(ctx, IssueIdentity{IssueURL: "https://github.com/digitaldrywood/symphony-go/issues/6"})
+			if err != nil {
+				t.Fatalf("IssueTokenSpend(url) error = %v", err)
+			}
+			if urlSpend.TotalTokens != 125 {
+				t.Fatalf("IssueTokenSpend(url).TotalTokens = %d, want 125", urlSpend.TotalTokens)
 			}
 		})
 	}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -229,6 +229,17 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 			if len(spend.ByModel) != 1 || spend.ByModel[0].Model != "gpt-5" {
 				t.Fatalf("DailyTokenSpend().ByModel = %#v", spend.ByModel)
 			}
+
+			issueSpend, err := backend.IssueTokenSpend(ctx, "I_kwDOSskuwc8AAAABD42c3Q")
+			if err != nil {
+				t.Fatalf("IssueTokenSpend() error = %v", err)
+			}
+			if issueSpend.InputTokens != 100 || issueSpend.OutputTokens != 25 || issueSpend.TotalTokens != 125 || issueSpend.Sessions != 1 {
+				t.Fatalf("IssueTokenSpend() = %#v", issueSpend)
+			}
+			if len(issueSpend.ByModel) != 1 || issueSpend.ByModel[0].Model != "gpt-5" {
+				t.Fatalf("IssueTokenSpend().ByModel = %#v", issueSpend.ByModel)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary
- Add internal budget checker for daily and per-issue dispatch caps using token spend and projected cost.
- Add embedded default pricing with YAML override loading plus refusal comments and cooldown tracking.
- Add issue token spend support to StatsStore and regenerate sqlc output.

Fixes #14

## Test Plan
- go test ./internal/budget ./internal/store
- make check
