### PR TITLE
chore(cli): default dev logging to text

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -14,7 +14,7 @@ tmp_dir = "tmp"
   exclude_regex = ["_test\\.go", "_templ\\.go$"]
   exclude_unchanged = false
   follow_symlink = false
-  full_bin = "SYMPHONY_ENV=development SYMPHONY_LOG_LEVEL=debug ./tmp/symphony"
+  full_bin = "./tmp/symphony"
   include_dir = []
   include_ext = ["go", "templ", "sql", "css", "js", "html", "yaml", "yml", "toml"]
   include_file = []

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,9 +26,18 @@ make setup
 make dev
 ```
 
-`make dev` runs Air, builds `./tmp/symphony`, rotates `tmp/air-combined.log`, and streams combined build and application output to `tmp/air-combined.log`.
+`make dev` runs Air with `SYMPHONY_ENV=dev` and `SYMPHONY_LOG_LEVEL=debug`, builds `./tmp/symphony`, rotates `tmp/air-combined.log`, and streams combined build and application output to `tmp/air-combined.log`.
 
 The default web bind is `127.0.0.1:4000` when no config or port is supplied. If another Symphony process is already using that port, do not start a second server on it. Run a built binary with `./tmp/symphony --port 0` when you need an ephemeral port.
+
+## Logging
+
+Symphony logs with `log/slog`.
+
+- `SYMPHONY_ENV=dev`, `development`, or `local` enables tint text logs.
+- `SYMPHONY_ENV=prod` or any other non-development value keeps JSON logs.
+- When `SYMPHONY_ENV` is unset, interactive stdout TTY runs use tint text logs; non-TTY runs use JSON logs.
+- `SYMPHONY_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
 
 ## Validation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,6 +38,7 @@ Symphony logs with `log/slog`.
 - `SYMPHONY_ENV=prod` or any other non-development value keeps JSON logs.
 - When `SYMPHONY_ENV` is unset, interactive stdout TTY runs use tint text logs; non-TTY runs use JSON logs.
 - `SYMPHONY_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- Text logs are written to stdout; JSON logs are written to stderr.
 
 ## Validation
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dev:
 		mv tmp/air-combined.log tmp/air-combined-$$(date +%Y%m%d-%H%M%S).log; \
 	fi
 	@ls -t tmp/air-combined-*.log 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null || true
-	@air 2>&1 | tee tmp/air-combined.log
+	@SYMPHONY_ENV=dev SYMPHONY_LOG_LEVEL=debug air 2>&1 | tee tmp/air-combined.log
 
 generate:
 	@go generate ./...
@@ -116,7 +116,7 @@ clean:
 
 help:
 	@echo "Available targets:"
-	@echo "  dev          Run Air with combined log rotation"
+	@echo "  dev          Run Air with dev logging and combined log rotation"
 	@echo "  generate     Run go generate, templ, sqlc, and Tailwind"
 	@echo "  css          Build Tailwind CSS"
 	@echo "  css-watch    Watch and rebuild Tailwind CSS"

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Symphony logs with `log/slog`.
 - `SYMPHONY_ENV=prod` or any other non-development value keeps JSON logs.
 - When `SYMPHONY_ENV` is unset, interactive stdout TTY runs use tint text logs; non-TTY runs use JSON logs.
 - `SYMPHONY_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- Text logs are written to stdout; JSON logs are written to stderr.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,25 @@ Symphony is an agent orchestrator for tracker-backed work queues, delivered as a
 
 The previous Elixir implementation is retained only as a cutover reference and should remain archived after the Go repository is renamed to `digitaldrywood/symphony`.
 
+## Development
+
+Run the local hot-reload loop with:
+
+```bash
+make dev
+```
+
+The target runs Air with `SYMPHONY_ENV=dev` and `SYMPHONY_LOG_LEVEL=debug`, and writes the combined stream to `tmp/air-combined.log`.
+
+## Logging
+
+Symphony logs with `log/slog`.
+
+- `SYMPHONY_ENV=dev`, `development`, or `local` enables tint text logs.
+- `SYMPHONY_ENV=prod` or any other non-development value keeps JSON logs.
+- When `SYMPHONY_ENV` is unset, interactive stdout TTY runs use tint text logs; non-TTY runs use JSON logs.
+- `SYMPHONY_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+
 ## License
 
 Symphony is released under the [MIT License](LICENSE).

--- a/cmd/symphony/main.go
+++ b/cmd/symphony/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 func main() {
-	setupLoggerFromEnv(os.Stderr)
+	setupLoggerFromEnv(os.Stdout, os.Stderr)
 
 	ctx, stop := newSignalContext(context.Background())
 	defer stop()

--- a/cmd/symphony/slog.go
+++ b/cmd/symphony/slog.go
@@ -11,22 +11,31 @@ import (
 )
 
 func setupLoggerFromEnv(w io.Writer) *slog.Logger {
-	return setupLogger(envValue("SYMPHONY_ENV", "ENV"), envValue("SYMPHONY_LOG_LEVEL", "LOG_LEVEL"), w)
+	env, envSet := envValueWithPresence("SYMPHONY_ENV", "ENV")
+	return setupLoggerForTerminal(env, envSet, envValue("SYMPHONY_LOG_LEVEL", "LOG_LEVEL"), w, stdoutIsTTY())
 }
 
 func setupLogger(env string, level string, w io.Writer) *slog.Logger {
-	logger := slog.New(newLogHandler(env, level, w))
+	return setupLoggerForTerminal(env, strings.TrimSpace(env) != "", level, w, false)
+}
+
+func setupLoggerForTerminal(env string, envSet bool, level string, w io.Writer, stdoutTTY bool) *slog.Logger {
+	logger := slog.New(newLogHandlerForTerminal(env, envSet, level, w, stdoutTTY))
 	slog.SetDefault(logger)
 	return logger
 }
 
 func newLogHandler(env string, level string, w io.Writer) slog.Handler {
+	return newLogHandlerForTerminal(env, strings.TrimSpace(env) != "", level, w, false)
+}
+
+func newLogHandlerForTerminal(env string, envSet bool, level string, w io.Writer, stdoutTTY bool) slog.Handler {
 	if w == nil {
 		w = io.Discard
 	}
 
 	logLevel := parseLogLevel(level)
-	if isDevelopment(env) {
+	if useTextLogs(env, envSet, stdoutTTY) {
 		return tint.NewHandler(w, &tint.Options{
 			Level:      logLevel,
 			TimeFormat: time.Kitchen,
@@ -37,6 +46,21 @@ func newLogHandler(env string, level string, w io.Writer) slog.Handler {
 	return slog.NewJSONHandler(w, &slog.HandlerOptions{
 		Level: logLevel,
 	})
+}
+
+func useTextLogs(env string, envSet bool, stdoutTTY bool) bool {
+	if isDevelopment(env) {
+		return true
+	}
+	if envSet {
+		return false
+	}
+	return stdoutTTY
+}
+
+func stdoutIsTTY() bool {
+	info, err := os.Stdout.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
 func parseLogLevel(level string) slog.Level {
@@ -62,8 +86,16 @@ func isDevelopment(env string) bool {
 }
 
 func envValue(primary string, fallback string) string {
-	if value := os.Getenv(primary); value != "" {
-		return value
+	value, _ := envValueWithPresence(primary, fallback)
+	return value
+}
+
+func envValueWithPresence(primary string, fallback string) (string, bool) {
+	if value, ok := os.LookupEnv(primary); ok && value != "" {
+		return value, true
 	}
-	return os.Getenv(fallback)
+	if value, ok := os.LookupEnv(fallback); ok && value != "" {
+		return value, true
+	}
+	return "", false
 }

--- a/cmd/symphony/slog.go
+++ b/cmd/symphony/slog.go
@@ -10,13 +10,21 @@ import (
 	"github.com/lmittmann/tint"
 )
 
-func setupLoggerFromEnv(w io.Writer) *slog.Logger {
+func setupLoggerFromEnv(stdout io.Writer, stderr io.Writer) *slog.Logger {
 	env, envSet := envValueWithPresence("SYMPHONY_ENV", "ENV")
-	return setupLoggerForTerminal(env, envSet, envValue("SYMPHONY_LOG_LEVEL", "LOG_LEVEL"), w, stdoutIsTTY())
+	return setupLoggerWithOutputs(env, envSet, envValue("SYMPHONY_LOG_LEVEL", "LOG_LEVEL"), stdout, stderr, writerIsTTY(stdout))
 }
 
 func setupLogger(env string, level string, w io.Writer) *slog.Logger {
 	return setupLoggerForTerminal(env, strings.TrimSpace(env) != "", level, w, false)
+}
+
+func setupLoggerWithOutputs(env string, envSet bool, level string, stdout io.Writer, stderr io.Writer, stdoutTTY bool) *slog.Logger {
+	w := stderr
+	if useTextLogs(env, envSet, stdoutTTY) {
+		w = stdout
+	}
+	return setupLoggerForTerminal(env, envSet, level, w, stdoutTTY)
 }
 
 func setupLoggerForTerminal(env string, envSet bool, level string, w io.Writer, stdoutTTY bool) *slog.Logger {
@@ -58,8 +66,12 @@ func useTextLogs(env string, envSet bool, stdoutTTY bool) bool {
 	return stdoutTTY
 }
 
-func stdoutIsTTY() bool {
-	info, err := os.Stdout.Stat()
+func writerIsTTY(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 

--- a/cmd/symphony/slog_test.go
+++ b/cmd/symphony/slog_test.go
@@ -61,7 +61,7 @@ func TestSetupLoggerFromEnvUsesSymphonyVariables(t *testing.T) {
 	t.Setenv("SYMPHONY_LOG_LEVEL", "debug")
 	t.Setenv("LOG_LEVEL", "error")
 
-	logger := setupLoggerFromEnv(&bytes.Buffer{})
+	logger := setupLoggerFromEnv(&bytes.Buffer{}, &bytes.Buffer{})
 
 	if !logger.Enabled(context.Background(), slog.LevelDebug) {
 		t.Fatal("expected SYMPHONY_LOG_LEVEL to enable debug records")
@@ -127,6 +127,52 @@ func TestInteractiveDefaultLoggerWritesText(t *testing.T) {
 	}
 	if !strings.Contains(out.String(), "ready") {
 		t.Fatalf("log output missing message:\n%s", out.String())
+	}
+}
+
+func TestSetupLoggerWithOutputsRoutesTextToStdout(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	logger := setupLoggerWithOutputs("", false, "debug", &stdout, &stderr, true)
+	logger.Debug("ready")
+
+	if json.Valid(stdout.Bytes()) {
+		t.Fatalf("stdout log output is JSON, want text:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "ready") {
+		t.Fatalf("stdout log output missing message:\n%s", stdout.String())
+	}
+	if stderr.Len() != 0 {
+		t.Fatalf("stderr = %q, want empty", stderr.String())
+	}
+}
+
+func TestSetupLoggerWithOutputsRoutesJSONToStderr(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	logger := setupLoggerWithOutputs("prod", true, "info", &stdout, &stderr, true)
+	logger.Info("ready")
+
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(stderr.Bytes(), &record); err != nil {
+		t.Fatalf("stderr log output is not JSON: %v\n%s", err, stderr.String())
+	}
+	if record["msg"] != "ready" {
+		t.Fatalf("msg = %v, want ready", record["msg"])
 	}
 }
 

--- a/cmd/symphony/slog_test.go
+++ b/cmd/symphony/slog_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"strings"
 	"testing"
 )
 
@@ -86,6 +87,46 @@ func TestProductionLoggerWritesJSON(t *testing.T) {
 	}
 	if record["component"] != "test" {
 		t.Fatalf("component = %v, want test", record["component"])
+	}
+}
+
+func TestUseTextLogs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		env       string
+		envSet    bool
+		stdoutTTY bool
+		want      bool
+	}{
+		{name: "dev env uses text without tty", env: "dev", envSet: true, stdoutTTY: false, want: true},
+		{name: "unset env uses text with tty", env: "", envSet: false, stdoutTTY: true, want: true},
+		{name: "unset env uses json without tty", env: "", envSet: false, stdoutTTY: false, want: false},
+		{name: "prod env uses json with tty", env: "prod", envSet: true, stdoutTTY: true, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := useTextLogs(tt.env, tt.envSet, tt.stdoutTTY); got != tt.want {
+				t.Fatalf("useTextLogs(%q, %v, %v) = %v, want %v", tt.env, tt.envSet, tt.stdoutTTY, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInteractiveDefaultLoggerWritesText(t *testing.T) {
+	var out bytes.Buffer
+	logger := slog.New(newLogHandlerForTerminal("", false, "debug", &out, true))
+	logger.Debug("ready", "component", "test")
+
+	if json.Valid(out.Bytes()) {
+		t.Fatalf("log output is JSON, want text:\n%s", out.String())
+	}
+	if !strings.Contains(out.String(), "ready") {
+		t.Fatalf("log output missing message:\n%s", out.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- default unset `SYMPHONY_ENV` interactive stdout TTY runs to tint text logs while preserving JSON for prod and non-TTY runs
- run Air from `make dev` with `SYMPHONY_ENV=dev` and `SYMPHONY_LOG_LEVEL=debug`
- document logging environment variables in README and CONTRIBUTING

Fixes #106

## Test Plan
- `go test ./cmd/symphony`
- `make check`