### PR TITLE
feat(cli): add graceful shutdown drain mode

### DIFF
--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -18,13 +18,18 @@ import (
 func main() {
 	setupLoggerFromEnv(os.Stdout, os.Stderr)
 
-	ctx, stop := newSignalContext(context.Background())
-	defer stop()
+	ctx := context.Background()
+	shutdownController := cli.NewShutdownController()
+	stopSignals := notifyShutdownRequests(shutdownController)
+	defer stopSignals()
 
-	if err := newRootCommand(ctx).ExecuteContext(ctx); err != nil {
+	if err := newRootCommand(ctx, shutdownController).ExecuteContext(ctx); err != nil {
 		if errors.Is(err, context.Canceled) {
 			slog.Info("shutdown requested")
 			return
+		}
+		if errors.Is(err, cli.ErrShutdownForced) || errors.Is(err, cli.ErrShutdownTimeout) {
+			os.Exit(1)
 		}
 
 		slog.Error("command failed", "error", err)
@@ -32,13 +37,17 @@ func main() {
 	}
 }
 
-func newRootCommand(ctx context.Context) *cobra.Command {
+func newRootCommand(ctx context.Context, shutdownControllers ...*cli.ShutdownController) *cobra.Command {
 	build := currentBuildInfo()
-	cmd := cli.NewRootCommand(ctx,
+	opts := []cli.Option{
 		cli.WithVersion(build.Version),
 		cli.WithBuild(build),
 		cli.WithLoggerFunc(setupLoggerFromRuntime),
-	)
+	}
+	if len(shutdownControllers) > 0 && shutdownControllers[0] != nil {
+		opts = append(opts, cli.WithShutdownController(shutdownControllers[0]))
+	}
+	cmd := cli.NewRootCommand(ctx, opts...)
 	cmd.Version = build.Version
 	cmd.SetVersionTemplate("{{.Version}}\n")
 	cmd.AddCommand(

--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -18,9 +18,10 @@ import (
 func main() {
 	setupLoggerFromEnv(os.Stdout, os.Stderr)
 
-	ctx := context.Background()
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 	shutdownController := cli.NewShutdownController()
-	stopSignals := notifyShutdownRequests(shutdownController)
+	stopSignals := notifyShutdownRequests(shutdownController, cancel)
 	defer stopSignals()
 
 	if err := newRootCommand(ctx, shutdownController).ExecuteContext(ctx); err != nil {

--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -2,9 +2,55 @@ package main
 
 import (
 	"context"
+	"os"
 	"os/signal"
+	"sync"
+
+	"github.com/digitaldrywood/detent/internal/cli"
 )
 
 func newSignalContext(parent context.Context) (context.Context, context.CancelFunc) {
 	return signal.NotifyContext(parent, shutdownSignals()...)
+}
+
+func notifyShutdownRequests(controller *cli.ShutdownController) func() {
+	if controller == nil {
+		return func() {}
+	}
+
+	stop := make(chan struct{})
+	done := make(chan struct{})
+	first := make(chan os.Signal, 1)
+	signal.Notify(first, shutdownSignals()...)
+
+	go func() {
+		defer close(done)
+		select {
+		case <-stop:
+			signal.Stop(first)
+			return
+		case <-first:
+			controller.RequestDrain()
+			signal.Stop(first)
+		}
+
+		second := make(chan os.Signal, 1)
+		signal.Notify(second, shutdownSignals()...)
+		defer signal.Stop(second)
+		select {
+		case <-stop:
+			return
+		case <-second:
+			controller.RequestForce()
+		}
+	}()
+
+	var once sync.Once
+	return func() {
+		once.Do(func() {
+			close(stop)
+			signal.Stop(first)
+			<-done
+		})
+	}
 }

--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -13,7 +13,7 @@ func newSignalContext(parent context.Context) (context.Context, context.CancelFu
 	return signal.NotifyContext(parent, shutdownSignals()...)
 }
 
-func notifyShutdownRequests(controller *cli.ShutdownController) func() {
+func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot context.CancelFunc) func() {
 	if controller == nil {
 		return func() {}
 	}
@@ -30,8 +30,14 @@ func notifyShutdownRequests(controller *cli.ShutdownController) func() {
 			signal.Stop(first)
 			return
 		case <-first:
-			controller.RequestDrain()
 			signal.Stop(first)
+			if !controller.Active() {
+				if cancelRoot != nil {
+					cancelRoot()
+				}
+				return
+			}
+			controller.RequestDrain()
 		}
 
 		second := make(chan os.Signal, 1)
@@ -41,7 +47,13 @@ func notifyShutdownRequests(controller *cli.ShutdownController) func() {
 		case <-stop:
 			return
 		case <-second:
-			controller.RequestForce()
+			if controller.Active() {
+				controller.RequestForce()
+				return
+			}
+			if cancelRoot != nil {
+				cancelRoot()
+			}
 		}
 	}()
 

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -243,13 +243,45 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			return err
 		}
 		listenerOwned = false
-		return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub, cfg.Build)
+		if cfg.Shutdown == nil {
+			return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub, cfg.Build)
+		}
+		return runWithShutdown(runCtx, runningShutdownConfig{
+			Controller:       cfg.Shutdown,
+			Registry:         manager.Registry(),
+			SnapshotHub:      snapshotHub,
+			LifetimeSource:   runtimeStore,
+			DashboardURL:     displayURL,
+			Output:           cfg.Output,
+			Logger:           logger,
+			DrainTimeout:     shutdownDrainTimeout(manager.Registry()),
+			ProgressInterval: defaultShutdownProgressInterval,
+			HardTimeout:      defaultShutdownHardTimeout,
+		}, func(ctx context.Context) error {
+			return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build)
+		})
 	}
 	if err := printBootBanner(cfg, displayURL); err != nil {
 		return err
 	}
 	listenerOwned = false
-	return serve(runCtx, server, listener)
+	if cfg.Shutdown == nil {
+		return serve(runCtx, server, listener)
+	}
+	return runWithShutdown(runCtx, runningShutdownConfig{
+		Controller:       cfg.Shutdown,
+		Registry:         manager.Registry(),
+		SnapshotHub:      snapshotHub,
+		LifetimeSource:   runtimeStore,
+		DashboardURL:     displayURL,
+		Output:           cfg.Output,
+		Logger:           logger,
+		DrainTimeout:     shutdownDrainTimeout(manager.Registry()),
+		ProgressInterval: defaultShutdownProgressInterval,
+		HardTimeout:      defaultShutdownHardTimeout,
+	}, func(ctx context.Context) error {
+		return serve(ctx, server, listener)
+	})
 }
 
 func startOnboarding(ctx context.Context, cfg BootConfig) error {
@@ -282,6 +314,16 @@ func startOnboarding(ctx context.Context, cfg BootConfig) error {
 		return err
 	}
 	listenerOwned = false
+	if cfg.Shutdown != nil {
+		return runWithShutdown(ctx, runningShutdownConfig{
+			Controller:  cfg.Shutdown,
+			Output:      cfg.Output,
+			Logger:      logger,
+			HardTimeout: defaultShutdownHardTimeout,
+		}, func(ctx context.Context) error {
+			return serve(ctx, server, listener)
+		})
+	}
 	return serve(ctx, server, listener)
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -59,6 +59,7 @@ type BootConfig struct {
 	Headless       bool
 	StdoutTTY      bool
 	Output         io.Writer
+	Shutdown       *ShutdownController
 }
 
 type BootFunc func(context.Context, BootConfig) error
@@ -89,6 +90,7 @@ type options struct {
 	version       string
 	build         buildinfo.Info
 	stdoutTTY     func() bool
+	shutdown      *ShutdownController
 }
 
 func WithBootFunc(boot BootFunc) Option {
@@ -130,6 +132,12 @@ func WithStdoutTTY(stdoutTTY func() bool) Option {
 		if stdoutTTY != nil {
 			opts.stdoutTTY = stdoutTTY
 		}
+	}
+}
+
+func WithShutdownController(controller *ShutdownController) Option {
+	return func(opts *options) {
+		opts.shutdown = controller
 	}
 }
 
@@ -198,6 +206,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 			boot.Headless = headless
 			boot.StdoutTTY = stdoutTTY
 			boot.Output = cmd.OutOrStdout()
+			boot.Shutdown = opts.shutdown
 			slog.Info("resolved global config", "path", boot.Global.Path, "rule", boot.ConfigPathRule)
 			for _, warning := range boot.Runtime.Warnings {
 				slog.Warn(warning.Detail, "check", warning.Name, "hint", warning.Hint)

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -405,6 +405,7 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 		current.DashboardURL = next.DashboardURL
 	}
 	current.Refresh = mergeRefresh(current.Refresh, next.Refresh)
+	current.Shutdown = mergeShutdown(current.Shutdown, next.Shutdown)
 
 	current.Running = append(current.Running, next.Running...)
 	current.Queue = append(current.Queue, next.Queue...)
@@ -458,6 +459,37 @@ func stampIssueProjectID(issue telemetry.Issue, projectID string) telemetry.Issu
 		issue.ProjectID = projectID
 	}
 	return issue
+}
+
+func mergeShutdown(current, next telemetry.Shutdown) telemetry.Shutdown {
+	if next == (telemetry.Shutdown{}) {
+		if current == (telemetry.Shutdown{}) {
+			return telemetry.Shutdown{Status: "running"}
+		}
+		return current
+	}
+	if current == (telemetry.Shutdown{}) {
+		current = telemetry.Shutdown{Status: "running"}
+	}
+	if strings.TrimSpace(next.Status) == "" {
+		next.Status = "running"
+	}
+	if !current.Draining && !next.Draining {
+		if current.Status == "" || current.Status == "running" {
+			current.Status = next.Status
+		}
+		return current
+	}
+
+	current.Status = "draining"
+	current.Draining = current.Draining || next.Draining
+	current.SessionsRemaining += next.SessionsRemaining
+	current.RequestedAt = earliestTime(current.RequestedAt, next.RequestedAt)
+	current.CompletedAt = latestTime(current.CompletedAt, next.CompletedAt)
+	if strings.TrimSpace(next.Result) != "" {
+		current.Result = next.Result
+	}
+	return current
 }
 
 func projectSnapshot(snapshot telemetry.Snapshot) telemetry.ProjectSnapshot {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -361,6 +361,39 @@ func TestMergeSnapshotStampsProjectIDOnIssueRows(t *testing.T) {
 	}
 }
 
+func TestMergeSnapshotMergesDrainingShutdown(t *testing.T) {
+	t.Parallel()
+
+	firstRequestedAt := time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+	secondRequestedAt := firstRequestedAt.Add(2 * time.Minute)
+	got := mergeSnapshot(telemetry.Snapshot{}, telemetry.Snapshot{
+		Shutdown: telemetry.Shutdown{
+			Status:            "draining",
+			Draining:          true,
+			SessionsRemaining: 2,
+			RequestedAt:       &secondRequestedAt,
+		},
+	})
+	got = mergeSnapshot(got, telemetry.Snapshot{
+		Shutdown: telemetry.Shutdown{
+			Status:            "draining",
+			Draining:          true,
+			SessionsRemaining: 1,
+			RequestedAt:       &firstRequestedAt,
+		},
+	})
+
+	if got.Shutdown.Status != "draining" || !got.Shutdown.Draining {
+		t.Fatalf("Shutdown = %#v, want draining", got.Shutdown)
+	}
+	if got.Shutdown.SessionsRemaining != 3 {
+		t.Fatalf("Shutdown.SessionsRemaining = %d, want 3", got.Shutdown.SessionsRemaining)
+	}
+	if got.Shutdown.RequestedAt == nil || !got.Shutdown.RequestedAt.Equal(firstRequestedAt) {
+		t.Fatalf("Shutdown.RequestedAt = %v, want %v", got.Shutdown.RequestedAt, firstRequestedAt)
+	}
+}
+
 func TestTokenTrendRecorderAppliesRollingWindow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"sort"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -39,6 +40,7 @@ const (
 
 type ShutdownController struct {
 	requests chan ShutdownRequest
+	active   atomic.Bool
 }
 
 func NewShutdownController() *ShutdownController {
@@ -58,6 +60,20 @@ func (c *ShutdownController) Requests() <-chan ShutdownRequest {
 		return nil
 	}
 	return c.requests
+}
+
+func (c *ShutdownController) Active() bool {
+	return c != nil && c.active.Load()
+}
+
+func (c *ShutdownController) activate() func() {
+	if c == nil {
+		return func() {}
+	}
+	c.active.Store(true)
+	return func() {
+		c.active.Store(false)
+	}
 }
 
 func (c *ShutdownController) request(request ShutdownRequest) {
@@ -96,6 +112,8 @@ func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutd
 	if cfg.Controller == nil {
 		return serve(ctx)
 	}
+	deactivate := cfg.Controller.activate()
+	defer deactivate()
 
 	serveCtx, cancelServe := context.WithCancel(ctx)
 	defer cancelServe()

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -1,0 +1,526 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/project"
+	shutdownstate "github.com/digitaldrywood/detent/internal/shutdown"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+var (
+	ErrShutdownForced  = errors.New("shutdown forced")
+	ErrShutdownTimeout = errors.New("shutdown drain timeout")
+)
+
+const (
+	defaultShutdownProgressInterval = 15 * time.Second
+	defaultShutdownHardTimeout      = 5 * time.Second
+	shutdownDrainPollInterval       = 500 * time.Millisecond
+)
+
+type ShutdownRequest int
+
+const (
+	ShutdownRequestDrain ShutdownRequest = iota + 1
+	ShutdownRequestForce
+)
+
+type ShutdownController struct {
+	requests chan ShutdownRequest
+}
+
+func NewShutdownController() *ShutdownController {
+	return &ShutdownController{requests: make(chan ShutdownRequest, 4)}
+}
+
+func (c *ShutdownController) RequestDrain() {
+	c.request(ShutdownRequestDrain)
+}
+
+func (c *ShutdownController) RequestForce() {
+	c.request(ShutdownRequestForce)
+}
+
+func (c *ShutdownController) Requests() <-chan ShutdownRequest {
+	if c == nil {
+		return nil
+	}
+	return c.requests
+}
+
+func (c *ShutdownController) request(request ShutdownRequest) {
+	if c == nil {
+		return
+	}
+	select {
+	case c.requests <- request:
+	default:
+	}
+}
+
+type shutdownServeFunc func(context.Context) error
+
+type runningShutdownConfig struct {
+	Controller       *ShutdownController
+	Registry         *project.Registry
+	SnapshotHub      *hub.Hub[telemetry.Snapshot]
+	LifetimeSource   lifetimeTotalsSource
+	DashboardURL     string
+	Output           io.Writer
+	Logger           *slog.Logger
+	DrainTimeout     time.Duration
+	ProgressInterval time.Duration
+	HardTimeout      time.Duration
+	Now              func() time.Time
+}
+
+func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutdownServeFunc) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if serve == nil {
+		serve = func(context.Context) error { return nil }
+	}
+	if cfg.Controller == nil {
+		return serve(ctx)
+	}
+
+	serveCtx, cancelServe := context.WithCancel(ctx)
+	defer cancelServe()
+	serveErrs := make(chan error, 1)
+	go func() {
+		serveErrs <- serve(serveCtx)
+	}()
+
+	machine := shutdownstate.NewMachine()
+	for {
+		select {
+		case err := <-serveErrs:
+			return unexpectedShutdownServeError(err)
+		case <-ctx.Done():
+			cancelServe()
+			if err := waitForServeExit(serveErrs); err != nil {
+				return err
+			}
+			return ctx.Err()
+		case request := <-cfg.Controller.Requests():
+			switch request {
+			case ShutdownRequestDrain:
+				machine = machine.Apply(shutdownstate.EventDrainRequested)
+				return runDrainShutdown(ctx, cfg, cancelServe, serveErrs, machine)
+			case ShutdownRequestForce:
+				machine = machine.Apply(shutdownstate.EventForceRequested)
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced")
+			}
+		}
+	}
+}
+
+func runDrainShutdown(
+	ctx context.Context,
+	cfg runningShutdownConfig,
+	cancelServe context.CancelFunc,
+	serveErrs <-chan error,
+	machine shutdownstate.Machine,
+) error {
+	startedAt := shutdownNow(cfg)
+	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
+	writeShutdownBanner(shutdownOutput(cfg), sessions)
+	shutdownLogger(cfg).Info("shutdown requested", "sessions", len(sessions))
+
+	if err := drainProjects(ctx, cfg.Registry); err != nil {
+		return err
+	}
+	publishShutdownSnapshot(ctx, cfg, startedAt)
+
+	if len(sessions) == 0 {
+		machine = machine.Apply(shutdownstate.EventDrained)
+		return completeShutdown(ctx, cfg, cancelServe, serveErrs, startedAt, machine, nil)
+	}
+
+	progressInterval := cfg.ProgressInterval
+	if progressInterval <= 0 {
+		progressInterval = defaultShutdownProgressInterval
+	}
+	hardTimeout := cfg.HardTimeout
+	if hardTimeout <= 0 {
+		hardTimeout = defaultShutdownHardTimeout
+	}
+
+	poll := time.NewTicker(shutdownDrainPollInterval)
+	defer poll.Stop()
+	progress := time.NewTicker(progressInterval)
+	defer progress.Stop()
+
+	var timeout <-chan time.Time
+	var timeoutTimer *time.Timer
+	if cfg.DrainTimeout > 0 {
+		timeoutTimer = time.NewTimer(cfg.DrainTimeout)
+		timeout = timeoutTimer.C
+		defer timeoutTimer.Stop()
+	}
+
+	for {
+		sessions = shutdownRunningSessions(ctx, cfg.Registry, shutdownNow(cfg))
+		if len(sessions) == 0 {
+			machine = machine.Apply(shutdownstate.EventDrained)
+			return completeShutdown(ctx, cfg, cancelServe, serveErrs, startedAt, machine, nil)
+		}
+
+		select {
+		case err := <-serveErrs:
+			return unexpectedShutdownServeError(err)
+		case <-ctx.Done():
+			cancelServe()
+			if err := waitForServeExit(serveErrs); err != nil {
+				return err
+			}
+			return ctx.Err()
+		case request := <-cfg.Controller.Requests():
+			if request == ShutdownRequestForce {
+				machine = machine.Apply(shutdownstate.EventForceRequested)
+				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced")
+			}
+		case <-poll.C:
+		case <-progress.C:
+			writeShutdownProgress(shutdownOutput(cfg), sessions)
+		case <-timeout:
+			machine = machine.Apply(shutdownstate.EventDrainTimedOut)
+			return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, "drain timeout", ErrShutdownTimeout, hardTimeout)
+		}
+	}
+}
+
+func runForceShutdown(
+	ctx context.Context,
+	cfg runningShutdownConfig,
+	cancelServe context.CancelFunc,
+	serveErrs <-chan error,
+	machine shutdownstate.Machine,
+	result string,
+) error {
+	hardTimeout := cfg.HardTimeout
+	if hardTimeout <= 0 {
+		hardTimeout = defaultShutdownHardTimeout
+	}
+	return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, result, ErrShutdownForced, hardTimeout)
+}
+
+func runForceShutdownWithDeadline(
+	ctx context.Context,
+	cfg runningShutdownConfig,
+	cancelServe context.CancelFunc,
+	serveErrs <-chan error,
+	machine shutdownstate.Machine,
+	result string,
+	returnErr error,
+	hardTimeout time.Duration,
+) error {
+	startedAt := shutdownNow(cfg)
+	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
+	if result == "drain timeout" {
+		fmt.Fprintf(shutdownOutput(cfg), "drain timeout reached — interrupting %d %s\n", len(sessions), shutdownSessionNoun(len(sessions)))
+	} else {
+		fmt.Fprintf(shutdownOutput(cfg), "force quit requested — interrupting %d %s\n", len(sessions), shutdownSessionNoun(len(sessions)))
+	}
+
+	forceCtx, cancel := context.WithTimeout(context.Background(), hardTimeout)
+	defer cancel()
+	if err := forceProjects(forceCtx, cfg.Registry); err != nil {
+		shutdownLogger(cfg).Warn("force shutdown cleanup failed", "error", err)
+	}
+	publishShutdownSnapshot(forceCtx, cfg, startedAt)
+
+	return completeShutdown(forceCtx, cfg, cancelServe, serveErrs, startedAt, machine, returnErr)
+}
+
+func completeShutdown(
+	ctx context.Context,
+	cfg runningShutdownConfig,
+	cancelServe context.CancelFunc,
+	serveErrs <-chan error,
+	startedAt time.Time,
+	machine shutdownstate.Machine,
+	returnErr error,
+) error {
+	hardTimeout := cfg.HardTimeout
+	if hardTimeout <= 0 {
+		hardTimeout = defaultShutdownHardTimeout
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	stopCtx, cancel := context.WithTimeout(ctx, hardTimeout)
+	defer cancel()
+	if err := stopProjects(stopCtx, cfg.Registry); err != nil {
+		shutdownLogger(cfg).Warn("stop projects during shutdown failed", "error", err)
+	}
+
+	cancelServe()
+	if err := waitForServeExit(serveErrs); err != nil {
+		return err
+	}
+
+	result := shutdownResultLabel(machine)
+	shutdownLogger(cfg).Info("shutdown complete ("+result+")", "duration", shutdownNow(cfg).Sub(startedAt))
+	return returnErr
+}
+
+func shutdownResultLabel(machine shutdownstate.Machine) string {
+	switch machine.Result {
+	case shutdownstate.ResultForced:
+		return "forced"
+	case shutdownstate.ResultTimeout:
+		return "drain timeout"
+	default:
+		return "graceful"
+	}
+}
+
+func drainProjects(ctx context.Context, registry *project.Registry) error {
+	if registry == nil {
+		return nil
+	}
+	for _, trackedProject := range registry.List() {
+		if !trackedProject.Running() {
+			continue
+		}
+		orch := trackedProject.Orchestrator()
+		if orch == nil {
+			continue
+		}
+		if err := orch.Drain(ctx); err != nil && !errors.Is(err, orchestrator.ErrStopped) {
+			return err
+		}
+	}
+	return nil
+}
+
+func forceProjects(ctx context.Context, registry *project.Registry) error {
+	if registry == nil {
+		return nil
+	}
+	for _, trackedProject := range registry.List() {
+		if !trackedProject.Running() {
+			continue
+		}
+		orch := trackedProject.Orchestrator()
+		if orch == nil {
+			continue
+		}
+		if err := orch.ForceQuit(ctx); err != nil && !errors.Is(err, orchestrator.ErrStopped) {
+			return err
+		}
+	}
+	return nil
+}
+
+func stopProjects(ctx context.Context, registry *project.Registry) error {
+	if registry == nil {
+		return nil
+	}
+	for _, trackedProject := range registry.List() {
+		if !trackedProject.Running() {
+			continue
+		}
+		if err := trackedProject.Stop(ctx); err != nil && !errors.Is(err, project.ErrNotRunning) {
+			return err
+		}
+	}
+	return nil
+}
+
+func shutdownRunningSessions(ctx context.Context, registry *project.Registry, now time.Time) []telemetry.Running {
+	if registry == nil {
+		return nil
+	}
+
+	var sessions []telemetry.Running
+	for _, trackedProject := range registry.List() {
+		if !trackedProject.Running() {
+			continue
+		}
+		orch := trackedProject.Orchestrator()
+		if orch == nil {
+			continue
+		}
+		state, err := orch.State(ctx)
+		if err != nil {
+			continue
+		}
+		sessions = append(sessions, state.Snapshot(now).Running...)
+	}
+	sort.Slice(sessions, func(i int, j int) bool {
+		return shutdownIssueLabel(sessions[i]) < shutdownIssueLabel(sessions[j])
+	})
+	return sessions
+}
+
+func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now time.Time) {
+	if cfg.Registry == nil || cfg.SnapshotHub == nil {
+		return
+	}
+	if err := publishSnapshotOnce(ctx, cfg.Registry, cfg.SnapshotHub, now, nil, cfg.LifetimeSource, cfg.DashboardURL); err != nil {
+		shutdownLogger(cfg).Warn("publish shutdown telemetry snapshot failed", "error", err)
+	}
+}
+
+func shutdownDrainTimeout(registry *project.Registry) time.Duration {
+	timeoutMS := workflowconfig.DefaultShutdownDrainTimeoutMS
+	if registry == nil {
+		return time.Duration(timeoutMS) * time.Millisecond
+	}
+
+	found := false
+	for _, trackedProject := range registry.List() {
+		workflow := trackedProject.Workflow()
+		next := workflow.Config.Agent.Shutdown.DrainTimeoutMS
+		if next == 0 {
+			return 0
+		}
+		if !found || next > timeoutMS {
+			timeoutMS = next
+		}
+		found = true
+	}
+	return time.Duration(timeoutMS) * time.Millisecond
+}
+
+func writeShutdownBanner(out io.Writer, sessions []telemetry.Running) {
+	if out == nil {
+		out = io.Discard
+	}
+	count := len(sessions)
+	if count == 0 {
+		fmt.Fprintln(out, "shutdown requested — no agent sessions in flight")
+		return
+	}
+
+	fmt.Fprintf(out, "shutdown requested — %d %s in flight\n", count, shutdownSessionNoun(count))
+	for _, session := range sessions {
+		fmt.Fprintf(out, "  %-30s %-14s %8s\n", shutdownIssueLabel(session), defaultShutdownString(session.State, "running"), formatShutdownDuration(session.RuntimeSeconds))
+	}
+	fmt.Fprintln(out, "draining: no new work will be dispatched; waiting for running sessions to finish")
+	fmt.Fprintln(out, "press Ctrl+C again to force quit (sessions will be interrupted and issues re-queued)")
+}
+
+func writeShutdownProgress(out io.Writer, sessions []telemetry.Running) {
+	if out == nil || len(sessions) == 0 {
+		return
+	}
+	parts := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		parts = append(parts, fmt.Sprintf("%s (%s)", shutdownIssueNumber(session), formatShutdownDuration(session.RuntimeSeconds)))
+	}
+	fmt.Fprintf(out, "%d %s remaining — %s\n", len(sessions), shutdownSessionNoun(len(sessions)), strings.Join(parts, ", "))
+}
+
+func shutdownIssueLabel(session telemetry.Running) string {
+	issue := shutdownIssueNumber(session)
+	title := strings.TrimSpace(session.Title)
+	if title == "" {
+		return issue
+	}
+	return truncateShutdownText(issue+" "+title, 30)
+}
+
+func shutdownIssueNumber(session telemetry.Running) string {
+	identifier := strings.TrimSpace(session.Identifier)
+	if identifier == "" {
+		identifier = strings.TrimSpace(session.ID)
+	}
+	if index := strings.LastIndex(identifier, "#"); index >= 0 {
+		return identifier[index:]
+	}
+	return identifier
+}
+
+func shutdownSessionNoun(count int) string {
+	if count == 1 {
+		return "agent session"
+	}
+	return "agent sessions"
+}
+
+func truncateShutdownText(value string, limit int) string {
+	value = strings.TrimSpace(value)
+	if limit <= 0 || len(value) <= limit {
+		return value
+	}
+	if limit <= 3 {
+		return value[:limit]
+	}
+	return value[:limit-3] + "..."
+}
+
+func formatShutdownDuration(seconds float64) string {
+	duration := time.Duration(seconds * float64(time.Second)).Round(time.Second)
+	if duration < time.Second {
+		return "0s"
+	}
+	hours := int(duration / time.Hour)
+	duration -= time.Duration(hours) * time.Hour
+	minutes := int(duration / time.Minute)
+	duration -= time.Duration(minutes) * time.Minute
+	secs := int(duration / time.Second)
+	if hours > 0 {
+		return fmt.Sprintf("%dh %dm", hours, minutes)
+	}
+	if minutes > 0 {
+		return fmt.Sprintf("%dm %ds", minutes, secs)
+	}
+	return fmt.Sprintf("%ds", secs)
+}
+
+func defaultShutdownString(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func shutdownOutput(cfg runningShutdownConfig) io.Writer {
+	if cfg.Output == nil {
+		return io.Discard
+	}
+	return cfg.Output
+}
+
+func shutdownLogger(cfg runningShutdownConfig) *slog.Logger {
+	if cfg.Logger != nil {
+		return cfg.Logger
+	}
+	return slog.Default()
+}
+
+func shutdownNow(cfg runningShutdownConfig) time.Time {
+	if cfg.Now != nil {
+		return cfg.Now()
+	}
+	return time.Now()
+}
+
+func waitForServeExit(serveErrs <-chan error) error {
+	err := <-serveErrs
+	return unexpectedShutdownServeError(err)
+}
+
+func unexpectedShutdownServeError(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
+}

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -1,0 +1,151 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/hub"
+	projectpkg "github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestShutdownControllerQueuesRequests(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	controller.RequestDrain()
+	controller.RequestForce()
+
+	if got := <-controller.Requests(); got != ShutdownRequestDrain {
+		t.Fatalf("first request = %v, want drain", got)
+	}
+	if got := <-controller.Requests(); got != ShutdownRequestForce {
+		t.Fatalf("second request = %v, want force", got)
+	}
+}
+
+func TestRunWithShutdownZeroSessionsExitsGracefully(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	var output bytes.Buffer
+	errs := make(chan error, 1)
+
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:       controller,
+			Registry:         projectpkg.NewRegistry(),
+			SnapshotHub:      hub.New[telemetry.Snapshot](),
+			Output:           &output,
+			ProgressInterval: time.Millisecond,
+			HardTimeout:      time.Second,
+			Now: func() time.Time {
+				return time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+			},
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestDrain()
+
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
+	}
+	if got := output.String(); !strings.Contains(got, "shutdown requested — no agent sessions in flight") {
+		t.Fatalf("output missing zero-session notice:\n%s", got)
+	}
+}
+
+func TestRunWithShutdownForceReturnsForcedError(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	var output bytes.Buffer
+	errs := make(chan error, 1)
+
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:  controller,
+			Registry:    projectpkg.NewRegistry(),
+			SnapshotHub: hub.New[telemetry.Snapshot](),
+			Output:      &output,
+			HardTimeout: time.Second,
+			Now: func() time.Time {
+				return time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+			},
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestForce()
+
+	select {
+	case err := <-errs:
+		if !errors.Is(err, ErrShutdownForced) {
+			t.Fatalf("runWithShutdown() error = %v, want ErrShutdownForced", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for force shutdown")
+	}
+	if got := output.String(); !strings.Contains(got, "force quit requested — interrupting 0 agent sessions") {
+		t.Fatalf("output missing force notice:\n%s", got)
+	}
+}
+
+func TestShutdownBannerFormatsRunningSessions(t *testing.T) {
+	t.Parallel()
+
+	var output bytes.Buffer
+	writeShutdownBanner(&output, []telemetry.Running{
+		{
+			Issue: telemetry.Issue{
+				ID:         "issue-365",
+				Identifier: "digitaldrywood/detent#365",
+				Title:      "docs(onboarding): tighten setup",
+				State:      "In Progress",
+			},
+			RuntimeSeconds: 724,
+		},
+	})
+
+	got := output.String()
+	for _, want := range []string{
+		"shutdown requested — 1 agent session in flight",
+		"#365 docs(onboarding)",
+		"In Progress",
+		"12m 4s",
+		"draining: no new work will be dispatched",
+		"press Ctrl+C again to force quit",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("banner missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -74,6 +74,50 @@ func TestRunWithShutdownZeroSessionsExitsGracefully(t *testing.T) {
 	}
 }
 
+func TestRunWithShutdownMarksControllerActive(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	ctx, cancel := context.WithCancel(context.Background())
+	active := make(chan bool, 1)
+	errs := make(chan error, 1)
+
+	go func() {
+		errs <- runWithShutdown(ctx, runningShutdownConfig{
+			Controller:  controller,
+			Registry:    projectpkg.NewRegistry(),
+			SnapshotHub: hub.New[telemetry.Snapshot](),
+			HardTimeout: time.Second,
+		}, func(ctx context.Context) error {
+			active <- controller.Active()
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case got := <-active:
+		if !got {
+			t.Fatal("controller active = false while runWithShutdown is serving")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	cancel()
+
+	select {
+	case err := <-errs:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("runWithShutdown() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
+	}
+	if controller.Active() {
+		t.Fatal("controller active = true after runWithShutdown returned")
+	}
+}
+
 func TestRunWithShutdownForceReturnsForcedError(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,8 +29,9 @@ const (
 	DefaultAgentBackendID = "codex"
 	AgentBackendCodex     = "codex"
 
-	DefaultPollingIntervalMS = 120000
-	MinPollingIntervalMS     = 60000
+	DefaultPollingIntervalMS      = 120000
+	MinPollingIntervalMS          = 60000
+	DefaultShutdownDrainTimeoutMS = 600000
 
 	defaultCodexProtocol = "app-server"
 
@@ -119,12 +120,17 @@ type Agent struct {
 	MaxConcurrentAgents        int            `yaml:"max_concurrent_agents"`
 	MaxTurns                   int            `yaml:"max_turns"`
 	MaxRetryBackoffMS          int            `yaml:"max_retry_backoff_ms"`
+	Shutdown                   Shutdown       `yaml:"shutdown"`
 	MaxConcurrentAgentsByState map[string]int `yaml:"max_concurrent_agents_by_state"`
 	DispatchPriorityByState    []string       `yaml:"dispatch_priority_by_state"`
 	AutoPromote                AutoPromote    `yaml:"auto_promote"`
 	Budget                     Budget         `yaml:"budget"`
 	Lessons                    Lessons        `yaml:"lessons"`
 	Skills                     Skills         `yaml:"skills"`
+}
+
+type Shutdown struct {
+	DrainTimeoutMS int `yaml:"drain_timeout_ms"`
 }
 
 type Agents struct {
@@ -459,6 +465,7 @@ func Default() Config {
 			MaxConcurrentAgents:        10,
 			MaxTurns:                   20,
 			MaxRetryBackoffMS:          300000,
+			Shutdown:                   Shutdown{DrainTimeoutMS: DefaultShutdownDrainTimeoutMS},
 			MaxConcurrentAgentsByState: map[string]int{},
 			DispatchPriorityByState:    []string{},
 			AutoPromote: AutoPromote{
@@ -652,12 +659,19 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	validatePositive(prefix+".max_concurrent_agents", a.MaxConcurrentAgents, problems)
 	validatePositive(prefix+".max_turns", a.MaxTurns, problems)
 	validatePositive(prefix+".max_retry_backoff_ms", a.MaxRetryBackoffMS, problems)
+	a.Shutdown.validate(prefix+".shutdown", problems)
 	validateStateLimits(prefix+".max_concurrent_agents_by_state", a.MaxConcurrentAgentsByState, problems)
 	validateStateList(prefix+".dispatch_priority_by_state", a.DispatchPriorityByState, problems)
 	a.AutoPromote.validate(prefix+".auto_promote", problems)
 	a.Budget.validate(prefix+".budget", problems)
 	a.Lessons.validate(prefix+".lessons", problems)
 	a.Skills.validate(prefix+".skills", problems)
+}
+
+func (s Shutdown) validate(prefix string, problems *[]string) {
+	if s.DrainTimeoutMS < 0 {
+		*problems = append(*problems, prefix+".drain_timeout_ms must be greater than or equal to 0")
+	}
 }
 
 func (a *Agents) normalize() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -62,6 +62,8 @@ worker:
   max_concurrent_agents_per_host: 2
 agent:
   max_concurrent_agents: 5
+  shutdown:
+    drain_timeout_ms: 300000
   max_concurrent_agents_by_state:
     Merging: 1
   dispatch_priority_by_state:
@@ -199,6 +201,9 @@ Ticket prompt {{ issue.title }}
 	if got := cfg.Agent.MaxConcurrentAgentsByState["merging"]; got != 1 {
 		t.Fatalf("Agent.MaxConcurrentAgentsByState[merging] = %d, want 1", got)
 	}
+	if cfg.Agent.Shutdown.DrainTimeoutMS != 300000 {
+		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want 300000", cfg.Agent.Shutdown.DrainTimeoutMS)
+	}
 	if got := cfg.Agent.DispatchPriorityByState; len(got) != 2 || got[0] != "merging" || got[1] != "rework" {
 		t.Fatalf("Agent.DispatchPriorityByState = %#v", got)
 	}
@@ -273,6 +278,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.MaxConcurrentAgents != 10 {
 		t.Fatalf("Agent.MaxConcurrentAgents = %d, want 10", cfg.Agent.MaxConcurrentAgents)
+	}
+	if cfg.Agent.Shutdown.DrainTimeoutMS != DefaultShutdownDrainTimeoutMS {
+		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want %d", cfg.Agent.Shutdown.DrainTimeoutMS, DefaultShutdownDrainTimeoutMS)
 	}
 	if cfg.Agent.Lessons.Path != ".detent/lessons.md" {
 		t.Fatalf("Agent.Lessons.Path = %q", cfg.Agent.Lessons.Path)

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -635,7 +635,7 @@ func TestDispatchIssueRequiresSharedGlobalSlot(t *testing.T) {
 	default:
 	}
 
-	alpha.handleRunResult(&alphaState, runpkg.Completion{
+	alpha.handleRunResult(ctx, &alphaState, runpkg.Completion{
 		IssueID:     alphaIssue.ID,
 		CompletedAt: now.Add(time.Second),
 		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -254,7 +254,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.tick(ctx, &state, now)
 			resetTicker(ticker, state.PollInterval)
 		case result := <-o.runResults:
-			o.handleRunResult(&state, result)
+			o.handleRunResult(ctx, &state, result)
 		case update := <-o.runUpdates:
 			o.handleRunUpdate(&state, update)
 		case request := <-o.drainRequests:
@@ -1259,7 +1259,7 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	}
 }
 
-func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
+func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event runpkg.Completion) {
 	running, ok := state.Running[event.IssueID]
 	if !ok {
 		return
@@ -1333,6 +1333,12 @@ func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
 	}
 
 	if state.Draining {
+		if err := o.abandonClaim(ctx, event.IssueID); err != nil && o.logger != nil {
+			o.logger.Warn("abandon completed drain claim failed", "issue_id", event.IssueID, "error", err)
+		}
+		delete(state.Claimed, event.IssueID)
+		delete(state.Retry, event.IssueID)
+		delete(state.BudgetRefusals, event.IssueID)
 		return
 	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -104,6 +104,8 @@ type Orchestrator struct {
 	logger             *slog.Logger
 	globalDispatchGate scheduler.ProjectDispatchGate
 	stateRequests      chan stateRequest
+	drainRequests      chan drainRequest
+	forceRequests      chan forceRequest
 	configUpdates      chan configUpdateRequest
 	refreshes          chan time.Time
 	runResults         chan runpkg.Completion
@@ -113,6 +115,17 @@ type Orchestrator struct {
 
 type stateRequest struct {
 	reply chan State
+}
+
+type drainRequest struct {
+	at    time.Time
+	reply chan struct{}
+}
+
+type forceRequest struct {
+	ctx   context.Context
+	at    time.Time
+	reply chan error
 }
 
 type configUpdateRequest struct {
@@ -206,6 +219,8 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		logger:             logger,
 		globalDispatchGate: deps.GlobalDispatchGate,
 		stateRequests:      make(chan stateRequest),
+		drainRequests:      make(chan drainRequest),
+		forceRequests:      make(chan forceRequest),
 		configUpdates:      make(chan configUpdateRequest),
 		refreshes:          make(chan time.Time, 1),
 		runResults:         make(chan runpkg.Completion),
@@ -242,6 +257,11 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			o.handleRunResult(&state, result)
 		case update := <-o.runUpdates:
 			o.handleRunUpdate(&state, update)
+		case request := <-o.drainRequests:
+			o.startDrain(&state, request.at)
+			request.reply <- struct{}{}
+		case request := <-o.forceRequests:
+			request.reply <- o.forceQuit(request.ctx, &state, request.at)
 		case update := <-o.configUpdates:
 			o.applyRuntimeUpdate(&state, update.update, ticker)
 			update.reply <- struct{}{}
@@ -310,6 +330,61 @@ func (o *Orchestrator) State(ctx context.Context) (State, error) {
 		return State{}, ErrStopped
 	case state := <-request.reply:
 		return state, nil
+	}
+}
+
+func (o *Orchestrator) Drain(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	request := drainRequest{
+		at:    time.Now().UTC(),
+		reply: make(chan struct{}, 1),
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	case o.drainRequests <- request:
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	case <-request.reply:
+		return nil
+	}
+}
+
+func (o *Orchestrator) ForceQuit(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	request := forceRequest{
+		ctx:   ctx,
+		at:    time.Now().UTC(),
+		reply: make(chan error, 1),
+	}
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	case o.forceRequests <- request:
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-o.done:
+		return ErrStopped
+	case err := <-request.reply:
+		return err
 	}
 }
 
@@ -873,8 +948,79 @@ func blockedStatusReason(issue connector.Issue) string {
 	return blockedReasonProjectStatus
 }
 
+func (o *Orchestrator) startDrain(state *State, now time.Time) {
+	if state == nil {
+		return
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	if !state.Draining {
+		state.Draining = true
+		state.DrainStartedAt = now
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "shutdown_drain_started",
+			Message: "shutdown drain started",
+		})
+	}
+	o.markGlobalProjectIdle()
+}
+
+func (o *Orchestrator) forceQuit(ctx context.Context, state *State, now time.Time) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if state == nil {
+		return nil
+	}
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	state.Draining = true
+	if state.DrainStartedAt.IsZero() {
+		state.DrainStartedAt = now
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "shutdown_force_requested",
+		Message: "shutdown force requested",
+	})
+
+	var err error
+	for _, issueID := range sortedKeys(state.Running) {
+		o.cancelRunning(state, issueID)
+		err = errors.Join(err, o.abandonClaim(ctx, issueID))
+		delete(state.Running, issueID)
+		delete(state.Claimed, issueID)
+		delete(state.Retry, issueID)
+		delete(state.BudgetRefusals, issueID)
+	}
+	o.markGlobalProjectIdle()
+	return err
+}
+
+func (o *Orchestrator) abandonClaim(ctx context.Context, issueID string) error {
+	if !o.cfg.Claiming.Enabled || strings.TrimSpace(o.cfg.Claiming.LeaseField) == "" {
+		return nil
+	}
+	if strings.TrimSpace(issueID) == "" || o.connector == nil {
+		return nil
+	}
+	if err := o.connector.SetField(ctx, issueID, o.cfg.Claiming.LeaseField, ""); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("abandon claim lease failed", "issue_id", issueID, "error", err)
+		}
+		return err
+	}
+	return nil
+}
+
 func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
 	o.markGlobalProjectIdle()
+	if state.Draining {
+		return
+	}
 	planner := o.dispatchPlanner()
 	planner.plan(state, issues, now, dispatchPlanHooks{
 		hydrate: func(issue connector.Issue) (connector.Issue, bool) {
@@ -916,6 +1062,9 @@ func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector
 
 func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
 	o.markGlobalProjectIdle()
+	if state.Draining {
+		return
+	}
 	for _, issue := range issues {
 		if availableSlots(state) == 0 {
 			return
@@ -1183,6 +1332,9 @@ func (o *Orchestrator) handleRunResult(state *State, event runpkg.Completion) {
 		state.BudgetRefusals[event.IssueID] = refusal
 	}
 
+	if state.Draining {
+		return
+	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -9,6 +9,7 @@ import (
 	"testing"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -146,6 +147,136 @@ func TestRunReportsRunningStateWhileRunnerIsInFlight(t *testing.T) {
 		_, completed := state.Completed[issue.ID]
 		return completed
 	})
+}
+
+func TestDrainStopsDispatchAndLetsRunningSessionFinish(t *testing.T) {
+	t.Parallel()
+
+	runningIssue := testIssue("issue-running", "digitaldrywood/detent#11", "In Progress")
+	nextIssue := testIssue("issue-next", "digitaldrywood/detent#12", "Todo")
+	tracker := newFakeConnector(runningIssue, nextIssue)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:            5 * time.Millisecond,
+		MaxConcurrentAgents:     1,
+		DispatchPriorityByState: []string{"In Progress", "Todo"},
+		ActiveStates:            []string{"Todo", "In Progress"},
+		TerminalStates:          []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay:  time.Millisecond,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	started := receiveRunRequest(t, runner.started)
+	if started.Issue.ID != runningIssue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", started.Issue.ID, runningIssue.ID)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := orch.Drain(ctx); err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+
+	state, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if !state.Draining {
+		t.Fatal("State().Draining = false, want true")
+	}
+
+	close(runner.release)
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		return state.Draining && len(state.Running) == 0
+	})
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected dispatch while draining = %#v", request)
+	case <-time.After(50 * time.Millisecond):
+	}
+
+	state, err = orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() final error = %v", err)
+	}
+	if _, ok := state.Retry[runningIssue.ID]; ok {
+		t.Fatalf("Retry[%q] present after drain completion", runningIssue.ID)
+	}
+	if _, ok := state.Running[nextIssue.ID]; ok {
+		t.Fatalf("Running[%q] present while draining", nextIssue.ID)
+	}
+}
+
+func TestForceQuitInterruptsRunningSessionAndAbandonsClaim(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-force", "digitaldrywood/detent#383", "In Progress")
+	tracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        5 * time.Millisecond,
+		MaxConcurrentAgents: 1,
+		Claiming: orchestrator.ClaimingConfig{
+			Enabled:           true,
+			OwnershipMode:     workflowconfig.IdentityOwnershipField,
+			Owner:             "detent-test",
+			OwnerField:        "Owner",
+			LeaseField:        "Lease",
+			LeaseTTL:          time.Minute,
+			HeartbeatInterval: time.Hour,
+		},
+		ActiveStates:           []string{"In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Millisecond,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	receiveRunRequest(t, runner.started)
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		_, running := state.Running[issue.ID]
+		_, claimed := state.Claimed[issue.ID]
+		return running && claimed
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := orch.ForceQuit(ctx); err != nil {
+		t.Fatalf("ForceQuit() error = %v", err)
+	}
+
+	state, err := orch.State(context.Background())
+	if err != nil {
+		t.Fatalf("State() error = %v", err)
+	}
+	if !state.Draining {
+		t.Fatal("State().Draining = false, want true")
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after force quit", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after force quit", issue.ID)
+	}
+	if !tracker.hasSetField(issue.ID, "Lease", "") {
+		t.Fatalf("SetField(%q, Lease, empty) not recorded; calls = %#v", issue.ID, tracker.setFieldCalls())
+	}
 }
 
 func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
@@ -948,6 +1079,13 @@ type fakeConnector struct {
 	fetchCandidateCount int
 	fetchByStatesCount  int
 	fetchByStatesLog    [][]string
+	setFields           []setFieldCall
+}
+
+type setFieldCall struct {
+	issueID string
+	field   string
+	value   string
 }
 
 func newFakeConnector(issues ...connector.Issue) *fakeConnector {
@@ -1016,8 +1154,49 @@ func (c *fakeConnector) SetAssignee(context.Context, string, string) error {
 	return nil
 }
 
-func (c *fakeConnector) SetField(context.Context, string, string, string) error {
+func (c *fakeConnector) SetField(_ context.Context, issueID string, field string, value string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.setFields = append(c.setFields, setFieldCall{issueID: issueID, field: field, value: value})
+	for i := range c.candidates {
+		if c.candidates[i].ID != issueID {
+			continue
+		}
+		if c.candidates[i].Fields == nil {
+			c.candidates[i].Fields = map[string]string{}
+		}
+		c.candidates[i].Fields[field] = value
+	}
+	for i := range c.stateIssues {
+		if c.stateIssues[i].ID != issueID {
+			continue
+		}
+		if c.stateIssues[i].Fields == nil {
+			c.stateIssues[i].Fields = map[string]string{}
+		}
+		c.stateIssues[i].Fields[field] = value
+	}
 	return nil
+}
+
+func (c *fakeConnector) hasSetField(issueID string, field string, value string) bool {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, call := range c.setFields {
+		if call.issueID == issueID && call.field == field && call.value == value {
+			return true
+		}
+	}
+	return false
+}
+
+func (c *fakeConnector) setFieldCalls() []setFieldCall {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([]setFieldCall(nil), c.setFields...)
 }
 
 func (c *fakeConnector) fetchCandidateCalls() int {
@@ -1229,6 +1408,12 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 		}
 		cloned[i].BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
 		cloned[i].Labels = append([]string(nil), issue.Labels...)
+		if issue.Fields != nil {
+			cloned[i].Fields = make(map[string]string, len(issue.Fields))
+			for key, value := range issue.Fields {
+				cloned[i].Fields[key] = value
+			}
+		}
 	}
 	return cloned
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -279,6 +279,66 @@ func TestForceQuitInterruptsRunningSessionAndAbandonsClaim(t *testing.T) {
 	}
 }
 
+func TestDrainCompletionAbandonsClaim(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-drain-claim", "digitaldrywood/detent#384", "In Progress")
+	tracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        5 * time.Millisecond,
+		MaxConcurrentAgents: 1,
+		Claiming: orchestrator.ClaimingConfig{
+			Enabled:           true,
+			OwnershipMode:     workflowconfig.IdentityOwnershipField,
+			Owner:             "detent-test",
+			OwnerField:        "Owner",
+			LeaseField:        "Lease",
+			LeaseTTL:          time.Minute,
+			HeartbeatInterval: time.Hour,
+		},
+		ActiveStates:           []string{"In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Millisecond,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	receiveRunRequest(t, runner.started)
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		_, running := state.Running[issue.ID]
+		_, claimed := state.Claimed[issue.ID]
+		return running && claimed
+	})
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := orch.Drain(ctx); err != nil {
+		t.Fatalf("Drain() error = %v", err)
+	}
+	close(runner.release)
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, completed := state.Completed[issue.ID]
+		_, running := state.Running[issue.ID]
+		_, claimed := state.Claimed[issue.ID]
+		return state.Draining && completed && !running && !claimed
+	})
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after drain completion", issue.ID)
+	}
+	if !tracker.hasSetField(issue.ID, "Lease", "") {
+		t.Fatalf("SetField(%q, Lease, empty) not recorded; calls = %#v", issue.ID, tracker.setFieldCalls())
+	}
+}
+
 func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -16,6 +16,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	snapshot := telemetry.Snapshot{
 		GeneratedAt: now,
 		Instance:    s.Instance,
+		Shutdown:    shutdownSnapshot(s),
 		Events:      cloneActivityEvents(s.RecentEvents),
 		Refresh: telemetry.Refresh{
 			PollIntervalSeconds: int64(s.PollInterval / time.Second),
@@ -40,6 +41,19 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Completed: len(snapshot.Completed),
 	}
 	return snapshot
+}
+
+func shutdownSnapshot(state State) telemetry.Shutdown {
+	if !state.Draining {
+		return telemetry.Shutdown{Status: "running"}
+	}
+
+	return telemetry.Shutdown{
+		Status:            "draining",
+		Draining:          true,
+		SessionsRemaining: len(state.Running),
+		RequestedAt:       timePointer(state.DrainStartedAt),
+	}
 }
 
 func instanceSnapshot(cfg Config) telemetry.Instance {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -13,6 +13,8 @@ type State struct {
 	PollInterval             time.Duration
 	MaxConcurrentAgents      int
 	Instance                 telemetry.Instance
+	Draining                 bool
+	DrainStartedAt           time.Time
 	LastRefreshAt            time.Time
 	NextRefreshAt            time.Time
 	LastRunningReconcileAt   time.Time
@@ -111,6 +113,8 @@ func (s State) clone() State {
 		PollInterval:             s.PollInterval,
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,
 		Instance:                 s.Instance,
+		Draining:                 s.Draining,
+		DrainStartedAt:           s.DrainStartedAt,
 		LastRefreshAt:            s.LastRefreshAt,
 		NextRefreshAt:            s.NextRefreshAt,
 		LastRunningReconcileAt:   s.LastRunningReconcileAt,

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -39,6 +39,9 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	}
 
 	o.refreshActiveRuns(ctx, state, now)
+	if state.Draining {
+		return
+	}
 	fetched, ok := o.fetchTickIssues(ctx)
 	if !ok {
 		return

--- a/internal/shutdown/state.go
+++ b/internal/shutdown/state.go
@@ -1,0 +1,58 @@
+package shutdown
+
+type Phase string
+
+const (
+	PhaseRunning  Phase = "running"
+	PhaseDraining Phase = "draining"
+	PhaseComplete Phase = "complete"
+)
+
+type Result string
+
+const (
+	ResultNone     Result = ""
+	ResultGraceful Result = "graceful"
+	ResultForced   Result = "forced"
+	ResultTimeout  Result = "timeout"
+)
+
+type Event string
+
+const (
+	EventDrainRequested Event = "drain_requested"
+	EventForceRequested Event = "force_requested"
+	EventDrained        Event = "drained"
+	EventDrainTimedOut  Event = "drain_timed_out"
+)
+
+type Machine struct {
+	Phase  Phase
+	Result Result
+}
+
+func NewMachine() Machine {
+	return Machine{Phase: PhaseRunning}
+}
+
+func (m Machine) Apply(event Event) Machine {
+	if m.Phase == PhaseComplete {
+		return m
+	}
+
+	switch event {
+	case EventDrainRequested:
+		m.Phase = PhaseDraining
+		m.Result = ResultNone
+	case EventDrained:
+		m.Phase = PhaseComplete
+		m.Result = ResultGraceful
+	case EventForceRequested:
+		m.Phase = PhaseComplete
+		m.Result = ResultForced
+	case EventDrainTimedOut:
+		m.Phase = PhaseComplete
+		m.Result = ResultTimeout
+	}
+	return m
+}

--- a/internal/shutdown/state_test.go
+++ b/internal/shutdown/state_test.go
@@ -1,0 +1,69 @@
+package shutdown
+
+import "testing"
+
+func TestMachineTransitions(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		events     []Event
+		wantPhase  Phase
+		wantResult Result
+	}{
+		{
+			name:       "request enters drain",
+			events:     []Event{EventDrainRequested},
+			wantPhase:  PhaseDraining,
+			wantResult: ResultNone,
+		},
+		{
+			name:       "drained completes gracefully",
+			events:     []Event{EventDrainRequested, EventDrained},
+			wantPhase:  PhaseComplete,
+			wantResult: ResultGraceful,
+		},
+		{
+			name:       "force while draining completes forced",
+			events:     []Event{EventDrainRequested, EventForceRequested},
+			wantPhase:  PhaseComplete,
+			wantResult: ResultForced,
+		},
+		{
+			name:       "timeout while draining completes timeout",
+			events:     []Event{EventDrainRequested, EventDrainTimedOut},
+			wantPhase:  PhaseComplete,
+			wantResult: ResultTimeout,
+		},
+		{
+			name:       "force from running completes forced",
+			events:     []Event{EventForceRequested},
+			wantPhase:  PhaseComplete,
+			wantResult: ResultForced,
+		},
+		{
+			name:       "completed machine ignores later events",
+			events:     []Event{EventDrainRequested, EventDrained, EventForceRequested},
+			wantPhase:  PhaseComplete,
+			wantResult: ResultGraceful,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			machine := NewMachine()
+			for _, event := range tt.events {
+				machine = machine.Apply(event)
+			}
+
+			if machine.Phase != tt.wantPhase {
+				t.Fatalf("Phase = %q, want %q", machine.Phase, tt.wantPhase)
+			}
+			if machine.Result != tt.wantResult {
+				t.Fatalf("Result = %q, want %q", machine.Result, tt.wantResult)
+			}
+		})
+	}
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -8,6 +8,7 @@ type Snapshot struct {
 	Instance       Instance          `json:"instance"`
 	Projects       []ProjectSnapshot `json:"projects,omitempty"`
 	DashboardURL   string            `json:"dashboard_url,omitempty"`
+	Shutdown       Shutdown          `json:"shutdown,omitempty"`
 	Refresh        Refresh           `json:"refresh"`
 	Events         []ActivityEvent   `json:"events,omitempty"`
 	Counts         Counts            `json:"counts"`
@@ -23,6 +24,15 @@ type Snapshot struct {
 	LifetimeTotals LifetimeTotals    `json:"lifetime_totals"`
 	CycleTime      CycleTimeReport   `json:"cycle_time,omitempty"`
 	TokenTrend     []TokenTrendPoint `json:"token_trend,omitempty"`
+}
+
+type Shutdown struct {
+	Status            string     `json:"status,omitempty"`
+	Draining          bool       `json:"draining"`
+	SessionsRemaining int        `json:"sessions_remaining"`
+	RequestedAt       *time.Time `json:"requested_at,omitempty"`
+	CompletedAt       *time.Time `json:"completed_at,omitempty"`
+	Result            string     `json:"result,omitempty"`
 }
 
 type Project struct {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -106,7 +106,7 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
-		case "q", "esc", "ctrl+c":
+		case "q", "esc":
 			m.Close()
 			return m, tea.Quit
 		default:
@@ -183,6 +183,7 @@ func (m Model) renderSnapshot() string {
 			m.styles.warn.Render("total "+formatCount(snapshot.Tokens.Total)),
 		"│ Budget: " + formatBudget(snapshot.Budget, m.styles),
 		"│ Rate Limits: " + formatRateLimits(snapshot.RateLimits, m.now, m.styles),
+		"│ Shutdown: " + formatShutdown(snapshot.Shutdown, m.styles),
 		"│ Project: " + formatOptionalInfo(formatProject(snapshot.Project), m.styles),
 		"│ Instance: " + formatOptionalInfo(formatInstance(snapshot.Instance), m.styles),
 		"│ Scope: " + formatOptionalInfo(formatAuthorizationScope(snapshot.Instance), m.styles),
@@ -204,6 +205,17 @@ func (m Model) renderSnapshot() string {
 	lines = append(lines, closingBorder)
 
 	return strings.Join(lines, "\n")
+}
+
+func formatShutdown(shutdown telemetry.Shutdown, s styles) string {
+	if shutdown.Draining {
+		return s.warn.Render(fmt.Sprintf("draining (%d sessions remaining)", shutdown.SessionsRemaining))
+	}
+	status := strings.TrimSpace(shutdown.Status)
+	if status == "" {
+		status = "running"
+	}
+	return s.ok.Render(status)
 }
 
 func formatRunningRows(running []telemetry.Running, eventWidth int, s styles) []string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -55,6 +55,7 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 		"Tokens: in 110 | out 220 | total 330",
 		"Budget: enabled current $12.50 | projected $0.75 | day max $50.00 | issue max $5.00",
 		"Rate Limits: codex-primary | primary 90/100 reset 60s | secondary 0/100 reset 30s | credits 0/1",
+		"Shutdown: running",
 		"Running",
 		"PID",
 		"DD-44",
@@ -79,6 +80,29 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 	}
 	if strings.Contains(view, "worker-1") {
 		t.Fatalf("View() rendered worker host as process identity:\n%s", view)
+	}
+}
+
+func TestModelRendersDrainingShutdown(t *testing.T) {
+	t.Parallel()
+
+	snapshot := testSnapshot()
+	snapshot.Shutdown = telemetry.Shutdown{
+		Status:            "draining",
+		Draining:          true,
+		SessionsRemaining: 2,
+	}
+	model := Model{
+		snapshot:    snapshot,
+		hasSnapshot: true,
+		width:       defaultTerminalColumns,
+		now:         time.Now,
+		styles:      newStyles(),
+	}
+
+	view := stripANSI(model.View())
+	if !strings.Contains(view, "Shutdown: draining (2 sessions remaining)") {
+		t.Fatalf("View() missing draining shutdown:\n%s", view)
 	}
 }
 
@@ -133,6 +157,19 @@ func TestModelClosesSubscriptionOnQuit(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for subscription channel to close")
+	}
+}
+
+func TestModelLeavesCtrlCForSignalHandler(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(context.Background(), hub.New[telemetry.Snapshot]())
+	if err != nil {
+		t.Fatalf("NewModel() error = %v", err)
+	}
+
+	if _, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC}); cmd != nil {
+		t.Fatal("Update(ctrl+c) returned command, want signal handler to own shutdown")
 	}
 }
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -182,6 +182,8 @@ func (s *Server) handleHTTPError(err error, c echo.Context) {
 func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time) stateAPIResponse {
 	return stateAPIResponse{
 		GeneratedAt:    generatedAt,
+		Status:         runtimeStatus(snapshot),
+		Shutdown:       shutdownResponse(snapshot.Shutdown),
 		Counts:         countsResponse(snapshot),
 		Running:        runningEntries(snapshot.Running),
 		Retrying:       retryEntries(snapshot.Queue),
@@ -194,6 +196,28 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time) stateAPIR
 		RecentSessions: recentSessionEntries(snapshot.Completed),
 		RateLimits:     snapshot.RateLimits,
 		Budget:         budgetResponse(snapshot.Budget),
+	}
+}
+
+func runtimeStatus(snapshot telemetry.Snapshot) string {
+	if snapshot.Shutdown.Draining {
+		return "draining"
+	}
+	return "running"
+}
+
+func shutdownResponse(shutdown telemetry.Shutdown) shutdownAPIResponse {
+	status := strings.TrimSpace(shutdown.Status)
+	if status == "" {
+		status = "running"
+	}
+	return shutdownAPIResponse{
+		Status:            status,
+		Draining:          shutdown.Draining,
+		SessionsRemaining: shutdown.SessionsRemaining,
+		RequestedAt:       timestampStringPtr(shutdown.RequestedAt),
+		CompletedAt:       timestampStringPtr(shutdown.CompletedAt),
+		Result:            optionalString(strings.TrimSpace(shutdown.Result)),
 	}
 }
 
@@ -840,6 +864,8 @@ func snapshotErrorResponse(generatedAt time.Time, code string, message string) s
 
 type stateAPIResponse struct {
 	GeneratedAt    time.Time                  `json:"generated_at"`
+	Status         string                     `json:"status"`
+	Shutdown       shutdownAPIResponse        `json:"shutdown"`
 	Counts         countsAPIResponse          `json:"counts"`
 	Running        []runningAPIResponse       `json:"running"`
 	Retrying       []retryAPIResponse         `json:"retrying"`
@@ -852,6 +878,15 @@ type stateAPIResponse struct {
 	RecentSessions []recentSessionAPIResponse `json:"recent_sessions"`
 	RateLimits     *telemetry.RateLimits      `json:"rate_limits"`
 	Budget         budgetAPIResponse          `json:"budget"`
+}
+
+type shutdownAPIResponse struct {
+	Status            string  `json:"status"`
+	Draining          bool    `json:"draining"`
+	SessionsRemaining int     `json:"sessions_remaining"`
+	RequestedAt       *string `json:"requested_at,omitempty"`
+	CompletedAt       *string `json:"completed_at,omitempty"`
+	Result            *string `json:"result,omitempty"`
 }
 
 type boardAPIResponse struct {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -302,10 +302,19 @@ func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
 }
 
 func (s *Server) health(c echo.Context) error {
+	status := "ok"
+	sessionsRemaining := 0
+	if s.hub != nil {
+		if snapshot, ok := s.hub.Latest(); ok && snapshot.Shutdown.Draining {
+			status = "draining"
+			sessionsRemaining = snapshot.Shutdown.SessionsRemaining
+		}
+	}
 	return c.JSON(http.StatusOK, healthResponse{
-		Status:    "ok",
-		Mode:      string(s.mode),
-		Connector: s.connectorName(),
+		Status:            status,
+		Mode:              string(s.mode),
+		Connector:         s.connectorName(),
+		SessionsRemaining: sessionsRemaining,
 		Checks: map[string]string{
 			"hub":       configuredStatus(s.hub),
 			"store":     configuredStatus(s.store),
@@ -404,8 +413,9 @@ func (s *Server) connectorName() string {
 }
 
 type healthResponse struct {
-	Status    string            `json:"status"`
-	Mode      string            `json:"mode"`
-	Connector string            `json:"connector"`
-	Checks    map[string]string `json:"checks"`
+	Status            string            `json:"status"`
+	Mode              string            `json:"mode"`
+	Connector         string            `json:"connector"`
+	SessionsRemaining int               `json:"sessions_remaining,omitempty"`
+	Checks            map[string]string `json:"checks"`
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -786,6 +786,95 @@ func TestTimeSeriesAPIRoutesReturnChartDatasets(t *testing.T) {
 	}
 }
 
+func TestHealthReportsDraining(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC),
+		Shutdown: telemetry.Shutdown{
+			Status:            "draining",
+			Draining:          true,
+			SessionsRemaining: 2,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"status":"draining"`) {
+		t.Fatalf("body missing draining status:\n%s", rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), `"sessions_remaining":2`) {
+		t.Fatalf("body missing sessions remaining:\n%s", rec.Body.String())
+	}
+}
+
+func TestAPIStateReportsDraining(t *testing.T) {
+	t.Parallel()
+
+	requestedAt := time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: requestedAt,
+		Shutdown: telemetry.Shutdown{
+			Status:            "draining",
+			Draining:          true,
+			SessionsRemaining: 1,
+			RequestedAt:       &requestedAt,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	var payload struct {
+		Status   string `json:"status"`
+		Shutdown struct {
+			Status            string `json:"status"`
+			Draining          bool   `json:"draining"`
+			SessionsRemaining int    `json:"sessions_remaining"`
+			RequestedAt       string `json:"requested_at"`
+		} `json:"shutdown"`
+	}
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v; body = %s", err, rec.Body.String())
+	}
+	if payload.Status != "draining" {
+		t.Fatalf("Status = %q, want draining", payload.Status)
+	}
+	if payload.Shutdown.Status != "draining" || !payload.Shutdown.Draining || payload.Shutdown.SessionsRemaining != 1 {
+		t.Fatalf("Shutdown = %#v, want draining with one session", payload.Shutdown)
+	}
+	if payload.Shutdown.RequestedAt != "2026-06-12T15:00:00Z" {
+		t.Fatalf("Shutdown.RequestedAt = %q, want RFC3339 timestamp", payload.Shutdown.RequestedAt)
+	}
+}
+
 func TestDashboardReadsLatestSnapshotWithoutSubscribing(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1854,12 +1854,18 @@ func runtimeStatusLabel(snapshot telemetry.Snapshot) string {
 	if snapshot.GeneratedAt.IsZero() {
 		return "Offline"
 	}
+	if snapshot.Shutdown.Draining {
+		return "Draining"
+	}
 	return "Live"
 }
 
 func runtimeStatusClass(snapshot telemetry.Snapshot) string {
 	if snapshot.GeneratedAt.IsZero() {
 		return "border-border bg-muted text-muted-foreground"
+	}
+	if snapshot.Shutdown.Draining {
+		return "border-warning-soft bg-warning-soft text-warning"
 	}
 	return "border-success-soft bg-success-soft text-success"
 }

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -48,6 +48,26 @@ func TestThroughputRateFormatsRollingTokenTPS(t *testing.T) {
 	}
 }
 
+func TestRuntimeStatusReflectsDraining(t *testing.T) {
+	t.Parallel()
+
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC),
+		Shutdown: telemetry.Shutdown{
+			Status:            "draining",
+			Draining:          true,
+			SessionsRemaining: 2,
+		},
+	}
+
+	if got := runtimeStatusLabel(snapshot); got != "Draining" {
+		t.Fatalf("runtimeStatusLabel() = %q, want Draining", got)
+	}
+	if got := runtimeStatusClass(snapshot); got != "border-warning-soft bg-warning-soft text-warning" {
+		t.Fatalf("runtimeStatusClass() = %q, want warning class", got)
+	}
+}
+
 func TestThroughputTrendPoints(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add two-phase shutdown handling with drain mode, progress output, force quit, and drain timeout support
- stop orchestrator dispatch during drain while allowing running sessions and claim heartbeats to finish
- surface draining state in telemetry, /api/v1/state, /health, dashboard status, and TUI

Fixes #383

## Test Plan

- [x] `make check`