### PR TITLE
feat(release): publish homebrew formula

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,3 +37,4 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -42,6 +42,24 @@ archives:
       - README.md
       - LICENSE
 
+brews:
+  - name: symphony
+    ids:
+      - symphony
+    repository:
+      owner: digitaldrywood
+      name: homebrew-tap
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    directory: Formula
+    url_template: "https://github.com/digitaldrywood/symphony/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+    homepage: https://github.com/digitaldrywood/symphony
+    description: Agent orchestrator for tracker-backed work queues
+    license: MIT
+    install: |
+      bin.install "symphony"
+    test: |
+      system "#{bin}/symphony", "--version"
+
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
   algorithm: sha256


### PR DESCRIPTION
## Summary

- add GoReleaser Homebrew formula publishing for `digitaldrywood/homebrew-tap`
- pass `HOMEBREW_TAP_GITHUB_TOKEN` into the release workflow for tap pushes
- pin generated formula download URLs to `digitaldrywood/symphony` release assets

Fixes #98

## Test Plan

- [x] `make check`
- [x] `goreleaser release --snapshot --clean`