### PR TITLE
fix(dashboard): show blocked status issues

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -88,6 +88,18 @@ query SymphonyGitHubIssuesByID($issueIds: [ID!]!, $projectItemsFirst: Int!) {
   }
 }`
 
+const issueCommentsQuery = `
+query SymphonyGitHubIssueComments($issueIds: [ID!]!) {
+  nodes(ids: $issueIds) {
+    __typename
+    ... on Issue {
+      id
+      body
+      comments(first: 100) { nodes { body } }
+    }
+  }
+}`
+
 const addCommentMutation = `
 mutation SymphonyGitHubAddComment($subjectId: ID!, $body: String!) {
   addComment(input: {subjectId: $subjectId, body: $body}) {
@@ -146,6 +158,7 @@ var (
 	modelOverridePattern  = regexp.MustCompile(`(?i)<!--\s*model:\s*(\S+?)\s*-->`)
 	dependencyLinePattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*:\\s*(?:[*_`~]+)?\\s*(.+)\\s*$")
 	issueRefPattern       = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
+	numberedListPattern   = regexp.MustCompile(`^\d+[.)]\s+`)
 )
 
 type pageInfo struct {
@@ -167,20 +180,21 @@ type projectItemNode struct {
 }
 
 type githubIssueNode struct {
-	TypeName                       string                      `json:"__typename"`
-	ID                             string                      `json:"id"`
-	Number                         int                         `json:"number"`
-	Title                          string                      `json:"title"`
-	Body                           string                      `json:"body"`
-	State                          string                      `json:"state"`
-	URL                            string                      `json:"url"`
-	CreatedAt                      *string                     `json:"createdAt"`
-	UpdatedAt                      *string                     `json:"updatedAt"`
-	Assignees                      nodeConnection[assignee]    `json:"assignees"`
-	Labels                         nodeConnection[label]       `json:"labels"`
-	Repository                     repository                  `json:"repository"`
-	ClosedByPullRequestsReferences nodeConnection[pullRequest] `json:"closedByPullRequestsReferences"`
-	ProjectItems                   *projectItemsConnection     `json:"projectItems"`
+	TypeName                       string                       `json:"__typename"`
+	ID                             string                       `json:"id"`
+	Number                         int                          `json:"number"`
+	Title                          string                       `json:"title"`
+	Body                           string                       `json:"body"`
+	State                          string                       `json:"state"`
+	URL                            string                       `json:"url"`
+	CreatedAt                      *string                      `json:"createdAt"`
+	UpdatedAt                      *string                      `json:"updatedAt"`
+	Assignees                      nodeConnection[assignee]     `json:"assignees"`
+	Labels                         nodeConnection[label]        `json:"labels"`
+	Comments                       nodeConnection[issueComment] `json:"comments"`
+	Repository                     repository                   `json:"repository"`
+	ClosedByPullRequestsReferences nodeConnection[pullRequest]  `json:"closedByPullRequestsReferences"`
+	ProjectItems                   *projectItemsConnection      `json:"projectItems"`
 }
 
 type nodeConnection[T any] struct {
@@ -193,6 +207,10 @@ type assignee struct {
 
 type label struct {
 	Name string `json:"name"`
+}
+
+type issueComment struct {
+	Body string `json:"body"`
 }
 
 type pullRequest struct {
@@ -231,10 +249,19 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 		return nil, ErrMissingProject
 	}
 
-	return c.fetchProjectItems(ctx, func(issue connector.Issue) bool {
+	issues, err := c.fetchProjectItems(ctx, func(issue connector.Issue) bool {
 		_, ok := wantedStates[normalizeStateName(issue.State)]
 		return ok
 	})
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
+		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+			return nil, err
+		}
+	}
+	return issues, nil
 }
 
 func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) ([]connector.Issue, error) {
@@ -268,6 +295,44 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 	}
 	sortIssuesByRequestedIDs(issues, ids)
 	return issues, nil
+}
+
+func (c *Connector) populateBlockerReasons(ctx context.Context, issues []connector.Issue) error {
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		if normalizeStateName(issue.State) == normalizeStateName("Blocked") {
+			ids = append(ids, issue.ID)
+		}
+	}
+	ids = uniqueNonBlank(ids)
+	if len(ids) == 0 {
+		return nil
+	}
+
+	var response struct {
+		Nodes []githubIssueNode `json:"nodes"`
+	}
+	if err := c.client.GraphQL(ctx, issueCommentsQuery, map[string]any{
+		"issueIds": ids,
+	}, &response); err != nil {
+		return fmt.Errorf("fetch github issue comments: %w", err)
+	}
+
+	reasonsByID := make(map[string]string, len(response.Nodes))
+	for _, node := range response.Nodes {
+		if node.TypeName != "Issue" {
+			continue
+		}
+		if reason := parseBlockerReason(node); reason != "" {
+			reasonsByID[node.ID] = reason
+		}
+	}
+	for index := range issues {
+		if reason, ok := reasonsByID[issues[index].ID]; ok {
+			issues[index].BlockerReason = reason
+		}
+	}
+	return nil
 }
 
 func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
@@ -491,6 +556,7 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		PRNumber:         firstPullRequestNumber(issue.ClosedByPullRequestsReferences),
 		AssigneeID:       firstAssigneeLogin(issue.Assignees),
 		BlockedBy:        parseBlockedBy(issue.Body, repo),
+		BlockerReason:    parseBlockerReason(issue),
 		Labels:           labelNames(issue.Labels),
 		AssignedToWorker: true,
 		CreatedAt:        parseGitHubTime(issue.CreatedAt),
@@ -741,6 +807,84 @@ func parseModelOverride(body string) string {
 		return ""
 	}
 	return strings.TrimSpace(matches[1])
+}
+
+func parseBlockerReason(issue githubIssueNode) string {
+	for index := len(issue.Comments.Nodes) - 1; index >= 0; index-- {
+		body := issue.Comments.Nodes[index].Body
+		if !strings.Contains(strings.ToLower(body), "codex workpad") {
+			continue
+		}
+		if reason := markdownSectionText(body, "Human Action Needed"); reason != "" {
+			return reason
+		}
+	}
+	return markdownSectionText(issue.Body, "Human Action Needed")
+}
+
+func markdownSectionText(body string, title string) string {
+	want := normalizeSectionTitle(title)
+	inSection := false
+	lines := []string{}
+	for _, line := range strings.Split(body, "\n") {
+		heading, ok := markdownHeadingTitle(line)
+		if ok {
+			if inSection {
+				break
+			}
+			inSection = normalizeSectionTitle(heading) == want
+			continue
+		}
+		if inSection {
+			lines = append(lines, line)
+		}
+	}
+	return normalizeSectionLines(lines)
+}
+
+func markdownHeadingTitle(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || line[0] != '#' {
+		return "", false
+	}
+	index := 0
+	for index < len(line) && line[index] == '#' {
+		index++
+	}
+	if index > 6 || index == len(line) {
+		return "", false
+	}
+	if line[index] != ' ' && line[index] != '\t' {
+		return "", false
+	}
+	return strings.Trim(strings.TrimSpace(line[index:]), "# \t"), true
+}
+
+func normalizeSectionTitle(title string) string {
+	return strings.ToLower(strings.Join(strings.Fields(title), " "))
+}
+
+func normalizeSectionLines(lines []string) string {
+	parts := make([]string, 0, len(lines))
+	for _, line := range lines {
+		line = normalizeSectionLine(line)
+		if line != "" {
+			parts = append(parts, line)
+		}
+	}
+	return strings.Join(parts, "; ")
+}
+
+func normalizeSectionLine(line string) string {
+	line = strings.TrimSpace(line)
+	for _, marker := range []string{"- ", "* ", "+ "} {
+		if strings.HasPrefix(line, marker) {
+			line = strings.TrimSpace(strings.TrimPrefix(line, marker))
+			break
+		}
+	}
+	line = numberedListPattern.ReplaceAllString(line, "")
+	return strings.Join(strings.Fields(line), " ")
 }
 
 func parseBlockedBy(body string, repo string) []connector.BlockedRef {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -144,6 +144,47 @@ func TestConnectorFetchIssuesByStatesFiltersMappedStates(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssuesByStatesExtractsWorkpadHumanActionNeeded(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw98","number":98,"title":"Homebrew tap","body":"Depends on: #97","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/98","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Blocked"},"priorityValue":null}]}}}}`,
+		},
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw98","body":"Depends on: #97","comments":{"nodes":[{"body":"## Codex Workpad\n\n### Plan\n- Check prerequisites.\n\n### Human Action Needed\n- Create public repository ` + "`" + `digitaldrywood/homebrew-tap` + "`" + `.\n- Add repository Actions secret ` + "`" + `HOMEBREW_TAP_GITHUB_TOKEN` + "`" + `.\n\n### Validation Evidence\n- Not run."}]}}]}}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Blocked"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	want := "Create public repository `digitaldrywood/homebrew-tap`.; Add repository Actions secret `HOMEBREW_TAP_GITHUB_TOKEN`."
+	if got[0].BlockerReason != want {
+		t.Fatalf("BlockerReason = %q, want %q", got[0].BlockerReason, want)
+	}
+
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	if strings.Contains(requests[0]["query"].(string), "comments") {
+		t.Fatalf("project query = %q, want no comments", requests[0]["query"])
+	}
+	if !strings.Contains(requests[1]["query"].(string), "comments") {
+		t.Fatalf("comments query = %q, want comments", requests[1]["query"])
+	}
+}
+
 func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -18,6 +18,7 @@ type Issue struct {
 	PRNumber         *int         `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
 	AssigneeID       string       `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`
 	BlockedBy        []BlockedRef `json:"blocked_by" yaml:"blocked_by"`
+	BlockerReason    string       `json:"blocker_reason,omitempty" yaml:"blocker_reason,omitempty"`
 	Labels           []string     `json:"labels" yaml:"labels"`
 	AssignedToWorker bool         `json:"assigned_to_worker" yaml:"assigned_to_worker"`
 	CreatedAt        *time.Time   `json:"created_at,omitempty" yaml:"created_at,omitempty"`

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -20,6 +20,9 @@ const (
 	defaultContinuationRetry     = time.Second
 	defaultFailureRetryBaseDelay = 10 * time.Second
 	runUpdateBufferSize          = 128
+	blockedStatusState           = "Blocked"
+	blockedReasonDependency      = "blocked by non-terminal dependency"
+	blockedReasonProjectStatus   = "blocked by project status"
 )
 
 var (
@@ -237,11 +240,19 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		o.logger.Warn("fetch candidate issues failed", "error", err)
 		return
 	}
+	blockedIssues, blockedErr := o.connector.FetchIssuesByStates(ctx, []string{blockedStatusState})
+	if blockedErr != nil {
+		o.logger.Warn("fetch blocked status issues failed", "error", blockedErr)
+	}
 
 	issues = cloneIssues(issues)
+	blockedIssues = cloneIssues(blockedIssues)
 	sortIssuesForDispatch(issues, o.cfg.DispatchPriorityByState)
 	o.pruneBudgetRefusals(state, now)
 	o.trackBlockedCandidates(state, issues, now)
+	if blockedErr == nil {
+		o.trackBlockedStatusIssues(state, blockedIssues, now)
+	}
 	o.dispatchReadyIssues(ctx, state, issues, now)
 }
 
@@ -284,20 +295,59 @@ func (o *Orchestrator) trackBlockedCandidates(state *State, issues []connector.I
 			seenBlocked[issue.ID] = struct{}{}
 			state.Blocked[issue.ID] = Blocked{
 				Issue:     cloneIssue(issue),
-				Reason:    "blocked by non-terminal dependency",
+				Reason:    blockedReasonDependency,
 				BlockedAt: now,
+				Source:    BlockedSourceDependency,
 			}
 		}
 	}
 
 	for issueID, blocked := range state.Blocked {
-		if blocked.Reason != "blocked by non-terminal dependency" {
+		if !blockedFromDependency(blocked) {
 			continue
 		}
 		if _, ok := seenBlocked[issueID]; !ok {
 			delete(state.Blocked, issueID)
 		}
 	}
+}
+
+func (o *Orchestrator) trackBlockedStatusIssues(state *State, issues []connector.Issue, now time.Time) {
+	seenBlocked := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		if issue.ID == "" {
+			continue
+		}
+		seenBlocked[issue.ID] = struct{}{}
+		state.Blocked[issue.ID] = Blocked{
+			Issue:     cloneIssue(issue),
+			Reason:    blockedStatusReason(issue),
+			BlockedAt: now,
+			Source:    BlockedSourceProjectStatus,
+		}
+	}
+
+	for issueID, blocked := range state.Blocked {
+		if blocked.Source != BlockedSourceProjectStatus {
+			continue
+		}
+		if _, ok := seenBlocked[issueID]; !ok {
+			delete(state.Blocked, issueID)
+		}
+	}
+}
+
+func blockedFromDependency(blocked Blocked) bool {
+	return blocked.Source == BlockedSourceDependency ||
+		(blocked.Source == "" && blocked.Reason == blockedReasonDependency)
+}
+
+func blockedStatusReason(issue connector.Issue) string {
+	reason := strings.TrimSpace(issue.BlockerReason)
+	if reason != "" {
+		return reason
+	}
+	return blockedReasonProjectStatus
 }
 
 func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
@@ -359,6 +409,10 @@ func (o *Orchestrator) releaseMissingDueRetries(
 
 	for issueID := range dueRetries {
 		if _, ok := byID[issueID]; !ok {
+			if _, blocked := state.Blocked[issueID]; blocked {
+				o.releaseClaim(state, issueID)
+				continue
+			}
 			o.releaseIssue(state, issueID)
 		}
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -452,6 +452,69 @@ func TestRunSkipsTodoBlockedByNonTerminalDependency(t *testing.T) {
 	}
 }
 
+func TestRunTracksBlockedStatusIssuesForDisplayOnly(t *testing.T) {
+	t.Parallel()
+
+	candidate := testIssue("issue-ready", "digitaldrywood/symphony#170", "Todo")
+	blocked := testIssue("issue-blocked-status", "digitaldrywood/symphony#98", "Blocked")
+	blocked.BlockerReason = "Create public repository digitaldrywood/homebrew-tap"
+	tracker := newFakeConnector(candidate)
+	tracker.setStateIssues(blocked)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           5 * time.Millisecond,
+		MaxConcurrentAgents:    2,
+		MaxRetryBackoff:        time.Hour,
+		FailureRetryBaseDelay:  time.Hour,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+	defer close(runner.release)
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != candidate.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, candidate.ID)
+	}
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Blocked[blocked.ID]
+		return ok
+	})
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected display-only blocked dispatch = %#v", request)
+	case <-time.After(25 * time.Millisecond):
+	}
+	if got := tracker.fetchByStatesCalls(); got == 0 {
+		t.Fatal("FetchIssuesByStates() calls = 0, want blocked status fetch")
+	}
+	if _, ok := state.Claimed[blocked.ID]; ok {
+		t.Fatalf("Claimed[%q] present for display-only blocked issue", blocked.ID)
+	}
+	entry := state.Blocked[blocked.ID]
+	if entry.Issue.ID != blocked.ID || entry.Issue.State != "Blocked" {
+		t.Fatalf("Blocked[%q].Issue = %#v, want Blocked issue", blocked.ID, entry.Issue)
+	}
+	if entry.Reason != blocked.BlockerReason {
+		t.Fatalf("Blocked[%q].Reason = %q, want %q", blocked.ID, entry.Reason, blocked.BlockerReason)
+	}
+	snapshot := state.Snapshot(time.Now())
+	if snapshot.Counts.Blocked != 1 || len(snapshot.Blocked) != 1 {
+		t.Fatalf("snapshot blocked count = %d len = %d, want 1", snapshot.Counts.Blocked, len(snapshot.Blocked))
+	}
+}
+
 func TestStateReturnsDefensiveCopies(t *testing.T) {
 	t.Parallel()
 
@@ -688,7 +751,9 @@ func rankedTestIssue(issue connector.Issue, priority int, createdAt time.Time) c
 type fakeConnector struct {
 	mu                  sync.Mutex
 	candidates          []connector.Issue
+	stateIssues         []connector.Issue
 	fetchCandidateCount int
+	fetchByStatesCount  int
 }
 
 func newFakeConnector(issues ...connector.Issue) *fakeConnector {
@@ -707,11 +772,22 @@ func (c *fakeConnector) FetchCandidateIssues(context.Context) ([]connector.Issue
 	return cloneIssues(c.candidates), nil
 }
 
-func (c *fakeConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+func (c *fakeConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	return cloneIssues(c.candidates), nil
+	c.fetchByStatesCount++
+	wanted := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		wanted[strings.ToLower(strings.TrimSpace(state))] = struct{}{}
+	}
+	issues := make([]connector.Issue, 0, len(c.stateIssues))
+	for _, issue := range c.stateIssues {
+		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.State))]; ok {
+			issues = append(issues, issue)
+		}
+	}
+	return cloneIssues(issues), nil
 }
 
 func (c *fakeConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
@@ -746,6 +822,20 @@ func (c *fakeConnector) fetchCandidateCalls() int {
 	defer c.mu.Unlock()
 
 	return c.fetchCandidateCount
+}
+
+func (c *fakeConnector) fetchByStatesCalls() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.fetchByStatesCount
+}
+
+func (c *fakeConnector) setStateIssues(issues ...connector.Issue) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.stateIssues = cloneIssues(issues)
 }
 
 type staticRunner struct {

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -134,6 +134,50 @@ func TestDispatchReadyIssuesRanksDueRetriesWithCandidates(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesPreservesBlockedStatusForMissingDueRetry(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:   1,
+		ActiveStates:          []string{"Todo"},
+		TerminalStates:        []string{"Done"},
+		MaxRetryBackoff:       time.Minute,
+		FailureRetryBaseDelay: time.Second,
+	})
+	orch := Orchestrator{cfg: cfg}
+	state := newState(cfg)
+	now := time.Now()
+	retrying := retryTestIssue("retrying", "digitaldrywood/symphony#21")
+	blocked := retrying
+	blocked.State = "Blocked"
+
+	state.Claimed[retrying.ID] = Claimed{Issue: retrying, ClaimedAt: now.Add(-time.Minute)}
+	state.Retry[retrying.ID] = Retry{
+		Issue:   retrying,
+		Attempt: 2,
+		DueAt:   now.Add(-time.Millisecond),
+		Error:   "previous failure",
+	}
+	state.Blocked[retrying.ID] = Blocked{
+		Issue:     blocked,
+		Reason:    "human action needed",
+		BlockedAt: now,
+		Source:    BlockedSourceProjectStatus,
+	}
+
+	orch.dispatchReadyIssues(context.Background(), &state, nil, now)
+
+	if _, ok := state.Blocked[retrying.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing after missing due retry cleanup", retrying.ID)
+	}
+	if _, ok := state.Claimed[retrying.ID]; ok {
+		t.Fatalf("Claimed[%q] present after missing due retry cleanup", retrying.ID)
+	}
+	if _, ok := state.Retry[retrying.ID]; ok {
+		t.Fatalf("Retry[%q] present after missing due retry cleanup", retrying.ID)
+	}
+}
+
 func TestDispatchReadyIssuesKeepsAttemptWhenWorkerCapacityIsFull(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -43,10 +43,18 @@ type Claimed struct {
 	ClaimedAt time.Time
 }
 
+type BlockedSource string
+
+const (
+	BlockedSourceDependency    BlockedSource = "dependency"
+	BlockedSourceProjectStatus BlockedSource = "project_status"
+)
+
 type Blocked struct {
 	Issue     connector.Issue
 	Reason    string
 	BlockedAt time.Time
+	Source    BlockedSource
 }
 
 type Completed struct {


### PR DESCRIPTION
## Summary

- fetch Blocked project-status issues for display-only blocked snapshots
- extract Codex Workpad Human Action Needed text for blocked issue reasons
- keep dispatch candidates limited to the existing active issue fetch path

Fixes #169

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/connector/github -count=1`
- [x] `make check`