### PR TITLE
fix(web): improve PR pipeline done lanes

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -46,7 +46,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
             }
           }
           statusValue: fieldValueByName(name: "Status") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name }
+            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
           }
           priorityValue: fieldValueByName(name: "Priority") {
             ... on ProjectV2ItemFieldSingleSelectValue { name }
@@ -80,7 +80,7 @@ query DetentGitHubIssuesByID($issueIds: [ID!]!, $projectItemsFirst: Int!) {
           id
           project { id }
           statusValue: fieldValueByName(name: "Status") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name }
+            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
           }
           priorityValue: fieldValueByName(name: "Priority") {
             ... on ProjectV2ItemFieldSingleSelectValue { name }
@@ -163,7 +163,7 @@ query DetentGitHubProjectItemForIssue($issueId: ID!, $projectItemsFirst: Int!, $
           id
           project { id }
           statusValue: fieldValueByName(name: "Status") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name }
+            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
           }
           priorityValue: fieldValueByName(name: "Priority") {
             ... on ProjectV2ItemFieldSingleSelectValue { name }
@@ -296,7 +296,8 @@ type projectRef struct {
 }
 
 type singleSelectValue struct {
-	Name string `json:"name"`
+	Name      string  `json:"name"`
+	UpdatedAt *string `json:"updatedAt"`
 }
 
 func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
@@ -654,7 +655,12 @@ func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue,
 	if item.Content == nil || item.Content.TypeName != "Issue" {
 		return connector.Issue{}, false
 	}
-	return c.buildIssue(*item.Content, singleSelectName(item.StatusValue), singleSelectName(item.PriorityValue)), true
+	return c.buildIssue(
+		*item.Content,
+		singleSelectName(item.StatusValue),
+		singleSelectName(item.PriorityValue),
+		singleSelectUpdatedAt(item.StatusValue),
+	), true
 }
 
 func resolveBlockedByProjectState(issues []connector.Issue) {
@@ -688,44 +694,44 @@ func (c *Connector) normalizeIssueNode(ctx context.Context, issue githubIssueNod
 	if issue.TypeName != "Issue" {
 		return connector.Issue{}, false, nil
 	}
-	stateName, priorityName, ok, err := c.resolveIssueProjectFields(ctx, issue.ID, issue.ProjectItems)
+	stateName, priorityName, statusUpdatedAt, ok, err := c.resolveIssueProjectFields(ctx, issue.ID, issue.ProjectItems)
 	if err != nil {
 		return connector.Issue{}, false, err
 	}
 	if ok {
-		return c.buildIssue(issue, stateName, priorityName), true, nil
+		return c.buildIssue(issue, stateName, priorityName, statusUpdatedAt), true, nil
 	}
-	return c.buildIssue(issue, c.githubIssueStateToDetentState(issue.State), ""), true, nil
+	return c.buildIssue(issue, c.githubIssueStateToDetentState(issue.State), "", nil), true, nil
 }
 
-func (c *Connector) resolveIssueProjectFields(ctx context.Context, issueID string, items *projectItemsConnection) (string, string, bool, error) {
-	if stateName, priorityName, ok := c.projectFields(issueID, items); ok {
-		return stateName, priorityName, true, nil
+func (c *Connector) resolveIssueProjectFields(ctx context.Context, issueID string, items *projectItemsConnection) (string, string, *time.Time, bool, error) {
+	if stateName, priorityName, statusUpdatedAt, ok := c.projectFields(issueID, items); ok {
+		return stateName, priorityName, statusUpdatedAt, true, nil
 	}
 	if items == nil || !items.PageInfo.HasNextPage {
-		return "", "", false, nil
+		return "", "", nil, false, nil
 	}
 	cursor := strings.TrimSpace(items.PageInfo.EndCursor)
 	if cursor == "" {
-		return "", "", false, ErrInvalidResponse
+		return "", "", nil, false, ErrInvalidResponse
 	}
 	return c.fetchProjectFieldsPage(ctx, issueID, &cursor)
 }
 
-func (c *Connector) projectFields(issueID string, items *projectItemsConnection) (string, string, bool) {
+func (c *Connector) projectFields(issueID string, items *projectItemsConnection) (string, string, *time.Time, bool) {
 	if items == nil {
-		return "", "", false
+		return "", "", nil, false
 	}
 	for _, item := range items.Nodes {
 		if item.Project != nil && item.Project.ID == c.projectID {
 			c.projectCache.SetItemID(c.projectID, issueID, item.ID)
-			return singleSelectName(item.StatusValue), singleSelectName(item.PriorityValue), true
+			return singleSelectName(item.StatusValue), singleSelectName(item.PriorityValue), singleSelectUpdatedAt(item.StatusValue), true
 		}
 	}
-	return "", "", false
+	return "", "", nil, false
 }
 
-func (c *Connector) fetchProjectFieldsPage(ctx context.Context, issueID string, after *string) (string, string, bool, error) {
+func (c *Connector) fetchProjectFieldsPage(ctx context.Context, issueID string, after *string) (string, string, *time.Time, bool, error) {
 	var response struct {
 		Node *struct {
 			ProjectItems projectItemsConnection `json:"projectItems"`
@@ -736,25 +742,25 @@ func (c *Connector) fetchProjectFieldsPage(ctx context.Context, issueID string, 
 		"projectItemsFirst": projectItemsPerIssue,
 		"after":             after,
 	}, &response); err != nil {
-		return "", "", false, fmt.Errorf("fetch github project item fields: %w", err)
+		return "", "", nil, false, fmt.Errorf("fetch github project item fields: %w", err)
 	}
 	if response.Node == nil {
-		return "", "", false, ErrProjectItemNotFound
+		return "", "", nil, false, ErrProjectItemNotFound
 	}
-	if stateName, priorityName, ok := c.projectFields(issueID, &response.Node.ProjectItems); ok {
-		return stateName, priorityName, true, nil
+	if stateName, priorityName, statusUpdatedAt, ok := c.projectFields(issueID, &response.Node.ProjectItems); ok {
+		return stateName, priorityName, statusUpdatedAt, true, nil
 	}
 	if !response.Node.ProjectItems.PageInfo.HasNextPage {
-		return "", "", false, nil
+		return "", "", nil, false, nil
 	}
 	cursor := strings.TrimSpace(response.Node.ProjectItems.PageInfo.EndCursor)
 	if cursor == "" {
-		return "", "", false, ErrInvalidResponse
+		return "", "", nil, false, ErrInvalidResponse
 	}
 	return c.fetchProjectFieldsPage(ctx, issueID, &cursor)
 }
 
-func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorityName string) connector.Issue {
+func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorityName string, statusUpdatedAt *time.Time) connector.Issue {
 	repo := strings.TrimSpace(issue.Repository.NameWithOwner)
 	return connector.Issue{
 		ID:               issue.ID,
@@ -772,6 +778,7 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		AssignedToWorker: true,
 		CreatedAt:        parseGitHubTime(issue.CreatedAt),
 		UpdatedAt:        parseGitHubTime(issue.UpdatedAt),
+		StageUpdatedAt:   statusUpdatedAt,
 		ModelOverride:    parseModelOverride(issue.Body),
 	}
 }
@@ -972,6 +979,13 @@ func singleSelectName(value *singleSelectValue) string {
 		return ""
 	}
 	return strings.TrimSpace(value.Name)
+}
+
+func singleSelectUpdatedAt(value *singleSelectValue) *time.Time {
+	if value == nil {
+		return nil
+	}
+	return parseGitHubTime(value.UpdatedAt)
 }
 
 func buildIdentifier(repo string, number int) string {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -266,6 +266,40 @@ func TestConnectorFetchIssuesByStatesFiltersMappedStates(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssuesByStatesUsesStatusUpdatedAtForStage(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":1,"title":"Done issue","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/1","createdAt":"2026-05-31T01:02:03Z","updatedAt":"2026-05-31T02:03:04Z","assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Done","updatedAt":"2026-06-01T12:30:00Z"},"priorityValue":null}]}}}}`,
+		},
+		{
+			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Done"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	issueUpdatedAt := time.Date(2026, 5, 31, 2, 3, 4, 0, time.UTC)
+	stageUpdatedAt := time.Date(2026, 6, 1, 12, 30, 0, 0, time.UTC)
+	if got[0].UpdatedAt == nil || !got[0].UpdatedAt.Equal(issueUpdatedAt) {
+		t.Fatalf("UpdatedAt = %v, want issue updatedAt %v", got[0].UpdatedAt, issueUpdatedAt)
+	}
+	if got[0].StageUpdatedAt == nil || !got[0].StageUpdatedAt.Equal(stageUpdatedAt) {
+		t.Fatalf("StageUpdatedAt = %v, want status updatedAt %v", got[0].StageUpdatedAt, stageUpdatedAt)
+	}
+}
+
 func TestConnectorFetchIssuesByStatesExtractsWorkpadHumanActionNeeded(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -24,6 +24,7 @@ type Issue struct {
 	AssignedToWorker bool         `json:"assigned_to_worker" yaml:"assigned_to_worker"`
 	CreatedAt        *time.Time   `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	UpdatedAt        *time.Time   `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	StageUpdatedAt   *time.Time   `json:"stage_updated_at,omitempty" yaml:"stage_updated_at,omitempty"`
 	ModelOverride    string       `json:"model_override" yaml:"model_override"`
 }
 

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -134,6 +134,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	issue.CreatedAt = cloneTime(issue.CreatedAt)
 	issue.UpdatedAt = cloneTime(issue.UpdatedAt)
+	issue.StageUpdatedAt = cloneTime(issue.StageUpdatedAt)
 
 	return issue
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -247,7 +247,7 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	if blockedErr != nil {
 		o.logger.Warn("fetch blocked status issues failed", "error", blockedErr)
 	}
-	pipelineIssues, pipelineErr := o.connector.FetchIssuesByStates(ctx, prPipelineStates)
+	pipelineIssues, pipelineErr := o.connector.FetchIssuesByStates(ctx, prPipelineFetchStates(o.cfg.TerminalStates))
 	if pipelineErr != nil {
 		o.logger.Warn("fetch pr pipeline issues failed", "error", pipelineErr)
 	}
@@ -264,6 +264,23 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		o.trackBlockedStatusIssues(state, blockedIssues, now)
 	}
 	o.dispatchReadyIssues(ctx, state, issues, now)
+}
+
+func prPipelineFetchStates(terminalStates []string) []string {
+	states := make([]string, 0, len(prPipelineStates)+len(terminalStates))
+	seen := make(map[string]struct{}, len(prPipelineStates)+len(terminalStates))
+	for _, state := range append(append([]string(nil), prPipelineStates...), terminalStates...) {
+		key := normalizeState(state)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		states = append(states, state)
+	}
+	return states
 }
 
 func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State) {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -522,6 +522,23 @@ func TestRunTracksBlockedStatusIssuesForDisplayOnly(t *testing.T) {
 	}
 }
 
+func TestRunFetchesPipelineTerminalStates(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeConnector()
+	orch := newTestOrchestrator(t, tracker, &staticRunner{})
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForFetchByStatesCalls(t, tracker, 2)
+
+	got := tracker.fetchByStatesRequests()
+	want := []string{"Human Review", "Merging", "Done", "Cancelled", "Canceled", "Closed"}
+	if !stateRequestsContain(got, want) {
+		t.Fatalf("FetchIssuesByStates requests = %#v, want pipeline request containing %#v", got, want)
+	}
+}
+
 func TestStateReturnsDefensiveCopies(t *testing.T) {
 	t.Parallel()
 
@@ -726,6 +743,46 @@ func waitForFetchCalls(t *testing.T, tracker *fakeConnector, want int) {
 	}
 }
 
+func waitForFetchByStatesCalls(t *testing.T, tracker *fakeConnector, want int) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		if tracker.fetchByStatesCalls() >= want {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d FetchIssuesByStates() calls; got %d", want, tracker.fetchByStatesCalls())
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func stateRequestsContain(requests [][]string, want []string) bool {
+	wanted := make(map[string]struct{}, len(want))
+	for _, state := range want {
+		wanted[strings.ToLower(strings.TrimSpace(state))] = struct{}{}
+	}
+	for _, request := range requests {
+		if len(request) != len(wanted) {
+			continue
+		}
+		matched := 0
+		for _, state := range request {
+			if _, ok := wanted[strings.ToLower(strings.TrimSpace(state))]; ok {
+				matched++
+			}
+		}
+		if matched == len(wanted) {
+			return true
+		}
+	}
+	return false
+}
+
 func receiveRunRequest(t *testing.T, requests <-chan orchestrator.RunRequest) orchestrator.RunRequest {
 	t.Helper()
 
@@ -761,6 +818,7 @@ type fakeConnector struct {
 	stateIssues         []connector.Issue
 	fetchCandidateCount int
 	fetchByStatesCount  int
+	fetchByStatesLog    [][]string
 }
 
 func newFakeConnector(issues ...connector.Issue) *fakeConnector {
@@ -784,6 +842,7 @@ func (c *fakeConnector) FetchIssuesByStates(_ context.Context, states []string) 
 	defer c.mu.Unlock()
 
 	c.fetchByStatesCount++
+	c.fetchByStatesLog = append(c.fetchByStatesLog, append([]string(nil), states...))
 	wanted := make(map[string]struct{}, len(states))
 	for _, state := range states {
 		wanted[strings.ToLower(strings.TrimSpace(state))] = struct{}{}
@@ -836,6 +895,17 @@ func (c *fakeConnector) fetchByStatesCalls() int {
 	defer c.mu.Unlock()
 
 	return c.fetchByStatesCount
+}
+
+func (c *fakeConnector) fetchByStatesRequests() [][]string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	requests := make([][]string, len(c.fetchByStatesLog))
+	for index, request := range c.fetchByStatesLog {
+		requests[index] = append([]string(nil), request...)
+	}
+	return requests
 }
 
 func (c *fakeConnector) setStateIssues(issues ...connector.Issue) {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -162,16 +162,17 @@ func budgetRefusalSnapshots(refusals map[string]BudgetRefusal) []telemetry.Budge
 
 func telemetryIssue(issue connector.Issue) telemetry.Issue {
 	return telemetry.Issue{
-		ID:          issue.ID,
-		Identifier:  issue.Identifier,
-		URL:         issue.URL,
-		Title:       issue.Title,
-		Description: issue.Description,
-		State:       issue.State,
-		Labels:      append([]string(nil), issue.Labels...),
-		PullRequest: telemetryPullRequest(issue.PullRequest, issue.PRNumber),
-		CreatedAt:   timePointerFromPtr(issue.CreatedAt),
-		UpdatedAt:   timePointerFromPtr(issue.UpdatedAt),
+		ID:             issue.ID,
+		Identifier:     issue.Identifier,
+		URL:            issue.URL,
+		Title:          issue.Title,
+		Description:    issue.Description,
+		State:          issue.State,
+		Labels:         append([]string(nil), issue.Labels...),
+		PullRequest:    telemetryPullRequest(issue.PullRequest, issue.PRNumber),
+		CreatedAt:      timePointerFromPtr(issue.CreatedAt),
+		UpdatedAt:      timePointerFromPtr(issue.UpdatedAt),
+		StageUpdatedAt: timePointerFromPtr(issue.StageUpdatedAt),
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -169,6 +169,10 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		updatedAt := *issue.UpdatedAt
 		cloned.UpdatedAt = &updatedAt
 	}
+	if issue.StageUpdatedAt != nil {
+		stageUpdatedAt := *issue.StageUpdatedAt
+		cloned.StageUpdatedAt = &stageUpdatedAt
+	}
 	cloned.BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
 	cloned.Labels = append([]string(nil), issue.Labels...)
 	return cloned

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -50,16 +50,17 @@ type Counts struct {
 }
 
 type Issue struct {
-	ID          string       `json:"issue_id"`
-	Identifier  string       `json:"identifier,omitempty"`
-	URL         string       `json:"url,omitempty"`
-	Title       string       `json:"title,omitempty"`
-	Description string       `json:"description,omitempty"`
-	State       string       `json:"state,omitempty"`
-	Labels      []string     `json:"labels,omitempty"`
-	PullRequest *PullRequest `json:"pull_request,omitempty"`
-	CreatedAt   *time.Time   `json:"created_at,omitempty"`
-	UpdatedAt   *time.Time   `json:"updated_at,omitempty"`
+	ID             string       `json:"issue_id"`
+	Identifier     string       `json:"identifier,omitempty"`
+	URL            string       `json:"url,omitempty"`
+	Title          string       `json:"title,omitempty"`
+	Description    string       `json:"description,omitempty"`
+	State          string       `json:"state,omitempty"`
+	Labels         []string     `json:"labels,omitempty"`
+	PullRequest    *PullRequest `json:"pull_request,omitempty"`
+	CreatedAt      *time.Time   `json:"created_at,omitempty"`
+	UpdatedAt      *time.Time   `json:"updated_at,omitempty"`
+	StageUpdatedAt *time.Time   `json:"stage_updated_at,omitempty"`
 }
 
 type PullRequest struct {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -653,6 +653,9 @@ func pipelineNow(snapshot telemetry.Snapshot) time.Time {
 	}
 	latest := time.Time{}
 	for _, issue := range snapshot.Pipeline {
+		if issue.StageUpdatedAt != nil && issue.StageUpdatedAt.After(latest) {
+			latest = *issue.StageUpdatedAt
+		}
 		if issue.UpdatedAt != nil && issue.UpdatedAt.After(latest) {
 			latest = *issue.UpdatedAt
 		}
@@ -671,6 +674,9 @@ func pipelineNow(snapshot telemetry.Snapshot) time.Time {
 }
 
 func pipelineIssueStageTime(issue telemetry.Issue) time.Time {
+	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+		return issue.StageUpdatedAt.UTC()
+	}
 	if issue.UpdatedAt != nil && !issue.UpdatedAt.IsZero() {
 		return issue.UpdatedAt.UTC()
 	}

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -665,6 +665,19 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 						State:      "Done",
 						UpdatedAt:  &oldDoneAt,
 					},
+					{
+						ID:             "cancelled-today",
+						Identifier:     "digitaldrywood/detent#17",
+						Title:          "Cancelled today PR",
+						State:          "Cancelled",
+						UpdatedAt:      &oldDoneAt,
+						StageUpdatedAt: &doneAt,
+						PullRequest: &telemetry.PullRequest{
+							Number:           146,
+							State:            "MERGED",
+							CodexReviewState: "clean",
+						},
+					},
 				},
 			},
 			want: []pipelineCardSnapshot{
@@ -672,6 +685,7 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 				{Lane: "Merging", IssueNumber: "#143", Title: "Merge lane PR", CIStatus: "pending", CodexReviewState: "P2", TimeInStage: "15m 0s"},
 				{Lane: "Done today", IssueNumber: "#144", Title: "Done lane PR", CIStatus: "pass", CodexReviewState: "P1", TimeInStage: "45m 0s"},
 				{Lane: "Done today", IssueNumber: "#145", Title: "Done lane unverified PR", CIStatus: "pending", CodexReviewState: "clean", TimeInStage: "45m 0s"},
+				{Lane: "Done today", IssueNumber: "#146", Title: "Cancelled today PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "45m 0s"},
 			},
 		},
 		{
@@ -739,6 +753,23 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestPipelineNowUsesStageUpdatedAt(t *testing.T) {
+	t.Parallel()
+
+	issueUpdatedAt := time.Date(2026, 5, 31, 10, 0, 0, 0, time.UTC)
+	stageUpdatedAt := time.Date(2026, 6, 1, 12, 30, 0, 0, time.UTC)
+	got := pipelineNow(telemetry.Snapshot{
+		Pipeline: []telemetry.Issue{{
+			ID:             "done",
+			UpdatedAt:      &issueUpdatedAt,
+			StageUpdatedAt: &stageUpdatedAt,
+		}},
+	})
+	if !got.Equal(stageUpdatedAt) {
+		t.Fatalf("pipelineNow() = %v, want %v", got, stageUpdatedAt)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fetch PR pipeline rows for configured terminal states so mapped `Cancelled` / `Canceled` Done rows are visible.
- Carry GitHub Project status field `updatedAt` as stage-entry time while preserving issue `UpdatedAt`.
- Prefer stage-entry timestamps in Done-today lane filtering and fallback clock selection.

Fixes #223

## Test Plan

- [x] `make check`