### PR TITLE
fix(ci): bump goreleaser action to v7

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,7 @@ jobs:
           MINISIGN_PASSWORD: ${{ secrets.MINISIGN_PASSWORD }}
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+        uses: goreleaser/goreleaser-action@v7
         with:
           args: release --clean
         env:


### PR DESCRIPTION
## Summary

- Bump the release workflow from `goreleaser/goreleaser-action@v6` to `@v7` so it runs on Node 24.
- Keep the release workflow aligned with the CI GoReleaser Snapshot job.

Fixes #363

## Test Plan

- [x] `make check`
- [x] `rg -n "goreleaser/goreleaser-action@v6|node20" .github/workflows`