### PR TITLE
perf(connector): reduce github poll cost

### DIFF
--- a/internal/codex/transport_unix_test.go
+++ b/internal/codex/transport_unix_test.go
@@ -68,22 +68,27 @@ func waitForPIDFile(t *testing.T, path string) int {
 	t.Helper()
 
 	deadline := time.After(time.Second)
+	var lastErr error
 	for {
 		raw, err := os.ReadFile(path)
 		if err == nil {
-			pid, parseErr := strconv.Atoi(strings.TrimSpace(string(raw)))
+			pidText := strings.TrimSpace(string(raw))
+			pid, parseErr := strconv.Atoi(pidText)
+			if parseErr == nil && pid > 0 {
+				return pid
+			}
 			if parseErr != nil {
-				t.Fatalf("parse pid file: %v", parseErr)
+				lastErr = parseErr
+			} else {
+				lastErr = errors.New("pid is not positive")
 			}
-			if pid <= 0 {
-				t.Fatalf("pid = %d, want positive", pid)
-			}
-			return pid
+		} else {
+			lastErr = err
 		}
 
 		select {
 		case <-deadline:
-			t.Fatalf("timed out waiting for pid file: %v", err)
+			t.Fatalf("timed out waiting for pid file: %v", lastErr)
 		default:
 			time.Sleep(time.Millisecond)
 		}

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/url"
 	"regexp"
 	"sort"
 	"strconv"
@@ -15,17 +17,13 @@ import (
 )
 
 const (
-	projectItemsPageSize                      = 50
-	projectItemsPerIssue                      = 100
-	projectItemFieldValuesPageSize            = 100
-	linkedIssuePageSize                       = 20
-	linkedIssueProjectItemsPageSize           = 10
-	linkedIssueProjectItemFieldValuesPageSize = 20
-	pullRequestsPageSize                      = 100
-	pullRequestsPageLimit                     = 3
-	defaultProjectItemStatusState             = "Backlog"
-	defaultProjectItemStatusWriteParallelism  = 4
-	defaultProjectItemStatusWriteTimeout      = 2 * time.Minute
+	projectItemsPageSize                     = 50
+	projectItemsPerIssue                     = 100
+	pullRequestsPageSize                     = 100
+	pullRequestsPageLimit                    = 3
+	defaultProjectItemStatusState            = "Backlog"
+	defaultProjectItemStatusWriteParallelism = 4
+	defaultProjectItemStatusWriteTimeout     = 2 * time.Minute
 )
 
 const projectItemsQuery = `
@@ -34,10 +32,6 @@ query DetentGitHubProjectItems(
   $first: Int!
   $after: String
   $query: String
-  $projectItemFieldValuesFirst: Int!
-  $linkedIssuesFirst: Int!
-  $linkedProjectItemsFirst: Int!
-  $linkedProjectItemFieldValuesFirst: Int!
 ) {
   node(id: $projectId) {
     ... on ProjectV2 {
@@ -51,98 +45,9 @@ query DetentGitHubProjectItems(
               id
               number
               title
-              body
               state
               url
-              createdAt
-              updatedAt
-              author { login }
-              assignees(first: 100) { nodes { id login } }
-              labels(first: 20) { nodes { name } }
               repository { nameWithOwner }
-              closedByPullRequestsReferences(first: 5) { nodes { number url } }
-              subIssues(first: $linkedIssuesFirst) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  number
-                  title
-                  state
-                  url
-                  repository { nameWithOwner }
-                  projectItems(first: $linkedProjectItemsFirst) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      id
-                      project { id }
-                      statusValue: fieldValueByName(name: "Status") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
-                      }
-                      priorityValue: fieldValueByName(name: "Priority") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name }
-                      }
-                      fieldValues(first: $linkedProjectItemFieldValuesFirst) {
-                        nodes {
-                          __typename
-                          ... on ProjectV2ItemFieldSingleSelectValue {
-                            name
-                            field { ... on ProjectV2FieldCommon { name } }
-                          }
-                          ... on ProjectV2ItemFieldTextValue {
-                            text
-                            field { ... on ProjectV2FieldCommon { name } }
-                          }
-                          ... on ProjectV2ItemFieldNumberValue {
-                            number
-                            field { ... on ProjectV2FieldCommon { name } }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
-              trackedIssues(first: $linkedIssuesFirst) {
-                pageInfo { hasNextPage endCursor }
-                nodes {
-                  id
-                  number
-                  title
-                  state
-                  url
-                  repository { nameWithOwner }
-                  projectItems(first: $linkedProjectItemsFirst) {
-                    pageInfo { hasNextPage endCursor }
-                    nodes {
-                      id
-                      project { id }
-                      statusValue: fieldValueByName(name: "Status") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
-                      }
-                      priorityValue: fieldValueByName(name: "Priority") {
-                        ... on ProjectV2ItemFieldSingleSelectValue { name }
-                      }
-                      fieldValues(first: $linkedProjectItemFieldValuesFirst) {
-                        nodes {
-                          __typename
-                          ... on ProjectV2ItemFieldSingleSelectValue {
-                            name
-                            field { ... on ProjectV2FieldCommon { name } }
-                          }
-                          ... on ProjectV2ItemFieldTextValue {
-                            text
-                            field { ... on ProjectV2FieldCommon { name } }
-                          }
-                          ... on ProjectV2ItemFieldNumberValue {
-                            number
-                            field { ... on ProjectV2FieldCommon { name } }
-                          }
-                        }
-                      }
-                    }
-                  }
-                }
-              }
             }
           }
           statusValue: fieldValueByName(name: "Status") {
@@ -151,23 +56,6 @@ query DetentGitHubProjectItems(
           priorityValue: fieldValueByName(name: "Priority") {
             ... on ProjectV2ItemFieldSingleSelectValue { name }
           }
-          fieldValues(first: $projectItemFieldValuesFirst) {
-            nodes {
-              __typename
-              ... on ProjectV2ItemFieldSingleSelectValue {
-                name
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldTextValue {
-                text
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldNumberValue {
-                number
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-            }
-          }
         }
       }
     }
@@ -175,189 +63,14 @@ query DetentGitHubProjectItems(
   rateLimit { limit used remaining cost resetAt }
 }`
 
-const issuesByIDQuery = `
-query DetentGitHubIssuesByID($issueIds: [ID!]!, $projectItemsFirst: Int!) {
+const issueIdentitiesByIDQuery = `
+query DetentGitHubIssueIdentitiesByID($issueIds: [ID!]!) {
   nodes(ids: $issueIds) {
     __typename
     ... on Issue {
       id
       number
-      title
-      body
-      state
-      url
-      createdAt
-      updatedAt
-      author { login }
-      assignees(first: 100) { nodes { id login } }
-      labels(first: 20) { nodes { name } }
       repository { nameWithOwner }
-      closedByPullRequestsReferences(first: 5) { nodes { number url } }
-      subIssues(first: 100) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          id
-          number
-          title
-          state
-          url
-          repository { nameWithOwner }
-          projectItems(first: 100) {
-            pageInfo { hasNextPage endCursor }
-            nodes {
-              id
-              project { id }
-              statusValue: fieldValueByName(name: "Status") {
-                ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
-              }
-              priorityValue: fieldValueByName(name: "Priority") {
-                ... on ProjectV2ItemFieldSingleSelectValue { name }
-              }
-              fieldValues(first: 100) {
-                nodes {
-                  __typename
-                  ... on ProjectV2ItemFieldSingleSelectValue {
-                    name
-                    field { ... on ProjectV2FieldCommon { name } }
-                  }
-                  ... on ProjectV2ItemFieldTextValue {
-                    text
-                    field { ... on ProjectV2FieldCommon { name } }
-                  }
-                  ... on ProjectV2ItemFieldNumberValue {
-                    number
-                    field { ... on ProjectV2FieldCommon { name } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      trackedIssues(first: 100) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          id
-          number
-          title
-          state
-          url
-          repository { nameWithOwner }
-          projectItems(first: 100) {
-            pageInfo { hasNextPage endCursor }
-            nodes {
-              id
-              project { id }
-              statusValue: fieldValueByName(name: "Status") {
-                ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
-              }
-              priorityValue: fieldValueByName(name: "Priority") {
-                ... on ProjectV2ItemFieldSingleSelectValue { name }
-              }
-              fieldValues(first: 100) {
-                nodes {
-                  __typename
-                  ... on ProjectV2ItemFieldSingleSelectValue {
-                    name
-                    field { ... on ProjectV2FieldCommon { name } }
-                  }
-                  ... on ProjectV2ItemFieldTextValue {
-                    text
-                    field { ... on ProjectV2FieldCommon { name } }
-                  }
-                  ... on ProjectV2ItemFieldNumberValue {
-                    number
-                    field { ... on ProjectV2FieldCommon { name } }
-                  }
-                }
-              }
-            }
-          }
-        }
-      }
-      projectItems(first: $projectItemsFirst) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          id
-          project { id }
-          statusValue: fieldValueByName(name: "Status") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
-          }
-          priorityValue: fieldValueByName(name: "Priority") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name }
-          }
-          fieldValues(first: 100) {
-            nodes {
-              __typename
-              ... on ProjectV2ItemFieldSingleSelectValue {
-                name
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldTextValue {
-                text
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldNumberValue {
-                number
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-            }
-          }
-        }
-      }
-    }
-  }
-  rateLimit { limit used remaining cost resetAt }
-}`
-
-const issueByNumberQuery = `
-query DetentGitHubIssueByNumber($owner: String!, $name: String!, $number: Int!, $projectItemsFirst: Int!) {
-  repository(owner: $owner, name: $name) {
-    issue(number: $number) {
-      __typename
-      id
-      number
-      title
-      body
-      state
-      url
-      createdAt
-      updatedAt
-      author { login }
-      assignees(first: 100) { nodes { id login } }
-      labels(first: 20) { nodes { name } }
-      repository { nameWithOwner }
-      closedByPullRequestsReferences(first: 5) { nodes { number url } }
-      projectItems(first: $projectItemsFirst) {
-        pageInfo { hasNextPage endCursor }
-        nodes {
-          id
-          project { id }
-          statusValue: fieldValueByName(name: "Status") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
-          }
-          priorityValue: fieldValueByName(name: "Priority") {
-            ... on ProjectV2ItemFieldSingleSelectValue { name }
-          }
-          fieldValues(first: 100) {
-            nodes {
-              __typename
-              ... on ProjectV2ItemFieldSingleSelectValue {
-                name
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldTextValue {
-                text
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-              ... on ProjectV2ItemFieldNumberValue {
-                number
-                field { ... on ProjectV2FieldCommon { name } }
-              }
-            }
-          }
-        }
-      }
     }
   }
   rateLimit { limit used remaining cost resetAt }
@@ -461,91 +174,6 @@ query DetentGitHubIssueTrackedIssues($issueId: ID!, $after: String) {
     }
   }
   rateLimit { limit used remaining cost resetAt }
-}`
-
-const issueCommentsQuery = `
-query DetentGitHubIssueComments($issueIds: [ID!]!) {
-  nodes(ids: $issueIds) {
-    __typename
-    ... on Issue {
-      id
-      body
-      comments(first: 100) { nodes { body } }
-    }
-  }
-  rateLimit { limit used remaining cost resetAt }
-}`
-
-const pullRequestsQuery = `
-query DetentGitHubPullRequests($owner: String!, $name: String!, $states: [PullRequestState!]!, $first: Int!, $after: String) {
-  repository(owner: $owner, name: $name) {
-    pullRequests(first: $first, after: $after, states: $states, orderBy: {field: UPDATED_AT, direction: DESC}) {
-      pageInfo { hasNextPage endCursor }
-      nodes {
-        number
-        url
-        state
-        headRefName
-        commits(last: 1) {
-          nodes {
-            commit {
-              statusCheckRollup { state }
-            }
-          }
-        }
-        latestReviews(first: 20) {
-          nodes {
-            body
-            state
-            author { login }
-          }
-        }
-      }
-    }
-  }
-  rateLimit { limit used remaining cost resetAt }
-}`
-
-const addCommentMutation = `
-mutation DetentGitHubAddComment($subjectId: ID!, $body: String!) {
-  addComment(input: {subjectId: $subjectId, body: $body}) {
-    commentEdge { node { id } }
-  }
-}`
-
-const closeIssueMutation = `
-mutation DetentGitHubCloseIssue($issueId: ID!, $stateReason: IssueClosedStateReason!) {
-  closeIssue(input: {issueId: $issueId, stateReason: $stateReason}) {
-    issue { id state }
-  }
-}`
-
-const userByLoginQuery = `
-query DetentGitHubUserByLogin($login: String!) {
-  user(login: $login) { id }
-}`
-
-const addAssigneesMutation = `
-mutation DetentGitHubAddAssignee($assignableId: ID!, $assigneeIds: [ID!]!) {
-  addAssigneesToAssignable(input: {assignableId: $assignableId, assigneeIds: $assigneeIds}) {
-    assignable { ... on Issue { id } }
-  }
-}`
-
-const issueAssigneesQuery = `
-query DetentGitHubIssueAssignees($issueId: ID!) {
-  node(id: $issueId) {
-    ... on Issue {
-      assignees(first: 100) { nodes { id login } }
-    }
-  }
-}`
-
-const removeAssigneesMutation = `
-mutation DetentGitHubRemoveAssignees($assignableId: ID!, $assigneeIds: [ID!]!) {
-  removeAssigneesFromAssignable(input: {assignableId: $assignableId, assigneeIds: $assigneeIds}) {
-    assignable { ... on Issue { id } }
-  }
 }`
 
 const statusFieldQuery = `
@@ -736,6 +364,7 @@ type pullRequestNode struct {
 	URL           string                            `json:"url"`
 	State         string                            `json:"state"`
 	HeadRefName   string                            `json:"headRefName"`
+	HeadSHA       string                            `json:"headSHA"`
 	Commits       nodeConnection[pullRequestCommit] `json:"commits"`
 	LatestReviews nodeConnection[pullRequestReview] `json:"latestReviews"`
 }
@@ -762,9 +391,55 @@ type actor struct {
 	Login string `json:"login"`
 }
 
-type pullRequestsConnection struct {
-	PageInfo pageInfo          `json:"pageInfo"`
-	Nodes    []pullRequestNode `json:"nodes"`
+type restIssue struct {
+	NodeID    string         `json:"node_id"`
+	Number    int            `json:"number"`
+	Title     string         `json:"title"`
+	Body      *string        `json:"body"`
+	State     string         `json:"state"`
+	HTMLURL   string         `json:"html_url"`
+	CreatedAt *time.Time     `json:"created_at"`
+	UpdatedAt *time.Time     `json:"updated_at"`
+	User      *actor         `json:"user"`
+	Assignees []restAssignee `json:"assignees"`
+	Labels    []label        `json:"labels"`
+}
+
+type restAssignee struct {
+	NodeID string `json:"node_id"`
+	Login  string `json:"login"`
+}
+
+type restPullRequest struct {
+	Number   int      `json:"number"`
+	HTMLURL  string   `json:"html_url"`
+	State    string   `json:"state"`
+	Head     restHead `json:"head"`
+	MergedAt *string  `json:"merged_at"`
+}
+
+type restHead struct {
+	Ref string `json:"ref"`
+	SHA string `json:"sha"`
+}
+
+type restReview struct {
+	Body  string `json:"body"`
+	State string `json:"state"`
+	User  *actor `json:"user"`
+}
+
+type restCheckRuns struct {
+	CheckRuns []restCheckRun `json:"check_runs"`
+}
+
+type restCheckRun struct {
+	Status     string `json:"status"`
+	Conclusion string `json:"conclusion"`
+}
+
+type restComment struct {
+	Body string `json:"body"`
 }
 
 type repository struct {
@@ -847,21 +522,20 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 		return nil, ErrMissingProject
 	}
 
-	var response struct {
-		Nodes []githubIssueNode `json:"nodes"`
-	}
-	if err := c.client.GraphQL(ctx, issuesByIDQuery, map[string]any{
-		"issueIds":          ids,
-		"projectItemsFirst": projectItemsPerIssue,
-	}, &response); err != nil {
-		return nil, fmt.Errorf("fetch github issue states by ids: %w", err)
+	refs, err := c.issueRefsForIDs(ctx, ids)
+	if err != nil {
+		return nil, err
 	}
 
-	issues := make([]connector.Issue, 0, len(response.Nodes))
-	for _, node := range response.Nodes {
-		issue, ok, err := c.normalizeIssueNode(ctx, node)
+	issues := make([]connector.Issue, 0, len(ids))
+	for _, id := range ids {
+		ref, ok := refs[id]
+		if !ok {
+			continue
+		}
+		issue, ok, err := c.fetchIssueByRef(ctx, ref)
 		if err != nil {
-			return nil, err
+			return nil, fmt.Errorf("fetch github issue states by ids: %w", err)
 		}
 		if ok {
 			issues = append(issues, issue)
@@ -989,93 +663,160 @@ func (c *Connector) fetchLinkedIssuePage(
 }
 
 func (c *Connector) fetchIssueByIdentifier(ctx context.Context, identifier string) (connector.Issue, bool, error) {
-	repo, number, ok := splitIssueIdentifier(identifier)
+	ref, ok := issueRefFromIdentifier(identifier)
 	if !ok {
 		return connector.Issue{}, false, nil
 	}
-	parts := strings.Split(repo, "/")
-	if len(parts) != 2 {
-		return connector.Issue{}, false, nil
-	}
-
-	var response struct {
-		Repository *struct {
-			Issue *githubIssueNode `json:"issue"`
-		} `json:"repository"`
-	}
-	if err := c.client.GraphQL(ctx, issueByNumberQuery, map[string]any{
-		"owner":             strings.TrimSpace(parts[0]),
-		"name":              strings.TrimSpace(parts[1]),
-		"number":            number,
-		"projectItemsFirst": projectItemsPerIssue,
-	}, &response); err != nil {
-		return connector.Issue{}, false, fmt.Errorf("fetch github issue by identifier: %w", err)
-	}
-	if response.Repository == nil || response.Repository.Issue == nil {
-		return connector.Issue{}, false, nil
-	}
-
-	return c.normalizeIssueNode(ctx, *response.Repository.Issue)
+	return c.fetchIssueByRef(ctx, ref)
 }
 
-func (c *Connector) populateBlockerReasons(ctx context.Context, issues []connector.Issue) error {
-	ids := make([]string, 0, len(issues))
-	for _, issue := range issues {
-		if normalizeStateName(issue.State) == normalizeStateName("Blocked") {
-			ids = append(ids, issue.ID)
+func (c *Connector) issueRefsForIDs(ctx context.Context, ids []string) (map[string]issueRef, error) {
+	refs := make(map[string]issueRef, len(ids))
+	missing := make([]string, 0, len(ids))
+	for _, id := range ids {
+		if ref, ok := c.projectCache.GetIssueRef(id); ok {
+			refs[id] = ref
+			continue
 		}
+		missing = append(missing, id)
 	}
-	ids = uniqueNonBlank(ids)
-	if len(ids) == 0 {
-		return nil
+	if len(missing) == 0 {
+		return refs, nil
 	}
 
+	fetched, err := c.fetchIssueRefsByID(ctx, missing)
+	if err != nil {
+		return nil, err
+	}
+	for id, ref := range fetched {
+		refs[id] = ref
+	}
+	return refs, nil
+}
+
+func (c *Connector) issueRefForID(ctx context.Context, issueID string) (issueRef, bool, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return issueRef{}, false, nil
+	}
+	if ref, ok := c.projectCache.GetIssueRef(issueID); ok {
+		return ref, true, nil
+	}
+	refs, err := c.fetchIssueRefsByID(ctx, []string{issueID})
+	if err != nil {
+		return issueRef{}, false, err
+	}
+	ref, ok := refs[issueID]
+	return ref, ok, nil
+}
+
+func (c *Connector) fetchIssueRefsByID(ctx context.Context, ids []string) (map[string]issueRef, error) {
 	var response struct {
 		Nodes []githubIssueNode `json:"nodes"`
 	}
-	if err := c.client.GraphQL(ctx, issueCommentsQuery, map[string]any{
-		"issueIds": ids,
-	}, &response); err != nil {
-		return fmt.Errorf("fetch github issue comments: %w", err)
+	if err := c.client.GraphQL(ctx, issueIdentitiesByIDQuery, map[string]any{"issueIds": ids}, &response); err != nil {
+		return nil, fmt.Errorf("fetch github issue identities by ids: %w", err)
 	}
 
-	reasonsByID := make(map[string]string, len(response.Nodes))
+	refs := make(map[string]issueRef, len(response.Nodes))
 	for _, node := range response.Nodes {
 		if node.TypeName != "Issue" {
 			continue
 		}
-		if reason := parseBlockerReason(node); reason != "" {
-			reasonsByID[node.ID] = reason
+		ref, ok := issueRefFromNode(node)
+		if !ok {
+			continue
 		}
+		refs[node.ID] = ref
+		c.projectCache.SetIssueRef(node.ID, ref)
 	}
+	return refs, nil
+}
+
+func (c *Connector) fetchIssueByRef(ctx context.Context, ref issueRef) (connector.Issue, bool, error) {
+	issue, err := c.fetchRESTIssue(ctx, ref)
+	if err != nil {
+		return connector.Issue{}, false, err
+	}
+	if strings.TrimSpace(issue.ID) == "" {
+		return connector.Issue{}, false, nil
+	}
+	c.cacheIssueRef(issue)
+
+	stateName, priorityName, statusUpdatedAt, fields, ok, err := c.fetchProjectFieldsPage(ctx, issue.ID, nil)
+	if err != nil {
+		return connector.Issue{}, false, err
+	}
+	if ok {
+		return c.buildIssue(issue, stateName, priorityName, statusUpdatedAt, fields), true, nil
+	}
+	return c.buildIssue(issue, c.githubIssueStateToDetentState(issue.State), "", nil, nil), true, nil
+}
+
+func (c *Connector) fetchRESTIssue(ctx context.Context, ref issueRef) (githubIssueNode, error) {
+	var response restIssue
+	if err := c.client.REST(ctx, http.MethodGet, restIssuePath(ref), nil, &response); err != nil {
+		if errors.Is(err, ErrNotFound) {
+			return githubIssueNode{}, nil
+		}
+		return githubIssueNode{}, fmt.Errorf("fetch github issue: %w", err)
+	}
+	return githubIssueNodeFromREST(ref, response), nil
+}
+
+func (c *Connector) populateBlockerReasons(ctx context.Context, issues []connector.Issue) error {
 	for index := range issues {
-		if reason, ok := reasonsByID[issues[index].ID]; ok {
+		if normalizeStateName(issues[index].State) != normalizeStateName("Blocked") {
+			continue
+		}
+		ref, ok := issueRefFromIdentifier(issues[index].Identifier)
+		if !ok {
+			continue
+		}
+		comments, err := c.fetchIssueComments(ctx, ref)
+		if err != nil {
+			return fmt.Errorf("fetch github issue comments: %w", err)
+		}
+		node := githubIssueNode{
+			ID:       issues[index].ID,
+			Body:     issues[index].Description,
+			Comments: nodeConnection[issueComment]{Nodes: comments},
+		}
+		if reason := parseBlockerReason(node); reason != "" {
 			issues[index].BlockerReason = reason
 		}
 	}
 	return nil
 }
 
-func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
-	var response struct {
-		AddComment *struct {
-			CommentEdge *struct {
-				Node *struct {
-					ID string `json:"id"`
-				} `json:"node"`
-			} `json:"commentEdge"`
-		} `json:"addComment"`
+func (c *Connector) fetchIssueComments(ctx context.Context, ref issueRef) ([]issueComment, error) {
+	var response []restComment
+	if err := c.client.REST(ctx, http.MethodGet, restIssueCommentsListPath(ref), nil, &response); err != nil {
+		return nil, err
 	}
-	if err := c.client.GraphQL(ctx, addCommentMutation, map[string]any{
-		"subjectId": strings.TrimSpace(issueID),
-		"body":      body,
-	}, &response); err != nil {
+	comments := make([]issueComment, 0, len(response))
+	for _, comment := range response {
+		comments = append(comments, issueComment(comment))
+	}
+	return comments, nil
+}
+
+func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
+	ref, ok, err := c.issueRefForID(ctx, issueID)
+	if err != nil {
+		return err
+	}
+	if !ok {
+		return ErrCommentCreateFailed
+	}
+
+	var response struct {
+		NodeID string `json:"node_id"`
+	}
+	if err := c.client.REST(ctx, http.MethodPost, restIssueCommentsPath(ref), map[string]any{"body": body}, &response); err != nil {
 		return fmt.Errorf("create github comment: %w", err)
 	}
-	if response.AddComment == nil ||
-		response.AddComment.CommentEdge == nil ||
-		response.AddComment.CommentEdge.Node == nil ||
-		strings.TrimSpace(response.AddComment.CommentEdge.Node.ID) == "" {
+	if strings.TrimSpace(response.NodeID) == "" {
 		return ErrCommentCreateFailed
 	}
 
@@ -1083,23 +824,22 @@ func (c *Connector) CreateComment(ctx context.Context, issueID string, body stri
 }
 
 func (c *Connector) CloseIssue(ctx context.Context, issueID string) error {
-	var response struct {
-		CloseIssue *struct {
-			Issue *struct {
-				ID    string `json:"id"`
-				State string `json:"state"`
-			} `json:"issue"`
-		} `json:"closeIssue"`
+	ref, ok, err := c.issueRefForID(ctx, issueID)
+	if err != nil {
+		return err
 	}
-	if err := c.client.GraphQL(ctx, closeIssueMutation, map[string]any{
-		"issueId":     strings.TrimSpace(issueID),
-		"stateReason": "COMPLETED",
+	if !ok {
+		return ErrIssueCloseFailed
+	}
+
+	var response restIssue
+	if err := c.client.REST(ctx, http.MethodPatch, restIssuePath(ref), map[string]any{
+		"state":        "closed",
+		"state_reason": "completed",
 	}, &response); err != nil {
 		return fmt.Errorf("close github issue: %w", err)
 	}
-	if response.CloseIssue == nil ||
-		response.CloseIssue.Issue == nil ||
-		strings.TrimSpace(response.CloseIssue.Issue.ID) == "" {
+	if strings.TrimSpace(response.NodeID) == "" || !strings.EqualFold(response.State, "closed") {
 		return ErrIssueCloseFailed
 	}
 
@@ -1146,22 +886,29 @@ func (c *Connector) setProjectItemStatus(ctx context.Context, itemID string, git
 
 func (c *Connector) SetAssignee(ctx context.Context, issueID string, login string) error {
 	issueID = strings.TrimSpace(issueID)
-	userID, err := c.resolveUserID(ctx, login)
+	login = strings.TrimSpace(login)
+	if issueID == "" || login == "" {
+		return ErrAssigneeNotFound
+	}
+	ref, ok, err := c.issueRefForID(ctx, issueID)
 	if err != nil {
 		return err
 	}
-	currentAssignees, err := c.fetchIssueAssignees(ctx, issueID)
+	if !ok {
+		return ErrAssigneeNotFound
+	}
+	currentAssignees, err := c.fetchIssueAssignees(ctx, ref)
 	if err != nil {
 		return err
 	}
-	removeIDs, alreadyAssigned := assigneeReplacement(currentAssignees, userID)
+	removeLogins, alreadyAssigned := assigneeLoginReplacement(currentAssignees, login)
 	if !alreadyAssigned {
-		if err := c.addAssignee(ctx, issueID, userID); err != nil {
+		if err := c.addAssignee(ctx, ref, login); err != nil {
 			return err
 		}
 	}
-	if len(removeIDs) > 0 {
-		if err := c.removeAssignees(ctx, issueID, removeIDs); err != nil {
+	if len(removeLogins) > 0 {
+		if err := c.removeAssignees(ctx, ref, removeLogins); err != nil {
 			return err
 		}
 	}
@@ -1236,59 +983,57 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 		if err != nil {
 			return err
 		}
-		attachMatchingPullRequests(issues, byRepo[repo], pullRequests)
+		if err := c.attachMatchingPullRequests(ctx, repo, issues, byRepo[repo], pullRequests); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
 func (c *Connector) fetchRepositoryPullRequests(ctx context.Context, repo pullRequestRepo) ([]pullRequestNode, error) {
-	return c.fetchRepositoryPullRequestsPage(ctx, repo, nil, 1)
+	pullRequests := []pullRequestNode{}
+	for page := 1; page <= pullRequestsPageLimit; page++ {
+		pagePullRequests, err := c.fetchRepositoryPullRequestsPage(ctx, repo, page)
+		if err != nil {
+			return nil, err
+		}
+		pullRequests = append(pullRequests, pagePullRequests...)
+		if len(pagePullRequests) < pullRequestsPageSize {
+			break
+		}
+	}
+	return pullRequests, nil
 }
 
 func (c *Connector) fetchRepositoryPullRequestsPage(
 	ctx context.Context,
 	repo pullRequestRepo,
-	after *string,
 	page int,
 ) ([]pullRequestNode, error) {
-	var response struct {
-		Repository *struct {
-			PullRequests pullRequestsConnection `json:"pullRequests"`
-		} `json:"repository"`
-	}
-	if err := c.client.GraphQL(ctx, pullRequestsQuery, map[string]any{
-		"owner":  repo.Owner,
-		"name":   repo.Name,
-		"states": []string{"OPEN", "MERGED"},
-		"first":  pullRequestsPageSize,
-		"after":  after,
-	}, &response); err != nil {
+	var response []restPullRequest
+	if err := c.client.REST(ctx, http.MethodGet, restPullRequestsPath(repo, page), nil, &response); err != nil {
 		return nil, fmt.Errorf("fetch github pull requests: %w", err)
 	}
-	if response.Repository == nil {
-		return nil, ErrInvalidResponse
+	pullRequests := make([]pullRequestNode, 0, len(response))
+	for _, pullRequest := range response {
+		pullRequests = append(pullRequests, pullRequestNode{
+			Number:      pullRequest.Number,
+			URL:         pullRequest.HTMLURL,
+			State:       restPullRequestState(pullRequest),
+			HeadRefName: pullRequest.Head.Ref,
+			HeadSHA:     pullRequest.Head.SHA,
+		})
 	}
-
-	pullRequests := append([]pullRequestNode(nil), response.Repository.PullRequests.Nodes...)
-	if !response.Repository.PullRequests.PageInfo.HasNextPage || page >= pullRequestsPageLimit {
-		return pullRequests, nil
-	}
-	cursor := strings.TrimSpace(response.Repository.PullRequests.PageInfo.EndCursor)
-	if cursor == "" {
-		return nil, ErrInvalidResponse
-	}
-	next, err := c.fetchRepositoryPullRequestsPage(ctx, repo, &cursor, page+1)
-	if err != nil {
-		return nil, err
-	}
-	return append(pullRequests, next...), nil
+	return pullRequests, nil
 }
 
-func attachMatchingPullRequests(
+func (c *Connector) attachMatchingPullRequests(
+	ctx context.Context,
+	repo pullRequestRepo,
 	issues []connector.Issue,
 	candidates []issuePullRequestCandidate,
 	pullRequests []pullRequestNode,
-) {
+) error {
 	for _, pullRequest := range pullRequests {
 		branchName := strings.TrimSpace(pullRequest.HeadRefName)
 		if branchName == "" {
@@ -1302,6 +1047,9 @@ func attachMatchingPullRequests(
 				continue
 			}
 
+			if err := c.populatePullRequestStatus(ctx, repo, &pullRequest); err != nil {
+				return err
+			}
 			issues[candidate.Index].PullRequest = &connector.PullRequest{
 				Number:           pullRequest.Number,
 				URL:              strings.TrimSpace(pullRequest.URL),
@@ -1316,6 +1064,49 @@ func attachMatchingPullRequests(
 			}
 		}
 	}
+	return nil
+}
+
+func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode) error {
+	if strings.TrimSpace(pullRequest.HeadSHA) != "" {
+		ciState, err := c.fetchPullRequestCIState(ctx, repo, pullRequest.HeadSHA)
+		if err != nil {
+			return err
+		}
+		pullRequest.Commits = nodeConnection[pullRequestCommit]{Nodes: []pullRequestCommit{{
+			Commit: commitNode{StatusCheckRollup: &statusCheckRollup{State: ciState}},
+		}}}
+	}
+	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number)
+	if err != nil {
+		return err
+	}
+	pullRequest.LatestReviews = nodeConnection[pullRequestReview]{Nodes: reviews}
+	return nil
+}
+
+func (c *Connector) fetchPullRequestCIState(ctx context.Context, repo pullRequestRepo, sha string) (string, error) {
+	var response restCheckRuns
+	if err := c.client.REST(ctx, http.MethodGet, restCommitCheckRunsPath(repo, sha), nil, &response); err != nil {
+		return "", fmt.Errorf("fetch github check runs: %w", err)
+	}
+	return checkRunsState(response.CheckRuns), nil
+}
+
+func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int) ([]pullRequestReview, error) {
+	var response []restReview
+	if err := c.client.REST(ctx, http.MethodGet, restPullRequestReviewsPath(repo, number), nil, &response); err != nil {
+		return nil, fmt.Errorf("fetch github pull request reviews: %w", err)
+	}
+	reviews := make([]pullRequestReview, 0, len(response))
+	for _, review := range response {
+		reviews = append(reviews, pullRequestReview{
+			Body:   review.Body,
+			State:  review.State,
+			Author: review.User,
+		})
+	}
+	return reviews, nil
 }
 
 func (c *Connector) fetchProjectItems(ctx context.Context, query string, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
@@ -1334,14 +1125,10 @@ func (c *Connector) fetchProjectItems(ctx context.Context, query string, keepIss
 			} `json:"node"`
 		}
 		if err := c.client.GraphQL(ctx, projectItemsQuery, map[string]any{
-			"projectId":                         c.projectID,
-			"first":                             projectItemsPageSize,
-			"after":                             after,
-			"query":                             projectQuery,
-			"projectItemFieldValuesFirst":       projectItemFieldValuesPageSize,
-			"linkedIssuesFirst":                 linkedIssuePageSize,
-			"linkedProjectItemsFirst":           linkedIssueProjectItemsPageSize,
-			"linkedProjectItemFieldValuesFirst": linkedIssueProjectItemFieldValuesPageSize,
+			"projectId": c.projectID,
+			"first":     projectItemsPageSize,
+			"after":     after,
+			"query":     projectQuery,
 		}, &response); err != nil {
 			return nil, fmt.Errorf("fetch github project items: %w", err)
 		}
@@ -1386,6 +1173,7 @@ func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue,
 	if item.Content == nil || item.Content.TypeName != "Issue" {
 		return connector.Issue{}, false, "", nil
 	}
+	c.cacheIssueRef(*item.Content)
 	statusName, statusUpdatedAt, blankStatusItemID, err := c.projectItemStatusOrDefault(item)
 	if err != nil {
 		return connector.Issue{}, false, "", err
@@ -1516,34 +1304,6 @@ func resolveBlockedByProjectState(issues []connector.Issue) {
 
 func normalizedIssueIdentifier(identifier string) string {
 	return strings.ToLower(strings.TrimSpace(identifier))
-}
-
-func (c *Connector) normalizeIssueNode(ctx context.Context, issue githubIssueNode) (connector.Issue, bool, error) {
-	if issue.TypeName != "Issue" {
-		return connector.Issue{}, false, nil
-	}
-	stateName, priorityName, statusUpdatedAt, fields, ok, err := c.resolveIssueProjectFields(ctx, issue.ID, issue.ProjectItems)
-	if err != nil {
-		return connector.Issue{}, false, err
-	}
-	if ok {
-		return c.buildIssue(issue, stateName, priorityName, statusUpdatedAt, fields), true, nil
-	}
-	return c.buildIssue(issue, c.githubIssueStateToDetentState(issue.State), "", nil, nil), true, nil
-}
-
-func (c *Connector) resolveIssueProjectFields(ctx context.Context, issueID string, items *projectItemsConnection) (string, string, *time.Time, map[string]string, bool, error) {
-	if stateName, priorityName, statusUpdatedAt, fields, ok := c.projectFields(issueID, items); ok {
-		return stateName, priorityName, statusUpdatedAt, fields, true, nil
-	}
-	if items == nil || !items.PageInfo.HasNextPage {
-		return "", "", nil, nil, false, nil
-	}
-	cursor := strings.TrimSpace(items.PageInfo.EndCursor)
-	if cursor == "" {
-		return "", "", nil, nil, false, ErrInvalidResponse
-	}
-	return c.fetchProjectFieldsPage(ctx, issueID, &cursor)
 }
 
 func (c *Connector) projectFields(issueID string, items *projectItemsConnection) (string, string, *time.Time, map[string]string, bool) {
@@ -1678,97 +1438,48 @@ func (c *Connector) resolveStatusOption(ctx context.Context, githubState string)
 	return metadata.FieldID, optionID, nil
 }
 
-func (c *Connector) resolveUserID(ctx context.Context, login string) (string, error) {
+func (c *Connector) addAssignee(ctx context.Context, ref issueRef, login string) error {
 	login = strings.TrimSpace(login)
 	if login == "" {
-		return "", ErrAssigneeNotFound
-	}
-
-	var response struct {
-		User *struct {
-			ID string `json:"id"`
-		} `json:"user"`
-	}
-	if err := c.client.GraphQL(ctx, userByLoginQuery, map[string]any{"login": login}, &response); err != nil {
-		return "", fmt.Errorf("fetch github assignee: %w", err)
-	}
-	if response.User == nil || strings.TrimSpace(response.User.ID) == "" {
-		return "", fmt.Errorf("%w: %s", ErrAssigneeNotFound, login)
-	}
-	return strings.TrimSpace(response.User.ID), nil
-}
-
-func (c *Connector) addAssignee(ctx context.Context, issueID string, userID string) error {
-	issueID = strings.TrimSpace(issueID)
-	userID = strings.TrimSpace(userID)
-	if issueID == "" || userID == "" {
 		return ErrAssigneeNotFound
 	}
 
-	var response struct {
-		AddAssigneesToAssignable *struct {
-			Assignable *struct {
-				ID string `json:"id"`
-			} `json:"assignable"`
-		} `json:"addAssigneesToAssignable"`
-	}
-	if err := c.client.GraphQL(ctx, addAssigneesMutation, map[string]any{
-		"assignableId": issueID,
-		"assigneeIds":  []string{userID},
+	var response restIssue
+	if err := c.client.REST(ctx, http.MethodPost, restIssueAssigneesPath(ref), map[string]any{
+		"assignees": []string{login},
 	}, &response); err != nil {
 		return fmt.Errorf("set github assignee: %w", err)
 	}
-	if response.AddAssigneesToAssignable == nil ||
-		response.AddAssigneesToAssignable.Assignable == nil ||
-		strings.TrimSpace(response.AddAssigneesToAssignable.Assignable.ID) == "" {
+	if strings.TrimSpace(response.NodeID) == "" {
 		return ErrAssigneeUpdateFailed
 	}
 	return nil
 }
 
-func (c *Connector) fetchIssueAssignees(ctx context.Context, issueID string) ([]assignee, error) {
-	issueID = strings.TrimSpace(issueID)
-	if issueID == "" {
-		return nil, ErrAssigneeNotFound
-	}
-
-	var response struct {
-		Node *struct {
-			Assignees nodeConnection[assignee] `json:"assignees"`
-		} `json:"node"`
-	}
-	if err := c.client.GraphQL(ctx, issueAssigneesQuery, map[string]any{"issueId": issueID}, &response); err != nil {
+func (c *Connector) fetchIssueAssignees(ctx context.Context, ref issueRef) ([]assignee, error) {
+	issue, err := c.fetchRESTIssue(ctx, ref)
+	if err != nil {
 		return nil, fmt.Errorf("fetch github issue assignees: %w", err)
 	}
-	if response.Node == nil {
+	if strings.TrimSpace(issue.ID) == "" {
 		return nil, ErrAssigneeNotFound
 	}
-	return response.Node.Assignees.Nodes, nil
+	return issue.Assignees.Nodes, nil
 }
 
-func (c *Connector) removeAssignees(ctx context.Context, issueID string, userIDs []string) error {
-	issueID = strings.TrimSpace(issueID)
-	userIDs = uniqueNonBlank(userIDs)
-	if issueID == "" || len(userIDs) == 0 {
+func (c *Connector) removeAssignees(ctx context.Context, ref issueRef, logins []string) error {
+	logins = uniqueNonBlank(logins)
+	if len(logins) == 0 {
 		return ErrAssigneeUpdateFailed
 	}
 
-	var response struct {
-		RemoveAssigneesFromAssignable *struct {
-			Assignable *struct {
-				ID string `json:"id"`
-			} `json:"assignable"`
-		} `json:"removeAssigneesFromAssignable"`
-	}
-	if err := c.client.GraphQL(ctx, removeAssigneesMutation, map[string]any{
-		"assignableId": issueID,
-		"assigneeIds":  userIDs,
+	var response restIssue
+	if err := c.client.REST(ctx, http.MethodDelete, restIssueAssigneesPath(ref), map[string]any{
+		"assignees": logins,
 	}, &response); err != nil {
 		return fmt.Errorf("replace github assignee: %w", err)
 	}
-	if response.RemoveAssigneesFromAssignable == nil ||
-		response.RemoveAssigneesFromAssignable.Assignable == nil ||
-		strings.TrimSpace(response.RemoveAssigneesFromAssignable.Assignable.ID) == "" {
+	if strings.TrimSpace(response.NodeID) == "" {
 		return ErrAssigneeUpdateFailed
 	}
 	return nil
@@ -2193,16 +1904,140 @@ func buildIdentifier(repo string, number int) string {
 	return fmt.Sprintf("%s#%d", repo, number)
 }
 
+func issueRefFromIdentifier(identifier string) (issueRef, bool) {
+	repo, number, ok := splitIssueIdentifier(identifier)
+	if !ok {
+		return issueRef{}, false
+	}
+	owner, name, ok := splitRepositoryName(repo)
+	if !ok {
+		return issueRef{}, false
+	}
+	return issueRef{Owner: owner, Name: name, Number: number}, true
+}
+
+func issueRefFromNode(issue githubIssueNode) (issueRef, bool) {
+	owner, name, ok := splitRepositoryName(issue.Repository.NameWithOwner)
+	if !ok || issue.Number <= 0 {
+		return issueRef{}, false
+	}
+	return issueRef{Owner: owner, Name: name, Number: issue.Number}, true
+}
+
+func splitRepositoryName(repo string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(repo), "/")
+	if len(parts) != 2 {
+		return "", "", false
+	}
+	owner := strings.TrimSpace(parts[0])
+	name := strings.TrimSpace(parts[1])
+	if owner == "" || name == "" {
+		return "", "", false
+	}
+	return owner, name, true
+}
+
+func (c *Connector) cacheIssueRef(issue githubIssueNode) {
+	ref, ok := issueRefFromNode(issue)
+	if !ok {
+		return
+	}
+	c.projectCache.SetIssueRef(issue.ID, ref)
+}
+
+func restIssuePath(ref issueRef) string {
+	return "/repos/" + url.PathEscape(ref.Owner) + "/" + url.PathEscape(ref.Name) + "/issues/" + strconv.Itoa(ref.Number)
+}
+
+func restIssueCommentsPath(ref issueRef) string {
+	return restIssuePath(ref) + "/comments"
+}
+
+func restIssueCommentsListPath(ref issueRef) string {
+	return restIssueCommentsPath(ref) + "?per_page=100"
+}
+
+func restIssueAssigneesPath(ref issueRef) string {
+	return restIssuePath(ref) + "/assignees"
+}
+
+func restPullRequestsPath(repo pullRequestRepo, page int) string {
+	values := url.Values{}
+	values.Set("state", "all")
+	values.Set("sort", "updated")
+	values.Set("direction", "desc")
+	values.Set("per_page", strconv.Itoa(pullRequestsPageSize))
+	values.Set("page", strconv.Itoa(page))
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/pulls?" + values.Encode()
+}
+
+func restPullRequestReviewsPath(repo pullRequestRepo, number int) string {
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/pulls/" + strconv.Itoa(number) + "/reviews?per_page=100"
+}
+
+func restCommitCheckRunsPath(repo pullRequestRepo, sha string) string {
+	values := url.Values{}
+	values.Set("per_page", "100")
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/commits/" + url.PathEscape(sha) + "/check-runs?" + values.Encode()
+}
+
+func githubIssueNodeFromREST(ref issueRef, issue restIssue) githubIssueNode {
+	repo := ref.Owner + "/" + ref.Name
+	return githubIssueNode{
+		TypeName:  "Issue",
+		ID:        strings.TrimSpace(issue.NodeID),
+		Number:    issue.Number,
+		Title:     issue.Title,
+		Body:      restStringValue(issue.Body),
+		State:     issue.State,
+		URL:       issue.HTMLURL,
+		CreatedAt: restTimeString(issue.CreatedAt),
+		UpdatedAt: restTimeString(issue.UpdatedAt),
+		Author:    issue.User,
+		Assignees: restAssigneesConnection(issue.Assignees),
+		Labels:    nodeConnection[label]{Nodes: issue.Labels},
+		Repository: repository{
+			NameWithOwner: repo,
+		},
+	}
+}
+
+func restStringValue(value *string) string {
+	if value == nil {
+		return ""
+	}
+	return *value
+}
+
+func restTimeString(value *time.Time) *string {
+	if value == nil {
+		return nil
+	}
+	formatted := value.UTC().Format(time.RFC3339)
+	return &formatted
+}
+
+func restAssigneesConnection(values []restAssignee) nodeConnection[assignee] {
+	out := make([]assignee, 0, len(values))
+	for _, value := range values {
+		out = append(out, assignee{
+			ID:    strings.TrimSpace(value.NodeID),
+			Login: strings.TrimSpace(value.Login),
+		})
+	}
+	return nodeConnection[assignee]{Nodes: out}
+}
+
 func pullRequestRepoFromIdentifier(identifier string) (pullRequestRepo, bool) {
 	repo, _, ok := splitIssueIdentifier(identifier)
 	if !ok {
 		return pullRequestRepo{}, false
 	}
-	parts := strings.Split(repo, "/")
-	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+	owner, name, ok := splitRepositoryName(repo)
+	if !ok {
 		return pullRequestRepo{}, false
 	}
-	return pullRequestRepo{Owner: strings.TrimSpace(parts[0]), Name: strings.TrimSpace(parts[1])}, true
+	return pullRequestRepo{Owner: owner, Name: name}, true
 }
 
 func detentIssueBranchPrefix(identifier string) string {
@@ -2279,22 +2114,22 @@ func allAssigneeLogins(assignees nodeConnection[assignee]) []string {
 	return logins
 }
 
-func assigneeReplacement(current []assignee, targetID string) ([]string, bool) {
-	targetID = strings.TrimSpace(targetID)
-	removeIDs := make([]string, 0, len(current))
+func assigneeLoginReplacement(current []assignee, targetLogin string) ([]string, bool) {
+	targetLogin = strings.TrimSpace(targetLogin)
+	removeLogins := make([]string, 0, len(current))
 	alreadyAssigned := false
 	for _, candidate := range current {
-		id := strings.TrimSpace(candidate.ID)
-		if id == "" {
+		login := strings.TrimSpace(candidate.Login)
+		if login == "" {
 			continue
 		}
-		if id == targetID {
+		if strings.EqualFold(login, targetLogin) {
 			alreadyAssigned = true
 			continue
 		}
-		removeIDs = append(removeIDs, id)
+		removeLogins = append(removeLogins, login)
 	}
-	return removeIDs, alreadyAssigned
+	return removeLogins, alreadyAssigned
 }
 
 func projectFieldValues(values nodeConnection[projectFieldValue]) map[string]string {
@@ -2346,6 +2181,39 @@ func pullRequestCIState(pullRequest pullRequestNode) string {
 		}
 	}
 	return ""
+}
+
+func restPullRequestState(pullRequest restPullRequest) string {
+	if pullRequest.MergedAt != nil && strings.TrimSpace(*pullRequest.MergedAt) != "" {
+		return "MERGED"
+	}
+	return strings.ToUpper(strings.TrimSpace(pullRequest.State))
+}
+
+func checkRunsState(checkRuns []restCheckRun) string {
+	if len(checkRuns) == 0 {
+		return ""
+	}
+	pending := false
+	for _, checkRun := range checkRuns {
+		status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+		if status != "" && status != "completed" {
+			pending = true
+			continue
+		}
+		switch conclusion {
+		case "success", "skipped", "neutral":
+		case "":
+			pending = true
+		default:
+			return "failure"
+		}
+	}
+	if pending {
+		return "pending"
+	}
+	return "success"
 }
 
 func normalizePullRequestCIStatus(status string) string {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -382,9 +382,11 @@ type statusCheckRollup struct {
 }
 
 type pullRequestReview struct {
-	Body   string `json:"body"`
-	State  string `json:"state"`
-	Author *actor `json:"author"`
+	Body        string     `json:"body"`
+	State       string     `json:"state"`
+	Author      *actor     `json:"author"`
+	CommitID    string     `json:"commitId"`
+	SubmittedAt *time.Time `json:"submittedAt"`
 }
 
 type actor struct {
@@ -424,9 +426,11 @@ type restHead struct {
 }
 
 type restReview struct {
-	Body  string `json:"body"`
-	State string `json:"state"`
-	User  *actor `json:"user"`
+	Body        string     `json:"body"`
+	State       string     `json:"state"`
+	User        *actor     `json:"user"`
+	CommitID    string     `json:"commit_id"`
+	SubmittedAt *time.Time `json:"submitted_at"`
 }
 
 type restCheckRuns struct {
@@ -436,6 +440,12 @@ type restCheckRuns struct {
 type restCheckRun struct {
 	Status     string `json:"status"`
 	Conclusion string `json:"conclusion"`
+}
+
+type restCommitStatus struct {
+	Context   string     `json:"context"`
+	State     string     `json:"state"`
+	CreatedAt *time.Time `json:"created_at"`
 }
 
 type restComment struct {
@@ -1077,7 +1087,7 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 			Commit: commitNode{StatusCheckRollup: &statusCheckRollup{State: ciState}},
 		}}}
 	}
-	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number)
+	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number, pullRequest.HeadSHA)
 	if err != nil {
 		return err
 	}
@@ -1086,27 +1096,27 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 }
 
 func (c *Connector) fetchPullRequestCIState(ctx context.Context, repo pullRequestRepo, sha string) (string, error) {
-	var response restCheckRuns
-	if err := c.client.REST(ctx, http.MethodGet, restCommitCheckRunsPath(repo, sha), nil, &response); err != nil {
+	var checkRuns restCheckRuns
+	if err := c.client.REST(ctx, http.MethodGet, restCommitCheckRunsPath(repo, sha), nil, &checkRuns); err != nil {
 		return "", fmt.Errorf("fetch github check runs: %w", err)
 	}
-	return checkRunsState(response.CheckRuns), nil
+	var statuses []restCommitStatus
+	if err := c.client.REST(ctx, http.MethodGet, restCommitStatusesPath(repo, sha), nil, &statuses); err != nil {
+		return "", fmt.Errorf("fetch github commit statuses: %w", err)
+	}
+	return combinedCIState(checkRunsState(checkRuns.CheckRuns), commitStatusesState(statuses)), nil
 }
 
-func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int) ([]pullRequestReview, error) {
+func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int, headSHA string) ([]pullRequestReview, error) {
 	var response []restReview
 	if err := c.client.REST(ctx, http.MethodGet, restPullRequestReviewsPath(repo, number), nil, &response); err != nil {
 		return nil, fmt.Errorf("fetch github pull request reviews: %w", err)
 	}
-	reviews := make([]pullRequestReview, 0, len(response))
-	for _, review := range response {
-		reviews = append(reviews, pullRequestReview{
-			Body:   review.Body,
-			State:  review.State,
-			Author: review.User,
-		})
+	review, ok := latestCodexReview(response, headSHA)
+	if !ok {
+		return nil, nil
 	}
-	return reviews, nil
+	return []pullRequestReview{review}, nil
 }
 
 func (c *Connector) fetchProjectItems(ctx context.Context, query string, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
@@ -1981,6 +1991,12 @@ func restCommitCheckRunsPath(repo pullRequestRepo, sha string) string {
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/commits/" + url.PathEscape(sha) + "/check-runs?" + values.Encode()
 }
 
+func restCommitStatusesPath(repo pullRequestRepo, sha string) string {
+	values := url.Values{}
+	values.Set("per_page", "100")
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/commits/" + url.PathEscape(sha) + "/statuses?" + values.Encode()
+}
+
 func githubIssueNodeFromREST(ref issueRef, issue restIssue) githubIssueNode {
 	repo := ref.Owner + "/" + ref.Name
 	return githubIssueNode{
@@ -2216,6 +2232,72 @@ func checkRunsState(checkRuns []restCheckRun) string {
 	return "success"
 }
 
+func commitStatusesState(statuses []restCommitStatus) string {
+	if len(statuses) == 0 {
+		return ""
+	}
+	latestByContext := map[string]restCommitStatus{}
+	for index, status := range statuses {
+		context := strings.TrimSpace(status.Context)
+		if context == "" {
+			context = strconv.Itoa(index)
+		}
+		previous, ok := latestByContext[context]
+		if !ok || restCommitStatusAfter(status, previous) {
+			latestByContext[context] = status
+		}
+	}
+	pending := false
+	for _, status := range latestByContext {
+		switch strings.ToLower(strings.TrimSpace(status.State)) {
+		case "success":
+		case "pending":
+			pending = true
+		case "":
+			pending = true
+		default:
+			return "failure"
+		}
+	}
+	if pending {
+		return "pending"
+	}
+	return "success"
+}
+
+func restCommitStatusAfter(left restCommitStatus, right restCommitStatus) bool {
+	if left.CreatedAt == nil {
+		return false
+	}
+	if right.CreatedAt == nil {
+		return true
+	}
+	return left.CreatedAt.After(*right.CreatedAt)
+}
+
+func combinedCIState(checkRuns string, statuses string) string {
+	states := []string{checkRuns, statuses}
+	hasSuccess := false
+	hasPending := false
+	for _, state := range states {
+		switch strings.ToLower(strings.TrimSpace(state)) {
+		case "failure", "failed", "error":
+			return "failure"
+		case "pending", "expected", "queued", "waiting", "in_progress", "in progress":
+			hasPending = true
+		case "success", "green", "pass", "passed":
+			hasSuccess = true
+		}
+	}
+	if hasPending {
+		return "pending"
+	}
+	if hasSuccess {
+		return "success"
+	}
+	return ""
+}
+
 func normalizePullRequestCIStatus(status string) string {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "success", "green", "pass", "passed":
@@ -2229,8 +2311,52 @@ func normalizePullRequestCIStatus(status string) string {
 	}
 }
 
+func latestCodexReview(reviews []restReview, headSHA string) (pullRequestReview, bool) {
+	headSHA = strings.TrimSpace(headSHA)
+	var latest pullRequestReview
+	found := false
+	for _, review := range reviews {
+		if !codexReviewAuthor(review.User) || strings.EqualFold(strings.TrimSpace(review.State), "DISMISSED") {
+			continue
+		}
+		if headSHA != "" && strings.TrimSpace(review.CommitID) != "" && review.CommitID != headSHA {
+			continue
+		}
+		candidate := pullRequestReview{
+			Body:        review.Body,
+			State:       review.State,
+			Author:      review.User,
+			CommitID:    review.CommitID,
+			SubmittedAt: review.SubmittedAt,
+		}
+		if !found || pullRequestReviewAfter(candidate, latest) {
+			latest = candidate
+			found = true
+		}
+	}
+	return latest, found
+}
+
+func codexReviewAuthor(author *actor) bool {
+	if author == nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(strings.TrimSpace(author.Login)), "codex")
+}
+
+func pullRequestReviewAfter(left pullRequestReview, right pullRequestReview) bool {
+	if left.SubmittedAt == nil {
+		return right.SubmittedAt == nil
+	}
+	if right.SubmittedAt == nil {
+		return true
+	}
+	return left.SubmittedAt.After(*right.SubmittedAt)
+}
+
 func pullRequestCodexReviewState(pullRequest pullRequestNode) string {
 	hasP2 := false
+	reviewState := ""
 	for _, review := range pullRequest.LatestReviews.Nodes {
 		if containsReviewSeverity(review.Body, "P1") {
 			return "P1"
@@ -2238,11 +2364,14 @@ func pullRequestCodexReviewState(pullRequest pullRequestNode) string {
 		if containsReviewSeverity(review.Body, "P2") {
 			hasP2 = true
 		}
+		if state := strings.ToUpper(strings.TrimSpace(review.State)); state != "" {
+			reviewState = state
+		}
 	}
 	if hasP2 {
 		return "P2"
 	}
-	return ""
+	return reviewState
 }
 
 func containsReviewSeverity(body string, severity string) bool {

--- a/internal/connector/github/adapter_parity_test.go
+++ b/internal/connector/github/adapter_parity_test.go
@@ -21,10 +21,12 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 			body: `{"data":{"updateProjectV2Field":{"projectV2Field":{"options":[{"name":"Urgent","color":"RED","description":"Needs immediate attention."},{"name":"High","color":"ORANGE","description":"Important work to prioritize soon."},{"id":"OPT_medium","name":"Medium","color":"YELLOW","description":"Normal."},{"name":"Low","color":"BLUE","description":"Can wait behind higher-priority work."},{"name":"No priority","color":"GRAY","description":"Priority has not been set."}]}}}}`,
 		},
 		{
-			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_28","content":{"__typename":"Issue","id":"I_kw28","number":28,"title":"Projects-v2 parity gate","body":"Depends on: #26 #27\n<!-- model: gpt-5-codex-high -->","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/28","createdAt":"2026-05-31T04:12:00Z","updatedAt":"2026-05-31T04:30:00Z","assignees":{"nodes":[{"login":"codex"}]},"labels":{"nodes":[{"name":"gate"},{"name":"stage:S4"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"Urgent"}},{"id":"PVTI_29","content":{"__typename":"Issue","id":"I_kw29","number":29,"title":"Human review","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/29","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"In Review"},"priorityValue":{"name":"No priority"}}]}}}}`,
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_28","content":{"__typename":"Issue","id":"I_kw28","number":28,"title":"Projects-v2 parity gate","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/28","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"Urgent"}},{"id":"PVTI_29","content":{"__typename":"Issue","id":"I_kw29","number":29,"title":"Human review","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/29","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"In Review"},"priorityValue":{"name":"No priority"}}]}}}}`,
 		},
 		{
-			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+			method: "GET",
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
 		},
 		{
 			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_28","project":{"id":"PVT_throwaway"}}]}}}}`,
@@ -36,7 +38,9 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 			body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_28"}}}}`,
 		},
 		{
-			body: `{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_workpad"}}}}}`,
+			method: "POST",
+			path:   "/repos/digitaldrywood/detent/issues/28/comments",
+			body:   `{"node_id":"IC_workpad"}`,
 		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
@@ -75,12 +79,6 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 	}
 	if issues[0].Priority == nil || *issues[0].Priority != 1 {
 		t.Fatalf("candidate priority = %v, want rank 1", issues[0].Priority)
-	}
-	if issues[0].ModelOverride != "gpt-5-codex-high" {
-		t.Fatalf("candidate ModelOverride = %q, want gpt-5-codex-high", issues[0].ModelOverride)
-	}
-	if got := len(issues[0].BlockedBy); got != 2 {
-		t.Fatalf("candidate BlockedBy len = %d, want 2", got)
 	}
 
 	if err := c.UpdateIssueState(ctx, "I_kw28", "Human Review"); err != nil {
@@ -135,15 +133,12 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 		t.Fatalf("update query = %q, want updateProjectV2ItemFieldValue", requests[7]["query"])
 	}
 
-	commentVariables := requestVariables(t, requests[8])
-	if commentVariables["subjectId"] != "I_kw28" {
-		t.Fatalf("comment subjectId = %v, want I_kw28", commentVariables["subjectId"])
+	if requests[8]["method"] != "POST" || requests[8]["path"] != "/repos/digitaldrywood/detent/issues/28/comments" {
+		t.Fatalf("comment request = %#v, want REST issue comment", requests[8])
 	}
-	if commentVariables["body"] != "## Codex Workpad\n\nReady for review." {
-		t.Fatalf("comment body = %q", commentVariables["body"])
-	}
-	if !strings.Contains(requests[8]["query"].(string), "addComment") {
-		t.Fatalf("comment query = %q, want addComment", requests[8]["query"])
+	commentBody := requests[8]["body"].(map[string]any)
+	if commentBody["body"] != "## Codex Workpad\n\nReady for review." {
+		t.Fatalf("comment body = %q", commentBody["body"])
 	}
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -18,9 +19,11 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","body":"Depends on: #24 digitaldrywood/detent#25\n<!-- model: gpt-5-codex-high -->","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/26","createdAt":"2026-05-31T01:02:03Z","updatedAt":"2026-05-31T02:03:04Z","author":{"login":"corylanou"},"assignees":{"nodes":[{"login":"worker-1"},{"login":"worker-2"}]},"labels":{"nodes":[{"name":"Enhancement"},{"name":"stage:S4"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":42,"url":"https://github.com/digitaldrywood/detent/pull/42"}]}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P0"},"fieldValues":{"nodes":[{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"Ready","field":{"name":"Status"}},{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"P0","field":{"name":"Priority"}},{"__typename":"ProjectV2ItemFieldTextValue","text":"release-ready","field":{"name":"Track"}},{"__typename":"ProjectV2ItemFieldNumberValue","number":7,"field":{"name":"Sort"}}]}},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":27,"title":"Backlog item","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/27","createdAt":"2026-05-31T03:02:03Z","updatedAt":"2026-05-31T04:03:04Z","author":{"login":"octocat"},"assignees":{"nodes":[{"login":"worker-1"}]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Backlog"},"priorityValue":{"name":"No priority"},"fieldValues":{"nodes":[]}}]}}}}`,
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/26","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P0"}},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":27,"title":"Backlog item","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/27","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"},"priorityValue":{"name":"No priority"}}]}}}}`,
 	}, {
-		body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+		body:   `[]`,
 	}})
 
 	c := newGitHubTestConnector(t, server, Config{
@@ -38,29 +41,19 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
 	}
 
-	createdAt := time.Date(2026, 5, 31, 1, 2, 3, 0, time.UTC)
-	updatedAt := time.Date(2026, 5, 31, 2, 3, 4, 0, time.UTC)
 	priority := 1
-	prNumber := 42
 	want := connector.Issue{
 		ID:               "I_kw1",
 		Identifier:       "digitaldrywood/detent#26",
 		Title:            "GitHub adapter",
-		Description:      "Depends on: #24 digitaldrywood/detent#25\n<!-- model: gpt-5-codex-high -->",
 		Priority:         &priority,
 		State:            "Todo",
 		URL:              "https://github.com/digitaldrywood/detent/issues/26",
-		PRNumber:         &prNumber,
-		AuthorID:         "corylanou",
-		AssigneeID:       "worker-1",
-		Assignees:        []string{"worker-1", "worker-2"},
-		BlockedBy:        []connector.BlockedRef{{Identifier: "digitaldrywood/detent#24"}, {Identifier: "digitaldrywood/detent#25"}},
-		Labels:           []string{"enhancement", "stage:s4"},
-		Fields:           map[string]string{"Priority": "P0", "Sort": "7", "Status": "Ready", "Track": "release-ready"},
+		BlockedBy:        []connector.BlockedRef{},
+		Labels:           []string{},
+		Assignees:        []string{},
+		Fields:           map[string]string{},
 		AssignedToWorker: true,
-		CreatedAt:        &createdAt,
-		UpdatedAt:        &updatedAt,
-		ModelOverride:    "gpt-5-codex-high",
 	}
 	if !reflect.DeepEqual(got[0], want) {
 		t.Fatalf("FetchCandidateIssues()[0] = %#v, want %#v", got[0], want)
@@ -80,27 +73,23 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	if variables["query"] != "status:Ready" {
 		t.Fatalf("query = %v, want status:Ready", variables["query"])
 	}
-	if variables["projectItemFieldValuesFirst"] != float64(projectItemFieldValuesPageSize) {
-		t.Fatalf("projectItemFieldValuesFirst = %v, want %d", variables["projectItemFieldValuesFirst"], projectItemFieldValuesPageSize)
-	}
-	if variables["linkedIssuesFirst"] != float64(linkedIssuePageSize) {
-		t.Fatalf("linkedIssuesFirst = %v, want %d", variables["linkedIssuesFirst"], linkedIssuePageSize)
-	}
-	if variables["linkedProjectItemsFirst"] != float64(linkedIssueProjectItemsPageSize) {
-		t.Fatalf("linkedProjectItemsFirst = %v, want %d", variables["linkedProjectItemsFirst"], linkedIssueProjectItemsPageSize)
-	}
-	if variables["linkedProjectItemFieldValuesFirst"] != float64(linkedIssueProjectItemFieldValuesPageSize) {
-		t.Fatalf("linkedProjectItemFieldValuesFirst = %v, want %d", variables["linkedProjectItemFieldValuesFirst"], linkedIssueProjectItemFieldValuesPageSize)
-	}
-	prVariables := requests[1]["variables"].(map[string]any)
-	if prVariables["owner"] != "digitaldrywood" || prVariables["name"] != "detent" {
-		t.Fatalf("pull request repo variables = %#v, want digitaldrywood/detent", prVariables)
-	}
 	query := requests[0]["query"].(string)
-	for _, want := range []string{"author { login }", "assignees(first: 100)", "fieldValues(first: $projectItemFieldValuesFirst)"} {
-		if !strings.Contains(query, want) {
-			t.Fatalf("project query missing %q:\n%s", want, query)
+	for _, forbidden := range []string{
+		"author { login }",
+		"assignees(",
+		"labels(",
+		"body",
+		"closedByPullRequestsReferences",
+		"subIssues(",
+		"trackedIssues(",
+		"fieldValues(",
+	} {
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("project query contains %q:\n%s", forbidden, query)
 		}
+	}
+	if requests[1]["method"] != http.MethodGet || !strings.HasPrefix(requests[1]["path"].(string), "/repos/digitaldrywood/detent/pulls?") {
+		t.Fatalf("pull request request = %#v, want REST pulls list", requests[1])
 	}
 }
 
@@ -364,13 +353,15 @@ func TestConnectorFetchIssuesByStatesIgnoresBlankStatusDefaultWriteFailure(t *te
 	}
 }
 
-func TestConnectorFetchCandidateIssuesResolvesBlockedByProjectState(t *testing.T) {
+func TestConnectorFetchCandidateIssuesLeavesDependencyResolutionForHydration(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_candidate","number":26,"title":"Candidate","body":"Depends on: DigitalDryWood/Detent#24 digitaldrywood/detent#25 digitaldrywood/detent#999","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/26","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":null},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_done","number":24,"title":"Done blocker","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/24","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Done"},"priorityValue":null},{"id":"PVTI_3","content":{"__typename":"Issue","id":"I_progress","number":25,"title":"Active blocker","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/25","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Working"},"priorityValue":null}]}}}}`,
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_candidate","number":26,"title":"Candidate","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/26","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":null},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_done","number":24,"title":"Done blocker","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/24","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Done"},"priorityValue":null},{"id":"PVTI_3","content":{"__typename":"Issue","id":"I_progress","number":25,"title":"Active blocker","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/25","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Working"},"priorityValue":null}]}}}}`,
 	}, {
-		body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+		body:   `[]`,
 	}})
 
 	c := newGitHubTestConnector(t, server, Config{
@@ -390,13 +381,8 @@ func TestConnectorFetchCandidateIssuesResolvesBlockedByProjectState(t *testing.T
 		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
 	}
 
-	want := []connector.BlockedRef{
-		{ID: "I_done", Identifier: "digitaldrywood/detent#24", State: "Done"},
-		{ID: "I_progress", Identifier: "digitaldrywood/detent#25", State: "In Progress"},
-		{Identifier: "digitaldrywood/detent#999"},
-	}
-	if !reflect.DeepEqual(got[0].BlockedBy, want) {
-		t.Fatalf("BlockedBy = %#v, want %#v", got[0].BlockedBy, want)
+	if len(got[0].BlockedBy) != 0 {
+		t.Fatalf("BlockedBy = %#v, want no dependency graph from lightweight poll", got[0].BlockedBy)
 	}
 }
 
@@ -404,9 +390,11 @@ func TestConnectorFetchCandidateIssuesCapturesLinkedChildIssues(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_epic","content":{"__typename":"Issue","id":"I_epic","number":258,"title":"Epic: release readiness","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/258","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"epic"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]},"subIssues":{"nodes":[{"id":"I_sub","number":251,"title":"Sub issue","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/251","repository":{"nameWithOwner":"digitaldrywood/detent"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[]}}]},"trackedIssues":{"nodes":[{"id":"I_tracked","number":252,"title":"Tracked issue","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/252","repository":{"nameWithOwner":"digitaldrywood/detent"},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_tracked","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}]}},"statusValue":{"name":"Todo"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}}}`,
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_epic","content":{"__typename":"Issue","id":"I_epic","number":258,"title":"Epic: release readiness","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/258","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
 	}, {
-		body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+		body:   `[]`,
 	}})
 
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
@@ -419,22 +407,18 @@ func TestConnectorFetchCandidateIssuesCapturesLinkedChildIssues(t *testing.T) {
 		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
 	}
 
-	want := []connector.BlockedRef{
-		{ID: "I_sub", Identifier: "digitaldrywood/detent#251", State: "Done"},
-		{ID: "I_tracked", Identifier: "digitaldrywood/detent#252", State: "Done"},
-	}
-	if !reflect.DeepEqual(got[0].ChildIssues, want) {
-		t.Fatalf("ChildIssues = %#v, want %#v", got[0].ChildIssues, want)
+	if got[0].ChildIssues != nil {
+		t.Fatalf("ChildIssues = %#v, want nil from lightweight poll", got[0].ChildIssues)
 	}
 
 	query := server.requests()[0]["query"].(string)
-	for _, want := range []string{
-		"subIssues(first: $linkedIssuesFirst)",
-		"trackedIssues(first: $linkedIssuesFirst)",
-		"fieldValues(first: $linkedProjectItemFieldValuesFirst)",
+	for _, forbidden := range []string{
+		"subIssues(",
+		"trackedIssues(",
+		"fieldValues(",
 	} {
-		if !strings.Contains(query, want) {
-			t.Fatalf("project query missing %q:\n%s", want, query)
+		if strings.Contains(query, forbidden) {
+			t.Fatalf("project query contains %q:\n%s", forbidden, query)
 		}
 	}
 }
@@ -447,7 +431,19 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_182","content":{"__typename":"Issue","id":"I_182","number":182,"title":"First issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/182","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Todo"},"priorityValue":null},{"id":"PVTI_18","content":{"__typename":"Issue","id":"I_18","number":18,"title":"Prefix neighbor","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/18","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
 		},
 		{
-			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"number":187,"url":"https://github.com/digitaldrywood/detent/pull/187","state":"OPEN","headRefName":"detent/digitaldrywood_detent_182_followup","commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"SUCCESS"}}}]},"latestReviews":{"nodes":[{"body":"[P2] The fallback path needs cleanup.","state":"COMMENTED","author":{"login":"codex"}}]}},{"number":188,"url":"https://github.com/digitaldrywood/detent/pull/188","state":"MERGED","headRefName":"detent/digitaldrywood_detent_181"}]}}}}`,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","head":{"ref":"detent/digitaldrywood_detent_182_followup","sha":"sha-187"}},{"number":188,"html_url":"https://github.com/digitaldrywood/detent/pull/188","state":"closed","head":{"ref":"detent/digitaldrywood_detent_181","sha":"sha-188"},"merged_at":"2026-06-01T00:00:00Z"}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/187/reviews?per_page=100",
+			body:   `[{"body":"[P2] The fallback path needs cleanup.","state":"COMMENTED","user":{"login":"codex"}}]`,
 		},
 	})
 
@@ -488,7 +484,19 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_182","content":{"__typename":"Issue","id":"I_182","number":182,"title":"Review issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/182","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Reviewing"},"priorityValue":null}]}}}}`,
 		},
 		{
-			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"number":190,"url":"https://github.com/digitaldrywood/detent/pull/190","state":"OPEN","headRefName":"detent/digitaldrywood_detent_182","commits":{"nodes":[{"commit":{"statusCheckRollup":{"state":"FAILURE"}}}]},"latestReviews":{"nodes":[{"body":"[P1] Unsafe migration.","state":"COMMENTED","author":{"login":"codex"}}]}}]}}}}`,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[{"number":190,"html_url":"https://github.com/digitaldrywood/detent/pull/190","state":"open","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-190"}}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-190/check-runs?per_page=100",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"failure"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/190/reviews?per_page=100",
+			body:   `[{"body":"[P1] Unsafe migration.","state":"COMMENTED","user":{"login":"codex"}}]`,
 		},
 	})
 
@@ -520,13 +528,9 @@ func TestConnectorFetchCandidateIssuesLimitsPullRequestPagination(t *testing.T) 
 			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_1","number":1,"title":"Candidate","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/1","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
 		},
 		{
-			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[]}}}}`,
-		},
-		{
-			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-2"},"nodes":[]}}}}`,
-		},
-		{
-			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-3"},"nodes":[]}}}}`,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
 		},
 	})
 
@@ -544,12 +548,11 @@ func TestConnectorFetchCandidateIssuesLimitsPullRequestPagination(t *testing.T) 
 	}
 
 	requests := server.requests()
-	if len(requests) != 4 {
-		t.Fatalf("request count = %d, want project query plus 3 pull request pages", len(requests))
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want project query plus pull request page", len(requests))
 	}
-	variables := requests[3]["variables"].(map[string]any)
-	if variables["after"] != "cursor-2" {
-		t.Fatalf("third pull request page after = %v, want cursor-2", variables["after"])
+	if requests[1]["method"] != http.MethodGet || !strings.HasPrefix(requests[1]["path"].(string), "/repos/digitaldrywood/detent/pulls?") {
+		t.Fatalf("pull request request = %#v, want REST pulls list", requests[1])
 	}
 }
 
@@ -599,10 +602,12 @@ func TestConnectorFetchIssuesByStatesUsesStatusUpdatedAtForStage(t *testing.T) {
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":1,"title":"Done issue","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/1","createdAt":"2026-05-31T01:02:03Z","updatedAt":"2026-05-31T02:03:04Z","assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Done","updatedAt":"2026-06-01T12:30:00Z"},"priorityValue":null}]}}}}`,
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":1,"title":"Done issue","state":"OPEN","url":"https://github.com/example/repo/issues/1","repository":{"nameWithOwner":"example/repo"}},"statusValue":{"name":"Done","updatedAt":"2026-06-01T12:30:00Z"},"priorityValue":null}]}}}}`,
 		},
 		{
-			body: `{"data":{"repository":{"pullRequests":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
 		},
 	})
 
@@ -618,10 +623,9 @@ func TestConnectorFetchIssuesByStatesUsesStatusUpdatedAtForStage(t *testing.T) {
 		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
 	}
 
-	issueUpdatedAt := time.Date(2026, 5, 31, 2, 3, 4, 0, time.UTC)
 	stageUpdatedAt := time.Date(2026, 6, 1, 12, 30, 0, 0, time.UTC)
-	if got[0].UpdatedAt == nil || !got[0].UpdatedAt.Equal(issueUpdatedAt) {
-		t.Fatalf("UpdatedAt = %v, want issue updatedAt %v", got[0].UpdatedAt, issueUpdatedAt)
+	if got[0].UpdatedAt != nil {
+		t.Fatalf("UpdatedAt = %v, want nil from lightweight poll", got[0].UpdatedAt)
 	}
 	if got[0].StageUpdatedAt == nil || !got[0].StageUpdatedAt.Equal(stageUpdatedAt) {
 		t.Fatalf("StageUpdatedAt = %v, want status updatedAt %v", got[0].StageUpdatedAt, stageUpdatedAt)
@@ -633,10 +637,12 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadHumanActionNeeded(t *testing
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw98","number":98,"title":"Homebrew tap","body":"Depends on: #97","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/98","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Blocked"},"priorityValue":null}]}}}}`,
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw98","number":98,"title":"Homebrew tap","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/98","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Blocked"},"priorityValue":null}]}}}}`,
 		},
 		{
-			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw98","body":"Depends on: #97","comments":{"nodes":[{"body":"## Codex Workpad\n\n### Plan\n- Check prerequisites.\n\n### Human Action Needed\n- Create public repository ` + "`" + `digitaldrywood/homebrew-tap` + "`" + `.\n- Add repository Actions secret ` + "`" + `HOMEBREW_TAP_GITHUB_TOKEN` + "`" + `.\n\n### Validation Evidence\n- Not run."}]}}]}}`,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/98/comments?per_page=100",
+			body:   `[{"body":"## Codex Workpad\n\n### Plan\n- Check prerequisites.\n\n### Human Action Needed\n- Create public repository ` + "`" + `digitaldrywood/homebrew-tap` + "`" + `.\n- Add repository Actions secret ` + "`" + `HOMEBREW_TAP_GITHUB_TOKEN` + "`" + `.\n\n### Validation Evidence\n- Not run."}]`,
 		},
 	})
 
@@ -664,17 +670,35 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadHumanActionNeeded(t *testing
 	if strings.Contains(requests[0]["query"].(string), "comments") {
 		t.Fatalf("project query = %q, want no comments", requests[0]["query"])
 	}
-	if !strings.Contains(requests[1]["query"].(string), "comments") {
-		t.Fatalf("comments query = %q, want comments", requests[1]["query"])
+	if requests[1]["method"] != http.MethodGet || requests[1]["path"] != "/repos/digitaldrywood/detent/issues/98/comments?per_page=100" {
+		t.Fatalf("comments request = %#v, want REST issue comments", requests[1])
 	}
 }
 
 func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"title":"First","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/1","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"closedByPullRequestsReferences":{"nodes":[{"number":81,"url":"https://github.com/example/repo/pull/81"}]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"}}]}},{"__typename":"Issue","id":"I_kw2","number":2,"title":"Second","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/2","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"closedByPullRequestsReferences":{"nodes":[]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_2","project":{"id":"PVT_1"},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"No priority"}}]}}]}}`,
-	}})
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"repository":{"nameWithOwner":"example/repo"}},{"__typename":"Issue","id":"I_kw2","number":2,"repository":{"nameWithOwner":"example/repo"}}]}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/issues/2",
+			body:   `{"node_id":"I_kw2","number":2,"title":"Second","body":"","state":"open","html_url":"https://github.com/example/repo/issues/2","assignees":[],"labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_2","project":{"id":"PVT_1"},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"No priority"},"fieldValues":{"nodes":[]}}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/issues/1",
+			body:   `{"node_id":"I_kw1","number":1,"title":"First","body":"","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[],"labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[]}}]}}}}`,
+		},
+	})
 
 	c := newGitHubTestConnector(t, server, Config{
 		ProjectSlug: "PVT_1",
@@ -698,17 +722,24 @@ func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testi
 	if got[1].Priority == nil || *got[1].Priority != 2 {
 		t.Fatalf("second Priority = %v, want 2", got[1].Priority)
 	}
-	if got[1].PRNumber == nil || *got[1].PRNumber != 81 {
-		t.Fatalf("second PRNumber = %v, want 81", got[1].PRNumber)
-	}
 }
 
 func TestConnectorFetchIssueStatesByIDsCapturesIssueMetadata(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"title":"First","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/1","createdAt":null,"updatedAt":null,"author":{"login":"author-1"},"assignees":{"nodes":[{"login":"worker-1"},{"login":"worker-2"}]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"closedByPullRequestsReferences":{"nodes":[]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"Ready","field":{"name":"Status"}},{"__typename":"ProjectV2ItemFieldTextValue","text":"team-a","field":{"name":"Owner"}},{"__typename":"ProjectV2ItemFieldNumberValue","number":3,"field":{"name":"Weight"}}]}}]}}]}}`,
-	}})
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"repository":{"nameWithOwner":"example/repo"}}]}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/issues/1",
+			body:   `{"node_id":"I_kw1","number":1,"title":"First","body":"","state":"open","html_url":"https://github.com/example/repo/issues/1","user":{"login":"author-1"},"assignees":[{"node_id":"U_1","login":"worker-1"},{"node_id":"U_2","login":"worker-2"}],"labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"Ready","field":{"name":"Status"}},{"__typename":"ProjectV2ItemFieldTextValue","text":"team-a","field":{"name":"Owner"}},{"__typename":"ProjectV2ItemFieldNumberValue","number":3,"field":{"name":"Weight"}}]}}]}}}}`,
+		},
+	})
 
 	c := newGitHubTestConnector(t, server, Config{
 		ProjectSlug: "PVT_1",
@@ -744,7 +775,15 @@ func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"title":"Later project","body":"","state":"OPEN","url":"https://github.com/example/repo/issues/1","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"example/repo"},"projectItems":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[{"id":"PVTI_other","project":{"id":"PVT_other"},"statusValue":{"name":"Open"},"priorityValue":{"name":"P1"}}]}}]}}`,
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_kw1","number":1,"repository":{"nameWithOwner":"example/repo"}}]}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/issues/1",
+			body:   `{"node_id":"I_kw1","number":1,"title":"Later project","body":"","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[],"labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":true,"endCursor":"cursor-1"},"nodes":[{"id":"PVTI_other","project":{"id":"PVT_other"},"statusValue":{"name":"Open"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[]}}]}}}}`,
 		},
 		{
 			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Reviewing"},"priorityValue":{"name":"P2"}}]}}}}`,
@@ -774,10 +813,10 @@ func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 2 {
-		t.Fatalf("request count = %d, want 2", len(requests))
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want identity, REST issue, and 2 project item pages", len(requests))
 	}
-	variables := requests[1]["variables"].(map[string]any)
+	variables := requests[3]["variables"].(map[string]any)
 	if variables["after"] != "cursor-1" {
 		t.Fatalf("after = %v, want cursor-1", variables["after"])
 	}
@@ -791,10 +830,20 @@ func TestConnectorFetchIssueStatesByIdentifiersResolvesGitHubStateAndProjectStat
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"repository":{"issue":{"__typename":"Issue","id":"I_closed","number":251,"title":"Closed child","body":"","state":"CLOSED","url":"https://github.com/digitaldrywood/detent/issues/251","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}}`,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/251",
+			body:   `{"node_id":"I_closed","number":251,"title":"Closed child","body":"","state":"closed","html_url":"https://github.com/digitaldrywood/detent/issues/251","assignees":[],"labels":[]}`,
 		},
 		{
-			body: `{"data":{"repository":{"issue":{"__typename":"Issue","id":"I_done","number":252,"title":"Done child","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/252","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]},"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_done","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}}}}`,
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/252",
+			body:   `{"node_id":"I_done","number":252,"title":"Done child","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/252","assignees":[],"labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_done","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}}}`,
 		},
 	})
 
@@ -815,12 +864,11 @@ func TestConnectorFetchIssueStatesByIdentifiersResolvesGitHubStateAndProjectStat
 	}
 
 	requests := server.requests()
-	if len(requests) != 2 {
-		t.Fatalf("request count = %d, want 2", len(requests))
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want REST issue and project field reads for each identifier", len(requests))
 	}
-	firstVariables := requests[0]["variables"].(map[string]any)
-	if firstVariables["owner"] != "digitaldrywood" || firstVariables["name"] != "detent" || firstVariables["number"] != float64(251) {
-		t.Fatalf("first variables = %#v, want digitaldrywood/detent#251", firstVariables)
+	if requests[0]["method"] != http.MethodGet || requests[0]["path"] != "/repos/digitaldrywood/detent/issues/251" {
+		t.Fatalf("first request = %#v, want REST issue lookup", requests[0])
 	}
 }
 
@@ -871,9 +919,12 @@ func TestConnectorCreateCommentCallsAddComment(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"addComment":{"commentEdge":{"node":{"id":"IC_kw1"}}}}}`,
+		method: http.MethodPost,
+		path:   "/repos/example/repo/issues/1/comments",
+		body:   `{"node_id":"IC_kw1"}`,
 	}})
 	c := newGitHubTestConnector(t, server, Config{})
+	c.projectCache.SetIssueRef("I_kw1", issueRef{Owner: "example", Name: "repo", Number: 1})
 
 	if err := c.CreateComment(context.Background(), "I_kw1", "hello"); err != nil {
 		t.Fatalf("CreateComment() error = %v", err)
@@ -883,19 +934,12 @@ func TestConnectorCreateCommentCallsAddComment(t *testing.T) {
 	if len(requests) != 1 {
 		t.Fatalf("request count = %d, want 1", len(requests))
 	}
-	query := requests[0]["query"].(string)
-	if !strings.Contains(query, "addComment") {
-		t.Fatalf("query = %q, want addComment", query)
+	if requests[0]["method"] != http.MethodPost || requests[0]["path"] != "/repos/example/repo/issues/1/comments" {
+		t.Fatalf("comment request = %#v, want REST issue comment", requests[0])
 	}
-	if strings.Contains(query, "rateLimit") {
-		t.Fatalf("query = %q, want no rateLimit on mutation root", query)
-	}
-	variables := requests[0]["variables"].(map[string]any)
-	if variables["subjectId"] != "I_kw1" {
-		t.Fatalf("subjectId = %v, want I_kw1", variables["subjectId"])
-	}
-	if variables["body"] != "hello" {
-		t.Fatalf("body = %v, want hello", variables["body"])
+	body := requests[0]["body"].(map[string]any)
+	if body["body"] != "hello" {
+		t.Fatalf("body = %v, want hello", body["body"])
 	}
 }
 
@@ -903,9 +947,12 @@ func TestConnectorCloseIssueCallsCloseIssue(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"closeIssue":{"issue":{"id":"I_kw1","state":"CLOSED"}}}}`,
+		method: http.MethodPatch,
+		path:   "/repos/example/repo/issues/1",
+		body:   `{"node_id":"I_kw1","state":"closed"}`,
 	}})
 	c := newGitHubTestConnector(t, server, Config{})
+	c.projectCache.SetIssueRef("I_kw1", issueRef{Owner: "example", Name: "repo", Number: 1})
 
 	if err := c.CloseIssue(context.Background(), " I_kw1 "); err != nil {
 		t.Fatalf("CloseIssue() error = %v", err)
@@ -915,19 +962,12 @@ func TestConnectorCloseIssueCallsCloseIssue(t *testing.T) {
 	if len(requests) != 1 {
 		t.Fatalf("request count = %d, want 1", len(requests))
 	}
-	query := requests[0]["query"].(string)
-	if !strings.Contains(query, "closeIssue") {
-		t.Fatalf("query = %q, want closeIssue", query)
+	if requests[0]["method"] != http.MethodPatch || requests[0]["path"] != "/repos/example/repo/issues/1" {
+		t.Fatalf("close request = %#v, want REST issue patch", requests[0])
 	}
-	if strings.Contains(query, "rateLimit") {
-		t.Fatalf("query = %q, want no rateLimit on mutation root", query)
-	}
-	variables := requests[0]["variables"].(map[string]any)
-	if variables["issueId"] != "I_kw1" {
-		t.Fatalf("issueId = %v, want I_kw1", variables["issueId"])
-	}
-	if variables["stateReason"] != "COMPLETED" {
-		t.Fatalf("stateReason = %v, want COMPLETED", variables["stateReason"])
+	body := requests[0]["body"].(map[string]any)
+	if body["state"] != "closed" || body["state_reason"] != "completed" {
+		t.Fatalf("close body = %#v, want closed/completed", body)
 	}
 }
 
@@ -1004,38 +1044,24 @@ func TestConnectorSetAssigneeAddsUserByLogin(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{body: `{"data":{"user":{"id":"U_worker"}}}`},
-		{body: `{"data":{"node":{"assignees":{"nodes":[]}}}}`},
-		{body: `{"data":{"addAssigneesToAssignable":{"assignable":{"id":"I_kw1"}}}}`},
+		{method: http.MethodGet, path: "/repos/example/repo/issues/1", body: `{"node_id":"I_kw1","number":1,"title":"Issue","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[],"labels":[]}`},
+		{method: http.MethodPost, path: "/repos/example/repo/issues/1/assignees", body: `{"node_id":"I_kw1"}`},
 	})
 	c := newGitHubTestConnector(t, server, Config{})
+	c.projectCache.SetIssueRef("I_kw1", issueRef{Owner: "example", Name: "repo", Number: 1})
 
 	if err := c.SetAssignee(context.Background(), " I_kw1 ", " worker-1 "); err != nil {
 		t.Fatalf("SetAssignee() error = %v", err)
 	}
 
 	requests := server.requests()
-	if len(requests) != 3 {
-		t.Fatalf("request count = %d, want 3", len(requests))
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
 	}
-	userVariables := requests[0]["variables"].(map[string]any)
-	if userVariables["login"] != "worker-1" {
-		t.Fatalf("login = %v, want worker-1", userVariables["login"])
-	}
-	currentVariables := requests[1]["variables"].(map[string]any)
-	if currentVariables["issueId"] != "I_kw1" {
-		t.Fatalf("current issueId = %v, want I_kw1", currentVariables["issueId"])
-	}
-	assignVariables := requests[2]["variables"].(map[string]any)
-	if assignVariables["assignableId"] != "I_kw1" {
-		t.Fatalf("assignableId = %v, want I_kw1", assignVariables["assignableId"])
-	}
-	assigneeIDs, ok := assignVariables["assigneeIds"].([]any)
-	if !ok || len(assigneeIDs) != 1 || assigneeIDs[0] != "U_worker" {
-		t.Fatalf("assigneeIds = %#v, want [U_worker]", assignVariables["assigneeIds"])
-	}
-	if !strings.Contains(requests[2]["query"].(string), "addAssigneesToAssignable") {
-		t.Fatalf("assign query = %q, want addAssigneesToAssignable", requests[2]["query"])
+	assignBody := requests[1]["body"].(map[string]any)
+	assignees, ok := assignBody["assignees"].([]any)
+	if !ok || len(assignees) != 1 || assignees[0] != "worker-1" {
+		t.Fatalf("assignees = %#v, want [worker-1]", assignBody["assignees"])
 	}
 }
 
@@ -1043,33 +1069,24 @@ func TestConnectorSetAssigneeReplacesExistingAssignees(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{body: `{"data":{"user":{"id":"U_worker"}}}`},
-		{body: `{"data":{"node":{"assignees":{"nodes":[{"id":"U_old","login":"old-owner"},{"id":"U_worker","login":"worker-1"}]}}}}`},
-		{body: `{"data":{"removeAssigneesFromAssignable":{"assignable":{"id":"I_kw1"}}}}`},
+		{method: http.MethodGet, path: "/repos/example/repo/issues/1", body: `{"node_id":"I_kw1","number":1,"title":"Issue","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[{"node_id":"U_old","login":"old-owner"},{"node_id":"U_worker","login":"worker-1"}],"labels":[]}`},
+		{method: http.MethodDelete, path: "/repos/example/repo/issues/1/assignees", body: `{"node_id":"I_kw1"}`},
 	})
 	c := newGitHubTestConnector(t, server, Config{})
+	c.projectCache.SetIssueRef("I_kw1", issueRef{Owner: "example", Name: "repo", Number: 1})
 
 	if err := c.SetAssignee(context.Background(), "I_kw1", "worker-1"); err != nil {
 		t.Fatalf("SetAssignee() error = %v", err)
 	}
 
 	requests := server.requests()
-	if len(requests) != 3 {
-		t.Fatalf("request count = %d, want 3", len(requests))
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
 	}
-	removeVariables := requests[2]["variables"].(map[string]any)
-	if removeVariables["assignableId"] != "I_kw1" {
-		t.Fatalf("remove assignableId = %v, want I_kw1", removeVariables["assignableId"])
-	}
-	assigneeIDs, ok := removeVariables["assigneeIds"].([]any)
-	if !ok || len(assigneeIDs) != 1 || assigneeIDs[0] != "U_old" {
-		t.Fatalf("removed assigneeIds = %#v, want [U_old]", removeVariables["assigneeIds"])
-	}
-	if strings.Contains(requests[2]["query"].(string), "addAssigneesToAssignable") {
-		t.Fatalf("replace query added already assigned target: %q", requests[2]["query"])
-	}
-	if !strings.Contains(requests[2]["query"].(string), "removeAssigneesFromAssignable") {
-		t.Fatalf("replace query = %q, want removeAssigneesFromAssignable", requests[2]["query"])
+	removeBody := requests[1]["body"].(map[string]any)
+	assignees, ok := removeBody["assignees"].([]any)
+	if !ok || len(assignees) != 1 || assignees[0] != "old-owner" {
+		t.Fatalf("removed assignees = %#v, want [old-owner]", removeBody["assignees"])
 	}
 }
 
@@ -1077,26 +1094,26 @@ func TestConnectorSetAssigneeAddsReplacementBeforeRemovingExistingAssignees(t *t
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{body: `{"data":{"user":{"id":"U_worker"}}}`},
-		{body: `{"data":{"node":{"assignees":{"nodes":[{"id":"U_old","login":"old-owner"}]}}}}`},
-		{body: `{"data":{"addAssigneesToAssignable":{"assignable":{"id":"I_kw1"}}}}`},
-		{body: `{"data":{"removeAssigneesFromAssignable":{"assignable":{"id":"I_kw1"}}}}`},
+		{method: http.MethodGet, path: "/repos/example/repo/issues/1", body: `{"node_id":"I_kw1","number":1,"title":"Issue","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[{"node_id":"U_old","login":"old-owner"}],"labels":[]}`},
+		{method: http.MethodPost, path: "/repos/example/repo/issues/1/assignees", body: `{"node_id":"I_kw1"}`},
+		{method: http.MethodDelete, path: "/repos/example/repo/issues/1/assignees", body: `{"node_id":"I_kw1"}`},
 	})
 	c := newGitHubTestConnector(t, server, Config{})
+	c.projectCache.SetIssueRef("I_kw1", issueRef{Owner: "example", Name: "repo", Number: 1})
 
 	if err := c.SetAssignee(context.Background(), "I_kw1", "worker-1"); err != nil {
 		t.Fatalf("SetAssignee() error = %v", err)
 	}
 
 	requests := server.requests()
-	if len(requests) != 4 {
-		t.Fatalf("request count = %d, want 4", len(requests))
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
 	}
-	if !strings.Contains(requests[2]["query"].(string), "addAssigneesToAssignable") {
-		t.Fatalf("third query = %q, want addAssigneesToAssignable", requests[2]["query"])
+	if requests[1]["method"] != http.MethodPost {
+		t.Fatalf("second request = %#v, want assignee add", requests[1])
 	}
-	if !strings.Contains(requests[3]["query"].(string), "removeAssigneesFromAssignable") {
-		t.Fatalf("fourth query = %q, want removeAssigneesFromAssignable", requests[3]["query"])
+	if requests[2]["method"] != http.MethodDelete {
+		t.Fatalf("third request = %#v, want assignee remove", requests[2])
 	}
 }
 
@@ -1104,22 +1121,22 @@ func TestConnectorSetAssigneeDoesNotRemoveExistingAssigneesWhenAddFails(t *testi
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{body: `{"data":{"user":{"id":"U_worker"}}}`},
-		{body: `{"data":{"node":{"assignees":{"nodes":[{"id":"U_old","login":"old-owner"}]}}}}`},
-		{body: `{"errors":[{"message":"not assignable"}]}`},
+		{method: http.MethodGet, path: "/repos/example/repo/issues/1", body: `{"node_id":"I_kw1","number":1,"title":"Issue","state":"open","html_url":"https://github.com/example/repo/issues/1","assignees":[{"node_id":"U_old","login":"old-owner"}],"labels":[]}`},
+		{method: http.MethodPost, path: "/repos/example/repo/issues/1/assignees", status: http.StatusUnprocessableEntity, body: `{"message":"not assignable"}`},
 	})
 	c := newGitHubTestConnector(t, server, Config{})
+	c.projectCache.SetIssueRef("I_kw1", issueRef{Owner: "example", Name: "repo", Number: 1})
 
 	if err := c.SetAssignee(context.Background(), "I_kw1", "worker-1"); err == nil {
 		t.Fatal("SetAssignee() error = nil, want error")
 	}
 
 	requests := server.requests()
-	if len(requests) != 3 {
-		t.Fatalf("request count = %d, want 3", len(requests))
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want 2", len(requests))
 	}
-	if !strings.Contains(requests[2]["query"].(string), "addAssigneesToAssignable") {
-		t.Fatalf("third query = %q, want addAssigneesToAssignable", requests[2]["query"])
+	if requests[1]["method"] != http.MethodPost {
+		t.Fatalf("second request = %#v, want assignee add", requests[1])
 	}
 }
 
@@ -1225,6 +1242,8 @@ type graphqlTestServer struct {
 
 type graphqlTestResponse struct {
 	status  int
+	method  string
+	path    string
 	body    string
 	release <-chan struct{}
 }
@@ -1239,9 +1258,28 @@ func newGraphQLTestServer(t *testing.T, responses []graphqlTestResponse) *graphq
 }
 
 func (s *graphqlTestServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
-	var payload map[string]any
-	if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
-		s.t.Fatalf("Decode() error = %v", err)
+	payload := map[string]any{
+		"method": r.Method,
+		"path":   r.URL.RequestURI(),
+	}
+	if r.Method == http.MethodPost && r.URL.Path == "/" {
+		if err := json.NewDecoder(r.Body).Decode(&payload); err != nil {
+			s.t.Fatalf("Decode() error = %v", err)
+		}
+		payload["method"] = r.Method
+		payload["path"] = r.URL.RequestURI()
+	} else {
+		raw, err := io.ReadAll(r.Body)
+		if err != nil {
+			s.t.Fatalf("ReadAll() error = %v", err)
+		}
+		if len(raw) > 0 {
+			var body map[string]any
+			if err := json.Unmarshal(raw, &body); err != nil {
+				s.t.Fatalf("Unmarshal() error = %v", err)
+			}
+			payload["body"] = body
+		}
 	}
 
 	s.mu.Lock()
@@ -1253,6 +1291,12 @@ func (s *graphqlTestServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 	response := s.responses[0]
 	s.responses = s.responses[1:]
 	s.mu.Unlock()
+	if response.method != "" && response.method != r.Method {
+		s.t.Fatalf("method = %s, want %s", r.Method, response.method)
+	}
+	if response.path != "" && response.path != r.URL.RequestURI() {
+		s.t.Fatalf("path = %s, want %s", r.URL.RequestURI(), response.path)
+	}
 
 	if response.release != nil {
 		<-response.release

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -438,12 +438,17 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100",
-			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+			body:   `{"check_runs":[]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-187/statuses?per_page=100",
+			body:   `[{"context":"ci/build","state":"success","created_at":"2026-06-05T11:00:00Z"}]`,
 		},
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls/187/reviews?per_page=100",
-			body:   `[{"body":"[P2] The fallback path needs cleanup.","state":"COMMENTED","user":{"login":"codex"}}]`,
+			body:   `[{"body":"[P1] Stale finding on the previous review.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-187","submitted_at":"2026-06-05T10:00:00Z"},{"body":"No blocking findings on the current head.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-187","submitted_at":"2026-06-05T11:00:00Z"}]`,
 		},
 	})
 
@@ -468,7 +473,7 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 	if pr == nil {
 		t.Fatal("I_182 PullRequest = nil, want matching open PR")
 	}
-	if pr.Number != 187 || pr.State != "OPEN" || pr.BranchName != "detent/digitaldrywood_detent_182_followup" || pr.CIStatus != "pass" || pr.CodexReviewState != "P2" {
+	if pr.Number != 187 || pr.State != "OPEN" || pr.BranchName != "detent/digitaldrywood_detent_182_followup" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
 		t.Fatalf("I_182 PullRequest = %#v, want PR 187 open followup", pr)
 	}
 	if byID["I_18"].PullRequest != nil {
@@ -495,8 +500,13 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		},
 		{
 			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-190/statuses?per_page=100",
+			body:   `[{"context":"ci/build","state":"success","created_at":"2026-06-05T11:00:00Z"}]`,
+		},
+		{
+			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls/190/reviews?per_page=100",
-			body:   `[{"body":"[P1] Unsafe migration.","state":"COMMENTED","user":{"login":"codex"}}]`,
+			body:   `[{"body":"[P1] Unsafe migration.","state":"COMMENTED","user":{"login":"codex"},"commit_id":"sha-190","submitted_at":"2026-06-05T11:00:00Z"}]`,
 		},
 	})
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -36,6 +36,7 @@ type ClientConfig struct {
 
 type Client struct {
 	endpoint     string
+	restEndpoint string
 	tokenSource  TokenSource
 	httpClient   HTTPClient
 	logger       *slog.Logger
@@ -50,6 +51,10 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 		endpoint = DefaultGraphQLEndpoint
 	}
 	if err := validateEndpoint(endpoint); err != nil {
+		return nil, err
+	}
+	restEndpoint, err := restEndpointFromGraphQLEndpoint(endpoint)
+	if err != nil {
 		return nil, err
 	}
 	if cfg.TokenSource == nil {
@@ -67,10 +72,11 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		endpoint:    endpoint,
-		tokenSource: cfg.TokenSource,
-		httpClient:  httpClient,
-		logger:      logger,
+		endpoint:     endpoint,
+		restEndpoint: restEndpoint,
+		tokenSource:  cfg.TokenSource,
+		httpClient:   httpClient,
+		logger:       logger,
 	}, nil
 }
 
@@ -152,6 +158,74 @@ func (c *Client) GraphQL(ctx context.Context, query string, variables map[string
 		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
 	}
 
+	return nil
+}
+
+func (c *Client) REST(ctx context.Context, method string, path string, body any, out any) error {
+	token, err := c.tokenSource.Token(ctx)
+	if err != nil {
+		return fmt.Errorf("resolve github token: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ErrMissingToken
+	}
+
+	var requestBody io.Reader
+	if body != nil {
+		var encoded bytes.Buffer
+		if err := json.NewEncoder(&encoded).Encode(body); err != nil {
+			return fmt.Errorf("encode github rest request: %w", err)
+		}
+		requestBody = &encoded
+	}
+
+	url, err := c.restURL(path)
+	if err != nil {
+		return err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", gitHubAPIVersion)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	c.logger.DebugContext(ctx, "github rest request", "method", method, "path", path, "live_connections", c.LiveConnections())
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	defer func() {
+		if err := drainAndClose(resp.Body); err != nil {
+			c.logger.DebugContext(ctx, "github rest response body drain failed", "method", method, "path", path, "error", err)
+		}
+	}()
+
+	c.logger.DebugContext(ctx, "github rest response", "method", method, "path", path, "status", resp.StatusCode, "live_connections", c.LiveConnections())
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+	}
+	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
+		return classifyStatus(resp.StatusCode, resp.Header, raw)
+	}
+	if out == nil || resp.StatusCode == http.StatusNoContent {
+		return nil
+	}
+	if len(raw) == 0 {
+		return ErrInvalidResponse
+	}
+	if err := json.Unmarshal(raw, out); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
 	return nil
 }
 
@@ -263,6 +337,48 @@ func validateEndpoint(endpoint string) error {
 		return fmt.Errorf("%w: %s", ErrInvalidEndpoint, endpoint)
 	}
 	return nil
+}
+
+func restEndpointFromGraphQLEndpoint(endpoint string) (string, error) {
+	parsed, err := url.Parse(endpoint)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+
+	basePath := strings.TrimRight(parsed.Path, "/")
+	if parsed.Host == "api.github.com" {
+		basePath = ""
+	} else if strings.HasSuffix(basePath, "/api/graphql") {
+		basePath = strings.TrimSuffix(basePath, "/api/graphql") + "/api/v3"
+	} else if strings.HasSuffix(basePath, "/graphql") {
+		basePath = strings.TrimSuffix(basePath, "/graphql")
+	}
+
+	parsed.Path = strings.TrimRight(basePath, "/")
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return strings.TrimRight(parsed.String(), "/"), nil
+}
+
+func (c *Client) restURL(path string) (string, error) {
+	parsed, err := url.Parse(c.restEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", ErrInvalidEndpoint
+	}
+	if !strings.HasPrefix(path, "/") {
+		path = "/" + path
+	}
+	relative, err := url.Parse(path)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	parsed.Path = strings.TrimRight(parsed.Path, "/") + relative.Path
+	parsed.RawQuery = relative.RawQuery
+	return parsed.String(), nil
 }
 
 func classifyStatus(status int, headers http.Header, body []byte) error {

--- a/internal/connector/github/projectcache.go
+++ b/internal/connector/github/projectcache.go
@@ -11,11 +11,23 @@ type projectCache struct {
 	ttl     time.Duration
 	now     func() time.Time
 	entries map[string]map[string]projectItemCacheEntry
+	refs    map[string]issueRefCacheEntry
 }
 
 type projectItemCacheEntry struct {
 	itemID   string
 	cachedAt time.Time
+}
+
+type issueRefCacheEntry struct {
+	ref      issueRef
+	cachedAt time.Time
+}
+
+type issueRef struct {
+	Owner  string
+	Name   string
+	Number int
 }
 
 func newProjectCache(ttl time.Duration, now func() time.Time) *projectCache {
@@ -27,6 +39,7 @@ func newProjectCache(ttl time.Duration, now func() time.Time) *projectCache {
 		ttl:     ttl,
 		now:     now,
 		entries: map[string]map[string]projectItemCacheEntry{},
+		refs:    map[string]issueRefCacheEntry{},
 	}
 }
 
@@ -87,6 +100,52 @@ func (c *projectCache) SetItemID(projectID string, issueID string, itemID string
 	}
 	projectEntries[issueID] = projectItemCacheEntry{
 		itemID:   itemID,
+		cachedAt: c.now(),
+	}
+	c.mu.Unlock()
+}
+
+func (c *projectCache) GetIssueRef(issueID string) (issueRef, bool) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return issueRef{}, false
+	}
+
+	c.mu.RLock()
+	entry, ok := c.refs[issueID]
+	c.mu.RUnlock()
+	if !ok {
+		return issueRef{}, false
+	}
+	if c.fresh(entry.cachedAt) {
+		return entry.ref, true
+	}
+
+	c.mu.Lock()
+	if current, ok := c.refs[issueID]; ok && c.fresh(current.cachedAt) {
+		entry = current
+	} else if ok {
+		delete(c.refs, issueID)
+	}
+	c.mu.Unlock()
+
+	if c.fresh(entry.cachedAt) {
+		return entry.ref, true
+	}
+	return issueRef{}, false
+}
+
+func (c *projectCache) SetIssueRef(issueID string, ref issueRef) {
+	issueID = strings.TrimSpace(issueID)
+	ref.Owner = strings.TrimSpace(ref.Owner)
+	ref.Name = strings.TrimSpace(ref.Name)
+	if issueID == "" || ref.Owner == "" || ref.Name == "" || ref.Number <= 0 {
+		return
+	}
+
+	c.mu.Lock()
+	c.refs[issueID] = issueRefCacheEntry{
+		ref:      ref,
 		cachedAt: c.now(),
 	}
 	c.mu.Unlock()

--- a/internal/connector/github/projectcache_test.go
+++ b/internal/connector/github/projectcache_test.go
@@ -62,6 +62,40 @@ func TestProjectCacheClearsEntries(t *testing.T) {
 	}
 }
 
+func TestProjectCacheReturnsFreshIssueRef(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.SetIssueRef("I_1", issueRef{Owner: "digitaldrywood", Name: "detent", Number: 313})
+
+	got, ok := cache.GetIssueRef("I_1")
+	if !ok {
+		t.Fatal("GetIssueRef() ok = false, want true")
+	}
+	if got.Owner != "digitaldrywood" || got.Name != "detent" || got.Number != 313 {
+		t.Fatalf("issue ref = %#v, want digitaldrywood/detent#313", got)
+	}
+}
+
+func TestProjectCacheExpiresIssueRef(t *testing.T) {
+	t.Parallel()
+
+	now := time.Now()
+	cache := newProjectCache(5*time.Minute, func() time.Time { return now })
+	cache.SetIssueRef("I_1", issueRef{Owner: "digitaldrywood", Name: "detent", Number: 313})
+
+	now = now.Add(5*time.Minute - time.Nanosecond)
+	if _, ok := cache.GetIssueRef("I_1"); !ok {
+		t.Fatal("GetIssueRef() ok = false before TTL, want true")
+	}
+
+	now = now.Add(time.Nanosecond)
+	if _, ok := cache.GetIssueRef("I_1"); ok {
+		t.Fatal("GetIssueRef() ok = true after TTL, want false")
+	}
+}
+
 func TestProjectCacheIgnoresBlankKeys(t *testing.T) {
 	t.Parallel()
 
@@ -79,5 +113,13 @@ func TestProjectCacheIgnoresBlankKeys(t *testing.T) {
 	}
 	if _, ok := cache.GetItemID("PVT_1", "I_1"); ok {
 		t.Fatal("GetItemID() ok = true for blank item, want false")
+	}
+
+	cache.SetIssueRef("", issueRef{Owner: "digitaldrywood", Name: "detent", Number: 313})
+	cache.SetIssueRef("I_1", issueRef{Owner: "", Name: "detent", Number: 313})
+	cache.SetIssueRef("I_1", issueRef{Owner: "digitaldrywood", Name: "", Number: 313})
+	cache.SetIssueRef("I_1", issueRef{Owner: "digitaldrywood", Name: "detent"})
+	if _, ok := cache.GetIssueRef("I_1"); ok {
+		t.Fatal("GetIssueRef() ok = true for blank issue ref, want false")
 	}
 }

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -585,7 +585,7 @@ func TestDispatchReadyIssuesHydratesLightweightCandidateBeforeDependencyGate(t *
 	})
 	runner := newWorkerHostRunner()
 	candidate := dispatchTestIssue("issue-lightweight", "Todo")
-	candidate.Fields = nil
+	candidate.Fields = map[string]string{}
 	candidate.BlockedBy = nil
 	hydrated := candidate
 	hydrated.Fields = map[string]string{}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -575,6 +575,51 @@ func TestDispatchCandidatesClaimsDuplicateIssueWithinCycle(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesHydratesLightweightCandidateBeforeDependencyGate(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+	})
+	runner := newWorkerHostRunner()
+	candidate := dispatchTestIssue("issue-lightweight", "Todo")
+	candidate.Fields = nil
+	candidate.BlockedBy = nil
+	hydrated := candidate
+	hydrated.Fields = map[string]string{}
+	hydrated.BlockedBy = []connector.BlockedRef{{
+		Identifier: "digitaldrywood/detent#issue-blocker",
+		State:      "In Progress",
+	}}
+	orch := Orchestrator{
+		cfg:        cfg,
+		connector:  hydratingDispatchConnector{issue: hydrated},
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion),
+	}
+	state := newState(cfg)
+	now := time.Now()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{candidate}, now)
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected dispatch for hydrated blocked candidate = %#v", request)
+	default:
+	}
+	blocked, ok := state.Blocked[candidate.ID]
+	if !ok {
+		t.Fatalf("Blocked[%q] missing after hydrated dependency gate", candidate.ID)
+	}
+	if blocked.Issue.BlockedBy[0].State != "In Progress" {
+		t.Fatalf("blocked dependency state = %q, want In Progress", blocked.Issue.BlockedBy[0].State)
+	}
+}
+
 func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	t.Parallel()
 
@@ -783,6 +828,47 @@ func dispatchTestIssueWithPullRequest(id, state, prState string) connector.Issue
 		State:      prState,
 	}
 	return issue
+}
+
+type hydratingDispatchConnector struct {
+	issue connector.Issue
+}
+
+func (c hydratingDispatchConnector) Name() string {
+	return "hydrating"
+}
+
+func (c hydratingDispatchConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return []connector.Issue{c.issue}, nil
+}
+
+func (c hydratingDispatchConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c hydratingDispatchConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
+	for _, id := range ids {
+		if id == c.issue.ID {
+			return []connector.Issue{c.issue}, nil
+		}
+	}
+	return nil, nil
+}
+
+func (c hydratingDispatchConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c hydratingDispatchConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c hydratingDispatchConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c hydratingDispatchConnector) SetField(context.Context, string, string, string) error {
+	return nil
 }
 
 type workerHostRunner struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -782,7 +782,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 }
 
 func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector.Issue) (connector.Issue, bool) {
-	if strings.TrimSpace(issue.ID) == "" || issue.Fields != nil {
+	if strings.TrimSpace(issue.ID) == "" || len(issue.Fields) > 0 || o.connector == nil {
 		return issue, true
 	}
 	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{issue.ID})

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -753,7 +753,19 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		if availableSlots(state) == 0 {
 			return
 		}
+		issue, ok := o.hydrateDispatchIssue(ctx, issue)
+		if !ok {
+			continue
+		}
 		if !o.dispatchable(issue, state, now) {
+			if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
+				state.Blocked[issue.ID] = Blocked{
+					Issue:     cloneIssue(issue),
+					Reason:    blockedReasonDependency,
+					BlockedAt: now,
+					Source:    BlockedSourceDependency,
+				}
+			}
 			continue
 		}
 
@@ -769,10 +781,33 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 	}
 }
 
+func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector.Issue) (connector.Issue, bool) {
+	if strings.TrimSpace(issue.ID) == "" || issue.Fields != nil {
+		return issue, true
+	}
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{issue.ID})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("hydrate dispatch issue failed", "issue_id", issue.ID, "error", err)
+		}
+		return connector.Issue{}, false
+	}
+	for _, hydrated := range issues {
+		if hydrated.ID == issue.ID {
+			return mergeIssueTrackerFields(issue, hydrated), true
+		}
+	}
+	return connector.Issue{}, false
+}
+
 func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
 	for _, issue := range issues {
 		if availableSlots(state) == 0 {
 			return
+		}
+		issue, ok := o.hydrateDispatchIssue(ctx, issue)
+		if !ok {
+			continue
 		}
 		if !o.dispatchable(issue, state, now) {
 			continue


### PR DESCRIPTION
## Summary
- Minimize the ProjectV2 board poll to issue identity plus Status/Priority values.
- Hydrate full issue metadata JIT before dispatch and move REST-able GitHub reads/writes to REST.
- Keep linked issue/project field resolution out of the per-poll path.

Fixes #313

## Test Plan
- `go test ./internal/connector/github ./internal/orchestrator`
- `go test ./...`
- `make check`
- Live active-state board query: 552 pts/poll before; 1 pt after via `rateLimit.cost`.