### PR TITLE
docs(config): clarify live reload scope

### DIFF
--- a/README.md
+++ b/README.md
@@ -515,9 +515,11 @@ detent --config ~/.detent/global.yaml remove-project <id>
 ```
 
 These commands persist the global config. A running Detent process watches the
-active `global.yaml` and reconciles project additions, removals, and setting
-changes without a restart. Invalid edits are logged and ignored while the last
-valid config stays live.
+active `global.yaml` and reconciles project additions, removals, and
+`global.startup` changes without a restart. Changes to
+`global.max_concurrent_agents`, `global.scheduling`, and `global.fair_share`
+require a restart before runtime concurrency and scheduling behavior changes.
+Invalid edits are logged and ignored while the last valid config stays live.
 
 ## Dashboard And APIs
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -615,6 +615,8 @@ func TestSettingsRendersConfigProjectsAndRuntimePaths(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Settings",
+		"Startup configuration, project paths, and runtime files.",
+		"Project membership and startup settings reload live; concurrency and scheduling settings require a restart.",
 		`href="/"`,
 		`href="/reports"`,
 		`href="/settings"`,

--- a/internal/web/templates/settings.templ
+++ b/internal/web/templates/settings.templ
@@ -45,7 +45,7 @@ templ Settings(data SettingsData) {
 								<span>Configuration</span>
 							</div>
 							<h1 class="mt-2 text-2xl font-semibold text-foreground sm:text-3xl">Settings</h1>
-							<p class="mt-1 max-w-3xl text-sm text-muted-foreground">Running configuration, project paths, and runtime files.</p>
+							<p class="mt-1 max-w-3xl text-sm text-muted-foreground">Startup configuration, project paths, and runtime files.</p>
 						</div>
 						<span class="inline-flex min-w-0 items-center justify-between gap-3 rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground lg:w-auto">
 							<span class="text-xs font-medium uppercase text-muted-foreground">Version</span>
@@ -59,7 +59,7 @@ templ Settings(data SettingsData) {
 						<div class="flex flex-col gap-1 sm:flex-row sm:items-start sm:justify-between">
 							<div>
 								@helpHeading2("Global config", helpSettingsConfig, "settings-global-config")
-								<p class="text-sm text-muted-foreground">Resolved startup configuration.</p>
+								<p class="text-sm text-muted-foreground">Project membership and startup settings reload live; concurrency and scheduling settings require a restart.</p>
 							</div>
 							<span class="rounded-full bg-accent-soft px-2 py-1 font-mono text-xs font-medium text-accent">{ settingsPathRule(data.Global.PathRule) }</span>
 						</div>

--- a/internal/web/templates/settings_templ.go
+++ b/internal/web/templates/settings_templ.go
@@ -71,7 +71,7 @@ func Settings(data SettingsData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<main class=\"mx-auto grid min-h-screen w-full max-w-7xl content-start gap-4 px-4 py-4 sm:gap-5 sm:px-6 sm:py-6 lg:px-8\"><header class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between\"><div class=\"min-w-0\"><div class=\"flex flex-wrap items-center gap-2 text-xs font-medium text-muted-foreground\"><span class=\"inline-flex items-center gap-2 rounded-full bg-accent-soft px-2.5 py-1 text-accent\"><span class=\"h-1.5 w-1.5 rounded-full bg-accent\"></span> <span>Detent</span></span> <span>Configuration</span></div><h1 class=\"mt-2 text-2xl font-semibold text-foreground sm:text-3xl\">Settings</h1><p class=\"mt-1 max-w-3xl text-sm text-muted-foreground\">Running configuration, project paths, and runtime files.</p></div><span class=\"inline-flex min-w-0 items-center justify-between gap-3 rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground lg:w-auto\"><span class=\"text-xs font-medium uppercase text-muted-foreground\">Version</span> <span class=\"font-mono text-xs font-semibold text-foreground\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 5, "<main class=\"mx-auto grid min-h-screen w-full max-w-7xl content-start gap-4 px-4 py-4 sm:gap-5 sm:px-6 sm:py-6 lg:px-8\"><header class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex flex-col gap-4 lg:flex-row lg:items-end lg:justify-between\"><div class=\"min-w-0\"><div class=\"flex flex-wrap items-center gap-2 text-xs font-medium text-muted-foreground\"><span class=\"inline-flex items-center gap-2 rounded-full bg-accent-soft px-2.5 py-1 text-accent\"><span class=\"h-1.5 w-1.5 rounded-full bg-accent\"></span> <span>Detent</span></span> <span>Configuration</span></div><h1 class=\"mt-2 text-2xl font-semibold text-foreground sm:text-3xl\">Settings</h1><p class=\"mt-1 max-w-3xl text-sm text-muted-foreground\">Startup configuration, project paths, and runtime files.</p></div><span class=\"inline-flex min-w-0 items-center justify-between gap-3 rounded-md border border-border bg-muted px-3 py-2 text-sm text-muted-foreground lg:w-auto\"><span class=\"text-xs font-medium uppercase text-muted-foreground\">Version</span> <span class=\"font-mono text-xs font-semibold text-foreground\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -100,7 +100,7 @@ func Settings(data SettingsData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<p class=\"text-sm text-muted-foreground\">Resolved startup configuration.</p></div><span class=\"rounded-full bg-accent-soft px-2 py-1 font-mono text-xs font-medium text-accent\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "<p class=\"text-sm text-muted-foreground\">Project membership and startup settings reload live; concurrency and scheduling settings require a restart.</p></div><span class=\"rounded-full bg-accent-soft px-2 py-1 font-mono text-xs font-medium text-accent\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Clarify README live-reload wording so only project membership and `global.startup` are described as restart-free.
- Update settings dashboard copy and coverage to state concurrency and scheduling changes require a restart.

Fixes #222

## Test Plan

- [x] `go test ./internal/web -run TestSettingsRendersConfigProjectsAndRuntimePaths`
- [x] `make generate`
- [x] `make check`