### PR TITLE
fix(github): order project status columns

### DIFF
--- a/internal/connector/github/adapter_parity_test.go
+++ b/internal/connector/github/adapter_parity_test.go
@@ -15,10 +15,10 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 			body: `{"data":{"node":{"__typename":"ProjectV2","statusField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog","color":"GRAY","description":"Backlog."},{"id":"OPT_ready","name":"Ready","color":"GREEN","description":"Ready."},{"id":"OPT_progress","name":"In Progress","color":"YELLOW","description":"Active."},{"id":"OPT_review","name":"In Review","color":"PURPLE","description":"Review."}]},"priorityField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_priority","options":[{"id":"OPT_medium","name":"Medium","color":"YELLOW","description":"Normal."}]}}}}`,
 		},
 		{
-			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_backlog","name":"Backlog","color":"GRAY","description":"Backlog."},{"id":"OPT_ready","name":"Ready","color":"GREEN","description":"Ready."},{"id":"OPT_progress","name":"In Progress","color":"YELLOW","description":"Active."},{"id":"OPT_review","name":"In Review","color":"PURPLE","description":"Review."},{"name":"Merging","color":"PURPLE","description":"Approved work is being integrated."},{"name":"Rework","color":"ORANGE","description":"Changes are requested before review can continue."},{"name":"Blocked","color":"RED","description":"Cannot continue without human input."},{"name":"Done","color":"GREEN","description":"Work is complete."}]}}}}`,
+			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_backlog","name":"Backlog","color":"GRAY","description":"Backlog."},{"id":"OPT_ready","name":"Ready","color":"GREEN","description":"Ready."},{"id":"OPT_progress","name":"In Progress","color":"YELLOW","description":"Active."},{"name":"Blocked","color":"RED","description":"Cannot continue without human input."},{"id":"OPT_review","name":"In Review","color":"PURPLE","description":"Review."},{"name":"Rework","color":"ORANGE","description":"Changes are requested before review can continue."},{"name":"Merging","color":"PURPLE","description":"Approved work is being integrated."},{"name":"Done","color":"GREEN","description":"Work is complete."}]}}}}`,
 		},
 		{
-			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_medium","name":"Medium","color":"YELLOW","description":"Normal."},{"name":"Urgent","color":"RED","description":"Needs immediate attention."},{"name":"High","color":"ORANGE","description":"Important work to prioritize soon."},{"name":"Low","color":"BLUE","description":"Can wait behind higher-priority work."},{"name":"No priority","color":"GRAY","description":"Priority has not been set."}]}}}}`,
+			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"name":"Urgent","color":"RED","description":"Needs immediate attention."},{"name":"High","color":"ORANGE","description":"Important work to prioritize soon."},{"id":"OPT_medium","name":"Medium","color":"YELLOW","description":"Normal."},{"name":"Low","color":"BLUE","description":"Can wait behind higher-priority work."},{"name":"No priority","color":"GRAY","description":"Priority has not been set."}]}}}}`,
 		},
 		{
 			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_28","content":{"__typename":"Issue","id":"I_kw28","number":28,"title":"Projects-v2 parity gate","body":"Depends on: #26 #27\n<!-- model: gpt-5-codex-high -->","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/28","createdAt":"2026-05-31T04:12:00Z","updatedAt":"2026-05-31T04:30:00Z","assignees":{"nodes":[{"login":"codex"}]},"labels":{"nodes":[{"name":"gate"},{"name":"stage:S4"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"Urgent"}},{"id":"PVTI_29","content":{"__typename":"Issue","id":"I_kw29","number":29,"title":"Human review","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/29","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"In Review"},"priorityValue":{"name":"No priority"}}]}}}}`,
@@ -100,7 +100,7 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 		t.Fatalf("status fieldId = %v, want PVTSSF_status", statusInput["fieldId"])
 	}
 	statusOptions := graphQLOptions(t, statusInput)
-	if got := optionNames(statusOptions); !reflect.DeepEqual(got, []string{"Backlog", "Ready", "In Progress", "In Review", "Merging", "Rework", "Blocked", "Done"}) {
+	if got := optionNames(statusOptions); !reflect.DeepEqual(got, []string{"Backlog", "Ready", "In Progress", "Blocked", "In Review", "Rework", "Merging", "Done"}) {
 		t.Fatalf("status option names = %#v", got)
 	}
 
@@ -109,7 +109,7 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 		t.Fatalf("priority fieldId = %v, want PVTSSF_priority", priorityInput["fieldId"])
 	}
 	priorityOptions := graphQLOptions(t, priorityInput)
-	if got := optionNames(priorityOptions); !reflect.DeepEqual(got, []string{"Medium", "Urgent", "High", "Low", "No priority"}) {
+	if got := optionNames(priorityOptions); !reflect.DeepEqual(got, []string{"Urgent", "High", "Medium", "Low", "No priority"}) {
 		t.Fatalf("priority option names = %#v", got)
 	}
 

--- a/internal/connector/github/provision.go
+++ b/internal/connector/github/provision.go
@@ -56,6 +56,22 @@ var statusOptionDefaultsByState = map[string]projectSingleSelectOption{
 	"Duplicate":    {Color: "GRAY", Description: "Work is tracked elsewhere."},
 }
 
+// GitHub Projects uses single-select option order as kanban column order.
+var defaultStatusOptionOrder = []string{
+	"Backlog",
+	"Todo",
+	"In Progress",
+	"Blocked",
+	"Human Review",
+	"Rework",
+	"Merging",
+	"Done",
+	"Closed",
+	"Cancelled",
+	"Canceled",
+	"Duplicate",
+}
+
 var defaultPriorityOptionsByName = map[string]projectSingleSelectOption{
 	"Urgent":      {Name: "Urgent", Color: "RED", Description: "Needs immediate attention."},
 	"High":        {Name: "High", Color: "ORANGE", Description: "Important work to prioritize soon."},
@@ -84,6 +100,12 @@ type projectSingleSelectOption struct {
 type priorityOptionRequirement struct {
 	Name string
 	Rank *int
+}
+
+type statusOptionRequirement struct {
+	State       string
+	Option      projectSingleSelectOption
+	InputOffset int
 }
 
 type projectOptionsFieldResponse struct {
@@ -201,12 +223,11 @@ func decodeOptionalProjectSingleSelectField(fieldName string, field *projectOpti
 }
 
 func (c *Connector) ensureFieldOptions(ctx context.Context, field projectSingleSelectField, required []projectSingleSelectOption) (bool, error) {
-	missing := missingProjectOptions(field.Options, required)
-	if len(missing) == 0 {
+	options := singleSelectOptionsWithRequiredOrder(field.Options, required)
+	if singleSelectOptionsEqual(field.Options, options) {
 		return false, nil
 	}
 
-	options := singleSelectOptionsWithAppended(field.Options, missing)
 	var response struct {
 		UpdateProjectV2Field *struct {
 			ProjectV2Field *struct {
@@ -231,50 +252,77 @@ func (c *Connector) ensureFieldOptions(ctx context.Context, field projectSingleS
 	return true, nil
 }
 
-func missingProjectOptions(current []projectSingleSelectOption, required []projectSingleSelectOption) []projectSingleSelectOption {
-	currentNames := make(map[string]struct{}, len(current))
-	for _, option := range current {
-		name := strings.TrimSpace(option.Name)
-		if name != "" {
-			currentNames[name] = struct{}{}
-		}
-	}
-
-	missing := make([]projectSingleSelectOption, 0, len(required))
-	for _, option := range required {
-		name := strings.TrimSpace(option.Name)
-		if name == "" {
-			continue
-		}
-		if _, ok := currentNames[name]; ok {
-			continue
-		}
-		currentNames[name] = struct{}{}
-		option.Name = name
-		missing = append(missing, option)
-	}
-	return missing
-}
-
-func singleSelectOptionsWithAppended(current []projectSingleSelectOption, newOptions []projectSingleSelectOption) []projectSingleSelectOption {
-	options := make([]projectSingleSelectOption, 0, len(current)+len(newOptions))
-	currentNames := make(map[string]struct{}, len(current))
+func singleSelectOptionsWithRequiredOrder(current []projectSingleSelectOption, required []projectSingleSelectOption) []projectSingleSelectOption {
+	options := make([]projectSingleSelectOption, 0, len(current)+len(required))
+	currentByName := make(map[string]projectSingleSelectOption, len(current))
+	currentNames := make([]string, 0, len(current))
 	for _, option := range current {
 		input := singleSelectOptionInput(option)
 		if strings.TrimSpace(input.Name) == "" {
 			continue
 		}
-		currentNames[input.Name] = struct{}{}
-		options = append(options, input)
+		if _, ok := currentByName[input.Name]; ok {
+			continue
+		}
+		currentByName[input.Name] = input
+		currentNames = append(currentNames, input.Name)
 	}
-	for _, option := range newOptions {
+
+	seen := make(map[string]struct{}, len(required))
+	for _, option := range required {
 		input := singleSelectOptionInput(option)
-		if _, ok := currentNames[input.Name]; ok {
+		if input.Name == "" {
+			continue
+		}
+		if _, ok := seen[input.Name]; ok {
+			continue
+		}
+		seen[input.Name] = struct{}{}
+		if existing, ok := currentByName[input.Name]; ok {
+			options = append(options, existing)
 			continue
 		}
 		options = append(options, input)
 	}
+
+	for _, name := range currentNames {
+		if _, ok := seen[name]; ok {
+			continue
+		}
+		options = append(options, currentByName[name])
+	}
 	return options
+}
+
+func singleSelectOptionsEqual(current []projectSingleSelectOption, want []projectSingleSelectOption) bool {
+	current = normalizedSingleSelectOptions(current)
+	want = normalizedSingleSelectOptions(want)
+	if len(current) != len(want) {
+		return false
+	}
+	for i := range current {
+		if current[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func normalizedSingleSelectOptions(options []projectSingleSelectOption) []projectSingleSelectOption {
+	normalized := make([]projectSingleSelectOption, 0, len(options))
+	seen := make(map[string]struct{}, len(options))
+	for _, option := range options {
+		input := singleSelectOptionInput(option)
+		if input.Name == "" {
+			continue
+		}
+		if _, ok := seen[input.Name]; ok {
+			continue
+		}
+		seen[input.Name] = struct{}{}
+		normalized = append(normalized, input)
+	}
+	return normalized
 }
 
 func singleSelectOptionInput(option projectSingleSelectOption) projectSingleSelectOption {
@@ -289,14 +337,9 @@ func singleSelectOptionInput(option projectSingleSelectOption) projectSingleSele
 }
 
 func (c *Connector) requiredStatusOptions() []projectSingleSelectOption {
-	states := make([]string, 0, len(c.activeStates)+len(c.observedStates)+len(c.terminalStates))
-	states = append(states, c.activeStates...)
-	states = append(states, c.observedStates...)
-	states = append(states, c.terminalStates...)
-
-	options := make([]projectSingleSelectOption, 0, len(states))
+	requirements := make([]statusOptionRequirement, 0, len(c.activeStates)+len(c.observedStates)+len(c.terminalStates))
 	seen := map[string]struct{}{}
-	for _, state := range states {
+	for index, state := range appendStatusStates(nil, c.activeStates, c.observedStates, c.terminalStates) {
 		state = strings.TrimSpace(state)
 		if state == "" {
 			continue
@@ -312,9 +355,50 @@ func (c *Connector) requiredStatusOptions() []projectSingleSelectOption {
 
 		option := statusOptionDefaults(state)
 		option.Name = githubState
-		options = append(options, option)
+		requirements = append(requirements, statusOptionRequirement{
+			State:       state,
+			Option:      option,
+			InputOffset: index,
+		})
+	}
+	sort.SliceStable(requirements, func(i, j int) bool {
+		leftRank := statusOptionSortRank(requirements[i])
+		rightRank := statusOptionSortRank(requirements[j])
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return requirements[i].InputOffset < requirements[j].InputOffset
+	})
+
+	options := make([]projectSingleSelectOption, 0, len(requirements))
+	for _, requirement := range requirements {
+		options = append(options, requirement.Option)
 	}
 	return options
+}
+
+func appendStatusStates(out []string, groups ...[]string) []string {
+	for _, group := range groups {
+		out = append(out, group...)
+	}
+	return out
+}
+
+func statusOptionSortRank(requirement statusOptionRequirement) int {
+	if rank, ok := statusOptionOrderRank(requirement.State); ok {
+		return rank
+	}
+	return len(defaultStatusOptionOrder) + requirement.InputOffset
+}
+
+func statusOptionOrderRank(state string) (int, bool) {
+	state = normalizeStateName(state)
+	for rank, orderedState := range defaultStatusOptionOrder {
+		if normalizeStateName(orderedState) == state {
+			return rank, true
+		}
+	}
+	return 0, false
 }
 
 func statusOptionDefaults(state string) projectSingleSelectOption {

--- a/internal/connector/github/provision_test.go
+++ b/internal/connector/github/provision_test.go
@@ -18,10 +18,10 @@ func TestConnectorEnsureStateOptionsCreatesMissingStatusAndPriorityOptions(t *te
 			body: `{"data":{"node":{"__typename":"ProjectV2","statusField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_status","options":[{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"}]},"priorityField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_priority","options":[{"id":"OPT_none","name":"No priority","color":"GRAY","description":"Existing none"}]}}}}`,
 		},
 		{
-			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"},{"id":"OPT_rework","name":"Rework","color":"ORANGE","description":"Changes are requested before review can continue."}]}}}}`,
+			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"},{"name":"Blocked","color":"RED","description":"Cannot continue without human input."},{"name":"Reviewing","color":"PURPLE","description":"Waiting for human review."},{"name":"Rework","color":"ORANGE","description":"Changes are requested before review can continue."},{"name":"Done","color":"GREEN","description":"Work is complete."}]}}}}`,
 		},
 		{
-			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_none","name":"No priority","color":"GRAY","description":"Existing none"},{"id":"OPT_p0","name":"P0","color":"RED","description":"Detent priority rank 1."}]}}}}`,
+			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_p0","name":"P0","color":"RED","description":"Detent priority rank 1."},{"id":"OPT_none","name":"No priority","color":"GRAY","description":"Existing none"}]}}}}`,
 		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
@@ -59,7 +59,7 @@ func TestConnectorEnsureStateOptionsCreatesMissingStatusAndPriorityOptions(t *te
 		t.Fatalf("status fieldId = %v, want PVTSSF_status", statusInput["fieldId"])
 	}
 	statusOptions := graphQLOptions(t, statusInput)
-	if got := optionNames(statusOptions); !reflect.DeepEqual(got, []string{"Todo", "Rework", "Reviewing", "Blocked", "Done"}) {
+	if got := optionNames(statusOptions); !reflect.DeepEqual(got, []string{"Todo", "Blocked", "Reviewing", "Rework", "Done"}) {
 		t.Fatalf("status option names = %#v", got)
 	}
 	if statusOptions[0]["id"] != "OPT_todo" {
@@ -71,20 +71,65 @@ func TestConnectorEnsureStateOptionsCreatesMissingStatusAndPriorityOptions(t *te
 	if _, ok := statusOptions[1]["id"]; ok {
 		t.Fatalf("new status option has id = %v, want no id", statusOptions[1]["id"])
 	}
+	if statusOptions[2]["description"] != "Waiting for human review." {
+		t.Fatalf("mapped human review description = %v, want Waiting for human review.", statusOptions[2]["description"])
+	}
 
 	priorityInput := graphQLInput(t, requests[2])
 	if priorityInput["fieldId"] != "PVTSSF_priority" {
 		t.Fatalf("priority fieldId = %v, want PVTSSF_priority", priorityInput["fieldId"])
 	}
 	priorityOptions := graphQLOptions(t, priorityInput)
-	if got := optionNames(priorityOptions); !reflect.DeepEqual(got, []string{"No priority", "P0"}) {
+	if got := optionNames(priorityOptions); !reflect.DeepEqual(got, []string{"P0", "No priority"}) {
 		t.Fatalf("priority option names = %#v", got)
 	}
-	if priorityOptions[0]["id"] != "OPT_none" {
-		t.Fatalf("existing priority id = %v, want OPT_none", priorityOptions[0]["id"])
+	if _, ok := priorityOptions[0]["id"]; ok {
+		t.Fatalf("new priority option has id = %v, want no id", priorityOptions[0]["id"])
 	}
-	if priorityOptions[1]["color"] != "RED" {
-		t.Fatalf("P0 color = %v, want RED", priorityOptions[1]["color"])
+	if priorityOptions[0]["color"] != "RED" {
+		t.Fatalf("P0 color = %v, want RED", priorityOptions[0]["color"])
+	}
+	if priorityOptions[1]["id"] != "OPT_none" {
+		t.Fatalf("existing priority id = %v, want OPT_none", priorityOptions[1]["id"])
+	}
+}
+
+func TestConnectorEnsureStateOptionsReordersExistingOptions(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"__typename":"ProjectV2","statusField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_status","options":[{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"},{"id":"OPT_progress","name":"In Progress","color":"YELLOW","description":"Existing progress"},{"id":"OPT_backlog","name":"Backlog","color":"GRAY","description":"Existing backlog"},{"id":"OPT_done","name":"Done","color":"GREEN","description":"Existing done"},{"id":"OPT_custom","name":"Parked","color":"BLUE","description":"Custom lane"}]},"priorityField":null}}}`,
+		},
+		{
+			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_backlog","name":"Backlog","color":"GRAY","description":"Existing backlog"},{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"},{"id":"OPT_progress","name":"In Progress","color":"YELLOW","description":"Existing progress"},{"id":"OPT_done","name":"Done","color":"GREEN","description":"Existing done"},{"id":"OPT_custom","name":"Parked","color":"BLUE","description":"Custom lane"}]}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:    "PVT_1",
+		ActiveStates:   []string{"Todo", "In Progress"},
+		ObservedStates: []string{"Backlog"},
+		TerminalStates: []string{"Done"},
+	})
+
+	if err := c.EnsureStateOptions(context.Background()); err != nil {
+		t.Fatalf("EnsureStateOptions() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	input := graphQLInput(t, requests[1])
+	statusOptions := graphQLOptions(t, input)
+	if got := optionNames(statusOptions); !reflect.DeepEqual(got, []string{"Backlog", "Todo", "In Progress", "Done", "Parked"}) {
+		t.Fatalf("status option names = %#v", got)
+	}
+	if statusOptions[0]["id"] != "OPT_backlog" || statusOptions[1]["id"] != "OPT_todo" || statusOptions[2]["id"] != "OPT_progress" {
+		t.Fatalf("existing status ids were not preserved: %#v", statusOptions)
+	}
+	if statusOptions[4]["id"] != "OPT_custom" {
+		t.Fatalf("extra status id = %v, want OPT_custom", statusOptions[4]["id"])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Order GitHub ProjectV2 Status options by Detent's canonical board flow so kanban columns provision in the expected sequence.
- Rebuild single-select update payloads with required options first, preserving existing option IDs/metadata and appending custom extras.
- Keep Priority provisioning ordered by configured rank while preserving existing option metadata.

Fixes: N/A

## Test Plan

- [x] `go test ./internal/connector/github`
- [x] `go test ./...`