### PR TITLE
fix(update): harden self-update trust

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,6 +179,13 @@ switches the detected Go-installed binary to the release asset and pins future
 updates to release-binary management. Source builds still print the recommended
 command instead of overwriting the binary.
 
+Release self-updates verify SHA256 checksums fetched from GitHub releases. The
+checksum verifier supports detached minisign signature assets named
+`<checksum>.minisig`, but enforcement is gated until the binary embeds the
+pinned minisign public key for the release stream. Until that release signing
+key is provisioned in #337, update integrity still depends on GitHub TLS plus
+the published checksum file.
+
 ## Release
 
 Cut releases from `main` by pushing a semver tag:

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/lmittmann/tint v1.1.3
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/spf13/cobra v1.10.2
+	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
 )
@@ -46,7 +47,6 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.53.0 // indirect
 	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/ed25519"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -20,25 +22,33 @@ import (
 	"strings"
 	"time"
 	"unicode"
+
+	"golang.org/x/crypto/blake2b"
 )
 
 const (
-	defaultAPIBase          = "https://api.github.com/repos/digitaldrywood/detent"
-	moduleInstallPackage    = "github.com/digitaldrywood/detent/cmd/detent"
-	moduleInstallTarget     = moduleInstallPackage + "@latest"
-	moduleInstallCommand    = "go install " + moduleInstallTarget
-	homebrewUpdateCommand   = "brew upgrade digitaldrywood/tap/detent"
-	defaultChecksumName     = "checksums.txt"
-	projectName             = "detent"
-	windowsExecutableName   = "detent.exe"
-	nonWindowsArchiveExt    = ".tar.gz"
-	windowsArchiveExt       = ".zip"
-	defaultRequestUserAgent = "detent-updater"
+	defaultAPIBase           = "https://api.github.com/repos/digitaldrywood/detent"
+	moduleInstallPackage     = "github.com/digitaldrywood/detent/cmd/detent"
+	moduleInstallTarget      = moduleInstallPackage + "@latest"
+	moduleInstallCommand     = "go install " + moduleInstallTarget
+	homebrewUpdateCommand    = "brew upgrade digitaldrywood/tap/detent"
+	defaultChecksumName      = "checksums.txt"
+	projectName              = "detent"
+	windowsExecutableName    = "detent.exe"
+	nonWindowsArchiveExt     = ".tar.gz"
+	windowsArchiveExt        = ".zip"
+	defaultRequestUserAgent  = "detent-updater"
+	defaultHTTPClientTimeout = 2 * time.Minute
+	defaultMaxDownloadBytes  = 256 * 1024 * 1024
+	minisignPublicKeySize    = 42
+	minisignSignatureSize    = 74
 )
 
 var (
 	ErrConfirmationRequired = errors.New("update confirmation required")
 	ErrRefused              = errors.New("update refused")
+
+	defaultChecksumMinisignPublicKey = ""
 )
 
 type InstallSource string
@@ -74,8 +84,9 @@ type Release struct {
 }
 
 type ReleaseAssets struct {
-	Archive  Asset
-	Checksum Asset
+	Archive           Asset
+	Checksum          Asset
+	ChecksumSignature Asset
 }
 
 type ReleaseClient interface {
@@ -87,15 +98,19 @@ type ProcessStarter func(string, []string) error
 type CommandRunner func(context.Context, string, []string, io.Writer, io.Writer) error
 type BinaryVerifier func(context.Context, string) (string, error)
 type BinarySigner func(context.Context, string) error
+type CodeSignatureVerifier func(context.Context, string) (bool, error)
+type ChecksumSignatureVerifier func(context.Context, []byte, []byte) error
 
 type GitHubClientConfig struct {
-	APIBase    string
-	HTTPClient *http.Client
+	APIBase          string
+	HTTPClient       *http.Client
+	MaxDownloadBytes int64
 }
 
 type GitHubClient struct {
-	apiBase string
-	http    *http.Client
+	apiBase          string
+	http             *http.Client
+	maxDownloadBytes int64
 }
 
 func NewGitHubClient(cfg GitHubClientConfig) *GitHubClient {
@@ -105,9 +120,13 @@ func NewGitHubClient(cfg GitHubClientConfig) *GitHubClient {
 	}
 	httpClient := cfg.HTTPClient
 	if httpClient == nil {
-		httpClient = http.DefaultClient
+		httpClient = &http.Client{Timeout: defaultHTTPClientTimeout}
 	}
-	return &GitHubClient{apiBase: apiBase, http: httpClient}
+	maxDownloadBytes := cfg.MaxDownloadBytes
+	if maxDownloadBytes <= 0 {
+		maxDownloadBytes = defaultMaxDownloadBytes
+	}
+	return &GitHubClient{apiBase: apiBase, http: httpClient, maxDownloadBytes: maxDownloadBytes}
 }
 
 func (c *GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
@@ -150,9 +169,15 @@ func (c *GitHubClient) Download(ctx context.Context, url string) ([]byte, error)
 		return nil, fmt.Errorf("download %s: server returned %s", url, resp.Status)
 	}
 
-	raw, err := io.ReadAll(resp.Body)
+	if resp.ContentLength > c.maxDownloadBytes {
+		return nil, fmt.Errorf("download %s exceeds maximum download size of %d bytes", url, c.maxDownloadBytes)
+	}
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, c.maxDownloadBytes+1))
 	if err != nil {
 		return nil, fmt.Errorf("read download %s: %w", url, err)
+	}
+	if int64(len(raw)) > c.maxDownloadBytes {
+		return nil, fmt.Errorf("download %s exceeds maximum download size of %d bytes", url, c.maxDownloadBytes)
 	}
 	return raw, nil
 }
@@ -228,17 +253,19 @@ func IsDevelopmentVersion(version string) bool {
 }
 
 type Config struct {
-	CurrentVersion string
-	ExecutablePath string
-	GOOS           string
-	GOARCH         string
-	Client         ReleaseClient
-	CommandRunner  CommandRunner
-	BinaryVerifier BinaryVerifier
-	BinarySigner   BinarySigner
-	HomeDir        string
-	Env            map[string]string
-	EvalSymlinks   func(string) (string, error)
+	CurrentVersion            string
+	ExecutablePath            string
+	GOOS                      string
+	GOARCH                    string
+	Client                    ReleaseClient
+	CommandRunner             CommandRunner
+	BinaryVerifier            BinaryVerifier
+	BinarySigner              BinarySigner
+	ChecksumSignatureVerifier ChecksumSignatureVerifier
+	RequireChecksumSignature  bool
+	HomeDir                   string
+	Env                       map[string]string
+	EvalSymlinks              func(string) (string, error)
 }
 
 type Service struct {
@@ -263,15 +290,16 @@ const (
 )
 
 type Replacement struct {
-	Target       string
-	Binary       []byte
-	Mode         os.FileMode
-	GOOS         string
-	Context      context.Context
-	StartProcess ProcessStarter
-	Verify       BinaryVerifier
-	Sign         BinarySigner
-	AfterReplace func(context.Context, string) error
+	Target                string
+	Binary                []byte
+	Mode                  os.FileMode
+	GOOS                  string
+	Context               context.Context
+	StartProcess          ProcessStarter
+	Verify                BinaryVerifier
+	Sign                  BinarySigner
+	CodeSignatureVerifier CodeSignatureVerifier
+	AfterReplace          func(context.Context, string) error
 }
 
 type Status struct {
@@ -288,6 +316,7 @@ type Status struct {
 }
 
 func NewService(cfg Config) *Service {
+	checksumSignatureVerifierConfigured := cfg.ChecksumSignatureVerifier != nil
 	if cfg.GOOS == "" {
 		cfg.GOOS = runtime.GOOS
 	}
@@ -305,6 +334,12 @@ func NewService(cfg Config) *Service {
 	}
 	if cfg.BinarySigner == nil {
 		cfg.BinarySigner = signBinary
+	}
+	if cfg.ChecksumSignatureVerifier == nil {
+		cfg.ChecksumSignatureVerifier = VerifyChecksumSignature
+	}
+	if !cfg.RequireChecksumSignature {
+		cfg.RequireChecksumSignature = checksumSignatureVerifierConfigured || checksumSignaturePublicKeyConfigured()
 	}
 	return &Service{cfg: cfg}
 }
@@ -441,19 +476,32 @@ func (s *Service) applyReleaseUpdate(ctx context.Context, status Status, release
 		}
 	}
 
-	assets, err := SelectReleaseAssets(release, s.cfg.GOOS, s.cfg.GOARCH)
-	if err != nil {
-		status.Action = ActionRefused
-		status.Message = err.Error()
-		return status, err
-	}
-	archive, err := s.cfg.Client.Download(ctx, assets.Archive.BrowserDownloadURL)
+	assets, err := selectReleaseAssets(release, s.cfg.GOOS, s.cfg.GOARCH, s.cfg.RequireChecksumSignature)
 	if err != nil {
 		status.Action = ActionRefused
 		status.Message = err.Error()
 		return status, err
 	}
 	checksums, err := s.cfg.Client.Download(ctx, assets.Checksum.BrowserDownloadURL)
+	if err != nil {
+		status.Action = ActionRefused
+		status.Message = err.Error()
+		return status, err
+	}
+	if s.cfg.RequireChecksumSignature {
+		checksumSignature, err := s.cfg.Client.Download(ctx, assets.ChecksumSignature.BrowserDownloadURL)
+		if err != nil {
+			status.Action = ActionRefused
+			status.Message = err.Error()
+			return status, err
+		}
+		if err := s.cfg.ChecksumSignatureVerifier(ctx, checksums, checksumSignature); err != nil {
+			status.Action = ActionRefused
+			status.Message = err.Error()
+			return status, err
+		}
+	}
+	archive, err := s.cfg.Client.Download(ctx, assets.Archive.BrowserDownloadURL)
 	if err != nil {
 		status.Action = ActionRefused
 		status.Message = err.Error()
@@ -607,6 +655,10 @@ func CompareVersions(a string, b string) (int, error) {
 }
 
 func SelectReleaseAssets(release Release, goos string, goarch string) (ReleaseAssets, error) {
+	return selectReleaseAssets(release, goos, goarch, true)
+}
+
+func selectReleaseAssets(release Release, goos string, goarch string, requireChecksumSignature bool) (ReleaseAssets, error) {
 	archiveNames := archiveAssetNames(release.TagName, goos, goarch)
 	checksumNames := checksumAssetNames(release.TagName)
 
@@ -614,11 +666,14 @@ func SelectReleaseAssets(release Release, goos string, goarch string) (ReleaseAs
 	if !ok {
 		return ReleaseAssets{}, fmt.Errorf("release %s does not include an archive for %s/%s", release.TagName, goos, goarch)
 	}
-	checksum, ok := assetByName(release.Assets, checksumNames)
-	if !ok {
+	checksum, checksumSignature, checksumFound, signatureFound := checksumAssetPair(release.Assets, checksumNames)
+	if !checksumFound {
 		return ReleaseAssets{}, fmt.Errorf("release %s does not include a checksum asset", release.TagName)
 	}
-	return ReleaseAssets{Archive: archive, Checksum: checksum}, nil
+	if requireChecksumSignature && !signatureFound {
+		return ReleaseAssets{}, fmt.Errorf("release %s does not include a minisign signature for checksum asset %s", release.TagName, checksum.Name)
+	}
+	return ReleaseAssets{Archive: archive, Checksum: checksum, ChecksumSignature: checksumSignature}, nil
 }
 
 func VerifyChecksum(checksums []byte, assetName string, archive []byte) error {
@@ -630,6 +685,43 @@ func VerifyChecksum(checksums []byte, assetName string, archive []byte) error {
 	actual := fmt.Sprintf("%x", sum)
 	if !strings.EqualFold(actual, expected) {
 		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", assetName, expected, actual)
+	}
+	return nil
+}
+
+func VerifyChecksumSignature(ctx context.Context, checksums []byte, signature []byte) error {
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	if err := VerifyMinisignSignature(defaultChecksumMinisignPublicKey, checksums, signature); err != nil {
+		return fmt.Errorf("verify checksum signature: %w", err)
+	}
+	return nil
+}
+
+func checksumSignaturePublicKeyConfigured() bool {
+	return strings.TrimSpace(defaultChecksumMinisignPublicKey) != ""
+}
+
+func VerifyMinisignSignature(publicKey string, message []byte, signature []byte) error {
+	keyID, ed25519PublicKey, err := parseMinisignPublicKey(publicKey)
+	if err != nil {
+		return fmt.Errorf("parse minisign public key: %w", err)
+	}
+	signatureKeyID, messageSignature, trustedComment, globalSignature, err := parseMinisignSignature(signature)
+	if err != nil {
+		return fmt.Errorf("parse minisign signature: %w", err)
+	}
+	if !bytes.Equal(signatureKeyID, keyID) {
+		return errors.New("minisign signature key id does not match pinned public key")
+	}
+
+	digest := blake2b.Sum512(message)
+	if !ed25519.Verify(ed25519PublicKey, digest[:], messageSignature) {
+		return errors.New("invalid minisign signature")
+	}
+	if !ed25519.Verify(ed25519PublicKey, minisignTrustedCommentMessage(messageSignature, trustedComment), globalSignature) {
+		return errors.New("invalid minisign trusted comment signature")
 	}
 	return nil
 }
@@ -764,12 +856,18 @@ func finalizeReplacement(replacement Replacement) error {
 		ctx = context.Background()
 	}
 	if replacement.GOOS == "darwin" {
-		signer := replacement.Sign
-		if signer == nil {
-			signer = signBinary
-		}
-		if err := signer(ctx, replacement.Target); err != nil {
+		signed, err := hasValidCodeSignature(ctx, replacement.Target, replacement.CodeSignatureVerifier)
+		if err != nil {
 			return err
+		}
+		if !signed {
+			signer := replacement.Sign
+			if signer == nil {
+				signer = signBinary
+			}
+			if err := signer(ctx, replacement.Target); err != nil {
+				return err
+			}
 		}
 	}
 	if replacement.Verify != nil {
@@ -946,6 +1044,23 @@ func signBinary(ctx context.Context, path string) error {
 		return fmt.Errorf("codesign %s: %w: %s", path, err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+func hasValidCodeSignature(ctx context.Context, path string, verifier CodeSignatureVerifier) (bool, error) {
+	if verifier != nil {
+		return verifier(ctx, path)
+	}
+	cmd := exec.CommandContext(ctx, "codesign", "--verify", "--strict", path)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return true, nil
+	}
+	text := strings.TrimSpace(string(output))
+	lower := strings.ToLower(text)
+	if strings.Contains(lower, "code object is not signed") || strings.Contains(lower, "not signed at all") {
+		return false, nil
+	}
+	return false, fmt.Errorf("verify codesign %s: %w: %s", path, err, text)
 }
 
 func outputWriter(writer io.Writer) io.Writer {
@@ -1142,6 +1257,78 @@ func expectedChecksum(checksums []byte, assetName string) (string, bool) {
 	return "", false
 }
 
+func parseMinisignPublicKey(raw string) ([]byte, ed25519.PublicKey, error) {
+	encoded := firstMinisignPayloadLine(raw)
+	if encoded == "" {
+		return nil, nil, errors.New("public key is not configured")
+	}
+	packet, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return nil, nil, err
+	}
+	if len(packet) != minisignPublicKeySize {
+		return nil, nil, fmt.Errorf("public key packet has %d bytes, want %d", len(packet), minisignPublicKeySize)
+	}
+	if string(packet[:2]) != "Ed" {
+		return nil, nil, fmt.Errorf("unsupported public key algorithm %q", packet[:2])
+	}
+	keyID := append([]byte(nil), packet[2:10]...)
+	publicKey := append(ed25519.PublicKey(nil), packet[10:]...)
+	return keyID, publicKey, nil
+}
+
+func parseMinisignSignature(raw []byte) ([]byte, []byte, string, []byte, error) {
+	lines := strings.Split(strings.ReplaceAll(string(raw), "\r\n", "\n"), "\n")
+	if len(lines) < 4 {
+		return nil, nil, "", nil, errors.New("signature file has fewer than 4 lines")
+	}
+	if !strings.HasPrefix(lines[0], "untrusted comment:") {
+		return nil, nil, "", nil, errors.New("missing untrusted comment")
+	}
+	signaturePacket, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[1]))
+	if err != nil {
+		return nil, nil, "", nil, fmt.Errorf("decode signature packet: %w", err)
+	}
+	if len(signaturePacket) != minisignSignatureSize {
+		return nil, nil, "", nil, fmt.Errorf("signature packet has %d bytes, want %d", len(signaturePacket), minisignSignatureSize)
+	}
+	if string(signaturePacket[:2]) != "ED" {
+		return nil, nil, "", nil, fmt.Errorf("unsupported signature algorithm %q", signaturePacket[:2])
+	}
+	trustedComment, ok := strings.CutPrefix(lines[2], "trusted comment: ")
+	if !ok {
+		return nil, nil, "", nil, errors.New("missing trusted comment")
+	}
+	globalSignature, err := base64.StdEncoding.DecodeString(strings.TrimSpace(lines[3]))
+	if err != nil {
+		return nil, nil, "", nil, fmt.Errorf("decode trusted comment signature: %w", err)
+	}
+	if len(globalSignature) != ed25519.SignatureSize {
+		return nil, nil, "", nil, fmt.Errorf("trusted comment signature has %d bytes, want %d", len(globalSignature), ed25519.SignatureSize)
+	}
+	keyID := append([]byte(nil), signaturePacket[2:10]...)
+	messageSignature := append([]byte(nil), signaturePacket[10:]...)
+	return keyID, messageSignature, trustedComment, globalSignature, nil
+}
+
+func firstMinisignPayloadLine(raw string) string {
+	for _, line := range strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "untrusted comment:") {
+			continue
+		}
+		return line
+	}
+	return ""
+}
+
+func minisignTrustedCommentMessage(signature []byte, trustedComment string) []byte {
+	message := make([]byte, 0, len(signature)+len(trustedComment))
+	message = append(message, signature...)
+	message = append(message, trustedComment...)
+	return message
+}
+
 func archiveAssetNames(tag string, goos string, goarch string) []string {
 	version := displayVersion(tag)
 	extension := nonWindowsArchiveExt
@@ -1167,6 +1354,28 @@ func checksumAssetNames(tag string) []string {
 		names = append([]string{fmt.Sprintf("%s_%s_checksums.txt", projectName, tag)}, names...)
 	}
 	return names
+}
+
+func checksumAssetPair(assets []Asset, checksumNames []string) (Asset, Asset, bool, bool) {
+	var firstChecksum Asset
+	for _, name := range checksumNames {
+		checksum, ok := assetByName(assets, []string{name})
+		if !ok {
+			continue
+		}
+		if firstChecksum.Name == "" {
+			firstChecksum = checksum
+		}
+		signature, ok := assetByName(assets, checksumSignatureAssetNames(checksum.Name))
+		if ok {
+			return checksum, signature, true, true
+		}
+	}
+	return firstChecksum, Asset{}, firstChecksum.Name != "", false
+}
+
+func checksumSignatureAssetNames(checksumName string) []string {
+	return []string{checksumName + ".minisig"}
 }
 
 func assetByName(assets []Asset, names []string) (Asset, bool) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -6,7 +6,9 @@ import (
 	"bytes"
 	"compress/gzip"
 	"context"
+	"crypto/ed25519"
 	"crypto/sha256"
+	"encoding/base64"
 	"errors"
 	"fmt"
 	"io"
@@ -17,6 +19,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
+
+	"golang.org/x/crypto/blake2b"
 )
 
 func TestCompareVersions(t *testing.T) {
@@ -174,6 +179,7 @@ func TestSelectReleaseAssetsAndVerifyChecksum(t *testing.T) {
 	t.Parallel()
 
 	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
+	signatureName := "detent_1.2.4_checksums.txt.minisig"
 	archive := []byte("archive")
 	sum := sha256.Sum256(archive)
 	checksums := []byte(fmt.Sprintf("%x  %s\n", sum, archiveName))
@@ -183,6 +189,7 @@ func TestSelectReleaseAssetsAndVerifyChecksum(t *testing.T) {
 		Assets: []Asset{
 			{Name: archiveName, BrowserDownloadURL: "https://example.invalid/archive"},
 			{Name: "detent_1.2.4_checksums.txt", BrowserDownloadURL: "https://example.invalid/checksums"},
+			{Name: signatureName, BrowserDownloadURL: "https://example.invalid/checksums.minisig"},
 		},
 	}, "linux", "amd64")
 	if err != nil {
@@ -191,11 +198,168 @@ func TestSelectReleaseAssetsAndVerifyChecksum(t *testing.T) {
 	if assets.Archive.Name != archiveName {
 		t.Fatalf("Archive.Name = %q, want %q", assets.Archive.Name, archiveName)
 	}
+	if assets.ChecksumSignature.Name != signatureName {
+		t.Fatalf("ChecksumSignature.Name = %q, want %q", assets.ChecksumSignature.Name, signatureName)
+	}
 	if err := VerifyChecksum(checksums, archiveName, archive); err != nil {
 		t.Fatalf("VerifyChecksum() error = %v", err)
 	}
 	if err := VerifyChecksum(checksums, archiveName, []byte("different")); err == nil {
 		t.Fatal("VerifyChecksum() error = nil, want checksum mismatch")
+	}
+}
+
+func TestVerifyMinisignSignatureRejectsTamper(t *testing.T) {
+	t.Parallel()
+
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	keyID := []byte("12345678")
+	trustedComment := "detent checksums v1.2.4"
+	checksums := []byte("abc123  detent_1.2.4_linux_amd64.tar.gz\n")
+	minisignPublicKey := testMinisignPublicKey(publicKey, keyID)
+	signature := testMinisignSignature(t, privateKey, keyID, checksums, trustedComment)
+
+	tests := []struct {
+		name      string
+		checksums []byte
+		signature []byte
+		wantErr   string
+	}{
+		{
+			name:      "valid",
+			checksums: checksums,
+			signature: signature,
+		},
+		{
+			name:      "tampered checksums",
+			checksums: []byte("abc123  detent_1.2.4_darwin_amd64.tar.gz\n"),
+			signature: signature,
+			wantErr:   "invalid minisign signature",
+		},
+		{
+			name:      "tampered signature",
+			checksums: checksums,
+			signature: append([]byte("x"), signature[1:]...),
+			wantErr:   "parse minisign signature",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := VerifyMinisignSignature(minisignPublicKey, tt.checksums, tt.signature)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("VerifyMinisignSignature() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("VerifyMinisignSignature() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("VerifyMinisignSignature() error = %v, want %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestVerifyChecksumSignatureFailsClosedWithoutPinnedKey(t *testing.T) {
+	previous := defaultChecksumMinisignPublicKey
+	defaultChecksumMinisignPublicKey = ""
+	t.Cleanup(func() {
+		defaultChecksumMinisignPublicKey = previous
+	})
+
+	err := VerifyChecksumSignature(context.Background(), []byte("checksums"), []byte("signature"))
+	if err == nil {
+		t.Fatal("VerifyChecksumSignature() error = nil, want missing public key")
+	}
+	if !strings.Contains(err.Error(), "public key is not configured") {
+		t.Fatalf("VerifyChecksumSignature() error = %v, want missing public key", err)
+	}
+}
+
+func TestNewServiceGatesChecksumSignatureUntilConfigured(t *testing.T) {
+	previous := defaultChecksumMinisignPublicKey
+	defaultChecksumMinisignPublicKey = ""
+	t.Cleanup(func() {
+		defaultChecksumMinisignPublicKey = previous
+	})
+
+	defaultService := NewService(Config{})
+	if defaultService.cfg.RequireChecksumSignature {
+		t.Fatal("RequireChecksumSignature = true, want false without a pinned key")
+	}
+
+	injectedVerifier := NewService(Config{ChecksumSignatureVerifier: acceptChecksumSignature})
+	if !injectedVerifier.cfg.RequireChecksumSignature {
+		t.Fatal("RequireChecksumSignature = false, want true with injected verifier")
+	}
+}
+
+func TestNewGitHubClientDefaultsTransportBounds(t *testing.T) {
+	t.Parallel()
+
+	client := NewGitHubClient(GitHubClientConfig{})
+	if client.http == http.DefaultClient {
+		t.Fatal("http client = http.DefaultClient, want bounded default client")
+	}
+	if client.http.Timeout != defaultHTTPClientTimeout {
+		t.Fatalf("http Timeout = %v, want %v", client.http.Timeout, defaultHTTPClientTimeout)
+	}
+	if client.maxDownloadBytes != defaultMaxDownloadBytes {
+		t.Fatalf("maxDownloadBytes = %d, want %d", client.maxDownloadBytes, defaultMaxDownloadBytes)
+	}
+}
+
+func TestGitHubClientDownloadRejectsOversize(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = w.Write([]byte("abcd"))
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewGitHubClient(GitHubClientConfig{
+		HTTPClient:       server.Client(),
+		MaxDownloadBytes: 3,
+	})
+	_, err := client.Download(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("Download() error = nil, want oversize error")
+	}
+	if !strings.Contains(err.Error(), "exceeds maximum download size") {
+		t.Fatalf("Download() error = %v, want maximum download size", err)
+	}
+}
+
+func TestGitHubClientDownloadHonorsHTTPTimeout(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		if flusher, ok := w.(http.Flusher); ok {
+			flusher.Flush()
+		}
+		time.Sleep(100 * time.Millisecond)
+		_, _ = w.Write([]byte("late"))
+	}))
+	t.Cleanup(server.Close)
+
+	httpClient := server.Client()
+	httpClient.Timeout = 10 * time.Millisecond
+	client := NewGitHubClient(GitHubClientConfig{HTTPClient: httpClient})
+	_, err := client.Download(context.Background(), server.URL)
+	if err == nil {
+		t.Fatal("Download() error = nil, want timeout")
+	}
+	if !strings.Contains(err.Error(), "timeout") && !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Download() error = %v, want timeout", err)
 	}
 }
 
@@ -220,20 +384,24 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 
 	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
 	checksumName := "detent_1.2.4_checksums.txt"
+	signatureName := checksumName + ".minisig"
 	archive := detentUpdateArchive(t, "updated")
 	sum := sha256.Sum256(archive)
 	checksums := fmt.Sprintf("%x  %s\n", sum, archiveName)
+	signature := []byte("valid signature")
 
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		switch r.URL.Path {
 		case "/releases":
 			w.Header().Set("Content-Type", "application/json")
-			fmt.Fprintf(w, `[{"tag_name":"v1.2.4","draft":false,"prerelease":false,"assets":[{"name":"%s","browser_download_url":"%s/archive"},{"name":"%s","browser_download_url":"%s/checksums"}]}]`, archiveName, server.URL, checksumName, server.URL)
+			fmt.Fprintf(w, `[{"tag_name":"v1.2.4","draft":false,"prerelease":false,"assets":[{"name":"%s","browser_download_url":"%s/archive"},{"name":"%s","browser_download_url":"%s/checksums"},{"name":"%s","browser_download_url":"%s/checksums.minisig"}]}]`, archiveName, server.URL, checksumName, server.URL, signatureName, server.URL)
 		case "/archive":
 			_, _ = w.Write(archive)
 		case "/checksums":
 			fmt.Fprint(w, checksums)
+		case "/checksums.minisig":
+			_, _ = w.Write(signature)
 		default:
 			http.NotFound(w, r)
 		}
@@ -253,6 +421,7 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 		BinaryVerifier: func(context.Context, string) (string, error) {
 			return "version: v1.2.4\n", nil
 		},
+		ChecksumSignatureVerifier: acceptChecksumSignature,
 	})
 
 	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
@@ -271,6 +440,148 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 	}
 	if strings.TrimSpace(string(raw)) != "updated" {
 		t.Fatalf("updated binary = %q, want updated", raw)
+	}
+}
+
+func TestServiceAppliesReleaseUpdateWithoutChecksumSignatureWhenKeyMissing(t *testing.T) {
+	previous := defaultChecksumMinisignPublicKey
+	defaultChecksumMinisignPublicKey = ""
+	t.Cleanup(func() {
+		defaultChecksumMinisignPublicKey = previous
+	})
+
+	tmp := t.TempDir()
+	binary := filepath.Join(tmp, "bin", "detent")
+	lockPath := filepath.Join(tmp, "state", "install.lock")
+	if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
+		t.Fatalf("MkdirAll(binary dir) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte("binary="+binary+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(lock) error = %v", err)
+	}
+
+	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
+	checksumName := "detent_1.2.4_checksums.txt"
+	archive := detentUpdateArchive(t, "updated")
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%x  %s\n", sum, archiveName)
+	service := NewService(Config{
+		CurrentVersion: "1.2.3",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: staticReleaseClient{
+			releases: []Release{{
+				TagName: "v1.2.4",
+				Assets: []Asset{
+					{Name: archiveName, BrowserDownloadURL: "https://example.invalid/archive"},
+					{Name: checksumName, BrowserDownloadURL: "https://example.invalid/checksums"},
+				},
+			}},
+			downloads: map[string][]byte{
+				"https://example.invalid/archive":   archive,
+				"https://example.invalid/checksums": []byte(checksums),
+			},
+		},
+		Env: map[string]string{"DETENT_INSTALL_LOCK": lockPath},
+		BinaryVerifier: func(context.Context, string) (string, error) {
+			return "version: v1.2.4\n", nil
+		},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
+	if err != nil {
+		t.Fatalf("Apply() error = %v", err)
+	}
+	if status.Action != ActionUpdated {
+		t.Fatalf("Action = %q, want %q", status.Action, ActionUpdated)
+	}
+	raw, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("ReadFile(binary) error = %v", err)
+	}
+	if strings.TrimSpace(string(raw)) != "updated" {
+		t.Fatalf("updated binary = %q, want updated", raw)
+	}
+}
+
+func TestServiceRejectsBadChecksumSignatureBeforeReplacement(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	binary := filepath.Join(tmp, "bin", "detent")
+	lockPath := filepath.Join(tmp, "state", "install.lock")
+	if err := os.MkdirAll(filepath.Dir(binary), 0o755); err != nil {
+		t.Fatalf("MkdirAll(binary dir) error = %v", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(lockPath), 0o755); err != nil {
+		t.Fatalf("MkdirAll(lock dir) error = %v", err)
+	}
+	if err := os.WriteFile(binary, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(binary) error = %v", err)
+	}
+	if err := os.WriteFile(lockPath, []byte("binary="+binary+"\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(lock) error = %v", err)
+	}
+
+	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
+	checksumName := "detent_1.2.4_checksums.txt"
+	signatureName := checksumName + ".minisig"
+	archive := detentUpdateArchive(t, "updated")
+	sum := sha256.Sum256(archive)
+	checksums := fmt.Sprintf("%x  %s\n", sum, archiveName)
+
+	service := NewService(Config{
+		CurrentVersion: "1.2.3",
+		ExecutablePath: binary,
+		GOOS:           "linux",
+		GOARCH:         "amd64",
+		Client: staticReleaseClient{
+			releases: []Release{{
+				TagName: "v1.2.4",
+				Assets: []Asset{
+					{Name: archiveName, BrowserDownloadURL: "https://example.invalid/archive"},
+					{Name: checksumName, BrowserDownloadURL: "https://example.invalid/checksums"},
+					{Name: signatureName, BrowserDownloadURL: "https://example.invalid/checksums.minisig"},
+				},
+			}},
+			downloads: map[string][]byte{
+				"https://example.invalid/archive":           archive,
+				"https://example.invalid/checksums":         []byte(checksums),
+				"https://example.invalid/checksums.minisig": []byte("bad signature"),
+			},
+		},
+		Env: map[string]string{"DETENT_INSTALL_LOCK": lockPath},
+		BinaryVerifier: func(context.Context, string) (string, error) {
+			return "version: v1.2.4\n", nil
+		},
+		ChecksumSignatureVerifier: func(context.Context, []byte, []byte) error {
+			return errors.New("bad checksum signature")
+		},
+	})
+
+	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})
+	if err == nil {
+		t.Fatal("Apply() error = nil, want bad checksum signature")
+	}
+	if status.Action != ActionRefused {
+		t.Fatalf("Action = %q, want %q", status.Action, ActionRefused)
+	}
+	if !strings.Contains(status.Message, "bad checksum signature") {
+		t.Fatalf("Message = %q, want bad checksum signature", status.Message)
+	}
+	raw, err := os.ReadFile(binary)
+	if err != nil {
+		t.Fatalf("ReadFile(binary) error = %v", err)
+	}
+	if string(raw) != "old" {
+		t.Fatalf("binary = %q, want original binary", raw)
 	}
 }
 
@@ -492,12 +803,14 @@ func TestServiceGoInstallFromReleaseUsesReleaseAsset(t *testing.T) {
 
 	archiveName := "detent_1.2.4_linux_amd64.tar.gz"
 	checksumName := "detent_1.2.4_checksums.txt"
+	signatureName := checksumName + ".minisig"
 	archive := detentUpdateArchive(t, "updated")
 	sum := sha256.Sum256(archive)
 	checksums := fmt.Sprintf("%x  %s\n", sum, archiveName)
 	downloads := map[string][]byte{
-		"https://example.invalid/archive":   archive,
-		"https://example.invalid/checksums": []byte(checksums),
+		"https://example.invalid/archive":           archive,
+		"https://example.invalid/checksums":         []byte(checksums),
+		"https://example.invalid/checksums.minisig": []byte("valid signature"),
 	}
 	var stderr bytes.Buffer
 	var verifiedPath string
@@ -512,6 +825,7 @@ func TestServiceGoInstallFromReleaseUsesReleaseAsset(t *testing.T) {
 				Assets: []Asset{
 					{Name: archiveName, BrowserDownloadURL: "https://example.invalid/archive"},
 					{Name: checksumName, BrowserDownloadURL: "https://example.invalid/checksums"},
+					{Name: signatureName, BrowserDownloadURL: "https://example.invalid/checksums.minisig"},
 				},
 			}},
 			downloads: downloads,
@@ -522,6 +836,7 @@ func TestServiceGoInstallFromReleaseUsesReleaseAsset(t *testing.T) {
 			verifiedPath = path
 			return "version: v1.2.4\n", nil
 		},
+		ChecksumSignatureVerifier: acceptChecksumSignature,
 	})
 
 	status, err := service.Apply(context.Background(), ApplyOptions{
@@ -686,7 +1001,7 @@ func TestReplaceBinaryRollsBackWhenAfterReplaceFails(t *testing.T) {
 	}
 }
 
-func TestReplaceBinarySignsDarwinBeforeVerify(t *testing.T) {
+func TestReplaceBinarySignsUnsignedDarwinBeforeVerify(t *testing.T) {
 	t.Parallel()
 
 	tmp := t.TempDir()
@@ -701,6 +1016,10 @@ func TestReplaceBinarySignsDarwinBeforeVerify(t *testing.T) {
 		Binary: []byte("new"),
 		Mode:   0o755,
 		GOOS:   "darwin",
+		CodeSignatureVerifier: func(_ context.Context, path string) (bool, error) {
+			calls = append(calls, "signature:"+path)
+			return false, nil
+		},
 		Sign: func(_ context.Context, path string) error {
 			calls = append(calls, "sign:"+path)
 			return nil
@@ -713,7 +1032,44 @@ func TestReplaceBinarySignsDarwinBeforeVerify(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReplaceBinary() error = %v", err)
 	}
-	want := []string{"sign:" + target, "verify:" + target}
+	want := []string{"signature:" + target, "sign:" + target, "verify:" + target}
+	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
+		t.Fatalf("calls = %q, want %q", calls, want)
+	}
+}
+
+func TestReplaceBinaryPreservesValidDarwinSignature(t *testing.T) {
+	t.Parallel()
+
+	tmp := t.TempDir()
+	target := filepath.Join(tmp, "detent")
+	if err := os.WriteFile(target, []byte("old"), 0o755); err != nil {
+		t.Fatalf("WriteFile(target) error = %v", err)
+	}
+
+	var calls []string
+	err := ReplaceBinary(Replacement{
+		Target: target,
+		Binary: []byte("new"),
+		Mode:   0o755,
+		GOOS:   "darwin",
+		CodeSignatureVerifier: func(_ context.Context, path string) (bool, error) {
+			calls = append(calls, "signature:"+path)
+			return true, nil
+		},
+		Sign: func(context.Context, string) error {
+			t.Fatal("Sign called for a binary with a valid code signature")
+			return nil
+		},
+		Verify: func(_ context.Context, path string) (string, error) {
+			calls = append(calls, "verify:"+path)
+			return "version: v1.2.4\n", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("ReplaceBinary() error = %v", err)
+	}
+	want := []string{"signature:" + target, "verify:" + target}
 	if strings.Join(calls, "\n") != strings.Join(want, "\n") {
 		t.Fatalf("calls = %q, want %q", calls, want)
 	}
@@ -841,6 +1197,32 @@ func detentWindowsUpdateArchive(t *testing.T, content string) []byte {
 		t.Fatalf("zip Close() error = %v", err)
 	}
 	return buf.Bytes()
+}
+
+func testMinisignPublicKey(publicKey ed25519.PublicKey, keyID []byte) string {
+	packet := append([]byte("Ed"), keyID...)
+	packet = append(packet, publicKey...)
+	return base64.StdEncoding.EncodeToString(packet)
+}
+
+func testMinisignSignature(t *testing.T, privateKey ed25519.PrivateKey, keyID []byte, message []byte, trustedComment string) []byte {
+	t.Helper()
+
+	digest := blake2b.Sum512(message)
+	signature := ed25519.Sign(privateKey, digest[:])
+	packet := append([]byte("ED"), keyID...)
+	packet = append(packet, signature...)
+	globalSignature := ed25519.Sign(privateKey, append(signature, []byte(trustedComment)...))
+	return []byte(fmt.Sprintf(
+		"untrusted comment: signature from minisign secret key\n%s\ntrusted comment: %s\n%s\n",
+		base64.StdEncoding.EncodeToString(packet),
+		trustedComment,
+		base64.StdEncoding.EncodeToString(globalSignature),
+	))
+}
+
+func acceptChecksumSignature(context.Context, []byte, []byte) error {
+	return nil
 }
 
 type staticReleaseClient struct {


### PR DESCRIPTION
## Summary

- Bound self-update HTTP downloads with a default timeout and max-size reader.
- Require minisign-signed checksum assets before trusting archive checksums; fail closed until release key/signature publication is provisioned in #337.
- Preserve valid macOS code signatures and only ad-hoc sign unsigned binaries.

Fixes #324

## Test Plan

- [x] `go test ./internal/update`
- [x] `make check`