### PR TITLE
fix(core): split shutdown signals by os

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,10 +84,27 @@ jobs:
       - name: Check coverage
         run: make test-cover
 
+  windows-core:
+    name: Windows Core
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run non-agent core tests
+        run: go test ./cmd/symphony ./internal/config ./internal/config/global ./internal/store ./internal/web ./internal/tui ./internal/orchestrator ./internal/cli
+
+      - name: Build command
+        run: go build ./cmd/symphony
+
   goreleaser-snapshot:
     name: GoReleaser Snapshot
     runs-on: ubuntu-latest
-    needs: [lint, verify, test-cover]
+    needs: [lint, verify, test-cover, windows-core]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/cmd/symphony/main.go
+++ b/cmd/symphony/main.go
@@ -8,8 +8,6 @@ import (
 	"io"
 	"log/slog"
 	"os"
-	"os/signal"
-	"syscall"
 
 	"github.com/spf13/cobra"
 
@@ -91,8 +89,4 @@ func runShadowRun(out io.Writer, inputPath string, allowDiff bool) error {
 		return shadow.ErrDifferences
 	}
 	return nil
-}
-
-func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
-	return signal.NotifyContext(parent, os.Interrupt, syscall.SIGTERM)
 }

--- a/cmd/symphony/signal.go
+++ b/cmd/symphony/signal.go
@@ -1,0 +1,10 @@
+package main
+
+import (
+	"context"
+	"os/signal"
+)
+
+func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
+	return signal.NotifyContext(parent, shutdownSignals()...)
+}

--- a/cmd/symphony/signal_other.go
+++ b/cmd/symphony/signal_other.go
@@ -1,0 +1,9 @@
+//go:build !unix && !windows
+
+package main
+
+import "os"
+
+func shutdownSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/cmd/symphony/signal_unix.go
+++ b/cmd/symphony/signal_unix.go
@@ -1,0 +1,12 @@
+//go:build unix
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func shutdownSignals() []os.Signal {
+	return []os.Signal{os.Interrupt, syscall.SIGTERM}
+}

--- a/cmd/symphony/signal_unix_test.go
+++ b/cmd/symphony/signal_unix_test.go
@@ -1,0 +1,43 @@
+//go:build unix
+
+package main
+
+import (
+	"context"
+	"os"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestShutdownSignalsUnix(t *testing.T) {
+	signals := shutdownSignals()
+	if len(signals) != 2 {
+		t.Fatalf("shutdownSignals() length = %d, want 2", len(signals))
+	}
+	if signals[0] != os.Interrupt {
+		t.Fatalf("shutdownSignals()[0] = %v, want %v", signals[0], os.Interrupt)
+	}
+	if signals[1] != syscall.SIGTERM {
+		t.Fatalf("shutdownSignals()[1] = %v, want %v", signals[1], syscall.SIGTERM)
+	}
+}
+
+func TestSignalContextCancelsOnSIGTERM(t *testing.T) {
+	ctx, stop := newSignalContext(context.Background())
+	defer stop()
+
+	process, err := os.FindProcess(os.Getpid())
+	if err != nil {
+		t.Fatalf("FindProcess() error = %v", err)
+	}
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		t.Fatalf("Signal() error = %v", err)
+	}
+
+	select {
+	case <-ctx.Done():
+	case <-time.After(time.Second):
+		t.Fatal("signal context was not canceled by SIGTERM")
+	}
+}

--- a/cmd/symphony/signal_windows.go
+++ b/cmd/symphony/signal_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func shutdownSignals() []os.Signal {
+	return []os.Signal{os.Interrupt}
+}

--- a/cmd/symphony/signal_windows_test.go
+++ b/cmd/symphony/signal_windows_test.go
@@ -1,0 +1,18 @@
+//go:build windows
+
+package main
+
+import (
+	"os"
+	"testing"
+)
+
+func TestShutdownSignalsWindows(t *testing.T) {
+	signals := shutdownSignals()
+	if len(signals) != 1 {
+		t.Fatalf("shutdownSignals() length = %d, want 1", len(signals))
+	}
+	if signals[0] != os.Interrupt {
+		t.Fatalf("shutdownSignals()[0] = %v, want %v", signals[0], os.Interrupt)
+	}
+}

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -3,9 +3,13 @@ package cli
 import (
 	"context"
 	"errors"
+	"io"
 	"log/slog"
+	"net"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -144,6 +148,43 @@ func TestRegistryRefresherRequestsProjectOrchestrators(t *testing.T) {
 	assertRefresh(t, response)
 }
 
+func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
+	t.Parallel()
+
+	host, port := freeLoopbackPort(t)
+	globalPath := filepath.Join(t.TempDir(), "global.yaml")
+	global, err := globalconfig.DefaultAt(globalPath)
+	if err != nil {
+		t.Fatalf("DefaultAt() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, BootConfig{
+			Mode:   BootModeRunning,
+			Global: global,
+			Host:   host,
+			Port:   &port,
+		})
+	}()
+
+	body := waitForDashboard(t, "http://"+net.JoinHostPort(host, strconv.Itoa(port))+"/", done)
+	if !strings.Contains(body, "Symphony") {
+		t.Fatalf("dashboard body missing Symphony:\n%s", body)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for startRunning to stop")
+	}
+}
+
 func TestRegistryRefresherSkipsStoppedProjectOrchestrators(t *testing.T) {
 	t.Parallel()
 
@@ -165,6 +206,61 @@ func TestRegistryRefresherReturnsProjectNotFoundWithoutOrchestrators(t *testing.
 	if !errors.Is(err, projectpkg.ErrProjectNotFound) {
 		t.Fatalf("RequestRefresh() error = %v, want %v", err, projectpkg.ErrProjectNotFound)
 	}
+}
+
+func freeLoopbackPort(t *testing.T) (string, int) {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	defer listener.Close()
+
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		t.Fatalf("listener addr = %T, want *net.TCPAddr", listener.Addr())
+	}
+	return "127.0.0.1", addr.Port
+}
+
+func waitForDashboard(t *testing.T, url string, done <-chan error) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	client := http.Client{Timeout: 500 * time.Millisecond}
+	for ctx.Err() == nil {
+		select {
+		case err := <-done:
+			t.Fatalf("startRunning returned before dashboard responded: %v", err)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+		if err != nil {
+			t.Fatalf("NewRequestWithContext() error = %v", err)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			body, readErr := io.ReadAll(resp.Body)
+			closeErr := resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("ReadAll() error = %v", readErr)
+			}
+			if closeErr != nil {
+				t.Fatalf("Body.Close() error = %v", closeErr)
+			}
+			if resp.StatusCode == http.StatusOK {
+				return string(body)
+			}
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for dashboard at %s", url)
+	return ""
 }
 
 func newRefreshProject(t *testing.T, id string) *projectpkg.Project {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -806,8 +806,8 @@ func validPriorityRank(value any) bool {
 func validateWorkspaceRelativePath(field string, path string, problems *[]string) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" || strings.HasPrefix(trimmed, "~") || filepath.IsAbs(trimmed) ||
-		strings.HasPrefix(trimmed, `/`) ||
-		strings.HasPrefix(trimmed, `\`) || windowsAbsPathPattern.MatchString(trimmed) ||
+		strings.HasPrefix(trimmed, `/`) || strings.HasPrefix(trimmed, `\`) ||
+		windowsAbsPathPattern.MatchString(trimmed) ||
 		pathEscapesWorkspace(trimmed) {
 		*problems = append(*problems, field+" must be a relative path inside the workspace")
 	}


### PR DESCRIPTION
## Summary
- Split shutdown signal registration into build-tagged OS files.
- Keep Unix shutdown on `os.Interrupt` plus `syscall.SIGTERM`, while Windows registers only `os.Interrupt`.
- Reject slash-rooted workspace-relative config paths consistently across operating systems.
- Add focused signal tests, boot/dashboard shutdown coverage, and a Windows Core CI job for non-agent core packages.

Fixes #127

## Test Plan
- `go test ./cmd/symphony`
- `go test ./internal/cli`
- `go test ./internal/config`
- `GOOS=windows go test -exec=true ./cmd/symphony ./internal/config ./internal/config/global ./internal/store ./internal/web ./internal/tui ./internal/orchestrator ./internal/cli`
- `make check`
- GitHub CI, including `Windows Core`