### PR TITLE
fix(orchestrator): wire auto promote

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -564,6 +564,7 @@ type statusCheckRollup struct {
 
 type pullRequestReview struct {
 	Body        string     `json:"body"`
+	URL         string     `json:"url"`
 	State       string     `json:"state"`
 	Author      *actor     `json:"author"`
 	CommitID    string     `json:"commitId"`
@@ -614,6 +615,7 @@ type restHead struct {
 
 type restReview struct {
 	Body        string     `json:"body"`
+	HTMLURL     string     `json:"html_url"`
 	State       string     `json:"state"`
 	User        *actor     `json:"user"`
 	CommitID    string     `json:"commit_id"`
@@ -1408,12 +1410,14 @@ func (c *Connector) attachMatchingPullRequests(
 				return err
 			}
 			issues[candidate.Index].PullRequest = &connector.PullRequest{
-				Number:           pullRequest.Number,
-				URL:              strings.TrimSpace(pullRequest.URL),
-				BranchName:       branchName,
-				State:            strings.ToUpper(strings.TrimSpace(pullRequest.State)),
-				CIStatus:         normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
-				CodexReviewState: pullRequestCodexReviewState(pullRequest),
+				Number:                 pullRequest.Number,
+				URL:                    strings.TrimSpace(pullRequest.URL),
+				BranchName:             branchName,
+				State:                  strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+				CIStatus:               normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
+				CodexReviewState:       pullRequestCodexReviewState(pullRequest),
+				CodexReviewSubmittedAt: pullRequestCodexReviewSubmittedAt(pullRequest),
+				CodexReviewFindings:    pullRequestCodexReviewFindings(pullRequest),
 			}
 			if issues[candidate.Index].PRNumber == nil && pullRequest.Number > 0 {
 				number := pullRequest.Number
@@ -2789,6 +2793,7 @@ func latestCodexReview(reviews []restReview, headSHA string) (pullRequestReview,
 		}
 		candidate := pullRequestReview{
 			Body:        review.Body,
+			URL:         review.HTMLURL,
 			State:       review.State,
 			Author:      review.User,
 			CommitID:    review.CommitID,
@@ -2837,6 +2842,34 @@ func pullRequestCodexReviewState(pullRequest pullRequestNode) string {
 		return "P2"
 	}
 	return reviewState
+}
+
+func pullRequestCodexReviewSubmittedAt(pullRequest pullRequestNode) *time.Time {
+	var latest *time.Time
+	for _, review := range pullRequest.LatestReviews.Nodes {
+		if review.SubmittedAt == nil {
+			continue
+		}
+		if latest == nil || review.SubmittedAt.After(*latest) {
+			value := *review.SubmittedAt
+			latest = &value
+		}
+	}
+	return latest
+}
+
+func pullRequestCodexReviewFindings(pullRequest pullRequestNode) []connector.PullRequestFinding {
+	findings := []connector.PullRequestFinding{}
+	for _, review := range pullRequest.LatestReviews.Nodes {
+		if !containsReviewSeverity(review.Body, "P1") {
+			continue
+		}
+		findings = append(findings, connector.PullRequestFinding{
+			Body: strings.TrimSpace(review.Body),
+			URL:  strings.TrimSpace(review.URL),
+		})
+	}
+	return findings
 }
 
 func containsReviewSeverity(body string, severity string) bool {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -478,6 +478,13 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 	if pr.Number != 187 || pr.State != "OPEN" || pr.BranchName != "detent/digitaldrywood_detent_182_followup" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
 		t.Fatalf("I_182 PullRequest = %#v, want PR 187 open followup", pr)
 	}
+	wantReviewSubmittedAt := time.Date(2026, 6, 5, 11, 0, 0, 0, time.UTC)
+	if pr.CodexReviewSubmittedAt == nil || !pr.CodexReviewSubmittedAt.Equal(wantReviewSubmittedAt) {
+		t.Fatalf("I_182 PullRequest.CodexReviewSubmittedAt = %v, want %v", pr.CodexReviewSubmittedAt, wantReviewSubmittedAt)
+	}
+	if len(pr.CodexReviewFindings) != 0 {
+		t.Fatalf("I_182 PullRequest.CodexReviewFindings = %#v, want none", pr.CodexReviewFindings)
+	}
 	if byID["I_18"].PullRequest != nil {
 		t.Fatalf("I_18 PullRequest = %#v, want nil", byID["I_18"].PullRequest)
 	}
@@ -526,7 +533,7 @@ func TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints(t 
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls/187/reviews?per_page=100&page=2",
-			body:   `[{"body":"[P1] Later paged finding.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-187","submitted_at":"2026-06-05T12:00:00Z"}]`,
+			body:   `[{"body":"[P1] Later paged finding.","html_url":"https://github.com/digitaldrywood/detent/pull/187#pullrequestreview-1","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-187","submitted_at":"2026-06-05T12:00:00Z"}]`,
 		},
 	})
 
@@ -549,6 +556,11 @@ func TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints(t 
 	}
 	if pr.CIStatus != "fail" || pr.CodexReviewState != "P1" {
 		t.Fatalf("PullRequest status = CI %q review %q, want fail/P1", pr.CIStatus, pr.CodexReviewState)
+	}
+	if len(pr.CodexReviewFindings) != 1 ||
+		pr.CodexReviewFindings[0].Body != "[P1] Later paged finding." ||
+		pr.CodexReviewFindings[0].URL != "https://github.com/digitaldrywood/detent/pull/187#pullrequestreview-1" {
+		t.Fatalf("PullRequest.CodexReviewFindings = %#v, want P1 review finding", pr.CodexReviewFindings)
 	}
 
 	requests := server.requests()
@@ -582,7 +594,7 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls/190/reviews?per_page=100",
-			body:   `[{"body":"[P1] Unsafe migration.","state":"COMMENTED","user":{"login":"codex"},"commit_id":"sha-190","submitted_at":"2026-06-05T11:00:00Z"}]`,
+			body:   `[{"body":"[P1] Unsafe migration.","html_url":"https://github.com/digitaldrywood/detent/pull/190#pullrequestreview-2","state":"COMMENTED","user":{"login":"codex"},"commit_id":"sha-190","submitted_at":"2026-06-05T11:00:00Z"}]`,
 		},
 	})
 
@@ -603,6 +615,11 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	pr := got[0].PullRequest
 	if pr == nil || pr.Number != 190 || pr.CIStatus != "fail" || pr.CodexReviewState != "P1" {
 		t.Fatalf("PullRequest = %#v, want PR 190 with failing CI and P1 review", pr)
+	}
+	if len(pr.CodexReviewFindings) != 1 ||
+		pr.CodexReviewFindings[0].Body != "[P1] Unsafe migration." ||
+		pr.CodexReviewFindings[0].URL != "https://github.com/digitaldrywood/detent/pull/190#pullrequestreview-2" {
+		t.Fatalf("PullRequest.CodexReviewFindings = %#v, want P1 review finding", pr.CodexReviewFindings)
 	}
 }
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -41,12 +41,21 @@ type BlockedRef struct {
 }
 
 type PullRequest struct {
-	Number           int    `json:"number,omitempty" yaml:"number,omitempty"`
-	URL              string `json:"url,omitempty" yaml:"url,omitempty"`
-	BranchName       string `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
-	State            string `json:"state,omitempty" yaml:"state,omitempty"`
-	CIStatus         string `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
-	CodexReviewState string `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
+	Number                 int                  `json:"number,omitempty" yaml:"number,omitempty"`
+	URL                    string               `json:"url,omitempty" yaml:"url,omitempty"`
+	BranchName             string               `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
+	State                  string               `json:"state,omitempty" yaml:"state,omitempty"`
+	CIStatus               string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
+	CodexReviewState       string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
+	CodexReviewSubmittedAt *time.Time           `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`
+	CodexReviewFindings    []PullRequestFinding `json:"codex_review_findings,omitempty" yaml:"codex_review_findings,omitempty"`
+}
+
+type PullRequestFinding struct {
+	Body string `json:"body,omitempty" yaml:"body,omitempty"`
+	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
+	Path string `json:"path,omitempty" yaml:"path,omitempty"`
+	Line int    `json:"line,omitempty" yaml:"line,omitempty"`
 }
 
 func NewIssue() Issue {

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -251,6 +251,11 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	if issue.PullRequest != nil {
 		pullRequest := *issue.PullRequest
+		if issue.PullRequest.CodexReviewSubmittedAt != nil {
+			submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
+			pullRequest.CodexReviewSubmittedAt = &submittedAt
+		}
+		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		issue.PullRequest = &pullRequest
 	}
 	if issue.BlockedBy != nil {

--- a/internal/orchestrator/autopromote_integration_test.go
+++ b/internal/orchestrator/autopromote_integration_test.go
@@ -1,0 +1,157 @@
+package orchestrator_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+)
+
+func TestRunAutoPromotesQuietHumanReviewIssueThroughMemoryConnector(t *testing.T) {
+	t.Parallel()
+
+	reviewedAt := time.Now().Add(-20 * time.Minute)
+	issue := testIssue("issue-auto-promote", "digitaldrywood/detent#385", "Human Review")
+	issue.Labels = []string{"bug"}
+	issue.PullRequest = &connector.PullRequest{
+		Number:                 385,
+		URL:                    "https://github.com/digitaldrywood/detent/pull/385",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &reviewedAt,
+	}
+
+	events := make(chan memory.Event, 4)
+	tracker := memory.New(memory.Config{
+		Issues: []connector.Issue{issue},
+		EventSink: func(event memory.Event) {
+			events <- event
+		},
+	})
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		AutoPromote: orchestrator.AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    &staticRunner{},
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	var gotStateUpdate bool
+	var gotComment bool
+	deadline := time.After(time.Second)
+	for !gotStateUpdate || !gotComment {
+		select {
+		case event := <-events:
+			switch event.Kind {
+			case memory.EventKindStateUpdate:
+				if event.IssueID == issue.ID && event.State == "Merging" {
+					gotStateUpdate = true
+				}
+			case memory.EventKindComment:
+				if event.IssueID == issue.ID && strings.Contains(event.Body, "Auto-promoted this issue from Human Review to Merging.") {
+					gotComment = true
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for auto-promote memory events; state_update=%v comment=%v", gotStateUpdate, gotComment)
+		}
+	}
+}
+
+func TestRunAutoPromoteUsesRuntimeQuietDurationUpdate(t *testing.T) {
+	t.Parallel()
+
+	reviewedAt := time.Now().Add(-5 * time.Minute)
+	issue := testIssue("issue-auto-promote-hot-reload", "digitaldrywood/detent#386", "Human Review")
+	issue.Labels = []string{"bug"}
+	issue.PullRequest = &connector.PullRequest{
+		Number:                 386,
+		URL:                    "https://github.com/digitaldrywood/detent/pull/386",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &reviewedAt,
+	}
+
+	events := make(chan memory.Event, 4)
+	tracker := memory.New(memory.Config{
+		Issues: []connector.Issue{issue},
+		EventSink: func(event memory.Event) {
+			events <- event
+		},
+	})
+	cfg := orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		AutoPromote: orchestrator.AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	}
+	orch, err := orchestrator.New(cfg, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    &staticRunner{},
+		Logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		return len(state.Pipeline) == 1 && state.Pipeline[0].ID == issue.ID
+	})
+	select {
+	case event := <-events:
+		t.Fatalf("unexpected auto-promote event before quiet duration update: %#v", event)
+	default:
+	}
+
+	cfg.AutoPromote.QuietDuration = time.Minute
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	if err := orch.UpdateConfig(ctx, cfg); err != nil {
+		cancel()
+		t.Fatalf("UpdateConfig() error = %v", err)
+	}
+	if _, err := orch.RequestRefresh(ctx); err != nil {
+		cancel()
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	cancel()
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case event := <-events:
+			if event.Kind == memory.EventKindStateUpdate && event.IssueID == issue.ID && event.State == "Merging" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for auto-promote after quiet duration update")
+		}
+	}
+}

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -64,6 +64,9 @@ func autoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	}
 
 	pullRequest := issue.PullRequest
+	if normalizePullRequestState(pullRequest.State) != "open" {
+		return summary
+	}
 	summary.PullRequestPresent = true
 	summary.PullRequestURL = strings.TrimSpace(pullRequest.URL)
 	summary.CIStatus = pullRequest.CIStatus

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1,0 +1,255 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	autoPromoteSourceState  = "Human Review"
+	autoPromoteMergingState = "Merging"
+	autoPromoteReworkState  = "Rework"
+)
+
+func (o *Orchestrator) autoPromoteHumanReviewIssues(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) map[string]struct{} {
+	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	if !cfg.Enabled {
+		if o.logger != nil {
+			o.logger.Debug("auto promote skipped", "reason", AutoPromoteReasonDisabled)
+		}
+		return nil
+	}
+
+	transitioned := map[string]struct{}{}
+	for _, issue := range issuesInStates(issues, []string{autoPromoteSourceState}) {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+
+		summary := autoPromoteSummaryFromIssue(issue)
+		decision := EvaluateAutoPromote(issue, summary, cfg, now)
+		targetState := autoPromoteTargetState(decision.Action)
+		if targetState == "" {
+			o.logAutoPromoteDecision(issue, decision, "")
+			continue
+		}
+		if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
+			continue
+		}
+		transitioned[issueID] = struct{}{}
+	}
+	if len(transitioned) == 0 {
+		return nil
+	}
+	return transitioned
+}
+
+func autoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
+	summary := AutoPromoteSummary{
+		LastActivityAt: autoPromoteLastActivityAt(issue),
+	}
+	if issue.PullRequest == nil {
+		return summary
+	}
+
+	pullRequest := issue.PullRequest
+	summary.PullRequestPresent = true
+	summary.PullRequestURL = strings.TrimSpace(pullRequest.URL)
+	summary.CIStatus = pullRequest.CIStatus
+	summary.ReviewState = pullRequest.CodexReviewState
+	summary.P1Findings = autoPromoteFindingsFromPullRequest(pullRequest)
+	return summary
+}
+
+func autoPromoteLastActivityAt(issue connector.Issue) *time.Time {
+	var latest *time.Time
+	latest = latestTime(latest, issue.StageUpdatedAt)
+	latest = latestTime(latest, issue.UpdatedAt)
+	if issue.PullRequest != nil {
+		latest = latestTime(latest, issue.PullRequest.CodexReviewSubmittedAt)
+	}
+	return latest
+}
+
+func latestTime(current *time.Time, candidate *time.Time) *time.Time {
+	if candidate == nil {
+		return current
+	}
+	if current == nil || candidate.After(*current) {
+		value := *candidate
+		return &value
+	}
+	return current
+}
+
+func autoPromoteFindingsFromPullRequest(pullRequest *connector.PullRequest) []AutoPromoteFinding {
+	if pullRequest == nil {
+		return nil
+	}
+	findings := make([]AutoPromoteFinding, 0, len(pullRequest.CodexReviewFindings))
+	for _, finding := range pullRequest.CodexReviewFindings {
+		findings = append(findings, AutoPromoteFinding{
+			Body: finding.Body,
+			URL:  finding.URL,
+			Path: finding.Path,
+			Line: finding.Line,
+		})
+	}
+	if len(findings) == 0 && strings.EqualFold(strings.TrimSpace(pullRequest.CodexReviewState), "P1") {
+		findings = append(findings, AutoPromoteFinding{
+			Body: "Codex review reported P1 findings.",
+			URL:  strings.TrimSpace(pullRequest.URL),
+		})
+	}
+	return findings
+}
+
+func autoPromoteTargetState(action AutoPromoteAction) string {
+	switch action {
+	case AutoPromoteActionPromote:
+		return autoPromoteMergingState
+	case AutoPromoteActionRework:
+		return autoPromoteReworkState
+	default:
+		return ""
+	}
+}
+
+func (o *Orchestrator) applyAutoPromoteDecision(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	summary AutoPromoteSummary,
+	decision AutoPromoteDecision,
+	targetState string,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"auto promote transition failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"action", decision.Action,
+				"reason", decision.Reason,
+				"target_state", targetState,
+				"error", err,
+			)
+		}
+		return false
+	}
+
+	body := autoPromoteComment(summary, decision, targetState)
+	if strings.TrimSpace(body) != "" {
+		if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+			o.logger.Warn(
+				"auto promote comment failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"action", decision.Action,
+				"reason", decision.Reason,
+				"target_state", targetState,
+				"error", err,
+			)
+		}
+	}
+
+	o.logAutoPromoteDecision(issue, decision, targetState)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "auto_promote_transition",
+		Message: "auto-promoted " + issueLabel(issue) + " from " + autoPromoteSourceState + " to " + targetState,
+	})
+	return true
+}
+
+func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision AutoPromoteDecision, targetState string) {
+	if o.logger == nil {
+		return
+	}
+
+	attrs := []any{
+		"issue_id", strings.TrimSpace(issue.ID),
+		"identifier", issue.Identifier,
+		"action", decision.Action,
+		"reason", decision.Reason,
+	}
+	if decision.CIStatus != "" {
+		attrs = append(attrs, "ci_status", decision.CIStatus)
+	}
+	if decision.QuietRemaining > 0 {
+		attrs = append(attrs, "quiet_remaining", decision.QuietRemaining)
+	}
+	if targetState != "" {
+		attrs = append(attrs, "target_state", targetState)
+		o.logger.Info("auto promote decision", attrs...)
+		return
+	}
+	o.logger.Debug("auto promote decision", attrs...)
+}
+
+func autoPromoteComment(
+	summary AutoPromoteSummary,
+	decision AutoPromoteDecision,
+	targetState string,
+) string {
+	var b strings.Builder
+	switch targetState {
+	case autoPromoteMergingState:
+		b.WriteString("Auto-promoted this issue from Human Review to Merging.")
+	case autoPromoteReworkState:
+		b.WriteString("Auto-promote routed this issue from Human Review to Rework.")
+	default:
+		return ""
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString("- reason: ")
+	b.WriteString(string(decision.Reason))
+	if summary.PullRequestURL != "" {
+		b.WriteString("\n- pull request: ")
+		b.WriteString(summary.PullRequestURL)
+	}
+	if decision.CIStatus != "" {
+		b.WriteString("\n- ci_status: ")
+		b.WriteString(decision.CIStatus)
+	}
+
+	if len(decision.Findings) > 0 {
+		b.WriteString("\n\nFindings:")
+		for _, finding := range decision.Findings {
+			b.WriteString("\n- ")
+			b.WriteString(autoPromoteFindingText(finding))
+		}
+	}
+
+	return b.String()
+}
+
+func autoPromoteFindingText(finding AutoPromoteFinding) string {
+	body := strings.Join(strings.Fields(finding.Body), " ")
+	if body == "" {
+		body = "P1 finding"
+	}
+	if finding.Path != "" && finding.Line > 0 {
+		body = fmt.Sprintf("%s (%s:%d)", body, finding.Path, finding.Line)
+	} else if finding.Path != "" {
+		body = body + " (" + finding.Path + ")"
+	}
+	if finding.URL != "" {
+		body = body + " " + finding.URL
+	}
+	return body
+}

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -95,6 +95,21 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			}),
 		},
 		{
+			name: "skips closed pull request",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-closed-pr", []string{"bug"}, &connector.PullRequest{
+				Number:                 47,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/47",
+				State:                  "MERGED",
+				CIStatus:               "pass",
+				CodexReviewState:       "COMMENTED",
+				CodexReviewSubmittedAt: &oldReview,
+			}),
+		},
+		{
 			name: "honors evaluator label filters",
 			cfg: AutoPromoteConfig{
 				Enabled:            true,

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1,0 +1,265 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 14, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	recentReview := now.Add(-30 * time.Second)
+
+	tests := []struct {
+		name                 string
+		cfg                  AutoPromoteConfig
+		issue                connector.Issue
+		wantUpdates          []autoPromoteTickUpdate
+		wantCommentFragments []string
+	}{
+		{
+			name: "promotes ready issue to merging",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-ready", []string{"bug"}, &connector.PullRequest{
+				Number:                 42,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/42",
+				State:                  "OPEN",
+				CIStatus:               "success",
+				CodexReviewState:       "COMMENTED",
+				CodexReviewSubmittedAt: &oldReview,
+			}),
+			wantUpdates: []autoPromoteTickUpdate{{
+				issueID: "issue-ready",
+				state:   "Merging",
+			}},
+			wantCommentFragments: []string{
+				"Auto-promoted this issue from Human Review to Merging.",
+				"reason: ready",
+				"https://github.test/digitaldrywood/detent/pull/42",
+			},
+		},
+		{
+			name: "routes P1 findings to rework",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-p1", []string{"bug"}, &connector.PullRequest{
+				Number:                 43,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/43",
+				State:                  "OPEN",
+				CIStatus:               "pass",
+				CodexReviewState:       "P1",
+				CodexReviewSubmittedAt: &oldReview,
+				CodexReviewFindings: []connector.PullRequestFinding{{
+					Body: "![P1 Badge](https://example.test/p1.svg) Unsafe migration.",
+					URL:  "https://github.test/digitaldrywood/detent/pull/43#pullrequestreview-1",
+				}},
+			}),
+			wantUpdates: []autoPromoteTickUpdate{{
+				issueID: "issue-p1",
+				state:   "Rework",
+			}},
+			wantCommentFragments: []string{
+				"Auto-promote routed this issue from Human Review to Rework.",
+				"reason: p1_findings",
+				"Unsafe migration.",
+				"https://github.test/digitaldrywood/detent/pull/43#pullrequestreview-1",
+			},
+		},
+		{
+			name: "waits for quiet period",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-recent", []string{"bug"}, &connector.PullRequest{
+				Number:                 44,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/44",
+				State:                  "OPEN",
+				CIStatus:               "pass",
+				CodexReviewState:       "COMMENTED",
+				CodexReviewSubmittedAt: &recentReview,
+			}),
+		},
+		{
+			name: "honors evaluator label filters",
+			cfg: AutoPromoteConfig{
+				Enabled:            true,
+				QuietDuration:      10 * time.Minute,
+				AllowedIssueLabels: []string{"release"},
+			},
+			issue: autoPromoteTickIssue("issue-label", []string{"bug"}, &connector.PullRequest{
+				Number:                 45,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/45",
+				State:                  "OPEN",
+				CIStatus:               "pass",
+				CodexReviewState:       "COMMENTED",
+				CodexReviewSubmittedAt: &oldReview,
+			}),
+		},
+		{
+			name: "disabled config does not evaluate",
+			cfg: AutoPromoteConfig{
+				Enabled:       false,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-disabled", []string{"bug"}, &connector.PullRequest{
+				Number:                 46,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/46",
+				State:                  "OPEN",
+				CIStatus:               "pass",
+				CodexReviewState:       "COMMENTED",
+				CodexReviewSubmittedAt: &oldReview,
+			}),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				PollInterval:        time.Minute,
+				MaxConcurrentAgents: 1,
+				AutoPromote:         tt.cfg,
+				ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+				TerminalStates:      []string{"Done", "Cancelled"},
+			})
+			state := newState(cfg)
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{tt.issue}}
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tracker,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug})),
+			}
+
+			orch.tick(context.Background(), &state, now)
+
+			if !reflect.DeepEqual(tracker.updates, tt.wantUpdates) {
+				t.Fatalf("updates = %#v, want %#v", tracker.updates, tt.wantUpdates)
+			}
+			if len(tracker.fetchByStatesRequests) != 1 {
+				t.Fatalf("FetchIssuesByStates() calls = %d, want 1", len(tracker.fetchByStatesRequests))
+			}
+			if !autoPromoteTickStatesEqual(tracker.fetchByStatesRequests[0], []string{"Blocked", "Human Review", "Merging"}) {
+				t.Fatalf("FetchIssuesByStates() states = %#v, want Blocked/Human Review/Merging", tracker.fetchByStatesRequests[0])
+			}
+			if len(tt.wantCommentFragments) == 0 {
+				if len(tracker.comments) != 0 {
+					t.Fatalf("comments = %#v, want none", tracker.comments)
+				}
+				return
+			}
+			if len(tracker.comments) != 1 {
+				t.Fatalf("comments = %#v, want one comment", tracker.comments)
+			}
+			for _, fragment := range tt.wantCommentFragments {
+				if !strings.Contains(tracker.comments[0].body, fragment) {
+					t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+				}
+			}
+		})
+	}
+}
+
+func autoPromoteTickIssue(id string, labels []string, pullRequest *connector.PullRequest) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/detent#42"
+	issue.Title = "Auto promote test"
+	issue.State = "Human Review"
+	issue.Labels = append([]string(nil), labels...)
+	issue.PullRequest = pullRequest
+	return issue
+}
+
+func autoPromoteTickStatesEqual(got []string, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	seen := make(map[string]struct{}, len(got))
+	for _, state := range got {
+		seen[strings.ToLower(strings.TrimSpace(state))] = struct{}{}
+	}
+	for _, state := range want {
+		if _, ok := seen[strings.ToLower(strings.TrimSpace(state))]; !ok {
+			return false
+		}
+	}
+	return true
+}
+
+type autoPromoteTickUpdate struct {
+	issueID string
+	state   string
+}
+
+type autoPromoteTickComment struct {
+	issueID string
+	body    string
+}
+
+type autoPromoteTickConnector struct {
+	stateIssues           []connector.Issue
+	fetchByStatesRequests [][]string
+	updates               []autoPromoteTickUpdate
+	comments              []autoPromoteTickComment
+}
+
+func (c *autoPromoteTickConnector) Name() string {
+	return "auto-promote-tick"
+}
+
+func (c *autoPromoteTickConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return []connector.Issue{}, nil
+}
+
+func (c *autoPromoteTickConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	c.fetchByStatesRequests = append(c.fetchByStatesRequests, append([]string(nil), states...))
+	wanted := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		wanted[strings.ToLower(strings.TrimSpace(state))] = struct{}{}
+	}
+	issues := make([]connector.Issue, 0, len(c.stateIssues))
+	for _, issue := range c.stateIssues {
+		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.State))]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+	return issues, nil
+}
+
+func (c *autoPromoteTickConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return []connector.Issue{}, nil
+}
+
+func (c *autoPromoteTickConnector) CreateComment(_ context.Context, issueID string, body string) error {
+	c.comments = append(c.comments, autoPromoteTickComment{issueID: issueID, body: body})
+	return nil
+}
+
+func (c *autoPromoteTickConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updates = append(c.updates, autoPromoteTickUpdate{issueID: issueID, state: state})
+	return nil
+}
+
+func (c *autoPromoteTickConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *autoPromoteTickConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1464,6 +1464,11 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 		}
 		if issue.PullRequest != nil {
 			pullRequest := *issue.PullRequest
+			if issue.PullRequest.CodexReviewSubmittedAt != nil {
+				submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
+				pullRequest.CodexReviewSubmittedAt = &submittedAt
+			}
+			pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 			cloned[i].PullRequest = &pullRequest
 		}
 		cloned[i].BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -192,6 +192,11 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	if issue.PullRequest != nil {
 		pullRequest := *issue.PullRequest
+		if issue.PullRequest.CodexReviewSubmittedAt != nil {
+			submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
+			pullRequest.CodexReviewSubmittedAt = &submittedAt
+		}
+		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		cloned.PullRequest = &pullRequest
 	}
 	if issue.CreatedAt != nil {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -54,6 +54,13 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		fetched,
 		o.reconcileClosedCompletedIssueStatuses(ctx, state, transitions.issues, now),
 	)
+	if fetched.statusOK {
+		fetched = filterReconciledTickIssues(
+			state,
+			fetched,
+			o.autoPromoteHumanReviewIssues(ctx, state, fetched.status, now),
+		)
+	}
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
 }
 


### PR DESCRIPTION
## Summary

- Wire `agent.auto_promote` into the Human Review status tick.
- Reuse existing attached PR summaries for CI, Codex review state, quiet timing, and P1 finding comments.
- Add tick wiring and memory-connector integration coverage, including runtime quiet-duration updates.

Fixes #385

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/connector ./internal/connector/github ./internal/connector/memory`
- [x] `make check`