### PR TITLE
chore(release): gitignore signing secrets + track release public key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 tmp/
 /detent
 node_modules/
+
+# Release signing secrets — NEVER commit the private key or the password
+.envrc
+detent-release.key
+*.key

--- a/detent-release.pub
+++ b/detent-release.pub
@@ -1,0 +1,2 @@
+untrusted comment: minisign public key 9900D2E1BFA12C7D
+RWR9LKG/4dIAmbeS4Ow7XOSjxOE7GKiwQ0OPHNoViW5V0FSo4WU0vucx


### PR DESCRIPTION
Adds `.gitignore` rules so the minisign **secret key** (`*.key`) and the **password** (`.envrc`) provisioned for release signing (#337 / #346) can never be committed, and tracks the **public** key (`detent-release.pub`) for reference.

Operator follow-up to the signing-key provisioning. No code paths affected; the pinned public key value lives in `internal/update` via #346.

## Test plan
- `git status` clean after merge; `git check-ignore detent-release.key .envrc` matches.
- `make check` green.