### PR TITLE
fix(deps): bump Go toolchain to 1.26.4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.4'
           cache: true
 
       - name: Download modules
@@ -51,7 +51,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.4'
           cache: true
 
       - name: Download modules
@@ -78,7 +78,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.4'
           cache: true
 
       - name: Check coverage
@@ -92,7 +92,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.4'
           cache: true
 
       - name: Run non-agent core tests
@@ -112,7 +112,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version-file: go.mod
+          go-version: '1.26.4'
           cache: true
 
       - name: Run GoReleaser snapshot

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: '1.26'
+          go-version: '1.26.4'
           cache: true
 
       - name: Verify tag points at main

--- a/go.mod
+++ b/go.mod
@@ -2,6 +2,8 @@ module github.com/digitaldrywood/detent
 
 go 1.26
 
+toolchain go1.26.4
+
 require (
 	github.com/a-h/templ v0.3.1001
 	github.com/charmbracelet/bubbletea v1.3.10


### PR DESCRIPTION
## Summary

- Add the Go toolchain directive for go1.26.4 while keeping go 1.26 as the module minimum.
- Pin CI and release workflow Go setup to 1.26.4 so binaries build with the fixed standard library.

Fixes #323

## Test Plan

- [x] `govulncheck ./...`
- [x] `make check`
