### PR TITLE
fix(cli): refine doctor checks

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -291,7 +291,8 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 			})
 			continue
 		}
-		if err := deps.gitWorkTree(ctx, sourceRoot); err != nil {
+		expandedSourceRoot, err := expandDoctorWorkspacePath(sourceRoot)
+		if err != nil {
 			checks = append(checks, doctorCheck{
 				Name:   "Project " + id + " source repo",
 				Status: doctorFail,
@@ -300,10 +301,19 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 			})
 			continue
 		}
+		if err := deps.gitWorkTree(ctx, expandedSourceRoot); err != nil {
+			checks = append(checks, doctorCheck{
+				Name:   "Project " + id + " source repo",
+				Status: doctorFail,
+				Detail: fmt.Sprintf("%s: %v", expandedSourceRoot, err),
+				Hint:   "Set workspace.source_root to an existing git checkout.",
+			})
+			continue
+		}
 		checks = append(checks, doctorCheck{
 			Name:   "Project " + id + " source repo",
 			Status: doctorOK,
-			Detail: sourceRoot + " is a git worktree",
+			Detail: expandedSourceRoot + " is a git worktree",
 		})
 	}
 
@@ -318,6 +328,32 @@ func projectSourceRoot(project globalconfig.Project, cfg workflowconfig.Config) 
 		return root
 	}
 	return strings.TrimSpace(project.Workdir)
+}
+
+func expandDoctorWorkspacePath(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Clean(home), nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	if filepath.IsAbs(path) {
+		return filepath.Clean(path), nil
+	}
+	abs, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("absolute path: %w", err)
+	}
+	return filepath.Clean(abs), nil
 }
 
 func checkDoctorSQLite(ctx context.Context, resolution globalconfig.PathResolution, deps doctorDeps) doctorCheck {
@@ -391,7 +427,15 @@ func checkDoctorBinary(ctx context.Context, deps doctorDeps, binary string, name
 }
 
 func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps) doctorCheck {
-	token, source := doctorGitHubToken(cfg, deps)
+	token, source, hasGitHubProject := doctorGitHubToken(cfg, deps)
+	if cfg != nil && !hasGitHubProject {
+		return doctorCheck{
+			Name:   "GitHub token",
+			Status: doctorWarn,
+			Detail: "no GitHub tracker projects configured; token scope check skipped",
+			Hint:   "Add a GitHub project before relying on GitHub token preflight checks.",
+		}
+	}
 	if token == "" {
 		return doctorCheck{
 			Name:   "GitHub token",
@@ -427,25 +471,29 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, deps docto
 	}
 }
 
-func doctorGitHubToken(cfg *globalconfig.Config, deps doctorDeps) (string, string) {
+func doctorGitHubToken(cfg *globalconfig.Config, deps doctorDeps) (string, string, bool) {
+	hasGitHubProject := false
 	if cfg != nil {
 		for _, project := range cfg.Projects {
 			workflow, err := deps.loadWorkflow(project.Workflow)
 			if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 				continue
 			}
+			hasGitHubProject = true
 			if token, source := resolveDoctorSecret(workflow.Config.Tracker.APIKey, deps.lookupEnv); token != "" {
 				if source == "" {
 					source = "tracker.api_key"
 				}
-				return token, source
+				return token, source, true
 			}
 		}
 	}
-	if token := strings.TrimSpace(deps.lookupEnv("GITHUB_TOKEN")); token != "" {
-		return token, "GITHUB_TOKEN"
+	if cfg == nil || hasGitHubProject {
+		if token := strings.TrimSpace(deps.lookupEnv("GITHUB_TOKEN")); token != "" {
+			return token, "GITHUB_TOKEN", hasGitHubProject
+		}
 	}
-	return "", ""
+	return "", "", hasGitHubProject
 }
 
 func resolveDoctorSecret(value string, lookupEnv func(string) string) (string, string) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"net"
+	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -159,6 +160,37 @@ func TestCheckDoctorProjects(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("UserHomeDir() error = %v", err)
+	}
+
+	workflow := validDoctorWorkflow("~/repo")
+	var gotPath string
+	checks := checkDoctorProjects(context.Background(), globalconfig.Config{
+		Projects: []globalconfig.Project{{ID: "alpha", Workflow: "WORKFLOW.md"}},
+	}, doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: workflow}, nil
+		},
+		gitWorkTree: func(_ context.Context, path string) error {
+			gotPath = path
+			return nil
+		},
+	})
+
+	wantPath := filepath.Join(home, "repo")
+	if gotPath != wantPath {
+		t.Fatalf("git path = %q, want %q", gotPath, wantPath)
+	}
+	if len(checks) != 2 || checks[1].Status != doctorOK {
+		t.Fatalf("checks = %#v, want source repo OK", checks)
+	}
+}
+
 func TestCheckDoctorGitHub(t *testing.T) {
 	t.Parallel()
 
@@ -172,6 +204,7 @@ func TestCheckDoctorGitHub(t *testing.T) {
 		env        map[string]string
 		scopes     []string
 		scopeErr   error
+		workflow   workflowconfig.Config
 		want       doctorStatus
 		wantDetail string
 	}{
@@ -193,6 +226,15 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			scopes:     []string{"repo"},
 			want:       doctorFail,
 			wantDetail: "read:org",
+		},
+		{
+			name: "non github projects skip token scopes",
+			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			}},
+			workflow:   validDoctorWorkflow("/repo"),
+			want:       doctorWarn,
+			wantDetail: "token scope check skipped",
 		},
 		{
 			name: "workflow token has required scopes",
@@ -217,9 +259,13 @@ func TestCheckDoctorGitHub(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
+			workflow := githubWorkflow
+			if tt.workflow.Tracker.Kind != "" {
+				workflow = tt.workflow
+			}
 			got := checkDoctorGitHub(context.Background(), tt.cfg, doctorDeps{
 				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
-					return workflowconfig.Workflow{Config: githubWorkflow}, nil
+					return workflowconfig.Workflow{Config: workflow}, nil
 				},
 				lookupEnv: func(key string) string {
 					return tt.env[key]
@@ -235,6 +281,24 @@ func TestCheckDoctorGitHub(t *testing.T) {
 				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
 			}
 		})
+	}
+}
+
+func TestExpandDoctorWorkspacePath(t *testing.T) {
+	t.Parallel()
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skipf("UserHomeDir() error = %v", err)
+	}
+
+	got, err := expandDoctorWorkspacePath("~/repo")
+	if err != nil {
+		t.Fatalf("expandDoctorWorkspacePath() error = %v", err)
+	}
+	want := filepath.Join(home, "repo")
+	if got != want {
+		t.Fatalf("expandDoctorWorkspacePath() = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Skip the GitHub token scope check when no configured project uses the GitHub tracker.
- Expand `~` and relative workspace source paths before checking git worktrees.
- Add regression coverage for both review findings.

Fixes #184

## Test Plan

- [x] `go test ./internal/cli -run 'TestCheckDoctorProjects|TestCheckDoctorGitHub|TestExpandDoctorWorkspacePath' -count=1`\n- [x] `go test ./internal/cli ./internal/orchestrator`\n- [x] `make check`