### PR TITLE
feat(telemetry): stream live token usage

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,6 +19,7 @@ const (
 	defaultMaxRetryBackoff       = 5 * time.Minute
 	defaultContinuationRetry     = time.Second
 	defaultFailureRetryBaseDelay = 10 * time.Second
+	runUpdateBufferSize          = 128
 )
 
 var (
@@ -135,7 +136,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		configUpdates: make(chan configUpdateRequest),
 		refreshes:     make(chan time.Time, 1),
 		runResults:    make(chan runpkg.Completion),
-		runUpdates:    make(chan runUpdate),
+		runUpdates:    make(chan runUpdate, runUpdateBufferSize),
 		done:          make(chan struct{}),
 	}, nil
 }
@@ -486,10 +487,16 @@ func (o *Orchestrator) dispatchIssue(
 func (o *Orchestrator) usageUpdateHandler(ctx context.Context, issueID string) runpkg.UsageUpdateHandler {
 	return func(update runpkg.UsageUpdate) error {
 		select {
-		case o.runUpdates <- runUpdate{issueID: issueID, usage: update}:
-			return nil
 		case <-ctx.Done():
 			return ctx.Err()
+		default:
+		}
+
+		select {
+		case o.runUpdates <- runUpdate{issueID: issueID, usage: update}:
+			return nil
+		default:
+			return nil
 		}
 	}
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -62,6 +62,7 @@ type Orchestrator struct {
 	configUpdates chan configUpdateRequest
 	refreshes     chan time.Time
 	runResults    chan runpkg.Completion
+	runUpdates    chan runUpdate
 	done          chan struct{}
 }
 
@@ -72,6 +73,11 @@ type stateRequest struct {
 type configUpdateRequest struct {
 	update RuntimeUpdate
 	reply  chan struct{}
+}
+
+type runUpdate struct {
+	issueID string
+	usage   runpkg.UsageUpdate
 }
 
 func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
@@ -129,6 +135,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		configUpdates: make(chan configUpdateRequest),
 		refreshes:     make(chan time.Time, 1),
 		runResults:    make(chan runpkg.Completion),
+		runUpdates:    make(chan runUpdate),
 		done:          make(chan struct{}),
 	}, nil
 }
@@ -155,6 +162,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.tick(ctx, &state, now)
 		case result := <-o.runResults:
 			o.handleRunResult(&state, result)
+		case update := <-o.runUpdates:
+			o.handleRunUpdate(&state, update)
 		case update := <-o.configUpdates:
 			o.applyRuntimeUpdate(&state, update.update, ticker)
 			update.reply <- struct{}{}
@@ -465,12 +474,38 @@ func (o *Orchestrator) dispatchIssue(
 	delete(state.BudgetRefusals, issue.ID)
 
 	request := RunRequest{
-		Issue:      issue,
-		Attempt:    attempt,
-		StartedAt:  now,
-		WorkerHost: workerHost,
+		Issue:         issue,
+		Attempt:       attempt,
+		StartedAt:     now,
+		WorkerHost:    workerHost,
+		OnUsageUpdate: o.usageUpdateHandler(ctx, issue.ID),
 	}
 	o.supervisor.Dispatch(ctx, request, o.runResults)
+}
+
+func (o *Orchestrator) usageUpdateHandler(ctx context.Context, issueID string) runpkg.UsageUpdateHandler {
+	return func(update runpkg.UsageUpdate) error {
+		select {
+		case o.runUpdates <- runUpdate{issueID: issueID, usage: update}:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
+	running, ok := state.Running[event.issueID]
+	if !ok {
+		return
+	}
+
+	running.Tokens = event.usage.Tokens
+	running.TurnCount = event.usage.TurnCount
+	state.Running[event.issueID] = running
+	if event.usage.RateLimits != nil {
+		state.RateLimits = cloneRateLimits(event.usage.RateLimits)
+	}
 }
 
 func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -111,6 +111,46 @@ func TestRunReportsRunningStateWhileRunnerIsInFlight(t *testing.T) {
 	})
 }
 
+func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-live-usage", "digitaldrywood/symphony#115", "In Progress")
+	tracker := newFakeConnector(issue)
+	runner := newUsageStreamingRunner(orchestrator.UsageUpdate{
+		TurnCount: 1,
+		Tokens: orchestrator.CodexTotals{
+			InputTokens:    40,
+			OutputTokens:   12,
+			TotalTokens:    52,
+			RuntimeSeconds: 3.5,
+		},
+	})
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	receiveRunRequest(t, runner.started)
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		running, ok := state.Running[issue.ID]
+		return ok && running.Tokens.TotalTokens == 52 && running.TurnCount == 1
+	})
+
+	running := state.Running[issue.ID]
+	if running.Tokens.InputTokens != 40 || running.Tokens.OutputTokens != 12 {
+		t.Fatalf("Running[%q].Tokens = %#v, want input 40 output 12", issue.ID, running.Tokens)
+	}
+	if running.Tokens.RuntimeSeconds != 3.5 {
+		t.Fatalf("Running[%q].Tokens.RuntimeSeconds = %v, want 3.5", issue.ID, running.Tokens.RuntimeSeconds)
+	}
+	if state.CodexTotals.TotalTokens != 0 {
+		t.Fatalf("CodexTotals.TotalTokens = %d, want completed totals only", state.CodexTotals.TotalTokens)
+	}
+
+	close(runner.release)
+}
+
 func TestUpdateConfigAppliesBeforeNextTick(t *testing.T) {
 	t.Parallel()
 
@@ -720,6 +760,42 @@ func (r *blockingRunner) Run(ctx context.Context, request orchestrator.RunReques
 	select {
 	case <-r.release:
 		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+}
+
+type usageStreamingRunner struct {
+	started chan orchestrator.RunRequest
+	release chan struct{}
+	update  orchestrator.UsageUpdate
+}
+
+func newUsageStreamingRunner(update orchestrator.UsageUpdate) *usageStreamingRunner {
+	return &usageStreamingRunner{
+		started: make(chan orchestrator.RunRequest, 1),
+		release: make(chan struct{}),
+		update:  update,
+	}
+}
+
+func (r *usageStreamingRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	select {
+	case r.started <- request:
+	case <-ctx.Done():
+		return orchestrator.RunResult{}, ctx.Err()
+	}
+
+	if request.OnUsageUpdate == nil {
+		return orchestrator.RunResult{}, errors.New("missing usage update callback")
+	}
+	if err := request.OnUsageUpdate(r.update); err != nil {
+		return orchestrator.RunResult{}, err
+	}
+
+	select {
+	case <-r.release:
+		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted, Tokens: r.update.Tokens}, nil
 	case <-ctx.Done():
 		return orchestrator.RunResult{}, ctx.Err()
 	}

--- a/internal/orchestrator/run_update_test.go
+++ b/internal/orchestrator/run_update_test.go
@@ -1,0 +1,55 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runpkg "github.com/digitaldrywood/symphony/internal/runner"
+)
+
+func TestUsageUpdateHandlerDoesNotBlockWhenBufferIsFull(t *testing.T) {
+	t.Parallel()
+
+	orch := &Orchestrator{
+		runUpdates: make(chan runUpdate, 1),
+	}
+	orch.runUpdates <- runUpdate{issueID: "queued"}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- orch.usageUpdateHandler(context.Background(), "issue-1")(runpkg.UsageUpdate{
+			TurnCount: 1,
+			Tokens: runpkg.CodexTotals{
+				InputTokens:  10,
+				OutputTokens: 5,
+				TotalTokens:  15,
+			},
+		})
+	}()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("usage update error = %v", err)
+		}
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("usage update blocked with a full buffer")
+	}
+}
+
+func TestUsageUpdateHandlerReturnsCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	orch := &Orchestrator{
+		runUpdates: make(chan runUpdate, 1),
+	}
+
+	err := orch.usageUpdateHandler(ctx, "issue-1")(runpkg.UsageUpdate{})
+	if err == nil {
+		t.Fatal("usage update error = nil, want context canceled")
+	}
+}

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -18,4 +18,6 @@ type DiffStats = runner.DiffStats
 
 type CodexTotals = runner.CodexTotals
 
+type UsageUpdate = runner.UsageUpdate
+
 type FakeRunner = runner.FakeRunner

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -19,7 +19,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Blocked:     blockedSnapshots(s.Blocked),
 		Completed:   completedSnapshots(s.Completed),
 		RateLimits:  cloneRateLimits(s.RateLimits),
-		Tokens:      tokensFromCodexTotals(s.CodexTotals),
+		Tokens:      tokensFromCodexTotals(s.liveCodexTotals()),
 		Budget: telemetry.Budget{
 			Refusals: budgetRefusalSnapshots(s.BudgetRefusals),
 		},
@@ -42,8 +42,9 @@ func runningSnapshots(running map[string]Running) []telemetry.Running {
 			Issue:          telemetryIssue(entry.Issue),
 			WorkerHost:     entry.WorkerHost,
 			StartedAt:      entry.StartedAt,
-			RuntimeSeconds: 0,
-			Tokens:         telemetry.Tokens{},
+			TurnCount:      entry.TurnCount,
+			RuntimeSeconds: entry.Tokens.RuntimeSeconds,
+			Tokens:         tokensFromCodexTotals(entry.Tokens),
 		})
 	}
 	return out
@@ -152,6 +153,14 @@ func tokensFromCodexTotals(totals CodexTotals) telemetry.Tokens {
 		Total:          totals.TotalTokens,
 		RuntimeSeconds: totals.RuntimeSeconds,
 	}
+}
+
+func (s State) liveCodexTotals() CodexTotals {
+	totals := s.CodexTotals
+	for _, running := range s.Running {
+		totals = addCodexTotals(totals, running.Tokens)
+	}
+	return totals
 }
 
 func sortedKeys[V any](m map[string]V) []string {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -51,11 +51,15 @@ func TestStateSnapshotPopulated(t *testing.T) {
 		Attempt:    1,
 		StartedAt:  startedAt,
 		WorkerHost: "host-b",
+		TurnCount:  2,
+		Tokens:     CodexTotals{InputTokens: 20, OutputTokens: 8, TotalTokens: 28, RuntimeSeconds: 30},
 	}
 	state.Running["i-1"] = Running{
 		Issue:     connector.Issue{ID: "i-1", Identifier: "ISS-1", Title: "One", State: "In Progress"},
 		Attempt:   0,
 		StartedAt: startedAt,
+		TurnCount: 1,
+		Tokens:    CodexTotals{InputTokens: 2, OutputTokens: 1, TotalTokens: 3, RuntimeSeconds: 15},
 	}
 	state.Retry["i-3"] = Retry{
 		Issue:      connector.Issue{ID: "i-3", Identifier: "ISS-3", Title: "Three", State: "Todo"},
@@ -102,6 +106,12 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	if !snapshot.Running[0].StartedAt.Equal(startedAt) {
 		t.Fatalf("Running[0].StartedAt = %v, want %v", snapshot.Running[0].StartedAt, startedAt)
 	}
+	if snapshot.Running[0].TurnCount != 1 || snapshot.Running[0].Tokens.Total != 3 {
+		t.Fatalf("Running[0] live usage = turns %d tokens %#v, want 1 turn and 3 tokens", snapshot.Running[0].TurnCount, snapshot.Running[0].Tokens)
+	}
+	if snapshot.Running[1].RuntimeSeconds != 30 {
+		t.Fatalf("Running[1].RuntimeSeconds = %v, want 30", snapshot.Running[1].RuntimeSeconds)
+	}
 
 	if len(snapshot.Queue) != 1 {
 		t.Fatalf("Queue len = %d, want 1", len(snapshot.Queue))
@@ -139,7 +149,7 @@ func TestStateSnapshotPopulated(t *testing.T) {
 		t.Fatalf("Completed[0].Tokens.Total = %d, want 15", c.Tokens.Total)
 	}
 
-	wantTokens := telemetry.Tokens{Input: 100, Output: 50, Total: 150, RuntimeSeconds: 120}
+	wantTokens := telemetry.Tokens{Input: 122, Output: 59, Total: 181, RuntimeSeconds: 165}
 	if snapshot.Tokens != wantTokens {
 		t.Fatalf("Tokens = %#v, want %#v", snapshot.Tokens, wantTokens)
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -26,6 +26,8 @@ type Running struct {
 	Attempt    int
 	StartedAt  time.Time
 	WorkerHost string
+	TurnCount  int
+	Tokens     CodexTotals
 }
 
 type Claimed struct {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -152,6 +152,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Model:             model,
 	}, func(update codex.Update) error {
 		applyCodexUpdate(&result, update)
+		if err := r.publishUsageUpdate(req, result, update, runStartedAt); err != nil {
+			return err
+		}
 		return nil
 	})
 	_ = turnResult
@@ -294,6 +297,28 @@ func applyCodexUpdate(result *RunResult, update codex.Update) {
 	case codex.UpdateRateLimits:
 		result.RateLimits = rateLimitsFromCodex(update.RateLimits)
 	}
+}
+
+func (r *Runner) publishUsageUpdate(
+	req RunRequest,
+	result RunResult,
+	update codex.Update,
+	runStartedAt time.Time,
+) error {
+	if req.OnUsageUpdate == nil {
+		return nil
+	}
+	if update.Type != codex.UpdateTokenUsage {
+		return nil
+	}
+
+	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
+	usage := UsageUpdate{
+		Tokens:     result.Tokens,
+		TurnCount:  1,
+		RateLimits: result.RateLimits,
+	}
+	return req.OnUsageUpdate(usage)
 }
 
 func rateLimitsFromCodex(snapshot *codex.RateLimitSnapshot) *telemetry.RateLimits {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -57,7 +57,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		result: codex.RunTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "thread-1-turn-1"},
 	}
 	sessionStore := &fakeSessionStore{sessionID: 42}
-	now := newFakeClock(startedAt, completedAt)
+	now := newFakeClock(startedAt, startedAt.Add(time.Second), completedAt)
 
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
@@ -89,6 +89,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		t.Fatalf("NewRunner() error = %v", err)
 	}
 
+	var usageUpdates []UsageUpdate
 	result, err := runner.Run(context.Background(), RunRequest{
 		Issue: connector.Issue{
 			ID:            "issue-22",
@@ -100,6 +101,10 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		},
 		Attempt:   2,
 		StartedAt: startedAt,
+		OnUsageUpdate: func(update UsageUpdate) error {
+			usageUpdates = append(usageUpdates, update)
+			return nil
+		},
 	})
 	if err != nil {
 		t.Fatalf("Run() error = %v", err)
@@ -110,6 +115,15 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if result.Tokens.TotalTokens != 125 || result.Tokens.RuntimeSeconds != 2 {
 		t.Fatalf("Tokens = %#v, want total 125 and runtime 2s", result.Tokens)
+	}
+	if len(usageUpdates) != 1 {
+		t.Fatalf("usage updates len = %d, want 1", len(usageUpdates))
+	}
+	if usageUpdates[0].TurnCount != 1 || usageUpdates[0].Tokens.TotalTokens != 125 {
+		t.Fatalf("usage update = %#v, want 1 turn and 125 tokens", usageUpdates[0])
+	}
+	if usageUpdates[0].Tokens.RuntimeSeconds != 1 {
+		t.Fatalf("usage update runtime = %v, want 1", usageUpdates[0].Tokens.RuntimeSeconds)
 	}
 	if result.DiffStats.FilesChanged != 2 || result.DiffStats.AddedLines != 5 || result.DiffStats.RemovedLines != 1 {
 		t.Fatalf("DiffStats = %#v, want 2 files, 5 added, 1 removed", result.DiffStats)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -18,10 +18,11 @@ type Backend interface {
 }
 
 type RunRequest struct {
-	Issue      connector.Issue
-	Attempt    int
-	StartedAt  time.Time
-	WorkerHost string
+	Issue         connector.Issue
+	Attempt       int
+	StartedAt     time.Time
+	WorkerHost    string
+	OnUsageUpdate UsageUpdateHandler
 }
 
 type RunResult struct {
@@ -30,6 +31,14 @@ type RunResult struct {
 	DiffStats     DiffStats
 	RateLimits    *telemetry.RateLimits
 	BudgetRefusal *BudgetRefusal
+}
+
+type UsageUpdateHandler func(UsageUpdate) error
+
+type UsageUpdate struct {
+	Tokens     CodexTotals
+	TurnCount  int
+	RateLimits *telemetry.RateLimits
 }
 
 type BudgetRefusal struct {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -669,6 +669,13 @@ func TestServerAPIRoutes(t *testing.T) {
 			t.Fatalf("running[%q] = %#v, want %#v; row = %#v", key, running[key], want, running)
 		}
 	}
+	if running["turn_count"] != float64(3) {
+		t.Fatalf("running.turn_count = %#v, want 3", running["turn_count"])
+	}
+	runningTokens := running["tokens"].(map[string]any)
+	if runningTokens["input_tokens"] != float64(10) || runningTokens["output_tokens"] != float64(20) || runningTokens["total_tokens"] != float64(30) {
+		t.Fatalf("running.tokens = %#v, want live token counts", runningTokens)
+	}
 
 	retrying := state["retrying"].([]any)[0].(map[string]any)
 	if retrying["issue_identifier"] != "DD-RETRY" || retrying["attempt"] != float64(2) {
@@ -706,6 +713,13 @@ func TestServerAPIRoutes(t *testing.T) {
 		if runningIssue[key] != want {
 			t.Fatalf("issue.running[%q] = %#v, want %#v; running = %#v", key, runningIssue[key], want, runningIssue)
 		}
+	}
+	if runningIssue["turn_count"] != float64(3) {
+		t.Fatalf("issue.running.turn_count = %#v, want 3", runningIssue["turn_count"])
+	}
+	issueTokens := runningIssue["tokens"].(map[string]any)
+	if issueTokens["input_tokens"] != float64(10) || issueTokens["output_tokens"] != float64(20) || issueTokens["total_tokens"] != float64(30) {
+		t.Fatalf("issue.running.tokens = %#v, want live token counts", issueTokens)
 	}
 
 	retryIssue := requestJSON(t, server, http.MethodGet, "/api/v1/DD-RETRY", http.StatusOK)


### PR DESCRIPTION
## Summary
- stream Codex token usage updates from runner requests while runs are in flight
- apply live usage on the orchestrator goroutine to running rows and snapshot aggregate totals
- expose running token and turn counts through existing state/API snapshot conversion

Fixes #115

## Test Plan
- go test ./internal/runner ./internal/orchestrator ./internal/web
- make check