### PR TITLE
chore(install): add Windows installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,23 @@ disciplined as you would be, every time, in parallel.
 
 ## Install
 
-Install the latest released binary with Go:
+Install the latest Windows release with PowerShell:
+
+```powershell
+irm https://raw.githubusercontent.com/digitaldrywood/detent/main/install.ps1 | iex
+```
+
+The PowerShell installer downloads the Windows release archive, verifies the
+SHA-256 checksum, installs `detent.exe` to `%LOCALAPPDATA%\detent\bin`, and
+adds that directory to the user PATH.
+
+Install with Homebrew on macOS or Linux:
+
+```sh
+brew install digitaldrywood/tap/detent
+```
+
+Install with Go on any platform:
 
 ```sh
 go install github.com/digitaldrywood/detent/cmd/detent@latest
@@ -101,18 +117,22 @@ go install github.com/digitaldrywood/detent/cmd/detent@latest
 
 Requirements:
 
-- Go 1.26 or newer.
+- Go 1.26 or newer when installing with `go install` or building from source.
 - A working `codex app-server` command on the host that runs agents.
 - A GitHub token with access to the target ProjectV2 board. For organization
   projects, `repo`, `read:org`, and `project` scopes are usually required.
 
-Source checkouts can also run the repository-local installer:
+macOS and Linux hosts can install the latest release with the shell installer:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/digitaldrywood/detent/main/install.sh | sh
+```
+
+Source checkouts can also run the repository-local shell installer:
 
 ```sh
 ./install.sh
 ```
-
-Homebrew support is tracked separately in #98.
 
 ## Release
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,343 @@
+$ErrorActionPreference = 'Stop'
+$ProgressPreference = 'SilentlyContinue'
+
+$Repo = 'digitaldrywood/detent'
+$ProjectName = 'detent'
+$ModulePackage = 'github.com/digitaldrywood/detent/cmd/detent'
+$Headers = @{ 'User-Agent' = 'detent-installer' }
+$ApiBase = if ($env:DETENT_GITHUB_API_BASE) { $env:DETENT_GITHUB_API_BASE } else { "https://api.github.com/repos/$Repo" }
+$DownloadBase = if ($env:DETENT_RELEASE_DOWNLOAD_BASE) { $env:DETENT_RELEASE_DOWNLOAD_BASE } else { "https://github.com/$Repo/releases/download" }
+$InstallMode = if ($env:DETENT_INSTALL_MODE) { $env:DETENT_INSTALL_MODE } else { 'auto' }
+
+try {
+	[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch {
+}
+
+function Abort {
+	param([string]$Message)
+	Write-Error $Message
+	exit 1
+}
+
+function Test-Command {
+	param([string]$Name)
+	return [bool](Get-Command $Name -ErrorAction SilentlyContinue)
+}
+
+function Join-Url {
+	param(
+		[string]$Base,
+		[string]$Path
+	)
+	return "$($Base.TrimEnd('/'))/$($Path.TrimStart('/'))"
+}
+
+function Remove-LeadingV {
+	param([string]$Version)
+	if ($Version.StartsWith('v')) {
+		return $Version.Substring(1)
+	}
+	return $Version
+}
+
+function Get-InstallDir {
+	if ($env:DETENT_INSTALL_DIR) {
+		return $env:DETENT_INSTALL_DIR
+	}
+	if ($env:LOCALAPPDATA) {
+		return Join-Path $env:LOCALAPPDATA 'detent\bin'
+	}
+	return Join-Path $HOME '.detent\bin'
+}
+
+function Get-TargetArch {
+	if ($env:DETENT_INSTALL_TEST_ARCH) {
+		return $env:DETENT_INSTALL_TEST_ARCH
+	}
+
+	$arch = $env:PROCESSOR_ARCHITECTURE
+	try {
+		$arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+	} catch {
+	}
+
+	switch ($arch.ToLowerInvariant()) {
+		'x64' { return 'amd64' }
+		'amd64' { return 'amd64' }
+		'arm64' { return 'arm64' }
+		'aarch64' { return 'arm64' }
+		default { return $null }
+	}
+}
+
+function Save-Url {
+	param(
+		[string]$Url,
+		[string]$Path
+	)
+	Invoke-WebRequest -Uri $Url -OutFile $Path -Headers $Headers -UseBasicParsing | Out-Null
+}
+
+function Save-OptionalUrl {
+	param(
+		[string]$Url,
+		[string]$Path
+	)
+	try {
+		Save-Url $Url $Path
+		return $true
+	} catch {
+		return $false
+	}
+}
+
+function Get-ReleaseTag {
+	if ($env:DETENT_VERSION) {
+		return $env:DETENT_VERSION
+	}
+
+	try {
+		$release = Invoke-RestMethod -Uri (Join-Url $ApiBase 'releases/latest') -Headers $Headers
+		if ($release.tag_name) {
+			return [string]$release.tag_name
+		}
+	} catch {
+	}
+	return $null
+}
+
+function Save-ReleaseArchive {
+	param(
+		[string]$Tag,
+		[string]$Version,
+		[string]$Arch,
+		[string]$Output
+	)
+
+	$versionWithoutV = Remove-LeadingV $Version
+	$assetNames = @("${ProjectName}_${versionWithoutV}_windows_${Arch}.zip")
+	if ($Version -ne $versionWithoutV) {
+		$assetNames += "${ProjectName}_${Version}_windows_${Arch}.zip"
+	}
+
+	foreach ($assetName in $assetNames) {
+		if (Save-OptionalUrl (Join-Url $DownloadBase "$Tag/$assetName") $Output) {
+			return $assetName
+		}
+	}
+	return $null
+}
+
+function Save-Checksums {
+	param(
+		[string]$Tag,
+		[string]$Version,
+		[string]$Output
+	)
+
+	$versionWithoutV = Remove-LeadingV $Version
+	$checksumNames = @("${ProjectName}_${versionWithoutV}_checksums.txt", 'checksums.txt')
+	foreach ($checksumName in $checksumNames) {
+		if (Save-OptionalUrl (Join-Url $DownloadBase "$Tag/$checksumName") $Output) {
+			return $true
+		}
+	}
+	return $false
+}
+
+function Get-ExpectedChecksum {
+	param(
+		[string]$Checksums,
+		[string]$AssetName
+	)
+
+	foreach ($line in Get-Content -LiteralPath $Checksums) {
+		$parts = $line.Trim() -split '\s+', 2
+		if ($parts.Count -ne 2) {
+			continue
+		}
+		$file = $parts[1].TrimStart([char]'*')
+		if ($file -eq $AssetName) {
+			return $parts[0].ToLowerInvariant()
+		}
+	}
+	return $null
+}
+
+function Assert-Checksum {
+	param(
+		[string]$Archive,
+		[string]$Checksums,
+		[string]$AssetName
+	)
+
+	$expected = Get-ExpectedChecksum $Checksums $AssetName
+	if (-not $expected) {
+		Abort "Checksum for $AssetName not found"
+	}
+
+	$actual = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
+	if ($actual -ne $expected) {
+		Abort "Checksum mismatch for ${AssetName}: expected $expected, got $actual"
+	}
+	Write-Host "Verified checksum for $AssetName"
+}
+
+function Install-Release {
+	param([string]$Arch)
+
+	$tag = Get-ReleaseTag
+	if (-not $tag) {
+		Write-Warning 'Could not resolve the latest Detent release; falling back to go install'
+		return $false
+	}
+
+	$archive = Join-Path $TmpDir 'archive.zip'
+	$checksums = Join-Path $TmpDir 'checksums.txt'
+	$assetName = Save-ReleaseArchive $tag $tag $Arch $archive
+	if (-not $assetName) {
+		Write-Warning "No Detent release asset found for $tag windows/$Arch; falling back to go install"
+		return $false
+	}
+
+	if (-not (Save-Checksums $tag $tag $checksums)) {
+		Abort "Could not download checksums for release $tag"
+	}
+	Assert-Checksum $archive $checksums $assetName
+
+	$releaseDir = Join-Path $TmpDir 'release'
+	New-Item -ItemType Directory -Force -Path $releaseDir | Out-Null
+	Expand-Archive -Path $archive -DestinationPath $releaseDir -Force
+
+	$binary = Join-Path $releaseDir 'detent.exe'
+	if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+		$candidate = Get-ChildItem -LiteralPath $releaseDir -Filter 'detent.exe' -Recurse -File | Select-Object -First 1
+		if (-not $candidate) {
+			Abort "Release archive $assetName did not contain detent.exe"
+		}
+		$binary = $candidate.FullName
+	}
+
+	Copy-Item -LiteralPath $binary -Destination (Join-Path $TmpDir 'detent.exe') -Force
+	return $true
+}
+
+function Install-Go {
+	$version = if ($env:DETENT_VERSION) { $env:DETENT_VERSION } else { 'latest' }
+	if (-not (Test-Command 'go')) {
+		Abort 'Cannot install Detent: release asset unavailable and go is not installed'
+	}
+
+	$goBin = Join-Path $TmpDir 'go-bin'
+	New-Item -ItemType Directory -Force -Path $goBin | Out-Null
+
+	$previousGoBin = $env:GOBIN
+	try {
+		$env:GOBIN = $goBin
+		& go install "$ModulePackage@$version"
+		if ($LASTEXITCODE -ne 0) {
+			Abort 'go install failed'
+		}
+	} finally {
+		$env:GOBIN = $previousGoBin
+	}
+
+	$binary = Join-Path $goBin 'detent.exe'
+	if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+		Abort 'go install did not produce detent.exe'
+	}
+	Copy-Item -LiteralPath $binary -Destination (Join-Path $TmpDir 'detent.exe') -Force
+}
+
+function Install-ReleaseOrGo {
+	if ($TargetArch) {
+		if (Install-Release $TargetArch) {
+			return
+		}
+	} else {
+		Write-Warning 'No supported Windows release target detected; falling back to go install'
+	}
+	Install-Go
+}
+
+function Split-PathList {
+	param([string]$Value)
+	if ([string]::IsNullOrWhiteSpace($Value)) {
+		return @()
+	}
+	return $Value -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) }
+}
+
+function Test-PathListContains {
+	param(
+		[string]$Value,
+		[string]$Dir
+	)
+
+	$target = [IO.Path]::GetFullPath($Dir).TrimEnd('\')
+	foreach ($entry in Split-PathList $Value) {
+		try {
+			$expanded = [Environment]::ExpandEnvironmentVariables($entry)
+			$normalized = [IO.Path]::GetFullPath($expanded).TrimEnd('\')
+		} catch {
+			$normalized = $entry.TrimEnd('\')
+		}
+		if ([string]::Equals($normalized, $target, [StringComparison]::OrdinalIgnoreCase)) {
+			return $true
+		}
+	}
+	return $false
+}
+
+function Add-ToUserPath {
+	param([string]$Dir)
+
+	if ($env:DETENT_INSTALL_SKIP_PATH -eq '1') {
+		return $false
+	}
+
+	$fullDir = [IO.Path]::GetFullPath($Dir)
+	if (-not (Test-PathListContains $env:Path $fullDir)) {
+		$env:Path = "$fullDir;$env:Path"
+	}
+
+	$userPath = [Environment]::GetEnvironmentVariable('Path', 'User')
+	if (Test-PathListContains $userPath $fullDir) {
+		return $false
+	}
+
+	$newUserPath = if ([string]::IsNullOrWhiteSpace($userPath)) { $fullDir } else { "$fullDir;$userPath" }
+	[Environment]::SetEnvironmentVariable('Path', $newUserPath, 'User')
+	return $true
+}
+
+$InstallDir = Get-InstallDir
+$Target = Join-Path $InstallDir 'detent.exe'
+$TargetArch = Get-TargetArch
+$TmpDir = Join-Path ([IO.Path]::GetTempPath()) "detent-install-$([Guid]::NewGuid().ToString('N'))"
+
+if ($TargetArch) {
+	Write-Host "Detected target windows/$TargetArch"
+}
+
+New-Item -ItemType Directory -Force -Path $TmpDir | Out-Null
+try {
+	switch ($InstallMode) {
+		'auto' { Install-ReleaseOrGo; break }
+		'release' { Install-ReleaseOrGo; break }
+		'go' { Install-Go; break }
+		default { Abort "Unknown DETENT_INSTALL_MODE: $InstallMode" }
+	}
+
+	New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+	Copy-Item -LiteralPath (Join-Path $TmpDir 'detent.exe') -Destination $Target -Force
+	$pathChanged = Add-ToUserPath $InstallDir
+
+	Write-Host "Installed Detent at $Target"
+	if ($pathChanged) {
+		Write-Host "Added $InstallDir to the user PATH. Open a new terminal before running detent."
+	}
+} finally {
+	Remove-Item -LiteralPath $TmpDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/install.ps1
+++ b/install.ps1
@@ -165,6 +165,24 @@ function Get-ExpectedChecksum {
 	return $null
 }
 
+function Get-Sha256File {
+	param([string]$Path)
+
+	$stream = [IO.File]::OpenRead($Path)
+	try {
+		$sha = [Security.Cryptography.SHA256]::Create()
+		try {
+			$hash = $sha.ComputeHash($stream)
+		} finally {
+			$sha.Dispose()
+		}
+	} finally {
+		$stream.Dispose()
+	}
+
+	return -join ($hash | ForEach-Object { $_.ToString('x2') })
+}
+
 function Assert-Checksum {
 	param(
 		[string]$Archive,
@@ -177,7 +195,7 @@ function Assert-Checksum {
 		Abort "Checksum for $AssetName not found"
 	}
 
-	$actual = (Get-FileHash -Algorithm SHA256 -Path $Archive).Hash.ToLowerInvariant()
+	$actual = Get-Sha256File $Archive
 	if ($actual -ne $expected) {
 		Abort "Checksum mismatch for ${AssetName}: expected $expected, got $actual"
 	}

--- a/install.ps1
+++ b/install.ps1
@@ -56,19 +56,33 @@ function Get-TargetArch {
 		return $env:DETENT_INSTALL_TEST_ARCH
 	}
 
-	$arch = $env:PROCESSOR_ARCHITECTURE
+	$candidates = @()
 	try {
-		$arch = [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+		$candidates += [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
 	} catch {
 	}
 
-	switch ($arch.ToLowerInvariant()) {
-		'x64' { return 'amd64' }
-		'amd64' { return 'amd64' }
-		'arm64' { return 'arm64' }
-		'aarch64' { return 'arm64' }
-		default { return $null }
+	$candidates += $env:PROCESSOR_ARCHITEW6432
+	try {
+		$candidates += [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+	} catch {
 	}
+	$candidates += $env:PROCESSOR_ARCHITECTURE
+
+	foreach ($arch in $candidates) {
+		if ([string]::IsNullOrWhiteSpace($arch)) {
+			continue
+		}
+
+		switch ($arch.ToLowerInvariant()) {
+			'x64' { return 'amd64' }
+			'amd64' { return 'amd64' }
+			'arm64' { return 'arm64' }
+			'aarch64' { return 'arm64' }
+		}
+	}
+
+	return $null
 }
 
 function Save-Url {

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -1,0 +1,48 @@
+//go:build !windows
+
+package detent_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
+	t.Parallel()
+
+	read := func(path string) string {
+		t.Helper()
+
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", path, err)
+		}
+		return string(raw)
+	}
+
+	readme := read("README.md")
+	script := read("install.ps1")
+
+	wantCommand := "irm https://raw.githubusercontent.com/digitaldrywood/detent/main/install.ps1 | iex"
+	for _, tt := range []struct {
+		name    string
+		content string
+		want    string
+	}{
+		{name: "readme one-step command", content: readme, want: wantCommand},
+		{name: "readme windows path", content: readme, want: `%LOCALAPPDATA%\detent\bin`},
+		{name: "script downloads release archive", content: script, want: "releases/latest"},
+		{name: "script verifies checksum", content: script, want: "Get-FileHash -Algorithm SHA256"},
+		{name: "script installs exe", content: script, want: "detent.exe"},
+		{name: "script updates user path", content: script, want: "SetEnvironmentVariable('Path'"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if !strings.Contains(tt.content, tt.want) {
+				t.Fatalf("%s missing %q", tt.name, tt.want)
+			}
+		})
+	}
+}

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -35,6 +35,8 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 		{name: "script downloads release archive", content: script, want: "releases/latest"},
 		{name: "script verifies checksum", content: script, want: "Security.Cryptography.SHA256"},
 		{name: "script installs exe", content: script, want: "detent.exe"},
+		{name: "script checks os architecture", content: script, want: "OSArchitecture"},
+		{name: "script checks 64-bit host from 32-bit powershell", content: script, want: "PROCESSOR_ARCHITEW6432"},
 		{name: "script updates user path", content: script, want: "SetEnvironmentVariable('Path'"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -33,7 +33,7 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 		{name: "readme one-step command", content: readme, want: wantCommand},
 		{name: "readme windows path", content: readme, want: `%LOCALAPPDATA%\detent\bin`},
 		{name: "script downloads release archive", content: script, want: "releases/latest"},
-		{name: "script verifies checksum", content: script, want: "Get-FileHash -Algorithm SHA256"},
+		{name: "script verifies checksum", content: script, want: "Security.Cryptography.SHA256"},
 		{name: "script installs exe", content: script, want: "detent.exe"},
 		{name: "script updates user path", content: script, want: "SetEnvironmentVariable('Path'"},
 	} {

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -1,0 +1,134 @@
+//go:build windows
+
+package detent_test
+
+import (
+	"archive/zip"
+	"bytes"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestPowerShellInstallScriptInstallsReleaseArchive(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	archiveName := "detent_1.2.3_windows_amd64.zip"
+	archive := detentWindowsArchive(t, "release-ok")
+	server := newPowerShellInstallReleaseServer("v1.2.3", archiveName, archive, windowsArchiveChecksum(archive))
+	t.Cleanup(server.Close)
+
+	tmp := t.TempDir()
+	installDir := filepath.Join(tmp, "bin")
+	env := append(os.Environ(),
+		"DETENT_GITHUB_API_BASE="+server.URL,
+		"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"DETENT_INSTALL_DIR="+installDir,
+		"DETENT_INSTALL_MODE=release",
+		"DETENT_INSTALL_SKIP_PATH=1",
+		"DETENT_INSTALL_TEST_ARCH=amd64",
+	)
+
+	result := runPowerShellInstall(t, root, env)
+	if result.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+
+	binary := filepath.Join(installDir, "detent.exe")
+	raw, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("ReadFile(installed binary) error = %v", err)
+	}
+	if string(raw) != "release-ok" {
+		t.Fatalf("installed binary = %q, want release-ok", raw)
+	}
+	if !strings.Contains(result.stdout, "Verified checksum for "+archiveName) {
+		t.Fatalf("install stdout = %q, want checksum verification", result.stdout)
+	}
+}
+
+func detentWindowsArchive(t *testing.T, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	writer, err := zw.Create("detent.exe")
+	if err != nil {
+		t.Fatalf("Create(detent.exe) error = %v", err)
+	}
+	if _, err := writer.Write([]byte(content)); err != nil {
+		t.Fatalf("Write(detent.exe) error = %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close() error = %v", err)
+	}
+	return buf.Bytes()
+}
+
+func windowsArchiveChecksum(content []byte) string {
+	sum := sha256.Sum256(content)
+	return fmt.Sprintf("%x", sum)
+}
+
+func newPowerShellInstallReleaseServer(tag string, archiveName string, archive []byte, checksum string) *httptest.Server {
+	version := strings.TrimPrefix(tag, "v")
+	checksumName := "detent_" + version + "_checksums.txt"
+
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/latest":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `{"tag_name":%q}`, tag)
+		case "/" + tag + "/" + archiveName:
+			w.Header().Set("Content-Type", "application/zip")
+			_, _ = w.Write(archive)
+		case "/" + tag + "/" + checksumName:
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%s  %s\n", checksum, archiveName)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+}
+
+type powerShellInstallRun struct {
+	stdout string
+	stderr string
+	err    error
+}
+
+func runPowerShellInstall(t *testing.T, root string, env []string) powerShellInstallRun {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "powershell.exe", "-NoProfile", "-ExecutionPolicy", "Bypass", "-File", "install.ps1")
+	cmd.Dir = root
+	cmd.Env = env
+
+	var stdout strings.Builder
+	var stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	return powerShellInstallRun{
+		stdout: stdout.String(),
+		stderr: stderr.String(),
+		err:    err,
+	}
+}


### PR DESCRIPTION
## Summary

- Add `install.ps1` for Windows release zip download, SHA-256 verification, install under `%LOCALAPPDATA%\detent\bin`, and user PATH updates.
- Document one-step Windows install alongside Homebrew, Go, and shell installer paths.
- Add installer/docs tests, including a Windows-only PowerShell release install test for CI.

Fixes #130

## Test Plan

- [x] `go test .`
- [x] `GOOS=windows go test -c -o tmp/detent-windows.test .`
- [x] `make check`