### PR TITLE
fix(config): return global build errors

### DIFF
--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -15,6 +15,10 @@ func TestGlobalConfigReloaderApply(t *testing.T) {
 	t.Parallel()
 
 	reloadErr := errors.New("invalid global config")
+	buildErr := globalconfig.ValidationError{
+		Path:     "global.yaml",
+		Problems: []string{"projects[0].workflow: expand path: home directory is not available"},
+	}
 	reconcileErr := errors.New("reconcile failed")
 	current := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
 	next := reloadTestConfig("global.yaml", 4, []globalconfig.Project{
@@ -29,6 +33,7 @@ func TestGlobalConfigReloaderApply(t *testing.T) {
 		wantCurrent globalconfig.Config
 		wantCalls   int
 		wantErr     error
+		wantErrText string
 	}{
 		{
 			name:        "valid update reconciles and retains next config",
@@ -41,6 +46,12 @@ func TestGlobalConfigReloaderApply(t *testing.T) {
 			update:      configwatcher.FileUpdate[globalconfig.Config]{Path: current.Path, Err: reloadErr},
 			wantCurrent: current,
 			wantErr:     reloadErr,
+		},
+		{
+			name:        "build error keeps current config",
+			update:      configwatcher.FileUpdate[globalconfig.Config]{Path: current.Path, Err: buildErr},
+			wantCurrent: current,
+			wantErrText: buildErr.Error(),
 		},
 		{
 			name:        "reconcile error keeps current config",
@@ -63,7 +74,11 @@ func TestGlobalConfigReloaderApply(t *testing.T) {
 			}
 
 			_, err := reloader.apply(context.Background(), tt.update)
-			if !errors.Is(err, tt.wantErr) {
+			if tt.wantErrText != "" {
+				if err == nil || err.Error() != tt.wantErrText {
+					t.Fatalf("apply() error = %v, want %v", err, tt.wantErrText)
+				}
+			} else if !errors.Is(err, tt.wantErr) {
 				t.Fatalf("apply() error = %v, want %v", err, tt.wantErr)
 			}
 			if manager.calls != tt.wantCalls {

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -250,7 +250,10 @@ func Parse(raw []byte, path string, opts ...Option) (Config, error) {
 		return Config{}, ValidationError{Path: path, Problems: problems}
 	}
 
-	cfg := build(root, path, readOptions)
+	cfg, err := build(root, path, readOptions)
+	if err != nil {
+		return Config{}, err
+	}
 	if err := cfg.Validate(opts...); err != nil {
 		return Config{}, err
 	}
@@ -785,125 +788,205 @@ func duplicateProjectIDErrorsFromProjects(projects []Project) []string {
 	return problems
 }
 
-func build(attrs map[string]any, path string, opts options) Config {
-	global := mustMap(attrs["global"])
-	projects := mustList(attrs["projects"])
+func build(attrs map[string]any, path string, opts options) (Config, error) {
+	global, err := mapValue(attrs["global"], "global")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	projects, err := listValue(attrs["projects"], "projects")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	apiVersion, err := stringValue(attrs["apiVersion"], "apiVersion")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	kind, err := stringValue(attrs["kind"], "kind")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	settings, err := buildSettings(global)
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	builtProjects, err := buildProjects(projects, opts)
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
 
 	return Config{
 		Path:       path,
-		APIVersion: mustString(attrs["apiVersion"]),
-		Kind:       mustString(attrs["kind"]),
-		Global:     buildSettings(global),
-		Projects:   buildProjects(projects, opts),
-	}
+		APIVersion: apiVersion,
+		Kind:       kind,
+		Global:     settings,
+		Projects:   builtProjects,
+	}, nil
 }
 
-func buildSettings(attrs map[string]any) Settings {
+func buildSettings(attrs map[string]any) (Settings, error) {
 	settings := defaultSettings()
-	settings.MaxConcurrentAgents = mustInt(attrs["max_concurrent_agents"])
-	settings.Scheduling = mustString(attrs["scheduling"])
-	settings.FairShare = mergeMap(settings.FairShare, attrs["fair_share"])
-	settings.Startup = mergeMap(settings.Startup, attrs["startup"])
-	return settings
+	maxConcurrentAgents, err := intValue(attrs["max_concurrent_agents"], "global.max_concurrent_agents")
+	if err != nil {
+		return Settings{}, err
+	}
+	scheduling, err := stringValue(attrs["scheduling"], "global.scheduling")
+	if err != nil {
+		return Settings{}, err
+	}
+	fairShare, err := mergeMap(settings.FairShare, attrs["fair_share"], "global.fair_share")
+	if err != nil {
+		return Settings{}, err
+	}
+	startup, err := mergeMap(settings.Startup, attrs["startup"], "global.startup")
+	if err != nil {
+		return Settings{}, err
+	}
+
+	settings.MaxConcurrentAgents = maxConcurrentAgents
+	settings.Scheduling = scheduling
+	settings.FairShare = fairShare
+	settings.Startup = startup
+	return settings, nil
 }
 
-func buildProjects(projects []any, opts options) []Project {
+func buildProjects(projects []any, opts options) ([]Project, error) {
 	out := make([]Project, 0, len(projects))
-	for _, item := range projects {
-		project := mustMap(item)
-		workflow := mustString(project["workflow"])
-		workdir := mustString(project["workdir"])
+	for index, item := range projects {
+		prefix := fmt.Sprintf("projects[%d]", index)
+		project, err := mapValue(item, prefix)
+		if err != nil {
+			return nil, err
+		}
+		workflow, err := stringValue(project["workflow"], prefix+".workflow")
+		if err != nil {
+			return nil, err
+		}
+		workdir, err := stringValue(project["workdir"], prefix+".workdir")
+		if err != nil {
+			return nil, err
+		}
 		if !opts.projectPathLiterals {
 			expandedWorkflow, err := expandPath(workflow, opts)
 			if err != nil {
-				panic("validated global config workflow path did not expand")
+				return nil, fmt.Errorf("%s.workflow: expand path: %w", prefix, err)
 			}
 			expandedWorkdir, err := expandPath(workdir, opts)
 			if err != nil {
-				panic("validated global config workdir path did not expand")
+				return nil, fmt.Errorf("%s.workdir: expand path: %w", prefix, err)
 			}
 			workflow = expandedWorkflow
 			workdir = expandedWorkdir
 		}
+		id, err := stringValue(project["id"], prefix+".id")
+		if err != nil {
+			return nil, err
+		}
+		weight, err := intValue(project["weight"], prefix+".weight")
+		if err != nil {
+			return nil, err
+		}
+		priority, err := intValue(project["priority"], prefix+".priority")
+		if err != nil {
+			return nil, err
+		}
+		paused, err := optionalBool(project["paused"], prefix+".paused")
+		if err != nil {
+			return nil, err
+		}
+		credentialRef, err := optionalString(project["credential_ref"], prefix+".credential_ref")
+		if err != nil {
+			return nil, err
+		}
 
 		out = append(out, Project{
-			ID:            strings.TrimSpace(mustString(project["id"])),
+			ID:            strings.TrimSpace(id),
 			Workflow:      workflow,
 			Workdir:       workdir,
-			Weight:        mustInt(project["weight"]),
-			Priority:      mustInt(project["priority"]),
-			Paused:        optionalBool(project["paused"]),
-			CredentialRef: optionalString(project["credential_ref"]),
+			Weight:        weight,
+			Priority:      priority,
+			Paused:        paused,
+			CredentialRef: credentialRef,
 		})
 	}
-	return out
+	return out, nil
 }
 
-func mergeMap(defaults map[string]any, value any) map[string]any {
+func mergeMap(defaults map[string]any, value any, field string) (map[string]any, error) {
 	out := make(map[string]any, len(defaults))
 	for key, nestedValue := range defaults {
 		out[key] = nestedValue
 	}
 
 	if value == nil {
-		return out
+		return out, nil
 	}
 
-	source := mustMap(value)
+	source, err := mapValue(value, field)
+	if err != nil {
+		return nil, err
+	}
 	for key, nestedValue := range source {
 		out[key] = nestedValue
 	}
-	return out
+	return out, nil
 }
 
-func optionalBool(value any) bool {
+func optionalBool(value any, field string) (bool, error) {
 	if value == nil {
-		return false
+		return false, nil
 	}
 	paused, ok := value.(bool)
 	if !ok {
-		panic("validated global config paused value was not a boolean")
+		return false, fmt.Errorf("%s: must be a boolean", field)
 	}
-	return paused
+	return paused, nil
 }
 
-func optionalString(value any) string {
+func optionalString(value any, field string) (string, error) {
 	if value == nil {
-		return ""
+		return "", nil
 	}
-	return strings.TrimSpace(mustString(value))
+	text, err := stringValue(value, field)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(text), nil
 }
 
-func mustMap(value any) map[string]any {
+func mapValue(value any, field string) (map[string]any, error) {
 	typed, ok := value.(map[string]any)
 	if !ok {
-		panic("validated global config value was not a mapping")
+		return nil, fmt.Errorf("%s: must be a mapping", field)
 	}
-	return typed
+	return typed, nil
 }
 
-func mustList(value any) []any {
+func listValue(value any, field string) ([]any, error) {
 	typed, ok := value.([]any)
 	if !ok {
-		panic("validated global config value was not a list")
+		return nil, fmt.Errorf("%s: must be a list", field)
 	}
-	return typed
+	return typed, nil
 }
 
-func mustString(value any) string {
+func stringValue(value any, field string) (string, error) {
 	typed, ok := value.(string)
 	if !ok {
-		panic("validated global config value was not a string")
+		return "", fmt.Errorf("%s: must be a string", field)
 	}
-	return typed
+	return typed, nil
 }
 
-func mustInt(value any) int {
+func intValue(value any, field string) (int, error) {
 	typed, ok := value.(int)
 	if !ok {
-		panic("validated global config value was not an integer")
+		return 0, fmt.Errorf("%s: must be an integer", field)
 	}
-	return typed
+	return typed, nil
+}
+
+func buildValidationError(path string, err error) error {
+	return ValidationError{Path: path, Problems: []string{err.Error()}}
 }
 
 func expandPath(path string, opts options) (string, error) {

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -598,6 +598,85 @@ projects: {}
 	}
 }
 
+func TestBuildReturnsErrorsForDecodedConfigMismatches(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+
+	tests := []struct {
+		name   string
+		mutate func(map[string]any)
+		opts   options
+		want   string
+	}{
+		{
+			name: "api version type mismatch",
+			mutate: func(attrs map[string]any) {
+				attrs["apiVersion"] = 123
+			},
+			opts: options{home: paths.home, relativeTo: paths.root},
+			want: "apiVersion: must be a string",
+		},
+		{
+			name: "global type mismatch",
+			mutate: func(attrs map[string]any) {
+				attrs["global"] = []any{}
+			},
+			opts: options{home: paths.home, relativeTo: paths.root},
+			want: "global: must be a mapping",
+		},
+		{
+			name: "projects type mismatch",
+			mutate: func(attrs map[string]any) {
+				attrs["projects"] = map[string]any{}
+			},
+			opts: options{home: paths.home, relativeTo: paths.root},
+			want: "projects: must be a list",
+		},
+		{
+			name: "setting type mismatch",
+			mutate: func(attrs map[string]any) {
+				global := attrs["global"].(map[string]any)
+				global["max_concurrent_agents"] = "8"
+			},
+			opts: options{home: paths.home, relativeTo: paths.root},
+			want: "global.max_concurrent_agents: must be an integer",
+		},
+		{
+			name: "project optional bool mismatch",
+			mutate: func(attrs map[string]any) {
+				project := attrs["projects"].([]any)[0].(map[string]any)
+				project["paused"] = "false"
+			},
+			opts: options{home: paths.home, relativeTo: paths.root},
+			want: "projects[0].paused: must be a boolean",
+		},
+		{
+			name: "project path expansion mismatch",
+			mutate: func(attrs map[string]any) {
+				project := attrs["projects"].([]any)[0].(map[string]any)
+				project["workflow"] = "~/WORKFLOW.md"
+			},
+			opts: options{relativeTo: paths.root},
+			want: "projects[0].workflow: expand path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			attrs := validDecodedConfig(paths)
+			tt.mutate(attrs)
+
+			_, err := build(attrs, configPath, tt.opts)
+			if err == nil {
+				t.Fatal("build() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.want) {
+				t.Fatalf("build() error = %q, want substring %q", err, tt.want)
+			}
+		})
+	}
+}
+
 type projectPaths struct {
 	root         string
 	home         string
@@ -702,4 +781,32 @@ projects:
     priority: 50
     credential_ref: " github-default "
 `
+}
+
+func validDecodedConfig(paths projectPaths) map[string]any {
+	return map[string]any{
+		"apiVersion": APIVersion,
+		"kind":       Kind,
+		"global": map[string]any{
+			"max_concurrent_agents": 8,
+			"scheduling":            SchedulingWeighted,
+			"fair_share": map[string]any{
+				"half_life": "1h",
+			},
+			"startup": map[string]any{
+				"jitter_seconds":       10,
+				"max_spawn_per_second": 2,
+			},
+		},
+		"projects": []any{
+			map[string]any{
+				"id":             " detent ",
+				"workflow":       paths.workflow,
+				"workdir":        paths.workdir,
+				"weight":         5,
+				"priority":       50,
+				"credential_ref": " github-default ",
+			},
+		},
+	}
 }


### PR DESCRIPTION
## Summary

- Return validation errors from global config builders instead of panicking on decoded YAML mismatches.
- Preserve the existing hot-reload last-good behavior for config build/load errors.
- Add focused table coverage for builder mismatch errors and reload retention.

Fixes #230

## Test Plan

- [x] `go test ./internal/config/global`
- [x] `go test ./internal/cli -run TestGlobalConfigReloaderApply`
- [x] `go test ./internal/config/... ./internal/cli`
- [x] `make check`