### PR TITLE
fix(update): sign release checksums

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -115,6 +115,14 @@ jobs:
           go-version: '1.26.4'
           cache: true
 
+      - name: Install minisign
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Prepare minisign snapshot key
+        run: minisign -G -W -s "$RUNNER_TEMP/detent-minisign.key" -p "$RUNNER_TEMP/detent-minisign.pub"
+
       - name: Run GoReleaser snapshot
         uses: goreleaser/goreleaser-action@v7
         with:
@@ -123,3 +131,5 @@ jobs:
           args: release --snapshot --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MINISIGN_KEY_FILE: ${{ runner.temp }}/detent-minisign.key
+          MINISIGN_PASSWORD: ""

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,6 +31,28 @@ jobs:
             exit 1
           fi
 
+      - name: Install minisign
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y minisign
+
+      - name: Prepare minisign key
+        run: |
+          if [ -z "$MINISIGN_KEY" ]; then
+            echo "MINISIGN_KEY secret is required."
+            exit 1
+          fi
+          if [ -z "$MINISIGN_PASSWORD" ]; then
+            echo "MINISIGN_PASSWORD secret is required."
+            exit 1
+          fi
+          key_file="$RUNNER_TEMP/detent-minisign.key"
+          printf '%s' "$MINISIGN_KEY" > "$key_file"
+          chmod 600 "$key_file"
+        env:
+          MINISIGN_KEY: ${{ secrets.MINISIGN_KEY }}
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:
@@ -38,3 +60,5 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          MINISIGN_KEY_FILE: ${{ runner.temp }}/detent-minisign.key
+          MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -64,5 +64,21 @@ checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
   algorithm: sha256
 
+signs:
+  - artifacts: checksum
+    cmd: minisign
+    signature: "${artifact}.minisig"
+    args:
+      - -S
+      - -s
+      - "{{ .Env.MINISIGN_KEY_FILE }}"
+      - -m
+      - "${artifact}"
+      - -x
+      - "${signature}"
+      - -t
+      - "detent checksums {{ .Version }}"
+    stdin: "{{ .Env.MINISIGN_PASSWORD }}"
+
 snapshot:
   version_template: "{{ incpatch .Version }}-snapshot"

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -48,7 +48,7 @@ var (
 	ErrConfirmationRequired = errors.New("update confirmation required")
 	ErrRefused              = errors.New("update refused")
 
-	defaultChecksumMinisignPublicKey = ""
+	defaultChecksumMinisignPublicKey = "RWR9LKG/4dIAmbeS4Ow7XOSjxOE7GKiwQ0OPHNoViW5V0FSo4WU0vucx"
 )
 
 type InstallSource string

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -284,6 +284,16 @@ func TestVerifyChecksumSignatureFailsClosedWithoutPinnedKey(t *testing.T) {
 	}
 }
 
+func TestNewServiceRequiresChecksumSignatureWithPinnedKey(t *testing.T) {
+	service := NewService(Config{})
+	if !service.cfg.RequireChecksumSignature {
+		t.Fatal("RequireChecksumSignature = false, want true with a pinned key")
+	}
+	if _, _, err := parseMinisignPublicKey(defaultChecksumMinisignPublicKey); err != nil {
+		t.Fatalf("parseMinisignPublicKey(defaultChecksumMinisignPublicKey) error = %v", err)
+	}
+}
+
 func TestNewServiceGatesChecksumSignatureUntilConfigured(t *testing.T) {
 	previous := defaultChecksumMinisignPublicKey
 	defaultChecksumMinisignPublicKey = ""
@@ -363,9 +373,7 @@ func TestGitHubClientDownloadHonorsHTTPTimeout(t *testing.T) {
 	}
 }
 
-func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
-	t.Parallel()
-
+func TestServiceAppliesReleaseUpdateWithMinisignSignatureFromHTTPServer(t *testing.T) {
 	tmp := t.TempDir()
 	binary := filepath.Join(tmp, "bin", "detent")
 	lockPath := filepath.Join(tmp, "state", "install.lock")
@@ -388,7 +396,18 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 	archive := detentUpdateArchive(t, "updated")
 	sum := sha256.Sum256(archive)
 	checksums := fmt.Sprintf("%x  %s\n", sum, archiveName)
-	signature := []byte("valid signature")
+	publicKey, privateKey, err := ed25519.GenerateKey(nil)
+	if err != nil {
+		t.Fatalf("GenerateKey() error = %v", err)
+	}
+	keyID := []byte("12345678")
+	signature := testMinisignSignature(t, privateKey, keyID, []byte(checksums), "detent checksums v1.2.4")
+
+	previous := defaultChecksumMinisignPublicKey
+	defaultChecksumMinisignPublicKey = testMinisignPublicKey(publicKey, keyID)
+	t.Cleanup(func() {
+		defaultChecksumMinisignPublicKey = previous
+	})
 
 	var server *httptest.Server
 	server = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -421,7 +440,6 @@ func TestServiceAppliesReleaseUpdateFromHTTPServer(t *testing.T) {
 		BinaryVerifier: func(context.Context, string) (string, error) {
 			return "version: v1.2.4\n", nil
 		},
-		ChecksumSignatureVerifier: acceptChecksumSignature,
 	})
 
 	status, err := service.Apply(context.Background(), ApplyOptions{AssumeYes: true})


### PR DESCRIPTION
## Summary

- Pin the Detent release minisign public key for self-update checksum verification.
- Sign GoReleaser checksum artifacts with minisign and prepare the CI signing key from the provisioned repo secrets.
- Strengthen update tests to cover the default pinned-key gate and a real minisign-verified release update path.

Fixes #337

## Test Plan

- [x] `go test ./internal/update`
- [x] `make check`
- [x] `MINISIGN_KEY_FILE="$PWD/tmp/minisign-smoke/minisign.key" MINISIGN_PASSWORD=passphrase HOMEBREW_TAP_GITHUB_TOKEN=snapshot-token GITHUB_TOKEN=snapshot-token goreleaser release --snapshot --clean`
- [x] `minisign -V -p tmp/minisign-smoke/minisign.pub -m tmp/goreleaser/detent_0.3.1-snapshot_checksums.txt -x tmp/goreleaser/detent_0.3.1-snapshot_checksums.txt.minisig`