### PR TITLE
fix(tooling): correct stale database paths

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -69,7 +69,7 @@ linters:
       - path: _templ\.go$
         linters:
           - all
-      - path: internal/database/sqlc/
+      - path: internal/store/sqlc/
         linters:
           - all
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -37,4 +37,4 @@
 - `make generate` runs `go generate`, Templ, sqlc, and Tailwind when their inputs exist.
 - `make setup` installs Air, Templ, sqlc, goose, and golangci-lint v2.
 - `make sqlc` uses `sqlc/sqlc.yaml` by default.
-- `make db-migrate` uses goose against `internal/database/migrations` by default.
+- `make db-migrate` uses goose against `internal/store/migrations` by default.

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ TEMPL ?= go run github.com/a-h/templ/cmd/templ@v0.3.1001
 TAILWIND_INPUT ?= static/css/input.css
 TAILWIND_OUTPUT ?= static/css/output.css
 SQLC_CONFIG ?= sqlc/sqlc.yaml
-MIGRATIONS_DIR ?= internal/database/migrations
+MIGRATIONS_DIR ?= internal/store/migrations
 GOOSE_DRIVER ?= sqlite3
 DATABASE_URL ?= tmp/detent.db
 


### PR DESCRIPTION
## Summary

- Point `db-migrate` at `internal/store/migrations` so goose finds the real migrations.
- Update the generated sqlc lint exclusion and project tooling docs to use `internal/store` paths.

Fixes #328

## Test Plan

- [x] `make db-migrate`
- [x] `rg -n --hidden --glob '!.git' 'internal/database'`
- [x] `make check`