### PR TITLE
fix(workflow): unblock stalled board automation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,10 @@ The board is the state machine; board status drives everything.
    contract — moving the issue to `In Progress`.
 3. **The agent works** in its own branch, runs your validation gate, and opens
    or updates a PR, then moves the issue to `Human Review`.
-4. **Gates decide.** Your approval plus current-head automated review (e.g.
-   Codex) clear it to `Merging`; unresolved feedback sends it to `Rework` for
-   another pass.
+4. **Gates decide.** `Human Review` is the holding state. The workflow decides
+   whether promotion to `Merging` waits for a human label, a current-head
+   automated PR review, or only linked PR + green CI + quiet time. Unresolved
+   feedback sends it to `Rework` for another pass.
 5. **The merge train is serialized** — one rebase, CI-watch, and merge at a
    time, so concurrent candidates never invalidate each other's CI — then the
    issue is `Done`.
@@ -85,11 +86,14 @@ counts:
   labels, blockers, comments, and pull requests are the state machine.
 - **Multi-project from one host.** `global.yaml` runs many repositories with
   weights, priority, pause, and fair scheduling.
-- **Explicit gates + a serialized merge train.** CI plus automated (Codex)
-  review plus a one-at-a-time `Merging` lane, so what lands is always green.
+- **Explicit gates + a serialized merge train.** CI, optional automated PR
+  review criteria, and a one-at-a-time `Merging` lane, so what lands is always
+  green.
 - **Pluggable validation gates.** Code defaults use `make check`, CI, and
-  automated review, while workflow authors can choose a command gate or a human
-  approval-label gate for files-in-repo work.
+  automated review, while workflow authors can choose whether a command gate
+  requires automated PR review or instead only waits for CI and the quiet
+  window. A human approval-label gate is available when the workflow explicitly
+  wants one.
 - **A real operator surface.** A live dashboard (charts, trends, timelines,
   hover detail, budget and rate-limit state) and terminal UI, `detent doctor`
   preflight checks, cross-platform config discovery, and a GoReleaser pipeline.
@@ -313,6 +317,7 @@ codex:
 gate:
   kind: command
   run: make check
+  require_automated_review: true
 server:
   host: 127.0.0.1
   port: 4000
@@ -346,9 +351,13 @@ default because Symphony polls Linear, which has a different rate model.
 
 `gate` controls the validation contract the agent and operator flow follow.
 Omitting it preserves the code default: `kind: command` with `run: make check`,
-plus green CI and clean automated review before promotion. Use
-`kind: human_review` with `approval_label` when the gate is a human label rather
-than a command.
+plus green CI, no P1 automated PR review findings, a quiet window, and a
+current-head automated PR review before auto-promotion. Set
+`require_automated_review: false` on a command gate when the workflow should
+auto-promote from `Human Review` after a linked open PR, green CI, no P1 bot
+review findings, and the quiet period. Use `kind: human_review` with
+`approval_label` only when the workflow explicitly requires a human approval
+label to promote.
 
 For production, self-hosted, or multi-instance GitHub Projects, prefer GitHub
 App installation authentication instead of a shared personal access token. App
@@ -603,11 +612,30 @@ The recommended GitHub Project board states are:
 | `Todo` | Ready for Detent to claim and dispatch. |
 | `In Progress` | An agent is actively working or continuing work. |
 | `Blocked` | Human-blocked work, or dependency-waiting work when auto-unblock is enabled. |
-| `Human Review` | The PR is ready for approval. |
+| `Human Review` | The PR is ready for review/soak until the workflow's promotion criteria pass. |
 | `Rework` | Human or bot feedback needs another agent pass. |
 | `Merging` | Final rebase, validation, CI watch, and merge. |
 | `Done` | Complete. |
 | `Cancelled` | Terminal state mapped to `Done` in the default release flow. |
+
+### Review gate
+
+`Human Review` is the holding state before the merge train. Auto-promotion out
+of that state is controlled by the workflow:
+
+- `gate.kind: command` requires a linked open PR, green CI, no P1 automated PR
+  review findings, and the configured quiet period. By default it also requires
+  a current-head automated GitHub PR review.
+- `gate.kind: command` with `require_automated_review: false` keeps the linked
+  PR, green CI, no-P1, and quiet-period checks but does not require a bot PR
+  review to exist.
+- `gate.kind: human_review` requires a linked open PR plus the configured
+  `approval_label` on the issue.
+
+A Codex coding session that created the PR is not the same signal as a
+Codex/ChatGPT/Claude GitHub PR review. If automated PR review is required and
+the PR head changes after a review, request or wait for a fresh automated review
+before expecting auto-promotion.
 
 ### Set up the board
 

--- a/README.md
+++ b/README.md
@@ -51,8 +51,9 @@ The board is the state machine; board status drives everything.
    contract — moving the issue to `In Progress`.
 3. **The agent works** in its own branch, runs your validation gate, and opens
    or updates a PR, then moves the issue to `Human Review`.
-4. **Gates decide.** Your approval plus automated review (e.g. Codex) clear it
-   to `Merging`; unresolved feedback sends it to `Rework` for another pass.
+4. **Gates decide.** Your approval plus current-head automated review (e.g.
+   Codex) clear it to `Merging`; unresolved feedback sends it to `Rework` for
+   another pass.
 5. **The merge train is serialized** — one rebase, CI-watch, and merge at a
    time, so concurrent candidates never invalidate each other's CI — then the
    issue is `Done`.
@@ -601,7 +602,7 @@ The recommended GitHub Project board states are:
 | `Backlog` | Not eligible for agents yet. |
 | `Todo` | Ready for Detent to claim and dispatch. |
 | `In Progress` | An agent is actively working or continuing work. |
-| `Blocked` | Detent cannot continue without human action. |
+| `Blocked` | Human-blocked work, or dependency-waiting work when auto-unblock is enabled. |
 | `Human Review` | The PR is ready for approval. |
 | `Rework` | Human or bot feedback needs another agent pass. |
 | `Merging` | Final rebase, validation, CI watch, and merge. |
@@ -638,17 +639,20 @@ Detent supports two dependency patterns. Use the one that matches how much of
 the wait should be visible on the board.
 
 - **Keep the issue in `Todo`.** Add a machine-readable dependency line such as
-  `Depends on: #123` or `Blocked by: owner/repo#123`. Detent keeps the issue out
-  of dispatch while any referenced blocker is non-terminal, then dispatches it
-  normally after blockers clear. This is the default behavior and needs no extra
-  configuration.
+  `Depends on: #123`, `Blocked by: owner/repo#123`, or
+  `Depends on: https://github.com/owner/repo/issues/123`. Detent keeps the
+  issue out of dispatch while any referenced blocker is non-terminal, then
+  dispatches it normally after blockers clear. This is the default behavior and
+  needs no extra configuration.
 - **Keep the issue in `Blocked`.** Enable `tracker.dependency_auto_unblock` when
   your team wants dependency-waiting issues to sit in a waiting column. Detent
   only moves issues that have explicit `Depends on:` or `Blocked by:` references.
   When all blockers are terminal, closed, or have a merged linked PR under the
   configured `readiness` rule, Detent updates the ProjectV2 `Status` to
-  `target_state` and posts an audit comment. Human blockers without explicit
-  dependency references stay blocked.
+  `target_state` and posts an audit comment. Without
+  `tracker.dependency_auto_unblock.enabled: true`, a `Blocked` issue is observed
+  for display but will not be moved back to `Todo`. Human blockers without
+  explicit dependency references stay blocked.
 
 Before you dispatch anything, run **`detent doctor`** — it checks config
 resolution, the database, the `codex` binary, your GitHub token and scopes, git,

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -439,9 +439,10 @@ recommendation, and default-if-silent. Record answers in
    For criteria-based auto-promote, use only existing config keys:
    `agent.auto_promote.enabled`, `quiet_seconds`, `optout_label`, and
    `allowed_issue_labels`. `quiet_seconds` is the quiet period after automated
-   review activity, `optout_label` is the per-issue escape hatch, and
-   `allowed_issue_labels` is an allowlist such as `documentation` for
-   low-risk issue classes. Verify:
+   review activity on the current pull request head, `optout_label` is the
+   per-issue escape hatch, and `allowed_issue_labels` is an allowlist such as
+   `documentation` for low-risk issue classes. A Codex review on an older commit
+   does not clear this gate. Verify:
 
    ```sh
    printf '%s\n' \
@@ -459,7 +460,9 @@ recommendation, and default-if-silent. Record answers in
    `tracker.dependency_auto_unblock.enabled: false`. Use the `Blocked`
    auto-unblock mode only when the team writes explicit `Depends on:` or
    `Blocked by:` lines for dependency blockers; Detent will not clear unrelated
-   human blockers. Verify:
+   human blockers. If dependency-waiting issues are placed in `Blocked` while
+   this setting stays disabled, Detent will only display them as blocked and
+   will not move them back to `Todo`. Verify:
 
    ```sh
    printf '%s\n' \
@@ -771,6 +774,11 @@ recommendation, and default-if-silent. Record answers in
          - <allowed-label>
    ```
 
+   Auto-promote requires a linked open PR, green CI, a current-head Codex review
+   with no P1 findings, and the configured quiet period. `detent doctor --port
+   0` reports sampled `Human Review` candidates and reasons such as
+   `automated_review_missing` when that gate is not met.
+
    Dependency auto-unblock default:
 
    ```yaml
@@ -784,7 +792,9 @@ recommendation, and default-if-silent. Record answers in
    ```
 
    Enable it only for projects that use `Blocked` as a dependency-waiting state
-   with explicit machine-readable dependency references.
+   with explicit machine-readable dependency references. Without this enabled,
+   `Blocked` is an observed/display state and dependency completion will not
+   move issues back to `Todo`.
 
 6. **Write the prompt body.** Keep the `## Codex Workpad` instruction, include
    repo authority files discovered in Phase 2, and state the validation gate.
@@ -1136,7 +1146,10 @@ issue starts. If there is no dependency, omit the line.
 ```
 
 Keep dependency order explicit. If issue B relies on issue A, issue B should
-carry `Depends on: #A` and stay out of `Todo` until A has merged.
+carry `Depends on: #A` and stay out of `Todo` until A has merged. Same-repo
+`#A`, cross-repo `owner/repo#A`, and full
+`https://github.com/owner/repo/issues/A` issue URLs are supported inside
+`Depends on:` and `Blocked by:` lines.
 
 Alternatively, if the project has opted into
 `tracker.dependency_auto_unblock.enabled`, issue B can sit in a configured
@@ -1144,3 +1157,5 @@ waiting state such as `Blocked` with the same `Depends on:` or `Blocked by:`
 line. Detent will move it to the configured ready state after every blocker is
 terminal, closed, or merged according to the workflow readiness rule. Do not use
 that mode for free-form human blockers without explicit dependency references.
+If auto-unblock is disabled, a dependency-waiting issue in `Blocked` will remain
+there even after the dependency clears.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -158,7 +158,8 @@ grounded recommendation per Phase 2 question, then interview the human.
    invented command. If `make check` exists, recommend `gate.kind: command`
    with `gate.run: make check`. If there is no local command but CI is clear,
    recommend the closest local equivalent. If no command can be inferred,
-   recommend `gate.kind: human_review` with an approval label. Verify:
+   recommend `gate.kind: human_review` with an approval label only when the
+   workflow explicitly wants a human label to promote. Verify:
 
    ```sh
    cd <source-root>
@@ -387,15 +388,18 @@ recommendation, and default-if-silent. Record answers in
    ```
 
 6. **Validation gate.** Ask: "Use the detected command, a custom command, or a
-   human review label gate?" Recommendation source:
-   `$ONBOARDING_DIR/gate.txt`, Makefile targets, and CI workflow commands.
-   Default if silent: detected `make check` when present; otherwise
-   `kind: human_review` with `approval_label: human-approved`. Verify:
+   human review label gate? If this is a command gate, should auto-promotion
+   require an automated GitHub PR review from a bot?" Recommendation source:
+   `$ONBOARDING_DIR/gate.txt`, Makefile targets, CI workflow commands, and the
+   repo's review policy. Default if silent: detected `make check` when present
+   with `require_automated_review: true`; otherwise `kind: human_review` with
+   `approval_label: human-approved`. Verify:
 
    ```sh
    printf '%s\n' \
      'GATE_KIND=<command|human_review>' \
      'GATE_RUN=<command-if-command>' \
+     'GATE_REQUIRE_AUTOMATED_REVIEW=<true|false-if-command>' \
      'GATE_APPROVAL_LABEL=<label-if-human-review>' \
      >> "$ONBOARDING_DIR/answers.env"
    rg '^GATE_' "$ONBOARDING_DIR/answers.env"
@@ -436,18 +440,20 @@ recommendation, and default-if-silent. Record answers in
    `agent.auto_promote.enabled: false`, the safe hard stop. Both modes are
    fully supported, and this is the human's call.
 
-   For criteria-based auto-promote, use only existing config keys:
-   `agent.auto_promote.enabled`, `quiet_seconds`, `optout_label`, and
-   `allowed_issue_labels`. `quiet_seconds` is the quiet period after automated
-   review activity on the current pull request head, `optout_label` is the
-   per-issue escape hatch, and `allowed_issue_labels` is an allowlist such as
-   `documentation` for low-risk issue classes. A Codex review on an older commit
-   does not clear this gate. Verify:
+   For criteria-based auto-promote, use `agent.auto_promote.enabled`,
+   `quiet_seconds`, `optout_label`, `allowed_issue_labels`, and the top-level
+   command gate's `require_automated_review` setting. `quiet_seconds` is the
+   quiet period after observed issue/status/review activity, `optout_label` is
+   the per-issue escape hatch, and `allowed_issue_labels` is an allowlist such
+   as `documentation` for low-risk issue classes. When automated review is
+   required, a Codex/ChatGPT/Claude review on an older commit does not clear
+   this gate. Verify:
 
    ```sh
    printf '%s\n' \
      'AUTO_PROMOTE_ENABLED=<true|false>' \
      'AUTO_PROMOTE_QUIET_SECONDS=<seconds>' \
+     'AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW=<true|false-if-command>' \
      'AUTO_PROMOTE_OPTOUT_LABEL=<label>' \
      'AUTO_PROMOTE_ALLOWED_LABELS=<comma-separated-labels-or-empty>' \
      >> "$ONBOARDING_DIR/answers.env"
@@ -718,11 +724,12 @@ recommendation, and default-if-silent. Record answers in
    rg -n '^server:|host: <dashboard-host>|port:' <source-root>/WORKFLOW.md
    ```
 
-4. **Set the gate from the interview.** For command gates, include the command.
+4. **Set the gate from the interview.** For command gates, include the command
+   and whether an automated GitHub PR review is required for auto-promotion.
    For human gates, include the approval label. Verify:
 
    ```sh
-   rg -n '^gate:|kind: <command|human_review>|run: <gate-command>|approval_label: <label>' \
+   rg -n '^gate:|kind: <command|human_review>|run: <gate-command>|require_automated_review: <true|false>|approval_label: <label>' \
      <source-root>/WORKFLOW.md
    ```
 
@@ -732,6 +739,7 @@ recommendation, and default-if-silent. Record answers in
    gate:
      kind: command
      run: <gate-command>
+     require_automated_review: <true|false>
    ```
 
    Human review gate shape:
@@ -774,10 +782,14 @@ recommendation, and default-if-silent. Record answers in
          - <allowed-label>
    ```
 
-   Auto-promote requires a linked open PR, green CI, a current-head Codex review
-   with no P1 findings, and the configured quiet period. `detent doctor --port
-   0` reports sampled `Human Review` candidates and reasons such as
-   `automated_review_missing` when that gate is not met.
+   For a command gate, auto-promote requires a linked open PR, green CI, no P1
+   automated PR review findings, and the configured quiet period. With
+   `require_automated_review: true`, it also requires a current-head automated
+   GitHub PR review. With `require_automated_review: false`, bot PR review is
+   not required to exist, but any observed P1 bot findings still route the item
+   to `Rework`. `detent doctor --port 0` reports sampled `Human Review`
+   candidates and reasons such as `automated_review_missing` when that gate is
+   not met.
 
    Dependency auto-unblock default:
 
@@ -1102,6 +1114,7 @@ changing `global.yaml` or `WORKFLOW.md`.
 | Authorization filters | `tracker.authorization` in `WORKFLOW.md`; optionally `projects[].authorization` in `global.yaml` for host-level scoping. |
 | Dashboard bind | `server.host` in `WORKFLOW.md`, or `--host` in the startup command or service `ExecStart`. |
 | Validation command | `gate.kind: command` and `gate.run` in `WORKFLOW.md`. |
+| Automated PR review requirement | `gate.kind: command` and `gate.require_automated_review` in `WORKFLOW.md`. |
 | Human validation label | `gate.kind: human_review` and `gate.approval_label` in `WORKFLOW.md`. |
 | Per-project concurrency | `agent.max_concurrent_agents` in `WORKFLOW.md`. |
 | Merge serialization | `agent.max_concurrent_agents_by_state.Merging: 1` in `WORKFLOW.md`. |

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -20,6 +20,9 @@ The execution edge still carries these code/git/PR assumptions.
 - `gate.kind: command` is the default and keeps the code workflow contract:
   run `gate.run` (`make check` by default), then require green CI and clean
   automated review before promotion.
+- `gate.kind: command` with `require_automated_review: false` keeps the
+  command, linked PR, green CI, no-P1, and quiet-period checks but does not
+  require an automated GitHub PR review to exist before promotion.
 - `gate.kind: human_review` requires a PR plus `gate.approval_label`
   (`human-approved` by default) before promotion.
 - `internal/runner/prompt.go` renders gate variables and appends gate

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -19,6 +19,7 @@ import (
 	"github.com/spf13/cobra"
 	_ "modernc.org/sqlite"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -73,6 +74,7 @@ type doctorConfig struct {
 	Flags        runtimeFlags
 	Output       io.Writer
 	CheckTimeout time.Duration
+	Build        buildinfo.Info
 }
 
 type doctorStore interface {
@@ -102,6 +104,7 @@ type doctorDeps struct {
 	openSQLite           func(context.Context, string) (doctorStore, error)
 	gitWorkTree          func(context.Context, string) error
 	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
+	executable           func() (string, error)
 }
 
 func newDoctorCommand(configPath *string, env *string, logLevel *string, host *string, port *int, opts options) *cobra.Command {
@@ -120,6 +123,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 				Host:         derefString(host),
 				Output:       cmd.OutOrStdout(),
 				CheckTimeout: timeout,
+				Build:        opts.build,
 				Flags: runtimeFlags{
 					Env:      runtimeStringFlag{Value: derefString(env), Set: flagChanged(cmd, "env")},
 					LogLevel: runtimeStringFlag{Value: derefString(logLevel), Set: flagChanged(cmd, "log-level")},
@@ -185,6 +189,10 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		writeDoctorProgressDone(progressOut, check)
 		report.Add(check)
 	}
+	writeDoctorProgressStart(progressOut, "Detent executable")
+	executableCheck := checkDoctorDetentExecutable(cfg.Build, deps)
+	writeDoctorProgressDone(progressOut, executableCheck)
+	report.Add(executableCheck)
 
 	boot := BootConfig{
 		Host: strings.TrimSpace(cfg.Host),
@@ -435,6 +443,28 @@ func checkDoctorRuntimeSettings(settings RuntimeSettings) doctorCheck {
 	check.Detail = check.Detail + "; " + warning.Detail
 	check.Hint = warning.Hint
 	return check
+}
+
+func checkDoctorDetentExecutable(build buildinfo.Info, deps doctorDeps) doctorCheck {
+	path, err := deps.executable()
+	if err != nil {
+		return doctorCheck{
+			Name:   "Detent executable",
+			Status: doctorFail,
+			Detail: err.Error(),
+			Hint:   "Start Detent from the expected installed binary.",
+		}
+	}
+	path = filepath.Clean(path)
+	detail := path + " is running"
+	if !buildinfo.IsZero(build) {
+		detail = path + " " + buildinfo.DisplayLabel(build)
+	}
+	return doctorCheck{
+		Name:   "Detent executable",
+		Status: doctorOK,
+		Detail: detail,
+	}
 }
 
 func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps, githubToken string) []doctorCheck {
@@ -1201,6 +1231,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.autoPromoteConnector == nil {
 		d.autoPromoteConnector = defaults.autoPromoteConnector
 	}
+	if d.executable == nil {
+		d.executable = defaults.executable
+	}
 	return d
 }
 
@@ -1216,6 +1249,7 @@ func defaultDoctorDeps() doctorDeps {
 		openSQLite:           openDoctorSQLite,
 		gitWorkTree:          defaultGitWorkTree,
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
+		executable:           os.Executable,
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -29,7 +29,10 @@ import (
 
 var ErrDoctorFailed = errors.New("doctor found failed checks")
 
-const doctorCommandTimeout = 5 * time.Second
+const (
+	doctorCommandTimeout = 5 * time.Second
+	doctorCheckTimeout   = 5 * time.Second
+)
 
 type doctorStatus string
 
@@ -54,10 +57,22 @@ type doctorReport struct {
 	Checks []doctorCheck
 }
 
+type doctorCheckJob struct {
+	Name string
+	Run  func(context.Context) []doctorCheck
+}
+
+type doctorCheckResult struct {
+	Index  int
+	Checks []doctorCheck
+}
+
 type doctorConfig struct {
-	ConfigPath string
-	Host       string
-	Flags      runtimeFlags
+	ConfigPath   string
+	Host         string
+	Flags        runtimeFlags
+	Output       io.Writer
+	CheckTimeout time.Duration
 }
 
 type doctorStore interface {
@@ -94,14 +109,17 @@ func newDoctorCommand(configPath *string, env *string, logLevel *string, host *s
 }
 
 func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
-	return &cobra.Command{
+	timeout := doctorCheckTimeout
+	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Run preflight health checks",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			report := runDoctor(cmd.Context(), doctorConfig{
-				ConfigPath: derefString(configPath),
-				Host:       derefString(host),
+				ConfigPath:   derefString(configPath),
+				Host:         derefString(host),
+				Output:       cmd.OutOrStdout(),
+				CheckTimeout: timeout,
 				Flags: runtimeFlags{
 					Env:      runtimeStringFlag{Value: derefString(env), Set: flagChanged(cmd, "env")},
 					LogLevel: runtimeStringFlag{Value: derefString(logLevel), Set: flagChanged(cmd, "log-level")},
@@ -117,6 +135,8 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 			return nil
 		},
 	}
+	cmd.Flags().DurationVar(&timeout, "timeout", doctorCheckTimeout, "per-check timeout")
+	return cmd
 }
 
 func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorDeps) doctorReport {
@@ -125,16 +145,22 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	}
 	opts = doctorOptions(opts)
 	deps = deps.withDefaults()
+	timeout := doctorNormalizedTimeout(cfg.CheckTimeout)
+	progressOut := cfg.Output
 
 	var report doctorReport
+	writeDoctorProgressStart(progressOut, "Config resolution")
 	resolution, global, configCheck := checkDoctorConfig(cfg.ConfigPath, opts)
+	writeDoctorProgressDone(progressOut, configCheck)
 	report.Add(configCheck)
 
 	workflowPath := ""
 	if global != nil {
 		workflowPath = firstGlobalWorkflowPath(*global)
 	}
-	runtime, runtimeErr := resolveRuntimeSettings(ctx, runtimeInput{
+	writeDoctorProgressStart(progressOut, "Runtime settings")
+	runtimeCtx, cancelRuntime := context.WithTimeout(ctx, timeout)
+	runtime, runtimeErr := resolveRuntimeSettings(runtimeCtx, runtimeInput{
 		Config:     global,
 		ConfigPath: resolution,
 		Workflow:   workflowPath,
@@ -144,15 +170,20 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		ghAuthToken:  deps.ghAuthToken,
 		loadWorkflow: deps.loadWorkflow,
 	})
+	cancelRuntime()
 	if runtimeErr != nil {
-		report.Add(doctorCheck{
+		check := doctorCheck{
 			Name:   "Runtime settings",
 			Status: doctorFail,
 			Detail: runtimeErr.Error(),
 			Hint:   "Fix runtime flags, environment variables, or global.yaml.",
-		})
+		}
+		writeDoctorProgressDone(progressOut, check)
+		report.Add(check)
 	} else {
-		report.Add(checkDoctorRuntimeSettings(runtime))
+		check := checkDoctorRuntimeSettings(runtime)
+		writeDoctorProgressDone(progressOut, check)
+		report.Add(check)
 	}
 
 	boot := BootConfig{
@@ -166,24 +197,134 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	if global != nil {
 		boot.Global = *global
 		boot.Host = bootHost(cfg.Host, firstGlobalWorkflowPath(*global))
-		report.Add(checkDoctorInstanceIdentity(*global))
-		report.Checks = append(report.Checks, checkDoctorProjects(ctx, *global, deps, runtimeGlobalGitHubToken(runtime.GitHubToken))...)
+		writeDoctorProgressStart(progressOut, "Instance identity")
+		check := checkDoctorInstanceIdentity(*global)
+		writeDoctorProgressDone(progressOut, check)
+		report.Add(check)
 	} else {
-		report.Add(doctorCheck{
+		writeDoctorProgressStart(progressOut, "Project workflows")
+		check := doctorCheck{
 			Name:   "Project workflows",
 			Status: doctorWarn,
 			Detail: "skipped because global config could not be loaded",
 			Hint:   "Fix the global config, then rerun detent doctor.",
-		})
+		}
+		writeDoctorProgressDone(progressOut, check)
+		report.Add(check)
 	}
 
-	report.Add(checkDoctorSQLite(ctx, resolution, deps))
-	report.Add(checkDoctorCodex(ctx, deps))
-	report.Add(checkDoctorGitHub(ctx, global, runtime.GitHubToken, deps))
-	report.Add(checkDoctorServerPort(boot, deps))
-	report.Add(checkDoctorGit(ctx, deps))
+	jobs := []doctorCheckJob{}
+	if global != nil {
+		globalConfig := *global
+		githubToken := runtimeGlobalGitHubToken(runtime.GitHubToken)
+		jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken)...)
+	}
+	jobs = append(jobs,
+		doctorCheckJob{
+			Name: "SQLite database",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorSQLite(jobCtx, resolution, deps)}
+			},
+		},
+		doctorCheckJob{
+			Name: "codex binary",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorCodex(jobCtx, deps)}
+			},
+		},
+		doctorCheckJob{
+			Name: "GitHub token",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorGitHub(jobCtx, global, runtime.GitHubToken, deps)}
+			},
+		},
+		doctorCheckJob{
+			Name: "Server port",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorServerPort(boot, deps)}
+			},
+		},
+		doctorCheckJob{
+			Name: "git binary",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorGit(jobCtx, deps)}
+			},
+		},
+	)
+	for _, checks := range runDoctorChecks(ctx, jobs, timeout, progressOut) {
+		report.Checks = append(report.Checks, checks...)
+	}
 
 	return report
+}
+
+func runDoctorChecks(ctx context.Context, jobs []doctorCheckJob, timeout time.Duration, out io.Writer) [][]doctorCheck {
+	results := make([][]doctorCheck, len(jobs))
+	done := make(chan doctorCheckResult, len(jobs))
+	for i, job := range jobs {
+		writeDoctorProgressStart(out, job.Name)
+		go func(index int, job doctorCheckJob) {
+			done <- doctorCheckResult{
+				Index:  index,
+				Checks: runDoctorCheck(ctx, job, timeout),
+			}
+		}(i, job)
+	}
+	for range jobs {
+		result := <-done
+		for _, check := range result.Checks {
+			writeDoctorProgressDone(out, check)
+		}
+		results[result.Index] = result.Checks
+	}
+	return results
+}
+
+func runDoctorCheck(ctx context.Context, job doctorCheckJob, timeout time.Duration) []doctorCheck {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	timeout = doctorNormalizedTimeout(timeout)
+	checkCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	done := make(chan []doctorCheck, 1)
+	go func() {
+		done <- job.Run(checkCtx)
+	}()
+
+	select {
+	case checks := <-done:
+		return checks
+	case <-checkCtx.Done():
+		return []doctorCheck{{
+			Name:   job.Name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("timed out after %s: %v", timeout, checkCtx.Err()),
+			Hint:   "Rerun detent doctor; if this repeats, check network access, GitHub availability, local subprocesses, and SQLite locks.",
+		}}
+	}
+}
+
+func doctorNormalizedTimeout(timeout time.Duration) time.Duration {
+	if timeout <= 0 {
+		return doctorCheckTimeout
+	}
+	return timeout
+}
+
+func writeDoctorProgressStart(out io.Writer, name string) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "%-5s  %-28s  checking\n", "RUN", name)
+}
+
+func writeDoctorProgressDone(out io.Writer, check doctorCheck) {
+	if out == nil {
+		return
+	}
+	fmt.Fprintf(out, "%-5s  %-28s  %s\n", check.Status, check.Name, check.Detail)
 }
 
 func (r *doctorReport) Add(check doctorCheck) {
@@ -310,89 +451,130 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 
 	checks := make([]doctorCheck, 0, len(cfg.Projects)*2)
 	for _, project := range cfg.Projects {
-		id := strings.TrimSpace(project.ID)
-		if id == "" {
-			id = "project"
-		}
-		workflow, err := deps.loadWorkflow(project.Workflow)
-		if err != nil {
-			checks = append(checks, doctorCheck{
+		checks = append(checks, checkDoctorProject(ctx, project, deps, githubToken)...)
+	}
+
+	return checks
+}
+
+func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken string) []doctorCheckJob {
+	if len(cfg.Projects) == 0 {
+		return []doctorCheckJob{{
+			Name: "Project workflows",
+			Run: func(context.Context) []doctorCheck {
+				return []doctorCheck{
+					{
+						Name:   "Project workflows",
+						Status: doctorWarn,
+						Detail: "no projects configured",
+						Hint:   "Run detent add-project to add a project.",
+					},
+				}
+			},
+		}}
+	}
+
+	jobs := make([]doctorCheckJob, 0, len(cfg.Projects))
+	for _, project := range cfg.Projects {
+		project := project
+		id := doctorProjectID(project)
+		jobs = append(jobs, doctorCheckJob{
+			Name: "Project " + id + " checks",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return checkDoctorProject(jobCtx, project, deps, githubToken)
+			},
+		})
+	}
+	return jobs
+}
+
+func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps doctorDeps, githubToken string) []doctorCheck {
+	id := doctorProjectID(project)
+	workflow, err := deps.loadWorkflow(project.Workflow)
+	if err != nil {
+		return []doctorCheck{
+			{
 				Name:   "Project " + id + " workflow",
 				Status: doctorFail,
 				Detail: fmt.Sprintf("%s: %v", project.Workflow, err),
 				Hint:   "Fix the WORKFLOW.md path or YAML frontmatter.",
-			})
-			checks = append(checks, doctorCheck{
+			},
+			{
 				Name:   "Project " + id + " source repo",
 				Status: doctorWarn,
 				Detail: "skipped because WORKFLOW.md could not be loaded",
 				Hint:   "Fix the workflow file, then rerun detent doctor.",
-			})
-			continue
+			},
 		}
-		workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, githubToken)
-		if err := workflow.Config.Validate(); err != nil {
-			checks = append(checks, doctorCheck{
+	}
+	workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, githubToken)
+	if err := workflow.Config.Validate(); err != nil {
+		return []doctorCheck{
+			{
 				Name:   "Project " + id + " workflow",
 				Status: doctorFail,
 				Detail: fmt.Sprintf("%s: %v", project.Workflow, err),
 				Hint:   "Fix invalid WORKFLOW.md frontmatter.",
-			})
-			checks = append(checks, doctorCheck{
+			},
+			{
 				Name:   "Project " + id + " source repo",
 				Status: doctorWarn,
 				Detail: "skipped because WORKFLOW.md is invalid",
 				Hint:   "Fix the workflow file, then rerun detent doctor.",
-			})
-			continue
+			},
 		}
+	}
 
-		checks = append(checks, doctorCheck{
+	checks := []doctorCheck{
+		{
 			Name:   "Project " + id + " workflow",
 			Status: doctorOK,
 			Detail: doctorWorkflowDetail(project.Workflow, project, workflow.Config),
-		})
-		if workflow.Config.Agent.AutoPromote.Enabled {
-			checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
-		}
-
-		sourceRoot := projectSourceRoot(project, workflow.Config)
-		if sourceRoot == "" {
-			checks = append(checks, doctorCheck{
-				Name:   "Project " + id + " source repo",
-				Status: doctorFail,
-				Detail: "source root is not configured",
-				Hint:   "Set workspace.source_root, project workdir, or workspace.root to an existing git checkout.",
-			})
-			continue
-		}
-		expandedSourceRoot, err := expandDoctorWorkspacePath(sourceRoot)
-		if err != nil {
-			checks = append(checks, doctorCheck{
-				Name:   "Project " + id + " source repo",
-				Status: doctorFail,
-				Detail: fmt.Sprintf("%s: %v", sourceRoot, err),
-				Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
-			})
-			continue
-		}
-		if err := deps.gitWorkTree(ctx, expandedSourceRoot); err != nil {
-			checks = append(checks, doctorCheck{
-				Name:   "Project " + id + " source repo",
-				Status: doctorFail,
-				Detail: fmt.Sprintf("%s: %v", expandedSourceRoot, err),
-				Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
-			})
-			continue
-		}
-		checks = append(checks, doctorCheck{
-			Name:   "Project " + id + " source repo",
-			Status: doctorOK,
-			Detail: expandedSourceRoot + " is a git worktree",
-		})
+		},
+	}
+	if workflow.Config.Agent.AutoPromote.Enabled {
+		checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
 	}
 
-	return checks
+	sourceRoot := projectSourceRoot(project, workflow.Config)
+	if sourceRoot == "" {
+		return append(checks, doctorCheck{
+			Name:   "Project " + id + " source repo",
+			Status: doctorFail,
+			Detail: "source root is not configured",
+			Hint:   "Set workspace.source_root, project workdir, or workspace.root to an existing git checkout.",
+		})
+	}
+	expandedSourceRoot, err := expandDoctorWorkspacePath(sourceRoot)
+	if err != nil {
+		return append(checks, doctorCheck{
+			Name:   "Project " + id + " source repo",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s: %v", sourceRoot, err),
+			Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
+		})
+	}
+	if err := deps.gitWorkTree(ctx, expandedSourceRoot); err != nil {
+		return append(checks, doctorCheck{
+			Name:   "Project " + id + " source repo",
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s: %v", expandedSourceRoot, err),
+			Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
+		})
+	}
+	return append(checks, doctorCheck{
+		Name:   "Project " + id + " source repo",
+		Status: doctorOK,
+		Detail: expandedSourceRoot + " is a git worktree",
+	})
+}
+
+func doctorProjectID(project globalconfig.Project) string {
+	id := strings.TrimSpace(project.ID)
+	if id == "" {
+		return "project"
+	}
+	return id
 }
 
 func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps, now time.Time) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -13,6 +13,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/buildinfo"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -440,6 +441,29 @@ func TestCheckDoctorRuntimeSettingsReportsSources(t *testing.T) {
 	}
 	if strings.Contains(got.Detail, "secret-token") {
 		t.Fatalf("Detail leaked token: %s", got.Detail)
+	}
+}
+
+func TestCheckDoctorDetentExecutableReportsRunningBinary(t *testing.T) {
+	t.Parallel()
+
+	got := checkDoctorDetentExecutable(buildinfo.Info{
+		Version: "v1.2.3",
+		Commit:  "abcdef123456",
+		Date:    "2026-06-13T15:35:40Z",
+	}, doctorDeps{
+		executable: func() (string, error) {
+			return "/Users/corylanou/go/bin/detent", nil
+		},
+	})
+
+	if got.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s", got.Status, doctorOK)
+	}
+	for _, want := range []string{"/Users/corylanou/go/bin/detent", "v1.2.3", "abcdef1"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail missing %q:\n%s", want, got.Detail)
+		}
 	}
 }
 
@@ -1066,6 +1090,9 @@ func successfulDoctorDeps() doctorDeps {
 		},
 		gitWorkTree: func(context.Context, string) error {
 			return nil
+		},
+		executable: func() (string, error) {
+			return "/Users/corylanou/go/bin/detent", nil
 		},
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -4,10 +4,12 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"net"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -777,6 +779,199 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 	}
 }
 
+func TestDoctorCommandStreamsProgressBeforeSlowCheckCompletes(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	env := ""
+	logLevel := ""
+	host := "127.0.0.1"
+	port := 0
+	opts := successfulDoctorOptions(configPath)
+	deps := successfulDoctorDeps()
+	codexStarted := make(chan struct{})
+	releaseCodex := make(chan struct{})
+	var once sync.Once
+	deps.runCommand = func(ctx context.Context, path string, _ ...string) error {
+		if strings.HasSuffix(path, "codex") {
+			once.Do(func() {
+				close(codexStarted)
+			})
+			select {
+			case <-releaseCodex:
+				return nil
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+		return nil
+	}
+
+	cmd := newDoctorCommandWithDeps(&configPath, &env, &logLevel, &host, &port, opts, deps)
+	stdout := &synchronizedBuffer{}
+	cmd.SetOut(stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	errs := make(chan error, 1)
+	go func() {
+		errs <- cmd.Execute()
+	}()
+
+	select {
+	case <-codexStarted:
+	case <-time.After(time.Second):
+		t.Fatal("codex check did not start")
+	}
+	if got := stdout.String(); !strings.Contains(got, "RUN    codex binary") {
+		t.Fatalf("progress output missing codex start before check returned:\n%s", got)
+	}
+	close(releaseCodex)
+
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("Execute() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for doctor command")
+	}
+}
+
+func TestDoctorCommandTimeoutFlagBoundsCheck(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	env := ""
+	logLevel := ""
+	host := "127.0.0.1"
+	port := 0
+	opts := successfulDoctorOptions(configPath)
+	deps := successfulDoctorDeps()
+	releaseCodex := make(chan struct{})
+	defer close(releaseCodex)
+	deps.runCommand = func(_ context.Context, path string, _ ...string) error {
+		if strings.HasSuffix(path, "codex") {
+			<-releaseCodex
+		}
+		return nil
+	}
+
+	cmd := newDoctorCommandWithDeps(&configPath, &env, &logLevel, &host, &port, opts, deps)
+	cmd.SetArgs([]string{"--timeout", "20ms"})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	err := cmd.Execute()
+	if !errors.Is(err, ErrDoctorFailed) {
+		t.Fatalf("Execute() error = %v, want %v", err, ErrDoctorFailed)
+	}
+	for _, want := range []string{"FAIL", "codex binary", "timed out after 20ms", "Result: FAIL"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("output missing %q:\n%s", want, stdout.String())
+		}
+	}
+}
+
+func TestRunDoctorChecksRunsJobsInParallel(t *testing.T) {
+	t.Parallel()
+
+	firstStarted := make(chan struct{})
+	secondStarted := make(chan struct{})
+	jobs := []doctorCheckJob{
+		{
+			Name: "first",
+			Run: func(context.Context) []doctorCheck {
+				close(firstStarted)
+				<-secondStarted
+				return []doctorCheck{{Name: "first", Status: doctorOK, Detail: "done"}}
+			},
+		},
+		{
+			Name: "second",
+			Run: func(context.Context) []doctorCheck {
+				close(secondStarted)
+				<-firstStarted
+				return []doctorCheck{{Name: "second", Status: doctorOK, Detail: "done"}}
+			},
+		},
+	}
+
+	results := runDoctorChecks(context.Background(), jobs, time.Second, io.Discard)
+	if len(results) != 2 || len(results[0]) != 1 || len(results[1]) != 1 {
+		t.Fatalf("results = %#v", results)
+	}
+	if results[0][0].Name != "first" || results[1][0].Name != "second" {
+		t.Fatalf("results order = %#v, want first then second", results)
+	}
+}
+
+func TestDoctorReportKeepsStableOrderAfterParallelChecks(t *testing.T) {
+	t.Parallel()
+
+	firstDone := make(chan struct{})
+	secondDone := make(chan struct{})
+	jobs := []doctorCheckJob{
+		{
+			Name: "first",
+			Run: func(context.Context) []doctorCheck {
+				<-secondDone
+				close(firstDone)
+				return []doctorCheck{{Name: "first", Status: doctorOK, Detail: "done"}}
+			},
+		},
+		{
+			Name: "second",
+			Run: func(context.Context) []doctorCheck {
+				close(secondDone)
+				return []doctorCheck{{Name: "second", Status: doctorOK, Detail: "done"}}
+			},
+		},
+	}
+
+	var report doctorReport
+	for _, checks := range runDoctorChecks(context.Background(), jobs, time.Second, io.Discard) {
+		report.Checks = append(report.Checks, checks...)
+	}
+	select {
+	case <-firstDone:
+	default:
+		t.Fatal("first check did not complete")
+	}
+
+	var output bytes.Buffer
+	if err := writeDoctorReport(&output, report); err != nil {
+		t.Fatalf("writeDoctorReport() error = %v", err)
+	}
+	got := output.String()
+	firstIndex := strings.Index(got, "first")
+	secondIndex := strings.Index(got, "second")
+	if firstIndex < 0 || secondIndex < 0 || firstIndex > secondIndex {
+		t.Fatalf("report order =\n%s\nwant first before second", got)
+	}
+}
+
+func TestRunDoctorCheckTimesOutUnresponsiveJob(t *testing.T) {
+	t.Parallel()
+
+	checks := runDoctorCheck(context.Background(), doctorCheckJob{
+		Name: "slow check",
+		Run: func(context.Context) []doctorCheck {
+			select {}
+		},
+	}, 20*time.Millisecond)
+
+	if len(checks) != 1 {
+		t.Fatalf("checks len = %d, want 1", len(checks))
+	}
+	if checks[0].Status != doctorFail {
+		t.Fatalf("Status = %s, want %s", checks[0].Status, doctorFail)
+	}
+	if checks[0].Name != "slow check" || !strings.Contains(checks[0].Detail, "timed out after 20ms") {
+		t.Fatalf("check = %#v, want timeout detail", checks[0])
+	}
+}
+
 func validDoctorWorkflow(sourceRoot string) workflowconfig.Config {
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
@@ -908,4 +1103,21 @@ func (a fakeDoctorAddr) Network() string {
 
 func (a fakeDoctorAddr) String() string {
 	return string(a)
+}
+
+type synchronizedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *synchronizedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *synchronizedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -447,20 +447,21 @@ func TestCheckDoctorRuntimeSettingsReportsSources(t *testing.T) {
 func TestCheckDoctorDetentExecutableReportsRunningBinary(t *testing.T) {
 	t.Parallel()
 
+	executablePath := filepath.Join("Users", "corylanou", "go", "bin", "detent")
 	got := checkDoctorDetentExecutable(buildinfo.Info{
 		Version: "v1.2.3",
 		Commit:  "abcdef123456",
 		Date:    "2026-06-13T15:35:40Z",
 	}, doctorDeps{
 		executable: func() (string, error) {
-			return "/Users/corylanou/go/bin/detent", nil
+			return executablePath, nil
 		},
 	})
 
 	if got.Status != doctorOK {
 		t.Fatalf("Status = %s, want %s", got.Status, doctorOK)
 	}
-	for _, want := range []string{"/Users/corylanou/go/bin/detent", "v1.2.3", "abcdef1"} {
+	for _, want := range []string{executablePath, "v1.2.3", "abcdef1"} {
 		if !strings.Contains(got.Detail, want) {
 			t.Fatalf("Detail missing %q:\n%s", want, got.Detail)
 		}
@@ -1092,7 +1093,7 @@ func successfulDoctorDeps() doctorDeps {
 			return nil
 		},
 		executable: func() (string, error) {
-			return "/Users/corylanou/go/bin/detent", nil
+			return filepath.Join("Users", "corylanou", "go", "bin", "detent"), nil
 		},
 	}
 }

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -129,7 +129,7 @@ func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutd
 			return unexpectedShutdownServeError(err)
 		case <-ctx.Done():
 			cancelServe()
-			if err := waitForServeExit(serveErrs); err != nil {
+			if err := waitForServeExit(context.Background(), serveErrs); err != nil {
 				return err
 			}
 			return ctx.Err()
@@ -158,9 +158,17 @@ func runDrainShutdown(
 	writeShutdownBanner(shutdownOutput(cfg), sessions)
 	shutdownLogger(cfg).Info("shutdown requested", "sessions", len(sessions))
 
-	if err := drainProjects(ctx, cfg.Registry); err != nil {
-		return err
+	hardTimeout := cfg.HardTimeout
+	if hardTimeout <= 0 {
+		hardTimeout = defaultShutdownHardTimeout
 	}
+	drainCtx, cancelDrain := context.WithTimeout(ctx, hardTimeout)
+	if err := runShutdownStep(drainCtx, func(stepCtx context.Context) error {
+		return drainProjects(stepCtx, cfg.Registry)
+	}); err != nil {
+		shutdownLogger(cfg).Warn("drain projects during shutdown failed", "error", err)
+	}
+	cancelDrain()
 	publishShutdownSnapshot(ctx, cfg, startedAt)
 
 	if len(sessions) == 0 {
@@ -172,11 +180,6 @@ func runDrainShutdown(
 	if progressInterval <= 0 {
 		progressInterval = defaultShutdownProgressInterval
 	}
-	hardTimeout := cfg.HardTimeout
-	if hardTimeout <= 0 {
-		hardTimeout = defaultShutdownHardTimeout
-	}
-
 	poll := time.NewTicker(shutdownDrainPollInterval)
 	defer poll.Stop()
 	progress := time.NewTicker(progressInterval)
@@ -202,7 +205,7 @@ func runDrainShutdown(
 			return unexpectedShutdownServeError(err)
 		case <-ctx.Done():
 			cancelServe()
-			if err := waitForServeExit(serveErrs); err != nil {
+			if err := waitForServeExit(context.Background(), serveErrs); err != nil {
 				return err
 			}
 			return ctx.Err()
@@ -256,7 +259,9 @@ func runForceShutdownWithDeadline(
 
 	forceCtx, cancel := context.WithTimeout(context.Background(), hardTimeout)
 	defer cancel()
-	if err := forceProjects(forceCtx, cfg.Registry); err != nil {
+	if err := runShutdownStep(forceCtx, func(stepCtx context.Context) error {
+		return forceProjects(stepCtx, cfg.Registry)
+	}); err != nil {
 		shutdownLogger(cfg).Warn("force shutdown cleanup failed", "error", err)
 	}
 	publishShutdownSnapshot(forceCtx, cfg, startedAt)
@@ -282,18 +287,41 @@ func completeShutdown(
 	}
 	stopCtx, cancel := context.WithTimeout(ctx, hardTimeout)
 	defer cancel()
-	if err := stopProjects(stopCtx, cfg.Registry); err != nil {
+	if err := runShutdownStep(stopCtx, func(stepCtx context.Context) error {
+		return stopProjects(stepCtx, cfg.Registry)
+	}); err != nil {
 		shutdownLogger(cfg).Warn("stop projects during shutdown failed", "error", err)
 	}
 
 	cancelServe()
-	if err := waitForServeExit(serveErrs); err != nil {
+	if err := waitForServeExit(stopCtx, serveErrs); err != nil {
+		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+			shutdownLogger(cfg).Warn("serve did not exit before shutdown deadline", "error", err)
+			return returnErr
+		}
 		return err
 	}
 
 	result := shutdownResultLabel(machine)
 	shutdownLogger(cfg).Info("shutdown complete ("+result+")", "duration", shutdownNow(cfg).Sub(startedAt))
 	return returnErr
+}
+
+func runShutdownStep(ctx context.Context, step func(context.Context) error) error {
+	if step == nil {
+		return nil
+	}
+	done := make(chan error, 1)
+	go func() {
+		done <- step(ctx)
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func shutdownResultLabel(machine shutdownstate.Machine) string {
@@ -531,9 +559,16 @@ func shutdownNow(cfg runningShutdownConfig) time.Time {
 	return time.Now()
 }
 
-func waitForServeExit(serveErrs <-chan error) error {
-	err := <-serveErrs
-	return unexpectedShutdownServeError(err)
+func waitForServeExit(ctx context.Context, serveErrs <-chan error) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	select {
+	case err := <-serveErrs:
+		return unexpectedShutdownServeError(err)
+	case <-ctx.Done():
+		return ctx.Err()
+	}
 }
 
 func unexpectedShutdownServeError(err error) error {

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"io"
 	"strings"
 	"testing"
 	"time"
@@ -71,6 +72,47 @@ func TestRunWithShutdownZeroSessionsExitsGracefully(t *testing.T) {
 	}
 	if got := output.String(); !strings.Contains(got, "shutdown requested — no agent sessions in flight") {
 		t.Fatalf("output missing zero-session notice:\n%s", got)
+	}
+}
+
+func TestRunWithShutdownZeroSessionsExitsWhenServeIgnoresCancellation(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	errs := make(chan error, 1)
+
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:       controller,
+			Registry:         projectpkg.NewRegistry(),
+			SnapshotHub:      hub.New[telemetry.Snapshot](),
+			Output:           io.Discard,
+			ProgressInterval: time.Millisecond,
+			HardTimeout:      20 * time.Millisecond,
+			Now: func() time.Time {
+				return time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+			},
+		}, func(context.Context) error {
+			close(started)
+			select {}
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestDrain()
+
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -436,6 +436,38 @@ Prompt
 	}
 }
 
+func TestParseWorkflowCommandGateDisablesAutomatedReviewRequirement(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+gate:
+  kind: command
+  run: make check
+  require_automated_review: false
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	cfg := workflow.Config.Gate
+	if cfg.Kind != gate.KindCommand || cfg.Run != gate.DefaultCommand {
+		t.Fatalf("Gate = %#v, want command make check", cfg)
+	}
+	if cfg.RequireAutomatedReview == nil {
+		t.Fatal("Gate.RequireAutomatedReview = nil, want false")
+	}
+	if *cfg.RequireAutomatedReview {
+		t.Fatal("Gate.RequireAutomatedReview = true, want false")
+	}
+}
+
 func TestParseWorkflowAgentRoutesCanUseLegacyCodexBackend(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -3367,18 +3367,15 @@ func parseBlockedBy(body string, repo string) []connector.BlockedRef {
 		if len(lineMatches) != 2 {
 			continue
 		}
-		for _, refMatches := range issueRefPattern.FindAllStringSubmatch(lineMatches[1], -1) {
-			if len(refMatches) != 3 {
+		for _, identifier := range issueReferencesInText(lineMatches[1], repo) {
+			key := normalizedIssueIdentifier(identifier)
+			if key == "" {
 				continue
 			}
-			identifier := blockerIdentifier(refMatches[1], refMatches[2], repo)
-			if identifier == "" {
+			if _, ok := seen[key]; ok {
 				continue
 			}
-			if _, ok := seen[identifier]; ok {
-				continue
-			}
-			seen[identifier] = struct{}{}
+			seen[key] = struct{}{}
 			blockers = append(blockers, connector.BlockedRef{Identifier: identifier})
 		}
 	}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -389,6 +389,28 @@ func TestConnectorFetchCandidateIssuesLeavesDependencyResolutionForHydration(t *
 	}
 }
 
+func TestParseBlockedByRecognizesIssueReferences(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Join([]string{
+		"Depends on: #24",
+		"Blocked by: digitaldrywood/agent-runtime#25",
+		"Depends on: https://github.com/digitaldrywood/detent/issues/26",
+		"Depends on: https://github.com/digitaldrywood/detent/issues/26 and #24",
+		"Mention only: #27",
+	}, "\n")
+
+	got := parseBlockedBy(body, "digitaldrywood/detent")
+	want := []connector.BlockedRef{
+		{Identifier: "digitaldrywood/detent#24"},
+		{Identifier: "digitaldrywood/agent-runtime#25"},
+		{Identifier: "digitaldrywood/detent#26"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("parseBlockedBy() = %#v, want %#v", got, want)
+	}
+}
+
 func TestConnectorFetchCandidateIssuesCapturesLinkedChildIssues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -14,9 +14,10 @@ const (
 )
 
 type Config struct {
-	Kind          string `yaml:"kind"`
-	Run           string `yaml:"run"`
-	ApprovalLabel string `yaml:"approval_label"`
+	Kind                   string `yaml:"kind"`
+	Run                    string `yaml:"run"`
+	ApprovalLabel          string `yaml:"approval_label"`
+	RequireAutomatedReview *bool  `yaml:"require_automated_review"`
 }
 
 type Summary struct {
@@ -70,9 +71,10 @@ type Decision struct {
 
 func DefaultConfig() Config {
 	return Config{
-		Kind:          KindCommand,
-		Run:           DefaultCommand,
-		ApprovalLabel: DefaultApprovalLabel,
+		Kind:                   KindCommand,
+		Run:                    DefaultCommand,
+		ApprovalLabel:          DefaultApprovalLabel,
+		RequireAutomatedReview: new(true),
 	}
 }
 
@@ -89,9 +91,12 @@ func Effective(cfg Config) Config {
 	}
 	if cfg.Kind == KindHumanReview {
 		cfg.Run = ""
+		cfg.RequireAutomatedReview = nil
 		if cfg.ApprovalLabel == "" {
 			cfg.ApprovalLabel = DefaultApprovalLabel
 		}
+	} else if cfg.RequireAutomatedReview == nil {
+		cfg.RequireAutomatedReview = new(true)
 	}
 	if cfg.ApprovalLabel == "" {
 		cfg.ApprovalLabel = DefaultApprovalLabel
@@ -126,8 +131,12 @@ func Instructions(cfg Config) string {
 		return "The validation gate is human review. Keep the pull request in Human Review until a human applies label `" +
 			cfg.ApprovalLabel + "`; do not move it to Merging before that label is present."
 	default:
-		return "The validation gate is a command. Run `" + cfg.Run +
-			"` from the workspace root before Human Review and after any rebase in Merging; the pull request still needs green CI and clean automated review before promotion."
+		instructions := "The validation gate is a command. Run `" + cfg.Run +
+			"` from the workspace root before Human Review and after any rebase in Merging; the pull request still needs green CI before promotion."
+		if automatedReviewRequired(cfg) {
+			return instructions + " Automated review is required on the current pull request head before promotion."
+		}
+		return instructions + " Automated review is not required for promotion, but any P1 automated review findings still block promotion."
 	}
 }
 
@@ -137,11 +146,11 @@ func Evaluate(cfg Config, labels []string, summary Summary, now time.Time, opts 
 	case KindHumanReview:
 		return evaluateHumanReview(cfg, labels, summary)
 	default:
-		return evaluateCommand(summary, now, opts)
+		return evaluateCommand(cfg, summary, now, opts)
 	}
 }
 
-func evaluateCommand(summary Summary, now time.Time, opts EvaluationOptions) Decision {
+func evaluateCommand(cfg Config, summary Summary, now time.Time, opts EvaluationOptions) Decision {
 	if missingPullRequest(summary) {
 		return decision(ActionSkip, ReasonMissingPullRequest)
 	}
@@ -155,7 +164,7 @@ func evaluateCommand(summary Summary, now time.Time, opts EvaluationOptions) Dec
 		out.Findings = cloneFindings(summary.P1Findings)
 		return out
 	}
-	if !automatedReviewSubmitted(summary.ReviewState) {
+	if automatedReviewRequired(cfg) && !automatedReviewSubmitted(summary.ReviewState) {
 		return decision(ActionWait, ReasonAutomatedReviewMissing)
 	}
 	if remaining := quietRemaining(summary, opts, now); remaining > 0 {
@@ -234,4 +243,9 @@ func cloneFindings(findings []Finding) []Finding {
 
 func normalizeLabel(label string) string {
 	return strings.ToLower(strings.TrimSpace(label))
+}
+
+func automatedReviewRequired(cfg Config) bool {
+	cfg = Effective(cfg)
+	return cfg.Kind == KindCommand && cfg.RequireAutomatedReview != nil && *cfg.RequireAutomatedReview
 }

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -16,12 +16,17 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 		{
 			name: "omitted gate defaults to make check command",
 			cfg:  Config{},
-			want: Config{Kind: KindCommand, Run: DefaultCommand, ApprovalLabel: DefaultApprovalLabel},
+			want: Config{Kind: KindCommand, Run: DefaultCommand, ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true)},
 		},
 		{
 			name: "command keeps custom run",
 			cfg:  Config{Kind: " command ", Run: " make verify "},
-			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true)},
+		},
+		{
+			name: "command can disable automated review requirement",
+			cfg:  Config{Kind: KindCommand, Run: "make verify", RequireAutomatedReview: new(false)},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(false)},
 		},
 		{
 			name: "human review normalizes alias and approval label",
@@ -40,7 +45,7 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 			t.Parallel()
 
 			got := Effective(tt.cfg)
-			if got != tt.want {
+			if !configsEqual(got, tt.want) {
 				t.Fatalf("Effective() = %#v, want %#v", got, tt.want)
 			}
 		})
@@ -89,6 +94,17 @@ func TestEvaluate(t *testing.T) {
 				CIStatus:       "green",
 			},
 			want: Decision{Action: ActionWait, Reason: ReasonAutomatedReviewMissing},
+		},
+		{
+			name: "command gate passes without automated review when disabled",
+			cfg:  Config{Kind: KindCommand, RequireAutomatedReview: new(false)},
+			input: Summary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			opts: EvaluationOptions{QuietDuration: 10 * time.Minute},
+			want: Decision{Action: ActionPass, Reason: ReasonReady},
 		},
 		{
 			name: "command gate requests rework for p1 findings",
@@ -162,4 +178,18 @@ func TestEvaluate(t *testing.T) {
 			}
 		})
 	}
+}
+
+func configsEqual(left Config, right Config) bool {
+	return left.Kind == right.Kind &&
+		left.Run == right.Run &&
+		left.ApprovalLabel == right.ApprovalLabel &&
+		boolPointerEqual(left.RequireAutomatedReview, right.RequireAutomatedReview)
+}
+
+func boolPointerEqual(left *bool, right *bool) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
 }

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -105,7 +105,7 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
-			name:  "missing Codex review awaits human review",
+			name:  "missing automated review awaits review",
 			issue: autoPromoteTestIssue("issue-missing-review", nil),
 			cfg:   enabled,
 			input: AutoPromoteSummary{
@@ -115,6 +115,25 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			want: AutoPromoteDecision{
 				Action: AutoPromoteActionAwaitReview,
 				Reason: AutoPromoteReasonCodexReviewMissing,
+			},
+		},
+		{
+			name:  "automated review disabled promotes after green ci and quiet period",
+			issue: autoPromoteTestIssue("issue-no-review-required", nil),
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				OptoutLabel:   "requires-human-review",
+				Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
 			},
 		},
 		{

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -52,7 +52,7 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			},
 		},
 		{
-			name: "linked pull request without automated review waits for review",
+			name: "linked pull request without required automated review waits for review",
 			cfg: AutoPromoteConfig{
 				Enabled:       true,
 				QuietDuration: 10 * time.Minute,

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -178,10 +178,16 @@ func promptAssigns(cfg config.Config, issue connector.Issue, opts PromptOptions)
 func gateAssigns(cfg gate.Config) map[string]any {
 	effective := gate.Effective(cfg)
 	return map[string]any{
-		"kind":           effective.Kind,
-		"run":            effective.Run,
-		"approval_label": effective.ApprovalLabel,
+		"kind":                     effective.Kind,
+		"run":                      effective.Run,
+		"approval_label":           effective.ApprovalLabel,
+		"require_automated_review": requireAutomatedReview(effective),
 	}
+}
+
+func requireAutomatedReview(cfg gate.Config) bool {
+	effective := gate.Effective(cfg)
+	return effective.RequireAutomatedReview != nil && *effective.RequireAutomatedReview
 }
 
 func issueAssigns(issue connector.Issue) map[string]any {


### PR DESCRIPTION
## Summary

- accept full GitHub issue URLs in `Depends on:` / `Blocked by:` dependency lines so dependency auto-unblock can recognize existing issue references
- add `gate.require_automated_review` so a project workflow can auto-promote from `Human Review` after linked PR + green CI + no P1 findings + quiet time without requiring a bot GitHub PR review to exist
- clarify README/onboarding docs that `Human Review` is a holding state and the workflow decides whether promotion waits for human label, bot PR review, or CI/quiet criteria
- make Ctrl+C shutdown bounded so cancellation-resistant server/project cleanup cannot keep the process alive forever
- make `detent doctor` stream progress by default, run independent checks in parallel, bound each check with a timeout, expose `--timeout`, and show the Detent executable separately from external `git`

Closes #424
Refs #417
Refs #418
Refs #420

## Test Plan

- [x] `go test ./internal/connector/github -run 'TestParseBlockedByRecognizesIssueReferences|TestConnectorFetchIssueStatesByIdentifiersResolvesDependencyReadinessSignals' -count=1`
- [x] `go test ./internal/orchestrator ./internal/gate -run 'TestTickAutoPromoteHumanReviewIssues|TestTickAutoUnblocksDependencyWaitingIssue|TestTickAutoUnblocksLightweightDependencyWaitingIssue' -count=1`
- [x] `go test ./internal/gate ./internal/config ./internal/orchestrator ./internal/runner -count=1`
- [x] `go test ./internal/cli -run 'TestDoctor|TestRunDoctor|TestCheckDoctor|TestRunWithShutdown|TestShutdownController|TestShutdownBanner' -count=1`
- [x] `go test ./internal/cli -race -count=1`
- [x] `go test ./internal/cli ./internal/project ./internal/orchestrator -count=1`
- [x] `./tmp/detent doctor --port 0 --timeout 2s`
- [x] `/Users/corylanou/go/bin/detent doctor --port 0 --timeout 2s`
- [x] `make check`
