### PR TITLE
fix(concurrency): harden shared update paths

### DIFF
--- a/internal/config/watcher/watcher.go
+++ b/internal/config/watcher/watcher.go
@@ -3,14 +3,8 @@ package watcher
 import (
 	"context"
 	"errors"
-	"fmt"
 	"log/slog"
-	"path/filepath"
-	"reflect"
-	"strings"
 	"time"
-
-	"github.com/fsnotify/fsnotify"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 )
@@ -34,11 +28,7 @@ type Update struct {
 type Option func(*options)
 
 type Watcher struct {
-	path     string
-	dir      string
-	debounce time.Duration
-	loader   Loader
-	logger   *slog.Logger
+	file *FileWatcher[workflowconfig.Workflow]
 }
 
 type options struct {
@@ -48,16 +38,6 @@ type options struct {
 }
 
 func New(path string, opts ...Option) (*Watcher, error) {
-	path = strings.TrimSpace(path)
-	if path == "" {
-		return nil, ErrMissingPath
-	}
-
-	absolute, err := filepath.Abs(path)
-	if err != nil {
-		return nil, fmt.Errorf("resolve workflow watch path: %w", err)
-	}
-
 	cfg := options{
 		debounce: defaultDebounce,
 		loader:   workflowconfig.LoadWorkflow,
@@ -76,13 +56,18 @@ func New(path string, opts ...Option) (*Watcher, error) {
 		cfg.logger = slog.Default()
 	}
 
-	return &Watcher{
-		path:     filepath.Clean(absolute),
-		dir:      filepath.Dir(absolute),
-		debounce: cfg.debounce,
-		loader:   cfg.loader,
-		logger:   cfg.logger,
-	}, nil
+	file, err := NewFile(path, func(path string) (workflowconfig.Workflow, error) {
+		workflow, err := cfg.loader(path)
+		if err == nil {
+			err = workflow.Config.Validate()
+		}
+		return workflow, err
+	}, WithFileDebounce(cfg.debounce), WithFileLogger(cfg.logger))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Watcher{file: file}, nil
 }
 
 func WithDebounce(debounce time.Duration) Option {
@@ -108,122 +93,29 @@ func (w *Watcher) Watch(ctx context.Context) (<-chan Update, error) {
 		ctx = context.Background()
 	}
 
-	fsWatcher, err := fsnotify.NewWatcher()
+	fileUpdates, err := w.file.Watch(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("create workflow watcher: %w", err)
-	}
-	if err := fsWatcher.Add(w.dir); err != nil {
-		closeErr := fsWatcher.Close()
-		return nil, errors.Join(fmt.Errorf("watch workflow directory: %w", err), closeErr)
+		return nil, err
 	}
 
 	updates := make(chan Update, 1)
-	go w.run(ctx, fsWatcher, updates)
-	return updates, nil
-}
-
-func (w *Watcher) run(ctx context.Context, fsWatcher *fsnotify.Watcher, updates chan<- Update) {
-	defer close(updates)
-	defer func() {
-		if err := fsWatcher.Close(); err != nil {
-			w.logger.Warn("close workflow watcher failed", "path", w.path, "error", err)
+	go func() {
+		defer close(updates)
+		for update := range fileUpdates {
+			mapped := Update{
+				Path:     update.Path,
+				Workflow: update.Value,
+				Err:      update.Err,
+				At:       update.At,
+			}
+			select {
+			case updates <- mapped:
+			case <-ctx.Done():
+				return
+			}
 		}
 	}()
-
-	timer := time.NewTimer(w.debounce)
-	if !timer.Stop() {
-		<-timer.C
-	}
-	var timerC <-chan time.Time
-	var lastUpdate *Update
-
-	for {
-		select {
-		case <-ctx.Done():
-			return
-		case event, ok := <-fsWatcher.Events:
-			if !ok {
-				return
-			}
-			if w.matches(event) {
-				resetTimer(timer, w.debounce)
-				timerC = timer.C
-			}
-		case err, ok := <-fsWatcher.Errors:
-			if !ok {
-				return
-			}
-			w.send(ctx, updates, Update{Path: w.path, Err: err, At: time.Now()})
-		case <-timerC:
-			timerC = nil
-			update := w.reload(ctx)
-			if sameUpdate(update, lastUpdate) {
-				continue
-			}
-			w.send(ctx, updates, update)
-			last := update
-			lastUpdate = &last
-		}
-	}
-}
-
-func (w *Watcher) matches(event fsnotify.Event) bool {
-	if event.Op&(fsnotify.Create|fsnotify.Write|fsnotify.Rename|fsnotify.Remove) == 0 {
-		return false
-	}
-	return filepath.Clean(event.Name) == w.path
-}
-
-func (w *Watcher) reload(ctx context.Context) Update {
-	update := Update{
-		Path: w.path,
-		At:   time.Now(),
-	}
-
-	workflow, err := w.load(ctx)
-	if err != nil {
-		update.Err = err
-	} else {
-		update.Workflow = workflow
-	}
-
-	return update
-}
-
-func (w *Watcher) load(ctx context.Context) (workflowconfig.Workflow, error) {
-	workflow, err := w.loadOnce()
-	if err == nil {
-		return workflow, nil
-	}
-	lastErr := err
-
-	deadline := time.NewTimer(w.debounce)
-	defer deadline.Stop()
-	retry := time.NewTicker(retryInterval(w.debounce))
-	defer retry.Stop()
-
-	for {
-		select {
-		case <-ctx.Done():
-			return workflowconfig.Workflow{}, ctx.Err()
-		case <-deadline.C:
-			return workflowconfig.Workflow{}, lastErr
-		case <-retry.C:
-			workflow, err := w.loadOnce()
-			if err == nil {
-				return workflow, nil
-			}
-			lastErr = err
-		}
-	}
-}
-
-func (w *Watcher) loadOnce() (workflowconfig.Workflow, error) {
-	workflow, err := w.loader(w.path)
-	if err == nil {
-		err = workflow.Config.Validate()
-	}
-	return workflow, err
+	return updates, nil
 }
 
 func retryInterval(debounce time.Duration) time.Duration {
@@ -231,26 +123,6 @@ func retryInterval(debounce time.Duration) time.Duration {
 		return debounce
 	}
 	return reloadRetryInterval
-}
-
-func (w *Watcher) send(ctx context.Context, updates chan<- Update, update Update) {
-	select {
-	case updates <- update:
-	case <-ctx.Done():
-	}
-}
-
-func sameUpdate(update Update, last *Update) bool {
-	if last == nil || update.Path != last.Path {
-		return false
-	}
-	if (update.Err == nil) != (last.Err == nil) {
-		return false
-	}
-	if update.Err != nil {
-		return update.Err.Error() == last.Err.Error()
-	}
-	return reflect.DeepEqual(update.Workflow, last.Workflow)
 }
 
 func resetTimer(timer *time.Timer, debounce time.Duration) {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -1147,8 +1147,8 @@ func (c *Connector) populateBlockerReasons(ctx context.Context, issues []connect
 }
 
 func (c *Connector) fetchIssueComments(ctx context.Context, ref issueRef) ([]issueComment, error) {
-	var response []restComment
-	if err := c.client.REST(ctx, http.MethodGet, restIssueCommentsListPath(ref), nil, &response); err != nil {
+	response, err := fetchRESTList[restComment](ctx, c.client, restIssueCommentsListPath(ref))
+	if err != nil {
 		return nil, err
 	}
 	comments := make([]issueComment, 0, len(response))
@@ -1443,20 +1443,20 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 }
 
 func (c *Connector) fetchPullRequestCIState(ctx context.Context, repo pullRequestRepo, sha string) (string, error) {
-	var checkRuns restCheckRuns
-	if err := c.client.REST(ctx, http.MethodGet, restCommitCheckRunsPath(repo, sha), nil, &checkRuns); err != nil {
+	checkRuns, err := fetchRESTCheckRuns(ctx, c.client, restCommitCheckRunsPath(repo, sha))
+	if err != nil {
 		return "", fmt.Errorf("fetch github check runs: %w", err)
 	}
-	var statuses []restCommitStatus
-	if err := c.client.REST(ctx, http.MethodGet, restCommitStatusesPath(repo, sha), nil, &statuses); err != nil {
+	statuses, err := fetchRESTList[restCommitStatus](ctx, c.client, restCommitStatusesPath(repo, sha))
+	if err != nil {
 		return "", fmt.Errorf("fetch github commit statuses: %w", err)
 	}
-	return combinedCIState(checkRunsState(checkRuns.CheckRuns), commitStatusesState(statuses)), nil
+	return combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses)), nil
 }
 
 func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int, headSHA string) ([]pullRequestReview, error) {
-	var response []restReview
-	if err := c.client.REST(ctx, http.MethodGet, restPullRequestReviewsPath(repo, number), nil, &response); err != nil {
+	response, err := fetchRESTList[restReview](ctx, c.client, restPullRequestReviewsPath(repo, number))
+	if err != nil {
 		return nil, fmt.Errorf("fetch github pull request reviews: %w", err)
 	}
 	review, ok := latestCodexReview(response, headSHA)
@@ -2425,6 +2425,40 @@ func restCommitStatusesPath(repo pullRequestRepo, sha string) string {
 	values := url.Values{}
 	values.Set("per_page", "100")
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/commits/" + url.PathEscape(sha) + "/statuses?" + values.Encode()
+}
+
+func fetchRESTList[T any](ctx context.Context, client *Client, path string) ([]T, error) {
+	values := []T{}
+	for path != "" {
+		var page []T
+		headers, err := client.rest(ctx, http.MethodGet, path, nil, &page)
+		if err != nil {
+			return nil, err
+		}
+		values = append(values, page...)
+		path, err = client.nextRESTPage(headers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return values, nil
+}
+
+func fetchRESTCheckRuns(ctx context.Context, client *Client, path string) ([]restCheckRun, error) {
+	checkRuns := []restCheckRun{}
+	for path != "" {
+		var page restCheckRuns
+		headers, err := client.rest(ctx, http.MethodGet, path, nil, &page)
+		if err != nil {
+			return nil, err
+		}
+		checkRuns = append(checkRuns, page.CheckRuns...)
+		path, err = client.nextRESTPage(headers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return checkRuns, nil
 }
 
 func githubIssueNodeFromREST(ref issueRef, issue restIssue) githubIssueNode {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -483,6 +483,80 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 	}
 }
 
+func TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_182","content":{"__typename":"Issue","id":"I_182","number":182,"title":"First issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/182","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-187"}}]`,
+		},
+		{
+			method:  http.MethodGet,
+			path:    "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100",
+			headers: map[string]string{"Link": `</repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100&page=2>; rel="next"`},
+			body:    `{"check_runs":[]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100&page=2",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method:  http.MethodGet,
+			path:    "/repos/digitaldrywood/detent/commits/sha-187/statuses?per_page=100",
+			headers: map[string]string{"Link": `</repos/digitaldrywood/detent/commits/sha-187/statuses?per_page=100&page=2>; rel="next"`},
+			body:    `[{"context":"ci/build","state":"success","created_at":"2026-06-05T11:00:00Z"}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-187/statuses?per_page=100&page=2",
+			body:   `[{"context":"ci/build","state":"failure","created_at":"2026-06-05T12:00:00Z"}]`,
+		},
+		{
+			method:  http.MethodGet,
+			path:    "/repos/digitaldrywood/detent/pulls/187/reviews?per_page=100",
+			headers: map[string]string{"Link": `</repos/digitaldrywood/detent/pulls/187/reviews?per_page=100&page=2>; rel="next"`},
+			body:    `[{"body":"No blocking findings.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-187","submitted_at":"2026-06-05T10:00:00Z"}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/187/reviews?per_page=100&page=2",
+			body:   `[{"body":"[P1] Later paged finding.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-187","submitted_at":"2026-06-05T12:00:00Z"}]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+	})
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
+	}
+
+	pr := got[0].PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want matching PR")
+	}
+	if pr.CIStatus != "fail" || pr.CodexReviewState != "P1" {
+		t.Fatalf("PullRequest status = CI %q review %q, want fail/P1", pr.CIStatus, pr.CodexReviewState)
+	}
+
+	requests := server.requests()
+	if len(requests) != 8 {
+		t.Fatalf("request count = %d, want project query plus paged PR REST requests", len(requests))
+	}
+}
+
 func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	t.Parallel()
 
@@ -652,8 +726,14 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadHumanActionNeeded(t *testing
 			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw98","number":98,"title":"Homebrew tap","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/98","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Blocked"},"priorityValue":null}]}}}}`,
 		},
 		{
+			method:  http.MethodGet,
+			path:    "/repos/digitaldrywood/detent/issues/98/comments?per_page=100",
+			headers: map[string]string{"Link": `</repos/digitaldrywood/detent/issues/98/comments?per_page=100&page=2>; rel="next"`},
+			body:    `[]`,
+		},
+		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/issues/98/comments?per_page=100",
+			path:   "/repos/digitaldrywood/detent/issues/98/comments?per_page=100&page=2",
 			body:   `[{"body":"## Codex Workpad\n\n### Plan\n- Check prerequisites.\n\n### Human Action Needed\n- Create public repository ` + "`" + `digitaldrywood/homebrew-tap` + "`" + `.\n- Add repository Actions secret ` + "`" + `HOMEBREW_TAP_GITHUB_TOKEN` + "`" + `.\n\n### Validation Evidence\n- Not run."}]`,
 		},
 	})
@@ -676,8 +756,8 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadHumanActionNeeded(t *testing
 	}
 
 	requests := server.requests()
-	if len(requests) != 2 {
-		t.Fatalf("request count = %d, want 2", len(requests))
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
 	}
 	if strings.Contains(requests[0]["query"].(string), "comments") {
 		t.Fatalf("project query = %q, want no comments", requests[0]["query"])
@@ -1488,6 +1568,7 @@ type graphqlTestResponse struct {
 	status  int
 	method  string
 	path    string
+	headers map[string]string
 	body    string
 	release <-chan struct{}
 }
@@ -1551,6 +1632,9 @@ func (s *graphqlTestServer) serveHTTP(w http.ResponseWriter, r *http.Request) {
 		status = http.StatusOK
 	}
 	w.Header().Set("Content-Type", "application/json")
+	for key, value := range response.headers {
+		w.Header().Set(key, value)
+	}
 	w.WriteHeader(status)
 	_, _ = w.Write([]byte(response.body))
 }

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -172,31 +172,36 @@ func (c *Client) GraphQLWithType(ctx context.Context, queryType string, query st
 }
 
 func (c *Client) REST(ctx context.Context, method string, path string, body any, out any) error {
+	_, err := c.rest(ctx, method, path, body, out)
+	return err
+}
+
+func (c *Client) rest(ctx context.Context, method string, path string, body any, out any) (http.Header, error) {
 	token, err := c.tokenSource.Token(ctx)
 	if err != nil {
-		return fmt.Errorf("resolve github token: %w", err)
+		return nil, fmt.Errorf("resolve github token: %w", err)
 	}
 	token = strings.TrimSpace(token)
 	if token == "" {
-		return ErrMissingToken
+		return nil, ErrMissingToken
 	}
 
 	var requestBody io.Reader
 	if body != nil {
 		var encoded bytes.Buffer
 		if err := json.NewEncoder(&encoded).Encode(body); err != nil {
-			return fmt.Errorf("encode github rest request: %w", err)
+			return nil, fmt.Errorf("encode github rest request: %w", err)
 		}
 		requestBody = &encoded
 	}
 
 	url, err := c.restURL(path)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
 	if err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -209,9 +214,9 @@ func (c *Client) REST(ctx context.Context, method string, path string, body any,
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return ctxErr
+			return nil, ctxErr
 		}
-		return fmt.Errorf("%w: %w", ErrTransient, err)
+		return nil, fmt.Errorf("%w: %w", ErrTransient, err)
 	}
 	defer func() {
 		if err := drainAndClose(resp.Body); err != nil {
@@ -222,21 +227,22 @@ func (c *Client) REST(ctx context.Context, method string, path string, body any,
 	c.logger.DebugContext(ctx, "github rest response", "method", method, "path", path, "status", resp.StatusCode, "live_connections", c.LiveConnections())
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+		return nil, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return classifyStatus(resp.StatusCode, resp.Header, raw)
+		return nil, classifyStatus(resp.StatusCode, resp.Header, raw)
 	}
+	headers := resp.Header.Clone()
 	if out == nil || resp.StatusCode == http.StatusNoContent {
-		return nil
+		return headers, nil
 	}
 	if len(raw) == 0 {
-		return ErrInvalidResponse
+		return nil, ErrInvalidResponse
 	}
 	if err := json.Unmarshal(raw, out); err != nil {
-		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+		return nil, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
 	}
-	return nil
+	return headers, nil
 }
 
 func (c *Client) GraphQLRateLimit() (connector.GraphQLRateLimit, bool) {
@@ -504,6 +510,93 @@ func (c *Client) restURL(path string) (string, error) {
 	parsed.Path = strings.TrimRight(parsed.Path, "/") + relative.Path
 	parsed.RawQuery = relative.RawQuery
 	return parsed.String(), nil
+}
+
+func (c *Client) nextRESTPage(headers http.Header) (string, error) {
+	link := nextRESTLink(headers)
+	if link == "" {
+		return "", nil
+	}
+	return c.restPath(link)
+}
+
+func nextRESTLink(headers http.Header) string {
+	for _, value := range headers.Values("Link") {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if !strings.HasPrefix(part, "<") {
+				continue
+			}
+			end := strings.Index(part, ">")
+			if end <= 1 {
+				continue
+			}
+			if linkHasRelNext(part[end+1:]) {
+				return strings.TrimSpace(part[1:end])
+			}
+		}
+	}
+	return ""
+}
+
+func linkHasRelNext(params string) bool {
+	for _, param := range strings.Split(params, ";") {
+		key, value, ok := strings.Cut(strings.TrimSpace(param), "=")
+		if !ok || !strings.EqualFold(strings.TrimSpace(key), "rel") {
+			continue
+		}
+		if strings.EqualFold(strings.Trim(strings.TrimSpace(value), `"`), "next") {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *Client) restPath(value string) (string, error) {
+	parsed, err := url.Parse(strings.TrimSpace(value))
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	if !parsed.IsAbs() {
+		if parsed.Path == "" {
+			return "", ErrInvalidEndpoint
+		}
+		return requestPath(parsed), nil
+	}
+
+	base, err := url.Parse(c.restEndpoint)
+	if err != nil {
+		return "", fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	if !strings.EqualFold(parsed.Scheme, base.Scheme) || !strings.EqualFold(parsed.Host, base.Host) {
+		return "", fmt.Errorf("%w: unexpected rest page host %s", ErrInvalidEndpoint, parsed.Host)
+	}
+
+	path := parsed.Path
+	basePath := strings.TrimRight(base.Path, "/")
+	if basePath != "" {
+		switch {
+		case path == basePath:
+			path = "/"
+		case strings.HasPrefix(path, basePath+"/"):
+			path = strings.TrimPrefix(path, basePath)
+		default:
+			return "", fmt.Errorf("%w: unexpected rest page path %s", ErrInvalidEndpoint, path)
+		}
+	}
+	parsed.Path = path
+	return requestPath(parsed), nil
+}
+
+func requestPath(value *url.URL) string {
+	path := value.EscapedPath()
+	if path == "" {
+		path = "/"
+	}
+	if value.RawQuery != "" {
+		path += "?" + value.RawQuery
+	}
+	return path
 }
 
 func classifyStatus(status int, headers http.Header, body []byte) error {

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -72,6 +73,7 @@ type Connector struct {
 	priorityMap    map[string]*int
 	statusCache    *statusCache
 	projectCache   *projectCache
+	mu             sync.RWMutex
 	instanceLogin  string
 }
 
@@ -166,12 +168,18 @@ func (c *Connector) Authenticate(ctx context.Context) error {
 	if response.Node == nil || response.Node.TypeName != "ProjectV2" || strings.TrimSpace(response.Node.ID) == "" {
 		return ErrProjectNotFound
 	}
-	c.instanceLogin = strings.TrimSpace(response.Viewer.Login)
+	login := strings.TrimSpace(response.Viewer.Login)
+	c.mu.Lock()
+	c.instanceLogin = login
+	c.mu.Unlock()
 
 	return nil
 }
 
 func (c *Connector) InstanceLogin() string {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return c.instanceLogin
 }
 

--- a/internal/connector/github/connector_test.go
+++ b/internal/connector/github/connector_test.go
@@ -6,6 +6,9 @@ import (
 	"errors"
 	"net/http"
 	"net/http/httptest"
+	"strconv"
+	"sync"
+	"sync/atomic"
 	"testing"
 )
 
@@ -51,6 +54,58 @@ func TestConnectorAuthenticateValidatesViewerAndProject(t *testing.T) {
 	if variables["projectId"] != "PVT_1" {
 		t.Fatalf("projectId = %v, want PVT_1", variables["projectId"])
 	}
+}
+
+func TestConnectorInstanceLoginConcurrentAuthenticateAndRead(t *testing.T) {
+	t.Parallel()
+
+	var count atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		login := "octocat-" + strconv.FormatInt(count.Add(1), 10)
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"` + login + `"},"node":{"__typename":"ProjectV2","id":"PVT_1"}}}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := NewConnector(Config{
+		Endpoint:    server.URL,
+		APIKey:      "token",
+		ProjectSlug: "PVT_1",
+		HTTPClient:  server.Client(),
+		GHToken: func(context.Context, string) (string, error) {
+			t.Fatal("gh token fallback should not run")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 25 {
+				if err := c.Authenticate(context.Background()); err != nil {
+					t.Errorf("Authenticate() error = %v", err)
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 200 {
+			_ = c.InstanceLogin()
+		}
+	}()
+
+	close(start)
+	wg.Wait()
 }
 
 func TestConnectorAuthenticateReportsProjectProblems(t *testing.T) {

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -127,6 +127,9 @@ func (h *Hub[T]) Close() {
 	}
 }
 
+// C returns a lossy subscription stream. Slow subscribers may miss intermediate
+// values when their buffer is full, and consumers racing with publishers should
+// use Latest when they need the authoritative current value.
 func (s *Subscription[T]) C() <-chan T {
 	return s.ch
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -3,6 +3,7 @@ package hub_test
 import (
 	"context"
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -124,6 +125,42 @@ func TestHubWithBufferKeepsNewestBufferedEvents(t *testing.T) {
 	if got := receive(t, sub.C()); got != "new" {
 		t.Fatalf("second buffered event = %q, want new", got)
 	}
+}
+
+func TestHubConcurrentPublishAndConsumeIsRaceFree(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[int]()
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		for {
+			select {
+			case _, ok := <-sub.C():
+				if !ok {
+					return
+				}
+			case <-done:
+				return
+			}
+		}
+	}()
+
+	for value := range 1000 {
+		if err := events.Publish(value); err != nil {
+			t.Fatalf("Publish(%d) error = %v", value, err)
+		}
+	}
+	close(done)
+	wg.Wait()
+	sub.Close()
 }
 
 func TestHubCloseClosesSubscribersAndRejectsOperations(t *testing.T) {


### PR DESCRIPTION
## Summary

- synchronize GitHub connector instance login reads and writes during re-authentication
- follow REST `Link: rel="next"` pagination for blocker comments, pull request reviews, check runs, and statuses
- wrap workflow config watching around the generic `FileWatcher[workflowconfig.Workflow]` and document hub subscription delivery as lossy

Fixes #332

## Test Plan

- [x] `go test -race ./internal/connector/github ./internal/config/watcher ./internal/hub`
- [x] `make check`