### PR TITLE
feat(workspace): parse git diff stat

### DIFF
--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -1,0 +1,81 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+)
+
+var (
+	diffStatFilesPattern   = regexp.MustCompile(`(\d+)\s+files?\s+changed`)
+	diffStatAddedPattern   = regexp.MustCompile(`(\d+)\s+insertions?\(\+\)`)
+	diffStatRemovedPattern = regexp.MustCompile(`(\d+)\s+deletions?\(-\)`)
+)
+
+type DiffStat struct {
+	Files   int `json:"files"`
+	Added   int `json:"added"`
+	Removed int `json:"removed"`
+}
+
+func (l *LocalGit) DiffStat(ctx context.Context, info Info, issue Issue) (DiffStat, error) {
+	normalized, err := l.normalizeInfo(info, issue)
+	if err != nil {
+		return DiffStat{}, err
+	}
+	return GitDiffStat(ctx, normalized.Path)
+}
+
+func GitDiffStat(ctx context.Context, workspacePath string) (DiffStat, error) {
+	if strings.TrimSpace(workspacePath) == "" {
+		return DiffStat{}, errors.New("workspace path is required")
+	}
+
+	output, err := runGitAt(ctx, workspacePath, "diff", "--stat", "HEAD")
+	if err != nil {
+		return DiffStat{}, fmt.Errorf("git diff stat: %w", err)
+	}
+	return ParseDiffStat(output)
+}
+
+func ParseDiffStat(output string) (DiffStat, error) {
+	summary := diffStatSummaryLine(output)
+	if summary == "" {
+		return DiffStat{}, nil
+	}
+	if !diffStatFilesPattern.MatchString(summary) {
+		return DiffStat{}, fmt.Errorf("parse git diff stat: missing file count in %q", summary)
+	}
+
+	return DiffStat{
+		Files:   parseDiffStatInt(diffStatFilesPattern, summary),
+		Added:   parseDiffStatInt(diffStatAddedPattern, summary),
+		Removed: parseDiffStatInt(diffStatRemovedPattern, summary),
+	}, nil
+}
+
+func diffStatSummaryLine(output string) string {
+	lines := strings.Split(output, "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := strings.TrimSpace(lines[i])
+		if line != "" {
+			return line
+		}
+	}
+	return ""
+}
+
+func parseDiffStatInt(pattern *regexp.Regexp, input string) int {
+	matches := pattern.FindStringSubmatch(input)
+	if len(matches) < 2 {
+		return 0
+	}
+	value, err := strconv.Atoi(matches[1])
+	if err != nil {
+		return 0
+	}
+	return value
+}

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
+	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -34,11 +36,75 @@ func GitDiffStat(ctx context.Context, workspacePath string) (DiffStat, error) {
 		return DiffStat{}, errors.New("workspace path is required")
 	}
 
-	output, err := runGitAt(ctx, workspacePath, "diff", "--stat", "HEAD")
+	output, err := gitDiffStatOutput(ctx, workspacePath)
 	if err != nil {
-		return DiffStat{}, fmt.Errorf("git diff stat: %w", err)
+		return DiffStat{}, err
 	}
 	return ParseDiffStat(output)
+}
+
+func gitDiffStatOutput(ctx context.Context, workspacePath string) (string, error) {
+	indexPath, err := gitIndexPath(ctx, workspacePath)
+	if err != nil {
+		return "", err
+	}
+	tempIndex, cleanup, err := copyGitIndex(indexPath)
+	if err != nil {
+		return "", err
+	}
+	defer cleanup()
+
+	env := []string{"GIT_INDEX_FILE=" + tempIndex}
+	if _, err := runGitAtWithEnv(ctx, workspacePath, env, "add", "--intent-to-add", "--", "."); err != nil {
+		return "", fmt.Errorf("git add intent to add: %w", err)
+	}
+	output, err := runGitAtWithEnv(ctx, workspacePath, env, "diff", "--stat", "HEAD")
+	if err != nil {
+		return "", fmt.Errorf("git diff stat: %w", err)
+	}
+	return output, nil
+}
+
+func gitIndexPath(ctx context.Context, workspacePath string) (string, error) {
+	output, err := runGitAt(ctx, workspacePath, "rev-parse", "--git-path", "index")
+	if err != nil {
+		return "", fmt.Errorf("git index path: %w", err)
+	}
+	indexPath := strings.TrimSpace(output)
+	if indexPath == "" {
+		return "", errors.New("git index path is empty")
+	}
+	if !filepath.IsAbs(indexPath) {
+		indexPath = filepath.Join(workspacePath, indexPath)
+	}
+	return filepath.Clean(indexPath), nil
+}
+
+func copyGitIndex(indexPath string) (string, func(), error) {
+	data, err := os.ReadFile(indexPath)
+	if err != nil {
+		return "", nil, fmt.Errorf("read git index: %w", err)
+	}
+	file, err := os.CreateTemp(filepath.Dir(indexPath), "symphony-index-*")
+	if err != nil {
+		return "", nil, fmt.Errorf("create temporary git index: %w", err)
+	}
+	tempIndex := file.Name()
+	cleanup := func() {
+		if err := os.Remove(tempIndex); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return
+		}
+	}
+	if _, err := file.Write(data); err != nil {
+		_ = file.Close()
+		cleanup()
+		return "", nil, fmt.Errorf("write temporary git index: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		cleanup()
+		return "", nil, fmt.Errorf("close temporary git index: %w", err)
+	}
+	return tempIndex, cleanup, nil
 }
 
 func ParseDiffStat(output string) (DiffStat, error) {

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -1,0 +1,113 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestParseDiffStat(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		output  string
+		want    DiffStat
+		wantErr bool
+	}{
+		{name: "empty", output: "", want: DiffStat{}},
+		{
+			name: "full stat output",
+			output: " README.md | 1 -\n added.txt | 2 ++\n" +
+				" 2 files changed, 2 insertions(+), 1 deletion(-)\n",
+			want: DiffStat{Files: 2, Added: 2, Removed: 1},
+		},
+		{
+			name:   "insertions only",
+			output: " 1 file changed, 5 insertions(+)\n",
+			want:   DiffStat{Files: 1, Added: 5},
+		},
+		{
+			name:   "deletions only",
+			output: " 3 files changed, 8 deletions(-)\n",
+			want:   DiffStat{Files: 3, Removed: 8},
+		},
+		{
+			name:   "no line changes",
+			output: " 1 file changed\n",
+			want:   DiffStat{Files: 1},
+		},
+		{
+			name:    "malformed",
+			output:  "not a diff stat\n",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := ParseDiffStat(tt.output)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("ParseDiffStat() error = nil, want error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseDiffStat() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ParseDiffStat() = %+v, want %+v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLocalGitDiffStat(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), Issue{Identifier: "DD-DIFF"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	clean, err := backend.DiffStat(context.Background(), info, Issue{Identifier: "DD-DIFF"})
+	if err != nil {
+		t.Fatalf("clean DiffStat() error = %v", err)
+	}
+	if clean != (DiffStat{}) {
+		t.Fatalf("clean DiffStat() = %+v, want zero", clean)
+	}
+
+	if err := os.WriteFile(filepath.Join(info.Path, "added.txt"), []byte("first\nsecond\n"), 0o600); err != nil {
+		t.Fatalf("write added file: %v", err)
+	}
+	runGit(t, info.Path, "add", "added.txt")
+	if err := os.Remove(filepath.Join(info.Path, "README.md")); err != nil {
+		t.Fatalf("remove README.md: %v", err)
+	}
+
+	got, err := backend.DiffStat(context.Background(), info, Issue{Identifier: "DD-DIFF"})
+	if err != nil {
+		t.Fatalf("DiffStat() error = %v", err)
+	}
+	want := DiffStat{Files: 2, Added: 2, Removed: 1}
+	if got != want {
+		t.Fatalf("DiffStat() = %+v, want %+v", got, want)
+	}
+}

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -97,7 +98,6 @@ func TestLocalGitDiffStat(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(info.Path, "added.txt"), []byte("first\nsecond\n"), 0o600); err != nil {
 		t.Fatalf("write added file: %v", err)
 	}
-	runGit(t, info.Path, "add", "added.txt")
 	if err := os.Remove(filepath.Join(info.Path, "README.md")); err != nil {
 		t.Fatalf("remove README.md: %v", err)
 	}
@@ -109,5 +109,10 @@ func TestLocalGitDiffStat(t *testing.T) {
 	want := DiffStat{Files: 2, Added: 2, Removed: 1}
 	if got != want {
 		t.Fatalf("DiffStat() = %+v, want %+v", got, want)
+	}
+
+	status := runGit(t, info.Path, "status", "--short")
+	if !strings.Contains(status, "?? added.txt") {
+		t.Fatalf("git status = %q, want added.txt to remain untracked", status)
 	}
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -32,6 +32,7 @@ type Backend interface {
 	Cleanup(context.Context, string) error
 	BeforeRun(context.Context, Info, Issue) error
 	AfterRun(context.Context, Info, Issue)
+	DiffStat(context.Context, Info, Issue) (DiffStat, error)
 }
 
 type Issue struct {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -462,9 +462,16 @@ func (l *LocalGit) runGit(ctx context.Context, args ...string) (string, error) {
 }
 
 func runGitAt(ctx context.Context, dir string, args ...string) (string, error) {
+	return runGitAtWithEnv(ctx, dir, nil, args...)
+}
+
+func runGitAtWithEnv(ctx context.Context, dir string, env []string, args ...string) (string, error) {
 	gitArgs := append([]string{"git", "-C", dir}, args...)
 	cmd := exec.CommandContext(ctx, "git")
 	cmd.Args = gitArgs
+	if len(env) > 0 {
+		cmd.Env = append(os.Environ(), env...)
+	}
 	output, err := cmd.CombinedOutput()
 	if err == nil {
 		return string(output), nil


### PR DESCRIPTION
## Summary
- Add workspace diffstat parsing for `git diff --stat HEAD` output.
- Expose diff stats through the workspace backend interface for future runner use.
- Cover parser cases and real git worktree changes with stdlib tests.

Fixes #20

## Test Plan
- `go test ./internal/workspace`
- `make check`