### PR TITLE
feat(config): add workflow hot reload

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.26
 
 require (
 	github.com/a-h/templ v0.3.1001
+	github.com/fsnotify/fsnotify v1.7.0
 	github.com/labstack/echo/v4 v4.15.1
 	github.com/lmittmann/tint v1.1.3
 	github.com/pressly/goose/v3 v3.27.1

--- a/go.sum
+++ b/go.sum
@@ -5,6 +5,8 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
 github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
+github.com/fsnotify/fsnotify v1.7.0 h1:8JEhPFa5W2WU7YfeZzPNqzMP6Lwt7L2715Ggo0nosvA=
+github.com/fsnotify/fsnotify v1.7.0/go.mod h1:40Bi/Hjc2AVfZrqy+aj+yEI+/bRxZnMJyTJwOpGvigM=
 github.com/google/go-cmp v0.6.0 h1:ofyhxvXcZhMsU5ulbFiLKl/XBFqE1GSq7atu8tAmTRI=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/pprof v0.0.0-20250317173921-a4b03ec1a45e h1:ijClszYn+mADRFY17kjQEVQ1XRhq2/JR1M3sGqeJoxs=

--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -1,0 +1,200 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+)
+
+const defaultDebounce = 150 * time.Millisecond
+
+var ErrMissingPath = errors.New("workflow watch path is required")
+
+type Loader func(string) (workflowconfig.Workflow, error)
+
+type Update struct {
+	Path     string
+	Workflow workflowconfig.Workflow
+	Err      error
+	At       time.Time
+}
+
+type Option func(*options)
+
+type Watcher struct {
+	path     string
+	dir      string
+	debounce time.Duration
+	loader   Loader
+	logger   *slog.Logger
+}
+
+type options struct {
+	debounce time.Duration
+	loader   Loader
+	logger   *slog.Logger
+}
+
+func New(path string, opts ...Option) (*Watcher, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, ErrMissingPath
+	}
+
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve workflow watch path: %w", err)
+	}
+
+	cfg := options{
+		debounce: defaultDebounce,
+		loader:   workflowconfig.LoadWorkflow,
+		logger:   slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.debounce <= 0 {
+		cfg.debounce = defaultDebounce
+	}
+	if cfg.loader == nil {
+		cfg.loader = workflowconfig.LoadWorkflow
+	}
+	if cfg.logger == nil {
+		cfg.logger = slog.Default()
+	}
+
+	return &Watcher{
+		path:     filepath.Clean(absolute),
+		dir:      filepath.Dir(absolute),
+		debounce: cfg.debounce,
+		loader:   cfg.loader,
+		logger:   cfg.logger,
+	}, nil
+}
+
+func WithDebounce(debounce time.Duration) Option {
+	return func(opts *options) {
+		opts.debounce = debounce
+	}
+}
+
+func WithLoader(loader Loader) Option {
+	return func(opts *options) {
+		opts.loader = loader
+	}
+}
+
+func WithLogger(logger *slog.Logger) Option {
+	return func(opts *options) {
+		opts.logger = logger
+	}
+}
+
+func (w *Watcher) Watch(ctx context.Context) (<-chan Update, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create workflow watcher: %w", err)
+	}
+	if err := fsWatcher.Add(w.dir); err != nil {
+		closeErr := fsWatcher.Close()
+		return nil, errors.Join(fmt.Errorf("watch workflow directory: %w", err), closeErr)
+	}
+
+	updates := make(chan Update, 1)
+	go w.run(ctx, fsWatcher, updates)
+	return updates, nil
+}
+
+func (w *Watcher) run(ctx context.Context, fsWatcher *fsnotify.Watcher, updates chan<- Update) {
+	defer close(updates)
+	defer func() {
+		if err := fsWatcher.Close(); err != nil {
+			w.logger.Warn("close workflow watcher failed", "path", w.path, "error", err)
+		}
+	}()
+
+	timer := time.NewTimer(w.debounce)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-fsWatcher.Events:
+			if !ok {
+				return
+			}
+			if w.matches(event) {
+				resetTimer(timer, w.debounce)
+				timerC = timer.C
+			}
+		case err, ok := <-fsWatcher.Errors:
+			if !ok {
+				return
+			}
+			w.send(ctx, updates, Update{Path: w.path, Err: err, At: time.Now()})
+		case <-timerC:
+			timerC = nil
+			w.reload(ctx, updates)
+		}
+	}
+}
+
+func (w *Watcher) matches(event fsnotify.Event) bool {
+	if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename|fsnotify.Remove) == 0 {
+		return false
+	}
+	return filepath.Clean(event.Name) == w.path
+}
+
+func (w *Watcher) reload(ctx context.Context, updates chan<- Update) {
+	update := Update{
+		Path: w.path,
+		At:   time.Now(),
+	}
+
+	workflow, err := w.loader(w.path)
+	if err == nil {
+		err = workflow.Config.Validate()
+	}
+	if err != nil {
+		update.Err = err
+	} else {
+		update.Workflow = workflow
+	}
+
+	w.send(ctx, updates, update)
+}
+
+func (w *Watcher) send(ctx context.Context, updates chan<- Update, update Update) {
+	select {
+	case updates <- update:
+	case <-ctx.Done():
+	}
+}
+
+func resetTimer(timer *time.Timer, debounce time.Duration) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+	timer.Reset(debounce)
+}

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -1,0 +1,151 @@
+package watcher
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+)
+
+func TestWatchDebouncesWorkflowWrites(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	writeWorkflow(t, path, 100, "initial")
+
+	w, err := New(path, WithDebounce(25*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	writeWorkflow(t, path, 200, "first")
+	writeWorkflow(t, path, 300, "second")
+
+	update := receiveUpdate(t, updates)
+	if update.Err != nil {
+		t.Fatalf("update error = %v", update.Err)
+	}
+	if update.Workflow.Config.Polling.IntervalMS != 300 {
+		t.Fatalf("Polling.IntervalMS = %d, want 300", update.Workflow.Config.Polling.IntervalMS)
+	}
+	if update.Workflow.Prompt != "second\n" {
+		t.Fatalf("Prompt = %q, want second", update.Workflow.Prompt)
+	}
+
+	select {
+	case extra := <-updates:
+		t.Fatalf("extra update after debounce = %#v", extra)
+	case <-time.After(75 * time.Millisecond):
+	}
+}
+
+func TestWatchHandlesAtomicSaveRename(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	writeWorkflow(t, path, 100, "initial")
+
+	w, err := New(path, WithDebounce(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	tmp := filepath.Join(dir, ".WORKFLOW.md.tmp")
+	writeWorkflow(t, tmp, 450, "renamed")
+	if err := os.Rename(tmp, path); err != nil {
+		t.Fatalf("Rename() error = %v", err)
+	}
+
+	update := receiveUpdate(t, updates)
+	if update.Err != nil {
+		t.Fatalf("update error = %v", update.Err)
+	}
+	if update.Workflow.Config.Polling.IntervalMS != 450 {
+		t.Fatalf("Polling.IntervalMS = %d, want 450", update.Workflow.Config.Polling.IntervalMS)
+	}
+	if update.Workflow.Prompt != "renamed\n" {
+		t.Fatalf("Prompt = %q, want renamed", update.Workflow.Prompt)
+	}
+}
+
+func TestWatchReportsInvalidReload(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	writeWorkflow(t, path, 100, "initial")
+
+	w, err := New(path, WithDebounce(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	if err := os.WriteFile(path, []byte("---\ntracker: [\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	update := receiveUpdate(t, updates)
+	if update.Err == nil {
+		t.Fatal("update error = nil, want parse error")
+	}
+}
+
+func receiveUpdate(t *testing.T, updates <-chan Update) Update {
+	t.Helper()
+
+	select {
+	case update, ok := <-updates:
+		if !ok {
+			t.Fatal("updates channel closed")
+		}
+		return update
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watcher update")
+	}
+
+	return Update{}
+}
+
+func writeWorkflow(t *testing.T, path string, intervalMS int, prompt string) {
+	t.Helper()
+
+	raw := []byte(`---
+tracker:
+  kind: memory
+polling:
+  interval_ms: ` + strconv.Itoa(intervalMS) + `
+---
+` + prompt + `
+`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -54,12 +54,18 @@ type Orchestrator struct {
 	supervisor    *runpkg.Supervisor
 	logger        *slog.Logger
 	stateRequests chan stateRequest
+	configUpdates chan configUpdateRequest
 	runResults    chan runpkg.Completion
 	done          chan struct{}
 }
 
 type stateRequest struct {
 	reply chan State
+}
+
+type configUpdateRequest struct {
+	cfg   Config
+	reply chan struct{}
 }
 
 func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
@@ -114,6 +120,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		supervisor:    supervisor,
 		logger:        logger,
 		stateRequests: make(chan stateRequest),
+		configUpdates: make(chan configUpdateRequest),
 		runResults:    make(chan runpkg.Completion),
 		done:          make(chan struct{}),
 	}, nil
@@ -139,9 +146,39 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.tick(ctx, &state, now)
 		case result := <-o.runResults:
 			o.handleRunResult(&state, result)
+		case update := <-o.configUpdates:
+			o.applyConfigUpdate(&state, update.cfg, ticker)
+			update.reply <- struct{}{}
 		case request := <-o.stateRequests:
 			request.reply <- state.clone()
 		}
+	}
+}
+
+func (o *Orchestrator) UpdateConfig(ctx context.Context, cfg Config) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	request := configUpdateRequest{
+		cfg:   cfg,
+		reply: make(chan struct{}, 1),
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	case o.configUpdates <- request:
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	case <-request.reply:
+		return nil
 	}
 }
 
@@ -181,6 +218,14 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	o.pruneBudgetRefusals(state, now)
 	o.trackBlockedCandidates(state, issues, now)
 	o.dispatchReadyIssues(ctx, state, issues, now)
+}
+
+func (o *Orchestrator) applyConfigUpdate(state *State, cfg Config, ticker *time.Ticker) {
+	cfg = normalizeConfig(cfg)
+	o.cfg = cfg
+	state.PollInterval = cfg.PollInterval
+	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
+	ticker.Reset(cfg.PollInterval)
 }
 
 func (o *Orchestrator) trackBlockedCandidates(state *State, issues []connector.Issue, now time.Time) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -48,6 +48,11 @@ type Dependencies struct {
 	Logger    *slog.Logger
 }
 
+type RuntimeUpdate struct {
+	Config    Config
+	Connector connector.Connector
+}
+
 type Orchestrator struct {
 	cfg           Config
 	connector     connector.Connector
@@ -64,8 +69,8 @@ type stateRequest struct {
 }
 
 type configUpdateRequest struct {
-	cfg   Config
-	reply chan struct{}
+	update RuntimeUpdate
+	reply  chan struct{}
 }
 
 func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
@@ -147,7 +152,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		case result := <-o.runResults:
 			o.handleRunResult(&state, result)
 		case update := <-o.configUpdates:
-			o.applyConfigUpdate(&state, update.cfg, ticker)
+			o.applyRuntimeUpdate(&state, update.update, ticker)
 			update.reply <- struct{}{}
 		case request := <-o.stateRequests:
 			request.reply <- state.clone()
@@ -156,13 +161,17 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 }
 
 func (o *Orchestrator) UpdateConfig(ctx context.Context, cfg Config) error {
+	return o.UpdateRuntime(ctx, RuntimeUpdate{Config: cfg})
+}
+
+func (o *Orchestrator) UpdateRuntime(ctx context.Context, update RuntimeUpdate) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
 
 	request := configUpdateRequest{
-		cfg:   cfg,
-		reply: make(chan struct{}, 1),
+		update: update,
+		reply:  make(chan struct{}, 1),
 	}
 	select {
 	case <-ctx.Done():
@@ -220,9 +229,16 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	o.dispatchReadyIssues(ctx, state, issues, now)
 }
 
-func (o *Orchestrator) applyConfigUpdate(state *State, cfg Config, ticker *time.Ticker) {
-	cfg = normalizeConfig(cfg)
+func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ticker *time.Ticker) {
+	cfg := normalizeConfig(update.Config)
 	o.cfg = cfg
+	if update.Connector != nil {
+		o.connector = update.Connector
+	}
+	o.supervisor.UpdateConfig(runpkg.SupervisorConfig{
+		MaxRetryBackoff:       cfg.MaxRetryBackoff,
+		FailureRetryBaseDelay: cfg.FailureRetryBaseDelay,
+	})
 	state.PollInterval = cfg.PollInterval
 	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
 	ticker.Reset(cfg.PollInterval)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -169,6 +169,57 @@ func TestUpdateConfigAppliesBeforeNextTick(t *testing.T) {
 	close(runner.release)
 }
 
+func TestUpdateRuntimeSwapsConnectorBeforeNextTick(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-reload-connector", "digitaldrywood/symphony-go#41", "Todo")
+	initialTracker := newFakeConnector()
+	reloadedTracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+	}, orchestrator.Dependencies{
+		Connector: initialTracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected run before connector update = %#v", request)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	updateCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := orch.UpdateRuntime(updateCtx, orchestrator.RuntimeUpdate{
+		Config: orchestrator.Config{
+			PollInterval:        5 * time.Millisecond,
+			MaxConcurrentAgents: 1,
+			ActiveStates:        []string{"Todo"},
+			TerminalStates:      []string{"Done"},
+		},
+		Connector: reloadedTracker,
+	}); err != nil {
+		t.Fatalf("UpdateRuntime() error = %v", err)
+	}
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != issue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
+	}
+
+	close(runner.release)
+}
+
 func TestRunDispatchesByStateRankBeforePriorityAndAge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -111,6 +111,64 @@ func TestRunReportsRunningStateWhileRunnerIsInFlight(t *testing.T) {
 	})
 }
 
+func TestUpdateConfigAppliesBeforeNextTick(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-reload", "digitaldrywood/symphony-go#41", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Backlog"},
+		TerminalStates:      []string{"Done"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected run before config update = %#v", request)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	updateCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := orch.UpdateConfig(updateCtx, orchestrator.Config{
+		PollInterval:        5 * time.Millisecond,
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+	}); err != nil {
+		t.Fatalf("UpdateConfig() error = %v", err)
+	}
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != issue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
+	}
+
+	state, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if state.PollInterval != 5*time.Millisecond {
+		t.Fatalf("State().PollInterval = %s, want 5ms", state.PollInterval)
+	}
+	if state.MaxConcurrentAgents != 2 {
+		t.Fatalf("State().MaxConcurrentAgents = %d, want 2", state.MaxConcurrentAgents)
+	}
+
+	close(runner.release)
+}
+
 func TestRunDispatchesByStateRankBeforePriorityAndAge(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -51,6 +51,42 @@ func TestDispatchReadyIssuesKeepsRetryAttemptWhenCapacityIsFull(t *testing.T) {
 	}
 }
 
+func TestApplyRuntimeUpdateRefreshesSupervisorRetryConfig(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		PollInterval:           time.Hour,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Minute,
+		FailureRetryBaseDelay:  10 * time.Second,
+		ActiveStates:           []string{"Todo"},
+		TerminalStates:         []string{"Done"},
+		ContinuationRetryDelay: time.Second,
+	})
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, FakeRunner{}, cfg),
+	}
+	state := newState(cfg)
+	ticker := time.NewTicker(time.Hour)
+	defer ticker.Stop()
+
+	orch.applyRuntimeUpdate(&state, RuntimeUpdate{
+		Config: Config{
+			PollInterval:          time.Hour,
+			MaxConcurrentAgents:   1,
+			MaxRetryBackoff:       2 * time.Second,
+			FailureRetryBaseDelay: time.Second,
+			ActiveStates:          []string{"Todo"},
+			TerminalStates:        []string{"Done"},
+		},
+	}, ticker)
+
+	if got := orch.supervisor.RetryDelay(4); got != 2*time.Second {
+		t.Fatalf("RetryDelay(4) = %s, want reloaded 2s cap", got)
+	}
+}
+
 func TestDispatchReadyIssuesRanksDueRetriesWithCandidates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -11,6 +11,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
 	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	configwatcher "github.com/digitaldrywood/symphony-go/internal/config/watcher"
 	"github.com/digitaldrywood/symphony-go/internal/connector"
 	"github.com/digitaldrywood/symphony-go/internal/connector/factory"
 	"github.com/digitaldrywood/symphony-go/internal/connector/memory"
@@ -57,14 +58,21 @@ type ConnectorFactory func(workflowconfig.Config) (connector.Connector, error)
 
 type OrchestratorFactory func(orchestrator.Config, orchestrator.Dependencies) (*orchestrator.Orchestrator, error)
 
+type WorkflowWatcher interface {
+	Watch(context.Context) (<-chan configwatcher.Update, error)
+}
+
+type WorkflowWatcherFactory func(string) (WorkflowWatcher, error)
+
 type Dependencies struct {
-	Connector           connector.Connector
-	ConnectorFactory    ConnectorFactory
-	OrchestratorFactory OrchestratorFactory
-	Runner              orchestrator.Runner
-	Scheduler           scheduler.Scheduler
-	Events              *hub.Hub[Event]
-	Logger              *slog.Logger
+	Connector              connector.Connector
+	ConnectorFactory       ConnectorFactory
+	OrchestratorFactory    OrchestratorFactory
+	WorkflowWatcherFactory WorkflowWatcherFactory
+	Runner                 orchestrator.Runner
+	Scheduler              scheduler.Scheduler
+	Events                 *hub.Hub[Event]
+	Logger                 *slog.Logger
 }
 
 type Project struct {
@@ -76,9 +84,11 @@ type Project struct {
 	orchFactory  OrchestratorFactory
 	orchConfig   orchestrator.Config
 	orchDeps     orchestrator.Dependencies
+	runner       orchestrator.Runner
 	scheduler    scheduler.Scheduler
 	events       *hub.Hub[Event]
 	logger       *slog.Logger
+	watcher      WorkflowWatcherFactory
 
 	mu      sync.Mutex
 	cancel  context.CancelFunc
@@ -146,6 +156,11 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		return nil, ErrMissingOrchestrator
 	}
 
+	watcherFactory := deps.WorkflowWatcherFactory
+	if watcherFactory == nil {
+		watcherFactory = defaultWorkflowWatcherFactory
+	}
+
 	cfg.Project.ID = string(id)
 	return &Project{
 		id:           id,
@@ -156,9 +171,11 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		orchFactory:  orchestratorFactory,
 		orchConfig:   orchConfig,
 		orchDeps:     orchDeps,
+		runner:       deps.Runner,
 		scheduler:    projectScheduler,
 		events:       projectEvents,
 		logger:       logger,
+		watcher:      watcherFactory,
 	}, nil
 }
 
@@ -177,6 +194,9 @@ func (p *Project) Config() globalconfig.Project {
 }
 
 func (p *Project) Workflow() workflowconfig.Workflow {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.workflow
 }
 
@@ -380,7 +400,14 @@ func (p *Project) waitDone(ctx context.Context, done <-chan struct{}) error {
 }
 
 func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrator.Orchestrator) {
+	watcherCtx, stopWatcher := context.WithCancel(ctx)
+	watcherDone := p.startWorkflowWatcher(watcherCtx)
+
 	err := orch.Run(ctx)
+	stopWatcher()
+	if watcherDone != nil {
+		<-watcherDone
+	}
 	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
 		err = nil
 	}
@@ -403,6 +430,86 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	close(done)
 }
 
+func (p *Project) startWorkflowWatcher(ctx context.Context) <-chan struct{} {
+	path := strings.TrimSpace(p.cfg.Workflow)
+	if path == "" {
+		return nil
+	}
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+
+		watcher, err := p.watcher(path)
+		if err != nil {
+			p.logger.Warn("create workflow watcher failed", "project_id", p.id, "path", path, "error", err)
+			return
+		}
+
+		updates, err := watcher.Watch(ctx)
+		if err != nil {
+			p.logger.Warn("watch workflow failed", "project_id", p.id, "path", path, "error", err)
+			return
+		}
+
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case update, ok := <-updates:
+				if !ok {
+					return
+				}
+				p.handleWorkflowUpdate(ctx, update)
+			}
+		}
+	}()
+	return done
+}
+
+func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher.Update) {
+	if update.Err != nil {
+		p.logger.Warn("workflow reload failed",
+			"project_id", p.id,
+			"path", update.Path,
+			"error", update.Err,
+		)
+		return
+	}
+
+	workflow := normalizeWorkflow(update.Workflow)
+	if err := workflow.Config.Validate(); err != nil {
+		p.logger.Warn("workflow reload validation failed",
+			"project_id", p.id,
+			"path", update.Path,
+			"error", err,
+		)
+		return
+	}
+
+	p.mu.Lock()
+	p.workflow = workflow
+	p.mu.Unlock()
+
+	if updater, ok := p.runner.(workflowUpdater); ok {
+		updater.UpdateWorkflow(workflow)
+	}
+
+	if err := p.orchestrator.UpdateConfig(ctx, orchestrator.ConfigFromWorkflow(workflow.Config)); err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		p.logger.Warn("apply workflow reload failed",
+			"project_id", p.id,
+			"path", update.Path,
+			"error", err,
+		)
+		return
+	}
+
+	p.logger.Info("workflow reloaded", "project_id", p.id, "path", update.Path)
+}
+
 func (p *Project) publish(event Event) {
 	if err := p.events.Publish(event); err != nil {
 		p.logger.Warn("publish project event failed",
@@ -411,6 +518,10 @@ func (p *Project) publish(event Event) {
 			"error", err,
 		)
 	}
+}
+
+type workflowUpdater interface {
+	UpdateWorkflow(workflowconfig.Workflow)
 }
 
 func buildConnector(cfg workflowconfig.Config, deps Dependencies) (connector.Connector, error) {
@@ -463,6 +574,10 @@ func defaultConnectorFactory(cfg workflowconfig.Config) (connector.Connector, er
 		GitHubAppInstallationID: cfg.Tracker.GitHubAppInstallationID,
 		ProjectSlug:             cfg.Tracker.ProjectSlug,
 	})
+}
+
+func defaultWorkflowWatcherFactory(path string) (WorkflowWatcher, error) {
+	return configwatcher.New(path)
 }
 
 func normalizeWorkflow(workflow workflowconfig.Workflow) workflowconfig.Workflow {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -76,19 +76,21 @@ type Dependencies struct {
 }
 
 type Project struct {
-	id           ProjectID
-	cfg          globalconfig.Project
-	workflow     workflowconfig.Workflow
-	connector    connector.Connector
-	orchestrator *orchestrator.Orchestrator
-	orchFactory  OrchestratorFactory
-	orchConfig   orchestrator.Config
-	orchDeps     orchestrator.Dependencies
-	runner       orchestrator.Runner
-	scheduler    scheduler.Scheduler
-	events       *hub.Hub[Event]
-	logger       *slog.Logger
-	watcher      WorkflowWatcherFactory
+	id               ProjectID
+	cfg              globalconfig.Project
+	workflow         workflowconfig.Workflow
+	connector        connector.Connector
+	connectorFactory ConnectorFactory
+	orchestrator     *orchestrator.Orchestrator
+	orchFactory      OrchestratorFactory
+	orchConfig       orchestrator.Config
+	orchDeps         orchestrator.Dependencies
+	runner           orchestrator.Runner
+	scheduler        scheduler.Scheduler
+	schedulerFactory schedulerFactory
+	events           *hub.Hub[Event]
+	logger           *slog.Logger
+	watcher          WorkflowWatcherFactory
 
 	mu      sync.Mutex
 	cancel  context.CancelFunc
@@ -117,12 +119,14 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		return nil, fmt.Errorf("validate project workflow: %w", err)
 	}
 
-	projectConnector, err := buildConnector(workflow.Config, deps)
+	connectorFactory := resolveConnectorFactory(deps)
+	projectConnector, err := buildConnector(workflow.Config, connectorFactory)
 	if err != nil {
 		return nil, err
 	}
 
-	projectScheduler, err := buildScheduler(workflow.Config, deps)
+	schedulerFactory := resolveSchedulerFactory(deps)
+	projectScheduler, err := buildScheduler(workflow.Config, schedulerFactory)
 	if err != nil {
 		return nil, err
 	}
@@ -163,19 +167,21 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 
 	cfg.Project.ID = string(id)
 	return &Project{
-		id:           id,
-		cfg:          cfg.Project,
-		workflow:     workflow,
-		connector:    projectConnector,
-		orchestrator: orch,
-		orchFactory:  orchestratorFactory,
-		orchConfig:   orchConfig,
-		orchDeps:     orchDeps,
-		runner:       deps.Runner,
-		scheduler:    projectScheduler,
-		events:       projectEvents,
-		logger:       logger,
-		watcher:      watcherFactory,
+		id:               id,
+		cfg:              cfg.Project,
+		workflow:         workflow,
+		connector:        projectConnector,
+		connectorFactory: connectorFactory,
+		orchestrator:     orch,
+		orchFactory:      orchestratorFactory,
+		orchConfig:       orchConfig,
+		orchDeps:         orchDeps,
+		runner:           deps.Runner,
+		scheduler:        projectScheduler,
+		schedulerFactory: schedulerFactory,
+		events:           projectEvents,
+		logger:           logger,
+		watcher:          watcherFactory,
 	}, nil
 }
 
@@ -201,6 +207,9 @@ func (p *Project) Workflow() workflowconfig.Workflow {
 }
 
 func (p *Project) Connector() connector.Connector {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.connector
 }
 
@@ -209,6 +218,9 @@ func (p *Project) Orchestrator() *orchestrator.Orchestrator {
 }
 
 func (p *Project) Scheduler() scheduler.Scheduler {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.scheduler
 }
 
@@ -487,15 +499,35 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		return
 	}
 
-	p.mu.Lock()
-	p.workflow = workflow
-	p.mu.Unlock()
+	projectConnector, err := buildConnector(workflow.Config, p.connectorFactory)
+	if err != nil {
+		p.logger.Warn("workflow reload connector failed",
+			"project_id", p.id,
+			"path", update.Path,
+			"error", err,
+		)
+		return
+	}
+
+	projectScheduler, err := buildScheduler(workflow.Config, p.schedulerFactory)
+	if err != nil {
+		p.logger.Warn("workflow reload scheduler failed",
+			"project_id", p.id,
+			"path", update.Path,
+			"error", err,
+		)
+		return
+	}
 
 	if updater, ok := p.runner.(workflowUpdater); ok {
 		updater.UpdateWorkflow(workflow)
 	}
 
-	if err := p.orchestrator.UpdateConfig(ctx, orchestrator.ConfigFromWorkflow(workflow.Config)); err != nil {
+	runtimeConfig := orchestrator.ConfigFromWorkflow(workflow.Config)
+	if err := p.orchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
+		Config:    runtimeConfig,
+		Connector: projectConnector,
+	}); err != nil {
 		if ctx.Err() != nil {
 			return
 		}
@@ -506,6 +538,14 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		)
 		return
 	}
+
+	p.mu.Lock()
+	p.workflow = workflow
+	p.connector = projectConnector
+	p.scheduler = projectScheduler
+	p.orchConfig = runtimeConfig
+	p.orchDeps.Connector = projectConnector
+	p.mu.Unlock()
 
 	p.logger.Info("workflow reloaded", "project_id", p.id, "path", update.Path)
 }
@@ -524,16 +564,21 @@ type workflowUpdater interface {
 	UpdateWorkflow(workflowconfig.Workflow)
 }
 
-func buildConnector(cfg workflowconfig.Config, deps Dependencies) (connector.Connector, error) {
+type schedulerFactory func(workflowconfig.Config) (scheduler.Scheduler, error)
+
+func resolveConnectorFactory(deps Dependencies) ConnectorFactory {
 	if deps.Connector != nil {
-		return deps.Connector, nil
+		return func(workflowconfig.Config) (connector.Connector, error) {
+			return deps.Connector, nil
+		}
 	}
-
-	connectorFactory := deps.ConnectorFactory
-	if connectorFactory == nil {
-		connectorFactory = defaultConnectorFactory
+	if deps.ConnectorFactory != nil {
+		return deps.ConnectorFactory
 	}
+	return defaultConnectorFactory
+}
 
+func buildConnector(cfg workflowconfig.Config, connectorFactory ConnectorFactory) (connector.Connector, error) {
 	projectConnector, err := connectorFactory(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("create project connector: %w", err)
@@ -545,18 +590,34 @@ func buildConnector(cfg workflowconfig.Config, deps Dependencies) (connector.Con
 	return projectConnector, nil
 }
 
-func buildScheduler(cfg workflowconfig.Config, deps Dependencies) (scheduler.Scheduler, error) {
+func resolveSchedulerFactory(deps Dependencies) schedulerFactory {
 	if deps.Scheduler != nil {
-		return deps.Scheduler, nil
+		return func(workflowconfig.Config) (scheduler.Scheduler, error) {
+			return deps.Scheduler, nil
+		}
 	}
+	return defaultSchedulerFactory
+}
 
+func buildScheduler(cfg workflowconfig.Config, schedulerFactory schedulerFactory) (scheduler.Scheduler, error) {
+	projectScheduler, err := schedulerFactory(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create project scheduler: %w", err)
+	}
+	if projectScheduler == nil {
+		return nil, fmt.Errorf("create project scheduler: %w", scheduler.ErrUnsupportedBackend)
+	}
+	return projectScheduler, nil
+}
+
+func defaultSchedulerFactory(cfg workflowconfig.Config) (scheduler.Scheduler, error) {
 	projectScheduler, err := scheduler.NewFromConfig(scheduler.Config{
 		Capacity:        cfg.Agent.MaxConcurrentAgents,
 		CapacityByState: cfg.Agent.MaxConcurrentAgentsByState,
 		CapacityPerHost: maxConcurrentAgentsPerHost(cfg),
 	})
 	if err != nil {
-		return nil, fmt.Errorf("create project scheduler: %w", err)
+		return nil, err
 	}
 
 	return projectScheduler, nil
@@ -573,7 +634,44 @@ func defaultConnectorFactory(cfg workflowconfig.Config) (connector.Connector, er
 		GitHubAppPrivateKeyPath: cfg.Tracker.GitHubAppPrivateKeyPath,
 		GitHubAppInstallationID: cfg.Tracker.GitHubAppInstallationID,
 		ProjectSlug:             cfg.Tracker.ProjectSlug,
+		ActiveStates:            cfg.Tracker.ActiveStates,
+		TerminalStates:          cfg.Tracker.TerminalStates,
+		StateMap:                stateMapValue(cfg.Tracker.StateMap),
+		PriorityMap:             priorityMapValue(cfg.Tracker.PriorityMap),
 	})
+}
+
+func stateMapValue(value workflowconfig.StringOrMap) map[string]string {
+	if !value.IsMap {
+		return nil
+	}
+
+	out := make(map[string]string, len(value.Map))
+	for state, mapped := range value.Map {
+		if mappedState, ok := mapped.(string); ok {
+			out[state] = mappedState
+		}
+	}
+	return out
+}
+
+func priorityMapValue(value workflowconfig.StringOrMap) map[string]*int {
+	if !value.IsMap {
+		return nil
+	}
+
+	out := make(map[string]*int, len(value.Map))
+	for name, rank := range value.Map {
+		if rank == nil {
+			out[name] = nil
+			continue
+		}
+		if intRank, ok := rank.(int); ok {
+			rankCopy := intRank
+			out[name] = &rankCopy
+		}
+	}
+	return out
 }
 
 func defaultWorkflowWatcherFactory(path string) (WorkflowWatcher, error) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -134,12 +134,9 @@ func TestProjectAppliesWorkflowReloadsToRunningOrchestrator(t *testing.T) {
 
 	updates := make(chan configwatcher.Update, 1)
 	runner := newProjectBlockingRunner()
-	initial := workflowConfigWithMemoryIssue("issue-1")
+	initial := workflowConfig("memory")
 	initial.Polling.IntervalMS = int(time.Hour / time.Millisecond)
-	initial.Tracker.ActiveStates = []string{"Backlog"}
-	initial.Tracker.Issues[0].State = "Todo"
-	initial.Tracker.Issues[0].Title = "Reload workflow"
-	initial.Tracker.Issues[0].AssignedToWorker = true
+	initial.Tracker.ActiveStates = []string{"Todo"}
 
 	got, err := project.New(project.Config{
 		Project: globalconfig.Project{
@@ -179,9 +176,15 @@ func TestProjectAppliesWorkflowReloadsToRunningOrchestrator(t *testing.T) {
 	case <-time.After(25 * time.Millisecond):
 	}
 
+	issue := connector.NewIssue()
+	issue.ID = "issue-1"
+	issue.Identifier = "issue-1"
+	issue.Title = "Reload workflow"
+	issue.State = "Todo"
+
 	reloaded := initial
 	reloaded.Polling.IntervalMS = 5
-	reloaded.Tracker.ActiveStates = []string{"Todo"}
+	reloaded.Tracker.Issues = []connector.Issue{issue}
 	updates <- configwatcher.Update{
 		Workflow: workflowconfig.Workflow{
 			Config: reloaded,
@@ -196,8 +199,108 @@ func TestProjectAppliesWorkflowReloadsToRunningOrchestrator(t *testing.T) {
 	if got.Workflow().Prompt != "reloaded" {
 		t.Fatalf("Workflow().Prompt = %q, want reloaded", got.Workflow().Prompt)
 	}
+	issues, err := got.Connector().FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("Connector().FetchCandidateIssues() error = %v", err)
+	}
+	if len(issues) != 1 || issues[0].ID != "issue-1" {
+		t.Fatalf("reloaded connector issues = %#v, want issue-1", issues)
+	}
 
 	close(runner.release)
+}
+
+func TestProjectWorkflowReloadRefreshesRestartDependencies(t *testing.T) {
+	t.Parallel()
+
+	updates := make(chan configwatcher.Update, 1)
+	runner := newProjectBlockingRunner()
+	configs := make(chan orchestrator.Config, 2)
+	connectors := make(chan connector.Connector, 2)
+	initial := workflowConfig("memory")
+	initial.Polling.IntervalMS = int(time.Hour / time.Millisecond)
+	initial.Tracker.ActiveStates = []string{"Todo"}
+
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:       "symphony",
+			Workflow: "workflow.md",
+			Weight:   1,
+		},
+		Workflow: workflowconfig.Workflow{
+			Config: initial,
+			Prompt: "initial",
+		},
+	}, project.Dependencies{
+		Runner: runner,
+		OrchestratorFactory: func(cfg orchestrator.Config, deps orchestrator.Dependencies) (*orchestrator.Orchestrator, error) {
+			configs <- cfg
+			connectors <- deps.Connector
+			return orchestrator.New(cfg, deps)
+		},
+		WorkflowWatcherFactory: func(string) (project.WorkflowWatcher, error) {
+			return fakeWorkflowWatcher{updates: updates}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if cfg := receiveOrchestratorConfig(t, configs); cfg.PollInterval != time.Hour {
+		t.Fatalf("initial PollInterval = %v, want %v", cfg.PollInterval, time.Hour)
+	}
+	_ = receiveConnector(t, connectors)
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected run before workflow reload = %#v", request)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	issue := connector.NewIssue()
+	issue.ID = "issue-1"
+	issue.Identifier = "issue-1"
+	issue.Title = "Reload workflow"
+	issue.State = "Todo"
+
+	reloaded := initial
+	reloaded.Polling.IntervalMS = 5
+	reloaded.Tracker.Issues = []connector.Issue{issue}
+	updates <- configwatcher.Update{
+		Workflow: workflowconfig.Workflow{
+			Config: reloaded,
+			Prompt: "reloaded",
+		},
+	}
+	_ = receiveRunRequest(t, runner.started)
+
+	if err := got.Pause(context.Background()); err != nil {
+		t.Fatalf("Pause() error = %v", err)
+	}
+	if err := got.Unpause(context.Background()); err != nil {
+		t.Fatalf("Unpause() error = %v", err)
+	}
+
+	if cfg := receiveOrchestratorConfig(t, configs); cfg.PollInterval != 5*time.Millisecond {
+		t.Fatalf("restarted PollInterval = %v, want %v", cfg.PollInterval, 5*time.Millisecond)
+	}
+	restartedConnector := receiveConnector(t, connectors)
+	issues, err := restartedConnector.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("restarted connector FetchCandidateIssues() error = %v", err)
+	}
+	if len(issues) != 1 || issues[0].ID != "issue-1" {
+		t.Fatalf("restarted connector issues = %#v, want issue-1", issues)
+	}
+
+	close(runner.release)
+	if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+		t.Fatalf("Stop() error = %v", err)
+	}
 }
 
 func TestNewRejectsInvalidProjectConfig(t *testing.T) {
@@ -563,6 +666,32 @@ func receiveRunRequest(t *testing.T, ch <-chan orchestrator.RunRequest) orchestr
 	}
 
 	return orchestrator.RunRequest{}
+}
+
+func receiveOrchestratorConfig(t *testing.T, ch <-chan orchestrator.Config) orchestrator.Config {
+	t.Helper()
+
+	select {
+	case cfg := <-ch:
+		return cfg
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for orchestrator config")
+	}
+
+	return orchestrator.Config{}
+}
+
+func receiveConnector(t *testing.T, ch <-chan connector.Connector) connector.Connector {
+	t.Helper()
+
+	select {
+	case got := <-ch:
+		return got
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connector")
+	}
+
+	return nil
 }
 
 func receiveEvent(t *testing.T, ch <-chan project.Event) project.Event {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -9,6 +9,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
 	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	configwatcher "github.com/digitaldrywood/symphony-go/internal/config/watcher"
 	"github.com/digitaldrywood/symphony-go/internal/connector"
 	"github.com/digitaldrywood/symphony-go/internal/hub"
 	"github.com/digitaldrywood/symphony-go/internal/orchestrator"
@@ -126,6 +127,77 @@ func TestProjectStartStopPublishesLifecycleEvents(t *testing.T) {
 	if err := got.Start(context.Background()); !errors.Is(err, project.ErrProjectStopped) {
 		t.Fatalf("Start() after Stop error = %v, want %v", err, project.ErrProjectStopped)
 	}
+}
+
+func TestProjectAppliesWorkflowReloadsToRunningOrchestrator(t *testing.T) {
+	t.Parallel()
+
+	updates := make(chan configwatcher.Update, 1)
+	runner := newProjectBlockingRunner()
+	initial := workflowConfigWithMemoryIssue("issue-1")
+	initial.Polling.IntervalMS = int(time.Hour / time.Millisecond)
+	initial.Tracker.ActiveStates = []string{"Backlog"}
+	initial.Tracker.Issues[0].State = "Todo"
+	initial.Tracker.Issues[0].Title = "Reload workflow"
+	initial.Tracker.Issues[0].AssignedToWorker = true
+
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:       "symphony",
+			Workflow: "workflow.md",
+			Weight:   1,
+		},
+		Workflow: workflowconfig.Workflow{
+			Config: initial,
+			Prompt: "initial",
+		},
+	}, project.Dependencies{
+		Runner: runner,
+		WorkflowWatcherFactory: func(path string) (project.WorkflowWatcher, error) {
+			if path != "workflow.md" {
+				t.Fatalf("watch path = %q, want workflow.md", path)
+			}
+			return fakeWorkflowWatcher{updates: updates}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer func() {
+		if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	}()
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected run before workflow reload = %#v", request)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	reloaded := initial
+	reloaded.Polling.IntervalMS = 5
+	reloaded.Tracker.ActiveStates = []string{"Todo"}
+	updates <- configwatcher.Update{
+		Workflow: workflowconfig.Workflow{
+			Config: reloaded,
+			Prompt: "reloaded",
+		},
+	}
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != "issue-1" {
+		t.Fatalf("RunRequest.Issue.ID = %q, want issue-1", request.Issue.ID)
+	}
+	if got.Workflow().Prompt != "reloaded" {
+		t.Fatalf("Workflow().Prompt = %q, want reloaded", got.Workflow().Prompt)
+	}
+
+	close(runner.release)
 }
 
 func TestNewRejectsInvalidProjectConfig(t *testing.T) {
@@ -443,6 +515,54 @@ func (c *pauseBlockingConnector) waitEntered(t *testing.T) {
 
 func (c *pauseBlockingConnector) release() {
 	close(c.releasec)
+}
+
+type projectBlockingRunner struct {
+	started chan orchestrator.RunRequest
+	release chan struct{}
+}
+
+func newProjectBlockingRunner() *projectBlockingRunner {
+	return &projectBlockingRunner{
+		started: make(chan orchestrator.RunRequest, 1),
+		release: make(chan struct{}),
+	}
+}
+
+func (r *projectBlockingRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	select {
+	case r.started <- request:
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+
+	select {
+	case <-r.release:
+		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+}
+
+type fakeWorkflowWatcher struct {
+	updates <-chan configwatcher.Update
+}
+
+func (w fakeWorkflowWatcher) Watch(context.Context) (<-chan configwatcher.Update, error) {
+	return w.updates, nil
+}
+
+func receiveRunRequest(t *testing.T, ch <-chan orchestrator.RunRequest) orchestrator.RunRequest {
+	t.Helper()
+
+	select {
+	case request := <-ch:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner request")
+	}
+
+	return orchestrator.RunRequest{}
 }
 
 func receiveEvent(t *testing.T, ch <-chan project.Event) project.Event {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"math"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/symphony-go/internal/codex"
@@ -47,6 +48,7 @@ type Dependencies struct {
 }
 
 type Runner struct {
+	mu              sync.RWMutex
 	workflow        config.Workflow
 	workspace       workspace.Backend
 	codex           CodexClient
@@ -84,10 +86,18 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	}, nil
 }
 
+func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.workflow = workflow
+}
+
 func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	workflow := r.workflowSnapshot()
 
 	workspaceIssue := workspaceIssue(req.Issue)
 	info, err := r.workspace.Create(ctx, workspaceIssue)
@@ -106,13 +116,13 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 	}()
 
-	availableSkills, err := r.availableSkills(info.Path)
+	availableSkills, err := r.availableSkills(workflow, info.Path)
 	if err != nil {
 		return RunResult{}, err
 	}
 
 	attempt := req.Attempt
-	prompt, err := BuildPrompt(r.workflow, req.Issue, PromptOptions{
+	prompt, err := BuildPrompt(workflow, req.Issue, PromptOptions{
 		Attempt:         &attempt,
 		WorkspacePath:   info.Path,
 		AvailableSkills: availableSkills,
@@ -136,9 +146,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	turnResult, turnErr := r.codex.RunTurn(ctx, codex.RunTurnRequest{
 		Workspace:         info.Path,
 		Prompt:            prompt,
-		ApprovalPolicy:    stringOrMapValue(r.workflow.Config.Codex.ApprovalPolicy),
-		ThreadSandbox:     r.workflow.Config.Codex.ThreadSandbox,
-		TurnSandboxPolicy: r.workflow.Config.Codex.TurnSandboxPolicy,
+		ApprovalPolicy:    stringOrMapValue(workflow.Config.Codex.ApprovalPolicy),
+		ThreadSandbox:     workflow.Config.Codex.ThreadSandbox,
+		TurnSandboxPolicy: workflow.Config.Codex.TurnSandboxPolicy,
 		Model:             model,
 	}, func(update codex.Update) error {
 		applyCodexUpdate(&result, update)
@@ -176,8 +186,15 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	return result, nil
 }
 
-func (r *Runner) availableSkills(workspacePath string) ([]skills.Skill, error) {
-	cfg := r.workflow.Config.Agent.Skills
+func (r *Runner) workflowSnapshot() config.Workflow {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.workflow
+}
+
+func (r *Runner) availableSkills(workflow config.Workflow, workspacePath string) ([]skills.Skill, error) {
+	cfg := workflow.Config.Agent.Skills
 	if !cfg.Enabled {
 		return nil, nil
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -139,6 +139,53 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 }
 
+func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-41", Branch: "symphony/issue-41"},
+	}
+	codexClient := &fakeCodexClient{}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Codex: config.Codex{ThreadSandbox: "workspace-write"},
+			},
+			Prompt: "initial {{ issue.identifier }}",
+		},
+		Workspace: workspaceBackend,
+		Codex:     codexClient,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	runner.UpdateWorkflow(config.Workflow{
+		Config: config.Config{
+			Codex: config.Codex{ThreadSandbox: "danger-full-access"},
+		},
+		Prompt: "reloaded {{ issue.identifier }}",
+	})
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-41",
+			Identifier: "digitaldrywood/symphony-go#41",
+			Title:      "Reload workflow",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if !strings.Contains(codexClient.request.Prompt, "reloaded digitaldrywood/symphony-go#41") {
+		t.Fatalf("codex prompt = %q, want reloaded workflow prompt", codexClient.request.Prompt)
+	}
+	if codexClient.request.ThreadSandbox != "danger-full-access" {
+		t.Fatalf("ThreadSandbox = %q, want danger-full-access", codexClient.request.ThreadSandbox)
+	}
+}
+
 func TestRunnerRunFinishesFailedSessionAndAfterRunOnCodexError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"sync"
 	"time"
 )
 
@@ -25,6 +26,7 @@ type SupervisorConfig struct {
 }
 
 type Supervisor struct {
+	mu                    sync.RWMutex
 	backend               Backend
 	maxRetryBackoff       time.Duration
 	failureRetryBaseDelay time.Duration
@@ -69,6 +71,21 @@ func NewSupervisor(backend Backend, cfg SupervisorConfig) (*Supervisor, error) {
 	}, nil
 }
 
+func (s *Supervisor) UpdateConfig(cfg SupervisorConfig) {
+	if cfg.MaxRetryBackoff <= 0 {
+		cfg.MaxRetryBackoff = defaultSupervisorMaxRetryBackoff
+	}
+	if cfg.FailureRetryBaseDelay <= 0 {
+		cfg.FailureRetryBaseDelay = defaultSupervisorFailureRetryBaseDelay
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.maxRetryBackoff = cfg.MaxRetryBackoff
+	s.failureRetryBaseDelay = cfg.FailureRetryBaseDelay
+}
+
 func (s *Supervisor) Dispatch(ctx context.Context, request RunRequest, completions chan<- Completion) {
 	go func() {
 		completion := s.Run(ctx, request)
@@ -111,6 +128,11 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 }
 
 func (s *Supervisor) RetryDelay(attempt int) time.Duration {
+	s.mu.RLock()
+	maxRetryBackoff := s.maxRetryBackoff
+	failureRetryBaseDelay := s.failureRetryBaseDelay
+	s.mu.RUnlock()
+
 	if attempt < 1 {
 		attempt = 1
 	}
@@ -119,9 +141,9 @@ func (s *Supervisor) RetryDelay(attempt int) time.Duration {
 		exponent = 30
 	}
 
-	delay := s.failureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
-	if delay > s.maxRetryBackoff {
-		return s.maxRetryBackoff
+	delay := failureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
+	if delay > maxRetryBackoff {
+		return maxRetryBackoff
 	}
 	return delay
 }

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -75,6 +75,27 @@ func TestSupervisorAppliesCappedBackoffForRunnerErrors(t *testing.T) {
 	}
 }
 
+func TestSupervisorUpdateConfigChangesRetryDelay(t *testing.T) {
+	t.Parallel()
+
+	supervisor, err := NewSupervisor(errorBackend{}, SupervisorConfig{
+		FailureRetryBaseDelay: 10 * time.Second,
+		MaxRetryBackoff:       25 * time.Second,
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	supervisor.UpdateConfig(SupervisorConfig{
+		FailureRetryBaseDelay: time.Second,
+		MaxRetryBackoff:       2 * time.Second,
+	})
+
+	if got := supervisor.RetryDelay(4); got != 2*time.Second {
+		t.Fatalf("RetryDelay(4) = %s, want 2s", got)
+	}
+}
+
 func TestSupervisorDispatchSendsCompletion(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add an internal config watcher backed by debounced fsnotify directory watches so atomic-save renames reload WORKFLOW.md.
- Add an orchestrator config update channel that applies validated runtime config between ticks and resets polling cadence.
- Wire project workflow reloads into the runner and orchestrator so future dispatch uses the refreshed prompt/codex settings and dispatch limits.

Fixes #41

## Test Plan
- go test ./internal/config/watcher ./internal/orchestrator ./internal/project ./internal/runner
- go test -race ./internal/config/watcher ./internal/orchestrator ./internal/project ./internal/runner
- make check