### PR TITLE
fix(doctor): require read:project scope

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -47,7 +47,7 @@ const (
 	doctorFail doctorStatus = "FAIL"
 )
 
-var requiredGitHubScopes = []string{"repo", "read:org", "project"}
+var requiredGitHubScopes = []string{"repo", "read:org", "read:project", "project"}
 
 const (
 	doctorAutoPromoteSampleLimit           = 5
@@ -2395,7 +2395,7 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 			Name:   "GitHub token",
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s scope check failed: %v", source, err),
-			Hint:   `Refresh the token with repo, read:org, and project scopes.`,
+			Hint:   githubAuthHint,
 		}
 	}
 	if len(scopes) == 0 {

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2489,11 +2489,23 @@ func missingGitHubScopes(scopes []string) []string {
 
 	var missing []string
 	for _, scope := range requiredGitHubScopes {
-		if _, ok := have[scope]; !ok {
+		if !hasEffectiveGitHubScope(have, scope) {
 			missing = append(missing, scope)
 		}
 	}
 	return missing
+}
+
+func hasEffectiveGitHubScope(scopes map[string]struct{}, scope string) bool {
+	if _, ok := scopes[scope]; ok {
+		return true
+	}
+	return scope == "read:project" && hasGitHubProjectScope(scopes)
+}
+
+func hasGitHubProjectScope(scopes map[string]struct{}) bool {
+	_, ok := scopes["project"]
+	return ok
 }
 
 func checkDoctorServerPort(ctx context.Context, cfg BootConfig, deps doctorDeps) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -988,6 +988,7 @@ func TestCheckDoctorGitHub(t *testing.T) {
 		env        map[string]string
 		want       doctorStatus
 		wantDetail string
+		wantHint   string
 	}{
 		{
 			name:       "missing token",
@@ -1002,11 +1003,20 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			wantDetail: "scope check failed",
 		},
 		{
-			name:       "missing required scope",
+			name:       "missing required scopes",
 			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
 			scopes:     []string{"repo"},
 			want:       doctorFail,
-			wantDetail: "read:org",
+			wantDetail: "read:org, read:project, project",
+			wantHint:   `gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"`,
+		},
+		{
+			name:       "missing read project scope",
+			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
+			scopes:     []string{"repo", "read:org", "project"},
+			want:       doctorFail,
+			wantDetail: "missing scope(s): read:project",
+			wantHint:   `gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"`,
 		},
 		{
 			name:       "fine grained token has no classic scopes",
@@ -1053,21 +1063,21 @@ func TestCheckDoctorGitHub(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			}},
 			token:      RuntimeSecret{Value: "token", Source: "PROJECT_TOKEN"},
-			scopes:     []string{"project", "read:org", "repo"},
+			scopes:     []string{"project", "read:project", "read:org", "repo"},
 			want:       doctorOK,
 			wantDetail: "PROJECT_TOKEN has classic PAT scopes",
 		},
 		{
 			name:       "environment token has required scopes",
 			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
-			scopes:     []string{"workflow", "project", "read:org", "repo"},
+			scopes:     []string{"workflow", "project", "read:project", "read:org", "repo"},
 			want:       doctorOK,
 			wantDetail: "GITHUB_TOKEN has classic PAT scopes",
 		},
 		{
 			name:       "gh sentinel token has required scopes",
 			token:      RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"},
-			scopes:     []string{"project", "read:org", "repo"},
+			scopes:     []string{"project", "read:project", "read:org", "repo"},
 			want:       doctorOK,
 			wantDetail: "github_token resolved via gh has classic PAT scopes",
 		},
@@ -1095,6 +1105,9 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			}
 			if !strings.Contains(got.Detail, tt.wantDetail) {
 				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+			if tt.wantHint != "" && !strings.Contains(got.Hint, tt.wantHint) {
+				t.Fatalf("Hint = %q, want containing %q", got.Hint, tt.wantHint)
 			}
 		})
 	}
@@ -1855,7 +1868,7 @@ func successfulDoctorDeps() doctorDeps {
 			return nil
 		},
 		githubScopes: func(context.Context, string) ([]string, error) {
-			return []string{"repo", "read:org", "project"}, nil
+			return []string{"repo", "read:org", "read:project", "project"}, nil
 		},
 		githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
 			return []ghconnector.ReadinessCheck{

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1011,12 +1011,19 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			wantHint:   `gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"`,
 		},
 		{
-			name:       "missing read project scope",
+			name:       "missing write project scope",
+			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
+			scopes:     []string{"repo", "read:org", "read:project"},
+			want:       doctorFail,
+			wantDetail: "missing scope(s): project",
+			wantHint:   `gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"`,
+		},
+		{
+			name:       "project scope satisfies normalized read project scope",
 			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
 			scopes:     []string{"repo", "read:org", "project"},
-			want:       doctorFail,
-			wantDetail: "missing scope(s): read:project",
-			wantHint:   `gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"`,
+			want:       doctorOK,
+			wantDetail: "GITHUB_TOKEN has classic PAT scopes",
 		},
 		{
 			name:       "fine grained token has no classic scopes",

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -26,7 +26,7 @@ const (
 	runtimeSourceWorkflow = "workflow"
 	runtimeSourceDefault  = "default"
 
-	githubAuthHint = `Run gh auth login --scopes "repo,read:org,project" and set github_token: gh in global.yaml.`
+	githubAuthHint = `Run gh auth login --scopes "repo,read:org,read:project,project" and set github_token: gh in global.yaml. For existing auth, run gh auth refresh -h github.com --scopes "repo,read:org,read:project,project".`
 )
 
 type RuntimeValue struct {


### PR DESCRIPTION
## Summary

- Add `read:project` to the GitHub ProjectV2 scope guidance and doctor required-scope reporting.
- Keep GitHub App credential behavior unchanged.
- Accept GitHub's normalized `project` scope as satisfying the ProjectV2 read side when `read:project` is omitted from reported OAuth scopes.
- Update focused doctor tests for missing scopes, normalized Projects scopes, and the exact refresh hint.

Fixes #396

## Test Plan

- [x] `go test ./internal/cli -run TestCheckDoctorGitHub`
- [x] `go test ./internal/cli`
- [x] `make check`