### PR TITLE
feat(runner): add agent backend router

### DIFF
--- a/install_test.go
+++ b/install_test.go
@@ -493,29 +493,49 @@ func waitForOnboardingHealth(t *testing.T, port int) {
 	t.Helper()
 
 	url := fmt.Sprintf("http://127.0.0.1:%d/health", port)
-	deadline := time.Now().Add(5 * time.Second)
-	for time.Now().Before(deadline) {
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(25 * time.Millisecond)
+	defer tick.Stop()
+
+	for {
 		body, err := tryReadURL(url)
 		if err == nil && strings.Contains(body, `"mode":"onboarding"`) {
 			return
 		}
-		time.Sleep(25 * time.Millisecond)
+		select {
+		case <-deadline.C:
+			t.Fatalf("health endpoint did not report onboarding mode at %s", url)
+		case <-tick.C:
+		}
 	}
-	t.Fatalf("health endpoint did not report onboarding mode at %s", url)
 }
 
 func readURL(t *testing.T, url string) string {
 	t.Helper()
 
-	body, err := tryReadURL(url)
-	if err != nil {
-		t.Fatalf("GET %s error = %v", url, err)
+	deadline := time.NewTimer(5 * time.Second)
+	defer deadline.Stop()
+	tick := time.NewTicker(25 * time.Millisecond)
+	defer tick.Stop()
+
+	var lastErr error
+	for {
+		body, err := tryReadURL(url)
+		if err == nil {
+			return body
+		}
+		lastErr = err
+		select {
+		case <-deadline.C:
+			t.Fatalf("GET %s error = %v", url, lastErr)
+		case <-tick.C:
+		}
 	}
-	return body
 }
 
 func tryReadURL(url string) (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 250*time.Millisecond)
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -80,11 +80,6 @@ func buildRunner(
 		return nil, err
 	}
 
-	codexClient, err := buildCodexClient(cfg)
-	if err != nil {
-		return nil, err
-	}
-
 	pricing, err := budget.PricingForConfig(budget.Config{
 		PricingPath: cfg.Budget.PricingPath,
 	})
@@ -93,13 +88,13 @@ func buildRunner(
 	}
 
 	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
-		ProjectID: projectID,
-		Workflow:  workflow,
-		Workspace: backend,
-		Codex:     codexClient,
-		Store:     sessionStore,
-		Pricing:   pricing,
-		Logger:    logger,
+		ProjectID:           projectID,
+		Workflow:            workflow,
+		Workspace:           backend,
+		AgentBackendFactory: runnerpkg.AgentBackendFactoryFunc(buildAgentBackend),
+		Store:               sessionStore,
+		Pricing:             pricing,
+		Logger:              logger,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create runner: %w", err)
@@ -136,24 +131,33 @@ func buildWorkspaceBackend(cfg workflowconfig.Config, sourceRootFallback string,
 	return backend, nil
 }
 
-func buildCodexClient(cfg workflowconfig.Config) (runnerpkg.CodexClient, error) {
-	command := strings.TrimSpace(cfg.Codex.Command)
+func buildAgentBackend(backend workflowconfig.AgentBackend) (runnerpkg.AgentBackend, error) {
+	switch backend.Kind {
+	case workflowconfig.AgentBackendCodex:
+		return buildCodexAgentBackend(backend.CodexConfig(workflowconfig.Codex{}))
+	default:
+		return nil, fmt.Errorf("unsupported agent backend kind %q", backend.Kind)
+	}
+}
+
+func buildCodexAgentBackend(cfg workflowconfig.Codex) (runnerpkg.AgentBackend, error) {
+	command := strings.TrimSpace(cfg.Command)
 	if command == "" {
 		return nil, fmt.Errorf("codex command is required")
 	}
 
 	factory, err := codex.NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
-		return buildCodexCommand(ctx, cfg)
+		return buildCodexCommandFromConfig(ctx, cfg)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create codex transport factory: %w", err)
 	}
 
 	opts := []codex.AppServerOption{}
-	if timeout := durationFromMillis(cfg.Codex.ReadTimeoutMS); timeout > 0 {
+	if timeout := durationFromMillis(cfg.ReadTimeoutMS); timeout > 0 {
 		opts = append(opts, codex.WithReadTimeout(timeout))
 	}
-	if timeout := durationFromMillis(cfg.Codex.TurnTimeoutMS); timeout > 0 {
+	if timeout := durationFromMillis(cfg.TurnTimeoutMS); timeout > 0 {
 		opts = append(opts, codex.WithTurnTimeout(timeout))
 	}
 
@@ -161,11 +165,19 @@ func buildCodexClient(cfg workflowconfig.Config) (runnerpkg.CodexClient, error) 
 	if err != nil {
 		return nil, fmt.Errorf("create codex app-server: %w", err)
 	}
-	return client, nil
+	backend, err := codex.NewAgentBackend(client)
+	if err != nil {
+		return nil, fmt.Errorf("create codex backend: %w", err)
+	}
+	return backend, nil
 }
 
 func buildCodexCommand(ctx context.Context, cfg workflowconfig.Config) *exec.Cmd {
-	return commandshell.Command(ctx, strings.TrimSpace(cfg.Codex.Command), cfg.Codex.Shell)
+	return buildCodexCommandFromConfig(ctx, cfg.Codex)
+}
+
+func buildCodexCommandFromConfig(ctx context.Context, cfg workflowconfig.Codex) *exec.Cmd {
+	return commandshell.Command(ctx, strings.TrimSpace(cfg.Command), cfg.Shell)
 }
 
 // publishSnapshots ticks at interval, building a merged telemetry snapshot

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -1,0 +1,125 @@
+package codex
+
+import (
+	"context"
+	"errors"
+	"math"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+var ErrMissingAppServer = errors.New("codex app-server is required")
+
+type AgentBackend struct {
+	client *AppServer
+}
+
+func NewAgentBackend(client *AppServer) (*AgentBackend, error) {
+	if client == nil {
+		return nil, ErrMissingAppServer
+	}
+	return &AgentBackend{client: client}, nil
+}
+
+func (b *AgentBackend) RunTurn(
+	ctx context.Context,
+	req runner.AgentTurnRequest,
+	onUpdate runner.AgentUpdateHandler,
+) (runner.AgentTurnResult, error) {
+	result, err := b.client.RunTurn(ctx, RunTurnRequest{
+		Workspace:         req.Workspace,
+		Prompt:            req.Prompt,
+		ApprovalPolicy:    req.ApprovalPolicy,
+		ThreadSandbox:     req.ThreadSandbox,
+		TurnSandboxPolicy: req.TurnSandboxPolicy,
+		Model:             req.Model,
+		ModelProvider:     req.ModelProvider,
+		ServiceTier:       req.ServiceTier,
+	}, func(update Update) error {
+		if onUpdate == nil {
+			return nil
+		}
+		return onUpdate(agentUpdateFromCodex(update))
+	})
+	if err != nil {
+		return runner.AgentTurnResult{}, err
+	}
+	return runner.AgentTurnResult{
+		ThreadID:  result.ThreadID,
+		TurnID:    result.TurnID,
+		SessionID: result.SessionID,
+	}, nil
+}
+
+func agentUpdateFromCodex(update Update) runner.AgentUpdate {
+	return runner.AgentUpdate{
+		Type:            runner.AgentUpdateType(update.Type),
+		Method:          update.Method,
+		ProcessIdentity: update.ProcessIdentity,
+		ThreadID:        update.ThreadID,
+		TurnID:          update.TurnID,
+		ItemID:          update.ItemID,
+		Delta:           update.Delta,
+		Status:          update.Status,
+		Tokens: runner.AgentTokenUsage{
+			InputTokens:           update.Tokens.InputTokens,
+			CachedInputTokens:     update.Tokens.CachedInputTokens,
+			OutputTokens:          update.Tokens.OutputTokens,
+			ReasoningOutputTokens: update.Tokens.ReasoningOutputTokens,
+			TotalTokens:           update.Tokens.TotalTokens,
+			ModelContextWindow:    update.Tokens.ModelContextWindow,
+		},
+		RateLimits: rateLimitsFromCodex(update.RateLimits),
+	}
+}
+
+func rateLimitsFromCodex(snapshot *RateLimitSnapshot) *telemetry.RateLimits {
+	if snapshot == nil {
+		return nil
+	}
+	return &telemetry.RateLimits{
+		LimitID:   snapshot.LimitID,
+		LimitName: snapshot.LimitName,
+		Primary:   rateLimitBucketFromCodex(snapshot.Primary),
+		Secondary: rateLimitBucketFromCodex(snapshot.Secondary),
+		Credits:   creditsBucketFromCodex(snapshot.Credits),
+	}
+}
+
+func rateLimitBucketFromCodex(window *RateLimitWindow) *telemetry.RateLimitBucket {
+	if window == nil {
+		return nil
+	}
+
+	used := int64(math.Round(window.UsedPercent))
+	if used < 0 {
+		used = 0
+	}
+	if used > 100 {
+		used = 100
+	}
+
+	bucket := &telemetry.RateLimitBucket{
+		Limit:     100,
+		Used:      used,
+		Remaining: 100 - used,
+	}
+	if window.ResetsAt != nil {
+		resetAt := time.Unix(*window.ResetsAt, 0).UTC()
+		bucket.ResetAt = &resetAt
+	}
+	return bucket
+}
+
+func creditsBucketFromCodex(credits *CreditsSnapshot) *telemetry.RateLimitBucket {
+	if credits == nil {
+		return nil
+	}
+	return &telemetry.RateLimitBucket{
+		HasCredits: credits.HasCredits,
+		Unlimited:  credits.Unlimited,
+		Balance:    credits.Balance,
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -571,14 +571,10 @@ func normalizeAgentProtocol(protocol string) string {
 }
 
 func (a *Agents) validate(problems *[]string) {
-	if len(a.Backends) == 0 {
-		if len(a.Routes) > 0 {
-			*problems = append(*problems, "agents.backends is required when agents.routes are configured")
-		}
-		return
-	}
-
 	backendIDs := make(map[string]struct{}, len(a.Backends))
+	if len(a.Backends) == 0 {
+		backendIDs[DefaultAgentBackendID] = struct{}{}
+	}
 	for _, backend := range a.Backends {
 		if strings.TrimSpace(backend.ID) == "" {
 			*problems = append(*problems, "agents.backends.id is required")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -13,6 +13,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
 )
 
@@ -23,6 +24,11 @@ const (
 
 	defaultLinearEndpoint = "https://api.linear.app/graphql"
 	defaultGitHubEndpoint = "https://api.github.com/graphql"
+
+	DefaultAgentBackendID = "codex"
+	AgentBackendCodex     = "codex"
+
+	defaultCodexProtocol = "app-server"
 )
 
 var windowsAbsPathPattern = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
@@ -38,6 +44,7 @@ type Config struct {
 	Workspace     Workspace     `yaml:"workspace"`
 	Worker        Worker        `yaml:"worker"`
 	Agent         Agent         `yaml:"agent"`
+	Agents        Agents        `yaml:"agents"`
 	Codex         Codex         `yaml:"codex"`
 	Server        Server        `yaml:"server"`
 	Observability Observability `yaml:"observability"`
@@ -94,6 +101,38 @@ type Agent struct {
 	Skills                     Skills         `yaml:"skills"`
 }
 
+type Agents struct {
+	Backends []AgentBackend `yaml:"backends"`
+	Routes   []AgentRoute   `yaml:"routes"`
+}
+
+type AgentBackend struct {
+	ID       string              `yaml:"id"`
+	Kind     string              `yaml:"kind"`
+	Protocol string              `yaml:"protocol"`
+	Command  string              `yaml:"command"`
+	Options  AgentBackendOptions `yaml:"options"`
+}
+
+type AgentBackendOptions struct {
+	Shell             string         `yaml:"shell"`
+	ApprovalPolicy    StringOrMap    `yaml:"approval_policy"`
+	ThreadSandbox     string         `yaml:"thread_sandbox"`
+	TurnSandboxPolicy map[string]any `yaml:"turn_sandbox_policy"`
+	TurnTimeoutMS     int            `yaml:"turn_timeout_ms"`
+	ReadTimeoutMS     int            `yaml:"read_timeout_ms"`
+	StallTimeoutMS    int            `yaml:"stall_timeout_ms"`
+}
+
+type AgentRoute struct {
+	Name       string            `yaml:"name"`
+	Backend    string            `yaml:"backend"`
+	Model      string            `yaml:"model"`
+	ModelField string            `yaml:"model_field"`
+	Default    bool              `yaml:"default"`
+	Selector   selector.Selector `yaml:"selector"`
+}
+
 type AutoPromote struct {
 	Enabled            bool     `yaml:"enabled"`
 	QuietSeconds       int      `yaml:"quiet_seconds"`
@@ -132,6 +171,80 @@ type Codex struct {
 	TurnTimeoutMS     int            `yaml:"turn_timeout_ms"`
 	ReadTimeoutMS     int            `yaml:"read_timeout_ms"`
 	StallTimeoutMS    int            `yaml:"stall_timeout_ms"`
+}
+
+func (c Config) AgentBackendConfigs() []AgentBackend {
+	if len(c.Agents.Backends) > 0 {
+		backends := make([]AgentBackend, len(c.Agents.Backends))
+		copy(backends, c.Agents.Backends)
+		return backends
+	}
+	return []AgentBackend{CodexAgentBackend(c.Codex)}
+}
+
+func (c Config) AgentRouteConfigs() []AgentRoute {
+	if len(c.Agents.Routes) > 0 {
+		routes := make([]AgentRoute, len(c.Agents.Routes))
+		copy(routes, c.Agents.Routes)
+		return routes
+	}
+
+	backendID := DefaultAgentBackendID
+	if backends := c.AgentBackendConfigs(); len(backends) > 0 {
+		backendID = backends[0].ID
+	}
+	return []AgentRoute{{
+		Name:    "default",
+		Backend: backendID,
+		Default: true,
+	}}
+}
+
+func CodexAgentBackend(codex Codex) AgentBackend {
+	return AgentBackend{
+		ID:       DefaultAgentBackendID,
+		Kind:     AgentBackendCodex,
+		Protocol: defaultCodexProtocol,
+		Command:  strings.TrimSpace(codex.Command),
+		Options: AgentBackendOptions{
+			Shell:             codex.Shell,
+			ApprovalPolicy:    codex.ApprovalPolicy,
+			ThreadSandbox:     codex.ThreadSandbox,
+			TurnSandboxPolicy: codex.TurnSandboxPolicy,
+			TurnTimeoutMS:     codex.TurnTimeoutMS,
+			ReadTimeoutMS:     codex.ReadTimeoutMS,
+			StallTimeoutMS:    codex.StallTimeoutMS,
+		},
+	}
+}
+
+func (b AgentBackend) CodexConfig(fallback Codex) Codex {
+	cfg := fallback
+	if strings.TrimSpace(b.Command) != "" {
+		cfg.Command = strings.TrimSpace(b.Command)
+	}
+	if strings.TrimSpace(b.Options.Shell) != "" {
+		cfg.Shell = b.Options.Shell
+	}
+	if b.Options.ApprovalPolicy.IsString || b.Options.ApprovalPolicy.IsMap {
+		cfg.ApprovalPolicy = b.Options.ApprovalPolicy
+	}
+	if strings.TrimSpace(b.Options.ThreadSandbox) != "" {
+		cfg.ThreadSandbox = strings.TrimSpace(b.Options.ThreadSandbox)
+	}
+	if b.Options.TurnSandboxPolicy != nil {
+		cfg.TurnSandboxPolicy = b.Options.TurnSandboxPolicy
+	}
+	if b.Options.TurnTimeoutMS > 0 {
+		cfg.TurnTimeoutMS = b.Options.TurnTimeoutMS
+	}
+	if b.Options.ReadTimeoutMS > 0 {
+		cfg.ReadTimeoutMS = b.Options.ReadTimeoutMS
+	}
+	if b.Options.StallTimeoutMS > 0 {
+		cfg.StallTimeoutMS = b.Options.StallTimeoutMS
+	}
+	return cfg
 }
 
 type Server struct {
@@ -303,6 +416,7 @@ func (c *Config) Validate() error {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
 	}
 	c.Agent.validate("agent", &problems)
+	c.Agents.validate(&problems)
 	c.Codex.validate(&problems)
 	c.Server.validate(&problems)
 	c.Observability.validate(&problems)
@@ -354,6 +468,7 @@ func (c *Config) normalize() {
 	c.Agent.DispatchPriorityByState = normalizeStateList(c.Agent.DispatchPriorityByState)
 	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
 	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
+	c.Agents.normalize()
 	c.Codex.Shell = commandshell.Normalize(c.Codex.Shell)
 	c.Hooks.Shell = commandshell.Normalize(c.Hooks.Shell)
 }
@@ -419,6 +534,111 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	a.Budget.validate(prefix+".budget", problems)
 	a.Lessons.validate(prefix+".lessons", problems)
 	a.Skills.validate(prefix+".skills", problems)
+}
+
+func (a *Agents) normalize() {
+	for index := range a.Backends {
+		backend := &a.Backends[index]
+		backend.ID = strings.TrimSpace(backend.ID)
+		backend.Kind = strings.ToLower(strings.TrimSpace(backend.Kind))
+		backend.Protocol = normalizeAgentProtocol(backend.Protocol)
+		if backend.Protocol == "" && backend.Kind == AgentBackendCodex {
+			backend.Protocol = defaultCodexProtocol
+		}
+		backend.Command = strings.TrimSpace(backend.Command)
+		backend.Options.Shell = strings.TrimSpace(backend.Options.Shell)
+		if backend.Options.Shell != "" {
+			backend.Options.Shell = commandshell.Normalize(backend.Options.Shell)
+		}
+		backend.Options.ThreadSandbox = strings.TrimSpace(backend.Options.ThreadSandbox)
+	}
+	for index := range a.Routes {
+		route := &a.Routes[index]
+		route.Name = strings.TrimSpace(route.Name)
+		route.Backend = strings.TrimSpace(route.Backend)
+		route.Model = strings.TrimSpace(route.Model)
+		route.ModelField = strings.TrimSpace(route.ModelField)
+	}
+}
+
+func normalizeAgentProtocol(protocol string) string {
+	switch strings.ToLower(strings.TrimSpace(protocol)) {
+	case "app_server", "appserver":
+		return defaultCodexProtocol
+	default:
+		return strings.ToLower(strings.TrimSpace(protocol))
+	}
+}
+
+func (a *Agents) validate(problems *[]string) {
+	if len(a.Backends) == 0 {
+		if len(a.Routes) > 0 {
+			*problems = append(*problems, "agents.backends is required when agents.routes are configured")
+		}
+		return
+	}
+
+	backendIDs := make(map[string]struct{}, len(a.Backends))
+	for _, backend := range a.Backends {
+		if strings.TrimSpace(backend.ID) == "" {
+			*problems = append(*problems, "agents.backends.id is required")
+			continue
+		}
+		if _, ok := backendIDs[backend.ID]; ok {
+			*problems = append(*problems, "agents.backends ids must be unique")
+		}
+		backendIDs[backend.ID] = struct{}{}
+
+		switch backend.Kind {
+		case "":
+			*problems = append(*problems, "agents.backends.kind is required")
+		case AgentBackendCodex:
+		default:
+			*problems = append(*problems, "agents.backends.kind must be codex")
+		}
+		if backend.Kind == AgentBackendCodex && backend.Protocol != defaultCodexProtocol {
+			*problems = append(*problems, "agents.backends.protocol must be app-server for codex")
+		}
+		validateRequired("agents.backends.command", backend.Command, "", problems)
+		backend.Options.validate("agents.backends.options", problems)
+	}
+
+	defaultRoutes := 0
+	for _, route := range a.Routes {
+		if strings.TrimSpace(route.Backend) == "" {
+			*problems = append(*problems, "agents.routes.backend is required")
+		} else if _, ok := backendIDs[route.Backend]; !ok {
+			*problems = append(*problems, "agents.routes.backend must reference a configured backend")
+		}
+		if route.Default {
+			defaultRoutes++
+		}
+		validatePriorityValues("agents.routes.selector.priority_in", route.Selector.PriorityIn, problems)
+	}
+	if defaultRoutes > 1 {
+		*problems = append(*problems, "agents.routes must not define multiple default routes")
+	}
+}
+
+func (o *AgentBackendOptions) validate(prefix string, problems *[]string) {
+	if o.TurnTimeoutMS < 0 {
+		*problems = append(*problems, prefix+".turn_timeout_ms must be greater than or equal to 0")
+	}
+	if o.ReadTimeoutMS < 0 {
+		*problems = append(*problems, prefix+".read_timeout_ms must be greater than or equal to 0")
+	}
+	if o.StallTimeoutMS < 0 {
+		*problems = append(*problems, prefix+".stall_timeout_ms must be greater than or equal to 0")
+	}
+}
+
+func validatePriorityValues(field string, priorities []int, problems *[]string) {
+	for _, priority := range priorities {
+		if priority < 1 || priority > 4 {
+			*problems = append(*problems, field+" values must be integers 1 through 4")
+			return
+		}
+	}
 }
 
 func (a *AutoPromote) validate(prefix string, problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -214,6 +214,100 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if cfg.Budget.PricingPath != "priv/pricing/models.yaml" {
 		t.Fatalf("Budget.PricingPath = %q", cfg.Budget.PricingPath)
 	}
+	if len(cfg.Agents.Backends) != 0 {
+		t.Fatalf("Agents.Backends len = %d, want legacy empty config", len(cfg.Agents.Backends))
+	}
+	if len(cfg.Agents.Routes) != 0 {
+		t.Fatalf("Agents.Routes len = %d, want legacy empty config", len(cfg.Agents.Routes))
+	}
+}
+
+func TestParseWorkflowAgentsConfig(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-high
+      kind: codex
+      protocol: app-server
+      command: codex app-server --profile high
+      options:
+        shell: bash
+        approval_policy: never
+        thread_sandbox: danger-full-access
+        turn_sandbox_policy:
+          type: dangerFullAccess
+        turn_timeout_ms: 600000
+        read_timeout_ms: 1000
+        stall_timeout_ms: 0
+  routes:
+    - name: high-label
+      backend: codex-high
+      model: gpt-5-codex-high
+      selector:
+        labels:
+          include:
+            - tier:high
+    - name: project-model
+      backend: codex-high
+      model_field: Model
+    - name: urgent
+      backend: codex-high
+      model: gpt-5-codex
+      selector:
+        priority_in:
+          - 1
+    - name: default
+      backend: codex-high
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	agents := workflow.Config.Agents
+	if len(agents.Backends) != 1 {
+		t.Fatalf("Agents.Backends len = %d, want 1", len(agents.Backends))
+	}
+	backend := agents.Backends[0]
+	if backend.ID != "codex-high" || backend.Kind != "codex" || backend.Protocol != "app-server" {
+		t.Fatalf("backend identity = %#v, want codex-high codex app-server", backend)
+	}
+	if backend.Command != "codex app-server --profile high" {
+		t.Fatalf("backend Command = %q, want configured command", backend.Command)
+	}
+	if backend.Options.Shell != "bash" {
+		t.Fatalf("backend shell = %q, want bash", backend.Options.Shell)
+	}
+	if !backend.Options.ApprovalPolicy.IsString || backend.Options.ApprovalPolicy.String != "never" {
+		t.Fatalf("backend approval policy = %#v, want never", backend.Options.ApprovalPolicy)
+	}
+	if backend.Options.TurnSandboxPolicy["type"] != "dangerFullAccess" {
+		t.Fatalf("backend turn sandbox policy = %#v, want dangerFullAccess", backend.Options.TurnSandboxPolicy)
+	}
+	if len(agents.Routes) != 4 {
+		t.Fatalf("Agents.Routes len = %d, want 4", len(agents.Routes))
+	}
+	if got := agents.Routes[0].Selector.Labels.Include; len(got) != 1 || got[0] != "tier:high" {
+		t.Fatalf("route label selector = %#v, want tier:high", got)
+	}
+	if agents.Routes[1].ModelField != "Model" {
+		t.Fatalf("route ModelField = %q, want Model", agents.Routes[1].ModelField)
+	}
+	if got := agents.Routes[2].Selector.PriorityIn; len(got) != 1 || got[0] != 1 {
+		t.Fatalf("route priority selector = %#v, want priority 1", got)
+	}
+	if !agents.Routes[3].Default {
+		t.Fatal("default route Default = false, want true")
+	}
 }
 
 func TestParseWorkflowMemoryTrackerIssues(t *testing.T) {
@@ -508,6 +602,35 @@ Prompt
 				"tracker.priority_map ranks must be integers 1 through 4 or null",
 				"agent.lessons.path must be a relative path inside the workspace",
 				"agent.skills.path must be a relative path inside the workspace",
+			},
+		},
+		{
+			name: "invalid agents config",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex
+      kind: claude
+      protocol: stream
+      command: ""
+  routes:
+    - backend: missing
+      default: true
+    - backend: codex
+      default: true
+      selector:
+        priority_in: [0]
+---
+Prompt
+`,
+			want: []string{
+				"agents.backends.kind must be codex",
+				"agents.backends.command is required",
+				"agents.routes.backend must reference a configured backend",
+				"agents.routes.selector.priority_in values must be integers 1 through 4",
+				"agents.routes must not define multiple default routes",
 			},
 		},
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -310,6 +310,33 @@ Prompt
 	}
 }
 
+func TestParseWorkflowAgentRoutesCanUseLegacyCodexBackend(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+codex:
+  command: codex app-server
+agents:
+  routes:
+    - name: project-model
+      backend: codex
+      model_field: Model
+    - name: default
+      backend: codex
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+}
+
 func TestParseWorkflowMemoryTrackerIssues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -501,6 +501,39 @@ func TestDispatchCandidatesAssignsLeastLoadedWorkerHost(t *testing.T) {
 	}
 }
 
+func TestDispatchIssueIncludesSelectorContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		SelectorPersona:     " persona-reviewer ",
+	})
+	runner := newWorkerHostRunner()
+	orch := Orchestrator{
+		cfg:        cfg,
+		connector:  selectorContextConnector{login: "worker-1"},
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion),
+	}
+	state := newState(cfg)
+	now := time.Now()
+	issue := dispatchTestIssue("issue-selector-context", "Todo")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch.dispatchIssue(ctx, &state, issue, 0, now, "")
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.SelectorContext.InstanceLogin != "worker-1" {
+		t.Fatalf("SelectorContext.InstanceLogin = %q, want worker-1", request.SelectorContext.InstanceLogin)
+	}
+	if request.SelectorContext.Persona != "persona-reviewer" {
+		t.Fatalf("SelectorContext.Persona = %q, want persona-reviewer", request.SelectorContext.Persona)
+	}
+}
+
 func TestSelectWorkerHostKeepsPreferredHostWhenAvailable(t *testing.T) {
 	t.Parallel()
 
@@ -547,6 +580,15 @@ func dispatchTestIssueWithPullRequest(id, state, prState string) connector.Issue
 
 type workerHostRunner struct {
 	started chan RunRequest
+}
+
+type selectorContextConnector struct {
+	connector.Connector
+	login string
+}
+
+func (c selectorContextConnector) InstanceLogin() string {
+	return c.login
 }
 
 func newWorkerHostRunner() *workerHostRunner {

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/digitaldrywood/detent/internal/codex"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
@@ -63,7 +62,7 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 			Prompt: "Work on {{ issue.identifier }}",
 		},
 		Workspace: workspaceBackend,
-		Codex: &e2eCodexClient{
+		AgentBackend: &e2eAgentBackend{
 			inputTokens:  321,
 			outputTokens: 45,
 			totalTokens:  366,
@@ -139,32 +138,32 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 	}
 }
 
-type e2eCodexClient struct {
+type e2eAgentBackend struct {
 	inputTokens  int64
 	outputTokens int64
 	totalTokens  int64
 }
 
-func (c *e2eCodexClient) RunTurn(_ context.Context, req codex.RunTurnRequest, onUpdate codex.UpdateHandler) (codex.RunTurnResult, error) {
+func (c *e2eAgentBackend) RunTurn(_ context.Context, req runpkg.AgentTurnRequest, onUpdate runpkg.AgentUpdateHandler) (runpkg.AgentTurnResult, error) {
 	if strings.TrimSpace(req.Workspace) == "" {
-		return codex.RunTurnResult{}, errors.New("workspace is required")
+		return runpkg.AgentTurnResult{}, errors.New("workspace is required")
 	}
 	if err := os.WriteFile(filepath.Join(req.Workspace, "agent-output.txt"), []byte("done\n"), 0o600); err != nil {
-		return codex.RunTurnResult{}, fmt.Errorf("write agent output: %w", err)
+		return runpkg.AgentTurnResult{}, fmt.Errorf("write agent output: %w", err)
 	}
 	if onUpdate != nil {
-		if err := onUpdate(codex.Update{
-			Type: codex.UpdateTokenUsage,
-			Tokens: codex.TokenUsage{
+		if err := onUpdate(runpkg.AgentUpdate{
+			Type: runpkg.AgentUpdateTokenUsage,
+			Tokens: runpkg.AgentTokenUsage{
 				InputTokens:  c.inputTokens,
 				OutputTokens: c.outputTokens,
 				TotalTokens:  c.totalTokens,
 			},
 		}); err != nil {
-			return codex.RunTurnResult{}, err
+			return runpkg.AgentTurnResult{}, err
 		}
 	}
-	return codex.RunTurnResult{ThreadID: "thread-e2e", TurnID: "turn-e2e", SessionID: "thread-e2e-turn-e2e"}, nil
+	return runpkg.AgentTurnResult{ThreadID: "thread-e2e", TurnID: "turn-e2e", SessionID: "thread-e2e-turn-e2e"}, nil
 }
 
 func waitForCompletedIssue(t *testing.T, orch *Orchestrator, issueID string) State {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -11,6 +11,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -51,6 +52,7 @@ type Config struct {
 	BudgetRefusalCooldown      time.Duration
 	ContinuationRetryDelay     time.Duration
 	FailureRetryBaseDelay      time.Duration
+	SelectorPersona            string
 }
 
 type Dependencies struct {
@@ -109,6 +111,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		TerminalStates:        append([]string(nil), cfg.Tracker.TerminalStates...),
 		WorkerHosts:           append([]string(nil), cfg.Worker.SSHHosts...),
 		BudgetRefusalCooldown: durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
+		SelectorPersona:       cfg.Tracker.Assignee,
 	}
 }
 
@@ -880,13 +883,24 @@ func (o *Orchestrator) dispatchIssue(
 	delete(state.BudgetRefusals, issue.ID)
 
 	request := RunRequest{
-		Issue:         issue,
-		Attempt:       attempt,
-		StartedAt:     now,
-		WorkerHost:    workerHost,
-		OnUsageUpdate: o.usageUpdateHandler(ctx, issue.ID),
+		Issue:           issue,
+		Attempt:         attempt,
+		StartedAt:       now,
+		WorkerHost:      workerHost,
+		SelectorContext: o.selectorContext(),
+		OnUsageUpdate:   o.usageUpdateHandler(ctx, issue.ID),
 	}
 	o.supervisor.Dispatch(ctx, request, o.runResults)
+}
+
+func (o *Orchestrator) selectorContext() selector.Context {
+	ctx := selector.Context{
+		Persona: o.cfg.SelectorPersona,
+	}
+	if identifier, ok := o.connector.(connector.InstanceIdentifier); ok {
+		ctx.InstanceLogin = identifier.InstanceLogin()
+	}
+	return ctx
 }
 
 func (o *Orchestrator) usageUpdateHandler(ctx context.Context, issueID string) runpkg.UsageUpdateHandler {
@@ -1113,6 +1127,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
 	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
 	cfg.WorkerHosts = normalizeWorkerHosts(cfg.WorkerHosts)
+	cfg.SelectorPersona = strings.TrimSpace(cfg.SelectorPersona)
 	if cfg.MaxConcurrentAgentsPerHost < 0 {
 		cfg.MaxConcurrentAgentsPerHost = 0
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -226,8 +226,8 @@ func routesFromConfig(routes []config.AgentRoute) []Route {
 	return out
 }
 
-func (r agentRuntime) selectBackend(issue connector.Issue) (RouteSelection, AgentBackend, config.AgentBackend, error) {
-	selection, err := r.router.Route(issue, selectorContext())
+func (r agentRuntime) selectBackend(issue connector.Issue, ctx selector.Context) (RouteSelection, AgentBackend, config.AgentBackend, error) {
+	selection, err := r.router.Route(issue, ctx)
 	if err != nil {
 		return RouteSelection{}, nil, config.AgentBackend{}, err
 	}
@@ -242,10 +242,6 @@ func (r agentRuntime) selectBackend(issue connector.Issue) (RouteSelection, Agen
 	return selection, backend, backendConfig, nil
 }
 
-func selectorContext() selector.Context {
-	return selector.Context{}
-}
-
 func cloneAgentBackends(in map[string]AgentBackend) map[string]AgentBackend {
 	if len(in) == 0 {
 		return nil
@@ -255,6 +251,13 @@ func cloneAgentBackends(in map[string]AgentBackend) map[string]AgentBackend {
 		out[id] = backend
 	}
 	return out
+}
+
+func selectorContext(ctx selector.Context, workflow config.Workflow) selector.Context {
+	if strings.TrimSpace(ctx.Persona) == "" {
+		ctx.Persona = workflow.Config.Tracker.Assignee
+	}
+	return ctx
 }
 
 func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
@@ -294,7 +297,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
 	}
-	selection, backend, backendConfig, err := agentRuntime.selectBackend(req.Issue)
+	selection, backend, backendConfig, err := agentRuntime.selectBackend(req.Issue, selectorContext(req.SelectorContext, workflow))
 	if err != nil {
 		return RunResult{}, err
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -14,9 +14,9 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/budget"
-	"github.com/digitaldrywood/detent/internal/codex"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/skills"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -31,13 +31,9 @@ const (
 )
 
 var (
-	ErrMissingWorkspace = errors.New("runner workspace backend is required")
-	ErrMissingCodex     = errors.New("runner codex client is required")
+	ErrMissingWorkspace    = errors.New("runner workspace backend is required")
+	ErrMissingAgentBackend = errors.New("runner agent backend is required")
 )
-
-type CodexClient interface {
-	RunTurn(context.Context, codex.RunTurnRequest, codex.UpdateHandler) (codex.RunTurnResult, error)
-}
 
 type SessionStore interface {
 	StartSession(context.Context, store.SessionStart) (int64, error)
@@ -45,37 +41,47 @@ type SessionStore interface {
 	RecordUsageEvent(context.Context, store.UsageEvent) (int64, error)
 }
 
+type AgentBackendFactory interface {
+	NewAgentBackend(config.AgentBackend) (AgentBackend, error)
+}
+
+type AgentBackendFactoryFunc func(config.AgentBackend) (AgentBackend, error)
+
+func (f AgentBackendFactoryFunc) NewAgentBackend(cfg config.AgentBackend) (AgentBackend, error) {
+	return f(cfg)
+}
+
 type Dependencies struct {
-	ProjectID       string
-	Workflow        config.Workflow
-	Workspace       workspace.Backend
-	Codex           CodexClient
-	Store           SessionStore
-	Pricing         budget.PricingTable
-	Now             func() time.Time
-	Logger          *slog.Logger
-	AfterRunTimeout time.Duration
+	ProjectID           string
+	Workflow            config.Workflow
+	Workspace           workspace.Backend
+	AgentBackend        AgentBackend
+	AgentBackends       map[string]AgentBackend
+	AgentBackendFactory AgentBackendFactory
+	Store               SessionStore
+	Pricing             budget.PricingTable
+	Now                 func() time.Time
+	Logger              *slog.Logger
+	AfterRunTimeout     time.Duration
 }
 
 type Runner struct {
-	mu              sync.RWMutex
-	projectID       string
-	workflow        config.Workflow
-	workspace       workspace.Backend
-	codex           CodexClient
-	store           SessionStore
-	pricing         budget.PricingTable
-	now             func() time.Time
-	logger          *slog.Logger
-	afterRunTimeout time.Duration
+	mu                  sync.RWMutex
+	projectID           string
+	workflow            config.Workflow
+	workspace           workspace.Backend
+	agentRuntime        agentRuntime
+	agentBackendFactory AgentBackendFactory
+	store               SessionStore
+	pricing             budget.PricingTable
+	now                 func() time.Time
+	logger              *slog.Logger
+	afterRunTimeout     time.Duration
 }
 
 func NewRunner(deps Dependencies) (*Runner, error) {
 	if deps.Workspace == nil {
 		return nil, ErrMissingWorkspace
-	}
-	if deps.Codex == nil {
-		return nil, ErrMissingCodex
 	}
 	if deps.Now == nil {
 		deps.Now = time.Now
@@ -90,32 +96,172 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 	if projectID == "" {
 		projectID = defaultProjectID
 	}
+	agentBackends := cloneAgentBackends(deps.AgentBackends)
+	if deps.AgentBackend != nil {
+		if agentBackends == nil {
+			agentBackends = map[string]AgentBackend{}
+		}
+		agentBackends[config.DefaultAgentBackendID] = deps.AgentBackend
+	}
+	runtime, err := newAgentRuntime(deps.Workflow, agentBackends, deps.AgentBackendFactory)
+	if err != nil {
+		return nil, err
+	}
 
 	return &Runner{
-		projectID:       projectID,
-		workflow:        deps.Workflow,
-		workspace:       deps.Workspace,
-		codex:           deps.Codex,
-		store:           deps.Store,
-		pricing:         deps.Pricing,
-		now:             deps.Now,
-		logger:          deps.Logger,
-		afterRunTimeout: deps.AfterRunTimeout,
+		projectID:           projectID,
+		workflow:            deps.Workflow,
+		workspace:           deps.Workspace,
+		agentRuntime:        runtime,
+		agentBackendFactory: deps.AgentBackendFactory,
+		store:               deps.Store,
+		pricing:             deps.Pricing,
+		now:                 deps.Now,
+		logger:              deps.Logger,
+		afterRunTimeout:     deps.AfterRunTimeout,
 	}, nil
 }
 
 func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
+	r.mu.RLock()
+	currentBackends := cloneAgentBackends(r.agentRuntime.backends)
+	factory := r.agentBackendFactory
+	r.mu.RUnlock()
+
+	runtime, err := newAgentRuntime(workflow, currentBackends, factory)
+
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.workflow = workflow
+	if err != nil {
+		r.logger.Warn("reload agent runtime failed", "error", err)
+		return
+	}
+	r.agentRuntime = runtime
+}
+
+type agentRuntime struct {
+	backends       map[string]AgentBackend
+	backendConfigs map[string]config.AgentBackend
+	router         *Router
+}
+
+func newAgentRuntime(
+	workflow config.Workflow,
+	staticBackends map[string]AgentBackend,
+	factory AgentBackendFactory,
+) (agentRuntime, error) {
+	backendConfigs := effectiveAgentBackendConfigs(workflow.Config)
+	backends := make(map[string]AgentBackend, len(backendConfigs))
+	configsByID := make(map[string]config.AgentBackend, len(backendConfigs))
+	for _, backendConfig := range backendConfigs {
+		if strings.TrimSpace(backendConfig.ID) == "" {
+			continue
+		}
+		configsByID[backendConfig.ID] = backendConfig
+		if factory != nil {
+			backend, err := factory.NewAgentBackend(backendConfig)
+			if err != nil {
+				return agentRuntime{}, fmt.Errorf("create agent backend %s: %w", backendConfig.ID, err)
+			}
+			backends[backendConfig.ID] = backend
+			continue
+		}
+		backend, ok := staticBackends[backendConfig.ID]
+		if !ok {
+			return agentRuntime{}, fmt.Errorf("%w: %s", ErrMissingAgentBackend, backendConfig.ID)
+		}
+		backends[backendConfig.ID] = backend
+	}
+	if len(backends) == 0 {
+		return agentRuntime{}, ErrMissingAgentBackend
+	}
+
+	router, err := NewRouter(routesFromConfig(workflow.Config.AgentRouteConfigs()))
+	if err != nil {
+		return agentRuntime{}, err
+	}
+	for _, route := range router.routes {
+		if _, ok := backends[route.BackendID]; !ok {
+			return agentRuntime{}, fmt.Errorf("%w: %s", ErrMissingAgentBackend, route.BackendID)
+		}
+	}
+
+	return agentRuntime{
+		backends:       backends,
+		backendConfigs: configsByID,
+		router:         router,
+	}, nil
+}
+
+func effectiveAgentBackendConfigs(cfg config.Config) []config.AgentBackend {
+	configs := cfg.AgentBackendConfigs()
+	for index, backend := range configs {
+		if backend.Kind != config.AgentBackendCodex {
+			continue
+		}
+		effectiveCodex := backend.CodexConfig(cfg.Codex)
+		effective := config.CodexAgentBackend(effectiveCodex)
+		effective.ID = backend.ID
+		effective.Kind = backend.Kind
+		effective.Protocol = backend.Protocol
+		configs[index] = effective
+	}
+	return configs
+}
+
+func routesFromConfig(routes []config.AgentRoute) []Route {
+	out := make([]Route, 0, len(routes))
+	for _, route := range routes {
+		out = append(out, Route{
+			Name:       route.Name,
+			BackendID:  route.Backend,
+			Model:      route.Model,
+			ModelField: route.ModelField,
+			Default:    route.Default,
+			Selector:   route.Selector,
+		})
+	}
+	return out
+}
+
+func (r agentRuntime) selectBackend(issue connector.Issue) (RouteSelection, AgentBackend, config.AgentBackend, error) {
+	selection, err := r.router.Route(issue, selectorContext())
+	if err != nil {
+		return RouteSelection{}, nil, config.AgentBackend{}, err
+	}
+	backend, ok := r.backends[selection.BackendID]
+	if !ok {
+		return RouteSelection{}, nil, config.AgentBackend{}, fmt.Errorf("%w: %s", ErrMissingAgentBackend, selection.BackendID)
+	}
+	backendConfig, ok := r.backendConfigs[selection.BackendID]
+	if !ok {
+		return RouteSelection{}, nil, config.AgentBackend{}, fmt.Errorf("agent backend config not found: %s", selection.BackendID)
+	}
+	return selection, backend, backendConfig, nil
+}
+
+func selectorContext() selector.Context {
+	return selector.Context{}
+}
+
+func cloneAgentBackends(in map[string]AgentBackend) map[string]AgentBackend {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]AgentBackend, len(in))
+	for id, backend := range in {
+		out[id] = backend
+	}
+	return out
 }
 
 func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	workflow := r.workflowSnapshot()
+	workflow, agentRuntime := r.runtimeSnapshot()
 
 	workspaceIssue := workspaceIssue(req.Issue)
 	info, err := r.workspace.Create(ctx, workspaceIssue)
@@ -148,29 +294,33 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
 	}
+	selection, backend, backendConfig, err := agentRuntime.selectBackend(req.Issue)
+	if err != nil {
+		return RunResult{}, err
+	}
 
 	startedAt := req.StartedAt
 	if startedAt.IsZero() {
 		startedAt = r.now().UTC()
 	}
 	runStartedAt := r.now()
-	model := strings.TrimSpace(req.Issue.ModelOverride)
+	model := selection.Model
 	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, model)
 	if err != nil {
 		return RunResult{}, err
 	}
 
 	result := RunResult{FinalState: FinalStateCompleted}
-	progress := newCodexRunProgress()
-	turnResult, turnErr := r.codex.RunTurn(ctx, codex.RunTurnRequest{
+	progress := newAgentRunProgress()
+	turnResult, turnErr := backend.RunTurn(ctx, AgentTurnRequest{
 		Workspace:         info.Path,
 		Prompt:            prompt,
-		ApprovalPolicy:    stringOrMapValue(workflow.Config.Codex.ApprovalPolicy),
-		ThreadSandbox:     workflow.Config.Codex.ThreadSandbox,
-		TurnSandboxPolicy: workflow.Config.Codex.TurnSandboxPolicy,
+		ApprovalPolicy:    stringOrMapValue(backendConfig.Options.ApprovalPolicy),
+		ThreadSandbox:     backendConfig.Options.ThreadSandbox,
+		TurnSandboxPolicy: backendConfig.Options.TurnSandboxPolicy,
 		Model:             model,
-	}, func(update codex.Update) error {
-		applyCodexUpdate(&result, update)
+	}, func(update AgentUpdate) error {
+		applyAgentUpdate(&result, update)
 		if err := r.publishRunUpdate(ctx, req, info, workspaceIssue, progress, result, update, runStartedAt); err != nil {
 			return err
 		}
@@ -186,7 +336,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		finishedAt := r.now().UTC()
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
-			fmt.Errorf("run codex turn: %w", turnErr),
+			fmt.Errorf("run agent turn: %w", turnErr),
 			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1),
 		)
 	}
@@ -211,11 +361,11 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	return result, nil
 }
 
-func (r *Runner) workflowSnapshot() config.Workflow {
+func (r *Runner) runtimeSnapshot() (config.Workflow, agentRuntime) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	return r.workflow
+	return r.workflow, r.agentRuntime
 }
 
 func (r *Runner) availableSkills(workflow config.Workflow, workspacePath string) ([]skills.Skill, error) {
@@ -340,18 +490,18 @@ func workspaceIssue(issue connector.Issue) workspace.Issue {
 	}
 }
 
-func applyCodexUpdate(result *RunResult, update codex.Update) {
+func applyAgentUpdate(result *RunResult, update AgentUpdate) {
 	switch update.Type {
-	case codex.UpdateTokenUsage:
+	case AgentUpdateTokenUsage:
 		result.Tokens.InputTokens = update.Tokens.InputTokens
 		result.Tokens.OutputTokens = update.Tokens.OutputTokens
 		result.Tokens.TotalTokens = update.Tokens.TotalTokens
-	case codex.UpdateRateLimits:
-		result.RateLimits = rateLimitsFromCodex(update.RateLimits)
+	case AgentUpdateRateLimits:
+		result.RateLimits = update.RateLimits
 	}
 }
 
-type codexRunProgress struct {
+type agentRunProgress struct {
 	sessionID          string
 	processIdentity    string
 	turnIDs            map[string]struct{}
@@ -365,14 +515,14 @@ type codexRunProgress struct {
 	diffStatsCheckedAt time.Time
 }
 
-func newCodexRunProgress() *codexRunProgress {
-	return &codexRunProgress{
+func newAgentRunProgress() *agentRunProgress {
+	return &agentRunProgress{
 		turnIDs:  map[string]struct{}{},
 		messages: map[string]string{},
 	}
 }
 
-func (p *codexRunProgress) apply(update codex.Update, eventAt time.Time) {
+func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 	if update.ProcessIdentity != "" {
 		p.processIdentity = update.ProcessIdentity
 	}
@@ -389,7 +539,7 @@ func (p *codexRunProgress) apply(update codex.Update, eventAt time.Time) {
 
 	eventMessage := ""
 	switch update.Type {
-	case codex.UpdateAgentMessageDelta:
+	case AgentUpdateMessageDelta:
 		key := update.ItemID
 		if key == "" {
 			key = update.TurnID
@@ -397,21 +547,21 @@ func (p *codexRunProgress) apply(update codex.Update, eventAt time.Time) {
 		p.messages[key] += update.Delta
 		p.lastMessage = strings.TrimSpace(p.messages[key])
 		eventMessage = p.lastMessage
-	case codex.UpdateTurnStarted:
+	case AgentUpdateTurnStarted:
 		p.lastMessage = "turn started"
 		eventMessage = p.lastMessage
-	case codex.UpdateTurnCompleted:
+	case AgentUpdateTurnCompleted:
 		status := update.Status
 		if status == "" {
 			status = "completed"
 		}
 		p.lastMessage = "turn " + status
 		eventMessage = p.lastMessage
-	case codex.UpdateTokenUsage:
+	case AgentUpdateTokenUsage:
 		eventMessage = tokenUsageActivityMessage(update.Tokens)
-	case codex.UpdateRateLimits:
+	case AgentUpdateRateLimits:
 		eventMessage = rateLimitsActivityMessage(update.RateLimits)
-	case codex.UpdateProcessStarted:
+	case AgentUpdateProcessStarted:
 		if p.processIdentity != "" {
 			eventMessage = "process " + p.processIdentity + " started"
 		} else {
@@ -426,7 +576,7 @@ func (p *codexRunProgress) apply(update codex.Update, eventAt time.Time) {
 	})
 }
 
-func tokenUsageActivityMessage(tokens codex.TokenUsage) string {
+func tokenUsageActivityMessage(tokens AgentTokenUsage) string {
 	if tokens.TotalTokens > 0 && (tokens.InputTokens > 0 || tokens.OutputTokens > 0) {
 		return fmt.Sprintf("%d total tokens (%d in, %d out)", tokens.TotalTokens, tokens.InputTokens, tokens.OutputTokens)
 	}
@@ -436,7 +586,7 @@ func tokenUsageActivityMessage(tokens codex.TokenUsage) string {
 	return "tokens updated"
 }
 
-func rateLimitsActivityMessage(snapshot *codex.RateLimitSnapshot) string {
+func rateLimitsActivityMessage(snapshot *telemetry.RateLimits) string {
 	if snapshot == nil {
 		return "rate limits updated"
 	}
@@ -450,11 +600,11 @@ func rateLimitsActivityMessage(snapshot *codex.RateLimitSnapshot) string {
 	return name + " rate limits updated"
 }
 
-func (p *codexRunProgress) turnCount() int {
+func (p *agentRunProgress) turnCount() int {
 	return len(p.turnIDs)
 }
 
-func (p *codexRunProgress) addRecentEvent(event telemetry.ActivityEvent) {
+func (p *agentRunProgress) addRecentEvent(event telemetry.ActivityEvent) {
 	if event.Event == "" && event.Message == "" {
 		return
 	}
@@ -464,7 +614,7 @@ func (p *codexRunProgress) addRecentEvent(event telemetry.ActivityEvent) {
 	}
 }
 
-func (p *codexRunProgress) recentActivity() []telemetry.ActivityEvent {
+func (p *agentRunProgress) recentActivity() []telemetry.ActivityEvent {
 	if len(p.recentEvents) == 0 {
 		return nil
 	}
@@ -478,9 +628,9 @@ func (r *Runner) publishRunUpdate(
 	req RunRequest,
 	info workspace.Info,
 	issue workspace.Issue,
-	progress *codexRunProgress,
+	progress *agentRunProgress,
 	result RunResult,
-	update codex.Update,
+	update AgentUpdate,
 	runStartedAt time.Time,
 ) error {
 	if req.OnUsageUpdate == nil {
@@ -512,7 +662,7 @@ func (r *Runner) liveDiffStats(
 	ctx context.Context,
 	info workspace.Info,
 	issue workspace.Issue,
-	progress *codexRunProgress,
+	progress *agentRunProgress,
 	eventAt time.Time,
 ) (DiffStats, bool) {
 	if !progress.shouldRefreshDiffStats(eventAt) {
@@ -538,14 +688,14 @@ func (r *Runner) liveDiffStats(
 	return diffStats, true
 }
 
-func (p *codexRunProgress) shouldRefreshDiffStats(eventAt time.Time) bool {
+func (p *agentRunProgress) shouldRefreshDiffStats(eventAt time.Time) bool {
 	if p.diffStatsCheckedAt.IsZero() {
 		return true
 	}
 	return eventAt.Sub(p.diffStatsCheckedAt) >= liveDiffStatsInterval
 }
 
-func (p *codexRunProgress) cachedDiffStats() (DiffStats, bool) {
+func (p *agentRunProgress) cachedDiffStats() (DiffStats, bool) {
 	if !p.diffStatsCollected {
 		return DiffStats{}, false
 	}
@@ -578,55 +728,6 @@ func pullRequestNumber(issue connector.Issue) *int64 {
 		return nil
 	}
 	return &number
-}
-
-func rateLimitsFromCodex(snapshot *codex.RateLimitSnapshot) *telemetry.RateLimits {
-	if snapshot == nil {
-		return nil
-	}
-	return &telemetry.RateLimits{
-		LimitID:   snapshot.LimitID,
-		LimitName: snapshot.LimitName,
-		Primary:   rateLimitBucketFromCodex(snapshot.Primary),
-		Secondary: rateLimitBucketFromCodex(snapshot.Secondary),
-		Credits:   creditsBucketFromCodex(snapshot.Credits),
-	}
-}
-
-func rateLimitBucketFromCodex(window *codex.RateLimitWindow) *telemetry.RateLimitBucket {
-	if window == nil {
-		return nil
-	}
-
-	used := int64(math.Round(window.UsedPercent))
-	if used < 0 {
-		used = 0
-	}
-	if used > 100 {
-		used = 100
-	}
-
-	bucket := &telemetry.RateLimitBucket{
-		Limit:     100,
-		Used:      used,
-		Remaining: 100 - used,
-	}
-	if window.ResetsAt != nil {
-		resetAt := time.Unix(*window.ResetsAt, 0).UTC()
-		bucket.ResetAt = &resetAt
-	}
-	return bucket
-}
-
-func creditsBucketFromCodex(credits *codex.CreditsSnapshot) *telemetry.RateLimitBucket {
-	if credits == nil {
-		return nil
-	}
-	return &telemetry.RateLimitBucket{
-		HasCredits: credits.HasCredits,
-		Unlimited:  credits.Unlimited,
-		Balance:    credits.Balance,
-	}
 }
 
 func diffStatsFromWorkspace(stat workspace.DiffStat) DiffStats {

--- a/internal/runner/router.go
+++ b/internal/runner/router.go
@@ -1,0 +1,128 @@
+package runner
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+var (
+	ErrMissingAgentRoutes = errors.New("agent routes are required")
+	ErrNoMatchingRoute    = errors.New("no matching agent route")
+)
+
+type Route struct {
+	Name       string
+	BackendID  string
+	Model      string
+	ModelField string
+	Default    bool
+	Selector   selector.Selector
+}
+
+type RouteSelection struct {
+	BackendID string
+	Model     string
+	RouteName string
+}
+
+type Router struct {
+	routes       []Route
+	defaultIndex int
+}
+
+func NewRouter(routes []Route) (*Router, error) {
+	if len(routes) == 0 {
+		return nil, ErrMissingAgentRoutes
+	}
+
+	normalized := make([]Route, len(routes))
+	defaultIndex := -1
+	for index, route := range routes {
+		route.Name = strings.TrimSpace(route.Name)
+		route.BackendID = strings.TrimSpace(route.BackendID)
+		route.Model = strings.TrimSpace(route.Model)
+		route.ModelField = strings.TrimSpace(route.ModelField)
+		if route.BackendID == "" {
+			return nil, fmt.Errorf("agent route %d backend is required", index)
+		}
+		if route.Default {
+			if defaultIndex >= 0 {
+				return nil, errors.New("agent routes must not define multiple defaults")
+			}
+			defaultIndex = index
+		}
+		normalized[index] = route
+	}
+
+	return &Router{
+		routes:       normalized,
+		defaultIndex: defaultIndex,
+	}, nil
+}
+
+func (r *Router) Route(issue connector.Issue, ctx selector.Context) (RouteSelection, error) {
+	if r == nil || len(r.routes) == 0 {
+		return RouteSelection{}, ErrMissingAgentRoutes
+	}
+
+	for _, route := range r.routes {
+		if route.Default {
+			continue
+		}
+		if route.matches(issue, ctx) {
+			return route.selection(issue), nil
+		}
+	}
+
+	if r.defaultIndex >= 0 {
+		return r.routes[r.defaultIndex].selection(issue), nil
+	}
+
+	return RouteSelection{}, ErrNoMatchingRoute
+}
+
+func (r Route) matches(issue connector.Issue, ctx selector.Context) bool {
+	if r.ModelField != "" {
+		value, ok := issueFieldValue(issue.Fields, r.ModelField)
+		if !ok || strings.TrimSpace(value) == "" {
+			return false
+		}
+	}
+	return selector.Match(issue, r.Selector, ctx)
+}
+
+func (r Route) selection(issue connector.Issue) RouteSelection {
+	model := strings.TrimSpace(r.Model)
+	if model == "" && r.ModelField != "" {
+		model, _ = issueFieldValue(issue.Fields, r.ModelField)
+		model = strings.TrimSpace(model)
+	}
+	if model == "" {
+		model = strings.TrimSpace(issue.ModelOverride)
+	}
+	return RouteSelection{
+		BackendID: r.BackendID,
+		Model:     model,
+		RouteName: r.Name,
+	}
+}
+
+func issueFieldValue(fields map[string]string, name string) (string, bool) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", false
+	}
+	if value, ok := fields[name]; ok {
+		return value, true
+	}
+	for fieldName, value := range fields {
+		if strings.TrimSpace(fieldName) == name {
+			return value, true
+		}
+	}
+	return "", false
+}

--- a/internal/runner/router_test.go
+++ b/internal/runner/router_test.go
@@ -1,0 +1,171 @@
+package runner
+
+import (
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+func TestRouterRoutesByLabelModelFieldPriorityAndDefault(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter([]Route{
+		{
+			Name:      "label",
+			BackendID: "codex-high",
+			Model:     "gpt-5-codex-high",
+			Selector: selector.Selector{
+				Labels: selector.Labels{Include: []string{"tier:high"}},
+			},
+		},
+		{
+			Name:       "model-field",
+			BackendID:  "codex-standard",
+			ModelField: "Model",
+		},
+		{
+			Name:      "priority",
+			BackendID: "codex-high",
+			Model:     "gpt-5-codex-priority",
+			Selector: selector.Selector{
+				PriorityIn: []int{1},
+			},
+		},
+		{
+			Name:      "default",
+			BackendID: "codex-standard",
+			Model:     "gpt-5-codex-mini",
+			Default:   true,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	priorityOne := 1
+	tests := []struct {
+		name        string
+		issue       connector.Issue
+		wantBackend string
+		wantModel   string
+		wantRoute   string
+	}{
+		{
+			name: "label route",
+			issue: connector.Issue{
+				Labels: []string{"tier:high"},
+				Fields: map[string]string{},
+			},
+			wantBackend: "codex-high",
+			wantModel:   "gpt-5-codex-high",
+			wantRoute:   "label",
+		},
+		{
+			name: "model project field route",
+			issue: connector.Issue{
+				Labels: []string{},
+				Fields: map[string]string{"Model": "gpt-5-codex"},
+			},
+			wantBackend: "codex-standard",
+			wantModel:   "gpt-5-codex",
+			wantRoute:   "model-field",
+		},
+		{
+			name: "priority route",
+			issue: connector.Issue{
+				Priority: &priorityOne,
+				Labels:   []string{},
+				Fields:   map[string]string{},
+			},
+			wantBackend: "codex-high",
+			wantModel:   "gpt-5-codex-priority",
+			wantRoute:   "priority",
+		},
+		{
+			name: "default route",
+			issue: connector.Issue{
+				Labels: []string{},
+				Fields: map[string]string{},
+			},
+			wantBackend: "codex-standard",
+			wantModel:   "gpt-5-codex-mini",
+			wantRoute:   "default",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := router.Route(tt.issue, selector.Context{})
+			if err != nil {
+				t.Fatalf("Route() error = %v", err)
+			}
+			if got.BackendID != tt.wantBackend || got.Model != tt.wantModel || got.RouteName != tt.wantRoute {
+				t.Fatalf("Route() = %#v, want backend %q model %q route %q", got, tt.wantBackend, tt.wantModel, tt.wantRoute)
+			}
+		})
+	}
+}
+
+func TestRouterSingleDefaultRouteKeepsIssueModelOverride(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter([]Route{{
+		Name:      "default",
+		BackendID: "codex",
+		Default:   true,
+	}})
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	got, err := router.Route(connector.Issue{ModelOverride: "gpt-5-codex-high"}, selector.Context{})
+	if err != nil {
+		t.Fatalf("Route() error = %v", err)
+	}
+	if got.BackendID != "codex" {
+		t.Fatalf("BackendID = %q, want codex", got.BackendID)
+	}
+	if got.Model != "gpt-5-codex-high" {
+		t.Fatalf("Model = %q, want issue override", got.Model)
+	}
+}
+
+func TestRouterRejectsInvalidRoutes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		routes []Route
+	}{
+		{
+			name:   "empty",
+			routes: nil,
+		},
+		{
+			name: "blank backend",
+			routes: []Route{{
+				Default: true,
+			}},
+		},
+		{
+			name: "multiple defaults",
+			routes: []Route{
+				{BackendID: "codex", Default: true},
+				{BackendID: "codex-high", Default: true},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := NewRouter(tt.routes); err == nil {
+				t.Fatal("NewRouter() error = nil, want error")
+			}
+		})
+	}
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -12,10 +12,10 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/budget"
-	"github.com/digitaldrywood/detent/internal/codex"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
 
@@ -41,9 +41,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 		},
 	}
 	codexClient := &fakeCodexClient{
-		updates: []codex.Update{
+		updates: []AgentUpdate{
 			{
-				Type:            codex.UpdateAgentMessageDelta,
+				Type:            AgentUpdateMessageDelta,
 				ProcessIdentity: "4242",
 				ThreadID:        "thread-1",
 				TurnID:          "turn-1",
@@ -51,28 +51,28 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 				Delta:           "hello",
 			},
 			{
-				Type:     codex.UpdateTokenUsage,
+				Type:     AgentUpdateTokenUsage,
 				ThreadID: "thread-1",
 				TurnID:   "turn-1",
-				Tokens: codex.TokenUsage{
+				Tokens: AgentTokenUsage{
 					InputTokens:  100,
 					OutputTokens: 25,
 					TotalTokens:  125,
 				},
 			},
 			{
-				Type: codex.UpdateRateLimits,
-				RateLimits: &codex.RateLimitSnapshot{
+				Type: AgentUpdateRateLimits,
+				RateLimits: &telemetry.RateLimits{
 					LimitID:   "codex-primary",
 					LimitName: "Codex primary",
-					Credits: &codex.CreditsSnapshot{
+					Credits: &telemetry.RateLimitBucket{
 						HasCredits: true,
 						Balance:    "7.25",
 					},
 				},
 			},
 		},
-		result: codex.RunTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "thread-1-turn-1"},
+		result: AgentTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "thread-1-turn-1"},
 	}
 	sessionStore := &fakeSessionStore{sessionID: 42}
 	now := newFakeClock(
@@ -107,9 +107,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 			},
 			Prompt: "Work on {{ issue.identifier }} attempt {{ attempt }}",
 		},
-		Workspace: workspaceBackend,
-		Codex:     codexClient,
-		Store:     sessionStore,
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
+		Store:        sessionStore,
 		Pricing: budget.PricingTable{
 			"gpt-5-codex-high": {
 				USDPerInputToken:  0.000004,
@@ -283,8 +283,8 @@ func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
 			},
 			Prompt: "initial {{ issue.identifier }}",
 		},
-		Workspace: workspaceBackend,
-		Codex:     codexClient,
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
@@ -316,6 +316,58 @@ func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
 	}
 }
 
+func TestRunnerRunUsesSingleConfiguredBackendDefaultRoute(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-55", Branch: "detent/issue-55"},
+	}
+	backend := &fakeCodexClient{}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agents: config.Agents{
+					Backends: []config.AgentBackend{{
+						ID:       "codex-high",
+						Kind:     config.AgentBackendCodex,
+						Protocol: "app-server",
+						Command:  "codex app-server --profile high",
+					}},
+					Routes: []config.AgentRoute{{
+						Backend: "codex-high",
+						Default: true,
+					}},
+				},
+			},
+			Prompt: "work {{ issue.identifier }}",
+		},
+		Workspace: workspaceBackend,
+		AgentBackends: map[string]AgentBackend{
+			"codex-high": backend,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-55",
+			Identifier:    "digitaldrywood/detent#55",
+			ModelOverride: "gpt-5-codex-high",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if backend.request.Model != "gpt-5-codex-high" {
+		t.Fatalf("Model = %q, want issue override", backend.request.Model)
+	}
+	if backend.request.Workspace != workspaceBackend.info.Path {
+		t.Fatalf("Workspace = %q, want %q", backend.request.Workspace, workspaceBackend.info.Path)
+	}
+}
+
 func TestRunnerRunFinishesFailedSessionAndAfterRunOnCodexError(t *testing.T) {
 	t.Parallel()
 
@@ -327,11 +379,11 @@ func TestRunnerRunFinishesFailedSessionAndAfterRunOnCodexError(t *testing.T) {
 	now := newFakeClock(time.Date(2026, 5, 31, 13, 0, 0, 0, time.UTC))
 
 	runner, err := NewRunner(Dependencies{
-		Workflow:  config.Workflow{Config: config.Config{}},
-		Workspace: workspaceBackend,
-		Codex:     codexClient,
-		Store:     sessionStore,
-		Now:       now.Now,
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
+		Store:        sessionStore,
+		Now:          now.Now,
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
@@ -371,9 +423,9 @@ func TestRunnerRunUsesFreshContextForAfterRunCleanup(t *testing.T) {
 	codexClient := &cancelingCodexClient{cancel: cancel}
 
 	runner, err := NewRunner(Dependencies{
-		Workflow:  config.Workflow{Config: config.Config{}},
-		Workspace: workspaceBackend,
-		Codex:     codexClient,
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
@@ -443,17 +495,17 @@ func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspa
 }
 
 type fakeCodexClient struct {
-	request codex.RunTurnRequest
-	updates []codex.Update
-	result  codex.RunTurnResult
+	request AgentTurnRequest
+	updates []AgentUpdate
+	result  AgentTurnResult
 	err     error
 }
 
-func (c *fakeCodexClient) RunTurn(_ context.Context, req codex.RunTurnRequest, onUpdate codex.UpdateHandler) (codex.RunTurnResult, error) {
+func (c *fakeCodexClient) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
 	c.request = req
 	for _, update := range c.updates {
 		if err := onUpdate(update); err != nil {
-			return codex.RunTurnResult{}, err
+			return AgentTurnResult{}, err
 		}
 	}
 	return c.result, c.err
@@ -463,9 +515,9 @@ type cancelingCodexClient struct {
 	cancel context.CancelFunc
 }
 
-func (c *cancelingCodexClient) RunTurn(context.Context, codex.RunTurnRequest, codex.UpdateHandler) (codex.RunTurnResult, error) {
+func (c *cancelingCodexClient) RunTurn(context.Context, AgentTurnRequest, AgentUpdateHandler) (AgentTurnResult, error) {
 	c.cancel()
-	return codex.RunTurnResult{}, context.Canceled
+	return AgentTurnResult{}, context.Canceled
 }
 
 type fakeSessionStore struct {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workspace"
@@ -365,6 +366,97 @@ func TestRunnerRunUsesSingleConfiguredBackendDefaultRoute(t *testing.T) {
 	}
 	if backend.request.Workspace != workspaceBackend.info.Path {
 		t.Fatalf("Workspace = %q, want %q", backend.request.Workspace, workspaceBackend.info.Path)
+	}
+}
+
+func TestRunnerRunRoutesAtMeSelectorsWithContext(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		issue   connector.Issue
+		route   config.AgentRoute
+		request RunRequest
+		cfg     config.Config
+	}{
+		{
+			name: "instance login",
+			issue: connector.Issue{
+				ID:         "issue-56",
+				Identifier: "digitaldrywood/detent#56",
+				Assignees:  []string{"worker-1"},
+			},
+			route: config.AgentRoute{
+				Backend: "codex",
+				Model:   "gpt-5-codex-high",
+				Selector: selector.Selector{
+					AssigneeIn: []string{"@me"},
+				},
+			},
+			request: RunRequest{
+				SelectorContext: selector.Context{InstanceLogin: "worker-1"},
+			},
+		},
+		{
+			name: "tracker assignee persona",
+			issue: connector.Issue{
+				ID:         "issue-57",
+				Identifier: "digitaldrywood/detent#57",
+				AuthorID:   "persona-reviewer",
+			},
+			route: config.AgentRoute{
+				Backend: "codex",
+				Model:   "gpt-5-codex-high",
+				Selector: selector.Selector{
+					AuthorIn: []string{"@me"},
+				},
+			},
+			cfg: config.Config{
+				Tracker: config.Tracker{Assignee: "persona-reviewer"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Key: tt.issue.ID, Branch: "detent/" + tt.issue.ID},
+			}
+			backend := &fakeCodexClient{}
+			cfg := tt.cfg
+			cfg.Agents = config.Agents{
+				Backends: []config.AgentBackend{{
+					ID:       "codex",
+					Kind:     config.AgentBackendCodex,
+					Protocol: "app-server",
+					Command:  "codex app-server",
+				}},
+				Routes: []config.AgentRoute{
+					tt.route,
+					{Backend: "codex", Model: "gpt-5-codex-mini", Default: true},
+				},
+			}
+			runner, err := NewRunner(Dependencies{
+				Workflow:     config.Workflow{Config: cfg, Prompt: "work {{ issue.identifier }}"},
+				Workspace:    workspaceBackend,
+				AgentBackend: backend,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			req := tt.request
+			req.Issue = tt.issue
+			_, err = runner.Run(context.Background(), req)
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if backend.request.Model != "gpt-5-codex-high" {
+				t.Fatalf("Model = %q, want @me route model", backend.request.Model)
+			}
+		})
 	}
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -74,11 +75,12 @@ type AgentTokenUsage struct {
 }
 
 type RunRequest struct {
-	Issue         connector.Issue
-	Attempt       int
-	StartedAt     time.Time
-	WorkerHost    string
-	OnUsageUpdate UsageUpdateHandler
+	Issue           connector.Issue
+	Attempt         int
+	StartedAt       time.Time
+	WorkerHost      string
+	SelectorContext selector.Context
+	OnUsageUpdate   UsageUpdateHandler
 }
 
 type RunResult struct {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -17,6 +17,62 @@ type Backend interface {
 	Run(context.Context, RunRequest) (RunResult, error)
 }
 
+type AgentBackend interface {
+	RunTurn(context.Context, AgentTurnRequest, AgentUpdateHandler) (AgentTurnResult, error)
+}
+
+type AgentTurnRequest struct {
+	Workspace         string
+	Prompt            string
+	ApprovalPolicy    any
+	ThreadSandbox     string
+	TurnSandboxPolicy any
+	Model             string
+	ModelProvider     string
+	ServiceTier       string
+}
+
+type AgentTurnResult struct {
+	ThreadID  string
+	TurnID    string
+	SessionID string
+}
+
+type AgentUpdateHandler func(AgentUpdate) error
+
+type AgentUpdateType string
+
+const (
+	AgentUpdateProcessStarted AgentUpdateType = "process_started"
+	AgentUpdateMessageDelta   AgentUpdateType = "agent_message_delta"
+	AgentUpdateTokenUsage     AgentUpdateType = "token_usage"
+	AgentUpdateRateLimits     AgentUpdateType = "rate_limits"
+	AgentUpdateTurnStarted    AgentUpdateType = "turn_started"
+	AgentUpdateTurnCompleted  AgentUpdateType = "turn_completed"
+)
+
+type AgentUpdate struct {
+	Type            AgentUpdateType
+	Method          string
+	ProcessIdentity string
+	ThreadID        string
+	TurnID          string
+	ItemID          string
+	Delta           string
+	Status          string
+	Tokens          AgentTokenUsage
+	RateLimits      *telemetry.RateLimits
+}
+
+type AgentTokenUsage struct {
+	InputTokens           int64
+	CachedInputTokens     int64
+	OutputTokens          int64
+	ReasoningOutputTokens int64
+	TotalTokens           int64
+	ModelContextWindow    *int64
+}
+
 type RunRequest struct {
 	Issue         connector.Issue
 	Attempt       int

--- a/internal/selector/match.go
+++ b/internal/selector/match.go
@@ -14,22 +14,23 @@ type Context struct {
 }
 
 type Selector struct {
-	AssigneeIn []string
-	AuthorIn   []string
-	Labels     Labels
-	Fields     []FieldEquals
-	And        []Selector
-	Or         []Selector
+	AssigneeIn []string      `yaml:"assignee_in"`
+	AuthorIn   []string      `yaml:"author_in"`
+	PriorityIn []int         `yaml:"priority_in"`
+	Labels     Labels        `yaml:"labels"`
+	Fields     []FieldEquals `yaml:"fields"`
+	And        []Selector    `yaml:"and"`
+	Or         []Selector    `yaml:"or"`
 }
 
 type Labels struct {
-	Include []string
-	Exclude []string
+	Include []string `yaml:"include"`
+	Exclude []string `yaml:"exclude"`
 }
 
 type FieldEquals struct {
-	Name  string
-	Value string
+	Name  string `yaml:"name"`
+	Value string `yaml:"value"`
 }
 
 func Match(issue connector.Issue, selector Selector, ctx Context) bool {
@@ -43,6 +44,9 @@ func Match(issue connector.Issue, selector Selector, ctx Context) bool {
 		return false
 	}
 	if !matchFields(issue.Fields, selector.Fields, ctx) {
+		return false
+	}
+	if !matchPriority(issue.Priority, selector.PriorityIn) {
 		return false
 	}
 	for _, child := range selector.And {
@@ -59,6 +63,21 @@ func Match(issue connector.Issue, selector Selector, ctx Context) bool {
 		return false
 	}
 	return true
+}
+
+func matchPriority(priority *int, allowed []int) bool {
+	if len(allowed) == 0 {
+		return true
+	}
+	if priority == nil {
+		return false
+	}
+	for _, allowedPriority := range allowed {
+		if *priority == allowedPriority {
+			return true
+		}
+	}
+	return false
 }
 
 func issueAssignees(issue connector.Issue) []string {

--- a/internal/selector/match_test.go
+++ b/internal/selector/match_test.go
@@ -119,6 +119,30 @@ func TestMatch(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "priority in matches configured rank",
+			issue: &connector.Issue{
+				Priority: intPtr(2),
+				Labels:   []string{},
+				Fields:   map[string]string{},
+			},
+			selector: Selector{
+				PriorityIn: []int{1, 2},
+			},
+			want: true,
+		},
+		{
+			name: "priority in rejects different rank",
+			issue: &connector.Issue{
+				Priority: intPtr(3),
+				Labels:   []string{},
+				Fields:   map[string]string{},
+			},
+			selector: Selector{
+				PriorityIn: []int{1, 2},
+			},
+			want: false,
+		},
+		{
 			name: "and group requires every child selector",
 			selector: Selector{
 				And: []Selector{
@@ -209,4 +233,8 @@ func TestMatch(t *testing.T) {
 			}
 		})
 	}
+}
+
+func intPtr(value int) *int {
+	return &value
 }


### PR DESCRIPTION
## Summary

- Add `agents.backends` and `agents.routes` workflow config with legacy `codex:` compatibility.
- Replace the runner Codex client dependency with a generic `AgentBackend` interface, router, and Codex adapter.
- Route tasks by label selectors, `Model` ProjectV2 field values, priority, and default routes.

Fixes #255

## Test Plan

- [x] `go test ./...`
- [x] `make check`