### PR TITLE
feat(cli): add semantic exit codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,19 @@ pinned minisign public key for the release stream. Until that release signing
 key is provisioned in #337, update integrity still depends on GitHub TLS plus
 the published checksum file.
 
+## CLI exit codes
+
+Detent uses stable process exit codes so scripts and agents can branch on the
+failure class.
+
+| Code | Meaning |
+| --- | --- |
+| 0 | Success |
+| 1 | General or unexpected error |
+| 2 | Auth or GitHub token problem |
+| 3 | Input validation error |
+| 4 | Not found or config conflict |
+
 ## Release
 
 Cut releases from `main` by pushing a semver tag:

--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -26,27 +26,32 @@ func main() {
 
 	cmd := newRootCommand(ctx, shutdownController)
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		if errors.Is(err, context.Canceled) {
-			slog.Info("shutdown requested")
-			return
-		}
-		if errors.Is(err, cli.ErrShutdownForced) || errors.Is(err, cli.ErrShutdownTimeout) {
-			os.Exit(1)
-		}
-
-		os.Exit(writeCommandError(cmd, err))
+		os.Exit(handleCommandError(cmd, err))
 	}
 }
 
-func writeCommandError(cmd *cobra.Command, err error) int {
-	if cli.CommandOutputIsJSON(cmd) {
-		if writeErr := cli.WriteCommandErrorJSON(cmd.ErrOrStderr(), err); writeErr != nil {
-			fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", writeErr)
-		}
-		return 1
+func handleCommandError(cmd *cobra.Command, err error) int {
+	code := cli.ExitCode(err)
+	if code == cli.ExitSuccess {
+		slog.Info("shutdown requested")
+		return code
 	}
-	fmt.Fprintf(cmd.ErrOrStderr(), "Error: %v\n", err)
-	return 1
+	if errors.Is(err, cli.ErrShutdownForced) || errors.Is(err, cli.ErrShutdownTimeout) {
+		return code
+	}
+
+	var errOut io.Writer = os.Stderr
+	if cmd != nil {
+		errOut = cmd.ErrOrStderr()
+	}
+	if cli.CommandOutputIsJSON(cmd) {
+		if writeErr := cli.WriteCommandErrorJSON(errOut, err); writeErr != nil {
+			fmt.Fprintf(errOut, "Error: %v\n", writeErr)
+		}
+		return code
+	}
+	fmt.Fprintf(errOut, "Error: %v\n", err)
+	return code
 }
 
 func newRootCommand(ctx context.Context, shutdownControllers ...*cli.ShutdownController) *cobra.Command {
@@ -78,10 +83,11 @@ func newShadowRunCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:          "shadow-run",
 		Short:        "Compare read-only Go decisions with an Elixir shadow report",
+		Args:         cli.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if inputPath == "" {
-				return errors.New("shadow-run --input is required")
+				return cli.ValidationError("shadow-run --input is required")
 			}
 			return runShadowRun(cmd.OutOrStdout(), inputPath, allowDiff)
 		},

--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -4,11 +4,17 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/cli"
 )
 
 func TestRootCommandHelp(t *testing.T) {
@@ -24,7 +30,7 @@ func TestRootCommandHelp(t *testing.T) {
 	}
 
 	output := stdout.String()
-	for _, want := range []string{"detent", "agent orchestrator", "Usage:"} {
+	for _, want := range []string{"detent", "agent orchestrator", "Usage:", "Exit codes:", "2  auth", "4  not found"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("help output missing %q:\n%s", want, output)
 		}
@@ -44,13 +50,14 @@ func TestRootCommandWritesSuggestionErrorsAsJSON(t *testing.T) {
 	if err == nil {
 		t.Fatal("Execute() error = nil, want error")
 	}
-	if exitCode := writeCommandError(cmd, err); exitCode == 0 {
-		t.Fatal("writeCommandError() exit code = 0, want non-zero")
+	if exitCode := handleCommandError(cmd, err); exitCode != cli.ExitValidation {
+		t.Fatalf("handleCommandError() exit code = %d, want %d", exitCode, cli.ExitValidation)
 	}
 
 	var got struct {
 		Error struct {
 			Code       string   `json:"code"`
+			ExitCode   int      `json:"exit_code"`
 			Input      string   `json:"input"`
 			DidYouMean []string `json:"did_you_mean"`
 		} `json:"error"`
@@ -64,12 +71,119 @@ func TestRootCommandWritesSuggestionErrorsAsJSON(t *testing.T) {
 	if got.Error.Code != "unknown_command" {
 		t.Fatalf("error.code = %q, want unknown_command", got.Error.Code)
 	}
+	if got.Error.ExitCode != cli.ExitValidation {
+		t.Fatalf("error.exit_code = %d, want %d", got.Error.ExitCode, cli.ExitValidation)
+	}
 	if got.Error.Input != "paues" {
 		t.Fatalf("error.input = %q, want paues", got.Error.Input)
 	}
 	if len(got.Error.DidYouMean) != 1 || got.Error.DidYouMean[0] != "pause" {
 		t.Fatalf("error.did_you_mean = %#v, want [pause]", got.Error.DidYouMean)
 	}
+}
+
+func TestHandleCommandErrorUsesSemanticExitCodes(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	slog.SetDefault(slog.New(slog.NewJSONHandler(io.Discard, nil)))
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "context canceled", err: context.Canceled, want: cli.ExitSuccess},
+		{name: "general", err: errors.New("boom"), want: cli.ExitGeneral},
+		{name: "shutdown forced", err: cli.ErrShutdownForced, want: cli.ExitGeneral},
+		{name: "auth", err: fmt.Errorf("wrapped: %w", cli.ErrGitHubAuth), want: cli.ExitAuth},
+		{name: "validation", err: fmt.Errorf("wrapped: %w", cli.ErrValidation), want: cli.ExitValidation},
+		{name: "not found", err: fmt.Errorf("wrapped: %w", cli.ErrProjectNotFound), want: cli.ExitNotFoundOrConfig},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := newRootCommand(context.Background())
+			cmd.SetErr(io.Discard)
+			if got := handleCommandError(cmd, tt.err); got != tt.want {
+				t.Fatalf("handleCommandError(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCommandErrorsUseSemanticExitCodes(t *testing.T) {
+	t.Run("validation", func(t *testing.T) {
+		cmd := newRootCommand(context.Background())
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"shadow-run"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() error = nil, want error")
+		}
+		if got := cli.ExitCode(err); got != cli.ExitValidation {
+			t.Fatalf("ExitCode(%v) = %d, want %d", err, got, cli.ExitValidation)
+		}
+	})
+
+	t.Run("not found", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "global.yaml")
+		if err := os.WriteFile(configPath, []byte(`apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 1
+  scheduling: weighted
+projects: []
+`), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		cmd := newRootCommand(context.Background())
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"--config", configPath, "pause", "missing"})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() error = nil, want error")
+		}
+		if got := cli.ExitCode(err); got != cli.ExitNotFoundOrConfig {
+			t.Fatalf("ExitCode(%v) = %d, want %d", err, got, cli.ExitNotFoundOrConfig)
+		}
+	})
+
+	t.Run("invalid global config", func(t *testing.T) {
+		configPath := filepath.Join(t.TempDir(), "global.yaml")
+		if err := os.WriteFile(configPath, []byte(`apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 1
+  scheduling: weighted
+projects:
+  - id: detent
+    workflow: WORKFLOW.md
+    workdir: .
+    weight: 1
+`), 0o644); err != nil {
+			t.Fatalf("WriteFile() error = %v", err)
+		}
+
+		cmd := newRootCommand(context.Background())
+		cmd.SetOut(&bytes.Buffer{})
+		cmd.SetErr(&bytes.Buffer{})
+		cmd.SetArgs([]string{"--config", configPath})
+
+		err := cmd.Execute()
+		if err == nil {
+			t.Fatal("Execute() error = nil, want error")
+		}
+		if got := cli.ExitCode(err); got != cli.ExitValidation {
+			t.Fatalf("ExitCode(%v) = %d, want %d", err, got, cli.ExitValidation)
+		}
+	})
 }
 
 func TestSignalContextCancel(t *testing.T) {

--- a/cmd/detent/update.go
+++ b/cmd/detent/update.go
@@ -32,7 +32,7 @@ func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command
 	cmd := &cobra.Command{
 		Use:          "update",
 		Short:        "Check for and apply Detent updates",
-		Args:         cobra.NoArgs,
+		Args:         cli.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := cli.OutputForCommand(cmd)
@@ -155,7 +155,7 @@ func selectGoInstallAction(cmd *cobra.Command) func(detentupdate.Status) (detent
 		case "", "3", "a", "abort", "n", "no":
 			return detentupdate.GoInstallActionAbort, nil
 		default:
-			return "", fmt.Errorf("invalid update choice: %s", strings.TrimSpace(line))
+			return "", cli.ValidationErrorf("invalid update choice: %s", strings.TrimSpace(line))
 		}
 	}
 }

--- a/cmd/detent/version.go
+++ b/cmd/detent/version.go
@@ -26,7 +26,7 @@ func newVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Print version metadata",
-		Args:  cobra.NoArgs,
+		Args:  cli.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			info := currentVersionInfo()
 			out, err := cli.OutputForCommand(cmd)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -268,9 +268,16 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	var headless bool
 	var outputFormat string
 	cmd := &cobra.Command{
-		Use:                        "detent",
-		Short:                      "Detent agent orchestrator",
-		Long:                       "Detent is an agent orchestrator for tracker-backed work queues.",
+		Use:   "detent",
+		Short: "Detent agent orchestrator",
+		Long: `Detent is an agent orchestrator for tracker-backed work queues.
+
+Exit codes:
+  0  success
+  1  general or unexpected error
+  2  auth or GitHub token problem
+  3  input validation error
+  4  not found or config conflict`,
 		Args:                       suggestedNoArgs,
 		SilenceUsage:               true,
 		SilenceErrors:              true,
@@ -314,7 +321,9 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	cmd.PersistentFlags().IntVar(&port, "port", -1, "web server port, or 0 for an ephemeral port")
 	cmd.PersistentFlags().BoolVar(&headless, "headless", false, "stream logs instead of launching the terminal dashboard")
 	cmd.PersistentFlags().Var(newOutputFormatValue(&outputFormat), outputFormatFlagName, "output format: pretty or json (default: pretty on TTY, json when piped; DETENT_FORMAT overrides)")
-	cmd.SetFlagErrorFunc(flagSuggestionError)
+	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return WrapValidation(flagSuggestionError(cmd, err))
+	})
 
 	addProjectCommand := newAddProjectCommand(&configPath, opts)
 	addProjectCommand.SuggestFor = []string{"add", "new"}
@@ -431,7 +440,7 @@ func newInitCommand(configPath *string, opts options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "init",
 		Short: "Create a default global config",
-		Args:  cobra.NoArgs,
+		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -498,7 +507,7 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add-project",
 		Short: "Add a project to global config",
-		Args:  cobra.NoArgs,
+		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -549,14 +558,14 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 func validateProjectFlags(cfg globalconfig.Project) error {
 	switch {
 	case cfg.ID == "":
-		return hintedError(nil, "--id is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand)
+		return WrapValidation(hintedError(nil, "--id is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand))
 	case strings.TrimSpace(cfg.Workflow) == "":
-		return hintedError(nil, "--workflow is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand)
+		return WrapValidation(hintedError(nil, "--workflow is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand))
 	case strings.TrimSpace(cfg.Workdir) == "":
-		return hintedError(nil, "--workdir is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand)
+		return WrapValidation(hintedError(nil, "--workdir is required", exampleHint(addProjectExampleCommand), addProjectExampleCommand))
 	case cfg.Weight <= 0:
 		command := addProjectExampleCommand + " --weight 1"
-		return hintedError(nil, "--weight must be positive", exampleHint(command), command)
+		return WrapValidation(hintedError(nil, "--weight must be positive", exampleHint(command), command))
 	default:
 		return nil
 	}
@@ -568,7 +577,7 @@ func newEditProjectCommand(configPath *string, opts options, operation Operation
 	return &cobra.Command{
 		Use:   use + " PROJECT_ID",
 		Short: short,
-		Args:  cobra.ExactArgs(1),
+		Args:  ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -596,7 +605,7 @@ func newConfigPathCommand(configPath *string, opts options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "path",
 		Short: "Print the resolved global config path",
-		Args:  cobra.NoArgs,
+		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -622,10 +631,10 @@ func newPromoteCommand(configPath *string, opts options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "promote PROJECT_ID",
 		Short: "Promote a project priority",
-		Args:  cobra.ExactArgs(1),
+		Args:  ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if priority <= 0 {
-				return hintedError(nil, "--priority must be positive", exampleHint(promoteExampleCommand), promoteExampleCommand)
+				return WrapValidation(hintedError(nil, "--priority must be positive", exampleHint(promoteExampleCommand), promoteExampleCommand))
 			}
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -685,7 +694,7 @@ func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
 	return &cobra.Command{
 		Use:   "remove-project PROJECT_ID",
 		Short: "Remove a project from global config",
-		Args:  cobra.ExactArgs(1),
+		Args:  ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -687,6 +687,9 @@ func TestCLIValidationErrorsCarryHints(t *testing.T) {
 			if err == nil {
 				t.Fatal("Execute() error = nil, want error")
 			}
+			if !errors.Is(err, cli.ErrValidation) {
+				t.Fatalf("Execute() error = %v, want %v", err, cli.ErrValidation)
+			}
 			assertHintedError(t, err, nil, tt.wantMessage, tt.wantHint, tt.wantCommands)
 			if !strings.Contains(stderr.String(), "Hint: "+tt.wantHint) {
 				t.Fatalf("stderr missing hint %q:\n%s", tt.wantHint, stderr.String())

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -133,7 +133,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	cmd := &cobra.Command{
 		Use:   "doctor",
 		Short: "Run preflight health checks",
-		Args:  cobra.NoArgs,
+		Args:  NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {

--- a/internal/cli/exitcode.go
+++ b/internal/cli/exitcode.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+const (
+	ExitSuccess          = 0
+	ExitGeneral          = 1
+	ExitAuth             = 2
+	ExitValidation       = 3
+	ExitNotFoundOrConfig = 4
+)
+
+var (
+	ErrGitHubAuth = errors.New("github auth failed")
+	ErrValidation = errors.New("input validation failed")
+)
+
+type ErrorClass struct {
+	Slug     string
+	ExitCode int
+}
+
+var errorClassifiers = []struct {
+	class ErrorClass
+	match func(error) bool
+}{
+	{
+		class: ErrorClass{Slug: "github_auth", ExitCode: ExitAuth},
+		match: func(err error) bool {
+			return errors.Is(err, ErrGitHubAuth) ||
+				errors.Is(err, githubconnector.ErrMissingToken) ||
+				errors.Is(err, githubconnector.ErrAuthenticationFailed)
+		},
+	},
+	{
+		class: ErrorClass{Slug: "validation", ExitCode: ExitValidation},
+		match: func(err error) bool {
+			var globalValidation globalconfig.ValidationError
+			var globalParse globalconfig.ParseError
+			var workflowValidation workflowconfig.ValidationError
+			return errors.Is(err, ErrValidation) ||
+				errors.Is(err, ErrInvalidOutputFormat) ||
+				errors.As(err, &globalValidation) ||
+				errors.As(err, &globalParse) ||
+				errors.As(err, &workflowValidation)
+		},
+	},
+	{
+		class: ErrorClass{Slug: "not_found_or_config", ExitCode: ExitNotFoundOrConfig},
+		match: func(err error) bool {
+			return errors.Is(err, ErrConfigExists) ||
+				errors.Is(err, ErrProjectExists) ||
+				errors.Is(err, ErrProjectNotFound) ||
+				errors.Is(err, project.ErrProjectExists) ||
+				errors.Is(err, project.ErrProjectNotFound) ||
+				errors.Is(err, githubconnector.ErrProjectNotFound) ||
+				errors.Is(err, githubconnector.ErrProjectItemNotFound) ||
+				errors.Is(err, githubconnector.ErrProjectFieldNotFound) ||
+				errors.Is(err, githubconnector.ErrProjectFieldOptionNotFound) ||
+				errors.Is(err, githubconnector.ErrStatusFieldNotFound) ||
+				errors.Is(err, githubconnector.ErrStatusOptionNotFound)
+		},
+	},
+}
+
+func ClassifyError(err error) ErrorClass {
+	if err == nil || errors.Is(err, context.Canceled) {
+		return ErrorClass{Slug: "success", ExitCode: ExitSuccess}
+	}
+	for _, classifier := range errorClassifiers {
+		if classifier.match(err) {
+			return classifier.class
+		}
+	}
+	return ErrorClass{Slug: "general", ExitCode: ExitGeneral}
+}
+
+func ExitCode(err error) int {
+	return ClassifyError(err).ExitCode
+}
+
+func NoArgs(cmd *cobra.Command, args []string) error {
+	return WrapValidation(cobra.NoArgs(cmd, args))
+}
+
+func ExactArgs(n int) cobra.PositionalArgs {
+	return func(cmd *cobra.Command, args []string) error {
+		return WrapValidation(cobra.ExactArgs(n)(cmd, args))
+	}
+}
+
+func WrapValidation(err error) error {
+	if err == nil || errors.Is(err, ErrValidation) {
+		return err
+	}
+	return classifiedError{class: ErrValidation, err: err}
+}
+
+func ValidationError(message string) error {
+	return WrapValidation(errors.New(message))
+}
+
+func ValidationErrorf(format string, args ...any) error {
+	return WrapValidation(fmt.Errorf(format, args...))
+}
+
+func GitHubAuthError(err error) error {
+	if err == nil || errors.Is(err, ErrGitHubAuth) {
+		return err
+	}
+	return classifiedError{class: ErrGitHubAuth, err: err}
+}
+
+type classifiedError struct {
+	class error
+	err   error
+}
+
+func (e classifiedError) Error() string {
+	if e.err == nil {
+		return e.class.Error()
+	}
+	return e.err.Error()
+}
+
+func (e classifiedError) Unwrap() []error {
+	switch {
+	case e.class == nil && e.err == nil:
+		return nil
+	case e.class == nil:
+		return []error{e.err}
+	case e.err == nil:
+		return []error{e.class}
+	default:
+		return []error{e.class, e.err}
+	}
+}

--- a/internal/cli/exitcode_test.go
+++ b/internal/cli/exitcode_test.go
@@ -1,0 +1,54 @@
+package cli_test
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/cli"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/project"
+)
+
+func TestExitCodeClassifiesRepresentativeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "success", want: cli.ExitSuccess},
+		{name: "context canceled", err: context.Canceled, want: cli.ExitSuccess},
+		{name: "general", err: errors.New("boom"), want: cli.ExitGeneral},
+		{name: "doctor failed", err: cli.ErrDoctorFailed, want: cli.ExitGeneral},
+		{name: "shutdown forced", err: cli.ErrShutdownForced, want: cli.ExitGeneral},
+		{name: "shutdown timeout", err: cli.ErrShutdownTimeout, want: cli.ExitGeneral},
+		{name: "runtime github auth", err: fmt.Errorf("wrapped: %w", cli.ErrGitHubAuth), want: cli.ExitAuth},
+		{name: "connector missing token", err: fmt.Errorf("wrapped: %w", githubconnector.ErrMissingToken), want: cli.ExitAuth},
+		{name: "validation", err: fmt.Errorf("wrapped: %w", cli.ErrValidation), want: cli.ExitValidation},
+		{name: "invalid output format", err: fmt.Errorf("wrapped: %w", cli.ErrInvalidOutputFormat), want: cli.ExitValidation},
+		{name: "global config validation", err: globalconfig.ValidationError{Problems: []string{"global bad"}}, want: cli.ExitValidation},
+		{name: "global config parse", err: globalconfig.ParseError{Path: "global.yaml", Err: errors.New("bad yaml")}, want: cli.ExitValidation},
+		{name: "workflow config validation", err: workflowconfig.ValidationError{Problems: []string{"workflow bad"}}, want: cli.ExitValidation},
+		{name: "cli project missing", err: fmt.Errorf("wrapped: %w", cli.ErrProjectNotFound), want: cli.ExitNotFoundOrConfig},
+		{name: "cli config exists", err: fmt.Errorf("wrapped: %w", cli.ErrConfigExists), want: cli.ExitNotFoundOrConfig},
+		{name: "cli project exists", err: fmt.Errorf("wrapped: %w", cli.ErrProjectExists), want: cli.ExitNotFoundOrConfig},
+		{name: "manager project missing", err: fmt.Errorf("wrapped: %w", project.ErrProjectNotFound), want: cli.ExitNotFoundOrConfig},
+		{name: "manager project exists", err: fmt.Errorf("wrapped: %w", project.ErrProjectExists), want: cli.ExitNotFoundOrConfig},
+		{name: "github project missing", err: fmt.Errorf("wrapped: %w", githubconnector.ErrProjectNotFound), want: cli.ExitNotFoundOrConfig},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := cli.ExitCode(tt.err); got != tt.want {
+				t.Fatalf("ExitCode(%v) = %d, want %d", tt.err, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -183,14 +183,14 @@ func resolveRuntimeString(input runtimeStringInput, lookupEnv func(string) strin
 func resolveRuntimePort(ctx context.Context, input runtimeInput, deps runtimeDeps) (RuntimeIntValue, error) {
 	if input.Flags.Port.Set {
 		if input.Flags.Port.Value < 0 {
-			return RuntimeIntValue{}, hintedError(nil, "--port must be greater than or equal to 0", exampleHint(portExampleCommand), portExampleCommand)
+			return RuntimeIntValue{}, WrapValidation(hintedError(nil, "--port must be greater than or equal to 0", exampleHint(portExampleCommand), portExampleCommand))
 		}
 		return RuntimeIntValue{Value: input.Flags.Port.Value, Source: runtimeSourceFlag}, nil
 	}
 	if raw := strings.TrimSpace(deps.lookupEnv("PORT")); raw != "" {
 		port, err := strconv.Atoi(raw)
 		if err != nil || port < 0 {
-			return RuntimeIntValue{}, hintedError(nil, "PORT must be an integer greater than or equal to 0", "set PORT=4000 or run detent --port 0", portExampleCommand)
+			return RuntimeIntValue{}, WrapValidation(hintedError(nil, "PORT must be an integer greater than or equal to 0", "set PORT=4000 or run detent --port 0", portExampleCommand))
 		}
 		return RuntimeIntValue{Value: port, Source: "PORT"}, nil
 	}
@@ -244,7 +244,7 @@ func resolveRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, de
 		return token, nil, nil
 	}
 	if requiresRuntimeToken {
-		return RuntimeSecret{}, nil, hintedError(nil, "GITHUB_TOKEN is not set, github_token is not configured, and no usable tracker.api_key was found", githubAuthHint, ghAuthLoginCommand)
+		return RuntimeSecret{}, nil, GitHubAuthError(hintedError(nil, "GITHUB_TOKEN is not set, github_token is not configured, and no usable tracker.api_key was found", githubAuthHint, ghAuthLoginCommand))
 	}
 	return RuntimeSecret{Required: false}, nil, nil
 }
@@ -254,12 +254,12 @@ func resolveConfiguredGitHubToken(ctx context.Context, token string, deps runtim
 		resolved, err := deps.ghAuthToken(ctx)
 		if err != nil {
 			cause := fmt.Errorf("resolve github_token via gh auth token: %w", err)
-			return RuntimeSecret{}, hintedError(cause, cause.Error(), githubAuthHint, ghAuthLoginCommand)
+			return RuntimeSecret{}, GitHubAuthError(hintedError(cause, cause.Error(), githubAuthHint, ghAuthLoginCommand))
 		}
 		resolved = strings.TrimSpace(resolved)
 		if resolved == "" {
 			message := "resolve github_token via gh auth token: empty token"
-			return RuntimeSecret{}, hintedError(nil, message, githubAuthHint, ghAuthLoginCommand)
+			return RuntimeSecret{}, GitHubAuthError(hintedError(nil, message, githubAuthHint, ghAuthLoginCommand))
 		}
 		return RuntimeSecret{Value: resolved, Source: "github_token", ResolvedVia: "gh", Required: true}, nil
 	}

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -242,6 +242,9 @@ func TestResolveRuntimeSettingsGitHubTokenErrors(t *testing.T) {
 			if err == nil {
 				t.Fatal("resolveRuntimeSettings() error = nil, want error")
 			}
+			if !errors.Is(err, ErrGitHubAuth) {
+				t.Fatalf("resolveRuntimeSettings() error = %v, want %v", err, ErrGitHubAuth)
+			}
 			if !strings.Contains(err.Error(), tt.wantErr) {
 				t.Fatalf("error = %v, want containing %q", err, tt.wantErr)
 			}

--- a/internal/cli/suggestions.go
+++ b/internal/cli/suggestions.go
@@ -81,6 +81,7 @@ type commandErrorResponse struct {
 
 type commandError struct {
 	Code       string   `json:"code"`
+	ExitCode   int      `json:"exit_code"`
 	Input      string   `json:"input,omitempty"`
 	DidYouMean []string `json:"did_you_mean,omitempty"`
 	Message    string   `json:"message,omitempty"`
@@ -99,10 +100,12 @@ func commandErrorResponseFromError(err error) commandErrorResponse {
 	if err != nil {
 		message = err.Error()
 	}
+	exitCode := ExitCode(err)
 
 	if input, ok := unknownCommandInput(message); ok {
 		return commandErrorResponse{Error: commandError{
 			Code:       unknownCommandErrorCode,
+			ExitCode:   exitCode,
 			Input:      input,
 			DidYouMean: didYouMeanSuggestions(message),
 		}}
@@ -110,13 +113,15 @@ func commandErrorResponseFromError(err error) commandErrorResponse {
 	if input, ok := unknownFlagInput(message); ok {
 		return commandErrorResponse{Error: commandError{
 			Code:       unknownFlagErrorCode,
+			ExitCode:   exitCode,
 			Input:      input,
 			DidYouMean: didYouMeanSuggestions(message),
 		}}
 	}
 	return commandErrorResponse{Error: commandError{
-		Code:    commandFailedErrorCode,
-		Message: firstErrorLine(message),
+		Code:     commandFailedErrorCode,
+		ExitCode: exitCode,
+		Message:  firstErrorLine(message),
 	}}
 }
 
@@ -124,7 +129,7 @@ func suggestedNoArgs(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return nil
 	}
-	return unknownCommandError(cmd, args[0])
+	return WrapValidation(unknownCommandError(cmd, args[0]))
 }
 
 func unknownCommandError(cmd *cobra.Command, typedName string) error {


### PR DESCRIPTION
## Summary

- Add a shared CLI error classifier with stable semantic exit codes and slugs.
- Wrap auth, validation, config-validation, not-found, and config-conflict error paths so main exits with scriptable codes while graceful cancellation remains 0.
- Document the exit-code table in root help and README.

Fixes #408

## Test Plan

- [x] `go test ./internal/cli`
- [x] `go test ./cmd/detent`
- [x] Direct binary probes: auth=2, validation=3, invalid config=3, not-found=4, invalid flag=3
- [x] `make check`