### PR TITLE
feat(store): persist usage event cost

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -108,12 +108,13 @@ INSERT INTO usage_events (
   input_tokens,
   output_tokens,
   total_tokens,
+  cost_usd,
   runtime_seconds,
   started_at,
   finished_at,
   event_day,
   outcome
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetUsageEvent :one

--- a/internal/budget/pricing.go
+++ b/internal/budget/pricing.go
@@ -99,6 +99,15 @@ func (p PricingTable) Lookup(model string) (ModelPricing, bool) {
 	return row, ok
 }
 
+func UsageCostUSD(pricing PricingTable, model string, inputTokens int64, outputTokens int64) (float64, bool) {
+	modelPricing, ok := pricing.Lookup(model)
+	if !ok {
+		return 0, false
+	}
+	return float64(nonNegative(inputTokens))*modelPricing.USDPerInputToken +
+		float64(nonNegative(outputTokens))*modelPricing.USDPerOutputToken, true
+}
+
 func normalizePricingRow(value any) (ModelPricing, bool) {
 	row := mapValue(value)
 	if row == nil {

--- a/internal/budget/pricing_test.go
+++ b/internal/budget/pricing_test.go
@@ -104,3 +104,60 @@ func TestPricingForConfigUsesEmbeddedDefaultPath(t *testing.T) {
 		t.Fatal("PricingForConfig(default).Lookup(gpt-5.5) ok = false, want true")
 	}
 }
+
+func TestUsageCostUSD(t *testing.T) {
+	t.Parallel()
+
+	pricing := PricingTable{
+		"gpt-test": {
+			USDPerInputToken:  0.01,
+			USDPerOutputToken: 0.02,
+		},
+	}
+
+	tests := []struct {
+		name         string
+		model        string
+		inputTokens  int64
+		outputTokens int64
+		want         float64
+		wantOK       bool
+	}{
+		{
+			name:         "known model",
+			model:        " GPT-TEST ",
+			inputTokens:  10,
+			outputTokens: 5,
+			want:         0.20,
+			wantOK:       true,
+		},
+		{
+			name:         "unknown model",
+			model:        "missing",
+			inputTokens:  10,
+			outputTokens: 5,
+			want:         0,
+			wantOK:       false,
+		},
+		{
+			name:         "negative tokens are ignored",
+			model:        "gpt-test",
+			inputTokens:  -10,
+			outputTokens: 5,
+			want:         0.10,
+			wantOK:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := UsageCostUSD(pricing, tt.model, tt.inputTokens, tt.outputTokens)
+			if ok != tt.wantOK {
+				t.Fatalf("UsageCostUSD() ok = %v, want %v", ok, tt.wantOK)
+			}
+			assertInDelta(t, got, tt.want)
+		})
+	}
+}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -78,7 +78,7 @@ func buildRunner(
 	}
 
 	pricing, err := budget.PricingForConfig(budget.Config{
-		PricingPath: cfg.Agent.Budget.PricingPath,
+		PricingPath: cfg.Budget.PricingPath,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("load pricing: %w", err)

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/symphony/internal/budget"
 	"github.com/digitaldrywood/symphony/internal/codex"
 	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
 	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
@@ -76,12 +77,20 @@ func buildRunner(
 		return nil, err
 	}
 
+	pricing, err := budget.PricingForConfig(budget.Config{
+		PricingPath: cfg.Agent.Budget.PricingPath,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("load pricing: %w", err)
+	}
+
 	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
 		ProjectID: projectID,
 		Workflow:  workflow,
 		Workspace: backend,
 		Codex:     codexClient,
 		Store:     sessionStore,
+		Pricing:   pricing,
 		Logger:    logger,
 	})
 	if err != nil {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -34,6 +35,23 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	}
 	if _, ok := run.(*runnerpkg.Runner); !ok {
 		t.Fatalf("buildRunner() = %T, want *runner.Runner", run)
+	}
+}
+
+func TestBuildRunnerUsesTopLevelPricingPath(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Workspace.Root = t.TempDir()
+	cfg.Budget.PricingPath = filepath.Join(t.TempDir(), "missing-models.yaml")
+
+	_, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", nil, nil)
+	if err == nil {
+		t.Fatal("buildRunner() error = nil, want pricing load error")
+	}
+	if !strings.Contains(err.Error(), "load pricing") {
+		t.Fatalf("buildRunner() error = %v, want load pricing error", err)
 	}
 }
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -13,6 +13,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/digitaldrywood/symphony/internal/budget"
 	"github.com/digitaldrywood/symphony/internal/codex"
 	"github.com/digitaldrywood/symphony/internal/config"
 	"github.com/digitaldrywood/symphony/internal/connector"
@@ -49,6 +50,7 @@ type Dependencies struct {
 	Workspace       workspace.Backend
 	Codex           CodexClient
 	Store           SessionStore
+	Pricing         budget.PricingTable
 	Now             func() time.Time
 	Logger          *slog.Logger
 	AfterRunTimeout time.Duration
@@ -61,6 +63,7 @@ type Runner struct {
 	workspace       workspace.Backend
 	codex           CodexClient
 	store           SessionStore
+	pricing         budget.PricingTable
 	now             func() time.Time
 	logger          *slog.Logger
 	afterRunTimeout time.Duration
@@ -93,6 +96,7 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		workspace:       deps.Workspace,
 		codex:           deps.Codex,
 		store:           deps.Store,
+		pricing:         deps.Pricing,
 		now:             deps.Now,
 		logger:          deps.Logger,
 		afterRunTimeout: deps.AfterRunTimeout,
@@ -307,6 +311,7 @@ func (r *Runner) finishSession(
 		InputTokens:    result.Tokens.InputTokens,
 		OutputTokens:   result.Tokens.OutputTokens,
 		TotalTokens:    result.Tokens.TotalTokens,
+		CostUSD:        r.usageCostUSD(model, result.Tokens.InputTokens, result.Tokens.OutputTokens),
 		RuntimeSeconds: int64(math.Round(result.Tokens.RuntimeSeconds)),
 		StartedAt:      startedAt,
 		FinishedAt:     finishedAt,
@@ -315,6 +320,15 @@ func (r *Runner) finishSession(
 		return fmt.Errorf("record usage event: %w", err)
 	}
 	return nil
+}
+
+func (r *Runner) usageCostUSD(model string, inputTokens int64, outputTokens int64) float64 {
+	cost, ok := budget.UsageCostUSD(r.pricing, model, inputTokens, outputTokens)
+	if !ok {
+		r.logger.Warn("usage event model pricing not found", "model", strings.TrimSpace(model))
+		return 0
+	}
+	return cost
 }
 
 func workspaceIssue(issue connector.Issue) workspace.Issue {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,14 +1,17 @@
 package runner
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/symphony/internal/budget"
 	"github.com/digitaldrywood/symphony/internal/codex"
 	"github.com/digitaldrywood/symphony/internal/config"
 	"github.com/digitaldrywood/symphony/internal/connector"
@@ -106,7 +109,13 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		Workspace: workspaceBackend,
 		Codex:     codexClient,
 		Store:     sessionStore,
-		Now:       now.Now,
+		Pricing: budget.PricingTable{
+			"gpt-5-codex-high": {
+				USDPerInputToken:  0.000004,
+				USDPerOutputToken: 0.00002,
+			},
+		},
+		Now: now.Now,
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
@@ -215,6 +224,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if sessionStore.usage.Model != "gpt-5-codex-high" || sessionStore.usage.TotalTokens != 125 {
 		t.Fatalf("UsageEvent totals = %#v, want model gpt-5-codex-high and total 125", sessionStore.usage)
 	}
+	if sessionStore.usage.CostUSD != 0.0009 {
+		t.Fatalf("UsageEvent CostUSD = %.12f, want 0.000900000000", sessionStore.usage.CostUSD)
+	}
 	if sessionStore.usage.PRNumber == nil || *sessionStore.usage.PRNumber != 133 {
 		t.Fatalf("UsageEvent PRNumber = %v, want 133", sessionStore.usage.PRNumber)
 	}
@@ -223,6 +235,24 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if sessionStore.usage.Outcome != FinalStateCompleted {
 		t.Fatalf("UsageEvent outcome = %q, want %q", sessionStore.usage.Outcome, FinalStateCompleted)
+	}
+}
+
+func TestRunnerUsageCostWarnsForUnknownModel(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	runner := &Runner{
+		pricing: budget.PricingTable{},
+		logger:  slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	cost := runner.usageCostUSD(" missing-model ", 10, 5)
+	if cost != 0 {
+		t.Fatalf("usageCostUSD() = %.12f, want 0", cost)
+	}
+	if got := logs.String(); !strings.Contains(got, "usage event model pricing not found") || !strings.Contains(got, "missing-model") {
+		t.Fatalf("log output = %q, want unknown pricing warning", got)
 	}
 }
 

--- a/internal/store/migrations/00004_add_usage_event_cost.sql
+++ b/internal/store/migrations/00004_add_usage_event_cost.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE usage_events
+ADD COLUMN cost_usd REAL NOT NULL DEFAULT 0.0;
+
+-- +goose Down
+ALTER TABLE usage_events
+DROP COLUMN cost_usd;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -63,4 +63,5 @@ type UsageEvent struct {
 	FinishedAt     string         `json:"finished_at"`
 	EventDay       string         `json:"event_day"`
 	Outcome        string         `json:"outcome"`
+	CostUsd        float64        `json:"cost_usd"`
 }

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -148,13 +148,14 @@ INSERT INTO usage_events (
   input_tokens,
   output_tokens,
   total_tokens,
+  cost_usd,
   runtime_seconds,
   started_at,
   finished_at,
   event_day,
   outcome
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome, cost_usd
 `
 
 type CreateUsageEventParams struct {
@@ -168,6 +169,7 @@ type CreateUsageEventParams struct {
 	InputTokens    int64          `json:"input_tokens"`
 	OutputTokens   int64          `json:"output_tokens"`
 	TotalTokens    int64          `json:"total_tokens"`
+	CostUsd        float64        `json:"cost_usd"`
 	RuntimeSeconds int64          `json:"runtime_seconds"`
 	StartedAt      string         `json:"started_at"`
 	FinishedAt     string         `json:"finished_at"`
@@ -187,6 +189,7 @@ func (q *Queries) CreateUsageEvent(ctx context.Context, arg CreateUsageEventPara
 		arg.InputTokens,
 		arg.OutputTokens,
 		arg.TotalTokens,
+		arg.CostUsd,
 		arg.RuntimeSeconds,
 		arg.StartedAt,
 		arg.FinishedAt,
@@ -211,6 +214,7 @@ func (q *Queries) CreateUsageEvent(ctx context.Context, arg CreateUsageEventPara
 		&i.FinishedAt,
 		&i.EventDay,
 		&i.Outcome,
+		&i.CostUsd,
 	)
 	return i, err
 }
@@ -361,7 +365,7 @@ func (q *Queries) GetSymphonyRun(ctx context.Context, id int64) (SymphonyRun, er
 }
 
 const getUsageEvent = `-- name: GetUsageEvent :one
-SELECT id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome
+SELECT id, project_id, run_id, session_id, issue_id, identifier, pr_number, model, input_tokens, output_tokens, total_tokens, runtime_seconds, started_at, finished_at, event_day, outcome, cost_usd
 FROM usage_events
 WHERE id = ?
 `
@@ -386,6 +390,7 @@ func (q *Queries) GetUsageEvent(ctx context.Context, id int64) (UsageEvent, erro
 		&i.FinishedAt,
 		&i.EventDay,
 		&i.Outcome,
+		&i.CostUsd,
 	)
 	return i, err
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -197,6 +197,7 @@ func (s *sqliteStore) RecordUsageEvent(ctx context.Context, attrs UsageEvent) (i
 		InputTokens:    nonNegative(attrs.InputTokens),
 		OutputTokens:   nonNegative(attrs.OutputTokens),
 		TotalTokens:    nonNegative(attrs.TotalTokens),
+		CostUsd:        nonNegativeFloat(attrs.CostUSD),
 		RuntimeSeconds: nonNegative(attrs.RuntimeSeconds),
 		StartedAt:      startedAt,
 		FinishedAt:     finishedAt,
@@ -395,6 +396,13 @@ func nullOptionalInt64(value *int64) sql.NullInt64 {
 }
 
 func nonNegative(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
+}
+
+func nonNegativeFloat(value float64) float64 {
 	if value < 0 {
 		return 0
 	}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -107,6 +107,7 @@ type UsageEvent struct {
 	InputTokens    int64
 	OutputTokens   int64
 	TotalTokens    int64
+	CostUSD        float64
 	RuntimeSeconds int64
 	StartedAt      time.Time
 	FinishedAt     time.Time

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -330,6 +330,7 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 				InputTokens:    123,
 				OutputTokens:   45,
 				TotalTokens:    168,
+				CostUSD:        0.00123,
 				RuntimeSeconds: 73,
 				StartedAt:      time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC),
 				FinishedAt:     time.Date(2026, 5, 31, 13, 1, 13, 0, time.UTC),
@@ -380,6 +381,9 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 			if got.InputTokens != 123 || got.OutputTokens != 45 || got.TotalTokens != 168 || got.RuntimeSeconds != 73 {
 				t.Fatalf("tokens/runtime = %d/%d/%d/%d", got.InputTokens, got.OutputTokens, got.TotalTokens, got.RuntimeSeconds)
 			}
+			if got.CostUsd != 0.00123 {
+				t.Fatalf("cost_usd = %.12f, want 0.001230000000", got.CostUsd)
+			}
 			if got.StartedAt != "2026-05-31T13:00:00Z" || got.FinishedAt != "2026-05-31T13:01:13Z" {
 				t.Fatalf("timestamps = %q/%q", got.StartedAt, got.FinishedAt)
 			}
@@ -413,6 +417,9 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 			}
 			if persisted.TotalTokens != 168 {
 				t.Fatalf("persisted total_tokens = %d, want 168", persisted.TotalTokens)
+			}
+			if persisted.CostUsd != 0.00123 {
+				t.Fatalf("persisted cost_usd = %.12f, want 0.001230000000", persisted.CostUsd)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- add `cost_usd` to usage ledger rows and sqlc inserts
- compute usage-event cost from budget pricing before ledger writes
- warn and store zero cost when model pricing is unknown

Fixes #118

## Test Plan

- [x] `go test ./internal/budget ./internal/store ./internal/runner ./internal/cli ./internal/orchestrator`
- [x] `make generate`
- [x] `make check`