### PR TITLE
fix(github): default blank project statuses to backlog

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -14,10 +14,11 @@ import (
 )
 
 const (
-	projectItemsPageSize  = 50
-	projectItemsPerIssue  = 100
-	pullRequestsPageSize  = 100
-	pullRequestsPageLimit = 3
+	projectItemsPageSize          = 50
+	projectItemsPerIssue          = 100
+	pullRequestsPageSize          = 100
+	pullRequestsPageLimit         = 3
+	defaultProjectItemStatusState = "Backlog"
 )
 
 const projectItemsQuery = `
@@ -591,6 +592,10 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 	}
 
 	githubState := c.detentToGitHubState(stateName)
+	return c.setProjectItemStatus(ctx, item.ID, githubState)
+}
+
+func (c *Connector) setProjectItemStatus(ctx context.Context, itemID string, githubState string) error {
 	fieldID, optionID, err := c.resolveStatusOption(ctx, githubState)
 	if err != nil {
 		if errors.Is(err, ErrStatusOptionNotFound) {
@@ -599,7 +604,7 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 		return err
 	}
 
-	if err := c.updateStatusFieldValue(ctx, item.ID, fieldID, optionID); err == nil {
+	if err := c.updateStatusFieldValue(ctx, itemID, fieldID, optionID); err == nil {
 		return nil
 	}
 
@@ -608,7 +613,7 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 	if err != nil {
 		return err
 	}
-	return c.updateStatusFieldValue(ctx, item.ID, fieldID, optionID)
+	return c.updateStatusFieldValue(ctx, itemID, fieldID, optionID)
 }
 
 func (c *Connector) SetAssignee(ctx context.Context, issueID string, login string) error {
@@ -807,7 +812,10 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 		}
 
 		for _, item := range response.Node.Items.Nodes {
-			issue, ok := c.normalizeProjectItem(item)
+			issue, ok, err := c.normalizeProjectItem(ctx, item)
+			if err != nil {
+				return nil, err
+			}
 			if !ok {
 				continue
 			}
@@ -832,17 +840,42 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 	}
 }
 
-func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, bool) {
+func (c *Connector) normalizeProjectItem(ctx context.Context, item projectItemNode) (connector.Issue, bool, error) {
 	if item.Content == nil || item.Content.TypeName != "Issue" {
-		return connector.Issue{}, false
+		return connector.Issue{}, false, nil
+	}
+	statusName, statusUpdatedAt, err := c.projectItemStatusOrDefault(ctx, item)
+	if err != nil {
+		return connector.Issue{}, false, err
 	}
 	return c.buildIssue(
 		*item.Content,
-		singleSelectName(item.StatusValue),
+		statusName,
 		singleSelectName(item.PriorityValue),
-		singleSelectUpdatedAt(item.StatusValue),
+		statusUpdatedAt,
 		projectFieldValues(item.FieldValues),
-	), true
+	), true, nil
+}
+
+func (c *Connector) projectItemStatusOrDefault(ctx context.Context, item projectItemNode) (string, *time.Time, error) {
+	statusName := singleSelectName(item.StatusValue)
+	if statusName != "" {
+		return statusName, singleSelectUpdatedAt(item.StatusValue), nil
+	}
+
+	itemID := strings.TrimSpace(item.ID)
+	if itemID == "" {
+		return "", nil, ErrInvalidResponse
+	}
+
+	statusName = c.detentToGitHubState(defaultProjectItemStatusState)
+	if statusName == "" {
+		return "", nil, nil
+	}
+	if err := c.setProjectItemStatus(ctx, itemID, statusName); err != nil {
+		return "", nil, fmt.Errorf("default github status: %w", err)
+	}
+	return statusName, nil, nil
 }
 
 func resolveBlockedByProjectState(issues []connector.Issue) {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -185,6 +185,50 @@ func TestConnectorFetchCandidateIssuesRequestsRateLimitSnapshot(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesToBacklog(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null},{"id":"PVTI_todo","content":{"__typename":"Issue","id":"I_todo","number":31,"title":"Ready status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/31","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_todo","name":"Todo"}]}}}}`,
+		},
+		{
+			body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_blank"}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:    "PVT_1",
+		ActiveStates:   []string{"Todo"},
+		ObservedStates: []string{"Backlog"},
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Backlog"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	if got[0].ID != "I_blank" || got[0].State != "Backlog" {
+		t.Fatalf("defaulted issue = %#v, want blank issue in Backlog", got[0])
+	}
+
+	requests := server.requests()
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
+	}
+	updateVariables := requestVariables(t, requests[2])
+	if updateVariables["projectId"] != "PVT_1" ||
+		updateVariables["itemId"] != "PVTI_blank" ||
+		updateVariables["fieldId"] != "PVTSSF_status" ||
+		updateVariables["optionId"] != "OPT_backlog" {
+		t.Fatalf("update variables = %#v, want blank item moved to Backlog", updateVariables)
+	}
+}
+
 func TestConnectorFetchCandidateIssuesResolvesBlockedByProjectState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/provision.go
+++ b/internal/connector/github/provision.go
@@ -349,9 +349,9 @@ func singleSelectOptionInput(option projectSingleSelectOption) projectSingleSele
 }
 
 func (c *Connector) requiredStatusOptions() []projectSingleSelectOption {
-	requirements := make([]statusOptionRequirement, 0, len(c.activeStates)+len(c.observedStates)+len(c.terminalStates))
+	requirements := make([]statusOptionRequirement, 0, len(c.activeStates)+len(c.observedStates)+len(c.terminalStates)+1)
 	seen := map[string]struct{}{}
-	for index, state := range appendStatusStates(nil, c.activeStates, c.observedStates, c.terminalStates) {
+	for index, state := range appendStatusStates(nil, c.activeStates, c.observedStates, c.terminalStates, []string{defaultProjectItemStatusState}) {
 		state = strings.TrimSpace(state)
 		if state == "" {
 			continue

--- a/internal/connector/github/provision_test.go
+++ b/internal/connector/github/provision_test.go
@@ -18,7 +18,7 @@ func TestConnectorEnsureStateOptionsCreatesMissingStatusAndPriorityOptions(t *te
 			body: `{"data":{"node":{"__typename":"ProjectV2","statusField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_status","options":[{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"}]},"priorityField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_priority","options":[{"id":"OPT_none","name":"No priority","color":"GRAY","description":"Existing none"}]}}}}`,
 		},
 		{
-			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"},{"name":"Blocked","color":"RED","description":"Cannot continue without human input."},{"name":"Reviewing","color":"PURPLE","description":"Waiting for human review."},{"name":"Rework","color":"ORANGE","description":"Changes are requested before review can continue."},{"name":"Done","color":"GREEN","description":"Work is complete."}]}}}}`,
+			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_todo","name":"Todo","color":"GREEN","description":"Existing todo"},{"name":"Blocked","color":"RED","description":"Cannot continue without human input."},{"name":"Reviewing","color":"PURPLE","description":"Waiting for human review."},{"name":"Rework","color":"ORANGE","description":"Changes are requested before review can continue."},{"name":"Done","color":"GREEN","description":"Work is complete."},{"name":"Backlog","color":"GRAY","description":"Not ready for Detent dispatch."}]}}}}`,
 		},
 		{
 			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"id":"OPT_p0","name":"P0","color":"RED","description":"Detent priority rank 1."},{"id":"OPT_none","name":"No priority","color":"GRAY","description":"Existing none"}]}}}}`,
@@ -59,20 +59,20 @@ func TestConnectorEnsureStateOptionsCreatesMissingStatusAndPriorityOptions(t *te
 		t.Fatalf("status fieldId = %v, want PVTSSF_status", statusInput["fieldId"])
 	}
 	statusOptions := graphQLOptions(t, statusInput)
-	if got := optionNames(statusOptions); !reflect.DeepEqual(got, []string{"Todo", "Blocked", "Reviewing", "Rework", "Done"}) {
+	if got := optionNames(statusOptions); !reflect.DeepEqual(got, []string{"Backlog", "Todo", "Blocked", "Reviewing", "Rework", "Done"}) {
 		t.Fatalf("status option names = %#v", got)
 	}
-	if statusOptions[0]["id"] != "OPT_todo" {
-		t.Fatalf("existing status id = %v, want OPT_todo", statusOptions[0]["id"])
+	if statusOptions[1]["id"] != "OPT_todo" {
+		t.Fatalf("existing status id = %v, want OPT_todo", statusOptions[1]["id"])
 	}
-	if statusOptions[0]["color"] != "GREEN" {
-		t.Fatalf("existing status color = %v, want GREEN", statusOptions[0]["color"])
+	if statusOptions[1]["color"] != "GREEN" {
+		t.Fatalf("existing status color = %v, want GREEN", statusOptions[1]["color"])
 	}
-	if _, ok := statusOptions[1]["id"]; ok {
-		t.Fatalf("new status option has id = %v, want no id", statusOptions[1]["id"])
+	if _, ok := statusOptions[0]["id"]; ok {
+		t.Fatalf("new status option has id = %v, want no id", statusOptions[0]["id"])
 	}
-	if statusOptions[2]["description"] != "Waiting for human review." {
-		t.Fatalf("mapped human review description = %v, want Waiting for human review.", statusOptions[2]["description"])
+	if statusOptions[3]["description"] != "Waiting for human review." {
+		t.Fatalf("mapped human review description = %v, want Waiting for human review.", statusOptions[3]["description"])
 	}
 
 	priorityInput := graphQLInput(t, requests[2])
@@ -137,7 +137,7 @@ func TestConnectorEnsureStateOptionsNoopsWhenOptionsPresent(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"node":{"__typename":"ProjectV2","statusField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_status","options":[{"id":"OPT_todo","name":"Todo","color":"GRAY","description":""},{"id":"OPT_done","name":"Done","color":"GREEN","description":""}]},"priorityField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_priority","options":[{"id":"OPT_high","name":"High","color":"ORANGE","description":""},{"id":"OPT_none","name":"No priority","color":"GRAY","description":""}]}}}}`,
+		body: `{"data":{"node":{"__typename":"ProjectV2","statusField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog","color":"GRAY","description":""},{"id":"OPT_todo","name":"Todo","color":"GRAY","description":""},{"id":"OPT_done","name":"Done","color":"GREEN","description":""}]},"priorityField":{"__typename":"ProjectV2SingleSelectField","id":"PVTSSF_priority","options":[{"id":"OPT_high","name":"High","color":"ORANGE","description":""},{"id":"OPT_none","name":"No priority","color":"GRAY","description":""}]}}}}`,
 	}})
 	c := newGitHubTestConnector(t, server, Config{
 		ProjectSlug:    "PVT_1",


### PR DESCRIPTION
## Summary

- Default GitHub ProjectV2 issue items with blank Status to `Backlog` during the full project scan before candidate filtering.
- Reuse the existing Status update/cache retry path so defaulting behaves like normal Detent status transitions.
- Always provision the `Backlog` Status option so defaulting works even if workflows omit it from configured states.

Fixes: N/A

## Test Plan

- [x] `go test ./internal/connector/github`
- [x] `go test ./...`