### PR TITLE
feat(selector): add issue predicate engine

### DIFF
--- a/internal/selector/match.go
+++ b/internal/selector/match.go
@@ -1,0 +1,196 @@
+package selector
+
+import (
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const meToken = "@me"
+
+type Context struct {
+	InstanceLogin string
+	Persona       string
+}
+
+type Selector struct {
+	AssigneeIn []string
+	AuthorIn   []string
+	Labels     Labels
+	Fields     []FieldEquals
+	And        []Selector
+	Or         []Selector
+}
+
+type Labels struct {
+	Include []string
+	Exclude []string
+}
+
+type FieldEquals struct {
+	Name  string
+	Value string
+}
+
+func Match(issue connector.Issue, selector Selector, ctx Context) bool {
+	if !matchIdentityList(issueAssignees(issue), selector.AssigneeIn, ctx) {
+		return false
+	}
+	if !matchIdentityList([]string{issue.AuthorID}, selector.AuthorIn, ctx) {
+		return false
+	}
+	if !matchLabels(issue.Labels, selector.Labels) {
+		return false
+	}
+	if !matchFields(issue.Fields, selector.Fields, ctx) {
+		return false
+	}
+	for _, child := range selector.And {
+		if !Match(issue, child, ctx) {
+			return false
+		}
+	}
+	if len(selector.Or) > 0 {
+		for _, child := range selector.Or {
+			if Match(issue, child, ctx) {
+				return true
+			}
+		}
+		return false
+	}
+	return true
+}
+
+func issueAssignees(issue connector.Issue) []string {
+	assignees := append([]string(nil), issue.Assignees...)
+	if strings.TrimSpace(issue.AssigneeID) != "" {
+		assignees = append(assignees, issue.AssigneeID)
+	}
+	return assignees
+}
+
+func matchIdentityList(values, allowed []string, ctx Context) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+
+	present := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = normalizeIdentity(value)
+		if value == "" {
+			continue
+		}
+		present[value] = struct{}{}
+	}
+
+	for _, allowedValue := range allowed {
+		for _, resolved := range resolveValue(allowedValue, ctx) {
+			if _, ok := present[normalizeIdentity(resolved)]; ok {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func matchLabels(issueLabels []string, labels Labels) bool {
+	present := make(map[string]struct{}, len(issueLabels))
+	for _, label := range issueLabels {
+		label = normalizeLabel(label)
+		if label == "" {
+			continue
+		}
+		present[label] = struct{}{}
+	}
+
+	for _, label := range labels.Include {
+		if _, ok := present[normalizeLabel(label)]; !ok {
+			return false
+		}
+	}
+	for _, label := range labels.Exclude {
+		if _, ok := present[normalizeLabel(label)]; ok {
+			return false
+		}
+	}
+	return true
+}
+
+func matchFields(fields map[string]string, rules []FieldEquals, ctx Context) bool {
+	for _, rule := range rules {
+		value, ok := fieldValue(fields, rule.Name)
+		if !ok {
+			return false
+		}
+		if !matchFieldValue(value, rule.Value, ctx) {
+			return false
+		}
+	}
+	return true
+}
+
+func fieldValue(fields map[string]string, name string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	if value, ok := fields[name]; ok {
+		return value, true
+	}
+	for fieldName, value := range fields {
+		if strings.TrimSpace(fieldName) == name {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func matchFieldValue(value, expected string, ctx Context) bool {
+	if isMeToken(expected) {
+		value = normalizeIdentity(value)
+		for _, resolved := range resolveMe(ctx) {
+			if value == normalizeIdentity(resolved) {
+				return true
+			}
+		}
+		return false
+	}
+	return strings.TrimSpace(value) == strings.TrimSpace(expected)
+}
+
+func resolveValue(value string, ctx Context) []string {
+	if isMeToken(value) {
+		return resolveMe(ctx)
+	}
+	return []string{value}
+}
+
+func resolveMe(ctx Context) []string {
+	values := []string{ctx.InstanceLogin, ctx.Persona}
+	resolved := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		normalized := normalizeIdentity(value)
+		if normalized == "" {
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			continue
+		}
+		seen[normalized] = struct{}{}
+		resolved = append(resolved, value)
+	}
+	return resolved
+}
+
+func isMeToken(value string) bool {
+	return strings.EqualFold(strings.TrimSpace(value), meToken)
+}
+
+func normalizeIdentity(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func normalizeLabel(label string) string {
+	return strings.ToLower(strings.TrimSpace(label))
+}

--- a/internal/selector/match_test.go
+++ b/internal/selector/match_test.go
@@ -1,0 +1,212 @@
+package selector
+
+import (
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestMatch(t *testing.T) {
+	t.Parallel()
+
+	issue := connector.Issue{
+		AuthorID:   "corylanou",
+		AssigneeID: "worker-1",
+		Assignees:  []string{"worker-1", "worker-2"},
+		Labels:     []string{"Enhancement", "stage:s2"},
+		Fields: map[string]string{
+			"Status": "Todo",
+			"Track":  "multi-instance",
+		},
+	}
+	ctx := Context{
+		InstanceLogin: "worker-2",
+		Persona:       "persona-reviewer",
+	}
+
+	tests := []struct {
+		name     string
+		issue    *connector.Issue
+		ctx      *Context
+		selector Selector
+		want     bool
+	}{
+		{
+			name: "assignee in matches any assigned login",
+			selector: Selector{
+				AssigneeIn: []string{"worker-2"},
+			},
+			want: true,
+		},
+		{
+			name: "assignee in misses unassigned login",
+			selector: Selector{
+				AssigneeIn: []string{"worker-3"},
+			},
+			want: false,
+		},
+		{
+			name: "assignee in matches legacy assignee id",
+			issue: &connector.Issue{
+				AssigneeID: "worker-legacy",
+				Labels:     []string{},
+				Fields:     map[string]string{},
+			},
+			selector: Selector{
+				AssigneeIn: []string{"worker-legacy"},
+			},
+			want: true,
+		},
+		{
+			name: "author in matches author login",
+			selector: Selector{
+				AuthorIn: []string{"corylanou"},
+			},
+			want: true,
+		},
+		{
+			name: "label include requires every requested label",
+			selector: Selector{
+				Labels: Labels{
+					Include: []string{"enhancement", "stage:s2"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "label include misses absent label",
+			selector: Selector{
+				Labels: Labels{
+					Include: []string{"bug"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "label exclude rejects present label",
+			selector: Selector{
+				Labels: Labels{
+					Exclude: []string{"enhancement"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "label exclude allows absent label",
+			selector: Selector{
+				Labels: Labels{
+					Exclude: []string{"bug"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "field equals matches configured project field",
+			selector: Selector{
+				Fields: []FieldEquals{
+					{Name: "Track", Value: "multi-instance"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "field equals misses different project field value",
+			selector: Selector{
+				Fields: []FieldEquals{
+					{Name: "Status", Value: "In Progress"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "and group requires every child selector",
+			selector: Selector{
+				And: []Selector{
+					{AuthorIn: []string{"corylanou"}},
+					{Labels: Labels{Include: []string{"stage:s2"}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "and group rejects false child selector",
+			selector: Selector{
+				And: []Selector{
+					{AuthorIn: []string{"corylanou"}},
+					{Labels: Labels{Include: []string{"bug"}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "or group matches any child selector",
+			selector: Selector{
+				Or: []Selector{
+					{Labels: Labels{Include: []string{"bug"}}},
+					{Fields: []FieldEquals{{Name: "Status", Value: "Todo"}}},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "or group rejects when no child selector matches",
+			selector: Selector{
+				Or: []Selector{
+					{Labels: Labels{Include: []string{"bug"}}},
+					{Fields: []FieldEquals{{Name: "Status", Value: "Done"}}},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "at me matches instance login",
+			selector: Selector{
+				AssigneeIn: []string{"@me"},
+			},
+			want: true,
+		},
+		{
+			name: "at me misses when neither identity matches author",
+			selector: Selector{
+				AuthorIn: []string{"@me"},
+			},
+			want: false,
+		},
+		{
+			name: "at me matches configured persona",
+			issue: &connector.Issue{
+				AuthorID:  "persona-reviewer",
+				Labels:    []string{},
+				Fields:    map[string]string{},
+				Assignees: []string{},
+			},
+			selector: Selector{
+				AuthorIn: []string{"@me"},
+			},
+			want: true,
+		},
+		{
+			name: "empty selector matches",
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			testIssue := issue
+			if tt.issue != nil {
+				testIssue = *tt.issue
+			}
+			testCtx := ctx
+			if tt.ctx != nil {
+				testCtx = *tt.ctx
+			}
+
+			if got := Match(testIssue, tt.selector, testCtx); got != tt.want {
+				t.Fatalf("Match() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Add internal/selector as a pure predicate engine for connector issues.
- Support assignee, author, label include/exclude, field equality, AND/OR groups, and @me identity resolution.

Fixes #251

## Test Plan

- [x] `go test ./internal/selector`
- [x] `make check`