### PR TITLE
feat(config): add global config discovery

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,20 @@ Symphony logs with `log/slog`.
 - `SYMPHONY_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
 - Text logs are written to stdout; JSON logs are written to stderr.
 
+## Global Config Discovery
+
+Symphony must resolve `global.yaml` consistently across supported operating systems. Keep this precedence intact when changing startup or config commands:
+
+1. `--config <path>` uses the direct CLI file path.
+2. `SYMPHONY_CONFIG=<file>` uses the direct environment file path.
+3. `SYMPHONY_HOME=<dir>` uses `<dir>/global.yaml`.
+4. `os.UserConfigDir()` uses `<config-dir>/symphony/global.yaml`.
+5. The legacy default uses `~/.symphony/global.yaml`.
+
+The OS-native config directory is `%AppData%\symphony\global.yaml` on Windows, `~/Library/Application Support/symphony/global.yaml` on macOS, and `~/.config/symphony/global.yaml` on Linux, with `XDG_CONFIG_HOME` honored by `os.UserConfigDir()`.
+
+After global config lookup fails, startup may fall back to a valid `WORKFLOW.md` in the current working directory for single-project mode. `symphony config path` should continue to report both the selected path and the matching rule.
+
 ## Validation
 
 Run the full local gate before every commit and pull request:

--- a/README.md
+++ b/README.md
@@ -311,6 +311,22 @@ Symphony logs with `log/slog`.
 - `SYMPHONY_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
 - Text logs are written to stdout; JSON logs are written to stderr.
 
+## Configuration
+
+At startup, Symphony resolves `global.yaml` in this order. The first matching rule wins.
+
+| Order | Rule | Path |
+| --- | --- | --- |
+| 1 | `--config <path>` | Direct file path from the CLI flag |
+| 2 | `SYMPHONY_CONFIG=<file>` | Direct file path from the environment |
+| 3 | `SYMPHONY_HOME=<dir>` | `<dir>/global.yaml` |
+| 4 | `os.UserConfigDir()` | `<config-dir>/symphony/global.yaml` |
+| 5 | Legacy home config | `~/.symphony/global.yaml` |
+
+`os.UserConfigDir()` maps to `%AppData%\symphony\global.yaml` on Windows, `~/Library/Application Support/symphony/global.yaml` on macOS, and `~/.config/symphony/global.yaml` on Linux while honoring `XDG_CONFIG_HOME`.
+
+If no global config is found, Symphony keeps the single-project fallback and looks for `WORKFLOW.md` in the current working directory. Use `symphony config path` to print the resolved config path and the rule that selected it.
+
 ## License
 
 Symphony is released under the MIT license. See [LICENSE](LICENSE).

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -42,20 +42,22 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 		return BootConfig{}, errors.New("port must be greater than or equal to 0")
 	}
 
-	path, err := resolveConfigPath(configPath, opts)
+	resolution, err := resolveConfigPathResolution(configPath, opts)
 	if err != nil {
 		return BootConfig{}, err
 	}
+	path := resolution.Path
 
 	cfg, err := opts.read(path)
 	if err == nil {
 		host, port := bootServer(host, port, firstGlobalWorkflowPath(cfg))
 		return BootConfig{
-			Mode:    BootModeRunning,
-			Global:  cfg,
-			Host:    host,
-			Port:    port,
-			Version: opts.version,
+			Mode:           BootModeRunning,
+			Global:         cfg,
+			ConfigPathRule: resolution.Rule,
+			Host:           host,
+			Port:           port,
+			Version:        opts.version,
 		}, nil
 	}
 	if !missingGlobalConfig(err) {
@@ -70,12 +72,13 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 		}
 		host, port := bootServer(host, port, workflowPath)
 		return BootConfig{
-			Mode:         BootModeRunning,
-			Global:       cfg,
-			WorkflowPath: workflowPath,
-			Host:         host,
-			Port:         port,
-			Version:      opts.version,
+			Mode:           BootModeRunning,
+			Global:         cfg,
+			ConfigPathRule: resolution.Rule,
+			WorkflowPath:   workflowPath,
+			Host:           host,
+			Port:           port,
+			Version:        opts.version,
 		}, nil
 	}
 
@@ -84,12 +87,13 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 		return BootConfig{}, err
 	}
 	return BootConfig{
-		Mode:         BootModeOnboarding,
-		Global:       cfg,
-		WorkflowPath: workflowPath,
-		Host:         strings.TrimSpace(host),
-		Port:         bootPort(port),
-		Version:      opts.version,
+		Mode:           BootModeOnboarding,
+		Global:         cfg,
+		ConfigPathRule: resolution.Rule,
+		WorkflowPath:   workflowPath,
+		Host:           strings.TrimSpace(host),
+		Port:           bootPort(port),
+		Version:        opts.version,
 	}, nil
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"strings"
 
@@ -45,15 +46,16 @@ const (
 )
 
 type BootConfig struct {
-	Mode         BootMode
-	Global       globalconfig.Config
-	WorkflowPath string
-	Host         string
-	Port         *int
-	Version      string
-	Headless     bool
-	StdoutTTY    bool
-	Output       io.Writer
+	Mode           BootMode
+	Global         globalconfig.Config
+	ConfigPathRule globalconfig.PathRule
+	WorkflowPath   string
+	Host           string
+	Port           *int
+	Version        string
+	Headless       bool
+	StdoutTTY      bool
+	Output         io.Writer
 }
 
 type BootFunc func(context.Context, BootConfig) error
@@ -70,7 +72,7 @@ type ProjectManager interface {
 type Option func(*options)
 
 type options struct {
-	defaultPath   func() (string, error)
+	resolvePath   func(string) (globalconfig.PathResolution, error)
 	read          func(string) (globalconfig.Config, error)
 	readOrDefault func(string) (globalconfig.Config, error)
 	write         func(string, globalconfig.Config) error
@@ -164,6 +166,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 			boot.Headless = headless
 			boot.StdoutTTY = opts.stdoutTTY()
 			boot.Output = cmd.OutOrStdout()
+			slog.Info("resolved global config", "path", boot.Global.Path, "rule", boot.ConfigPathRule)
 			return opts.boot(cmd.Context(), boot)
 		},
 	}
@@ -183,6 +186,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 			project.Paused = false
 			return nil
 		}),
+		newConfigCommand(&configPath, opts),
 		newPromoteCommand(&configPath, opts),
 		newRemoveProjectCommand(&configPath, opts),
 	)
@@ -192,7 +196,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 
 func defaultOptions() options {
 	return options{
-		defaultPath: globalconfig.DefaultPath,
+		resolvePath: globalconfig.ResolvePath,
 		read: func(path string) (globalconfig.Config, error) {
 			return globalconfig.Read(path)
 		},
@@ -340,6 +344,31 @@ func newEditProjectCommand(configPath *string, opts options, operation Operation
 	}
 }
 
+func newConfigCommand(configPath *string, opts options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "config",
+		Short: "Inspect global config settings",
+	}
+	cmd.AddCommand(newConfigPathCommand(configPath, opts))
+	return cmd
+}
+
+func newConfigPathCommand(configPath *string, opts options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "path",
+		Short: "Print the resolved global config path",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			resolution, err := resolveConfigPathResolution(*configPath, opts)
+			if err != nil {
+				return err
+			}
+			_, err = fmt.Fprintf(cmd.OutOrStdout(), "path: %s\nrule: %s\n", resolution.Path, resolution.Rule)
+			return err
+		},
+	}
+}
+
 func newPromoteCommand(configPath *string, opts options) *cobra.Command {
 	var priority int
 	cmd := &cobra.Command{
@@ -428,10 +457,18 @@ func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
 }
 
 func resolveConfigPath(path string, opts options) (string, error) {
-	if strings.TrimSpace(path) != "" {
-		return strings.TrimSpace(path), nil
+	resolution, err := resolveConfigPathResolution(path, opts)
+	if err != nil {
+		return "", err
 	}
-	return opts.defaultPath()
+	return resolution.Path, nil
+}
+
+func resolveConfigPathResolution(path string, opts options) (globalconfig.PathResolution, error) {
+	if opts.resolvePath == nil {
+		opts.resolvePath = globalconfig.ResolvePath
+	}
+	return opts.resolvePath(path)
 }
 
 func projectIndex(projects []globalconfig.Project, id string) int {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -64,6 +64,31 @@ func TestRootCommandBootsFromGlobalConfig(t *testing.T) {
 	if got.Global.Path != path {
 		t.Fatalf("booted config path = %q, want %q", got.Global.Path, path)
 	}
+	if got.ConfigPathRule != globalconfig.PathRuleFlag {
+		t.Fatalf("config path rule = %q, want %q", got.ConfigPathRule, globalconfig.PathRuleFlag)
+	}
+}
+
+func TestConfigPathCommandPrintsResolvedPathAndRule(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	cmd := cli.NewRootCommand(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", path, "config", "path"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{path, string(globalconfig.PathRuleFlag)} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("config path output missing %q:\n%s", want, output)
+		}
+	}
 }
 
 func TestRootCommandPassesVersionToBoot(t *testing.T) {

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -27,6 +27,21 @@ var schedulingModes = []string{
 	SchedulingFairShare,
 }
 
+type PathRule string
+
+const (
+	PathRuleFlag          PathRule = "--config"
+	PathRuleEnvConfig     PathRule = "SYMPHONY_CONFIG"
+	PathRuleEnvHome       PathRule = "SYMPHONY_HOME"
+	PathRuleUserConfigDir PathRule = "os.UserConfigDir()"
+	PathRuleLegacyHome    PathRule = "~/.symphony"
+)
+
+type PathResolution struct {
+	Path string
+	Rule PathRule
+}
+
 type Config struct {
 	Path       string    `yaml:"-"`
 	APIVersion string    `yaml:"apiVersion"`
@@ -75,6 +90,13 @@ type options struct {
 	projectPathLiterals bool
 }
 
+type pathOptions struct {
+	config        options
+	lookupEnv     func(string) string
+	userConfigDir func() (string, error)
+	stat          func(string) (os.FileInfo, error)
+}
+
 func WithHome(home string) Option {
 	return func(opts *options) {
 		opts.home = home
@@ -93,21 +115,16 @@ func WithProjectPathLiterals() Option {
 	}
 }
 
-func DefaultPath() (string, error) {
-	if symphonyHome := os.Getenv("SYMPHONY_HOME"); symphonyHome != "" {
-		opts := defaultOptions()
-		expanded, err := expandPath(symphonyHome, opts)
-		if err != nil {
-			return "", err
-		}
-		return filepath.Join(expanded, "global.yaml"), nil
-	}
+func ResolvePath(configPath string) (PathResolution, error) {
+	return resolvePath(configPath, defaultPathOptions())
+}
 
-	home, err := os.UserHomeDir()
+func DefaultPath() (string, error) {
+	resolution, err := ResolvePath("")
 	if err != nil {
-		return "", fmt.Errorf("resolve user home: %w", err)
+		return "", err
 	}
-	return filepath.Join(home, ".symphony", "global.yaml"), nil
+	return resolution.Path, nil
 }
 
 func Default() (Config, error) {
@@ -331,6 +348,92 @@ func defaultOptions() options {
 		home:       home,
 		relativeTo: cwd,
 	}
+}
+
+func defaultPathOptions() pathOptions {
+	return pathOptions{
+		config:        defaultOptions(),
+		lookupEnv:     os.Getenv,
+		userConfigDir: os.UserConfigDir,
+		stat:          os.Stat,
+	}
+}
+
+func resolvePath(configPath string, opts pathOptions) (PathResolution, error) {
+	opts = normalizePathOptions(opts)
+
+	if strings.TrimSpace(configPath) != "" {
+		return pathResolution(configPath, PathRuleFlag, opts.config)
+	}
+	if envPath := strings.TrimSpace(opts.lookupEnv("SYMPHONY_CONFIG")); envPath != "" {
+		return pathResolution(envPath, PathRuleEnvConfig, opts.config)
+	}
+	if symphonyHome := strings.TrimSpace(opts.lookupEnv("SYMPHONY_HOME")); symphonyHome != "" {
+		expanded, err := expandPath(symphonyHome, opts.config)
+		if err != nil {
+			return PathResolution{}, err
+		}
+		return PathResolution{Path: filepath.Join(expanded, "global.yaml"), Rule: PathRuleEnvHome}, nil
+	}
+
+	nativePath, nativeErr := userConfigPath(opts)
+	legacyPath, legacyErr := legacyConfigPath(opts.config)
+	switch {
+	case nativeErr == nil && existingConfigFile(nativePath, opts):
+		return PathResolution{Path: nativePath, Rule: PathRuleUserConfigDir}, nil
+	case legacyErr == nil && existingConfigFile(legacyPath, opts):
+		return PathResolution{Path: legacyPath, Rule: PathRuleLegacyHome}, nil
+	case nativeErr == nil:
+		return PathResolution{Path: nativePath, Rule: PathRuleUserConfigDir}, nil
+	case legacyErr == nil:
+		return PathResolution{Path: legacyPath, Rule: PathRuleLegacyHome}, nil
+	default:
+		return PathResolution{}, nativeErr
+	}
+}
+
+func normalizePathOptions(opts pathOptions) pathOptions {
+	if opts.config.home == "" && opts.config.relativeTo == "" {
+		opts.config = defaultOptions()
+	}
+	if opts.lookupEnv == nil {
+		opts.lookupEnv = os.Getenv
+	}
+	if opts.userConfigDir == nil {
+		opts.userConfigDir = os.UserConfigDir
+	}
+	if opts.stat == nil {
+		opts.stat = os.Stat
+	}
+	return opts
+}
+
+func pathResolution(path string, rule PathRule, opts options) (PathResolution, error) {
+	expanded, err := expandPath(strings.TrimSpace(path), opts)
+	if err != nil {
+		return PathResolution{}, err
+	}
+	return PathResolution{Path: expanded, Rule: rule}, nil
+}
+
+func userConfigPath(opts pathOptions) (string, error) {
+	dir, err := opts.userConfigDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve user config dir: %w", err)
+	}
+	return filepath.Join(dir, "symphony", "global.yaml"), nil
+}
+
+func legacyConfigPath(opts options) (string, error) {
+	if opts.home == "" {
+		return "", errors.New("home directory is not available")
+	}
+	return filepath.Join(opts.home, ".symphony", "global.yaml"), nil
+}
+
+func existingConfigFile(path string, opts pathOptions) bool {
+	info, err := opts.stat(path)
+	return err == nil && info.Mode().IsRegular()
 }
 
 func defaultConfig(path string) Config {

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -5,16 +5,140 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"strings"
 	"testing"
 )
 
+func TestResolvePathPrecedence(t *testing.T) {
+	t.Setenv("SYMPHONY_HOME", "")
+	t.Setenv("SYMPHONY_CONFIG", "")
+
+	root := t.TempDir()
+	home := configurePathTestHome(t, root)
+	nativeRoot, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error = %v", err)
+	}
+
+	flagPath := filepath.Join(root, "flag.yaml")
+	envPath := filepath.Join(root, "env.yaml")
+	symphonyHome := filepath.Join(root, "symphony-home")
+	homePath := filepath.Join(symphonyHome, "global.yaml")
+	nativePath := filepath.Join(nativeRoot, "symphony", "global.yaml")
+	legacyPath := filepath.Join(home, ".symphony", "global.yaml")
+	for _, path := range []string{flagPath, envPath, homePath, nativePath, legacyPath} {
+		writeFile(t, path, "# config\n")
+	}
+	t.Setenv("SYMPHONY_CONFIG", envPath)
+	t.Setenv("SYMPHONY_HOME", symphonyHome)
+
+	tests := []struct {
+		name     string
+		flagPath string
+		setup    func()
+		wantPath string
+		wantRule PathRule
+	}{
+		{
+			name:     "flag wins",
+			flagPath: flagPath,
+			wantPath: flagPath,
+			wantRule: PathRuleFlag,
+		},
+		{
+			name: "symphony config wins after flag",
+			setup: func() {
+				t.Setenv("SYMPHONY_CONFIG", envPath)
+				t.Setenv("SYMPHONY_HOME", symphonyHome)
+			},
+			wantPath: envPath,
+			wantRule: PathRuleEnvConfig,
+		},
+		{
+			name: "symphony home wins after direct config env",
+			setup: func() {
+				t.Setenv("SYMPHONY_CONFIG", "")
+				t.Setenv("SYMPHONY_HOME", symphonyHome)
+			},
+			wantPath: homePath,
+			wantRule: PathRuleEnvHome,
+		},
+		{
+			name: "native config wins before legacy",
+			setup: func() {
+				t.Setenv("SYMPHONY_CONFIG", "")
+				t.Setenv("SYMPHONY_HOME", "")
+			},
+			wantPath: nativePath,
+			wantRule: PathRuleUserConfigDir,
+		},
+		{
+			name: "legacy config wins when native is missing",
+			setup: func() {
+				t.Setenv("SYMPHONY_CONFIG", "")
+				t.Setenv("SYMPHONY_HOME", "")
+				if err := os.Remove(nativePath); err != nil {
+					t.Fatalf("Remove() error = %v", err)
+				}
+			},
+			wantPath: legacyPath,
+			wantRule: PathRuleLegacyHome,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.setup != nil {
+				tt.setup()
+			}
+
+			got, err := ResolvePath(tt.flagPath)
+			if err != nil {
+				t.Fatalf("ResolvePath() error = %v", err)
+			}
+			if got.Path != tt.wantPath {
+				t.Fatalf("Path = %q, want %q", got.Path, tt.wantPath)
+			}
+			if got.Rule != tt.wantRule {
+				t.Fatalf("Rule = %q, want %q", got.Rule, tt.wantRule)
+			}
+		})
+	}
+}
+
+func TestResolvePathUsesNativeConfigDirWhenNoConfigExists(t *testing.T) {
+	t.Setenv("SYMPHONY_HOME", "")
+	t.Setenv("SYMPHONY_CONFIG", "")
+	configurePathTestHome(t, t.TempDir())
+
+	nativeRoot, err := os.UserConfigDir()
+	if err != nil {
+		t.Fatalf("UserConfigDir() error = %v", err)
+	}
+
+	got, err := ResolvePath("")
+	if err != nil {
+		t.Fatalf("ResolvePath() error = %v", err)
+	}
+
+	want := filepath.Join(nativeRoot, "symphony", "global.yaml")
+	if got.Path != want {
+		t.Fatalf("Path = %q, want %q", got.Path, want)
+	}
+	if got.Rule != PathRuleUserConfigDir {
+		t.Fatalf("Rule = %q, want %q", got.Rule, PathRuleUserConfigDir)
+	}
+}
+
 func TestDefaultPath(t *testing.T) {
 	t.Setenv("SYMPHONY_HOME", "")
+	t.Setenv("SYMPHONY_CONFIG", "")
+	configurePathTestHome(t, t.TempDir())
 
-	home, err := os.UserHomeDir()
+	nativeRoot, err := os.UserConfigDir()
 	if err != nil {
-		t.Fatalf("UserHomeDir() error = %v", err)
+		t.Fatalf("UserConfigDir() error = %v", err)
 	}
 
 	got, err := DefaultPath()
@@ -22,22 +146,24 @@ func TestDefaultPath(t *testing.T) {
 		t.Fatalf("DefaultPath() error = %v", err)
 	}
 
-	want := filepath.Join(home, ".symphony", "global.yaml")
+	want := filepath.Join(nativeRoot, "symphony", "global.yaml")
 	if got != want {
 		t.Fatalf("DefaultPath() = %q, want %q", got, want)
 	}
 }
 
 func TestDefaultPathHonorsSymphonyHome(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("SYMPHONY_HOME", home)
+	root := t.TempDir()
+	home := configurePathTestHome(t, root)
+	t.Setenv("SYMPHONY_CONFIG", "")
+	t.Setenv("SYMPHONY_HOME", "~/custom")
 
 	got, err := DefaultPath()
 	if err != nil {
 		t.Fatalf("DefaultPath() error = %v", err)
 	}
 
-	want := filepath.Join(home, "global.yaml")
+	want := filepath.Join(home, "custom", "global.yaml")
 	if got != want {
 		t.Fatalf("DefaultPath() = %q, want %q", got, want)
 	}
@@ -45,6 +171,7 @@ func TestDefaultPathHonorsSymphonyHome(t *testing.T) {
 
 func TestDefaultConfig(t *testing.T) {
 	t.Setenv("SYMPHONY_HOME", "")
+	t.Setenv("SYMPHONY_CONFIG", "")
 
 	cfg, err := Default()
 	if err != nil {
@@ -512,6 +639,21 @@ func writeFile(t *testing.T, path string, content string) {
 	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
+}
+
+func configurePathTestHome(t *testing.T, root string) string {
+	t.Helper()
+
+	home := filepath.Join(root, "home")
+	t.Setenv("HOME", home)
+	switch runtime.GOOS {
+	case "windows":
+		t.Setenv("USERPROFILE", home)
+		t.Setenv("APPDATA", filepath.Join(home, "AppData", "Roaming"))
+	default:
+		t.Setenv("XDG_CONFIG_HOME", "")
+	}
+	return home
 }
 
 func assertMap(t *testing.T, name string, got map[string]any, want map[string]any) {

--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -14,7 +14,10 @@ import (
 	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
 )
 
-const defaultDebounce = 150 * time.Millisecond
+const (
+	defaultDebounce     = 150 * time.Millisecond
+	reloadRetryInterval = 5 * time.Millisecond
+)
 
 var ErrMissingPath = errors.New("workflow watch path is required")
 
@@ -169,10 +172,7 @@ func (w *Watcher) reload(ctx context.Context, updates chan<- Update) {
 		At:   time.Now(),
 	}
 
-	workflow, err := w.loader(w.path)
-	if err == nil {
-		err = workflow.Config.Validate()
-	}
+	workflow, err := w.load(ctx)
 	if err != nil {
 		update.Err = err
 	} else {
@@ -180,6 +180,49 @@ func (w *Watcher) reload(ctx context.Context, updates chan<- Update) {
 	}
 
 	w.send(ctx, updates, update)
+}
+
+func (w *Watcher) load(ctx context.Context) (workflowconfig.Workflow, error) {
+	workflow, err := w.loadOnce()
+	if err == nil {
+		return workflow, nil
+	}
+	lastErr := err
+
+	deadline := time.NewTimer(w.debounce)
+	defer deadline.Stop()
+	retry := time.NewTicker(retryInterval(w.debounce))
+	defer retry.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return workflowconfig.Workflow{}, ctx.Err()
+		case <-deadline.C:
+			return workflowconfig.Workflow{}, lastErr
+		case <-retry.C:
+			workflow, err := w.loadOnce()
+			if err == nil {
+				return workflow, nil
+			}
+			lastErr = err
+		}
+	}
+}
+
+func (w *Watcher) loadOnce() (workflowconfig.Workflow, error) {
+	workflow, err := w.loader(w.path)
+	if err == nil {
+		err = workflow.Config.Validate()
+	}
+	return workflow, err
+}
+
+func retryInterval(debounce time.Duration) time.Duration {
+	if debounce < reloadRetryInterval {
+		return debounce
+	}
+	return reloadRetryInterval
 }
 
 func (w *Watcher) send(ctx context.Context, updates chan<- Update, update Update) {

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -2,11 +2,15 @@ package watcher
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strconv"
+	"sync/atomic"
 	"testing"
 	"time"
+
+	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
 )
 
 func TestWatchDebouncesWorkflowWrites(t *testing.T) {
@@ -85,6 +89,49 @@ func TestWatchHandlesAtomicSaveRename(t *testing.T) {
 	}
 	if update.Workflow.Prompt != "renamed\n" {
 		t.Fatalf("Prompt = %q, want renamed", update.Workflow.Prompt)
+	}
+}
+
+func TestWatchRetriesTransientReloadErrors(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "WORKFLOW.md")
+	writeWorkflow(t, path, 100, "initial")
+
+	var attempts atomic.Int32
+	w, err := New(path,
+		WithDebounce(10*time.Millisecond),
+		WithLoader(func(path string) (workflowconfig.Workflow, error) {
+			if attempts.Add(1) == 1 {
+				return workflowconfig.Workflow{}, errors.New("missing YAML frontmatter")
+			}
+			return workflowconfig.LoadWorkflow(path)
+		}),
+	)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	writeWorkflow(t, path, 300, "second")
+
+	update := receiveUpdate(t, updates)
+	if update.Err != nil {
+		t.Fatalf("update error = %v", update.Err)
+	}
+	if update.Workflow.Config.Polling.IntervalMS != 300 {
+		t.Fatalf("Polling.IntervalMS = %d, want 300", update.Workflow.Config.Polling.IntervalMS)
+	}
+	if got := attempts.Load(); got < 2 {
+		t.Fatalf("loader attempts = %d, want at least 2", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Implement cross-platform global config discovery with flag, `SYMPHONY_CONFIG`, `SYMPHONY_HOME`, OS-native config dir, and legacy home precedence.
- Add startup config-path logging and `symphony config path` reporting.
- Document the precedence in README and CONTRIBUTING.

Fixes #124

## Test Plan
- `go test ./internal/config/global ./internal/cli`
- `make check`