### PR TITLE
feat(orchestrator): add auto-promote evaluator

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -1,0 +1,207 @@
+package orchestrator
+
+import (
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+type AutoPromoteConfig struct {
+	Enabled            bool
+	QuietDuration      time.Duration
+	OptoutLabel        string
+	AllowedIssueLabels []string
+}
+
+type AutoPromoteSummary struct {
+	PullRequestPresent bool
+	PullRequestURL     string
+	CIStatus           string
+	ReviewState        string
+	P1Findings         []AutoPromoteFinding
+	LastActivityAt     *time.Time
+}
+
+type AutoPromoteFinding struct {
+	Body string
+	URL  string
+	Path string
+	Line int
+}
+
+type AutoPromoteAction string
+
+const (
+	AutoPromoteActionPromote     AutoPromoteAction = "promote"
+	AutoPromoteActionRework      AutoPromoteAction = "rework"
+	AutoPromoteActionAwaitReview AutoPromoteAction = "await_review"
+	AutoPromoteActionSkip        AutoPromoteAction = "skip"
+)
+
+type AutoPromoteReason string
+
+const (
+	AutoPromoteReasonReady               AutoPromoteReason = "ready"
+	AutoPromoteReasonDisabled            AutoPromoteReason = "disabled"
+	AutoPromoteReasonOptoutLabel         AutoPromoteReason = "optout_label"
+	AutoPromoteReasonLabelNotAllowed     AutoPromoteReason = "label_not_allowed"
+	AutoPromoteReasonMissingPullRequest  AutoPromoteReason = "missing_pull_request"
+	AutoPromoteReasonCINotGreen          AutoPromoteReason = "ci_not_green"
+	AutoPromoteReasonCodexReviewMissing  AutoPromoteReason = "codex_review_missing"
+	AutoPromoteReasonP1Findings          AutoPromoteReason = "p1_findings"
+	AutoPromoteReasonCodexReviewNotQuiet AutoPromoteReason = "codex_review_not_quiet"
+)
+
+type AutoPromoteDecision struct {
+	Action         AutoPromoteAction
+	Reason         AutoPromoteReason
+	CIStatus       string
+	QuietRemaining time.Duration
+	Findings       []AutoPromoteFinding
+}
+
+func EvaluateAutoPromote(
+	issue connector.Issue,
+	summary AutoPromoteSummary,
+	cfg AutoPromoteConfig,
+	now time.Time,
+) AutoPromoteDecision {
+	cfg = normalizeAutoPromoteConfig(cfg)
+
+	if !cfg.Enabled {
+		return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonDisabled)
+	}
+	if autoPromoteOptoutLabel(issue, cfg) {
+		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonOptoutLabel)
+	}
+	if !autoPromoteAllowedIssueLabel(issue, cfg) {
+		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonLabelNotAllowed)
+	}
+	if autoPromoteMissingPullRequest(summary) {
+		return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonMissingPullRequest)
+	}
+	if normalizeAutoPromoteCIStatus(summary.CIStatus) != "green" {
+		decision := autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen)
+		decision.CIStatus = normalizeAutoPromoteCIStatus(summary.CIStatus)
+		return decision
+	}
+	if !autoPromoteCodexReviewSubmitted(summary) {
+		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonCodexReviewMissing)
+	}
+	if len(summary.P1Findings) > 0 {
+		decision := autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonP1Findings)
+		decision.Findings = cloneAutoPromoteFindings(summary.P1Findings)
+		return decision
+	}
+	if remaining := autoPromoteQuietRemaining(summary, cfg, now); remaining > 0 {
+		decision := autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonCodexReviewNotQuiet)
+		decision.QuietRemaining = remaining
+		return decision
+	}
+
+	return autoPromoteDecision(AutoPromoteActionPromote, AutoPromoteReasonReady)
+}
+
+func autoPromoteDecision(action AutoPromoteAction, reason AutoPromoteReason) AutoPromoteDecision {
+	return AutoPromoteDecision{
+		Action: action,
+		Reason: reason,
+	}
+}
+
+func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
+	if cfg.QuietDuration < 0 {
+		cfg.QuietDuration = 0
+	}
+	cfg.OptoutLabel = normalizeLabel(cfg.OptoutLabel)
+	cfg.AllowedIssueLabels = normalizeLabels(cfg.AllowedIssueLabels)
+	return cfg
+}
+
+func autoPromoteOptoutLabel(issue connector.Issue, cfg AutoPromoteConfig) bool {
+	if cfg.OptoutLabel == "" {
+		return false
+	}
+
+	for _, label := range issue.Labels {
+		if normalizeLabel(label) == cfg.OptoutLabel {
+			return true
+		}
+	}
+	return false
+}
+
+func autoPromoteAllowedIssueLabel(issue connector.Issue, cfg AutoPromoteConfig) bool {
+	if len(cfg.AllowedIssueLabels) == 0 {
+		return true
+	}
+
+	allowed := make(map[string]struct{}, len(cfg.AllowedIssueLabels))
+	for _, label := range cfg.AllowedIssueLabels {
+		allowed[label] = struct{}{}
+	}
+	for _, label := range issue.Labels {
+		if _, ok := allowed[normalizeLabel(label)]; ok {
+			return true
+		}
+	}
+	return false
+}
+
+func autoPromoteMissingPullRequest(summary AutoPromoteSummary) bool {
+	return !summary.PullRequestPresent && strings.TrimSpace(summary.PullRequestURL) == ""
+}
+
+func normalizeAutoPromoteCIStatus(status string) string {
+	return strings.ToLower(strings.TrimSpace(status))
+}
+
+func autoPromoteCodexReviewSubmitted(summary AutoPromoteSummary) bool {
+	switch strings.ToUpper(strings.TrimSpace(summary.ReviewState)) {
+	case "APPROVED", "COMMENTED", "REQUESTED_CHANGES":
+		return true
+	default:
+		return false
+	}
+}
+
+func autoPromoteQuietRemaining(summary AutoPromoteSummary, cfg AutoPromoteConfig, now time.Time) time.Duration {
+	if cfg.QuietDuration <= 0 {
+		return 0
+	}
+	if summary.LastActivityAt == nil {
+		return cfg.QuietDuration
+	}
+
+	remaining := cfg.QuietDuration - now.Sub(*summary.LastActivityAt)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func cloneAutoPromoteFindings(findings []AutoPromoteFinding) []AutoPromoteFinding {
+	return append([]AutoPromoteFinding(nil), findings...)
+}
+
+func normalizeLabel(label string) string {
+	return strings.ToLower(strings.TrimSpace(label))
+}
+
+func normalizeLabels(labels []string) []string {
+	normalized := make([]string, 0, len(labels))
+	seen := make(map[string]struct{}, len(labels))
+	for _, label := range labels {
+		label = normalizeLabel(label)
+		if label == "" {
+			continue
+		}
+		if _, ok := seen[label]; ok {
+			continue
+		}
+		seen[label] = struct{}{}
+		normalized = append(normalized, label)
+	}
+	return normalized
+}

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -159,7 +159,7 @@ func normalizeAutoPromoteCIStatus(status string) string {
 
 func autoPromoteCodexReviewSubmitted(summary AutoPromoteSummary) bool {
 	switch strings.ToUpper(strings.TrimSpace(summary.ReviewState)) {
-	case "APPROVED", "COMMENTED", "REQUESTED_CHANGES":
+	case "APPROVED", "COMMENTED", "REQUESTED_CHANGES", "CHANGES_REQUESTED":
 		return true
 	default:
 		return false

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -134,6 +134,23 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
+			name:  "GitHub changes requested review counts as submitted",
+			issue: autoPromoteTestIssue("issue-github-changes-requested", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				ReviewState:    "CHANGES_REQUESTED",
+				P1Findings:     []AutoPromoteFinding{finding},
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action:   AutoPromoteActionRework,
+				Reason:   AutoPromoteReasonP1Findings,
+				Findings: []AutoPromoteFinding{finding},
+			},
+		},
+		{
 			name:  "recent Codex activity awaits quiet window",
 			issue: autoPromoteTestIssue("issue-recent", nil),
 			cfg:   enabled,

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -1,0 +1,233 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestEvaluateAutoPromote(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 22, 12, 0, 0, 0, time.UTC)
+	oldActivity := now.Add(-20 * time.Minute)
+	recentActivity := now.Add(-30 * time.Second)
+	finding := AutoPromoteFinding{
+		Body: "![P1 Badge](https://example.test/p1.svg) The migration drops rows.",
+		URL:  "https://github.test/comment/p1",
+		Path: "db/migrations/example.sql",
+		Line: 7,
+	}
+
+	enabled := AutoPromoteConfig{
+		Enabled:       true,
+		QuietDuration: 10 * time.Minute,
+		OptoutLabel:   "requires-human-review",
+	}
+	ready := AutoPromoteSummary{
+		PullRequestURL: "https://github.test/pull/42",
+		CIStatus:       "green",
+		ReviewState:    "COMMENTED",
+		LastActivityAt: &oldActivity,
+	}
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		cfg   AutoPromoteConfig
+		input AutoPromoteSummary
+		want  AutoPromoteDecision
+	}{
+		{
+			name:  "disabled",
+			issue: autoPromoteTestIssue("issue-disabled", nil),
+			cfg:   AutoPromoteConfig{Enabled: false},
+			input: ready,
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionSkip,
+				Reason: AutoPromoteReasonDisabled,
+			},
+		},
+		{
+			name:  "opt-out label awaits human review",
+			issue: autoPromoteTestIssue("issue-optout", []string{"Requires-Human-Review", "docs"}),
+			cfg: AutoPromoteConfig{
+				Enabled:            true,
+				QuietDuration:      10 * time.Minute,
+				OptoutLabel:        "requires-human-review",
+				AllowedIssueLabels: []string{"docs"},
+			},
+			input: ready,
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonOptoutLabel,
+			},
+		},
+		{
+			name:  "allowed label miss awaits human review",
+			issue: autoPromoteTestIssue("issue-label-miss", []string{"enhancement"}),
+			cfg: AutoPromoteConfig{
+				Enabled:            true,
+				QuietDuration:      10 * time.Minute,
+				OptoutLabel:        "requires-human-review",
+				AllowedIssueLabels: []string{"docs"},
+			},
+			input: ready,
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonLabelNotAllowed,
+			},
+		},
+		{
+			name:  "missing pull request skips",
+			issue: autoPromoteTestIssue("issue-missing-pr", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionSkip,
+				Reason: AutoPromoteReasonMissingPullRequest,
+			},
+		},
+		{
+			name:  "red ci skips",
+			issue: autoPromoteTestIssue("issue-red-ci", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "red",
+			},
+			want: AutoPromoteDecision{
+				Action:   AutoPromoteActionSkip,
+				Reason:   AutoPromoteReasonCINotGreen,
+				CIStatus: "red",
+			},
+		},
+		{
+			name:  "missing Codex review awaits human review",
+			issue: autoPromoteTestIssue("issue-missing-review", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonCodexReviewMissing,
+			},
+		},
+		{
+			name:  "P1 findings move to rework",
+			issue: autoPromoteTestIssue("issue-p1", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				ReviewState:    "APPROVED",
+				P1Findings:     []AutoPromoteFinding{finding},
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action:   AutoPromoteActionRework,
+				Reason:   AutoPromoteReasonP1Findings,
+				Findings: []AutoPromoteFinding{finding},
+			},
+		},
+		{
+			name:  "recent Codex activity awaits quiet window",
+			issue: autoPromoteTestIssue("issue-recent", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				ReviewState:    "REQUESTED_CHANGES",
+				LastActivityAt: &recentActivity,
+			},
+			want: AutoPromoteDecision{
+				Action:         AutoPromoteActionAwaitReview,
+				Reason:         AutoPromoteReasonCodexReviewNotQuiet,
+				QuietRemaining: 570 * time.Second,
+			},
+		},
+		{
+			name:  "missing last activity awaits full quiet window",
+			issue: autoPromoteTestIssue("issue-missing-activity", nil),
+			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				ReviewState:    "COMMENTED",
+			},
+			want: AutoPromoteDecision{
+				Action:         AutoPromoteActionAwaitReview,
+				Reason:         AutoPromoteReasonCodexReviewNotQuiet,
+				QuietRemaining: 10 * time.Minute,
+			},
+		},
+		{
+			name:  "quiet validated pull request promotes",
+			issue: autoPromoteTestIssue("issue-promote", nil),
+			cfg:   enabled,
+			input: ready,
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+		{
+			name:  "zero quiet duration promotes without activity timestamp",
+			issue: autoPromoteTestIssue("issue-zero-quiet", nil),
+			cfg: AutoPromoteConfig{
+				Enabled:     true,
+				OptoutLabel: "requires-human-review",
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				ReviewState:    "COMMENTED",
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := EvaluateAutoPromote(tt.issue, tt.input, tt.cfg, now)
+			if got.Action != tt.want.Action {
+				t.Fatalf("Action = %q, want %q", got.Action, tt.want.Action)
+			}
+			if got.Reason != tt.want.Reason {
+				t.Fatalf("Reason = %q, want %q", got.Reason, tt.want.Reason)
+			}
+			if got.CIStatus != tt.want.CIStatus {
+				t.Fatalf("CIStatus = %q, want %q", got.CIStatus, tt.want.CIStatus)
+			}
+			if got.QuietRemaining != tt.want.QuietRemaining {
+				t.Fatalf("QuietRemaining = %s, want %s", got.QuietRemaining, tt.want.QuietRemaining)
+			}
+			if len(got.Findings) != len(tt.want.Findings) {
+				t.Fatalf("Findings len = %d, want %d", len(got.Findings), len(tt.want.Findings))
+			}
+			for i := range tt.want.Findings {
+				if got.Findings[i] != tt.want.Findings[i] {
+					t.Fatalf("Findings[%d] = %#v, want %#v", i, got.Findings[i], tt.want.Findings[i])
+				}
+			}
+		})
+	}
+}
+
+func autoPromoteTestIssue(id string, labels []string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/symphony-go#15"
+	issue.Title = "Auto promote"
+	issue.State = "Human Review"
+	issue.Labels = append([]string(nil), labels...)
+	return issue
+}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -17,6 +17,10 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Worker.SSHHosts = []string{"worker-a", "worker-b"}
 	cfg.Worker.MaxConcurrentAgentsPerHost = &perHost
 	cfg.Budget.RefusalCooldownSeconds = 45
+	cfg.Agent.AutoPromote.Enabled = true
+	cfg.Agent.AutoPromote.QuietSeconds = 30
+	cfg.Agent.AutoPromote.OptoutLabel = " Requires-Human-Review "
+	cfg.Agent.AutoPromote.AllowedIssueLabels = []string{" Docs ", "docs", "Chore"}
 
 	got := ConfigFromWorkflow(cfg)
 
@@ -28,6 +32,20 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.BudgetRefusalCooldown != 45*time.Second {
 		t.Fatalf("BudgetRefusalCooldown = %s, want 45s", got.BudgetRefusalCooldown)
+	}
+	if !got.AutoPromote.Enabled {
+		t.Fatal("AutoPromote.Enabled = false, want true")
+	}
+	if got.AutoPromote.QuietDuration != 30*time.Second {
+		t.Fatalf("AutoPromote.QuietDuration = %s, want 30s", got.AutoPromote.QuietDuration)
+	}
+	if got.AutoPromote.OptoutLabel != "requires-human-review" {
+		t.Fatalf("AutoPromote.OptoutLabel = %q, want requires-human-review", got.AutoPromote.OptoutLabel)
+	}
+	if len(got.AutoPromote.AllowedIssueLabels) != 2 ||
+		got.AutoPromote.AllowedIssueLabels[0] != "docs" ||
+		got.AutoPromote.AllowedIssueLabels[1] != "chore" {
+		t.Fatalf("AutoPromote.AllowedIssueLabels = %#v, want docs and chore", got.AutoPromote.AllowedIssueLabels)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -32,6 +32,7 @@ type Config struct {
 	DispatchPriorityByState    []string
 	MaxConcurrentAgentsPerHost int
 	MaxRetryBackoff            time.Duration
+	AutoPromote                AutoPromoteConfig
 	ActiveStates               []string
 	TerminalStates             []string
 	WorkerHosts                []string
@@ -75,10 +76,16 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		DispatchPriorityByState:    append([]string(nil), cfg.Agent.DispatchPriorityByState...),
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
-		ActiveStates:               append([]string(nil), cfg.Tracker.ActiveStates...),
-		TerminalStates:             append([]string(nil), cfg.Tracker.TerminalStates...),
-		WorkerHosts:                append([]string(nil), cfg.Worker.SSHHosts...),
-		BudgetRefusalCooldown:      durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
+		AutoPromote: normalizeAutoPromoteConfig(AutoPromoteConfig{
+			Enabled:            cfg.Agent.AutoPromote.Enabled,
+			QuietDuration:      durationFromSeconds(cfg.Agent.AutoPromote.QuietSeconds),
+			OptoutLabel:        cfg.Agent.AutoPromote.OptoutLabel,
+			AllowedIssueLabels: append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
+		}),
+		ActiveStates:          append([]string(nil), cfg.Tracker.ActiveStates...),
+		TerminalStates:        append([]string(nil), cfg.Tracker.TerminalStates...),
+		WorkerHosts:           append([]string(nil), cfg.Worker.SSHHosts...),
+		BudgetRefusalCooldown: durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
 	}
 }
 
@@ -553,6 +560,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
+	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
 	cfg.WorkerHosts = normalizeWorkerHosts(cfg.WorkerHosts)
 	if cfg.MaxConcurrentAgentsPerHost < 0 {
 		cfg.MaxConcurrentAgentsPerHost = 0


### PR DESCRIPTION
## Summary
- add the orchestrator auto-promote evaluator ported from the Elixir quiet-window and review-signal rules
- map workflow `agent.auto_promote` config into orchestrator config with label normalization and quiet duration
- cover disabled, opt-out, allowed-label, CI, review, P1, quiet-window, and promotion decisions

Fixes #15

## Test Plan
- go test ./internal/orchestrator -run 'TestEvaluateAutoPromote|TestConfigFromWorkflowIncludesDispatchControls'\n- go test ./internal/orchestrator\n- make check