### PR TITLE
chore(go): tidy minor control flow

### DIFF
--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -166,9 +166,9 @@ func (w *FileWatcher[T]) reload(ctx context.Context) FileUpdate[T] {
 	value, err := w.load(ctx)
 	if err != nil {
 		update.Err = err
-	} else {
-		update.Value = value
+		return update
 	}
+	update.Value = value
 
 	return update
 }

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -613,7 +613,8 @@ func formatUSDCap(value *float64) string {
 type align int
 
 const (
-	alignLeft align = iota
+	_ align = iota
+	alignLeft
 	alignRight
 )
 


### PR DESCRIPTION
## Summary

- flatten the file watcher reload error path into a guard clause
- reserve the zero value of the TUI alignment enum

Fixes #236

## Test Plan

- [x] `go test ./internal/config/watcher ./internal/tui`
- [x] `make check`