### PR TITLE
fix(update): repair stale ReplaceBinary call

### DIFF
--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -1066,7 +1066,7 @@ func TestReplaceBinaryPreservesValidDarwinSignature(t *testing.T) {
 	}
 
 	var calls []string
-	err := ReplaceBinary(Replacement{
+	err := ReplaceBinary(context.Background(), Replacement{
 		Target: target,
 		Binary: []byte("new"),
 		Mode:   0o755,

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1149,7 +1149,8 @@ func TestServerReadHeaderTimeoutDropsStalledHeaders(t *testing.T) {
 		if err == nil {
 			continue
 		}
-		if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		var netErr net.Error
+		if errors.As(err, &netErr) && netErr.Timeout() {
 			t.Fatalf("connection remained open after %v", time.Since(start))
 		}
 		if elapsed := time.Since(start); elapsed > readHeaderTimeout+500*time.Millisecond {


### PR DESCRIPTION
## Summary
- Pass a context to the stale `ReplaceBinary` test call in `internal/update/update_test.go`.
- Use `errors.As` for the exposed `net.Error` lint failure so the full gate can complete.

Fixes #353

## Test Plan
- `go test ./internal/update`
- `go test ./internal/web`
- `go vet ./...`
- `golangci-lint run ./...`
- `make check`