### PR TITLE
perf(orchestrator): filter actionable status polls

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -33,6 +33,7 @@ query DetentGitHubProjectItems(
   $projectId: ID!
   $first: Int!
   $after: String
+  $query: String
   $projectItemFieldValuesFirst: Int!
   $linkedIssuesFirst: Int!
   $linkedProjectItemsFirst: Int!
@@ -40,7 +41,7 @@ query DetentGitHubProjectItems(
 ) {
   node(id: $projectId) {
     ... on ProjectV2 {
-      items(first: $first, after: $after) {
+      items(first: $first, after: $after, query: $query) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -796,7 +797,7 @@ func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue
 		return nil, ErrMissingProject
 	}
 
-	issues, err := c.fetchProjectItems(ctx, func(issue connector.Issue) bool {
+	issues, err := c.fetchProjectItems(ctx, c.projectStatusQuery(c.activeStates), func(issue connector.Issue) bool {
 		return stateInList(issue.State, c.activeStates)
 	})
 	if err != nil {
@@ -817,7 +818,7 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 		return nil, ErrMissingProject
 	}
 
-	issues, err := c.fetchProjectItems(ctx, func(issue connector.Issue) bool {
+	issues, err := c.fetchProjectItems(ctx, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
 		_, ok := wantedStates[normalizeStateName(issue.State)]
 		return ok
 	})
@@ -1317,10 +1318,14 @@ func attachMatchingPullRequests(
 	}
 }
 
-func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
+func (c *Connector) fetchProjectItems(ctx context.Context, query string, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
 	var after *string
 	allIssues := []connector.Issue{}
 	blankStatusItemIDs := []string{}
+	var projectQuery *string
+	if query != "" {
+		projectQuery = &query
+	}
 
 	for {
 		var response struct {
@@ -1332,6 +1337,7 @@ func (c *Connector) fetchProjectItems(ctx context.Context, keepIssue func(connec
 			"projectId":                         c.projectID,
 			"first":                             projectItemsPageSize,
 			"after":                             after,
+			"query":                             projectQuery,
 			"projectItemFieldValuesFirst":       projectItemFieldValuesPageSize,
 			"linkedIssuesFirst":                 linkedIssuePageSize,
 			"linkedProjectItemsFirst":           linkedIssueProjectItemsPageSize,
@@ -2001,7 +2007,70 @@ func (c *Connector) detentToGitHubState(stateName string) string {
 	if mapped, ok := c.stateMap[stateName]; ok {
 		return strings.TrimSpace(mapped)
 	}
+	normalized := normalizeStateName(stateName)
+	for detentState, mapped := range c.stateMap {
+		if normalizeStateName(detentState) == normalized {
+			return strings.TrimSpace(mapped)
+		}
+	}
 	return stateName
+}
+
+func (c *Connector) detentToGitHubStates(stateNames []string) []string {
+	states := make([]string, 0, len(stateNames))
+	seen := make(map[string]struct{}, len(stateNames))
+	for _, stateName := range stateNames {
+		state := c.detentToGitHubState(stateName)
+		key := normalizeStateName(state)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		states = append(states, state)
+	}
+	return states
+}
+
+func (c *Connector) projectStatusQuery(stateNames []string) string {
+	if stateInList(defaultProjectItemStatusState, stateNames) {
+		return ""
+	}
+	states := c.detentToGitHubStates(stateNames)
+	if len(states) == 0 {
+		return ""
+	}
+
+	values := make([]string, 0, len(states))
+	for _, state := range states {
+		values = append(values, projectFilterValue(state))
+	}
+	return "status:" + strings.Join(values, ",")
+}
+
+func projectFilterValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return ""
+	}
+	for _, r := range value {
+		if r >= 'a' && r <= 'z' {
+			continue
+		}
+		if r >= 'A' && r <= 'Z' {
+			continue
+		}
+		if r >= '0' && r <= '9' {
+			continue
+		}
+		if r == '_' || r == '-' || r == '.' {
+			continue
+		}
+		return strconv.Quote(value)
+	}
+	return value
 }
 
 func (c *Connector) githubToDetentState(githubState string) string {

--- a/internal/connector/github/adapter_parity_test.go
+++ b/internal/connector/github/adapter_parity_test.go
@@ -117,6 +117,9 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 	if fetchVariables["projectId"] != "PVT_throwaway" {
 		t.Fatalf("fetch projectId = %v, want PVT_throwaway", fetchVariables["projectId"])
 	}
+	if fetchVariables["query"] != `status:Ready,"In Progress",Merging,Rework` {
+		t.Fatalf("fetch query = %v, want actionable statuses", fetchVariables["query"])
+	}
 	if !strings.Contains(requests[3]["query"].(string), "ProjectV2") {
 		t.Fatalf("fetch query = %q, want ProjectV2", requests[3]["query"])
 	}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -77,6 +77,9 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	if variables["first"] != float64(50) {
 		t.Fatalf("first = %v, want 50", variables["first"])
 	}
+	if variables["query"] != "status:Ready" {
+		t.Fatalf("query = %v, want status:Ready", variables["query"])
+	}
 	if variables["projectItemFieldValuesFirst"] != float64(projectItemFieldValuesPageSize) {
 		t.Fatalf("projectItemFieldValuesFirst = %v, want %d", variables["projectItemFieldValuesFirst"], projectItemFieldValuesPageSize)
 	}
@@ -167,6 +170,30 @@ func TestProjectFieldValues(t *testing.T) {
 				t.Fatalf("projectFieldValues() = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestProjectStatusQueryFormatsMappedStatuses(t *testing.T) {
+	t.Parallel()
+
+	c := &Connector{stateMap: map[string]string{
+		"Todo":         "Ready",
+		"Human Review": "In Review",
+	}}
+
+	got := c.projectStatusQuery([]string{"Todo", "In Progress", "Human Review", "Rework", "Blocked", "Merging"})
+	want := `status:Ready,"In Progress","In Review",Rework,Blocked,Merging`
+	if got != want {
+		t.Fatalf("projectStatusQuery() = %q, want %q", got, want)
+	}
+	for _, forbidden := range []string{"Backlog", "Done"} {
+		if strings.Contains(got, forbidden) {
+			t.Fatalf("projectStatusQuery() = %q, want no %s", got, forbidden)
+		}
+	}
+
+	if got := c.projectStatusQuery([]string{"Backlog"}); got != "" {
+		t.Fatalf("projectStatusQuery(Backlog) = %q, want empty query", got)
 	}
 }
 
@@ -547,6 +574,11 @@ func TestConnectorFetchIssuesByStatesFiltersMappedStates(t *testing.T) {
 	}
 	if ids := githubIssueIDs(got); !reflect.DeepEqual(ids, []string{"I_kw1"}) {
 		t.Fatalf("FetchIssuesByStates() ids = %#v, want [I_kw1]", ids)
+	}
+	requests := server.requests()
+	queryVariables := requests[0]["variables"].(map[string]any)
+	if queryVariables["query"] != "status:Ready" {
+		t.Fatalf("query = %v, want status:Ready", queryVariables["query"])
 	}
 
 	requestsBeforeEmpty := len(server.requests())

--- a/internal/orchestrator/epic_test.go
+++ b/internal/orchestrator/epic_test.go
@@ -94,10 +94,8 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 			candidates: []connector.Issue{
 				epicTestIssue("epic-258", "Todo", false, "Epic: Release readiness", []string{"epic"}, "- [ ] #251\n- [ ] #252"),
 			},
-			stateIssues: []connector.Issue{
-				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
-			},
 			resolved: []connector.Issue{
+				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
 				epicTestIssue("child-252", "Open", true, "Child 252", nil, ""),
 			},
 			wantUpdates:  []epicStateUpdate{{issueID: "epic-258", state: "Done"}},
@@ -110,7 +108,7 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 				epicTestIssue("epic-258", "Todo", false, "Epic: Release readiness", []string{"epic"}, "- [ ] #251\n- [ ] #252"),
 				epicTestIssue("child-252", "In Progress", false, "Child 252", nil, ""),
 			},
-			stateIssues: []connector.Issue{
+			resolved: []connector.Issue{
 				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
 			},
 		},
@@ -142,7 +140,7 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 			},
 		},
 		{
-			name: "open done epic is closed without status update",
+			name: "open done epic is not fetched by recurring scan",
 			stateIssues: []connector.Issue{
 				func() connector.Issue {
 					issue := epicTestIssue("epic-258", "Done", false, "Epic: Release readiness", []string{"epic"}, "")
@@ -151,11 +149,9 @@ func TestTickFinalizesCompletedEpics(t *testing.T) {
 				}(),
 				epicTestIssue("child-251", "Done", false, "Child 251", nil, ""),
 			},
-			wantClosed:   []string{"epic-258"},
-			wantComments: []string{"Auto-closing completed epic: 1 child issue is Done."},
 		},
 		{
-			name: "open done epic close failure does not comment",
+			name: "open done epic close failure is not reached by recurring scan",
 			stateIssues: []connector.Issue{
 				func() connector.Issue {
 					issue := epicTestIssue("epic-258", "Done", false, "Epic: Release readiness", []string{"epic"}, "")

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -32,7 +32,7 @@ const (
 	blockedReasonProjectStatus      = "blocked by project status"
 )
 
-var prPipelineStates = []string{"Human Review", "Merging", "Done"}
+var prPipelineStates = []string{"Human Review", "Merging"}
 
 var (
 	ErrMissingConnector = errors.New("orchestrator connector is required")
@@ -300,7 +300,7 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		o.logger.Warn("fetch candidate issues failed", "error", err)
 		return
 	}
-	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, observedStatusFetchStates(o.cfg.TerminalStates))
+	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, observedStatusFetchStates())
 	if statusErr != nil {
 		o.logger.Warn("fetch observed status issues failed", "error", statusErr)
 	}
@@ -308,7 +308,7 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	issues = cloneIssues(issues)
 	if statusErr == nil {
 		statusIssues = cloneIssues(statusIssues)
-		state.Pipeline = issuesInStates(statusIssues, prPipelineFetchStates(o.cfg.TerminalStates))
+		state.Pipeline = issuesInStates(statusIssues, prPipelineFetchStates())
 	}
 	observedIssues := cloneIssues(issues)
 	if statusErr == nil {
@@ -324,14 +324,14 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	o.dispatchReadyIssues(ctx, state, issues, now)
 }
 
-func observedStatusFetchStates(terminalStates []string) []string {
-	return append([]string{blockedStatusState}, prPipelineFetchStates(terminalStates)...)
+func observedStatusFetchStates() []string {
+	return append([]string{blockedStatusState}, prPipelineFetchStates()...)
 }
 
-func prPipelineFetchStates(terminalStates []string) []string {
-	states := make([]string, 0, len(prPipelineStates)+len(terminalStates))
-	seen := make(map[string]struct{}, len(prPipelineStates)+len(terminalStates))
-	for _, state := range append(append([]string(nil), prPipelineStates...), terminalStates...) {
+func prPipelineFetchStates() []string {
+	states := make([]string, 0, len(prPipelineStates))
+	seen := make(map[string]struct{}, len(prPipelineStates))
+	for _, state := range prPipelineStates {
 		key := normalizeState(state)
 		if key == "" {
 			continue

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -559,7 +559,7 @@ func TestRunTracksBlockedStatusIssuesForDisplayOnly(t *testing.T) {
 	}
 }
 
-func TestRunFetchesPipelineTerminalStates(t *testing.T) {
+func TestRunFetchesOnlyActionableObservedStates(t *testing.T) {
 	t.Parallel()
 
 	tracker := newFakeConnector()
@@ -570,10 +570,17 @@ func TestRunFetchesPipelineTerminalStates(t *testing.T) {
 	waitForFetchByStatesCalls(t, tracker, 1)
 
 	got := tracker.fetchByStatesRequests()
-	want := []string{"Blocked", "Human Review", "Merging", "Done", "Cancelled", "Canceled", "Closed"}
+	want := []string{"Blocked", "Human Review", "Merging"}
 	for _, request := range got {
 		if !stateRequestsContain([][]string{request}, want) {
 			t.Fatalf("FetchIssuesByStates request = %#v, want combined status request containing %#v; all requests = %#v", request, want, got)
+		}
+		for _, forbidden := range []string{"Backlog", "Done", "Cancelled", "Canceled", "Closed"} {
+			for _, state := range request {
+				if strings.EqualFold(strings.TrimSpace(state), forbidden) {
+					t.Fatalf("FetchIssuesByStates request = %#v, want no non-actionable state %q", request, forbidden)
+				}
+			}
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- add ProjectV2 status query filtering for candidate and status fetches
- stop recurring observed-state polls from requesting Done/terminal states
- cover actionable query formatting and Done/Backlog exclusion in tests

Fixes #302

## Test Plan

- [x] `go test -count=1 ./internal/connector/github`
- [x] `go test -count=1 ./internal/orchestrator`
- [x] `make check`