### PR TITLE
feat(install): add boot modes

### DIFF
--- a/cmd/symphony/main_test.go
+++ b/cmd/symphony/main_test.go
@@ -30,25 +30,6 @@ func TestRootCommandHelp(t *testing.T) {
 	}
 }
 
-func TestRootCommandWithoutArgsBootsFromGlobalConfig(t *testing.T) {
-	t.Setenv("SYMPHONY_HOME", t.TempDir())
-
-	cmd := newRootCommand(context.Background())
-
-	var stdout bytes.Buffer
-	cmd.SetOut(&stdout)
-	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{})
-
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("Execute() error = nil, want missing global config")
-	}
-	if !strings.Contains(err.Error(), "read global config") {
-		t.Fatalf("Execute() error = %v, want missing global config", err)
-	}
-}
-
 func TestSignalContextCancel(t *testing.T) {
 	ctx, cancel := newSignalContext(context.Background())
 	cancel()

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+install_dir="${SYMPHONY_INSTALL_DIR:-"$HOME/.local/bin"}"
+state_dir="${SYMPHONY_STATE_DIR:-"$HOME/.symphony"}"
+lock_path="${SYMPHONY_INSTALL_LOCK:-"$state_dir/install.lock"}"
+target="$install_dir/symphony"
+source_binary="${SYMPHONY_INSTALL_SOURCE:-}"
+
+mkdir -p "$install_dir" "$state_dir"
+
+if ! (set -C; : > "$lock_path") 2>/dev/null; then
+	echo "Symphony is already installed on this host: $lock_path" >&2
+	exit 1
+fi
+
+cleanup_lock=true
+cleanup() {
+	if [ "$cleanup_lock" = true ]; then
+		rm -f "$lock_path"
+	fi
+}
+trap cleanup EXIT
+
+tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/symphony-install.XXXXXX")"
+cleanup_tmp() {
+	rm -rf "$tmp_dir"
+}
+trap 'cleanup_tmp; cleanup' EXIT
+
+if [ -n "$source_binary" ]; then
+	cp "$source_binary" "$tmp_dir/symphony"
+else
+	(cd "$repo_root" && go build -o "$tmp_dir/symphony" ./cmd/symphony)
+fi
+
+install -m 0755 "$tmp_dir/symphony" "$target"
+
+{
+	printf 'binary=%s\n' "$target"
+	printf 'installed_at=%s\n' "$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+} > "$lock_path"
+
+cleanup_lock=false
+echo "Installed Symphony at $target"

--- a/install_test.go
+++ b/install_test.go
@@ -1,0 +1,89 @@
+package symphony_test
+
+import (
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestInstallScriptInstallsBinaryAndRefusesExistingLock(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source-symphony")
+	if err := os.WriteFile(source, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	lockPath := filepath.Join(stateDir, "install.lock")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"SYMPHONY_INSTALL_SOURCE="+source,
+		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_STATE_DIR="+stateDir,
+		"SYMPHONY_INSTALL_LOCK="+lockPath,
+	)
+
+	first := runInstall(t, root, env)
+	if first.err != nil {
+		t.Fatalf("first install error = %v\nstdout:\n%s\nstderr:\n%s", first.err, first.stdout, first.stderr)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "symphony")); err != nil {
+		t.Fatalf("installed binary stat error = %v", err)
+	}
+	lock, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile(lock) error = %v", err)
+	}
+	if !strings.Contains(string(lock), filepath.Join(installDir, "symphony")) {
+		t.Fatalf("lock file = %q, want installed binary path", string(lock))
+	}
+
+	second := runInstall(t, root, env)
+	if second.err == nil {
+		t.Fatal("second install error = nil, want lock failure")
+	}
+	if !strings.Contains(second.stderr, "already installed") {
+		t.Fatalf("second install stderr = %q, want already installed", second.stderr)
+	}
+}
+
+type installRun struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func runInstall(t *testing.T, root string, env []string) installRun {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bash", "install.sh")
+	cmd.Dir = root
+	cmd.Env = env
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return installRun{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    err,
+	}
+}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -1,0 +1,264 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	"github.com/digitaldrywood/symphony-go/internal/connector"
+	"github.com/digitaldrywood/symphony-go/internal/connector/memory"
+	"github.com/digitaldrywood/symphony-go/internal/hub"
+	"github.com/digitaldrywood/symphony-go/internal/project"
+	"github.com/digitaldrywood/symphony-go/internal/store"
+	"github.com/digitaldrywood/symphony-go/internal/telemetry"
+	"github.com/digitaldrywood/symphony-go/internal/web"
+)
+
+const (
+	defaultWorkflowFile = "WORKFLOW.md"
+	defaultProjectID    = "default"
+	defaultWebHost      = "127.0.0.1"
+	defaultWebPort      = 4000
+)
+
+func resolveBootConfig(configPath string, host string, port int, opts options) (BootConfig, error) {
+	if port < -1 {
+		return BootConfig{}, errors.New("port must be greater than or equal to 0")
+	}
+
+	path, err := resolveConfigPath(configPath, opts)
+	if err != nil {
+		return BootConfig{}, err
+	}
+
+	cfg, err := opts.read(path)
+	if err == nil {
+		return BootConfig{
+			Mode:   BootModeRunning,
+			Global: cfg,
+			Host:   strings.TrimSpace(host),
+			Port:   bootPort(port),
+		}, nil
+	}
+	if !missingGlobalConfig(err) {
+		return BootConfig{}, err
+	}
+
+	workflowPath := filepath.Join(mustGetwd(), defaultWorkflowFile)
+	if validWorkflowFile(workflowPath) {
+		cfg, err := globalConfigFromWorkflow(path, workflowPath)
+		if err != nil {
+			return BootConfig{}, err
+		}
+		return BootConfig{
+			Mode:         BootModeRunning,
+			Global:       cfg,
+			WorkflowPath: workflowPath,
+			Host:         strings.TrimSpace(host),
+			Port:         bootPort(port),
+		}, nil
+	}
+
+	cfg, err = globalconfig.DefaultAt(path)
+	if err != nil {
+		return BootConfig{}, err
+	}
+	return BootConfig{
+		Mode:         BootModeOnboarding,
+		Global:       cfg,
+		WorkflowPath: workflowPath,
+		Host:         strings.TrimSpace(host),
+		Port:         bootPort(port),
+	}, nil
+}
+
+func defaultBoot(ctx context.Context, cfg BootConfig) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	switch cfg.Mode {
+	case BootModeOnboarding:
+		return startOnboarding(ctx, cfg)
+	default:
+		return startRunning(ctx, cfg)
+	}
+}
+
+func startRunning(ctx context.Context, cfg BootConfig) error {
+	logger := slog.Default()
+	runtimeStore, err := openRuntimeStore(ctx, cfg)
+	if err != nil {
+		return err
+	}
+	defer func() {
+		if err := runtimeStore.Close(); err != nil {
+			logger.Warn("close runtime store failed", "error", err)
+		}
+	}()
+
+	events := hub.New[project.Event]()
+	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg.Global), project.ManagerDependencies{
+		Events: events,
+		Logger: logger,
+	})
+	if err != nil {
+		return err
+	}
+	if err := manager.Start(ctx); err != nil {
+		return err
+	}
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	server, err := web.NewServer(web.Config{
+		Mode:         web.ModeRunning,
+		WorkflowPath: firstWorkflowPath(cfg),
+	}, web.Dependencies{
+		Hub:       snapshotHub,
+		Store:     runtimeStore,
+		Registry:  manager.Registry(),
+		Connector: firstConnector(manager),
+	})
+	if err != nil {
+		return err
+	}
+
+	return serve(ctx, server, serverAddr(cfg))
+}
+
+func startOnboarding(ctx context.Context, cfg BootConfig) error {
+	server, err := web.NewServer(web.Config{
+		Mode:         web.ModeOnboarding,
+		WorkflowPath: firstWorkflowPath(cfg),
+	}, web.Dependencies{})
+	if err != nil {
+		return err
+	}
+
+	return serve(ctx, server, serverAddr(cfg))
+}
+
+func serve(ctx context.Context, server *web.Server, addr string) error {
+	errs := make(chan error, 1)
+	go func() {
+		errs <- server.Start(addr)
+	}()
+
+	select {
+	case <-ctx.Done():
+		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if err := server.Shutdown(shutdownCtx); err != nil {
+			return err
+		}
+		err := <-errs
+		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			return err
+		}
+		return ctx.Err()
+	case err := <-errs:
+		if errors.Is(err, http.ErrServerClosed) {
+			return nil
+		}
+		return err
+	}
+}
+
+func missingGlobalConfig(err error) bool {
+	var missing globalconfig.MissingFileError
+	return errors.As(err, &missing) && errors.Is(missing.Err, os.ErrNotExist)
+}
+
+func validWorkflowFile(path string) bool {
+	workflow, err := workflowconfig.LoadWorkflow(path)
+	if err != nil {
+		return false
+	}
+	return workflow.Config.Validate() == nil
+}
+
+func globalConfigFromWorkflow(globalPath string, workflowPath string) (globalconfig.Config, error) {
+	cfg, err := globalconfig.DefaultAt(globalPath)
+	if err != nil {
+		return globalconfig.Config{}, err
+	}
+
+	workdir := filepath.Dir(workflowPath)
+	cfg.Projects = []globalconfig.Project{
+		{
+			ID:       defaultProjectID,
+			Workflow: workflowPath,
+			Workdir:  workdir,
+			Weight:   1,
+			Priority: 0,
+		},
+	}
+	return cfg, nil
+}
+
+func openRuntimeStore(ctx context.Context, cfg BootConfig) (store.Store, error) {
+	path := filepath.Join(filepath.Dir(cfg.Global.Path), "symphony.db")
+	if strings.TrimSpace(cfg.Global.Path) == "" {
+		path = filepath.Join(mustGetwd(), ".symphony", "symphony.db")
+	}
+	return store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    path,
+	})
+}
+
+func firstConnector(manager *project.Manager) connector.Connector {
+	for _, project := range manager.Registry().List() {
+		if projectConnector := project.Connector(); projectConnector != nil {
+			return projectConnector
+		}
+	}
+	return memory.New(memory.Config{})
+}
+
+func firstWorkflowPath(cfg BootConfig) string {
+	if strings.TrimSpace(cfg.WorkflowPath) != "" {
+		return cfg.WorkflowPath
+	}
+	if len(cfg.Global.Projects) == 0 {
+		return filepath.Join(mustGetwd(), defaultWorkflowFile)
+	}
+	return cfg.Global.Projects[0].Workflow
+}
+
+func bootPort(port int) *int {
+	if port < 0 {
+		return nil
+	}
+	value := port
+	return &value
+}
+
+func serverAddr(cfg BootConfig) string {
+	host := strings.TrimSpace(cfg.Host)
+	if host == "" {
+		host = defaultWebHost
+	}
+	port := defaultWebPort
+	if cfg.Port != nil {
+		port = *cfg.Port
+	}
+	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func mustGetwd() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return wd
+}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -42,11 +42,12 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 
 	cfg, err := opts.read(path)
 	if err == nil {
+		host, port := bootServer(host, port, firstGlobalWorkflowPath(cfg))
 		return BootConfig{
 			Mode:   BootModeRunning,
 			Global: cfg,
-			Host:   strings.TrimSpace(host),
-			Port:   bootPort(port),
+			Host:   host,
+			Port:   port,
 		}, nil
 	}
 	if !missingGlobalConfig(err) {
@@ -59,12 +60,13 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 		if err != nil {
 			return BootConfig{}, err
 		}
+		host, port := bootServer(host, port, workflowPath)
 		return BootConfig{
 			Mode:         BootModeRunning,
 			Global:       cfg,
 			WorkflowPath: workflowPath,
-			Host:         strings.TrimSpace(host),
-			Port:         bootPort(port),
+			Host:         host,
+			Port:         port,
 		}, nil
 	}
 
@@ -127,6 +129,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		Store:     runtimeStore,
 		Registry:  manager.Registry(),
 		Connector: firstConnector(manager),
+		Refresher: refresherForRegistry(manager.Registry()),
 	})
 	if err != nil {
 		return err
@@ -225,6 +228,74 @@ func firstConnector(manager *project.Manager) connector.Connector {
 	return memory.New(memory.Config{})
 }
 
+func refresherForRegistry(registry *project.Registry) web.Refresher {
+	if registry == nil {
+		return nil
+	}
+	return registryRefresher{registry: registry}
+}
+
+type registryRefresher struct {
+	registry *project.Registry
+}
+
+func (r registryRefresher) RequestRefresh(ctx context.Context) (web.RefreshResponse, error) {
+	var response web.RefreshResponse
+	refreshed := false
+	for _, trackedProject := range r.registry.List() {
+		if !trackedProject.Running() {
+			continue
+		}
+		orch := trackedProject.Orchestrator()
+		if orch == nil {
+			continue
+		}
+
+		next, err := orch.RequestRefresh(ctx)
+		if err != nil {
+			return web.RefreshResponse{}, err
+		}
+		if !refreshed {
+			response = next
+			refreshed = true
+			continue
+		}
+		response = mergeRefreshResponse(response, next)
+	}
+	if !refreshed {
+		return web.RefreshResponse{}, project.ErrProjectNotFound
+	}
+	return response, nil
+}
+
+func mergeRefreshResponse(current web.RefreshResponse, next web.RefreshResponse) web.RefreshResponse {
+	current.Queued = current.Queued || next.Queued
+	current.Coalesced = current.Coalesced || next.Coalesced
+	if current.RequestedAt.IsZero() || (!next.RequestedAt.IsZero() && next.RequestedAt.Before(current.RequestedAt)) {
+		current.RequestedAt = next.RequestedAt
+	}
+	current.Operations = appendOperations(current.Operations, next.Operations)
+	return current
+}
+
+func appendOperations(operations []string, next []string) []string {
+	for _, operation := range next {
+		if !hasOperation(operations, operation) {
+			operations = append(operations, operation)
+		}
+	}
+	return operations
+}
+
+func hasOperation(operations []string, operation string) bool {
+	for _, existing := range operations {
+		if existing == operation {
+			return true
+		}
+	}
+	return false
+}
+
 func firstWorkflowPath(cfg BootConfig) string {
 	if strings.TrimSpace(cfg.WorkflowPath) != "" {
 		return cfg.WorkflowPath
@@ -233,6 +304,35 @@ func firstWorkflowPath(cfg BootConfig) string {
 		return filepath.Join(mustGetwd(), defaultWorkflowFile)
 	}
 	return cfg.Global.Projects[0].Workflow
+}
+
+func firstGlobalWorkflowPath(cfg globalconfig.Config) string {
+	if len(cfg.Projects) == 0 {
+		return ""
+	}
+	return cfg.Projects[0].Workflow
+}
+
+func bootServer(host string, port int, workflowPath string) (string, *int) {
+	resolvedHost := strings.TrimSpace(host)
+	resolvedPort := bootPort(port)
+
+	workflowPath = strings.TrimSpace(workflowPath)
+	if workflowPath == "" || (resolvedHost != "" && resolvedPort != nil) {
+		return resolvedHost, resolvedPort
+	}
+
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil || workflow.Config.Validate() != nil {
+		return resolvedHost, resolvedPort
+	}
+	if resolvedHost == "" {
+		resolvedHost = strings.TrimSpace(workflow.Config.Server.Host)
+	}
+	if resolvedPort == nil {
+		resolvedPort = workflow.Config.Server.Port
+	}
+	return resolvedHost, resolvedPort
 }
 
 func bootPort(port int) *int {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony-go/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
+	projectpkg "github.com/digitaldrywood/symphony-go/internal/project"
+	"github.com/digitaldrywood/symphony-go/internal/web"
+)
+
+func TestRegistryRefresherRequestsProjectOrchestrators(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+	mustSetProject(t, registry, startRefreshProject(t, "beta"))
+
+	refresher := refresherForRegistry(registry)
+	if refresher == nil {
+		t.Fatal("refresherForRegistry() = nil, want refresher")
+	}
+
+	response, err := refresher.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	assertRefresh(t, response)
+}
+
+func TestRegistryRefresherSkipsStoppedProjectOrchestrators(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, newRefreshProject(t, "stopped"))
+
+	refresher := refresherForRegistry(registry)
+	_, err := refresher.RequestRefresh(context.Background())
+	if !errors.Is(err, projectpkg.ErrProjectNotFound) {
+		t.Fatalf("RequestRefresh() error = %v, want %v", err, projectpkg.ErrProjectNotFound)
+	}
+}
+
+func TestRegistryRefresherReturnsProjectNotFoundWithoutOrchestrators(t *testing.T) {
+	t.Parallel()
+
+	refresher := refresherForRegistry(projectpkg.NewRegistry())
+	_, err := refresher.RequestRefresh(context.Background())
+	if !errors.Is(err, projectpkg.ErrProjectNotFound) {
+		t.Fatalf("RequestRefresh() error = %v, want %v", err, projectpkg.ErrProjectNotFound)
+	}
+}
+
+func newRefreshProject(t *testing.T, id string) *projectpkg.Project {
+	t.Helper()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	project, err := projectpkg.New(projectpkg.Config{
+		Project: globalconfig.Project{
+			ID:      id,
+			Workdir: t.TempDir(),
+			Weight:  1,
+		},
+		Workflow: workflowconfig.Workflow{Config: cfg, Prompt: "Test workflow prompt."},
+	}, projectpkg.Dependencies{})
+	if err != nil {
+		t.Fatalf("project.New() error = %v", err)
+	}
+	return project
+}
+
+func startRefreshProject(t *testing.T, id string) *projectpkg.Project {
+	t.Helper()
+
+	project := newRefreshProject(t, id)
+	if err := project.Start(context.Background()); err != nil {
+		t.Fatalf("Project.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		defer cancel()
+		if err := project.Stop(ctx); err != nil && !errors.Is(err, projectpkg.ErrNotRunning) {
+			t.Fatalf("Project.Stop() error = %v", err)
+		}
+	})
+	return project
+}
+
+func mustSetProject(t *testing.T, registry *projectpkg.Registry, project *projectpkg.Project) {
+	t.Helper()
+
+	if err := registry.Set(project); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+}
+
+func assertRefresh(t *testing.T, response web.RefreshResponse) {
+	t.Helper()
+
+	if !response.Queued {
+		t.Fatalf("Queued = false, want true; response = %#v", response)
+	}
+	if response.RequestedAt.IsZero() {
+		t.Fatalf("RequestedAt is zero; response = %#v", response)
+	}
+	if len(response.Operations) != 2 || response.Operations[0] != "poll" || response.Operations[1] != "reconcile" {
+		t.Fatalf("Operations = %#v, want poll/reconcile", response.Operations)
+	}
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"log/slog"
 	"os"
 	"strings"
 
@@ -37,7 +36,22 @@ type Signal struct {
 	Project   globalconfig.Project
 }
 
-type BootFunc func(context.Context, globalconfig.Config) error
+type BootMode string
+
+const (
+	BootModeRunning    BootMode = "running"
+	BootModeOnboarding BootMode = "onboarding"
+)
+
+type BootConfig struct {
+	Mode         BootMode
+	Global       globalconfig.Config
+	WorkflowPath string
+	Host         string
+	Port         *int
+}
+
+type BootFunc func(context.Context, BootConfig) error
 
 type SignalFunc func(context.Context, Signal) error
 
@@ -112,6 +126,8 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	}
 
 	var configPath string
+	var host string
+	var port int
 	cmd := &cobra.Command{
 		Use:          "symphony",
 		Short:        "Symphony agent orchestrator",
@@ -119,19 +135,17 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			path, err := resolveConfigPath(configPath, opts)
+			boot, err := resolveBootConfig(configPath, host, port, opts)
 			if err != nil {
 				return err
 			}
-			cfg, err := opts.read(path)
-			if err != nil {
-				return err
-			}
-			return opts.boot(cmd.Context(), cfg)
+			return opts.boot(cmd.Context(), boot)
 		},
 	}
 	cmd.SetContext(ctx)
 	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to global.yaml")
+	cmd.PersistentFlags().StringVar(&host, "host", "", "web server host")
+	cmd.PersistentFlags().IntVar(&port, "port", -1, "web server port, or 0 for an ephemeral port")
 	cmd.AddCommand(
 		newInitCommand(&configPath, opts),
 		newAddProjectCommand(&configPath, opts),
@@ -165,25 +179,6 @@ func defaultOptions() options {
 		boot:   defaultBoot,
 		signal: noSignal,
 	}
-}
-
-func defaultBoot(ctx context.Context, cfg globalconfig.Config) error {
-	if ctx == nil {
-		ctx = context.Background()
-	}
-
-	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg), project.ManagerDependencies{
-		Logger: slog.Default(),
-	})
-	if err != nil {
-		return err
-	}
-	if err := manager.Start(ctx); err != nil {
-		return err
-	}
-
-	<-ctx.Done()
-	return ctx.Err()
 }
 
 func noSignal(context.Context, Signal) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,6 +98,75 @@ func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing
 	if got.Global.Projects[0].Workflow != got.WorkflowPath {
 		t.Fatalf("project workflow = %q, want %q", got.Global.Projects[0].Workflow, got.WorkflowPath)
 	}
+}
+
+func TestRootCommandUsesDefaultWorkflowServerAddress(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
+	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer("0.0.0.0", 4101))
+	t.Chdir(root)
+
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertBootServer(t, <-booted, "0.0.0.0", 4101)
+}
+
+func TestRootCommandUsesConfiguredProjectWorkflowServerAddress(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFilesWithWorkflow(t, workflowContentWithServer("127.0.0.2", 4102))
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "symphony", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
+	})
+
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", configPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertBootServer(t, <-booted, "127.0.0.2", 4102)
+}
+
+func TestRootCommandCLIAddressOverridesWorkflowServerAddress(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
+	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer("0.0.0.0", 4103))
+	t.Chdir(root)
+
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--host", "127.0.0.3", "--port", "0"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	assertBootServer(t, <-booted, "127.0.0.3", 0)
 }
 
 func TestRootCommandUsesOnboardingModeWithoutValidWorkflow(t *testing.T) {
@@ -465,6 +535,12 @@ type projectPaths struct {
 func createProjectFiles(t *testing.T) projectPaths {
 	t.Helper()
 
+	return createProjectFilesWithWorkflow(t, validWorkflowContent())
+}
+
+func createProjectFilesWithWorkflow(t *testing.T, content string) projectPaths {
+	t.Helper()
+
 	root := t.TempDir()
 	workdir := filepath.Join(root, "project")
 	workflow := filepath.Join(workdir, "WORKFLOW.md")
@@ -472,7 +548,7 @@ func createProjectFiles(t *testing.T) projectPaths {
 	if err := os.MkdirAll(workdir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
-	writeWorkflow(t, workflow, validWorkflowContent())
+	writeWorkflow(t, workflow, content)
 
 	return projectPaths{
 		root:         root,
@@ -499,6 +575,32 @@ tracker:
 ---
 Test workflow prompt.
 `
+}
+
+func workflowContentWithServer(host string, port int) string {
+	return fmt.Sprintf(`---
+tracker:
+  kind: memory
+server:
+  host: %s
+  port: %d
+---
+Test workflow prompt.
+`, host, port)
+}
+
+func assertBootServer(t *testing.T, cfg cli.BootConfig, host string, port int) {
+	t.Helper()
+
+	if cfg.Host != host {
+		t.Fatalf("boot host = %q, want %q", cfg.Host, host)
+	}
+	if cfg.Port == nil {
+		t.Fatalf("boot port = nil, want %d", port)
+	}
+	if *cfg.Port != port {
+		t.Fatalf("boot port = %d, want %d", *cfg.Port, port)
+	}
 }
 
 func writeGlobalConfig(t *testing.T, path string, projects []globalconfig.Project) {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -43,8 +43,8 @@ func TestRootCommandBootsFromGlobalConfig(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "global.yaml")
 	writeGlobalConfig(t, path, nil)
 
-	booted := make(chan globalconfig.Config, 1)
-	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg globalconfig.Config) error {
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
 		booted <- cfg
 		return nil
 	}))
@@ -57,8 +57,87 @@ func TestRootCommandBootsFromGlobalConfig(t *testing.T) {
 	}
 
 	got := <-booted
-	if got.Path != path {
-		t.Fatalf("booted config path = %q, want %q", got.Path, path)
+	if got.Mode != cli.BootModeRunning {
+		t.Fatalf("boot mode = %q, want %q", got.Mode, cli.BootModeRunning)
+	}
+	if got.Global.Path != path {
+		t.Fatalf("booted config path = %q, want %q", got.Global.Path, path)
+	}
+}
+
+func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
+	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), validWorkflowContent())
+	t.Chdir(root)
+
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if got.Mode != cli.BootModeRunning {
+		t.Fatalf("boot mode = %q, want %q", got.Mode, cli.BootModeRunning)
+	}
+	if got.WorkflowPath != filepath.Join(root, "WORKFLOW.md") {
+		t.Fatalf("workflow path = %q, want default WORKFLOW.md", got.WorkflowPath)
+	}
+	if len(got.Global.Projects) != 1 {
+		t.Fatalf("projects length = %d, want 1", len(got.Global.Projects))
+	}
+	if got.Global.Projects[0].Workflow != got.WorkflowPath {
+		t.Fatalf("project workflow = %q, want %q", got.Global.Projects[0].Workflow, got.WorkflowPath)
+	}
+}
+
+func TestRootCommandUsesOnboardingModeWithoutValidWorkflow(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+	}{
+		{name: "missing workflow"},
+		{name: "invalid workflow", content: "not frontmatter\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			root := t.TempDir()
+			t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
+			if tt.content != "" {
+				writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), tt.content)
+			}
+			t.Chdir(root)
+
+			booted := make(chan cli.BootConfig, 1)
+			cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+				booted <- cfg
+				return nil
+			}))
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			got := <-booted
+			if got.Mode != cli.BootModeOnboarding {
+				t.Fatalf("boot mode = %q, want %q", got.Mode, cli.BootModeOnboarding)
+			}
+			if len(got.Global.Projects) != 0 {
+				t.Fatalf("projects = %#v, want none in onboarding mode", got.Global.Projects)
+			}
+		})
 	}
 }
 
@@ -393,15 +472,33 @@ func createProjectFiles(t *testing.T) projectPaths {
 	if err := os.MkdirAll(workdir, 0o755); err != nil {
 		t.Fatalf("MkdirAll() error = %v", err)
 	}
-	if err := os.WriteFile(workflow, []byte("# workflow\n"), 0o644); err != nil {
-		t.Fatalf("WriteFile() error = %v", err)
-	}
+	writeWorkflow(t, workflow, validWorkflowContent())
 
 	return projectPaths{
 		root:         root,
 		workflowPath: workflow,
 		workdirPath:  workdir,
 	}
+}
+
+func writeWorkflow(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func validWorkflowContent() string {
+	return `---
+tracker:
+  kind: memory
+---
+Test workflow prompt.
+`
 }
 
 func writeGlobalConfig(t *testing.T, path string, projects []globalconfig.Project) {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -214,6 +214,9 @@ func (p *Project) Connector() connector.Connector {
 }
 
 func (p *Project) Orchestrator() *orchestrator.Orchestrator {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
 	return p.orchestrator
 }
 

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -17,7 +17,7 @@ func TestOnboardingRoutesProgressThroughWizard(t *testing.T) {
 	t.Parallel()
 
 	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
-	server, err := web.NewServer(web.Config{WorkflowPath: workflowPath}, testDeps(t))
+	server, err := web.NewServer(web.Config{Mode: web.ModeOnboarding, WorkflowPath: workflowPath}, web.Dependencies{})
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -32,8 +32,16 @@ type Dependencies struct {
 	Refresher Refresher
 }
 
+type Mode string
+
+const (
+	ModeRunning    Mode = "running"
+	ModeOnboarding Mode = "onboarding"
+)
+
 type Config struct {
 	Logger          *slog.Logger
+	Mode            Mode
 	StaticDir       string
 	SSETickInterval time.Duration
 	WorkflowPath    string
@@ -47,22 +55,26 @@ type Server struct {
 	connector connector.Connector
 	refresher Refresher
 	logger    *slog.Logger
+	mode      Mode
 	tickEvery time.Duration
 	workflow  string
 }
 
 func NewServer(cfg Config, deps Dependencies) (*Server, error) {
-	if deps.Hub == nil {
-		return nil, ErrMissingHub
-	}
-	if deps.Store == nil {
-		return nil, ErrMissingStore
-	}
-	if deps.Registry == nil {
-		return nil, ErrMissingRegistry
-	}
-	if deps.Connector == nil {
-		return nil, ErrMissingConnector
+	mode := cfg.mode()
+	if mode == ModeRunning {
+		if deps.Hub == nil {
+			return nil, ErrMissingHub
+		}
+		if deps.Store == nil {
+			return nil, ErrMissingStore
+		}
+		if deps.Registry == nil {
+			return nil, ErrMissingRegistry
+		}
+		if deps.Connector == nil {
+			return nil, ErrMissingConnector
+		}
 	}
 
 	e := echo.New()
@@ -77,6 +89,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		connector: deps.Connector,
 		refresher: deps.Refresher,
 		logger:    cfg.logger(),
+		mode:      mode,
 		tickEvery: cfg.sseTickInterval(),
 		workflow:  cfg.workflowPath(),
 	}
@@ -106,15 +119,26 @@ func (s *Server) Shutdown(ctx context.Context) error {
 
 func (s *Server) registerRoutes(staticDir string) {
 	s.echo.Static("/static", staticDir)
+	s.echo.GET("/health", s.health)
+	if s.mode == ModeOnboarding {
+		s.echo.GET("/", s.redirectToOnboarding)
+		s.echo.GET("/onboarding", s.onboarding)
+		s.echo.POST("/onboarding/tracker", s.onboardingTracker)
+		s.echo.POST("/onboarding/credentials", s.onboardingCredentials)
+		s.echo.POST("/onboarding/project", s.onboardingProject)
+		s.echo.POST("/onboarding/agent", s.onboardingAgent)
+		s.echo.POST("/onboarding/write", s.onboardingWrite)
+		return
+	}
+
 	s.echo.GET("/", s.dashboard)
 	s.echo.GET("/events", s.events)
-	s.echo.GET("/onboarding", s.onboarding)
+	s.echo.GET("/onboarding", s.redirectToDashboard)
 	s.echo.POST("/onboarding/tracker", s.onboardingTracker)
 	s.echo.POST("/onboarding/credentials", s.onboardingCredentials)
 	s.echo.POST("/onboarding/project", s.onboardingProject)
 	s.echo.POST("/onboarding/agent", s.onboardingAgent)
 	s.echo.POST("/onboarding/write", s.onboardingWrite)
-	s.echo.GET("/health", s.health)
 	s.echo.GET("/api/v1/state", s.apiState)
 	s.echo.POST("/api/v1/refresh", s.apiRefresh)
 	s.echo.GET("/api/v1/refresh", s.methodNotAllowed)
@@ -149,7 +173,8 @@ func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
 func (s *Server) health(c echo.Context) error {
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:    "ok",
-		Connector: s.connector.Name(),
+		Mode:      string(s.mode),
+		Connector: s.connectorName(),
 		Checks: map[string]string{
 			"hub":       configuredStatus(s.hub),
 			"store":     configuredStatus(s.store),
@@ -157,6 +182,14 @@ func (s *Server) health(c echo.Context) error {
 			"connector": configuredStatus(s.connector),
 		},
 	})
+}
+
+func (s *Server) redirectToOnboarding(c echo.Context) error {
+	return c.Redirect(http.StatusFound, "/onboarding")
+}
+
+func (s *Server) redirectToDashboard(c echo.Context) error {
+	return c.Redirect(http.StatusFound, "/")
 }
 
 func render(c echo.Context, component templ.Component) error {
@@ -169,6 +202,13 @@ func (cfg Config) logger() *slog.Logger {
 		return cfg.Logger
 	}
 	return slog.Default()
+}
+
+func (cfg Config) mode() Mode {
+	if cfg.Mode == ModeOnboarding {
+		return ModeOnboarding
+	}
+	return ModeRunning
 }
 
 func (cfg Config) staticDir() string {
@@ -199,8 +239,16 @@ func configuredStatus(value any) string {
 	return "configured"
 }
 
+func (s *Server) connectorName() string {
+	if s.connector == nil {
+		return ""
+	}
+	return s.connector.Name()
+}
+
 type healthResponse struct {
 	Status    string            `json:"status"`
+	Mode      string            `json:"mode"`
 	Connector string            `json:"connector"`
 	Checks    map[string]string `json:"checks"`
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -143,6 +143,66 @@ func TestServerRoutes(t *testing.T) {
 	}
 }
 
+func TestOnboardingModeDoesNotRequireRuntimeDependencies(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{
+		Mode:      web.ModeOnboarding,
+		StaticDir: t.TempDir(),
+	}, web.Dependencies{})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	tests := []struct {
+		name         string
+		path         string
+		wantStatus   int
+		wantContent  string
+		wantLocation string
+	}{
+		{
+			name:         "root redirects to onboarding",
+			path:         "/",
+			wantStatus:   http.StatusFound,
+			wantLocation: "/onboarding",
+		},
+		{
+			name:        "onboarding page",
+			path:        "/onboarding",
+			wantStatus:  http.StatusOK,
+			wantContent: "Symphony onboarding",
+		},
+		{
+			name:        "health",
+			path:        "/health",
+			wantStatus:  http.StatusOK,
+			wantContent: `"mode":"onboarding"`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, tt.path, nil)
+
+			server.Handler().ServeHTTP(rec, req)
+
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			if tt.wantLocation != "" && rec.Header().Get("Location") != tt.wantLocation {
+				t.Fatalf("Location = %q, want %q", rec.Header().Get("Location"), tt.wantLocation)
+			}
+			if tt.wantContent != "" && !strings.Contains(rec.Body.String(), tt.wantContent) {
+				t.Fatalf("body missing %q:\n%s", tt.wantContent, rec.Body.String())
+			}
+		})
+	}
+}
+
 func TestDashboardRendersLatestSnapshot(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- add install.sh single-binary installer with a one-per-host lock file
- route root boot through running versus onboarding decisions, including default WORKFLOW.md fallback when global.yaml is absent
- allow onboarding web mode to start without orchestrator/runtime dependencies

Fixes #42

## Test Plan
- go test . ./cmd/symphony ./internal/cli ./internal/web
- go test ./...
- make check