### PR TITLE
chore(release): add GoReleaser config

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,42 @@
+version: 2
+
+project_name: symphony
+
+before:
+  hooks:
+    - go mod tidy
+    - go generate ./...
+    - go test ./...
+
+builds:
+  - id: symphony
+    main: ./cmd/symphony
+    binary: symphony
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - darwin
+      - linux
+      - windows
+    goarch:
+      - amd64
+      - arm64
+    ldflags:
+      - -X main.version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
+
+archives:
+  - id: symphony
+    ids:
+      - symphony
+    formats:
+      - tar.gz
+    format_overrides:
+      - goos: windows
+        formats:
+          - zip
+    files:
+      - README.md
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt

--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ MIGRATIONS_DIR ?= internal/database/migrations
 GOOSE_DRIVER ?= sqlite3
 DATABASE_URL ?= tmp/symphony.db
 
-.PHONY: dev generate css css-watch build test test-race test-cover lint vet check sqlc db-migrate setup clean help
+.PHONY: dev generate css css-watch build test test-race test-cover lint vet check release-snapshot sqlc db-migrate setup clean help
 
 dev:
 	@mkdir -p tmp
@@ -88,6 +88,9 @@ vet:
 check: build lint vet test-race test-cover
 	@echo "All checks passed."
 
+release-snapshot:
+	goreleaser release --snapshot --clean
+
 sqlc:
 	@if [ -f "$(SQLC_CONFIG)" ]; then \
 		sqlc generate -f "$(SQLC_CONFIG)"; \
@@ -126,6 +129,7 @@ help:
 	@echo "  test-cover   Run Go coverage with a $(COVERAGE_THRESHOLD)% minimum"
 	@echo "  lint         Run golangci-lint"
 	@echo "  check        Run the local validation gate"
+	@echo "  release-snapshot  Build local GoReleaser snapshot archives"
 	@echo "  sqlc         Generate sqlc output"
 	@echo "  db-migrate   Run goose migrations"
 	@echo "  setup        Install development tools"


### PR DESCRIPTION
## Summary

- Add GoReleaser v2 configuration for darwin, linux, and windows on amd64 and arm64.
- Add a `make release-snapshot` target for local snapshot release archives and checksums.

Fixes #96

## Test Plan

- [x] `goreleaser check`
- [x] `make release-snapshot`
- [x] `dist/symphony_darwin_arm64_v8.0/symphony version`
- [x] `make check`