### PR TITLE
feat(scheduler): add counting semaphore

### DIFF
--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -1,0 +1,278 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+)
+
+const defaultCapacity = 1
+
+const (
+	ModeCountingSemaphore Mode = "counting_semaphore"
+)
+
+var (
+	ErrInvalidWeight         = errors.New("scheduler slot weight must be positive")
+	ErrNoSlots               = errors.New("scheduler slot unavailable")
+	ErrSlotNotHeld           = errors.New("scheduler slot is not held")
+	ErrUnsupportedBackend    = errors.New("unsupported scheduler backend")
+	ErrWeightExceedsCapacity = errors.New("scheduler slot weight exceeds capacity")
+)
+
+type Mode string
+
+type Scheduler interface {
+	RequestSlot(context.Context, SlotRequest) (Slot, error)
+	ReleaseSlot(Slot) error
+	Mode() Mode
+}
+
+type Config struct {
+	Kind            string
+	Capacity        int
+	CapacityByState map[string]int
+	CapacityPerHost int
+}
+
+type SlotRequest struct {
+	State  string
+	Host   string
+	Weight int
+}
+
+type Slot struct {
+	State  string
+	Host   string
+	Weight int
+	token  uint64
+}
+
+type Counters struct {
+	Used        int
+	UsedByState map[string]int
+	UsedByHost  map[string]int
+}
+
+type CountingSemaphore struct {
+	mu              sync.Mutex
+	capacity        int
+	capacityByState map[string]int
+	capacityPerHost int
+	used            int
+	usedByState     map[string]int
+	usedByHost      map[string]int
+	active          map[uint64]Slot
+	nextToken       uint64
+}
+
+var _ Scheduler = (*CountingSemaphore)(nil)
+
+func NewFromConfig(cfg Config) (Scheduler, error) {
+	switch normalizeKind(cfg.Kind) {
+	case "", "counting_semaphore", "semaphore":
+		return NewCountingSemaphore(cfg), nil
+	default:
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, strings.TrimSpace(cfg.Kind))
+	}
+}
+
+func NewCountingSemaphore(cfg Config) *CountingSemaphore {
+	capacity := cfg.Capacity
+	if capacity <= 0 {
+		capacity = defaultCapacity
+	}
+
+	return &CountingSemaphore{
+		capacity:        capacity,
+		capacityByState: normalizedCapacities(cfg.CapacityByState),
+		capacityPerHost: normalizedCapacity(cfg.CapacityPerHost),
+		usedByState:     map[string]int{},
+		usedByHost:      map[string]int{},
+		active:          map[uint64]Slot{},
+	}
+}
+
+func (s *CountingSemaphore) Mode() Mode {
+	return ModeCountingSemaphore
+}
+
+func (s *CountingSemaphore) RequestSlot(ctx context.Context, req SlotRequest) (Slot, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return Slot{}, ctx.Err()
+	default:
+	}
+
+	slot, err := normalizeRequest(req)
+	if err != nil {
+		return Slot{}, err
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		return Slot{}, ctx.Err()
+	default:
+	}
+
+	if err := s.checkCapacity(slot); err != nil {
+		return Slot{}, err
+	}
+	if !s.canGrant(slot) {
+		return Slot{}, ErrNoSlots
+	}
+
+	slot.token = s.nextSlotToken()
+	s.active[slot.token] = slot
+	s.used += slot.Weight
+	increment(s.usedByState, slot.State, slot.Weight)
+	increment(s.usedByHost, slot.Host, slot.Weight)
+
+	return slot, nil
+}
+
+func (s *CountingSemaphore) ReleaseSlot(slot Slot) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	held, ok := s.active[slot.token]
+	if !ok || slot.token == 0 {
+		return ErrSlotNotHeld
+	}
+
+	delete(s.active, slot.token)
+	s.used -= held.Weight
+	decrement(s.usedByState, held.State, held.Weight)
+	decrement(s.usedByHost, held.Host, held.Weight)
+
+	return nil
+}
+
+func (s *CountingSemaphore) Counters() Counters {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return Counters{
+		Used:        s.used,
+		UsedByState: cloneIntMap(s.usedByState),
+		UsedByHost:  cloneIntMap(s.usedByHost),
+	}
+}
+
+func (s *CountingSemaphore) checkCapacity(slot Slot) error {
+	if slot.Weight > s.capacity {
+		return fmt.Errorf("%w: global capacity %d", ErrWeightExceedsCapacity, s.capacity)
+	}
+	if capacity, ok := s.capacityByState[slot.State]; ok && slot.Weight > capacity {
+		return fmt.Errorf("%w: state %q capacity %d", ErrWeightExceedsCapacity, slot.State, capacity)
+	}
+	if slot.Host != "" && s.capacityPerHost > 0 && slot.Weight > s.capacityPerHost {
+		return fmt.Errorf("%w: host %q capacity %d", ErrWeightExceedsCapacity, slot.Host, s.capacityPerHost)
+	}
+
+	return nil
+}
+
+func (s *CountingSemaphore) canGrant(slot Slot) bool {
+	if s.used+slot.Weight > s.capacity {
+		return false
+	}
+	if capacity, ok := s.capacityByState[slot.State]; ok && s.usedByState[slot.State]+slot.Weight > capacity {
+		return false
+	}
+	if slot.Host != "" && s.capacityPerHost > 0 && s.usedByHost[slot.Host]+slot.Weight > s.capacityPerHost {
+		return false
+	}
+
+	return true
+}
+
+func (s *CountingSemaphore) nextSlotToken() uint64 {
+	s.nextToken++
+	if s.nextToken == 0 {
+		s.nextToken++
+	}
+	return s.nextToken
+}
+
+func normalizeRequest(req SlotRequest) (Slot, error) {
+	weight := req.Weight
+	if weight == 0 {
+		weight = 1
+	}
+	if weight < 0 {
+		return Slot{}, ErrInvalidWeight
+	}
+
+	return Slot{
+		State:  normalizeState(req.State),
+		Host:   normalizeHost(req.Host),
+		Weight: weight,
+	}, nil
+}
+
+func normalizedCapacities(values map[string]int) map[string]int {
+	normalized := make(map[string]int, len(values))
+	for key, value := range values {
+		key = normalizeState(key)
+		value = normalizedCapacity(value)
+		if key == "" || value == 0 {
+			continue
+		}
+		normalized[key] = value
+	}
+	return normalized
+}
+
+func normalizedCapacity(value int) int {
+	if value <= 0 {
+		return 0
+	}
+	return value
+}
+
+func increment(values map[string]int, key string, value int) {
+	if key == "" {
+		return
+	}
+	values[key] += value
+}
+
+func decrement(values map[string]int, key string, value int) {
+	if key == "" {
+		return
+	}
+
+	values[key] -= value
+	if values[key] <= 0 {
+		delete(values, key)
+	}
+}
+
+func cloneIntMap(values map[string]int) map[string]int {
+	cloned := make(map[string]int, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func normalizeKind(kind string) string {
+	return strings.ToLower(strings.TrimSpace(kind))
+}
+
+func normalizeState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func normalizeHost(host string) string {
+	return strings.TrimSpace(host)
+}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -1,0 +1,330 @@
+package scheduler_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sync"
+	"testing"
+
+	"github.com/digitaldrywood/symphony-go/internal/scheduler"
+)
+
+func TestNewFromConfigReturnsCountingSemaphore(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		kind string
+	}{
+		{name: "empty defaults to counting semaphore", kind: ""},
+		{name: "counting semaphore", kind: "counting_semaphore"},
+		{name: "semaphore alias", kind: " semaphore "},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := scheduler.NewFromConfig(scheduler.Config{
+				Kind:     tt.kind,
+				Capacity: 2,
+			})
+			if err != nil {
+				t.Fatalf("NewFromConfig() error = %v", err)
+			}
+			if got.Mode() != scheduler.ModeCountingSemaphore {
+				t.Fatalf("Mode() = %q, want %q", got.Mode(), scheduler.ModeCountingSemaphore)
+			}
+		})
+	}
+}
+
+func TestNewFromConfigRejectsUnsupportedBackend(t *testing.T) {
+	t.Parallel()
+
+	got, err := scheduler.NewFromConfig(scheduler.Config{Kind: "remote"})
+	if got != nil {
+		t.Fatalf("scheduler = %T, want nil", got)
+	}
+	if !errors.Is(err, scheduler.ErrUnsupportedBackend) {
+		t.Fatalf("error = %v, want ErrUnsupportedBackend", err)
+	}
+}
+
+func TestCountingSemaphoreRequestSlotEnforcesGlobalWeightedCapacity(t *testing.T) {
+	t.Parallel()
+
+	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 3})
+	first, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{
+		State:  "Todo",
+		Weight: 2,
+	})
+	if err != nil {
+		t.Fatalf("RequestSlot() first error = %v", err)
+	}
+
+	_, err = sched.RequestSlot(context.Background(), scheduler.SlotRequest{
+		State:  "In Progress",
+		Weight: 2,
+	})
+	if !errors.Is(err, scheduler.ErrNoSlots) {
+		t.Fatalf("RequestSlot() second error = %v, want ErrNoSlots", err)
+	}
+
+	if err := sched.ReleaseSlot(first); err != nil {
+		t.Fatalf("ReleaseSlot() error = %v", err)
+	}
+	if _, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{Weight: 2}); err != nil {
+		t.Fatalf("RequestSlot() after release error = %v", err)
+	}
+}
+
+func TestCountingSemaphoreTracksStateAndHostCounters(t *testing.T) {
+	t.Parallel()
+
+	sched := scheduler.NewCountingSemaphore(scheduler.Config{
+		Capacity: 4,
+		CapacityByState: map[string]int{
+			"todo": 3,
+		},
+		CapacityPerHost: 2,
+	})
+
+	first, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{
+		State:  " Todo ",
+		Host:   " worker-a ",
+		Weight: 2,
+	})
+	if err != nil {
+		t.Fatalf("RequestSlot() first error = %v", err)
+	}
+
+	assertCounters(t, sched.Counters(), scheduler.Counters{
+		Used:        2,
+		UsedByState: map[string]int{"todo": 2},
+		UsedByHost:  map[string]int{"worker-a": 2},
+	})
+
+	_, err = sched.RequestSlot(context.Background(), scheduler.SlotRequest{
+		State: "Todo",
+		Host:  "worker-a",
+	})
+	if !errors.Is(err, scheduler.ErrNoSlots) {
+		t.Fatalf("RequestSlot() host-capped error = %v, want ErrNoSlots", err)
+	}
+
+	second, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{
+		State: "Todo",
+		Host:  "worker-b",
+	})
+	if err != nil {
+		t.Fatalf("RequestSlot() second error = %v", err)
+	}
+
+	_, err = sched.RequestSlot(context.Background(), scheduler.SlotRequest{
+		State: "Todo",
+		Host:  "worker-b",
+	})
+	if !errors.Is(err, scheduler.ErrNoSlots) {
+		t.Fatalf("RequestSlot() state-capped error = %v, want ErrNoSlots", err)
+	}
+
+	if err := sched.ReleaseSlot(first); err != nil {
+		t.Fatalf("ReleaseSlot() first error = %v", err)
+	}
+	assertCounters(t, sched.Counters(), scheduler.Counters{
+		Used:        1,
+		UsedByState: map[string]int{"todo": 1},
+		UsedByHost:  map[string]int{"worker-b": 1},
+	})
+
+	if err := sched.ReleaseSlot(second); err != nil {
+		t.Fatalf("ReleaseSlot() second error = %v", err)
+	}
+	assertCounters(t, sched.Counters(), scheduler.Counters{
+		UsedByState: map[string]int{},
+		UsedByHost:  map[string]int{},
+	})
+}
+
+func TestCountingSemaphoreValidatesWeight(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  scheduler.Config
+		req  scheduler.SlotRequest
+		want error
+	}{
+		{
+			name: "negative weight",
+			cfg:  scheduler.Config{Capacity: 2},
+			req:  scheduler.SlotRequest{Weight: -1},
+			want: scheduler.ErrInvalidWeight,
+		},
+		{
+			name: "global capacity",
+			cfg:  scheduler.Config{Capacity: 2},
+			req:  scheduler.SlotRequest{Weight: 3},
+			want: scheduler.ErrWeightExceedsCapacity,
+		},
+		{
+			name: "state capacity",
+			cfg: scheduler.Config{
+				Capacity:        3,
+				CapacityByState: map[string]int{"todo": 1},
+			},
+			req:  scheduler.SlotRequest{State: "Todo", Weight: 2},
+			want: scheduler.ErrWeightExceedsCapacity,
+		},
+		{
+			name: "host capacity",
+			cfg: scheduler.Config{
+				Capacity:        3,
+				CapacityPerHost: 1,
+			},
+			req:  scheduler.SlotRequest{Host: "worker-a", Weight: 2},
+			want: scheduler.ErrWeightExceedsCapacity,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			sched := scheduler.NewCountingSemaphore(tt.cfg)
+			_, err := sched.RequestSlot(context.Background(), tt.req)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("RequestSlot() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestCountingSemaphoreRespectsContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 1})
+	_, err := sched.RequestSlot(ctx, scheduler.SlotRequest{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("RequestSlot() error = %v, want context.Canceled", err)
+	}
+}
+
+func TestCountingSemaphoreRejectsUnknownOrDuplicateRelease(t *testing.T) {
+	t.Parallel()
+
+	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 1})
+	if err := sched.ReleaseSlot(scheduler.Slot{}); !errors.Is(err, scheduler.ErrSlotNotHeld) {
+		t.Fatalf("ReleaseSlot() unknown error = %v, want ErrSlotNotHeld", err)
+	}
+
+	slot, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{})
+	if err != nil {
+		t.Fatalf("RequestSlot() error = %v", err)
+	}
+	if err := sched.ReleaseSlot(slot); err != nil {
+		t.Fatalf("ReleaseSlot() first error = %v", err)
+	}
+	if err := sched.ReleaseSlot(slot); !errors.Is(err, scheduler.ErrSlotNotHeld) {
+		t.Fatalf("ReleaseSlot() duplicate error = %v, want ErrSlotNotHeld", err)
+	}
+}
+
+func TestCountingSemaphoreCountersAreDefensiveCopies(t *testing.T) {
+	t.Parallel()
+
+	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 2})
+	if _, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{
+		State: "Todo",
+		Host:  "worker-a",
+	}); err != nil {
+		t.Fatalf("RequestSlot() error = %v", err)
+	}
+
+	counters := sched.Counters()
+	counters.UsedByState["todo"] = 99
+	counters.UsedByHost["worker-a"] = 99
+
+	assertCounters(t, sched.Counters(), scheduler.Counters{
+		Used:        1,
+		UsedByState: map[string]int{"todo": 1},
+		UsedByHost:  map[string]int{"worker-a": 1},
+	})
+}
+
+func TestCountingSemaphoreSupportsConcurrentRequests(t *testing.T) {
+	t.Parallel()
+
+	const capacity = 5
+	const workers = 20
+
+	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: capacity})
+	start := make(chan struct{})
+	results := make(chan error, workers)
+	slots := make(chan scheduler.Slot, capacity)
+	var wg sync.WaitGroup
+
+	for range workers {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+
+			slot, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{})
+			if err == nil {
+				slots <- slot
+			}
+			results <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(results)
+	close(slots)
+
+	successes := 0
+	failures := 0
+	for err := range results {
+		switch {
+		case err == nil:
+			successes++
+		case errors.Is(err, scheduler.ErrNoSlots):
+			failures++
+		default:
+			t.Fatalf("RequestSlot() error = %v", err)
+		}
+	}
+
+	if successes != capacity {
+		t.Fatalf("successful requests = %d, want %d", successes, capacity)
+	}
+	if failures != workers-capacity {
+		t.Fatalf("failed requests = %d, want %d", failures, workers-capacity)
+	}
+
+	for slot := range slots {
+		if err := sched.ReleaseSlot(slot); err != nil {
+			t.Fatalf("ReleaseSlot() error = %v", err)
+		}
+	}
+}
+
+func assertCounters(t *testing.T, got scheduler.Counters, want scheduler.Counters) {
+	t.Helper()
+
+	if got.Used != want.Used {
+		t.Fatalf("Used = %d, want %d", got.Used, want.Used)
+	}
+	if !reflect.DeepEqual(got.UsedByState, want.UsedByState) {
+		t.Fatalf("UsedByState = %#v, want %#v", got.UsedByState, want.UsedByState)
+	}
+	if !reflect.DeepEqual(got.UsedByHost, want.UsedByHost) {
+		t.Fatalf("UsedByHost = %#v, want %#v", got.UsedByHost, want.UsedByHost)
+	}
+}


### PR DESCRIPTION
## Summary
- Add the internal scheduler interface and factory for the counting semaphore backend.
- Implement weighted slot requests, release token tracking, and per-state/per-host counters.
- Cover scheduler mode, capacity checks, release safety, context cancellation, counter snapshots, and concurrent requests.

Fixes #13

## Test Plan
- go test ./internal/scheduler
- go test -race ./internal/scheduler
- make check