### PR TITLE
feat(web): add usage reports API

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -128,7 +128,7 @@ WITH usage_report_rows AS (
       WHEN sqlc.arg(bucket_by) = 'day' THEN event_day
       WHEN sqlc.arg(bucket_by) = 'project' THEN project_id
       WHEN sqlc.arg(bucket_by) = 'issue' THEN COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), 'unassigned')
-      WHEN sqlc.arg(bucket_by) = 'pr' THEN COALESCE(CAST(pr_number AS TEXT), 'unassigned')
+      WHEN sqlc.arg(bucket_by) = 'pr' THEN project_id || '#' || COALESCE(CAST(pr_number AS TEXT), 'unassigned')
       WHEN sqlc.arg(bucket_by) = 'model' THEN COALESCE(NULLIF(model, ''), 'unassigned')
       ELSE event_day
     END AS group_key,

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -121,6 +121,38 @@ SELECT *
 FROM usage_events
 WHERE id = ?;
 
+-- name: UsageReportRows :many
+WITH usage_report_rows AS (
+  SELECT
+    CASE
+      WHEN sqlc.arg(bucket_by) = 'day' THEN event_day
+      WHEN sqlc.arg(bucket_by) = 'project' THEN project_id
+      WHEN sqlc.arg(bucket_by) = 'issue' THEN COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), 'unassigned')
+      WHEN sqlc.arg(bucket_by) = 'pr' THEN COALESCE(CAST(pr_number AS TEXT), 'unassigned')
+      WHEN sqlc.arg(bucket_by) = 'model' THEN COALESCE(NULLIF(model, ''), 'unassigned')
+      ELSE event_day
+    END AS group_key,
+    COALESCE(NULLIF(model, ''), 'unassigned') AS model,
+    input_tokens,
+    output_tokens,
+    total_tokens,
+    runtime_seconds
+  FROM usage_events
+  WHERE (sqlc.narg(from_day) IS NULL OR event_day >= sqlc.narg(from_day))
+    AND (sqlc.narg(to_day) IS NULL OR event_day <= sqlc.narg(to_day))
+)
+SELECT
+  CAST(usage_report_rows.group_key AS TEXT) AS group_key,
+  CAST(usage_report_rows.model AS TEXT) AS model,
+  CAST(COALESCE(SUM(usage_report_rows.input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(usage_report_rows.output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(usage_report_rows.total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COALESCE(SUM(usage_report_rows.runtime_seconds), 0) AS INTEGER) AS runtime_seconds,
+  CAST(COUNT(*) AS INTEGER) AS events
+FROM usage_report_rows
+GROUP BY usage_report_rows.group_key, usage_report_rows.model
+ORDER BY usage_report_rows.group_key, usage_report_rows.model;
+
 -- name: ListFairShareUsage :many
 SELECT
   project_id,

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -624,7 +624,7 @@ WITH usage_report_rows AS (
       WHEN ?1 = 'day' THEN event_day
       WHEN ?1 = 'project' THEN project_id
       WHEN ?1 = 'issue' THEN COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), 'unassigned')
-      WHEN ?1 = 'pr' THEN COALESCE(CAST(pr_number AS TEXT), 'unassigned')
+      WHEN ?1 = 'pr' THEN project_id || '#' || COALESCE(CAST(pr_number AS TEXT), 'unassigned')
       WHEN ?1 = 'model' THEN COALESCE(NULLIF(model, ''), 'unassigned')
       ELSE event_day
     END AS group_key,

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -616,3 +616,83 @@ func (q *Queries) UpsertFairShareUsage(ctx context.Context, arg UpsertFairShareU
 	)
 	return i, err
 }
+
+const usageReportRows = `-- name: UsageReportRows :many
+WITH usage_report_rows AS (
+  SELECT
+    CASE
+      WHEN ?1 = 'day' THEN event_day
+      WHEN ?1 = 'project' THEN project_id
+      WHEN ?1 = 'issue' THEN COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), 'unassigned')
+      WHEN ?1 = 'pr' THEN COALESCE(CAST(pr_number AS TEXT), 'unassigned')
+      WHEN ?1 = 'model' THEN COALESCE(NULLIF(model, ''), 'unassigned')
+      ELSE event_day
+    END AS group_key,
+    COALESCE(NULLIF(model, ''), 'unassigned') AS model,
+    input_tokens,
+    output_tokens,
+    total_tokens,
+    runtime_seconds
+  FROM usage_events
+  WHERE (?2 IS NULL OR event_day >= ?2)
+    AND (?3 IS NULL OR event_day <= ?3)
+)
+SELECT
+  CAST(usage_report_rows.group_key AS TEXT) AS group_key,
+  CAST(usage_report_rows.model AS TEXT) AS model,
+  CAST(COALESCE(SUM(usage_report_rows.input_tokens), 0) AS INTEGER) AS input_tokens,
+  CAST(COALESCE(SUM(usage_report_rows.output_tokens), 0) AS INTEGER) AS output_tokens,
+  CAST(COALESCE(SUM(usage_report_rows.total_tokens), 0) AS INTEGER) AS total_tokens,
+  CAST(COALESCE(SUM(usage_report_rows.runtime_seconds), 0) AS INTEGER) AS runtime_seconds,
+  CAST(COUNT(*) AS INTEGER) AS events
+FROM usage_report_rows
+GROUP BY usage_report_rows.group_key, usage_report_rows.model
+ORDER BY usage_report_rows.group_key, usage_report_rows.model
+`
+
+type UsageReportRowsParams struct {
+	BucketBy interface{} `json:"bucket_by"`
+	FromDay  interface{} `json:"from_day"`
+	ToDay    interface{} `json:"to_day"`
+}
+
+type UsageReportRowsRow struct {
+	GroupKey       string `json:"group_key"`
+	Model          string `json:"model"`
+	InputTokens    int64  `json:"input_tokens"`
+	OutputTokens   int64  `json:"output_tokens"`
+	TotalTokens    int64  `json:"total_tokens"`
+	RuntimeSeconds int64  `json:"runtime_seconds"`
+	Events         int64  `json:"events"`
+}
+
+func (q *Queries) UsageReportRows(ctx context.Context, arg UsageReportRowsParams) ([]UsageReportRowsRow, error) {
+	rows, err := q.db.QueryContext(ctx, usageReportRows, arg.BucketBy, arg.FromDay, arg.ToDay)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []UsageReportRowsRow{}
+	for rows.Next() {
+		var i UsageReportRowsRow
+		if err := rows.Scan(
+			&i.GroupKey,
+			&i.Model,
+			&i.InputTokens,
+			&i.OutputTokens,
+			&i.TotalTokens,
+			&i.RuntimeSeconds,
+			&i.Events,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -209,6 +209,102 @@ func (s *sqliteStore) RecordUsageEvent(ctx context.Context, attrs UsageEvent) (i
 	return event.ID, nil
 }
 
+func (s *sqliteStore) UsageReport(ctx context.Context, query UsageReportQuery) (UsageReport, error) {
+	group, err := normalizeUsageReportGroup(query.By)
+	if err != nil {
+		return UsageReport{}, err
+	}
+	from, err := optionalDateString(query.From)
+	if err != nil {
+		return UsageReport{}, err
+	}
+	to, err := optionalDateString(query.To)
+	if err != nil {
+		return UsageReport{}, err
+	}
+	if from != "" && to != "" && from > to {
+		return UsageReport{}, errors.New("from date must be on or before to date")
+	}
+
+	rows, err := s.queries.UsageReportRows(ctx, sqlc.UsageReportRowsParams{
+		BucketBy: string(group),
+		FromDay:  nullString(from),
+		ToDay:    nullString(to),
+	})
+	if err != nil {
+		return UsageReport{}, fmt.Errorf("reading usage report: %w", err)
+	}
+
+	report := UsageReport{
+		By:   group,
+		From: from,
+		To:   to,
+		Rows: []UsageReportRow{},
+		Totals: UsageReportTotals{
+			Models: []UsageReportModel{},
+		},
+	}
+	rowByKey := map[string]int{}
+	modelTotals := map[string]int{}
+	for _, row := range rows {
+		key := row.GroupKey
+		if key == "" {
+			key = "unassigned"
+		}
+
+		index, ok := rowByKey[key]
+		if !ok {
+			report.Rows = append(report.Rows, UsageReportRow{
+				Key:    key,
+				Models: []UsageReportModel{},
+			})
+			index = len(report.Rows) - 1
+			rowByKey[key] = index
+		}
+
+		model := UsageReportModel{
+			Model:          row.Model,
+			InputTokens:    row.InputTokens,
+			OutputTokens:   row.OutputTokens,
+			TotalTokens:    row.TotalTokens,
+			RuntimeSeconds: row.RuntimeSeconds,
+			Events:         row.Events,
+		}
+		if model.Model == "" {
+			model.Model = "unassigned"
+		}
+
+		report.Rows[index].InputTokens += model.InputTokens
+		report.Rows[index].OutputTokens += model.OutputTokens
+		report.Rows[index].TotalTokens += model.TotalTokens
+		report.Rows[index].RuntimeSeconds += model.RuntimeSeconds
+		report.Rows[index].Events += model.Events
+		report.Rows[index].Models = append(report.Rows[index].Models, model)
+
+		report.Totals.InputTokens += model.InputTokens
+		report.Totals.OutputTokens += model.OutputTokens
+		report.Totals.TotalTokens += model.TotalTokens
+		report.Totals.RuntimeSeconds += model.RuntimeSeconds
+		report.Totals.Events += model.Events
+
+		modelIndex, ok := modelTotals[model.Model]
+		if !ok {
+			report.Totals.Models = append(report.Totals.Models, UsageReportModel{
+				Model: model.Model,
+			})
+			modelIndex = len(report.Totals.Models) - 1
+			modelTotals[model.Model] = modelIndex
+		}
+		report.Totals.Models[modelIndex].InputTokens += model.InputTokens
+		report.Totals.Models[modelIndex].OutputTokens += model.OutputTokens
+		report.Totals.Models[modelIndex].TotalTokens += model.TotalTokens
+		report.Totals.Models[modelIndex].RuntimeSeconds += model.RuntimeSeconds
+		report.Totals.Models[modelIndex].Events += model.Events
+	}
+
+	return report, nil
+}
+
 func (s *sqliteStore) DailyTokenSpend(ctx context.Context, day time.Time) (TokenSpend, error) {
 	date, err := dateString(day)
 	if err != nil {
@@ -330,6 +426,17 @@ func normalizeIssueIdentity(identity IssueIdentity) IssueIdentity {
 	}
 }
 
+func normalizeUsageReportGroup(group UsageReportGroup) (UsageReportGroup, error) {
+	switch group {
+	case "", UsageReportByDay:
+		return UsageReportByDay, nil
+	case UsageReportByProject, UsageReportByIssue, UsageReportByPR, UsageReportByModel:
+		return group, nil
+	default:
+		return "", fmt.Errorf("unsupported usage report group %q", group)
+	}
+}
+
 func configureSQLite(ctx context.Context, db *sql.DB, busyTimeoutMillis int64) error {
 	if _, err := db.ExecContext(ctx, fmt.Sprintf("PRAGMA busy_timeout = %d", busyTimeoutMillis)); err != nil {
 		return fmt.Errorf("setting sqlite busy_timeout: %w", err)
@@ -358,6 +465,13 @@ func dateString(value time.Time) (string, error) {
 		return "", errors.New("date is required")
 	}
 	return value.Format("2006-01-02"), nil
+}
+
+func optionalDateString(value time.Time) (string, error) {
+	if value.IsZero() {
+		return "", nil
+	}
+	return dateString(value)
 }
 
 func parseTimestamp(name string, value string) (time.Time, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,6 +37,7 @@ type StatsStore interface {
 	StartSession(context.Context, SessionStart) (int64, error)
 	FinishSession(context.Context, int64, SessionFinish) error
 	RecordUsageEvent(context.Context, UsageEvent) (int64, error)
+	UsageReport(context.Context, UsageReportQuery) (UsageReport, error)
 	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
 	IssueTokenSpend(context.Context, IssueIdentity) (TokenSpend, error)
 }
@@ -111,6 +112,58 @@ type UsageEvent struct {
 	StartedAt      time.Time
 	FinishedAt     time.Time
 	Outcome        string
+}
+
+type UsageReportGroup string
+
+const (
+	UsageReportByDay     UsageReportGroup = "day"
+	UsageReportByProject UsageReportGroup = "project"
+	UsageReportByIssue   UsageReportGroup = "issue"
+	UsageReportByPR      UsageReportGroup = "pr"
+	UsageReportByModel   UsageReportGroup = "model"
+)
+
+type UsageReportQuery struct {
+	By   UsageReportGroup
+	From time.Time
+	To   time.Time
+}
+
+type UsageReport struct {
+	By     UsageReportGroup
+	From   string
+	To     string
+	Totals UsageReportTotals
+	Rows   []UsageReportRow
+}
+
+type UsageReportTotals struct {
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	RuntimeSeconds int64
+	Events         int64
+	Models         []UsageReportModel
+}
+
+type UsageReportRow struct {
+	Key            string
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	RuntimeSeconds int64
+	Events         int64
+	Models         []UsageReportModel
+}
+
+type UsageReportModel struct {
+	Model          string
+	InputTokens    int64
+	OutputTokens   int64
+	TotalTokens    int64
+	RuntimeSeconds int64
+	Events         int64
 }
 
 type IssueIdentity struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -418,6 +418,167 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 	}
 }
 
+func TestUsageReportAggregates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	seedUsageReportEvents(t, ctx, backend)
+
+	tests := []struct {
+		name  string
+		query UsageReportQuery
+		want  []UsageReportRow
+	}{
+		{
+			name:  "by day with inclusive range",
+			query: UsageReportQuery{By: UsageReportByDay, From: dateOnly(2026, 5, 31), To: dateOnly(2026, 6, 1)},
+			want: []UsageReportRow{
+				{
+					Key:            "2026-05-31",
+					InputTokens:    150,
+					OutputTokens:   75,
+					TotalTokens:    225,
+					RuntimeSeconds: 45,
+					Events:         2,
+				},
+				{
+					Key:            "2026-06-01",
+					InputTokens:    70,
+					OutputTokens:   30,
+					TotalTokens:    100,
+					RuntimeSeconds: 25,
+					Events:         1,
+				},
+			},
+		},
+		{
+			name:  "by project",
+			query: UsageReportQuery{By: UsageReportByProject, From: dateOnly(2026, 5, 31), To: dateOnly(2026, 6, 1)},
+			want: []UsageReportRow{
+				{
+					Key:            "symphony",
+					InputTokens:    220,
+					OutputTokens:   105,
+					TotalTokens:    325,
+					RuntimeSeconds: 70,
+					Events:         3,
+				},
+			},
+		},
+		{
+			name:  "by issue",
+			query: UsageReportQuery{By: UsageReportByIssue},
+			want: []UsageReportRow{
+				{
+					Key:            "digitaldrywood/symphony#117",
+					InputTokens:    100,
+					OutputTokens:   50,
+					TotalTokens:    150,
+					RuntimeSeconds: 30,
+					Events:         1,
+				},
+				{
+					Key:            "digitaldrywood/symphony#119",
+					InputTokens:    120,
+					OutputTokens:   55,
+					TotalTokens:    175,
+					RuntimeSeconds: 40,
+					Events:         2,
+				},
+				{
+					Key:            "unassigned",
+					InputTokens:    5,
+					OutputTokens:   2,
+					TotalTokens:    7,
+					RuntimeSeconds: 3,
+					Events:         1,
+				},
+			},
+		},
+		{
+			name:  "by PR",
+			query: UsageReportQuery{By: UsageReportByPR},
+			want: []UsageReportRow{
+				{
+					Key:            "133",
+					InputTokens:    100,
+					OutputTokens:   50,
+					TotalTokens:    150,
+					RuntimeSeconds: 30,
+					Events:         1,
+				},
+				{
+					Key:            "141",
+					InputTokens:    120,
+					OutputTokens:   55,
+					TotalTokens:    175,
+					RuntimeSeconds: 40,
+					Events:         2,
+				},
+				{
+					Key:            "unassigned",
+					InputTokens:    5,
+					OutputTokens:   2,
+					TotalTokens:    7,
+					RuntimeSeconds: 3,
+					Events:         1,
+				},
+			},
+		},
+		{
+			name:  "by model",
+			query: UsageReportQuery{By: UsageReportByModel, From: dateOnly(2026, 5, 31), To: dateOnly(2026, 6, 1)},
+			want: []UsageReportRow{
+				{
+					Key:            "gpt-5.4",
+					InputTokens:    150,
+					OutputTokens:   75,
+					TotalTokens:    225,
+					RuntimeSeconds: 45,
+					Events:         2,
+				},
+				{
+					Key:            "gpt-5.4-mini",
+					InputTokens:    70,
+					OutputTokens:   30,
+					TotalTokens:    100,
+					RuntimeSeconds: 25,
+					Events:         1,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			report, err := backend.UsageReport(ctx, tt.query)
+			if err != nil {
+				t.Fatalf("UsageReport() error = %v", err)
+			}
+			assertUsageRows(t, report.Rows, tt.want)
+		})
+	}
+}
+
+func TestUsageReportRejectsInvalidRange(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+
+	_, err := backend.UsageReport(ctx, UsageReportQuery{
+		By:   UsageReportByDay,
+		From: dateOnly(2026, 6, 2),
+		To:   dateOnly(2026, 6, 1),
+	})
+	if err == nil {
+		t.Fatal("UsageReport() error = nil, want invalid date range")
+	}
+}
+
 func TestOpenRejectsUnsupportedBackend(t *testing.T) {
 	t.Parallel()
 
@@ -508,6 +669,94 @@ func openTestStore(t *testing.T, ctx context.Context) Store {
 		}
 	})
 	return backend
+}
+
+func seedUsageReportEvents(t *testing.T, ctx context.Context, backend Store) {
+	t.Helper()
+
+	events := []UsageEvent{
+		{
+			ProjectID:      "symphony",
+			IssueID:        "issue-117",
+			Identifier:     "digitaldrywood/symphony#117",
+			PRNumber:       int64Ptr(133),
+			Model:          "gpt-5.4",
+			InputTokens:    100,
+			OutputTokens:   50,
+			TotalTokens:    150,
+			RuntimeSeconds: 30,
+			StartedAt:      time.Date(2026, 5, 31, 9, 0, 0, 0, time.UTC),
+			FinishedAt:     time.Date(2026, 5, 31, 9, 1, 0, 0, time.UTC),
+			Outcome:        "completed",
+		},
+		{
+			ProjectID:      "symphony",
+			IssueID:        "issue-119",
+			Identifier:     "digitaldrywood/symphony#119",
+			PRNumber:       int64Ptr(141),
+			Model:          "gpt-5.4",
+			InputTokens:    50,
+			OutputTokens:   25,
+			TotalTokens:    75,
+			RuntimeSeconds: 15,
+			StartedAt:      time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC),
+			FinishedAt:     time.Date(2026, 5, 31, 10, 1, 0, 0, time.UTC),
+			Outcome:        "completed",
+		},
+		{
+			ProjectID:      "symphony",
+			IssueID:        "issue-119",
+			Identifier:     "digitaldrywood/symphony#119",
+			PRNumber:       int64Ptr(141),
+			Model:          "gpt-5.4-mini",
+			InputTokens:    70,
+			OutputTokens:   30,
+			TotalTokens:    100,
+			RuntimeSeconds: 25,
+			StartedAt:      time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC),
+			FinishedAt:     time.Date(2026, 6, 1, 11, 1, 0, 0, time.UTC),
+			Outcome:        "completed",
+		},
+		{
+			ProjectID:      "pyroapex",
+			Model:          "",
+			InputTokens:    5,
+			OutputTokens:   2,
+			TotalTokens:    7,
+			RuntimeSeconds: 3,
+			StartedAt:      time.Date(2026, 6, 2, 12, 0, 0, 0, time.UTC),
+			FinishedAt:     time.Date(2026, 6, 2, 12, 1, 0, 0, time.UTC),
+			Outcome:        "completed",
+		},
+	}
+
+	for _, event := range events {
+		if _, err := backend.RecordUsageEvent(ctx, event); err != nil {
+			t.Fatalf("RecordUsageEvent() error = %v", err)
+		}
+	}
+}
+
+func assertUsageRows(t *testing.T, got []UsageReportRow, want []UsageReportRow) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("rows len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i].Key != want[i].Key ||
+			got[i].InputTokens != want[i].InputTokens ||
+			got[i].OutputTokens != want[i].OutputTokens ||
+			got[i].TotalTokens != want[i].TotalTokens ||
+			got[i].RuntimeSeconds != want[i].RuntimeSeconds ||
+			got[i].Events != want[i].Events {
+			t.Fatalf("row %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
+func dateOnly(year int, month time.Month, day int) time.Time {
+	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
 }
 
 func queryString(t *testing.T, db *sql.DB, query string) string {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -501,7 +501,15 @@ func TestUsageReportAggregates(t *testing.T) {
 			query: UsageReportQuery{By: UsageReportByPR},
 			want: []UsageReportRow{
 				{
-					Key:            "133",
+					Key:            "pyroapex#141",
+					InputTokens:    5,
+					OutputTokens:   2,
+					TotalTokens:    7,
+					RuntimeSeconds: 3,
+					Events:         1,
+				},
+				{
+					Key:            "symphony#133",
 					InputTokens:    100,
 					OutputTokens:   50,
 					TotalTokens:    150,
@@ -509,20 +517,12 @@ func TestUsageReportAggregates(t *testing.T) {
 					Events:         1,
 				},
 				{
-					Key:            "141",
+					Key:            "symphony#141",
 					InputTokens:    120,
 					OutputTokens:   55,
 					TotalTokens:    175,
 					RuntimeSeconds: 40,
 					Events:         2,
-				},
-				{
-					Key:            "unassigned",
-					InputTokens:    5,
-					OutputTokens:   2,
-					TotalTokens:    7,
-					RuntimeSeconds: 3,
-					Events:         1,
 				},
 			},
 		},
@@ -719,6 +719,7 @@ func seedUsageReportEvents(t *testing.T, ctx context.Context, backend Store) {
 		},
 		{
 			ProjectID:      "pyroapex",
+			PRNumber:       int64Ptr(141),
 			Model:          "",
 			InputTokens:    5,
 			OutputTokens:   2,

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -10,7 +10,9 @@ import (
 
 	"github.com/labstack/echo/v4"
 
+	"github.com/digitaldrywood/symphony/internal/budget"
 	"github.com/digitaldrywood/symphony/internal/orchestrator"
+	"github.com/digitaldrywood/symphony/internal/store"
 	"github.com/digitaldrywood/symphony/internal/telemetry"
 )
 
@@ -63,6 +65,21 @@ func (s *Server) apiRefresh(c echo.Context) error {
 	}
 
 	return c.JSON(http.StatusAccepted, payload)
+}
+
+func (s *Server) apiUsage(c echo.Context) error {
+	query, response, status := usageReportQuery(c)
+	if response != nil {
+		return c.JSON(status, response)
+	}
+
+	report, err := s.store.UsageReport(c.Request().Context(), query)
+	if err != nil {
+		s.logger.Error("usage report failed", slog.Any("error", err))
+		return c.JSON(http.StatusInternalServerError, errorResponse("usage_report_failed", "Usage report failed"))
+	}
+
+	return c.JSON(http.StatusOK, usageReportResponse(report, s.pricing))
 }
 
 func (s *Server) methodNotAllowed(c echo.Context) error {
@@ -400,6 +417,157 @@ func budgetResponse(budget telemetry.Budget) budgetAPIResponse {
 	}
 }
 
+func usageReportQuery(c echo.Context) (store.UsageReportQuery, *apiErrorResponse, int) {
+	group, ok := usageReportGroup(c.QueryParam("by"))
+	if !ok {
+		response := errorResponse("invalid_usage_group", "by must be one of day, project, issue, pr, model")
+		return store.UsageReportQuery{}, &response, http.StatusBadRequest
+	}
+
+	from, response, status := usageDate("from", c.QueryParam("from"))
+	if response != nil {
+		return store.UsageReportQuery{}, response, status
+	}
+	to, response, status := usageDate("to", c.QueryParam("to"))
+	if response != nil {
+		return store.UsageReportQuery{}, response, status
+	}
+	if !from.IsZero() && !to.IsZero() && from.After(to) {
+		response := errorResponse("invalid_date_range", "from must be on or before to")
+		return store.UsageReportQuery{}, &response, http.StatusBadRequest
+	}
+
+	return store.UsageReportQuery{
+		By:   group,
+		From: from,
+		To:   to,
+	}, nil, 0
+}
+
+func usageReportGroup(value string) (store.UsageReportGroup, bool) {
+	switch strings.TrimSpace(value) {
+	case "", string(store.UsageReportByDay):
+		return store.UsageReportByDay, true
+	case string(store.UsageReportByProject):
+		return store.UsageReportByProject, true
+	case string(store.UsageReportByIssue):
+		return store.UsageReportByIssue, true
+	case string(store.UsageReportByPR):
+		return store.UsageReportByPR, true
+	case string(store.UsageReportByModel):
+		return store.UsageReportByModel, true
+	default:
+		return "", false
+	}
+}
+
+func usageDate(name string, value string) (time.Time, *apiErrorResponse, int) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, nil, 0
+	}
+
+	parsed, err := time.ParseInLocation("2006-01-02", value, time.UTC)
+	if err != nil {
+		response := errorResponse("invalid_date", name+" must use YYYY-MM-DD")
+		return time.Time{}, &response, http.StatusBadRequest
+	}
+	return parsed, nil, 0
+}
+
+func usageReportResponse(report store.UsageReport, pricing budget.PricingTable) usageReportAPIResponse {
+	rows := usageBucketResponses(report.By, report.Rows, pricing)
+	response := usageReportAPIResponse{
+		By:         string(report.By),
+		From:       optionalString(report.From),
+		To:         optionalString(report.To),
+		Totals:     usageTotalsResponse(report.Totals, pricing),
+		Series:     []usageBucketAPIResponse{},
+		Breakdowns: []usageBucketAPIResponse{},
+	}
+	if report.By == store.UsageReportByDay {
+		response.Series = rows
+		return response
+	}
+
+	response.Breakdowns = rows
+	return response
+}
+
+func usageBucketResponses(group store.UsageReportGroup, rows []store.UsageReportRow, pricing budget.PricingTable) []usageBucketAPIResponse {
+	payload := make([]usageBucketAPIResponse, 0, len(rows))
+	for _, row := range rows {
+		payload = append(payload, usageBucketResponse(group, row, pricing))
+	}
+	return payload
+}
+
+func usageBucketResponse(group store.UsageReportGroup, row store.UsageReportRow, pricing budget.PricingTable) usageBucketAPIResponse {
+	return usageBucketAPIResponse{
+		Bucket:         row.Key,
+		Label:          row.Key,
+		Date:           usageBucketDate(group, row.Key),
+		InputTokens:    row.InputTokens,
+		OutputTokens:   row.OutputTokens,
+		TotalTokens:    row.TotalTokens,
+		RuntimeSeconds: row.RuntimeSeconds,
+		Events:         row.Events,
+		SpendUSD:       usageSpendUSD(row.Models, pricing),
+		Models:         usageModelResponses(row.Models, pricing),
+	}
+}
+
+func usageTotalsResponse(totals store.UsageReportTotals, pricing budget.PricingTable) usageTotalsAPIResponse {
+	return usageTotalsAPIResponse{
+		InputTokens:    totals.InputTokens,
+		OutputTokens:   totals.OutputTokens,
+		TotalTokens:    totals.TotalTokens,
+		RuntimeSeconds: totals.RuntimeSeconds,
+		Events:         totals.Events,
+		SpendUSD:       usageSpendUSD(totals.Models, pricing),
+		Models:         usageModelResponses(totals.Models, pricing),
+	}
+}
+
+func usageModelResponses(models []store.UsageReportModel, pricing budget.PricingTable) []usageModelAPIResponse {
+	payload := make([]usageModelAPIResponse, 0, len(models))
+	for _, model := range models {
+		payload = append(payload, usageModelAPIResponse{
+			Model:          model.Model,
+			InputTokens:    model.InputTokens,
+			OutputTokens:   model.OutputTokens,
+			TotalTokens:    model.TotalTokens,
+			RuntimeSeconds: model.RuntimeSeconds,
+			Events:         model.Events,
+			SpendUSD:       usageSpendUSD([]store.UsageReportModel{model}, pricing),
+		})
+	}
+	return payload
+}
+
+func usageSpendUSD(models []store.UsageReportModel, pricing budget.PricingTable) float64 {
+	spend := store.TokenSpend{
+		ByModel: make([]store.ModelTokenSpend, 0, len(models)),
+	}
+	for _, model := range models {
+		spend.ByModel = append(spend.ByModel, store.ModelTokenSpend{
+			Model:        model.Model,
+			InputTokens:  model.InputTokens,
+			OutputTokens: model.OutputTokens,
+			TotalTokens:  model.TotalTokens,
+			Sessions:     model.Events,
+		})
+	}
+	return budget.SpendUSD(spend, pricing)
+}
+
+func usageBucketDate(group store.UsageReportGroup, key string) *string {
+	if group != store.UsageReportByDay {
+		return nil
+	}
+	return optionalString(key)
+}
+
 func dueAtString(entry telemetry.Queued) *string {
 	if entry.DueAt != nil {
 		return timestampStringPtr(entry.DueAt)
@@ -622,6 +790,48 @@ type budgetAPIResponse struct {
 	PerIssueMaxUSD   *float64                  `json:"per_issue_max_usd"`
 	Days             []telemetry.BudgetDay     `json:"days"`
 	Refusals         []telemetry.BudgetRefusal `json:"refusals,omitempty"`
+}
+
+type usageReportAPIResponse struct {
+	By         string                   `json:"by"`
+	From       *string                  `json:"from"`
+	To         *string                  `json:"to"`
+	Totals     usageTotalsAPIResponse   `json:"totals"`
+	Series     []usageBucketAPIResponse `json:"series"`
+	Breakdowns []usageBucketAPIResponse `json:"breakdowns"`
+}
+
+type usageTotalsAPIResponse struct {
+	InputTokens    int64                   `json:"input_tokens"`
+	OutputTokens   int64                   `json:"output_tokens"`
+	TotalTokens    int64                   `json:"total_tokens"`
+	RuntimeSeconds int64                   `json:"runtime_seconds"`
+	Events         int64                   `json:"events"`
+	SpendUSD       float64                 `json:"spend_usd"`
+	Models         []usageModelAPIResponse `json:"models"`
+}
+
+type usageBucketAPIResponse struct {
+	Bucket         string                  `json:"bucket"`
+	Label          string                  `json:"label"`
+	Date           *string                 `json:"date"`
+	InputTokens    int64                   `json:"input_tokens"`
+	OutputTokens   int64                   `json:"output_tokens"`
+	TotalTokens    int64                   `json:"total_tokens"`
+	RuntimeSeconds int64                   `json:"runtime_seconds"`
+	Events         int64                   `json:"events"`
+	SpendUSD       float64                 `json:"spend_usd"`
+	Models         []usageModelAPIResponse `json:"models"`
+}
+
+type usageModelAPIResponse struct {
+	Model          string  `json:"model"`
+	InputTokens    int64   `json:"input_tokens"`
+	OutputTokens   int64   `json:"output_tokens"`
+	TotalTokens    int64   `json:"total_tokens"`
+	RuntimeSeconds int64   `json:"runtime_seconds"`
+	Events         int64   `json:"events"`
+	SpendUSD       float64 `json:"spend_usd"`
 }
 
 type issueAPIResponse struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	symphony "github.com/digitaldrywood/symphony"
+	"github.com/digitaldrywood/symphony/internal/budget"
 	"github.com/digitaldrywood/symphony/internal/connector"
 	"github.com/digitaldrywood/symphony/internal/hub"
 	"github.com/digitaldrywood/symphony/internal/store"
@@ -50,6 +51,7 @@ type Config struct {
 	WorkflowPath    string
 	Version         string
 	DashboardURL    string
+	Pricing         budget.PricingTable
 }
 
 type Server struct {
@@ -65,6 +67,7 @@ type Server struct {
 	workflow     string
 	version      string
 	dashboardURL string
+	pricing      budget.PricingTable
 }
 
 func NewServer(cfg Config, deps Dependencies) (*Server, error) {
@@ -101,6 +104,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		workflow:     cfg.workflowPath(),
 		version:      strings.TrimSpace(cfg.Version),
 		dashboardURL: cfg.dashboardURL(),
+		pricing:      cfg.pricing(),
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
 	server.registerRoutes(cfg.staticDir())
@@ -160,6 +164,7 @@ func (s *Server) registerRoutes(staticDir string) {
 	s.echo.GET("/api/v1/state", s.apiState)
 	s.echo.POST("/api/v1/refresh", s.apiRefresh)
 	s.echo.GET("/api/v1/refresh", s.methodNotAllowed)
+	s.echo.GET("/api/v1/usage", s.apiUsage)
 	s.echo.GET("/api/v1/*", s.apiIssue)
 }
 
@@ -254,6 +259,13 @@ func (cfg Config) dashboardURL() string {
 		return dashboardURL
 	}
 	return "http://localhost:4000"
+}
+
+func (cfg Config) pricing() budget.PricingTable {
+	if cfg.Pricing != nil {
+		return cfg.Pricing
+	}
+	return budget.DefaultPricingTable()
 }
 
 func configuredStatus(value any) string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -993,7 +993,7 @@ func TestServerUsageAPIReportsAggregates(t *testing.T) {
 		wantBucket string
 	}{
 		{name: "issue", path: "/api/v1/usage?by=issue", wantBucket: "digitaldrywood/symphony#119"},
-		{name: "pr", path: "/api/v1/usage?by=pr", wantBucket: "141"},
+		{name: "pr", path: "/api/v1/usage?by=pr", wantBucket: "symphony#141"},
 		{name: "model", path: "/api/v1/usage?by=model", wantBucket: "gpt-report"},
 	}
 
@@ -1107,6 +1107,7 @@ func seedUsageAPIEvents(t *testing.T, ctx context.Context, backend store.Store) 
 			ProjectID:      "pyroapex",
 			IssueID:        "issue-119",
 			Identifier:     "digitaldrywood/symphony#119",
+			PRNumber:       int64Ptr(141),
 			Model:          "gpt-report",
 			InputTokens:    70,
 			OutputTokens:   30,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -15,6 +15,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/symphony/internal/budget"
 	"github.com/digitaldrywood/symphony/internal/connector"
 	"github.com/digitaldrywood/symphony/internal/hub"
 	"github.com/digitaldrywood/symphony/internal/store"
@@ -921,6 +922,126 @@ func TestServerAPIErrorRoutes(t *testing.T) {
 	}
 }
 
+func TestServerUsageAPIReportsAggregates(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	usageStore, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "symphony.db"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := usageStore.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	seedUsageAPIEvents(t, ctx, usageStore)
+
+	deps := testDeps(t)
+	deps.Store = usageStore
+	server, err := web.NewServer(web.Config{
+		Pricing: budget.PricingTable{
+			"gpt-report": {
+				USDPerInputToken:  0.01,
+				USDPerOutputToken: 0.02,
+			},
+			"gpt-report-mini": {
+				USDPerInputToken:  0.001,
+				USDPerOutputToken: 0.002,
+			},
+		},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	day := requestJSON(t, server, http.MethodGet, "/api/v1/usage?by=day&from=2026-05-31&to=2026-05-31", http.StatusOK)
+	if day["by"] != "day" {
+		t.Fatalf("by = %#v, want day", day["by"])
+	}
+	if got := nestedString(t, day, "totals", "total_tokens"); got != "225" {
+		t.Fatalf("totals.total_tokens = %s, want 225", got)
+	}
+	if got := nestedString(t, day, "totals", "spend_usd"); got != "2.1" {
+		t.Fatalf("totals.spend_usd = %s, want 2.1", got)
+	}
+	series := day["series"].([]any)
+	if len(series) != 1 {
+		t.Fatalf("series len = %d, want 1: %#v", len(series), series)
+	}
+	point := series[0].(map[string]any)
+	if point["bucket"] != "2026-05-31" || point["date"] != "2026-05-31" || point["events"] != float64(2) {
+		t.Fatalf("day point = %#v", point)
+	}
+
+	project := requestJSON(t, server, http.MethodGet, "/api/v1/usage?by=project&from=2026-05-31&to=2026-06-01", http.StatusOK)
+	breakdowns := project["breakdowns"].([]any)
+	if len(breakdowns) != 2 {
+		t.Fatalf("breakdowns len = %d, want 2: %#v", len(breakdowns), breakdowns)
+	}
+	symphony := usageBucket(t, breakdowns, "symphony")
+	if symphony["total_tokens"] != float64(225) || symphony["spend_usd"] != 2.1 {
+		t.Fatalf("symphony breakdown = %#v", symphony)
+	}
+
+	tests := []struct {
+		name       string
+		path       string
+		wantBucket string
+	}{
+		{name: "issue", path: "/api/v1/usage?by=issue", wantBucket: "digitaldrywood/symphony#119"},
+		{name: "pr", path: "/api/v1/usage?by=pr", wantBucket: "141"},
+		{name: "model", path: "/api/v1/usage?by=model", wantBucket: "gpt-report"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := requestJSON(t, server, http.MethodGet, tt.path, http.StatusOK)
+			rows := payload["breakdowns"].([]any)
+			if usageBucket(t, rows, tt.wantBucket) == nil {
+				t.Fatalf("missing bucket %q in %#v", tt.wantBucket, rows)
+			}
+		})
+	}
+}
+
+func TestServerUsageAPIRejectsInvalidParameters(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	deps.Store = openWebTestStore(t)
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	tests := []struct {
+		name     string
+		path     string
+		wantCode string
+	}{
+		{name: "invalid group", path: "/api/v1/usage?by=week", wantCode: "invalid_usage_group"},
+		{name: "invalid from", path: "/api/v1/usage?by=day&from=2026-31-05", wantCode: "invalid_date"},
+		{name: "invalid range", path: "/api/v1/usage?by=day&from=2026-06-02&to=2026-06-01", wantCode: "invalid_date_range"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			payload := requestJSON(t, server, http.MethodGet, tt.path, http.StatusBadRequest)
+			if got := nestedString(t, payload, "error", "code"); got != tt.wantCode {
+				t.Fatalf("error.code = %q, want %q; payload = %#v", got, tt.wantCode, payload)
+			}
+		})
+	}
+}
+
 func testDeps(t *testing.T) web.Dependencies {
 	t.Helper()
 
@@ -930,6 +1051,95 @@ func testDeps(t *testing.T) web.Dependencies {
 		Registry:  struct{}{},
 		Connector: connectorProbe{name: "memory"},
 	}
+}
+
+func openWebTestStore(t *testing.T) store.Store {
+	t.Helper()
+
+	backend, err := store.Open(context.Background(), store.Config{
+		Backend: store.BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "symphony.db"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	return backend
+}
+
+func seedUsageAPIEvents(t *testing.T, ctx context.Context, backend store.Store) {
+	t.Helper()
+
+	events := []store.UsageEvent{
+		{
+			ProjectID:      "symphony",
+			IssueID:        "issue-119",
+			Identifier:     "digitaldrywood/symphony#119",
+			PRNumber:       int64Ptr(141),
+			Model:          "gpt-report",
+			InputTokens:    100,
+			OutputTokens:   50,
+			TotalTokens:    150,
+			RuntimeSeconds: 30,
+			StartedAt:      time.Date(2026, 5, 31, 9, 0, 0, 0, time.UTC),
+			FinishedAt:     time.Date(2026, 5, 31, 9, 1, 0, 0, time.UTC),
+			Outcome:        "completed",
+		},
+		{
+			ProjectID:      "symphony",
+			IssueID:        "issue-120",
+			Identifier:     "digitaldrywood/symphony#120",
+			PRNumber:       int64Ptr(142),
+			Model:          "gpt-report-mini",
+			InputTokens:    50,
+			OutputTokens:   25,
+			TotalTokens:    75,
+			RuntimeSeconds: 15,
+			StartedAt:      time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC),
+			FinishedAt:     time.Date(2026, 5, 31, 10, 1, 0, 0, time.UTC),
+			Outcome:        "completed",
+		},
+		{
+			ProjectID:      "pyroapex",
+			IssueID:        "issue-119",
+			Identifier:     "digitaldrywood/symphony#119",
+			Model:          "gpt-report",
+			InputTokens:    70,
+			OutputTokens:   30,
+			TotalTokens:    100,
+			RuntimeSeconds: 25,
+			StartedAt:      time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC),
+			FinishedAt:     time.Date(2026, 6, 1, 11, 1, 0, 0, time.UTC),
+			Outcome:        "completed",
+		},
+	}
+
+	for _, event := range events {
+		if _, err := backend.RecordUsageEvent(ctx, event); err != nil {
+			t.Fatalf("RecordUsageEvent() error = %v", err)
+		}
+	}
+}
+
+func usageBucket(t *testing.T, rows []any, bucket string) map[string]any {
+	t.Helper()
+
+	for _, row := range rows {
+		object := row.(map[string]any)
+		if object["bucket"] == bucket {
+			return object
+		}
+	}
+	t.Fatalf("missing bucket %q in %#v", bucket, rows)
+	return nil
+}
+
+func int64Ptr(value int64) *int64 {
+	return &value
 }
 
 func requestJSON(t *testing.T, server *web.Server, method string, path string, wantStatus int) map[string]any {


### PR DESCRIPTION
## Summary

- Add sqlc-backed usage ledger report aggregation by day, project, issue, PR, and model with inclusive date filters.
- Add `GET /api/v1/usage` with chart-friendly totals, series, breakdowns, model splits, and read-time spend calculation from budget pricing.
- Cover store aggregation and web API behavior with seeded table tests.

Fixes #119

## Test Plan

- [x] `go test ./internal/store ./internal/web`
- [x] `make generate`
- [x] `make check`