### PR TITLE
feat(update): handle go-install updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,8 +170,14 @@ Release-installer installs can update with `detent update`; use
 `detent update --yes` for non-interactive automation and `detent update --json`
 for machine-readable status. On Windows, replacement is staged and completes
 after the running `detent.exe` exits. Homebrew installs delegate to
-`brew upgrade digitaldrywood/tap/detent`, while Go and source builds print the
-recommended command instead of overwriting the binary.
+`brew upgrade digitaldrywood/tap/detent`. Go-installed binaries offer an
+interactive choice: run
+`go install github.com/digitaldrywood/detent/cmd/detent@latest`, switch to the
+checksum-verified release binary, or abort. `detent update --yes` runs the Go
+install command for go-installed binaries; `detent update --from-release`
+switches the detected Go-installed binary to the release asset and pins future
+updates to release-binary management. Source builds still print the recommended
+command instead of overwriting the binary.
 
 ## Release
 

--- a/cmd/detent/update.go
+++ b/cmd/detent/update.go
@@ -26,6 +26,7 @@ type updateFactory func() (updateRunner, error)
 func newUpdateCommand(factory updateFactory) *cobra.Command {
 	var checkOnly bool
 	var assumeYes bool
+	var fromRelease bool
 	var jsonOutput bool
 
 	cmd := &cobra.Command{
@@ -43,9 +44,19 @@ func newUpdateCommand(factory updateFactory) *cobra.Command {
 			if checkOnly {
 				status, err = runner.Check(cmd.Context())
 			} else {
-				opts := detentupdate.ApplyOptions{AssumeYes: assumeYes}
-				if !assumeYes && !jsonOutput {
+				streamOut := cmd.OutOrStdout()
+				if jsonOutput {
+					streamOut = cmd.ErrOrStderr()
+				}
+				opts := detentupdate.ApplyOptions{
+					AssumeYes:   assumeYes,
+					FromRelease: fromRelease,
+					Stdout:      streamOut,
+					Stderr:      cmd.ErrOrStderr(),
+				}
+				if !assumeYes && !fromRelease && !jsonOutput {
 					opts.Confirm = confirmUpdate(cmd)
+					opts.SelectGoInstallAction = selectGoInstallAction(cmd)
 				}
 				status, err = runner.Apply(cmd.Context(), opts)
 			}
@@ -64,6 +75,7 @@ func newUpdateCommand(factory updateFactory) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&checkOnly, "check", false, "check for updates without changing the binary")
 	cmd.Flags().BoolVar(&assumeYes, "yes", false, "apply the update without prompting")
+	cmd.Flags().BoolVar(&fromRelease, "from-release", false, "replace a go-install-managed binary with the latest release asset")
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "write machine-readable update status")
 	return cmd
 }
@@ -92,6 +104,48 @@ func confirmUpdate(cmd *cobra.Command) func(detentupdate.Status) (bool, error) {
 		}
 		answer := strings.ToLower(strings.TrimSpace(line))
 		return answer == "y" || answer == "yes", nil
+	}
+}
+
+func selectGoInstallAction(cmd *cobra.Command) func(detentupdate.Status) (detentupdate.GoInstallAction, error) {
+	return func(status detentupdate.Status) (detentupdate.GoInstallAction, error) {
+		out := cmd.OutOrStdout()
+		if _, err := fmt.Fprintf(out, "This Detent binary appears to be managed by go install.\n"); err != nil {
+			return "", err
+		}
+		if _, err := fmt.Fprintf(out, "Update Detent from %s to %s?\n", status.CurrentVersion, status.LatestVersion); err != nil {
+			return "", err
+		}
+		if _, err := fmt.Fprintf(out, "  1) Run the Go install for me: %s\n", status.Command); err != nil {
+			return "", err
+		}
+		if _, err := fmt.Fprintln(out, "  2) Switch to the release binary"); err != nil {
+			return "", err
+		}
+		if _, err := fmt.Fprintf(out, "     WARNING: This replaces %s and changes how Detent is managed. Future go install or go.mod upgrades will not track it.\n", status.Binary); err != nil {
+			return "", err
+		}
+		if _, err := fmt.Fprintln(out, "  3) Abort"); err != nil {
+			return "", err
+		}
+		if _, err := fmt.Fprint(out, "Choose 1, 2, or 3 [3]: "); err != nil {
+			return "", err
+		}
+
+		line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+		if err != nil && !errors.Is(err, io.EOF) {
+			return "", fmt.Errorf("read update choice: %w", err)
+		}
+		switch strings.ToLower(strings.TrimSpace(line)) {
+		case "1", "g", "go", "go install", "run", "run go install":
+			return detentupdate.GoInstallActionRun, nil
+		case "2", "r", "release", "switch", "switch to release", "from release":
+			return detentupdate.GoInstallActionRelease, nil
+		case "", "3", "a", "abort", "n", "no":
+			return detentupdate.GoInstallActionAbort, nil
+		default:
+			return "", fmt.Errorf("invalid update choice: %s", strings.TrimSpace(line))
+		}
 	}
 }
 

--- a/cmd/detent/update_test.go
+++ b/cmd/detent/update_test.go
@@ -88,8 +88,85 @@ func TestUpdateCommandYesAppliesWithoutPrompt(t *testing.T) {
 	if fake.applyOptions.Confirm != nil {
 		t.Fatal("Confirm is set for --yes")
 	}
+	if fake.applyOptions.SelectGoInstallAction != nil {
+		t.Fatal("SelectGoInstallAction is set for --yes")
+	}
 	if !strings.Contains(stdout.String(), "Updated Detent from 1.2.3 to 1.2.4.") {
 		t.Fatalf("stdout = %q, want update message", stdout.String())
+	}
+}
+
+func TestUpdateCommandFromReleasePassesOptionWithoutPrompt(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeUpdater{
+		applyStatus: update.Status{
+			CurrentVersion:  "1.2.3",
+			LatestVersion:   "1.2.4",
+			UpdateAvailable: true,
+			InstallSource:   update.InstallSourceGoInstall,
+			Action:          update.ActionUpdated,
+			Message:         "Updated Detent from 1.2.3 to 1.2.4.",
+		},
+	}
+	cmd := newUpdateCommand(func() (updateRunner, error) {
+		return fake, nil
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--from-release"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+	if !fake.applyCalled {
+		t.Fatal("Apply() was not called")
+	}
+	if !fake.applyOptions.FromRelease {
+		t.Fatal("FromRelease = false, want true")
+	}
+	if fake.applyOptions.Confirm != nil {
+		t.Fatal("Confirm is set for --from-release")
+	}
+	if fake.applyOptions.SelectGoInstallAction != nil {
+		t.Fatal("SelectGoInstallAction is set for --from-release")
+	}
+}
+
+func TestSelectGoInstallActionParsesReleaseChoice(t *testing.T) {
+	t.Parallel()
+
+	cmd := newUpdateCommand(func() (updateRunner, error) {
+		return &fakeUpdater{}, nil
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetIn(strings.NewReader("2\n"))
+
+	choice, err := selectGoInstallAction(cmd)(update.Status{
+		CurrentVersion: "1.2.3",
+		LatestVersion:  "1.2.4",
+		Binary:         "/tmp/detent",
+		Command:        "go install github.com/digitaldrywood/detent/cmd/detent@latest",
+	})
+	if err != nil {
+		t.Fatalf("selectGoInstallAction() error = %v", err)
+	}
+	if choice != update.GoInstallActionRelease {
+		t.Fatalf("choice = %q, want %q", choice, update.GoInstallActionRelease)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"Run the Go install for me",
+		"Switch to the release binary",
+		"Abort",
+		"WARNING:",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, output)
+		}
 	}
 }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -23,7 +23,8 @@ import (
 
 const (
 	defaultAPIBase          = "https://api.github.com/repos/digitaldrywood/detent"
-	moduleInstallTarget     = "github.com/digitaldrywood/detent/cmd/detent@latest"
+	moduleInstallPackage    = "github.com/digitaldrywood/detent/cmd/detent"
+	moduleInstallTarget     = moduleInstallPackage + "@latest"
 	moduleInstallCommand    = "go install " + moduleInstallTarget
 	homebrewUpdateCommand   = "brew upgrade digitaldrywood/tap/detent"
 	defaultChecksumName     = "checksums.txt"
@@ -365,6 +366,7 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 }
 
 func (s *Service) applyGoInstallUpdate(ctx context.Context, status Status, release Release, opts ApplyOptions) (Status, error) {
+	status.Command = goInstallCommand(status)
 	action, err := goInstallAction(status, opts)
 	if err != nil {
 		status.Action = ActionRefused
@@ -402,7 +404,9 @@ func goInstallAction(status Status, opts ApplyOptions) (GoInstallAction, error) 
 }
 
 func (s *Service) runGoInstallUpdate(ctx context.Context, status Status, opts ApplyOptions) (Status, error) {
-	if err := s.cfg.CommandRunner(ctx, "go", []string{"install", moduleInstallTarget}, outputWriter(opts.Stdout), outputWriter(opts.Stderr)); err != nil {
+	target := goInstallTarget(status)
+	status.Command = "go install " + target
+	if err := s.cfg.CommandRunner(ctx, "go", []string{"install", target}, outputWriter(opts.Stdout), outputWriter(opts.Stderr)); err != nil {
 		status.Action = ActionRefused
 		status.Message = fmt.Sprintf("go install failed: %v", err)
 		return status, err
@@ -414,9 +418,15 @@ func (s *Service) runGoInstallUpdate(ctx context.Context, status Status, opts Ap
 		status.Message = fmt.Sprintf("go install completed, but verifying Detent failed: %v", err)
 		return status, err
 	}
+	installed := installedVersion(status, versionOutput)
+	if err := verifyInstalledVersion(status, installed); err != nil {
+		status.Action = ActionRefused
+		status.Message = fmt.Sprintf("go install completed, but installed Detent version is not the planned update: %v", err)
+		return status, err
+	}
 
 	status.Action = ActionUpdated
-	status.Message = goInstallAppliedMessage(status, versionOutput)
+	status.Message = goInstallAppliedMessage(status, installed)
 	return status, nil
 }
 
@@ -935,9 +945,39 @@ func updateAppliedMessage(status Status, goos string, releaseSwap bool) string {
 	return fmt.Sprintf("Updated Detent from %s to %s. %s", status.CurrentVersion, status.LatestVersion, restartNote())
 }
 
-func goInstallAppliedMessage(status Status, versionOutput string) string {
-	version := installedVersion(status, versionOutput)
-	return fmt.Sprintf("Ran %s. Installed Detent version: %s. %s", moduleInstallCommand, version, restartNote())
+func goInstallAppliedMessage(status Status, installed string) string {
+	return fmt.Sprintf("Ran %s. Installed Detent version: %s. %s", status.Command, installed, restartNote())
+}
+
+func goInstallCommand(status Status) string {
+	return "go install " + goInstallTarget(status)
+}
+
+func goInstallTarget(status Status) string {
+	tag := strings.TrimSpace(status.LatestTag)
+	if tag == "" {
+		return moduleInstallTarget
+	}
+	version, err := parseVersion(tag)
+	if err != nil || len(version.prerelease) == 0 {
+		return moduleInstallTarget
+	}
+	return moduleInstallPackage + "@" + tag
+}
+
+func verifyInstalledVersion(status Status, installed string) error {
+	expected := firstNonEmpty(status.LatestTag, status.LatestVersion)
+	if expected == "" {
+		return nil
+	}
+	cmp, err := CompareVersions(installed, expected)
+	if err != nil {
+		return fmt.Errorf("parse installed version %s: %w", installed, err)
+	}
+	if cmp != 0 {
+		return fmt.Errorf("installed version %s does not match expected %s", installed, expected)
+	}
+	return nil
 }
 
 func installedVersion(status Status, versionOutput string) string {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -18,6 +18,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"time"
 	"unicode"
 )
 
@@ -270,6 +271,7 @@ type Replacement struct {
 	StartProcess ProcessStarter
 	Verify       BinaryVerifier
 	Sign         BinarySigner
+	AfterReplace func(context.Context, string) error
 }
 
 type Status struct {
@@ -469,7 +471,7 @@ func (s *Service) applyReleaseUpdate(ctx context.Context, status Status, release
 		status.Message = err.Error()
 		return status, err
 	}
-	if err := ReplaceBinary(Replacement{
+	replacement := Replacement{
 		Target:  s.cfg.ExecutablePath,
 		Binary:  binary,
 		Mode:    mode,
@@ -477,7 +479,16 @@ func (s *Service) applyReleaseUpdate(ctx context.Context, status Status, release
 		Context: ctx,
 		Verify:  s.cfg.BinaryVerifier,
 		Sign:    s.cfg.BinarySigner,
-	}); err != nil {
+	}
+	if releaseSwap {
+		replacement.AfterReplace = func(_ context.Context, target string) error {
+			return writeReleaseInstallLock(s.cfg.GOOS, DetectionOptions{
+				HomeDir: s.cfg.HomeDir,
+				Env:     s.cfg.Env,
+			}, target)
+		}
+	}
+	if err := ReplaceBinary(replacement); err != nil {
 		status.Action = ActionRefused
 		status.Message = err.Error()
 		return status, err
@@ -766,6 +777,11 @@ func finalizeReplacement(replacement Replacement) error {
 			return err
 		}
 	}
+	if replacement.AfterReplace != nil {
+		if err := replacement.AfterReplace(ctx, replacement.Target); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -818,6 +834,15 @@ func stageWindowsReplacement(replacement Replacement) error {
 	}
 	if err := starter("cmd.exe", []string{"/D", "/C", "start", "", "/B", "cmd.exe", "/D", "/C", script}); err != nil {
 		return fmt.Errorf("start windows updater: %w", err)
+	}
+	if replacement.AfterReplace != nil {
+		ctx := replacement.Context
+		if ctx == nil {
+			ctx = context.Background()
+		}
+		if err := replacement.AfterReplace(ctx, replacement.Target); err != nil {
+			return err
+		}
 	}
 
 	cleanupSource = false
@@ -1348,6 +1373,80 @@ func readInstallLockBinary(path string) (string, bool) {
 		}
 	}
 	return "", false
+}
+
+func writeReleaseInstallLock(goos string, opts DetectionOptions, binary string) error {
+	lockPath, ok := installLockPath(goos, opts)
+	if !ok {
+		return errors.New("resolve release install lock path: home directory is unavailable")
+	}
+	return writeInstallLock(lockPath, binary, time.Now().UTC())
+}
+
+func installLockPath(goos string, opts DetectionOptions) (string, bool) {
+	if lockPath := envValue(opts.Env, "DETENT_INSTALL_LOCK"); lockPath != "" {
+		return lockPath, true
+	}
+	if stateDir := envValue(opts.Env, "DETENT_STATE_DIR"); stateDir != "" {
+		return filepath.Join(stateDir, "install.lock"), true
+	}
+	if goos == "windows" {
+		if localAppData := envValue(opts.Env, "LOCALAPPDATA"); localAppData != "" {
+			return filepath.Join(localAppData, "detent", "install.lock"), true
+		}
+	}
+	if home := homeDir(opts.HomeDir, opts.Env); home != "" {
+		return filepath.Join(home, ".detent", "install.lock"), true
+	}
+	return "", false
+}
+
+func writeInstallLock(path string, binary string, installedAt time.Time) error {
+	if strings.TrimSpace(path) == "" {
+		return errors.New("install lock path is required")
+	}
+	if strings.TrimSpace(binary) == "" {
+		return errors.New("install lock binary path is required")
+	}
+	dir := filepath.Dir(path)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return fmt.Errorf("create install lock dir: %w", err)
+	}
+	base := filepath.Base(path)
+	temp, err := os.CreateTemp(dir, "."+base+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("create install lock temp file: %w", err)
+	}
+	tempPath := temp.Name()
+	cleanup := true
+	defer func() {
+		if cleanup {
+			removeFile(tempPath)
+		}
+	}()
+	raw := fmt.Sprintf("binary=%s\ninstalled_at=%s\n", binary, installedAt.UTC().Format(time.RFC3339))
+	if _, err := temp.WriteString(raw); err != nil {
+		closeErr := temp.Close()
+		if closeErr != nil {
+			return fmt.Errorf("write install lock: %w; close install lock: %w", err, closeErr)
+		}
+		return fmt.Errorf("write install lock: %w", err)
+	}
+	if err := temp.Chmod(0o600); err != nil {
+		closeErr := temp.Close()
+		if closeErr != nil {
+			return fmt.Errorf("chmod install lock: %w; close install lock: %w", err, closeErr)
+		}
+		return fmt.Errorf("chmod install lock: %w", err)
+	}
+	if err := temp.Close(); err != nil {
+		return fmt.Errorf("close install lock: %w", err)
+	}
+	if err := os.Rename(tempPath, path); err != nil {
+		return fmt.Errorf("replace install lock: %w", err)
+	}
+	cleanup = false
+	return nil
 }
 
 func windowsInstallerPathMatches(executable string, goos string, opts DetectionOptions) bool {

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -23,7 +23,8 @@ import (
 
 const (
 	defaultAPIBase          = "https://api.github.com/repos/digitaldrywood/detent"
-	moduleInstallCommand    = "go install github.com/digitaldrywood/detent/cmd/detent@latest"
+	moduleInstallTarget     = "github.com/digitaldrywood/detent/cmd/detent@latest"
+	moduleInstallCommand    = "go install " + moduleInstallTarget
 	homebrewUpdateCommand   = "brew upgrade digitaldrywood/tap/detent"
 	defaultChecksumName     = "checksums.txt"
 	projectName             = "detent"
@@ -81,6 +82,9 @@ type ReleaseClient interface {
 }
 
 type ProcessStarter func(string, []string) error
+type CommandRunner func(context.Context, string, []string, io.Writer, io.Writer) error
+type BinaryVerifier func(context.Context, string) (string, error)
+type BinarySigner func(context.Context, string) error
 
 type GitHubClientConfig struct {
 	APIBase    string
@@ -227,6 +231,9 @@ type Config struct {
 	GOOS           string
 	GOARCH         string
 	Client         ReleaseClient
+	CommandRunner  CommandRunner
+	BinaryVerifier BinaryVerifier
+	BinarySigner   BinarySigner
 	HomeDir        string
 	Env            map[string]string
 	EvalSymlinks   func(string) (string, error)
@@ -237,16 +244,31 @@ type Service struct {
 }
 
 type ApplyOptions struct {
-	AssumeYes bool
-	Confirm   func(Status) (bool, error)
+	AssumeYes             bool
+	FromRelease           bool
+	Confirm               func(Status) (bool, error)
+	SelectGoInstallAction func(Status) (GoInstallAction, error)
+	Stdout                io.Writer
+	Stderr                io.Writer
 }
+
+type GoInstallAction string
+
+const (
+	GoInstallActionRun     GoInstallAction = "run_go_install"
+	GoInstallActionRelease GoInstallAction = "switch_to_release"
+	GoInstallActionAbort   GoInstallAction = "abort"
+)
 
 type Replacement struct {
 	Target       string
 	Binary       []byte
 	Mode         os.FileMode
 	GOOS         string
+	Context      context.Context
 	StartProcess ProcessStarter
+	Verify       BinaryVerifier
+	Sign         BinarySigner
 }
 
 type Status struct {
@@ -271,6 +293,15 @@ func NewService(cfg Config) *Service {
 	}
 	if cfg.Client == nil {
 		cfg.Client = NewGitHubClient(GitHubClientConfig{})
+	}
+	if cfg.CommandRunner == nil {
+		cfg.CommandRunner = runCommand
+	}
+	if cfg.BinaryVerifier == nil {
+		cfg.BinaryVerifier = verifyBinaryVersion
+	}
+	if cfg.BinarySigner == nil {
+		cfg.BinarySigner = signBinary
 	}
 	return &Service{cfg: cfg}
 }
@@ -299,10 +330,8 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 		return status, nil
 	case InstallSourceRelease:
 	case InstallSourceGoInstall:
-		status.Action = ActionRefused
 		status.Command = moduleInstallCommand
-		status.Message = "This Detent binary appears to be managed by go install. Run the Go install command instead."
-		return status, ErrRefused
+		return s.applyGoInstallUpdate(ctx, status, release, opts)
 	case InstallSourceDevelopment:
 		status.Action = ActionRefused
 		status.Message = "This Detent binary does not include release version metadata. Install a published release before using self-update."
@@ -313,7 +342,7 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 		return status, ErrRefused
 	}
 
-	if !opts.AssumeYes {
+	if !opts.AssumeYes && !opts.FromRelease {
 		if opts.Confirm == nil {
 			status.Action = ActionRefused
 			status.Message = "Update requires confirmation. Rerun with --yes to update non-interactively."
@@ -329,6 +358,74 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 			status.Action = ActionRefused
 			status.Message = "Update cancelled."
 			return status, ErrConfirmationRequired
+		}
+	}
+
+	return s.applyReleaseUpdate(ctx, status, release, opts, false, false)
+}
+
+func (s *Service) applyGoInstallUpdate(ctx context.Context, status Status, release Release, opts ApplyOptions) (Status, error) {
+	action, err := goInstallAction(status, opts)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+
+	switch action {
+	case GoInstallActionRun:
+		return s.runGoInstallUpdate(ctx, status, opts)
+	case GoInstallActionRelease:
+		return s.applyReleaseUpdate(ctx, status, release, opts, true, opts.FromRelease)
+	case GoInstallActionAbort:
+		status.Action = ActionRefused
+		status.Message = "Update aborted."
+		return status, ErrRefused
+	default:
+		status.Action = ActionRefused
+		status.Message = fmt.Sprintf("unsupported go install update action: %s", action)
+		return status, ErrRefused
+	}
+}
+
+func goInstallAction(status Status, opts ApplyOptions) (GoInstallAction, error) {
+	if opts.FromRelease {
+		return GoInstallActionRelease, nil
+	}
+	if opts.AssumeYes {
+		return GoInstallActionRun, nil
+	}
+	if opts.SelectGoInstallAction == nil {
+		return GoInstallActionAbort, fmt.Errorf("%w: this Detent binary appears to be managed by go install. Rerun with --yes to run go install, or --from-release to switch to the release binary", ErrConfirmationRequired)
+	}
+	return opts.SelectGoInstallAction(status)
+}
+
+func (s *Service) runGoInstallUpdate(ctx context.Context, status Status, opts ApplyOptions) (Status, error) {
+	if err := s.cfg.CommandRunner(ctx, "go", []string{"install", moduleInstallTarget}, outputWriter(opts.Stdout), outputWriter(opts.Stderr)); err != nil {
+		status.Action = ActionRefused
+		status.Message = fmt.Sprintf("go install failed: %v", err)
+		return status, err
+	}
+
+	versionOutput, err := s.cfg.BinaryVerifier(ctx, s.cfg.ExecutablePath)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = fmt.Sprintf("go install completed, but verifying Detent failed: %v", err)
+		return status, err
+	}
+
+	status.Action = ActionUpdated
+	status.Message = goInstallAppliedMessage(status, versionOutput)
+	return status, nil
+}
+
+func (s *Service) applyReleaseUpdate(ctx context.Context, status Status, release Release, opts ApplyOptions, releaseSwap bool, emitWarning bool) (Status, error) {
+	if emitWarning {
+		if err := writeReleaseSwapWarning(outputWriter(opts.Stderr), status); err != nil {
+			status.Action = ActionRefused
+			status.Message = err.Error()
+			return status, err
 		}
 	}
 
@@ -363,10 +460,13 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 		return status, err
 	}
 	if err := ReplaceBinary(Replacement{
-		Target: s.cfg.ExecutablePath,
-		Binary: binary,
-		Mode:   mode,
-		GOOS:   s.cfg.GOOS,
+		Target:  s.cfg.ExecutablePath,
+		Binary:  binary,
+		Mode:    mode,
+		GOOS:    s.cfg.GOOS,
+		Context: ctx,
+		Verify:  s.cfg.BinaryVerifier,
+		Sign:    s.cfg.BinarySigner,
 	}); err != nil {
 		status.Action = ActionRefused
 		status.Message = err.Error()
@@ -375,7 +475,7 @@ func (s *Service) Apply(ctx context.Context, opts ApplyOptions) (Status, error) 
 
 	status.Action = ActionUpdated
 	status.Asset = assets.Archive.Name
-	status.Message = updateAppliedMessage(status, s.cfg.GOOS)
+	status.Message = updateAppliedMessage(status, s.cfg.GOOS, releaseSwap)
 	return status, nil
 }
 
@@ -525,16 +625,16 @@ func ReplaceBinary(replacement Replacement) error {
 	if goos == "windows" {
 		return stageWindowsReplacement(replacement)
 	}
-	return replaceBinaryNow(replacement.Target, replacement.Binary, replacement.Mode)
+	replacement.GOOS = goos
+	return replaceBinaryNow(replacement)
 }
 
-func replaceBinaryNow(target string, binary []byte, mode os.FileMode) error {
+func replaceBinaryNow(replacement Replacement) error {
+	target := replacement.Target
 	if strings.TrimSpace(target) == "" {
 		return errors.New("target binary path is required")
 	}
-	if mode == 0 {
-		mode = 0o755
-	}
+	mode := replacementMode(target, replacement.Mode)
 
 	dir := filepath.Dir(target)
 	base := filepath.Base(target)
@@ -550,14 +650,122 @@ func replaceBinaryNow(target string, binary []byte, mode os.FileMode) error {
 		}
 	}()
 
-	writeErr := writeBinaryTemp(temp, binary, mode)
+	writeErr := writeBinaryTemp(temp, replacement.Binary, mode)
 	if writeErr != nil {
 		return writeErr
 	}
+
+	backupPath, err := backupBinary(target)
+	if err != nil {
+		return err
+	}
+	cleanupBackup := backupPath != ""
+	defer func() {
+		if cleanupBackup {
+			removeFile(backupPath)
+		}
+	}()
+
 	if err := os.Rename(tempPath, target); err != nil {
 		return fmt.Errorf("replace binary %s: %w", target, err)
 	}
 	cleanup = false
+	if err := finalizeReplacement(replacement); err != nil {
+		if rollbackErr := rollbackBinary(target, backupPath); rollbackErr != nil {
+			return fmt.Errorf("%w; rollback failed: %w", err, rollbackErr)
+		}
+		cleanupBackup = false
+		return err
+	}
+	return nil
+}
+
+func replacementMode(target string, fallback os.FileMode) os.FileMode {
+	info, err := os.Stat(target)
+	if err == nil {
+		if mode := info.Mode().Perm(); mode != 0 {
+			return mode
+		}
+	}
+	if fallback != 0 {
+		return fallback.Perm()
+	}
+	return 0o755
+}
+
+func backupBinary(target string) (string, error) {
+	source, err := os.Open(target)
+	if errors.Is(err, os.ErrNotExist) {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("open current binary for backup: %w", err)
+	}
+	defer source.Close()
+
+	info, err := source.Stat()
+	if err != nil {
+		return "", fmt.Errorf("stat current binary for backup: %w", err)
+	}
+	dir := filepath.Dir(target)
+	base := filepath.Base(target)
+	backup, err := os.CreateTemp(dir, "."+base+".rollback-*")
+	if err != nil {
+		return "", fmt.Errorf("create rollback binary: %w", err)
+	}
+	backupPath := backup.Name()
+	if _, err := io.Copy(backup, source); err != nil {
+		closeErr := backup.Close()
+		removeFile(backupPath)
+		if closeErr != nil {
+			return "", fmt.Errorf("write rollback binary: %w; close rollback binary: %w", err, closeErr)
+		}
+		return "", fmt.Errorf("write rollback binary: %w", err)
+	}
+	if err := backup.Chmod(info.Mode().Perm()); err != nil {
+		closeErr := backup.Close()
+		removeFile(backupPath)
+		if closeErr != nil {
+			return "", fmt.Errorf("chmod rollback binary: %w; close rollback binary: %w", err, closeErr)
+		}
+		return "", fmt.Errorf("chmod rollback binary: %w", err)
+	}
+	if err := backup.Close(); err != nil {
+		removeFile(backupPath)
+		return "", fmt.Errorf("close rollback binary: %w", err)
+	}
+	return backupPath, nil
+}
+
+func finalizeReplacement(replacement Replacement) error {
+	ctx := replacement.Context
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if replacement.GOOS == "darwin" {
+		signer := replacement.Sign
+		if signer == nil {
+			signer = signBinary
+		}
+		if err := signer(ctx, replacement.Target); err != nil {
+			return err
+		}
+	}
+	if replacement.Verify != nil {
+		if _, err := replacement.Verify(ctx, replacement.Target); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func rollbackBinary(target string, backupPath string) error {
+	if backupPath == "" {
+		return nil
+	}
+	if err := os.Rename(backupPath, target); err != nil {
+		return fmt.Errorf("restore previous binary %s: %w", target, err)
+	}
 	return nil
 }
 
@@ -677,11 +885,90 @@ func startProcess(command string, args []string) error {
 	return exec.Command(command, args...).Start()
 }
 
-func updateAppliedMessage(status Status, goos string) string {
+func runCommand(ctx context.Context, command string, args []string, stdout io.Writer, stderr io.Writer) error {
+	cmd := exec.CommandContext(ctx, command, args...)
+	cmd.Stdout = outputWriter(stdout)
+	cmd.Stderr = outputWriter(stderr)
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("run %s: %w", strings.Join(append([]string{command}, args...), " "), err)
+	}
+	return nil
+}
+
+func verifyBinaryVersion(ctx context.Context, path string) (string, error) {
+	cmd := exec.CommandContext(ctx, path, "version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return string(output), fmt.Errorf("verify %s version: %w: %s", path, err, strings.TrimSpace(string(output)))
+	}
+	return string(output), nil
+}
+
+func signBinary(ctx context.Context, path string) error {
+	cmd := exec.CommandContext(ctx, "codesign", "-s", "-", path)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("codesign %s: %w: %s", path, err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func outputWriter(writer io.Writer) io.Writer {
+	if writer == nil {
+		return io.Discard
+	}
+	return writer
+}
+
+func updateAppliedMessage(status Status, goos string, releaseSwap bool) string {
 	if goos == "windows" {
 		return fmt.Sprintf("Updated Detent from %s to %s. The replacement will finish after Detent exits.", status.CurrentVersion, status.LatestVersion)
 	}
-	return fmt.Sprintf("Updated Detent from %s to %s.", status.CurrentVersion, status.LatestVersion)
+	if releaseSwap {
+		return fmt.Sprintf(
+			"Updated Detent from %s to %s from the release binary. This binary is now release-pinned instead of go-install-managed. %s",
+			status.CurrentVersion,
+			status.LatestVersion,
+			restartNote(),
+		)
+	}
+	return fmt.Sprintf("Updated Detent from %s to %s. %s", status.CurrentVersion, status.LatestVersion, restartNote())
+}
+
+func goInstallAppliedMessage(status Status, versionOutput string) string {
+	version := installedVersion(status, versionOutput)
+	return fmt.Sprintf("Ran %s. Installed Detent version: %s. %s", moduleInstallCommand, version, restartNote())
+}
+
+func installedVersion(status Status, versionOutput string) string {
+	for _, line := range strings.Split(versionOutput, "\n") {
+		key, value, ok := strings.Cut(line, ":")
+		if ok && strings.EqualFold(strings.TrimSpace(key), "version") {
+			if version := strings.TrimSpace(value); version != "" {
+				return version
+			}
+		}
+	}
+	for _, line := range strings.Split(versionOutput, "\n") {
+		if value := strings.TrimSpace(line); value != "" {
+			return value
+		}
+	}
+	return firstNonEmpty(status.LatestVersion, status.LatestTag, "unknown")
+}
+
+func restartNote() string {
+	return "Restart Detent to use the new binary; any running orchestrator process keeps the old version until restarted."
+}
+
+func writeReleaseSwapWarning(out io.Writer, status Status) error {
+	_, err := fmt.Fprintf(
+		out,
+		"WARNING: Switching to the release binary replaces %s and changes how Detent is managed. Future go install or go.mod upgrades will not track this binary; it will be pinned to GitHub release %s.\n",
+		status.Binary,
+		firstNonEmpty(status.LatestTag, status.LatestVersion),
+	)
+	return err
 }
 
 func writeBinaryTemp(file *os.File, binary []byte, mode os.FileMode) error {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -342,6 +342,98 @@ func TestServiceGoInstallYesRunsCommandAndReportsVersion(t *testing.T) {
 	}
 }
 
+func TestServiceGoInstallPrereleasePinsSelectedTag(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	goBin := filepath.Join(tmp, "gobin")
+	binary := filepath.Join(goBin, "detent")
+	if err := os.MkdirAll(goBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(goBin) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+
+	var gotArgs []string
+	service := NewService(Config{
+		CurrentVersion: "1.3.0-rc.1",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: staticReleaseClient{
+			releases: []Release{
+				{TagName: "v1.2.4"},
+				{TagName: "v1.3.0-rc.2", Prerelease: true},
+			},
+		},
+		Env: map[string]string{"GOBIN": goBin},
+		CommandRunner: func(_ context.Context, _ string, args []string, _ io.Writer, _ io.Writer) error {
+			gotArgs = append(gotArgs, args...)
+			return nil
+		},
+		BinaryVerifier: func(context.Context, string) (string, error) {
+			return "version: v1.3.0-rc.2\n", nil
+		},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if strings.Join(gotArgs, " ") != "install github.com/digitaldrywood/detent/cmd/detent@v1.3.0-rc.2" {
+		t.Fatalf("args = %q, want go install pinned prerelease", gotArgs)
+	}
+	if status.Command != "go install github.com/digitaldrywood/detent/cmd/detent@v1.3.0-rc.2" {
+		t.Fatalf("Command = %q, want pinned prerelease command", status.Command)
+	}
+}
+
+func TestServiceGoInstallRefusesVersionMismatch(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	goBin := filepath.Join(tmp, "gobin")
+	binary := filepath.Join(goBin, "detent")
+	if err := os.MkdirAll(goBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(goBin) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+
+	service := NewService(Config{
+		CurrentVersion: "1.3.0-rc.1",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: staticReleaseClient{
+			releases: []Release{
+				{TagName: "v1.2.4"},
+				{TagName: "v1.3.0-rc.2", Prerelease: true},
+			},
+		},
+		Env: map[string]string{"GOBIN": goBin},
+		CommandRunner: func(context.Context, string, []string, io.Writer, io.Writer) error {
+			return nil
+		},
+		BinaryVerifier: func(context.Context, string) (string, error) {
+			return "version: v1.2.4\n", nil
+		},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
+	if err == nil {
+		t.Fatal("Apply() error = nil, want version mismatch")
+	}
+	if status.Action != ActionRefused {
+		t.Fatalf("Action = %q, want %q", status.Action, ActionRefused)
+	}
+	if !strings.Contains(status.Message, "does not match expected") {
+		t.Fatalf("Message = %q, want version mismatch", status.Message)
+	}
+}
+
 func TestServiceGoInstallInteractiveAbortReturnsCommand(t *testing.T) {
 	t.Parallel()
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -7,7 +7,9 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"errors"
 	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -247,6 +249,9 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 			HTTPClient: server.Client(),
 		}),
 		Env: map[string]string{"DETENT_INSTALL_LOCK": lockPath},
+		BinaryVerifier: func(context.Context, string) (string, error) {
+			return "version: v1.2.4\n", nil
+		},
 	})
 
 	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
@@ -265,6 +270,299 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 	}
 	if strings.TrimSpace(string(raw)) != "updated" {
 		t.Fatalf("updated binary = %q, want updated", raw)
+	}
+}
+
+func TestServiceGoInstallYesRunsCommandAndReportsVersion(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	goBin := filepath.Join(tmp, "gobin")
+	binary := filepath.Join(goBin, "detent")
+	if err := os.MkdirAll(goBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(goBin) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	var gotCommand string
+	var gotArgs []string
+	service := NewService(Config{
+		CurrentVersion: "1.2.3",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: staticReleaseClient{
+			releases: []Release{{TagName: "v1.2.4"}},
+		},
+		Env: map[string]string{"GOBIN": goBin},
+		CommandRunner: func(_ context.Context, command string, args []string, out io.Writer, errOut io.Writer) error {
+			gotCommand = command
+			gotArgs = append(gotArgs, args...)
+			_, _ = fmt.Fprintln(out, "go install output")
+			return nil
+		},
+		BinaryVerifier: func(context.Context, string) (string, error) {
+			return "version: v1.2.4\ncommit: abc1234\n", nil
+		},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{
+		AssumeYes: true,
+		Stdout:    &stdout,
+		Stderr:    &stderr,
+	})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if status.Action != ActionUpdated {
+		t.Fatalf("Action = %q, want %q", status.Action, ActionUpdated)
+	}
+	if gotCommand != "go" {
+		t.Fatalf("command = %q, want go", gotCommand)
+	}
+	if strings.Join(gotArgs, " ") != "install github.com/digitaldrywood/detent/cmd/detent@latest" {
+		t.Fatalf("args = %q, want go install module", gotArgs)
+	}
+	if !strings.Contains(stdout.String(), "go install output") {
+		t.Fatalf("stdout = %q, want streamed go install output", stdout.String())
+	}
+	if !strings.Contains(status.Message, "Installed Detent version: v1.2.4") {
+		t.Fatalf("Message = %q, want installed version", status.Message)
+	}
+	if !strings.Contains(status.Message, "Restart Detent") {
+		t.Fatalf("Message = %q, want restart note", status.Message)
+	}
+	if status.Command != moduleInstallCommand {
+		t.Fatalf("Command = %q, want %q", status.Command, moduleInstallCommand)
+	}
+}
+
+func TestServiceGoInstallInteractiveAbortReturnsCommand(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	goBin := filepath.Join(tmp, "gobin")
+	binary := filepath.Join(goBin, "detent")
+	if err := os.MkdirAll(goBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(goBin) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+
+	service := NewService(Config{
+		CurrentVersion: "1.2.3",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: staticReleaseClient{
+			releases: []Release{{TagName: "v1.2.4"}},
+		},
+		Env: map[string]string{"GOBIN": goBin},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{
+		SelectGoInstallAction: func(Status) (GoInstallAction, error) {
+			return GoInstallActionAbort, nil
+		},
+	})
+	if !errors.Is(err, ErrRefused) {
+		t.Fatalf("Apply() error = %v, want %v", err, ErrRefused)
+	}
+	if status.Action != ActionRefused {
+		t.Fatalf("Action = %q, want %q", status.Action, ActionRefused)
+	}
+	if status.Command != moduleInstallCommand {
+		t.Fatalf("Command = %q, want %q", status.Command, moduleInstallCommand)
+	}
+	if !strings.Contains(status.Message, "Update aborted") {
+		t.Fatalf("Message = %q, want abort message", status.Message)
+	}
+}
+
+func TestServiceGoInstallFromReleaseUsesReleaseAsset(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	goBin := filepath.Join(tmp, "gobin")
+	binary := filepath.Join(goBin, "detent")
+	if err := os.MkdirAll(goBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(goBin) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+
+	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
+	checksumName := "detent_1.2.4_checksums.txt"
+	archive := detentUpdateArchive(t, "updated")
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%x  %s\n", sum, archiveName)
+	downloads := map[string][]byte{
+		"https://example.invalid/archive":   archive,
+		"https://example.invalid/checksums": []byte(checksums),
+	}
+	var stderr bytes.Buffer
+	var verifiedPath string
+	service := NewService(Config{
+		CurrentVersion: "1.2.3",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: staticReleaseClient{
+			releases: []Release{{
+				TagName: "v1.2.4",
+				Assets: []Asset{
+					{Name: archiveName, BrowserDownloadURL: "https://example.invalid/archive"},
+					{Name: checksumName, BrowserDownloadURL: "https://example.invalid/checksums"},
+				},
+			}},
+			downloads: downloads,
+		},
+		Env: map[string]string{"GOBIN": goBin},
+		BinaryVerifier: func(_ context.Context, path string) (string, error) {
+			verifiedPath = path
+			return "version: v1.2.4\n", nil
+		},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{
+		FromRelease: true,
+		Stderr:      &stderr,
+	})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if status.Action != ActionUpdated {
+		t.Fatalf("Action = %q, want %q", status.Action, ActionUpdated)
+	}
+	if status.Asset != archiveName {
+		t.Fatalf("Asset = %q, want %q", status.Asset, archiveName)
+	}
+	if verifiedPath != binary {
+		t.Fatalf("verifiedPath = %q, want %q", verifiedPath, binary)
+	}
+	raw, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("ReadFile(binary) error = %v", err)
+	}
+	if strings.TrimSpace(string(raw)) != "updated" {
+		t.Fatalf("updated binary = %q, want updated", raw)
+	}
+	if !strings.Contains(stderr.String(), "WARNING:") {
+		t.Fatalf("stderr = %q, want release-swap warning", stderr.String())
+	}
+	if !strings.Contains(status.Message, "Restart Detent") {
+		t.Fatalf("Message = %q, want restart note", status.Message)
+	}
+}
+
+func TestReplaceBinaryPreservesPermissionsAndVerifies(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "detent")
+	if err := os.WriteFile(target, []byte("old"), 0o750); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	var verifiedPath string
+	err := ReplaceBinary(Replacement{
+		Target: target,
+		Binary: []byte("new"),
+		Mode:   0o600,
+		GOOS:   "linux",
+		Verify: func(_ context.Context, path string) (string, error) {
+			verifiedPath = path
+			return "version: v1.2.4\n", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceBinary() error = %v", err)
+	}
+	if verifiedPath != target {
+		t.Fatalf("verifiedPath = %q, want %q", verifiedPath, target)
+	}
+	raw, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target) error = %v", err)
+	}
+	if string(raw) != "new" {
+		t.Fatalf("target = %q, want new", raw)
+	}
+	info, err := os.Stat(target)
+	if err != nil {
+		t.Fatalf("Stat(target) error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != 0o750 {
+		t.Fatalf("mode = %v, want 0750", got)
+	}
+}
+
+func TestReplaceBinaryRollsBackWhenVerificationFails(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "detent")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	err := ReplaceBinary(Replacement{
+		Target: target,
+		Binary: []byte("new"),
+		Mode:   0o755,
+		GOOS:   "linux",
+		Verify: func(context.Context, string) (string, error) {
+			return "", errors.New("verification failed")
+		},
+	})
+	if err == nil {
+		t.Fatal("ReplaceBinary() error = nil, want verification failure")
+	}
+	raw, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target) error = %v", err)
+	}
+	if string(raw) != "old" {
+		t.Fatalf("target = %q, want rollback to old", raw)
+	}
+}
+
+func TestReplaceBinarySignsDarwinBeforeVerify(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "detent")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	var calls []string
+	err := ReplaceBinary(Replacement{
+		Target: target,
+		Binary: []byte("new"),
+		Mode:   0o755,
+		GOOS:   "darwin",
+		Sign: func(_ context.Context, path string) error {
+			calls = append(calls, "sign:"+path)
+			return nil
+		},
+		Verify: func(_ context.Context, path string) (string, error) {
+			calls = append(calls, "verify:"+path)
+			return "version: v1.2.4\n", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceBinary() error = %v", err)
+	}
+	want := []string{"sign:" + target, "verify:" + target}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("calls = %q, want %q", calls, want)
 	}
 }
 
@@ -390,6 +688,23 @@ func detentWindowsUpdateArchive(t *testing.T, content string) []byte {
 		t.Fatalf("zip Close() error = %v", err)
 	}
 	return buf.Bytes()
+}
+
+type staticReleaseClient struct {
+	releases  []Release
+	downloads map[string][]byte
+}
+
+func (c staticReleaseClient) ListReleases(context.Context) ([]Release, error) {
+	return c.releases, nil
+}
+
+func (c staticReleaseClient) Download(_ context.Context, url string) ([]byte, error) {
+	raw, ok := c.downloads[url]
+	if !ok {
+		return nil, fmt.Errorf("download not found: %s", url)
+	}
+	return raw, nil
 }
 
 func stagedWindowsUpdateFiles(t *testing.T, dir string) (string, string) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -14,6 +14,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -494,12 +495,14 @@ func TestReplaceBinaryPreservesPermissionsAndVerifies(t *testing.T) {
 	if string(raw) != "new" {
 		t.Fatalf("target = %q, want new", raw)
 	}
-	info, err := os.Stat(target)
-	if err != nil {
-		t.Fatalf("Stat(target) error = %v", err)
-	}
-	if got := info.Mode().Perm(); got != 0o750 {
-		t.Fatalf("mode = %v, want 0750", got)
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(target)
+		if err != nil {
+			t.Fatalf("Stat(target) error = %v", err)
+		}
+		if got := info.Mode().Perm(); got != 0o750 {
+			t.Fatalf("mode = %v, want 0750", got)
+		}
 	}
 }
 

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -516,7 +516,8 @@ func TestServiceGoInstallFromReleaseUsesReleaseAsset(t *testing.T) {
 			}},
 			downloads: downloads,
 		},
-		Env: map[string]string{"GOBIN": goBin},
+		Env:     map[string]string{"GOBIN": goBin},
+		HomeDir: tmp,
 		BinaryVerifier: func(_ context.Context, path string) (string, error) {
 			verifiedPath = path
 			return "version: v1.2.4\n", nil
@@ -551,6 +552,30 @@ func TestServiceGoInstallFromReleaseUsesReleaseAsset(t *testing.T) {
 	}
 	if !strings.Contains(status.Message, "Restart Detent") {
 		t.Fatalf("Message = %q, want restart note", status.Message)
+	}
+
+	lockPath := filepath.Join(tmp, ".detent", "install.lock")
+	lockRaw, err := os.ReadFile(lockPath)
+	if err != nil {
+		t.Fatalf("ReadFile(lock) error = %v", err)
+	}
+	lockText := string(lockRaw)
+	if !strings.Contains(lockText, "binary="+binary+"\n") {
+		t.Fatalf("install lock = %q, want binary path", lockText)
+	}
+	if !strings.Contains(lockText, "installed_at=") {
+		t.Fatalf("install lock = %q, want installed_at", lockText)
+	}
+
+	detected := DetectInstallSource(DetectionOptions{
+		CurrentVersion: "1.2.4",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		HomeDir:        tmp,
+		Env:            map[string]string{"GOBIN": goBin},
+	})
+	if detected.Source != InstallSourceRelease {
+		t.Fatalf("Source after release swap = %q, want %q", detected.Source, InstallSourceRelease)
 	}
 }
 
@@ -618,6 +643,39 @@ func TestReplaceBinaryRollsBackWhenVerificationFails(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("ReplaceBinary() error = nil, want verification failure")
+	}
+	raw, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("ReadFile(target) error = %v", err)
+	}
+	if string(raw) != "old" {
+		t.Fatalf("target = %q, want rollback to old", raw)
+	}
+}
+
+func TestReplaceBinaryRollsBackWhenAfterReplaceFails(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "detent")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	err := ReplaceBinary(Replacement{
+		Target: target,
+		Binary: []byte("new"),
+		Mode:   0o755,
+		GOOS:   "linux",
+		Verify: func(context.Context, string) (string, error) {
+			return "version: v1.2.4\n", nil
+		},
+		AfterReplace: func(context.Context, string) error {
+			return errors.New("metadata failed")
+		},
+	})
+	if err == nil {
+		t.Fatal("ReplaceBinary() error = nil, want metadata failure")
 	}
 	raw, err := os.ReadFile(target)
 	if err != nil {


### PR DESCRIPTION
## Summary

- add go-install update choices for run-go-install, release swap, and abort
- add `--from-release` for explicit release-asset swaps from go-installed binaries
- verify release swaps with checksum, atomic replace, preserved permissions, macOS signing, post-install version checks, and rollback on verification failure
- document the go-install `--yes` default and release-pinned behavior

Fixes #317

## Test Plan

- [x] `go test ./internal/update ./cmd/detent`
- [x] `make check`