### PR TITLE
fix(scheduler): wire global dispatch gate

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -23,6 +23,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/tui"
@@ -184,11 +185,17 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}()
 
 	events := hub.New[project.Event]()
+	globalScheduler, err := buildGlobalScheduler(cfg.Global.Global, runtimeStore)
+	if err != nil {
+		return err
+	}
+	globalDispatchGate := scheduler.NewGlobalDispatchGate(globalScheduler)
 	runtimeGitHubToken := newRuntimeGitHubTokenState(runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken))
 	projectFactory := withRunnerFactory(project.Dependencies{
-		Events:      events,
-		Logger:      logger,
-		GitHubToken: runtimeGitHubToken.get(),
+		Events:             events,
+		Logger:             logger,
+		GlobalDispatchGate: globalDispatchGate,
+		GitHubToken:        runtimeGitHubToken.get(),
 	}, runtimeStore, nil, runtimeGitHubToken.get)
 	manager, err := project.NewManager(managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get()), project.ManagerDependencies{
 		ProjectFactory: projectFactory,
@@ -430,6 +437,56 @@ func globalConfigFromWorkflow(globalPath string, workflowPath string) (globalcon
 		},
 	}
 	return cfg, nil
+}
+
+func buildGlobalScheduler(settings globalconfig.Settings, fairShareStore scheduler.FairShareStore) (scheduler.GlobalScheduler, error) {
+	halfLife, err := globalFairShareHalfLife(settings.FairShare)
+	if err != nil {
+		return nil, err
+	}
+
+	schedulerConfig := scheduler.Config{
+		Kind:          settings.Scheduling,
+		Capacity:      settings.MaxConcurrentAgents,
+		DecayHalfLife: halfLife,
+	}
+	if settings.Scheduling == globalconfig.SchedulingFairShare {
+		schedulerConfig.FairShareStore = fairShareStore
+	}
+
+	sched, err := scheduler.NewFromConfig(schedulerConfig)
+	if err != nil {
+		return nil, fmt.Errorf("create global scheduler: %w", err)
+	}
+	global, ok := sched.(scheduler.GlobalScheduler)
+	if !ok {
+		return nil, fmt.Errorf("create global scheduler: %w", scheduler.ErrUnsupportedBackend)
+	}
+	return global, nil
+}
+
+func globalFairShareHalfLife(settings map[string]any) (time.Duration, error) {
+	value, ok := settings["half_life"]
+	if !ok || value == nil {
+		return 0, nil
+	}
+
+	switch halfLife := value.(type) {
+	case string:
+		text := strings.TrimSpace(halfLife)
+		if text == "" {
+			return 0, nil
+		}
+		duration, err := time.ParseDuration(text)
+		if err != nil {
+			return 0, fmt.Errorf("global.fair_share.half_life: %w", err)
+		}
+		return duration, nil
+	case time.Duration:
+		return halfLife, nil
+	default:
+		return 0, fmt.Errorf("global.fair_share.half_life: must be a duration string")
+	}
 }
 
 func openRuntimeStore(ctx context.Context, cfg BootConfig) (store.Store, error) {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -17,6 +17,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
@@ -58,6 +59,40 @@ func TestShouldLaunchTerminalDashboard(t *testing.T) {
 				t.Fatalf("shouldLaunchTerminalDashboard(%#v) = %v, want %v", tt.cfg, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestBuildGlobalSchedulerFromSettings(t *testing.T) {
+	t.Parallel()
+
+	global, err := buildGlobalScheduler(globalconfig.Settings{
+		MaxConcurrentAgents: 2,
+		Scheduling:          globalconfig.SchedulingRoundRobin,
+		FairShare:           map[string]any{"half_life": "30m"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("buildGlobalScheduler() error = %v", err)
+	}
+	if global.Mode() != scheduler.ModeRoundRobin {
+		t.Fatalf("Mode() = %q, want %q", global.Mode(), scheduler.ModeRoundRobin)
+	}
+
+	first, err := global.RequestSlot(context.Background(), scheduler.SlotRequest{State: "Todo"})
+	if err != nil {
+		t.Fatalf("RequestSlot() first error = %v", err)
+	}
+	second, err := global.RequestSlot(context.Background(), scheduler.SlotRequest{State: "Todo"})
+	if err != nil {
+		t.Fatalf("RequestSlot() second error = %v", err)
+	}
+	if _, err := global.RequestSlot(context.Background(), scheduler.SlotRequest{State: "Todo"}); !errors.Is(err, scheduler.ErrNoSlots) {
+		t.Fatalf("RequestSlot() third error = %v, want ErrNoSlots", err)
+	}
+	if err := global.ReleaseSlot(first); err != nil {
+		t.Fatalf("ReleaseSlot() first error = %v", err)
+	}
+	if err := global.ReleaseSlot(second); err != nil {
+		t.Fatalf("ReleaseSlot() second error = %v", err)
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
 
@@ -573,6 +574,79 @@ func TestDispatchCandidatesClaimsDuplicateIssueWithinCycle(t *testing.T) {
 	}
 	if len(state.Claimed) != 1 {
 		t.Fatalf("Claimed len = %d, want 1", len(state.Claimed))
+	}
+}
+
+func TestDispatchIssueRequiresSharedGlobalSlot(t *testing.T) {
+	t.Parallel()
+
+	global := scheduler.NewRoundRobin(scheduler.Config{Capacity: 1})
+	globalGate := scheduler.NewGlobalDispatchGate(global)
+	now := time.Now()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	alphaRunner := newWorkerHostRunner()
+	alphaCfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Project:             scheduler.ProjectCandidate{ID: "alpha", Weight: 1},
+	})
+	alpha := Orchestrator{
+		cfg:                alphaCfg,
+		supervisor:         newTestSupervisor(t, alphaRunner, alphaCfg),
+		runResults:         make(chan runpkg.Completion),
+		globalDispatchGate: globalGate,
+	}
+	alphaState := newState(alphaCfg)
+	alphaIssue := dispatchTestIssue("issue-alpha", "Todo")
+
+	if !alpha.dispatchIssue(ctx, &alphaState, alphaIssue, 0, now, "") {
+		t.Fatal("alpha dispatchIssue() = false, want true")
+	}
+	alphaRequest := receiveWorkerHostRunRequest(t, alphaRunner.started)
+	if alphaRequest.Issue.ID != alphaIssue.ID {
+		t.Fatalf("alpha RunRequest.Issue.ID = %q, want %q", alphaRequest.Issue.ID, alphaIssue.ID)
+	}
+
+	bravoRunner := newWorkerHostRunner()
+	bravoCfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		Project:             scheduler.ProjectCandidate{ID: "bravo", Weight: 1},
+	})
+	bravo := Orchestrator{
+		cfg:                bravoCfg,
+		supervisor:         newTestSupervisor(t, bravoRunner, bravoCfg),
+		runResults:         make(chan runpkg.Completion),
+		globalDispatchGate: globalGate,
+	}
+	bravoState := newState(bravoCfg)
+	bravoIssue := dispatchTestIssue("issue-bravo", "Todo")
+
+	if bravo.dispatchIssue(ctx, &bravoState, bravoIssue, 0, now, "") {
+		t.Fatal("bravo dispatchIssue() = true while global slot is held, want false")
+	}
+	select {
+	case request := <-bravoRunner.started:
+		t.Fatalf("unexpected bravo dispatch while global slot is held = %#v", request)
+	default:
+	}
+
+	alpha.handleRunResult(&alphaState, runpkg.Completion{
+		IssueID:     alphaIssue.ID,
+		CompletedAt: now.Add(time.Second),
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	if !bravo.dispatchIssue(ctx, &bravoState, bravoIssue, 0, now.Add(2*time.Second), "") {
+		t.Fatal("bravo dispatchIssue() after alpha completion = false, want true")
+	}
+	bravoRequest := receiveWorkerHostRunRequest(t, bravoRunner.started)
+	if bravoRequest.Issue.ID != bravoIssue.ID {
+		t.Fatalf("bravo RunRequest.Issue.ID = %q, want %q", bravoRequest.Issue.ID, bravoIssue.ID)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -49,6 +50,7 @@ type Config struct {
 	DispatchPriorityByState       []string
 	MaxConcurrentAgentsPerHost    int
 	MaxRetryBackoff               time.Duration
+	Project                       scheduler.ProjectCandidate
 	Claiming                      ClaimingConfig
 	AutoPromote                   AutoPromoteConfig
 	ActiveStates                  []string
@@ -78,10 +80,11 @@ type ClaimingConfig struct {
 }
 
 type Dependencies struct {
-	Connector       connector.Connector
-	Runner          Runner
-	WorkspaceReaper WorkspaceReaper
-	Logger          *slog.Logger
+	Connector          connector.Connector
+	Runner             Runner
+	WorkspaceReaper    WorkspaceReaper
+	GlobalDispatchGate scheduler.ProjectDispatchGate
+	Logger             *slog.Logger
 }
 
 type WorkspaceReapResult = runpkg.WorkspaceReapResult
@@ -94,17 +97,18 @@ type RuntimeUpdate struct {
 }
 
 type Orchestrator struct {
-	cfg           Config
-	connector     connector.Connector
-	supervisor    *runpkg.Supervisor
-	reaper        WorkspaceReaper
-	logger        *slog.Logger
-	stateRequests chan stateRequest
-	configUpdates chan configUpdateRequest
-	refreshes     chan time.Time
-	runResults    chan runpkg.Completion
-	runUpdates    chan runUpdate
-	done          chan struct{}
+	cfg                Config
+	connector          connector.Connector
+	supervisor         *runpkg.Supervisor
+	reaper             WorkspaceReaper
+	logger             *slog.Logger
+	globalDispatchGate scheduler.ProjectDispatchGate
+	stateRequests      chan stateRequest
+	configUpdates      chan configUpdateRequest
+	refreshes          chan time.Time
+	runResults         chan runpkg.Completion
+	runUpdates         chan runUpdate
+	done               chan struct{}
 }
 
 type stateRequest struct {
@@ -195,17 +199,18 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	}
 
 	return &Orchestrator{
-		cfg:           cfg,
-		connector:     deps.Connector,
-		supervisor:    supervisor,
-		reaper:        reaper,
-		logger:        logger,
-		stateRequests: make(chan stateRequest),
-		configUpdates: make(chan configUpdateRequest),
-		refreshes:     make(chan time.Time, 1),
-		runResults:    make(chan runpkg.Completion),
-		runUpdates:    make(chan runUpdate, runUpdateBufferSize),
-		done:          make(chan struct{}),
+		cfg:                cfg,
+		connector:          deps.Connector,
+		supervisor:         supervisor,
+		reaper:             reaper,
+		logger:             logger,
+		globalDispatchGate: deps.GlobalDispatchGate,
+		stateRequests:      make(chan stateRequest),
+		configUpdates:      make(chan configUpdateRequest),
+		refreshes:          make(chan time.Time, 1),
+		runResults:         make(chan runpkg.Completion),
+		runUpdates:         make(chan runUpdate, runUpdateBufferSize),
+		done:               make(chan struct{}),
 	}, nil
 }
 
@@ -219,6 +224,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 	defer ticker.Stop()
 
 	state := newState(o.cfg)
+	defer o.releaseRunningSlots(&state)
 	o.tick(ctx, &state, time.Now())
 	resetTicker(ticker, state.PollInterval)
 
@@ -485,7 +491,7 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 		running.Issue = mergeIssueTrackerFields(running.Issue, issue)
 		state.Running[id] = running
 		if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
-			cancelRunning(state, id)
+			o.cancelRunning(state, id)
 		}
 
 		if claimed, ok := state.Claimed[id]; ok {
@@ -864,6 +870,7 @@ func blockedStatusReason(issue connector.Issue) string {
 }
 
 func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
+	o.markGlobalProjectIdle()
 	planner := o.dispatchPlanner()
 	planner.plan(state, issues, now, dispatchPlanHooks{
 		hydrate: func(issue connector.Issue) (connector.Issue, bool) {
@@ -904,6 +911,7 @@ func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector
 }
 
 func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
+	o.markGlobalProjectIdle()
 	for _, issue := range issues {
 		if availableSlots(state) == 0 {
 			return
@@ -947,8 +955,14 @@ func (o *Orchestrator) dispatchIssue(
 		return false
 	}
 
+	globalSlot, ok := o.acquireGlobalDispatchSlot(ctx, issue, workerHost, now)
+	if !ok {
+		return false
+	}
+
 	claimedIssue, claim, ok := o.claimIssue(ctx, issue, now)
 	if !ok {
+		o.releaseGlobalDispatchSlot(globalSlot)
 		return false
 	}
 
@@ -960,6 +974,7 @@ func (o *Orchestrator) dispatchIssue(
 		Attempt:    attempt,
 		StartedAt:  now,
 		WorkerHost: workerHost,
+		globalSlot: globalSlot,
 		cancel:     cancel,
 	}
 	state.Claimed[issue.ID] = claim
@@ -978,6 +993,45 @@ func (o *Orchestrator) dispatchIssue(
 	}
 	o.supervisor.Dispatch(runCtx, request, o.runResults)
 	return true
+}
+
+func (o *Orchestrator) markGlobalProjectIdle() {
+	if o.globalDispatchGate == nil {
+		return
+	}
+	o.globalDispatchGate.MarkIdle(o.cfg.Project.ID)
+}
+
+func (o *Orchestrator) acquireGlobalDispatchSlot(
+	ctx context.Context,
+	issue connector.Issue,
+	workerHost string,
+	now time.Time,
+) (scheduler.Slot, bool) {
+	if o.globalDispatchGate == nil {
+		return scheduler.Slot{}, true
+	}
+
+	slot, ok, err := o.globalDispatchGate.TryAcquire(ctx, o.cfg.Project, scheduler.SlotRequest{
+		State: issue.State,
+		Host:  workerHost,
+	}, now)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("global dispatch slot unavailable", "project_id", o.cfg.Project.ID, "issue_id", issue.ID, "error", err)
+		}
+		return scheduler.Slot{}, false
+	}
+	return slot, ok
+}
+
+func (o *Orchestrator) releaseGlobalDispatchSlot(slot scheduler.Slot) {
+	if o.globalDispatchGate == nil || slot == (scheduler.Slot{}) {
+		return
+	}
+	if err := o.globalDispatchGate.Release(slot); err != nil && o.logger != nil {
+		o.logger.Warn("release global dispatch slot failed", "project_id", o.cfg.Project.ID, "error", err)
+	}
 }
 
 func (o *Orchestrator) selectorContext() selector.Context {
@@ -1049,6 +1103,8 @@ func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
 	if !ok {
 		return
 	}
+	o.releaseGlobalDispatchSlot(running.globalSlot)
+	running.globalSlot = scheduler.Slot{}
 	if running.cancel != nil {
 		running.cancel()
 	}
@@ -1139,18 +1195,43 @@ func (o *Orchestrator) retryDelay(attempt int, continuation bool) time.Duration 
 	return o.dispatchPlanner().retryDelay(attempt, continuation)
 }
 
-func (o *Orchestrator) releaseClaim(state *State, issueID string) {
-	o.dispatchPlanner().releaseClaim(state, issueID)
+func (o *Orchestrator) releaseIssue(state *State, issueID string) {
+	o.cancelRunning(state, issueID)
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Blocked, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
 }
 
-func cancelRunning(state *State, issueID string) {
+func (o *Orchestrator) releaseClaim(state *State, issueID string) {
+	o.cancelRunning(state, issueID)
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+}
+
+func (o *Orchestrator) cancelRunning(state *State, issueID string) {
 	running, ok := state.Running[issueID]
-	if !ok || running.cancel == nil {
+	if !ok {
 		return
 	}
-	running.cancel()
+	o.releaseGlobalDispatchSlot(running.globalSlot)
+	running.globalSlot = scheduler.Slot{}
+	if running.cancel != nil {
+		running.cancel()
+	}
 	running.cancel = nil
 	state.Running[issueID] = running
+}
+
+func (o *Orchestrator) releaseRunningSlots(state *State) {
+	for issueID, running := range state.Running {
+		o.releaseGlobalDispatchSlot(running.globalSlot)
+		running.globalSlot = scheduler.Slot{}
+		state.Running[issueID] = running
+	}
 }
 
 func normalizeConfig(cfg Config) Config {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -977,6 +977,7 @@ func (o *Orchestrator) dispatchIssue(
 		globalSlot: globalSlot,
 		cancel:     cancel,
 	}
+	o.setGlobalDispatchPreempt(globalSlot, cancel)
 	state.Claimed[issue.ID] = claim
 	delete(state.Retry, issue.ID)
 	delete(state.Blocked, issue.ID)
@@ -1032,6 +1033,13 @@ func (o *Orchestrator) releaseGlobalDispatchSlot(slot scheduler.Slot) {
 	if err := o.globalDispatchGate.Release(slot); err != nil && o.logger != nil {
 		o.logger.Warn("release global dispatch slot failed", "project_id", o.cfg.Project.ID, "error", err)
 	}
+}
+
+func (o *Orchestrator) setGlobalDispatchPreempt(slot scheduler.Slot, preempt func()) {
+	if o.globalDispatchGate == nil || slot == (scheduler.Slot{}) {
+		return
+	}
+	o.globalDispatchGate.SetPreempt(slot, preempt)
 }
 
 func (o *Orchestrator) selectorContext() selector.Context {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1203,15 +1203,6 @@ func (o *Orchestrator) retryDelay(attempt int, continuation bool) time.Duration 
 	return o.dispatchPlanner().retryDelay(attempt, continuation)
 }
 
-func (o *Orchestrator) releaseIssue(state *State, issueID string) {
-	o.cancelRunning(state, issueID)
-	delete(state.Running, issueID)
-	delete(state.Claimed, issueID)
-	delete(state.Blocked, issueID)
-	delete(state.Retry, issueID)
-	delete(state.BudgetRefusals, issueID)
-}
-
 func (o *Orchestrator) releaseClaim(state *State, issueID string) {
 	o.cancelRunning(state, issueID)
 	delete(state.Running, issueID)
@@ -1227,9 +1218,16 @@ func (o *Orchestrator) cancelRunning(state *State, issueID string) {
 	}
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	running.globalSlot = scheduler.Slot{}
-	if running.cancel != nil {
-		running.cancel()
+	state.Running[issueID] = running
+	cancelRunning(state, issueID)
+}
+
+func cancelRunning(state *State, issueID string) {
+	running, ok := state.Running[issueID]
+	if !ok || running.cancel == nil {
+		return
 	}
+	running.cancel()
 	running.cancel = nil
 	state.Running[issueID] = running
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -46,6 +47,7 @@ type Running struct {
 	RecentEvents    []telemetry.ActivityEvent
 	DiffStats       DiffStats
 	Tokens          CodexTotals
+	globalSlot      scheduler.Slot
 	cancel          context.CancelFunc
 }
 
@@ -132,6 +134,7 @@ func (s State) clone() State {
 	for id, running := range s.Running {
 		running.Issue = cloneIssue(running.Issue)
 		running.RecentEvents = cloneActivityEvents(running.RecentEvents)
+		running.globalSlot = scheduler.Slot{}
 		running.cancel = nil
 		cloned.Running[id] = running
 	}

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -755,7 +755,7 @@ func TestManagerProjectsShareGlobalDispatchCap(t *testing.T) {
 	t.Parallel()
 
 	globalGate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1}))
-	runners := map[project.ProjectID]*projectBlockingRunner{
+	runners := map[project.ID]*projectBlockingRunner{
 		"alpha": newProjectBlockingRunner(),
 		"bravo": newProjectBlockingRunner(),
 	}
@@ -775,7 +775,7 @@ func TestManagerProjectsShareGlobalDispatchCap(t *testing.T) {
 				Project:  cfg,
 				Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Run test issue."},
 			}, project.Dependencies{
-				Runner:             runners[project.ProjectID(cfg.ID)],
+				Runner:             runners[project.ID(cfg.ID)],
 				GlobalDispatchGate: globalGate,
 			})
 		},
@@ -994,7 +994,7 @@ func receiveFirstProjectRun(
 	t *testing.T,
 	alpha <-chan orchestrator.RunRequest,
 	bravo <-chan orchestrator.RunRequest,
-) project.ProjectID {
+) project.ID {
 	t.Helper()
 
 	select {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -10,6 +10,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 )
@@ -750,6 +751,74 @@ func TestManagerSharedGlobalSchedulerGate(t *testing.T) {
 	})
 }
 
+func TestManagerProjectsShareGlobalDispatchCap(t *testing.T) {
+	t.Parallel()
+
+	globalGate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1}))
+	runners := map[project.ProjectID]*projectBlockingRunner{
+		"alpha": newProjectBlockingRunner(),
+		"bravo": newProjectBlockingRunner(),
+	}
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			workflowCfg := workflowConfigWithMemoryIssue("issue-" + cfg.ID)
+			workflowCfg.Agent.MaxConcurrentAgents = 2
+			workflowCfg.Tracker.Issues[0].State = "Todo"
+			workflowCfg.Tracker.Issues[0].Title = "Run " + cfg.ID
+			workflowCfg.Tracker.Issues[0].AssignedToWorker = true
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Run test issue."},
+			}, project.Dependencies{
+				Runner:             runners[project.ProjectID(cfg.ID)],
+				GlobalDispatchGate: globalGate,
+			})
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		for _, item := range manager.Registry().List() {
+			if !item.Running() {
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			if err := item.Stop(ctx); err != nil && !errors.Is(err, project.ErrNotRunning) {
+				cancel()
+				t.Fatalf("Stop(%s) error = %v", item.ID(), err)
+			}
+			cancel()
+		}
+	})
+
+	first := receiveFirstProjectRun(t, runners["alpha"].started, runners["bravo"].started)
+	var blocked <-chan orchestrator.RunRequest
+	if first == "alpha" {
+		blocked = runners["bravo"].started
+	} else {
+		blocked = runners["alpha"].started
+	}
+	select {
+	case request := <-blocked:
+		t.Fatalf("unexpected second project dispatch while global slot is full = %#v", request)
+	default:
+	}
+
+	if got := runningProjects(t, manager); got != 1 {
+		t.Fatalf("combined running agents = %d, want 1", got)
+	}
+}
+
 func TestManagerConfigFromGlobal(t *testing.T) {
 	t.Parallel()
 
@@ -919,6 +988,38 @@ func requestProjectSlot(manager *project.Manager, id project.ID) (scheduler.Slot
 		State: "Todo",
 		Host:  string(id),
 	})
+}
+
+func receiveFirstProjectRun(
+	t *testing.T,
+	alpha <-chan orchestrator.RunRequest,
+	bravo <-chan orchestrator.RunRequest,
+) project.ProjectID {
+	t.Helper()
+
+	select {
+	case <-alpha:
+		return "alpha"
+	case <-bravo:
+		return "bravo"
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for first project dispatch")
+	}
+	return ""
+}
+
+func runningProjects(t *testing.T, manager *project.Manager) int {
+	t.Helper()
+
+	total := 0
+	for _, item := range manager.Registry().List() {
+		state, err := item.Orchestrator().State(context.Background())
+		if err != nil {
+			t.Fatalf("State(%s) error = %v", item.ID(), err)
+		}
+		total += len(state.Running)
+	}
+	return total
 }
 
 func releaseProjectSlot(t *testing.T, global scheduler.GlobalScheduler, slot scheduler.Slot) {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -385,6 +385,10 @@ func (p *Project) Unpause(ctx context.Context) error {
 	}
 	p.cfg.Paused = false
 	running := p.done != nil
+	if !running {
+		p.orchConfig = projectOrchestratorConfig(p.cfg, p.workflow.Config)
+		p.orchestrator = nil
+	}
 	p.mu.Unlock()
 
 	if !running {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -77,6 +77,7 @@ type Dependencies struct {
 	WorkflowWatcherFactory WorkflowWatcherFactory
 	Runner                 orchestrator.Runner
 	Scheduler              scheduler.Scheduler
+	GlobalDispatchGate     scheduler.ProjectDispatchGate
 	Events                 *hub.Hub[Event]
 	Logger                 *slog.Logger
 	GitHubToken            string
@@ -159,9 +160,10 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 
 	orchConfig := projectOrchestratorConfig(cfg.Project, workflow.Config)
 	orchDeps := orchestrator.Dependencies{
-		Connector: projectConnector,
-		Runner:    deps.Runner,
-		Logger:    logger,
+		Connector:          projectConnector,
+		Runner:             deps.Runner,
+		GlobalDispatchGate: deps.GlobalDispatchGate,
+		Logger:             logger,
 	}
 	orch, err := orchestratorFactory(orchConfig, orchDeps)
 	if err != nil {
@@ -653,6 +655,12 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 func projectOrchestratorConfig(project globalconfig.Project, workflow workflowconfig.Config) orchestrator.Config {
 	workflow = workflowConfigWithProjectIdentity(project, workflow)
 	cfg := orchestrator.ConfigFromWorkflow(workflow)
+	cfg.Project = scheduler.ProjectCandidate{
+		ID:       project.ID,
+		Weight:   project.Weight,
+		Priority: project.Priority,
+		Paused:   project.Paused,
+	}
 	cfg.Authorization = combineAuthorizationSelectors(cfg.Authorization, project.Authorization)
 	return cfg
 }

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -27,7 +27,9 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 
 	events := hub.New[project.Event]()
 	sched := scheduler.NewCountingSemaphore(scheduler.Config{Capacity: 3})
+	global := scheduler.NewGlobalDispatchGate(scheduler.NewRoundRobin(scheduler.Config{Capacity: 8}))
 	created := make(chan orchestrator.Config, 1)
+	createdDeps := make(chan orchestrator.Dependencies, 1)
 	workflowCfg := workflowConfigWithMemoryIssue("issue-1")
 	workflowCfg.Identity.Name = "workflow-persona"
 	workflowCfg.Identity.GitHubLogin = "workflow-bot"
@@ -55,11 +57,13 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 			Prompt: "Run issue",
 		},
 	}, project.Dependencies{
-		Scheduler: sched,
-		Events:    events,
-		Runner:    orchestrator.FakeRunner{},
+		Scheduler:          sched,
+		GlobalDispatchGate: global,
+		Events:             events,
+		Runner:             orchestrator.FakeRunner{},
 		OrchestratorFactory: func(cfg orchestrator.Config, deps orchestrator.Dependencies) (*orchestrator.Orchestrator, error) {
 			created <- cfg
+			createdDeps <- deps
 			return orchestrator.New(cfg, deps)
 		},
 	})
@@ -100,8 +104,20 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 		if len(cfg.Authorization.And) != 2 {
 			t.Fatalf("Authorization.And = %#v, want workflow and project selectors", cfg.Authorization.And)
 		}
+		if cfg.Project.ID != "detent" || cfg.Project.Weight != 2 || cfg.Project.Priority != 10 {
+			t.Fatalf("orchestrator Project = %#v, want detent weight 2 priority 10", cfg.Project)
+		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for orchestrator factory")
+	}
+
+	select {
+	case deps := <-createdDeps:
+		if deps.GlobalDispatchGate != global {
+			t.Fatalf("orchestrator GlobalDispatchGate = %T, want shared gate", deps.GlobalDispatchGate)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for orchestrator dependencies")
 	}
 }
 

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -636,6 +636,57 @@ func TestProjectStartRejectsPausedProject(t *testing.T) {
 	}
 }
 
+func TestProjectUnpauseRebuildsGlobalDispatchCandidate(t *testing.T) {
+	t.Parallel()
+
+	workflowCfg := workflowConfigWithMemoryIssue("issue-paused")
+	workflowCfg.Tracker.Issues[0].State = "Todo"
+	workflowCfg.Tracker.Issues[0].Title = "Run initially paused project"
+	workflowCfg.Tracker.Issues[0].AssignedToWorker = true
+	runner := newProjectBlockingRunner()
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "paused",
+			Paused: true,
+			Weight: 1,
+		},
+		Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Run paused project."},
+	}, project.Dependencies{
+		Runner:             runner,
+		GlobalDispatchGate: scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1})),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if !got.Running() {
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+		if err := got.Stop(ctx); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			cancel()
+			t.Fatalf("Stop() error = %v", err)
+		}
+		cancel()
+	})
+
+	if err := got.Start(context.Background()); !errors.Is(err, project.ErrProjectPaused) {
+		t.Fatalf("Start() error = %v, want %v", err, project.ErrProjectPaused)
+	}
+	if err := got.Unpause(context.Background()); err != nil {
+		t.Fatalf("Unpause() error = %v", err)
+	}
+
+	select {
+	case request := <-runner.started:
+		if request.Issue.ID != "issue-paused" {
+			t.Fatalf("RunRequest.Issue.ID = %q, want issue-paused", request.Issue.ID)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for unpaused project dispatch")
+	}
+}
+
 func TestProjectPauseUnpauseRestartsProject(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -12,23 +12,31 @@ type ProjectDispatchGate interface {
 	MarkReady(ProjectCandidate)
 	MarkIdle(string)
 	TryAcquire(context.Context, ProjectCandidate, SlotRequest, time.Time) (Slot, bool, error)
+	SetPreempt(Slot, func())
 	Release(Slot) error
+}
+
+type runningProjectSlot struct {
+	RunningProject
+	slot    Slot
+	preempt func()
 }
 
 type GlobalDispatchGate struct {
 	global GlobalScheduler
 
-	mu       sync.Mutex
-	ready    map[string]ProjectCandidate
-	running  map[uint64]RunningProject
-	selected string
+	mu          sync.Mutex
+	ready       map[string]ProjectCandidate
+	running     map[uint64]runningProjectSlot
+	selected    string
+	preemptions []RunningProject
 }
 
 func NewGlobalDispatchGate(global GlobalScheduler) *GlobalDispatchGate {
 	return &GlobalDispatchGate{
 		global:  global,
 		ready:   map[string]ProjectCandidate{},
-		running: map[uint64]RunningProject{},
+		running: map[uint64]runningProjectSlot{},
 	}
 }
 
@@ -62,6 +70,7 @@ func (g *GlobalDispatchGate) MarkIdle(projectID string) {
 	delete(g.ready, projectID)
 	if g.selected == projectID {
 		g.selected = ""
+		g.preemptions = nil
 	}
 }
 
@@ -105,9 +114,15 @@ func (g *GlobalDispatchGate) TryAcquire(
 			return Slot{}, false, err
 		}
 		g.selected = selection.Project.ID
+		g.preemptions = selection.Preemptions
 	}
 	if g.selected != project.ID {
 		return Slot{}, false, nil
+	}
+	if err := g.preemptProjectsLocked(g.preemptions); err != nil {
+		g.selected = ""
+		g.preemptions = nil
+		return Slot{}, false, err
 	}
 
 	slot, err := g.global.RequestSlot(ctx, req)
@@ -116,6 +131,7 @@ func (g *GlobalDispatchGate) TryAcquire(
 			return Slot{}, false, nil
 		}
 		g.selected = ""
+		g.preemptions = nil
 		return Slot{}, false, err
 	}
 	if err := g.global.RecordProjectDispatch(ctx, ProjectDispatch{
@@ -124,16 +140,37 @@ func (g *GlobalDispatchGate) TryAcquire(
 		DispatchedAt: now,
 	}); err != nil {
 		g.selected = ""
+		g.preemptions = nil
 		return Slot{}, false, errors.Join(err, g.global.ReleaseSlot(slot))
 	}
 
 	delete(g.ready, project.ID)
 	g.selected = ""
-	g.running[slot.token] = RunningProject{
-		ProjectID: project.ID,
-		Priority:  project.Priority,
+	g.preemptions = nil
+	g.running[slot.token] = runningProjectSlot{
+		RunningProject: RunningProject{
+			ProjectID: project.ID,
+			Priority:  project.Priority,
+		},
+		slot: slot,
 	}
 	return slot, true, nil
+}
+
+func (g *GlobalDispatchGate) SetPreempt(slot Slot, preempt func()) {
+	if g == nil || slot == (Slot{}) {
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	running, ok := g.running[slot.token]
+	if !ok {
+		return
+	}
+	running.preempt = preempt
+	g.running[slot.token] = running
 }
 
 func (g *GlobalDispatchGate) Release(slot Slot) error {
@@ -144,10 +181,37 @@ func (g *GlobalDispatchGate) Release(slot Slot) error {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	if _, ok := g.running[slot.token]; !ok {
+		return nil
+	}
 	if err := g.global.ReleaseSlot(slot); err != nil {
 		return err
 	}
 	delete(g.running, slot.token)
+	return nil
+}
+
+func (g *GlobalDispatchGate) preemptProjectsLocked(preemptions []RunningProject) error {
+	for _, preemption := range preemptions {
+		if err := g.preemptProjectLocked(preemption); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (g *GlobalDispatchGate) preemptProjectLocked(preemption RunningProject) error {
+	for token, running := range g.running {
+		if running.ProjectID != preemption.ProjectID || running.Priority != preemption.Priority || running.preempt == nil {
+			continue
+		}
+		running.preempt()
+		if err := g.global.ReleaseSlot(running.slot); err != nil && !errors.Is(err, ErrSlotNotHeld) {
+			return err
+		}
+		delete(g.running, token)
+		return nil
+	}
 	return nil
 }
 
@@ -165,7 +229,7 @@ func (g *GlobalDispatchGate) readyProjectsLocked() []ProjectCandidate {
 func (g *GlobalDispatchGate) runningProjectsLocked() []RunningProject {
 	projects := make([]RunningProject, 0, len(g.running))
 	for _, project := range g.running {
-		projects = append(projects, project)
+		projects = append(projects, project.RunningProject)
 	}
 	sort.Slice(projects, func(i, j int) bool {
 		if projects[i].ProjectID != projects[j].ProjectID {

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -1,0 +1,185 @@
+package scheduler
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"sync"
+	"time"
+)
+
+type ProjectDispatchGate interface {
+	MarkReady(ProjectCandidate)
+	MarkIdle(string)
+	TryAcquire(context.Context, ProjectCandidate, SlotRequest, time.Time) (Slot, bool, error)
+	Release(Slot) error
+}
+
+type GlobalDispatchGate struct {
+	global GlobalScheduler
+
+	mu       sync.Mutex
+	ready    map[string]ProjectCandidate
+	running  map[uint64]RunningProject
+	selected string
+}
+
+func NewGlobalDispatchGate(global GlobalScheduler) *GlobalDispatchGate {
+	return &GlobalDispatchGate{
+		global:  global,
+		ready:   map[string]ProjectCandidate{},
+		running: map[uint64]RunningProject{},
+	}
+}
+
+func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
+	if g == nil || g.global == nil {
+		return
+	}
+	project, ok := normalizeSingleProjectCandidate(project)
+	if !ok {
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.ready[project.ID] = project
+}
+
+func (g *GlobalDispatchGate) MarkIdle(projectID string) {
+	if g == nil {
+		return
+	}
+	projectID = normalizeProjectID(projectID)
+	if projectID == "" {
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	delete(g.ready, projectID)
+	if g.selected == projectID {
+		g.selected = ""
+	}
+}
+
+func (g *GlobalDispatchGate) TryAcquire(
+	ctx context.Context,
+	project ProjectCandidate,
+	req SlotRequest,
+	now time.Time,
+) (Slot, bool, error) {
+	if g == nil || g.global == nil {
+		return Slot{}, true, nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	project, ok := normalizeSingleProjectCandidate(project)
+	if !ok {
+		return Slot{}, false, ErrNoCandidates
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		return Slot{}, false, ctx.Err()
+	default:
+	}
+
+	g.ready[project.ID] = project
+	if g.selected == "" {
+		selection, err := g.global.SelectProject(ctx, ProjectSelectionRequest{
+			Projects: g.readyProjectsLocked(),
+			Running:  g.runningProjectsLocked(),
+			Now:      now,
+		})
+		if err != nil {
+			if errors.Is(err, ErrNoSlots) {
+				return Slot{}, false, nil
+			}
+			return Slot{}, false, err
+		}
+		g.selected = selection.Project.ID
+	}
+	if g.selected != project.ID {
+		return Slot{}, false, nil
+	}
+
+	slot, err := g.global.RequestSlot(ctx, req)
+	if err != nil {
+		if errors.Is(err, ErrNoSlots) {
+			return Slot{}, false, nil
+		}
+		g.selected = ""
+		return Slot{}, false, err
+	}
+	if err := g.global.RecordProjectDispatch(ctx, ProjectDispatch{
+		ProjectID:    project.ID,
+		Weight:       project.Weight,
+		DispatchedAt: now,
+	}); err != nil {
+		g.selected = ""
+		return Slot{}, false, errors.Join(err, g.global.ReleaseSlot(slot))
+	}
+
+	delete(g.ready, project.ID)
+	g.selected = ""
+	g.running[slot.token] = RunningProject{
+		ProjectID: project.ID,
+		Priority:  project.Priority,
+	}
+	return slot, true, nil
+}
+
+func (g *GlobalDispatchGate) Release(slot Slot) error {
+	if g == nil || g.global == nil || slot == (Slot{}) {
+		return nil
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	if err := g.global.ReleaseSlot(slot); err != nil {
+		return err
+	}
+	delete(g.running, slot.token)
+	return nil
+}
+
+func (g *GlobalDispatchGate) readyProjectsLocked() []ProjectCandidate {
+	projects := make([]ProjectCandidate, 0, len(g.ready))
+	for _, project := range g.ready {
+		projects = append(projects, project)
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		return projects[i].ID < projects[j].ID
+	})
+	return projects
+}
+
+func (g *GlobalDispatchGate) runningProjectsLocked() []RunningProject {
+	projects := make([]RunningProject, 0, len(g.running))
+	for _, project := range g.running {
+		projects = append(projects, project)
+	}
+	sort.Slice(projects, func(i, j int) bool {
+		if projects[i].ProjectID != projects[j].ProjectID {
+			return projects[i].ProjectID < projects[j].ProjectID
+		}
+		return projects[i].Priority < projects[j].Priority
+	})
+	return projects
+}
+
+func normalizeSingleProjectCandidate(project ProjectCandidate) (ProjectCandidate, bool) {
+	projects := normalizeProjectCandidates([]ProjectCandidate{project})
+	if len(projects) == 0 {
+		return ProjectCandidate{}, false
+	}
+	return projects[0], true
+}

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -1,0 +1,48 @@
+package scheduler_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+func TestGlobalDispatchGateUsesConfiguredProjectSelection(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewRoundRobin(scheduler.Config{Capacity: 1}))
+	alpha := scheduler.ProjectCandidate{ID: "alpha", Weight: 1}
+	bravo := scheduler.ProjectCandidate{ID: "bravo", Weight: 1}
+
+	slot, ok, err := gate.TryAcquire(ctx, alpha, scheduler.SlotRequest{State: "Todo"}, now)
+	if err != nil {
+		t.Fatalf("alpha TryAcquire() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("alpha TryAcquire() ok = false, want true")
+	}
+	if err := gate.Release(slot); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+
+	gate.MarkReady(bravo)
+	if _, ok, err := gate.TryAcquire(ctx, alpha, scheduler.SlotRequest{State: "Todo"}, now.Add(time.Second)); err != nil {
+		t.Fatalf("alpha second TryAcquire() error = %v", err)
+	} else if ok {
+		t.Fatal("alpha second TryAcquire() ok = true, want false while bravo has the round-robin turn")
+	}
+
+	slot, ok, err = gate.TryAcquire(ctx, bravo, scheduler.SlotRequest{State: "Todo"}, now.Add(2*time.Second))
+	if err != nil {
+		t.Fatalf("bravo TryAcquire() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("bravo TryAcquire() ok = false, want true")
+	}
+	if err := gate.Release(slot); err != nil {
+		t.Fatalf("bravo Release() error = %v", err)
+	}
+}

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -46,3 +46,44 @@ func TestGlobalDispatchGateUsesConfiguredProjectSelection(t *testing.T) {
 		t.Fatalf("bravo Release() error = %v", err)
 	}
 }
+
+func TestGlobalDispatchGateHonorsStrictPriorityPreemption(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 11, 12, 0, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}))
+	low := scheduler.ProjectCandidate{ID: "low", Weight: 1, Priority: 4}
+	urgent := scheduler.ProjectCandidate{ID: "urgent", Weight: 1, Priority: 1}
+
+	lowSlot, ok, err := gate.TryAcquire(ctx, low, scheduler.SlotRequest{State: "Todo"}, now)
+	if err != nil {
+		t.Fatalf("low TryAcquire() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("low TryAcquire() ok = false, want true")
+	}
+	preempted := make(chan struct{})
+	gate.SetPreempt(lowSlot, func() {
+		close(preempted)
+	})
+
+	urgentSlot, ok, err := gate.TryAcquire(ctx, urgent, scheduler.SlotRequest{State: "Todo"}, now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("urgent TryAcquire() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("urgent TryAcquire() ok = false, want true")
+	}
+	select {
+	case <-preempted:
+	default:
+		t.Fatal("low-priority project was not preempted")
+	}
+	if err := gate.Release(lowSlot); err != nil {
+		t.Fatalf("low Release() after preemption error = %v", err)
+	}
+	if err := gate.Release(urgentSlot); err != nil {
+		t.Fatalf("urgent Release() error = %v", err)
+	}
+}

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1066,7 +1066,7 @@ func TestReplaceBinaryPreservesValidDarwinSignature(t *testing.T) {
 	}
 
 	var calls []string
-	err := ReplaceBinary(Replacement{
+	err := ReplaceBinary(context.Background(), Replacement{
 		Target: target,
 		Binary: []byte("new"),
 		Mode:   0o755,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1149,7 +1149,8 @@ func TestServerReadHeaderTimeoutDropsStalledHeaders(t *testing.T) {
 		if err == nil {
 			continue
 		}
-		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
 			t.Fatalf("connection remained open after %v", time.Since(start))
 		}
 		if elapsed := time.Since(start); elapsed > readHeaderTimeout+500*time.Millisecond {


### PR DESCRIPTION
## Summary

- Wire a boot-created global scheduler and shared dispatch gate into project/orchestrator dispatch.
- Enforce global slots before runner dispatch while preserving per-project caps.
- Add scheduler, orchestrator, manager, and boot coverage for global cap and cross-project ordering.

Fixes #348

## Test Plan

- [x] `go test ./...`
- [x] `make check`