### PR TITLE
fix(workspace): namespace worktree keys

### DIFF
--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -117,7 +117,14 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 		t.Fatalf("DiffStats = %#v, want one added file", diffStat)
 	}
 
-	workspaceKey := workspace.SafeKey("detent") + "-" + workspace.SafeKey(issue.Identifier)
+	entries, err := os.ReadDir(workspacesRoot)
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("workspace entries = %d, want 1", len(entries))
+	}
+	workspaceKey := entries[0].Name()
 	workspacePath := filepath.Join(workspacesRoot, workspaceKey)
 	wantBranch := "detent/" + strings.ToLower(workspaceKey)
 	if got := strings.TrimSpace(e2eRunGit(t, workspacePath, "branch", "--show-current")); got != wantBranch {

--- a/internal/orchestrator/e2e_test.go
+++ b/internal/orchestrator/e2e_test.go
@@ -117,8 +117,9 @@ func TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens(t *tes
 		t.Fatalf("DiffStats = %#v, want one added file", diffStat)
 	}
 
-	workspacePath := filepath.Join(workspacesRoot, workspace.SafeKey(issue.Identifier))
-	wantBranch := "detent/" + strings.ToLower(workspace.SafeKey(issue.Identifier))
+	workspaceKey := workspace.SafeKey("detent") + "-" + workspace.SafeKey(issue.Identifier)
+	workspacePath := filepath.Join(workspacesRoot, workspaceKey)
+	wantBranch := "detent/" + strings.ToLower(workspaceKey)
 	if got := strings.TrimSpace(e2eRunGit(t, workspacePath, "branch", "--show-current")); got != wantBranch {
 		t.Fatalf("workspace branch = %q, want %q", got, wantBranch)
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -266,7 +266,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	workflow, agentRuntime := r.runtimeSnapshot()
 
-	workspaceIssue := workspaceIssue(req.Issue)
+	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
 	info, err := r.workspace.Create(ctx, workspaceIssue)
 	if err != nil {
 		return RunResult{}, fmt.Errorf("create workspace: %w", err)
@@ -369,7 +369,7 @@ func (r *Runner) ReapWorkspace(ctx context.Context, issue connector.Issue) (Work
 		ctx = context.Background()
 	}
 
-	workspaceIssue := workspaceIssue(issue)
+	workspaceIssue := workspaceIssue(r.projectID, issue)
 	if cleaner, ok := r.workspace.(workspace.IssueCleaner); ok {
 		result, err := cleaner.CleanupIssue(ctx, workspaceIssue)
 		return WorkspaceReapResult{
@@ -505,8 +505,9 @@ func (r *Runner) usageCostUSD(model string, inputTokens int64, outputTokens int6
 	return cost
 }
 
-func workspaceIssue(issue connector.Issue) workspace.Issue {
+func workspaceIssue(projectID string, issue connector.Issue) workspace.Issue {
 	return workspace.Issue{
+		ProjectID:  projectID,
 		ID:         issue.ID,
 		Identifier: issue.Identifier,
 		BranchName: issue.BranchName,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -205,6 +205,12 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if !workspaceBackend.created || !workspaceBackend.beforeRun || !workspaceBackend.afterRun || !workspaceBackend.diffed {
 		t.Fatalf("workspace calls = created:%v before:%v after:%v diff:%v, want all true", workspaceBackend.created, workspaceBackend.beforeRun, workspaceBackend.afterRun, workspaceBackend.diffed)
 	}
+	if workspaceBackend.createIssue.ProjectID != "detent" ||
+		workspaceBackend.createIssue.ID != "issue-22" ||
+		workspaceBackend.createIssue.Identifier != "digitaldrywood/detent#22" ||
+		workspaceBackend.createIssue.BranchName != "detent/digitaldrywood_detent_22" {
+		t.Fatalf("Create() issue = %#v", workspaceBackend.createIssue)
+	}
 	if workspaceBackend.diffCalls != 3 {
 		t.Fatalf("DiffStat calls = %d, want throttled live calls plus final stat", workspaceBackend.diffCalls)
 	}
@@ -568,7 +574,8 @@ func TestRunnerReapWorkspaceUsesWorkspaceIssueCleanup(t *testing.T) {
 	if result.Worktrees != 1 || result.Branches != 1 || result.Processes != 2 {
 		t.Fatalf("ReapWorkspace() result = %#v, want 1 worktree, 1 branch, 2 processes", result)
 	}
-	if workspaceBackend.cleanupIssue.ID != "issue-311" ||
+	if workspaceBackend.cleanupIssue.ProjectID != "default" ||
+		workspaceBackend.cleanupIssue.ID != "issue-311" ||
 		workspaceBackend.cleanupIssue.Identifier != "digitaldrywood/detent#311" ||
 		workspaceBackend.cleanupIssue.BranchName != "detent/digitaldrywood_detent_311" {
 		t.Fatalf("CleanupIssue() issue = %#v", workspaceBackend.cleanupIssue)
@@ -585,12 +592,14 @@ type fakeWorkspaceBackend struct {
 	afterRunErr   error
 	diffed        bool
 	diffCalls     int
+	createIssue   workspace.Issue
 	cleanupIssue  workspace.Issue
 	cleanupResult workspace.CleanupResult
 }
 
 func (b *fakeWorkspaceBackend) Create(_ context.Context, issue workspace.Issue) (workspace.Info, error) {
 	b.created = true
+	b.createIssue = issue
 	b.info.Branch = issue.BranchName
 	return b.info, nil
 }

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -48,6 +48,7 @@ type IssueCleaner interface {
 }
 
 type Issue struct {
+	ProjectID  string
 	ID         string
 	Identifier string
 	BranchName string
@@ -191,6 +192,15 @@ func SafeKey(identifier string) string {
 	return key
 }
 
+func issueKey(issue Issue) string {
+	identifierKey := SafeKey(issue.Identifier)
+	projectKey := SafeKey(issue.ProjectID)
+	if strings.TrimSpace(issue.ProjectID) == "" {
+		return identifierKey
+	}
+	return projectKey + "-" + identifierKey
+}
+
 func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {
 	info, err := l.infoForIssue(issue)
 	if err != nil {
@@ -289,7 +299,7 @@ func (l *LocalGit) AfterRun(ctx context.Context, info Info, issue Issue) {
 }
 
 func (l *LocalGit) infoForIssue(issue Issue) (Info, error) {
-	key := SafeKey(issue.Identifier)
+	key := issueKey(issue)
 	path, err := l.workspacePath(key)
 	if err != nil {
 		return Info{}, err
@@ -305,7 +315,7 @@ func (l *LocalGit) infoForIssue(issue Issue) (Info, error) {
 func (l *LocalGit) normalizeInfo(info Info, issue Issue) (Info, error) {
 	key := info.Key
 	if key == "" {
-		key = SafeKey(issue.Identifier)
+		key = issueKey(issue)
 	}
 	path := info.Path
 	if path == "" {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -2,6 +2,8 @@ package workspace
 
 import (
 	"context"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"io"
@@ -198,7 +200,12 @@ func issueKey(issue Issue) string {
 	if strings.TrimSpace(issue.ProjectID) == "" {
 		return identifierKey
 	}
-	return projectKey + "-" + identifierKey
+	return projectKey + "-" + identifierKey + "-" + issueKeyDigest(issue)
+}
+
+func issueKeyDigest(issue Issue) string {
+	sum := sha256.Sum256([]byte(strings.TrimSpace(issue.ProjectID) + "\x00" + strings.TrimSpace(issue.Identifier)))
+	return hex.EncodeToString(sum[:])[:12]
 }
 
 func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -98,49 +98,84 @@ func TestLocalGitInfoForIssueNamespacesKeysByProjectID(t *testing.T) {
 	}
 
 	tests := []struct {
-		name       string
-		issue      Issue
-		wantKey    string
-		wantBranch string
+		name          string
+		issue         Issue
+		wantKey       string
+		wantKeyPrefix string
 	}{
 		{
-			name:       "legacy issue identifier without project id",
-			issue:      Issue{Identifier: "digitaldrywood/detent#42"},
-			wantKey:    "digitaldrywood_detent_42",
-			wantBranch: "detent/digitaldrywood_detent_42",
+			name:    "legacy issue identifier without project id",
+			issue:   Issue{Identifier: "digitaldrywood/detent#42"},
+			wantKey: "digitaldrywood_detent_42",
 		},
 		{
-			name:       "alpha project",
-			issue:      Issue{ProjectID: "alpha", Identifier: "digitaldrywood/detent#42"},
-			wantKey:    "alpha-digitaldrywood_detent_42",
-			wantBranch: "detent/alpha-digitaldrywood_detent_42",
+			name:          "alpha project",
+			issue:         Issue{ProjectID: "alpha", Identifier: "digitaldrywood/detent#42"},
+			wantKeyPrefix: "alpha-digitaldrywood_detent_42-",
 		},
 		{
-			name:       "bravo project same identifier",
-			issue:      Issue{ProjectID: "bravo", Identifier: "digitaldrywood/detent#42"},
-			wantKey:    "bravo-digitaldrywood_detent_42",
-			wantBranch: "detent/bravo-digitaldrywood_detent_42",
+			name:          "bravo project same identifier",
+			issue:         Issue{ProjectID: "bravo", Identifier: "digitaldrywood/detent#42"},
+			wantKeyPrefix: "bravo-digitaldrywood_detent_42-",
+		},
+		{
+			name:          "project ids with same safe key",
+			issue:         Issue{ProjectID: "foo/bar", Identifier: "baz"},
+			wantKeyPrefix: "foo_bar-baz-",
+		},
+		{
+			name:          "second project id with same safe key",
+			issue:         Issue{ProjectID: "foo_bar", Identifier: "baz"},
+			wantKeyPrefix: "foo_bar-baz-",
+		},
+		{
+			name:          "separator ambiguity left",
+			issue:         Issue{ProjectID: "foo", Identifier: "bar-baz"},
+			wantKeyPrefix: "foo-bar-baz-",
+		},
+		{
+			name:          "separator ambiguity right",
+			issue:         Issue{ProjectID: "foo-bar", Identifier: "baz"},
+			wantKeyPrefix: "foo-bar-baz-",
 		},
 	}
 
+	keys := make(map[string]string, len(tests))
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
 			info, err := backend.infoForIssue(tt.issue)
 			if err != nil {
 				t.Fatalf("infoForIssue() error = %v", err)
 			}
-			if info.Key != tt.wantKey {
+			switch {
+			case tt.wantKey != "" && info.Key != tt.wantKey:
 				t.Fatalf("Key = %q, want %q", info.Key, tt.wantKey)
+			case tt.wantKeyPrefix != "" && !strings.HasPrefix(info.Key, tt.wantKeyPrefix):
+				t.Fatalf("Key = %q, want prefix %q", info.Key, tt.wantKeyPrefix)
+			case tt.wantKeyPrefix != "" && len(info.Key) == len(tt.wantKeyPrefix):
+				t.Fatalf("Key = %q, want digest suffix", info.Key)
 			}
-			if filepath.Base(info.Path) != tt.wantKey {
-				t.Fatalf("Path basename = %q, want %q", filepath.Base(info.Path), tt.wantKey)
+			if filepath.Base(info.Path) != info.Key {
+				t.Fatalf("Path basename = %q, want %q", filepath.Base(info.Path), info.Key)
 			}
-			if info.Branch != tt.wantBranch {
-				t.Fatalf("Branch = %q, want %q", info.Branch, tt.wantBranch)
+			wantBranch := "detent/" + strings.ToLower(info.Key)
+			if info.Branch != wantBranch {
+				t.Fatalf("Branch = %q, want %q", info.Branch, wantBranch)
 			}
+
+			keys[tt.name] = info.Key
 		})
+	}
+
+	for leftName, leftKey := range keys {
+		for rightName, rightKey := range keys {
+			if leftName >= rightName {
+				continue
+			}
+			if leftKey == rightKey {
+				t.Fatalf("%s and %s both produced key %q", leftName, rightName, leftKey)
+			}
+		}
 	}
 }
 

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -88,6 +88,62 @@ func TestLocalGitCreateCreatesWorktreeBranchAndRunsAfterCreateHook(t *testing.T)
 	}
 }
 
+func TestLocalGitInfoForIssueNamespacesKeysByProjectID(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	backend := &LocalGit{
+		root:       root,
+		autoBranch: true,
+	}
+
+	tests := []struct {
+		name       string
+		issue      Issue
+		wantKey    string
+		wantBranch string
+	}{
+		{
+			name:       "legacy issue identifier without project id",
+			issue:      Issue{Identifier: "digitaldrywood/detent#42"},
+			wantKey:    "digitaldrywood_detent_42",
+			wantBranch: "detent/digitaldrywood_detent_42",
+		},
+		{
+			name:       "alpha project",
+			issue:      Issue{ProjectID: "alpha", Identifier: "digitaldrywood/detent#42"},
+			wantKey:    "alpha-digitaldrywood_detent_42",
+			wantBranch: "detent/alpha-digitaldrywood_detent_42",
+		},
+		{
+			name:       "bravo project same identifier",
+			issue:      Issue{ProjectID: "bravo", Identifier: "digitaldrywood/detent#42"},
+			wantKey:    "bravo-digitaldrywood_detent_42",
+			wantBranch: "detent/bravo-digitaldrywood_detent_42",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			info, err := backend.infoForIssue(tt.issue)
+			if err != nil {
+				t.Fatalf("infoForIssue() error = %v", err)
+			}
+			if info.Key != tt.wantKey {
+				t.Fatalf("Key = %q, want %q", info.Key, tt.wantKey)
+			}
+			if filepath.Base(info.Path) != tt.wantKey {
+				t.Fatalf("Path basename = %q, want %q", filepath.Base(info.Path), tt.wantKey)
+			}
+			if info.Branch != tt.wantBranch {
+				t.Fatalf("Branch = %q, want %q", info.Branch, tt.wantBranch)
+			}
+		})
+	}
+}
+
 func TestLocalGitCreateAndCleanupWithoutHooks(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Namespace local workspace keys and auto branches by runner project ID so projects sharing a workspace root do not collide on the same issue identifier.
- Propagate runner project ID into workspace create/reap paths and update e2e expectations.

Fixes #349

## Test Plan

- [x] `go test ./internal/workspace ./internal/runner -count=1`
- [x] `go test -race ./internal/orchestrator -run TestMemoryConnectorRunnerE2EGateCreatesBranchDiffStatAndSQLiteTokens -count=1`
- [x] `make check`