### PR TITLE
docs: audit recent feature docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,9 @@ worktree, dispatches a Codex coding agent against a workflow contract you wrote,
 runs your validation gate, opens a pull request, waits for review, and merges
 through a serialized train — with all of it live on a web dashboard and a
 terminal UI. The same board-to-gated-review-to-done shape is the trajectory for
-non-code work, and [#266](https://github.com/digitaldrywood/detent/issues/266)
-tracks the domain-agnostic execution seams needed to unlock it.
+non-code work: validation gates are now pluggable, while non-git or non-PR
+deliverables remain follow-up work described in
+[Execution Seams](docs/execution-seams.md).
 
 It is a **system, not an agent.** You specify the work — the issues, acceptance
 criteria, review gates, and merge rules — and Detent runs that process with
@@ -83,8 +84,8 @@ counts:
 - **Explicit gates + a serialized merge train.** CI plus automated (Codex)
   review plus a one-at-a-time `Merging` lane, so what lands is always green.
 - **Pluggable validation gates.** Code defaults use `make check`, CI, and
-  automated review, while workflow authors can select other review gates for
-  files-in-repo work.
+  automated review, while workflow authors can choose a command gate or a human
+  approval-label gate for files-in-repo work.
 - **A real operator surface.** A live dashboard (charts, trends, timelines,
   hover detail, budget and rate-limit state) and terminal UI, `detent doctor`
   preflight checks, cross-platform config discovery, and a GoReleaser pipeline.
@@ -192,6 +193,9 @@ gh project list --owner <org-or-user> --format json --limit 20
 Detent auto-provisions any missing `Status` and `Priority` options on the board
 the first time it runs, so you do not have to hand-create every column — but the
 option names it creates and reads must match the states in your `WORKFLOW.md`.
+GitHub uses single-select option order as board column order; Detent keeps the
+known status options in canonical board order and leaves extra custom options
+after the required Detent states.
 
 3. Create a `WORKFLOW.md` in the repository you want Detent to work on:
 
@@ -372,7 +376,8 @@ repo is a real, working instance of this setup to copy from.
 
    The board only needs to exist — Detent auto-provisions missing `Status` and
    `Priority` options on first run. The option names must match your
-   `WORKFLOW.md` states.
+   `WORKFLOW.md` states, and Detent keeps known `Status` options in canonical
+   board order.
 
 5. **Clone the repository you want Detent to work on** (its checkout becomes
    `workspace.source_root`):
@@ -443,8 +448,8 @@ GitHub App REST token requests. Tune `tracker.http_max_idle_conns`,
 `tracker.http_idle_conn_timeout_ms` when many Detent instances share one host.
 Keep host-level agent concurrency within the machine's shared outbound
 connection and ephemeral-port budget; the connector logs its live connection
-count on GitHub requests to help spot pressure. See the multi-instance rollout
-epic #258 for host-wide caps and coordination work.
+count on GitHub requests to help spot pressure. For shared-board operation, see
+[Running Multiple Instances](#running-multiple-instances).
 
 ### Board States
 
@@ -473,8 +478,15 @@ You bring the board; Detent fills in the rest.
 - **Detent auto-provisions** the *missing options* inside those fields on first
   run — the `Todo` / `In Progress` / `Rework` / `Merging` / `Done` columns above
   and the `Urgent`…`Low` priorities — so the option names always match your
-  `WORKFLOW.md`. It provisions the options, not the board or the fields
-  themselves, so create the board (and the `Priority` field if used) first.
+  `WORKFLOW.md`. It also reorders the known `Status` options to Detent's
+  canonical column order: `Backlog`, `Todo`, `In Progress`, `Blocked`,
+  `Human Review`, `Rework`, `Merging`, then terminal states. Extra custom
+  status options are preserved after the configured Detent states. It provisions
+  the options, not the board or the fields themselves, so create the board (and
+  the `Priority` field if used) first.
+- **Blank `Status` values are not `Backlog`.** In the current release, an issue
+  with no Project `Status` value is not dispatchable through the board state
+  machine. Put unready work in the `Backlog` option explicitly.
 - **Detent reads** status, priority, labels, blockers, assignees, and linked
   pull requests from each issue, and **writes back** status transitions and a
   `## Codex Workpad` comment as the agent works.
@@ -664,9 +676,9 @@ only if the refreshed owner and lease still match the current instance. With
 must be omitted. With `ownership_mode: field`, ownership is written to
 `identity.owner_field`, which must exist on the board. While another owner has
 a fresh lease, the issue is skipped. When the lease timestamp is stale by
-`ttl_seconds` or missing, another matching instance may reclaim it. Running
-claims heartbeat every `heartbeat_seconds`; that value must be greater than
-zero and less than or equal to `ttl_seconds`.
+`ttl_seconds` or missing, another matching instance may reclaim it. Detent
+refreshes running claim leases every `heartbeat_seconds`; that value must be
+greater than zero and less than or equal to `ttl_seconds`.
 
 Task-to-model routing also lives in `WORKFLOW.md`. If `agents.backends` is
 omitted, routes can reference the legacy `codex` backend built from the top-level
@@ -696,6 +708,10 @@ agents:
 
 For explicit backend profiles, configure `agents.backends` and route to those
 ids. Today the shipped backend kind is `codex` with `protocol: app-server`.
+Backend `options` use the same runtime fields as the top-level `codex` block,
+including `shell`, `approval_policy`, `thread_sandbox`,
+`turn_sandbox_policy`, `turn_timeout_ms`, `read_timeout_ms`, and
+`stall_timeout_ms`.
 
 ```yaml
 agents:

--- a/README.md
+++ b/README.md
@@ -710,8 +710,7 @@ For explicit backend profiles, configure `agents.backends` and route to those
 ids. Today the shipped backend kind is `codex` with `protocol: app-server`.
 Backend `options` use the same runtime fields as the top-level `codex` block,
 including `shell`, `approval_policy`, `thread_sandbox`,
-`turn_sandbox_policy`, `turn_timeout_ms`, `read_timeout_ms`, and
-`stall_timeout_ms`.
+`turn_sandbox_policy`, `turn_timeout_ms`, and `read_timeout_ms`.
 
 ```yaml
 agents:

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -24,9 +24,9 @@ These tools are adjacent, but they are not all the same category.
 | Primary interaction | GitHub Projects v2 board state | Linear board state in the reference implementation | Assign an issue to Copilot, or prompt from GitHub / VS Code | IDE chat, agent mode, cloud agents, Slack / web handoff | Chat / terminal / messaging gateway | Chat / messaging gateway / local assistant |
 | Execution locality | Detent runtime runs on your node; current default workflow uses local worktrees, GitHub Projects, and Codex CLI | Self-hosted Elixir / BEAM service that launches Codex in per-issue workspaces | GitHub Actions-powered ephemeral environment; can use larger or self-hosted Actions runners, including ARC scale sets | Cursor-hosted cloud sandbox, or self-hosted cloud-agent workers in your infrastructure | Self-host or hosted option; gateway and terminal backends can run on your infrastructure | Local-first gateway on your machine / infrastructure |
 | Control plane | No Detent SaaS control plane; sovereignty depends on the tracker and model backends you configure | No packaged SaaS product; you run the reference implementation, but Linear and Codex are external services | GitHub cloud and Copilot Agent Control Plane | Cursor cloud orchestrates inference / planning even when workers are self-hosted | Your hosted gateway when self-hosted | Your local gateway |
-| Models | Codex app-server today; model-agnostic and local-model paths are roadmap / in-progress work | Codex app-server | Copilot, Claude, and Codex agents through GitHub-managed access | Cursor-managed first-party and frontier models, including Composer and third-party frontier models | BYO provider or endpoint; docs mention many providers and self-hosted endpoints | Configurable model providers, including OpenAI and other providers; local/self-hosted options depend on configuration |
+| Models | Codex app-server today; workflow routes can select Codex backend profiles and models; non-Codex / local backends are roadmap work | Codex app-server | Copilot, Claude, and Codex agents through GitHub-managed access | Cursor-managed first-party and frontier models, including Composer and third-party frontier models | BYO provider or endpoint; docs mention many providers and self-hosted endpoints | Configurable model providers, including OpenAI and other providers; local/self-hosted options depend on configuration |
 | Tracker / board | GitHub Projects v2 | Linear in the reference implementation | GitHub Issues / PRs, plus integrations | Repository / IDE / cloud-agent task surfaces, not a board-native state machine | None for code orchestration | None for code orchestration |
-| Multi-agent / fleet | Multi-project from one host; worktree-per-issue dispatch; serialized `Merging` lane | Multiple concurrent issues within one service instance | Multiple agent sessions, but GitHub governs the platform | Parallel cloud agents and team-level agent runs | Assistant can delegate / parallelize, but it is not a PR merge train | Multi-agent routing exists, but the product remains assistant-centric |
+| Multi-agent / fleet | Multi-project and multi-instance from self-hosted nodes; authorized and claimed ProjectV2 work; worktree-per-issue dispatch; serialized `Merging` lane | Multiple concurrent issues within one service instance | Multiple agent sessions, but GitHub governs the platform | Parallel cloud agents and team-level agent runs | Assistant can delegate / parallelize, but it is not a PR merge train | Multi-agent routing exists, but the product remains assistant-centric |
 | Gating / merge discipline | Workflow-defined validation, Codex review, budget checks, and one-at-a-time merge train | Spec defines workflow gates and handoff states; the exact policy is implementation-defined | Draft PRs, branch protection, review, CI, and GitHub policies | PR review and generated artifacts; no board-native deterministic merge train | Not applicable | Not applicable |
 | Memory / skills | Repository-local workflow contract, skills, workpad, telemetry, budget history | `WORKFLOW.md`, skills, tracker comments, runtime observability | Repository instructions, Copilot Memory, MCP, skills, custom agents | Rules, MCP, skills, hooks, cloud-agent memory / automations | Persistent memory, self-improving skills, agentskills.io compatibility | Persistent memory, workspace skills, channel sessions |
 | License | MIT | Apache-2.0 | Proprietary SaaS | Proprietary SaaS | MIT | MIT |
@@ -56,8 +56,9 @@ The caveat is important: Detent does not currently make GitHub Projects or
 Codex disappear. The Detent process has no vendor SaaS control plane of its
 own, but a fully sovereign deployment depends on the tracker and model backends
 available in your environment. Today the product path is GitHub Projects plus
-Codex; broader model / local-model support is a roadmap direction, not a reason
-to claim parity with every BYO-model assistant.
+Codex; workflow routing can choose Codex backend profiles and models, but
+broader non-Codex / local-model support is a roadmap direction, not a reason to
+claim parity with every BYO-model assistant.
 
 Sources: [README](../README.md), [License](../LICENSE).
 
@@ -224,6 +225,8 @@ Detent's distinction is the combination, not any single checkbox:
 - A self-hosted orchestrator with no Detent SaaS control plane.
 - GitHub Projects v2 as the native state machine.
 - Worktree-per-issue execution owned by your node.
+- Multi-instance authorization selectors plus claim / lease ownership for
+  shared boards.
 - Explicit workflow contracts, validation gates, workpad comments, and
   acceptance-driven handoff.
 - Budget checks and operational telemetry in the same runtime that dispatches
@@ -235,8 +238,9 @@ Detent's distinction is the combination, not any single checkbox:
 
 Against Symphony specifically, Detent is the productized Go evolution: GitHub
 Projects instead of Linear, native Git worktrees instead of a reference
-workspace script, multi-project scheduling from one host, release-oriented
-operator surfaces, and the merge train built in.
+workspace script, multi-project scheduling and multi-instance ownership from
+self-hosted nodes, release-oriented operator surfaces, and the merge train
+built in.
 
 ### Ease Of Use
 
@@ -258,10 +262,12 @@ Copilot self-hosted Actions runners and Cursor self-hosted cloud-agent workers
 have closed much of the local-execution gap. Detent should not claim "local
 execution" as a unique advantage by itself.
 
-Detent also should not overclaim model sovereignty before the model backend
-surface exists in production. The current system is Codex-first. The long-term
-edge is the combination of local orchestration, board-native governance,
-pluggable tracker / model boundaries, and deterministic release gates.
+Detent also should not overclaim model sovereignty before non-Codex backends
+exist in production. The current system is Codex-first, even though workflow
+routes can choose among configured Codex backend profiles and model fields. The
+long-term edge is the combination of local orchestration, board-native
+governance, pluggable tracker / model boundaries, and deterministic release
+gates.
 
 For organizations that value vendor-managed UX, enterprise policy integration,
 and polished agent surfaces more than owning the orchestration loop, Copilot or

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -10,8 +10,8 @@ The execution edge still carries these code/git/PR assumptions.
 
 - `internal/runner` owns `AgentBackend`, backend factories, and task routing.
 - `internal/config` exposes `agents.backends` and `agents.routes`.
-- Domain or label based model routing is handled by the existing selector and
-  router; this issue does not add another agent seam.
+- Domain, label, priority, assignee, author, or ProjectV2 field based routing
+  is handled by the existing selector and router.
 
 ### Validation Gate
 


### PR DESCRIPTION
## Summary

- Update README feature docs for shipped pluggable gates, ProjectV2 status option ordering, and current blank-status behavior
- Clarify multi-instance docs around connection pooling, claim lease heartbeat wording, and Codex backend options
- Refresh comparison and execution-seams docs for multi-instance ownership and Codex backend routing

Fixes #283

## Test Plan

- [x] `git diff --check`
- [x] `make check`