### PR TITLE
refactor(orchestrator): unify dispatch planning

### DIFF
--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -5,72 +5,16 @@ import (
 	"time"
 )
 
+func (o *Orchestrator) dispatchPlanner() dispatchPlanner {
+	return newDispatchPlanner(o.cfg)
+}
+
 func (o *Orchestrator) pruneBudgetRefusals(state *State, now time.Time) {
-	for issueID, refusal := range state.BudgetRefusals {
-		if !o.budgetRefusalActive(refusal, now) {
-			delete(state.BudgetRefusals, issueID)
-		}
-	}
-}
-
-func (o *Orchestrator) budgetCooldownActive(state *State, issueID string, now time.Time) bool {
-	refusal, ok := state.BudgetRefusals[issueID]
-	if !ok {
-		return false
-	}
-
-	return o.budgetRefusalActive(refusal, now)
-}
-
-func (o *Orchestrator) budgetRefusalActive(refusal BudgetRefusal, now time.Time) bool {
-	if refusal.ResetAt != nil && now.Before(*refusal.ResetAt) {
-		return true
-	}
-	if o.cfg.BudgetRefusalCooldown <= 0 || refusal.RefusedAt.IsZero() {
-		return false
-	}
-
-	return now.Before(refusal.RefusedAt.Add(o.cfg.BudgetRefusalCooldown))
-}
-
-func (o *Orchestrator) workerSlotsAvailable(state *State, preferredWorkerHost string) bool {
-	_, ok := o.selectWorkerHost(state, preferredWorkerHost)
-	return ok
+	o.dispatchPlanner().pruneBudgetRefusals(state, now)
 }
 
 func (o *Orchestrator) selectWorkerHost(state *State, preferredWorkerHost string) (string, bool) {
-	if len(o.cfg.WorkerHosts) == 0 {
-		return "", true
-	}
-
-	availableHosts := make([]string, 0, len(o.cfg.WorkerHosts))
-	for _, host := range o.cfg.WorkerHosts {
-		if o.workerHostSlotsAvailable(state, host) {
-			availableHosts = append(availableHosts, host)
-		}
-	}
-	if len(availableHosts) == 0 {
-		return "", false
-	}
-
-	preferredWorkerHost = strings.TrimSpace(preferredWorkerHost)
-	if preferredWorkerHost != "" {
-		for _, host := range availableHosts {
-			if host == preferredWorkerHost {
-				return preferredWorkerHost, true
-			}
-		}
-	}
-
-	return leastLoadedWorkerHost(state, availableHosts), true
-}
-
-func (o *Orchestrator) workerHostSlotsAvailable(state *State, workerHost string) bool {
-	if o.cfg.MaxConcurrentAgentsPerHost <= 0 {
-		return true
-	}
-
-	return runningWorkerHostCount(state, workerHost) < o.cfg.MaxConcurrentAgentsPerHost
+	return o.dispatchPlanner().selectWorkerHost(state, preferredWorkerHost)
 }
 
 func leastLoadedWorkerHost(state *State, hosts []string) string {

--- a/internal/orchestrator/dispatch_parity_test.go
+++ b/internal/orchestrator/dispatch_parity_test.go
@@ -51,6 +51,14 @@ func TestDispatchParityWithElixirRecordedCandidateSets(t *testing.T) {
 				t.Fatalf("dispatch order = %#v, want %#v", gotOrder, tt.Want.DispatchOrder)
 			}
 
+			plan := PlanDispatch(cfg, state.clone(), candidates, now)
+			if !slices.Equal(plan.DispatchOrder(), tt.Want.DispatchOrder) {
+				t.Fatalf("PlanDispatch order = %#v, want %#v", plan.DispatchOrder(), tt.Want.DispatchOrder)
+			}
+			assertParitySet(t, "PlanDispatch blocked", plan.Blocked, tt.Want.Blocked)
+			assertParitySet(t, "PlanDispatch claimed", plan.Claimed, tt.Want.Claimed)
+			assertParitySet(t, "PlanDispatch refusals", plan.BudgetRefusals, tt.Want.Refusals)
+
 			ctx, cancel := context.WithCancel(context.Background())
 			orch.dispatchReadyIssues(ctx, &state, candidates, now)
 			cancel()

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -1,0 +1,491 @@
+package orchestrator
+
+import (
+	"math"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
+)
+
+type dispatchPlanner struct {
+	cfg Config
+}
+
+type dispatchPlanHooks struct {
+	hydrate             func(connector.Issue) (connector.Issue, bool)
+	beforeDispatch      func(connector.Issue, int) bool
+	dispatch            func(connector.Issue, int, string) bool
+	retryDispatchFailed func(connector.Issue, Retry)
+}
+
+type dispatchAction struct {
+	issue      connector.Issue
+	attempt    int
+	workerHost string
+	retry      bool
+}
+
+func newDispatchPlanner(cfg Config) dispatchPlanner {
+	return dispatchPlanner{cfg: normalizeConfig(cfg)}
+}
+
+func (p dispatchPlanner) plan(
+	state *State,
+	candidates []connector.Issue,
+	now time.Time,
+	hooks dispatchPlanHooks,
+) DispatchPlan {
+	state.ensureInitialized(p.cfg)
+
+	plannedCandidates := cloneIssues(candidates)
+	sortIssuesForDispatch(plannedCandidates, p.cfg.DispatchPriorityByState)
+	dueRetries := dueRetriesByIssue(state, now)
+	p.releaseMissingDueRetries(state, plannedCandidates, dueRetries)
+
+	plan := DispatchPlan{}
+	continuations := 0
+	for _, issue := range plannedCandidates {
+		if retry, ok := dueRetries[issue.ID]; ok {
+			action, ok := p.retryAction(state, issue, retry, now)
+			if !ok {
+				continue
+			}
+			if p.applyDispatchAction(state, action, now, hooks) {
+				plan.Dispatches = append(plan.Dispatches, action.decision())
+			} else if hooks.retryDispatchFailed != nil {
+				hooks.retryDispatchFailed(action.issue, retry)
+			}
+			continue
+		}
+		if availableSlots(state) == 0 {
+			break
+		}
+		if hooks.hydrate != nil {
+			var ok bool
+			issue, ok = hooks.hydrate(issue)
+			if !ok {
+				continue
+			}
+		}
+		action, ok := p.dispatchAction(state, issue, now)
+		if !ok {
+			continue
+		}
+		continuationIndex := -1
+		if continuationDispatch(action.issue) {
+			continuationIndex = continuations
+			continuations++
+		}
+		if hooks.beforeDispatch != nil && !hooks.beforeDispatch(action.issue, continuationIndex) {
+			break
+		}
+		if p.applyDispatchAction(state, action, now, hooks) {
+			plan.Dispatches = append(plan.Dispatches, action.decision())
+		}
+	}
+
+	plan.Claimed = claimedIDs(state.Claimed)
+	plan.Blocked = blockedIDs(state.Blocked)
+	plan.BudgetRefusals = budgetRefusalIDs(state.BudgetRefusals)
+	plan.Retry = retryIDs(state.Retry)
+	return plan
+}
+
+func (p dispatchPlanner) applyDispatchAction(
+	state *State,
+	action dispatchAction,
+	now time.Time,
+	hooks dispatchPlanHooks,
+) bool {
+	if hooks.dispatch != nil {
+		return hooks.dispatch(action.issue, action.attempt, action.workerHost)
+	}
+	p.markDispatched(state, action.issue, action.attempt, now, action.workerHost)
+	return true
+}
+
+func (p dispatchPlanner) retryAction(
+	state *State,
+	issue connector.Issue,
+	retry Retry,
+	now time.Time,
+) (dispatchAction, bool) {
+	delete(state.Retry, retry.Issue.ID)
+
+	if !p.dispatchableForRetry(issue, state, now, retry.WorkerHost) {
+		if p.budgetCooldownActive(state, issue.ID, now) {
+			p.scheduleRetry(state, issue, retry.Attempt, now, "budget cooldown active", false, retry.WorkerHost)
+			return dispatchAction{}, false
+		}
+		if !p.slotsAvailable(issue, state, retry.WorkerHost) {
+			p.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false, retry.WorkerHost)
+			return dispatchAction{}, false
+		}
+		if _, blocked := state.Blocked[issue.ID]; blocked {
+			p.releaseClaim(state, issue.ID)
+			return dispatchAction{}, false
+		}
+
+		p.releaseIssue(state, issue.ID)
+		return dispatchAction{}, false
+	}
+
+	return p.newDispatchAction(state, issue, retry.Attempt, retry.WorkerHost, true)
+}
+
+func (p dispatchPlanner) dispatchAction(state *State, issue connector.Issue, now time.Time) (dispatchAction, bool) {
+	if !p.dispatchable(issue, state, now) {
+		if todoBlockedByNonTerminal(issue, p.cfg.TerminalStates) {
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     cloneIssue(issue),
+				Reason:    blockedReasonDependency,
+				BlockedAt: now,
+				Source:    BlockedSourceDependency,
+			}
+		}
+		return dispatchAction{}, false
+	}
+
+	return p.newDispatchAction(state, issue, 0, "", false)
+}
+
+func (p dispatchPlanner) newDispatchAction(
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	preferredWorkerHost string,
+	retry bool,
+) (dispatchAction, bool) {
+	workerHost, ok := p.selectWorkerHost(state, preferredWorkerHost)
+	if !ok {
+		return dispatchAction{}, false
+	}
+
+	return dispatchAction{
+		issue:      cloneIssue(issue),
+		attempt:    attempt,
+		workerHost: workerHost,
+		retry:      retry,
+	}, true
+}
+
+func (p dispatchPlanner) markDispatched(
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	workerHost string,
+) {
+	issue = cloneIssue(issue)
+	state.Running[issue.ID] = Running{
+		Issue:      issue,
+		Attempt:    attempt,
+		StartedAt:  now,
+		WorkerHost: workerHost,
+	}
+	state.Claimed[issue.ID] = Claimed{
+		Issue:     issue,
+		ClaimedAt: now,
+	}
+	delete(state.Retry, issue.ID)
+	delete(state.Blocked, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+}
+
+func (a dispatchAction) decision() DispatchDecision {
+	return DispatchDecision{
+		IssueID:    a.issue.ID,
+		Identifier: a.issue.Identifier,
+		State:      a.issue.State,
+		Attempt:    a.attempt,
+		WorkerHost: a.workerHost,
+		Retry:      a.retry,
+	}
+}
+
+func (p dispatchPlanner) pruneBudgetRefusals(state *State, now time.Time) {
+	for issueID, refusal := range state.BudgetRefusals {
+		if !p.budgetRefusalActive(refusal, now) {
+			delete(state.BudgetRefusals, issueID)
+		}
+	}
+}
+
+func (p dispatchPlanner) budgetCooldownActive(state *State, issueID string, now time.Time) bool {
+	refusal, ok := state.BudgetRefusals[issueID]
+	if !ok {
+		return false
+	}
+
+	return p.budgetRefusalActive(refusal, now)
+}
+
+func (p dispatchPlanner) budgetRefusalActive(refusal BudgetRefusal, now time.Time) bool {
+	if refusal.ResetAt != nil && now.Before(*refusal.ResetAt) {
+		return true
+	}
+	if p.cfg.BudgetRefusalCooldown <= 0 || refusal.RefusedAt.IsZero() {
+		return false
+	}
+
+	return now.Before(refusal.RefusedAt.Add(p.cfg.BudgetRefusalCooldown))
+}
+
+func (p dispatchPlanner) trackBlockedCandidates(state *State, issues []connector.Issue, now time.Time) {
+	seenBlocked := make(map[string]struct{})
+	for _, issue := range issues {
+		if issue.ID == "" {
+			continue
+		}
+		if todoBlockedByNonTerminal(issue, p.cfg.TerminalStates) {
+			seenBlocked[issue.ID] = struct{}{}
+			state.Blocked[issue.ID] = Blocked{
+				Issue:     cloneIssue(issue),
+				Reason:    blockedReasonDependency,
+				BlockedAt: now,
+				Source:    BlockedSourceDependency,
+			}
+		}
+	}
+
+	for issueID, blocked := range state.Blocked {
+		if !blockedFromDependency(blocked) {
+			continue
+		}
+		if _, ok := seenBlocked[issueID]; !ok {
+			delete(state.Blocked, issueID)
+		}
+	}
+}
+
+func (p dispatchPlanner) releaseMissingDueRetries(
+	state *State,
+	issues []connector.Issue,
+	dueRetries map[string]Retry,
+) {
+	if len(dueRetries) == 0 {
+		return
+	}
+
+	byID := make(map[string]struct{}, len(issues))
+	for _, issue := range issues {
+		byID[issue.ID] = struct{}{}
+	}
+
+	for issueID := range dueRetries {
+		if _, ok := byID[issueID]; !ok {
+			if _, blocked := state.Blocked[issueID]; blocked {
+				p.releaseClaim(state, issueID)
+				continue
+			}
+			p.releaseIssue(state, issueID)
+		}
+	}
+}
+
+func (p dispatchPlanner) dispatchable(issue connector.Issue, state *State, now time.Time) bool {
+	return p.dispatchableIssue(issue, state, false, now, "")
+}
+
+func (p dispatchPlanner) dispatchableForRetry(
+	issue connector.Issue,
+	state *State,
+	now time.Time,
+	preferredWorkerHost string,
+) bool {
+	return p.dispatchableIssue(issue, state, true, now, preferredWorkerHost)
+}
+
+func (p dispatchPlanner) dispatchableIssue(
+	issue connector.Issue,
+	state *State,
+	allowClaimed bool,
+	now time.Time,
+	preferredWorkerHost string,
+) bool {
+	if !validCandidate(issue) {
+		return false
+	}
+	if !stateIn(issue.State, p.cfg.ActiveStates) || stateIn(issue.State, p.cfg.TerminalStates) {
+		return false
+	}
+	if duplicatePullRequestWork(issue) {
+		return false
+	}
+	if !p.authorized(issue) {
+		return false
+	}
+	if todoBlockedByNonTerminal(issue, p.cfg.TerminalStates) {
+		return false
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		return false
+	}
+	if _, ok := state.Claimed[issue.ID]; ok && !allowClaimed {
+		return false
+	}
+	if _, ok := state.Blocked[issue.ID]; ok {
+		return false
+	}
+	if p.budgetCooldownActive(state, issue.ID, now) {
+		return false
+	}
+
+	return p.slotsAvailable(issue, state, preferredWorkerHost)
+}
+
+func (p dispatchPlanner) authorized(issue connector.Issue) bool {
+	if !p.cfg.Authorization.Configured() {
+		return true
+	}
+	return selector.Match(issue, p.cfg.Authorization, p.cfg.SelectorContext)
+}
+
+func (p dispatchPlanner) slotsAvailable(issue connector.Issue, state *State, preferredWorkerHost string) bool {
+	return availableSlots(state) > 0 &&
+		p.stateSlotsAvailable(issue, state) &&
+		p.workerSlotsAvailable(state, preferredWorkerHost)
+}
+
+func (p dispatchPlanner) stateSlotsAvailable(issue connector.Issue, state *State) bool {
+	limit := p.cfg.MaxConcurrentAgents
+	if stateLimit, ok := p.cfg.MaxConcurrentAgentsByState[normalizeState(issue.State)]; ok {
+		limit = stateLimit
+	}
+
+	used := 0
+	normalized := normalizeState(issue.State)
+	for _, running := range state.Running {
+		if normalizeState(running.Issue.State) == normalized {
+			used++
+		}
+	}
+
+	return used < limit
+}
+
+func (p dispatchPlanner) workerSlotsAvailable(state *State, preferredWorkerHost string) bool {
+	_, ok := p.selectWorkerHost(state, preferredWorkerHost)
+	return ok
+}
+
+func (p dispatchPlanner) selectWorkerHost(state *State, preferredWorkerHost string) (string, bool) {
+	if len(p.cfg.WorkerHosts) == 0 {
+		return "", true
+	}
+
+	availableHosts := make([]string, 0, len(p.cfg.WorkerHosts))
+	for _, host := range p.cfg.WorkerHosts {
+		if p.workerHostSlotsAvailable(state, host) {
+			availableHosts = append(availableHosts, host)
+		}
+	}
+	if len(availableHosts) == 0 {
+		return "", false
+	}
+
+	preferredWorkerHost = strings.TrimSpace(preferredWorkerHost)
+	if preferredWorkerHost != "" {
+		for _, host := range availableHosts {
+			if host == preferredWorkerHost {
+				return preferredWorkerHost, true
+			}
+		}
+	}
+
+	return leastLoadedWorkerHost(state, availableHosts), true
+}
+
+func (p dispatchPlanner) workerHostSlotsAvailable(state *State, workerHost string) bool {
+	if p.cfg.MaxConcurrentAgentsPerHost <= 0 {
+		return true
+	}
+
+	return runningWorkerHostCount(state, workerHost) < p.cfg.MaxConcurrentAgentsPerHost
+}
+
+func (p dispatchPlanner) scheduleRetry(
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	err string,
+	continuation bool,
+	workerHost string,
+) {
+	if attempt < 1 {
+		attempt = 1
+	}
+
+	p.scheduleRetryAfter(state, issue, attempt, now, p.retryDelay(attempt, continuation), err, workerHost)
+}
+
+func (p dispatchPlanner) scheduleRetryAfter(
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	delay time.Duration,
+	err string,
+	workerHost string,
+) {
+	if attempt < 1 {
+		attempt = 1
+	}
+	if delay < 0 {
+		delay = 0
+	}
+
+	issue = cloneIssue(issue)
+	state.Retry[issue.ID] = Retry{
+		Issue:      issue,
+		Attempt:    attempt,
+		DueAt:      now.Add(delay),
+		Error:      err,
+		WorkerHost: workerHost,
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		state.Claimed[issue.ID] = Claimed{
+			Issue:     issue,
+			ClaimedAt: now,
+		}
+	}
+}
+
+func (p dispatchPlanner) retryDelay(attempt int, continuation bool) time.Duration {
+	if continuation {
+		return p.cfg.ContinuationRetryDelay
+	}
+	if attempt < 1 {
+		attempt = 1
+	}
+	exponent := attempt - 1
+	if exponent > 30 {
+		exponent = 30
+	}
+
+	delay := p.cfg.FailureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
+	if delay > p.cfg.MaxRetryBackoff {
+		return p.cfg.MaxRetryBackoff
+	}
+	return delay
+}
+
+func (p dispatchPlanner) releaseIssue(state *State, issueID string) {
+	cancelRunning(state, issueID)
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Blocked, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+}
+
+func (p dispatchPlanner) releaseClaim(state *State, issueID string) {
+	cancelRunning(state, issueID)
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"log/slog"
-	"math"
 	"strings"
 	"time"
 
@@ -306,85 +305,6 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 	case state := <-request.reply:
 		return state, nil
 	}
-}
-
-func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
-	lastRefreshAt := state.LastRefreshAt
-	previousPipeline := cloneIssues(state.Pipeline)
-	previousEpicTransitionWatch := cloneIssues(state.epicTransitionWatch)
-	previousBlockedStatusIssues := blockedStatusTransitionIssues(state.Blocked)
-	pendingEpicParentLookups := cloneIssueMap(state.pendingEpicParentLookups)
-	o.markRefresh(state, now)
-	defer o.finishRefresh(state, now)
-
-	if pause := o.gitHubGraphQLPause(state, now); pause > 0 {
-		o.logger.Warn("github graphql polling paused", "remaining", gitHubGraphQLRemaining(state), "pause", pause)
-		return
-	}
-
-	o.reapWorkspacesIfDue(ctx, state, now)
-	o.reconcileRunningIssues(ctx, state, now)
-	o.heartbeatRunningClaims(ctx, state, now)
-
-	issues, err := o.connector.FetchCandidateIssues(ctx)
-	if err != nil {
-		o.logger.Warn("fetch candidate issues failed", "error", err)
-		return
-	}
-	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, observedStatusFetchStates())
-	if statusErr != nil {
-		o.logger.Warn("fetch observed status issues failed", "error", statusErr)
-	}
-
-	issues = cloneIssues(issues)
-	transitionIssues := cloneIssues(issues)
-	pipelineIssues, pipelineRefreshOK := o.fetchEpicTransitionIssueStates(ctx, previousPipeline)
-	transitionIssues = append(transitionIssues, pipelineIssues...)
-	watchedIssues, watchRefreshOK := o.fetchEpicTransitionIssueStates(ctx, previousEpicTransitionWatch)
-	transitionIssues = append(transitionIssues, watchedIssues...)
-	blockedIssues, blockedRefreshOK := o.fetchEpicTransitionIssueStates(ctx, previousBlockedStatusIssues)
-	transitionIssues = append(transitionIssues, blockedIssues...)
-	pendingTransitions, pendingParentLookups := o.refreshPendingEpicParentLookups(ctx, pendingEpicParentLookups)
-	transitionIssues = append(transitionIssues, pendingTransitions...)
-	state.epicTransitionWatch = issuesInStates(issues, o.cfg.ActiveStates)
-	if !watchRefreshOK {
-		state.epicTransitionWatch = mergeIssueSlices(state.epicTransitionWatch, previousEpicTransitionWatch)
-	}
-	if statusErr == nil {
-		statusIssues = cloneIssues(statusIssues)
-		transitionIssues = append(transitionIssues, statusIssues...)
-		state.Pipeline = issuesInStates(statusIssues, prPipelineFetchStates())
-		if !pipelineRefreshOK {
-			state.Pipeline = mergeIssueSlices(state.Pipeline, previousPipeline)
-		}
-	}
-	previousTransitions := mergeIssueSlices(previousPipeline, previousEpicTransitionWatch)
-	previousTransitions = mergeIssueSlices(previousTransitions, previousBlockedStatusIssues)
-	completedEpics, failedParentLookups := o.closeCompletedEpicsForTerminalTransitions(
-		ctx,
-		transitionIssues,
-		previousTransitions,
-		lastRefreshAt,
-		pendingTransitions,
-	)
-	state.pendingEpicParentLookups = mergeIssueMaps(pendingParentLookups, failedParentLookups)
-	reconciledClosedIssues := o.reconcileClosedCompletedIssueStatuses(ctx, state, transitionIssues, now)
-	issues = filterReconciledIssues(issues, reconciledClosedIssues)
-	statusIssues = filterReconciledIssues(statusIssues, reconciledClosedIssues)
-	state.epicTransitionWatch = filterReconciledIssues(state.epicTransitionWatch, reconciledClosedIssues)
-	state.Pipeline = filterReconciledIssues(state.Pipeline, reconciledClosedIssues)
-	issues = filterCompletedEpicCandidates(issues, completedEpics)
-	sortIssuesForDispatch(issues, o.cfg.DispatchPriorityByState)
-	o.pruneBudgetRefusals(state, now)
-	o.trackBlockedCandidates(state, issues, now)
-	if statusErr == nil {
-		currentBlockedStatusIssues := issuesInStates(statusIssues, []string{blockedStatusState})
-		if !blockedRefreshOK {
-			currentBlockedStatusIssues = mergeIssueSlices(currentBlockedStatusIssues, previousBlockedStatusIssues)
-		}
-		o.trackBlockedStatusIssues(state, currentBlockedStatusIssues, now)
-	}
-	o.dispatchReadyIssues(ctx, state, issues, now)
 }
 
 func observedStatusFetchStates() []string {
@@ -902,30 +822,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 }
 
 func (o *Orchestrator) trackBlockedCandidates(state *State, issues []connector.Issue, now time.Time) {
-	seenBlocked := make(map[string]struct{})
-	for _, issue := range issues {
-		if issue.ID == "" {
-			continue
-		}
-		if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
-			seenBlocked[issue.ID] = struct{}{}
-			state.Blocked[issue.ID] = Blocked{
-				Issue:     cloneIssue(issue),
-				Reason:    blockedReasonDependency,
-				BlockedAt: now,
-				Source:    BlockedSourceDependency,
-			}
-		}
-	}
-
-	for issueID, blocked := range state.Blocked {
-		if !blockedFromDependency(blocked) {
-			continue
-		}
-		if _, ok := seenBlocked[issueID]; !ok {
-			delete(state.Blocked, issueID)
-		}
-	}
+	o.dispatchPlanner().trackBlockedCandidates(state, issues, now)
 }
 
 func (o *Orchestrator) trackBlockedStatusIssues(state *State, issues []connector.Issue, now time.Time) {
@@ -967,44 +864,24 @@ func blockedStatusReason(issue connector.Issue) string {
 }
 
 func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
-	dueRetries := dueRetriesByIssue(state, now)
-	o.releaseMissingDueRetries(state, issues, dueRetries)
-
-	continuations := 0
-	for _, issue := range issues {
-		if retry, ok := dueRetries[issue.ID]; ok {
-			o.dispatchRetryIssue(ctx, state, issue, retry, now)
-			continue
-		}
-		if availableSlots(state) == 0 {
-			return
-		}
-		issue, ok := o.hydrateDispatchIssue(ctx, issue)
-		if !ok {
-			continue
-		}
-		if !o.dispatchable(issue, state, now) {
-			if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
-				state.Blocked[issue.ID] = Blocked{
-					Issue:     cloneIssue(issue),
-					Reason:    blockedReasonDependency,
-					BlockedAt: now,
-					Source:    BlockedSourceDependency,
-				}
+	planner := o.dispatchPlanner()
+	planner.plan(state, issues, now, dispatchPlanHooks{
+		hydrate: func(issue connector.Issue) (connector.Issue, bool) {
+			return o.hydrateDispatchIssue(ctx, issue)
+		},
+		beforeDispatch: func(_ connector.Issue, continuationIndex int) bool {
+			if continuationIndex < 0 {
+				return true
 			}
-			continue
-		}
-
-		delay := time.Duration(0)
-		if continuationDispatch(issue) {
-			delay = continuationDelay(continuations)
-			continuations++
-		}
-		if !waitForDispatchBackoff(ctx, delay) {
-			return
-		}
-		o.dispatchIssue(ctx, state, issue, 0, now, "")
-	}
+			return waitForDispatchBackoff(ctx, continuationDelay(continuationIndex))
+		},
+		dispatch: func(issue connector.Issue, attempt int, workerHost string) bool {
+			return o.dispatchIssue(ctx, state, issue, attempt, now, workerHost)
+		},
+		retryDispatchFailed: func(issue connector.Issue, retry Retry) {
+			planner.scheduleRetry(state, issue, retry.Attempt, now, "claim verification failed", false, retry.WorkerHost)
+		},
+	})
 }
 
 func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector.Issue) (connector.Issue, bool) {
@@ -1053,142 +930,8 @@ func dueRetriesByIssue(state *State, now time.Time) map[string]Retry {
 	return retries
 }
 
-func (o *Orchestrator) releaseMissingDueRetries(
-	state *State,
-	issues []connector.Issue,
-	dueRetries map[string]Retry,
-) {
-	if len(dueRetries) == 0 {
-		return
-	}
-
-	byID := make(map[string]struct{}, len(issues))
-	for _, issue := range issues {
-		byID[issue.ID] = struct{}{}
-	}
-
-	for issueID := range dueRetries {
-		if _, ok := byID[issueID]; !ok {
-			if _, blocked := state.Blocked[issueID]; blocked {
-				o.releaseClaim(state, issueID)
-				continue
-			}
-			o.releaseIssue(state, issueID)
-		}
-	}
-}
-
-func (o *Orchestrator) dispatchRetryIssue(
-	ctx context.Context,
-	state *State,
-	issue connector.Issue,
-	retry Retry,
-	now time.Time,
-) {
-	delete(state.Retry, retry.Issue.ID)
-
-	if !o.dispatchableForRetry(issue, state, now, retry.WorkerHost) {
-		if o.budgetCooldownActive(state, issue.ID, now) {
-			o.scheduleRetry(state, issue, retry.Attempt, now, "budget cooldown active", false, retry.WorkerHost)
-			return
-		}
-		if !o.slotsAvailable(issue, state, retry.WorkerHost) {
-			o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false, retry.WorkerHost)
-			return
-		}
-		if _, blocked := state.Blocked[issue.ID]; blocked {
-			o.releaseClaim(state, issue.ID)
-			return
-		}
-
-		o.releaseIssue(state, issue.ID)
-		return
-	}
-
-	if !o.dispatchIssue(ctx, state, issue, retry.Attempt, now, retry.WorkerHost) {
-		o.scheduleRetry(state, issue, retry.Attempt, now, "claim verification failed", false, retry.WorkerHost)
-	}
-}
-
 func (o *Orchestrator) dispatchable(issue connector.Issue, state *State, now time.Time) bool {
-	return o.dispatchableIssue(issue, state, false, now, "")
-}
-
-func (o *Orchestrator) dispatchableForRetry(
-	issue connector.Issue,
-	state *State,
-	now time.Time,
-	preferredWorkerHost string,
-) bool {
-	return o.dispatchableIssue(issue, state, true, now, preferredWorkerHost)
-}
-
-func (o *Orchestrator) dispatchableIssue(
-	issue connector.Issue,
-	state *State,
-	allowClaimed bool,
-	now time.Time,
-	preferredWorkerHost string,
-) bool {
-	if !validCandidate(issue) {
-		return false
-	}
-	if !stateIn(issue.State, o.cfg.ActiveStates) || stateIn(issue.State, o.cfg.TerminalStates) {
-		return false
-	}
-	if duplicatePullRequestWork(issue) {
-		return false
-	}
-	if !o.authorized(issue) {
-		return false
-	}
-	if todoBlockedByNonTerminal(issue, o.cfg.TerminalStates) {
-		return false
-	}
-	if _, ok := state.Running[issue.ID]; ok {
-		return false
-	}
-	if _, ok := state.Claimed[issue.ID]; ok && !allowClaimed {
-		return false
-	}
-	if _, ok := state.Blocked[issue.ID]; ok {
-		return false
-	}
-	if o.budgetCooldownActive(state, issue.ID, now) {
-		return false
-	}
-
-	return o.slotsAvailable(issue, state, preferredWorkerHost)
-}
-
-func (o *Orchestrator) authorized(issue connector.Issue) bool {
-	if !o.cfg.Authorization.Configured() {
-		return true
-	}
-	return selector.Match(issue, o.cfg.Authorization, o.cfg.SelectorContext)
-}
-
-func (o *Orchestrator) slotsAvailable(issue connector.Issue, state *State, preferredWorkerHost string) bool {
-	return availableSlots(state) > 0 &&
-		o.stateSlotsAvailable(issue, state) &&
-		o.workerSlotsAvailable(state, preferredWorkerHost)
-}
-
-func (o *Orchestrator) stateSlotsAvailable(issue connector.Issue, state *State) bool {
-	limit := o.cfg.MaxConcurrentAgents
-	if stateLimit, ok := o.cfg.MaxConcurrentAgentsByState[normalizeState(issue.State)]; ok {
-		limit = stateLimit
-	}
-
-	used := 0
-	normalized := normalizeState(issue.State)
-	for _, running := range state.Running {
-		if normalizeState(running.Issue.State) == normalized {
-			used++
-		}
-	}
-
-	return used < limit
+	return o.dispatchPlanner().dispatchable(issue, state, now)
 }
 
 func (o *Orchestrator) dispatchIssue(
@@ -1377,11 +1120,7 @@ func (o *Orchestrator) scheduleRetry(
 	continuation bool,
 	workerHost string,
 ) {
-	if attempt < 1 {
-		attempt = 1
-	}
-
-	o.scheduleRetryAfter(state, issue, attempt, now, o.retryDelay(attempt, continuation), err, workerHost)
+	o.dispatchPlanner().scheduleRetry(state, issue, attempt, now, err, continuation, workerHost)
 }
 
 func (o *Orchestrator) scheduleRetryAfter(
@@ -1393,63 +1132,15 @@ func (o *Orchestrator) scheduleRetryAfter(
 	err string,
 	workerHost string,
 ) {
-	if attempt < 1 {
-		attempt = 1
-	}
-	if delay < 0 {
-		delay = 0
-	}
-
-	issue = cloneIssue(issue)
-	state.Retry[issue.ID] = Retry{
-		Issue:      issue,
-		Attempt:    attempt,
-		DueAt:      now.Add(delay),
-		Error:      err,
-		WorkerHost: workerHost,
-	}
-	if _, ok := state.Claimed[issue.ID]; !ok {
-		state.Claimed[issue.ID] = Claimed{
-			Issue:     issue,
-			ClaimedAt: now,
-		}
-	}
+	o.dispatchPlanner().scheduleRetryAfter(state, issue, attempt, now, delay, err, workerHost)
 }
 
 func (o *Orchestrator) retryDelay(attempt int, continuation bool) time.Duration {
-	if continuation {
-		return o.cfg.ContinuationRetryDelay
-	}
-	if attempt < 1 {
-		attempt = 1
-	}
-	exponent := attempt - 1
-	if exponent > 30 {
-		exponent = 30
-	}
-
-	delay := o.cfg.FailureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
-	if delay > o.cfg.MaxRetryBackoff {
-		return o.cfg.MaxRetryBackoff
-	}
-	return delay
-}
-
-func (o *Orchestrator) releaseIssue(state *State, issueID string) {
-	cancelRunning(state, issueID)
-	delete(state.Running, issueID)
-	delete(state.Claimed, issueID)
-	delete(state.Blocked, issueID)
-	delete(state.Retry, issueID)
-	delete(state.BudgetRefusals, issueID)
+	return o.dispatchPlanner().retryDelay(attempt, continuation)
 }
 
 func (o *Orchestrator) releaseClaim(state *State, issueID string) {
-	cancelRunning(state, issueID)
-	delete(state.Running, issueID)
-	delete(state.Claimed, issueID)
-	delete(state.Retry, issueID)
-	delete(state.BudgetRefusals, issueID)
+	o.dispatchPlanner().releaseClaim(state, issueID)
 }
 
 func cancelRunning(state *State, issueID string) {

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -25,48 +25,18 @@ type DispatchPlan struct {
 }
 
 func PlanDispatch(cfg Config, state State, candidates []connector.Issue, now time.Time) DispatchPlan {
-	cfg = normalizeConfig(cfg)
+	planner := newDispatchPlanner(cfg)
 	if now.IsZero() {
 		now = time.Now().UTC()
 	}
 
 	plannedState := state.clone()
-	plannedState.ensureInitialized(cfg)
+	plannedState.ensureInitialized(planner.cfg)
 	plannedCandidates := cloneIssues(candidates)
-	sortIssuesForDispatch(plannedCandidates, cfg.DispatchPriorityByState)
+	planner.pruneBudgetRefusals(&plannedState, now)
+	planner.trackBlockedCandidates(&plannedState, plannedCandidates, now)
 
-	orch := Orchestrator{cfg: cfg}
-	orch.pruneBudgetRefusals(&plannedState, now)
-	orch.trackBlockedCandidates(&plannedState, plannedCandidates, now)
-	dueRetries := dueRetriesByIssue(&plannedState, now)
-	orch.releaseMissingDueRetries(&plannedState, plannedCandidates, dueRetries)
-
-	dispatches := make([]DispatchDecision, 0)
-	for _, issue := range plannedCandidates {
-		if retry, ok := dueRetries[issue.ID]; ok {
-			if decision, ok := orch.planRetryIssue(&plannedState, issue, retry, now); ok {
-				dispatches = append(dispatches, decision)
-			}
-			continue
-		}
-		if availableSlots(&plannedState) == 0 {
-			break
-		}
-		if !orch.dispatchable(issue, &plannedState, now) {
-			continue
-		}
-		if decision, ok := orch.planDispatchIssue(&plannedState, issue, 0, now, ""); ok {
-			dispatches = append(dispatches, decision)
-		}
-	}
-
-	return DispatchPlan{
-		Dispatches:     dispatches,
-		Claimed:        claimedIDs(plannedState.Claimed),
-		Blocked:        blockedIDs(plannedState.Blocked),
-		BudgetRefusals: budgetRefusalIDs(plannedState.BudgetRefusals),
-		Retry:          retryIDs(plannedState.Retry),
-	}
+	return planner.plan(&plannedState, plannedCandidates, now, dispatchPlanHooks{})
 }
 
 func (p DispatchPlan) DispatchOrder() []string {
@@ -105,72 +75,6 @@ func (s *State) ensureInitialized(cfg Config) {
 	if s.DiffStats == nil {
 		s.DiffStats = map[string]DiffStats{}
 	}
-}
-
-func (o *Orchestrator) planRetryIssue(
-	state *State,
-	issue connector.Issue,
-	retry Retry,
-	now time.Time,
-) (DispatchDecision, bool) {
-	delete(state.Retry, retry.Issue.ID)
-
-	if !o.dispatchableForRetry(issue, state, now, retry.WorkerHost) {
-		if o.budgetCooldownActive(state, issue.ID, now) {
-			o.scheduleRetry(state, issue, retry.Attempt, now, "budget cooldown active", false, retry.WorkerHost)
-			return DispatchDecision{}, false
-		}
-		if !o.slotsAvailable(issue, state, retry.WorkerHost) {
-			o.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false, retry.WorkerHost)
-			return DispatchDecision{}, false
-		}
-		if _, blocked := state.Blocked[issue.ID]; blocked {
-			o.releaseClaim(state, issue.ID)
-			return DispatchDecision{}, false
-		}
-
-		o.releaseIssue(state, issue.ID)
-		return DispatchDecision{}, false
-	}
-
-	return o.planDispatchIssue(state, issue, retry.Attempt, now, retry.WorkerHost)
-}
-
-func (o *Orchestrator) planDispatchIssue(
-	state *State,
-	issue connector.Issue,
-	attempt int,
-	now time.Time,
-	preferredWorkerHost string,
-) (DispatchDecision, bool) {
-	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
-	if !ok {
-		return DispatchDecision{}, false
-	}
-
-	issue = cloneIssue(issue)
-	state.Running[issue.ID] = Running{
-		Issue:      issue,
-		Attempt:    attempt,
-		StartedAt:  now,
-		WorkerHost: workerHost,
-	}
-	state.Claimed[issue.ID] = Claimed{
-		Issue:     issue,
-		ClaimedAt: now,
-	}
-	delete(state.Retry, issue.ID)
-	delete(state.Blocked, issue.ID)
-	delete(state.BudgetRefusals, issue.ID)
-
-	return DispatchDecision{
-		IssueID:    issue.ID,
-		Identifier: issue.Identifier,
-		State:      issue.State,
-		Attempt:    attempt,
-		WorkerHost: workerHost,
-		Retry:      attempt > 0,
-	}, true
 }
 
 func claimedIDs(values map[string]Claimed) []string {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -1,0 +1,181 @@
+package orchestrator
+
+import (
+	"context"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+type tickPreviousState struct {
+	lastRefreshAt            time.Time
+	pipeline                 []connector.Issue
+	epicTransitionWatch      []connector.Issue
+	blockedStatusIssues      []connector.Issue
+	pendingEpicParentLookups map[string]connector.Issue
+}
+
+type tickFetchedIssues struct {
+	candidates []connector.Issue
+	status     []connector.Issue
+	statusOK   bool
+}
+
+type tickTransitionRefresh struct {
+	issues               []connector.Issue
+	pendingTransitions   []connector.Issue
+	pendingParentLookups map[string]connector.Issue
+	blockedRefreshOK     bool
+}
+
+func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
+	previous := captureTickPreviousState(state)
+	o.markRefresh(state, now)
+	defer o.finishRefresh(state, now)
+
+	if pause := o.gitHubGraphQLPause(state, now); pause > 0 {
+		o.logger.Warn("github graphql polling paused", "remaining", gitHubGraphQLRemaining(state), "pause", pause)
+		return
+	}
+
+	o.refreshActiveRuns(ctx, state, now)
+	fetched, ok := o.fetchTickIssues(ctx)
+	if !ok {
+		return
+	}
+
+	transitions := o.refreshTransitionSets(ctx, state, fetched, previous)
+	completedEpics := o.resolveCompletedEpics(ctx, state, transitions, previous)
+	fetched = filterReconciledTickIssues(
+		state,
+		fetched,
+		o.reconcileClosedCompletedIssueStatuses(ctx, state, transitions.issues, now),
+	)
+	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
+}
+
+func captureTickPreviousState(state *State) tickPreviousState {
+	return tickPreviousState{
+		lastRefreshAt:            state.LastRefreshAt,
+		pipeline:                 cloneIssues(state.Pipeline),
+		epicTransitionWatch:      cloneIssues(state.epicTransitionWatch),
+		blockedStatusIssues:      blockedStatusTransitionIssues(state.Blocked),
+		pendingEpicParentLookups: cloneIssueMap(state.pendingEpicParentLookups),
+	}
+}
+
+func (o *Orchestrator) refreshActiveRuns(ctx context.Context, state *State, now time.Time) {
+	o.reapWorkspacesIfDue(ctx, state, now)
+	o.reconcileRunningIssues(ctx, state, now)
+	o.heartbeatRunningClaims(ctx, state, now)
+}
+
+func (o *Orchestrator) fetchTickIssues(ctx context.Context) (tickFetchedIssues, bool) {
+	issues, err := o.connector.FetchCandidateIssues(ctx)
+	if err != nil {
+		o.logger.Warn("fetch candidate issues failed", "error", err)
+		return tickFetchedIssues{}, false
+	}
+
+	fetched := tickFetchedIssues{
+		candidates: cloneIssues(issues),
+	}
+	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, observedStatusFetchStates())
+	if statusErr != nil {
+		o.logger.Warn("fetch observed status issues failed", "error", statusErr)
+		return fetched, true
+	}
+	fetched.status = cloneIssues(statusIssues)
+	fetched.statusOK = true
+	return fetched, true
+}
+
+func (o *Orchestrator) refreshTransitionSets(
+	ctx context.Context,
+	state *State,
+	fetched tickFetchedIssues,
+	previous tickPreviousState,
+) tickTransitionRefresh {
+	transitionIssues := cloneIssues(fetched.candidates)
+	pipelineIssues, pipelineRefreshOK := o.fetchEpicTransitionIssueStates(ctx, previous.pipeline)
+	transitionIssues = append(transitionIssues, pipelineIssues...)
+	watchedIssues, watchRefreshOK := o.fetchEpicTransitionIssueStates(ctx, previous.epicTransitionWatch)
+	transitionIssues = append(transitionIssues, watchedIssues...)
+	blockedIssues, blockedRefreshOK := o.fetchEpicTransitionIssueStates(ctx, previous.blockedStatusIssues)
+	transitionIssues = append(transitionIssues, blockedIssues...)
+	pendingTransitions, pendingParentLookups := o.refreshPendingEpicParentLookups(ctx, previous.pendingEpicParentLookups)
+	transitionIssues = append(transitionIssues, pendingTransitions...)
+
+	state.epicTransitionWatch = issuesInStates(fetched.candidates, o.cfg.ActiveStates)
+	if !watchRefreshOK {
+		state.epicTransitionWatch = mergeIssueSlices(state.epicTransitionWatch, previous.epicTransitionWatch)
+	}
+	if fetched.statusOK {
+		transitionIssues = append(transitionIssues, fetched.status...)
+		state.Pipeline = issuesInStates(fetched.status, prPipelineFetchStates())
+		if !pipelineRefreshOK {
+			state.Pipeline = mergeIssueSlices(state.Pipeline, previous.pipeline)
+		}
+	}
+
+	return tickTransitionRefresh{
+		issues:               transitionIssues,
+		pendingTransitions:   pendingTransitions,
+		pendingParentLookups: pendingParentLookups,
+		blockedRefreshOK:     blockedRefreshOK,
+	}
+}
+
+func (o *Orchestrator) resolveCompletedEpics(
+	ctx context.Context,
+	state *State,
+	transitions tickTransitionRefresh,
+	previous tickPreviousState,
+) map[string]struct{} {
+	previousTransitions := mergeIssueSlices(previous.pipeline, previous.epicTransitionWatch)
+	previousTransitions = mergeIssueSlices(previousTransitions, previous.blockedStatusIssues)
+	completedEpics, failedParentLookups := o.closeCompletedEpicsForTerminalTransitions(
+		ctx,
+		transitions.issues,
+		previousTransitions,
+		previous.lastRefreshAt,
+		transitions.pendingTransitions,
+	)
+	state.pendingEpicParentLookups = mergeIssueMaps(transitions.pendingParentLookups, failedParentLookups)
+	return completedEpics
+}
+
+func filterReconciledTickIssues(
+	state *State,
+	fetched tickFetchedIssues,
+	reconciled map[string]struct{},
+) tickFetchedIssues {
+	fetched.candidates = filterReconciledIssues(fetched.candidates, reconciled)
+	fetched.status = filterReconciledIssues(fetched.status, reconciled)
+	state.epicTransitionWatch = filterReconciledIssues(state.epicTransitionWatch, reconciled)
+	state.Pipeline = filterReconciledIssues(state.Pipeline, reconciled)
+	return fetched
+}
+
+func (o *Orchestrator) dispatchTickIssues(
+	ctx context.Context,
+	state *State,
+	fetched tickFetchedIssues,
+	transitions tickTransitionRefresh,
+	previous tickPreviousState,
+	completedEpics map[string]struct{},
+	now time.Time,
+) {
+	issues := filterCompletedEpicCandidates(fetched.candidates, completedEpics)
+	planner := o.dispatchPlanner()
+	planner.pruneBudgetRefusals(state, now)
+	planner.trackBlockedCandidates(state, issues, now)
+	if fetched.statusOK {
+		currentBlockedStatusIssues := issuesInStates(fetched.status, []string{blockedStatusState})
+		if !transitions.blockedRefreshOK {
+			currentBlockedStatusIssues = mergeIssueSlices(currentBlockedStatusIssues, previous.blockedStatusIssues)
+		}
+		o.trackBlockedStatusIssues(state, currentBlockedStatusIssues, now)
+	}
+	o.dispatchReadyIssues(ctx, state, issues, now)
+}


### PR DESCRIPTION
## Summary

- Split the orchestrator tick path into named refresh/reconciliation/dispatch helpers in `tick.go`.
- Added a shared dispatch planner used by both `PlanDispatch` and live `dispatchReadyIssues`.
- Extended recorded dispatch parity coverage to assert `PlanDispatch` results directly.

Fixes #330

## Test Plan

- [x] `go test ./internal/orchestrator`
- [x] `go test ./...`
- [x] `make check`