### PR TITLE
fix(install): detect Windows OS architecture

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -107,7 +107,10 @@ function Get-OSArchitectureCandidates {
 	$candidates += $env:PROCESSOR_ARCHITEW6432
 
 	try {
-		if (Test-Command 'Get-CimInstance') {
+		$testCimProcessorArch = [Environment]::GetEnvironmentVariable('DETENT_INSTALL_TEST_CIM_PROCESSOR_ARCH', 'Process')
+		if ($null -ne $testCimProcessorArch) {
+			$candidates += Convert-CimProcessorArchitectureToTargetArch $testCimProcessorArch
+		} elseif (Test-Command 'Get-CimInstance') {
 			$processor = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop | Select-Object -First 1
 			$candidates += Convert-CimProcessorArchitectureToTargetArch $processor.Architecture
 

--- a/install.ps1
+++ b/install.ps1
@@ -51,38 +51,88 @@ function Get-InstallDir {
 	return Join-Path $HOME '.detent\bin'
 }
 
+function Convert-ToTargetArch {
+	param([string]$Arch)
+
+	if ([string]::IsNullOrWhiteSpace($Arch)) {
+		return $null
+	}
+
+	switch -Wildcard ($Arch.Trim().ToLowerInvariant()) {
+		'x64*' { return 'amd64' }
+		'amd64*' { return 'amd64' }
+		'x86_64*' { return 'amd64' }
+		'64-bit' { return 'amd64' }
+		'arm64*' { return 'arm64' }
+		'aarch64*' { return 'arm64' }
+	}
+
+	return $null
+}
+
+function Select-TargetArch {
+	param([object[]]$Candidates)
+
+	foreach ($arch in $Candidates) {
+		$targetArch = Convert-ToTargetArch $arch
+		if ($targetArch) {
+			return $targetArch
+		}
+	}
+
+	return $null
+}
+
+function Get-OSArchitectureCandidates {
+	$candidates = @()
+	if ($env:DETENT_INSTALL_TEST_OS_ARCH) {
+		$candidates += $env:DETENT_INSTALL_TEST_OS_ARCH
+	} else {
+		try {
+			$candidates += [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
+		} catch {
+		}
+	}
+
+	$candidates += $env:PROCESSOR_ARCHITEW6432
+
+	try {
+		if (Test-Command 'Get-CimInstance') {
+			$os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
+			$candidates += $os.OSArchitecture
+		}
+	} catch {
+	}
+
+	return $candidates
+}
+
+function Get-ProcessArchitectureCandidates {
+	$candidates = @()
+	if ($env:DETENT_INSTALL_TEST_PROCESS_ARCH) {
+		$candidates += $env:DETENT_INSTALL_TEST_PROCESS_ARCH
+	} else {
+		try {
+			$candidates += [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
+		} catch {
+		}
+	}
+	$candidates += $env:PROCESSOR_ARCHITECTURE
+
+	return $candidates
+}
+
 function Get-TargetArch {
 	if ($env:DETENT_INSTALL_TEST_ARCH) {
 		return $env:DETENT_INSTALL_TEST_ARCH
 	}
 
-	$candidates = @()
-	try {
-		$candidates += [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
-	} catch {
+	$targetArch = Select-TargetArch (Get-OSArchitectureCandidates)
+	if ($targetArch) {
+		return $targetArch
 	}
 
-	$candidates += $env:PROCESSOR_ARCHITEW6432
-	try {
-		$candidates += [System.Runtime.InteropServices.RuntimeInformation]::ProcessArchitecture.ToString()
-	} catch {
-	}
-	$candidates += $env:PROCESSOR_ARCHITECTURE
-
-	foreach ($arch in $candidates) {
-		if ([string]::IsNullOrWhiteSpace($arch)) {
-			continue
-		}
-
-		switch ($arch.ToLowerInvariant()) {
-			'x64' { return 'amd64' }
-			'amd64' { return 'amd64' }
-			'arm64' { return 'arm64' }
-			'aarch64' { return 'arm64' }
-		}
-	}
-
-	return $null
+	return Select-TargetArch (Get-ProcessArchitectureCandidates)
 }
 
 function Save-Url {

--- a/install.ps1
+++ b/install.ps1
@@ -62,7 +62,6 @@ function Convert-ToTargetArch {
 		'x64*' { return 'amd64' }
 		'amd64*' { return 'amd64' }
 		'x86_64*' { return 'amd64' }
-		'64-bit' { return 'amd64' }
 		'arm64*' { return 'arm64' }
 		'aarch64*' { return 'arm64' }
 	}
@@ -83,6 +82,17 @@ function Select-TargetArch {
 	return $null
 }
 
+function Convert-CimProcessorArchitectureToTargetArch {
+	param($Architecture)
+
+	switch ([string]$Architecture) {
+		'9' { return 'amd64' }
+		'12' { return 'arm64' }
+	}
+
+	return $null
+}
+
 function Get-OSArchitectureCandidates {
 	$candidates = @()
 	if ($env:DETENT_INSTALL_TEST_OS_ARCH) {
@@ -98,6 +108,9 @@ function Get-OSArchitectureCandidates {
 
 	try {
 		if (Test-Command 'Get-CimInstance') {
+			$processor = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop | Select-Object -First 1
+			$candidates += Convert-CimProcessorArchitectureToTargetArch $processor.Architecture
+
 			$os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
 			$candidates += $os.OSArchitecture
 		}

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -37,6 +37,7 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 		{name: "script installs exe", content: script, want: "detent.exe"},
 		{name: "script checks os architecture", content: script, want: "OSArchitecture"},
 		{name: "script checks 64-bit host from 32-bit powershell", content: script, want: "PROCESSOR_ARCHITEW6432"},
+		{name: "script queries cim processor architecture", content: script, want: "Win32_Processor"},
 		{name: "script queries cim os architecture", content: script, want: "Get-CimInstance"},
 		{name: "script updates user path", content: script, want: "SetEnvironmentVariable('Path'"},
 	} {
@@ -47,5 +48,24 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 				t.Fatalf("%s missing %q", tt.name, tt.want)
 			}
 		})
+	}
+}
+
+func TestWindowsInstallScriptDoesNotMapGeneric64BitCIMOutputToAmd64(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("install.ps1")
+	if err != nil {
+		t.Fatalf("ReadFile(install.ps1) error = %v", err)
+	}
+
+	script := string(raw)
+	for _, disallowed := range []string{
+		"'64-bit' { return 'amd64' }",
+		`"64-bit" { return "amd64" }`,
+	} {
+		if strings.Contains(script, disallowed) {
+			t.Fatalf("install.ps1 maps generic CIM bitness %q to amd64", disallowed)
+		}
 	}
 }

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -37,6 +37,7 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 		{name: "script installs exe", content: script, want: "detent.exe"},
 		{name: "script checks os architecture", content: script, want: "OSArchitecture"},
 		{name: "script checks 64-bit host from 32-bit powershell", content: script, want: "PROCESSOR_ARCHITEW6432"},
+		{name: "script queries cim os architecture", content: script, want: "Get-CimInstance"},
 		{name: "script updates user path", content: script, want: "SetEnvironmentVariable('Path'"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -69,13 +69,17 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		osArch     string
-		assetArch  string
-		archiveOut string
+		name          string
+		osArch        string
+		processArch   string
+		wow64Arch     string
+		processorArch string
+		assetArch     string
+		archiveOut    string
 	}{
-		{name: "amd64 os", osArch: "AMD64", assetArch: "amd64", archiveOut: "release-amd64"},
-		{name: "arm64 os", osArch: "ARM64", assetArch: "arm64", archiveOut: "release-arm64"},
+		{name: "amd64 os", osArch: "AMD64", processArch: "X86", wow64Arch: "AMD64", processorArch: "x86", assetArch: "amd64", archiveOut: "release-amd64"},
+		{name: "arm64 os", osArch: "ARM64", processArch: "X86", wow64Arch: "ARM64", processorArch: "x86", assetArch: "arm64", archiveOut: "release-arm64"},
+		{name: "generic 64 bit os defers to arm64 process", osArch: "64-bit", processArch: "ARM64", processorArch: "ARM64", assetArch: "arm64", archiveOut: "release-arm64"},
 	}
 
 	for _, tt := range tests {
@@ -105,9 +109,9 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 				"DETENT_INSTALL_MODE=release",
 				"DETENT_INSTALL_SKIP_PATH=1",
 				"DETENT_INSTALL_TEST_OS_ARCH="+tt.osArch,
-				"DETENT_INSTALL_TEST_PROCESS_ARCH=X86",
-				"PROCESSOR_ARCHITECTURE=x86",
-				"PROCESSOR_ARCHITEW6432="+tt.osArch,
+				"DETENT_INSTALL_TEST_PROCESS_ARCH="+tt.processArch,
+				"PROCESSOR_ARCHITECTURE="+tt.processorArch,
+				"PROCESSOR_ARCHITEW6432="+tt.wow64Arch,
 				"PATH="+fakeBin+";"+os.Getenv("PATH"),
 			)
 

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -60,6 +60,77 @@ func TestPowerShellInstallScriptInstallsReleaseArchive(t *testing.T) {
 	}
 }
 
+func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		osArch     string
+		assetArch  string
+		archiveOut string
+	}{
+		{name: "amd64 os", osArch: "AMD64", assetArch: "amd64", archiveOut: "release-amd64"},
+		{name: "arm64 os", osArch: "ARM64", assetArch: "arm64", archiveOut: "release-arm64"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			archiveName := "detent_1.2.3_windows_" + tt.assetArch + ".zip"
+			archive := detentWindowsArchive(t, tt.archiveOut)
+			server := newPowerShellInstallReleaseServer("v1.2.3", archiveName, archive, windowsArchiveChecksum(archive))
+			t.Cleanup(server.Close)
+
+			tmp := t.TempDir()
+			installDir := filepath.Join(tmp, "bin")
+			fakeBin := filepath.Join(tmp, "fakebin")
+			if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+				t.Fatalf("MkdirAll(fakebin) error = %v", err)
+			}
+			fakeGo := filepath.Join(fakeBin, "go.cmd")
+			if err := os.WriteFile(fakeGo, []byte("@echo off\r\nexit /b 1\r\n"), 0o755); err != nil {
+				t.Fatalf("WriteFile(fake go) error = %v", err)
+			}
+
+			env := append(os.Environ(),
+				"DETENT_GITHUB_API_BASE="+server.URL,
+				"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
+				"DETENT_INSTALL_DIR="+installDir,
+				"DETENT_INSTALL_MODE=release",
+				"DETENT_INSTALL_SKIP_PATH=1",
+				"DETENT_INSTALL_TEST_OS_ARCH="+tt.osArch,
+				"DETENT_INSTALL_TEST_PROCESS_ARCH=X86",
+				"PROCESSOR_ARCHITECTURE=x86",
+				"PROCESSOR_ARCHITEW6432="+tt.osArch,
+				"PATH="+fakeBin+";"+os.Getenv("PATH"),
+			)
+
+			result := runPowerShellInstall(t, root, env)
+			if result.err != nil {
+				t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+			}
+			if !strings.Contains(result.stdout, "Detected target windows/"+tt.assetArch) {
+				t.Fatalf("install stdout = %q, want target windows/%s", result.stdout, tt.assetArch)
+			}
+
+			binary := filepath.Join(installDir, "detent.exe")
+			raw, err := os.ReadFile(binary)
+			if err != nil {
+				t.Fatalf("ReadFile(installed binary) error = %v", err)
+			}
+			if string(raw) != tt.archiveOut {
+				t.Fatalf("installed binary = %q, want %s", raw, tt.archiveOut)
+			}
+		})
+	}
+}
+
 func detentWindowsArchive(t *testing.T, content string) []byte {
 	t.Helper()
 

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -74,12 +74,13 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 		processArch   string
 		wow64Arch     string
 		processorArch string
+		cimArch       string
 		assetArch     string
 		archiveOut    string
 	}{
 		{name: "amd64 os", osArch: "AMD64", processArch: "X86", wow64Arch: "AMD64", processorArch: "x86", assetArch: "amd64", archiveOut: "release-amd64"},
 		{name: "arm64 os", osArch: "ARM64", processArch: "X86", wow64Arch: "ARM64", processorArch: "x86", assetArch: "arm64", archiveOut: "release-arm64"},
-		{name: "generic 64 bit os defers to arm64 process", osArch: "64-bit", processArch: "ARM64", processorArch: "ARM64", assetArch: "arm64", archiveOut: "release-arm64"},
+		{name: "generic 64 bit os defers to arm64 process", osArch: "64-bit", processArch: "ARM64", processorArch: "ARM64", cimArch: "0", assetArch: "arm64", archiveOut: "release-arm64"},
 	}
 
 	for _, tt := range tests {
@@ -112,6 +113,7 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 				"DETENT_INSTALL_TEST_PROCESS_ARCH="+tt.processArch,
 				"PROCESSOR_ARCHITECTURE="+tt.processorArch,
 				"PROCESSOR_ARCHITEW6432="+tt.wow64Arch,
+				"DETENT_INSTALL_TEST_CIM_PROCESSOR_ARCH="+tt.cimArch,
 				"PATH="+fakeBin+";"+os.Getenv("PATH"),
 			)
 


### PR DESCRIPTION
## Summary

- Prefer OS architecture signals before process architecture in the Windows installer.
- Add CIM OS architecture probing and Windows coverage for x86 PowerShell on amd64/arm64 hosts.

Fixes #206

## Test Plan

- [x] `go test ./...`
- [x] `make check`