### PR TITLE
fix(workspace): add workspace.source_root so worktrees create from the source clone

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -87,9 +87,13 @@ func buildRunner(
 
 func buildWorkspaceBackend(cfg workflowconfig.Config, logger *slog.Logger) (workspace.Backend, error) {
 	root := strings.TrimSpace(cfg.Workspace.Root)
+	sourceRoot := strings.TrimSpace(cfg.Workspace.SourceRoot)
+	if sourceRoot == "" {
+		sourceRoot = root
+	}
 	backend, err := workspace.NewBackend(workspace.KindLocalGit, workspace.LocalGitOptions{
 		Root:       root,
-		SourceRoot: root,
+		SourceRoot: sourceRoot,
 		AutoBranch: cfg.Workspace.AutoBranch,
 		Hooks: workspace.Hooks{
 			AfterCreate:  cfg.Hooks.AfterCreate,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ type Polling struct {
 
 type Workspace struct {
 	Root       string `yaml:"root"`
+	SourceRoot string `yaml:"source_root"`
 	AutoBranch bool   `yaml:"auto_branch"`
 }
 


### PR DESCRIPTION
Fixes #110. Follow-up to #103.

Dispatch was failing at `create workspace: git -C <root> show-ref` because `buildWorkspaceBackend` set `SourceRoot` to the worktree parent (not a git repo). Adds `workspace.source_root` to the config and wires it to the backend `SourceRoot` (worktree `root` unchanged). `make check` green (79.8%).