### PR TITLE
feat(connector/github): add project caches

### DIFF
--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -36,8 +36,10 @@ type Config struct {
 }
 
 type Connector struct {
-	client    *Client
-	projectID string
+	client       *Client
+	projectID    string
+	statusCache  *statusCache
+	projectCache *projectCache
 }
 
 func NewConnector(cfg Config) (*Connector, error) {
@@ -68,8 +70,10 @@ func NewConnector(cfg Config) (*Connector, error) {
 	}
 
 	return &Connector{
-		client:    client,
-		projectID: strings.TrimSpace(cfg.ProjectSlug),
+		client:       client,
+		projectID:    strings.TrimSpace(cfg.ProjectSlug),
+		statusCache:  newStatusCache(githubCacheTTL, cfg.Now),
+		projectCache: newProjectCache(githubCacheTTL, cfg.Now),
 	}, nil
 }
 

--- a/internal/connector/github/projectcache.go
+++ b/internal/connector/github/projectcache.go
@@ -1,0 +1,125 @@
+package github
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+type projectCache struct {
+	mu      sync.RWMutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries map[string]map[string]projectItemCacheEntry
+}
+
+type projectItemCacheEntry struct {
+	itemID   string
+	cachedAt time.Time
+}
+
+func newProjectCache(ttl time.Duration, now func() time.Time) *projectCache {
+	if now == nil {
+		now = time.Now
+	}
+
+	return &projectCache{
+		ttl:     ttl,
+		now:     now,
+		entries: map[string]map[string]projectItemCacheEntry{},
+	}
+}
+
+func (c *projectCache) GetItemID(projectID string, issueID string) (string, bool) {
+	projectID = strings.TrimSpace(projectID)
+	issueID = strings.TrimSpace(issueID)
+	if projectID == "" || issueID == "" {
+		return "", false
+	}
+
+	c.mu.RLock()
+	projectEntries, ok := c.entries[projectID]
+	if !ok {
+		c.mu.RUnlock()
+		return "", false
+	}
+	entry, ok := projectEntries[issueID]
+	c.mu.RUnlock()
+	if !ok {
+		return "", false
+	}
+	if c.fresh(entry.cachedAt) {
+		return entry.itemID, true
+	}
+
+	c.mu.Lock()
+	projectEntries = c.entries[projectID]
+	if current, ok := projectEntries[issueID]; ok && c.fresh(current.cachedAt) {
+		entry = current
+	} else if ok {
+		delete(projectEntries, issueID)
+		if len(projectEntries) == 0 {
+			delete(c.entries, projectID)
+		}
+	}
+	c.mu.Unlock()
+
+	if c.fresh(entry.cachedAt) {
+		return entry.itemID, true
+	}
+
+	return "", false
+}
+
+func (c *projectCache) SetItemID(projectID string, issueID string, itemID string) {
+	projectID = strings.TrimSpace(projectID)
+	issueID = strings.TrimSpace(issueID)
+	itemID = strings.TrimSpace(itemID)
+	if projectID == "" || issueID == "" || itemID == "" {
+		return
+	}
+
+	c.mu.Lock()
+	projectEntries := c.entries[projectID]
+	if projectEntries == nil {
+		projectEntries = map[string]projectItemCacheEntry{}
+		c.entries[projectID] = projectEntries
+	}
+	projectEntries[issueID] = projectItemCacheEntry{
+		itemID:   itemID,
+		cachedAt: c.now(),
+	}
+	c.mu.Unlock()
+}
+
+func (c *projectCache) ClearItemID(projectID string, issueID string) {
+	projectID = strings.TrimSpace(projectID)
+	issueID = strings.TrimSpace(issueID)
+	if projectID == "" || issueID == "" {
+		return
+	}
+
+	c.mu.Lock()
+	if projectEntries := c.entries[projectID]; projectEntries != nil {
+		delete(projectEntries, issueID)
+		if len(projectEntries) == 0 {
+			delete(c.entries, projectID)
+		}
+	}
+	c.mu.Unlock()
+}
+
+func (c *projectCache) ClearProject(projectID string) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return
+	}
+
+	c.mu.Lock()
+	delete(c.entries, projectID)
+	c.mu.Unlock()
+}
+
+func (c *projectCache) fresh(cachedAt time.Time) bool {
+	return c.ttl > 0 && c.now().Sub(cachedAt) < c.ttl
+}

--- a/internal/connector/github/projectcache_test.go
+++ b/internal/connector/github/projectcache_test.go
@@ -1,0 +1,83 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+func TestProjectCacheReturnsFreshItemIDByProjectAndIssue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.SetItemID("PVT_1", "I_1", "PVTI_1")
+	cache.SetItemID("PVT_2", "I_1", "PVTI_2")
+
+	got, ok := cache.GetItemID("PVT_1", "I_1")
+	if !ok {
+		t.Fatal("GetItemID() ok = false, want true")
+	}
+	if got != "PVTI_1" {
+		t.Fatalf("itemID = %q, want PVTI_1", got)
+	}
+}
+
+func TestProjectCacheExpiresItemID(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.SetItemID("PVT_1", "I_1", "PVTI_1")
+
+	now = now.Add(5*time.Minute - time.Nanosecond)
+	if _, ok := cache.GetItemID("PVT_1", "I_1"); !ok {
+		t.Fatal("GetItemID() ok = false before TTL, want true")
+	}
+
+	now = now.Add(time.Nanosecond)
+	if _, ok := cache.GetItemID("PVT_1", "I_1"); ok {
+		t.Fatal("GetItemID() ok = true after TTL, want false")
+	}
+}
+
+func TestProjectCacheClearsEntries(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.SetItemID("PVT_1", "I_1", "PVTI_1")
+	cache.SetItemID("PVT_1", "I_2", "PVTI_2")
+
+	cache.ClearItemID("PVT_1", "I_1")
+	if _, ok := cache.GetItemID("PVT_1", "I_1"); ok {
+		t.Fatal("GetItemID() ok = true after ClearItemID(), want false")
+	}
+	if _, ok := cache.GetItemID("PVT_1", "I_2"); !ok {
+		t.Fatal("GetItemID() ok = false for untouched issue, want true")
+	}
+
+	cache.ClearProject("PVT_1")
+	if _, ok := cache.GetItemID("PVT_1", "I_2"); ok {
+		t.Fatal("GetItemID() ok = true after ClearProject(), want false")
+	}
+}
+
+func TestProjectCacheIgnoresBlankKeys(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.SetItemID("", "I_1", "PVTI_1")
+	cache.SetItemID("PVT_1", "", "PVTI_1")
+	cache.SetItemID("PVT_1", "I_1", "")
+
+	if _, ok := cache.GetItemID("", "I_1"); ok {
+		t.Fatal("GetItemID() ok = true for blank project, want false")
+	}
+	if _, ok := cache.GetItemID("PVT_1", ""); ok {
+		t.Fatal("GetItemID() ok = true for blank issue, want false")
+	}
+	if _, ok := cache.GetItemID("PVT_1", "I_1"); ok {
+		t.Fatal("GetItemID() ok = true for blank item, want false")
+	}
+}

--- a/internal/connector/github/statuscache.go
+++ b/internal/connector/github/statuscache.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"strings"
+	"sync"
+	"time"
+)
+
+const githubCacheTTL = 5 * time.Minute
+
+type statusMetadata struct {
+	FieldID         string
+	OptionIDsByName map[string]string
+}
+
+type statusCache struct {
+	mu      sync.RWMutex
+	ttl     time.Duration
+	now     func() time.Time
+	entries map[string]statusCacheEntry
+}
+
+type statusCacheEntry struct {
+	metadata statusMetadata
+	cachedAt time.Time
+}
+
+func newStatusCache(ttl time.Duration, now func() time.Time) *statusCache {
+	if now == nil {
+		now = time.Now
+	}
+
+	return &statusCache{
+		ttl:     ttl,
+		now:     now,
+		entries: map[string]statusCacheEntry{},
+	}
+}
+
+func (c *statusCache) Get(projectID string) (statusMetadata, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return statusMetadata{}, false
+	}
+
+	c.mu.RLock()
+	entry, ok := c.entries[projectID]
+	c.mu.RUnlock()
+	if !ok {
+		return statusMetadata{}, false
+	}
+	if c.fresh(entry.cachedAt) {
+		return cloneStatusMetadata(entry.metadata), true
+	}
+
+	c.mu.Lock()
+	if current, ok := c.entries[projectID]; ok && c.fresh(current.cachedAt) {
+		entry = current
+	} else if ok {
+		delete(c.entries, projectID)
+	}
+	c.mu.Unlock()
+
+	if c.fresh(entry.cachedAt) {
+		return cloneStatusMetadata(entry.metadata), true
+	}
+
+	return statusMetadata{}, false
+}
+
+func (c *statusCache) Set(projectID string, metadata statusMetadata) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return
+	}
+
+	c.mu.Lock()
+	c.entries[projectID] = statusCacheEntry{
+		metadata: cloneStatusMetadata(metadata),
+		cachedAt: c.now(),
+	}
+	c.mu.Unlock()
+}
+
+func (c *statusCache) Clear(projectID string) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return
+	}
+
+	c.mu.Lock()
+	delete(c.entries, projectID)
+	c.mu.Unlock()
+}
+
+func (c *statusCache) fresh(cachedAt time.Time) bool {
+	return c.ttl > 0 && c.now().Sub(cachedAt) < c.ttl
+}
+
+func cloneStatusMetadata(metadata statusMetadata) statusMetadata {
+	return statusMetadata{
+		FieldID:         metadata.FieldID,
+		OptionIDsByName: cloneStringMap(metadata.OptionIDsByName),
+	}
+}
+
+func cloneStringMap(values map[string]string) map[string]string {
+	if values == nil {
+		return nil
+	}
+
+	cloned := make(map[string]string, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}

--- a/internal/connector/github/statuscache_test.go
+++ b/internal/connector/github/statuscache_test.go
@@ -1,0 +1,97 @@
+package github
+
+import (
+	"testing"
+	"time"
+)
+
+func TestStatusCacheReturnsFreshMetadataByProject(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newStatusCache(5*time.Minute, func() time.Time { return now })
+
+	cache.Set("PVT_1", statusMetadata{
+		FieldID: "PVTSSF_status",
+		OptionIDsByName: map[string]string{
+			"Done": "OPT_done",
+			"Todo": "OPT_todo",
+		},
+	})
+	cache.Set("PVT_2", statusMetadata{
+		FieldID:         "PVTSSF_other",
+		OptionIDsByName: map[string]string{"Done": "OPT_other"},
+	})
+
+	got, ok := cache.Get("PVT_1")
+	if !ok {
+		t.Fatal("Get() ok = false, want true")
+	}
+	if got.FieldID != "PVTSSF_status" {
+		t.Fatalf("FieldID = %q, want PVTSSF_status", got.FieldID)
+	}
+	if got.OptionIDsByName["Done"] != "OPT_done" {
+		t.Fatalf("Done option = %q, want OPT_done", got.OptionIDsByName["Done"])
+	}
+}
+
+func TestStatusCacheExpiresMetadata(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newStatusCache(5*time.Minute, func() time.Time { return now })
+	cache.Set("PVT_1", statusMetadata{FieldID: "PVTSSF_status"})
+
+	now = now.Add(5*time.Minute - time.Nanosecond)
+	if _, ok := cache.Get("PVT_1"); !ok {
+		t.Fatal("Get() ok = false before TTL, want true")
+	}
+
+	now = now.Add(time.Nanosecond)
+	if _, ok := cache.Get("PVT_1"); ok {
+		t.Fatal("Get() ok = true after TTL, want false")
+	}
+}
+
+func TestStatusCacheClonesOptionIDs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newStatusCache(5*time.Minute, func() time.Time { return now })
+	options := map[string]string{"Done": "OPT_done"}
+	cache.Set("PVT_1", statusMetadata{
+		FieldID:         "PVTSSF_status",
+		OptionIDsByName: options,
+	})
+
+	options["Done"] = "OPT_mutated"
+	got, ok := cache.Get("PVT_1")
+	if !ok {
+		t.Fatal("Get() ok = false, want true")
+	}
+	if got.OptionIDsByName["Done"] != "OPT_done" {
+		t.Fatalf("Done option = %q, want OPT_done", got.OptionIDsByName["Done"])
+	}
+
+	got.OptionIDsByName["Done"] = "OPT_changed"
+	got, ok = cache.Get("PVT_1")
+	if !ok {
+		t.Fatal("Get() ok = false after caller mutation, want true")
+	}
+	if got.OptionIDsByName["Done"] != "OPT_done" {
+		t.Fatalf("cached Done option = %q, want OPT_done", got.OptionIDsByName["Done"])
+	}
+}
+
+func TestStatusCacheClearProject(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newStatusCache(5*time.Minute, func() time.Time { return now })
+	cache.Set("PVT_1", statusMetadata{FieldID: "PVTSSF_status"})
+	cache.Clear("PVT_1")
+
+	if _, ok := cache.Get("PVT_1"); ok {
+		t.Fatal("Get() ok = true after Clear(), want false")
+	}
+}


### PR DESCRIPTION
## Summary
- Add 5-minute RWMutex-backed status metadata cache keyed by GitHub ProjectV2 id.
- Add 5-minute RWMutex-backed project item cache keyed by project id and issue id for adapter status writes.
- Wire both caches into the GitHub connector constructor and cover TTL, clear, cloning, and key behavior.

Fixes #25

## Test Plan
- go test ./internal/connector/github
- go test -race ./internal/connector/github
- go test ./internal/connector/...
- make check