### PR TITLE
feat(telemetry): stream live run details

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -70,6 +70,7 @@ const (
 	UpdateAgentMessageDelta UpdateType = "agent_message_delta"
 	UpdateTokenUsage        UpdateType = "token_usage"
 	UpdateRateLimits        UpdateType = "rate_limits"
+	UpdateTurnStarted       UpdateType = "turn_started"
 	UpdateTurnCompleted     UpdateType = "turn_completed"
 )
 
@@ -201,6 +202,15 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		ThreadID:  threadID,
 		TurnID:    turnID,
 		SessionID: threadID + "-" + turnID,
+	}
+	if err := emitUpdate(Update{
+		Type:     UpdateTurnStarted,
+		Method:   "turn/start",
+		ThreadID: threadID,
+		TurnID:   turnID,
+		Status:   "started",
+	}, onUpdate); err != nil {
+		return RunTurnResult{}, err
 	}
 
 	if err := s.streamTurn(ctx, transport, onUpdate); err != nil {

--- a/internal/codex/appserver_parity_test.go
+++ b/internal/codex/appserver_parity_test.go
@@ -47,11 +47,14 @@ func TestAppServerRunTurnMatchesElixirTranscriptBytes(t *testing.T) {
 	if result.ThreadID != "thread-elixir-1" || result.TurnID != "turn-elixir-1" {
 		t.Fatalf("RunTurn() result = %#v, want recorded thread and turn", result)
 	}
-	if len(updates) != 3 {
-		t.Fatalf("updates = %d, want 3", len(updates))
+	if len(updates) != 4 {
+		t.Fatalf("updates = %d, want 4", len(updates))
 	}
-	if updates[1].Tokens.InputTokens != 123 || updates[1].Tokens.OutputTokens != 45 || updates[1].Tokens.TotalTokens != 168 {
-		t.Fatalf("token update = %#v, want recorded totals", updates[1].Tokens)
+	if updates[0].Type != UpdateTurnStarted {
+		t.Fatalf("updates[0] = %#v, want turn started", updates[0])
+	}
+	if updates[2].Tokens.InputTokens != 123 || updates[2].Tokens.OutputTokens != 45 || updates[2].Tokens.TotalTokens != 168 {
+		t.Fatalf("token update = %#v, want recorded totals", updates[2].Tokens)
 	}
 	assertTranscriptBytes(t, transport.sent.Bytes(), wantSent)
 }

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -125,32 +125,35 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	assertJSONContains(t, sent[3].Params, "approvalPolicy", "never")
 	assertJSONContains(t, sent[3].Params, "sandboxPolicy.type", "workspaceWrite")
 
-	if len(updates) != 4 {
-		t.Fatalf("updates = %d, want 4: %#v", len(updates), updates)
+	if len(updates) != 5 {
+		t.Fatalf("updates = %d, want 5: %#v", len(updates), updates)
 	}
-	if updates[0].Type != UpdateAgentMessageDelta || updates[0].Delta != "hello" {
-		t.Fatalf("updates[0] = %#v, want agent message delta", updates[0])
+	if updates[0].Type != UpdateTurnStarted || updates[0].ThreadID != "thread-1" || updates[0].TurnID != "turn-1" {
+		t.Fatalf("updates[0] = %#v, want turn started", updates[0])
 	}
-	if updates[1].Type != UpdateTokenUsage || updates[1].Tokens.TotalTokens != 27 {
-		t.Fatalf("updates[1] = %#v, want token usage total 27", updates[1])
+	if updates[1].Type != UpdateAgentMessageDelta || updates[1].Delta != "hello" {
+		t.Fatalf("updates[1] = %#v, want agent message delta", updates[1])
 	}
-	if updates[1].Tokens.CachedInputTokens != 5 || updates[1].Tokens.ReasoningOutputTokens != 3 {
-		t.Fatalf("updates[1].Tokens = %#v", updates[1].Tokens)
+	if updates[2].Type != UpdateTokenUsage || updates[2].Tokens.TotalTokens != 27 {
+		t.Fatalf("updates[2] = %#v, want token usage total 27", updates[2])
 	}
-	if updates[1].Tokens.ModelContextWindow == nil || *updates[1].Tokens.ModelContextWindow != 200000 {
-		t.Fatalf("updates[1].Tokens.ModelContextWindow = %#v", updates[1].Tokens.ModelContextWindow)
+	if updates[2].Tokens.CachedInputTokens != 5 || updates[2].Tokens.ReasoningOutputTokens != 3 {
+		t.Fatalf("updates[2].Tokens = %#v", updates[2].Tokens)
 	}
-	if updates[2].Type != UpdateRateLimits || updates[2].RateLimits == nil {
-		t.Fatalf("updates[2] = %#v, want rate limits", updates[2])
+	if updates[2].Tokens.ModelContextWindow == nil || *updates[2].Tokens.ModelContextWindow != 200000 {
+		t.Fatalf("updates[2].Tokens.ModelContextWindow = %#v", updates[2].Tokens.ModelContextWindow)
 	}
-	if updates[2].RateLimits.LimitID != "codex-primary" || updates[2].RateLimits.Primary == nil {
-		t.Fatalf("updates[2].RateLimits = %#v", updates[2].RateLimits)
+	if updates[3].Type != UpdateRateLimits || updates[3].RateLimits == nil {
+		t.Fatalf("updates[3] = %#v, want rate limits", updates[3])
 	}
-	if updates[2].RateLimits.Primary.UsedPercent != 12.5 {
-		t.Fatalf("Primary.UsedPercent = %f, want 12.5", updates[2].RateLimits.Primary.UsedPercent)
+	if updates[3].RateLimits.LimitID != "codex-primary" || updates[3].RateLimits.Primary == nil {
+		t.Fatalf("updates[3].RateLimits = %#v", updates[3].RateLimits)
 	}
-	if updates[3].Type != UpdateTurnCompleted || updates[3].TurnID != "turn-1" {
-		t.Fatalf("updates[3] = %#v, want turn completed", updates[3])
+	if updates[3].RateLimits.Primary.UsedPercent != 12.5 {
+		t.Fatalf("Primary.UsedPercent = %f, want 12.5", updates[3].RateLimits.Primary.UsedPercent)
+	}
+	if updates[4].Type != UpdateTurnCompleted || updates[4].TurnID != "turn-1" {
+		t.Fatalf("updates[4] = %#v, want turn completed", updates[4])
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -507,8 +507,25 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 		return
 	}
 
+	if event.usage.SessionID != "" {
+		running.SessionID = event.usage.SessionID
+	}
+	if event.usage.TurnCount > 0 {
+		running.TurnCount = event.usage.TurnCount
+	}
+	if !event.usage.LastEventAt.IsZero() {
+		running.LastEventAt = event.usage.LastEventAt
+	}
+	if event.usage.LastEvent != "" {
+		running.LastEvent = event.usage.LastEvent
+	}
+	if event.usage.LastMessage != "" {
+		running.LastMessage = event.usage.LastMessage
+	}
+	if diffStatsPresent(event.usage.DiffStats) {
+		running.DiffStats = event.usage.DiffStats
+	}
 	running.Tokens = event.usage.Tokens
-	running.TurnCount = event.usage.TurnCount
 	state.Running[event.issueID] = running
 	if event.usage.RateLimits != nil {
 		state.RateLimits = cloneRateLimits(event.usage.RateLimits)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -114,15 +114,26 @@ func TestRunReportsRunningStateWhileRunnerIsInFlight(t *testing.T) {
 func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 	t.Parallel()
 
+	lastEventAt := time.Date(2026, 5, 31, 14, 30, 0, 0, time.UTC)
 	issue := testIssue("issue-live-usage", "digitaldrywood/symphony#115", "In Progress")
 	tracker := newFakeConnector(issue)
 	runner := newUsageStreamingRunner(orchestrator.UsageUpdate{
-		TurnCount: 1,
+		SessionID:   "thread-live-turn-live",
+		TurnCount:   1,
+		LastEventAt: lastEventAt,
+		LastEvent:   "agent_message_delta",
+		LastMessage: "editing telemetry",
 		Tokens: orchestrator.CodexTotals{
 			InputTokens:    40,
 			OutputTokens:   12,
 			TotalTokens:    52,
 			RuntimeSeconds: 3.5,
+		},
+		DiffStats: orchestrator.DiffStats{
+			FilesChanged: 2,
+			AddedLines:   9,
+			RemovedLines: 1,
+			Status:       "ok",
 		},
 	})
 
@@ -143,6 +154,15 @@ func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 	}
 	if running.Tokens.RuntimeSeconds != 3.5 {
 		t.Fatalf("Running[%q].Tokens.RuntimeSeconds = %v, want 3.5", issue.ID, running.Tokens.RuntimeSeconds)
+	}
+	if running.SessionID != "thread-live-turn-live" || running.LastEvent != "agent_message_delta" || running.LastMessage != "editing telemetry" {
+		t.Fatalf("Running[%q] live activity = %#v", issue.ID, running)
+	}
+	if !running.LastEventAt.Equal(lastEventAt) {
+		t.Fatalf("Running[%q].LastEventAt = %v, want %v", issue.ID, running.LastEventAt, lastEventAt)
+	}
+	if running.DiffStats.FilesChanged != 2 || running.DiffStats.AddedLines != 9 || running.DiffStats.RemovedLines != 1 || running.DiffStats.Status != "ok" {
+		t.Fatalf("Running[%q].DiffStats = %#v, want live diff stats", issue.ID, running.DiffStats)
 	}
 	if state.CodexTotals.TotalTokens != 0 {
 		t.Fatalf("CodexTotals.TotalTokens = %d, want completed totals only", state.CodexTotals.TotalTokens)

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -38,12 +38,21 @@ func runningSnapshots(running map[string]Running) []telemetry.Running {
 	out := make([]telemetry.Running, 0, len(ids))
 	for _, id := range ids {
 		entry := running[id]
+		lastEventAt := timePointer(entry.LastEventAt)
 		out = append(out, telemetry.Running{
 			Issue:          telemetryIssue(entry.Issue),
 			WorkerHost:     entry.WorkerHost,
+			SessionID:      entry.SessionID,
 			StartedAt:      entry.StartedAt,
+			LastEventAt:    lastEventAt,
+			LastEvent:      entry.LastEvent,
+			LastMessage:    entry.LastMessage,
 			TurnCount:      entry.TurnCount,
 			RuntimeSeconds: entry.Tokens.RuntimeSeconds,
+			DiffAdded:      entry.DiffStats.AddedLines,
+			DiffRemoved:    entry.DiffStats.RemovedLines,
+			DiffFiles:      entry.DiffStats.FilesChanged,
+			DiffStatus:     entry.DiffStats.Status,
 			Tokens:         tokensFromCodexTotals(entry.Tokens),
 		})
 	}
@@ -153,6 +162,13 @@ func tokensFromCodexTotals(totals CodexTotals) telemetry.Tokens {
 		Total:          totals.TotalTokens,
 		RuntimeSeconds: totals.RuntimeSeconds,
 	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	return &value
 }
 
 func (s State) liveCodexTotals() CodexTotals {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -47,12 +47,17 @@ func TestStateSnapshotPopulated(t *testing.T) {
 
 	state := newState(normalizeConfig(Config{}))
 	state.Running["i-2"] = Running{
-		Issue:      connector.Issue{ID: "i-2", Identifier: "ISS-2", Title: "Two", State: "In Progress", URL: "u2"},
-		Attempt:    1,
-		StartedAt:  startedAt,
-		WorkerHost: "host-b",
-		TurnCount:  2,
-		Tokens:     CodexTotals{InputTokens: 20, OutputTokens: 8, TotalTokens: 28, RuntimeSeconds: 30},
+		Issue:       connector.Issue{ID: "i-2", Identifier: "ISS-2", Title: "Two", State: "In Progress", URL: "u2"},
+		Attempt:     1,
+		StartedAt:   startedAt,
+		WorkerHost:  "host-b",
+		SessionID:   "thread-2-turn-2",
+		TurnCount:   2,
+		LastEventAt: now.Add(-10 * time.Second),
+		LastEvent:   "agent_message_delta",
+		LastMessage: "editing dashboard telemetry",
+		DiffStats:   DiffStats{FilesChanged: 3, AddedLines: 12, RemovedLines: 4, Status: "ok"},
+		Tokens:      CodexTotals{InputTokens: 20, OutputTokens: 8, TotalTokens: 28, RuntimeSeconds: 30},
 	}
 	state.Running["i-1"] = Running{
 		Issue:     connector.Issue{ID: "i-1", Identifier: "ISS-1", Title: "One", State: "In Progress"},
@@ -111,6 +116,18 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	}
 	if snapshot.Running[1].RuntimeSeconds != 30 {
 		t.Fatalf("Running[1].RuntimeSeconds = %v, want 30", snapshot.Running[1].RuntimeSeconds)
+	}
+	if snapshot.Running[1].SessionID != "thread-2-turn-2" || snapshot.Running[1].LastEvent != "agent_message_delta" {
+		t.Fatalf("Running[1] live activity = %#v", snapshot.Running[1])
+	}
+	if snapshot.Running[1].LastEventAt == nil || !snapshot.Running[1].LastEventAt.Equal(now.Add(-10*time.Second)) {
+		t.Fatalf("Running[1].LastEventAt = %v", snapshot.Running[1].LastEventAt)
+	}
+	if snapshot.Running[1].LastMessage != "editing dashboard telemetry" {
+		t.Fatalf("Running[1].LastMessage = %q", snapshot.Running[1].LastMessage)
+	}
+	if snapshot.Running[1].DiffFiles != 3 || snapshot.Running[1].DiffAdded != 12 || snapshot.Running[1].DiffRemoved != 4 || snapshot.Running[1].DiffStatus != "ok" {
+		t.Fatalf("Running[1] diff = %#v", snapshot.Running[1])
 	}
 
 	if len(snapshot.Queue) != 1 {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -22,12 +22,17 @@ type State struct {
 }
 
 type Running struct {
-	Issue      connector.Issue
-	Attempt    int
-	StartedAt  time.Time
-	WorkerHost string
-	TurnCount  int
-	Tokens     CodexTotals
+	Issue       connector.Issue
+	Attempt     int
+	StartedAt   time.Time
+	WorkerHost  string
+	SessionID   string
+	TurnCount   int
+	LastEventAt time.Time
+	LastEvent   string
+	LastMessage string
+	DiffStats   DiffStats
+	Tokens      CodexTotals
 }
 
 type Claimed struct {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -21,7 +21,10 @@ import (
 	"github.com/digitaldrywood/symphony/internal/workspace"
 )
 
-const defaultAfterRunTimeout = time.Minute
+const (
+	defaultAfterRunTimeout = time.Minute
+	liveDiffStatsInterval  = 2 * time.Second
+)
 
 var (
 	ErrMissingWorkspace = errors.New("runner workspace backend is required")
@@ -301,12 +304,15 @@ func applyCodexUpdate(result *RunResult, update codex.Update) {
 }
 
 type codexRunProgress struct {
-	sessionID   string
-	turnIDs     map[string]struct{}
-	messages    map[string]string
-	lastEventAt time.Time
-	lastEvent   string
-	lastMessage string
+	sessionID          string
+	turnIDs            map[string]struct{}
+	messages           map[string]string
+	lastEventAt        time.Time
+	lastEvent          string
+	lastMessage        string
+	diffStats          DiffStats
+	diffStatsCollected bool
+	diffStatsCheckedAt time.Time
 }
 
 func newCodexRunProgress() *codexRunProgress {
@@ -377,14 +383,25 @@ func (r *Runner) publishRunUpdate(
 		Tokens:      result.Tokens,
 		RateLimits:  result.RateLimits,
 	}
-	diffStats, ok := r.liveDiffStats(ctx, info, issue)
+	diffStats, ok := r.liveDiffStats(ctx, info, issue, progress, eventAt)
 	if ok {
 		usage.DiffStats = diffStats
 	}
 	return req.OnUsageUpdate(usage)
 }
 
-func (r *Runner) liveDiffStats(ctx context.Context, info workspace.Info, issue workspace.Issue) (DiffStats, bool) {
+func (r *Runner) liveDiffStats(
+	ctx context.Context,
+	info workspace.Info,
+	issue workspace.Issue,
+	progress *codexRunProgress,
+	eventAt time.Time,
+) (DiffStats, bool) {
+	if !progress.shouldRefreshDiffStats(eventAt) {
+		return progress.cachedDiffStats()
+	}
+
+	progress.diffStatsCheckedAt = eventAt
 	stat, err := r.workspace.DiffStat(ctx, info, issue)
 	if err != nil {
 		r.logger.Warn(
@@ -393,12 +410,28 @@ func (r *Runner) liveDiffStats(ctx context.Context, info workspace.Info, issue w
 			slog.String("issue_identifier", issue.Identifier),
 			slog.String("error", err.Error()),
 		)
-		return DiffStats{}, false
+		return progress.cachedDiffStats()
 	}
 
 	diffStats := diffStatsFromWorkspace(stat)
 	diffStats.Status = "ok"
+	progress.diffStats = diffStats
+	progress.diffStatsCollected = true
 	return diffStats, true
+}
+
+func (p *codexRunProgress) shouldRefreshDiffStats(eventAt time.Time) bool {
+	if p.diffStatsCheckedAt.IsZero() {
+		return true
+	}
+	return eventAt.Sub(p.diffStatsCheckedAt) >= liveDiffStatsInterval
+}
+
+func (p *codexRunProgress) cachedDiffStats() (DiffStats, bool) {
+	if !p.diffStatsCollected {
+		return DiffStats{}, false
+	}
+	return p.diffStats, true
 }
 
 func rateLimitsFromCodex(snapshot *codex.RateLimitSnapshot) *telemetry.RateLimits {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -143,6 +143,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 
 	result := RunResult{FinalState: FinalStateCompleted}
+	progress := newCodexRunProgress()
 	turnResult, turnErr := r.codex.RunTurn(ctx, codex.RunTurnRequest{
 		Workspace:         info.Path,
 		Prompt:            prompt,
@@ -152,7 +153,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Model:             model,
 	}, func(update codex.Update) error {
 		applyCodexUpdate(&result, update)
-		if err := r.publishUsageUpdate(req, result, update, runStartedAt); err != nil {
+		if err := r.publishRunUpdate(ctx, req, info, workspaceIssue, progress, result, update, runStartedAt); err != nil {
 			return err
 		}
 		return nil
@@ -299,8 +300,63 @@ func applyCodexUpdate(result *RunResult, update codex.Update) {
 	}
 }
 
-func (r *Runner) publishUsageUpdate(
+type codexRunProgress struct {
+	sessionID   string
+	turnIDs     map[string]struct{}
+	messages    map[string]string
+	lastEventAt time.Time
+	lastEvent   string
+	lastMessage string
+}
+
+func newCodexRunProgress() *codexRunProgress {
+	return &codexRunProgress{
+		turnIDs:  map[string]struct{}{},
+		messages: map[string]string{},
+	}
+}
+
+func (p *codexRunProgress) apply(update codex.Update, eventAt time.Time) {
+	if update.ThreadID != "" && update.TurnID != "" {
+		p.sessionID = update.ThreadID + "-" + update.TurnID
+		p.turnIDs[update.TurnID] = struct{}{}
+	}
+	if update.Type != "" {
+		p.lastEvent = string(update.Type)
+	} else {
+		p.lastEvent = update.Method
+	}
+	p.lastEventAt = eventAt.UTC()
+
+	switch update.Type {
+	case codex.UpdateAgentMessageDelta:
+		key := update.ItemID
+		if key == "" {
+			key = update.TurnID
+		}
+		p.messages[key] += update.Delta
+		p.lastMessage = strings.TrimSpace(p.messages[key])
+	case codex.UpdateTurnStarted:
+		p.lastMessage = "turn started"
+	case codex.UpdateTurnCompleted:
+		status := update.Status
+		if status == "" {
+			status = "completed"
+		}
+		p.lastMessage = "turn " + status
+	}
+}
+
+func (p *codexRunProgress) turnCount() int {
+	return len(p.turnIDs)
+}
+
+func (r *Runner) publishRunUpdate(
+	ctx context.Context,
 	req RunRequest,
+	info workspace.Info,
+	issue workspace.Issue,
+	progress *codexRunProgress,
 	result RunResult,
 	update codex.Update,
 	runStartedAt time.Time,
@@ -308,17 +364,41 @@ func (r *Runner) publishUsageUpdate(
 	if req.OnUsageUpdate == nil {
 		return nil
 	}
-	if update.Type != codex.UpdateTokenUsage {
-		return nil
-	}
 
-	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, r.now())
+	eventAt := r.now()
+	progress.apply(update, eventAt)
+	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, eventAt)
 	usage := UsageUpdate{
-		Tokens:     result.Tokens,
-		TurnCount:  1,
-		RateLimits: result.RateLimits,
+		SessionID:   progress.sessionID,
+		TurnCount:   progress.turnCount(),
+		LastEventAt: progress.lastEventAt,
+		LastEvent:   progress.lastEvent,
+		LastMessage: progress.lastMessage,
+		Tokens:      result.Tokens,
+		RateLimits:  result.RateLimits,
+	}
+	diffStats, ok := r.liveDiffStats(ctx, info, issue)
+	if ok {
+		usage.DiffStats = diffStats
 	}
 	return req.OnUsageUpdate(usage)
+}
+
+func (r *Runner) liveDiffStats(ctx context.Context, info workspace.Info, issue workspace.Issue) (DiffStats, bool) {
+	stat, err := r.workspace.DiffStat(ctx, info, issue)
+	if err != nil {
+		r.logger.Warn(
+			"workspace live diff stat failed",
+			slog.String("issue_id", issue.ID),
+			slog.String("issue_identifier", issue.Identifier),
+			slog.String("error", err.Error()),
+		)
+		return DiffStats{}, false
+	}
+
+	diffStats := diffStatsFromWorkspace(stat)
+	diffStats.Status = "ok"
+	return diffStats, true
 }
 
 func rateLimitsFromCodex(snapshot *codex.RateLimitSnapshot) *telemetry.RateLimits {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -158,11 +158,14 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if usageUpdates[1].Tokens.RuntimeSeconds != 2 {
 		t.Fatalf("second usage update runtime = %v, want 2", usageUpdates[1].Tokens.RuntimeSeconds)
 	}
-	if usageUpdates[1].DiffStats.FilesChanged != 2 || usageUpdates[1].DiffStats.AddedLines != 5 || usageUpdates[1].DiffStats.RemovedLines != 1 {
-		t.Fatalf("second usage update DiffStats = %#v, want changed diff", usageUpdates[1].DiffStats)
+	if usageUpdates[1].DiffStats.FilesChanged != 1 || usageUpdates[1].DiffStats.AddedLines != 2 || usageUpdates[1].DiffStats.RemovedLines != 0 {
+		t.Fatalf("second usage update DiffStats = %#v, want cached diff", usageUpdates[1].DiffStats)
 	}
 	if usageUpdates[2].RateLimits == nil || usageUpdates[2].RateLimits.LimitID != "codex-primary" {
 		t.Fatalf("third usage update RateLimits = %#v, want codex-primary", usageUpdates[2].RateLimits)
+	}
+	if usageUpdates[2].DiffStats.FilesChanged != 2 || usageUpdates[2].DiffStats.AddedLines != 5 || usageUpdates[2].DiffStats.RemovedLines != 1 {
+		t.Fatalf("third usage update DiffStats = %#v, want refreshed diff", usageUpdates[2].DiffStats)
 	}
 	if result.DiffStats.FilesChanged != 2 || result.DiffStats.AddedLines != 5 || result.DiffStats.RemovedLines != 1 {
 		t.Fatalf("DiffStats = %#v, want 2 files, 5 added, 1 removed", result.DiffStats)
@@ -175,6 +178,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if !workspaceBackend.created || !workspaceBackend.beforeRun || !workspaceBackend.afterRun || !workspaceBackend.diffed {
 		t.Fatalf("workspace calls = created:%v before:%v after:%v diff:%v, want all true", workspaceBackend.created, workspaceBackend.beforeRun, workspaceBackend.afterRun, workspaceBackend.diffed)
+	}
+	if workspaceBackend.diffCalls != 3 {
+		t.Fatalf("DiffStat calls = %d, want throttled live calls plus final stat", workspaceBackend.diffCalls)
 	}
 	if codexClient.request.Workspace != workspacePath {
 		t.Fatalf("codex workspace = %q, want %q", codexClient.request.Workspace, workspacePath)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -23,19 +23,33 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	writeSkill(t, workspacePath, "review.md", "review", "Review code.", "Issue needs code review.")
 
 	startedAt := time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC)
-	completedAt := startedAt.Add(2 * time.Second)
+	completedAt := startedAt.Add(4 * time.Second)
 	workspaceBackend := &fakeWorkspaceBackend{
 		info: workspace.Info{
 			Path:   workspacePath,
 			Key:    "digitaldrywood_symphony_22",
 			Branch: "symphony/digitaldrywood_symphony_22",
 		},
-		diffStat: workspace.DiffStat{Files: 2, Added: 5, Removed: 1},
+		diffStats: []workspace.DiffStat{
+			{Files: 1, Added: 2},
+			{Files: 2, Added: 5, Removed: 1},
+			{Files: 2, Added: 5, Removed: 1},
+			{Files: 2, Added: 5, Removed: 1},
+		},
 	}
 	codexClient := &fakeCodexClient{
 		updates: []codex.Update{
 			{
-				Type: codex.UpdateTokenUsage,
+				Type:     codex.UpdateAgentMessageDelta,
+				ThreadID: "thread-1",
+				TurnID:   "turn-1",
+				ItemID:   "item-1",
+				Delta:    "hello",
+			},
+			{
+				Type:     codex.UpdateTokenUsage,
+				ThreadID: "thread-1",
+				TurnID:   "turn-1",
 				Tokens: codex.TokenUsage{
 					InputTokens:  100,
 					OutputTokens: 25,
@@ -57,7 +71,14 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		result: codex.RunTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "thread-1-turn-1"},
 	}
 	sessionStore := &fakeSessionStore{sessionID: 42}
-	now := newFakeClock(startedAt, startedAt.Add(time.Second), completedAt)
+	now := newFakeClock(
+		startedAt,
+		startedAt.Add(time.Second),
+		startedAt.Add(2*time.Second),
+		startedAt.Add(3*time.Second),
+		completedAt,
+		completedAt,
+	)
 
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
@@ -113,17 +134,35 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if result.FinalState != FinalStateCompleted {
 		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
 	}
-	if result.Tokens.TotalTokens != 125 || result.Tokens.RuntimeSeconds != 2 {
-		t.Fatalf("Tokens = %#v, want total 125 and runtime 2s", result.Tokens)
+	if result.Tokens.TotalTokens != 125 || result.Tokens.RuntimeSeconds != 4 {
+		t.Fatalf("Tokens = %#v, want total 125 and runtime 4s", result.Tokens)
 	}
-	if len(usageUpdates) != 1 {
-		t.Fatalf("usage updates len = %d, want 1", len(usageUpdates))
+	if len(usageUpdates) != 3 {
+		t.Fatalf("usage updates len = %d, want 3", len(usageUpdates))
 	}
-	if usageUpdates[0].TurnCount != 1 || usageUpdates[0].Tokens.TotalTokens != 125 {
-		t.Fatalf("usage update = %#v, want 1 turn and 125 tokens", usageUpdates[0])
+	if usageUpdates[0].SessionID != "thread-1-turn-1" || usageUpdates[0].TurnCount != 1 {
+		t.Fatalf("first usage update = %#v, want live session and one turn", usageUpdates[0])
 	}
-	if usageUpdates[0].Tokens.RuntimeSeconds != 1 {
-		t.Fatalf("usage update runtime = %v, want 1", usageUpdates[0].Tokens.RuntimeSeconds)
+	if usageUpdates[0].LastEvent != "agent_message_delta" || usageUpdates[0].LastMessage != "hello" {
+		t.Fatalf("first usage update activity = %#v, want agent message", usageUpdates[0])
+	}
+	if usageUpdates[0].LastEventAt.IsZero() {
+		t.Fatal("first usage update LastEventAt is zero")
+	}
+	if usageUpdates[0].DiffStats.FilesChanged != 1 || usageUpdates[0].DiffStats.AddedLines != 2 || usageUpdates[0].DiffStats.Status != "ok" {
+		t.Fatalf("first usage update DiffStats = %#v, want live diff", usageUpdates[0].DiffStats)
+	}
+	if usageUpdates[1].TurnCount != 1 || usageUpdates[1].Tokens.TotalTokens != 125 {
+		t.Fatalf("second usage update = %#v, want 1 turn and 125 tokens", usageUpdates[1])
+	}
+	if usageUpdates[1].Tokens.RuntimeSeconds != 2 {
+		t.Fatalf("second usage update runtime = %v, want 2", usageUpdates[1].Tokens.RuntimeSeconds)
+	}
+	if usageUpdates[1].DiffStats.FilesChanged != 2 || usageUpdates[1].DiffStats.AddedLines != 5 || usageUpdates[1].DiffStats.RemovedLines != 1 {
+		t.Fatalf("second usage update DiffStats = %#v, want changed diff", usageUpdates[1].DiffStats)
+	}
+	if usageUpdates[2].RateLimits == nil || usageUpdates[2].RateLimits.LimitID != "codex-primary" {
+		t.Fatalf("third usage update RateLimits = %#v, want codex-primary", usageUpdates[2].RateLimits)
 	}
 	if result.DiffStats.FilesChanged != 2 || result.DiffStats.AddedLines != 5 || result.DiffStats.RemovedLines != 1 {
 		t.Fatalf("DiffStats = %#v, want 2 files, 5 added, 1 removed", result.DiffStats)
@@ -291,11 +330,13 @@ func TestRunnerRunUsesFreshContextForAfterRunCleanup(t *testing.T) {
 type fakeWorkspaceBackend struct {
 	info        workspace.Info
 	diffStat    workspace.DiffStat
+	diffStats   []workspace.DiffStat
 	created     bool
 	beforeRun   bool
 	afterRun    bool
 	afterRunErr error
 	diffed      bool
+	diffCalls   int
 }
 
 func (b *fakeWorkspaceBackend) Create(_ context.Context, issue workspace.Issue) (workspace.Info, error) {
@@ -320,6 +361,14 @@ func (b *fakeWorkspaceBackend) AfterRun(ctx context.Context, _ workspace.Info, _
 
 func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspace.Issue) (workspace.DiffStat, error) {
 	b.diffed = true
+	if len(b.diffStats) > 0 {
+		index := b.diffCalls
+		if index >= len(b.diffStats) {
+			index = len(b.diffStats) - 1
+		}
+		b.diffCalls++
+		return b.diffStats[index], nil
+	}
 	return b.diffStat, nil
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -36,9 +36,14 @@ type RunResult struct {
 type UsageUpdateHandler func(UsageUpdate) error
 
 type UsageUpdate struct {
-	Tokens     CodexTotals
-	TurnCount  int
-	RateLimits *telemetry.RateLimits
+	SessionID   string
+	TurnCount   int
+	LastEventAt time.Time
+	LastEvent   string
+	LastMessage string
+	Tokens      CodexTotals
+	DiffStats   DiffStats
+	RateLimits  *telemetry.RateLimits
 }
 
 type BudgetRefusal struct {


### PR DESCRIPTION
## Summary
- Emit Codex turn-start updates so live rows get session and turn IDs before token events.
- Extend runner updates and orchestrator running state with latest activity, live tokens, runtime, and diff stats.
- Throttle live diff stat collection so streamed Codex updates reuse cached stats between refreshes.
- Map the new running fields into telemetry snapshots for the dashboard and API.

Fixes #135

## Test Plan
- go test ./internal/runner
- make check
