### PR TITLE
feat(orchestrator): support PR-only merge items

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -45,6 +45,38 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
               repository { nameWithOwner }
               closedByPullRequestsReferences(first: 5) { nodes { number url } }
             }
+            ... on PullRequest {
+              id
+              number
+              title
+              body
+              state
+              url
+              createdAt
+              updatedAt
+              author { login }
+              assignees(first: 100) { nodes { id login } }
+              labels(first: 20) { nodes { name } }
+              repository { nameWithOwner }
+              headRefName
+              headRepository { nameWithOwner }
+              baseRepository { nameWithOwner }
+              maintainerCanModify
+              commits(last: 1) {
+                nodes {
+                  commit {
+                    statusCheckRollup { state }
+                  }
+                }
+              }
+              latestReviews(first: 20) {
+                nodes {
+                  body
+                  state
+                  author { login }
+                }
+              }
+            }
           }
           statusValue: fieldValueByName(name: "Status") {
             ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
@@ -152,6 +184,9 @@ query DetentGitHubPullRequests($owner: String!, $name: String!, $states: [PullRe
         url
         state
         headRefName
+        headRepository { nameWithOwner }
+        baseRepository { nameWithOwner }
+        maintainerCanModify
         commits(last: 1) {
           nodes {
             commit {
@@ -277,6 +312,38 @@ query DetentGitHubProjectItemForIssue($issueId: ID!, $projectItemsFirst: Int!, $
         }
       }
     }
+    ... on PullRequest {
+      projectItems(first: $projectItemsFirst, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          project { id }
+          statusValue: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+          }
+          priorityValue: fieldValueByName(name: "Priority") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+          fieldValues(first: 100) {
+            nodes {
+              __typename
+              ... on ProjectV2ItemFieldSingleSelectValue {
+                name
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldTextValue {
+                text
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+              ... on ProjectV2ItemFieldNumberValue {
+                number
+                field { ... on ProjectV2FieldCommon { name } }
+              }
+            }
+          }
+        }
+      }
+    }
   }
   rateLimit { limit used remaining cost resetAt }
 }`
@@ -325,11 +392,34 @@ type projectItemsConnection struct {
 
 type projectItemNode struct {
 	ID            string                            `json:"id"`
-	Content       *githubIssueNode                  `json:"content"`
+	Content       *projectItemContentNode           `json:"content"`
 	Project       *projectRef                       `json:"project"`
 	StatusValue   *singleSelectValue                `json:"statusValue"`
 	PriorityValue *singleSelectValue                `json:"priorityValue"`
 	FieldValues   nodeConnection[projectFieldValue] `json:"fieldValues"`
+}
+
+type projectItemContentNode struct {
+	TypeName                       string                            `json:"__typename"`
+	ID                             string                            `json:"id"`
+	Number                         int                               `json:"number"`
+	Title                          string                            `json:"title"`
+	Body                           string                            `json:"body"`
+	State                          string                            `json:"state"`
+	URL                            string                            `json:"url"`
+	CreatedAt                      *string                           `json:"createdAt"`
+	UpdatedAt                      *string                           `json:"updatedAt"`
+	Author                         *actor                            `json:"author"`
+	Assignees                      nodeConnection[assignee]          `json:"assignees"`
+	Labels                         nodeConnection[label]             `json:"labels"`
+	Repository                     repository                        `json:"repository"`
+	ClosedByPullRequestsReferences nodeConnection[pullRequest]       `json:"closedByPullRequestsReferences"`
+	HeadRefName                    string                            `json:"headRefName"`
+	HeadRepository                 *repository                       `json:"headRepository"`
+	BaseRepository                 *repository                       `json:"baseRepository"`
+	MaintainerCanModify            bool                              `json:"maintainerCanModify"`
+	Commits                        nodeConnection[pullRequestCommit] `json:"commits"`
+	LatestReviews                  nodeConnection[pullRequestReview] `json:"latestReviews"`
 }
 
 type githubIssueNode struct {
@@ -374,12 +464,15 @@ type pullRequest struct {
 }
 
 type pullRequestNode struct {
-	Number        int                               `json:"number"`
-	URL           string                            `json:"url"`
-	State         string                            `json:"state"`
-	HeadRefName   string                            `json:"headRefName"`
-	Commits       nodeConnection[pullRequestCommit] `json:"commits"`
-	LatestReviews nodeConnection[pullRequestReview] `json:"latestReviews"`
+	Number              int                               `json:"number"`
+	URL                 string                            `json:"url"`
+	State               string                            `json:"state"`
+	HeadRefName         string                            `json:"headRefName"`
+	HeadRepository      *repository                       `json:"headRepository"`
+	BaseRepository      *repository                       `json:"baseRepository"`
+	MaintainerCanModify bool                              `json:"maintainerCanModify"`
+	Commits             nodeConnection[pullRequestCommit] `json:"commits"`
+	LatestReviews       nodeConnection[pullRequestReview] `json:"latestReviews"`
 }
 
 type pullRequestCommit struct {
@@ -770,12 +863,15 @@ func attachMatchingPullRequests(
 			}
 
 			issues[candidate.Index].PullRequest = &connector.PullRequest{
-				Number:           pullRequest.Number,
-				URL:              strings.TrimSpace(pullRequest.URL),
-				BranchName:       branchName,
-				State:            strings.ToUpper(strings.TrimSpace(pullRequest.State)),
-				CIStatus:         normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
-				CodexReviewState: pullRequestCodexReviewState(pullRequest),
+				Number:              pullRequest.Number,
+				URL:                 strings.TrimSpace(pullRequest.URL),
+				BranchName:          branchName,
+				State:               strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+				CIStatus:            normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
+				CodexReviewState:    pullRequestCodexReviewState(pullRequest),
+				HeadRepository:      repositoryName(pullRequest.HeadRepository),
+				BaseRepository:      repositoryName(pullRequest.BaseRepository),
+				MaintainerCanModify: pullRequest.MaintainerCanModify,
 			}
 			if issues[candidate.Index].PRNumber == nil && pullRequest.Number > 0 {
 				number := pullRequest.Number
@@ -833,16 +929,155 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 }
 
 func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, bool) {
-	if item.Content == nil || item.Content.TypeName != "Issue" {
+	if item.Content == nil {
 		return connector.Issue{}, false
 	}
-	return c.buildIssue(
-		*item.Content,
-		singleSelectName(item.StatusValue),
-		singleSelectName(item.PriorityValue),
-		singleSelectUpdatedAt(item.StatusValue),
-		projectFieldValues(item.FieldValues),
-	), true
+	switch item.Content.TypeName {
+	case "Issue":
+		issue := c.buildIssue(
+			item.Content.githubIssueNode(),
+			singleSelectName(item.StatusValue),
+			singleSelectName(item.PriorityValue),
+			singleSelectUpdatedAt(item.StatusValue),
+			projectFieldValues(item.FieldValues),
+		)
+		c.cacheProjectItem(issue.ID, item)
+		return issue, true
+	case "PullRequest":
+		issue := c.buildPullRequestIssue(*item.Content,
+			singleSelectName(item.StatusValue),
+			singleSelectName(item.PriorityValue),
+			singleSelectUpdatedAt(item.StatusValue),
+			projectFieldValues(item.FieldValues),
+		)
+		c.cacheProjectItem(issue.ID, item)
+		return issue, true
+	default:
+		return connector.Issue{}, false
+	}
+}
+
+func (c *Connector) cacheProjectItem(contentID string, item projectItemNode) {
+	c.projectCache.SetItem(c.projectID, contentID, projectItemStatus{
+		ID:         item.ID,
+		StatusName: singleSelectName(item.StatusValue),
+	})
+}
+
+func (n projectItemContentNode) githubIssueNode() githubIssueNode {
+	return githubIssueNode{
+		TypeName:                       n.TypeName,
+		ID:                             n.ID,
+		Number:                         n.Number,
+		Title:                          n.Title,
+		Body:                           n.Body,
+		State:                          n.State,
+		URL:                            n.URL,
+		CreatedAt:                      n.CreatedAt,
+		UpdatedAt:                      n.UpdatedAt,
+		Author:                         n.Author,
+		Assignees:                      n.Assignees,
+		Labels:                         n.Labels,
+		Repository:                     n.Repository,
+		ClosedByPullRequestsReferences: n.ClosedByPullRequestsReferences,
+	}
+}
+
+func (c *Connector) buildPullRequestIssue(pr projectItemContentNode, statusName string, priorityName string, statusUpdatedAt *time.Time, fields map[string]string) connector.Issue {
+	repo := strings.TrimSpace(pr.Repository.NameWithOwner)
+	prNumber := pr.Number
+	return connector.Issue{
+		ID:          pr.ID,
+		Identifier:  buildPullRequestIdentifier(repo, pr.Number),
+		Title:       pr.Title,
+		Description: pr.Body,
+		Priority:    c.priorityRank(priorityName),
+		State:       c.githubToDetentState(statusName),
+		URL:         pr.URL,
+		PRNumber:    positiveIntPointer(prNumber),
+		PullRequest: &connector.PullRequest{
+			Number:              pr.Number,
+			URL:                 strings.TrimSpace(pr.URL),
+			BranchName:          strings.TrimSpace(pr.HeadRefName),
+			State:               strings.ToUpper(strings.TrimSpace(pr.State)),
+			CIStatus:            normalizePullRequestCIStatus(pullRequestCIState(pr.pullRequestNode())),
+			CodexReviewState:    pullRequestCodexReviewState(pr.pullRequestNode()),
+			HeadRepository:      repositoryName(pr.HeadRepository),
+			BaseRepository:      repositoryName(pr.BaseRepository),
+			MaintainerCanModify: pr.MaintainerCanModify,
+		},
+		AuthorID:         actorLogin(pr.Author),
+		AssigneeID:       firstAssigneeLogin(pr.Assignees),
+		Assignees:        allAssigneeLogins(pr.Assignees),
+		Labels:           labelNames(pr.Labels),
+		Fields:           cloneStringMap(fields),
+		AssignedToWorker: true,
+		CreatedAt:        parseGitHubTime(pr.CreatedAt),
+		UpdatedAt:        parseGitHubTime(pr.UpdatedAt),
+		StageUpdatedAt:   statusUpdatedAt,
+	}
+}
+
+func (n projectItemContentNode) pullRequestNode() pullRequestNode {
+	return pullRequestNode{
+		Number:              n.Number,
+		URL:                 n.URL,
+		State:               n.State,
+		HeadRefName:         n.HeadRefName,
+		HeadRepository:      n.HeadRepository,
+		BaseRepository:      n.BaseRepository,
+		MaintainerCanModify: n.MaintainerCanModify,
+		Commits:             n.Commits,
+		LatestReviews:       n.LatestReviews,
+	}
+}
+
+func repositoryName(repo *repository) string {
+	if repo == nil {
+		return ""
+	}
+	return strings.TrimSpace(repo.NameWithOwner)
+}
+
+func positiveIntPointer(value int) *int {
+	if value <= 0 {
+		return nil
+	}
+	return &value
+}
+
+func buildPullRequestIdentifier(repo string, number int) string {
+	repo = strings.TrimSpace(repo)
+	if repo == "" || number <= 0 {
+		return ""
+	}
+	return repo + "!" + strconv.Itoa(number)
+}
+
+func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorityName string, statusUpdatedAt *time.Time, fields map[string]string) connector.Issue {
+	repo := strings.TrimSpace(issue.Repository.NameWithOwner)
+	return connector.Issue{
+		ID:               issue.ID,
+		Identifier:       buildIdentifier(repo, issue.Number),
+		Title:            issue.Title,
+		Description:      issue.Body,
+		Priority:         c.priorityRank(priorityName),
+		State:            c.githubToDetentState(statusName),
+		URL:              issue.URL,
+		PRNumber:         firstPullRequestNumber(issue.ClosedByPullRequestsReferences),
+		AuthorID:         actorLogin(issue.Author),
+		AssigneeID:       firstAssigneeLogin(issue.Assignees),
+		Assignees:        allAssigneeLogins(issue.Assignees),
+		BlockedBy:        parseBlockedBy(issue.Body, repo),
+		BlockerReason:    parseBlockerReason(issue),
+		Labels:           labelNames(issue.Labels),
+		Fields:           cloneStringMap(fields),
+		AssignedToWorker: true,
+		CreatedAt:        parseGitHubTime(issue.CreatedAt),
+		UpdatedAt:        parseGitHubTime(issue.UpdatedAt),
+		StageUpdatedAt:   statusUpdatedAt,
+		ModelOverride:    parseModelOverride(issue.Body),
+	}
 }
 
 func resolveBlockedByProjectState(issues []connector.Issue) {
@@ -906,7 +1141,7 @@ func (c *Connector) projectFields(issueID string, items *projectItemsConnection)
 	}
 	for _, item := range items.Nodes {
 		if item.Project != nil && item.Project.ID == c.projectID {
-			c.projectCache.SetItemID(c.projectID, issueID, item.ID)
+			c.cacheProjectItem(issueID, item)
 			return singleSelectName(item.StatusValue), singleSelectName(item.PriorityValue), singleSelectUpdatedAt(item.StatusValue), projectFieldValues(item.FieldValues), true
 		}
 	}
@@ -940,32 +1175,6 @@ func (c *Connector) fetchProjectFieldsPage(ctx context.Context, issueID string, 
 		return "", "", nil, nil, false, ErrInvalidResponse
 	}
 	return c.fetchProjectFieldsPage(ctx, issueID, &cursor)
-}
-
-func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorityName string, statusUpdatedAt *time.Time, fields map[string]string) connector.Issue {
-	repo := strings.TrimSpace(issue.Repository.NameWithOwner)
-	return connector.Issue{
-		ID:               issue.ID,
-		Identifier:       buildIdentifier(repo, issue.Number),
-		Title:            issue.Title,
-		Description:      issue.Body,
-		Priority:         c.priorityRank(priorityName),
-		State:            c.githubToDetentState(statusName),
-		URL:              issue.URL,
-		PRNumber:         firstPullRequestNumber(issue.ClosedByPullRequestsReferences),
-		AuthorID:         actorLogin(issue.Author),
-		AssigneeID:       firstAssigneeLogin(issue.Assignees),
-		Assignees:        allAssigneeLogins(issue.Assignees),
-		BlockedBy:        parseBlockedBy(issue.Body, repo),
-		BlockerReason:    parseBlockerReason(issue),
-		Labels:           labelNames(issue.Labels),
-		Fields:           cloneStringMap(fields),
-		AssignedToWorker: true,
-		CreatedAt:        parseGitHubTime(issue.CreatedAt),
-		UpdatedAt:        parseGitHubTime(issue.UpdatedAt),
-		StageUpdatedAt:   statusUpdatedAt,
-		ModelOverride:    parseModelOverride(issue.Body),
-	}
 }
 
 func (c *Connector) resolveStatusOption(ctx context.Context, githubState string) (string, string, error) {
@@ -1194,6 +1403,9 @@ type projectItemStatus struct {
 }
 
 func (c *Connector) resolveProjectItem(ctx context.Context, issueID string) (projectItemStatus, error) {
+	if item, ok := c.projectCache.GetItem(c.projectID, issueID); ok {
+		return item, nil
+	}
 	return c.fetchProjectItemPage(ctx, issueID, nil)
 }
 
@@ -1216,11 +1428,12 @@ func (c *Connector) fetchProjectItemPage(ctx context.Context, issueID string, af
 
 	for _, item := range response.Node.ProjectItems.Nodes {
 		if item.Project != nil && item.Project.ID == c.projectID && strings.TrimSpace(item.ID) != "" {
-			c.projectCache.SetItemID(c.projectID, issueID, item.ID)
-			return projectItemStatus{
+			status := projectItemStatus{
 				ID:         item.ID,
 				StatusName: singleSelectName(item.StatusValue),
-			}, nil
+			}
+			c.projectCache.SetItem(c.projectID, issueID, status)
+			return status, nil
 		}
 	}
 	if !response.Node.ProjectItems.PageInfo.HasNextPage {

--- a/internal/connector/github/adapter_parity_test.go
+++ b/internal/connector/github/adapter_parity_test.go
@@ -27,9 +27,6 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
 		},
 		{
-			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_28","project":{"id":"PVT_throwaway"}}]}}}}`,
-		},
-		{
 			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_ready","name":"Ready"},{"id":"OPT_progress","name":"In Progress"},{"id":"OPT_review","name":"In Review"},{"id":"OPT_merging","name":"Merging"},{"id":"OPT_rework","name":"Rework"},{"id":"OPT_blocked","name":"Blocked"},{"id":"OPT_done","name":"Done"}]}}}}`,
 		},
 		{
@@ -91,8 +88,8 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 9 {
-		t.Fatalf("request count = %d, want 9", len(requests))
+	if len(requests) != 8 {
+		t.Fatalf("request count = %d, want 8", len(requests))
 	}
 
 	statusInput := graphQLInput(t, requests[1])
@@ -121,26 +118,26 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 		t.Fatalf("fetch query = %q, want ProjectV2", requests[3]["query"])
 	}
 
-	updateVariables := requestVariables(t, requests[7])
+	updateVariables := requestVariables(t, requests[6])
 	if updateVariables["projectId"] != "PVT_throwaway" ||
 		updateVariables["itemId"] != "PVTI_28" ||
 		updateVariables["fieldId"] != "PVTSSF_status" ||
 		updateVariables["optionId"] != "OPT_review" {
 		t.Fatalf("update variables = %#v, want Status option OPT_review on PVTI_28", updateVariables)
 	}
-	if !strings.Contains(requests[7]["query"].(string), "updateProjectV2ItemFieldValue") {
-		t.Fatalf("update query = %q, want updateProjectV2ItemFieldValue", requests[7]["query"])
+	if !strings.Contains(requests[6]["query"].(string), "updateProjectV2ItemFieldValue") {
+		t.Fatalf("update query = %q, want updateProjectV2ItemFieldValue", requests[6]["query"])
 	}
 
-	commentVariables := requestVariables(t, requests[8])
+	commentVariables := requestVariables(t, requests[7])
 	if commentVariables["subjectId"] != "I_kw28" {
 		t.Fatalf("comment subjectId = %v, want I_kw28", commentVariables["subjectId"])
 	}
 	if commentVariables["body"] != "## Codex Workpad\n\nReady for review." {
 		t.Fatalf("comment body = %q", commentVariables["body"])
 	}
-	if !strings.Contains(requests[8]["query"].(string), "addComment") {
-		t.Fatalf("comment query = %q, want addComment", requests[8]["query"])
+	if !strings.Contains(requests[7]["query"].(string), "addComment") {
+		t.Fatalf("comment query = %q, want addComment", requests[7]["query"])
 	}
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -294,6 +294,68 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssuesByStatesNormalizesPullRequestProjectItem(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_pr_268","content":{"__typename":"PullRequest","id":"PR_kw1","number":268,"title":"Contributor fix","body":"Ready to merge.","state":"OPEN","url":"https://github.com/digitaldrywood/detent/pull/268","createdAt":"2026-05-30T01:02:03Z","updatedAt":"2026-06-01T02:03:04Z","author":{"login":"external-contributor"},"repository":{"nameWithOwner":"digitaldrywood/detent"},"headRefName":"fix-from-fork","headRepository":{"nameWithOwner":"contributor/detent"},"baseRepository":{"nameWithOwner":"digitaldrywood/detent"},"maintainerCanModify":true,"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"SUCCESS"}}}]},"latestReviews":{"nodes":[{"body":"Looks good.","state":"APPROVED","author":{"login":"maintainer"}},{"body":"[P2] Clean.","state":"COMMENTED","author":{"login":"codex"}}]}},"statusValue":{"name":"Merging","updatedAt":"2026-06-01T12:30:00Z"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"Merging","field":{"name":"Status"}},{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"P1","field":{"name":"Priority"}}]}}]}}}}`,
+	}})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+		PriorityMap: map[string]*int{"P1": intPtr(2)},
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Merging"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	issue := got[0]
+	if issue.ID != "PR_kw1" || issue.Identifier != "digitaldrywood/detent!268" {
+		t.Fatalf("PR issue identity = %q/%q, want PR_kw1/digitaldrywood/detent!268", issue.ID, issue.Identifier)
+	}
+	if issue.Title != "Contributor fix" || issue.Description != "Ready to merge." || issue.URL != "https://github.com/digitaldrywood/detent/pull/268" {
+		t.Fatalf("PR issue metadata = %#v", issue)
+	}
+	if issue.Priority == nil || *issue.Priority != 2 {
+		t.Fatalf("Priority = %v, want 2", issue.Priority)
+	}
+	if issue.AuthorID != "external-contributor" {
+		t.Fatalf("AuthorID = %q, want external-contributor", issue.AuthorID)
+	}
+	if issue.PRNumber == nil || *issue.PRNumber != 268 {
+		t.Fatalf("PRNumber = %v, want 268", issue.PRNumber)
+	}
+	pr := issue.PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want normalized PR metadata")
+	}
+	if pr.Number != 268 || pr.State != "OPEN" || pr.BranchName != "fix-from-fork" || pr.CIStatus != "pass" || pr.CodexReviewState != "P2" {
+		t.Fatalf("PullRequest = %#v, want PR 268 pass/P2 fork metadata", pr)
+	}
+	if pr.HeadRepository != "contributor/detent" || pr.BaseRepository != "digitaldrywood/detent" || !pr.MaintainerCanModify {
+		t.Fatalf("PullRequest fork fields = %#v, want contributor fork with maintainer edit", pr)
+	}
+	if issue.StageUpdatedAt == nil || !issue.StageUpdatedAt.Equal(time.Date(2026, 6, 1, 12, 30, 0, 0, time.UTC)) {
+		t.Fatalf("StageUpdatedAt = %v, want project status update time", issue.StageUpdatedAt)
+	}
+
+	requests := server.requests()
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want one project item query", len(requests))
+	}
+	query := requests[0]["query"].(string)
+	for _, want := range []string{"... on PullRequest", "headRepository", "baseRepository", "maintainerCanModify"} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("project query missing %q:\n%s", want, query)
+		}
+	}
+}
+
 func TestConnectorFetchCandidateIssuesLimitsPullRequestPagination(t *testing.T) {
 	t.Parallel()
 
@@ -637,6 +699,87 @@ func TestConnectorUpdateIssueStateWritesStatusOptionID(t *testing.T) {
 	}
 	if variables["optionId"] == "Ready" {
 		t.Fatal("optionId used the option name, want option id")
+	}
+}
+
+func TestConnectorUpdateIssueStateUsesCachedProjectItemForPullRequest(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_pr_268","content":{"__typename":"PullRequest","id":"PR_kw1","number":268,"title":"Contributor fix","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/pull/268","createdAt":null,"updatedAt":null,"author":{"login":"external-contributor"},"repository":{"nameWithOwner":"digitaldrywood/detent"},"headRefName":"fix-from-fork","headRepository":{"nameWithOwner":"contributor/detent"},"baseRepository":{"nameWithOwner":"digitaldrywood/detent"},"maintainerCanModify":true,"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"SUCCESS"}}}]},"latestReviews":{"nodes":[]}},"statusValue":{"name":"Merging"},"priorityValue":null}]}}}}`},
+		{body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_done","name":"Done"}]}}}}`},
+		{body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_pr_268"}}}}`},
+	})
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Merging"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	if err := c.UpdateIssueState(context.Background(), got[0].ID, "Done"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want project query, status metadata, update", len(requests))
+	}
+	if strings.Contains(requests[1]["query"].(string), "projectItems") {
+		t.Fatalf("UpdateIssueState refetched project item instead of using cache:\n%s", requests[1]["query"])
+	}
+	variables := requests[2]["variables"].(map[string]any)
+	if variables["itemId"] != "PVTI_pr_268" {
+		t.Fatalf("itemId = %v, want cached PR project item", variables["itemId"])
+	}
+	if variables["optionId"] != "OPT_done" {
+		t.Fatalf("optionId = %v, want Done option id", variables["optionId"])
+	}
+}
+
+func TestConnectorUpdateIssueStateResolvesPullRequestProjectItemAfterCacheExpiry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_pr_268","content":{"__typename":"PullRequest","id":"PR_kw1","number":268,"title":"Contributor fix","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/pull/268","createdAt":null,"updatedAt":null,"author":{"login":"external-contributor"},"repository":{"nameWithOwner":"digitaldrywood/detent"},"headRefName":"fix-from-fork","headRepository":{"nameWithOwner":"contributor/detent"},"baseRepository":{"nameWithOwner":"digitaldrywood/detent"},"maintainerCanModify":true,"commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"SUCCESS"}}}]},"latestReviews":{"nodes":[]}},"statusValue":{"name":"Merging"},"priorityValue":null}]}}}}`},
+		{body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_pr_268","project":{"id":"PVT_1"},"statusValue":{"name":"Merging"}}]}}}}`},
+		{body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_done","name":"Done"}]}}}}`},
+		{body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_pr_268"}}}}`},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+		Now:         func() time.Time { return now },
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Merging"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	now = now.Add(githubCacheTTL)
+	if err := c.UpdateIssueState(context.Background(), got[0].ID, "Done"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want project query, PR item lookup, status metadata, update", len(requests))
+	}
+	if !strings.Contains(requests[1]["query"].(string), "... on PullRequest") {
+		t.Fatalf("project item lookup query missing PullRequest fragment:\n%s", requests[1]["query"])
+	}
+	lookupVariables := requests[1]["variables"].(map[string]any)
+	if lookupVariables["issueId"] != "PR_kw1" {
+		t.Fatalf("issueId = %v, want PR node id", lookupVariables["issueId"])
+	}
+	updateVariables := requests[3]["variables"].(map[string]any)
+	if updateVariables["itemId"] != "PVTI_pr_268" {
+		t.Fatalf("itemId = %v, want resolved PR project item", updateVariables["itemId"])
 	}
 }
 

--- a/internal/connector/github/projectcache.go
+++ b/internal/connector/github/projectcache.go
@@ -14,8 +14,9 @@ type projectCache struct {
 }
 
 type projectItemCacheEntry struct {
-	itemID   string
-	cachedAt time.Time
+	itemID     string
+	statusName string
+	cachedAt   time.Time
 }
 
 func newProjectCache(ttl time.Duration, now func() time.Time) *projectCache {
@@ -31,25 +32,30 @@ func newProjectCache(ttl time.Duration, now func() time.Time) *projectCache {
 }
 
 func (c *projectCache) GetItemID(projectID string, issueID string) (string, bool) {
+	status, ok := c.GetItem(projectID, issueID)
+	return status.ID, ok
+}
+
+func (c *projectCache) GetItem(projectID string, issueID string) (projectItemStatus, bool) {
 	projectID = strings.TrimSpace(projectID)
 	issueID = strings.TrimSpace(issueID)
 	if projectID == "" || issueID == "" {
-		return "", false
+		return projectItemStatus{}, false
 	}
 
 	c.mu.RLock()
 	projectEntries, ok := c.entries[projectID]
 	if !ok {
 		c.mu.RUnlock()
-		return "", false
+		return projectItemStatus{}, false
 	}
 	entry, ok := projectEntries[issueID]
 	c.mu.RUnlock()
 	if !ok {
-		return "", false
+		return projectItemStatus{}, false
 	}
 	if c.fresh(entry.cachedAt) {
-		return entry.itemID, true
+		return projectItemStatus{ID: entry.itemID, StatusName: entry.statusName}, true
 	}
 
 	c.mu.Lock()
@@ -65,16 +71,20 @@ func (c *projectCache) GetItemID(projectID string, issueID string) (string, bool
 	c.mu.Unlock()
 
 	if c.fresh(entry.cachedAt) {
-		return entry.itemID, true
+		return projectItemStatus{ID: entry.itemID, StatusName: entry.statusName}, true
 	}
 
-	return "", false
+	return projectItemStatus{}, false
 }
 
 func (c *projectCache) SetItemID(projectID string, issueID string, itemID string) {
+	c.SetItem(projectID, issueID, projectItemStatus{ID: itemID})
+}
+
+func (c *projectCache) SetItem(projectID string, issueID string, item projectItemStatus) {
 	projectID = strings.TrimSpace(projectID)
 	issueID = strings.TrimSpace(issueID)
-	itemID = strings.TrimSpace(itemID)
+	itemID := strings.TrimSpace(item.ID)
 	if projectID == "" || issueID == "" || itemID == "" {
 		return
 	}
@@ -86,8 +96,9 @@ func (c *projectCache) SetItemID(projectID string, issueID string, itemID string
 		c.entries[projectID] = projectEntries
 	}
 	projectEntries[issueID] = projectItemCacheEntry{
-		itemID:   itemID,
-		cachedAt: c.now(),
+		itemID:     itemID,
+		statusName: strings.TrimSpace(item.StatusName),
+		cachedAt:   c.now(),
 	}
 	c.mu.Unlock()
 }

--- a/internal/connector/github/projectcache_test.go
+++ b/internal/connector/github/projectcache_test.go
@@ -22,6 +22,22 @@ func TestProjectCacheReturnsFreshItemIDByProjectAndIssue(t *testing.T) {
 	}
 }
 
+func TestProjectCacheReturnsFreshItemStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.SetItem("PVT_1", "PR_1", projectItemStatus{ID: "PVTI_1", StatusName: "Merging"})
+
+	got, ok := cache.GetItem("PVT_1", "PR_1")
+	if !ok {
+		t.Fatal("GetItem() ok = false, want true")
+	}
+	if got.ID != "PVTI_1" || got.StatusName != "Merging" {
+		t.Fatalf("GetItem() = %#v, want item id PVTI_1 with Merging status", got)
+	}
+}
+
 func TestProjectCacheExpiresItemID(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -38,12 +38,15 @@ type BlockedRef struct {
 }
 
 type PullRequest struct {
-	Number           int    `json:"number,omitempty" yaml:"number,omitempty"`
-	URL              string `json:"url,omitempty" yaml:"url,omitempty"`
-	BranchName       string `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
-	State            string `json:"state,omitempty" yaml:"state,omitempty"`
-	CIStatus         string `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
-	CodexReviewState string `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
+	Number              int    `json:"number,omitempty" yaml:"number,omitempty"`
+	URL                 string `json:"url,omitempty" yaml:"url,omitempty"`
+	BranchName          string `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
+	State               string `json:"state,omitempty" yaml:"state,omitempty"`
+	CIStatus            string `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
+	CodexReviewState    string `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
+	HeadRepository      string `json:"head_repository,omitempty" yaml:"head_repository,omitempty"`
+	BaseRepository      string `json:"base_repository,omitempty" yaml:"base_repository,omitempty"`
+	MaintainerCanModify bool   `json:"maintainer_can_modify,omitempty" yaml:"maintainer_can_modify,omitempty"`
 }
 
 func NewIssue() Issue {

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -195,6 +195,8 @@ func issueAssigns(issue connector.Issue) map[string]any {
 		"state":              issue.State,
 		"branch_name":        issue.BranchName,
 		"url":                issue.URL,
+		"pr_number":          intPointerValue(issue.PRNumber),
+		"pull_request":       pullRequestAssigns(issue.PullRequest),
 		"author_id":          issue.AuthorID,
 		"assignee_id":        issue.AssigneeID,
 		"assignees":          issue.Assignees,
@@ -205,6 +207,23 @@ func issueAssigns(issue connector.Issue) map[string]any {
 		"created_at":         timePointerValue(issue.CreatedAt),
 		"updated_at":         timePointerValue(issue.UpdatedAt),
 		"model_override":     issue.ModelOverride,
+	}
+}
+
+func pullRequestAssigns(pullRequest *connector.PullRequest) map[string]any {
+	if pullRequest == nil {
+		return nil
+	}
+	return map[string]any{
+		"number":                pullRequest.Number,
+		"url":                   pullRequest.URL,
+		"branch_name":           pullRequest.BranchName,
+		"state":                 pullRequest.State,
+		"ci_status":             pullRequest.CIStatus,
+		"codex_review_state":    pullRequest.CodexReviewState,
+		"head_repository":       pullRequest.HeadRepository,
+		"base_repository":       pullRequest.BaseRepository,
+		"maintainer_can_modify": pullRequest.MaintainerCanModify,
 	}
 }
 

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -163,6 +163,44 @@ func TestBuildPromptAppendsGitHubClosingReferenceInstruction(t *testing.T) {
 	}
 }
 
+func TestBuildPromptRendersPullRequestAssigns(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 268
+	prompt, err := BuildPrompt(config.Workflow{
+		Prompt: "PR {{ issue.pr_number }} {{ issue.pull_request.url }} {{ issue.pull_request.branch_name }} {{ issue.pull_request.head_repository }} {{ issue.pull_request.base_repository }} maintainer={{ issue.pull_request.maintainer_can_modify }}",
+	}, connector.Issue{
+		ID:          "PR_kw1",
+		Identifier:  "digitaldrywood/detent!268",
+		Title:       "Contributor fix",
+		Description: "Ready to merge.",
+		URL:         "https://github.com/digitaldrywood/detent/pull/268",
+		PRNumber:    &prNumber,
+		PullRequest: &connector.PullRequest{
+			Number:              268,
+			URL:                 "https://github.com/digitaldrywood/detent/pull/268",
+			BranchName:          "fix-from-fork",
+			State:               "OPEN",
+			CIStatus:            "pass",
+			CodexReviewState:    "P2",
+			HeadRepository:      "contributor/detent",
+			BaseRepository:      "digitaldrywood/detent",
+			MaintainerCanModify: true,
+		},
+	}, PromptOptions{})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	want := "PR 268 https://github.com/digitaldrywood/detent/pull/268 fix-from-fork contributor/detent digitaldrywood/detent maintainer=true"
+	if !strings.HasPrefix(prompt, want) {
+		t.Fatalf("prompt = %q, want prefix %q", prompt, want)
+	}
+	if strings.Contains(prompt, "Fixes #268") {
+		t.Fatalf("PR-only identifier appended issue closing reference:\n%s", prompt)
+	}
+}
+
 func TestBuildPromptRejectsUnknownTemplateVariables(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Normalize GitHub ProjectV2 `PullRequest` items into Detent work items, including fork metadata and PR gate status.
- Allow PR-only items to update their board Status through cached or refetched ProjectV2 item ids without requiring a linked issue.
- Expose PR metadata to workflow prompts while avoiding issue-closing references for PR-only identifiers.

Fixes #289

## Test Plan

- [x] `go test ./internal/connector/...`
- [x] `go test ./internal/runner`
- [x] `make check`