### PR TITLE
feat(web): add observability REST API

### DIFF
--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -105,6 +105,13 @@ func (h *Hub[T]) Publish(value T) error {
 	return nil
 }
 
+func (h *Hub[T]) Latest() (T, bool) {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	return h.last, h.hasLast
+}
+
 func (h *Hub[T]) Close() {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -58,6 +58,30 @@ func TestHubSubscribeReplaysLastEvent(t *testing.T) {
 	}
 }
 
+func TestHubLatestReturnsLastEvent(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[string]()
+	if got, ok := events.Latest(); ok || got != "" {
+		t.Fatalf("Latest() before publish = %q, %v; want empty, false", got, ok)
+	}
+
+	if err := events.Publish("ready"); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	got, ok := events.Latest()
+	if !ok || got != "ready" {
+		t.Fatalf("Latest() = %q, %v; want ready, true", got, ok)
+	}
+
+	events.Close()
+	got, ok = events.Latest()
+	if !ok || got != "ready" {
+		t.Fatalf("Latest() after Close() = %q, %v; want ready, true", got, ok)
+	}
+}
+
 func TestHubDropsOldestForSlowSubscriber(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -60,6 +60,7 @@ type Orchestrator struct {
 	logger        *slog.Logger
 	stateRequests chan stateRequest
 	configUpdates chan configUpdateRequest
+	refreshes     chan time.Time
 	runResults    chan runpkg.Completion
 	done          chan struct{}
 }
@@ -126,6 +127,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		logger:        logger,
 		stateRequests: make(chan stateRequest),
 		configUpdates: make(chan configUpdateRequest),
+		refreshes:     make(chan time.Time, 1),
 		runResults:    make(chan runpkg.Completion),
 		done:          make(chan struct{}),
 	}, nil
@@ -148,6 +150,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		case <-ctx.Done():
 			return ctx.Err()
 		case now := <-ticker.C:
+			o.tick(ctx, &state, now)
+		case now := <-o.refreshes:
 			o.tick(ctx, &state, now)
 		case result := <-o.runResults:
 			o.handleRunResult(&state, result)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -426,6 +426,79 @@ func TestStateReturnsDefensiveCopies(t *testing.T) {
 	close(runner.release)
 }
 
+func TestRequestRefreshQueuesImmediateTick(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeConnector()
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    &staticRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForFetchCalls(t, tracker, 1)
+
+	refresh, err := orch.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	if !refresh.Queued || refresh.Coalesced || len(refresh.Operations) != 2 {
+		t.Fatalf("RequestRefresh() = %#v, want queued non-coalesced poll/reconcile", refresh)
+	}
+	if refresh.Operations[0] != "poll" || refresh.Operations[1] != "reconcile" {
+		t.Fatalf("Operations = %#v, want poll/reconcile", refresh.Operations)
+	}
+	if refresh.RequestedAt.IsZero() {
+		t.Fatal("RequestedAt is zero")
+	}
+
+	waitForFetchCalls(t, tracker, 2)
+}
+
+func TestRequestRefreshCoalescesPendingTick(t *testing.T) {
+	t.Parallel()
+
+	orch := newTestOrchestrator(t, newFakeConnector(), &staticRunner{})
+
+	first, err := orch.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("first RequestRefresh() error = %v", err)
+	}
+	second, err := orch.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("second RequestRefresh() error = %v", err)
+	}
+	if first.Coalesced {
+		t.Fatalf("first RequestRefresh().Coalesced = true, want false")
+	}
+	if !second.Coalesced {
+		t.Fatalf("second RequestRefresh().Coalesced = false, want true")
+	}
+}
+
+func TestRequestRefreshReturnsStoppedAfterRunStops(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeConnector()
+	orch := newTestOrchestrator(t, tracker, &staticRunner{})
+	stop := runOrchestrator(t, orch)
+	waitForFetchCalls(t, tracker, 1)
+	stop()
+
+	if _, err := orch.RequestRefresh(context.Background()); !errors.Is(err, orchestrator.ErrStopped) {
+		t.Fatalf("RequestRefresh() error = %v, want ErrStopped", err)
+	}
+}
+
 func TestFakeRunnerCompletes(t *testing.T) {
 	t.Parallel()
 
@@ -498,6 +571,24 @@ func waitForState(t *testing.T, orch *orchestrator.Orchestrator, ready func(orch
 		select {
 		case <-deadline:
 			t.Fatal("timed out waiting for orchestrator state")
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func waitForFetchCalls(t *testing.T, tracker *fakeConnector, want int) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		if tracker.fetchCandidateCalls() >= want {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d FetchCandidateIssues() calls; got %d", want, tracker.fetchCandidateCalls())
 		default:
 			time.Sleep(time.Millisecond)
 		}

--- a/internal/orchestrator/refresh.go
+++ b/internal/orchestrator/refresh.go
@@ -1,0 +1,45 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+)
+
+type RefreshResponse struct {
+	Queued      bool      `json:"queued"`
+	Coalesced   bool      `json:"coalesced"`
+	RequestedAt time.Time `json:"requested_at"`
+	Operations  []string  `json:"operations"`
+}
+
+func (o *Orchestrator) RequestRefresh(ctx context.Context) (RefreshResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	response := RefreshResponse{
+		Queued:      true,
+		RequestedAt: time.Now().UTC().Truncate(time.Second),
+		Operations:  []string{"poll", "reconcile"},
+	}
+
+	select {
+	case <-ctx.Done():
+		return RefreshResponse{}, ctx.Err()
+	case <-o.done:
+		return RefreshResponse{}, ErrStopped
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return RefreshResponse{}, ctx.Err()
+	case <-o.done:
+		return RefreshResponse{}, ErrStopped
+	case o.refreshes <- response.RequestedAt:
+		return response, nil
+	default:
+		response.Coalesced = true
+		return response, nil
+	}
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1,0 +1,676 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/symphony-go/internal/orchestrator"
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+)
+
+const issueDescriptionLimit = 250
+
+type Refresher interface {
+	RequestRefresh(context.Context) (RefreshResponse, error)
+}
+
+type RefreshResponse = orchestrator.RefreshResponse
+
+func (s *Server) apiState(c echo.Context) error {
+	generatedAt := apiNow()
+	snapshot, ok := s.hub.Latest()
+	if !ok {
+		return c.JSON(http.StatusOK, snapshotErrorResponse(generatedAt, "snapshot_unavailable", "Snapshot unavailable"))
+	}
+
+	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt))
+}
+
+func (s *Server) apiIssue(c echo.Context) error {
+	snapshot, ok := s.hub.Latest()
+	if !ok {
+		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
+	}
+
+	payload, ok := issueResponse(c.Param("issue"), snapshot)
+	if !ok {
+		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
+	}
+
+	return c.JSON(http.StatusOK, payload)
+}
+
+func (s *Server) apiRefresh(c echo.Context) error {
+	if s.refresher == nil {
+		return c.JSON(http.StatusServiceUnavailable, errorResponse("orchestrator_unavailable", "Orchestrator is unavailable"))
+	}
+
+	payload, err := s.refresher.RequestRefresh(c.Request().Context())
+	if err != nil {
+		return c.JSON(http.StatusServiceUnavailable, errorResponse("orchestrator_unavailable", "Orchestrator is unavailable"))
+	}
+	if payload.RequestedAt.IsZero() {
+		payload.RequestedAt = apiNow()
+	}
+	if payload.Operations == nil {
+		payload.Operations = []string{}
+	}
+
+	return c.JSON(http.StatusAccepted, payload)
+}
+
+func (s *Server) methodNotAllowed(c echo.Context) error {
+	return c.JSON(http.StatusMethodNotAllowed, errorResponse("method_not_allowed", "Method not allowed"))
+}
+
+func (s *Server) handleHTTPError(err error, c echo.Context) {
+	if c.Response().Committed {
+		return
+	}
+
+	status := http.StatusInternalServerError
+	payload := errorResponse("internal_server_error", "Internal server error")
+
+	var httpErr *echo.HTTPError
+	if errors.As(err, &httpErr) {
+		status = httpErr.Code
+		switch status {
+		case http.StatusNotFound:
+			payload = errorResponse("not_found", "Route not found")
+		case http.StatusMethodNotAllowed:
+			payload = errorResponse("method_not_allowed", "Method not allowed")
+		}
+	}
+
+	if writeErr := c.JSON(status, payload); writeErr != nil {
+		s.logger.Error("write http error response failed", slog.Any("error", writeErr))
+	}
+}
+
+func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time) stateAPIResponse {
+	return stateAPIResponse{
+		GeneratedAt:    generatedAt,
+		Counts:         countsResponse(snapshot),
+		Running:        runningEntries(snapshot.Running),
+		Retrying:       retryEntries(snapshot.Queue),
+		Blocked:        blockedEntries(snapshot.Blocked),
+		Stats:          statsAPIResponse{Status: "enabled"},
+		CodexTotals:    totalsResponse(snapshot.Tokens),
+		LifetimeTotals: lifetimeTotalsResponse{},
+		RecentSessions: recentSessionEntries(snapshot.Completed),
+		RateLimits:     snapshot.RateLimits,
+		Budget:         budgetResponse(snapshot.Budget),
+	}
+}
+
+func issueResponse(identifier string, snapshot telemetry.Snapshot) (issueAPIResponse, bool) {
+	if running, ok := findRunning(identifier, snapshot.Running); ok {
+		return issueAPIResponse{
+			IssueIdentifier: running.Identifier,
+			IssueID:         running.ID,
+			Status:          "running",
+			Workspace:       workspaceResponse(running.WorkspacePath, running.WorkerHost),
+			Attempts:        attemptsAPIResponse{},
+			Running:         runningIssueResponse(running),
+			Retry:           nil,
+			Blocked:         nil,
+			Logs:            logsAPIResponse{CodexSessionLogs: []logAPIResponse{}},
+			RecentEvents:    recentEvents(running.LastEventAt, running.LastEvent, running.LastMessage),
+			LastError:       nil,
+			Tracked:         map[string]any{},
+		}, true
+	}
+	if retry, ok := findRetry(identifier, snapshot.Queue); ok {
+		err := optionalString(retry.Error)
+		return issueAPIResponse{
+			IssueIdentifier: retry.Identifier,
+			IssueID:         retry.ID,
+			Status:          "retrying",
+			Workspace:       workspaceResponse(retry.WorkspacePath, retry.WorkerHost),
+			Attempts: attemptsAPIResponse{
+				RestartCount:        max(retry.Attempt-1, 0),
+				CurrentRetryAttempt: retry.Attempt,
+			},
+			Running:      nil,
+			Retry:        retryIssueResponse(retry),
+			Blocked:      nil,
+			Logs:         logsAPIResponse{CodexSessionLogs: []logAPIResponse{}},
+			RecentEvents: []recentEventAPIResponse{},
+			LastError:    err,
+			Tracked:      map[string]any{},
+		}, true
+	}
+	if blocked, ok := findBlocked(identifier, snapshot.Blocked); ok {
+		err := optionalString(blocked.Error)
+		return issueAPIResponse{
+			IssueIdentifier: blocked.Identifier,
+			IssueID:         blocked.ID,
+			Status:          "blocked",
+			Workspace:       workspaceResponse(blocked.WorkspacePath, blocked.WorkerHost),
+			Attempts:        attemptsAPIResponse{},
+			Running:         nil,
+			Retry:           nil,
+			Blocked:         blockedIssueResponse(blocked),
+			Logs:            logsAPIResponse{CodexSessionLogs: []logAPIResponse{}},
+			RecentEvents:    recentEvents(blocked.LastEventAt, blocked.LastEvent, blocked.LastMessage),
+			LastError:       err,
+			Tracked:         map[string]any{},
+		}, true
+	}
+
+	return issueAPIResponse{}, false
+}
+
+func countsResponse(snapshot telemetry.Snapshot) countsAPIResponse {
+	return countsAPIResponse{
+		Running:  len(snapshot.Running),
+		Retrying: len(snapshot.Queue),
+		Blocked:  len(snapshot.Blocked),
+	}
+}
+
+func runningEntries(entries []telemetry.Running) []runningAPIResponse {
+	payload := make([]runningAPIResponse, 0, len(entries))
+	for _, entry := range entries {
+		payload = append(payload, runningAPIResponse{
+			IssueID:          entry.ID,
+			IssueIdentifier:  entry.Identifier,
+			IssueURL:         optionalString(entry.URL),
+			IssueTitle:       optionalTrimmedString(entry.Title),
+			IssueDescription: issueDescription(entry.Description),
+			BudgetAlert:      false,
+			State:            entry.State,
+			WorkerHost:       optionalString(entry.WorkerHost),
+			WorkspacePath:    optionalString(entry.WorkspacePath),
+			SessionID:        optionalString(entry.SessionID),
+			TurnCount:        entry.TurnCount,
+			LastEvent:        optionalString(entry.LastEvent),
+			LastMessage:      optionalString(entry.LastMessage),
+			StartedAt:        timestampString(entry.StartedAt),
+			LastEventAt:      timestampStringPtr(entry.LastEventAt),
+			Tokens:           tokenCountsResponse(entry.Tokens),
+		})
+	}
+	return payload
+}
+
+func retryEntries(entries []telemetry.Queued) []retryAPIResponse {
+	payload := make([]retryAPIResponse, 0, len(entries))
+	for _, entry := range entries {
+		payload = append(payload, retryAPIResponse{
+			IssueID:          entry.ID,
+			IssueIdentifier:  entry.Identifier,
+			IssueURL:         optionalString(entry.URL),
+			IssueTitle:       optionalTrimmedString(entry.Title),
+			IssueDescription: issueDescription(entry.Description),
+			BudgetAlert:      false,
+			Attempt:          entry.Attempt,
+			DueAt:            dueAtString(entry),
+			Error:            optionalString(entry.Error),
+			WorkerHost:       optionalString(entry.WorkerHost),
+			WorkspacePath:    optionalString(entry.WorkspacePath),
+		})
+	}
+	return payload
+}
+
+func blockedEntries(entries []telemetry.Blocked) []blockedAPIResponse {
+	payload := make([]blockedAPIResponse, 0, len(entries))
+	for _, entry := range entries {
+		payload = append(payload, blockedAPIResponse{
+			IssueID:          entry.ID,
+			IssueIdentifier:  entry.Identifier,
+			IssueURL:         optionalString(entry.URL),
+			IssueTitle:       optionalTrimmedString(entry.Title),
+			IssueDescription: issueDescription(entry.Description),
+			BudgetAlert:      false,
+			State:            entry.State,
+			Error:            optionalString(entry.Error),
+			WorkerHost:       optionalString(entry.WorkerHost),
+			WorkspacePath:    optionalString(entry.WorkspacePath),
+			SessionID:        optionalString(entry.SessionID),
+			BlockedAt:        timestampStringPtr(entry.BlockedAt),
+			LastEvent:        optionalString(entry.LastEvent),
+			LastMessage:      optionalString(entry.LastMessage),
+			LastEventAt:      timestampStringPtr(entry.LastEventAt),
+		})
+	}
+	return payload
+}
+
+func recentSessionEntries(entries []telemetry.Completed) []recentSessionAPIResponse {
+	payload := make([]recentSessionAPIResponse, 0, len(entries))
+	for _, entry := range entries {
+		payload = append(payload, recentSessionAPIResponse{
+			IssueID:        entry.ID,
+			Identifier:     entry.Identifier,
+			IssueURL:       optionalString(entry.URL),
+			StartedAt:      timestampString(entry.StartedAt),
+			CompletedAt:    timestampString(entry.CompletedAt),
+			Turns:          entry.Turns,
+			InputTokens:    entry.Tokens.Input,
+			OutputTokens:   entry.Tokens.Output,
+			TotalTokens:    entry.Tokens.Total,
+			RuntimeSeconds: entry.RuntimeSeconds,
+			FinalState:     optionalString(entry.FinalState),
+			Model:          optionalString(entry.Model),
+			BudgetAlert:    false,
+		})
+	}
+	return payload
+}
+
+func runningIssueResponse(entry telemetry.Running) *runningIssueAPIResponse {
+	return &runningIssueAPIResponse{
+		WorkerHost:    optionalString(entry.WorkerHost),
+		WorkspacePath: optionalString(entry.WorkspacePath),
+		SessionID:     optionalString(entry.SessionID),
+		TurnCount:     entry.TurnCount,
+		State:         entry.State,
+		StartedAt:     timestampString(entry.StartedAt),
+		LastEvent:     optionalString(entry.LastEvent),
+		LastMessage:   optionalString(entry.LastMessage),
+		LastEventAt:   timestampStringPtr(entry.LastEventAt),
+		Tokens:        tokenCountsResponse(entry.Tokens),
+	}
+}
+
+func retryIssueResponse(entry telemetry.Queued) *retryIssueAPIResponse {
+	return &retryIssueAPIResponse{
+		Attempt:       entry.Attempt,
+		DueAt:         dueAtString(entry),
+		Error:         optionalString(entry.Error),
+		WorkerHost:    optionalString(entry.WorkerHost),
+		WorkspacePath: optionalString(entry.WorkspacePath),
+	}
+}
+
+func blockedIssueResponse(entry telemetry.Blocked) *blockedIssueAPIResponse {
+	return &blockedIssueAPIResponse{
+		WorkerHost:    optionalString(entry.WorkerHost),
+		WorkspacePath: optionalString(entry.WorkspacePath),
+		SessionID:     optionalString(entry.SessionID),
+		State:         entry.State,
+		Error:         optionalString(entry.Error),
+		BlockedAt:     timestampStringPtr(entry.BlockedAt),
+		LastEvent:     optionalString(entry.LastEvent),
+		LastMessage:   optionalString(entry.LastMessage),
+		LastEventAt:   timestampStringPtr(entry.LastEventAt),
+	}
+}
+
+func recentEvents(at *time.Time, event string, message string) []recentEventAPIResponse {
+	timestamp := timestampStringPtr(at)
+	if timestamp == nil {
+		return []recentEventAPIResponse{}
+	}
+	return []recentEventAPIResponse{
+		{
+			At:      *timestamp,
+			Event:   optionalString(event),
+			Message: optionalString(message),
+		},
+	}
+}
+
+func findRunning(identifier string, entries []telemetry.Running) (telemetry.Running, bool) {
+	for _, entry := range entries {
+		if issueMatches(entry.Issue, identifier) {
+			return entry, true
+		}
+	}
+	return telemetry.Running{}, false
+}
+
+func findRetry(identifier string, entries []telemetry.Queued) (telemetry.Queued, bool) {
+	for _, entry := range entries {
+		if issueMatches(entry.Issue, identifier) {
+			return entry, true
+		}
+	}
+	return telemetry.Queued{}, false
+}
+
+func findBlocked(identifier string, entries []telemetry.Blocked) (telemetry.Blocked, bool) {
+	for _, entry := range entries {
+		if issueMatches(entry.Issue, identifier) {
+			return entry, true
+		}
+	}
+	return telemetry.Blocked{}, false
+}
+
+func issueMatches(issue telemetry.Issue, value string) bool {
+	return value != "" && (issue.Identifier == value || issue.ID == value)
+}
+
+func workspaceResponse(path string, host string) workspaceAPIResponse {
+	return workspaceAPIResponse{
+		Path: optionalString(path),
+		Host: optionalString(host),
+	}
+}
+
+func totalsResponse(tokens telemetry.Tokens) tokenTotalsAPIResponse {
+	return tokenTotalsAPIResponse{
+		Input:          tokens.Input,
+		Output:         tokens.Output,
+		Total:          tokens.Total,
+		RuntimeSeconds: tokens.RuntimeSeconds,
+	}
+}
+
+func tokenCountsResponse(tokens telemetry.Tokens) tokenCountsAPIResponse {
+	return tokenCountsAPIResponse{
+		Input:  tokens.Input,
+		Output: tokens.Output,
+		Total:  tokens.Total,
+	}
+}
+
+func budgetResponse(budget telemetry.Budget) budgetAPIResponse {
+	return budgetAPIResponse{
+		Enabled:          budget.Enabled,
+		TodaySpendUSD:    budget.CurrentSpendUSD,
+		CurrentSpendUSD:  budget.CurrentSpendUSD,
+		ProjectedCostUSD: budget.ProjectedCostUSD,
+		PerDayMaxUSD:     budget.PerDayMaxUSD,
+		PerIssueMaxUSD:   budget.PerIssueMaxUSD,
+		Refusals:         budget.Refusals,
+	}
+}
+
+func dueAtString(entry telemetry.Queued) *string {
+	if entry.DueAt != nil {
+		return timestampStringPtr(entry.DueAt)
+	}
+	if entry.DueInMillis > 0 {
+		dueAt := apiNow().Add(time.Duration(entry.DueInMillis) * time.Millisecond)
+		return timestampString(dueAt)
+	}
+	return nil
+}
+
+func issueDescription(description string) *string {
+	value := strings.TrimSpace(description)
+	if value == "" {
+		return nil
+	}
+
+	runes := []rune(value)
+	if len(runes) <= issueDescriptionLimit {
+		return &value
+	}
+
+	truncated := string(runes[:issueDescriptionLimit-3]) + "..."
+	return &truncated
+}
+
+func optionalTrimmedString(value string) *string {
+	value = strings.TrimSpace(value)
+	return optionalString(value)
+}
+
+func optionalString(value string) *string {
+	if value == "" {
+		return nil
+	}
+	return &value
+}
+
+func timestampString(value time.Time) *string {
+	if value.IsZero() {
+		return nil
+	}
+
+	formatted := value.UTC().Truncate(time.Second).Format(time.RFC3339)
+	return &formatted
+}
+
+func timestampStringPtr(value *time.Time) *string {
+	if value == nil {
+		return nil
+	}
+	return timestampString(*value)
+}
+
+func apiNow() time.Time {
+	return time.Now().UTC().Truncate(time.Second)
+}
+
+func errorResponse(code string, message string) apiErrorResponse {
+	return apiErrorResponse{
+		Error: apiError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+func snapshotErrorResponse(generatedAt time.Time, code string, message string) snapshotErrorAPIResponse {
+	return snapshotErrorAPIResponse{
+		GeneratedAt: generatedAt,
+		Error: apiError{
+			Code:    code,
+			Message: message,
+		},
+	}
+}
+
+type stateAPIResponse struct {
+	GeneratedAt    time.Time                  `json:"generated_at"`
+	Counts         countsAPIResponse          `json:"counts"`
+	Running        []runningAPIResponse       `json:"running"`
+	Retrying       []retryAPIResponse         `json:"retrying"`
+	Blocked        []blockedAPIResponse       `json:"blocked"`
+	Stats          statsAPIResponse           `json:"stats"`
+	CodexTotals    tokenTotalsAPIResponse     `json:"codex_totals"`
+	LifetimeTotals lifetimeTotalsResponse     `json:"lifetime_totals"`
+	RecentSessions []recentSessionAPIResponse `json:"recent_sessions"`
+	RateLimits     *telemetry.RateLimits      `json:"rate_limits"`
+	Budget         budgetAPIResponse          `json:"budget"`
+}
+
+type countsAPIResponse struct {
+	Running  int `json:"running"`
+	Retrying int `json:"retrying"`
+	Blocked  int `json:"blocked"`
+}
+
+type runningAPIResponse struct {
+	IssueID          string                 `json:"issue_id"`
+	IssueIdentifier  string                 `json:"issue_identifier"`
+	IssueURL         *string                `json:"issue_url"`
+	IssueTitle       *string                `json:"issue_title"`
+	IssueDescription *string                `json:"issue_description"`
+	BudgetAlert      bool                   `json:"budget_alert?"`
+	State            string                 `json:"state"`
+	WorkerHost       *string                `json:"worker_host"`
+	WorkspacePath    *string                `json:"workspace_path"`
+	SessionID        *string                `json:"session_id"`
+	TurnCount        int                    `json:"turn_count"`
+	LastEvent        *string                `json:"last_event"`
+	LastMessage      *string                `json:"last_message"`
+	StartedAt        *string                `json:"started_at"`
+	LastEventAt      *string                `json:"last_event_at"`
+	Tokens           tokenCountsAPIResponse `json:"tokens"`
+}
+
+type retryAPIResponse struct {
+	IssueID          string  `json:"issue_id"`
+	IssueIdentifier  string  `json:"issue_identifier"`
+	IssueURL         *string `json:"issue_url"`
+	IssueTitle       *string `json:"issue_title"`
+	IssueDescription *string `json:"issue_description"`
+	BudgetAlert      bool    `json:"budget_alert?"`
+	Attempt          int     `json:"attempt"`
+	DueAt            *string `json:"due_at"`
+	Error            *string `json:"error"`
+	WorkerHost       *string `json:"worker_host"`
+	WorkspacePath    *string `json:"workspace_path"`
+}
+
+type blockedAPIResponse struct {
+	IssueID          string  `json:"issue_id"`
+	IssueIdentifier  string  `json:"issue_identifier"`
+	IssueURL         *string `json:"issue_url"`
+	IssueTitle       *string `json:"issue_title"`
+	IssueDescription *string `json:"issue_description"`
+	BudgetAlert      bool    `json:"budget_alert?"`
+	State            string  `json:"state"`
+	Error            *string `json:"error"`
+	WorkerHost       *string `json:"worker_host"`
+	WorkspacePath    *string `json:"workspace_path"`
+	SessionID        *string `json:"session_id"`
+	BlockedAt        *string `json:"blocked_at"`
+	LastEvent        *string `json:"last_event"`
+	LastMessage      *string `json:"last_message"`
+	LastEventAt      *string `json:"last_event_at"`
+}
+
+type statsAPIResponse struct {
+	Status string  `json:"status"`
+	Reason *string `json:"reason"`
+}
+
+type tokenCountsAPIResponse struct {
+	Input  int64 `json:"input_tokens"`
+	Output int64 `json:"output_tokens"`
+	Total  int64 `json:"total_tokens"`
+}
+
+type tokenTotalsAPIResponse struct {
+	Input          int64   `json:"input_tokens"`
+	Output         int64   `json:"output_tokens"`
+	Total          int64   `json:"total_tokens"`
+	RuntimeSeconds float64 `json:"seconds_running"`
+}
+
+type lifetimeTotalsResponse struct {
+	InputTokens    int64 `json:"input_tokens"`
+	OutputTokens   int64 `json:"output_tokens"`
+	TotalTokens    int64 `json:"total_tokens"`
+	RuntimeSeconds int64 `json:"runtime_seconds"`
+	Sessions       int64 `json:"sessions"`
+	Runs           int64 `json:"runs"`
+}
+
+type recentSessionAPIResponse struct {
+	IssueID        string  `json:"issue_id"`
+	Identifier     string  `json:"identifier"`
+	IssueURL       *string `json:"issue_url"`
+	StartedAt      *string `json:"started_at"`
+	CompletedAt    *string `json:"completed_at"`
+	Turns          int     `json:"turns"`
+	InputTokens    int64   `json:"input_tokens"`
+	OutputTokens   int64   `json:"output_tokens"`
+	TotalTokens    int64   `json:"total_tokens"`
+	RuntimeSeconds float64 `json:"runtime_seconds"`
+	FinalState     *string `json:"final_state"`
+	Model          *string `json:"model"`
+	BudgetAlert    bool    `json:"budget_alert?"`
+}
+
+type budgetAPIResponse struct {
+	Enabled          bool                      `json:"enabled"`
+	TodaySpendUSD    float64                   `json:"today_spend_usd"`
+	CurrentSpendUSD  float64                   `json:"current_spend_usd"`
+	ProjectedCostUSD float64                   `json:"projected_cost_usd"`
+	PerDayMaxUSD     *float64                  `json:"per_day_max_usd"`
+	PerIssueMaxUSD   *float64                  `json:"per_issue_max_usd"`
+	Refusals         []telemetry.BudgetRefusal `json:"refusals,omitempty"`
+}
+
+type issueAPIResponse struct {
+	IssueIdentifier string                   `json:"issue_identifier"`
+	IssueID         string                   `json:"issue_id"`
+	Status          string                   `json:"status"`
+	Workspace       workspaceAPIResponse     `json:"workspace"`
+	Attempts        attemptsAPIResponse      `json:"attempts"`
+	Running         *runningIssueAPIResponse `json:"running"`
+	Retry           *retryIssueAPIResponse   `json:"retry"`
+	Blocked         *blockedIssueAPIResponse `json:"blocked"`
+	Logs            logsAPIResponse          `json:"logs"`
+	RecentEvents    []recentEventAPIResponse `json:"recent_events"`
+	LastError       *string                  `json:"last_error"`
+	Tracked         map[string]any           `json:"tracked"`
+}
+
+type workspaceAPIResponse struct {
+	Path *string `json:"path"`
+	Host *string `json:"host"`
+}
+
+type attemptsAPIResponse struct {
+	RestartCount        int `json:"restart_count"`
+	CurrentRetryAttempt int `json:"current_retry_attempt"`
+}
+
+type runningIssueAPIResponse struct {
+	WorkerHost    *string                `json:"worker_host"`
+	WorkspacePath *string                `json:"workspace_path"`
+	SessionID     *string                `json:"session_id"`
+	TurnCount     int                    `json:"turn_count"`
+	State         string                 `json:"state"`
+	StartedAt     *string                `json:"started_at"`
+	LastEvent     *string                `json:"last_event"`
+	LastMessage   *string                `json:"last_message"`
+	LastEventAt   *string                `json:"last_event_at"`
+	Tokens        tokenCountsAPIResponse `json:"tokens"`
+}
+
+type retryIssueAPIResponse struct {
+	Attempt       int     `json:"attempt"`
+	DueAt         *string `json:"due_at"`
+	Error         *string `json:"error"`
+	WorkerHost    *string `json:"worker_host"`
+	WorkspacePath *string `json:"workspace_path"`
+}
+
+type blockedIssueAPIResponse struct {
+	WorkerHost    *string `json:"worker_host"`
+	WorkspacePath *string `json:"workspace_path"`
+	SessionID     *string `json:"session_id"`
+	State         string  `json:"state"`
+	Error         *string `json:"error"`
+	BlockedAt     *string `json:"blocked_at"`
+	LastEvent     *string `json:"last_event"`
+	LastMessage   *string `json:"last_message"`
+	LastEventAt   *string `json:"last_event_at"`
+}
+
+type logsAPIResponse struct {
+	CodexSessionLogs []logAPIResponse `json:"codex_session_logs"`
+}
+
+type logAPIResponse struct {
+	Label string  `json:"label"`
+	Path  string  `json:"path"`
+	URL   *string `json:"url"`
+}
+
+type recentEventAPIResponse struct {
+	At      string  `json:"at"`
+	Event   *string `json:"event"`
+	Message *string `json:"message"`
+}
+
+type apiErrorResponse struct {
+	Error apiError `json:"error"`
+}
+
+type snapshotErrorAPIResponse struct {
+	GeneratedAt time.Time `json:"generated_at"`
+	Error       apiError  `json:"error"`
+}
+
+type apiError struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -23,13 +23,13 @@ type Refresher interface {
 type RefreshResponse = orchestrator.RefreshResponse
 
 func (s *Server) apiState(c echo.Context) error {
-	generatedAt := apiNow()
+	now := apiNow()
 	snapshot, ok := s.hub.Latest()
 	if !ok {
-		return c.JSON(http.StatusOK, snapshotErrorResponse(generatedAt, "snapshot_unavailable", "Snapshot unavailable"))
+		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
 
-	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt))
+	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now)))
 }
 
 func (s *Server) apiIssue(c echo.Context) error {
@@ -38,7 +38,7 @@ func (s *Server) apiIssue(c echo.Context) error {
 		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
 	}
 
-	payload, ok := issueResponse(c.Param("issue"), snapshot)
+	payload, ok := issueResponse(issueIdentifier(c), snapshot)
 	if !ok {
 		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
 	}
@@ -442,6 +442,20 @@ func timestampStringPtr(value *time.Time) *string {
 
 func apiNow() time.Time {
 	return time.Now().UTC().Truncate(time.Second)
+}
+
+func generatedAt(snapshot telemetry.Snapshot, fallback time.Time) time.Time {
+	if snapshot.GeneratedAt.IsZero() {
+		return fallback
+	}
+	return snapshot.GeneratedAt.UTC().Truncate(time.Second)
+}
+
+func issueIdentifier(c echo.Context) string {
+	if issue := c.Param("issue"); issue != "" {
+		return issue
+	}
+	return c.Param("*")
 }
 
 func errorResponse(code string, message string) apiErrorResponse {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -29,6 +29,7 @@ type Dependencies struct {
 	Store     store.Store
 	Registry  any
 	Connector connector.Connector
+	Refresher Refresher
 }
 
 type Config struct {
@@ -43,6 +44,7 @@ type Server struct {
 	store     store.Store
 	registry  any
 	connector connector.Connector
+	refresher Refresher
 	logger    *slog.Logger
 	tickEvery time.Duration
 }
@@ -71,9 +73,11 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		store:     deps.Store,
 		registry:  deps.Registry,
 		connector: deps.Connector,
+		refresher: deps.Refresher,
 		logger:    cfg.logger(),
 		tickEvery: cfg.sseTickInterval(),
 	}
+	e.HTTPErrorHandler = server.handleHTTPError
 	server.registerRoutes(cfg.staticDir())
 
 	return server, nil
@@ -102,6 +106,10 @@ func (s *Server) registerRoutes(staticDir string) {
 	s.echo.GET("/", s.dashboard)
 	s.echo.GET("/events", s.events)
 	s.echo.GET("/health", s.health)
+	s.echo.GET("/api/v1/state", s.apiState)
+	s.echo.POST("/api/v1/refresh", s.apiRefresh)
+	s.echo.GET("/api/v1/refresh", s.methodNotAllowed)
+	s.echo.GET("/api/v1/:issue", s.apiIssue)
 }
 
 func (s *Server) dashboard(c echo.Context) error {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -109,7 +109,7 @@ func (s *Server) registerRoutes(staticDir string) {
 	s.echo.GET("/api/v1/state", s.apiState)
 	s.echo.POST("/api/v1/refresh", s.apiRefresh)
 	s.echo.GET("/api/v1/refresh", s.methodNotAllowed)
-	s.echo.GET("/api/v1/:issue", s.apiIssue)
+	s.echo.GET("/api/v1/*", s.apiIssue)
 }
 
 func (s *Server) dashboard(c echo.Context) error {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -318,7 +318,7 @@ func TestServerAPIRoutes(t *testing.T) {
 			{
 				Issue: telemetry.Issue{
 					ID:          "issue-running",
-					Identifier:  "DD-37",
+					Identifier:  "digitaldrywood/symphony-go#37",
 					URL:         "https://github.com/digitaldrywood/symphony-go/issues/37",
 					Title:       "REST API",
 					Description: strings.Repeat("api ", 90),
@@ -426,6 +426,9 @@ func TestServerAPIRoutes(t *testing.T) {
 	}
 
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	if state["generated_at"] != generatedAt.Format(time.RFC3339) {
+		t.Fatalf("generated_at = %q, want %q", state["generated_at"], generatedAt.Format(time.RFC3339))
+	}
 	if got := nestedString(t, state, "counts", "running"); got != "1" {
 		t.Fatalf("counts.running = %s, want 1", got)
 	}
@@ -437,7 +440,7 @@ func TestServerAPIRoutes(t *testing.T) {
 	}
 
 	running := state["running"].([]any)[0].(map[string]any)
-	if running["issue_identifier"] != "DD-37" || running["issue_title"] != "REST API" {
+	if running["issue_identifier"] != "digitaldrywood/symphony-go#37" || running["issue_title"] != "REST API" {
 		t.Fatalf("running row = %#v", running)
 	}
 	description := running["issue_description"].(string)
@@ -460,7 +463,7 @@ func TestServerAPIRoutes(t *testing.T) {
 		t.Fatalf("recent_sessions = %#v, want one entry", state["recent_sessions"])
 	}
 
-	issue := requestJSON(t, server, http.MethodGet, "/api/v1/DD-37", http.StatusOK)
+	issue := requestJSON(t, server, http.MethodGet, "/api/v1/digitaldrywood/symphony-go%2337", http.StatusOK)
 	if issue["status"] != "running" || issue["issue_id"] != "issue-running" {
 		t.Fatalf("issue payload = %#v", issue)
 	}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3,12 +3,14 @@ package web_test
 import (
 	"bufio"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -299,6 +301,261 @@ func TestServerEventsSendsTickEvents(t *testing.T) {
 	}
 }
 
+func TestServerAPIRoutes(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 5, 31, 3, 25, 0, 0, time.UTC)
+	startedAt := generatedAt.Add(-5 * time.Minute)
+	blockedAt := generatedAt.Add(-2 * time.Minute)
+	lastEventAt := generatedAt.Add(-time.Minute)
+	dueAt := generatedAt.Add(time.Minute)
+	completedAt := generatedAt.Add(-30 * time.Second)
+
+	events := hub.New[telemetry.Snapshot]()
+	if err := events.Publish(telemetry.Snapshot{
+		GeneratedAt: generatedAt,
+		Running: []telemetry.Running{
+			{
+				Issue: telemetry.Issue{
+					ID:          "issue-running",
+					Identifier:  "DD-37",
+					URL:         "https://github.com/digitaldrywood/symphony-go/issues/37",
+					Title:       "REST API",
+					Description: strings.Repeat("api ", 90),
+					State:       "In Progress",
+				},
+				WorkerHost:     "host-a",
+				WorkspacePath:  "/workspaces/DD-37",
+				SessionID:      "thread-running",
+				TurnCount:      3,
+				StartedAt:      startedAt,
+				LastEventAt:    &lastEventAt,
+				LastEvent:      "notification",
+				LastMessage:    "rendered",
+				RuntimeSeconds: 300,
+				Tokens: telemetry.Tokens{
+					Input:  10,
+					Output: 20,
+					Total:  30,
+				},
+			},
+		},
+		Queue: []telemetry.Queued{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-retry",
+					Identifier: "DD-RETRY",
+					URL:        "https://github.com/digitaldrywood/symphony-go/issues/38",
+					Title:      "Retry API",
+					State:      "Todo",
+				},
+				Attempt:       2,
+				DueAt:         &dueAt,
+				Error:         "no available orchestrator slots",
+				WorkspacePath: "/workspaces/DD-RETRY",
+			},
+		},
+		Blocked: []telemetry.Blocked{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-blocked",
+					Identifier: "DD-BLOCKED",
+					URL:        "https://github.com/digitaldrywood/symphony-go/issues/39",
+					Title:      "Blocked API",
+					State:      "Todo",
+				},
+				WorkerHost:    "host-b",
+				WorkspacePath: "/workspaces/DD-BLOCKED",
+				SessionID:     "thread-blocked",
+				Error:         "dependency is not merged",
+				BlockedAt:     &blockedAt,
+				LastEventAt:   &lastEventAt,
+				LastEvent:     "turn_input_required",
+				LastMessage:   "waiting for operator input",
+			},
+		},
+		Completed: []telemetry.Completed{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-completed",
+					Identifier: "DD-DONE",
+					URL:        "https://github.com/digitaldrywood/symphony-go/issues/40",
+				},
+				StartedAt:      startedAt,
+				CompletedAt:    completedAt,
+				Turns:          2,
+				RuntimeSeconds: 45,
+				FinalState:     "Done",
+				Model:          "gpt-5",
+				Tokens: telemetry.Tokens{
+					Input:  100,
+					Output: 200,
+					Total:  300,
+				},
+			},
+		},
+		RateLimits: &telemetry.RateLimits{
+			Primary: &telemetry.RateLimitBucket{Remaining: 11},
+		},
+		Tokens: telemetry.Tokens{
+			Input:          11,
+			Output:         22,
+			Total:          33,
+			RuntimeSeconds: 44.5,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	refresher := &refreshProbe{
+		response: web.RefreshResponse{
+			Queued:      true,
+			Coalesced:   false,
+			RequestedAt: generatedAt,
+			Operations:  []string{"poll", "reconcile"},
+		},
+	}
+
+	deps := testDeps(t)
+	deps.Hub = events
+	deps.Refresher = refresher
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	if got := nestedString(t, state, "counts", "running"); got != "1" {
+		t.Fatalf("counts.running = %s, want 1", got)
+	}
+	if got := nestedString(t, state, "counts", "retrying"); got != "1" {
+		t.Fatalf("counts.retrying = %s, want 1", got)
+	}
+	if got := nestedString(t, state, "counts", "blocked"); got != "1" {
+		t.Fatalf("counts.blocked = %s, want 1", got)
+	}
+
+	running := state["running"].([]any)[0].(map[string]any)
+	if running["issue_identifier"] != "DD-37" || running["issue_title"] != "REST API" {
+		t.Fatalf("running row = %#v", running)
+	}
+	description := running["issue_description"].(string)
+	if len(description) != 250 || !strings.HasSuffix(description, "...") {
+		t.Fatalf("issue_description length = %d, suffix ok = %v", len(description), strings.HasSuffix(description, "..."))
+	}
+	if running["budget_alert?"] != false {
+		t.Fatalf("budget_alert? = %#v, want false", running["budget_alert?"])
+	}
+
+	retrying := state["retrying"].([]any)[0].(map[string]any)
+	if retrying["issue_identifier"] != "DD-RETRY" || retrying["attempt"] != float64(2) {
+		t.Fatalf("retrying row = %#v", retrying)
+	}
+
+	if got := nestedString(t, state, "codex_totals", "seconds_running"); got != "44.5" {
+		t.Fatalf("codex_totals.seconds_running = %s, want 44.5", got)
+	}
+	if len(state["recent_sessions"].([]any)) != 1 {
+		t.Fatalf("recent_sessions = %#v, want one entry", state["recent_sessions"])
+	}
+
+	issue := requestJSON(t, server, http.MethodGet, "/api/v1/DD-37", http.StatusOK)
+	if issue["status"] != "running" || issue["issue_id"] != "issue-running" {
+		t.Fatalf("issue payload = %#v", issue)
+	}
+	if issue["retry"] != nil || issue["blocked"] != nil || issue["last_error"] != nil {
+		t.Fatalf("running issue nullable fields = %#v", issue)
+	}
+
+	retryIssue := requestJSON(t, server, http.MethodGet, "/api/v1/DD-RETRY", http.StatusOK)
+	if retryIssue["status"] != "retrying" || retryIssue["last_error"] != "no available orchestrator slots" {
+		t.Fatalf("retry issue payload = %#v", retryIssue)
+	}
+
+	blockedIssue := requestJSON(t, server, http.MethodGet, "/api/v1/DD-BLOCKED", http.StatusOK)
+	if blockedIssue["status"] != "blocked" || blockedIssue["last_error"] != "dependency is not merged" {
+		t.Fatalf("blocked issue payload = %#v", blockedIssue)
+	}
+
+	missing := requestJSON(t, server, http.MethodGet, "/api/v1/DD-MISSING", http.StatusNotFound)
+	if nestedString(t, missing, "error", "code") != "issue_not_found" {
+		t.Fatalf("missing issue response = %#v", missing)
+	}
+
+	refresh := requestJSON(t, server, http.MethodPost, "/api/v1/refresh", http.StatusAccepted)
+	if refresher.calls != 1 || refresh["queued"] != true || refresh["coalesced"] != false {
+		t.Fatalf("refresh calls = %d, payload = %#v", refresher.calls, refresh)
+	}
+	if operations := refresh["operations"].([]any); len(operations) != 2 || operations[0] != "poll" || operations[1] != "reconcile" {
+		t.Fatalf("refresh operations = %#v", refresh["operations"])
+	}
+}
+
+func TestServerAPIErrorRoutes(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		method     string
+		path       string
+		wantStatus int
+		wantCode   string
+	}{
+		{
+			name:       "state method not allowed",
+			method:     http.MethodPost,
+			path:       "/api/v1/state",
+			wantStatus: http.StatusMethodNotAllowed,
+			wantCode:   "method_not_allowed",
+		},
+		{
+			name:       "refresh method not allowed",
+			method:     http.MethodGet,
+			path:       "/api/v1/refresh",
+			wantStatus: http.StatusMethodNotAllowed,
+			wantCode:   "method_not_allowed",
+		},
+		{
+			name:       "unknown route",
+			method:     http.MethodGet,
+			path:       "/unknown",
+			wantStatus: http.StatusNotFound,
+			wantCode:   "not_found",
+		},
+		{
+			name:       "state unavailable",
+			method:     http.MethodGet,
+			path:       "/api/v1/state",
+			wantStatus: http.StatusOK,
+			wantCode:   "snapshot_unavailable",
+		},
+		{
+			name:       "refresh unavailable",
+			method:     http.MethodPost,
+			path:       "/api/v1/refresh",
+			wantStatus: http.StatusServiceUnavailable,
+			wantCode:   "orchestrator_unavailable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := requestJSON(t, server, tt.method, tt.path, tt.wantStatus)
+			if got := nestedString(t, payload, "error", "code"); got != tt.wantCode {
+				t.Fatalf("error.code = %q, want %q; payload = %#v", got, tt.wantCode, payload)
+			}
+		})
+	}
+}
+
 func testDeps(t *testing.T) web.Dependencies {
 	t.Helper()
 
@@ -307,6 +564,46 @@ func testDeps(t *testing.T) web.Dependencies {
 		Store:     storeProbe{},
 		Registry:  struct{}{},
 		Connector: connectorProbe{name: "memory"},
+	}
+}
+
+func requestJSON(t *testing.T, server *web.Server, method string, path string, wantStatus int) map[string]any {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != wantStatus {
+		t.Fatalf("%s %s status = %d, want %d; body = %s", method, path, rec.Code, wantStatus, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal(%s %s) error = %v; body = %s", method, path, err, rec.Body.String())
+	}
+	return payload
+}
+
+func nestedString(t *testing.T, payload map[string]any, keys ...string) string {
+	t.Helper()
+
+	var current any = payload
+	for _, key := range keys {
+		object, ok := current.(map[string]any)
+		if !ok {
+			t.Fatalf("value for %v is %T, want object", keys, current)
+		}
+		current = object[key]
+	}
+	switch value := current.(type) {
+	case string:
+		return value
+	case float64:
+		return strconv.FormatFloat(value, 'f', -1, 64)
+	default:
+		t.Fatalf("value for %v is %T, want string or number", keys, current)
+		return ""
 	}
 }
 
@@ -436,4 +733,18 @@ func readSSEEvent(t *testing.T, r io.Reader) sseEvent {
 			t.Fatal("timed out waiting for SSE event")
 		}
 	}
+}
+
+type refreshProbe struct {
+	response web.RefreshResponse
+	err      error
+	calls    int
+}
+
+func (p *refreshProbe) RequestRefresh(context.Context) (web.RefreshResponse, error) {
+	p.calls++
+	if p.err != nil {
+		return web.RefreshResponse{}, p.err
+	}
+	return p.response, nil
 }


### PR DESCRIPTION
## Summary
- Add `/api/v1/state`, `/api/v1/:issue`, and `/api/v1/refresh` routes with JSON error envelopes.
- Project telemetry hub snapshots into Elixir-compatible state and issue payloads.
- Add orchestrator `RequestRefresh` support for immediate out-of-band poll/reconcile ticks.

Fixes #37

## Test Plan
- `go test ./internal/hub ./internal/orchestrator ./internal/web`
- `go test ./...`
- `make check`