### PR TITLE
feat(config): hot-reload global config

### DIFF
--- a/README.md
+++ b/README.md
@@ -376,9 +376,10 @@ detent --config ~/.detent/global.yaml promote <id> --priority 1
 detent --config ~/.detent/global.yaml remove-project <id>
 ```
 
-These commands persist the global config. Restart a foreground Detent process
-after structural edits unless your deployment wires the live manager signal path
-into the same process.
+These commands persist the global config. A running Detent process watches the
+active `global.yaml` and reconciles project additions, removals, and setting
+changes without a restart. Invalid edits are logged and ignored while the last
+valid config stays live.
 
 ## Dashboard And APIs
 

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -167,6 +167,11 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err := manager.Start(runCtx); err != nil {
 		return err
 	}
+	globalWatcherDone := startGlobalConfigWatcher(runCtx, cfg.Global, manager, logger)
+	defer func() {
+		stop()
+		waitGlobalConfigWatcher(globalWatcherDone)
+	}()
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, runtimeStore, displayURL, defaultSnapshotInterval, time.Now)

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -149,8 +149,6 @@ func TestRegistryRefresherRequestsProjectOrchestrators(t *testing.T) {
 }
 
 func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
-	t.Parallel()
-
 	host, port := freeLoopbackPort(t)
 	globalPath := filepath.Join(t.TempDir(), "global.yaml")
 	global, err := globalconfig.DefaultAt(globalPath)
@@ -187,8 +185,6 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 }
 
 func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
-	t.Parallel()
-
 	host, port := freeLoopbackPort(t)
 	configPath := filepath.Join(t.TempDir(), "global.yaml")
 	alpha := createBootProjectFiles(t)

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -186,6 +186,71 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
+	t.Parallel()
+
+	host, port := freeLoopbackPort(t)
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	bravo := createBootProjectFiles(t)
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
+	})
+	global, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, BootConfig{
+			Mode:   BootModeRunning,
+			Global: global,
+			Host:   host,
+			Port:   &port,
+		})
+	}()
+
+	settingsURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port)) + "/settings"
+	body := waitForDashboard(t, settingsURL, done)
+	if !strings.Contains(body, "alpha") {
+		t.Fatalf("settings body missing alpha:\n%s", body)
+	}
+
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
+		{ID: "bravo", Workflow: bravo.workflowPath, Workdir: bravo.workdirPath, Weight: 1},
+	})
+	body = waitForDashboardCondition(t, settingsURL, done, "bravo added", func(body string) bool {
+		return strings.Contains(body, "bravo")
+	})
+	if !strings.Contains(body, "alpha") {
+		t.Fatalf("settings body missing alpha after reload:\n%s", body)
+	}
+
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "bravo", Workflow: bravo.workflowPath, Workdir: bravo.workdirPath, Weight: 1},
+	})
+	body = waitForDashboardCondition(t, settingsURL, done, "alpha removed", func(body string) bool {
+		return strings.Contains(body, "bravo") && !strings.Contains(body, "alpha")
+	})
+	if strings.Contains(body, "alpha") {
+		t.Fatalf("settings body still contains alpha after removal:\n%s", body)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for startRunning to stop")
+	}
+}
+
 func TestRegistryRefresherSkipsStoppedProjectOrchestrators(t *testing.T) {
 	t.Parallel()
 
@@ -262,6 +327,67 @@ func waitForDashboard(t *testing.T, url string, done <-chan error) string {
 	}
 	t.Fatalf("timed out waiting for dashboard at %s", url)
 	return ""
+}
+
+func waitForDashboardCondition(t *testing.T, url string, done <-chan error, name string, ok func(string) bool) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	for ctx.Err() == nil {
+		body := waitForDashboard(t, url, done)
+		if ok(body) {
+			return body
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for dashboard condition %q at %s", name, url)
+	return ""
+}
+
+type bootProjectFiles struct {
+	workflowPath string
+	workdirPath  string
+}
+
+func createBootProjectFiles(t *testing.T) bootProjectFiles {
+	t.Helper()
+
+	workdir := t.TempDir()
+	workflow := filepath.Join(workdir, "WORKFLOW.md")
+	if err := os.WriteFile(workflow, []byte(`---
+tracker:
+  kind: memory
+---
+Test workflow prompt.
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return bootProjectFiles{
+		workflowPath: workflow,
+		workdirPath:  workdir,
+	}
+}
+
+func writeBootGlobalConfig(t *testing.T, path string, projects []globalconfig.Project) {
+	t.Helper()
+
+	cfg := globalconfig.Config{
+		Path:       path,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 8,
+			Scheduling:          globalconfig.SchedulingWeighted,
+			FairShare:           map[string]any{"half_life": "1h"},
+			Startup:             map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
+		},
+		Projects: projects,
+	}
+	if err := globalconfig.Write(path, cfg); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
 }
 
 func newRefreshProject(t *testing.T, id string) *projectpkg.Project {

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -1,0 +1,167 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"reflect"
+	"strings"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+var errMissingGlobalConfigManager = errors.New("global config reload manager is required")
+
+type globalConfigManager interface {
+	Reconcile(context.Context, project.ManagerConfig) (project.ReconcileResult, error)
+}
+
+type globalConfigReloader struct {
+	current globalconfig.Config
+	manager globalConfigManager
+	logger  *slog.Logger
+}
+
+func startGlobalConfigWatcher(
+	ctx context.Context,
+	current globalconfig.Config,
+	manager globalConfigManager,
+	logger *slog.Logger,
+) <-chan struct{} {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	path := strings.TrimSpace(current.Path)
+	if path == "" {
+		logger.Warn("global config watcher skipped", "error", "global config path is empty")
+		return nil
+	}
+
+	watcher, err := configwatcher.NewFile(path, readGlobalConfig, configwatcher.WithFileLogger(logger))
+	if err != nil {
+		logger.Warn("create global config watcher failed", "path", path, "error", err)
+		return nil
+	}
+	updates, err := watcher.Watch(ctx)
+	if err != nil {
+		logger.Warn("watch global config failed", "path", path, "error", err)
+		return nil
+	}
+
+	done := make(chan struct{})
+	reloader := &globalConfigReloader{
+		current: current,
+		manager: manager,
+		logger:  logger,
+	}
+	go func() {
+		defer close(done)
+		for {
+			select {
+			case <-ctx.Done():
+				return
+			case update, ok := <-updates:
+				if !ok {
+					return
+				}
+				reloader.handle(ctx, update)
+			}
+		}
+	}()
+	return done
+}
+
+func readGlobalConfig(path string) (globalconfig.Config, error) {
+	return globalconfig.Read(path)
+}
+
+func waitGlobalConfigWatcher(done <-chan struct{}) {
+	if done != nil {
+		<-done
+	}
+}
+
+func (r *globalConfigReloader) handle(ctx context.Context, update configwatcher.FileUpdate[globalconfig.Config]) {
+	logger := r.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
+	previous := r.current
+	result, err := r.apply(ctx, update)
+	if err != nil {
+		logger.Warn("global config reload failed", "path", update.Path, "error", err)
+		return
+	}
+
+	logGlobalSettingChanges(logger, previous.Global, r.current.Global)
+	logger.Info("global config reloaded",
+		"path", update.Path,
+		"added_projects", projectIDs(result.Added),
+		"removed_projects", projectIDs(result.Removed),
+		"changed_projects", projectIDs(result.Changed),
+		"unchanged_projects", projectIDs(result.Unchanged),
+	)
+}
+
+func (r *globalConfigReloader) apply(
+	ctx context.Context,
+	update configwatcher.FileUpdate[globalconfig.Config],
+) (project.ReconcileResult, error) {
+	if update.Err != nil {
+		return project.ReconcileResult{}, update.Err
+	}
+	if r.manager == nil {
+		return project.ReconcileResult{}, errMissingGlobalConfigManager
+	}
+
+	result, err := r.manager.Reconcile(ctx, project.ManagerConfigFromGlobal(update.Value))
+	if err != nil {
+		return result, err
+	}
+
+	r.current = update.Value
+	return result, nil
+}
+
+func logGlobalSettingChanges(logger *slog.Logger, previous globalconfig.Settings, next globalconfig.Settings) {
+	for _, field := range changedGlobalSettings(previous, next) {
+		switch field {
+		case "global.startup":
+			logger.Info("global config setting reloaded", "field", field)
+		default:
+			logger.Warn("global config setting change requires restart", "field", field)
+		}
+	}
+}
+
+func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Settings) []string {
+	fields := []string{}
+	if previous.MaxConcurrentAgents != next.MaxConcurrentAgents {
+		fields = append(fields, "global.max_concurrent_agents")
+	}
+	if previous.Scheduling != next.Scheduling {
+		fields = append(fields, "global.scheduling")
+	}
+	if !reflect.DeepEqual(previous.FairShare, next.FairShare) {
+		fields = append(fields, "global.fair_share")
+	}
+	if !reflect.DeepEqual(previous.Startup, next.Startup) {
+		fields = append(fields, "global.startup")
+	}
+	return fields
+}
+
+func projectIDs(ids []project.ProjectID) []string {
+	out := make([]string, 0, len(ids))
+	for _, id := range ids {
+		out = append(out, string(id))
+	}
+	return out
+}

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"testing"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+func TestGlobalConfigReloaderApply(t *testing.T) {
+	t.Parallel()
+
+	reloadErr := errors.New("invalid global config")
+	reconcileErr := errors.New("reconcile failed")
+	current := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+	next := reloadTestConfig("global.yaml", 4, []globalconfig.Project{
+		{ID: "alpha", Weight: 1},
+		{ID: "bravo", Weight: 2},
+	})
+
+	tests := []struct {
+		name        string
+		update      configwatcher.FileUpdate[globalconfig.Config]
+		managerErr  error
+		wantCurrent globalconfig.Config
+		wantCalls   int
+		wantErr     error
+	}{
+		{
+			name:        "valid update reconciles and retains next config",
+			update:      configwatcher.FileUpdate[globalconfig.Config]{Path: next.Path, Value: next},
+			wantCurrent: next,
+			wantCalls:   1,
+		},
+		{
+			name:        "invalid update keeps current config",
+			update:      configwatcher.FileUpdate[globalconfig.Config]{Path: current.Path, Err: reloadErr},
+			wantCurrent: current,
+			wantErr:     reloadErr,
+		},
+		{
+			name:        "reconcile error keeps current config",
+			update:      configwatcher.FileUpdate[globalconfig.Config]{Path: next.Path, Value: next},
+			managerErr:  reconcileErr,
+			wantCurrent: current,
+			wantCalls:   1,
+			wantErr:     reconcileErr,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			manager := &globalReloadManager{err: tt.managerErr}
+			reloader := &globalConfigReloader{
+				current: current,
+				manager: manager,
+			}
+
+			_, err := reloader.apply(context.Background(), tt.update)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("apply() error = %v, want %v", err, tt.wantErr)
+			}
+			if manager.calls != tt.wantCalls {
+				t.Fatalf("manager calls = %d, want %d", manager.calls, tt.wantCalls)
+			}
+			if manager.calls > 0 {
+				wantConfig := project.ManagerConfigFromGlobal(tt.update.Value)
+				if !reflect.DeepEqual(manager.config, wantConfig) {
+					t.Fatalf("manager config = %#v, want %#v", manager.config, wantConfig)
+				}
+			}
+			if !reflect.DeepEqual(reloader.current, tt.wantCurrent) {
+				t.Fatalf("current = %#v, want %#v", reloader.current, tt.wantCurrent)
+			}
+		})
+	}
+}
+
+type globalReloadManager struct {
+	calls  int
+	config project.ManagerConfig
+	err    error
+}
+
+func (m *globalReloadManager) Reconcile(
+	_ context.Context,
+	cfg project.ManagerConfig,
+) (project.ReconcileResult, error) {
+	m.calls++
+	m.config = cfg
+	return project.ReconcileResult{Added: []project.ProjectID{"bravo"}}, m.err
+}
+
+func reloadTestConfig(path string, maxConcurrentAgents int, projects []globalconfig.Project) globalconfig.Config {
+	return globalconfig.Config{
+		Path:       path,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: maxConcurrentAgents,
+			Scheduling:          globalconfig.SchedulingWeighted,
+			FairShare:           map[string]any{"half_life": "1h"},
+			Startup:             map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
+		},
+		Projects: projects,
+	}
+}

--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -1,0 +1,224 @@
+package watcher
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"time"
+
+	"github.com/fsnotify/fsnotify"
+)
+
+type FileLoader[T any] func(string) (T, error)
+
+type FileUpdate[T any] struct {
+	Path  string
+	Value T
+	Err   error
+	At    time.Time
+}
+
+type FileOption func(*fileOptions)
+
+type FileWatcher[T any] struct {
+	path     string
+	dir      string
+	debounce time.Duration
+	loader   FileLoader[T]
+	logger   *slog.Logger
+}
+
+type fileOptions struct {
+	debounce time.Duration
+	logger   *slog.Logger
+}
+
+func NewFile[T any](path string, loader FileLoader[T], opts ...FileOption) (*FileWatcher[T], error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, ErrMissingPath
+	}
+	if loader == nil {
+		return nil, errors.New("config watch loader is required")
+	}
+
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve config watch path: %w", err)
+	}
+
+	cfg := fileOptions{
+		debounce: defaultDebounce,
+		logger:   slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(&cfg)
+	}
+	if cfg.debounce <= 0 {
+		cfg.debounce = defaultDebounce
+	}
+	if cfg.logger == nil {
+		cfg.logger = slog.Default()
+	}
+
+	return &FileWatcher[T]{
+		path:     filepath.Clean(absolute),
+		dir:      filepath.Dir(absolute),
+		debounce: cfg.debounce,
+		loader:   loader,
+		logger:   cfg.logger,
+	}, nil
+}
+
+func WithFileDebounce(debounce time.Duration) FileOption {
+	return func(opts *fileOptions) {
+		opts.debounce = debounce
+	}
+}
+
+func WithFileLogger(logger *slog.Logger) FileOption {
+	return func(opts *fileOptions) {
+		opts.logger = logger
+	}
+}
+
+func (w *FileWatcher[T]) Watch(ctx context.Context) (<-chan FileUpdate[T], error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	fsWatcher, err := fsnotify.NewWatcher()
+	if err != nil {
+		return nil, fmt.Errorf("create config watcher: %w", err)
+	}
+	if err := fsWatcher.Add(w.dir); err != nil {
+		closeErr := fsWatcher.Close()
+		return nil, errors.Join(fmt.Errorf("watch config directory: %w", err), closeErr)
+	}
+
+	updates := make(chan FileUpdate[T], 1)
+	go w.run(ctx, fsWatcher, updates)
+	return updates, nil
+}
+
+func (w *FileWatcher[T]) run(ctx context.Context, fsWatcher *fsnotify.Watcher, updates chan<- FileUpdate[T]) {
+	defer close(updates)
+	defer func() {
+		if err := fsWatcher.Close(); err != nil {
+			w.logger.Warn("close config watcher failed", "path", w.path, "error", err)
+		}
+	}()
+
+	timer := time.NewTimer(w.debounce)
+	if !timer.Stop() {
+		<-timer.C
+	}
+	var timerC <-chan time.Time
+	var lastUpdate *FileUpdate[T]
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case event, ok := <-fsWatcher.Events:
+			if !ok {
+				return
+			}
+			if w.matches(event) {
+				resetTimer(timer, w.debounce)
+				timerC = timer.C
+			}
+		case err, ok := <-fsWatcher.Errors:
+			if !ok {
+				return
+			}
+			w.send(ctx, updates, FileUpdate[T]{Path: w.path, Err: err, At: time.Now()})
+		case <-timerC:
+			timerC = nil
+			update := w.reload(ctx)
+			if sameFileUpdate(update, lastUpdate) {
+				continue
+			}
+			w.send(ctx, updates, update)
+			last := update
+			lastUpdate = &last
+		}
+	}
+}
+
+func (w *FileWatcher[T]) matches(event fsnotify.Event) bool {
+	if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename|fsnotify.Remove) == 0 {
+		return false
+	}
+	return filepath.Clean(event.Name) == w.path
+}
+
+func (w *FileWatcher[T]) reload(ctx context.Context) FileUpdate[T] {
+	update := FileUpdate[T]{
+		Path: w.path,
+		At:   time.Now(),
+	}
+
+	value, err := w.load(ctx)
+	if err != nil {
+		update.Err = err
+	} else {
+		update.Value = value
+	}
+
+	return update
+}
+
+func (w *FileWatcher[T]) load(ctx context.Context) (T, error) {
+	value, err := w.loader(w.path)
+	if err == nil {
+		return value, nil
+	}
+	lastErr := err
+
+	deadline := time.NewTimer(w.debounce)
+	defer deadline.Stop()
+	retry := time.NewTicker(retryInterval(w.debounce))
+	defer retry.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			var zero T
+			return zero, ctx.Err()
+		case <-deadline.C:
+			var zero T
+			return zero, lastErr
+		case <-retry.C:
+			value, err := w.loader(w.path)
+			if err == nil {
+				return value, nil
+			}
+			lastErr = err
+		}
+	}
+}
+
+func (w *FileWatcher[T]) send(ctx context.Context, updates chan<- FileUpdate[T], update FileUpdate[T]) {
+	select {
+	case updates <- update:
+	case <-ctx.Done():
+	}
+}
+
+func sameFileUpdate[T any](update FileUpdate[T], last *FileUpdate[T]) bool {
+	if last == nil || update.Path != last.Path {
+		return false
+	}
+	if (update.Err == nil) != (last.Err == nil) {
+		return false
+	}
+	if update.Err != nil {
+		return update.Err.Error() == last.Err.Error()
+	}
+	return reflect.DeepEqual(update.Value, last.Value)
+}

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
 func TestWatchDebouncesWorkflowWrites(t *testing.T) {
@@ -203,6 +204,43 @@ func TestWatchReportsInvalidReload(t *testing.T) {
 	}
 }
 
+func TestFileWatcherDebouncesGlobalConfigWrites(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "global.yaml")
+	writeGlobalConfig(t, path, 2)
+
+	w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
+		return globalconfig.Read(path)
+	}, WithFileDebounce(10*time.Millisecond))
+	if err != nil {
+		t.Fatalf("NewFile() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	updates, err := w.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	writeGlobalConfig(t, path, 3)
+	writeGlobalConfig(t, path, 4)
+
+	update := receiveFileUpdate(t, updates)
+	if update.Err != nil {
+		t.Fatalf("update error = %v", update.Err)
+	}
+	if update.Value.Global.MaxConcurrentAgents != 4 {
+		t.Fatalf("MaxConcurrentAgents = %d, want 4", update.Value.Global.MaxConcurrentAgents)
+	}
+	if update.Value.Path != path {
+		t.Fatalf("Path = %q, want %q", update.Value.Path, path)
+	}
+}
+
 func receiveUpdate(t *testing.T, updates <-chan Update) Update {
 	t.Helper()
 
@@ -219,6 +257,22 @@ func receiveUpdate(t *testing.T, updates <-chan Update) Update {
 	return Update{}
 }
 
+func receiveFileUpdate[T any](t *testing.T, updates <-chan FileUpdate[T]) FileUpdate[T] {
+	t.Helper()
+
+	select {
+	case update, ok := <-updates:
+		if !ok {
+			t.Fatal("updates channel closed")
+		}
+		return update
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for watcher update")
+	}
+
+	return FileUpdate[T]{}
+}
+
 func writeWorkflow(t *testing.T, path string, intervalMS int, prompt string) {
 	t.Helper()
 
@@ -229,6 +283,21 @@ polling:
   interval_ms: ` + strconv.Itoa(intervalMS) + `
 ---
 ` + prompt + `
+`)
+	if err := os.WriteFile(path, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func writeGlobalConfig(t *testing.T, path string, maxConcurrentAgents int) {
+	t.Helper()
+
+	raw := []byte(`apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: ` + strconv.Itoa(maxConcurrentAgents) + `
+  scheduling: weighted
+projects: []
 `)
 	if err := os.WriteFile(path, raw, 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)

--- a/internal/config/watcher/watcher_test.go
+++ b/internal/config/watcher/watcher_test.go
@@ -213,7 +213,7 @@ func TestFileWatcherDebouncesGlobalConfigWrites(t *testing.T) {
 
 	w, err := NewFile(path, func(path string) (globalconfig.Config, error) {
 		return globalconfig.Read(path)
-	}, WithFileDebounce(10*time.Millisecond))
+	}, WithFileDebounce(150*time.Millisecond))
 	if err != nil {
 		t.Fatalf("NewFile() error = %v", err)
 	}

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -231,11 +231,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		}
 	}
 	for _, id := range result.Changed {
-		if err := m.removeLocked(ctx, id); err != nil {
-			m.cfg = previous
-			return result, err
-		}
-		if err := m.registerProjectLocked(ctx, id, prepared[id]); err != nil {
+		if err := m.replaceProjectLocked(ctx, id, prepared[id]); err != nil {
 			m.cfg = previous
 			return result, err
 		}
@@ -262,6 +258,42 @@ func (m *Manager) removeLocked(ctx context.Context, id ProjectID) error {
 		}
 	}
 	m.registry.Delete(id)
+	return nil
+}
+
+func (m *Manager) replaceProjectLocked(ctx context.Context, id ProjectID, replacement *Project) error {
+	current, ok := m.registry.Get(id)
+	if !ok {
+		return ErrProjectNotFound
+	}
+
+	shouldStart := m.running && !replacement.Paused()
+	if shouldStart {
+		if err := m.waitBeforeSpawn(ctx); err != nil {
+			return err
+		}
+		if err := replacement.provision(ctx); err != nil {
+			return fmt.Errorf("provision replacement project %s: %w", id, err)
+		}
+	}
+
+	if current.Running() {
+		if err := current.Stop(ctx); err != nil {
+			return err
+		}
+	}
+	m.registry.Delete(id)
+	if err := m.registry.Set(replacement); err != nil {
+		return err
+	}
+	if !shouldStart {
+		return nil
+	}
+	if err := replacement.start(ctx, false); err != nil {
+		m.registry.Delete(id)
+		return err
+	}
+	m.spawned = true
 	return nil
 }
 

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -40,6 +40,11 @@ type ReconcileResult struct {
 	Unchanged []ProjectID
 }
 
+type startedProject struct {
+	id      ProjectID
+	project *Project
+}
+
 type ManagerDependencies struct {
 	Registry            *Registry
 	ProjectFactory      ProjectFactory
@@ -223,24 +228,67 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	}
 
 	previous := m.cfg
+	previousSpawned := m.spawned
 	m.cfg.Startup = cfg.Startup
-	for _, id := range result.Removed {
-		if err := m.removeLocked(ctx, id); err != nil {
-			m.cfg = previous
-			return result, err
-		}
-	}
+	started := make([]startedProject, 0, len(prepared))
+	startedByID := map[ProjectID]*Project{}
 	for _, id := range result.Changed {
-		if err := m.replaceProjectLocked(ctx, id, prepared[id]); err != nil {
+		preparedProject := prepared[id]
+		if didStart, err := m.startPreparedProjectLocked(ctx, preparedProject); err != nil {
+			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, nil)
 			m.cfg = previous
-			return result, err
+			m.spawned = previousSpawned
+			return result, errors.Join(err, cleanupErr)
+		} else if didStart {
+			started = append(started, startedProject{id: id, project: preparedProject})
+			startedByID[id] = preparedProject
 		}
 	}
 	for _, id := range result.Added {
-		if err := m.registerProjectLocked(ctx, id, prepared[id]); err != nil {
+		preparedProject := prepared[id]
+		if didStart, err := m.startPreparedProjectLocked(ctx, preparedProject); err != nil {
+			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, nil)
 			m.cfg = previous
-			return result, err
+			m.spawned = previousSpawned
+			return result, errors.Join(err, cleanupErr)
+		} else if didStart {
+			started = append(started, startedProject{id: id, project: preparedProject})
+			startedByID[id] = preparedProject
 		}
+	}
+
+	committed := map[ProjectID]struct{}{}
+	for _, id := range result.Removed {
+		if err := m.removeLocked(ctx, id); err != nil {
+			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, committed)
+			m.cfg = previous
+			m.spawned = previousSpawned
+			return result, errors.Join(err, cleanupErr)
+		}
+	}
+	for _, id := range result.Changed {
+		if err := m.replaceStartedProjectLocked(ctx, id, prepared[id]); err != nil {
+			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, committed)
+			m.cfg = previous
+			m.spawned = previousSpawned
+			return result, errors.Join(err, cleanupErr)
+		}
+		if startedProject, ok := startedByID[id]; ok {
+			startedProject.publishStarted()
+		}
+		committed[id] = struct{}{}
+	}
+	for _, id := range result.Added {
+		if err := m.registry.Set(prepared[id]); err != nil {
+			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, committed)
+			m.cfg = previous
+			m.spawned = previousSpawned
+			return result, errors.Join(err, cleanupErr)
+		}
+		if startedProject, ok := startedByID[id]; ok {
+			startedProject.publishStarted()
+		}
+		committed[id] = struct{}{}
 	}
 
 	m.cfg = cfg
@@ -261,40 +309,17 @@ func (m *Manager) removeLocked(ctx context.Context, id ProjectID) error {
 	return nil
 }
 
-func (m *Manager) replaceProjectLocked(ctx context.Context, id ProjectID, replacement *Project) error {
+func (m *Manager) replaceStartedProjectLocked(ctx context.Context, id ProjectID, replacement *Project) error {
 	current, ok := m.registry.Get(id)
 	if !ok {
 		return ErrProjectNotFound
 	}
-
-	shouldStart := m.running && !replacement.Paused()
-	if shouldStart {
-		if err := m.waitBeforeSpawn(ctx); err != nil {
-			return err
-		}
-		if err := replacement.provision(ctx); err != nil {
-			return fmt.Errorf("provision replacement project %s: %w", id, err)
-		}
-	}
-
 	if current.Running() {
 		if err := current.Stop(ctx); err != nil {
 			return err
 		}
 	}
-	m.registry.Delete(id)
-	if err := m.registry.Set(replacement); err != nil {
-		return err
-	}
-	if !shouldStart {
-		return nil
-	}
-	if err := replacement.start(ctx, false); err != nil {
-		m.registry.Delete(id)
-		return err
-	}
-	m.spawned = true
-	return nil
+	return m.registry.Set(replacement)
 }
 
 func (m *Manager) Pause(ctx context.Context, id ProjectID) error {
@@ -382,15 +407,47 @@ func (m *Manager) registerProjectLocked(ctx context.Context, id ProjectID, proje
 	return nil
 }
 
+func (m *Manager) startPreparedProjectLocked(ctx context.Context, project *Project) (bool, error) {
+	if !m.running || project.Paused() {
+		return false, nil
+	}
+	if err := m.startProjectLocked(ctx, project, false); err != nil {
+		return false, err
+	}
+	return true, nil
+}
+
 func (m *Manager) startLocked(ctx context.Context, project *Project) error {
+	return m.startProjectLocked(ctx, project, true)
+}
+
+func (m *Manager) startProjectLocked(ctx context.Context, project *Project, publishEvents bool) error {
 	if err := m.waitBeforeSpawn(ctx); err != nil {
 		return err
 	}
-	if err := project.Start(ctx); err != nil {
+	if err := project.start(ctx, startOptions{provision: true, publishEvents: publishEvents}); err != nil {
 		return err
 	}
 	m.spawned = true
 	return nil
+}
+
+func (m *Manager) stopUncommittedStartedProjects(
+	ctx context.Context,
+	started []startedProject,
+	committed map[ProjectID]struct{},
+) error {
+	var cleanupErr error
+	for i := len(started) - 1; i >= 0; i-- {
+		item := started[i]
+		if _, ok := committed[item.id]; ok {
+			continue
+		}
+		if item.project.Running() {
+			cleanupErr = errors.Join(cleanupErr, item.project.Stop(ctx))
+		}
+	}
+	return cleanupErr
 }
 
 func (m *Manager) waitBeforeSpawn(ctx context.Context) error {

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -41,8 +41,12 @@ type ReconcileResult struct {
 }
 
 type startedProject struct {
-	id      ProjectID
 	project *Project
+}
+
+type rollbackProject struct {
+	project    *Project
+	wasRunning bool
 }
 
 type ManagerDependencies struct {
@@ -230,68 +234,98 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	previous := m.cfg
 	previousSpawned := m.spawned
 	m.cfg.Startup = cfg.Startup
+	stopped := make([]rollbackProject, 0, len(result.Removed)+len(result.Changed))
 	started := make([]startedProject, 0, len(prepared))
-	startedByID := map[ProjectID]*Project{}
-	for _, id := range result.Changed {
-		preparedProject := prepared[id]
-		if didStart, err := m.startPreparedProjectLocked(ctx, preparedProject); err != nil {
-			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, nil)
-			m.cfg = previous
-			m.spawned = previousSpawned
-			return result, errors.Join(err, cleanupErr)
-		} else if didStart {
-			started = append(started, startedProject{id: id, project: preparedProject})
-			startedByID[id] = preparedProject
+	added := map[ProjectID]struct{}{}
+	rollback := func() error {
+		cleanupErr := m.stopUncommittedStartedProjects(ctx, started)
+		for id := range added {
+			m.registry.Delete(id)
 		}
-	}
-	for _, id := range result.Added {
-		preparedProject := prepared[id]
-		if didStart, err := m.startPreparedProjectLocked(ctx, preparedProject); err != nil {
-			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, nil)
-			m.cfg = previous
-			m.spawned = previousSpawned
-			return result, errors.Join(err, cleanupErr)
-		} else if didStart {
-			started = append(started, startedProject{id: id, project: preparedProject})
-			startedByID[id] = preparedProject
+		for i := len(stopped) - 1; i >= 0; i-- {
+			item := stopped[i]
+			if err := m.registry.Set(item.project); err != nil {
+				cleanupErr = errors.Join(cleanupErr, err)
+			}
 		}
+		m.cfg = previous
+		m.spawned = previousSpawned
+		for i := len(stopped) - 1; i >= 0; i-- {
+			item := stopped[i]
+			if !item.wasRunning || item.project.Running() {
+				continue
+			}
+			if err := m.restartProjectLocked(ctx, item.project, false); err != nil {
+				cleanupErr = errors.Join(cleanupErr, err)
+			}
+		}
+		return cleanupErr
 	}
 
-	committed := map[ProjectID]struct{}{}
 	for _, id := range result.Removed {
-		if err := m.removeLocked(ctx, id); err != nil {
-			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, committed)
-			m.cfg = previous
-			m.spawned = previousSpawned
-			return result, errors.Join(err, cleanupErr)
+		current, ok := m.registry.Get(id)
+		if !ok {
+			return result, errors.Join(ErrProjectNotFound, rollback())
+		}
+		wasRunning := current.Running()
+		if wasRunning {
+			if err := current.stop(ctx, false); err != nil {
+				return result, errors.Join(err, rollback())
+			}
+		}
+		stopped = append(stopped, rollbackProject{project: current, wasRunning: wasRunning})
+		if !m.registry.Delete(id) {
+			return result, errors.Join(ErrProjectNotFound, rollback())
 		}
 	}
 	for _, id := range result.Changed {
-		if err := m.replaceStartedProjectLocked(ctx, id, prepared[id]); err != nil {
-			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, committed)
-			m.cfg = previous
-			m.spawned = previousSpawned
-			return result, errors.Join(err, cleanupErr)
+		current, ok := m.registry.Get(id)
+		if !ok {
+			return result, errors.Join(ErrProjectNotFound, rollback())
 		}
-		if startedProject, ok := startedByID[id]; ok {
-			startedProject.publishStarted()
+		wasRunning := current.Running()
+		if wasRunning {
+			if err := current.stop(ctx, false); err != nil {
+				return result, errors.Join(err, rollback())
+			}
 		}
-		committed[id] = struct{}{}
+		stopped = append(stopped, rollbackProject{project: current, wasRunning: wasRunning})
+		preparedProject := prepared[id]
+		didStart, err := m.startPreparedProjectLocked(ctx, preparedProject)
+		if err != nil {
+			return result, errors.Join(err, rollback())
+		}
+		if didStart {
+			started = append(started, startedProject{project: preparedProject})
+		}
+		if err := m.registry.Set(preparedProject); err != nil {
+			return result, errors.Join(err, rollback())
+		}
 	}
 	for _, id := range result.Added {
-		if err := m.registry.Set(prepared[id]); err != nil {
-			cleanupErr := m.stopUncommittedStartedProjects(ctx, started, committed)
-			m.cfg = previous
-			m.spawned = previousSpawned
-			return result, errors.Join(err, cleanupErr)
+		preparedProject := prepared[id]
+		didStart, err := m.startPreparedProjectLocked(ctx, preparedProject)
+		if err != nil {
+			return result, errors.Join(err, rollback())
 		}
-		if startedProject, ok := startedByID[id]; ok {
-			startedProject.publishStarted()
+		if didStart {
+			started = append(started, startedProject{project: preparedProject})
 		}
-		committed[id] = struct{}{}
+		if err := m.registry.Set(preparedProject); err != nil {
+			return result, errors.Join(err, rollback())
+		}
+		added[id] = struct{}{}
 	}
 
 	m.cfg = cfg
+	for _, item := range stopped {
+		if item.wasRunning {
+			item.project.publishStopped(nil)
+		}
+	}
+	for _, item := range started {
+		item.project.publishStarted()
+	}
 	return result, nil
 }
 
@@ -307,19 +341,6 @@ func (m *Manager) removeLocked(ctx context.Context, id ProjectID) error {
 	}
 	m.registry.Delete(id)
 	return nil
-}
-
-func (m *Manager) replaceStartedProjectLocked(ctx context.Context, id ProjectID, replacement *Project) error {
-	current, ok := m.registry.Get(id)
-	if !ok {
-		return ErrProjectNotFound
-	}
-	if current.Running() {
-		if err := current.Stop(ctx); err != nil {
-			return err
-		}
-	}
-	return m.registry.Set(replacement)
 }
 
 func (m *Manager) Pause(ctx context.Context, id ProjectID) error {
@@ -432,19 +453,23 @@ func (m *Manager) startProjectLocked(ctx context.Context, project *Project, publ
 	return nil
 }
 
-func (m *Manager) stopUncommittedStartedProjects(
-	ctx context.Context,
-	started []startedProject,
-	committed map[ProjectID]struct{},
-) error {
+func (m *Manager) restartProjectLocked(ctx context.Context, project *Project, publishEvents bool) error {
+	if err := m.waitBeforeSpawn(ctx); err != nil {
+		return err
+	}
+	if err := project.restart(ctx, startOptions{provision: true, publishEvents: publishEvents}); err != nil {
+		return err
+	}
+	m.spawned = true
+	return nil
+}
+
+func (m *Manager) stopUncommittedStartedProjects(ctx context.Context, started []startedProject) error {
 	var cleanupErr error
 	for i := len(started) - 1; i >= 0; i-- {
 		item := started[i]
-		if _, ok := committed[item.id]; ok {
-			continue
-		}
 		if item.project.Running() {
-			cleanupErr = errors.Join(cleanupErr, item.project.Stop(ctx))
+			cleanupErr = errors.Join(cleanupErr, item.project.stop(ctx, false))
 		}
 	}
 	return cleanupErr

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"math/big"
+	"reflect"
 	"sync"
 	"time"
 
@@ -30,6 +31,13 @@ type StartupConfig struct {
 type ManagerConfig struct {
 	Projects []globalconfig.Project
 	Startup  StartupConfig
+}
+
+type ReconcileResult struct {
+	Added     []ProjectID
+	Removed   []ProjectID
+	Changed   []ProjectID
+	Unchanged []ProjectID
 }
 
 type ManagerDependencies struct {
@@ -150,6 +158,100 @@ func (m *Manager) Remove(ctx context.Context, id ProjectID) error {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	return m.removeLocked(ctx, id)
+}
+
+func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	cfg.Projects = append([]globalconfig.Project(nil), cfg.Projects...)
+	desired := make(map[ProjectID]globalconfig.Project, len(cfg.Projects))
+	for i, project := range cfg.Projects {
+		normalized := normalizeManagerProjectConfig(project)
+		id := ProjectID(normalized.ID)
+		if id == "" {
+			return ReconcileResult{}, ErrMissingProjectID
+		}
+		if _, ok := desired[id]; ok {
+			return ReconcileResult{}, ErrProjectExists
+		}
+		cfg.Projects[i] = normalized
+		desired[id] = normalized
+	}
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	result := ReconcileResult{}
+	for _, current := range m.registry.List() {
+		id := current.ID()
+		next, ok := desired[id]
+		if !ok {
+			result.Removed = append(result.Removed, id)
+			continue
+		}
+		if sameProjectConfig(current.Config(), next) {
+			result.Unchanged = append(result.Unchanged, id)
+			continue
+		}
+		result.Changed = append(result.Changed, id)
+	}
+
+	for _, next := range cfg.Projects {
+		id := ProjectID(next.ID)
+		if _, ok := m.registry.Get(id); !ok {
+			result.Added = append(result.Added, id)
+		}
+	}
+
+	prepared := make(map[ProjectID]*Project, len(result.Added)+len(result.Changed))
+	for _, id := range result.Changed {
+		_, preparedProject, err := m.createProjectLocked(desired[id])
+		if err != nil {
+			return result, err
+		}
+		prepared[id] = preparedProject
+	}
+	for _, id := range result.Added {
+		_, preparedProject, err := m.createProjectLocked(desired[id])
+		if err != nil {
+			return result, err
+		}
+		prepared[id] = preparedProject
+	}
+
+	previous := m.cfg
+	m.cfg.Startup = cfg.Startup
+	for _, id := range result.Removed {
+		if err := m.removeLocked(ctx, id); err != nil {
+			m.cfg = previous
+			return result, err
+		}
+	}
+	for _, id := range result.Changed {
+		if err := m.removeLocked(ctx, id); err != nil {
+			m.cfg = previous
+			return result, err
+		}
+		if err := m.registerProjectLocked(ctx, id, prepared[id]); err != nil {
+			m.cfg = previous
+			return result, err
+		}
+	}
+	for _, id := range result.Added {
+		if err := m.registerProjectLocked(ctx, id, prepared[id]); err != nil {
+			m.cfg = previous
+			return result, err
+		}
+	}
+
+	m.cfg = cfg
+	return result, nil
+}
+
+func (m *Manager) removeLocked(ctx context.Context, id ProjectID) error {
 	project, ok := m.registry.Get(id)
 	if !ok {
 		return ErrProjectNotFound
@@ -214,11 +316,27 @@ func (m *Manager) addLocked(ctx context.Context, cfg globalconfig.Project) error
 		return ErrProjectExists
 	}
 
+	_, project, err := m.createProjectLocked(cfg)
+	if err != nil {
+		return err
+	}
+	return m.registerProjectLocked(ctx, id, project)
+}
+
+func (m *Manager) createProjectLocked(cfg globalconfig.Project) (ProjectID, *Project, error) {
+	id := normalizeProjectID(ProjectID(cfg.ID))
+	if id == "" {
+		return "", nil, ErrMissingProjectID
+	}
 	cfg.ID = string(id)
 	project, err := m.factory(cfg)
 	if err != nil {
-		return fmt.Errorf("create project %s: %w", id, err)
+		return "", nil, fmt.Errorf("create project %s: %w", id, err)
 	}
+	return id, project, nil
+}
+
+func (m *Manager) registerProjectLocked(ctx context.Context, id ProjectID, project *Project) error {
 	if err := m.registry.Set(project); err != nil {
 		return err
 	}
@@ -267,6 +385,15 @@ func startupInt(values map[string]any, key string) int {
 		return 0
 	}
 	return number
+}
+
+func normalizeManagerProjectConfig(cfg globalconfig.Project) globalconfig.Project {
+	cfg.ID = string(normalizeProjectID(ProjectID(cfg.ID)))
+	return cfg
+}
+
+func sameProjectConfig(left globalconfig.Project, right globalconfig.Project) bool {
+	return reflect.DeepEqual(normalizeManagerProjectConfig(left), normalizeManagerProjectConfig(right))
 }
 
 func sleepContext(ctx context.Context, delay time.Duration) error {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"testing"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/project"
@@ -321,6 +322,68 @@ func TestManagerReconcileKeepsRegistryWhenNewProjectCannotBeCreated(t *testing.T
 	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
 		"alpha": {ID: "alpha", Weight: 1},
 	})
+}
+
+func TestManagerReconcileKeepsChangedProjectWhenReplacementProvisionFails(t *testing.T) {
+	t.Parallel()
+
+	provisionErr := errors.New("provision failed")
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			var provision func(context.Context) error
+			if cfg.ID == "alpha" && cfg.Weight == 2 {
+				provision = func(context.Context) error {
+					return provisionErr
+				}
+			}
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			}, project.Dependencies{
+				Connector: provisioningConnector{provision: provision},
+				Events:    events,
+				Runner:    blockingRunner{},
+			})
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+
+	_, err = manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 2}},
+	})
+	if !errors.Is(err, provisionErr) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, provisionErr)
+	}
+	assertNoProjectEvent(t, sub.C())
+	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+		"alpha": {ID: "alpha", Weight: 1},
+	})
+
+	got, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Registry().Get(alpha) ok = false, want true")
+	}
+	if !got.Running() {
+		t.Fatal("alpha Running() = false, want true")
+	}
 }
 
 func TestManagerSharedGlobalSchedulerGate(t *testing.T) {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -386,6 +386,107 @@ func TestManagerReconcileKeepsChangedProjectWhenReplacementProvisionFails(t *tes
 	}
 }
 
+func TestManagerReconcileKeepsChangedProjectWhenReplacementStartFails(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "alpha" && cfg.Weight == 2 {
+				return newStoppedManagerTestProject(t, cfg)
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+
+	_, err = manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 2}},
+	})
+	if !errors.Is(err, project.ErrProjectStopped) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, project.ErrProjectStopped)
+	}
+	assertNoProjectEvent(t, sub.C())
+	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+		"alpha": {ID: "alpha", Weight: 1},
+	})
+
+	got, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Registry().Get(alpha) ok = false, want true")
+	}
+	if !got.Running() {
+		t.Fatal("alpha Running() = false, want true")
+	}
+}
+
+func TestManagerReconcileKeepsRegistryWhenAddedProjectStartFailsAfterRemoval(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "charlie", Weight: 1},
+		},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "bravo" {
+				return newStoppedManagerTestProject(t, cfg)
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 2)
+
+	_, err = manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "charlie", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	})
+	if !errors.Is(err, project.ErrProjectStopped) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, project.ErrProjectStopped)
+	}
+	assertNoProjectEvent(t, sub.C())
+	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+		"alpha":   {ID: "alpha", Weight: 1},
+		"charlie": {ID: "charlie", Weight: 1},
+	})
+}
+
 func TestManagerSharedGlobalSchedulerGate(t *testing.T) {
 	t.Parallel()
 
@@ -523,6 +624,31 @@ func newManagerTestProject(t *testing.T, cfg globalconfig.Project, events *hub.H
 		Events: events,
 		Runner: blockingRunner{},
 	})
+}
+
+func newStoppedManagerTestProject(t *testing.T, cfg globalconfig.Project) (*project.Project, error) {
+	t.Helper()
+
+	if cfg.Weight == 0 {
+		cfg.Weight = 1
+	}
+	got, err := project.New(project.Config{
+		Project:  cfg,
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+	}, project.Dependencies{
+		Events: hub.New[project.Event](hub.WithBuffer(4)),
+		Runner: blockingRunner{},
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("replacement Start() error = %v", err)
+	}
+	if err := got.Stop(context.Background()); err != nil {
+		t.Fatalf("replacement Stop() error = %v", err)
+	}
+	return got, nil
 }
 
 func startedProjectCount(configs []globalconfig.Project) int {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -151,6 +151,178 @@ func TestManagerLiveAddRemovePauseUnpause(t *testing.T) {
 	}
 }
 
+func TestManagerReconcileProjects(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		initial     []globalconfig.Project
+		next        []globalconfig.Project
+		want        project.ReconcileResult
+		wantEvents  []project.Event
+		wantConfigs map[project.ProjectID]globalconfig.Project
+		wantErr     error
+	}{
+		{
+			name:    "unchanged",
+			initial: []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/alpha"}},
+			next:    []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/alpha"}},
+			want: project.ReconcileResult{
+				Unchanged: []project.ProjectID{"alpha"},
+			},
+			wantConfigs: map[project.ProjectID]globalconfig.Project{
+				"alpha": {ID: "alpha", Weight: 1, Workdir: "/repo/alpha"},
+			},
+		},
+		{
+			name:    "added",
+			initial: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+			next: []globalconfig.Project{
+				{ID: "alpha", Weight: 1},
+				{ID: "bravo", Weight: 2, Priority: 3, Workdir: "/repo/bravo"},
+			},
+			want: project.ReconcileResult{
+				Added:     []project.ProjectID{"bravo"},
+				Unchanged: []project.ProjectID{"alpha"},
+			},
+			wantEvents: []project.Event{{ProjectID: "bravo", Kind: project.EventStarted}},
+			wantConfigs: map[project.ProjectID]globalconfig.Project{
+				"alpha": {ID: "alpha", Weight: 1},
+				"bravo": {ID: "bravo", Weight: 2, Priority: 3, Workdir: "/repo/bravo"},
+			},
+		},
+		{
+			name: "removed",
+			initial: []globalconfig.Project{
+				{ID: "alpha", Weight: 1},
+				{ID: "bravo", Weight: 1},
+			},
+			next: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+			want: project.ReconcileResult{
+				Removed:   []project.ProjectID{"bravo"},
+				Unchanged: []project.ProjectID{"alpha"},
+			},
+			wantEvents: []project.Event{{ProjectID: "bravo", Kind: project.EventStopped}},
+			wantConfigs: map[project.ProjectID]globalconfig.Project{
+				"alpha": {ID: "alpha", Weight: 1},
+			},
+		},
+		{
+			name:    "changed",
+			initial: []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/old"}},
+			next:    []globalconfig.Project{{ID: "alpha", Weight: 2, Priority: 1, Workdir: "/repo/new"}},
+			want: project.ReconcileResult{
+				Changed: []project.ProjectID{"alpha"},
+			},
+			wantEvents: []project.Event{
+				{ProjectID: "alpha", Kind: project.EventStopped},
+				{ProjectID: "alpha", Kind: project.EventStarted},
+			},
+			wantConfigs: map[project.ProjectID]globalconfig.Project{
+				"alpha": {ID: "alpha", Weight: 2, Priority: 1, Workdir: "/repo/new"},
+			},
+		},
+		{
+			name:    "invalid config retention",
+			initial: []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/alpha"}},
+			next:    []globalconfig.Project{{ID: "  ", Weight: 1, Workdir: "/repo/invalid"}},
+			wantConfigs: map[project.ProjectID]globalconfig.Project{
+				"alpha": {ID: "alpha", Weight: 1, Workdir: "/repo/alpha"},
+			},
+			wantErr: project.ErrMissingProjectID,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			events := hub.New[project.Event](hub.WithBuffer(16))
+			sub, err := events.Subscribe(context.Background())
+			if err != nil {
+				t.Fatalf("Subscribe() error = %v", err)
+			}
+
+			manager, err := project.NewManager(project.ManagerConfig{
+				Projects: tt.initial,
+			}, project.ManagerDependencies{
+				Events: events,
+				ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+					return newManagerTestProject(t, cfg, events)
+				},
+				Sleep: func(context.Context, time.Duration) error {
+					return nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewManager() error = %v", err)
+			}
+			if err := manager.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			drainProjectEvents(t, sub.C(), startedProjectCount(tt.initial))
+
+			got, err := manager.Reconcile(context.Background(), project.ManagerConfig{Projects: tt.next})
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("Reconcile() error = %v, want %v", err, tt.wantErr)
+			}
+			if err == nil && !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("Reconcile() = %#v, want %#v", got, tt.want)
+			}
+			assertProjectEvents(t, sub.C(), tt.wantEvents)
+			assertNoProjectEvent(t, sub.C())
+			assertManagerProjectConfigs(t, manager, tt.wantConfigs)
+		})
+	}
+}
+
+func TestManagerReconcileKeepsRegistryWhenNewProjectCannotBeCreated(t *testing.T) {
+	t.Parallel()
+
+	factoryErr := errors.New("invalid workflow")
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "bravo" {
+				return nil, factoryErr
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+
+	_, err = manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	})
+	if !errors.Is(err, factoryErr) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, factoryErr)
+	}
+	assertNoProjectEvent(t, sub.C())
+	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+		"alpha": {ID: "alpha", Weight: 1},
+	})
+}
+
 func TestManagerSharedGlobalSchedulerGate(t *testing.T) {
 	t.Parallel()
 
@@ -288,6 +460,62 @@ func newManagerTestProject(t *testing.T, cfg globalconfig.Project, events *hub.H
 		Events: events,
 		Runner: blockingRunner{},
 	})
+}
+
+func startedProjectCount(configs []globalconfig.Project) int {
+	count := 0
+	for _, cfg := range configs {
+		if !cfg.Paused {
+			count++
+		}
+	}
+	return count
+}
+
+func drainProjectEvents(t *testing.T, ch <-chan project.Event, count int) {
+	t.Helper()
+
+	for range count {
+		receiveEvent(t, ch)
+	}
+}
+
+func assertProjectEvents(t *testing.T, ch <-chan project.Event, want []project.Event) {
+	t.Helper()
+
+	for _, expected := range want {
+		got := receiveEvent(t, ch)
+		if got.ProjectID != expected.ProjectID || got.Kind != expected.Kind {
+			t.Fatalf("event = %#v, want project_id=%q kind=%q", got, expected.ProjectID, expected.Kind)
+		}
+	}
+}
+
+func assertNoProjectEvent(t *testing.T, ch <-chan project.Event) {
+	t.Helper()
+
+	select {
+	case event := <-ch:
+		t.Fatalf("unexpected project event = %#v", event)
+	case <-time.After(50 * time.Millisecond):
+	}
+}
+
+func assertManagerProjectConfigs(t *testing.T, manager *project.Manager, want map[project.ProjectID]globalconfig.Project) {
+	t.Helper()
+
+	for id, expected := range want {
+		got, ok := manager.Registry().Get(id)
+		if !ok {
+			t.Fatalf("Registry().Get(%q) ok = false, want true", id)
+		}
+		if cfg := got.Config(); !reflect.DeepEqual(cfg, expected) {
+			t.Fatalf("project %q config = %#v, want %#v", id, cfg, expected)
+		}
+	}
+	if got := manager.Registry().Len(); got != len(want) {
+		t.Fatalf("Registry().Len() = %d, want %d", got, len(want))
+	}
 }
 
 func assertStartedProjects(t *testing.T, ch <-chan project.Event, want []project.ProjectID) {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -324,6 +324,127 @@ func TestManagerReconcileKeepsRegistryWhenNewProjectCannotBeCreated(t *testing.T
 	})
 }
 
+func TestManagerReconcileKeepsChangedProjectWhenReplacementCannotBeCreated(t *testing.T) {
+	t.Parallel()
+
+	factoryErr := errors.New("invalid workflow")
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "alpha" && cfg.Weight == 2 {
+				return nil, factoryErr
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+
+	_, err = manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 2}},
+	})
+	if !errors.Is(err, factoryErr) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, factoryErr)
+	}
+	assertNoProjectEvent(t, sub.C())
+	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+		"alpha": {ID: "alpha", Weight: 1},
+	})
+
+	got, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Registry().Get(alpha) ok = false, want true")
+	}
+	if !got.Running() {
+		t.Fatal("alpha Running() = false, want true")
+	}
+}
+
+func TestManagerReconcileStopsChangedProjectBeforeStartingReplacement(t *testing.T) {
+	t.Parallel()
+
+	oldStillRunningErr := errors.New("old project still running")
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	var manager *project.Manager
+	manager, err = project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "alpha" && cfg.Weight == 2 {
+				return project.New(project.Config{
+					Project:  cfg,
+					Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+				}, project.Dependencies{
+					Connector: provisioningConnector{provision: func(context.Context) error {
+						current, ok := manager.Registry().Get("alpha")
+						if !ok {
+							return project.ErrProjectNotFound
+						}
+						if current.Running() {
+							return oldStillRunningErr
+						}
+						return nil
+					}},
+					Events: events,
+					Runner: blockingRunner{},
+				})
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+
+	got, err := manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 2}},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	want := project.ReconcileResult{Changed: []project.ProjectID{"alpha"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Reconcile() = %#v, want %#v", got, want)
+	}
+	assertProjectEvents(t, sub.C(), []project.Event{
+		{ProjectID: "alpha", Kind: project.EventStopped},
+		{ProjectID: "alpha", Kind: project.EventStarted},
+	})
+	assertNoProjectEvent(t, sub.C())
+	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+		"alpha": {ID: "alpha", Weight: 2},
+	})
+}
+
 func TestManagerReconcileKeepsChangedProjectWhenReplacementProvisionFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -417,6 +417,10 @@ func (p *Project) provision(ctx context.Context) error {
 }
 
 func (p *Project) Stop(ctx context.Context) error {
+	return p.stop(ctx, true)
+}
+
+func (p *Project) stop(ctx context.Context, publishEvents bool) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -428,10 +432,32 @@ func (p *Project) Stop(ctx context.Context) error {
 		p.mu.Unlock()
 		return ErrNotRunning
 	}
+	p.lifecycleEvents = publishEvents
 	cancel()
 	p.mu.Unlock()
 
 	return p.waitDone(ctx, done)
+}
+
+func (p *Project) restart(ctx context.Context, opts startOptions) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	if p.cfg.Paused {
+		p.mu.Unlock()
+		return ErrProjectPaused
+	}
+	if p.done != nil {
+		p.mu.Unlock()
+		return ErrAlreadyRunning
+	}
+	p.started = false
+	p.orchestrator = nil
+	p.mu.Unlock()
+
+	return p.start(ctx, opts)
 }
 
 func (p *Project) Wait(ctx context.Context) error {
@@ -624,6 +650,20 @@ func (p *Project) publishStarted() {
 		ProjectID: id,
 		Kind:      EventStarted,
 		At:        time.Now(),
+	})
+}
+
+func (p *Project) publishStopped(err error) {
+	p.mu.Lock()
+	p.lifecycleEvents = true
+	id := p.id
+	p.mu.Unlock()
+
+	p.publish(Event{
+		ProjectID: id,
+		Kind:      EventStopped,
+		At:        time.Now(),
+		Error:     errorString(err),
 	})
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -64,6 +64,11 @@ type WorkflowWatcher interface {
 
 type WorkflowWatcherFactory func(string) (WorkflowWatcher, error)
 
+type startOptions struct {
+	provision     bool
+	publishEvents bool
+}
+
 type Dependencies struct {
 	Connector              connector.Connector
 	ConnectorFactory       ConnectorFactory
@@ -92,11 +97,12 @@ type Project struct {
 	logger           *slog.Logger
 	watcher          WorkflowWatcherFactory
 
-	mu      sync.Mutex
-	cancel  context.CancelFunc
-	done    chan struct{}
-	runErr  error
-	started bool
+	mu              sync.Mutex
+	cancel          context.CancelFunc
+	done            chan struct{}
+	runErr          error
+	started         bool
+	lifecycleEvents bool
 }
 
 func Load(cfg globalconfig.Project, deps Dependencies) (*Project, error) {
@@ -246,10 +252,10 @@ func (p *Project) Paused() bool {
 }
 
 func (p *Project) Start(ctx context.Context) error {
-	return p.start(ctx, true)
+	return p.start(ctx, startOptions{provision: true, publishEvents: true})
 }
 
-func (p *Project) start(ctx context.Context, provision bool) error {
+func (p *Project) start(ctx context.Context, opts startOptions) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -269,7 +275,7 @@ func (p *Project) start(ctx context.Context, provision bool) error {
 	}
 	p.mu.Unlock()
 
-	if provision {
+	if opts.provision {
 		if err := p.provision(ctx); err != nil {
 			return err
 		}
@@ -307,13 +313,12 @@ func (p *Project) start(ctx context.Context, provision bool) error {
 	p.done = done
 	p.runErr = nil
 	p.started = true
+	p.lifecycleEvents = opts.publishEvents
 	p.mu.Unlock()
 
-	p.publish(Event{
-		ProjectID: p.id,
-		Kind:      EventStarted,
-		At:        time.Now(),
-	})
+	if opts.publishEvents {
+		p.publishStarted()
+	}
 
 	go p.run(runCtx, done, orch)
 	return nil
@@ -471,6 +476,7 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	}
 
 	p.mu.Lock()
+	publishEvents := p.lifecycleEvents
 	if p.done == done {
 		p.cancel = nil
 		p.done = nil
@@ -478,12 +484,14 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	}
 	p.mu.Unlock()
 
-	p.publish(Event{
-		ProjectID: p.id,
-		Kind:      EventStopped,
-		At:        time.Now(),
-		Error:     errorString(err),
-	})
+	if publishEvents {
+		p.publish(Event{
+			ProjectID: p.id,
+			Kind:      EventStopped,
+			At:        time.Now(),
+			Error:     errorString(err),
+		})
+	}
 
 	close(done)
 }
@@ -604,6 +612,19 @@ func (p *Project) publish(event Event) {
 			"error", err,
 		)
 	}
+}
+
+func (p *Project) publishStarted() {
+	p.mu.Lock()
+	p.lifecycleEvents = true
+	id := p.id
+	p.mu.Unlock()
+
+	p.publish(Event{
+		ProjectID: id,
+		Kind:      EventStarted,
+		At:        time.Now(),
+	})
 }
 
 type workflowUpdater interface {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -246,6 +246,10 @@ func (p *Project) Paused() bool {
 }
 
 func (p *Project) Start(ctx context.Context) error {
+	return p.start(ctx, true)
+}
+
+func (p *Project) start(ctx context.Context, provision bool) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -265,8 +269,10 @@ func (p *Project) Start(ctx context.Context) error {
 	}
 	p.mu.Unlock()
 
-	if err := p.provision(ctx); err != nil {
-		return err
+	if provision {
+		if err := p.provision(ctx); err != nil {
+			return err
+		}
 	}
 
 	p.mu.Lock()


### PR DESCRIPTION
## Summary

- watch the active global.yaml and reconcile running projects on valid edits
- add manager diff/reconcile support for added, removed, changed, and unchanged projects
- keep the last good config live when reload or reconcile fails

Fixes #211

## Test Plan

- [x] `make check`