### PR TITLE
chore(quality): enable stricter linting

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,7 +9,9 @@ linters:
   default: none
   enable:
     - bodyclose
+    - contextcheck
     - errcheck
+    - errorlint
     - gosec
     - govet
     - ineffassign
@@ -72,6 +74,9 @@ linters:
       - path: internal/database/sqlc/
         linters:
           - all
+      - linters:
+          - contextcheck
+        text: "Non-inherited new context"
 
 issues:
   max-issues-per-linter: 0

--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -43,7 +43,7 @@ func newRootCommand(ctx context.Context) *cobra.Command {
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.AddCommand(
 		newVersionCommand(),
-		newUpdateCommand(newDefaultUpdateRunner),
+		newUpdateCommand(ctx, newDefaultUpdateRunner),
 		newShadowRunCommand(),
 	)
 

--- a/cmd/detent/update.go
+++ b/cmd/detent/update.go
@@ -21,9 +21,9 @@ type updateRunner interface {
 	Apply(context.Context, detentupdate.ApplyOptions) (detentupdate.Status, error)
 }
 
-type updateFactory func() (updateRunner, error)
+type updateFactory func(context.Context) (updateRunner, error)
 
-func newUpdateCommand(factory updateFactory) *cobra.Command {
+func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command {
 	var checkOnly bool
 	var assumeYes bool
 	var fromRelease bool
@@ -35,14 +35,21 @@ func newUpdateCommand(factory updateFactory) *cobra.Command {
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			runner, err := factory()
+			runCtx := cmd.Context()
+			if runCtx == nil {
+				runCtx = ctx
+			}
+			if runCtx == nil {
+				runCtx = context.Background()
+			}
+			runner, err := factory(runCtx)
 			if err != nil {
 				return err
 			}
 
 			var status detentupdate.Status
 			if checkOnly {
-				status, err = runner.Check(cmd.Context())
+				status, err = runner.Check(runCtx)
 			} else {
 				streamOut := cmd.OutOrStdout()
 				if jsonOutput {
@@ -58,7 +65,7 @@ func newUpdateCommand(factory updateFactory) *cobra.Command {
 					opts.Confirm = confirmUpdate(cmd)
 					opts.SelectGoInstallAction = selectGoInstallAction(cmd)
 				}
-				status, err = runner.Apply(cmd.Context(), opts)
+				status, err = runner.Apply(runCtx, opts)
 			}
 
 			var writeErr error
@@ -80,7 +87,7 @@ func newUpdateCommand(factory updateFactory) *cobra.Command {
 	return cmd
 }
 
-func newDefaultUpdateRunner() (updateRunner, error) {
+func newDefaultUpdateRunner(context.Context) (updateRunner, error) {
 	executable, err := os.Executable()
 	if err != nil {
 		return nil, fmt.Errorf("resolve current executable: %w", err)

--- a/cmd/detent/update_test.go
+++ b/cmd/detent/update_test.go
@@ -25,7 +25,7 @@ func TestUpdateCommandCheckJSON(t *testing.T) {
 			Message:         "Detent 1.2.3 can be updated to 1.2.4.",
 		},
 	}
-	cmd := newUpdateCommand(func() (updateRunner, error) {
+	cmd := newUpdateCommand(context.Background(), func(context.Context) (updateRunner, error) {
 		return fake, nil
 	})
 	var stdout bytes.Buffer
@@ -68,7 +68,7 @@ func TestUpdateCommandYesAppliesWithoutPrompt(t *testing.T) {
 			Message:         "Updated Detent from 1.2.3 to 1.2.4.",
 		},
 	}
-	cmd := newUpdateCommand(func() (updateRunner, error) {
+	cmd := newUpdateCommand(context.Background(), func(context.Context) (updateRunner, error) {
 		return fake, nil
 	})
 	var stdout bytes.Buffer
@@ -109,7 +109,7 @@ func TestUpdateCommandFromReleasePassesOptionWithoutPrompt(t *testing.T) {
 			Message:         "Updated Detent from 1.2.3 to 1.2.4.",
 		},
 	}
-	cmd := newUpdateCommand(func() (updateRunner, error) {
+	cmd := newUpdateCommand(context.Background(), func(context.Context) (updateRunner, error) {
 		return fake, nil
 	})
 	var stdout bytes.Buffer
@@ -137,7 +137,7 @@ func TestUpdateCommandFromReleasePassesOptionWithoutPrompt(t *testing.T) {
 func TestSelectGoInstallActionParsesReleaseChoice(t *testing.T) {
 	t.Parallel()
 
-	cmd := newUpdateCommand(func() (updateRunner, error) {
+	cmd := newUpdateCommand(context.Background(), func(context.Context) (updateRunner, error) {
 		return &fakeUpdater{}, nil
 	})
 	var stdout bytes.Buffer
@@ -182,7 +182,7 @@ func TestUpdateCommandJSONWritesRefusalStatus(t *testing.T) {
 		},
 		applyErr: update.ErrRefused,
 	}
-	cmd := newUpdateCommand(func() (updateRunner, error) {
+	cmd := newUpdateCommand(context.Background(), func(context.Context) (updateRunner, error) {
 		return fake, nil
 	})
 	var stdout bytes.Buffer

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -297,7 +297,7 @@ This issue will be reconsidered after: %s
 	}
 }
 
-func (c *Checker) refusal(code ReasonCode, req DispatchRequest, now time.Time, currentSpend float64, projectedCost float64, cap float64, resetAt *time.Time) *Refusal {
+func (c *Checker) refusal(code ReasonCode, req DispatchRequest, now time.Time, currentSpend float64, projectedCost float64, maxUSD float64, resetAt *time.Time) *Refusal {
 	message := "budget exceeded"
 	switch code {
 	case ReasonPerDayMaxUSD:
@@ -306,7 +306,6 @@ func (c *Checker) refusal(code ReasonCode, req DispatchRequest, now time.Time, c
 		message = "per-issue budget exceeded"
 	}
 
-	maxUSD := cap
 	projectedSpend := currentSpend + projectedCost
 	return &Refusal{
 		Code:              code,
@@ -347,8 +346,8 @@ func tokenCostUSD(tokens TokenEstimate, pricing ModelPricing) float64 {
 		float64(tokens.OutputTokens)*pricing.USDPerOutputToken
 }
 
-func capActive(cap float64) bool {
-	return cap > 0
+func capActive(maxUSD float64) bool {
+	return maxUSD > 0
 }
 
 func issueIdentityPresent(identity store.IssueIdentity) bool {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -69,9 +69,9 @@ type LoggerFunc func(RuntimeSettings, io.Writer, io.Writer, bool)
 
 type ProjectManager interface {
 	Add(context.Context, globalconfig.Project) error
-	Remove(context.Context, project.ProjectID) error
-	Pause(context.Context, project.ProjectID) error
-	Unpause(context.Context, project.ProjectID) error
+	Remove(context.Context, project.ID) error
+	Pause(context.Context, project.ID) error
+	Unpause(context.Context, project.ID) error
 }
 
 type Option func(*options)
@@ -149,11 +149,11 @@ func ProjectManagerSignalFunc(manager ProjectManager) SignalFunc {
 		case OperationAddProject:
 			return manager.Add(ctx, signal.Project)
 		case OperationRemoveProject:
-			return manager.Remove(ctx, project.ProjectID(signal.ProjectID))
+			return manager.Remove(ctx, project.ID(signal.ProjectID))
 		case OperationPauseProject:
-			return manager.Pause(ctx, project.ProjectID(signal.ProjectID))
+			return manager.Pause(ctx, project.ID(signal.ProjectID))
 		case OperationUnpauseProject:
-			return manager.Unpause(ctx, project.ProjectID(signal.ProjectID))
+			return manager.Unpause(ctx, project.ID(signal.ProjectID))
 		default:
 			return nil
 		}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -778,14 +778,14 @@ func (p *projectManagerProbe) Add(_ context.Context, cfg globalconfig.Project) e
 	return nil
 }
 
-func (p *projectManagerProbe) Remove(context.Context, project.ProjectID) error {
+func (p *projectManagerProbe) Remove(context.Context, project.ID) error {
 	return nil
 }
 
-func (p *projectManagerProbe) Pause(context.Context, project.ProjectID) error {
+func (p *projectManagerProbe) Pause(context.Context, project.ID) error {
 	return nil
 }
 
-func (p *projectManagerProbe) Unpause(context.Context, project.ProjectID) error {
+func (p *projectManagerProbe) Unpause(context.Context, project.ID) error {
 	return nil
 }

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -203,7 +203,7 @@ func changedGlobalSettings(previous globalconfig.Settings, next globalconfig.Set
 	return fields
 }
 
-func projectIDs(ids []project.ProjectID) []string {
+func projectIDs(ids []project.ID) []string {
 	out := make([]string, 0, len(ids))
 	for _, id := range ids {
 		out = append(out, string(id))

--- a/internal/cli/global_reload_test.go
+++ b/internal/cli/global_reload_test.go
@@ -170,7 +170,7 @@ func (m *globalReloadManager) Reconcile(
 ) (project.ReconcileResult, error) {
 	m.calls++
 	m.config = cfg
-	return project.ReconcileResult{Added: []project.ProjectID{"bravo"}}, m.err
+	return project.ReconcileResult{Added: []project.ID{"bravo"}}, m.err
 }
 
 func reloadTestConfig(path string, maxConcurrentAgents int, projects []globalconfig.Project) globalconfig.Config {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -32,7 +32,7 @@ type lifetimeTotalsSource interface {
 	LifetimeTotals(context.Context) (store.LifetimeTotals, error)
 }
 
-// withRunnerFactory returns a project.ProjectFactory that constructs a
+// withRunnerFactory returns a project.Factory that constructs a
 // per-project agent Runner from the project's own workflow (so each project's
 // codex command and workspace root are honored), injects it into the project's
 // dependencies, and then delegates to load.
@@ -43,7 +43,7 @@ func withRunnerFactory(
 	sessionStore runnerpkg.SessionStore,
 	load func(project.Dependencies) (*project.Project, error),
 	githubTokenSource ...func() string,
-) project.ProjectFactory {
+) project.Factory {
 	return func(cfg globalconfig.Project) (*project.Project, error) {
 		workflow, err := workflowconfig.LoadWorkflow(cfg.Workflow)
 		if err != nil {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -116,7 +116,7 @@ func TestProjectDependenciesInjectsNonNilRunner(t *testing.T) {
 		Workdir:  filepath.Dir(workflowPath),
 		Weight:   1,
 	})
-	if err != errProjectFactoryStub {
+	if !errors.Is(err, errProjectFactoryStub) {
 		t.Fatalf("ProjectFactory() error = %v, want stub", err)
 	}
 	if captured.Runner == nil {
@@ -146,7 +146,7 @@ func TestProjectDependenciesUseRuntimeGitHubTokenSource(t *testing.T) {
 		Workdir:  filepath.Dir(workflowPath),
 		Weight:   1,
 	})
-	if err != errProjectFactoryStub {
+	if !errors.Is(err, errProjectFactoryStub) {
 		t.Fatalf("ProjectFactory() error = %v, want %v", err, errProjectFactoryStub)
 	}
 	if captured.GitHubToken != "first-token" {
@@ -160,7 +160,7 @@ func TestProjectDependenciesUseRuntimeGitHubTokenSource(t *testing.T) {
 		Workdir:  filepath.Dir(workflowPath),
 		Weight:   1,
 	})
-	if err != errProjectFactoryStub {
+	if !errors.Is(err, errProjectFactoryStub) {
 		t.Fatalf("ProjectFactory() error = %v, want %v", err, errProjectFactoryStub)
 	}
 	if captured.GitHubToken != "second-token" {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -180,7 +180,7 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		return RunTurnResult{}, fmt.Errorf("start codex app-server transport: %w", err)
 	}
 	defer func() {
-		closeErr := closeTransport(transport, s.readTimeout)
+		closeErr := closeTransport(ctx, transport, s.readTimeout)
 		if err == nil && closeErr != nil {
 			err = closeErr
 		}
@@ -713,8 +713,9 @@ func rawPayload(msg Message) json.RawMessage {
 	return data
 }
 
-func closeTransport(transport Transport, timeout time.Duration) error {
-	ctx := context.Background()
+func closeTransport(ctx context.Context, transport Transport, timeout time.Duration) error {
+	ctx = contextOrBackground(ctx)
+	ctx = context.WithoutCancel(ctx)
 	if timeout > 0 {
 		var cancel context.CancelFunc
 		ctx, cancel = context.WithTimeout(ctx, timeout)

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"strconv"
 	"strings"
 
@@ -14,6 +13,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/pathsafe"
 	"github.com/digitaldrywood/detent/internal/selector"
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
 )
@@ -37,8 +37,6 @@ const (
 	IdentityOwnershipAssignee = "assignee"
 	IdentityOwnershipField    = "field"
 )
-
-var windowsAbsPathPattern = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
 
 type Workflow struct {
 	Config Config
@@ -1172,22 +1170,7 @@ func validPriorityRank(value any) bool {
 }
 
 func validateWorkspaceRelativePath(field string, path string, problems *[]string) {
-	trimmed := strings.TrimSpace(path)
-	if trimmed == "" || strings.HasPrefix(trimmed, "~") || filepath.IsAbs(trimmed) ||
-		strings.HasPrefix(trimmed, `/`) || strings.HasPrefix(trimmed, `\`) ||
-		windowsAbsPathPattern.MatchString(trimmed) ||
-		pathEscapesWorkspace(trimmed) {
+	if !pathsafe.IsWorkspaceRelative(path) {
 		*problems = append(*problems, field+" must be a relative path inside the workspace")
 	}
-}
-
-func pathEscapesWorkspace(path string) bool {
-	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
-		return r == '/' || r == '\\'
-	}) {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
 }

--- a/internal/lessons/lessons.go
+++ b/internal/lessons/lessons.go
@@ -141,7 +141,7 @@ func parseEntries(content string) []string {
 }
 
 func writeEntries(path string, entries []string) error {
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -352,7 +353,7 @@ func TestMemoryConnectorOrchestratorsPartitionSharedIssuesByAuthorization(t *tes
 			cancel()
 			select {
 			case err := <-done:
-				if err != context.Canceled {
+				if !errors.Is(err, context.Canceled) {
 					t.Fatalf("Run() error = %v, want context canceled", err)
 				}
 			case <-time.After(time.Second):

--- a/internal/pathsafe/workspace.go
+++ b/internal/pathsafe/workspace.go
@@ -34,6 +34,7 @@ func IsWorkspaceRelative(relativePath string) bool {
 	return path != "" &&
 		!strings.HasPrefix(path, "~") &&
 		!filepath.IsAbs(path) &&
+		!strings.HasPrefix(path, "/") &&
 		!strings.HasPrefix(path, `\`) &&
 		!windowsAbsPathPattern.MatchString(path) &&
 		!escapesWorkspace(path)

--- a/internal/pathsafe/workspace.go
+++ b/internal/pathsafe/workspace.go
@@ -1,0 +1,51 @@
+package pathsafe
+
+import (
+	"errors"
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+var windowsAbsPathPattern = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
+
+func WorkspaceRelative(workspacePath string, relativePath string) (string, error) {
+	workspace := strings.TrimSpace(workspacePath)
+	if workspace == "" {
+		return "", errors.New("workspace path is required")
+	}
+
+	if !IsWorkspaceRelative(relativePath) {
+		return "", errors.New("path must be a relative path inside the workspace")
+	}
+
+	absWorkspace, err := filepath.Abs(workspace)
+	if err != nil {
+		return "", fmt.Errorf("absolute workspace path: %w", err)
+	}
+
+	path := strings.TrimSpace(relativePath)
+	return filepath.Join(absWorkspace, filepath.Clean(path)), nil
+}
+
+func IsWorkspaceRelative(relativePath string) bool {
+	path := strings.TrimSpace(relativePath)
+	return path != "" &&
+		!strings.HasPrefix(path, "~") &&
+		!filepath.IsAbs(path) &&
+		!strings.HasPrefix(path, `\`) &&
+		!windowsAbsPathPattern.MatchString(path) &&
+		!escapesWorkspace(path)
+}
+
+func escapesWorkspace(path string) bool {
+	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\'
+	}) {
+		if part == ".." {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/pathsafe/workspace_test.go
+++ b/internal/pathsafe/workspace_test.go
@@ -1,0 +1,67 @@
+package pathsafe
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestWorkspaceRelativeResolvesCleanPath(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	got, err := WorkspaceRelative(" "+workspace+" ", " .detent/skills/. ")
+	if err != nil {
+		t.Fatalf("WorkspaceRelative() error = %v", err)
+	}
+
+	want := filepath.Join(workspace, ".detent", "skills")
+	if got != want {
+		t.Fatalf("WorkspaceRelative() = %q, want %q", got, want)
+	}
+}
+
+func TestWorkspaceRelativeRejectsUnsafePaths(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	tests := []string{
+		"",
+		"~/skills",
+		"/tmp/skills",
+		`\tmp\skills`,
+		`C:\tmp\skills`,
+		"../skills",
+		"skills/../skills",
+		`skills\..\skills`,
+	}
+
+	for _, path := range tests {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := WorkspaceRelative(workspace, path)
+			if err == nil {
+				t.Fatal("WorkspaceRelative() error = nil, want error")
+			}
+			if IsWorkspaceRelative(path) {
+				t.Fatal("IsWorkspaceRelative() = true, want false")
+			}
+			if !strings.Contains(err.Error(), "relative path inside the workspace") {
+				t.Fatalf("WorkspaceRelative() error = %v, want workspace-relative path error", err)
+			}
+		})
+	}
+}
+
+func TestWorkspaceRelativeRejectsMissingWorkspace(t *testing.T) {
+	t.Parallel()
+
+	_, err := WorkspaceRelative("", ".detent/skills")
+	if err == nil {
+		t.Fatal("WorkspaceRelative() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "workspace path is required") {
+		t.Fatalf("WorkspaceRelative() error = %v, want workspace path error", err)
+	}
+}

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -21,7 +21,7 @@ var (
 	ErrProjectNotFound = errors.New("project not found")
 )
 
-type ProjectFactory func(globalconfig.Project) (*Project, error)
+type Factory func(globalconfig.Project) (*Project, error)
 
 type StartupConfig struct {
 	Jitter            time.Duration
@@ -36,10 +36,10 @@ type ManagerConfig struct {
 }
 
 type ReconcileResult struct {
-	Added     []ProjectID
-	Removed   []ProjectID
-	Changed   []ProjectID
-	Unchanged []ProjectID
+	Added     []ID
+	Removed   []ID
+	Changed   []ID
+	Unchanged []ID
 }
 
 type startedProject struct {
@@ -53,7 +53,7 @@ type rollbackProject struct {
 
 type ManagerDependencies struct {
 	Registry            *Registry
-	ProjectFactory      ProjectFactory
+	ProjectFactory      Factory
 	ProjectDependencies Dependencies
 	Events              *hub.Hub[Event]
 	Logger              *slog.Logger
@@ -65,7 +65,7 @@ type Manager struct {
 	mu       sync.Mutex
 	cfg      ManagerConfig
 	registry *Registry
-	factory  ProjectFactory
+	factory  Factory
 	sleep    func(context.Context, time.Duration) error
 	jitter   func(time.Duration) time.Duration
 
@@ -162,7 +162,7 @@ func (m *Manager) Add(ctx context.Context, cfg globalconfig.Project) error {
 	return m.addLocked(ctx, cfg)
 }
 
-func (m *Manager) Remove(ctx context.Context, id ProjectID) error {
+func (m *Manager) Remove(ctx context.Context, id ID) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -179,10 +179,10 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	}
 
 	cfg = normalizeManagerConfig(cfg)
-	desired := make(map[ProjectID]globalconfig.Project, len(cfg.Projects))
+	desired := make(map[ID]globalconfig.Project, len(cfg.Projects))
 	for i, project := range cfg.Projects {
 		normalized := project
-		id := ProjectID(normalized.ID)
+		id := ID(normalized.ID)
 		if id == "" {
 			return ReconcileResult{}, ErrMissingProjectID
 		}
@@ -213,13 +213,13 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	}
 
 	for _, next := range cfg.Projects {
-		id := ProjectID(next.ID)
+		id := ID(next.ID)
 		if _, ok := m.registry.Get(id); !ok {
 			result.Added = append(result.Added, id)
 		}
 	}
 
-	prepared := make(map[ProjectID]*Project, len(result.Added)+len(result.Changed))
+	prepared := make(map[ID]*Project, len(result.Added)+len(result.Changed))
 	for _, id := range result.Changed {
 		_, preparedProject, err := m.createProjectLocked(desired[id])
 		if err != nil {
@@ -240,7 +240,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	m.cfg.Startup = cfg.Startup
 	stopped := make([]rollbackProject, 0, len(result.Removed)+len(result.Changed))
 	started := make([]startedProject, 0, len(prepared))
-	added := map[ProjectID]struct{}{}
+	added := map[ID]struct{}{}
 	rollback := func() error {
 		cleanupErr := m.stopUncommittedStartedProjects(ctx, started)
 		for id := range added {
@@ -333,7 +333,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	return result, nil
 }
 
-func (m *Manager) removeLocked(ctx context.Context, id ProjectID) error {
+func (m *Manager) removeLocked(ctx context.Context, id ID) error {
 	project, ok := m.registry.Get(id)
 	if !ok {
 		return ErrProjectNotFound
@@ -347,7 +347,7 @@ func (m *Manager) removeLocked(ctx context.Context, id ProjectID) error {
 	return nil
 }
 
-func (m *Manager) Pause(ctx context.Context, id ProjectID) error {
+func (m *Manager) Pause(ctx context.Context, id ID) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -362,7 +362,7 @@ func (m *Manager) Pause(ctx context.Context, id ProjectID) error {
 	return project.Pause(ctx)
 }
 
-func (m *Manager) Unpause(ctx context.Context, id ProjectID) error {
+func (m *Manager) Unpause(ctx context.Context, id ID) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -391,7 +391,7 @@ func (m *Manager) Unpause(ctx context.Context, id ProjectID) error {
 
 func (m *Manager) addLocked(ctx context.Context, cfg globalconfig.Project) error {
 	cfg = normalizeManagerProjectConfigWithIdentity(cfg, m.cfg.Identity)
-	id := ProjectID(cfg.ID)
+	id := ID(cfg.ID)
 	if id == "" {
 		return ErrMissingProjectID
 	}
@@ -406,8 +406,8 @@ func (m *Manager) addLocked(ctx context.Context, cfg globalconfig.Project) error
 	return m.registerProjectLocked(ctx, id, project)
 }
 
-func (m *Manager) createProjectLocked(cfg globalconfig.Project) (ProjectID, *Project, error) {
-	id := normalizeProjectID(ProjectID(cfg.ID))
+func (m *Manager) createProjectLocked(cfg globalconfig.Project) (ID, *Project, error) {
+	id := normalizeProjectID(ID(cfg.ID))
 	if id == "" {
 		return "", nil, ErrMissingProjectID
 	}
@@ -419,7 +419,7 @@ func (m *Manager) createProjectLocked(cfg globalconfig.Project) (ProjectID, *Pro
 	return id, project, nil
 }
 
-func (m *Manager) registerProjectLocked(ctx context.Context, id ProjectID, project *Project) error {
+func (m *Manager) registerProjectLocked(ctx context.Context, id ID, project *Project) error {
 	if err := m.registry.Set(project); err != nil {
 		return err
 	}
@@ -507,7 +507,7 @@ func startupInt(values map[string]any, key string) int {
 }
 
 func normalizeManagerProjectConfig(cfg globalconfig.Project) globalconfig.Project {
-	cfg.ID = string(normalizeProjectID(ProjectID(cfg.ID)))
+	cfg.ID = string(normalizeProjectID(ID(cfg.ID)))
 	cfg.Identity.Normalize()
 	return cfg
 }

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -60,11 +60,11 @@ func TestManagerStartsProjectsWithStartupLimits(t *testing.T) {
 		t.Fatalf("sleep delays = %v, want %v", slept, wantSleeps)
 	}
 
-	started := []project.ProjectID{
+	started := []project.ID{
 		receiveEvent(t, sub.C()).ProjectID,
 		receiveEvent(t, sub.C()).ProjectID,
 	}
-	if !reflect.DeepEqual(started, []project.ProjectID{"alpha", "bravo"}) {
+	if !reflect.DeepEqual(started, []project.ID{"alpha", "bravo"}) {
 		t.Fatalf("started projects = %v, want [alpha bravo]", started)
 	}
 	if manager.Registry().Len() != 3 {
@@ -161,7 +161,7 @@ func TestManagerReconcileProjects(t *testing.T) {
 		next        []globalconfig.Project
 		want        project.ReconcileResult
 		wantEvents  []project.Event
-		wantConfigs map[project.ProjectID]globalconfig.Project
+		wantConfigs map[project.ID]globalconfig.Project
 		wantErr     error
 	}{
 		{
@@ -169,9 +169,9 @@ func TestManagerReconcileProjects(t *testing.T) {
 			initial: []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/alpha"}},
 			next:    []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/alpha"}},
 			want: project.ReconcileResult{
-				Unchanged: []project.ProjectID{"alpha"},
+				Unchanged: []project.ID{"alpha"},
 			},
-			wantConfigs: map[project.ProjectID]globalconfig.Project{
+			wantConfigs: map[project.ID]globalconfig.Project{
 				"alpha": {ID: "alpha", Weight: 1, Workdir: "/repo/alpha"},
 			},
 		},
@@ -183,11 +183,11 @@ func TestManagerReconcileProjects(t *testing.T) {
 				{ID: "bravo", Weight: 2, Priority: 3, Workdir: "/repo/bravo"},
 			},
 			want: project.ReconcileResult{
-				Added:     []project.ProjectID{"bravo"},
-				Unchanged: []project.ProjectID{"alpha"},
+				Added:     []project.ID{"bravo"},
+				Unchanged: []project.ID{"alpha"},
 			},
 			wantEvents: []project.Event{{ProjectID: "bravo", Kind: project.EventStarted}},
-			wantConfigs: map[project.ProjectID]globalconfig.Project{
+			wantConfigs: map[project.ID]globalconfig.Project{
 				"alpha": {ID: "alpha", Weight: 1},
 				"bravo": {ID: "bravo", Weight: 2, Priority: 3, Workdir: "/repo/bravo"},
 			},
@@ -200,11 +200,11 @@ func TestManagerReconcileProjects(t *testing.T) {
 			},
 			next: []globalconfig.Project{{ID: "alpha", Weight: 1}},
 			want: project.ReconcileResult{
-				Removed:   []project.ProjectID{"bravo"},
-				Unchanged: []project.ProjectID{"alpha"},
+				Removed:   []project.ID{"bravo"},
+				Unchanged: []project.ID{"alpha"},
 			},
 			wantEvents: []project.Event{{ProjectID: "bravo", Kind: project.EventStopped}},
-			wantConfigs: map[project.ProjectID]globalconfig.Project{
+			wantConfigs: map[project.ID]globalconfig.Project{
 				"alpha": {ID: "alpha", Weight: 1},
 			},
 		},
@@ -213,13 +213,13 @@ func TestManagerReconcileProjects(t *testing.T) {
 			initial: []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/old"}},
 			next:    []globalconfig.Project{{ID: "alpha", Weight: 2, Priority: 1, Workdir: "/repo/new"}},
 			want: project.ReconcileResult{
-				Changed: []project.ProjectID{"alpha"},
+				Changed: []project.ID{"alpha"},
 			},
 			wantEvents: []project.Event{
 				{ProjectID: "alpha", Kind: project.EventStopped},
 				{ProjectID: "alpha", Kind: project.EventStarted},
 			},
-			wantConfigs: map[project.ProjectID]globalconfig.Project{
+			wantConfigs: map[project.ID]globalconfig.Project{
 				"alpha": {ID: "alpha", Weight: 2, Priority: 1, Workdir: "/repo/new"},
 			},
 		},
@@ -227,7 +227,7 @@ func TestManagerReconcileProjects(t *testing.T) {
 			name:    "invalid config retention",
 			initial: []globalconfig.Project{{ID: "alpha", Weight: 1, Workdir: "/repo/alpha"}},
 			next:    []globalconfig.Project{{ID: "  ", Weight: 1, Workdir: "/repo/invalid"}},
-			wantConfigs: map[project.ProjectID]globalconfig.Project{
+			wantConfigs: map[project.ID]globalconfig.Project{
 				"alpha": {ID: "alpha", Weight: 1, Workdir: "/repo/alpha"},
 			},
 			wantErr: project.ErrMissingProjectID,
@@ -313,7 +313,7 @@ func TestManagerReconcileChangesProjectsWhenRuntimeCredentialVersionChanges(t *t
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
-	want := project.ReconcileResult{Changed: []project.ProjectID{"alpha"}}
+	want := project.ReconcileResult{Changed: []project.ID{"alpha"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Reconcile() = %#v, want %#v", got, want)
 	}
@@ -365,7 +365,7 @@ func TestManagerReconcileKeepsRegistryWhenNewProjectCannotBeCreated(t *testing.T
 		t.Fatalf("Reconcile() error = %v, want %v", err, factoryErr)
 	}
 	assertNoProjectEvent(t, sub.C())
-	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+	assertManagerProjectConfigs(t, manager, map[project.ID]globalconfig.Project{
 		"alpha": {ID: "alpha", Weight: 1},
 	})
 }
@@ -409,7 +409,7 @@ func TestManagerReconcileKeepsChangedProjectWhenReplacementCannotBeCreated(t *te
 		t.Fatalf("Reconcile() error = %v, want %v", err, factoryErr)
 	}
 	assertNoProjectEvent(t, sub.C())
-	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+	assertManagerProjectConfigs(t, manager, map[project.ID]globalconfig.Project{
 		"alpha": {ID: "alpha", Weight: 1},
 	})
 
@@ -477,7 +477,7 @@ func TestManagerReconcileStopsChangedProjectBeforeStartingReplacement(t *testing
 	if err != nil {
 		t.Fatalf("Reconcile() error = %v", err)
 	}
-	want := project.ReconcileResult{Changed: []project.ProjectID{"alpha"}}
+	want := project.ReconcileResult{Changed: []project.ID{"alpha"}}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("Reconcile() = %#v, want %#v", got, want)
 	}
@@ -486,7 +486,7 @@ func TestManagerReconcileStopsChangedProjectBeforeStartingReplacement(t *testing
 		{ProjectID: "alpha", Kind: project.EventStarted},
 	})
 	assertNoProjectEvent(t, sub.C())
-	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+	assertManagerProjectConfigs(t, manager, map[project.ID]globalconfig.Project{
 		"alpha": {ID: "alpha", Weight: 2},
 	})
 }
@@ -540,7 +540,7 @@ func TestManagerReconcileKeepsChangedProjectWhenReplacementProvisionFails(t *tes
 		t.Fatalf("Reconcile() error = %v, want %v", err, provisionErr)
 	}
 	assertNoProjectEvent(t, sub.C())
-	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+	assertManagerProjectConfigs(t, manager, map[project.ID]globalconfig.Project{
 		"alpha": {ID: "alpha", Weight: 1},
 	})
 
@@ -591,7 +591,7 @@ func TestManagerReconcileKeepsChangedProjectWhenReplacementStartFails(t *testing
 		t.Fatalf("Reconcile() error = %v, want %v", err, project.ErrProjectStopped)
 	}
 	assertNoProjectEvent(t, sub.C())
-	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+	assertManagerProjectConfigs(t, manager, map[project.ID]globalconfig.Project{
 		"alpha": {ID: "alpha", Weight: 1},
 	})
 
@@ -648,7 +648,7 @@ func TestManagerReconcileKeepsRegistryWhenAddedProjectStartFailsAfterRemoval(t *
 		t.Fatalf("Reconcile() error = %v, want %v", err, project.ErrProjectStopped)
 	}
 	assertNoProjectEvent(t, sub.C())
-	assertManagerProjectConfigs(t, manager, map[project.ProjectID]globalconfig.Project{
+	assertManagerProjectConfigs(t, manager, map[project.ID]globalconfig.Project{
 		"alpha":   {ID: "alpha", Weight: 1},
 		"charlie": {ID: "charlie", Weight: 1},
 	})
@@ -687,9 +687,9 @@ func TestManagerSharedGlobalSchedulerGate(t *testing.T) {
 	if err := manager.Start(context.Background()); err != nil {
 		t.Fatalf("Start() error = %v", err)
 	}
-	assertStartedProjects(t, sub.C(), []project.ProjectID{"alpha", "bravo", "charlie"})
+	assertStartedProjects(t, sub.C(), []project.ID{"alpha", "bravo", "charlie"})
 
-	for _, id := range []project.ProjectID{"alpha", "bravo", "charlie"} {
+	for _, id := range []project.ID{"alpha", "bravo", "charlie"} {
 		got, ok := manager.Registry().Get(id)
 		if !ok {
 			t.Fatalf("Registry().Get(%q) ok = false, want true", id)
@@ -699,7 +699,7 @@ func TestManagerSharedGlobalSchedulerGate(t *testing.T) {
 		}
 	}
 
-	slots := requestProjectSlots(t, manager, []project.ProjectID{"alpha", "bravo"})
+	slots := requestProjectSlots(t, manager, []project.ID{"alpha", "bravo"})
 	if _, err := requestProjectSlot(manager, "charlie"); !errors.Is(err, scheduler.ErrNoSlots) {
 		t.Fatalf("charlie RequestSlot() error = %v, want ErrNoSlots", err)
 	}
@@ -863,7 +863,7 @@ func assertNoProjectEvent(t *testing.T, ch <-chan project.Event) {
 	}
 }
 
-func assertManagerProjectConfigs(t *testing.T, manager *project.Manager, want map[project.ProjectID]globalconfig.Project) {
+func assertManagerProjectConfigs(t *testing.T, manager *project.Manager, want map[project.ID]globalconfig.Project) {
 	t.Helper()
 
 	for id, expected := range want {
@@ -880,10 +880,10 @@ func assertManagerProjectConfigs(t *testing.T, manager *project.Manager, want ma
 	}
 }
 
-func assertStartedProjects(t *testing.T, ch <-chan project.Event, want []project.ProjectID) {
+func assertStartedProjects(t *testing.T, ch <-chan project.Event, want []project.ID) {
 	t.Helper()
 
-	got := make([]project.ProjectID, 0, len(want))
+	got := make([]project.ID, 0, len(want))
 	for range want {
 		event := receiveEvent(t, ch)
 		if event.Kind != project.EventStarted {
@@ -896,7 +896,7 @@ func assertStartedProjects(t *testing.T, ch <-chan project.Event, want []project
 	}
 }
 
-func requestProjectSlots(t *testing.T, manager *project.Manager, ids []project.ProjectID) []scheduler.Slot {
+func requestProjectSlots(t *testing.T, manager *project.Manager, ids []project.ID) []scheduler.Slot {
 	t.Helper()
 
 	slots := make([]scheduler.Slot, 0, len(ids))
@@ -910,7 +910,7 @@ func requestProjectSlots(t *testing.T, manager *project.Manager, ids []project.P
 	return slots
 }
 
-func requestProjectSlot(manager *project.Manager, id project.ProjectID) (scheduler.Slot, error) {
+func requestProjectSlot(manager *project.Manager, id project.ID) (scheduler.Slot, error) {
 	got, ok := manager.Registry().Get(id)
 	if !ok {
 		return scheduler.Slot{}, project.ErrProjectNotFound

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -39,12 +39,12 @@ const (
 	EventUnpaused EventKind = "project_unpaused"
 )
 
-type ProjectID string
+type ID string
 
 type EventKind string
 
 type Event struct {
-	ProjectID ProjectID
+	ProjectID ID
 	Kind      EventKind
 	At        time.Time
 	Error     string
@@ -83,7 +83,7 @@ type Dependencies struct {
 }
 
 type Project struct {
-	id               ProjectID
+	id               ID
 	cfg              globalconfig.Project
 	workflow         workflowconfig.Workflow
 	githubToken      string
@@ -118,7 +118,7 @@ func Load(cfg globalconfig.Project, deps Dependencies) (*Project, error) {
 }
 
 func New(cfg Config, deps Dependencies) (*Project, error) {
-	id := normalizeProjectID(ProjectID(cfg.Project.ID))
+	id := normalizeProjectID(ID(cfg.Project.ID))
 	if id == "" {
 		return nil, ErrMissingProjectID
 	}
@@ -197,7 +197,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	}, nil
 }
 
-func (p *Project) ID() ProjectID {
+func (p *Project) ID() ID {
 	if p == nil {
 		return ""
 	}
@@ -880,8 +880,8 @@ func maxConcurrentAgentsPerHost(cfg workflowconfig.Config) int {
 	return *cfg.Worker.MaxConcurrentAgentsPerHost
 }
 
-func normalizeProjectID(id ProjectID) ProjectID {
-	return ProjectID(strings.TrimSpace(string(id)))
+func normalizeProjectID(id ID) ID {
+	return ID(strings.TrimSpace(string(id)))
 }
 
 func errorString(err error) string {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -67,7 +67,7 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	if got.ID() != project.ProjectID("detent") {
+	if got.ID() != project.ID("detent") {
 		t.Fatalf("ID() = %q, want detent", got.ID())
 	}
 	if got.Config().Workdir != "/workspace/detent" {

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -7,12 +7,12 @@ import (
 
 type Registry struct {
 	mu       sync.RWMutex
-	projects map[ProjectID]*Project
+	projects map[ID]*Project
 }
 
 func NewRegistry() *Registry {
 	return &Registry{
-		projects: map[ProjectID]*Project{},
+		projects: map[ID]*Project{},
 	}
 }
 
@@ -33,7 +33,7 @@ func (r *Registry) Set(project *Project) error {
 	return nil
 }
 
-func (r *Registry) Get(id ProjectID) (*Project, bool) {
+func (r *Registry) Get(id ID) (*Project, bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
@@ -41,7 +41,7 @@ func (r *Registry) Get(id ProjectID) (*Project, bool) {
 	return project, ok
 }
 
-func (r *Registry) Delete(id ProjectID) bool {
+func (r *Registry) Delete(id ID) bool {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
@@ -58,7 +58,7 @@ func (r *Registry) List() []*Project {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	ids := make([]ProjectID, 0, len(r.projects))
+	ids := make([]ID, 0, len(r.projects))
 	for id := range r.projects {
 		ids = append(ids, id)
 	}

--- a/internal/project/registry_test.go
+++ b/internal/project/registry_test.go
@@ -1,6 +1,7 @@
 package project_test
 
 import (
+	"errors"
 	"testing"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -21,7 +22,7 @@ func TestRegistryStoresAndListsProjectsByID(t *testing.T) {
 		t.Fatalf("Set(first) error = %v", err)
 	}
 
-	got, ok := registry.Get(project.ProjectID("alpha"))
+	got, ok := registry.Get(project.ID("alpha"))
 	if !ok {
 		t.Fatal("Get(alpha) ok = false, want true")
 	}
@@ -66,12 +67,12 @@ func TestRegistryRejectsInvalidProject(t *testing.T) {
 
 	registry := project.NewRegistry()
 
-	if err := registry.Set(nil); err != project.ErrMissingProject {
+	if err := registry.Set(nil); !errors.Is(err, project.ErrMissingProject) {
 		t.Fatalf("Set(nil) error = %v, want %v", err, project.ErrMissingProject)
 	}
 
 	invalid := &project.Project{}
-	if err := registry.Set(invalid); err != project.ErrMissingProjectID {
+	if err := registry.Set(invalid); !errors.Is(err, project.ErrMissingProjectID) {
 		t.Fatalf("Set(invalid) error = %v, want %v", err, project.ErrMissingProjectID)
 	}
 }

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -3,7 +3,6 @@ package runner
 import (
 	"errors"
 	"fmt"
-	"path/filepath"
 	"regexp"
 	"strconv"
 	"strings"
@@ -13,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/pathsafe"
 	"github.com/digitaldrywood/detent/internal/skills"
 )
 
@@ -32,7 +32,6 @@ No description provided.
 var (
 	templateVariablePattern = regexp.MustCompile(`{{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*}}`)
 	conditionalTagPattern   = regexp.MustCompile(`{%\s*(if\s+([A-Za-z_][A-Za-z0-9_.]*)|else|endif)\s*%}`)
-	windowsAbsPathPattern   = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
 )
 
 type PromptOptions struct {
@@ -417,33 +416,5 @@ func formatTemplateValue(value any) string {
 }
 
 func promptWorkspaceRelativePath(workspacePath string, relativePath string) (string, error) {
-	workspace := strings.TrimSpace(workspacePath)
-	if workspace == "" {
-		return "", errors.New("workspace path is required")
-	}
-
-	path := strings.TrimSpace(relativePath)
-	if path == "" || strings.HasPrefix(path, "~") || filepath.IsAbs(path) ||
-		strings.HasPrefix(path, `\`) || windowsAbsPathPattern.MatchString(path) ||
-		pathEscapesWorkspace(path) {
-		return "", errors.New("path must be a relative path inside the workspace")
-	}
-
-	absWorkspace, err := filepath.Abs(workspace)
-	if err != nil {
-		return "", fmt.Errorf("absolute workspace path: %w", err)
-	}
-
-	return filepath.Join(absWorkspace, filepath.Clean(path)), nil
-}
-
-func pathEscapesWorkspace(path string) bool {
-	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
-		return r == '/' || r == '\\'
-	}) {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
+	return pathsafe.WorkspaceRelative(workspacePath, relativePath)
 }

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -7,9 +7,10 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
+
+	"github.com/digitaldrywood/detent/internal/pathsafe"
 
 	"gopkg.in/yaml.v3"
 )
@@ -18,8 +19,6 @@ const (
 	DefaultPath              = ".detent/skills"
 	DefaultMaxSkillsInPrompt = 50
 )
-
-var windowsAbsPathPattern = regexp.MustCompile(`^[A-Za-z]:[\\/]`)
 
 type Skill struct {
 	Name        string
@@ -234,33 +233,5 @@ func rejectDuplicateNames(skillList []Skill) ([]Skill, []ValidationError) {
 }
 
 func workspaceRelativePath(workspacePath string, relativePath string) (string, error) {
-	workspace := strings.TrimSpace(workspacePath)
-	if workspace == "" {
-		return "", errors.New("workspace path is required")
-	}
-
-	path := strings.TrimSpace(relativePath)
-	if path == "" || strings.HasPrefix(path, "~") || filepath.IsAbs(path) ||
-		strings.HasPrefix(path, `\`) || windowsAbsPathPattern.MatchString(path) ||
-		pathEscapesWorkspace(path) {
-		return "", errors.New("path must be a relative path inside the workspace")
-	}
-
-	absWorkspace, err := filepath.Abs(workspace)
-	if err != nil {
-		return "", fmt.Errorf("absolute workspace path: %w", err)
-	}
-
-	return filepath.Join(absWorkspace, filepath.Clean(path)), nil
-}
-
-func pathEscapesWorkspace(path string) bool {
-	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
-		return r == '/' || r == '\\'
-	}) {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
+	return pathsafe.WorkspaceRelative(workspacePath, relativePath)
 }

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -130,7 +130,7 @@ func (s *sqliteStore) StartSession(ctx context.Context, attrs SessionStart) (int
 	}
 
 	session, err := s.queries.CreateCodexSession(ctx, sqlc.CreateCodexSessionParams{
-		RunID:       nullInt64(attrs.RunID),
+		RunID:       nullPositiveInt64(attrs.RunID),
 		IssueID:     nullString(attrs.IssueID),
 		Identifier:  nullString(attrs.Identifier),
 		IssueURL:    nullString(attrs.IssueURL),
@@ -190,8 +190,8 @@ func (s *sqliteStore) RecordUsageEvent(ctx context.Context, attrs UsageEvent) (i
 
 	event, err := s.queries.CreateUsageEvent(ctx, sqlc.CreateUsageEventParams{
 		ProjectID:      projectID,
-		RunID:          nullInt64(attrs.RunID),
-		SessionID:      nullInt64(attrs.SessionID),
+		RunID:          nullPositiveInt64(attrs.RunID),
+		SessionID:      nullPositiveInt64(attrs.SessionID),
 		IssueID:        nullString(attrs.IssueID),
 		Identifier:     nullString(attrs.Identifier),
 		PrNumber:       nullOptionalInt64(attrs.PRNumber),
@@ -609,7 +609,7 @@ func nullString(value string) sql.NullString {
 	return sql.NullString{String: trimmed, Valid: true}
 }
 
-func nullInt64(value int64) sql.NullInt64 {
+func nullPositiveInt64(value int64) sql.NullInt64 {
 	if value <= 0 {
 		return sql.NullInt64{}
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -488,7 +488,7 @@ func (s *Service) applyReleaseUpdate(ctx context.Context, status Status, release
 			}, target)
 		}
 	}
-	if err := ReplaceBinary(replacement); err != nil {
+	if err := ReplaceBinary(ctx, replacement); err != nil {
 		status.Action = ActionRefused
 		status.Message = err.Error()
 		return status, err
@@ -641,16 +641,19 @@ func ExtractBinary(archive []byte, goos string) ([]byte, os.FileMode, error) {
 	return extractTarGzipBinary(archive)
 }
 
-func ReplaceBinary(replacement Replacement) error {
+func ReplaceBinary(ctx context.Context, replacement Replacement) error {
+	if replacement.Context == nil {
+		replacement.Context = ctx
+	}
 	goos := firstNonEmpty(replacement.GOOS, runtime.GOOS)
 	if goos == "windows" {
-		return stageWindowsReplacement(replacement)
+		return stageWindowsReplacement(ctx, replacement)
 	}
 	replacement.GOOS = goos
-	return replaceBinaryNow(replacement)
+	return replaceBinaryNow(ctx, replacement)
 }
 
-func replaceBinaryNow(replacement Replacement) error {
+func replaceBinaryNow(ctx context.Context, replacement Replacement) error {
 	target := replacement.Target
 	if strings.TrimSpace(target) == "" {
 		return errors.New("target binary path is required")
@@ -691,7 +694,7 @@ func replaceBinaryNow(replacement Replacement) error {
 		return fmt.Errorf("replace binary %s: %w", target, err)
 	}
 	cleanup = false
-	if err := finalizeReplacement(replacement); err != nil {
+	if err := finalizeReplacement(ctx, replacement); err != nil {
 		if rollbackErr := rollbackBinary(target, backupPath); rollbackErr != nil {
 			return fmt.Errorf("%w; rollback failed: %w", err, rollbackErr)
 		}
@@ -758,8 +761,10 @@ func backupBinary(target string) (string, error) {
 	return backupPath, nil
 }
 
-func finalizeReplacement(replacement Replacement) error {
-	ctx := replacement.Context
+func finalizeReplacement(ctx context.Context, replacement Replacement) error {
+	if replacement.Context != nil {
+		ctx = replacement.Context
+	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -795,7 +800,7 @@ func rollbackBinary(target string, backupPath string) error {
 	return nil
 }
 
-func stageWindowsReplacement(replacement Replacement) error {
+func stageWindowsReplacement(ctx context.Context, replacement Replacement) error {
 	if strings.TrimSpace(replacement.Target) == "" {
 		return errors.New("target binary path is required")
 	}
@@ -836,7 +841,9 @@ func stageWindowsReplacement(replacement Replacement) error {
 		return fmt.Errorf("start windows updater: %w", err)
 	}
 	if replacement.AfterReplace != nil {
-		ctx := replacement.Context
+		if replacement.Context != nil {
+			ctx = replacement.Context
+		}
 		if ctx == nil {
 			ctx = context.Background()
 		}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -589,7 +589,7 @@ func TestReplaceBinaryPreservesPermissionsAndVerifies(t *testing.T) {
 	}
 
 	var verifiedPath string
-	err := ReplaceBinary(Replacement{
+	err := ReplaceBinary(context.Background(), Replacement{
 		Target: target,
 		Binary: []byte("new"),
 		Mode:   0o600,
@@ -632,7 +632,7 @@ func TestReplaceBinaryRollsBackWhenVerificationFails(t *testing.T) {
 		t.Fatalf("WriteFile(target) error = %v", err)
 	}
 
-	err := ReplaceBinary(Replacement{
+	err := ReplaceBinary(context.Background(), Replacement{
 		Target: target,
 		Binary: []byte("new"),
 		Mode:   0o755,
@@ -662,7 +662,7 @@ func TestReplaceBinaryRollsBackWhenAfterReplaceFails(t *testing.T) {
 		t.Fatalf("WriteFile(target) error = %v", err)
 	}
 
-	err := ReplaceBinary(Replacement{
+	err := ReplaceBinary(context.Background(), Replacement{
 		Target: target,
 		Binary: []byte("new"),
 		Mode:   0o755,
@@ -696,7 +696,7 @@ func TestReplaceBinarySignsDarwinBeforeVerify(t *testing.T) {
 	}
 
 	var calls []string
-	err := ReplaceBinary(Replacement{
+	err := ReplaceBinary(context.Background(), Replacement{
 		Target: target,
 		Binary: []byte("new"),
 		Mode:   0o755,
@@ -730,7 +730,7 @@ func TestReplaceBinaryStagesWindowsReplacement(t *testing.T) {
 
 	var startedCommand string
 	var startedArgs []string
-	err := ReplaceBinary(Replacement{
+	err := ReplaceBinary(context.Background(), Replacement{
 		Target: target,
 		Binary: []byte("new"),
 		Mode:   0o755,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -76,7 +76,7 @@ func TestNewServerValidatesDependencies(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if tt.want == web.ErrMissingHub {
+			if errors.Is(tt.want, web.ErrMissingHub) {
 				tt.deps.Hub = nil
 			}
 


### PR DESCRIPTION
## Summary

- Enable `errorlint` and `contextcheck`, with an explicit `contextcheck` exclusion for the existing nil-context fallback idiom.
- Rename the stuttering project types to `project.ID` and `project.Factory`, plus the listed budget/store naming nits.
- Centralize workspace-relative path safety in `internal/pathsafe` and tighten lessons directory permissions.

Fixes #333

## Test Plan

- [x] `make check`