### PR TITLE
fix(workspace): wire source root for worktrees

### DIFF
--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -59,6 +59,7 @@ func newRefreshProject(t *testing.T, id string) *projectpkg.Project {
 
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Workspace.SourceRoot = "."
 	project, err := projectpkg.New(projectpkg.Config{
 		Project: globalconfig.Project{
 			ID:      id,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -69,7 +69,7 @@ func TestRootCommandBootsFromGlobalConfig(t *testing.T) {
 func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
-	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), validWorkflowContent())
+	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), validWorkflowContent(t))
 	t.Chdir(root)
 
 	booted := make(chan cli.BootConfig, 1)
@@ -103,7 +103,7 @@ func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing
 func TestRootCommandUsesDefaultWorkflowServerAddress(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
-	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer("0.0.0.0", 4101))
+	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer(t, "0.0.0.0", 4101))
 	t.Chdir(root)
 
 	booted := make(chan cli.BootConfig, 1)
@@ -125,7 +125,7 @@ func TestRootCommandUsesDefaultWorkflowServerAddress(t *testing.T) {
 func TestRootCommandUsesConfiguredProjectWorkflowServerAddress(t *testing.T) {
 	t.Parallel()
 
-	paths := createProjectFilesWithWorkflow(t, workflowContentWithServer("127.0.0.2", 4102))
+	paths := createProjectFilesWithWorkflow(t, workflowContentWithServer(t, "127.0.0.2", 4102))
 	configPath := filepath.Join(paths.root, "global.yaml")
 	writeGlobalConfig(t, configPath, []globalconfig.Project{
 		{ID: "symphony", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
@@ -150,7 +150,7 @@ func TestRootCommandUsesConfiguredProjectWorkflowServerAddress(t *testing.T) {
 func TestRootCommandCLIAddressOverridesWorkflowServerAddress(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
-	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer("0.0.0.0", 4103))
+	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer(t, "0.0.0.0", 4103))
 	t.Chdir(root)
 
 	booted := make(chan cli.BootConfig, 1)
@@ -535,7 +535,7 @@ type projectPaths struct {
 func createProjectFiles(t *testing.T) projectPaths {
 	t.Helper()
 
-	return createProjectFilesWithWorkflow(t, validWorkflowContent())
+	return createProjectFilesWithWorkflow(t, validWorkflowContent(t))
 }
 
 func createProjectFilesWithWorkflow(t *testing.T, content string) projectPaths {
@@ -568,25 +568,43 @@ func writeWorkflow(t *testing.T, path string, content string) {
 	}
 }
 
-func validWorkflowContent() string {
-	return `---
-tracker:
-  kind: memory
----
-Test workflow prompt.
-`
-}
+func validWorkflowContent(t *testing.T) string {
+	t.Helper()
 
-func workflowContentWithServer(host string, port int) string {
 	return fmt.Sprintf(`---
 tracker:
   kind: memory
+workspace:
+  source_root: %s
+---
+Test workflow prompt.
+`, testSourceRoot(t))
+}
+
+func workflowContentWithServer(t *testing.T, host string, port int) string {
+	t.Helper()
+
+	return fmt.Sprintf(`---
+tracker:
+  kind: memory
+workspace:
+  source_root: %s
 server:
   host: %s
   port: %d
 ---
 Test workflow prompt.
-`, host, port)
+`, testSourceRoot(t), host, port)
+}
+
+func testSourceRoot(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	return cwd
 }
 
 func assertBootServer(t *testing.T, cfg cli.BootConfig, host string, port int) {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -88,9 +88,6 @@ func buildRunner(
 func buildWorkspaceBackend(cfg workflowconfig.Config, logger *slog.Logger) (workspace.Backend, error) {
 	root := strings.TrimSpace(cfg.Workspace.Root)
 	sourceRoot := strings.TrimSpace(cfg.Workspace.SourceRoot)
-	if sourceRoot == "" {
-		sourceRoot = root
-	}
 	backend, err := workspace.NewBackend(workspace.KindLocalGit, workspace.LocalGitOptions{
 		Root:       root,
 		SourceRoot: sourceRoot,

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -87,9 +87,13 @@ func buildRunner(
 
 func buildWorkspaceBackend(cfg workflowconfig.Config, logger *slog.Logger) (workspace.Backend, error) {
 	root := strings.TrimSpace(cfg.Workspace.Root)
+	sourceRoot := strings.TrimSpace(cfg.Workspace.SourceRoot)
+	if sourceRoot == "" {
+		sourceRoot = root
+	}
 	backend, err := workspace.NewBackend(workspace.KindLocalGit, workspace.LocalGitOptions{
 		Root:       root,
-		SourceRoot: root,
+		SourceRoot: sourceRoot,
 		AutoBranch: cfg.Workspace.AutoBranch,
 		Hooks: workspace.Hooks{
 			AfterCreate:  cfg.Hooks.AfterCreate,

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -14,6 +16,7 @@ import (
 	projectpkg "github.com/digitaldrywood/symphony/internal/project"
 	runnerpkg "github.com/digitaldrywood/symphony/internal/runner"
 	"github.com/digitaldrywood/symphony/internal/telemetry"
+	"github.com/digitaldrywood/symphony/internal/workspace"
 )
 
 var errProjectFactoryStub = errors.New("project factory stub")
@@ -24,6 +27,7 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Workspace.Root = t.TempDir()
+	cfg.Workspace.SourceRoot = initRunnerSourceRepo(t)
 
 	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, nil, nil)
 	if err != nil {
@@ -34,6 +38,43 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	}
 	if _, ok := run.(*runnerpkg.Runner); !ok {
 		t.Fatalf("buildRunner() = %T, want *runner.Runner", run)
+	}
+}
+
+func TestBuildWorkspaceBackendUsesConfiguredSourceRoot(t *testing.T) {
+	t.Parallel()
+
+	sourceRoot := initRunnerSourceRepo(t)
+	workspaceRoot := filepath.Join(t.TempDir(), "workspaces")
+
+	cfg := workflowconfig.Default()
+	cfg.Workspace.Root = workspaceRoot
+	cfg.Workspace.SourceRoot = sourceRoot
+	cfg.Workspace.AutoBranch = true
+
+	backend, err := buildWorkspaceBackend(cfg, nil)
+	if err != nil {
+		t.Fatalf("buildWorkspaceBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), workspace.Issue{Identifier: "DD-110"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	canonicalWorkspaceRoot, err := filepath.EvalSymlinks(workspaceRoot)
+	if err != nil {
+		t.Fatalf("EvalSymlinks() error = %v", err)
+	}
+	if !strings.HasPrefix(info.Path, canonicalWorkspaceRoot+string(os.PathSeparator)) {
+		t.Fatalf("workspace path = %q, want under %q", info.Path, canonicalWorkspaceRoot)
+	}
+	raw, err := os.ReadFile(filepath.Join(info.Path, "README.md"))
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if string(raw) != "source repo\n" {
+		t.Fatalf("README.md = %q, want source repo", raw)
 	}
 }
 
@@ -113,9 +154,37 @@ func writeWorkflowFile(t *testing.T) string {
 		"tracker:\n  kind: memory\n" +
 		"codex:\n  command: codex app-server\n" +
 		"workspace:\n  root: " + filepath.Join(dir, "workspaces") + "\n" +
+		"  source_root: " + initRunnerSourceRepo(t) + "\n" +
 		"---\n\nTest workflow prompt.\n"
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		t.Fatalf("write workflow file: %v", err)
 	}
 	return path
+}
+
+func initRunnerSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runRunnerCommand(t, dir, "git", "init", "-b", "main")
+	runRunnerCommand(t, dir, "git", "config", "user.name", "Test User")
+	runRunnerCommand(t, dir, "git", "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("source repo\n"), 0o600); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runRunnerCommand(t, dir, "git", "add", "README.md")
+	runRunnerCommand(t, dir, "git", "commit", "-m", "initial")
+	return dir
+}
+
+func runRunnerCommand(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
 	"strconv"
@@ -288,6 +289,7 @@ func (c Config) Validate() error {
 
 	c.validateTracker(&problems)
 	validatePositive("polling.interval_ms", c.Polling.IntervalMS, &problems)
+	c.Workspace.validate(&problems)
 	if c.Worker.MaxConcurrentAgentsPerHost != nil {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
 	}
@@ -391,6 +393,18 @@ func (t Tracker) hasGitHubAppCredentials() bool {
 	return strings.TrimSpace(t.GitHubAppID) != "" &&
 		strings.TrimSpace(t.GitHubAppInstallationID) != "" &&
 		(strings.TrimSpace(t.GitHubAppPrivateKey) != "" || strings.TrimSpace(t.GitHubAppPrivateKeyPath) != "")
+}
+
+func (w Workspace) validate(problems *[]string) {
+	validateRequired("workspace.root", w.Root, "", problems)
+	sourceRoot := strings.TrimSpace(w.SourceRoot)
+	if sourceRoot == "" {
+		*problems = append(*problems, "workspace.source_root is required")
+		return
+	}
+	if err := validateExistingGitRepo(sourceRoot); err != nil {
+		*problems = append(*problems, "workspace.source_root must be an existing git repo: "+err.Error())
+	}
 }
 
 func (a Agent) validate(prefix string, problems *[]string) {
@@ -810,6 +824,49 @@ func validateWorkspaceRelativePath(field string, path string, problems *[]string
 		pathEscapesWorkspace(trimmed) {
 		*problems = append(*problems, field+" must be a relative path inside the workspace")
 	}
+}
+
+func validateExistingGitRepo(path string) error {
+	expanded, err := expandUserPath(path)
+	if err != nil {
+		return err
+	}
+	info, err := os.Stat(expanded)
+	if err != nil {
+		return err
+	}
+	if !info.IsDir() {
+		return fmt.Errorf("%s is not a directory", expanded)
+	}
+
+	// #nosec G204 -- source_root is operator-supplied config passed as an argv value, not shell.
+	cmd := exec.Command("git", "-C", expanded, "rev-parse", "--is-inside-work-tree")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git rev-parse failed: %w", err)
+	}
+	if strings.TrimSpace(string(output)) != "true" {
+		return errors.New("git rev-parse did not report a work tree")
+	}
+	return nil
+}
+
+func expandUserPath(path string) (string, error) {
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	return path, nil
 }
 
 func pathEscapesWorkspace(path string) bool {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -166,7 +166,14 @@ func LoadWorkflow(path string) (Workflow, error) {
 		return Workflow{}, fmt.Errorf("read workflow file: %w", err)
 	}
 
-	return ParseWorkflow(raw)
+	workflow, err := ParseWorkflow(raw)
+	if err != nil {
+		return Workflow{}, err
+	}
+	if err := workflow.Config.resolveWorkflowPaths(filepath.Dir(path)); err != nil {
+		return Workflow{}, err
+	}
+	return workflow, nil
 }
 
 func ParseWorkflow(raw []byte) (Workflow, error) {
@@ -345,6 +352,25 @@ func (c *Config) normalize() {
 	c.Agent.DispatchPriorityByState = normalizeStateList(c.Agent.DispatchPriorityByState)
 	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
 	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
+}
+
+func (c *Config) resolveWorkflowPaths(baseDir string) error {
+	sourceRoot := strings.TrimSpace(c.Workspace.SourceRoot)
+	if sourceRoot == "" {
+		return nil
+	}
+
+	expanded, err := expandUserPath(sourceRoot)
+	if err != nil {
+		return err
+	}
+	if filepath.IsAbs(expanded) || windowsAbsPathPattern.MatchString(expanded) {
+		c.Workspace.SourceRoot = expanded
+		return nil
+	}
+
+	c.Workspace.SourceRoot = filepath.Join(baseDir, expanded)
+	return nil
 }
 
 func (c Config) validateTracker(problems *[]string) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -69,6 +69,7 @@ type Polling struct {
 
 type Workspace struct {
 	Root       string `yaml:"root"`
+	SourceRoot string `yaml:"source_root"`
 	AutoBranch bool   `yaml:"auto_branch"`
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,9 @@
 package config
 
 import (
+	"fmt"
+	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -10,7 +13,7 @@ import (
 func TestParseWorkflowFrontmatter(t *testing.T) {
 	t.Parallel()
 
-	raw := []byte(`---
+	raw := []byte(fmt.Sprintf(`---
 tracker:
   kind: github
   api_key: $GITHUB_TOKEN
@@ -27,6 +30,7 @@ polling:
   interval_ms: 15000
 workspace:
   root: ~/code/symphony-workspaces
+  source_root: %s
   auto_branch: false
 worker:
   ssh_hosts:
@@ -86,7 +90,7 @@ hooks:
   timeout_ms: 30000
 ---
 Ticket prompt {{ issue.title }}
-`)
+`, initConfigSourceRepo(t)))
 
 	workflow, err := ParseWorkflow(raw)
 	if err != nil {
@@ -119,6 +123,9 @@ Ticket prompt {{ issue.title }}
 	if got := cfg.Agent.DispatchPriorityByState; len(got) != 2 || got[0] != "merging" || got[1] != "rework" {
 		t.Fatalf("Agent.DispatchPriorityByState = %#v", got)
 	}
+	if cfg.Workspace.SourceRoot == "" {
+		t.Fatal("Workspace.SourceRoot is blank, want configured source root")
+	}
 	if cfg.Agent.AutoPromote.OptoutLabel != "requires-human-review" {
 		t.Fatalf("Agent.AutoPromote.OptoutLabel = %q", cfg.Agent.AutoPromote.OptoutLabel)
 	}
@@ -139,7 +146,7 @@ Ticket prompt {{ issue.title }}
 func TestParseWorkflowDefaults(t *testing.T) {
 	t.Parallel()
 
-	workflow, err := ParseWorkflow([]byte("---\ntracker:\n  kind: memory\n---\nPrompt\n"))
+	workflow, err := ParseWorkflow([]byte(fmt.Sprintf("---\ntracker:\n  kind: memory\nworkspace:\n  source_root: %s\n---\nPrompt\n", initConfigSourceRepo(t))))
 	if err != nil {
 		t.Fatalf("ParseWorkflow() error = %v", err)
 	}
@@ -307,16 +314,18 @@ Prompt
 func TestConfigValidateAcceptsGitHubAppCredentials(t *testing.T) {
 	t.Parallel()
 
-	workflow, err := ParseWorkflow([]byte(`---
+	workflow, err := ParseWorkflow([]byte(fmt.Sprintf(`---
 tracker:
   kind: github
   project_slug: PVT_project
   github_app_id: 12345
   github_app_private_key_path: .symphony/github-app.pem
   github_app_installation_id: 67890
+workspace:
+  source_root: %s
 ---
 Prompt
-`))
+`, initConfigSourceRepo(t))))
 	if err != nil {
 		t.Fatalf("ParseWorkflow() error = %v", err)
 	}
@@ -447,6 +456,18 @@ Prompt
 			},
 		},
 		{
+			name: "invalid source root",
+			raw: `---
+tracker:
+  kind: memory
+workspace:
+  source_root: /path/that/does/not/exist
+---
+Prompt
+`,
+			want: []string{"workspace.source_root must be an existing git repo"},
+		},
+		{
 			name: "invalid paths and priority map",
 			raw: `---
 tracker:
@@ -519,5 +540,25 @@ func TestParseWorkflowReportsInvalidFrontmatter(t *testing.T) {
 				t.Fatalf("ParseWorkflow() error = %q, want substring %q", err, tt.want)
 			}
 		})
+	}
+}
+
+func initConfigSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runConfigCommand(t, dir, "git", "init", "-b", "main")
+	return dir
+}
+
+func runConfigCommand(t *testing.T, dir string, name string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(), "GIT_CONFIG_NOSYSTEM=1")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
 	}
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -185,6 +186,35 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Budget.PricingPath != "priv/pricing/models.yaml" {
 		t.Fatalf("Budget.PricingPath = %q", cfg.Budget.PricingPath)
+	}
+}
+
+func TestLoadWorkflowResolvesRelativeSourceRootFromWorkflowDirectory(t *testing.T) {
+	t.Parallel()
+
+	sourceRoot := initConfigSourceRepo(t)
+	path := filepath.Join(sourceRoot, "WORKFLOW.md")
+	raw := []byte(`---
+tracker:
+  kind: memory
+workspace:
+  source_root: .
+---
+Prompt
+`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	workflow, err := LoadWorkflow(path)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if workflow.Config.Workspace.SourceRoot != sourceRoot {
+		t.Fatalf("Workspace.SourceRoot = %q, want %q", workflow.Config.Workspace.SourceRoot, sourceRoot)
 	}
 }
 

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -142,6 +142,8 @@ tracker:
   kind: memory
 polling:
   interval_ms: ` + strconv.Itoa(intervalMS) + `
+workspace:
+  source_root: .
 ---
 ` + prompt + `
 `)

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -143,11 +143,21 @@ tracker:
 polling:
   interval_ms: ` + strconv.Itoa(intervalMS) + `
 workspace:
-  source_root: .
+  source_root: ` + watcherSourceRoot(t) + `
 ---
 ` + prompt + `
 `)
 	if err := os.WriteFile(path, raw, 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
+}
+
+func watcherSourceRoot(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	return cwd
 }

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
 	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
 	"github.com/digitaldrywood/symphony/internal/hub"
 	"github.com/digitaldrywood/symphony/internal/project"
@@ -170,7 +171,10 @@ func TestManagerSharedGlobalSchedulerGate(t *testing.T) {
 	}, project.ManagerDependencies{
 		Events: events,
 		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
-			return project.New(project.Config{Project: cfg}, project.Dependencies{
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			}, project.Dependencies{
 				Events:    events,
 				Runner:    blockingRunner{},
 				Scheduler: global,
@@ -283,7 +287,8 @@ func newManagerTestProject(t *testing.T, cfg globalconfig.Project, events *hub.H
 		cfg.Weight = 1
 	}
 	return project.New(project.Config{
-		Project: cfg,
+		Project:  cfg,
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
 	}, project.Dependencies{
 		Events: events,
 		Runner: blockingRunner{},

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -571,6 +571,7 @@ func TestProjectStartRejectsPausedProject(t *testing.T) {
 			Paused: true,
 			Weight: 1,
 		},
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
 	}, project.Dependencies{})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -594,6 +595,7 @@ func TestProjectPauseUnpauseRestartsProject(t *testing.T) {
 			ID:     "symphony",
 			Weight: 1,
 		},
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
 	}, project.Dependencies{
 		Events: events,
 		Runner: blockingRunner{},
@@ -643,6 +645,7 @@ func TestProjectPauseDoesNotMarkPausedWhenShutdownTimesOut(t *testing.T) {
 			ID:     "symphony",
 			Weight: 1,
 		},
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
 	}, project.Dependencies{
 		Connector: blocker,
 		Runner:    blockingRunner{},
@@ -686,6 +689,7 @@ func TestProjectUnpauseKeepsProjectPausedWhenRestartFails(t *testing.T) {
 			ID:     "symphony",
 			Weight: 1,
 		},
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
 	}, project.Dependencies{
 		Events: events,
 		Runner: blockingRunner{},
@@ -734,6 +738,7 @@ func workflowConfigWithMemoryIssue(id string) workflowconfig.Config {
 func workflowConfig(kind string) workflowconfig.Config {
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = kind
+	cfg.Workspace.SourceRoot = "."
 	return cfg
 }
 
@@ -885,6 +890,8 @@ tracker:
   kind: memory
 %spolling:
   interval_ms: %d
+workspace:
+  source_root: .
 ---
 %s
 `, issues, intervalMS, prompt)

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -891,13 +891,23 @@ tracker:
 %spolling:
   interval_ms: %d
 workspace:
-  source_root: .
+  source_root: %s
 ---
 %s
-`, issues, intervalMS, prompt)
+`, issues, intervalMS, projectSourceRoot(t), prompt)
 	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
 		t.Fatalf("WriteFile(%s) error = %v", path, err)
 	}
+}
+
+func projectSourceRoot(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	return cwd
 }
 
 func receiveOrchestratorConfig(t *testing.T, ch <-chan orchestrator.Config) orchestrator.Config {

--- a/internal/project/registry_test.go
+++ b/internal/project/registry_test.go
@@ -3,6 +3,7 @@ package project_test
 import (
 	"testing"
 
+	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
 	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
 	"github.com/digitaldrywood/symphony/internal/project"
 )
@@ -84,6 +85,7 @@ func newTestProject(t *testing.T, id string) *project.Project {
 			ID:     id,
 			Weight: 1,
 		},
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
 	}, project.Dependencies{})
 	if err != nil {
 		t.Fatalf("New(%q) error = %v", id, err)

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -42,6 +42,7 @@ func (s *Server) onboarding(c echo.Context) error {
 		Step:                  onboardingStepTracker,
 		TrackerKind:           config.TrackerGitHub,
 		WorkspaceRoot:         defaultWorkspaceRoot,
+		SourceRoot:            defaultSourceRoot(),
 		MaxConcurrentAgents:   defaultMaxConcurrentAgents,
 		MaxTurns:              defaultMaxTurns,
 		PollingIntervalMS:     defaultPollingIntervalMS,
@@ -173,6 +174,7 @@ func parseOnboardingForm(c echo.Context) templates.OnboardingForm {
 		ProjectSlug:           strings.TrimSpace(c.FormValue("project_slug")),
 		Repo:                  strings.TrimSpace(c.FormValue("repo")),
 		WorkspaceRoot:         strings.TrimSpace(c.FormValue("workspace_root")),
+		SourceRoot:            strings.TrimSpace(c.FormValue("source_root")),
 		MaxConcurrentAgents:   strings.TrimSpace(c.FormValue("max_concurrent_agents")),
 		MaxTurns:              strings.TrimSpace(c.FormValue("max_turns")),
 		PollingIntervalMS:     strings.TrimSpace(c.FormValue("polling_interval_ms")),
@@ -253,7 +255,11 @@ func validateAgent(form templates.OnboardingForm) []string {
 	if strings.TrimSpace(form.WorkspaceRoot) == "" {
 		problems = append(problems, "workspace root is required")
 	}
+	if strings.TrimSpace(form.SourceRoot) == "" {
+		problems = append(problems, "source root is required")
+	}
 	problems = append(problems, rejectNewlines("workspace root", form.WorkspaceRoot)...)
+	problems = append(problems, rejectNewlines("source root", form.SourceRoot)...)
 	problems = append(problems, positiveIntegerProblem("max concurrent agents", form.MaxConcurrentAgents)...)
 	problems = append(problems, positiveIntegerProblem("max turns", form.MaxTurns)...)
 	problems = append(problems, positiveIntegerProblem("polling interval", form.PollingIntervalMS)...)
@@ -315,6 +321,9 @@ func applyAgentDefaults(form *templates.OnboardingForm) {
 	if form.WorkspaceRoot == "" {
 		form.WorkspaceRoot = defaultWorkspaceRoot
 	}
+	if form.SourceRoot == "" {
+		form.SourceRoot = defaultSourceRoot()
+	}
 	if form.MaxConcurrentAgents == "" {
 		form.MaxConcurrentAgents = defaultMaxConcurrentAgents
 	}
@@ -330,6 +339,14 @@ func applyAgentDefaults(form *templates.OnboardingForm) {
 	if form.DispatchPriorityState == "" {
 		form.DispatchPriorityState = defaultDispatchPriorityText
 	}
+}
+
+func defaultSourceRoot() string {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "."
+	}
+	return cwd
 }
 
 func renderWorkflow(form templates.OnboardingForm) string {
@@ -373,6 +390,7 @@ func renderWorkflow(form templates.OnboardingForm) string {
 	writeScalar(&b, "  ", "interval_ms", form.PollingIntervalMS)
 	b.WriteString("workspace:\n")
 	writeScalar(&b, "  ", "root", form.WorkspaceRoot)
+	writeScalar(&b, "  ", "source_root", form.SourceRoot)
 	b.WriteString("  auto_branch: true\n")
 	b.WriteString("agent:\n")
 	writeScalar(&b, "  ", "max_concurrent_agents", form.MaxConcurrentAgents)
@@ -397,12 +415,6 @@ func renderWorkflow(form templates.OnboardingForm) string {
 	b.WriteString("    type: workspaceWrite\n")
 	b.WriteString("    networkAccess: true\n")
 	b.WriteString("hooks:\n")
-	if form.Repo != "" {
-		b.WriteString("  after_create: |\n")
-		b.WriteString("    git clone --depth 1 https://github.com/")
-		b.WriteString(form.Repo)
-		b.WriteString(" .\n")
-	}
 	b.WriteString("  timeout_ms: 60000\n")
 	b.WriteString("---\n\n")
 	b.WriteString(renderWorkflowPrompt(form))

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -85,6 +85,7 @@ func TestOnboardingRoutesProgressThroughWizard(t *testing.T) {
 				"Agent config",
 				"name=\"max_concurrent_agents\"",
 				"name=\"workspace_root\"",
+				"name=\"source_root\"",
 			},
 		},
 		{
@@ -98,6 +99,7 @@ func TestOnboardingRoutesProgressThroughWizard(t *testing.T) {
 				"project_slug":               {"PVT_project"},
 				"repo":                       {"digitaldrywood/symphony"},
 				"workspace_root":             {"~/code/symphony-workspaces"},
+				"source_root":                {"."},
 				"max_concurrent_agents":      {"5"},
 				"max_turns":                  {"20"},
 				"polling_interval_ms":        {"30000"},
@@ -165,7 +167,7 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		"tracker:\n  kind: github",
 		"api_key: $GITHUB_TOKEN",
 		"project_slug: PVT_project",
-		"git clone --depth 1 https://github.com/digitaldrywood/symphony .",
+		"source_root: .",
 		"max_concurrent_agents_by_state:\n    Merging: 1",
 		"You are working on GitHub issue `{{ issue.identifier }}`",
 	} {
@@ -260,6 +262,35 @@ func TestOnboardingWriteDoesNotOverwriteWithoutReplace(t *testing.T) {
 	}
 }
 
+func TestOnboardingWriteDoesNotGenerateAfterCreateClone(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	server, err := web.NewServer(web.Config{WorkflowPath: workflowPath}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := onboardingRequest(http.MethodPost, "/onboarding/write", validOnboardingForm())
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	raw, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(raw)
+	for _, unwanted := range []string{"after_create:", "git clone", "git worktree add"} {
+		if strings.Contains(content, unwanted) {
+			t.Fatalf("workflow contains %q:\n%s", unwanted, content)
+		}
+	}
+}
+
 func TestOnboardingWriteValidatesInput(t *testing.T) {
 	t.Parallel()
 
@@ -337,6 +368,7 @@ func validOnboardingForm() url.Values {
 		"project_slug":               {"PVT_project"},
 		"repo":                       {"digitaldrywood/symphony"},
 		"workspace_root":             {"~/code/symphony-workspaces"},
+		"source_root":                {"."},
 		"max_concurrent_agents":      {"5"},
 		"max_turns":                  {"20"},
 		"polling_interval_ms":        {"30000"},

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -145,7 +145,7 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		t.Fatalf("NewServer() error = %v", err)
 	}
 
-	form := validOnboardingForm()
+	form := validOnboardingForm(t)
 	rec := httptest.NewRecorder()
 	req := onboardingRequest(http.MethodPost, "/onboarding/write", form)
 
@@ -167,7 +167,7 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		"tracker:\n  kind: github",
 		"api_key: $GITHUB_TOKEN",
 		"project_slug: PVT_project",
-		"source_root: .",
+		"source_root: " + webTestSourceRoot(t),
 		"max_concurrent_agents_by_state:\n    Merging: 1",
 		"You are working on GitHub issue `{{ issue.identifier }}`",
 	} {
@@ -187,7 +187,7 @@ func TestOnboardingWriteMemoryWorkflowSeedsSampleIssue(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := onboardingRequest(http.MethodPost, "/onboarding/write", validMemoryOnboardingForm())
+	req := onboardingRequest(http.MethodPost, "/onboarding/write", validMemoryOnboardingForm(t))
 
 	server.Handler().ServeHTTP(rec, req)
 
@@ -225,7 +225,7 @@ func TestOnboardingWriteDoesNotOverwriteWithoutReplace(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := onboardingRequest(http.MethodPost, "/onboarding/write", validOnboardingForm())
+	req := onboardingRequest(http.MethodPost, "/onboarding/write", validOnboardingForm(t))
 
 	server.Handler().ServeHTTP(rec, req)
 
@@ -243,7 +243,7 @@ func TestOnboardingWriteDoesNotOverwriteWithoutReplace(t *testing.T) {
 		t.Fatalf("workflow content = %q, want existing", raw)
 	}
 
-	form := validOnboardingForm()
+	form := validOnboardingForm(t)
 	form.Set("replace", "true")
 	rec = httptest.NewRecorder()
 	req = onboardingRequest(http.MethodPost, "/onboarding/write", form)
@@ -272,7 +272,7 @@ func TestOnboardingWriteDoesNotGenerateAfterCreateClone(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := onboardingRequest(http.MethodPost, "/onboarding/write", validOnboardingForm())
+	req := onboardingRequest(http.MethodPost, "/onboarding/write", validOnboardingForm(t))
 
 	server.Handler().ServeHTTP(rec, req)
 
@@ -339,7 +339,7 @@ func TestOnboardingWriteValidatesInput(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			form := validOnboardingForm()
+			form := validOnboardingForm(t)
 			tt.edit(form)
 
 			rec := httptest.NewRecorder()
@@ -360,7 +360,9 @@ func TestOnboardingWriteValidatesInput(t *testing.T) {
 	}
 }
 
-func validOnboardingForm() url.Values {
+func validOnboardingForm(t *testing.T) url.Values {
+	t.Helper()
+
 	return url.Values{
 		"tracker_kind":               {"github"},
 		"endpoint":                   {"https://api.github.com/graphql"},
@@ -368,7 +370,7 @@ func validOnboardingForm() url.Values {
 		"project_slug":               {"PVT_project"},
 		"repo":                       {"digitaldrywood/symphony"},
 		"workspace_root":             {"~/code/symphony-workspaces"},
-		"source_root":                {"."},
+		"source_root":                {webTestSourceRoot(t)},
 		"max_concurrent_agents":      {"5"},
 		"max_turns":                  {"20"},
 		"polling_interval_ms":        {"30000"},
@@ -377,14 +379,26 @@ func validOnboardingForm() url.Values {
 	}
 }
 
-func validMemoryOnboardingForm() url.Values {
-	form := validOnboardingForm()
+func validMemoryOnboardingForm(t *testing.T) url.Values {
+	t.Helper()
+
+	form := validOnboardingForm(t)
 	form.Set("tracker_kind", "memory")
 	form.Del("endpoint")
 	form.Del("api_key")
 	form.Del("project_slug")
 	form.Del("repo")
 	return form
+}
+
+func webTestSourceRoot(t *testing.T) string {
+	t.Helper()
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	return cwd
 }
 
 func onboardingRequest(method string, path string, form url.Values) *http.Request {

--- a/internal/web/templates/onboarding.templ
+++ b/internal/web/templates/onboarding.templ
@@ -17,6 +17,7 @@ type OnboardingForm struct {
 	ProjectSlug           string
 	Repo                  string
 	WorkspaceRoot         string
+	SourceRoot            string
 	MaxConcurrentAgents   string
 	MaxTurns              string
 	PollingIntervalMS     string
@@ -199,6 +200,10 @@ templ agentStep(data OnboardingData) {
 				<span class="text-sm font-medium">Workspace root</span>
 				<input class={ fieldClass() } type="text" name="workspace_root" value={ data.Form.WorkspaceRoot }/>
 			</label>
+			<label class="block sm:col-span-2">
+				<span class="text-sm font-medium">Source root</span>
+				<input class={ fieldClass() } type="text" name="source_root" value={ data.Form.SourceRoot }/>
+			</label>
 			<label class="block">
 				<span class="text-sm font-medium">Max agents</span>
 				<input class={ fieldClass() } type="number" min="1" name="max_concurrent_agents" value={ data.Form.MaxConcurrentAgents }/>
@@ -288,6 +293,7 @@ templ hiddenProject(form OnboardingForm) {
 templ hiddenAgent(form OnboardingForm) {
 	@hiddenProject(form)
 	<input type="hidden" name="workspace_root" value={ form.WorkspaceRoot }/>
+	<input type="hidden" name="source_root" value={ form.SourceRoot }/>
 	<input type="hidden" name="max_concurrent_agents" value={ form.MaxConcurrentAgents }/>
 	<input type="hidden" name="max_turns" value={ form.MaxTurns }/>
 	<input type="hidden" name="polling_interval_ms" value={ form.PollingIntervalMS }/>

--- a/internal/web/templates/onboarding_templ.go
+++ b/internal/web/templates/onboarding_templ.go
@@ -25,6 +25,7 @@ type OnboardingForm struct {
 	ProjectSlug           string
 	Repo                  string
 	WorkspaceRoot         string
+	SourceRoot            string
 	MaxConcurrentAgents   string
 	MaxTurns              string
 	PollingIntervalMS     string
@@ -100,7 +101,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(data.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 73, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 74, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -173,7 +174,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var6 string
 			templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(item.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 93, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 94, Col: 68}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 			if templ_7745c5c3_Err != nil {
@@ -201,7 +202,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 				var templ_7745c5c3_Var7 string
 				templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(problem)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 101, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 102, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 				if templ_7745c5c3_Err != nil {
@@ -342,7 +343,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 135, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 136, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -365,7 +366,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 137, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 138, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
@@ -378,7 +379,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 138, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 139, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
@@ -456,7 +457,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Endpoint)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 153, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 154, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
@@ -491,7 +492,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var21 string
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.APIKey)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 157, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 158, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
@@ -618,7 +619,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var29 string
 			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 178, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 179, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 			if templ_7745c5c3_Err != nil {
@@ -653,7 +654,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var32 string
 			templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 182, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 183, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 			if templ_7745c5c3_Err != nil {
@@ -774,13 +775,13 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 200, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 201, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Max agents</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "\"></label> <label class=\"block sm:col-span-2\"><span class=\"text-sm font-medium\">Source root</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -802,20 +803,20 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\" type=\"number\" min=\"1\" name=\"max_concurrent_agents\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\" type=\"text\" name=\"source_root\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var43 string
-		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxConcurrentAgents)
+		templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.SourceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 204, Col: 122}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 205, Col: 93}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Max turns</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Max agents</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -837,20 +838,20 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\" type=\"number\" min=\"1\" name=\"max_turns\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\" type=\"number\" min=\"1\" name=\"max_concurrent_agents\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var46 string
-		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxTurns)
+		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 208, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 209, Col: 122}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Polling interval</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Max turns</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -872,20 +873,20 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" type=\"number\" min=\"1\" name=\"polling_interval_ms\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" type=\"number\" min=\"1\" name=\"max_turns\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var49 string
-		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.PollingIntervalMS)
+		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxTurns)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 212, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 213, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Merging concurrency</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Polling interval</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -907,29 +908,29 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\" type=\"number\" min=\"1\" name=\"merging_concurrency\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "\" type=\"number\" min=\"1\" name=\"polling_interval_ms\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var52 string
-		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MergingConcurrency)
+		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.PollingIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 216, Col: 119}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 217, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\"></label> <label class=\"block sm:col-span-2\"><span class=\"text-sm font-medium\">Dispatch priority by state</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "\"></label> <label class=\"block\"><span class=\"text-sm font-medium\">Merging concurrency</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var53 = []any{fieldClass() + " min-h-24"}
+		var templ_7745c5c3_Var53 = []any{fieldClass()}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var53...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<textarea class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<input class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -942,29 +943,29 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" name=\"dispatch_priority_by_state\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" type=\"number\" min=\"1\" name=\"merging_concurrency\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var55 string
-		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.DispatchPriorityState)
+		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MergingConcurrency)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 220, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 221, Col: 119}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</textarea></label><div class=\"flex flex-wrap gap-2 pt-2 sm:col-span-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\"></label> <label class=\"block sm:col-span-2\"><span class=\"text-sm font-medium\">Dispatch priority by state</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var56 = []any{buttonClass()}
+		var templ_7745c5c3_Var56 = []any{fieldClass() + " min-h-24"}
 		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var56...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "<button class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "<textarea class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -977,29 +978,64 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\" type=\"submit\">Continue</button> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\" name=\"dispatch_priority_by_state\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var58 = []any{secondaryButtonClass()}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var58...)
+		var templ_7745c5c3_Var58 string
+		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.DispatchPriorityState)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 225, Col: 118}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<button class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "</textarea></label><div class=\"flex flex-wrap gap-2 pt-2 sm:col-span-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var59 string
-		templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var58).String())
+		var templ_7745c5c3_Var59 = []any{buttonClass()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var59...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "<button class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var60 string
+		templ_7745c5c3_Var60, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var59).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var60))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\" type=\"submit\" hx-post=\"/onboarding/credentials\">Back</button></div></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "\" type=\"submit\">Continue</button> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var61 = []any{secondaryButtonClass()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var61...)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<button class=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var62 string
+		templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var61).String())
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 1, Col: 0}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "\" type=\"submit\" hx-post=\"/onboarding/credentials\">Back</button></div></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1023,80 +1059,80 @@ func writeStep(data OnboardingData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var60 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var60 == nil {
-			templ_7745c5c3_Var60 = templ.NopComponent
+		templ_7745c5c3_Var63 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var63 == nil {
+			templ_7745c5c3_Var63 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "<div class=\"rounded-md border border-border bg-card p-5\"><h2 class=\"text-xl font-semibold\">Write WORKFLOW.md</h2><div class=\"mt-4 grid gap-3 text-sm text-muted-foreground sm:grid-cols-2\"><p><span class=\"font-medium text-foreground\">Tracker:</span> ")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var61 string
-		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.TrackerKind)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 234, Col: 87}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</p>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		if data.Form.ProjectSlug != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "<p><span class=\"font-medium text-foreground\">ProjectV2:</span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var62 string
-			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 236, Col: 90}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</p>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if data.Form.Repo != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<p><span class=\"font-medium text-foreground\">Repo:</span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var63 string
-			templ_7745c5c3_Var63, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 239, Col: 78}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var63))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "</p>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<p><span class=\"font-medium text-foreground\">Output:</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "<div class=\"rounded-md border border-border bg-card p-5\"><h2 class=\"text-xl font-semibold\">Write WORKFLOW.md</h2><div class=\"mt-4 grid gap-3 text-sm text-muted-foreground sm:grid-cols-2\"><p><span class=\"font-medium text-foreground\">Tracker:</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var64 string
-		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(data.WorkflowPath)
+		templ_7745c5c3_Var64, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 241, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 239, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var64))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</p></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</p>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if data.Form.ProjectSlug != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "<p><span class=\"font-medium text-foreground\">ProjectV2:</span> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var65 string
+			templ_7745c5c3_Var65, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 241, Col: 90}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var65))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		if data.Form.Repo != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "<p><span class=\"font-medium text-foreground\">Repo:</span> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var66 string
+			templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 244, Col: 78}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<p><span class=\"font-medium text-foreground\">Output:</span> ")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var67 string
+		templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(data.WorkflowPath)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 246, Col: 82}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "</p></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1104,7 +1140,7 @@ func writeStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<form class=\"mt-5 flex flex-wrap gap-2\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<form class=\"mt-5 flex flex-wrap gap-2\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1112,25 +1148,25 @@ func writeStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var65 = []any{buttonClass()}
-		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var65...)
+		var templ_7745c5c3_Var68 = []any{buttonClass()}
+		templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var68...)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "<button class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "<button class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var66 string
-		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var65).String())
+		var templ_7745c5c3_Var69 string
+		templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var68).String())
 		if templ_7745c5c3_Err != nil {
 			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 1, Col: 0}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "\" type=\"submit\">Write WORKFLOW.md</button></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "\" type=\"submit\">Write WORKFLOW.md</button></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1154,44 +1190,44 @@ func resultPanel(data OnboardingData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var67 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var67 == nil {
-			templ_7745c5c3_Var67 = templ.NopComponent
+		templ_7745c5c3_Var70 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var70 == nil {
+			templ_7745c5c3_Var70 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if data.Result.Kind == "success" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<div class=\"mt-4 rounded-md border border-success bg-card p-4 text-sm text-success\"><strong>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<div class=\"mt-4 rounded-md border border-success bg-card p-4 text-sm text-success\"><strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var68 string
-			templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
+			var templ_7745c5c3_Var71 string
+			templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 254, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 259, Col: 32}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</strong></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</strong></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else if data.Result.Kind == "exists" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<div class=\"mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning\"><p><strong>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<div class=\"mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning\"><p><strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var69 string
-			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
+			var templ_7745c5c3_Var72 string
+			templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 258, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 263, Col: 35}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "</strong></p><form class=\"mt-3\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</strong></p><form class=\"mt-3\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1199,47 +1235,47 @@ func resultPanel(data OnboardingData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "<input type=\"hidden\" name=\"replace\" value=\"true\"> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<input type=\"hidden\" name=\"replace\" value=\"true\"> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var70 = []any{buttonClass()}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var70...)
+			var templ_7745c5c3_Var73 = []any{buttonClass()}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var73...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<button class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<button class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var71 string
-			templ_7745c5c3_Var71, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var70).String())
+			var templ_7745c5c3_Var74 string
+			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var73).String())
 			if templ_7745c5c3_Err != nil {
 				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 1, Col: 0}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var71))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "\" type=\"submit\">Overwrite</button></form></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\" type=\"submit\">Overwrite</button></form></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else if data.Result.Kind == "error" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<div class=\"mt-4 rounded-md border border-danger bg-card p-4 text-sm text-danger\"><strong>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<div class=\"mt-4 rounded-md border border-danger bg-card p-4 text-sm text-danger\"><strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var72 string
-			templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
+			var templ_7745c5c3_Var75 string
+			templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 267, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 272, Col: 32}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "</strong></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "</strong></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1264,25 +1300,25 @@ func hiddenTracker(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var73 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var73 == nil {
-			templ_7745c5c3_Var73 = templ.NopComponent
+		templ_7745c5c3_Var76 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var76 == nil {
+			templ_7745c5c3_Var76 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "<input type=\"hidden\" name=\"tracker_kind\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "<input type=\"hidden\" name=\"tracker_kind\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var74 string
-		templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(form.TrackerKind)
+		var templ_7745c5c3_Var77 string
+		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 273, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 278, Col: 66}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1306,42 +1342,42 @@ func hiddenCredentials(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var75 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var75 == nil {
-			templ_7745c5c3_Var75 = templ.NopComponent
+		templ_7745c5c3_Var78 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var78 == nil {
+			templ_7745c5c3_Var78 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = hiddenTracker(form).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "<input type=\"hidden\" name=\"endpoint\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "<input type=\"hidden\" name=\"endpoint\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var76 string
-		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(form.Endpoint)
+		var templ_7745c5c3_Var79 string
+		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(form.Endpoint)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 278, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 283, Col: 59}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "\"> <input type=\"hidden\" name=\"api_key\" value=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var77 string
-		templ_7745c5c3_Var77, templ_7745c5c3_Err = templ.JoinStringErrs(form.APIKey)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 279, Col: 56}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var77))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "\"> <input type=\"hidden\" name=\"api_key\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "\">")
+		var templ_7745c5c3_Var80 string
+		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(form.APIKey)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 284, Col: 56}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1365,42 +1401,42 @@ func hiddenProject(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var78 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var78 == nil {
-			templ_7745c5c3_Var78 = templ.NopComponent
+		templ_7745c5c3_Var81 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var81 == nil {
+			templ_7745c5c3_Var81 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = hiddenCredentials(form).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "<input type=\"hidden\" name=\"project_slug\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "<input type=\"hidden\" name=\"project_slug\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var79 string
-		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(form.ProjectSlug)
+		var templ_7745c5c3_Var82 string
+		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(form.ProjectSlug)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 284, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 289, Col: 66}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "\"> <input type=\"hidden\" name=\"repo\" value=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var80 string
-		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(form.Repo)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 285, Col: 51}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "\"> <input type=\"hidden\" name=\"repo\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "\">")
+		var templ_7745c5c3_Var83 string
+		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(form.Repo)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 290, Col: 51}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1424,94 +1460,107 @@ func hiddenAgent(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var81 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var81 == nil {
-			templ_7745c5c3_Var81 = templ.NopComponent
+		templ_7745c5c3_Var84 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var84 == nil {
+			templ_7745c5c3_Var84 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = hiddenProject(form).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "<input type=\"hidden\" name=\"workspace_root\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var82 string
-		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(form.WorkspaceRoot)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 290, Col: 70}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "\"> <input type=\"hidden\" name=\"max_concurrent_agents\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var83 string
-		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxConcurrentAgents)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 291, Col: 83}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "\"> <input type=\"hidden\" name=\"max_turns\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var84 string
-		templ_7745c5c3_Var84, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxTurns)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 292, Col: 60}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var84))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "\"> <input type=\"hidden\" name=\"polling_interval_ms\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "<input type=\"hidden\" name=\"workspace_root\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var85 string
-		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(form.PollingIntervalMS)
+		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 293, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 295, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "\"> <input type=\"hidden\" name=\"merging_concurrency\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "\"> <input type=\"hidden\" name=\"source_root\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var86 string
-		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(form.MergingConcurrency)
+		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(form.SourceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 294, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 296, Col: 64}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_state\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "\"> <input type=\"hidden\" name=\"max_concurrent_agents\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var87 string
-		templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityState)
+		templ_7745c5c3_Var87, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 295, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 297, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var87))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\"> <input type=\"hidden\" name=\"max_turns\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var88 string
+		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxTurns)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 298, Col: 60}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "\"> <input type=\"hidden\" name=\"polling_interval_ms\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var89 string
+		templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(form.PollingIntervalMS)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 299, Col: 79}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "\"> <input type=\"hidden\" name=\"merging_concurrency\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var90 string
+		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(form.MergingConcurrency)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 300, Col: 80}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_state\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var91 string
+		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityState)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 301, Col: 90}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -146,6 +146,9 @@ func NewLocalGit(opts LocalGitOptions) (*LocalGit, error) {
 	if err != nil {
 		return nil, fmt.Errorf("source root: %w", err)
 	}
+	if err := validateGitSourceRoot(sourceRoot); err != nil {
+		return nil, fmt.Errorf("source root: %w", err)
+	}
 
 	hooks := opts.Hooks
 	if hooks.Timeout == 0 {
@@ -508,6 +511,17 @@ func gitCommonDir(ctx context.Context, dir string) (string, error) {
 		commonDir = filepath.Join(dir, commonDir)
 	}
 	return canonicalExistingPath(commonDir)
+}
+
+func validateGitSourceRoot(path string) error {
+	output, err := runGitAt(context.Background(), path, "rev-parse", "--is-inside-work-tree")
+	if err != nil {
+		return fmt.Errorf("must be a git work tree: %w", err)
+	}
+	if strings.TrimSpace(output) != "true" {
+		return errors.New("must be a git work tree")
+	}
+	return nil
 }
 
 func hookEnv(info Info, issue Issue) []string {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -99,7 +99,7 @@ func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
 		AutoBranch: true,
 		Hooks: Hooks{
 			AfterCreate: "printf 'ok\n' > " + shellQuote(tracePath),
-			Timeout:     time.Second,
+			Timeout:     5 * time.Second,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- add `workspace.source_root` to workflow config and validate it points at an existing git work tree
- wire LocalGit `SourceRoot` from `workspace.source_root` while keeping `workspace.root` as the worktree parent
- update onboarding-generated workflows to emit `source_root` and stop cloning in `after_create`
- add focused coverage for config validation, backend worktree creation, onboarding output, and updated workflow fixtures

Fixes #110

## Test Plan
- `go test ./internal/config ./internal/cli ./internal/web ./internal/workspace ./internal/project`
- `go test -race ./internal/config/watcher ./internal/workspace`
- `make check`