### PR TITLE
fix(install): prefer arm64 env in CIM fallback

### DIFF
--- a/install.ps1
+++ b/install.ps1
@@ -108,6 +108,22 @@ function Convert-CimOSArchitectureToTargetArch {
 	return Convert-ToTargetArch $Architecture
 }
 
+function Get-ProcessorArchitectureCandidate {
+	$testArch = [Environment]::GetEnvironmentVariable('DETENT_INSTALL_TEST_PROCESSOR_ARCHITECTURE', 'Process')
+	if ($null -ne $testArch) {
+		return $testArch
+	}
+	return $env:PROCESSOR_ARCHITECTURE
+}
+
+function Get-ProcessorArchitectureW6432Candidate {
+	$testArch = [Environment]::GetEnvironmentVariable('DETENT_INSTALL_TEST_PROCESSOR_ARCHITEW6432', 'Process')
+	if ($null -ne $testArch) {
+		return $testArch
+	}
+	return $env:PROCESSOR_ARCHITEW6432
+}
+
 function Get-OSArchitectureCandidates {
 	$candidates = @()
 	if ($env:DETENT_INSTALL_TEST_OS_ARCH) {
@@ -119,19 +135,19 @@ function Get-OSArchitectureCandidates {
 		}
 	}
 
-	$candidates += $env:PROCESSOR_ARCHITEW6432
+	$candidates += Get-ProcessorArchitectureW6432Candidate
 
 	try {
 		$testCimProcessorArch = [Environment]::GetEnvironmentVariable('DETENT_INSTALL_TEST_CIM_PROCESSOR_ARCH', 'Process')
 		$testCimOSArch = [Environment]::GetEnvironmentVariable('DETENT_INSTALL_TEST_CIM_OS_ARCH', 'Process')
 		if (-not [string]::IsNullOrEmpty($testCimProcessorArch) -or -not [string]::IsNullOrEmpty($testCimOSArch)) {
 			$candidates += Convert-CimProcessorArchitectureToTargetArch $testCimProcessorArch
-			$candidates += $env:PROCESSOR_ARCHITECTURE
+			$candidates += Get-ProcessorArchitectureCandidate
 			$candidates += Convert-CimOSArchitectureToTargetArch $testCimOSArch
 		} elseif (Test-Command 'Get-CimInstance') {
 			$processor = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop | Select-Object -First 1
 			$candidates += Convert-CimProcessorArchitectureToTargetArch $processor.Architecture
-			$candidates += $env:PROCESSOR_ARCHITECTURE
+			$candidates += Get-ProcessorArchitectureCandidate
 
 			$os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
 			$candidates += Convert-CimOSArchitectureToTargetArch $os.OSArchitecture
@@ -152,7 +168,7 @@ function Get-ProcessArchitectureCandidates {
 		} catch {
 		}
 	}
-	$candidates += $env:PROCESSOR_ARCHITECTURE
+	$candidates += Get-ProcessorArchitectureCandidate
 
 	return $candidates
 }

--- a/install.ps1
+++ b/install.ps1
@@ -93,11 +93,26 @@ function Convert-CimProcessorArchitectureToTargetArch {
 	return $null
 }
 
+function Convert-CimOSArchitectureToTargetArch {
+	param([string]$Architecture)
+
+	if ([string]::IsNullOrWhiteSpace($Architecture)) {
+		return $null
+	}
+
+	$normalized = $Architecture.Trim().ToLowerInvariant()
+	if ($normalized -eq '64-bit') {
+		return 'amd64'
+	}
+
+	return Convert-ToTargetArch $Architecture
+}
+
 function Get-OSArchitectureCandidates {
 	$candidates = @()
 	if ($env:DETENT_INSTALL_TEST_OS_ARCH) {
 		$candidates += $env:DETENT_INSTALL_TEST_OS_ARCH
-	} else {
+	} elseif ($env:DETENT_INSTALL_TEST_OS_ARCH_UNAVAILABLE -ne '1') {
 		try {
 			$candidates += [System.Runtime.InteropServices.RuntimeInformation]::OSArchitecture.ToString()
 		} catch {
@@ -108,14 +123,18 @@ function Get-OSArchitectureCandidates {
 
 	try {
 		$testCimProcessorArch = [Environment]::GetEnvironmentVariable('DETENT_INSTALL_TEST_CIM_PROCESSOR_ARCH', 'Process')
-		if ($null -ne $testCimProcessorArch) {
+		$testCimOSArch = [Environment]::GetEnvironmentVariable('DETENT_INSTALL_TEST_CIM_OS_ARCH', 'Process')
+		if (-not [string]::IsNullOrEmpty($testCimProcessorArch) -or -not [string]::IsNullOrEmpty($testCimOSArch)) {
 			$candidates += Convert-CimProcessorArchitectureToTargetArch $testCimProcessorArch
+			$candidates += $env:PROCESSOR_ARCHITECTURE
+			$candidates += Convert-CimOSArchitectureToTargetArch $testCimOSArch
 		} elseif (Test-Command 'Get-CimInstance') {
 			$processor = Get-CimInstance -ClassName Win32_Processor -ErrorAction Stop | Select-Object -First 1
 			$candidates += Convert-CimProcessorArchitectureToTargetArch $processor.Architecture
+			$candidates += $env:PROCESSOR_ARCHITECTURE
 
 			$os = Get-CimInstance -ClassName Win32_OperatingSystem -ErrorAction Stop
-			$candidates += $os.OSArchitecture
+			$candidates += Convert-CimOSArchitectureToTargetArch $os.OSArchitecture
 		}
 	} catch {
 	}

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -51,7 +51,7 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 	}
 }
 
-func TestWindowsInstallScriptDoesNotMapGeneric64BitCIMOutputToAmd64(t *testing.T) {
+func TestWindowsInstallScriptKeepsGeneric64BitOutOfTargetArchConverter(t *testing.T) {
 	t.Parallel()
 
 	raw, err := os.ReadFile("install.ps1")
@@ -67,5 +67,28 @@ func TestWindowsInstallScriptDoesNotMapGeneric64BitCIMOutputToAmd64(t *testing.T
 		if strings.Contains(script, disallowed) {
 			t.Fatalf("install.ps1 maps generic CIM bitness %q to amd64", disallowed)
 		}
+	}
+}
+
+func TestWindowsInstallScriptChecksProcessorEnvBeforeGenericCIMBitness(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("install.ps1")
+	if err != nil {
+		t.Fatalf("ReadFile(install.ps1) error = %v", err)
+	}
+
+	script := string(raw)
+	envIndex := strings.Index(script, "$candidates += $env:PROCESSOR_ARCHITECTURE")
+	if envIndex == -1 {
+		t.Fatal("install.ps1 does not add PROCESSOR_ARCHITECTURE to OS fallback candidates")
+	}
+
+	cimOSIndex := strings.Index(script, "$candidates += Convert-CimOSArchitectureToTargetArch")
+	if cimOSIndex == -1 {
+		t.Fatal("install.ps1 does not normalize CIM OSArchitecture output")
+	}
+	if envIndex > cimOSIndex {
+		t.Fatal("install.ps1 checks generic CIM OSArchitecture before PROCESSOR_ARCHITECTURE")
 	}
 }

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -79,7 +79,7 @@ func TestWindowsInstallScriptChecksProcessorEnvBeforeGenericCIMBitness(t *testin
 	}
 
 	script := string(raw)
-	envIndex := strings.Index(script, "$candidates += $env:PROCESSOR_ARCHITECTURE")
+	envIndex := strings.Index(script, "$candidates += Get-ProcessorArchitectureCandidate")
 	if envIndex == -1 {
 		t.Fatal("install.ps1 does not add PROCESSOR_ARCHITECTURE to OS fallback candidates")
 	}

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -114,6 +114,8 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 				"DETENT_INSTALL_SKIP_PATH=1",
 				"DETENT_INSTALL_TEST_OS_ARCH="+tt.osArch,
 				"DETENT_INSTALL_TEST_PROCESS_ARCH="+tt.processArch,
+				"DETENT_INSTALL_TEST_PROCESSOR_ARCHITECTURE="+tt.processorArch,
+				"DETENT_INSTALL_TEST_PROCESSOR_ARCHITEW6432="+tt.wow64Arch,
 				"PROCESSOR_ARCHITECTURE="+tt.processorArch,
 				"PROCESSOR_ARCHITEW6432="+tt.wow64Arch,
 				"DETENT_INSTALL_TEST_CIM_PROCESSOR_ARCH="+tt.cimArch,

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -75,12 +75,15 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 		wow64Arch     string
 		processorArch string
 		cimArch       string
+		cimOSArch     string
+		runtimeSkip   string
 		assetArch     string
 		archiveOut    string
 	}{
 		{name: "amd64 os", osArch: "AMD64", processArch: "X86", wow64Arch: "AMD64", processorArch: "x86", assetArch: "amd64", archiveOut: "release-amd64"},
 		{name: "arm64 os", osArch: "ARM64", processArch: "X86", wow64Arch: "ARM64", processorArch: "x86", assetArch: "arm64", archiveOut: "release-arm64"},
 		{name: "generic 64 bit os defers to arm64 process", osArch: "64-bit", processArch: "ARM64", processorArch: "ARM64", cimArch: "0", assetArch: "arm64", archiveOut: "release-arm64"},
+		{name: "runtime unavailable arm64 env before generic cim os", processorArch: "ARM64", cimArch: "0", cimOSArch: "64-bit", runtimeSkip: "1", assetArch: "arm64", archiveOut: "release-arm64"},
 	}
 
 	for _, tt := range tests {
@@ -114,6 +117,8 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 				"PROCESSOR_ARCHITECTURE="+tt.processorArch,
 				"PROCESSOR_ARCHITEW6432="+tt.wow64Arch,
 				"DETENT_INSTALL_TEST_CIM_PROCESSOR_ARCH="+tt.cimArch,
+				"DETENT_INSTALL_TEST_CIM_OS_ARCH="+tt.cimOSArch,
+				"DETENT_INSTALL_TEST_OS_ARCH_UNAVAILABLE="+tt.runtimeSkip,
 				"PATH="+fakeBin+";"+os.Getenv("PATH"),
 			)
 

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -33,7 +33,7 @@ func TestPowerShellInstallScriptInstallsReleaseArchive(t *testing.T) {
 
 	tmp := t.TempDir()
 	installDir := filepath.Join(tmp, "bin")
-	env := append(os.Environ(),
+	env := powerShellInstallEnv(
 		"DETENT_GITHUB_API_BASE="+server.URL,
 		"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
 		"DETENT_INSTALL_DIR="+installDir,
@@ -106,7 +106,7 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 				t.Fatalf("WriteFile(fake go) error = %v", err)
 			}
 
-			env := append(os.Environ(),
+			env := powerShellInstallEnv(
 				"DETENT_GITHUB_API_BASE="+server.URL,
 				"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
 				"DETENT_INSTALL_DIR="+installDir,
@@ -140,6 +140,27 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 			}
 		})
 	}
+}
+
+func powerShellInstallEnv(overrides ...string) []string {
+	env := os.Environ()
+	for _, override := range overrides {
+		key, _, ok := strings.Cut(override, "=")
+		if !ok {
+			continue
+		}
+
+		filtered := make([]string, 0, len(env)+1)
+		for _, entry := range env {
+			existingKey, _, ok := strings.Cut(entry, "=")
+			if ok && strings.EqualFold(existingKey, key) {
+				continue
+			}
+			filtered = append(filtered, entry)
+		}
+		env = append(filtered, override)
+	}
+	return env
 }
 
 func detentWindowsArchive(t *testing.T, content string) []byte {


### PR DESCRIPTION
## Summary

- Prefer processor architecture environment variables before generic CIM OS bitness in install.ps1 fallback detection.
- Add fixtures for RuntimeInformation-unavailable ARM64 detection and a static ordering guard.

Fixes #210

## Test Plan

- [x] `go test -run 'TestWindowsInstallScript(ChecksProcessorEnvBeforeGenericCIMBitness|KeepsGeneric64BitOutOfTargetArchConverter)|TestWindowsInstallDocsExposeOneStepPowerShellInstall' ./...`
- [x] `GOOS=windows GOARCH=amd64 go test -c -o tmp/detent-windows.test.exe .`
- [x] `make check`