### PR TITLE
feat(observability): show build metadata

### DIFF
--- a/.air.toml
+++ b/.air.toml
@@ -6,15 +6,15 @@ tmp_dir = "tmp"
 
 [build]
   args_bin = []
-  bin = "./tmp/symphony"
-  cmd = "go build -o ./tmp/symphony ./cmd/symphony"
+  bin = "./tmp/detent"
+  cmd = "make build VERSION=${DETENT_AIR_VERSION:-dev}"
   delay = 1000
   exclude_dir = ["tmp", "vendor", "testdata", "node_modules", "internal/database/sqlc"]
   exclude_file = ["go.sum"]
   exclude_regex = ["_test\\.go", "_templ\\.go$"]
   exclude_unchanged = false
   follow_symlink = false
-  full_bin = "./tmp/symphony"
+  full_bin = "./tmp/detent"
   include_dir = []
   include_ext = ["go", "templ", "sql", "css", "js", "html", "yaml", "yml", "toml"]
   include_file = []
@@ -23,7 +23,7 @@ tmp_dir = "tmp"
   poll = false
   poll_interval = 0
   post_cmd = []
-  pre_cmd = ["mkdir -p tmp; lsof -ti:${PORT:-8080} | xargs kill -9 2>/dev/null || true; sleep 0.5", "go generate ./...", "go mod tidy"]
+  pre_cmd = ["mkdir -p tmp; lsof -ti:${PORT:-8080} | xargs kill -9 2>/dev/null || true; sleep 0.5", "go mod tidy"]
   rerun = false
   rerun_delay = 500
   send_interrupt = true

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ VERSION ?= $(shell git describe --tags --always 2>/dev/null || echo dev)
 COMMIT ?= $(shell git rev-parse --short HEAD 2>/dev/null || echo none)
 DATE ?= $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 LDFLAGS ?= -X main.version=$(VERSION) -X main.commit=$(COMMIT) -X main.date=$(DATE)
+DEV_VERSION ?= dev
 COVERPROFILE := tmp/coverage.out
 COVERPROFILE_RAW := tmp/coverage.raw.out
 COVERAGE_THRESHOLD := 70.0
@@ -26,7 +27,7 @@ dev:
 		mv tmp/air-combined.log tmp/air-combined-$$(date +%Y%m%d-%H%M%S).log; \
 	fi
 	@ls -t tmp/air-combined-*.log 2>/dev/null | tail -n +6 | xargs rm -f 2>/dev/null || true
-	@ENV=dev LOG_LEVEL=debug air 2>&1 | tee tmp/air-combined.log
+	@ENV=dev LOG_LEVEL=debug DETENT_AIR_VERSION=$(DEV_VERSION) air 2>&1 | tee tmp/air-combined.log
 
 generate:
 	@go generate ./...

--- a/README.md
+++ b/README.md
@@ -808,7 +808,8 @@ make check
 ```
 
 `make dev` runs Air with `ENV=dev` and
-`LOG_LEVEL=debug`, builds `./tmp/detent`, rotates
+`LOG_LEVEL=debug`, builds a `dev`-versioned `./tmp/detent` with the current
+commit SHA and build date, rotates
 `tmp/air-combined.log`, and streams combined build and application output to
 `tmp/air-combined.log`.
 

--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -33,8 +33,9 @@ func main() {
 }
 
 func newRootCommand(ctx context.Context) *cobra.Command {
-	cmd := cli.NewRootCommand(ctx, cli.WithVersion(version))
-	cmd.Version = version
+	build := currentBuildInfo()
+	cmd := cli.NewRootCommand(ctx, cli.WithVersion(build.Version), cli.WithBuild(build))
+	cmd.Version = build.Version
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.AddCommand(
 		newVersionCommand(),

--- a/cmd/detent/version.go
+++ b/cmd/detent/version.go
@@ -6,6 +6,8 @@ import (
 	"runtime"
 
 	"github.com/spf13/cobra"
+
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 )
 
 var version, commit, date = "dev", "none", "unknown"
@@ -32,14 +34,19 @@ func newVersionCommand() *cobra.Command {
 }
 
 func currentVersionInfo() versionInfo {
+	build := currentBuildInfo()
 	return versionInfo{
-		Version:   version,
-		Commit:    commit,
-		Date:      date,
+		Version:   build.Version,
+		Commit:    build.Commit,
+		Date:      build.Date,
 		GoVersion: runtime.Version(),
 		OS:        runtime.GOOS,
 		Arch:      runtime.GOARCH,
 	}
+}
+
+func currentBuildInfo() buildinfo.Info {
+	return buildinfo.Resolve(version, commit, date)
 }
 
 func formatVersionInfo(info versionInfo) string {

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -142,7 +142,7 @@ func buildSettings(settings []debug.BuildSetting) map[string]string {
 }
 
 func shouldReadGit(info Info) bool {
-	return placeholderCommit(info.Commit) || placeholderDate(info.Date) || !info.Dirty
+	return placeholderCommit(info.Commit) || placeholderDate(info.Date)
 }
 
 func readGitInfo(modulePath string) (Info, bool) {

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -1,0 +1,244 @@
+package buildinfo
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime/debug"
+	"strings"
+	"time"
+)
+
+const (
+	defaultVersion   = "dev"
+	defaultCommit    = "none"
+	defaultDate      = "unknown"
+	shortCommitWidth = 7
+	gitTimeout       = 2 * time.Second
+)
+
+type Info struct {
+	Version string `json:"version"`
+	Commit  string `json:"commit"`
+	Date    string `json:"date"`
+	Dirty   bool   `json:"dirty,omitempty"`
+}
+
+type Reader func() (*debug.BuildInfo, bool)
+
+type GitReader func(string) (Info, bool)
+
+func Resolve(version string, commit string, date string) Info {
+	return ResolveWithReaders(version, commit, date, debug.ReadBuildInfo, readGitInfo)
+}
+
+func ResolveWithReader(version string, commit string, date string, reader Reader) Info {
+	return ResolveWithReaders(version, commit, date, reader, nil)
+}
+
+func ResolveWithReaders(version string, commit string, date string, reader Reader, gitReader GitReader) Info {
+	info := Normalize(Info{
+		Version: version,
+		Commit:  commit,
+		Date:    date,
+	})
+	build, ok := readBuildInfo(reader)
+	if !ok {
+		return info
+	}
+
+	if placeholderVersion(info.Version) {
+		if moduleVersion := cleanModuleVersion(build.Main.Version); moduleVersion != "" {
+			info.Version = moduleVersion
+		}
+	}
+
+	settings := buildSettings(build.Settings)
+	if placeholderCommit(info.Commit) {
+		if revision := strings.TrimSpace(settings["vcs.revision"]); revision != "" {
+			info.Commit = revision
+		}
+	}
+	if placeholderDate(info.Date) {
+		if buildTime := strings.TrimSpace(settings["vcs.time"]); buildTime != "" {
+			info.Date = buildTime
+		}
+	}
+	info.Dirty = info.Dirty || strings.EqualFold(strings.TrimSpace(settings["vcs.modified"]), "true")
+	if gitReader != nil && shouldReadGit(info) {
+		if gitInfo, ok := gitReader(build.Main.Path); ok {
+			if placeholderCommit(info.Commit) && !placeholderCommit(gitInfo.Commit) {
+				info.Commit = gitInfo.Commit
+			}
+			if placeholderDate(info.Date) && !placeholderDate(gitInfo.Date) {
+				info.Date = gitInfo.Date
+			}
+			info.Dirty = info.Dirty || gitInfo.Dirty
+		}
+	}
+
+	return Normalize(info)
+}
+
+func Normalize(info Info) Info {
+	info.Version = strings.TrimSpace(info.Version)
+	info.Commit = strings.TrimSpace(info.Commit)
+	info.Date = strings.TrimSpace(info.Date)
+	if info.Version == "" || info.Version == "(devel)" {
+		info.Version = defaultVersion
+	}
+	if info.Commit == "" {
+		info.Commit = defaultCommit
+	}
+	if info.Date == "" {
+		info.Date = defaultDate
+	}
+	return info
+}
+
+func IsZero(info Info) bool {
+	return strings.TrimSpace(info.Version) == "" &&
+		strings.TrimSpace(info.Commit) == "" &&
+		strings.TrimSpace(info.Date) == "" &&
+		!info.Dirty
+}
+
+func DisplayLabel(info Info) string {
+	info = Normalize(info)
+	commit := ShortCommit(info.Commit)
+	if info.Dirty {
+		commit += ", dirty"
+	}
+	return fmt.Sprintf("%s (%s) %s", info.Version, commit, info.Date)
+}
+
+func ShortCommit(commit string) string {
+	commit = strings.TrimSpace(commit)
+	if placeholderCommit(commit) {
+		return defaultCommit
+	}
+	if len(commit) <= shortCommitWidth {
+		return commit
+	}
+	return commit[:shortCommitWidth]
+}
+
+func readBuildInfo(reader Reader) (*debug.BuildInfo, bool) {
+	if reader == nil {
+		return nil, false
+	}
+	build, ok := reader()
+	return build, ok && build != nil
+}
+
+func buildSettings(settings []debug.BuildSetting) map[string]string {
+	byKey := make(map[string]string, len(settings))
+	for _, setting := range settings {
+		byKey[setting.Key] = setting.Value
+	}
+	return byKey
+}
+
+func shouldReadGit(info Info) bool {
+	return placeholderCommit(info.Commit) || placeholderDate(info.Date) || !info.Dirty
+}
+
+func readGitInfo(modulePath string) (Info, bool) {
+	modulePath = strings.TrimSpace(modulePath)
+	if modulePath == "" {
+		return Info{}, false
+	}
+	root, err := runGit("", "rev-parse", "--show-toplevel")
+	if err != nil || !modulePathMatches(root, modulePath) {
+		return Info{}, false
+	}
+	commit, err := runGit(root, "rev-parse", "--short", "HEAD")
+	if err != nil {
+		return Info{}, false
+	}
+	date, err := runGit(root, "log", "-1", "--format=%cI")
+	if err != nil {
+		date = ""
+	}
+	status, err := runGit(root, "status", "--porcelain")
+	dirty := err == nil && strings.TrimSpace(status) != ""
+	return Info{
+		Commit: commit,
+		Date:   normalizeGitDate(date),
+		Dirty:  dirty,
+	}, true
+}
+
+func runGit(dir string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), gitTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if strings.TrimSpace(dir) != "" {
+		cmd.Dir = dir
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+func modulePathMatches(root string, modulePath string) bool {
+	data, err := os.ReadFile(filepath.Join(strings.TrimSpace(root), "go.mod"))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(string(data), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[0] == "module" {
+			return strings.Trim(fields[1], `"`) == modulePath
+		}
+	}
+	return false
+}
+
+func normalizeGitDate(date string) string {
+	parsed, err := time.Parse(time.RFC3339, strings.TrimSpace(date))
+	if err != nil {
+		return strings.TrimSpace(date)
+	}
+	return parsed.UTC().Format(time.RFC3339)
+}
+
+func cleanModuleVersion(version string) string {
+	version = strings.TrimSpace(version)
+	if placeholderVersion(version) {
+		return ""
+	}
+	return version
+}
+
+func placeholderVersion(version string) bool {
+	switch strings.TrimSpace(version) {
+	case "", defaultVersion, "(devel)":
+		return true
+	default:
+		return false
+	}
+}
+
+func placeholderCommit(commit string) bool {
+	switch strings.TrimSpace(commit) {
+	case "", defaultCommit, defaultDate, "(devel)":
+		return true
+	default:
+		return false
+	}
+}
+
+func placeholderDate(date string) bool {
+	switch strings.TrimSpace(date) {
+	case "", defaultDate, defaultCommit, "(devel)":
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -61,6 +61,34 @@ func TestResolveWithReadersFallsBackToGitWhenVCSBuildSettingsAreMissing(t *testi
 	}
 }
 
+func TestResolveWithReadersDoesNotReadGitWhenBuildSettingsAreComplete(t *testing.T) {
+	t.Parallel()
+
+	info := ResolveWithReaders("dev", "none", "unknown", func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Path: "github.com/digitaldrywood/detent"},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abcdef1234567890"},
+				{Key: "vcs.time", Value: "2026-06-05T21:00:00Z"},
+				{Key: "vcs.modified", Value: "false"},
+			},
+		}, true
+	}, func(modulePath string) (Info, bool) {
+		t.Fatalf("gitReader called with modulePath %q", modulePath)
+		return Info{}, false
+	})
+
+	if info.Commit != "abcdef1234567890" {
+		t.Fatalf("Commit = %q, want abcdef1234567890", info.Commit)
+	}
+	if info.Date != "2026-06-05T21:00:00Z" {
+		t.Fatalf("Date = %q, want 2026-06-05T21:00:00Z", info.Date)
+	}
+	if info.Dirty {
+		t.Fatal("Dirty = true, want false")
+	}
+}
+
 func TestDisplayLabelFormatsShortCommitAndDirtyMarker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/buildinfo/buildinfo_test.go
+++ b/internal/buildinfo/buildinfo_test.go
@@ -1,0 +1,77 @@
+package buildinfo
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+func TestResolveWithReaderFallsBackToVCSBuildSettings(t *testing.T) {
+	t.Parallel()
+
+	info := ResolveWithReader("dev", "none", "unknown", func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "abcdef1234567890"},
+				{Key: "vcs.time", Value: "2026-06-05T21:00:00Z"},
+				{Key: "vcs.modified", Value: "true"},
+			},
+		}, true
+	})
+
+	if info.Version != "dev" {
+		t.Fatalf("Version = %q, want dev", info.Version)
+	}
+	if info.Commit != "abcdef1234567890" {
+		t.Fatalf("Commit = %q, want abcdef1234567890", info.Commit)
+	}
+	if info.Date != "2026-06-05T21:00:00Z" {
+		t.Fatalf("Date = %q, want 2026-06-05T21:00:00Z", info.Date)
+	}
+	if !info.Dirty {
+		t.Fatal("Dirty = false, want true")
+	}
+}
+
+func TestResolveWithReadersFallsBackToGitWhenVCSBuildSettingsAreMissing(t *testing.T) {
+	t.Parallel()
+
+	info := ResolveWithReaders("dev", "none", "unknown", func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Path: "github.com/digitaldrywood/detent"},
+		}, true
+	}, func(modulePath string) (Info, bool) {
+		if modulePath != "github.com/digitaldrywood/detent" {
+			t.Fatalf("modulePath = %q, want github.com/digitaldrywood/detent", modulePath)
+		}
+		return Info{
+			Commit: "82d5622",
+			Date:   "2026-06-05T12:53:11Z",
+			Dirty:  true,
+		}, true
+	})
+
+	if info.Commit != "82d5622" {
+		t.Fatalf("Commit = %q, want 82d5622", info.Commit)
+	}
+	if info.Date != "2026-06-05T12:53:11Z" {
+		t.Fatalf("Date = %q, want 2026-06-05T12:53:11Z", info.Date)
+	}
+	if !info.Dirty {
+		t.Fatal("Dirty = false, want true")
+	}
+}
+
+func TestDisplayLabelFormatsShortCommitAndDirtyMarker(t *testing.T) {
+	t.Parallel()
+
+	info := Info{
+		Version: "dev",
+		Commit:  "abcdef1234567890",
+		Date:    "2026-06-05T21:00:00Z",
+		Dirty:   true,
+	}
+
+	if got, want := DisplayLabel(info), "dev (abcdef1, dirty) 2026-06-05T21:00:00Z"; got != want {
+		t.Fatalf("DisplayLabel() = %q, want %q", got, want)
+	}
+}

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -16,6 +16,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -58,6 +59,7 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 			Host:           host,
 			Port:           port,
 			Version:        opts.version,
+			Build:          opts.build,
 		}, nil
 	}
 	if !missingGlobalConfig(err) {
@@ -79,6 +81,7 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 			Host:           host,
 			Port:           port,
 			Version:        opts.version,
+			Build:          opts.build,
 		}, nil
 	}
 
@@ -94,6 +97,7 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 		Host:           strings.TrimSpace(host),
 		Port:           bootPort(port),
 		Version:        opts.version,
+		Build:          opts.build,
 	}, nil
 }
 
@@ -179,6 +183,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		Mode:           web.ModeRunning,
 		WorkflowPath:   firstWorkflowPath(cfg),
 		Version:        cfg.Version,
+		Build:          cfg.Build,
 		DashboardURL:   displayURL,
 		GlobalConfig:   cfg.Global,
 		ConfigPathRule: cfg.ConfigPathRule,
@@ -201,7 +206,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			return err
 		}
 		listenerOwned = false
-		return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub)
+		return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub, cfg.Build)
 	}
 	if err := printBootBanner(cfg, displayURL); err != nil {
 		return err
@@ -229,6 +234,7 @@ func startOnboarding(ctx context.Context, cfg BootConfig) error {
 		Mode:         web.ModeOnboarding,
 		WorkflowPath: firstWorkflowPath(cfg),
 		Version:      cfg.Version,
+		Build:        cfg.Build,
 		DashboardURL: displayURL,
 	}, web.Dependencies{})
 	if err != nil {
@@ -268,7 +274,7 @@ func serve(ctx context.Context, server *web.Server, listener net.Listener) error
 	}
 }
 
-func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listener net.Listener, snapshots *hub.Hub[telemetry.Snapshot]) error {
+func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listener net.Listener, snapshots *hub.Hub[telemetry.Snapshot], build buildinfo.Info) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -284,7 +290,7 @@ func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listene
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	model, err := tui.NewModel(runCtx, snapshots)
+	model, err := tui.NewModel(runCtx, snapshots, tui.WithBuild(build))
 	if err != nil {
 		return err
 	}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/project"
 )
@@ -53,6 +54,7 @@ type BootConfig struct {
 	Host           string
 	Port           *int
 	Version        string
+	Build          buildinfo.Info
 	Headless       bool
 	StdoutTTY      bool
 	Output         io.Writer
@@ -79,6 +81,7 @@ type options struct {
 	boot          BootFunc
 	signal        SignalFunc
 	version       string
+	build         buildinfo.Info
 	stdoutTTY     func() bool
 }
 
@@ -101,6 +104,12 @@ func WithSignalFunc(signal SignalFunc) Option {
 func WithVersion(version string) Option {
 	return func(opts *options) {
 		opts.version = strings.TrimSpace(version)
+	}
+}
+
+func WithBuild(build buildinfo.Info) Option {
+	return func(opts *options) {
+		opts.build = build
 	}
 }
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -12,6 +12,7 @@ import (
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -23,7 +24,8 @@ const defaultDashboardURL = "http://localhost:4000"
 type Option func(*options)
 
 type options struct {
-	now func() time.Time
+	now   func() time.Time
+	build buildinfo.Info
 }
 
 type Model struct {
@@ -34,6 +36,7 @@ type Model struct {
 	width        int
 	height       int
 	now          func() time.Time
+	build        buildinfo.Info
 	styles       styles
 }
 
@@ -66,6 +69,7 @@ func NewModel(ctx context.Context, snapshots *hub.Hub[telemetry.Snapshot], opts 
 		updates:      subscription.C(),
 		width:        defaultTerminalColumns,
 		now:          cfg.now,
+		build:        cfg.build,
 		styles:       newStyles(),
 	}, nil
 }
@@ -75,6 +79,12 @@ func WithNow(now func() time.Time) Option {
 		if now != nil {
 			cfg.now = now
 		}
+	}
+}
+
+func WithBuild(build buildinfo.Info) Option {
+	return func(cfg *options) {
+		cfg.build = build
 	}
 }
 
@@ -152,6 +162,11 @@ func (m Model) renderSnapshot() string {
 	lines := []string{
 		m.styles.title.Render("╭─ DETENT STATUS"),
 		"│ Generated: " + m.styles.muted.Render(formatTimestamp(snapshot.GeneratedAt)),
+	}
+	if !buildinfo.IsZero(m.build) {
+		lines = append(lines, "│ Build: "+m.styles.muted.Render(buildinfo.DisplayLabel(m.build)))
+	}
+	lines = append(lines, []string{
 		"│ Agents: " + m.styles.ok.Render(fmt.Sprintf("%d running", countOrLen(snapshot.Counts.Running, len(snapshot.Running)))) +
 			m.styles.muted.Render(" | ") +
 			m.styles.warn.Render(fmt.Sprintf("%d queued", countOrLen(snapshot.Counts.Queue, len(snapshot.Queue)))) +
@@ -175,7 +190,7 @@ func (m Model) renderSnapshot() string {
 		"│ Next refresh: " + formatOptionalInfo(formatNextRefresh(snapshot.Refresh), m.styles),
 		m.styles.title.Render("├─ Running"),
 		"│",
-	}
+	}...)
 
 	runningWidth := runningEventWidth(m.width)
 	lines = append(lines, runningTableHeader(runningWidth, m.styles), runningTableSeparator(runningWidth, m.styles))

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -9,6 +9,7 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -19,6 +20,11 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 	snapshots := hub.New[telemetry.Snapshot]()
 	model, err := NewModel(context.Background(), snapshots, WithNow(func() time.Time {
 		return time.Date(2026, 5, 31, 0, 0, 0, 0, time.UTC)
+	}), WithBuild(buildinfo.Info{
+		Version: "dev",
+		Commit:  "abcdef1234567890",
+		Date:    "2026-06-05T21:00:00Z",
+		Dirty:   true,
 	}))
 	if err != nil {
 		t.Fatalf("NewModel() error = %v", err)
@@ -38,6 +44,7 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 	view := stripANSI(next.(Model).View())
 	for _, want := range []string{
 		"DETENT STATUS",
+		"Build: dev (abcdef1, dirty) 2026-06-05T21:00:00Z",
 		"Project: https://github.com/digitaldrywood/detent",
 		"Instance: release-captain (detent-bot)",
 		"Scope: assignee in @me (detent-bot, release-captain)",

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -13,6 +13,7 @@ import (
 	"github.com/labstack/echo/v4"
 
 	"github.com/digitaldrywood/detent/internal/budget"
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
@@ -51,6 +52,7 @@ type Config struct {
 	SSETickInterval time.Duration
 	WorkflowPath    string
 	Version         string
+	Build           buildinfo.Info
 	DashboardURL    string
 	Pricing         budget.PricingTable
 	GlobalConfig    globalconfig.Config
@@ -72,6 +74,7 @@ type Server struct {
 	tickEvery    time.Duration
 	workflow     string
 	version      string
+	build        buildinfo.Info
 	dashboardURL string
 	pricing      budget.PricingTable
 	globalConfig globalconfig.Config
@@ -116,6 +119,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		tickEvery:    cfg.sseTickInterval(),
 		workflow:     cfg.workflowPath(),
 		version:      strings.TrimSpace(cfg.Version),
+		build:        cfg.Build,
 		dashboardURL: cfg.dashboardURL(),
 		pricing:      cfg.pricing(),
 		globalConfig: cfg.GlobalConfig,
@@ -195,6 +199,7 @@ func (s *Server) dashboardData(ctx context.Context, snapshot telemetry.Snapshot)
 	return templates.DashboardData{
 		Title:         "Detent",
 		Version:       s.version,
+		Build:         s.build,
 		ConnectorName: s.connector.Name(),
 		DashboardURL:  s.dashboardURL,
 		Snapshot:      snapshot,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -18,6 +18,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/budget"
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -534,6 +535,11 @@ func TestDashboardRendersServerMetadata(t *testing.T) {
 	server, err := web.NewServer(web.Config{
 		StaticDir: t.TempDir(),
 		Version:   "v9.8.7",
+		Build: buildinfo.Info{
+			Version: "v9.8.7",
+			Commit:  "abcdef1234567890",
+			Date:    "2026-06-05T21:00:00Z",
+		},
 	}, testDeps(t))
 	if err != nil {
 		t.Fatalf("NewServer() error = %v", err)
@@ -550,6 +556,7 @@ func TestDashboardRendersServerMetadata(t *testing.T) {
 	}
 	for _, want := range []string{
 		"v9.8.7",
+		"Build v9.8.7 (abcdef1) 2026-06-05T21:00:00Z",
 		`aria-label="Detent dashboard"`,
 		`href="/"`,
 		`href="/reports"`,

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -33,7 +33,7 @@ templ Dashboard(data DashboardData) {
 						@dashboardPageHeading("Dashboard")
 						@dashboardNav("")
 						<div class="dashboard-topbar-actions ml-auto flex min-w-0 flex-wrap items-center justify-end gap-x-2 gap-y-1 text-xs text-muted-foreground">
-							<span class="truncate font-mono">{ versionLabel(data) }</span>
+							<span class="truncate font-mono">{ dashboardBuildVersionLabel(data) }</span>
 							@dashboardTopbarDivider()
 							<span class="truncate">{ connectorName(data) }</span>
 							@dashboardTopbarDivider()

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	webchart "github.com/digitaldrywood/detent/internal/web/chart"
 )
@@ -22,6 +23,7 @@ const (
 type DashboardData struct {
 	Title         string
 	Version       string
+	Build         buildinfo.Info
 	DashboardURL  string
 	ConnectorName string
 	Snapshot      telemetry.Snapshot
@@ -188,6 +190,20 @@ func versionLabel(data DashboardData) string {
 		return "dev"
 	}
 	return version
+}
+
+func buildLabel(data DashboardData) string {
+	if buildinfo.IsZero(data.Build) {
+		return ""
+	}
+	return "Build " + buildinfo.DisplayLabel(data.Build)
+}
+
+func dashboardBuildVersionLabel(data DashboardData) string {
+	if build := buildLabel(data); build != "" {
+		return build
+	}
+	return versionLabel(data)
 }
 
 func connectorName(data DashboardData) string {

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -111,9 +111,9 @@ func Dashboard(data DashboardData) templ.Component {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var5 string
-		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(versionLabel(data))
+		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(dashboardBuildVersionLabel(data))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 36, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/dashboard.templ`, Line: 36, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary

- add build metadata resolution from ldflags, Go build info, and a matching git checkout fallback
- show build version, short SHA, dirty marker, and date in the TUI status block and dashboard topbar
- route Air dev builds through the stamped Makefile build path

Fixes #315

## Test Plan

- [x] `go test ./internal/buildinfo ./internal/tui ./internal/web ./internal/web/templates ./cmd/detent ./internal/cli`
- [x] `go build -o tmp/detent-plain ./cmd/detent` then `./tmp/detent-plain version`
- [x] `make build VERSION=dev` then `./tmp/detent version`
- [x] `make check`