### PR TITLE
feat(runner): add agent supervisor

### DIFF
--- a/internal/orchestrator/dispatch_parity_test.go
+++ b/internal/orchestrator/dispatch_parity_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/symphony-go/internal/connector"
+	runpkg "github.com/digitaldrywood/symphony-go/internal/runner"
 )
 
 func TestDispatchParityWithElixirRecordedCandidateSets(t *testing.T) {
@@ -32,7 +33,11 @@ func TestDispatchParityWithElixirRecordedCandidateSets(t *testing.T) {
 				MaxConcurrentAgentsPerHost: tt.Config.MaxConcurrentAgentsPerHost,
 				BudgetRefusalCooldown:      time.Duration(tt.Config.BudgetRefusalCooldownSeconds) * time.Second,
 			})
-			orch := Orchestrator{cfg: cfg, runner: parityBlockingRunner{}, runResults: make(chan runResultEvent)}
+			orch := Orchestrator{
+				cfg:        cfg,
+				supervisor: newTestSupervisor(t, parityBlockingRunner{}, cfg),
+				runResults: make(chan runpkg.Completion),
+			}
 			state := newState(cfg)
 			applyParityInitialState(t, &state, tt.InitialState, now)
 
@@ -222,9 +227,14 @@ func parityDispatchOrder(orch *Orchestrator, state State, candidates []connector
 			continue
 		}
 
+		workerHost, ok := orch.selectWorkerHost(&state, "")
+		if !ok {
+			continue
+		}
+
 		issue = cloneIssue(issue)
 		order = append(order, issue.ID)
-		state.Running[issue.ID] = Running{Issue: issue, StartedAt: now}
+		state.Running[issue.ID] = Running{Issue: issue, StartedAt: now, WorkerHost: workerHost}
 		state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now}
 		delete(state.Retry, issue.ID)
 		delete(state.Blocked, issue.ID)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -7,6 +7,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
 	"github.com/digitaldrywood/symphony-go/internal/connector"
+	runpkg "github.com/digitaldrywood/symphony-go/internal/runner"
 )
 
 func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
@@ -278,8 +279,8 @@ func TestDispatchCandidatesAssignsLeastLoadedWorkerHost(t *testing.T) {
 	runner := newWorkerHostRunner()
 	orch := Orchestrator{
 		cfg:        cfg,
-		runner:     runner,
-		runResults: make(chan runResultEvent),
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion),
 	}
 	state := newState(cfg)
 	now := time.Now()

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -10,6 +10,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
 	"github.com/digitaldrywood/symphony-go/internal/connector"
+	runpkg "github.com/digitaldrywood/symphony-go/internal/runner"
 )
 
 const (
@@ -50,22 +51,15 @@ type Dependencies struct {
 type Orchestrator struct {
 	cfg           Config
 	connector     connector.Connector
-	runner        Runner
+	supervisor    *runpkg.Supervisor
 	logger        *slog.Logger
 	stateRequests chan stateRequest
-	runResults    chan runResultEvent
+	runResults    chan runpkg.Completion
 	done          chan struct{}
 }
 
 type stateRequest struct {
 	reply chan State
-}
-
-type runResultEvent struct {
-	issueID     string
-	result      RunResult
-	err         error
-	completedAt time.Time
 }
 
 func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
@@ -105,13 +99,22 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		logger = slog.Default()
 	}
 
+	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
+		MaxRetryBackoff:       cfg.MaxRetryBackoff,
+		FailureRetryBaseDelay: cfg.FailureRetryBaseDelay,
+		Logger:                logger,
+	})
+	if err != nil {
+		return nil, err
+	}
+
 	return &Orchestrator{
 		cfg:           cfg,
 		connector:     deps.Connector,
-		runner:        runner,
+		supervisor:    supervisor,
 		logger:        logger,
 		stateRequests: make(chan stateRequest),
-		runResults:    make(chan runResultEvent),
+		runResults:    make(chan runpkg.Completion),
 		done:          make(chan struct{}),
 	}, nil
 }
@@ -402,68 +405,63 @@ func (o *Orchestrator) dispatchIssue(
 		StartedAt:  now,
 		WorkerHost: workerHost,
 	}
-	go func() {
-		result, err := o.runner.Run(ctx, request)
-		event := runResultEvent{
-			issueID:     request.Issue.ID,
-			result:      result,
-			err:         err,
-			completedAt: time.Now(),
-		}
-
-		select {
-		case o.runResults <- event:
-		case <-ctx.Done():
-		}
-	}()
+	o.supervisor.Dispatch(ctx, request, o.runResults)
 }
 
-func (o *Orchestrator) handleRunResult(state *State, event runResultEvent) {
-	running, ok := state.Running[event.issueID]
+func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
+	running, ok := state.Running[event.IssueID]
 	if !ok {
 		return
 	}
-	delete(state.Running, event.issueID)
+	delete(state.Running, event.IssueID)
 
-	if event.err != nil {
-		o.scheduleRetry(
+	if event.Err != nil {
+		attempt := event.RetryAttempt
+		if attempt < 1 {
+			attempt = nextAttempt(running.Attempt)
+		}
+		delay := event.RetryDelay
+		if delay <= 0 {
+			delay = o.retryDelay(attempt, false)
+		}
+		o.scheduleRetryAfter(
 			state,
 			running.Issue,
-			nextAttempt(running.Attempt),
-			event.completedAt,
-			event.err.Error(),
-			false,
+			attempt,
+			event.CompletedAt,
+			delay,
+			event.Err.Error(),
 			running.WorkerHost,
 		)
 		return
 	}
 
-	finalState := event.result.FinalState
+	finalState := event.Result.FinalState
 	if finalState == "" {
 		finalState = FinalStateCompleted
 	}
 
-	state.Completed[event.issueID] = Completed{
+	state.Completed[event.IssueID] = Completed{
 		Issue:       cloneIssue(running.Issue),
 		StartedAt:   running.StartedAt,
-		CompletedAt: event.completedAt,
+		CompletedAt: event.CompletedAt,
 		FinalState:  finalState,
-		Tokens:      event.result.Tokens,
+		Tokens:      event.Result.Tokens,
 	}
-	state.CodexTotals = addCodexTotals(state.CodexTotals, event.result.Tokens)
-	if event.result.RateLimits != nil {
-		state.RateLimits = cloneRateLimits(event.result.RateLimits)
+	state.CodexTotals = addCodexTotals(state.CodexTotals, event.Result.Tokens)
+	if event.Result.RateLimits != nil {
+		state.RateLimits = cloneRateLimits(event.Result.RateLimits)
 	}
-	if diffStatsPresent(event.result.DiffStats) {
-		state.DiffStats[event.issueID] = event.result.DiffStats
+	if diffStatsPresent(event.Result.DiffStats) {
+		state.DiffStats[event.IssueID] = event.Result.DiffStats
 	}
-	if event.result.BudgetRefusal != nil {
-		refusal := *event.result.BudgetRefusal
+	if event.Result.BudgetRefusal != nil {
+		refusal := *event.Result.BudgetRefusal
 		refusal.Issue = cloneIssue(running.Issue)
-		state.BudgetRefusals[event.issueID] = refusal
+		state.BudgetRefusals[event.IssueID] = refusal
 	}
 
-	o.scheduleRetry(state, running.Issue, 1, event.completedAt, "", true, running.WorkerHost)
+	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
 }
 
 func (o *Orchestrator) scheduleRetry(
@@ -479,7 +477,25 @@ func (o *Orchestrator) scheduleRetry(
 		attempt = 1
 	}
 
-	delay := o.retryDelay(attempt, continuation)
+	o.scheduleRetryAfter(state, issue, attempt, now, o.retryDelay(attempt, continuation), err, workerHost)
+}
+
+func (o *Orchestrator) scheduleRetryAfter(
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	delay time.Duration,
+	err string,
+	workerHost string,
+) {
+	if attempt < 1 {
+		attempt = 1
+	}
+	if delay < 0 {
+		delay = 0
+	}
+
 	issue = cloneIssue(issue)
 	state.Retry[issue.ID] = Retry{
 		Issue:      issue,

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3,6 +3,7 @@ package orchestrator_test
 import (
 	"context"
 	"errors"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -171,6 +172,36 @@ func TestRunSchedulesRetryAfterRunnerError(t *testing.T) {
 	}
 	if got := state.Retry[issue.ID].Error; got != "runner failed" {
 		t.Fatalf("Retry[%q].Error = %q, want runner failed", issue.ID, got)
+	}
+}
+
+func TestRunSchedulesRetryAfterRunnerPanic(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-panic", "digitaldrywood/symphony-go#22", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := panicRunner{}
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		retry, ok := state.Retry[issue.ID]
+		return ok && retry.Error != ""
+	})
+
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after runner panic", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing after runner panic", issue.ID)
+	}
+	if got := state.Retry[issue.ID].Attempt; got != 1 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 1", issue.ID, got)
+	}
+	if got := state.Retry[issue.ID].Error; !strings.Contains(got, "runner panic: boom") {
+		t.Fatalf("Retry[%q].Error = %q, want runner panic", issue.ID, got)
 	}
 }
 
@@ -505,6 +536,12 @@ func newRetryRunner() *retryRunner {
 		retryStarted: make(chan orchestrator.RunRequest, 1),
 		release:      make(chan struct{}),
 	}
+}
+
+type panicRunner struct{}
+
+func (panicRunner) Run(context.Context, orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	panic("boom")
 }
 
 func (r *retryRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/symphony-go/internal/connector"
+	runpkg "github.com/digitaldrywood/symphony-go/internal/runner"
 )
 
 func TestDispatchReadyIssuesKeepsRetryAttemptWhenCapacityIsFull(t *testing.T) {
@@ -61,8 +62,8 @@ func TestDispatchReadyIssuesRanksDueRetriesWithCandidates(t *testing.T) {
 	})
 	orch := Orchestrator{
 		cfg:        cfg,
-		runner:     FakeRunner{},
-		runResults: make(chan runResultEvent, 1),
+		supervisor: newTestSupervisor(t, FakeRunner{}, cfg),
+		runResults: make(chan runpkg.Completion, 1),
 	}
 	state := newState(cfg)
 	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -1,36 +1,21 @@
 package orchestrator
 
 import (
-	"context"
-	"time"
-
-	"github.com/digitaldrywood/symphony-go/internal/connector"
-	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+	"github.com/digitaldrywood/symphony-go/internal/runner"
 )
 
-const FinalStateCompleted = "completed"
+const FinalStateCompleted = runner.FinalStateCompleted
 
-type Runner interface {
-	Run(context.Context, RunRequest) (RunResult, error)
-}
+type Runner = runner.Backend
 
-type RunRequest struct {
-	Issue      connector.Issue
-	Attempt    int
-	StartedAt  time.Time
-	WorkerHost string
-}
+type RunRequest = runner.RunRequest
 
-type RunResult struct {
-	FinalState    string
-	Tokens        CodexTotals
-	DiffStats     DiffStats
-	RateLimits    *telemetry.RateLimits
-	BudgetRefusal *BudgetRefusal
-}
+type RunResult = runner.RunResult
 
-type FakeRunner struct{}
+type BudgetRefusal = runner.BudgetRefusal
 
-func (FakeRunner) Run(context.Context, RunRequest) (RunResult, error) {
-	return RunResult{FinalState: FinalStateCompleted}, nil
-}
+type DiffStats = runner.DiffStats
+
+type CodexTotals = runner.CodexTotals
+
+type FakeRunner = runner.FakeRunner

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -55,31 +55,6 @@ type Retry struct {
 	WorkerHost string
 }
 
-type BudgetRefusal struct {
-	Issue            connector.Issue
-	Code             string
-	Message          string
-	CurrentSpendUSD  float64
-	ProjectedCostUSD float64
-	MaxUSD           *float64
-	ResetAt          *time.Time
-	RefusedAt        time.Time
-}
-
-type DiffStats struct {
-	FilesChanged int
-	AddedLines   int
-	RemovedLines int
-	Status       string
-}
-
-type CodexTotals struct {
-	InputTokens    int64
-	OutputTokens   int64
-	TotalTokens    int64
-	RuntimeSeconds float64
-}
-
 func newState(cfg Config) State {
 	return State{
 		PollInterval:        cfg.PollInterval,

--- a/internal/orchestrator/test_helpers_test.go
+++ b/internal/orchestrator/test_helpers_test.go
@@ -1,0 +1,20 @@
+package orchestrator
+
+import (
+	"testing"
+
+	runpkg "github.com/digitaldrywood/symphony-go/internal/runner"
+)
+
+func newTestSupervisor(t *testing.T, backend Runner, cfg Config) *runpkg.Supervisor {
+	t.Helper()
+
+	supervisor, err := runpkg.NewSupervisor(backend, runpkg.SupervisorConfig{
+		MaxRetryBackoff:       cfg.MaxRetryBackoff,
+		FailureRetryBaseDelay: cfg.FailureRetryBaseDelay,
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+	return supervisor
+}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -20,6 +20,8 @@ import (
 	"github.com/digitaldrywood/symphony-go/internal/workspace"
 )
 
+const defaultAfterRunTimeout = time.Minute
+
 var (
 	ErrMissingWorkspace = errors.New("runner workspace backend is required")
 	ErrMissingCodex     = errors.New("runner codex client is required")
@@ -35,21 +37,23 @@ type SessionStore interface {
 }
 
 type Dependencies struct {
-	Workflow  config.Workflow
-	Workspace workspace.Backend
-	Codex     CodexClient
-	Store     SessionStore
-	Now       func() time.Time
-	Logger    *slog.Logger
+	Workflow        config.Workflow
+	Workspace       workspace.Backend
+	Codex           CodexClient
+	Store           SessionStore
+	Now             func() time.Time
+	Logger          *slog.Logger
+	AfterRunTimeout time.Duration
 }
 
 type Runner struct {
-	workflow  config.Workflow
-	workspace workspace.Backend
-	codex     CodexClient
-	store     SessionStore
-	now       func() time.Time
-	logger    *slog.Logger
+	workflow        config.Workflow
+	workspace       workspace.Backend
+	codex           CodexClient
+	store           SessionStore
+	now             func() time.Time
+	logger          *slog.Logger
+	afterRunTimeout time.Duration
 }
 
 func NewRunner(deps Dependencies) (*Runner, error) {
@@ -65,14 +69,18 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	if deps.Logger == nil {
 		deps.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
 	}
+	if deps.AfterRunTimeout <= 0 {
+		deps.AfterRunTimeout = defaultAfterRunTimeout
+	}
 
 	return &Runner{
-		workflow:  deps.Workflow,
-		workspace: deps.Workspace,
-		codex:     deps.Codex,
-		store:     deps.Store,
-		now:       deps.Now,
-		logger:    deps.Logger,
+		workflow:        deps.Workflow,
+		workspace:       deps.Workspace,
+		codex:           deps.Codex,
+		store:           deps.Store,
+		now:             deps.Now,
+		logger:          deps.Logger,
+		afterRunTimeout: deps.AfterRunTimeout,
 	}, nil
 }
 
@@ -94,7 +102,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	afterRunPending := true
 	defer func() {
 		if afterRunPending {
-			r.workspace.AfterRun(ctx, info, workspaceIssue)
+			r.afterRun(info, workspaceIssue)
 		}
 	}()
 
@@ -138,7 +146,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	})
 	_ = turnResult
 
-	r.workspace.AfterRun(ctx, info, workspaceIssue)
+	r.afterRun(info, workspaceIssue)
 	afterRunPending = false
 
 	if turnErr != nil {
@@ -190,6 +198,13 @@ func (r *Runner) availableSkills(workspacePath string) ([]skills.Skill, error) {
 		)
 	}
 	return result.Skills, nil
+}
+
+func (r *Runner) afterRun(info workspace.Info, issue workspace.Issue) {
+	ctx, cancel := context.WithTimeout(context.Background(), r.afterRunTimeout)
+	defer cancel()
+
+	r.workspace.AfterRun(ctx, info, issue)
 }
 
 func (r *Runner) startSession(

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1,0 +1,348 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/codex"
+	"github.com/digitaldrywood/symphony-go/internal/config"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/skills"
+	"github.com/digitaldrywood/symphony-go/internal/store"
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+	"github.com/digitaldrywood/symphony-go/internal/workspace"
+)
+
+var (
+	ErrMissingWorkspace = errors.New("runner workspace backend is required")
+	ErrMissingCodex     = errors.New("runner codex client is required")
+)
+
+type CodexClient interface {
+	RunTurn(context.Context, codex.RunTurnRequest, codex.UpdateHandler) (codex.RunTurnResult, error)
+}
+
+type SessionStore interface {
+	StartSession(context.Context, store.SessionStart) (int64, error)
+	FinishSession(context.Context, int64, store.SessionFinish) error
+}
+
+type Dependencies struct {
+	Workflow  config.Workflow
+	Workspace workspace.Backend
+	Codex     CodexClient
+	Store     SessionStore
+	Now       func() time.Time
+	Logger    *slog.Logger
+}
+
+type Runner struct {
+	workflow  config.Workflow
+	workspace workspace.Backend
+	codex     CodexClient
+	store     SessionStore
+	now       func() time.Time
+	logger    *slog.Logger
+}
+
+func NewRunner(deps Dependencies) (*Runner, error) {
+	if deps.Workspace == nil {
+		return nil, ErrMissingWorkspace
+	}
+	if deps.Codex == nil {
+		return nil, ErrMissingCodex
+	}
+	if deps.Now == nil {
+		deps.Now = time.Now
+	}
+	if deps.Logger == nil {
+		deps.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	return &Runner{
+		workflow:  deps.Workflow,
+		workspace: deps.Workspace,
+		codex:     deps.Codex,
+		store:     deps.Store,
+		now:       deps.Now,
+		logger:    deps.Logger,
+	}, nil
+}
+
+func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	workspaceIssue := workspaceIssue(req.Issue)
+	info, err := r.workspace.Create(ctx, workspaceIssue)
+	if err != nil {
+		return RunResult{}, fmt.Errorf("create workspace: %w", err)
+	}
+
+	if err := r.workspace.BeforeRun(ctx, info, workspaceIssue); err != nil {
+		return RunResult{}, fmt.Errorf("workspace before_run: %w", err)
+	}
+
+	afterRunPending := true
+	defer func() {
+		if afterRunPending {
+			r.workspace.AfterRun(ctx, info, workspaceIssue)
+		}
+	}()
+
+	availableSkills, err := r.availableSkills(info.Path)
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	attempt := req.Attempt
+	prompt, err := BuildPrompt(r.workflow, req.Issue, PromptOptions{
+		Attempt:         &attempt,
+		WorkspacePath:   info.Path,
+		AvailableSkills: availableSkills,
+	})
+	if err != nil {
+		return RunResult{}, fmt.Errorf("build prompt: %w", err)
+	}
+
+	startedAt := req.StartedAt
+	if startedAt.IsZero() {
+		startedAt = r.now().UTC()
+	}
+	runStartedAt := r.now()
+	model := strings.TrimSpace(req.Issue.ModelOverride)
+	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, model)
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	result := RunResult{FinalState: FinalStateCompleted}
+	turnResult, turnErr := r.codex.RunTurn(ctx, codex.RunTurnRequest{
+		Workspace:         info.Path,
+		Prompt:            prompt,
+		ApprovalPolicy:    stringOrMapValue(r.workflow.Config.Codex.ApprovalPolicy),
+		ThreadSandbox:     r.workflow.Config.Codex.ThreadSandbox,
+		TurnSandboxPolicy: r.workflow.Config.Codex.TurnSandboxPolicy,
+		Model:             model,
+	}, func(update codex.Update) error {
+		applyCodexUpdate(&result, update)
+		return nil
+	})
+	_ = turnResult
+
+	r.workspace.AfterRun(ctx, info, workspaceIssue)
+	afterRunPending = false
+
+	if turnErr != nil {
+		result.FinalState = FinalStateFailed
+		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
+		return result, errors.Join(
+			fmt.Errorf("run codex turn: %w", turnErr),
+			r.finishSession(ctx, sessionID, sessionStarted, result, model, 1),
+		)
+	}
+
+	diffStat, err := r.workspace.DiffStat(ctx, info, workspaceIssue)
+	if err != nil {
+		result.FinalState = FinalStateFailed
+		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
+		return result, errors.Join(
+			fmt.Errorf("workspace diff stat: %w", err),
+			r.finishSession(ctx, sessionID, sessionStarted, result, model, 1),
+		)
+	}
+
+	result.DiffStats = diffStatsFromWorkspace(diffStat)
+	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
+	if err := r.finishSession(ctx, sessionID, sessionStarted, result, model, 1); err != nil {
+		return result, err
+	}
+	return result, nil
+}
+
+func (r *Runner) availableSkills(workspacePath string) ([]skills.Skill, error) {
+	cfg := r.workflow.Config.Agent.Skills
+	if !cfg.Enabled {
+		return nil, nil
+	}
+
+	result, err := skills.Load(workspacePath, skills.Options{
+		Path:              cfg.Path,
+		MaxSkillsInPrompt: cfg.MaxSkillsInPrompt,
+		Logger:            r.logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load skills: %w", err)
+	}
+	for _, validation := range result.Errors {
+		r.logger.Warn(
+			"invalid repo skill ignored",
+			slog.String("path", validation.Path),
+			slog.String("message", validation.Message),
+		)
+	}
+	return result.Skills, nil
+}
+
+func (r *Runner) startSession(
+	ctx context.Context,
+	issue connector.Issue,
+	startedAt time.Time,
+	model string,
+) (int64, bool, error) {
+	if r.store == nil {
+		return 0, false, nil
+	}
+
+	sessionID, err := r.store.StartSession(ctx, store.SessionStart{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		IssueURL:   issue.URL,
+		StartedAt:  startedAt,
+		Model:      model,
+	})
+	if err != nil {
+		return 0, false, fmt.Errorf("start codex session: %w", err)
+	}
+	return sessionID, true, nil
+}
+
+func (r *Runner) finishSession(
+	ctx context.Context,
+	sessionID int64,
+	started bool,
+	result RunResult,
+	model string,
+	turns int64,
+) error {
+	if !started {
+		return nil
+	}
+	if result.FinalState == "" {
+		result.FinalState = FinalStateCompleted
+	}
+
+	if err := r.store.FinishSession(ctx, sessionID, store.SessionFinish{
+		CompletedAt:    r.now().UTC(),
+		Turns:          turns,
+		InputTokens:    result.Tokens.InputTokens,
+		OutputTokens:   result.Tokens.OutputTokens,
+		TotalTokens:    result.Tokens.TotalTokens,
+		RuntimeSeconds: int64(math.Round(result.Tokens.RuntimeSeconds)),
+		FinalState:     result.FinalState,
+		Model:          model,
+	}); err != nil {
+		return fmt.Errorf("finish codex session: %w", err)
+	}
+	return nil
+}
+
+func workspaceIssue(issue connector.Issue) workspace.Issue {
+	return workspace.Issue{
+		ID:         issue.ID,
+		Identifier: issue.Identifier,
+		BranchName: issue.BranchName,
+	}
+}
+
+func applyCodexUpdate(result *RunResult, update codex.Update) {
+	switch update.Type {
+	case codex.UpdateTokenUsage:
+		result.Tokens.InputTokens = update.Tokens.InputTokens
+		result.Tokens.OutputTokens = update.Tokens.OutputTokens
+		result.Tokens.TotalTokens = update.Tokens.TotalTokens
+	case codex.UpdateRateLimits:
+		result.RateLimits = rateLimitsFromCodex(update.RateLimits)
+	}
+}
+
+func rateLimitsFromCodex(snapshot *codex.RateLimitSnapshot) *telemetry.RateLimits {
+	if snapshot == nil {
+		return nil
+	}
+	return &telemetry.RateLimits{
+		LimitID:   snapshot.LimitID,
+		LimitName: snapshot.LimitName,
+		Primary:   rateLimitBucketFromCodex(snapshot.Primary),
+		Secondary: rateLimitBucketFromCodex(snapshot.Secondary),
+	}
+}
+
+func rateLimitBucketFromCodex(window *codex.RateLimitWindow) *telemetry.RateLimitBucket {
+	if window == nil {
+		return nil
+	}
+
+	used := int64(math.Round(window.UsedPercent))
+	if used < 0 {
+		used = 0
+	}
+	if used > 100 {
+		used = 100
+	}
+
+	bucket := &telemetry.RateLimitBucket{
+		Limit:     100,
+		Used:      used,
+		Remaining: 100 - used,
+	}
+	if window.ResetsAt != nil {
+		resetAt := time.Unix(*window.ResetsAt, 0).UTC()
+		bucket.ResetAt = &resetAt
+	}
+	return bucket
+}
+
+func diffStatsFromWorkspace(stat workspace.DiffStat) DiffStats {
+	status := "clean"
+	if stat.Files != 0 || stat.Added != 0 || stat.Removed != 0 {
+		status = "changed"
+	}
+	return DiffStats{
+		FilesChanged: stat.Files,
+		AddedLines:   stat.Added,
+		RemovedLines: stat.Removed,
+		Status:       status,
+	}
+}
+
+func stringOrMapValue(value config.StringOrMap) any {
+	if value.IsMap {
+		return cloneMap(value.Map)
+	}
+	if value.IsString {
+		return value.String
+	}
+	return nil
+}
+
+func cloneMap(value map[string]any) map[string]any {
+	if value == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return value
+	}
+	return cloned
+}
+
+func runtimeSeconds(startedAt, completedAt time.Time) float64 {
+	if startedAt.IsZero() || completedAt.IsZero() || completedAt.Before(startedAt) {
+		return 0
+	}
+	return completedAt.Sub(startedAt).Seconds()
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -184,13 +184,50 @@ func TestRunnerRunFinishesFailedSessionAndAfterRunOnCodexError(t *testing.T) {
 	}
 }
 
+func TestRunnerRunUsesFreshContextForAfterRunCleanup(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-22", Branch: "symphony/issue-22"},
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	codexClient := &cancelingCodexClient{cancel: cancel}
+
+	runner, err := NewRunner(Dependencies{
+		Workflow:  config.Workflow{Config: config.Config{}},
+		Workspace: workspaceBackend,
+		Codex:     codexClient,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(ctx, RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-22",
+			Identifier: "digitaldrywood/symphony-go#22",
+			Title:      "Add runner",
+		},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Run() error = %v, want context canceled", err)
+	}
+	if !workspaceBackend.afterRun {
+		t.Fatal("AfterRun was not called")
+	}
+	if workspaceBackend.afterRunErr != nil {
+		t.Fatalf("AfterRun context error = %v, want nil", workspaceBackend.afterRunErr)
+	}
+}
+
 type fakeWorkspaceBackend struct {
-	info      workspace.Info
-	diffStat  workspace.DiffStat
-	created   bool
-	beforeRun bool
-	afterRun  bool
-	diffed    bool
+	info        workspace.Info
+	diffStat    workspace.DiffStat
+	created     bool
+	beforeRun   bool
+	afterRun    bool
+	afterRunErr error
+	diffed      bool
 }
 
 func (b *fakeWorkspaceBackend) Create(_ context.Context, issue workspace.Issue) (workspace.Info, error) {
@@ -208,8 +245,9 @@ func (b *fakeWorkspaceBackend) BeforeRun(context.Context, workspace.Info, worksp
 	return nil
 }
 
-func (b *fakeWorkspaceBackend) AfterRun(context.Context, workspace.Info, workspace.Issue) {
+func (b *fakeWorkspaceBackend) AfterRun(ctx context.Context, _ workspace.Info, _ workspace.Issue) {
 	b.afterRun = true
+	b.afterRunErr = ctx.Err()
 }
 
 func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspace.Issue) (workspace.DiffStat, error) {
@@ -232,6 +270,15 @@ func (c *fakeCodexClient) RunTurn(_ context.Context, req codex.RunTurnRequest, o
 		}
 	}
 	return c.result, c.err
+}
+
+type cancelingCodexClient struct {
+	cancel context.CancelFunc
+}
+
+func (c *cancelingCodexClient) RunTurn(context.Context, codex.RunTurnRequest, codex.UpdateHandler) (codex.RunTurnResult, error) {
+	c.cancel()
+	return codex.RunTurnResult{}, context.Canceled
 }
 
 type fakeSessionStore struct {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,0 +1,289 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/codex"
+	"github.com/digitaldrywood/symphony-go/internal/config"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/store"
+	"github.com/digitaldrywood/symphony-go/internal/workspace"
+)
+
+func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	writeSkill(t, workspacePath, "review.md", "review", "Review code.", "Issue needs code review.")
+
+	startedAt := time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC)
+	completedAt := startedAt.Add(2 * time.Second)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{
+			Path:   workspacePath,
+			Key:    "digitaldrywood_symphony-go_22",
+			Branch: "symphony/digitaldrywood_symphony-go_22",
+		},
+		diffStat: workspace.DiffStat{Files: 2, Added: 5, Removed: 1},
+	}
+	codexClient := &fakeCodexClient{
+		updates: []codex.Update{
+			{
+				Type: codex.UpdateTokenUsage,
+				Tokens: codex.TokenUsage{
+					InputTokens:  100,
+					OutputTokens: 25,
+					TotalTokens:  125,
+				},
+			},
+			{
+				Type: codex.UpdateRateLimits,
+				RateLimits: &codex.RateLimitSnapshot{
+					LimitID:   "codex-primary",
+					LimitName: "Codex primary",
+				},
+			},
+		},
+		result: codex.RunTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "thread-1-turn-1"},
+	}
+	sessionStore := &fakeSessionStore{sessionID: 42}
+	now := newFakeClock(startedAt, completedAt)
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agent: config.Agent{
+					Skills: config.Skills{
+						Enabled:           true,
+						Path:              ".symphony/skills",
+						MaxSkillsInPrompt: 10,
+					},
+				},
+				Codex: config.Codex{
+					ApprovalPolicy: config.StringValue("never"),
+					ThreadSandbox:  "workspace-write",
+					TurnSandboxPolicy: map[string]any{
+						"type":          "workspaceWrite",
+						"networkAccess": true,
+					},
+				},
+			},
+			Prompt: "Work on {{ issue.identifier }} attempt {{ attempt }}",
+		},
+		Workspace: workspaceBackend,
+		Codex:     codexClient,
+		Store:     sessionStore,
+		Now:       now.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-22",
+			Identifier:    "digitaldrywood/symphony-go#22",
+			Title:         "Add runner",
+			URL:           "https://github.com/digitaldrywood/symphony-go/issues/22",
+			BranchName:    "symphony/digitaldrywood_symphony-go_22",
+			ModelOverride: "gpt-5-codex-high",
+		},
+		Attempt:   2,
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.FinalState != FinalStateCompleted {
+		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
+	}
+	if result.Tokens.TotalTokens != 125 || result.Tokens.RuntimeSeconds != 2 {
+		t.Fatalf("Tokens = %#v, want total 125 and runtime 2s", result.Tokens)
+	}
+	if result.DiffStats.FilesChanged != 2 || result.DiffStats.AddedLines != 5 || result.DiffStats.RemovedLines != 1 {
+		t.Fatalf("DiffStats = %#v, want 2 files, 5 added, 1 removed", result.DiffStats)
+	}
+	if result.RateLimits == nil || result.RateLimits.LimitID != "codex-primary" {
+		t.Fatalf("RateLimits = %#v, want codex-primary", result.RateLimits)
+	}
+	if !workspaceBackend.created || !workspaceBackend.beforeRun || !workspaceBackend.afterRun || !workspaceBackend.diffed {
+		t.Fatalf("workspace calls = created:%v before:%v after:%v diff:%v, want all true", workspaceBackend.created, workspaceBackend.beforeRun, workspaceBackend.afterRun, workspaceBackend.diffed)
+	}
+	if codexClient.request.Workspace != workspacePath {
+		t.Fatalf("codex workspace = %q, want %q", codexClient.request.Workspace, workspacePath)
+	}
+	if codexClient.request.Model != "gpt-5-codex-high" {
+		t.Fatalf("codex model = %q, want issue override", codexClient.request.Model)
+	}
+	for _, want := range []string{
+		"Work on digitaldrywood/symphony-go#22 attempt 2",
+		"## Available skills",
+		"review — Issue needs code review.",
+	} {
+		if !strings.Contains(codexClient.request.Prompt, want) {
+			t.Fatalf("codex prompt missing %q:\n%s", want, codexClient.request.Prompt)
+		}
+	}
+	if sessionStore.started.Identifier != "digitaldrywood/symphony-go#22" || sessionStore.started.Model != "gpt-5-codex-high" {
+		t.Fatalf("SessionStart = %#v, want issue identity and model", sessionStore.started)
+	}
+	if sessionStore.finished.FinalState != FinalStateCompleted || sessionStore.finished.TotalTokens != 125 || sessionStore.finished.Turns != 1 {
+		t.Fatalf("SessionFinish = %#v, want completed session with tokens", sessionStore.finished)
+	}
+}
+
+func TestRunnerRunFinishesFailedSessionAndAfterRunOnCodexError(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-22", Branch: "symphony/issue-22"},
+	}
+	codexClient := &fakeCodexClient{err: errors.New("codex failed")}
+	sessionStore := &fakeSessionStore{sessionID: 7}
+	now := newFakeClock(time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC))
+
+	runner, err := NewRunner(Dependencies{
+		Workflow:  config.Workflow{Config: config.Config{}},
+		Workspace: workspaceBackend,
+		Codex:     codexClient,
+		Store:     sessionStore,
+		Now:       now.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-22",
+			Identifier: "digitaldrywood/symphony-go#22",
+			Title:      "Add runner",
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want codex failure")
+	}
+	if !strings.Contains(err.Error(), "codex failed") {
+		t.Fatalf("Run() error = %v, want codex failure", err)
+	}
+	if !workspaceBackend.afterRun {
+		t.Fatal("AfterRun was not called after codex failure")
+	}
+	if workspaceBackend.diffed {
+		t.Fatal("DiffStat was called after codex failure")
+	}
+	if sessionStore.finished.FinalState != FinalStateFailed {
+		t.Fatalf("SessionFinish.FinalState = %q, want %q", sessionStore.finished.FinalState, FinalStateFailed)
+	}
+}
+
+type fakeWorkspaceBackend struct {
+	info      workspace.Info
+	diffStat  workspace.DiffStat
+	created   bool
+	beforeRun bool
+	afterRun  bool
+	diffed    bool
+}
+
+func (b *fakeWorkspaceBackend) Create(_ context.Context, issue workspace.Issue) (workspace.Info, error) {
+	b.created = true
+	b.info.Branch = issue.BranchName
+	return b.info, nil
+}
+
+func (b *fakeWorkspaceBackend) Cleanup(context.Context, string) error {
+	return nil
+}
+
+func (b *fakeWorkspaceBackend) BeforeRun(context.Context, workspace.Info, workspace.Issue) error {
+	b.beforeRun = true
+	return nil
+}
+
+func (b *fakeWorkspaceBackend) AfterRun(context.Context, workspace.Info, workspace.Issue) {
+	b.afterRun = true
+}
+
+func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspace.Issue) (workspace.DiffStat, error) {
+	b.diffed = true
+	return b.diffStat, nil
+}
+
+type fakeCodexClient struct {
+	request codex.RunTurnRequest
+	updates []codex.Update
+	result  codex.RunTurnResult
+	err     error
+}
+
+func (c *fakeCodexClient) RunTurn(_ context.Context, req codex.RunTurnRequest, onUpdate codex.UpdateHandler) (codex.RunTurnResult, error) {
+	c.request = req
+	for _, update := range c.updates {
+		if err := onUpdate(update); err != nil {
+			return codex.RunTurnResult{}, err
+		}
+	}
+	return c.result, c.err
+}
+
+type fakeSessionStore struct {
+	sessionID int64
+	started   store.SessionStart
+	finished  store.SessionFinish
+}
+
+func (s *fakeSessionStore) StartSession(_ context.Context, attrs store.SessionStart) (int64, error) {
+	s.started = attrs
+	return s.sessionID, nil
+}
+
+func (s *fakeSessionStore) FinishSession(_ context.Context, _ int64, attrs store.SessionFinish) error {
+	s.finished = attrs
+	return nil
+}
+
+type fakeClock struct {
+	values []time.Time
+}
+
+func newFakeClock(values ...time.Time) *fakeClock {
+	return &fakeClock{values: values}
+}
+
+func (c *fakeClock) Now() time.Time {
+	if len(c.values) == 0 {
+		return time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC)
+	}
+	value := c.values[0]
+	c.values = c.values[1:]
+	return value
+}
+
+func writeSkill(t *testing.T, workspacePath, name, skillName, description, whenToUse string) {
+	t.Helper()
+
+	skillsDir := filepath.Join(workspacePath, ".symphony", "skills")
+	if err := os.MkdirAll(skillsDir, 0o755); err != nil {
+		t.Fatalf("mkdir skills: %v", err)
+	}
+	content := strings.Join([]string{
+		"---",
+		"name: " + skillName,
+		"description: " + description,
+		"when_to_use: " + whenToUse,
+		"---",
+		"Skill body stays out of the prompt.",
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(skillsDir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("write skill: %v", err)
+	}
+}

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -1,0 +1,134 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"math"
+	"time"
+)
+
+const (
+	defaultSupervisorMaxRetryBackoff       = 5 * time.Minute
+	defaultSupervisorFailureRetryBaseDelay = 10 * time.Second
+)
+
+var ErrMissingRunner = errors.New("runner backend is required")
+
+type SupervisorConfig struct {
+	MaxRetryBackoff       time.Duration
+	FailureRetryBaseDelay time.Duration
+	Now                   func() time.Time
+	Logger                *slog.Logger
+}
+
+type Supervisor struct {
+	backend               Backend
+	maxRetryBackoff       time.Duration
+	failureRetryBaseDelay time.Duration
+	now                   func() time.Time
+	logger                *slog.Logger
+}
+
+type Completion struct {
+	IssueID      string
+	Request      RunRequest
+	Result       RunResult
+	Err          error
+	CompletedAt  time.Time
+	Retryable    bool
+	RetryAttempt int
+	RetryDelay   time.Duration
+}
+
+func NewSupervisor(backend Backend, cfg SupervisorConfig) (*Supervisor, error) {
+	if backend == nil {
+		return nil, ErrMissingRunner
+	}
+	if cfg.MaxRetryBackoff <= 0 {
+		cfg.MaxRetryBackoff = defaultSupervisorMaxRetryBackoff
+	}
+	if cfg.FailureRetryBaseDelay <= 0 {
+		cfg.FailureRetryBaseDelay = defaultSupervisorFailureRetryBaseDelay
+	}
+	if cfg.Now == nil {
+		cfg.Now = time.Now
+	}
+	if cfg.Logger == nil {
+		cfg.Logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	return &Supervisor{
+		backend:               backend,
+		maxRetryBackoff:       cfg.MaxRetryBackoff,
+		failureRetryBaseDelay: cfg.FailureRetryBaseDelay,
+		now:                   cfg.Now,
+		logger:                cfg.Logger,
+	}, nil
+}
+
+func (s *Supervisor) Dispatch(ctx context.Context, request RunRequest, completions chan<- Completion) {
+	go func() {
+		completion := s.Run(ctx, request)
+		select {
+		case completions <- completion:
+		case <-ctx.Done():
+		}
+	}()
+}
+
+func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Completion) {
+	completion = Completion{
+		IssueID:     request.Issue.ID,
+		Request:     request,
+		CompletedAt: s.now(),
+	}
+
+	defer func() {
+		if recovered := recover(); recovered != nil {
+			completion.Err = fmt.Errorf("runner panic: %v", recovered)
+			s.logger.Error(
+				"runner panic recovered",
+				slog.String("issue_id", request.Issue.ID),
+				slog.String("issue_identifier", request.Issue.Identifier),
+				slog.Any("panic", recovered),
+			)
+		}
+		if completion.Err != nil {
+			completion.Retryable = true
+			completion.RetryAttempt = nextFailureAttempt(request.Attempt)
+			completion.RetryDelay = s.RetryDelay(completion.RetryAttempt)
+		}
+	}()
+
+	result, err := s.backend.Run(ctx, request)
+	completion.CompletedAt = s.now()
+	completion.Result = result
+	completion.Err = err
+	return completion
+}
+
+func (s *Supervisor) RetryDelay(attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	exponent := attempt - 1
+	if exponent > 30 {
+		exponent = 30
+	}
+
+	delay := s.failureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
+	if delay > s.maxRetryBackoff {
+		return s.maxRetryBackoff
+	}
+	return delay
+}
+
+func nextFailureAttempt(current int) int {
+	if current < 0 {
+		return 1
+	}
+	return current + 1
+}

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -1,0 +1,130 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestSupervisorConvertsPanicToRetryableCompletion(t *testing.T) {
+	t.Parallel()
+
+	completedAt := time.Date(2026, 5, 31, 14, 0, 0, 0, time.UTC)
+	supervisor, err := NewSupervisor(panicBackend{}, SupervisorConfig{
+		FailureRetryBaseDelay: 10 * time.Second,
+		MaxRetryBackoff:       time.Minute,
+		Now:                   func() time.Time { return completedAt },
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	completion := supervisor.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{ID: "issue-22", Identifier: "digitaldrywood/symphony-go#22"},
+	})
+
+	if completion.IssueID != "issue-22" {
+		t.Fatalf("IssueID = %q, want issue-22", completion.IssueID)
+	}
+	if completion.Err == nil || !strings.Contains(completion.Err.Error(), "runner panic: boom") {
+		t.Fatalf("Err = %v, want runner panic", completion.Err)
+	}
+	if !completion.Retryable {
+		t.Fatal("Retryable = false, want true")
+	}
+	if completion.RetryAttempt != 1 {
+		t.Fatalf("RetryAttempt = %d, want 1", completion.RetryAttempt)
+	}
+	if completion.RetryDelay != 10*time.Second {
+		t.Fatalf("RetryDelay = %s, want 10s", completion.RetryDelay)
+	}
+	if !completion.CompletedAt.Equal(completedAt) {
+		t.Fatalf("CompletedAt = %v, want %v", completion.CompletedAt, completedAt)
+	}
+}
+
+func TestSupervisorAppliesCappedBackoffForRunnerErrors(t *testing.T) {
+	t.Parallel()
+
+	supervisor, err := NewSupervisor(errorBackend{}, SupervisorConfig{
+		FailureRetryBaseDelay: 10 * time.Second,
+		MaxRetryBackoff:       25 * time.Second,
+		Now:                   func() time.Time { return time.Date(2026, 5, 31, 14, 0, 0, 0, time.UTC) },
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	completion := supervisor.Run(context.Background(), RunRequest{
+		Issue:   connector.Issue{ID: "issue-22", Identifier: "digitaldrywood/symphony-go#22"},
+		Attempt: 2,
+	})
+
+	if completion.Err == nil || !strings.Contains(completion.Err.Error(), "runner failed") {
+		t.Fatalf("Err = %v, want runner failed", completion.Err)
+	}
+	if completion.RetryAttempt != 3 {
+		t.Fatalf("RetryAttempt = %d, want 3", completion.RetryAttempt)
+	}
+	if completion.RetryDelay != 25*time.Second {
+		t.Fatalf("RetryDelay = %s, want capped 25s", completion.RetryDelay)
+	}
+}
+
+func TestSupervisorDispatchSendsCompletion(t *testing.T) {
+	t.Parallel()
+
+	supervisor, err := NewSupervisor(staticBackend{
+		result: RunResult{FinalState: FinalStateCompleted},
+	}, SupervisorConfig{
+		FailureRetryBaseDelay: time.Second,
+		MaxRetryBackoff:       time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	completions := make(chan Completion, 1)
+	supervisor.Dispatch(context.Background(), RunRequest{
+		Issue: connector.Issue{ID: "issue-22", Identifier: "digitaldrywood/symphony-go#22"},
+	}, completions)
+
+	select {
+	case completion := <-completions:
+		if completion.Err != nil {
+			t.Fatalf("Completion.Err = %v, want nil", completion.Err)
+		}
+		if completion.Retryable {
+			t.Fatal("Retryable = true, want false")
+		}
+		if completion.Result.FinalState != FinalStateCompleted {
+			t.Fatalf("FinalState = %q, want %q", completion.Result.FinalState, FinalStateCompleted)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for completion")
+	}
+}
+
+type panicBackend struct{}
+
+func (panicBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	panic("boom")
+}
+
+type errorBackend struct{}
+
+func (errorBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, errors.New("runner failed")
+}
+
+type staticBackend struct {
+	result RunResult
+}
+
+func (b staticBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	return b.result, nil
+}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -1,0 +1,64 @@
+package runner
+
+import (
+	"context"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+)
+
+const (
+	FinalStateCompleted = "completed"
+	FinalStateFailed    = "failed"
+)
+
+type Backend interface {
+	Run(context.Context, RunRequest) (RunResult, error)
+}
+
+type RunRequest struct {
+	Issue      connector.Issue
+	Attempt    int
+	StartedAt  time.Time
+	WorkerHost string
+}
+
+type RunResult struct {
+	FinalState    string
+	Tokens        CodexTotals
+	DiffStats     DiffStats
+	RateLimits    *telemetry.RateLimits
+	BudgetRefusal *BudgetRefusal
+}
+
+type BudgetRefusal struct {
+	Issue            connector.Issue
+	Code             string
+	Message          string
+	CurrentSpendUSD  float64
+	ProjectedCostUSD float64
+	MaxUSD           *float64
+	ResetAt          *time.Time
+	RefusedAt        time.Time
+}
+
+type DiffStats struct {
+	FilesChanged int
+	AddedLines   int
+	RemovedLines int
+	Status       string
+}
+
+type CodexTotals struct {
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	RuntimeSeconds float64
+}
+
+type FakeRunner struct{}
+
+func (FakeRunner) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{FinalState: FinalStateCompleted}, nil
+}


### PR DESCRIPTION
## Summary
- Add `internal/runner.Runner` to prepare workspaces, load skills, build prompts, run Codex, capture diff stats, and record Codex sessions.
- Add `runner.Supervisor` for goroutine-per-dispatch execution, panic recovery, retryable completions, and capped backoff.
- Wire orchestrator dispatch through the supervisor while preserving existing runner type aliases for callers.

Fixes #22

## Test Plan
- `go test ./internal/runner ./internal/orchestrator`
- `go test ./...`
- `go test -race ./internal/runner ./internal/orchestrator`
- `make check`