### PR TITLE
feat(store): add usage ledger ingestion

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -96,6 +96,31 @@ WHERE issue_id = sqlc.arg(issue_id)
 GROUP BY COALESCE(model, '')
 ORDER BY COALESCE(model, '');
 
+-- name: CreateUsageEvent :one
+INSERT INTO usage_events (
+  project_id,
+  run_id,
+  session_id,
+  issue_id,
+  identifier,
+  pr_number,
+  model,
+  input_tokens,
+  output_tokens,
+  total_tokens,
+  runtime_seconds,
+  started_at,
+  finished_at,
+  event_day,
+  outcome
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING *;
+
+-- name: GetUsageEvent :one
+SELECT *
+FROM usage_events
+WHERE id = ?;
+
 -- name: ListFairShareUsage :many
 SELECT
   project_id,

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -41,7 +41,7 @@ func withRunnerFactory(
 			return nil, fmt.Errorf("load project workflow %s: %w", cfg.ID, err)
 		}
 
-		run, err := buildRunner(workflow, sessionStore, deps.Logger)
+		run, err := buildRunner(workflow, cfg.ID, sessionStore, deps.Logger)
 		if err != nil {
 			return nil, fmt.Errorf("build project runner %s: %w", cfg.ID, err)
 		}
@@ -60,6 +60,7 @@ func withRunnerFactory(
 // wiring its workspace backend, codex app-server client, and session store.
 func buildRunner(
 	workflow workflowconfig.Workflow,
+	projectID string,
 	sessionStore runnerpkg.SessionStore,
 	logger *slog.Logger,
 ) (orchestrator.Runner, error) {
@@ -76,6 +77,7 @@ func buildRunner(
 	}
 
 	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
+		ProjectID: projectID,
 		Workflow:  workflow,
 		Workspace: backend,
 		Codex:     codexClient,

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -25,7 +25,7 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Workspace.Root = t.TempDir()
 
-	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, nil, nil)
+	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRunner() error = %v", err)
 	}

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -39,6 +39,7 @@ query SymphonyGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) 
               assignees(first: 5) { nodes { login } }
               labels(first: 20) { nodes { name } }
               repository { nameWithOwner }
+              closedByPullRequestsReferences(first: 5) { nodes { number url } }
             }
           }
           statusValue: fieldValueByName(name: "Status") {
@@ -69,6 +70,7 @@ query SymphonyGitHubIssuesByID($issueIds: [ID!]!, $projectItemsFirst: Int!) {
       assignees(first: 5) { nodes { login } }
       labels(first: 20) { nodes { name } }
       repository { nameWithOwner }
+      closedByPullRequestsReferences(first: 5) { nodes { number url } }
       projectItems(first: $projectItemsFirst) {
         pageInfo { hasNextPage endCursor }
         nodes {
@@ -165,19 +167,20 @@ type projectItemNode struct {
 }
 
 type githubIssueNode struct {
-	TypeName     string                   `json:"__typename"`
-	ID           string                   `json:"id"`
-	Number       int                      `json:"number"`
-	Title        string                   `json:"title"`
-	Body         string                   `json:"body"`
-	State        string                   `json:"state"`
-	URL          string                   `json:"url"`
-	CreatedAt    *string                  `json:"createdAt"`
-	UpdatedAt    *string                  `json:"updatedAt"`
-	Assignees    nodeConnection[assignee] `json:"assignees"`
-	Labels       nodeConnection[label]    `json:"labels"`
-	Repository   repository               `json:"repository"`
-	ProjectItems *projectItemsConnection  `json:"projectItems"`
+	TypeName                       string                      `json:"__typename"`
+	ID                             string                      `json:"id"`
+	Number                         int                         `json:"number"`
+	Title                          string                      `json:"title"`
+	Body                           string                      `json:"body"`
+	State                          string                      `json:"state"`
+	URL                            string                      `json:"url"`
+	CreatedAt                      *string                     `json:"createdAt"`
+	UpdatedAt                      *string                     `json:"updatedAt"`
+	Assignees                      nodeConnection[assignee]    `json:"assignees"`
+	Labels                         nodeConnection[label]       `json:"labels"`
+	Repository                     repository                  `json:"repository"`
+	ClosedByPullRequestsReferences nodeConnection[pullRequest] `json:"closedByPullRequestsReferences"`
+	ProjectItems                   *projectItemsConnection     `json:"projectItems"`
 }
 
 type nodeConnection[T any] struct {
@@ -190,6 +193,11 @@ type assignee struct {
 
 type label struct {
 	Name string `json:"name"`
+}
+
+type pullRequest struct {
+	Number int    `json:"number"`
+	URL    string `json:"url"`
 }
 
 type repository struct {
@@ -480,6 +488,7 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		Priority:         c.priorityRank(priorityName),
 		State:            c.githubToSymphonyState(statusName),
 		URL:              issue.URL,
+		PRNumber:         firstPullRequestNumber(issue.ClosedByPullRequestsReferences),
 		AssigneeID:       firstAssigneeLogin(issue.Assignees),
 		BlockedBy:        parseBlockedBy(issue.Body, repo),
 		Labels:           labelNames(issue.Labels),
@@ -692,6 +701,16 @@ func firstAssigneeLogin(assignees nodeConnection[assignee]) string {
 		}
 	}
 	return ""
+}
+
+func firstPullRequestNumber(pullRequests nodeConnection[pullRequest]) *int {
+	for _, pullRequest := range pullRequests.Nodes {
+		if pullRequest.Number > 0 {
+			number := pullRequest.Number
+			return &number
+		}
+	}
+	return nil
 }
 
 func labelNames(labels nodeConnection[label]) []string {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -18,7 +18,7 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","body":"Depends on: #24 digitaldrywood/symphony#25\n<!-- model: gpt-5-codex-high -->","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/26","createdAt":"2026-05-31T01:02:03Z","updatedAt":"2026-05-31T02:03:04Z","assignees":{"nodes":[{"login":"worker-1"}]},"labels":{"nodes":[{"name":"Enhancement"},{"name":"stage:S4"}]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P0"}},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":27,"title":"Backlog item","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/27","createdAt":"2026-05-31T03:02:03Z","updatedAt":"2026-05-31T04:03:04Z","assignees":{"nodes":[{"login":"worker-1"}]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Backlog"},"priorityValue":{"name":"No priority"}}]}}}}`,
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","body":"Depends on: #24 digitaldrywood/symphony#25\n<!-- model: gpt-5-codex-high -->","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/26","createdAt":"2026-05-31T01:02:03Z","updatedAt":"2026-05-31T02:03:04Z","assignees":{"nodes":[{"login":"worker-1"}]},"labels":{"nodes":[{"name":"Enhancement"},{"name":"stage:S4"}]},"repository":{"nameWithOwner":"digitaldrywood/symphony"},"closedByPullRequestsReferences":{"nodes":[{"number":42,"url":"https://github.com/digitaldrywood/symphony/pull/42"}]}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P0"}},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":27,"title":"Backlog item","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/27","createdAt":"2026-05-31T03:02:03Z","updatedAt":"2026-05-31T04:03:04Z","assignees":{"nodes":[{"login":"worker-1"}]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Backlog"},"priorityValue":{"name":"No priority"}}]}}}}`,
 	}})
 
 	c := newGitHubTestConnector(t, server, Config{
@@ -39,6 +39,7 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	createdAt := time.Date(2026, 5, 31, 1, 2, 3, 0, time.UTC)
 	updatedAt := time.Date(2026, 5, 31, 2, 3, 4, 0, time.UTC)
 	priority := 1
+	prNumber := 42
 	want := connector.Issue{
 		ID:               "I_kw1",
 		Identifier:       "digitaldrywood/symphony#26",
@@ -47,6 +48,7 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 		Priority:         &priority,
 		State:            "Todo",
 		URL:              "https://github.com/digitaldrywood/symphony/issues/26",
+		PRNumber:         &prNumber,
 		AssigneeID:       "worker-1",
 		BlockedBy:        []connector.BlockedRef{{Identifier: "digitaldrywood/symphony#24"}, {Identifier: "digitaldrywood/symphony#25"}},
 		Labels:           []string{"enhancement", "stage:s4"},
@@ -146,7 +148,7 @@ func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testi
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"title":"First","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/1","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"}}]}},{"__typename":"Issue","id":"I_kw2","number":2,"title":"Second","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/2","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_2","project":{"id":"PVT_1"},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"No priority"}}]}}]}}`,
+		body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"title":"First","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/1","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"closedByPullRequestsReferences":{"nodes":[{"number":81,"url":"https://github.com/example/repo/pull/81"}]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"}}]}},{"__typename":"Issue","id":"I_kw2","number":2,"title":"Second","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/2","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"closedByPullRequestsReferences":{"nodes":[]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_2","project":{"id":"PVT_1"},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"No priority"}}]}}]}}`,
 	}})
 
 	c := newGitHubTestConnector(t, server, Config{
@@ -170,6 +172,9 @@ func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testi
 	}
 	if got[1].Priority == nil || *got[1].Priority != 2 {
 		t.Fatalf("second Priority = %v, want 2", got[1].Priority)
+	}
+	if got[1].PRNumber == nil || *got[1].PRNumber != 81 {
+		t.Fatalf("second PRNumber = %v, want 81", got[1].PRNumber)
 	}
 }
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -15,6 +15,7 @@ type Issue struct {
 	State            string       `json:"state,omitempty" yaml:"state,omitempty"`
 	BranchName       string       `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	URL              string       `json:"url,omitempty" yaml:"url,omitempty"`
+	PRNumber         *int         `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
 	AssigneeID       string       `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`
 	BlockedBy        []BlockedRef `json:"blocked_by" yaml:"blocked_by"`
 	Labels           []string     `json:"labels" yaml:"labels"`

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -53,6 +53,7 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 	}
 
 	runnerBackend, err := runpkg.NewRunner(runpkg.Dependencies{
+		ProjectID: "symphony",
 		Workflow: config.Workflow{
 			Config: config.Config{
 				Codex: config.Codex{

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -136,6 +136,10 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		priority := *issue.Priority
 		cloned.Priority = &priority
 	}
+	if issue.PRNumber != nil {
+		prNumber := *issue.PRNumber
+		cloned.PRNumber = &prNumber
+	}
 	if issue.CreatedAt != nil {
 		createdAt := *issue.CreatedAt
 		cloned.CreatedAt = &createdAt

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -468,6 +468,11 @@ func (p *codexRunProgress) cachedDiffStats() (DiffStats, bool) {
 }
 
 func pullRequestNumber(issue connector.Issue) *int64 {
+	if issue.PRNumber != nil && *issue.PRNumber > 0 {
+		number := int64(*issue.PRNumber)
+		return &number
+	}
+
 	value := strings.TrimSpace(issue.URL)
 	const marker = "/pull/"
 	index := strings.LastIndex(value, marker)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -24,6 +25,7 @@ import (
 const (
 	defaultAfterRunTimeout = time.Minute
 	liveDiffStatsInterval  = 2 * time.Second
+	defaultProjectID       = "default"
 )
 
 var (
@@ -38,9 +40,11 @@ type CodexClient interface {
 type SessionStore interface {
 	StartSession(context.Context, store.SessionStart) (int64, error)
 	FinishSession(context.Context, int64, store.SessionFinish) error
+	RecordUsageEvent(context.Context, store.UsageEvent) (int64, error)
 }
 
 type Dependencies struct {
+	ProjectID       string
 	Workflow        config.Workflow
 	Workspace       workspace.Backend
 	Codex           CodexClient
@@ -52,6 +56,7 @@ type Dependencies struct {
 
 type Runner struct {
 	mu              sync.RWMutex
+	projectID       string
 	workflow        config.Workflow
 	workspace       workspace.Backend
 	codex           CodexClient
@@ -77,8 +82,13 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	if deps.AfterRunTimeout <= 0 {
 		deps.AfterRunTimeout = defaultAfterRunTimeout
 	}
+	projectID := strings.TrimSpace(deps.ProjectID)
+	if projectID == "" {
+		projectID = defaultProjectID
+	}
 
 	return &Runner{
+		projectID:       projectID,
 		workflow:        deps.Workflow,
 		workspace:       deps.Workspace,
 		codex:           deps.Codex,
@@ -168,26 +178,29 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	if turnErr != nil {
 		result.FinalState = FinalStateFailed
-		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
+		finishedAt := r.now().UTC()
+		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("run codex turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, result, model, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1),
 		)
 	}
 
 	diffStat, err := r.workspace.DiffStat(ctx, info, workspaceIssue)
 	if err != nil {
 		result.FinalState = FinalStateFailed
-		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
+		finishedAt := r.now().UTC()
+		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("workspace diff stat: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, result, model, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1),
 		)
 	}
 
 	result.DiffStats = diffStatsFromWorkspace(diffStat)
-	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
-	if err := r.finishSession(ctx, sessionID, sessionStarted, result, model, 1); err != nil {
+	finishedAt := r.now().UTC()
+	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -258,6 +271,9 @@ func (r *Runner) finishSession(
 	ctx context.Context,
 	sessionID int64,
 	started bool,
+	issue connector.Issue,
+	startedAt time.Time,
+	finishedAt time.Time,
 	result RunResult,
 	model string,
 	turns int64,
@@ -270,7 +286,7 @@ func (r *Runner) finishSession(
 	}
 
 	if err := r.store.FinishSession(ctx, sessionID, store.SessionFinish{
-		CompletedAt:    r.now().UTC(),
+		CompletedAt:    finishedAt,
 		Turns:          turns,
 		InputTokens:    result.Tokens.InputTokens,
 		OutputTokens:   result.Tokens.OutputTokens,
@@ -280,6 +296,23 @@ func (r *Runner) finishSession(
 		Model:          model,
 	}); err != nil {
 		return fmt.Errorf("finish codex session: %w", err)
+	}
+	if _, err := r.store.RecordUsageEvent(ctx, store.UsageEvent{
+		ProjectID:      r.projectID,
+		SessionID:      sessionID,
+		IssueID:        issue.ID,
+		Identifier:     issue.Identifier,
+		PRNumber:       pullRequestNumber(issue),
+		Model:          model,
+		InputTokens:    result.Tokens.InputTokens,
+		OutputTokens:   result.Tokens.OutputTokens,
+		TotalTokens:    result.Tokens.TotalTokens,
+		RuntimeSeconds: int64(math.Round(result.Tokens.RuntimeSeconds)),
+		StartedAt:      startedAt,
+		FinishedAt:     finishedAt,
+		Outcome:        result.FinalState,
+	}); err != nil {
+		return fmt.Errorf("record usage event: %w", err)
 	}
 	return nil
 }
@@ -432,6 +465,29 @@ func (p *codexRunProgress) cachedDiffStats() (DiffStats, bool) {
 		return DiffStats{}, false
 	}
 	return p.diffStats, true
+}
+
+func pullRequestNumber(issue connector.Issue) *int64 {
+	value := strings.TrimSpace(issue.URL)
+	const marker = "/pull/"
+	index := strings.LastIndex(value, marker)
+	if index == -1 {
+		return nil
+	}
+
+	value = value[index+len(marker):]
+	end := strings.IndexFunc(value, func(r rune) bool {
+		return r < '0' || r > '9'
+	})
+	if end != -1 {
+		value = value[:end]
+	}
+
+	number, err := strconv.ParseInt(value, 10, 64)
+	if err != nil || number <= 0 {
+		return nil
+	}
+	return &number
 }
 
 func rateLimitsFromCodex(snapshot *codex.RateLimitSnapshot) *telemetry.RateLimits {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -81,6 +81,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	)
 
 	runner, err := NewRunner(Dependencies{
+		ProjectID: "symphony",
 		Workflow: config.Workflow{
 			Config: config.Config{
 				Agent: config.Agent{
@@ -202,6 +203,21 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if sessionStore.finished.FinalState != FinalStateCompleted || sessionStore.finished.TotalTokens != 125 || sessionStore.finished.Turns != 1 {
 		t.Fatalf("SessionFinish = %#v, want completed session with tokens", sessionStore.finished)
+	}
+	if sessionStore.usage.ProjectID != "symphony" || sessionStore.usage.SessionID != 42 {
+		t.Fatalf("UsageEvent identity = %#v, want project symphony and session 42", sessionStore.usage)
+	}
+	if sessionStore.usage.IssueID != "issue-22" || sessionStore.usage.Identifier != "digitaldrywood/symphony#22" {
+		t.Fatalf("UsageEvent issue = %#v, want issue-22/digitaldrywood/symphony#22", sessionStore.usage)
+	}
+	if sessionStore.usage.Model != "gpt-5-codex-high" || sessionStore.usage.TotalTokens != 125 {
+		t.Fatalf("UsageEvent totals = %#v, want model gpt-5-codex-high and total 125", sessionStore.usage)
+	}
+	if sessionStore.usage.StartedAt != startedAt || sessionStore.usage.FinishedAt != completedAt {
+		t.Fatalf("UsageEvent timestamps = %s/%s, want %s/%s", sessionStore.usage.StartedAt, sessionStore.usage.FinishedAt, startedAt, completedAt)
+	}
+	if sessionStore.usage.Outcome != FinalStateCompleted {
+		t.Fatalf("UsageEvent outcome = %q, want %q", sessionStore.usage.Outcome, FinalStateCompleted)
 	}
 }
 
@@ -408,6 +424,7 @@ type fakeSessionStore struct {
 	sessionID int64
 	started   store.SessionStart
 	finished  store.SessionFinish
+	usage     store.UsageEvent
 }
 
 func (s *fakeSessionStore) StartSession(_ context.Context, attrs store.SessionStart) (int64, error) {
@@ -418,6 +435,11 @@ func (s *fakeSessionStore) StartSession(_ context.Context, attrs store.SessionSt
 func (s *fakeSessionStore) FinishSession(_ context.Context, _ int64, attrs store.SessionFinish) error {
 	s.finished = attrs
 	return nil
+}
+
+func (s *fakeSessionStore) RecordUsageEvent(_ context.Context, attrs store.UsageEvent) (int64, error) {
+	s.usage = attrs
+	return 1, nil
 }
 
 type fakeClock struct {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -79,6 +79,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		completedAt,
 		completedAt,
 	)
+	prNumber := 133
 
 	runner, err := NewRunner(Dependencies{
 		ProjectID: "symphony",
@@ -118,6 +119,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 			Identifier:    "digitaldrywood/symphony#22",
 			Title:         "Add runner",
 			URL:           "https://github.com/digitaldrywood/symphony/issues/22",
+			PRNumber:      &prNumber,
 			BranchName:    "symphony/digitaldrywood_symphony_22",
 			ModelOverride: "gpt-5-codex-high",
 		},
@@ -212,6 +214,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if sessionStore.usage.Model != "gpt-5-codex-high" || sessionStore.usage.TotalTokens != 125 {
 		t.Fatalf("UsageEvent totals = %#v, want model gpt-5-codex-high and total 125", sessionStore.usage)
+	}
+	if sessionStore.usage.PRNumber == nil || *sessionStore.usage.PRNumber != 133 {
+		t.Fatalf("UsageEvent PRNumber = %v, want 133", sessionStore.usage.PRNumber)
 	}
 	if sessionStore.usage.StartedAt != startedAt || sessionStore.usage.FinishedAt != completedAt {
 		t.Fatalf("UsageEvent timestamps = %s/%s, want %s/%s", sessionStore.usage.StartedAt, sessionStore.usage.FinishedAt, startedAt, completedAt)

--- a/internal/store/migrations/00003_create_usage_events.sql
+++ b/internal/store/migrations/00003_create_usage_events.sql
@@ -1,0 +1,31 @@
+-- +goose Up
+CREATE TABLE usage_events (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  run_id INTEGER,
+  session_id INTEGER,
+  issue_id TEXT,
+  identifier TEXT,
+  pr_number INTEGER,
+  model TEXT NOT NULL DEFAULT '',
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  total_tokens INTEGER NOT NULL DEFAULT 0,
+  runtime_seconds INTEGER NOT NULL DEFAULT 0,
+  started_at TEXT NOT NULL,
+  finished_at TEXT NOT NULL,
+  event_day TEXT NOT NULL,
+  outcome TEXT NOT NULL
+);
+
+CREATE INDEX usage_events_project_issue_day_idx
+ON usage_events(project_id, issue_id, event_day);
+
+CREATE INDEX usage_events_project_identifier_day_idx
+ON usage_events(project_id, identifier, event_day);
+
+CREATE INDEX usage_events_project_day_idx
+ON usage_events(project_id, event_day);
+
+-- +goose Down
+DROP TABLE IF EXISTS usage_events;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -45,3 +45,22 @@ type SymphonyRun struct {
 	TotalTokens          int64          `json:"total_tokens"`
 	RuntimeSeconds       int64          `json:"runtime_seconds"`
 }
+
+type UsageEvent struct {
+	ID             int64          `json:"id"`
+	ProjectID      string         `json:"project_id"`
+	RunID          sql.NullInt64  `json:"run_id"`
+	SessionID      sql.NullInt64  `json:"session_id"`
+	IssueID        sql.NullString `json:"issue_id"`
+	Identifier     sql.NullString `json:"identifier"`
+	PrNumber       sql.NullInt64  `json:"pr_number"`
+	Model          string         `json:"model"`
+	InputTokens    int64          `json:"input_tokens"`
+	OutputTokens   int64          `json:"output_tokens"`
+	TotalTokens    int64          `json:"total_tokens"`
+	RuntimeSeconds int64          `json:"runtime_seconds"`
+	StartedAt      string         `json:"started_at"`
+	FinishedAt     string         `json:"finished_at"`
+	EventDay       string         `json:"event_day"`
+	Outcome        string         `json:"outcome"`
+}

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -136,6 +136,85 @@ func (q *Queries) CreateSymphonyRun(ctx context.Context, arg CreateSymphonyRunPa
 	return i, err
 }
 
+const createUsageEvent = `-- name: CreateUsageEvent :one
+INSERT INTO usage_events (
+  project_id,
+  run_id,
+  session_id,
+  issue_id,
+  identifier,
+  pr_number,
+  model,
+  input_tokens,
+  output_tokens,
+  total_tokens,
+  runtime_seconds,
+  started_at,
+  finished_at,
+  event_day,
+  outcome
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome
+`
+
+type CreateUsageEventParams struct {
+	ProjectID      string         `json:"project_id"`
+	RunID          sql.NullInt64  `json:"run_id"`
+	SessionID      sql.NullInt64  `json:"session_id"`
+	IssueID        sql.NullString `json:"issue_id"`
+	Identifier     sql.NullString `json:"identifier"`
+	PrNumber       sql.NullInt64  `json:"pr_number"`
+	Model          string         `json:"model"`
+	InputTokens    int64          `json:"input_tokens"`
+	OutputTokens   int64          `json:"output_tokens"`
+	TotalTokens    int64          `json:"total_tokens"`
+	RuntimeSeconds int64          `json:"runtime_seconds"`
+	StartedAt      string         `json:"started_at"`
+	FinishedAt     string         `json:"finished_at"`
+	EventDay       string         `json:"event_day"`
+	Outcome        string         `json:"outcome"`
+}
+
+func (q *Queries) CreateUsageEvent(ctx context.Context, arg CreateUsageEventParams) (UsageEvent, error) {
+	row := q.db.QueryRowContext(ctx, createUsageEvent,
+		arg.ProjectID,
+		arg.RunID,
+		arg.SessionID,
+		arg.IssueID,
+		arg.Identifier,
+		arg.PrNumber,
+		arg.Model,
+		arg.InputTokens,
+		arg.OutputTokens,
+		arg.TotalTokens,
+		arg.RuntimeSeconds,
+		arg.StartedAt,
+		arg.FinishedAt,
+		arg.EventDay,
+		arg.Outcome,
+	)
+	var i UsageEvent
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.RunID,
+		&i.SessionID,
+		&i.IssueID,
+		&i.Identifier,
+		&i.PrNumber,
+		&i.Model,
+		&i.InputTokens,
+		&i.OutputTokens,
+		&i.TotalTokens,
+		&i.RuntimeSeconds,
+		&i.StartedAt,
+		&i.FinishedAt,
+		&i.EventDay,
+		&i.Outcome,
+	)
+	return i, err
+}
+
 const dailyTokenSpend = `-- name: DailyTokenSpend :many
 SELECT
   CAST(COALESCE(model, '') AS TEXT) AS model,
@@ -277,6 +356,36 @@ func (q *Queries) GetSymphonyRun(ctx context.Context, id int64) (SymphonyRun, er
 		&i.OutputTokens,
 		&i.TotalTokens,
 		&i.RuntimeSeconds,
+	)
+	return i, err
+}
+
+const getUsageEvent = `-- name: GetUsageEvent :one
+SELECT id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome
+FROM usage_events
+WHERE id = ?
+`
+
+func (q *Queries) GetUsageEvent(ctx context.Context, id int64) (UsageEvent, error) {
+	row := q.db.QueryRowContext(ctx, getUsageEvent, id)
+	var i UsageEvent
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.RunID,
+		&i.SessionID,
+		&i.IssueID,
+		&i.Identifier,
+		&i.PrNumber,
+		&i.Model,
+		&i.InputTokens,
+		&i.OutputTokens,
+		&i.TotalTokens,
+		&i.RuntimeSeconds,
+		&i.StartedAt,
+		&i.FinishedAt,
+		&i.EventDay,
+		&i.Outcome,
 	)
 	return i, err
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -166,6 +166,49 @@ func (s *sqliteStore) FinishSession(ctx context.Context, sessionID int64, attrs 
 	return requireAffected(rows, "codex session", sessionID)
 }
 
+func (s *sqliteStore) RecordUsageEvent(ctx context.Context, attrs UsageEvent) (int64, error) {
+	projectID := strings.TrimSpace(attrs.ProjectID)
+	if projectID == "" {
+		return 0, errors.New("project_id is required")
+	}
+
+	startedAt, err := requiredTimestamp("started_at", attrs.StartedAt)
+	if err != nil {
+		return 0, err
+	}
+	finishedAt, err := requiredTimestamp("finished_at", attrs.FinishedAt)
+	if err != nil {
+		return 0, err
+	}
+
+	outcome := strings.TrimSpace(attrs.Outcome)
+	if outcome == "" {
+		return 0, errors.New("outcome is required")
+	}
+
+	event, err := s.queries.CreateUsageEvent(ctx, sqlc.CreateUsageEventParams{
+		ProjectID:      projectID,
+		RunID:          nullInt64(attrs.RunID),
+		SessionID:      nullInt64(attrs.SessionID),
+		IssueID:        nullString(attrs.IssueID),
+		Identifier:     nullString(attrs.Identifier),
+		PrNumber:       nullOptionalInt64(attrs.PRNumber),
+		Model:          strings.TrimSpace(attrs.Model),
+		InputTokens:    nonNegative(attrs.InputTokens),
+		OutputTokens:   nonNegative(attrs.OutputTokens),
+		TotalTokens:    nonNegative(attrs.TotalTokens),
+		RuntimeSeconds: nonNegative(attrs.RuntimeSeconds),
+		StartedAt:      startedAt,
+		FinishedAt:     finishedAt,
+		EventDay:       attrs.FinishedAt.UTC().Format("2006-01-02"),
+		Outcome:        outcome,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("recording usage event: %w", err)
+	}
+	return event.ID, nil
+}
+
 func (s *sqliteStore) DailyTokenSpend(ctx context.Context, day time.Time) (TokenSpend, error) {
 	date, err := dateString(day)
 	if err != nil {
@@ -342,6 +385,13 @@ func nullInt64(value int64) sql.NullInt64 {
 		return sql.NullInt64{}
 	}
 	return sql.NullInt64{Int64: value, Valid: true}
+}
+
+func nullOptionalInt64(value *int64) sql.NullInt64 {
+	if value == nil || *value <= 0 {
+		return sql.NullInt64{}
+	}
+	return sql.NullInt64{Int64: *value, Valid: true}
 }
 
 func nonNegative(value int64) int64 {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -36,6 +36,7 @@ type StatsStore interface {
 	StopRun(context.Context, int64, RunStop) error
 	StartSession(context.Context, SessionStart) (int64, error)
 	FinishSession(context.Context, int64, SessionFinish) error
+	RecordUsageEvent(context.Context, UsageEvent) (int64, error)
 	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
 	IssueTokenSpend(context.Context, IssueIdentity) (TokenSpend, error)
 }
@@ -93,6 +94,23 @@ type SessionFinish struct {
 	RuntimeSeconds int64
 	FinalState     string
 	Model          string
+}
+
+type UsageEvent struct {
+	ProjectID      string
+	RunID          int64
+	SessionID      int64
+	IssueID        string
+	Identifier     string
+	PRNumber       *int64
+	Model          string
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	RuntimeSeconds int64
+	StartedAt      time.Time
+	FinishedAt     time.Time
+	Outcome        string
 }
 
 type IssueIdentity struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -40,8 +40,8 @@ func TestOpenSQLiteAppliesMigrationsAndPragmas(t *testing.T) {
 	if got := queryInt(t, sqliteBackend.db, "PRAGMA busy_timeout"); got != 5000 {
 		t.Fatalf("busy_timeout = %d, want 5000", got)
 	}
-	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('symphony_runs', 'codex_sessions', 'fair_share_usage')"); got != 3 {
-		t.Fatalf("migrated table count = %d, want 3", got)
+	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('symphony_runs', 'codex_sessions', 'fair_share_usage', 'usage_events')"); got != 4 {
+		t.Fatalf("migrated table count = %d, want 4", got)
 	}
 }
 
@@ -310,6 +310,114 @@ func TestFairShareStoreRoundTrip(t *testing.T) {
 	}
 }
 
+func TestUsageLedgerRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		event UsageEvent
+	}{
+		{
+			name: "persists usage event across reopen",
+			event: UsageEvent{
+				ProjectID:      " symphony ",
+				RunID:          11,
+				SessionID:      42,
+				IssueID:        " I_kwDOSskuwc8AAAABD6psJQ ",
+				Identifier:     " digitaldrywood/symphony#117 ",
+				PRNumber:       int64Ptr(91),
+				Model:          " gpt-5-codex ",
+				InputTokens:    123,
+				OutputTokens:   45,
+				TotalTokens:    168,
+				RuntimeSeconds: 73,
+				StartedAt:      time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC),
+				FinishedAt:     time.Date(2026, 5, 31, 13, 1, 13, 0, time.UTC),
+				Outcome:        " completed ",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			dbPath := filepath.Join(t.TempDir(), "symphony.db")
+
+			backend, err := Open(ctx, Config{
+				Backend: BackendSQLite,
+				Path:    dbPath,
+			})
+			if err != nil {
+				t.Fatalf("Open() error = %v", err)
+			}
+
+			eventID, err := backend.RecordUsageEvent(ctx, tt.event)
+			if err != nil {
+				t.Fatalf("RecordUsageEvent() error = %v", err)
+			}
+
+			got, err := backend.Queries().GetUsageEvent(ctx, eventID)
+			if err != nil {
+				t.Fatalf("GetUsageEvent() error = %v", err)
+			}
+			if got.ProjectID != "symphony" {
+				t.Fatalf("ProjectID = %q, want symphony", got.ProjectID)
+			}
+			if got.RunID.Int64 != 11 || got.SessionID.Int64 != 42 {
+				t.Fatalf("run/session = %d/%d, want 11/42", got.RunID.Int64, got.SessionID.Int64)
+			}
+			if got.IssueID.String != "I_kwDOSskuwc8AAAABD6psJQ" || got.Identifier.String != "digitaldrywood/symphony#117" {
+				t.Fatalf("issue identity = %q/%q", got.IssueID.String, got.Identifier.String)
+			}
+			if got.PrNumber.Int64 != 91 {
+				t.Fatalf("pr_number = %d, want 91", got.PrNumber.Int64)
+			}
+			if got.Model != "gpt-5-codex" {
+				t.Fatalf("model = %q, want gpt-5-codex", got.Model)
+			}
+			if got.InputTokens != 123 || got.OutputTokens != 45 || got.TotalTokens != 168 || got.RuntimeSeconds != 73 {
+				t.Fatalf("tokens/runtime = %d/%d/%d/%d", got.InputTokens, got.OutputTokens, got.TotalTokens, got.RuntimeSeconds)
+			}
+			if got.StartedAt != "2026-05-31T13:00:00Z" || got.FinishedAt != "2026-05-31T13:01:13Z" {
+				t.Fatalf("timestamps = %q/%q", got.StartedAt, got.FinishedAt)
+			}
+			if got.EventDay != "2026-05-31" {
+				t.Fatalf("event_day = %q, want 2026-05-31", got.EventDay)
+			}
+			if got.Outcome != "completed" {
+				t.Fatalf("outcome = %q, want completed", got.Outcome)
+			}
+
+			if err := backend.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+
+			reopened, err := Open(ctx, Config{
+				Backend: BackendSQLite,
+				Path:    dbPath,
+			})
+			if err != nil {
+				t.Fatalf("reopen Open() error = %v", err)
+			}
+			t.Cleanup(func() {
+				if err := reopened.Close(); err != nil {
+					t.Fatalf("reopened Close() error = %v", err)
+				}
+			})
+
+			persisted, err := reopened.Queries().GetUsageEvent(ctx, eventID)
+			if err != nil {
+				t.Fatalf("GetUsageEvent() after reopen error = %v", err)
+			}
+			if persisted.TotalTokens != 168 {
+				t.Fatalf("persisted total_tokens = %d, want 168", persisted.TotalTokens)
+			}
+		})
+	}
+}
+
 func TestOpenRejectsUnsupportedBackend(t *testing.T) {
 	t.Parallel()
 
@@ -420,4 +528,8 @@ func queryInt(t *testing.T, db *sql.DB, query string) int64 {
 		t.Fatalf("querying %q: %v", query, err)
 	}
 	return value
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
 }


### PR DESCRIPTION
## Summary
- Add the retained `usage_events` ledger migration and sqlc insert/read queries.
- Record a usage event from runner completion with project, issue, optional PR, model, token, runtime, timestamp, and outcome fields.
- Cover store persistence with a table-driven round-trip and runner ingestion assertions.

Fixes #117

## Test Plan
- `make generate`
- `go test ./internal/store`
- `go test ./internal/runner`
- `go test ./internal/cli`
- `go test ./internal/orchestrator`
- `make check`