### PR TITLE
fix(workspace): preserve failed hook output

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -1,6 +1,7 @@
 package workspace
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -23,6 +24,7 @@ const KindLocalGit = "local_git"
 
 const defaultHookTimeout = time.Minute
 const workspaceCommandWaitDelay = time.Second
+const hookOutputTailBytes = 16 * 1024
 
 var (
 	ErrHookFailed         = errors.New("workspace hook failed")
@@ -105,16 +107,43 @@ func (e *PathError) Unwrap() error {
 
 type HookError struct {
 	Hook     string
+	Command  string
+	Dir      string
 	ExitCode int
+	LogPath  string
 	Output   string
 	Err      error
 }
 
 func (e *HookError) Error() string {
-	if e.Err != nil {
-		return fmt.Sprintf("%s: %s: %v", ErrHookFailed, e.Hook, e.Err)
+	parts := []string{}
+	if e.Command != "" {
+		parts = append(parts, fmt.Sprintf("command %q", e.Command))
 	}
-	return fmt.Sprintf("%s: %s exited with status %d", ErrHookFailed, e.Hook, e.ExitCode)
+	if e.Dir != "" {
+		parts = append(parts, fmt.Sprintf("working directory %q", e.Dir))
+	}
+	if e.ExitCode >= 0 {
+		parts = append(parts, fmt.Sprintf("exit status %d", e.ExitCode))
+	}
+	if e.LogPath != "" {
+		parts = append(parts, fmt.Sprintf("hook log %q", e.LogPath))
+	}
+
+	detail := ""
+	if len(parts) > 0 {
+		detail = " (" + strings.Join(parts, "; ") + ")"
+	}
+
+	output := hookOutputTail(e.Output, hookOutputTailBytes)
+	if output != "" {
+		detail += fmt.Sprintf("\noutput (last %d KiB):\n%s", hookOutputTailBytes/1024, output)
+	}
+
+	if e.Err != nil {
+		return fmt.Sprintf("%s: %s: %v%s", ErrHookFailed, e.Hook, e.Err, detail)
+	}
+	return fmt.Sprintf("%s: %s exited with status %d%s", ErrHookFailed, e.Hook, e.ExitCode, detail)
 }
 
 func (e *HookError) Unwrap() error {
@@ -509,7 +538,12 @@ func (l *LocalGit) runHook(ctx context.Context, name string, command string, inf
 	cmd.Env = hookEnv(info, issue)
 	cmd.WaitDelay = workspaceCommandWaitDelay
 
-	l.logger.Info("running workspace hook", slog.String("hook", name), slog.String("path", info.Path))
+	l.logger.Info(
+		"running workspace hook",
+		slog.String("hook", name),
+		slog.String("path", info.Path),
+		slog.String("command", command),
+	)
 
 	output, err := cmd.CombinedOutput()
 	if err == nil {
@@ -528,12 +562,91 @@ func (l *LocalGit) runHook(ctx context.Context, name string, command string, inf
 		err = hookCtx.Err()
 	}
 
-	return &HookError{
+	logPath, logErr := l.writeHookLog(name, command, info, exitCode, err, output)
+	hookErr := &HookError{
 		Hook:     name,
+		Command:  command,
+		Dir:      info.Path,
 		ExitCode: exitCode,
+		LogPath:  logPath,
 		Output:   string(output),
 		Err:      err,
 	}
+	if logErr != nil {
+		l.logger.Warn(
+			"workspace hook log write failed",
+			slog.String("hook", name),
+			slog.String("path", info.Path),
+			slog.String("command", command),
+			slog.Any("error", logErr),
+		)
+	}
+	l.logger.Warn(
+		"workspace hook failed",
+		slog.String("hook", name),
+		slog.String("path", info.Path),
+		slog.String("command", command),
+		slog.Int("exit_code", exitCode),
+		slog.String("log_path", logPath),
+		slog.String("output_tail", hookOutputTail(string(output), hookOutputTailBytes)),
+		slog.Any("error", err),
+	)
+	return hookErr
+}
+
+func (l *LocalGit) writeHookLog(
+	name string,
+	command string,
+	info Info,
+	exitCode int,
+	err error,
+	output []byte,
+) (string, error) {
+	root := strings.TrimSpace(l.root)
+	if root == "" {
+		root = strings.TrimSpace(info.Path)
+	}
+	if root == "" {
+		return "", errors.New("workspace hook log root is empty")
+	}
+	dir := filepath.Join(root, ".detent", "hook-logs", SafeKey(info.Key))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, hookLogFileName(name, time.Now().UTC(), os.Getpid()))
+
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "hook: %s\n", name)
+	fmt.Fprintf(&buf, "command: %s\n", command)
+	fmt.Fprintf(&buf, "working_directory: %s\n", info.Path)
+	fmt.Fprintf(&buf, "exit_status: %d\n", exitCode)
+	if err != nil {
+		fmt.Fprintf(&buf, "error: %s\n", err)
+	}
+	fmt.Fprint(&buf, "\noutput:\n")
+	fmt.Fprint(&buf, string(output))
+	if len(output) > 0 && output[len(output)-1] != '\n' {
+		fmt.Fprint(&buf, "\n")
+	}
+
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}
+
+func hookLogFileName(name string, at time.Time, pid int) string {
+	return at.Format("20060102T150405.000000000Z") + "-" + SafeKey(name) + fmt.Sprintf("-%d.log", pid)
+}
+
+func hookOutputTail(output string, limit int) string {
+	if limit <= 0 || output == "" {
+		return ""
+	}
+	if len(output) <= limit {
+		return output
+	}
+	return "[truncated to last " + fmt.Sprint(limit/1024) + " KiB]\n" + output[len(output)-limit:]
 }
 
 func (l *LocalGit) runGit(ctx context.Context, args ...string) (string, error) {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -218,7 +218,7 @@ func NewLocalGit(opts LocalGitOptions) (*LocalGit, error) {
 
 func SafeKey(identifier string) string {
 	key := unsafeKeyPattern.ReplaceAllString(strings.TrimSpace(identifier), "_")
-	if key == "" || key == "." || key == ".." {
+	if key == "" || key == "." || key == ".." || key == ".detent" {
 		return "issue"
 	}
 	return key

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -112,6 +112,11 @@ func TestLocalGitInfoForIssueNamespacesKeysByProjectID(t *testing.T) {
 			wantKey: "digitaldrywood_detent_42",
 		},
 		{
+			name:    "reserved detent metadata key",
+			issue:   Issue{Identifier: ".detent"},
+			wantKey: "issue",
+		},
+		{
 			name:          "alpha project",
 			issue:         Issue{ProjectID: "alpha", Identifier: "digitaldrywood/detent#42"},
 			wantKeyPrefix: "alpha-digitaldrywood_detent_42-",

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -3,6 +3,7 @@ package workspace
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
 	"log/slog"
 	"os"
@@ -497,13 +498,14 @@ func TestLocalGitHookFailureSurfaces(t *testing.T) {
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
+	hookCommand := "printf 'out\\n'; printf 'err\\n' >&2; exit 17"
 
 	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
 		Root:       root,
 		SourceRoot: source,
 		AutoBranch: true,
 		Hooks: Hooks{
-			AfterCreate: "echo nope && exit 17",
+			AfterCreate: hookCommand,
 			Timeout:     time.Second,
 		},
 	})
@@ -525,11 +527,83 @@ func TestLocalGitHookFailureSurfaces(t *testing.T) {
 	if hookErr.ExitCode != 17 {
 		t.Fatalf("HookError.ExitCode = %d, want 17", hookErr.ExitCode)
 	}
-	if !strings.Contains(hookErr.Output, "nope") {
-		t.Fatalf("HookError.Output = %q, want nope", hookErr.Output)
+	for _, want := range []string{"out", "err"} {
+		if !strings.Contains(hookErr.Output, want) {
+			t.Fatalf("HookError.Output = %q, want %q", hookErr.Output, want)
+		}
+	}
+	if hookErr.Command != hookCommand {
+		t.Fatalf("HookError.Command = %q, want hook command", hookErr.Command)
+	}
+	if filepath.Base(hookErr.Dir) != "DD-FAIL" {
+		t.Fatalf("HookError.Dir = %q, want DD-FAIL workspace", hookErr.Dir)
+	}
+	if hookErr.LogPath == "" {
+		t.Fatal("HookError.LogPath is empty")
+	}
+	wantLogDir := filepath.Join(backend.(*LocalGit).root, ".detent", "hook-logs", "DD-FAIL")
+	if !strings.HasPrefix(hookErr.LogPath, wantLogDir) {
+		t.Fatalf("HookError.LogPath = %q, want under root hook logs", hookErr.LogPath)
+	}
+	errorDetail := err.Error()
+	for _, want := range []string{
+		fmt.Sprintf("command %q", hookCommand),
+		"working directory",
+		"exit status 17",
+		"hook log",
+		"output (last",
+		"out",
+		"err",
+	} {
+		if !strings.Contains(errorDetail, want) {
+			t.Fatalf("Create() error = %q, want %q", errorDetail, want)
+		}
+	}
+	logContent := readFile(t, hookErr.LogPath)
+	for _, want := range []string{
+		"hook: after_create\n",
+		"command: " + hookCommand + "\n",
+		"exit_status: 17\n",
+		"output:\nout\nerr\n",
+	} {
+		if !strings.Contains(logContent, want) {
+			t.Fatalf("hook log = %q, want %q", logContent, want)
+		}
 	}
 	if _, statErr := os.Stat(filepath.Join(root, "DD-FAIL")); !errors.Is(statErr, os.ErrNotExist) {
 		t.Fatalf("failed after_create workspace exists, stat error = %v", statErr)
+	}
+}
+
+func TestHookErrorErrorIncludesBoundedOutputTail(t *testing.T) {
+	t.Parallel()
+
+	output := "prefix-" + strings.Repeat("x", hookOutputTailBytes) + "-tail"
+	err := (&HookError{
+		Hook:     "after_create",
+		Command:  "bootstrap",
+		Dir:      "/workspaces/DD-TAIL",
+		ExitCode: 1,
+		LogPath:  "/workspaces/.detent/hook-logs/DD-TAIL/hook.log",
+		Output:   output,
+		Err:      errors.New("exit status 1"),
+	}).Error()
+
+	for _, want := range []string{
+		"command \"bootstrap\"",
+		"working directory \"/workspaces/DD-TAIL\"",
+		"exit status 1",
+		"hook log \"/workspaces/.detent/hook-logs/DD-TAIL/hook.log\"",
+		"output (last 16 KiB)",
+		"truncated to last 16 KiB",
+		"-tail",
+	} {
+		if !strings.Contains(err, want) {
+			t.Fatalf("HookError.Error() = %q, want %q", err, want)
+		}
+	}
+	if strings.Contains(err, "prefix-") {
+		t.Fatalf("HookError.Error() includes truncated prefix: %q", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Preserve failed workspace hook diagnostics in a Detent-local hook log before cleanup.
- Surface hook command, working directory, exit status, hook log path, and a bounded stdout/stderr tail in retry/API/dashboard error text.
- Add focused workspace tests for stdout/stderr preservation and output tail truncation.

Fixes #371

## Test Plan

- [x] `go test ./internal/workspace ./internal/runner ./internal/orchestrator ./internal/web -count=1`
- [x] `make check`