### PR TITLE
fix(orchestrator): refresh running issue state

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -236,6 +236,7 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 
 func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	o.markRefresh(state, now)
+	o.reconcileRunningIssues(ctx, state)
 
 	issues, err := o.connector.FetchCandidateIssues(ctx)
 	if err != nil {
@@ -263,6 +264,56 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		o.trackBlockedStatusIssues(state, blockedIssues, now)
 	}
 	o.dispatchReadyIssues(ctx, state, issues, now)
+}
+
+func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State) {
+	ids := runningIssueIDs(state.Running)
+	if len(ids) == 0 {
+		return
+	}
+
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, ids)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("fetch running issue states failed", "error", err)
+		}
+		return
+	}
+
+	byID := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.ID) == "" {
+			continue
+		}
+		byID[issue.ID] = issue
+	}
+
+	for _, id := range ids {
+		issue, ok := byID[id]
+		if !ok {
+			continue
+		}
+
+		running := state.Running[id]
+		running.Issue = cloneIssue(issue)
+		state.Running[id] = running
+
+		if claimed, ok := state.Claimed[id]; ok {
+			claimed.Issue = cloneIssue(issue)
+			state.Claimed[id] = claimed
+		}
+	}
+}
+
+func runningIssueIDs(running map[string]Running) []string {
+	ids := sortedKeys(running)
+	out := ids[:0]
+	for _, id := range ids {
+		if strings.TrimSpace(id) != "" {
+			out = append(out, id)
+		}
+	}
+	return out
 }
 
 func (o *Orchestrator) markRefresh(state *State, now time.Time) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -295,14 +295,73 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State)
 		}
 
 		running := state.Running[id]
-		running.Issue = cloneIssue(issue)
+		running.Issue = mergeIssueTrackerFields(running.Issue, issue)
 		state.Running[id] = running
 
 		if claimed, ok := state.Claimed[id]; ok {
-			claimed.Issue = cloneIssue(issue)
+			claimed.Issue = mergeIssueTrackerFields(claimed.Issue, issue)
 			state.Claimed[id] = claimed
 		}
 	}
+}
+
+func mergeIssueTrackerFields(current, refreshed connector.Issue) connector.Issue {
+	merged := cloneIssue(current)
+	refreshed = cloneIssue(refreshed)
+
+	if strings.TrimSpace(refreshed.ID) != "" {
+		merged.ID = refreshed.ID
+	}
+	if refreshed.Identifier != "" {
+		merged.Identifier = refreshed.Identifier
+	}
+	if refreshed.Title != "" {
+		merged.Title = refreshed.Title
+	}
+	if refreshed.Description != "" {
+		merged.Description = refreshed.Description
+	}
+	if refreshed.Priority != nil {
+		merged.Priority = refreshed.Priority
+	}
+	if refreshed.State != "" {
+		merged.State = refreshed.State
+	}
+	if refreshed.BranchName != "" {
+		merged.BranchName = refreshed.BranchName
+	}
+	if refreshed.URL != "" {
+		merged.URL = refreshed.URL
+	}
+	if refreshed.PRNumber != nil {
+		merged.PRNumber = refreshed.PRNumber
+	}
+	if refreshed.PullRequest != nil {
+		merged.PullRequest = refreshed.PullRequest
+	}
+	if refreshed.AssigneeID != "" {
+		merged.AssigneeID = refreshed.AssigneeID
+	}
+	if refreshed.BlockedBy != nil {
+		merged.BlockedBy = refreshed.BlockedBy
+	}
+	if refreshed.BlockerReason != "" {
+		merged.BlockerReason = refreshed.BlockerReason
+	}
+	if refreshed.Labels != nil {
+		merged.Labels = refreshed.Labels
+	}
+	if refreshed.CreatedAt != nil {
+		merged.CreatedAt = refreshed.CreatedAt
+	}
+	if refreshed.UpdatedAt != nil {
+		merged.UpdatedAt = refreshed.UpdatedAt
+	}
+	if refreshed.ModelOverride != "" {
+		merged.ModelOverride = refreshed.ModelOverride
+	}
+
+	return merged
 }
 
 func runningIssueIDs(running map[string]Running) []string {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -1,0 +1,146 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"slices"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	prior := connector.Issue{
+		ID:         "issue-running",
+		Identifier: "digitaldrywood/detent#225",
+		Title:      "Dispatch title",
+		State:      "Todo",
+		URL:        "https://github.com/digitaldrywood/detent/issues/225",
+		Labels:     []string{"bug"},
+	}
+
+	tests := []struct {
+		name       string
+		tracker    []connector.Issue
+		err        error
+		wantState  string
+		wantTitle  string
+		wantURL    string
+		wantLabels []string
+	}{
+		{
+			name: "updates running issue from tracker",
+			tracker: []connector.Issue{
+				{
+					ID:         prior.ID,
+					Identifier: prior.Identifier,
+					Title:      "Live title",
+					State:      "In Progress",
+					URL:        "https://github.com/digitaldrywood/detent/issues/225#live",
+					Labels:     []string{"bug", "live"},
+				},
+			},
+			wantState:  "In Progress",
+			wantTitle:  "Live title",
+			wantURL:    "https://github.com/digitaldrywood/detent/issues/225#live",
+			wantLabels: []string{"bug", "live"},
+		},
+		{
+			name:       "retains previous running issue on fetch error",
+			err:        errors.New("tracker unavailable"),
+			wantState:  "Todo",
+			wantTitle:  "Dispatch title",
+			wantURL:    "https://github.com/digitaldrywood/detent/issues/225",
+			wantLabels: []string{"bug"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				PollInterval:        time.Minute,
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo", "In Progress", "Human Review", "Rework", "Merging"},
+				TerminalStates:      []string{"Done", "Cancelled"},
+			})
+			state := newState(cfg)
+			state.Running[prior.ID] = Running{Issue: cloneIssue(prior)}
+			state.Claimed[prior.ID] = Claimed{Issue: cloneIssue(prior)}
+
+			tracker := &runningStateConnector{
+				issues: tt.tracker,
+				err:    tt.err,
+			}
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tracker,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			orch.tick(context.Background(), &state, now)
+
+			snapshot := state.Snapshot(now)
+			if len(snapshot.Running) != 1 {
+				t.Fatalf("Running len = %d, want 1", len(snapshot.Running))
+			}
+			got := snapshot.Running[0].Issue
+			if got.State != tt.wantState {
+				t.Fatalf("running snapshot state = %q, want %q", got.State, tt.wantState)
+			}
+			if got.Title != tt.wantTitle {
+				t.Fatalf("running snapshot title = %q, want %q", got.Title, tt.wantTitle)
+			}
+			if got.URL != tt.wantURL {
+				t.Fatalf("running snapshot URL = %q, want %q", got.URL, tt.wantURL)
+			}
+			if !slices.Equal(got.Labels, tt.wantLabels) {
+				t.Fatalf("running snapshot labels = %#v, want %#v", got.Labels, tt.wantLabels)
+			}
+			if !slices.Equal(tracker.requestedIDs, []string{prior.ID}) {
+				t.Fatalf("FetchIssueStatesByIDs() ids = %#v, want [%s]", tracker.requestedIDs, prior.ID)
+			}
+		})
+	}
+}
+
+type runningStateConnector struct {
+	issues       []connector.Issue
+	err          error
+	requestedIDs []string
+}
+
+func (c *runningStateConnector) Name() string {
+	return "running-state"
+}
+
+func (c *runningStateConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return []connector.Issue{}, nil
+}
+
+func (c *runningStateConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return []connector.Issue{}, nil
+}
+
+func (c *runningStateConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
+	c.requestedIDs = append([]string(nil), ids...)
+	if c.err != nil {
+		return nil, c.err
+	}
+	return cloneIssues(c.issues), nil
+}
+
+func (c *runningStateConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *runningStateConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -16,6 +16,7 @@ func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	prNumber := 226
 	prior := connector.Issue{
 		ID:         "issue-running",
 		Identifier: "digitaldrywood/detent#225",
@@ -23,6 +24,15 @@ func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
 		State:      "Todo",
 		URL:        "https://github.com/digitaldrywood/detent/issues/225",
 		Labels:     []string{"bug"},
+		PRNumber:   &prNumber,
+		PullRequest: &connector.PullRequest{
+			Number:           prNumber,
+			URL:              "https://github.com/digitaldrywood/detent/pull/226",
+			BranchName:       "detent/digitaldrywood_detent_225",
+			State:            "OPEN",
+			CIStatus:         "success",
+			CodexReviewState: "COMMENTED",
+		},
 	}
 
 	tests := []struct {
@@ -103,6 +113,15 @@ func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
 			}
 			if !slices.Equal(got.Labels, tt.wantLabels) {
 				t.Fatalf("running snapshot labels = %#v, want %#v", got.Labels, tt.wantLabels)
+			}
+			if got.PullRequest == nil {
+				t.Fatal("running snapshot pull request = nil, want preserved metadata")
+			}
+			if got.PullRequest.URL != "https://github.com/digitaldrywood/detent/pull/226" {
+				t.Fatalf("running snapshot pull request URL = %q, want preserved metadata", got.PullRequest.URL)
+			}
+			if got.PullRequest.CIStatus != "success" || got.PullRequest.CodexReviewState != "COMMENTED" {
+				t.Fatalf("running snapshot pull request status = %#v, want preserved metadata", got.PullRequest)
 			}
 			if !slices.Equal(tracker.requestedIDs, []string{prior.ID}) {
 				t.Fatalf("FetchIssueStatesByIDs() ids = %#v, want [%s]", tracker.requestedIDs, prior.ID)


### PR DESCRIPTION
## Summary

- reconcile running issue snapshots with current tracker data on each orchestrator tick
- retain the last-known running issue state when tracker state refresh fails
- merge refreshed tracker fields so existing running PR metadata is preserved
- add table-driven coverage for live state refresh, fetch-error retention, and PR metadata preservation

Fixes #225

## Test Plan

- [x] `go test ./internal/orchestrator -run TestTickReconcilesRunningIssueTrackerState -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`
- [x] `gh pr checks 226 --watch`