### PR TITLE
fix(web): restore dashboard SSE wiring

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -656,7 +656,7 @@ func TestDashboardWiresHTMXSSE(t *testing.T) {
 		`src="https://unpkg.com/htmx.org@2.0.4"`,
 		`src="https://cdn.jsdelivr.net/npm/htmx-ext-sse@2.2.4"`,
 		`src="https://cdn.jsdelivr.net/npm/idiomorph@0.7.3/dist/idiomorph-ext.min.js"`,
-		`hx-ext="sse morph"`,
+		`hx-ext="sse, morph"`,
 		`sse-connect="/events"`,
 		`sse-swap="snapshot"`,
 		`sse-swap="tick"`,
@@ -665,6 +665,9 @@ func TestDashboardWiresHTMXSSE(t *testing.T) {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("dashboard missing %q:\n%s", want, rec.Body.String())
 		}
+	}
+	if strings.Contains(rec.Body.String(), `hx-ext="sse morph"`) {
+		t.Fatalf("dashboard rendered space-separated htmx extensions:\n%s", rec.Body.String())
 	}
 }
 

--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -26,7 +26,7 @@ templ Dashboard(data DashboardData) {
 		</head>
 		<body class="min-h-screen overflow-x-hidden bg-background text-foreground antialiased">
 			@helpTooltipHost()
-			<main class="dashboard-shell mx-auto grid min-h-screen w-full max-w-7xl content-start gap-3 px-3 py-3 sm:gap-4 sm:px-6 lg:px-8" hx-ext="sse morph" sse-connect="/events">
+			<main class="dashboard-shell mx-auto grid min-h-screen w-full max-w-7xl content-start gap-3 px-3 py-3 sm:gap-4 sm:px-6 lg:px-8" hx-ext="sse, morph" sse-connect="/events">
 				<header class="dashboard-topbar min-w-0 border-b border-border py-2">
 					<div class="flex min-w-0 flex-wrap items-center gap-x-5 gap-y-2">
 						@dashboardTopbarBrand()

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -90,7 +90,7 @@ func Dashboard(data DashboardData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<main class=\"dashboard-shell mx-auto grid min-h-screen w-full max-w-7xl content-start gap-3 px-3 py-3 sm:gap-4 sm:px-6 lg:px-8\" hx-ext=\"sse morph\" sse-connect=\"/events\"><header class=\"dashboard-topbar min-w-0 border-b border-border py-2\"><div class=\"flex min-w-0 flex-wrap items-center gap-x-5 gap-y-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "<main class=\"dashboard-shell mx-auto grid min-h-screen w-full max-w-7xl content-start gap-3 px-3 py-3 sm:gap-4 sm:px-6 lg:px-8\" hx-ext=\"sse, morph\" sse-connect=\"/events\"><header class=\"dashboard-topbar min-w-0 border-b border-border py-2\"><div class=\"flex min-w-0 flex-wrap items-center gap-x-5 gap-y-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/help_test.go
+++ b/internal/web/templates/help_test.go
@@ -94,11 +94,15 @@ func TestHelpScriptUsesStableSharedPopoverUtility(t *testing.T) {
 		"availableBelow",
 		"maxHeight",
 		"aria-describedby",
+		`document.addEventListener("htmx:afterSettle"`,
 		"Escape",
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("help script missing %q:\n%s", want, html)
 		}
+	}
+	if strings.Contains(html, `document.body.addEventListener("htmx:afterSettle"`) {
+		t.Fatalf("help script installs htmx settle listener on document.body:\n%s", html)
 	}
 	if strings.Contains(html, "mousemove") {
 		t.Fatalf("help script should not reposition on mousemove:\n%s", html)


### PR DESCRIPTION
## Summary

- Restore htmx extension parsing by rendering `hx-ext="sse, morph"` on the dashboard shell.
- Register the help popover `htmx:afterSettle` reassert listener on `document` so the head script does not crash before `<body>` exists.
- Add regression coverage for comma-separated htmx extensions and the head-safe settle listener.

Fixes #360

## Test Plan

- [x] `go test ./internal/web ./internal/web/templates -run 'TestDashboardWiresHTMXSSE|TestHelpScriptUsesStableSharedPopoverUtility'`
- [x] `make generate`
- [x] `make check`
- [x] Browser E2E on isolated fixture dashboard at `http://localhost:51744`: `/events` EventSource 200, zero console messages, `#snapshot` settled via `hx-swap="morph:innerHTML"`, help tooltip opened, row popover stayed open across a later SSE settle.