### PR TITLE
fix(runner): reap agent worktrees

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,6 +247,8 @@ workspace:
   root: /absolute/path/to/detent-workspaces
   source_root: /absolute/path/to/project-checkout
   auto_branch: true
+  cleanup_idle_ttl_ms: 86400000
+  cleanup_sweep_interval_ms: 600000
 agent:
   max_concurrent_agents: 5
   max_turns: 20
@@ -295,6 +297,11 @@ human review.
 If `workspace.source_root` is omitted, Detent falls back to the project
 `workdir` from global config, then to `workspace.root` for older single-root
 setups.
+
+`workspace.cleanup_idle_ttl_ms` controls how long non-active observed
+workspaces can sit idle before cleanup. Terminal issues are cleaned immediately
+when observed. `workspace.cleanup_sweep_interval_ms` controls the startup and
+periodic cleanup cadence.
 
 `polling.interval_ms` defaults to `120000` and must be at least `60000`.
 Detent work is async, so it does not need sub-minute board scans. Detent polls

--- a/internal/codex/process_group_other.go
+++ b/internal/codex/process_group_other.go
@@ -1,0 +1,26 @@
+//go:build !unix
+
+package codex
+
+import "os/exec"
+
+func configureCommandProcessGroup(cmd *exec.Cmd) {
+	cmd.Cancel = func() error {
+		return terminateCommandProcessTree(cmd, 0)
+	}
+}
+
+func commandProcessGroupID(*exec.Cmd) int {
+	return 0
+}
+
+func terminateCommandProcessTree(cmd *exec.Cmd, _ int) error {
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+func cleanupCommandProcessGroup(int) error {
+	return nil
+}

--- a/internal/codex/process_group_unix.go
+++ b/internal/codex/process_group_unix.go
@@ -1,0 +1,55 @@
+//go:build unix
+
+package codex
+
+import (
+	"errors"
+	"os/exec"
+	"syscall"
+)
+
+func configureCommandProcessGroup(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.Cancel = func() error {
+		return terminateCommandProcessTree(cmd, commandProcessGroupID(cmd))
+	}
+}
+
+func commandProcessGroupID(cmd *exec.Cmd) int {
+	if cmd == nil || cmd.Process == nil {
+		return 0
+	}
+	pgid, err := syscall.Getpgid(cmd.Process.Pid)
+	if err != nil || pgid <= 0 {
+		return cmd.Process.Pid
+	}
+	return pgid
+}
+
+func terminateCommandProcessTree(cmd *exec.Cmd, processGroupID int) error {
+	if processGroupID > 0 {
+		err := syscall.Kill(-processGroupID, syscall.SIGKILL)
+		if err == nil || errors.Is(err, syscall.ESRCH) {
+			return nil
+		}
+		return err
+	}
+	if cmd == nil || cmd.Process == nil {
+		return nil
+	}
+	return cmd.Process.Kill()
+}
+
+func cleanupCommandProcessGroup(processGroupID int) error {
+	if processGroupID <= 0 {
+		return nil
+	}
+	err := syscall.Kill(-processGroupID, syscall.SIGKILL)
+	if err == nil || errors.Is(err, syscall.ESRCH) {
+		return nil
+	}
+	return err
+}

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -29,17 +29,18 @@ type LocalTransportFactory struct {
 }
 
 type localTransport struct {
-	cmd       *exec.Cmd
-	stdin     io.WriteCloser
-	codec     *Codec
-	received  chan transportResult
-	readDone  chan struct{}
-	done      chan struct{}
-	sendLock  chan struct{}
-	waitErr   error
-	waitMu    sync.Mutex
-	closeOnce sync.Once
-	closeErr  error
+	cmd            *exec.Cmd
+	processGroupID int
+	stdin          io.WriteCloser
+	codec          *Codec
+	received       chan transportResult
+	readDone       chan struct{}
+	done           chan struct{}
+	sendLock       chan struct{}
+	waitErr        error
+	waitMu         sync.Mutex
+	closeOnce      sync.Once
+	closeErr       error
 }
 
 type transportResult struct {
@@ -74,19 +75,21 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		return nil, fmt.Errorf("create stdout pipe: %w", err)
 	}
 
+	configureCommandProcessGroup(cmd)
 	if err := cmd.Start(); err != nil {
 		_ = stdin.Close()
 		return nil, fmt.Errorf("start command: %w", err)
 	}
 
 	transport := &localTransport{
-		cmd:      cmd,
-		stdin:    stdin,
-		codec:    NewCodec(stdout, stdin),
-		received: make(chan transportResult, 64),
-		readDone: make(chan struct{}),
-		done:     make(chan struct{}),
-		sendLock: make(chan struct{}, 1),
+		cmd:            cmd,
+		processGroupID: commandProcessGroupID(cmd),
+		stdin:          stdin,
+		codec:          NewCodec(stdout, stdin),
+		received:       make(chan transportResult, 64),
+		readDone:       make(chan struct{}),
+		done:           make(chan struct{}),
+		sendLock:       make(chan struct{}, 1),
 	}
 	transport.sendLock <- struct{}{}
 
@@ -155,9 +158,7 @@ func (t *localTransport) Close(ctx context.Context) error {
 		return t.waitError()
 	case <-ctx.Done():
 		var killErr error
-		if t.cmd.Process != nil {
-			killErr = t.cmd.Process.Kill()
-		}
+		killErr = terminateCommandProcessTree(t.cmd, t.processGroupID)
 
 		select {
 		case <-t.done:
@@ -238,6 +239,9 @@ func (t *localTransport) readLoop() {
 func (t *localTransport) wait() {
 	<-t.readDone
 	err := t.cmd.Wait()
+	if cleanupErr := cleanupCommandProcessGroup(t.processGroupID); cleanupErr != nil {
+		err = errors.Join(err, cleanupErr)
+	}
 	t.waitMu.Lock()
 	t.waitErr = err
 	t.waitMu.Unlock()

--- a/internal/codex/transport_unix_test.go
+++ b/internal/codex/transport_unix_test.go
@@ -1,0 +1,118 @@
+//go:build unix
+
+package codex
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+)
+
+func TestLocalTransportReapsChildAfterParentExits(t *testing.T) {
+	t.Parallel()
+
+	pidPath := t.TempDir() + "/child.pid"
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c", "sleep 3600 >/dev/null 2>&1 & printf '%s\n' \"$!\" > "+shellQuote(pidPath))
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+
+	transport, err := factory.NewTransport(context.Background())
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	pid := waitForPIDFile(t, pidPath)
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := transport.Close(closeCtx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	waitForProcessExit(t, pid)
+}
+
+func TestLocalTransportCloseKillsChildProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	pidPath := t.TempDir() + "/child.pid"
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return exec.CommandContext(ctx, "sh", "-c", "sleep 3600 & printf '%s\n' \"$!\" > "+shellQuote(pidPath)+"; wait")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+
+	transport, err := factory.NewTransport(context.Background())
+	if err != nil {
+		t.Fatalf("NewTransport() error = %v", err)
+	}
+	pid := waitForPIDFile(t, pidPath)
+
+	closeCtx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+	if err := transport.Close(closeCtx); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Close() error = %v, want context deadline exceeded", err)
+	}
+	waitForProcessExit(t, pid)
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+			if parseErr != nil {
+				t.Fatalf("parse pid file: %v", parseErr)
+			}
+			if pid <= 0 {
+				t.Fatalf("pid = %d, want positive", pid)
+			}
+			return pid
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for pid file: %v", err)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		if !processAlive(pid) {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("process %d is still alive", pid)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -104,9 +104,11 @@ type Claims struct {
 }
 
 type Workspace struct {
-	Root       string `yaml:"root"`
-	SourceRoot string `yaml:"source_root"`
-	AutoBranch bool   `yaml:"auto_branch"`
+	Root                   string `yaml:"root"`
+	SourceRoot             string `yaml:"source_root"`
+	AutoBranch             bool   `yaml:"auto_branch"`
+	CleanupIdleTTLMS       int    `yaml:"cleanup_idle_ttl_ms"`
+	CleanupSweepIntervalMS int    `yaml:"cleanup_sweep_interval_ms"`
 }
 
 type Worker struct {
@@ -445,8 +447,10 @@ func Default() Config {
 			IntervalMS: DefaultPollingIntervalMS,
 		},
 		Workspace: Workspace{
-			Root:       filepath.Join(os.TempDir(), "detent_workspaces"),
-			AutoBranch: true,
+			Root:                   filepath.Join(os.TempDir(), "detent_workspaces"),
+			AutoBranch:             true,
+			CleanupIdleTTLMS:       86400000,
+			CleanupSweepIntervalMS: 600000,
 		},
 		Worker: Worker{
 			SSHHosts: []string{},
@@ -518,6 +522,7 @@ func (c *Config) Validate() error {
 	problems = append(problems, c.Identity.Validate("identity")...)
 	c.validateTracker(&problems)
 	validatePollingInterval(c.Polling.IntervalMS, &problems)
+	c.Workspace.validate(&problems)
 	if c.Worker.MaxConcurrentAgentsPerHost != nil {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
 	}
@@ -635,6 +640,11 @@ func (t *Tracker) hasGitHubAppCredentials() bool {
 	return strings.TrimSpace(t.GitHubAppID) != "" &&
 		strings.TrimSpace(t.GitHubAppInstallationID) != "" &&
 		(strings.TrimSpace(t.GitHubAppPrivateKey) != "" || strings.TrimSpace(t.GitHubAppPrivateKeyPath) != "")
+}
+
+func (w *Workspace) validate(problems *[]string) {
+	validatePositive("workspace.cleanup_idle_ttl_ms", w.CleanupIdleTTLMS, problems)
+	validatePositive("workspace.cleanup_sweep_interval_ms", w.CleanupSweepIntervalMS, problems)
 }
 
 func (a *Agent) validate(prefix string, problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -53,6 +53,8 @@ polling:
 workspace:
   root: ~/code/detent-workspaces
   auto_branch: false
+  cleanup_idle_ttl_ms: 7200000
+  cleanup_sweep_interval_ms: 120000
 worker:
   ssh_hosts:
     - worker-1
@@ -158,6 +160,12 @@ Ticket prompt {{ issue.title }}
 	if cfg.Tracker.HTTPIdleConnTimeoutMS != 120000 {
 		t.Fatalf("Tracker.HTTPIdleConnTimeoutMS = %d, want 120000", cfg.Tracker.HTTPIdleConnTimeoutMS)
 	}
+	if cfg.Workspace.CleanupIdleTTLMS != 7200000 {
+		t.Fatalf("Workspace.CleanupIdleTTLMS = %d, want 7200000", cfg.Workspace.CleanupIdleTTLMS)
+	}
+	if cfg.Workspace.CleanupSweepIntervalMS != 120000 {
+		t.Fatalf("Workspace.CleanupSweepIntervalMS = %d, want 120000", cfg.Workspace.CleanupSweepIntervalMS)
+	}
 	if !cfg.Tracker.Claims.Enabled {
 		t.Fatal("Tracker.Claims.Enabled = false, want true")
 	}
@@ -252,6 +260,12 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Workspace.AutoBranch != true {
 		t.Fatal("Workspace.AutoBranch = false, want true")
+	}
+	if cfg.Workspace.CleanupIdleTTLMS != 86400000 {
+		t.Fatalf("Workspace.CleanupIdleTTLMS = %d, want 86400000", cfg.Workspace.CleanupIdleTTLMS)
+	}
+	if cfg.Workspace.CleanupSweepIntervalMS != 600000 {
+		t.Fatalf("Workspace.CleanupSweepIntervalMS = %d, want 600000", cfg.Workspace.CleanupSweepIntervalMS)
 	}
 	if cfg.Agent.MaxConcurrentAgents != 10 {
 		t.Fatalf("Agent.MaxConcurrentAgents = %d, want 10", cfg.Agent.MaxConcurrentAgents)
@@ -642,6 +656,9 @@ polling:
   interval_ms: 0
 worker:
   max_concurrent_agents_per_host: 0
+workspace:
+  cleanup_idle_ttl_ms: 0
+  cleanup_sweep_interval_ms: 0
 agent:
   max_concurrent_agents: 0
   max_concurrent_agents_by_state:
@@ -667,6 +684,8 @@ Prompt
 				"tracker.http_idle_conn_timeout_ms must be greater than 0",
 				"polling.interval_ms must be greater than 0",
 				"worker.max_concurrent_agents_per_host must be greater than 0",
+				"workspace.cleanup_idle_ttl_ms must be greater than 0",
+				"workspace.cleanup_sweep_interval_ms must be greater than 0",
 				"agent.max_concurrent_agents must be greater than 0",
 				"agent.max_concurrent_agents_by_state limits must be positive integers",
 				"agent.dispatch_priority_by_state state names must be unique",

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -715,6 +715,32 @@ func TestDispatchIssueIncludesSelectorContext(t *testing.T) {
 	}
 }
 
+func TestDispatchIssueClearsReapedWorkspaceMarker(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+	})
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, FakeRunner{}, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+	}
+	state := newState(cfg)
+	now := time.Now()
+	issue := dispatchTestIssue("issue-reopened", "Todo")
+	state.ReapedWorkspaces[issue.ID] = now.Add(-time.Hour)
+
+	if !orch.dispatchIssue(context.Background(), &state, issue, 0, now, "") {
+		t.Fatal("dispatchIssue() = false, want true")
+	}
+	if _, ok := state.ReapedWorkspaces[issue.ID]; ok {
+		t.Fatalf("ReapedWorkspaces[%q] present after dispatch", issue.ID)
+	}
+}
+
 func TestSelectWorkerHostKeepsPreferredHostWhenAvailable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -20,6 +20,8 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg := workflowconfig.Default()
 	cfg.Worker.SSHHosts = []string{"worker-a", "worker-b"}
 	cfg.Worker.MaxConcurrentAgentsPerHost = &perHost
+	cfg.Workspace.CleanupIdleTTLMS = 7200000
+	cfg.Workspace.CleanupSweepIntervalMS = 120000
 	cfg.Budget.RefusalCooldownSeconds = 45
 	cfg.Agent.AutoPromote.Enabled = true
 	cfg.Agent.AutoPromote.QuietSeconds = 30
@@ -46,6 +48,12 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.BudgetRefusalCooldown != 45*time.Second {
 		t.Fatalf("BudgetRefusalCooldown = %s, want 45s", got.BudgetRefusalCooldown)
+	}
+	if got.WorkspaceCleanupIdleTTL != 2*time.Hour {
+		t.Fatalf("WorkspaceCleanupIdleTTL = %s, want 2h0m0s", got.WorkspaceCleanupIdleTTL)
+	}
+	if got.WorkspaceCleanupSweepInterval != 2*time.Minute {
+		t.Fatalf("WorkspaceCleanupSweepInterval = %s, want 2m0s", got.WorkspaceCleanupSweepInterval)
 	}
 	if !got.AutoPromote.Enabled {
 		t.Fatal("AutoPromote.Enabled = false, want true")

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -962,6 +962,7 @@ func (o *Orchestrator) dispatchIssue(
 	delete(state.Retry, issue.ID)
 	delete(state.Blocked, issue.ID)
 	delete(state.BudgetRefusals, issue.ID)
+	delete(state.ReapedWorkspaces, issue.ID)
 
 	request := RunRequest{
 		Issue:           issue,

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,6 +19,8 @@ import (
 const (
 	defaultPollInterval             = 30 * time.Second
 	defaultRunningReconcileInterval = 2 * time.Minute
+	defaultWorkspaceCleanupIdleTTL  = 24 * time.Hour
+	defaultWorkspaceCleanupSweep    = 10 * time.Minute
 	gitHubGraphQLPauseRemaining     = 100
 	gitHubGraphQLBackoffRemaining   = 500
 	defaultMaxConcurrentAgents      = 1
@@ -40,23 +42,26 @@ var (
 )
 
 type Config struct {
-	PollInterval               time.Duration
-	MaxConcurrentAgents        int
-	MaxConcurrentAgentsByState map[string]int
-	DispatchPriorityByState    []string
-	MaxConcurrentAgentsPerHost int
-	MaxRetryBackoff            time.Duration
-	Claiming                   ClaimingConfig
-	AutoPromote                AutoPromoteConfig
-	ActiveStates               []string
-	TerminalStates             []string
-	Authorization              selector.Selector
-	SelectorContext            selector.Context
-	WorkerHosts                []string
-	BudgetRefusalCooldown      time.Duration
-	ContinuationRetryDelay     time.Duration
-	FailureRetryBaseDelay      time.Duration
-	SelectorPersona            string
+	PollInterval                  time.Duration
+	MaxConcurrentAgents           int
+	MaxConcurrentAgentsByState    map[string]int
+	DispatchPriorityByState       []string
+	MaxConcurrentAgentsPerHost    int
+	MaxRetryBackoff               time.Duration
+	Claiming                      ClaimingConfig
+	AutoPromote                   AutoPromoteConfig
+	ActiveStates                  []string
+	ObservedStates                []string
+	TerminalStates                []string
+	Authorization                 selector.Selector
+	SelectorContext               selector.Context
+	WorkerHosts                   []string
+	BudgetRefusalCooldown         time.Duration
+	WorkspaceCleanupIdleTTL       time.Duration
+	WorkspaceCleanupSweepInterval time.Duration
+	ContinuationRetryDelay        time.Duration
+	FailureRetryBaseDelay         time.Duration
+	SelectorPersona               string
 }
 
 type ClaimingConfig struct {
@@ -71,10 +76,15 @@ type ClaimingConfig struct {
 }
 
 type Dependencies struct {
-	Connector connector.Connector
-	Runner    Runner
-	Logger    *slog.Logger
+	Connector       connector.Connector
+	Runner          Runner
+	WorkspaceReaper WorkspaceReaper
+	Logger          *slog.Logger
 }
+
+type WorkspaceReapResult = runpkg.WorkspaceReapResult
+
+type WorkspaceReaper = runpkg.WorkspaceReaper
 
 type RuntimeUpdate struct {
 	Config    Config
@@ -85,6 +95,7 @@ type Orchestrator struct {
 	cfg           Config
 	connector     connector.Connector
 	supervisor    *runpkg.Supervisor
+	reaper        WorkspaceReaper
 	logger        *slog.Logger
 	stateRequests chan stateRequest
 	configUpdates chan configUpdateRequest
@@ -136,13 +147,16 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			AllowedIssueLabels: append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
 			Gate:               gate.Effective(cfg.Gate),
 		}),
-		ActiveStates:          append([]string(nil), cfg.Tracker.ActiveStates...),
-		TerminalStates:        append([]string(nil), cfg.Tracker.TerminalStates...),
-		Authorization:         cfg.Tracker.Authorization,
-		SelectorContext:       selector.Context{InstanceLogin: identity.GitHubLogin, Persona: identity.Name},
-		WorkerHosts:           append([]string(nil), cfg.Worker.SSHHosts...),
-		BudgetRefusalCooldown: durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
-		SelectorPersona:       cfg.Tracker.Assignee,
+		ActiveStates:                  append([]string(nil), cfg.Tracker.ActiveStates...),
+		ObservedStates:                append([]string(nil), cfg.Tracker.ObservedStates...),
+		TerminalStates:                append([]string(nil), cfg.Tracker.TerminalStates...),
+		Authorization:                 cfg.Tracker.Authorization,
+		SelectorContext:               selector.Context{InstanceLogin: identity.GitHubLogin, Persona: identity.Name},
+		WorkerHosts:                   append([]string(nil), cfg.Worker.SSHHosts...),
+		BudgetRefusalCooldown:         durationFromSeconds(cfg.Budget.RefusalCooldownSeconds),
+		WorkspaceCleanupIdleTTL:       durationFromMillis(cfg.Workspace.CleanupIdleTTLMS),
+		WorkspaceCleanupSweepInterval: durationFromMillis(cfg.Workspace.CleanupSweepIntervalMS),
+		SelectorPersona:               cfg.Tracker.Assignee,
 	}
 }
 
@@ -155,6 +169,12 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	runner := deps.Runner
 	if runner == nil {
 		runner = FakeRunner{}
+	}
+	reaper := deps.WorkspaceReaper
+	if reaper == nil {
+		if candidate, ok := runner.(WorkspaceReaper); ok {
+			reaper = candidate
+		}
 	}
 
 	logger := deps.Logger
@@ -175,6 +195,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		cfg:           cfg,
 		connector:     deps.Connector,
 		supervisor:    supervisor,
+		reaper:        reaper,
 		logger:        logger,
 		stateRequests: make(chan stateRequest),
 		configUpdates: make(chan configUpdateRequest),
@@ -292,6 +313,7 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		return
 	}
 
+	o.reapWorkspacesIfDue(ctx, state, now)
 	o.reconcileRunningIssues(ctx, state, now)
 	o.heartbeatRunningClaims(ctx, state, now)
 
@@ -406,6 +428,9 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 		running := state.Running[id]
 		running.Issue = mergeIssueTrackerFields(running.Issue, issue)
 		state.Running[id] = running
+		if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+			cancelRunning(state, id)
+		}
 
 		if claimed, ok := state.Claimed[id]; ok {
 			claimed.Issue = mergeIssueTrackerFields(claimed.Issue, issue)
@@ -1024,6 +1049,14 @@ func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
 	}
 	delete(state.Running, event.IssueID)
 
+	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		delete(state.Claimed, event.IssueID)
+		delete(state.Retry, event.IssueID)
+		delete(state.BudgetRefusals, event.IssueID)
+		o.reapWorkspace(context.Background(), state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates))
+		return
+	}
+
 	if event.Err != nil {
 		attempt := event.RetryAttempt
 		if attempt < 1 {
@@ -1192,8 +1225,15 @@ func normalizeConfig(cfg Config) Config {
 	if len(cfg.TerminalStates) == 0 {
 		cfg.TerminalStates = []string{"Done", "Cancelled", "Canceled", "Closed"}
 	}
+	if cfg.WorkspaceCleanupIdleTTL <= 0 {
+		cfg.WorkspaceCleanupIdleTTL = defaultWorkspaceCleanupIdleTTL
+	}
+	if cfg.WorkspaceCleanupSweepInterval <= 0 {
+		cfg.WorkspaceCleanupSweepInterval = defaultWorkspaceCleanupSweep
+	}
 
 	cfg.ActiveStates = normalizedStates(cfg.ActiveStates)
+	cfg.ObservedStates = normalizedStates(cfg.ObservedStates)
 	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -559,6 +559,89 @@ func TestRunTracksBlockedStatusIssuesForDisplayOnly(t *testing.T) {
 	}
 }
 
+func TestRunReapsTerminalWorkspacesOnStartupSweep(t *testing.T) {
+	t.Parallel()
+
+	done := testIssue("issue-done", "digitaldrywood/detent#80", "Done")
+	reaper := &fakeWorkspaceReaper{result: orchestrator.WorkspaceReapResult{Worktrees: 1, Branches: 1}}
+	tracker := newFakeConnector()
+	tracker.setStateIssues(done)
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:                  time.Hour,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		ObservedStates:                []string{"Human Review"},
+		WorkspaceCleanupIdleTTL:       time.Hour,
+		WorkspaceCleanupSweepInterval: time.Hour,
+	}, orchestrator.Dependencies{
+		Connector:       tracker,
+		Runner:          &staticRunner{},
+		WorkspaceReaper: reaper,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	reaped := waitForWorkspaceReaps(t, reaper, 1)
+	if reaped[0].ID != done.ID {
+		t.Fatalf("reaped issue ID = %q, want %q", reaped[0].ID, done.ID)
+	}
+	if !stateRequestsContain(tracker.fetchByStatesRequests(), []string{"Done", "Cancelled", "Human Review"}) {
+		t.Fatalf("FetchIssuesByStates requests = %#v, want cleanup request", tracker.fetchByStatesRequests())
+	}
+}
+
+func TestRunReapsIdleObservedWorkspacesWithoutTouchingActiveIssues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	staleAt := now.Add(-2 * time.Hour)
+	recentAt := now.Add(-5 * time.Minute)
+	idle := testIssue("issue-review", "digitaldrywood/detent#81", "Human Review")
+	idle.StageUpdatedAt = &staleAt
+	recent := testIssue("issue-blocked", "digitaldrywood/detent#82", "Blocked")
+	recent.StageUpdatedAt = &recentAt
+	active := testIssue("issue-active", "digitaldrywood/detent#83", "In Progress")
+	active.StageUpdatedAt = &staleAt
+
+	reaper := &fakeWorkspaceReaper{result: orchestrator.WorkspaceReapResult{Worktrees: 1}}
+	tracker := newFakeConnector()
+	tracker.setStateIssues(idle, recent, active)
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:                  time.Hour,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework"},
+		TerminalStates:                []string{"Done"},
+		ObservedStates:                []string{"Human Review", "Blocked", "In Progress"},
+		WorkspaceCleanupIdleTTL:       time.Hour,
+		WorkspaceCleanupSweepInterval: time.Hour,
+	}, orchestrator.Dependencies{
+		Connector:       tracker,
+		Runner:          &staticRunner{},
+		WorkspaceReaper: reaper,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	reaped := waitForWorkspaceReaps(t, reaper, 1)
+	if reaped[0].ID != idle.ID {
+		t.Fatalf("reaped issue ID = %q, want %q", reaped[0].ID, idle.ID)
+	}
+
+	time.Sleep(25 * time.Millisecond)
+	if got := reaper.reapedIssues(); len(got) != 1 {
+		t.Fatalf("reaped issues = %#v, want only idle issue", got)
+	}
+}
+
 func TestRunFetchesOnlyActionableObservedStates(t *testing.T) {
 	t.Parallel()
 
@@ -978,6 +1061,56 @@ type staticRunner struct {
 func (r *staticRunner) Run(context.Context, orchestrator.RunRequest) (orchestrator.RunResult, error) {
 	r.calls.Add(1)
 	return r.result, r.err
+}
+
+type fakeWorkspaceReaper struct {
+	mu      sync.Mutex
+	result  orchestrator.WorkspaceReapResult
+	issues  []connector.Issue
+	changed chan struct{}
+}
+
+func (r *fakeWorkspaceReaper) ReapWorkspace(_ context.Context, issue connector.Issue) (orchestrator.WorkspaceReapResult, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if r.changed == nil {
+		r.changed = make(chan struct{}, 8)
+	}
+	r.issues = append(r.issues, issue)
+	r.changed <- struct{}{}
+	return r.result, nil
+}
+
+func (r *fakeWorkspaceReaper) reapedIssues() []connector.Issue {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return cloneIssues(r.issues)
+}
+
+func waitForWorkspaceReaps(t *testing.T, reaper *fakeWorkspaceReaper, want int) []connector.Issue {
+	t.Helper()
+
+	reaper.mu.Lock()
+	if reaper.changed == nil {
+		reaper.changed = make(chan struct{}, 8)
+	}
+	changed := reaper.changed
+	reaper.mu.Unlock()
+
+	deadline := time.After(time.Second)
+	for {
+		if got := reaper.reapedIssues(); len(got) >= want {
+			return got
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d workspace reaps; got %#v", want, reaper.reapedIssues())
+		case <-changed:
+		}
+	}
 }
 
 type blockingRunner struct {

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -1,0 +1,145 @@
+package orchestrator
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, now time.Time) {
+	if o.reaper == nil {
+		return
+	}
+	if !state.LastWorkspaceCleanupAt.IsZero() && now.Before(state.LastWorkspaceCleanupAt.Add(o.cfg.WorkspaceCleanupSweepInterval)) {
+		return
+	}
+	state.LastWorkspaceCleanupAt = now
+
+	states := cleanupFetchStates(o.cfg)
+	if len(states) == 0 {
+		return
+	}
+
+	issues, err := o.connector.FetchIssuesByStates(ctx, states)
+	if err != nil {
+		o.logger.Warn("fetch workspace cleanup candidates failed", slog.Any("error", err))
+		return
+	}
+	for _, issue := range issues {
+		if !o.shouldReapWorkspaceIssue(issue, now) {
+			continue
+		}
+		o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates))
+	}
+}
+
+func cleanupFetchStates(cfg Config) []string {
+	return appendUniqueStates(cfg.TerminalStates, cfg.ObservedStates)
+}
+
+func appendUniqueStates(groups ...[]string) []string {
+	seen := map[string]struct{}{}
+	out := []string{}
+	for _, group := range groups {
+		for _, state := range group {
+			key := normalizeState(state)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			out = append(out, state)
+		}
+	}
+	return out
+}
+
+func (o *Orchestrator) shouldReapWorkspaceIssue(issue connector.Issue, now time.Time) bool {
+	if strings.TrimSpace(issue.ID) == "" || strings.TrimSpace(issue.Identifier) == "" {
+		return false
+	}
+	if workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+		return true
+	}
+	if stateIn(issue.State, o.cfg.ActiveStates) {
+		return false
+	}
+	if o.cfg.WorkspaceCleanupIdleTTL <= 0 {
+		return false
+	}
+	idleSince, ok := workspaceIssueIdleSince(issue)
+	if !ok {
+		return false
+	}
+	return !now.Before(idleSince.Add(o.cfg.WorkspaceCleanupIdleTTL))
+}
+
+func workspaceIssueTerminal(issue connector.Issue, terminalStates []string) bool {
+	if issue.Closed || stateIn(issue.State, terminalStates) {
+		return true
+	}
+	if issue.PullRequest != nil && normalizePullRequestState(issue.PullRequest.State) == "merged" {
+		return true
+	}
+	return false
+}
+
+func workspaceIssueIdleSince(issue connector.Issue) (time.Time, bool) {
+	for _, candidate := range []*time.Time{issue.StageUpdatedAt, issue.UpdatedAt, issue.CreatedAt} {
+		if candidate != nil && !candidate.IsZero() {
+			return *candidate, true
+		}
+	}
+	return time.Time{}, false
+}
+
+func workspaceReapReason(issue connector.Issue, terminalStates []string) string {
+	switch {
+	case issue.Closed:
+		return "closed"
+	case issue.PullRequest != nil && normalizePullRequestState(issue.PullRequest.State) == "merged":
+		return "merged"
+	case stateIn(issue.State, terminalStates):
+		return "terminal"
+	default:
+		return "idle"
+	}
+}
+
+func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue connector.Issue, reason string) {
+	if o.reaper == nil {
+		return
+	}
+	if _, ok := state.ReapedWorkspaces[issue.ID]; ok {
+		return
+	}
+	result, err := o.reaper.ReapWorkspace(ctx, issue)
+	if err != nil {
+		o.logger.Warn(
+			"workspace reap failed",
+			slog.String("issue_id", issue.ID),
+			slog.String("issue_identifier", issue.Identifier),
+			slog.String("reason", reason),
+			slog.Any("error", err),
+		)
+		return
+	}
+	state.ReapedWorkspaces[issue.ID] = time.Now().UTC()
+	if result.Worktrees == 0 && result.Branches == 0 && result.Processes == 0 {
+		return
+	}
+	o.logger.Info(
+		"workspace reaped",
+		slog.String("issue_id", issue.ID),
+		slog.String("issue_identifier", issue.Identifier),
+		slog.String("reason", reason),
+		slog.Int("worktrees", result.Worktrees),
+		slog.Int("branches", result.Branches),
+		slog.Int("processes", result.Processes),
+	)
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -15,6 +15,7 @@ type State struct {
 	LastRefreshAt          time.Time
 	NextRefreshAt          time.Time
 	LastRunningReconcileAt time.Time
+	LastWorkspaceCleanupAt time.Time
 	Pipeline               []connector.Issue
 	Running                map[string]Running
 	Claimed                map[string]Claimed
@@ -23,6 +24,7 @@ type State struct {
 	Retry                  map[string]Retry
 	BudgetRefusals         map[string]BudgetRefusal
 	DiffStats              map[string]DiffStats
+	ReapedWorkspaces       map[string]time.Time
 	CodexTotals            CodexTotals
 	RateLimits             *telemetry.RateLimits
 }
@@ -94,6 +96,7 @@ func newState(cfg Config) State {
 		Retry:               map[string]Retry{},
 		BudgetRefusals:      map[string]BudgetRefusal{},
 		DiffStats:           map[string]DiffStats{},
+		ReapedWorkspaces:    map[string]time.Time{},
 	}
 }
 
@@ -105,6 +108,7 @@ func (s State) clone() State {
 		LastRefreshAt:          s.LastRefreshAt,
 		NextRefreshAt:          s.NextRefreshAt,
 		LastRunningReconcileAt: s.LastRunningReconcileAt,
+		LastWorkspaceCleanupAt: s.LastWorkspaceCleanupAt,
 		Pipeline:               cloneIssues(s.Pipeline),
 		Running:                make(map[string]Running, len(s.Running)),
 		Claimed:                make(map[string]Claimed, len(s.Claimed)),
@@ -113,6 +117,7 @@ func (s State) clone() State {
 		Retry:                  make(map[string]Retry, len(s.Retry)),
 		BudgetRefusals:         make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		DiffStats:              make(map[string]DiffStats, len(s.DiffStats)),
+		ReapedWorkspaces:       make(map[string]time.Time, len(s.ReapedWorkspaces)),
 		CodexTotals:            s.CodexTotals,
 		RateLimits:             cloneRateLimits(s.RateLimits),
 	}
@@ -153,6 +158,9 @@ func (s State) clone() State {
 	}
 	for id, diffStats := range s.DiffStats {
 		cloned.DiffStats[id] = diffStats
+	}
+	for id, reapedAt := range s.ReapedWorkspaces {
+		cloned.ReapedWorkspaces[id] = reapedAt
 	}
 
 	return cloned

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -364,6 +364,26 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	return result, nil
 }
 
+func (r *Runner) ReapWorkspace(ctx context.Context, issue connector.Issue) (WorkspaceReapResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	workspaceIssue := workspaceIssue(issue)
+	if cleaner, ok := r.workspace.(workspace.IssueCleaner); ok {
+		result, err := cleaner.CleanupIssue(ctx, workspaceIssue)
+		return WorkspaceReapResult{
+			Worktrees: result.Worktrees,
+			Branches:  result.Branches,
+			Processes: result.Processes,
+		}, err
+	}
+	if err := r.workspace.Cleanup(ctx, issue.Identifier); err != nil {
+		return WorkspaceReapResult{}, err
+	}
+	return WorkspaceReapResult{}, nil
+}
+
 func (r *Runner) runtimeSnapshot() (config.Workflow, agentRuntime) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -541,16 +541,52 @@ func TestRunnerRunUsesFreshContextForAfterRunCleanup(t *testing.T) {
 	}
 }
 
+func TestRunnerReapWorkspaceUsesWorkspaceIssueCleanup(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		cleanupResult: workspace.CleanupResult{Worktrees: 1, Branches: 1, Processes: 2},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: &fakeCodexClient{},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.ReapWorkspace(context.Background(), connector.Issue{
+		ID:         "issue-311",
+		Identifier: "digitaldrywood/detent#311",
+		BranchName: "detent/digitaldrywood_detent_311",
+	})
+	if err != nil {
+		t.Fatalf("ReapWorkspace() error = %v", err)
+	}
+
+	if result.Worktrees != 1 || result.Branches != 1 || result.Processes != 2 {
+		t.Fatalf("ReapWorkspace() result = %#v, want 1 worktree, 1 branch, 2 processes", result)
+	}
+	if workspaceBackend.cleanupIssue.ID != "issue-311" ||
+		workspaceBackend.cleanupIssue.Identifier != "digitaldrywood/detent#311" ||
+		workspaceBackend.cleanupIssue.BranchName != "detent/digitaldrywood_detent_311" {
+		t.Fatalf("CleanupIssue() issue = %#v", workspaceBackend.cleanupIssue)
+	}
+}
+
 type fakeWorkspaceBackend struct {
-	info        workspace.Info
-	diffStat    workspace.DiffStat
-	diffStats   []workspace.DiffStat
-	created     bool
-	beforeRun   bool
-	afterRun    bool
-	afterRunErr error
-	diffed      bool
-	diffCalls   int
+	info          workspace.Info
+	diffStat      workspace.DiffStat
+	diffStats     []workspace.DiffStat
+	created       bool
+	beforeRun     bool
+	afterRun      bool
+	afterRunErr   error
+	diffed        bool
+	diffCalls     int
+	cleanupIssue  workspace.Issue
+	cleanupResult workspace.CleanupResult
 }
 
 func (b *fakeWorkspaceBackend) Create(_ context.Context, issue workspace.Issue) (workspace.Info, error) {
@@ -561,6 +597,11 @@ func (b *fakeWorkspaceBackend) Create(_ context.Context, issue workspace.Issue) 
 
 func (b *fakeWorkspaceBackend) Cleanup(context.Context, string) error {
 	return nil
+}
+
+func (b *fakeWorkspaceBackend) CleanupIssue(_ context.Context, issue workspace.Issue) (workspace.CleanupResult, error) {
+	b.cleanupIssue = issue
+	return b.cleanupResult, nil
 }
 
 func (b *fakeWorkspaceBackend) BeforeRun(context.Context, workspace.Info, workspace.Issue) error {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -18,6 +18,16 @@ type Backend interface {
 	Run(context.Context, RunRequest) (RunResult, error)
 }
 
+type WorkspaceReaper interface {
+	ReapWorkspace(context.Context, connector.Issue) (WorkspaceReapResult, error)
+}
+
+type WorkspaceReapResult struct {
+	Worktrees int
+	Branches  int
+	Processes int
+}
+
 type AgentBackend interface {
 	RunTurn(context.Context, AgentTurnRequest, AgentUpdateHandler) (AgentTurnResult, error)
 }

--- a/internal/workspace/process_other.go
+++ b/internal/workspace/process_other.go
@@ -1,0 +1,12 @@
+//go:build !unix
+
+package workspace
+
+import (
+	"context"
+	"log/slog"
+)
+
+func reapWorkspaceProcesses(context.Context, string, *slog.Logger) int {
+	return 0
+}

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -1,0 +1,123 @@
+//go:build unix
+
+package workspace
+
+import (
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+func reapWorkspaceProcesses(ctx context.Context, path string, logger *slog.Logger) int {
+	pids, err := workspaceProcessIDs(ctx, path)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("workspace process scan failed", slog.String("path", path), slog.Any("error", err))
+		}
+		return 0
+	}
+
+	killed := 0
+	for _, pid := range pids {
+		if pid <= 0 || pid == os.Getpid() {
+			continue
+		}
+		err := syscall.Kill(pid, syscall.SIGKILL)
+		if err == nil {
+			killed++
+			continue
+		}
+		if !errors.Is(err, syscall.ESRCH) && logger != nil {
+			logger.Warn("workspace process kill failed", slog.String("path", path), slog.Int("pid", pid), slog.Any("error", err))
+		}
+	}
+	return killed
+}
+
+func workspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
+	if runtime.GOOS == "linux" {
+		return linuxWorkspaceProcessIDs(path)
+	}
+	return lsofWorkspaceProcessIDs(ctx, path)
+}
+
+func linuxWorkspaceProcessIDs(path string) ([]int, error) {
+	root := filepath.Clean(path)
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil, err
+	}
+
+	seen := map[int]struct{}{}
+	pids := []int{}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		cwd, err := os.Readlink(filepath.Join("/proc", entry.Name(), "cwd"))
+		if err != nil {
+			continue
+		}
+		cwd = strings.TrimSuffix(cwd, " (deleted)")
+		if !pathInside(root, cwd) {
+			continue
+		}
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
+	cmd := exec.CommandContext(ctx, "lsof", "-t", "+D", path)
+	output, err := cmd.Output()
+	if err != nil && len(output) == 0 {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	seen := map[int]struct{}{}
+	pids := []int{}
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		pid, err := strconv.Atoi(line)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[pid]; ok {
+			continue
+		}
+		seen[pid] = struct{}{}
+		pids = append(pids, pid)
+	}
+	return pids, nil
+}
+
+func pathInside(root string, path string) bool {
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -37,6 +37,16 @@ type Backend interface {
 	DiffStat(context.Context, Info, Issue) (DiffStat, error)
 }
 
+type CleanupResult struct {
+	Worktrees int
+	Branches  int
+	Processes int
+}
+
+type IssueCleaner interface {
+	CleanupIssue(context.Context, Issue) (CleanupResult, error)
+}
+
 type Issue struct {
 	ID         string
 	Identifier string
@@ -206,30 +216,57 @@ func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {
 }
 
 func (l *LocalGit) Cleanup(ctx context.Context, identifier string) error {
-	info, err := l.infoForIssue(Issue{Identifier: identifier})
+	_, err := l.CleanupIssue(ctx, Issue{Identifier: identifier})
+	return err
+}
+
+func (l *LocalGit) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult, error) {
+	info, err := l.infoForIssue(issue)
 	if err != nil {
-		return err
+		return CleanupResult{}, err
 	}
 
+	result := CleanupResult{}
 	exists, isDir, err := pathExists(info.Path)
 	if err != nil {
-		return err
+		return CleanupResult{}, err
 	}
 	if !exists {
 		_, pruneErr := l.runGit(ctx, "worktree", "prune")
-		return pruneErr
+		if pruneErr != nil {
+			return CleanupResult{}, pruneErr
+		}
+		branchRemoved, branchErr := l.deleteBranch(ctx, info.Branch)
+		if branchErr != nil {
+			return CleanupResult{}, branchErr
+		}
+		if branchRemoved {
+			result.Branches = 1
+		}
+		return result, nil
 	}
+	result.Processes = reapWorkspaceProcesses(ctx, info.Path, l.logger)
 	if isDir && l.isSourceWorktree(ctx, info.Path) {
-		if err := l.runHook(ctx, "before_remove", l.hooks.BeforeRemove, info, Issue{Identifier: identifier}); err != nil {
+		if err := l.runHook(ctx, "before_remove", l.hooks.BeforeRemove, info, issue); err != nil {
 			l.logger.Warn("workspace before_remove hook failed", slog.String("path", info.Path), slog.Any("error", err))
 		}
 	}
 
 	if err := l.removePath(ctx, info.Path); err != nil {
-		return err
+		return CleanupResult{}, err
 	}
-	_, err = l.runGit(ctx, "worktree", "prune")
-	return err
+	result.Worktrees = 1
+	if _, err := l.runGit(ctx, "worktree", "prune"); err != nil {
+		return CleanupResult{}, err
+	}
+	branchRemoved, err := l.deleteBranch(ctx, info.Branch)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	if branchRemoved {
+		result.Branches = 1
+	}
+	return result, nil
 }
 
 func (l *LocalGit) BeforeRun(ctx context.Context, info Info, issue Issue) error {
@@ -374,6 +411,22 @@ func (l *LocalGit) branchExists(ctx context.Context, branch string) (bool, error
 		return false, nil
 	}
 	return false, err
+}
+
+func (l *LocalGit) deleteBranch(ctx context.Context, branch string) (bool, error) {
+	branch = strings.TrimSpace(branch)
+	if !l.autoBranch || branch == "" || !strings.HasPrefix(branch, "detent/") {
+		return false, nil
+	}
+	exists, err := l.branchExists(ctx, branch)
+	if err != nil {
+		return false, err
+	}
+	if !exists {
+		return false, nil
+	}
+	_, err = l.runGit(ctx, "branch", "-D", branch)
+	return err == nil, err
 }
 
 func (l *LocalGit) isGitWorkspace(ctx context.Context, path string) bool {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -127,6 +127,9 @@ func TestLocalGitCreateAndCleanupWithoutHooks(t *testing.T) {
 	if got := runGit(t, source, "worktree", "list", "--porcelain"); strings.Contains(got, info.Path) {
 		t.Fatalf("git worktree list still contains removed path:\n%s", got)
 	}
+	if branchExists(t, source, "detent/dd-native") {
+		t.Fatal("detent/dd-native branch still exists after cleanup")
+	}
 }
 
 func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
@@ -516,6 +519,22 @@ func initSourceRepo(t *testing.T) string {
 func runGit(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	return runCommand(t, dir, "git", args...)
+}
+
+func branchExists(t *testing.T, dir string, branch string) bool {
+	t.Helper()
+
+	cmd := exec.Command("git", "-C", dir, "show-ref", "--verify", "--quiet", "refs/heads/"+branch)
+	err := cmd.Run()
+	if err == nil {
+		return true
+	}
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+		return false
+	}
+	t.Fatalf("git show-ref failed: %v", err)
+	return false
 }
 
 func runCommand(t *testing.T, dir string, name string, args ...string) string {


### PR DESCRIPTION
## Summary

- run Codex transports in isolated process groups and kill the group on cancellation, close timeout, and parent exit
- reap terminal and idle non-active worktrees on startup/periodic sweeps, including generated branch refs and stray workspace processes
- add cleanup TTL/sweep config, README coverage, and focused lifecycle tests

Fixes #311

## Test Plan

- [x] `make check`