### PR TITLE
fix(errors): preserve joined error chains

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -649,12 +649,16 @@ func openDoctorSQLite(ctx context.Context, path string) (doctorStore, error) {
 	db.SetMaxOpenConns(1)
 
 	if err := db.PingContext(ctx); err != nil {
-		if closeErr := db.Close(); closeErr != nil {
-			return nil, fmt.Errorf("ping sqlite database: %w; close sqlite database: %v", err, closeErr)
-		}
-		return nil, fmt.Errorf("ping sqlite database: %w", err)
+		return nil, doctorSQLitePingError(err, db.Close())
 	}
 	return db, nil
+}
+
+func doctorSQLitePingError(err, closeErr error) error {
+	if closeErr != nil {
+		return fmt.Errorf("ping sqlite database: %w; close sqlite database: %w", err, closeErr)
+	}
+	return fmt.Errorf("ping sqlite database: %w", err)
 }
 
 func runDoctorCommand(ctx context.Context, path string, args ...string) error {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -382,6 +382,21 @@ func TestCheckDoctorSQLite(t *testing.T) {
 	}
 }
 
+func TestDoctorSQLitePingErrorWrapsPingAndCloseErrors(t *testing.T) {
+	t.Parallel()
+
+	pingErr := errors.New("ping failed")
+	closeErr := errors.New("close failed")
+
+	err := doctorSQLitePingError(pingErr, closeErr)
+	if !errors.Is(err, pingErr) {
+		t.Fatalf("doctorSQLitePingError() error = %v, want ping error in chain", err)
+	}
+	if !errors.Is(err, closeErr) {
+		t.Fatalf("doctorSQLitePingError() error = %v, want close error in chain", err)
+	}
+}
+
 func TestCheckDoctorServerPort(t *testing.T) {
 	t.Parallel()
 

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -122,7 +122,7 @@ func (t *localTransport) Send(ctx context.Context, msg Message) error {
 		closeErr := t.closeStdin()
 		<-writeDone
 		if closeErr != nil {
-			return fmt.Errorf("%w: close stdin: %v", ctx.Err(), closeErr)
+			return transportContextError(ctx.Err(), "close stdin", closeErr)
 		}
 		return ctx.Err()
 	}
@@ -165,7 +165,7 @@ func (t *localTransport) Close(ctx context.Context) error {
 		}
 
 		if killErr != nil {
-			return fmt.Errorf("%w: kill process: %v", ctx.Err(), killErr)
+			return transportContextError(ctx.Err(), "kill process", killErr)
 		}
 		return ctx.Err()
 	}
@@ -176,6 +176,10 @@ func (t *localTransport) ProcessIdentity() string {
 		return ""
 	}
 	return strconv.Itoa(t.cmd.Process.Pid)
+}
+
+func transportContextError(ctxErr error, operation string, err error) error {
+	return fmt.Errorf("%w: %s: %w", ctxErr, operation, err)
 }
 
 func (t *localTransport) acquireSend(ctx context.Context) error {

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 )
@@ -131,6 +132,46 @@ func TestLocalTransportSendHonorsContextDuringBlockedWrite(t *testing.T) {
 	}
 }
 
+func TestLocalTransportSendWrapsCloseErrorAfterContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	closeErr := errors.New("close stdin failed")
+	stdin := newBlockingWriteCloser(closeErr)
+	transport := &localTransport{
+		stdin:    stdin,
+		codec:    NewCodec(nil, stdin),
+		sendLock: make(chan struct{}, 1),
+		done:     make(chan struct{}),
+	}
+	transport.sendLock <- struct{}{}
+
+	sendCtx, cancel := context.WithCancel(context.Background())
+	errCh := make(chan error, 1)
+	go func() {
+		errCh <- transport.Send(sendCtx, Message{Method: "blocked"})
+	}()
+
+	select {
+	case <-stdin.writeStarted:
+	case <-time.After(time.Second):
+		t.Fatal("Send() did not start writing")
+	}
+
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("Send() error = %v, want context canceled", err)
+		}
+		if !errors.Is(err, closeErr) {
+			t.Fatalf("Send() error = %v, want close error in chain", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("Send() did not return after context cancellation")
+	}
+}
+
 func TestLocalTransportCloseKillsUnresponsiveProcess(t *testing.T) {
 	t.Parallel()
 
@@ -152,6 +193,45 @@ func TestLocalTransportCloseKillsUnresponsiveProcess(t *testing.T) {
 	err = transport.Close(closeCtx)
 	if !errors.Is(err, context.DeadlineExceeded) {
 		t.Fatalf("Close() error = %v, want context deadline exceeded", err)
+	}
+}
+
+func TestLocalTransportCloseWrapsKillErrorAfterContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	cmd := helperCommand(context.Background(), "exit")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v", err)
+	}
+	killErr := cmd.Process.Kill()
+	if killErr == nil {
+		t.Fatal("Kill() error = nil, want post-exit process error")
+	}
+
+	done := make(chan struct{})
+	go func() {
+		time.Sleep(10 * time.Millisecond)
+		close(done)
+	}()
+
+	closeCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	transport := &localTransport{
+		cmd:   cmd,
+		stdin: noopWriteCloser{},
+		done:  done,
+	}
+
+	err := transport.Close(closeCtx)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Close() error = %v, want context canceled", err)
+	}
+	if !errors.Is(err, killErr) {
+		t.Fatalf("Close() error = %v, want kill error %v in chain", err, killErr)
 	}
 }
 
@@ -205,6 +285,8 @@ func TestLocalTransportHelperProcess(t *testing.T) {
 		time.Sleep(time.Hour)
 	case "ignore-close":
 		time.Sleep(time.Hour)
+	case "exit":
+		return
 	default:
 		os.Exit(2)
 	}
@@ -253,4 +335,45 @@ func helperRoundTrip() {
 	if err := encoder.Encode(response); err != nil {
 		os.Exit(6)
 	}
+}
+
+type blockingWriteCloser struct {
+	closeErr     error
+	writeStarted chan struct{}
+	closed       chan struct{}
+	startOnce    sync.Once
+	closeOnce    sync.Once
+}
+
+func newBlockingWriteCloser(closeErr error) *blockingWriteCloser {
+	return &blockingWriteCloser{
+		closeErr:     closeErr,
+		writeStarted: make(chan struct{}),
+		closed:       make(chan struct{}),
+	}
+}
+
+func (w *blockingWriteCloser) Write([]byte) (int, error) {
+	w.startOnce.Do(func() {
+		close(w.writeStarted)
+	})
+	<-w.closed
+	return 0, io.ErrClosedPipe
+}
+
+func (w *blockingWriteCloser) Close() error {
+	w.closeOnce.Do(func() {
+		close(w.closed)
+	})
+	return w.closeErr
+}
+
+type noopWriteCloser struct{}
+
+func (noopWriteCloser) Write(p []byte) (int, error) {
+	return len(p), nil
+}
+
+func (noopWriteCloser) Close() error {
+	return nil
 }


### PR DESCRIPTION
## Summary

- Wrap secondary close/kill errors with `%w` so joined error chains remain inspectable.
- Add focused regression coverage for transport and SQLite doctor cleanup error chains.

Fixes #231

## Test Plan

- [x] `go test ./internal/codex`
- [x] `go test ./internal/cli`
- [x] `make check`