### PR TITLE
ci(release): add cross-platform checks

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.jsonl text eol=lf

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,19 @@ jobs:
       - name: Run golangci-lint
         run: golangci-lint run --timeout=5m
 
-  test:
-    name: Test
-    runs-on: ubuntu-latest
+  verify:
+    name: Verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: ubuntu-latest
+            race: true
+          - os: macos-latest
+            race: true
+          - os: windows-latest
+            race: true
     steps:
       - uses: actions/checkout@v5
 
@@ -44,22 +54,21 @@ jobs:
           go-version-file: go.mod
           cache: true
 
-      - name: Run tests
-        run: make test
+      - name: Download modules
+        run: go mod download
 
-  test-race:
-    name: Test Race
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
+      - name: Build
+        run: go build ./...
 
-      - uses: actions/setup-go@v6
-        with:
-          go-version-file: go.mod
-          cache: true
+      - name: Vet
+        run: go vet ./...
 
-      - name: Run race tests
-        run: make test-race
+      - name: Test
+        run: go test ./...
+
+      - name: Race test
+        if: matrix.race
+        run: go test -race ./...
 
   test-cover:
     name: Test Coverage
@@ -75,20 +84,25 @@ jobs:
       - name: Check coverage
         run: make test-cover
 
-  build:
-    name: Build
+  goreleaser-snapshot:
+    name: GoReleaser Snapshot
     runs-on: ubuntu-latest
-    needs: [lint, test, test-race, test-cover]
+    needs: [lint, verify, test-cover]
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
           go-version-file: go.mod
           cache: true
 
-      - name: Install sqlc
-        run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
-
-      - name: Build
-        run: make build
+      - name: Run GoReleaser snapshot
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          args: release --snapshot --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,12 @@
 version: 2
-
 project_name: symphony
+dist: tmp/goreleaser
 
 before:
   hooks:
-    - go mod tidy
-    - go generate ./...
+    - go mod download
+    - go install github.com/sqlc-dev/sqlc/cmd/sqlc@v1.30.0
+    - make generate
     - go test ./...
 
 builds:
@@ -14,6 +15,10 @@ builds:
     binary: symphony
     env:
       - CGO_ENABLED=0
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w -X main.version={{ .Version }} -X main.commit={{ .ShortCommit }} -X main.date={{ .Date }}
     goos:
       - darwin
       - linux
@@ -21,8 +26,6 @@ builds:
     goarch:
       - amd64
       - arm64
-    ldflags:
-      - -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
 
 archives:
   - id: symphony
@@ -34,9 +37,14 @@ archives:
       - goos: windows
         formats:
           - zip
+    name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     files:
       - README.md
       - LICENSE
 
 checksum:
-  name_template: checksums.txt
+  name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot"

--- a/install_test.go
+++ b/install_test.go
@@ -1,3 +1,5 @@
+//go:build !windows
+
 package symphony_test
 
 import (

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -806,6 +806,7 @@ func validPriorityRank(value any) bool {
 func validateWorkspaceRelativePath(field string, path string, problems *[]string) {
 	trimmed := strings.TrimSpace(path)
 	if trimmed == "" || strings.HasPrefix(trimmed, "~") || filepath.IsAbs(trimmed) ||
+		strings.HasPrefix(trimmed, `/`) ||
 		strings.HasPrefix(trimmed, `\`) || windowsAbsPathPattern.MatchString(trimmed) ||
 		pathEscapesWorkspace(trimmed) {
 		*problems = append(*problems, field+" must be a relative path inside the workspace")

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -579,7 +579,8 @@ func newTestOrchestrator(t *testing.T, tracker connector.Connector, runner orche
 	orch, err := orchestrator.New(orchestrator.Config{
 		PollInterval:           5 * time.Millisecond,
 		MaxConcurrentAgents:    1,
-		MaxRetryBackoff:        50 * time.Millisecond,
+		MaxRetryBackoff:        time.Hour,
+		FailureRetryBaseDelay:  time.Hour,
 		ActiveStates:           []string{"Todo", "In Progress"},
 		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
 		ContinuationRetryDelay: time.Second,

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -13,6 +14,7 @@ import (
 
 func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T) {
 	t.Parallel()
+	skipWindows(t)
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
@@ -78,6 +80,8 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 }
 
 func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
+	skipWindows(t)
+
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
 	tracePath := filepath.Join(t.TempDir(), "after-create.trace")
@@ -99,7 +103,7 @@ func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
 		AutoBranch: true,
 		Hooks: Hooks{
 			AfterCreate: "printf 'ok\n' > " + shellQuote(tracePath),
-			Timeout:     time.Second,
+			Timeout:     5 * time.Second,
 		},
 	})
 	if err != nil {
@@ -120,6 +124,7 @@ func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
 
 func TestLocalGitCreateReusesExistingWorktreeWithoutAfterCreate(t *testing.T) {
 	t.Parallel()
+	skipWindows(t)
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
@@ -167,6 +172,7 @@ func TestLocalGitCreateReusesExistingWorktreeWithoutAfterCreate(t *testing.T) {
 
 func TestLocalGitBeforeAndAfterRunHooks(t *testing.T) {
 	t.Parallel()
+	skipWindows(t)
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
@@ -203,6 +209,7 @@ func TestLocalGitBeforeAndAfterRunHooks(t *testing.T) {
 
 func TestLocalGitHookFailureSurfaces(t *testing.T) {
 	t.Parallel()
+	skipWindows(t)
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
@@ -244,6 +251,7 @@ func TestLocalGitHookFailureSurfaces(t *testing.T) {
 
 func TestLocalGitCleanupRemovesOnlyTargetWorktree(t *testing.T) {
 	t.Parallel()
+	skipWindows(t)
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
@@ -331,6 +339,7 @@ func TestLocalGitCleanupRejectsForeignGitRepoWithoutBeforeRemove(t *testing.T) {
 
 func TestLocalGitRejectsSymlinkEscape(t *testing.T) {
 	t.Parallel()
+	skipWindows(t)
 
 	source := initSourceRepo(t)
 	testRoot := t.TempDir()
@@ -441,4 +450,11 @@ func readFile(t *testing.T, path string) string {
 
 func shellQuote(value string) string {
 	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func skipWindows(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("requires a UNIX test environment")
+	}
 }


### PR DESCRIPTION
## Summary
- Add an Ubuntu/macOS/Windows CI verification matrix for build, vet, test, and race tests.
- Add GoReleaser v2 snapshot coverage with Windows amd64/arm64 zip archives and checksums.
- Guard UNIX-only install and workspace hook tests from Windows test runs.

Fixes #126

## Test Plan
- go test ./internal/workspace
- go test .
- GOOS=windows go test -exec=true ./...
- go run github.com/goreleaser/goreleaser/v2@v2.16.0 check
- go run github.com/goreleaser/goreleaser/v2@v2.16.0 release --snapshot --clean
- make check