### PR TITLE
fix(github): default blank project statuses asynchronously

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -19,6 +20,8 @@ const (
 	pullRequestsPageSize          = 100
 	pullRequestsPageLimit         = 3
 	defaultProjectItemStatusState = "Backlog"
+	defaultProjectItemStatusJobs  = 4
+	defaultProjectItemStatusTTL   = 2 * time.Minute
 )
 
 const projectItemsQuery = `
@@ -1305,6 +1308,7 @@ func attachMatchingPullRequests(
 func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
 	var after *string
 	allIssues := []connector.Issue{}
+	statusDefaults := []projectItemStatusDefault{}
 
 	for {
 		var response struct {
@@ -1324,17 +1328,21 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 		}
 
 		for _, item := range response.Node.Items.Nodes {
-			issue, ok, err := c.normalizeProjectItem(ctx, item)
+			issue, statusDefault, ok, err := c.normalizeProjectItem(item)
 			if err != nil {
 				return nil, err
 			}
 			if !ok {
 				continue
 			}
+			if statusDefault.ItemID != "" {
+				statusDefaults = append(statusDefaults, statusDefault)
+			}
 			allIssues = append(allIssues, issue)
 		}
 
 		if !response.Node.Items.PageInfo.HasNextPage {
+			c.defaultProjectItemStatusesAsync(ctx, statusDefaults)
 			resolveBlockedByProjectState(allIssues)
 			issues := make([]connector.Issue, 0, len(allIssues))
 			for _, issue := range allIssues {
@@ -1352,13 +1360,13 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 	}
 }
 
-func (c *Connector) normalizeProjectItem(ctx context.Context, item projectItemNode) (connector.Issue, bool, error) {
+func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, projectItemStatusDefault, bool, error) {
 	if item.Content == nil || item.Content.TypeName != "Issue" {
-		return connector.Issue{}, false, nil
+		return connector.Issue{}, projectItemStatusDefault{}, false, nil
 	}
-	statusName, statusUpdatedAt, err := c.projectItemStatusOrDefault(ctx, item)
+	statusName, statusUpdatedAt, statusDefault, err := c.projectItemStatusOrDefault(item)
 	if err != nil {
-		return connector.Issue{}, false, err
+		return connector.Issue{}, projectItemStatusDefault{}, false, err
 	}
 	return c.buildIssue(
 		*item.Content,
@@ -1366,28 +1374,166 @@ func (c *Connector) normalizeProjectItem(ctx context.Context, item projectItemNo
 		singleSelectName(item.PriorityValue),
 		statusUpdatedAt,
 		projectFieldValues(item.FieldValues),
-	), true, nil
+	), statusDefault, true, nil
 }
 
-func (c *Connector) projectItemStatusOrDefault(ctx context.Context, item projectItemNode) (string, *time.Time, error) {
+type projectItemStatusDefault struct {
+	ItemID      string
+	GitHubState string
+}
+
+func (c *Connector) projectItemStatusOrDefault(item projectItemNode) (string, *time.Time, projectItemStatusDefault, error) {
 	statusName := singleSelectName(item.StatusValue)
 	if statusName != "" {
-		return statusName, singleSelectUpdatedAt(item.StatusValue), nil
+		return statusName, singleSelectUpdatedAt(item.StatusValue), projectItemStatusDefault{}, nil
 	}
 
 	itemID := strings.TrimSpace(item.ID)
 	if itemID == "" {
-		return "", nil, ErrInvalidResponse
+		return "", nil, projectItemStatusDefault{}, ErrInvalidResponse
 	}
 
 	statusName = c.detentToGitHubState(defaultProjectItemStatusState)
 	if statusName == "" {
-		return "", nil, nil
+		return "", nil, projectItemStatusDefault{}, nil
 	}
-	if err := c.setProjectItemStatus(ctx, itemID, statusName); err != nil {
-		return "", nil, fmt.Errorf("default github status: %w", err)
+	return statusName, nil, projectItemStatusDefault{ItemID: itemID, GitHubState: statusName}, nil
+}
+
+func (c *Connector) defaultProjectItemStatusesAsync(ctx context.Context, statusDefaults []projectItemStatusDefault) {
+	statusDefaults = c.claimProjectItemStatusDefaults(statusDefaults)
+	if len(statusDefaults) == 0 {
+		return
 	}
-	return statusName, nil, nil
+
+	go func() {
+		defer c.releaseProjectItemStatusDefaults(statusDefaults)
+
+		ctx, cancel := context.WithTimeout(context.WithoutCancel(ctx), defaultProjectItemStatusTTL)
+		defer cancel()
+
+		if err := c.defaultProjectItemStatuses(ctx, statusDefaults); err != nil {
+			c.client.logger.WarnContext(ctx, "default github project item statuses failed", "error", err)
+		}
+	}()
+}
+
+func (c *Connector) defaultProjectItemStatuses(ctx context.Context, statusDefaults []projectItemStatusDefault) error {
+	statusDefaults = uniqueProjectItemStatusDefaults(statusDefaults)
+	if len(statusDefaults) == 0 {
+		return nil
+	}
+
+	for _, githubState := range uniqueProjectItemDefaultStates(statusDefaults) {
+		if _, _, err := c.resolveStatusOption(ctx, githubState); err != nil {
+			return fmt.Errorf("default github status option: %w", err)
+		}
+	}
+
+	errs := make(chan error, len(statusDefaults))
+	sem := make(chan struct{}, defaultProjectItemStatusJobs)
+	var wg sync.WaitGroup
+	for _, statusDefault := range statusDefaults {
+		statusDefault := statusDefault
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+
+			select {
+			case sem <- struct{}{}:
+				defer func() { <-sem }()
+			case <-ctx.Done():
+				errs <- ctx.Err()
+				return
+			}
+
+			if err := c.setProjectItemStatus(ctx, statusDefault.ItemID, statusDefault.GitHubState); err != nil {
+				errs <- fmt.Errorf("default github status %s: %w", statusDefault.ItemID, err)
+			}
+		}()
+	}
+	wg.Wait()
+	close(errs)
+
+	var joined error
+	for err := range errs {
+		joined = errors.Join(joined, err)
+	}
+	return joined
+}
+
+func (c *Connector) claimProjectItemStatusDefaults(statusDefaults []projectItemStatusDefault) []projectItemStatusDefault {
+	statusDefaults = uniqueProjectItemStatusDefaults(statusDefaults)
+	if len(statusDefaults) == 0 {
+		return nil
+	}
+
+	c.defaultStatusMu.Lock()
+	defer c.defaultStatusMu.Unlock()
+
+	claimed := make([]projectItemStatusDefault, 0, len(statusDefaults))
+	for _, statusDefault := range statusDefaults {
+		key := statusDefault.key()
+		if _, ok := c.defaultStatusInFlight[key]; ok {
+			continue
+		}
+		c.defaultStatusInFlight[key] = struct{}{}
+		claimed = append(claimed, statusDefault)
+	}
+	return claimed
+}
+
+func (c *Connector) releaseProjectItemStatusDefaults(statusDefaults []projectItemStatusDefault) {
+	if len(statusDefaults) == 0 {
+		return
+	}
+
+	c.defaultStatusMu.Lock()
+	defer c.defaultStatusMu.Unlock()
+
+	for _, statusDefault := range statusDefaults {
+		delete(c.defaultStatusInFlight, statusDefault.key())
+	}
+}
+
+func uniqueProjectItemStatusDefaults(statusDefaults []projectItemStatusDefault) []projectItemStatusDefault {
+	seen := make(map[string]struct{}, len(statusDefaults))
+	out := make([]projectItemStatusDefault, 0, len(statusDefaults))
+	for _, statusDefault := range statusDefaults {
+		itemID := strings.TrimSpace(statusDefault.ItemID)
+		githubState := strings.TrimSpace(statusDefault.GitHubState)
+		if itemID == "" || githubState == "" {
+			continue
+		}
+		statusDefault = projectItemStatusDefault{ItemID: itemID, GitHubState: githubState}
+		if _, ok := seen[statusDefault.key()]; ok {
+			continue
+		}
+		seen[statusDefault.key()] = struct{}{}
+		out = append(out, statusDefault)
+	}
+	return out
+}
+
+func (d projectItemStatusDefault) key() string {
+	return d.ItemID + "\x00" + d.GitHubState
+}
+
+func uniqueProjectItemDefaultStates(statusDefaults []projectItemStatusDefault) []string {
+	seen := make(map[string]struct{}, len(statusDefaults))
+	states := make([]string, 0, len(statusDefaults))
+	for _, statusDefault := range statusDefaults {
+		githubState := strings.TrimSpace(statusDefault.GitHubState)
+		if githubState == "" {
+			continue
+		}
+		if _, ok := seen[githubState]; ok {
+			continue
+		}
+		seen[githubState] = struct{}{}
+		states = append(states, githubState)
+	}
+	return states
 }
 
 func resolveBlockedByProjectState(issues []connector.Issue) {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -185,27 +185,75 @@ func TestConnectorFetchCandidateIssuesRequestsRateLimitSnapshot(t *testing.T) {
 	}
 }
 
-func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesToBacklog(t *testing.T) {
+func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesWithoutBlockingScan(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{
-			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null},{"id":"PVTI_todo","content":{"__typename":"Issue","id":"I_todo","number":31,"title":"Ready status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/31","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
-		},
-		{
-			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_todo","name":"Todo"}]}}}}`,
-		},
-		{
-			body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_blank"}}}}`,
-		},
-	})
-	c := newGitHubTestConnector(t, server, Config{
+	var (
+		mu                   sync.Mutex
+		requests             []map[string]any
+		defaultWriteStarted  = make(chan struct{})
+		defaultWriteReleased = make(chan struct{})
+		defaultWriteFinished = make(chan struct{})
+		startedOnce          sync.Once
+		finishedOnce         sync.Once
+	)
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			t.Fatalf("Decode() error = %v", err)
+		}
+		mu.Lock()
+		requests = append(requests, payload)
+		mu.Unlock()
+
+		query, ok := payload["query"].(string)
+		if !ok {
+			t.Fatalf("query = %T, want string", payload["query"])
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case strings.Contains(query, "DetentGitHubProjectItems"):
+			_, _ = w.Write([]byte(`{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null},{"id":"PVTI_todo","content":{"__typename":"Issue","id":"I_todo","number":31,"title":"Ready status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/31","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`))
+		case strings.Contains(query, "DetentGitHubStatusField"):
+			startedOnce.Do(func() { close(defaultWriteStarted) })
+			select {
+			case <-defaultWriteReleased:
+			case <-r.Context().Done():
+				return
+			}
+			_, _ = w.Write([]byte(`{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_todo","name":"Todo"}]}}}}`))
+		case strings.Contains(query, "DetentGitHubUpdateSingleSelectField"):
+			_, _ = w.Write([]byte(`{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_blank"}}}}`))
+			finishedOnce.Do(func() { close(defaultWriteFinished) })
+		default:
+			t.Fatalf("unexpected GraphQL query: %s", query)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	cfg := Config{
+		Endpoint:       server.URL,
+		APIKey:         "token",
+		HTTPClient:     server.Client(),
 		ProjectSlug:    "PVT_1",
 		ActiveStates:   []string{"Todo"},
 		ObservedStates: []string{"Backlog"},
-	})
+		GHToken: func(context.Context, string) (string, error) {
+			t.Fatal("gh token fallback should not run")
+			return "", nil
+		},
+	}
+	c, err := NewConnector(cfg)
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
 
-	got, err := c.FetchIssuesByStates(context.Background(), []string{"Backlog"})
+	ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+	defer cancel()
+	got, err := c.FetchIssuesByStates(ctx, []string{"Backlog"})
+	close(defaultWriteReleased)
 	if err != nil {
 		t.Fatalf("FetchIssuesByStates() error = %v", err)
 	}
@@ -216,11 +264,35 @@ func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesToBacklog(t *te
 		t.Fatalf("defaulted issue = %#v, want blank issue in Backlog", got[0])
 	}
 
-	requests := server.requests()
-	if len(requests) != 3 {
-		t.Fatalf("request count = %d, want 3", len(requests))
+	select {
+	case <-defaultWriteStarted:
+	case <-time.After(time.Second):
+		t.Fatal("blank status default write was not started")
 	}
-	updateVariables := requestVariables(t, requests[2])
+
+	select {
+	case <-defaultWriteFinished:
+	case <-time.After(time.Second):
+		t.Fatal("blank status default write did not finish")
+	}
+
+	mu.Lock()
+	seen := make([]map[string]any, len(requests))
+	copy(seen, requests)
+	mu.Unlock()
+
+	var updateRequest map[string]any
+	for _, request := range seen {
+		query, _ := request["query"].(string)
+		if strings.Contains(query, "updateProjectV2ItemFieldValue") {
+			updateRequest = request
+			break
+		}
+	}
+	if updateRequest == nil {
+		t.Fatalf("requests = %#v, want updateProjectV2ItemFieldValue request", seen)
+	}
+	updateVariables := requestVariables(t, updateRequest)
 	if updateVariables["projectId"] != "PVT_1" ||
 		updateVariables["itemId"] != "PVTI_blank" ||
 		updateVariables["fieldId"] != "PVTSSF_status" ||

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -53,6 +54,9 @@ type Connector struct {
 	statusCache    *statusCache
 	projectCache   *projectCache
 	instanceLogin  string
+
+	defaultStatusMu       sync.Mutex
+	defaultStatusInFlight map[string]struct{}
 }
 
 func NewConnector(cfg Config) (*Connector, error) {
@@ -97,6 +101,8 @@ func NewConnector(cfg Config) (*Connector, error) {
 		priorityMap:    clonePriorityMapWithDefault(cfg.PriorityMap),
 		statusCache:    newStatusCache(githubCacheTTL, cfg.Now),
 		projectCache:   newProjectCache(githubCacheTTL, cfg.Now),
+
+		defaultStatusInFlight: map[string]struct{}{},
 	}, nil
 }
 


### PR DESCRIPTION
## Summary
- treat blank GitHub ProjectV2 statuses as Backlog during project item scans without blocking on writes
- move blank-status default mutations into a bounded background worker with in-flight dedupe
- add a regression test that blocks the default write path and verifies scanning still returns promptly

Fixes #295

## Test Plan
- go test -run TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesWithoutBlockingScan ./internal/connector/github
- go test ./internal/connector/github
- go build ./...
- go test ./...
- go vet ./...
- go run github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6 run --timeout=5m
- golangci-lint run --timeout=5m --new-from-rev=origin/main
- go test -race ./internal/connector/github