### PR TITLE
test(s7): add fresh install gate

### DIFF
--- a/install_test.go
+++ b/install_test.go
@@ -2,12 +2,21 @@ package symphony_test
 
 import (
 	"context"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
+	"sync"
+	"syscall"
 	"testing"
 	"time"
+
+	globalconfig "github.com/digitaldrywood/symphony-go/internal/config/global"
 )
 
 func TestInstallScriptInstallsBinaryAndRefusesExistingLock(t *testing.T) {
@@ -59,6 +68,52 @@ func TestInstallScriptInstallsBinaryAndRefusesExistingLock(t *testing.T) {
 	}
 }
 
+func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	tmp := t.TempDir()
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_STATE_DIR="+stateDir,
+		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+	)
+
+	install := runInstallWithTimeout(t, root, env, time.Minute)
+	if install.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", install.err, install.stdout, install.stderr)
+	}
+
+	binary := filepath.Join(installDir, "symphony")
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("installed binary stat error = %v", err)
+	}
+
+	home := filepath.Join(tmp, "home")
+	workdir := filepath.Join(tmp, "fresh")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workdir) error = %v", err)
+	}
+	serverEnv := append(os.Environ(),
+		"HOME="+home,
+		"SYMPHONY_HOME="+filepath.Join(home, ".symphony"),
+	)
+	port := reservePort(t)
+	stop := startSymphonyServer(t, binary, workdir, serverEnv, port)
+	waitForOnboardingHealth(t, port)
+	onboarding := readURL(t, fmt.Sprintf("http://127.0.0.1:%d/onboarding", port))
+	if !strings.Contains(onboarding, "Symphony onboarding") {
+		t.Fatalf("onboarding page missing wizard heading:\n%s", onboarding)
+	}
+	stop()
+
+	runInstalledSubcommands(t, binary, tmp, serverEnv)
+}
+
 type installRun struct {
 	stdout string
 	stderr string
@@ -68,7 +123,13 @@ type installRun struct {
 func runInstall(t *testing.T, root string, env []string) installRun {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	return runInstallWithTimeout(t, root, env, 10*time.Second)
+}
+
+func runInstallWithTimeout(t *testing.T, root string, env []string, timeout time.Duration) installRun {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bash", "install.sh")
@@ -86,4 +147,223 @@ func runInstall(t *testing.T, root string, env []string) installRun {
 		stderr: stderr.String(),
 		err:    err,
 	}
+}
+
+func reservePort(t *testing.T) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener address = %T, want *net.TCPAddr", listener.Addr())
+	}
+	return addr.Port
+}
+
+func startSymphonyServer(t *testing.T, binary string, workdir string, env []string, port int) func() {
+	t.Helper()
+
+	cmd := exec.Command(binary, "--host", "127.0.0.1", "--port", strconv.Itoa(port))
+	cmd.Dir = workdir
+	cmd.Env = env
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- cmd.Wait()
+	}()
+
+	var once sync.Once
+	stop := func() {
+		t.Helper()
+
+		once.Do(func() {
+			if cmd.Process != nil {
+				_ = cmd.Process.Signal(syscall.SIGTERM)
+			}
+			select {
+			case err := <-done:
+				if err != nil {
+					t.Fatalf("symphony shutdown error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+				}
+			case <-time.After(2 * time.Second):
+				if cmd.Process != nil {
+					_ = cmd.Process.Kill()
+				}
+				t.Fatalf("timed out waiting for symphony shutdown\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+			}
+		})
+	}
+	t.Cleanup(stop)
+
+	return stop
+}
+
+func waitForOnboardingHealth(t *testing.T, port int) {
+	t.Helper()
+
+	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		body, err := tryReadURL(url)
+		if err == nil && strings.Contains(body, `"mode":"onboarding"`) {
+			return
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	t.Fatalf("health endpoint did not report onboarding mode at %s", url)
+}
+
+func readURL(t *testing.T, url string) string {
+	t.Helper()
+
+	body, err := tryReadURL(url)
+	if err != nil {
+		t.Fatalf("GET %s error = %v", url, err)
+	}
+	return body
+}
+
+func tryReadURL(url string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return "", err
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", err
+	}
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("status = %d body = %s", resp.StatusCode, raw)
+	}
+	return string(raw), nil
+}
+
+func runInstalledSubcommands(t *testing.T, binary string, root string, env []string) {
+	t.Helper()
+
+	workdir := filepath.Join(root, "subcommands")
+	projectDir := filepath.Join(workdir, "project")
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll(projectDir) error = %v", err)
+	}
+	workflowPath := filepath.Join(projectDir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(gateWorkflowContent()), 0o600); err != nil {
+		t.Fatalf("WriteFile(workflow) error = %v", err)
+	}
+	configPath := filepath.Join(workdir, "global.yaml")
+
+	runSymphonyCommand(t, binary, workdir, env, "--config", configPath, "init")
+	runSymphonyCommand(t, binary, workdir, env,
+		"--config", configPath,
+		"add-project",
+		"--id", "symphony",
+		"--workflow", workflowPath,
+		"--workdir", projectDir,
+		"--weight", "2",
+		"--priority", "4",
+	)
+	assertInstalledProject(t, configPath, func(project globalconfig.Project) {
+		if project.ID != "symphony" || project.Workflow != workflowPath || project.Workdir != projectDir {
+			t.Fatalf("project = %#v, want installed symphony project", project)
+		}
+		if project.Weight != 2 || project.Priority != 4 {
+			t.Fatalf("project scheduling = weight %d priority %d, want 2/4", project.Weight, project.Priority)
+		}
+	})
+
+	runSymphonyCommand(t, binary, workdir, env, "--config", configPath, "pause", "symphony")
+	assertInstalledProject(t, configPath, func(project globalconfig.Project) {
+		if !project.Paused {
+			t.Fatal("project Paused = false, want true")
+		}
+	})
+
+	runSymphonyCommand(t, binary, workdir, env, "--config", configPath, "unpause", "symphony")
+	assertInstalledProject(t, configPath, func(project globalconfig.Project) {
+		if project.Paused {
+			t.Fatal("project Paused = true, want false")
+		}
+	})
+
+	runSymphonyCommand(t, binary, workdir, env, "--config", configPath, "promote", "symphony", "--priority", "1")
+	assertInstalledProject(t, configPath, func(project globalconfig.Project) {
+		if project.Priority != 1 {
+			t.Fatalf("project Priority = %d, want 1", project.Priority)
+		}
+	})
+
+	runSymphonyCommand(t, binary, workdir, env, "--config", configPath, "remove-project", "symphony")
+	cfg, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("Projects = %#v, want none", cfg.Projects)
+	}
+}
+
+func runSymphonyCommand(t *testing.T, binary string, workdir string, env []string, args ...string) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, binary, args...)
+	cmd.Dir = workdir
+	cmd.Env = env
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("symphony %v error = %v\nstdout:\n%s\nstderr:\n%s", args, err, stdout.String(), stderr.String())
+	}
+}
+
+func assertInstalledProject(t *testing.T, configPath string, check func(globalconfig.Project)) {
+	t.Helper()
+
+	cfg, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(cfg.Projects) != 1 {
+		t.Fatalf("Projects length = %d, want 1", len(cfg.Projects))
+	}
+	check(cfg.Projects[0])
+}
+
+func gateWorkflowContent() string {
+	return `---
+tracker:
+  kind: memory
+---
+Gate prompt.
+`
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -3,7 +3,11 @@ package project_test
 import (
 	"context"
 	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -295,6 +299,85 @@ func TestProjectWorkflowReloadRefreshesRestartDependencies(t *testing.T) {
 	}
 	if len(issues) != 1 || issues[0].ID != "issue-1" {
 		t.Fatalf("restarted connector issues = %#v, want issue-1", issues)
+	}
+
+	close(runner.release)
+	if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+		t.Fatalf("Stop() error = %v", err)
+	}
+}
+
+func TestProjectHotReloadsWorkflowFileWithoutRestart(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	writeProjectGateWorkflow(t, workflowPath, int(time.Hour/time.Millisecond), "", "initial")
+
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	runner := newProjectBlockingRunner()
+	var orchestratorCreates atomic.Int32
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:       "symphony",
+			Workflow: workflowPath,
+			Weight:   1,
+		},
+		Workflow: workflow,
+	}, project.Dependencies{
+		Events: events,
+		Runner: runner,
+		OrchestratorFactory: func(cfg orchestrator.Config, deps orchestrator.Dependencies) (*orchestrator.Orchestrator, error) {
+			orchestratorCreates.Add(1)
+			return orchestrator.New(cfg, deps)
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if orchestratorCreates.Load() != 1 {
+		t.Fatalf("orchestrator creations = %d, want 1", orchestratorCreates.Load())
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	started := receiveEvent(t, sub.C())
+	if started.Kind != project.EventStarted {
+		t.Fatalf("started event = %#v, want project started", started)
+	}
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected run before workflow reload = %#v", request)
+	case <-time.After(25 * time.Millisecond):
+	}
+
+	request := receiveHotReloadRun(t, runner.started, func() {
+		writeProjectGateWorkflow(t, workflowPath, 5, "issue-43", "reloaded")
+	})
+	if request.Issue.ID != "issue-43" {
+		t.Fatalf("RunRequest.Issue.ID = %q, want issue-43", request.Issue.ID)
+	}
+	if got.Workflow().Prompt != "reloaded\n" {
+		t.Fatalf("Workflow().Prompt = %q, want reloaded", got.Workflow().Prompt)
+	}
+	if orchestratorCreates.Load() != 1 {
+		t.Fatalf("orchestrator creations after reload = %d, want no restart", orchestratorCreates.Load())
+	}
+
+	select {
+	case event := <-sub.C():
+		t.Fatalf("unexpected lifecycle event after hot reload = %#v", event)
+	case <-time.After(25 * time.Millisecond):
 	}
 
 	close(runner.release)
@@ -762,6 +845,52 @@ func receiveRunRequest(t *testing.T, ch <-chan orchestrator.RunRequest) orchestr
 	}
 
 	return orchestrator.RunRequest{}
+}
+
+func receiveHotReloadRun(t *testing.T, ch <-chan orchestrator.RunRequest, reload func()) orchestrator.RunRequest {
+	t.Helper()
+
+	ticker := time.NewTicker(250 * time.Millisecond)
+	defer ticker.Stop()
+	deadline := time.After(3 * time.Second)
+
+	for {
+		reload()
+		select {
+		case request := <-ch:
+			return request
+		case <-ticker.C:
+		case <-deadline:
+			t.Fatal("timed out waiting for hot-reload runner request")
+		}
+	}
+}
+
+func writeProjectGateWorkflow(t *testing.T, path string, intervalMS int, issueID string, prompt string) {
+	t.Helper()
+
+	issues := ""
+	if issueID != "" {
+		issues = fmt.Sprintf(`  issues:
+    - id: %s
+      identifier: %s
+      title: Hot reload gate
+      state: Todo
+      assigned_to_worker: true
+`, issueID, issueID)
+	}
+
+	raw := fmt.Sprintf(`---
+tracker:
+  kind: memory
+%spolling:
+  interval_ms: %d
+---
+%s
+`, issues, intervalMS, prompt)
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
 }
 
 func receiveOrchestratorConfig(t *testing.T, ch <-chan orchestrator.Config) orchestrator.Config {


### PR DESCRIPTION
## Summary
- add an installed-binary gate covering install.sh, onboarding boot on an ephemeral port, and admin subcommands
- add a real WORKFLOW.md hot-reload gate that verifies the running project reloads without recreating the orchestrator

Fixes #43

## Test Plan
- go test . ./internal/project
- make check