### PR TITLE
feat(cli): add global admin commands

### DIFF
--- a/cmd/symphony/main.go
+++ b/cmd/symphony/main.go
@@ -9,6 +9,8 @@ import (
 	"syscall"
 
 	"github.com/spf13/cobra"
+
+	"github.com/digitaldrywood/symphony-go/internal/cli"
 )
 
 func main() {
@@ -29,18 +31,7 @@ func main() {
 }
 
 func newRootCommand(ctx context.Context) *cobra.Command {
-	cmd := &cobra.Command{
-		Use:          "symphony",
-		Short:        "Symphony agent orchestrator",
-		Long:         "Symphony is an agent orchestrator for tracker-backed work queues.",
-		SilenceUsage: true,
-		RunE: func(cmd *cobra.Command, _ []string) error {
-			return cmd.Help()
-		},
-	}
-	cmd.SetContext(ctx)
-
-	return cmd
+	return cli.NewRootCommand(ctx)
 }
 
 func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/cmd/symphony/main_test.go
+++ b/cmd/symphony/main_test.go
@@ -28,7 +28,9 @@ func TestRootCommandHelp(t *testing.T) {
 	}
 }
 
-func TestRootCommandWithoutArgsShowsHelp(t *testing.T) {
+func TestRootCommandWithoutArgsBootsFromGlobalConfig(t *testing.T) {
+	t.Setenv("SYMPHONY_HOME", t.TempDir())
+
 	cmd := newRootCommand(context.Background())
 
 	var stdout bytes.Buffer
@@ -36,12 +38,12 @@ func TestRootCommandWithoutArgsShowsHelp(t *testing.T) {
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{})
 
-	if err := cmd.Execute(); err != nil {
-		t.Fatalf("Execute() error = %v", err)
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing global config")
 	}
-
-	if !strings.Contains(stdout.String(), "Usage:") {
-		t.Fatalf("expected usage output, got:\n%s", stdout.String())
+	if !strings.Contains(err.Error(), "read global config") {
+		t.Fatalf("Execute() error = %v, want missing global config", err)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1,0 +1,418 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/project"
+)
+
+var (
+	ErrConfigExists    = errors.New("global config already exists")
+	ErrProjectExists   = errors.New("project already exists")
+	ErrProjectNotFound = errors.New("project not found")
+)
+
+type Operation string
+
+const (
+	OperationInit           Operation = "init"
+	OperationAddProject     Operation = "add-project"
+	OperationPauseProject   Operation = "pause"
+	OperationUnpauseProject Operation = "unpause"
+	OperationPromoteProject Operation = "promote"
+	OperationRemoveProject  Operation = "remove-project"
+)
+
+type Signal struct {
+	Operation Operation
+	ProjectID string
+	Project   globalconfig.Project
+}
+
+type BootFunc func(context.Context, globalconfig.Config) error
+
+type SignalFunc func(context.Context, Signal) error
+
+type ProjectManager interface {
+	Add(context.Context, globalconfig.Project) error
+	Remove(context.Context, project.ProjectID) error
+	Pause(context.Context, project.ProjectID) error
+	Unpause(context.Context, project.ProjectID) error
+}
+
+type Option func(*options)
+
+type options struct {
+	defaultPath   func() (string, error)
+	read          func(string) (globalconfig.Config, error)
+	readOrDefault func(string) (globalconfig.Config, error)
+	write         func(string, globalconfig.Config) error
+	boot          BootFunc
+	signal        SignalFunc
+}
+
+func WithBootFunc(boot BootFunc) Option {
+	return func(opts *options) {
+		if boot != nil {
+			opts.boot = boot
+		}
+	}
+}
+
+func WithSignalFunc(signal SignalFunc) Option {
+	return func(opts *options) {
+		if signal != nil {
+			opts.signal = signal
+		}
+	}
+}
+
+func WithProjectManager(manager ProjectManager) Option {
+	return func(opts *options) {
+		opts.signal = ProjectManagerSignalFunc(manager)
+	}
+}
+
+func ProjectManagerSignalFunc(manager ProjectManager) SignalFunc {
+	if manager == nil {
+		return noSignal
+	}
+
+	return func(ctx context.Context, signal Signal) error {
+		switch signal.Operation {
+		case OperationAddProject:
+			return manager.Add(ctx, signal.Project)
+		case OperationRemoveProject:
+			return manager.Remove(ctx, project.ProjectID(signal.ProjectID))
+		case OperationPauseProject:
+			return manager.Pause(ctx, project.ProjectID(signal.ProjectID))
+		case OperationUnpauseProject:
+			return manager.Unpause(ctx, project.ProjectID(signal.ProjectID))
+		default:
+			return nil
+		}
+	}
+}
+
+func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
+	opts := defaultOptions()
+	for _, opt := range optFns {
+		opt(&opts)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	var configPath string
+	cmd := &cobra.Command{
+		Use:          "symphony",
+		Short:        "Symphony agent orchestrator",
+		Long:         "Symphony is an agent orchestrator for tracker-backed work queues.",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := resolveConfigPath(configPath, opts)
+			if err != nil {
+				return err
+			}
+			cfg, err := opts.read(path)
+			if err != nil {
+				return err
+			}
+			return opts.boot(cmd.Context(), cfg)
+		},
+	}
+	cmd.SetContext(ctx)
+	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to global.yaml")
+	cmd.AddCommand(
+		newInitCommand(&configPath, opts),
+		newAddProjectCommand(&configPath, opts),
+		newEditProjectCommand(&configPath, opts, OperationPauseProject, "pause", "Pause a project", func(project *globalconfig.Project) error {
+			project.Paused = true
+			return nil
+		}),
+		newEditProjectCommand(&configPath, opts, OperationUnpauseProject, "unpause", "Unpause a project", func(project *globalconfig.Project) error {
+			project.Paused = false
+			return nil
+		}),
+		newPromoteCommand(&configPath, opts),
+		newRemoveProjectCommand(&configPath, opts),
+	)
+
+	return cmd
+}
+
+func defaultOptions() options {
+	return options{
+		defaultPath: globalconfig.DefaultPath,
+		read: func(path string) (globalconfig.Config, error) {
+			return globalconfig.Read(path)
+		},
+		readOrDefault: func(path string) (globalconfig.Config, error) {
+			return globalconfig.ReadOrDefault(path, globalconfig.WithProjectPathLiterals())
+		},
+		write: func(path string, cfg globalconfig.Config) error {
+			return globalconfig.Write(path, cfg, globalconfig.WithProjectPathLiterals())
+		},
+		boot:   defaultBoot,
+		signal: noSignal,
+	}
+}
+
+func defaultBoot(ctx context.Context, cfg globalconfig.Config) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg), project.ManagerDependencies{
+		Logger: slog.Default(),
+	})
+	if err != nil {
+		return err
+	}
+	if err := manager.Start(ctx); err != nil {
+		return err
+	}
+
+	<-ctx.Done()
+	return ctx.Err()
+}
+
+func noSignal(context.Context, Signal) error {
+	return nil
+}
+
+func newInitCommand(configPath *string, opts options) *cobra.Command {
+	var force bool
+	cmd := &cobra.Command{
+		Use:   "init",
+		Short: "Create a default global config",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := resolveConfigPath(*configPath, opts)
+			if err != nil {
+				return err
+			}
+
+			cfg, err := globalconfig.DefaultAt(path)
+			if err != nil {
+				return err
+			}
+			path = cfg.Path
+			if err := checkInitTarget(path, force); err != nil {
+				return err
+			}
+			if err := opts.write(path, cfg); err != nil {
+				return err
+			}
+			return opts.signal(cmd.Context(), Signal{
+				Operation: OperationInit,
+			})
+		},
+	}
+	cmd.Flags().BoolVar(&force, "force", false, "overwrite an existing global config")
+	return cmd
+}
+
+func checkInitTarget(path string, force bool) error {
+	_, err := os.Stat(path)
+	if err == nil {
+		if !force {
+			return fmt.Errorf("%w: %s", ErrConfigExists, path)
+		}
+		if _, readErr := os.ReadFile(path); readErr != nil {
+			return fmt.Errorf("read existing global config %s: %w", path, readErr)
+		}
+		return nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return nil
+	}
+	return fmt.Errorf("stat global config %s: %w", path, err)
+}
+
+func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
+	var cfg globalconfig.Project
+	cmd := &cobra.Command{
+		Use:   "add-project",
+		Short: "Add a project to global config",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			path, err := resolveConfigPath(*configPath, opts)
+			if err != nil {
+				return err
+			}
+			cfg.ID = strings.TrimSpace(cfg.ID)
+			cfg.CredentialRef = strings.TrimSpace(cfg.CredentialRef)
+			if err := validateProjectFlags(cfg); err != nil {
+				return err
+			}
+
+			global, err := opts.readOrDefault(path)
+			if err != nil {
+				return err
+			}
+			if projectIndex(global.Projects, cfg.ID) >= 0 {
+				return fmt.Errorf("%w: %s", ErrProjectExists, cfg.ID)
+			}
+
+			global.Projects = append(global.Projects, cfg)
+			if err := opts.write(path, global); err != nil {
+				return err
+			}
+			return opts.signal(cmd.Context(), Signal{
+				Operation: OperationAddProject,
+				ProjectID: cfg.ID,
+				Project:   cfg,
+			})
+		},
+	}
+	cmd.Flags().StringVar(&cfg.ID, "id", "", "project id")
+	cmd.Flags().StringVar(&cfg.Workflow, "workflow", "", "project workflow path")
+	cmd.Flags().StringVar(&cfg.Workdir, "workdir", "", "project worktree root")
+	cmd.Flags().IntVar(&cfg.Weight, "weight", 1, "project scheduling weight")
+	cmd.Flags().IntVar(&cfg.Priority, "priority", 0, "project dispatch priority")
+	cmd.Flags().BoolVar(&cfg.Paused, "paused", false, "add the project in a paused state")
+	cmd.Flags().StringVar(&cfg.CredentialRef, "credential-ref", "", "project credential reference")
+	return cmd
+}
+
+func validateProjectFlags(cfg globalconfig.Project) error {
+	switch {
+	case cfg.ID == "":
+		return errors.New("project id is required")
+	case strings.TrimSpace(cfg.Workflow) == "":
+		return errors.New("project workflow is required")
+	case strings.TrimSpace(cfg.Workdir) == "":
+		return errors.New("project workdir is required")
+	case cfg.Weight <= 0:
+		return errors.New("project weight must be positive")
+	default:
+		return nil
+	}
+}
+
+type projectEdit func(*globalconfig.Project) error
+
+func newEditProjectCommand(configPath *string, opts options, operation Operation, use string, short string, edit projectEdit) *cobra.Command {
+	return &cobra.Command{
+		Use:   use + " PROJECT_ID",
+		Short: short,
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return updateProject(cmd.Context(), *configPath, opts, operation, args[0], edit)
+		},
+	}
+}
+
+func newPromoteCommand(configPath *string, opts options) *cobra.Command {
+	var priority int
+	cmd := &cobra.Command{
+		Use:   "promote PROJECT_ID",
+		Short: "Promote a project priority",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if priority <= 0 {
+				return errors.New("priority must be positive")
+			}
+			return updateProject(cmd.Context(), *configPath, opts, OperationPromoteProject, args[0], func(project *globalconfig.Project) error {
+				project.Priority = priority
+				return nil
+			})
+		},
+	}
+	cmd.Flags().IntVar(&priority, "priority", 1, "project priority rank")
+	return cmd
+}
+
+func updateProject(ctx context.Context, configPath string, opts options, operation Operation, id string, edit projectEdit) error {
+	path, err := resolveConfigPath(configPath, opts)
+	if err != nil {
+		return err
+	}
+	cfg, err := opts.readOrDefault(path)
+	if err != nil {
+		return err
+	}
+
+	id = strings.TrimSpace(id)
+	index := projectIndex(cfg.Projects, id)
+	if index < 0 {
+		return fmt.Errorf("%w: %s", ErrProjectNotFound, id)
+	}
+	if err := edit(&cfg.Projects[index]); err != nil {
+		return err
+	}
+	if err := opts.write(path, cfg); err != nil {
+		return err
+	}
+
+	return opts.signal(ctx, Signal{
+		Operation: operation,
+		ProjectID: cfg.Projects[index].ID,
+		Project:   cfg.Projects[index],
+	})
+}
+
+func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "remove-project PROJECT_ID",
+		Short: "Remove a project from global config",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			path, err := resolveConfigPath(*configPath, opts)
+			if err != nil {
+				return err
+			}
+			cfg, err := opts.readOrDefault(path)
+			if err != nil {
+				return err
+			}
+
+			id := strings.TrimSpace(args[0])
+			index := projectIndex(cfg.Projects, id)
+			if index < 0 {
+				return fmt.Errorf("%w: %s", ErrProjectNotFound, id)
+			}
+			removed := cfg.Projects[index]
+			cfg.Projects = append(cfg.Projects[:index], cfg.Projects[index+1:]...)
+			if cfg.Projects == nil {
+				cfg.Projects = []globalconfig.Project{}
+			}
+			if err := opts.write(path, cfg); err != nil {
+				return err
+			}
+
+			return opts.signal(cmd.Context(), Signal{
+				Operation: OperationRemoveProject,
+				ProjectID: removed.ID,
+				Project:   removed,
+			})
+		},
+	}
+}
+
+func resolveConfigPath(path string, opts options) (string, error) {
+	if strings.TrimSpace(path) != "" {
+		return strings.TrimSpace(path), nil
+	}
+	return opts.defaultPath()
+}
+
+func projectIndex(projects []globalconfig.Project, id string) int {
+	id = strings.TrimSpace(id)
+	for index, project := range projects {
+		if strings.TrimSpace(project.ID) == id {
+			return index
+		}
+	}
+	return -1
+}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1,0 +1,474 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/digitaldrywood/symphony-go/internal/cli"
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/project"
+)
+
+func TestRootCommandHelpListsAdminCommands(t *testing.T) {
+	t.Parallel()
+
+	cmd := cli.NewRootCommand(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--help"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{"symphony", "agent orchestrator", "init", "add-project", "pause", "unpause", "promote", "remove-project"} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("help output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestRootCommandBootsFromGlobalConfig(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	writeGlobalConfig(t, path, nil)
+
+	booted := make(chan globalconfig.Config, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg globalconfig.Config) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", path})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if got.Path != path {
+		t.Fatalf("booted config path = %q, want %q", got.Path, path)
+	}
+}
+
+func TestInitWritesDefaultGlobalConfig(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".symphony", "global.yaml")
+	cmd := cli.NewRootCommand(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", path, "init"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	cfg, err := globalconfig.Read(path)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if cfg.APIVersion != globalconfig.APIVersion || cfg.Kind != globalconfig.Kind {
+		t.Fatalf("config identity = %s/%s", cfg.APIVersion, cfg.Kind)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("Projects = %#v, want empty", cfg.Projects)
+	}
+}
+
+func TestInitRefusesExistingConfigWithoutForce(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	writeGlobalConfig(t, path, nil)
+
+	cmd := cli.NewRootCommand(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", path, "init"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "already exists") {
+		t.Fatalf("Execute() error = %v, want already exists", err)
+	}
+}
+
+func TestAddProjectWritesConfigAndSignalsManager(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	signals := make(chan cli.Signal, 1)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithSignalFunc(func(_ context.Context, signal cli.Signal) error {
+		signals <- signal
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"add-project",
+		"--id", " symphony ",
+		"--workflow", paths.workflowPath,
+		"--workdir", paths.workdirPath,
+		"--weight", "5",
+		"--priority", "50",
+		"--paused",
+		"--credential-ref", " github-default ",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	cfg, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("Projects length = %d, want 1", len(cfg.Projects))
+	}
+	got := cfg.Projects[0]
+	want := globalconfig.Project{
+		ID:            "symphony",
+		Workflow:      paths.workflowPath,
+		Workdir:       paths.workdirPath,
+		Weight:        5,
+		Priority:      50,
+		Paused:        true,
+		CredentialRef: "github-default",
+	}
+	if got != want {
+		t.Fatalf("project = %#v, want %#v", got, want)
+	}
+
+	signal := <-signals
+	if signal.Operation != cli.OperationAddProject || signal.Project != want {
+		t.Fatalf("signal = %#v, want add project %#v", signal, want)
+	}
+}
+
+func TestProjectAdminCommandsEditConfigAndSignalManager(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{
+		{
+			ID:       "symphony",
+			Workflow: paths.workflowPath,
+			Workdir:  paths.workdirPath,
+			Weight:   2,
+			Priority: 4,
+		},
+	})
+
+	signals := make(chan cli.Signal, 4)
+	runCommand := func(args ...string) {
+		t.Helper()
+
+		allArgs := append([]string{"--config", configPath}, args...)
+		cmd := cli.NewRootCommand(context.Background(), cli.WithSignalFunc(func(_ context.Context, signal cli.Signal) error {
+			signals <- signal
+			return nil
+		}))
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs(allArgs)
+
+		if err := cmd.Execute(); err != nil {
+			t.Fatalf("Execute(%v) error = %v", args, err)
+		}
+	}
+
+	runCommand("pause", "symphony")
+	assertProject(t, configPath, "symphony", func(project globalconfig.Project) {
+		if !project.Paused {
+			t.Fatal("Paused = false, want true")
+		}
+	})
+	assertSignal(t, signals, cli.OperationPauseProject, "symphony")
+
+	runCommand("unpause", "symphony")
+	assertProject(t, configPath, "symphony", func(project globalconfig.Project) {
+		if project.Paused {
+			t.Fatal("Paused = true, want false")
+		}
+	})
+	assertSignal(t, signals, cli.OperationUnpauseProject, "symphony")
+
+	runCommand("promote", "symphony", "--priority", "1")
+	assertProject(t, configPath, "symphony", func(project globalconfig.Project) {
+		if project.Priority != 1 {
+			t.Fatalf("Priority = %d, want 1", project.Priority)
+		}
+	})
+	assertSignal(t, signals, cli.OperationPromoteProject, "symphony")
+
+	runCommand("remove-project", "symphony")
+	cfg, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("Projects = %#v, want empty", cfg.Projects)
+	}
+	assertSignal(t, signals, cli.OperationRemoveProject, "symphony")
+}
+
+func TestProjectAdminCommandsPreserveProjectPathLiterals(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	if err := os.WriteFile(configPath, []byte(`apiVersion: symphony/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects:
+  - id: symphony
+    workflow: cli.go
+    workdir: .
+    weight: 1
+    priority: 0
+  - id: docs
+    workflow: cli.go
+    workdir: .
+    weight: 2
+    priority: 1
+`), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cmd := cli.NewRootCommand(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", configPath, "pause", "symphony"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+
+	var written struct {
+		Projects []struct {
+			ID       string `yaml:"id"`
+			Workflow string `yaml:"workflow"`
+			Workdir  string `yaml:"workdir"`
+			Paused   bool   `yaml:"paused"`
+		} `yaml:"projects"`
+	}
+	if err := yaml.Unmarshal(raw, &written); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if len(written.Projects) != 2 {
+		t.Fatalf("Projects length = %d, want 2", len(written.Projects))
+	}
+	for _, project := range written.Projects {
+		if project.Workflow != "cli.go" {
+			t.Fatalf("project %s workflow = %q, want cli.go", project.ID, project.Workflow)
+		}
+		if project.Workdir != "." {
+			t.Fatalf("project %s workdir = %q, want .", project.ID, project.Workdir)
+		}
+	}
+	if !written.Projects[0].Paused {
+		t.Fatal("symphony Paused = false, want true")
+	}
+	if written.Projects[1].Paused {
+		t.Fatal("docs Paused = true, want false")
+	}
+}
+
+func TestProjectAdminCommandsRejectMissingProject(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	writeGlobalConfig(t, configPath, nil)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithSignalFunc(func(context.Context, cli.Signal) error {
+		t.Fatal("signal should not be emitted")
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", configPath, "pause", "missing"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+	if !errors.Is(err, cli.ErrProjectNotFound) {
+		t.Fatalf("Execute() error = %v, want %v", err, cli.ErrProjectNotFound)
+	}
+}
+
+func TestAddProjectRejectsDuplicateID(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "symphony", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
+	})
+
+	cmd := cli.NewRootCommand(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"add-project",
+		"--id", "symphony",
+		"--workflow", paths.workflowPath,
+		"--workdir", paths.workdirPath,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want error")
+	}
+	if !errors.Is(err, cli.ErrProjectExists) {
+		t.Fatalf("Execute() error = %v, want %v", err, cli.ErrProjectExists)
+	}
+}
+
+func TestWithProjectManagerSignalsLiveManager(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	manager := &projectManagerProbe{}
+	cmd := cli.NewRootCommand(context.Background(), cli.WithProjectManager(manager))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"add-project",
+		"--id", "symphony",
+		"--workflow", paths.workflowPath,
+		"--workdir", paths.workdirPath,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if manager.added.ID != "symphony" {
+		t.Fatalf("added project = %#v, want symphony", manager.added)
+	}
+}
+
+type projectPaths struct {
+	root         string
+	workflowPath string
+	workdirPath  string
+}
+
+func createProjectFiles(t *testing.T) projectPaths {
+	t.Helper()
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "project")
+	workflow := filepath.Join(workdir, "WORKFLOW.md")
+
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(workflow, []byte("# workflow\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	return projectPaths{
+		root:         root,
+		workflowPath: workflow,
+		workdirPath:  workdir,
+	}
+}
+
+func writeGlobalConfig(t *testing.T, path string, projects []globalconfig.Project) {
+	t.Helper()
+
+	cfg := globalconfig.Config{
+		Path:       path,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 8,
+			Scheduling:          globalconfig.SchedulingWeighted,
+			FairShare:           map[string]any{"half_life": "1h"},
+			Startup:             map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
+		},
+		Projects: projects,
+	}
+	if cfg.Projects == nil {
+		cfg.Projects = []globalconfig.Project{}
+	}
+	if err := globalconfig.Write(path, cfg); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+}
+
+func assertProject(t *testing.T, configPath string, id string, assert func(globalconfig.Project)) {
+	t.Helper()
+
+	cfg, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	for _, project := range cfg.Projects {
+		if project.ID == id {
+			assert(project)
+			return
+		}
+	}
+	t.Fatalf("project %q not found in %#v", id, cfg.Projects)
+}
+
+func assertSignal(t *testing.T, signals <-chan cli.Signal, operation cli.Operation, projectID string) {
+	t.Helper()
+
+	signal := <-signals
+	if signal.Operation != operation || signal.ProjectID != projectID {
+		t.Fatalf("signal = %#v, want %s %s", signal, operation, projectID)
+	}
+}
+
+type projectManagerProbe struct {
+	added globalconfig.Project
+}
+
+func (p *projectManagerProbe) Add(_ context.Context, cfg globalconfig.Project) error {
+	p.added = cfg
+	return nil
+}
+
+func (p *projectManagerProbe) Remove(context.Context, project.ProjectID) error {
+	return nil
+}
+
+func (p *projectManagerProbe) Pause(context.Context, project.ProjectID) error {
+	return nil
+}
+
+func (p *projectManagerProbe) Unpause(context.Context, project.ProjectID) error {
+	return nil
+}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -38,8 +38,8 @@ type Config struct {
 type Settings struct {
 	MaxConcurrentAgents int            `yaml:"max_concurrent_agents"`
 	Scheduling          string         `yaml:"scheduling"`
-	FairShare           map[string]any `yaml:"fair_share"`
-	Startup             map[string]any `yaml:"startup"`
+	FairShare           map[string]any `yaml:"fair_share,omitempty"`
+	Startup             map[string]any `yaml:"startup,omitempty"`
 }
 
 type Project struct {
@@ -48,8 +48,8 @@ type Project struct {
 	Workdir       string `yaml:"workdir"`
 	Weight        int    `yaml:"weight"`
 	Priority      int    `yaml:"priority"`
-	Paused        bool   `yaml:"paused"`
-	CredentialRef string `yaml:"credential_ref"`
+	Paused        bool   `yaml:"paused,omitempty"`
+	CredentialRef string `yaml:"credential_ref,omitempty"`
 }
 
 type Option func(*options)
@@ -70,8 +70,9 @@ type ValidationError struct {
 }
 
 type options struct {
-	home       string
-	relativeTo string
+	home                string
+	relativeTo          string
+	projectPathLiterals bool
 }
 
 func WithHome(home string) Option {
@@ -83,6 +84,12 @@ func WithHome(home string) Option {
 func WithRelativeTo(path string) Option {
 	return func(opts *options) {
 		opts.relativeTo = path
+	}
+}
+
+func WithProjectPathLiterals() Option {
+	return func(opts *options) {
+		opts.projectPathLiterals = true
 	}
 }
 
@@ -111,6 +118,23 @@ func Default() (Config, error) {
 	return defaultConfig(path), nil
 }
 
+func DefaultAt(path string, opts ...Option) (Config, error) {
+	if strings.TrimSpace(path) == "" {
+		return Config{}, errors.New("global config path is required")
+	}
+
+	readOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&readOptions)
+	}
+
+	expandedPath, err := expandPath(path, readOptions)
+	if err != nil {
+		return Config{}, err
+	}
+	return defaultConfig(expandedPath), nil
+}
+
 func Read(path string, opts ...Option) (Config, error) {
 	readOptions := defaultOptions()
 	for _, opt := range opts {
@@ -128,6 +152,41 @@ func Read(path string, opts ...Option) (Config, error) {
 	}
 
 	return Parse(raw, expandedPath, opts...)
+}
+
+func Write(path string, cfg Config, opts ...Option) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("global config path is required")
+	}
+
+	writeOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&writeOptions)
+	}
+
+	expandedPath, err := expandPath(path, writeOptions)
+	if err != nil {
+		return err
+	}
+
+	cfg.Path = expandedPath
+	if err := cfg.Validate(opts...); err != nil {
+		return err
+	}
+
+	raw, err := yaml.Marshal(cfg)
+	if err != nil {
+		return fmt.Errorf("marshal global config %s: %w", expandedPath, err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(expandedPath), 0o755); err != nil {
+		return fmt.Errorf("create global config directory %s: %w", filepath.Dir(expandedPath), err)
+	}
+	if err := os.WriteFile(expandedPath, raw, 0o644); err != nil {
+		return fmt.Errorf("write global config %s: %w", expandedPath, err)
+	}
+
+	return nil
 }
 
 func ReadOrDefault(path string, opts ...Option) (Config, error) {
@@ -649,13 +708,19 @@ func buildProjects(projects []any, opts options) []Project {
 	out := make([]Project, 0, len(projects))
 	for _, item := range projects {
 		project := mustMap(item)
-		workflow, err := expandPath(mustString(project["workflow"]), opts)
-		if err != nil {
-			panic("validated global config workflow path did not expand")
-		}
-		workdir, err := expandPath(mustString(project["workdir"]), opts)
-		if err != nil {
-			panic("validated global config workdir path did not expand")
+		workflow := mustString(project["workflow"])
+		workdir := mustString(project["workdir"])
+		if !opts.projectPathLiterals {
+			expandedWorkflow, err := expandPath(workflow, opts)
+			if err != nil {
+				panic("validated global config workflow path did not expand")
+			}
+			expandedWorkdir, err := expandPath(workdir, opts)
+			if err != nil {
+				panic("validated global config workdir path did not expand")
+			}
+			workflow = expandedWorkflow
+			workdir = expandedWorkdir
 		}
 
 		out = append(out, Project{

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -1,6 +1,7 @@
 package global
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -95,6 +96,75 @@ func TestReadOrDefaultUsesDefaultForMissingFile(t *testing.T) {
 	}
 }
 
+func TestWriteRoundTripsConfig(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "written", "global.yaml")
+
+	cfg := Config{
+		Path:       configPath,
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Global: Settings{
+			MaxConcurrentAgents: 3,
+			Scheduling:          SchedulingStrict,
+			FairShare:           map[string]any{"half_life": "30m"},
+			Startup:             map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
+		},
+		Projects: []Project{
+			{
+				ID:            "symphony",
+				Workflow:      paths.workflowPath,
+				Workdir:       paths.workdirPath,
+				Weight:        5,
+				Priority:      2,
+				Paused:        true,
+				CredentialRef: "github-default",
+			},
+		},
+	}
+
+	if err := Write(configPath, cfg, WithHome(paths.home)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if !reflect.DeepEqual(got.Global, cfg.Global) {
+		t.Fatalf("Global = %#v, want %#v", got.Global, cfg.Global)
+	}
+	if !reflect.DeepEqual(got.Projects, cfg.Projects) {
+		t.Fatalf("Projects = %#v, want %#v", got.Projects, cfg.Projects)
+	}
+}
+
+func TestWriteValidatesConfigBeforeWriting(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "global.yaml")
+
+	err := Write(path, Config{
+		APIVersion: APIVersion,
+		Kind:       Kind,
+		Global: Settings{
+			MaxConcurrentAgents: 8,
+			Scheduling:          SchedulingWeighted,
+		},
+		Projects: []Project{
+			{ID: "symphony", Weight: 0},
+		},
+	})
+	if err == nil {
+		t.Fatal("Write() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "projects[0].workflow") {
+		t.Fatalf("Write() error = %v, want workflow validation", err)
+	}
+	if _, statErr := os.Stat(path); !errors.Is(statErr, os.ErrNotExist) {
+		t.Fatalf("Stat() error = %v, want not exist", statErr)
+	}
+}
+
 func TestReadValidConfig(t *testing.T) {
 	paths := createProjectFiles(t)
 	configPath := filepath.Join(paths.root, "global.yaml")
@@ -160,6 +230,28 @@ func TestReadValidConfig(t *testing.T) {
 	}
 	if project.CredentialRef != "github-default" {
 		t.Fatalf("Project.CredentialRef = %q, want github-default", project.CredentialRef)
+	}
+}
+
+func TestReadWithProjectPathLiteralsPreservesYAMLLiterals(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, configPath, validYAML(paths, nil))
+
+	cfg, err := Read(configPath, WithHome(paths.home), WithProjectPathLiterals())
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("Projects length = %d, want 1", len(cfg.Projects))
+	}
+	project := cfg.Projects[0]
+	if project.Workflow != paths.workflow {
+		t.Fatalf("Project.Workflow = %q, want %q", project.Workflow, paths.workflow)
+	}
+	if project.Workdir != paths.workdir {
+		t.Fatalf("Project.Workdir = %q, want %q", project.Workdir, paths.workdir)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Move Cobra wiring into `internal/cli` and boot the root command from `global.yaml`.
- Add `init`, `add-project`, `pause`, `unpause`, `promote`, and `remove-project` commands that mutate `global.yaml`.
- Add manager signaling hooks plus global config write/default helpers with focused tests.

Fixes #40

## Test Plan
- `go test ./internal/cli ./internal/config/global ./cmd/symphony`
- `go test ./...`
- `make check`