### PR TITLE
fix(github): default blank statuses async

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -8,6 +8,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -23,6 +24,8 @@ const (
 	pullRequestsPageSize                      = 100
 	pullRequestsPageLimit                     = 3
 	defaultProjectItemStatusState             = "Backlog"
+	defaultProjectItemStatusWriteParallelism  = 4
+	defaultProjectItemStatusWriteTimeout      = 2 * time.Minute
 )
 
 const projectItemsQuery = `
@@ -1317,6 +1320,7 @@ func attachMatchingPullRequests(
 func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
 	var after *string
 	allIssues := []connector.Issue{}
+	blankStatusItemIDs := []string{}
 
 	for {
 		var response struct {
@@ -1340,17 +1344,21 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 		}
 
 		for _, item := range response.Node.Items.Nodes {
-			issue, ok, err := c.normalizeProjectItem(ctx, item)
+			issue, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
 			if err != nil {
 				return nil, err
 			}
 			if !ok {
 				continue
 			}
+			if blankStatusItemID != "" {
+				blankStatusItemIDs = append(blankStatusItemIDs, blankStatusItemID)
+			}
 			allIssues = append(allIssues, issue)
 		}
 
 		if !response.Node.Items.PageInfo.HasNextPage {
+			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
 			resolveBlockedByProjectState(allIssues)
 			issues := make([]connector.Issue, 0, len(allIssues))
 			for _, issue := range allIssues {
@@ -1368,13 +1376,13 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 	}
 }
 
-func (c *Connector) normalizeProjectItem(ctx context.Context, item projectItemNode) (connector.Issue, bool, error) {
+func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, bool, string, error) {
 	if item.Content == nil || item.Content.TypeName != "Issue" {
-		return connector.Issue{}, false, nil
+		return connector.Issue{}, false, "", nil
 	}
-	statusName, statusUpdatedAt, err := c.projectItemStatusOrDefault(ctx, item)
+	statusName, statusUpdatedAt, blankStatusItemID, err := c.projectItemStatusOrDefault(item)
 	if err != nil {
-		return connector.Issue{}, false, err
+		return connector.Issue{}, false, "", err
 	}
 	return c.buildIssue(
 		*item.Content,
@@ -1382,28 +1390,99 @@ func (c *Connector) normalizeProjectItem(ctx context.Context, item projectItemNo
 		singleSelectName(item.PriorityValue),
 		statusUpdatedAt,
 		projectFieldValues(item.FieldValues),
-	), true, nil
+	), true, blankStatusItemID, nil
 }
 
-func (c *Connector) projectItemStatusOrDefault(ctx context.Context, item projectItemNode) (string, *time.Time, error) {
+func (c *Connector) projectItemStatusOrDefault(item projectItemNode) (string, *time.Time, string, error) {
 	statusName := singleSelectName(item.StatusValue)
 	if statusName != "" {
-		return statusName, singleSelectUpdatedAt(item.StatusValue), nil
+		return statusName, singleSelectUpdatedAt(item.StatusValue), "", nil
 	}
 
 	itemID := strings.TrimSpace(item.ID)
 	if itemID == "" {
-		return "", nil, ErrInvalidResponse
+		return "", nil, "", ErrInvalidResponse
 	}
 
 	statusName = c.detentToGitHubState(defaultProjectItemStatusState)
 	if statusName == "" {
-		return "", nil, nil
+		return "", nil, "", nil
 	}
-	if err := c.setProjectItemStatus(ctx, itemID, statusName); err != nil {
-		return "", nil, fmt.Errorf("default github status: %w", err)
+	return statusName, nil, itemID, nil
+}
+
+func (c *Connector) defaultBlankProjectItemStatuses(ctx context.Context, itemIDs []string) {
+	itemIDs = uniqueNonBlank(itemIDs)
+	if len(itemIDs) == 0 {
+		return
 	}
-	return statusName, nil, nil
+
+	statusName := c.detentToGitHubState(defaultProjectItemStatusState)
+	if statusName == "" {
+		return
+	}
+
+	go c.defaultBlankProjectItemStatusesAsync(ctx, itemIDs, statusName)
+}
+
+func (c *Connector) defaultBlankProjectItemStatusesAsync(parentCtx context.Context, itemIDs []string, statusName string) {
+	baseCtx := context.Background()
+	if parentCtx != nil {
+		baseCtx = context.WithoutCancel(parentCtx)
+	}
+	ctx, cancel := context.WithTimeout(baseCtx, defaultProjectItemStatusWriteTimeout)
+	defer cancel()
+
+	if err := c.writeDefaultProjectItemStatuses(ctx, itemIDs, statusName); err != nil {
+		c.client.logger.WarnContext(ctx, "default github project item statuses failed", "count", len(itemIDs), "error", err)
+	}
+}
+
+func (c *Connector) writeDefaultProjectItemStatuses(ctx context.Context, itemIDs []string, statusName string) error {
+	itemIDs = uniqueNonBlank(itemIDs)
+	if len(itemIDs) == 0 {
+		return nil
+	}
+
+	workerCount := min(defaultProjectItemStatusWriteParallelism, len(itemIDs))
+	jobs := make(chan string)
+	errs := make(chan error, len(itemIDs))
+	var wg sync.WaitGroup
+	wg.Add(workerCount)
+	for range workerCount {
+		go func() {
+			defer wg.Done()
+			for itemID := range jobs {
+				if err := c.setProjectItemStatus(ctx, itemID, statusName); err != nil {
+					errs <- fmt.Errorf("%s: %w", itemID, err)
+				}
+			}
+		}()
+	}
+
+	for _, itemID := range itemIDs {
+		select {
+		case <-ctx.Done():
+			close(jobs)
+			wg.Wait()
+			close(errs)
+			return errors.Join(ctx.Err(), joinErrors(errs))
+		case jobs <- itemID:
+		}
+	}
+
+	close(jobs)
+	wg.Wait()
+	close(errs)
+	return joinErrors(errs)
+}
+
+func joinErrors(errs <-chan error) error {
+	var joined error
+	for err := range errs {
+		joined = errors.Join(joined, err)
+	}
+	return joined
 }
 
 func resolveBlockedByProjectState(issues []connector.Issue) {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -228,7 +228,7 @@ func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesToBacklog(t *te
 		t.Fatalf("defaulted issue = %#v, want blank issue in Backlog", got[0])
 	}
 
-	requests := server.requests()
+	requests := waitForGraphQLRequests(t, server, 3)
 	if len(requests) != 3 {
 		t.Fatalf("request count = %d, want 3", len(requests))
 	}
@@ -238,6 +238,102 @@ func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesToBacklog(t *te
 		updateVariables["fieldId"] != "PVTSSF_status" ||
 		updateVariables["optionId"] != "OPT_backlog" {
 		t.Fatalf("update variables = %#v, want blank item moved to Backlog", updateVariables)
+	}
+}
+
+func TestConnectorFetchCandidateIssuesDoesNotBlockOnBlankProjectStatusDefaulting(t *testing.T) {
+	t.Parallel()
+
+	releaseDefaultWrite := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseDefaultWrite)
+		})
+	}
+	defer release()
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null}]}}}}`,
+		},
+		{
+			release: releaseDefaultWrite,
+			body:    `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_todo","name":"Todo"}]}}}}`,
+		},
+		{
+			body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_blank"}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+	})
+
+	type result struct {
+		issues []connector.Issue
+		err    error
+	}
+	results := make(chan result, 1)
+	go func() {
+		issues, err := c.FetchCandidateIssues(context.Background())
+		results <- result{issues: issues, err: err}
+	}()
+
+	select {
+	case result := <-results:
+		if result.err != nil {
+			t.Fatalf("FetchCandidateIssues() error = %v", result.err)
+		}
+		if len(result.issues) != 0 {
+			t.Fatalf("FetchCandidateIssues() len = %d, want 0", len(result.issues))
+		}
+	case <-time.After(200 * time.Millisecond):
+		release()
+		result := <-results
+		t.Fatalf("FetchCandidateIssues() blocked on default status write; issues = %#v error = %v", result.issues, result.err)
+	}
+
+	release()
+	requests := waitForGraphQLRequests(t, server, 3)
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
+	}
+	updateVariables := requestVariables(t, requests[2])
+	if updateVariables["itemId"] != "PVTI_blank" || updateVariables["optionId"] != "OPT_backlog" {
+		t.Fatalf("update variables = %#v, want blank item moved to Backlog", updateVariables)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesIgnoresBlankStatusDefaultWriteFailure(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_todo","name":"Todo"}]}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:    "PVT_1",
+		ObservedStates: []string{"Backlog"},
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Backlog"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	if got[0].ID != "I_blank" || got[0].State != "Backlog" {
+		t.Fatalf("defaulted issue = %#v, want blank issue in Backlog", got[0])
+	}
+
+	requests := waitForGraphQLRequests(t, server, 2)
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
 	}
 }
 
@@ -1096,8 +1192,9 @@ type graphqlTestServer struct {
 }
 
 type graphqlTestResponse struct {
-	status int
-	body   string
+	status  int
+	body    string
+	release <-chan struct{}
 }
 
 func newGraphQLTestServer(t *testing.T, responses []graphqlTestResponse) *graphqlTestServer {
@@ -1125,6 +1222,10 @@ func (s *graphqlTestServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	s.responses = s.responses[1:]
 	s.mu.Unlock()
 
+	if response.release != nil {
+		<-response.release
+	}
+
 	status := response.status
 	if status == 0 {
 		status = http.StatusOK
@@ -1141,6 +1242,22 @@ func (s *graphqlTestServer) requests() []map[string]any {
 	out := make([]map[string]any, len(s.seen))
 	copy(out, s.seen)
 	return out
+}
+
+func waitForGraphQLRequests(t *testing.T, server *graphqlTestServer, want int) []map[string]any {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		requests := server.requests()
+		if len(requests) >= want {
+			return requests
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	requests := server.requests()
+	t.Fatalf("request count = %d, want at least %d", len(requests), want)
+	return nil
 }
 
 func newGitHubTestConnector(t *testing.T, server *graphqlTestServer, cfg Config) *Connector {


### PR DESCRIPTION
## Summary

- Treat blank ProjectV2 Status values as the configured Backlog default during fetch without inline mutations.
- Move Backlog default writes into a bounded background worker pass so slow or failing writes do not block candidate scans.
- Add regression coverage for non-blocking candidate fetch and ignored default-write failures.

Fixes #295

## Test Plan

- [x] `go test ./internal/connector/github -run 'TestConnectorFetch(CandidateIssuesDoesNotBlockOnBlankProjectStatusDefaulting|IssuesByStatesIgnoresBlankStatusDefaultWriteFailure|IssuesByStatesDefaultsBlankProjectStatusesToBacklog)'`
- [x] `go test -race ./internal/connector/github`
- [x] `make check`
