### PR TITLE
feat(runner): add cross-platform shell

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,7 @@ agent:
     max_skills_in_prompt: 50
 codex:
   command: codex app-server
+  shell: sh
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:
@@ -208,6 +209,7 @@ server:
   host: 127.0.0.1
   port: 4000
 hooks:
+  shell: sh
   timeout_ms: 60000
 ---
 You are working on {{ issue.identifier }}: {{ issue.title }}.
@@ -216,6 +218,10 @@ Read the issue description, follow repository instructions, keep changes
 scoped to the issue, run the project validation gate, and prepare the work for
 human review.
 ```
+
+Omit `codex.shell` and `hooks.shell` to use the per-OS defaults: `sh` on Unix
+and `cmd` on Windows. Set either field to `pwsh` or `powershell` when hooks or
+the Codex app-server command should run through PowerShell.
 
 4. Create the global config and add the project:
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -16,6 +16,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workspace"
@@ -116,6 +117,7 @@ func buildWorkspaceBackend(cfg workflowconfig.Config, logger *slog.Logger) (work
 		SourceRoot: sourceRoot,
 		AutoBranch: cfg.Workspace.AutoBranch,
 		Hooks: workspace.Hooks{
+			Shell:        cfg.Hooks.Shell,
 			AfterCreate:  cfg.Hooks.AfterCreate,
 			BeforeRun:    cfg.Hooks.BeforeRun,
 			AfterRun:     cfg.Hooks.AfterRun,
@@ -137,8 +139,7 @@ func buildCodexClient(cfg workflowconfig.Config) (runnerpkg.CodexClient, error) 
 	}
 
 	factory, err := codex.NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
-		// #nosec G204 -- codex command is operator-supplied trusted workflow config.
-		return exec.CommandContext(ctx, "sh", "-c", command)
+		return buildCodexCommand(ctx, cfg)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create codex transport factory: %w", err)
@@ -157,6 +158,10 @@ func buildCodexClient(cfg workflowconfig.Config) (runnerpkg.CodexClient, error) 
 		return nil, fmt.Errorf("create codex app-server: %w", err)
 	}
 	return client, nil
+}
+
+func buildCodexCommand(ctx context.Context, cfg workflowconfig.Config) *exec.Cmd {
+	return commandshell.Command(ctx, strings.TrimSpace(cfg.Codex.Command), cfg.Codex.Shell)
 }
 
 // publishSnapshots ticks at interval, building a merged telemetry snapshot

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -55,6 +55,19 @@ func TestBuildRunnerUsesTopLevelPricingPath(t *testing.T) {
 	}
 }
 
+func TestBuildCodexCommandUsesConfiguredShell(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Codex.Command = "codex app-server --experimental"
+	cfg.Codex.Shell = "bash"
+
+	cmd := buildCodexCommand(context.Background(), cfg)
+	if got := strings.Join(cmd.Args, "\x00"); got != "bash\x00-c\x00codex app-server --experimental" {
+		t.Fatalf("Args = %#v, want bash -c configured command", cmd.Args)
+	}
+}
+
 func TestProjectDependenciesInjectsNonNilRunner(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
 )
 
 const (
@@ -121,6 +122,7 @@ type Budget struct {
 
 type Codex struct {
 	Command           string         `yaml:"command"`
+	Shell             string         `yaml:"shell"`
 	ApprovalPolicy    StringOrMap    `yaml:"approval_policy"`
 	ThreadSandbox     string         `yaml:"thread_sandbox"`
 	TurnSandboxPolicy map[string]any `yaml:"turn_sandbox_policy"`
@@ -141,6 +143,7 @@ type Observability struct {
 }
 
 type Hooks struct {
+	Shell        string `yaml:"shell"`
 	AfterCreate  string `yaml:"after_create"`
 	BeforeRun    string `yaml:"before_run"`
 	AfterRun     string `yaml:"after_run"`
@@ -242,6 +245,7 @@ func Default() Config {
 		},
 		Codex: Codex{
 			Command: "codex app-server",
+			Shell:   commandshell.Default(),
 			ApprovalPolicy: MapValue(map[string]any{
 				"reject": map[string]any{
 					"sandbox_approval": true,
@@ -264,6 +268,7 @@ func Default() Config {
 		},
 		Budget: budget,
 		Hooks: Hooks{
+			Shell:     commandshell.Default(),
 			TimeoutMS: 60000,
 		},
 	}
@@ -343,6 +348,8 @@ func (c *Config) normalize() {
 	c.Agent.DispatchPriorityByState = normalizeStateList(c.Agent.DispatchPriorityByState)
 	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
 	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
+	c.Codex.Shell = commandshell.Normalize(c.Codex.Shell)
+	c.Hooks.Shell = commandshell.Normalize(c.Hooks.Shell)
 }
 
 func (c Config) validateTracker(problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -57,6 +57,7 @@ agent:
     max_skills_in_prompt: 20
 codex:
   command: codex app-server
+  shell: bash
   approval_policy: never
   thread_sandbox: danger-full-access
   turn_sandbox_policy:
@@ -79,6 +80,7 @@ budget:
   refusal_cooldown_seconds: 30
   pricing_path: priv/pricing/models.yaml
 hooks:
+  shell: bash
   after_create: git clone .
   before_run: echo before
   after_run: echo after
@@ -125,6 +127,9 @@ Ticket prompt {{ issue.title }}
 	if !cfg.Codex.ApprovalPolicy.IsString || cfg.Codex.ApprovalPolicy.String != "never" {
 		t.Fatalf("Codex.ApprovalPolicy = %#v, want string never", cfg.Codex.ApprovalPolicy)
 	}
+	if cfg.Codex.Shell != "bash" {
+		t.Fatalf("Codex.Shell = %q, want bash", cfg.Codex.Shell)
+	}
 	if got := cfg.Codex.TurnSandboxPolicy["networkAccess"]; got != true {
 		t.Fatalf("Codex.TurnSandboxPolicy[networkAccess] = %v, want true", got)
 	}
@@ -133,6 +138,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Hooks.AfterCreate != "git clone ." {
 		t.Fatalf("Hooks.AfterCreate = %q", cfg.Hooks.AfterCreate)
+	}
+	if cfg.Hooks.Shell != "bash" {
+		t.Fatalf("Hooks.Shell = %q, want bash", cfg.Hooks.Shell)
 	}
 }
 
@@ -169,6 +177,12 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if !cfg.Codex.ApprovalPolicy.IsMap {
 		t.Fatalf("Codex.ApprovalPolicy = %#v, want map default", cfg.Codex.ApprovalPolicy)
+	}
+	if strings.TrimSpace(cfg.Codex.Shell) == "" {
+		t.Fatal("Codex.Shell is blank, want per-OS default")
+	}
+	if strings.TrimSpace(cfg.Hooks.Shell) == "" {
+		t.Fatal("Hooks.Shell is blank, want per-OS default")
 	}
 	if cfg.Server.Host != "127.0.0.1" {
 		t.Fatalf("Server.Host = %q", cfg.Server.Host)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -66,7 +66,8 @@ func CommandSpecForOS(command string, shellName string, goos string) CommandSpec
 
 func shellBase(name string) string {
 	name = strings.ReplaceAll(name, "\\", "/")
-	return strings.ToLower(path.Base(name))
+	base := strings.ToLower(path.Base(name))
+	return strings.TrimSuffix(base, ".exe")
 }
 
 func isPOSIXShell(base string) bool {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -1,0 +1,79 @@
+package shell
+
+import (
+	"context"
+	"os/exec"
+	"path"
+	"runtime"
+	"strings"
+)
+
+type CommandSpec struct {
+	Name string
+	Args []string
+}
+
+func Default() string {
+	return DefaultForOS(runtime.GOOS)
+}
+
+func DefaultForOS(goos string) string {
+	if goos == "windows" {
+		return "cmd"
+	}
+	return "sh"
+}
+
+func Normalize(name string) string {
+	return NormalizeForOS(name, runtime.GOOS)
+}
+
+func NormalizeForOS(name string, goos string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return DefaultForOS(goos)
+	}
+	return name
+}
+
+func Command(ctx context.Context, command string, shellName string) *exec.Cmd {
+	return CommandForOS(ctx, command, shellName, runtime.GOOS)
+}
+
+func CommandForOS(ctx context.Context, command string, shellName string, goos string) *exec.Cmd {
+	spec := CommandSpecForOS(command, shellName, goos)
+	return exec.CommandContext(ctx, spec.Name, spec.Args...) // #nosec G204 -- workflow shell and command are operator-supplied.
+}
+
+func CommandSpecForOS(command string, shellName string, goos string) CommandSpec {
+	shellName = NormalizeForOS(shellName, goos)
+	if goos != "windows" {
+		return CommandSpec{Name: shellName, Args: []string{"-c", command}}
+	}
+
+	base := shellBase(shellName)
+	switch {
+	case base == "cmd" || base == "cmd.exe":
+		return CommandSpec{Name: shellName, Args: []string{"/C", command}}
+	case base == "powershell" || base == "powershell.exe" || base == "pwsh" || base == "pwsh.exe":
+		return CommandSpec{Name: shellName, Args: []string{"-NoLogo", "-NoProfile", "-NonInteractive", "-Command", command}}
+	case isPOSIXShell(base):
+		return CommandSpec{Name: shellName, Args: []string{"-c", command}}
+	default:
+		return CommandSpec{Name: shellName, Args: []string{"/C", command}}
+	}
+}
+
+func shellBase(name string) string {
+	name = strings.ReplaceAll(name, "\\", "/")
+	return strings.ToLower(path.Base(name))
+}
+
+func isPOSIXShell(base string) bool {
+	switch base {
+	case "sh", "bash", "dash", "zsh", "ksh", "ash":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -1,0 +1,112 @@
+package shell
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+func TestCommandSpecUsesPerOSDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		goos     string
+		command  string
+		wantName string
+		wantArgs []string
+	}{
+		{
+			name:     "unix",
+			goos:     "linux",
+			command:  "printf ok",
+			wantName: "sh",
+			wantArgs: []string{"-c", "printf ok"},
+		},
+		{
+			name:     "windows",
+			goos:     "windows",
+			command:  "echo ok",
+			wantName: "cmd",
+			wantArgs: []string{"/C", "echo ok"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := CommandSpecForOS(tt.command, "", tt.goos)
+			if got.Name != tt.wantName {
+				t.Fatalf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if !reflect.DeepEqual(got.Args, tt.wantArgs) {
+				t.Fatalf("Args = %#v, want %#v", got.Args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestCommandSpecUsesConfiguredShell(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		goos     string
+		shell    string
+		wantName string
+		wantArgs []string
+	}{
+		{
+			name:     "unix custom shell",
+			goos:     "linux",
+			shell:    "bash",
+			wantName: "bash",
+			wantArgs: []string{"-c", "echo ok"},
+		},
+		{
+			name:     "windows cmd path",
+			goos:     "windows",
+			shell:    `C:\Windows\System32\cmd.exe`,
+			wantName: `C:\Windows\System32\cmd.exe`,
+			wantArgs: []string{"/C", "echo ok"},
+		},
+		{
+			name:     "windows powershell",
+			goos:     "windows",
+			shell:    "pwsh",
+			wantName: "pwsh",
+			wantArgs: []string{"-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "echo ok"},
+		},
+		{
+			name:     "windows posix shell override",
+			goos:     "windows",
+			shell:    "bash",
+			wantName: "bash",
+			wantArgs: []string{"-c", "echo ok"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := CommandSpecForOS("echo ok", tt.shell, tt.goos)
+			if got.Name != tt.wantName {
+				t.Fatalf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if !reflect.DeepEqual(got.Args, tt.wantArgs) {
+				t.Fatalf("Args = %#v, want %#v", got.Args, tt.wantArgs)
+			}
+		})
+	}
+}
+
+func TestCommandBuildsExecCommand(t *testing.T) {
+	t.Parallel()
+
+	cmd := CommandForOS(context.Background(), "echo ok", "bash", "linux")
+	if !reflect.DeepEqual(cmd.Args, []string{"bash", "-c", "echo ok"}) {
+		t.Fatalf("Args = %#v, want bash -c command", cmd.Args)
+	}
+}

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -85,6 +85,13 @@ func TestCommandSpecUsesConfiguredShell(t *testing.T) {
 			wantName: "bash",
 			wantArgs: []string{"-c", "echo ok"},
 		},
+		{
+			name:     "windows posix shell exe path",
+			goos:     "windows",
+			shell:    `C:\Program Files\Git\bin\bash.exe`,
+			wantName: `C:\Program Files\Git\bin\bash.exe`,
+			wantArgs: []string{"-c", "echo ok"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/digitaldrywood/detent/internal/config"
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
 	"github.com/digitaldrywood/detent/internal/web/templates"
 )
 
@@ -392,12 +393,14 @@ func renderWorkflow(form templates.OnboardingForm) string {
 	b.WriteString("    max_skills_in_prompt: 50\n")
 	b.WriteString("codex:\n")
 	b.WriteString("  command: codex app-server\n")
+	writeScalar(&b, "  ", "shell", commandshell.Default())
 	b.WriteString("  approval_policy: never\n")
 	b.WriteString("  thread_sandbox: workspace-write\n")
 	b.WriteString("  turn_sandbox_policy:\n")
 	b.WriteString("    type: workspaceWrite\n")
 	b.WriteString("    networkAccess: true\n")
 	b.WriteString("hooks:\n")
+	writeScalar(&b, "  ", "shell", commandshell.Default())
 	if form.Repo != "" {
 		b.WriteString("  after_create: |\n")
 		b.WriteString("    git clone --depth 1 https://github.com/")

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
@@ -165,6 +166,8 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		"tracker:\n  kind: github",
 		"api_key: $GITHUB_TOKEN",
 		"project_slug: PVT_project",
+		"codex:\n  command: codex app-server\n  shell: " + commandshell.Default(),
+		"hooks:\n  shell: " + commandshell.Default(),
 		"git clone --depth 1 https://github.com/digitaldrywood/detent .",
 		"max_concurrent_agents_by_state:\n    Merging: 1",
 		"You are working on GitHub issue `{{ issue.identifier }}`",

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -13,6 +13,8 @@ import (
 	"regexp"
 	"strings"
 	"time"
+
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
 )
 
 const KindLocalGit = "local_git"
@@ -49,6 +51,7 @@ type Info struct {
 }
 
 type Hooks struct {
+	Shell        string
 	AfterCreate  string
 	BeforeRun    string
 	AfterRun     string
@@ -154,6 +157,7 @@ func NewLocalGit(opts LocalGitOptions) (*LocalGit, error) {
 	if hooks.Timeout < 0 {
 		return nil, errors.New("hooks timeout must be greater than or equal to 0")
 	}
+	hooks.Shell = commandshell.Normalize(hooks.Shell)
 
 	logger := opts.Logger
 	if logger == nil {
@@ -429,7 +433,7 @@ func (l *LocalGit) runHook(ctx context.Context, name string, command string, inf
 	}
 	defer cancel()
 
-	cmd := exec.CommandContext(hookCtx, "sh", "-c", command)
+	cmd := commandshell.Command(hookCtx, command, l.hooks.Shell)
 	cmd.Dir = info.Path
 	cmd.Env = hookEnv(info, issue)
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -122,6 +122,47 @@ func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
 	}
 }
 
+func TestLocalGitHooksUseConfiguredShell(t *testing.T) {
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "after-create.trace")
+	argsPath := filepath.Join(t.TempDir(), "shell-args.trace")
+	shellPath := filepath.Join(t.TempDir(), "custom-sh")
+	shellScript := "#!/bin/sh\nprintf '%s\\n' \"$0|$1|$2\" > " + shellQuote(argsPath) + "\nexec /bin/sh \"$@\"\n"
+	if err := os.WriteFile(shellPath, []byte(shellScript), 0o700); err != nil {
+		t.Fatalf("write shell wrapper: %v", err)
+	}
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			Shell:       shellPath,
+			AfterCreate: "printf 'ok\n' > " + shellQuote(tracePath),
+			Timeout:     5 * time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	if _, err := backend.Create(context.Background(), Issue{Identifier: "DD-SHELL-CFG"}); err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	gotArgs := strings.TrimSpace(readFile(t, argsPath))
+	wantArgs := shellPath + "|-c|" + "printf 'ok\n' > " + shellQuote(tracePath)
+	if gotArgs != wantArgs {
+		t.Fatalf("hook shell args = %q, want %q", gotArgs, wantArgs)
+	}
+	if got := readFile(t, tracePath); got != "ok\n" {
+		t.Fatalf("hook trace = %q, want ok", got)
+	}
+}
+
 func TestLocalGitCreateReusesExistingWorktreeWithoutAfterCreate(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)


### PR DESCRIPTION
## Summary

- Adds a shared shell helper that keeps Unix commands on `sh -c` and uses `cmd /C` by default on Windows, with PowerShell and POSIX shell override handling.
- Adds `codex.shell` and `hooks.shell` workflow config fields and wires them into codex app-server startup and workspace hook execution.
- Updates onboarding workflow generation and README docs for shell configuration.

Fixes #128

## Test Plan

- [x] `go test ./internal/shell ./internal/config ./internal/cli ./internal/workspace ./internal/web`
- [x] `make check`