### PR TITLE
fix(web): embed dashboard static assets

### DIFF
--- a/embed.go
+++ b/embed.go
@@ -1,0 +1,17 @@
+package symphony
+
+import (
+	"embed"
+	"io/fs"
+)
+
+//go:embed static/**
+var embeddedStaticFiles embed.FS
+
+func StaticFS() fs.FS {
+	staticFS, err := fs.Sub(embeddedStaticFiles, "static")
+	if err != nil {
+		panic(err)
+	}
+	return staticFS
+}

--- a/embed_test.go
+++ b/embed_test.go
@@ -1,0 +1,20 @@
+package symphony
+
+import (
+	"bytes"
+	"io/fs"
+	"testing"
+)
+
+func TestStaticFSContainsCSSOutput(t *testing.T) {
+	data, err := fs.ReadFile(StaticFS(), "css/output.css")
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if len(data) == 0 {
+		t.Fatal("css/output.css is empty")
+	}
+	if !bytes.Contains(data, []byte("tailwindcss")) {
+		t.Fatalf("css/output.css missing Tailwind marker:\n%s", data)
+	}
+}

--- a/install_test.go
+++ b/install_test.go
@@ -111,6 +111,10 @@ func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
 	if !strings.Contains(onboarding, "Symphony onboarding") {
 		t.Fatalf("onboarding page missing wizard heading:\n%s", onboarding)
 	}
+	css := readURL(t, fmt.Sprintf("http://127.0.0.1:%d/static/css/output.css", port))
+	if !strings.Contains(css, "tailwindcss") {
+		t.Fatalf("static CSS missing Tailwind marker:\n%s", css)
+	}
 	stop()
 
 	runInstalledSubcommands(t, binary, tmp, serverEnv)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -10,6 +10,7 @@ import (
 	"github.com/a-h/templ"
 	"github.com/labstack/echo/v4"
 
+	symphony "github.com/digitaldrywood/symphony"
 	"github.com/digitaldrywood/symphony/internal/connector"
 	"github.com/digitaldrywood/symphony/internal/hub"
 	"github.com/digitaldrywood/symphony/internal/store"
@@ -118,7 +119,11 @@ func (s *Server) Shutdown(ctx context.Context) error {
 }
 
 func (s *Server) registerRoutes(staticDir string) {
-	s.echo.Static("/static", staticDir)
+	if staticDir != "" {
+		s.echo.Static("/static", staticDir)
+	} else {
+		s.echo.StaticFS("/static", symphony.StaticFS())
+	}
 	s.echo.GET("/health", s.health)
 	if s.mode == ModeOnboarding {
 		s.echo.GET("/", s.redirectToOnboarding)
@@ -212,10 +217,7 @@ func (cfg Config) mode() Mode {
 }
 
 func (cfg Config) staticDir() string {
-	if cfg.StaticDir != "" {
-		return cfg.StaticDir
-	}
-	return "static"
+	return cfg.StaticDir
 }
 
 func (cfg Config) sseTickInterval() time.Duration {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -143,6 +143,41 @@ func TestServerRoutes(t *testing.T) {
 	}
 }
 
+func TestServerServesDefaultStaticAssetsFromArbitraryWorkingDirectory(t *testing.T) {
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatalf("Chdir() error = %v", err)
+	}
+	defer func() {
+		if err := os.Chdir(wd); err != nil {
+			t.Fatalf("restore Chdir() error = %v", err)
+		}
+	}()
+
+	server, err := web.NewServer(web.Config{Mode: web.ModeOnboarding}, web.Dependencies{})
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/static/css/output.css", nil)
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := rec.Header().Get("Content-Type"); !strings.HasPrefix(got, "text/css") {
+		t.Fatalf("Content-Type = %q, want text/css", got)
+	}
+	if !strings.Contains(rec.Body.String(), "tailwindcss") {
+		t.Fatalf("body missing embedded CSS marker:\n%s", rec.Body.String())
+	}
+}
+
 func TestOnboardingModeDoesNotRequireRuntimeDependencies(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- embed the dashboard static assets into the Symphony binary
- serve embedded assets by default while preserving Config.StaticDir as a live-dev override
- add route, embedded FS, and installed-binary coverage for /static/css/output.css

Fixes #108

## Test Plan
- go test ./internal/web -count=1
- go test . -count=1
- make check
- GOBIN=$PWD/tmp/install-bin go install ./cmd/symphony; run the installed binary from tmp/acceptance/cwd.* on an ephemeral port; curl /static/css/output.css -> 200 text/css