### PR TITLE
feat(orchestrator): auto-close completed epics

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -37,3 +37,7 @@ type IssueCloser interface {
 type IssueReferenceResolver interface {
 	FetchIssueStatesByIdentifiers(context.Context, []string) ([]Issue, error)
 }
+
+type IssueChildrenResolver interface {
+	FetchIssueChildren(context.Context, string) ([]BlockedRef, error)
+}

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -29,3 +29,11 @@ type InstanceIdentifier interface {
 type Provisioner interface {
 	Provision(context.Context) error
 }
+
+type IssueCloser interface {
+	CloseIssue(context.Context, string) error
+}
+
+type IssueReferenceResolver interface {
+	FetchIssueStatesByIdentifiers(context.Context, []string) ([]Issue, error)
+}

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -46,6 +46,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
               repository { nameWithOwner }
               closedByPullRequestsReferences(first: 5) { nodes { number url } }
               subIssues(first: 100) {
+                pageInfo { hasNextPage endCursor }
                 nodes {
                   id
                   number
@@ -86,6 +87,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
                 }
               }
               trackedIssues(first: 100) {
+                pageInfo { hasNextPage endCursor }
                 nodes {
                   id
                   number
@@ -176,6 +178,7 @@ query DetentGitHubIssuesByID($issueIds: [ID!]!, $projectItemsFirst: Int!) {
       repository { nameWithOwner }
       closedByPullRequestsReferences(first: 5) { nodes { number url } }
       subIssues(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           number
@@ -216,6 +219,7 @@ query DetentGitHubIssuesByID($issueIds: [ID!]!, $projectItemsFirst: Int!) {
         }
       }
       trackedIssues(first: 100) {
+        pageInfo { hasNextPage endCursor }
         nodes {
           id
           number
@@ -333,6 +337,106 @@ query DetentGitHubIssueByNumber($owner: String!, $name: String!, $number: Int!, 
               ... on ProjectV2ItemFieldNumberValue {
                 number
                 field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
+const issueSubIssuesQuery = `
+query DetentGitHubIssueSubIssues($issueId: ID!, $after: String) {
+  node(id: $issueId) {
+    ... on Issue {
+      subIssues(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          number
+          title
+          state
+          url
+          repository { nameWithOwner }
+          projectItems(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              project { id }
+              statusValue: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+              }
+              priorityValue: fieldValueByName(name: "Priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              fieldValues(first: 100) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldNumberValue {
+                    number
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
+const issueTrackedIssuesQuery = `
+query DetentGitHubIssueTrackedIssues($issueId: ID!, $after: String) {
+  node(id: $issueId) {
+    ... on Issue {
+      trackedIssues(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          number
+          title
+          state
+          url
+          repository { nameWithOwner }
+          projectItems(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              project { id }
+              statusValue: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+              }
+              priorityValue: fieldValueByName(name: "Priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              fieldValues(first: 100) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldNumberValue {
+                    number
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                }
               }
             }
           }
@@ -570,8 +674,13 @@ type githubIssueNode struct {
 	Repository                     repository                   `json:"repository"`
 	ClosedByPullRequestsReferences nodeConnection[pullRequest]  `json:"closedByPullRequestsReferences"`
 	ProjectItems                   *projectItemsConnection      `json:"projectItems"`
-	SubIssues                      nodeConnection[linkedIssue]  `json:"subIssues"`
-	TrackedIssues                  nodeConnection[linkedIssue]  `json:"trackedIssues"`
+	SubIssues                      linkedIssuesConnection       `json:"subIssues"`
+	TrackedIssues                  linkedIssuesConnection       `json:"trackedIssues"`
+}
+
+type linkedIssuesConnection struct {
+	PageInfo pageInfo      `json:"pageInfo"`
+	Nodes    []linkedIssue `json:"nodes"`
 }
 
 type linkedIssue struct {
@@ -764,6 +873,103 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 	}
 	sortIssuesByRequestedIdentifiers(issues, identifiers)
 	return issues, nil
+}
+
+func (c *Connector) FetchIssueChildren(ctx context.Context, issueID string) ([]connector.BlockedRef, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return []connector.BlockedRef{}, nil
+	}
+
+	seen := map[string]struct{}{}
+	children := []connector.BlockedRef{}
+	subIssues, err := c.fetchLinkedIssueRefs(ctx, issueID, issueSubIssuesQuery, "subIssues")
+	if err != nil {
+		return nil, err
+	}
+	children = appendUniqueLinkedIssueRefs(children, seen, subIssues)
+	trackedIssues, err := c.fetchLinkedIssueRefs(ctx, issueID, issueTrackedIssuesQuery, "trackedIssues")
+	if err != nil {
+		return nil, err
+	}
+	children = appendUniqueLinkedIssueRefs(children, seen, trackedIssues)
+	return children, nil
+}
+
+func (c *Connector) fetchLinkedIssueRefs(ctx context.Context, issueID string, query string, connectionName string) ([]connector.BlockedRef, error) {
+	var after *string
+	seen := map[string]struct{}{}
+	refs := []connector.BlockedRef{}
+	for {
+		connection, err := c.fetchLinkedIssuePage(ctx, issueID, query, connectionName, after)
+		if err != nil {
+			return nil, err
+		}
+		pageRefs := c.appendLinkedChildIssues(nil, map[string]struct{}{}, connection.Nodes, "")
+		refs = appendUniqueLinkedIssueRefs(refs, seen, pageRefs)
+		if !connection.PageInfo.HasNextPage {
+			return refs, nil
+		}
+		cursor := strings.TrimSpace(connection.PageInfo.EndCursor)
+		if cursor == "" {
+			return nil, ErrInvalidResponse
+		}
+		after = &cursor
+	}
+}
+
+func appendUniqueLinkedIssueRefs(
+	refs []connector.BlockedRef,
+	seen map[string]struct{},
+	incoming []connector.BlockedRef,
+) []connector.BlockedRef {
+	for _, ref := range incoming {
+		key := normalizedIssueIdentifier(ref.Identifier)
+		if key == "" {
+			key = "id:" + strings.TrimSpace(ref.ID)
+		}
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, ref)
+	}
+	return refs
+}
+
+func (c *Connector) fetchLinkedIssuePage(
+	ctx context.Context,
+	issueID string,
+	query string,
+	connectionName string,
+	after *string,
+) (linkedIssuesConnection, error) {
+	var response struct {
+		Node *struct {
+			SubIssues     linkedIssuesConnection `json:"subIssues"`
+			TrackedIssues linkedIssuesConnection `json:"trackedIssues"`
+		} `json:"node"`
+	}
+	if err := c.client.GraphQL(ctx, query, map[string]any{
+		"issueId": issueID,
+		"after":   after,
+	}, &response); err != nil {
+		return linkedIssuesConnection{}, fmt.Errorf("fetch github issue children: %w", err)
+	}
+	if response.Node == nil {
+		return linkedIssuesConnection{}, ErrInvalidResponse
+	}
+	switch connectionName {
+	case "subIssues":
+		return response.Node.SubIssues, nil
+	case "trackedIssues":
+		return response.Node.TrackedIssues, nil
+	default:
+		return linkedIssuesConnection{}, ErrInvalidResponse
+	}
 }
 
 func (c *Connector) fetchIssueByIdentifier(ctx context.Context, identifier string) (connector.Issue, bool, error) {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -45,6 +45,86 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
               labels(first: 20) { nodes { name } }
               repository { nameWithOwner }
               closedByPullRequestsReferences(first: 5) { nodes { number url } }
+              subIssues(first: 100) {
+                nodes {
+                  id
+                  number
+                  title
+                  state
+                  url
+                  repository { nameWithOwner }
+                  projectItems(first: 100) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id
+                      project { id }
+                      statusValue: fieldValueByName(name: "Status") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+                      }
+                      priorityValue: fieldValueByName(name: "Priority") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name }
+                      }
+                      fieldValues(first: 100) {
+                        nodes {
+                          __typename
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                          ... on ProjectV2ItemFieldTextValue {
+                            text
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                          ... on ProjectV2ItemFieldNumberValue {
+                            number
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+              trackedIssues(first: 100) {
+                nodes {
+                  id
+                  number
+                  title
+                  state
+                  url
+                  repository { nameWithOwner }
+                  projectItems(first: 100) {
+                    pageInfo { hasNextPage endCursor }
+                    nodes {
+                      id
+                      project { id }
+                      statusValue: fieldValueByName(name: "Status") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+                      }
+                      priorityValue: fieldValueByName(name: "Priority") {
+                        ... on ProjectV2ItemFieldSingleSelectValue { name }
+                      }
+                      fieldValues(first: 100) {
+                        nodes {
+                          __typename
+                          ... on ProjectV2ItemFieldSingleSelectValue {
+                            name
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                          ... on ProjectV2ItemFieldTextValue {
+                            text
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                          ... on ProjectV2ItemFieldNumberValue {
+                            number
+                            field { ... on ProjectV2FieldCommon { name } }
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
             }
           }
           statusValue: fieldValueByName(name: "Status") {
@@ -82,6 +162,139 @@ query DetentGitHubIssuesByID($issueIds: [ID!]!, $projectItemsFirst: Int!) {
   nodes(ids: $issueIds) {
     __typename
     ... on Issue {
+      id
+      number
+      title
+      body
+      state
+      url
+      createdAt
+      updatedAt
+      author { login }
+      assignees(first: 100) { nodes { id login } }
+      labels(first: 20) { nodes { name } }
+      repository { nameWithOwner }
+      closedByPullRequestsReferences(first: 5) { nodes { number url } }
+      subIssues(first: 100) {
+        nodes {
+          id
+          number
+          title
+          state
+          url
+          repository { nameWithOwner }
+          projectItems(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              project { id }
+              statusValue: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+              }
+              priorityValue: fieldValueByName(name: "Priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              fieldValues(first: 100) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldNumberValue {
+                    number
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      trackedIssues(first: 100) {
+        nodes {
+          id
+          number
+          title
+          state
+          url
+          repository { nameWithOwner }
+          projectItems(first: 100) {
+            pageInfo { hasNextPage endCursor }
+            nodes {
+              id
+              project { id }
+              statusValue: fieldValueByName(name: "Status") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+              }
+              priorityValue: fieldValueByName(name: "Priority") {
+                ... on ProjectV2ItemFieldSingleSelectValue { name }
+              }
+              fieldValues(first: 100) {
+                nodes {
+                  __typename
+                  ... on ProjectV2ItemFieldSingleSelectValue {
+                    name
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldTextValue {
+                    text
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                  ... on ProjectV2ItemFieldNumberValue {
+                    number
+                    field { ... on ProjectV2FieldCommon { name } }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+      projectItems(first: $projectItemsFirst) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          project { id }
+          statusValue: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+          }
+          priorityValue: fieldValueByName(name: "Priority") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+          fieldValues(first: 100) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
+const issueByNumberQuery = `
+query DetentGitHubIssueByNumber($owner: String!, $name: String!, $number: Int!, $projectItemsFirst: Int!) {
+  repository(owner: $owner, name: $name) {
+    issue(number: $number) {
+      __typename
       id
       number
       title
@@ -177,6 +390,13 @@ const addCommentMutation = `
 mutation DetentGitHubAddComment($subjectId: ID!, $body: String!) {
   addComment(input: {subjectId: $subjectId, body: $body}) {
     commentEdge { node { id } }
+  }
+}`
+
+const closeIssueMutation = `
+mutation DetentGitHubCloseIssue($issueId: ID!, $stateReason: IssueClosedStateReason!) {
+  closeIssue(input: {issueId: $issueId, stateReason: $stateReason}) {
+    issue { id state }
   }
 }`
 
@@ -350,6 +570,18 @@ type githubIssueNode struct {
 	Repository                     repository                   `json:"repository"`
 	ClosedByPullRequestsReferences nodeConnection[pullRequest]  `json:"closedByPullRequestsReferences"`
 	ProjectItems                   *projectItemsConnection      `json:"projectItems"`
+	SubIssues                      nodeConnection[linkedIssue]  `json:"subIssues"`
+	TrackedIssues                  nodeConnection[linkedIssue]  `json:"trackedIssues"`
+}
+
+type linkedIssue struct {
+	ID           string                  `json:"id"`
+	Number       int                     `json:"number"`
+	Title        string                  `json:"title"`
+	State        string                  `json:"state"`
+	URL          string                  `json:"url"`
+	Repository   repository              `json:"repository"`
+	ProjectItems *projectItemsConnection `json:"projectItems"`
 }
 
 type nodeConnection[T any] struct {
@@ -514,6 +746,56 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 	return issues, nil
 }
 
+func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) ([]connector.Issue, error) {
+	identifiers = uniqueNonBlank(identifiers)
+	if len(identifiers) == 0 {
+		return []connector.Issue{}, nil
+	}
+
+	issues := make([]connector.Issue, 0, len(identifiers))
+	for _, identifier := range identifiers {
+		issue, ok, err := c.fetchIssueByIdentifier(ctx, identifier)
+		if err != nil {
+			return nil, err
+		}
+		if ok {
+			issues = append(issues, issue)
+		}
+	}
+	sortIssuesByRequestedIdentifiers(issues, identifiers)
+	return issues, nil
+}
+
+func (c *Connector) fetchIssueByIdentifier(ctx context.Context, identifier string) (connector.Issue, bool, error) {
+	repo, number, ok := splitIssueIdentifier(identifier)
+	if !ok {
+		return connector.Issue{}, false, nil
+	}
+	parts := strings.Split(repo, "/")
+	if len(parts) != 2 {
+		return connector.Issue{}, false, nil
+	}
+
+	var response struct {
+		Repository *struct {
+			Issue *githubIssueNode `json:"issue"`
+		} `json:"repository"`
+	}
+	if err := c.client.GraphQL(ctx, issueByNumberQuery, map[string]any{
+		"owner":             strings.TrimSpace(parts[0]),
+		"name":              strings.TrimSpace(parts[1]),
+		"number":            number,
+		"projectItemsFirst": projectItemsPerIssue,
+	}, &response); err != nil {
+		return connector.Issue{}, false, fmt.Errorf("fetch github issue by identifier: %w", err)
+	}
+	if response.Repository == nil || response.Repository.Issue == nil {
+		return connector.Issue{}, false, nil
+	}
+
+	return c.normalizeIssueNode(ctx, *response.Repository.Issue)
+}
+
 func (c *Connector) populateBlockerReasons(ctx context.Context, issues []connector.Issue) error {
 	ids := make([]string, 0, len(issues))
 	for _, issue := range issues {
@@ -573,6 +855,30 @@ func (c *Connector) CreateComment(ctx context.Context, issueID string, body stri
 		response.AddComment.CommentEdge.Node == nil ||
 		strings.TrimSpace(response.AddComment.CommentEdge.Node.ID) == "" {
 		return ErrCommentCreateFailed
+	}
+
+	return nil
+}
+
+func (c *Connector) CloseIssue(ctx context.Context, issueID string) error {
+	var response struct {
+		CloseIssue *struct {
+			Issue *struct {
+				ID    string `json:"id"`
+				State string `json:"state"`
+			} `json:"issue"`
+		} `json:"closeIssue"`
+	}
+	if err := c.client.GraphQL(ctx, closeIssueMutation, map[string]any{
+		"issueId":     strings.TrimSpace(issueID),
+		"stateReason": "COMPLETED",
+	}, &response); err != nil {
+		return fmt.Errorf("close github issue: %w", err)
+	}
+	if response.CloseIssue == nil ||
+		response.CloseIssue.Issue == nil ||
+		strings.TrimSpace(response.CloseIssue.Issue.ID) == "" {
+		return ErrIssueCloseFailed
 	}
 
 	return nil
@@ -985,11 +1291,13 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		Priority:         c.priorityRank(priorityName),
 		State:            c.githubToDetentState(statusName),
 		URL:              issue.URL,
+		Closed:           githubIssueClosed(issue.State),
 		PRNumber:         firstPullRequestNumber(issue.ClosedByPullRequestsReferences),
 		AuthorID:         actorLogin(issue.Author),
 		AssigneeID:       firstAssigneeLogin(issue.Assignees),
 		Assignees:        allAssigneeLogins(issue.Assignees),
 		BlockedBy:        parseBlockedBy(issue.Body, repo),
+		ChildIssues:      c.linkedChildIssues(issue, repo),
 		BlockerReason:    parseBlockerReason(issue),
 		Labels:           labelNames(issue.Labels),
 		Fields:           cloneStringMap(fields),
@@ -999,6 +1307,55 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		StageUpdatedAt:   statusUpdatedAt,
 		ModelOverride:    parseModelOverride(issue.Body),
 	}
+}
+
+func (c *Connector) linkedChildIssues(issue githubIssueNode, fallbackRepo string) []connector.BlockedRef {
+	seen := map[string]struct{}{}
+	children := []connector.BlockedRef{}
+	children = c.appendLinkedChildIssues(children, seen, issue.SubIssues.Nodes, fallbackRepo)
+	children = c.appendLinkedChildIssues(children, seen, issue.TrackedIssues.Nodes, fallbackRepo)
+	if len(children) == 0 {
+		return nil
+	}
+	return children
+}
+
+func (c *Connector) appendLinkedChildIssues(
+	children []connector.BlockedRef,
+	seen map[string]struct{},
+	linked []linkedIssue,
+	fallbackRepo string,
+) []connector.BlockedRef {
+	for _, child := range linked {
+		identifier := buildIdentifier(strings.TrimSpace(child.Repository.NameWithOwner), child.Number)
+		if identifier == "" {
+			identifier = buildIdentifier(strings.TrimSpace(fallbackRepo), child.Number)
+		}
+		if identifier == "" {
+			continue
+		}
+		key := normalizedIssueIdentifier(identifier)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		children = append(children, connector.BlockedRef{
+			ID:         strings.TrimSpace(child.ID),
+			Identifier: identifier,
+			State:      c.linkedChildIssueState(child),
+		})
+	}
+	return children
+}
+
+func (c *Connector) linkedChildIssueState(child linkedIssue) string {
+	state := c.githubIssueStateToDetentState(child.State)
+	if stateName, _, _, _, ok := c.projectFields(child.ID, child.ProjectItems); ok {
+		if stateName = strings.TrimSpace(stateName); stateName != "" {
+			state = c.githubToDetentState(stateName)
+		}
+	}
+	return state
 }
 
 func (c *Connector) resolveStatusOption(ctx context.Context, githubState string) (string, string, error) {
@@ -1368,6 +1725,10 @@ func (c *Connector) githubIssueStateToDetentState(state string) string {
 	default:
 		return ""
 	}
+}
+
+func githubIssueClosed(state string) bool {
+	return strings.EqualFold(strings.TrimSpace(state), "CLOSED")
 }
 
 func (c *Connector) closedIssueState() string {
@@ -1835,6 +2196,27 @@ func sortIssuesByRequestedIDs(issues []connector.Issue, ids []string) {
 	fallback := len(order)
 	sort.SliceStable(issues, func(i, j int) bool {
 		return orderForIssue(issues[i], order, fallback) < orderForIssue(issues[j], order, fallback)
+	})
+}
+
+func sortIssuesByRequestedIdentifiers(issues []connector.Issue, identifiers []string) {
+	order := make(map[string]int, len(identifiers))
+	for index, identifier := range identifiers {
+		order[normalizedIssueIdentifier(identifier)] = index
+	}
+	fallback := len(order)
+	sort.SliceStable(issues, func(i, j int) bool {
+		left := normalizedIssueIdentifier(issues[i].Identifier)
+		right := normalizedIssueIdentifier(issues[j].Identifier)
+		leftOrder, ok := order[left]
+		if !ok {
+			leftOrder = fallback
+		}
+		rightOrder, ok := order[right]
+		if !ok {
+			rightOrder = fallback
+		}
+		return leftOrder < rightOrder
 	})
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -680,6 +680,49 @@ func TestConnectorFetchIssueStatesByIdentifiersResolvesGitHubStateAndProjectStat
 	}
 }
 
+func TestConnectorFetchIssueChildrenPaginatesLinkedIssues(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"subIssues":{"pageInfo":{"hasNextPage":true,"endCursor":"sub-cursor-1"},"nodes":[{"id":"I_sub_1","number":251,"title":"Sub child","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/251","repository":{"nameWithOwner":"digitaldrywood/detent"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[]}}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"subIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"I_sub_2","number":252,"title":"Sub child 2","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/252","repository":{"nameWithOwner":"digitaldrywood/detent"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_sub_2","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"trackedIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"I_tracked","number":253,"title":"Tracked child","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/253","repository":{"nameWithOwner":"digitaldrywood/detent"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_tracked","project":{"id":"PVT_1"},"statusValue":{"name":"In Progress"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}]}}}}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssueChildren(context.Background(), "I_epic")
+	if err != nil {
+		t.Fatalf("FetchIssueChildren() error = %v", err)
+	}
+	want := []connector.BlockedRef{
+		{ID: "I_sub_1", Identifier: "digitaldrywood/detent#251", State: "Done"},
+		{ID: "I_sub_2", Identifier: "digitaldrywood/detent#252", State: "Done"},
+		{ID: "I_tracked", Identifier: "digitaldrywood/detent#253", State: "In Progress"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("FetchIssueChildren() = %#v, want %#v", got, want)
+	}
+
+	requests := server.requests()
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
+	}
+	secondVariables := requests[1]["variables"].(map[string]any)
+	if secondVariables["after"] != "sub-cursor-1" {
+		t.Fatalf("second after = %v, want sub-cursor-1", secondVariables["after"])
+	}
+	if !strings.Contains(requests[2]["query"].(string), "trackedIssues") {
+		t.Fatalf("third query = %q, want trackedIssues", requests[2]["query"])
+	}
+}
+
 func TestConnectorCreateCommentCallsAddComment(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -265,6 +265,41 @@ func TestConnectorFetchCandidateIssuesResolvesBlockedByProjectState(t *testing.T
 	}
 }
 
+func TestConnectorFetchCandidateIssuesCapturesLinkedChildIssues(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_epic","content":{"__typename":"Issue","id":"I_epic","number":258,"title":"Epic: release readiness","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/258","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"epic"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]},"subIssues":{"nodes":[{"id":"I_sub","number":251,"title":"Sub issue","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/251","repository":{"nameWithOwner":"digitaldrywood/detent"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[]}}]},"trackedIssues":{"nodes":[{"id":"I_tracked","number":252,"title":"Tracked issue","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/252","repository":{"nameWithOwner":"digitaldrywood/detent"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_tracked","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}]}},"statusValue":{"name":"Todo"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}}}`,
+	}, {
+		body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+	}})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
+	}
+
+	want := []connector.BlockedRef{
+		{ID: "I_sub", Identifier: "digitaldrywood/detent#251", State: "Done"},
+		{ID: "I_tracked", Identifier: "digitaldrywood/detent#252", State: "Done"},
+	}
+	if !reflect.DeepEqual(got[0].ChildIssues, want) {
+		t.Fatalf("ChildIssues = %#v, want %#v", got[0].ChildIssues, want)
+	}
+
+	query := server.requests()[0]["query"].(string)
+	for _, want := range []string{"subIssues(first: 100)", "trackedIssues(first: 100)"} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("project query missing %q:\n%s", want, query)
+		}
+	}
+}
+
 func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testing.T) {
 	t.Parallel()
 
@@ -607,6 +642,44 @@ func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssueStatesByIdentifiersResolvesGitHubStateAndProjectStatus(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"repository":{"issue":{"__typename":"Issue","id":"I_closed","number":251,"title":"Closed child","body":"","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/251","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}`,
+		},
+		{
+			body: `{"data":{"repository":{"issue":{"__typename":"Issue","id":"I_done","number":252,"title":"Done child","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/252","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_done","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}}}}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssueStatesByIdentifiers(context.Background(), []string{"digitaldrywood/detent#251", "digitaldrywood/detent#252"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers() error = %v", err)
+	}
+	if ids := githubIssueIDs(got); !reflect.DeepEqual(ids, []string{"I_closed", "I_done"}) {
+		t.Fatalf("FetchIssueStatesByIdentifiers() ids = %#v, want [I_closed I_done]", ids)
+	}
+	if !got[0].Closed || got[0].State != "Done" {
+		t.Fatalf("closed child = %#v, want Closed true and State Done", got[0])
+	}
+	if got[1].Closed || got[1].State != "Done" {
+		t.Fatalf("project done child = %#v, want open issue with State Done", got[1])
+	}
+
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
+	}
+	firstVariables := requests[0]["variables"].(map[string]any)
+	if firstVariables["owner"] != "digitaldrywood" || firstVariables["name"] != "detent" || firstVariables["number"] != float64(251) {
+		t.Fatalf("first variables = %#v, want digitaldrywood/detent#251", firstVariables)
+	}
+}
+
 func TestConnectorCreateCommentCallsAddComment(t *testing.T) {
 	t.Parallel()
 
@@ -636,6 +709,38 @@ func TestConnectorCreateCommentCallsAddComment(t *testing.T) {
 	}
 	if variables["body"] != "hello" {
 		t.Fatalf("body = %v, want hello", variables["body"])
+	}
+}
+
+func TestConnectorCloseIssueCallsCloseIssue(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		body: `{"data":{"closeIssue":{"issue":{"id":"I_kw1","state":"CLOSED"}}}}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+
+	if err := c.CloseIssue(context.Background(), " I_kw1 "); err != nil {
+		t.Fatalf("CloseIssue() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(requests))
+	}
+	query := requests[0]["query"].(string)
+	if !strings.Contains(query, "closeIssue") {
+		t.Fatalf("query = %q, want closeIssue", query)
+	}
+	if strings.Contains(query, "rateLimit") {
+		t.Fatalf("query = %q, want no rateLimit on mutation root", query)
+	}
+	variables := requests[0]["variables"].(map[string]any)
+	if variables["issueId"] != "I_kw1" {
+		t.Fatalf("issueId = %v, want I_kw1", variables["issueId"])
+	}
+	if variables["stateReason"] != "COMPLETED" {
+		t.Fatalf("stateReason = %v, want COMPLETED", variables["stateReason"])
 	}
 }
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -150,6 +150,7 @@ func (c *Connector) InstanceLogin() string {
 var _ connector.Connector = (*Connector)(nil)
 var _ connector.Authenticator = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
+var _ connector.IssueChildrenResolver = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
 var _ connector.IssueReferenceResolver = (*Connector)(nil)
 var _ connector.Provisioner = (*Connector)(nil)

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -150,5 +150,7 @@ func (c *Connector) InstanceLogin() string {
 var _ connector.Connector = (*Connector)(nil)
 var _ connector.Authenticator = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
+var _ connector.IssueCloser = (*Connector)(nil)
+var _ connector.IssueReferenceResolver = (*Connector)(nil)
 var _ connector.Provisioner = (*Connector)(nil)
 var _ connector.RateLimitReporter = (*Connector)(nil)

--- a/internal/connector/github/errors.go
+++ b/internal/connector/github/errors.go
@@ -19,6 +19,7 @@ var (
 	ErrAssigneeNotFound           = errors.New("github assignee not found")
 	ErrAssigneeUpdateFailed       = errors.New("github assignee update failed")
 	ErrCommentCreateFailed        = errors.New("github comment create failed")
+	ErrIssueCloseFailed           = errors.New("github issue close failed")
 	ErrProjectItemNotFound        = errors.New("github project item not found")
 	ErrProjectFieldNotFound       = errors.New("github project field not found")
 	ErrProjectFieldOptionNotFound = errors.New("github project field option not found")

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -15,12 +15,14 @@ type Issue struct {
 	State            string            `json:"state,omitempty" yaml:"state,omitempty"`
 	BranchName       string            `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	URL              string            `json:"url,omitempty" yaml:"url,omitempty"`
+	Closed           bool              `json:"closed,omitempty" yaml:"closed,omitempty"`
 	PRNumber         *int              `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
 	PullRequest      *PullRequest      `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
 	AuthorID         string            `json:"author_id,omitempty" yaml:"author_id,omitempty"`
 	AssigneeID       string            `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`
 	Assignees        []string          `json:"assignees,omitempty" yaml:"assignees,omitempty"`
 	BlockedBy        []BlockedRef      `json:"blocked_by" yaml:"blocked_by"`
+	ChildIssues      []BlockedRef      `json:"child_issues,omitempty" yaml:"child_issues,omitempty"`
 	BlockerReason    string            `json:"blocker_reason,omitempty" yaml:"blocker_reason,omitempty"`
 	Labels           []string          `json:"labels" yaml:"labels"`
 	Fields           map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -43,6 +43,7 @@ type Connector struct {
 
 var _ connector.Connector = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
+var _ connector.IssueChildrenResolver = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
 var _ connector.IssueReferenceResolver = (*Connector)(nil)
 
@@ -111,6 +112,15 @@ func (c *Connector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers
 	}
 
 	return issues, nil
+}
+
+func (c *Connector) FetchIssueChildren(_ context.Context, issueID string) ([]connector.BlockedRef, error) {
+	for _, issue := range c.issues {
+		if issue.ID == issueID {
+			return append([]connector.BlockedRef(nil), issue.ChildIssues...), nil
+		}
+	}
+	return []connector.BlockedRef{}, nil
 }
 
 func (c *Connector) CreateComment(_ context.Context, issueID string, body string) error {

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -13,6 +13,7 @@ const (
 	EventKindStateUpdate    EventKind = "memory_tracker_state_update"
 	EventKindAssigneeUpdate EventKind = "memory_tracker_assignee_update"
 	EventKindFieldUpdate    EventKind = "memory_tracker_field_update"
+	EventKindClose          EventKind = "memory_tracker_close"
 )
 
 type EventKind string
@@ -42,6 +43,8 @@ type Connector struct {
 
 var _ connector.Connector = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
+var _ connector.IssueCloser = (*Connector)(nil)
+var _ connector.IssueReferenceResolver = (*Connector)(nil)
 
 func New(cfg Config) *Connector {
 	return &Connector{
@@ -94,8 +97,29 @@ func (c *Connector) FetchIssueStatesByIDs(_ context.Context, issueIDs []string) 
 	return issues, nil
 }
 
+func (c *Connector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
+	wantedIdentifiers := make(map[string]struct{}, len(identifiers))
+	for _, identifier := range identifiers {
+		wantedIdentifiers[normalizeState(identifier)] = struct{}{}
+	}
+
+	issues := make([]connector.Issue, 0, len(c.issues))
+	for _, issue := range c.issues {
+		if _, ok := wantedIdentifiers[normalizeState(issue.Identifier)]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+
+	return issues, nil
+}
+
 func (c *Connector) CreateComment(_ context.Context, issueID string, body string) error {
 	c.send(Event{Kind: EventKindComment, IssueID: issueID, Body: body})
+	return nil
+}
+
+func (c *Connector) CloseIssue(_ context.Context, issueID string) error {
+	c.send(Event{Kind: EventKindClose, IssueID: issueID})
 	return nil
 }
 
@@ -149,6 +173,9 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	if issue.BlockedBy != nil {
 		issue.BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
+	}
+	if issue.ChildIssues != nil {
+		issue.ChildIssues = append([]connector.BlockedRef(nil), issue.ChildIssues...)
 	}
 	if issue.Labels != nil {
 		issue.Labels = append([]string(nil), issue.Labels...)

--- a/internal/connector/memory/memory_test.go
+++ b/internal/connector/memory/memory_test.go
@@ -28,6 +28,7 @@ func TestConnectorFetchesConfiguredIssues(t *testing.T) {
 			AssigneeID:       "worker-1",
 			Assignees:        []string{"worker-1", "worker-2"},
 			BlockedBy:        []connector.BlockedRef{{ID: "issue-0", Identifier: "MT-0", State: "Done"}},
+			ChildIssues:      []connector.BlockedRef{{ID: "issue-10", Identifier: "MT-10", State: "Done"}},
 			Labels:           []string{"stage:s1"},
 			Fields:           map[string]string{"Status": "Todo", "Track": "foundation"},
 			AssignedToWorker: true,
@@ -59,6 +60,9 @@ func TestConnectorReturnsDefensiveIssueCopies(t *testing.T) {
 		State:     "Todo",
 		Assignees: []string{"worker-1"},
 		BlockedBy: []connector.BlockedRef{{Identifier: "MT-0"}},
+		ChildIssues: []connector.BlockedRef{{
+			Identifier: "MT-10",
+		}},
 		Labels:    []string{"stage:s1"},
 		Fields:    map[string]string{"Status": "Todo"},
 		CreatedAt: &createdAt,
@@ -74,6 +78,7 @@ func TestConnectorReturnsDefensiveIssueCopies(t *testing.T) {
 	*first[0].Priority = 3
 	first[0].Assignees[0] = "changed"
 	first[0].BlockedBy[0].Identifier = "changed"
+	first[0].ChildIssues[0].Identifier = "changed"
 	first[0].Labels[0] = "changed"
 	first[0].Fields["Status"] = "changed"
 	*first[0].CreatedAt = first[0].CreatedAt.Add(time.Hour)
@@ -92,6 +97,9 @@ func TestConnectorReturnsDefensiveIssueCopies(t *testing.T) {
 	}
 	if second[0].BlockedBy[0].Identifier != "MT-0" {
 		t.Fatalf("BlockedBy[0].Identifier = %q, want MT-0", second[0].BlockedBy[0].Identifier)
+	}
+	if second[0].ChildIssues[0].Identifier != "MT-10" {
+		t.Fatalf("ChildIssues[0].Identifier = %q, want MT-10", second[0].ChildIssues[0].Identifier)
 	}
 	if second[0].Labels[0] != "stage:s1" {
 		t.Fatalf("Labels[0] = %q, want stage:s1", second[0].Labels[0])
@@ -192,6 +200,9 @@ func TestConnectorMutationsMatchElixirMemoryAdapter(t *testing.T) {
 	if err := c.CreateComment(context.Background(), "issue-1", "comment"); err != nil {
 		t.Fatalf("CreateComment() error = %v", err)
 	}
+	if err := c.CloseIssue(context.Background(), "issue-1"); err != nil {
+		t.Fatalf("CloseIssue() error = %v", err)
+	}
 	if err := c.UpdateIssueState(context.Background(), "issue-1", "Done"); err != nil {
 		t.Fatalf("UpdateIssueState() error = %v", err)
 	}
@@ -208,6 +219,7 @@ func TestConnectorMutationsMatchElixirMemoryAdapter(t *testing.T) {
 
 	wantEvents := []Event{
 		{Kind: EventKindComment, IssueID: "issue-1", Body: "comment"},
+		{Kind: EventKindClose, IssueID: "issue-1"},
 		{Kind: EventKindStateUpdate, IssueID: "issue-1", State: "Done"},
 		{Kind: EventKindAssigneeUpdate, IssueID: "issue-1", Login: "worker-1"},
 		{Kind: EventKindFieldUpdate, IssueID: "issue-1", FieldName: "Owner", FieldValue: "worker-1"},
@@ -233,6 +245,9 @@ func TestConnectorMutationsNoopWithoutEventSink(t *testing.T) {
 
 	if err := c.CreateComment(context.Background(), "issue-1", "comment"); err != nil {
 		t.Fatalf("CreateComment() error = %v", err)
+	}
+	if err := c.CloseIssue(context.Background(), "issue-1"); err != nil {
+		t.Fatalf("CloseIssue() error = %v", err)
 	}
 	if err := c.UpdateIssueState(context.Background(), "issue-1", "Done"); err != nil {
 		t.Fatalf("UpdateIssueState() error = %v", err)

--- a/internal/orchestrator/epic.go
+++ b/internal/orchestrator/epic.go
@@ -1,0 +1,372 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+var (
+	epicDependencyLinePattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*:\\s*(?:[*_`~]+)?\\s*(.+)\\s*$")
+	epicChecklistLinePattern  = regexp.MustCompile(`^\s*[-*+]\s+\[[ xX]\]\s+(.+)$`)
+	epicIssueRefPattern       = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
+	epicIssueURLPattern       = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
+)
+
+type completedEpicPlan struct {
+	issue    connector.Issue
+	children []connector.BlockedRef
+}
+
+type epicIssueIndex struct {
+	byID         map[string]connector.Issue
+	byIdentifier map[string]connector.Issue
+}
+
+func (o *Orchestrator) closeCompletedEpics(ctx context.Context, issues []connector.Issue) map[string]struct{} {
+	index := newEpicIssueIndex(issues)
+	plans := completedEpicPlans(issues)
+	if len(plans) == 0 {
+		return nil
+	}
+
+	o.resolveMissingEpicChildren(ctx, index, plans)
+
+	completed := map[string]struct{}{}
+	for _, plan := range plans {
+		if !epicChildrenDone(plan.children, index, o.cfg.TerminalStates) {
+			continue
+		}
+		if strings.TrimSpace(plan.issue.ID) != "" {
+			completed[plan.issue.ID] = struct{}{}
+		}
+		o.finalizeCompletedEpic(ctx, plan.issue, plan.children)
+	}
+	return completed
+}
+
+func completedEpicPlans(issues []connector.Issue) []completedEpicPlan {
+	plans := make([]completedEpicPlan, 0, len(issues))
+	for _, issue := range issues {
+		if !epicIssue(issue) {
+			continue
+		}
+		children := epicChildRefs(issue)
+		if len(children) == 0 {
+			continue
+		}
+		plans = append(plans, completedEpicPlan{
+			issue:    cloneIssue(issue),
+			children: children,
+		})
+	}
+	return plans
+}
+
+func (o *Orchestrator) resolveMissingEpicChildren(ctx context.Context, index *epicIssueIndex, plans []completedEpicPlan) {
+	resolver, ok := o.connector.(connector.IssueReferenceResolver)
+	if !ok {
+		return
+	}
+
+	identifiers := make([]string, 0)
+	seen := map[string]struct{}{}
+	for _, plan := range plans {
+		for _, child := range plan.children {
+			if _, ok := index.issueForRef(child); ok {
+				continue
+			}
+			identifier := strings.TrimSpace(child.Identifier)
+			if identifier == "" {
+				continue
+			}
+			key := strings.ToLower(identifier)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			identifiers = append(identifiers, identifier)
+		}
+	}
+	if len(identifiers) == 0 {
+		return
+	}
+
+	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("resolve epic child issues failed", "error", err)
+		}
+		return
+	}
+	index.addIssues(issues)
+}
+
+func (o *Orchestrator) finalizeCompletedEpic(ctx context.Context, issue connector.Issue, children []connector.BlockedRef) {
+	if !stateIn(issue.State, o.cfg.TerminalStates) {
+		if err := o.connector.UpdateIssueState(ctx, issue.ID, doneStateName(o.cfg.TerminalStates)); err != nil && o.logger != nil {
+			o.logger.Warn("move completed epic to done failed", "issue_id", issue.ID, "error", err)
+		}
+	}
+	if issue.Closed {
+		return
+	}
+
+	body := completedEpicComment(len(children))
+	if err := o.connector.CreateComment(ctx, issue.ID, body); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("comment completed epic failed", "issue_id", issue.ID, "error", err)
+		}
+		return
+	}
+	closer, ok := o.connector.(connector.IssueCloser)
+	if !ok {
+		if o.logger != nil {
+			o.logger.Warn("close completed epic unsupported", "issue_id", issue.ID)
+		}
+		return
+	}
+	if err := closer.CloseIssue(ctx, issue.ID); err != nil && o.logger != nil {
+		o.logger.Warn("close completed epic failed", "issue_id", issue.ID, "error", err)
+	}
+}
+
+func completedEpicComment(childCount int) string {
+	if childCount == 1 {
+		return "Auto-closing completed epic: 1 child issue is Done."
+	}
+	return fmt.Sprintf("Auto-closing completed epic: %d child issues are Done.", childCount)
+}
+
+func epicChildrenDone(children []connector.BlockedRef, index *epicIssueIndex, terminalStates []string) bool {
+	for _, child := range children {
+		issue, ok := index.issueForRef(child)
+		if !ok {
+			return false
+		}
+		if issue.Closed {
+			continue
+		}
+		if !stateIn(issue.State, terminalStates) {
+			return false
+		}
+	}
+	return len(children) > 0
+}
+
+func newEpicIssueIndex(issues []connector.Issue) *epicIssueIndex {
+	index := &epicIssueIndex{
+		byID:         make(map[string]connector.Issue, len(issues)),
+		byIdentifier: make(map[string]connector.Issue, len(issues)),
+	}
+	index.addIssues(issues)
+	return index
+}
+
+func (i *epicIssueIndex) addIssues(issues []connector.Issue) {
+	for _, issue := range issues {
+		i.addIssue(issue)
+	}
+}
+
+func (i *epicIssueIndex) addIssue(issue connector.Issue) {
+	issue = cloneIssue(issue)
+	if id := strings.TrimSpace(issue.ID); id != "" {
+		i.byID[id] = issue
+	}
+	if identifier := normalizedIssueIdentifier(issue.Identifier); identifier != "" {
+		i.byIdentifier[identifier] = issue
+	}
+}
+
+func (i *epicIssueIndex) issueForRef(ref connector.BlockedRef) (connector.Issue, bool) {
+	if id := strings.TrimSpace(ref.ID); id != "" {
+		if issue, ok := i.byID[id]; ok {
+			return cloneIssue(issue), true
+		}
+	}
+	if identifier := normalizedIssueIdentifier(ref.Identifier); identifier != "" {
+		if issue, ok := i.byIdentifier[identifier]; ok {
+			return cloneIssue(issue), true
+		}
+	}
+	if strings.TrimSpace(ref.State) != "" {
+		return connector.Issue{
+			ID:         strings.TrimSpace(ref.ID),
+			Identifier: strings.TrimSpace(ref.Identifier),
+			State:      strings.TrimSpace(ref.State),
+		}, true
+	}
+	return connector.Issue{}, false
+}
+
+func filterCompletedEpicCandidates(issues []connector.Issue, completed map[string]struct{}) []connector.Issue {
+	if len(completed) == 0 {
+		return issues
+	}
+	out := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if _, ok := completed[issue.ID]; ok {
+			continue
+		}
+		out = append(out, issue)
+	}
+	return out
+}
+
+func epicIssue(issue connector.Issue) bool {
+	for _, label := range issue.Labels {
+		if strings.EqualFold(strings.TrimSpace(label), "epic") {
+			return true
+		}
+	}
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(issue.Title)), "epic:")
+}
+
+func epicChildRefs(issue connector.Issue) []connector.BlockedRef {
+	repo := issueRepo(issue.Identifier)
+	children := []connector.BlockedRef{}
+	positions := map[string]int{}
+	selfID := strings.TrimSpace(issue.ID)
+	selfIdentifier := normalizedIssueIdentifier(issue.Identifier)
+
+	add := func(ref connector.BlockedRef) {
+		ref.ID = strings.TrimSpace(ref.ID)
+		ref.Identifier = strings.TrimSpace(ref.Identifier)
+		ref.State = strings.TrimSpace(ref.State)
+		if ref.ID == "" && ref.Identifier == "" {
+			return
+		}
+		if ref.ID != "" && ref.ID == selfID {
+			return
+		}
+		if normalizedIssueIdentifier(ref.Identifier) == selfIdentifier {
+			return
+		}
+		key := epicRefKey(ref)
+		if index, ok := positions[key]; ok {
+			children[index] = mergeEpicRef(children[index], ref)
+			return
+		}
+		positions[key] = len(children)
+		children = append(children, ref)
+	}
+
+	for _, ref := range parseEpicBodyChildRefs(issue.Description, repo) {
+		add(ref)
+	}
+	for _, ref := range issue.BlockedBy {
+		add(ref)
+	}
+	for _, ref := range issue.ChildIssues {
+		add(ref)
+	}
+	return children
+}
+
+func parseEpicBodyChildRefs(body string, repo string) []connector.BlockedRef {
+	children := []connector.BlockedRef{}
+	for _, line := range strings.FieldsFunc(body, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	}) {
+		if matches := epicDependencyLinePattern.FindStringSubmatch(line); len(matches) == 2 {
+			children = append(children, parseEpicRefs(matches[1], repo)...)
+			continue
+		}
+		if matches := epicChecklistLinePattern.FindStringSubmatch(line); len(matches) == 2 {
+			children = append(children, parseEpicRefs(matches[1], repo)...)
+		}
+	}
+	return children
+}
+
+func parseEpicRefs(text string, repo string) []connector.BlockedRef {
+	refs := []connector.BlockedRef{}
+	seen := map[string]struct{}{}
+	addIdentifier := func(identifier string) {
+		identifier = strings.TrimSpace(identifier)
+		key := normalizedIssueIdentifier(identifier)
+		if key == "" {
+			return
+		}
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, connector.BlockedRef{Identifier: identifier})
+	}
+
+	for _, matches := range epicIssueURLPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) == 3 {
+			addIdentifier(blockerIdentifier(matches[1], matches[2], repo))
+		}
+	}
+	for _, matches := range epicIssueRefPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) == 3 {
+			addIdentifier(blockerIdentifier(matches[1], matches[2], repo))
+		}
+	}
+	return refs
+}
+
+func mergeEpicRef(current connector.BlockedRef, incoming connector.BlockedRef) connector.BlockedRef {
+	if current.ID == "" {
+		current.ID = incoming.ID
+	}
+	if current.Identifier == "" {
+		current.Identifier = incoming.Identifier
+	}
+	if current.State == "" {
+		current.State = incoming.State
+	}
+	return current
+}
+
+func epicRefKey(ref connector.BlockedRef) string {
+	if identifier := normalizedIssueIdentifier(ref.Identifier); identifier != "" {
+		return identifier
+	}
+	return "id:" + strings.TrimSpace(ref.ID)
+}
+
+func issueRepo(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	index := strings.LastIndex(identifier, "#")
+	if index <= 0 {
+		return ""
+	}
+	return strings.TrimSpace(identifier[:index])
+}
+
+func blockerIdentifier(refRepo string, number string, repo string) string {
+	if strings.TrimSpace(number) == "" {
+		return ""
+	}
+	refRepo = strings.TrimSpace(refRepo)
+	if refRepo == "" {
+		if strings.TrimSpace(repo) == "" {
+			return "#" + number
+		}
+		refRepo = strings.TrimSpace(repo)
+	}
+	return refRepo + "#" + number
+}
+
+func normalizedIssueIdentifier(identifier string) string {
+	return strings.ToLower(strings.TrimSpace(identifier))
+}
+
+func doneStateName(terminalStates []string) string {
+	for _, state := range terminalStates {
+		if normalizeState(state) == "done" {
+			return "Done"
+		}
+	}
+	if len(terminalStates) > 0 {
+		return strings.TrimSpace(terminalStates[0])
+	}
+	return "Done"
+}

--- a/internal/orchestrator/epic.go
+++ b/internal/orchestrator/epic.go
@@ -17,8 +17,9 @@ var (
 )
 
 type completedEpicPlan struct {
-	issue    connector.Issue
-	children []connector.BlockedRef
+	issue      connector.Issue
+	children   []connector.BlockedRef
+	incomplete bool
 }
 
 type epicIssueIndex struct {
@@ -33,10 +34,14 @@ func (o *Orchestrator) closeCompletedEpics(ctx context.Context, issues []connect
 		return nil
 	}
 
+	o.refreshLinkedEpicChildren(ctx, plans)
 	o.resolveMissingEpicChildren(ctx, index, plans)
 
 	completed := map[string]struct{}{}
 	for _, plan := range plans {
+		if plan.incomplete {
+			continue
+		}
 		if !epicChildrenDone(plan.children, index, o.cfg.TerminalStates) {
 			continue
 		}
@@ -66,6 +71,28 @@ func completedEpicPlans(issues []connector.Issue) []completedEpicPlan {
 	return plans
 }
 
+func (o *Orchestrator) refreshLinkedEpicChildren(ctx context.Context, plans []completedEpicPlan) {
+	resolver, ok := o.connector.(connector.IssueChildrenResolver)
+	if !ok {
+		return
+	}
+	for index := range plans {
+		issueID := strings.TrimSpace(plans[index].issue.ID)
+		if issueID == "" {
+			continue
+		}
+		children, err := resolver.FetchIssueChildren(ctx, issueID)
+		if err != nil {
+			plans[index].incomplete = true
+			if o.logger != nil {
+				o.logger.Warn("fetch epic linked children failed", "issue_id", issueID, "error", err)
+			}
+			continue
+		}
+		plans[index].children = mergeEpicChildRefs(plans[index].issue, plans[index].children, children)
+	}
+}
+
 func (o *Orchestrator) resolveMissingEpicChildren(ctx context.Context, index *epicIssueIndex, plans []completedEpicPlan) {
 	resolver, ok := o.connector.(connector.IssueReferenceResolver)
 	if !ok {
@@ -75,6 +102,9 @@ func (o *Orchestrator) resolveMissingEpicChildren(ctx context.Context, index *ep
 	identifiers := make([]string, 0)
 	seen := map[string]struct{}{}
 	for _, plan := range plans {
+		if plan.incomplete {
+			continue
+		}
 		for _, child := range plan.children {
 			if _, ok := index.issueForRef(child); ok {
 				continue
@@ -227,7 +257,12 @@ func epicIssue(issue connector.Issue) bool {
 }
 
 func epicChildRefs(issue connector.Issue) []connector.BlockedRef {
-	repo := issueRepo(issue.Identifier)
+	linked := append([]connector.BlockedRef(nil), issue.BlockedBy...)
+	linked = append(linked, issue.ChildIssues...)
+	return mergeEpicChildRefs(issue, parseEpicBodyChildRefs(issue.Description, issueRepo(issue.Identifier)), linked)
+}
+
+func mergeEpicChildRefs(issue connector.Issue, groups ...[]connector.BlockedRef) []connector.BlockedRef {
 	children := []connector.BlockedRef{}
 	positions := map[string]int{}
 	selfID := strings.TrimSpace(issue.ID)
@@ -255,14 +290,13 @@ func epicChildRefs(issue connector.Issue) []connector.BlockedRef {
 		children = append(children, ref)
 	}
 
-	for _, ref := range parseEpicBodyChildRefs(issue.Description, repo) {
-		add(ref)
-	}
-	for _, ref := range issue.BlockedBy {
-		add(ref)
-	}
-	for _, ref := range issue.ChildIssues {
-		add(ref)
+	for _, group := range groups {
+		for _, ref := range group {
+			if strings.TrimSpace(ref.Identifier) == "" && strings.TrimSpace(ref.ID) == "" {
+				continue
+			}
+			add(ref)
+		}
 	}
 	return children
 }

--- a/internal/orchestrator/epic.go
+++ b/internal/orchestrator/epic.go
@@ -145,13 +145,6 @@ func (o *Orchestrator) finalizeCompletedEpic(ctx context.Context, issue connecto
 		return
 	}
 
-	body := completedEpicComment(len(children))
-	if err := o.connector.CreateComment(ctx, issue.ID, body); err != nil {
-		if o.logger != nil {
-			o.logger.Warn("comment completed epic failed", "issue_id", issue.ID, "error", err)
-		}
-		return
-	}
 	closer, ok := o.connector.(connector.IssueCloser)
 	if !ok {
 		if o.logger != nil {
@@ -159,8 +152,16 @@ func (o *Orchestrator) finalizeCompletedEpic(ctx context.Context, issue connecto
 		}
 		return
 	}
-	if err := closer.CloseIssue(ctx, issue.ID); err != nil && o.logger != nil {
-		o.logger.Warn("close completed epic failed", "issue_id", issue.ID, "error", err)
+	if err := closer.CloseIssue(ctx, issue.ID); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("close completed epic failed", "issue_id", issue.ID, "error", err)
+		}
+		return
+	}
+
+	body := completedEpicComment(len(children))
+	if err := o.connector.CreateComment(ctx, issue.ID, body); err != nil && o.logger != nil {
+		o.logger.Warn("comment completed epic failed", "issue_id", issue.ID, "error", err)
 	}
 }
 

--- a/internal/orchestrator/epic_test.go
+++ b/internal/orchestrator/epic_test.go
@@ -82,6 +82,7 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 		candidates   []connector.Issue
 		stateIssues  []connector.Issue
 		resolved     []connector.Issue
+		linked       map[string][]connector.BlockedRef
 		wantUpdates  []epicStateUpdate
 		wantClosed   []string
 		wantComments []string
@@ -109,6 +110,22 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 			},
 			stateIssues: []connector.Issue{
 				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
+			},
+		},
+		{
+			name: "paginated linked child keeps epic open",
+			candidates: []connector.Issue{
+				func() connector.Issue {
+					issue := epicTestIssue("epic-258", "Todo", false, "Epic: Release readiness", []string{"epic"}, "")
+					issue.ChildIssues = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#251", State: "Done"}}
+					return issue
+				}(),
+			},
+			linked: map[string][]connector.BlockedRef{
+				"epic-258": {
+					{Identifier: "digitaldrywood/detent#251", State: "Done"},
+					{Identifier: "digitaldrywood/detent#252", State: "In Progress"},
+				},
 			},
 		},
 		{
@@ -153,6 +170,7 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 				candidates:  tt.candidates,
 				stateIssues: tt.stateIssues,
 				resolved:    tt.resolved,
+				linked:      tt.linked,
 			}
 			orch := &Orchestrator{
 				cfg:       cfg,
@@ -180,6 +198,7 @@ type epicConnector struct {
 	candidates  []connector.Issue
 	stateIssues []connector.Issue
 	resolved    []connector.Issue
+	linked      map[string][]connector.BlockedRef
 	updates     []epicStateUpdate
 	closed      []string
 	comments    []string
@@ -233,6 +252,21 @@ func (c *epicConnector) FetchIssueStatesByIdentifiers(_ context.Context, identif
 		}
 	}
 	return issues, nil
+}
+
+func (c *epicConnector) FetchIssueChildren(_ context.Context, issueID string) ([]connector.BlockedRef, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.linked != nil {
+		return append([]connector.BlockedRef(nil), c.linked[issueID]...), nil
+	}
+	for _, issue := range append(append([]connector.Issue(nil), c.candidates...), c.stateIssues...) {
+		if issue.ID == issueID {
+			return append([]connector.BlockedRef(nil), issue.ChildIssues...), nil
+		}
+	}
+	return []connector.BlockedRef{}, nil
 }
 
 func (c *epicConnector) CreateComment(_ context.Context, _ string, body string) error {

--- a/internal/orchestrator/epic_test.go
+++ b/internal/orchestrator/epic_test.go
@@ -1,0 +1,299 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestEpicIssueDetection(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		want  bool
+	}{
+		{
+			name:  "epic label",
+			issue: epicTestIssue("issue-label", "Todo", false, "Release", []string{"enhancement", "Epic"}, ""),
+			want:  true,
+		},
+		{
+			name:  "epic title prefix",
+			issue: epicTestIssue("issue-title", "Todo", false, " epic: Release readiness ", nil, ""),
+			want:  true,
+		},
+		{
+			name:  "non epic",
+			issue: epicTestIssue("issue-feature", "Todo", false, "Release readiness", []string{"enhancement"}, ""),
+			want:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := epicIssue(tt.issue); got != tt.want {
+				t.Fatalf("epicIssue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEpicChildRefs(t *testing.T) {
+	t.Parallel()
+
+	issue := epicTestIssue("epic", "Todo", false, "Epic: Release", nil, strings.Join([]string{
+		"- [ ] #251",
+		"- [x] https://github.com/digitaldrywood/detent/issues/252",
+		"Depends on: #253 digitaldrywood/detent#253",
+	}, "\n"))
+	issue.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#254"}}
+	issue.ChildIssues = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#255"}}
+
+	got := epicChildRefs(issue)
+	want := []connector.BlockedRef{
+		{Identifier: "digitaldrywood/detent#251"},
+		{Identifier: "digitaldrywood/detent#252"},
+		{Identifier: "digitaldrywood/detent#253"},
+		{Identifier: "digitaldrywood/detent#254"},
+		{Identifier: "digitaldrywood/detent#255"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("epicChildRefs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestTickFinalizesCompletedEpics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 2, 16, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name         string
+		candidates   []connector.Issue
+		stateIssues  []connector.Issue
+		resolved     []connector.Issue
+		wantUpdates  []epicStateUpdate
+		wantClosed   []string
+		wantComments []string
+	}{
+		{
+			name: "completed active epic is commented closed and moved to done",
+			candidates: []connector.Issue{
+				epicTestIssue("epic-258", "Todo", false, "Epic: Release readiness", []string{"epic"}, "- [ ] #251\n- [ ] #252"),
+			},
+			stateIssues: []connector.Issue{
+				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
+			},
+			resolved: []connector.Issue{
+				epicTestIssue("child-252", "Open", true, "Child 252", nil, ""),
+			},
+			wantUpdates:  []epicStateUpdate{{issueID: "epic-258", state: "Done"}},
+			wantClosed:   []string{"epic-258"},
+			wantComments: []string{"Auto-closing completed epic: 2 child issues are Done."},
+		},
+		{
+			name: "partial epic is untouched",
+			candidates: []connector.Issue{
+				epicTestIssue("epic-258", "Todo", false, "Epic: Release readiness", []string{"epic"}, "- [ ] #251\n- [ ] #252"),
+				epicTestIssue("child-252", "In Progress", false, "Child 252", nil, ""),
+			},
+			stateIssues: []connector.Issue{
+				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
+			},
+		},
+		{
+			name: "already closed done epic is idempotent",
+			stateIssues: []connector.Issue{
+				func() connector.Issue {
+					issue := epicTestIssue("epic-258", "Done", true, "Epic: Release readiness", []string{"epic"}, "")
+					issue.ChildIssues = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#251"}}
+					return issue
+				}(),
+				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
+			},
+		},
+		{
+			name: "open done epic is closed without status update",
+			stateIssues: []connector.Issue{
+				func() connector.Issue {
+					issue := epicTestIssue("epic-258", "Done", false, "Epic: Release readiness", []string{"epic"}, "")
+					issue.ChildIssues = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#251"}}
+					return issue
+				}(),
+				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
+			},
+			wantClosed:   []string{"epic-258"},
+			wantComments: []string{"Auto-closing completed epic: 1 child issue is Done."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				PollInterval:        time.Minute,
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo", "In Progress"},
+				TerminalStates:      []string{"Done", "Cancelled", "Closed"},
+			})
+			state := newState(cfg)
+			state.Running["occupied"] = Running{Issue: connector.Issue{ID: "occupied", Identifier: "occupied", Title: "Occupied", State: "Todo"}}
+			tracker := &epicConnector{
+				candidates:  tt.candidates,
+				stateIssues: tt.stateIssues,
+				resolved:    tt.resolved,
+			}
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tracker,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			orch.tick(context.Background(), &state, now)
+
+			if got := tracker.stateUpdates(); !reflect.DeepEqual(got, tt.wantUpdates) {
+				t.Fatalf("state updates = %#v, want %#v", got, tt.wantUpdates)
+			}
+			if got := tracker.closedIssues(); !reflect.DeepEqual(got, tt.wantClosed) {
+				t.Fatalf("closed issues = %#v, want %#v", got, tt.wantClosed)
+			}
+			if got := tracker.commentBodies(); !reflect.DeepEqual(got, tt.wantComments) {
+				t.Fatalf("comments = %#v, want %#v", got, tt.wantComments)
+			}
+		})
+	}
+}
+
+type epicConnector struct {
+	mu          sync.Mutex
+	candidates  []connector.Issue
+	stateIssues []connector.Issue
+	resolved    []connector.Issue
+	updates     []epicStateUpdate
+	closed      []string
+	comments    []string
+}
+
+type epicStateUpdate struct {
+	issueID string
+	state   string
+}
+
+func (c *epicConnector) Name() string {
+	return "epic"
+}
+
+func (c *epicConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return cloneIssues(c.candidates), nil
+}
+
+func (c *epicConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	wanted := stateNameSet(states)
+	issues := make([]connector.Issue, 0, len(c.stateIssues))
+	for _, issue := range c.stateIssues {
+		if _, ok := wanted[normalizeState(issue.State)]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+	return issues, nil
+}
+
+func (c *epicConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return []connector.Issue{}, nil
+}
+
+func (c *epicConnector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	wanted := make(map[string]struct{}, len(identifiers))
+	for _, identifier := range identifiers {
+		wanted[strings.ToLower(strings.TrimSpace(identifier))] = struct{}{}
+	}
+	issues := make([]connector.Issue, 0, len(c.resolved))
+	for _, issue := range c.resolved {
+		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+	return issues, nil
+}
+
+func (c *epicConnector) CreateComment(_ context.Context, _ string, body string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.comments = append(c.comments, body)
+	return nil
+}
+
+func (c *epicConnector) CloseIssue(_ context.Context, issueID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.closed = append(c.closed, issueID)
+	return nil
+}
+
+func (c *epicConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.updates = append(c.updates, epicStateUpdate{issueID: issueID, state: state})
+	return nil
+}
+
+func (c *epicConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *epicConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c *epicConnector) stateUpdates() []epicStateUpdate {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]epicStateUpdate(nil), c.updates...)
+}
+
+func (c *epicConnector) closedIssues() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.closed...)
+}
+
+func (c *epicConnector) commentBodies() []string {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return append([]string(nil), c.comments...)
+}
+
+func epicTestIssue(id string, state string, closed bool, title string, labels []string, description string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/detent#" + strings.TrimPrefix(id, "child-")
+	if strings.HasPrefix(id, "epic-") {
+		issue.Identifier = "digitaldrywood/detent#" + strings.TrimPrefix(id, "epic-")
+	}
+	issue.Title = title
+	issue.State = state
+	issue.Closed = closed
+	issue.Description = description
+	issue.Labels = append([]string(nil), labels...)
+	issue.URL = "https://github.com/" + strings.ReplaceAll(issue.Identifier, "#", "/issues/")
+	return issue
+}

--- a/internal/orchestrator/epic_test.go
+++ b/internal/orchestrator/epic_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"reflect"
@@ -83,6 +84,7 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 		stateIssues  []connector.Issue
 		resolved     []connector.Issue
 		linked       map[string][]connector.BlockedRef
+		closeErr     error
 		wantUpdates  []epicStateUpdate
 		wantClosed   []string
 		wantComments []string
@@ -152,6 +154,18 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 			wantClosed:   []string{"epic-258"},
 			wantComments: []string{"Auto-closing completed epic: 1 child issue is Done."},
 		},
+		{
+			name: "open done epic close failure does not comment",
+			stateIssues: []connector.Issue{
+				func() connector.Issue {
+					issue := epicTestIssue("epic-258", "Done", false, "Epic: Release readiness", []string{"epic"}, "")
+					issue.ChildIssues = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#251"}}
+					return issue
+				}(),
+				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
+			},
+			closeErr: errors.New("close failed"),
+		},
 	}
 
 	for _, tt := range tests {
@@ -171,6 +185,7 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 				stateIssues: tt.stateIssues,
 				resolved:    tt.resolved,
 				linked:      tt.linked,
+				closeErr:    tt.closeErr,
 			}
 			orch := &Orchestrator{
 				cfg:       cfg,
@@ -199,6 +214,7 @@ type epicConnector struct {
 	stateIssues []connector.Issue
 	resolved    []connector.Issue
 	linked      map[string][]connector.BlockedRef
+	closeErr    error
 	updates     []epicStateUpdate
 	closed      []string
 	comments    []string
@@ -279,6 +295,9 @@ func (c *epicConnector) CreateComment(_ context.Context, _ string, body string) 
 func (c *epicConnector) CloseIssue(_ context.Context, issueID string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
+	if c.closeErr != nil {
+		return c.closeErr
+	}
 	c.closed = append(c.closed, issueID)
 	return nil
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -310,6 +310,11 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		statusIssues = cloneIssues(statusIssues)
 		state.Pipeline = issuesInStates(statusIssues, prPipelineFetchStates(o.cfg.TerminalStates))
 	}
+	observedIssues := cloneIssues(issues)
+	if statusErr == nil {
+		observedIssues = append(observedIssues, statusIssues...)
+	}
+	issues = filterCompletedEpicCandidates(issues, o.closeCompletedEpics(ctx, observedIssues))
 	sortIssuesForDispatch(issues, o.cfg.DispatchPriorityByState)
 	o.pruneBudgetRefusals(state, now)
 	o.trackBlockedCandidates(state, issues, now)
@@ -451,6 +456,7 @@ func mergeIssueTrackerFields(current, refreshed connector.Issue) connector.Issue
 	if refreshed.URL != "" {
 		merged.URL = refreshed.URL
 	}
+	merged.Closed = refreshed.Closed
 	if refreshed.PRNumber != nil {
 		merged.PRNumber = refreshed.PRNumber
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -185,6 +185,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		cloned.StageUpdatedAt = &stageUpdatedAt
 	}
 	cloned.BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
+	cloned.ChildIssues = append([]connector.BlockedRef(nil), issue.ChildIssues...)
 	cloned.Labels = cloneStringSlice(issue.Labels)
 	cloned.Assignees = cloneStringSlice(issue.Assignees)
 	cloned.Fields = cloneStringMap(issue.Fields)


### PR DESCRIPTION
## Summary

- Add completed-epic detection during orchestrator polling.
- Resolve epic children from checklist/dependency refs plus GitHub linked child issues.
- Comment, close, and move completed epics to Done while leaving partial and already-closed epics untouched.

Fixes #281

## Test Plan

- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/connector/github ./internal/connector/memory`
- [x] `make check`