### PR TITLE
fix(github): cap project item query fanout

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -14,14 +14,15 @@ import (
 )
 
 const (
-	projectItemsPageSize            = 50
-	projectItemsPerIssue            = 100
-	projectItemFieldValuesPageSize  = 20
-	linkedIssuePageSize             = 20
-	linkedIssueProjectItemsPageSize = 10
-	pullRequestsPageSize            = 100
-	pullRequestsPageLimit           = 3
-	defaultProjectItemStatusState   = "Backlog"
+	projectItemsPageSize                      = 50
+	projectItemsPerIssue                      = 100
+	projectItemFieldValuesPageSize            = 100
+	linkedIssuePageSize                       = 20
+	linkedIssueProjectItemsPageSize           = 10
+	linkedIssueProjectItemFieldValuesPageSize = 20
+	pullRequestsPageSize                      = 100
+	pullRequestsPageLimit                     = 3
+	defaultProjectItemStatusState             = "Backlog"
 )
 
 const projectItemsQuery = `
@@ -29,9 +30,10 @@ query DetentGitHubProjectItems(
   $projectId: ID!
   $first: Int!
   $after: String
-  $fieldValuesFirst: Int!
+  $projectItemFieldValuesFirst: Int!
   $linkedIssuesFirst: Int!
   $linkedProjectItemsFirst: Int!
+  $linkedProjectItemFieldValuesFirst: Int!
 ) {
   node(id: $projectId) {
     ... on ProjectV2 {
@@ -75,7 +77,7 @@ query DetentGitHubProjectItems(
                       priorityValue: fieldValueByName(name: "Priority") {
                         ... on ProjectV2ItemFieldSingleSelectValue { name }
                       }
-                      fieldValues(first: $fieldValuesFirst) {
+                      fieldValues(first: $linkedProjectItemFieldValuesFirst) {
                         nodes {
                           __typename
                           ... on ProjectV2ItemFieldSingleSelectValue {
@@ -116,7 +118,7 @@ query DetentGitHubProjectItems(
                       priorityValue: fieldValueByName(name: "Priority") {
                         ... on ProjectV2ItemFieldSingleSelectValue { name }
                       }
-                      fieldValues(first: $fieldValuesFirst) {
+                      fieldValues(first: $linkedProjectItemFieldValuesFirst) {
                         nodes {
                           __typename
                           ... on ProjectV2ItemFieldSingleSelectValue {
@@ -145,7 +147,7 @@ query DetentGitHubProjectItems(
           priorityValue: fieldValueByName(name: "Priority") {
             ... on ProjectV2ItemFieldSingleSelectValue { name }
           }
-          fieldValues(first: $fieldValuesFirst) {
+          fieldValues(first: $projectItemFieldValuesFirst) {
             nodes {
               __typename
               ... on ProjectV2ItemFieldSingleSelectValue {
@@ -1323,12 +1325,13 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 			} `json:"node"`
 		}
 		if err := c.client.GraphQL(ctx, projectItemsQuery, map[string]any{
-			"projectId":               c.projectID,
-			"first":                   projectItemsPageSize,
-			"after":                   after,
-			"fieldValuesFirst":        projectItemFieldValuesPageSize,
-			"linkedIssuesFirst":       linkedIssuePageSize,
-			"linkedProjectItemsFirst": linkedIssueProjectItemsPageSize,
+			"projectId":                         c.projectID,
+			"first":                             projectItemsPageSize,
+			"after":                             after,
+			"projectItemFieldValuesFirst":       projectItemFieldValuesPageSize,
+			"linkedIssuesFirst":                 linkedIssuePageSize,
+			"linkedProjectItemsFirst":           linkedIssueProjectItemsPageSize,
+			"linkedProjectItemFieldValuesFirst": linkedIssueProjectItemFieldValuesPageSize,
 		}, &response); err != nil {
 			return nil, fmt.Errorf("fetch github project items: %w", err)
 		}

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -14,15 +14,25 @@ import (
 )
 
 const (
-	projectItemsPageSize          = 50
-	projectItemsPerIssue          = 100
-	pullRequestsPageSize          = 100
-	pullRequestsPageLimit         = 3
-	defaultProjectItemStatusState = "Backlog"
+	projectItemsPageSize            = 50
+	projectItemsPerIssue            = 100
+	projectItemFieldValuesPageSize  = 20
+	linkedIssuePageSize             = 20
+	linkedIssueProjectItemsPageSize = 10
+	pullRequestsPageSize            = 100
+	pullRequestsPageLimit           = 3
+	defaultProjectItemStatusState   = "Backlog"
 )
 
 const projectItemsQuery = `
-query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
+query DetentGitHubProjectItems(
+  $projectId: ID!
+  $first: Int!
+  $after: String
+  $fieldValuesFirst: Int!
+  $linkedIssuesFirst: Int!
+  $linkedProjectItemsFirst: Int!
+) {
   node(id: $projectId) {
     ... on ProjectV2 {
       items(first: $first, after: $after) {
@@ -45,7 +55,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
               labels(first: 20) { nodes { name } }
               repository { nameWithOwner }
               closedByPullRequestsReferences(first: 5) { nodes { number url } }
-              subIssues(first: 100) {
+              subIssues(first: $linkedIssuesFirst) {
                 pageInfo { hasNextPage endCursor }
                 nodes {
                   id
@@ -54,7 +64,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
                   state
                   url
                   repository { nameWithOwner }
-                  projectItems(first: 100) {
+                  projectItems(first: $linkedProjectItemsFirst) {
                     pageInfo { hasNextPage endCursor }
                     nodes {
                       id
@@ -65,7 +75,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
                       priorityValue: fieldValueByName(name: "Priority") {
                         ... on ProjectV2ItemFieldSingleSelectValue { name }
                       }
-                      fieldValues(first: 100) {
+                      fieldValues(first: $fieldValuesFirst) {
                         nodes {
                           __typename
                           ... on ProjectV2ItemFieldSingleSelectValue {
@@ -86,7 +96,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
                   }
                 }
               }
-              trackedIssues(first: 100) {
+              trackedIssues(first: $linkedIssuesFirst) {
                 pageInfo { hasNextPage endCursor }
                 nodes {
                   id
@@ -95,7 +105,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
                   state
                   url
                   repository { nameWithOwner }
-                  projectItems(first: 100) {
+                  projectItems(first: $linkedProjectItemsFirst) {
                     pageInfo { hasNextPage endCursor }
                     nodes {
                       id
@@ -106,7 +116,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
                       priorityValue: fieldValueByName(name: "Priority") {
                         ... on ProjectV2ItemFieldSingleSelectValue { name }
                       }
-                      fieldValues(first: 100) {
+                      fieldValues(first: $fieldValuesFirst) {
                         nodes {
                           __typename
                           ... on ProjectV2ItemFieldSingleSelectValue {
@@ -135,7 +145,7 @@ query DetentGitHubProjectItems($projectId: ID!, $first: Int!, $after: String) {
           priorityValue: fieldValueByName(name: "Priority") {
             ... on ProjectV2ItemFieldSingleSelectValue { name }
           }
-          fieldValues(first: 100) {
+          fieldValues(first: $fieldValuesFirst) {
             nodes {
               __typename
               ... on ProjectV2ItemFieldSingleSelectValue {
@@ -1313,9 +1323,12 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 			} `json:"node"`
 		}
 		if err := c.client.GraphQL(ctx, projectItemsQuery, map[string]any{
-			"projectId": c.projectID,
-			"first":     projectItemsPageSize,
-			"after":     after,
+			"projectId":               c.projectID,
+			"first":                   projectItemsPageSize,
+			"after":                   after,
+			"fieldValuesFirst":        projectItemFieldValuesPageSize,
+			"linkedIssuesFirst":       linkedIssuePageSize,
+			"linkedProjectItemsFirst": linkedIssueProjectItemsPageSize,
 		}, &response); err != nil {
 			return nil, fmt.Errorf("fetch github project items: %w", err)
 		}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -77,12 +77,21 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	if variables["first"] != float64(50) {
 		t.Fatalf("first = %v, want 50", variables["first"])
 	}
+	if variables["fieldValuesFirst"] != float64(projectItemFieldValuesPageSize) {
+		t.Fatalf("fieldValuesFirst = %v, want %d", variables["fieldValuesFirst"], projectItemFieldValuesPageSize)
+	}
+	if variables["linkedIssuesFirst"] != float64(linkedIssuePageSize) {
+		t.Fatalf("linkedIssuesFirst = %v, want %d", variables["linkedIssuesFirst"], linkedIssuePageSize)
+	}
+	if variables["linkedProjectItemsFirst"] != float64(linkedIssueProjectItemsPageSize) {
+		t.Fatalf("linkedProjectItemsFirst = %v, want %d", variables["linkedProjectItemsFirst"], linkedIssueProjectItemsPageSize)
+	}
 	prVariables := requests[1]["variables"].(map[string]any)
 	if prVariables["owner"] != "digitaldrywood" || prVariables["name"] != "detent" {
 		t.Fatalf("pull request repo variables = %#v, want digitaldrywood/detent", prVariables)
 	}
 	query := requests[0]["query"].(string)
-	for _, want := range []string{"author { login }", "assignees(first: 100)", "fieldValues(first: 100)"} {
+	for _, want := range []string{"author { login }", "assignees(first: 100)", "fieldValues(first: $fieldValuesFirst)"} {
 		if !strings.Contains(query, want) {
 			t.Fatalf("project query missing %q:\n%s", want, query)
 		}
@@ -293,7 +302,7 @@ func TestConnectorFetchCandidateIssuesCapturesLinkedChildIssues(t *testing.T) {
 	}
 
 	query := server.requests()[0]["query"].(string)
-	for _, want := range []string{"subIssues(first: 100)", "trackedIssues(first: 100)"} {
+	for _, want := range []string{"subIssues(first: $linkedIssuesFirst)", "trackedIssues(first: $linkedIssuesFirst)"} {
 		if !strings.Contains(query, want) {
 			t.Fatalf("project query missing %q:\n%s", want, query)
 		}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -77,8 +77,8 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	if variables["first"] != float64(50) {
 		t.Fatalf("first = %v, want 50", variables["first"])
 	}
-	if variables["fieldValuesFirst"] != float64(projectItemFieldValuesPageSize) {
-		t.Fatalf("fieldValuesFirst = %v, want %d", variables["fieldValuesFirst"], projectItemFieldValuesPageSize)
+	if variables["projectItemFieldValuesFirst"] != float64(projectItemFieldValuesPageSize) {
+		t.Fatalf("projectItemFieldValuesFirst = %v, want %d", variables["projectItemFieldValuesFirst"], projectItemFieldValuesPageSize)
 	}
 	if variables["linkedIssuesFirst"] != float64(linkedIssuePageSize) {
 		t.Fatalf("linkedIssuesFirst = %v, want %d", variables["linkedIssuesFirst"], linkedIssuePageSize)
@@ -86,12 +86,15 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	if variables["linkedProjectItemsFirst"] != float64(linkedIssueProjectItemsPageSize) {
 		t.Fatalf("linkedProjectItemsFirst = %v, want %d", variables["linkedProjectItemsFirst"], linkedIssueProjectItemsPageSize)
 	}
+	if variables["linkedProjectItemFieldValuesFirst"] != float64(linkedIssueProjectItemFieldValuesPageSize) {
+		t.Fatalf("linkedProjectItemFieldValuesFirst = %v, want %d", variables["linkedProjectItemFieldValuesFirst"], linkedIssueProjectItemFieldValuesPageSize)
+	}
 	prVariables := requests[1]["variables"].(map[string]any)
 	if prVariables["owner"] != "digitaldrywood" || prVariables["name"] != "detent" {
 		t.Fatalf("pull request repo variables = %#v, want digitaldrywood/detent", prVariables)
 	}
 	query := requests[0]["query"].(string)
-	for _, want := range []string{"author { login }", "assignees(first: 100)", "fieldValues(first: $fieldValuesFirst)"} {
+	for _, want := range []string{"author { login }", "assignees(first: 100)", "fieldValues(first: $projectItemFieldValuesFirst)"} {
 		if !strings.Contains(query, want) {
 			t.Fatalf("project query missing %q:\n%s", want, query)
 		}
@@ -302,7 +305,11 @@ func TestConnectorFetchCandidateIssuesCapturesLinkedChildIssues(t *testing.T) {
 	}
 
 	query := server.requests()[0]["query"].(string)
-	for _, want := range []string{"subIssues(first: $linkedIssuesFirst)", "trackedIssues(first: $linkedIssuesFirst)"} {
+	for _, want := range []string{
+		"subIssues(first: $linkedIssuesFirst)",
+		"trackedIssues(first: $linkedIssuesFirst)",
+		"fieldValues(first: $linkedProjectItemFieldValuesFirst)",
+	} {
 		if !strings.Contains(query, want) {
 			t.Fatalf("project query missing %q:\n%s", want, query)
 		}


### PR DESCRIPTION
## Summary

- Parameterize nested GitHub ProjectV2 connection limits in the project item scan query.
- Cap linked issue, linked project item, and project field-value fanout so large boards stay under GitHub GraphQL possible-node limits.
- Update connector tests to assert the new query variables and capped nested connections.

Fixes N/A

Note: issue 295 remains separate. That issue is about blank-status defaulting doing synchronous writes during the scan path; this PR only fixes the GitHub GraphQL query fanout failure.

## Test Plan

- [x] `go test -count=1 ./internal/connector/github`
- [x] `golangci-lint run --timeout=5m ./internal/connector/github`
- [x] `golangci-lint run --timeout=5m --new-from-rev=origin/main`
- [x] `go test ./...`
- [x] `go vet ./...`

Additional note: full `golangci-lint run --timeout=5m` still reports existing baseline findings outside this PR diff.