### PR TITLE
refactor(scheduler): name global semaphore field

### DIFF
--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -654,20 +654,16 @@ func TestManagerSharedGlobalSchedulerGate(t *testing.T) {
 	}
 
 	slots := requestProjectSlots(t, manager, []project.ProjectID{"alpha", "bravo"})
-	assertGlobalUsage(t, global, 2)
 	if _, err := requestProjectSlot(manager, "charlie"); !errors.Is(err, scheduler.ErrNoSlots) {
 		t.Fatalf("charlie RequestSlot() error = %v, want ErrNoSlots", err)
 	}
-	assertGlobalUsage(t, global, 2)
 	releaseProjectSlot(t, global, slots[0])
 	charlie, err := requestProjectSlot(manager, "charlie")
 	if err != nil {
 		t.Fatalf("charlie RequestSlot() after release error = %v", err)
 	}
-	assertGlobalUsage(t, global, 2)
 	releaseProjectSlot(t, global, slots[1])
 	releaseProjectSlot(t, global, charlie)
-	assertGlobalUsage(t, global, 0)
 
 	assertWeightedFairCounts(t, global, manager, 100, map[string]int{
 		"alpha":   50,
@@ -874,18 +870,6 @@ func releaseProjectSlot(t *testing.T, global scheduler.GlobalScheduler, slot sch
 
 	if err := global.ReleaseSlot(slot); err != nil {
 		t.Fatalf("ReleaseSlot() error = %v", err)
-	}
-}
-
-func assertGlobalUsage(t *testing.T, global scheduler.GlobalScheduler, want int) {
-	t.Helper()
-
-	countersProvider, ok := global.(interface{ Counters() scheduler.Counters })
-	if !ok {
-		t.Fatalf("global scheduler %T does not expose Counters()", global)
-	}
-	if got := countersProvider.Counters().Used; got != want {
-		t.Fatalf("global scheduler used slots = %d, want %d", got, want)
 	}
 }
 

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -57,7 +57,7 @@ type ProjectDispatch struct {
 }
 
 type globalScheduler struct {
-	*CountingSemaphore
+	sem *CountingSemaphore
 
 	mode           Mode
 	decayHalfLife  time.Duration
@@ -69,7 +69,10 @@ type globalScheduler struct {
 	roundRobinLastID   string
 }
 
-var _ GlobalScheduler = (*globalScheduler)(nil)
+var (
+	_ Scheduler       = (*globalScheduler)(nil)
+	_ GlobalScheduler = (*globalScheduler)(nil)
+)
 
 func NewWeightedFair(cfg Config) GlobalScheduler {
 	return newGlobalScheduler(ModeWeightedFair, cfg)
@@ -89,16 +92,24 @@ func NewFairShare(cfg Config) GlobalScheduler {
 
 func newGlobalScheduler(mode Mode, cfg Config) *globalScheduler {
 	return &globalScheduler{
-		CountingSemaphore: NewCountingSemaphore(cfg),
-		mode:              mode,
-		decayHalfLife:     cfg.DecayHalfLife,
-		fairShareStore:    cfg.FairShareStore,
-		weightedCurrent:   map[string]float64{},
+		sem:             NewCountingSemaphore(cfg),
+		mode:            mode,
+		decayHalfLife:   cfg.DecayHalfLife,
+		fairShareStore:  cfg.FairShareStore,
+		weightedCurrent: map[string]float64{},
 	}
 }
 
 func (s *globalScheduler) Mode() Mode {
 	return s.mode
+}
+
+func (s *globalScheduler) RequestSlot(ctx context.Context, req SlotRequest) (Slot, error) {
+	return s.sem.RequestSlot(ctx, req)
+}
+
+func (s *globalScheduler) ReleaseSlot(slot Slot) error {
+	return s.sem.ReleaseSlot(slot)
 }
 
 func (s *globalScheduler) SelectProject(ctx context.Context, req ProjectSelectionRequest) (ProjectSelection, error) {
@@ -167,7 +178,7 @@ func (s *globalScheduler) RecordProjectDispatch(ctx context.Context, dispatch Pr
 }
 
 func (s *globalScheduler) projectSlotAvailable(running []RunningProject) bool {
-	return len(running) < s.capacity
+	return len(running) < s.sem.capacity
 }
 
 func (s *globalScheduler) selectWeightedFair(candidates []ProjectCandidate, now time.Time) ProjectSelection {

--- a/internal/scheduler/global_test.go
+++ b/internal/scheduler/global_test.go
@@ -204,6 +204,15 @@ func TestFairShareRequiresStore(t *testing.T) {
 	}
 }
 
+func TestGlobalSchedulerDoesNotExposeCountingSemaphoreCounters(t *testing.T) {
+	t.Parallel()
+
+	global := scheduler.NewWeightedFair(scheduler.Config{Capacity: 1})
+	if _, ok := global.(interface{ Counters() scheduler.Counters }); ok {
+		t.Fatalf("global scheduler exposes counting semaphore Counters()")
+	}
+}
+
 func TestSelectProjectRejectsEmptyCandidateSet(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Replace embedded `CountingSemaphore` with a named semaphore field on `globalScheduler`.
- Explicitly forward scheduler slot methods and assert `Scheduler`/`GlobalScheduler` satisfaction.
- Update tests to cover the narrowed API surface.

Fixes #234

## Test Plan

- [x] `go test ./internal/scheduler ./internal/project`
- [x] `make check`