### PR TITLE
chore(install): harden release installer

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -9,7 +9,7 @@ download_base="${SYMPHONY_RELEASE_DOWNLOAD_BASE:-https://github.com/$repo/releas
 state_dir="${SYMPHONY_STATE_DIR:-"$HOME/.symphony"}"
 lock_path="${SYMPHONY_INSTALL_LOCK:-"$state_dir/install.lock"}"
 source_binary="${SYMPHONY_INSTALL_SOURCE:-}"
-install_mode="${SYMPHONY_INSTALL_MODE:-release}"
+install_mode="${SYMPHONY_INSTALL_MODE:-auto}"
 
 abort() {
 	printf '%s\n' "$1" >&2
@@ -27,6 +27,15 @@ script_dir() {
 	else
 		printf ''
 	fi
+}
+
+source_checkout_dir() {
+	dir="$(script_dir)"
+	if [ -n "$dir" ] && [ -f "$dir/go.mod" ] && [ -d "$dir/cmd/symphony" ]; then
+		printf '%s\n' "$dir"
+		return 0
+	fi
+	return 1
 }
 
 choose_install_dir() {
@@ -229,10 +238,9 @@ install_go() {
 }
 
 install_local() {
-	dir="$(script_dir)"
-	if [ -z "$dir" ] || [ ! -f "$dir/go.mod" ]; then
+	dir="$(source_checkout_dir)" || {
 		abort "Cannot build Symphony locally: install.sh is not running from a checkout"
-	fi
+	}
 
 	build_version="$(git -C "$dir" describe --tags --always 2>/dev/null || echo dev)"
 	build_commit="$(git -C "$dir" rev-parse --short HEAD 2>/dev/null || echo none)"
@@ -252,6 +260,13 @@ install_binary() {
 		cp "$tmp_dir/symphony" "$target"
 		chmod 0755 "$target"
 	fi
+}
+
+install_release_or_go() {
+	if [ -n "$target_os" ] && install_release "$target_os" "$target_arch"; then
+		return
+	fi
+	install_go
 }
 
 install_dir="$(choose_install_dir)"
@@ -295,12 +310,16 @@ if [ -n "$source_binary" ]; then
 	copy_source
 elif [ "$install_mode" = "local" ]; then
 	install_local
-else
-	if [ -n "$target_os" ] && install_release "$target_os" "$target_arch"; then
-		:
+elif [ "$install_mode" = "release" ]; then
+	install_release_or_go
+elif [ "$install_mode" = "auto" ]; then
+	if source_checkout_dir >/dev/null 2>&1; then
+		install_local
 	else
-		install_go
+		install_release_or_go
 	fi
+else
+	abort "Unknown SYMPHONY_INSTALL_MODE: $install_mode"
 fi
 
 install_binary

--- a/install.sh
+++ b/install.sh
@@ -1,45 +1,309 @@
-#!/usr/bin/env bash
-set -euo pipefail
+#!/bin/sh
+set -eu
 
-repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
-install_dir="${SYMPHONY_INSTALL_DIR:-"$HOME/.local/bin"}"
+repo="digitaldrywood/symphony"
+project_name="symphony"
+module_package="github.com/digitaldrywood/symphony/cmd/symphony"
+api_base="${SYMPHONY_GITHUB_API_BASE:-https://api.github.com/repos/$repo}"
+download_base="${SYMPHONY_RELEASE_DOWNLOAD_BASE:-https://github.com/$repo/releases/download}"
 state_dir="${SYMPHONY_STATE_DIR:-"$HOME/.symphony"}"
 lock_path="${SYMPHONY_INSTALL_LOCK:-"$state_dir/install.lock"}"
-target="$install_dir/symphony"
 source_binary="${SYMPHONY_INSTALL_SOURCE:-}"
+install_mode="${SYMPHONY_INSTALL_MODE:-release}"
 
-mkdir -p "$install_dir" "$state_dir"
+abort() {
+	printf '%s\n' "$1" >&2
+	exit 1
+}
+
+script_dir() {
+	case "$0" in
+		/*) path="$0" ;;
+		*) path="$(pwd -P)/$0" ;;
+	esac
+
+	if [ -f "$path" ]; then
+		dirname "$path"
+	else
+		printf ''
+	fi
+}
+
+choose_install_dir() {
+	if [ -n "${SYMPHONY_INSTALL_DIR:-}" ]; then
+		printf '%s\n' "$SYMPHONY_INSTALL_DIR"
+		return
+	fi
+	if [ -n "${PREFIX:-}" ]; then
+		printf '%s\n' "$PREFIX"
+		return
+	fi
+	if mkdir -p /usr/local/bin 2>/dev/null && [ -w /usr/local/bin ]; then
+		printf '%s\n' /usr/local/bin
+		return
+	fi
+	printf '%s\n' "$HOME/.local/bin"
+}
+
+detect_target() {
+	uname_s="${SYMPHONY_INSTALL_TEST_UNAME_S:-$(uname -s)}"
+	uname_m="${SYMPHONY_INSTALL_TEST_UNAME_M:-$(uname -m)}"
+
+	case "$uname_s" in
+		Darwin|darwin) os=darwin ;;
+		Linux|linux) os=linux ;;
+		*) return 1 ;;
+	esac
+
+	case "$uname_m" in
+		x86_64|amd64) arch=amd64 ;;
+		arm64|aarch64) arch=arm64 ;;
+		*) return 1 ;;
+	esac
+
+	printf '%s %s\n' "$os" "$arch"
+}
+
+download_file() {
+	curl -fsSL "$1" -o "$2"
+}
+
+download_optional_file() {
+	curl -fsSL "$1" -o "$2" 2>/dev/null
+}
+
+release_tag() {
+	if [ -n "${SYMPHONY_VERSION:-}" ]; then
+		printf '%s\n' "$SYMPHONY_VERSION"
+		return
+	fi
+
+	response="$tmp_dir/latest-release.json"
+	if ! download_file "$api_base/releases/latest" "$response"; then
+		return 1
+	fi
+
+	tag="$(sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' "$response" | head -n 1)"
+	if [ -z "$tag" ]; then
+		return 1
+	fi
+	printf '%s\n' "$tag"
+}
+
+trim_v() {
+	case "$1" in
+		v*) printf '%s\n' "${1#v}" ;;
+		*) printf '%s\n' "$1" ;;
+	esac
+}
+
+download_archive() {
+	tag="$1"
+	version="$2"
+	os="$3"
+	arch="$4"
+	output="$5"
+
+	version_without_v="$(trim_v "$version")"
+	asset_name="$project_name"_"$version_without_v"_"$os"_"$arch".tar.gz
+	if download_optional_file "$download_base/$tag/$asset_name" "$output"; then
+		printf '%s\n' "$asset_name"
+		return 0
+	fi
+
+	asset_name="$project_name"_"$version"_"$os"_"$arch".tar.gz
+	if [ "$version" != "$version_without_v" ] && download_optional_file "$download_base/$tag/$asset_name" "$output"; then
+		printf '%s\n' "$asset_name"
+		return 0
+	fi
+
+	return 1
+}
+
+download_checksums() {
+	tag="$1"
+	version="$2"
+	output="$3"
+	version_without_v="$(trim_v "$version")"
+
+	checksum_name="$project_name"_"$version_without_v"_checksums.txt
+	if download_optional_file "$download_base/$tag/$checksum_name" "$output"; then
+		return 0
+	fi
+	if download_optional_file "$download_base/$tag/checksums.txt" "$output"; then
+		return 0
+	fi
+	return 1
+}
+
+sha256_file() {
+	if command -v sha256sum >/dev/null 2>&1; then
+		sha256sum "$1" | awk '{print $1}'
+		return
+	fi
+	if command -v shasum >/dev/null 2>&1; then
+		shasum -a 256 "$1" | awk '{print $1}'
+		return
+	fi
+	abort "Cannot verify checksum: sha256sum or shasum is required"
+}
+
+expected_checksum() {
+	checksums="$1"
+	asset_name="$2"
+
+	awk -v name="$asset_name" '
+		{
+			file = $2
+			sub(/^\*/, "", file)
+			if (file == name) {
+				print $1
+				found = 1
+				exit
+			}
+		}
+		END {
+			if (!found) {
+				exit 1
+			}
+		}
+	' "$checksums"
+}
+
+verify_checksum() {
+	archive="$1"
+	checksums="$2"
+	asset_name="$3"
+
+	expected="$(expected_checksum "$checksums" "$asset_name")" || abort "Checksum for $asset_name not found"
+	actual="$(sha256_file "$archive")"
+	if [ "$actual" != "$expected" ]; then
+		abort "Checksum mismatch for $asset_name: expected $expected, got $actual"
+	fi
+}
+
+install_release() {
+	os="$1"
+	arch="$2"
+
+	if ! command -v curl >/dev/null 2>&1; then
+		printf '%s\n' "curl is not available; falling back to go install" >&2
+		return 1
+	fi
+	if ! command -v tar >/dev/null 2>&1; then
+		printf '%s\n' "tar is not available; falling back to go install" >&2
+		return 1
+	fi
+
+	tag="$(release_tag)" || {
+		printf '%s\n' "Could not resolve the latest Symphony release; falling back to go install" >&2
+		return 1
+	}
+	version="$tag"
+	archive="$tmp_dir/archive.tar.gz"
+	checksums="$tmp_dir/checksums.txt"
+
+	asset_name="$(download_archive "$tag" "$version" "$os" "$arch" "$archive")" || {
+		printf '%s\n' "No Symphony release asset found for $tag $os/$arch; falling back to go install" >&2
+		return 1
+	}
+	download_checksums "$tag" "$version" "$checksums" || abort "Could not download checksums for release $tag"
+	verify_checksum "$archive" "$checksums" "$asset_name"
+
+	mkdir -p "$tmp_dir/release"
+	tar -xzf "$archive" -C "$tmp_dir/release"
+	if [ ! -f "$tmp_dir/release/symphony" ]; then
+		abort "Release archive $asset_name did not contain symphony"
+	fi
+	cp "$tmp_dir/release/symphony" "$tmp_dir/symphony"
+}
+
+install_go() {
+	version="${SYMPHONY_VERSION:-latest}"
+	go_bin="$tmp_dir/go-bin"
+
+	command -v go >/dev/null 2>&1 || abort "Cannot install Symphony: release asset unavailable and go is not installed"
+	mkdir -p "$go_bin"
+	GOBIN="$go_bin" go install "$module_package@$version"
+	cp "$go_bin/symphony" "$tmp_dir/symphony"
+}
+
+install_local() {
+	dir="$(script_dir)"
+	if [ -z "$dir" ] || [ ! -f "$dir/go.mod" ]; then
+		abort "Cannot build Symphony locally: install.sh is not running from a checkout"
+	fi
+
+	build_version="$(git -C "$dir" describe --tags --always 2>/dev/null || echo dev)"
+	build_commit="$(git -C "$dir" rev-parse --short HEAD 2>/dev/null || echo none)"
+	build_date="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+	ldflags="-X main.version=$build_version -X main.commit=$build_commit -X main.date=$build_date"
+	(cd "$dir" && go build -ldflags "$ldflags" -o "$tmp_dir/symphony" ./cmd/symphony)
+}
+
+copy_source() {
+	cp "$source_binary" "$tmp_dir/symphony"
+}
+
+install_binary() {
+	if command -v install >/dev/null 2>&1; then
+		install -m 0755 "$tmp_dir/symphony" "$target"
+	else
+		cp "$tmp_dir/symphony" "$target"
+		chmod 0755 "$target"
+	fi
+}
+
+install_dir="$(choose_install_dir)"
+target="$install_dir/symphony"
+
+target_info="$(detect_target || true)"
+if [ -n "$target_info" ]; then
+	target_os="${target_info% *}"
+	target_arch="${target_info#* }"
+	printf 'Detected target %s/%s\n' "$target_os" "$target_arch"
+else
+	target_os=""
+	target_arch=""
+	printf '%s\n' "No supported release target detected; falling back to go install if needed" >&2
+fi
+
+mkdir -p "$install_dir" "$state_dir" || abort "Cannot create install or state directory"
+if [ ! -w "$install_dir" ]; then
+	abort "Install directory is not writable: $install_dir"
+fi
 
 if ! (set -C; : > "$lock_path") 2>/dev/null; then
-	echo "Symphony is already installed on this host: $lock_path" >&2
-	exit 1
+	abort "Symphony is already installed on this host: $lock_path"
 fi
 
 cleanup_lock=true
-cleanup() {
+cleanup_lock_file() {
 	if [ "$cleanup_lock" = true ]; then
 		rm -f "$lock_path"
 	fi
 }
-trap cleanup EXIT
+trap cleanup_lock_file EXIT
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/symphony-install.XXXXXX")"
 cleanup_tmp() {
 	rm -rf "$tmp_dir"
 }
-trap 'cleanup_tmp; cleanup' EXIT
+trap 'cleanup_tmp; cleanup_lock_file' EXIT
 
 if [ -n "$source_binary" ]; then
-	cp "$source_binary" "$tmp_dir/symphony"
+	copy_source
+elif [ "$install_mode" = "local" ]; then
+	install_local
 else
-	build_version="$(git -C "$repo_root" describe --tags --always 2>/dev/null || echo dev)"
-	build_commit="$(git -C "$repo_root" rev-parse --short HEAD 2>/dev/null || echo none)"
-	build_date="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
-	ldflags="-X main.version=$build_version -X main.commit=$build_commit -X main.date=$build_date"
-	(cd "$repo_root" && go build -ldflags "$ldflags" -o "$tmp_dir/symphony" ./cmd/symphony)
+	if [ -n "$target_os" ] && install_release "$target_os" "$target_arch"; then
+		:
+	else
+		install_go
+	fi
 fi
 
-install -m 0755 "$tmp_dir/symphony" "$target"
+install_binary
 
 {
 	printf 'binary=%s\n' "$target"

--- a/install_test.go
+++ b/install_test.go
@@ -3,11 +3,16 @@
 package symphony_test
 
 import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -71,6 +76,215 @@ func TestInstallScriptInstallsBinaryAndRefusesExistingLock(t *testing.T) {
 	}
 }
 
+func TestInstallScriptDetectsSupportedTargets(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source-symphony")
+	if err := os.WriteFile(source, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		unameS string
+		unameM string
+		want   string
+	}{
+		{name: "darwin arm64", unameS: "Darwin", unameM: "arm64", want: "Detected target darwin/arm64"},
+		{name: "linux amd64", unameS: "Linux", unameM: "x86_64", want: "Detected target linux/amd64"},
+		{name: "linux arm64", unameS: "Linux", unameM: "aarch64", want: "Detected target linux/arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			caseDir := filepath.Join(tmp, strings.ReplaceAll(tt.name, " ", "-"))
+			installDir := filepath.Join(caseDir, "bin")
+			stateDir := filepath.Join(caseDir, "state")
+			env := append(os.Environ(),
+				"HOME="+caseDir,
+				"SYMPHONY_INSTALL_SOURCE="+source,
+				"SYMPHONY_INSTALL_DIR="+installDir,
+				"SYMPHONY_STATE_DIR="+stateDir,
+				"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+				"SYMPHONY_INSTALL_TEST_UNAME_S="+tt.unameS,
+				"SYMPHONY_INSTALL_TEST_UNAME_M="+tt.unameM,
+			)
+
+			result := runInstall(t, root, env)
+			if result.err != nil {
+				t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+			}
+			if !strings.Contains(result.stdout, tt.want) {
+				t.Fatalf("install stdout = %q, want %q", result.stdout, tt.want)
+			}
+		})
+	}
+}
+
+func TestInstallScriptInstallsReleaseArchive(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	archiveName := "symphony_1.2.3_linux_amd64.tar.gz"
+	archive := symphonyArchive(t, "#!/usr/bin/env sh\nprintf 'release-ok\\n'\n")
+	server := newInstallReleaseServer("v1.2.3", archiveName, archive, archiveChecksum(archive))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"SYMPHONY_GITHUB_API_BASE="+server.URL,
+		"SYMPHONY_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_STATE_DIR="+stateDir,
+		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+		"SYMPHONY_INSTALL_TEST_UNAME_S=Linux",
+		"SYMPHONY_INSTALL_TEST_UNAME_M=x86_64",
+	)
+
+	result := runInstall(t, root, env)
+	if result.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	binary := filepath.Join(installDir, "symphony")
+	if _, err := os.Stat(binary); err != nil {
+		t.Fatalf("installed binary stat error = %v", err)
+	}
+	stdout, stderr, err := runSymphonyCommandOutput(t, binary, root, env)
+	if err != nil {
+		t.Fatalf("installed release binary error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if stdout != "release-ok\n" {
+		t.Fatalf("installed release binary stdout = %q, want release-ok", stdout)
+	}
+}
+
+func TestInstallScriptAbortsOnChecksumMismatch(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	archiveName := "symphony_1.2.3_linux_amd64.tar.gz"
+	archive := symphonyArchive(t, "#!/usr/bin/env sh\nexit 0\n")
+	server := newInstallReleaseServer("v1.2.3", archiveName, archive, strings.Repeat("0", 64))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"SYMPHONY_GITHUB_API_BASE="+server.URL,
+		"SYMPHONY_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_STATE_DIR="+stateDir,
+		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+		"SYMPHONY_INSTALL_TEST_UNAME_S=Linux",
+		"SYMPHONY_INSTALL_TEST_UNAME_M=x86_64",
+	)
+
+	result := runInstall(t, root, env)
+	if result.err == nil {
+		t.Fatal("install error = nil, want checksum failure")
+	}
+	if !strings.Contains(result.stderr, "Checksum mismatch for "+archiveName) {
+		t.Fatalf("install stderr = %q, want checksum mismatch for %s", result.stderr, archiveName)
+	}
+	if _, err := os.Stat(filepath.Join(installDir, "symphony")); !os.IsNotExist(err) {
+		t.Fatalf("installed binary stat error = %v, want not exist", err)
+	}
+}
+
+func TestInstallScriptFallsBackToGoInstallWhenReleaseAssetMissing(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/releases/latest" {
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"tag_name":"v1.2.3"}`)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	fakeBin := filepath.Join(tmp, "fakebin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(fakebin) error = %v", err)
+	}
+	fakeGo := filepath.Join(fakeBin, "go")
+	fakeGoScript := `#!/usr/bin/env sh
+if [ "$1" = install ]; then
+mkdir -p "$GOBIN"
+cat > "$GOBIN/symphony" <<'EOF'
+#!/usr/bin/env sh
+printf 'go-install-ok\n'
+EOF
+chmod 755 "$GOBIN/symphony"
+exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(fakeGo, []byte(fakeGoScript), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake go) error = %v", err)
+	}
+
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"SYMPHONY_GITHUB_API_BASE="+server.URL,
+		"SYMPHONY_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_STATE_DIR="+stateDir,
+		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+		"SYMPHONY_INSTALL_TEST_UNAME_S=Linux",
+		"SYMPHONY_INSTALL_TEST_UNAME_M=x86_64",
+	)
+
+	result := runInstall(t, root, env)
+	if result.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stderr, "No Symphony release asset found") {
+		t.Fatalf("install stderr = %q, want release asset fallback", result.stderr)
+	}
+
+	binary := filepath.Join(installDir, "symphony")
+	stdout, stderr, err := runSymphonyCommandOutput(t, binary, root, env)
+	if err != nil {
+		t.Fatalf("installed fallback binary error = %v\nstdout:\n%s\nstderr:\n%s", err, stdout, stderr)
+	}
+	if stdout != "go-install-ok\n" {
+		t.Fatalf("installed fallback binary stdout = %q, want go-install-ok", stdout)
+	}
+}
+
 func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
 	root, err := os.Getwd()
 	if err != nil {
@@ -82,6 +296,7 @@ func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
 	stateDir := filepath.Join(tmp, "state")
 	env := append(os.Environ(),
 		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_INSTALL_MODE=local",
 		"SYMPHONY_STATE_DIR="+stateDir,
 		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
 	)
@@ -122,6 +337,58 @@ func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
 	runInstalledSubcommands(t, binary, tmp, serverEnv)
 }
 
+func symphonyArchive(t *testing.T, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	header := &tar.Header{
+		Name: "symphony",
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatalf("WriteHeader() error = %v", err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close() error = %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip Close() error = %v", err)
+	}
+	return buf.Bytes()
+}
+
+func archiveChecksum(content []byte) string {
+	sum := sha256.Sum256(content)
+	return fmt.Sprintf("%x", sum)
+}
+
+func newInstallReleaseServer(tag string, archiveName string, archive []byte, checksum string) *httptest.Server {
+	version := strings.TrimPrefix(tag, "v")
+	checksumName := "symphony_" + version + "_checksums.txt"
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"tag_name":%q}`, tag)
+		case "/" + tag + "/" + archiveName:
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archive)
+		case "/" + tag + "/" + checksumName:
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%s  %s\n", checksum, archiveName)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
 type installRun struct {
 	stdout string
 	stderr string
@@ -140,7 +407,7 @@ func runInstallWithTimeout(t *testing.T, root string, env []string, timeout time
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "bash", "install.sh")
+	cmd := exec.CommandContext(ctx, "sh", "install.sh")
 	cmd.Dir = root
 	cmd.Env = env
 

--- a/install_test.go
+++ b/install_test.go
@@ -150,6 +150,7 @@ func TestInstallScriptInstallsReleaseArchive(t *testing.T) {
 		"SYMPHONY_GITHUB_API_BASE="+server.URL,
 		"SYMPHONY_RELEASE_DOWNLOAD_BASE="+server.URL,
 		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_INSTALL_MODE=release",
 		"SYMPHONY_STATE_DIR="+stateDir,
 		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
 		"SYMPHONY_INSTALL_TEST_UNAME_S=Linux",
@@ -195,6 +196,7 @@ func TestInstallScriptAbortsOnChecksumMismatch(t *testing.T) {
 		"SYMPHONY_GITHUB_API_BASE="+server.URL,
 		"SYMPHONY_RELEASE_DOWNLOAD_BASE="+server.URL,
 		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_INSTALL_MODE=release",
 		"SYMPHONY_STATE_DIR="+stateDir,
 		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
 		"SYMPHONY_INSTALL_TEST_UNAME_S=Linux",
@@ -261,6 +263,7 @@ exit 1
 		"SYMPHONY_GITHUB_API_BASE="+server.URL,
 		"SYMPHONY_RELEASE_DOWNLOAD_BASE="+server.URL,
 		"SYMPHONY_INSTALL_DIR="+installDir,
+		"SYMPHONY_INSTALL_MODE=release",
 		"SYMPHONY_STATE_DIR="+stateDir,
 		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
 		"SYMPHONY_INSTALL_TEST_UNAME_S=Linux",
@@ -296,7 +299,6 @@ func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
 	stateDir := filepath.Join(tmp, "state")
 	env := append(os.Environ(),
 		"SYMPHONY_INSTALL_DIR="+installDir,
-		"SYMPHONY_INSTALL_MODE=local",
 		"SYMPHONY_STATE_DIR="+stateDir,
 		"SYMPHONY_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
 	)


### PR DESCRIPTION
## Summary

- install matching GitHub release archives by default with latest-tag API resolution and SYMPHONY_VERSION override
- verify downloaded archives against release checksums before extraction
- keep source/local install paths for tests and add coverage for target detection, checksum failure, and go install fallback

Fixes #99

## Test Plan

- [x] `go test -count=1 -run 'TestInstallScript|TestFreshInstall' .`
- [x] `go test -race -count=1 .`
- [x] `make check`