### PR TITLE
feat(cli): add actionable error hints

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -22,6 +22,50 @@ var (
 	ErrProjectNotFound = errors.New("project not found")
 )
 
+const (
+	addProjectExampleCommand = "detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"
+	configPathCommand        = "detent config path"
+	forceInitCommand         = "detent init --force"
+	ghAuthLoginCommand       = `gh auth login --scopes "repo,read:org,project"`
+	portExampleCommand       = "detent --port 0"
+	promoteExampleCommand    = "detent promote api --priority 10"
+)
+
+type HintedError struct {
+	Err      error
+	Message  string
+	Hint     string
+	Commands []string
+}
+
+func (e *HintedError) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return ""
+}
+
+func (e *HintedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func HintFor(err error) (string, []string, bool) {
+	var hinted *HintedError
+	if !errors.As(err, &hinted) {
+		return "", nil, false
+	}
+	return hinted.Hint, append([]string(nil), hinted.Commands...), true
+}
+
 type Operation string
 
 const (
@@ -237,6 +281,7 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 		newPromoteCommand(&configPath, opts),
 		newRemoveProjectCommand(&configPath, opts),
 	)
+	wrapHintedErrors(cmd)
 
 	return cmd
 }
@@ -278,6 +323,49 @@ func stdoutIsTTY() bool {
 	return err == nil && info.Mode()&os.ModeCharDevice != 0
 }
 
+func hintedError(cause error, message string, hint string, commands ...string) error {
+	return &HintedError{
+		Err:      cause,
+		Message:  message,
+		Hint:     strings.TrimSpace(hint),
+		Commands: append([]string(nil), commands...),
+	}
+}
+
+func exampleHint(command string) string {
+	return "e.g. " + command
+}
+
+func wrapHintedErrors(cmd *cobra.Command) {
+	if cmd == nil {
+		return
+	}
+	if cmd.RunE != nil {
+		runE := cmd.RunE
+		cmd.RunE = func(cmd *cobra.Command, args []string) error {
+			err := runE(cmd, args)
+			if err != nil {
+				if writeErr := writeErrorHint(cmd.ErrOrStderr(), err); writeErr != nil {
+					return errors.Join(err, writeErr)
+				}
+			}
+			return err
+		}
+	}
+	for _, child := range cmd.Commands() {
+		wrapHintedErrors(child)
+	}
+}
+
+func writeErrorHint(out io.Writer, err error) error {
+	hint, _, ok := HintFor(err)
+	if !ok || strings.TrimSpace(hint) == "" {
+		return nil
+	}
+	_, writeErr := fmt.Fprintf(out, "Hint: %s\n", hint)
+	return writeErr
+}
+
 func newInitCommand(configPath *string, opts options) *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
@@ -314,7 +402,13 @@ func checkInitTarget(path string, force bool) error {
 	_, err := os.Stat(path)
 	if err == nil {
 		if !force {
-			return fmt.Errorf("%w: %s", ErrConfigExists, path)
+			return hintedError(
+				ErrConfigExists,
+				fmt.Sprintf("%s: %s", ErrConfigExists, path),
+				"run detent init --force to overwrite it, or edit the file reported by detent config path",
+				forceInitCommand,
+				configPathCommand,
+			)
 		}
 		if _, readErr := os.ReadFile(path); readErr != nil {
 			return fmt.Errorf("read existing global config %s: %w", path, readErr)
@@ -349,7 +443,7 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 				return err
 			}
 			if projectIndex(global.Projects, cfg.ID) >= 0 {
-				return fmt.Errorf("%w: %s", ErrProjectExists, cfg.ID)
+				return projectExistsError(cfg.ID)
 			}
 
 			global.Projects = append(global.Projects, cfg)
@@ -376,13 +470,14 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 func validateProjectFlags(cfg globalconfig.Project) error {
 	switch {
 	case cfg.ID == "":
-		return errors.New("project id is required")
+		return hintedError(nil, "--id is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand)
 	case strings.TrimSpace(cfg.Workflow) == "":
-		return errors.New("project workflow is required")
+		return hintedError(nil, "--workflow is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand)
 	case strings.TrimSpace(cfg.Workdir) == "":
-		return errors.New("project workdir is required")
+		return hintedError(nil, "--workdir is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand)
 	case cfg.Weight <= 0:
-		return errors.New("project weight must be positive")
+		command := addProjectExampleCommand + " --weight 1"
+		return hintedError(nil, "--weight must be positive", exampleHint(command), command)
 	default:
 		return nil
 	}
@@ -434,7 +529,7 @@ func newPromoteCommand(configPath *string, opts options) *cobra.Command {
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if priority <= 0 {
-				return errors.New("priority must be positive")
+				return hintedError(nil, "--priority must be positive", exampleHint(promoteExampleCommand), promoteExampleCommand)
 			}
 			return updateProject(cmd.Context(), *configPath, opts, OperationPromoteProject, args[0], func(project *globalconfig.Project) error {
 				project.Priority = priority
@@ -459,7 +554,7 @@ func updateProject(ctx context.Context, configPath string, opts options, operati
 	id = strings.TrimSpace(id)
 	index := projectIndex(cfg.Projects, id)
 	if index < 0 {
-		return fmt.Errorf("%w: %s", ErrProjectNotFound, id)
+		return projectNotFoundError(id, cfg.Projects)
 	}
 	if err := edit(&cfg.Projects[index]); err != nil {
 		return err
@@ -493,7 +588,7 @@ func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
 			id := strings.TrimSpace(args[0])
 			index := projectIndex(cfg.Projects, id)
 			if index < 0 {
-				return fmt.Errorf("%w: %s", ErrProjectNotFound, id)
+				return projectNotFoundError(id, cfg.Projects)
 			}
 			removed := cfg.Projects[index]
 			cfg.Projects = append(cfg.Projects[:index], cfg.Projects[index+1:]...)
@@ -536,4 +631,103 @@ func projectIndex(projects []globalconfig.Project, id string) int {
 		}
 	}
 	return -1
+}
+
+func projectExistsError(id string) error {
+	id = strings.TrimSpace(id)
+	return hintedError(
+		ErrProjectExists,
+		fmt.Sprintf("project %q already exists", id),
+		fmt.Sprintf("project id %q is already taken; run detent config path to inspect current projects before choosing a new --id", id),
+		configPathCommand,
+	)
+}
+
+func projectNotFoundError(id string, projects []globalconfig.Project) error {
+	id = strings.TrimSpace(id)
+	ids := projectHintIDs(projects)
+	if len(ids) == 0 {
+		return hintedError(
+			ErrProjectNotFound,
+			fmt.Sprintf("project %q not found", id),
+			"no projects are configured; run detent add-project to add one",
+			addProjectExampleCommand,
+		)
+	}
+
+	hint := "available: " + strings.Join(ids, ", ")
+	if closest := closestProjectID(id, ids); closest != "" {
+		hint += fmt.Sprintf("\ndid you mean %q? see `%s`, then retry", closest, configPathCommand)
+	} else {
+		hint += fmt.Sprintf("\nsee `%s`, then retry", configPathCommand)
+	}
+	return hintedError(ErrProjectNotFound, fmt.Sprintf("project %q not found", id), hint, configPathCommand)
+}
+
+func projectHintIDs(projects []globalconfig.Project) []string {
+	ids := make([]string, 0, len(projects))
+	for _, project := range projects {
+		id := strings.TrimSpace(project.ID)
+		if id != "" {
+			ids = append(ids, id)
+		}
+	}
+	return ids
+}
+
+func closestProjectID(target string, ids []string) string {
+	target = strings.TrimSpace(target)
+	bestID := ""
+	bestDistance := 0
+	for _, id := range ids {
+		distance := levenshteinDistance(target, id)
+		if bestID == "" || distance < bestDistance {
+			bestID = id
+			bestDistance = distance
+		}
+	}
+	return bestID
+}
+
+func levenshteinDistance(a string, b string) int {
+	ar := []rune(a)
+	br := []rune(b)
+	if len(ar) == 0 {
+		return len(br)
+	}
+	if len(br) == 0 {
+		return len(ar)
+	}
+
+	previous := make([]int, len(br)+1)
+	for j := range previous {
+		previous[j] = j
+	}
+	for i, ra := range ar {
+		current := make([]int, len(br)+1)
+		current[0] = i + 1
+		for j, rb := range br {
+			cost := 0
+			if ra != rb {
+				cost = 1
+			}
+			current[j+1] = minInt(
+				current[j]+1,
+				previous[j+1]+1,
+				previous[j]+cost,
+			)
+		}
+		previous = current
+	}
+	return previous[len(br)]
+}
+
+func minInt(values ...int) int {
+	min := values[0]
+	for _, value := range values[1:] {
+		if value < min {
+			min = value
+		}
+	}
+	return min
 }

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -374,6 +374,151 @@ func TestInitRefusesExistingConfigWithoutForce(t *testing.T) {
 	}
 }
 
+func TestCLIValidationErrorsCarryHints(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	writeGlobalConfig(t, configPath, nil)
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantMessage  string
+		wantHint     string
+		wantCommands []string
+	}{
+		{
+			name:         "root port",
+			args:         []string{"--config", configPath, "--port", "-1"},
+			wantMessage:  "--port must be greater than or equal to 0",
+			wantHint:     "e.g. detent --port 0",
+			wantCommands: []string{"detent --port 0"},
+		},
+		{
+			name:         "missing project id",
+			args:         []string{"--config", configPath, "add-project", "--workflow", "./WORKFLOW.md", "--workdir", "~/code/api"},
+			wantMessage:  "--id is required",
+			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api",
+			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"},
+		},
+		{
+			name:         "missing project workflow",
+			args:         []string{"--config", configPath, "add-project", "--id", "api", "--workdir", "~/code/api"},
+			wantMessage:  "--workflow is required",
+			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api",
+			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"},
+		},
+		{
+			name:         "missing project workdir",
+			args:         []string{"--config", configPath, "add-project", "--id", "api", "--workflow", "./WORKFLOW.md"},
+			wantMessage:  "--workdir is required",
+			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api",
+			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"},
+		},
+		{
+			name:         "invalid project weight",
+			args:         []string{"--config", configPath, "add-project", "--id", "api", "--workflow", "./WORKFLOW.md", "--workdir", "~/code/api", "--weight", "0"},
+			wantMessage:  "--weight must be positive",
+			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api --weight 1",
+			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api --weight 1"},
+		},
+		{
+			name:         "invalid promote priority",
+			args:         []string{"--config", configPath, "promote", "api", "--priority", "0"},
+			wantMessage:  "--priority must be positive",
+			wantHint:     "e.g. detent promote api --priority 10",
+			wantCommands: []string{"detent promote api --priority 10"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr bytes.Buffer
+			cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(context.Context, cli.BootConfig) error {
+				t.Fatal("boot should not run")
+				return nil
+			}))
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want error")
+			}
+			assertHintedError(t, err, nil, tt.wantMessage, tt.wantHint, tt.wantCommands)
+			if !strings.Contains(stderr.String(), "Hint: "+tt.wantHint) {
+				t.Fatalf("stderr missing hint %q:\n%s", tt.wantHint, stderr.String())
+			}
+		})
+	}
+}
+
+func TestConfigAndProjectConflictErrorsCarryHints(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "detent", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
+	})
+
+	tests := []struct {
+		name         string
+		args         []string
+		wantErr      error
+		wantMessage  string
+		wantHint     string
+		wantCommands []string
+	}{
+		{
+			name:         "config exists",
+			args:         []string{"--config", configPath, "init"},
+			wantErr:      cli.ErrConfigExists,
+			wantMessage:  "global config already exists: " + configPath,
+			wantHint:     "run detent init --force to overwrite it, or edit the file reported by detent config path",
+			wantCommands: []string{"detent init --force", "detent config path"},
+		},
+		{
+			name: "project exists",
+			args: []string{
+				"--config", configPath,
+				"add-project",
+				"--id", "detent",
+				"--workflow", paths.workflowPath,
+				"--workdir", paths.workdirPath,
+			},
+			wantErr:      cli.ErrProjectExists,
+			wantMessage:  `project "detent" already exists`,
+			wantHint:     `project id "detent" is already taken; run detent config path to inspect current projects before choosing a new --id`,
+			wantCommands: []string{"detent config path"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var stderr bytes.Buffer
+			cmd := cli.NewRootCommand(context.Background())
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&stderr)
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want error")
+			}
+			assertHintedError(t, err, tt.wantErr, tt.wantMessage, tt.wantHint, tt.wantCommands)
+			if !strings.Contains(stderr.String(), "Hint: "+tt.wantHint) {
+				t.Fatalf("stderr missing hint %q:\n%s", tt.wantHint, stderr.String())
+			}
+		})
+	}
+}
+
 func TestAddProjectWritesConfigAndSignalsManager(t *testing.T) {
 	t.Parallel()
 
@@ -569,16 +714,22 @@ projects:
 func TestProjectAdminCommandsRejectMissingProject(t *testing.T) {
 	t.Parallel()
 
-	configPath := filepath.Join(t.TempDir(), "global.yaml")
-	writeGlobalConfig(t, configPath, nil)
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "api", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
+		{ID: "web", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
+		{ID: "infra", Workflow: paths.workflowPath, Workdir: paths.workdirPath, Weight: 1},
+	})
 
+	var stderr bytes.Buffer
 	cmd := cli.NewRootCommand(context.Background(), cli.WithSignalFunc(func(context.Context, cli.Signal) error {
 		t.Fatal("signal should not be emitted")
 		return nil
 	}))
 	cmd.SetOut(&bytes.Buffer{})
-	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--config", configPath, "pause", "missing"})
+	cmd.SetErr(&stderr)
+	cmd.SetArgs([]string{"--config", configPath, "pause", "ap"})
 
 	err := cmd.Execute()
 	if err == nil {
@@ -586,6 +737,13 @@ func TestProjectAdminCommandsRejectMissingProject(t *testing.T) {
 	}
 	if !errors.Is(err, cli.ErrProjectNotFound) {
 		t.Fatalf("Execute() error = %v, want %v", err, cli.ErrProjectNotFound)
+	}
+	assertHintedError(t, err, cli.ErrProjectNotFound, `project "ap" not found`, "available: api, web, infra\n"+
+		"did you mean \"api\"? see `detent config path`, then retry", []string{"detent config path"})
+	for _, want := range []string{"Hint: available: api, web, infra", "did you mean \"api\"? see `detent config path`, then retry"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
 	}
 }
 
@@ -766,6 +924,27 @@ func assertSignal(t *testing.T, signals <-chan cli.Signal, operation cli.Operati
 	signal := <-signals
 	if signal.Operation != operation || signal.ProjectID != projectID {
 		t.Fatalf("signal = %#v, want %s %s", signal, operation, projectID)
+	}
+}
+
+func assertHintedError(t *testing.T, err error, wantErr error, wantMessage string, wantHint string, wantCommands []string) {
+	t.Helper()
+
+	if wantErr != nil && !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if err.Error() != wantMessage {
+		t.Fatalf("error message = %q, want %q", err.Error(), wantMessage)
+	}
+	gotHint, gotCommands, ok := cli.HintFor(err)
+	if !ok {
+		t.Fatalf("HintFor(%v) ok = false, want true", err)
+	}
+	if gotHint != wantHint {
+		t.Fatalf("hint = %q, want %q", gotHint, wantHint)
+	}
+	if !reflect.DeepEqual(gotCommands, wantCommands) {
+		t.Fatalf("commands = %#v, want %#v", gotCommands, wantCommands)
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -181,11 +181,15 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	})
 	cancelRuntime()
 	if runtimeErr != nil {
+		hint := "Fix runtime flags, environment variables, or global.yaml."
+		if runtimeHint, _, ok := HintFor(runtimeErr); ok && strings.TrimSpace(runtimeHint) != "" {
+			hint = runtimeHint
+		}
 		check := doctorCheck{
 			Name:   "Runtime settings",
 			Status: doctorFail,
 			Detail: runtimeErr.Error(),
-			Hint:   "Fix runtime flags, environment variables, or global.yaml.",
+			Hint:   hint,
 		}
 		writeDoctorProgressDone(progressOut, check)
 		report.Add(check)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -494,6 +494,57 @@ func TestCheckDoctorRuntimeSettingsReportsSources(t *testing.T) {
 	}
 }
 
+func TestRunDoctorPreservesHintedRuntimeErrorHint(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	opts := successfulDoctorOptions(configPath)
+	opts.read = func(string) (globalconfig.Config, error) {
+		return globalconfig.Config{
+			Path:       configPath,
+			APIVersion: globalconfig.APIVersion,
+			Kind:       globalconfig.Kind,
+			Global: globalconfig.Settings{
+				MaxConcurrentAgents: 1,
+				Scheduling:          globalconfig.SchedulingWeighted,
+			},
+			Projects: []globalconfig.Project{
+				{ID: "api", Workflow: "WORKFLOW.md", Workdir: "/repo"},
+			},
+		}, nil
+	}
+	deps := successfulDoctorDeps()
+	deps.lookupEnv = func(string) string {
+		return ""
+	}
+	deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+		cfg := validDoctorWorkflow("/repo")
+		cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+		return workflowconfig.Workflow{Config: cfg}, nil
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:   configPath,
+		Host:         "127.0.0.1",
+		Output:       io.Discard,
+		CheckTimeout: time.Second,
+	}, opts, deps)
+
+	for _, check := range report.Checks {
+		if check.Name != "Runtime settings" {
+			continue
+		}
+		if check.Hint != githubAuthHint {
+			t.Fatalf("Runtime settings hint = %q, want %q", check.Hint, githubAuthHint)
+		}
+		if strings.Contains(check.Detail, githubAuthHint) {
+			t.Fatalf("Runtime settings detail includes hint: %q", check.Detail)
+		}
+		return
+	}
+	t.Fatal("Runtime settings check not found")
+}
+
 func TestCheckDoctorDetentExecutableReportsRunningBinary(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -183,14 +183,14 @@ func resolveRuntimeString(input runtimeStringInput, lookupEnv func(string) strin
 func resolveRuntimePort(ctx context.Context, input runtimeInput, deps runtimeDeps) (RuntimeIntValue, error) {
 	if input.Flags.Port.Set {
 		if input.Flags.Port.Value < 0 {
-			return RuntimeIntValue{}, errors.New("port must be greater than or equal to 0")
+			return RuntimeIntValue{}, hintedError(nil, "--port must be greater than or equal to 0", exampleHint(portExampleCommand), portExampleCommand)
 		}
 		return RuntimeIntValue{Value: input.Flags.Port.Value, Source: runtimeSourceFlag}, nil
 	}
 	if raw := strings.TrimSpace(deps.lookupEnv("PORT")); raw != "" {
 		port, err := strconv.Atoi(raw)
 		if err != nil || port < 0 {
-			return RuntimeIntValue{}, errors.New("PORT must be an integer greater than or equal to 0")
+			return RuntimeIntValue{}, hintedError(nil, "PORT must be an integer greater than or equal to 0", "set PORT=4000 or run detent --port 0", portExampleCommand)
 		}
 		return RuntimeIntValue{Value: port, Source: "PORT"}, nil
 	}
@@ -244,7 +244,7 @@ func resolveRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, de
 		return token, nil, nil
 	}
 	if requiresRuntimeToken {
-		return RuntimeSecret{}, nil, fmt.Errorf("GITHUB_TOKEN is not set, github_token is not configured, and no usable tracker.api_key was found. %s", githubAuthHint)
+		return RuntimeSecret{}, nil, hintedError(nil, "GITHUB_TOKEN is not set, github_token is not configured, and no usable tracker.api_key was found", githubAuthHint, ghAuthLoginCommand)
 	}
 	return RuntimeSecret{Required: false}, nil, nil
 }
@@ -253,11 +253,13 @@ func resolveConfiguredGitHubToken(ctx context.Context, token string, deps runtim
 	if githubTokenSentinel(token) {
 		resolved, err := deps.ghAuthToken(ctx)
 		if err != nil {
-			return RuntimeSecret{}, fmt.Errorf("resolve github_token via gh auth token: %w. %s", err, githubAuthHint)
+			cause := fmt.Errorf("resolve github_token via gh auth token: %w", err)
+			return RuntimeSecret{}, hintedError(cause, cause.Error(), githubAuthHint, ghAuthLoginCommand)
 		}
 		resolved = strings.TrimSpace(resolved)
 		if resolved == "" {
-			return RuntimeSecret{}, fmt.Errorf("resolve github_token via gh auth token: empty token. %s", githubAuthHint)
+			message := "resolve github_token via gh auth token: empty token"
+			return RuntimeSecret{}, hintedError(nil, message, githubAuthHint, ghAuthLoginCommand)
 		}
 		return RuntimeSecret{Value: resolved, Source: "github_token", ResolvedVia: "gh", Required: true}, nil
 	}

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -203,21 +203,24 @@ func TestResolveRuntimeSettingsGitHubTokenErrors(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name    string
-		cfg     globalconfig.Config
-		ghErr   error
-		wantErr string
+		name     string
+		cfg      globalconfig.Config
+		ghErr    error
+		wantErr  string
+		wantHint string
 	}{
 		{
-			name:    "sentinel failure includes gh auth guidance",
-			cfg:     githubRuntimeConfig("gh"),
-			ghErr:   errors.New("not logged in"),
-			wantErr: "gh auth login",
+			name:     "sentinel failure includes gh auth guidance",
+			cfg:      githubRuntimeConfig("gh"),
+			ghErr:    errors.New("not logged in"),
+			wantErr:  "not logged in",
+			wantHint: "gh auth login",
 		},
 		{
-			name:    "github projects require token",
-			cfg:     githubRuntimeConfig(""),
-			wantErr: "GITHUB_TOKEN",
+			name:     "github projects require token",
+			cfg:      githubRuntimeConfig(""),
+			wantErr:  "GITHUB_TOKEN",
+			wantHint: "gh auth login",
 		},
 	}
 
@@ -241,6 +244,13 @@ func TestResolveRuntimeSettingsGitHubTokenErrors(t *testing.T) {
 			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
+			}
+			hint, _, ok := HintFor(err)
+			if !ok {
+				t.Fatalf("HintFor(%v) ok = false, want true", err)
+			}
+			if !strings.Contains(hint, tt.wantHint) {
+				t.Fatalf("hint = %q, want containing %q", hint, tt.wantHint)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Add reusable hinted CLI errors with separable hint text and suggested commands.
- Add actionable validation, config/project conflict, runtime auth, and project-not-found hints.
- Cover required/invalid flags, project suggestions, and conflict remediation with table-driven tests.

Fixes #405

## Test Plan

- [x] `go test ./internal/cli`
- [x] `make check`
