### PR TITLE
fix(codex): unblock transport read loop

### DIFF
--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -34,11 +34,13 @@ type localTransport struct {
 	stdin          io.WriteCloser
 	codec          *Codec
 	received       chan transportResult
+	readStop       chan struct{}
 	readDone       chan struct{}
 	done           chan struct{}
 	sendLock       chan struct{}
 	waitErr        error
 	waitMu         sync.Mutex
+	readStopOnce   sync.Once
 	closeOnce      sync.Once
 	closeErr       error
 }
@@ -87,6 +89,7 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 		stdin:          stdin,
 		codec:          NewCodec(stdout, stdin),
 		received:       make(chan transportResult, 64),
+		readStop:       make(chan struct{}),
 		readDone:       make(chan struct{}),
 		done:           make(chan struct{}),
 		sendLock:       make(chan struct{}, 1),
@@ -149,6 +152,7 @@ func (t *localTransport) Close(ctx context.Context) error {
 	ctx = contextOrBackground(ctx)
 
 	closeErr := t.closeStdin()
+	t.stopReading()
 
 	select {
 	case <-t.done:
@@ -228,16 +232,19 @@ func (t *localTransport) readLoop() {
 	for {
 		msg, err := t.codec.ReadMessage()
 		if err != nil {
-			t.received <- transportResult{err: err}
+			t.publishReceived(transportResult{err: err})
 			return
 		}
 
-		t.received <- transportResult{msg: msg}
+		if !t.publishReceived(transportResult{msg: msg}) {
+			return
+		}
 	}
 }
 
 func (t *localTransport) wait() {
 	<-t.readDone
+	t.stopReading()
 	err := t.cmd.Wait()
 	if cleanupErr := cleanupCommandProcessGroup(t.processGroupID); cleanupErr != nil {
 		err = errors.Join(err, cleanupErr)
@@ -246,6 +253,35 @@ func (t *localTransport) wait() {
 	t.waitErr = err
 	t.waitMu.Unlock()
 	close(t.done)
+}
+
+func (t *localTransport) publishReceived(result transportResult) bool {
+	if t.readStop == nil {
+		t.received <- result
+		return true
+	}
+
+	select {
+	case <-t.readStop:
+		return false
+	default:
+	}
+
+	select {
+	case t.received <- result:
+		return true
+	case <-t.readStop:
+		return false
+	}
+}
+
+func (t *localTransport) stopReading() {
+	if t.readStop == nil {
+		return
+	}
+	t.readStopOnce.Do(func() {
+		close(t.readStop)
+	})
 }
 
 func (t *localTransport) waitError() error {

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -232,13 +232,16 @@ func (t *localTransport) readLoop() {
 	for {
 		msg, err := t.codec.ReadMessage()
 		if err != nil {
-			t.publishReceived(transportResult{err: err})
+			if !t.readingStopped() {
+				t.publishReceived(transportResult{err: err})
+			}
 			return
 		}
 
-		if !t.publishReceived(transportResult{msg: msg}) {
-			return
+		if t.readingStopped() {
+			continue
 		}
+		t.publishReceived(transportResult{msg: msg})
 	}
 }
 
@@ -271,6 +274,19 @@ func (t *localTransport) publishReceived(result transportResult) bool {
 	case t.received <- result:
 		return true
 	case <-t.readStop:
+		return false
+	}
+}
+
+func (t *localTransport) readingStopped() bool {
+	if t.readStop == nil {
+		return false
+	}
+
+	select {
+	case <-t.readStop:
+		return true
+	default:
 		return false
 	}
 }

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -132,6 +132,48 @@ func TestLocalTransportSendHonorsContextDuringBlockedWrite(t *testing.T) {
 	}
 }
 
+func TestLocalTransportCloseExitsAfterTurnErrorBackpressure(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "turn-error-backpressure")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+	capturingFactory := &capturingLocalTransportFactory{factory: factory}
+	server, err := NewAppServer(capturingFactory,
+		WithReadTimeout(20*time.Millisecond),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	started := time.Now()
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "fail mid stream",
+	}, nil)
+	elapsed := time.Since(started)
+	if !errors.Is(err, ErrTurnFailed) {
+		t.Fatalf("RunTurn() error = %v, want ErrTurnFailed", err)
+	}
+	if elapsed > 500*time.Millisecond {
+		t.Fatalf("RunTurn() took %s after turn error, want prompt close", elapsed)
+	}
+
+	transport := capturingFactory.transport
+	if transport == nil {
+		t.Fatal("captured transport is nil")
+	}
+	assertChannelClosed(t, transport.readDone, "readLoop")
+	assertChannelClosed(t, transport.done, "wait")
+	if transport.cmd.ProcessState == nil {
+		t.Fatal("ProcessState is nil, want reaped process")
+	}
+}
+
 func TestLocalTransportSendWrapsCloseErrorAfterContextCancellation(t *testing.T) {
 	t.Parallel()
 
@@ -287,6 +329,8 @@ func TestLocalTransportHelperProcess(t *testing.T) {
 		time.Sleep(time.Hour)
 	case "exit":
 		return
+	case "turn-error-backpressure":
+		helperTurnErrorBackpressure()
 	default:
 		os.Exit(2)
 	}
@@ -301,6 +345,52 @@ func helperCommand(ctx context.Context, mode string) *exec.Cmd {
 		"DETENT_CODEX_TRANSPORT_MODE="+mode,
 	)
 	return cmd
+}
+
+func helperTurnErrorBackpressure() {
+	encoder := json.NewEncoder(os.Stdout)
+	encoder.SetEscapeHTML(false)
+
+	messages := []Message{
+		{
+			JSONRPC: JSONRPCVersion,
+			ID:      json.RawMessage(`1`),
+			Result:  json.RawMessage(`{"userAgent":"codex-cli/test"}`),
+		},
+		{
+			JSONRPC: JSONRPCVersion,
+			ID:      json.RawMessage(`2`),
+			Result:  json.RawMessage(`{"thread":{"id":"thread-1"}}`),
+		},
+		{
+			JSONRPC: JSONRPCVersion,
+			ID:      json.RawMessage(`3`),
+			Result:  json.RawMessage(`{"turn":{"id":"turn-1"}}`),
+		},
+		{
+			JSONRPC: JSONRPCVersion,
+			Method:  "turn/completed",
+			Params:  json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"failed"}}`),
+		},
+	}
+	for _, msg := range messages {
+		if err := encoder.Encode(msg); err != nil {
+			os.Exit(7)
+		}
+	}
+	for i := range 1024 {
+		msg := Message{
+			JSONRPC: JSONRPCVersion,
+			Method:  "item/agentMessage/delta",
+			Params:  json.RawMessage(`{"threadId":"thread-1","turnId":"turn-1","itemId":"item-1","delta":"still streaming"}`),
+		}
+		if err := encoder.Encode(msg); err != nil {
+			os.Exit(8)
+		}
+		if i == 1023 {
+			time.Sleep(time.Hour)
+		}
+	}
 }
 
 func helperRoundTrip() {
@@ -376,4 +466,32 @@ func (noopWriteCloser) Write(p []byte) (int, error) {
 
 func (noopWriteCloser) Close() error {
 	return nil
+}
+
+type capturingLocalTransportFactory struct {
+	factory   *LocalTransportFactory
+	transport *localTransport
+}
+
+func (f *capturingLocalTransportFactory) NewTransport(ctx context.Context) (Transport, error) {
+	transport, err := f.factory.NewTransport(ctx)
+	if err != nil {
+		return nil, err
+	}
+	local, ok := transport.(*localTransport)
+	if !ok {
+		return nil, errors.New("transport is not local")
+	}
+	f.transport = local
+	return transport, nil
+}
+
+func assertChannelClosed(t *testing.T, ch <-chan struct{}, name string) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatalf("%s did not exit", name)
+	}
 }

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -143,7 +143,7 @@ func TestLocalTransportCloseExitsAfterTurnErrorBackpressure(t *testing.T) {
 	}
 	capturingFactory := &capturingLocalTransportFactory{factory: factory}
 	server, err := NewAppServer(capturingFactory,
-		WithReadTimeout(20*time.Millisecond),
+		WithReadTimeout(500*time.Millisecond),
 		WithTurnTimeout(time.Second),
 	)
 	if err != nil {
@@ -159,7 +159,7 @@ func TestLocalTransportCloseExitsAfterTurnErrorBackpressure(t *testing.T) {
 	if !errors.Is(err, ErrTurnFailed) {
 		t.Fatalf("RunTurn() error = %v, want ErrTurnFailed", err)
 	}
-	if elapsed > 500*time.Millisecond {
+	if elapsed > 900*time.Millisecond {
 		t.Fatalf("RunTurn() took %s after turn error, want prompt close", elapsed)
 	}
 

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -174,6 +174,51 @@ func TestLocalTransportCloseExitsAfterTurnErrorBackpressure(t *testing.T) {
 	}
 }
 
+func TestLocalTransportCloseDrainsAfterSuccessfulTurnBackpressure(t *testing.T) {
+	t.Parallel()
+
+	factory, err := NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
+		return helperCommand(ctx, "turn-complete-backpressure")
+	})
+	if err != nil {
+		t.Fatalf("NewLocalTransportFactory() error = %v", err)
+	}
+	capturingFactory := &capturingLocalTransportFactory{factory: factory}
+	server, err := NewAppServer(capturingFactory,
+		WithReadTimeout(2*time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	started := time.Now()
+	result, err := server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "complete then drain",
+	}, nil)
+	elapsed := time.Since(started)
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ThreadID != "thread-1" || result.TurnID != "turn-1" {
+		t.Fatalf("RunTurn() result = %#v, want thread-1 turn-1", result)
+	}
+	if elapsed > 1500*time.Millisecond {
+		t.Fatalf("RunTurn() took %s after completed turn, want prompt close", elapsed)
+	}
+
+	transport := capturingFactory.transport
+	if transport == nil {
+		t.Fatal("captured transport is nil")
+	}
+	assertChannelClosed(t, transport.readDone, "readLoop")
+	assertChannelClosed(t, transport.done, "wait")
+	if transport.cmd.ProcessState == nil {
+		t.Fatal("ProcessState is nil, want reaped process")
+	}
+}
+
 func TestLocalTransportSendWrapsCloseErrorAfterContextCancellation(t *testing.T) {
 	t.Parallel()
 
@@ -330,7 +375,9 @@ func TestLocalTransportHelperProcess(t *testing.T) {
 	case "exit":
 		return
 	case "turn-error-backpressure":
-		helperTurnErrorBackpressure()
+		helperTurnBackpressure(json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"failed"}}`), true)
+	case "turn-complete-backpressure":
+		helperTurnBackpressure(json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`), false)
 	default:
 		os.Exit(2)
 	}
@@ -347,7 +394,7 @@ func helperCommand(ctx context.Context, mode string) *exec.Cmd {
 	return cmd
 }
 
-func helperTurnErrorBackpressure() {
+func helperTurnBackpressure(completedParams json.RawMessage, blockAfterFlood bool) {
 	encoder := json.NewEncoder(os.Stdout)
 	encoder.SetEscapeHTML(false)
 
@@ -370,7 +417,7 @@ func helperTurnErrorBackpressure() {
 		{
 			JSONRPC: JSONRPCVersion,
 			Method:  "turn/completed",
-			Params:  json.RawMessage(`{"threadId":"thread-1","turn":{"id":"turn-1","status":"failed"}}`),
+			Params:  completedParams,
 		},
 	}
 	for _, msg := range messages {
@@ -387,7 +434,7 @@ func helperTurnErrorBackpressure() {
 		if err := encoder.Encode(msg); err != nil {
 			os.Exit(8)
 		}
-		if i == 1023 {
+		if blockAfterFlood && i == 1023 {
 			time.Sleep(time.Hour)
 		}
 	}


### PR DESCRIPTION
## Summary
- Add a read-stop signal so `Close()` stops publishing into `received` when the consumer has returned, while `readLoop` keeps draining stdout until the child exits or is killed.
- Cover both failed-turn and successful-turn back-pressure paths with helper processes that keep writing after the turn result, then assert `readLoop`, `wait`, and process reaping complete.

Fixes #326

## Test Plan
- `go test ./internal/codex -run "TestLocalTransportClose(ExitsAfterTurnErrorBackpressure|DrainsAfterSuccessfulTurnBackpressure)" -count=1`
- `go test -race ./internal/codex -run "TestLocalTransportClose(ExitsAfterTurnErrorBackpressure|DrainsAfterSuccessfulTurnBackpressure)" -count=1`
- `go test ./internal/codex -count=1`
- `go test -race ./internal/codex -count=1`
- `make check`