### PR TITLE
chore(release): add version metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ SHELL := /bin/bash
 BINARY_NAME := symphony
 BINARY_PATH := tmp/$(BINARY_NAME)
 CMD_PACKAGE := ./cmd/symphony
+VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
+COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
+DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
+LDFLAGS ?= -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
 COVERPROFILE := tmp/coverage.out
 COVERPROFILE_RAW := tmp/coverage.raw.out
 COVERAGE_THRESHOLD := 70.0
@@ -54,7 +58,7 @@ css-watch:
 
 build: generate
 	@mkdir -p tmp
-	go build -o $(BINARY_PATH) $(CMD_PACKAGE)
+	go build -ldflags "$(LDFLAGS)" -o $(BINARY_PATH) $(CMD_PACKAGE)
 
 test:
 	go test ./...

--- a/cmd/symphony/main.go
+++ b/cmd/symphony/main.go
@@ -36,7 +36,12 @@ func main() {
 
 func newRootCommand(ctx context.Context) *cobra.Command {
 	cmd := cli.NewRootCommand(ctx)
-	cmd.AddCommand(newShadowRunCommand())
+	cmd.Version = version
+	cmd.SetVersionTemplate("{{.Version}}\n")
+	cmd.AddCommand(
+		newVersionCommand(),
+		newShadowRunCommand(),
+	)
 
 	return cmd
 }

--- a/cmd/symphony/version.go
+++ b/cmd/symphony/version.go
@@ -1,0 +1,55 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"runtime"
+
+	"github.com/spf13/cobra"
+)
+
+var version, commit, date = "dev", "none", "unknown"
+
+type versionInfo struct {
+	Version   string
+	Commit    string
+	Date      string
+	GoVersion string
+	OS        string
+	Arch      string
+}
+
+func newVersionCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "version",
+		Short: "Print version metadata",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			_, err := io.WriteString(cmd.OutOrStdout(), formatVersionInfo(currentVersionInfo()))
+			return err
+		},
+	}
+}
+
+func currentVersionInfo() versionInfo {
+	return versionInfo{
+		Version:   version,
+		Commit:    commit,
+		Date:      date,
+		GoVersion: runtime.Version(),
+		OS:        runtime.GOOS,
+		Arch:      runtime.GOARCH,
+	}
+}
+
+func formatVersionInfo(info versionInfo) string {
+	return fmt.Sprintf(
+		"version: %s\ncommit: %s\nbuild date: %s\ngo version: %s\nos/arch: %s/%s\n",
+		info.Version,
+		info.Commit,
+		info.Date,
+		info.GoVersion,
+		info.OS,
+		info.Arch,
+	)
+}

--- a/cmd/symphony/version_test.go
+++ b/cmd/symphony/version_test.go
@@ -1,0 +1,115 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestFormatVersionInfo(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		info versionInfo
+		want string
+	}{
+		{
+			name: "development build",
+			info: versionInfo{
+				Version:   "dev",
+				Commit:    "none",
+				Date:      "unknown",
+				GoVersion: "go1.26.0",
+				OS:        "linux",
+				Arch:      "amd64",
+			},
+			want: "version: dev\ncommit: none\nbuild date: unknown\ngo version: go1.26.0\nos/arch: linux/amd64\n",
+		},
+		{
+			name: "release build",
+			info: versionInfo{
+				Version:   "v1.2.3",
+				Commit:    "abc1234",
+				Date:      "2026-05-31T18:30:00Z",
+				GoVersion: "go1.26.1",
+				OS:        "darwin",
+				Arch:      "arm64",
+			},
+			want: "version: v1.2.3\ncommit: abc1234\nbuild date: 2026-05-31T18:30:00Z\ngo version: go1.26.1\nos/arch: darwin/arm64\n",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := formatVersionInfo(tt.info); got != tt.want {
+				t.Fatalf("formatVersionInfo() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestVersionCommandPrintsBuildFields(t *testing.T) {
+	withVersionMetadata(t, "v1.2.3", "abc1234", "2026-05-31T18:30:00Z")
+
+	cmd := newRootCommand(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"version: v1.2.3",
+		"commit: abc1234",
+		"build date: 2026-05-31T18:30:00Z",
+		"go version: " + runtime.Version(),
+		"os/arch: " + runtime.GOOS + "/" + runtime.GOARCH,
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("version output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestRootVersionFlagPrintsVersionString(t *testing.T) {
+	withVersionMetadata(t, "v1.2.3", "abc1234", "2026-05-31T18:30:00Z")
+
+	cmd := newRootCommand(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if got, want := stdout.String(), "v1.2.3\n"; got != want {
+		t.Fatalf("--version output = %q, want %q", got, want)
+	}
+}
+
+func withVersionMetadata(t *testing.T, nextVersion, nextCommit, nextDate string) {
+	t.Helper()
+
+	oldVersion := version
+	oldCommit := commit
+	oldDate := date
+	version = nextVersion
+	commit = nextCommit
+	date = nextDate
+
+	t.Cleanup(func() {
+		version = oldVersion
+		commit = oldCommit
+		date = oldDate
+	})
+}

--- a/install.sh
+++ b/install.sh
@@ -32,7 +32,11 @@ trap 'cleanup_tmp; cleanup' EXIT
 if [ -n "$source_binary" ]; then
 	cp "$source_binary" "$tmp_dir/symphony"
 else
-	(cd "$repo_root" && go build -o "$tmp_dir/symphony" ./cmd/symphony)
+	build_version="$(git -C "$repo_root" describe --tags --always 2>/dev/null || echo dev)"
+	build_commit="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo none)"
+	build_date="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+	ldflags="-X main.version=$build_version -X main.commit=$build_commit -X main.date=$build_date"
+	(cd "$repo_root" && go build -ldflags "$ldflags" -o "$tmp_dir/symphony" ./cmd/symphony)
 fi
 
 install -m 0755 "$tmp_dir/symphony" "$target"

--- a/install_test.go
+++ b/install_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"sync"
@@ -92,6 +93,7 @@ func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
 	if _, err := os.Stat(binary); err != nil {
 		t.Fatalf("installed binary stat error = %v", err)
 	}
+	assertInstalledVersionMetadata(t, binary, root, env)
 
 	home := filepath.Join(tmp, "home")
 	workdir := filepath.Join(tmp, "fresh")
@@ -329,6 +331,15 @@ func runInstalledSubcommands(t *testing.T, binary string, root string, env []str
 func runSymphonyCommand(t *testing.T, binary string, workdir string, env []string, args ...string) {
 	t.Helper()
 
+	stdout, stderr, err := runSymphonyCommandOutput(t, binary, workdir, env, args...)
+	if err != nil {
+		t.Fatalf("symphony %v error = %v\nstdout:\n%s\nstderr:\n%s", args, err, stdout, stderr)
+	}
+}
+
+func runSymphonyCommandOutput(t *testing.T, binary string, workdir string, env []string, args ...string) (string, string, error) {
+	t.Helper()
+
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
@@ -341,9 +352,59 @@ func runSymphonyCommand(t *testing.T, binary string, workdir string, env []strin
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 
-	if err := cmd.Run(); err != nil {
-		t.Fatalf("symphony %v error = %v\nstdout:\n%s\nstderr:\n%s", args, err, stdout.String(), stderr.String())
+	err := cmd.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+func assertInstalledVersionMetadata(t *testing.T, binary string, root string, env []string) {
+	t.Helper()
+
+	wantVersion, ok := gitOutput(t, root, "describe", "--tags", "--always")
+	if !ok {
+		t.Skip("git metadata unavailable")
 	}
+	wantCommit, ok := gitOutput(t, root, "rev-parse", "--short", "HEAD")
+	if !ok {
+		t.Skip("git metadata unavailable")
+	}
+
+	stdout, stderr, err := runSymphonyCommandOutput(t, binary, root, env, "--version")
+	if err != nil {
+		t.Fatalf("symphony --version error = %v\nstderr:\n%s", err, stderr)
+	}
+	if got, want := stdout, wantVersion+"\n"; got != want {
+		t.Fatalf("symphony --version = %q, want %q", got, want)
+	}
+
+	stdout, stderr, err = runSymphonyCommandOutput(t, binary, root, env, "version")
+	if err != nil {
+		t.Fatalf("symphony version error = %v\nstderr:\n%s", err, stderr)
+	}
+	for _, want := range []string{
+		"version: " + wantVersion,
+		"commit: " + wantCommit,
+		"go version: " + runtime.Version(),
+		"os/arch: " + runtime.GOOS + "/" + runtime.GOARCH,
+	} {
+		if !strings.Contains(stdout, want) {
+			t.Fatalf("symphony version output missing %q:\n%s", want, stdout)
+		}
+	}
+	if strings.Contains(stdout, "build date: unknown") {
+		t.Fatalf("symphony version output kept unknown build date:\n%s", stdout)
+	}
+}
+
+func gitOutput(t *testing.T, root string, args ...string) (string, bool) {
+	t.Helper()
+
+	cmd := exec.Command("git", args...)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	return strings.TrimSpace(string(out)), true
 }
 
 func assertInstalledProject(t *testing.T, configPath string, check func(globalconfig.Project)) {


### PR DESCRIPTION
## Summary
- Add build metadata defaults and a `symphony version` command.
- Wire Cobra root `--version` to print the version string.
- Inject git describe, short commit, and RFC3339 build date in `make build` and fresh installer builds.
- Cover the version formatter, CLI behavior, and installer metadata path with tests.

Fixes #95

## Test Plan
- `go test ./cmd/symphony .`
- `GOBIN="$PWD/tmp/go-install-bin" go install ./cmd/symphony && tmp/go-install-bin/symphony version && tmp/go-install-bin/symphony --version`
- `make build && tmp/symphony version && tmp/symphony --version`
- `make check`