### PR TITLE
fix(github): attach linked pull requests

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -92,7 +92,7 @@ query DetentGitHubObservedStatusProjectItems(
               stateReason
               url
               repository { nameWithOwner }
-              closedByPullRequestsReferences(first: 5) { nodes { number url state } }
+              closedByPullRequestsReferences(first: 5) { nodes { number url state repository { nameWithOwner } } }
             }
           }
           statusValue: fieldValueByName(name: "Status") {
@@ -265,7 +265,7 @@ fragment DetentGitHubIssueParent on Issue {
   assignees(first: 100) { nodes { id login } }
   labels(first: 20) { nodes { name } }
   repository { nameWithOwner }
-  closedByPullRequestsReferences(first: 5) { nodes { number url } }
+  closedByPullRequestsReferences(first: 5) { nodes { number url state repository { nameWithOwner } } }
   subIssues(first: $linkedIssuesFirst) {
     pageInfo { hasNextPage endCursor }
     nodes {
@@ -575,9 +575,10 @@ type issueComment struct {
 }
 
 type pullRequest struct {
-	Number int    `json:"number"`
-	URL    string `json:"url"`
-	State  string `json:"state"`
+	Number     int        `json:"number"`
+	URL        string     `json:"url"`
+	State      string     `json:"state"`
+	Repository repository `json:"repository"`
 }
 
 type pullRequestNode struct {
@@ -1344,6 +1345,12 @@ type issuePullRequestCandidate struct {
 	Index             int
 	BranchPrefix      string
 	PullRequestNumber int
+	PullRequestRepo   pullRequestRepo
+}
+
+type pullRequestKey struct {
+	Repo   pullRequestRepo
+	Number int
 }
 
 type pullRequestRepo struct {
@@ -1360,8 +1367,12 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 		}
 		branchPrefix := detentIssueBranchPrefix(issue.Identifier)
 		pullRequestNumber := 0
+		linkedPullRequestRepo := repo
 		if issue.PRNumber != nil {
 			pullRequestNumber = *issue.PRNumber
+		}
+		if owner, name, ok := splitRepositoryName(issue.PRRepository); ok {
+			linkedPullRequestRepo = pullRequestRepo{Owner: owner, Name: name}
 		}
 		if branchPrefix == "" && pullRequestNumber <= 0 {
 			continue
@@ -1370,6 +1381,7 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 			Index:             index,
 			BranchPrefix:      branchPrefix,
 			PullRequestNumber: pullRequestNumber,
+			PullRequestRepo:   linkedPullRequestRepo,
 		})
 	}
 	if len(byRepo) == 0 {
@@ -1442,12 +1454,13 @@ func (c *Connector) attachPullRequestMergeStates(ctx context.Context, issues []c
 		if err != nil {
 			return err
 		}
-		attachMatchingPullRequestMergeStates(issues, byRepo[repo], pullRequests)
+		attachMatchingPullRequestMergeStates(repo, issues, byRepo[repo], pullRequests)
 	}
 	return nil
 }
 
 func attachMatchingPullRequestMergeStates(
+	repo pullRequestRepo,
 	issues []connector.Issue,
 	candidates []issuePullRequestCandidate,
 	pullRequests []pullRequestNode,
@@ -1476,6 +1489,9 @@ func attachMatchingPullRequestMergeStates(
 			if issues[candidate.Index].PRNumber == nil && pullRequest.Number > 0 {
 				number := pullRequest.Number
 				issues[candidate.Index].PRNumber = &number
+			}
+			if issues[candidate.Index].PRRepository == "" {
+				issues[candidate.Index].PRRepository = pullRequestRepoName(repo)
 			}
 		}
 	}
@@ -1526,24 +1542,29 @@ func (c *Connector) attachLinkedPullRequests(
 	issues []connector.Issue,
 	candidates []issuePullRequestCandidate,
 ) error {
-	pullRequests := map[int]pullRequestNode{}
+	pullRequests := map[pullRequestKey]pullRequestNode{}
 	for _, candidate := range candidates {
 		if issues[candidate.Index].PullRequest != nil || candidate.PullRequestNumber <= 0 {
 			continue
 		}
-		pullRequest, ok := pullRequests[candidate.PullRequestNumber]
+		pullRequestRepo := candidate.PullRequestRepo
+		if strings.TrimSpace(pullRequestRepo.Owner) == "" || strings.TrimSpace(pullRequestRepo.Name) == "" {
+			pullRequestRepo = repo
+		}
+		key := pullRequestKey{Repo: pullRequestRepo, Number: candidate.PullRequestNumber}
+		pullRequest, ok := pullRequests[key]
 		if !ok {
 			var err error
-			pullRequest, err = c.fetchRepositoryPullRequest(ctx, repo, candidate.PullRequestNumber)
+			pullRequest, err = c.fetchRepositoryPullRequest(ctx, pullRequestRepo, candidate.PullRequestNumber)
 			if err != nil {
 				return err
 			}
-			if err := c.populatePullRequestStatus(ctx, repo, &pullRequest); err != nil {
+			if err := c.populatePullRequestStatus(ctx, pullRequestRepo, &pullRequest); err != nil {
 				return err
 			}
-			pullRequests[candidate.PullRequestNumber] = pullRequest
+			pullRequests[key] = pullRequest
 		}
-		attachPullRequestToIssue(&issues[candidate.Index], pullRequest)
+		attachPullRequestToIssue(&issues[candidate.Index], pullRequestRepo, pullRequest)
 	}
 	return nil
 }
@@ -1571,7 +1592,7 @@ func (c *Connector) attachMatchingPullRequests(
 			if err := c.populatePullRequestStatus(ctx, repo, &pullRequest); err != nil {
 				return err
 			}
-			attachPullRequestToIssue(&issues[candidate.Index], pullRequest)
+			attachPullRequestToIssue(&issues[candidate.Index], repo, pullRequest)
 		}
 	}
 	return nil
@@ -1596,7 +1617,7 @@ func pullRequestNodeFromREST(pullRequest restPullRequest) pullRequestNode {
 	}
 }
 
-func attachPullRequestToIssue(issue *connector.Issue, pullRequest pullRequestNode) {
+func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pullRequest pullRequestNode) {
 	issue.PullRequest = &connector.PullRequest{
 		Number:                 pullRequest.Number,
 		URL:                    strings.TrimSpace(pullRequest.URL),
@@ -1611,6 +1632,18 @@ func attachPullRequestToIssue(issue *connector.Issue, pullRequest pullRequestNod
 		number := pullRequest.Number
 		issue.PRNumber = &number
 	}
+	if issue.PRRepository == "" {
+		issue.PRRepository = pullRequestRepoName(repo)
+	}
+}
+
+func pullRequestRepoName(repo pullRequestRepo) string {
+	owner := strings.TrimSpace(repo.Owner)
+	name := strings.TrimSpace(repo.Name)
+	if owner == "" || name == "" {
+		return ""
+	}
+	return owner + "/" + name
 }
 
 func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode) error {
@@ -1941,6 +1974,17 @@ func (c *Connector) fetchProjectFieldsPage(ctx context.Context, issueID string, 
 
 func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorityName string, statusUpdatedAt *time.Time, fields map[string]string) connector.Issue {
 	repo := strings.TrimSpace(issue.Repository.NameWithOwner)
+	pullRequestRef, hasPullRequestRef := firstPullRequestReference(issue.ClosedByPullRequestsReferences)
+	var pullRequestNumber *int
+	var pullRequestRepository string
+	if hasPullRequestRef {
+		number := pullRequestRef.Number
+		pullRequestNumber = &number
+		pullRequestRepository = pullRequestRef.Repository
+		if pullRequestRepository == "" {
+			pullRequestRepository = repo
+		}
+	}
 	return connector.Issue{
 		ID:               issue.ID,
 		Identifier:       buildIdentifier(repo, issue.Number),
@@ -1951,7 +1995,8 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		URL:              issue.URL,
 		Closed:           githubIssueClosed(issue.State),
 		ClosedReason:     issue.StateReason,
-		PRNumber:         firstPullRequestNumber(issue.ClosedByPullRequestsReferences),
+		PRNumber:         pullRequestNumber,
+		PRRepository:     pullRequestRepository,
 		AuthorID:         actorLogin(issue.Author),
 		AssigneeID:       firstAssigneeLogin(issue.Assignees),
 		Assignees:        allAssigneeLogins(issue.Assignees),
@@ -2845,22 +2890,31 @@ func projectFieldValueString(value projectFieldValue) (string, bool) {
 	}
 }
 
-func firstPullRequestNumber(pullRequests nodeConnection[pullRequest]) *int {
-	var fallback *int
+type pullRequestReference struct {
+	Number     int
+	Repository string
+}
+
+func firstPullRequestReference(pullRequests nodeConnection[pullRequest]) (pullRequestReference, bool) {
+	var fallback pullRequestReference
+	fallbackOK := false
 	for _, pullRequest := range pullRequests.Nodes {
 		if pullRequest.Number <= 0 {
 			continue
 		}
-		if fallback == nil {
-			number := pullRequest.Number
-			fallback = &number
+		ref := pullRequestReference{
+			Number:     pullRequest.Number,
+			Repository: strings.TrimSpace(pullRequest.Repository.NameWithOwner),
+		}
+		if !fallbackOK {
+			fallback = ref
+			fallbackOK = true
 		}
 		if normalizeStateName(pullRequest.State) == "open" {
-			number := pullRequest.Number
-			return &number
+			return ref, true
 		}
 	}
-	return fallback
+	return fallback, fallbackOK
 }
 
 func pullRequestCIState(pullRequest pullRequestNode) string {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -92,7 +92,7 @@ query DetentGitHubObservedStatusProjectItems(
               stateReason
               url
               repository { nameWithOwner }
-              closedByPullRequestsReferences(first: 5) { nodes { number url } }
+              closedByPullRequestsReferences(first: 5) { nodes { number url state } }
             }
           }
           statusValue: fieldValueByName(name: "Status") {
@@ -577,6 +577,7 @@ type issueComment struct {
 type pullRequest struct {
 	Number int    `json:"number"`
 	URL    string `json:"url"`
+	State  string `json:"state"`
 }
 
 type pullRequestNode struct {
@@ -2845,13 +2846,21 @@ func projectFieldValueString(value projectFieldValue) (string, bool) {
 }
 
 func firstPullRequestNumber(pullRequests nodeConnection[pullRequest]) *int {
+	var fallback *int
 	for _, pullRequest := range pullRequests.Nodes {
-		if pullRequest.Number > 0 {
+		if pullRequest.Number <= 0 {
+			continue
+		}
+		if fallback == nil {
+			number := pullRequest.Number
+			fallback = &number
+		}
+		if normalizeStateName(pullRequest.State) == "open" {
 			number := pullRequest.Number
 			return &number
 		}
 	}
-	return nil
+	return fallback
 }
 
 func pullRequestCIState(pullRequest pullRequestNode) string {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -69,6 +69,45 @@ query DetentGitHubProjectItems(
   rateLimit { limit used remaining cost resetAt }
 }`
 
+const observedStatusProjectItemsQuery = `
+query DetentGitHubObservedStatusProjectItems(
+  $projectId: ID!
+  $first: Int!
+  $after: String
+  $query: String
+) {
+  node(id: $projectId) {
+    ... on ProjectV2 {
+      items(first: $first, after: $after, query: $query) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          content {
+            __typename
+            ... on Issue {
+              id
+              number
+              title
+              state
+              stateReason
+              url
+              repository { nameWithOwner }
+              closedByPullRequestsReferences(first: 5) { nodes { number url } }
+            }
+          }
+          statusValue: fieldValueByName(name: "Status") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name updatedAt }
+          }
+          priorityValue: fieldValueByName(name: "Priority") {
+            ... on ProjectV2ItemFieldSingleSelectValue { name }
+          }
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
 const issueIdentitiesByIDQuery = `
 query DetentGitHubIssueIdentitiesByID($issueIds: [ID!]!) {
   nodes(ids: $issueIds) {
@@ -1301,8 +1340,9 @@ func (c *Connector) SetField(ctx context.Context, issueID string, fieldName stri
 }
 
 type issuePullRequestCandidate struct {
-	Index        int
-	BranchPrefix string
+	Index             int
+	BranchPrefix      string
+	PullRequestNumber int
 }
 
 type pullRequestRepo struct {
@@ -1318,12 +1358,17 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 			continue
 		}
 		branchPrefix := detentIssueBranchPrefix(issue.Identifier)
-		if branchPrefix == "" {
+		pullRequestNumber := 0
+		if issue.PRNumber != nil {
+			pullRequestNumber = *issue.PRNumber
+		}
+		if branchPrefix == "" && pullRequestNumber <= 0 {
 			continue
 		}
 		byRepo[repo] = append(byRepo[repo], issuePullRequestCandidate{
-			Index:        index,
-			BranchPrefix: branchPrefix,
+			Index:             index,
+			BranchPrefix:      branchPrefix,
+			PullRequestNumber: pullRequestNumber,
 		})
 	}
 	if len(byRepo) == 0 {
@@ -1341,6 +1386,12 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 	})
 
 	for _, repo := range repos {
+		if err := c.attachLinkedPullRequests(ctx, repo, issues, byRepo[repo]); err != nil {
+			return err
+		}
+		if !hasUnattachedBranchPullRequestCandidates(issues, byRepo[repo]) {
+			continue
+		}
 		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
 		if err != nil {
 			return err
@@ -1444,6 +1495,14 @@ func (c *Connector) fetchRepositoryPullRequests(ctx context.Context, repo pullRe
 	return pullRequests, nil
 }
 
+func (c *Connector) fetchRepositoryPullRequest(ctx context.Context, repo pullRequestRepo, number int) (pullRequestNode, error) {
+	var response restPullRequest
+	if err := c.client.REST(ctx, http.MethodGet, restPullRequestPath(repo, number), nil, &response); err != nil {
+		return pullRequestNode{}, fmt.Errorf("fetch github pull request: %w", err)
+	}
+	return pullRequestNodeFromREST(response), nil
+}
+
 func (c *Connector) fetchRepositoryPullRequestsPage(
 	ctx context.Context,
 	repo pullRequestRepo,
@@ -1455,15 +1514,37 @@ func (c *Connector) fetchRepositoryPullRequestsPage(
 	}
 	pullRequests := make([]pullRequestNode, 0, len(response))
 	for _, pullRequest := range response {
-		pullRequests = append(pullRequests, pullRequestNode{
-			Number:      pullRequest.Number,
-			URL:         pullRequest.HTMLURL,
-			State:       restPullRequestState(pullRequest),
-			HeadRefName: pullRequest.Head.Ref,
-			HeadSHA:     pullRequest.Head.SHA,
-		})
+		pullRequests = append(pullRequests, pullRequestNodeFromREST(pullRequest))
 	}
 	return pullRequests, nil
+}
+
+func (c *Connector) attachLinkedPullRequests(
+	ctx context.Context,
+	repo pullRequestRepo,
+	issues []connector.Issue,
+	candidates []issuePullRequestCandidate,
+) error {
+	pullRequests := map[int]pullRequestNode{}
+	for _, candidate := range candidates {
+		if issues[candidate.Index].PullRequest != nil || candidate.PullRequestNumber <= 0 {
+			continue
+		}
+		pullRequest, ok := pullRequests[candidate.PullRequestNumber]
+		if !ok {
+			var err error
+			pullRequest, err = c.fetchRepositoryPullRequest(ctx, repo, candidate.PullRequestNumber)
+			if err != nil {
+				return err
+			}
+			if err := c.populatePullRequestStatus(ctx, repo, &pullRequest); err != nil {
+				return err
+			}
+			pullRequests[candidate.PullRequestNumber] = pullRequest
+		}
+		attachPullRequestToIssue(&issues[candidate.Index], pullRequest)
+	}
+	return nil
 }
 
 func (c *Connector) attachMatchingPullRequests(
@@ -1489,23 +1570,46 @@ func (c *Connector) attachMatchingPullRequests(
 			if err := c.populatePullRequestStatus(ctx, repo, &pullRequest); err != nil {
 				return err
 			}
-			issues[candidate.Index].PullRequest = &connector.PullRequest{
-				Number:                 pullRequest.Number,
-				URL:                    strings.TrimSpace(pullRequest.URL),
-				BranchName:             branchName,
-				State:                  strings.ToUpper(strings.TrimSpace(pullRequest.State)),
-				CIStatus:               normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
-				CodexReviewState:       pullRequestCodexReviewState(pullRequest),
-				CodexReviewSubmittedAt: pullRequestCodexReviewSubmittedAt(pullRequest),
-				CodexReviewFindings:    pullRequestCodexReviewFindings(pullRequest),
-			}
-			if issues[candidate.Index].PRNumber == nil && pullRequest.Number > 0 {
-				number := pullRequest.Number
-				issues[candidate.Index].PRNumber = &number
-			}
+			attachPullRequestToIssue(&issues[candidate.Index], pullRequest)
 		}
 	}
 	return nil
+}
+
+func hasUnattachedBranchPullRequestCandidates(issues []connector.Issue, candidates []issuePullRequestCandidate) bool {
+	for _, candidate := range candidates {
+		if issues[candidate.Index].PullRequest == nil && strings.TrimSpace(candidate.BranchPrefix) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func pullRequestNodeFromREST(pullRequest restPullRequest) pullRequestNode {
+	return pullRequestNode{
+		Number:      pullRequest.Number,
+		URL:         pullRequest.HTMLURL,
+		State:       restPullRequestState(pullRequest),
+		HeadRefName: pullRequest.Head.Ref,
+		HeadSHA:     pullRequest.Head.SHA,
+	}
+}
+
+func attachPullRequestToIssue(issue *connector.Issue, pullRequest pullRequestNode) {
+	issue.PullRequest = &connector.PullRequest{
+		Number:                 pullRequest.Number,
+		URL:                    strings.TrimSpace(pullRequest.URL),
+		BranchName:             strings.TrimSpace(pullRequest.HeadRefName),
+		State:                  strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+		CIStatus:               normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
+		CodexReviewState:       pullRequestCodexReviewState(pullRequest),
+		CodexReviewSubmittedAt: pullRequestCodexReviewSubmittedAt(pullRequest),
+		CodexReviewFindings:    pullRequestCodexReviewFindings(pullRequest),
+	}
+	if issue.PRNumber == nil && pullRequest.Number > 0 {
+		number := pullRequest.Number
+		issue.PRNumber = &number
+	}
 }
 
 func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode) error {
@@ -1565,7 +1669,7 @@ func (c *Connector) fetchProjectItems(ctx context.Context, queryType string, que
 				Items projectItemsConnection `json:"items"`
 			} `json:"node"`
 		}
-		if err := c.client.GraphQLWithType(ctx, queryType, projectItemsQuery, map[string]any{
+		if err := c.client.GraphQLWithType(ctx, queryType, projectItemsQueryForType(queryType), map[string]any{
 			"projectId": c.projectID,
 			"first":     projectItemsPageSize,
 			"after":     after,
@@ -1608,6 +1712,13 @@ func (c *Connector) fetchProjectItems(ctx context.Context, queryType string, que
 		}
 		after = &cursor
 	}
+}
+
+func projectItemsQueryForType(queryType string) string {
+	if queryType == graphQLQueryObservedStatus {
+		return observedStatusProjectItemsQuery
+	}
+	return projectItemsQuery
 }
 
 func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, bool, string, error) {
@@ -2493,6 +2604,10 @@ func restPullRequestsPath(repo pullRequestRepo, page int) string {
 	values.Set("per_page", strconv.Itoa(pullRequestsPageSize))
 	values.Set("page", strconv.Itoa(page))
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/pulls?" + values.Encode()
+}
+
+func restPullRequestPath(repo pullRequestRepo, number int) string {
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/pulls/" + strconv.Itoa(number)
 }
 
 func restPullRequestReviewsPath(repo pullRequestRepo, number int) string {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -490,6 +490,74 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 	}
 }
 
+func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_370","content":{"__typename":"Issue","id":"I_370","number":370,"title":"Linked PR issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/370","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"bug"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":376,"url":"https://github.com/digitaldrywood/detent/pull/376"}]}},"statusValue":{"name":"Reviewing"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/376",
+			body:   `{"number":376,"html_url":"https://github.com/digitaldrywood/detent/pull/376","state":"open","head":{"ref":"detent/detent-digitaldrywood_detent_370-e71678a9ca7e","sha":"sha-376"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-376/check-runs?per_page=100",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-376/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/376/reviews?per_page=100",
+			body:   `[{"body":"No blocking findings.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-376","submitted_at":"2026-06-05T11:00:00Z"}]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+		StateMap: map[string]string{
+			"Human Review": "Reviewing",
+		},
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	pr := got[0].PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want linked PR")
+	}
+	if pr.Number != 376 || pr.State != "OPEN" || pr.BranchName != "detent/detent-digitaldrywood_detent_370-e71678a9ca7e" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
+		t.Fatalf("PullRequest = %#v, want linked PR 376 with hydrated status", pr)
+	}
+
+	requests := server.requests()
+	if len(requests) != 5 {
+		t.Fatalf("request count = %d, want observed query plus linked PR status requests", len(requests))
+	}
+	query := requests[0]["query"].(string)
+	if !strings.Contains(query, "closedByPullRequestsReferences") {
+		t.Fatalf("observed status query does not request linked pull requests:\n%s", query)
+	}
+	for _, request := range requests {
+		path, _ := request["path"].(string)
+		if strings.Contains(path, "/pulls?") {
+			t.Fatalf("request path = %q, want linked PR path without repository-wide pull list", path)
+		}
+	}
+}
+
 func TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -495,7 +495,7 @@ func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_370","content":{"__typename":"Issue","id":"I_370","number":370,"title":"Linked PR issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/370","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"bug"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":376,"url":"https://github.com/digitaldrywood/detent/pull/376"}]}},"statusValue":{"name":"Reviewing"},"priorityValue":null}]}}}}`,
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_370","content":{"__typename":"Issue","id":"I_370","number":370,"title":"Linked PR issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/370","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"bug"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":375,"url":"https://github.com/digitaldrywood/detent/pull/375","state":"CLOSED"},{"number":376,"url":"https://github.com/digitaldrywood/detent/pull/376","state":"OPEN"}]}},"statusValue":{"name":"Reviewing"},"priorityValue":null}]}}}}`,
 		},
 		{
 			method: http.MethodGet,
@@ -549,6 +549,9 @@ func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix
 	query := requests[0]["query"].(string)
 	if !strings.Contains(query, "closedByPullRequestsReferences") {
 		t.Fatalf("observed status query does not request linked pull requests:\n%s", query)
+	}
+	if !strings.Contains(query, "nodes { number url state }") {
+		t.Fatalf("observed status query does not request linked pull request states:\n%s", query)
 	}
 	for _, request := range requests {
 		path, _ := request["path"].(string)

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -495,26 +495,26 @@ func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_370","content":{"__typename":"Issue","id":"I_370","number":370,"title":"Linked PR issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/370","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"bug"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":375,"url":"https://github.com/digitaldrywood/detent/pull/375","state":"CLOSED"},{"number":376,"url":"https://github.com/digitaldrywood/detent/pull/376","state":"OPEN"}]}},"statusValue":{"name":"Reviewing"},"priorityValue":null}]}}}}`,
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_370","content":{"__typename":"Issue","id":"I_370","number":370,"title":"Linked PR issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/370","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"bug"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":375,"url":"https://github.com/digitaldrywood/detent/pull/375","state":"CLOSED","repository":{"nameWithOwner":"digitaldrywood/detent"}},{"number":376,"url":"https://github.com/corylanou/detent/pull/376","state":"OPEN","repository":{"nameWithOwner":"corylanou/detent"}}]}},"statusValue":{"name":"Reviewing"},"priorityValue":null}]}}}}`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/pulls/376",
-			body:   `{"number":376,"html_url":"https://github.com/digitaldrywood/detent/pull/376","state":"open","head":{"ref":"detent/detent-digitaldrywood_detent_370-e71678a9ca7e","sha":"sha-376"}}`,
+			path:   "/repos/corylanou/detent/pulls/376",
+			body:   `{"number":376,"html_url":"https://github.com/corylanou/detent/pull/376","state":"open","head":{"ref":"detent/detent-digitaldrywood_detent_370-e71678a9ca7e","sha":"sha-376"}}`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/commits/sha-376/check-runs?per_page=100",
+			path:   "/repos/corylanou/detent/commits/sha-376/check-runs?per_page=100",
 			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/commits/sha-376/statuses?per_page=100",
+			path:   "/repos/corylanou/detent/commits/sha-376/statuses?per_page=100",
 			body:   `[]`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/pulls/376/reviews?per_page=100",
+			path:   "/repos/corylanou/detent/pulls/376/reviews?per_page=100",
 			body:   `[{"body":"No blocking findings.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"sha-376","submitted_at":"2026-06-05T11:00:00Z"}]`,
 		},
 	})
@@ -538,8 +538,11 @@ func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix
 	if pr == nil {
 		t.Fatal("PullRequest = nil, want linked PR")
 	}
-	if pr.Number != 376 || pr.State != "OPEN" || pr.BranchName != "detent/detent-digitaldrywood_detent_370-e71678a9ca7e" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
+	if pr.Number != 376 || pr.URL != "https://github.com/corylanou/detent/pull/376" || pr.State != "OPEN" || pr.BranchName != "detent/detent-digitaldrywood_detent_370-e71678a9ca7e" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
 		t.Fatalf("PullRequest = %#v, want linked PR 376 with hydrated status", pr)
+	}
+	if got[0].PRRepository != "corylanou/detent" {
+		t.Fatalf("PRRepository = %q, want corylanou/detent", got[0].PRRepository)
 	}
 
 	requests := server.requests()
@@ -550,7 +553,7 @@ func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix
 	if !strings.Contains(query, "closedByPullRequestsReferences") {
 		t.Fatalf("observed status query does not request linked pull requests:\n%s", query)
 	}
-	if !strings.Contains(query, "nodes { number url state }") {
+	if !strings.Contains(query, "nodes { number url state repository { nameWithOwner } }") {
 		t.Fatalf("observed status query does not request linked pull request states:\n%s", query)
 	}
 	for _, request := range requests {

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -18,6 +18,7 @@ type Issue struct {
 	Closed           bool              `json:"closed,omitempty" yaml:"closed,omitempty"`
 	ClosedReason     string            `json:"closed_reason,omitempty" yaml:"closed_reason,omitempty"`
 	PRNumber         *int              `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
+	PRRepository     string            `json:"pr_repository,omitempty" yaml:"pr_repository,omitempty"`
 	PullRequest      *PullRequest      `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
 	AuthorID         string            `json:"author_id,omitempty" yaml:"author_id,omitempty"`
 	AssigneeID       string            `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -50,7 +50,7 @@ const (
 	AutoPromoteReasonLabelNotAllowed      AutoPromoteReason = "label_not_allowed"
 	AutoPromoteReasonMissingPullRequest   AutoPromoteReason = "missing_pull_request"
 	AutoPromoteReasonCINotGreen           AutoPromoteReason = "ci_not_green"
-	AutoPromoteReasonCodexReviewMissing   AutoPromoteReason = "codex_review_missing"
+	AutoPromoteReasonCodexReviewMissing   AutoPromoteReason = "automated_review_missing"
 	AutoPromoteReasonP1Findings           AutoPromoteReason = "p1_findings"
 	AutoPromoteReasonCodexReviewNotQuiet  AutoPromoteReason = "codex_review_not_quiet"
 	AutoPromoteReasonHumanApprovalMissing AutoPromoteReason = "human_approval_missing"

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -2,7 +2,6 @@ package orchestrator
 
 import (
 	"context"
-	"io"
 	"log/slog"
 	"reflect"
 	"strings"
@@ -25,6 +24,8 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 		issue                connector.Issue
 		wantUpdates          []autoPromoteTickUpdate
 		wantCommentFragments []string
+		wantLogFragments     []string
+		rejectLogFragments   []string
 	}{
 		{
 			name: "promotes ready issue to merging",
@@ -48,6 +49,26 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 				"Auto-promoted this issue from Human Review to Merging.",
 				"reason: ready",
 				"https://github.test/digitaldrywood/detent/pull/42",
+			},
+		},
+		{
+			name: "linked pull request without automated review waits for review",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-linked-missing-review", []string{"bug"}, &connector.PullRequest{
+				Number:     390,
+				URL:        "https://github.test/digitaldrywood/detent/pull/390",
+				BranchName: "detent/detent-digitaldrywood_detent_387-29d3e4765f21",
+				State:      "OPEN",
+				CIStatus:   "pass",
+			}),
+			wantLogFragments: []string{
+				"reason=automated_review_missing",
+			},
+			rejectLogFragments: []string{
+				"reason=missing_pull_request",
 			},
 		},
 		{
@@ -155,10 +176,11 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			})
 			state := newState(cfg)
 			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{tt.issue}}
+			var logs strings.Builder
 			orch := &Orchestrator{
 				cfg:       cfg,
 				connector: tracker,
-				logger:    slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{Level: slog.LevelDebug})),
+				logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
 			}
 
 			orch.tick(context.Background(), &state, now)
@@ -176,14 +198,24 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 				if len(tracker.comments) != 0 {
 					t.Fatalf("comments = %#v, want none", tracker.comments)
 				}
-				return
+			} else {
+				if len(tracker.comments) != 1 {
+					t.Fatalf("comments = %#v, want one comment", tracker.comments)
+				}
+				for _, fragment := range tt.wantCommentFragments {
+					if !strings.Contains(tracker.comments[0].body, fragment) {
+						t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+					}
+				}
 			}
-			if len(tracker.comments) != 1 {
-				t.Fatalf("comments = %#v, want one comment", tracker.comments)
+			for _, fragment := range tt.wantLogFragments {
+				if !strings.Contains(logs.String(), fragment) {
+					t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+				}
 			}
-			for _, fragment := range tt.wantCommentFragments {
-				if !strings.Contains(tracker.comments[0].body, fragment) {
-					t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+			for _, fragment := range tt.rejectLogFragments {
+				if strings.Contains(logs.String(), fragment) {
+					t.Fatalf("logs %q contain rejected fragment %q", logs.String(), fragment)
 				}
 			}
 		})


### PR DESCRIPTION
## Summary

- Request closing PR references with state and repository data when fetching observed status issues.
- Prefer open linked PRs, hydrate linked PRs from their own repository, then fall back to branch-prefix matching.
- Cover linked PR auto-promote behavior, including the no-review wait reason.

Fixes #392

## Test Plan

- [x] `go test ./internal/connector/github ./internal/orchestrator -count=1`
- [x] `make check`
- [x] GitHub Actions passed on `28d0edee6a309bd06dbb573e053f722f64a2f130`