### PR TITLE
feat(scheduler): add global scheduling modes

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -95,3 +95,28 @@ WHERE issue_id = sqlc.arg(issue_id)
    OR issue_url = sqlc.arg(issue_url)
 GROUP BY COALESCE(model, '')
 ORDER BY COALESCE(model, '');
+
+-- name: ListFairShareUsage :many
+SELECT
+  project_id,
+  weight,
+  dispatches,
+  runtime_seconds,
+  updated_at
+FROM fair_share_usage
+ORDER BY project_id;
+
+-- name: UpsertFairShareUsage :one
+INSERT INTO fair_share_usage (
+  project_id,
+  weight,
+  dispatches,
+  runtime_seconds,
+  updated_at
+) VALUES (?, ?, 1, ?, ?)
+ON CONFLICT(project_id) DO UPDATE SET
+  weight = excluded.weight,
+  dispatches = fair_share_usage.dispatches + excluded.dispatches,
+  runtime_seconds = fair_share_usage.runtime_seconds + excluded.runtime_seconds,
+  updated_at = excluded.updated_at
+RETURNING *;

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -1,0 +1,356 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"math"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/store"
+)
+
+var ErrNoCandidates = errors.New("scheduler has no project candidates")
+
+type FairShareStore interface {
+	ListFairShareUsage(context.Context) ([]store.FairShareUsage, error)
+	RecordFairShareDispatch(context.Context, store.FairShareDispatch) error
+}
+
+type GlobalScheduler interface {
+	Scheduler
+	SelectProject(context.Context, ProjectSelectionRequest) (ProjectSelection, error)
+	RecordProjectDispatch(context.Context, ProjectDispatch) error
+}
+
+type ProjectCandidate struct {
+	ID       string
+	Weight   int
+	Priority int
+	Paused   bool
+}
+
+type RunningProject struct {
+	ProjectID string
+	Priority  int
+}
+
+type ProjectSelectionRequest struct {
+	Projects []ProjectCandidate
+	Running  []RunningProject
+	Now      time.Time
+}
+
+type ProjectSelection struct {
+	Project     ProjectCandidate
+	Preemptions []RunningProject
+}
+
+type ProjectDispatch struct {
+	ProjectID      string
+	Weight         int
+	RuntimeSeconds int64
+	DispatchedAt   time.Time
+}
+
+type globalScheduler struct {
+	*CountingSemaphore
+
+	mode           Mode
+	decayHalfLife  time.Duration
+	fairShareStore FairShareStore
+
+	mu                 sync.Mutex
+	weightedCurrent    map[string]float64
+	weightedLastUpdate time.Time
+	roundRobinLastID   string
+}
+
+var _ GlobalScheduler = (*globalScheduler)(nil)
+
+func NewWeightedFair(cfg Config) GlobalScheduler {
+	return newGlobalScheduler(ModeWeightedFair, cfg)
+}
+
+func NewStrictPriority(cfg Config) GlobalScheduler {
+	return newGlobalScheduler(ModeStrictPriority, cfg)
+}
+
+func NewRoundRobin(cfg Config) GlobalScheduler {
+	return newGlobalScheduler(ModeRoundRobin, cfg)
+}
+
+func NewFairShare(cfg Config) GlobalScheduler {
+	return newGlobalScheduler(ModeFairShare, cfg)
+}
+
+func newGlobalScheduler(mode Mode, cfg Config) *globalScheduler {
+	return &globalScheduler{
+		CountingSemaphore: NewCountingSemaphore(cfg),
+		mode:              mode,
+		decayHalfLife:     cfg.DecayHalfLife,
+		fairShareStore:    cfg.FairShareStore,
+		weightedCurrent:   map[string]float64{},
+	}
+}
+
+func (s *globalScheduler) Mode() Mode {
+	return s.mode
+}
+
+func (s *globalScheduler) SelectProject(ctx context.Context, req ProjectSelectionRequest) (ProjectSelection, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case <-ctx.Done():
+		return ProjectSelection{}, ctx.Err()
+	default:
+	}
+
+	candidates := normalizeProjectCandidates(req.Projects)
+	if len(candidates) == 0 {
+		return ProjectSelection{}, ErrNoCandidates
+	}
+
+	switch s.mode {
+	case ModeStrictPriority:
+		return s.selectStrictPriority(candidates, req.Running)
+	case ModeRoundRobin:
+		if !s.projectSlotAvailable(req.Running) {
+			return ProjectSelection{}, ErrNoSlots
+		}
+		return s.selectRoundRobin(candidates), nil
+	case ModeFairShare:
+		if !s.projectSlotAvailable(req.Running) {
+			return ProjectSelection{}, ErrNoSlots
+		}
+		return s.selectFairShare(ctx, candidates)
+	default:
+		if !s.projectSlotAvailable(req.Running) {
+			return ProjectSelection{}, ErrNoSlots
+		}
+		return s.selectWeightedFair(candidates, req.Now), nil
+	}
+}
+
+func (s *globalScheduler) RecordProjectDispatch(ctx context.Context, dispatch ProjectDispatch) error {
+	if s.mode != ModeFairShare || s.fairShareStore == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	projectID := normalizeProjectID(dispatch.ProjectID)
+	if projectID == "" {
+		return fmt.Errorf("%w: project id is required", ErrNoCandidates)
+	}
+
+	dispatchedAt := dispatch.DispatchedAt
+	if dispatchedAt.IsZero() {
+		dispatchedAt = time.Now()
+	}
+
+	return s.fairShareStore.RecordFairShareDispatch(ctx, store.FairShareDispatch{
+		ProjectID:      projectID,
+		Weight:         normalizeProjectWeight(dispatch.Weight),
+		RuntimeSeconds: nonNegative(dispatch.RuntimeSeconds),
+		DispatchedAt:   dispatchedAt,
+	})
+}
+
+func (s *globalScheduler) projectSlotAvailable(running []RunningProject) bool {
+	return len(running) < s.capacity
+}
+
+func (s *globalScheduler) selectWeightedFair(candidates []ProjectCandidate, now time.Time) ProjectSelection {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if now.IsZero() {
+		now = time.Now()
+	}
+	s.applyWeightedDecayLocked(now)
+
+	totalWeight := 0
+	for _, candidate := range candidates {
+		totalWeight += candidate.Weight
+		s.weightedCurrent[candidate.ID] += float64(candidate.Weight)
+	}
+
+	selected := candidates[0]
+	best := s.weightedCurrent[selected.ID]
+	for _, candidate := range candidates[1:] {
+		if current := s.weightedCurrent[candidate.ID]; current > best {
+			selected = candidate
+			best = current
+		}
+	}
+	s.weightedCurrent[selected.ID] -= float64(totalWeight)
+	s.weightedLastUpdate = now
+
+	return ProjectSelection{Project: selected}
+}
+
+func (s *globalScheduler) applyWeightedDecayLocked(now time.Time) {
+	if s.decayHalfLife <= 0 || s.weightedLastUpdate.IsZero() || !now.After(s.weightedLastUpdate) {
+		return
+	}
+
+	factor := math.Pow(0.5, now.Sub(s.weightedLastUpdate).Seconds()/s.decayHalfLife.Seconds())
+	if factor < 0.01 {
+		clear(s.weightedCurrent)
+		return
+	}
+
+	for projectID, current := range s.weightedCurrent {
+		s.weightedCurrent[projectID] = current * factor
+	}
+}
+
+func (s *globalScheduler) selectStrictPriority(candidates []ProjectCandidate, running []RunningProject) (ProjectSelection, error) {
+	sort.SliceStable(candidates, func(i, j int) bool {
+		left := priorityRank(candidates[i].Priority)
+		right := priorityRank(candidates[j].Priority)
+		if left != right {
+			return left < right
+		}
+		return candidates[i].ID < candidates[j].ID
+	})
+
+	selected := candidates[0]
+	if s.projectSlotAvailable(running) {
+		return ProjectSelection{Project: selected}, nil
+	}
+
+	preempt, ok := preemptableRunningProject(selected.Priority, running)
+	if !ok {
+		return ProjectSelection{}, ErrNoSlots
+	}
+
+	return ProjectSelection{
+		Project:     selected,
+		Preemptions: []RunningProject{preempt},
+	}, nil
+}
+
+func preemptableRunningProject(priority int, running []RunningProject) (RunningProject, bool) {
+	selectedRank := priorityRank(priority)
+	var preempt RunningProject
+	found := false
+	worstRank := 0
+	for _, candidate := range running {
+		rank := priorityRank(candidate.Priority)
+		if rank <= selectedRank {
+			continue
+		}
+		if !found || rank > worstRank {
+			preempt = candidate
+			worstRank = rank
+			found = true
+		}
+	}
+	return preempt, found
+}
+
+func (s *globalScheduler) selectRoundRobin(candidates []ProjectCandidate) ProjectSelection {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	index := 0
+	if s.roundRobinLastID != "" {
+		for i, candidate := range candidates {
+			if candidate.ID == s.roundRobinLastID {
+				index = (i + 1) % len(candidates)
+				break
+			}
+		}
+	}
+
+	selected := candidates[index]
+	s.roundRobinLastID = selected.ID
+	return ProjectSelection{Project: selected}
+}
+
+func (s *globalScheduler) selectFairShare(ctx context.Context, candidates []ProjectCandidate) (ProjectSelection, error) {
+	usageByProject := map[string]store.FairShareUsage{}
+	if s.fairShareStore != nil {
+		usage, err := s.fairShareStore.ListFairShareUsage(ctx)
+		if err != nil {
+			return ProjectSelection{}, fmt.Errorf("read fair-share usage: %w", err)
+		}
+		for _, item := range usage {
+			projectID := normalizeProjectID(item.ProjectID)
+			if projectID == "" {
+				continue
+			}
+			usageByProject[projectID] = item
+		}
+	}
+
+	selected := candidates[0]
+	best := fairShareScore(selected, usageByProject[selected.ID])
+	for _, candidate := range candidates[1:] {
+		if score := fairShareScore(candidate, usageByProject[candidate.ID]); score < best {
+			selected = candidate
+			best = score
+		}
+	}
+
+	return ProjectSelection{Project: selected}, nil
+}
+
+func fairShareScore(candidate ProjectCandidate, usage store.FairShareUsage) float64 {
+	cost := float64(nonNegative(usage.Dispatches)) + float64(nonNegative(usage.RuntimeSeconds))/60
+	return cost / float64(candidate.Weight)
+}
+
+func priorityRank(priority int) int {
+	if priority < 1 || priority > 4 {
+		return 5
+	}
+	return priority
+}
+
+func normalizeProjectCandidates(projects []ProjectCandidate) []ProjectCandidate {
+	candidates := make([]ProjectCandidate, 0, len(projects))
+	seen := make(map[string]struct{}, len(projects))
+	for _, project := range projects {
+		if project.Paused {
+			continue
+		}
+		project.ID = normalizeProjectID(project.ID)
+		if project.ID == "" {
+			continue
+		}
+		if _, ok := seen[project.ID]; ok {
+			continue
+		}
+		seen[project.ID] = struct{}{}
+		project.Weight = normalizeProjectWeight(project.Weight)
+		candidates = append(candidates, project)
+	}
+	return candidates
+}
+
+func normalizeProjectID(projectID string) string {
+	return strings.TrimSpace(projectID)
+}
+
+func normalizeProjectWeight(weight int) int {
+	if weight <= 0 {
+		return 1
+	}
+	return weight
+}
+
+func nonNegative(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -138,8 +138,11 @@ func (s *globalScheduler) SelectProject(ctx context.Context, req ProjectSelectio
 }
 
 func (s *globalScheduler) RecordProjectDispatch(ctx context.Context, dispatch ProjectDispatch) error {
-	if s.mode != ModeFairShare || s.fairShareStore == nil {
+	if s.mode != ModeFairShare {
 		return nil
+	}
+	if s.fairShareStore == nil {
+		return ErrFairShareStoreRequired
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -277,19 +280,21 @@ func (s *globalScheduler) selectRoundRobin(candidates []ProjectCandidate) Projec
 }
 
 func (s *globalScheduler) selectFairShare(ctx context.Context, candidates []ProjectCandidate) (ProjectSelection, error) {
+	if s.fairShareStore == nil {
+		return ProjectSelection{}, ErrFairShareStoreRequired
+	}
+
 	usageByProject := map[string]store.FairShareUsage{}
-	if s.fairShareStore != nil {
-		usage, err := s.fairShareStore.ListFairShareUsage(ctx)
-		if err != nil {
-			return ProjectSelection{}, fmt.Errorf("read fair-share usage: %w", err)
+	usage, err := s.fairShareStore.ListFairShareUsage(ctx)
+	if err != nil {
+		return ProjectSelection{}, fmt.Errorf("read fair-share usage: %w", err)
+	}
+	for _, item := range usage {
+		projectID := normalizeProjectID(item.ProjectID)
+		if projectID == "" {
+			continue
 		}
-		for _, item := range usage {
-			projectID := normalizeProjectID(item.ProjectID)
-			if projectID == "" {
-				continue
-			}
-			usageByProject[projectID] = item
-		}
+		usageByProject[projectID] = item
 	}
 
 	selected := candidates[0]

--- a/internal/scheduler/global_test.go
+++ b/internal/scheduler/global_test.go
@@ -1,0 +1,226 @@
+package scheduler_test
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/scheduler"
+	"github.com/digitaldrywood/symphony-go/internal/store"
+)
+
+func TestWeightedFairSelectProjectConvergesToWeights(t *testing.T) {
+	t.Parallel()
+
+	global := newGlobalScheduler(t, scheduler.Config{Kind: "weighted_fair", Capacity: 1})
+	request := scheduler.ProjectSelectionRequest{
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "alpha", Weight: 3},
+			{ID: "beta", Weight: 1},
+		},
+	}
+
+	counts := map[string]int{}
+	for range 8 {
+		selection, err := global.SelectProject(context.Background(), request)
+		if err != nil {
+			t.Fatalf("SelectProject() error = %v", err)
+		}
+		counts[selection.Project.ID]++
+	}
+
+	want := map[string]int{"alpha": 6, "beta": 2}
+	if !reflect.DeepEqual(counts, want) {
+		t.Fatalf("selection counts = %#v, want %#v", counts, want)
+	}
+}
+
+func TestWeightedFairAppliesDecay(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	global := newGlobalScheduler(t, scheduler.Config{
+		Kind:          "weighted_fair",
+		Capacity:      1,
+		DecayHalfLife: time.Second,
+	})
+	request := scheduler.ProjectSelectionRequest{
+		Now: now,
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "alpha", Weight: 1},
+			{ID: "beta", Weight: 1},
+		},
+	}
+
+	first, err := global.SelectProject(context.Background(), request)
+	if err != nil {
+		t.Fatalf("SelectProject() first error = %v", err)
+	}
+	if first.Project.ID != "alpha" {
+		t.Fatalf("first project = %q, want alpha", first.Project.ID)
+	}
+
+	request.Now = now.Add(10 * time.Second)
+	second, err := global.SelectProject(context.Background(), request)
+	if err != nil {
+		t.Fatalf("SelectProject() second error = %v", err)
+	}
+	if second.Project.ID != "alpha" {
+		t.Fatalf("second project = %q, want alpha after decay", second.Project.ID)
+	}
+}
+
+func TestStrictPriorityReportsPreemption(t *testing.T) {
+	t.Parallel()
+
+	global := newGlobalScheduler(t, scheduler.Config{Kind: "strict", Capacity: 1})
+	request := scheduler.ProjectSelectionRequest{
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "urgent", Priority: 1},
+		},
+		Running: []scheduler.RunningProject{
+			{ProjectID: "background", Priority: 4},
+		},
+	}
+
+	selection, err := global.SelectProject(context.Background(), request)
+	if err != nil {
+		t.Fatalf("SelectProject() error = %v", err)
+	}
+	if selection.Project.ID != "urgent" {
+		t.Fatalf("selected project = %q, want urgent", selection.Project.ID)
+	}
+	if len(selection.Preemptions) != 1 || selection.Preemptions[0].ProjectID != "background" {
+		t.Fatalf("preemptions = %#v, want background", selection.Preemptions)
+	}
+}
+
+func TestStrictPriorityRejectsCandidateThatCannotPreempt(t *testing.T) {
+	t.Parallel()
+
+	global := newGlobalScheduler(t, scheduler.Config{Kind: "strict", Capacity: 1})
+	_, err := global.SelectProject(context.Background(), scheduler.ProjectSelectionRequest{
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "low", Priority: 4},
+		},
+		Running: []scheduler.RunningProject{
+			{ProjectID: "urgent", Priority: 1},
+		},
+	})
+	if !errors.Is(err, scheduler.ErrNoSlots) {
+		t.Fatalf("SelectProject() error = %v, want ErrNoSlots", err)
+	}
+}
+
+func TestRoundRobinRotatesProjects(t *testing.T) {
+	t.Parallel()
+
+	global := newGlobalScheduler(t, scheduler.Config{Kind: "round_robin", Capacity: 1})
+	request := scheduler.ProjectSelectionRequest{
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "alpha"},
+			{ID: "beta"},
+			{ID: "gamma"},
+		},
+	}
+
+	var got []string
+	for range 5 {
+		selection, err := global.SelectProject(context.Background(), request)
+		if err != nil {
+			t.Fatalf("SelectProject() error = %v", err)
+		}
+		got = append(got, selection.Project.ID)
+	}
+
+	want := []string{"alpha", "beta", "gamma", "alpha", "beta"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("selected projects = %#v, want %#v", got, want)
+	}
+}
+
+func TestFairShareUsesPersistedUsage(t *testing.T) {
+	t.Parallel()
+
+	store := &fairShareStore{
+		usage: []store.FairShareUsage{
+			{ProjectID: "alpha", Dispatches: 10, RuntimeSeconds: 100},
+			{ProjectID: "beta", Dispatches: 1, RuntimeSeconds: 10},
+		},
+	}
+	global := newGlobalScheduler(t, scheduler.Config{
+		Kind:           "fair_share",
+		Capacity:       1,
+		FairShareStore: store,
+	})
+
+	selection, err := global.SelectProject(context.Background(), scheduler.ProjectSelectionRequest{
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "alpha", Weight: 1},
+			{ID: "beta", Weight: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("SelectProject() error = %v", err)
+	}
+	if selection.Project.ID != "beta" {
+		t.Fatalf("selected project = %q, want beta", selection.Project.ID)
+	}
+
+	if err := global.RecordProjectDispatch(context.Background(), scheduler.ProjectDispatch{
+		ProjectID:      selection.Project.ID,
+		Weight:         2,
+		RuntimeSeconds: 30,
+		DispatchedAt:   time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("RecordProjectDispatch() error = %v", err)
+	}
+	if len(store.records) != 1 || store.records[0].ProjectID != "beta" {
+		t.Fatalf("recorded dispatches = %#v, want beta", store.records)
+	}
+}
+
+func TestSelectProjectRejectsEmptyCandidateSet(t *testing.T) {
+	t.Parallel()
+
+	global := newGlobalScheduler(t, scheduler.Config{Kind: "weighted_fair", Capacity: 1})
+	_, err := global.SelectProject(context.Background(), scheduler.ProjectSelectionRequest{
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "paused", Paused: true},
+			{ID: " "},
+		},
+	})
+	if !errors.Is(err, scheduler.ErrNoCandidates) {
+		t.Fatalf("SelectProject() error = %v, want ErrNoCandidates", err)
+	}
+}
+
+func newGlobalScheduler(t *testing.T, cfg scheduler.Config) scheduler.GlobalScheduler {
+	t.Helper()
+
+	sched, err := scheduler.NewFromConfig(cfg)
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+	global, ok := sched.(scheduler.GlobalScheduler)
+	if !ok {
+		t.Fatalf("NewFromConfig() returned %T, want GlobalScheduler", sched)
+	}
+	return global
+}
+
+type fairShareStore struct {
+	usage   []store.FairShareUsage
+	records []store.FairShareDispatch
+}
+
+func (s *fairShareStore) ListFairShareUsage(context.Context) ([]store.FairShareUsage, error) {
+	return append([]store.FairShareUsage(nil), s.usage...), nil
+}
+
+func (s *fairShareStore) RecordFairShareDispatch(_ context.Context, record store.FairShareDispatch) error {
+	s.records = append(s.records, record)
+	return nil
+}

--- a/internal/scheduler/global_test.go
+++ b/internal/scheduler/global_test.go
@@ -182,6 +182,28 @@ func TestFairShareUsesPersistedUsage(t *testing.T) {
 	}
 }
 
+func TestFairShareRequiresStore(t *testing.T) {
+	t.Parallel()
+
+	global := scheduler.NewFairShare(scheduler.Config{Capacity: 1})
+	_, err := global.SelectProject(context.Background(), scheduler.ProjectSelectionRequest{
+		Projects: []scheduler.ProjectCandidate{
+			{ID: "alpha"},
+			{ID: "beta"},
+		},
+	})
+	if !errors.Is(err, scheduler.ErrFairShareStoreRequired) {
+		t.Fatalf("SelectProject() error = %v, want ErrFairShareStoreRequired", err)
+	}
+
+	err = global.RecordProjectDispatch(context.Background(), scheduler.ProjectDispatch{
+		ProjectID: "alpha",
+	})
+	if !errors.Is(err, scheduler.ErrFairShareStoreRequired) {
+		t.Fatalf("RecordProjectDispatch() error = %v, want ErrFairShareStoreRequired", err)
+	}
+}
+
 func TestSelectProjectRejectsEmptyCandidateSet(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -6,12 +6,17 @@ import (
 	"fmt"
 	"strings"
 	"sync"
+	"time"
 )
 
 const defaultCapacity = 1
 
 const (
 	ModeCountingSemaphore Mode = "counting_semaphore"
+	ModeWeightedFair      Mode = "weighted_fair"
+	ModeStrictPriority    Mode = "strict_priority"
+	ModeRoundRobin        Mode = "round_robin"
+	ModeFairShare         Mode = "fair_share"
 )
 
 var (
@@ -35,6 +40,8 @@ type Config struct {
 	Capacity        int
 	CapacityByState map[string]int
 	CapacityPerHost int
+	DecayHalfLife   time.Duration
+	FairShareStore  FairShareStore
 }
 
 type SlotRequest struct {
@@ -72,7 +79,15 @@ var _ Scheduler = (*CountingSemaphore)(nil)
 
 func NewFromConfig(cfg Config) (Scheduler, error) {
 	switch normalizeKind(cfg.Kind) {
-	case "", "counting_semaphore", "semaphore":
+	case "", "weighted", "weighted_fair", "weightedfair":
+		return NewWeightedFair(cfg), nil
+	case "strict", "strict_priority", "strictpriority":
+		return NewStrictPriority(cfg), nil
+	case "round_robin", "roundrobin":
+		return NewRoundRobin(cfg), nil
+	case "fair_share", "fairshare":
+		return NewFairShare(cfg), nil
+	case "counting_semaphore", "semaphore":
 		return NewCountingSemaphore(cfg), nil
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, strings.TrimSpace(cfg.Kind))
@@ -266,7 +281,9 @@ func cloneIntMap(values map[string]int) map[string]int {
 }
 
 func normalizeKind(kind string) string {
-	return strings.ToLower(strings.TrimSpace(kind))
+	kind = strings.ToLower(strings.TrimSpace(kind))
+	kind = strings.ReplaceAll(kind, "-", "_")
+	return kind
 }
 
 func normalizeState(state string) string {

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -20,11 +20,12 @@ const (
 )
 
 var (
-	ErrInvalidWeight         = errors.New("scheduler slot weight must be positive")
-	ErrNoSlots               = errors.New("scheduler slot unavailable")
-	ErrSlotNotHeld           = errors.New("scheduler slot is not held")
-	ErrUnsupportedBackend    = errors.New("unsupported scheduler backend")
-	ErrWeightExceedsCapacity = errors.New("scheduler slot weight exceeds capacity")
+	ErrInvalidWeight          = errors.New("scheduler slot weight must be positive")
+	ErrNoSlots                = errors.New("scheduler slot unavailable")
+	ErrSlotNotHeld            = errors.New("scheduler slot is not held")
+	ErrFairShareStoreRequired = errors.New("fair-share scheduler requires a store")
+	ErrUnsupportedBackend     = errors.New("unsupported scheduler backend")
+	ErrWeightExceedsCapacity  = errors.New("scheduler slot weight exceeds capacity")
 )
 
 type Mode string
@@ -86,6 +87,9 @@ func NewFromConfig(cfg Config) (Scheduler, error) {
 	case "round_robin", "roundrobin":
 		return NewRoundRobin(cfg), nil
 	case "fair_share", "fairshare":
+		if cfg.FairShareStore == nil {
+			return nil, ErrFairShareStoreRequired
+		}
 		return NewFairShare(cfg), nil
 	case "counting_semaphore", "semaphore":
 		return NewCountingSemaphore(cfg), nil

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -10,16 +10,24 @@ import (
 	"github.com/digitaldrywood/symphony-go/internal/scheduler"
 )
 
-func TestNewFromConfigReturnsCountingSemaphore(t *testing.T) {
+func TestNewFromConfigSelectsMode(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
 		name string
 		kind string
+		want scheduler.Mode
 	}{
-		{name: "empty defaults to counting semaphore", kind: ""},
-		{name: "counting semaphore", kind: "counting_semaphore"},
-		{name: "semaphore alias", kind: " semaphore "},
+		{name: "empty defaults to weighted fair", kind: "", want: scheduler.ModeWeightedFair},
+		{name: "weighted fair", kind: "weighted_fair", want: scheduler.ModeWeightedFair},
+		{name: "weighted alias", kind: " weighted ", want: scheduler.ModeWeightedFair},
+		{name: "strict priority", kind: "strict_priority", want: scheduler.ModeStrictPriority},
+		{name: "strict alias", kind: "strict", want: scheduler.ModeStrictPriority},
+		{name: "round robin", kind: "round_robin", want: scheduler.ModeRoundRobin},
+		{name: "round-robin alias", kind: "round-robin", want: scheduler.ModeRoundRobin},
+		{name: "fair share", kind: "fair_share", want: scheduler.ModeFairShare},
+		{name: "fair-share alias", kind: "fair-share", want: scheduler.ModeFairShare},
+		{name: "counting semaphore compatibility", kind: "counting_semaphore", want: scheduler.ModeCountingSemaphore},
 	}
 
 	for _, tt := range tests {
@@ -33,8 +41,8 @@ func TestNewFromConfigReturnsCountingSemaphore(t *testing.T) {
 			if err != nil {
 				t.Fatalf("NewFromConfig() error = %v", err)
 			}
-			if got.Mode() != scheduler.ModeCountingSemaphore {
-				t.Fatalf("Mode() = %q, want %q", got.Mode(), scheduler.ModeCountingSemaphore)
+			if got.Mode() != tt.want {
+				t.Fatalf("Mode() = %q, want %q", got.Mode(), tt.want)
 			}
 		})
 	}

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -35,8 +35,9 @@ func TestNewFromConfigSelectsMode(t *testing.T) {
 			t.Parallel()
 
 			got, err := scheduler.NewFromConfig(scheduler.Config{
-				Kind:     tt.kind,
-				Capacity: 2,
+				Kind:           tt.kind,
+				Capacity:       2,
+				FairShareStore: &fairShareStore{},
 			})
 			if err != nil {
 				t.Fatalf("NewFromConfig() error = %v", err)
@@ -45,6 +46,18 @@ func TestNewFromConfigSelectsMode(t *testing.T) {
 				t.Fatalf("Mode() = %q, want %q", got.Mode(), tt.want)
 			}
 		})
+	}
+}
+
+func TestNewFromConfigRejectsFairShareWithoutStore(t *testing.T) {
+	t.Parallel()
+
+	got, err := scheduler.NewFromConfig(scheduler.Config{Kind: "fair_share"})
+	if got != nil {
+		t.Fatalf("scheduler = %T, want nil", got)
+	}
+	if !errors.Is(err, scheduler.ErrFairShareStoreRequired) {
+		t.Fatalf("error = %v, want ErrFairShareStoreRequired", err)
 	}
 }
 

--- a/internal/store/migrations/00002_create_fair_share_usage.sql
+++ b/internal/store/migrations/00002_create_fair_share_usage.sql
@@ -1,0 +1,11 @@
+-- +goose Up
+CREATE TABLE fair_share_usage (
+  project_id TEXT PRIMARY KEY,
+  weight INTEGER NOT NULL DEFAULT 1,
+  dispatches INTEGER NOT NULL DEFAULT 0,
+  runtime_seconds INTEGER NOT NULL DEFAULT 0,
+  updated_at TEXT NOT NULL
+);
+
+-- +goose Down
+DROP TABLE IF EXISTS fair_share_usage;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -25,6 +25,14 @@ type CodexSession struct {
 	Model          sql.NullString `json:"model"`
 }
 
+type FairShareUsage struct {
+	ProjectID      string `json:"project_id"`
+	Weight         int64  `json:"weight"`
+	Dispatches     int64  `json:"dispatches"`
+	RuntimeSeconds int64  `json:"runtime_seconds"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
 type SymphonyRun struct {
 	ID                   int64          `json:"id"`
 	StartedAt            string         `json:"started_at"`

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -339,6 +339,46 @@ func (q *Queries) IssueTokenSpend(ctx context.Context, arg IssueTokenSpendParams
 	return items, nil
 }
 
+const listFairShareUsage = `-- name: ListFairShareUsage :many
+SELECT
+  project_id,
+  weight,
+  dispatches,
+  runtime_seconds,
+  updated_at
+FROM fair_share_usage
+ORDER BY project_id
+`
+
+func (q *Queries) ListFairShareUsage(ctx context.Context) ([]FairShareUsage, error) {
+	rows, err := q.db.QueryContext(ctx, listFairShareUsage)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []FairShareUsage{}
+	for rows.Next() {
+		var i FairShareUsage
+		if err := rows.Scan(
+			&i.ProjectID,
+			&i.Weight,
+			&i.Dispatches,
+			&i.RuntimeSeconds,
+			&i.UpdatedAt,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
 SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model
 FROM codex_sessions
@@ -425,4 +465,45 @@ func (q *Queries) UpdateSymphonyRun(ctx context.Context, arg UpdateSymphonyRunPa
 		return 0, err
 	}
 	return result.RowsAffected()
+}
+
+const upsertFairShareUsage = `-- name: UpsertFairShareUsage :one
+INSERT INTO fair_share_usage (
+  project_id,
+  weight,
+  dispatches,
+  runtime_seconds,
+  updated_at
+) VALUES (?, ?, 1, ?, ?)
+ON CONFLICT(project_id) DO UPDATE SET
+  weight = excluded.weight,
+  dispatches = fair_share_usage.dispatches + excluded.dispatches,
+  runtime_seconds = fair_share_usage.runtime_seconds + excluded.runtime_seconds,
+  updated_at = excluded.updated_at
+RETURNING project_id, weight, dispatches, runtime_seconds, updated_at
+`
+
+type UpsertFairShareUsageParams struct {
+	ProjectID      string `json:"project_id"`
+	Weight         int64  `json:"weight"`
+	RuntimeSeconds int64  `json:"runtime_seconds"`
+	UpdatedAt      string `json:"updated_at"`
+}
+
+func (q *Queries) UpsertFairShareUsage(ctx context.Context, arg UpsertFairShareUsageParams) (FairShareUsage, error) {
+	row := q.db.QueryRowContext(ctx, upsertFairShareUsage,
+		arg.ProjectID,
+		arg.Weight,
+		arg.RuntimeSeconds,
+		arg.UpdatedAt,
+	)
+	var i FairShareUsage
+	err := row.Scan(
+		&i.ProjectID,
+		&i.Weight,
+		&i.Dispatches,
+		&i.RuntimeSeconds,
+		&i.UpdatedAt,
+	)
+	return i, err
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -233,6 +233,52 @@ func (s *sqliteStore) IssueTokenSpend(ctx context.Context, identity IssueIdentit
 	return spend, nil
 }
 
+func (s *sqliteStore) ListFairShareUsage(ctx context.Context) ([]FairShareUsage, error) {
+	rows, err := s.queries.ListFairShareUsage(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("reading fair-share usage: %w", err)
+	}
+
+	usage := make([]FairShareUsage, 0, len(rows))
+	for _, row := range rows {
+		updatedAt, err := parseTimestamp("updated_at", row.UpdatedAt)
+		if err != nil {
+			return nil, err
+		}
+		usage = append(usage, FairShareUsage{
+			ProjectID:      row.ProjectID,
+			Weight:         int(row.Weight),
+			Dispatches:     row.Dispatches,
+			RuntimeSeconds: row.RuntimeSeconds,
+			UpdatedAt:      updatedAt,
+		})
+	}
+	return usage, nil
+}
+
+func (s *sqliteStore) RecordFairShareDispatch(ctx context.Context, attrs FairShareDispatch) error {
+	projectID := strings.TrimSpace(attrs.ProjectID)
+	if projectID == "" {
+		return errors.New("project_id is required")
+	}
+
+	dispatchedAt, err := requiredTimestamp("dispatched_at", attrs.DispatchedAt)
+	if err != nil {
+		return err
+	}
+
+	_, err = s.queries.UpsertFairShareUsage(ctx, sqlc.UpsertFairShareUsageParams{
+		ProjectID:      projectID,
+		Weight:         int64(positiveWeight(attrs.Weight)),
+		RuntimeSeconds: nonNegative(attrs.RuntimeSeconds),
+		UpdatedAt:      dispatchedAt,
+	})
+	if err != nil {
+		return fmt.Errorf("recording fair-share dispatch: %w", err)
+	}
+	return nil
+}
+
 func normalizeIssueIdentity(identity IssueIdentity) IssueIdentity {
 	return IssueIdentity{
 		IssueID:    strings.TrimSpace(identity.IssueID),
@@ -271,6 +317,18 @@ func dateString(value time.Time) (string, error) {
 	return value.Format("2006-01-02"), nil
 }
 
+func parseTimestamp(name string, value string) (time.Time, error) {
+	if strings.TrimSpace(value) == "" {
+		return time.Time{}, fmt.Errorf("%s is required", name)
+	}
+
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse %s: %w", name, err)
+	}
+	return parsed, nil
+}
+
 func nullString(value string) sql.NullString {
 	trimmed := strings.TrimSpace(value)
 	if trimmed == "" {
@@ -289,6 +347,13 @@ func nullInt64(value int64) sql.NullInt64 {
 func nonNegative(value int64) int64 {
 	if value < 0 {
 		return 0
+	}
+	return value
+}
+
+func positiveWeight(value int) int {
+	if value <= 0 {
+		return 1
 	}
 	return value
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -25,6 +25,7 @@ type Config struct {
 
 type Store interface {
 	StatsStore
+	FairShareStore
 	Queries() *sqlc.Queries
 	Close() error
 }
@@ -37,6 +38,11 @@ type StatsStore interface {
 	FinishSession(context.Context, int64, SessionFinish) error
 	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
 	IssueTokenSpend(context.Context, IssueIdentity) (TokenSpend, error)
+}
+
+type FairShareStore interface {
+	ListFairShareUsage(context.Context) ([]FairShareUsage, error)
+	RecordFairShareDispatch(context.Context, FairShareDispatch) error
 }
 
 type RunStart struct {
@@ -110,6 +116,21 @@ type ModelTokenSpend struct {
 	OutputTokens int64
 	TotalTokens  int64
 	Sessions     int64
+}
+
+type FairShareUsage struct {
+	ProjectID      string
+	Weight         int
+	Dispatches     int64
+	RuntimeSeconds int64
+	UpdatedAt      time.Time
+}
+
+type FairShareDispatch struct {
+	ProjectID      string
+	Weight         int
+	RuntimeSeconds int64
+	DispatchedAt   time.Time
 }
 
 func Open(ctx context.Context, cfg Config) (Store, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -40,8 +40,8 @@ func TestOpenSQLiteAppliesMigrationsAndPragmas(t *testing.T) {
 	if got := queryInt(t, sqliteBackend.db, "PRAGMA busy_timeout"); got != 5000 {
 		t.Fatalf("busy_timeout = %d, want 5000", got)
 	}
-	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('symphony_runs', 'codex_sessions')"); got != 2 {
-		t.Fatalf("migrated table count = %d, want 2", got)
+	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('symphony_runs', 'codex_sessions', 'fair_share_usage')"); got != 3 {
+		t.Fatalf("migrated table count = %d, want 3", got)
 	}
 }
 
@@ -257,6 +257,56 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				t.Fatalf("IssueTokenSpend(url).TotalTokens = %d, want 125", urlSpend.TotalTokens)
 			}
 		})
+	}
+}
+
+func TestFairShareStoreRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	dispatchedAt := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+
+	if err := backend.RecordFairShareDispatch(ctx, FairShareDispatch{
+		ProjectID:      " alpha ",
+		Weight:         2,
+		RuntimeSeconds: 30,
+		DispatchedAt:   dispatchedAt,
+	}); err != nil {
+		t.Fatalf("RecordFairShareDispatch() first error = %v", err)
+	}
+	if err := backend.RecordFairShareDispatch(ctx, FairShareDispatch{
+		ProjectID:      "alpha",
+		Weight:         2,
+		RuntimeSeconds: 45,
+		DispatchedAt:   dispatchedAt.Add(time.Minute),
+	}); err != nil {
+		t.Fatalf("RecordFairShareDispatch() second error = %v", err)
+	}
+
+	usage, err := backend.ListFairShareUsage(ctx)
+	if err != nil {
+		t.Fatalf("ListFairShareUsage() error = %v", err)
+	}
+	if len(usage) != 1 {
+		t.Fatalf("usage len = %d, want 1: %#v", len(usage), usage)
+	}
+
+	got := usage[0]
+	if got.ProjectID != "alpha" {
+		t.Fatalf("ProjectID = %q, want alpha", got.ProjectID)
+	}
+	if got.Weight != 2 {
+		t.Fatalf("Weight = %d, want 2", got.Weight)
+	}
+	if got.Dispatches != 2 {
+		t.Fatalf("Dispatches = %d, want 2", got.Dispatches)
+	}
+	if got.RuntimeSeconds != 75 {
+		t.Fatalf("RuntimeSeconds = %d, want 75", got.RuntimeSeconds)
+	}
+	if !got.UpdatedAt.Equal(dispatchedAt.Add(time.Minute)) {
+		t.Fatalf("UpdatedAt = %s, want %s", got.UpdatedAt, dispatchedAt.Add(time.Minute))
 	}
 }
 


### PR DESCRIPTION
## Summary
- add a global scheduler API with weighted-fair, strict-priority, round-robin, and fair-share modes
- make weighted-fair the default scheduler mode while keeping counting semaphore compatibility
- add fair-share usage persistence through sqlite/sqlc and focused scheduler/store tests

Fixes #32

## Test Plan
- go test ./internal/scheduler
- go test ./internal/store ./internal/scheduler
- go test ./internal/project
- go test ./...
- make generate
- make check