### PR TITLE
feat(orchestrator): reconcile closed issue statuses

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -51,6 +51,7 @@ query DetentGitHubProjectItems(
               number
               title
               state
+              stateReason
               url
               repository { nameWithOwner }
             }
@@ -217,6 +218,7 @@ fragment DetentGitHubIssueParent on Issue {
   title
   body
   state
+  stateReason
   url
   createdAt
   updatedAt
@@ -473,6 +475,7 @@ type githubIssueNode struct {
 	Title                          string                       `json:"title"`
 	Body                           string                       `json:"body"`
 	State                          string                       `json:"state"`
+	StateReason                    string                       `json:"stateReason"`
 	URL                            string                       `json:"url"`
 	CreatedAt                      *string                      `json:"createdAt"`
 	UpdatedAt                      *string                      `json:"updatedAt"`
@@ -572,17 +575,18 @@ type actor struct {
 }
 
 type restIssue struct {
-	NodeID    string         `json:"node_id"`
-	Number    int            `json:"number"`
-	Title     string         `json:"title"`
-	Body      *string        `json:"body"`
-	State     string         `json:"state"`
-	HTMLURL   string         `json:"html_url"`
-	CreatedAt *time.Time     `json:"created_at"`
-	UpdatedAt *time.Time     `json:"updated_at"`
-	User      *actor         `json:"user"`
-	Assignees []restAssignee `json:"assignees"`
-	Labels    []label        `json:"labels"`
+	NodeID      string         `json:"node_id"`
+	Number      int            `json:"number"`
+	Title       string         `json:"title"`
+	Body        *string        `json:"body"`
+	State       string         `json:"state"`
+	StateReason string         `json:"state_reason"`
+	HTMLURL     string         `json:"html_url"`
+	CreatedAt   *time.Time     `json:"created_at"`
+	UpdatedAt   *time.Time     `json:"updated_at"`
+	User        *actor         `json:"user"`
+	Assignees   []restAssignee `json:"assignees"`
+	Labels      []label        `json:"labels"`
 }
 
 type restIssueSearchResponse struct {
@@ -1750,6 +1754,7 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		State:            c.githubToDetentState(statusName),
 		URL:              issue.URL,
 		Closed:           githubIssueClosed(issue.State),
+		ClosedReason:     issue.StateReason,
 		PRNumber:         firstPullRequestNumber(issue.ClosedByPullRequestsReferences),
 		AuthorID:         actorLogin(issue.Author),
 		AssigneeID:       firstAssigneeLogin(issue.Assignees),
@@ -2425,18 +2430,19 @@ func restCommitStatusesPath(repo pullRequestRepo, sha string) string {
 func githubIssueNodeFromREST(ref issueRef, issue restIssue) githubIssueNode {
 	repo := ref.Owner + "/" + ref.Name
 	return githubIssueNode{
-		TypeName:  "Issue",
-		ID:        strings.TrimSpace(issue.NodeID),
-		Number:    issue.Number,
-		Title:     issue.Title,
-		Body:      restStringValue(issue.Body),
-		State:     issue.State,
-		URL:       issue.HTMLURL,
-		CreatedAt: restTimeString(issue.CreatedAt),
-		UpdatedAt: restTimeString(issue.UpdatedAt),
-		Author:    issue.User,
-		Assignees: restAssigneesConnection(issue.Assignees),
-		Labels:    nodeConnection[label]{Nodes: issue.Labels},
+		TypeName:    "Issue",
+		ID:          strings.TrimSpace(issue.NodeID),
+		Number:      issue.Number,
+		Title:       issue.Title,
+		Body:        restStringValue(issue.Body),
+		State:       issue.State,
+		StateReason: issue.StateReason,
+		URL:         issue.HTMLURL,
+		CreatedAt:   restTimeString(issue.CreatedAt),
+		UpdatedAt:   restTimeString(issue.UpdatedAt),
+		Author:      issue.User,
+		Assignees:   restAssigneesConnection(issue.Assignees),
+		Labels:      nodeConnection[label]{Nodes: issue.Labels},
 		Repository: repository{
 			NameWithOwner: repo,
 		},

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -19,7 +19,7 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{{
-		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/26","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P0"}},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":27,"title":"Backlog item","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/27","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"},"priorityValue":{"name":"No priority"}}]}}}}`,
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","state":"CLOSED","stateReason":"COMPLETED","url":"https://github.com/digitaldrywood/detent/issues/26","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P0"}},{"id":"PVTI_2","content":{"__typename":"Issue","id":"I_kw2","number":27,"title":"Backlog item","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/27","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"},"priorityValue":{"name":"No priority"}}]}}}}`,
 	}, {
 		method: http.MethodGet,
 		path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
@@ -49,6 +49,8 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 		Priority:         &priority,
 		State:            "Todo",
 		URL:              "https://github.com/digitaldrywood/detent/issues/26",
+		Closed:           true,
+		ClosedReason:     "COMPLETED",
 		BlockedBy:        []connector.BlockedRef{},
 		Labels:           []string{},
 		Assignees:        []string{},
@@ -744,7 +746,7 @@ func TestConnectorFetchIssueStatesByIDsCapturesIssueMetadata(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/repos/example/repo/issues/1",
-			body:   `{"node_id":"I_kw1","number":1,"title":"First","body":"","state":"open","html_url":"https://github.com/example/repo/issues/1","user":{"login":"author-1"},"assignees":[{"node_id":"U_1","login":"worker-1"},{"node_id":"U_2","login":"worker-2"}],"labels":[]}`,
+			body:   `{"node_id":"I_kw1","number":1,"title":"First","body":"","state":"closed","state_reason":"not_planned","html_url":"https://github.com/example/repo/issues/1","user":{"login":"author-1"},"assignees":[{"node_id":"U_1","login":"worker-1"},{"node_id":"U_2","login":"worker-2"}],"labels":[]}`,
 		},
 		{
 			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Ready"},"priorityValue":{"name":"P1"},"fieldValues":{"nodes":[{"__typename":"ProjectV2ItemFieldSingleSelectValue","name":"Ready","field":{"name":"Status"}},{"__typename":"ProjectV2ItemFieldTextValue","text":"team-a","field":{"name":"Owner"}},{"__typename":"ProjectV2ItemFieldNumberValue","number":3,"field":{"name":"Weight"}}]}}]}}}}`,
@@ -767,6 +769,9 @@ func TestConnectorFetchIssueStatesByIDsCapturesIssueMetadata(t *testing.T) {
 	issue := got[0]
 	if issue.AuthorID != "author-1" {
 		t.Fatalf("AuthorID = %q, want author-1", issue.AuthorID)
+	}
+	if !issue.Closed || issue.ClosedReason != "not_planned" {
+		t.Fatalf("closed metadata = (%v, %q), want closed not_planned", issue.Closed, issue.ClosedReason)
 	}
 	if !reflect.DeepEqual(issue.Assignees, []string{"worker-1", "worker-2"}) {
 		t.Fatalf("Assignees = %#v, want worker-1 and worker-2", issue.Assignees)

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -16,6 +16,7 @@ type Issue struct {
 	BranchName       string            `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	URL              string            `json:"url,omitempty" yaml:"url,omitempty"`
 	Closed           bool              `json:"closed,omitempty" yaml:"closed,omitempty"`
+	ClosedReason     string            `json:"closed_reason,omitempty" yaml:"closed_reason,omitempty"`
 	PRNumber         *int              `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
 	PullRequest      *PullRequest      `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
 	AuthorID         string            `json:"author_id,omitempty" yaml:"author_id,omitempty"`

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -30,6 +30,7 @@ const (
 	defaultFailureRetryBaseDelay      = 10 * time.Second
 	continuationDispatchBackoff       = 100 * time.Millisecond
 	runUpdateBufferSize               = 128
+	maxRecentEvents                   = 50
 	blockedStatusState                = "Blocked"
 	blockedReasonDependency           = "blocked by non-terminal dependency"
 	blockedReasonProjectStatus        = "blocked by project status"
@@ -367,6 +368,11 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		pendingTransitions,
 	)
 	state.pendingEpicParentLookups = mergeIssueMaps(pendingParentLookups, failedParentLookups)
+	reconciledClosedIssues := o.reconcileClosedCompletedIssueStatuses(ctx, state, transitionIssues, now)
+	issues = filterReconciledIssues(issues, reconciledClosedIssues)
+	statusIssues = filterReconciledIssues(statusIssues, reconciledClosedIssues)
+	state.epicTransitionWatch = filterReconciledIssues(state.epicTransitionWatch, reconciledClosedIssues)
+	state.Pipeline = filterReconciledIssues(state.Pipeline, reconciledClosedIssues)
 	issues = filterCompletedEpicCandidates(issues, completedEpics)
 	sortIssuesForDispatch(issues, o.cfg.DispatchPriorityByState)
 	o.pruneBudgetRefusals(state, now)
@@ -441,6 +447,86 @@ func stateNameSet(states []string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+func (o *Orchestrator) reconcileClosedCompletedIssueStatuses(ctx context.Context, state *State, issues []connector.Issue, now time.Time) map[string]struct{} {
+	targetState := doneStateName(o.cfg.TerminalStates)
+	reconciled := map[string]struct{}{}
+	for _, issue := range issues {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+		if _, ok := reconciled[issueID]; ok {
+			continue
+		}
+		if !closedCompletedIssueNeedsStatusReconciliation(issue, o.cfg.TerminalStates) {
+			continue
+		}
+		if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
+			if o.logger != nil {
+				o.logger.Warn("reconcile closed completed issue status failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
+			}
+			continue
+		}
+		reconciled[issueID] = struct{}{}
+		if o.logger != nil {
+			o.logger.Info("reconciled closed completed issue status", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState)
+		}
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "closed_completed_status_reconciled",
+			Message: "reconciled " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState,
+		})
+	}
+	if len(reconciled) == 0 {
+		return nil
+	}
+	return reconciled
+}
+
+func closedCompletedIssueNeedsStatusReconciliation(issue connector.Issue, terminalStates []string) bool {
+	return issue.Closed &&
+		closedReasonCompleted(issue.ClosedReason) &&
+		strings.TrimSpace(issue.State) != "" &&
+		!stateIn(issue.State, terminalStates)
+}
+
+func closedReasonCompleted(reason string) bool {
+	reason = strings.ToLower(strings.TrimSpace(reason))
+	reason = strings.ReplaceAll(reason, "-", "_")
+	return reason == "completed"
+}
+
+func filterReconciledIssues(issues []connector.Issue, reconciled map[string]struct{}) []connector.Issue {
+	if len(reconciled) == 0 || len(issues) == 0 {
+		return issues
+	}
+	out := issues[:0]
+	for _, issue := range issues {
+		if _, ok := reconciled[strings.TrimSpace(issue.ID)]; ok {
+			continue
+		}
+		out = append(out, issue)
+	}
+	return out
+}
+
+func recordStateEvent(state *State, event telemetry.ActivityEvent) {
+	if state == nil {
+		return
+	}
+	state.RecentEvents = append(state.RecentEvents, event)
+	if len(state.RecentEvents) > maxRecentEvents {
+		state.RecentEvents = append([]telemetry.ActivityEvent(nil), state.RecentEvents[len(state.RecentEvents)-maxRecentEvents:]...)
+	}
+}
+
+func issueLabel(issue connector.Issue) string {
+	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" {
+		return identifier
+	}
+	return strings.TrimSpace(issue.ID)
 }
 
 func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State, now time.Time) {
@@ -1492,6 +1578,7 @@ func validCandidate(issue connector.Issue) bool {
 		issue.Identifier != "" &&
 		issue.Title != "" &&
 		issue.State != "" &&
+		!issue.Closed &&
 		issue.AssignedToWorker
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -16,6 +16,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	snapshot := telemetry.Snapshot{
 		GeneratedAt: now,
 		Instance:    s.Instance,
+		Events:      cloneActivityEvents(s.RecentEvents),
 		Refresh: telemetry.Refresh{
 			PollIntervalSeconds: int64(s.PollInterval / time.Second),
 			LastRefreshAt:       timePointer(s.LastRefreshAt),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -16,6 +16,7 @@ type State struct {
 	NextRefreshAt            time.Time
 	LastRunningReconcileAt   time.Time
 	LastWorkspaceCleanupAt   time.Time
+	RecentEvents             []telemetry.ActivityEvent
 	Pipeline                 []connector.Issue
 	Running                  map[string]Running
 	Claimed                  map[string]Claimed
@@ -112,6 +113,7 @@ func (s State) clone() State {
 		NextRefreshAt:            s.NextRefreshAt,
 		LastRunningReconcileAt:   s.LastRunningReconcileAt,
 		LastWorkspaceCleanupAt:   s.LastWorkspaceCleanupAt,
+		RecentEvents:             cloneActivityEvents(s.RecentEvents),
 		Pipeline:                 cloneIssues(s.Pipeline),
 		Running:                  make(map[string]Running, len(s.Running)),
 		Claimed:                  make(map[string]Claimed, len(s.Claimed)),

--- a/internal/orchestrator/status_reconciliation_test.go
+++ b/internal/orchestrator/status_reconciliation_test.go
@@ -1,0 +1,195 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestReconcileClosedCompletedIssueStatusesMovesNonTerminalStatesToDone(t *testing.T) {
+	t.Parallel()
+
+	for _, stateName := range []string{"Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging"} {
+		t.Run(stateName, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &statusReconcileConnector{}
+			orch := newStatusReconcileOrchestrator(tracker)
+			state := newState(orch.cfg)
+			now := time.Date(2026, 6, 8, 12, 0, 0, 0, time.UTC)
+			issue := statusReconcileIssue("issue-"+strings.ToLower(strings.ReplaceAll(stateName, " ", "-")), stateName, true, "completed")
+
+			reconciled := orch.reconcileClosedCompletedIssueStatuses(context.Background(), &state, []connector.Issue{issue}, now)
+
+			if got := tracker.updates; len(got) != 1 || got[0] != (statusUpdate{issueID: issue.ID, state: "Done"}) {
+				t.Fatalf("updates = %#v, want Done update for %s", got, issue.ID)
+			}
+			if _, ok := reconciled[issue.ID]; !ok {
+				t.Fatalf("reconciled[%q] missing", issue.ID)
+			}
+			if len(state.RecentEvents) != 1 {
+				t.Fatalf("RecentEvents len = %d, want 1", len(state.RecentEvents))
+			}
+			if got := state.RecentEvents[0].Event; got != "closed_completed_status_reconciled" {
+				t.Fatalf("RecentEvents[0].Event = %q, want closed_completed_status_reconciled", got)
+			}
+			if !state.RecentEvents[0].At.Equal(now) {
+				t.Fatalf("RecentEvents[0].At = %v, want %v", state.RecentEvents[0].At, now)
+			}
+			snapshot := state.Snapshot(now)
+			if len(snapshot.Events) != 1 || snapshot.Events[0].Event != "closed_completed_status_reconciled" {
+				t.Fatalf("snapshot Events = %#v, want reconciliation event", snapshot.Events)
+			}
+		})
+	}
+}
+
+func TestReconcileClosedCompletedIssueStatusesLeavesOtherIssuesUnchanged(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+	}{
+		{
+			name:  "closed not planned",
+			issue: statusReconcileIssue("issue-not-planned", "In Progress", true, "not_planned"),
+		},
+		{
+			name:  "open completed",
+			issue: statusReconcileIssue("issue-open", "In Progress", false, "completed"),
+		},
+		{
+			name:  "closed completed terminal",
+			issue: statusReconcileIssue("issue-done", "Done", true, "completed"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &statusReconcileConnector{}
+			orch := newStatusReconcileOrchestrator(tracker)
+			state := newState(orch.cfg)
+
+			reconciled := orch.reconcileClosedCompletedIssueStatuses(context.Background(), &state, []connector.Issue{tt.issue}, time.Now())
+
+			if len(tracker.updates) != 0 {
+				t.Fatalf("updates = %#v, want none", tracker.updates)
+			}
+			if len(reconciled) != 0 {
+				t.Fatalf("reconciled = %#v, want empty", reconciled)
+			}
+			if len(state.RecentEvents) != 0 {
+				t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)
+			}
+		})
+	}
+}
+
+func TestTickReconcilesClosedCompletedIssueStatusesFromExistingPolls(t *testing.T) {
+	t.Parallel()
+
+	todo := statusReconcileIssue("issue-todo", "Todo", true, "COMPLETED")
+	review := statusReconcileIssue("issue-review", "Human Review", true, "completed")
+	tracker := &statusReconcileConnector{
+		candidates:  []connector.Issue{todo},
+		stateIssues: []connector.Issue{review},
+	}
+	orch := newStatusReconcileOrchestrator(tracker)
+	orch.cfg.ActiveStates = []string{"Todo", "In Progress", "Rework", "Merging"}
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 8, 12, 30, 0, 0, time.UTC))
+
+	want := []statusUpdate{
+		{issueID: todo.ID, state: "Done"},
+		{issueID: review.ID, state: "Done"},
+	}
+	if got := tracker.updates; len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if tracker.fetchByIDCount != 0 {
+		t.Fatalf("FetchIssueStatesByIDs calls = %d, want 0", tracker.fetchByIDCount)
+	}
+	if len(state.epicTransitionWatch) != 0 {
+		t.Fatalf("epicTransitionWatch = %#v, want reconciled issues filtered", state.epicTransitionWatch)
+	}
+	if len(state.Pipeline) != 0 {
+		t.Fatalf("Pipeline = %#v, want reconciled issues filtered", state.Pipeline)
+	}
+}
+
+func newStatusReconcileOrchestrator(tracker *statusReconcileConnector) *Orchestrator {
+	cfg := normalizeConfig(Config{
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	return &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func statusReconcileIssue(id string, state string, closed bool, closedReason string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/detent#" + strings.TrimPrefix(strings.TrimPrefix(id, "issue-"), "issue")
+	issue.Title = "Reconcile issue status"
+	issue.State = state
+	issue.Closed = closed
+	issue.ClosedReason = closedReason
+	return issue
+}
+
+type statusUpdate struct {
+	issueID string
+	state   string
+}
+
+type statusReconcileConnector struct {
+	candidates     []connector.Issue
+	stateIssues    []connector.Issue
+	updates        []statusUpdate
+	fetchByIDCount int
+}
+
+func (c *statusReconcileConnector) Name() string {
+	return "status-reconcile"
+}
+
+func (c *statusReconcileConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return cloneIssues(c.candidates), nil
+}
+
+func (c *statusReconcileConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	return issuesInStates(c.stateIssues, states), nil
+}
+
+func (c *statusReconcileConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	c.fetchByIDCount++
+	return nil, nil
+}
+
+func (c *statusReconcileConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *statusReconcileConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updates = append(c.updates, statusUpdate{issueID: issueID, state: state})
+	return nil
+}
+
+func (c *statusReconcileConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *statusReconcileConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -9,6 +9,7 @@ type Snapshot struct {
 	Projects       []ProjectSnapshot `json:"projects,omitempty"`
 	DashboardURL   string            `json:"dashboard_url,omitempty"`
 	Refresh        Refresh           `json:"refresh"`
+	Events         []ActivityEvent   `json:"events,omitempty"`
 	Counts         Counts            `json:"counts"`
 	Pipeline       []Issue           `json:"pipeline,omitempty"`
 	Running        []Running         `json:"running"`


### PR DESCRIPTION
## Summary

- Add an orchestrator tick reconciliation pass for CLOSED/completed issues in non-terminal project statuses.
- Hydrate GitHub close reasons through ProjectV2 GraphQL issue nodes and REST issue refreshes.
- Emit a log line plus snapshot event when reconciliation succeeds and prevent closed items from dispatching.

Fixes #321

## Test Plan

- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/connector/github`
- [x] `make check`