### PR TITLE
ci(release): add tag-triggered release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: GoReleaser
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26'
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,15 @@ jobs:
           go-version: '1.26'
           cache: true
 
+      - name: Verify tag points at main
+        run: |
+          git fetch --no-tags origin main:refs/remotes/origin/main
+          main_sha="$(git rev-parse origin/main)"
+          if [ "$GITHUB_SHA" != "$main_sha" ]; then
+            echo "Release tags must point at origin/main ($main_sha); got $GITHUB_SHA."
+            exit 1
+          fi
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:

--- a/README.md
+++ b/README.md
@@ -39,6 +39,17 @@ Source checkouts can also run the repository-local installer:
 
 Homebrew support is tracked separately in #98.
 
+## Release
+
+Cut releases from `main` by pushing a semver tag:
+
+```sh
+git tag v0.1.0 && git push origin v0.1.0
+```
+
+Tags matching `v*` trigger the release workflow, which runs GoReleaser and
+publishes the GitHub Release archives and checksums.
+
 ## Quick Start
 
 The quickest production-shaped setup is one GitHub ProjectV2 board and one


### PR DESCRIPTION
## Summary

- Add a tag-triggered GoReleaser workflow for `v*` tags.
- Document the release tag command in the README.

Fixes #97

## Test Plan

- [x] `goreleaser check`
- [x] `make check`