### PR TITLE
feat(cli): add doctor preflight

### DIFF
--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -159,6 +159,7 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 	}
 
 	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	done := make(chan error, 1)
 	go func() {
 		done <- startRunning(ctx, BootConfig{
@@ -180,7 +181,7 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
 		}
-	case <-time.After(5 * time.Second):
+	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for startRunning to stop")
 	}
 }
@@ -227,10 +228,10 @@ func freeLoopbackPort(t *testing.T) (string, int) {
 func waitForDashboard(t *testing.T, url string, done <-chan error) string {
 	t.Helper()
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
-	client := http.Client{Timeout: 500 * time.Millisecond}
+	client := http.Client{Timeout: time.Second}
 	for ctx.Err() == nil {
 		select {
 		case err := <-done:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -176,6 +176,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	cmd.PersistentFlags().IntVar(&port, "port", -1, "web server port, or 0 for an ephemeral port")
 	cmd.PersistentFlags().BoolVar(&headless, "headless", false, "stream logs instead of launching the terminal dashboard")
 	cmd.AddCommand(
+		newDoctorCommand(&configPath, &host, &port, opts),
 		newInitCommand(&configPath, opts),
 		newAddProjectCommand(&configPath, opts),
 		newEditProjectCommand(&configPath, opts, OperationPauseProject, "pause", "Pause a project", func(project *globalconfig.Project) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -31,7 +31,7 @@ func TestRootCommandHelpListsAdminCommands(t *testing.T) {
 	}
 
 	output := stdout.String()
-	for _, want := range []string{"symphony", "agent orchestrator", "init", "add-project", "pause", "unpause", "promote", "remove-project"} {
+	for _, want := range []string{"symphony", "agent orchestrator", "doctor", "init", "add-project", "pause", "unpause", "promote", "remove-project"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("help output missing %q:\n%s", want, output)
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1,0 +1,708 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	_ "modernc.org/sqlite"
+
+	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
+)
+
+var ErrDoctorFailed = errors.New("doctor found failed checks")
+
+const doctorCommandTimeout = 5 * time.Second
+
+type doctorStatus string
+
+const (
+	doctorOK   doctorStatus = "OK"
+	doctorWarn doctorStatus = "WARN"
+	doctorFail doctorStatus = "FAIL"
+)
+
+var requiredGitHubScopes = []string{"repo", "read:org", "project"}
+
+type doctorCheck struct {
+	Name   string
+	Status doctorStatus
+	Detail string
+	Hint   string
+}
+
+type doctorReport struct {
+	Checks []doctorCheck
+}
+
+type doctorConfig struct {
+	ConfigPath string
+	Host       string
+	Port       int
+}
+
+type doctorStore interface {
+	Close() error
+}
+
+type doctorDeps struct {
+	loadWorkflow func(string) (workflowconfig.Workflow, error)
+	lookupEnv    func(string) string
+	lookPath     func(string) (string, error)
+	runCommand   func(context.Context, string, ...string) error
+	githubScopes func(context.Context, string) ([]string, error)
+	listen       func(string, string) (net.Listener, error)
+	openSQLite   func(context.Context, string) (doctorStore, error)
+	gitWorkTree  func(context.Context, string) error
+}
+
+func newDoctorCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
+	return newDoctorCommandWithDeps(configPath, host, port, opts, doctorDeps{})
+}
+
+func newDoctorCommandWithDeps(configPath *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
+	return &cobra.Command{
+		Use:   "doctor",
+		Short: "Run preflight health checks",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			report := runDoctor(cmd.Context(), doctorConfig{
+				ConfigPath: derefString(configPath),
+				Host:       derefString(host),
+				Port:       derefInt(port, -1),
+			}, opts, deps)
+			if err := writeDoctorReport(cmd.OutOrStdout(), report); err != nil {
+				return err
+			}
+			if report.HasFailures() {
+				return ErrDoctorFailed
+			}
+			return nil
+		},
+	}
+}
+
+func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorDeps) doctorReport {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	opts = doctorOptions(opts)
+	deps = deps.withDefaults()
+
+	var report doctorReport
+	resolution, global, configCheck := checkDoctorConfig(cfg.ConfigPath, opts)
+	report.Add(configCheck)
+
+	boot := BootConfig{
+		Host: strings.TrimSpace(cfg.Host),
+		Port: bootPort(cfg.Port),
+	}
+	if global != nil {
+		boot.Global = *global
+		boot.Host, boot.Port = bootServer(cfg.Host, cfg.Port, firstGlobalWorkflowPath(*global))
+		report.Checks = append(report.Checks, checkDoctorProjects(ctx, *global, deps)...)
+	} else {
+		report.Add(doctorCheck{
+			Name:   "Project workflows",
+			Status: doctorWarn,
+			Detail: "skipped because global config could not be loaded",
+			Hint:   "Fix the global config, then rerun symphony doctor.",
+		})
+	}
+
+	report.Add(checkDoctorSQLite(ctx, resolution, deps))
+	report.Add(checkDoctorCodex(ctx, deps))
+	report.Add(checkDoctorGitHub(ctx, global, deps))
+	report.Add(checkDoctorServerPort(boot, deps))
+	report.Add(checkDoctorGit(ctx, deps))
+
+	return report
+}
+
+func (r *doctorReport) Add(check doctorCheck) {
+	r.Checks = append(r.Checks, check)
+}
+
+func (r doctorReport) HasFailures() bool {
+	for _, check := range r.Checks {
+		if check.Status == doctorFail {
+			return true
+		}
+	}
+	return false
+}
+
+func (r doctorReport) counts() map[doctorStatus]int {
+	counts := map[doctorStatus]int{
+		doctorOK:   0,
+		doctorWarn: 0,
+		doctorFail: 0,
+	}
+	for _, check := range r.Checks {
+		counts[check.Status]++
+	}
+	return counts
+}
+
+func writeDoctorReport(out io.Writer, report doctorReport) error {
+	if out == nil {
+		out = io.Discard
+	}
+
+	if _, err := fmt.Fprintln(out, "Symphony Doctor"); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(out); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "%-5s  %-28s  %s\n", "STATUS", "CHECK", "DETAIL"); err != nil {
+		return err
+	}
+	for _, check := range report.Checks {
+		if _, err := fmt.Fprintf(out, "%-5s  %-28s  %s\n", check.Status, check.Name, check.Detail); err != nil {
+			return err
+		}
+		if strings.TrimSpace(check.Hint) != "" {
+			if _, err := fmt.Fprintf(out, "%-5s  %-28s  Hint: %s\n", "", "", check.Hint); err != nil {
+				return err
+			}
+		}
+	}
+
+	counts := report.counts()
+	if _, err := fmt.Fprintln(out); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintf(out, "Summary: %d OK, %d WARN, %d FAIL\n", counts[doctorOK], counts[doctorWarn], counts[doctorFail]); err != nil {
+		return err
+	}
+	result := "PASS"
+	if counts[doctorFail] > 0 {
+		result = "FAIL"
+	}
+	_, err := fmt.Fprintf(out, "Result: %s\n", result)
+	return err
+}
+
+func checkDoctorConfig(configPath string, opts options) (globalconfig.PathResolution, *globalconfig.Config, doctorCheck) {
+	resolution, err := resolveConfigPathResolution(configPath, opts)
+	if err != nil {
+		return globalconfig.PathResolution{}, nil, doctorCheck{
+			Name:   "Config resolution",
+			Status: doctorFail,
+			Detail: err.Error(),
+			Hint:   "Pass --config or set SYMPHONY_CONFIG to a readable global.yaml.",
+		}
+	}
+
+	cfg, err := opts.read(resolution.Path)
+	if err != nil {
+		return resolution, nil, doctorCheck{
+			Name:   "Config resolution",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s via %s; %v", resolution.Path, resolution.Rule, err),
+			Hint:   "Run symphony init or fix the global config file.",
+		}
+	}
+
+	return resolution, &cfg, doctorCheck{
+		Name:   "Config resolution",
+		Status: doctorOK,
+		Detail: fmt.Sprintf("%s via %s; %d project(s)", cfg.Path, resolution.Rule, len(cfg.Projects)),
+	}
+}
+
+func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps) []doctorCheck {
+	if len(cfg.Projects) == 0 {
+		return []doctorCheck{
+			{
+				Name:   "Project workflows",
+				Status: doctorWarn,
+				Detail: "no projects configured",
+				Hint:   "Run symphony add-project to add a project.",
+			},
+		}
+	}
+
+	checks := make([]doctorCheck, 0, len(cfg.Projects)*2)
+	for _, project := range cfg.Projects {
+		id := strings.TrimSpace(project.ID)
+		if id == "" {
+			id = "project"
+		}
+		workflow, err := deps.loadWorkflow(project.Workflow)
+		if err != nil {
+			checks = append(checks, doctorCheck{
+				Name:   "Project " + id + " workflow",
+				Status: doctorFail,
+				Detail: fmt.Sprintf("%s: %v", project.Workflow, err),
+				Hint:   "Fix the WORKFLOW.md path or YAML frontmatter.",
+			})
+			checks = append(checks, doctorCheck{
+				Name:   "Project " + id + " source repo",
+				Status: doctorWarn,
+				Detail: "skipped because WORKFLOW.md could not be loaded",
+				Hint:   "Fix the workflow file, then rerun symphony doctor.",
+			})
+			continue
+		}
+		if err := workflow.Config.Validate(); err != nil {
+			checks = append(checks, doctorCheck{
+				Name:   "Project " + id + " workflow",
+				Status: doctorFail,
+				Detail: fmt.Sprintf("%s: %v", project.Workflow, err),
+				Hint:   "Fix invalid WORKFLOW.md frontmatter.",
+			})
+			checks = append(checks, doctorCheck{
+				Name:   "Project " + id + " source repo",
+				Status: doctorWarn,
+				Detail: "skipped because WORKFLOW.md is invalid",
+				Hint:   "Fix the workflow file, then rerun symphony doctor.",
+			})
+			continue
+		}
+
+		checks = append(checks, doctorCheck{
+			Name:   "Project " + id + " workflow",
+			Status: doctorOK,
+			Detail: project.Workflow + " is valid",
+		})
+
+		sourceRoot := projectSourceRoot(project, workflow.Config)
+		if sourceRoot == "" {
+			checks = append(checks, doctorCheck{
+				Name:   "Project " + id + " source repo",
+				Status: doctorFail,
+				Detail: "source root is not configured",
+				Hint:   "Set workspace.source_root or workspace.root to an existing git checkout.",
+			})
+			continue
+		}
+		if err := deps.gitWorkTree(ctx, sourceRoot); err != nil {
+			checks = append(checks, doctorCheck{
+				Name:   "Project " + id + " source repo",
+				Status: doctorFail,
+				Detail: fmt.Sprintf("%s: %v", sourceRoot, err),
+				Hint:   "Set workspace.source_root to an existing git checkout.",
+			})
+			continue
+		}
+		checks = append(checks, doctorCheck{
+			Name:   "Project " + id + " source repo",
+			Status: doctorOK,
+			Detail: sourceRoot + " is a git worktree",
+		})
+	}
+
+	return checks
+}
+
+func projectSourceRoot(project globalconfig.Project, cfg workflowconfig.Config) string {
+	if sourceRoot := strings.TrimSpace(cfg.Workspace.SourceRoot); sourceRoot != "" {
+		return sourceRoot
+	}
+	if root := strings.TrimSpace(cfg.Workspace.Root); root != "" {
+		return root
+	}
+	return strings.TrimSpace(project.Workdir)
+}
+
+func checkDoctorSQLite(ctx context.Context, resolution globalconfig.PathResolution, deps doctorDeps) doctorCheck {
+	if strings.TrimSpace(resolution.Path) == "" {
+		return doctorCheck{
+			Name:   "SQLite database",
+			Status: doctorFail,
+			Detail: "global config path is unavailable",
+			Hint:   "Fix config resolution, then rerun symphony doctor.",
+		}
+	}
+
+	dbPath := filepath.Join(filepath.Dir(resolution.Path), "symphony.db")
+	db, err := deps.openSQLite(ctx, dbPath)
+	if err != nil {
+		return doctorCheck{
+			Name:   "SQLite database",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s: %v", dbPath, err),
+			Hint:   "Check directory permissions and remove any corrupt runtime database.",
+		}
+	}
+	if err := db.Close(); err != nil {
+		return doctorCheck{
+			Name:   "SQLite database",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s close failed: %v", dbPath, err),
+			Hint:   "Check for filesystem or SQLite errors, then rerun symphony doctor.",
+		}
+	}
+
+	return doctorCheck{
+		Name:   "SQLite database",
+		Status: doctorOK,
+		Detail: dbPath + " is reachable",
+	}
+}
+
+func checkDoctorCodex(ctx context.Context, deps doctorDeps) doctorCheck {
+	return checkDoctorBinary(ctx, deps, "codex", "codex binary", "--version", "Install Codex and ensure codex --version succeeds.")
+}
+
+func checkDoctorGit(ctx context.Context, deps doctorDeps) doctorCheck {
+	return checkDoctorBinary(ctx, deps, "git", "git binary", "--version", "Install git and ensure git --version succeeds.")
+}
+
+func checkDoctorBinary(ctx context.Context, deps doctorDeps, binary string, name string, arg string, hint string) doctorCheck {
+	path, err := deps.lookPath(binary)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: binary + " was not found on PATH",
+			Hint:   hint,
+		}
+	}
+	if err := deps.runCommand(ctx, path, arg); err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s %s failed: %v", path, arg, err),
+			Hint:   hint,
+		}
+	}
+
+	return doctorCheck{
+		Name:   name,
+		Status: doctorOK,
+		Detail: path + " is runnable",
+	}
+}
+
+func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps) doctorCheck {
+	token, source := doctorGitHubToken(cfg, deps)
+	if token == "" {
+		return doctorCheck{
+			Name:   "GitHub token",
+			Status: doctorFail,
+			Detail: "GITHUB_TOKEN is not set and no usable tracker.api_key was found",
+			Hint:   `Run gh auth login --scopes "repo,read:org,project" and export GITHUB_TOKEN="$(gh auth token)".`,
+		}
+	}
+
+	scopes, err := deps.githubScopes(ctx, token)
+	if err != nil {
+		return doctorCheck{
+			Name:   "GitHub token",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s scope check failed: %v", source, err),
+			Hint:   `Refresh the token with repo, read:org, and project scopes.`,
+		}
+	}
+	missing := missingGitHubScopes(scopes)
+	if len(missing) > 0 {
+		return doctorCheck{
+			Name:   "GitHub token",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s missing scope(s): %s", source, strings.Join(missing, ", ")),
+			Hint:   `Run gh auth login --scopes "repo,read:org,project" and export GITHUB_TOKEN="$(gh auth token)".`,
+		}
+	}
+
+	return doctorCheck{
+		Name:   "GitHub token",
+		Status: doctorOK,
+		Detail: fmt.Sprintf("%s has required scopes: %s", source, strings.Join(requiredGitHubScopes, ", ")),
+	}
+}
+
+func doctorGitHubToken(cfg *globalconfig.Config, deps doctorDeps) (string, string) {
+	if cfg != nil {
+		for _, project := range cfg.Projects {
+			workflow, err := deps.loadWorkflow(project.Workflow)
+			if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+				continue
+			}
+			if token, source := resolveDoctorSecret(workflow.Config.Tracker.APIKey, deps.lookupEnv); token != "" {
+				if source == "" {
+					source = "tracker.api_key"
+				}
+				return token, source
+			}
+		}
+	}
+	if token := strings.TrimSpace(deps.lookupEnv("GITHUB_TOKEN")); token != "" {
+		return token, "GITHUB_TOKEN"
+	}
+	return "", ""
+}
+
+func resolveDoctorSecret(value string, lookupEnv func(string) string) (string, string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", ""
+	}
+	if strings.HasPrefix(value, "$") {
+		name := strings.TrimPrefix(value, "$")
+		if validEnvName(name) {
+			return strings.TrimSpace(lookupEnv(name)), name
+		}
+	}
+	return value, "tracker.api_key"
+}
+
+func validEnvName(name string) bool {
+	if name == "" {
+		return false
+	}
+	for index, r := range name {
+		if r == '_' || r >= 'A' && r <= 'Z' || r >= 'a' && r <= 'z' {
+			continue
+		}
+		if index > 0 && r >= '0' && r <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func missingGitHubScopes(scopes []string) []string {
+	have := make(map[string]struct{}, len(scopes))
+	for _, scope := range scopes {
+		scope = strings.ToLower(strings.TrimSpace(scope))
+		if scope != "" {
+			have[scope] = struct{}{}
+		}
+	}
+
+	var missing []string
+	for _, scope := range requiredGitHubScopes {
+		if _, ok := have[scope]; !ok {
+			missing = append(missing, scope)
+		}
+	}
+	return missing
+}
+
+func checkDoctorServerPort(cfg BootConfig, deps doctorDeps) doctorCheck {
+	addr := serverAddr(cfg)
+	listener, err := deps.listen("tcp", addr)
+	if err != nil {
+		return doctorCheck{
+			Name:   "Server port",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s is not available: %v", addr, err),
+			Hint:   "Stop the process using the port or pass --port with an available value.",
+		}
+	}
+	if err := listener.Close(); err != nil {
+		return doctorCheck{
+			Name:   "Server port",
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("%s was available, but close failed: %v", addr, err),
+			Hint:   "Rerun symphony doctor and check for local network errors.",
+		}
+	}
+
+	host, portText, err := net.SplitHostPort(listener.Addr().String())
+	if err == nil && portText != "" {
+		if port, parseErr := strconv.Atoi(portText); parseErr == nil && port > 0 && host != "" {
+			addr = net.JoinHostPort(host, strconv.Itoa(port))
+		}
+	}
+
+	return doctorCheck{
+		Name:   "Server port",
+		Status: doctorOK,
+		Detail: addr + " is available",
+	}
+}
+
+func doctorOptions(opts options) options {
+	defaults := defaultOptions()
+	if opts.resolvePath == nil {
+		opts.resolvePath = defaults.resolvePath
+	}
+	if opts.read == nil {
+		opts.read = defaults.read
+	}
+	return opts
+}
+
+func (d doctorDeps) withDefaults() doctorDeps {
+	defaults := defaultDoctorDeps()
+	if d.loadWorkflow == nil {
+		d.loadWorkflow = defaults.loadWorkflow
+	}
+	if d.lookupEnv == nil {
+		d.lookupEnv = defaults.lookupEnv
+	}
+	if d.lookPath == nil {
+		d.lookPath = defaults.lookPath
+	}
+	if d.runCommand == nil {
+		d.runCommand = defaults.runCommand
+	}
+	if d.githubScopes == nil {
+		d.githubScopes = defaults.githubScopes
+	}
+	if d.listen == nil {
+		d.listen = defaults.listen
+	}
+	if d.openSQLite == nil {
+		d.openSQLite = defaults.openSQLite
+	}
+	if d.gitWorkTree == nil {
+		d.gitWorkTree = defaults.gitWorkTree
+	}
+	return d
+}
+
+func defaultDoctorDeps() doctorDeps {
+	return doctorDeps{
+		loadWorkflow: workflowconfig.LoadWorkflow,
+		lookupEnv:    os.Getenv,
+		lookPath:     exec.LookPath,
+		runCommand:   runDoctorCommand,
+		githubScopes: defaultGitHubScopes,
+		listen:       net.Listen,
+		openSQLite:   openDoctorSQLite,
+		gitWorkTree:  defaultGitWorkTree,
+	}
+}
+
+func openDoctorSQLite(ctx context.Context, path string) (doctorStore, error) {
+	if strings.TrimSpace(path) == "" {
+		return nil, errors.New("sqlite path is required")
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("create sqlite directory: %w", err)
+	}
+
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite database: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+
+	if err := db.PingContext(ctx); err != nil {
+		if closeErr := db.Close(); closeErr != nil {
+			return nil, fmt.Errorf("ping sqlite database: %w; close sqlite database: %v", err, closeErr)
+		}
+		return nil, fmt.Errorf("ping sqlite database: %w", err)
+	}
+	return db, nil
+}
+
+func runDoctorCommand(ctx context.Context, path string, args ...string) error {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, path, args...) // #nosec G204 -- doctor runs fixed PATH-resolved preflight binaries.
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return commandCtx.Err()
+	}
+	if err == nil {
+		return nil
+	}
+	if detail := strings.TrimSpace(string(output)); detail != "" {
+		return fmt.Errorf("%w: %s", err, detail)
+	}
+	return err
+}
+
+func defaultGitWorkTree(ctx context.Context, path string) error {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, "git", "-C", path, "rev-parse", "--is-inside-work-tree")
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return commandCtx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return fmt.Errorf("%w: %s", err, detail)
+		}
+		return err
+	}
+	if strings.TrimSpace(string(output)) != "true" {
+		return errors.New("not inside a git worktree")
+	}
+	return nil
+}
+
+func defaultGitHubScopes(ctx context.Context, token string) ([]string, error) {
+	requestCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, "https://api.github.com/user", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("User-Agent", "symphony-doctor")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	_, copyErr := io.Copy(io.Discard, resp.Body)
+	closeErr := resp.Body.Close()
+	if copyErr != nil {
+		return nil, copyErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("GitHub returned %s", resp.Status)
+	}
+
+	scopes := parseGitHubScopes(resp.Header.Get("X-OAuth-Scopes"))
+	if len(scopes) == 0 {
+		return nil, errors.New("GitHub did not report OAuth scopes")
+	}
+	return scopes, nil
+}
+
+func parseGitHubScopes(raw string) []string {
+	fields := strings.Split(raw, ",")
+	scopes := make([]string, 0, len(fields))
+	for _, field := range fields {
+		scope := strings.TrimSpace(field)
+		if scope != "" {
+			scopes = append(scopes, scope)
+		}
+	}
+	sort.Strings(scopes)
+	return scopes
+}
+
+func derefString(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func derefInt(value *int, fallback int) int {
+	if value == nil {
+		return fallback
+	}
+	return *value
+}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1,0 +1,512 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"net"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/symphony/internal/config"
+	globalconfig "github.com/digitaldrywood/symphony/internal/config/global"
+)
+
+func TestCheckDoctorBinary(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		lookPath   func(string) (string, error)
+		runCommand func(context.Context, string, ...string) error
+		want       doctorStatus
+		wantDetail string
+	}{
+		{
+			name: "missing from path",
+			lookPath: func(string) (string, error) {
+				return "", errors.New("missing")
+			},
+			runCommand: func(context.Context, string, ...string) error {
+				return nil
+			},
+			want:       doctorFail,
+			wantDetail: "not found on PATH",
+		},
+		{
+			name: "not runnable",
+			lookPath: func(string) (string, error) {
+				return "/usr/bin/codex", nil
+			},
+			runCommand: func(context.Context, string, ...string) error {
+				return errors.New("permission denied")
+			},
+			want:       doctorFail,
+			wantDetail: "permission denied",
+		},
+		{
+			name: "runnable",
+			lookPath: func(string) (string, error) {
+				return "/usr/bin/codex", nil
+			},
+			runCommand: func(context.Context, string, ...string) error {
+				return nil
+			},
+			want:       doctorOK,
+			wantDetail: "is runnable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := checkDoctorBinary(context.Background(), doctorDeps{
+				lookPath:   tt.lookPath,
+				runCommand: tt.runCommand,
+			}, "codex", "codex binary", "--version", "install codex")
+			if got.Status != tt.want {
+				t.Fatalf("Status = %s, want %s", got.Status, tt.want)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorProjects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		projects   []globalconfig.Project
+		workflow   workflowconfig.Workflow
+		loadErr    error
+		gitErr     error
+		wantStatus []doctorStatus
+		wantDetail []string
+	}{
+		{
+			name:       "no projects configured",
+			wantStatus: []doctorStatus{doctorWarn},
+			wantDetail: []string{"no projects configured"},
+		},
+		{
+			name: "workflow cannot load",
+			projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			},
+			loadErr:    errors.New("missing workflow"),
+			wantStatus: []doctorStatus{doctorFail, doctorWarn},
+			wantDetail: []string{"missing workflow", "skipped"},
+		},
+		{
+			name: "workflow invalid",
+			projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			},
+			workflow:   workflowconfig.Workflow{Config: workflowconfig.Config{}},
+			wantStatus: []doctorStatus{doctorFail, doctorWarn},
+			wantDetail: []string{"tracker.kind", "skipped"},
+		},
+		{
+			name: "source repo missing",
+			projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			},
+			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
+			gitErr:     errors.New("not a git worktree"),
+			wantStatus: []doctorStatus{doctorOK, doctorFail},
+			wantDetail: []string{"is valid", "not a git worktree"},
+		},
+		{
+			name: "workflow and source repo valid",
+			projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			},
+			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
+			wantStatus: []doctorStatus{doctorOK, doctorOK},
+			wantDetail: []string{"is valid", "is a git worktree"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := checkDoctorProjects(context.Background(), globalconfig.Config{Projects: tt.projects}, doctorDeps{
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return tt.workflow, tt.loadErr
+				},
+				gitWorkTree: func(context.Context, string) error {
+					return tt.gitErr
+				},
+			})
+			if len(got) != len(tt.wantStatus) {
+				t.Fatalf("len(checks) = %d, want %d: %#v", len(got), len(tt.wantStatus), got)
+			}
+			for i, check := range got {
+				if check.Status != tt.wantStatus[i] {
+					t.Fatalf("checks[%d].Status = %s, want %s", i, check.Status, tt.wantStatus[i])
+				}
+				if !strings.Contains(check.Detail, tt.wantDetail[i]) {
+					t.Fatalf("checks[%d].Detail = %q, want containing %q", i, check.Detail, tt.wantDetail[i])
+				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorGitHub(t *testing.T) {
+	t.Parallel()
+
+	githubWorkflow := validDoctorWorkflow("/repo")
+	githubWorkflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	githubWorkflow.Tracker.APIKey = "$PROJECT_TOKEN"
+
+	tests := []struct {
+		name       string
+		cfg        *globalconfig.Config
+		env        map[string]string
+		scopes     []string
+		scopeErr   error
+		want       doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "missing token",
+			want:       doctorFail,
+			wantDetail: "GITHUB_TOKEN is not set",
+		},
+		{
+			name:       "scope check fails",
+			env:        map[string]string{"GITHUB_TOKEN": "token"},
+			scopeErr:   errors.New("unauthorized"),
+			want:       doctorFail,
+			wantDetail: "scope check failed",
+		},
+		{
+			name:       "missing required scope",
+			env:        map[string]string{"GITHUB_TOKEN": "token"},
+			scopes:     []string{"repo"},
+			want:       doctorFail,
+			wantDetail: "read:org",
+		},
+		{
+			name: "workflow token has required scopes",
+			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			}},
+			env:        map[string]string{"PROJECT_TOKEN": "token"},
+			scopes:     []string{"project", "read:org", "repo"},
+			want:       doctorOK,
+			wantDetail: "PROJECT_TOKEN has required scopes",
+		},
+		{
+			name:       "environment token has required scopes",
+			env:        map[string]string{"GITHUB_TOKEN": "token"},
+			scopes:     []string{"workflow", "project", "read:org", "repo"},
+			want:       doctorOK,
+			wantDetail: "GITHUB_TOKEN has required scopes",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := checkDoctorGitHub(context.Background(), tt.cfg, doctorDeps{
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return workflowconfig.Workflow{Config: githubWorkflow}, nil
+				},
+				lookupEnv: func(key string) string {
+					return tt.env[key]
+				},
+				githubScopes: func(context.Context, string) ([]string, error) {
+					return tt.scopes, tt.scopeErr
+				},
+			})
+			if got.Status != tt.want {
+				t.Fatalf("Status = %s, want %s", got.Status, tt.want)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorSQLite(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		path       string
+		openErr    error
+		closeErr   error
+		want       doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "missing config path",
+			want:       doctorFail,
+			wantDetail: "global config path is unavailable",
+		},
+		{
+			name:       "open fails",
+			path:       "/tmp/symphony/global.yaml",
+			openErr:    errors.New("readonly"),
+			want:       doctorFail,
+			wantDetail: "readonly",
+		},
+		{
+			name:       "close fails",
+			path:       "/tmp/symphony/global.yaml",
+			closeErr:   errors.New("close failed"),
+			want:       doctorFail,
+			wantDetail: "close failed",
+		},
+		{
+			name:       "database reachable",
+			path:       "/tmp/symphony/global.yaml",
+			want:       doctorOK,
+			wantDetail: "symphony.db is reachable",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := checkDoctorSQLite(context.Background(), globalconfig.PathResolution{Path: tt.path}, doctorDeps{
+				openSQLite: func(_ context.Context, path string) (doctorStore, error) {
+					if tt.openErr != nil {
+						return nil, tt.openErr
+					}
+					if got := filepath.Base(path); got != "symphony.db" {
+						t.Fatalf("store path base = %q, want symphony.db", got)
+					}
+					return fakeDoctorStore{closeErr: tt.closeErr}, nil
+				},
+			})
+			if got.Status != tt.want {
+				t.Fatalf("Status = %s, want %s", got.Status, tt.want)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorServerPort(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		listenErr  error
+		closeErr   error
+		want       doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "port unavailable",
+			listenErr:  errors.New("address already in use"),
+			want:       doctorFail,
+			wantDetail: "address already in use",
+		},
+		{
+			name:       "close fails after bind",
+			closeErr:   errors.New("close failed"),
+			want:       doctorWarn,
+			wantDetail: "close failed",
+		},
+		{
+			name:       "port available",
+			want:       doctorOK,
+			wantDetail: "is available",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			port := 0
+			got := checkDoctorServerPort(BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+				listen: func(_, address string) (net.Listener, error) {
+					if address != "127.0.0.1:0" {
+						t.Fatalf("listen address = %q, want 127.0.0.1:0", address)
+					}
+					if tt.listenErr != nil {
+						return nil, tt.listenErr
+					}
+					return fakeDoctorListener{addr: fakeDoctorAddr("127.0.0.1:49152"), closeErr: tt.closeErr}, nil
+				},
+			})
+			if got.Status != tt.want {
+				t.Fatalf("Status = %s, want %s", got.Status, tt.want)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+		})
+	}
+}
+
+func TestDoctorCommandExitStatus(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		deps       doctorDeps
+		wantErr    error
+		wantOutput string
+	}{
+		{
+			name:       "passes with warnings only",
+			deps:       successfulDoctorDeps(),
+			wantOutput: "Result: PASS",
+		},
+		{
+			name: "fails when any check fails",
+			deps: doctorDeps{
+				runCommand: func(_ context.Context, path string, _ ...string) error {
+					if strings.HasSuffix(path, "codex") {
+						return errors.New("not runnable")
+					}
+					return nil
+				},
+			},
+			wantErr:    ErrDoctorFailed,
+			wantOutput: "Result: FAIL",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			configPath := filepath.Join(t.TempDir(), "global.yaml")
+			host := "127.0.0.1"
+			port := 0
+			opts := successfulDoctorOptions(configPath)
+			deps := successfulDoctorDeps()
+			if tt.deps.runCommand != nil {
+				deps.runCommand = tt.deps.runCommand
+			}
+			if tt.deps.lookPath != nil {
+				deps.lookPath = tt.deps.lookPath
+			}
+
+			cmd := newDoctorCommandWithDeps(&configPath, &host, &port, opts, deps)
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+
+			err := cmd.Execute()
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Execute() error = %v, want %v", err, tt.wantErr)
+			}
+			if !strings.Contains(stdout.String(), tt.wantOutput) {
+				t.Fatalf("output missing %q:\n%s", tt.wantOutput, stdout.String())
+			}
+		})
+	}
+}
+
+func validDoctorWorkflow(sourceRoot string) workflowconfig.Config {
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Workspace.Root = sourceRoot
+	return cfg
+}
+
+func successfulDoctorOptions(configPath string) options {
+	return options{
+		resolvePath: func(string) (globalconfig.PathResolution, error) {
+			return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
+		},
+		read: func(string) (globalconfig.Config, error) {
+			return globalconfig.Config{
+				Path:       configPath,
+				APIVersion: globalconfig.APIVersion,
+				Kind:       globalconfig.Kind,
+				Global: globalconfig.Settings{
+					MaxConcurrentAgents: 1,
+					Scheduling:          globalconfig.SchedulingWeighted,
+				},
+				Projects: []globalconfig.Project{},
+			}, nil
+		},
+	}
+}
+
+func successfulDoctorDeps() doctorDeps {
+	return doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")}, nil
+		},
+		lookupEnv: func(key string) string {
+			if key == "GITHUB_TOKEN" {
+				return "token"
+			}
+			return ""
+		},
+		lookPath: func(binary string) (string, error) {
+			return "/usr/bin/" + binary, nil
+		},
+		runCommand: func(context.Context, string, ...string) error {
+			return nil
+		},
+		githubScopes: func(context.Context, string) ([]string, error) {
+			return []string{"repo", "read:org", "project"}, nil
+		},
+		listen: func(string, string) (net.Listener, error) {
+			return fakeDoctorListener{addr: fakeDoctorAddr("127.0.0.1:49152")}, nil
+		},
+		openSQLite: func(context.Context, string) (doctorStore, error) {
+			return fakeDoctorStore{}, nil
+		},
+		gitWorkTree: func(context.Context, string) error {
+			return nil
+		},
+	}
+}
+
+type fakeDoctorStore struct {
+	closeErr error
+}
+
+func (s fakeDoctorStore) Close() error {
+	return s.closeErr
+}
+
+type fakeDoctorListener struct {
+	addr     net.Addr
+	closeErr error
+}
+
+func (l fakeDoctorListener) Accept() (net.Conn, error) {
+	return nil, errors.New("not implemented")
+}
+
+func (l fakeDoctorListener) Close() error {
+	return l.closeErr
+}
+
+func (l fakeDoctorListener) Addr() net.Addr {
+	return l.addr
+}
+
+type fakeDoctorAddr string
+
+func (a fakeDoctorAddr) Network() string {
+	return "tcp"
+}
+
+func (a fakeDoctorAddr) String() string {
+	return string(a)
+}

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -170,7 +170,7 @@ func (c *e2eCodexClient) RunTurn(_ context.Context, req codex.RunTurnRequest, on
 func waitForCompletedIssue(t *testing.T, orch *Orchestrator, issueID string) State {
 	t.Helper()
 
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(20 * time.Second)
 	for time.Now().Before(deadline) {
 		stateCtx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
 		state, err := orch.State(stateCtx)
@@ -197,7 +197,7 @@ func assertOrchestratorStopped(t *testing.T, errCh <-chan error) {
 		if !errors.Is(err, context.Canceled) {
 			t.Fatalf("orchestrator Run() error = %v, want context canceled", err)
 		}
-	case <-time.After(2 * time.Second):
+	case <-time.After(5 * time.Second):
 		t.Fatal("timed out waiting for orchestrator to stop")
 	}
 }


### PR DESCRIPTION
## Summary

- Add `symphony doctor` with OK/WARN/FAIL preflight checks and remediation hints.
- Check config resolution, project WORKFLOW validity, source repos, SQLite reachability, `codex`, GitHub token scopes, server port availability, and git.
- Add table-driven doctor check tests and command exit coverage.

Fixes #184

## Test Plan

- [x] `go test ./internal/cli`
- [x] `go test ./...`
- [x] `make check`
- [x] `tmp/symphony --config <temp>/global.yaml --host 127.0.0.1 --port 0 doctor`