### PR TITLE
fix(web): surface budget query failures

### DIFF
--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -134,6 +134,7 @@ type Completed struct {
 
 type Budget struct {
 	Enabled           bool               `json:"enabled"`
+	DegradedReason    string             `json:"degraded_reason,omitempty"`
 	PerDayMaxUSD      *float64           `json:"per_day_max_usd"`
 	PerIssueMaxUSD    *float64           `json:"per_issue_max_usd"`
 	CurrentSpendUSD   float64            `json:"current_spend_usd"`

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -464,6 +464,7 @@ func budgetResponse(budget telemetry.Budget) budgetAPIResponse {
 
 	return budgetAPIResponse{
 		Enabled:           budget.Enabled,
+		DegradedReason:    budget.DegradedReason,
 		TodaySpendUSD:     budget.CurrentSpendUSD,
 		CurrentSpendUSD:   budget.CurrentSpendUSD,
 		ProjectedCostUSD:  budget.ProjectedCostUSD,
@@ -868,6 +869,7 @@ type recentSessionAPIResponse struct {
 
 type budgetAPIResponse struct {
 	Enabled           bool                         `json:"enabled"`
+	DegradedReason    string                       `json:"degraded_reason,omitempty"`
 	TodaySpendUSD     float64                      `json:"today_spend_usd"`
 	CurrentSpendUSD   float64                      `json:"current_spend_usd"`
 	ProjectedCostUSD  float64                      `json:"projected_cost_usd"`

--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -11,7 +11,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
-const budgetHistoryWindowDays = 7
+const (
+	budgetHistoryWindowDays      = 7
+	budgetSpendQueryFailedReason = "budget spend query failed"
+)
 
 type configuredBudget struct {
 	ProjectID      string
@@ -26,6 +29,10 @@ func (s *Server) enrichSnapshot(ctx context.Context, snapshot telemetry.Snapshot
 
 	budget, ok := s.snapshotBudget(ctx, snapshot.GeneratedAt)
 	if !ok {
+		return snapshot
+	}
+	if budget.DegradedReason != "" {
+		snapshot.Budget = degradedSnapshotBudget(snapshot.Budget, budget)
 		return snapshot
 	}
 
@@ -54,7 +61,14 @@ func (s *Server) snapshotBudget(ctx context.Context, now time.Time) (telemetry.B
 	})
 	if err != nil {
 		s.logger.Warn("budget spend query failed", slog.Any("error", err))
-		return telemetry.Budget{}, false
+		return telemetry.Budget{
+			Enabled:        true,
+			DegradedReason: budgetSpendQueryFailedReason,
+			PerDayMaxUSD:   positiveFloatPtr(totalDailyBudgetCap(projects)),
+			PerIssueMaxUSD: issueBudgetCap(projects),
+			PeriodStart:    periodStart,
+			PeriodEnd:      periodEnd,
+		}, true
 	}
 
 	points, currentSpend := currentBudgetSpendPoints(events, periodStart, periodEnd)
@@ -70,6 +84,26 @@ func (s *Server) snapshotBudget(ctx context.Context, now time.Time) (telemetry.B
 		Days:              budgetSpendDays(events),
 	}
 	return budget, true
+}
+
+func degradedSnapshotBudget(snapshotBudget telemetry.Budget, degradedBudget telemetry.Budget) telemetry.Budget {
+	if !snapshotBudget.Enabled {
+		snapshotBudget.Enabled = degradedBudget.Enabled
+	}
+	if snapshotBudget.PerDayMaxUSD == nil {
+		snapshotBudget.PerDayMaxUSD = degradedBudget.PerDayMaxUSD
+	}
+	if snapshotBudget.PerIssueMaxUSD == nil {
+		snapshotBudget.PerIssueMaxUSD = degradedBudget.PerIssueMaxUSD
+	}
+	if snapshotBudget.PeriodStart.IsZero() {
+		snapshotBudget.PeriodStart = degradedBudget.PeriodStart
+	}
+	if snapshotBudget.PeriodEnd.IsZero() {
+		snapshotBudget.PeriodEnd = degradedBudget.PeriodEnd
+	}
+	snapshotBudget.DegradedReason = degradedBudget.DegradedReason
+	return snapshotBudget
 }
 
 func (s *Server) configuredBudgets() []configuredBudget {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1420,6 +1420,96 @@ func TestServerPreservesSnapshotBudgetWhenSpendQueryFails(t *testing.T) {
 	}
 }
 
+func TestServerDistinguishesNoBudgetSpendFromSpendQueryFailure(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	capUSD := 100.0
+
+	tests := []struct {
+		name             string
+		budgetCostEvents func(context.Context, store.BudgetCostQuery) ([]store.BudgetCostEvent, error)
+		wantReason       string
+		wantHTML         string
+		forbiddenHTML    []string
+	}{
+		{
+			name: "successful empty query",
+			budgetCostEvents: func(context.Context, store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+				return nil, nil
+			},
+			wantHTML:      "No budget spend yet.",
+			forbiddenHTML: []string{"Budget data unavailable."},
+		},
+		{
+			name: "failed query",
+			budgetCostEvents: func(context.Context, store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+				return nil, errors.New("store is busy")
+			},
+			wantReason:    "budget spend query failed",
+			wantHTML:      "Budget data unavailable.",
+			forbiddenHTML: []string{"No budget spend yet.", "$0.00 / $100.00"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			snapshots := hub.New[telemetry.Snapshot]()
+			if err := snapshots.Publish(telemetry.Snapshot{
+				GeneratedAt: generatedAt,
+				Budget: telemetry.Budget{
+					Enabled:      true,
+					PerDayMaxUSD: &capUSD,
+				},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+
+			registry := project.NewRegistry()
+			if err := registry.Set(newBudgetTestProject(t, "detent", capUSD, 10)); err != nil {
+				t.Fatalf("Registry.Set() error = %v", err)
+			}
+
+			deps := testDeps(t)
+			deps.Hub = snapshots
+			deps.Registry = registry
+			deps.Store = storeProbe{budgetCostEvents: tt.budgetCostEvents}
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+			budget := state["budget"].(map[string]any)
+			if tt.wantReason == "" {
+				if _, ok := budget["degraded_reason"]; ok {
+					t.Fatalf("budget degraded_reason = %#v, want omitted", budget["degraded_reason"])
+				}
+			} else if budget["degraded_reason"] != tt.wantReason {
+				t.Fatalf("budget degraded_reason = %#v, want %q", budget["degraded_reason"], tt.wantReason)
+			}
+
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/", nil)
+			server.Handler().ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("dashboard status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+			}
+			html := rec.Body.String()
+			if !strings.Contains(html, tt.wantHTML) {
+				t.Fatalf("dashboard missing %q:\n%s", tt.wantHTML, html)
+			}
+			for _, forbidden := range tt.forbiddenHTML {
+				if strings.Contains(html, forbidden) {
+					t.Fatalf("dashboard rendered %q:\n%s", forbidden, html)
+				}
+			}
+		})
+	}
+}
+
 func TestServerAPIPreservesUnknownDiffStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1276,6 +1276,9 @@ func optionalUSD(value *float64) string {
 }
 
 func budgetStatus(budget telemetry.Budget) string {
+	if strings.TrimSpace(budget.DegradedReason) != "" {
+		return "Budget unavailable"
+	}
 	if budget.Enabled {
 		return "Budget enabled"
 	}
@@ -1283,6 +1286,9 @@ func budgetStatus(budget telemetry.Budget) string {
 }
 
 func budgetSpendTodayLabel(budget telemetry.Budget) string {
+	if strings.TrimSpace(budget.DegradedReason) != "" && budget.CurrentSpendUSD <= 0 && len(budget.SpendPoints) == 0 {
+		return "unavailable / " + budgetDailyCapLabel(budget)
+	}
 	return formatUSD(budget.CurrentSpendUSD) + " / " + budgetDailyCapLabel(budget)
 }
 
@@ -1302,6 +1308,15 @@ func budgetDailyUsageStyle(budget telemetry.Budget) string {
 
 func budgetBurnDownView(snapshot telemetry.Snapshot) budgetBurnDownViewModel {
 	budget := snapshot.Budget
+	if strings.TrimSpace(budget.DegradedReason) != "" {
+		return budgetBurnDownViewModel{
+			EmptyTitle:      "Budget data unavailable.",
+			EmptyDetail:     budgetUnavailableDetail(budget),
+			CurrentLabel:    formatUSD(budget.CurrentSpendUSD),
+			CapLabel:        optionalUSD(budget.PerDayMaxUSD),
+			ProjectionLabel: budgetProjectionLabel(budget),
+		}
+	}
 	if !budget.Enabled {
 		return budgetBurnDownViewModel{
 			EmptyTitle:      "Budget disabled.",
@@ -1366,6 +1381,23 @@ func budgetBurnDownView(snapshot telemetry.Snapshot) budgetBurnDownViewModel {
 			Cap:         budgetCapValue(budget.PerDayMaxUSD),
 		},
 	}
+}
+
+func budgetUnavailableDetail(budget telemetry.Budget) string {
+	if reason := strings.TrimSpace(budget.DegradedReason); reason != "" {
+		return reason
+	}
+	return "Budget spend data unavailable."
+}
+
+func budgetProjectionLabel(budget telemetry.Budget) string {
+	if budget.ProjectedCostUSD > 0 {
+		return formatUSD(budget.ProjectedCostUSD)
+	}
+	if budget.ProjectedSpendUSD > 0 {
+		return formatUSD(budget.ProjectedSpendUSD)
+	}
+	return "unavailable"
 }
 
 func budgetProjectedSpendUSD(periodStart time.Time, periodEnd time.Time, now time.Time, currentSpend float64) float64 {


### PR DESCRIPTION
## Summary

- Mark budget spend query failures as degraded instead of preserving a default zero-spend burn-down state.
- Expose `budget.degraded_reason` through the state API and render the dashboard budget burn-down as unavailable.
- Add regression coverage for successful no-spend data versus failed spend queries.

Fixes #221

## Test Plan

- [x] `go test ./internal/telemetry ./internal/web ./internal/web/templates -count=1`
- [x] `make check`