### PR TITLE
fix(tui): route ctrl-c to shutdown

### DIFF
--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -31,13 +31,12 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 			return
 		case <-first:
 			signal.Stop(first)
-			if !controller.Active() {
+			if !controller.RequestInterrupt() {
 				if cancelRoot != nil {
 					cancelRoot()
 				}
 				return
 			}
-			controller.RequestDrain()
 		}
 
 		second := make(chan os.Signal, 1)
@@ -47,8 +46,7 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 		case <-stop:
 			return
 		case <-second:
-			if controller.Active() {
-				controller.RequestForce()
+			if controller.RequestInterrupt() {
 				return
 			}
 			if cancelRoot != nil {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -246,7 +246,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		}
 		listenerOwned = false
 		if cfg.Shutdown == nil {
-			return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub, cfg.Build)
+			return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub, cfg.Build, nil)
 		}
 		return runWithShutdown(runCtx, runningShutdownConfig{
 			Controller:       cfg.Shutdown,
@@ -260,7 +260,9 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			ProgressInterval: defaultShutdownProgressInterval,
 			HardTimeout:      defaultShutdownHardTimeout,
 		}, func(ctx context.Context) error {
-			return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build)
+			return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, func() {
+				cfg.Shutdown.RequestInterrupt()
+			})
 		})
 	}
 	if err := printBootBanner(cfg, displayURL); err != nil {
@@ -356,7 +358,7 @@ func serve(ctx context.Context, server *web.Server, listener net.Listener) error
 	}
 }
 
-func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listener net.Listener, snapshots *hub.Hub[telemetry.Snapshot], build buildinfo.Info) error {
+func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listener net.Listener, snapshots *hub.Hub[telemetry.Snapshot], build buildinfo.Info, interrupt func()) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -372,7 +374,7 @@ func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listene
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	model, err := tui.NewModel(runCtx, snapshots, tui.WithBuild(build))
+	model, err := tui.NewModel(runCtx, snapshots, tui.WithBuild(build), tui.WithInterruptFunc(interrupt))
 	if err != nil {
 		return err
 	}
@@ -384,7 +386,7 @@ func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listene
 		errs <- serve(runCtx, server, listener)
 	}()
 	go func() {
-		_, err := tea.NewProgram(model, tea.WithAltScreen(), tea.WithContext(runCtx)).Run()
+		_, err := tea.NewProgram(model, tea.WithAltScreen(), tea.WithContext(runCtx), tea.WithoutSignalHandler()).Run()
 		errs <- err
 	}()
 

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -39,8 +39,9 @@ const (
 )
 
 type ShutdownController struct {
-	requests chan ShutdownRequest
-	active   atomic.Bool
+	requests          chan ShutdownRequest
+	active            atomic.Bool
+	shutdownRequested atomic.Bool
 }
 
 func NewShutdownController() *ShutdownController {
@@ -48,10 +49,16 @@ func NewShutdownController() *ShutdownController {
 }
 
 func (c *ShutdownController) RequestDrain() {
+	if c != nil {
+		c.shutdownRequested.Store(true)
+	}
 	c.request(ShutdownRequestDrain)
 }
 
 func (c *ShutdownController) RequestForce() {
+	if c != nil {
+		c.shutdownRequested.Store(true)
+	}
 	c.request(ShutdownRequestForce)
 }
 
@@ -66,13 +73,27 @@ func (c *ShutdownController) Active() bool {
 	return c != nil && c.active.Load()
 }
 
+func (c *ShutdownController) RequestInterrupt() bool {
+	if c == nil || !c.Active() {
+		return false
+	}
+	if c.shutdownRequested.CompareAndSwap(false, true) {
+		c.request(ShutdownRequestDrain)
+		return true
+	}
+	c.request(ShutdownRequestForce)
+	return true
+}
+
 func (c *ShutdownController) activate() func() {
 	if c == nil {
 		return func() {}
 	}
+	c.shutdownRequested.Store(false)
 	c.active.Store(true)
 	return func() {
 		c.active.Store(false)
+		c.shutdownRequested.Store(false)
 	}
 }
 

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -28,6 +28,52 @@ func TestShutdownControllerQueuesRequests(t *testing.T) {
 	}
 }
 
+func TestShutdownControllerInterruptRequestsDrainThenForce(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	if controller.RequestInterrupt() {
+		t.Fatal("inactive interrupt was handled")
+	}
+
+	deactivate := controller.activate()
+	defer deactivate()
+
+	if !controller.RequestInterrupt() {
+		t.Fatal("active interrupt was not handled")
+	}
+	if got := <-controller.Requests(); got != ShutdownRequestDrain {
+		t.Fatalf("first interrupt = %v, want drain", got)
+	}
+
+	if !controller.RequestInterrupt() {
+		t.Fatal("second interrupt was not handled")
+	}
+	if got := <-controller.Requests(); got != ShutdownRequestForce {
+		t.Fatalf("second interrupt = %v, want force", got)
+	}
+}
+
+func TestShutdownControllerDrainMakesNextInterruptForce(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	deactivate := controller.activate()
+	defer deactivate()
+
+	controller.RequestDrain()
+	if got := <-controller.Requests(); got != ShutdownRequestDrain {
+		t.Fatalf("explicit drain = %v, want drain", got)
+	}
+
+	if !controller.RequestInterrupt() {
+		t.Fatal("interrupt after drain was not handled")
+	}
+	if got := <-controller.Requests(); got != ShutdownRequestForce {
+		t.Fatalf("interrupt after drain = %v, want force", got)
+	}
+}
+
 func TestRunWithShutdownZeroSessionsExitsGracefully(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -24,8 +24,9 @@ const defaultDashboardURL = "http://localhost:4000"
 type Option func(*options)
 
 type options struct {
-	now   func() time.Time
-	build buildinfo.Info
+	now       func() time.Time
+	build     buildinfo.Info
+	interrupt func()
 }
 
 type Model struct {
@@ -37,6 +38,7 @@ type Model struct {
 	height       int
 	now          func() time.Time
 	build        buildinfo.Info
+	interrupt    func()
 	styles       styles
 }
 
@@ -70,6 +72,7 @@ func NewModel(ctx context.Context, snapshots *hub.Hub[telemetry.Snapshot], opts 
 		width:        defaultTerminalColumns,
 		now:          cfg.now,
 		build:        cfg.build,
+		interrupt:    cfg.interrupt,
 		styles:       newStyles(),
 	}, nil
 }
@@ -85,6 +88,12 @@ func WithNow(now func() time.Time) Option {
 func WithBuild(build buildinfo.Info) Option {
 	return func(cfg *options) {
 		cfg.build = build
+	}
+}
+
+func WithInterruptFunc(interrupt func()) Option {
+	return func(cfg *options) {
+		cfg.interrupt = interrupt
 	}
 }
 
@@ -106,6 +115,13 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		return m, nil
 	case tea.KeyMsg:
 		switch msg.String() {
+		case "ctrl+c":
+			if m.interrupt != nil {
+				m.interrupt()
+				return m, nil
+			}
+			m.Close()
+			return m, tea.Quit
 		case "q", "esc":
 			m.Close()
 			return m, tea.Quit

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -160,7 +160,29 @@ func TestModelClosesSubscriptionOnQuit(t *testing.T) {
 	}
 }
 
-func TestModelLeavesCtrlCForSignalHandler(t *testing.T) {
+func TestModelRequestsInterruptOnCtrlC(t *testing.T) {
+	t.Parallel()
+
+	interrupts := make(chan struct{}, 1)
+	model, err := NewModel(context.Background(), hub.New[telemetry.Snapshot]())
+	if err != nil {
+		t.Fatalf("NewModel() error = %v", err)
+	}
+	model.interrupt = func() {
+		interrupts <- struct{}{}
+	}
+
+	if _, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC}); cmd != nil {
+		t.Fatal("Update(ctrl+c) returned command")
+	}
+	select {
+	case <-interrupts:
+	case <-time.After(time.Second):
+		t.Fatal("interrupt handler was not called")
+	}
+}
+
+func TestModelQuitsOnCtrlCWithoutInterruptHandler(t *testing.T) {
 	t.Parallel()
 
 	model, err := NewModel(context.Background(), hub.New[telemetry.Snapshot]())
@@ -168,8 +190,8 @@ func TestModelLeavesCtrlCForSignalHandler(t *testing.T) {
 		t.Fatalf("NewModel() error = %v", err)
 	}
 
-	if _, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC}); cmd != nil {
-		t.Fatal("Update(ctrl+c) returned command, want signal handler to own shutdown")
+	if _, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC}); cmd == nil {
+		t.Fatal("Update(ctrl+c) did not return quit command")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Route raw-mode terminal Ctrl+C through the graceful shutdown controller.
- Share first/second interrupt state between TUI key events and OS signals.
- Disable Bubble Tea internal signal handling for the terminal dashboard.

Fixes N/A

## Test Plan

- [x] `make check`
- [x] Manual PTY run with raw Ctrl+C triggering graceful shutdown and clean exit