### PR TITLE
fix(doctor): diagnose stalled auto-promote

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -21,6 +21,10 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/factory"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 )
 
 var ErrDoctorFailed = errors.New("doctor found failed checks")
@@ -36,6 +40,8 @@ const (
 )
 
 var requiredGitHubScopes = []string{"repo", "read:org", "project"}
+
+const doctorAutoPromoteSampleLimit = 5
 
 type doctorCheck struct {
 	Name   string
@@ -58,16 +64,29 @@ type doctorStore interface {
 	Close() error
 }
 
+type doctorAutoPromoteConnector interface {
+	FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error)
+}
+
+type doctorAutoPromoteLimitedConnector interface {
+	FetchIssuesByStatesLimit(context.Context, []string, int) ([]connector.Issue, error)
+}
+
+type doctorStatusOptionVerifier interface {
+	VerifyStatusOptions(context.Context, []string) error
+}
+
 type doctorDeps struct {
-	loadWorkflow func(string) (workflowconfig.Workflow, error)
-	lookupEnv    func(string) string
-	lookPath     func(string) (string, error)
-	runCommand   func(context.Context, string, ...string) error
-	githubScopes func(context.Context, string) ([]string, error)
-	ghAuthToken  func(context.Context) (string, error)
-	listen       func(string, string) (net.Listener, error)
-	openSQLite   func(context.Context, string) (doctorStore, error)
-	gitWorkTree  func(context.Context, string) error
+	loadWorkflow         func(string) (workflowconfig.Workflow, error)
+	lookupEnv            func(string) string
+	lookPath             func(string) (string, error)
+	runCommand           func(context.Context, string, ...string) error
+	githubScopes         func(context.Context, string) ([]string, error)
+	ghAuthToken          func(context.Context) (string, error)
+	listen               func(string, string) (net.Listener, error)
+	openSQLite           func(context.Context, string) (doctorStore, error)
+	gitWorkTree          func(context.Context, string) error
+	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
 }
 
 func newDoctorCommand(configPath *string, env *string, logLevel *string, host *string, port *int, opts options) *cobra.Command {
@@ -333,6 +352,9 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 			Status: doctorOK,
 			Detail: doctorWorkflowDetail(project.Workflow, project, workflow.Config),
 		})
+		if workflow.Config.Agent.AutoPromote.Enabled {
+			checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
+		}
 
 		sourceRoot := projectSourceRoot(project, workflow.Config)
 		if sourceRoot == "" {
@@ -371,6 +393,264 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	}
 
 	return checks
+}
+
+func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps, now time.Time) doctorCheck {
+	name := "Project " + id + " auto-promote"
+	if !cfg.Agent.AutoPromote.Enabled {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "agent.auto_promote.enabled=false; live candidate diagnostics disabled",
+		}
+	}
+	if !doctorStateInList("Human Review", cfg.Tracker.ObservedStates) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "agent.auto_promote.enabled=true but tracker.observed_states does not include Human Review",
+			Hint:   "Add Human Review to tracker.observed_states so Detent can observe review-lane candidates.",
+		}
+	}
+	if !doctorStateInList("Merging", cfg.Tracker.ActiveStates) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "agent.auto_promote.enabled=true but tracker.active_states does not include Merging",
+			Hint:   "Add Merging to tracker.active_states so promoted issues can enter the merge lane.",
+		}
+	}
+	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "agent.auto_promote.enabled=true; live GitHub diagnostics skipped for " + cfg.Tracker.Kind + " tracker",
+		}
+	}
+
+	if deps.autoPromoteConnector == nil {
+		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector
+	}
+	projectConnector, err := deps.autoPromoteConnector(cfg)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("create auto-promote diagnostic connector: %v", err),
+			Hint:   "Fix GitHub tracker credentials and ProjectV2 configuration.",
+		}
+	}
+	if projectConnector == nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "create auto-promote diagnostic connector: connector is nil",
+			Hint:   "Fix GitHub tracker configuration.",
+		}
+	}
+
+	check := checkDoctorAutoPromoteLive(ctx, name, cfg, projectConnector, now)
+	if err := closeDoctorAutoPromoteConnector(projectConnector); err != nil && check.Status != doctorFail {
+		check.Status = doctorWarn
+		check.Detail = check.Detail + "; connector close failed: " + err.Error()
+		check.Hint = "Rerun detent doctor and check local network resources."
+	}
+	return check
+}
+
+func checkDoctorAutoPromoteLive(
+	ctx context.Context,
+	name string,
+	cfg workflowconfig.Config,
+	projectConnector doctorAutoPromoteConnector,
+	now time.Time,
+) doctorCheck {
+	if verifier, ok := projectConnector.(doctorStatusOptionVerifier); ok {
+		if err := verifier.VerifyStatusOptions(ctx, []string{"Human Review", "Merging"}); err != nil {
+			return doctorCheck{
+				Name:   name,
+				Status: doctorFail,
+				Detail: fmt.Sprintf("status option verification failed: %v", err),
+				Hint:   "Ensure Human Review and Merging resolve through tracker.state_map to existing GitHub Project Status options.",
+			}
+		}
+	}
+
+	issues, err := fetchDoctorAutoPromoteIssues(ctx, projectConnector, []string{"Human Review"})
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("fetch Human Review candidates: %v", err),
+			Hint:   "Check GitHub Project access, Status field options, and repository pull request access.",
+		}
+	}
+
+	autoPromoteCfg := doctorAutoPromoteConfig(cfg)
+	reasonCounts := map[orchestrator.AutoPromoteReason]int{}
+	var quietRemaining time.Duration
+	for _, issue := range issues {
+		summary := orchestrator.AutoPromoteSummaryFromIssue(issue)
+		decision := orchestrator.EvaluateAutoPromote(issue, summary, autoPromoteCfg, now)
+		reasonCounts[decision.Reason]++
+		if decision.QuietRemaining > quietRemaining {
+			quietRemaining = decision.QuietRemaining
+		}
+		if decision.Reason == orchestrator.AutoPromoteReasonMissingPullRequest {
+			if prNumber, ok := doctorLinkedPullRequestNumber(issue); ok {
+				return doctorCheck{
+					Name:   name,
+					Status: doctorFail,
+					Detail: fmt.Sprintf("%s has linked PR #%d but auto-promote readiness reports missing_pull_request", doctorIssueLabel(issue), prNumber),
+					Hint:   "Verify GitHub PR attachment, branch prefix matching, and repository access for Human Review candidates.",
+				}
+			}
+		}
+	}
+
+	detail := fmt.Sprintf(
+		"agent.auto_promote.enabled=true; status options resolved; sampled %d Human Review candidate(s)",
+		len(issues),
+	)
+	if len(reasonCounts) > 0 {
+		detail += "; reasons: " + doctorAutoPromoteReasonCounts(reasonCounts)
+	}
+	if quietRemaining > 0 {
+		detail += "; max_quiet_remaining=" + quietRemaining.Truncate(time.Second).String()
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorOK,
+		Detail: detail,
+	}
+}
+
+func fetchDoctorAutoPromoteIssues(
+	ctx context.Context,
+	projectConnector doctorAutoPromoteConnector,
+	states []string,
+) ([]connector.Issue, error) {
+	if limited, ok := projectConnector.(doctorAutoPromoteLimitedConnector); ok {
+		return limited.FetchIssuesByStatesLimit(ctx, states, doctorAutoPromoteSampleLimit)
+	}
+	issues, err := projectConnector.FetchIssuesByStates(ctx, states)
+	if err != nil {
+		return nil, err
+	}
+	if len(issues) > doctorAutoPromoteSampleLimit {
+		issues = issues[:doctorAutoPromoteSampleLimit]
+	}
+	return issues, nil
+}
+
+func doctorAutoPromoteConfig(cfg workflowconfig.Config) orchestrator.AutoPromoteConfig {
+	return orchestrator.AutoPromoteConfig{
+		Enabled:            cfg.Agent.AutoPromote.Enabled,
+		QuietDuration:      time.Duration(cfg.Agent.AutoPromote.QuietSeconds) * time.Second,
+		OptoutLabel:        cfg.Agent.AutoPromote.OptoutLabel,
+		AllowedIssueLabels: append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
+		Gate:               cfg.Gate,
+	}
+}
+
+func doctorAutoPromoteReasonCounts(counts map[orchestrator.AutoPromoteReason]int) string {
+	reasons := make([]string, 0, len(counts))
+	for reason := range counts {
+		if strings.TrimSpace(string(reason)) != "" {
+			reasons = append(reasons, string(reason))
+		}
+	}
+	sort.Strings(reasons)
+
+	parts := make([]string, 0, len(reasons))
+	for _, reason := range reasons {
+		parts = append(parts, fmt.Sprintf("%s=%d", reason, counts[orchestrator.AutoPromoteReason(reason)]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func doctorLinkedPullRequestNumber(issue connector.Issue) (int, bool) {
+	if issue.PRNumber == nil || *issue.PRNumber <= 0 {
+		return 0, false
+	}
+	return *issue.PRNumber, true
+}
+
+func doctorIssueLabel(issue connector.Issue) string {
+	id := strings.TrimSpace(issue.ID)
+	identifier := strings.TrimSpace(issue.Identifier)
+	switch {
+	case id != "" && identifier != "":
+		return id + " (" + identifier + ")"
+	case id != "":
+		return id
+	case identifier != "":
+		return identifier
+	default:
+		return "sampled issue"
+	}
+}
+
+func doctorStateInList(state string, states []string) bool {
+	state = strings.ToLower(strings.TrimSpace(state))
+	if state == "" {
+		return false
+	}
+	for _, candidate := range states {
+		if strings.ToLower(strings.TrimSpace(candidate)) == state {
+			return true
+		}
+	}
+	return false
+}
+
+func closeDoctorAutoPromoteConnector(projectConnector doctorAutoPromoteConnector) error {
+	closer, ok := projectConnector.(connector.Closer)
+	if !ok {
+		return nil
+	}
+	return closer.Close()
+}
+
+func defaultDoctorAutoPromoteConnector(cfg workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+	return factory.NewFromConfig(factory.Config{
+		Kind:                    cfg.Tracker.Kind,
+		Memory:                  memory.Config{Issues: cfg.Tracker.Issues},
+		Endpoint:                cfg.Tracker.Endpoint,
+		APIKey:                  cfg.Tracker.APIKey,
+		HTTPMaxIdleConns:        cfg.Tracker.HTTPMaxIdleConns,
+		HTTPMaxIdleConnsPerHost: cfg.Tracker.HTTPMaxIdleConnsPerHost,
+		HTTPIdleConnTimeoutMS:   cfg.Tracker.HTTPIdleConnTimeoutMS,
+		GitHubAppID:             cfg.Tracker.GitHubAppID,
+		GitHubAppPrivateKey:     cfg.Tracker.GitHubAppPrivateKey,
+		GitHubAppPrivateKeyPath: cfg.Tracker.GitHubAppPrivateKeyPath,
+		GitHubAppInstallationID: cfg.Tracker.GitHubAppInstallationID,
+		ProjectSlug:             cfg.Tracker.ProjectSlug,
+		ActiveStates:            cfg.Tracker.ActiveStates,
+		ObservedStates:          cfg.Tracker.ObservedStates,
+		TerminalStates:          cfg.Tracker.TerminalStates,
+		StateMap:                doctorTrackerStateMap(cfg.Tracker.StateMap),
+	})
+}
+
+func doctorTrackerStateMap(value workflowconfig.StringOrMap) map[string]string {
+	if !value.IsMap {
+		return nil
+	}
+
+	out := make(map[string]string, len(value.Map))
+	for state, mapped := range value.Map {
+		mappedState, ok := mapped.(string)
+		if !ok {
+			continue
+		}
+		state = strings.TrimSpace(state)
+		mappedState = strings.TrimSpace(mappedState)
+		if state != "" && mappedState != "" {
+			out[state] = mappedState
+		}
+	}
+	return out
 }
 
 func doctorWorkflowConfigWithRuntimeGitHubToken(cfg workflowconfig.Config, token string) workflowconfig.Config {
@@ -744,20 +1024,24 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.gitWorkTree == nil {
 		d.gitWorkTree = defaults.gitWorkTree
 	}
+	if d.autoPromoteConnector == nil {
+		d.autoPromoteConnector = defaults.autoPromoteConnector
+	}
 	return d
 }
 
 func defaultDoctorDeps() doctorDeps {
 	return doctorDeps{
-		loadWorkflow: workflowconfig.LoadWorkflow,
-		lookupEnv:    os.Getenv,
-		lookPath:     exec.LookPath,
-		runCommand:   runDoctorCommand,
-		githubScopes: defaultGitHubScopes,
-		ghAuthToken:  defaultGHAuthToken,
-		listen:       net.Listen,
-		openSQLite:   openDoctorSQLite,
-		gitWorkTree:  defaultGitWorkTree,
+		loadWorkflow:         workflowconfig.LoadWorkflow,
+		lookupEnv:            os.Getenv,
+		lookPath:             exec.LookPath,
+		runCommand:           runDoctorCommand,
+		githubScopes:         defaultGitHubScopes,
+		ghAuthToken:          defaultGHAuthToken,
+		listen:               net.Listen,
+		openSQLite:           openDoctorSQLite,
+		gitWorkTree:          defaultGitWorkTree,
+		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -404,14 +404,6 @@ func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.C
 			Detail: "agent.auto_promote.enabled=false; live candidate diagnostics disabled",
 		}
 	}
-	if !doctorStateInList("Human Review", cfg.Tracker.ObservedStates) {
-		return doctorCheck{
-			Name:   name,
-			Status: doctorFail,
-			Detail: "agent.auto_promote.enabled=true but tracker.observed_states does not include Human Review",
-			Hint:   "Add Human Review to tracker.observed_states so Detent can observe review-lane candidates.",
-		}
-	}
 	if !doctorStateInList("Merging", cfg.Tracker.ActiveStates) {
 		return doctorCheck{
 			Name:   name,

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -224,14 +224,15 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 			wantDetails: []string{"disabled"},
 		},
 		{
-			name: "missing human review observed state",
+			name: "human review observed state is not required",
 			cfg: func() workflowconfig.Config {
 				cfg := validDoctorAutoPromoteWorkflow()
 				cfg.Tracker.ObservedStates = []string{"Blocked"}
 				return cfg
 			}(),
-			want:        doctorFail,
-			wantDetails: []string{"tracker.observed_states", "Human Review"},
+			connector:   &fakeDoctorAutoPromoteConnector{},
+			want:        doctorOK,
+			wantDetails: []string{"sampled 0 Human Review candidate"},
 		},
 		{
 			name: "missing merging active state",

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -269,7 +269,7 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 				issues: []connector.Issue{waitingIssue, missingReviewIssue},
 			},
 			want:        doctorOK,
-			wantDetails: []string{"ci_not_green=1", "codex_review_missing=1"},
+			wantDetails: []string{"automated_review_missing=1", "ci_not_green=1"},
 		},
 		{
 			name: "ready candidate passes with count",

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -9,9 +9,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
 
@@ -175,6 +177,130 @@ func TestProjectSourceRootPrefersProjectWorkdirBeforeWorkspaceRoot(t *testing.T)
 	cfg.Workspace.SourceRoot = "/configured-source"
 	if got := projectSourceRoot(project, cfg); got != "/configured-source" {
 		t.Fatalf("projectSourceRoot() with source_root = %q, want /configured-source", got)
+	}
+}
+
+func TestCheckDoctorAutoPromote(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	oldActivity := now.Add(-20 * time.Minute)
+	prNumber := 42
+	waitingIssue := doctorAutoPromoteIssue("issue-ci", &connector.PullRequest{
+		Number:           41,
+		URL:              "https://github.test/pull/41",
+		State:            "OPEN",
+		CIStatus:         "fail",
+		CodexReviewState: "COMMENTED",
+	})
+	missingReviewIssue := doctorAutoPromoteIssue("issue-review", &connector.PullRequest{
+		Number:   43,
+		URL:      "https://github.test/pull/43",
+		State:    "OPEN",
+		CIStatus: "success",
+	})
+	linkedWithoutMetadata := doctorAutoPromoteIssue("issue-missing-pr", nil)
+	linkedWithoutMetadata.PRNumber = &prNumber
+	readyIssue := doctorAutoPromoteIssue("issue-ready", &connector.PullRequest{
+		Number:                 44,
+		URL:                    "https://github.test/pull/44",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldActivity,
+	})
+
+	tests := []struct {
+		name        string
+		cfg         workflowconfig.Config
+		connector   *fakeDoctorAutoPromoteConnector
+		want        doctorStatus
+		wantDetails []string
+	}{
+		{
+			name:        "disabled",
+			cfg:         validDoctorWorkflow("/repo"),
+			want:        doctorOK,
+			wantDetails: []string{"disabled"},
+		},
+		{
+			name: "missing human review observed state",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorAutoPromoteWorkflow()
+				cfg.Tracker.ObservedStates = []string{"Blocked"}
+				return cfg
+			}(),
+			want:        doctorFail,
+			wantDetails: []string{"tracker.observed_states", "Human Review"},
+		},
+		{
+			name: "missing merging active state",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorAutoPromoteWorkflow()
+				cfg.Tracker.ActiveStates = []string{"Todo", "In Progress", "Rework"}
+				return cfg
+			}(),
+			want:        doctorFail,
+			wantDetails: []string{"tracker.active_states", "Merging"},
+		},
+		{
+			name: "status option verification fails",
+			cfg:  validDoctorAutoPromoteWorkflow(),
+			connector: &fakeDoctorAutoPromoteConnector{
+				verifyErr: errors.New("github status option not found: Human Review maps to Reviewing"),
+			},
+			want:        doctorFail,
+			wantDetails: []string{"status option", "Human Review", "Reviewing"},
+		},
+		{
+			name: "linked pr missing metadata fails",
+			cfg:  validDoctorAutoPromoteWorkflow(),
+			connector: &fakeDoctorAutoPromoteConnector{
+				issues: []connector.Issue{linkedWithoutMetadata},
+			},
+			want:        doctorFail,
+			wantDetails: []string{"missing_pull_request", "linked PR #42", "issue-missing-pr"},
+		},
+		{
+			name: "expected waiting reasons pass with counts",
+			cfg:  validDoctorAutoPromoteWorkflow(),
+			connector: &fakeDoctorAutoPromoteConnector{
+				issues: []connector.Issue{waitingIssue, missingReviewIssue},
+			},
+			want:        doctorOK,
+			wantDetails: []string{"ci_not_green=1", "codex_review_missing=1"},
+		},
+		{
+			name: "ready candidate passes with count",
+			cfg:  validDoctorAutoPromoteWorkflow(),
+			connector: &fakeDoctorAutoPromoteConnector{
+				issues: []connector.Issue{readyIssue},
+			},
+			want:        doctorOK,
+			wantDetails: []string{"ready=1"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := doctorDeps{}
+			if tt.connector != nil {
+				deps.autoPromoteConnector = func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+					return tt.connector, nil
+				}
+			}
+			got := checkDoctorAutoPromote(context.Background(), "alpha", tt.cfg, deps, now)
+			if got.Status != tt.want {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.want, got)
+			}
+			for _, want := range tt.wantDetails {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+		})
 	}
 }
 
@@ -655,6 +781,45 @@ func validDoctorWorkflow(sourceRoot string) workflowconfig.Config {
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Workspace.Root = sourceRoot
 	return cfg
+}
+
+func validDoctorAutoPromoteWorkflow() workflowconfig.Config {
+	cfg := validDoctorWorkflow("/repo")
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	cfg.Tracker.APIKey = "token"
+	cfg.Tracker.ProjectSlug = "PVT_1"
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress", "Rework", "Merging"}
+	cfg.Tracker.ObservedStates = []string{"Backlog", "Human Review", "Blocked"}
+	cfg.Agent.AutoPromote.Enabled = true
+	cfg.Agent.AutoPromote.QuietSeconds = 600
+	return cfg
+}
+
+func doctorAutoPromoteIssue(id string, pullRequest *connector.PullRequest) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = "digitaldrywood/detent#399"
+	issue.Title = "Auto promote diagnostic"
+	issue.State = "Human Review"
+	issue.PullRequest = pullRequest
+	return issue
+}
+
+type fakeDoctorAutoPromoteConnector struct {
+	issues    []connector.Issue
+	verifyErr error
+}
+
+func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return c.issues, nil
+}
+
+func (c *fakeDoctorAutoPromoteConnector) FetchIssuesByStatesLimit(context.Context, []string, int) ([]connector.Issue, error) {
+	return c.issues, nil
+}
+
+func (c *fakeDoctorAutoPromoteConnector) VerifyStatusOptions(context.Context, []string) error {
+	return c.verifyErr
 }
 
 func successfulDoctorOptions(configPath string) options {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -753,6 +753,64 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 	return issues, nil
 }
 
+func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []string, limit int) ([]connector.Issue, error) {
+	if limit <= 0 {
+		return []connector.Issue{}, nil
+	}
+	wantedStates := normalizedStateSet(stateNames)
+	if len(wantedStates) == 0 {
+		return []connector.Issue{}, nil
+	}
+	if c.projectID == "" {
+		return nil, ErrMissingProject
+	}
+
+	issues, err := c.fetchProjectItemsWithPullRequestRefsLimit(ctx, graphQLQueryObservedStatus, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
+		_, ok := wantedStates[normalizeStateName(issue.State)]
+		return ok
+	}, limit)
+	if err != nil {
+		return nil, err
+	}
+	if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
+		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+			return nil, err
+		}
+	}
+	if attachPullRequestsForStates(wantedStates) {
+		if err := c.attachPullRequests(ctx, issues); err != nil {
+			return nil, err
+		}
+	}
+	return issues, nil
+}
+
+func (c *Connector) VerifyStatusOptions(ctx context.Context, stateNames []string) error {
+	seen := map[string]struct{}{}
+	for _, stateName := range stateNames {
+		stateName = strings.TrimSpace(stateName)
+		if stateName == "" {
+			continue
+		}
+		githubState := c.detentToGitHubState(stateName)
+		key := normalizeStateName(githubState)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		if _, _, err := c.resolveStatusOption(ctx, githubState); err != nil {
+			if errors.Is(err, ErrStatusOptionNotFound) {
+				return fmt.Errorf("%w: %s maps to %s", ErrStatusOptionNotFound, stateName, githubState)
+			}
+			return err
+		}
+	}
+	return nil
+}
+
 func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) ([]connector.Issue, error) {
 	ids := uniqueNonBlank(issueIDs)
 	if len(ids) == 0 {
@@ -1689,6 +1747,37 @@ func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullReques
 }
 
 func (c *Connector) fetchProjectItems(ctx context.Context, queryType string, query string, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
+	return c.fetchProjectItemsLimit(ctx, queryType, query, keepIssue, 0)
+}
+
+func (c *Connector) fetchProjectItemsLimit(
+	ctx context.Context,
+	queryType string,
+	query string,
+	keepIssue func(connector.Issue) bool,
+	limit int,
+) ([]connector.Issue, error) {
+	return c.fetchProjectItemsWithLimit(ctx, projectItemsQueryForType(queryType), queryType, query, keepIssue, limit)
+}
+
+func (c *Connector) fetchProjectItemsWithPullRequestRefsLimit(
+	ctx context.Context,
+	queryType string,
+	query string,
+	keepIssue func(connector.Issue) bool,
+	limit int,
+) ([]connector.Issue, error) {
+	return c.fetchProjectItemsWithLimit(ctx, observedStatusProjectItemsQuery, queryType, query, keepIssue, limit)
+}
+
+func (c *Connector) fetchProjectItemsWithLimit(
+	ctx context.Context,
+	queryDocument string,
+	queryType string,
+	query string,
+	keepIssue func(connector.Issue) bool,
+	limit int,
+) ([]connector.Issue, error) {
 	var after *string
 	allIssues := []connector.Issue{}
 	blankStatusItemIDs := []string{}
@@ -1703,7 +1792,7 @@ func (c *Connector) fetchProjectItems(ctx context.Context, queryType string, que
 				Items projectItemsConnection `json:"items"`
 			} `json:"node"`
 		}
-		if err := c.client.GraphQLWithType(ctx, queryType, projectItemsQueryForType(queryType), map[string]any{
+		if err := c.client.GraphQLWithType(ctx, queryType, queryDocument, map[string]any{
 			"projectId": c.projectID,
 			"first":     projectItemsPageSize,
 			"after":     after,
@@ -1727,18 +1816,20 @@ func (c *Connector) fetchProjectItems(ctx context.Context, queryType string, que
 				blankStatusItemIDs = append(blankStatusItemIDs, blankStatusItemID)
 			}
 			allIssues = append(allIssues, issue)
+			if limit > 0 && keepIssue(issue) {
+				issues := keptProjectIssues(allIssues, keepIssue, limit)
+				if len(issues) >= limit {
+					c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
+					resolveBlockedByProjectState(issues)
+					return issues, nil
+				}
+			}
 		}
 
 		if !response.Node.Items.PageInfo.HasNextPage {
 			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
 			resolveBlockedByProjectState(allIssues)
-			issues := make([]connector.Issue, 0, len(allIssues))
-			for _, issue := range allIssues {
-				if keepIssue(issue) {
-					issues = append(issues, issue)
-				}
-			}
-			return issues, nil
+			return keptProjectIssues(allIssues, keepIssue, limit), nil
 		}
 		cursor := strings.TrimSpace(response.Node.Items.PageInfo.EndCursor)
 		if cursor == "" {
@@ -1753,6 +1844,20 @@ func projectItemsQueryForType(queryType string) string {
 		return observedStatusProjectItemsQuery
 	}
 	return projectItemsQuery
+}
+
+func keptProjectIssues(allIssues []connector.Issue, keepIssue func(connector.Issue) bool, limit int) []connector.Issue {
+	issues := make([]connector.Issue, 0, len(allIssues))
+	for _, issue := range allIssues {
+		if !keepIssue(issue) {
+			continue
+		}
+		issues = append(issues, issue)
+		if limit > 0 && len(issues) >= limit {
+			return issues
+		}
+	}
+	return issues
 }
 
 func (c *Connector) normalizeProjectItem(item projectItemNode) (connector.Issue, bool, string, error) {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -707,7 +707,22 @@ func TestConnectorFetchIssuesByStatesLimitStopsAfterSample(t *testing.T) {
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			path:   "/repos/digitaldrywood/detent/pulls/371",
+			body:   `{"number":371,"html_url":"https://github.com/digitaldrywood/detent/pull/371","state":"open","head":{"ref":"detent/digitaldrywood_detent_370","sha":"sha-371"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-371/check-runs?per_page=100",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-371/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/371/reviews?per_page=100",
 			body:   `[]`,
 		},
 	})
@@ -723,13 +738,14 @@ func TestConnectorFetchIssuesByStatesLimitStopsAfterSample(t *testing.T) {
 	if got[0].PRNumber == nil || *got[0].PRNumber != 371 {
 		t.Fatalf("PRNumber = %v, want linked PR 371", got[0].PRNumber)
 	}
-	if got[0].PullRequest != nil {
-		t.Fatalf("PullRequest = %#v, want nil when branch metadata is not attached", got[0].PullRequest)
+	pr := got[0].PullRequest
+	if pr == nil || pr.Number != 371 || pr.CIStatus != "pass" {
+		t.Fatalf("PullRequest = %#v, want hydrated linked PR 371 with passing CI", pr)
 	}
 
 	requests := server.requests()
-	if len(requests) != 2 {
-		t.Fatalf("request count = %d, want one project page and one pull request page", len(requests))
+	if len(requests) != 5 {
+		t.Fatalf("request count = %d, want one project page and linked PR status requests", len(requests))
 	}
 	if requests[0]["variables"].(map[string]any)["after"] != nil {
 		t.Fatalf("first project request after = %v, want nil", requests[0]["variables"].(map[string]any)["after"])

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -694,6 +695,44 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		pr.CodexReviewFindings[0].Body != "[P1] Unsafe migration." ||
 		pr.CodexReviewFindings[0].URL != "https://github.com/digitaldrywood/detent/pull/190#pullrequestreview-2" {
 		t.Fatalf("PullRequest.CodexReviewFindings = %#v, want P1 review finding", pr.CodexReviewFindings)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesLimitStopsAfterSample(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":true,"endCursor":"next"},"nodes":[{"id":"PVTI_370","content":{"__typename":"Issue","id":"I_370","number":370,"title":"Review issue","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/370","repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":371,"url":"https://github.com/digitaldrywood/detent/pull/371"}]}},"statusValue":{"name":"Human Review"},"priorityValue":null},{"id":"PVTI_387","content":{"__typename":"Issue","id":"I_387","number":387,"title":"Review issue 2","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/387","repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssuesByStatesLimit(context.Background(), []string{"Human Review"}, 1)
+	if err != nil {
+		t.Fatalf("FetchIssuesByStatesLimit() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStatesLimit() len = %d, want 1", len(got))
+	}
+	if got[0].PRNumber == nil || *got[0].PRNumber != 371 {
+		t.Fatalf("PRNumber = %v, want linked PR 371", got[0].PRNumber)
+	}
+	if got[0].PullRequest != nil {
+		t.Fatalf("PullRequest = %#v, want nil when branch metadata is not attached", got[0].PullRequest)
+	}
+
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want one project page and one pull request page", len(requests))
+	}
+	if requests[0]["variables"].(map[string]any)["after"] != nil {
+		t.Fatalf("first project request after = %v, want nil", requests[0]["variables"].(map[string]any)["after"])
 	}
 }
 
@@ -1450,6 +1489,34 @@ func TestConnectorUpdateIssueStateWritesStatusOptionID(t *testing.T) {
 	}
 	if variables["optionId"] == "Ready" {
 		t.Fatal("optionId used the option name, want option id")
+	}
+}
+
+func TestConnectorVerifyStatusOptionsChecksMappedStatusOptions(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_review","name":"Reviewing"}]}}}}`},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+		StateMap:    map[string]string{"Human Review": "Reviewing"},
+	})
+
+	err := c.VerifyStatusOptions(context.Background(), []string{"Human Review", "Merging"})
+	if !errors.Is(err, ErrStatusOptionNotFound) {
+		t.Fatalf("VerifyStatusOptions() error = %v, want ErrStatusOptionNotFound", err)
+	}
+	if !strings.Contains(err.Error(), "Merging") {
+		t.Fatalf("VerifyStatusOptions() error = %q, want missing Merging detail", err.Error())
+	}
+
+	requests := server.requests()
+	if len(requests) != 1 {
+		t.Fatalf("request count = %d, want 1", len(requests))
+	}
+	if strings.Contains(requests[0]["query"].(string), "updateProjectV2ItemFieldValue") {
+		t.Fatalf("VerifyStatusOptions issued mutation: %q", requests[0]["query"])
 	}
 }
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -37,7 +37,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 			continue
 		}
 
-		summary := autoPromoteSummaryFromIssue(issue)
+		summary := AutoPromoteSummaryFromIssue(issue)
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
 		targetState := autoPromoteTargetState(decision.Action)
 		if targetState == "" {
@@ -55,7 +55,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 	return transitioned
 }
 
-func autoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
+func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	summary := AutoPromoteSummary{
 		LastActivityAt: autoPromoteLastActivityAt(issue),
 	}


### PR DESCRIPTION
## Summary
- Add a doctor auto-promote preflight for enabled GitHub projects that checks Human Review/Merging config and ProjectV2 status options.
- Sample up to five Human Review issues through the same auto-promote readiness summary path and fail when GitHub exposes a linked PR but Detent still reports missing_pull_request.
- Add bounded GitHub sampling with closing PR references and tests for broken wiring, waiting reasons, and ready candidates.

Fixes #399

## Test Plan
- go test ./internal/cli
- go test ./internal/connector/github
- go test ./internal/orchestrator ./internal/connector
- make check