### PR TITLE
feat(config): add instance authorization schema

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -377,7 +377,12 @@ func globalConfigFromWorkflow(globalPath string, workflowPath string) (globalcon
 	if err != nil {
 		return globalconfig.Config{}, err
 	}
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		return globalconfig.Config{}, err
+	}
 
+	cfg.Global.Identity = workflow.Config.Identity
 	workdir := filepath.Dir(workflowPath)
 	cfg.Projects = []globalconfig.Project{
 		{

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
@@ -419,12 +420,12 @@ func TestAddProjectWritesConfigAndSignalsManager(t *testing.T) {
 		Paused:        true,
 		CredentialRef: "github-default",
 	}
-	if got != want {
+	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("project = %#v, want %#v", got, want)
 	}
 
 	signal := <-signals
-	if signal.Operation != cli.OperationAddProject || signal.Project != want {
+	if signal.Operation != cli.OperationAddProject || !reflect.DeepEqual(signal.Project, want) {
 		t.Fatalf("signal = %#v, want add project %#v", signal, want)
 	}
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -113,6 +113,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	if global != nil {
 		boot.Global = *global
 		boot.Host, boot.Port = bootServer(cfg.Host, cfg.Port, firstGlobalWorkflowPath(*global))
+		report.Add(checkDoctorInstanceIdentity(*global))
 		report.Checks = append(report.Checks, checkDoctorProjects(ctx, *global, deps)...)
 	} else {
 		report.Add(doctorCheck{
@@ -278,7 +279,7 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 		checks = append(checks, doctorCheck{
 			Name:   "Project " + id + " workflow",
 			Status: doctorOK,
-			Detail: project.Workflow + " is valid",
+			Detail: doctorWorkflowDetail(project.Workflow, project, workflow.Config),
 		})
 
 		sourceRoot := projectSourceRoot(project, workflow.Config)
@@ -318,6 +319,57 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	}
 
 	return checks
+}
+
+func checkDoctorInstanceIdentity(cfg globalconfig.Config) doctorCheck {
+	return doctorCheck{
+		Name:   "Instance identity",
+		Status: doctorOK,
+		Detail: doctorIdentityDetail(cfg.Global.Identity),
+	}
+}
+
+func doctorWorkflowDetail(path string, project globalconfig.Project, cfg workflowconfig.Config) string {
+	details := []string{path + " is valid"}
+	if cfg.Identity.Configured() {
+		details = append(details, "identity "+doctorIdentityDetail(cfg.Identity))
+	}
+	details = append(details, doctorAuthorizationDetail(project, cfg))
+	return strings.Join(details, "; ")
+}
+
+func doctorIdentityDetail(identity workflowconfig.Identity) string {
+	identity.Normalize()
+	if !identity.Configured() {
+		return "not configured; ownership defaults to assignee"
+	}
+
+	details := []string{identity.Name}
+	if identity.GitHubLogin != "" {
+		details = append(details, "github_login "+identity.GitHubLogin)
+	}
+	switch identity.OwnershipMode {
+	case workflowconfig.IdentityOwnershipField:
+		details = append(details, "owner field "+identity.OwnerField)
+	default:
+		details = append(details, "owner "+identity.OwnershipMode)
+	}
+	return strings.Join(details, ", ")
+}
+
+func doctorAuthorizationDetail(project globalconfig.Project, cfg workflowconfig.Config) string {
+	projectAuthorization := project.Authorization.Configured()
+	workflowAuthorization := cfg.Tracker.Authorization.Configured()
+	switch {
+	case projectAuthorization && workflowAuthorization:
+		return "authorization selectors from global.yaml and WORKFLOW.md"
+	case projectAuthorization:
+		return "authorization selector from global.yaml"
+	case workflowAuthorization:
+		return "authorization selector from WORKFLOW.md"
+	default:
+		return "authorization allows all issues"
+	}
 }
 
 func projectSourceRoot(project globalconfig.Project, cfg workflowconfig.Config) string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -12,6 +12,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/selector"
 )
 
 func TestCheckDoctorBinary(t *testing.T) {
@@ -174,6 +175,81 @@ func TestProjectSourceRootPrefersProjectWorkdirBeforeWorkspaceRoot(t *testing.T)
 	cfg.Workspace.SourceRoot = "/configured-source"
 	if got := projectSourceRoot(project, cfg); got != "/configured-source" {
 		t.Fatalf("projectSourceRoot() with source_root = %q, want /configured-source", got)
+	}
+}
+
+func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
+	t.Parallel()
+
+	cfg := validDoctorWorkflow("/repo")
+	cfg.Identity = workflowconfig.Identity{
+		Name:          "release-captain",
+		GitHubLogin:   "detent-bot",
+		OwnershipMode: workflowconfig.IdentityOwnershipField,
+		OwnerField:    "Owner",
+	}
+	cfg.Tracker.Authorization = selector.Selector{
+		AssigneeIn: []string{"@me"},
+	}
+	project := globalconfig.Project{
+		Authorization: selector.Selector{
+			Labels: selector.Labels{Include: []string{"release"}},
+		},
+	}
+
+	got := doctorWorkflowDetail("WORKFLOW.md", project, cfg)
+	for _, want := range []string{
+		"WORKFLOW.md is valid",
+		"identity release-captain",
+		"authorization selectors from global.yaml and WORKFLOW.md",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctorWorkflowDetail() = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestCheckDoctorInstanceIdentity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		identity   globalconfig.Identity
+		want       doctorStatus
+		wantDetail string
+	}{
+		{
+			name:       "omitted identity is valid",
+			want:       doctorOK,
+			wantDetail: "not configured",
+		},
+		{
+			name: "configured identity",
+			identity: globalconfig.Identity{
+				Name:          "release-captain",
+				GitHubLogin:   "detent-bot",
+				OwnershipMode: "field",
+				OwnerField:    "Owner",
+			},
+			want:       doctorOK,
+			wantDetail: "release-captain",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := checkDoctorInstanceIdentity(globalconfig.Config{
+				Global: globalconfig.Settings{Identity: tt.identity},
+			})
+			if got.Status != tt.want {
+				t.Fatalf("Status = %s, want %s", got.Status, tt.want)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+		})
 	}
 }
 

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -149,6 +149,9 @@ func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Set
 	if previous.Scheduling != next.Scheduling {
 		fields = append(fields, "global.scheduling")
 	}
+	if !reflect.DeepEqual(previous.Identity, next.Identity) {
+		fields = append(fields, "global.identity")
+	}
 	if !reflect.DeepEqual(previous.FairShare, next.FairShare) {
 		fields = append(fields, "global.fair_share")
 	}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -48,6 +48,10 @@ func withRunnerFactory(
 		if err != nil {
 			return nil, fmt.Errorf("load project workflow %s: %w", cfg.ID, err)
 		}
+		if cfg.Identity.Configured() {
+			workflow.Config.Identity = cfg.Identity
+			workflow.Config.Identity.Normalize()
+		}
 
 		run, err := buildRunner(workflow, cfg.ID, cfg.Workdir, sessionStore, deps.Logger)
 		if err != nil {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,9 @@ const (
 	AgentBackendCodex     = "codex"
 
 	defaultCodexProtocol = "app-server"
+
+	IdentityOwnershipAssignee = "assignee"
+	IdentityOwnershipField    = "field"
 )
 
 var windowsAbsPathPattern = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
@@ -39,6 +42,7 @@ type Workflow struct {
 }
 
 type Config struct {
+	Identity      Identity      `yaml:"identity,omitempty"`
 	Tracker       Tracker       `yaml:"tracker"`
 	Polling       Polling       `yaml:"polling"`
 	Workspace     Workspace     `yaml:"workspace"`
@@ -71,7 +75,15 @@ type Tracker struct {
 	StateMap                StringOrMap       `yaml:"state_map"`
 	PriorityMap             StringOrMap       `yaml:"priority_map"`
 	AutoProvision           bool              `yaml:"auto_provision"`
+	Authorization           selector.Selector `yaml:"authorization,omitempty"`
 	Issues                  []connector.Issue `yaml:"issues"`
+}
+
+type Identity struct {
+	Name          string `yaml:"name"`
+	GitHubLogin   string `yaml:"github_login,omitempty"`
+	OwnershipMode string `yaml:"ownership_mode,omitempty"`
+	OwnerField    string `yaml:"owner_field,omitempty"`
 }
 
 type Polling struct {
@@ -267,6 +279,57 @@ type Hooks struct {
 	TimeoutMS    int    `yaml:"timeout_ms"`
 }
 
+func (i Identity) Configured() bool {
+	return strings.TrimSpace(i.Name) != "" ||
+		strings.TrimSpace(i.GitHubLogin) != "" ||
+		strings.TrimSpace(i.OwnershipMode) != "" ||
+		strings.TrimSpace(i.OwnerField) != ""
+}
+
+func (i Identity) IsZero() bool {
+	return !i.Configured()
+}
+
+func (i *Identity) Normalize() {
+	if i == nil {
+		return
+	}
+	i.Name = strings.TrimSpace(i.Name)
+	i.GitHubLogin = strings.TrimSpace(i.GitHubLogin)
+	i.OwnershipMode = strings.ToLower(strings.TrimSpace(i.OwnershipMode))
+	i.OwnerField = strings.TrimSpace(i.OwnerField)
+	if i.OwnershipMode == "" && i.Configured() {
+		i.OwnershipMode = IdentityOwnershipAssignee
+	}
+}
+
+func (i Identity) Validate(prefix string) []string {
+	if !i.Configured() {
+		return nil
+	}
+
+	identity := i
+	identity.Normalize()
+
+	var problems []string
+	if identity.Name == "" {
+		problems = append(problems, prefix+".name must not be blank")
+	}
+	switch identity.OwnershipMode {
+	case IdentityOwnershipAssignee:
+		if identity.OwnerField != "" {
+			problems = append(problems, prefix+".owner_field must be blank when "+prefix+".ownership_mode is assignee")
+		}
+	case IdentityOwnershipField:
+		if identity.OwnerField == "" {
+			problems = append(problems, prefix+".owner_field is required when "+prefix+".ownership_mode is field")
+		}
+	default:
+		problems = append(problems, prefix+".ownership_mode must be one of assignee, field")
+	}
+	return problems
+}
+
 type StringOrMap struct {
 	IsString bool
 	String   string
@@ -410,6 +473,7 @@ func StringValue(value string) StringOrMap {
 func (c *Config) Validate() error {
 	var problems []string
 
+	problems = append(problems, c.Identity.Validate("identity")...)
 	c.validateTracker(&problems)
 	validatePositive("polling.interval_ms", c.Polling.IntervalMS, &problems)
 	if c.Worker.MaxConcurrentAgentsPerHost != nil {
@@ -459,10 +523,12 @@ func (s *StringOrMap) UnmarshalYAML(value *yaml.Node) error {
 }
 
 func (c *Config) normalize() {
+	c.Identity.Normalize()
 	c.Tracker.Kind = strings.ToLower(strings.TrimSpace(c.Tracker.Kind))
 	if c.Tracker.Kind == TrackerGitHub && c.Tracker.Endpoint == defaultLinearEndpoint {
 		c.Tracker.Endpoint = defaultGitHubEndpoint
 	}
+	c.Tracker.Authorization.Normalize()
 
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
 	c.Agent.DispatchPriorityByState = normalizeStateList(c.Agent.DispatchPriorityByState)
@@ -496,6 +562,7 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.http_max_idle_conns", c.Tracker.HTTPMaxIdleConns, problems)
 	validatePositive("tracker.http_max_idle_conns_per_host", c.Tracker.HTTPMaxIdleConnsPerHost, problems)
 	validatePositive("tracker.http_idle_conn_timeout_ms", c.Tracker.HTTPIdleConnTimeoutMS, problems)
+	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
 }
 
 func (t *Tracker) validateGitHubAuth(problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,16 +1,23 @@
 package config
 
 import (
+	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
 )
 
 func TestParseWorkflowFrontmatter(t *testing.T) {
 	t.Parallel()
 
 	raw := []byte(`---
+identity:
+  name: release-captain
+  github_login: detent-bot
+  ownership_mode: field
+  owner_field: Owner
 tracker:
   kind: github
   api_key: $GITHUB_TOKEN
@@ -18,6 +25,15 @@ tracker:
   http_max_idle_conns: 120
   http_max_idle_conns_per_host: 40
   http_idle_conn_timeout_ms: 120000
+  authorization:
+    assignee_in:
+      - "@me"
+    labels:
+      include:
+        - release
+    fields:
+      - name: Track
+        value: multi-instance
   active_states:
     - Todo
     - In Progress
@@ -109,6 +125,18 @@ Ticket prompt {{ issue.title }}
 	if cfg.Tracker.Kind != TrackerGitHub {
 		t.Fatalf("Tracker.Kind = %q, want %q", cfg.Tracker.Kind, TrackerGitHub)
 	}
+	if cfg.Identity.Name != "release-captain" {
+		t.Fatalf("Identity.Name = %q, want release-captain", cfg.Identity.Name)
+	}
+	if cfg.Identity.GitHubLogin != "detent-bot" {
+		t.Fatalf("Identity.GitHubLogin = %q, want detent-bot", cfg.Identity.GitHubLogin)
+	}
+	if cfg.Identity.OwnershipMode != IdentityOwnershipField {
+		t.Fatalf("Identity.OwnershipMode = %q, want %q", cfg.Identity.OwnershipMode, IdentityOwnershipField)
+	}
+	if cfg.Identity.OwnerField != "Owner" {
+		t.Fatalf("Identity.OwnerField = %q, want Owner", cfg.Identity.OwnerField)
+	}
 	if cfg.Tracker.Endpoint != "https://api.github.com/graphql" {
 		t.Fatalf("Tracker.Endpoint = %q", cfg.Tracker.Endpoint)
 	}
@@ -120,6 +148,14 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Tracker.HTTPIdleConnTimeoutMS != 120000 {
 		t.Fatalf("Tracker.HTTPIdleConnTimeoutMS = %d, want 120000", cfg.Tracker.HTTPIdleConnTimeoutMS)
+	}
+	wantAuthorization := selector.Selector{
+		AssigneeIn: []string{"@me"},
+		Labels:     selector.Labels{Include: []string{"release"}},
+		Fields:     []selector.FieldEquals{{Name: "Track", Value: "multi-instance"}},
+	}
+	if got := cfg.Tracker.Authorization; !reflect.DeepEqual(got, wantAuthorization) {
+		t.Fatalf("Tracker.Authorization = %#v, want %#v", got, wantAuthorization)
 	}
 	if got := cfg.Tracker.StateMap.Map["Cancelled"]; got != "Done" {
 		t.Fatalf("Tracker.StateMap[Cancelled] = %v, want Done", got)
@@ -171,6 +207,12 @@ func TestParseWorkflowDefaults(t *testing.T) {
 
 	if cfg.Tracker.Endpoint != "https://api.linear.app/graphql" {
 		t.Fatalf("Tracker.Endpoint = %q", cfg.Tracker.Endpoint)
+	}
+	if cfg.Identity.Configured() {
+		t.Fatalf("Identity = %#v, want omitted default", cfg.Identity)
+	}
+	if cfg.Tracker.Authorization.Configured() {
+		t.Fatalf("Tracker.Authorization = %#v, want authorize all default", cfg.Tracker.Authorization)
 	}
 	if cfg.Polling.IntervalMS != 30000 {
 		t.Fatalf("Polling.IntervalMS = %d", cfg.Polling.IntervalMS)
@@ -658,6 +700,28 @@ Prompt
 				"agents.routes.backend must reference a configured backend",
 				"agents.routes.selector.priority_in values must be integers 1 through 4",
 				"agents.routes must not define multiple default routes",
+			},
+		},
+		{
+			name: "invalid identity and authorization",
+			raw: `---
+identity:
+  github_login: detent-bot
+  ownership_mode: field
+tracker:
+  kind: memory
+  authorization:
+    priority_in: [0]
+    fields:
+      - value: multi-instance
+---
+Prompt
+`,
+			want: []string{
+				"identity.name must not be blank",
+				"identity.owner_field is required when identity.ownership_mode is field",
+				"tracker.authorization.priority_in values must be integers 1 through 4",
+				"tracker.authorization.fields[0].name must not be blank",
 			},
 		},
 	}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -70,6 +70,7 @@ type Project struct {
 	Paused        bool              `yaml:"paused,omitempty"`
 	CredentialRef string            `yaml:"credential_ref,omitempty"`
 	Authorization selector.Selector `yaml:"authorization,omitempty"`
+	Identity      Identity          `yaml:"-"`
 }
 
 type Identity = workflowconfig.Identity

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -8,6 +8,9 @@ import (
 	"strings"
 
 	"gopkg.in/yaml.v3"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/selector"
 )
 
 const (
@@ -53,19 +56,23 @@ type Config struct {
 type Settings struct {
 	MaxConcurrentAgents int            `yaml:"max_concurrent_agents"`
 	Scheduling          string         `yaml:"scheduling"`
+	Identity            Identity       `yaml:"identity,omitempty"`
 	FairShare           map[string]any `yaml:"fair_share,omitempty"`
 	Startup             map[string]any `yaml:"startup,omitempty"`
 }
 
 type Project struct {
-	ID            string `yaml:"id"`
-	Workflow      string `yaml:"workflow"`
-	Workdir       string `yaml:"workdir"`
-	Weight        int    `yaml:"weight"`
-	Priority      int    `yaml:"priority"`
-	Paused        bool   `yaml:"paused,omitempty"`
-	CredentialRef string `yaml:"credential_ref,omitempty"`
+	ID            string            `yaml:"id"`
+	Workflow      string            `yaml:"workflow"`
+	Workdir       string            `yaml:"workdir"`
+	Weight        int               `yaml:"weight"`
+	Priority      int               `yaml:"priority"`
+	Paused        bool              `yaml:"paused,omitempty"`
+	CredentialRef string            `yaml:"credential_ref,omitempty"`
+	Authorization selector.Selector `yaml:"authorization,omitempty"`
 }
+
+type Identity = workflowconfig.Identity
 
 type Option func(*options)
 
@@ -285,6 +292,7 @@ func (c Config) Validate(opts ...Option) error {
 	if !validSchedulingMode(c.Global.Scheduling) {
 		problems = append(problems, "global.scheduling: must be one of "+strings.Join(schedulingModes, ", "))
 	}
+	problems = append(problems, c.Global.Identity.Validate("global.identity")...)
 	problems = append(problems, startupErrors(c.Global.Startup, "global.startup")...)
 
 	if c.Projects == nil {
@@ -303,6 +311,7 @@ func (c Config) Validate(opts ...Option) error {
 		if project.CredentialRef != "" && strings.TrimSpace(project.CredentialRef) == "" {
 			problems = append(problems, prefix+".credential_ref: must not be blank")
 		}
+		problems = append(problems, project.Authorization.Validate(prefix+".authorization")...)
 	}
 	problems = append(problems, duplicateProjectIDErrorsFromProjects(c.Projects)...)
 
@@ -522,6 +531,8 @@ func globalErrors(value any) []string {
 	problems = append(problems, prefixErrors(requiredErrors(global, []string{"max_concurrent_agents", "scheduling"}), "global")...)
 	problems = append(problems, positiveIntegerError(global["max_concurrent_agents"], "global.max_concurrent_agents")...)
 	problems = append(problems, schedulingErrors(global["scheduling"])...)
+	problems = append(problems, optionalMapErrors(global, "identity")...)
+	problems = append(problems, identityErrors(global["identity"], "global.identity")...)
 	problems = append(problems, optionalMapErrors(global, "fair_share")...)
 	problems = append(problems, optionalMapErrors(global, "startup")...)
 
@@ -612,8 +623,41 @@ func projectErrors(value any, index int, opts options) []string {
 	problems = append(problems, integerError(project["priority"], prefix+".priority")...)
 	problems = append(problems, pausedErrors(project, prefix)...)
 	problems = append(problems, credentialRefErrors(project, prefix)...)
+	problems = append(problems, authorizationErrors(project["authorization"], prefix+".authorization")...)
 
 	return problems
+}
+
+func identityErrors(value any, prefix string) []string {
+	if value == nil {
+		return nil
+	}
+	if _, ok := value.(map[string]any); !ok {
+		return nil
+	}
+
+	var identity Identity
+	if err := decodeYAMLValue(value, &identity); err != nil {
+		return []string{prefix + ": " + err.Error()}
+	}
+	identity.Normalize()
+	return identity.Validate(prefix)
+}
+
+func authorizationErrors(value any, prefix string) []string {
+	if value == nil {
+		return nil
+	}
+	if _, ok := value.(map[string]any); !ok {
+		return []string{prefix + ": must be a mapping"}
+	}
+
+	var authorization selector.Selector
+	if err := decodeYAMLValue(value, &authorization); err != nil {
+		return []string{prefix + ": " + err.Error()}
+	}
+	authorization.Normalize()
+	return authorization.Validate(prefix)
 }
 
 func prefixErrors(errors []string, prefix string) []string {
@@ -841,9 +885,14 @@ func buildSettings(attrs map[string]any) (Settings, error) {
 	if err != nil {
 		return Settings{}, err
 	}
+	identity, err := buildIdentity(attrs["identity"], "global.identity")
+	if err != nil {
+		return Settings{}, err
+	}
 
 	settings.MaxConcurrentAgents = maxConcurrentAgents
 	settings.Scheduling = scheduling
+	settings.Identity = identity
 	settings.FairShare = fairShare
 	settings.Startup = startup
 	return settings, nil
@@ -897,6 +946,10 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 		if err != nil {
 			return nil, err
 		}
+		authorization, err := buildAuthorization(project["authorization"], prefix+".authorization")
+		if err != nil {
+			return nil, err
+		}
 
 		out = append(out, Project{
 			ID:            strings.TrimSpace(id),
@@ -906,9 +959,54 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 			Priority:      priority,
 			Paused:        paused,
 			CredentialRef: credentialRef,
+			Authorization: authorization,
 		})
 	}
 	return out, nil
+}
+
+func buildIdentity(value any, field string) (Identity, error) {
+	var identity Identity
+	if value == nil {
+		return identity, nil
+	}
+	if _, err := mapValue(value, field); err != nil {
+		return Identity{}, err
+	}
+	if err := decodeYAMLValue(value, &identity); err != nil {
+		return Identity{}, fmt.Errorf("%s: %w", field, err)
+	}
+	identity.Normalize()
+	if problems := identity.Validate(field); len(problems) > 0 {
+		return Identity{}, errors.New(strings.Join(problems, "; "))
+	}
+	return identity, nil
+}
+
+func buildAuthorization(value any, field string) (selector.Selector, error) {
+	var authorization selector.Selector
+	if value == nil {
+		return authorization, nil
+	}
+	if _, err := mapValue(value, field); err != nil {
+		return selector.Selector{}, err
+	}
+	if err := decodeYAMLValue(value, &authorization); err != nil {
+		return selector.Selector{}, fmt.Errorf("%s: %w", field, err)
+	}
+	authorization.Normalize()
+	if problems := authorization.Validate(field); len(problems) > 0 {
+		return selector.Selector{}, errors.New(strings.Join(problems, "; "))
+	}
+	return authorization, nil
+}
+
+func decodeYAMLValue(value any, out any) error {
+	raw, err := yaml.Marshal(value)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(raw, out)
 }
 
 func mergeMap(defaults map[string]any, value any, field string) (map[string]any, error) {

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/digitaldrywood/detent/internal/selector"
 )
 
 func TestResolvePathPrecedence(t *testing.T) {
@@ -199,6 +201,9 @@ func TestDefaultConfig(t *testing.T) {
 	if got := cfg.Global.Startup["max_spawn_per_second"]; got != 2 {
 		t.Fatalf("Global.Startup[max_spawn_per_second] = %v, want 2", got)
 	}
+	if cfg.Global.Identity.Configured() {
+		t.Fatalf("Global.Identity = %#v, want omitted default", cfg.Global.Identity)
+	}
 	if len(cfg.Projects) != 0 {
 		t.Fatalf("Projects = %#v, want empty", cfg.Projects)
 	}
@@ -236,6 +241,12 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 			Scheduling:          SchedulingStrict,
 			FairShare:           map[string]any{"half_life": "30m"},
 			Startup:             map[string]any{"jitter_seconds": 0, "max_spawn_per_second": 1},
+			Identity: Identity{
+				Name:          "release-captain",
+				GitHubLogin:   "detent-bot",
+				OwnershipMode: "field",
+				OwnerField:    "Owner",
+			},
 		},
 		Projects: []Project{
 			{
@@ -246,6 +257,10 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 				Priority:      2,
 				Paused:        true,
 				CredentialRef: "github-default",
+				Authorization: selector.Selector{
+					Labels: selector.Labels{Include: []string{"release"}},
+					Fields: []selector.FieldEquals{{Name: "Track", Value: "multi-instance"}},
+				},
 			},
 		},
 	}
@@ -357,6 +372,70 @@ func TestReadValidConfig(t *testing.T) {
 	}
 	if project.CredentialRef != "github-default" {
 		t.Fatalf("Project.CredentialRef = %q, want github-default", project.CredentialRef)
+	}
+	if project.Authorization.Configured() {
+		t.Fatalf("Project.Authorization = %#v, want authorize all default", project.Authorization)
+	}
+}
+
+func TestReadParsesIdentityAndAuthorization(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, configPath, `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  identity:
+    name: release-captain
+    github_login: detent-bot
+    ownership_mode: field
+    owner_field: Owner
+projects:
+  - id: detent
+    workflow: `+paths.workflow+`
+    workdir: `+paths.workdir+`
+    weight: 5
+    priority: 50
+    authorization:
+      author_in:
+        - "@me"
+      labels:
+        exclude:
+          - blocked
+      and:
+        - fields:
+            - name: Track
+              value: multi-instance
+`)
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if cfg.Global.Identity.Name != "release-captain" {
+		t.Fatalf("Global.Identity.Name = %q, want release-captain", cfg.Global.Identity.Name)
+	}
+	if cfg.Global.Identity.GitHubLogin != "detent-bot" {
+		t.Fatalf("Global.Identity.GitHubLogin = %q, want detent-bot", cfg.Global.Identity.GitHubLogin)
+	}
+	if cfg.Global.Identity.OwnershipMode != "field" {
+		t.Fatalf("Global.Identity.OwnershipMode = %q, want field", cfg.Global.Identity.OwnershipMode)
+	}
+	if cfg.Global.Identity.OwnerField != "Owner" {
+		t.Fatalf("Global.Identity.OwnerField = %q, want Owner", cfg.Global.Identity.OwnerField)
+	}
+
+	wantAuthorization := selector.Selector{
+		AuthorIn: []string{"@me"},
+		Labels:   selector.Labels{Exclude: []string{"blocked"}},
+		And: []selector.Selector{
+			{Fields: []selector.FieldEquals{{Name: "Track", Value: "multi-instance"}}},
+		},
+	}
+	if got := cfg.Projects[0].Authorization; !reflect.DeepEqual(got, wantAuthorization) {
+		t.Fatalf("Project.Authorization = %#v, want %#v", got, wantAuthorization)
 	}
 }
 
@@ -539,6 +618,32 @@ projects:
 				"projects[0].workdir: is required",
 				"projects[0].weight: is required",
 				"projects[0].priority: is required",
+			},
+		},
+		{
+			name: "invalid identity and authorization",
+			raw: `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  identity:
+    github_login: detent-bot
+    ownership_mode: field
+projects:
+  - id: detent
+    workflow: ` + paths.workflow + `
+    workdir: ` + paths.workdir + `
+    weight: 5
+    priority: 50
+    authorization:
+      fields:
+        - value: multi-instance
+`,
+			want: []string{
+				"global.identity.name must not be blank",
+				"global.identity.owner_field is required when global.identity.ownership_mode is field",
+				"projects[0].authorization.fields[0].name must not be blank",
 			},
 		},
 		{

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -8,6 +8,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/selector"
 )
 
 func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
@@ -22,6 +23,11 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.QuietSeconds = 30
 	cfg.Agent.AutoPromote.OptoutLabel = " Requires-Human-Review "
 	cfg.Agent.AutoPromote.AllowedIssueLabels = []string{" Docs ", "docs", "Chore"}
+	cfg.Identity.Name = "release-captain"
+	cfg.Identity.GitHubLogin = "detent-bot"
+	cfg.Tracker.Authorization = selector.Selector{
+		AssigneeIn: []string{"@me"},
+	}
 
 	got := ConfigFromWorkflow(cfg)
 
@@ -47,6 +53,15 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 		got.AutoPromote.AllowedIssueLabels[0] != "docs" ||
 		got.AutoPromote.AllowedIssueLabels[1] != "chore" {
 		t.Fatalf("AutoPromote.AllowedIssueLabels = %#v, want docs and chore", got.AutoPromote.AllowedIssueLabels)
+	}
+	if got.SelectorContext.InstanceLogin != "detent-bot" {
+		t.Fatalf("SelectorContext.InstanceLogin = %q, want detent-bot", got.SelectorContext.InstanceLogin)
+	}
+	if got.SelectorContext.Persona != "release-captain" {
+		t.Fatalf("SelectorContext.Persona = %q, want release-captain", got.SelectorContext.Persona)
+	}
+	if len(got.Authorization.AssigneeIn) != 1 || got.Authorization.AssigneeIn[0] != "@me" {
+		t.Fatalf("Authorization.AssigneeIn = %#v, want @me", got.Authorization.AssigneeIn)
 	}
 }
 
@@ -175,6 +190,61 @@ func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
 
 			got := orch.dispatchable(tt.issue, &state, now)
 			if got != tt.want {
+				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDispatchableFiltersUnauthorizedCandidates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Authorization: selector.Selector{
+			AssigneeIn: []string{"@me"},
+		},
+		SelectorContext: selector.Context{
+			InstanceLogin: "worker-1",
+			Persona:       "release-captain",
+		},
+	})
+	orch := Orchestrator{cfg: cfg}
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		want  bool
+	}{
+		{
+			name: "matching assignee is dispatchable",
+			issue: func() connector.Issue {
+				issue := dispatchTestIssue("issue-authorized", "Todo")
+				issue.Assignees = []string{"worker-1"}
+				return issue
+			}(),
+			want: true,
+		},
+		{
+			name: "nonmatching assignee is skipped",
+			issue: func() connector.Issue {
+				issue := dispatchTestIssue("issue-unauthorized", "Todo")
+				issue.Assignees = []string{"worker-2"}
+				return issue
+			}(),
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newState(cfg)
+			if got := orch.dispatchable(tt.issue, &state, now); got != tt.want {
 				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
 			}
 		})

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -48,6 +48,8 @@ type Config struct {
 	AutoPromote                AutoPromoteConfig
 	ActiveStates               []string
 	TerminalStates             []string
+	Authorization              selector.Selector
+	SelectorContext            selector.Context
 	WorkerHosts                []string
 	BudgetRefusalCooldown      time.Duration
 	ContinuationRetryDelay     time.Duration
@@ -109,6 +111,8 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		}),
 		ActiveStates:          append([]string(nil), cfg.Tracker.ActiveStates...),
 		TerminalStates:        append([]string(nil), cfg.Tracker.TerminalStates...),
+		Authorization:         cfg.Tracker.Authorization,
+		SelectorContext:       selector.Context{InstanceLogin: cfg.Identity.GitHubLogin, Persona: cfg.Identity.Name},
 		WorkerHosts:           append([]string(nil), cfg.Worker.SSHHosts...),
 		BudgetRefusalCooldown: durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
 		SelectorPersona:       cfg.Tracker.Assignee,
@@ -812,6 +816,9 @@ func (o *Orchestrator) dispatchableIssue(
 	if duplicatePullRequestWork(issue) {
 		return false
 	}
+	if !o.authorized(issue) {
+		return false
+	}
 	if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
 		return false
 	}
@@ -829,6 +836,13 @@ func (o *Orchestrator) dispatchableIssue(
 	}
 
 	return o.slotsAvailable(issue, state, preferredWorkerHost)
+}
+
+func (o *Orchestrator) authorized(issue connector.Issue) bool {
+	if !o.cfg.Authorization.Configured() {
+		return true
+	}
+	return selector.Match(issue, o.cfg.Authorization, o.cfg.SelectorContext)
 }
 
 func (o *Orchestrator) slotsAvailable(issue connector.Issue, state *State, preferredWorkerHost string) bool {
@@ -1126,6 +1140,9 @@ func normalizeConfig(cfg Config) Config {
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
 	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
+	cfg.Authorization.Normalize()
+	cfg.SelectorContext.InstanceLogin = strings.TrimSpace(cfg.SelectorContext.InstanceLogin)
+	cfg.SelectorContext.Persona = strings.TrimSpace(cfg.SelectorContext.Persona)
 	cfg.WorkerHosts = normalizeWorkerHosts(cfg.WorkerHosts)
 	cfg.SelectorPersona = strings.TrimSpace(cfg.SelectorPersona)
 	if cfg.MaxConcurrentAgentsPerHost < 0 {

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -29,6 +29,7 @@ type StartupConfig struct {
 }
 
 type ManagerConfig struct {
+	Identity globalconfig.Identity
 	Projects []globalconfig.Project
 	Startup  StartupConfig
 }
@@ -72,13 +73,14 @@ type Manager struct {
 }
 
 func ManagerConfigFromGlobal(cfg globalconfig.Config) ManagerConfig {
-	return ManagerConfig{
-		Projects: append([]globalconfig.Project(nil), cfg.Projects...),
+	return normalizeManagerConfig(ManagerConfig{
+		Identity: cfg.Global.Identity,
+		Projects: cfg.Projects,
 		Startup: StartupConfig{
 			Jitter:            time.Duration(startupInt(cfg.Global.Startup, "jitter_seconds")) * time.Second,
 			MaxSpawnPerSecond: startupInt(cfg.Global.Startup, "max_spawn_per_second"),
 		},
-	}
+	})
 }
 
 func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
@@ -112,7 +114,7 @@ func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
 		jitter = randomJitter
 	}
 
-	cfg.Projects = append([]globalconfig.Project(nil), cfg.Projects...)
+	cfg = normalizeManagerConfig(cfg)
 	return &Manager{
 		cfg:      cfg,
 		registry: registry,
@@ -175,10 +177,10 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		ctx = context.Background()
 	}
 
-	cfg.Projects = append([]globalconfig.Project(nil), cfg.Projects...)
+	cfg = normalizeManagerConfig(cfg)
 	desired := make(map[ProjectID]globalconfig.Project, len(cfg.Projects))
 	for i, project := range cfg.Projects {
-		normalized := normalizeManagerProjectConfig(project)
+		normalized := project
 		id := ProjectID(normalized.ID)
 		if id == "" {
 			return ReconcileResult{}, ErrMissingProjectID
@@ -386,7 +388,8 @@ func (m *Manager) Unpause(ctx context.Context, id ProjectID) error {
 }
 
 func (m *Manager) addLocked(ctx context.Context, cfg globalconfig.Project) error {
-	id := normalizeProjectID(ProjectID(cfg.ID))
+	cfg = normalizeManagerProjectConfigWithIdentity(cfg, m.cfg.Identity)
+	id := ProjectID(cfg.ID)
 	if id == "" {
 		return ErrMissingProjectID
 	}
@@ -503,6 +506,28 @@ func startupInt(values map[string]any, key string) int {
 
 func normalizeManagerProjectConfig(cfg globalconfig.Project) globalconfig.Project {
 	cfg.ID = string(normalizeProjectID(ProjectID(cfg.ID)))
+	cfg.Identity.Normalize()
+	return cfg
+}
+
+func normalizeManagerProjectConfigWithIdentity(
+	cfg globalconfig.Project,
+	identity globalconfig.Identity,
+) globalconfig.Project {
+	cfg = normalizeManagerProjectConfig(cfg)
+	identity.Normalize()
+	if identity.Configured() {
+		cfg.Identity = identity
+	}
+	return cfg
+}
+
+func normalizeManagerConfig(cfg ManagerConfig) ManagerConfig {
+	cfg.Identity.Normalize()
+	cfg.Projects = append([]globalconfig.Project(nil), cfg.Projects...)
+	for i := range cfg.Projects {
+		cfg.Projects[i] = normalizeManagerProjectConfigWithIdentity(cfg.Projects[i], cfg.Identity)
+	}
 	return cfg
 }
 

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -709,6 +709,10 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 
 	cfg := globalconfig.Config{
 		Global: globalconfig.Settings{
+			Identity: globalconfig.Identity{
+				Name:        "release-captain",
+				GitHubLogin: "detent-bot",
+			},
 			Startup: map[string]any{
 				"jitter_seconds":       3,
 				"max_spawn_per_second": 4,
@@ -724,8 +728,14 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 	if got.Startup.MaxSpawnPerSecond != 4 {
 		t.Fatalf("Startup.MaxSpawnPerSecond = %d, want 4", got.Startup.MaxSpawnPerSecond)
 	}
+	if got.Identity.Name != "release-captain" {
+		t.Fatalf("Identity.Name = %q, want release-captain", got.Identity.Name)
+	}
 	if len(got.Projects) != 1 || got.Projects[0].ID != "alpha" {
 		t.Fatalf("Projects = %#v, want alpha", got.Projects)
+	}
+	if got.Projects[0].Identity.GitHubLogin != "detent-bot" {
+		t.Fatalf("Projects[0].Identity.GitHubLogin = %q, want detent-bot", got.Projects[0].Identity.GitHubLogin)
 	}
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -122,6 +122,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	}
 
 	workflow := normalizeWorkflow(cfg.Workflow)
+	workflow.Config = workflowConfigWithProjectIdentity(cfg.Project, workflow.Config)
 	if err := workflow.Config.Validate(); err != nil {
 		return nil, fmt.Errorf("validate project workflow: %w", err)
 	}
@@ -570,7 +571,12 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		return
 	}
 
+	p.mu.Lock()
+	projectConfig := p.cfg
+	p.mu.Unlock()
+
 	workflow := normalizeWorkflow(update.Workflow)
+	workflow.Config = workflowConfigWithProjectIdentity(projectConfig, workflow.Config)
 	if err := workflow.Config.Validate(); err != nil {
 		p.logger.Warn("workflow reload validation failed",
 			"project_id", p.id,
@@ -604,10 +610,6 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		updater.UpdateWorkflow(workflow)
 	}
 
-	p.mu.Lock()
-	projectConfig := p.cfg
-	p.mu.Unlock()
-
 	runtimeConfig := projectOrchestratorConfig(projectConfig, workflow.Config)
 	if err := p.orchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
 		Config:    runtimeConfig,
@@ -636,9 +638,23 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 }
 
 func projectOrchestratorConfig(project globalconfig.Project, workflow workflowconfig.Config) orchestrator.Config {
+	workflow = workflowConfigWithProjectIdentity(project, workflow)
 	cfg := orchestrator.ConfigFromWorkflow(workflow)
 	cfg.Authorization = combineAuthorizationSelectors(cfg.Authorization, project.Authorization)
 	return cfg
+}
+
+func workflowConfigWithProjectIdentity(
+	project globalconfig.Project,
+	workflow workflowconfig.Config,
+) workflowconfig.Config {
+	if !project.Identity.Configured() {
+		return workflow
+	}
+	identity := project.Identity
+	identity.Normalize()
+	workflow.Identity = identity
+	return workflow
 }
 
 func combineAuthorizationSelectors(selectors ...selector.Selector) selector.Selector {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -18,6 +18,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/selector"
 )
 
 var (
@@ -152,7 +153,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		orchestratorFactory = orchestrator.New
 	}
 
-	orchConfig := orchestrator.ConfigFromWorkflow(workflow.Config)
+	orchConfig := projectOrchestratorConfig(cfg.Project, workflow.Config)
 	orchDeps := orchestrator.Dependencies{
 		Connector: projectConnector,
 		Runner:    deps.Runner,
@@ -603,7 +604,11 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		updater.UpdateWorkflow(workflow)
 	}
 
-	runtimeConfig := orchestrator.ConfigFromWorkflow(workflow.Config)
+	p.mu.Lock()
+	projectConfig := p.cfg
+	p.mu.Unlock()
+
+	runtimeConfig := projectOrchestratorConfig(projectConfig, workflow.Config)
 	if err := p.orchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
 		Config:    runtimeConfig,
 		Connector: projectConnector,
@@ -628,6 +633,30 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	p.mu.Unlock()
 
 	p.logger.Info("workflow reloaded", "project_id", p.id, "path", update.Path)
+}
+
+func projectOrchestratorConfig(project globalconfig.Project, workflow workflowconfig.Config) orchestrator.Config {
+	cfg := orchestrator.ConfigFromWorkflow(workflow)
+	cfg.Authorization = combineAuthorizationSelectors(cfg.Authorization, project.Authorization)
+	return cfg
+}
+
+func combineAuthorizationSelectors(selectors ...selector.Selector) selector.Selector {
+	configured := make([]selector.Selector, 0, len(selectors))
+	for _, candidate := range selectors {
+		if candidate.Configured() {
+			configured = append(configured, candidate)
+		}
+	}
+
+	switch len(configured) {
+	case 0:
+		return selector.Selector{}
+	case 1:
+		return configured[0]
+	default:
+		return selector.Selector{And: configured}
+	}
 }
 
 func (p *Project) publish(event Event) {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/selector"
 )
 
 func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
@@ -27,6 +28,12 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 	events := hub.New[project.Event]()
 	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 3})
 	created := make(chan orchestrator.Config, 1)
+	workflowCfg := workflowConfigWithMemoryIssue("issue-1")
+	workflowCfg.Identity.Name = "release-captain"
+	workflowCfg.Identity.GitHubLogin = "detent-bot"
+	workflowCfg.Tracker.Authorization = selector.Selector{
+		AssigneeIn: []string{"@me"},
+	}
 
 	got, err := project.New(project.Config{
 		Project: globalconfig.Project{
@@ -35,9 +42,12 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 			Workdir:  "/workspace/detent",
 			Weight:   2,
 			Priority: 10,
+			Authorization: selector.Selector{
+				Labels: selector.Labels{Include: []string{"release"}},
+			},
 		},
 		Workflow: workflowconfig.Workflow{
-			Config: workflowConfigWithMemoryIssue("issue-1"),
+			Config: workflowCfg,
 			Prompt: "Run issue",
 		},
 	}, project.Dependencies{
@@ -76,6 +86,12 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 	case cfg := <-created:
 		if cfg.MaxConcurrentAgents != 4 {
 			t.Fatalf("orchestrator MaxConcurrentAgents = %d, want 4", cfg.MaxConcurrentAgents)
+		}
+		if cfg.SelectorContext.InstanceLogin != "detent-bot" {
+			t.Fatalf("SelectorContext.InstanceLogin = %q, want detent-bot", cfg.SelectorContext.InstanceLogin)
+		}
+		if len(cfg.Authorization.And) != 2 {
+			t.Fatalf("Authorization.And = %#v, want workflow and project selectors", cfg.Authorization.And)
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for orchestrator factory")

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -29,8 +29,8 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 3})
 	created := make(chan orchestrator.Config, 1)
 	workflowCfg := workflowConfigWithMemoryIssue("issue-1")
-	workflowCfg.Identity.Name = "release-captain"
-	workflowCfg.Identity.GitHubLogin = "detent-bot"
+	workflowCfg.Identity.Name = "workflow-persona"
+	workflowCfg.Identity.GitHubLogin = "workflow-bot"
 	workflowCfg.Tracker.Authorization = selector.Selector{
 		AssigneeIn: []string{"@me"},
 	}
@@ -42,6 +42,10 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 			Workdir:  "/workspace/detent",
 			Weight:   2,
 			Priority: 10,
+			Identity: globalconfig.Identity{
+				Name:        "release-captain",
+				GitHubLogin: "detent-bot",
+			},
 			Authorization: selector.Selector{
 				Labels: selector.Labels{Include: []string{"release"}},
 			},
@@ -80,6 +84,9 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 	}
 	if got.Orchestrator() == nil {
 		t.Fatal("Orchestrator() = nil, want configured orchestrator")
+	}
+	if got.Workflow().Config.Identity.Name != "release-captain" {
+		t.Fatalf("Workflow().Config.Identity.Name = %q, want release-captain", got.Workflow().Config.Identity.Name)
 	}
 
 	select {
@@ -163,6 +170,10 @@ func TestProjectAppliesWorkflowReloadsToRunningOrchestrator(t *testing.T) {
 			ID:       "detent",
 			Workflow: "workflow.md",
 			Weight:   1,
+			Identity: globalconfig.Identity{
+				Name:        "release-captain",
+				GitHubLogin: "detent-bot",
+			},
 		},
 		Workflow: workflowconfig.Workflow{
 			Config: initial,
@@ -246,6 +257,10 @@ func TestProjectWorkflowReloadRefreshesRestartDependencies(t *testing.T) {
 			ID:       "detent",
 			Workflow: "workflow.md",
 			Weight:   1,
+			Identity: globalconfig.Identity{
+				Name:        "release-captain",
+				GitHubLogin: "detent-bot",
+			},
 		},
 		Workflow: workflowconfig.Workflow{
 			Config: initial,
@@ -266,8 +281,12 @@ func TestProjectWorkflowReloadRefreshesRestartDependencies(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	if cfg := receiveOrchestratorConfig(t, configs); cfg.PollInterval != time.Hour {
+	cfg := receiveOrchestratorConfig(t, configs)
+	if cfg.PollInterval != time.Hour {
 		t.Fatalf("initial PollInterval = %v, want %v", cfg.PollInterval, time.Hour)
+	}
+	if cfg.SelectorContext.InstanceLogin != "detent-bot" {
+		t.Fatalf("initial SelectorContext.InstanceLogin = %q, want detent-bot", cfg.SelectorContext.InstanceLogin)
 	}
 	_ = receiveConnector(t, connectors)
 
@@ -305,8 +324,12 @@ func TestProjectWorkflowReloadRefreshesRestartDependencies(t *testing.T) {
 		t.Fatalf("Unpause() error = %v", err)
 	}
 
-	if cfg := receiveOrchestratorConfig(t, configs); cfg.PollInterval != 5*time.Millisecond {
+	cfg = receiveOrchestratorConfig(t, configs)
+	if cfg.PollInterval != 5*time.Millisecond {
 		t.Fatalf("restarted PollInterval = %v, want %v", cfg.PollInterval, 5*time.Millisecond)
+	}
+	if cfg.SelectorContext.InstanceLogin != "detent-bot" {
+		t.Fatalf("restarted SelectorContext.InstanceLogin = %q, want detent-bot", cfg.SelectorContext.InstanceLogin)
 	}
 	restartedConnector := receiveConnector(t, connectors)
 	issues, err := restartedConnector.FetchCandidateIssues(context.Background())

--- a/internal/selector/match.go
+++ b/internal/selector/match.go
@@ -1,6 +1,7 @@
 package selector
 
 import (
+	"fmt"
 	"strings"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -14,23 +15,87 @@ type Context struct {
 }
 
 type Selector struct {
-	AssigneeIn []string      `yaml:"assignee_in"`
-	AuthorIn   []string      `yaml:"author_in"`
-	PriorityIn []int         `yaml:"priority_in"`
-	Labels     Labels        `yaml:"labels"`
-	Fields     []FieldEquals `yaml:"fields"`
-	And        []Selector    `yaml:"and"`
-	Or         []Selector    `yaml:"or"`
+	AssigneeIn []string      `yaml:"assignee_in,omitempty"`
+	AuthorIn   []string      `yaml:"author_in,omitempty"`
+	PriorityIn []int         `yaml:"priority_in,omitempty"`
+	Labels     Labels        `yaml:"labels,omitempty"`
+	Fields     []FieldEquals `yaml:"fields,omitempty"`
+	And        []Selector    `yaml:"and,omitempty"`
+	Or         []Selector    `yaml:"or,omitempty"`
 }
 
 type Labels struct {
-	Include []string `yaml:"include"`
-	Exclude []string `yaml:"exclude"`
+	Include []string `yaml:"include,omitempty"`
+	Exclude []string `yaml:"exclude,omitempty"`
 }
 
 type FieldEquals struct {
 	Name  string `yaml:"name"`
 	Value string `yaml:"value"`
+}
+
+func (s Selector) Configured() bool {
+	if anyNonBlank(s.AssigneeIn) || anyNonBlank(s.AuthorIn) ||
+		len(s.PriorityIn) > 0 || anyNonBlank(s.Labels.Include) ||
+		anyNonBlank(s.Labels.Exclude) {
+		return true
+	}
+	for _, field := range s.Fields {
+		if strings.TrimSpace(field.Name) != "" || strings.TrimSpace(field.Value) != "" {
+			return true
+		}
+	}
+	return len(s.And) > 0 || len(s.Or) > 0
+}
+
+func (s Selector) IsZero() bool {
+	return !s.Configured()
+}
+
+func (s *Selector) Normalize() {
+	if s == nil {
+		return
+	}
+	s.AssigneeIn = trimStringSlice(s.AssigneeIn)
+	s.AuthorIn = trimStringSlice(s.AuthorIn)
+	s.Labels.Include = trimStringSlice(s.Labels.Include)
+	s.Labels.Exclude = trimStringSlice(s.Labels.Exclude)
+	for index := range s.Fields {
+		s.Fields[index].Name = strings.TrimSpace(s.Fields[index].Name)
+		s.Fields[index].Value = strings.TrimSpace(s.Fields[index].Value)
+	}
+	for index := range s.And {
+		s.And[index].Normalize()
+	}
+	for index := range s.Or {
+		s.Or[index].Normalize()
+	}
+}
+
+func (s Selector) Validate(prefix string) []string {
+	var problems []string
+	problems = append(problems, stringListProblems(prefix+".assignee_in", s.AssigneeIn)...)
+	problems = append(problems, stringListProblems(prefix+".author_in", s.AuthorIn)...)
+	problems = append(problems, priorityProblems(prefix+".priority_in", s.PriorityIn)...)
+	problems = append(problems, stringListProblems(prefix+".labels.include", s.Labels.Include)...)
+	problems = append(problems, stringListProblems(prefix+".labels.exclude", s.Labels.Exclude)...)
+
+	for index, field := range s.Fields {
+		fieldPrefix := fmt.Sprintf("%s.fields[%d]", prefix, index)
+		if strings.TrimSpace(field.Name) == "" {
+			problems = append(problems, fieldPrefix+".name must not be blank")
+		}
+		if strings.TrimSpace(field.Value) == "" {
+			problems = append(problems, fieldPrefix+".value must not be blank")
+		}
+	}
+	for index, child := range s.And {
+		problems = append(problems, child.Validate(fmt.Sprintf("%s.and[%d]", prefix, index))...)
+	}
+	for index, child := range s.Or {
+		problems = append(problems, child.Validate(fmt.Sprintf("%s.or[%d]", prefix, index))...)
+	}
+	return problems
 }
 
 func Match(issue connector.Issue, selector Selector, ctx Context) bool {
@@ -212,4 +277,43 @@ func normalizeIdentity(value string) string {
 
 func normalizeLabel(label string) string {
 	return strings.ToLower(strings.TrimSpace(label))
+}
+
+func anyNonBlank(values []string) bool {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func trimStringSlice(values []string) []string {
+	if values == nil {
+		return nil
+	}
+	out := make([]string, len(values))
+	for index, value := range values {
+		out[index] = strings.TrimSpace(value)
+	}
+	return out
+}
+
+func stringListProblems(field string, values []string) []string {
+	var problems []string
+	for index, value := range values {
+		if strings.TrimSpace(value) == "" {
+			problems = append(problems, fmt.Sprintf("%s[%d] must not be blank", field, index))
+		}
+	}
+	return problems
+}
+
+func priorityProblems(field string, priorities []int) []string {
+	for _, priority := range priorities {
+		if priority < 1 || priority > 4 {
+			return []string{field + " values must be integers 1 through 4"}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- Add instance identity schema with ownership validation for WORKFLOW.md and global.yaml.
- Add tracker/project authorization selectors using the shared selector schema.
- Enforce configured authorization selectors before dispatch, combining global.yaml and WORKFLOW.md selectors with AND semantics.
- Apply global instance identity to project runtime config so @me selectors use the instance identity without duplicating it in WORKFLOW.md.
- Surface identity and authorization scope in detent doctor while preserving omitted-config defaults.

Fixes #252

## Test Plan

- [x] `go test ./internal/config/global ./internal/project ./internal/cli ./internal/orchestrator ./internal/selector ./internal/config`
- [x] `git diff --check`
- [x] `make check`