### PR TITLE
feat(cli): add boot dashboard banner

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"net"
 	"net/http"
@@ -32,6 +33,8 @@ const (
 	defaultProjectID    = "default"
 	defaultWebHost      = "127.0.0.1"
 	defaultWebPort      = 4000
+	dashboardHost       = "localhost"
+	projectURL          = "https://github.com/digitaldrywood/symphony"
 )
 
 func resolveBootConfig(configPath string, host string, port int, opts options) (BootConfig, error) {
@@ -131,6 +134,19 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		}
 	}()
 
+	listener, displayURL, err := listenForBoot(cfg)
+	if err != nil {
+		return err
+	}
+	listenerOwned := true
+	defer func() {
+		if listenerOwned {
+			if err := listener.Close(); err != nil {
+				logger.Warn("close web listener failed", "error", err)
+			}
+		}
+	}()
+
 	events := hub.New[project.Event]()
 	projectFactory := withRunnerFactory(project.Dependencies{
 		Events: events,
@@ -154,6 +170,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		Mode:         web.ModeRunning,
 		WorkflowPath: firstWorkflowPath(cfg),
 		Version:      cfg.Version,
+		DashboardURL: displayURL,
 	}, web.Dependencies{
 		Hub:       snapshotHub,
 		Store:     runtimeStore,
@@ -166,28 +183,55 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 
 	if useDashboard {
-		return serveWithTerminalDashboard(runCtx, server, serverAddr(cfg), snapshotHub)
+		if err := printBootBanner(cfg, displayURL); err != nil {
+			return err
+		}
+		listenerOwned = false
+		return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub)
 	}
-	return serve(runCtx, server, serverAddr(cfg))
+	if err := printBootBanner(cfg, displayURL); err != nil {
+		return err
+	}
+	listenerOwned = false
+	return serve(runCtx, server, listener)
 }
 
 func startOnboarding(ctx context.Context, cfg BootConfig) error {
+	logger := slog.Default()
+	listener, displayURL, err := listenForBoot(cfg)
+	if err != nil {
+		return err
+	}
+	listenerOwned := true
+	defer func() {
+		if listenerOwned {
+			if err := listener.Close(); err != nil {
+				logger.Warn("close web listener failed", "error", err)
+			}
+		}
+	}()
+
 	server, err := web.NewServer(web.Config{
 		Mode:         web.ModeOnboarding,
 		WorkflowPath: firstWorkflowPath(cfg),
 		Version:      cfg.Version,
+		DashboardURL: displayURL,
 	}, web.Dependencies{})
 	if err != nil {
 		return err
 	}
 
-	return serve(ctx, server, serverAddr(cfg))
+	if err := printBootBanner(cfg, displayURL); err != nil {
+		return err
+	}
+	listenerOwned = false
+	return serve(ctx, server, listener)
 }
 
-func serve(ctx context.Context, server *web.Server, addr string) error {
+func serve(ctx context.Context, server *web.Server, listener net.Listener) error {
 	errs := make(chan error, 1)
 	go func() {
-		errs <- server.Start(addr)
+		errs <- server.StartListener(listener)
 	}()
 
 	select {
@@ -210,10 +254,18 @@ func serve(ctx context.Context, server *web.Server, addr string) error {
 	}
 }
 
-func serveWithTerminalDashboard(ctx context.Context, server *web.Server, addr string, snapshots *hub.Hub[telemetry.Snapshot]) error {
+func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listener net.Listener, snapshots *hub.Hub[telemetry.Snapshot]) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
+	listenerOwned := true
+	defer func() {
+		if listenerOwned && listener != nil {
+			if err := listener.Close(); err != nil {
+				slog.Default().Warn("close web listener failed", "error", err)
+			}
+		}
+	}()
 
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
@@ -225,8 +277,9 @@ func serveWithTerminalDashboard(ctx context.Context, server *web.Server, addr st
 	defer model.Close()
 
 	errs := make(chan error, 2)
+	listenerOwned = false
 	go func() {
-		errs <- serve(runCtx, server, addr)
+		errs <- serve(runCtx, server, listener)
 	}()
 	go func() {
 		_, err := tea.NewProgram(model, tea.WithAltScreen(), tea.WithContext(runCtx)).Run()
@@ -499,6 +552,69 @@ func serverAddr(cfg BootConfig) string {
 		port = *cfg.Port
 	}
 	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func listenForBoot(cfg BootConfig) (net.Listener, string, error) {
+	listener, err := net.Listen("tcp", serverAddr(cfg))
+	if err != nil {
+		return nil, "", err
+	}
+	return listener, dashboardURL(listener.Addr()), nil
+}
+
+func dashboardURL(addr net.Addr) string {
+	port := dashboardPort(addr)
+	return "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(port))
+}
+
+func dashboardPort(addr net.Addr) int {
+	if tcpAddr, ok := addr.(*net.TCPAddr); ok && tcpAddr.Port > 0 {
+		return tcpAddr.Port
+	}
+	if addr == nil {
+		return defaultWebPort
+	}
+	_, port, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return defaultWebPort
+	}
+	value, err := strconv.Atoi(port)
+	if err != nil || value <= 0 {
+		return defaultWebPort
+	}
+	return value
+}
+
+func printBootBanner(cfg BootConfig, displayURL string) error {
+	out := cfg.Output
+	if out == nil {
+		out = os.Stdout
+	}
+	_, err := io.WriteString(out, bootBanner(cfg.Version, displayURL))
+	return err
+}
+
+func bootBanner(version string, displayURL string) string {
+	version = strings.TrimSpace(version)
+	if version == "" {
+		version = "dev"
+	}
+	displayURL = strings.TrimSpace(displayURL)
+	if displayURL == "" {
+		displayURL = "http://" + net.JoinHostPort(dashboardHost, strconv.Itoa(defaultWebPort))
+	}
+
+	var out strings.Builder
+	out.WriteString("Symphony ")
+	out.WriteString(version)
+	out.WriteByte('\n')
+	out.WriteString("Project: ")
+	out.WriteString(projectURL)
+	out.WriteByte('\n')
+	out.WriteString("Dashboard: ")
+	out.WriteString(displayURL)
+	out.WriteByte('\n')
+	return out.String()
 }
 
 func mustGetwd() string {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 
@@ -52,6 +53,7 @@ type BootConfig struct {
 	Version      string
 	Headless     bool
 	StdoutTTY    bool
+	Output       io.Writer
 }
 
 type BootFunc func(context.Context, BootConfig) error
@@ -161,6 +163,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 			}
 			boot.Headless = headless
 			boot.StdoutTTY = opts.stdoutTTY()
+			boot.Output = cmd.OutOrStdout()
 			return opts.boot(cmd.Context(), boot)
 		},
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -125,6 +125,39 @@ func TestRootCommandCapturesHeadlessFlagAndTerminalState(t *testing.T) {
 	}
 }
 
+func TestRootCommandPrintsBootBanner(t *testing.T) {
+	root := t.TempDir()
+	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	cmd := cli.NewRootCommand(ctx, cli.WithVersion("v1.2.3"))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", filepath.Join(root, ".symphony", "global.yaml"), "--host", "127.0.0.1", "--port", "0"})
+
+	if err := cmd.Execute(); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Execute() error = %v, want %v", err, context.Canceled)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Symphony v1.2.3",
+		"Project: https://github.com/digitaldrywood/symphony",
+		"Dashboard: http://localhost:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("boot banner missing %q:\n%s", want, output)
+		}
+	}
+	for _, unwanted := range []string{"http://0.0.0.0", "http://127.0.0.1", "http://localhost:0"} {
+		if strings.Contains(output, unwanted) {
+			t.Fatalf("boot banner contains non-localhost URL %q:\n%s", unwanted, output)
+		}
+	}
+}
+
 func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,6 +18,8 @@ import (
 
 var ErrNilHub = errors.New("nil telemetry hub")
 
+const dashboardURL = "http://localhost:4000"
+
 type Option func(*options)
 
 type options struct {
@@ -137,6 +139,7 @@ func waitForSnapshot(updates <-chan telemetry.Snapshot) tea.Cmd {
 func (m Model) renderWaiting() string {
 	lines := []string{
 		m.styles.title.Render("╭─ SYMPHONY STATUS"),
+		"│ Dashboard: " + m.styles.info.Render(dashboardURL),
 		"│ " + m.styles.muted.Render("Waiting for telemetry snapshot"),
 		closingBorder,
 	}
@@ -148,6 +151,7 @@ func (m Model) renderSnapshot() string {
 	snapshot := m.snapshot
 	lines := []string{
 		m.styles.title.Render("╭─ SYMPHONY STATUS"),
+		"│ Dashboard: " + m.styles.info.Render(dashboardURL),
 		"│ Generated: " + m.styles.muted.Render(formatTimestamp(snapshot.GeneratedAt)),
 		"│ Agents: " + m.styles.ok.Render(fmt.Sprintf("%d running", countOrLen(snapshot.Counts.Running, len(snapshot.Running)))) +
 			m.styles.muted.Render(" | ") +

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -38,6 +38,7 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 	view := stripANSI(next.(Model).View())
 	for _, want := range []string{
 		"SYMPHONY STATUS",
+		"Dashboard: http://localhost:4000",
 		"Agents: 1 running | 1 queued | 1 blocked | 1 completed",
 		"Tokens: in 110 | out 220 | total 330",
 		"Budget: enabled current $12.50 | projected $0.75 | day max $50.00 | issue max $5.00",
@@ -74,7 +75,7 @@ func TestModelRendersWaitingStateBeforeSnapshot(t *testing.T) {
 	}
 
 	view := stripANSI(model.View())
-	for _, want := range []string{"SYMPHONY STATUS", "Waiting for telemetry snapshot"} {
+	for _, want := range []string{"SYMPHONY STATUS", "Dashboard: http://localhost:4000", "Waiting for telemetry snapshot"} {
 		if !strings.Contains(view, want) {
 			t.Fatalf("View() missing %q:\n%s", want, view)
 		}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"net"
 	"net/http"
 	"strings"
 	"time"
@@ -48,20 +49,22 @@ type Config struct {
 	SSETickInterval time.Duration
 	WorkflowPath    string
 	Version         string
+	DashboardURL    string
 }
 
 type Server struct {
-	echo      *echo.Echo
-	hub       *hub.Hub[telemetry.Snapshot]
-	store     store.Store
-	registry  any
-	connector connector.Connector
-	refresher Refresher
-	logger    *slog.Logger
-	mode      Mode
-	tickEvery time.Duration
-	workflow  string
-	version   string
+	echo         *echo.Echo
+	hub          *hub.Hub[telemetry.Snapshot]
+	store        store.Store
+	registry     any
+	connector    connector.Connector
+	refresher    Refresher
+	logger       *slog.Logger
+	mode         Mode
+	tickEvery    time.Duration
+	workflow     string
+	version      string
+	dashboardURL string
 }
 
 func NewServer(cfg Config, deps Dependencies) (*Server, error) {
@@ -86,17 +89,18 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	e.HidePort = true
 
 	server := &Server{
-		echo:      e,
-		hub:       deps.Hub,
-		store:     deps.Store,
-		registry:  deps.Registry,
-		connector: deps.Connector,
-		refresher: deps.Refresher,
-		logger:    cfg.logger(),
-		mode:      mode,
-		tickEvery: cfg.sseTickInterval(),
-		workflow:  cfg.workflowPath(),
-		version:   strings.TrimSpace(cfg.Version),
+		echo:         e,
+		hub:          deps.Hub,
+		store:        deps.Store,
+		registry:     deps.Registry,
+		connector:    deps.Connector,
+		refresher:    deps.Refresher,
+		logger:       cfg.logger(),
+		mode:         mode,
+		tickEvery:    cfg.sseTickInterval(),
+		workflow:     cfg.workflowPath(),
+		version:      strings.TrimSpace(cfg.Version),
+		dashboardURL: cfg.dashboardURL(),
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
 	server.registerRoutes(cfg.staticDir())
@@ -115,6 +119,11 @@ func (s *Server) Echo() *echo.Echo {
 func (s *Server) Start(addr string) error {
 	s.logger.Info("starting web server", "addr", addr)
 	return s.echo.Start(addr)
+}
+
+func (s *Server) StartListener(listener net.Listener) error {
+	s.logger.Info("starting web server", "addr", listener.Addr().String())
+	return s.echo.Server.Serve(listener)
 }
 
 func (s *Server) Shutdown(ctx context.Context) error {
@@ -158,22 +167,10 @@ func (s *Server) dashboard(c echo.Context) error {
 	return render(c, templates.Dashboard(templates.DashboardData{
 		Title:         "Symphony",
 		Version:       s.version,
-		DashboardURL:  currentDashboardURL(c),
 		ConnectorName: s.connector.Name(),
+		DashboardURL:  s.dashboardURL,
 		Snapshot:      s.latestSnapshot(c.Request().Context()),
 	}))
-}
-
-func currentDashboardURL(c echo.Context) string {
-	req := c.Request()
-	if strings.TrimSpace(req.Host) == "" {
-		return "/"
-	}
-	scheme := strings.TrimSpace(c.Scheme())
-	if scheme == "" {
-		scheme = "http"
-	}
-	return scheme + "://" + req.Host + "/"
 }
 
 func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
@@ -250,6 +247,13 @@ func (cfg Config) workflowPath() string {
 		return cfg.WorkflowPath
 	}
 	return "WORKFLOW.md"
+}
+
+func (cfg Config) dashboardURL() string {
+	if dashboardURL := strings.TrimSpace(cfg.DashboardURL); dashboardURL != "" {
+		return dashboardURL
+	}
+	return "http://localhost:4000"
 }
 
 func configuredStatus(value any) string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -315,18 +315,21 @@ func TestDashboardRendersServerMetadata(t *testing.T) {
 	}
 	for _, want := range []string{
 		"v9.8.7",
-		`href="http://dashboard.example.test:4100/"`,
+		`href="http://localhost:4000"`,
 	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
 		}
+	}
+	if strings.Contains(rec.Body.String(), "http://dashboard.example.test:4100") {
+		t.Fatalf("dashboard link used request host:\n%s", rec.Body.String())
 	}
 }
 
 func TestDashboardWiresHTMXSSE(t *testing.T) {
 	t.Parallel()
 
-	server, err := web.NewServer(web.Config{}, testDeps(t))
+	server, err := web.NewServer(web.Config{DashboardURL: "http://localhost:4101"}, testDeps(t))
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
 	}
@@ -341,6 +344,7 @@ func TestDashboardWiresHTMXSSE(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		`href="http://localhost:4101"`,
 		`src="https://unpkg.com/htmx.org@2.0.4"`,
 		`src="https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4"`,
 		`hx-ext="sse"`,

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -56,7 +56,7 @@ func versionLabel(data DashboardData) string {
 func dashboardURL(data DashboardData) string {
 	url := strings.TrimSpace(data.DashboardURL)
 	if url == "" {
-		return "/"
+		return "http://localhost:4000"
 	}
 	return url
 }
@@ -64,7 +64,7 @@ func dashboardURL(data DashboardData) string {
 func dashboardURLLabel(data DashboardData) string {
 	url := strings.TrimSpace(data.DashboardURL)
 	if url == "" {
-		return "Dashboard"
+		return "http://localhost:4000"
 	}
 	return url
 }

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -21,8 +21,8 @@ func TestDashboardRendersTelemetrySnapshot(t *testing.T) {
 	html := renderDashboard(t, templates.DashboardData{
 		Title:         "Symphony",
 		Version:       "v1.2.3",
-		DashboardURL:  "http://127.0.0.1:4100/",
 		ConnectorName: "github",
+		DashboardURL:  "http://localhost:4101",
 		Snapshot: telemetry.Snapshot{
 			GeneratedAt: now,
 			Counts: telemetry.Counts{
@@ -97,9 +97,10 @@ func TestDashboardRendersTelemetrySnapshot(t *testing.T) {
 		"Blocked",
 		"Completed",
 		"v1.2.3",
-		"href=\"http://127.0.0.1:4100/\"",
+		"href=\"http://localhost:4101\"",
 		"digitaldrywood/symphony#35",
 		"Dashboard templates",
+		"http://localhost:4101",
 		"turn completed successfully",
 		"+4 -2 (3 files)",
 		"162,000",


### PR DESCRIPTION
## Summary

- Print a startup banner with the Symphony version, project URL, and localhost dashboard URL.
- Surface the same dashboard URL in the TUI header and web dashboard.
- Preserve configured server bind host while using localhost for display links.

Fixes #105

## Test Plan

- [x] `go test ./internal/cli ./internal/tui ./internal/web ./internal/web/templates`
- [x] `make check`