### PR TITLE
feat(orchestrator): rank dispatch candidates

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"log/slog"
 	"math"
-	"sort"
 	"strings"
 	"time"
 
@@ -30,6 +29,7 @@ type Config struct {
 	PollInterval               time.Duration
 	MaxConcurrentAgents        int
 	MaxConcurrentAgentsByState map[string]int
+	DispatchPriorityByState    []string
 	MaxRetryBackoff            time.Duration
 	ActiveStates               []string
 	TerminalStates             []string
@@ -69,6 +69,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		PollInterval:               durationFromMillis(cfg.Polling.IntervalMS),
 		MaxConcurrentAgents:        cfg.Agent.MaxConcurrentAgents,
 		MaxConcurrentAgentsByState: cloneStateLimits(cfg.Agent.MaxConcurrentAgentsByState),
+		DispatchPriorityByState:    append([]string(nil), cfg.Agent.DispatchPriorityByState...),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
 		ActiveStates:               append([]string(nil), cfg.Tracker.ActiveStates...),
 		TerminalStates:             append([]string(nil), cfg.Tracker.TerminalStates...),
@@ -160,10 +161,9 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	}
 
 	issues = cloneIssues(issues)
-	sortIssuesForDispatch(issues)
+	sortIssuesForDispatch(issues, o.cfg.DispatchPriorityByState)
 	o.trackBlockedCandidates(state, issues, now)
-	o.dispatchDueRetries(ctx, state, issues, now)
-	o.dispatchCandidates(ctx, state, issues, now)
+	o.dispatchReadyIssues(ctx, state, issues, now)
 }
 
 func (o *Orchestrator) trackBlockedCandidates(state *State, issues []connector.Issue, now time.Time) {
@@ -192,59 +192,15 @@ func (o *Orchestrator) trackBlockedCandidates(state *State, issues []connector.I
 	}
 }
 
-func (o *Orchestrator) dispatchDueRetries(
-	ctx context.Context,
-	state *State,
-	issues []connector.Issue,
-	now time.Time,
-) {
-	if len(state.Retry) == 0 {
-		return
-	}
+func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
+	dueRetries := dueRetriesByIssue(state, now)
+	o.releaseMissingDueRetries(state, issues, dueRetries)
 
-	byID := make(map[string]connector.Issue, len(issues))
 	for _, issue := range issues {
-		byID[issue.ID] = issue
-	}
-
-	retries := make([]Retry, 0, len(state.Retry))
-	for _, retry := range state.Retry {
-		if !retry.DueAt.After(now) {
-			retries = append(retries, retry)
-		}
-	}
-	sort.SliceStable(retries, func(i, j int) bool {
-		return retries[i].DueAt.Before(retries[j].DueAt)
-	})
-
-	for _, retry := range retries {
-		delete(state.Retry, retry.Issue.ID)
-
-		issue, ok := byID[retry.Issue.ID]
-		if !ok {
-			o.releaseIssue(state, retry.Issue.ID)
+		if retry, ok := dueRetries[issue.ID]; ok {
+			o.dispatchRetryIssue(ctx, state, issue, retry, now)
 			continue
 		}
-		if !o.dispatchableForRetry(issue, state) {
-			if availableSlots(state) == 0 {
-				o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false)
-				continue
-			}
-			if _, blocked := state.Blocked[issue.ID]; blocked {
-				o.releaseClaim(state, issue.ID)
-				continue
-			}
-
-			o.releaseIssue(state, issue.ID)
-			continue
-		}
-
-		o.dispatchIssue(ctx, state, issue, retry.Attempt, now)
-	}
-}
-
-func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
-	for _, issue := range issues {
 		if availableSlots(state) == 0 {
 			return
 		}
@@ -254,6 +210,63 @@ func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, iss
 
 		o.dispatchIssue(ctx, state, issue, 0, now)
 	}
+}
+
+func dueRetriesByIssue(state *State, now time.Time) map[string]Retry {
+	retries := make(map[string]Retry, len(state.Retry))
+	for _, retry := range state.Retry {
+		if !retry.DueAt.After(now) {
+			retries[retry.Issue.ID] = retry
+		}
+	}
+	return retries
+}
+
+func (o *Orchestrator) releaseMissingDueRetries(
+	state *State,
+	issues []connector.Issue,
+	dueRetries map[string]Retry,
+) {
+	if len(dueRetries) == 0 {
+		return
+	}
+
+	byID := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		byID[issue.ID] = struct{}{}
+	}
+
+	for issueID := range dueRetries {
+		if _, ok := byID[issueID]; !ok {
+			o.releaseIssue(state, issueID)
+		}
+	}
+}
+
+func (o *Orchestrator) dispatchRetryIssue(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	retry Retry,
+	now time.Time,
+) {
+	delete(state.Retry, retry.Issue.ID)
+
+	if !o.dispatchableForRetry(issue, state) {
+		if availableSlots(state) == 0 {
+			o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false)
+			return
+		}
+		if _, blocked := state.Blocked[issue.ID]; blocked {
+			o.releaseClaim(state, issue.ID)
+			return
+		}
+
+		o.releaseIssue(state, issue.ID)
+		return
+	}
+
+	o.dispatchIssue(ctx, state, issue, retry.Attempt, now)
 }
 
 func (o *Orchestrator) dispatchable(issue connector.Issue, state *State) bool {
@@ -480,6 +493,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.ActiveStates = normalizedStates(cfg.ActiveStates)
 	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
+	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
 
 	return cfg
 }
@@ -507,35 +521,6 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 		cloned[i] = cloneIssue(issue)
 	}
 	return cloned
-}
-
-func sortIssuesForDispatch(issues []connector.Issue) {
-	sort.SliceStable(issues, func(i, j int) bool {
-		left := issues[i]
-		right := issues[j]
-
-		if leftRank, rightRank := priorityRank(left.Priority), priorityRank(right.Priority); leftRank != rightRank {
-			return leftRank < rightRank
-		}
-		if left.CreatedAt != nil && right.CreatedAt != nil && !left.CreatedAt.Equal(*right.CreatedAt) {
-			return left.CreatedAt.Before(*right.CreatedAt)
-		}
-		if left.CreatedAt != nil && right.CreatedAt == nil {
-			return true
-		}
-		if left.CreatedAt == nil && right.CreatedAt != nil {
-			return false
-		}
-
-		return left.Identifier < right.Identifier
-	})
-}
-
-func priorityRank(priority *int) int {
-	if priority == nil || *priority < 1 || *priority > 4 {
-		return 5
-	}
-	return *priority
 }
 
 func validCandidate(issue connector.Issue) bool {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -110,6 +110,40 @@ func TestRunReportsRunningStateWhileRunnerIsInFlight(t *testing.T) {
 	})
 }
 
+func TestRunDispatchesByStateRankBeforePriorityAndAge(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	todo := rankedTestIssue(testIssue("todo-old-urgent", "digitaldrywood/symphony-go#20", "Todo"), 1, now.Add(-4*time.Hour))
+	rework := rankedTestIssue(testIssue("rework-new-low", "digitaldrywood/symphony-go#21", "Rework"), 4, now.Add(-time.Hour))
+	merging := rankedTestIssue(testIssue("merging-new-low", "digitaldrywood/symphony-go#22", "Merging"), 4, now.Add(-30*time.Minute))
+	tracker := newFakeConnector(todo, rework, merging)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:            time.Hour,
+		MaxConcurrentAgents:     1,
+		DispatchPriorityByState: []string{"Merging", "Rework"},
+		ActiveStates:            []string{"Todo", "Rework", "Merging"},
+		TerminalStates:          []string{"Done", "Cancelled", "Canceled", "Closed"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != merging.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, merging.ID)
+	}
+
+	close(runner.release)
+}
+
 func TestRunSchedulesRetryAfterRunnerError(t *testing.T) {
 	t.Parallel()
 
@@ -350,6 +384,12 @@ func testIssue(id, identifier, state string) connector.Issue {
 	issue.Title = "Port orchestrator"
 	issue.State = state
 	issue.URL = "https://github.com/digitaldrywood/symphony-go/issues/10"
+	return issue
+}
+
+func rankedTestIssue(issue connector.Issue, priority int, createdAt time.Time) connector.Issue {
+	issue.Priority = &priority
+	issue.CreatedAt = &createdAt
 	return issue
 }
 

--- a/internal/orchestrator/ranking.go
+++ b/internal/orchestrator/ranking.go
@@ -1,0 +1,63 @@
+package orchestrator
+
+import (
+	"sort"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func sortIssuesForDispatch(issues []connector.Issue, dispatchPriority []string) {
+	stateRanks := stateDispatchRanks(dispatchPriority)
+
+	sort.SliceStable(issues, func(i, j int) bool {
+		left := issues[i]
+		right := issues[j]
+
+		if leftRank, rightRank := stateDispatchRank(stateRanks, left.State), stateDispatchRank(stateRanks, right.State); leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		if leftRank, rightRank := priorityRank(left.Priority), priorityRank(right.Priority); leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		if left.CreatedAt != nil && right.CreatedAt != nil && !left.CreatedAt.Equal(*right.CreatedAt) {
+			return left.CreatedAt.Before(*right.CreatedAt)
+		}
+		if left.CreatedAt != nil && right.CreatedAt == nil {
+			return true
+		}
+		if left.CreatedAt == nil && right.CreatedAt != nil {
+			return false
+		}
+
+		return left.Identifier < right.Identifier
+	})
+}
+
+func stateDispatchRanks(states []string) map[string]int {
+	ranks := make(map[string]int, len(states))
+	for _, state := range states {
+		state = normalizeState(state)
+		if state == "" {
+			continue
+		}
+		if _, ok := ranks[state]; ok {
+			continue
+		}
+		ranks[state] = len(ranks)
+	}
+	return ranks
+}
+
+func stateDispatchRank(ranks map[string]int, state string) int {
+	if rank, ok := ranks[normalizeState(state)]; ok {
+		return rank
+	}
+	return len(ranks)
+}
+
+func priorityRank(priority *int) int {
+	if priority == nil || *priority < 1 || *priority > 4 {
+		return 5
+	}
+	return *priority
+}

--- a/internal/orchestrator/ranking_test.go
+++ b/internal/orchestrator/ranking_test.go
@@ -1,0 +1,142 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestSortIssuesForDispatch(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+
+	tests := []struct {
+		name             string
+		dispatchPriority []string
+		issues           []connector.Issue
+		want             []string
+	}{
+		{
+			name:             "sorts by state dispatch rank before priority and age",
+			dispatchPriority: []string{"Merging", "Rework"},
+			issues: []connector.Issue{
+				rankingIssue("todo-old-urgent", "Todo", 1, now.Add(-4*time.Hour)),
+				rankingIssue("rework-new-low", "Rework", 4, now.Add(-time.Hour)),
+				rankingIssue("merging-new-low", "Merging", 4, now.Add(-30*time.Minute)),
+			},
+			want: []string{"merging-new-low", "rework-new-low", "todo-old-urgent"},
+		},
+		{
+			name:             "sorts by priority within the same state rank",
+			dispatchPriority: []string{"Todo"},
+			issues: []connector.Issue{
+				rankingIssue("todo-medium", "Todo", 3, now.Add(-3*time.Hour)),
+				rankingIssue("todo-none", "Todo", 0, now.Add(-4*time.Hour)),
+				rankingIssue("todo-urgent", "Todo", 1, now.Add(-time.Hour)),
+				rankingIssue("todo-high", "Todo", 2, now.Add(-2*time.Hour)),
+			},
+			want: []string{"todo-urgent", "todo-high", "todo-medium", "todo-none"},
+		},
+		{
+			name:             "sorts older issues first within the same state rank and priority",
+			dispatchPriority: []string{"Todo"},
+			issues: []connector.Issue{
+				rankingIssue("todo-new", "Todo", 2, now.Add(-time.Hour)),
+				rankingIssue("todo-old", "Todo", 2, now.Add(-3*time.Hour)),
+				rankingIssue("todo-middle", "Todo", 2, now.Add(-2*time.Hour)),
+			},
+			want: []string{"todo-old", "todo-middle", "todo-new"},
+		},
+		{
+			name:             "normalizes state ranks and sorts unranked states last",
+			dispatchPriority: []string{" Merging ", "Rework"},
+			issues: []connector.Issue{
+				rankingIssue("todo-old-urgent", "Todo", 1, now.Add(-4*time.Hour)),
+				rankingIssue("rework-high", " rework ", 2, now.Add(-time.Hour)),
+				rankingIssue("merging-low", "merging", 4, now.Add(-30*time.Minute)),
+				rankingIssue("in-progress-high", "In Progress", 2, now.Add(-3*time.Hour)),
+			},
+			want: []string{"merging-low", "rework-high", "todo-old-urgent", "in-progress-high"},
+		},
+		{
+			name: "uses deterministic identifier order after state rank priority and age",
+			issues: []connector.Issue{
+				rankingIssue("issue-c", "Todo", 2, now),
+				rankingIssue("issue-a", "Todo", 2, now),
+				rankingIssue("issue-b", "Todo", 2, now),
+			},
+			want: []string{"issue-a", "issue-b", "issue-c"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issues := cloneRankingIssues(tt.issues)
+			sortIssuesForDispatch(issues, tt.dispatchPriority)
+
+			if got := rankingIssueIDs(issues); !equalStrings(got, tt.want) {
+				t.Fatalf("sortIssuesForDispatch() ids = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestConfigFromWorkflowIncludesDispatchPriorityByState(t *testing.T) {
+	t.Parallel()
+
+	workflow := workflowconfig.Default()
+	workflow.Agent.DispatchPriorityByState = []string{"Merging", "Rework"}
+
+	cfg := ConfigFromWorkflow(workflow)
+	workflow.Agent.DispatchPriorityByState[0] = "Todo"
+
+	want := []string{"Merging", "Rework"}
+	if !equalStrings(cfg.DispatchPriorityByState, want) {
+		t.Fatalf("ConfigFromWorkflow().DispatchPriorityByState = %#v, want %#v", cfg.DispatchPriorityByState, want)
+	}
+}
+
+func rankingIssue(id string, state string, priority int, createdAt time.Time) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = id
+	issue.State = state
+	issue.CreatedAt = &createdAt
+	if priority > 0 {
+		issue.Priority = &priority
+	}
+	return issue
+}
+
+func cloneRankingIssues(issues []connector.Issue) []connector.Issue {
+	cloned := make([]connector.Issue, len(issues))
+	for i, issue := range issues {
+		cloned[i] = cloneIssue(issue)
+	}
+	return cloned
+}
+
+func rankingIssueIDs(issues []connector.Issue) []string {
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		ids = append(ids, issue.ID)
+	}
+	return ids
+}
+
+func equalStrings(left, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/digitaldrywood/symphony-go/internal/connector"
 )
 
-func TestDispatchDueRetriesKeepsAttemptWhenCapacityIsFull(t *testing.T) {
+func TestDispatchReadyIssuesKeepsRetryAttemptWhenCapacityIsFull(t *testing.T) {
 	t.Parallel()
 
 	cfg := normalizeConfig(Config{
@@ -33,7 +33,7 @@ func TestDispatchDueRetriesKeepsAttemptWhenCapacityIsFull(t *testing.T) {
 		Error:   "previous failure",
 	}
 
-	orch.dispatchDueRetries(context.Background(), &state, []connector.Issue{retrying}, now)
+	orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{retrying}, now)
 
 	retry, ok := state.Retry[retrying.ID]
 	if !ok {
@@ -47,6 +47,53 @@ func TestDispatchDueRetriesKeepsAttemptWhenCapacityIsFull(t *testing.T) {
 	}
 	if !retry.DueAt.After(now) {
 		t.Fatalf("Retry[%q].DueAt = %s, want after %s", retrying.ID, retry.DueAt, now)
+	}
+}
+
+func TestDispatchReadyIssuesRanksDueRetriesWithCandidates(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:     1,
+		DispatchPriorityByState: []string{"Merging"},
+		ActiveStates:            []string{"Todo", "Merging"},
+		TerminalStates:          []string{"Done"},
+	})
+	orch := Orchestrator{
+		cfg:        cfg,
+		runner:     FakeRunner{},
+		runResults: make(chan runResultEvent, 1),
+	}
+	state := newState(cfg)
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	retrying := retryTestIssue("retrying", "digitaldrywood/symphony-go#21")
+	merging := retryTestIssue("merging", "digitaldrywood/symphony-go#22")
+	merging.State = "Merging"
+	priority := 4
+	merging.Priority = &priority
+
+	state.Claimed[retrying.ID] = Claimed{Issue: retrying, ClaimedAt: now.Add(-time.Minute)}
+	state.Retry[retrying.ID] = Retry{
+		Issue:   retrying,
+		Attempt: 2,
+		DueAt:   now.Add(-time.Millisecond),
+		Error:   "previous failure",
+	}
+
+	issues := []connector.Issue{retrying, merging}
+	sortIssuesForDispatch(issues, cfg.DispatchPriorityByState)
+	orch.dispatchReadyIssues(context.Background(), &state, issues, now)
+
+	if _, ok := state.Running[merging.ID]; !ok {
+		t.Fatalf("Running[%q] missing", merging.ID)
+	}
+	if _, ok := state.Running[retrying.ID]; ok {
+		t.Fatalf("Running[%q] present", retrying.ID)
+	}
+	if retry, ok := state.Retry[retrying.ID]; !ok {
+		t.Fatalf("Retry[%q] missing", retrying.ID)
+	} else if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 2", retrying.ID, retry.Attempt)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add orchestrator candidate ranking by configured state dispatch rank, priority, then age.
- Wire workflow dispatch priority state order into orchestrator config.
- Add table-driven ranking tests plus dispatch integration coverage.

Fixes #11

## Test Plan
- go test ./internal/orchestrator
- make check