### PR TITLE
refactor(config): prefer unprefixed env vars

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,7 +26,7 @@ make setup
 make dev
 ```
 
-`make dev` runs Air with `DETENT_ENV=dev` and `DETENT_LOG_LEVEL=debug`, builds `./tmp/detent`, rotates `tmp/air-combined.log`, and streams combined build and application output to `tmp/air-combined.log`.
+`make dev` runs Air with `ENV=dev` and `LOG_LEVEL=debug`, builds `./tmp/detent`, rotates `tmp/air-combined.log`, and streams combined build and application output to `tmp/air-combined.log`.
 
 The default web bind is `127.0.0.1:4000` when no config or port is supplied. If another Detent process is already using that port, do not start a second server on it. Run a built binary with `./tmp/detent --port 0` when you need an ephemeral port.
 
@@ -34,10 +34,11 @@ The default web bind is `127.0.0.1:4000` when no config or port is supplied. If 
 
 Detent logs with `log/slog`.
 
-- `DETENT_ENV=dev`, `development`, or `local` enables tint text logs.
-- `DETENT_ENV=prod` or any other non-development value keeps JSON logs.
-- When `DETENT_ENV` is unset, interactive stdout TTY runs use tint text logs; non-TTY runs use JSON logs.
-- `DETENT_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- `ENV=dev`, `development`, or `local` enables tint text logs.
+- `ENV=prod` or any other non-development value keeps JSON logs.
+- When `ENV` is unset, interactive stdout TTY runs use tint text logs; non-TTY runs use JSON logs.
+- `LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- `DETENT_ENV` and `DETENT_LOG_LEVEL` remain deprecated fallbacks for one release. The unprefixed names win when both are set.
 - Text logs are written to stdout; JSON logs are written to stderr.
 
 ## Global Config Discovery
@@ -45,12 +46,14 @@ Detent logs with `log/slog`.
 Detent must resolve `global.yaml` consistently across supported operating systems. Keep this precedence intact when changing startup or config commands:
 
 1. `--config <path>` uses the direct CLI file path.
-2. `DETENT_CONFIG=<file>` uses the direct environment file path.
-3. `DETENT_HOME=<dir>` uses `<dir>/global.yaml`.
+2. `CONFIG=<file>` uses the direct environment file path.
+3. `CONFIG_HOME=<dir>` uses `<dir>/global.yaml`.
 4. `os.UserConfigDir()` uses `<config-dir>/detent/global.yaml`.
 5. The legacy default uses `~/.detent/global.yaml`.
 
 The OS-native config directory is `%AppData%\detent\global.yaml` on Windows, `~/Library/Application Support/detent/global.yaml` on macOS, and `~/.config/detent/global.yaml` on Linux, with `XDG_CONFIG_HOME` honored by `os.UserConfigDir()`.
+
+`DETENT_CONFIG` and `DETENT_HOME` remain deprecated fallbacks for one release. Detent uses `CONFIG_HOME` instead of `HOME` because `HOME` is standard process state, not Detent configuration.
 
 After global config lookup fails, startup may fall back to a valid `WORKFLOW.md` in the current working directory for single-project mode. `detent config path` should continue to report both the selected path and the matching rule.
 

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dev:
 		mv tmp/air-combined.log tmp/air-combined-$$(date +%Y%m%d-%H%M%S).log; \
 	fi
 	@ls -t tmp/air-combined-*.log 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null || true
-	@DETENT_ENV=dev DETENT_LOG_LEVEL=debug air 2>&1 | tee tmp/air-combined.log
+	@ENV=dev LOG_LEVEL=debug air 2>&1 | tee tmp/air-combined.log
 
 generate:
 	@go generate ./...

--- a/README.md
+++ b/README.md
@@ -304,8 +304,9 @@ Omit `codex.shell` and `hooks.shell` to use the per-OS defaults: `sh` on Unix
 and `cmd` on Windows. For portable hooks, prefer no hook when Detent already
 does the setup natively. When a hook is necessary, keep it to commands available
 on every target or set `hooks.shell: pwsh` and write PowerShell that reads
-Detent values from `$env:DETENT_WORKSPACE`, `$env:DETENT_WORKSPACE_KEY`,
-`$env:DETENT_BRANCH`, and `$env:DETENT_ISSUE_IDENTIFIER`.
+Detent values from `$env:WORKSPACE`, `$env:WORKSPACE_KEY`, `$env:BRANCH`,
+and `$env:ISSUE_IDENTIFIER`. The older `DETENT_*` hook variables remain
+available as deprecated aliases for one release.
 
 4. Create the global config and add the project:
 
@@ -319,9 +320,9 @@ detent add-project \
 
 5. Verify the setup before dispatching:
 
-```sh
-detent --config ~/.detent/global.yaml doctor
-```
+   ```sh
+   detent doctor
+   ```
 
 `detent doctor` is a preflight check: config resolution, the SQLite database,
 the `codex` binary, the GitHub token and scopes, the git binary, and whether the
@@ -331,14 +332,14 @@ an unauthenticated `codex` are the usual culprits).
 6. Start Detent:
 
 ```sh
-detent --config ~/.detent/global.yaml
+detent
 ```
 
 Open the dashboard at <http://localhost:4000>. Use `--host` and `--port` to
 override the address:
 
 ```sh
-detent --config ~/.detent/global.yaml --host 127.0.0.1 --port 4001
+detent --host 127.0.0.1 --port 4001
 ```
 
 ## Bootstrap On A New Machine (Humans And AI Agents)
@@ -410,7 +411,7 @@ repo is a real, working instance of this setup to copy from.
 8. **Verify everything:**
 
    ```sh
-   detent --config ~/.detent/global.yaml doctor
+   detent doctor
    ```
 
    Every check must pass (the server-port check may fail if Detent is already
@@ -419,7 +420,7 @@ repo is a real, working instance of this setup to copy from.
 9. **Start Detent and confirm the dashboard:**
 
    ```sh
-   detent --config ~/.detent/global.yaml
+   detent
    curl -fsS http://localhost:4000/api/v1/state    # returns JSON telemetry
    ```
 
@@ -514,7 +515,7 @@ stay busy while merge candidates wait for CI or a clean base branch.
 
 Detent separates host-level orchestration from per-project workflow:
 
-- `~/.detent/global.yaml` lists projects and host-level scheduling settings.
+- The resolved global config file lists projects and host-level scheduling settings.
 - Each project has its own `WORKFLOW.md` with tracker credentials, states,
   workspace rules, Codex settings, budgets, hooks, and agent instructions.
 
@@ -553,17 +554,17 @@ means no explicit priority.
 Use the project administration commands to edit `global.yaml`:
 
 ```sh
-detent --config ~/.detent/global.yaml add-project \
+detent add-project \
   --id <id> \
   --workflow <WORKFLOW.md> \
   --workdir <dir> \
   --weight 1 \
   --priority 3
 
-detent --config ~/.detent/global.yaml pause <id>
-detent --config ~/.detent/global.yaml unpause <id>
-detent --config ~/.detent/global.yaml promote <id> --priority 1
-detent --config ~/.detent/global.yaml remove-project <id>
+detent pause <id>
+detent unpause <id>
+detent promote <id> --priority 1
+detent remove-project <id>
 ```
 
 These commands persist the global config. A running Detent process watches the
@@ -777,8 +778,8 @@ make dev
 make check
 ```
 
-`make dev` runs Air with `DETENT_ENV=dev` and
-`DETENT_LOG_LEVEL=debug`, builds `./tmp/detent`, rotates
+`make dev` runs Air with `ENV=dev` and
+`LOG_LEVEL=debug`, builds `./tmp/detent`, rotates
 `tmp/air-combined.log`, and streams combined build and application output to
 `tmp/air-combined.log`.
 
@@ -792,11 +793,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 
 Detent logs with `log/slog`.
 
-- `DETENT_ENV=dev`, `development`, or `local` enables tint text logs.
-- `DETENT_ENV=prod` or any other non-development value keeps JSON logs.
-- When `DETENT_ENV` is unset, interactive stdout TTY runs use tint text logs;
+- `ENV=dev`, `development`, or `local` enables tint text logs.
+- `ENV=prod` or any other non-development value keeps JSON logs.
+- When `ENV` is unset, interactive stdout TTY runs use tint text logs;
   non-TTY runs use JSON logs.
-- `DETENT_LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- `LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- `DETENT_ENV` and `DETENT_LOG_LEVEL` remain deprecated fallbacks for one release. The unprefixed names win when both are set.
 - Text logs are written to stdout; JSON logs are written to stderr.
 
 ## Configuration
@@ -806,12 +808,14 @@ At startup, Detent resolves `global.yaml` in this order. The first matching rule
 | Order | Rule | Path |
 | --- | --- | --- |
 | 1 | `--config <path>` | Direct file path from the CLI flag |
-| 2 | `DETENT_CONFIG=<file>` | Direct file path from the environment |
-| 3 | `DETENT_HOME=<dir>` | `<dir>/global.yaml` |
+| 2 | `CONFIG=<file>` | Direct file path from the environment |
+| 3 | `CONFIG_HOME=<dir>` | `<dir>/global.yaml` |
 | 4 | `os.UserConfigDir()` | `<config-dir>/detent/global.yaml` |
 | 5 | Legacy home config | `~/.detent/global.yaml` |
 
 `os.UserConfigDir()` maps to `%AppData%\detent\global.yaml` on Windows, `~/Library/Application Support/detent/global.yaml` on macOS, and `~/.config/detent/global.yaml` on Linux while honoring `XDG_CONFIG_HOME`.
+
+`DETENT_CONFIG` and `DETENT_HOME` remain deprecated fallbacks for one release. Detent uses `CONFIG_HOME` instead of `HOME` because `HOME` is standard process state, not Detent configuration.
 
 If no global config is found, Detent keeps the single-project fallback and looks for `WORKFLOW.md` in the current working directory. Use `detent config path` to print the resolved config path and the rule that selected it.
 

--- a/cmd/detent/slog.go
+++ b/cmd/detent/slog.go
@@ -11,8 +11,8 @@ import (
 )
 
 func setupLoggerFromEnv(stdout io.Writer, stderr io.Writer) *slog.Logger {
-	env, envSet := envValueWithPresence("DETENT_ENV", "ENV")
-	return setupLoggerWithOutputs(env, envSet, envValue("DETENT_LOG_LEVEL", "LOG_LEVEL"), stdout, stderr, writerIsTTY(stdout))
+	env, envSet := envValueWithPresence("ENV", "DETENT_ENV")
+	return setupLoggerWithOutputs(env, envSet, envValue("LOG_LEVEL", "DETENT_LOG_LEVEL"), stdout, stderr, writerIsTTY(stdout))
 }
 
 func setupLogger(env string, level string, w io.Writer) *slog.Logger {

--- a/cmd/detent/slog_test.go
+++ b/cmd/detent/slog_test.go
@@ -51,20 +51,37 @@ func TestSetupLoggerSetsDefault(t *testing.T) {
 	}
 }
 
-func TestSetupLoggerFromEnvUsesDetentVariables(t *testing.T) {
+func TestSetupLoggerFromEnvUsesUnprefixedVariables(t *testing.T) {
 	previous := slog.Default()
 	t.Cleanup(func() {
 		slog.SetDefault(previous)
 	})
-	t.Setenv("DETENT_ENV", "development")
-	t.Setenv("ENV", "production")
-	t.Setenv("DETENT_LOG_LEVEL", "debug")
-	t.Setenv("LOG_LEVEL", "error")
+	t.Setenv("ENV", "development")
+	t.Setenv("DETENT_ENV", "production")
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("DETENT_LOG_LEVEL", "error")
 
 	logger := setupLoggerFromEnv(&bytes.Buffer{}, &bytes.Buffer{})
 
 	if !logger.Enabled(context.Background(), slog.LevelDebug) {
-		t.Fatal("expected DETENT_LOG_LEVEL to enable debug records")
+		t.Fatal("expected LOG_LEVEL to enable debug records")
+	}
+}
+
+func TestSetupLoggerFromEnvFallsBackToDeprecatedPrefixedVariables(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	t.Setenv("ENV", "")
+	t.Setenv("LOG_LEVEL", "")
+	t.Setenv("DETENT_ENV", "development")
+	t.Setenv("DETENT_LOG_LEVEL", "debug")
+
+	logger := setupLoggerFromEnv(&bytes.Buffer{}, &bytes.Buffer{})
+
+	if !logger.Enabled(context.Background(), slog.LevelDebug) {
+		t.Fatal("expected DETENT_LOG_LEVEL fallback to enable debug records")
 	}
 }
 
@@ -182,9 +199,9 @@ func TestNewLogHandlerAllowsNilWriter(t *testing.T) {
 }
 
 func TestEnvValueFallback(t *testing.T) {
-	t.Setenv("DETENT_TEST_FALLBACK", "fallback")
+	t.Setenv("TEST_FALLBACK", "fallback")
 
-	if got := envValue("DETENT_TEST_PRIMARY", "DETENT_TEST_FALLBACK"); got != "fallback" {
+	if got := envValue("TEST_PRIMARY", "TEST_FALLBACK"); got != "fallback" {
 		t.Fatalf("envValue fallback = %q, want fallback", got)
 	}
 }

--- a/install_test.go
+++ b/install_test.go
@@ -321,7 +321,7 @@ func TestFreshInstallBootsOnboardingWizardAndRunsSubcommands(t *testing.T) {
 	}
 	serverEnv := append(os.Environ(),
 		"HOME="+home,
-		"DETENT_HOME="+filepath.Join(home, ".detent"),
+		"CONFIG_HOME="+filepath.Join(home, ".detent"),
 	)
 	port := reservePort(t)
 	stop := startDetentServer(t, binary, workdir, serverEnv, port)

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -416,8 +416,8 @@ func runtimeLogPath(cfg BootConfig) string {
 }
 
 func logLevelFromEnv() slog.Level {
-	for _, key := range []string{"DETENT_LOG_LEVEL", "LOG_LEVEL"} {
-		if level, ok := os.LookupEnv(key); ok {
+	for _, key := range []string{"LOG_LEVEL", "DETENT_LOG_LEVEL"} {
+		if level, ok := os.LookupEnv(key); ok && strings.TrimSpace(level) != "" {
 			return parseSlogLevel(level)
 		}
 	}

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -91,6 +91,24 @@ func TestRedirectDefaultLoggerWritesToFile(t *testing.T) {
 	}
 }
 
+func TestLogLevelFromEnvUsesUnprefixedBeforeDeprecatedPrefixed(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("DETENT_LOG_LEVEL", "error")
+
+	if got := logLevelFromEnv(); got != slog.LevelDebug {
+		t.Fatalf("logLevelFromEnv() = %v, want %v", got, slog.LevelDebug)
+	}
+}
+
+func TestLogLevelFromEnvFallsBackToDeprecatedPrefixed(t *testing.T) {
+	t.Setenv("LOG_LEVEL", "")
+	t.Setenv("DETENT_LOG_LEVEL", "warn")
+
+	if got := logLevelFromEnv(); got != slog.LevelWarn {
+		t.Fatalf("logLevelFromEnv() = %v, want %v", got, slog.LevelWarn)
+	}
+}
+
 func TestTerminalDashboardError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -153,7 +153,7 @@ func TestRootCommandCapturesHeadlessFlagAndTerminalState(t *testing.T) {
 
 func TestRootCommandPrintsBootBanner(t *testing.T) {
 	root := t.TempDir()
-	t.Setenv("DETENT_HOME", filepath.Join(root, ".detent"))
+	t.Setenv("CONFIG_HOME", filepath.Join(root, ".detent"))
 	ctx, cancel := context.WithCancel(context.Background())
 	cancel()
 
@@ -186,7 +186,7 @@ func TestRootCommandPrintsBootBanner(t *testing.T) {
 
 func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing.T) {
 	root := t.TempDir()
-	t.Setenv("DETENT_HOME", filepath.Join(root, ".detent"))
+	t.Setenv("CONFIG_HOME", filepath.Join(root, ".detent"))
 	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), validWorkflowContent())
 	t.Chdir(root)
 
@@ -220,7 +220,7 @@ func TestRootCommandBootsFromDefaultWorkflowWhenGlobalConfigIsMissing(t *testing
 
 func TestRootCommandUsesDefaultWorkflowServerAddress(t *testing.T) {
 	root := t.TempDir()
-	t.Setenv("DETENT_HOME", filepath.Join(root, ".detent"))
+	t.Setenv("CONFIG_HOME", filepath.Join(root, ".detent"))
 	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer("0.0.0.0", 4101))
 	t.Chdir(root)
 
@@ -267,7 +267,7 @@ func TestRootCommandUsesConfiguredProjectWorkflowServerAddress(t *testing.T) {
 
 func TestRootCommandCLIAddressOverridesWorkflowServerAddress(t *testing.T) {
 	root := t.TempDir()
-	t.Setenv("DETENT_HOME", filepath.Join(root, ".detent"))
+	t.Setenv("CONFIG_HOME", filepath.Join(root, ".detent"))
 	writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), workflowContentWithServer("0.0.0.0", 4103))
 	t.Chdir(root)
 
@@ -299,7 +299,7 @@ func TestRootCommandUsesOnboardingModeWithoutValidWorkflow(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			root := t.TempDir()
-			t.Setenv("DETENT_HOME", filepath.Join(root, ".detent"))
+			t.Setenv("CONFIG_HOME", filepath.Join(root, ".detent"))
 			if tt.content != "" {
 				writeWorkflow(t, filepath.Join(root, "WORKFLOW.md"), tt.content)
 			}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -205,7 +205,7 @@ func checkDoctorConfig(configPath string, opts options) (globalconfig.PathResolu
 			Name:   "Config resolution",
 			Status: doctorFail,
 			Detail: err.Error(),
-			Hint:   "Pass --config or set DETENT_CONFIG to a readable global.yaml.",
+			Hint:   "Pass --config or set CONFIG to a readable global.yaml.",
 		}
 	}
 

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -33,11 +33,13 @@ var schedulingModes = []string{
 type PathRule string
 
 const (
-	PathRuleFlag          PathRule = "--config"
-	PathRuleEnvConfig     PathRule = "DETENT_CONFIG"
-	PathRuleEnvHome       PathRule = "DETENT_HOME"
-	PathRuleUserConfigDir PathRule = "os.UserConfigDir()"
-	PathRuleLegacyHome    PathRule = "~/.detent"
+	PathRuleFlag                PathRule = "--config"
+	PathRuleEnvConfig           PathRule = "CONFIG"
+	PathRuleDeprecatedEnvConfig PathRule = "DETENT_CONFIG"
+	PathRuleEnvHome             PathRule = "CONFIG_HOME"
+	PathRuleDeprecatedEnvHome   PathRule = "DETENT_HOME"
+	PathRuleUserConfigDir       PathRule = "os.UserConfigDir()"
+	PathRuleLegacyHome          PathRule = "~/.detent"
 )
 
 type PathResolution struct {
@@ -378,15 +380,21 @@ func resolvePath(configPath string, opts pathOptions) (PathResolution, error) {
 	if strings.TrimSpace(configPath) != "" {
 		return pathResolution(configPath, PathRuleFlag, opts.config)
 	}
-	if envPath := strings.TrimSpace(opts.lookupEnv("DETENT_CONFIG")); envPath != "" {
-		return pathResolution(envPath, PathRuleEnvConfig, opts.config)
+	if envPath, rule := lookupPathEnv(opts.lookupEnv, pathEnvCandidates{
+		{name: string(PathRuleEnvConfig), rule: PathRuleEnvConfig},
+		{name: string(PathRuleDeprecatedEnvConfig), rule: PathRuleDeprecatedEnvConfig},
+	}); envPath != "" {
+		return pathResolution(envPath, rule, opts.config)
 	}
-	if detentHome := strings.TrimSpace(opts.lookupEnv("DETENT_HOME")); detentHome != "" {
-		expanded, err := expandPath(detentHome, opts.config)
+	if configHome, rule := lookupPathEnv(opts.lookupEnv, pathEnvCandidates{
+		{name: string(PathRuleEnvHome), rule: PathRuleEnvHome},
+		{name: string(PathRuleDeprecatedEnvHome), rule: PathRuleDeprecatedEnvHome},
+	}); configHome != "" {
+		expanded, err := expandPath(configHome, opts.config)
 		if err != nil {
 			return PathResolution{}, err
 		}
-		return PathResolution{Path: filepath.Join(expanded, "global.yaml"), Rule: PathRuleEnvHome}, nil
+		return PathResolution{Path: filepath.Join(expanded, "global.yaml"), Rule: rule}, nil
 	}
 
 	nativePath, nativeErr := userConfigPath(opts)
@@ -403,6 +411,22 @@ func resolvePath(configPath string, opts pathOptions) (PathResolution, error) {
 	default:
 		return PathResolution{}, nativeErr
 	}
+}
+
+type pathEnvCandidate struct {
+	name string
+	rule PathRule
+}
+
+type pathEnvCandidates []pathEnvCandidate
+
+func lookupPathEnv(lookupEnv func(string) string, candidates pathEnvCandidates) (string, PathRule) {
+	for _, candidate := range candidates {
+		if value := strings.TrimSpace(lookupEnv(candidate.name)); value != "" {
+			return value, candidate.rule
+		}
+	}
+	return "", ""
 }
 
 func normalizePathOptions(opts pathOptions) pathOptions {

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -382,19 +382,23 @@ func resolvePath(configPath string, opts pathOptions) (PathResolution, error) {
 	}
 	if envPath, rule := lookupPathEnv(opts.lookupEnv, pathEnvCandidates{
 		{name: string(PathRuleEnvConfig), rule: PathRuleEnvConfig},
-		{name: string(PathRuleDeprecatedEnvConfig), rule: PathRuleDeprecatedEnvConfig},
 	}); envPath != "" {
 		return pathResolution(envPath, rule, opts.config)
 	}
 	if configHome, rule := lookupPathEnv(opts.lookupEnv, pathEnvCandidates{
 		{name: string(PathRuleEnvHome), rule: PathRuleEnvHome},
+	}); configHome != "" {
+		return configHomeResolution(configHome, rule, opts.config)
+	}
+	if envPath, rule := lookupPathEnv(opts.lookupEnv, pathEnvCandidates{
+		{name: string(PathRuleDeprecatedEnvConfig), rule: PathRuleDeprecatedEnvConfig},
+	}); envPath != "" {
+		return pathResolution(envPath, rule, opts.config)
+	}
+	if configHome, rule := lookupPathEnv(opts.lookupEnv, pathEnvCandidates{
 		{name: string(PathRuleDeprecatedEnvHome), rule: PathRuleDeprecatedEnvHome},
 	}); configHome != "" {
-		expanded, err := expandPath(configHome, opts.config)
-		if err != nil {
-			return PathResolution{}, err
-		}
-		return PathResolution{Path: filepath.Join(expanded, "global.yaml"), Rule: rule}, nil
+		return configHomeResolution(configHome, rule, opts.config)
 	}
 
 	nativePath, nativeErr := userConfigPath(opts)
@@ -451,6 +455,14 @@ func pathResolution(path string, rule PathRule, opts options) (PathResolution, e
 		return PathResolution{}, err
 	}
 	return PathResolution{Path: expanded, Rule: rule}, nil
+}
+
+func configHomeResolution(configHome string, rule PathRule, opts options) (PathResolution, error) {
+	expanded, err := expandPath(configHome, opts)
+	if err != nil {
+		return PathResolution{}, err
+	}
+	return PathResolution{Path: filepath.Join(expanded, "global.yaml"), Rule: rule}, nil
 }
 
 func userConfigPath(opts pathOptions) (string, error) {

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -25,21 +25,24 @@ func TestResolvePathPrecedence(t *testing.T) {
 	flagPath := filepath.Join(root, "flag.yaml")
 	envPath := filepath.Join(root, "env.yaml")
 	detentHome := filepath.Join(root, "detent-home")
+	deprecatedEnvPath := filepath.Join(root, "deprecated-env.yaml")
+	deprecatedHome := filepath.Join(root, "deprecated-home")
 	homePath := filepath.Join(detentHome, "global.yaml")
+	deprecatedHomePath := filepath.Join(deprecatedHome, "global.yaml")
 	nativePath := filepath.Join(nativeRoot, "detent", "global.yaml")
 	legacyPath := filepath.Join(home, ".detent", "global.yaml")
-	for _, path := range []string{flagPath, envPath, homePath, nativePath, legacyPath} {
+	for _, path := range []string{flagPath, envPath, homePath, deprecatedEnvPath, deprecatedHomePath, nativePath, legacyPath} {
 		writeFile(t, path, "# config\n")
 	}
 	t.Setenv("CONFIG", envPath)
 	t.Setenv("CONFIG_HOME", detentHome)
-	t.Setenv("DETENT_CONFIG", filepath.Join(root, "deprecated-env.yaml"))
-	t.Setenv("DETENT_HOME", filepath.Join(root, "deprecated-home"))
+	t.Setenv("DETENT_CONFIG", deprecatedEnvPath)
+	t.Setenv("DETENT_HOME", deprecatedHome)
 
 	tests := []struct {
 		name     string
 		flagPath string
-		setup    func()
+		setup    func(*testing.T)
 		wantPath string
 		wantRule PathRule
 	}{
@@ -51,7 +54,7 @@ func TestResolvePathPrecedence(t *testing.T) {
 		},
 		{
 			name: "config env wins after flag",
-			setup: func() {
+			setup: func(t *testing.T) {
 				t.Setenv("CONFIG", envPath)
 				t.Setenv("CONFIG_HOME", detentHome)
 			},
@@ -59,18 +62,26 @@ func TestResolvePathPrecedence(t *testing.T) {
 			wantRule: PathRuleEnvConfig,
 		},
 		{
-			name: "config home wins after direct config env",
-			setup: func() {
+			name: "config home wins before deprecated direct config env",
+			setup: func(t *testing.T) {
 				t.Setenv("CONFIG", "")
-				t.Setenv("DETENT_CONFIG", "")
 				t.Setenv("CONFIG_HOME", detentHome)
 			},
 			wantPath: homePath,
 			wantRule: PathRuleEnvHome,
 		},
 		{
+			name: "deprecated direct config env wins before deprecated home env",
+			setup: func(t *testing.T) {
+				t.Setenv("CONFIG", "")
+				t.Setenv("CONFIG_HOME", "")
+			},
+			wantPath: deprecatedEnvPath,
+			wantRule: PathRuleDeprecatedEnvConfig,
+		},
+		{
 			name: "native config wins before legacy",
-			setup: func() {
+			setup: func(t *testing.T) {
 				clearPathEnv(t)
 			},
 			wantPath: nativePath,
@@ -78,7 +89,7 @@ func TestResolvePathPrecedence(t *testing.T) {
 		},
 		{
 			name: "legacy config wins when native is missing",
-			setup: func() {
+			setup: func(t *testing.T) {
 				clearPathEnv(t)
 				if err := os.Remove(nativePath); err != nil {
 					t.Fatalf("Remove() error = %v", err)
@@ -92,7 +103,7 @@ func TestResolvePathPrecedence(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			if tt.setup != nil {
-				tt.setup()
+				tt.setup(t)
 			}
 
 			got, err := ResolvePath(tt.flagPath)

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -13,8 +13,7 @@ import (
 )
 
 func TestResolvePathPrecedence(t *testing.T) {
-	t.Setenv("DETENT_HOME", "")
-	t.Setenv("DETENT_CONFIG", "")
+	clearPathEnv(t)
 
 	root := t.TempDir()
 	home := configurePathTestHome(t, root)
@@ -32,8 +31,10 @@ func TestResolvePathPrecedence(t *testing.T) {
 	for _, path := range []string{flagPath, envPath, homePath, nativePath, legacyPath} {
 		writeFile(t, path, "# config\n")
 	}
-	t.Setenv("DETENT_CONFIG", envPath)
-	t.Setenv("DETENT_HOME", detentHome)
+	t.Setenv("CONFIG", envPath)
+	t.Setenv("CONFIG_HOME", detentHome)
+	t.Setenv("DETENT_CONFIG", filepath.Join(root, "deprecated-env.yaml"))
+	t.Setenv("DETENT_HOME", filepath.Join(root, "deprecated-home"))
 
 	tests := []struct {
 		name     string
@@ -49,19 +50,20 @@ func TestResolvePathPrecedence(t *testing.T) {
 			wantRule: PathRuleFlag,
 		},
 		{
-			name: "detent config wins after flag",
+			name: "config env wins after flag",
 			setup: func() {
-				t.Setenv("DETENT_CONFIG", envPath)
-				t.Setenv("DETENT_HOME", detentHome)
+				t.Setenv("CONFIG", envPath)
+				t.Setenv("CONFIG_HOME", detentHome)
 			},
 			wantPath: envPath,
 			wantRule: PathRuleEnvConfig,
 		},
 		{
-			name: "detent home wins after direct config env",
+			name: "config home wins after direct config env",
 			setup: func() {
+				t.Setenv("CONFIG", "")
 				t.Setenv("DETENT_CONFIG", "")
-				t.Setenv("DETENT_HOME", detentHome)
+				t.Setenv("CONFIG_HOME", detentHome)
 			},
 			wantPath: homePath,
 			wantRule: PathRuleEnvHome,
@@ -69,8 +71,7 @@ func TestResolvePathPrecedence(t *testing.T) {
 		{
 			name: "native config wins before legacy",
 			setup: func() {
-				t.Setenv("DETENT_CONFIG", "")
-				t.Setenv("DETENT_HOME", "")
+				clearPathEnv(t)
 			},
 			wantPath: nativePath,
 			wantRule: PathRuleUserConfigDir,
@@ -78,8 +79,7 @@ func TestResolvePathPrecedence(t *testing.T) {
 		{
 			name: "legacy config wins when native is missing",
 			setup: func() {
-				t.Setenv("DETENT_CONFIG", "")
-				t.Setenv("DETENT_HOME", "")
+				clearPathEnv(t)
 				if err := os.Remove(nativePath); err != nil {
 					t.Fatalf("Remove() error = %v", err)
 				}
@@ -110,8 +110,7 @@ func TestResolvePathPrecedence(t *testing.T) {
 }
 
 func TestResolvePathUsesNativeConfigDirWhenNoConfigExists(t *testing.T) {
-	t.Setenv("DETENT_HOME", "")
-	t.Setenv("DETENT_CONFIG", "")
+	clearPathEnv(t)
 	configurePathTestHome(t, t.TempDir())
 
 	nativeRoot, err := os.UserConfigDir()
@@ -134,8 +133,7 @@ func TestResolvePathUsesNativeConfigDirWhenNoConfigExists(t *testing.T) {
 }
 
 func TestDefaultPath(t *testing.T) {
-	t.Setenv("DETENT_HOME", "")
-	t.Setenv("DETENT_CONFIG", "")
+	clearPathEnv(t)
 	configurePathTestHome(t, t.TempDir())
 
 	nativeRoot, err := os.UserConfigDir()
@@ -154,10 +152,27 @@ func TestDefaultPath(t *testing.T) {
 	}
 }
 
-func TestDefaultPathHonorsDetentHome(t *testing.T) {
+func TestDefaultPathHonorsConfigHome(t *testing.T) {
 	root := t.TempDir()
 	home := configurePathTestHome(t, root)
-	t.Setenv("DETENT_CONFIG", "")
+	clearPathEnv(t)
+	t.Setenv("CONFIG_HOME", "~/custom")
+
+	got, err := DefaultPath()
+	if err != nil {
+		t.Fatalf("DefaultPath() error = %v", err)
+	}
+
+	want := filepath.Join(home, "custom", "global.yaml")
+	if got != want {
+		t.Fatalf("DefaultPath() = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultPathFallsBackToDeprecatedDetentHome(t *testing.T) {
+	root := t.TempDir()
+	home := configurePathTestHome(t, root)
+	clearPathEnv(t)
 	t.Setenv("DETENT_HOME", "~/custom")
 
 	got, err := DefaultPath()
@@ -172,8 +187,7 @@ func TestDefaultPathHonorsDetentHome(t *testing.T) {
 }
 
 func TestDefaultConfig(t *testing.T) {
-	t.Setenv("DETENT_HOME", "")
-	t.Setenv("DETENT_CONFIG", "")
+	clearPathEnv(t)
 
 	cfg, err := Default()
 	if err != nil {
@@ -838,6 +852,14 @@ func configurePathTestHome(t *testing.T, root string) string {
 		t.Setenv("XDG_CONFIG_HOME", "")
 	}
 	return home
+}
+
+func clearPathEnv(t *testing.T) {
+	t.Helper()
+
+	for _, key := range []string{"CONFIG", "CONFIG_HOME", "DETENT_CONFIG", "DETENT_HOME"} {
+		t.Setenv(key, "")
+	}
 }
 
 func assertMap(t *testing.T, name string, got map[string]any, want map[string]any) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -516,15 +516,23 @@ func gitCommonDir(ctx context.Context, dir string) (string, error) {
 
 func hookEnv(info Info, issue Issue) []string {
 	env := append([]string{}, os.Environ()...)
-	values := map[string]string{
-		"DETENT_WORKSPACE":        info.Path,
-		"DETENT_WORKSPACE_KEY":    info.Key,
-		"DETENT_BRANCH":           info.Branch,
-		"DETENT_ISSUE_ID":         issue.ID,
-		"DETENT_ISSUE_IDENTIFIER": issue.Identifier,
+	values := []struct {
+		key   string
+		value string
+	}{
+		{"DETENT_WORKSPACE", info.Path},
+		{"DETENT_WORKSPACE_KEY", info.Key},
+		{"DETENT_BRANCH", info.Branch},
+		{"DETENT_ISSUE_ID", issue.ID},
+		{"DETENT_ISSUE_IDENTIFIER", issue.Identifier},
+		{"WORKSPACE", info.Path},
+		{"WORKSPACE_KEY", info.Key},
+		{"BRANCH", info.Branch},
+		{"ISSUE_ID", issue.ID},
+		{"ISSUE_IDENTIFIER", issue.Identifier},
 	}
-	for key, value := range values {
-		env = append(env, key+"="+value)
+	for _, value := range values {
+		env = append(env, value.key+"="+value.value)
 	}
 	return env
 }

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -25,7 +25,7 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 		SourceRoot: source,
 		AutoBranch: true,
 		Hooks: Hooks{
-			AfterCreate: "printf '%s|%s|%s|%s|%s\n' \"$PWD\" \"$(git branch --show-current)\" \"$DETENT_ISSUE_IDENTIFIER\" \"$DETENT_WORKSPACE_KEY\" \"$DETENT_BRANCH\" >> " + shellQuote(tracePath),
+			AfterCreate: "printf '%s|%s|%s|%s|%s|%s|%s|%s\n' \"$PWD\" \"$(git branch --show-current)\" \"$ISSUE_IDENTIFIER\" \"$WORKSPACE_KEY\" \"$BRANCH\" \"$DETENT_ISSUE_IDENTIFIER\" \"$DETENT_WORKSPACE_KEY\" \"$DETENT_BRANCH\" >> " + shellQuote(tracePath),
 			Timeout:     time.Second,
 		},
 	})
@@ -59,8 +59,8 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 
 	trace := strings.TrimSpace(readFile(t, tracePath))
 	fields := strings.Split(trace, "|")
-	if len(fields) != 5 {
-		t.Fatalf("after_create trace = %q, want five fields", trace)
+	if len(fields) != 8 {
+		t.Fatalf("after_create trace = %q, want eight fields", trace)
 	}
 	if fields[0] != info.Path {
 		t.Fatalf("after_create cwd = %q, want %q", fields[0], info.Path)
@@ -69,13 +69,22 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 		t.Fatalf("after_create branch = %q, want detent/dd_19", fields[1])
 	}
 	if fields[2] != "DD/19" {
-		t.Fatalf("DETENT_ISSUE_IDENTIFIER = %q, want DD/19", fields[2])
+		t.Fatalf("ISSUE_IDENTIFIER = %q, want DD/19", fields[2])
 	}
 	if fields[3] != "DD_19" {
-		t.Fatalf("DETENT_WORKSPACE_KEY = %q, want DD_19", fields[3])
+		t.Fatalf("WORKSPACE_KEY = %q, want DD_19", fields[3])
 	}
 	if fields[4] != "detent/dd_19" {
-		t.Fatalf("DETENT_BRANCH = %q, want detent/dd_19", fields[4])
+		t.Fatalf("BRANCH = %q, want detent/dd_19", fields[4])
+	}
+	if fields[5] != "DD/19" {
+		t.Fatalf("DETENT_ISSUE_IDENTIFIER = %q, want DD/19", fields[5])
+	}
+	if fields[6] != "DD_19" {
+		t.Fatalf("DETENT_WORKSPACE_KEY = %q, want DD_19", fields[6])
+	}
+	if fields[7] != "detent/dd_19" {
+		t.Fatalf("DETENT_BRANCH = %q, want detent/dd_19", fields[7])
 	}
 }
 
@@ -265,8 +274,8 @@ func TestLocalGitBeforeAndAfterRunHooks(t *testing.T) {
 		SourceRoot: source,
 		AutoBranch: true,
 		Hooks: Hooks{
-			BeforeRun: "printf 'before:%s:%s\n' \"$PWD\" \"$DETENT_WORKSPACE_KEY\" >> " + shellQuote(tracePath),
-			AfterRun:  "printf 'after:%s:%s\n' \"$PWD\" \"$DETENT_WORKSPACE_KEY\" >> " + shellQuote(tracePath),
+			BeforeRun: "printf 'before:%s:%s\n' \"$PWD\" \"$WORKSPACE_KEY\" >> " + shellQuote(tracePath),
+			AfterRun:  "printf 'after:%s:%s\n' \"$PWD\" \"$WORKSPACE_KEY\" >> " + shellQuote(tracePath),
 			Timeout:   time.Second,
 		},
 	})
@@ -344,7 +353,7 @@ func TestLocalGitCleanupRemovesOnlyTargetWorktree(t *testing.T) {
 		SourceRoot: source,
 		AutoBranch: true,
 		Hooks: Hooks{
-			BeforeRemove: "printf '%s\n' \"$DETENT_WORKSPACE_KEY\" >> " + shellQuote(tracePath),
+			BeforeRemove: "printf '%s\n' \"$WORKSPACE_KEY\" >> " + shellQuote(tracePath),
 			Timeout:      time.Second,
 		},
 	})


### PR DESCRIPTION
## Summary

- Read `ENV`, `LOG_LEVEL`, `CONFIG`, and `CONFIG_HOME` before deprecated `DETENT_` fallbacks.
- Export unprefixed hook context variables while keeping `DETENT_*` aliases for one release.
- Update docs and `make dev`; companion orchestration launch update is in `digitaldrywood/detent-orchestration@detent/282-env-vars`.

Fixes #282

## Test Plan

- [x] `go test . ./cmd/detent ./internal/cli ./internal/config/global ./internal/workspace`
- [x] `make check`
