### PR TITLE
fix(runtime): harden retry subprocess waits

### DIFF
--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
-	"math"
 	"sync"
 	"time"
 )
@@ -136,12 +135,14 @@ func (s *Supervisor) RetryDelay(attempt int) time.Duration {
 	if attempt < 1 {
 		attempt = 1
 	}
-	exponent := attempt - 1
-	if exponent > 30 {
-		exponent = 30
-	}
 
-	delay := failureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
+	delay := failureRetryBaseDelay
+	for range attempt - 1 {
+		if delay >= maxRetryBackoff || delay > maxRetryBackoff/2 {
+			return maxRetryBackoff
+		}
+		delay *= 2
+	}
 	if delay > maxRetryBackoff {
 		return maxRetryBackoff
 	}

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -75,6 +75,76 @@ func TestSupervisorAppliesCappedBackoffForRunnerErrors(t *testing.T) {
 	}
 }
 
+func TestSupervisorRetryDelayNeverOverflows(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		baseDelay time.Duration
+		maxDelay  time.Duration
+		attempt   int
+		want      time.Duration
+	}{
+		{
+			name:      "first attempt uses base delay",
+			baseDelay: 10 * time.Second,
+			maxDelay:  5 * time.Minute,
+			attempt:   1,
+			want:      10 * time.Second,
+		},
+		{
+			name:      "negative attempt uses first attempt",
+			baseDelay: 10 * time.Second,
+			maxDelay:  5 * time.Minute,
+			attempt:   -10,
+			want:      10 * time.Second,
+		},
+		{
+			name:      "caps before default backoff can overflow",
+			baseDelay: 10 * time.Second,
+			maxDelay:  5 * time.Minute,
+			attempt:   31,
+			want:      5 * time.Minute,
+		},
+		{
+			name:      "large attempt stays capped",
+			baseDelay: time.Nanosecond,
+			maxDelay:  time.Duration(1<<63 - 1),
+			attempt:   int(^uint(0) >> 1),
+			want:      time.Duration(1<<63 - 1),
+		},
+		{
+			name:      "near max duration multiplication caps",
+			baseDelay: time.Duration(1<<62 + 1),
+			maxDelay:  time.Duration(1<<63 - 1),
+			attempt:   2,
+			want:      time.Duration(1<<63 - 1),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			supervisor, err := NewSupervisor(errorBackend{}, SupervisorConfig{
+				FailureRetryBaseDelay: tt.baseDelay,
+				MaxRetryBackoff:       tt.maxDelay,
+			})
+			if err != nil {
+				t.Fatalf("NewSupervisor() error = %v", err)
+			}
+
+			got := supervisor.RetryDelay(tt.attempt)
+			if got != tt.want {
+				t.Fatalf("RetryDelay(%d) = %s, want %s", tt.attempt, got, tt.want)
+			}
+			if got < 0 {
+				t.Fatalf("RetryDelay(%d) = %s, want non-negative duration", tt.attempt, got)
+			}
+		})
+	}
+}
+
 func TestSupervisorUpdateConfigChangesRetryDelay(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -498,6 +498,9 @@ func (l *LocalGit) runHook(ctx context.Context, name string, command string, inf
 	if err == nil {
 		return nil
 	}
+	if errors.Is(err, exec.ErrWaitDelay) && hookCtx.Err() == nil {
+		return nil
+	}
 
 	exitCode := -1
 	var exitErr *exec.ExitError

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -20,6 +20,7 @@ import (
 const KindLocalGit = "local_git"
 
 const defaultHookTimeout = time.Minute
+const workspaceCommandWaitDelay = time.Second
 
 var (
 	ErrHookFailed         = errors.New("workspace hook failed")
@@ -489,6 +490,7 @@ func (l *LocalGit) runHook(ctx context.Context, name string, command string, inf
 	cmd := commandshell.Command(hookCtx, command, l.hooks.Shell)
 	cmd.Dir = info.Path
 	cmd.Env = hookEnv(info, issue)
+	cmd.WaitDelay = workspaceCommandWaitDelay
 
 	l.logger.Info("running workspace hook", slog.String("hook", name), slog.String("path", info.Path))
 
@@ -526,6 +528,7 @@ func runGitAtWithEnv(ctx context.Context, dir string, env []string, args ...stri
 	gitArgs := append([]string{"git", "-C", dir}, args...)
 	cmd := exec.CommandContext(ctx, "git")
 	cmd.Args = gitArgs
+	cmd.WaitDelay = workspaceCommandWaitDelay
 	if len(env) > 0 {
 		cmd.Env = append(os.Environ(), env...)
 	}

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,8 @@ package workspace
 import (
 	"context"
 	"errors"
+	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -213,6 +215,76 @@ func TestLocalGitHooksUseConfiguredShell(t *testing.T) {
 	}
 	if got := readFile(t, tracePath); got != "ok\n" {
 		t.Fatalf("hook trace = %q, want ok", got)
+	}
+}
+
+func TestRunGitAtWithEnvCancellationReturnsPromptly(t *testing.T) {
+	skipWindows(t)
+
+	binDir := filepath.Join(t.TempDir(), "bin")
+	if err := os.MkdirAll(binDir, 0o700); err != nil {
+		t.Fatalf("mkdir bin: %v", err)
+	}
+	gitPath := filepath.Join(binDir, "git")
+	gitScript := "#!/bin/sh\nsleep 4 &\nwait\n"
+	if err := os.WriteFile(gitPath, []byte(gitScript), 0o700); err != nil {
+		t.Fatalf("write fake git: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Millisecond)
+	defer cancel()
+
+	started := time.Now()
+	_, err := runGitAtWithEnv(ctx, t.TempDir(), nil, "status")
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatal("runGitAtWithEnv() error = nil, want cancellation error")
+	}
+	var commandErr *CommandError
+	if !errors.As(err, &commandErr) {
+		t.Fatalf("runGitAtWithEnv() error = %T, want *CommandError", err)
+	}
+	if !errors.Is(commandErr.Err, context.DeadlineExceeded) {
+		t.Fatalf("CommandError.Err = %v, want context deadline exceeded", commandErr.Err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("runGitAtWithEnv() elapsed = %s, want cancellation within wait delay", elapsed)
+	}
+}
+
+func TestLocalGitHookCancellationReturnsPromptly(t *testing.T) {
+	skipWindows(t)
+
+	workspacePath := t.TempDir()
+	backend := &LocalGit{
+		hooks:  Hooks{Timeout: 20 * time.Millisecond},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	started := time.Now()
+	err := backend.runHook(
+		context.Background(),
+		"before_run",
+		"sleep 4 & wait",
+		Info{Path: workspacePath, Key: "DD-HOOK", Branch: "detent/dd-hook"},
+		Issue{Identifier: "DD-HOOK"},
+	)
+	elapsed := time.Since(started)
+
+	if err == nil {
+		t.Fatal("runHook() error = nil, want cancellation error")
+	}
+	var hookErr *HookError
+	if !errors.As(err, &hookErr) {
+		t.Fatalf("runHook() error = %T, want *HookError", err)
+	}
+	if !errors.Is(hookErr.Err, context.DeadlineExceeded) {
+		t.Fatalf("HookError.Err = %v, want context deadline exceeded", hookErr.Err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("runHook() elapsed = %s, want cancellation within wait delay", elapsed)
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -288,6 +288,33 @@ func TestLocalGitHookCancellationReturnsPromptly(t *testing.T) {
 	}
 }
 
+func TestLocalGitHookAllowsDaemonizedSuccess(t *testing.T) {
+	skipWindows(t)
+
+	workspacePath := t.TempDir()
+	backend := &LocalGit{
+		hooks:  Hooks{Timeout: 3 * time.Second},
+		logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	started := time.Now()
+	err := backend.runHook(
+		context.Background(),
+		"before_run",
+		"sleep 4 &",
+		Info{Path: workspacePath, Key: "DD-HOOK", Branch: "detent/dd-hook"},
+		Issue{Identifier: "DD-HOOK"},
+	)
+	elapsed := time.Since(started)
+
+	if err != nil {
+		t.Fatalf("runHook() error = %v, want nil", err)
+	}
+	if elapsed > 2*time.Second {
+		t.Fatalf("runHook() elapsed = %s, want daemonized hook within wait delay", elapsed)
+	}
+}
+
 func TestLocalGitCreateReusesExistingWorktreeWithoutAfterCreate(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)


### PR DESCRIPTION
## Summary

- Clamp supervisor retry backoff multiplication before it can overflow `time.Duration`.
- Set `WaitDelay` on workspace git and hook subprocesses so cancelled commands return promptly when descendants keep pipes open.
- Preserve successful daemonized hooks that hit `exec.ErrWaitDelay` without cancellation.
- Add regression coverage for large retry attempts and wedged git/hook subprocess cancellation.

Fixes #331

## Test Plan

- [x] `go test ./internal/runner -run TestSupervisorRetryDelayNeverOverflows`
- [x] `go test ./internal/workspace -run 'TestRunGitAtWithEnvCancellationReturnsPromptly|TestLocalGitHookCancellationReturnsPromptly|TestLocalGitHookAllowsDaemonizedSuccess'`
- [x] `go test ./internal/runner ./internal/workspace`
- [x] `make check`