### PR TITLE
test(orchestrator): add Elixir dispatch gate

### DIFF
--- a/internal/orchestrator/dispatch_parity_test.go
+++ b/internal/orchestrator/dispatch_parity_test.go
@@ -1,0 +1,278 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestDispatchParityWithElixirRecordedCandidateSets(t *testing.T) {
+	t.Parallel()
+
+	fixture := loadDispatchParityFixture(t)
+	for _, tt := range fixture.Cases {
+		t.Run(tt.Name, func(t *testing.T) {
+			t.Parallel()
+
+			now := mustParseParityTime(t, tt.Now)
+			cfg := normalizeConfig(Config{
+				MaxConcurrentAgents:        tt.Config.MaxConcurrentAgents,
+				MaxConcurrentAgentsByState: tt.Config.MaxConcurrentAgentsByState,
+				DispatchPriorityByState:    tt.Config.DispatchPriorityByState,
+				ActiveStates:               tt.Config.ActiveStates,
+				TerminalStates:             tt.Config.TerminalStates,
+				WorkerHosts:                tt.Config.WorkerHosts,
+				MaxConcurrentAgentsPerHost: tt.Config.MaxConcurrentAgentsPerHost,
+				BudgetRefusalCooldown:      time.Duration(tt.Config.BudgetRefusalCooldownSeconds) * time.Second,
+			})
+			orch := Orchestrator{cfg: cfg, runner: parityBlockingRunner{}, runResults: make(chan runResultEvent)}
+			state := newState(cfg)
+			applyParityInitialState(t, &state, tt.InitialState, now)
+
+			candidates := parityIssues(t, tt.Candidates)
+			sortIssuesForDispatch(candidates, cfg.DispatchPriorityByState)
+			orch.pruneBudgetRefusals(&state, now)
+			orch.trackBlockedCandidates(&state, candidates, now)
+
+			gotOrder := parityDispatchOrder(&orch, state.clone(), candidates, now)
+			if !slices.Equal(gotOrder, tt.Want.DispatchOrder) {
+				t.Fatalf("dispatch order = %#v, want %#v", gotOrder, tt.Want.DispatchOrder)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			orch.dispatchReadyIssues(ctx, &state, candidates, now)
+			cancel()
+
+			assertParitySet(t, "blocked", stateIDs(state.Blocked), tt.Want.Blocked)
+			assertParitySet(t, "claimed", stateIDs(state.Claimed), tt.Want.Claimed)
+			assertParitySet(t, "refusals", stateIDs(state.BudgetRefusals), tt.Want.Refusals)
+		})
+	}
+}
+
+type dispatchParityFixture struct {
+	Source string               `json:"source"`
+	Cases  []dispatchParityCase `json:"cases"`
+}
+
+type dispatchParityCase struct {
+	Name         string             `json:"name"`
+	Now          string             `json:"now"`
+	Config       dispatchParityCfg  `json:"config"`
+	InitialState parityInitialState `json:"initial_state"`
+	Candidates   []parityIssue      `json:"candidates"`
+	Want         parityWant         `json:"want"`
+}
+
+type dispatchParityCfg struct {
+	MaxConcurrentAgents          int            `json:"max_concurrent_agents"`
+	MaxConcurrentAgentsByState   map[string]int `json:"max_concurrent_agents_by_state"`
+	DispatchPriorityByState      []string       `json:"dispatch_priority_by_state"`
+	ActiveStates                 []string       `json:"active_states"`
+	TerminalStates               []string       `json:"terminal_states"`
+	BudgetRefusalCooldownSeconds int            `json:"budget_refusal_cooldown_seconds"`
+	MaxConcurrentAgentsPerHost   int            `json:"max_concurrent_agents_per_host"`
+	WorkerHosts                  []string       `json:"worker_hosts"`
+}
+
+type parityInitialState struct {
+	Running        []parityRunning       `json:"running"`
+	Claimed        []parityClaimed       `json:"claimed"`
+	Blocked        []parityBlocked       `json:"blocked"`
+	BudgetRefusals []parityBudgetRefusal `json:"budget_refusals"`
+}
+
+type parityRunning struct {
+	Issue      parityIssue `json:"issue"`
+	WorkerHost string      `json:"worker_host"`
+}
+
+type parityClaimed struct {
+	Issue parityIssue `json:"issue"`
+}
+
+type parityBlocked struct {
+	Issue  parityIssue `json:"issue"`
+	Reason string      `json:"reason"`
+}
+
+type parityBudgetRefusal struct {
+	Issue     parityIssue `json:"issue"`
+	RefusedAt string      `json:"refused_at"`
+	ResetAt   string      `json:"reset_at"`
+}
+
+type parityIssue struct {
+	ID               string                 `json:"id"`
+	Identifier       string                 `json:"identifier"`
+	Title            string                 `json:"title"`
+	State            string                 `json:"state"`
+	Priority         *int                   `json:"priority"`
+	CreatedAt        string                 `json:"created_at"`
+	BlockedBy        []connector.BlockedRef `json:"blocked_by"`
+	AssignedToWorker *bool                  `json:"assigned_to_worker"`
+}
+
+type parityWant struct {
+	DispatchOrder []string `json:"dispatch_order"`
+	Blocked       []string `json:"blocked"`
+	Claimed       []string `json:"claimed"`
+	Refusals      []string `json:"refusals"`
+}
+
+type parityBlockingRunner struct{}
+
+func (parityBlockingRunner) Run(ctx context.Context, _ RunRequest) (RunResult, error) {
+	<-ctx.Done()
+	return RunResult{}, ctx.Err()
+}
+
+func loadDispatchParityFixture(t *testing.T) dispatchParityFixture {
+	t.Helper()
+
+	path := filepath.Join("testdata", "elixir_dispatch_parity.json")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var fixture dispatchParityFixture
+	if err := json.Unmarshal(raw, &fixture); err != nil {
+		t.Fatalf("decode %s: %v", path, err)
+	}
+	if len(fixture.Cases) == 0 {
+		t.Fatalf("%s contains no parity cases", path)
+	}
+	return fixture
+}
+
+func applyParityInitialState(t *testing.T, state *State, initial parityInitialState, now time.Time) {
+	t.Helper()
+
+	for _, running := range initial.Running {
+		issue := parityConnectorIssue(t, running.Issue)
+		state.Running[issue.ID] = Running{
+			Issue:      issue,
+			StartedAt:  now,
+			WorkerHost: running.WorkerHost,
+		}
+	}
+	for _, claimed := range initial.Claimed {
+		issue := parityConnectorIssue(t, claimed.Issue)
+		state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now}
+	}
+	for _, blocked := range initial.Blocked {
+		issue := parityConnectorIssue(t, blocked.Issue)
+		state.Blocked[issue.ID] = Blocked{Issue: issue, Reason: blocked.Reason, BlockedAt: now}
+	}
+	for _, refusal := range initial.BudgetRefusals {
+		issue := parityConnectorIssue(t, refusal.Issue)
+		state.BudgetRefusals[issue.ID] = BudgetRefusal{
+			Issue:     issue,
+			RefusedAt: mustParseParityTime(t, refusal.RefusedAt),
+			ResetAt:   optionalParityTime(t, refusal.ResetAt),
+		}
+	}
+}
+
+func parityIssues(t *testing.T, issues []parityIssue) []connector.Issue {
+	t.Helper()
+
+	got := make([]connector.Issue, len(issues))
+	for i, issue := range issues {
+		got[i] = parityConnectorIssue(t, issue)
+	}
+	return got
+}
+
+func parityConnectorIssue(t *testing.T, input parityIssue) connector.Issue {
+	t.Helper()
+
+	issue := connector.NewIssue()
+	issue.ID = input.ID
+	issue.Identifier = input.Identifier
+	issue.Title = input.Title
+	issue.State = input.State
+	issue.Priority = input.Priority
+	issue.BlockedBy = append([]connector.BlockedRef(nil), input.BlockedBy...)
+	if input.CreatedAt != "" {
+		createdAt := mustParseParityTime(t, input.CreatedAt)
+		issue.CreatedAt = &createdAt
+	}
+	if input.AssignedToWorker != nil {
+		issue.AssignedToWorker = *input.AssignedToWorker
+	}
+	return issue
+}
+
+func parityDispatchOrder(orch *Orchestrator, state State, candidates []connector.Issue, now time.Time) []string {
+	order := make([]string, 0)
+	for _, issue := range candidates {
+		if availableSlots(&state) == 0 {
+			return order
+		}
+		if !orch.dispatchable(issue, &state, now) {
+			continue
+		}
+
+		issue = cloneIssue(issue)
+		order = append(order, issue.ID)
+		state.Running[issue.ID] = Running{Issue: issue, StartedAt: now}
+		state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now}
+		delete(state.Retry, issue.ID)
+		delete(state.Blocked, issue.ID)
+		delete(state.BudgetRefusals, issue.ID)
+	}
+	return order
+}
+
+func assertParitySet(t *testing.T, name string, got []string, want []string) {
+	t.Helper()
+
+	sortedGot := sortedParityStrings(got)
+	sortedWant := sortedParityStrings(want)
+	if !slices.Equal(sortedGot, sortedWant) {
+		t.Fatalf("%s = %#v, want %#v", name, sortedGot, sortedWant)
+	}
+}
+
+func sortedParityStrings(values []string) []string {
+	sorted := append([]string(nil), values...)
+	sort.Strings(sorted)
+	return sorted
+}
+
+func stateIDs[T any](items map[string]T) []string {
+	ids := make([]string, 0, len(items))
+	for id := range items {
+		ids = append(ids, id)
+	}
+	return ids
+}
+
+func mustParseParityTime(t *testing.T, value string) time.Time {
+	t.Helper()
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse time %q: %v", value, err)
+	}
+	return parsed
+}
+
+func optionalParityTime(t *testing.T, value string) *time.Time {
+	t.Helper()
+
+	if value == "" {
+		return nil
+	}
+	parsed := mustParseParityTime(t, value)
+	return &parsed
+}

--- a/internal/orchestrator/testdata/elixir_dispatch_parity.json
+++ b/internal/orchestrator/testdata/elixir_dispatch_parity.json
@@ -1,0 +1,319 @@
+{
+  "source": "digitaldrywood/symphony Elixir SymphonyElixir.Orchestrator dispatch helpers",
+  "cases": [
+    {
+      "name": "mixed active candidates honor rank, slots, blocked dependencies, claims, and budget cooldowns",
+      "now": "2026-05-31T12:00:00Z",
+      "config": {
+        "max_concurrent_agents": 3,
+        "max_concurrent_agents_by_state": {
+          "Merging": 1,
+          "Rework": 1,
+          "Todo": 2
+        },
+        "dispatch_priority_by_state": ["Merging", "Rework", "Todo"],
+        "active_states": ["Todo", "Rework", "Merging", "In Progress"],
+        "terminal_states": ["Done", "Cancelled", "Canceled", "Closed"],
+        "budget_refusal_cooldown_seconds": 3600
+      },
+      "initial_state": {
+        "running": [
+          {
+            "issue": {
+              "id": "running-todo",
+              "identifier": "digitaldrywood/symphony-go#101",
+              "title": "Already running Todo issue",
+              "state": "Todo",
+              "priority": 2,
+              "created_at": "2026-05-31T07:00:00Z"
+            }
+          }
+        ],
+        "claimed": [
+          {
+            "issue": {
+              "id": "running-todo",
+              "identifier": "digitaldrywood/symphony-go#101",
+              "title": "Already running Todo issue",
+              "state": "Todo",
+              "priority": 2,
+              "created_at": "2026-05-31T07:00:00Z"
+            }
+          },
+          {
+            "issue": {
+              "id": "claimed-existing",
+              "identifier": "digitaldrywood/symphony-go#102",
+              "title": "Already claimed issue",
+              "state": "Todo",
+              "priority": 1,
+              "created_at": "2026-05-31T06:00:00Z"
+            }
+          }
+        ],
+        "blocked": [
+          {
+            "issue": {
+              "id": "blocked-existing",
+              "identifier": "digitaldrywood/symphony-go#103",
+              "title": "Existing operator block",
+              "state": "Todo"
+            },
+            "reason": "operator input required"
+          }
+        ],
+        "budget_refusals": [
+          {
+            "issue": {
+              "id": "budget-active",
+              "identifier": "digitaldrywood/symphony-go#104",
+              "title": "Budget cooldown active",
+              "state": "Todo",
+              "priority": 1,
+              "created_at": "2026-05-31T05:00:00Z"
+            },
+            "refused_at": "2026-05-31T11:30:00Z"
+          },
+          {
+            "issue": {
+              "id": "budget-expired",
+              "identifier": "digitaldrywood/symphony-go#105",
+              "title": "Budget cooldown expired",
+              "state": "Todo",
+              "priority": 1,
+              "created_at": "2026-05-31T05:30:00Z"
+            },
+            "refused_at": "2026-05-31T10:00:00Z"
+          }
+        ]
+      },
+      "candidates": [
+        {
+          "id": "todo-ready",
+          "identifier": "digitaldrywood/symphony-go#106",
+          "title": "Ready Todo issue",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T04:00:00Z"
+        },
+        {
+          "id": "done-candidate",
+          "identifier": "digitaldrywood/symphony-go#107",
+          "title": "Done issue",
+          "state": "Done",
+          "priority": 1,
+          "created_at": "2026-05-31T02:00:00Z"
+        },
+        {
+          "id": "blocked-dependency",
+          "identifier": "digitaldrywood/symphony-go#108",
+          "title": "Blocked by in-progress dependency",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T01:00:00Z",
+          "blocked_by": [
+            {
+              "identifier": "digitaldrywood/symphony-go#90",
+              "state": "In Progress"
+            }
+          ]
+        },
+        {
+          "id": "rework-ready",
+          "identifier": "digitaldrywood/symphony-go#109",
+          "title": "Ready Rework issue",
+          "state": "Rework",
+          "priority": 4,
+          "created_at": "2026-05-31T10:30:00Z"
+        },
+        {
+          "id": "merging-ready",
+          "identifier": "digitaldrywood/symphony-go#110",
+          "title": "Ready Merging issue",
+          "state": "Merging",
+          "priority": 4,
+          "created_at": "2026-05-31T11:00:00Z"
+        },
+        {
+          "id": "claimed-existing",
+          "identifier": "digitaldrywood/symphony-go#102",
+          "title": "Already claimed issue",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T06:00:00Z"
+        },
+        {
+          "id": "budget-active",
+          "identifier": "digitaldrywood/symphony-go#104",
+          "title": "Budget cooldown active",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T05:00:00Z"
+        },
+        {
+          "id": "budget-expired",
+          "identifier": "digitaldrywood/symphony-go#105",
+          "title": "Budget cooldown expired",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T05:30:00Z"
+        },
+        {
+          "id": "running-todo",
+          "identifier": "digitaldrywood/symphony-go#101",
+          "title": "Already running Todo issue",
+          "state": "Todo",
+          "priority": 2,
+          "created_at": "2026-05-31T07:00:00Z"
+        }
+      ],
+      "want": {
+        "dispatch_order": ["merging-ready", "rework-ready"],
+        "blocked": ["blocked-dependency", "blocked-existing"],
+        "claimed": ["claimed-existing", "merging-ready", "rework-ready", "running-todo"],
+        "refusals": ["budget-active"]
+      }
+    },
+    {
+      "name": "terminal blockers remain dispatchable and nil created dates sort last",
+      "now": "2026-05-31T12:00:00Z",
+      "config": {
+        "max_concurrent_agents": 2,
+        "dispatch_priority_by_state": ["Todo"],
+        "active_states": ["Todo"],
+        "terminal_states": ["Done", "Cancelled", "Canceled", "Closed"],
+        "budget_refusal_cooldown_seconds": 3600
+      },
+      "initial_state": {},
+      "candidates": [
+        {
+          "id": "todo-missing-created",
+          "identifier": "digitaldrywood/symphony-go#203",
+          "title": "Ready Todo without created date",
+          "state": "Todo",
+          "priority": 1
+        },
+        {
+          "id": "todo-terminal-blocker",
+          "identifier": "digitaldrywood/symphony-go#202",
+          "title": "Ready Todo with completed dependency",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T10:00:00Z",
+          "blocked_by": [
+            {
+              "identifier": "digitaldrywood/symphony-go#180",
+              "state": "Done"
+            }
+          ]
+        },
+        {
+          "id": "todo-old",
+          "identifier": "digitaldrywood/symphony-go#201",
+          "title": "Old ready Todo",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T09:00:00Z"
+        }
+      ],
+      "want": {
+        "dispatch_order": ["todo-old", "todo-terminal-blocker"],
+        "blocked": [],
+        "claimed": ["todo-old", "todo-terminal-blocker"],
+        "refusals": []
+      }
+    },
+    {
+      "name": "non-terminal blockers are tracked and skipped before the next eligible candidate",
+      "now": "2026-05-31T12:00:00Z",
+      "config": {
+        "max_concurrent_agents": 1,
+        "dispatch_priority_by_state": ["Todo"],
+        "active_states": ["Todo"],
+        "terminal_states": ["Done", "Cancelled", "Canceled", "Closed"],
+        "budget_refusal_cooldown_seconds": 3600
+      },
+      "initial_state": {},
+      "candidates": [
+        {
+          "id": "todo-blocked-first",
+          "identifier": "digitaldrywood/symphony-go#301",
+          "title": "Blocked Todo candidate",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T08:00:00Z",
+          "blocked_by": [
+            {
+              "identifier": "digitaldrywood/symphony-go#280",
+              "state": "In Progress"
+            }
+          ]
+        },
+        {
+          "id": "todo-next-ready",
+          "identifier": "digitaldrywood/symphony-go#302",
+          "title": "Next ready Todo candidate",
+          "state": "Todo",
+          "priority": 2,
+          "created_at": "2026-05-31T09:00:00Z"
+        }
+      ],
+      "want": {
+        "dispatch_order": ["todo-next-ready"],
+        "blocked": ["todo-blocked-first"],
+        "claimed": ["todo-next-ready"],
+        "refusals": []
+      }
+    },
+    {
+      "name": "budget cooldown candidates are skipped before the next eligible candidate",
+      "now": "2026-05-31T12:00:00Z",
+      "config": {
+        "max_concurrent_agents": 1,
+        "dispatch_priority_by_state": ["Todo"],
+        "active_states": ["Todo"],
+        "terminal_states": ["Done", "Cancelled", "Canceled", "Closed"],
+        "budget_refusal_cooldown_seconds": 3600
+      },
+      "initial_state": {
+        "budget_refusals": [
+          {
+            "issue": {
+              "id": "todo-budget-first",
+              "identifier": "digitaldrywood/symphony-go#401",
+              "title": "Budget-refused Todo candidate",
+              "state": "Todo",
+              "priority": 1,
+              "created_at": "2026-05-31T08:00:00Z"
+            },
+            "refused_at": "2026-05-31T11:30:00Z"
+          }
+        ]
+      },
+      "candidates": [
+        {
+          "id": "todo-budget-first",
+          "identifier": "digitaldrywood/symphony-go#401",
+          "title": "Budget-refused Todo candidate",
+          "state": "Todo",
+          "priority": 1,
+          "created_at": "2026-05-31T08:00:00Z"
+        },
+        {
+          "id": "todo-budget-next-ready",
+          "identifier": "digitaldrywood/symphony-go#402",
+          "title": "Ready Todo after budget cooldown",
+          "state": "Todo",
+          "priority": 2,
+          "created_at": "2026-05-31T09:00:00Z"
+        }
+      ],
+      "want": {
+        "dispatch_order": ["todo-budget-next-ready"],
+        "blocked": [],
+        "claimed": ["todo-budget-next-ready"],
+        "refusals": ["todo-budget-first"]
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary
- Add fixture-backed Elixir dispatch parity cases for orchestrator candidate replay.
- Assert dispatch order plus final blocked, claimed, and budget-refusal sets.

Fixes #16

## Test Plan
- go test ./internal/orchestrator -run TestDispatchParityWithElixirRecordedCandidateSets -count=1
- go test ./internal/orchestrator -count=1
- make check