### PR TITLE
chore(store): emit IssueURL from sqlc

### DIFF
--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -13,7 +13,7 @@ type CodexSession struct {
 	RunID          sql.NullInt64  `json:"run_id"`
 	IssueID        sql.NullString `json:"issue_id"`
 	Identifier     sql.NullString `json:"identifier"`
-	IssueUrl       sql.NullString `json:"issue_url"`
+	IssueURL       sql.NullString `json:"issue_url"`
 	StartedAt      sql.NullString `json:"started_at"`
 	CompletedAt    sql.NullString `json:"completed_at"`
 	Turns          int64          `json:"turns"`

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -144,7 +144,7 @@ type CreateCodexSessionParams struct {
 	RunID          sql.NullInt64  `json:"run_id"`
 	IssueID        sql.NullString `json:"issue_id"`
 	Identifier     sql.NullString `json:"identifier"`
-	IssueUrl       sql.NullString `json:"issue_url"`
+	IssueURL       sql.NullString `json:"issue_url"`
 	StartedAt      sql.NullString `json:"started_at"`
 	CompletedAt    sql.NullString `json:"completed_at"`
 	Turns          int64          `json:"turns"`
@@ -161,7 +161,7 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		arg.RunID,
 		arg.IssueID,
 		arg.Identifier,
-		arg.IssueUrl,
+		arg.IssueURL,
 		arg.StartedAt,
 		arg.CompletedAt,
 		arg.Turns,
@@ -178,7 +178,7 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.RunID,
 		&i.IssueID,
 		&i.Identifier,
-		&i.IssueUrl,
+		&i.IssueURL,
 		&i.StartedAt,
 		&i.CompletedAt,
 		&i.Turns,
@@ -437,7 +437,7 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.RunID,
 		&i.IssueID,
 		&i.Identifier,
-		&i.IssueUrl,
+		&i.IssueURL,
 		&i.StartedAt,
 		&i.CompletedAt,
 		&i.Turns,
@@ -524,7 +524,7 @@ ORDER BY COALESCE(model, '')
 type IssueTokenSpendParams struct {
 	IssueID    sql.NullString `json:"issue_id"`
 	Identifier sql.NullString `json:"identifier"`
-	IssueUrl   sql.NullString `json:"issue_url"`
+	IssueURL   sql.NullString `json:"issue_url"`
 }
 
 type IssueTokenSpendRow struct {
@@ -536,7 +536,7 @@ type IssueTokenSpendRow struct {
 }
 
 func (q *Queries) IssueTokenSpend(ctx context.Context, arg IssueTokenSpendParams) ([]IssueTokenSpendRow, error) {
-	rows, err := q.db.QueryContext(ctx, issueTokenSpend, arg.IssueID, arg.Identifier, arg.IssueUrl)
+	rows, err := q.db.QueryContext(ctx, issueTokenSpend, arg.IssueID, arg.Identifier, arg.IssueURL)
 	if err != nil {
 		return nil, err
 	}
@@ -660,7 +660,7 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.RunID,
 			&i.IssueID,
 			&i.Identifier,
-			&i.IssueUrl,
+			&i.IssueURL,
 			&i.StartedAt,
 			&i.CompletedAt,
 			&i.Turns,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -131,7 +131,7 @@ func (s *sqliteStore) StartSession(ctx context.Context, attrs SessionStart) (int
 		RunID:       nullInt64(attrs.RunID),
 		IssueID:     nullString(attrs.IssueID),
 		Identifier:  nullString(attrs.Identifier),
-		IssueUrl:    nullString(attrs.IssueURL),
+		IssueURL:    nullString(attrs.IssueURL),
 		StartedAt:   sql.NullString{String: startedAt, Valid: true},
 		CompletedAt: sql.NullString{},
 		FinalState:  sql.NullString{},
@@ -403,7 +403,7 @@ func (s *sqliteStore) IssueTokenSpend(ctx context.Context, identity IssueIdentit
 	rows, err := s.queries.IssueTokenSpend(ctx, sqlc.IssueTokenSpendParams{
 		IssueID:    nullString(identity.IssueID),
 		Identifier: nullString(identity.Identifier),
-		IssueUrl:   nullString(identity.IssueURL),
+		IssueURL:   nullString(identity.IssueURL),
 	})
 	if err != nil {
 		return TokenSpend{}, fmt.Errorf("reading issue token spend: %w", err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -84,7 +84,7 @@ func TestSQLiteQueriesRoundTrip(t *testing.T) {
 		RunID:          sql.NullInt64{Int64: run.ID, Valid: true},
 		IssueID:        sql.NullString{String: "I_kwDOSskuwc8AAAABD42cNw", Valid: true},
 		Identifier:     sql.NullString{String: "digitaldrywood/detent#5", Valid: true},
-		IssueUrl:       sql.NullString{String: "https://github.com/digitaldrywood/detent/issues/5", Valid: true},
+		IssueURL:       sql.NullString{String: "https://github.com/digitaldrywood/detent/issues/5", Valid: true},
 		StartedAt:      sql.NullString{String: "2026-05-30T12:01:00Z", Valid: true},
 		CompletedAt:    sql.NullString{String: "2026-05-30T12:02:00Z", Valid: true},
 		Turns:          2,

--- a/sqlc/sqlc.yaml
+++ b/sqlc/sqlc.yaml
@@ -10,3 +10,5 @@ sql:
         sql_package: "database/sql"
         emit_json_tags: true
         emit_empty_slices: true
+        rename:
+          issue_url: "IssueURL"


### PR DESCRIPTION
## Summary

- Add a sqlc rename for `issue_url` so generated Go fields use `IssueURL`.
- Update store call sites and tests to use the regenerated field name.

Fixes #232

## Test Plan

- [x] `go test ./internal/store`
- [x] `make check`