### PR TITLE
fix(orchestrator): dedupe dispatched issues

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -14,9 +14,10 @@ import (
 )
 
 const (
-	projectItemsPageSize = 50
-	projectItemsPerIssue = 100
-	pullRequestsPageSize = 100
+	projectItemsPageSize  = 50
+	projectItemsPerIssue  = 100
+	pullRequestsPageSize  = 100
+	pullRequestsPageLimit = 3
 )
 
 const projectItemsQuery = `
@@ -473,7 +474,7 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 	})
 
 	for _, repo := range repos {
-		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo, nil)
+		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
 		if err != nil {
 			return err
 		}
@@ -482,10 +483,15 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 	return nil
 }
 
-func (c *Connector) fetchRepositoryPullRequests(
+func (c *Connector) fetchRepositoryPullRequests(ctx context.Context, repo pullRequestRepo) ([]pullRequestNode, error) {
+	return c.fetchRepositoryPullRequestsPage(ctx, repo, nil, 1)
+}
+
+func (c *Connector) fetchRepositoryPullRequestsPage(
 	ctx context.Context,
 	repo pullRequestRepo,
 	after *string,
+	page int,
 ) ([]pullRequestNode, error) {
 	var response struct {
 		Repository *struct {
@@ -506,14 +512,14 @@ func (c *Connector) fetchRepositoryPullRequests(
 	}
 
 	pullRequests := append([]pullRequestNode(nil), response.Repository.PullRequests.Nodes...)
-	if !response.Repository.PullRequests.PageInfo.HasNextPage {
+	if !response.Repository.PullRequests.PageInfo.HasNextPage || page >= pullRequestsPageLimit {
 		return pullRequests, nil
 	}
 	cursor := strings.TrimSpace(response.Repository.PullRequests.PageInfo.EndCursor)
 	if cursor == "" {
 		return nil, ErrInvalidResponse
 	}
-	next, err := c.fetchRepositoryPullRequests(ctx, repo, &cursor)
+	next, err := c.fetchRepositoryPullRequestsPage(ctx, repo, &cursor, page+1)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -15,6 +16,7 @@ import (
 const (
 	projectItemsPageSize = 50
 	projectItemsPerIssue = 100
+	pullRequestsPageSize = 100
 )
 
 const projectItemsQuery = `
@@ -100,6 +102,21 @@ query SymphonyGitHubIssueComments($issueIds: [ID!]!) {
   }
 }`
 
+const pullRequestsQuery = `
+query SymphonyGitHubPullRequests($owner: String!, $name: String!, $states: [PullRequestState!]!, $first: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequests(first: $first, after: $after, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}) {
+      pageInfo { hasNextPage endCursor }
+      nodes {
+        number
+        url
+        state
+        headRefName
+      }
+    }
+  }
+}`
+
 const addCommentMutation = `
 mutation SymphonyGitHubAddComment($subjectId: ID!, $body: String!) {
   addComment(input: {subjectId: $subjectId, body: $body}) {
@@ -159,6 +176,7 @@ var (
 	dependencyLinePattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*:\\s*(?:[*_`~]+)?\\s*(.+)\\s*$")
 	issueRefPattern       = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
 	numberedListPattern   = regexp.MustCompile(`^\d+[.)]\s+`)
+	branchKeyPattern      = regexp.MustCompile(`[^A-Za-z0-9._-]`)
 )
 
 type pageInfo struct {
@@ -218,6 +236,18 @@ type pullRequest struct {
 	URL    string `json:"url"`
 }
 
+type pullRequestNode struct {
+	Number      int    `json:"number"`
+	URL         string `json:"url"`
+	State       string `json:"state"`
+	HeadRefName string `json:"headRefName"`
+}
+
+type pullRequestsConnection struct {
+	PageInfo pageInfo          `json:"pageInfo"`
+	Nodes    []pullRequestNode `json:"nodes"`
+}
+
 type repository struct {
 	NameWithOwner string `json:"nameWithOwner"`
 }
@@ -235,9 +265,16 @@ func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue
 		return nil, ErrMissingProject
 	}
 
-	return c.fetchProjectItems(ctx, func(issue connector.Issue) bool {
+	issues, err := c.fetchProjectItems(ctx, func(issue connector.Issue) bool {
 		return stateInList(issue.State, c.activeStates)
 	})
+	if err != nil {
+		return nil, err
+	}
+	if err := c.attachPullRequests(ctx, issues); err != nil {
+		return nil, err
+	}
+	return issues, nil
 }
 
 func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string) ([]connector.Issue, error) {
@@ -366,6 +403,14 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 		return ErrMissingProject
 	}
 
+	item, err := c.resolveProjectItem(ctx, strings.TrimSpace(issueID))
+	if err != nil {
+		return err
+	}
+	if c.terminalStatusUpdateBlocked(item.StatusName, stateName) {
+		return nil
+	}
+
 	githubState := c.symphonyToGitHubState(stateName)
 	fieldID, optionID, err := c.resolveStatusOption(ctx, githubState)
 	if err != nil {
@@ -375,12 +420,7 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 		return err
 	}
 
-	itemID, err := c.resolveProjectItemID(ctx, strings.TrimSpace(issueID))
-	if err != nil {
-		return err
-	}
-
-	if err := c.updateStatusFieldValue(ctx, itemID, fieldID, optionID); err == nil {
+	if err := c.updateStatusFieldValue(ctx, item.ID, fieldID, optionID); err == nil {
 		return nil
 	}
 
@@ -389,7 +429,127 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 	if err != nil {
 		return err
 	}
-	return c.updateStatusFieldValue(ctx, itemID, fieldID, optionID)
+	return c.updateStatusFieldValue(ctx, item.ID, fieldID, optionID)
+}
+
+type issuePullRequestCandidate struct {
+	Index        int
+	BranchPrefix string
+}
+
+type pullRequestRepo struct {
+	Owner string
+	Name  string
+}
+
+func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.Issue) error {
+	byRepo := make(map[pullRequestRepo][]issuePullRequestCandidate)
+	for index, issue := range issues {
+		repo, ok := pullRequestRepoFromIdentifier(issue.Identifier)
+		if !ok {
+			continue
+		}
+		branchPrefix := symphonyIssueBranchPrefix(issue.Identifier)
+		if branchPrefix == "" {
+			continue
+		}
+		byRepo[repo] = append(byRepo[repo], issuePullRequestCandidate{
+			Index:        index,
+			BranchPrefix: branchPrefix,
+		})
+	}
+	if len(byRepo) == 0 {
+		return nil
+	}
+
+	repos := make([]pullRequestRepo, 0, len(byRepo))
+	for repo := range byRepo {
+		repos = append(repos, repo)
+	}
+	sort.Slice(repos, func(i, j int) bool {
+		left := repos[i].Owner + "/" + repos[i].Name
+		right := repos[j].Owner + "/" + repos[j].Name
+		return left < right
+	})
+
+	for _, repo := range repos {
+		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo, nil)
+		if err != nil {
+			return err
+		}
+		attachMatchingPullRequests(issues, byRepo[repo], pullRequests)
+	}
+	return nil
+}
+
+func (c *Connector) fetchRepositoryPullRequests(
+	ctx context.Context,
+	repo pullRequestRepo,
+	after *string,
+) ([]pullRequestNode, error) {
+	var response struct {
+		Repository *struct {
+			PullRequests pullRequestsConnection `json:"pullRequests"`
+		} `json:"repository"`
+	}
+	if err := c.client.GraphQL(ctx, pullRequestsQuery, map[string]any{
+		"owner":  repo.Owner,
+		"name":   repo.Name,
+		"states": []string{"OPEN", "MERGED"},
+		"first":  pullRequestsPageSize,
+		"after":  after,
+	}, &response); err != nil {
+		return nil, fmt.Errorf("fetch github pull requests: %w", err)
+	}
+	if response.Repository == nil {
+		return nil, ErrInvalidResponse
+	}
+
+	pullRequests := append([]pullRequestNode(nil), response.Repository.PullRequests.Nodes...)
+	if !response.Repository.PullRequests.PageInfo.HasNextPage {
+		return pullRequests, nil
+	}
+	cursor := strings.TrimSpace(response.Repository.PullRequests.PageInfo.EndCursor)
+	if cursor == "" {
+		return nil, ErrInvalidResponse
+	}
+	next, err := c.fetchRepositoryPullRequests(ctx, repo, &cursor)
+	if err != nil {
+		return nil, err
+	}
+	return append(pullRequests, next...), nil
+}
+
+func attachMatchingPullRequests(
+	issues []connector.Issue,
+	candidates []issuePullRequestCandidate,
+	pullRequests []pullRequestNode,
+) {
+	for _, pullRequest := range pullRequests {
+		branchName := strings.TrimSpace(pullRequest.HeadRefName)
+		if branchName == "" {
+			continue
+		}
+		for _, candidate := range candidates {
+			if issues[candidate.Index].PullRequest != nil {
+				continue
+			}
+			if !branchMatchesIssuePrefix(branchName, candidate.BranchPrefix) {
+				continue
+			}
+
+			issues[candidate.Index].PullRequest = &connector.PullRequest{
+				Number:     pullRequest.Number,
+				URL:        strings.TrimSpace(pullRequest.URL),
+				BranchName: branchName,
+				State:      strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+			}
+			if issues[candidate.Index].PRNumber == nil && pullRequest.Number > 0 {
+				number := pullRequest.Number
+				issues[candidate.Index].PRNumber = &number
+			}
+		}
+	}
 }
 
 func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
@@ -617,14 +777,16 @@ func (c *Connector) resolveStatusMetadata(ctx context.Context) (statusMetadata, 
 	return metadata, nil
 }
 
-func (c *Connector) resolveProjectItemID(ctx context.Context, issueID string) (string, error) {
-	if itemID, ok := c.projectCache.GetItemID(c.projectID, issueID); ok {
-		return itemID, nil
-	}
-	return c.fetchProjectItemIDPage(ctx, issueID, nil)
+type projectItemStatus struct {
+	ID         string
+	StatusName string
 }
 
-func (c *Connector) fetchProjectItemIDPage(ctx context.Context, issueID string, after *string) (string, error) {
+func (c *Connector) resolveProjectItem(ctx context.Context, issueID string) (projectItemStatus, error) {
+	return c.fetchProjectItemPage(ctx, issueID, nil)
+}
+
+func (c *Connector) fetchProjectItemPage(ctx context.Context, issueID string, after *string) (projectItemStatus, error) {
 	var response struct {
 		Node *struct {
 			ProjectItems projectItemsConnection `json:"projectItems"`
@@ -635,26 +797,37 @@ func (c *Connector) fetchProjectItemIDPage(ctx context.Context, issueID string, 
 		"projectItemsFirst": projectItemsPerIssue,
 		"after":             after,
 	}, &response); err != nil {
-		return "", fmt.Errorf("fetch github project item: %w", err)
+		return projectItemStatus{}, fmt.Errorf("fetch github project item: %w", err)
 	}
 	if response.Node == nil {
-		return "", ErrProjectItemNotFound
+		return projectItemStatus{}, ErrProjectItemNotFound
 	}
 
 	for _, item := range response.Node.ProjectItems.Nodes {
 		if item.Project != nil && item.Project.ID == c.projectID && strings.TrimSpace(item.ID) != "" {
 			c.projectCache.SetItemID(c.projectID, issueID, item.ID)
-			return item.ID, nil
+			return projectItemStatus{
+				ID:         item.ID,
+				StatusName: singleSelectName(item.StatusValue),
+			}, nil
 		}
 	}
 	if !response.Node.ProjectItems.PageInfo.HasNextPage {
-		return "", ErrProjectItemNotFound
+		return projectItemStatus{}, ErrProjectItemNotFound
 	}
 	cursor := strings.TrimSpace(response.Node.ProjectItems.PageInfo.EndCursor)
 	if cursor == "" {
-		return "", ErrProjectItemNotFound
+		return projectItemStatus{}, ErrProjectItemNotFound
 	}
-	return c.fetchProjectItemIDPage(ctx, issueID, &cursor)
+	return c.fetchProjectItemPage(ctx, issueID, &cursor)
+}
+
+func (c *Connector) terminalStatusUpdateBlocked(currentStatus string, targetState string) bool {
+	currentState := c.githubToSymphonyState(currentStatus)
+	if !stateInList(currentState, c.terminalStates) {
+		return false
+	}
+	return !stateInList(targetState, c.terminalStates)
 }
 
 func (c *Connector) updateStatusFieldValue(ctx context.Context, itemID string, fieldID string, optionID string) error {
@@ -758,6 +931,66 @@ func buildIdentifier(repo string, number int) string {
 		return fmt.Sprintf("#%d", number)
 	}
 	return fmt.Sprintf("%s#%d", repo, number)
+}
+
+func pullRequestRepoFromIdentifier(identifier string) (pullRequestRepo, bool) {
+	repo, _, ok := splitIssueIdentifier(identifier)
+	if !ok {
+		return pullRequestRepo{}, false
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return pullRequestRepo{}, false
+	}
+	return pullRequestRepo{Owner: strings.TrimSpace(parts[0]), Name: strings.TrimSpace(parts[1])}, true
+}
+
+func symphonyIssueBranchPrefix(identifier string) string {
+	_, _, ok := splitIssueIdentifier(identifier)
+	if !ok {
+		return ""
+	}
+
+	key := branchKeyPattern.ReplaceAllString(strings.TrimSpace(identifier), "_")
+	key = strings.TrimSpace(key)
+	if key == "" || key == "." || key == ".." {
+		return ""
+	}
+	return "symphony/" + strings.ToLower(key)
+}
+
+func splitIssueIdentifier(identifier string) (string, int, bool) {
+	identifier = strings.TrimSpace(identifier)
+	index := strings.LastIndex(identifier, "#")
+	if index <= 0 || index == len(identifier)-1 {
+		return "", 0, false
+	}
+	number, err := strconv.Atoi(identifier[index+1:])
+	if err != nil || number <= 0 {
+		return "", 0, false
+	}
+	repo := strings.TrimSpace(identifier[:index])
+	if repo == "" {
+		return "", 0, false
+	}
+	return repo, number, true
+}
+
+func branchMatchesIssuePrefix(branchName string, prefix string) bool {
+	branchName = strings.ToLower(strings.TrimSpace(branchName))
+	prefix = strings.ToLower(strings.TrimSpace(prefix))
+	if branchName == "" || prefix == "" {
+		return false
+	}
+	if branchName == prefix {
+		return true
+	}
+	for _, suffix := range []string{"_", "-", "/"} {
+		if strings.HasPrefix(branchName, prefix+suffix) {
+			return true
+		}
+	}
+	return false
 }
 
 func firstAssigneeLogin(assignees nodeConnection[assignee]) string {

--- a/internal/connector/github/adapter_parity_test.go
+++ b/internal/connector/github/adapter_parity_test.go
@@ -24,10 +24,13 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_28","content":{"__typename":"Issue","id":"I_kw28","number":28,"title":"Projects-v2 parity gate","body":"Depends on: #26 #27\n<!-- model: gpt-5-codex-high -->","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/28","createdAt":"2026-05-31T04:12:00Z","updatedAt":"2026-05-31T04:30:00Z","assignees":{"nodes":[{"login":"codex"}]},"labels":{"nodes":[{"name":"gate"},{"name":"stage:S4"}]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"Urgent"}},{"id":"PVTI_29","content":{"__typename":"Issue","id":"I_kw29","number":29,"title":"Human review","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/29","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"In Review"},"priorityValue":{"name":"No priority"}}]}}}}`,
 		},
 		{
-			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_ready","name":"Ready"},{"id":"OPT_progress","name":"In Progress"},{"id":"OPT_review","name":"In Review"},{"id":"OPT_merging","name":"Merging"},{"id":"OPT_rework","name":"Rework"},{"id":"OPT_blocked","name":"Blocked"},{"id":"OPT_done","name":"Done"}]}}}}`,
+			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
 		},
 		{
 			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_28","project":{"id":"PVT_throwaway"}}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_ready","name":"Ready"},{"id":"OPT_progress","name":"In Progress"},{"id":"OPT_review","name":"In Review"},{"id":"OPT_merging","name":"Merging"},{"id":"OPT_rework","name":"Rework"},{"id":"OPT_blocked","name":"Blocked"},{"id":"OPT_done","name":"Done"}]}}}}`,
 		},
 		{
 			body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_28"}}}}`,
@@ -88,8 +91,8 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 8 {
-		t.Fatalf("request count = %d, want 8", len(requests))
+	if len(requests) != 9 {
+		t.Fatalf("request count = %d, want 9", len(requests))
 	}
 
 	statusInput := graphQLInput(t, requests[1])
@@ -118,26 +121,26 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 		t.Fatalf("fetch query = %q, want ProjectV2", requests[3]["query"])
 	}
 
-	updateVariables := requestVariables(t, requests[6])
+	updateVariables := requestVariables(t, requests[7])
 	if updateVariables["projectId"] != "PVT_throwaway" ||
 		updateVariables["itemId"] != "PVTI_28" ||
 		updateVariables["fieldId"] != "PVTSSF_status" ||
 		updateVariables["optionId"] != "OPT_review" {
 		t.Fatalf("update variables = %#v, want Status option OPT_review on PVTI_28", updateVariables)
 	}
-	if !strings.Contains(requests[6]["query"].(string), "updateProjectV2ItemFieldValue") {
-		t.Fatalf("update query = %q, want updateProjectV2ItemFieldValue", requests[6]["query"])
+	if !strings.Contains(requests[7]["query"].(string), "updateProjectV2ItemFieldValue") {
+		t.Fatalf("update query = %q, want updateProjectV2ItemFieldValue", requests[7]["query"])
 	}
 
-	commentVariables := requestVariables(t, requests[7])
+	commentVariables := requestVariables(t, requests[8])
 	if commentVariables["subjectId"] != "I_kw28" {
 		t.Fatalf("comment subjectId = %v, want I_kw28", commentVariables["subjectId"])
 	}
 	if commentVariables["body"] != "## Codex Workpad\n\nReady for review." {
 		t.Fatalf("comment body = %q", commentVariables["body"])
 	}
-	if !strings.Contains(requests[7]["query"].(string), "addComment") {
-		t.Fatalf("comment query = %q, want addComment", requests[7]["query"])
+	if !strings.Contains(requests[8]["query"].(string), "addComment") {
+		t.Fatalf("comment query = %q, want addComment", requests[8]["query"])
 	}
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -19,6 +19,8 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
 		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","body":"Depends on: #24 digitaldrywood/symphony#25\n<!-- model: gpt-5-codex-high -->","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/26","createdAt":"2026-05-31T01:02:03Z","updatedAt":"2026-05-31T02:03:04Z","assignees":{"nodes":[{"login":"worker-1"}]},"labels":{"nodes":[{"name":"Enhancement"},{"name":"stage:S4"}]},"repository":{"nameWithOwner":"digitaldrywood/symphony"},"closedByPullRequestsReferences":{"nodes":[{"number":42,"url":"https://github.com/digitaldrywood/symphony/pull/42"}]}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P0"}},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":27,"title":"Backlog item","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/27","createdAt":"2026-05-31T03:02:03Z","updatedAt":"2026-05-31T04:03:04Z","assignees":{"nodes":[{"login":"worker-1"}]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Backlog"},"priorityValue":{"name":"No priority"}}]}}}}`,
+	}, {
+		body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
 	}})
 
 	c := newGitHubTestConnector(t, server, Config{
@@ -62,8 +64,8 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 1 {
-		t.Fatalf("request count = %d, want 1", len(requests))
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
 	}
 	variables := requests[0]["variables"].(map[string]any)
 	if variables["projectId"] != "PVT_1" {
@@ -72,6 +74,10 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	if variables["first"] != float64(50) {
 		t.Fatalf("first = %v, want 50", variables["first"])
 	}
+	prVariables := requests[1]["variables"].(map[string]any)
+	if prVariables["owner"] != "digitaldrywood" || prVariables["name"] != "symphony" {
+		t.Fatalf("pull request repo variables = %#v, want digitaldrywood/symphony", prVariables)
+	}
 }
 
 func TestConnectorFetchCandidateIssuesResolvesBlockedByProjectState(t *testing.T) {
@@ -79,6 +85,8 @@ func TestConnectorFetchCandidateIssuesResolvesBlockedByProjectState(t *testing.T
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
 		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_candidate","number":26,"title":"Candidate","body":"Depends on: DigitalDryWood/Symphony#24 digitaldrywood/symphony#25 digitaldrywood/symphony#999","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/26","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Ready"},"priorityValue":null},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_done","number":24,"title":"Done blocker","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/24","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Done"},"priorityValue":null},{"id":"PVTI_3","content":{"__typename":"Issue","id":"I_progress","number":25,"title":"Active blocker","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/25","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Working"},"priorityValue":null}]}}}}`,
+	}, {
+		body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
 	}})
 
 	c := newGitHubTestConnector(t, server, Config{
@@ -105,6 +113,47 @@ func TestConnectorFetchCandidateIssuesResolvesBlockedByProjectState(t *testing.T
 	}
 	if !reflect.DeepEqual(got[0].BlockedBy, want) {
 		t.Fatalf("BlockedBy = %#v, want %#v", got[0].BlockedBy, want)
+	}
+}
+
+func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_182","content":{"__typename":"Issue","id":"I_182","number":182,"title":"First issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/182","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Todo"},"priorityValue":null},{"id":"PVTI_18","content":{"__typename":"Issue","id":"I_18","number":18,"title":"Prefix neighbor","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/18","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
+		},
+		{
+			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"number":187,"url":"https://github.com/digitaldrywood/symphony/pull/187","state":"OPEN","headRefName":"symphony/digitaldrywood_symphony_182_followup"},{"number":188,"url":"https://github.com/digitaldrywood/symphony/pull/188","state":"MERGED","headRefName":"symphony/digitaldrywood_symphony_181"}]}}}}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+	})
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 2", len(got))
+	}
+
+	byID := map[string]connector.Issue{}
+	for _, issue := range got {
+		byID[issue.ID] = issue
+	}
+	pr := byID["I_182"].PullRequest
+	if pr == nil {
+		t.Fatal("I_182 PullRequest = nil, want matching open PR")
+	}
+	if pr.Number != 187 || pr.State != "OPEN" || pr.BranchName != "symphony/digitaldrywood_symphony_182_followup" {
+		t.Fatalf("I_182 PullRequest = %#v, want PR 187 open followup", pr)
+	}
+	if byID["I_18"].PullRequest != nil {
+		t.Fatalf("I_18 PullRequest = %#v, want nil", byID["I_18"].PullRequest)
 	}
 }
 
@@ -299,8 +348,8 @@ func TestConnectorUpdateIssueStateWritesStatusOptionID(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_ready","name":"Ready"},{"id":"OPT_todo","name":"Todo"}]}}}}`},
 		{body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"}}]}}}}`},
+		{body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_ready","name":"Ready"},{"id":"OPT_todo","name":"Todo"}]}}}}`},
 		{body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_1"}}}}`},
 	})
 	c := newGitHubTestConnector(t, server, Config{
@@ -334,6 +383,30 @@ func TestConnectorUpdateIssueStateWritesStatusOptionID(t *testing.T) {
 	}
 	if variables["optionId"] == "Ready" {
 		t.Fatal("optionId used the option name, want option id")
+	}
+}
+
+func TestConnectorUpdateIssueStateSkipsTerminalToActiveTransition(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Done"}}]}}}}`},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:    "PVT_1",
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+
+	if err := c.UpdateIssueState(context.Background(), "I_kw1", "In Progress"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(requests))
+	}
+	if strings.Contains(requests[0]["query"].(string), "updateProjectV2ItemFieldValue") {
+		t.Fatalf("terminal guard issued update mutation: %q", requests[0]["query"])
 	}
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -157,6 +157,47 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 	}
 }
 
+func TestConnectorFetchCandidateIssuesLimitsPullRequestPagination(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_1","number":1,"title":"Candidate","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/symphony/issues/1","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/symphony"}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
+		},
+		{
+			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[]}}}}`,
+		},
+		{
+			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-2"},"nodes":[]}}}}`,
+		},
+		{
+			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-3"},"nodes":[]}}}}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+	})
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
+	}
+
+	requests := server.requests()
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want project query plus 3 pull request pages", len(requests))
+	}
+	variables := requests[3]["variables"].(map[string]any)
+	if variables["after"] != "cursor-2" {
+		t.Fatalf("third pull request page after = %v, want cursor-2", variables["after"])
+	}
+}
+
 func TestConnectorFetchIssuesByStatesFiltersMappedStates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -16,6 +16,7 @@ type Issue struct {
 	BranchName       string       `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	URL              string       `json:"url,omitempty" yaml:"url,omitempty"`
 	PRNumber         *int         `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
+	PullRequest      *PullRequest `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
 	AssigneeID       string       `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`
 	BlockedBy        []BlockedRef `json:"blocked_by" yaml:"blocked_by"`
 	BlockerReason    string       `json:"blocker_reason,omitempty" yaml:"blocker_reason,omitempty"`
@@ -29,6 +30,13 @@ type Issue struct {
 type BlockedRef struct {
 	ID         string `json:"id,omitempty" yaml:"id,omitempty"`
 	Identifier string `json:"identifier" yaml:"identifier"`
+	State      string `json:"state,omitempty" yaml:"state,omitempty"`
+}
+
+type PullRequest struct {
+	Number     int    `json:"number,omitempty" yaml:"number,omitempty"`
+	URL        string `json:"url,omitempty" yaml:"url,omitempty"`
+	BranchName string `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	State      string `json:"state,omitempty" yaml:"state,omitempty"`
 }
 

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -118,6 +118,14 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		priority := *issue.Priority
 		issue.Priority = &priority
 	}
+	if issue.PRNumber != nil {
+		prNumber := *issue.PRNumber
+		issue.PRNumber = &prNumber
+	}
+	if issue.PullRequest != nil {
+		pullRequest := *issue.PullRequest
+		issue.PullRequest = &pullRequest
+	}
 	if issue.BlockedBy != nil {
 		issue.BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
 	}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -284,6 +284,116 @@ func TestDispatchableChecksSlots(t *testing.T) {
 	}
 }
 
+func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 3,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done"},
+	})
+	orch := Orchestrator{cfg: cfg}
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		want  bool
+	}{
+		{
+			name:  "todo without pull request dispatches",
+			issue: dispatchTestIssue("issue-no-pr", "Todo"),
+			want:  true,
+		},
+		{
+			name:  "todo with open pull request skips",
+			issue: dispatchTestIssueWithPullRequest("issue-todo-open-pr", "Todo", "OPEN"),
+			want:  false,
+		},
+		{
+			name:  "in progress with open pull request skips",
+			issue: dispatchTestIssueWithPullRequest("issue-progress-open-pr", "In Progress", "OPEN"),
+			want:  false,
+		},
+		{
+			name:  "rework with open pull request dispatches",
+			issue: dispatchTestIssueWithPullRequest("issue-rework-open-pr", "Rework", "OPEN"),
+			want:  true,
+		},
+		{
+			name:  "merging with open pull request dispatches",
+			issue: dispatchTestIssueWithPullRequest("issue-merging-open-pr", "Merging", "OPEN"),
+			want:  true,
+		},
+		{
+			name:  "todo with merged pull request skips",
+			issue: dispatchTestIssueWithPullRequest("issue-todo-merged-pr", "Todo", "MERGED"),
+			want:  false,
+		},
+		{
+			name:  "rework with merged pull request skips",
+			issue: dispatchTestIssueWithPullRequest("issue-rework-merged-pr", "Rework", "MERGED"),
+			want:  false,
+		},
+		{
+			name:  "todo with closed unmerged pull request dispatches",
+			issue: dispatchTestIssueWithPullRequest("issue-todo-closed-pr", "Todo", "CLOSED"),
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newState(cfg)
+			got := orch.dispatchable(tt.issue, &state, now)
+			if got != tt.want {
+				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatchCandidatesClaimsDuplicateIssueWithinCycle(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+	})
+	runner := newWorkerHostRunner()
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion),
+	}
+	state := newState(cfg)
+	now := time.Now()
+	candidate := dispatchTestIssue("issue-duplicate", "Todo")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch.dispatchCandidates(ctx, &state, []connector.Issue{candidate, candidate}, now)
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.Issue.ID != candidate.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, candidate.ID)
+	}
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected duplicate dispatch = %#v", request)
+	default:
+	}
+	if len(state.Running) != 1 {
+		t.Fatalf("Running len = %d, want 1", len(state.Running))
+	}
+	if len(state.Claimed) != 1 {
+		t.Fatalf("Claimed len = %d, want 1", len(state.Claimed))
+	}
+}
+
 func TestDispatchCandidatesAssignsLeastLoadedWorkerHost(t *testing.T) {
 	t.Parallel()
 
@@ -350,6 +460,17 @@ func dispatchTestIssue(id, state string) connector.Issue {
 	issue.Identifier = "digitaldrywood/symphony#" + id
 	issue.Title = "Dispatch test issue"
 	issue.State = state
+	return issue
+}
+
+func dispatchTestIssueWithPullRequest(id, state, prState string) connector.Issue {
+	issue := dispatchTestIssue(id, state)
+	issue.PullRequest = &connector.PullRequest{
+		Number:     187,
+		URL:        "https://github.com/digitaldrywood/symphony/pull/187",
+		BranchName: "symphony/digitaldrywood_symphony_187",
+		State:      prState,
+	}
 	return issue
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -474,6 +474,9 @@ func (o *Orchestrator) dispatchableIssue(
 	if !stateIn(issue.State, o.cfg.ActiveStates) || stateIn(issue.State, o.cfg.TerminalStates) {
 		return false
 	}
+	if duplicatePullRequestWork(issue) {
+		return false
+	}
 	if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
 		return false
 	}
@@ -830,6 +833,24 @@ func validCandidate(issue connector.Issue) bool {
 		issue.Title != "" &&
 		issue.State != "" &&
 		issue.AssignedToWorker
+}
+
+func duplicatePullRequestWork(issue connector.Issue) bool {
+	if issue.PullRequest == nil {
+		return false
+	}
+	switch normalizePullRequestState(issue.PullRequest.State) {
+	case "merged":
+		return true
+	case "open":
+		return normalizeState(issue.State) == "todo" || normalizeState(issue.State) == "in progress"
+	default:
+		return false
+	}
+}
+
+func normalizePullRequestState(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
 }
 
 func todoBlockedByNonTerminal(issue connector.Issue, terminalStates []string) bool {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -962,6 +962,14 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 	cloned := make([]connector.Issue, len(issues))
 	for i, issue := range issues {
 		cloned[i] = issue
+		if issue.PRNumber != nil {
+			prNumber := *issue.PRNumber
+			cloned[i].PRNumber = &prNumber
+		}
+		if issue.PullRequest != nil {
+			pullRequest := *issue.PullRequest
+			cloned[i].PullRequest = &pullRequest
+		}
 		cloned[i].BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
 		cloned[i].Labels = append([]string(nil), issue.Labels...)
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -155,6 +155,10 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		prNumber := *issue.PRNumber
 		cloned.PRNumber = &prNumber
 	}
+	if issue.PullRequest != nil {
+		pullRequest := *issue.PullRequest
+		cloned.PullRequest = &pullRequest
+	}
 	if issue.CreatedAt != nil {
 		createdAt := *issue.CreatedAt
 		cloned.CreatedAt = &createdAt

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -58,7 +58,8 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 		return "", err
 	}
 
-	return appendAvailableSkills(rendered, AvailableSkillsBlock(opts.AvailableSkills)), nil
+	rendered = appendAvailableSkills(rendered, AvailableSkillsBlock(opts.AvailableSkills))
+	return appendClosingReferenceInstruction(rendered, issue), nil
 }
 
 func AvailableSkillsBlock(skillList []skills.Skill) string {
@@ -80,6 +81,40 @@ func appendAvailableSkills(prompt string, skillsBlock string) string {
 	}
 
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + skillsBlock
+}
+
+func appendClosingReferenceInstruction(prompt string, issue connector.Issue) string {
+	number := githubIssueNumber(issue.Identifier)
+	if number == "" {
+		return prompt
+	}
+
+	reference := "Fixes #" + number
+	if strings.Contains(prompt, reference) ||
+		strings.Contains(prompt, "Closes #"+number) ||
+		strings.Contains(prompt, "Resolves #"+number) {
+		return prompt
+	}
+
+	return strings.TrimRight(prompt, " \t\r\n") +
+		"\n\n## Pull request\n\nWhen creating or updating the pull request body, include `" +
+		reference + "`."
+}
+
+func githubIssueNumber(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	index := strings.LastIndex(identifier, "#")
+	if index == -1 || index == len(identifier)-1 {
+		return ""
+	}
+
+	number := identifier[index+1:]
+	for _, r := range number {
+		if r < '0' || r > '9' {
+			return ""
+		}
+	}
+	return number
 }
 
 func appendLessonsBlock(prompt string, cfg config.Lessons, workspacePath string) (string, error) {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -108,6 +108,24 @@ func TestBuildPromptUsesDefaultPromptDescriptionFallback(t *testing.T) {
 	}
 }
 
+func TestBuildPromptAppendsGitHubClosingReferenceInstruction(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Prompt: "Base prompt",
+	}, connector.Issue{
+		Identifier: "digitaldrywood/symphony#193",
+		Title:      "Dedupe dispatch",
+	}, PromptOptions{})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	if !strings.Contains(prompt, "Fixes #193") {
+		t.Fatalf("prompt missing closing reference instruction:\n%s", prompt)
+	}
+}
+
 func TestBuildPromptRejectsUnknownTemplateVariables(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- attach matching open or merged GitHub PR metadata to candidate issues by Symphony branch prefix
- skip duplicate Todo/In Progress dispatches with open PRs and treat merged-PR issues as terminal
- guard terminal GitHub project statuses from active-state rewrites and append `Fixes #N` PR guidance to prompts

Fixes #193

## Test Plan
- go test ./internal/orchestrator ./internal/connector/github ./internal/runner
- go test ./internal/connector/... ./internal/orchestrator ./internal/runner ./internal/workspace
- make check