### PR TITLE
docs(onboarding): add reconfiguration closeout

### DIFF
--- a/README.md
+++ b/README.md
@@ -395,8 +395,12 @@ port: 4000
 
 `detent doctor` is a preflight check: config resolution, the SQLite database,
 the `codex` binary, the GitHub token and scopes, the git binary, and whether the
-server port is free. Fix any `FAIL` before starting (missing `github_token: gh`
-or an unauthenticated `codex` are the usual culprits).
+server port is free. Before starting Detent, fix any `FAIL` (missing
+`github_token: gh` or an unauthenticated `codex` are the usual culprits). If
+Detent is already running on the configured port, the server-port check can fail
+because the live service owns the port; use `detent doctor --port 0` for the
+same config, toolchain, token, and database preflight without the port
+collision, then verify the live service with `/health`.
 
 6. Start Detent:
 
@@ -531,8 +535,15 @@ repo is a real, working instance of this setup to copy from.
    detent doctor
    ```
 
-   Every check must pass (the server-port check may fail if Detent is already
-   running — that is expected).
+   Every check must pass before starting Detent. If Detent is already running on
+   the configured port, the server-port check may fail because the live service
+   owns the port. In that case, validate the rest of the setup without the port
+   collision, then verify the running service:
+
+   ```sh
+   detent doctor --port 0
+   curl -fsS http://127.0.0.1:4000/health | jq -e '.status == "ok" and .mode == "running"'
+   ```
 
 9. **Start Detent and confirm the dashboard:**
 
@@ -641,11 +652,16 @@ the wait should be visible on the board.
 
 Before you dispatch anything, run **`detent doctor`** — it checks config
 resolution, the database, the `codex` binary, your GitHub token and scopes, git,
-and the server port. A clean `doctor` clears Detent's direct preflight. If
-Detent runs under a systemd user service, also verify the service PATH resolves
-every command used by project hooks and validation gates; `doctor` checks
-Detent's direct dependencies, not repo-specific bootstrap tools. The onboarding
-runbook includes the service-context check.
+and the server port. A clean pre-start `doctor` clears Detent's direct
+preflight. When a running Detent process already owns the configured port,
+`detent doctor --port 0` validates the config, database, tools, and token
+without treating the live listener as a blocker; pair it with `/health` on the
+actual service before dispatching more work. Do not dispatch from a failed
+doctor run unless the only failure is that expected live-port collision and
+`/health` is green. If Detent runs under a systemd user service, also verify the
+service PATH resolves every command used by project hooks and validation gates;
+`doctor` checks Detent's direct dependencies, not repo-specific bootstrap tools.
+The onboarding runbook includes the service-context check.
 
 ### Merge Train
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1040,6 +1040,46 @@ recommendation, and default-if-silent. Record answers in
      --jq '.[] | select(.body | startswith("## Codex Workpad")) | .html_url' | rg .
    ```
 
+## Reconfiguration Closeout
+
+Use this checklist after editing an existing Detent setup, especially after
+changing `global.yaml` or `WORKFLOW.md`.
+
+1. **Verify the binary you are about to run.** After pulling, rebuilding, or
+   installing updates, confirm the expected version, commit, and build date:
+
+   ```sh
+   detent version
+   ```
+
+2. **Run the preflight again.** `detent doctor` should pass before starting a
+   stopped instance because Phase 5 expects the configured server port to be
+   free:
+
+   ```sh
+   detent doctor
+   ```
+
+   If Detent is already running on the configured port, the server-port check
+   can fail because the live service owns that port. In that case, rerun the
+   config, toolchain, token, and database preflight with an ephemeral port, then
+   verify the live service separately:
+
+   ```sh
+   detent doctor --port 0
+   curl -fsS http://<dashboard-check-host>:<port>/health | jq -e '.status == "ok" and .mode == "running"'
+   ```
+
+3. **Reload the runtime that needs the change.** Restart Detent, reload the
+   user service, or rely on the documented hot-reload path only for settings
+   Detent reconciles while running. When in doubt, restart before dispatching
+   more work.
+
+4. **Hold dispatch on failed preflight.** Do not move new work to `Todo` from a
+   failed `detent doctor` run unless the only failure is the expected live-port
+   collision, `detent doctor --port 0` passes, and `/health` is green for the
+   running service.
+
 ## Appendix
 
 ### Interview Answers To Config Keys


### PR DESCRIPTION
## Summary

- add an onboarding reconfiguration closeout checklist covering doctor, live-port collisions, --port 0, /health, version verification, and runtime reload
- clarify README setup guidance for pre-start doctor runs versus validating an already-running service

Fixes #393

## Test Plan

- [x] `make check`