### PR TITLE
test(shell): cover bash.exe on windows

### DIFF
--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -86,6 +86,13 @@ func TestCommandSpecUsesConfiguredShell(t *testing.T) {
 			wantArgs: []string{"-c", "echo ok"},
 		},
 		{
+			name:     "windows posix shell exe name",
+			goos:     "windows",
+			shell:    "bash.exe",
+			wantName: "bash.exe",
+			wantArgs: []string{"-c", "echo ok"},
+		},
+		{
 			name:     "windows posix shell exe path",
 			goos:     "windows",
 			shell:    `C:\Program Files\Git\bin\bash.exe`,


### PR DESCRIPTION
## Summary

- Add a Windows configured-shell table case for bare `bash.exe` so POSIX shell overrides keep using `-c`.
- Preserve the configured shell name while covering the `.exe` normalization path already used by full Git Bash paths.

Fixes #205

## Test Plan

- [x] `go test ./internal/shell -count=1`
- [x] `make check`