### PR TITLE
feat(runner): add prompt context loaders

### DIFF
--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -1,0 +1,149 @@
+package lessons
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+const (
+	DefaultPath       = ".symphony/lessons.md"
+	DefaultMaxEntries = 50
+)
+
+type Entry struct {
+	IssueNumber string
+	IssueRef    string
+	Title       string
+	FailureKind string
+	Symptom     string
+	Hypothesis  string
+	Hint        string
+}
+
+type AppendOptions struct {
+	Date       time.Time
+	MaxEntries int
+}
+
+func Append(path string, entry Entry, opts AppendOptions) error {
+	maxEntries := opts.MaxEntries
+	if maxEntries <= 0 {
+		maxEntries = DefaultMaxEntries
+	}
+
+	date := opts.Date
+	if date.IsZero() {
+		date = time.Now().UTC()
+	}
+
+	entries, err := ReadAll(path)
+	if err != nil {
+		return err
+	}
+
+	rendered := renderEntry(entry, date)
+	entries = append([]string{rendered}, entries...)
+	if len(entries) > maxEntries {
+		entries = entries[:maxEntries]
+	}
+
+	return writeEntries(path, entries)
+}
+
+func Recent(path string, count int) ([]string, error) {
+	if count <= 0 {
+		return []string{}, nil
+	}
+
+	entries, err := ReadAll(path)
+	if err != nil {
+		return nil, err
+	}
+	if len(entries) > count {
+		entries = entries[:count]
+	}
+
+	return entries, nil
+}
+
+func ReadAll(path string) ([]string, error) {
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	return parseEntries(string(content)), nil
+}
+
+func renderEntry(entry Entry, date time.Time) string {
+	lines := []string{
+		"## " + date.Format("2006-01-02") + " - " + issueRef(entry) + " - \"" + headingTitle(entry) + "\"",
+		"- **Failure kind:** " + field(entry.FailureKind, "<unknown>"),
+		"- **Symptom:** " + field(entry.Symptom, "<unavailable>"),
+		"- **Hypothesis (Symphony):** " + field(entry.Hypothesis, "<unavailable>"),
+		"- **Hint for next time:** " + field(entry.Hint, "<unavailable>"),
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+func issueRef(entry Entry) string {
+	if strings.TrimSpace(entry.IssueNumber) != "" {
+		return "issue #" + strings.TrimLeft(strings.TrimSpace(entry.IssueNumber), "#")
+	}
+	if strings.TrimSpace(entry.IssueRef) != "" {
+		return strings.TrimSpace(entry.IssueRef)
+	}
+	return "issue <unknown>"
+}
+
+func headingTitle(entry Entry) string {
+	return strings.ReplaceAll(field(entry.Title, "Untitled"), `"`, `\"`)
+}
+
+func field(value string, fallback string) string {
+	normalized := strings.Join(strings.Fields(value), " ")
+	if normalized == "" {
+		return fallback
+	}
+	return normalized
+}
+
+func parseEntries(content string) []string {
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	entries := make([]string, 0)
+	var current []string
+
+	for _, line := range lines {
+		if strings.HasPrefix(line, "## ") {
+			if len(current) > 0 {
+				entries = append(entries, strings.TrimSpace(strings.Join(current, "\n")))
+			}
+			current = []string{line}
+			continue
+		}
+		if len(current) > 0 {
+			current = append(current, line)
+		}
+	}
+	if len(current) > 0 {
+		entries = append(entries, strings.TrimSpace(strings.Join(current, "\n")))
+	}
+
+	return entries
+}
+
+func writeEntries(path string, entries []string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+
+	return os.WriteFile(path, []byte(strings.Join(entries, "\n\n")+"\n"), 0o600)
+}

--- a/internal/lessons/lessons_test.go
+++ b/internal/lessons/lessons_test.go
@@ -1,0 +1,129 @@
+package lessons
+
+import (
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadAllAndRecentTreatMissingFileAsEmpty(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".symphony", "lessons.md")
+
+	entries, err := ReadAll(path)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("ReadAll() len = %d, want 0", len(entries))
+	}
+
+	recent, err := Recent(path, 3)
+	if err != nil {
+		t.Fatalf("Recent() error = %v", err)
+	}
+	if len(recent) != 0 {
+		t.Fatalf("Recent() len = %d, want 0", len(recent))
+	}
+}
+
+func TestAppendStoresNewestFirstAndCapsEntries(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".symphony", "lessons.md")
+
+	for index := 1; index <= 4; index++ {
+		err := Append(path, Entry{
+			IssueNumber: strconv.Itoa(index),
+			Title:       "Issue " + strconv.Itoa(index),
+			FailureKind: "kind " + strconv.Itoa(index),
+			Symptom:     "symptom " + strconv.Itoa(index),
+			Hypothesis:  "hypothesis " + strconv.Itoa(index),
+			Hint:        "hint " + strconv.Itoa(index),
+		}, AppendOptions{
+			Date:       time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC),
+			MaxEntries: 3,
+		})
+		if err != nil {
+			t.Fatalf("Append(%d) error = %v", index, err)
+		}
+	}
+
+	entries, err := ReadAll(path)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	if len(entries) != 3 {
+		t.Fatalf("entries len = %d, want 3", len(entries))
+	}
+	if !strings.Contains(entries[0], "issue #4") || !strings.Contains(entries[2], "issue #2") {
+		t.Fatalf("entries not newest first with oldest capped: %#v", entries)
+	}
+	if strings.Contains(strings.Join(entries, "\n"), "issue #1") {
+		t.Fatalf("oldest entry was not capped: %#v", entries)
+	}
+
+	recent, err := Recent(path, 2)
+	if err != nil {
+		t.Fatalf("Recent() error = %v", err)
+	}
+	if len(recent) != 2 || !strings.Contains(recent[0], "issue #4") || !strings.Contains(recent[1], "issue #3") {
+		t.Fatalf("Recent() = %#v, want issue #4 then issue #3", recent)
+	}
+}
+
+func TestAppendRendersFallbacksAndEscapesTitleQuotes(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".symphony", "lessons.md")
+
+	err := Append(path, Entry{
+		IssueRef:    "issue MT-9",
+		Title:       `Needs "quotes" escaped`,
+		FailureKind: "",
+		Symptom:     "  command\nfailed\tbefore diff  ",
+		Hypothesis:  "",
+		Hint:        "",
+	}, AppendOptions{Date: time.Date(2026, 5, 22, 0, 0, 0, 0, time.UTC)})
+	if err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	entries, err := ReadAll(path)
+	if err != nil {
+		t.Fatalf("ReadAll() error = %v", err)
+	}
+	entry := entries[0]
+	for _, want := range []string{
+		`## 2026-05-22 - issue MT-9 - "Needs \"quotes\" escaped"`,
+		"- **Failure kind:** <unknown>",
+		"- **Symptom:** command failed before diff",
+		"- **Hypothesis (Symphony):** <unavailable>",
+		"- **Hint for next time:** <unavailable>",
+	} {
+		if !strings.Contains(entry, want) {
+			t.Fatalf("entry missing %q:\n%s", want, entry)
+		}
+	}
+}
+
+func TestReadAllReturnsReadErrors(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+
+	_, err := ReadAll(root)
+	if err == nil {
+		t.Fatal("ReadAll() error = nil, want error")
+	}
+	_, err = Recent(root, 1)
+	if err == nil {
+		t.Fatal("Recent() error = nil, want error")
+	}
+	if err := Append(root, Entry{Title: "cannot append"}, AppendOptions{}); err == nil {
+		t.Fatal("Append() error = nil, want error")
+	}
+}

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -30,7 +30,7 @@ No description provided.
 
 var (
 	templateVariablePattern = regexp.MustCompile(`{{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*}}`)
-	templateIfPattern       = regexp.MustCompile(`(?s){%\s*if\s+([A-Za-z_][A-Za-z0-9_.]*)\s*%}(.*?)(?:{%\s*else\s*%}(.*?))?{%\s*endif\s*%}`)
+	conditionalTagPattern   = regexp.MustCompile(`{%\s*(if\s+([A-Za-z_][A-Za-z0-9_.]*)|else|endif)\s*%}`)
 	windowsAbsPathPattern   = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
 )
 
@@ -191,33 +191,113 @@ func renderTemplate(template string, assigns map[string]any) (string, error) {
 }
 
 func renderConditionals(template string, assigns map[string]any) (string, error) {
-	for {
-		matches := templateIfPattern.FindStringSubmatchIndex(template)
-		if matches == nil {
-			return template, nil
+	var out strings.Builder
+	offset := 0
+
+	for offset < len(template) {
+		tag := findConditionalTag(template, offset)
+		if tag == nil {
+			out.WriteString(template[offset:])
+			break
+		}
+		if tag.kind != "if" {
+			return "", fmt.Errorf("unexpected template tag %q", tag.kind)
 		}
 
-		name := template[matches[2]:matches[3]]
+		out.WriteString(template[offset:tag.start])
+
+		name := tag.expr
 		value, ok := lookupAssign(assigns, name)
 		if !ok {
 			return "", fmt.Errorf("unknown template variable %q", name)
 		}
 
-		selected := template[matches[4]:matches[5]]
+		thenBranch, elseBranch, nextOffset, err := splitConditional(template, tag.end)
+		if err != nil {
+			return "", err
+		}
+
+		selected := thenBranch
 		if !truthy(value) {
-			selected = ""
-			if matches[6] >= 0 {
-				selected = template[matches[6]:matches[7]]
-			}
+			selected = elseBranch
 		}
 
 		rendered, err := renderConditionals(selected, assigns)
 		if err != nil {
 			return "", err
 		}
-
-		template = template[:matches[0]] + rendered + template[matches[1]:]
+		out.WriteString(rendered)
+		offset = nextOffset
 	}
+
+	return out.String(), nil
+}
+
+type conditionalTag struct {
+	start int
+	end   int
+	kind  string
+	expr  string
+}
+
+func findConditionalTag(template string, offset int) *conditionalTag {
+	matches := conditionalTagPattern.FindStringSubmatchIndex(template[offset:])
+	if matches == nil {
+		return nil
+	}
+
+	start := offset + matches[0]
+	end := offset + matches[1]
+	kind := template[offset+matches[2] : offset+matches[3]]
+	expr := ""
+	if matches[4] >= 0 {
+		kind = "if"
+		expr = template[offset+matches[4] : offset+matches[5]]
+	}
+
+	return &conditionalTag{
+		start: start,
+		end:   end,
+		kind:  kind,
+		expr:  expr,
+	}
+}
+
+func splitConditional(template string, offset int) (string, string, int, error) {
+	depth := 1
+	thenStart := offset
+	elseTagStart := -1
+	elseStart := -1
+	searchOffset := offset
+
+	for searchOffset < len(template) {
+		tag := findConditionalTag(template, searchOffset)
+		if tag == nil {
+			return "", "", 0, errors.New("missing endif template tag")
+		}
+
+		switch tag.kind {
+		case "if":
+			depth++
+		case "else":
+			if depth == 1 && elseStart < 0 {
+				elseTagStart = tag.start
+				elseStart = tag.end
+			}
+		case "endif":
+			depth--
+			if depth == 0 {
+				if elseStart >= 0 {
+					return template[thenStart:elseTagStart], template[elseStart:tag.start], tag.end, nil
+				}
+				return template[thenStart:tag.start], "", tag.end, nil
+			}
+		}
+
+		searchOffset = tag.end
+	}
+
+	return "", "", 0, errors.New("missing endif template tag")
 }
 
 func lookupAssign(assigns map[string]any, name string) (any, bool) {

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -1,0 +1,303 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/config"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/lessons"
+	"github.com/digitaldrywood/symphony-go/internal/skills"
+)
+
+const DefaultPromptTemplate = `You are working on a Linear issue.
+
+Identifier: {{ issue.identifier }}
+Title: {{ issue.title }}
+
+Body:
+{% if issue.description %}
+{{ issue.description }}
+{% else %}
+No description provided.
+{% endif %}
+`
+
+var (
+	templateVariablePattern = regexp.MustCompile(`{{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*}}`)
+	templateIfPattern       = regexp.MustCompile(`(?s){%\s*if\s+([A-Za-z_][A-Za-z0-9_.]*)\s*%}(.*?)(?:{%\s*else\s*%}(.*?))?{%\s*endif\s*%}`)
+	windowsAbsPathPattern   = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
+)
+
+type PromptOptions struct {
+	Attempt         *int
+	WorkspacePath   string
+	AutoBranch      *bool
+	AvailableSkills []skills.Skill
+}
+
+func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOptions) (string, error) {
+	template := workflow.Prompt
+	if strings.TrimSpace(template) == "" {
+		template = DefaultPromptTemplate
+	}
+
+	assigns := promptAssigns(workflow.Config, issue, opts)
+	rendered, err := renderTemplate(template, assigns)
+	if err != nil {
+		return "", err
+	}
+
+	rendered, err = appendLessonsBlock(rendered, workflow.Config.Agent.Lessons, opts.WorkspacePath)
+	if err != nil {
+		return "", err
+	}
+
+	return appendAvailableSkills(rendered, AvailableSkillsBlock(opts.AvailableSkills)), nil
+}
+
+func AvailableSkillsBlock(skillList []skills.Skill) string {
+	if len(skillList) == 0 {
+		return ""
+	}
+
+	lines := make([]string, 0, len(skillList))
+	for _, skill := range skillList {
+		lines = append(lines, "- "+skill.Name+" — "+skill.WhenToUse)
+	}
+
+	return "## Available skills\n\n" + strings.Join(lines, "\n")
+}
+
+func appendAvailableSkills(prompt string, skillsBlock string) string {
+	if strings.TrimSpace(skillsBlock) == "" {
+		return prompt
+	}
+
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + skillsBlock
+}
+
+func appendLessonsBlock(prompt string, cfg config.Lessons, workspacePath string) (string, error) {
+	if !cfg.Enabled || strings.TrimSpace(workspacePath) == "" || cfg.RecallN <= 0 {
+		return prompt, nil
+	}
+
+	path := cfg.Path
+	if strings.TrimSpace(path) == "" {
+		path = lessons.DefaultPath
+	}
+
+	lessonsPath, err := promptWorkspaceRelativePath(workspacePath, path)
+	if err != nil {
+		return "", err
+	}
+
+	entries, err := lessons.Recent(lessonsPath, cfg.RecallN)
+	if err != nil || len(entries) == 0 {
+		return prompt, nil
+	}
+
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Lessons from prior runs\n\n" + strings.Join(entries, "\n\n"), nil
+}
+
+func promptAssigns(cfg config.Config, issue connector.Issue, opts PromptOptions) map[string]any {
+	var attempt any
+	if opts.Attempt != nil {
+		attempt = *opts.Attempt
+	}
+
+	autoBranch := cfg.Workspace.AutoBranch
+	if opts.AutoBranch != nil {
+		autoBranch = *opts.AutoBranch
+	}
+
+	return map[string]any{
+		"attempt": attempt,
+		"issue":   issueAssigns(issue),
+		"tracker": map[string]any{
+			"kind":         cfg.Tracker.Kind,
+			"endpoint":     cfg.Tracker.Endpoint,
+			"project_slug": cfg.Tracker.ProjectSlug,
+		},
+		"workspace": map[string]any{
+			"auto_branch": autoBranch,
+		},
+	}
+}
+
+func issueAssigns(issue connector.Issue) map[string]any {
+	return map[string]any{
+		"id":                 issue.ID,
+		"identifier":         issue.Identifier,
+		"title":              issue.Title,
+		"description":        issue.Description,
+		"priority":           intPointerValue(issue.Priority),
+		"state":              issue.State,
+		"branch_name":        issue.BranchName,
+		"url":                issue.URL,
+		"assignee_id":        issue.AssigneeID,
+		"blocked_by":         issue.BlockedBy,
+		"labels":             issue.Labels,
+		"assigned_to_worker": issue.AssignedToWorker,
+		"created_at":         timePointerValue(issue.CreatedAt),
+		"updated_at":         timePointerValue(issue.UpdatedAt),
+		"model_override":     issue.ModelOverride,
+	}
+}
+
+func intPointerValue(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func timePointerValue(value *time.Time) any {
+	if value == nil {
+		return nil
+	}
+	return value.UTC().Format(time.RFC3339)
+}
+
+func renderTemplate(template string, assigns map[string]any) (string, error) {
+	rendered, err := renderConditionals(template, assigns)
+	if err != nil {
+		return "", err
+	}
+
+	var renderErr error
+	rendered = templateVariablePattern.ReplaceAllStringFunc(rendered, func(match string) string {
+		if renderErr != nil {
+			return match
+		}
+		parts := templateVariablePattern.FindStringSubmatch(match)
+		value, ok := lookupAssign(assigns, parts[1])
+		if !ok {
+			renderErr = fmt.Errorf("unknown template variable %q", parts[1])
+			return match
+		}
+		return formatTemplateValue(value)
+	})
+	if renderErr != nil {
+		return "", renderErr
+	}
+
+	return rendered, nil
+}
+
+func renderConditionals(template string, assigns map[string]any) (string, error) {
+	for {
+		matches := templateIfPattern.FindStringSubmatchIndex(template)
+		if matches == nil {
+			return template, nil
+		}
+
+		name := template[matches[2]:matches[3]]
+		value, ok := lookupAssign(assigns, name)
+		if !ok {
+			return "", fmt.Errorf("unknown template variable %q", name)
+		}
+
+		selected := template[matches[4]:matches[5]]
+		if !truthy(value) {
+			selected = ""
+			if matches[6] >= 0 {
+				selected = template[matches[6]:matches[7]]
+			}
+		}
+
+		rendered, err := renderConditionals(selected, assigns)
+		if err != nil {
+			return "", err
+		}
+
+		template = template[:matches[0]] + rendered + template[matches[1]:]
+	}
+}
+
+func lookupAssign(assigns map[string]any, name string) (any, bool) {
+	parts := strings.Split(name, ".")
+	var current any = assigns
+	for _, part := range parts {
+		values, ok := current.(map[string]any)
+		if !ok {
+			return nil, false
+		}
+		current, ok = values[part]
+		if !ok {
+			return nil, false
+		}
+	}
+	return current, true
+}
+
+func truthy(value any) bool {
+	switch v := value.(type) {
+	case nil:
+		return false
+	case bool:
+		return v
+	case string:
+		return strings.TrimSpace(v) != ""
+	case int:
+		return v != 0
+	case []string:
+		return len(v) > 0
+	default:
+		return true
+	}
+}
+
+func formatTemplateValue(value any) string {
+	switch v := value.(type) {
+	case nil:
+		return ""
+	case string:
+		return v
+	case bool:
+		return strconv.FormatBool(v)
+	case int:
+		return strconv.Itoa(v)
+	case []string:
+		return strings.Join(v, ", ")
+	default:
+		return fmt.Sprint(v)
+	}
+}
+
+func promptWorkspaceRelativePath(workspacePath string, relativePath string) (string, error) {
+	workspace := strings.TrimSpace(workspacePath)
+	if workspace == "" {
+		return "", errors.New("workspace path is required")
+	}
+
+	path := strings.TrimSpace(relativePath)
+	if path == "" || strings.HasPrefix(path, "~") || filepath.IsAbs(path) ||
+		strings.HasPrefix(path, `\`) || windowsAbsPathPattern.MatchString(path) ||
+		pathEscapesWorkspace(path) {
+		return "", errors.New("path must be a relative path inside the workspace")
+	}
+
+	absWorkspace, err := filepath.Abs(workspace)
+	if err != nil {
+		return "", fmt.Errorf("absolute workspace path: %w", err)
+	}
+
+	return filepath.Join(absWorkspace, filepath.Clean(path)), nil
+}
+
+func pathEscapesWorkspace(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -1,0 +1,151 @@
+package runner
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/config"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/lessons"
+	"github.com/digitaldrywood/symphony-go/internal/skills"
+)
+
+func TestBuildPromptRendersAssignsLessonsAndSkills(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	lessonsPath := filepath.Join(workspace, ".symphony", "lessons.md")
+	if err := lessons.Append(lessonsPath, lessons.Entry{
+		IssueNumber: "21",
+		Title:       "Previous failure",
+		FailureKind: "workspace HEAD did not advance",
+		Symptom:     "Codex produced no diff",
+		Hypothesis:  "The command failed before writing files.",
+		Hint:        "Check generator aliases before editing.",
+	}, lessons.AppendOptions{Date: time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC)}); err != nil {
+		t.Fatalf("append lesson: %v", err)
+	}
+
+	attempt := 2
+	autoBranch := true
+	prompt, err := BuildPrompt(config.Workflow{
+		Config: config.Config{
+			Tracker: config.Tracker{
+				Kind:        config.TrackerMemory,
+				Endpoint:    "memory://local",
+				ProjectSlug: "memory-project",
+			},
+			Workspace: config.Workspace{AutoBranch: false},
+			Agent: config.Agent{
+				Lessons: config.Lessons{
+					Enabled: true,
+					Path:    ".symphony/lessons.md",
+					RecallN: 1,
+				},
+			},
+		},
+		Prompt: "Prompt for {{ issue.identifier }} via {{ tracker.kind }} attempt={{ attempt }} auto={{ workspace.auto_branch }}",
+	}, connector.Issue{
+		ID:          "issue-21",
+		Identifier:  "digitaldrywood/symphony-go#21",
+		Title:       "Build prompt",
+		Description: "Wire prompt builder",
+		Labels:      []string{"enhancement", "stage:s3"},
+	}, PromptOptions{
+		Attempt:       &attempt,
+		WorkspacePath: workspace,
+		AutoBranch:    &autoBranch,
+		AvailableSkills: []skills.Skill{
+			{Name: "migrate", Description: "Add migrations.", WhenToUse: "Issue mentions schema changes.", BodyPath: "migrate.md"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"Prompt for digitaldrywood/symphony-go#21 via memory attempt=2 auto=true",
+		"## Lessons from prior runs",
+		"Check generator aliases before editing.",
+		"## Available skills",
+		"- migrate — Issue mentions schema changes.",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "Add migrations.") {
+		t.Fatalf("prompt included skill description, want only when_to_use:\n%s", prompt)
+	}
+}
+
+func TestBuildPromptUsesDefaultPromptDescriptionFallback(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Config: config.Config{},
+		Prompt: " \n",
+	}, connector.Issue{
+		Identifier: "MT-1",
+		Title:      "Missing body",
+	}, PromptOptions{})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"You are working on a Linear issue.",
+		"Identifier: MT-1",
+		"Title: Missing body",
+		"No description provided.",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("default prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
+func TestBuildPromptRejectsUnknownTemplateVariables(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildPrompt(config.Workflow{
+		Prompt: "Prompt {{ issue.missing }}",
+	}, connector.Issue{Identifier: "MT-1"}, PromptOptions{})
+	if err == nil {
+		t.Fatal("BuildPrompt() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "unknown template variable") {
+		t.Fatalf("BuildPrompt() error = %v, want unknown variable", err)
+	}
+}
+
+func TestBuildPromptIgnoresUnreadableLessons(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(workspace, ".symphony", "lessons.md"), 0o755); err != nil {
+		t.Fatalf("mkdir lessons path: %v", err)
+	}
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Config: config.Config{
+			Agent: config.Agent{
+				Lessons: config.Lessons{
+					Enabled: true,
+					Path:    ".symphony/lessons.md",
+					RecallN: 2,
+				},
+			},
+		},
+		Prompt: "Base prompt",
+	}, connector.Issue{Identifier: "MT-1"}, PromptOptions{WorkspacePath: workspace})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+	if strings.Contains(prompt, "## Lessons from prior runs") {
+		t.Fatalf("prompt included unreadable lessons:\n%s", prompt)
+	}
+}

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -122,6 +122,26 @@ func TestBuildPromptRejectsUnknownTemplateVariables(t *testing.T) {
 	}
 }
 
+func TestBuildPromptRendersNestedConditionals(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Prompt: `{% if issue.description %}{{ issue.description }} {% if issue.title %}{{ issue.title }}{% endif %}{% else %}No body{% endif %}`,
+	}, connector.Issue{
+		Identifier: "MT-1",
+		Title:      "Nested title",
+	}, PromptOptions{})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+	if prompt != "No body" {
+		t.Fatalf("prompt = %q, want No body", prompt)
+	}
+	if strings.Contains(prompt, "{% endif %}") {
+		t.Fatalf("prompt left template delimiter: %q", prompt)
+	}
+}
+
 func TestBuildPromptIgnoresUnreadableLessons(t *testing.T) {
 	t.Parallel()
 

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -1,0 +1,266 @@
+package skills
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"regexp"
+	"sort"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+const (
+	DefaultPath              = ".symphony/skills"
+	DefaultMaxSkillsInPrompt = 50
+)
+
+var windowsAbsPathPattern = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
+
+type Skill struct {
+	Name        string
+	Description string
+	WhenToUse   string
+	BodyPath    string
+}
+
+type ValidationError struct {
+	Path    string
+	Message string
+}
+
+func (e ValidationError) Error() string {
+	return e.Path + ": " + e.Message
+}
+
+type Options struct {
+	Path              string
+	MaxSkillsInPrompt int
+	Logger            *slog.Logger
+}
+
+type Result struct {
+	Skills []Skill
+	Errors []ValidationError
+}
+
+func Load(workspacePath string, opts Options) (Result, error) {
+	path := opts.Path
+	if strings.TrimSpace(path) == "" {
+		path = DefaultPath
+	}
+	maxSkills := opts.MaxSkillsInPrompt
+	if maxSkills <= 0 {
+		maxSkills = DefaultMaxSkillsInPrompt
+	}
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	skillsDir, err := workspaceRelativePath(workspacePath, path)
+	if err != nil {
+		return Result{}, err
+	}
+
+	entries, err := os.ReadDir(skillsDir)
+	if errors.Is(err, os.ErrNotExist) {
+		return Result{}, nil
+	}
+	if err != nil {
+		return Result{}, fmt.Errorf("read skills directory: %w", err)
+	}
+
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || strings.ToLower(filepath.Ext(entry.Name())) != ".md" {
+			continue
+		}
+		files = append(files, filepath.Join(skillsDir, entry.Name()))
+	}
+	sort.Strings(files)
+
+	skills := make([]Skill, 0, len(files))
+	validationErrors := make([]ValidationError, 0)
+	for _, file := range files {
+		content, err := os.ReadFile(file)
+		if err != nil {
+			validationErrors = append(validationErrors, ValidationError{
+				Path:    file,
+				Message: "failed to read skill: " + err.Error(),
+			})
+			continue
+		}
+
+		skill, validationErr := parseSkill(file, content)
+		if validationErr != nil {
+			validationErrors = append(validationErrors, *validationErr)
+			continue
+		}
+		skills = append(skills, skill)
+	}
+
+	skills, duplicateErrors := rejectDuplicateNames(skills)
+	validationErrors = append(validationErrors, duplicateErrors...)
+
+	if len(skills) > maxSkills {
+		for _, skill := range skills[maxSkills:] {
+			logger.Info(
+				"dropped skill from prompt",
+				slog.Int("max_skills_in_prompt", maxSkills),
+				slog.String("skill_name", skill.Name),
+				slog.String("body_path", skill.BodyPath),
+			)
+		}
+		skills = skills[:maxSkills]
+	}
+
+	return Result{
+		Skills: skills,
+		Errors: validationErrors,
+	}, nil
+}
+
+func parseSkill(path string, content []byte) (Skill, *ValidationError) {
+	frontmatter, err := splitFrontmatter(content)
+	if err != nil {
+		return Skill{}, &ValidationError{Path: path, Message: err.Error()}
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(frontmatter, &doc); err != nil {
+		return Skill{}, &ValidationError{Path: path, Message: "invalid YAML: " + err.Error()}
+	}
+
+	root := yamlRoot(&doc)
+	if root == nil || root.Kind != yaml.MappingNode {
+		return Skill{}, &ValidationError{Path: path, Message: "front matter must be a mapping"}
+	}
+
+	fields := map[string]string{}
+	missing := make([]string, 0, 3)
+	for _, field := range []string{"name", "description", "when_to_use"} {
+		value, ok := stringField(root, field)
+		if !ok || strings.TrimSpace(value) == "" {
+			missing = append(missing, field+" is required")
+			continue
+		}
+		fields[field] = strings.TrimSpace(value)
+	}
+	if len(missing) > 0 {
+		return Skill{}, &ValidationError{Path: path, Message: strings.Join(missing, ", ")}
+	}
+
+	return Skill{
+		Name:        fields["name"],
+		Description: fields["description"],
+		WhenToUse:   fields["when_to_use"],
+		BodyPath:    path,
+	}, nil
+}
+
+func splitFrontmatter(content []byte) ([]byte, error) {
+	normalized := strings.ReplaceAll(strings.TrimPrefix(string(content), "\ufeff"), "\r\n", "\n")
+	if !strings.HasPrefix(normalized, "---\n") {
+		return nil, errors.New("missing front matter")
+	}
+
+	body := normalized[len("---\n"):]
+	if strings.HasPrefix(body, "---\n") {
+		return []byte{}, nil
+	}
+	if body == "---" {
+		return []byte{}, nil
+	}
+	closeIndex := strings.Index(body, "\n---\n")
+	if closeIndex >= 0 {
+		return []byte(body[:closeIndex]), nil
+	}
+	if strings.HasSuffix(body, "\n---") {
+		return []byte(strings.TrimSuffix(body, "\n---")), nil
+	}
+
+	return nil, errors.New("missing closing front matter delimiter")
+}
+
+func yamlRoot(doc *yaml.Node) *yaml.Node {
+	if doc.Kind == yaml.DocumentNode && len(doc.Content) > 0 {
+		return doc.Content[0]
+	}
+	if doc.Kind == yaml.MappingNode {
+		return doc
+	}
+	return nil
+}
+
+func stringField(root *yaml.Node, name string) (string, bool) {
+	for i := 0; i < len(root.Content); i += 2 {
+		key := root.Content[i]
+		value := root.Content[i+1]
+		if key.Value != name {
+			continue
+		}
+		if value.Kind != yaml.ScalarNode || value.Tag != "!!str" {
+			return "", false
+		}
+		return value.Value, true
+	}
+	return "", false
+}
+
+func rejectDuplicateNames(skillList []Skill) ([]Skill, []ValidationError) {
+	seen := make(map[string]string, len(skillList))
+	skills := make([]Skill, 0, len(skillList))
+	validationErrors := make([]ValidationError, 0)
+
+	for _, skill := range skillList {
+		existingPath, ok := seen[skill.Name]
+		if ok {
+			validationErrors = append(validationErrors, ValidationError{
+				Path:    skill.BodyPath,
+				Message: fmt.Sprintf("duplicate skill name %q already defined at %s", skill.Name, existingPath),
+			})
+			continue
+		}
+		seen[skill.Name] = skill.BodyPath
+		skills = append(skills, skill)
+	}
+
+	return skills, validationErrors
+}
+
+func workspaceRelativePath(workspacePath string, relativePath string) (string, error) {
+	workspace := strings.TrimSpace(workspacePath)
+	if workspace == "" {
+		return "", errors.New("workspace path is required")
+	}
+
+	path := strings.TrimSpace(relativePath)
+	if path == "" || strings.HasPrefix(path, "~") || filepath.IsAbs(path) ||
+		strings.HasPrefix(path, `\`) || windowsAbsPathPattern.MatchString(path) ||
+		pathEscapesWorkspace(path) {
+		return "", errors.New("path must be a relative path inside the workspace")
+	}
+
+	absWorkspace, err := filepath.Abs(workspace)
+	if err != nil {
+		return "", fmt.Errorf("absolute workspace path: %w", err)
+	}
+
+	return filepath.Join(absWorkspace, filepath.Clean(path)), nil
+}
+
+func pathEscapesWorkspace(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -1,0 +1,127 @@
+package skills
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadReadsSkillsDeterministicallyDeduplicatesAndCaps(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	skillsDir := filepath.Join(workspace, ".symphony", "skills")
+	writeSkill(t, skillsDir, "01-alpha.md", "deploy", "Deploy changes.", "Issue mentions deploys.")
+	writeSkill(t, skillsDir, "02-duplicate.md", "deploy", "Duplicate deploy.", "Issue mentions deploys again.")
+	writeSkill(t, skillsDir, "03-migrate.md", "migrate", "Add migrations.", "Issue mentions schema changes.")
+	writeSkill(t, skillsDir, "04-lint.md", "lint", "Fix lint.", "Issue mentions lint failures.")
+
+	result, err := Load(workspace, Options{MaxSkillsInPrompt: 2})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(result.Skills) != 2 {
+		t.Fatalf("skills len = %d, want 2: %#v", len(result.Skills), result.Skills)
+	}
+	if result.Skills[0].Name != "deploy" || result.Skills[1].Name != "migrate" {
+		t.Fatalf("skills order = %#v, want deploy then migrate", result.Skills)
+	}
+	if result.Skills[0].Description != "Deploy changes." {
+		t.Fatalf("Description = %q", result.Skills[0].Description)
+	}
+	if !strings.HasSuffix(result.Skills[0].BodyPath, filepath.Join(".symphony", "skills", "01-alpha.md")) {
+		t.Fatalf("BodyPath = %q", result.Skills[0].BodyPath)
+	}
+	if len(result.Errors) != 1 {
+		t.Fatalf("errors len = %d, want 1: %#v", len(result.Errors), result.Errors)
+	}
+	if !strings.Contains(result.Errors[0].Message, `duplicate skill name "deploy"`) {
+		t.Fatalf("duplicate error = %q", result.Errors[0].Message)
+	}
+}
+
+func TestLoadReportsInvalidSkillsAndKeepsValidSkills(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	skillsDir := filepath.Join(workspace, ".symphony", "skills")
+	writeSkill(t, skillsDir, "good.md", "good", "Good skill.", "Issue mentions a good path.")
+	writeFile(t, filepath.Join(skillsDir, "missing-name.md"), `---
+description: Missing name.
+when_to_use: Never.
+---
+Body
+`)
+	writeFile(t, filepath.Join(skillsDir, "not-frontmatter.md"), "Body only\n")
+
+	result, err := Load(workspace, Options{})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+
+	if len(result.Skills) != 1 {
+		t.Fatalf("skills len = %d, want 1: %#v", len(result.Skills), result.Skills)
+	}
+	if result.Skills[0].Name != "good" {
+		t.Fatalf("skill name = %q, want good", result.Skills[0].Name)
+	}
+	if len(result.Errors) != 2 {
+		t.Fatalf("errors len = %d, want 2: %#v", len(result.Errors), result.Errors)
+	}
+
+	messages := result.Errors[0].Message + "\n" + result.Errors[1].Message
+	for _, want := range []string{"name is required", "missing front matter"} {
+		if !strings.Contains(messages, want) {
+			t.Fatalf("errors missing %q:\n%s", want, messages)
+		}
+	}
+}
+
+func TestLoadMissingDirectoryIsEmpty(t *testing.T) {
+	t.Parallel()
+
+	result, err := Load(t.TempDir(), Options{})
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if len(result.Skills) != 0 || len(result.Errors) != 0 {
+		t.Fatalf("Load() = %#v, want empty result", result)
+	}
+}
+
+func TestLoadRejectsUnsafePath(t *testing.T) {
+	t.Parallel()
+
+	_, err := Load(t.TempDir(), Options{Path: "../skills"})
+	if err == nil {
+		t.Fatal("Load() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "relative path inside the workspace") {
+		t.Fatalf("Load() error = %v, want workspace-relative path error", err)
+	}
+}
+
+func writeSkill(t *testing.T, dir string, name string, skillName string, description string, whenToUse string) {
+	t.Helper()
+
+	writeFile(t, filepath.Join(dir, name), `---
+name: `+skillName+`
+description: `+description+`
+when_to_use: `+whenToUse+`
+---
+Body should stay out of prompt.
+`)
+}
+
+func writeFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir %s: %v", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}


### PR DESCRIPTION
## Summary
- Add internal skills loader for `.symphony/skills/*.md` frontmatter with validation, deduplication, and prompt caps
- Add LIFO lessons storage with markdown rendering, recent recall, and max-entry retention
- Add runner prompt builder for workflow assigns, lessons recall, and available skills context

Fixes #21

## Test Plan
- `go test ./internal/skills ./internal/lessons ./internal/runner`
- `go test ./...`
- `make check`