### PR TITLE
fix(orchestrator): redispatch active issues

### DIFF
--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -416,7 +416,11 @@ func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 
-	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{first, second}, now)
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		orch.dispatchReadyIssues(ctx, &state, []connector.Issue{first, second}, now)
+	}()
 
 	request := receiveWorkerHostRunRequest(t, runner.started)
 	if request.Issue.ID != first.ID {
@@ -431,6 +435,11 @@ func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	request = receiveWorkerHostRunRequest(t, runner.started)
 	if request.Issue.ID != second.ID {
 		t.Fatalf("second RunRequest.Issue.ID = %q, want %q", request.Issue.ID, second.ID)
+	}
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for dispatchReadyIssues to finish")
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -311,9 +311,9 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 			want:  false,
 		},
 		{
-			name:  "in progress with open pull request skips",
+			name:  "in progress with open pull request dispatches",
 			issue: dispatchTestIssueWithPullRequest("issue-progress-open-pr", "In Progress", "OPEN"),
-			want:  false,
+			want:  true,
 		},
 		{
 			name:  "rework with open pull request dispatches",
@@ -391,6 +391,46 @@ func TestDispatchCandidatesClaimsDuplicateIssueWithinCycle(t *testing.T) {
 	}
 	if len(state.Claimed) != 1 {
 		t.Fatalf("Claimed len = %d, want 1", len(state.Claimed))
+	}
+}
+
+func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+	})
+	runner := newWorkerHostRunner()
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion),
+	}
+	state := newState(cfg)
+	now := time.Now()
+	first := dispatchTestIssueWithPullRequest("issue-first", "In Progress", "OPEN")
+	second := dispatchTestIssueWithPullRequest("issue-second", "In Progress", "OPEN")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{first, second}, now)
+
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.Issue.ID != first.ID {
+		t.Fatalf("first RunRequest.Issue.ID = %q, want %q", request.Issue.ID, first.ID)
+	}
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected unstaggered continuation dispatch = %#v", request)
+	default:
+	}
+
+	request = receiveWorkerHostRunRequest(t, runner.started)
+	if request.Issue.ID != second.ID {
+		t.Fatalf("second RunRequest.Issue.ID = %q, want %q", request.Issue.ID, second.ID)
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -443,6 +443,28 @@ func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	}
 }
 
+func TestContinuationDelayUsesConstantGap(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		index int
+		want  time.Duration
+	}{
+		{index: -1, want: 0},
+		{index: 0, want: 0},
+		{index: 1, want: continuationDispatchBackoff},
+		{index: 2, want: continuationDispatchBackoff},
+		{index: 50, want: continuationDispatchBackoff},
+	}
+
+	for _, tt := range tests {
+		got := continuationDelay(tt.index)
+		if got != tt.want {
+			t.Fatalf("continuationDelay(%d) = %s, want %s", tt.index, got, tt.want)
+		}
+	}
+}
+
 func TestDispatchCandidatesAssignsLeastLoadedWorkerHost(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -509,7 +509,10 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			delay = continuationDelay(continuations)
 			continuations++
 		}
-		o.dispatchIssueAfter(ctx, state, issue, 0, now, "", delay)
+		if !waitForDispatchBackoff(ctx, delay) {
+			return
+		}
+		o.dispatchIssue(ctx, state, issue, 0, now, "")
 	}
 }
 
@@ -670,18 +673,6 @@ func (o *Orchestrator) dispatchIssue(
 	now time.Time,
 	preferredWorkerHost string,
 ) {
-	o.dispatchIssueAfter(ctx, state, issue, attempt, now, preferredWorkerHost, 0)
-}
-
-func (o *Orchestrator) dispatchIssueAfter(
-	ctx context.Context,
-	state *State,
-	issue connector.Issue,
-	attempt int,
-	now time.Time,
-	preferredWorkerHost string,
-	delay time.Duration,
-) {
 	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
 	if !ok {
 		return
@@ -709,26 +700,7 @@ func (o *Orchestrator) dispatchIssueAfter(
 		WorkerHost:    workerHost,
 		OnUsageUpdate: o.usageUpdateHandler(ctx, issue.ID),
 	}
-	o.dispatchRun(ctx, request, delay)
-}
-
-func (o *Orchestrator) dispatchRun(ctx context.Context, request RunRequest, delay time.Duration) {
-	if delay <= 0 {
-		o.supervisor.Dispatch(ctx, request, o.runResults)
-		return
-	}
-
-	go func() {
-		timer := time.NewTimer(delay)
-		defer timer.Stop()
-
-		select {
-		case <-ctx.Done():
-			return
-		case <-timer.C:
-			o.supervisor.Dispatch(ctx, request, o.runResults)
-		}
-	}()
+	o.supervisor.Dispatch(ctx, request, o.runResults)
 }
 
 func (o *Orchestrator) usageUpdateHandler(ctx context.Context, issueID string) runpkg.UsageUpdateHandler {
@@ -1033,6 +1005,22 @@ func continuationDelay(index int) time.Duration {
 		return 0
 	}
 	return time.Duration(index) * continuationDispatchBackoff
+}
+
+func waitForDispatchBackoff(ctx context.Context, delay time.Duration) bool {
+	if delay <= 0 {
+		return true
+	}
+
+	timer := time.NewTimer(delay)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
 }
 
 func normalizePullRequestState(state string) string {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,6 +19,7 @@ const (
 	defaultMaxRetryBackoff       = 5 * time.Minute
 	defaultContinuationRetry     = time.Second
 	defaultFailureRetryBaseDelay = 10 * time.Second
+	continuationDispatchBackoff  = 100 * time.Millisecond
 	runUpdateBufferSize          = 128
 	blockedStatusState           = "Blocked"
 	blockedReasonDependency      = "blocked by non-terminal dependency"
@@ -490,6 +491,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	dueRetries := dueRetriesByIssue(state, now)
 	o.releaseMissingDueRetries(state, issues, dueRetries)
 
+	continuations := 0
 	for _, issue := range issues {
 		if retry, ok := dueRetries[issue.ID]; ok {
 			o.dispatchRetryIssue(ctx, state, issue, retry, now)
@@ -502,7 +504,12 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			continue
 		}
 
-		o.dispatchIssue(ctx, state, issue, 0, now, "")
+		delay := time.Duration(0)
+		if continuationDispatch(issue) {
+			delay = continuationDelay(continuations)
+			continuations++
+		}
+		o.dispatchIssueAfter(ctx, state, issue, 0, now, "", delay)
 	}
 }
 
@@ -663,6 +670,18 @@ func (o *Orchestrator) dispatchIssue(
 	now time.Time,
 	preferredWorkerHost string,
 ) {
+	o.dispatchIssueAfter(ctx, state, issue, attempt, now, preferredWorkerHost, 0)
+}
+
+func (o *Orchestrator) dispatchIssueAfter(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	preferredWorkerHost string,
+	delay time.Duration,
+) {
 	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
 	if !ok {
 		return
@@ -690,7 +709,26 @@ func (o *Orchestrator) dispatchIssue(
 		WorkerHost:    workerHost,
 		OnUsageUpdate: o.usageUpdateHandler(ctx, issue.ID),
 	}
-	o.supervisor.Dispatch(ctx, request, o.runResults)
+	o.dispatchRun(ctx, request, delay)
+}
+
+func (o *Orchestrator) dispatchRun(ctx context.Context, request RunRequest, delay time.Duration) {
+	if delay <= 0 {
+		o.supervisor.Dispatch(ctx, request, o.runResults)
+		return
+	}
+
+	go func() {
+		timer := time.NewTimer(delay)
+		defer timer.Stop()
+
+		select {
+		case <-ctx.Done():
+			return
+		case <-timer.C:
+			o.supervisor.Dispatch(ctx, request, o.runResults)
+		}
+	}()
 }
 
 func (o *Orchestrator) usageUpdateHandler(ctx context.Context, issueID string) runpkg.UsageUpdateHandler {
@@ -979,10 +1017,22 @@ func duplicatePullRequestWork(issue connector.Issue) bool {
 	case "merged":
 		return true
 	case "open":
-		return normalizeState(issue.State) == "todo" || normalizeState(issue.State) == "in progress"
+		return normalizeState(issue.State) == "todo"
 	default:
 		return false
 	}
+}
+
+func continuationDispatch(issue connector.Issue) bool {
+	state := normalizeState(issue.State)
+	return state != "" && state != "todo"
+}
+
+func continuationDelay(index int) time.Duration {
+	if index <= 0 {
+		return 0
+	}
+	return time.Duration(index) * continuationDispatchBackoff
 }
 
 func normalizePullRequestState(state string) string {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1004,7 +1004,7 @@ func continuationDelay(index int) time.Duration {
 	if index <= 0 {
 		return 0
 	}
-	return time.Duration(index) * continuationDispatchBackoff
+	return continuationDispatchBackoff
 }
 
 func waitForDispatchBackoff(ctx context.Context, delay time.Duration) bool {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -76,6 +76,43 @@ func TestRunDispatchesCandidateAndRecordsCompletion(t *testing.T) {
 	}
 }
 
+func TestRunRedispatchesInProgressIssueWithOpenPullRequestAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 245
+	issue := testIssue("issue-in-progress-pr", "digitaldrywood/detent#245", "In Progress")
+	issue.PRNumber = &prNumber
+	issue.PullRequest = &connector.PullRequest{
+		Number:     prNumber,
+		URL:        "https://github.com/digitaldrywood/detent/pull/245",
+		BranchName: "detent/digitaldrywood_detent_245",
+		State:      "OPEN",
+	}
+	tracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+	defer close(runner.release)
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != issue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
+	}
+	if request.Issue.PullRequest == nil || request.Issue.PullRequest.State != "OPEN" {
+		t.Fatalf("RunRequest.Issue.PullRequest = %#v, want open pull request", request.Issue.PullRequest)
+	}
+
+	state, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if _, ok := state.Running[issue.ID]; !ok {
+		t.Fatalf("Running[%q] missing after startup redispatch", issue.ID)
+	}
+}
+
 func TestRunReportsRunningStateWhileRunnerIsInFlight(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Allow `In Progress` continuation issues with open PRs to dispatch when no live orchestrator session exists
- Stagger continuation redispatches during restart/reconcile to avoid launching every recovered agent at once
- Add dispatch and startup regression coverage for active-state redispatch

Fixes #245

## Test Plan

- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`