### PR TITLE
feat(doctor): recognize running instance

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -692,11 +692,23 @@ func serverAddr(cfg BootConfig) string {
 	if host == "" {
 		host = defaultWebHost
 	}
+	host = unbracketIPv6Host(host)
 	port := defaultWebPort
 	if cfg.Port != nil {
 		port = *cfg.Port
 	}
 	return net.JoinHostPort(host, strconv.Itoa(port))
+}
+
+func unbracketIPv6Host(host string) string {
+	if len(host) < 2 || host[0] != '[' || host[len(host)-1] != ']' {
+		return host
+	}
+	unbracketed := strings.TrimSuffix(strings.TrimPrefix(host, "["), "]")
+	if net.ParseIP(unbracketed) == nil {
+		return host
+	}
+	return unbracketed
 }
 
 func listenForBoot(cfg BootConfig) (net.Listener, string, error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -14,6 +15,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -98,6 +100,7 @@ type doctorDeps struct {
 	lookupEnv            func(string) string
 	lookPath             func(string) (string, error)
 	runCommand           func(context.Context, string, ...string) error
+	httpDo               func(*http.Request) (*http.Response, error)
 	githubScopes         func(context.Context, string) ([]string, error)
 	ghAuthToken          func(context.Context) (string, error)
 	listen               func(string, string) (net.Listener, error)
@@ -1155,21 +1158,36 @@ func missingGitHubScopes(scopes []string) []string {
 }
 
 func checkDoctorServerPort(cfg BootConfig, deps doctorDeps) doctorCheck {
+	deps = deps.withDefaults()
 	addr := serverAddr(cfg)
 	listener, err := deps.listen("tcp", addr)
 	if err != nil {
-		return doctorCheck{
+		check := doctorCheck{
 			Name:   "Server port",
 			Status: doctorFail,
-			Detail: fmt.Sprintf("%s is not available: %v", addr, err),
+			Detail: fmt.Sprintf("%s is not available for pre-start bind: %v", addr, err),
 			Hint:   "Stop the process using the port or pass --port with an available value.",
+		}
+		if !doctorListenErrIndicatesOccupied(err) || doctorServerPort(cfg) == 0 {
+			return check
+		}
+		probe, probeErr := probeDoctorHealth(cfg, deps)
+		if probeErr != nil {
+			check.Detail = fmt.Sprintf("%s is occupied for pre-start bind; health probe %s %v", addr, probe.URL, probeErr)
+			return check
+		}
+		return doctorCheck{
+			Name:   "Server port",
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("%s is occupied for pre-start bind; health probe %s found healthy Detent instance (status %s, mode %s)", addr, probe.URL, probe.Health.Status, probe.Health.Mode),
+			Hint:   "No action is needed if doctor is checking the live instance; stop Detent before a clean pre-start availability check.",
 		}
 	}
 	if err := listener.Close(); err != nil {
 		return doctorCheck{
 			Name:   "Server port",
 			Status: doctorWarn,
-			Detail: fmt.Sprintf("%s was available, but close failed: %v", addr, err),
+			Detail: fmt.Sprintf("%s was available for pre-start bind, but close failed: %v", addr, err),
 			Hint:   "Rerun detent doctor and check for local network errors.",
 		}
 	}
@@ -1184,8 +1202,86 @@ func checkDoctorServerPort(cfg BootConfig, deps doctorDeps) doctorCheck {
 	return doctorCheck{
 		Name:   "Server port",
 		Status: doctorOK,
-		Detail: addr + " is available",
+		Detail: addr + " is available for pre-start bind",
 	}
+}
+
+type doctorHealthProbe struct {
+	URL    string
+	Health doctorHealthResponse
+}
+
+type doctorHealthResponse struct {
+	Status string            `json:"status"`
+	Mode   string            `json:"mode"`
+	Checks map[string]string `json:"checks"`
+}
+
+func probeDoctorHealth(cfg BootConfig, deps doctorDeps) (doctorHealthProbe, error) {
+	url := doctorHealthProbeURL(cfg)
+	probe := doctorHealthProbe{URL: url}
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return probe, fmt.Errorf("could not be built: %w", err)
+	}
+	resp, err := deps.httpDo(req)
+	if err != nil {
+		return probe, fmt.Errorf("could not be reached: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return probe, fmt.Errorf("returned HTTP %d", resp.StatusCode)
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&probe.Health); err != nil {
+		return probe, fmt.Errorf("did not return Detent health: %w", err)
+	}
+	probe.Health.Status = strings.TrimSpace(probe.Health.Status)
+	probe.Health.Mode = strings.TrimSpace(probe.Health.Mode)
+	if probe.Health.Mode == "" || probe.Health.Checks == nil {
+		return probe, errors.New("did not return Detent health")
+	}
+	if probe.Health.Status != "ok" {
+		return probe, fmt.Errorf("did not report healthy status: status %s, mode %s", probe.Health.Status, probe.Health.Mode)
+	}
+	return probe, nil
+}
+
+func doctorHealthProbeURL(cfg BootConfig) string {
+	return "http://" + net.JoinHostPort(doctorHealthProbeHost(cfg.Host), strconv.Itoa(doctorServerPort(cfg))) + "/health"
+}
+
+func doctorHealthProbeHost(host string) string {
+	host = strings.TrimSpace(host)
+	if host == "" {
+		host = defaultWebHost
+	}
+	host = unbracketIPv6Host(host)
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return host
+	}
+	if ip.IsUnspecified() {
+		if ip.To4() != nil {
+			return "127.0.0.1"
+		}
+		return "::1"
+	}
+	return host
+}
+
+func doctorServerPort(cfg BootConfig) int {
+	if cfg.Port != nil {
+		return *cfg.Port
+	}
+	return defaultWebPort
+}
+
+func doctorListenErrIndicatesOccupied(err error) bool {
+	if err == nil {
+		return false
+	}
+	return errors.Is(err, syscall.EADDRINUSE) || strings.Contains(strings.ToLower(err.Error()), "address already in use")
 }
 
 func doctorOptions(opts options) options {
@@ -1212,6 +1308,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	}
 	if d.runCommand == nil {
 		d.runCommand = defaults.runCommand
+	}
+	if d.httpDo == nil {
+		d.httpDo = defaults.httpDo
 	}
 	if d.githubScopes == nil {
 		d.githubScopes = defaults.githubScopes
@@ -1243,6 +1342,7 @@ func defaultDoctorDeps() doctorDeps {
 		lookupEnv:            os.Getenv,
 		lookPath:             exec.LookPath,
 		runCommand:           runDoctorCommand,
+		httpDo:               defaultDoctorHTTPDo,
 		githubScopes:         defaultGitHubScopes,
 		ghAuthToken:          defaultGHAuthToken,
 		listen:               net.Listen,
@@ -1251,6 +1351,11 @@ func defaultDoctorDeps() doctorDeps {
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
 		executable:           os.Executable,
 	}
+}
+
+func defaultDoctorHTTPDo(req *http.Request) (*http.Response, error) {
+	client := http.Client{Timeout: doctorCommandTimeout}
+	return client.Do(req)
 }
 
 func openDoctorSQLite(ctx context.Context, path string) (doctorStore, error) {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -254,7 +254,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		doctorCheckJob{
 			Name: "Server port",
 			Run: func(jobCtx context.Context) []doctorCheck {
-				return []doctorCheck{checkDoctorServerPort(boot, deps)}
+				return []doctorCheck{checkDoctorServerPort(jobCtx, boot, deps)}
 			},
 		},
 		doctorCheckJob{
@@ -1159,7 +1159,10 @@ func missingGitHubScopes(scopes []string) []string {
 	return missing
 }
 
-func checkDoctorServerPort(cfg BootConfig, deps doctorDeps) doctorCheck {
+func checkDoctorServerPort(ctx context.Context, cfg BootConfig, deps doctorDeps) doctorCheck {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	deps = deps.withDefaults()
 	addr := serverAddr(cfg)
 	listener, err := deps.listen("tcp", addr)
@@ -1173,7 +1176,7 @@ func checkDoctorServerPort(cfg BootConfig, deps doctorDeps) doctorCheck {
 		if !doctorListenErrIndicatesOccupied(err) || doctorServerPort(cfg) == 0 {
 			return check
 		}
-		probe, probeErr := probeDoctorHealth(cfg, deps)
+		probe, probeErr := probeDoctorHealth(ctx, cfg, deps)
 		if probeErr != nil {
 			check.Detail = fmt.Sprintf("%s is occupied for pre-start bind; health probe %s %v", addr, probe.URL, probeErr)
 			return check
@@ -1219,10 +1222,13 @@ type doctorHealthResponse struct {
 	Checks map[string]string `json:"checks"`
 }
 
-func probeDoctorHealth(cfg BootConfig, deps doctorDeps) (doctorHealthProbe, error) {
+func probeDoctorHealth(ctx context.Context, cfg BootConfig, deps doctorDeps) (doctorHealthProbe, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
 	url := doctorHealthProbeURL(cfg)
 	probe := doctorHealthProbe{URL: url}
-	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return probe, fmt.Errorf("could not be built: %w", err)
 	}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1281,7 +1281,10 @@ func doctorListenErrIndicatesOccupied(err error) bool {
 	if err == nil {
 		return false
 	}
-	return errors.Is(err, syscall.EADDRINUSE) || strings.Contains(strings.ToLower(err.Error()), "address already in use")
+	message := strings.ToLower(err.Error())
+	return errors.Is(err, syscall.EADDRINUSE) ||
+		strings.Contains(message, "address already in use") ||
+		strings.Contains(message, "only one usage of each socket address")
 }
 
 func doctorOptions(opts options) options {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -49,6 +49,8 @@ var requiredGitHubScopes = []string{"repo", "read:org", "project"}
 
 const doctorAutoPromoteSampleLimit = 5
 
+var doctorHealthCheckKeys = []string{"hub", "store", "registry", "connector"}
+
 type doctorCheck struct {
 	Name   string
 	Status doctorStatus
@@ -1238,13 +1240,25 @@ func probeDoctorHealth(cfg BootConfig, deps doctorDeps) (doctorHealthProbe, erro
 	}
 	probe.Health.Status = strings.TrimSpace(probe.Health.Status)
 	probe.Health.Mode = strings.TrimSpace(probe.Health.Mode)
-	if probe.Health.Mode == "" || probe.Health.Checks == nil {
+	if probe.Health.Mode == "" || !doctorHealthHasDetentChecks(probe.Health.Checks) {
 		return probe, errors.New("did not return Detent health")
 	}
 	if probe.Health.Status != "ok" {
 		return probe, fmt.Errorf("did not report healthy status: status %s, mode %s", probe.Health.Status, probe.Health.Mode)
 	}
 	return probe, nil
+}
+
+func doctorHealthHasDetentChecks(checks map[string]string) bool {
+	if checks == nil {
+		return false
+	}
+	for _, key := range doctorHealthCheckKeys {
+		if _, ok := checks[key]; !ok {
+			return false
+		}
+	}
+	return true
 }
 
 func doctorHealthProbeURL(cfg BootConfig) string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -856,6 +856,31 @@ func TestServerAddrNormalizesBracketedIPv6Host(t *testing.T) {
 	}
 }
 
+func TestDoctorListenErrIndicatesOccupied(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil", want: false},
+		{name: "unix bind collision", err: errors.New("bind: address already in use"), want: true},
+		{name: "windows bind collision", err: errors.New("bind: Only one usage of each socket address (protocol/network address/port) is normally permitted."), want: true},
+		{name: "other listen error", err: errors.New("bind: permission denied"), want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := doctorListenErrIndicatesOccupied(tt.err); got != tt.want {
+				t.Fatalf("doctorListenErrIndicatesOccupied() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDoctorCommandExitStatus(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -6,8 +6,11 @@ import (
 	"errors"
 	"io"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -711,7 +714,7 @@ func TestCheckDoctorServerPort(t *testing.T) {
 		{
 			name:       "port available",
 			want:       doctorOK,
-			wantDetail: "is available",
+			wantDetail: "available for pre-start bind",
 		},
 	}
 
@@ -738,6 +741,118 @@ func TestCheckDoctorServerPort(t *testing.T) {
 				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
 			}
 		})
+	}
+}
+
+func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		host       string
+		listenHost string
+		statusCode int
+		body       string
+		want       doctorStatus
+		wantDetail []string
+	}{
+		{
+			name:       "healthy running detent on wildcard host",
+			host:       "0.0.0.0",
+			listenHost: "0.0.0.0",
+			statusCode: http.StatusOK,
+			body:       `{"status":"ok","mode":"running","checks":{"hub":"configured"}}`,
+			want:       doctorWarn,
+			wantDetail: []string{
+				"pre-start bind",
+				"healthy Detent instance",
+				"http://127.0.0.1:",
+				"/health",
+				"status ok",
+				"mode running",
+			},
+		},
+		{
+			name:       "unhealthy detent service",
+			host:       "127.0.0.1",
+			listenHost: "127.0.0.1",
+			statusCode: http.StatusOK,
+			body:       `{"status":"error","mode":"running","checks":{"hub":"configured"}}`,
+			want:       doctorFail,
+			wantDetail: []string{
+				"pre-start bind",
+				"health probe",
+				"did not report healthy status",
+			},
+		},
+		{
+			name:       "non-detent service",
+			host:       "127.0.0.1",
+			listenHost: "127.0.0.1",
+			statusCode: http.StatusOK,
+			body:       `{"status":"ok"}`,
+			want:       doctorFail,
+			wantDetail: []string{
+				"pre-start bind",
+				"health probe",
+				"did not return Detent health",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			port := occupiedDoctorPort(t, tt.listenHost, tt.statusCode, tt.body)
+			got := checkDoctorServerPort(BootConfig{Host: tt.host, Port: &port}, doctorDeps{
+				listen: net.Listen,
+			})
+			if got.Status != tt.want {
+				t.Fatalf("Status = %s, want %s: %+v", got.Status, tt.want, got)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorHealthProbeHostMapsWildcardToLoopback(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		host string
+		want string
+	}{
+		{name: "empty uses default", want: "127.0.0.1"},
+		{name: "ipv4 wildcard", host: "0.0.0.0", want: "127.0.0.1"},
+		{name: "ipv6 wildcard", host: "::", want: "::1"},
+		{name: "bracketed ipv6 wildcard", host: "[::]", want: "::1"},
+		{name: "loopback unchanged", host: "127.0.0.1", want: "127.0.0.1"},
+		{name: "hostname unchanged", host: "dashboard.internal", want: "dashboard.internal"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := doctorHealthProbeHost(tt.host); got != tt.want {
+				t.Fatalf("doctorHealthProbeHost(%q) = %q, want %q", tt.host, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestServerAddrNormalizesBracketedIPv6Host(t *testing.T) {
+	t.Parallel()
+
+	port := 4001
+	if got := serverAddr(BootConfig{Host: "[::]", Port: &port}); got != "[::]:4001" {
+		t.Fatalf("serverAddr() = %q, want [::]:4001", got)
 	}
 }
 
@@ -1148,4 +1263,45 @@ func (b *synchronizedBuffer) String() string {
 	b.mu.Lock()
 	defer b.mu.Unlock()
 	return b.buf.String()
+}
+
+func occupiedDoctorPort(t *testing.T, host string, statusCode int, body string) int {
+	t.Helper()
+
+	listener, err := net.Listen("tcp", net.JoinHostPort(host, "0"))
+	if err != nil {
+		t.Fatalf("Listen(%q) error = %v", host, err)
+	}
+	port := doctorPortFromAddr(t, listener.Addr())
+
+	server := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(statusCode)
+		if _, err := w.Write([]byte(body)); err != nil {
+			t.Errorf("Write() error = %v", err)
+		}
+	}))
+	server.Listener = listener
+	server.Start()
+	t.Cleanup(server.Close)
+
+	return port
+}
+
+func doctorPortFromAddr(t *testing.T, addr net.Addr) int {
+	t.Helper()
+
+	_, portText, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q) error = %v", addr.String(), err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("Atoi(%q) error = %v", portText, err)
+	}
+	return port
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -723,7 +723,7 @@ func TestCheckDoctorServerPort(t *testing.T) {
 			t.Parallel()
 
 			port := 0
-			got := checkDoctorServerPort(BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
+			got := checkDoctorServerPort(context.Background(), BootConfig{Host: "127.0.0.1", Port: &port}, doctorDeps{
 				listen: func(_, address string) (net.Listener, error) {
 					if address != "127.0.0.1:0" {
 						t.Fatalf("listen address = %q, want 127.0.0.1:0", address)
@@ -818,7 +818,7 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 			t.Parallel()
 
 			port := occupiedDoctorPort(t, tt.listenHost, tt.statusCode, tt.body)
-			got := checkDoctorServerPort(BootConfig{Host: tt.host, Port: &port}, doctorDeps{
+			got := checkDoctorServerPort(context.Background(), BootConfig{Host: tt.host, Port: &port}, doctorDeps{
 				listen: net.Listen,
 			})
 			if got.Status != tt.want {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -761,7 +761,7 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 			host:       "0.0.0.0",
 			listenHost: "0.0.0.0",
 			statusCode: http.StatusOK,
-			body:       `{"status":"ok","mode":"running","checks":{"hub":"configured"}}`,
+			body:       `{"status":"ok","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"}}`,
 			want:       doctorWarn,
 			wantDetail: []string{
 				"pre-start bind",
@@ -777,7 +777,7 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 			host:       "127.0.0.1",
 			listenHost: "127.0.0.1",
 			statusCode: http.StatusOK,
-			body:       `{"status":"error","mode":"running","checks":{"hub":"configured"}}`,
+			body:       `{"status":"error","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"}}`,
 			want:       doctorFail,
 			wantDetail: []string{
 				"pre-start bind",
@@ -791,6 +791,19 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 			listenHost: "127.0.0.1",
 			statusCode: http.StatusOK,
 			body:       `{"status":"ok"}`,
+			want:       doctorFail,
+			wantDetail: []string{
+				"pre-start bind",
+				"health probe",
+				"did not return Detent health",
+			},
+		},
+		{
+			name:       "generic health service",
+			host:       "127.0.0.1",
+			listenHost: "127.0.0.1",
+			statusCode: http.StatusOK,
+			body:       `{"status":"ok","mode":"ready","checks":{}}`,
 			want:       doctorFail,
 			wantDetail: []string{
 				"pre-start bind",


### PR DESCRIPTION
## Summary
- Probe `/health` when the configured doctor server port is already occupied.
- Treat healthy Detent health responses as a warning instead of a hard port failure.
- Map wildcard bind hosts to loopback for health probes and clarify pre-start bind output.

Fixes #394

## Test Plan
- `go test ./internal/cli -run "TestCheckDoctorServerPort|TestDoctorHealthProbeHostMapsWildcardToLoopback|TestServerAddrNormalizesBracketedIPv6Host|TestDoctorListenErrIndicatesOccupied"`
- `make check`