### PR TITLE
feat(project): add lifecycle registry

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1,0 +1,383 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/connector/factory"
+	"github.com/digitaldrywood/symphony-go/internal/connector/memory"
+	"github.com/digitaldrywood/symphony-go/internal/hub"
+	"github.com/digitaldrywood/symphony-go/internal/orchestrator"
+	"github.com/digitaldrywood/symphony-go/internal/scheduler"
+)
+
+var (
+	ErrAlreadyRunning      = errors.New("project already running")
+	ErrMissingConnector    = errors.New("project connector is required")
+	ErrMissingOrchestrator = errors.New("project orchestrator is required")
+	ErrMissingProject      = errors.New("project is required")
+	ErrMissingProjectID    = errors.New("project id is required")
+	ErrNotRunning          = errors.New("project is not running")
+	ErrProjectPaused       = errors.New("project is paused")
+)
+
+const (
+	EventStarted EventKind = "project_started"
+	EventStopped EventKind = "project_stopped"
+)
+
+type ProjectID string
+
+type EventKind string
+
+type Event struct {
+	ProjectID ProjectID
+	Kind      EventKind
+	At        time.Time
+	Error     string
+}
+
+type Config struct {
+	Project  globalconfig.Project
+	Workflow workflowconfig.Workflow
+}
+
+type ConnectorFactory func(workflowconfig.Config) (connector.Connector, error)
+
+type OrchestratorFactory func(orchestrator.Config, orchestrator.Dependencies) (*orchestrator.Orchestrator, error)
+
+type Dependencies struct {
+	Connector           connector.Connector
+	ConnectorFactory    ConnectorFactory
+	OrchestratorFactory OrchestratorFactory
+	Runner              orchestrator.Runner
+	Scheduler           scheduler.Scheduler
+	Events              *hub.Hub[Event]
+	Logger              *slog.Logger
+}
+
+type Project struct {
+	id           ProjectID
+	cfg          globalconfig.Project
+	workflow     workflowconfig.Workflow
+	connector    connector.Connector
+	orchestrator *orchestrator.Orchestrator
+	scheduler    scheduler.Scheduler
+	events       *hub.Hub[Event]
+	logger       *slog.Logger
+
+	mu     sync.Mutex
+	cancel context.CancelFunc
+	done   chan error
+}
+
+func Load(cfg globalconfig.Project, deps Dependencies) (*Project, error) {
+	workflow, err := workflowconfig.LoadWorkflow(cfg.Workflow)
+	if err != nil {
+		return nil, fmt.Errorf("load project workflow: %w", err)
+	}
+
+	return New(Config{Project: cfg, Workflow: workflow}, deps)
+}
+
+func New(cfg Config, deps Dependencies) (*Project, error) {
+	id := normalizeProjectID(ProjectID(cfg.Project.ID))
+	if id == "" {
+		return nil, ErrMissingProjectID
+	}
+
+	workflow := normalizeWorkflow(cfg.Workflow)
+	if err := workflow.Config.Validate(); err != nil {
+		return nil, fmt.Errorf("validate project workflow: %w", err)
+	}
+
+	projectConnector, err := buildConnector(workflow.Config, deps)
+	if err != nil {
+		return nil, err
+	}
+
+	projectScheduler, err := buildScheduler(workflow.Config, deps)
+	if err != nil {
+		return nil, err
+	}
+
+	projectEvents := deps.Events
+	if projectEvents == nil {
+		projectEvents = hub.New[Event]()
+	}
+
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	orchestratorFactory := deps.OrchestratorFactory
+	if orchestratorFactory == nil {
+		orchestratorFactory = orchestrator.New
+	}
+
+	orch, err := orchestratorFactory(orchestrator.ConfigFromWorkflow(workflow.Config), orchestrator.Dependencies{
+		Connector: projectConnector,
+		Runner:    deps.Runner,
+		Logger:    logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create project orchestrator: %w", err)
+	}
+	if orch == nil {
+		return nil, ErrMissingOrchestrator
+	}
+
+	cfg.Project.ID = string(id)
+	return &Project{
+		id:           id,
+		cfg:          cfg.Project,
+		workflow:     workflow,
+		connector:    projectConnector,
+		orchestrator: orch,
+		scheduler:    projectScheduler,
+		events:       projectEvents,
+		logger:       logger,
+	}, nil
+}
+
+func (p *Project) ID() ProjectID {
+	if p == nil {
+		return ""
+	}
+	return p.id
+}
+
+func (p *Project) Config() globalconfig.Project {
+	return p.cfg
+}
+
+func (p *Project) Workflow() workflowconfig.Workflow {
+	return p.workflow
+}
+
+func (p *Project) Connector() connector.Connector {
+	return p.connector
+}
+
+func (p *Project) Orchestrator() *orchestrator.Orchestrator {
+	return p.orchestrator
+}
+
+func (p *Project) Scheduler() scheduler.Scheduler {
+	return p.scheduler
+}
+
+func (p *Project) Events() *hub.Hub[Event] {
+	return p.events
+}
+
+func (p *Project) Running() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.done != nil
+}
+
+func (p *Project) Start(ctx context.Context) error {
+	if p.cfg.Paused {
+		return ErrProjectPaused
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	if p.done != nil {
+		p.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	done := make(chan error, 1)
+	p.cancel = cancel
+	p.done = done
+	p.mu.Unlock()
+
+	p.publish(Event{
+		ProjectID: p.id,
+		Kind:      EventStarted,
+		At:        time.Now(),
+	})
+
+	go p.run(runCtx, done)
+	return nil
+}
+
+func (p *Project) Stop(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	cancel := p.cancel
+	done := p.done
+	if done == nil {
+		p.mu.Unlock()
+		return ErrNotRunning
+	}
+	cancel()
+	p.mu.Unlock()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *Project) Wait(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	done := p.done
+	if done == nil {
+		p.mu.Unlock()
+		return ErrNotRunning
+	}
+	p.mu.Unlock()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (p *Project) run(ctx context.Context, done chan<- error) {
+	err := p.orchestrator.Run(ctx)
+	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+		err = nil
+	}
+
+	p.mu.Lock()
+	if p.done == done {
+		p.cancel = nil
+		p.done = nil
+	}
+	p.mu.Unlock()
+
+	p.publish(Event{
+		ProjectID: p.id,
+		Kind:      EventStopped,
+		At:        time.Now(),
+		Error:     errorString(err),
+	})
+
+	done <- err
+	close(done)
+}
+
+func (p *Project) publish(event Event) {
+	if err := p.events.Publish(event); err != nil {
+		p.logger.Warn("publish project event failed",
+			"project_id", event.ProjectID,
+			"event", event.Kind,
+			"error", err,
+		)
+	}
+}
+
+func buildConnector(cfg workflowconfig.Config, deps Dependencies) (connector.Connector, error) {
+	if deps.Connector != nil {
+		return deps.Connector, nil
+	}
+
+	connectorFactory := deps.ConnectorFactory
+	if connectorFactory == nil {
+		connectorFactory = defaultConnectorFactory
+	}
+
+	projectConnector, err := connectorFactory(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create project connector: %w", err)
+	}
+	if projectConnector == nil {
+		return nil, ErrMissingConnector
+	}
+
+	return projectConnector, nil
+}
+
+func buildScheduler(cfg workflowconfig.Config, deps Dependencies) (scheduler.Scheduler, error) {
+	if deps.Scheduler != nil {
+		return deps.Scheduler, nil
+	}
+
+	projectScheduler, err := scheduler.NewFromConfig(scheduler.Config{
+		Capacity:        cfg.Agent.MaxConcurrentAgents,
+		CapacityByState: cfg.Agent.MaxConcurrentAgentsByState,
+		CapacityPerHost: maxConcurrentAgentsPerHost(cfg),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create project scheduler: %w", err)
+	}
+
+	return projectScheduler, nil
+}
+
+func defaultConnectorFactory(cfg workflowconfig.Config) (connector.Connector, error) {
+	return factory.NewFromConfig(factory.Config{
+		Kind:                    cfg.Tracker.Kind,
+		Memory:                  memory.Config{Issues: cfg.Tracker.Issues},
+		Endpoint:                cfg.Tracker.Endpoint,
+		APIKey:                  cfg.Tracker.APIKey,
+		GitHubAppID:             cfg.Tracker.GitHubAppID,
+		GitHubAppPrivateKey:     cfg.Tracker.GitHubAppPrivateKey,
+		GitHubAppPrivateKeyPath: cfg.Tracker.GitHubAppPrivateKeyPath,
+		GitHubAppInstallationID: cfg.Tracker.GitHubAppInstallationID,
+		ProjectSlug:             cfg.Tracker.ProjectSlug,
+	})
+}
+
+func normalizeWorkflow(workflow workflowconfig.Workflow) workflowconfig.Workflow {
+	if !emptyWorkflowConfig(workflow.Config) {
+		return workflow
+	}
+
+	workflow.Config = workflowconfig.Default()
+	workflow.Config.Tracker.Kind = workflowconfig.TrackerMemory
+	return workflow
+}
+
+func emptyWorkflowConfig(cfg workflowconfig.Config) bool {
+	return cfg.Tracker.Kind == "" &&
+		cfg.Polling.IntervalMS == 0 &&
+		cfg.Agent.MaxConcurrentAgents == 0 &&
+		cfg.Codex.Command == ""
+}
+
+func maxConcurrentAgentsPerHost(cfg workflowconfig.Config) int {
+	if cfg.Worker.MaxConcurrentAgentsPerHost == nil {
+		return 0
+	}
+	return *cfg.Worker.MaxConcurrentAgentsPerHost
+}
+
+func normalizeProjectID(id ProjectID) ProjectID {
+	return ProjectID(strings.TrimSpace(string(id)))
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -27,6 +27,7 @@ var (
 	ErrMissingProjectID    = errors.New("project id is required")
 	ErrNotRunning          = errors.New("project is not running")
 	ErrProjectPaused       = errors.New("project is paused")
+	ErrProjectStopped      = errors.New("project is stopped")
 )
 
 const (
@@ -74,9 +75,11 @@ type Project struct {
 	events       *hub.Hub[Event]
 	logger       *slog.Logger
 
-	mu     sync.Mutex
-	cancel context.CancelFunc
-	done   chan error
+	mu      sync.Mutex
+	cancel  context.CancelFunc
+	done    chan struct{}
+	runErr  error
+	started bool
 }
 
 func Load(cfg globalconfig.Project, deps Dependencies) (*Project, error) {
@@ -200,11 +203,17 @@ func (p *Project) Start(ctx context.Context) error {
 		p.mu.Unlock()
 		return ErrAlreadyRunning
 	}
+	if p.started {
+		p.mu.Unlock()
+		return ErrProjectStopped
+	}
 
 	runCtx, cancel := context.WithCancel(ctx)
-	done := make(chan error, 1)
+	done := make(chan struct{})
 	p.cancel = cancel
 	p.done = done
+	p.runErr = nil
+	p.started = true
 	p.mu.Unlock()
 
 	p.publish(Event{
@@ -232,12 +241,7 @@ func (p *Project) Stop(ctx context.Context) error {
 	cancel()
 	p.mu.Unlock()
 
-	select {
-	case err := <-done:
-		return err
-	case <-ctx.Done():
-		return ctx.Err()
-	}
+	return p.waitDone(ctx, done)
 }
 
 func (p *Project) Wait(ctx context.Context) error {
@@ -253,15 +257,22 @@ func (p *Project) Wait(ctx context.Context) error {
 	}
 	p.mu.Unlock()
 
+	return p.waitDone(ctx, done)
+}
+
+func (p *Project) waitDone(ctx context.Context, done <-chan struct{}) error {
 	select {
-	case err := <-done:
-		return err
+	case <-done:
+		p.mu.Lock()
+		defer p.mu.Unlock()
+
+		return p.runErr
 	case <-ctx.Done():
 		return ctx.Err()
 	}
 }
 
-func (p *Project) run(ctx context.Context, done chan<- error) {
+func (p *Project) run(ctx context.Context, done chan struct{}) {
 	err := p.orchestrator.Run(ctx)
 	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
 		err = nil
@@ -271,6 +282,7 @@ func (p *Project) run(ctx context.Context, done chan<- error) {
 	if p.done == done {
 		p.cancel = nil
 		p.done = nil
+		p.runErr = err
 	}
 	p.mu.Unlock()
 
@@ -281,7 +293,6 @@ func (p *Project) run(ctx context.Context, done chan<- error) {
 		Error:     errorString(err),
 	})
 
-	done <- err
 	close(done)
 }
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -1,0 +1,226 @@
+package project_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/hub"
+	"github.com/digitaldrywood/symphony-go/internal/orchestrator"
+	"github.com/digitaldrywood/symphony-go/internal/project"
+	"github.com/digitaldrywood/symphony-go/internal/scheduler"
+)
+
+func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event]()
+	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 3})
+	created := make(chan orchestrator.Config, 1)
+
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:       "symphony",
+			Workflow: "workflow.md",
+			Workdir:  "/workspace/symphony",
+			Weight:   2,
+			Priority: 10,
+		},
+		Workflow: workflowconfig.Workflow{
+			Config: workflowConfigWithMemoryIssue("issue-1"),
+			Prompt: "Run issue",
+		},
+	}, project.Dependencies{
+		Scheduler: sched,
+		Events:    events,
+		Runner:    orchestrator.FakeRunner{},
+		OrchestratorFactory: func(cfg orchestrator.Config, deps orchestrator.Dependencies) (*orchestrator.Orchestrator, error) {
+			created <- cfg
+			return orchestrator.New(cfg, deps)
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if got.ID() != project.ProjectID("symphony") {
+		t.Fatalf("ID() = %q, want symphony", got.ID())
+	}
+	if got.Config().Workdir != "/workspace/symphony" {
+		t.Fatalf("Config().Workdir = %q, want /workspace/symphony", got.Config().Workdir)
+	}
+	if got.Connector().Name() != connector.BackendMemory.String() {
+		t.Fatalf("Connector().Name() = %q, want memory", got.Connector().Name())
+	}
+	if got.Scheduler() != sched {
+		t.Fatalf("Scheduler() = %p, want %p", got.Scheduler(), sched)
+	}
+	if got.Events() != events {
+		t.Fatalf("Events() = %p, want %p", got.Events(), events)
+	}
+	if got.Orchestrator() == nil {
+		t.Fatal("Orchestrator() = nil, want configured orchestrator")
+	}
+
+	select {
+	case cfg := <-created:
+		if cfg.MaxConcurrentAgents != 4 {
+			t.Fatalf("orchestrator MaxConcurrentAgents = %d, want 4", cfg.MaxConcurrentAgents)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for orchestrator factory")
+	}
+}
+
+func TestProjectStartStopPublishesLifecycleEvents(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(2))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "symphony",
+			Weight: 1,
+		},
+		Workflow: workflowconfig.Workflow{
+			Config: workflowConfigWithMemoryIssue("issue-1"),
+		},
+	}, project.Dependencies{
+		Events: events,
+		Runner: blockingRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := got.Start(context.Background()); !errors.Is(err, project.ErrAlreadyRunning) {
+		t.Fatalf("Start() second error = %v, want %v", err, project.ErrAlreadyRunning)
+	}
+
+	started := receiveEvent(t, sub.C())
+	if started.ProjectID != got.ID() || started.Kind != project.EventStarted {
+		t.Fatalf("started event = %#v, want project started", started)
+	}
+
+	if err := got.Stop(context.Background()); err != nil {
+		t.Fatalf("Stop() error = %v", err)
+	}
+	stopped := receiveEvent(t, sub.C())
+	if stopped.ProjectID != got.ID() || stopped.Kind != project.EventStopped {
+		t.Fatalf("stopped event = %#v, want project stopped", stopped)
+	}
+	if err := got.Stop(context.Background()); !errors.Is(err, project.ErrNotRunning) {
+		t.Fatalf("Stop() second error = %v, want %v", err, project.ErrNotRunning)
+	}
+}
+
+func TestNewRejectsInvalidProjectConfig(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  project.Config
+		deps project.Dependencies
+		want error
+	}{
+		{
+			name: "missing id",
+			cfg:  project.Config{},
+			want: project.ErrMissingProjectID,
+		},
+		{
+			name: "missing connector",
+			cfg: project.Config{
+				Project:  globalconfig.Project{ID: "memory"},
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			},
+			deps: project.Dependencies{
+				ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+					return nil, nil
+				},
+			},
+			want: project.ErrMissingConnector,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := project.New(tt.cfg, tt.deps)
+			if got != nil {
+				t.Fatalf("New() project = %#v, want nil", got)
+			}
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("New() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectStartRejectsPausedProject(t *testing.T) {
+	t.Parallel()
+
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "paused",
+			Paused: true,
+			Weight: 1,
+		},
+	}, project.Dependencies{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := got.Start(context.Background()); !errors.Is(err, project.ErrProjectPaused) {
+		t.Fatalf("Start() error = %v, want %v", err, project.ErrProjectPaused)
+	}
+}
+
+func workflowConfigWithMemoryIssue(id string) workflowconfig.Config {
+	cfg := workflowConfig("memory")
+	cfg.Agent.MaxConcurrentAgents = 4
+	cfg.Polling.IntervalMS = 10
+	cfg.Tracker.Issues = []connector.Issue{{
+		ID:         id,
+		Identifier: id,
+		State:      "Done",
+	}}
+	return cfg
+}
+
+func workflowConfig(kind string) workflowconfig.Config {
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = kind
+	return cfg
+}
+
+type blockingRunner struct{}
+
+func (blockingRunner) Run(ctx context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	<-ctx.Done()
+	return orchestrator.RunResult{}, ctx.Err()
+}
+
+func receiveEvent(t *testing.T, ch <-chan project.Event) project.Event {
+	t.Helper()
+
+	select {
+	case event := <-ch:
+		return event
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for project event")
+	}
+
+	return project.Event{}
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -122,6 +122,9 @@ func TestProjectStartStopPublishesLifecycleEvents(t *testing.T) {
 	if err := got.Stop(context.Background()); !errors.Is(err, project.ErrNotRunning) {
 		t.Fatalf("Stop() second error = %v, want %v", err, project.ErrNotRunning)
 	}
+	if err := got.Start(context.Background()); !errors.Is(err, project.ErrProjectStopped) {
+		t.Fatalf("Start() after Stop error = %v, want %v", err, project.ErrProjectStopped)
+	}
 }
 
 func TestNewRejectsInvalidProjectConfig(t *testing.T) {
@@ -165,6 +168,42 @@ func TestNewRejectsInvalidProjectConfig(t *testing.T) {
 				t.Fatalf("New() error = %v, want %v", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestProjectWaitersReceiveRunError(t *testing.T) {
+	t.Parallel()
+
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "symphony",
+			Weight: 1,
+		},
+		Workflow: workflowconfig.Workflow{
+			Config: workflowConfigWithMemoryIssue("issue-1"),
+		},
+	}, project.Dependencies{})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	defer cancel()
+	if err := got.Start(runCtx); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	errs := make(chan error, 2)
+	for range 2 {
+		go func() {
+			errs <- got.Wait(context.Background())
+		}()
+	}
+
+	for range 2 {
+		if err := <-errs; !errors.Is(err, context.DeadlineExceeded) {
+			t.Fatalf("Wait() error = %v, want %v", err, context.DeadlineExceeded)
+		}
 	}
 }
 

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -1,0 +1,81 @@
+package project
+
+import (
+	"sort"
+	"sync"
+)
+
+type Registry struct {
+	mu       sync.RWMutex
+	projects map[ProjectID]*Project
+}
+
+func NewRegistry() *Registry {
+	return &Registry{
+		projects: map[ProjectID]*Project{},
+	}
+}
+
+func (r *Registry) Set(project *Project) error {
+	if project == nil {
+		return ErrMissingProject
+	}
+
+	id := normalizeProjectID(project.ID())
+	if id == "" {
+		return ErrMissingProjectID
+	}
+
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.projects[id] = project
+	return nil
+}
+
+func (r *Registry) Get(id ProjectID) (*Project, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	project, ok := r.projects[normalizeProjectID(id)]
+	return project, ok
+}
+
+func (r *Registry) Delete(id ProjectID) bool {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	id = normalizeProjectID(id)
+	if _, ok := r.projects[id]; !ok {
+		return false
+	}
+
+	delete(r.projects, id)
+	return true
+}
+
+func (r *Registry) List() []*Project {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	ids := make([]ProjectID, 0, len(r.projects))
+	for id := range r.projects {
+		ids = append(ids, id)
+	}
+	sort.Slice(ids, func(i, j int) bool {
+		return ids[i] < ids[j]
+	})
+
+	projects := make([]*Project, 0, len(ids))
+	for _, id := range ids {
+		projects = append(projects, r.projects[id])
+	}
+	return projects
+}
+
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return len(r.projects)
+}

--- a/internal/project/registry_test.go
+++ b/internal/project/registry_test.go
@@ -1,0 +1,92 @@
+package project_test
+
+import (
+	"testing"
+
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/project"
+)
+
+func TestRegistryStoresAndListsProjectsByID(t *testing.T) {
+	t.Parallel()
+
+	registry := project.NewRegistry()
+	second := newTestProject(t, "beta")
+	first := newTestProject(t, "alpha")
+
+	if err := registry.Set(second); err != nil {
+		t.Fatalf("Set(second) error = %v", err)
+	}
+	if err := registry.Set(first); err != nil {
+		t.Fatalf("Set(first) error = %v", err)
+	}
+
+	got, ok := registry.Get(project.ProjectID("alpha"))
+	if !ok {
+		t.Fatal("Get(alpha) ok = false, want true")
+	}
+	if got != first {
+		t.Fatalf("Get(alpha) = %p, want %p", got, first)
+	}
+
+	projects := registry.List()
+	if len(projects) != 2 {
+		t.Fatalf("List() len = %d, want 2", len(projects))
+	}
+	if projects[0] != first || projects[1] != second {
+		t.Fatalf("List() = [%s %s], want [alpha beta]", projects[0].ID(), projects[1].ID())
+	}
+	if registry.Len() != 2 {
+		t.Fatalf("Len() = %d, want 2", registry.Len())
+	}
+}
+
+func TestRegistryDeletesProjects(t *testing.T) {
+	t.Parallel()
+
+	registry := project.NewRegistry()
+	existing := newTestProject(t, "alpha")
+	if err := registry.Set(existing); err != nil {
+		t.Fatalf("Set() error = %v", err)
+	}
+
+	if !registry.Delete(existing.ID()) {
+		t.Fatal("Delete(alpha) = false, want true")
+	}
+	if registry.Delete(existing.ID()) {
+		t.Fatal("Delete(alpha) after removal = true, want false")
+	}
+	if _, ok := registry.Get(existing.ID()); ok {
+		t.Fatal("Get(alpha) ok = true after Delete, want false")
+	}
+}
+
+func TestRegistryRejectsInvalidProject(t *testing.T) {
+	t.Parallel()
+
+	registry := project.NewRegistry()
+
+	if err := registry.Set(nil); err != project.ErrMissingProject {
+		t.Fatalf("Set(nil) error = %v, want %v", err, project.ErrMissingProject)
+	}
+
+	invalid := &project.Project{}
+	if err := registry.Set(invalid); err != project.ErrMissingProjectID {
+		t.Fatalf("Set(invalid) error = %v, want %v", err, project.ErrMissingProjectID)
+	}
+}
+
+func newTestProject(t *testing.T, id string) *project.Project {
+	t.Helper()
+
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     id,
+			Weight: 1,
+		},
+	}, project.Dependencies{})
+	if err != nil {
+		t.Fatalf("New(%q) error = %v", id, err)
+	}
+	return got
+}


### PR DESCRIPTION
## Summary
- Add internal/project registry keyed by ProjectID with RWMutex-backed Set/Get/Delete/List access.
- Add Project construction and lifecycle wiring for workflow config, connector factory, orchestrator, shared scheduler, and shared event hub.
- Cover registry behavior, constructor dependency wiring, lifecycle events, paused projects, and invalid config cases.

Fixes #30

## Test Plan
- go test ./internal/project
- make check