### PR TITLE
feat(orchestrator): add dependency auto-unblock

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,6 +268,12 @@ tracker:
     Medium: 3
     Low: 4
     No priority: null
+  dependency_auto_unblock:
+    enabled: false
+    source_states:
+      - Blocked
+    target_state: Todo
+    readiness: terminal_or_merged
 polling:
   interval_ms: 120000
 workspace:
@@ -614,6 +620,24 @@ You bring the board; Detent fills in the rest.
 - **Detent reads** status, priority, labels, blockers, assignees, and linked
   pull requests from each issue, and **writes back** status transitions and a
   `## Codex Workpad` comment as the agent works.
+
+### Dependency workflows
+
+Detent supports two dependency patterns. Use the one that matches how much of
+the wait should be visible on the board.
+
+- **Keep the issue in `Todo`.** Add a machine-readable dependency line such as
+  `Depends on: #123` or `Blocked by: owner/repo#123`. Detent keeps the issue out
+  of dispatch while any referenced blocker is non-terminal, then dispatches it
+  normally after blockers clear. This is the default behavior and needs no extra
+  configuration.
+- **Keep the issue in `Blocked`.** Enable `tracker.dependency_auto_unblock` when
+  your team wants dependency-waiting issues to sit in a waiting column. Detent
+  only moves issues that have explicit `Depends on:` or `Blocked by:` references.
+  When all blockers are terminal, closed, or have a merged linked PR under the
+  configured `readiness` rule, Detent updates the ProjectV2 `Status` to
+  `target_state` and posts an audit comment. Human blockers without explicit
+  dependency references stay blocked.
 
 Before you dispatch anything, run **`detent doctor`** — it checks config
 resolution, the database, the `codex` binary, your GitHub token and scopes, git,

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -453,7 +453,25 @@ recommendation, and default-if-silent. Record answers in
    rg '^AUTO_PROMOTE_' "$ONBOARDING_DIR/answers.env"
    ```
 
-9. **Prompt body.** Ask: "Use the template prompt or add repo-specific
+9. **Dependency waiting policy.** Ask: "Should dependency-waiting issues stay
+   in `Todo` and be gated by Detent, or should they sit in `Blocked` and be
+   auto-unblocked when dependencies clear?" Default if silent:
+   `tracker.dependency_auto_unblock.enabled: false`. Use the `Blocked`
+   auto-unblock mode only when the team writes explicit `Depends on:` or
+   `Blocked by:` lines for dependency blockers; Detent will not clear unrelated
+   human blockers. Verify:
+
+   ```sh
+   printf '%s\n' \
+     'DEPENDENCY_AUTO_UNBLOCK_ENABLED=<true|false>' \
+     'DEPENDENCY_AUTO_UNBLOCK_SOURCE_STATES=Blocked' \
+     'DEPENDENCY_AUTO_UNBLOCK_TARGET_STATE=Todo' \
+     'DEPENDENCY_AUTO_UNBLOCK_READINESS=terminal_or_merged' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^DEPENDENCY_AUTO_UNBLOCK_' "$ONBOARDING_DIR/answers.env"
+   ```
+
+10. **Prompt body.** Ask: "Use the template prompt or add repo-specific
    instructions?" Recommendation source: `CLAUDE.md`, `AGENTS.md`,
    `CONTRIBUTING.md`, README development commands, and CI workflows in
    `<source-root>`. Default if silent: template prompt plus any repo authority
@@ -470,7 +488,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^PROMPT_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-10. **Issue intake.** Ask: "Which issue filter should be bulk-added, should the
+11. **Issue intake.** Ask: "Which issue filter should be bulk-added, should the
    initial `Status` be `Backlog` or `Todo`, and should the human enable the
    auto-add workflow?" Recommendation source: `$ONBOARDING_DIR/issue-counts.json`
    and the authorization answer. Default if silent: bulk-add the narrowest safe
@@ -610,11 +628,12 @@ recommendation, and default-if-silent. Record answers in
      approval_label: <approval-label>
    ```
 
-5. **Set review policy and concurrency.** Keep `Merging: 1`. Use the review
-   policy selected by the human. Verify:
+5. **Set review policy, dependency waiting policy, and concurrency.** Keep
+   `Merging: 1`. Use the review and dependency policy selected by the human.
+   Verify:
 
    ```sh
-   rg -n 'max_concurrent_agents: <max>|Merging: 1|auto_promote:|enabled: <true|false>|quiet_seconds: <seconds>|optout_label: <label>|allowed_issue_labels:' \
+   rg -n 'max_concurrent_agents: <max>|Merging: 1|auto_promote:|dependency_auto_unblock:|enabled: <true|false>|quiet_seconds: <seconds>|optout_label: <label>|allowed_issue_labels:|source_states:|target_state:|readiness:' \
      <source-root>/WORKFLOW.md
    ```
 
@@ -640,6 +659,21 @@ recommendation, and default-if-silent. Record answers in
        allowed_issue_labels:
          - <allowed-label>
    ```
+
+   Dependency auto-unblock default:
+
+   ```yaml
+   tracker:
+     dependency_auto_unblock:
+       enabled: false
+       source_states:
+         - Blocked
+       target_state: Todo
+       readiness: terminal_or_merged
+   ```
+
+   Enable it only for projects that use `Blocked` as a dependency-waiting state
+   with explicit machine-readable dependency references.
 
 6. **Write the prompt body.** Keep the `## Codex Workpad` instruction, include
    repo authority files discovered in Phase 2, and state the validation gate.
@@ -952,3 +986,10 @@ issue starts. If there is no dependency, omit the line.
 
 Keep dependency order explicit. If issue B relies on issue A, issue B should
 carry `Depends on: #A` and stay out of `Todo` until A has merged.
+
+Alternatively, if the project has opted into
+`tracker.dependency_auto_unblock.enabled`, issue B can sit in a configured
+waiting state such as `Blocked` with the same `Depends on:` or `Blocked by:`
+line. Detent will move it to the configured ready state after every blocker is
+terminal, closed, or merged according to the workflow readiness rule. Do not use
+that mode for free-form human blockers without explicit dependency references.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,9 @@ const (
 	TrackerLinear = "linear"
 	TrackerMemory = "memory"
 
+	DependencyReadinessTerminal         = "terminal"
+	DependencyReadinessTerminalOrMerged = "terminal_or_merged"
+
 	defaultLinearEndpoint = "https://api.linear.app/graphql"
 	defaultGitHubEndpoint = "https://api.github.com/graphql"
 
@@ -61,28 +64,36 @@ type Config struct {
 }
 
 type Tracker struct {
-	Kind                       string            `yaml:"kind"`
-	Endpoint                   string            `yaml:"endpoint"`
-	APIKey                     string            `yaml:"api_key"`
-	HTTPMaxIdleConns           int               `yaml:"http_max_idle_conns"`
-	HTTPMaxIdleConnsPerHost    int               `yaml:"http_max_idle_conns_per_host"`
-	HTTPIdleConnTimeoutMS      int               `yaml:"http_idle_conn_timeout_ms"`
-	GitHubGraphQLWarnRemaining int               `yaml:"github_graphql_warn_remaining"`
-	GitHubAppID                string            `yaml:"github_app_id"`
-	GitHubAppPrivateKey        string            `yaml:"github_app_private_key"`
-	GitHubAppPrivateKeyPath    string            `yaml:"github_app_private_key_path"`
-	GitHubAppInstallationID    string            `yaml:"github_app_installation_id"`
-	ProjectSlug                string            `yaml:"project_slug"`
-	Assignee                   string            `yaml:"assignee"`
-	ActiveStates               []string          `yaml:"active_states"`
-	ObservedStates             []string          `yaml:"observed_states"`
-	TerminalStates             []string          `yaml:"terminal_states"`
-	StateMap                   StringOrMap       `yaml:"state_map"`
-	PriorityMap                StringOrMap       `yaml:"priority_map"`
-	AutoProvision              bool              `yaml:"auto_provision"`
-	Claims                     Claims            `yaml:"claims,omitempty"`
-	Authorization              selector.Selector `yaml:"authorization,omitempty"`
-	Issues                     []connector.Issue `yaml:"issues"`
+	Kind                       string                `yaml:"kind"`
+	Endpoint                   string                `yaml:"endpoint"`
+	APIKey                     string                `yaml:"api_key"`
+	HTTPMaxIdleConns           int                   `yaml:"http_max_idle_conns"`
+	HTTPMaxIdleConnsPerHost    int                   `yaml:"http_max_idle_conns_per_host"`
+	HTTPIdleConnTimeoutMS      int                   `yaml:"http_idle_conn_timeout_ms"`
+	GitHubGraphQLWarnRemaining int                   `yaml:"github_graphql_warn_remaining"`
+	GitHubAppID                string                `yaml:"github_app_id"`
+	GitHubAppPrivateKey        string                `yaml:"github_app_private_key"`
+	GitHubAppPrivateKeyPath    string                `yaml:"github_app_private_key_path"`
+	GitHubAppInstallationID    string                `yaml:"github_app_installation_id"`
+	ProjectSlug                string                `yaml:"project_slug"`
+	Assignee                   string                `yaml:"assignee"`
+	ActiveStates               []string              `yaml:"active_states"`
+	ObservedStates             []string              `yaml:"observed_states"`
+	TerminalStates             []string              `yaml:"terminal_states"`
+	StateMap                   StringOrMap           `yaml:"state_map"`
+	PriorityMap                StringOrMap           `yaml:"priority_map"`
+	DependencyAutoUnblock      DependencyAutoUnblock `yaml:"dependency_auto_unblock"`
+	AutoProvision              bool                  `yaml:"auto_provision"`
+	Claims                     Claims                `yaml:"claims,omitempty"`
+	Authorization              selector.Selector     `yaml:"authorization,omitempty"`
+	Issues                     []connector.Issue     `yaml:"issues"`
+}
+
+type DependencyAutoUnblock struct {
+	Enabled      bool     `yaml:"enabled"`
+	SourceStates []string `yaml:"source_states"`
+	TargetState  string   `yaml:"target_state"`
+	Readiness    string   `yaml:"readiness"`
 }
 
 type Identity struct {
@@ -378,6 +389,41 @@ func (c Claims) Validate(prefix string) []string {
 	return problems
 }
 
+func (d *DependencyAutoUnblock) Normalize() {
+	if d == nil {
+		return
+	}
+	d.SourceStates = normalizeStateList(d.SourceStates)
+	d.TargetState = strings.TrimSpace(d.TargetState)
+	d.Readiness = strings.ToLower(strings.TrimSpace(d.Readiness))
+	if d.Readiness == "" {
+		d.Readiness = DependencyReadinessTerminalOrMerged
+	}
+}
+
+func (d DependencyAutoUnblock) Validate(prefix string) []string {
+	d.Normalize()
+
+	var problems []string
+	validateStateList(prefix+".source_states", d.SourceStates, &problems)
+	if d.Enabled {
+		if len(d.SourceStates) == 0 {
+			problems = append(problems, prefix+".source_states must not be empty when "+prefix+".enabled is true")
+		}
+		if strings.TrimSpace(d.TargetState) == "" {
+			problems = append(problems, prefix+".target_state is required when "+prefix+".enabled is true")
+		}
+	}
+	if d.Readiness != "" {
+		switch d.Readiness {
+		case DependencyReadinessTerminal, DependencyReadinessTerminalOrMerged:
+		default:
+			problems = append(problems, prefix+".readiness must be one of terminal, terminal_or_merged")
+		}
+	}
+	return problems
+}
+
 type StringOrMap struct {
 	IsString bool
 	String   string
@@ -447,7 +493,12 @@ func Default() Config {
 			TerminalStates:             []string{"Closed", "Cancelled", "Canceled", "Duplicate", "Done"},
 			StateMap:                   MapValue(map[string]any{}),
 			PriorityMap:                MapValue(defaultPriorityMap()),
-			AutoProvision:              true,
+			DependencyAutoUnblock: DependencyAutoUnblock{
+				SourceStates: []string{"Blocked"},
+				TargetState:  "Todo",
+				Readiness:    DependencyReadinessTerminalOrMerged,
+			},
+			AutoProvision: true,
 		},
 		Polling: Polling{
 			IntervalMS: DefaultPollingIntervalMS,
@@ -584,6 +635,7 @@ func (c *Config) normalize() {
 		c.Tracker.Endpoint = defaultGitHubEndpoint
 	}
 	c.Tracker.Claims.Normalize()
+	c.Tracker.DependencyAutoUnblock.Normalize()
 	c.Tracker.Authorization.Normalize()
 
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
@@ -616,6 +668,7 @@ func (c *Config) validateTracker(problems *[]string) {
 	validateStateList("tracker.terminal_states", c.Tracker.TerminalStates, problems)
 	validateStateMap("tracker.state_map", c.Tracker.StateMap, problems)
 	validatePriorityMap("tracker.priority_map", c.Tracker.PriorityMap, problems)
+	*problems = append(*problems, c.Tracker.DependencyAutoUnblock.Validate("tracker.dependency_auto_unblock")...)
 	validatePositive("tracker.http_max_idle_conns", c.Tracker.HTTPMaxIdleConns, problems)
 	validatePositive("tracker.http_max_idle_conns_per_host", c.Tracker.HTTPMaxIdleConnsPerHost, problems)
 	validatePositive("tracker.http_idle_conn_timeout_ms", c.Tracker.HTTPIdleConnTimeoutMS, problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -49,6 +49,13 @@ tracker:
   priority_map:
     Urgent: 1
     No priority: null
+  dependency_auto_unblock:
+    enabled: true
+    source_states:
+      - Blocked
+      - Waiting
+    target_state: Todo
+    readiness: terminal_or_merged
 polling:
   interval_ms: 60000
 workspace:
@@ -198,6 +205,18 @@ Ticket prompt {{ issue.title }}
 	if got := cfg.Tracker.PriorityMap.Map["No priority"]; got != nil {
 		t.Fatalf("Tracker.PriorityMap[No priority] = %v, want nil", got)
 	}
+	if !cfg.Tracker.DependencyAutoUnblock.Enabled {
+		t.Fatal("Tracker.DependencyAutoUnblock.Enabled = false, want true")
+	}
+	if got := cfg.Tracker.DependencyAutoUnblock.SourceStates; !reflect.DeepEqual(got, []string{"blocked", "waiting"}) {
+		t.Fatalf("Tracker.DependencyAutoUnblock.SourceStates = %#v, want blocked/waiting", got)
+	}
+	if cfg.Tracker.DependencyAutoUnblock.TargetState != "Todo" {
+		t.Fatalf("Tracker.DependencyAutoUnblock.TargetState = %q, want Todo", cfg.Tracker.DependencyAutoUnblock.TargetState)
+	}
+	if cfg.Tracker.DependencyAutoUnblock.Readiness != DependencyReadinessTerminalOrMerged {
+		t.Fatalf("Tracker.DependencyAutoUnblock.Readiness = %q, want %q", cfg.Tracker.DependencyAutoUnblock.Readiness, DependencyReadinessTerminalOrMerged)
+	}
 	if got := cfg.Agent.MaxConcurrentAgentsByState["merging"]; got != 1 {
 		t.Fatalf("Agent.MaxConcurrentAgentsByState[merging] = %d, want 1", got)
 	}
@@ -254,6 +273,18 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Tracker.Authorization.Configured() {
 		t.Fatalf("Tracker.Authorization = %#v, want authorize all default", cfg.Tracker.Authorization)
+	}
+	if cfg.Tracker.DependencyAutoUnblock.Enabled {
+		t.Fatal("Tracker.DependencyAutoUnblock.Enabled = true, want disabled by default")
+	}
+	if got := cfg.Tracker.DependencyAutoUnblock.SourceStates; !reflect.DeepEqual(got, []string{"blocked"}) {
+		t.Fatalf("Tracker.DependencyAutoUnblock.SourceStates = %#v, want blocked", got)
+	}
+	if cfg.Tracker.DependencyAutoUnblock.TargetState != "Todo" {
+		t.Fatalf("Tracker.DependencyAutoUnblock.TargetState = %q, want Todo", cfg.Tracker.DependencyAutoUnblock.TargetState)
+	}
+	if cfg.Tracker.DependencyAutoUnblock.Readiness != DependencyReadinessTerminalOrMerged {
+		t.Fatalf("Tracker.DependencyAutoUnblock.Readiness = %q, want %q", cfg.Tracker.DependencyAutoUnblock.Readiness, DependencyReadinessTerminalOrMerged)
 	}
 	if cfg.Polling.IntervalMS != 120000 {
 		t.Fatalf("Polling.IntervalMS = %d", cfg.Polling.IntervalMS)
@@ -719,6 +750,25 @@ polling:
 Prompt
 `,
 			want: []string{"polling.interval_ms must be at least 60000"},
+		},
+		{
+			name: "invalid dependency auto unblock config",
+			raw: `---
+tracker:
+  kind: memory
+  dependency_auto_unblock:
+    enabled: true
+    source_states: [""]
+    target_state: ""
+    readiness: sometimes
+---
+Prompt
+`,
+			want: []string{
+				"tracker.dependency_auto_unblock.source_states state names must not be blank",
+				"tracker.dependency_auto_unblock.target_state is required when tracker.dependency_auto_unblock.enabled is true",
+				"tracker.dependency_auto_unblock.readiness must be one of terminal, terminal_or_merged",
+			},
 		},
 		{
 			name: "invalid paths and priority map",

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -760,6 +760,9 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 			issues = append(issues, issue)
 		}
 	}
+	if err := c.attachPullRequestMergeStates(ctx, issues); err != nil {
+		return nil, err
+	}
 	sortIssuesByRequestedIdentifiers(issues, identifiers)
 	return issues, nil
 }
@@ -1347,6 +1350,83 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 		}
 	}
 	return nil
+}
+
+func (c *Connector) attachPullRequestMergeStates(ctx context.Context, issues []connector.Issue) error {
+	byRepo := make(map[pullRequestRepo][]issuePullRequestCandidate)
+	for index, issue := range issues {
+		if issue.PullRequest != nil {
+			continue
+		}
+		repo, ok := pullRequestRepoFromIdentifier(issue.Identifier)
+		if !ok {
+			continue
+		}
+		branchPrefix := detentIssueBranchPrefix(issue.Identifier)
+		if branchPrefix == "" {
+			continue
+		}
+		byRepo[repo] = append(byRepo[repo], issuePullRequestCandidate{
+			Index:        index,
+			BranchPrefix: branchPrefix,
+		})
+	}
+	if len(byRepo) == 0 {
+		return nil
+	}
+
+	repos := make([]pullRequestRepo, 0, len(byRepo))
+	for repo := range byRepo {
+		repos = append(repos, repo)
+	}
+	sort.Slice(repos, func(i, j int) bool {
+		left := repos[i].Owner + "/" + repos[i].Name
+		right := repos[j].Owner + "/" + repos[j].Name
+		return left < right
+	})
+
+	for _, repo := range repos {
+		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
+		if err != nil {
+			return err
+		}
+		attachMatchingPullRequestMergeStates(issues, byRepo[repo], pullRequests)
+	}
+	return nil
+}
+
+func attachMatchingPullRequestMergeStates(
+	issues []connector.Issue,
+	candidates []issuePullRequestCandidate,
+	pullRequests []pullRequestNode,
+) {
+	for _, pullRequest := range pullRequests {
+		if normalizeStateName(pullRequest.State) != "merged" {
+			continue
+		}
+		branchName := strings.TrimSpace(pullRequest.HeadRefName)
+		if branchName == "" {
+			continue
+		}
+		for _, candidate := range candidates {
+			if issues[candidate.Index].PullRequest != nil {
+				continue
+			}
+			if !branchMatchesIssuePrefix(branchName, candidate.BranchPrefix) {
+				continue
+			}
+			issues[candidate.Index].PullRequest = &connector.PullRequest{
+				Number:     pullRequest.Number,
+				URL:        strings.TrimSpace(pullRequest.URL),
+				BranchName: branchName,
+				State:      strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+			}
+			if issues[candidate.Index].PRNumber == nil && pullRequest.Number > 0 {
+				number := pullRequest.Number
+				issues[candidate.Index].PRNumber = &number
+			}
+		}
+	}
 }
 
 func (c *Connector) fetchRepositoryPullRequests(ctx context.Context, repo pullRequestRepo) ([]pullRequestNode, error) {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -937,7 +937,7 @@ func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 	}
 }
 
-func TestConnectorFetchIssueStatesByIdentifiersResolvesGitHubStateAndProjectStatus(t *testing.T) {
+func TestConnectorFetchIssueStatesByIdentifiersResolvesDependencyReadinessSignals(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
@@ -957,16 +957,29 @@ func TestConnectorFetchIssueStatesByIdentifiersResolvesGitHubStateAndProjectStat
 		{
 			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_done","project":{"id":"PVT_1"},"statusValue":{"name":"Done"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}}}`,
 		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/253",
+			body:   `{"node_id":"I_merged_pr","number":253,"title":"Merged PR child","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/253","assignees":[],"labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false},"nodes":[{"id":"PVTI_merged_pr","project":{"id":"PVT_1"},"statusValue":{"name":"In Progress"},"priorityValue":null,"fieldValues":{"nodes":[]}}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[{"number":254,"html_url":"https://github.com/digitaldrywood/detent/pull/254","state":"closed","merged_at":"2026-06-12T16:00:00Z","head":{"ref":"detent/digitaldrywood_detent_253-autounblock","sha":"abc123"}}]`,
+		},
 	})
 
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
 
-	got, err := c.FetchIssueStatesByIdentifiers(context.Background(), []string{"digitaldrywood/detent#251", "digitaldrywood/detent#252"})
+	got, err := c.FetchIssueStatesByIdentifiers(context.Background(), []string{"digitaldrywood/detent#251", "digitaldrywood/detent#252", "digitaldrywood/detent#253"})
 	if err != nil {
 		t.Fatalf("FetchIssueStatesByIdentifiers() error = %v", err)
 	}
-	if ids := githubIssueIDs(got); !reflect.DeepEqual(ids, []string{"I_closed", "I_done"}) {
-		t.Fatalf("FetchIssueStatesByIdentifiers() ids = %#v, want [I_closed I_done]", ids)
+	if ids := githubIssueIDs(got); !reflect.DeepEqual(ids, []string{"I_closed", "I_done", "I_merged_pr"}) {
+		t.Fatalf("FetchIssueStatesByIdentifiers() ids = %#v, want [I_closed I_done I_merged_pr]", ids)
 	}
 	if !got[0].Closed || got[0].State != "Done" {
 		t.Fatalf("closed child = %#v, want Closed true and State Done", got[0])
@@ -974,13 +987,22 @@ func TestConnectorFetchIssueStatesByIdentifiersResolvesGitHubStateAndProjectStat
 	if got[1].Closed || got[1].State != "Done" {
 		t.Fatalf("project done child = %#v, want open issue with State Done", got[1])
 	}
+	if got[2].Closed || got[2].State != "In Progress" {
+		t.Fatalf("merged PR child = %#v, want open issue still In Progress", got[2])
+	}
+	if got[2].PullRequest == nil || got[2].PullRequest.State != "MERGED" || got[2].PullRequest.Number != 254 {
+		t.Fatalf("merged PR child PullRequest = %#v, want merged PR 254", got[2].PullRequest)
+	}
 
 	requests := server.requests()
-	if len(requests) != 4 {
-		t.Fatalf("request count = %d, want REST issue and project field reads for each identifier", len(requests))
+	if len(requests) != 7 {
+		t.Fatalf("request count = %d, want REST issue and project field reads for each identifier plus PR list", len(requests))
 	}
 	if requests[0]["method"] != http.MethodGet || requests[0]["path"] != "/repos/digitaldrywood/detent/issues/251" {
 		t.Fatalf("first request = %#v, want REST issue lookup", requests[0])
+	}
+	if requests[6]["method"] != http.MethodGet || requests[6]["path"] != "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all" {
+		t.Fatalf("PR request = %#v, want REST pull request list", requests[6])
 	}
 }
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -50,14 +50,18 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 	transitioned := map[string]struct{}{}
 	for _, issue := range issuesInStates(issues, cfg.SourceStates) {
 		issueID := strings.TrimSpace(issue.ID)
-		if issueID == "" || len(issue.BlockedBy) == 0 {
+		if issueID == "" {
 			continue
 		}
-		blockers := o.resolveDependencyBlockers(ctx, issue)
+		hydrated, ok := o.hydrateDependencyAutoUnblockIssue(ctx, issue, cfg.SourceStates)
+		if !ok || len(hydrated.BlockedBy) == 0 {
+			continue
+		}
+		blockers := o.resolveDependencyBlockers(ctx, hydrated)
 		if !dependencyBlockersReady(blockers, cfg, o.cfg.TerminalStates) {
 			continue
 		}
-		if !o.applyDependencyAutoUnblock(ctx, state, issue, blockers, cfg.TargetState, now) {
+		if !o.applyDependencyAutoUnblock(ctx, state, hydrated, blockers, cfg.TargetState, now) {
 			continue
 		}
 		transitioned[issueID] = struct{}{}
@@ -66,6 +70,46 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		return nil
 	}
 	return transitioned
+}
+
+func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(
+	ctx context.Context,
+	issue connector.Issue,
+	sourceStates []string,
+) (connector.Issue, bool) {
+	if len(issue.BlockedBy) > 0 || strings.TrimSpace(issue.Identifier) == "" {
+		return issue, stateIn(issue.State, sourceStates)
+	}
+	resolver, ok := o.connector.(connector.IssueReferenceResolver)
+	if !ok {
+		return issue, true
+	}
+	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, []string{issue.Identifier})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("hydrate dependency auto-unblock issue failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return connector.Issue{}, false
+	}
+	for _, hydrated := range issues {
+		if !sameIssueIdentity(issue, hydrated) {
+			continue
+		}
+		merged := mergeIssueTrackerFields(issue, hydrated)
+		return merged, stateIn(merged.State, sourceStates)
+	}
+	return issue, true
+}
+
+func sameIssueIdentity(left connector.Issue, right connector.Issue) bool {
+	leftID := strings.TrimSpace(left.ID)
+	rightID := strings.TrimSpace(right.ID)
+	if leftID != "" && rightID != "" && leftID == rightID {
+		return true
+	}
+	leftIdentifier := strings.ToLower(strings.TrimSpace(left.Identifier))
+	rightIdentifier := strings.ToLower(strings.TrimSpace(right.Identifier))
+	return leftIdentifier != "" && leftIdentifier == rightIdentifier
 }
 
 func (o *Orchestrator) resolveDependencyBlockers(ctx context.Context, issue connector.Issue) []dependencyBlocker {

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -1,0 +1,270 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	DependencyReadinessTerminal         = workflowconfig.DependencyReadinessTerminal
+	DependencyReadinessTerminalOrMerged = workflowconfig.DependencyReadinessTerminalOrMerged
+)
+
+type DependencyAutoUnblockConfig struct {
+	Enabled      bool
+	SourceStates []string
+	TargetState  string
+	Readiness    string
+}
+
+type dependencyBlocker struct {
+	Ref      connector.BlockedRef
+	Issue    connector.Issue
+	Resolved bool
+}
+
+func normalizeDependencyAutoUnblockConfig(cfg DependencyAutoUnblockConfig) DependencyAutoUnblockConfig {
+	cfg.SourceStates = normalizedStates(defaultStringSlice(cfg.SourceStates, []string{blockedStatusState}))
+	cfg.TargetState = strings.TrimSpace(defaultString(cfg.TargetState, "Todo"))
+	cfg.Readiness = strings.ToLower(strings.TrimSpace(defaultString(cfg.Readiness, DependencyReadinessTerminalOrMerged)))
+	return cfg
+}
+
+func (o *Orchestrator) autoUnblockDependencyIssues(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) map[string]struct{} {
+	cfg := normalizeDependencyAutoUnblockConfig(o.cfg.DependencyAutoUnblock)
+	if !cfg.Enabled {
+		return nil
+	}
+
+	transitioned := map[string]struct{}{}
+	for _, issue := range issuesInStates(issues, cfg.SourceStates) {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" || len(issue.BlockedBy) == 0 {
+			continue
+		}
+		blockers := o.resolveDependencyBlockers(ctx, issue)
+		if !dependencyBlockersReady(blockers, cfg, o.cfg.TerminalStates) {
+			continue
+		}
+		if !o.applyDependencyAutoUnblock(ctx, state, issue, blockers, cfg.TargetState, now) {
+			continue
+		}
+		transitioned[issueID] = struct{}{}
+	}
+	if len(transitioned) == 0 {
+		return nil
+	}
+	return transitioned
+}
+
+func (o *Orchestrator) resolveDependencyBlockers(ctx context.Context, issue connector.Issue) []dependencyBlocker {
+	blockers := make([]dependencyBlocker, 0, len(issue.BlockedBy))
+	identifiers := make([]string, 0, len(issue.BlockedBy))
+	seen := map[string]struct{}{}
+	for _, ref := range issue.BlockedBy {
+		ref.Identifier = strings.TrimSpace(ref.Identifier)
+		ref.ID = strings.TrimSpace(ref.ID)
+		ref.State = strings.TrimSpace(ref.State)
+		blockers = append(blockers, dependencyBlocker{Ref: ref})
+		if ref.Identifier == "" {
+			continue
+		}
+		key := strings.ToLower(ref.Identifier)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		identifiers = append(identifiers, ref.Identifier)
+	}
+
+	resolver, ok := o.connector.(connector.IssueReferenceResolver)
+	if !ok || len(identifiers) == 0 {
+		return blockers
+	}
+	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("resolve dependency blockers failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return blockers
+	}
+
+	byIdentifier := make(map[string]connector.Issue, len(issues))
+	for _, blocker := range issues {
+		identifier := strings.ToLower(strings.TrimSpace(blocker.Identifier))
+		if identifier == "" {
+			continue
+		}
+		byIdentifier[identifier] = blocker
+	}
+	for index := range blockers {
+		identifier := strings.ToLower(strings.TrimSpace(blockers[index].Ref.Identifier))
+		blocker, ok := byIdentifier[identifier]
+		if !ok {
+			continue
+		}
+		blockers[index].Issue = blocker
+		blockers[index].Resolved = true
+		blockers[index].Ref.ID = firstNonBlank(blocker.ID, blockers[index].Ref.ID)
+		blockers[index].Ref.Identifier = firstNonBlank(blocker.Identifier, blockers[index].Ref.Identifier)
+		blockers[index].Ref.State = firstNonBlank(blocker.State, blockers[index].Ref.State)
+	}
+	return blockers
+}
+
+func dependencyBlockersReady(blockers []dependencyBlocker, cfg DependencyAutoUnblockConfig, terminalStates []string) bool {
+	if len(blockers) == 0 {
+		return false
+	}
+	for _, blocker := range blockers {
+		if !dependencyBlockerReady(blocker, cfg, terminalStates) {
+			return false
+		}
+	}
+	return true
+}
+
+func dependencyBlockerReady(blocker dependencyBlocker, cfg DependencyAutoUnblockConfig, terminalStates []string) bool {
+	if blocker.Resolved {
+		if blocker.Issue.Closed || stateIn(blocker.Issue.State, terminalStates) {
+			return true
+		}
+		if cfg.Readiness == DependencyReadinessTerminalOrMerged && pullRequestMerged(blocker.Issue.PullRequest) {
+			return true
+		}
+		return false
+	}
+	if strings.TrimSpace(blocker.Ref.State) == "" {
+		return false
+	}
+	return stateIn(blocker.Ref.State, terminalStates)
+}
+
+func pullRequestMerged(pullRequest *connector.PullRequest) bool {
+	return pullRequest != nil && normalizePullRequestState(pullRequest.State) == "merged"
+}
+
+func (o *Orchestrator) applyDependencyAutoUnblock(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	blockers []dependencyBlocker,
+	targetState string,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("dependency auto-unblock transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
+		}
+		return false
+	}
+
+	body := dependencyAutoUnblockComment(issue.State, targetState, blockers)
+	if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+		o.logger.Warn("dependency auto-unblock comment failed", "issue_id", issueID, "identifier", issue.Identifier, "target_state", targetState, "error", err)
+	}
+
+	delete(state.Blocked, issueID)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "dependency_auto_unblock_transition",
+		Message: "auto-unblocked " + issueLabel(issue) + " from " + issue.State + " to " + targetState,
+	})
+	if o.logger != nil {
+		o.logger.Info("dependency auto-unblock transition", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState)
+	}
+	return true
+}
+
+func dependencyAutoUnblockComment(sourceState string, targetState string, blockers []dependencyBlocker) string {
+	var b strings.Builder
+	b.WriteString("Dependency blockers cleared.")
+	if strings.TrimSpace(sourceState) != "" && strings.TrimSpace(targetState) != "" {
+		b.WriteString(" Moved this issue from ")
+		b.WriteString(strings.TrimSpace(sourceState))
+		b.WriteString(" to ")
+		b.WriteString(strings.TrimSpace(targetState))
+		b.WriteString(".")
+	}
+	b.WriteString("\n\nCleared dependencies:")
+	for _, blocker := range blockers {
+		b.WriteString("\n- ")
+		b.WriteString(dependencyBlockerLabel(blocker))
+		if state := dependencyBlockerState(blocker); state != "" {
+			b.WriteString(" (state: ")
+			b.WriteString(state)
+			b.WriteString(")")
+		}
+		if pullRequest := dependencyBlockerPullRequest(blocker); pullRequest != nil && pullRequestMerged(pullRequest) {
+			b.WriteString(fmt.Sprintf(" (merged PR: #%d)", pullRequest.Number))
+		}
+	}
+	return b.String()
+}
+
+func dependencyBlockerLabel(blocker dependencyBlocker) string {
+	if blocker.Resolved {
+		if identifier := strings.TrimSpace(blocker.Issue.Identifier); identifier != "" {
+			return identifier
+		}
+		if id := strings.TrimSpace(blocker.Issue.ID); id != "" {
+			return id
+		}
+	}
+	if identifier := strings.TrimSpace(blocker.Ref.Identifier); identifier != "" {
+		return identifier
+	}
+	if id := strings.TrimSpace(blocker.Ref.ID); id != "" {
+		return id
+	}
+	return "unknown dependency"
+}
+
+func dependencyBlockerState(blocker dependencyBlocker) string {
+	if blocker.Resolved {
+		return strings.TrimSpace(blocker.Issue.State)
+	}
+	return strings.TrimSpace(blocker.Ref.State)
+}
+
+func dependencyBlockerPullRequest(blocker dependencyBlocker) *connector.PullRequest {
+	if !blocker.Resolved {
+		return nil
+	}
+	return blocker.Issue.PullRequest
+}
+
+func defaultString(value string, fallback string) string {
+	if strings.TrimSpace(value) == "" {
+		return fallback
+	}
+	return value
+}
+
+func defaultStringSlice(values []string, fallback []string) []string {
+	if len(values) == 0 {
+		return append([]string(nil), fallback...)
+	}
+	return append([]string(nil), values...)
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
+}

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -54,6 +55,44 @@ func TestTickAutoUnblocksDependencyWaitingIssue(t *testing.T) {
 	}
 	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "dependency_auto_unblock_transition" {
 		t.Fatalf("RecentEvents = %#v, want dependency auto-unblock event", state.RecentEvents)
+	}
+}
+
+func TestTickAutoUnblocksLightweightDependencyWaitingIssue(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-lightweight-blocked", "Blocked")
+	hydratedWaiting := waiting
+	hydratedWaiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#388"}}
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#388"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues:     []connector.Issue{waiting},
+		hydratedIssues:  []connector.Issue{hydratedWaiting},
+		blockers:        []connector.Issue{blocker},
+		identifierCalls: []string{},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 3, 0, 0, time.UTC))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
+		t.Fatalf("updates = %#v, want lightweight Blocked issue moved to Todo", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one audit comment", tracker.comments)
+	}
+	if !strings.Contains(tracker.comments[0].body, "digitaldrywood/detent#388") {
+		t.Fatalf("comment = %q, want hydrated dependency reference", tracker.comments[0].body)
+	}
+	if got, want := tracker.identifierCalls, []string{waiting.Identifier, "digitaldrywood/detent#388"}; !slices.Equal(got, want) {
+		t.Fatalf("identifier calls = %#v, want %#v", got, want)
 	}
 }
 
@@ -163,10 +202,12 @@ type dependencyAutoUnblockAudit struct {
 }
 
 type dependencyAutoUnblockConnector struct {
-	stateIssues []connector.Issue
-	blockers    []connector.Issue
-	updates     []dependencyAutoUnblockUpdate
-	comments    []dependencyAutoUnblockAudit
+	stateIssues     []connector.Issue
+	hydratedIssues  []connector.Issue
+	blockers        []connector.Issue
+	updates         []dependencyAutoUnblockUpdate
+	comments        []dependencyAutoUnblockAudit
+	identifierCalls []string
 }
 
 func (c *dependencyAutoUnblockConnector) Name() string {
@@ -188,10 +229,12 @@ func (c *dependencyAutoUnblockConnector) FetchIssueStatesByIDs(context.Context, 
 func (c *dependencyAutoUnblockConnector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
 	wanted := make(map[string]struct{}, len(identifiers))
 	for _, identifier := range identifiers {
-		wanted[strings.ToLower(strings.TrimSpace(identifier))] = struct{}{}
+		normalized := strings.ToLower(strings.TrimSpace(identifier))
+		wanted[normalized] = struct{}{}
+		c.identifierCalls = append(c.identifierCalls, normalized)
 	}
-	out := make([]connector.Issue, 0, len(c.blockers))
-	for _, issue := range c.blockers {
+	out := make([]connector.Issue, 0, len(c.hydratedIssues)+len(c.blockers))
+	for _, issue := range append(c.hydratedIssues, c.blockers...) {
 		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
 			out = append(out, cloneIssue(issue))
 		}

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -1,0 +1,218 @@
+package orchestrator
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestTickAutoUnblocksDependencyWaitingIssue(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-blocked", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#388"}}
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#388"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+	now := time.Date(2026, 6, 12, 16, 0, 0, 0, time.UTC)
+
+	orch.tick(context.Background(), &state, now)
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
+		t.Fatalf("updates = %#v, want Blocked issue moved to Todo", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one audit comment", tracker.comments)
+	}
+	for _, want := range []string{
+		"Dependency blockers cleared.",
+		"Blocked to Todo",
+		"digitaldrywood/detent#388",
+		"Done",
+	} {
+		if !strings.Contains(tracker.comments[0].body, want) {
+			t.Fatalf("comment %q missing %q", tracker.comments[0].body, want)
+		}
+	}
+	if _, ok := state.Blocked[waiting.ID]; ok {
+		t.Fatalf("Blocked[%q] present after auto-unblock", waiting.ID)
+	}
+	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "dependency_auto_unblock_transition" {
+		t.Fatalf("RecentEvents = %#v, want dependency auto-unblock event", state.RecentEvents)
+	}
+}
+
+func TestTickLeavesHumanBlockedIssueBlocked(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-human-blocked", "Blocked")
+	waiting.BlockerReason = "Waiting on production credentials"
+	tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{waiting}}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 5, 0, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none", tracker.comments)
+	}
+	blocked, ok := state.Blocked[waiting.ID]
+	if !ok {
+		t.Fatalf("Blocked[%q] missing for human blocker", waiting.ID)
+	}
+	if blocked.Reason != waiting.BlockerReason {
+		t.Fatalf("Blocked reason = %q, want %q", blocked.Reason, waiting.BlockerReason)
+	}
+}
+
+func TestDependencyAutoUnblockDoesNotChangeTodoDependencyGate(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+		DependencyAutoUnblock: DependencyAutoUnblockConfig{
+			Enabled:      true,
+			SourceStates: []string{"Blocked"},
+			TargetState:  "Todo",
+			Readiness:    DependencyReadinessTerminalOrMerged,
+		},
+	})
+	state := newState(cfg)
+	issue := dependencyAutoUnblockIssue("issue-todo", "Todo")
+	issue.BlockedBy = []connector.BlockedRef{{
+		Identifier: "digitaldrywood/detent#388",
+		State:      "In Progress",
+	}}
+
+	planner := newDispatchPlanner(cfg)
+	if _, ok := planner.dispatchAction(&state, issue, time.Date(2026, 6, 12, 16, 10, 0, 0, time.UTC)); ok {
+		t.Fatal("dispatchAction ok = true, want Todo issue blocked by dependency")
+	}
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok {
+		t.Fatalf("Blocked[%q] missing after Todo dependency gate", issue.ID)
+	}
+	if blocked.Source != BlockedSourceDependency {
+		t.Fatalf("Blocked source = %q, want dependency", blocked.Source)
+	}
+}
+
+func dependencyAutoUnblockOrchestrator(
+	tracker *dependencyAutoUnblockConnector,
+	autoUnblock DependencyAutoUnblockConfig,
+) *Orchestrator {
+	cfg := normalizeConfig(Config{
+		PollInterval:               time.Minute,
+		MaxConcurrentAgents:        1,
+		ActiveStates:               []string{"Todo", "In Progress"},
+		TerminalStates:             []string{"Done", "Cancelled"},
+		DependencyAutoUnblock:      autoUnblock,
+		ContinuationRetryDelay:     time.Second,
+		FailureRetryBaseDelay:      time.Second,
+		GitHubGraphQLWarnRemaining: 500,
+	})
+	return &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+}
+
+func dependencyAutoUnblockIssue(id string, state string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/detent#" + strings.TrimPrefix(id, "issue-")
+	issue.Title = "Dependency auto-unblock"
+	issue.State = state
+	return issue
+}
+
+type dependencyAutoUnblockUpdate struct {
+	issueID string
+	state   string
+}
+
+type dependencyAutoUnblockAudit struct {
+	issueID string
+	body    string
+}
+
+type dependencyAutoUnblockConnector struct {
+	stateIssues []connector.Issue
+	blockers    []connector.Issue
+	updates     []dependencyAutoUnblockUpdate
+	comments    []dependencyAutoUnblockAudit
+}
+
+func (c *dependencyAutoUnblockConnector) Name() string {
+	return "dependency-auto-unblock"
+}
+
+func (c *dependencyAutoUnblockConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return []connector.Issue{}, nil
+}
+
+func (c *dependencyAutoUnblockConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	return issuesInStates(c.stateIssues, states), nil
+}
+
+func (c *dependencyAutoUnblockConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return []connector.Issue{}, nil
+}
+
+func (c *dependencyAutoUnblockConnector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
+	wanted := make(map[string]struct{}, len(identifiers))
+	for _, identifier := range identifiers {
+		wanted[strings.ToLower(strings.TrimSpace(identifier))] = struct{}{}
+	}
+	out := make([]connector.Issue, 0, len(c.blockers))
+	for _, issue := range c.blockers {
+		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
+			out = append(out, cloneIssue(issue))
+		}
+	}
+	return out, nil
+}
+
+func (c *dependencyAutoUnblockConnector) CreateComment(_ context.Context, issueID string, body string) error {
+	c.comments = append(c.comments, dependencyAutoUnblockAudit{issueID: issueID, body: body})
+	return nil
+}
+
+func (c *dependencyAutoUnblockConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updates = append(c.updates, dependencyAutoUnblockUpdate{issueID: issueID, state: state})
+	return nil
+}
+
+func (c *dependencyAutoUnblockConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *dependencyAutoUnblockConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -53,6 +53,7 @@ type Config struct {
 	Project                       scheduler.ProjectCandidate
 	Claiming                      ClaimingConfig
 	AutoPromote                   AutoPromoteConfig
+	DependencyAutoUnblock         DependencyAutoUnblockConfig
 	ActiveStates                  []string
 	ObservedStates                []string
 	TerminalStates                []string
@@ -165,6 +166,12 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			OptoutLabel:        cfg.Agent.AutoPromote.OptoutLabel,
 			AllowedIssueLabels: append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
 			Gate:               gate.Effective(cfg.Gate),
+		}),
+		DependencyAutoUnblock: normalizeDependencyAutoUnblockConfig(DependencyAutoUnblockConfig{
+			Enabled:      cfg.Tracker.DependencyAutoUnblock.Enabled,
+			SourceStates: append([]string(nil), cfg.Tracker.DependencyAutoUnblock.SourceStates...),
+			TargetState:  cfg.Tracker.DependencyAutoUnblock.TargetState,
+			Readiness:    cfg.Tracker.DependencyAutoUnblock.Readiness,
 		}),
 		ActiveStates:                  append([]string(nil), cfg.Tracker.ActiveStates...),
 		ObservedStates:                append([]string(nil), cfg.Tracker.ObservedStates...),
@@ -388,8 +395,13 @@ func (o *Orchestrator) ForceQuit(ctx context.Context) error {
 	}
 }
 
-func observedStatusFetchStates() []string {
-	return append([]string{blockedStatusState}, prPipelineFetchStates()...)
+func (o *Orchestrator) observedStatusFetchStates() []string {
+	states := append([]string{blockedStatusState}, prPipelineFetchStates()...)
+	cfg := normalizeDependencyAutoUnblockConfig(o.cfg.DependencyAutoUnblock)
+	if cfg.Enabled {
+		states = append(states, cfg.SourceStates...)
+	}
+	return displayStateNames(states)
 }
 
 func prPipelineFetchStates() []string {
@@ -407,6 +419,43 @@ func prPipelineFetchStates() []string {
 		states = append(states, state)
 	}
 	return states
+}
+
+func displayStateNames(states []string) []string {
+	out := make([]string, 0, len(states))
+	seen := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		key := normalizeState(state)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, displayStateName(state))
+	}
+	return out
+}
+
+func displayStateName(state string) string {
+	state = strings.TrimSpace(state)
+	switch normalizeState(state) {
+	case "blocked":
+		return blockedStatusState
+	case "human review":
+		return autoPromoteSourceState
+	case "merging":
+		return autoPromoteMergingState
+	case "rework":
+		return autoPromoteReworkState
+	case "todo":
+		return "Todo"
+	case "in progress":
+		return "In Progress"
+	default:
+		return state
+	}
 }
 
 func issuesInStates(issues []connector.Issue, states []string) []connector.Issue {
@@ -1501,6 +1550,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
 	cfg.Claiming = normalizeClaimingConfig(cfg.Claiming)
 	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
+	cfg.DependencyAutoUnblock = normalizeDependencyAutoUnblockConfig(cfg.DependencyAutoUnblock)
 	cfg.Authorization.Normalize()
 	cfg.SelectorContext.InstanceLogin = strings.TrimSpace(cfg.SelectorContext.InstanceLogin)
 	cfg.SelectorContext.Persona = strings.TrimSpace(cfg.SelectorContext.Persona)

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -58,6 +58,11 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,
+			o.autoUnblockDependencyIssues(ctx, state, fetched.status, now),
+		)
+		fetched = filterReconciledTickIssues(
+			state,
+			fetched,
 			o.autoPromoteHumanReviewIssues(ctx, state, fetched.status, now),
 		)
 	}
@@ -90,7 +95,7 @@ func (o *Orchestrator) fetchTickIssues(ctx context.Context) (tickFetchedIssues, 
 	fetched := tickFetchedIssues{
 		candidates: cloneIssues(issues),
 	}
-	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, observedStatusFetchStates())
+	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, o.observedStatusFetchStates())
 	if statusErr != nil {
 		o.logger.Warn("fetch observed status issues failed", "error", statusErr)
 		return fetched, true

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -40,14 +40,15 @@ var (
 
 func (s *Server) onboarding(c echo.Context) error {
 	form := templates.OnboardingForm{
-		Step:                  onboardingStepTracker,
-		TrackerKind:           config.TrackerGitHub,
-		WorkspaceRoot:         defaultWorkspaceRoot,
-		MaxConcurrentAgents:   defaultMaxConcurrentAgents,
-		MaxTurns:              defaultMaxTurns,
-		PollingIntervalMS:     defaultPollingIntervalMS,
-		MergingConcurrency:    defaultMergingConcurrency,
-		DispatchPriorityState: defaultDispatchPriorityText,
+		Step:                         onboardingStepTracker,
+		TrackerKind:                  config.TrackerGitHub,
+		WorkspaceRoot:                defaultWorkspaceRoot,
+		MaxConcurrentAgents:          defaultMaxConcurrentAgents,
+		MaxTurns:                     defaultMaxTurns,
+		PollingIntervalMS:            defaultPollingIntervalMS,
+		MergingConcurrency:           defaultMergingConcurrency,
+		DispatchPriorityState:        defaultDispatchPriorityText,
+		DependencyAutoUnblockEnabled: "false",
 	}
 	return render(c, templates.OnboardingPage(s.onboardingData(form, nil, templates.OnboardingResult{})))
 }
@@ -173,17 +174,18 @@ func (s *Server) onboardingData(form templates.OnboardingForm, problems []string
 
 func parseOnboardingForm(c echo.Context) templates.OnboardingForm {
 	return templates.OnboardingForm{
-		TrackerKind:           strings.TrimSpace(c.FormValue("tracker_kind")),
-		Endpoint:              strings.TrimSpace(c.FormValue("endpoint")),
-		APIKey:                strings.TrimSpace(c.FormValue("api_key")),
-		ProjectSlug:           strings.TrimSpace(c.FormValue("project_slug")),
-		Repo:                  strings.TrimSpace(c.FormValue("repo")),
-		WorkspaceRoot:         strings.TrimSpace(c.FormValue("workspace_root")),
-		MaxConcurrentAgents:   strings.TrimSpace(c.FormValue("max_concurrent_agents")),
-		MaxTurns:              strings.TrimSpace(c.FormValue("max_turns")),
-		PollingIntervalMS:     strings.TrimSpace(c.FormValue("polling_interval_ms")),
-		MergingConcurrency:    strings.TrimSpace(c.FormValue("merging_concurrency")),
-		DispatchPriorityState: strings.TrimSpace(c.FormValue("dispatch_priority_by_state")),
+		TrackerKind:                  strings.TrimSpace(c.FormValue("tracker_kind")),
+		Endpoint:                     strings.TrimSpace(c.FormValue("endpoint")),
+		APIKey:                       strings.TrimSpace(c.FormValue("api_key")),
+		ProjectSlug:                  strings.TrimSpace(c.FormValue("project_slug")),
+		Repo:                         strings.TrimSpace(c.FormValue("repo")),
+		WorkspaceRoot:                strings.TrimSpace(c.FormValue("workspace_root")),
+		MaxConcurrentAgents:          strings.TrimSpace(c.FormValue("max_concurrent_agents")),
+		MaxTurns:                     strings.TrimSpace(c.FormValue("max_turns")),
+		PollingIntervalMS:            strings.TrimSpace(c.FormValue("polling_interval_ms")),
+		MergingConcurrency:           strings.TrimSpace(c.FormValue("merging_concurrency")),
+		DispatchPriorityState:        strings.TrimSpace(c.FormValue("dispatch_priority_by_state")),
+		DependencyAutoUnblockEnabled: onboardingBoolValue(c.FormValue("dependency_auto_unblock_enabled")),
 	}
 }
 
@@ -348,6 +350,9 @@ func applyAgentDefaults(form *templates.OnboardingForm) {
 	if form.DispatchPriorityState == "" {
 		form.DispatchPriorityState = defaultDispatchPriorityText
 	}
+	if form.DependencyAutoUnblockEnabled == "" {
+		form.DependencyAutoUnblockEnabled = "false"
+	}
 }
 
 func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
@@ -387,6 +392,11 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	b.WriteString("    Medium: 3\n")
 	b.WriteString("    Low: 4\n")
 	b.WriteString("    No priority: null\n")
+	b.WriteString("  dependency_auto_unblock:\n")
+	writeScalar(&b, "    ", "enabled", form.DependencyAutoUnblockEnabled)
+	writeList(&b, "    ", "source_states", []string{"Blocked"})
+	b.WriteString("    target_state: Todo\n")
+	b.WriteString("    readiness: terminal_or_merged\n")
 	b.WriteString("polling:\n")
 	writeScalar(&b, "  ", "interval_ms", form.PollingIntervalMS)
 	b.WriteString("workspace:\n")
@@ -423,6 +433,13 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	b.WriteString("---\n\n")
 	b.WriteString(renderWorkflowPrompt(form))
 	return b.String()
+}
+
+func onboardingBoolValue(value string) string {
+	if strings.EqualFold(strings.TrimSpace(value), "true") {
+		return "true"
+	}
+	return "false"
 }
 
 func workflowSourceRoot(workflowPath string) string {

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -89,6 +89,7 @@ func TestOnboardingRoutesProgressThroughWizard(t *testing.T) {
 				onboardingStepBadge("agent"),
 				"name=\"max_concurrent_agents\"",
 				"name=\"workspace_root\"",
+				"name=\"dependency_auto_unblock_enabled\"",
 			},
 		},
 		{
@@ -175,6 +176,7 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		"tracker:\n  kind: github",
 		"api_key: $GITHUB_TOKEN",
 		"project_slug: PVT_project",
+		"dependency_auto_unblock:\n    enabled: false\n    source_states:\n      - Blocked\n    target_state: Todo\n    readiness: terminal_or_merged",
 		"source_root: " + sourceRoot,
 		"codex:\n  command: codex app-server",
 		"gate:\n  kind: command\n  run: make check",
@@ -196,6 +198,34 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		if strings.Contains(content, unwanted) {
 			t.Fatalf("workflow contains %q:\n%s", unwanted, content)
 		}
+	}
+}
+
+func TestOnboardingWriteWorkflowCanEnableDependencyAutoUnblock(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	server, err := web.NewServer(web.Config{WorkflowPath: workflowPath}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := validOnboardingForm()
+	form.Set("dependency_auto_unblock_enabled", "true")
+	rec := httptest.NewRecorder()
+	req := onboardingRequest(http.MethodPost, "/onboarding/write", form)
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	raw, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if !strings.Contains(string(raw), "dependency_auto_unblock:\n    enabled: true") {
+		t.Fatalf("workflow missing enabled dependency auto-unblock:\n%s", raw)
 	}
 }
 
@@ -362,17 +392,18 @@ func TestOnboardingWriteValidatesInput(t *testing.T) {
 
 func validOnboardingForm() url.Values {
 	return url.Values{
-		"tracker_kind":               {"github"},
-		"endpoint":                   {"https://api.github.com/graphql"},
-		"api_key":                    {"$GITHUB_TOKEN"},
-		"project_slug":               {"PVT_project"},
-		"repo":                       {"digitaldrywood/detent"},
-		"workspace_root":             {"~/code/detent-workspaces"},
-		"max_concurrent_agents":      {"5"},
-		"max_turns":                  {"20"},
-		"polling_interval_ms":        {"120000"},
-		"merging_concurrency":        {"1"},
-		"dispatch_priority_by_state": {"Merging\nRework"},
+		"tracker_kind":                    {"github"},
+		"endpoint":                        {"https://api.github.com/graphql"},
+		"api_key":                         {"$GITHUB_TOKEN"},
+		"project_slug":                    {"PVT_project"},
+		"repo":                            {"digitaldrywood/detent"},
+		"workspace_root":                  {"~/code/detent-workspaces"},
+		"max_concurrent_agents":           {"5"},
+		"max_turns":                       {"20"},
+		"polling_interval_ms":             {"120000"},
+		"merging_concurrency":             {"1"},
+		"dispatch_priority_by_state":      {"Merging\nRework"},
+		"dependency_auto_unblock_enabled": {"false"},
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1298,6 +1298,8 @@ func TestSettingsRendersConfigProjectsAndRuntimePaths(t *testing.T) {
 		"paused true",
 		"github",
 		projectURL,
+		"Dependency auto-unblock",
+		"enabled: Blocked, Waiting -&gt; Todo when terminal_or_merged",
 		dbPath,
 		logPath,
 		"127.0.0.1:4101",
@@ -2675,6 +2677,10 @@ func newSettingsTestProject(t *testing.T, cfg globalconfig.Project, worktreeRoot
 	workflowCfg.Tracker.Endpoint = "https://api.github.com/graphql"
 	workflowCfg.Tracker.APIKey = "$GITHUB_TOKEN"
 	workflowCfg.Tracker.ProjectSlug = projectURL
+	workflowCfg.Tracker.DependencyAutoUnblock.Enabled = true
+	workflowCfg.Tracker.DependencyAutoUnblock.SourceStates = []string{"Blocked", "Waiting"}
+	workflowCfg.Tracker.DependencyAutoUnblock.TargetState = "Todo"
+	workflowCfg.Tracker.DependencyAutoUnblock.Readiness = workflowconfig.DependencyReadinessTerminalOrMerged
 	workflowCfg.Workspace.Root = worktreeRoot
 	workflowCfg.Workspace.SourceRoot = cfg.Workdir
 

--- a/internal/web/settings.go
+++ b/internal/web/settings.go
@@ -50,15 +50,16 @@ func settingsProjects(registry *project.Registry) []templates.SettingsProject {
 		cfg := trackedProject.Config()
 		workflow := trackedProject.Workflow().Config
 		out = append(out, templates.SettingsProject{
-			ID:             string(trackedProject.ID()),
-			WorkflowPath:   cfg.Workflow,
-			Workdir:        cfg.Workdir,
-			WorktreeRoot:   workflow.Workspace.Root,
-			Weight:         cfg.Weight,
-			Priority:       cfg.Priority,
-			Paused:         cfg.Paused,
-			TrackerKind:    trackerKind(workflow),
-			TrackerProject: trackerProject(workflow),
+			ID:                    string(trackedProject.ID()),
+			WorkflowPath:          cfg.Workflow,
+			Workdir:               cfg.Workdir,
+			WorktreeRoot:          workflow.Workspace.Root,
+			Weight:                cfg.Weight,
+			Priority:              cfg.Priority,
+			Paused:                cfg.Paused,
+			TrackerKind:           trackerKind(workflow),
+			TrackerProject:        trackerProject(workflow),
+			DependencyAutoUnblock: dependencyAutoUnblockPolicy(workflow),
 		})
 	}
 	return out
@@ -73,4 +74,25 @@ func trackerKind(cfg workflowconfig.Config) string {
 
 func trackerProject(cfg workflowconfig.Config) string {
 	return strings.TrimSpace(cfg.Tracker.ProjectSlug)
+}
+
+func dependencyAutoUnblockPolicy(cfg workflowconfig.Config) string {
+	policy := cfg.Tracker.DependencyAutoUnblock
+	status := "disabled"
+	if policy.Enabled {
+		status = "enabled"
+	}
+	sourceStates := strings.Join(policy.SourceStates, ", ")
+	if strings.TrimSpace(sourceStates) == "" {
+		sourceStates = "n/a"
+	}
+	targetState := strings.TrimSpace(policy.TargetState)
+	if targetState == "" {
+		targetState = "n/a"
+	}
+	readiness := strings.TrimSpace(policy.Readiness)
+	if readiness == "" {
+		readiness = workflowconfig.DependencyReadinessTerminalOrMerged
+	}
+	return status + ": " + sourceStates + " -> " + targetState + " when " + readiness
 }

--- a/internal/web/templates/onboarding.templ
+++ b/internal/web/templates/onboarding.templ
@@ -30,6 +30,7 @@ type OnboardingForm struct {
 	PollingIntervalMS     string
 	MergingConcurrency    string
 	DispatchPriorityState string
+	DependencyAutoUnblockEnabled string
 }
 
 type OnboardingResult struct {
@@ -242,6 +243,13 @@ templ agentStep(data OnboardingData) {
 				<span class="text-sm font-medium">Dispatch priority by state</span>
 				<textarea class={ fieldClass() + " min-h-24" } name="dispatch_priority_by_state">{ data.Form.DispatchPriorityState }</textarea>
 			</label>
+			<label class="flex items-start gap-3 rounded-md border border-border p-3 sm:col-span-2">
+				<input class="mt-1" type="checkbox" name="dependency_auto_unblock_enabled" value="true" checked?={ data.Form.DependencyAutoUnblockEnabled == "true" }/>
+				<span>
+					<span class="block text-sm font-semibold text-foreground">Dependency auto-unblock</span>
+					<span class="block text-sm text-muted-foreground">Move dependency-waiting Blocked issues back to Todo when blockers clear.</span>
+				</span>
+			</label>
 			<div class="flex flex-wrap gap-2 pt-2 sm:col-span-2">
 				<button class={ buttonClass() } type="submit">Continue</button>
 				<button class={ secondaryButtonClass() } type="submit" hx-post="/onboarding/credentials">Back</button>
@@ -316,4 +324,5 @@ templ hiddenAgent(form OnboardingForm) {
 	<input type="hidden" name="polling_interval_ms" value={ form.PollingIntervalMS }/>
 	<input type="hidden" name="merging_concurrency" value={ form.MergingConcurrency }/>
 	<input type="hidden" name="dispatch_priority_by_state" value={ form.DispatchPriorityState }/>
+	<input type="hidden" name="dependency_auto_unblock_enabled" value={ form.DependencyAutoUnblockEnabled }/>
 }

--- a/internal/web/templates/onboarding_templ.go
+++ b/internal/web/templates/onboarding_templ.go
@@ -26,18 +26,19 @@ type PollingData struct {
 }
 
 type OnboardingForm struct {
-	Step                  string
-	TrackerKind           string
-	Endpoint              string
-	APIKey                string
-	ProjectSlug           string
-	Repo                  string
-	WorkspaceRoot         string
-	MaxConcurrentAgents   string
-	MaxTurns              string
-	PollingIntervalMS     string
-	MergingConcurrency    string
-	DispatchPriorityState string
+	Step                         string
+	TrackerKind                  string
+	Endpoint                     string
+	APIKey                       string
+	ProjectSlug                  string
+	Repo                         string
+	WorkspaceRoot                string
+	MaxConcurrentAgents          string
+	MaxTurns                     string
+	PollingIntervalMS            string
+	MergingConcurrency           string
+	DispatchPriorityState        string
+	DependencyAutoUnblockEnabled string
 }
 
 type OnboardingResult struct {
@@ -108,7 +109,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(applicationName(data.ApplicationName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 81, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 82, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -121,7 +122,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 82, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 83, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -134,7 +135,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(faviconPath(data.Assets))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 83, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 84, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -147,7 +148,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var5 templ.SafeURL
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(stylesheetPath(data.Assets))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 84, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 85, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -236,7 +237,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var9 string
 			templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(item.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 107, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 108, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 			if templ_7745c5c3_Err != nil {
@@ -272,7 +273,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 				var templ_7745c5c3_Var10 string
 				templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(problem)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 117, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 118, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 				if templ_7745c5c3_Err != nil {
@@ -350,7 +351,7 @@ func onboardingStepBadge(step string) templ.Component {
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(step)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 139, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 140, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
@@ -455,7 +456,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 158, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 159, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -478,7 +479,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var18 string
 		templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 160, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 161, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 		if templ_7745c5c3_Err != nil {
@@ -491,7 +492,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var19 string
 		templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 161, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 162, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 		if templ_7745c5c3_Err != nil {
@@ -569,7 +570,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var23 string
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Endpoint)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 176, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 177, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -604,7 +605,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var26 string
 			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.APIKey)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 180, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 181, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 			if templ_7745c5c3_Err != nil {
@@ -731,7 +732,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 201, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 202, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
@@ -766,7 +767,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var37 string
 			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 205, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 206, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 			if templ_7745c5c3_Err != nil {
@@ -887,7 +888,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var45 string
 		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 223, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 224, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 		if templ_7745c5c3_Err != nil {
@@ -922,7 +923,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var48 string
 		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 227, Col: 122}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 228, Col: 122}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 		if templ_7745c5c3_Err != nil {
@@ -957,7 +958,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var51 string
 		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxTurns)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 231, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 232, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 		if templ_7745c5c3_Err != nil {
@@ -992,7 +993,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var54 string
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(data.Polling.MinIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 235, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 236, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
@@ -1005,7 +1006,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.PollingIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 235, Col: 145}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 236, Col: 145}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
@@ -1040,7 +1041,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var58 string
 		templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MergingConcurrency)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 239, Col: 119}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 240, Col: 119}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 		if templ_7745c5c3_Err != nil {
@@ -1075,13 +1076,23 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var61 string
 		templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.DispatchPriorityState)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 243, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 244, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</textarea></label><div class=\"flex flex-wrap gap-2 pt-2 sm:col-span-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</textarea></label> <label class=\"flex items-start gap-3 rounded-md border border-border p-3 sm:col-span-2\"><input class=\"mt-1\" type=\"checkbox\" name=\"dependency_auto_unblock_enabled\" value=\"true\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if data.Form.DependencyAutoUnblockEnabled == "true" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, " checked")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "> <span><span class=\"block text-sm font-semibold text-foreground\">Dependency auto-unblock</span> <span class=\"block text-sm text-muted-foreground\">Move dependency-waiting Blocked issues back to Todo when blockers clear.</span></span></label><div class=\"flex flex-wrap gap-2 pt-2 sm:col-span-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1090,7 +1101,7 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<button class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<button class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1103,7 +1114,7 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" type=\"submit\">Continue</button> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\" type=\"submit\">Continue</button> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1112,7 +1123,7 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "<button class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<button class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1125,7 +1136,7 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "\" type=\"submit\" hx-post=\"/onboarding/credentials\">Back</button></div></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "\" type=\"submit\" hx-post=\"/onboarding/credentials\">Back</button></div></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1154,53 +1165,34 @@ func writeStep(data OnboardingData) templ.Component {
 			templ_7745c5c3_Var66 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<div class=\"rounded-md border border-border bg-card p-5\"><h2 class=\"text-xl font-semibold\">Write WORKFLOW.md</h2><div class=\"mt-4 grid gap-3 text-sm text-muted-foreground sm:grid-cols-2\"><p><span class=\"font-medium text-foreground\">Tracker:</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<div class=\"rounded-md border border-border bg-card p-5\"><h2 class=\"text-xl font-semibold\">Write WORKFLOW.md</h2><div class=\"mt-4 grid gap-3 text-sm text-muted-foreground sm:grid-cols-2\"><p><span class=\"font-medium text-foreground\">Tracker:</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var67 string
 		templ_7745c5c3_Var67, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 257, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 265, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var67))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</p>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</p>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if data.Form.ProjectSlug != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<p><span class=\"font-medium text-foreground\">ProjectV2:</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "<p><span class=\"font-medium text-foreground\">ProjectV2:</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var68 string
 			templ_7745c5c3_Var68, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 259, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 267, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var68))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</p>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		}
-		if data.Form.Repo != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "<p><span class=\"font-medium text-foreground\">Repo:</span> ")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var69 string
-			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 262, Col: 78}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1209,20 +1201,39 @@ func writeStep(data OnboardingData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<p><span class=\"font-medium text-foreground\">Output:</span> ")
+		if data.Form.Repo != "" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "<p><span class=\"font-medium text-foreground\">Repo:</span> ")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var69 string
+			templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 270, Col: 78}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</p>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<p><span class=\"font-medium text-foreground\">Output:</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var70 string
 		templ_7745c5c3_Var70, templ_7745c5c3_Err = templ.JoinStringErrs(data.WorkflowPath)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 264, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 272, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var70))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</p></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</p></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1230,7 +1241,7 @@ func writeStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<form class=\"mt-5 flex flex-wrap gap-2\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<form class=\"mt-5 flex flex-wrap gap-2\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1243,7 +1254,7 @@ func writeStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "<button class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<button class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1256,7 +1267,7 @@ func writeStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "\" type=\"submit\">Write WORKFLOW.md</button></form></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\" type=\"submit\">Write WORKFLOW.md</button></form></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1286,38 +1297,38 @@ func resultPanel(data OnboardingData) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if data.Result.Kind == "success" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<div class=\"mt-4 rounded-md border border-success bg-card p-4 text-sm text-success\"><strong>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<div class=\"mt-4 rounded-md border border-success bg-card p-4 text-sm text-success\"><strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var74 string
 			templ_7745c5c3_Var74, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 277, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 285, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var74))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "</strong></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "</strong></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else if data.Result.Kind == "exists" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<div class=\"mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning\"><p><strong>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "<div class=\"mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning\"><p><strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var75 string
 			templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 281, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 289, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "</strong></p><form class=\"mt-3\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "</strong></p><form class=\"mt-3\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1325,7 +1336,7 @@ func resultPanel(data OnboardingData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "<input type=\"hidden\" name=\"replace\" value=\"true\"> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "<input type=\"hidden\" name=\"replace\" value=\"true\"> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1334,7 +1345,7 @@ func resultPanel(data OnboardingData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "<button class=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "<button class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1347,25 +1358,25 @@ func resultPanel(data OnboardingData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "\" type=\"submit\">Overwrite</button></form></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "\" type=\"submit\">Overwrite</button></form></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else if data.Result.Kind == "error" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "<div class=\"mt-4 rounded-md border border-danger bg-card p-4 text-sm text-danger\"><strong>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "<div class=\"mt-4 rounded-md border border-danger bg-card p-4 text-sm text-danger\"><strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var78 string
 			templ_7745c5c3_Var78, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 290, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 298, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var78))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "</strong></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "</strong></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -1395,20 +1406,20 @@ func hiddenTracker(form OnboardingForm) templ.Component {
 			templ_7745c5c3_Var79 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "<input type=\"hidden\" name=\"tracker_kind\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "<input type=\"hidden\" name=\"tracker_kind\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var80 string
 		templ_7745c5c3_Var80, templ_7745c5c3_Err = templ.JoinStringErrs(form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 296, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 304, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var80))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 105, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1441,33 +1452,33 @@ func hiddenCredentials(form OnboardingForm) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 106, "<input type=\"hidden\" name=\"endpoint\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "<input type=\"hidden\" name=\"endpoint\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var82 string
 		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(form.Endpoint)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 301, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 309, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 107, "\"> <input type=\"hidden\" name=\"api_key\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "\"> <input type=\"hidden\" name=\"api_key\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var83 string
 		templ_7745c5c3_Var83, templ_7745c5c3_Err = templ.JoinStringErrs(form.APIKey)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 302, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 310, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var83))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 108, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1500,33 +1511,33 @@ func hiddenProject(form OnboardingForm) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 109, "<input type=\"hidden\" name=\"project_slug\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "<input type=\"hidden\" name=\"project_slug\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var85 string
 		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(form.ProjectSlug)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 307, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 315, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 110, "\"> <input type=\"hidden\" name=\"repo\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "\"> <input type=\"hidden\" name=\"repo\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var86 string
 		templ_7745c5c3_Var86, templ_7745c5c3_Err = templ.JoinStringErrs(form.Repo)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 308, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 316, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var86))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 111, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1559,85 +1570,98 @@ func hiddenAgent(form OnboardingForm) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 112, "<input type=\"hidden\" name=\"workspace_root\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "<input type=\"hidden\" name=\"workspace_root\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var88 string
 		templ_7745c5c3_Var88, templ_7745c5c3_Err = templ.JoinStringErrs(form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 313, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 321, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var88))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "\"> <input type=\"hidden\" name=\"max_concurrent_agents\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "\"> <input type=\"hidden\" name=\"max_concurrent_agents\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var89 string
 		templ_7745c5c3_Var89, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 314, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 322, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var89))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 114, "\"> <input type=\"hidden\" name=\"max_turns\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, "\"> <input type=\"hidden\" name=\"max_turns\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var90 string
 		templ_7745c5c3_Var90, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxTurns)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 315, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 323, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var90))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 115, "\"> <input type=\"hidden\" name=\"polling_interval_ms\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "\"> <input type=\"hidden\" name=\"polling_interval_ms\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var91 string
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(form.PollingIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 316, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 324, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 116, "\"> <input type=\"hidden\" name=\"merging_concurrency\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "\"> <input type=\"hidden\" name=\"merging_concurrency\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var92 string
 		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(form.MergingConcurrency)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 317, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 325, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 117, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_state\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 119, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_state\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var93 string
 		templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityState)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 318, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 326, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 118, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 120, "\"> <input type=\"hidden\" name=\"dependency_auto_unblock_enabled\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var94 string
+		templ_7745c5c3_Var94, templ_7745c5c3_Err = templ.JoinStringErrs(form.DependencyAutoUnblockEnabled)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 327, Col: 102}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var94))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 121, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/settings.templ
+++ b/internal/web/templates/settings.templ
@@ -91,6 +91,7 @@ templ Settings(data SettingsData) {
 											@settingsPathRow("Worktree root", project.WorktreeRoot)
 											@settingsValueRow("Tracker kind", settingsText(project.TrackerKind))
 											@settingsPathRow("Project URL", project.TrackerProject)
+											@settingsValueRow("Dependency auto-unblock", settingsText(project.DependencyAutoUnblock))
 										</div>
 									</article>
 								}

--- a/internal/web/templates/settings_data.go
+++ b/internal/web/templates/settings_data.go
@@ -19,15 +19,16 @@ type SettingsGlobal struct {
 }
 
 type SettingsProject struct {
-	ID             string
-	WorkflowPath   string
-	Workdir        string
-	WorktreeRoot   string
-	Weight         int
-	Priority       int
-	Paused         bool
-	TrackerKind    string
-	TrackerProject string
+	ID                    string
+	WorkflowPath          string
+	Workdir               string
+	WorktreeRoot          string
+	Weight                int
+	Priority              int
+	Paused                bool
+	TrackerKind           string
+	TrackerProject        string
+	DependencyAutoUnblock string
 }
 
 type SettingsRuntime struct {

--- a/internal/web/templates/settings_templ.go
+++ b/internal/web/templates/settings_templ.go
@@ -284,6 +284,10 @@ func Settings(data SettingsData) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
+				templ_7745c5c3_Err = settingsValueRow("Dependency auto-unblock", settingsText(project.DependencyAutoUnblock)).Render(ctx, templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
 				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div></article>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
@@ -359,7 +363,7 @@ func dashboardTopbarBrand(instanceName string) templ.Component {
 			var templ_7745c5c3_Var15 string
 			templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(instanceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 122, Col: 188}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 123, Col: 188}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 			if templ_7745c5c3_Err != nil {
@@ -406,7 +410,7 @@ func dashboardPageHeading(title string) templ.Component {
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 128, Col: 28}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 129, Col: 28}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
@@ -519,7 +523,7 @@ func dashboardNavItem(active string, id string, href string, label string) templ
 			var templ_7745c5c3_Var21 templ.SafeURL
 			templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinURLErrs(href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 144, Col: 221}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 145, Col: 221}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 			if templ_7745c5c3_Err != nil {
@@ -532,7 +536,7 @@ func dashboardNavItem(active string, id string, href string, label string) templ
 			var templ_7745c5c3_Var22 string
 			templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 144, Col: 251}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 145, Col: 251}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 			if templ_7745c5c3_Err != nil {
@@ -550,7 +554,7 @@ func dashboardNavItem(active string, id string, href string, label string) templ
 			var templ_7745c5c3_Var23 templ.SafeURL
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinURLErrs(href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 146, Col: 207}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 147, Col: 207}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -563,7 +567,7 @@ func dashboardNavItem(active string, id string, href string, label string) templ
 			var templ_7745c5c3_Var24 string
 			templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 146, Col: 217}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 147, Col: 217}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 			if templ_7745c5c3_Err != nil {
@@ -606,7 +610,7 @@ func settingsPathRow(label string, value string) templ.Component {
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 152, Col: 75}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 153, Col: 75}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -619,7 +623,7 @@ func settingsPathRow(label string, value string) templ.Component {
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(settingsText(value))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 153, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 154, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -671,7 +675,7 @@ func settingsValueRow(label string, value string) templ.Component {
 		var templ_7745c5c3_Var29 string
 		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 162, Col: 75}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 163, Col: 75}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
@@ -684,7 +688,7 @@ func settingsValueRow(label string, value string) templ.Component {
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(settingsText(value))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 163, Col: 89}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 164, Col: 89}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
@@ -726,7 +730,7 @@ func settingsCopyButton(label string, value string) templ.Component {
 		var templ_7745c5c3_Var32 string
 		templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 172, Col: 19}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 173, Col: 19}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
 		if templ_7745c5c3_Err != nil {
@@ -739,7 +743,7 @@ func settingsCopyButton(label string, value string) templ.Component {
 		var templ_7745c5c3_Var33 string
 		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs("Copy " + label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 173, Col: 25}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 174, Col: 25}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
 		if templ_7745c5c3_Err != nil {
@@ -752,7 +756,7 @@ func settingsCopyButton(label string, value string) templ.Component {
 		var templ_7745c5c3_Var34 string
 		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs("Copy " + label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 174, Col: 30}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/settings.templ`, Line: 175, Col: 30}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 		if templ_7745c5c3_Err != nil {


### PR DESCRIPTION
## Summary
- add disabled-by-default tracker dependency auto-unblock config and runtime transition pass
- hydrate dependency blockers from ProjectV2 status, closed issues, and merged linked PRs before moving waiting issues to the ready state
- expose the policy in onboarding/settings and document both dependency workflows

Fixes #389

## Test Plan
- go test ./internal/config ./internal/connector/github ./internal/orchestrator ./internal/web
- go test ./...
- make check