### PR TITLE
feat(tui): launch dashboard by default

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -12,6 +13,8 @@ import (
 	"strings"
 	"time"
 
+	tea "github.com/charmbracelet/bubbletea"
+
 	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
 	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
 	"github.com/digitaldrywood/symphony/internal/connector"
@@ -20,6 +23,7 @@ import (
 	"github.com/digitaldrywood/symphony/internal/project"
 	"github.com/digitaldrywood/symphony/internal/store"
 	"github.com/digitaldrywood/symphony/internal/telemetry"
+	"github.com/digitaldrywood/symphony/internal/tui"
 	"github.com/digitaldrywood/symphony/internal/web"
 )
 
@@ -100,12 +104,28 @@ func defaultBoot(ctx context.Context, cfg BootConfig) error {
 }
 
 func startRunning(ctx context.Context, cfg BootConfig) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runCtx, stop := context.WithCancel(ctx)
+	defer stop()
+
+	useDashboard := shouldLaunchTerminalDashboard(cfg)
+	if useDashboard {
+		restoreLogger, err := redirectDefaultLogger(runtimeLogPath(cfg))
+		if err != nil {
+			return err
+		}
+		defer restoreLogger()
+	}
+
 	logger := slog.Default()
-	runtimeStore, err := openRuntimeStore(ctx, cfg)
+	runtimeStore, err := openRuntimeStore(runCtx, cfg)
 	if err != nil {
 		return err
 	}
 	defer func() {
+		stop()
 		if err := runtimeStore.Close(); err != nil {
 			logger.Warn("close runtime store failed", "error", err)
 		}
@@ -124,12 +144,12 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := manager.Start(ctx); err != nil {
+	if err := manager.Start(runCtx); err != nil {
 		return err
 	}
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
-	go publishSnapshots(ctx, manager.Registry(), snapshotHub, defaultSnapshotInterval, time.Now)
+	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, defaultSnapshotInterval, time.Now)
 	server, err := web.NewServer(web.Config{
 		Mode:         web.ModeRunning,
 		WorkflowPath: firstWorkflowPath(cfg),
@@ -145,7 +165,10 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		return err
 	}
 
-	return serve(ctx, server, serverAddr(cfg))
+	if useDashboard {
+		return serveWithTerminalDashboard(runCtx, server, serverAddr(cfg), snapshotHub)
+	}
+	return serve(runCtx, server, serverAddr(cfg))
 }
 
 func startOnboarding(ctx context.Context, cfg BootConfig) error {
@@ -187,6 +210,88 @@ func serve(ctx context.Context, server *web.Server, addr string) error {
 	}
 }
 
+func serveWithTerminalDashboard(ctx context.Context, server *web.Server, addr string, snapshots *hub.Hub[telemetry.Snapshot]) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	model, err := tui.NewModel(runCtx, snapshots)
+	if err != nil {
+		return err
+	}
+	defer model.Close()
+
+	errs := make(chan error, 2)
+	go func() {
+		errs <- serve(runCtx, server, addr)
+	}()
+	go func() {
+		_, err := tea.NewProgram(model, tea.WithAltScreen(), tea.WithContext(runCtx)).Run()
+		errs <- err
+	}()
+
+	first := <-errs
+	cancel()
+	second := <-errs
+	return terminalDashboardError(first, second)
+}
+
+func terminalDashboardError(first error, second error) error {
+	if err := unexpectedTerminalDashboardError(first); err != nil {
+		return err
+	}
+	if err := unexpectedTerminalDashboardError(second); err != nil {
+		return err
+	}
+	if first == nil || second == nil {
+		return nil
+	}
+	if errors.Is(first, context.Canceled) || errors.Is(second, context.Canceled) {
+		return context.Canceled
+	}
+	return nil
+}
+
+func unexpectedTerminalDashboardError(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}
+
+func shouldLaunchTerminalDashboard(cfg BootConfig) bool {
+	return cfg.Mode == BootModeRunning && cfg.StdoutTTY && !cfg.Headless
+}
+
+func redirectDefaultLogger(path string) (func(), error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("log path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create log directory: %w", err)
+	}
+
+	file, err := os.OpenFile(path, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open log file: %w", err)
+	}
+
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(file, &slog.HandlerOptions{
+		Level: logLevelFromEnv(),
+	})))
+
+	return func() {
+		slog.SetDefault(previous)
+		if err := file.Close(); err != nil {
+			previous.Warn("close log file failed", "path", path, "error", err)
+		}
+	}, nil
+}
+
 func missingGlobalConfig(err error) bool {
 	var missing globalconfig.MissingFileError
 	return errors.As(err, &missing) && errors.Is(missing.Err, os.ErrNotExist)
@@ -220,14 +325,44 @@ func globalConfigFromWorkflow(globalPath string, workflowPath string) (globalcon
 }
 
 func openRuntimeStore(ctx context.Context, cfg BootConfig) (store.Store, error) {
+	return store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    runtimeStorePath(cfg),
+	})
+}
+
+func runtimeStorePath(cfg BootConfig) string {
 	path := filepath.Join(filepath.Dir(cfg.Global.Path), "symphony.db")
 	if strings.TrimSpace(cfg.Global.Path) == "" {
 		path = filepath.Join(mustGetwd(), ".symphony", "symphony.db")
 	}
-	return store.Open(ctx, store.Config{
-		Backend: store.BackendSQLite,
-		Path:    path,
-	})
+	return path
+}
+
+func runtimeLogPath(cfg BootConfig) string {
+	return filepath.Join(filepath.Dir(runtimeStorePath(cfg)), "symphony.log")
+}
+
+func logLevelFromEnv() slog.Level {
+	for _, key := range []string{"SYMPHONY_LOG_LEVEL", "LOG_LEVEL"} {
+		if level, ok := os.LookupEnv(key); ok {
+			return parseSlogLevel(level)
+		}
+	}
+	return slog.LevelInfo
+}
+
+func parseSlogLevel(level string) slog.Level {
+	switch strings.ToLower(strings.TrimSpace(level)) {
+	case "debug":
+		return slog.LevelDebug
+	case "warn", "warning":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
 }
 
 func firstConnector(manager *project.Manager) connector.Connector {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -3,6 +3,10 @@ package cli
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -11,6 +15,115 @@ import (
 	projectpkg "github.com/digitaldrywood/symphony/internal/project"
 	"github.com/digitaldrywood/symphony/internal/web"
 )
+
+func TestShouldLaunchTerminalDashboard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  BootConfig
+		want bool
+	}{
+		{
+			name: "running terminal",
+			cfg:  BootConfig{Mode: BootModeRunning, StdoutTTY: true},
+			want: true,
+		},
+		{
+			name: "headless terminal",
+			cfg:  BootConfig{Mode: BootModeRunning, Headless: true, StdoutTTY: true},
+			want: false,
+		},
+		{
+			name: "non terminal",
+			cfg:  BootConfig{Mode: BootModeRunning},
+			want: false,
+		},
+		{
+			name: "onboarding terminal",
+			cfg:  BootConfig{Mode: BootModeOnboarding, StdoutTTY: true},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := shouldLaunchTerminalDashboard(tt.cfg); got != tt.want {
+				t.Fatalf("shouldLaunchTerminalDashboard(%#v) = %v, want %v", tt.cfg, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRedirectDefaultLoggerWritesToFile(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	path := filepath.Join(t.TempDir(), "runtime", "symphony.log")
+	restore, err := redirectDefaultLogger(path)
+	if err != nil {
+		t.Fatalf("redirectDefaultLogger() error = %v", err)
+	}
+
+	slog.Info("dashboard log message", "mode", "tui")
+	restore()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	logs := string(raw)
+	for _, want := range []string{`"msg":"dashboard log message"`, `"mode":"tui"`} {
+		if !strings.Contains(logs, want) {
+			t.Fatalf("log file missing %q:\n%s", want, logs)
+		}
+	}
+	if slog.Default() != previous {
+		t.Fatal("default logger was not restored")
+	}
+}
+
+func TestTerminalDashboardError(t *testing.T) {
+	t.Parallel()
+
+	serverErr := errors.New("server failed")
+	tests := []struct {
+		name   string
+		first  error
+		second error
+		want   error
+	}{
+		{
+			name:   "dashboard quit stops server cleanly",
+			second: context.Canceled,
+		},
+		{
+			name:  "server failure wins",
+			first: serverErr,
+			want:  serverErr,
+		},
+		{
+			name:   "external cancel is preserved",
+			first:  context.Canceled,
+			second: context.Canceled,
+			want:   context.Canceled,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := terminalDashboardError(tt.first, tt.second); !errors.Is(got, tt.want) {
+				t.Fatalf("terminalDashboardError() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
 
 func TestRegistryRefresherRequestsProjectOrchestrators(t *testing.T) {
 	t.Parallel()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -50,6 +50,8 @@ type BootConfig struct {
 	Host         string
 	Port         *int
 	Version      string
+	Headless     bool
+	StdoutTTY    bool
 }
 
 type BootFunc func(context.Context, BootConfig) error
@@ -73,6 +75,7 @@ type options struct {
 	boot          BootFunc
 	signal        SignalFunc
 	version       string
+	stdoutTTY     func() bool
 }
 
 func WithBootFunc(boot BootFunc) Option {
@@ -100,6 +103,14 @@ func WithVersion(version string) Option {
 func WithProjectManager(manager ProjectManager) Option {
 	return func(opts *options) {
 		opts.signal = ProjectManagerSignalFunc(manager)
+	}
+}
+
+func WithStdoutTTY(stdoutTTY func() bool) Option {
+	return func(opts *options) {
+		if stdoutTTY != nil {
+			opts.stdoutTTY = stdoutTTY
+		}
 	}
 }
 
@@ -136,6 +147,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	var configPath string
 	var host string
 	var port int
+	var headless bool
 	cmd := &cobra.Command{
 		Use:          "symphony",
 		Short:        "Symphony agent orchestrator",
@@ -147,6 +159,8 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 			if err != nil {
 				return err
 			}
+			boot.Headless = headless
+			boot.StdoutTTY = opts.stdoutTTY()
 			return opts.boot(cmd.Context(), boot)
 		},
 	}
@@ -154,6 +168,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to global.yaml")
 	cmd.PersistentFlags().StringVar(&host, "host", "", "web server host")
 	cmd.PersistentFlags().IntVar(&port, "port", -1, "web server port, or 0 for an ephemeral port")
+	cmd.PersistentFlags().BoolVar(&headless, "headless", false, "stream logs instead of launching the terminal dashboard")
 	cmd.AddCommand(
 		newInitCommand(&configPath, opts),
 		newAddProjectCommand(&configPath, opts),
@@ -184,13 +199,19 @@ func defaultOptions() options {
 		write: func(path string, cfg globalconfig.Config) error {
 			return globalconfig.Write(path, cfg, globalconfig.WithProjectPathLiterals())
 		},
-		boot:   defaultBoot,
-		signal: noSignal,
+		boot:      defaultBoot,
+		signal:    noSignal,
+		stdoutTTY: stdoutIsTTY,
 	}
 }
 
 func noSignal(context.Context, Signal) error {
 	return nil
+}
+
+func stdoutIsTTY() bool {
+	info, err := os.Stdout.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
 func newInitCommand(configPath *string, opts options) *cobra.Command {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -93,6 +93,38 @@ func TestRootCommandPassesVersionToBoot(t *testing.T) {
 	}
 }
 
+func TestRootCommandCapturesHeadlessFlagAndTerminalState(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	writeGlobalConfig(t, path, nil)
+
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return true }),
+		cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+			booted <- cfg
+			return nil
+		}),
+	)
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", path, "--headless"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if !got.Headless {
+		t.Fatal("Headless = false, want true")
+	}
+	if !got.StdoutTTY {
+		t.Fatal("StdoutTTY = false, want true")
+	}
+}
+
 func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing.T) {
 	root := t.TempDir()
 	t.Setenv("SYMPHONY_HOME", filepath.Join(root, ".symphony"))


### PR DESCRIPTION
## Summary

- launch the existing Bubble Tea dashboard when stdout is a TTY
- add `--headless` and non-TTY fallback to keep streaming logs
- redirect slog to `symphony.log` beside the runtime database while the TUI owns the terminal

Fixes #104

## Test Plan

- [x] `go test ./internal/cli ./cmd/symphony ./internal/tui`
- [x] `make check`