### PR TITLE
feat(orchestrator): add claim leases

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -77,6 +77,7 @@ type Tracker struct {
 	StateMap                StringOrMap       `yaml:"state_map"`
 	PriorityMap             StringOrMap       `yaml:"priority_map"`
 	AutoProvision           bool              `yaml:"auto_provision"`
+	Claims                  Claims            `yaml:"claims,omitempty"`
 	Authorization           selector.Selector `yaml:"authorization,omitempty"`
 	Issues                  []connector.Issue `yaml:"issues"`
 }
@@ -90,6 +91,13 @@ type Identity struct {
 
 type Polling struct {
 	IntervalMS int `yaml:"interval_ms"`
+}
+
+type Claims struct {
+	Enabled          bool   `yaml:"enabled"`
+	LeaseField       string `yaml:"lease_field,omitempty"`
+	TTLSeconds       int    `yaml:"ttl_seconds,omitempty"`
+	HeartbeatSeconds int    `yaml:"heartbeat_seconds,omitempty"`
 }
 
 type Workspace struct {
@@ -332,6 +340,34 @@ func (i Identity) Validate(prefix string) []string {
 	return problems
 }
 
+func (c *Claims) Normalize() {
+	if c == nil {
+		return
+	}
+	c.LeaseField = strings.TrimSpace(c.LeaseField)
+}
+
+func (c Claims) Validate(prefix string) []string {
+	if !c.Enabled {
+		return nil
+	}
+
+	var problems []string
+	if strings.TrimSpace(c.LeaseField) == "" {
+		problems = append(problems, prefix+".lease_field must not be blank when "+prefix+".enabled is true")
+	}
+	if c.TTLSeconds <= 0 {
+		problems = append(problems, prefix+".ttl_seconds must be greater than 0 when "+prefix+".enabled is true")
+	}
+	if c.HeartbeatSeconds <= 0 {
+		problems = append(problems, prefix+".heartbeat_seconds must be greater than 0 when "+prefix+".enabled is true")
+	}
+	if c.TTLSeconds > 0 && c.HeartbeatSeconds > c.TTLSeconds {
+		problems = append(problems, prefix+".heartbeat_seconds must be less than or equal to "+prefix+".ttl_seconds")
+	}
+	return problems
+}
+
 type StringOrMap struct {
 	IsString bool
 	String   string
@@ -532,6 +568,7 @@ func (c *Config) normalize() {
 	if c.Tracker.Kind == TrackerGitHub && c.Tracker.Endpoint == defaultLinearEndpoint {
 		c.Tracker.Endpoint = defaultGitHubEndpoint
 	}
+	c.Tracker.Claims.Normalize()
 	c.Tracker.Authorization.Normalize()
 
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
@@ -567,6 +604,7 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.http_max_idle_conns", c.Tracker.HTTPMaxIdleConns, problems)
 	validatePositive("tracker.http_max_idle_conns_per_host", c.Tracker.HTTPMaxIdleConnsPerHost, problems)
 	validatePositive("tracker.http_idle_conn_timeout_ms", c.Tracker.HTTPIdleConnTimeoutMS, problems)
+	*problems = append(*problems, c.Tracker.Claims.Validate("tracker.claims")...)
 	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -26,6 +26,11 @@ tracker:
   http_max_idle_conns: 120
   http_max_idle_conns_per_host: 40
   http_idle_conn_timeout_ms: 120000
+  claims:
+    enabled: true
+    lease_field: Detent Lease
+    ttl_seconds: 300
+    heartbeat_seconds: 45
   authorization:
     assignee_in:
       - "@me"
@@ -152,6 +157,18 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Tracker.HTTPIdleConnTimeoutMS != 120000 {
 		t.Fatalf("Tracker.HTTPIdleConnTimeoutMS = %d, want 120000", cfg.Tracker.HTTPIdleConnTimeoutMS)
+	}
+	if !cfg.Tracker.Claims.Enabled {
+		t.Fatal("Tracker.Claims.Enabled = false, want true")
+	}
+	if cfg.Tracker.Claims.LeaseField != "Detent Lease" {
+		t.Fatalf("Tracker.Claims.LeaseField = %q, want Detent Lease", cfg.Tracker.Claims.LeaseField)
+	}
+	if cfg.Tracker.Claims.TTLSeconds != 300 {
+		t.Fatalf("Tracker.Claims.TTLSeconds = %d, want 300", cfg.Tracker.Claims.TTLSeconds)
+	}
+	if cfg.Tracker.Claims.HeartbeatSeconds != 45 {
+		t.Fatalf("Tracker.Claims.HeartbeatSeconds = %d, want 45", cfg.Tracker.Claims.HeartbeatSeconds)
 	}
 	wantAuthorization := selector.Selector{
 		AssigneeIn: []string{"@me"},
@@ -732,6 +749,27 @@ Prompt
 				"identity.owner_field is required when identity.ownership_mode is field",
 				"tracker.authorization.priority_in values must be integers 1 through 4",
 				"tracker.authorization.fields[0].name must not be blank",
+			},
+		},
+		{
+			name: "invalid claim lease config",
+			raw: `---
+identity:
+  name: release-captain
+  github_login: detent-bot
+tracker:
+  kind: memory
+  claims:
+    enabled: true
+    lease_field: ""
+    ttl_seconds: 30
+    heartbeat_seconds: 60
+---
+Prompt
+`,
+			want: []string{
+				"tracker.claims.lease_field must not be blank when tracker.claims.enabled is true",
+				"tracker.claims.heartbeat_seconds must be less than or equal to tracker.claims.ttl_seconds",
 			},
 		},
 		{

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -223,12 +223,16 @@ query DetentGitHubStatusField($projectId: ID!) {
 }`
 
 const singleSelectFieldQuery = `
-query DetentGitHubSingleSelectField($projectId: ID!, $fieldName: String!) {
+query DetentGitHubProjectField($projectId: ID!, $fieldName: String!) {
   node(id: $projectId) {
     __typename
     ... on ProjectV2 {
       field(name: $fieldName) {
         __typename
+        ... on ProjectV2Field {
+          id
+          dataType
+        }
         ... on ProjectV2SingleSelectField {
           id
           options { id name color description }
@@ -284,6 +288,18 @@ mutation DetentGitHubUpdateSingleSelectField($projectId: ID!, $itemId: ID!, $fie
     itemId: $itemId,
     fieldId: $fieldId,
     value: { singleSelectOptionId: $optionId }
+  }) {
+    projectV2Item { id }
+  }
+}`
+
+const updateTextFieldValueMutation = `
+mutation DetentGitHubUpdateTextField($projectId: ID!, $itemId: ID!, $fieldId: ID!, $text: String!) {
+  updateProjectV2ItemFieldValue(input: {
+    projectId: $projectId,
+    itemId: $itemId,
+    fieldId: $fieldId,
+    value: { text: $text }
   }) {
     projectV2Item { id }
   }
@@ -628,7 +644,14 @@ func (c *Connector) SetField(ctx context.Context, issueID string, fieldName stri
 	if err != nil {
 		return err
 	}
-	fieldID, optionID, err := c.resolveSingleSelectFieldOption(ctx, fieldName, value)
+	field, err := c.fetchProjectField(ctx, fieldName)
+	if err != nil {
+		return err
+	}
+	if projectTextField(field) {
+		return c.updateProjectV2TextFieldValue(ctx, item.ID, field.ID, strings.TrimSpace(value), ErrProjectFieldUpdateFailed)
+	}
+	fieldID, optionID, err := c.resolveSingleSelectFieldOptionFromField(ctx, fieldName, value, field)
 	if err != nil {
 		return err
 	}
@@ -1054,42 +1077,51 @@ func (c *Connector) removeAssignees(ctx context.Context, issueID string, userIDs
 	return nil
 }
 
-func (c *Connector) resolveSingleSelectFieldOption(ctx context.Context, fieldName string, value string) (string, string, error) {
+func (c *Connector) resolveSingleSelectFieldOptionFromField(
+	ctx context.Context,
+	fieldName string,
+	value string,
+	field projectOptionsFieldResponse,
+) (string, string, error) {
 	fieldName = strings.TrimSpace(fieldName)
 	value = strings.TrimSpace(value)
 	if fieldName == "" || value == "" {
 		return "", "", ErrProjectFieldOptionNotFound
 	}
 
-	field, err := c.fetchSingleSelectField(ctx, fieldName)
+	decoded, err := decodeProjectSingleSelectField(fieldName, &field)
 	if err != nil {
 		return "", "", err
 	}
-	if optionID := singleSelectOptionID(field.Options, value); optionID != "" {
-		return field.ID, optionID, nil
+	if optionID := singleSelectOptionID(decoded.Options, value); optionID != "" {
+		return decoded.ID, optionID, nil
 	}
 
 	for range 3 {
-		field, err = c.fetchSingleSelectField(ctx, fieldName)
+		refetched, err := c.fetchProjectField(ctx, fieldName)
 		if err != nil {
 			return "", "", err
 		}
-		if optionID := singleSelectOptionID(field.Options, value); optionID != "" {
-			return field.ID, optionID, nil
+		decoded, err = decodeProjectSingleSelectField(fieldName, &refetched)
+		if err != nil {
+			return "", "", err
 		}
-		options := singleSelectOptionsWithRequiredAtEnd(field.Options, []projectSingleSelectOption{ownershipOption(value)})
-		updatedOptions, err := c.updateProjectFieldOptions(ctx, field.ID, options)
+		if optionID := singleSelectOptionID(decoded.Options, value); optionID != "" {
+			return decoded.ID, optionID, nil
+		}
+		options := singleSelectOptionsWithRequiredAtEnd(decoded.Options, []projectSingleSelectOption{ownershipOption(value)})
+		updatedOptions, err := c.updateProjectFieldOptions(ctx, decoded.ID, options)
 		if err != nil {
 			return "", "", fmt.Errorf("ensure github project field options: %w", err)
 		}
 		if optionID := singleSelectOptionID(updatedOptions, value); optionID != "" {
-			return field.ID, optionID, nil
+			return decoded.ID, optionID, nil
 		}
 	}
 	return "", "", fmt.Errorf("%w: %s=%s", ErrProjectFieldOptionNotFound, fieldName, value)
 }
 
-func (c *Connector) fetchSingleSelectField(ctx context.Context, fieldName string) (projectSingleSelectField, error) {
+func (c *Connector) fetchProjectField(ctx context.Context, fieldName string) (projectOptionsFieldResponse, error) {
 	var response struct {
 		Node *struct {
 			TypeName string                       `json:"__typename"`
@@ -1100,12 +1132,21 @@ func (c *Connector) fetchSingleSelectField(ctx context.Context, fieldName string
 		"projectId": c.projectID,
 		"fieldName": strings.TrimSpace(fieldName),
 	}, &response); err != nil {
-		return projectSingleSelectField{}, fmt.Errorf("fetch github project field: %w", err)
+		return projectOptionsFieldResponse{}, fmt.Errorf("fetch github project field: %w", err)
 	}
 	if response.Node == nil || response.Node.TypeName != "ProjectV2" {
-		return projectSingleSelectField{}, ErrProjectNotFound
+		return projectOptionsFieldResponse{}, ErrProjectNotFound
 	}
-	return decodeProjectSingleSelectField(fieldName, response.Node.Field)
+	if response.Node.Field == nil {
+		return projectOptionsFieldResponse{}, fmt.Errorf("%w: %s", ErrProjectFieldNotFound, strings.TrimSpace(fieldName))
+	}
+	return *response.Node.Field, nil
+}
+
+func projectTextField(field projectOptionsFieldResponse) bool {
+	return field.TypeName == "ProjectV2Field" &&
+		strings.EqualFold(strings.TrimSpace(field.DataType), "TEXT") &&
+		strings.TrimSpace(field.ID) != ""
 }
 
 func (c *Connector) resolveStatusMetadata(ctx context.Context) (statusMetadata, error) {
@@ -1223,6 +1264,36 @@ func (c *Connector) updateProjectV2SingleSelectFieldValue(
 		"itemId":    itemID,
 		"fieldId":   fieldID,
 		"optionId":  optionID,
+	}, &response); err != nil {
+		return fmt.Errorf("update github project field: %w", err)
+	}
+	if response.UpdateProjectV2ItemFieldValue == nil ||
+		response.UpdateProjectV2ItemFieldValue.ProjectV2Item == nil ||
+		strings.TrimSpace(response.UpdateProjectV2ItemFieldValue.ProjectV2Item.ID) == "" {
+		return emptyResponseError
+	}
+	return nil
+}
+
+func (c *Connector) updateProjectV2TextFieldValue(
+	ctx context.Context,
+	itemID string,
+	fieldID string,
+	text string,
+	emptyResponseError error,
+) error {
+	var response struct {
+		UpdateProjectV2ItemFieldValue *struct {
+			ProjectV2Item *struct {
+				ID string `json:"id"`
+			} `json:"projectV2Item"`
+		} `json:"updateProjectV2ItemFieldValue"`
+	}
+	if err := c.client.GraphQL(ctx, updateTextFieldValueMutation, map[string]any{
+		"projectId": c.projectID,
+		"itemId":    itemID,
+		"fieldId":   fieldID,
+		"text":      text,
 	}, &response); err != nil {
 		return fmt.Errorf("update github project field: %w", err)
 	}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -840,6 +840,45 @@ func TestConnectorSetFieldProvisionsOwnerOptionAndWritesProjectValue(t *testing.
 	}
 }
 
+func TestConnectorSetFieldWritesTextProjectValue(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"}}]}}}}`},
+		{body: `{"data":{"node":{"__typename":"ProjectV2","field":{"__typename":"ProjectV2Field","id":"PVTF_lease","dataType":"TEXT"}}}}`},
+		{body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_1"}}}}`},
+	})
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	if err := c.SetField(context.Background(), "I_kw1", "Detent Lease", "2026-06-02T15:00:00Z"); err != nil {
+		t.Fatalf("SetField() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
+	}
+	fieldVariables := requests[1]["variables"].(map[string]any)
+	if fieldVariables["fieldName"] != "Detent Lease" {
+		t.Fatalf("fieldName = %v, want Detent Lease", fieldVariables["fieldName"])
+	}
+	updateVariables := requests[2]["variables"].(map[string]any)
+	want := map[string]any{
+		"projectId": "PVT_1",
+		"itemId":    "PVTI_1",
+		"fieldId":   "PVTF_lease",
+		"text":      "2026-06-02T15:00:00Z",
+	}
+	for key, value := range want {
+		if updateVariables[key] != value {
+			t.Fatalf("%s = %v, want %v", key, updateVariables[key], value)
+		}
+	}
+	if !strings.Contains(requests[2]["query"].(string), "text") {
+		t.Fatalf("update query = %q, want text field mutation", requests[2]["query"])
+	}
+}
+
 type graphqlTestServer struct {
 	*httptest.Server
 	t         *testing.T

--- a/internal/connector/github/provision.go
+++ b/internal/connector/github/provision.go
@@ -111,6 +111,7 @@ type statusOptionRequirement struct {
 type projectOptionsFieldResponse struct {
 	TypeName string                  `json:"__typename"`
 	ID       string                  `json:"id"`
+	DataType string                  `json:"dataType"`
 	Options  []projectOptionResponse `json:"options"`
 }
 

--- a/internal/orchestrator/claim.go
+++ b/internal/orchestrator/claim.go
@@ -133,6 +133,18 @@ func (o *Orchestrator) heartbeatRunningClaims(ctx context.Context, state *State,
 		if !o.claimHeartbeatDue(claimed, now) {
 			continue
 		}
+		refreshed, ok := o.refetchClaimedIssue(ctx, claimed.Issue)
+		if !ok {
+			continue
+		}
+		winner := o.claimWinner(refreshed)
+		if !sameClaimOwner(winner, owner) {
+			if o.logger != nil {
+				o.logger.Warn("claim heartbeat owner changed", "issue_id", issueID, "owner", owner, "current_owner", winner)
+			}
+			o.releaseClaim(state, issueID)
+			continue
+		}
 		if err := o.connector.SetField(ctx, issueID, o.cfg.Claiming.LeaseField, formatClaimTime(now)); err != nil {
 			if o.logger != nil {
 				o.logger.Warn("claim heartbeat failed", "issue_id", issueID, "owner", owner, "error", err)
@@ -142,11 +154,11 @@ func (o *Orchestrator) heartbeatRunningClaims(ctx context.Context, state *State,
 		claimed.Owner = owner
 		claimed.LeaseRenewedAt = now
 		claimed.LeaseExpiresAt = o.leaseExpiresAt(now)
-		claimed.Issue = issueWithLeaseField(claimed.Issue, o.cfg.Claiming.LeaseField, now)
+		claimed.Issue = issueWithLeaseField(mergeIssueTrackerFields(claimed.Issue, refreshed), o.cfg.Claiming.LeaseField, now)
 		state.Claimed[issueID] = claimed
 
 		running := state.Running[issueID]
-		running.Issue = issueWithLeaseField(running.Issue, o.cfg.Claiming.LeaseField, now)
+		running.Issue = issueWithLeaseField(mergeIssueTrackerFields(running.Issue, refreshed), o.cfg.Claiming.LeaseField, now)
 		state.Running[issueID] = running
 	}
 }

--- a/internal/orchestrator/claim.go
+++ b/internal/orchestrator/claim.go
@@ -1,0 +1,297 @@
+package orchestrator
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const claimTimeFormat = time.RFC3339Nano
+
+func (o *Orchestrator) claimIssue(ctx context.Context, issue connector.Issue, now time.Time) (connector.Issue, Claimed, bool) {
+	issue = cloneIssue(issue)
+	claim := Claimed{
+		Issue:     issue,
+		ClaimedAt: now,
+	}
+	if !o.cfg.Claiming.Enabled {
+		return issue, claim, true
+	}
+
+	owner := o.claimOwner()
+	if owner == "" || o.cfg.Claiming.LeaseField == "" || o.fieldClaimMissingOwnerField() {
+		return connector.Issue{}, Claimed{}, false
+	}
+	if !o.claimable(issue, owner, now) {
+		return connector.Issue{}, Claimed{}, false
+	}
+	if err := o.writeClaim(ctx, issue.ID, owner, now); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("claim issue failed", "issue_id", issue.ID, "owner", owner, "error", err)
+		}
+		return connector.Issue{}, Claimed{}, false
+	}
+
+	refreshed, ok := o.refetchClaimedIssue(ctx, issue)
+	if !ok {
+		return connector.Issue{}, Claimed{}, false
+	}
+	claim, ok = o.verifiedClaim(refreshed, owner)
+	if !ok {
+		return connector.Issue{}, Claimed{}, false
+	}
+	return claim.Issue, claim, true
+}
+
+func (o *Orchestrator) fieldClaimMissingOwnerField() bool {
+	return o.cfg.Claiming.OwnershipMode == workflowconfig.IdentityOwnershipField &&
+		strings.TrimSpace(o.cfg.Claiming.OwnerField) == ""
+}
+
+func (o *Orchestrator) writeClaim(ctx context.Context, issueID string, owner string, now time.Time) error {
+	switch o.cfg.Claiming.OwnershipMode {
+	case workflowconfig.IdentityOwnershipField:
+		if err := o.connector.SetField(ctx, issueID, o.cfg.Claiming.OwnerField, owner); err != nil {
+			return err
+		}
+	default:
+		if err := o.connector.SetAssignee(ctx, issueID, owner); err != nil {
+			return err
+		}
+	}
+	return o.connector.SetField(ctx, issueID, o.cfg.Claiming.LeaseField, formatClaimTime(now))
+}
+
+func (o *Orchestrator) refetchClaimedIssue(ctx context.Context, fallback connector.Issue) (connector.Issue, bool) {
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{fallback.ID})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("refetch claimed issue failed", "issue_id", fallback.ID, "error", err)
+		}
+		return connector.Issue{}, false
+	}
+	for _, issue := range issues {
+		if issue.ID == fallback.ID {
+			return cloneIssue(issue), true
+		}
+	}
+	return connector.Issue{}, false
+}
+
+func (o *Orchestrator) claimable(issue connector.Issue, owner string, now time.Time) bool {
+	winner := o.claimWinner(issue)
+	if winner == "" || sameClaimOwner(winner, owner) {
+		return true
+	}
+	lease, ok := o.issueLease(issue)
+	if !ok {
+		return true
+	}
+	return o.leaseStale(lease, now)
+}
+
+func (o *Orchestrator) verifiedClaim(issue connector.Issue, owner string) (Claimed, bool) {
+	winner := o.claimWinner(issue)
+	if !sameClaimOwner(winner, owner) {
+		return Claimed{}, false
+	}
+	lease, ok := o.issueLease(issue)
+	if !ok {
+		return Claimed{}, false
+	}
+	issue = cloneIssue(issue)
+	return Claimed{
+		Issue:          issue,
+		ClaimedAt:      lease,
+		Owner:          owner,
+		LeaseRenewedAt: lease,
+		LeaseExpiresAt: o.leaseExpiresAt(lease),
+	}, true
+}
+
+func (o *Orchestrator) heartbeatRunningClaims(ctx context.Context, state *State, now time.Time) {
+	if !o.cfg.Claiming.Enabled || o.cfg.Claiming.LeaseField == "" {
+		return
+	}
+	owner := o.claimOwner()
+	if owner == "" {
+		return
+	}
+
+	for _, issueID := range sortedKeys(state.Running) {
+		claimed, ok := state.Claimed[issueID]
+		if !ok {
+			continue
+		}
+		if claimed.Owner != "" && !sameClaimOwner(claimed.Owner, owner) {
+			continue
+		}
+		if !o.claimHeartbeatDue(claimed, now) {
+			continue
+		}
+		if err := o.connector.SetField(ctx, issueID, o.cfg.Claiming.LeaseField, formatClaimTime(now)); err != nil {
+			if o.logger != nil {
+				o.logger.Warn("claim heartbeat failed", "issue_id", issueID, "owner", owner, "error", err)
+			}
+			continue
+		}
+		claimed.Owner = owner
+		claimed.LeaseRenewedAt = now
+		claimed.LeaseExpiresAt = o.leaseExpiresAt(now)
+		claimed.Issue = issueWithLeaseField(claimed.Issue, o.cfg.Claiming.LeaseField, now)
+		state.Claimed[issueID] = claimed
+
+		running := state.Running[issueID]
+		running.Issue = issueWithLeaseField(running.Issue, o.cfg.Claiming.LeaseField, now)
+		state.Running[issueID] = running
+	}
+}
+
+func (o *Orchestrator) claimHeartbeatDue(claim Claimed, now time.Time) bool {
+	if claim.LeaseRenewedAt.IsZero() {
+		return true
+	}
+	interval := o.cfg.Claiming.HeartbeatInterval
+	if interval <= 0 {
+		interval = o.cfg.Claiming.LeaseTTL / 2
+	}
+	if interval <= 0 {
+		return false
+	}
+	return !now.Before(claim.LeaseRenewedAt.Add(interval))
+}
+
+func (o *Orchestrator) claimOwner() string {
+	if o.cfg.Claiming.OwnershipMode == workflowconfig.IdentityOwnershipField {
+		for _, value := range []string{o.cfg.Claiming.Owner, o.cfg.Claiming.AssigneeLogin, o.cfg.SelectorContext.Persona, o.cfg.SelectorContext.InstanceLogin} {
+			if owner := strings.TrimSpace(value); owner != "" {
+				return owner
+			}
+		}
+		return o.connectorLogin()
+	}
+
+	for _, value := range []string{o.cfg.Claiming.AssigneeLogin, o.cfg.SelectorContext.InstanceLogin} {
+		if owner := strings.TrimSpace(value); owner != "" {
+			return owner
+		}
+	}
+	if owner := o.connectorLogin(); owner != "" {
+		return owner
+	}
+	return strings.TrimSpace(o.cfg.Claiming.Owner)
+}
+
+func (o *Orchestrator) connectorLogin() string {
+	identifier, ok := o.connector.(connector.InstanceIdentifier)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(identifier.InstanceLogin())
+}
+
+func (o *Orchestrator) claimWinner(issue connector.Issue) string {
+	owners := o.issueOwners(issue)
+	if len(owners) == 0 {
+		return ""
+	}
+	sortClaimOwners(owners)
+	return owners[0]
+}
+
+func (o *Orchestrator) issueOwners(issue connector.Issue) []string {
+	if o.cfg.Claiming.OwnershipMode == workflowconfig.IdentityOwnershipField {
+		owner := ""
+		if issue.Fields != nil {
+			owner = strings.TrimSpace(issue.Fields[o.cfg.Claiming.OwnerField])
+		}
+		if owner == "" {
+			return nil
+		}
+		return []string{owner}
+	}
+
+	owners := make([]string, 0, len(issue.Assignees)+1)
+	seen := map[string]struct{}{}
+	for _, owner := range append([]string{issue.AssigneeID}, issue.Assignees...) {
+		owner = strings.TrimSpace(owner)
+		if owner == "" {
+			continue
+		}
+		key := normalizeClaimOwner(owner)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		owners = append(owners, owner)
+	}
+	return owners
+}
+
+func (o *Orchestrator) issueLease(issue connector.Issue) (time.Time, bool) {
+	if issue.Fields == nil || o.cfg.Claiming.LeaseField == "" {
+		return time.Time{}, false
+	}
+	return parseClaimTime(issue.Fields[o.cfg.Claiming.LeaseField])
+}
+
+func (o *Orchestrator) leaseStale(lease time.Time, now time.Time) bool {
+	if lease.IsZero() {
+		return true
+	}
+	expires := o.leaseExpiresAt(lease)
+	if expires.IsZero() {
+		return false
+	}
+	return !now.Before(expires)
+}
+
+func (o *Orchestrator) leaseExpiresAt(lease time.Time) time.Time {
+	if lease.IsZero() || o.cfg.Claiming.LeaseTTL <= 0 {
+		return time.Time{}
+	}
+	return lease.Add(o.cfg.Claiming.LeaseTTL)
+}
+
+func issueWithLeaseField(issue connector.Issue, fieldName string, value time.Time) connector.Issue {
+	issue = cloneIssue(issue)
+	if issue.Fields == nil {
+		issue.Fields = map[string]string{}
+	}
+	issue.Fields[fieldName] = formatClaimTime(value)
+	return issue
+}
+
+func formatClaimTime(value time.Time) string {
+	return value.UTC().Format(claimTimeFormat)
+}
+
+func parseClaimTime(value string) (time.Time, bool) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return parsed.UTC(), true
+}
+
+func sameClaimOwner(left string, right string) bool {
+	return normalizeClaimOwner(left) == normalizeClaimOwner(right) && normalizeClaimOwner(left) != ""
+}
+
+func normalizeClaimOwner(owner string) string {
+	return strings.ToLower(strings.TrimSpace(owner))
+}
+
+func sortClaimOwners(owners []string) {
+	sort.SliceStable(owners, func(i, j int) bool {
+		return normalizeClaimOwner(owners[i]) < normalizeClaimOwner(owners[j])
+	})
+}

--- a/internal/orchestrator/claim_test.go
+++ b/internal/orchestrator/claim_test.go
@@ -1,0 +1,408 @@
+package orchestrator
+
+import (
+	"context"
+	"sort"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+func TestClaimingOverlappingOrchestratorsDispatchOnlyTieBreakWinner(t *testing.T) {
+	now := time.Date(2026, 6, 2, 15, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1")
+	store := newClaimTestStore([]connector.Issue{issue})
+	attempts := make(chan string, 2)
+	release := make(chan struct{})
+	store.assigneeHook = func(ctx context.Context, issueID string, login string) error {
+		select {
+		case attempts <- login:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+		select {
+		case <-release:
+			return nil
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	alphaRunner := newClaimBlockingRunner()
+	betaRunner := newClaimBlockingRunner()
+	alpha := newClaimTestOrchestrator(t, claimTestConfig("alpha", "alpha"), claimTestConnector{store: store, login: "alpha"}, alphaRunner)
+	beta := newClaimTestOrchestrator(t, claimTestConfig("beta", "beta"), claimTestConnector{store: store, login: "beta"}, betaRunner)
+	alphaState := newState(alpha.cfg)
+	betaState := newState(beta.cfg)
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+	go func() {
+		defer wg.Done()
+		alpha.tick(ctx, &alphaState, now)
+	}()
+	go func() {
+		defer wg.Done()
+		beta.tick(ctx, &betaState, now)
+	}()
+
+	owners := []string{
+		receiveClaimAttempt(t, attempts),
+		receiveClaimAttempt(t, attempts),
+	}
+	sort.Strings(owners)
+	store.setAssignees(issue.ID, owners)
+	close(release)
+	wg.Wait()
+
+	started := []RunRequest{}
+	if request, ok := receiveOptionalClaimRun(alphaRunner.started); ok {
+		started = append(started, request)
+	}
+	if request, ok := receiveOptionalClaimRun(betaRunner.started); ok {
+		started = append(started, request)
+	}
+	if len(started) != 1 {
+		t.Fatalf("started runners = %d, want 1: %#v", len(started), started)
+	}
+	if started[0].SelectorContext.InstanceLogin != "alpha" {
+		t.Fatalf("started owner = %q, want alpha", started[0].SelectorContext.InstanceLogin)
+	}
+	if _, ok := alphaState.Running[issue.ID]; !ok {
+		t.Fatalf("alpha Running[%q] missing", issue.ID)
+	}
+	if _, ok := betaState.Running[issue.ID]; ok {
+		t.Fatalf("beta Running[%q] present", issue.ID)
+	}
+}
+
+func TestClaimingReclaimsStaleLease(t *testing.T) {
+	now := time.Date(2026, 6, 2, 15, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1")
+	issue.AssigneeID = "beta"
+	issue.Assignees = []string{"beta"}
+	issue.Fields["Detent Lease"] = now.Add(-2 * time.Minute).Format(time.RFC3339Nano)
+	store := newClaimTestStore([]connector.Issue{issue})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runner := newClaimBlockingRunner()
+	orch := newClaimTestOrchestrator(t, claimTestConfig("alpha", "alpha"), claimTestConnector{store: store, login: "alpha"}, runner)
+	state := newState(orch.cfg)
+
+	orch.tick(ctx, &state, now)
+
+	request := receiveClaimRun(t, runner.started)
+	if request.Issue.ID != issue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
+	}
+	got := store.issue(issue.ID)
+	if got.AssigneeID != "alpha" {
+		t.Fatalf("AssigneeID = %q, want alpha", got.AssigneeID)
+	}
+	if got.Fields["Detent Lease"] != now.Format(time.RFC3339Nano) {
+		t.Fatalf("Detent Lease = %q, want %q", got.Fields["Detent Lease"], now.Format(time.RFC3339Nano))
+	}
+	if state.Claimed[issue.ID].Owner != "alpha" {
+		t.Fatalf("Claimed owner = %q, want alpha", state.Claimed[issue.ID].Owner)
+	}
+}
+
+func TestClaimingUsesConfiguredOwnerField(t *testing.T) {
+	now := time.Date(2026, 6, 2, 15, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1")
+	issue.Fields["Owner"] = "beta"
+	issue.Fields["Detent Lease"] = now.Add(-2 * time.Minute).Format(time.RFC3339Nano)
+	store := newClaimTestStore([]connector.Issue{issue})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	runner := newClaimBlockingRunner()
+	cfg := claimTestConfig("alpha", "alpha")
+	cfg.Claiming.OwnershipMode = "field"
+	cfg.Claiming.OwnerField = "Owner"
+	orch := newClaimTestOrchestrator(t, cfg, claimTestConnector{store: store, login: "alpha"}, runner)
+	state := newState(orch.cfg)
+
+	orch.tick(ctx, &state, now)
+
+	receiveClaimRun(t, runner.started)
+	got := store.issue(issue.ID)
+	if got.Fields["Owner"] != "alpha" {
+		t.Fatalf("Owner field = %q, want alpha", got.Fields["Owner"])
+	}
+	if got.Fields["Detent Lease"] != now.Format(time.RFC3339Nano) {
+		t.Fatalf("Detent Lease = %q, want %q", got.Fields["Detent Lease"], now.Format(time.RFC3339Nano))
+	}
+}
+
+func TestClaimingHeartbeatKeepsActiveLeaseFromReclaim(t *testing.T) {
+	now := time.Date(2026, 6, 2, 15, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1")
+	issue.AssigneeID = "alpha"
+	issue.Assignees = []string{"alpha"}
+	issue.Fields["Detent Lease"] = now.Format(time.RFC3339Nano)
+	store := newClaimTestStore([]connector.Issue{issue})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	alphaRunner := newClaimBlockingRunner()
+	alpha := newClaimTestOrchestrator(t, claimTestConfig("alpha", "alpha"), claimTestConnector{store: store, login: "alpha"}, alphaRunner)
+	alphaState := newState(alpha.cfg)
+	alpha.tick(ctx, &alphaState, now)
+	receiveClaimRun(t, alphaRunner.started)
+
+	heartbeatAt := now.Add(40 * time.Second)
+	alpha.tick(ctx, &alphaState, heartbeatAt)
+	got := store.issue(issue.ID)
+	if got.Fields["Detent Lease"] != heartbeatAt.Format(time.RFC3339Nano) {
+		t.Fatalf("Detent Lease after heartbeat = %q, want %q", got.Fields["Detent Lease"], heartbeatAt.Format(time.RFC3339Nano))
+	}
+
+	betaRunner := newClaimBlockingRunner()
+	beta := newClaimTestOrchestrator(t, claimTestConfig("beta", "beta"), claimTestConnector{store: store, login: "beta"}, betaRunner)
+	betaState := newState(beta.cfg)
+	beta.tick(ctx, &betaState, now.Add(70*time.Second))
+
+	if _, ok := receiveOptionalClaimRun(betaRunner.started); ok {
+		t.Fatalf("beta runner started for active heartbeat")
+	}
+	if _, ok := betaState.Running[issue.ID]; ok {
+		t.Fatalf("beta Running[%q] present", issue.ID)
+	}
+}
+
+func claimTestConfig(owner string, login string) Config {
+	return Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		SelectorContext:     selectorContextForClaimTest(login),
+		Claiming: ClaimingConfig{
+			Enabled:           true,
+			OwnershipMode:     "assignee",
+			Owner:             owner,
+			AssigneeLogin:     login,
+			LeaseField:        "Detent Lease",
+			LeaseTTL:          time.Minute,
+			HeartbeatInterval: 10 * time.Second,
+		},
+	}
+}
+
+func selectorContextForClaimTest(login string) selector.Context {
+	return selector.Context{InstanceLogin: login, Persona: login}
+}
+
+func claimTestIssue(id string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/detent#1"
+	issue.Title = "Claim test"
+	issue.State = "Todo"
+	return issue
+}
+
+type claimTestStore struct {
+	mu           sync.Mutex
+	issues       map[string]connector.Issue
+	assigneeHook func(context.Context, string, string) error
+}
+
+func newClaimTestStore(issues []connector.Issue) *claimTestStore {
+	out := &claimTestStore{issues: make(map[string]connector.Issue, len(issues))}
+	for _, issue := range issues {
+		out.issues[issue.ID] = cloneIssue(issue)
+	}
+	return out
+}
+
+func (s *claimTestStore) list() []connector.Issue {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	issues := make([]connector.Issue, 0, len(s.issues))
+	for _, issue := range s.issues {
+		issues = append(issues, cloneIssue(issue))
+	}
+	sort.Slice(issues, func(i, j int) bool {
+		return issues[i].ID < issues[j].ID
+	})
+	return issues
+}
+
+func (s *claimTestStore) issue(issueID string) connector.Issue {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return cloneIssue(s.issues[issueID])
+}
+
+func (s *claimTestStore) setAssignee(issueID string, login string) {
+	s.setAssignees(issueID, []string{login})
+}
+
+func (s *claimTestStore) setAssignees(issueID string, logins []string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	issue := cloneIssue(s.issues[issueID])
+	issue.Assignees = append([]string(nil), logins...)
+	if len(logins) > 0 {
+		issue.AssigneeID = logins[0]
+	} else {
+		issue.AssigneeID = ""
+	}
+	s.issues[issueID] = issue
+}
+
+func (s *claimTestStore) setField(issueID string, fieldName string, value string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	issue := cloneIssue(s.issues[issueID])
+	if issue.Fields == nil {
+		issue.Fields = map[string]string{}
+	}
+	issue.Fields[fieldName] = value
+	s.issues[issueID] = issue
+}
+
+type claimTestConnector struct {
+	store *claimTestStore
+	login string
+}
+
+func (c claimTestConnector) Name() string {
+	return "claim-test"
+}
+
+func (c claimTestConnector) InstanceLogin() string {
+	return c.login
+}
+
+func (c claimTestConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return c.store.list(), nil
+}
+
+func (c claimTestConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	wanted := stateNameSet(states)
+	issues := c.store.list()
+	out := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if _, ok := wanted[normalizeState(issue.State)]; ok {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+func (c claimTestConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
+	wanted := map[string]struct{}{}
+	for _, id := range ids {
+		wanted[id] = struct{}{}
+	}
+	issues := c.store.list()
+	out := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if _, ok := wanted[issue.ID]; ok {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+func (c claimTestConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c claimTestConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c claimTestConnector) SetAssignee(ctx context.Context, issueID string, login string) error {
+	if c.store.assigneeHook != nil {
+		return c.store.assigneeHook(ctx, issueID, login)
+	}
+	c.store.setAssignee(issueID, login)
+	return nil
+}
+
+func (c claimTestConnector) SetField(_ context.Context, issueID string, fieldName string, value string) error {
+	c.store.setField(issueID, fieldName, value)
+	return nil
+}
+
+type claimBlockingRunner struct {
+	started chan RunRequest
+}
+
+func newClaimBlockingRunner() *claimBlockingRunner {
+	return &claimBlockingRunner{started: make(chan RunRequest, 1)}
+}
+
+func (r *claimBlockingRunner) Run(ctx context.Context, request RunRequest) (RunResult, error) {
+	select {
+	case r.started <- request:
+	case <-ctx.Done():
+		return RunResult{}, ctx.Err()
+	}
+	<-ctx.Done()
+	return RunResult{}, ctx.Err()
+}
+
+func newClaimTestOrchestrator(t *testing.T, cfg Config, conn connector.Connector, runner Runner) *Orchestrator {
+	t.Helper()
+
+	orch, err := New(cfg, Dependencies{Connector: conn, Runner: runner})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	return orch
+}
+
+func receiveClaimAttempt(t *testing.T, attempts <-chan string) string {
+	t.Helper()
+
+	select {
+	case login := <-attempts:
+		return login
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for claim attempt")
+		return ""
+	}
+}
+
+func receiveClaimRun(t *testing.T, started <-chan RunRequest) RunRequest {
+	t.Helper()
+
+	select {
+	case request := <-started:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner start")
+		return RunRequest{}
+	}
+}
+
+func receiveOptionalClaimRun(started <-chan RunRequest) (RunRequest, bool) {
+	select {
+	case request := <-started:
+		return request, true
+	case <-time.After(50 * time.Millisecond):
+		return RunRequest{}, false
+	}
+}
+
+var _ connector.Connector = claimTestConnector{}
+var _ connector.InstanceIdentifier = claimTestConnector{}
+var _ Runner = (*claimBlockingRunner)(nil)

--- a/internal/orchestrator/claim_test.go
+++ b/internal/orchestrator/claim_test.go
@@ -217,6 +217,7 @@ func TestClaimingHeartbeatReleasesLocalRunWhenOwnershipChanges(t *testing.T) {
 	if _, ok := alphaState.Claimed[issue.ID]; ok {
 		t.Fatalf("alpha Claimed[%q] present after ownership changed", issue.ID)
 	}
+	receiveClaimCancellation(t, alphaRunner.canceled)
 }
 
 func claimTestConfig(owner string, login string) Config {
@@ -381,11 +382,15 @@ func (c claimTestConnector) SetField(_ context.Context, issueID string, fieldNam
 }
 
 type claimBlockingRunner struct {
-	started chan RunRequest
+	started  chan RunRequest
+	canceled chan struct{}
 }
 
 func newClaimBlockingRunner() *claimBlockingRunner {
-	return &claimBlockingRunner{started: make(chan RunRequest, 1)}
+	return &claimBlockingRunner{
+		started:  make(chan RunRequest, 1),
+		canceled: make(chan struct{}, 1),
+	}
 }
 
 func (r *claimBlockingRunner) Run(ctx context.Context, request RunRequest) (RunResult, error) {
@@ -395,6 +400,10 @@ func (r *claimBlockingRunner) Run(ctx context.Context, request RunRequest) (RunR
 		return RunResult{}, ctx.Err()
 	}
 	<-ctx.Done()
+	select {
+	case r.canceled <- struct{}{}:
+	default:
+	}
 	return RunResult{}, ctx.Err()
 }
 
@@ -438,6 +447,16 @@ func receiveOptionalClaimRun(started <-chan RunRequest) (RunRequest, bool) {
 		return request, true
 	case <-time.After(50 * time.Millisecond):
 		return RunRequest{}, false
+	}
+}
+
+func receiveClaimCancellation(t *testing.T, canceled <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-canceled:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner cancellation")
 	}
 }
 

--- a/internal/orchestrator/claim_test.go
+++ b/internal/orchestrator/claim_test.go
@@ -181,6 +181,44 @@ func TestClaimingHeartbeatKeepsActiveLeaseFromReclaim(t *testing.T) {
 	}
 }
 
+func TestClaimingHeartbeatReleasesLocalRunWhenOwnershipChanges(t *testing.T) {
+	now := time.Date(2026, 6, 2, 15, 0, 0, 0, time.UTC)
+	issue := claimTestIssue("issue-1")
+	issue.AssigneeID = "alpha"
+	issue.Assignees = []string{"alpha"}
+	issue.Fields["Detent Lease"] = now.Format(time.RFC3339Nano)
+	store := newClaimTestStore([]connector.Issue{issue})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	alphaRunner := newClaimBlockingRunner()
+	alpha := newClaimTestOrchestrator(t, claimTestConfig("alpha", "alpha"), claimTestConnector{store: store, login: "alpha"}, alphaRunner)
+	alphaState := newState(alpha.cfg)
+	alpha.tick(ctx, &alphaState, now)
+	receiveClaimRun(t, alphaRunner.started)
+
+	reclaimedAt := now.Add(20 * time.Second)
+	store.setAssignee(issue.ID, "beta")
+	store.setField(issue.ID, "Detent Lease", reclaimedAt.Format(time.RFC3339Nano))
+
+	alpha.tick(ctx, &alphaState, now.Add(40*time.Second))
+
+	got := store.issue(issue.ID)
+	if got.AssigneeID != "beta" {
+		t.Fatalf("AssigneeID = %q, want beta", got.AssigneeID)
+	}
+	if got.Fields["Detent Lease"] != reclaimedAt.Format(time.RFC3339Nano) {
+		t.Fatalf("Detent Lease = %q, want %q", got.Fields["Detent Lease"], reclaimedAt.Format(time.RFC3339Nano))
+	}
+	if _, ok := alphaState.Running[issue.ID]; ok {
+		t.Fatalf("alpha Running[%q] present after ownership changed", issue.ID)
+	}
+	if _, ok := alphaState.Claimed[issue.ID]; ok {
+		t.Fatalf("alpha Claimed[%q] present after ownership changed", issue.ID)
+	}
+}
+
 func claimTestConfig(owner string, login string) Config {
 	return Config{
 		PollInterval:        time.Hour,

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -30,6 +30,10 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Tracker.Authorization = selector.Selector{
 		AssigneeIn: []string{"@me"},
 	}
+	cfg.Tracker.Claims.Enabled = true
+	cfg.Tracker.Claims.LeaseField = "Detent Lease"
+	cfg.Tracker.Claims.TTLSeconds = 300
+	cfg.Tracker.Claims.HeartbeatSeconds = 45
 	cfg.Gate = gate.Config{Kind: gate.KindHumanReview, ApprovalLabel: " Approved-By-Human "}
 
 	got := ConfigFromWorkflow(cfg)
@@ -65,6 +69,27 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if len(got.Authorization.AssigneeIn) != 1 || got.Authorization.AssigneeIn[0] != "@me" {
 		t.Fatalf("Authorization.AssigneeIn = %#v, want @me", got.Authorization.AssigneeIn)
+	}
+	if !got.Claiming.Enabled {
+		t.Fatal("Claiming.Enabled = false, want true")
+	}
+	if got.Claiming.OwnershipMode != workflowconfig.IdentityOwnershipAssignee {
+		t.Fatalf("Claiming.OwnershipMode = %q, want assignee", got.Claiming.OwnershipMode)
+	}
+	if got.Claiming.Owner != "release-captain" {
+		t.Fatalf("Claiming.Owner = %q, want release-captain", got.Claiming.Owner)
+	}
+	if got.Claiming.AssigneeLogin != "detent-bot" {
+		t.Fatalf("Claiming.AssigneeLogin = %q, want detent-bot", got.Claiming.AssigneeLogin)
+	}
+	if got.Claiming.LeaseField != "Detent Lease" {
+		t.Fatalf("Claiming.LeaseField = %q, want Detent Lease", got.Claiming.LeaseField)
+	}
+	if got.Claiming.LeaseTTL != 300*time.Second {
+		t.Fatalf("Claiming.LeaseTTL = %s, want 5m0s", got.Claiming.LeaseTTL)
+	}
+	if got.Claiming.HeartbeatInterval != 45*time.Second {
+		t.Fatalf("Claiming.HeartbeatInterval = %s, want 45s", got.Claiming.HeartbeatInterval)
 	}
 	if got.AutoPromote.Gate.Kind != gate.KindHumanReview || got.AutoPromote.Gate.ApprovalLabel != "approved-by-human" {
 		t.Fatalf("AutoPromote.Gate = %#v, want human_review approved-by-human", got.AutoPromote.Gate)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -919,11 +919,13 @@ func (o *Orchestrator) dispatchIssue(
 
 	issue = cloneIssue(claimedIssue)
 	claim.Issue = issue
+	runCtx, cancel := context.WithCancel(ctx)
 	state.Running[issue.ID] = Running{
 		Issue:      issue,
 		Attempt:    attempt,
 		StartedAt:  now,
 		WorkerHost: workerHost,
+		cancel:     cancel,
 	}
 	state.Claimed[issue.ID] = claim
 	delete(state.Retry, issue.ID)
@@ -936,9 +938,9 @@ func (o *Orchestrator) dispatchIssue(
 		StartedAt:       now,
 		WorkerHost:      workerHost,
 		SelectorContext: o.selectorContext(),
-		OnUsageUpdate:   o.usageUpdateHandler(ctx, issue.ID),
+		OnUsageUpdate:   o.usageUpdateHandler(runCtx, issue.ID),
 	}
-	o.supervisor.Dispatch(ctx, request, o.runResults)
+	o.supervisor.Dispatch(runCtx, request, o.runResults)
 	return true
 }
 
@@ -1010,6 +1012,9 @@ func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
 	running, ok := state.Running[event.IssueID]
 	if !ok {
 		return
+	}
+	if running.cancel != nil {
+		running.cancel()
 	}
 	delete(state.Running, event.IssueID)
 
@@ -1130,6 +1135,7 @@ func (o *Orchestrator) retryDelay(attempt int, continuation bool) time.Duration 
 }
 
 func (o *Orchestrator) releaseIssue(state *State, issueID string) {
+	cancelRunning(state, issueID)
 	delete(state.Running, issueID)
 	delete(state.Claimed, issueID)
 	delete(state.Blocked, issueID)
@@ -1138,10 +1144,21 @@ func (o *Orchestrator) releaseIssue(state *State, issueID string) {
 }
 
 func (o *Orchestrator) releaseClaim(state *State, issueID string) {
+	cancelRunning(state, issueID)
 	delete(state.Running, issueID)
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+}
+
+func cancelRunning(state *State, issueID string) {
+	running, ok := state.Running[issueID]
+	if !ok || running.cancel == nil {
+		return
+	}
+	running.cancel()
+	running.cancel = nil
+	state.Running[issueID] = running
 }
 
 func normalizeConfig(cfg Config) Config {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -46,6 +46,7 @@ type Config struct {
 	DispatchPriorityByState    []string
 	MaxConcurrentAgentsPerHost int
 	MaxRetryBackoff            time.Duration
+	Claiming                   ClaimingConfig
 	AutoPromote                AutoPromoteConfig
 	ActiveStates               []string
 	TerminalStates             []string
@@ -56,6 +57,17 @@ type Config struct {
 	ContinuationRetryDelay     time.Duration
 	FailureRetryBaseDelay      time.Duration
 	SelectorPersona            string
+}
+
+type ClaimingConfig struct {
+	Enabled           bool
+	OwnershipMode     string
+	Owner             string
+	AssigneeLogin     string
+	OwnerField        string
+	LeaseField        string
+	LeaseTTL          time.Duration
+	HeartbeatInterval time.Duration
 }
 
 type Dependencies struct {
@@ -97,6 +109,9 @@ type runUpdate struct {
 }
 
 func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
+	identity := cfg.Identity
+	identity.Normalize()
+
 	return Config{
 		PollInterval:               durationFromMillis(cfg.Polling.IntervalMS),
 		MaxConcurrentAgents:        cfg.Agent.MaxConcurrentAgents,
@@ -104,6 +119,16 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		DispatchPriorityByState:    append([]string(nil), cfg.Agent.DispatchPriorityByState...),
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
+		Claiming: ClaimingConfig{
+			Enabled:           cfg.Tracker.Claims.Enabled,
+			OwnershipMode:     identity.OwnershipMode,
+			Owner:             identity.Name,
+			AssigneeLogin:     identity.GitHubLogin,
+			OwnerField:        identity.OwnerField,
+			LeaseField:        cfg.Tracker.Claims.LeaseField,
+			LeaseTTL:          durationFromSeconds(cfg.Tracker.Claims.TTLSeconds),
+			HeartbeatInterval: durationFromSeconds(cfg.Tracker.Claims.HeartbeatSeconds),
+		},
 		AutoPromote: normalizeAutoPromoteConfig(AutoPromoteConfig{
 			Enabled:            cfg.Agent.AutoPromote.Enabled,
 			QuietDuration:      durationFromSeconds(cfg.Agent.AutoPromote.QuietSeconds),
@@ -114,7 +139,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		ActiveStates:          append([]string(nil), cfg.Tracker.ActiveStates...),
 		TerminalStates:        append([]string(nil), cfg.Tracker.TerminalStates...),
 		Authorization:         cfg.Tracker.Authorization,
-		SelectorContext:       selector.Context{InstanceLogin: cfg.Identity.GitHubLogin, Persona: cfg.Identity.Name},
+		SelectorContext:       selector.Context{InstanceLogin: identity.GitHubLogin, Persona: identity.Name},
 		WorkerHosts:           append([]string(nil), cfg.Worker.SSHHosts...),
 		BudgetRefusalCooldown: durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
 		SelectorPersona:       cfg.Tracker.Assignee,
@@ -268,6 +293,7 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	}
 
 	o.reconcileRunningIssues(ctx, state, now)
+	o.heartbeatRunningClaims(ctx, state, now)
 
 	issues, err := o.connector.FetchCandidateIssues(ctx)
 	if err != nil {
@@ -787,7 +813,9 @@ func (o *Orchestrator) dispatchRetryIssue(
 		return
 	}
 
-	o.dispatchIssue(ctx, state, issue, retry.Attempt, now, retry.WorkerHost)
+	if !o.dispatchIssue(ctx, state, issue, retry.Attempt, now, retry.WorkerHost) {
+		o.scheduleRetry(state, issue, retry.Attempt, now, "claim verification failed", false, retry.WorkerHost)
+	}
 }
 
 func (o *Orchestrator) dispatchable(issue connector.Issue, state *State, now time.Time) bool {
@@ -878,23 +906,26 @@ func (o *Orchestrator) dispatchIssue(
 	attempt int,
 	now time.Time,
 	preferredWorkerHost string,
-) {
+) bool {
 	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
 	if !ok {
-		return
+		return false
 	}
 
-	issue = cloneIssue(issue)
+	claimedIssue, claim, ok := o.claimIssue(ctx, issue, now)
+	if !ok {
+		return false
+	}
+
+	issue = cloneIssue(claimedIssue)
+	claim.Issue = issue
 	state.Running[issue.ID] = Running{
 		Issue:      issue,
 		Attempt:    attempt,
 		StartedAt:  now,
 		WorkerHost: workerHost,
 	}
-	state.Claimed[issue.ID] = Claimed{
-		Issue:     issue,
-		ClaimedAt: now,
-	}
+	state.Claimed[issue.ID] = claim
 	delete(state.Retry, issue.ID)
 	delete(state.Blocked, issue.ID)
 	delete(state.BudgetRefusals, issue.ID)
@@ -908,6 +939,7 @@ func (o *Orchestrator) dispatchIssue(
 		OnUsageUpdate:   o.usageUpdateHandler(ctx, issue.ID),
 	}
 	o.supervisor.Dispatch(ctx, request, o.runResults)
+	return true
 }
 
 func (o *Orchestrator) selectorContext() selector.Context {
@@ -1142,6 +1174,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
+	cfg.Claiming = normalizeClaimingConfig(cfg.Claiming)
 	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
 	cfg.Authorization.Normalize()
 	cfg.SelectorContext.InstanceLogin = strings.TrimSpace(cfg.SelectorContext.InstanceLogin)
@@ -1152,6 +1185,24 @@ func normalizeConfig(cfg Config) Config {
 		cfg.MaxConcurrentAgentsPerHost = 0
 	}
 
+	return cfg
+}
+
+func normalizeClaimingConfig(cfg ClaimingConfig) ClaimingConfig {
+	cfg.OwnershipMode = strings.ToLower(strings.TrimSpace(cfg.OwnershipMode))
+	if cfg.OwnershipMode == "" {
+		cfg.OwnershipMode = workflowconfig.IdentityOwnershipAssignee
+	}
+	cfg.Owner = strings.TrimSpace(cfg.Owner)
+	cfg.AssigneeLogin = strings.TrimSpace(cfg.AssigneeLogin)
+	cfg.OwnerField = strings.TrimSpace(cfg.OwnerField)
+	cfg.LeaseField = strings.TrimSpace(cfg.LeaseField)
+	if cfg.LeaseTTL < 0 {
+		cfg.LeaseTTL = 0
+	}
+	if cfg.HeartbeatInterval < 0 {
+		cfg.HeartbeatInterval = 0
+	}
 	return cfg
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -22,10 +22,10 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 			NextRefreshAt:       timePointer(s.NextRefreshAt),
 		},
 		Pipeline:   pipelineSnapshots(s.Pipeline),
-		Running:    runningSnapshots(s.Running),
-		Queue:      queueSnapshots(s.Retry),
-		Blocked:    blockedSnapshots(s.Blocked),
-		Completed:  completedSnapshots(s.Completed),
+		Running:    runningSnapshots(s.Running, s.Claimed, now),
+		Queue:      queueSnapshots(s.Retry, s.Claimed, now),
+		Blocked:    blockedSnapshots(s.Blocked, s.Claimed, now),
+		Completed:  completedSnapshots(s.Completed, s.Claimed, now),
 		RateLimits: cloneRateLimits(s.RateLimits),
 		Tokens:     tokensFromCodexTotals(s.liveCodexTotals()),
 		Budget: telemetry.Budget{
@@ -58,14 +58,16 @@ func pipelineSnapshots(issues []connector.Issue) []telemetry.Issue {
 	return out
 }
 
-func runningSnapshots(running map[string]Running) []telemetry.Running {
+func runningSnapshots(running map[string]Running, claims map[string]Claimed, now time.Time) []telemetry.Running {
 	ids := sortedKeys(running)
 	out := make([]telemetry.Running, 0, len(ids))
 	for _, id := range ids {
 		entry := running[id]
 		lastEventAt := timePointer(entry.LastEventAt)
+		issue := telemetryIssue(entry.Issue)
+		applyClaimSnapshot(&issue, claims[id], now)
 		out = append(out, telemetry.Running{
-			Issue:           telemetryIssue(entry.Issue),
+			Issue:           issue,
 			WorkerHost:      entry.WorkerHost,
 			ProcessIdentity: entry.ProcessIdentity,
 			SessionID:       entry.SessionID,
@@ -86,13 +88,15 @@ func runningSnapshots(running map[string]Running) []telemetry.Running {
 	return out
 }
 
-func queueSnapshots(retry map[string]Retry) []telemetry.Queued {
+func queueSnapshots(retry map[string]Retry, claims map[string]Claimed, now time.Time) []telemetry.Queued {
 	ids := sortedKeys(retry)
 	out := make([]telemetry.Queued, 0, len(ids))
 	for _, id := range ids {
 		entry := retry[id]
+		issue := telemetryIssue(entry.Issue)
+		applyClaimSnapshot(&issue, claims[id], now)
 		queued := telemetry.Queued{
-			Issue:      telemetryIssue(entry.Issue),
+			Issue:      issue,
 			Attempt:    entry.Attempt,
 			Error:      entry.Error,
 			WorkerHost: entry.WorkerHost,
@@ -106,13 +110,15 @@ func queueSnapshots(retry map[string]Retry) []telemetry.Queued {
 	return out
 }
 
-func blockedSnapshots(blocked map[string]Blocked) []telemetry.Blocked {
+func blockedSnapshots(blocked map[string]Blocked, claims map[string]Claimed, now time.Time) []telemetry.Blocked {
 	ids := sortedKeys(blocked)
 	out := make([]telemetry.Blocked, 0, len(ids))
 	for _, id := range ids {
 		entry := blocked[id]
+		issue := telemetryIssue(entry.Issue)
+		applyClaimSnapshot(&issue, claims[id], now)
 		item := telemetry.Blocked{
-			Issue: telemetryIssue(entry.Issue),
+			Issue: issue,
 			Error: entry.Reason,
 		}
 		if !entry.BlockedAt.IsZero() {
@@ -124,13 +130,15 @@ func blockedSnapshots(blocked map[string]Blocked) []telemetry.Blocked {
 	return out
 }
 
-func completedSnapshots(completed map[string]Completed) []telemetry.Completed {
+func completedSnapshots(completed map[string]Completed, claims map[string]Claimed, now time.Time) []telemetry.Completed {
 	ids := sortedKeys(completed)
 	out := make([]telemetry.Completed, 0, len(ids))
 	for _, id := range ids {
 		entry := completed[id]
+		issue := telemetryIssue(entry.Issue)
+		applyClaimSnapshot(&issue, claims[id], now)
 		out = append(out, telemetry.Completed{
-			Issue:          telemetryIssue(entry.Issue),
+			Issue:          issue,
 			StartedAt:      entry.StartedAt,
 			CompletedAt:    entry.CompletedAt,
 			FinalState:     entry.FinalState,
@@ -169,6 +177,16 @@ func budgetRefusalSnapshots(refusals map[string]BudgetRefusal) []telemetry.Budge
 		out = append(out, refusal)
 	}
 	return out
+}
+
+func applyClaimSnapshot(issue *telemetry.Issue, claim Claimed, now time.Time) {
+	if issue == nil || claim.Owner == "" {
+		return
+	}
+	issue.Owner = claim.Owner
+	issue.LeaseRenewedAt = timePointer(claim.LeaseRenewedAt)
+	issue.LeaseExpiresAt = timePointer(claim.LeaseExpiresAt)
+	issue.LeaseStale = !claim.LeaseExpiresAt.IsZero() && !now.Before(claim.LeaseExpiresAt)
 }
 
 func telemetryIssue(issue connector.Issue) telemetry.Issue {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -71,6 +71,67 @@ func TestStateSnapshotIncludesInstanceIdentityAndScope(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotIncludesClaimLeaseState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 2, 15, 0, 0, 0, time.UTC)
+	renewedAt := now.Add(-30 * time.Second)
+	expiresAt := renewedAt.Add(time.Minute)
+	state := newState(normalizeConfig(Config{}))
+	state.Running["issue-1"] = Running{
+		Issue:     connector.Issue{ID: "issue-1", Identifier: "digitaldrywood/detent#1", Title: "Claimed", State: "Todo"},
+		StartedAt: now.Add(-time.Minute),
+	}
+	state.Claimed["issue-1"] = Claimed{
+		Issue:          state.Running["issue-1"].Issue,
+		ClaimedAt:      now.Add(-time.Minute),
+		Owner:          "alpha",
+		LeaseRenewedAt: renewedAt,
+		LeaseExpiresAt: expiresAt,
+	}
+	state.Retry["issue-2"] = Retry{
+		Issue:   connector.Issue{ID: "issue-2", Identifier: "digitaldrywood/detent#2", Title: "Retry", State: "Todo"},
+		Attempt: 2,
+		DueAt:   now.Add(time.Minute),
+	}
+	state.Claimed["issue-2"] = Claimed{
+		Issue:          state.Retry["issue-2"].Issue,
+		ClaimedAt:      now.Add(-2 * time.Minute),
+		Owner:          "beta",
+		LeaseRenewedAt: now.Add(-2 * time.Minute),
+		LeaseExpiresAt: now.Add(-time.Minute),
+	}
+
+	snapshot := state.Snapshot(now)
+
+	if len(snapshot.Running) != 1 {
+		t.Fatalf("Running len = %d, want 1", len(snapshot.Running))
+	}
+	running := snapshot.Running[0]
+	if running.Owner != "alpha" {
+		t.Fatalf("Running owner = %q, want alpha", running.Owner)
+	}
+	if running.LeaseRenewedAt == nil || !running.LeaseRenewedAt.Equal(renewedAt) {
+		t.Fatalf("Running lease renewed = %v, want %v", running.LeaseRenewedAt, renewedAt)
+	}
+	if running.LeaseExpiresAt == nil || !running.LeaseExpiresAt.Equal(expiresAt) {
+		t.Fatalf("Running lease expires = %v, want %v", running.LeaseExpiresAt, expiresAt)
+	}
+	if running.LeaseStale {
+		t.Fatal("Running lease stale = true, want false")
+	}
+	if len(snapshot.Queue) != 1 {
+		t.Fatalf("Queue len = %d, want 1", len(snapshot.Queue))
+	}
+	queued := snapshot.Queue[0]
+	if queued.Owner != "beta" {
+		t.Fatalf("Queued owner = %q, want beta", queued.Owner)
+	}
+	if !queued.LeaseStale {
+		t.Fatal("Queued lease stale = false, want true")
+	}
+}
+
 func TestStateSnapshotPopulated(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -43,8 +43,11 @@ type Running struct {
 }
 
 type Claimed struct {
-	Issue     connector.Issue
-	ClaimedAt time.Time
+	Issue          connector.Issue
+	ClaimedAt      time.Time
+	Owner          string
+	LeaseRenewedAt time.Time
+	LeaseExpiresAt time.Time
 }
 
 type BlockedSource string

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"context"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -40,6 +41,7 @@ type Running struct {
 	RecentEvents    []telemetry.ActivityEvent
 	DiffStats       DiffStats
 	Tokens          CodexTotals
+	cancel          context.CancelFunc
 }
 
 type Claimed struct {
@@ -118,6 +120,7 @@ func (s State) clone() State {
 	for id, running := range s.Running {
 		running.Issue = cloneIssue(running.Issue)
 		running.RecentEvents = cloneActivityEvents(running.RecentEvents)
+		running.cancel = nil
 		cloned.Running[id] = running
 	}
 	for id, claimed := range s.Claimed {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -66,6 +66,10 @@ type Issue struct {
 	State          string       `json:"state,omitempty"`
 	Labels         []string     `json:"labels,omitempty"`
 	PullRequest    *PullRequest `json:"pull_request,omitempty"`
+	Owner          string       `json:"owner,omitempty"`
+	LeaseRenewedAt *time.Time   `json:"lease_renewed_at,omitempty"`
+	LeaseExpiresAt *time.Time   `json:"lease_expires_at,omitempty"`
+	LeaseStale     bool         `json:"lease_stale,omitempty"`
 	CreatedAt      *time.Time   `json:"created_at,omitempty"`
 	UpdatedAt      *time.Time   `json:"updated_at,omitempty"`
 	StageUpdatedAt *time.Time   `json:"stage_updated_at,omitempty"`

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -1085,6 +1085,9 @@ templ issueCell(issue telemetry.Issue, prefix string, rowIndex int, jsonDetails 
 		if issueDescriptionPreview(issue) != "" {
 			<p class="line-clamp-2 text-xs text-muted-foreground">{ issueDescriptionPreview(issue) }</p>
 		}
+		if issueClaimSummary(issue) != "" {
+			<p class="line-clamp-2 font-mono text-xs text-muted-foreground">{ issueClaimSummary(issue) }</p>
+		}
 		if jsonDetails && issueDetailURL(issue) != "" {
 			<a class="w-fit text-xs font-medium text-accent underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent" href={ issueDetailURL(issue) }>JSON details</a>
 		}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -390,6 +390,21 @@ func issueDescriptionPreview(issue telemetry.Issue) string {
 	return string(runes[:limit-3]) + "..."
 }
 
+func issueClaimSummary(issue telemetry.Issue) string {
+	parts := make([]string, 0, 2)
+	if strings.TrimSpace(issue.Owner) != "" {
+		parts = append(parts, "Owner "+strings.TrimSpace(issue.Owner))
+	}
+	if issue.LeaseExpiresAt != nil {
+		label := "Lease expires "
+		if issue.LeaseStale {
+			label = "Lease stale since "
+		}
+		parts = append(parts, label+timeLabel(*issue.LeaseExpiresAt))
+	}
+	return strings.Join(parts, " / ")
+}
+
 func issueDetailURL(issue telemetry.Issue) string {
 	identifier := issueIdentifier(issue)
 	if identifier == "" || identifier == "unknown" {

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -4269,75 +4269,94 @@ func issueCell(issue telemetry.Issue, prefix string, rowIndex int, jsonDetails b
 				return templ_7745c5c3_Err
 			}
 		}
-		if jsonDetails && issueDetailURL(issue) != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 363, "<a class=\"w-fit text-xs font-medium text-accent underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
+		if issueClaimSummary(issue) != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 363, "<p class=\"line-clamp-2 font-mono text-xs text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var208 templ.SafeURL
-			templ_7745c5c3_Var208, templ_7745c5c3_Err = templ.JoinURLErrs(issueDetailURL(issue))
+			var templ_7745c5c3_Var208 string
+			templ_7745c5c3_Var208, templ_7745c5c3_Err = templ.JoinStringErrs(issueClaimSummary(issue))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1089, Col: 189}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1089, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var208))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 364, "\">JSON details</a>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 364, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 365, "<div id=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
+		if jsonDetails && issueDetailURL(issue) != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 365, "<a class=\"w-fit text-xs font-medium text-accent underline-offset-4 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" href=\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var209 templ.SafeURL
+			templ_7745c5c3_Var209, templ_7745c5c3_Err = templ.JoinURLErrs(issueDetailURL(issue))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1092, Col: 189}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var209))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 366, "\">JSON details</a>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
 		}
-		var templ_7745c5c3_Var209 string
-		templ_7745c5c3_Var209, templ_7745c5c3_Err = templ.JoinStringErrs(issuePopoverID(prefix, rowIndex))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1092, Col: 40}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var209))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 366, "\" class=\"popover-panel issue-popover-panel max-w-sm text-foreground\" role=\"tooltip\" aria-hidden=\"true\" data-popover-panel data-popover-width=\"320\"><p class=\"font-medium text-foreground\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 367, "<div id=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var210 string
-		templ_7745c5c3_Var210, templ_7745c5c3_Err = templ.JoinStringErrs(issueTitle(issue))
+		templ_7745c5c3_Var210, templ_7745c5c3_Err = templ.JoinStringErrs(issuePopoverID(prefix, rowIndex))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1099, Col: 61}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1095, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var210))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 367, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 368, "\" class=\"popover-panel issue-popover-panel max-w-sm text-foreground\" role=\"tooltip\" aria-hidden=\"true\" data-popover-panel data-popover-width=\"320\"><p class=\"font-medium text-foreground\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var211 string
+		templ_7745c5c3_Var211, templ_7745c5c3_Err = templ.JoinStringErrs(issueTitle(issue))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1102, Col: 61}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var211))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 369, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if issueDescriptionPreview(issue) != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 368, "<p class=\"mt-1 text-muted-foreground\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 370, "<p class=\"mt-1 text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var211 string
-			templ_7745c5c3_Var211, templ_7745c5c3_Err = templ.JoinStringErrs(issueDescriptionPreview(issue))
+			var templ_7745c5c3_Var212 string
+			templ_7745c5c3_Var212, templ_7745c5c3_Err = templ.JoinStringErrs(issueDescriptionPreview(issue))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1101, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1104, Col: 74}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var211))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var212))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 369, "</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 371, "</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 370, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 372, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4361,38 +4380,38 @@ func issueCopyButton(value string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var212 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var212 == nil {
-			templ_7745c5c3_Var212 = templ.NopComponent
+		templ_7745c5c3_Var213 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var213 == nil {
+			templ_7745c5c3_Var213 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 371, "<button type=\"button\" class=\"issue-copy issue-external inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border bg-card text-muted-foreground hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-label=\"Copy issue URL\" data-copy=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var213 string
-		templ_7745c5c3_Var213, templ_7745c5c3_Err = templ.JoinStringErrs(value)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1112, Col: 19}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var213))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 372, "\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 373, "<button type=\"button\" class=\"issue-copy issue-external inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-md border border-border bg-card text-muted-foreground hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-label=\"Copy issue URL\" data-copy=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var214 string
-		templ_7745c5c3_Var214, templ_7745c5c3_Err = templ.JoinStringErrs("Copy " + value)
+		templ_7745c5c3_Var214, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1113, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1115, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var214))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 373, "\" onclick=\"navigator.clipboard.writeText(this.dataset.copy); const label = this.querySelector('[data-copy-label]'); label.textContent = 'Copied'; clearTimeout(this._copyTimer); this._copyTimer = setTimeout(() => { label.textContent = this.dataset.label }, 1200);\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><rect x=\"9\" y=\"9\" width=\"13\" height=\"13\" rx=\"2\" ry=\"2\"></rect> <path d=\"M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1\"></path></svg> <span class=\"sr-only\" data-copy-label>Copy issue URL</span></button>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 374, "\" title=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var215 string
+		templ_7745c5c3_Var215, templ_7745c5c3_Err = templ.JoinStringErrs("Copy " + value)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1116, Col: 25}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var215))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 375, "\" onclick=\"navigator.clipboard.writeText(this.dataset.copy); const label = this.querySelector('[data-copy-label]'); label.textContent = 'Copied'; clearTimeout(this._copyTimer); this._copyTimer = setTimeout(() => { label.textContent = this.dataset.label }, 1200);\"><svg width=\"14\" height=\"14\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><rect x=\"9\" y=\"9\" width=\"13\" height=\"13\" rx=\"2\" ry=\"2\"></rect> <path d=\"M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1\"></path></svg> <span class=\"sr-only\" data-copy-label>Copy issue URL</span></button>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4416,70 +4435,70 @@ func sessionCopyButton(sessionID string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var215 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var215 == nil {
-			templ_7745c5c3_Var215 = templ.NopComponent
+		templ_7745c5c3_Var216 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var216 == nil {
+			templ_7745c5c3_Var216 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if sessionID == "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 374, "<span class=\"font-mono text-muted-foreground\">n/a</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 376, "<span class=\"font-mono text-muted-foreground\">n/a</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 375, "<button type=\"button\" class=\"inline-flex min-h-10 max-w-full items-center gap-2 rounded-md border border-border bg-muted px-3 py-2 font-mono text-xs text-foreground hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-label=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var216 string
-			templ_7745c5c3_Var216, templ_7745c5c3_Err = templ.JoinStringErrs(sessionLabel(sessionID))
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1131, Col: 39}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var216))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 376, "\" data-copy=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 377, "<button type=\"button\" class=\"inline-flex min-h-10 max-w-full items-center gap-2 rounded-md border border-border bg-muted px-3 py-2 font-mono text-xs text-foreground hover:border-accent hover:text-accent focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-accent\" data-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var217 string
-			templ_7745c5c3_Var217, templ_7745c5c3_Err = templ.JoinStringErrs(sessionID)
+			templ_7745c5c3_Var217, templ_7745c5c3_Err = templ.JoinStringErrs(sessionLabel(sessionID))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1132, Col: 24}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1134, Col: 39}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var217))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 377, "\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 378, "\" data-copy=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var218 string
-			templ_7745c5c3_Var218, templ_7745c5c3_Err = templ.JoinStringErrs("Copy " + sessionID)
+			templ_7745c5c3_Var218, templ_7745c5c3_Err = templ.JoinStringErrs(sessionID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1133, Col: 30}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1135, Col: 24}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var218))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 378, "\" onclick=\"navigator.clipboard.writeText(this.dataset.copy); const label = this.querySelector('[data-copy-label]'); label.textContent = 'Copied'; clearTimeout(this._copyTimer); this._copyTimer = setTimeout(() => { label.textContent = this.dataset.label }, 1200);\"><span class=\"truncate\" data-copy-label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 379, "\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var219 string
-			templ_7745c5c3_Var219, templ_7745c5c3_Err = templ.JoinStringErrs(sessionLabel(sessionID))
+			templ_7745c5c3_Var219, templ_7745c5c3_Err = templ.JoinStringErrs("Copy " + sessionID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1136, Col: 67}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1136, Col: 30}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var219))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 379, "</span> <svg class=\"shrink-0\" width=\"13\" height=\"13\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><rect x=\"9\" y=\"9\" width=\"13\" height=\"13\" rx=\"2\" ry=\"2\"></rect> <path d=\"M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1\"></path></svg></button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 380, "\" onclick=\"navigator.clipboard.writeText(this.dataset.copy); const label = this.querySelector('[data-copy-label]'); label.textContent = 'Copied'; clearTimeout(this._copyTimer); this._copyTimer = setTimeout(() => { label.textContent = this.dataset.label }, 1200);\"><span class=\"truncate\" data-copy-label>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var220 string
+			templ_7745c5c3_Var220, templ_7745c5c3_Err = templ.JoinStringErrs(sessionLabel(sessionID))
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1139, Col: 67}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var220))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 381, "</span> <svg class=\"shrink-0\" width=\"13\" height=\"13\" viewBox=\"0 0 24 24\" fill=\"none\" stroke=\"currentColor\" stroke-width=\"2\" stroke-linecap=\"round\" stroke-linejoin=\"round\" aria-hidden=\"true\"><rect x=\"9\" y=\"9\" width=\"13\" height=\"13\" rx=\"2\" ry=\"2\"></rect> <path d=\"M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1\"></path></svg></button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -4504,12 +4523,12 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var220 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var220 == nil {
-			templ_7745c5c3_Var220 = templ.NopComponent
+		templ_7745c5c3_Var221 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var221 == nil {
+			templ_7745c5c3_Var221 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 380, "<section class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex items-start justify-between gap-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 382, "<section class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex items-start justify-between gap-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4517,20 +4536,20 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 381, "<span class=\"shrink-0 rounded-full bg-muted px-2 py-1 text-xs font-medium text-muted-foreground\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 383, "<span class=\"shrink-0 rounded-full bg-muted px-2 py-1 text-xs font-medium text-muted-foreground\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var221 string
-		templ_7745c5c3_Var221, templ_7745c5c3_Err = templ.JoinStringErrs(budgetStatus(snapshot.Budget))
+		var templ_7745c5c3_Var222 string
+		templ_7745c5c3_Var222, templ_7745c5c3_Err = templ.JoinStringErrs(budgetStatus(snapshot.Budget))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1149, Col: 131}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1152, Col: 131}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var221))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var222))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 382, "</span></div><div class=\"mt-5 grid gap-4 text-sm\"><div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 384, "</span></div><div class=\"mt-5 grid gap-4 text-sm\"><div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4538,33 +4557,33 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 383, "<strong class=\"font-mono font-medium text-foreground\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var222 string
-		templ_7745c5c3_Var222, templ_7745c5c3_Err = templ.JoinStringErrs(budgetSpendTodayLabel(snapshot.Budget))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1155, Col: 99}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var222))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 384, "</strong></div><div class=\"h-2 overflow-hidden rounded-full bg-muted\" aria-label=\"Daily budget usage\"><div class=\"h-full rounded-full bg-accent transition-all\" style=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 385, "<strong class=\"font-mono font-medium text-foreground\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var223 string
-		templ_7745c5c3_Var223, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(budgetDailyUsageStyle(snapshot.Budget))
+		templ_7745c5c3_Var223, templ_7745c5c3_Err = templ.JoinStringErrs(budgetSpendTodayLabel(snapshot.Budget))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1158, Col: 109}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1158, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var223))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 385, "\"></div></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 386, "</strong></div><div class=\"h-2 overflow-hidden rounded-full bg-muted\" aria-label=\"Daily budget usage\"><div class=\"h-full rounded-full bg-accent transition-all\" style=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var224 string
+		templ_7745c5c3_Var224, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(budgetDailyUsageStyle(snapshot.Budget))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1161, Col: 109}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var224))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 387, "\"></div></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4574,7 +4593,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 386, "<div class=\"grid gap-3\"><div class=\"flex items-center justify-between gap-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 388, "<div class=\"grid gap-3\"><div class=\"flex items-center justify-between gap-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -4582,20 +4601,20 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 387, "<span class=\"font-mono text-xs text-muted-foreground\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 389, "<span class=\"font-mono text-xs text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var224 string
-			templ_7745c5c3_Var224, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).PeriodLabel)
+			var templ_7745c5c3_Var225 string
+			templ_7745c5c3_Var225, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).PeriodLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1167, Col: 102}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1170, Col: 102}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var224))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var225))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 388, "</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 390, "</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -4603,46 +4622,46 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 389, "<div class=\"grid grid-cols-3 gap-2 font-mono text-xs text-muted-foreground\"><span>Spend ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var225 string
-			templ_7745c5c3_Var225, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).CurrentLabel)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1171, Col: 61}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var225))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 390, "</span> <span>Cap ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 391, "<div class=\"grid grid-cols-3 gap-2 font-mono text-xs text-muted-foreground\"><span>Spend ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var226 string
-			templ_7745c5c3_Var226, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).CapLabel)
+			templ_7745c5c3_Var226, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).CurrentLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1172, Col: 55}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1174, Col: 61}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var226))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 391, "</span> <span>Projected ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 392, "</span> <span>Cap ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var227 string
-			templ_7745c5c3_Var227, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).ProjectionLabel)
+			templ_7745c5c3_Var227, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).CapLabel)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1173, Col: 68}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1175, Col: 55}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var227))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 392, "</span></div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 393, "</span> <span>Projected ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var228 string
+			templ_7745c5c3_Var228, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).ProjectionLabel)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1176, Col: 68}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var228))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 394, "</span></div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -4653,7 +4672,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 393, "<div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 395, "<div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -4661,99 +4680,78 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 394, "<span class=\"font-mono text-xs text-muted-foreground\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 396, "<span class=\"font-mono text-xs text-muted-foreground\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var228 string
-			templ_7745c5c3_Var228, templ_7745c5c3_Err = templ.JoinStringErrs(budgetHistoryCount(snapshot.Budget))
+			var templ_7745c5c3_Var229 string
+			templ_7745c5c3_Var229, templ_7745c5c3_Err = templ.JoinStringErrs(budgetHistoryCount(snapshot.Budget))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1183, Col: 97}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1186, Col: 97}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var228))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var229))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 395, "</span></div><div class=\"grid h-12 grid-cols-7 items-end gap-1 rounded-md border border-border bg-muted px-2 py-2\" aria-label=\"Spend over the last seven days\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 397, "</span></div><div class=\"grid h-12 grid-cols-7 items-end gap-1 rounded-md border border-border bg-muted px-2 py-2\" aria-label=\"Spend over the last seven days\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, bar := range budgetHistoryBars(snapshot.Budget) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 396, "<span class=\"block min-h-1 rounded-t bg-accent opacity-80\" style=\"")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var229 string
-				templ_7745c5c3_Var229, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(bar.Style)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1187, Col: 83}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var229))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 397, "\" title=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 398, "<span class=\"block min-h-1 rounded-t bg-accent opacity-80\" style=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var230 string
-				templ_7745c5c3_Var230, templ_7745c5c3_Err = templ.JoinStringErrs(bar.Title)
+				templ_7745c5c3_Var230, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(bar.Style)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1187, Col: 103}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1190, Col: 83}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var230))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 398, "\"><span class=\"sr-only\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 399, "\" title=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var231 string
 				templ_7745c5c3_Var231, templ_7745c5c3_Err = templ.JoinStringErrs(bar.Title)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1188, Col: 41}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1190, Col: 103}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var231))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 399, "</span></span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 400, "\"><span class=\"sr-only\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var232 string
+				templ_7745c5c3_Var232, templ_7745c5c3_Err = templ.JoinStringErrs(bar.Title)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1191, Col: 41}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var232))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 401, "</span></span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 400, "</div></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 402, "</div></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 401, "<div class=\"grid gap-3 border-t border-border pt-3\"><div class=\"flex items-center justify-between gap-4\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 403, "<div class=\"grid gap-3 border-t border-border pt-3\"><div class=\"flex items-center justify-between gap-4\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = helpInlineLabel("Projected", helpProjectedSpend, "budget-projected", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 402, "<strong class=\"font-mono font-medium text-foreground\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var232 string
-		templ_7745c5c3_Var232, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).ProjectionLabel)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1197, Col: 105}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var232))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 403, "</strong></div><div class=\"flex items-center justify-between gap-4\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = helpInlineLabel("Daily cap", helpDailyCap, "budget-daily-cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4762,9 +4760,9 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var233 string
-		templ_7745c5c3_Var233, templ_7745c5c3_Err = templ.JoinStringErrs(optionalUSD(snapshot.Budget.PerDayMaxUSD))
+		templ_7745c5c3_Var233, templ_7745c5c3_Err = templ.JoinStringErrs(budgetBurnDownView(snapshot).ProjectionLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1201, Col: 102}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1200, Col: 105}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var233))
 		if templ_7745c5c3_Err != nil {
@@ -4774,7 +4772,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Issue cap", helpIssueCap, "budget-issue-cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = helpInlineLabel("Daily cap", helpDailyCap, "budget-daily-cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4783,15 +4781,36 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var234 string
-		templ_7745c5c3_Var234, templ_7745c5c3_Err = templ.JoinStringErrs(optionalUSD(snapshot.Budget.PerIssueMaxUSD))
+		templ_7745c5c3_Var234, templ_7745c5c3_Err = templ.JoinStringErrs(optionalUSD(snapshot.Budget.PerDayMaxUSD))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1205, Col: 104}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1204, Col: 102}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var234))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 407, "</strong></div></div></div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 407, "</strong></div><div class=\"flex items-center justify-between gap-4\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = helpInlineLabel("Issue cap", helpIssueCap, "budget-issue-cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 408, "<strong class=\"font-mono font-medium text-foreground\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var235 string
+		templ_7745c5c3_Var235, templ_7745c5c3_Err = templ.JoinStringErrs(optionalUSD(snapshot.Budget.PerIssueMaxUSD))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1208, Col: 104}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var235))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 409, "</strong></div></div></div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4815,12 +4834,12 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var235 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var235 == nil {
-			templ_7745c5c3_Var235 = templ.NopComponent
+		templ_7745c5c3_Var236 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var236 == nil {
+			templ_7745c5c3_Var236 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 408, "<section class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex items-start justify-between gap-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 410, "<section class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex items-start justify-between gap-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4828,25 +4847,25 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 409, "<span class=\"shrink-0 rounded-full bg-accent-soft px-2 py-1 text-xs font-medium text-accent\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 411, "<span class=\"shrink-0 rounded-full bg-accent-soft px-2 py-1 text-xs font-medium text-accent\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var236 string
-		templ_7745c5c3_Var236, templ_7745c5c3_Err = templ.JoinStringErrs(rateLimitName(limits))
+		var templ_7745c5c3_Var237 string
+		templ_7745c5c3_Var237, templ_7745c5c3_Err = templ.JoinStringErrs(rateLimitName(limits))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1216, Col: 119}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1219, Col: 119}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var236))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var237))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 410, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 412, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(rateLimitRows(limits)) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 411, "<div class=\"mt-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 413, "<div class=\"mt-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -4854,17 +4873,17 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 412, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 414, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 413, "<div class=\"mt-5 grid gap-4\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 415, "<div class=\"mt-5 grid gap-4\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, row := range rateLimitRows(limits) {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 414, "<div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-3\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 416, "<div class=\"grid gap-2\"><div class=\"flex items-center justify-between gap-3\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -4872,82 +4891,82 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 415, "<span class=\"font-mono text-sm text-muted-foreground\">")
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				var templ_7745c5c3_Var237 string
-				templ_7745c5c3_Var237, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reset)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1228, Col: 72}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var237))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 416, "</span></div><div class=\"h-2 overflow-hidden rounded-full bg-muted\"><div class=\"h-full rounded-full bg-accent transition-all\" style=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 417, "<span class=\"font-mono text-sm text-muted-foreground\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var238 string
-				templ_7745c5c3_Var238, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(percentStyle(row.UsedPercent))
+				templ_7745c5c3_Var238, templ_7745c5c3_Err = templ.JoinStringErrs(row.Reset)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1231, Col: 102}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1231, Col: 72}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var238))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 417, "\"></div></div><div class=\"grid grid-cols-3 gap-2 font-mono text-xs text-muted-foreground\"><span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 418, "</span></div><div class=\"h-2 overflow-hidden rounded-full bg-muted\"><div class=\"h-full rounded-full bg-accent transition-all\" style=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var239 string
-				templ_7745c5c3_Var239, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
+				templ_7745c5c3_Var239, templ_7745c5c3_Err = templruntime.SanitizeStyleAttributeValues(percentStyle(row.UsedPercent))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1234, Col: 28}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1234, Col: 102}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var239))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 418, "</span> <span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 419, "\"></div></div><div class=\"grid grid-cols-3 gap-2 font-mono text-xs text-muted-foreground\"><span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var240 string
-				templ_7745c5c3_Var240, templ_7745c5c3_Err = templ.JoinStringErrs(row.Used)
+				templ_7745c5c3_Var240, templ_7745c5c3_Err = templ.JoinStringErrs(row.Remaining)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1235, Col: 23}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1237, Col: 28}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var240))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 419, "</span> <span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 420, "</span> <span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var241 string
-				templ_7745c5c3_Var241, templ_7745c5c3_Err = templ.JoinStringErrs(row.Limit)
+				templ_7745c5c3_Var241, templ_7745c5c3_Err = templ.JoinStringErrs(row.Used)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1236, Col: 24}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1238, Col: 23}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var241))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 420, "</span></div></div>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 421, "</span> <span>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var242 string
+				templ_7745c5c3_Var242, templ_7745c5c3_Err = templ.JoinStringErrs(row.Limit)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1239, Col: 24}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var242))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 422, "</span></div></div>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 421, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 423, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 422, "</section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 424, "</section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4971,12 +4990,12 @@ func tokenCard(data DashboardData) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var242 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var242 == nil {
-			templ_7745c5c3_Var242 = templ.NopComponent
+		templ_7745c5c3_Var243 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var243 == nil {
+			templ_7745c5c3_Var243 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 423, "<section class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex items-start justify-between gap-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 425, "<section class=\"min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5\"><div class=\"flex items-start justify-between gap-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -4984,46 +5003,46 @@ func tokenCard(data DashboardData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 424, "<span class=\"shrink-0 rounded-full bg-muted px-2 py-1 font-mono text-xs font-medium text-muted-foreground\">")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var243 string
-		templ_7745c5c3_Var243, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1249, Col: 136}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var243))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 425, "</span></div><div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-foreground sm:text-3xl\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 426, "<span class=\"shrink-0 rounded-full bg-muted px-2 py-1 font-mono text-xs font-medium text-muted-foreground\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var244 string
-		templ_7745c5c3_Var244, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
+		templ_7745c5c3_Var244, templ_7745c5c3_Err = templ.JoinStringErrs(tokenRate(data.Snapshot))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1252, Col: 123}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1252, Col: 136}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var244))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 426, "</div><div class=\"font-mono text-sm text-muted-foreground\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 427, "</span></div><div class=\"mt-5 grid gap-2\"><div class=\"break-all font-mono text-2xl font-semibold text-foreground sm:text-3xl\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var245 string
-		templ_7745c5c3_Var245, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
+		templ_7745c5c3_Var245, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokens(data.Snapshot.Tokens))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1253, Col: 100}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1255, Col: 123}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var245))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 427, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 428, "</div><div class=\"font-mono text-sm text-muted-foreground\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var246 string
+		templ_7745c5c3_Var246, templ_7745c5c3_Err = templ.JoinStringErrs(formatTokenBreakdown(data.Snapshot.Tokens))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1256, Col: 100}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var246))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 429, "</div></div><div class=\"mt-5\"><div class=\"mb-2 flex items-center justify-between gap-3 text-sm\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -5031,20 +5050,20 @@ func tokenCard(data DashboardData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 428, "<span class=\"font-mono text-xs text-muted-foreground\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 430, "<span class=\"font-mono text-xs text-muted-foreground\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var246 string
-		templ_7745c5c3_Var246, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
+		var templ_7745c5c3_Var247 string
+		templ_7745c5c3_Var247, templ_7745c5c3_Err = templ.JoinStringErrs(formatDuration(data.Snapshot.Tokens.RuntimeSeconds))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1258, Col: 111}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 1261, Col: 111}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var246))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var247))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 429, "</span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 431, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -5058,12 +5077,12 @@ func tokenCard(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 430, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-muted-foreground\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-success\"></span>Output</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 432, " <div class=\"mt-3 flex flex-wrap items-center gap-4 text-xs font-medium text-muted-foreground\"><span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-accent\"></span>Input</span> <span class=\"inline-flex items-center gap-2\"><span class=\"h-2 w-2 rounded-full bg-success\"></span>Output</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 431, "</div></section>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 433, "</div></section>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -19,6 +19,8 @@ func TestDashboardRendersTelemetrySnapshot(t *testing.T) {
 	perIssue := 10.0
 	now := time.Date(2026, 5, 31, 15, 0, 0, 0, time.UTC)
 	pipelineUpdatedAt := now.Add(-20 * time.Minute)
+	leaseRenewedAt := now.Add(-30 * time.Second)
+	leaseExpiresAt := now.Add(90 * time.Second)
 
 	html := renderDashboard(t, templates.DashboardData{
 		Title:         "Detent",
@@ -64,6 +66,13 @@ func TestDashboardRendersTelemetrySnapshot(t *testing.T) {
 						Title:       "Dashboard templates",
 						Description: "Running dashboard template row with enough issue detail to preview.",
 						State:       "In Progress",
+						Owner:       "alpha",
+						LeaseRenewedAt: func() *time.Time {
+							return &leaseRenewedAt
+						}(),
+						LeaseExpiresAt: func() *time.Time {
+							return &leaseExpiresAt
+						}(),
 					},
 					SessionID:      "thread-abc123456789",
 					TurnCount:      4,
@@ -232,6 +241,8 @@ func TestDashboardRendersTelemetrySnapshot(t *testing.T) {
 		"Dashboard templates",
 		"http://localhost:4101",
 		"Running dashboard template row with enough issue detail to preview.",
+		"Owner alpha",
+		"Lease expires May 31 15:01:30 UTC",
 		"turn completed successfully",
 		"+4 -2 (3 files)",
 		"162,000",


### PR DESCRIPTION
## Summary

- add opt-in tracker claim/lease config and orchestrator claim verification before dispatch
- renew active leases by heartbeat and allow stale leases to be reclaimed after TTL
- surface claim owner and lease expiry on telemetry/dashboard issue rows

Fixes #256

## Test Plan

- [x] `go test ./internal/config ./internal/connector/github ./internal/orchestrator ./internal/web/templates`
- [x] `make check`