### PR TITLE
feat(tui): restore refresh telemetry parity

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -169,7 +169,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
-	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, runtimeStore, defaultSnapshotInterval, time.Now)
+	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, runtimeStore, displayURL, defaultSnapshotInterval, time.Now)
 	server, err := web.NewServer(web.Config{
 		Mode:           web.ModeRunning,
 		WorkflowPath:   firstWorkflowPath(cfg),

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -167,6 +167,7 @@ func publishSnapshots(
 	registry *project.Registry,
 	snapshotHub *hub.Hub[telemetry.Snapshot],
 	lifetimeSource lifetimeTotalsSource,
+	dashboardURL string,
 	interval time.Duration,
 	now func() time.Time,
 ) {
@@ -185,7 +186,7 @@ func publishSnapshots(
 	defer ticker.Stop()
 
 	for {
-		if err := publishSnapshotOnce(ctx, registry, snapshotHub, now(), trend, lifetimeSource); err != nil {
+		if err := publishSnapshotOnce(ctx, registry, snapshotHub, now(), trend, lifetimeSource, dashboardURL); err != nil {
 			slog.Default().Warn("publish telemetry snapshot failed", "error", err)
 		}
 		select {
@@ -203,6 +204,7 @@ func publishSnapshotOnce(
 	now time.Time,
 	trend *tokenTrendRecorder,
 	lifetimeSource lifetimeTotalsSource,
+	dashboardURL string,
 ) error {
 	merged := telemetry.Snapshot{GeneratedAt: now}
 	for _, trackedProject := range registry.List() {
@@ -217,7 +219,10 @@ func publishSnapshotOnce(
 		if err != nil {
 			continue
 		}
-		merged = mergeSnapshot(merged, state.Snapshot(now))
+		snapshot := state.Snapshot(now)
+		snapshot.Project = projectSnapshotMetadata(trackedProject)
+		snapshot.DashboardURL = cleanDashboardURL(dashboardURL)
+		merged = mergeSnapshot(merged, snapshot)
 	}
 	if trend != nil {
 		merged = trend.apply(merged)
@@ -227,6 +232,31 @@ func publishSnapshotOnce(
 		return fmt.Errorf("publish snapshot: %w", err)
 	}
 	return nil
+}
+
+func projectSnapshotMetadata(trackedProject *project.Project) telemetry.Project {
+	if trackedProject == nil {
+		return telemetry.Project{}
+	}
+
+	cfg := trackedProject.Config()
+	workflow := trackedProject.Workflow()
+	return telemetry.Project{
+		DisplayName: strings.TrimSpace(cfg.ID),
+		URL:         projectURLFromWorkflow(workflow.Config),
+	}
+}
+
+func projectURLFromWorkflow(cfg workflowconfig.Config) string {
+	slug := strings.TrimSpace(cfg.Tracker.ProjectSlug)
+	if strings.HasPrefix(slug, "http://") || strings.HasPrefix(slug, "https://") {
+		return slug
+	}
+	return ""
+}
+
+func cleanDashboardURL(value string) string {
+	return strings.TrimSpace(value)
 }
 
 type tokenTrendRecorder struct {
@@ -334,6 +364,12 @@ func lifetimeTotals(ctx context.Context, source lifetimeTotalsSource) telemetry.
 }
 
 func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
+	current.Project = mergeProject(current.Project, next.Project)
+	if strings.TrimSpace(current.DashboardURL) == "" {
+		current.DashboardURL = next.DashboardURL
+	}
+	current.Refresh = mergeRefresh(current.Refresh, next.Refresh)
+
 	current.Running = append(current.Running, next.Running...)
 	current.Queue = append(current.Queue, next.Queue...)
 	current.Blocked = append(current.Blocked, next.Blocked...)
@@ -354,6 +390,56 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 		current.RateLimits = next.RateLimits
 	}
 	return current
+}
+
+func mergeProject(current, next telemetry.Project) telemetry.Project {
+	if current == (telemetry.Project{}) {
+		return next
+	}
+	if next == (telemetry.Project{}) || current == next {
+		return current
+	}
+	return telemetry.Project{DisplayName: "multiple projects"}
+}
+
+func mergeRefresh(current, next telemetry.Refresh) telemetry.Refresh {
+	if current.PollIntervalSeconds == 0 ||
+		(next.PollIntervalSeconds > 0 && next.PollIntervalSeconds < current.PollIntervalSeconds) {
+		current.PollIntervalSeconds = next.PollIntervalSeconds
+	}
+	current.LastRefreshAt = latestTime(current.LastRefreshAt, next.LastRefreshAt)
+	current.NextRefreshAt = earliestTime(current.NextRefreshAt, next.NextRefreshAt)
+	return current
+}
+
+func latestTime(current *time.Time, next *time.Time) *time.Time {
+	switch {
+	case current == nil:
+		return cloneTime(next)
+	case next == nil || current.After(*next):
+		return cloneTime(current)
+	default:
+		return cloneTime(next)
+	}
+}
+
+func earliestTime(current *time.Time, next *time.Time) *time.Time {
+	switch {
+	case current == nil:
+		return cloneTime(next)
+	case next == nil || current.Before(*next):
+		return cloneTime(current)
+	default:
+		return cloneTime(next)
+	}
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func durationFromMillis(ms int) time.Duration {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -98,7 +98,7 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	done := make(chan struct{})
 	go func() {
 		defer close(done)
-		publishSnapshots(ctx, registry, snapshotHub, nil, 5*time.Millisecond, func() time.Time { return now })
+		publishSnapshots(ctx, registry, snapshotHub, nil, "http://localhost:4101", 5*time.Millisecond, func() time.Time { return now })
 	}()
 
 	var (
@@ -119,6 +119,15 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	}
 	if !snapshot.GeneratedAt.Equal(now) {
 		t.Fatalf("snapshot.GeneratedAt = %v, want %v", snapshot.GeneratedAt, now)
+	}
+	if snapshot.Project.DisplayName != "alpha" {
+		t.Fatalf("snapshot.Project.DisplayName = %q, want alpha", snapshot.Project.DisplayName)
+	}
+	if snapshot.DashboardURL != "http://localhost:4101" {
+		t.Fatalf("snapshot.DashboardURL = %q, want dashboard URL", snapshot.DashboardURL)
+	}
+	if snapshot.Refresh.NextRefreshAt == nil {
+		t.Fatalf("snapshot.Refresh.NextRefreshAt = nil, want next refresh")
 	}
 }
 

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -67,6 +67,7 @@ type UpdateHandler func(Update) error
 type UpdateType string
 
 const (
+	UpdateProcessStarted    UpdateType = "process_started"
 	UpdateAgentMessageDelta UpdateType = "agent_message_delta"
 	UpdateTokenUsage        UpdateType = "token_usage"
 	UpdateRateLimits        UpdateType = "rate_limits"
@@ -75,16 +76,17 @@ const (
 )
 
 type Update struct {
-	Type       UpdateType
-	Method     string
-	ThreadID   string
-	TurnID     string
-	ItemID     string
-	Delta      string
-	Status     string
-	Tokens     TokenUsage
-	RateLimits *RateLimitSnapshot
-	Payload    json.RawMessage
+	Type            UpdateType
+	Method          string
+	ProcessIdentity string
+	ThreadID        string
+	TurnID          string
+	ItemID          string
+	Delta           string
+	Status          string
+	Tokens          TokenUsage
+	RateLimits      *RateLimitSnapshot
+	Payload         json.RawMessage
 }
 
 type TokenUsage struct {
@@ -183,6 +185,16 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 			err = closeErr
 		}
 	}()
+
+	if identity := transportProcessIdentity(transport); identity != "" {
+		if err := emitUpdate(Update{
+			Type:            UpdateProcessStarted,
+			Method:          "process/start",
+			ProcessIdentity: identity,
+		}, onUpdate); err != nil {
+			return RunTurnResult{}, err
+		}
+	}
 
 	if err := s.initialize(ctx, transport, onUpdate); err != nil {
 		return RunTurnResult{}, err
@@ -490,6 +502,16 @@ func emitUpdate(update Update, onUpdate UpdateHandler) error {
 		return fmt.Errorf("handle codex update: %w", err)
 	}
 	return nil
+}
+
+func transportProcessIdentity(transport Transport) string {
+	provider, ok := transport.(interface {
+		ProcessIdentity() string
+	})
+	if !ok {
+		return ""
+	}
+	return provider.ProcessIdentity()
 }
 
 func updateFromMessage(msg Message) (Update, bool, error) {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -67,6 +67,7 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 		}`),
 		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
 	})
+	transport.processIdentity = "4242"
 	server, err := NewAppServer(staticTransportFactory{transport: transport},
 		WithClientInfo(ClientInfo{
 			Name:    "symphony-test",
@@ -125,35 +126,38 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	assertJSONContains(t, sent[3].Params, "approvalPolicy", "never")
 	assertJSONContains(t, sent[3].Params, "sandboxPolicy.type", "workspaceWrite")
 
-	if len(updates) != 5 {
-		t.Fatalf("updates = %d, want 5: %#v", len(updates), updates)
+	if len(updates) != 6 {
+		t.Fatalf("updates = %d, want 6: %#v", len(updates), updates)
 	}
-	if updates[0].Type != UpdateTurnStarted || updates[0].ThreadID != "thread-1" || updates[0].TurnID != "turn-1" {
-		t.Fatalf("updates[0] = %#v, want turn started", updates[0])
+	if updates[0].Type != UpdateProcessStarted || updates[0].ProcessIdentity != "4242" {
+		t.Fatalf("updates[0] = %#v, want process identity", updates[0])
 	}
-	if updates[1].Type != UpdateAgentMessageDelta || updates[1].Delta != "hello" {
-		t.Fatalf("updates[1] = %#v, want agent message delta", updates[1])
+	if updates[1].Type != UpdateTurnStarted || updates[1].ThreadID != "thread-1" || updates[1].TurnID != "turn-1" {
+		t.Fatalf("updates[1] = %#v, want turn started", updates[1])
 	}
-	if updates[2].Type != UpdateTokenUsage || updates[2].Tokens.TotalTokens != 27 {
-		t.Fatalf("updates[2] = %#v, want token usage total 27", updates[2])
+	if updates[2].Type != UpdateAgentMessageDelta || updates[2].Delta != "hello" {
+		t.Fatalf("updates[2] = %#v, want agent message delta", updates[2])
 	}
-	if updates[2].Tokens.CachedInputTokens != 5 || updates[2].Tokens.ReasoningOutputTokens != 3 {
-		t.Fatalf("updates[2].Tokens = %#v", updates[2].Tokens)
+	if updates[3].Type != UpdateTokenUsage || updates[3].Tokens.TotalTokens != 27 {
+		t.Fatalf("updates[3] = %#v, want token usage total 27", updates[3])
 	}
-	if updates[2].Tokens.ModelContextWindow == nil || *updates[2].Tokens.ModelContextWindow != 200000 {
-		t.Fatalf("updates[2].Tokens.ModelContextWindow = %#v", updates[2].Tokens.ModelContextWindow)
+	if updates[3].Tokens.CachedInputTokens != 5 || updates[3].Tokens.ReasoningOutputTokens != 3 {
+		t.Fatalf("updates[3].Tokens = %#v", updates[3].Tokens)
 	}
-	if updates[3].Type != UpdateRateLimits || updates[3].RateLimits == nil {
-		t.Fatalf("updates[3] = %#v, want rate limits", updates[3])
+	if updates[3].Tokens.ModelContextWindow == nil || *updates[3].Tokens.ModelContextWindow != 200000 {
+		t.Fatalf("updates[3].Tokens.ModelContextWindow = %#v", updates[3].Tokens.ModelContextWindow)
 	}
-	if updates[3].RateLimits.LimitID != "codex-primary" || updates[3].RateLimits.Primary == nil {
-		t.Fatalf("updates[3].RateLimits = %#v", updates[3].RateLimits)
+	if updates[4].Type != UpdateRateLimits || updates[4].RateLimits == nil {
+		t.Fatalf("updates[4] = %#v, want rate limits", updates[4])
 	}
-	if updates[3].RateLimits.Primary.UsedPercent != 12.5 {
-		t.Fatalf("Primary.UsedPercent = %f, want 12.5", updates[3].RateLimits.Primary.UsedPercent)
+	if updates[4].RateLimits.LimitID != "codex-primary" || updates[4].RateLimits.Primary == nil {
+		t.Fatalf("updates[4].RateLimits = %#v", updates[4].RateLimits)
 	}
-	if updates[4].Type != UpdateTurnCompleted || updates[4].TurnID != "turn-1" {
-		t.Fatalf("updates[4] = %#v, want turn completed", updates[4])
+	if updates[4].RateLimits.Primary.UsedPercent != 12.5 {
+		t.Fatalf("Primary.UsedPercent = %f, want 12.5", updates[4].RateLimits.Primary.UsedPercent)
+	}
+	if updates[5].Type != UpdateTurnCompleted || updates[5].TurnID != "turn-1" {
+		t.Fatalf("updates[5] = %#v, want turn completed", updates[5])
 	}
 }
 
@@ -234,8 +238,9 @@ func (f staticTransportFactory) NewTransport(context.Context) (Transport, error)
 }
 
 type fakeAppServerTransport struct {
-	received []Message
-	sent     []Message
+	received        []Message
+	sent            []Message
+	processIdentity string
 }
 
 func newFakeAppServerTransport(received []Message) *fakeAppServerTransport {
@@ -258,6 +263,10 @@ func (t *fakeAppServerTransport) Receive(context.Context) (Message, error) {
 
 func (t *fakeAppServerTransport) Close(context.Context) error {
 	return nil
+}
+
+func (t *fakeAppServerTransport) ProcessIdentity() string {
+	return t.processIdentity
 }
 
 func (t *fakeAppServerTransport) sentMessages() []Message {

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"sync"
 	"time"
 )
@@ -168,6 +169,13 @@ func (t *localTransport) Close(ctx context.Context) error {
 		}
 		return ctx.Err()
 	}
+}
+
+func (t *localTransport) ProcessIdentity() string {
+	if t.cmd == nil || t.cmd.Process == nil {
+		return ""
+	}
+	return strconv.Itoa(t.cmd.Process.Pid)
 }
 
 func (t *localTransport) acquireSend(ctx context.Context) error {

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -16,11 +16,12 @@ import (
 func TestWatchDebouncesWorkflowWrites(t *testing.T) {
 	t.Parallel()
 
+	debounce := 150 * time.Millisecond
 	dir := t.TempDir()
 	path := filepath.Join(dir, "WORKFLOW.md")
 	writeWorkflow(t, path, 100, "initial")
 
-	w, err := New(path, WithDebounce(25*time.Millisecond))
+	w, err := New(path, WithDebounce(debounce))
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
 	}
@@ -50,7 +51,7 @@ func TestWatchDebouncesWorkflowWrites(t *testing.T) {
 	select {
 	case extra := <-updates:
 		t.Fatalf("extra update after debounce = %#v", extra)
-	case <-time.After(75 * time.Millisecond):
+	case <-time.After(2 * debounce):
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -230,6 +230,8 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 }
 
 func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
+	o.markRefresh(state, now)
+
 	issues, err := o.connector.FetchCandidateIssues(ctx)
 	if err != nil {
 		o.logger.Warn("fetch candidate issues failed", "error", err)
@@ -241,6 +243,17 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	o.pruneBudgetRefusals(state, now)
 	o.trackBlockedCandidates(state, issues, now)
 	o.dispatchReadyIssues(ctx, state, issues, now)
+}
+
+func (o *Orchestrator) markRefresh(state *State, now time.Time) {
+	state.PollInterval = o.cfg.PollInterval
+	state.MaxConcurrentAgents = o.cfg.MaxConcurrentAgents
+	state.LastRefreshAt = now
+	if o.cfg.PollInterval > 0 {
+		state.NextRefreshAt = now.Add(o.cfg.PollInterval)
+		return
+	}
+	state.NextRefreshAt = time.Time{}
 }
 
 func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ticker *time.Ticker) {
@@ -255,6 +268,9 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	})
 	state.PollInterval = cfg.PollInterval
 	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
+	if !state.LastRefreshAt.IsZero() && cfg.PollInterval > 0 {
+		state.NextRefreshAt = state.LastRefreshAt.Add(cfg.PollInterval)
+	}
 	ticker.Reset(cfg.PollInterval)
 }
 
@@ -521,6 +537,9 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	}
 	if event.usage.LastMessage != "" {
 		running.LastMessage = event.usage.LastMessage
+	}
+	if event.usage.ProcessIdentity != "" {
+		running.ProcessIdentity = event.usage.ProcessIdentity
 	}
 	if diffStatsPresent(event.usage.DiffStats) {
 		running.DiffStats = event.usage.DiffStats

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -14,12 +14,17 @@ import (
 func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	snapshot := telemetry.Snapshot{
 		GeneratedAt: now,
-		Running:     runningSnapshots(s.Running),
-		Queue:       queueSnapshots(s.Retry),
-		Blocked:     blockedSnapshots(s.Blocked),
-		Completed:   completedSnapshots(s.Completed),
-		RateLimits:  cloneRateLimits(s.RateLimits),
-		Tokens:      tokensFromCodexTotals(s.liveCodexTotals()),
+		Refresh: telemetry.Refresh{
+			PollIntervalSeconds: int64(s.PollInterval / time.Second),
+			LastRefreshAt:       timePointer(s.LastRefreshAt),
+			NextRefreshAt:       timePointer(s.NextRefreshAt),
+		},
+		Running:    runningSnapshots(s.Running),
+		Queue:      queueSnapshots(s.Retry),
+		Blocked:    blockedSnapshots(s.Blocked),
+		Completed:  completedSnapshots(s.Completed),
+		RateLimits: cloneRateLimits(s.RateLimits),
+		Tokens:     tokensFromCodexTotals(s.liveCodexTotals()),
 		Budget: telemetry.Budget{
 			Refusals: budgetRefusalSnapshots(s.BudgetRefusals),
 		},
@@ -40,20 +45,21 @@ func runningSnapshots(running map[string]Running) []telemetry.Running {
 		entry := running[id]
 		lastEventAt := timePointer(entry.LastEventAt)
 		out = append(out, telemetry.Running{
-			Issue:          telemetryIssue(entry.Issue),
-			WorkerHost:     entry.WorkerHost,
-			SessionID:      entry.SessionID,
-			StartedAt:      entry.StartedAt,
-			LastEventAt:    lastEventAt,
-			LastEvent:      entry.LastEvent,
-			LastMessage:    entry.LastMessage,
-			TurnCount:      entry.TurnCount,
-			RuntimeSeconds: entry.Tokens.RuntimeSeconds,
-			DiffAdded:      entry.DiffStats.AddedLines,
-			DiffRemoved:    entry.DiffStats.RemovedLines,
-			DiffFiles:      entry.DiffStats.FilesChanged,
-			DiffStatus:     entry.DiffStats.Status,
-			Tokens:         tokensFromCodexTotals(entry.Tokens),
+			Issue:           telemetryIssue(entry.Issue),
+			WorkerHost:      entry.WorkerHost,
+			ProcessIdentity: entry.ProcessIdentity,
+			SessionID:       entry.SessionID,
+			StartedAt:       entry.StartedAt,
+			LastEventAt:     lastEventAt,
+			LastEvent:       entry.LastEvent,
+			LastMessage:     entry.LastMessage,
+			TurnCount:       entry.TurnCount,
+			RuntimeSeconds:  entry.Tokens.RuntimeSeconds,
+			DiffAdded:       entry.DiffStats.AddedLines,
+			DiffRemoved:     entry.DiffStats.RemovedLines,
+			DiffFiles:       entry.DiffStats.FilesChanged,
+			DiffStatus:      entry.DiffStats.Status,
+			Tokens:          tokensFromCodexTotals(entry.Tokens),
 		})
 	}
 	return out

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -46,18 +46,21 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	blockedAt := now.Add(-3 * time.Minute)
 
 	state := newState(normalizeConfig(Config{}))
+	state.LastRefreshAt = now.Add(-30 * time.Second)
+	state.NextRefreshAt = now.Add(30 * time.Second)
 	state.Running["i-2"] = Running{
-		Issue:       connector.Issue{ID: "i-2", Identifier: "ISS-2", Title: "Two", State: "In Progress", URL: "u2"},
-		Attempt:     1,
-		StartedAt:   startedAt,
-		WorkerHost:  "host-b",
-		SessionID:   "thread-2-turn-2",
-		TurnCount:   2,
-		LastEventAt: now.Add(-10 * time.Second),
-		LastEvent:   "agent_message_delta",
-		LastMessage: "editing dashboard telemetry",
-		DiffStats:   DiffStats{FilesChanged: 3, AddedLines: 12, RemovedLines: 4, Status: "ok"},
-		Tokens:      CodexTotals{InputTokens: 20, OutputTokens: 8, TotalTokens: 28, RuntimeSeconds: 30},
+		Issue:           connector.Issue{ID: "i-2", Identifier: "ISS-2", Title: "Two", State: "In Progress", URL: "u2"},
+		Attempt:         1,
+		StartedAt:       startedAt,
+		WorkerHost:      "host-b",
+		ProcessIdentity: "4242",
+		SessionID:       "thread-2-turn-2",
+		TurnCount:       2,
+		LastEventAt:     now.Add(-10 * time.Second),
+		LastEvent:       "agent_message_delta",
+		LastMessage:     "editing dashboard telemetry",
+		DiffStats:       DiffStats{FilesChanged: 3, AddedLines: 12, RemovedLines: 4, Status: "ok"},
+		Tokens:          CodexTotals{InputTokens: 20, OutputTokens: 8, TotalTokens: 28, RuntimeSeconds: 30},
 	}
 	state.Running["i-1"] = Running{
 		Issue:     connector.Issue{ID: "i-1", Identifier: "ISS-1", Title: "One", State: "In Progress"},
@@ -104,6 +107,9 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	}
 	if snapshot.Running[1].WorkerHost != "host-b" {
 		t.Fatalf("Running[1].WorkerHost = %q, want host-b", snapshot.Running[1].WorkerHost)
+	}
+	if snapshot.Running[1].ProcessIdentity != "4242" {
+		t.Fatalf("Running[1].ProcessIdentity = %q, want 4242", snapshot.Running[1].ProcessIdentity)
 	}
 	if snapshot.Running[0].Identifier != "ISS-1" || snapshot.Running[0].Title != "One" {
 		t.Fatalf("Running[0] issue mapping = %#v", snapshot.Running[0].Issue)
@@ -172,6 +178,9 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	}
 	if snapshot.RateLimits == nil || snapshot.RateLimits.LimitID != "lim" {
 		t.Fatalf("RateLimits = %#v, want lim", snapshot.RateLimits)
+	}
+	if snapshot.Refresh.PollIntervalSeconds != 30 || snapshot.Refresh.LastRefreshAt == nil || snapshot.Refresh.NextRefreshAt == nil {
+		t.Fatalf("Refresh = %#v, want poll interval and refresh timestamps", snapshot.Refresh)
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -10,6 +10,8 @@ import (
 type State struct {
 	PollInterval        time.Duration
 	MaxConcurrentAgents int
+	LastRefreshAt       time.Time
+	NextRefreshAt       time.Time
 	Running             map[string]Running
 	Claimed             map[string]Claimed
 	Blocked             map[string]Blocked
@@ -22,17 +24,18 @@ type State struct {
 }
 
 type Running struct {
-	Issue       connector.Issue
-	Attempt     int
-	StartedAt   time.Time
-	WorkerHost  string
-	SessionID   string
-	TurnCount   int
-	LastEventAt time.Time
-	LastEvent   string
-	LastMessage string
-	DiffStats   DiffStats
-	Tokens      CodexTotals
+	Issue           connector.Issue
+	Attempt         int
+	StartedAt       time.Time
+	WorkerHost      string
+	ProcessIdentity string
+	SessionID       string
+	TurnCount       int
+	LastEventAt     time.Time
+	LastEvent       string
+	LastMessage     string
+	DiffStats       DiffStats
+	Tokens          CodexTotals
 }
 
 type Claimed struct {
@@ -80,6 +83,8 @@ func (s State) clone() State {
 	cloned := State{
 		PollInterval:        s.PollInterval,
 		MaxConcurrentAgents: s.MaxConcurrentAgents,
+		LastRefreshAt:       s.LastRefreshAt,
+		NextRefreshAt:       s.NextRefreshAt,
 		Running:             make(map[string]Running, len(s.Running)),
 		Claimed:             make(map[string]Claimed, len(s.Claimed)),
 		Blocked:             make(map[string]Blocked, len(s.Blocked)),

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -352,6 +352,7 @@ func applyCodexUpdate(result *RunResult, update codex.Update) {
 
 type codexRunProgress struct {
 	sessionID          string
+	processIdentity    string
 	turnIDs            map[string]struct{}
 	messages           map[string]string
 	lastEventAt        time.Time
@@ -370,6 +371,9 @@ func newCodexRunProgress() *codexRunProgress {
 }
 
 func (p *codexRunProgress) apply(update codex.Update, eventAt time.Time) {
+	if update.ProcessIdentity != "" {
+		p.processIdentity = update.ProcessIdentity
+	}
 	if update.ThreadID != "" && update.TurnID != "" {
 		p.sessionID = update.ThreadID + "-" + update.TurnID
 		p.turnIDs[update.TurnID] = struct{}{}
@@ -422,13 +426,14 @@ func (r *Runner) publishRunUpdate(
 	progress.apply(update, eventAt)
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, eventAt)
 	usage := UsageUpdate{
-		SessionID:   progress.sessionID,
-		TurnCount:   progress.turnCount(),
-		LastEventAt: progress.lastEventAt,
-		LastEvent:   progress.lastEvent,
-		LastMessage: progress.lastMessage,
-		Tokens:      result.Tokens,
-		RateLimits:  result.RateLimits,
+		SessionID:       progress.sessionID,
+		ProcessIdentity: progress.processIdentity,
+		TurnCount:       progress.turnCount(),
+		LastEventAt:     progress.lastEventAt,
+		LastEvent:       progress.lastEvent,
+		LastMessage:     progress.lastMessage,
+		Tokens:          result.Tokens,
+		RateLimits:      result.RateLimits,
 	}
 	diffStats, ok := r.liveDiffStats(ctx, info, issue, progress, eventAt)
 	if ok {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -43,11 +43,12 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	codexClient := &fakeCodexClient{
 		updates: []codex.Update{
 			{
-				Type:     codex.UpdateAgentMessageDelta,
-				ThreadID: "thread-1",
-				TurnID:   "turn-1",
-				ItemID:   "item-1",
-				Delta:    "hello",
+				Type:            codex.UpdateAgentMessageDelta,
+				ProcessIdentity: "4242",
+				ThreadID:        "thread-1",
+				TurnID:          "turn-1",
+				ItemID:          "item-1",
+				Delta:           "hello",
 			},
 			{
 				Type:     codex.UpdateTokenUsage,
@@ -154,6 +155,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if usageUpdates[0].SessionID != "thread-1-turn-1" || usageUpdates[0].TurnCount != 1 {
 		t.Fatalf("first usage update = %#v, want live session and one turn", usageUpdates[0])
+	}
+	if usageUpdates[0].ProcessIdentity != "4242" {
+		t.Fatalf("first usage update ProcessIdentity = %q, want 4242", usageUpdates[0].ProcessIdentity)
 	}
 	if usageUpdates[0].LastEvent != "agent_message_delta" || usageUpdates[0].LastMessage != "hello" {
 		t.Fatalf("first usage update activity = %#v, want agent message", usageUpdates[0])

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -36,14 +36,15 @@ type RunResult struct {
 type UsageUpdateHandler func(UsageUpdate) error
 
 type UsageUpdate struct {
-	SessionID   string
-	TurnCount   int
-	LastEventAt time.Time
-	LastEvent   string
-	LastMessage string
-	Tokens      CodexTotals
-	DiffStats   DiffStats
-	RateLimits  *telemetry.RateLimits
+	SessionID       string
+	ProcessIdentity string
+	TurnCount       int
+	LastEventAt     time.Time
+	LastEvent       string
+	LastMessage     string
+	Tokens          CodexTotals
+	DiffStats       DiffStats
+	RateLimits      *telemetry.RateLimits
 }
 
 type BudgetRefusal struct {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -4,6 +4,9 @@ import "time"
 
 type Snapshot struct {
 	GeneratedAt    time.Time         `json:"generated_at"`
+	Project        Project           `json:"project"`
+	DashboardURL   string            `json:"dashboard_url,omitempty"`
+	Refresh        Refresh           `json:"refresh"`
 	Counts         Counts            `json:"counts"`
 	Running        []Running         `json:"running"`
 	Queue          []Queued          `json:"queue"`
@@ -15,6 +18,17 @@ type Snapshot struct {
 	Throughput     TokenThroughput   `json:"throughput"`
 	LifetimeTotals LifetimeTotals    `json:"lifetime_totals"`
 	TokenTrend     []TokenTrendPoint `json:"token_trend,omitempty"`
+}
+
+type Project struct {
+	DisplayName string `json:"display_name,omitempty"`
+	URL         string `json:"url,omitempty"`
+}
+
+type Refresh struct {
+	PollIntervalSeconds int64      `json:"poll_interval_seconds,omitempty"`
+	LastRefreshAt       *time.Time `json:"last_refresh_at,omitempty"`
+	NextRefreshAt       *time.Time `json:"next_refresh_at,omitempty"`
 }
 
 type Counts struct {
@@ -35,20 +49,21 @@ type Issue struct {
 
 type Running struct {
 	Issue
-	WorkerHost     string     `json:"worker_host,omitempty"`
-	WorkspacePath  string     `json:"workspace_path,omitempty"`
-	SessionID      string     `json:"session_id,omitempty"`
-	TurnCount      int        `json:"turn_count"`
-	StartedAt      time.Time  `json:"started_at"`
-	LastEventAt    *time.Time `json:"last_event_at,omitempty"`
-	LastEvent      string     `json:"last_event,omitempty"`
-	LastMessage    string     `json:"last_message,omitempty"`
-	RuntimeSeconds float64    `json:"runtime_seconds"`
-	DiffAdded      int        `json:"diff_added"`
-	DiffRemoved    int        `json:"diff_removed"`
-	DiffFiles      int        `json:"diff_files"`
-	DiffStatus     string     `json:"diff_status,omitempty"`
-	Tokens         Tokens     `json:"tokens"`
+	WorkerHost      string     `json:"worker_host,omitempty"`
+	ProcessIdentity string     `json:"process_identity,omitempty"`
+	WorkspacePath   string     `json:"workspace_path,omitempty"`
+	SessionID       string     `json:"session_id,omitempty"`
+	TurnCount       int        `json:"turn_count"`
+	StartedAt       time.Time  `json:"started_at"`
+	LastEventAt     *time.Time `json:"last_event_at,omitempty"`
+	LastEvent       string     `json:"last_event,omitempty"`
+	LastMessage     string     `json:"last_message,omitempty"`
+	RuntimeSeconds  float64    `json:"runtime_seconds"`
+	DiffAdded       int        `json:"diff_added"`
+	DiffRemoved     int        `json:"diff_removed"`
+	DiffFiles       int        `json:"diff_files"`
+	DiffStatus      string     `json:"diff_status,omitempty"`
+	Tokens          Tokens     `json:"tokens"`
 }
 
 type Queued struct {

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -19,6 +19,15 @@ func TestSnapshotJSONShape(t *testing.T) {
 
 	snapshot := telemetry.Snapshot{
 		GeneratedAt: generatedAt,
+		Project: telemetry.Project{
+			DisplayName: "Symphony",
+			URL:         "https://github.com/digitaldrywood/symphony",
+		},
+		DashboardURL: "http://localhost:4101",
+		Refresh: telemetry.Refresh{
+			PollIntervalSeconds: 30,
+			NextRefreshAt:       timePointer(generatedAt.Add(30 * time.Second)),
+		},
 		Counts: telemetry.Counts{
 			Running:   1,
 			Queue:     2,
@@ -34,14 +43,15 @@ func TestSnapshotJSONShape(t *testing.T) {
 					Title:      "Port hub",
 					URL:        "https://example.com/issues/1",
 				},
-				SessionID:      "thread-1",
-				TurnCount:      2,
-				StartedAt:      startedAt,
-				RuntimeSeconds: 300,
-				DiffAdded:      4,
-				DiffRemoved:    2,
-				DiffFiles:      3,
-				DiffStatus:     "ok",
+				ProcessIdentity: "4242",
+				SessionID:       "thread-1",
+				TurnCount:       2,
+				StartedAt:       startedAt,
+				RuntimeSeconds:  300,
+				DiffAdded:       4,
+				DiffRemoved:     2,
+				DiffFiles:       3,
+				DiffStatus:      "ok",
 				Tokens: telemetry.Tokens{
 					Input:  10,
 					Output: 20,
@@ -159,6 +169,9 @@ func TestSnapshotJSONShape(t *testing.T) {
 
 	for _, key := range []string{
 		"generated_at",
+		"project",
+		"dashboard_url",
+		"refresh",
 		"counts",
 		"running",
 		"queue",
@@ -176,6 +189,18 @@ func TestSnapshotJSONShape(t *testing.T) {
 		}
 	}
 
+	project := got["project"].(map[string]any)
+	if project["display_name"] != "Symphony" || project["url"] != "https://github.com/digitaldrywood/symphony" {
+		t.Fatalf("project = %#v", project)
+	}
+	if got["dashboard_url"] != "http://localhost:4101" {
+		t.Fatalf("dashboard_url = %#v", got["dashboard_url"])
+	}
+	refresh := got["refresh"].(map[string]any)
+	if refresh["poll_interval_seconds"] != float64(30) || refresh["next_refresh_at"] != "2026-05-30T22:15:30Z" {
+		t.Fatalf("refresh = %#v", refresh)
+	}
+
 	counts := got["counts"].(map[string]any)
 	if counts["running"] != float64(1) || counts["queue"] != float64(2) || counts["blocked"] != float64(3) || counts["completed"] != float64(4) {
 		t.Fatalf("counts = %#v", counts)
@@ -184,6 +209,9 @@ func TestSnapshotJSONShape(t *testing.T) {
 	running := got["running"].([]any)[0].(map[string]any)
 	if running["issue_id"] != "issue-1" || running["identifier"] != "DD-1" {
 		t.Fatalf("running row = %#v", running)
+	}
+	if running["process_identity"] != "4242" {
+		t.Fatalf("running process identity = %#v", running)
 	}
 	if running["diff_added"] != float64(4) || running["diff_removed"] != float64(2) || running["diff_files"] != float64(3) || running["diff_status"] != "ok" {
 		t.Fatalf("running diff fields = %#v", running)
@@ -236,4 +264,8 @@ func TestSnapshotJSONShape(t *testing.T) {
 	if latest["input_tokens"] != float64(110) || latest["output_tokens"] != float64(220) || latest["total_tokens"] != float64(330) {
 		t.Fatalf("token_trend[1] = %#v", latest)
 	}
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -18,7 +18,7 @@ import (
 
 var ErrNilHub = errors.New("nil telemetry hub")
 
-const dashboardURL = "http://localhost:4000"
+const defaultDashboardURL = "http://localhost:4000"
 
 type Option func(*options)
 
@@ -139,7 +139,7 @@ func waitForSnapshot(updates <-chan telemetry.Snapshot) tea.Cmd {
 func (m Model) renderWaiting() string {
 	lines := []string{
 		m.styles.title.Render("╭─ SYMPHONY STATUS"),
-		"│ Dashboard: " + m.styles.info.Render(dashboardURL),
+		"│ Dashboard: " + m.styles.info.Render(defaultDashboardURL),
 		"│ " + m.styles.muted.Render("Waiting for telemetry snapshot"),
 		closingBorder,
 	}
@@ -151,7 +151,6 @@ func (m Model) renderSnapshot() string {
 	snapshot := m.snapshot
 	lines := []string{
 		m.styles.title.Render("╭─ SYMPHONY STATUS"),
-		"│ Dashboard: " + m.styles.info.Render(dashboardURL),
 		"│ Generated: " + m.styles.muted.Render(formatTimestamp(snapshot.GeneratedAt)),
 		"│ Agents: " + m.styles.ok.Render(fmt.Sprintf("%d running", countOrLen(snapshot.Counts.Running, len(snapshot.Running)))) +
 			m.styles.muted.Render(" | ") +
@@ -169,6 +168,9 @@ func (m Model) renderSnapshot() string {
 			m.styles.warn.Render("total "+formatCount(snapshot.Tokens.Total)),
 		"│ Budget: " + formatBudget(snapshot.Budget, m.styles),
 		"│ Rate Limits: " + formatRateLimits(snapshot.RateLimits, m.now, m.styles),
+		"│ Project: " + formatOptionalInfo(formatProject(snapshot.Project), m.styles),
+		"│ Dashboard: " + m.styles.info.Render(formatDashboardURL(snapshot)),
+		"│ Next refresh: " + formatOptionalInfo(formatNextRefresh(snapshot.Refresh), m.styles),
 		m.styles.title.Render("├─ Running"),
 		"│",
 	}
@@ -211,7 +213,7 @@ func formatRunningRows(running []telemetry.Running, eventWidth int, s styles) []
 		cells := []string{
 			formatCell(issueLabel(row.Issue), runningIDWidth, alignLeft),
 			formatCell(defaultString(row.State, "unknown"), runningStageWidth, alignLeft),
-			formatCell(defaultString(row.WorkerHost, "n/a"), runningHostWidth, alignLeft),
+			formatCell(defaultString(row.ProcessIdentity, "n/a"), runningProcessWidth, alignLeft),
 			formatCell(formatRuntimeAndTurns(row.RuntimeSeconds, row.TurnCount), runningAgeWidth, alignLeft),
 			formatCell(formatCount(row.Tokens.Total), runningTokensWidth, alignRight),
 			formatCell(compactSessionID(row.SessionID), runningSessionWidth, alignLeft),
@@ -432,7 +434,7 @@ func runningTableHeader(eventWidth int, s styles) string {
 	cells := []string{
 		formatCell("ID", runningIDWidth, alignLeft),
 		formatCell("STAGE", runningStageWidth, alignLeft),
-		formatCell("HOST", runningHostWidth, alignLeft),
+		formatCell("PID", runningProcessWidth, alignLeft),
 		formatCell("AGE / TURN", runningAgeWidth, alignLeft),
 		formatCell("TOKENS", runningTokensWidth, alignLeft),
 		formatCell("SESSION", runningSessionWidth, alignLeft),
@@ -443,7 +445,7 @@ func runningTableHeader(eventWidth int, s styles) string {
 }
 
 func runningTableSeparator(eventWidth int, s styles) string {
-	width := runningIDWidth + runningStageWidth + runningHostWidth + runningAgeWidth + runningTokensWidth + runningSessionWidth + eventWidth + runningColumnGaps
+	width := runningIDWidth + runningStageWidth + runningProcessWidth + runningAgeWidth + runningTokensWidth + runningSessionWidth + eventWidth + runningColumnGaps
 	return "│   " + s.muted.Render(strings.Repeat("─", width))
 }
 
@@ -509,6 +511,37 @@ func formatTimestamp(value time.Time) string {
 	}
 
 	return value.UTC().Truncate(time.Second).Format(time.RFC3339)
+}
+
+func formatProject(project telemetry.Project) string {
+	if strings.TrimSpace(project.URL) != "" {
+		return cleanInline(project.URL)
+	}
+	if strings.TrimSpace(project.DisplayName) != "" {
+		return cleanInline(project.DisplayName)
+	}
+	return ""
+}
+
+func formatDashboardURL(snapshot telemetry.Snapshot) string {
+	if strings.TrimSpace(snapshot.DashboardURL) != "" {
+		return cleanInline(snapshot.DashboardURL)
+	}
+	return defaultDashboardURL
+}
+
+func formatNextRefresh(refresh telemetry.Refresh) string {
+	if refresh.NextRefreshAt == nil {
+		return ""
+	}
+	return formatTimestamp(*refresh.NextRefreshAt)
+}
+
+func formatOptionalInfo(value string, s styles) string {
+	if strings.TrimSpace(value) == "" {
+		return s.muted.Render("n/a")
+	}
+	return s.info.Render(value)
 }
 
 func formatRuntimeAndTurns(seconds float64, turns int) string {
@@ -660,13 +693,13 @@ const (
 	defaultTerminalColumns = 123
 	runningIDWidth         = 8
 	runningStageWidth      = 14
-	runningHostWidth       = 12
+	runningProcessWidth    = 12
 	runningAgeWidth        = 12
 	runningTokensWidth     = 10
 	runningSessionWidth    = 18
 	runningEventMinWidth   = 12
 	runningRowChromeWidth  = 10
 	runningColumnGaps      = 6
-	fixedRunningWidth      = runningIDWidth + runningStageWidth + runningHostWidth + runningAgeWidth + runningTokensWidth + runningSessionWidth
+	fixedRunningWidth      = runningIDWidth + runningStageWidth + runningProcessWidth + runningAgeWidth + runningTokensWidth + runningSessionWidth
 	closingBorder          = "╰─"
 )

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -38,16 +38,19 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 	view := stripANSI(next.(Model).View())
 	for _, want := range []string{
 		"SYMPHONY STATUS",
-		"Dashboard: http://localhost:4000",
+		"Project: https://github.com/digitaldrywood/symphony",
+		"Dashboard: http://localhost:4101",
+		"Next refresh: 2026-05-31T00:16:00Z",
 		"Agents: 1 running | 1 queued | 1 blocked | 1 completed",
 		"Throughput: 7 tps",
 		"Tokens: in 110 | out 220 | total 330",
 		"Budget: enabled current $12.50 | projected $0.75 | day max $50.00 | issue max $5.00",
 		"Rate Limits: codex-primary | primary 90/100 reset 60s | secondary 0/100 reset 30s | credits 0/1",
 		"Running",
-		"HOST",
+		"PID",
 		"DD-44",
 		"In Progress",
+		"4242",
 		"12m 5s / 3",
 		"sess...567890",
 		"turn completed",
@@ -64,6 +67,9 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 		if !strings.Contains(view, want) {
 			t.Fatalf("View() missing %q:\n%s", want, view)
 		}
+	}
+	if strings.Contains(view, "worker-1") {
+		t.Fatalf("View() rendered worker host as process identity:\n%s", view)
 	}
 }
 
@@ -139,6 +145,16 @@ func testSnapshot() telemetry.Snapshot {
 
 	return telemetry.Snapshot{
 		GeneratedAt: generatedAt,
+		Project: telemetry.Project{
+			DisplayName: "Symphony",
+			URL:         "https://github.com/digitaldrywood/symphony",
+		},
+		DashboardURL: "http://localhost:4101",
+		Refresh: telemetry.Refresh{
+			PollIntervalSeconds: 30,
+			LastRefreshAt:       &generatedAt,
+			NextRefreshAt:       timePointer(generatedAt.Add(30 * time.Second)),
+		},
 		Counts: telemetry.Counts{
 			Running:   1,
 			Queue:     1,
@@ -153,14 +169,15 @@ func testSnapshot() telemetry.Snapshot {
 					State:      "In Progress",
 					Title:      "feat(tui): bubbletea ANSI dashboard on hub",
 				},
-				WorkerHost:     "worker-1",
-				WorkspacePath:  "/tmp/symphony/worktree",
-				SessionID:      "session-1234567890",
-				TurnCount:      3,
-				StartedAt:      startedAt,
-				LastEvent:      "turn_completed",
-				LastMessage:    "turn completed",
-				RuntimeSeconds: 12*60 + 5,
+				WorkerHost:      "worker-1",
+				ProcessIdentity: "4242",
+				WorkspacePath:   "/tmp/symphony/worktree",
+				SessionID:       "session-1234567890",
+				TurnCount:       3,
+				StartedAt:       startedAt,
+				LastEvent:       "turn_completed",
+				LastMessage:     "turn completed",
+				RuntimeSeconds:  12*60 + 5,
 				Tokens: telemetry.Tokens{
 					Input:  40,
 					Output: 60,
@@ -253,4 +270,8 @@ func testSnapshot() telemetry.Snapshot {
 func stripANSI(value string) string {
 	ansi := regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
 	return ansi.ReplaceAllString(value, "")
+}
+
+func timePointer(value time.Time) *time.Time {
+	return &value
 }

--- a/internal/tui/status_dashboard_parity_test.go
+++ b/internal/tui/status_dashboard_parity_test.go
@@ -68,6 +68,9 @@ func renderParitySnapshot(snapshot telemetry.Snapshot) string {
 }
 
 type statusDashboardParity struct {
+	Project        string
+	Dashboard      string
+	NextRefresh    string
 	AgentCount     int
 	Throughput     string
 	Runtime        string
@@ -117,6 +120,12 @@ func parseStatusDashboardParity(content string) statusDashboardParity {
 		switch {
 		case strings.HasPrefix(line, "│ Agents:"):
 			parsed.AgentCount = firstInteger(line)
+		case strings.HasPrefix(line, "│ Project:"):
+			parsed.Project = strings.TrimSpace(strings.TrimPrefix(line, "│ Project:"))
+		case strings.HasPrefix(line, "│ Dashboard:"):
+			parsed.Dashboard = strings.TrimSpace(strings.TrimPrefix(line, "│ Dashboard:"))
+		case strings.HasPrefix(line, "│ Next refresh:"):
+			parsed.NextRefresh = strings.TrimSpace(strings.TrimPrefix(line, "│ Next refresh:"))
 		case strings.HasPrefix(line, "│ Throughput:"):
 			parsed.Throughput = strings.TrimSpace(strings.TrimPrefix(line, "│ Throughput:"))
 		case strings.HasPrefix(line, "│ Runtime:"):
@@ -254,13 +263,13 @@ func sideBySide(want string, got string) string {
 }
 
 func parityIdleSnapshot() telemetry.Snapshot {
-	return telemetry.Snapshot{
+	return paritySnapshot(telemetry.Snapshot{
 		Tokens: telemetry.Tokens{},
-	}
+	})
 }
 
 func paritySuperBusySnapshot() telemetry.Snapshot {
-	return telemetry.Snapshot{
+	return paritySnapshot(telemetry.Snapshot{
 		Counts: telemetry.Counts{Running: 2},
 		Running: []telemetry.Running{
 			parityRunning(telemetry.Running{
@@ -269,13 +278,14 @@ func paritySuperBusySnapshot() telemetry.Snapshot {
 					Identifier: parityIdentifier("101"),
 					State:      "running",
 				},
-				WorkerHost:     "4242",
-				SessionID:      "thread-1234567890",
-				TurnCount:      11,
-				LastEvent:      "turn_completed",
-				LastMessage:    "turn completed (completed)",
-				RuntimeSeconds: 785,
-				Tokens:         telemetry.Tokens{Total: 120_450},
+				WorkerHost:      "worker-a",
+				ProcessIdentity: "4242",
+				SessionID:       "thread-1234567890",
+				TurnCount:       11,
+				LastEvent:       "turn_completed",
+				LastMessage:     "turn completed (completed)",
+				RuntimeSeconds:  785,
+				Tokens:          telemetry.Tokens{Total: 120_450},
 			}),
 			parityRunning(telemetry.Running{
 				Issue: telemetry.Issue{
@@ -283,13 +293,14 @@ func paritySuperBusySnapshot() telemetry.Snapshot {
 					Identifier: parityIdentifier("102"),
 					State:      "running",
 				},
-				WorkerHost:     "5252",
-				SessionID:      "thread-abcdef1234567890",
-				TurnCount:      4,
-				LastEvent:      "codex/event/task_started",
-				LastMessage:    "mix test --cover",
-				RuntimeSeconds: 412,
-				Tokens:         telemetry.Tokens{Total: 89_200},
+				WorkerHost:      "worker-b",
+				ProcessIdentity: "5252",
+				SessionID:       "thread-abcdef1234567890",
+				TurnCount:       4,
+				LastEvent:       "codex/event/task_started",
+				LastMessage:     "mix test --cover",
+				RuntimeSeconds:  412,
+				Tokens:          telemetry.Tokens{Total: 89_200},
 			}),
 		},
 		RateLimits: &telemetry.RateLimits{
@@ -316,11 +327,11 @@ func paritySuperBusySnapshot() telemetry.Snapshot {
 			RuntimeSeconds: 4_321,
 		},
 		Throughput: telemetry.TokenThroughput{TokensPerSecond: 1_842},
-	}
+	})
 }
 
 func parityBackoffQueueSnapshot() telemetry.Snapshot {
-	return telemetry.Snapshot{
+	return paritySnapshot(telemetry.Snapshot{
 		Counts: telemetry.Counts{Running: 1, Queue: 4},
 		Running: []telemetry.Running{
 			parityRunning(telemetry.Running{
@@ -329,13 +340,14 @@ func parityBackoffQueueSnapshot() telemetry.Snapshot {
 					Identifier: parityIdentifier("638"),
 					State:      "retrying",
 				},
-				WorkerHost:     "4242",
-				SessionID:      "thread-1234567890",
-				TurnCount:      7,
-				LastEvent:      "notification",
-				LastMessage:    "agent message streaming: waiting on rate-limit backoff window",
-				RuntimeSeconds: 1_225,
-				Tokens:         telemetry.Tokens{Total: 14_200},
+				WorkerHost:      "worker-a",
+				ProcessIdentity: "4242",
+				SessionID:       "thread-1234567890",
+				TurnCount:       7,
+				LastEvent:       "notification",
+				LastMessage:     "agent message streaming: waiting on rate-limit backoff window",
+				RuntimeSeconds:  1_225,
+				Tokens:          telemetry.Tokens{Total: 14_200},
 			}),
 		},
 		Queue: []telemetry.Queued{
@@ -363,11 +375,11 @@ func parityBackoffQueueSnapshot() telemetry.Snapshot {
 			RuntimeSeconds: 2_700,
 		},
 		Throughput: telemetry.TokenThroughput{TokensPerSecond: 15},
-	}
+	})
 }
 
 func parityCreditsUnlimitedSnapshot() telemetry.Snapshot {
-	return telemetry.Snapshot{
+	return paritySnapshot(telemetry.Snapshot{
 		Counts: telemetry.Counts{Running: 1},
 		Running: []telemetry.Running{
 			parityRunning(telemetry.Running{
@@ -376,13 +388,14 @@ func parityCreditsUnlimitedSnapshot() telemetry.Snapshot {
 					Identifier: parityIdentifier("777"),
 					State:      "running",
 				},
-				WorkerHost:     "4242",
-				SessionID:      "thread-1234567890",
-				TurnCount:      7,
-				LastEvent:      "codex/event/token_count",
-				LastMessage:    "thread token usage updated (in 90, out 12, total 102)",
-				RuntimeSeconds: 75,
-				Tokens:         telemetry.Tokens{Total: 3_200},
+				WorkerHost:      "worker-a",
+				ProcessIdentity: "4242",
+				SessionID:       "thread-1234567890",
+				TurnCount:       7,
+				LastEvent:       "codex/event/token_count",
+				LastMessage:     "thread token usage updated (in 90, out 12, total 102)",
+				RuntimeSeconds:  75,
+				Tokens:          telemetry.Tokens{Total: 3_200},
 			}),
 		},
 		RateLimits: &telemetry.RateLimits{
@@ -408,7 +421,13 @@ func parityCreditsUnlimitedSnapshot() telemetry.Snapshot {
 			RuntimeSeconds: 75,
 		},
 		Throughput: telemetry.TokenThroughput{TokensPerSecond: 42},
-	}
+	})
+}
+
+func paritySnapshot(snapshot telemetry.Snapshot) telemetry.Snapshot {
+	snapshot.Project = telemetry.Project{URL: parityProjectURL}
+	snapshot.DashboardURL = parityDashboardURL
+	return snapshot
 }
 
 func parityRunning(row telemetry.Running) telemetry.Running {
@@ -432,6 +451,11 @@ func parityIdentifier(number string) string {
 	return "M" + "T-" + number
 }
 
+const (
+	parityProjectURL   = "https://linear.app/project/project/issues"
+	parityDashboardURL = "http://localhost:4000"
+)
+
 const elixirIdleStatusSnapshot = `\e[1m╭─ SYMPHONY STATUS\e[0m
 \e[1m│ Agents: \e[0m\e[32m0\e[0m\e[90m/\e[0m\e[90m10\e[0m
 \e[1m│ Throughput: \e[0m\e[36m0 tps\e[0m
@@ -439,6 +463,7 @@ const elixirIdleStatusSnapshot = `\e[1m╭─ SYMPHONY STATUS\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 0\e[0m\e[90m | \e[0m\e[33mout 0\e[0m\e[90m | \e[0m\e[33mtotal 0\e[0m
 \e[1m│ Rate Limits: \e[0m\e[90munavailable\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
+\e[1m│ Dashboard: \e[0m\e[36mhttp://localhost:4000\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m
 │
@@ -459,6 +484,7 @@ const elixirSuperBusyStatusSnapshot = `\e[1m╭─ SYMPHONY STATUS\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 250,000\e[0m\e[90m | \e[0m\e[33mout 18,500\e[0m\e[90m | \e[0m\e[33mtotal 268,500\e[0m
 \e[1m│ Rate Limits: \e[0m\e[33mgpt-5\e[0m\e[90m | \e[0m\e[36mprimary 12,345/20,000 reset 30s\e[0m\e[90m | \e[0m\e[36msecondary 45/60 reset 12s\e[0m\e[90m | \e[0m\e[32mcredits 9876.50\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
+\e[1m│ Dashboard: \e[0m\e[36mhttp://localhost:4000\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m
 │
@@ -480,6 +506,7 @@ const elixirBackoffQueueStatusSnapshot = `\e[1m╭─ SYMPHONY STATUS\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 18,000\e[0m\e[90m | \e[0m\e[33mout 2,200\e[0m\e[90m | \e[0m\e[33mtotal 20,200\e[0m
 \e[1m│ Rate Limits: \e[0m\e[33mgpt-5\e[0m\e[90m | \e[0m\e[36mprimary 0/20,000 reset 95s\e[0m\e[90m | \e[0m\e[36msecondary 0/60 reset 45s\e[0m\e[90m | \e[0m\e[32mcredits none\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
+\e[1m│ Dashboard: \e[0m\e[36mhttp://localhost:4000\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m
 │
@@ -503,6 +530,7 @@ const elixirCreditsUnlimitedStatusSnapshot = `\e[1m╭─ SYMPHONY STATUS\e[0m
 \e[1m│ Tokens: \e[0m\e[33min 90\e[0m\e[90m | \e[0m\e[33mout 12\e[0m\e[90m | \e[0m\e[33mtotal 102\e[0m
 \e[1m│ Rate Limits: \e[0m\e[33mpriority-tier\e[0m\e[90m | \e[0m\e[36mprimary 100/100 reset 1s\e[0m\e[90m | \e[0m\e[36msecondary 500/500 reset 1s\e[0m\e[90m | \e[0m\e[32mcredits unlimited\e[0m
 \e[1m│ Project: \e[0m\e[36mhttps://linear.app/project/project/issues\e[0m
+\e[1m│ Dashboard: \e[0m\e[36mhttp://localhost:4000\e[0m
 \e[1m│ Next refresh: \e[0m\e[90mn/a\e[0m
 \e[1m├─ Running\e[0m
 │


### PR DESCRIPTION
## Summary

- carry project, dashboard, refresh, and process identity fields through telemetry snapshots
- render Project, Dashboard, Next refresh, and PID/process identity in the terminal status dashboard
- cover telemetry JSON, snapshot merging, process identity propagation, and TUI parity formatting

Fixes #150

## Test Plan

- [x] `go test ./internal/tui ./internal/telemetry ./internal/orchestrator ./internal/runner ./internal/codex ./internal/cli`
- [x] `make check`