### PR TITLE
feat(project): add live project manager

### DIFF
--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -1,0 +1,298 @@
+package project
+
+import (
+	"context"
+	"crypto/rand"
+	"errors"
+	"fmt"
+	"log/slog"
+	"math/big"
+	"sync"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/hub"
+)
+
+var (
+	ErrManagerRunning  = errors.New("project manager already running")
+	ErrProjectExists   = errors.New("project already exists")
+	ErrProjectNotFound = errors.New("project not found")
+)
+
+type ProjectFactory func(globalconfig.Project) (*Project, error)
+
+type StartupConfig struct {
+	Jitter            time.Duration
+	MaxSpawnPerSecond int
+}
+
+type ManagerConfig struct {
+	Projects []globalconfig.Project
+	Startup  StartupConfig
+}
+
+type ManagerDependencies struct {
+	Registry            *Registry
+	ProjectFactory      ProjectFactory
+	ProjectDependencies Dependencies
+	Events              *hub.Hub[Event]
+	Logger              *slog.Logger
+	Sleep               func(context.Context, time.Duration) error
+	Jitter              func(time.Duration) time.Duration
+}
+
+type Manager struct {
+	mu       sync.Mutex
+	cfg      ManagerConfig
+	registry *Registry
+	factory  ProjectFactory
+	sleep    func(context.Context, time.Duration) error
+	jitter   func(time.Duration) time.Duration
+
+	running bool
+	spawned bool
+}
+
+func ManagerConfigFromGlobal(cfg globalconfig.Config) ManagerConfig {
+	return ManagerConfig{
+		Projects: append([]globalconfig.Project(nil), cfg.Projects...),
+		Startup: StartupConfig{
+			Jitter:            time.Duration(startupInt(cfg.Global.Startup, "jitter_seconds")) * time.Second,
+			MaxSpawnPerSecond: startupInt(cfg.Global.Startup, "max_spawn_per_second"),
+		},
+	}
+}
+
+func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
+	registry := deps.Registry
+	if registry == nil {
+		registry = NewRegistry()
+	}
+
+	projectDeps := deps.ProjectDependencies
+	if projectDeps.Events == nil {
+		projectDeps.Events = deps.Events
+	}
+	if projectDeps.Logger == nil {
+		projectDeps.Logger = deps.Logger
+	}
+
+	factory := deps.ProjectFactory
+	if factory == nil {
+		factory = func(cfg globalconfig.Project) (*Project, error) {
+			return Load(cfg, projectDeps)
+		}
+	}
+
+	sleep := deps.Sleep
+	if sleep == nil {
+		sleep = sleepContext
+	}
+
+	jitter := deps.Jitter
+	if jitter == nil {
+		jitter = randomJitter
+	}
+
+	cfg.Projects = append([]globalconfig.Project(nil), cfg.Projects...)
+	return &Manager{
+		cfg:      cfg,
+		registry: registry,
+		factory:  factory,
+		sleep:    sleep,
+		jitter:   jitter,
+	}, nil
+}
+
+func (m *Manager) Registry() *Registry {
+	return m.registry
+}
+
+func (m *Manager) Start(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	if m.running {
+		return ErrManagerRunning
+	}
+	m.running = true
+
+	for _, cfg := range m.cfg.Projects {
+		if err := m.addLocked(ctx, cfg); err != nil {
+			m.running = false
+			return err
+		}
+	}
+	return nil
+}
+
+func (m *Manager) Add(ctx context.Context, cfg globalconfig.Project) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	return m.addLocked(ctx, cfg)
+}
+
+func (m *Manager) Remove(ctx context.Context, id ProjectID) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	project, ok := m.registry.Get(id)
+	if !ok {
+		return ErrProjectNotFound
+	}
+	if project.Running() {
+		if err := project.Stop(ctx); err != nil {
+			return err
+		}
+	}
+	m.registry.Delete(id)
+	return nil
+}
+
+func (m *Manager) Pause(ctx context.Context, id ProjectID) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	project, ok := m.registry.Get(id)
+	if !ok {
+		return ErrProjectNotFound
+	}
+	return project.Pause(ctx)
+}
+
+func (m *Manager) Unpause(ctx context.Context, id ProjectID) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	project, ok := m.registry.Get(id)
+	if !ok {
+		return ErrProjectNotFound
+	}
+	if !project.Paused() {
+		return nil
+	}
+	if m.running {
+		if err := m.waitBeforeSpawn(ctx); err != nil {
+			return err
+		}
+	}
+	if err := project.Unpause(ctx); err != nil {
+		return err
+	}
+	m.spawned = true
+	return nil
+}
+
+func (m *Manager) addLocked(ctx context.Context, cfg globalconfig.Project) error {
+	id := normalizeProjectID(ProjectID(cfg.ID))
+	if id == "" {
+		return ErrMissingProjectID
+	}
+	if _, ok := m.registry.Get(id); ok {
+		return ErrProjectExists
+	}
+
+	cfg.ID = string(id)
+	project, err := m.factory(cfg)
+	if err != nil {
+		return fmt.Errorf("create project %s: %w", id, err)
+	}
+	if err := m.registry.Set(project); err != nil {
+		return err
+	}
+	if !m.running || project.Paused() {
+		return nil
+	}
+	if err := m.startLocked(ctx, project); err != nil {
+		m.registry.Delete(id)
+		return err
+	}
+	return nil
+}
+
+func (m *Manager) startLocked(ctx context.Context, project *Project) error {
+	if err := m.waitBeforeSpawn(ctx); err != nil {
+		return err
+	}
+	if err := project.Start(ctx); err != nil {
+		return err
+	}
+	m.spawned = true
+	return nil
+}
+
+func (m *Manager) waitBeforeSpawn(ctx context.Context) error {
+	delay := time.Duration(0)
+	if m.spawned && m.cfg.Startup.MaxSpawnPerSecond > 0 {
+		delay += time.Second / time.Duration(m.cfg.Startup.MaxSpawnPerSecond)
+	}
+	if m.cfg.Startup.Jitter > 0 {
+		delay += m.jitter(m.cfg.Startup.Jitter)
+	}
+	if delay <= 0 {
+		return nil
+	}
+	return m.sleep(ctx, delay)
+}
+
+func startupInt(values map[string]any, key string) int {
+	value, ok := values[key]
+	if !ok {
+		return 0
+	}
+	number, ok := value.(int)
+	if !ok || number <= 0 {
+		return 0
+	}
+	return number
+}
+
+func sleepContext(ctx context.Context, delay time.Duration) error {
+	if delay <= 0 {
+		return nil
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-timer.C:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func randomJitter(max time.Duration) time.Duration {
+	if max <= 0 {
+		return 0
+	}
+
+	value, err := rand.Int(rand.Reader, big.NewInt(int64(max)))
+	if err != nil {
+		return 0
+	}
+	return time.Duration(value.Int64())
+}

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -1,0 +1,190 @@
+package project_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/hub"
+	"github.com/digitaldrywood/symphony-go/internal/project"
+)
+
+func TestManagerStartsProjectsWithStartupLimits(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	var slept []time.Duration
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+			{ID: "charlie", Weight: 1, Paused: true},
+		},
+		Startup: project.StartupConfig{
+			Jitter:            time.Second,
+			MaxSpawnPerSecond: 2,
+		},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			return newManagerTestProject(t, cfg, events)
+		},
+		Jitter: func(time.Duration) time.Duration {
+			return 100 * time.Millisecond
+		},
+		Sleep: func(_ context.Context, delay time.Duration) error {
+			slept = append(slept, delay)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	wantSleeps := []time.Duration{100 * time.Millisecond, 600 * time.Millisecond}
+	if !reflect.DeepEqual(slept, wantSleeps) {
+		t.Fatalf("sleep delays = %v, want %v", slept, wantSleeps)
+	}
+
+	started := []project.ProjectID{
+		receiveEvent(t, sub.C()).ProjectID,
+		receiveEvent(t, sub.C()).ProjectID,
+	}
+	if !reflect.DeepEqual(started, []project.ProjectID{"alpha", "bravo"}) {
+		t.Fatalf("started projects = %v, want [alpha bravo]", started)
+	}
+	if manager.Registry().Len() != 3 {
+		t.Fatalf("Registry().Len() = %d, want 3", manager.Registry().Len())
+	}
+}
+
+func TestManagerLiveAddRemovePauseUnpause(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Startup: project.StartupConfig{MaxSpawnPerSecond: 10},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	if err := manager.Add(context.Background(), globalconfig.Project{ID: "alpha", Weight: 1}); err != nil {
+		t.Fatalf("Add() error = %v", err)
+	}
+	if event := receiveEvent(t, sub.C()); event.ProjectID != "alpha" || event.Kind != project.EventStarted {
+		t.Fatalf("add event = %#v, want alpha started", event)
+	}
+	if err := manager.Add(context.Background(), globalconfig.Project{ID: "alpha", Weight: 1}); !errors.Is(err, project.ErrProjectExists) {
+		t.Fatalf("Add() duplicate error = %v, want %v", err, project.ErrProjectExists)
+	}
+
+	if err := manager.Pause(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Pause() error = %v", err)
+	}
+	stopped := receiveEvent(t, sub.C())
+	paused := receiveEvent(t, sub.C())
+	if stopped.Kind != project.EventStopped || paused.Kind != project.EventPaused {
+		t.Fatalf("pause events = %#v %#v, want stopped then paused", stopped, paused)
+	}
+	got, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Get(alpha) ok = false, want true")
+	}
+	if !got.Paused() {
+		t.Fatal("Paused() = false, want true")
+	}
+
+	if err := manager.Unpause(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Unpause() error = %v", err)
+	}
+	unpaused := receiveEvent(t, sub.C())
+	restarted := receiveEvent(t, sub.C())
+	if unpaused.Kind != project.EventUnpaused || restarted.Kind != project.EventStarted {
+		t.Fatalf("unpause events = %#v %#v, want unpaused then started", unpaused, restarted)
+	}
+	if got.Paused() {
+		t.Fatal("Paused() = true, want false")
+	}
+
+	if err := manager.Remove(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	removed := receiveEvent(t, sub.C())
+	if removed.Kind != project.EventStopped {
+		t.Fatalf("remove event = %#v, want stopped", removed)
+	}
+	if _, ok := manager.Registry().Get("alpha"); ok {
+		t.Fatal("Get(alpha) ok = true after Remove, want false")
+	}
+	if err := manager.Remove(context.Background(), "alpha"); !errors.Is(err, project.ErrProjectNotFound) {
+		t.Fatalf("Remove() missing error = %v, want %v", err, project.ErrProjectNotFound)
+	}
+}
+
+func TestManagerConfigFromGlobal(t *testing.T) {
+	t.Parallel()
+
+	cfg := globalconfig.Config{
+		Global: globalconfig.Settings{
+			Startup: map[string]any{
+				"jitter_seconds":       3,
+				"max_spawn_per_second": 4,
+			},
+		},
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}
+
+	got := project.ManagerConfigFromGlobal(cfg)
+	if got.Startup.Jitter != 3*time.Second {
+		t.Fatalf("Startup.Jitter = %s, want 3s", got.Startup.Jitter)
+	}
+	if got.Startup.MaxSpawnPerSecond != 4 {
+		t.Fatalf("Startup.MaxSpawnPerSecond = %d, want 4", got.Startup.MaxSpawnPerSecond)
+	}
+	if len(got.Projects) != 1 || got.Projects[0].ID != "alpha" {
+		t.Fatalf("Projects = %#v, want alpha", got.Projects)
+	}
+}
+
+func newManagerTestProject(t *testing.T, cfg globalconfig.Project, events *hub.Hub[project.Event]) (*project.Project, error) {
+	t.Helper()
+
+	if cfg.Weight == 0 {
+		cfg.Weight = 1
+	}
+	return project.New(project.Config{
+		Project: cfg,
+	}, project.Dependencies{
+		Events: events,
+		Runner: blockingRunner{},
+	})
+}

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -128,8 +128,8 @@ func TestManagerLiveAddRemovePauseUnpause(t *testing.T) {
 	}
 	unpaused := receiveEvent(t, sub.C())
 	restarted := receiveEvent(t, sub.C())
-	if unpaused.Kind != project.EventUnpaused || restarted.Kind != project.EventStarted {
-		t.Fatalf("unpause events = %#v %#v, want unpaused then started", unpaused, restarted)
+	if unpaused.Kind != project.EventStarted || restarted.Kind != project.EventUnpaused {
+		t.Fatalf("unpause events = %#v %#v, want started then unpaused", unpaused, restarted)
 	}
 	if got.Paused() {
 		t.Fatal("Paused() = true, want false")

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -31,8 +31,10 @@ var (
 )
 
 const (
-	EventStarted EventKind = "project_started"
-	EventStopped EventKind = "project_stopped"
+	EventStarted  EventKind = "project_started"
+	EventPaused   EventKind = "project_paused"
+	EventStopped  EventKind = "project_stopped"
+	EventUnpaused EventKind = "project_unpaused"
 )
 
 type ProjectID string
@@ -71,6 +73,9 @@ type Project struct {
 	workflow     workflowconfig.Workflow
 	connector    connector.Connector
 	orchestrator *orchestrator.Orchestrator
+	orchFactory  OrchestratorFactory
+	orchConfig   orchestrator.Config
+	orchDeps     orchestrator.Dependencies
 	scheduler    scheduler.Scheduler
 	events       *hub.Hub[Event]
 	logger       *slog.Logger
@@ -127,11 +132,13 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		orchestratorFactory = orchestrator.New
 	}
 
-	orch, err := orchestratorFactory(orchestrator.ConfigFromWorkflow(workflow.Config), orchestrator.Dependencies{
+	orchConfig := orchestrator.ConfigFromWorkflow(workflow.Config)
+	orchDeps := orchestrator.Dependencies{
 		Connector: projectConnector,
 		Runner:    deps.Runner,
 		Logger:    logger,
-	})
+	}
+	orch, err := orchestratorFactory(orchConfig, orchDeps)
 	if err != nil {
 		return nil, fmt.Errorf("create project orchestrator: %w", err)
 	}
@@ -146,6 +153,9 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		workflow:     workflow,
 		connector:    projectConnector,
 		orchestrator: orch,
+		orchFactory:  orchestratorFactory,
+		orchConfig:   orchConfig,
+		orchDeps:     orchDeps,
 		scheduler:    projectScheduler,
 		events:       projectEvents,
 		logger:       logger,
@@ -160,6 +170,9 @@ func (p *Project) ID() ProjectID {
 }
 
 func (p *Project) Config() globalconfig.Project {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.cfg
 }
 
@@ -190,15 +203,23 @@ func (p *Project) Running() bool {
 	return p.done != nil
 }
 
+func (p *Project) Paused() bool {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.cfg.Paused
+}
+
 func (p *Project) Start(ctx context.Context) error {
-	if p.cfg.Paused {
-		return ErrProjectPaused
-	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	p.mu.Lock()
+	if p.cfg.Paused {
+		p.mu.Unlock()
+		return ErrProjectPaused
+	}
 	if p.done != nil {
 		p.mu.Unlock()
 		return ErrAlreadyRunning
@@ -207,9 +228,22 @@ func (p *Project) Start(ctx context.Context) error {
 		p.mu.Unlock()
 		return ErrProjectStopped
 	}
+	if p.orchestrator == nil {
+		orch, err := p.orchFactory(p.orchConfig, p.orchDeps)
+		if err != nil {
+			p.mu.Unlock()
+			return fmt.Errorf("create project orchestrator: %w", err)
+		}
+		if orch == nil {
+			p.mu.Unlock()
+			return ErrMissingOrchestrator
+		}
+		p.orchestrator = orch
+	}
 
 	runCtx, cancel := context.WithCancel(ctx)
 	done := make(chan struct{})
+	orch := p.orchestrator
 	p.cancel = cancel
 	p.done = done
 	p.runErr = nil
@@ -222,8 +256,71 @@ func (p *Project) Start(ctx context.Context) error {
 		At:        time.Now(),
 	})
 
-	go p.run(runCtx, done)
+	go p.run(runCtx, done, orch)
 	return nil
+}
+
+func (p *Project) Pause(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	if p.cfg.Paused {
+		p.mu.Unlock()
+		return nil
+	}
+	p.cfg.Paused = true
+	cancel := p.cancel
+	done := p.done
+	wasRunning := done != nil
+	p.mu.Unlock()
+
+	if wasRunning {
+		cancel()
+		if err := p.waitDone(ctx, done); err != nil {
+			return err
+		}
+	}
+
+	p.mu.Lock()
+	if wasRunning && p.cfg.Paused && p.done == nil {
+		p.started = false
+		p.orchestrator = nil
+	}
+	p.mu.Unlock()
+
+	p.publish(Event{
+		ProjectID: p.id,
+		Kind:      EventPaused,
+		At:        time.Now(),
+	})
+	return nil
+}
+
+func (p *Project) Unpause(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	if !p.cfg.Paused {
+		p.mu.Unlock()
+		return nil
+	}
+	p.cfg.Paused = false
+	running := p.done != nil
+	p.mu.Unlock()
+
+	p.publish(Event{
+		ProjectID: p.id,
+		Kind:      EventUnpaused,
+		At:        time.Now(),
+	})
+	if running {
+		return nil
+	}
+	return p.Start(ctx)
 }
 
 func (p *Project) Stop(ctx context.Context) error {
@@ -272,8 +369,8 @@ func (p *Project) waitDone(ctx context.Context, done <-chan struct{}) error {
 	}
 }
 
-func (p *Project) run(ctx context.Context, done chan struct{}) {
-	err := p.orchestrator.Run(ctx)
+func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrator.Orchestrator) {
+	err := orch.Run(ctx)
 	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
 		err = nil
 	}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -270,10 +270,12 @@ func (p *Project) Pause(ctx context.Context) error {
 		p.mu.Unlock()
 		return nil
 	}
-	p.cfg.Paused = true
 	cancel := p.cancel
 	done := p.done
 	wasRunning := done != nil
+	if !wasRunning {
+		p.cfg.Paused = true
+	}
 	p.mu.Unlock()
 
 	if wasRunning {
@@ -284,7 +286,8 @@ func (p *Project) Pause(ctx context.Context) error {
 	}
 
 	p.mu.Lock()
-	if wasRunning && p.cfg.Paused && p.done == nil {
+	if wasRunning && p.done == nil {
+		p.cfg.Paused = true
 		p.started = false
 		p.orchestrator = nil
 	}
@@ -312,15 +315,22 @@ func (p *Project) Unpause(ctx context.Context) error {
 	running := p.done != nil
 	p.mu.Unlock()
 
+	if !running {
+		if err := p.Start(ctx); err != nil {
+			p.mu.Lock()
+			if p.done == nil {
+				p.cfg.Paused = true
+			}
+			p.mu.Unlock()
+			return err
+		}
+	}
 	p.publish(Event{
 		ProjectID: p.id,
 		Kind:      EventUnpaused,
 		At:        time.Now(),
 	})
-	if running {
-		return nil
-	}
-	return p.Start(ctx)
+	return nil
 }
 
 func (p *Project) Stop(ctx context.Context) error {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -226,6 +226,59 @@ func TestProjectStartRejectsPausedProject(t *testing.T) {
 	}
 }
 
+func TestProjectPauseUnpauseRestartsProject(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "symphony",
+			Weight: 1,
+		},
+	}, project.Dependencies{
+		Events: events,
+		Runner: blockingRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if event := receiveEvent(t, sub.C()); event.Kind != project.EventStarted {
+		t.Fatalf("first event = %#v, want started", event)
+	}
+
+	if err := got.Pause(context.Background()); err != nil {
+		t.Fatalf("Pause() error = %v", err)
+	}
+	stopped := receiveEvent(t, sub.C())
+	paused := receiveEvent(t, sub.C())
+	if stopped.Kind != project.EventStopped || paused.Kind != project.EventPaused {
+		t.Fatalf("pause events = %#v %#v, want stopped then paused", stopped, paused)
+	}
+	if !got.Paused() {
+		t.Fatal("Paused() = false, want true")
+	}
+
+	if err := got.Unpause(context.Background()); err != nil {
+		t.Fatalf("Unpause() error = %v", err)
+	}
+	unpaused := receiveEvent(t, sub.C())
+	started := receiveEvent(t, sub.C())
+	if unpaused.Kind != project.EventUnpaused || started.Kind != project.EventStarted {
+		t.Fatalf("unpause events = %#v %#v, want unpaused then started", unpaused, started)
+	}
+	if got.Paused() {
+		t.Fatal("Paused() = true, want false")
+	}
+}
+
 func workflowConfigWithMemoryIssue(id string) workflowconfig.Config {
 	cfg := workflowConfig("memory")
 	cfg.Agent.MaxConcurrentAgents = 4

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -3,6 +3,7 @@ package project_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -270,12 +271,97 @@ func TestProjectPauseUnpauseRestartsProject(t *testing.T) {
 		t.Fatalf("Unpause() error = %v", err)
 	}
 	unpaused := receiveEvent(t, sub.C())
-	started := receiveEvent(t, sub.C())
-	if unpaused.Kind != project.EventUnpaused || started.Kind != project.EventStarted {
-		t.Fatalf("unpause events = %#v %#v, want unpaused then started", unpaused, started)
+	restarted := receiveEvent(t, sub.C())
+	if unpaused.Kind != project.EventStarted || restarted.Kind != project.EventUnpaused {
+		t.Fatalf("unpause events = %#v %#v, want started then unpaused", unpaused, restarted)
 	}
 	if got.Paused() {
 		t.Fatal("Paused() = true, want false")
+	}
+}
+
+func TestProjectPauseDoesNotMarkPausedWhenShutdownTimesOut(t *testing.T) {
+	t.Parallel()
+
+	blocker := newPauseBlockingConnector()
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "symphony",
+			Weight: 1,
+		},
+	}, project.Dependencies{
+		Connector: blocker,
+		Runner:    blockingRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	blocker.waitEntered(t)
+
+	pauseCtx, cancel := context.WithTimeout(context.Background(), time.Millisecond)
+	defer cancel()
+	if err := got.Pause(pauseCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Pause() error = %v, want %v", err, context.DeadlineExceeded)
+	}
+	if got.Paused() {
+		t.Fatal("Paused() = true after failed Pause, want false")
+	}
+
+	blocker.release()
+	if err := got.Wait(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+		t.Fatalf("Wait() error = %v, want nil", err)
+	}
+}
+
+func TestProjectUnpauseKeepsProjectPausedWhenRestartFails(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	calls := 0
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "symphony",
+			Weight: 1,
+		},
+	}, project.Dependencies{
+		Events: events,
+		Runner: blockingRunner{},
+		OrchestratorFactory: func(cfg orchestrator.Config, deps orchestrator.Dependencies) (*orchestrator.Orchestrator, error) {
+			calls++
+			if calls > 1 {
+				return nil, errors.New("recreate failed")
+			}
+			return orchestrator.New(cfg, deps)
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveEvent(t, sub.C())
+	if err := got.Pause(context.Background()); err != nil {
+		t.Fatalf("Pause() error = %v", err)
+	}
+	receiveEvent(t, sub.C())
+	receiveEvent(t, sub.C())
+
+	if err := got.Unpause(context.Background()); err == nil || err.Error() != "create project orchestrator: recreate failed" {
+		t.Fatalf("Unpause() error = %v, want recreate failure", err)
+	}
+	if !got.Paused() {
+		t.Fatal("Paused() = false after failed Unpause, want true")
 	}
 }
 
@@ -302,6 +388,61 @@ type blockingRunner struct{}
 func (blockingRunner) Run(ctx context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
 	<-ctx.Done()
 	return orchestrator.RunResult{}, ctx.Err()
+}
+
+type pauseBlockingConnector struct {
+	entered  chan struct{}
+	releasec chan struct{}
+	once     sync.Once
+}
+
+func newPauseBlockingConnector() *pauseBlockingConnector {
+	return &pauseBlockingConnector{
+		entered:  make(chan struct{}),
+		releasec: make(chan struct{}),
+	}
+}
+
+func (c *pauseBlockingConnector) Name() string {
+	return "pause-blocking"
+}
+
+func (c *pauseBlockingConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	c.once.Do(func() {
+		close(c.entered)
+	})
+	<-c.releasec
+	return nil, ctx.Err()
+}
+
+func (c *pauseBlockingConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *pauseBlockingConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *pauseBlockingConnector) CreateComment(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *pauseBlockingConnector) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *pauseBlockingConnector) waitEntered(t *testing.T) {
+	t.Helper()
+
+	select {
+	case <-c.entered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connector fetch")
+	}
+}
+
+func (c *pauseBlockingConnector) release() {
+	close(c.releasec)
 }
 
 func receiveEvent(t *testing.T, ch <-chan project.Event) project.Event {


### PR DESCRIPTION
## Summary
- Add a project manager with live add, remove, pause, and unpause operations backed by the registry.
- Apply startup jitter and max_spawn_per_second pacing from global config.
- Allow paused projects to restart with a fresh orchestrator while preserving terminal Stop behavior.

Fixes #31

## Test Plan
- go test ./internal/project
- go test -race ./internal/project
- go test ./...
- make check
