### PR TITLE
docs(onboarding): document ProjectV2 scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,8 @@ Requirements:
 - The [GitHub CLI](https://cli.github.com) (`gh`) for authentication and board
   lookups (optional but assumed throughout this guide).
 - A GitHub token with access to the target ProjectV2 board. For organization
-  projects, `repo`, `read:org`, and `project` scopes are usually required.
+  projects, `repo`, `read:org`, `read:project`, and write `project` scopes are
+  usually required.
 
 macOS and Linux hosts can install the latest release with the shell installer:
 
@@ -208,7 +209,14 @@ local repository checkout.
 1. Authenticate GitHub access:
 
 ```sh
-gh auth login --scopes "repo,read:org,project"
+gh auth login --scopes "repo,read:org,read:project,project"
+# For existing auth:
+gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
+
+gh auth status 2>&1 | rg '\brepo\b'
+gh auth status 2>&1 | rg '\bread:org\b'
+gh auth status 2>&1 | rg '\bread:project\b'
+gh auth status 2>&1 | rg "'project'|, project|project,"
 ```
 
 2. Find the GitHub ProjectV2 node id. Use the `id` field, which starts with
@@ -217,6 +225,10 @@ gh auth login --scopes "repo,read:org,project"
 ```sh
 gh project list --owner <org-or-user> --format json --limit 20
 ```
+
+The `gh project list` command verifies the token can read ProjectV2 boards.
+The write `project` scope is verified when Detent first performs an intentional
+board mutation, such as provisioning fields or editing an issue status.
 
 Detent auto-provisions any missing `Status` and `Priority` options on the board
 the first time it runs, so you do not have to hand-create every column — but the
@@ -409,11 +421,22 @@ repo is a real, working instance of this setup to copy from.
    [`gh`](https://cli.github.com), then:
 
    ```sh
-   gh auth login --scopes "repo,read:org,project"
+   gh auth login --scopes "repo,read:org,read:project,project"
+   # For existing auth:
+   gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
    ```
 
-   Verify: `gh auth status`. Use `github_token: gh` in `global.yaml` so
-   Detent resolves this token at startup.
+   Verify each required scope independently:
+
+   ```sh
+   gh auth status 2>&1 | rg '\brepo\b'
+   gh auth status 2>&1 | rg '\bread:org\b'
+   gh auth status 2>&1 | rg '\bread:project\b'
+   gh auth status 2>&1 | rg "'project'|, project|project,"
+   ```
+
+   Use `github_token: gh` in `global.yaml` so Detent resolves this token at
+   startup.
 
 3. **Install and sign in to the Codex CLI.** Install the
    [OpenAI Codex CLI](https://github.com/openai/codex) and sign in. Detent
@@ -426,7 +449,9 @@ repo is a real, working instance of this setup to copy from.
    gh project list --owner <org-or-user> --format json --limit 50
    ```
 
-   The board only needs to exist — Detent auto-provisions missing `Status` and
+   This verifies the token can read ProjectV2 boards. The write `project` scope
+   is verified when Detent first performs an intentional board mutation. The
+   board only needs to exist — Detent auto-provisions missing `Status` and
    `Priority` options on first run. The option names must match your
    `WORKFLOW.md` states, and Detent keeps known `Status` options in canonical
    board order.

--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
 gh auth status 2>&1 | rg '\brepo\b'
 gh auth status 2>&1 | rg '\bread:org\b'
 gh auth status 2>&1 | rg '\bread:project\b'
-gh auth status 2>&1 | rg "'project'|, project|project,"
+gh auth status 2>&1 | rg "(^|[[:space:],'\"])project([[:space:],'\"]|$)"
 ```
 
 2. Find the GitHub ProjectV2 node id. Use the `id` field, which starts with
@@ -432,7 +432,7 @@ repo is a real, working instance of this setup to copy from.
    gh auth status 2>&1 | rg '\brepo\b'
    gh auth status 2>&1 | rg '\bread:org\b'
    gh auth status 2>&1 | rg '\bread:project\b'
-   gh auth status 2>&1 | rg "'project'|, project|project,"
+   gh auth status 2>&1 | rg "(^|[[:space:],'\"])project([[:space:],'\"]|$)"
    ```
 
    Use `github_token: gh` in `global.yaml` so Detent resolves this token at

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -29,16 +29,44 @@ Use these placeholders consistently:
    ```
 
 2. **Confirm GitHub CLI auth and scopes.** Detent needs a token that can read
-   the repo, org, and ProjectV2 board. If any scope check fails, refresh the
-   token with `gh auth refresh -s repo -s read:org -s project`. Verify each
+   the repo, org, and ProjectV2 board, plus write ProjectV2 status fields. For
+   first-time auth, request every required scope:
+
+   ```sh
+   gh auth login --scopes "repo,read:org,read:project,project"
+   ```
+
+   If any scope check fails for existing auth, refresh the token:
+
+   ```sh
+   gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
+   ```
+
+   In a remote or headless shell, avoid launching a remote GUI browser while
+   preserving the terminal-side device flow:
+
+   ```sh
+   BROWSER=/usr/bin/true gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
+   ```
+
+   Press Enter in the terminal so `gh` starts polling, open
+   `https://github.com/login/device` in the operator browser, enter the code,
+   and wait for the terminal to print authentication completion. Verify each
    required scope independently:
 
    ```sh
    gh auth status
    gh auth status 2>&1 | rg '\brepo\b'
    gh auth status 2>&1 | rg '\bread:org\b'
-   gh auth status 2>&1 | rg '\bproject\b'
+   gh auth status 2>&1 | rg '\bread:project\b'
+   gh auth status 2>&1 | rg "'project'|, project|project,"
+   gh project list --owner <project-owner> --format json --limit 1
    ```
+
+   `gh project list` verifies the `read:project` board discovery path. Defer
+   write `project` verification until the first intentional ProjectV2 mutation,
+   such as creating or linking a board, creating fields, or editing the status
+   of a real existing item.
 
 3. **Confirm Codex is installed and signed in.** Detent dispatches agents
    through the Codex app-server. Verify:
@@ -124,7 +152,8 @@ grounded recommendation per Phase 2 question, then interview the human.
 
 5. **Inspect existing ProjectV2 boards.** Recommend reuse when a board clearly
    belongs to this repo or workstream; otherwise recommend creating a new board
-   named after the repo or product. Verify:
+   named after the repo or product. This is the ProjectV2 read verification.
+   Verify:
 
    ```sh
    gh project list --owner <project-owner> --format json --limit 50 \
@@ -556,7 +585,8 @@ recommendation, and default-if-silent. Record answers in
 2. **Bulk-add issues by the selected filter and set initial `Status`.** Use
    the exact `gh issue list` flags from the intake answer. Use `Backlog` for
    broad intake and `Todo` only for work that should dispatch immediately.
-   Verify:
+   This verifies the write `project` scope if no earlier board creation,
+   linking, field creation, or item edit has already done so. Verify:
 
    ```sh
    PROJECT_NODE_ID="$(gh project view <project-number> --owner <project-owner> --format json --jq '.id')"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -59,7 +59,7 @@ Use these placeholders consistently:
    gh auth status 2>&1 | rg '\brepo\b'
    gh auth status 2>&1 | rg '\bread:org\b'
    gh auth status 2>&1 | rg '\bread:project\b'
-   gh auth status 2>&1 | rg "'project'|, project|project,"
+   gh auth status 2>&1 | rg "(^|[[:space:],'\"])project([[:space:],'\"]|$)"
    gh project list --owner <project-owner> --format json --limit 1
    ```
 


### PR DESCRIPTION
## Summary

- Update README and onboarding GitHub CLI auth docs to request `repo`, `read:org`, `read:project`, and write `project` scopes.
- Add explicit ProjectV2 read verification and defer write verification to intentional board mutations.
- Document the headless `gh auth refresh` device-flow workaround from the migration note.

Fixes #365

## Test Plan

- [x] `make check`