### PR TITLE
chore(interfaces): add backend assertions

### DIFF
--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -67,6 +67,8 @@ type unimplementedConnector struct {
 	name string
 }
 
+var _ connector.Connector = unimplementedConnector{}
+
 func (c unimplementedConnector) Name() string {
 	return c.name
 }

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -125,3 +125,4 @@ func (c *Connector) Authenticate(ctx context.Context) error {
 
 var _ connector.Connector = (*Connector)(nil)
 var _ connector.Authenticator = (*Connector)(nil)
+var _ connector.Provisioner = (*Connector)(nil)

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -20,6 +20,8 @@ type sqliteStore struct {
 	queries *sqlc.Queries
 }
 
+var _ Store = (*sqliteStore)(nil)
+
 func openSQLite(ctx context.Context, cfg Config) (*sqliteStore, error) {
 	if cfg.Path == "" {
 		return nil, errors.New("sqlite path is required")


### PR DESCRIPTION
## Summary

- Add compile-time interface assertions for the factory fallback connector and SQLite store backend.
- Add the GitHub connector provisioner assertion and confirm existing memory connector and scheduler assertions are already present.

Fixes #233

## Test Plan

- [x] `go test ./internal/connector/factory ./internal/connector/github ./internal/store`
- [x] `make check`