### PR TITLE
feat(shadow): add shadow-run harness

### DIFF
--- a/cmd/symphony/main.go
+++ b/cmd/symphony/main.go
@@ -2,7 +2,10 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
+	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"os/signal"
@@ -11,6 +14,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/digitaldrywood/symphony-go/internal/cli"
+	"github.com/digitaldrywood/symphony-go/internal/shadow"
 )
 
 func main() {
@@ -31,7 +35,57 @@ func main() {
 }
 
 func newRootCommand(ctx context.Context) *cobra.Command {
-	return cli.NewRootCommand(ctx)
+	cmd := cli.NewRootCommand(ctx)
+	cmd.AddCommand(newShadowRunCommand())
+
+	return cmd
+}
+
+func newShadowRunCommand() *cobra.Command {
+	var inputPath string
+	var allowDiff bool
+
+	cmd := &cobra.Command{
+		Use:          "shadow-run",
+		Short:        "Compare read-only Go decisions with an Elixir shadow report",
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if inputPath == "" {
+				return errors.New("shadow-run --input is required")
+			}
+			return runShadowRun(cmd.OutOrStdout(), inputPath, allowDiff)
+		},
+	}
+	cmd.Flags().StringVar(&inputPath, "input", "", "Path to shadow-run JSON input")
+	cmd.Flags().BoolVar(&allowDiff, "allow-diff", false, "Return success even when differences are found")
+	return cmd
+}
+
+func runShadowRun(out io.Writer, inputPath string, allowDiff bool) error {
+	raw, err := os.ReadFile(inputPath)
+	if err != nil {
+		return fmt.Errorf("read shadow-run input: %w", err)
+	}
+
+	var input shadow.Input
+	if err := json.Unmarshal(raw, &input); err != nil {
+		return fmt.Errorf("decode shadow-run input: %w", err)
+	}
+
+	report, err := shadow.Run(input)
+	if err != nil {
+		return err
+	}
+
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(report); err != nil {
+		return fmt.Errorf("write shadow-run report: %w", err)
+	}
+	if report.HasDifferences() && !allowDiff {
+		return shadow.ErrDifferences
+	}
+	return nil
 }
 
 func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {

--- a/cmd/symphony/main_test.go
+++ b/cmd/symphony/main_test.go
@@ -3,6 +3,8 @@ package main
 import (
 	"bytes"
 	"context"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -55,5 +57,59 @@ func TestSignalContextCancel(t *testing.T) {
 	case <-ctx.Done():
 	case <-time.After(time.Second):
 		t.Fatal("signal context was not canceled")
+	}
+}
+
+func TestShadowRunCommandAllowsDiffAndWritesReport(t *testing.T) {
+	inputPath := filepath.Join(t.TempDir(), "shadow.json")
+	input := `{
+  "date": "2026-05-31",
+  "now": "2026-05-31T12:00:00Z",
+  "go": {
+    "dispatch": {"dispatch_order": ["issue-go"]},
+    "tokens": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 3}
+  },
+  "elixir": {
+    "dispatch": {"dispatch_order": ["issue-elixir"]},
+    "tokens": {"input_tokens": 1, "output_tokens": 2, "total_tokens": 4}
+  }
+}`
+	if err := os.WriteFile(inputPath, []byte(input), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cmd := newRootCommand(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"shadow-run", "--input", inputPath, "--allow-diff"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !strings.Contains(stdout.String(), `"has_differences": true`) {
+		t.Fatalf("shadow report missing difference flag:\n%s", stdout.String())
+	}
+}
+
+func TestShadowRunCommandFailsOnDiffByDefault(t *testing.T) {
+	inputPath := filepath.Join(t.TempDir(), "shadow.json")
+	input := `{
+  "date": "2026-05-31",
+  "go": {"dispatch": {"dispatch_order": ["issue-go"]}},
+  "elixir": {"dispatch": {"dispatch_order": ["issue-elixir"]}}
+}`
+	if err := os.WriteFile(inputPath, []byte(input), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	cmd := newRootCommand(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"shadow-run", "--input", inputPath})
+
+	err := cmd.Execute()
+	if err == nil || !strings.Contains(err.Error(), "shadow run differences found") {
+		t.Fatalf("Execute() error = %v, want shadow run differences found", err)
 	}
 }

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -1,0 +1,210 @@
+package orchestrator
+
+import (
+	"sort"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+type DispatchDecision struct {
+	IssueID    string `json:"issue_id"`
+	Identifier string `json:"identifier,omitempty"`
+	State      string `json:"state,omitempty"`
+	Attempt    int    `json:"attempt,omitempty"`
+	WorkerHost string `json:"worker_host,omitempty"`
+	Retry      bool   `json:"retry,omitempty"`
+}
+
+type DispatchPlan struct {
+	Dispatches     []DispatchDecision `json:"dispatches,omitempty"`
+	Claimed        []string           `json:"claimed,omitempty"`
+	Blocked        []string           `json:"blocked,omitempty"`
+	BudgetRefusals []string           `json:"budget_refusals,omitempty"`
+	Retry          []string           `json:"retry,omitempty"`
+}
+
+func PlanDispatch(cfg Config, state State, candidates []connector.Issue, now time.Time) DispatchPlan {
+	cfg = normalizeConfig(cfg)
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	plannedState := state.clone()
+	plannedState.ensureInitialized(cfg)
+	plannedCandidates := cloneIssues(candidates)
+	sortIssuesForDispatch(plannedCandidates, cfg.DispatchPriorityByState)
+
+	orch := Orchestrator{cfg: cfg}
+	orch.pruneBudgetRefusals(&plannedState, now)
+	orch.trackBlockedCandidates(&plannedState, plannedCandidates, now)
+	dueRetries := dueRetriesByIssue(&plannedState, now)
+	orch.releaseMissingDueRetries(&plannedState, plannedCandidates, dueRetries)
+
+	dispatches := make([]DispatchDecision, 0)
+	for _, issue := range plannedCandidates {
+		if retry, ok := dueRetries[issue.ID]; ok {
+			if decision, ok := orch.planRetryIssue(&plannedState, issue, retry, now); ok {
+				dispatches = append(dispatches, decision)
+			}
+			continue
+		}
+		if availableSlots(&plannedState) == 0 {
+			break
+		}
+		if !orch.dispatchable(issue, &plannedState, now) {
+			continue
+		}
+		if decision, ok := orch.planDispatchIssue(&plannedState, issue, 0, now, ""); ok {
+			dispatches = append(dispatches, decision)
+		}
+	}
+
+	return DispatchPlan{
+		Dispatches:     dispatches,
+		Claimed:        claimedIDs(plannedState.Claimed),
+		Blocked:        blockedIDs(plannedState.Blocked),
+		BudgetRefusals: budgetRefusalIDs(plannedState.BudgetRefusals),
+		Retry:          retryIDs(plannedState.Retry),
+	}
+}
+
+func (p DispatchPlan) DispatchOrder() []string {
+	order := make([]string, 0, len(p.Dispatches))
+	for _, dispatch := range p.Dispatches {
+		order = append(order, dispatch.IssueID)
+	}
+	return order
+}
+
+func (s *State) ensureInitialized(cfg Config) {
+	if s.PollInterval <= 0 {
+		s.PollInterval = cfg.PollInterval
+	}
+	if s.MaxConcurrentAgents <= 0 {
+		s.MaxConcurrentAgents = cfg.MaxConcurrentAgents
+	}
+	if s.Running == nil {
+		s.Running = map[string]Running{}
+	}
+	if s.Claimed == nil {
+		s.Claimed = map[string]Claimed{}
+	}
+	if s.Blocked == nil {
+		s.Blocked = map[string]Blocked{}
+	}
+	if s.Completed == nil {
+		s.Completed = map[string]Completed{}
+	}
+	if s.Retry == nil {
+		s.Retry = map[string]Retry{}
+	}
+	if s.BudgetRefusals == nil {
+		s.BudgetRefusals = map[string]BudgetRefusal{}
+	}
+	if s.DiffStats == nil {
+		s.DiffStats = map[string]DiffStats{}
+	}
+}
+
+func (o *Orchestrator) planRetryIssue(
+	state *State,
+	issue connector.Issue,
+	retry Retry,
+	now time.Time,
+) (DispatchDecision, bool) {
+	delete(state.Retry, retry.Issue.ID)
+
+	if !o.dispatchableForRetry(issue, state, now, retry.WorkerHost) {
+		if o.budgetCooldownActive(state, issue.ID, now) {
+			o.scheduleRetry(state, issue, retry.Attempt, now, "budget cooldown active", false, retry.WorkerHost)
+			return DispatchDecision{}, false
+		}
+		if !o.slotsAvailable(issue, state, retry.WorkerHost) {
+			o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false, retry.WorkerHost)
+			return DispatchDecision{}, false
+		}
+		if _, blocked := state.Blocked[issue.ID]; blocked {
+			o.releaseClaim(state, issue.ID)
+			return DispatchDecision{}, false
+		}
+
+		o.releaseIssue(state, issue.ID)
+		return DispatchDecision{}, false
+	}
+
+	return o.planDispatchIssue(state, issue, retry.Attempt, now, retry.WorkerHost)
+}
+
+func (o *Orchestrator) planDispatchIssue(
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	preferredWorkerHost string,
+) (DispatchDecision, bool) {
+	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
+	if !ok {
+		return DispatchDecision{}, false
+	}
+
+	issue = cloneIssue(issue)
+	state.Running[issue.ID] = Running{
+		Issue:      issue,
+		Attempt:    attempt,
+		StartedAt:  now,
+		WorkerHost: workerHost,
+	}
+	state.Claimed[issue.ID] = Claimed{
+		Issue:     issue,
+		ClaimedAt: now,
+	}
+	delete(state.Retry, issue.ID)
+	delete(state.Blocked, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+
+	return DispatchDecision{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		State:      issue.State,
+		Attempt:    attempt,
+		WorkerHost: workerHost,
+		Retry:      attempt > 0,
+	}, true
+}
+
+func claimedIDs(values map[string]Claimed) []string {
+	ids := make([]string, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func blockedIDs(values map[string]Blocked) []string {
+	ids := make([]string, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func budgetRefusalIDs(values map[string]BudgetRefusal) []string {
+	ids := make([]string, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func retryIDs(values map[string]Retry) []string {
+	ids := make([]string, 0, len(values))
+	for id := range values {
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}

--- a/internal/orchestrator/shadow_test.go
+++ b/internal/orchestrator/shadow_test.go
@@ -1,0 +1,94 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+)
+
+func TestPlanDispatchReportsReadOnlyDispatchOrder(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		MaxConcurrentAgents:        2,
+		ActiveStates:               []string{"Todo"},
+		TerminalStates:             []string{"Done"},
+		WorkerHosts:                []string{"worker-a", "worker-b"},
+		MaxConcurrentAgentsPerHost: 1,
+	}
+	state := newState(normalizeConfig(cfg))
+	running := shadowTestIssue("issue-running", "Todo", nil, now.Add(-3*time.Hour))
+	state.Running[running.ID] = Running{Issue: running, WorkerHost: "worker-a"}
+
+	highPriority := 1
+	lowPriority := 4
+	candidates := []connector.Issue{
+		shadowTestIssue("issue-low", "Todo", &lowPriority, now.Add(-4*time.Hour)),
+		shadowTestIssue("issue-high", "Todo", &highPriority, now.Add(-time.Hour)),
+	}
+
+	plan := PlanDispatch(cfg, state, candidates, now)
+
+	if len(plan.Dispatches) != 1 {
+		t.Fatalf("Dispatches length = %d, want 1", len(plan.Dispatches))
+	}
+	dispatch := plan.Dispatches[0]
+	if dispatch.IssueID != "issue-high" {
+		t.Fatalf("Dispatches[0].IssueID = %q, want issue-high", dispatch.IssueID)
+	}
+	if dispatch.WorkerHost != "worker-b" {
+		t.Fatalf("Dispatches[0].WorkerHost = %q, want worker-b", dispatch.WorkerHost)
+	}
+	if _, ok := state.Running["issue-high"]; ok {
+		t.Fatal("PlanDispatch mutated input state running set")
+	}
+	if len(plan.Claimed) != 1 || plan.Claimed[0] != "issue-high" {
+		t.Fatalf("Claimed = %#v, want issue-high", plan.Claimed)
+	}
+}
+
+func TestPlanDispatchRetriesDueIssueWithoutStartingRunner(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	cfg := Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+	}
+	state := newState(normalizeConfig(cfg))
+	retryIssue := shadowTestIssue("issue-retry", "Todo", nil, now.Add(-time.Hour))
+	state.Retry[retryIssue.ID] = Retry{
+		Issue:   retryIssue,
+		Attempt: 2,
+		DueAt:   now.Add(-time.Minute),
+		Error:   "previous failure",
+	}
+	state.Claimed[retryIssue.ID] = Claimed{Issue: retryIssue, ClaimedAt: now.Add(-2 * time.Minute)}
+
+	plan := PlanDispatch(cfg, state, []connector.Issue{retryIssue}, now)
+
+	if len(plan.Dispatches) != 1 {
+		t.Fatalf("Dispatches length = %d, want 1", len(plan.Dispatches))
+	}
+	if plan.Dispatches[0].IssueID != retryIssue.ID || plan.Dispatches[0].Attempt != 2 {
+		t.Fatalf("Dispatches[0] = %#v, want retry attempt 2", plan.Dispatches[0])
+	}
+	if len(plan.Retry) != 0 {
+		t.Fatalf("Retry = %#v, want empty after retry dispatch", plan.Retry)
+	}
+}
+
+func shadowTestIssue(id, state string, priority *int, createdAt time.Time) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/symphony-go#" + id
+	issue.Title = "Shadow test issue"
+	issue.State = state
+	issue.Priority = priority
+	issue.CreatedAt = &createdAt
+	issue.AssignedToWorker = true
+	return issue
+}

--- a/internal/shadow/shadow.go
+++ b/internal/shadow/shadow.go
@@ -1,0 +1,678 @@
+package shadow
+
+import (
+	"errors"
+	"fmt"
+	"reflect"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/orchestrator"
+)
+
+var ErrDifferences = errors.New("shadow run differences found")
+
+type Input struct {
+	Date     string       `json:"date"`
+	Now      string       `json:"now,omitempty"`
+	Scenario *Scenario    `json:"scenario,omitempty"`
+	Go       *Observation `json:"go,omitempty"`
+	Elixir   Observation  `json:"elixir"`
+}
+
+type Scenario struct {
+	Config       DispatchConfig  `json:"config"`
+	InitialState InitialState    `json:"initial_state,omitempty"`
+	Candidates   []Issue         `json:"candidates,omitempty"`
+	Tokens       TokenAccounting `json:"tokens,omitempty"`
+}
+
+type DispatchConfig struct {
+	MaxConcurrentAgents          int            `json:"max_concurrent_agents"`
+	MaxConcurrentAgentsByState   map[string]int `json:"max_concurrent_agents_by_state,omitempty"`
+	DispatchPriorityByState      []string       `json:"dispatch_priority_by_state,omitempty"`
+	ActiveStates                 []string       `json:"active_states,omitempty"`
+	TerminalStates               []string       `json:"terminal_states,omitempty"`
+	BudgetRefusalCooldownSeconds int            `json:"budget_refusal_cooldown_seconds,omitempty"`
+	MaxConcurrentAgentsPerHost   int            `json:"max_concurrent_agents_per_host,omitempty"`
+	WorkerHosts                  []string       `json:"worker_hosts,omitempty"`
+}
+
+type InitialState struct {
+	Running        []Running       `json:"running,omitempty"`
+	Claimed        []Claimed       `json:"claimed,omitempty"`
+	Blocked        []Blocked       `json:"blocked,omitempty"`
+	Retry          []Retry         `json:"retry,omitempty"`
+	BudgetRefusals []BudgetRefusal `json:"budget_refusals,omitempty"`
+}
+
+type Running struct {
+	Issue      Issue  `json:"issue"`
+	Attempt    int    `json:"attempt,omitempty"`
+	StartedAt  string `json:"started_at,omitempty"`
+	WorkerHost string `json:"worker_host,omitempty"`
+}
+
+type Claimed struct {
+	Issue     Issue  `json:"issue"`
+	ClaimedAt string `json:"claimed_at,omitempty"`
+}
+
+type Blocked struct {
+	Issue     Issue  `json:"issue"`
+	Reason    string `json:"reason,omitempty"`
+	BlockedAt string `json:"blocked_at,omitempty"`
+}
+
+type Retry struct {
+	Issue      Issue  `json:"issue"`
+	Attempt    int    `json:"attempt,omitempty"`
+	DueAt      string `json:"due_at,omitempty"`
+	Error      string `json:"error,omitempty"`
+	WorkerHost string `json:"worker_host,omitempty"`
+}
+
+type BudgetRefusal struct {
+	Issue     Issue  `json:"issue"`
+	RefusedAt string `json:"refused_at,omitempty"`
+	ResetAt   string `json:"reset_at,omitempty"`
+}
+
+type Issue struct {
+	ID               string                 `json:"id"`
+	Identifier       string                 `json:"identifier,omitempty"`
+	URL              string                 `json:"url,omitempty"`
+	Title            string                 `json:"title,omitempty"`
+	State            string                 `json:"state,omitempty"`
+	Priority         *int                   `json:"priority,omitempty"`
+	CreatedAt        string                 `json:"created_at,omitempty"`
+	UpdatedAt        string                 `json:"updated_at,omitempty"`
+	BlockedBy        []connector.BlockedRef `json:"blocked_by,omitempty"`
+	Labels           []string               `json:"labels,omitempty"`
+	AssignedToWorker *bool                  `json:"assigned_to_worker,omitempty"`
+	ModelOverride    string                 `json:"model_override,omitempty"`
+	BranchName       string                 `json:"branch_name,omitempty"`
+}
+
+type Observation struct {
+	Dispatch DispatchObservation `json:"dispatch"`
+	Tokens   TokenAccounting     `json:"tokens"`
+}
+
+type DispatchObservation struct {
+	DispatchOrder  []string         `json:"dispatch_order,omitempty"`
+	Dispatches     []DispatchDetail `json:"dispatches,omitempty"`
+	Claimed        []string         `json:"claimed,omitempty"`
+	Blocked        []string         `json:"blocked,omitempty"`
+	BudgetRefusals []string         `json:"budget_refusals,omitempty"`
+	Refusals       []string         `json:"refusals,omitempty"`
+	Retry          []string         `json:"retry,omitempty"`
+}
+
+type DispatchDetail struct {
+	IssueID    string `json:"issue_id"`
+	Identifier string `json:"identifier,omitempty"`
+	State      string `json:"state,omitempty"`
+	Attempt    int    `json:"attempt,omitempty"`
+	WorkerHost string `json:"worker_host,omitempty"`
+	Retry      bool   `json:"retry,omitempty"`
+}
+
+type TokenAccounting struct {
+	InputTokens    int64                  `json:"input_tokens"`
+	OutputTokens   int64                  `json:"output_tokens"`
+	TotalTokens    int64                  `json:"total_tokens"`
+	Sessions       int64                  `json:"sessions,omitempty"`
+	RuntimeSeconds int64                  `json:"runtime_seconds,omitempty"`
+	ByModel        []ModelTokenAccounting `json:"by_model,omitempty"`
+}
+
+type ModelTokenAccounting struct {
+	Model          string `json:"model,omitempty"`
+	InputTokens    int64  `json:"input_tokens"`
+	OutputTokens   int64  `json:"output_tokens"`
+	TotalTokens    int64  `json:"total_tokens"`
+	Sessions       int64  `json:"sessions,omitempty"`
+	RuntimeSeconds int64  `json:"runtime_seconds,omitempty"`
+}
+
+type Report struct {
+	Date        string      `json:"date"`
+	GeneratedAt time.Time   `json:"generated_at"`
+	Go          Observation `json:"go"`
+	Elixir      Observation `json:"elixir"`
+	Diff        Diff        `json:"diff"`
+}
+
+type Diff struct {
+	HasDifferences bool             `json:"has_differences"`
+	Dispatch       []DispatchDiff   `json:"dispatch,omitempty"`
+	Tokens         []TokenDiff      `json:"tokens,omitempty"`
+	ModelTokens    []ModelTokenDiff `json:"model_tokens,omitempty"`
+}
+
+type DispatchDiff struct {
+	Field  string   `json:"field"`
+	Go     []string `json:"go"`
+	Elixir []string `json:"elixir"`
+}
+
+type TokenDiff struct {
+	Field  string `json:"field"`
+	Go     int64  `json:"go"`
+	Elixir int64  `json:"elixir"`
+}
+
+type ModelTokenDiff struct {
+	Model  string `json:"model"`
+	Field  string `json:"field"`
+	Go     int64  `json:"go"`
+	Elixir int64  `json:"elixir"`
+}
+
+func Run(input Input) (Report, error) {
+	generatedAt, err := reportTime(input.Date, input.Now)
+	if err != nil {
+		return Report{}, err
+	}
+
+	goObservation, err := goObservation(input, generatedAt)
+	if err != nil {
+		return Report{}, err
+	}
+
+	date := strings.TrimSpace(input.Date)
+	if date == "" {
+		date = generatedAt.Format("2006-01-02")
+	}
+
+	goObservation = normalizeObservation(goObservation)
+	elixirObservation := normalizeObservation(input.Elixir)
+	diff := compareObservations(goObservation, elixirObservation)
+
+	return Report{
+		Date:        date,
+		GeneratedAt: generatedAt,
+		Go:          goObservation,
+		Elixir:      elixirObservation,
+		Diff:        diff,
+	}, nil
+}
+
+func (r Report) HasDifferences() bool {
+	return r.Diff.HasDifferences
+}
+
+func goObservation(input Input, now time.Time) (Observation, error) {
+	if input.Scenario != nil {
+		return input.Scenario.observation(now)
+	}
+	if input.Go == nil {
+		return Observation{}, errors.New("go observation or scenario is required")
+	}
+	return *input.Go, nil
+}
+
+func (s Scenario) observation(now time.Time) (Observation, error) {
+	cfg := s.Config.orchestratorConfig()
+	state, err := s.InitialState.orchestratorState(cfg, now)
+	if err != nil {
+		return Observation{}, err
+	}
+
+	candidates := make([]connector.Issue, 0, len(s.Candidates))
+	for _, candidate := range s.Candidates {
+		issue, err := candidate.connectorIssue()
+		if err != nil {
+			return Observation{}, err
+		}
+		candidates = append(candidates, issue)
+	}
+
+	plan := orchestrator.PlanDispatch(cfg, state, candidates, now)
+	return Observation{
+		Dispatch: dispatchObservationFromPlan(plan),
+		Tokens:   s.Tokens,
+	}, nil
+}
+
+func (c DispatchConfig) orchestratorConfig() orchestrator.Config {
+	return orchestrator.Config{
+		MaxConcurrentAgents:        c.MaxConcurrentAgents,
+		MaxConcurrentAgentsByState: cloneIntMap(c.MaxConcurrentAgentsByState),
+		DispatchPriorityByState:    append([]string(nil), c.DispatchPriorityByState...),
+		ActiveStates:               append([]string(nil), c.ActiveStates...),
+		TerminalStates:             append([]string(nil), c.TerminalStates...),
+		WorkerHosts:                append([]string(nil), c.WorkerHosts...),
+		MaxConcurrentAgentsPerHost: c.MaxConcurrentAgentsPerHost,
+		BudgetRefusalCooldown:      time.Duration(c.BudgetRefusalCooldownSeconds) * time.Second,
+	}
+}
+
+func (s InitialState) orchestratorState(cfg orchestrator.Config, now time.Time) (orchestrator.State, error) {
+	state := orchestrator.State{
+		MaxConcurrentAgents: cfg.MaxConcurrentAgents,
+		Running:             map[string]orchestrator.Running{},
+		Claimed:             map[string]orchestrator.Claimed{},
+		Blocked:             map[string]orchestrator.Blocked{},
+		Completed:           map[string]orchestrator.Completed{},
+		Retry:               map[string]orchestrator.Retry{},
+		BudgetRefusals:      map[string]orchestrator.BudgetRefusal{},
+		DiffStats:           map[string]orchestrator.DiffStats{},
+	}
+
+	for _, row := range s.Running {
+		issue, err := row.Issue.connectorIssue()
+		if err != nil {
+			return orchestrator.State{}, err
+		}
+		state.Running[issue.ID] = orchestrator.Running{
+			Issue:      issue,
+			Attempt:    row.Attempt,
+			StartedAt:  optionalTime(row.StartedAt, now),
+			WorkerHost: strings.TrimSpace(row.WorkerHost),
+		}
+	}
+	for _, row := range s.Claimed {
+		issue, err := row.Issue.connectorIssue()
+		if err != nil {
+			return orchestrator.State{}, err
+		}
+		state.Claimed[issue.ID] = orchestrator.Claimed{
+			Issue:     issue,
+			ClaimedAt: optionalTime(row.ClaimedAt, now),
+		}
+	}
+	for _, row := range s.Blocked {
+		issue, err := row.Issue.connectorIssue()
+		if err != nil {
+			return orchestrator.State{}, err
+		}
+		state.Blocked[issue.ID] = orchestrator.Blocked{
+			Issue:     issue,
+			Reason:    strings.TrimSpace(row.Reason),
+			BlockedAt: optionalTime(row.BlockedAt, now),
+		}
+	}
+	for _, row := range s.Retry {
+		issue, err := row.Issue.connectorIssue()
+		if err != nil {
+			return orchestrator.State{}, err
+		}
+		state.Retry[issue.ID] = orchestrator.Retry{
+			Issue:      issue,
+			Attempt:    row.Attempt,
+			DueAt:      optionalTime(row.DueAt, now),
+			Error:      strings.TrimSpace(row.Error),
+			WorkerHost: strings.TrimSpace(row.WorkerHost),
+		}
+	}
+	for _, row := range s.BudgetRefusals {
+		issue, err := row.Issue.connectorIssue()
+		if err != nil {
+			return orchestrator.State{}, err
+		}
+		resetAt := optionalTimePtr(row.ResetAt)
+		state.BudgetRefusals[issue.ID] = orchestrator.BudgetRefusal{
+			Issue:     issue,
+			RefusedAt: optionalTime(row.RefusedAt, now),
+			ResetAt:   resetAt,
+		}
+	}
+
+	return state, nil
+}
+
+func (i Issue) connectorIssue() (connector.Issue, error) {
+	issue := connector.NewIssue()
+	issue.ID = strings.TrimSpace(i.ID)
+	issue.Identifier = strings.TrimSpace(i.Identifier)
+	issue.URL = strings.TrimSpace(i.URL)
+	issue.Title = strings.TrimSpace(i.Title)
+	issue.State = strings.TrimSpace(i.State)
+	issue.Priority = i.Priority
+	issue.BlockedBy = append([]connector.BlockedRef(nil), i.BlockedBy...)
+	issue.Labels = trimStrings(i.Labels)
+	issue.ModelOverride = strings.TrimSpace(i.ModelOverride)
+	issue.BranchName = strings.TrimSpace(i.BranchName)
+	issue.AssignedToWorker = true
+	if i.AssignedToWorker != nil {
+		issue.AssignedToWorker = *i.AssignedToWorker
+	}
+
+	if i.CreatedAt != "" {
+		createdAt, err := parseTime("created_at", i.CreatedAt)
+		if err != nil {
+			return connector.Issue{}, err
+		}
+		issue.CreatedAt = &createdAt
+	}
+	if i.UpdatedAt != "" {
+		updatedAt, err := parseTime("updated_at", i.UpdatedAt)
+		if err != nil {
+			return connector.Issue{}, err
+		}
+		issue.UpdatedAt = &updatedAt
+	}
+	return issue, nil
+}
+
+func dispatchObservationFromPlan(plan orchestrator.DispatchPlan) DispatchObservation {
+	dispatches := make([]DispatchDetail, 0, len(plan.Dispatches))
+	for _, dispatch := range plan.Dispatches {
+		dispatches = append(dispatches, DispatchDetail{
+			IssueID:    dispatch.IssueID,
+			Identifier: dispatch.Identifier,
+			State:      dispatch.State,
+			Attempt:    dispatch.Attempt,
+			WorkerHost: dispatch.WorkerHost,
+			Retry:      dispatch.Retry,
+		})
+	}
+
+	return DispatchObservation{
+		DispatchOrder:  plan.DispatchOrder(),
+		Dispatches:     dispatches,
+		Claimed:        append([]string(nil), plan.Claimed...),
+		Blocked:        append([]string(nil), plan.Blocked...),
+		BudgetRefusals: append([]string(nil), plan.BudgetRefusals...),
+		Retry:          append([]string(nil), plan.Retry...),
+	}
+}
+
+func normalizeObservation(observation Observation) Observation {
+	observation.Dispatch = normalizeDispatchObservation(observation.Dispatch)
+	observation.Tokens = normalizeTokenAccounting(observation.Tokens)
+	return observation
+}
+
+func normalizeDispatchObservation(observation DispatchObservation) DispatchObservation {
+	observation.DispatchOrder = normalizeOrderedIDs(observation.DispatchOrder)
+	observation.Dispatches = normalizeDispatchDetails(observation.Dispatches)
+	if len(observation.DispatchOrder) == 0 && len(observation.Dispatches) > 0 {
+		for _, dispatch := range observation.Dispatches {
+			observation.DispatchOrder = append(observation.DispatchOrder, dispatch.IssueID)
+		}
+	}
+
+	observation.Claimed = normalizeIDSet(observation.Claimed)
+	observation.Blocked = normalizeIDSet(observation.Blocked)
+	observation.BudgetRefusals = normalizeIDSet(append(observation.BudgetRefusals, observation.Refusals...))
+	observation.Refusals = nil
+	observation.Retry = normalizeIDSet(observation.Retry)
+	return observation
+}
+
+func normalizeDispatchDetails(dispatches []DispatchDetail) []DispatchDetail {
+	normalized := make([]DispatchDetail, 0, len(dispatches))
+	for _, dispatch := range dispatches {
+		dispatch.IssueID = strings.TrimSpace(dispatch.IssueID)
+		dispatch.Identifier = strings.TrimSpace(dispatch.Identifier)
+		dispatch.State = strings.TrimSpace(dispatch.State)
+		dispatch.WorkerHost = strings.TrimSpace(dispatch.WorkerHost)
+		if dispatch.IssueID == "" {
+			continue
+		}
+		normalized = append(normalized, dispatch)
+	}
+	return normalized
+}
+
+func normalizeTokenAccounting(tokens TokenAccounting) TokenAccounting {
+	tokens.InputTokens = nonNegative(tokens.InputTokens)
+	tokens.OutputTokens = nonNegative(tokens.OutputTokens)
+	tokens.TotalTokens = nonNegative(tokens.TotalTokens)
+	tokens.Sessions = nonNegative(tokens.Sessions)
+	tokens.RuntimeSeconds = nonNegative(tokens.RuntimeSeconds)
+	tokens.ByModel = normalizeModelTokens(tokens.ByModel)
+	return tokens
+}
+
+func normalizeModelTokens(rows []ModelTokenAccounting) []ModelTokenAccounting {
+	byModel := map[string]ModelTokenAccounting{}
+	for _, row := range rows {
+		model := strings.TrimSpace(row.Model)
+		existing := byModel[model]
+		existing.Model = model
+		existing.InputTokens += nonNegative(row.InputTokens)
+		existing.OutputTokens += nonNegative(row.OutputTokens)
+		existing.TotalTokens += nonNegative(row.TotalTokens)
+		existing.Sessions += nonNegative(row.Sessions)
+		existing.RuntimeSeconds += nonNegative(row.RuntimeSeconds)
+		byModel[model] = existing
+	}
+
+	models := make([]string, 0, len(byModel))
+	for model := range byModel {
+		models = append(models, model)
+	}
+	sort.Strings(models)
+
+	normalized := make([]ModelTokenAccounting, 0, len(models))
+	for _, model := range models {
+		normalized = append(normalized, byModel[model])
+	}
+	return normalized
+}
+
+func compareObservations(goObservation Observation, elixirObservation Observation) Diff {
+	diff := Diff{}
+	diff.Dispatch = dispatchDiffs(goObservation.Dispatch, elixirObservation.Dispatch)
+	diff.Tokens = tokenDiffs(goObservation.Tokens, elixirObservation.Tokens)
+	diff.ModelTokens = modelTokenDiffs(goObservation.Tokens.ByModel, elixirObservation.Tokens.ByModel)
+	diff.HasDifferences = len(diff.Dispatch) > 0 || len(diff.Tokens) > 0 || len(diff.ModelTokens) > 0
+	return diff
+}
+
+func dispatchDiffs(goDispatch DispatchObservation, elixirDispatch DispatchObservation) []DispatchDiff {
+	checks := []struct {
+		field string
+		goIDs []string
+		exIDs []string
+	}{
+		{field: "dispatch_order", goIDs: goDispatch.DispatchOrder, exIDs: elixirDispatch.DispatchOrder},
+		{field: "claimed", goIDs: goDispatch.Claimed, exIDs: elixirDispatch.Claimed},
+		{field: "blocked", goIDs: goDispatch.Blocked, exIDs: elixirDispatch.Blocked},
+		{field: "budget_refusals", goIDs: goDispatch.BudgetRefusals, exIDs: elixirDispatch.BudgetRefusals},
+		{field: "retry", goIDs: goDispatch.Retry, exIDs: elixirDispatch.Retry},
+	}
+
+	diffs := make([]DispatchDiff, 0)
+	for _, check := range checks {
+		if reflect.DeepEqual(check.goIDs, check.exIDs) {
+			continue
+		}
+		diffs = append(diffs, DispatchDiff{
+			Field:  check.field,
+			Go:     append([]string(nil), check.goIDs...),
+			Elixir: append([]string(nil), check.exIDs...),
+		})
+	}
+	return diffs
+}
+
+func tokenDiffs(goTokens TokenAccounting, elixirTokens TokenAccounting) []TokenDiff {
+	checks := []struct {
+		field string
+		goVal int64
+		exVal int64
+	}{
+		{field: "input_tokens", goVal: goTokens.InputTokens, exVal: elixirTokens.InputTokens},
+		{field: "output_tokens", goVal: goTokens.OutputTokens, exVal: elixirTokens.OutputTokens},
+		{field: "total_tokens", goVal: goTokens.TotalTokens, exVal: elixirTokens.TotalTokens},
+		{field: "sessions", goVal: goTokens.Sessions, exVal: elixirTokens.Sessions},
+		{field: "runtime_seconds", goVal: goTokens.RuntimeSeconds, exVal: elixirTokens.RuntimeSeconds},
+	}
+
+	diffs := make([]TokenDiff, 0)
+	for _, check := range checks {
+		if check.goVal == check.exVal {
+			continue
+		}
+		diffs = append(diffs, TokenDiff{Field: check.field, Go: check.goVal, Elixir: check.exVal})
+	}
+	return diffs
+}
+
+func modelTokenDiffs(goRows []ModelTokenAccounting, elixirRows []ModelTokenAccounting) []ModelTokenDiff {
+	goByModel := modelTokenMap(goRows)
+	elixirByModel := modelTokenMap(elixirRows)
+	models := unionSortedKeys(goByModel, elixirByModel)
+
+	diffs := make([]ModelTokenDiff, 0)
+	for _, model := range models {
+		goRow := goByModel[model]
+		elixirRow := elixirByModel[model]
+		checks := []struct {
+			field string
+			goVal int64
+			exVal int64
+		}{
+			{field: "input_tokens", goVal: goRow.InputTokens, exVal: elixirRow.InputTokens},
+			{field: "output_tokens", goVal: goRow.OutputTokens, exVal: elixirRow.OutputTokens},
+			{field: "total_tokens", goVal: goRow.TotalTokens, exVal: elixirRow.TotalTokens},
+			{field: "sessions", goVal: goRow.Sessions, exVal: elixirRow.Sessions},
+			{field: "runtime_seconds", goVal: goRow.RuntimeSeconds, exVal: elixirRow.RuntimeSeconds},
+		}
+		for _, check := range checks {
+			if check.goVal == check.exVal {
+				continue
+			}
+			diffs = append(diffs, ModelTokenDiff{
+				Model:  model,
+				Field:  check.field,
+				Go:     check.goVal,
+				Elixir: check.exVal,
+			})
+		}
+	}
+	return diffs
+}
+
+func modelTokenMap(rows []ModelTokenAccounting) map[string]ModelTokenAccounting {
+	byModel := make(map[string]ModelTokenAccounting, len(rows))
+	for _, row := range rows {
+		byModel[row.Model] = row
+	}
+	return byModel
+}
+
+func unionSortedKeys(left map[string]ModelTokenAccounting, right map[string]ModelTokenAccounting) []string {
+	seen := make(map[string]struct{}, len(left)+len(right))
+	for key := range left {
+		seen[key] = struct{}{}
+	}
+	for key := range right {
+		seen[key] = struct{}{}
+	}
+
+	keys := make([]string, 0, len(seen))
+	for key := range seen {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func reportTime(date string, now string) (time.Time, error) {
+	if strings.TrimSpace(now) != "" {
+		return parseTime("now", now)
+	}
+	if strings.TrimSpace(date) != "" {
+		parsed, err := time.Parse("2006-01-02", strings.TrimSpace(date))
+		if err != nil {
+			return time.Time{}, fmt.Errorf("parse date: %w", err)
+		}
+		return parsed, nil
+	}
+	return time.Now().UTC(), nil
+}
+
+func parseTime(name string, value string) (time.Time, error) {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse %s: %w", name, err)
+	}
+	return parsed, nil
+}
+
+func optionalTime(value string, fallback time.Time) time.Time {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	parsed, err := parseTime("time", value)
+	if err != nil {
+		return fallback
+	}
+	return parsed
+}
+
+func optionalTimePtr(value string) *time.Time {
+	if strings.TrimSpace(value) == "" {
+		return nil
+	}
+	parsed, err := parseTime("time", value)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func normalizeOrderedIDs(ids []string) []string {
+	normalized := make([]string, 0, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		normalized = append(normalized, id)
+	}
+	return normalized
+}
+
+func normalizeIDSet(ids []string) []string {
+	seen := make(map[string]struct{}, len(ids))
+	for _, id := range ids {
+		id = strings.TrimSpace(id)
+		if id == "" {
+			continue
+		}
+		seen[id] = struct{}{}
+	}
+
+	normalized := make([]string, 0, len(seen))
+	for id := range seen {
+		normalized = append(normalized, id)
+	}
+	sort.Strings(normalized)
+	return normalized
+}
+
+func trimStrings(values []string) []string {
+	trimmed := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		trimmed = append(trimmed, value)
+	}
+	return trimmed
+}
+
+func cloneIntMap(values map[string]int) map[string]int {
+	cloned := make(map[string]int, len(values))
+	for key, value := range values {
+		cloned[key] = value
+	}
+	return cloned
+}
+
+func nonNegative(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}

--- a/internal/shadow/shadow.go
+++ b/internal/shadow/shadow.go
@@ -490,7 +490,34 @@ func dispatchDiffs(goDispatch DispatchObservation, elixirDispatch DispatchObserv
 			Elixir: append([]string(nil), check.exIDs...),
 		})
 	}
+	if len(goDispatch.Dispatches) > 0 && len(elixirDispatch.Dispatches) > 0 {
+		goDetails := dispatchDetailValues(goDispatch.Dispatches)
+		elixirDetails := dispatchDetailValues(elixirDispatch.Dispatches)
+		if !reflect.DeepEqual(goDetails, elixirDetails) {
+			diffs = append(diffs, DispatchDiff{
+				Field:  "dispatch_details",
+				Go:     goDetails,
+				Elixir: elixirDetails,
+			})
+		}
+	}
 	return diffs
+}
+
+func dispatchDetailValues(dispatches []DispatchDetail) []string {
+	values := make([]string, 0, len(dispatches))
+	for _, dispatch := range dispatches {
+		values = append(values, fmt.Sprintf(
+			"%s|identifier=%s|state=%s|attempt=%d|worker_host=%s|retry=%t",
+			dispatch.IssueID,
+			dispatch.Identifier,
+			dispatch.State,
+			dispatch.Attempt,
+			dispatch.WorkerHost,
+			dispatch.Retry,
+		))
+	}
+	return values
 }
 
 func tokenDiffs(goTokens TokenAccounting, elixirTokens TokenAccounting) []TokenDiff {

--- a/internal/shadow/shadow_test.go
+++ b/internal/shadow/shadow_test.go
@@ -121,6 +121,42 @@ func TestRunNormalizesTokenModelOrder(t *testing.T) {
 	}
 }
 
+func TestRunDiffsDispatchDetailsWhenBothReportsIncludeThem(t *testing.T) {
+	t.Parallel()
+
+	input := Input{
+		Date: "2026-05-31",
+		Go: &Observation{
+			Dispatch: DispatchObservation{
+				DispatchOrder: []string{"issue-1"},
+				Dispatches: []DispatchDetail{
+					{IssueID: "issue-1", Attempt: 2, Retry: true, WorkerHost: "worker-a"},
+				},
+			},
+		},
+		Elixir: Observation{
+			Dispatch: DispatchObservation{
+				DispatchOrder: []string{"issue-1"},
+				Dispatches: []DispatchDetail{
+					{IssueID: "issue-1", Attempt: 1, Retry: true, WorkerHost: "worker-b"},
+				},
+			},
+		},
+	}
+
+	report, err := Run(input)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if !report.Diff.HasDifferences {
+		t.Fatal("HasDifferences = false, want true")
+	}
+	if !diffFieldsContain(report.Diff.Dispatch, "dispatch_details") {
+		t.Fatalf("Dispatch diffs = %#v, want dispatch_details", report.Diff.Dispatch)
+	}
+}
+
 func diffFieldsContain(diffs []DispatchDiff, field string) bool {
 	for _, diff := range diffs {
 		if diff.Field == field {

--- a/internal/shadow/shadow_test.go
+++ b/internal/shadow/shadow_test.go
@@ -1,0 +1,144 @@
+package shadow
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestRunComputesGoObservationAndReportsDiffs(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 31, 12, 0, 0, 0, time.UTC)
+	priority := 1
+	input := Input{
+		Date: "2026-05-31",
+		Now:  now.Format(time.RFC3339),
+		Scenario: &Scenario{
+			Config: DispatchConfig{
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+			},
+			Candidates: []Issue{
+				{
+					ID:               "issue-go",
+					Identifier:       "digitaldrywood/symphony-go#46",
+					Title:            "Go shadow issue",
+					State:            "Todo",
+					Priority:         &priority,
+					CreatedAt:        now.Add(-time.Hour).Format(time.RFC3339),
+					AssignedToWorker: boolPtr(true),
+				},
+			},
+			Tokens: TokenAccounting{
+				InputTokens:  10,
+				OutputTokens: 5,
+				TotalTokens:  15,
+				Sessions:     1,
+				ByModel: []ModelTokenAccounting{
+					{Model: "gpt-5", InputTokens: 10, OutputTokens: 5, TotalTokens: 15, Sessions: 1},
+				},
+			},
+		},
+		Elixir: Observation{
+			Dispatch: DispatchObservation{
+				DispatchOrder: []string{"issue-elixir"},
+				Claimed:       []string{"issue-elixir"},
+			},
+			Tokens: TokenAccounting{
+				InputTokens:  10,
+				OutputTokens: 5,
+				TotalTokens:  16,
+				Sessions:     1,
+				ByModel: []ModelTokenAccounting{
+					{Model: "gpt-5", InputTokens: 10, OutputTokens: 5, TotalTokens: 16, Sessions: 1},
+				},
+			},
+		},
+	}
+
+	report, err := Run(input)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if !report.Diff.HasDifferences {
+		t.Fatal("HasDifferences = false, want true")
+	}
+	if !slices.Equal(report.Go.Dispatch.DispatchOrder, []string{"issue-go"}) {
+		t.Fatalf("Go dispatch order = %#v, want issue-go", report.Go.Dispatch.DispatchOrder)
+	}
+	if !diffFieldsContain(report.Diff.Dispatch, "dispatch_order") {
+		t.Fatalf("Dispatch diffs = %#v, want dispatch_order", report.Diff.Dispatch)
+	}
+	if !tokenDiffsContain(report.Diff.Tokens, "total_tokens") {
+		t.Fatalf("Token diffs = %#v, want total_tokens", report.Diff.Tokens)
+	}
+}
+
+func TestRunNormalizesTokenModelOrder(t *testing.T) {
+	t.Parallel()
+
+	input := Input{
+		Date: "2026-05-31",
+		Now:  "2026-05-31T12:00:00Z",
+		Go: &Observation{
+			Dispatch: DispatchObservation{DispatchOrder: []string{"issue-1"}},
+			Tokens: TokenAccounting{
+				InputTokens:  12,
+				OutputTokens: 8,
+				TotalTokens:  20,
+				Sessions:     2,
+				ByModel: []ModelTokenAccounting{
+					{Model: "gpt-b", InputTokens: 2, OutputTokens: 3, TotalTokens: 5, Sessions: 1},
+					{Model: "gpt-a", InputTokens: 10, OutputTokens: 5, TotalTokens: 15, Sessions: 1},
+				},
+			},
+		},
+		Elixir: Observation{
+			Dispatch: DispatchObservation{DispatchOrder: []string{"issue-1"}},
+			Tokens: TokenAccounting{
+				InputTokens:  12,
+				OutputTokens: 8,
+				TotalTokens:  20,
+				Sessions:     2,
+				ByModel: []ModelTokenAccounting{
+					{Model: "gpt-a", InputTokens: 10, OutputTokens: 5, TotalTokens: 15, Sessions: 1},
+					{Model: "gpt-b", InputTokens: 2, OutputTokens: 3, TotalTokens: 5, Sessions: 1},
+				},
+			},
+		},
+	}
+
+	report, err := Run(input)
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if report.Diff.HasDifferences {
+		t.Fatalf("Diff = %#v, want no differences", report.Diff)
+	}
+}
+
+func diffFieldsContain(diffs []DispatchDiff, field string) bool {
+	for _, diff := range diffs {
+		if diff.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenDiffsContain(diffs []TokenDiff, field string) bool {
+	for _, diff := range diffs {
+		if diff.Field == field {
+			return true
+		}
+	}
+	return false
+}
+
+func boolPtr(value bool) *bool {
+	return &value
+}


### PR DESCRIPTION
## Summary
- Add a read-only dispatch planner that simulates Go dispatch decisions without starting runners or mutating tracker state.
- Add a shadow-run JSON harness and CLI command for daily Elixir/Go dispatch and token-accounting diffs.
- Cover planner, harness, and CLI behavior with focused tests.

Fixes #46

## Test Plan
- go test ./internal/orchestrator ./internal/shadow ./cmd/symphony
- go test -race ./internal/orchestrator ./internal/shadow ./cmd/symphony
- golangci-lint run ./internal/orchestrator ./internal/shadow ./cmd/symphony
- make check