### PR TITLE
fix(project): honor github token on reload

### DIFF
--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -174,10 +174,9 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		return nil, ErrMissingOrchestrator
 	}
 
-	watcherFactory := deps.WorkflowWatcherFactory
-	if watcherFactory == nil {
-		watcherFactory = defaultWorkflowWatcherFactory
-	}
+	watcherProject := cfg.Project
+	watcherProject.ID = string(id)
+	watcherFactory := resolveWorkflowWatcherFactory(deps, watcherProject, deps.GitHubToken, logger)
 
 	cfg.Project.ID = string(id)
 	return &Project{
@@ -928,8 +927,30 @@ func trackerPriorityMap(value workflowconfig.StringOrMap) map[string]*int {
 	return out
 }
 
-func defaultWorkflowWatcherFactory(path string) (WorkflowWatcher, error) {
-	return configwatcher.New(path)
+func resolveWorkflowWatcherFactory(
+	deps Dependencies,
+	project globalconfig.Project,
+	githubToken string,
+	logger *slog.Logger,
+) WorkflowWatcherFactory {
+	if deps.WorkflowWatcherFactory != nil {
+		return deps.WorkflowWatcherFactory
+	}
+	return func(path string) (WorkflowWatcher, error) {
+		return configwatcher.New(path,
+			configwatcher.WithLoader(func(path string) (workflowconfig.Workflow, error) {
+				workflow, err := workflowconfig.LoadWorkflow(path)
+				if err != nil {
+					return workflow, err
+				}
+				workflow = normalizeWorkflow(workflow)
+				workflow.Config = workflowConfigWithProjectIdentity(project, workflow.Config)
+				workflow.Config = workflowConfigWithGitHubToken(workflow.Config, githubToken)
+				return workflow, nil
+			}),
+			configwatcher.WithLogger(logger),
+		)
+	}
 }
 
 func normalizeWorkflow(workflow workflowconfig.Workflow) workflowconfig.Workflow {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -485,6 +485,75 @@ func TestProjectHotReloadsWorkflowFileWithoutRestart(t *testing.T) {
 	}
 }
 
+func TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation(t *testing.T) {
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	writeProjectGitHubWorkflow(t, workflowPath, int(time.Hour/time.Millisecond), "initial")
+
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	connectorConfigs := make(chan workflowconfig.Config, 2)
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:       "pyroapex",
+			Workflow: workflowPath,
+			Weight:   1,
+		},
+		Workflow: workflow,
+	}, project.Dependencies{
+		GitHubToken: "global-token",
+		ConnectorFactory: func(cfg workflowconfig.Config) (connector.Connector, error) {
+			connectorConfigs <- cfg
+			return provisioningConnector{}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	initial := receiveConnectorConfig(t, connectorConfigs)
+	if initial.Tracker.APIKey != "global-token" {
+		t.Fatalf("initial Tracker.APIKey = %q, want runtime token", initial.Tracker.APIKey)
+	}
+
+	if err := got.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	defer func() {
+		if err := got.Stop(context.Background()); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			t.Fatalf("Stop() error = %v", err)
+		}
+	}()
+
+	watcherDelay := time.NewTimer(25 * time.Millisecond)
+	<-watcherDelay.C
+
+	writeProjectGitHubWorkflow(t, workflowPath, 60000, "reloaded")
+	waitForWorkflowPrompt(t, got, "reloaded\n")
+
+	reloaded := receiveConnectorConfig(t, connectorConfigs)
+	if reloaded.Tracker.APIKey != "global-token" {
+		t.Fatalf("reloaded Tracker.APIKey = %q, want runtime token", reloaded.Tracker.APIKey)
+	}
+	if got.Workflow().Prompt != "reloaded\n" {
+		t.Fatalf("Workflow().Prompt = %q, want reloaded", got.Workflow().Prompt)
+	}
+
+	if err := os.WriteFile(workflowPath, []byte("---\ntracker: [\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", workflowPath, err)
+	}
+	select {
+	case extra := <-connectorConfigs:
+		t.Fatalf("connector rebuilt after invalid reload = %#v", extra)
+	case <-time.After(250 * time.Millisecond):
+	}
+	if got.Workflow().Prompt != "reloaded\n" {
+		t.Fatalf("Workflow().Prompt after invalid reload = %q, want last valid workflow", got.Workflow().Prompt)
+	}
+}
+
 func TestProjectStartRunsProvisionerWhenAutoProvisionEnabled(t *testing.T) {
 	t.Parallel()
 
@@ -1047,6 +1116,23 @@ tracker:
 	}
 }
 
+func writeProjectGitHubWorkflow(t *testing.T, path string, intervalMS int, prompt string) {
+	t.Helper()
+
+	raw := fmt.Sprintf(`---
+tracker:
+  kind: github
+  project_slug: PVT_pyroapex
+polling:
+  interval_ms: %d
+---
+%s
+`, intervalMS, prompt)
+	if err := os.WriteFile(path, []byte(raw), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
 func receiveOrchestratorConfig(t *testing.T, ch <-chan orchestrator.Config) orchestrator.Config {
 	t.Helper()
 
@@ -1058,6 +1144,19 @@ func receiveOrchestratorConfig(t *testing.T, ch <-chan orchestrator.Config) orch
 	}
 
 	return orchestrator.Config{}
+}
+
+func receiveConnectorConfig(t *testing.T, ch <-chan workflowconfig.Config) workflowconfig.Config {
+	t.Helper()
+
+	select {
+	case cfg := <-ch:
+		return cfg
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for connector config")
+	}
+
+	return workflowconfig.Config{}
 }
 
 func receiveConnector(t *testing.T, ch <-chan connector.Connector) connector.Connector {


### PR DESCRIPTION
## Summary

- Apply project identity and the resolved runtime GitHub token while loading workflow watcher updates so reload validation matches startup.
- Add a regression test for GitHub workflow hot reloads without `tracker.api_key` when the runtime global token is available.

Fixes #372

## Test Plan

- [x] `go test ./internal/project -run TestProjectHotReloadAppliesRuntimeGitHubTokenBeforeValidation -count=1`
- [x] `go test ./internal/project -count=1`
- [x] `make check`