### PR TITLE
feat(cli): add auto-update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,8 @@ detent update --check
 
 Release-installer installs can update with `detent update`; use
 `detent update --yes` for non-interactive automation and `detent update --json`
-for machine-readable status. Homebrew installs delegate to
+for machine-readable status. On Windows, replacement is staged and completes
+after the running `detent.exe` exits. Homebrew installs delegate to
 `brew upgrade digitaldrywood/tap/detent`, while Go and source builds print the
 recommended command instead of overwriting the binary.
 

--- a/README.md
+++ b/README.md
@@ -160,6 +160,18 @@ Source checkouts can also run the repository-local shell installer:
 ./install.sh
 ```
 
+After installing, check for updates with:
+
+```sh
+detent update --check
+```
+
+Release-installer installs can update with `detent update`; use
+`detent update --yes` for non-interactive automation and `detent update --json`
+for machine-readable status. Homebrew installs delegate to
+`brew upgrade digitaldrywood/tap/detent`, while Go and source builds print the
+recommended command instead of overwriting the binary.
+
 ## Release
 
 Cut releases from `main` by pushing a semver tag:

--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -38,6 +38,7 @@ func newRootCommand(ctx context.Context) *cobra.Command {
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.AddCommand(
 		newVersionCommand(),
+		newUpdateCommand(newDefaultUpdateRunner),
 		newShadowRunCommand(),
 	)
 

--- a/cmd/detent/update.go
+++ b/cmd/detent/update.go
@@ -1,0 +1,116 @@
+package main
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	detentupdate "github.com/digitaldrywood/detent/internal/update"
+)
+
+type updateRunner interface {
+	Check(context.Context) (detentupdate.Status, error)
+	Apply(context.Context, detentupdate.ApplyOptions) (detentupdate.Status, error)
+}
+
+type updateFactory func() (updateRunner, error)
+
+func newUpdateCommand(factory updateFactory) *cobra.Command {
+	var checkOnly bool
+	var assumeYes bool
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:          "update",
+		Short:        "Check for and apply Detent updates",
+		Args:         cobra.NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			runner, err := factory()
+			if err != nil {
+				return err
+			}
+
+			var status detentupdate.Status
+			if checkOnly {
+				status, err = runner.Check(cmd.Context())
+			} else {
+				opts := detentupdate.ApplyOptions{AssumeYes: assumeYes}
+				if !assumeYes && !jsonOutput {
+					opts.Confirm = confirmUpdate(cmd)
+				}
+				status, err = runner.Apply(cmd.Context(), opts)
+			}
+
+			var writeErr error
+			if jsonOutput {
+				writeErr = writeUpdateJSON(cmd.OutOrStdout(), status)
+			} else {
+				writeErr = writeUpdateText(cmd.OutOrStdout(), status)
+			}
+			if writeErr != nil {
+				return writeErr
+			}
+			return err
+		},
+	}
+	cmd.Flags().BoolVar(&checkOnly, "check", false, "check for updates without changing the binary")
+	cmd.Flags().BoolVar(&assumeYes, "yes", false, "apply the update without prompting")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "write machine-readable update status")
+	return cmd
+}
+
+func newDefaultUpdateRunner() (updateRunner, error) {
+	executable, err := os.Executable()
+	if err != nil {
+		return nil, fmt.Errorf("resolve current executable: %w", err)
+	}
+	return detentupdate.NewService(detentupdate.Config{
+		CurrentVersion: version,
+		ExecutablePath: executable,
+		GOOS:           runtime.GOOS,
+		GOARCH:         runtime.GOARCH,
+	}), nil
+}
+
+func confirmUpdate(cmd *cobra.Command) func(detentupdate.Status) (bool, error) {
+	return func(status detentupdate.Status) (bool, error) {
+		if _, err := fmt.Fprintf(cmd.OutOrStdout(), "Update Detent from %s to %s? [y/N] ", status.CurrentVersion, status.LatestVersion); err != nil {
+			return false, err
+		}
+		line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return false, fmt.Errorf("read update confirmation: %w", err)
+		}
+		answer := strings.ToLower(strings.TrimSpace(line))
+		return answer == "y" || answer == "yes", nil
+	}
+}
+
+func writeUpdateJSON(out io.Writer, status detentupdate.Status) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(status)
+}
+
+func writeUpdateText(out io.Writer, status detentupdate.Status) error {
+	if strings.TrimSpace(status.Message) != "" {
+		if _, err := fmt.Fprintln(out, status.Message); err != nil {
+			return err
+		}
+	}
+	if strings.TrimSpace(status.Command) != "" && (status.Action == detentupdate.ActionDelegate || status.Action == detentupdate.ActionRefused) {
+		if _, err := fmt.Fprintf(out, "Run: %s\n", status.Command); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cmd/detent/update_test.go
+++ b/cmd/detent/update_test.go
@@ -1,0 +1,152 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/update"
+)
+
+func TestUpdateCommandCheckJSON(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeUpdater{
+		checkStatus: update.Status{
+			CurrentVersion:  "1.2.3",
+			LatestVersion:   "1.2.4",
+			LatestTag:       "v1.2.4",
+			UpdateAvailable: true,
+			InstallSource:   update.InstallSourceRelease,
+			Action:          update.ActionAvailable,
+			Message:         "Detent 1.2.3 can be updated to 1.2.4.",
+		},
+	}
+	cmd := newUpdateCommand(func() (updateRunner, error) {
+		return fake, nil
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--check", "--json"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if !fake.checkCalled {
+		t.Fatal("Check() was not called")
+	}
+	if fake.applyCalled {
+		t.Fatal("Apply() was called for --check")
+	}
+
+	var got update.Status
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if !got.UpdateAvailable {
+		t.Fatal("UpdateAvailable = false, want true")
+	}
+	if got.LatestVersion != "1.2.4" {
+		t.Fatalf("LatestVersion = %q, want 1.2.4", got.LatestVersion)
+	}
+}
+
+func TestUpdateCommandYesAppliesWithoutPrompt(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeUpdater{
+		applyStatus: update.Status{
+			CurrentVersion:  "1.2.3",
+			LatestVersion:   "1.2.4",
+			UpdateAvailable: true,
+			InstallSource:   update.InstallSourceRelease,
+			Action:          update.ActionUpdated,
+			Message:         "Updated Detent from 1.2.3 to 1.2.4.",
+		},
+	}
+	cmd := newUpdateCommand(func() (updateRunner, error) {
+		return fake, nil
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--yes"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if !fake.applyCalled {
+		t.Fatal("Apply() was not called")
+	}
+	if !fake.applyOptions.AssumeYes {
+		t.Fatal("AssumeYes = false, want true")
+	}
+	if fake.applyOptions.Confirm != nil {
+		t.Fatal("Confirm is set for --yes")
+	}
+	if !strings.Contains(stdout.String(), "Updated Detent from 1.2.3 to 1.2.4.") {
+		t.Fatalf("stdout = %q, want update message", stdout.String())
+	}
+}
+
+func TestUpdateCommandJSONWritesRefusalStatus(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeUpdater{
+		applyStatus: update.Status{
+			CurrentVersion: "dev",
+			InstallSource:  update.InstallSourceDevelopment,
+			Action:         update.ActionRefused,
+			Message:        "This Detent binary does not include release version metadata.",
+		},
+		applyErr: update.ErrRefused,
+	}
+	cmd := newUpdateCommand(func() (updateRunner, error) {
+		return fake, nil
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--json"})
+
+	err := cmd.ExecuteContext(context.Background())
+	if !errors.Is(err, update.ErrRefused) {
+		t.Fatalf("ExecuteContext() error = %v, want %v", err, update.ErrRefused)
+	}
+	if fake.applyOptions.Confirm != nil {
+		t.Fatal("Confirm is set for --json")
+	}
+
+	var got update.Status
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if got.Action != update.ActionRefused {
+		t.Fatalf("Action = %q, want %q", got.Action, update.ActionRefused)
+	}
+}
+
+type fakeUpdater struct {
+	checkCalled  bool
+	applyCalled  bool
+	applyOptions update.ApplyOptions
+	checkStatus  update.Status
+	checkErr     error
+	applyStatus  update.Status
+	applyErr     error
+}
+
+func (f *fakeUpdater) Check(context.Context) (update.Status, error) {
+	f.checkCalled = true
+	return f.checkStatus, f.checkErr
+}
+
+func (f *fakeUpdater) Apply(_ context.Context, opts update.ApplyOptions) (update.Status, error) {
+	f.applyCalled = true
+	f.applyOptions = opts
+	return f.applyStatus, f.applyErr
+}

--- a/install.ps1
+++ b/install.ps1
@@ -472,7 +472,10 @@ try {
 	}
 
 	New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
-	New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
+	$InstallLockDir = Split-Path -Parent $InstallLock
+	if ($InstallLockDir) {
+		New-Item -ItemType Directory -Force -Path $InstallLockDir | Out-Null
+	}
 	Copy-Item -LiteralPath (Join-Path $TmpDir 'detent.exe') -Destination $Target -Force
 	@(
 		"binary=$Target"

--- a/install.ps1
+++ b/install.ps1
@@ -8,6 +8,14 @@ $Headers = @{ 'User-Agent' = 'detent-installer' }
 $ApiBase = if ($env:DETENT_GITHUB_API_BASE) { $env:DETENT_GITHUB_API_BASE } else { "https://api.github.com/repos/$Repo" }
 $DownloadBase = if ($env:DETENT_RELEASE_DOWNLOAD_BASE) { $env:DETENT_RELEASE_DOWNLOAD_BASE } else { "https://github.com/$Repo/releases/download" }
 $InstallMode = if ($env:DETENT_INSTALL_MODE) { $env:DETENT_INSTALL_MODE } else { 'auto' }
+$StateDir = if ($env:DETENT_STATE_DIR) {
+	$env:DETENT_STATE_DIR
+} elseif ($env:LOCALAPPDATA) {
+	Join-Path $env:LOCALAPPDATA 'detent'
+} else {
+	Join-Path $HOME '.detent'
+}
+$InstallLock = if ($env:DETENT_INSTALL_LOCK) { $env:DETENT_INSTALL_LOCK } else { Join-Path $StateDir 'install.lock' }
 
 try {
 	[Net.ServicePointManager]::SecurityProtocol = [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
@@ -464,7 +472,12 @@ try {
 	}
 
 	New-Item -ItemType Directory -Force -Path $InstallDir | Out-Null
+	New-Item -ItemType Directory -Force -Path $StateDir | Out-Null
 	Copy-Item -LiteralPath (Join-Path $TmpDir 'detent.exe') -Destination $Target -Force
+	@(
+		"binary=$Target"
+		"installed_at=$((Get-Date).ToUniversalTime().ToString('yyyy-MM-ddTHH:mm:ssZ'))"
+	) | Set-Content -LiteralPath $InstallLock -Encoding utf8
 	$pathChanged = Add-ToUserPath $InstallDir
 
 	Write-Host "Installed Detent at $Target"

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -40,6 +40,7 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 		{name: "script queries cim processor architecture", content: script, want: "Win32_Processor"},
 		{name: "script queries cim os architecture", content: script, want: "Get-CimInstance"},
 		{name: "script updates user path", content: script, want: "SetEnvironmentVariable('Path'"},
+		{name: "script records installer metadata", content: script, want: "install.lock"},
 	} {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/install_ps1_windows_test.go
+++ b/install_ps1_windows_test.go
@@ -33,10 +33,12 @@ func TestPowerShellInstallScriptInstallsReleaseArchive(t *testing.T) {
 
 	tmp := t.TempDir()
 	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
 	env := powerShellInstallEnv(
 		"DETENT_GITHUB_API_BASE="+server.URL,
 		"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
 		"DETENT_INSTALL_DIR="+installDir,
+		"DETENT_STATE_DIR="+stateDir,
 		"DETENT_INSTALL_MODE=release",
 		"DETENT_INSTALL_SKIP_PATH=1",
 		"DETENT_INSTALL_TEST_ARCH=amd64",
@@ -57,6 +59,13 @@ func TestPowerShellInstallScriptInstallsReleaseArchive(t *testing.T) {
 	}
 	if !strings.Contains(result.stdout, "Verified checksum for "+archiveName) {
 		t.Fatalf("install stdout = %q, want checksum verification", result.stdout)
+	}
+	lock, err := os.ReadFile(filepath.Join(stateDir, "install.lock"))
+	if err != nil {
+		t.Fatalf("ReadFile(install lock) error = %v", err)
+	}
+	if !strings.Contains(string(lock), binary) {
+		t.Fatalf("install lock = %q, want binary path %q", lock, binary)
 	}
 }
 
@@ -97,6 +106,7 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 
 			tmp := t.TempDir()
 			installDir := filepath.Join(tmp, "bin")
+			stateDir := filepath.Join(tmp, "state")
 			fakeBin := filepath.Join(tmp, "fakebin")
 			if err := os.MkdirAll(fakeBin, 0o755); err != nil {
 				t.Fatalf("MkdirAll(fakebin) error = %v", err)
@@ -110,6 +120,7 @@ func TestPowerShellInstallScriptMapsX86ProcessToOSArchitecture(t *testing.T) {
 				"DETENT_GITHUB_API_BASE="+server.URL,
 				"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
 				"DETENT_INSTALL_DIR="+installDir,
+				"DETENT_STATE_DIR="+stateDir,
 				"DETENT_INSTALL_MODE=release",
 				"DETENT_INSTALL_SKIP_PATH=1",
 				"DETENT_INSTALL_TEST_OS_ARCH="+tt.osArch,

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -1,0 +1,994 @@
+package update
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"unicode"
+)
+
+const (
+	defaultAPIBase          = "https://api.github.com/repos/digitaldrywood/detent"
+	moduleInstallCommand    = "go install github.com/digitaldrywood/detent/cmd/detent@latest"
+	homebrewUpdateCommand   = "brew upgrade digitaldrywood/tap/detent"
+	defaultChecksumName     = "checksums.txt"
+	projectName             = "detent"
+	windowsExecutableName   = "detent.exe"
+	nonWindowsArchiveExt    = ".tar.gz"
+	windowsArchiveExt       = ".zip"
+	defaultRequestUserAgent = "detent-updater"
+)
+
+var (
+	ErrConfirmationRequired = errors.New("update confirmation required")
+	ErrRefused              = errors.New("update refused")
+)
+
+type InstallSource string
+
+const (
+	InstallSourceRelease     InstallSource = "release"
+	InstallSourceHomebrew    InstallSource = "homebrew"
+	InstallSourceGoInstall   InstallSource = "go_install"
+	InstallSourceDevelopment InstallSource = "development"
+	InstallSourceUnknown     InstallSource = "unknown"
+)
+
+type Action string
+
+const (
+	ActionAvailable Action = "available"
+	ActionDelegate  Action = "delegate"
+	ActionRefused   Action = "refused"
+	ActionUpToDate  Action = "up_to_date"
+	ActionUpdated   Action = "updated"
+)
+
+type Asset struct {
+	Name               string `json:"name"`
+	BrowserDownloadURL string `json:"browser_download_url"`
+}
+
+type Release struct {
+	TagName    string  `json:"tag_name"`
+	Draft      bool    `json:"draft"`
+	Prerelease bool    `json:"prerelease"`
+	Assets     []Asset `json:"assets"`
+}
+
+type ReleaseAssets struct {
+	Archive  Asset
+	Checksum Asset
+}
+
+type ReleaseClient interface {
+	ListReleases(context.Context) ([]Release, error)
+	Download(context.Context, string) ([]byte, error)
+}
+
+type GitHubClientConfig struct {
+	APIBase    string
+	HTTPClient *http.Client
+}
+
+type GitHubClient struct {
+	apiBase string
+	http    *http.Client
+}
+
+func NewGitHubClient(cfg GitHubClientConfig) *GitHubClient {
+	apiBase := strings.TrimRight(strings.TrimSpace(cfg.APIBase), "/")
+	if apiBase == "" {
+		apiBase = defaultAPIBase
+	}
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+	return &GitHubClient{apiBase: apiBase, http: httpClient}
+}
+
+func (c *GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.apiBase+"/releases?per_page=20", nil)
+	if err != nil {
+		return nil, fmt.Errorf("create releases request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("User-Agent", defaultRequestUserAgent)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("list releases: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("list releases: GitHub returned %s", resp.Status)
+	}
+
+	var releases []Release
+	if err := json.NewDecoder(resp.Body).Decode(&releases); err != nil {
+		return nil, fmt.Errorf("decode releases: %w", err)
+	}
+	return releases, nil
+}
+
+func (c *GitHubClient) Download(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create download request: %w", err)
+	}
+	req.Header.Set("User-Agent", defaultRequestUserAgent)
+
+	resp, err := c.http.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("download %s: %w", url, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return nil, fmt.Errorf("download %s: server returned %s", url, resp.Status)
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("read download %s: %w", url, err)
+	}
+	return raw, nil
+}
+
+type DetectionOptions struct {
+	CurrentVersion string
+	ExecutablePath string
+	GOOS           string
+	HomeDir        string
+	Env            map[string]string
+	EvalSymlinks   func(string) (string, error)
+}
+
+type InstallInfo struct {
+	Source  InstallSource `json:"source"`
+	Command string        `json:"command,omitempty"`
+	Message string        `json:"message,omitempty"`
+	Binary  string        `json:"binary,omitempty"`
+}
+
+func DetectInstallSource(opts DetectionOptions) InstallInfo {
+	goos := firstNonEmpty(opts.GOOS, runtime.GOOS)
+	executable := cleanPath(opts.ExecutablePath, goos)
+	realExecutable := executable
+	evalSymlinks := opts.EvalSymlinks
+	if evalSymlinks == nil {
+		evalSymlinks = filepath.EvalSymlinks
+	}
+	if real, err := evalSymlinks(opts.ExecutablePath); err == nil && strings.TrimSpace(real) != "" {
+		realExecutable = cleanPath(real, goos)
+	}
+
+	if isHomebrewPath(executable) || isHomebrewPath(realExecutable) {
+		return InstallInfo{
+			Source:  InstallSourceHomebrew,
+			Command: homebrewUpdateCommand,
+			Binary:  opts.ExecutablePath,
+		}
+	}
+	if releaseLockMatches(executable, realExecutable, goos, opts) || windowsInstallerPathMatches(executable, goos, opts) {
+		return InstallInfo{
+			Source: InstallSourceRelease,
+			Binary: opts.ExecutablePath,
+		}
+	}
+	if isGoInstallPath(executable, goos, opts.HomeDir, opts.Env) || isGoInstallPath(realExecutable, goos, opts.HomeDir, opts.Env) {
+		return InstallInfo{
+			Source:  InstallSourceGoInstall,
+			Command: moduleInstallCommand,
+			Binary:  opts.ExecutablePath,
+		}
+	}
+	if IsDevelopmentVersion(opts.CurrentVersion) {
+		return InstallInfo{
+			Source: InstallSourceDevelopment,
+			Binary: opts.ExecutablePath,
+		}
+	}
+	return InstallInfo{
+		Source: InstallSourceUnknown,
+		Binary: opts.ExecutablePath,
+	}
+}
+
+func IsDevelopmentVersion(version string) bool {
+	trimmed := strings.TrimSpace(version)
+	switch trimmed {
+	case "", "dev", "none", "unknown", "(devel)":
+		return true
+	}
+	_, err := parseVersion(trimmed)
+	return err != nil
+}
+
+type Config struct {
+	CurrentVersion string
+	ExecutablePath string
+	GOOS           string
+	GOARCH         string
+	Client         ReleaseClient
+	HomeDir        string
+	Env            map[string]string
+	EvalSymlinks   func(string) (string, error)
+}
+
+type Service struct {
+	cfg Config
+}
+
+type ApplyOptions struct {
+	AssumeYes bool
+	Confirm   func(Status) (bool, error)
+}
+
+type Status struct {
+	CurrentVersion  string        `json:"current_version"`
+	LatestVersion   string        `json:"latest_version,omitempty"`
+	LatestTag       string        `json:"latest_tag,omitempty"`
+	UpdateAvailable bool          `json:"update_available"`
+	InstallSource   InstallSource `json:"install_source"`
+	Action          Action        `json:"action"`
+	Message         string        `json:"message,omitempty"`
+	Command         string        `json:"command,omitempty"`
+	Binary          string        `json:"binary,omitempty"`
+	Asset           string        `json:"asset,omitempty"`
+}
+
+func NewService(cfg Config) *Service {
+	if cfg.GOOS == "" {
+		cfg.GOOS = runtime.GOOS
+	}
+	if cfg.GOARCH == "" {
+		cfg.GOARCH = runtime.GOARCH
+	}
+	if cfg.Client == nil {
+		cfg.Client = NewGitHubClient(GitHubClientConfig{})
+	}
+	return &Service{cfg: cfg}
+}
+
+func (s *Service) Check(ctx context.Context) (Status, error) {
+	status, _, err := s.plan(ctx)
+	return status, err
+}
+
+func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) {
+	status, release, err := s.plan(ctx)
+	if err != nil {
+		return status, err
+	}
+	if !status.UpdateAvailable {
+		status.Action = ActionUpToDate
+		status.Message = fmt.Sprintf("Detent %s is up to date.", status.CurrentVersion)
+		return status, nil
+	}
+
+	switch status.InstallSource {
+	case InstallSourceHomebrew:
+		status.Action = ActionDelegate
+		status.Command = homebrewUpdateCommand
+		status.Message = "Homebrew-managed Detent install detected. Run the Homebrew upgrade command."
+		return status, nil
+	case InstallSourceRelease:
+	case InstallSourceGoInstall:
+		status.Action = ActionRefused
+		status.Command = moduleInstallCommand
+		status.Message = "This Detent binary appears to be managed by go install. Run the Go install command instead."
+		return status, ErrRefused
+	case InstallSourceDevelopment:
+		status.Action = ActionRefused
+		status.Message = "This Detent binary does not include release version metadata. Install a published release before using self-update."
+		return status, ErrRefused
+	default:
+		status.Action = ActionRefused
+		status.Message = "Detent cannot verify that this binary was installed by the release installer, so it will not overwrite it."
+		return status, ErrRefused
+	}
+
+	if !opts.AssumeYes {
+		if opts.Confirm == nil {
+			status.Action = ActionRefused
+			status.Message = "Update requires confirmation. Rerun with --yes to update non-interactively."
+			return status, ErrConfirmationRequired
+		}
+		confirmed, err := opts.Confirm(status)
+		if err != nil {
+			status.Action = ActionRefused
+			status.Message = err.Error()
+			return status, err
+		}
+		if !confirmed {
+			status.Action = ActionRefused
+			status.Message = "Update cancelled."
+			return status, ErrConfirmationRequired
+		}
+	}
+
+	assets, err := SelectReleaseAssets(release, s.cfg.GOOS, s.cfg.GOARCH)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+	archive, err := s.cfg.Client.Download(ctx, assets.Archive.BrowserDownloadURL)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+	checksums, err := s.cfg.Client.Download(ctx, assets.Checksum.BrowserDownloadURL)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+	if err := VerifyChecksum(checksums, assets.Archive.Name, archive); err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+
+	binary, mode, err := ExtractBinary(archive, s.cfg.GOOS)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+	if err := ReplaceBinary(s.cfg.ExecutablePath, binary, mode); err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+
+	status.Action = ActionUpdated
+	status.Asset = assets.Archive.Name
+	status.Message = fmt.Sprintf("Updated Detent from %s to %s.", status.CurrentVersion, status.LatestVersion)
+	return status, nil
+}
+
+func (s *Service) plan(ctx context.Context) (Status, Release, error) {
+	info := DetectInstallSource(DetectionOptions{
+		CurrentVersion: s.cfg.CurrentVersion,
+		ExecutablePath: s.cfg.ExecutablePath,
+		GOOS:           s.cfg.GOOS,
+		HomeDir:        s.cfg.HomeDir,
+		Env:            s.cfg.Env,
+		EvalSymlinks:   s.cfg.EvalSymlinks,
+	})
+	status := Status{
+		CurrentVersion: strings.TrimSpace(s.cfg.CurrentVersion),
+		InstallSource:  info.Source,
+		Command:        info.Command,
+		Binary:         s.cfg.ExecutablePath,
+	}
+
+	if IsDevelopmentVersion(s.cfg.CurrentVersion) {
+		status.Action = ActionRefused
+		switch info.Source {
+		case InstallSourceGoInstall:
+			status.Message = "This Detent binary appears to be managed by go install and does not include release metadata. Run the Go install command instead."
+			status.Command = moduleInstallCommand
+		default:
+			status.Message = "This Detent binary does not include release version metadata. Install a published release before using self-update."
+		}
+		return status, Release{}, ErrRefused
+	}
+
+	releases, err := s.cfg.Client.ListReleases(ctx)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, Release{}, err
+	}
+	release, ok, err := SelectLatestRelease(s.cfg.CurrentVersion, releases)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, Release{}, err
+	}
+	if !ok {
+		status.Action = ActionRefused
+		status.Message = "No eligible Detent release was found."
+		return status, Release{}, errors.New("no eligible Detent release found")
+	}
+
+	status.LatestTag = release.TagName
+	status.LatestVersion = displayVersion(release.TagName)
+	cmp, err := CompareVersions(release.TagName, s.cfg.CurrentVersion)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, Release{}, err
+	}
+	status.UpdateAvailable = cmp > 0
+	if status.UpdateAvailable {
+		status.Action = ActionAvailable
+		status.Message = fmt.Sprintf("Detent %s can be updated to %s.", status.CurrentVersion, status.LatestVersion)
+	} else {
+		status.Action = ActionUpToDate
+		status.Message = fmt.Sprintf("Detent %s is up to date.", status.CurrentVersion)
+	}
+	return status, release, nil
+}
+
+func SelectLatestRelease(current string, releases []Release) (Release, bool, error) {
+	currentVersion, err := parseVersion(current)
+	if err != nil {
+		return Release{}, false, err
+	}
+
+	var latest Release
+	var latestVersion semVersion
+	found := false
+	for _, release := range releases {
+		if release.Draft {
+			continue
+		}
+		if release.Prerelease && len(currentVersion.prerelease) == 0 {
+			continue
+		}
+		version, err := parseVersion(release.TagName)
+		if err != nil {
+			continue
+		}
+		if !found || compareSemVersions(version, latestVersion) > 0 {
+			latest = release
+			latestVersion = version
+			found = true
+		}
+	}
+	return latest, found, nil
+}
+
+func CompareVersions(a string, b string) (int, error) {
+	versionA, err := parseVersion(a)
+	if err != nil {
+		return 0, err
+	}
+	versionB, err := parseVersion(b)
+	if err != nil {
+		return 0, err
+	}
+	return compareSemVersions(versionA, versionB), nil
+}
+
+func SelectReleaseAssets(release Release, goos string, goarch string) (ReleaseAssets, error) {
+	archiveNames := archiveAssetNames(release.TagName, goos, goarch)
+	checksumNames := checksumAssetNames(release.TagName)
+
+	archive, ok := assetByName(release.Assets, archiveNames)
+	if !ok {
+		return ReleaseAssets{}, fmt.Errorf("release %s does not include an archive for %s/%s", release.TagName, goos, goarch)
+	}
+	checksum, ok := assetByName(release.Assets, checksumNames)
+	if !ok {
+		return ReleaseAssets{}, fmt.Errorf("release %s does not include a checksum asset", release.TagName)
+	}
+	return ReleaseAssets{Archive: archive, Checksum: checksum}, nil
+}
+
+func VerifyChecksum(checksums []byte, assetName string, archive []byte) error {
+	expected, ok := expectedChecksum(checksums, assetName)
+	if !ok {
+		return fmt.Errorf("checksum for %s not found", assetName)
+	}
+	sum := sha256.Sum256(archive)
+	actual := fmt.Sprintf("%x", sum)
+	if !strings.EqualFold(actual, expected) {
+		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", assetName, expected, actual)
+	}
+	return nil
+}
+
+func ExtractBinary(archive []byte, goos string) ([]byte, os.FileMode, error) {
+	if goos == "windows" {
+		return extractZipBinary(archive)
+	}
+	return extractTarGzipBinary(archive)
+}
+
+func ReplaceBinary(target string, binary []byte, mode os.FileMode) error {
+	if strings.TrimSpace(target) == "" {
+		return errors.New("target binary path is required")
+	}
+	if mode == 0 {
+		mode = 0o755
+	}
+
+	dir := filepath.Dir(target)
+	base := filepath.Base(target)
+	temp, err := os.CreateTemp(dir, "."+base+".update-*")
+	if err != nil {
+		return fmt.Errorf("create update temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			removeFile(tempPath)
+		}
+	}()
+
+	writeErr := writeBinaryTemp(temp, binary, mode)
+	if writeErr != nil {
+		return writeErr
+	}
+	if err := os.Rename(tempPath, target); err != nil {
+		return fmt.Errorf("replace binary %s: %w", target, err)
+	}
+	cleanup = false
+	return nil
+}
+
+func writeBinaryTemp(file *os.File, binary []byte, mode os.FileMode) error {
+	if _, err := file.Write(binary); err != nil {
+		closeErr := file.Close()
+		if closeErr != nil {
+			return fmt.Errorf("write update temp file: %w; close temp file: %w", err, closeErr)
+		}
+		return fmt.Errorf("write update temp file: %w", err)
+	}
+	if err := file.Chmod(mode); err != nil {
+		closeErr := file.Close()
+		if closeErr != nil {
+			return fmt.Errorf("chmod update temp file: %w; close temp file: %w", err, closeErr)
+		}
+		return fmt.Errorf("chmod update temp file: %w", err)
+	}
+	if err := file.Close(); err != nil {
+		return fmt.Errorf("close update temp file: %w", err)
+	}
+	return nil
+}
+
+func removeFile(path string) {
+	if err := os.Remove(path); err != nil && !errors.Is(err, os.ErrNotExist) {
+		return
+	}
+}
+
+func extractTarGzipBinary(archive []byte) (_ []byte, _ os.FileMode, err error) {
+	gz, err := gzip.NewReader(bytes.NewReader(archive))
+	if err != nil {
+		return nil, 0, fmt.Errorf("open release archive: %w", err)
+	}
+	defer func() {
+		if closeErr := gz.Close(); err == nil && closeErr != nil {
+			err = fmt.Errorf("close release archive: %w", closeErr)
+		}
+	}()
+
+	tr := tar.NewReader(gz)
+	for {
+		header, err := tr.Next()
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			return nil, 0, fmt.Errorf("read release archive: %w", err)
+		}
+		if header.Typeflag != tar.TypeReg && header.Typeflag != 0 {
+			continue
+		}
+		if filepath.Base(header.Name) != projectName {
+			continue
+		}
+		raw, err := io.ReadAll(tr)
+		if err != nil {
+			return nil, 0, fmt.Errorf("read detent from release archive: %w", err)
+		}
+		return raw, os.FileMode(header.Mode), nil
+	}
+	return nil, 0, errors.New("release archive did not contain detent")
+}
+
+func extractZipBinary(archive []byte) ([]byte, os.FileMode, error) {
+	zr, err := zip.NewReader(bytes.NewReader(archive), int64(len(archive)))
+	if err != nil {
+		return nil, 0, fmt.Errorf("open release archive: %w", err)
+	}
+	for _, file := range zr.File {
+		if filepath.Base(file.Name) != windowsExecutableName {
+			continue
+		}
+		reader, err := file.Open()
+		if err != nil {
+			return nil, 0, fmt.Errorf("open detent.exe from release archive: %w", err)
+		}
+		raw, readErr := io.ReadAll(reader)
+		closeErr := reader.Close()
+		if readErr != nil {
+			return nil, 0, fmt.Errorf("read detent.exe from release archive: %w", readErr)
+		}
+		if closeErr != nil {
+			return nil, 0, fmt.Errorf("close detent.exe from release archive: %w", closeErr)
+		}
+		mode := file.Mode()
+		if mode == 0 {
+			mode = 0o755
+		}
+		return raw, mode, nil
+	}
+	return nil, 0, errors.New("release archive did not contain detent.exe")
+}
+
+func expectedChecksum(checksums []byte, assetName string) (string, bool) {
+	for _, line := range strings.Split(string(checksums), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 {
+			continue
+		}
+		name := strings.TrimPrefix(fields[1], "*")
+		if name == assetName {
+			return strings.ToLower(fields[0]), true
+		}
+	}
+	return "", false
+}
+
+func archiveAssetNames(tag string, goos string, goarch string) []string {
+	version := displayVersion(tag)
+	extension := nonWindowsArchiveExt
+	if goos == "windows" {
+		extension = windowsArchiveExt
+	}
+	names := []string{
+		fmt.Sprintf("%s_%s_%s_%s%s", projectName, version, goos, goarch, extension),
+	}
+	if tag != version {
+		names = append(names, fmt.Sprintf("%s_%s_%s_%s%s", projectName, tag, goos, goarch, extension))
+	}
+	return names
+}
+
+func checksumAssetNames(tag string) []string {
+	version := displayVersion(tag)
+	names := []string{
+		fmt.Sprintf("%s_%s_checksums.txt", projectName, version),
+		defaultChecksumName,
+	}
+	if tag != version {
+		names = append([]string{fmt.Sprintf("%s_%s_checksums.txt", projectName, tag)}, names...)
+	}
+	return names
+}
+
+func assetByName(assets []Asset, names []string) (Asset, bool) {
+	for _, name := range names {
+		for _, asset := range assets {
+			if asset.Name == name {
+				return asset, true
+			}
+		}
+	}
+	return Asset{}, false
+}
+
+func displayVersion(version string) string {
+	return strings.TrimPrefix(strings.TrimSpace(version), "v")
+}
+
+type semVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease []string
+}
+
+func parseVersion(version string) (semVersion, error) {
+	trimmed := displayVersion(version)
+	withoutBuild, _, _ := strings.Cut(trimmed, "+")
+	core, prerelease, hasPrerelease := strings.Cut(withoutBuild, "-")
+	parts := strings.Split(core, ".")
+	if len(parts) != 3 {
+		return semVersion{}, fmt.Errorf("invalid semantic version: %s", version)
+	}
+
+	major, err := parseVersionNumber(parts[0], version)
+	if err != nil {
+		return semVersion{}, err
+	}
+	minor, err := parseVersionNumber(parts[1], version)
+	if err != nil {
+		return semVersion{}, err
+	}
+	patch, err := parseVersionNumber(parts[2], version)
+	if err != nil {
+		return semVersion{}, err
+	}
+
+	var prereleaseParts []string
+	if hasPrerelease {
+		prereleaseParts = strings.Split(prerelease, ".")
+		for _, part := range prereleaseParts {
+			if part == "" {
+				return semVersion{}, fmt.Errorf("invalid semantic version: %s", version)
+			}
+		}
+	}
+	return semVersion{major: major, minor: minor, patch: patch, prerelease: prereleaseParts}, nil
+}
+
+func parseVersionNumber(part string, original string) (int, error) {
+	if part == "" {
+		return 0, fmt.Errorf("invalid semantic version: %s", original)
+	}
+	for _, r := range part {
+		if !unicode.IsDigit(r) {
+			return 0, fmt.Errorf("invalid semantic version: %s", original)
+		}
+	}
+	value, err := strconv.Atoi(part)
+	if err != nil {
+		return 0, fmt.Errorf("invalid semantic version: %s", original)
+	}
+	return value, nil
+}
+
+func compareSemVersions(a semVersion, b semVersion) int {
+	for _, values := range [][2]int{{a.major, b.major}, {a.minor, b.minor}, {a.patch, b.patch}} {
+		if values[0] > values[1] {
+			return 1
+		}
+		if values[0] < values[1] {
+			return -1
+		}
+	}
+	return comparePrerelease(a.prerelease, b.prerelease)
+}
+
+func comparePrerelease(a []string, b []string) int {
+	if len(a) == 0 && len(b) == 0 {
+		return 0
+	}
+	if len(a) == 0 {
+		return 1
+	}
+	if len(b) == 0 {
+		return -1
+	}
+	for i := 0; i < len(a) && i < len(b); i++ {
+		cmp := comparePrereleaseIdentifier(a[i], b[i])
+		if cmp != 0 {
+			return cmp
+		}
+	}
+	if len(a) > len(b) {
+		return 1
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	return 0
+}
+
+func comparePrereleaseIdentifier(a string, b string) int {
+	aNumeric := isNumericIdentifier(a)
+	bNumeric := isNumericIdentifier(b)
+	switch {
+	case aNumeric && bNumeric:
+		return compareNumericStrings(a, b)
+	case aNumeric:
+		return -1
+	case bNumeric:
+		return 1
+	default:
+		return strings.Compare(a, b)
+	}
+}
+
+func isNumericIdentifier(value string) bool {
+	if value == "" {
+		return false
+	}
+	for _, r := range value {
+		if !unicode.IsDigit(r) {
+			return false
+		}
+	}
+	return true
+}
+
+func compareNumericStrings(a string, b string) int {
+	a = strings.TrimLeft(a, "0")
+	b = strings.TrimLeft(b, "0")
+	if a == "" {
+		a = "0"
+	}
+	if b == "" {
+		b = "0"
+	}
+	if len(a) > len(b) {
+		return 1
+	}
+	if len(a) < len(b) {
+		return -1
+	}
+	return strings.Compare(a, b)
+}
+
+func releaseLockMatches(executable string, realExecutable string, goos string, opts DetectionOptions) bool {
+	for _, candidate := range installLockCandidates(goos, opts) {
+		binary, ok := readInstallLockBinary(candidate)
+		if !ok {
+			continue
+		}
+		cleanBinary := cleanPath(binary, goos)
+		if samePath(cleanBinary, executable, goos) || samePath(cleanBinary, realExecutable, goos) {
+			return true
+		}
+	}
+	return false
+}
+
+func installLockCandidates(goos string, opts DetectionOptions) []string {
+	var candidates []string
+	if lockPath := envValue(opts.Env, "DETENT_INSTALL_LOCK"); lockPath != "" {
+		candidates = append(candidates, lockPath)
+	}
+	if stateDir := envValue(opts.Env, "DETENT_STATE_DIR"); stateDir != "" {
+		candidates = append(candidates, filepath.Join(stateDir, "install.lock"))
+	}
+	home := homeDir(opts.HomeDir, opts.Env)
+	if home != "" {
+		candidates = append(candidates, filepath.Join(home, ".detent", "install.lock"))
+	}
+	if goos == "windows" {
+		if localAppData := envValue(opts.Env, "LOCALAPPDATA"); localAppData != "" {
+			candidates = append(candidates, filepath.Join(localAppData, "detent", "install.lock"))
+		}
+	}
+	return candidates
+}
+
+func readInstallLockBinary(path string) (string, bool) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", false
+	}
+	for _, line := range strings.Split(string(raw), "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok || strings.TrimSpace(key) != "binary" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		if value != "" {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func windowsInstallerPathMatches(executable string, goos string, opts DetectionOptions) bool {
+	if goos != "windows" {
+		return false
+	}
+	for _, installDir := range windowsInstallDirs(opts) {
+		if samePath(executable, filepath.Join(installDir, windowsExecutableName), goos) {
+			return true
+		}
+	}
+	return false
+}
+
+func windowsInstallDirs(opts DetectionOptions) []string {
+	var dirs []string
+	if installDir := envValue(opts.Env, "DETENT_INSTALL_DIR"); installDir != "" {
+		dirs = append(dirs, installDir)
+	}
+	if localAppData := envValue(opts.Env, "LOCALAPPDATA"); localAppData != "" {
+		dirs = append(dirs, filepath.Join(localAppData, "detent", "bin"))
+	}
+	if home := homeDir(opts.HomeDir, opts.Env); home != "" {
+		dirs = append(dirs, filepath.Join(home, ".detent", "bin"))
+	}
+	return dirs
+}
+
+func isHomebrewPath(path string) bool {
+	normalized := filepath.ToSlash(path)
+	return strings.Contains(normalized, "/Cellar/detent/")
+}
+
+func isGoInstallPath(path string, goos string, explicitHome string, env map[string]string) bool {
+	executableName := projectName
+	if goos == "windows" {
+		executableName = windowsExecutableName
+	}
+	if gobin := envValue(env, "GOBIN"); gobin != "" && samePath(path, filepath.Join(gobin, executableName), goos) {
+		return true
+	}
+	gopath := envValue(env, "GOPATH")
+	if gopath == "" {
+		if home := homeDir(explicitHome, env); home != "" {
+			gopath = filepath.Join(home, "go")
+		}
+	}
+	for _, root := range filepath.SplitList(gopath) {
+		if root == "" {
+			continue
+		}
+		if samePath(path, filepath.Join(root, "bin", executableName), goos) {
+			return true
+		}
+	}
+	return false
+}
+
+func homeDir(explicitHome string, env map[string]string) string {
+	if explicitHome != "" {
+		return explicitHome
+	}
+	if home := envValue(env, "HOME"); home != "" {
+		return home
+	}
+	if home := envValue(env, "USERPROFILE"); home != "" {
+		return home
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ""
+	}
+	return home
+}
+
+func envValue(env map[string]string, key string) string {
+	if env == nil {
+		return os.Getenv(key)
+	}
+	for existingKey, value := range env {
+		if strings.EqualFold(existingKey, key) {
+			return value
+		}
+	}
+	return ""
+}
+
+func samePath(a string, b string, goos string) bool {
+	a = cleanPath(a, goos)
+	b = cleanPath(b, goos)
+	if goos == "windows" {
+		return strings.EqualFold(a, b)
+	}
+	return a == b
+}
+
+func cleanPath(path string, goos string) string {
+	if path == "" {
+		return ""
+	}
+	cleaned := filepath.Clean(path)
+	if abs, err := filepath.Abs(cleaned); err == nil {
+		cleaned = abs
+	}
+	if goos == "windows" {
+		cleaned = strings.TrimRight(cleaned, `\/`)
+	}
+	return cleaned
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -13,6 +13,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strconv"
@@ -78,6 +79,8 @@ type ReleaseClient interface {
 	ListReleases(context.Context) ([]Release, error)
 	Download(context.Context, string) ([]byte, error)
 }
+
+type ProcessStarter func(string, []string) error
 
 type GitHubClientConfig struct {
 	APIBase    string
@@ -238,6 +241,14 @@ type ApplyOptions struct {
 	Confirm   func(Status) (bool, error)
 }
 
+type Replacement struct {
+	Target       string
+	Binary       []byte
+	Mode         os.FileMode
+	GOOS         string
+	StartProcess ProcessStarter
+}
+
 type Status struct {
 	CurrentVersion  string        `json:"current_version"`
 	LatestVersion   string        `json:"latest_version,omitempty"`
@@ -351,7 +362,12 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 		status.Message = err.Error()
 		return status, err
 	}
-	if err := ReplaceBinary(s.cfg.ExecutablePath, binary, mode); err != nil {
+	if err := ReplaceBinary(Replacement{
+		Target: s.cfg.ExecutablePath,
+		Binary: binary,
+		Mode:   mode,
+		GOOS:   s.cfg.GOOS,
+	}); err != nil {
 		status.Action = ActionRefused
 		status.Message = err.Error()
 		return status, err
@@ -359,7 +375,7 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 
 	status.Action = ActionUpdated
 	status.Asset = assets.Archive.Name
-	status.Message = fmt.Sprintf("Updated Detent from %s to %s.", status.CurrentVersion, status.LatestVersion)
+	status.Message = updateAppliedMessage(status, s.cfg.GOOS)
 	return status, nil
 }
 
@@ -504,7 +520,15 @@ func ExtractBinary(archive []byte, goos string) ([]byte, os.FileMode, error) {
 	return extractTarGzipBinary(archive)
 }
 
-func ReplaceBinary(target string, binary []byte, mode os.FileMode) error {
+func ReplaceBinary(replacement Replacement) error {
+	goos := firstNonEmpty(replacement.GOOS, runtime.GOOS)
+	if goos == "windows" {
+		return stageWindowsReplacement(replacement)
+	}
+	return replaceBinaryNow(replacement.Target, replacement.Binary, replacement.Mode)
+}
+
+func replaceBinaryNow(target string, binary []byte, mode os.FileMode) error {
 	if strings.TrimSpace(target) == "" {
 		return errors.New("target binary path is required")
 	}
@@ -535,6 +559,129 @@ func ReplaceBinary(target string, binary []byte, mode os.FileMode) error {
 	}
 	cleanup = false
 	return nil
+}
+
+func stageWindowsReplacement(replacement Replacement) error {
+	if strings.TrimSpace(replacement.Target) == "" {
+		return errors.New("target binary path is required")
+	}
+	mode := replacement.Mode
+	if mode == 0 {
+		mode = 0o755
+	}
+
+	dir := filepath.Dir(replacement.Target)
+	base := filepath.Base(replacement.Target)
+	source, err := writeWindowsUpdateBinary(dir, base, replacement.Binary, mode)
+	if err != nil {
+		return err
+	}
+	cleanupSource := true
+	defer func() {
+		if cleanupSource {
+			removeFile(source)
+		}
+	}()
+
+	script, err := writeWindowsUpdateScript(dir, source, replacement.Target)
+	if err != nil {
+		return err
+	}
+	cleanupScript := true
+	defer func() {
+		if cleanupScript {
+			removeFile(script)
+		}
+	}()
+
+	starter := replacement.StartProcess
+	if starter == nil {
+		starter = startProcess
+	}
+	if err := starter("cmd.exe", []string{"/D", "/C", "start", "", "/B", "cmd.exe", "/D", "/C", script}); err != nil {
+		return fmt.Errorf("start windows updater: %w", err)
+	}
+
+	cleanupSource = false
+	cleanupScript = false
+	return nil
+}
+
+func writeWindowsUpdateBinary(dir string, base string, binary []byte, mode os.FileMode) (string, error) {
+	temp, err := os.CreateTemp(dir, "."+base+".update-*")
+	if err != nil {
+		return "", fmt.Errorf("create update temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	if err := writeBinaryTemp(temp, binary, mode); err != nil {
+		removeFile(tempPath)
+		return "", err
+	}
+	return tempPath, nil
+}
+
+func writeWindowsUpdateScript(dir string, source string, target string) (string, error) {
+	script, err := os.CreateTemp(dir, ".detent-update-*.cmd")
+	if err != nil {
+		return "", fmt.Errorf("create windows update script: %w", err)
+	}
+	scriptPath := script.Name()
+	raw := windowsUpdateScript(source, target)
+	if _, err := script.WriteString(raw); err != nil {
+		closeErr := script.Close()
+		removeFile(scriptPath)
+		if closeErr != nil {
+			return "", fmt.Errorf("write windows update script: %w; close update script: %w", err, closeErr)
+		}
+		return "", fmt.Errorf("write windows update script: %w", err)
+	}
+	if err := script.Chmod(0o700); err != nil {
+		closeErr := script.Close()
+		removeFile(scriptPath)
+		if closeErr != nil {
+			return "", fmt.Errorf("chmod windows update script: %w; close update script: %w", err, closeErr)
+		}
+		return "", fmt.Errorf("chmod windows update script: %w", err)
+	}
+	if err := script.Close(); err != nil {
+		removeFile(scriptPath)
+		return "", fmt.Errorf("close windows update script: %w", err)
+	}
+	return scriptPath, nil
+}
+
+func windowsUpdateScript(source string, target string) string {
+	return fmt.Sprintf(`@echo off
+setlocal DisableDelayedExpansion
+set "source=%s"
+set "target=%s"
+set /a attempts=0
+:retry
+move /Y "%%source%%" "%%target%%" >nul 2>nul
+if not exist "%%source%%" goto done
+set /a attempts+=1
+if %%attempts%% GEQ 60 exit /b 1
+timeout /t 1 /nobreak >nul 2>nul
+goto retry
+:done
+del "%%~f0" >nul 2>nul
+exit /b 0
+`, escapeBatchValue(source), escapeBatchValue(target))
+}
+
+func escapeBatchValue(value string) string {
+	return strings.ReplaceAll(value, "%", "%%")
+}
+
+func startProcess(command string, args []string) error {
+	return exec.Command(command, args...).Start()
+}
+
+func updateAppliedMessage(status Status, goos string) string {
+	if goos == "windows" {
+		return fmt.Sprintf("Updated Detent from %s to %s. The replacement will finish after Detent exits.", status.CurrentVersion, status.LatestVersion)
+	}
+	return fmt.Sprintf("Updated Detent from %s to %s.", status.CurrentVersion, status.LatestVersion)
 }
 
 func writeBinaryTemp(file *os.File, binary []byte, mode os.FileMode) error {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1,0 +1,294 @@
+package update
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCompareVersions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		a    string
+		b    string
+		want int
+	}{
+		{name: "equal with v prefix and build metadata", a: "v1.2.3", b: "1.2.3+build.7", want: 0},
+		{name: "patch greater", a: "1.2.4", b: "1.2.3", want: 1},
+		{name: "minor greater", a: "1.10.0", b: "1.9.9", want: 1},
+		{name: "release greater than prerelease", a: "1.2.3", b: "1.2.3-rc.1", want: 1},
+		{name: "prerelease identifiers compare numerically", a: "1.2.3-rc.2", b: "1.2.3-rc.1", want: 1},
+		{name: "lower major", a: "1.9.9", b: "2.0.0", want: -1},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := CompareVersions(tt.a, tt.b)
+			if err != nil {
+				t.Fatalf("CompareVersions() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("CompareVersions(%q, %q) = %d, want %d", tt.a, tt.b, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestSelectLatestReleasePrereleaseHandling(t *testing.T) {
+	t.Parallel()
+
+	releases := []Release{
+		{TagName: "v1.3.0-rc.2", Prerelease: true},
+		{TagName: "v1.2.4", Prerelease: false},
+		{TagName: "v2.0.0", Draft: true},
+		{TagName: "not-semver"},
+	}
+
+	stable, ok, err := SelectLatestRelease("1.2.3", releases)
+	if err != nil {
+		t.Fatalf("SelectLatestRelease() stable error = %v", err)
+	}
+	if !ok {
+		t.Fatal("SelectLatestRelease() stable ok = false, want true")
+	}
+	if stable.TagName != "v1.2.4" {
+		t.Fatalf("stable TagName = %q, want v1.2.4", stable.TagName)
+	}
+
+	prerelease, ok, err := SelectLatestRelease("1.3.0-rc.1", releases)
+	if err != nil {
+		t.Fatalf("SelectLatestRelease() prerelease error = %v", err)
+	}
+	if !ok {
+		t.Fatal("SelectLatestRelease() prerelease ok = false, want true")
+	}
+	if prerelease.TagName != "v1.3.0-rc.2" {
+		t.Fatalf("prerelease TagName = %q, want v1.3.0-rc.2", prerelease.TagName)
+	}
+}
+
+func TestDetectInstallSource(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	home := filepath.Join(tmp, "home")
+	releaseBin := filepath.Join(tmp, "bin", "detent")
+	goBin := filepath.Join(tmp, "gobin")
+	goInstalled := filepath.Join(goBin, "detent")
+	brewLink := filepath.Join(tmp, "homebrew", "bin", "detent")
+	brewTarget := filepath.Join(tmp, "homebrew", "Cellar", "detent", "1.2.3", "bin", "detent")
+	lockPath := filepath.Join(tmp, "state", "install.lock")
+
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte("binary="+releaseBin+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(lock) error = %v", err)
+	}
+
+	evalSymlinks := func(path string) (string, error) {
+		if path == brewLink {
+			return brewTarget, nil
+		}
+		return path, nil
+	}
+
+	tests := []struct {
+		name           string
+		currentVersion string
+		executable     string
+		env            map[string]string
+		want           InstallSource
+		wantCommand    string
+	}{
+		{
+			name:           "release installer lock",
+			currentVersion: "1.2.3",
+			executable:     releaseBin,
+			env:            map[string]string{"DETENT_INSTALL_LOCK": lockPath},
+			want:           InstallSourceRelease,
+		},
+		{
+			name:           "homebrew cellar target",
+			currentVersion: "1.2.3",
+			executable:     brewLink,
+			want:           InstallSourceHomebrew,
+			wantCommand:    "brew upgrade digitaldrywood/tap/detent",
+		},
+		{
+			name:           "go install bin",
+			currentVersion: "dev",
+			executable:     goInstalled,
+			env:            map[string]string{"GOBIN": goBin},
+			want:           InstallSourceGoInstall,
+			wantCommand:    "go install github.com/digitaldrywood/detent/cmd/detent@latest",
+		},
+		{
+			name:           "development build",
+			currentVersion: "dev",
+			executable:     filepath.Join(tmp, "checkout", "tmp", "detent"),
+			want:           InstallSourceDevelopment,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := DetectInstallSource(DetectionOptions{
+				CurrentVersion: tt.currentVersion,
+				ExecutablePath: tt.executable,
+				GOOS:           "linux",
+				HomeDir:        home,
+				Env:            tt.env,
+				EvalSymlinks:   evalSymlinks,
+			})
+			if got.Source != tt.want {
+				t.Fatalf("Source = %q, want %q", got.Source, tt.want)
+			}
+			if tt.wantCommand != "" && got.Command != tt.wantCommand {
+				t.Fatalf("Command = %q, want %q", got.Command, tt.wantCommand)
+			}
+		})
+	}
+}
+
+func TestSelectReleaseAssetsAndVerifyChecksum(t *testing.T) {
+	t.Parallel()
+
+	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
+	archive := []byte("archive")
+	sum := sha256.Sum256(archive)
+	checksums := []byte(fmt.Sprintf("%x  %s\n", sum, archiveName))
+
+	assets, err := SelectReleaseAssets(Release{
+		TagName: "v1.2.4",
+		Assets: []Asset{
+			{Name: archiveName, BrowserDownloadURL: "https://example.invalid/archive"},
+			{Name: "detent_1.2.4_checksums.txt", BrowserDownloadURL: "https://example.invalid/checksums"},
+		},
+	}, "linux", "amd64")
+	if err != nil {
+		t.Fatalf("SelectReleaseAssets() error = %v", err)
+	}
+	if assets.Archive.Name != archiveName {
+		t.Fatalf("Archive.Name = %q, want %q", assets.Archive.Name, archiveName)
+	}
+	if err := VerifyChecksum(checksums, archiveName, archive); err != nil {
+		t.Fatalf("VerifyChecksum() error = %v", err)
+	}
+	if err := VerifyChecksum(checksums, archiveName, []byte("different")); err == nil {
+		t.Fatal("VerifyChecksum() error = nil, want checksum mismatch")
+	}
+}
+
+func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binary := filepath.Join(tmp, "bin", "detent")
+	lockPath := filepath.Join(tmp, "state", "install.lock")
+	if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
+		t.Fatalf("MkdirAll(binary dir) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte("binary="+binary+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(lock) error = %v", err)
+	}
+
+	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
+	checksumName := "detent_1.2.4_checksums.txt"
+	archive := detentUpdateArchive(t, "updated")
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%x  %s\n", sum, archiveName)
+
+	var server *httptest.Server
+	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases":
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprintf(w, `[{"tag_name":"v1.2.4","draft":false,"prerelease":false,"assets":[{"name":"%s","browser_download_url":"%s/archive"},{"name":"%s","browser_download_url":"%s/checksums"}]}]`, archiveName, server.URL, checksumName, server.URL)
+		case "/archive":
+			_, _ = w.Write(archive)
+		case "/checksums":
+			fmt.Fprint(w, checksums)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	service := NewService(Config{
+		CurrentVersion: "1.2.3",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: NewGitHubClient(GitHubClientConfig{
+			APIBase:    server.URL,
+			HTTPClient: server.Client(),
+		}),
+		Env: map[string]string{"DETENT_INSTALL_LOCK": lockPath},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if status.Action != ActionUpdated {
+		t.Fatalf("Action = %q, want %q", status.Action, ActionUpdated)
+	}
+	if !status.UpdateAvailable {
+		t.Fatal("UpdateAvailable = false, want true")
+	}
+	raw, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("ReadFile(binary) error = %v", err)
+	}
+	if strings.TrimSpace(string(raw)) != "updated" {
+		t.Fatalf("updated binary = %q, want updated", raw)
+	}
+}
+
+func detentUpdateArchive(t *testing.T, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	header := &tar.Header{
+		Name: "detent",
+		Mode: 0o755,
+		Size: int64(len(content)),
+	}
+	if err := tw.WriteHeader(header); err != nil {
+		t.Fatalf("WriteHeader() error = %v", err)
+	}
+	if _, err := tw.Write([]byte(content)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("tar Close() error = %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("gzip Close() error = %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -2,6 +2,7 @@ package update
 
 import (
 	"archive/tar"
+	"archive/zip"
 	"bytes"
 	"compress/gzip"
 	"context"
@@ -267,6 +268,86 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 	}
 }
 
+func TestReplaceBinaryStagesWindowsReplacement(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "detent.exe")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	var startedCommand string
+	var startedArgs []string
+	err := ReplaceBinary(Replacement{
+		Target: target,
+		Binary: []byte("new"),
+		Mode:   0o755,
+		GOOS:   "windows",
+		StartProcess: func(command string, args []string) error {
+			startedCommand = command
+			startedArgs = append(startedArgs, args...)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceBinary() error = %v", err)
+	}
+
+	raw, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target) error = %v", err)
+	}
+	if string(raw) != "old" {
+		t.Fatalf("target = %q, want original binary to remain until handoff runs", raw)
+	}
+	if startedCommand != "cmd.exe" {
+		t.Fatalf("startedCommand = %q, want cmd.exe", startedCommand)
+	}
+	if len(startedArgs) == 0 {
+		t.Fatal("startedArgs is empty")
+	}
+
+	stagedBinary, script := stagedWindowsUpdateFiles(t, tmp)
+	stagedRaw, err := os.ReadFile(stagedBinary)
+	if err != nil {
+		t.Fatalf("ReadFile(staged binary) error = %v", err)
+	}
+	if string(stagedRaw) != "new" {
+		t.Fatalf("staged binary = %q, want new", stagedRaw)
+	}
+
+	scriptRaw, err := os.ReadFile(script)
+	if err != nil {
+		t.Fatalf("ReadFile(script) error = %v", err)
+	}
+	scriptText := string(scriptRaw)
+	if !strings.Contains(scriptText, `move /Y "%source%" "%target%"`) {
+		t.Fatalf("script does not move staged binary into place:\n%s", scriptText)
+	}
+	if !strings.Contains(scriptText, `timeout /t 1 /nobreak`) {
+		t.Fatalf("script does not wait for the running binary lock:\n%s", scriptText)
+	}
+
+	joinedArgs := strings.Join(startedArgs, "\n")
+	if !strings.Contains(joinedArgs, script) {
+		t.Fatalf("startedArgs = %q, want script path %q", startedArgs, script)
+	}
+}
+
+func TestExtractBinaryReadsWindowsArchive(t *testing.T) {
+	t.Parallel()
+
+	archive := detentWindowsUpdateArchive(t, "updated")
+	raw, _, err := ExtractBinary(archive, "windows")
+	if err != nil {
+		t.Fatalf("ExtractBinary() error = %v", err)
+	}
+	if string(raw) != "updated" {
+		t.Fatalf("binary = %q, want updated", raw)
+	}
+}
+
 func detentUpdateArchive(t *testing.T, content string) []byte {
 	t.Helper()
 
@@ -291,4 +372,49 @@ func detentUpdateArchive(t *testing.T, content string) []byte {
 		t.Fatalf("gzip Close() error = %v", err)
 	}
 	return buf.Bytes()
+}
+
+func detentWindowsUpdateArchive(t *testing.T, content string) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	writer, err := zw.Create("detent.exe")
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if _, err := writer.Write([]byte(content)); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	if err := zw.Close(); err != nil {
+		t.Fatalf("zip Close() error = %v", err)
+	}
+	return buf.Bytes()
+}
+
+func stagedWindowsUpdateFiles(t *testing.T, dir string) (string, string) {
+	t.Helper()
+
+	var stagedBinary string
+	var script string
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, entry := range entries {
+		name := entry.Name()
+		switch {
+		case strings.HasPrefix(name, ".detent.exe.update-"):
+			stagedBinary = filepath.Join(dir, name)
+		case strings.HasPrefix(name, ".detent-update-") && strings.HasSuffix(name, ".cmd"):
+			script = filepath.Join(dir, name)
+		}
+	}
+	if stagedBinary == "" {
+		t.Fatal("staged binary was not created")
+	}
+	if script == "" {
+		t.Fatal("update script was not created")
+	}
+	return stagedBinary, script
 }


### PR DESCRIPTION
## Summary

- Add `detent update` with `--check`, `--yes`, and `--json` flows.
- Add release lookup, semver/prerelease selection, install-source detection, checksum verification, archive extraction, and atomic binary replacement for release-installer managed binaries.
- Delegate Homebrew updates, refuse Go/source/dev overwrite paths, record Windows installer metadata, and document the update command.

Fixes #297

## Test Plan

- [x] `go test ./...`
- [x] `make check`