### PR TITLE
feat(config): resolve runtime settings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,8 +36,9 @@ Detent logs with `log/slog`.
 
 - `ENV=dev`, `development`, or `local` enables tint text logs.
 - `ENV=prod` or any other non-development value keeps JSON logs.
-- When `ENV` is unset, interactive stdout TTY runs use tint text logs; non-TTY runs use JSON logs.
+- When no environment is configured, Detent defaults to `prod`.
 - `LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- `--env` and `--log-level` override environment variables for one run.
 - `DETENT_ENV` and `DETENT_LOG_LEVEL` remain deprecated fallbacks for one release. The unprefixed names win when both are set.
 - Text logs are written to stdout; JSON logs are written to stderr.
 

--- a/README.md
+++ b/README.md
@@ -199,7 +199,6 @@ local repository checkout.
 
 ```sh
 gh auth login --scopes "repo,read:org,project"
-export GITHUB_TOKEN="$(gh auth token)"
 ```
 
 2. Find the GitHub ProjectV2 node id. Use the `id` field, which starts with
@@ -222,7 +221,6 @@ after the required Detent states.
 ---
 tracker:
   kind: github
-  api_key: $GITHUB_TOKEN
   project_slug: PVT_replace_with_project_id
   http_max_idle_conns: 100
   http_max_idle_conns_per_host: 32
@@ -352,6 +350,15 @@ detent add-project \
   --workdir /absolute/path/to/project-checkout
 ```
 
+Edit the resolved `global.yaml` and set the top-level runtime keys:
+
+```yaml
+env: prod
+log_level: info
+github_token: gh
+port: 4000
+```
+
 5. Verify the setup before dispatching:
 
    ```sh
@@ -360,8 +367,8 @@ detent add-project \
 
 `detent doctor` is a preflight check: config resolution, the SQLite database,
 the `codex` binary, the GitHub token and scopes, the git binary, and whether the
-server port is free. Fix any `FAIL` before starting (a missing `GITHUB_TOKEN` or
-an unauthenticated `codex` are the usual culprits).
+server port is free. Fix any `FAIL` before starting (missing `github_token: gh`
+or an unauthenticated `codex` are the usual culprits).
 
 6. Start Detent:
 
@@ -393,10 +400,10 @@ repo is a real, working instance of this setup to copy from.
 
    ```sh
    gh auth login --scopes "repo,read:org,project"
-   export GITHUB_TOKEN="$(gh auth token)"
    ```
 
-   Verify: `gh auth status`.
+   Verify: `gh auth status`. Use `github_token: gh` in `global.yaml` so
+   Detent resolves this token at startup.
 
 3. **Install and sign in to the Codex CLI.** Install the
    [OpenAI Codex CLI](https://github.com/openai/codex) and sign in. Detent
@@ -441,6 +448,9 @@ repo is a real, working instance of this setup to copy from.
      --workflow <source-root>/WORKFLOW.md \
      --workdir <source-root>
    ```
+
+   Edit the resolved `global.yaml` and set `github_token: gh` with any desired
+   `env`, `log_level`, and `port` overrides.
 
 8. **Verify everything:**
 
@@ -558,6 +568,10 @@ A minimal global config looks like this:
 ```yaml
 apiVersion: detent/v1
 kind: GlobalConfig
+env: prod
+log_level: info
+github_token: gh
+port: 4000
 global:
   max_concurrent_agents: 8
   scheduling: weighted
@@ -831,9 +845,9 @@ Detent logs with `log/slog`.
 
 - `ENV=dev`, `development`, or `local` enables tint text logs.
 - `ENV=prod` or any other non-development value keeps JSON logs.
-- When `ENV` is unset, interactive stdout TTY runs use tint text logs;
-  non-TTY runs use JSON logs.
+- When no environment is configured, Detent defaults to `prod`.
 - `LOG_LEVEL` accepts `debug`, `info`, `warn`, `warning`, and `error`.
+- `--env` and `--log-level` override environment variables for one run.
 - `DETENT_ENV` and `DETENT_LOG_LEVEL` remain deprecated fallbacks for one release. The unprefixed names win when both are set.
 - Text logs are written to stdout; JSON logs are written to stderr.
 
@@ -854,6 +868,26 @@ At startup, Detent resolves `global.yaml` in this order. The first matching rule
 `DETENT_CONFIG` and `DETENT_HOME` remain deprecated fallbacks for one release. Detent uses `CONFIG_HOME` instead of `HOME` because `HOME` is standard process state, not Detent configuration.
 
 If no global config is found, Detent keeps the single-project fallback and looks for `WORKFLOW.md` in the current working directory. Use `detent config path` to print the resolved config path and the rule that selected it.
+
+Runtime settings resolve in this order: explicit flag, environment variable,
+`global.yaml`, then built-in default.
+
+| Setting | Flag | Environment | `global.yaml` key | Default |
+| --- | --- | --- | --- | --- |
+| Environment | `--env` | `ENV`, then `DETENT_ENV` | `env` | `prod` |
+| Log level | `--log-level` | `LOG_LEVEL`, then `DETENT_LOG_LEVEL` | `log_level` | `info` |
+| GitHub token | | `GITHUB_TOKEN` | `github_token` | required for GitHub projects |
+| Web port | `--port` | `PORT` | `port` | `4000` |
+
+Use `github_token: gh` in `global.yaml` to resolve the token from
+`gh auth token` at startup. Literal token values also work but should not be
+committed. `github_token: gh-auth`, `${gh auth token}`, and
+`$(gh auth token)` are accepted aliases. If neither `GITHUB_TOKEN` nor
+`github_token` is set, Detent falls back to existing per-workflow
+`tracker.api_key` handling.
+
+`detent doctor` prints the resolved runtime values and their sources, with the
+GitHub token redacted.
 
 ## History
 

--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -34,7 +34,11 @@ func main() {
 
 func newRootCommand(ctx context.Context) *cobra.Command {
 	build := currentBuildInfo()
-	cmd := cli.NewRootCommand(ctx, cli.WithVersion(build.Version), cli.WithBuild(build))
+	cmd := cli.NewRootCommand(ctx,
+		cli.WithVersion(build.Version),
+		cli.WithBuild(build),
+		cli.WithLoggerFunc(setupLoggerFromRuntime),
+	)
 	cmd.Version = build.Version
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.AddCommand(

--- a/cmd/detent/slog.go
+++ b/cmd/detent/slog.go
@@ -8,11 +8,17 @@ import (
 	"time"
 
 	"github.com/lmittmann/tint"
+
+	"github.com/digitaldrywood/detent/internal/cli"
 )
 
 func setupLoggerFromEnv(stdout io.Writer, stderr io.Writer) *slog.Logger {
 	env, envSet := envValueWithPresence("ENV", "DETENT_ENV")
 	return setupLoggerWithOutputs(env, envSet, envValue("LOG_LEVEL", "DETENT_LOG_LEVEL"), stdout, stderr, writerIsTTY(stdout))
+}
+
+func setupLoggerFromRuntime(settings cli.RuntimeSettings, stdout io.Writer, stderr io.Writer, stdoutTTY bool) {
+	setupLoggerWithOutputs(settings.Env.Value, strings.TrimSpace(settings.Env.Value) != "", settings.LogLevel.Value, stdout, stderr, stdoutTTY)
 }
 
 func setupLogger(env string, level string, w io.Writer) *slog.Logger {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -187,7 +187,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	projectFactory := withRunnerFactory(project.Dependencies{
 		Events:      events,
 		Logger:      logger,
-		GitHubToken: cfg.Runtime.GitHubToken.Value,
+		GitHubToken: runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken),
 	}, runtimeStore, nil)
 	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg.Global), project.ManagerDependencies{
 		ProjectFactory: projectFactory,

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -184,11 +184,12 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}()
 
 	events := hub.New[project.Event]()
+	runtimeGitHubToken := newRuntimeGitHubTokenState(runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken))
 	projectFactory := withRunnerFactory(project.Dependencies{
 		Events:      events,
 		Logger:      logger,
-		GitHubToken: runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken),
-	}, runtimeStore, nil)
+		GitHubToken: runtimeGitHubToken.get(),
+	}, runtimeStore, nil, runtimeGitHubToken.get)
 	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg.Global), project.ManagerDependencies{
 		ProjectFactory: projectFactory,
 		Events:         events,
@@ -200,7 +201,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err := manager.Start(runCtx); err != nil {
 		return err
 	}
-	globalWatcherDone := startGlobalConfigWatcher(runCtx, cfg.Global, manager, logger)
+	globalWatcherDone := startGlobalConfigWatcher(runCtx, cfg.Global, manager, logger, runtimeGitHubToken)
 	defer func() {
 		stop()
 		waitGlobalConfigWatcher(globalWatcherDone)

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -38,11 +38,7 @@ const (
 	projectURL          = "https://github.com/digitaldrywood/detent"
 )
 
-func resolveBootConfig(configPath string, host string, port int, opts options) (BootConfig, error) {
-	if port < -1 {
-		return BootConfig{}, errors.New("port must be greater than or equal to 0")
-	}
-
+func resolveBootConfig(ctx context.Context, configPath string, host string, flags runtimeFlags, opts options) (BootConfig, error) {
 	resolution, err := resolveConfigPathResolution(configPath, opts)
 	if err != nil {
 		return BootConfig{}, err
@@ -51,13 +47,24 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 
 	cfg, err := opts.read(path)
 	if err == nil {
-		host, port := bootServer(host, port, firstGlobalWorkflowPath(cfg))
+		workflowPath := firstGlobalWorkflowPath(cfg)
+		runtime, err := resolveRuntimeSettings(ctx, runtimeInput{
+			Config:     &cfg,
+			ConfigPath: resolution,
+			Workflow:   workflowPath,
+			Flags:      flags,
+		}, runtimeDepsFromOptions(opts))
+		if err != nil {
+			return BootConfig{}, err
+		}
+		resolvedPort := runtime.Port.Value
 		return BootConfig{
 			Mode:           BootModeRunning,
 			Global:         cfg,
 			ConfigPathRule: resolution.Rule,
-			Host:           host,
-			Port:           port,
+			Runtime:        runtime,
+			Host:           bootHost(host, workflowPath),
+			Port:           &resolvedPort,
 			Version:        opts.version,
 			Build:          opts.build,
 		}, nil
@@ -72,14 +79,24 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 		if err != nil {
 			return BootConfig{}, err
 		}
-		host, port := bootServer(host, port, workflowPath)
+		runtime, err := resolveRuntimeSettings(ctx, runtimeInput{
+			Config:     &cfg,
+			ConfigPath: resolution,
+			Workflow:   workflowPath,
+			Flags:      flags,
+		}, runtimeDepsFromOptions(opts))
+		if err != nil {
+			return BootConfig{}, err
+		}
+		resolvedPort := runtime.Port.Value
 		return BootConfig{
 			Mode:           BootModeRunning,
 			Global:         cfg,
 			ConfigPathRule: resolution.Rule,
+			Runtime:        runtime,
 			WorkflowPath:   workflowPath,
-			Host:           host,
-			Port:           port,
+			Host:           bootHost(host, workflowPath),
+			Port:           &resolvedPort,
 			Version:        opts.version,
 			Build:          opts.build,
 		}, nil
@@ -89,13 +106,24 @@ func resolveBootConfig(configPath string, host string, port int, opts options) (
 	if err != nil {
 		return BootConfig{}, err
 	}
+	runtime, err := resolveRuntimeSettings(ctx, runtimeInput{
+		Config:     &cfg,
+		ConfigPath: resolution,
+		Workflow:   workflowPath,
+		Flags:      flags,
+	}, runtimeDepsFromOptions(opts))
+	if err != nil {
+		return BootConfig{}, err
+	}
+	resolvedPort := runtime.Port.Value
 	return BootConfig{
 		Mode:           BootModeOnboarding,
 		Global:         cfg,
 		ConfigPathRule: resolution.Rule,
+		Runtime:        runtime,
 		WorkflowPath:   workflowPath,
 		Host:           strings.TrimSpace(host),
-		Port:           bootPort(port),
+		Port:           &resolvedPort,
 		Version:        opts.version,
 		Build:          opts.build,
 	}, nil
@@ -123,7 +151,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 
 	useDashboard := shouldLaunchTerminalDashboard(cfg)
 	if useDashboard {
-		restoreLogger, err := redirectDefaultLogger(runtimeLogPath(cfg))
+		restoreLogger, err := redirectDefaultLogger(runtimeLogPath(cfg), cfg.Runtime.LogLevel.Value)
 		if err != nil {
 			return err
 		}
@@ -157,8 +185,9 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 
 	events := hub.New[project.Event]()
 	projectFactory := withRunnerFactory(project.Dependencies{
-		Events: events,
-		Logger: logger,
+		Events:      events,
+		Logger:      logger,
+		GitHubToken: cfg.Runtime.GitHubToken.Value,
 	}, runtimeStore, nil)
 	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg.Global), project.ManagerDependencies{
 		ProjectFactory: projectFactory,
@@ -339,7 +368,7 @@ func shouldLaunchTerminalDashboard(cfg BootConfig) bool {
 	return cfg.Mode == BootModeRunning && cfg.StdoutTTY && !cfg.Headless
 }
 
-func redirectDefaultLogger(path string) (func(), error) {
+func redirectDefaultLogger(path string, level string) (func(), error) {
 	if strings.TrimSpace(path) == "" {
 		return nil, errors.New("log path is required")
 	}
@@ -354,7 +383,7 @@ func redirectDefaultLogger(path string) (func(), error) {
 
 	previous := slog.Default()
 	slog.SetDefault(slog.New(slog.NewJSONHandler(file, &slog.HandlerOptions{
-		Level: logLevelFromEnv(),
+		Level: parseSlogLevel(level),
 	})))
 
 	return func() {
@@ -419,15 +448,6 @@ func runtimeStorePath(cfg BootConfig) string {
 
 func runtimeLogPath(cfg BootConfig) string {
 	return filepath.Join(filepath.Dir(runtimeStorePath(cfg)), "detent.log")
-}
-
-func logLevelFromEnv() slog.Level {
-	for _, key := range []string{"LOG_LEVEL", "DETENT_LOG_LEVEL"} {
-		if level, ok := os.LookupEnv(key); ok && strings.TrimSpace(level) != "" {
-			return parseSlogLevel(level)
-		}
-	}
-	return slog.LevelInfo
 }
 
 func parseSlogLevel(level string) slog.Level {
@@ -537,26 +557,21 @@ func firstGlobalWorkflowPath(cfg globalconfig.Config) string {
 	return cfg.Projects[0].Workflow
 }
 
-func bootServer(host string, port int, workflowPath string) (string, *int) {
+func bootHost(host string, workflowPath string) string {
 	resolvedHost := strings.TrimSpace(host)
-	resolvedPort := bootPort(port)
+	if resolvedHost != "" {
+		return resolvedHost
+	}
 
 	workflowPath = strings.TrimSpace(workflowPath)
-	if workflowPath == "" || (resolvedHost != "" && resolvedPort != nil) {
-		return resolvedHost, resolvedPort
+	if workflowPath == "" {
+		return ""
 	}
-
 	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
-	if err != nil || workflow.Config.Validate() != nil {
-		return resolvedHost, resolvedPort
+	if err != nil {
+		return ""
 	}
-	if resolvedHost == "" {
-		resolvedHost = strings.TrimSpace(workflow.Config.Server.Host)
-	}
-	if resolvedPort == nil {
-		resolvedPort = workflow.Config.Server.Port
-	}
-	return resolvedHost, resolvedPort
+	return strings.TrimSpace(workflow.Config.Server.Host)
 }
 
 func bootPort(port int) *int {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -190,7 +190,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		Logger:      logger,
 		GitHubToken: runtimeGitHubToken.get(),
 	}, runtimeStore, nil, runtimeGitHubToken.get)
-	manager, err := project.NewManager(project.ManagerConfigFromGlobal(cfg.Global), project.ManagerDependencies{
+	manager, err := project.NewManager(managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get()), project.ManagerDependencies{
 		ProjectFactory: projectFactory,
 		Events:         events,
 		Logger:         logger,

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -68,7 +68,7 @@ func TestRedirectDefaultLoggerWritesToFile(t *testing.T) {
 	})
 
 	path := filepath.Join(t.TempDir(), "runtime", "detent.log")
-	restore, err := redirectDefaultLogger(path)
+	restore, err := redirectDefaultLogger(path, "info")
 	if err != nil {
 		t.Fatalf("redirectDefaultLogger() error = %v", err)
 	}
@@ -88,24 +88,6 @@ func TestRedirectDefaultLoggerWritesToFile(t *testing.T) {
 	}
 	if slog.Default() != previous {
 		t.Fatal("default logger was not restored")
-	}
-}
-
-func TestLogLevelFromEnvUsesUnprefixedBeforeDeprecatedPrefixed(t *testing.T) {
-	t.Setenv("LOG_LEVEL", "debug")
-	t.Setenv("DETENT_LOG_LEVEL", "error")
-
-	if got := logLevelFromEnv(); got != slog.LevelDebug {
-		t.Fatalf("logLevelFromEnv() = %v, want %v", got, slog.LevelDebug)
-	}
-}
-
-func TestLogLevelFromEnvFallsBackToDeprecatedPrefixed(t *testing.T) {
-	t.Setenv("LOG_LEVEL", "")
-	t.Setenv("DETENT_LOG_LEVEL", "warn")
-
-	if got := logLevelFromEnv(); got != slog.LevelWarn {
-		t.Fatalf("logLevelFromEnv() = %v, want %v", got, slog.LevelWarn)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -50,6 +50,7 @@ type BootConfig struct {
 	Mode           BootMode
 	Global         globalconfig.Config
 	ConfigPathRule globalconfig.PathRule
+	Runtime        RuntimeSettings
 	WorkflowPath   string
 	Host           string
 	Port           *int
@@ -63,6 +64,8 @@ type BootConfig struct {
 type BootFunc func(context.Context, BootConfig) error
 
 type SignalFunc func(context.Context, Signal) error
+
+type LoggerFunc func(RuntimeSettings, io.Writer, io.Writer, bool)
 
 type ProjectManager interface {
 	Add(context.Context, globalconfig.Project) error
@@ -80,6 +83,9 @@ type options struct {
 	write         func(string, globalconfig.Config) error
 	boot          BootFunc
 	signal        SignalFunc
+	lookupEnv     func(string) string
+	ghAuthToken   func(context.Context) (string, error)
+	configureLog  LoggerFunc
 	version       string
 	build         buildinfo.Info
 	stdoutTTY     func() bool
@@ -127,6 +133,12 @@ func WithStdoutTTY(stdoutTTY func() bool) Option {
 	}
 }
 
+func WithLoggerFunc(configure LoggerFunc) Option {
+	return func(opts *options) {
+		opts.configureLog = configure
+	}
+}
+
 func ProjectManagerSignalFunc(manager ProjectManager) SignalFunc {
 	if manager == nil {
 		return noSignal
@@ -158,6 +170,8 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	}
 
 	var configPath string
+	var env string
+	var logLevel string
 	var host string
 	var port int
 	var headless bool
@@ -168,24 +182,38 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			boot, err := resolveBootConfig(configPath, host, port, opts)
+			flags := runtimeFlags{
+				Env:      runtimeStringFlag{Value: env, Set: flagChanged(cmd, "env")},
+				LogLevel: runtimeStringFlag{Value: logLevel, Set: flagChanged(cmd, "log-level")},
+				Port:     runtimeIntFlag{Value: port, Set: flagChanged(cmd, "port")},
+			}
+			boot, err := resolveBootConfig(cmd.Context(), configPath, host, flags, opts)
 			if err != nil {
 				return err
 			}
+			stdoutTTY := opts.stdoutTTY()
+			if opts.configureLog != nil {
+				opts.configureLog(boot.Runtime, cmd.OutOrStdout(), cmd.ErrOrStderr(), stdoutTTY)
+			}
 			boot.Headless = headless
-			boot.StdoutTTY = opts.stdoutTTY()
+			boot.StdoutTTY = stdoutTTY
 			boot.Output = cmd.OutOrStdout()
 			slog.Info("resolved global config", "path", boot.Global.Path, "rule", boot.ConfigPathRule)
+			for _, warning := range boot.Runtime.Warnings {
+				slog.Warn(warning.Detail, "check", warning.Name, "hint", warning.Hint)
+			}
 			return opts.boot(cmd.Context(), boot)
 		},
 	}
 	cmd.SetContext(ctx)
 	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to global.yaml")
+	cmd.PersistentFlags().StringVar(&env, "env", "", "runtime environment")
+	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "log level")
 	cmd.PersistentFlags().StringVar(&host, "host", "", "web server host")
 	cmd.PersistentFlags().IntVar(&port, "port", -1, "web server port, or 0 for an ephemeral port")
 	cmd.PersistentFlags().BoolVar(&headless, "headless", false, "stream logs instead of launching the terminal dashboard")
 	cmd.AddCommand(
-		newDoctorCommand(&configPath, &host, &port, opts),
+		newDoctorCommand(&configPath, &env, &logLevel, &host, &port, opts),
 		newInitCommand(&configPath, opts),
 		newAddProjectCommand(&configPath, opts),
 		newEditProjectCommand(&configPath, opts, OperationPauseProject, "pause", "Pause a project", func(project *globalconfig.Project) error {
@@ -216,10 +244,20 @@ func defaultOptions() options {
 		write: func(path string, cfg globalconfig.Config) error {
 			return globalconfig.Write(path, cfg, globalconfig.WithProjectPathLiterals())
 		},
-		boot:      defaultBoot,
-		signal:    noSignal,
-		stdoutTTY: stdoutIsTTY,
+		boot:        defaultBoot,
+		signal:      noSignal,
+		lookupEnv:   os.Getenv,
+		ghAuthToken: defaultGHAuthToken,
+		stdoutTTY:   stdoutIsTTY,
 	}
+}
+
+func flagChanged(cmd *cobra.Command, name string) bool {
+	flag := cmd.Flags().Lookup(name)
+	if flag == nil {
+		flag = cmd.InheritedFlags().Lookup(name)
+	}
+	return flag != nil && flag.Changed
 }
 
 func noSignal(context.Context, Signal) error {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -543,12 +543,21 @@ func checkDoctorBinary(ctx context.Context, deps doctorDeps, binary string, name
 
 func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token RuntimeSecret, deps doctorDeps) doctorCheck {
 	hasGitHubProject := doctorHasGitHubProject(cfg, deps)
+	requiresRuntimeToken := doctorRequiresRuntimeGitHubToken(cfg, deps)
 	if cfg != nil && !hasGitHubProject {
 		return doctorCheck{
 			Name:   "GitHub token",
 			Status: doctorWarn,
 			Detail: "no GitHub tracker projects configured; token scope check skipped",
 			Hint:   "Add a GitHub project before relying on GitHub token preflight checks.",
+		}
+	}
+	if token.Value == "" && !requiresRuntimeToken && hasGitHubProject {
+		return doctorCheck{
+			Name:   "GitHub token",
+			Status: doctorWarn,
+			Detail: "GitHub App credentials configured; token scope check skipped",
+			Hint:   "Use GitHub App installation authentication or configure github_token for PAT-based projects.",
 		}
 	}
 	if token.Value == "" {
@@ -596,6 +605,23 @@ func doctorHasGitHubProject(cfg *globalconfig.Config, deps doctorDeps) bool {
 			}
 			return true
 		}
+	}
+	return false
+}
+
+func doctorRequiresRuntimeGitHubToken(cfg *globalconfig.Config, deps doctorDeps) bool {
+	if cfg == nil {
+		return true
+	}
+	for _, project := range cfg.Projects {
+		workflow, err := deps.loadWorkflow(project.Workflow)
+		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+			continue
+		}
+		if trackerHasGitHubAppCredentials(workflow.Config.Tracker) {
+			continue
+		}
+		return true
 	}
 	return false
 }

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -51,7 +51,7 @@ type doctorReport struct {
 type doctorConfig struct {
 	ConfigPath string
 	Host       string
-	Port       int
+	Flags      runtimeFlags
 }
 
 type doctorStore interface {
@@ -64,16 +64,17 @@ type doctorDeps struct {
 	lookPath     func(string) (string, error)
 	runCommand   func(context.Context, string, ...string) error
 	githubScopes func(context.Context, string) ([]string, error)
+	ghAuthToken  func(context.Context) (string, error)
 	listen       func(string, string) (net.Listener, error)
 	openSQLite   func(context.Context, string) (doctorStore, error)
 	gitWorkTree  func(context.Context, string) error
 }
 
-func newDoctorCommand(configPath *string, host *string, port *int, opts options) *cobra.Command {
-	return newDoctorCommandWithDeps(configPath, host, port, opts, doctorDeps{})
+func newDoctorCommand(configPath *string, env *string, logLevel *string, host *string, port *int, opts options) *cobra.Command {
+	return newDoctorCommandWithDeps(configPath, env, logLevel, host, port, opts, doctorDeps{})
 }
 
-func newDoctorCommandWithDeps(configPath *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
+func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
 	return &cobra.Command{
 		Use:   "doctor",
 		Short: "Run preflight health checks",
@@ -82,7 +83,11 @@ func newDoctorCommandWithDeps(configPath *string, host *string, port *int, opts 
 			report := runDoctor(cmd.Context(), doctorConfig{
 				ConfigPath: derefString(configPath),
 				Host:       derefString(host),
-				Port:       derefInt(port, -1),
+				Flags: runtimeFlags{
+					Env:      runtimeStringFlag{Value: derefString(env), Set: flagChanged(cmd, "env")},
+					LogLevel: runtimeStringFlag{Value: derefString(logLevel), Set: flagChanged(cmd, "log-level")},
+					Port:     runtimeIntFlag{Value: derefInt(port, -1), Set: flagChanged(cmd, "port")},
+				},
 			}, opts, deps)
 			if err := writeDoctorReport(cmd.OutOrStdout(), report); err != nil {
 				return err
@@ -106,15 +111,44 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	resolution, global, configCheck := checkDoctorConfig(cfg.ConfigPath, opts)
 	report.Add(configCheck)
 
+	workflowPath := ""
+	if global != nil {
+		workflowPath = firstGlobalWorkflowPath(*global)
+	}
+	runtime, runtimeErr := resolveRuntimeSettings(ctx, runtimeInput{
+		Config:     global,
+		ConfigPath: resolution,
+		Workflow:   workflowPath,
+		Flags:      cfg.Flags,
+	}, runtimeDeps{
+		lookupEnv:    deps.lookupEnv,
+		ghAuthToken:  deps.ghAuthToken,
+		loadWorkflow: deps.loadWorkflow,
+	})
+	if runtimeErr != nil {
+		report.Add(doctorCheck{
+			Name:   "Runtime settings",
+			Status: doctorFail,
+			Detail: runtimeErr.Error(),
+			Hint:   "Fix runtime flags, environment variables, or global.yaml.",
+		})
+	} else {
+		report.Add(checkDoctorRuntimeSettings(runtime))
+	}
+
 	boot := BootConfig{
 		Host: strings.TrimSpace(cfg.Host),
-		Port: bootPort(cfg.Port),
+		Port: bootPort(cfg.Flags.Port.Value),
+	}
+	if runtimeErr == nil {
+		port := runtime.Port.Value
+		boot.Port = &port
 	}
 	if global != nil {
 		boot.Global = *global
-		boot.Host, boot.Port = bootServer(cfg.Host, cfg.Port, firstGlobalWorkflowPath(*global))
+		boot.Host = bootHost(cfg.Host, firstGlobalWorkflowPath(*global))
 		report.Add(checkDoctorInstanceIdentity(*global))
-		report.Checks = append(report.Checks, checkDoctorProjects(ctx, *global, deps)...)
+		report.Checks = append(report.Checks, checkDoctorProjects(ctx, *global, deps, runtime.GitHubToken.Value)...)
 	} else {
 		report.Add(doctorCheck{
 			Name:   "Project workflows",
@@ -126,7 +160,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 
 	report.Add(checkDoctorSQLite(ctx, resolution, deps))
 	report.Add(checkDoctorCodex(ctx, deps))
-	report.Add(checkDoctorGitHub(ctx, global, deps))
+	report.Add(checkDoctorGitHub(ctx, global, runtime.GitHubToken, deps))
 	report.Add(checkDoctorServerPort(boot, deps))
 	report.Add(checkDoctorGit(ctx, deps))
 
@@ -226,7 +260,24 @@ func checkDoctorConfig(configPath string, opts options) (globalconfig.PathResolu
 	}
 }
 
-func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps) []doctorCheck {
+func checkDoctorRuntimeSettings(settings RuntimeSettings) doctorCheck {
+	check := doctorCheck{
+		Name:   "Runtime settings",
+		Status: doctorOK,
+		Detail: runtimeSettingsDetail(settings),
+	}
+	if len(settings.Warnings) == 0 {
+		return check
+	}
+
+	check.Status = doctorWarn
+	warning := settings.Warnings[0]
+	check.Detail = check.Detail + "; " + warning.Detail
+	check.Hint = warning.Hint
+	return check
+}
+
+func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps, githubToken string) []doctorCheck {
 	if len(cfg.Projects) == 0 {
 		return []doctorCheck{
 			{
@@ -260,6 +311,7 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 			})
 			continue
 		}
+		workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, githubToken)
 		if err := workflow.Config.Validate(); err != nil {
 			checks = append(checks, doctorCheck{
 				Name:   "Project " + id + " workflow",
@@ -319,6 +371,14 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	}
 
 	return checks
+}
+
+func doctorWorkflowConfigWithRuntimeGitHubToken(cfg workflowconfig.Config, token string) workflowconfig.Config {
+	token = strings.TrimSpace(token)
+	if token != "" && cfg.Tracker.Kind == workflowconfig.TrackerGitHub {
+		cfg.Tracker.APIKey = token
+	}
+	return cfg
 }
 
 func checkDoctorInstanceIdentity(cfg globalconfig.Config) doctorCheck {
@@ -481,8 +541,8 @@ func checkDoctorBinary(ctx context.Context, deps doctorDeps, binary string, name
 	}
 }
 
-func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps) doctorCheck {
-	token, source, hasGitHubProject := doctorGitHubToken(cfg, deps)
+func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token RuntimeSecret, deps doctorDeps) doctorCheck {
+	hasGitHubProject := doctorHasGitHubProject(cfg, deps)
 	if cfg != nil && !hasGitHubProject {
 		return doctorCheck{
 			Name:   "GitHub token",
@@ -491,16 +551,17 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, deps docto
 			Hint:   "Add a GitHub project before relying on GitHub token preflight checks.",
 		}
 	}
-	if token == "" {
+	if token.Value == "" {
 		return doctorCheck{
 			Name:   "GitHub token",
 			Status: doctorFail,
-			Detail: "GITHUB_TOKEN is not set and no usable tracker.api_key was found",
-			Hint:   `Run gh auth login --scopes "repo,read:org,project" and export GITHUB_TOKEN="$(gh auth token)".`,
+			Detail: "GITHUB_TOKEN is not set, github_token is not configured, and no usable tracker.api_key was found",
+			Hint:   githubAuthHint,
 		}
 	}
 
-	scopes, err := deps.githubScopes(ctx, token)
+	source := doctorGitHubTokenSource(token)
+	scopes, err := deps.githubScopes(ctx, token.Value)
 	if err != nil {
 		return doctorCheck{
 			Name:   "GitHub token",
@@ -515,7 +576,7 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, deps docto
 			Name:   "GitHub token",
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s missing scope(s): %s", source, strings.Join(missing, ", ")),
-			Hint:   `Run gh auth login --scopes "repo,read:org,project" and export GITHUB_TOKEN="$(gh auth token)".`,
+			Hint:   githubAuthHint,
 		}
 	}
 
@@ -526,43 +587,27 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, deps docto
 	}
 }
 
-func doctorGitHubToken(cfg *globalconfig.Config, deps doctorDeps) (string, string, bool) {
-	hasGitHubProject := false
+func doctorHasGitHubProject(cfg *globalconfig.Config, deps doctorDeps) bool {
 	if cfg != nil {
 		for _, project := range cfg.Projects {
 			workflow, err := deps.loadWorkflow(project.Workflow)
 			if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 				continue
 			}
-			hasGitHubProject = true
-			if token, source := resolveDoctorSecret(workflow.Config.Tracker.APIKey, deps.lookupEnv); token != "" {
-				if source == "" {
-					source = "tracker.api_key"
-				}
-				return token, source, true
-			}
+			return true
 		}
 	}
-	if cfg == nil || hasGitHubProject {
-		if token := strings.TrimSpace(deps.lookupEnv("GITHUB_TOKEN")); token != "" {
-			return token, "GITHUB_TOKEN", hasGitHubProject
-		}
-	}
-	return "", "", hasGitHubProject
+	return false
 }
 
-func resolveDoctorSecret(value string, lookupEnv func(string) string) (string, string) {
-	value = strings.TrimSpace(value)
-	if value == "" {
-		return "", ""
+func doctorGitHubTokenSource(token RuntimeSecret) string {
+	if token.ResolvedVia == "gh" {
+		return "github_token resolved via gh"
 	}
-	if strings.HasPrefix(value, "$") {
-		name := strings.TrimPrefix(value, "$")
-		if validEnvName(name) {
-			return strings.TrimSpace(lookupEnv(name)), name
-		}
+	if source := strings.TrimSpace(token.Source); source != "" {
+		return source
 	}
-	return value, "tracker.api_key"
+	return "github_token"
 }
 
 func validEnvName(name string) bool {
@@ -661,6 +706,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.githubScopes == nil {
 		d.githubScopes = defaults.githubScopes
 	}
+	if d.ghAuthToken == nil {
+		d.ghAuthToken = defaults.ghAuthToken
+	}
 	if d.listen == nil {
 		d.listen = defaults.listen
 	}
@@ -680,6 +728,7 @@ func defaultDoctorDeps() doctorDeps {
 		lookPath:     exec.LookPath,
 		runCommand:   runDoctorCommand,
 		githubScopes: defaultGitHubScopes,
+		ghAuthToken:  defaultGHAuthToken,
 		listen:       net.Listen,
 		openSQLite:   openDoctorSQLite,
 		gitWorkTree:  defaultGitWorkTree,

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -148,7 +148,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		boot.Global = *global
 		boot.Host = bootHost(cfg.Host, firstGlobalWorkflowPath(*global))
 		report.Add(checkDoctorInstanceIdentity(*global))
-		report.Checks = append(report.Checks, checkDoctorProjects(ctx, *global, deps, runtime.GitHubToken.Value)...)
+		report.Checks = append(report.Checks, checkDoctorProjects(ctx, *global, deps, runtimeGlobalGitHubToken(runtime.GitHubToken))...)
 	} else {
 		report.Add(doctorCheck{
 			Name:   "Project workflows",

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -618,7 +618,7 @@ func doctorRequiresRuntimeGitHubToken(cfg *globalconfig.Config, deps doctorDeps)
 		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 			continue
 		}
-		if trackerHasGitHubAppCredentials(workflow.Config.Tracker) {
+		if trackerHasGitHubAppCredentials(workflow.Config.Tracker, deps.lookupEnv) {
 			continue
 		}
 		return true

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -145,7 +145,7 @@ func TestCheckDoctorProjects(t *testing.T) {
 				gitWorkTree: func(context.Context, string) error {
 					return tt.gitErr
 				},
-			})
+			}, "")
 			if len(got) != len(tt.wantStatus) {
 				t.Fatalf("len(checks) = %d, want %d: %#v", len(got), len(tt.wantStatus), got)
 			}
@@ -273,7 +273,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 			gotPath = path
 			return nil
 		},
-	})
+	}, "")
 
 	wantPath := filepath.Join(home, "repo")
 	if gotPath != wantPath {
@@ -281,6 +281,36 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	}
 	if len(checks) != 2 || checks[1].Status != doctorOK {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
+	}
+}
+
+func TestCheckDoctorRuntimeSettingsReportsSources(t *testing.T) {
+	t.Parallel()
+
+	got := checkDoctorRuntimeSettings(RuntimeSettings{
+		ConfigPath:  RuntimeValue{Value: "/tmp/global.yaml", Source: string(globalconfig.PathRuleFlag)},
+		Env:         RuntimeValue{Value: "prod", Source: runtimeSourceDefault},
+		LogLevel:    RuntimeValue{Value: "debug", Source: "LOG_LEVEL"},
+		Port:        RuntimeIntValue{Value: 4000, Source: runtimeSourceConfig},
+		GitHubToken: RuntimeSecret{Value: "secret-token", Source: "github_token", ResolvedVia: "gh"},
+	})
+
+	if got.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s", got.Status, doctorOK)
+	}
+	for _, want := range []string{
+		"config_path=/tmp/global.yaml (--config)",
+		"env=prod (default)",
+		"log_level=debug (LOG_LEVEL)",
+		"port=4000 (config)",
+		"github_token=resolved via gh",
+	} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail missing %q:\n%s", want, got.Detail)
+		}
+	}
+	if strings.Contains(got.Detail, "secret-token") {
+		t.Fatalf("Detail leaked token: %s", got.Detail)
 	}
 }
 
@@ -294,7 +324,7 @@ func TestCheckDoctorGitHub(t *testing.T) {
 	tests := []struct {
 		name       string
 		cfg        *globalconfig.Config
-		env        map[string]string
+		token      RuntimeSecret
 		scopes     []string
 		scopeErr   error
 		workflow   workflowconfig.Config
@@ -308,14 +338,14 @@ func TestCheckDoctorGitHub(t *testing.T) {
 		},
 		{
 			name:       "scope check fails",
-			env:        map[string]string{"GITHUB_TOKEN": "token"},
+			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
 			scopeErr:   errors.New("unauthorized"),
 			want:       doctorFail,
 			wantDetail: "scope check failed",
 		},
 		{
 			name:       "missing required scope",
-			env:        map[string]string{"GITHUB_TOKEN": "token"},
+			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
 			scopes:     []string{"repo"},
 			want:       doctorFail,
 			wantDetail: "read:org",
@@ -334,17 +364,24 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			}},
-			env:        map[string]string{"PROJECT_TOKEN": "token"},
+			token:      RuntimeSecret{Value: "token", Source: "PROJECT_TOKEN"},
 			scopes:     []string{"project", "read:org", "repo"},
 			want:       doctorOK,
 			wantDetail: "PROJECT_TOKEN has required scopes",
 		},
 		{
 			name:       "environment token has required scopes",
-			env:        map[string]string{"GITHUB_TOKEN": "token"},
+			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
 			scopes:     []string{"workflow", "project", "read:org", "repo"},
 			want:       doctorOK,
 			wantDetail: "GITHUB_TOKEN has required scopes",
+		},
+		{
+			name:       "gh sentinel token has required scopes",
+			token:      RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"},
+			scopes:     []string{"project", "read:org", "repo"},
+			want:       doctorOK,
+			wantDetail: "github_token resolved via gh has required scopes",
 		},
 	}
 
@@ -356,12 +393,9 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			if tt.workflow.Tracker.Kind != "" {
 				workflow = tt.workflow
 			}
-			got := checkDoctorGitHub(context.Background(), tt.cfg, doctorDeps{
+			got := checkDoctorGitHub(context.Background(), tt.cfg, tt.token, doctorDeps{
 				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
 					return workflowconfig.Workflow{Config: workflow}, nil
-				},
-				lookupEnv: func(key string) string {
-					return tt.env[key]
 				},
 				githubScopes: func(context.Context, string) ([]string, error) {
 					return tt.scopes, tt.scopeErr
@@ -562,6 +596,8 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 			t.Parallel()
 
 			configPath := filepath.Join(t.TempDir(), "global.yaml")
+			env := ""
+			logLevel := ""
 			host := "127.0.0.1"
 			port := 0
 			opts := successfulDoctorOptions(configPath)
@@ -573,7 +609,7 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 				deps.lookPath = tt.deps.lookPath
 			}
 
-			cmd := newDoctorCommandWithDeps(&configPath, &host, &port, opts, deps)
+			cmd := newDoctorCommandWithDeps(&configPath, &env, &logLevel, &host, &port, opts, deps)
 			var stdout bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&bytes.Buffer{})

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -360,6 +360,15 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			wantDetail: "token scope check skipped",
 		},
 		{
+			name: "github app projects skip token scopes",
+			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			}},
+			workflow:   githubAppWorkflow(),
+			want:       doctorWarn,
+			wantDetail: "GitHub App credentials configured",
+		},
+		{
 			name: "workflow token has required scopes",
 			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
 				{ID: "alpha", Workflow: "WORKFLOW.md"},

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -328,6 +328,7 @@ func TestCheckDoctorGitHub(t *testing.T) {
 		scopes     []string
 		scopeErr   error
 		workflow   workflowconfig.Config
+		env        map[string]string
 		want       doctorStatus
 		wantDetail string
 	}{
@@ -364,9 +365,23 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			}},
-			workflow:   githubAppWorkflow(),
+			workflow: githubAppWorkflow(),
+			env: map[string]string{
+				"APP_ID":           "12345",
+				"INSTALLATION_ID":  "67890",
+				"PRIVATE_KEY_PATH": ".detent/github-app.pem",
+			},
 			want:       doctorWarn,
 			wantDetail: "GitHub App credentials configured",
+		},
+		{
+			name: "github app env refs missing require token",
+			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			}},
+			workflow:   githubAppWorkflow(),
+			want:       doctorFail,
+			wantDetail: "GITHUB_TOKEN is not set",
 		},
 		{
 			name: "workflow token has required scopes",
@@ -403,6 +418,7 @@ func TestCheckDoctorGitHub(t *testing.T) {
 				workflow = tt.workflow
 			}
 			got := checkDoctorGitHub(context.Background(), tt.cfg, tt.token, doctorDeps{
+				lookupEnv: mapLookup(tt.env),
 				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
 					return workflowconfig.Workflow{Config: workflow}, nil
 				},

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -19,9 +19,11 @@ type globalConfigManager interface {
 }
 
 type globalConfigReloader struct {
-	current globalconfig.Config
-	manager globalConfigManager
-	logger  *slog.Logger
+	current            globalconfig.Config
+	manager            globalConfigManager
+	logger             *slog.Logger
+	githubToken        *runtimeGitHubTokenState
+	resolveGitHubToken func(context.Context, globalconfig.Config) (string, error)
 }
 
 func startGlobalConfigWatcher(
@@ -29,6 +31,7 @@ func startGlobalConfigWatcher(
 	current globalconfig.Config,
 	manager globalConfigManager,
 	logger *slog.Logger,
+	githubToken *runtimeGitHubTokenState,
 ) <-chan struct{} {
 	if ctx == nil {
 		ctx = context.Background()
@@ -56,9 +59,10 @@ func startGlobalConfigWatcher(
 
 	done := make(chan struct{})
 	reloader := &globalConfigReloader{
-		current: current,
-		manager: manager,
-		logger:  logger,
+		current:     current,
+		manager:     manager,
+		logger:      logger,
+		githubToken: githubToken,
 	}
 	go func() {
 		defer close(done)
@@ -121,13 +125,42 @@ func (r *globalConfigReloader) apply(
 		return project.ReconcileResult{}, errMissingGlobalConfigManager
 	}
 
+	previousGitHubToken := ""
+	if r.githubToken != nil {
+		nextGitHubToken, err := r.runtimeGitHubToken(ctx, update.Value)
+		if err != nil {
+			return project.ReconcileResult{}, err
+		}
+		previousGitHubToken = r.githubToken.get()
+		r.githubToken.set(nextGitHubToken)
+	}
+
 	result, err := r.manager.Reconcile(ctx, project.ManagerConfigFromGlobal(update.Value))
 	if err != nil {
+		if r.githubToken != nil {
+			r.githubToken.set(previousGitHubToken)
+		}
 		return result, err
 	}
 
 	r.current = update.Value
 	return result, nil
+}
+
+func (r *globalConfigReloader) runtimeGitHubToken(ctx context.Context, cfg globalconfig.Config) (string, error) {
+	if r.resolveGitHubToken != nil {
+		return r.resolveGitHubToken(ctx, cfg)
+	}
+	return resolveGlobalRuntimeGitHubToken(ctx, cfg)
+}
+
+func resolveGlobalRuntimeGitHubToken(ctx context.Context, cfg globalconfig.Config) (string, error) {
+	deps := runtimeDeps{}.withDefaults()
+	token, _, err := resolveRuntimeGitHubToken(ctx, &cfg, deps)
+	if err != nil {
+		return "", err
+	}
+	return runtimeGlobalGitHubToken(token), nil
 }
 
 func logGlobalSettingChanges(logger *slog.Logger, previous globalconfig.Settings, next globalconfig.Settings) {

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -126,16 +126,19 @@ func (r *globalConfigReloader) apply(
 	}
 
 	previousGitHubToken := ""
+	nextGitHubToken := ""
 	if r.githubToken != nil {
-		nextGitHubToken, err := r.runtimeGitHubToken(ctx, update.Value)
+		resolvedGitHubToken, err := r.runtimeGitHubToken(ctx, update.Value)
 		if err != nil {
 			return project.ReconcileResult{}, err
 		}
+		nextGitHubToken = resolvedGitHubToken
 		previousGitHubToken = r.githubToken.get()
 		r.githubToken.set(nextGitHubToken)
 	}
 
-	result, err := r.manager.Reconcile(ctx, project.ManagerConfigFromGlobal(update.Value))
+	managerConfig := managerConfigWithRuntimeGitHubToken(update.Value, nextGitHubToken)
+	result, err := r.manager.Reconcile(ctx, managerConfig)
 	if err != nil {
 		if r.githubToken != nil {
 			r.githubToken.set(previousGitHubToken)
@@ -161,6 +164,12 @@ func resolveGlobalRuntimeGitHubToken(ctx context.Context, cfg globalconfig.Confi
 		return "", err
 	}
 	return runtimeGlobalGitHubToken(token), nil
+}
+
+func managerConfigWithRuntimeGitHubToken(cfg globalconfig.Config, token string) project.ManagerConfig {
+	managerConfig := project.ManagerConfigFromGlobal(cfg)
+	managerConfig.RuntimeCredentialVersion = runtimeGitHubTokenVersion(token)
+	return managerConfig
 }
 
 func logGlobalSettingChanges(logger *slog.Logger, previous globalconfig.Settings, next globalconfig.Settings) {

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -97,6 +97,64 @@ func TestGlobalConfigReloaderApply(t *testing.T) {
 	}
 }
 
+func TestGlobalConfigReloaderUpdatesRuntimeGitHubToken(t *testing.T) {
+	t.Parallel()
+
+	current := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+	next := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+	next.GitHubToken = "next-token"
+	token := newRuntimeGitHubTokenState("current-token")
+	manager := &globalReloadManager{}
+	reloader := &globalConfigReloader{
+		current:     current,
+		manager:     manager,
+		githubToken: token,
+		resolveGitHubToken: func(_ context.Context, cfg globalconfig.Config) (string, error) {
+			return cfg.GitHubToken, nil
+		},
+	}
+
+	_, err := reloader.apply(context.Background(), configwatcher.FileUpdate[globalconfig.Config]{
+		Path:  next.Path,
+		Value: next,
+	})
+	if err != nil {
+		t.Fatalf("apply() error = %v", err)
+	}
+	if got := token.get(); got != "next-token" {
+		t.Fatalf("runtime GitHub token = %q, want next-token", got)
+	}
+}
+
+func TestGlobalConfigReloaderRestoresRuntimeGitHubTokenOnError(t *testing.T) {
+	t.Parallel()
+
+	reconcileErr := errors.New("reconcile failed")
+	current := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+	next := reloadTestConfig("global.yaml", 2, []globalconfig.Project{{ID: "alpha", Weight: 1}})
+	next.GitHubToken = "next-token"
+	token := newRuntimeGitHubTokenState("current-token")
+	reloader := &globalConfigReloader{
+		current:     current,
+		manager:     &globalReloadManager{err: reconcileErr},
+		githubToken: token,
+		resolveGitHubToken: func(_ context.Context, cfg globalconfig.Config) (string, error) {
+			return cfg.GitHubToken, nil
+		},
+	}
+
+	_, err := reloader.apply(context.Background(), configwatcher.FileUpdate[globalconfig.Config]{
+		Path:  next.Path,
+		Value: next,
+	})
+	if !errors.Is(err, reconcileErr) {
+		t.Fatalf("apply() error = %v, want %v", err, reconcileErr)
+	}
+	if got := token.get(); got != "current-token" {
+		t.Fatalf("runtime GitHub token = %q, want current-token", got)
+	}
+}
+
 type globalReloadManager struct {
 	calls  int
 	config project.ManagerConfig

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -124,6 +124,9 @@ func TestGlobalConfigReloaderUpdatesRuntimeGitHubToken(t *testing.T) {
 	if got := token.get(); got != "next-token" {
 		t.Fatalf("runtime GitHub token = %q, want next-token", got)
 	}
+	if got, want := manager.config.RuntimeCredentialVersion, runtimeGitHubTokenVersion("next-token"); got != want {
+		t.Fatalf("RuntimeCredentialVersion = %q, want %q", got, want)
+	}
 }
 
 func TestGlobalConfigReloaderRestoresRuntimeGitHubTokenOnError(t *testing.T) {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -42,6 +42,7 @@ func withRunnerFactory(
 	deps project.Dependencies,
 	sessionStore runnerpkg.SessionStore,
 	load func(project.Dependencies) (*project.Project, error),
+	githubTokenSource ...func() string,
 ) project.ProjectFactory {
 	return func(cfg globalconfig.Project) (*project.Project, error) {
 		workflow, err := workflowconfig.LoadWorkflow(cfg.Workflow)
@@ -60,6 +61,9 @@ func withRunnerFactory(
 
 		projectDeps := deps
 		projectDeps.Runner = run
+		if len(githubTokenSource) > 0 && githubTokenSource[0] != nil {
+			projectDeps.GitHubToken = githubTokenSource[0]()
+		}
 
 		if load != nil {
 			return load(projectDeps)

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -127,6 +127,47 @@ func TestProjectDependenciesInjectsNonNilRunner(t *testing.T) {
 	}
 }
 
+func TestProjectDependenciesUseRuntimeGitHubTokenSource(t *testing.T) {
+	t.Parallel()
+
+	var captured projectpkg.Dependencies
+	token := "first-token"
+	factory := withRunnerFactory(projectpkg.Dependencies{}, nil, func(d projectpkg.Dependencies) (*projectpkg.Project, error) {
+		captured = d
+		return nil, errProjectFactoryStub
+	}, func() string {
+		return token
+	})
+
+	workflowPath := writeWorkflowFile(t)
+	_, err := factory(globalconfig.Project{
+		ID:       "alpha",
+		Workflow: workflowPath,
+		Workdir:  filepath.Dir(workflowPath),
+		Weight:   1,
+	})
+	if err != errProjectFactoryStub {
+		t.Fatalf("ProjectFactory() error = %v, want %v", err, errProjectFactoryStub)
+	}
+	if captured.GitHubToken != "first-token" {
+		t.Fatalf("GitHubToken = %q, want first-token", captured.GitHubToken)
+	}
+
+	token = "second-token"
+	_, err = factory(globalconfig.Project{
+		ID:       "bravo",
+		Workflow: workflowPath,
+		Workdir:  filepath.Dir(workflowPath),
+		Weight:   1,
+	})
+	if err != errProjectFactoryStub {
+		t.Fatalf("ProjectFactory() error = %v, want %v", err, errProjectFactoryStub)
+	}
+	if captured.GitHubToken != "second-token" {
+		t.Fatalf("GitHubToken = %q, want second-token", captured.GitHubToken)
+	}
+}
+
 func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -192,18 +192,22 @@ func resolveRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, de
 		return RuntimeSecret{Value: token, Source: "GITHUB_TOKEN", Required: true}, nil, nil
 	}
 
+	token, requiresRuntimeToken := trackerGitHubToken(cfg, deps)
+	if token.Value == "" && !requiresRuntimeToken {
+		return RuntimeSecret{Required: false}, nil, nil
+	}
+
 	if cfg != nil {
-		if token := strings.TrimSpace(cfg.GitHubToken); token != "" {
-			resolved, err := resolveConfiguredGitHubToken(ctx, token, deps)
+		if configuredToken := strings.TrimSpace(cfg.GitHubToken); configuredToken != "" {
+			resolved, err := resolveConfiguredGitHubToken(ctx, configuredToken, deps)
 			if err != nil {
 				return RuntimeSecret{}, nil, err
 			}
-			warnings := literalTokenWarnings(token)
+			warnings := literalTokenWarnings(configuredToken)
 			return resolved, warnings, nil
 		}
 	}
 
-	token, requiresRuntimeToken := trackerGitHubToken(cfg, deps)
 	if token.Value != "" {
 		token.Required = true
 		return token, nil, nil

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -240,7 +240,7 @@ func trackerGitHubToken(cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecr
 		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 			continue
 		}
-		if trackerHasGitHubAppCredentials(workflow.Config.Tracker) {
+		if trackerHasGitHubAppCredentials(workflow.Config.Tracker, deps.lookupEnv) {
 			continue
 		}
 		if token, source := resolveRuntimeSecret(workflow.Config.Tracker.APIKey, deps.lookupEnv); token != "" {
@@ -254,10 +254,11 @@ func trackerGitHubToken(cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecr
 	return RuntimeSecret{}, requiresRuntimeToken
 }
 
-func trackerHasGitHubAppCredentials(tracker workflowconfig.Tracker) bool {
-	return strings.TrimSpace(tracker.GitHubAppID) != "" &&
-		strings.TrimSpace(tracker.GitHubAppInstallationID) != "" &&
-		(strings.TrimSpace(tracker.GitHubAppPrivateKey) != "" || strings.TrimSpace(tracker.GitHubAppPrivateKeyPath) != "")
+func trackerHasGitHubAppCredentials(tracker workflowconfig.Tracker, lookupEnv func(string) string) bool {
+	return resolveRuntimeSecretValue(tracker.GitHubAppID, lookupEnv) != "" &&
+		resolveRuntimeSecretValue(tracker.GitHubAppInstallationID, lookupEnv) != "" &&
+		(resolveRuntimeSecretValue(tracker.GitHubAppPrivateKey, lookupEnv) != "" ||
+			resolveRuntimeSecretValue(tracker.GitHubAppPrivateKeyPath, lookupEnv) != "")
 }
 
 func resolveRuntimeSecret(value string, lookupEnv func(string) string) (string, string) {
@@ -272,6 +273,11 @@ func resolveRuntimeSecret(value string, lookupEnv func(string) string) (string, 
 		}
 	}
 	return value, "tracker.api_key"
+}
+
+func resolveRuntimeSecretValue(value string, lookupEnv func(string) string) string {
+	resolved, _ := resolveRuntimeSecret(value, lookupEnv)
+	return resolved
 }
 
 func githubTokenSentinel(value string) bool {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -1,0 +1,400 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+const (
+	defaultRuntimeEnv      = "prod"
+	defaultRuntimeLogLevel = "info"
+	runtimeCommandTimeout  = 5 * time.Second
+
+	runtimeSourceFlag     = "flag"
+	runtimeSourceConfig   = "config"
+	runtimeSourceWorkflow = "workflow"
+	runtimeSourceDefault  = "default"
+
+	githubAuthHint = `Run gh auth login --scopes "repo,read:org,project" and set github_token: gh in global.yaml.`
+)
+
+type RuntimeValue struct {
+	Value  string
+	Source string
+}
+
+type RuntimeIntValue struct {
+	Value  int
+	Source string
+}
+
+type RuntimeSecret struct {
+	Value       string
+	Source      string
+	ResolvedVia string
+	Required    bool
+}
+
+type RuntimeWarning struct {
+	Name   string
+	Detail string
+	Hint   string
+}
+
+type RuntimeSettings struct {
+	ConfigPath  RuntimeValue
+	Env         RuntimeValue
+	LogLevel    RuntimeValue
+	Port        RuntimeIntValue
+	GitHubToken RuntimeSecret
+	Warnings    []RuntimeWarning
+}
+
+type runtimeInput struct {
+	Config     *globalconfig.Config
+	ConfigPath globalconfig.PathResolution
+	Workflow   string
+	Flags      runtimeFlags
+}
+
+type runtimeFlags struct {
+	Env      runtimeStringFlag
+	LogLevel runtimeStringFlag
+	Port     runtimeIntFlag
+}
+
+type runtimeStringFlag struct {
+	Value string
+	Set   bool
+}
+
+type runtimeIntFlag struct {
+	Value int
+	Set   bool
+}
+
+type runtimeDeps struct {
+	lookupEnv    func(string) string
+	ghAuthToken  func(context.Context) (string, error)
+	loadWorkflow func(string) (workflowconfig.Workflow, error)
+}
+
+func resolveRuntimeSettings(ctx context.Context, input runtimeInput, deps runtimeDeps) (RuntimeSettings, error) {
+	deps = deps.withDefaults()
+
+	settings := RuntimeSettings{
+		ConfigPath: RuntimeValue{
+			Value:  input.ConfigPath.Path,
+			Source: string(input.ConfigPath.Rule),
+		},
+		Env: resolveRuntimeString(runtimeStringInput{
+			Flag:          input.Flags.Env,
+			EnvCandidates: []string{"ENV", "DETENT_ENV"},
+			ConfigValue:   configEnv(input.Config),
+			DefaultValue:  defaultRuntimeEnv,
+		}, deps.lookupEnv),
+		LogLevel: resolveRuntimeString(runtimeStringInput{
+			Flag:          input.Flags.LogLevel,
+			EnvCandidates: []string{"LOG_LEVEL", "DETENT_LOG_LEVEL"},
+			ConfigValue:   configLogLevel(input.Config),
+			DefaultValue:  defaultRuntimeLogLevel,
+		}, deps.lookupEnv),
+	}
+
+	port, err := resolveRuntimePort(ctx, input, deps)
+	if err != nil {
+		return RuntimeSettings{}, err
+	}
+	settings.Port = port
+
+	token, warnings, err := resolveRuntimeGitHubToken(ctx, input.Config, deps)
+	if err != nil {
+		return RuntimeSettings{}, err
+	}
+	settings.GitHubToken = token
+	settings.Warnings = warnings
+	return settings, nil
+}
+
+type runtimeStringInput struct {
+	Flag          runtimeStringFlag
+	EnvCandidates []string
+	ConfigValue   string
+	DefaultValue  string
+}
+
+func resolveRuntimeString(input runtimeStringInput, lookupEnv func(string) string) RuntimeValue {
+	if input.Flag.Set {
+		if value := strings.TrimSpace(input.Flag.Value); value != "" {
+			return RuntimeValue{Value: value, Source: runtimeSourceFlag}
+		}
+	}
+	for _, key := range input.EnvCandidates {
+		if value := strings.TrimSpace(lookupEnv(key)); value != "" {
+			return RuntimeValue{Value: value, Source: key}
+		}
+	}
+	if value := strings.TrimSpace(input.ConfigValue); value != "" {
+		return RuntimeValue{Value: value, Source: runtimeSourceConfig}
+	}
+	return RuntimeValue{Value: input.DefaultValue, Source: runtimeSourceDefault}
+}
+
+func resolveRuntimePort(ctx context.Context, input runtimeInput, deps runtimeDeps) (RuntimeIntValue, error) {
+	if input.Flags.Port.Set {
+		if input.Flags.Port.Value < 0 {
+			return RuntimeIntValue{}, errors.New("port must be greater than or equal to 0")
+		}
+		return RuntimeIntValue{Value: input.Flags.Port.Value, Source: runtimeSourceFlag}, nil
+	}
+	if raw := strings.TrimSpace(deps.lookupEnv("PORT")); raw != "" {
+		port, err := strconv.Atoi(raw)
+		if err != nil || port < 0 {
+			return RuntimeIntValue{}, errors.New("PORT must be an integer greater than or equal to 0")
+		}
+		return RuntimeIntValue{Value: port, Source: "PORT"}, nil
+	}
+	if input.Config != nil && input.Config.Port != nil {
+		return RuntimeIntValue{Value: *input.Config.Port, Source: runtimeSourceConfig}, nil
+	}
+	if port, ok := workflowServerPort(ctx, input.Workflow, deps); ok {
+		return RuntimeIntValue{Value: port, Source: runtimeSourceWorkflow}, nil
+	}
+	return RuntimeIntValue{Value: defaultWebPort, Source: runtimeSourceDefault}, nil
+}
+
+func workflowServerPort(ctx context.Context, path string, deps runtimeDeps) (int, bool) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return 0, false
+	}
+	if err := ctx.Err(); err != nil {
+		return 0, false
+	}
+	workflow, err := deps.loadWorkflow(path)
+	if err != nil || workflow.Config.Server.Port == nil {
+		return 0, false
+	}
+	return *workflow.Config.Server.Port, true
+}
+
+func resolveRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecret, []RuntimeWarning, error) {
+	if token := strings.TrimSpace(deps.lookupEnv("GITHUB_TOKEN")); token != "" {
+		return RuntimeSecret{Value: token, Source: "GITHUB_TOKEN", Required: true}, nil, nil
+	}
+
+	if cfg != nil {
+		if token := strings.TrimSpace(cfg.GitHubToken); token != "" {
+			resolved, err := resolveConfiguredGitHubToken(ctx, token, deps)
+			if err != nil {
+				return RuntimeSecret{}, nil, err
+			}
+			warnings := literalTokenWarnings(token)
+			return resolved, warnings, nil
+		}
+	}
+
+	token, hasGitHubProject := trackerGitHubToken(cfg, deps)
+	if token.Value != "" {
+		token.Required = true
+		return token, nil, nil
+	}
+	if hasGitHubProject {
+		return RuntimeSecret{}, nil, fmt.Errorf("GITHUB_TOKEN is not set, github_token is not configured, and no usable tracker.api_key was found. %s", githubAuthHint)
+	}
+	return RuntimeSecret{Required: false}, nil, nil
+}
+
+func resolveConfiguredGitHubToken(ctx context.Context, token string, deps runtimeDeps) (RuntimeSecret, error) {
+	if githubTokenSentinel(token) {
+		resolved, err := deps.ghAuthToken(ctx)
+		if err != nil {
+			return RuntimeSecret{}, fmt.Errorf("resolve github_token via gh auth token: %w. %s", err, githubAuthHint)
+		}
+		resolved = strings.TrimSpace(resolved)
+		if resolved == "" {
+			return RuntimeSecret{}, fmt.Errorf("resolve github_token via gh auth token: empty token. %s", githubAuthHint)
+		}
+		return RuntimeSecret{Value: resolved, Source: "github_token", ResolvedVia: "gh", Required: true}, nil
+	}
+	return RuntimeSecret{Value: strings.TrimSpace(token), Source: "github_token", Required: true}, nil
+}
+
+func trackerGitHubToken(cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecret, bool) {
+	if cfg == nil {
+		return RuntimeSecret{}, false
+	}
+
+	hasGitHubProject := false
+	for _, project := range cfg.Projects {
+		workflow, err := deps.loadWorkflow(project.Workflow)
+		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+			continue
+		}
+		hasGitHubProject = true
+		if token, source := resolveRuntimeSecret(workflow.Config.Tracker.APIKey, deps.lookupEnv); token != "" {
+			if source == "" {
+				source = "tracker.api_key"
+			}
+			return RuntimeSecret{Value: token, Source: source}, true
+		}
+	}
+	return RuntimeSecret{}, hasGitHubProject
+}
+
+func resolveRuntimeSecret(value string, lookupEnv func(string) string) (string, string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "", ""
+	}
+	if strings.HasPrefix(value, "$") {
+		name := strings.TrimPrefix(value, "$")
+		if validEnvName(name) {
+			return strings.TrimSpace(lookupEnv(name)), name
+		}
+	}
+	return value, "tracker.api_key"
+}
+
+func githubTokenSentinel(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "gh", "gh-auth", "${gh auth token}", "$(gh auth token)":
+		return true
+	default:
+		return false
+	}
+}
+
+func literalTokenWarnings(token string) []RuntimeWarning {
+	if githubTokenSentinel(token) || !looksLikeGitHubToken(token) {
+		return nil
+	}
+	return []RuntimeWarning{{
+		Name:   "GitHub token storage",
+		Detail: "github_token is a literal token in global.yaml",
+		Hint:   "Use github_token: gh to resolve the token from GitHub CLI at startup.",
+	}}
+}
+
+func looksLikeGitHubToken(token string) bool {
+	token = strings.TrimSpace(token)
+	for _, prefix := range []string{"ghp_", "github_pat_", "gho_", "ghu_", "ghs_", "ghr_"} {
+		if strings.HasPrefix(token, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+func runtimeSettingsDetail(settings RuntimeSettings) string {
+	parts := []string{
+		runtimeTextDetail("config_path", settings.ConfigPath.Value, settings.ConfigPath.Source),
+		runtimeTextDetail("env", settings.Env.Value, settings.Env.Source),
+		runtimeTextDetail("log_level", settings.LogLevel.Value, settings.LogLevel.Source),
+		runtimeIntDetail("port", settings.Port.Value, settings.Port.Source),
+		runtimeGitHubTokenDetail(settings.GitHubToken),
+	}
+	return strings.Join(parts, "; ")
+}
+
+func runtimeTextDetail(name string, value string, source string) string {
+	return fmt.Sprintf("%s=%s (%s)", name, value, sourceDetail(source))
+}
+
+func runtimeIntDetail(name string, value int, source string) string {
+	return fmt.Sprintf("%s=%d (%s)", name, value, sourceDetail(source))
+}
+
+func runtimeGitHubTokenDetail(token RuntimeSecret) string {
+	if token.Value == "" {
+		if token.Required {
+			return "github_token=unresolved"
+		}
+		return "github_token=not required"
+	}
+	if token.ResolvedVia == "gh" {
+		return "github_token=resolved via gh"
+	}
+	return fmt.Sprintf("github_token=redacted (%s)", sourceDetail(token.Source))
+}
+
+func sourceDetail(source string) string {
+	source = strings.TrimSpace(source)
+	if source == "" {
+		return "unknown"
+	}
+	return source
+}
+
+func configEnv(cfg *globalconfig.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.Env
+}
+
+func configLogLevel(cfg *globalconfig.Config) string {
+	if cfg == nil {
+		return ""
+	}
+	return cfg.LogLevel
+}
+
+func (d runtimeDeps) withDefaults() runtimeDeps {
+	if d.lookupEnv == nil {
+		d.lookupEnv = os.Getenv
+	}
+	if d.ghAuthToken == nil {
+		d.ghAuthToken = defaultGHAuthToken
+	}
+	if d.loadWorkflow == nil {
+		d.loadWorkflow = workflowconfig.LoadWorkflow
+	}
+	return d
+}
+
+func runtimeDepsFromOptions(opts options) runtimeDeps {
+	return runtimeDeps{
+		lookupEnv:   opts.lookupEnv,
+		ghAuthToken: opts.ghAuthToken,
+	}
+}
+
+func defaultGHAuthToken(ctx context.Context) (string, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	path, err := exec.LookPath("gh")
+	if err != nil {
+		return "", errors.New("gh was not found on PATH")
+	}
+
+	commandCtx, cancel := context.WithTimeout(ctx, runtimeCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, path, "auth", "token") // #nosec G204 -- gh path is PATH-resolved and arguments are fixed.
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return "", commandCtx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return "", fmt.Errorf("gh auth token failed: %w: %s", err, detail)
+		}
+		return "", fmt.Errorf("gh auth token failed: %w", err)
+	}
+	token := strings.TrimSpace(string(output))
+	if token == "" {
+		return "", errors.New("gh auth token returned an empty token")
+	}
+	return token, nil
+}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"crypto/sha256"
 	"errors"
 	"fmt"
 	"os"
@@ -383,6 +384,14 @@ func runtimeGlobalGitHubToken(token RuntimeSecret) string {
 	default:
 		return ""
 	}
+}
+
+func runtimeGitHubTokenVersion(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	return fmt.Sprintf("%x", sha256.Sum256([]byte(token)))
 }
 
 func sourceDetail(source string) string {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -203,12 +203,12 @@ func resolveRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, de
 		}
 	}
 
-	token, hasGitHubProject := trackerGitHubToken(cfg, deps)
+	token, requiresRuntimeToken := trackerGitHubToken(cfg, deps)
 	if token.Value != "" {
 		token.Required = true
 		return token, nil, nil
 	}
-	if hasGitHubProject {
+	if requiresRuntimeToken {
 		return RuntimeSecret{}, nil, fmt.Errorf("GITHUB_TOKEN is not set, github_token is not configured, and no usable tracker.api_key was found. %s", githubAuthHint)
 	}
 	return RuntimeSecret{Required: false}, nil, nil
@@ -234,21 +234,30 @@ func trackerGitHubToken(cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecr
 		return RuntimeSecret{}, false
 	}
 
-	hasGitHubProject := false
+	requiresRuntimeToken := false
 	for _, project := range cfg.Projects {
 		workflow, err := deps.loadWorkflow(project.Workflow)
 		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 			continue
 		}
-		hasGitHubProject = true
+		if trackerHasGitHubAppCredentials(workflow.Config.Tracker) {
+			continue
+		}
 		if token, source := resolveRuntimeSecret(workflow.Config.Tracker.APIKey, deps.lookupEnv); token != "" {
 			if source == "" {
 				source = "tracker.api_key"
 			}
 			return RuntimeSecret{Value: token, Source: source}, true
 		}
+		requiresRuntimeToken = true
 	}
-	return RuntimeSecret{}, hasGitHubProject
+	return RuntimeSecret{}, requiresRuntimeToken
+}
+
+func trackerHasGitHubAppCredentials(tracker workflowconfig.Tracker) bool {
+	return strings.TrimSpace(tracker.GitHubAppID) != "" &&
+		strings.TrimSpace(tracker.GitHubAppInstallationID) != "" &&
+		(strings.TrimSpace(tracker.GitHubAppPrivateKey) != "" || strings.TrimSpace(tracker.GitHubAppPrivateKeyPath) != "")
 }
 
 func resolveRuntimeSecret(value string, lookupEnv func(string) string) (string, string) {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -346,6 +346,15 @@ func runtimeGitHubTokenDetail(token RuntimeSecret) string {
 	return fmt.Sprintf("github_token=redacted (%s)", sourceDetail(token.Source))
 }
 
+func runtimeGlobalGitHubToken(token RuntimeSecret) string {
+	switch strings.TrimSpace(token.Source) {
+	case "GITHUB_TOKEN", "github_token":
+		return strings.TrimSpace(token.Value)
+	default:
+		return ""
+	}
+}
+
 func sourceDetail(source string) string {
 	source = strings.TrimSpace(source)
 	if source == "" {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -82,10 +83,39 @@ type runtimeIntFlag struct {
 	Set   bool
 }
 
+type runtimeGitHubTokenState struct {
+	mu    sync.RWMutex
+	value string
+}
+
 type runtimeDeps struct {
 	lookupEnv    func(string) string
 	ghAuthToken  func(context.Context) (string, error)
 	loadWorkflow func(string) (workflowconfig.Workflow, error)
+}
+
+func newRuntimeGitHubTokenState(value string) *runtimeGitHubTokenState {
+	state := &runtimeGitHubTokenState{}
+	state.set(value)
+	return state
+}
+
+func (s *runtimeGitHubTokenState) get() string {
+	if s == nil {
+		return ""
+	}
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	return s.value
+}
+
+func (s *runtimeGitHubTokenState) set(value string) {
+	if s == nil {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.value = strings.TrimSpace(value)
 }
 
 func resolveRuntimeSettings(ctx context.Context, input runtimeInput, deps runtimeDeps) (RuntimeSettings, error) {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -252,7 +252,11 @@ func TestResolveRuntimeSettingsDoesNotRequireTokenForGitHubApp(t *testing.T) {
 	got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
 		Config: ptrGlobalConfig(githubRuntimeConfig("")),
 	}, runtimeDeps{
-		lookupEnv: mapLookup(nil),
+		lookupEnv: mapLookup(map[string]string{
+			"APP_ID":           "12345",
+			"INSTALLATION_ID":  "67890",
+			"PRIVATE_KEY_PATH": ".detent/github-app.pem",
+		}),
 		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
 			return workflowconfig.Workflow{Config: githubAppWorkflow()}, nil
 		},
@@ -265,6 +269,25 @@ func TestResolveRuntimeSettingsDoesNotRequireTokenForGitHubApp(t *testing.T) {
 	}
 	if got.GitHubToken.Value != "" {
 		t.Fatalf("GitHubToken.Value = %q, want empty", got.GitHubToken.Value)
+	}
+}
+
+func TestResolveRuntimeSettingsRequiresTokenForMissingGitHubAppEnvRefs(t *testing.T) {
+	t.Parallel()
+
+	_, err := resolveRuntimeSettings(context.Background(), runtimeInput{
+		Config: ptrGlobalConfig(githubRuntimeConfig("")),
+	}, runtimeDeps{
+		lookupEnv: mapLookup(nil),
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: githubAppWorkflow()}, nil
+		},
+	})
+	if err == nil {
+		t.Fatal("resolveRuntimeSettings() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "GITHUB_TOKEN") {
+		t.Fatalf("error = %v, want containing GITHUB_TOKEN", err)
 	}
 }
 
@@ -322,7 +345,7 @@ func githubAppWorkflow() workflowconfig.Config {
 	cfg := githubWorkflow("")
 	cfg.Tracker.GitHubAppID = "$APP_ID"
 	cfg.Tracker.GitHubAppInstallationID = "$INSTALLATION_ID"
-	cfg.Tracker.GitHubAppPrivateKeyPath = ".detent/github-app.pem"
+	cfg.Tracker.GitHubAppPrivateKeyPath = "$PRIVATE_KEY_PATH"
 	return cfg
 }
 

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -381,6 +381,52 @@ func TestRuntimeSettingsDetailRedactsGitHubToken(t *testing.T) {
 	}
 }
 
+func TestRuntimeGlobalGitHubTokenSources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		token RuntimeSecret
+		want  string
+	}{
+		{
+			name:  "environment token is global",
+			token: RuntimeSecret{Value: "env-token", Source: "GITHUB_TOKEN"},
+			want:  "env-token",
+		},
+		{
+			name:  "config token is global",
+			token: RuntimeSecret{Value: "config-token", Source: "github_token"},
+			want:  "config-token",
+		},
+		{
+			name:  "literal tracker token stays workflow local",
+			token: RuntimeSecret{Value: "tracker-token", Source: "tracker.api_key"},
+			want:  "",
+		},
+		{
+			name:  "tracker env token stays workflow local",
+			token: RuntimeSecret{Value: "tracker-token", Source: "PROJECT_TOKEN"},
+			want:  "",
+		},
+		{
+			name:  "empty token",
+			token: RuntimeSecret{},
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := runtimeGlobalGitHubToken(tt.token); got != tt.want {
+				t.Fatalf("runtimeGlobalGitHubToken() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func githubRuntimeConfig(token string) globalconfig.Config {
 	return globalconfig.Config{
 		GitHubToken: token,

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -246,6 +246,28 @@ func TestResolveRuntimeSettingsGitHubTokenErrors(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimeSettingsDoesNotRequireTokenForGitHubApp(t *testing.T) {
+	t.Parallel()
+
+	got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
+		Config: ptrGlobalConfig(githubRuntimeConfig("")),
+	}, runtimeDeps{
+		lookupEnv: mapLookup(nil),
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: githubAppWorkflow()}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSettings() error = %v", err)
+	}
+	if got.GitHubToken.Required {
+		t.Fatalf("GitHubToken.Required = true, want false")
+	}
+	if got.GitHubToken.Value != "" {
+		t.Fatalf("GitHubToken.Value = %q, want empty", got.GitHubToken.Value)
+	}
+}
+
 func TestRuntimeSettingsDetailRedactsGitHubToken(t *testing.T) {
 	t.Parallel()
 
@@ -294,6 +316,18 @@ func githubWorkflow(apiKey string) workflowconfig.Config {
 	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
 	cfg.Tracker.APIKey = apiKey
 	return cfg
+}
+
+func githubAppWorkflow() workflowconfig.Config {
+	cfg := githubWorkflow("")
+	cfg.Tracker.GitHubAppID = "$APP_ID"
+	cfg.Tracker.GitHubAppInstallationID = "$INSTALLATION_ID"
+	cfg.Tracker.GitHubAppPrivateKeyPath = ".detent/github-app.pem"
+	return cfg
+}
+
+func ptrGlobalConfig(cfg globalconfig.Config) *globalconfig.Config {
+	return &cfg
 }
 
 func mapLookup(values map[string]string) func(string) string {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -272,6 +272,62 @@ func TestResolveRuntimeSettingsDoesNotRequireTokenForGitHubApp(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimeSettingsSkipsConfigTokenWhenNoProjectNeedsRuntimeToken(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		workflow workflowconfig.Config
+		env      map[string]string
+	}{
+		{
+			name:     "non github tracker",
+			workflow: nonGitHubWorkflow(),
+		},
+		{
+			name:     "github app tracker",
+			workflow: githubAppWorkflow(),
+			env: map[string]string{
+				"APP_ID":           "12345",
+				"INSTALLATION_ID":  "67890",
+				"PRIVATE_KEY_PATH": ".detent/github-app.pem",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ghCalls := 0
+			got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
+				Config: ptrGlobalConfig(githubRuntimeConfig("gh")),
+			}, runtimeDeps{
+				lookupEnv: mapLookup(tt.env),
+				ghAuthToken: func(context.Context) (string, error) {
+					ghCalls++
+					return "", errors.New("gh should not be called")
+				},
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return workflowconfig.Workflow{Config: tt.workflow}, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("resolveRuntimeSettings() error = %v", err)
+			}
+			if ghCalls != 0 {
+				t.Fatalf("gh calls = %d, want 0", ghCalls)
+			}
+			if got.GitHubToken.Required {
+				t.Fatalf("GitHubToken.Required = true, want false")
+			}
+			if got.GitHubToken.Value != "" {
+				t.Fatalf("GitHubToken.Value = %q, want empty", got.GitHubToken.Value)
+			}
+		})
+	}
+}
+
 func TestResolveRuntimeSettingsRequiresTokenForMissingGitHubAppEnvRefs(t *testing.T) {
 	t.Parallel()
 
@@ -338,6 +394,12 @@ func githubWorkflow(apiKey string) workflowconfig.Config {
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
 	cfg.Tracker.APIKey = apiKey
+	return cfg
+}
+
+func nonGitHubWorkflow() workflowconfig.Config {
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	return cfg
 }
 

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -1,0 +1,303 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestResolveRuntimeSettingsPrecedence(t *testing.T) {
+	t.Parallel()
+
+	configPort := 4100
+	tests := []struct {
+		name         string
+		flags        runtimeFlags
+		env          map[string]string
+		cfg          *globalconfig.Config
+		wantEnv      RuntimeValue
+		wantLogLevel RuntimeValue
+		wantPort     RuntimeIntValue
+	}{
+		{
+			name: "flags win",
+			flags: runtimeFlags{
+				Env:      runtimeStringFlag{Value: "flag-env", Set: true},
+				LogLevel: runtimeStringFlag{Value: "debug", Set: true},
+				Port:     runtimeIntFlag{Value: 0, Set: true},
+			},
+			env: map[string]string{
+				"ENV":       "env-env",
+				"LOG_LEVEL": "error",
+				"PORT":      "4200",
+			},
+			cfg:          &globalconfig.Config{Env: "config-env", LogLevel: "warn", Port: &configPort},
+			wantEnv:      RuntimeValue{Value: "flag-env", Source: runtimeSourceFlag},
+			wantLogLevel: RuntimeValue{Value: "debug", Source: runtimeSourceFlag},
+			wantPort:     RuntimeIntValue{Value: 0, Source: runtimeSourceFlag},
+		},
+		{
+			name: "env wins after flags",
+			env: map[string]string{
+				"ENV":       "env-env",
+				"LOG_LEVEL": "error",
+				"PORT":      "4200",
+			},
+			cfg:          &globalconfig.Config{Env: "config-env", LogLevel: "warn", Port: &configPort},
+			wantEnv:      RuntimeValue{Value: "env-env", Source: "ENV"},
+			wantLogLevel: RuntimeValue{Value: "error", Source: "LOG_LEVEL"},
+			wantPort:     RuntimeIntValue{Value: 4200, Source: "PORT"},
+		},
+		{
+			name: "deprecated env fallbacks win before config",
+			env: map[string]string{
+				"DETENT_ENV":       "detent-env",
+				"DETENT_LOG_LEVEL": "debug",
+			},
+			cfg:          &globalconfig.Config{Env: "config-env", LogLevel: "warn", Port: &configPort},
+			wantEnv:      RuntimeValue{Value: "detent-env", Source: "DETENT_ENV"},
+			wantLogLevel: RuntimeValue{Value: "debug", Source: "DETENT_LOG_LEVEL"},
+			wantPort:     RuntimeIntValue{Value: 4100, Source: runtimeSourceConfig},
+		},
+		{
+			name:         "config wins before defaults",
+			cfg:          &globalconfig.Config{Env: "config-env", LogLevel: "warn", Port: &configPort},
+			wantEnv:      RuntimeValue{Value: "config-env", Source: runtimeSourceConfig},
+			wantLogLevel: RuntimeValue{Value: "warn", Source: runtimeSourceConfig},
+			wantPort:     RuntimeIntValue{Value: 4100, Source: runtimeSourceConfig},
+		},
+		{
+			name:         "defaults are last",
+			cfg:          &globalconfig.Config{},
+			wantEnv:      RuntimeValue{Value: defaultRuntimeEnv, Source: runtimeSourceDefault},
+			wantLogLevel: RuntimeValue{Value: defaultRuntimeLogLevel, Source: runtimeSourceDefault},
+			wantPort:     RuntimeIntValue{Value: defaultWebPort, Source: runtimeSourceDefault},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
+				Config: tt.cfg,
+				Flags:  tt.flags,
+			}, runtimeDeps{
+				lookupEnv: mapLookup(tt.env),
+			})
+			if err != nil {
+				t.Fatalf("resolveRuntimeSettings() error = %v", err)
+			}
+
+			if got.Env != tt.wantEnv {
+				t.Fatalf("Env = %#v, want %#v", got.Env, tt.wantEnv)
+			}
+			if got.LogLevel != tt.wantLogLevel {
+				t.Fatalf("LogLevel = %#v, want %#v", got.LogLevel, tt.wantLogLevel)
+			}
+			if got.Port != tt.wantPort {
+				t.Fatalf("Port = %#v, want %#v", got.Port, tt.wantPort)
+			}
+		})
+	}
+}
+
+func TestResolveRuntimeSettingsGitHubTokenPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		env         map[string]string
+		cfg         globalconfig.Config
+		workflow    workflowconfig.Config
+		ghToken     string
+		wantToken   string
+		wantSource  string
+		wantVia     string
+		wantGhCalls int
+	}{
+		{
+			name: "environment wins before config and tracker",
+			env: map[string]string{
+				"GITHUB_TOKEN":  "env-token",
+				"PROJECT_TOKEN": "tracker-token",
+			},
+			cfg:         githubRuntimeConfig("gh"),
+			workflow:    githubWorkflow("$PROJECT_TOKEN"),
+			ghToken:     "gh-token",
+			wantToken:   "env-token",
+			wantSource:  "GITHUB_TOKEN",
+			wantGhCalls: 0,
+		},
+		{
+			name:        "config literal wins before tracker",
+			env:         map[string]string{"PROJECT_TOKEN": "tracker-token"},
+			cfg:         githubRuntimeConfig("config-token"),
+			workflow:    githubWorkflow("$PROJECT_TOKEN"),
+			wantToken:   "config-token",
+			wantSource:  "github_token",
+			wantGhCalls: 0,
+		},
+		{
+			name:        "config sentinel resolves through gh auth token",
+			cfg:         githubRuntimeConfig("${gh auth token}"),
+			workflow:    githubWorkflow("tracker-token"),
+			ghToken:     "gh-token",
+			wantToken:   "gh-token",
+			wantSource:  "github_token",
+			wantVia:     "gh",
+			wantGhCalls: 1,
+		},
+		{
+			name:        "tracker api key is final fallback",
+			env:         map[string]string{"PROJECT_TOKEN": "tracker-token"},
+			cfg:         githubRuntimeConfig(""),
+			workflow:    githubWorkflow("$PROJECT_TOKEN"),
+			wantToken:   "tracker-token",
+			wantSource:  "PROJECT_TOKEN",
+			wantGhCalls: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ghCalls := 0
+			got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
+				Config: &tt.cfg,
+			}, runtimeDeps{
+				lookupEnv: mapLookup(tt.env),
+				ghAuthToken: func(context.Context) (string, error) {
+					ghCalls++
+					return tt.ghToken, nil
+				},
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return workflowconfig.Workflow{Config: tt.workflow}, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("resolveRuntimeSettings() error = %v", err)
+			}
+			if got.GitHubToken.Value != tt.wantToken {
+				t.Fatalf("GitHubToken.Value = %q, want %q", got.GitHubToken.Value, tt.wantToken)
+			}
+			if got.GitHubToken.Source != tt.wantSource {
+				t.Fatalf("GitHubToken.Source = %q, want %q", got.GitHubToken.Source, tt.wantSource)
+			}
+			if got.GitHubToken.ResolvedVia != tt.wantVia {
+				t.Fatalf("GitHubToken.ResolvedVia = %q, want %q", got.GitHubToken.ResolvedVia, tt.wantVia)
+			}
+			if ghCalls != tt.wantGhCalls {
+				t.Fatalf("gh calls = %d, want %d", ghCalls, tt.wantGhCalls)
+			}
+		})
+	}
+}
+
+func TestResolveRuntimeSettingsGitHubTokenErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		cfg     globalconfig.Config
+		ghErr   error
+		wantErr string
+	}{
+		{
+			name:    "sentinel failure includes gh auth guidance",
+			cfg:     githubRuntimeConfig("gh"),
+			ghErr:   errors.New("not logged in"),
+			wantErr: "gh auth login",
+		},
+		{
+			name:    "github projects require token",
+			cfg:     githubRuntimeConfig(""),
+			wantErr: "GITHUB_TOKEN",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := resolveRuntimeSettings(context.Background(), runtimeInput{
+				Config: &tt.cfg,
+			}, runtimeDeps{
+				lookupEnv: mapLookup(nil),
+				ghAuthToken: func(context.Context) (string, error) {
+					return "", tt.ghErr
+				},
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return workflowconfig.Workflow{Config: githubWorkflow("")}, nil
+				},
+			})
+			if err == nil {
+				t.Fatal("resolveRuntimeSettings() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRuntimeSettingsDetailRedactsGitHubToken(t *testing.T) {
+	t.Parallel()
+
+	settings := RuntimeSettings{
+		ConfigPath:  RuntimeValue{Value: "/tmp/global.yaml", Source: string(globalconfig.PathRuleFlag)},
+		Env:         RuntimeValue{Value: "dev", Source: "ENV"},
+		LogLevel:    RuntimeValue{Value: "debug", Source: "LOG_LEVEL"},
+		Port:        RuntimeIntValue{Value: 4000, Source: runtimeSourceConfig},
+		GitHubToken: RuntimeSecret{Value: "ghp_secret", Source: "GITHUB_TOKEN"},
+	}
+
+	detail := runtimeSettingsDetail(settings)
+	if strings.Contains(detail, "ghp_secret") {
+		t.Fatalf("runtime detail leaked token: %s", detail)
+	}
+	for _, want := range []string{
+		"config_path=/tmp/global.yaml (--config)",
+		"env=dev (ENV)",
+		"log_level=debug (LOG_LEVEL)",
+		"port=4000 (config)",
+		"github_token=redacted (GITHUB_TOKEN)",
+	} {
+		if !strings.Contains(detail, want) {
+			t.Fatalf("runtime detail missing %q:\n%s", want, detail)
+		}
+	}
+
+	settings.GitHubToken.ResolvedVia = "gh"
+	detail = runtimeSettingsDetail(settings)
+	if !strings.Contains(detail, "github_token=resolved via gh") {
+		t.Fatalf("runtime detail missing gh sentinel source:\n%s", detail)
+	}
+}
+
+func githubRuntimeConfig(token string) globalconfig.Config {
+	return globalconfig.Config{
+		GitHubToken: token,
+		Projects: []globalconfig.Project{
+			{ID: "detent", Workflow: "WORKFLOW.md", Workdir: ".", Weight: 1},
+		},
+	}
+}
+
+func githubWorkflow(apiKey string) workflowconfig.Config {
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Tracker.APIKey = apiKey
+	return cfg
+}
+
+func mapLookup(values map[string]string) func(string) string {
+	return func(key string) string {
+		return values[key]
+	}
+}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -21,6 +21,8 @@ const (
 	SchedulingStrict     = "strict"
 	SchedulingRoundRobin = "round_robin"
 	SchedulingFairShare  = "fair_share"
+
+	configFileMode = 0o600
 )
 
 var schedulingModes = []string{
@@ -213,8 +215,11 @@ func Write(path string, cfg Config, opts ...Option) error {
 	if err := os.MkdirAll(filepath.Dir(expandedPath), 0o755); err != nil {
 		return fmt.Errorf("create global config directory %s: %w", filepath.Dir(expandedPath), err)
 	}
-	if err := os.WriteFile(expandedPath, raw, 0o644); err != nil {
+	if err := os.WriteFile(expandedPath, raw, configFileMode); err != nil {
 		return fmt.Errorf("write global config %s: %w", expandedPath, err)
+	}
+	if err := os.Chmod(expandedPath, configFileMode); err != nil {
+		return fmt.Errorf("restrict global config permissions %s: %w", expandedPath, err)
 	}
 
 	return nil

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -48,11 +48,15 @@ type PathResolution struct {
 }
 
 type Config struct {
-	Path       string    `yaml:"-"`
-	APIVersion string    `yaml:"apiVersion"`
-	Kind       string    `yaml:"kind"`
-	Global     Settings  `yaml:"global"`
-	Projects   []Project `yaml:"projects"`
+	Path        string    `yaml:"-"`
+	APIVersion  string    `yaml:"apiVersion"`
+	Kind        string    `yaml:"kind"`
+	Env         string    `yaml:"env,omitempty"`
+	LogLevel    string    `yaml:"log_level,omitempty"`
+	GitHubToken string    `yaml:"github_token,omitempty"`
+	Port        *int      `yaml:"port,omitempty"`
+	Global      Settings  `yaml:"global"`
+	Projects    []Project `yaml:"projects"`
 }
 
 type Settings struct {
@@ -288,6 +292,9 @@ func (c Config) Validate(opts ...Option) error {
 	} else if c.Kind != Kind {
 		problems = append(problems, "kind: must equal "+Kind)
 	}
+	if c.Port != nil && *c.Port < 0 {
+		problems = append(problems, "port: must be greater than or equal to 0")
+	}
 
 	if c.Global.MaxConcurrentAgents <= 0 {
 		problems = append(problems, "global.max_concurrent_agents: must be a positive integer")
@@ -515,6 +522,10 @@ func validateRaw(attrs map[string]any, opts options) []string {
 	problems = append(problems, requiredErrors(attrs, []string{"apiVersion", "kind", "global", "projects"})...)
 	problems = append(problems, versionErrors(attrs["apiVersion"])...)
 	problems = append(problems, kindErrors(attrs["kind"])...)
+	problems = append(problems, optionalStringTypeError(attrs, "env")...)
+	problems = append(problems, optionalStringTypeError(attrs, "log_level")...)
+	problems = append(problems, optionalStringTypeError(attrs, "github_token")...)
+	problems = append(problems, optionalNonNegativeIntegerError(attrs["port"], "port")...)
 	problems = append(problems, globalErrors(attrs["global"])...)
 	problems = append(problems, projectsErrors(attrs["projects"], opts)...)
 
@@ -794,6 +805,27 @@ func nonNegativeInteger(value any) bool {
 	return ok && number >= 0
 }
 
+func optionalStringTypeError(attrs map[string]any, field string) []string {
+	value, ok := attrs[field]
+	if !ok || value == nil {
+		return nil
+	}
+	if _, ok := value.(string); ok {
+		return nil
+	}
+	return []string{field + ": must be a string"}
+}
+
+func optionalNonNegativeIntegerError(value any, field string) []string {
+	if value == nil {
+		return nil
+	}
+	if nonNegativeInteger(value) {
+		return nil
+	}
+	return []string{field + ": must be an integer greater than or equal to 0"}
+}
+
 func pausedErrors(attrs map[string]any, prefix string) []string {
 	value, ok := attrs["paused"]
 	if !ok {
@@ -886,6 +918,22 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
+	env, err := optionalString(attrs["env"], "env")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	logLevel, err := optionalString(attrs["log_level"], "log_level")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	githubToken, err := optionalString(attrs["github_token"], "github_token")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
+	port, err := optionalIntPointer(attrs["port"], "port")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
 	settings, err := buildSettings(global)
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
@@ -896,11 +944,15 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	}
 
 	return Config{
-		Path:       path,
-		APIVersion: apiVersion,
-		Kind:       kind,
-		Global:     settings,
-		Projects:   builtProjects,
+		Path:        path,
+		APIVersion:  apiVersion,
+		Kind:        kind,
+		Env:         env,
+		LogLevel:    logLevel,
+		GitHubToken: githubToken,
+		Port:        port,
+		Global:      settings,
+		Projects:    builtProjects,
 	}, nil
 }
 
@@ -1086,6 +1138,17 @@ func optionalString(value any, field string) (string, error) {
 		return "", err
 	}
 	return strings.TrimSpace(text), nil
+}
+
+func optionalIntPointer(value any, field string) (*int, error) {
+	if value == nil {
+		return nil, nil
+	}
+	number, err := intValue(value, field)
+	if err != nil {
+		return nil, err
+	}
+	return &number, nil
 }
 
 func mapValue(value any, field string) (map[string]any, error) {

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -234,6 +234,45 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestReadParsesRuntimeSettings(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, configPath, `apiVersion: detent/v1
+kind: GlobalConfig
+env: dev
+log_level: debug
+github_token: gh
+port: 4100
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects:
+  - id: detent
+    workflow: `+paths.workflow+`
+    workdir: `+paths.workdir+`
+    weight: 1
+    priority: 0
+`)
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if cfg.Env != "dev" {
+		t.Fatalf("Env = %q, want dev", cfg.Env)
+	}
+	if cfg.LogLevel != "debug" {
+		t.Fatalf("LogLevel = %q, want debug", cfg.LogLevel)
+	}
+	if cfg.GitHubToken != "gh" {
+		t.Fatalf("GitHubToken = %q, want gh", cfg.GitHubToken)
+	}
+	if cfg.Port == nil || *cfg.Port != 4100 {
+		t.Fatalf("Port = %v, want 4100", cfg.Port)
+	}
+}
+
 func TestReadOrDefaultUsesDefaultForMissingFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing", "global.yaml")
 
@@ -256,11 +295,16 @@ func TestReadOrDefaultUsesDefaultForMissingFile(t *testing.T) {
 func TestWriteRoundTripsConfig(t *testing.T) {
 	paths := createProjectFiles(t)
 	configPath := filepath.Join(paths.root, "written", "global.yaml")
+	port := 4100
 
 	cfg := Config{
-		Path:       configPath,
-		APIVersion: APIVersion,
-		Kind:       Kind,
+		Path:        configPath,
+		APIVersion:  APIVersion,
+		Kind:        Kind,
+		Env:         "dev",
+		LogLevel:    "debug",
+		GitHubToken: "gh",
+		Port:        &port,
 		Global: Settings{
 			MaxConcurrentAgents: 3,
 			Scheduling:          SchedulingStrict,
@@ -301,6 +345,18 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 
 	if !reflect.DeepEqual(got.Global, cfg.Global) {
 		t.Fatalf("Global = %#v, want %#v", got.Global, cfg.Global)
+	}
+	if got.Env != cfg.Env {
+		t.Fatalf("Env = %q, want %q", got.Env, cfg.Env)
+	}
+	if got.LogLevel != cfg.LogLevel {
+		t.Fatalf("LogLevel = %q, want %q", got.LogLevel, cfg.LogLevel)
+	}
+	if got.GitHubToken != cfg.GitHubToken {
+		t.Fatalf("GitHubToken = %q, want %q", got.GitHubToken, cfg.GitHubToken)
+	}
+	if got.Port == nil || *got.Port != *cfg.Port {
+		t.Fatalf("Port = %v, want %d", got.Port, *cfg.Port)
 	}
 	if !reflect.DeepEqual(got.Projects, cfg.Projects) {
 		t.Fatalf("Projects = %#v, want %#v", got.Projects, cfg.Projects)

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -363,6 +363,43 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 	}
 }
 
+func TestWriteRestrictsExistingConfigFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("windows does not expose POSIX file modes")
+	}
+
+	paths := createProjectFiles(t)
+	path := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, path, "old")
+	if err := os.Chmod(path, 0o644); err != nil {
+		t.Fatalf("Chmod() error = %v", err)
+	}
+
+	err := Write(path, Config{
+		APIVersion:  APIVersion,
+		Kind:        Kind,
+		GitHubToken: "ghp_secret",
+		Global: Settings{
+			MaxConcurrentAgents: 8,
+			Scheduling:          SchedulingWeighted,
+		},
+		Projects: []Project{
+			{ID: "detent", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("Stat() error = %v", err)
+	}
+	if got := info.Mode().Perm(); got != configFileMode {
+		t.Fatalf("mode = %o, want %o", got, configFileMode)
+	}
+}
+
 func TestWriteValidatesConfigBeforeWriting(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "global.yaml")
 

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -29,9 +29,10 @@ type StartupConfig struct {
 }
 
 type ManagerConfig struct {
-	Identity globalconfig.Identity
-	Projects []globalconfig.Project
-	Startup  StartupConfig
+	Identity                 globalconfig.Identity
+	Projects                 []globalconfig.Project
+	Startup                  StartupConfig
+	RuntimeCredentialVersion string
 }
 
 type ReconcileResult struct {
@@ -195,6 +196,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	m.mu.Lock()
 	defer m.mu.Unlock()
 
+	runtimeCredentialChanged := m.cfg.RuntimeCredentialVersion != cfg.RuntimeCredentialVersion
 	result := ReconcileResult{}
 	for _, current := range m.registry.List() {
 		id := current.ID()
@@ -203,7 +205,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 			result.Removed = append(result.Removed, id)
 			continue
 		}
-		if sameProjectConfig(current.Config(), next) {
+		if !runtimeCredentialChanged && sameProjectConfig(current.Config(), next) {
 			result.Unchanged = append(result.Unchanged, id)
 			continue
 		}

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -277,6 +277,52 @@ func TestManagerReconcileProjects(t *testing.T) {
 	}
 }
 
+func TestManagerReconcileChangesProjectsWhenRuntimeCredentialVersionChanges(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects:                 []globalconfig.Project{{ID: "alpha", Weight: 1}},
+		RuntimeCredentialVersion: "old",
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+
+	got, err := manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects:                 []globalconfig.Project{{ID: "alpha", Weight: 1}},
+		RuntimeCredentialVersion: "new",
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	want := project.ReconcileResult{Changed: []project.ProjectID{"alpha"}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Reconcile() = %#v, want %#v", got, want)
+	}
+	assertProjectEvents(t, sub.C(), []project.Event{
+		{ProjectID: "alpha", Kind: project.EventStopped},
+		{ProjectID: "alpha", Kind: project.EventStarted},
+	})
+}
+
 func TestManagerReconcileKeepsRegistryWhenNewProjectCannotBeCreated(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -79,12 +79,14 @@ type Dependencies struct {
 	Scheduler              scheduler.Scheduler
 	Events                 *hub.Hub[Event]
 	Logger                 *slog.Logger
+	GitHubToken            string
 }
 
 type Project struct {
 	id               ProjectID
 	cfg              globalconfig.Project
 	workflow         workflowconfig.Workflow
+	githubToken      string
 	connector        connector.Connector
 	connectorFactory ConnectorFactory
 	orchestrator     *orchestrator.Orchestrator
@@ -123,6 +125,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 
 	workflow := normalizeWorkflow(cfg.Workflow)
 	workflow.Config = workflowConfigWithProjectIdentity(cfg.Project, workflow.Config)
+	workflow.Config = workflowConfigWithGitHubToken(workflow.Config, deps.GitHubToken)
 	if err := workflow.Config.Validate(); err != nil {
 		return nil, fmt.Errorf("validate project workflow: %w", err)
 	}
@@ -178,6 +181,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		id:               id,
 		cfg:              cfg.Project,
 		workflow:         workflow,
+		githubToken:      strings.TrimSpace(deps.GitHubToken),
 		connector:        projectConnector,
 		connectorFactory: connectorFactory,
 		orchestrator:     orch,
@@ -577,6 +581,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 
 	workflow := normalizeWorkflow(update.Workflow)
 	workflow.Config = workflowConfigWithProjectIdentity(projectConfig, workflow.Config)
+	workflow.Config = workflowConfigWithGitHubToken(workflow.Config, p.githubToken)
 	if err := workflow.Config.Validate(); err != nil {
 		p.logger.Warn("workflow reload validation failed",
 			"project_id", p.id,
@@ -654,6 +659,14 @@ func workflowConfigWithProjectIdentity(
 	identity := project.Identity
 	identity.Normalize()
 	workflow.Identity = identity
+	return workflow
+}
+
+func workflowConfigWithGitHubToken(workflow workflowconfig.Config, token string) workflowconfig.Config {
+	token = strings.TrimSpace(token)
+	if token != "" && workflow.Tracker.Kind == workflowconfig.TrackerGitHub {
+		workflow.Tracker.APIKey = token
+	}
 	return workflow
 }
 


### PR DESCRIPTION
## Summary

- Add top-level global runtime settings for env, log_level, github_token, and port.
- Centralize flag/env/config/default resolution and wire it into boot, logging, GitHub connector startup, and doctor source reporting.
- Support github_token: gh / gh-auth / gh auth token sentinel resolution without logging secrets.

Fixes #318

## Test Plan

- [x] `make check`