### PR TITLE
feat(orchestrator): add dispatch slot checks

### DIFF
--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -1,0 +1,114 @@
+package orchestrator
+
+import (
+	"strings"
+	"time"
+)
+
+func (o *Orchestrator) pruneBudgetRefusals(state *State, now time.Time) {
+	for issueID, refusal := range state.BudgetRefusals {
+		if !o.budgetRefusalActive(refusal, now) {
+			delete(state.BudgetRefusals, issueID)
+		}
+	}
+}
+
+func (o *Orchestrator) budgetCooldownActive(state *State, issueID string, now time.Time) bool {
+	refusal, ok := state.BudgetRefusals[issueID]
+	if !ok {
+		return false
+	}
+
+	return o.budgetRefusalActive(refusal, now)
+}
+
+func (o *Orchestrator) budgetRefusalActive(refusal BudgetRefusal, now time.Time) bool {
+	if refusal.ResetAt != nil && now.Before(*refusal.ResetAt) {
+		return true
+	}
+	if o.cfg.BudgetRefusalCooldown <= 0 || refusal.RefusedAt.IsZero() {
+		return false
+	}
+
+	return now.Before(refusal.RefusedAt.Add(o.cfg.BudgetRefusalCooldown))
+}
+
+func (o *Orchestrator) workerSlotsAvailable(state *State, preferredWorkerHost string) bool {
+	_, ok := o.selectWorkerHost(state, preferredWorkerHost)
+	return ok
+}
+
+func (o *Orchestrator) selectWorkerHost(state *State, preferredWorkerHost string) (string, bool) {
+	if len(o.cfg.WorkerHosts) == 0 {
+		return "", true
+	}
+
+	availableHosts := make([]string, 0, len(o.cfg.WorkerHosts))
+	for _, host := range o.cfg.WorkerHosts {
+		if o.workerHostSlotsAvailable(state, host) {
+			availableHosts = append(availableHosts, host)
+		}
+	}
+	if len(availableHosts) == 0 {
+		return "", false
+	}
+
+	preferredWorkerHost = strings.TrimSpace(preferredWorkerHost)
+	if preferredWorkerHost != "" {
+		for _, host := range availableHosts {
+			if host == preferredWorkerHost {
+				return preferredWorkerHost, true
+			}
+		}
+	}
+
+	return leastLoadedWorkerHost(state, availableHosts), true
+}
+
+func (o *Orchestrator) workerHostSlotsAvailable(state *State, workerHost string) bool {
+	if o.cfg.MaxConcurrentAgentsPerHost <= 0 {
+		return true
+	}
+
+	return runningWorkerHostCount(state, workerHost) < o.cfg.MaxConcurrentAgentsPerHost
+}
+
+func leastLoadedWorkerHost(state *State, hosts []string) string {
+	selected := hosts[0]
+	selectedCount := runningWorkerHostCount(state, selected)
+	for _, host := range hosts[1:] {
+		count := runningWorkerHostCount(state, host)
+		if count < selectedCount {
+			selected = host
+			selectedCount = count
+		}
+	}
+	return selected
+}
+
+func runningWorkerHostCount(state *State, workerHost string) int {
+	count := 0
+	for _, running := range state.Running {
+		if running.WorkerHost == workerHost {
+			count++
+		}
+	}
+	return count
+}
+
+func normalizeWorkerHosts(hosts []string) []string {
+	normalized := make([]string, 0, len(hosts))
+	seen := make(map[string]struct{}, len(hosts))
+	for _, host := range hosts {
+		host = strings.TrimSpace(host)
+		if host == "" {
+			continue
+		}
+		if _, ok := seen[host]; ok {
+			continue
+		}
+		seen[host] = struct{}{}
+		normalized = append(normalized, host)
+	}
+	return normalized
+}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1,0 +1,349 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
+	t.Parallel()
+
+	perHost := 2
+	cfg := workflowconfig.Default()
+	cfg.Worker.SSHHosts = []string{"worker-a", "worker-b"}
+	cfg.Worker.MaxConcurrentAgentsPerHost = &perHost
+	cfg.Budget.RefusalCooldownSeconds = 45
+
+	got := ConfigFromWorkflow(cfg)
+
+	if got.MaxConcurrentAgentsPerHost != 2 {
+		t.Fatalf("MaxConcurrentAgentsPerHost = %d, want 2", got.MaxConcurrentAgentsPerHost)
+	}
+	if len(got.WorkerHosts) != 2 || got.WorkerHosts[0] != "worker-a" || got.WorkerHosts[1] != "worker-b" {
+		t.Fatalf("WorkerHosts = %#v, want worker-a and worker-b", got.WorkerHosts)
+	}
+	if got.BudgetRefusalCooldown != 45*time.Second {
+		t.Fatalf("BudgetRefusalCooldown = %s, want 45s", got.BudgetRefusalCooldown)
+	}
+}
+
+func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    2,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		BudgetRefusalCooldown:  time.Hour,
+		ContinuationRetryDelay: time.Second,
+	})
+	orch := Orchestrator{cfg: cfg}
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		state func(State)
+		want  bool
+	}{
+		{
+			name:  "active issue",
+			issue: dispatchTestIssue("issue-active", "Todo"),
+			want:  true,
+		},
+		{
+			name:  "terminal issue",
+			issue: dispatchTestIssue("issue-terminal", "Done"),
+			want:  false,
+		},
+		{
+			name:  "inactive issue",
+			issue: dispatchTestIssue("issue-inactive", "Backlog"),
+			want:  false,
+		},
+		{
+			name: "todo blocked by non-terminal dependency",
+			issue: func() connector.Issue {
+				issue := dispatchTestIssue("issue-blocked-dependency", "Todo")
+				issue.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/symphony-go#10", State: "In Progress"}}
+				return issue
+			}(),
+			want: false,
+		},
+		{
+			name:  "already running",
+			issue: dispatchTestIssue("issue-running", "Todo"),
+			state: func(state State) {
+				issue := dispatchTestIssue("issue-running", "Todo")
+				state.Running[issue.ID] = Running{Issue: issue}
+			},
+			want: false,
+		},
+		{
+			name:  "already claimed",
+			issue: dispatchTestIssue("issue-claimed", "Todo"),
+			state: func(state State) {
+				issue := dispatchTestIssue("issue-claimed", "Todo")
+				state.Claimed[issue.ID] = Claimed{Issue: issue}
+			},
+			want: false,
+		},
+		{
+			name:  "already blocked",
+			issue: dispatchTestIssue("issue-blocked", "Todo"),
+			state: func(state State) {
+				issue := dispatchTestIssue("issue-blocked", "Todo")
+				state.Blocked[issue.ID] = Blocked{Issue: issue}
+			},
+			want: false,
+		},
+		{
+			name:  "budget cooldown active",
+			issue: dispatchTestIssue("issue-budget", "Todo"),
+			state: func(state State) {
+				issue := dispatchTestIssue("issue-budget", "Todo")
+				state.BudgetRefusals[issue.ID] = BudgetRefusal{
+					Issue:     issue,
+					RefusedAt: now.Add(-time.Minute),
+				}
+			},
+			want: false,
+		},
+		{
+			name:  "budget cooldown expired",
+			issue: dispatchTestIssue("issue-budget-expired", "Todo"),
+			state: func(state State) {
+				issue := dispatchTestIssue("issue-budget-expired", "Todo")
+				state.BudgetRefusals[issue.ID] = BudgetRefusal{
+					Issue:     issue,
+					RefusedAt: now.Add(-2 * time.Hour),
+				}
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newState(cfg)
+			if tt.state != nil {
+				tt.state(state)
+			}
+
+			got := orch.dispatchable(tt.issue, &state, now)
+			if got != tt.want {
+				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatchableChecksSlots(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	issue := dispatchTestIssue("issue-candidate", "Todo")
+
+	tests := []struct {
+		name  string
+		cfg   Config
+		state func(State)
+		want  bool
+	}{
+		{
+			name: "global cap full",
+			cfg: Config{
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+			},
+			state: func(state State) {
+				running := dispatchTestIssue("issue-running", "In Progress")
+				state.Running[running.ID] = Running{Issue: running}
+			},
+			want: false,
+		},
+		{
+			name: "per-state cap full",
+			cfg: Config{
+				MaxConcurrentAgents:        2,
+				MaxConcurrentAgentsByState: map[string]int{"Todo": 1},
+				ActiveStates:               []string{"Todo", "In Progress"},
+				TerminalStates:             []string{"Done"},
+			},
+			state: func(state State) {
+				running := dispatchTestIssue("issue-running", "Todo")
+				state.Running[running.ID] = Running{Issue: running}
+			},
+			want: false,
+		},
+		{
+			name: "per-state falls back to global cap",
+			cfg: Config{
+				MaxConcurrentAgents: 2,
+				ActiveStates:        []string{"Todo", "In Progress"},
+				TerminalStates:      []string{"Done"},
+			},
+			state: func(state State) {
+				running := dispatchTestIssue("issue-running", "In Progress")
+				state.Running[running.ID] = Running{Issue: running}
+			},
+			want: true,
+		},
+		{
+			name: "per-host cap full",
+			cfg: Config{
+				MaxConcurrentAgents:        2,
+				ActiveStates:               []string{"Todo"},
+				TerminalStates:             []string{"Done"},
+				WorkerHosts:                []string{"worker-a"},
+				MaxConcurrentAgentsPerHost: 1,
+			},
+			state: func(state State) {
+				running := dispatchTestIssue("issue-running", "Todo")
+				state.Running[running.ID] = Running{Issue: running, WorkerHost: "worker-a"}
+			},
+			want: false,
+		},
+		{
+			name: "alternate host has capacity",
+			cfg: Config{
+				MaxConcurrentAgents:        3,
+				ActiveStates:               []string{"Todo"},
+				TerminalStates:             []string{"Done"},
+				WorkerHosts:                []string{"worker-a", "worker-b"},
+				MaxConcurrentAgentsPerHost: 1,
+			},
+			state: func(state State) {
+				running := dispatchTestIssue("issue-running", "Todo")
+				state.Running[running.ID] = Running{Issue: running, WorkerHost: "worker-a"}
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(tt.cfg)
+			orch := Orchestrator{cfg: cfg}
+			state := newState(cfg)
+			if tt.state != nil {
+				tt.state(state)
+			}
+
+			got := orch.dispatchable(issue, &state, now)
+			if got != tt.want {
+				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatchCandidatesAssignsLeastLoadedWorkerHost(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:        3,
+		ActiveStates:               []string{"Todo"},
+		TerminalStates:             []string{"Done"},
+		WorkerHosts:                []string{"worker-a", "worker-b"},
+		MaxConcurrentAgentsPerHost: 1,
+	})
+	runner := newWorkerHostRunner()
+	orch := Orchestrator{
+		cfg:        cfg,
+		runner:     runner,
+		runResults: make(chan runResultEvent),
+	}
+	state := newState(cfg)
+	now := time.Now()
+	running := dispatchTestIssue("issue-running", "Todo")
+	state.Running[running.ID] = Running{Issue: running, WorkerHost: "worker-a"}
+	candidate := dispatchTestIssue("issue-candidate", "Todo")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch.dispatchCandidates(ctx, &state, []connector.Issue{candidate}, now)
+	request := receiveWorkerHostRunRequest(t, runner.started)
+
+	if request.WorkerHost != "worker-b" {
+		t.Fatalf("RunRequest.WorkerHost = %q, want worker-b", request.WorkerHost)
+	}
+	if got := state.Running[candidate.ID].WorkerHost; got != "worker-b" {
+		t.Fatalf("Running[%q].WorkerHost = %q, want worker-b", candidate.ID, got)
+	}
+}
+
+func TestSelectWorkerHostKeepsPreferredHostWhenAvailable(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:        3,
+		ActiveStates:               []string{"Todo"},
+		TerminalStates:             []string{"Done"},
+		WorkerHosts:                []string{"worker-a", "worker-b"},
+		MaxConcurrentAgentsPerHost: 2,
+	})
+	orch := Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	running := dispatchTestIssue("issue-running", "Todo")
+	state.Running[running.ID] = Running{Issue: running, WorkerHost: "worker-a"}
+
+	host, ok := orch.selectWorkerHost(&state, "worker-a")
+	if !ok {
+		t.Fatal("selectWorkerHost() ok = false, want true")
+	}
+	if host != "worker-a" {
+		t.Fatalf("selectWorkerHost() host = %q, want worker-a", host)
+	}
+}
+
+func dispatchTestIssue(id, state string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/symphony-go#" + id
+	issue.Title = "Dispatch test issue"
+	issue.State = state
+	return issue
+}
+
+type workerHostRunner struct {
+	started chan RunRequest
+}
+
+func newWorkerHostRunner() *workerHostRunner {
+	return &workerHostRunner{started: make(chan RunRequest, 1)}
+}
+
+func (r *workerHostRunner) Run(ctx context.Context, request RunRequest) (RunResult, error) {
+	select {
+	case r.started <- request:
+	case <-ctx.Done():
+		return RunResult{}, ctx.Err()
+	}
+
+	<-ctx.Done()
+	return RunResult{}, ctx.Err()
+}
+
+func receiveWorkerHostRunRequest(t *testing.T, requests <-chan RunRequest) RunRequest {
+	t.Helper()
+
+	select {
+	case request := <-requests:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for worker host run request")
+	}
+
+	return RunRequest{}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -30,9 +30,12 @@ type Config struct {
 	MaxConcurrentAgents        int
 	MaxConcurrentAgentsByState map[string]int
 	DispatchPriorityByState    []string
+	MaxConcurrentAgentsPerHost int
 	MaxRetryBackoff            time.Duration
 	ActiveStates               []string
 	TerminalStates             []string
+	WorkerHosts                []string
+	BudgetRefusalCooldown      time.Duration
 	ContinuationRetryDelay     time.Duration
 	FailureRetryBaseDelay      time.Duration
 }
@@ -70,9 +73,12 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		MaxConcurrentAgents:        cfg.Agent.MaxConcurrentAgents,
 		MaxConcurrentAgentsByState: cloneStateLimits(cfg.Agent.MaxConcurrentAgentsByState),
 		DispatchPriorityByState:    append([]string(nil), cfg.Agent.DispatchPriorityByState...),
+		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
 		ActiveStates:               append([]string(nil), cfg.Tracker.ActiveStates...),
 		TerminalStates:             append([]string(nil), cfg.Tracker.TerminalStates...),
+		WorkerHosts:                append([]string(nil), cfg.Worker.SSHHosts...),
+		BudgetRefusalCooldown:      durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
 	}
 }
 
@@ -162,6 +168,7 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 
 	issues = cloneIssues(issues)
 	sortIssuesForDispatch(issues, o.cfg.DispatchPriorityByState)
+	o.pruneBudgetRefusals(state, now)
 	o.trackBlockedCandidates(state, issues, now)
 	o.dispatchReadyIssues(ctx, state, issues, now)
 }
@@ -204,11 +211,24 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		if availableSlots(state) == 0 {
 			return
 		}
-		if !o.dispatchable(issue, state) {
+		if !o.dispatchable(issue, state, now) {
 			continue
 		}
 
-		o.dispatchIssue(ctx, state, issue, 0, now)
+		o.dispatchIssue(ctx, state, issue, 0, now, "")
+	}
+}
+
+func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
+	for _, issue := range issues {
+		if availableSlots(state) == 0 {
+			return
+		}
+		if !o.dispatchable(issue, state, now) {
+			continue
+		}
+
+		o.dispatchIssue(ctx, state, issue, 0, now, "")
 	}
 }
 
@@ -252,9 +272,13 @@ func (o *Orchestrator) dispatchRetryIssue(
 ) {
 	delete(state.Retry, retry.Issue.ID)
 
-	if !o.dispatchableForRetry(issue, state) {
-		if availableSlots(state) == 0 {
-			o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false)
+	if !o.dispatchableForRetry(issue, state, now, retry.WorkerHost) {
+		if o.budgetCooldownActive(state, issue.ID, now) {
+			o.scheduleRetry(state, issue, retry.Attempt, now, "budget cooldown active", false, retry.WorkerHost)
+			return
+		}
+		if !o.slotsAvailable(issue, state, retry.WorkerHost) {
+			o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false, retry.WorkerHost)
 			return
 		}
 		if _, blocked := state.Blocked[issue.ID]; blocked {
@@ -266,18 +290,29 @@ func (o *Orchestrator) dispatchRetryIssue(
 		return
 	}
 
-	o.dispatchIssue(ctx, state, issue, retry.Attempt, now)
+	o.dispatchIssue(ctx, state, issue, retry.Attempt, now, retry.WorkerHost)
 }
 
-func (o *Orchestrator) dispatchable(issue connector.Issue, state *State) bool {
-	return o.dispatchableIssue(issue, state, false)
+func (o *Orchestrator) dispatchable(issue connector.Issue, state *State, now time.Time) bool {
+	return o.dispatchableIssue(issue, state, false, now, "")
 }
 
-func (o *Orchestrator) dispatchableForRetry(issue connector.Issue, state *State) bool {
-	return o.dispatchableIssue(issue, state, true)
+func (o *Orchestrator) dispatchableForRetry(
+	issue connector.Issue,
+	state *State,
+	now time.Time,
+	preferredWorkerHost string,
+) bool {
+	return o.dispatchableIssue(issue, state, true, now, preferredWorkerHost)
 }
 
-func (o *Orchestrator) dispatchableIssue(issue connector.Issue, state *State, allowClaimed bool) bool {
+func (o *Orchestrator) dispatchableIssue(
+	issue connector.Issue,
+	state *State,
+	allowClaimed bool,
+	now time.Time,
+	preferredWorkerHost string,
+) bool {
 	if !validCandidate(issue) {
 		return false
 	}
@@ -296,11 +331,17 @@ func (o *Orchestrator) dispatchableIssue(issue connector.Issue, state *State, al
 	if _, ok := state.Blocked[issue.ID]; ok {
 		return false
 	}
-	if availableSlots(state) == 0 {
+	if o.budgetCooldownActive(state, issue.ID, now) {
 		return false
 	}
 
-	return o.stateSlotsAvailable(issue, state)
+	return o.slotsAvailable(issue, state, preferredWorkerHost)
+}
+
+func (o *Orchestrator) slotsAvailable(issue connector.Issue, state *State, preferredWorkerHost string) bool {
+	return availableSlots(state) > 0 &&
+		o.stateSlotsAvailable(issue, state) &&
+		o.workerSlotsAvailable(state, preferredWorkerHost)
 }
 
 func (o *Orchestrator) stateSlotsAvailable(issue connector.Issue, state *State) bool {
@@ -326,12 +367,19 @@ func (o *Orchestrator) dispatchIssue(
 	issue connector.Issue,
 	attempt int,
 	now time.Time,
+	preferredWorkerHost string,
 ) {
+	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
+	if !ok {
+		return
+	}
+
 	issue = cloneIssue(issue)
 	state.Running[issue.ID] = Running{
-		Issue:     issue,
-		Attempt:   attempt,
-		StartedAt: now,
+		Issue:      issue,
+		Attempt:    attempt,
+		StartedAt:  now,
+		WorkerHost: workerHost,
 	}
 	state.Claimed[issue.ID] = Claimed{
 		Issue:     issue,
@@ -342,9 +390,10 @@ func (o *Orchestrator) dispatchIssue(
 	delete(state.BudgetRefusals, issue.ID)
 
 	request := RunRequest{
-		Issue:     issue,
-		Attempt:   attempt,
-		StartedAt: now,
+		Issue:      issue,
+		Attempt:    attempt,
+		StartedAt:  now,
+		WorkerHost: workerHost,
 	}
 	go func() {
 		result, err := o.runner.Run(ctx, request)
@@ -370,7 +419,15 @@ func (o *Orchestrator) handleRunResult(state *State, event runResultEvent) {
 	delete(state.Running, event.issueID)
 
 	if event.err != nil {
-		o.scheduleRetry(state, running.Issue, nextAttempt(running.Attempt), event.completedAt, event.err.Error(), false)
+		o.scheduleRetry(
+			state,
+			running.Issue,
+			nextAttempt(running.Attempt),
+			event.completedAt,
+			event.err.Error(),
+			false,
+			running.WorkerHost,
+		)
 		return
 	}
 
@@ -399,7 +456,7 @@ func (o *Orchestrator) handleRunResult(state *State, event runResultEvent) {
 		state.BudgetRefusals[event.issueID] = refusal
 	}
 
-	o.scheduleRetry(state, running.Issue, 1, event.completedAt, "", true)
+	o.scheduleRetry(state, running.Issue, 1, event.completedAt, "", true, running.WorkerHost)
 }
 
 func (o *Orchestrator) scheduleRetry(
@@ -409,6 +466,7 @@ func (o *Orchestrator) scheduleRetry(
 	now time.Time,
 	err string,
 	continuation bool,
+	workerHost string,
 ) {
 	if attempt < 1 {
 		attempt = 1
@@ -417,10 +475,11 @@ func (o *Orchestrator) scheduleRetry(
 	delay := o.retryDelay(attempt, continuation)
 	issue = cloneIssue(issue)
 	state.Retry[issue.ID] = Retry{
-		Issue:   issue,
-		Attempt: attempt,
-		DueAt:   now.Add(delay),
-		Error:   err,
+		Issue:      issue,
+		Attempt:    attempt,
+		DueAt:      now.Add(delay),
+		Error:      err,
+		WorkerHost: workerHost,
 	}
 	if _, ok := state.Claimed[issue.ID]; !ok {
 		state.Claimed[issue.ID] = Claimed{
@@ -494,6 +553,10 @@ func normalizeConfig(cfg Config) Config {
 	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
+	cfg.WorkerHosts = normalizeWorkerHosts(cfg.WorkerHosts)
+	if cfg.MaxConcurrentAgentsPerHost < 0 {
+		cfg.MaxConcurrentAgentsPerHost = 0
+	}
 
 	return cfg
 }
@@ -503,6 +566,20 @@ func durationFromMillis(ms int) time.Duration {
 		return 0
 	}
 	return time.Duration(ms) * time.Millisecond
+}
+
+func durationFromSeconds(seconds int) time.Duration {
+	if seconds <= 0 {
+		return 0
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+func positiveIntValue(value *int) int {
+	if value == nil || *value <= 0 {
+		return 0
+	}
+	return *value
 }
 
 func cloneStateLimits(limits map[string]int) map[string]int {

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -97,6 +97,48 @@ func TestDispatchReadyIssuesRanksDueRetriesWithCandidates(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesKeepsAttemptWhenWorkerCapacityIsFull(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:        2,
+		MaxRetryBackoff:            time.Minute,
+		FailureRetryBaseDelay:      time.Second,
+		ActiveStates:               []string{"Todo"},
+		TerminalStates:             []string{"Done"},
+		WorkerHosts:                []string{"worker-a"},
+		MaxConcurrentAgentsPerHost: 1,
+	})
+	orch := Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	now := time.Now()
+	running := retryTestIssue("running", "digitaldrywood/symphony-go#20")
+	retrying := retryTestIssue("retrying", "digitaldrywood/symphony-go#21")
+
+	state.Running[running.ID] = Running{Issue: running, StartedAt: now, WorkerHost: "worker-a"}
+	state.Claimed[retrying.ID] = Claimed{Issue: retrying, ClaimedAt: now.Add(-time.Minute)}
+	state.Retry[retrying.ID] = Retry{
+		Issue:      retrying,
+		Attempt:    2,
+		DueAt:      now.Add(-time.Millisecond),
+		Error:      "previous failure",
+		WorkerHost: "worker-a",
+	}
+
+	orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{retrying}, now)
+
+	retry, ok := state.Retry[retrying.ID]
+	if !ok {
+		t.Fatalf("Retry[%q] missing after worker capacity refusal", retrying.ID)
+	}
+	if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 2", retrying.ID, retry.Attempt)
+	}
+	if retry.WorkerHost != "worker-a" {
+		t.Fatalf("Retry[%q].WorkerHost = %q, want worker-a", retrying.ID, retry.WorkerHost)
+	}
+}
+
 func retryTestIssue(id, identifier string) connector.Issue {
 	issue := connector.NewIssue()
 	issue.ID = id

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -15,9 +15,10 @@ type Runner interface {
 }
 
 type RunRequest struct {
-	Issue     connector.Issue
-	Attempt   int
-	StartedAt time.Time
+	Issue      connector.Issue
+	Attempt    int
+	StartedAt  time.Time
+	WorkerHost string
 }
 
 type RunResult struct {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -22,9 +22,10 @@ type State struct {
 }
 
 type Running struct {
-	Issue     connector.Issue
-	Attempt   int
-	StartedAt time.Time
+	Issue      connector.Issue
+	Attempt    int
+	StartedAt  time.Time
+	WorkerHost string
 }
 
 type Claimed struct {
@@ -47,10 +48,11 @@ type Completed struct {
 }
 
 type Retry struct {
-	Issue   connector.Issue
-	Attempt int
-	DueAt   time.Time
-	Error   string
+	Issue      connector.Issue
+	Attempt    int
+	DueAt      time.Time
+	Error      string
+	WorkerHost string
 }
 
 type BudgetRefusal struct {


### PR DESCRIPTION
## Summary
- Add dispatch-side eligibility checks for active/terminal state, blocked/claimed/running issues, and budget refusal cooldowns.
- Wire worker host settings into the orchestrator and enforce per-host capacity while preserving retry host affinity.
- Add focused table-driven orchestrator tests for filters, capacity checks, worker host selection, and retry preservation.

Fixes #12

## Test Plan
- go test ./internal/orchestrator
- go test -race ./internal/orchestrator
- make check