### PR TITLE
perf(web): cache snapshot enrichment

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -30,7 +30,7 @@ func (s *Server) apiState(c echo.Context) error {
 	if !ok {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
-	snapshot = s.enrichSnapshot(c.Request().Context(), snapshot)
+	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
 
 	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now)))
 }
@@ -40,7 +40,7 @@ func (s *Server) apiIssue(c echo.Context) error {
 	if !ok {
 		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
 	}
-	snapshot = s.enrichSnapshot(c.Request().Context(), snapshot)
+	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
 
 	payload, ok := issueResponse(issueIdentifier(c), snapshot)
 	if !ok {

--- a/internal/web/budget.go
+++ b/internal/web/budget.go
@@ -3,8 +3,10 @@ package web
 import (
 	"context"
 	"log/slog"
+	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/store"
@@ -20,6 +22,66 @@ type configuredBudget struct {
 	ProjectID      string
 	PerDayMaxUSD   float64
 	PerIssueMaxUSD float64
+}
+
+type snapshotEnrichmentCache struct {
+	mu       sync.Mutex
+	cond     *sync.Cond
+	cached   bool
+	raw      telemetry.Snapshot
+	enriched telemetry.Snapshot
+	loading  bool
+}
+
+func newSnapshotEnrichmentCache() *snapshotEnrichmentCache {
+	cache := &snapshotEnrichmentCache{}
+	cache.cond = sync.NewCond(&cache.mu)
+	return cache
+}
+
+func (s *Server) cachedEnrichedSnapshot(ctx context.Context, snapshot telemetry.Snapshot) telemetry.Snapshot {
+	return s.snapshots.enrich(ctx, snapshot, s.enrichSnapshot)
+}
+
+func (c *snapshotEnrichmentCache) enrich(ctx context.Context, snapshot telemetry.Snapshot, enrich func(context.Context, telemetry.Snapshot) telemetry.Snapshot) telemetry.Snapshot {
+	if c == nil {
+		return enrich(ctx, snapshot)
+	}
+
+	c.mu.Lock()
+	for {
+		if c.cached && reflect.DeepEqual(c.raw, snapshot) {
+			enriched := c.enriched
+			c.mu.Unlock()
+			return enriched
+		}
+		if !c.loading {
+			c.loading = true
+			break
+		}
+		c.cond.Wait()
+	}
+	c.mu.Unlock()
+
+	enriched := enrich(ctx, snapshot)
+
+	if ctx != nil && ctx.Err() != nil {
+		c.mu.Lock()
+		c.loading = false
+		c.cond.Broadcast()
+		c.mu.Unlock()
+		return enriched
+	}
+
+	c.mu.Lock()
+	c.raw = snapshot
+	c.enriched = enriched
+	c.cached = true
+	c.loading = false
+	c.cond.Broadcast()
+	c.mu.Unlock()
+
+	return enriched
 }
 
 func (s *Server) enrichSnapshot(ctx context.Context, snapshot telemetry.Snapshot) telemetry.Snapshot {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -84,6 +84,7 @@ type Server struct {
 	serverAddr   string
 	assets       staticAssets
 	projects     *projectSmallMultipleRecorder
+	snapshots    *snapshotEnrichmentCache
 }
 
 func NewServer(cfg Config, deps Dependencies) (*Server, error) {
@@ -129,6 +130,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		serverAddr:   strings.TrimSpace(cfg.ServerAddress),
 		assets:       newStaticAssets(cfg.staticDir()),
 		projects:     newProjectSmallMultipleRecorder(),
+		snapshots:    newSnapshotEnrichmentCache(),
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
 	server.registerRoutes()
@@ -209,20 +211,11 @@ func (s *Server) dashboardData(ctx context.Context, snapshot telemetry.Snapshot)
 }
 
 func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
-	sub, err := s.hub.Subscribe(ctx)
-	if err != nil {
+	snapshot, ok := s.hub.Latest()
+	if !ok {
 		return s.enrichSnapshot(ctx, telemetry.Snapshot{})
 	}
-	defer sub.Close()
-
-	select {
-	case snapshot, ok := <-sub.C():
-		if ok {
-			return s.enrichSnapshot(ctx, snapshot)
-		}
-	default:
-	}
-	return s.enrichSnapshot(ctx, telemetry.Snapshot{})
+	return s.cachedEnrichedSnapshot(ctx, snapshot)
 }
 
 func (s *Server) health(c echo.Context) error {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -475,6 +476,45 @@ func TestDashboardRendersLatestSnapshot(t *testing.T) {
 	}
 }
 
+func TestDashboardReadsLatestSnapshotWithoutSubscribing(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC),
+		Running: []telemetry.Running{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-latest",
+					Identifier: "digitaldrywood/detent#329",
+					Title:      "Use latest snapshot",
+					State:      "In Progress",
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	deps.Hub.Close()
+
+	server, err := web.NewServer(web.Config{StaticDir: t.TempDir()}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Use latest snapshot") {
+		t.Fatalf("body missing latest snapshot:\n%s", rec.Body.String())
+	}
+}
+
 func TestDashboardEnrichesCycleTimeFromStore(t *testing.T) {
 	t.Parallel()
 
@@ -745,6 +785,112 @@ func TestServerEventsStreamsPublishedSnapshots(t *testing.T) {
 	}
 	if !strings.Contains(event.data, "4") {
 		t.Fatalf("snapshot event missing running count:\n%s", event.data)
+	}
+}
+
+func TestServerEventsEnrichesSnapshotOncePerPublish(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	year, month, day := generatedAt.UTC().Date()
+	budgetPeriodStart := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	budgetQueryFrom := budgetPeriodStart.AddDate(0, 0, -6)
+
+	var cycleTimeCalls atomic.Int64
+	var budgetCalls atomic.Int64
+
+	registry := project.NewRegistry()
+	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10)); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+
+	deps := testDeps(t)
+	deps.Registry = registry
+	deps.Store = storeProbe{
+		cycleTimeReport: func(context.Context) (store.CycleTimeReport, error) {
+			cycleTimeCalls.Add(1)
+			return store.CycleTimeReport{}, nil
+		},
+		budgetCostEvents: func(_ context.Context, query store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+			if query.From.Equal(budgetQueryFrom) {
+				budgetCalls.Add(1)
+			}
+			return nil, nil
+		},
+	}
+	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	first := openEventStream(t, server)
+	defer first.Close()
+	second := openEventStream(t, server)
+	defer second.Close()
+
+	if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	for _, body := range []io.Reader{first, second} {
+		event := readSSEEvent(t, body)
+		if event.name != "snapshot" {
+			t.Fatalf("event name = %q, want snapshot", event.name)
+		}
+	}
+
+	if got := cycleTimeCalls.Load(); got != 1 {
+		t.Fatalf("CycleTimeReport calls = %d, want 1", got)
+	}
+	if got := budgetCalls.Load(); got != 1 {
+		t.Fatalf("BudgetCostEvents calls = %d, want 1", got)
+	}
+}
+
+func TestSnapshotEnrichmentDoesNotCacheCanceledContext(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	var budgetCalls atomic.Int64
+
+	registry := project.NewRegistry()
+	if err := registry.Set(newBudgetTestProject(t, "detent", 100, 10)); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+
+	deps := testDeps(t)
+	deps.Registry = registry
+	deps.Store = storeProbe{
+		budgetCostEvents: func(ctx context.Context, _ store.BudgetCostQuery) ([]store.BudgetCostEvent, error) {
+			budgetCalls.Add(1)
+			if err := ctx.Err(); err != nil {
+				return nil, err
+			}
+			return nil, nil
+		},
+	}
+	if err := deps.Hub.Publish(telemetry.Snapshot{GeneratedAt: generatedAt}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil).WithContext(ctx)
+	server.Handler().ServeHTTP(rec, req)
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	budget := state["budget"].(map[string]any)
+	if reason, ok := budget["degraded_reason"]; ok {
+		t.Fatalf("budget degraded_reason = %#v, want omitted", reason)
+	}
+	if got := budgetCalls.Load(); got < 2 {
+		t.Fatalf("BudgetCostEvents calls = %d, want canceled and healthy calls", got)
 	}
 }
 
@@ -2045,6 +2191,7 @@ func boardStateCount(t *testing.T, payload map[string]any, stateName string) str
 type storeProbe struct {
 	store.Store
 
+	cycleTimeReport  func(context.Context) (store.CycleTimeReport, error)
 	budgetCostEvents func(context.Context, store.BudgetCostQuery) ([]store.BudgetCostEvent, error)
 }
 
@@ -2056,7 +2203,10 @@ func (storeProbe) UsageReport(_ context.Context, query store.UsageReportQuery) (
 	return store.UsageReport{By: query.By}, nil
 }
 
-func (storeProbe) CycleTimeReport(context.Context) (store.CycleTimeReport, error) {
+func (p storeProbe) CycleTimeReport(ctx context.Context) (store.CycleTimeReport, error) {
+	if p.cycleTimeReport != nil {
+		return p.cycleTimeReport(ctx)
+	}
 	return store.CycleTimeReport{}, nil
 }
 

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -56,7 +56,7 @@ func (s *Server) events(c echo.Context) error {
 			if !ok {
 				return nil
 			}
-			snapshot = s.enrichSnapshot(ctx, snapshot)
+			snapshot = s.cachedEnrichedSnapshot(ctx, snapshot)
 			if err := writeSSEComponent(ctx, res.Writer, sseEventSnapshot, templates.SnapshotView(s.dashboardData(ctx, snapshot))); err != nil {
 				return err
 			}


### PR DESCRIPTION
## Summary

- Cache web snapshot enrichment per snapshot so SSE subscribers and API/dashboard readers reuse the same store-backed cycle-time and budget data.
- Read the dashboard snapshot with `hub.Latest()` instead of creating a temporary subscription.
- Add regression tests for SSE enrichment query counts, dashboard latest reads, and canceled-context cache poisoning.

Fixes #329

## Test Plan

- [x] `go test ./internal/web`
- [x] `make check`