### PR TITLE
feat(workspace): use portable native worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,8 @@ tracker:
 polling:
   interval_ms: 30000
 workspace:
-  root: /absolute/path/to/project-checkout
+  root: /absolute/path/to/detent-workspaces
+  source_root: /absolute/path/to/project-checkout
   auto_branch: true
 agent:
   max_concurrent_agents: 5
@@ -219,7 +220,6 @@ agent:
     max_skills_in_prompt: 50
 codex:
   command: codex app-server
-  shell: sh
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:
@@ -229,7 +229,6 @@ server:
   host: 127.0.0.1
   port: 4000
 hooks:
-  shell: sh
   timeout_ms: 60000
 ---
 You are working on {{ issue.identifier }}: {{ issue.title }}.
@@ -239,9 +238,20 @@ scoped to the issue, run the project validation gate, and prepare the work for
 human review.
 ```
 
+`workspace.source_root` is the checked-out repository Detent uses for
+`git worktree add`; `workspace.root` is where per-issue worktrees are created.
+If `workspace.source_root` is omitted, Detent falls back to the project
+`workdir` from global config, then to `workspace.root` for older single-root
+setups.
+
+Default workflows do not need worktree setup hooks. Detent creates and removes
+Git worktrees natively, so a fresh Windows project can dispatch without bash.
 Omit `codex.shell` and `hooks.shell` to use the per-OS defaults: `sh` on Unix
-and `cmd` on Windows. Set either field to `pwsh` or `powershell` when hooks or
-the Codex app-server command should run through PowerShell.
+and `cmd` on Windows. For portable hooks, prefer no hook when Detent already
+does the setup natively. When a hook is necessary, keep it to commands available
+on every target or set `hooks.shell: pwsh` and write PowerShell that reads
+Detent values from `$env:DETENT_WORKSPACE`, `$env:DETENT_WORKSPACE_KEY`,
+`$env:DETENT_BRANCH`, and `$env:DETENT_ISSUE_IDENTIFIER`.
 
 4. Create the global config and add the project:
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -287,7 +287,7 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 				Name:   "Project " + id + " source repo",
 				Status: doctorFail,
 				Detail: "source root is not configured",
-				Hint:   "Set workspace.source_root or workspace.root to an existing git checkout.",
+				Hint:   "Set workspace.source_root, project workdir, or workspace.root to an existing git checkout.",
 			})
 			continue
 		}
@@ -297,7 +297,7 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 				Name:   "Project " + id + " source repo",
 				Status: doctorFail,
 				Detail: fmt.Sprintf("%s: %v", sourceRoot, err),
-				Hint:   "Set workspace.source_root to an existing git checkout.",
+				Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
 			})
 			continue
 		}
@@ -306,7 +306,7 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 				Name:   "Project " + id + " source repo",
 				Status: doctorFail,
 				Detail: fmt.Sprintf("%s: %v", expandedSourceRoot, err),
-				Hint:   "Set workspace.source_root to an existing git checkout.",
+				Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
 			})
 			continue
 		}
@@ -324,10 +324,13 @@ func projectSourceRoot(project globalconfig.Project, cfg workflowconfig.Config) 
 	if sourceRoot := strings.TrimSpace(cfg.Workspace.SourceRoot); sourceRoot != "" {
 		return sourceRoot
 	}
+	if workdir := strings.TrimSpace(project.Workdir); workdir != "" {
+		return workdir
+	}
 	if root := strings.TrimSpace(cfg.Workspace.Root); root != "" {
 		return root
 	}
-	return strings.TrimSpace(project.Workdir)
+	return ""
 }
 
 func expandDoctorWorkspacePath(path string) (string, error) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -160,6 +160,23 @@ func TestCheckDoctorProjects(t *testing.T) {
 	}
 }
 
+func TestProjectSourceRootPrefersProjectWorkdirBeforeWorkspaceRoot(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Workspace.Root = "/worktrees"
+	project := globalconfig.Project{Workdir: "/source"}
+
+	if got := projectSourceRoot(project, cfg); got != "/source" {
+		t.Fatalf("projectSourceRoot() = %q, want /source", got)
+	}
+
+	cfg.Workspace.SourceRoot = "/configured-source"
+	if got := projectSourceRoot(project, cfg); got != "/configured-source" {
+		t.Fatalf("projectSourceRoot() with source_root = %q, want /configured-source", got)
+	}
+}
+
 func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -49,7 +49,7 @@ func withRunnerFactory(
 			return nil, fmt.Errorf("load project workflow %s: %w", cfg.ID, err)
 		}
 
-		run, err := buildRunner(workflow, cfg.ID, sessionStore, deps.Logger)
+		run, err := buildRunner(workflow, cfg.ID, cfg.Workdir, sessionStore, deps.Logger)
 		if err != nil {
 			return nil, fmt.Errorf("build project runner %s: %w", cfg.ID, err)
 		}
@@ -69,12 +69,13 @@ func withRunnerFactory(
 func buildRunner(
 	workflow workflowconfig.Workflow,
 	projectID string,
+	projectWorkdir string,
 	sessionStore runnerpkg.SessionStore,
 	logger *slog.Logger,
 ) (orchestrator.Runner, error) {
 	cfg := workflow.Config
 
-	backend, err := buildWorkspaceBackend(cfg, logger)
+	backend, err := buildWorkspaceBackend(cfg, projectWorkdir, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -106,9 +107,12 @@ func buildRunner(
 	return run, nil
 }
 
-func buildWorkspaceBackend(cfg workflowconfig.Config, logger *slog.Logger) (workspace.Backend, error) {
+func buildWorkspaceBackend(cfg workflowconfig.Config, sourceRootFallback string, logger *slog.Logger) (workspace.Backend, error) {
 	root := strings.TrimSpace(cfg.Workspace.Root)
 	sourceRoot := strings.TrimSpace(cfg.Workspace.SourceRoot)
+	if sourceRoot == "" {
+		sourceRoot = strings.TrimSpace(sourceRootFallback)
+	}
 	if sourceRoot == "" {
 		sourceRoot = root
 	}

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,6 +16,7 @@ import (
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
 var errProjectFactoryStub = errors.New("project factory stub")
@@ -26,7 +28,7 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Workspace.Root = t.TempDir()
 
-	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", nil, nil)
+	run, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", "", nil, nil)
 	if err != nil {
 		t.Fatalf("buildRunner() error = %v", err)
 	}
@@ -46,7 +48,7 @@ func TestBuildRunnerUsesTopLevelPricingPath(t *testing.T) {
 	cfg.Workspace.Root = t.TempDir()
 	cfg.Budget.PricingPath = filepath.Join(t.TempDir(), "missing-models.yaml")
 
-	_, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", nil, nil)
+	_, err := buildRunner(workflowconfig.Workflow{Config: cfg}, "alpha", "", nil, nil)
 	if err == nil {
 		t.Fatal("buildRunner() error = nil, want pricing load error")
 	}
@@ -65,6 +67,33 @@ func TestBuildCodexCommandUsesConfiguredShell(t *testing.T) {
 	cmd := buildCodexCommand(context.Background(), cfg)
 	if got := strings.Join(cmd.Args, "\x00"); got != "bash\x00-c\x00codex app-server --experimental" {
 		t.Fatalf("Args = %#v, want bash -c configured command", cmd.Args)
+	}
+}
+
+func TestBuildWorkspaceBackendUsesProjectWorkdirAsSourceRoot(t *testing.T) {
+	t.Parallel()
+
+	source := initRunnerSourceRepo(t)
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Workspace.Root = filepath.Join(t.TempDir(), "workspaces")
+	cfg.Workspace.SourceRoot = ""
+
+	backend, err := buildWorkspaceBackend(cfg, source, nil)
+	if err != nil {
+		t.Fatalf("buildWorkspaceBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), workspace.Issue{Identifier: "DD-129"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(runRunnerGit(t, info.Path, "branch", "--show-current")); got != "detent/dd-129" {
+		t.Fatalf("worktree branch = %q, want detent/dd-129", got)
+	}
+	if got := readRunnerFile(t, filepath.Join(info.Path, "README.md")); got != "source repo\n" {
+		t.Fatalf("README.md = %q, want source repo", got)
 	}
 }
 
@@ -269,4 +298,48 @@ func writeWorkflowFile(t *testing.T) string {
 		t.Fatalf("write workflow file: %v", err)
 	}
 	return path
+}
+
+func initRunnerSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runRunnerCommand(t, dir, "git", "init", "-b", "main")
+	runRunnerGit(t, dir, "config", "core.autocrlf", "false")
+	runRunnerGit(t, dir, "config", "user.name", "Test User")
+	runRunnerGit(t, dir, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("source repo\n"), 0o600); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runRunnerGit(t, dir, "add", "README.md")
+	runRunnerGit(t, dir, "commit", "-m", "initial")
+
+	return dir
+}
+
+func runRunnerGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	return runRunnerCommand(t, dir, "git", args...)
+}
+
+func runRunnerCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	cmd.Dir = dir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s failed: %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}
+
+func readRunnerFile(t *testing.T, path string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	return string(raw)
 }

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -13,7 +13,6 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/digitaldrywood/detent/internal/config"
-	commandshell "github.com/digitaldrywood/detent/internal/shell"
 	"github.com/digitaldrywood/detent/internal/web/templates"
 )
 
@@ -115,7 +114,7 @@ func (s *Server) onboardingWrite(c echo.Context) error {
 		return s.renderOnboardingStep(c, form, problems, templates.OnboardingResult{})
 	}
 
-	content := renderWorkflow(form)
+	content := renderWorkflow(form, workflowSourceRoot(s.workflow))
 	workflow, err := config.ParseWorkflow([]byte(content))
 	if err == nil {
 		err = workflow.Config.Validate()
@@ -334,7 +333,7 @@ func applyAgentDefaults(form *templates.OnboardingForm) {
 	}
 }
 
-func renderWorkflow(form templates.OnboardingForm) string {
+func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	var b strings.Builder
 	b.WriteString("---\n")
 	b.WriteString("tracker:\n")
@@ -375,6 +374,7 @@ func renderWorkflow(form templates.OnboardingForm) string {
 	writeScalar(&b, "  ", "interval_ms", form.PollingIntervalMS)
 	b.WriteString("workspace:\n")
 	writeScalar(&b, "  ", "root", form.WorkspaceRoot)
+	writeScalar(&b, "  ", "source_root", sourceRoot)
 	b.WriteString("  auto_branch: true\n")
 	b.WriteString("agent:\n")
 	writeScalar(&b, "  ", "max_concurrent_agents", form.MaxConcurrentAgents)
@@ -393,24 +393,24 @@ func renderWorkflow(form templates.OnboardingForm) string {
 	b.WriteString("    max_skills_in_prompt: 50\n")
 	b.WriteString("codex:\n")
 	b.WriteString("  command: codex app-server\n")
-	writeScalar(&b, "  ", "shell", commandshell.Default())
 	b.WriteString("  approval_policy: never\n")
 	b.WriteString("  thread_sandbox: workspace-write\n")
 	b.WriteString("  turn_sandbox_policy:\n")
 	b.WriteString("    type: workspaceWrite\n")
 	b.WriteString("    networkAccess: true\n")
 	b.WriteString("hooks:\n")
-	writeScalar(&b, "  ", "shell", commandshell.Default())
-	if form.Repo != "" {
-		b.WriteString("  after_create: |\n")
-		b.WriteString("    git clone --depth 1 https://github.com/")
-		b.WriteString(form.Repo)
-		b.WriteString(" .\n")
-	}
 	b.WriteString("  timeout_ms: 60000\n")
 	b.WriteString("---\n\n")
 	b.WriteString(renderWorkflowPrompt(form))
 	return b.String()
+}
+
+func workflowSourceRoot(workflowPath string) string {
+	dir := filepath.Dir(strings.TrimSpace(workflowPath))
+	if dir == "" {
+		return "."
+	}
+	return filepath.Clean(dir)
 }
 
 func renderWorkflowPrompt(form templates.OnboardingForm) string {

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -10,7 +10,6 @@ import (
 	"strings"
 	"testing"
 
-	commandshell "github.com/digitaldrywood/detent/internal/shell"
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
@@ -162,18 +161,30 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		t.Fatalf("ReadFile() error = %v", err)
 	}
 	content := string(raw)
+	sourceRoot := filepath.Dir(workflowPath)
 	for _, want := range []string{
 		"tracker:\n  kind: github",
 		"api_key: $GITHUB_TOKEN",
 		"project_slug: PVT_project",
-		"codex:\n  command: codex app-server\n  shell: " + commandshell.Default(),
-		"hooks:\n  shell: " + commandshell.Default(),
-		"git clone --depth 1 https://github.com/digitaldrywood/detent .",
+		"source_root: " + sourceRoot,
+		"codex:\n  command: codex app-server",
+		"hooks:\n  timeout_ms: 60000",
 		"max_concurrent_agents_by_state:\n    Merging: 1",
 		"You are working on GitHub issue `{{ issue.identifier }}`",
 	} {
 		if !strings.Contains(content, want) {
 			t.Fatalf("workflow missing %q:\n%s", want, content)
+		}
+	}
+	for _, unwanted := range []string{
+		"codex:\n  command: codex app-server\n  shell:",
+		"hooks:\n  shell:",
+		"after_create:",
+		"git clone",
+		"git worktree add",
+	} {
+		if strings.Contains(content, unwanted) {
+			t.Fatalf("workflow contains %q:\n%s", unwanted, content)
 		}
 	}
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -79,6 +79,47 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 	}
 }
 
+func TestLocalGitCreateAndCleanupWithoutHooks(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), Issue{Identifier: "DD-NATIVE"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	if !info.Created {
+		t.Fatal("Create() Created = false, want true")
+	}
+	if got := strings.TrimSpace(runGit(t, info.Path, "branch", "--show-current")); got != "detent/dd-native" {
+		t.Fatalf("worktree branch = %q, want detent/dd-native", got)
+	}
+	if got := readFile(t, filepath.Join(info.Path, "README.md")); got != "source repo\n" {
+		t.Fatalf("README.md = %q, want source repo", got)
+	}
+
+	if err := backend.Cleanup(context.Background(), "DD-NATIVE"); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("workspace exists after cleanup, stat error = %v", err)
+	}
+	if got := runGit(t, source, "worktree", "list", "--porcelain"); strings.Contains(got, info.Path) {
+		t.Fatalf("git worktree list still contains removed path:\n%s", got)
+	}
+}
+
 func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
 	skipWindows(t)
 
@@ -451,6 +492,7 @@ func initSourceRepo(t *testing.T) string {
 
 	dir := t.TempDir()
 	runCommand(t, dir, "git", "init", "-b", "main")
+	runGit(t, dir, "config", "core.autocrlf", "false")
 	runGit(t, dir, "config", "user.name", "Test User")
 	runGit(t, dir, "config", "user.email", "test@example.com")
 	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("source repo\n"), 0o600); err != nil {


### PR DESCRIPTION
## Summary

- remove generated shell-specific workflow hooks so default onboarding relies on native git worktree setup
- pass the project workdir as the source-root fallback and document source/worktree root behavior
- add coverage for no-hook worktree create/cleanup and generated portable workflows

Fixes #129

## Test Plan

- [x] `go test ./internal/web ./internal/cli ./internal/workspace`
- [x] `make check`