### PR TITLE
fix(runner): reap terminal sessions

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -489,10 +489,11 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 
 		running := state.Running[id]
 		running.Issue = mergeIssueTrackerFields(running.Issue, issue)
-		state.Running[id] = running
 		if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
-			o.cancelRunning(state, id)
+			o.completeTerminalRunning(ctx, state, id, running, terminalCompletedAt(running.Issue, now), running.Tokens)
+			continue
 		}
+		state.Running[id] = running
 
 		if claimed, ok := state.Claimed[id]; ok {
 			claimed.Issue = mergeIssueTrackerFields(claimed.Issue, issue)
@@ -576,6 +577,9 @@ func mergeIssueTrackerFields(current, refreshed connector.Issue) connector.Issue
 	}
 	if refreshed.UpdatedAt != nil {
 		merged.UpdatedAt = refreshed.UpdatedAt
+	}
+	if refreshed.StageUpdatedAt != nil {
+		merged.StageUpdatedAt = refreshed.StageUpdatedAt
 	}
 	if refreshed.ModelOverride != "" {
 		merged.ModelOverride = refreshed.ModelOverride
@@ -1119,10 +1123,17 @@ func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
 	delete(state.Running, event.IssueID)
 
 	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
-		delete(state.Claimed, event.IssueID)
-		delete(state.Retry, event.IssueID)
-		delete(state.BudgetRefusals, event.IssueID)
-		o.reapWorkspace(context.Background(), state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates))
+		tokens := event.Result.Tokens
+		if tokens == (CodexTotals{}) {
+			tokens = running.Tokens
+		}
+		if diffStatsPresent(event.Result.DiffStats) {
+			running.DiffStats = event.Result.DiffStats
+		}
+		o.completeTerminalRunning(context.Background(), state, event.IssueID, running, terminalCompletedAt(running.Issue, event.CompletedAt), tokens)
+		if event.Result.RateLimits != nil {
+			state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
+		}
 		return
 	}
 
@@ -1209,6 +1220,53 @@ func (o *Orchestrator) releaseClaim(state *State, issueID string) {
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+}
+
+func (o *Orchestrator) completeTerminalRunning(
+	ctx context.Context,
+	state *State,
+	issueID string,
+	running Running,
+	completedAt time.Time,
+	tokens CodexTotals,
+) {
+	o.releaseGlobalDispatchSlot(running.globalSlot)
+	if running.cancel != nil {
+		running.cancel()
+	}
+	delete(state.Running, issueID)
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	finalState := strings.TrimSpace(running.Issue.State)
+	if finalState == "" {
+		finalState = FinalStateCompleted
+	}
+	state.Completed[issueID] = Completed{
+		Issue:       cloneIssue(running.Issue),
+		StartedAt:   running.StartedAt,
+		CompletedAt: completedAt,
+		FinalState:  finalState,
+		Tokens:      tokens,
+	}
+	state.CodexTotals = addCodexTotals(state.CodexTotals, tokens)
+	if diffStatsPresent(running.DiffStats) {
+		state.DiffStats[issueID] = running.DiffStats
+	}
+	o.reapWorkspace(ctx, state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates))
+}
+
+func terminalCompletedAt(issue connector.Issue, fallback time.Time) time.Time {
+	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+		return *issue.StageUpdatedAt
+	}
+	if issue.UpdatedAt != nil && !issue.UpdatedAt.IsZero() {
+		return *issue.UpdatedAt
+	}
+	if !fallback.IsZero() {
+		return fallback
+	}
+	return time.Now().UTC()
 }
 
 func (o *Orchestrator) cancelRunning(state *State, issueID string) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -490,7 +490,7 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 		running := state.Running[id]
 		running.Issue = mergeIssueTrackerFields(running.Issue, issue)
 		if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
-			o.completeTerminalRunning(ctx, state, id, running, terminalCompletedAt(running.Issue, now), running.Tokens)
+			o.completeTerminalRunning(ctx, state, id, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
 			continue
 		}
 		state.Running[id] = running
@@ -1130,7 +1130,7 @@ func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
 		if diffStatsPresent(event.Result.DiffStats) {
 			running.DiffStats = event.Result.DiffStats
 		}
-		o.completeTerminalRunning(context.Background(), state, event.IssueID, running, terminalCompletedAt(running.Issue, event.CompletedAt), tokens)
+		o.completeTerminalRunning(context.Background(), state, event.IssueID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, event.CompletedAt), tokens)
 		if event.Result.RateLimits != nil {
 			state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
 		}
@@ -1256,12 +1256,15 @@ func (o *Orchestrator) completeTerminalRunning(
 	o.reapWorkspace(ctx, state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates))
 }
 
-func terminalCompletedAt(issue connector.Issue, fallback time.Time) time.Time {
-	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+func terminalCompletedAt(issue connector.Issue, terminalStates []string, fallback time.Time) time.Time {
+	if stateIn(issue.State, terminalStates) && issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
 		return *issue.StageUpdatedAt
 	}
 	if issue.UpdatedAt != nil && !issue.UpdatedAt.IsZero() {
 		return *issue.UpdatedAt
+	}
+	if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+		return *issue.StageUpdatedAt
 	}
 	if !fallback.IsZero() {
 		return fallback

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 )
 
 func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
@@ -127,6 +128,106 @@ func TestTickReconcilesRunningIssueTrackerState(t *testing.T) {
 				t.Fatalf("FetchIssueStatesByIDs() ids = %#v, want [%s]", tracker.requestedIDs, prior.ID)
 			}
 		})
+	}
+}
+
+func TestTickReapsTerminalRunningIssue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	startedAt := now.Add(-10 * time.Minute)
+	terminalAt := now.Add(-30 * time.Second)
+	issue := connector.Issue{
+		ID:         "issue-cancelled",
+		Identifier: "digitaldrywood/detent#356",
+		Title:      "Cancelled session",
+		State:      "In Progress",
+		URL:        "https://github.com/digitaldrywood/detent/issues/356",
+	}
+	cancelled := cloneIssue(issue)
+	cancelled.State = "Cancelled"
+	cancelled.StageUpdatedAt = &terminalAt
+
+	project := scheduler.ProjectCandidate{ID: "detent", Weight: 1}
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1}))
+	slot, ok, err := gate.TryAcquire(context.Background(), project, scheduler.SlotRequest{State: issue.State}, startedAt)
+	if err != nil {
+		t.Fatalf("TryAcquire() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("TryAcquire() ok = false, want true")
+	}
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		Project:             project,
+		ActiveStates:        []string{"Todo", "In Progress", "Human Review", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled", "Failed"},
+	})
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:      cloneIssue(issue),
+		StartedAt:  startedAt,
+		Tokens:     CodexTotals{InputTokens: 10, OutputTokens: 5, TotalTokens: 15, RuntimeSeconds: 90},
+		globalSlot: slot,
+		cancel:     cancel,
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: startedAt, Owner: "worker-1"}
+
+	tracker := &runningStateConnector{issues: []connector.Issue{cancelled}}
+	orch := &Orchestrator{
+		cfg:                cfg,
+		connector:          tracker,
+		logger:             slog.New(slog.NewTextHandler(io.Discard, nil)),
+		globalDispatchGate: gate,
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after terminal reconciliation", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after terminal reconciliation", issue.ID)
+	}
+	completed, ok := state.Completed[issue.ID]
+	if !ok {
+		t.Fatalf("Completed[%q] missing after terminal reconciliation", issue.ID)
+	}
+	if completed.FinalState != "Cancelled" {
+		t.Fatalf("Completed[%q].FinalState = %q, want Cancelled", issue.ID, completed.FinalState)
+	}
+	if !completed.CompletedAt.Equal(terminalAt) {
+		t.Fatalf("Completed[%q].CompletedAt = %v, want %v", issue.ID, completed.CompletedAt, terminalAt)
+	}
+	if completed.Tokens.TotalTokens != 15 {
+		t.Fatalf("Completed[%q].Tokens.TotalTokens = %d, want 15", issue.ID, completed.Tokens.TotalTokens)
+	}
+	select {
+	case <-runCtx.Done():
+	default:
+		t.Fatal("running context was not cancelled")
+	}
+
+	nextSlot, ok, err := gate.TryAcquire(context.Background(), project, scheduler.SlotRequest{State: "Todo"}, now)
+	if err != nil {
+		t.Fatalf("TryAcquire() after terminal reap error = %v", err)
+	}
+	if !ok {
+		t.Fatal("TryAcquire() after terminal reap ok = false, want true")
+	}
+	if err := gate.Release(nextSlot); err != nil {
+		t.Fatalf("Release() after terminal reap error = %v", err)
+	}
+
+	snapshot := state.Snapshot(now)
+	if snapshot.Counts.Running != 0 || len(snapshot.Running) != 0 {
+		t.Fatalf("snapshot running count = %d len = %d, want 0", snapshot.Counts.Running, len(snapshot.Running))
+	}
+	if snapshot.Counts.Completed != 1 || len(snapshot.Completed) != 1 {
+		t.Fatalf("snapshot completed count = %d len = %d, want 1", snapshot.Counts.Completed, len(snapshot.Completed))
 	}
 }
 

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -231,6 +231,69 @@ func TestTickReapsTerminalRunningIssue(t *testing.T) {
 	}
 }
 
+func TestTerminalCompletedAtUsesTerminalConditionTimestamp(t *testing.T) {
+	t.Parallel()
+
+	stageUpdatedAt := time.Date(2026, 6, 1, 11, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	fallback := time.Date(2026, 6, 1, 13, 0, 0, 0, time.UTC)
+	terminalStates := normalizeConfig(Config{TerminalStates: []string{"Done", "Cancelled"}}).TerminalStates
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		want  time.Time
+	}{
+		{
+			name: "status terminal uses stage update time",
+			issue: connector.Issue{
+				State:          "Cancelled",
+				StageUpdatedAt: &stageUpdatedAt,
+				UpdatedAt:      &updatedAt,
+			},
+			want: stageUpdatedAt,
+		},
+		{
+			name: "closed active issue uses issue update time",
+			issue: connector.Issue{
+				State:          "In Progress",
+				Closed:         true,
+				StageUpdatedAt: &stageUpdatedAt,
+				UpdatedAt:      &updatedAt,
+			},
+			want: updatedAt,
+		},
+		{
+			name: "merged active pull request uses issue update time",
+			issue: connector.Issue{
+				State:          "Merging",
+				StageUpdatedAt: &stageUpdatedAt,
+				UpdatedAt:      &updatedAt,
+				PullRequest:    &connector.PullRequest{State: "MERGED"},
+			},
+			want: updatedAt,
+		},
+		{
+			name: "missing tracker timestamps uses fallback",
+			issue: connector.Issue{
+				State: "Cancelled",
+			},
+			want: fallback,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := terminalCompletedAt(tt.issue, terminalStates, fallback)
+			if !got.Equal(tt.want) {
+				t.Fatalf("terminalCompletedAt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeIssueTrackerFieldsDistinguishesMissingAndEmptyMetadata(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Reap running sessions as soon as their refreshed tracker state is terminal.
- Move terminal sessions into completed telemetry with the tracker terminal timestamp and release their scheduler slot/claim/retry bookkeeping.
- Preserve refreshed `StageUpdatedAt` metadata for running issues so stale terminal rows are detectable.

Fixes #356

## Test Plan

- [x] `go test ./internal/orchestrator -run TestTickReapsTerminalRunningIssue -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/scheduler ./internal/web ./internal/tui -count=1`
- [x] `make check`