### PR TITLE
fix(project): close connectors on removal

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -18,6 +18,10 @@ type Connector interface {
 	SetField(context.Context, string, string, string) error
 }
 
+type Closer interface {
+	Close() error
+}
+
 type Authenticator interface {
 	Authenticate(context.Context) error
 }

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -411,6 +411,23 @@ func (c *Client) LiveConnections() int {
 	return stats.LiveConnections()
 }
 
+func (c *Client) Close() error {
+	if c == nil || c.httpClient == nil {
+		return nil
+	}
+	if closer, ok := c.httpClient.(interface {
+		Close() error
+	}); ok {
+		return closer.Close()
+	}
+	if closer, ok := c.httpClient.(interface {
+		CloseIdleConnections()
+	}); ok {
+		closer.CloseIdleConnections()
+	}
+	return nil
+}
+
 func (c *Client) setRateLimit(snapshot connector.GraphQLRateLimit) {
 	c.mu.Lock()
 	defer c.mu.Unlock()

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -145,6 +145,13 @@ func (c *Connector) LiveConnections() int {
 	return c.client.LiveConnections()
 }
 
+func (c *Connector) Close() error {
+	if c == nil || c.client == nil {
+		return nil
+	}
+	return c.client.Close()
+}
+
 func (c *Connector) Authenticate(ctx context.Context) error {
 	if c.projectID == "" {
 		return ErrMissingProject
@@ -185,6 +192,7 @@ func (c *Connector) InstanceLogin() string {
 
 var _ connector.Connector = (*Connector)(nil)
 var _ connector.Authenticator = (*Connector)(nil)
+var _ connector.Closer = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
 var _ connector.IssueChildrenResolver = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)

--- a/internal/connector/github/transport.go
+++ b/internal/connector/github/transport.go
@@ -51,6 +51,14 @@ func (c *PooledHTTPClient) LiveConnections() int {
 	return c.connections.live()
 }
 
+func (c *PooledHTTPClient) Close() error {
+	if c == nil || c.Client == nil {
+		return nil
+	}
+	c.CloseIdleConnections()
+	return nil
+}
+
 func normalizeHTTPTransportConfig(cfg HTTPTransportConfig) HTTPTransportConfig {
 	if cfg.MaxIdleConns <= 0 {
 		cfg.MaxIdleConns = defaultHTTPMaxIdleConns

--- a/internal/connector/github/transport_test.go
+++ b/internal/connector/github/transport_test.go
@@ -137,6 +137,12 @@ func TestConnectorUsesOnePooledClientForGitHubAppAndGraphQL(t *testing.T) {
 	if got := connector.LiveConnections(); got != 1 {
 		t.Fatalf("LiveConnections() = %d, want 1", got)
 	}
+	if err := connector.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if got := connector.LiveConnections(); got != 0 {
+		t.Fatalf("LiveConnections() after Close = %d, want 0", got)
+	}
 }
 
 func testPooledClientPrivateKeyPEM(t *testing.T) string {

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -223,14 +223,14 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	for _, id := range result.Changed {
 		_, preparedProject, err := m.createProjectLocked(desired[id])
 		if err != nil {
-			return result, err
+			return result, errors.Join(err, closePreparedProjects(ctx, prepared))
 		}
 		prepared[id] = preparedProject
 	}
 	for _, id := range result.Added {
 		_, preparedProject, err := m.createProjectLocked(desired[id])
 		if err != nil {
-			return result, err
+			return result, errors.Join(err, closePreparedProjects(ctx, prepared))
 		}
 		prepared[id] = preparedProject
 	}
@@ -243,6 +243,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	added := map[ID]struct{}{}
 	rollback := func() error {
 		cleanupErr := m.stopUncommittedStartedProjects(ctx, started)
+		cleanupErr = errors.Join(cleanupErr, closePreparedProjects(ctx, prepared))
 		for id := range added {
 			m.registry.Delete(id)
 		}
@@ -330,7 +331,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	for _, item := range started {
 		item.project.publishStarted()
 	}
-	return result, nil
+	return result, closeStoppedProjects(ctx, stopped)
 }
 
 func (m *Manager) removeLocked(ctx context.Context, id ID) error {
@@ -338,10 +339,8 @@ func (m *Manager) removeLocked(ctx context.Context, id ID) error {
 	if !ok {
 		return ErrProjectNotFound
 	}
-	if project.Running() {
-		if err := project.Stop(ctx); err != nil {
-			return err
-		}
+	if err := project.close(ctx, true); err != nil {
+		return err
 	}
 	m.registry.Delete(id)
 	return nil
@@ -428,7 +427,7 @@ func (m *Manager) registerProjectLocked(ctx context.Context, id ID, project *Pro
 	}
 	if err := m.startLocked(ctx, project); err != nil {
 		m.registry.Delete(id)
-		return err
+		return errors.Join(err, project.close(ctx, false))
 	}
 	return nil
 }
@@ -476,6 +475,22 @@ func (m *Manager) stopUncommittedStartedProjects(ctx context.Context, started []
 		if item.project.Running() {
 			cleanupErr = errors.Join(cleanupErr, item.project.stop(ctx, false))
 		}
+	}
+	return cleanupErr
+}
+
+func closePreparedProjects(ctx context.Context, prepared map[ID]*Project) error {
+	var cleanupErr error
+	for _, project := range prepared {
+		cleanupErr = errors.Join(cleanupErr, project.close(ctx, false))
+	}
+	return cleanupErr
+}
+
+func closeStoppedProjects(ctx context.Context, stopped []rollbackProject) error {
+	var cleanupErr error
+	for _, item := range stopped {
+		cleanupErr = errors.Join(cleanupErr, item.project.close(ctx, false))
 	}
 	return cleanupErr
 }

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -196,6 +196,60 @@ func TestManagerRemoveClosesProjectConnector(t *testing.T) {
 	assertConnectorClosed(t, projectConnector)
 }
 
+func TestManagerRemoveKeepsProjectOpenWhenStopContextExpires(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	release := make(chan struct{})
+	projectConnector := newCloseTrackingConnector()
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			}, project.Dependencies{
+				Connector: projectConnector,
+				Events:    events,
+				Runner:    releaseBlockingRunner{release: release},
+			})
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveEvent(t, sub.C())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := manager.Remove(ctx, "alpha"); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Remove() error = %v, want %v", err, context.Canceled)
+	}
+	if _, ok := manager.Registry().Get("alpha"); !ok {
+		t.Fatal("Get(alpha) ok = false after failed Remove, want true")
+	}
+	assertConnectorOpen(t, projectConnector)
+
+	close(release)
+	if err := manager.Remove(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Remove() after release error = %v", err)
+	}
+	assertConnectorClosed(t, projectConnector)
+}
+
 func TestManagerReconcileProjects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -9,6 +9,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -152,6 +153,49 @@ func TestManagerLiveAddRemovePauseUnpause(t *testing.T) {
 	}
 }
 
+func TestManagerRemoveClosesProjectConnector(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	projectConnector := newCloseTrackingConnector()
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			}, project.Dependencies{
+				Connector: projectConnector,
+				Events:    events,
+				Runner:    blockingRunner{},
+			})
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveEvent(t, sub.C())
+
+	if err := manager.Remove(context.Background(), "alpha"); err != nil {
+		t.Fatalf("Remove() error = %v", err)
+	}
+	receiveEvent(t, sub.C())
+	assertConnectorClosed(t, projectConnector)
+}
+
 func TestManagerReconcileProjects(t *testing.T) {
 	t.Parallel()
 
@@ -275,6 +319,44 @@ func TestManagerReconcileProjects(t *testing.T) {
 			assertManagerProjectConfigs(t, manager, tt.wantConfigs)
 		})
 	}
+}
+
+func TestManagerReconcileClosesPreparedProjectWhenLaterCreateFails(t *testing.T) {
+	t.Parallel()
+
+	factoryErr := errors.New("invalid workflow")
+	preparedConnector := newCloseTrackingConnector()
+	manager, err := project.NewManager(project.ManagerConfig{}, project.ManagerDependencies{
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "bravo" {
+				return nil, factoryErr
+			}
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			}, project.Dependencies{
+				Connector: preparedConnector,
+				Runner:    blockingRunner{},
+			})
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	_, err = manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	})
+	if !errors.Is(err, factoryErr) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, factoryErr)
+	}
+	assertConnectorClosed(t, preparedConnector)
 }
 
 func TestManagerReconcileChangesProjectsWhenRuntimeCredentialVersionChanges(t *testing.T) {
@@ -495,6 +577,10 @@ func TestManagerReconcileKeepsChangedProjectWhenReplacementProvisionFails(t *tes
 	t.Parallel()
 
 	provisionErr := errors.New("provision failed")
+	replacementConnector := newCloseTrackingProvisioningConnector()
+	replacementConnector.provision = func(context.Context) error {
+		return provisionErr
+	}
 	events := hub.New[project.Event](hub.WithBuffer(8))
 	sub, err := events.Subscribe(context.Background())
 	if err != nil {
@@ -506,17 +592,15 @@ func TestManagerReconcileKeepsChangedProjectWhenReplacementProvisionFails(t *tes
 	}, project.ManagerDependencies{
 		Events: events,
 		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
-			var provision func(context.Context) error
+			var projectConnector connector.Connector = provisioningConnector{}
 			if cfg.ID == "alpha" && cfg.Weight == 2 {
-				provision = func(context.Context) error {
-					return provisionErr
-				}
+				projectConnector = replacementConnector
 			}
 			return project.New(project.Config{
 				Project:  cfg,
 				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
 			}, project.Dependencies{
-				Connector: provisioningConnector{provision: provision},
+				Connector: projectConnector,
 				Events:    events,
 				Runner:    blockingRunner{},
 			})
@@ -551,6 +635,7 @@ func TestManagerReconcileKeepsChangedProjectWhenReplacementProvisionFails(t *tes
 	if !got.Running() {
 		t.Fatal("alpha Running() = false, want true")
 	}
+	assertConnectorClosed(t, replacementConnector.closeTrackingConnector)
 }
 
 func TestManagerReconcileKeepsChangedProjectWhenReplacementStartFails(t *testing.T) {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -105,6 +105,7 @@ type Project struct {
 	done            chan struct{}
 	runErr          error
 	started         bool
+	closed          bool
 	lifecycleEvents bool
 }
 
@@ -275,7 +276,7 @@ func (p *Project) start(ctx context.Context, opts startOptions) error {
 		p.mu.Unlock()
 		return ErrAlreadyRunning
 	}
-	if p.started {
+	if p.started || p.closed {
 		p.mu.Unlock()
 		return ErrProjectStopped
 	}
@@ -296,7 +297,7 @@ func (p *Project) start(ctx context.Context, opts startOptions) error {
 		p.mu.Unlock()
 		return ErrAlreadyRunning
 	}
-	if p.started {
+	if p.started || p.closed {
 		p.mu.Unlock()
 		return ErrProjectStopped
 	}
@@ -426,6 +427,45 @@ func (p *Project) Stop(ctx context.Context) error {
 	return p.stop(ctx, true)
 }
 
+func (p *Project) Close() error {
+	return p.close(context.Background(), true)
+}
+
+func (p *Project) close(ctx context.Context, publishEvents bool) error {
+	if p == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	p.mu.Lock()
+	if p.closed {
+		p.mu.Unlock()
+		return nil
+	}
+	running := p.done != nil
+	p.closed = true
+	p.mu.Unlock()
+
+	var closeErr error
+	if running {
+		if err := p.stop(ctx, publishEvents); err != nil && !errors.Is(err, ErrNotRunning) {
+			closeErr = errors.Join(closeErr, err)
+		}
+	}
+	closeErr = errors.Join(closeErr, p.closeConnector())
+	return closeErr
+}
+
+func (p *Project) closeConnector() error {
+	p.mu.Lock()
+	projectConnector := p.connector
+	p.mu.Unlock()
+
+	return closeConnector(projectConnector)
+}
+
 func (p *Project) stop(ctx context.Context, publishEvents bool) error {
 	if ctx == nil {
 		ctx = context.Background()
@@ -454,6 +494,10 @@ func (p *Project) restart(ctx context.Context, opts startOptions) error {
 	if p.cfg.Paused {
 		p.mu.Unlock()
 		return ErrProjectPaused
+	}
+	if p.closed {
+		p.mu.Unlock()
+		return ErrProjectStopped
 	}
 	if p.done != nil {
 		p.mu.Unlock()
@@ -761,6 +805,14 @@ func buildConnector(cfg workflowconfig.Config, connectorFactory ConnectorFactory
 	}
 
 	return projectConnector, nil
+}
+
+func closeConnector(projectConnector connector.Connector) error {
+	closer, ok := projectConnector.(connector.Closer)
+	if !ok {
+		return nil
+	}
+	return closer.Close()
 }
 
 func resolveSchedulerFactory(deps Dependencies) schedulerFactory {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -445,17 +445,21 @@ func (p *Project) close(ctx context.Context, publishEvents bool) error {
 		return nil
 	}
 	running := p.done != nil
-	p.closed = true
 	p.mu.Unlock()
 
-	var closeErr error
 	if running {
 		if err := p.stop(ctx, publishEvents); err != nil && !errors.Is(err, ErrNotRunning) {
-			closeErr = errors.Join(closeErr, err)
+			return err
 		}
 	}
-	closeErr = errors.Join(closeErr, p.closeConnector())
-	return closeErr
+	if err := p.closeConnector(); err != nil {
+		return err
+	}
+
+	p.mu.Lock()
+	p.closed = true
+	p.mu.Unlock()
+	return nil
 }
 
 func (p *Project) closeConnector() error {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -156,6 +156,50 @@ func TestProjectStartStopPublishesLifecycleEvents(t *testing.T) {
 	}
 }
 
+func TestProjectCloseStopsAndClosesConnector(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(2))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	projectConnector := newCloseTrackingConnector()
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "detent",
+			Weight: 1,
+		},
+		Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+	}, project.Dependencies{
+		Connector: projectConnector,
+		Events:    events,
+		Runner:    blockingRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	receiveEvent(t, sub.C())
+	if err := got.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	stopped := receiveEvent(t, sub.C())
+	if stopped.ProjectID != got.ID() || stopped.Kind != project.EventStopped {
+		t.Fatalf("stopped event = %#v, want project stopped", stopped)
+	}
+	assertConnectorClosed(t, projectConnector)
+	if err := got.Close(); err != nil {
+		t.Fatalf("Close() second error = %v", err)
+	}
+	if err := got.Start(context.Background()); !errors.Is(err, project.ErrProjectStopped) {
+		t.Fatalf("Start() after Close error = %v, want %v", err, project.ErrProjectStopped)
+	}
+}
+
 func TestProjectAppliesWorkflowReloadsToRunningOrchestrator(t *testing.T) {
 	t.Parallel()
 
@@ -994,6 +1038,80 @@ func (c provisioningConnector) Provision(ctx context.Context) error {
 		return nil
 	}
 	return c.provision(ctx)
+}
+
+type closeTrackingConnector struct {
+	closed chan struct{}
+	once   sync.Once
+}
+
+func newCloseTrackingConnector() *closeTrackingConnector {
+	return &closeTrackingConnector{closed: make(chan struct{})}
+}
+
+func (c *closeTrackingConnector) Name() string {
+	return "close-tracking"
+}
+
+func (c *closeTrackingConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *closeTrackingConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *closeTrackingConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *closeTrackingConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *closeTrackingConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c *closeTrackingConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *closeTrackingConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c *closeTrackingConnector) Close() error {
+	c.once.Do(func() {
+		close(c.closed)
+	})
+	return nil
+}
+
+type closeTrackingProvisioningConnector struct {
+	*closeTrackingConnector
+	provision func(context.Context) error
+}
+
+func newCloseTrackingProvisioningConnector() *closeTrackingProvisioningConnector {
+	return &closeTrackingProvisioningConnector{closeTrackingConnector: newCloseTrackingConnector()}
+}
+
+func (c *closeTrackingProvisioningConnector) Provision(ctx context.Context) error {
+	if c.provision == nil {
+		return nil
+	}
+	return c.provision(ctx)
+}
+
+func assertConnectorClosed(t *testing.T, projectConnector *closeTrackingConnector) {
+	t.Helper()
+
+	select {
+	case <-projectConnector.closed:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connector close")
+	}
 }
 
 func receiveEvent(t *testing.T, ch <-chan project.Event) project.Event {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -827,6 +827,15 @@ func (blockingRunner) Run(ctx context.Context, _ orchestrator.RunRequest) (orche
 	return orchestrator.RunResult{}, ctx.Err()
 }
 
+type releaseBlockingRunner struct {
+	release <-chan struct{}
+}
+
+func (r releaseBlockingRunner) Run(ctx context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	<-r.release
+	return orchestrator.RunResult{}, ctx.Err()
+}
+
 type pauseBlockingConnector struct {
 	entered  chan struct{}
 	releasec chan struct{}
@@ -1111,6 +1120,16 @@ func assertConnectorClosed(t *testing.T, projectConnector *closeTrackingConnecto
 	case <-projectConnector.closed:
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for connector close")
+	}
+}
+
+func assertConnectorOpen(t *testing.T, projectConnector *closeTrackingConnector) {
+	t.Helper()
+
+	select {
+	case <-projectConnector.closed:
+		t.Fatal("connector closed, want open")
+	default:
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add terminal `Project.Close` cleanup and optional connector close support.
- Close project connectors on manager remove, reconcile preparation failures, rollback, and replaced/removed projects.
- Add GitHub connector/client/pooled transport close plumbing to drain idle connections.

Fixes #350

## Test Plan

- [x] `go test ./internal/project ./internal/connector/github`
- [x] `make check`