### PR TITLE
fix(project): synchronize workflow reload snapshot

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -577,11 +577,19 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 
 	p.mu.Lock()
 	projectConfig := p.cfg
+	githubToken := p.githubToken
+	connectorFactory := p.connectorFactory
+	schedulerFactory := p.schedulerFactory
+	runner := p.runner
+	projectOrchestrator := p.orchestrator
 	p.mu.Unlock()
+	if projectOrchestrator == nil {
+		return
+	}
 
 	workflow := normalizeWorkflow(update.Workflow)
 	workflow.Config = workflowConfigWithProjectIdentity(projectConfig, workflow.Config)
-	workflow.Config = workflowConfigWithGitHubToken(workflow.Config, p.githubToken)
+	workflow.Config = workflowConfigWithGitHubToken(workflow.Config, githubToken)
 	if err := workflow.Config.Validate(); err != nil {
 		p.logger.Warn("workflow reload validation failed",
 			"project_id", p.id,
@@ -591,7 +599,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		return
 	}
 
-	projectConnector, err := buildConnector(workflow.Config, p.connectorFactory)
+	projectConnector, err := buildConnector(workflow.Config, connectorFactory)
 	if err != nil {
 		p.logger.Warn("workflow reload connector failed",
 			"project_id", p.id,
@@ -601,7 +609,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		return
 	}
 
-	projectScheduler, err := buildScheduler(workflow.Config, p.schedulerFactory)
+	projectScheduler, err := buildScheduler(workflow.Config, schedulerFactory)
 	if err != nil {
 		p.logger.Warn("workflow reload scheduler failed",
 			"project_id", p.id,
@@ -611,12 +619,12 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 		return
 	}
 
-	if updater, ok := p.runner.(workflowUpdater); ok {
+	if updater, ok := runner.(workflowUpdater); ok {
 		updater.UpdateWorkflow(workflow)
 	}
 
 	runtimeConfig := projectOrchestratorConfig(projectConfig, workflow.Config)
-	if err := p.orchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
+	if err := projectOrchestrator.UpdateRuntime(ctx, orchestrator.RuntimeUpdate{
 		Config:    runtimeConfig,
 		Connector: projectConnector,
 	}); err != nil {

--- a/internal/project/project_race_test.go
+++ b/internal/project/project_race_test.go
@@ -1,0 +1,96 @@
+package project
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+)
+
+func TestHandleWorkflowUpdateDoesNotRaceWithPause(t *testing.T) {
+	t.Parallel()
+
+	reloadEntered := make(chan struct{})
+	reloadRelease := make(chan struct{})
+	var reloadEnteredOnce sync.Once
+	var connectorFactoryCalls atomic.Int32
+
+	got, err := New(Config{
+		Project: globalconfig.Project{
+			ID:     "detent",
+			Weight: 1,
+		},
+		Workflow: workflowconfig.Workflow{
+			Config: projectRaceWorkflowConfig(),
+			Prompt: "initial",
+		},
+	}, Dependencies{
+		ConnectorFactory: func(cfg workflowconfig.Config) (connector.Connector, error) {
+			if connectorFactoryCalls.Add(1) > 1 {
+				reloadEnteredOnce.Do(func() {
+					close(reloadEntered)
+				})
+				<-reloadRelease
+			}
+			return defaultConnectorFactory(cfg)
+		},
+		Runner: projectRaceBlockingRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+
+	updateDone := make(chan struct{})
+	go func() {
+		defer close(updateDone)
+		reloaded := projectRaceWorkflowConfig()
+		reloaded.Polling.IntervalMS = 60000
+		got.handleWorkflowUpdate(context.Background(), configwatcher.Update{
+			Workflow: workflowconfig.Workflow{
+				Config: reloaded,
+				Prompt: "reloaded",
+			},
+		})
+	}()
+
+	select {
+	case <-reloadEntered:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for workflow reload")
+	}
+
+	if err := got.Pause(context.Background()); err != nil {
+		t.Fatalf("Pause() error = %v", err)
+	}
+
+	close(reloadRelease)
+	select {
+	case <-updateDone:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for workflow reload to finish")
+	}
+}
+
+func projectRaceWorkflowConfig() workflowconfig.Config {
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = connector.BackendMemory.String()
+	cfg.Polling.IntervalMS = int(time.Hour / time.Millisecond)
+	return cfg
+}
+
+type projectRaceBlockingRunner struct{}
+
+func (projectRaceBlockingRunner) Run(ctx context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	<-ctx.Done()
+	return orchestrator.RunResult{}, ctx.Err()
+}


### PR DESCRIPTION
## Summary

- Snapshot lifecycle-managed workflow reload dependencies under `Project.mu`.
- Add a race test for `handleWorkflowUpdate` overlapping `Pause`.

Fixes #327

## Test Plan

- [x] `go test -race ./internal/project -run TestHandleWorkflowUpdateDoesNotRaceWithPause -count=1`
- [x] `go test -race ./internal/project -count=1`
- [x] `make check`
