### PR TITLE
fix(boot): wire agent runner + live telemetry so symphony dispatches

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -109,9 +109,14 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}()
 
 	events := hub.New[project.Event]()
-	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg.Global), project.ManagerDependencies{
+	projectFactory := withRunnerFactory(project.Dependencies{
 		Events: events,
 		Logger: logger,
+	}, runtimeStore, nil)
+	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg.Global), project.ManagerDependencies{
+		ProjectFactory: projectFactory,
+		Events:         events,
+		Logger:         logger,
 	})
 	if err != nil {
 		return err
@@ -121,6 +126,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
+	go publishSnapshots(ctx, manager.Registry(), snapshotHub, defaultSnapshotInterval, time.Now)
 	server, err := web.NewServer(web.Config{
 		Mode:         web.ModeRunning,
 		WorkflowPath: firstWorkflowPath(cfg),

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -1,0 +1,228 @@
+package cli
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/symphony/internal/codex"
+	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
+	"github.com/digitaldrywood/symphony/internal/hub"
+	"github.com/digitaldrywood/symphony/internal/orchestrator"
+	"github.com/digitaldrywood/symphony/internal/project"
+	runnerpkg "github.com/digitaldrywood/symphony/internal/runner"
+	"github.com/digitaldrywood/symphony/internal/telemetry"
+	"github.com/digitaldrywood/symphony/internal/workspace"
+)
+
+const defaultSnapshotInterval = time.Second
+
+// withRunnerFactory returns a project.ProjectFactory that constructs a
+// per-project agent Runner from the project's own workflow (so each project's
+// codex command and workspace root are honored), injects it into the project's
+// dependencies, and then delegates to load.
+//
+// If load is nil, the default project.Load is used.
+func withRunnerFactory(
+	deps project.Dependencies,
+	sessionStore runnerpkg.SessionStore,
+	load func(project.Dependencies) (*project.Project, error),
+) project.ProjectFactory {
+	return func(cfg globalconfig.Project) (*project.Project, error) {
+		workflow, err := workflowconfig.LoadWorkflow(cfg.Workflow)
+		if err != nil {
+			return nil, fmt.Errorf("load project workflow %s: %w", cfg.ID, err)
+		}
+
+		run, err := buildRunner(workflow, sessionStore, deps.Logger)
+		if err != nil {
+			return nil, fmt.Errorf("build project runner %s: %w", cfg.ID, err)
+		}
+
+		projectDeps := deps
+		projectDeps.Runner = run
+
+		if load != nil {
+			return load(projectDeps)
+		}
+		return project.Load(cfg, projectDeps)
+	}
+}
+
+// buildRunner constructs the agent Runner for a single project's workflow,
+// wiring its workspace backend, codex app-server client, and session store.
+func buildRunner(
+	workflow workflowconfig.Workflow,
+	sessionStore runnerpkg.SessionStore,
+	logger *slog.Logger,
+) (orchestrator.Runner, error) {
+	cfg := workflow.Config
+
+	backend, err := buildWorkspaceBackend(cfg, logger)
+	if err != nil {
+		return nil, err
+	}
+
+	codexClient, err := buildCodexClient(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
+		Workflow:  workflow,
+		Workspace: backend,
+		Codex:     codexClient,
+		Store:     sessionStore,
+		Logger:    logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create runner: %w", err)
+	}
+	return run, nil
+}
+
+func buildWorkspaceBackend(cfg workflowconfig.Config, logger *slog.Logger) (workspace.Backend, error) {
+	root := strings.TrimSpace(cfg.Workspace.Root)
+	backend, err := workspace.NewBackend(workspace.KindLocalGit, workspace.LocalGitOptions{
+		Root:       root,
+		SourceRoot: root,
+		AutoBranch: cfg.Workspace.AutoBranch,
+		Hooks: workspace.Hooks{
+			AfterCreate:  cfg.Hooks.AfterCreate,
+			BeforeRun:    cfg.Hooks.BeforeRun,
+			AfterRun:     cfg.Hooks.AfterRun,
+			BeforeRemove: cfg.Hooks.BeforeRemove,
+			Timeout:      durationFromMillis(cfg.Hooks.TimeoutMS),
+		},
+		Logger: logger,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create workspace backend: %w", err)
+	}
+	return backend, nil
+}
+
+func buildCodexClient(cfg workflowconfig.Config) (runnerpkg.CodexClient, error) {
+	command := strings.TrimSpace(cfg.Codex.Command)
+	if command == "" {
+		return nil, fmt.Errorf("codex command is required")
+	}
+
+	factory, err := codex.NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		// #nosec G204 -- codex command is operator-supplied trusted workflow config.
+		return exec.CommandContext(ctx, "sh", "-c", command)
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create codex transport factory: %w", err)
+	}
+
+	opts := []codex.AppServerOption{}
+	if timeout := durationFromMillis(cfg.Codex.ReadTimeoutMS); timeout > 0 {
+		opts = append(opts, codex.WithReadTimeout(timeout))
+	}
+	if timeout := durationFromMillis(cfg.Codex.TurnTimeoutMS); timeout > 0 {
+		opts = append(opts, codex.WithTurnTimeout(timeout))
+	}
+
+	client, err := codex.NewAppServer(factory, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("create codex app-server: %w", err)
+	}
+	return client, nil
+}
+
+// publishSnapshots ticks at interval, building a merged telemetry snapshot
+// across every running project's orchestrator and publishing it to hub until
+// ctx is cancelled.
+func publishSnapshots(
+	ctx context.Context,
+	registry *project.Registry,
+	snapshotHub *hub.Hub[telemetry.Snapshot],
+	interval time.Duration,
+	now func() time.Time,
+) {
+	if registry == nil || snapshotHub == nil {
+		return
+	}
+	if interval <= 0 {
+		interval = defaultSnapshotInterval
+	}
+	if now == nil {
+		now = time.Now
+	}
+
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		if err := publishSnapshotOnce(ctx, registry, snapshotHub, now()); err != nil {
+			slog.Default().Warn("publish telemetry snapshot failed", "error", err)
+		}
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+		}
+	}
+}
+
+func publishSnapshotOnce(
+	ctx context.Context,
+	registry *project.Registry,
+	snapshotHub *hub.Hub[telemetry.Snapshot],
+	now time.Time,
+) error {
+	merged := telemetry.Snapshot{GeneratedAt: now}
+	for _, trackedProject := range registry.List() {
+		if !trackedProject.Running() {
+			continue
+		}
+		orch := trackedProject.Orchestrator()
+		if orch == nil {
+			continue
+		}
+		state, err := orch.State(ctx)
+		if err != nil {
+			continue
+		}
+		merged = mergeSnapshot(merged, state.Snapshot(now))
+	}
+	if err := snapshotHub.Publish(merged); err != nil {
+		return fmt.Errorf("publish snapshot: %w", err)
+	}
+	return nil
+}
+
+func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
+	current.Running = append(current.Running, next.Running...)
+	current.Queue = append(current.Queue, next.Queue...)
+	current.Blocked = append(current.Blocked, next.Blocked...)
+	current.Completed = append(current.Completed, next.Completed...)
+	current.Budget.Refusals = append(current.Budget.Refusals, next.Budget.Refusals...)
+
+	current.Counts.Running += next.Counts.Running
+	current.Counts.Queue += next.Counts.Queue
+	current.Counts.Blocked += next.Counts.Blocked
+	current.Counts.Completed += next.Counts.Completed
+
+	current.Tokens.Input += next.Tokens.Input
+	current.Tokens.Output += next.Tokens.Output
+	current.Tokens.Total += next.Tokens.Total
+	current.Tokens.RuntimeSeconds += next.Tokens.RuntimeSeconds
+
+	if current.RateLimits == nil && next.RateLimits != nil {
+		current.RateLimits = next.RateLimits
+	}
+	return current
+}
+
+func durationFromMillis(ms int) time.Duration {
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
+}

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -1,0 +1,121 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
+	"github.com/digitaldrywood/symphony/internal/hub"
+	projectpkg "github.com/digitaldrywood/symphony/internal/project"
+	runnerpkg "github.com/digitaldrywood/symphony/internal/runner"
+	"github.com/digitaldrywood/symphony/internal/telemetry"
+)
+
+var errProjectFactoryStub = errors.New("project factory stub")
+
+func TestBuildRunnerReturnsRunner(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Workspace.Root = t.TempDir()
+
+	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, nil, nil)
+	if err != nil {
+		t.Fatalf("buildRunner() error = %v", err)
+	}
+	if run == nil {
+		t.Fatal("buildRunner() = nil, want non-nil runner")
+	}
+	if _, ok := run.(*runnerpkg.Runner); !ok {
+		t.Fatalf("buildRunner() = %T, want *runner.Runner", run)
+	}
+}
+
+func TestProjectDependenciesInjectsNonNilRunner(t *testing.T) {
+	t.Parallel()
+
+	var captured projectpkg.Dependencies
+	base := projectpkg.Dependencies{Logger: nil}
+	factory := withRunnerFactory(base, nil, func(d projectpkg.Dependencies) (*projectpkg.Project, error) {
+		captured = d
+		return nil, errProjectFactoryStub
+	})
+
+	workflowPath := writeWorkflowFile(t)
+	_, err := factory(globalconfig.Project{
+		ID:       "alpha",
+		Workflow: workflowPath,
+		Workdir:  filepath.Dir(workflowPath),
+		Weight:   1,
+	})
+	if err != errProjectFactoryStub {
+		t.Fatalf("ProjectFactory() error = %v, want stub", err)
+	}
+	if captured.Runner == nil {
+		t.Fatal("project dependencies Runner = nil, want non-nil injected runner")
+	}
+	if _, ok := captured.Runner.(*runnerpkg.Runner); !ok {
+		t.Fatalf("injected Runner = %T, want *runner.Runner", captured.Runner)
+	}
+}
+
+func TestPublishSnapshotsPublishesToHub(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		publishSnapshots(ctx, registry, snapshotHub, 5*time.Millisecond, func() time.Time { return now })
+	}()
+
+	var (
+		snapshot telemetry.Snapshot
+		ok       bool
+	)
+	for deadline := time.Now().Add(time.Second); time.Now().Before(deadline); {
+		if snapshot, ok = snapshotHub.Latest(); ok {
+			break
+		}
+		time.Sleep(2 * time.Millisecond)
+	}
+	cancel()
+	<-done
+
+	if !ok {
+		t.Fatal("publishSnapshots did not publish any snapshot")
+	}
+	if !snapshot.GeneratedAt.Equal(now) {
+		t.Fatalf("snapshot.GeneratedAt = %v, want %v", snapshot.GeneratedAt, now)
+	}
+}
+
+func writeWorkflowFile(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	content := "---\n" +
+		"tracker:\n  kind: memory\n" +
+		"codex:\n  command: codex app-server\n" +
+		"workspace:\n  root: " + filepath.Join(dir, "workspaces") + "\n" +
+		"---\n\nTest workflow prompt.\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write workflow file: %v", err)
+	}
+	return path
+}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -1,0 +1,164 @@
+package orchestrator
+
+import (
+	"sort"
+	"time"
+
+	"github.com/digitaldrywood/symphony/internal/connector"
+	"github.com/digitaldrywood/symphony/internal/telemetry"
+)
+
+// Snapshot converts the orchestrator State into a telemetry.Snapshot suitable
+// for publishing to the web dashboard. Slices are sorted by issue id so the
+// output is deterministic.
+func (s State) Snapshot(now time.Time) telemetry.Snapshot {
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Running:     runningSnapshots(s.Running),
+		Queue:       queueSnapshots(s.Retry),
+		Blocked:     blockedSnapshots(s.Blocked),
+		Completed:   completedSnapshots(s.Completed),
+		RateLimits:  cloneRateLimits(s.RateLimits),
+		Tokens:      tokensFromCodexTotals(s.CodexTotals),
+		Budget: telemetry.Budget{
+			Refusals: budgetRefusalSnapshots(s.BudgetRefusals),
+		},
+	}
+	snapshot.Counts = telemetry.Counts{
+		Running:   len(snapshot.Running),
+		Queue:     len(snapshot.Queue),
+		Blocked:   len(snapshot.Blocked),
+		Completed: len(snapshot.Completed),
+	}
+	return snapshot
+}
+
+func runningSnapshots(running map[string]Running) []telemetry.Running {
+	ids := sortedKeys(running)
+	out := make([]telemetry.Running, 0, len(ids))
+	for _, id := range ids {
+		entry := running[id]
+		out = append(out, telemetry.Running{
+			Issue:          telemetryIssue(entry.Issue),
+			WorkerHost:     entry.WorkerHost,
+			StartedAt:      entry.StartedAt,
+			RuntimeSeconds: 0,
+			Tokens:         telemetry.Tokens{},
+		})
+	}
+	return out
+}
+
+func queueSnapshots(retry map[string]Retry) []telemetry.Queued {
+	ids := sortedKeys(retry)
+	out := make([]telemetry.Queued, 0, len(ids))
+	for _, id := range ids {
+		entry := retry[id]
+		queued := telemetry.Queued{
+			Issue:      telemetryIssue(entry.Issue),
+			Attempt:    entry.Attempt,
+			Error:      entry.Error,
+			WorkerHost: entry.WorkerHost,
+		}
+		if !entry.DueAt.IsZero() {
+			dueAt := entry.DueAt
+			queued.DueAt = &dueAt
+		}
+		out = append(out, queued)
+	}
+	return out
+}
+
+func blockedSnapshots(blocked map[string]Blocked) []telemetry.Blocked {
+	ids := sortedKeys(blocked)
+	out := make([]telemetry.Blocked, 0, len(ids))
+	for _, id := range ids {
+		entry := blocked[id]
+		item := telemetry.Blocked{
+			Issue: telemetryIssue(entry.Issue),
+			Error: entry.Reason,
+		}
+		if !entry.BlockedAt.IsZero() {
+			blockedAt := entry.BlockedAt
+			item.BlockedAt = &blockedAt
+		}
+		out = append(out, item)
+	}
+	return out
+}
+
+func completedSnapshots(completed map[string]Completed) []telemetry.Completed {
+	ids := sortedKeys(completed)
+	out := make([]telemetry.Completed, 0, len(ids))
+	for _, id := range ids {
+		entry := completed[id]
+		out = append(out, telemetry.Completed{
+			Issue:          telemetryIssue(entry.Issue),
+			StartedAt:      entry.StartedAt,
+			CompletedAt:    entry.CompletedAt,
+			FinalState:     entry.FinalState,
+			RuntimeSeconds: entry.Tokens.RuntimeSeconds,
+			Tokens:         tokensFromCodexTotals(entry.Tokens),
+		})
+	}
+	return out
+}
+
+func budgetRefusalSnapshots(refusals map[string]BudgetRefusal) []telemetry.BudgetRefusal {
+	if len(refusals) == 0 {
+		return nil
+	}
+	ids := sortedKeys(refusals)
+	out := make([]telemetry.BudgetRefusal, 0, len(ids))
+	for _, id := range ids {
+		entry := refusals[id]
+		refusal := telemetry.BudgetRefusal{
+			IssueID:          entry.Issue.ID,
+			Identifier:       entry.Issue.Identifier,
+			Code:             entry.Code,
+			Message:          entry.Message,
+			CurrentSpendUSD:  entry.CurrentSpendUSD,
+			ProjectedCostUSD: entry.ProjectedCostUSD,
+			RefusedAt:        entry.RefusedAt,
+		}
+		if entry.MaxUSD != nil {
+			maxUSD := *entry.MaxUSD
+			refusal.MaxUSD = &maxUSD
+		}
+		if entry.ResetAt != nil {
+			resetAt := *entry.ResetAt
+			refusal.ResetAt = &resetAt
+		}
+		out = append(out, refusal)
+	}
+	return out
+}
+
+func telemetryIssue(issue connector.Issue) telemetry.Issue {
+	return telemetry.Issue{
+		ID:          issue.ID,
+		Identifier:  issue.Identifier,
+		URL:         issue.URL,
+		Title:       issue.Title,
+		Description: issue.Description,
+		State:       issue.State,
+	}
+}
+
+func tokensFromCodexTotals(totals CodexTotals) telemetry.Tokens {
+	return telemetry.Tokens{
+		Input:          totals.InputTokens,
+		Output:         totals.OutputTokens,
+		Total:          totals.TotalTokens,
+		RuntimeSeconds: totals.RuntimeSeconds,
+	}
+}
+
+func sortedKeys[V any](m map[string]V) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -1,0 +1,202 @@
+package orchestrator
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/symphony/internal/connector"
+	"github.com/digitaldrywood/symphony/internal/telemetry"
+)
+
+func TestStateSnapshotEmpty(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	state := newState(normalizeConfig(Config{}))
+
+	snapshot := state.Snapshot(now)
+
+	if !snapshot.GeneratedAt.Equal(now) {
+		t.Fatalf("GeneratedAt = %v, want %v", snapshot.GeneratedAt, now)
+	}
+	if snapshot.Counts != (telemetry.Counts{}) {
+		t.Fatalf("Counts = %#v, want zero", snapshot.Counts)
+	}
+	if len(snapshot.Running) != 0 {
+		t.Fatalf("Running = %#v, want empty", snapshot.Running)
+	}
+	if len(snapshot.Queue) != 0 {
+		t.Fatalf("Queue = %#v, want empty", snapshot.Queue)
+	}
+	if len(snapshot.Blocked) != 0 {
+		t.Fatalf("Blocked = %#v, want empty", snapshot.Blocked)
+	}
+	if len(snapshot.Completed) != 0 {
+		t.Fatalf("Completed = %#v, want empty", snapshot.Completed)
+	}
+}
+
+func TestStateSnapshotPopulated(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	startedAt := now.Add(-2 * time.Minute)
+	dueAt := now.Add(30 * time.Second)
+	completedAt := now.Add(-time.Minute)
+	blockedAt := now.Add(-3 * time.Minute)
+
+	state := newState(normalizeConfig(Config{}))
+	state.Running["i-2"] = Running{
+		Issue:      connector.Issue{ID: "i-2", Identifier: "ISS-2", Title: "Two", State: "In Progress", URL: "u2"},
+		Attempt:    1,
+		StartedAt:  startedAt,
+		WorkerHost: "host-b",
+	}
+	state.Running["i-1"] = Running{
+		Issue:     connector.Issue{ID: "i-1", Identifier: "ISS-1", Title: "One", State: "In Progress"},
+		Attempt:   0,
+		StartedAt: startedAt,
+	}
+	state.Retry["i-3"] = Retry{
+		Issue:      connector.Issue{ID: "i-3", Identifier: "ISS-3", Title: "Three", State: "Todo"},
+		Attempt:    2,
+		DueAt:      dueAt,
+		Error:      "boom",
+		WorkerHost: "host-c",
+	}
+	state.Blocked["i-4"] = Blocked{
+		Issue:     connector.Issue{ID: "i-4", Identifier: "ISS-4", Title: "Four", State: "Todo"},
+		Reason:    "blocked by non-terminal dependency",
+		BlockedAt: blockedAt,
+	}
+	state.Completed["i-5"] = Completed{
+		Issue:       connector.Issue{ID: "i-5", Identifier: "ISS-5", Title: "Five", State: "Done"},
+		StartedAt:   startedAt,
+		CompletedAt: completedAt,
+		FinalState:  FinalStateCompleted,
+		Tokens:      CodexTotals{InputTokens: 10, OutputTokens: 5, TotalTokens: 15, RuntimeSeconds: 60},
+	}
+	state.CodexTotals = CodexTotals{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, RuntimeSeconds: 120}
+	state.RateLimits = &telemetry.RateLimits{LimitID: "lim", LimitName: "name"}
+
+	snapshot := state.Snapshot(now)
+
+	wantCounts := telemetry.Counts{Running: 2, Queue: 1, Blocked: 1, Completed: 1}
+	if snapshot.Counts != wantCounts {
+		t.Fatalf("Counts = %#v, want %#v", snapshot.Counts, wantCounts)
+	}
+
+	if len(snapshot.Running) != 2 {
+		t.Fatalf("Running len = %d, want 2", len(snapshot.Running))
+	}
+	// Deterministic ordering by issue id.
+	if snapshot.Running[0].ID != "i-1" || snapshot.Running[1].ID != "i-2" {
+		t.Fatalf("Running order = [%s, %s], want [i-1, i-2]", snapshot.Running[0].ID, snapshot.Running[1].ID)
+	}
+	if snapshot.Running[1].WorkerHost != "host-b" {
+		t.Fatalf("Running[1].WorkerHost = %q, want host-b", snapshot.Running[1].WorkerHost)
+	}
+	if snapshot.Running[0].Identifier != "ISS-1" || snapshot.Running[0].Title != "One" {
+		t.Fatalf("Running[0] issue mapping = %#v", snapshot.Running[0].Issue)
+	}
+	if !snapshot.Running[0].StartedAt.Equal(startedAt) {
+		t.Fatalf("Running[0].StartedAt = %v, want %v", snapshot.Running[0].StartedAt, startedAt)
+	}
+
+	if len(snapshot.Queue) != 1 {
+		t.Fatalf("Queue len = %d, want 1", len(snapshot.Queue))
+	}
+	q := snapshot.Queue[0]
+	if q.ID != "i-3" || q.Attempt != 2 || q.Error != "boom" || q.WorkerHost != "host-c" {
+		t.Fatalf("Queue[0] = %#v", q)
+	}
+	if q.DueAt == nil || !q.DueAt.Equal(dueAt) {
+		t.Fatalf("Queue[0].DueAt = %v, want %v", q.DueAt, dueAt)
+	}
+
+	if len(snapshot.Blocked) != 1 {
+		t.Fatalf("Blocked len = %d, want 1", len(snapshot.Blocked))
+	}
+	b := snapshot.Blocked[0]
+	if b.ID != "i-4" || b.Error != "blocked by non-terminal dependency" {
+		t.Fatalf("Blocked[0] = %#v", b)
+	}
+	if b.BlockedAt == nil || !b.BlockedAt.Equal(blockedAt) {
+		t.Fatalf("Blocked[0].BlockedAt = %v, want %v", b.BlockedAt, blockedAt)
+	}
+
+	if len(snapshot.Completed) != 1 {
+		t.Fatalf("Completed len = %d, want 1", len(snapshot.Completed))
+	}
+	c := snapshot.Completed[0]
+	if c.ID != "i-5" || c.FinalState != FinalStateCompleted {
+		t.Fatalf("Completed[0] = %#v", c)
+	}
+	if !c.CompletedAt.Equal(completedAt) {
+		t.Fatalf("Completed[0].CompletedAt = %v, want %v", c.CompletedAt, completedAt)
+	}
+	if c.Tokens.Total != 15 {
+		t.Fatalf("Completed[0].Tokens.Total = %d, want 15", c.Tokens.Total)
+	}
+
+	wantTokens := telemetry.Tokens{Input: 100, Output: 50, Total: 150, RuntimeSeconds: 120}
+	if snapshot.Tokens != wantTokens {
+		t.Fatalf("Tokens = %#v, want %#v", snapshot.Tokens, wantTokens)
+	}
+	if snapshot.RateLimits == nil || snapshot.RateLimits.LimitID != "lim" {
+		t.Fatalf("RateLimits = %#v, want lim", snapshot.RateLimits)
+	}
+}
+
+func TestStateSnapshotBudgetRefusals(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 1, 2, 3, 4, 5, 0, time.UTC)
+	maxUSD := 12.5
+	state := newState(normalizeConfig(Config{}))
+	state.BudgetRefusals["i-9"] = BudgetRefusal{
+		Issue:            connector.Issue{ID: "i-9", Identifier: "ISS-9"},
+		Code:             "per_issue",
+		Message:          "too expensive",
+		CurrentSpendUSD:  3,
+		ProjectedCostUSD: 9,
+		MaxUSD:           &maxUSD,
+		RefusedAt:        now,
+	}
+
+	snapshot := state.Snapshot(now)
+
+	if len(snapshot.Budget.Refusals) != 1 {
+		t.Fatalf("Budget.Refusals len = %d, want 1", len(snapshot.Budget.Refusals))
+	}
+	refusal := snapshot.Budget.Refusals[0]
+	if refusal.IssueID != "i-9" || refusal.Identifier != "ISS-9" || refusal.Code != "per_issue" {
+		t.Fatalf("Refusals[0] = %#v", refusal)
+	}
+	if refusal.MaxUSD == nil || *refusal.MaxUSD != maxUSD {
+		t.Fatalf("Refusals[0].MaxUSD = %v, want %v", refusal.MaxUSD, maxUSD)
+	}
+}
+
+func TestStateSnapshotDeterministicOrdering(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	state := newState(normalizeConfig(Config{}))
+	for _, id := range []string{"c", "a", "b"} {
+		state.Running[id] = Running{Issue: connector.Issue{ID: id, Identifier: id, Title: id, State: "In Progress"}}
+	}
+
+	first := state.Snapshot(now)
+	second := state.Snapshot(now)
+
+	for i := range first.Running {
+		if first.Running[i].ID != second.Running[i].ID {
+			t.Fatalf("non-deterministic ordering at %d: %s vs %s", i, first.Running[i].ID, second.Running[i].ID)
+		}
+	}
+	if first.Running[0].ID != "a" || first.Running[1].ID != "b" || first.Running[2].ID != "c" {
+		t.Fatalf("Running order = [%s,%s,%s], want [a,b,c]",
+			first.Running[0].ID, first.Running[1].ID, first.Running[2].ID)
+	}
+}


### PR DESCRIPTION
Fixes #103.

## Summary
`startRunning` now injects a **per-project agent runner** (via a `ProjectFactory` that builds the runner from each project's workflow — codex command, workspace root, hooks) and launches a **telemetry bridge** goroutine that converts each orchestrator's `State` to a `telemetry.Snapshot` and publishes to the same hub the web/TUI consume. Previously the binary served an empty dashboard and never dispatched.

## Changes
- `internal/cli/boot.go` — inject `ProjectFactory`; `go publishSnapshots(...)` on the web snapshot hub.
- `internal/cli/runner.go` (new) — per-project runner factory (workspace + codex app-server + store), `publishSnapshots`/`mergeSnapshot`.
- `internal/orchestrator/snapshot.go` (new) — `State.Snapshot(now)` converter.
- tests for both.

## Test plan
- `make check` green locally (build + golangci-lint v2 + vet + `go test -race` + 79.8% coverage).
- Manual: `symphony --config ~/.symphony/global.yaml` dispatches a Todo issue and `/api/v1/state` is populated within one tick (verified post-merge on relaunch).