### PR TITLE
feat(cli): add structured output

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,9 @@ detent update --check
 ```
 
 Release-installer installs can update with `detent update`; use
-`detent update --yes` for non-interactive automation and `detent update --json`
-for machine-readable status. On Windows, replacement is staged and completes
+`detent update --yes` for non-interactive automation and
+`detent update --format json` for machine-readable status. The legacy
+`detent update --json` flag remains supported. On Windows, replacement is staged and completes
 after the running `detent.exe` exits. Homebrew installs delegate to
 `brew upgrade digitaldrywood/tap/detent`. Go-installed binaries offer an
 interactive choice: run
@@ -1019,6 +1020,32 @@ Detent logs with `log/slog`.
 - `--env` and `--log-level` override environment variables for one run.
 - `DETENT_ENV` and `DETENT_LOG_LEVEL` remain deprecated fallbacks for one release. The unprefixed names win when both are set.
 - Text logs are written to stdout; JSON logs are written to stderr.
+
+## CLI Output
+
+Detent command output is selected by `--format pretty|json`. The explicit flag
+wins, then `DETENT_FORMAT`, then the stdout terminal check. Interactive
+terminals default to `pretty`; pipes, redirects, and agent subprocesses default
+to `json`. JSON is written to stdout. Progress and logs that would corrupt a
+JSON stdout stream are written to stderr in JSON mode.
+
+This changes piped output for scripts that parsed the old prose output. Use
+`--format pretty` for a single command or `DETENT_FORMAT=pretty` for a process
+environment that must keep the old text shape.
+
+Structured command objects:
+
+| Command | JSON object |
+| --- | --- |
+| `detent version` | `{"version":"v0.1.0","commit":"abc1234","build_date":"2026-06-13T00:00:00Z","go_version":"go1.26.4","os":"linux","arch":"amd64"}` |
+| `detent update` | The update status object, including `current_version`, `latest_version`, `latest_tag`, `update_available`, `install_source`, `action`, `message`, and `command` when present. |
+| `detent init` | `{"status":"ok","path":"/path/global.yaml","rule":"--config"}` |
+| `detent add-project` | `{"id":"api","workflow":"/repo/WORKFLOW.md","workdir":"/repo","weight":1,"priority":0,"paused":false,"credential_ref":"github"}` |
+| `detent pause api` / `detent unpause api` | `{"status":"ok","project":"api","paused":true}` |
+| `detent promote api --priority 1` | `{"status":"ok","project":"api","priority":1}` |
+| `detent remove-project api` | `{"status":"ok","project":"api","removed":true}` |
+| `detent config path` | `{"path":"/path/global.yaml","rule":"--config"}` |
+| `detent doctor` | `{"checks":[{"name":"Config resolution","status":"OK","detail":"...","hint":"..."}],"summary":{"ok":8,"warn":0,"fail":0},"result":"PASS"}` |
 
 ## Configuration
 

--- a/cmd/detent/slog.go
+++ b/cmd/detent/slog.go
@@ -14,20 +14,21 @@ import (
 
 func setupLoggerFromEnv(stdout io.Writer, stderr io.Writer) *slog.Logger {
 	env, envSet := envValueWithPresence("ENV", "DETENT_ENV")
-	return setupLoggerWithOutputs(env, envSet, envValue("LOG_LEVEL", "DETENT_LOG_LEVEL"), stdout, stderr, writerIsTTY(stdout))
+	stdoutTTY := cli.WriterIsTTY(stdout)
+	return setupLoggerWithOutputs(env, envSet, envValue("LOG_LEVEL", "DETENT_LOG_LEVEL"), stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY))
 }
 
 func setupLoggerFromRuntime(settings cli.RuntimeSettings, stdout io.Writer, stderr io.Writer, stdoutTTY bool) {
-	setupLoggerWithOutputs(settings.Env.Value, strings.TrimSpace(settings.Env.Value) != "", settings.LogLevel.Value, stdout, stderr, stdoutTTY)
+	setupLoggerWithOutputs(settings.Env.Value, strings.TrimSpace(settings.Env.Value) != "", settings.LogLevel.Value, stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY))
 }
 
 func setupLogger(env string, level string, w io.Writer) *slog.Logger {
 	return setupLoggerForTerminal(env, strings.TrimSpace(env) != "", level, w, false)
 }
 
-func setupLoggerWithOutputs(env string, envSet bool, level string, stdout io.Writer, stderr io.Writer, stdoutTTY bool) *slog.Logger {
+func setupLoggerWithOutputs(env string, envSet bool, level string, stdout io.Writer, stderr io.Writer, stdoutTTY bool, forceStderr bool) *slog.Logger {
 	w := stderr
-	if useTextLogs(env, envSet, stdoutTTY) {
+	if !forceStderr && useTextLogs(env, envSet, stdoutTTY) {
 		w = stdout
 	}
 	return setupLoggerForTerminal(env, envSet, level, w, stdoutTTY)
@@ -72,13 +73,22 @@ func useTextLogs(env string, envSet bool, stdoutTTY bool) bool {
 	return stdoutTTY
 }
 
-func writerIsTTY(w io.Writer) bool {
-	file, ok := w.(*os.File)
-	if !ok {
-		return false
+func commandOutputJSONSelected(args []string, stdoutTTY bool) bool {
+	formatFlag, flagSet := outputFormatArg(args)
+	format, err := cli.ResolveOutputFormat(formatFlag, flagSet, os.Getenv("DETENT_FORMAT"), stdoutTTY)
+	return err == nil && format == cli.OutputFormatJSON
+}
+
+func outputFormatArg(args []string) (string, bool) {
+	for index, arg := range args {
+		if arg == "--format" && index+1 < len(args) {
+			return args[index+1], true
+		}
+		if value, ok := strings.CutPrefix(arg, "--format="); ok {
+			return value, true
+		}
 	}
-	info, err := file.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
+	return "", false
 }
 
 func parseLogLevel(level string) slog.Level {

--- a/cmd/detent/slog_test.go
+++ b/cmd/detent/slog_test.go
@@ -155,7 +155,7 @@ func TestSetupLoggerWithOutputsRoutesTextToStdout(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	logger := setupLoggerWithOutputs("", false, "debug", &stdout, &stderr, true)
+	logger := setupLoggerWithOutputs("", false, "debug", &stdout, &stderr, true, false)
 	logger.Debug("ready")
 
 	if json.Valid(stdout.Bytes()) {
@@ -177,7 +177,7 @@ func TestSetupLoggerWithOutputsRoutesJSONToStderr(t *testing.T) {
 
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer
-	logger := setupLoggerWithOutputs("prod", true, "info", &stdout, &stderr, true)
+	logger := setupLoggerWithOutputs("prod", true, "info", &stdout, &stderr, true, false)
 	logger.Info("ready")
 
 	if stdout.Len() != 0 {
@@ -190,6 +190,55 @@ func TestSetupLoggerWithOutputsRoutesJSONToStderr(t *testing.T) {
 	}
 	if record["msg"] != "ready" {
 		t.Fatalf("msg = %v, want ready", record["msg"])
+	}
+}
+
+func TestSetupLoggerWithOutputsRoutesTextToStderrForJSONCommandOutput(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	logger := setupLoggerWithOutputs("", false, "debug", &stdout, &stderr, true, true)
+	logger.Debug("ready")
+
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+	if json.Valid(stderr.Bytes()) {
+		t.Fatalf("stderr log output is JSON, want text:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "ready") {
+		t.Fatalf("stderr log output missing message:\n%s", stderr.String())
+	}
+}
+
+func TestCommandOutputJSONSelected(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       string
+		args      []string
+		stdoutTTY bool
+		want      bool
+	}{
+		{name: "tty defaults to pretty", stdoutTTY: true},
+		{name: "pipe defaults to json", want: true},
+		{name: "env json overrides tty", env: "json", stdoutTTY: true, want: true},
+		{name: "env pretty overrides pipe", env: "pretty"},
+		{name: "flag json overrides env pretty", env: "pretty", args: []string{"version", "--format", "json"}, stdoutTTY: true, want: true},
+		{name: "flag pretty overrides env json", env: "json", args: []string{"--format=pretty", "version"}, want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DETENT_FORMAT", tt.env)
+
+			if got := commandOutputJSONSelected(tt.args, tt.stdoutTTY); got != tt.want {
+				t.Fatalf("commandOutputJSONSelected(%v, %v) = %v, want %v", tt.args, tt.stdoutTTY, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/cmd/detent/update.go
+++ b/cmd/detent/update.go
@@ -3,7 +3,6 @@ package main
 import (
 	"bufio"
 	"context"
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -13,6 +12,7 @@ import (
 
 	"github.com/spf13/cobra"
 
+	"github.com/digitaldrywood/detent/internal/cli"
 	detentupdate "github.com/digitaldrywood/detent/internal/update"
 )
 
@@ -35,6 +35,14 @@ func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command
 		Args:         cobra.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := cli.OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			if jsonOutput {
+				out.Format = cli.OutputFormatJSON
+			}
+
 			runCtx := cmd.Context()
 			if runCtx == nil {
 				runCtx = ctx
@@ -52,7 +60,7 @@ func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command
 				status, err = runner.Check(runCtx)
 			} else {
 				streamOut := cmd.OutOrStdout()
-				if jsonOutput {
+				if out.IsJSON() {
 					streamOut = cmd.ErrOrStderr()
 				}
 				opts := detentupdate.ApplyOptions{
@@ -61,20 +69,16 @@ func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command
 					Stdout:      streamOut,
 					Stderr:      cmd.ErrOrStderr(),
 				}
-				if !assumeYes && !fromRelease && !jsonOutput {
+				if !assumeYes && !fromRelease && !out.IsJSON() {
 					opts.Confirm = confirmUpdate(cmd)
 					opts.SelectGoInstallAction = selectGoInstallAction(cmd)
 				}
 				status, err = runner.Apply(runCtx, opts)
 			}
 
-			var writeErr error
-			if jsonOutput {
-				writeErr = writeUpdateJSON(cmd.OutOrStdout(), status)
-			} else {
-				writeErr = writeUpdateText(cmd.OutOrStdout(), status)
-			}
-			if writeErr != nil {
+			if writeErr := out.Write(func(out io.Writer) error {
+				return writeUpdateText(out, status)
+			}, status); writeErr != nil {
 				return writeErr
 			}
 			return err
@@ -154,12 +158,6 @@ func selectGoInstallAction(cmd *cobra.Command) func(detentupdate.Status) (detent
 			return "", fmt.Errorf("invalid update choice: %s", strings.TrimSpace(line))
 		}
 	}
-}
-
-func writeUpdateJSON(out io.Writer, status detentupdate.Status) error {
-	encoder := json.NewEncoder(out)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(status)
 }
 
 func writeUpdateText(out io.Writer, status detentupdate.Status) error {

--- a/cmd/detent/update_test.go
+++ b/cmd/detent/update_test.go
@@ -56,7 +56,7 @@ func TestUpdateCommandCheckJSON(t *testing.T) {
 }
 
 func TestUpdateCommandYesAppliesWithoutPrompt(t *testing.T) {
-	t.Parallel()
+	t.Setenv("DETENT_FORMAT", "pretty")
 
 	fake := &fakeUpdater{
 		applyStatus: update.Status{
@@ -93,6 +93,41 @@ func TestUpdateCommandYesAppliesWithoutPrompt(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Updated Detent from 1.2.3 to 1.2.4.") {
 		t.Fatalf("stdout = %q, want update message", stdout.String())
+	}
+}
+
+func TestUpdateCommandDefaultsToJSONWhenStdoutIsNotTTY(t *testing.T) {
+	t.Parallel()
+
+	fake := &fakeUpdater{
+		checkStatus: update.Status{
+			CurrentVersion:  "1.2.3",
+			LatestVersion:   "1.2.4",
+			LatestTag:       "v1.2.4",
+			UpdateAvailable: true,
+			InstallSource:   update.InstallSourceRelease,
+			Action:          update.ActionAvailable,
+			Message:         "Detent 1.2.3 can be updated to 1.2.4.",
+		},
+	}
+	cmd := newUpdateCommand(context.Background(), func(context.Context) (updateRunner, error) {
+		return fake, nil
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--check"})
+
+	if err := cmd.ExecuteContext(context.Background()); err != nil {
+		t.Fatalf("ExecuteContext() error = %v", err)
+	}
+
+	var got update.Status
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if !got.UpdateAvailable {
+		t.Fatal("UpdateAvailable = false, want true")
 	}
 }
 

--- a/cmd/detent/version.go
+++ b/cmd/detent/version.go
@@ -8,17 +8,18 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/digitaldrywood/detent/internal/buildinfo"
+	"github.com/digitaldrywood/detent/internal/cli"
 )
 
 var version, commit, date = "dev", "none", "unknown"
 
 type versionInfo struct {
-	Version   string
-	Commit    string
-	Date      string
-	GoVersion string
-	OS        string
-	Arch      string
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	Date      string `json:"build_date"`
+	GoVersion string `json:"go_version"`
+	OS        string `json:"os"`
+	Arch      string `json:"arch"`
 }
 
 func newVersionCommand() *cobra.Command {
@@ -27,8 +28,15 @@ func newVersionCommand() *cobra.Command {
 		Short: "Print version metadata",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			_, err := io.WriteString(cmd.OutOrStdout(), formatVersionInfo(currentVersionInfo()))
-			return err
+			info := currentVersionInfo()
+			out, err := cli.OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			return out.Write(func(out io.Writer) error {
+				_, err := io.WriteString(out, formatVersionInfo(info))
+				return err
+			}, info)
 		},
 	}
 }

--- a/cmd/detent/version_test.go
+++ b/cmd/detent/version_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"runtime"
 	"strings"
 	"testing"
@@ -60,7 +61,7 @@ func TestVersionCommandPrintsBuildFields(t *testing.T) {
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"version"})
+	cmd.SetArgs([]string{"--format", "pretty", "version"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -77,6 +78,38 @@ func TestVersionCommandPrintsBuildFields(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("version output missing %q:\n%s", want, output)
 		}
+	}
+}
+
+func TestVersionCommandWritesJSON(t *testing.T) {
+	withVersionMetadata(t, "v1.2.3", "abc1234", "2026-05-31T18:30:00Z")
+
+	cmd := newRootCommand(context.Background())
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "version"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Version   string `json:"version"`
+		Commit    string `json:"commit"`
+		BuildDate string `json:"build_date"`
+		GoVersion string `json:"go_version"`
+		OS        string `json:"os"`
+		Arch      string `json:"arch"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if got.Version != "v1.2.3" || got.Commit != "abc1234" || got.BuildDate != "2026-05-31T18:30:00Z" {
+		t.Fatalf("version json = %#v", got)
+	}
+	if got.GoVersion != runtime.Version() || got.OS != runtime.GOOS || got.Arch != runtime.GOARCH {
+		t.Fatalf("runtime json = %#v", got)
 	}
 }
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -180,7 +180,7 @@ grounded recommendation per Phase 2 question, then interview the human.
    outrank peers. Verify:
 
    ```sh
-   detent config path > "$ONBOARDING_DIR/global-path.txt"
+   detent --format pretty config path > "$ONBOARDING_DIR/global-path.txt"
    GLOBAL_CONFIG="$(awk '/^path:/ {print $2}' "$ONBOARDING_DIR/global-path.txt")"
    if test -f "$GLOBAL_CONFIG"; then
      awk '/^projects:/ {show=1} show {print}' "$GLOBAL_CONFIG" > "$ONBOARDING_DIR/global-projects.txt"
@@ -832,7 +832,7 @@ recommendation, and default-if-silent. Record answers in
 
    ```sh
    detent init
-   detent config path
+   detent --format pretty config path
    ```
 
 2. **Register the project.** `priority` and `weight` are the scheduling answers
@@ -845,7 +845,7 @@ recommendation, and default-if-silent. Record answers in
      --workdir <source-root> \
      --weight <global-weight> \
      --priority <global-priority>
-   GLOBAL_CONFIG="$(detent config path | awk '/^path:/ {print $2}')"
+   GLOBAL_CONFIG="$(detent --format pretty config path | awk '/^path:/ {print $2}')"
    rg -n 'id: <detent-project-id>|workflow: <source-root>/WORKFLOW.md|workdir: <source-root>|weight: <global-weight>|priority: <global-priority>' \
      "$GLOBAL_CONFIG"
    ```
@@ -860,7 +860,7 @@ recommendation, and default-if-silent. Record answers in
    `WORKFLOW.md` `server.host` or pass it with `--host`. Verify:
 
    ```sh
-   GLOBAL_CONFIG="$(detent config path | awk '/^path:/ {print $2}')"
+   GLOBAL_CONFIG="$(detent --format pretty config path | awk '/^path:/ {print $2}')"
    perl -0pi -e 's/^(global:)/env: prod\nlog_level: info\ngithub_token: gh\nport: <port>\ninstance_name: <instance-name>\n$1/m if !/^github_token:/m' "$GLOBAL_CONFIG"
    rg -n '^(env|log_level|github_token|port|instance_name):' "$GLOBAL_CONFIG"
    ```

--- a/install_test.go
+++ b/install_test.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"
@@ -675,17 +676,24 @@ func assertInstalledVersionMetadata(t *testing.T, binary string, root string, en
 	if err != nil {
 		t.Fatalf("detent version error = %v\nstderr:\n%s", err, stderr)
 	}
-	for _, want := range []string{
-		"version: " + wantVersion,
-		"commit: " + wantCommit,
-		"go version: " + runtime.Version(),
-		"os/arch: " + runtime.GOOS + "/" + runtime.GOARCH,
-	} {
-		if !strings.Contains(stdout, want) {
-			t.Fatalf("detent version output missing %q:\n%s", want, stdout)
-		}
+	var got struct {
+		Version   string `json:"version"`
+		Commit    string `json:"commit"`
+		BuildDate string `json:"build_date"`
+		GoVersion string `json:"go_version"`
+		OS        string `json:"os"`
+		Arch      string `json:"arch"`
 	}
-	if strings.Contains(stdout, "build date: unknown") {
+	if err := json.Unmarshal([]byte(stdout), &got); err != nil {
+		t.Fatalf("detent version JSON error = %v\nstdout:\n%s", err, stdout)
+	}
+	if got.Version != wantVersion || got.Commit != wantCommit {
+		t.Fatalf("detent version metadata = %#v, want version %q commit %q", got, wantVersion, wantCommit)
+	}
+	if got.GoVersion != runtime.Version() || got.OS != runtime.GOOS || got.Arch != runtime.GOARCH {
+		t.Fatalf("detent version runtime metadata = %#v", got)
+	}
+	if got.BuildDate == "unknown" {
 		t.Fatalf("detent version output kept unknown build date:\n%s", stdout)
 	}
 }

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -83,6 +83,45 @@ type Signal struct {
 	Project   globalconfig.Project
 }
 
+type initResult struct {
+	Status string `json:"status"`
+	Path   string `json:"path"`
+	Rule   string `json:"rule"`
+}
+
+type configPathResult struct {
+	Path string `json:"path"`
+	Rule string `json:"rule"`
+}
+
+type projectResult struct {
+	ID            string `json:"id"`
+	Workflow      string `json:"workflow"`
+	Workdir       string `json:"workdir"`
+	Weight        int    `json:"weight"`
+	Priority      int    `json:"priority"`
+	Paused        bool   `json:"paused"`
+	CredentialRef string `json:"credential_ref,omitempty"`
+}
+
+type projectPausedResult struct {
+	Status  string `json:"status"`
+	Project string `json:"project"`
+	Paused  bool   `json:"paused"`
+}
+
+type projectPriorityResult struct {
+	Status   string `json:"status"`
+	Project  string `json:"project"`
+	Priority int    `json:"priority"`
+}
+
+type projectRemovedResult struct {
+	Status  string `json:"status"`
+	Project string `json:"project"`
+	Removed bool   `json:"removed"`
+}
+
 type BootMode string
 
 const (
@@ -237,6 +276,9 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 		SilenceErrors:              true,
 		SuggestionsMinimumDistance: 2,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := OutputForCommand(cmd); err != nil {
+				return err
+			}
 			flags := runtimeFlags{
 				Env:      runtimeStringFlag{Value: env, Set: flagChanged(cmd, "env")},
 				LogLevel: runtimeStringFlag{Value: logLevel, Set: flagChanged(cmd, "log-level")},
@@ -261,14 +303,17 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 			return opts.boot(cmd.Context(), boot)
 		},
 	}
-	cmd.SetContext(ctx)
+	cmd.SetContext(withCommandOutputOptions(ctx, commandOutputOptions{
+		lookupEnv: opts.lookupEnv,
+		stdoutTTY: opts.stdoutTTY,
+	}))
 	cmd.PersistentFlags().StringVar(&configPath, "config", "", "path to global.yaml")
 	cmd.PersistentFlags().StringVar(&env, "env", "", "runtime environment")
 	cmd.PersistentFlags().StringVar(&logLevel, "log-level", "", "log level")
 	cmd.PersistentFlags().StringVar(&host, "host", "", "web server host")
 	cmd.PersistentFlags().IntVar(&port, "port", -1, "web server port, or 0 for an ephemeral port")
 	cmd.PersistentFlags().BoolVar(&headless, "headless", false, "stream logs instead of launching the terminal dashboard")
-	cmd.PersistentFlags().Var(newOutputFormatValue(&outputFormat), outputFormatFlagName, "output format: pretty or json")
+	cmd.PersistentFlags().Var(newOutputFormatValue(&outputFormat), outputFormatFlagName, "output format: pretty or json (default: pretty on TTY, json when piped; DETENT_FORMAT overrides)")
 	cmd.SetFlagErrorFunc(flagSuggestionError)
 
 	addProjectCommand := newAddProjectCommand(&configPath, opts)
@@ -335,8 +380,7 @@ func noSignal(context.Context, Signal) error {
 }
 
 func stdoutIsTTY() bool {
-	info, err := os.Stdout.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
+	return WriterIsTTY(os.Stdout)
 }
 
 func hintedError(cause error, message string, hint string, commands ...string) error {
@@ -389,10 +433,15 @@ func newInitCommand(configPath *string, opts options) *cobra.Command {
 		Short: "Create a default global config",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			path, err := resolveConfigPath(*configPath, opts)
+			out, err := OutputForCommand(cmd)
 			if err != nil {
 				return err
 			}
+			resolution, err := resolveConfigPathResolution(*configPath, opts)
+			if err != nil {
+				return err
+			}
+			path := resolution.Path
 
 			cfg, err := globalconfig.DefaultAt(path)
 			if err != nil {
@@ -405,8 +454,15 @@ func newInitCommand(configPath *string, opts options) *cobra.Command {
 			if err := opts.write(path, cfg); err != nil {
 				return err
 			}
-			return opts.signal(cmd.Context(), Signal{
+			if err := opts.signal(cmd.Context(), Signal{
 				Operation: OperationInit,
+			}); err != nil {
+				return err
+			}
+			return out.Write(nil, initResult{
+				Status: "ok",
+				Path:   path,
+				Rule:   string(resolution.Rule),
 			})
 		},
 	}
@@ -444,6 +500,10 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 		Short: "Add a project to global config",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
 			path, err := resolveConfigPath(*configPath, opts)
 			if err != nil {
 				return err
@@ -466,11 +526,14 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 			if err := opts.write(path, global); err != nil {
 				return err
 			}
-			return opts.signal(cmd.Context(), Signal{
+			if err := opts.signal(cmd.Context(), Signal{
 				Operation: OperationAddProject,
 				ProjectID: cfg.ID,
 				Project:   cfg,
-			})
+			}); err != nil {
+				return err
+			}
+			return out.Write(nil, newProjectResult(cfg))
 		},
 	}
 	cmd.Flags().StringVar(&cfg.ID, "id", "", "project id")
@@ -507,7 +570,15 @@ func newEditProjectCommand(configPath *string, opts options, operation Operation
 		Short: short,
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
-			return updateProject(cmd.Context(), *configPath, opts, operation, args[0], edit)
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			updated, err := updateProject(cmd.Context(), *configPath, opts, operation, args[0], edit)
+			if err != nil {
+				return err
+			}
+			return out.Write(nil, projectEditResult(operation, updated))
 		},
 	}
 }
@@ -527,12 +598,21 @@ func newConfigPathCommand(configPath *string, opts options) *cobra.Command {
 		Short: "Print the resolved global config path",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
 			resolution, err := resolveConfigPathResolution(*configPath, opts)
 			if err != nil {
 				return err
 			}
-			_, err = fmt.Fprintf(cmd.OutOrStdout(), "path: %s\nrule: %s\n", resolution.Path, resolution.Rule)
-			return err
+			return out.Write(func(out io.Writer) error {
+				_, err := fmt.Fprintf(out, "path: %s\nrule: %s\n", resolution.Path, resolution.Rule)
+				return err
+			}, configPathResult{
+				Path: resolution.Path,
+				Rule: string(resolution.Rule),
+			})
 		},
 	}
 }
@@ -547,9 +627,21 @@ func newPromoteCommand(configPath *string, opts options) *cobra.Command {
 			if priority <= 0 {
 				return hintedError(nil, "--priority must be positive", exampleHint(promoteExampleCommand), promoteExampleCommand)
 			}
-			return updateProject(cmd.Context(), *configPath, opts, OperationPromoteProject, args[0], func(project *globalconfig.Project) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			updated, err := updateProject(cmd.Context(), *configPath, opts, OperationPromoteProject, args[0], func(project *globalconfig.Project) error {
 				project.Priority = priority
 				return nil
+			})
+			if err != nil {
+				return err
+			}
+			return out.Write(nil, projectPriorityResult{
+				Status:   "ok",
+				Project:  updated.ID,
+				Priority: updated.Priority,
 			})
 		},
 	}
@@ -557,33 +649,36 @@ func newPromoteCommand(configPath *string, opts options) *cobra.Command {
 	return cmd
 }
 
-func updateProject(ctx context.Context, configPath string, opts options, operation Operation, id string, edit projectEdit) error {
+func updateProject(ctx context.Context, configPath string, opts options, operation Operation, id string, edit projectEdit) (globalconfig.Project, error) {
 	path, err := resolveConfigPath(configPath, opts)
 	if err != nil {
-		return err
+		return globalconfig.Project{}, err
 	}
 	cfg, err := opts.readOrDefault(path)
 	if err != nil {
-		return err
+		return globalconfig.Project{}, err
 	}
 
 	id = strings.TrimSpace(id)
 	index := projectIndex(cfg.Projects, id)
 	if index < 0 {
-		return projectNotFoundError(id, cfg.Projects)
+		return globalconfig.Project{}, projectNotFoundError(id, cfg.Projects)
 	}
 	if err := edit(&cfg.Projects[index]); err != nil {
-		return err
+		return globalconfig.Project{}, err
 	}
 	if err := opts.write(path, cfg); err != nil {
-		return err
+		return globalconfig.Project{}, err
 	}
 
-	return opts.signal(ctx, Signal{
+	if err := opts.signal(ctx, Signal{
 		Operation: operation,
 		ProjectID: cfg.Projects[index].ID,
 		Project:   cfg.Projects[index],
-	})
+	}); err != nil {
+		return globalconfig.Project{}, err
+	}
+	return cfg.Projects[index], nil
 }
 
 func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
@@ -592,6 +687,10 @@ func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
 		Short: "Remove a project from global config",
 		Args:  cobra.ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
 			path, err := resolveConfigPath(*configPath, opts)
 			if err != nil {
 				return err
@@ -615,12 +714,44 @@ func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
 				return err
 			}
 
-			return opts.signal(cmd.Context(), Signal{
+			if err := opts.signal(cmd.Context(), Signal{
 				Operation: OperationRemoveProject,
 				ProjectID: removed.ID,
 				Project:   removed,
+			}); err != nil {
+				return err
+			}
+			return out.Write(nil, projectRemovedResult{
+				Status:  "ok",
+				Project: removed.ID,
+				Removed: true,
 			})
 		},
+	}
+}
+
+func newProjectResult(project globalconfig.Project) projectResult {
+	return projectResult{
+		ID:            project.ID,
+		Workflow:      project.Workflow,
+		Workdir:       project.Workdir,
+		Weight:        project.Weight,
+		Priority:      project.Priority,
+		Paused:        project.Paused,
+		CredentialRef: project.CredentialRef,
+	}
+}
+
+func projectEditResult(operation Operation, project globalconfig.Project) any {
+	switch operation {
+	case OperationPauseProject, OperationUnpauseProject:
+		return projectPausedResult{
+			Status:  "ok",
+			Project: project.ID,
+			Paused:  project.Paused,
+		}
+	default:
+		return newProjectResult(project)
 	}
 }
 

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -165,7 +166,7 @@ func TestConfigPathCommandPrintsResolvedPathAndRule(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), "global.yaml")
-	cmd := cli.NewRootCommand(context.Background())
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
@@ -180,6 +181,85 @@ func TestConfigPathCommandPrintsResolvedPathAndRule(t *testing.T) {
 		if !strings.Contains(output, want) {
 			t.Fatalf("config path output missing %q:\n%s", want, output)
 		}
+	}
+}
+
+func TestOutputFormatPrecedence(t *testing.T) {
+	tests := []struct {
+		name      string
+		env       string
+		stdoutTTY bool
+		args      []string
+		wantJSON  bool
+	}{
+		{
+			name:     "non tty defaults to json",
+			wantJSON: true,
+		},
+		{
+			name:      "tty defaults to pretty",
+			stdoutTTY: true,
+		},
+		{
+			name: "env pretty overrides non tty",
+			env:  "pretty",
+		},
+		{
+			name:      "env json overrides tty",
+			env:       "json",
+			stdoutTTY: true,
+			wantJSON:  true,
+		},
+		{
+			name:     "flag json overrides env pretty",
+			env:      "pretty",
+			args:     []string{"--format", "json"},
+			wantJSON: true,
+		},
+		{
+			name:      "flag pretty overrides env json",
+			env:       "json",
+			stdoutTTY: false,
+			args:      []string{"--format", "pretty"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			path := filepath.Join(t.TempDir(), "global.yaml")
+			cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return tt.stdoutTTY }))
+			if tt.env != "" {
+				t.Setenv("DETENT_FORMAT", tt.env)
+			}
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			args := append([]string{}, tt.args...)
+			args = append(args, "--config", path, "config", "path")
+			cmd.SetArgs(args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			if tt.wantJSON {
+				var got struct {
+					Path string `json:"path"`
+					Rule string `json:"rule"`
+				}
+				if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+					t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+				}
+				if got.Path != path || got.Rule != string(globalconfig.PathRuleFlag) {
+					t.Fatalf("json output = %#v, want path %q rule %q", got, path, globalconfig.PathRuleFlag)
+				}
+				return
+			}
+			for _, want := range []string{"path: " + path, "rule: " + string(globalconfig.PathRuleFlag)} {
+				if !strings.Contains(stdout.String(), want) {
+					t.Fatalf("pretty output missing %q:\n%s", want, stdout.String())
+				}
+			}
+		})
 	}
 }
 
@@ -424,7 +504,7 @@ func TestInitWritesDefaultGlobalConfig(t *testing.T) {
 	t.Parallel()
 
 	path := filepath.Join(t.TempDir(), ".detent", "global.yaml")
-	cmd := cli.NewRootCommand(context.Background())
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"--config", path, "init"})
@@ -442,6 +522,74 @@ func TestInitWritesDefaultGlobalConfig(t *testing.T) {
 	}
 	if len(cfg.Projects) != 0 {
 		t.Fatalf("Projects = %#v, want empty", cfg.Projects)
+	}
+}
+
+func TestProjectCommandsWriteJSONResults(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{
+			name: "init",
+			args: []string{"init"},
+			want: fmt.Sprintf(`{"status":"ok","path":%q,"rule":"--config"}`, configPath),
+		},
+		{
+			name: "add-project",
+			args: []string{
+				"add-project",
+				"--id", "detent",
+				"--workflow", paths.workflowPath,
+				"--workdir", paths.workdirPath,
+				"--weight", "5",
+				"--priority", "50",
+				"--paused",
+				"--credential-ref", "github-default",
+			},
+			want: fmt.Sprintf(`{"id":"detent","workflow":%q,"workdir":%q,"weight":5,"priority":50,"paused":true,"credential_ref":"github-default"}`, paths.workflowPath, paths.workdirPath),
+		},
+		{
+			name: "pause",
+			args: []string{"pause", "detent"},
+			want: `{"status":"ok","project":"detent","paused":true}`,
+		},
+		{
+			name: "unpause",
+			args: []string{"unpause", "detent"},
+			want: `{"status":"ok","project":"detent","paused":false}`,
+		},
+		{
+			name: "promote",
+			args: []string{"promote", "detent", "--priority", "1"},
+			want: `{"status":"ok","project":"detent","priority":1}`,
+		},
+		{
+			name: "remove-project",
+			args: []string{"remove-project", "detent"},
+			want: `{"status":"ok","project":"detent","removed":true}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := cli.NewRootCommand(context.Background())
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			args := append([]string{"--config", configPath}, tt.args...)
+			cmd.SetArgs(args)
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+			assertJSONEqual(t, stdout.Bytes(), tt.want)
+		})
 	}
 }
 
@@ -617,10 +765,14 @@ func TestAddProjectWritesConfigAndSignalsManager(t *testing.T) {
 	configPath := filepath.Join(paths.root, "global.yaml")
 	signals := make(chan cli.Signal, 1)
 
-	cmd := cli.NewRootCommand(context.Background(), cli.WithSignalFunc(func(_ context.Context, signal cli.Signal) error {
-		signals <- signal
-		return nil
-	}))
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return true }),
+		cli.WithSignalFunc(func(_ context.Context, signal cli.Signal) error {
+			signals <- signal
+			return nil
+		}),
+	)
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{
@@ -686,10 +838,14 @@ func TestProjectAdminCommandsEditConfigAndSignalManager(t *testing.T) {
 		t.Helper()
 
 		allArgs := append([]string{"--config", configPath}, args...)
-		cmd := cli.NewRootCommand(context.Background(), cli.WithSignalFunc(func(_ context.Context, signal cli.Signal) error {
-			signals <- signal
-			return nil
-		}))
+		cmd := cli.NewRootCommand(
+			context.Background(),
+			cli.WithStdoutTTY(func() bool { return true }),
+			cli.WithSignalFunc(func(_ context.Context, signal cli.Signal) error {
+				signals <- signal
+				return nil
+			}),
+		)
 		cmd.SetOut(&bytes.Buffer{})
 		cmd.SetErr(&bytes.Buffer{})
 		cmd.SetArgs(allArgs)
@@ -758,7 +914,7 @@ projects:
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 
-	cmd := cli.NewRootCommand(context.Background())
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{"--config", configPath, "pause", "detent"})
@@ -873,7 +1029,7 @@ func TestWithProjectManagerSignalsLiveManager(t *testing.T) {
 	paths := createProjectFiles(t)
 	configPath := filepath.Join(paths.root, "global.yaml")
 	manager := &projectManagerProbe{}
-	cmd := cli.NewRootCommand(context.Background(), cli.WithProjectManager(manager))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }), cli.WithProjectManager(manager))
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
 	cmd.SetArgs([]string{
@@ -1036,6 +1192,22 @@ func assertHintedError(t *testing.T, err error, wantErr error, wantMessage strin
 	}
 	if !reflect.DeepEqual(gotCommands, wantCommands) {
 		t.Fatalf("commands = %#v, want %#v", gotCommands, wantCommands)
+	}
+}
+
+func assertJSONEqual(t *testing.T, got []byte, want string) {
+	t.Helper()
+
+	var gotValue any
+	if err := json.Unmarshal(got, &gotValue); err != nil {
+		t.Fatalf("Unmarshal(got) error = %v\n%s", err, string(got))
+	}
+	var wantValue any
+	if err := json.Unmarshal([]byte(want), &wantValue); err != nil {
+		t.Fatalf("Unmarshal(want) error = %v\n%s", err, want)
+	}
+	if !reflect.DeepEqual(gotValue, wantValue) {
+		t.Fatalf("json output = %#v, want %#v\nraw: %s", gotValue, wantValue, string(got))
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -52,14 +52,26 @@ const doctorAutoPromoteSampleLimit = 5
 var doctorHealthCheckKeys = []string{"hub", "store", "registry", "connector"}
 
 type doctorCheck struct {
-	Name   string
-	Status doctorStatus
-	Detail string
-	Hint   string
+	Name   string       `json:"name"`
+	Status doctorStatus `json:"status"`
+	Detail string       `json:"detail"`
+	Hint   string       `json:"hint,omitempty"`
 }
 
 type doctorReport struct {
 	Checks []doctorCheck
+}
+
+type doctorOutputReport struct {
+	Checks  []doctorCheck `json:"checks"`
+	Summary doctorSummary `json:"summary"`
+	Result  string        `json:"result"`
+}
+
+type doctorSummary struct {
+	OK   int `json:"ok"`
+	Warn int `json:"warn"`
+	Fail int `json:"fail"`
 }
 
 type doctorCheckJob struct {
@@ -123,10 +135,18 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 		Short: "Run preflight health checks",
 		Args:  cobra.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			progressOut := cmd.OutOrStdout()
+			if out.IsJSON() {
+				progressOut = cmd.ErrOrStderr()
+			}
 			report := runDoctor(cmd.Context(), doctorConfig{
 				ConfigPath:   derefString(configPath),
 				Host:         derefString(host),
-				Output:       cmd.OutOrStdout(),
+				Output:       progressOut,
 				CheckTimeout: timeout,
 				Build:        opts.build,
 				Flags: runtimeFlags{
@@ -135,7 +155,9 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 					Port:     runtimeIntFlag{Value: derefInt(port, -1), Set: flagChanged(cmd, "port")},
 				},
 			}, opts, deps)
-			if err := writeDoctorReport(cmd.OutOrStdout(), report); err != nil {
+			if err := out.Write(func(out io.Writer) error {
+				return writeDoctorReport(out, report)
+			}, newDoctorOutputReport(report)); err != nil {
 				return err
 			}
 			if report.HasFailures() {
@@ -145,6 +167,10 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 		},
 	}
 	cmd.Flags().DurationVar(&timeout, "timeout", doctorCheckTimeout, "per-check timeout")
+	cmd.SetContext(withCommandOutputOptions(context.Background(), commandOutputOptions{
+		lookupEnv: opts.lookupEnv,
+		stdoutTTY: opts.stdoutTTY,
+	}))
 	return cmd
 }
 
@@ -411,6 +437,23 @@ func writeDoctorReport(out io.Writer, report doctorReport) error {
 	}
 	_, err := fmt.Fprintf(out, "Result: %s\n", result)
 	return err
+}
+
+func newDoctorOutputReport(report doctorReport) doctorOutputReport {
+	counts := report.counts()
+	result := "PASS"
+	if counts[doctorFail] > 0 {
+		result = "FAIL"
+	}
+	return doctorOutputReport{
+		Checks: report.Checks,
+		Summary: doctorSummary{
+			OK:   counts[doctorOK],
+			Warn: counts[doctorWarn],
+			Fail: counts[doctorFail],
+		},
+		Result: result,
+	}
 }
 
 func checkDoctorConfig(configPath string, opts options) (globalconfig.PathResolution, *globalconfig.Config, doctorCheck) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"net"
@@ -1149,6 +1150,57 @@ func TestDoctorCommandTimeoutFlagBoundsCheck(t *testing.T) {
 	}
 }
 
+func TestDoctorCommandWritesJSONReport(t *testing.T) {
+	t.Setenv("DETENT_FORMAT", "json")
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	env := ""
+	logLevel := ""
+	host := "127.0.0.1"
+	port := 0
+	opts := successfulDoctorOptions(configPath)
+	deps := successfulDoctorDeps()
+
+	cmd := newDoctorCommandWithDeps(&configPath, &env, &logLevel, &host, &port, opts, deps)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Checks []struct {
+			Name   string `json:"name"`
+			Status string `json:"status"`
+			Detail string `json:"detail"`
+			Hint   string `json:"hint,omitempty"`
+		} `json:"checks"`
+		Summary struct {
+			OK   int `json:"ok"`
+			Warn int `json:"warn"`
+			Fail int `json:"fail"`
+		} `json:"summary"`
+		Result string `json:"result"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if got.Result != "PASS" {
+		t.Fatalf("result = %q, want PASS", got.Result)
+	}
+	if got.Summary.OK == 0 {
+		t.Fatalf("summary.ok = 0, want successful checks\n%s", stdout.String())
+	}
+	if len(got.Checks) == 0 {
+		t.Fatal("checks length = 0, want checks")
+	}
+	if strings.Contains(stdout.String(), "RUN    ") {
+		t.Fatalf("json stdout contains progress lines:\n%s", stdout.String())
+	}
+}
+
 func TestRunDoctorChecksRunsJobsInParallel(t *testing.T) {
 	t.Parallel()
 
@@ -1311,6 +1363,7 @@ func successfulDoctorOptions(configPath string) options {
 				Projects: []globalconfig.Project{},
 			}, nil
 		},
+		stdoutTTY: func() bool { return true },
 	}
 }
 

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -1,0 +1,159 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+type OutputFormat string
+
+const (
+	OutputFormatPretty OutputFormat = "pretty"
+	OutputFormatJSON   OutputFormat = "json"
+
+	outputFormatFlag = "format"
+	outputFormatEnv  = "DETENT_FORMAT"
+)
+
+var ErrInvalidOutputFormat = errors.New("invalid output format")
+
+type commandOutputContextKey struct{}
+
+type commandOutputOptions struct {
+	lookupEnv func(string) string
+	stdoutTTY func() bool
+}
+
+type CommandOutput struct {
+	Format OutputFormat
+	Out    io.Writer
+}
+
+func withCommandOutputOptions(ctx context.Context, opts commandOutputOptions) context.Context {
+	return context.WithValue(ctx, commandOutputContextKey{}, opts)
+}
+
+func OutputForCommand(cmd *cobra.Command) (CommandOutput, error) {
+	opts := commandOutputOptions{
+		lookupEnv: os.Getenv,
+		stdoutTTY: func() bool {
+			if cmd == nil {
+				return WriterIsTTY(os.Stdout)
+			}
+			return WriterIsTTY(cmd.OutOrStdout())
+		},
+	}
+	if cmd != nil {
+		if root := cmd.Root(); root != nil && root.Context() != nil {
+			if configured, ok := root.Context().Value(commandOutputContextKey{}).(commandOutputOptions); ok {
+				if configured.lookupEnv != nil {
+					opts.lookupEnv = configured.lookupEnv
+				}
+				if configured.stdoutTTY != nil {
+					opts.stdoutTTY = configured.stdoutTTY
+				}
+			}
+		}
+	}
+
+	formatFlag, flagSet := outputFormatFlagValue(cmd)
+	format, err := ResolveOutputFormat(formatFlag, flagSet, opts.lookupEnv(outputFormatEnv), opts.stdoutTTY())
+	if err != nil {
+		return CommandOutput{}, err
+	}
+	out := io.Discard
+	if cmd != nil {
+		out = cmd.OutOrStdout()
+	}
+	return CommandOutput{Format: format, Out: out}, nil
+}
+
+func ResolveOutputFormat(flagValue string, flagSet bool, envValue string, stdoutTTY bool) (OutputFormat, error) {
+	if flagSet {
+		return parseOutputFormat(flagValue, "--"+outputFormatFlag)
+	}
+	if strings.TrimSpace(envValue) != "" {
+		return parseOutputFormat(envValue, outputFormatEnv)
+	}
+	if stdoutTTY {
+		return OutputFormatPretty, nil
+	}
+	return OutputFormatJSON, nil
+}
+
+func parseOutputFormat(value string, source string) (OutputFormat, error) {
+	switch OutputFormat(strings.ToLower(strings.TrimSpace(value))) {
+	case OutputFormatPretty:
+		return OutputFormatPretty, nil
+	case OutputFormatJSON:
+		return OutputFormatJSON, nil
+	default:
+		return "", fmt.Errorf("%w for %s: %q (want pretty or json)", ErrInvalidOutputFormat, source, value)
+	}
+}
+
+func (o CommandOutput) IsJSON() bool {
+	return o.Format == OutputFormatJSON
+}
+
+func (o CommandOutput) Write(pretty func(io.Writer) error, value any) error {
+	if o.Out == nil {
+		o.Out = io.Discard
+	}
+	if o.IsJSON() {
+		return writeJSON(o.Out, value)
+	}
+	if pretty == nil {
+		return nil
+	}
+	return pretty(o.Out)
+}
+
+func (o CommandOutput) WriteJSON(value any) error {
+	if o.Out == nil {
+		o.Out = io.Discard
+	}
+	return writeJSON(o.Out, value)
+}
+
+func writeJSON(out io.Writer, value any) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func outputFormatFlagValue(cmd *cobra.Command) (string, bool) {
+	if cmd == nil {
+		return "", false
+	}
+	flag := cmd.Flags().Lookup(outputFormatFlag)
+	if flag == nil {
+		flag = cmd.InheritedFlags().Lookup(outputFormatFlag)
+	}
+	if flag == nil {
+		flag = cmd.PersistentFlags().Lookup(outputFormatFlag)
+	}
+	if flag == nil && cmd.Root() != nil {
+		flag = cmd.Root().PersistentFlags().Lookup(outputFormatFlag)
+	}
+	if flag == nil {
+		return "", false
+	}
+	return flag.Value.String(), flag.Changed
+}
+
+func WriterIsTTY(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}


### PR DESCRIPTION
## Summary

- Add a shared CLI output resolver/writer with `--format pretty|json`, `DETENT_FORMAT`, and TTY-based defaults.
- Emit typed JSON objects for version, update, doctor, config, init, and project mutation commands while preserving pretty TTY output.
- Document the non-TTY JSON behavior change and update onboarding examples that parse pretty output.

Fixes #406

## Test Plan

- [x] `make check`