### PR TITLE
feat(cli): add dual-consumer output

### DIFF
--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -16,42 +16,63 @@ import (
 )
 
 func main() {
-	setupLoggerFromEnv(os.Stdout, os.Stderr)
+	os.Exit(runCLI(context.Background(), os.Args[1:], os.Stdout, os.Stderr))
+}
 
-	ctx, cancel := context.WithCancel(context.Background())
+func runCLI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writer) int {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	setupLoggerFromEnv(stdout, stderr)
+
+	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	shutdownController := cli.NewShutdownController()
 	stopSignals := notifyShutdownRequests(shutdownController, cancel)
 	defer stopSignals()
 
 	cmd := newRootCommand(ctx, shutdownController)
+	cmd.SetOut(stdout)
+	cmd.SetErr(stderr)
+	cmd.SetArgs(args)
+	cmd.SilenceErrors = true
+	format, formatErr := cli.ResolveOutputFormatFromArgs(args, os.Getenv, cli.WriterIsTTY(stdout))
 	if err := cmd.ExecuteContext(ctx); err != nil {
-		os.Exit(handleCommandError(cmd, err))
+		if errors.Is(err, context.Canceled) {
+			slog.Info("shutdown requested")
+			return cli.ExitSuccess
+		}
+		return renderCommandError(cmd, err, stderr, format, formatErr)
 	}
+	return cli.ExitSuccess
 }
 
-func handleCommandError(cmd *cobra.Command, err error) int {
-	code := cli.ExitCode(err)
-	if code == cli.ExitSuccess {
-		slog.Info("shutdown requested")
-		return code
-	}
-	if errors.Is(err, cli.ErrShutdownForced) || errors.Is(err, cli.ErrShutdownTimeout) {
-		return code
-	}
-
-	var errOut io.Writer = os.Stderr
-	if cmd != nil {
-		errOut = cmd.ErrOrStderr()
-	}
-	if cli.CommandOutputIsJSON(cmd) {
-		if writeErr := cli.WriteCommandErrorJSON(errOut, err); writeErr != nil {
-			fmt.Fprintf(errOut, "Error: %v\n", writeErr)
+func renderCommandError(cmd *cobra.Command, err error, stderr io.Writer, format cli.OutputFormat, formatErr error) int {
+	problem := cli.ProblemForCommandError(cmd, err)
+	if formatErr == nil && format == cli.OutputFormatJSON {
+		if writeErr := cli.WriteProblemJSON(stderr, problem); writeErr != nil {
+			slog.Error("write problem response", "error", writeErr)
 		}
-		return code
+		return problem.ExitCode
 	}
-	fmt.Fprintf(errOut, "Error: %v\n", err)
-	return code
+	if writeErr := writePrettyCommandError(stderr, err, problem); writeErr != nil {
+		slog.Error("write error response", "error", writeErr)
+	}
+	return problem.ExitCode
+}
+
+func writePrettyCommandError(stderr io.Writer, err error, problem cli.Problem) error {
+	if stderr == nil {
+		return nil
+	}
+	if writeErr := cli.WritePrettyError(stderr, err); writeErr != nil {
+		return writeErr
+	}
+	if cli.ErrorHint(err) != "" || problem.SuggestedFix == "" {
+		return nil
+	}
+	_, writeErr := fmt.Fprintf(stderr, "Hint: %s\n", problem.SuggestedFix)
+	return writeErr
 }
 
 func newRootCommand(ctx context.Context, shutdownControllers ...*cli.ShutdownController) *cobra.Command {
@@ -72,6 +93,7 @@ func newRootCommand(ctx context.Context, shutdownControllers ...*cli.ShutdownCon
 		newUpdateCommand(ctx, newDefaultUpdateRunner),
 		newShadowRunCommand(),
 	)
+	cli.ConfigureCommandSuggestions(cmd)
 
 	return cmd
 }
@@ -84,10 +106,11 @@ func newShadowRunCommand() *cobra.Command {
 		Use:          "shadow-run",
 		Short:        "Compare read-only Go decisions with an Elixir shadow report",
 		Args:         cli.NoArgs,
+		Example:      "detent shadow-run --input ./shadow.json --allow-diff",
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if inputPath == "" {
-				return cli.ValidationError("shadow-run --input is required")
+				return cli.NewValidationError("shadow-run --input is required", "Run detent shadow-run --input ./shadow.json.", nil)
 			}
 			return runShadowRun(cmd.OutOrStdout(), inputPath, allowDiff)
 		},

--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -7,12 +7,13 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/spf13/cobra"
 
 	"github.com/digitaldrywood/detent/internal/cli"
 )
@@ -37,58 +38,158 @@ func TestRootCommandHelp(t *testing.T) {
 	}
 }
 
-func TestRootCommandWritesSuggestionErrorsAsJSON(t *testing.T) {
+func TestRootCommandHelpCatalogJSON(t *testing.T) {
 	cmd := newRootCommand(context.Background())
 
 	var stdout bytes.Buffer
-	var stderr bytes.Buffer
 	cmd.SetOut(&stdout)
-	cmd.SetErr(&stderr)
-	cmd.SetArgs([]string{"--format", "json", "paues"})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "help"})
 
-	err := cmd.Execute()
-	if err == nil {
-		t.Fatal("Execute() error = nil, want error")
-	}
-	if exitCode := handleCommandError(cmd, err); exitCode != cli.ExitValidation {
-		t.Fatalf("handleCommandError() exit code = %d, want %d", exitCode, cli.ExitValidation)
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
 	}
 
 	var got struct {
-		Error struct {
-			Code       string   `json:"code"`
-			ExitCode   int      `json:"exit_code"`
-			Input      string   `json:"input"`
-			DidYouMean []string `json:"did_you_mean"`
-		} `json:"error"`
+		Commands []struct {
+			Name    string `json:"name"`
+			Short   string `json:"short"`
+			Example string `json:"example"`
+			Flags   []struct {
+				Name string `json:"name"`
+			} `json:"flags"`
+		} `json:"commands"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("help catalog is not JSON: %v\n%s", err, stdout.String())
+	}
+
+	wantCommands := map[string]bool{
+		"detent":      false,
+		"add-project": false,
+		"config path": false,
+		"doctor":      false,
+		"update":      false,
+		"version":     false,
+		"shadow-run":  false,
+	}
+	for _, command := range got.Commands {
+		if _, ok := wantCommands[command.Name]; ok {
+			wantCommands[command.Name] = true
+			if strings.TrimSpace(command.Short) == "" {
+				t.Fatalf("command %q short description is empty", command.Name)
+			}
+			if strings.TrimSpace(command.Example) == "" {
+				t.Fatalf("command %q example is empty", command.Name)
+			}
+		}
+	}
+	for command, found := range wantCommands {
+		if !found {
+			t.Fatalf("help catalog missing %q:\n%s", command, stdout.String())
+		}
+	}
+}
+
+func TestRegisteredCommandsHaveExamples(t *testing.T) {
+	cmd := newRootCommand(context.Background())
+	var missing []string
+	collectCommandsWithoutExamples(cmd, &missing)
+	if len(missing) > 0 {
+		t.Fatalf("commands missing examples: %s", strings.Join(missing, ", "))
+	}
+}
+
+func TestRunCLIWritesProblemJSONForUnknownCommand(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runCLI(context.Background(), []string{"--format", "json", "paues"}, &stdout, &stderr)
+	if code != 3 {
+		t.Fatalf("exit code = %d, want 3\nstderr:\n%s", code, stderr.String())
 	}
 	if stdout.Len() != 0 {
 		t.Fatalf("stdout = %q, want empty", stdout.String())
 	}
-	if decodeErr := json.Unmarshal(stderr.Bytes(), &got); decodeErr != nil {
-		t.Fatalf("Unmarshal() error = %v\n%s", decodeErr, stderr.String())
+
+	var got struct {
+		Type         string   `json:"type"`
+		Title        string   `json:"title"`
+		Detail       string   `json:"detail"`
+		ExitCode     int      `json:"exit_code"`
+		DidYouMean   []string `json:"did_you_mean"`
+		SuggestedFix string   `json:"suggested_fix"`
 	}
-	if got.Error.Code != "unknown_command" {
-		t.Fatalf("error.code = %q, want unknown_command", got.Error.Code)
+	if err := json.Unmarshal(stderr.Bytes(), &got); err != nil {
+		t.Fatalf("stderr is not problem JSON: %v\n%s", err, stderr.String())
 	}
-	if got.Error.ExitCode != cli.ExitValidation {
-		t.Fatalf("error.exit_code = %d, want %d", got.Error.ExitCode, cli.ExitValidation)
+	if got.Type != "https://detent.dev/errors/unknown_command" {
+		t.Fatalf("type = %q, want unknown_command", got.Type)
 	}
-	if got.Error.Input != "paues" {
-		t.Fatalf("error.input = %q, want paues", got.Error.Input)
+	if got.Title != "Unknown command" {
+		t.Fatalf("title = %q, want Unknown command", got.Title)
 	}
-	if len(got.Error.DidYouMean) != 1 || got.Error.DidYouMean[0] != "pause" {
-		t.Fatalf("error.did_you_mean = %#v, want [pause]", got.Error.DidYouMean)
+	if got.ExitCode != code {
+		t.Fatalf("exit_code = %d, want %d", got.ExitCode, code)
+	}
+	if !strings.Contains(got.Detail, "paues") {
+		t.Fatalf("detail = %q, want typo", got.Detail)
+	}
+	if len(got.DidYouMean) != 1 || got.DidYouMean[0] != "pause" {
+		t.Fatalf("did_you_mean = %#v, want pause", got.DidYouMean)
+	}
+	if !strings.Contains(got.SuggestedFix, "detent pause") {
+		t.Fatalf("suggested_fix = %q, want detent pause", got.SuggestedFix)
 	}
 }
 
-func TestHandleCommandErrorUsesSemanticExitCodes(t *testing.T) {
-	previous := slog.Default()
-	t.Cleanup(func() {
-		slog.SetDefault(previous)
-	})
-	slog.SetDefault(slog.New(slog.NewJSONHandler(io.Discard, nil)))
+func TestRunCLIWritesProblemJSONForUnknownFlag(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
 
+	code := runCLI(context.Background(), []string{"--format", "json", "--hedless"}, &stdout, &stderr)
+	if code != 3 {
+		t.Fatalf("exit code = %d, want 3\nstderr:\n%s", code, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+
+	var got struct {
+		Code       string   `json:"code"`
+		ExitCode   int      `json:"exit_code"`
+		DidYouMean []string `json:"did_you_mean"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &got); err != nil {
+		t.Fatalf("stderr is not problem JSON: %v\n%s", err, stderr.String())
+	}
+	if got.Code != "unknown_flag" {
+		t.Fatalf("code = %q, want unknown_flag", got.Code)
+	}
+	if got.ExitCode != code {
+		t.Fatalf("exit_code = %d, want %d", got.ExitCode, code)
+	}
+	if len(got.DidYouMean) != 1 || got.DidYouMean[0] != "--headless" {
+		t.Fatalf("did_you_mean = %#v, want --headless", got.DidYouMean)
+	}
+}
+
+func TestRunCLIPrettyUnknownCommandPrintsHint(t *testing.T) {
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runCLI(context.Background(), []string{"paues", "--format", "pretty"}, &stdout, &stderr)
+	if code != 3 {
+		t.Fatalf("exit code = %d, want 3\nstderr:\n%s", code, stderr.String())
+	}
+	for _, want := range []string{"Error: unknown command", "Hint: Run detent pause instead."} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Fatalf("stderr missing %q:\n%s", want, stderr.String())
+		}
+	}
+}
+
+func TestRenderCommandErrorUsesSemanticExitCodes(t *testing.T) {
 	tests := []struct {
 		name string
 		err  error
@@ -105,9 +206,8 @@ func TestHandleCommandErrorUsesSemanticExitCodes(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			cmd := newRootCommand(context.Background())
-			cmd.SetErr(io.Discard)
-			if got := handleCommandError(cmd, tt.err); got != tt.want {
-				t.Fatalf("handleCommandError(%v) = %d, want %d", tt.err, got, tt.want)
+			if got := renderCommandError(cmd, tt.err, io.Discard, cli.OutputFormatPretty, nil); got != tt.want {
+				t.Fatalf("renderCommandError(%v) = %d, want %d", tt.err, got, tt.want)
 			}
 		})
 	}
@@ -194,6 +294,23 @@ func TestSignalContextCancel(t *testing.T) {
 	case <-ctx.Done():
 	case <-time.After(time.Second):
 		t.Fatal("signal context was not canceled")
+	}
+}
+
+func collectCommandsWithoutExamples(cmd *cobra.Command, missing *[]string) {
+	name := cmd.CommandPath()
+	if name == "" {
+		name = cmd.Name()
+	}
+	switch cmd.Name() {
+	case "completion":
+		return
+	}
+	if strings.TrimSpace(cmd.Example) == "" {
+		*missing = append(*missing, name)
+	}
+	for _, child := range cmd.Commands() {
+		collectCommandsWithoutExamples(child, missing)
 	}
 }
 

--- a/cmd/detent/update.go
+++ b/cmd/detent/update.go
@@ -32,6 +32,7 @@ func newUpdateCommand(ctx context.Context, factory updateFactory) *cobra.Command
 	cmd := &cobra.Command{
 		Use:          "update",
 		Short:        "Check for and apply Detent updates",
+		Example:      "detent update --check",
 		Args:         cli.NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {

--- a/cmd/detent/version.go
+++ b/cmd/detent/version.go
@@ -24,9 +24,10 @@ type versionInfo struct {
 
 func newVersionCommand() *cobra.Command {
 	return &cobra.Command{
-		Use:   "version",
-		Short: "Print version metadata",
-		Args:  cli.NoArgs,
+		Use:     "version",
+		Short:   "Print version metadata",
+		Example: "detent version",
+		Args:    cli.NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			info := currentVersionInfo()
 			out, err := cli.OutputForCommand(cmd)

--- a/cmd/detent/version_test.go
+++ b/cmd/detent/version_test.go
@@ -81,14 +81,14 @@ func TestVersionCommandPrintsBuildFields(t *testing.T) {
 	}
 }
 
-func TestVersionCommandWritesJSON(t *testing.T) {
+func TestVersionCommandDefaultsJSONForNonTTY(t *testing.T) {
 	withVersionMetadata(t, "v1.2.3", "abc1234", "2026-05-31T18:30:00Z")
 
 	cmd := newRootCommand(context.Background())
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--format", "json", "version"})
+	cmd.SetArgs([]string{"version"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -103,13 +103,13 @@ func TestVersionCommandWritesJSON(t *testing.T) {
 		Arch      string `json:"arch"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
-		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+		t.Fatalf("version output is not JSON: %v\n%s", err, stdout.String())
 	}
 	if got.Version != "v1.2.3" || got.Commit != "abc1234" || got.BuildDate != "2026-05-31T18:30:00Z" {
-		t.Fatalf("version json = %#v", got)
+		t.Fatalf("version metadata = %#v, want build metadata", got)
 	}
 	if got.GoVersion != runtime.Version() || got.OS != runtime.GOOS || got.Arch != runtime.GOARCH {
-		t.Fatalf("runtime json = %#v", got)
+		t.Fatalf("runtime metadata = %#v, want current runtime", got)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -266,22 +266,33 @@ func NewRootCommand(ctx context.Context, optFns ...Option) *cobra.Command {
 	var host string
 	var port int
 	var headless bool
-	var outputFormat string
+	var format string
 	cmd := &cobra.Command{
 		Use:   "detent",
 		Short: "Detent agent orchestrator",
-		Long: `Detent is an agent orchestrator for tracker-backed work queues.
+		Long: strings.TrimSpace(`Detent is an agent orchestrator for tracker-backed work queues.
+
+Examples:
+  detent --config ~/.config/detent/global.yaml --headless
+  detent --format json config path
+  detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api
+
+Output:
+  --format pretty prints human-readable output.
+  --format json prints machine-readable JSON.
+  DETENT_FORMAT can set the default format.
+  When neither is set, Detent prints pretty output on a TTY and JSON otherwise.
 
 Exit codes:
   0  success
-  1  general or unexpected error
+  1  general or unexpected failure
   2  auth or GitHub token problem
-  3  input validation error
-  4  not found or config conflict`,
-		Args:                       suggestedNoArgs,
-		SilenceUsage:               true,
-		SilenceErrors:              true,
-		SuggestionsMinimumDistance: 2,
+  3  validation, unknown command, or unknown flag
+  4  not found or config conflict`),
+		Example: strings.TrimSpace(`detent --config ~/.config/detent/global.yaml --headless
+detent --format json config path`),
+		Args:         suggestedNoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if _, err := OutputForCommand(cmd); err != nil {
 				return err
@@ -320,38 +331,26 @@ Exit codes:
 	cmd.PersistentFlags().StringVar(&host, "host", "", "web server host")
 	cmd.PersistentFlags().IntVar(&port, "port", -1, "web server port, or 0 for an ephemeral port")
 	cmd.PersistentFlags().BoolVar(&headless, "headless", false, "stream logs instead of launching the terminal dashboard")
-	cmd.PersistentFlags().Var(newOutputFormatValue(&outputFormat), outputFormatFlagName, "output format: pretty or json (default: pretty on TTY, json when piped; DETENT_FORMAT overrides)")
-	cmd.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
-		return WrapValidation(flagSuggestionError(cmd, err))
-	})
-
-	addProjectCommand := newAddProjectCommand(&configPath, opts)
-	addProjectCommand.SuggestFor = []string{"add", "new"}
-	pauseCommand := newEditProjectCommand(&configPath, opts, OperationPauseProject, "pause", "Pause a project", func(project *globalconfig.Project) error {
-		project.Paused = true
-		return nil
-	})
-	pauseCommand.SuggestFor = []string{"stop"}
-	unpauseCommand := newEditProjectCommand(&configPath, opts, OperationUnpauseProject, "unpause", "Unpause a project", func(project *globalconfig.Project) error {
-		project.Paused = false
-		return nil
-	})
-	unpauseCommand.SuggestFor = []string{"resume", "start"}
-	promoteCommand := newPromoteCommand(&configPath, opts)
-	promoteCommand.SuggestFor = []string{"prioritize"}
-	removeProjectCommand := newRemoveProjectCommand(&configPath, opts)
-	removeProjectCommand.SuggestFor = []string{"rm", "delete", "remove"}
+	AddFormatFlag(cmd, &format)
 	cmd.AddCommand(
 		newDoctorCommand(&configPath, &env, &logLevel, &host, &port, opts),
 		newInitCommand(&configPath, opts),
-		addProjectCommand,
-		pauseCommand,
-		unpauseCommand,
+		newAddProjectCommand(&configPath, opts),
+		newEditProjectCommand(&configPath, opts, OperationPauseProject, "pause", "Pause a project", func(project *globalconfig.Project) error {
+			project.Paused = true
+			return nil
+		}),
+		newEditProjectCommand(&configPath, opts, OperationUnpauseProject, "unpause", "Unpause a project", func(project *globalconfig.Project) error {
+			project.Paused = false
+			return nil
+		}),
 		newConfigCommand(&configPath, opts),
-		promoteCommand,
-		removeProjectCommand,
+		newPromoteCommand(&configPath, opts),
+		newRemoveProjectCommand(&configPath, opts),
 	)
-	wrapHintedErrors(cmd)
+	cmd.SetHelpCommand(newHelpCommand(cmd, opts))
+	ConfigureCommandSuggestions(cmd)
+	wrapHintedErrors(cmd, opts)
 
 	return cmd
 }
@@ -373,6 +372,37 @@ func defaultOptions() options {
 		lookupEnv:   os.Getenv,
 		ghAuthToken: defaultGHAuthToken,
 		stdoutTTY:   stdoutIsTTY,
+	}
+}
+
+func newHelpCommand(root *cobra.Command, opts options) *cobra.Command {
+	return &cobra.Command{
+		Use:   "help [command]",
+		Short: "Show help for a command",
+		Example: strings.TrimSpace(`detent help add-project
+detent --format json help`),
+		Args: cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			format, err := commandOutputFormat(cmd, opts)
+			if err != nil {
+				return err
+			}
+			if format == OutputFormatJSON {
+				return WriteJSON(cmd.OutOrStdout(), NewCommandCatalog(root))
+			}
+
+			target := root
+			if len(args) > 0 {
+				found, _, findErr := root.Find(args)
+				if findErr != nil {
+					return findErr
+				}
+				target = found
+			}
+			target.SetOut(cmd.OutOrStdout())
+			target.SetErr(cmd.ErrOrStderr())
+			return target.Help()
+		},
 	}
 }
 
@@ -405,7 +435,7 @@ func exampleHint(command string) string {
 	return "e.g. " + command
 }
 
-func wrapHintedErrors(cmd *cobra.Command) {
+func wrapHintedErrors(cmd *cobra.Command, opts options) {
 	if cmd == nil {
 		return
 	}
@@ -414,6 +444,9 @@ func wrapHintedErrors(cmd *cobra.Command) {
 		cmd.RunE = func(cmd *cobra.Command, args []string) error {
 			err := runE(cmd, args)
 			if err != nil {
+				if cmd.Root().SilenceErrors {
+					return err
+				}
 				if writeErr := writeErrorHint(cmd.ErrOrStderr(), err); writeErr != nil {
 					return errors.Join(err, writeErr)
 				}
@@ -422,7 +455,7 @@ func wrapHintedErrors(cmd *cobra.Command) {
 		}
 	}
 	for _, child := range cmd.Commands() {
-		wrapHintedErrors(child)
+		wrapHintedErrors(child, opts)
 	}
 }
 
@@ -438,9 +471,10 @@ func writeErrorHint(out io.Writer, err error) error {
 func newInitCommand(configPath *string, opts options) *cobra.Command {
 	var force bool
 	cmd := &cobra.Command{
-		Use:   "init",
-		Short: "Create a default global config",
-		Args:  NoArgs,
+		Use:     "init",
+		Short:   "Create a default global config",
+		Example: "detent init --config ~/.config/detent/global.yaml",
+		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -505,9 +539,10 @@ func checkInitTarget(path string, force bool) error {
 func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 	var cfg globalconfig.Project
 	cmd := &cobra.Command{
-		Use:   "add-project",
-		Short: "Add a project to global config",
-		Args:  NoArgs,
+		Use:     "add-project",
+		Short:   "Add a project to global config",
+		Example: "detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api --weight 2",
+		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -575,9 +610,10 @@ type projectEdit func(*globalconfig.Project) error
 
 func newEditProjectCommand(configPath *string, opts options, operation Operation, use string, short string, edit projectEdit) *cobra.Command {
 	return &cobra.Command{
-		Use:   use + " PROJECT_ID",
-		Short: short,
-		Args:  ExactArgs(1),
+		Use:     use + " PROJECT_ID",
+		Short:   short,
+		Example: "detent " + use + " api",
+		Args:    ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -594,8 +630,9 @@ func newEditProjectCommand(configPath *string, opts options, operation Operation
 
 func newConfigCommand(configPath *string, opts options) *cobra.Command {
 	cmd := &cobra.Command{
-		Use:   "config",
-		Short: "Inspect global config settings",
+		Use:     "config",
+		Short:   "Inspect global config settings",
+		Example: "detent config path",
 	}
 	cmd.AddCommand(newConfigPathCommand(configPath, opts))
 	return cmd
@@ -603,9 +640,10 @@ func newConfigCommand(configPath *string, opts options) *cobra.Command {
 
 func newConfigPathCommand(configPath *string, opts options) *cobra.Command {
 	return &cobra.Command{
-		Use:   "path",
-		Short: "Print the resolved global config path",
-		Args:  NoArgs,
+		Use:     "path",
+		Short:   "Print the resolved global config path",
+		Example: "detent --format json config path",
+		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -629,9 +667,10 @@ func newConfigPathCommand(configPath *string, opts options) *cobra.Command {
 func newPromoteCommand(configPath *string, opts options) *cobra.Command {
 	var priority int
 	cmd := &cobra.Command{
-		Use:   "promote PROJECT_ID",
-		Short: "Promote a project priority",
-		Args:  ExactArgs(1),
+		Use:     "promote PROJECT_ID",
+		Short:   "Promote a project priority",
+		Example: "detent promote api --priority 1",
+		Args:    ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if priority <= 0 {
 				return WrapValidation(hintedError(nil, "--priority must be positive", exampleHint(promoteExampleCommand), promoteExampleCommand))
@@ -692,9 +731,10 @@ func updateProject(ctx context.Context, configPath string, opts options, operati
 
 func newRemoveProjectCommand(configPath *string, opts options) *cobra.Command {
 	return &cobra.Command{
-		Use:   "remove-project PROJECT_ID",
-		Short: "Remove a project from global config",
-		Args:  ExactArgs(1),
+		Use:     "remove-project PROJECT_ID",
+		Short:   "Remove a project from global config",
+		Example: "detent remove-project api",
+		Args:    ExactArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -22,7 +22,7 @@ import (
 func TestRootCommandHelpListsAdminCommands(t *testing.T) {
 	t.Parallel()
 
-	cmd := cli.NewRootCommand(context.Background())
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
@@ -170,7 +170,7 @@ func TestConfigPathCommandPrintsResolvedPathAndRule(t *testing.T) {
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
-	cmd.SetArgs([]string{"--config", path, "config", "path"})
+	cmd.SetArgs([]string{"--config", path, "--format", "pretty", "config", "path"})
 
 	if err := cmd.Execute(); err != nil {
 		t.Fatalf("Execute() error = %v", err)
@@ -258,6 +258,78 @@ func TestOutputFormatPrecedence(t *testing.T) {
 				if !strings.Contains(stdout.String(), want) {
 					t.Fatalf("pretty output missing %q:\n%s", want, stdout.String())
 				}
+			}
+		})
+	}
+}
+
+func TestResolveOutputFormatFromArgsPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		args      []string
+		env       string
+		stdoutTTY bool
+		want      cli.OutputFormat
+	}{
+		{
+			name:      "flag before unknown command beats tty",
+			args:      []string{"--format", "json", "paues"},
+			stdoutTTY: true,
+			want:      cli.OutputFormatJSON,
+		},
+		{
+			name:      "flag after unknown command beats tty",
+			args:      []string{"paues", "--format", "json"},
+			stdoutTTY: true,
+			want:      cli.OutputFormatJSON,
+		},
+		{
+			name:      "equals form beats tty",
+			args:      []string{"paues", "--format=json"},
+			stdoutTTY: true,
+			want:      cli.OutputFormatJSON,
+		},
+		{
+			name: "flag beats env and non tty",
+			args: []string{"paues", "--format", "pretty"},
+			env:  "json",
+			want: cli.OutputFormatPretty,
+		},
+		{
+			name:      "env beats tty",
+			args:      []string{"paues"},
+			env:       "json",
+			stdoutTTY: true,
+			want:      cli.OutputFormatJSON,
+		},
+		{
+			name:      "tty defaults pretty",
+			args:      []string{"paues"},
+			stdoutTTY: true,
+			want:      cli.OutputFormatPretty,
+		},
+		{
+			name:      "terminator stops flag scan",
+			args:      []string{"paues", "--", "--format", "json"},
+			stdoutTTY: true,
+			want:      cli.OutputFormatPretty,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := cli.ResolveOutputFormatFromArgs(tt.args, func(string) string {
+				return tt.env
+			}, tt.stdoutTTY)
+			if err != nil {
+				t.Fatalf("ResolveOutputFormatFromArgs() error = %v", err)
+			}
+			if got != tt.want {
+				t.Fatalf("ResolveOutputFormatFromArgs() = %q, want %q", got, tt.want)
 			}
 		})
 	}
@@ -818,6 +890,127 @@ func TestAddProjectWritesConfigAndSignalsManager(t *testing.T) {
 	signal := <-signals
 	if signal.Operation != cli.OperationAddProject || !reflect.DeepEqual(signal.Project, want) {
 		t.Fatalf("signal = %#v, want add project %#v", signal, want)
+	}
+}
+
+func TestAddProjectCommandEmitsJSONResult(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"add-project",
+		"--id", "detent",
+		"--workflow", paths.workflowPath,
+		"--workdir", paths.workdirPath,
+		"--weight", "5",
+		"--paused",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		ID       string `json:"id"`
+		Workflow string `json:"workflow"`
+		Workdir  string `json:"workdir"`
+		Weight   int    `json:"weight"`
+		Paused   bool   `json:"paused"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("add-project output is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.ID != "detent" || got.Workflow != paths.workflowPath || got.Workdir != paths.workdirPath {
+		t.Fatalf("project = %#v, want detent project", got)
+	}
+	if got.Weight != 5 || !got.Paused {
+		t.Fatalf("project weight/paused = %d/%v, want 5/true", got.Weight, got.Paused)
+	}
+}
+
+func TestRootCommandClassifiesMistypedCommandSuggestion(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{name: "near miss", args: []string{"paues"}, want: "pause"},
+		{name: "semantic alias", args: []string{"rm", "api"}, want: "remove-project"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cmd := cli.NewRootCommand(context.Background())
+			cmd.SetOut(&bytes.Buffer{})
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs(tt.args)
+
+			err := cmd.Execute()
+			if err == nil {
+				t.Fatal("Execute() error = nil, want unknown command")
+			}
+			problem := cli.ProblemForCommandError(cmd, err)
+			if len(problem.DidYouMean) != 1 || problem.DidYouMean[0] != tt.want {
+				t.Fatalf("did_you_mean = %#v, want %s", problem.DidYouMean, tt.want)
+			}
+			if !strings.Contains(problem.SuggestedFix, "detent "+tt.want) {
+				t.Fatalf("suggested_fix = %q, want detent %s", problem.SuggestedFix, tt.want)
+			}
+		})
+	}
+}
+
+func TestProblemForErrorClassifiesSemanticFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want int
+	}{
+		{name: "validation", err: cli.NewValidationError("--id is required", "Run detent add-project.", nil), want: cli.ExitValidation},
+		{name: "not found", err: fmt.Errorf("%w: api", cli.ErrProjectNotFound), want: cli.ExitNotFoundOrConfig},
+		{name: "auth", err: errors.New(`GITHUB_TOKEN is not set and github_token is not configured. Run gh auth login --scopes "repo,read:org,project" and set github_token: gh in global.yaml.`), want: cli.ExitAuth},
+		{name: "general", err: errors.New("disk is full"), want: cli.ExitGeneral},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := cli.ProblemForError(tt.err).ExitCode; got != tt.want {
+				t.Fatalf("ProblemForError().ExitCode = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRootCommandSuggestsMistypedFlag(t *testing.T) {
+	t.Parallel()
+
+	cmd := cli.NewRootCommand(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--hedless"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unknown flag")
+	}
+	for _, want := range []string{"unknown flag: --hedless", "Did you mean this?", "\t--headless"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Execute() error missing %q:\n%v", want, err)
+		}
 	}
 }
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -64,10 +64,6 @@ type doctorCheck struct {
 }
 
 type doctorReport struct {
-	Checks []doctorCheck
-}
-
-type doctorOutputReport struct {
 	Checks  []doctorCheck `json:"checks"`
 	Summary doctorSummary `json:"summary"`
 	Result  string        `json:"result"`
@@ -77,6 +73,12 @@ type doctorSummary struct {
 	OK   int `json:"ok"`
 	Warn int `json:"warn"`
 	Fail int `json:"fail"`
+}
+
+type doctorOutputReport struct {
+	Checks  []doctorCheck `json:"checks"`
+	Summary doctorSummary `json:"summary"`
+	Result  string        `json:"result"`
 }
 
 type doctorCheckJob struct {
@@ -140,9 +142,11 @@ func newDoctorCommand(configPath *string, env *string, logLevel *string, host *s
 func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
 	timeout := doctorCheckTimeout
 	cmd := &cobra.Command{
-		Use:   "doctor",
-		Short: "Run preflight health checks",
-		Args:  NoArgs,
+		Use:          "doctor",
+		Short:        "Run preflight health checks",
+		Example:      "detent doctor --config ~/.config/detent/global.yaml",
+		Args:         NoArgs,
+		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)
 			if err != nil {
@@ -408,9 +412,26 @@ func (r doctorReport) counts() map[doctorStatus]int {
 	return counts
 }
 
-func writeDoctorReport(out io.Writer, report doctorReport) error {
+func (r doctorReport) withSummary() doctorReport {
+	counts := r.counts()
+	r.Summary = doctorSummary{
+		OK:   counts[doctorOK],
+		Warn: counts[doctorWarn],
+		Fail: counts[doctorFail],
+	}
+	r.Result = "PASS"
+	if r.Summary.Fail > 0 {
+		r.Result = "FAIL"
+	}
+	return r
+}
+
+func writeDoctorReport(out io.Writer, report doctorReport, format ...OutputFormat) error {
 	if out == nil {
 		out = io.Discard
+	}
+	if len(format) > 0 && format[0] == OutputFormatJSON {
+		return WriteJSON(out, report.withSummary())
 	}
 
 	if _, err := fmt.Fprintln(out, "Detent Doctor"); err != nil {
@@ -433,18 +454,14 @@ func writeDoctorReport(out io.Writer, report doctorReport) error {
 		}
 	}
 
-	counts := report.counts()
 	if _, err := fmt.Fprintln(out); err != nil {
 		return err
 	}
-	if _, err := fmt.Fprintf(out, "Summary: %d OK, %d WARN, %d FAIL\n", counts[doctorOK], counts[doctorWarn], counts[doctorFail]); err != nil {
+	report = report.withSummary()
+	if _, err := fmt.Fprintf(out, "Summary: %d OK, %d WARN, %d FAIL\n", report.Summary.OK, report.Summary.Warn, report.Summary.Fail); err != nil {
 		return err
 	}
-	result := "PASS"
-	if counts[doctorFail] > 0 {
-		result = "FAIL"
-	}
-	_, err := fmt.Fprintf(out, "Result: %s\n", result)
+	_, err := fmt.Fprintf(out, "Result: %s\n", report.Result)
 	return err
 }
 

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -1,0 +1,343 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+const (
+	errorCodeGeneral         = "general"
+	errorCodeValidation      = "validation"
+	errorCodeUnknownCommand  = "unknown_command"
+	errorCodeUnknownFlag     = "unknown_flag"
+	errorCodeGitHubAuth      = "github_auth"
+	errorCodeConfigExists    = "config_exists"
+	errorCodeProjectExists   = "project_exists"
+	errorCodeProjectNotFound = "project_not_found"
+	errorCodeDoctorFailed    = "doctor_failed"
+	errorCodeShutdown        = "shutdown"
+)
+
+type ClassifiedError struct {
+	Err        error
+	Code       string
+	Detail     string
+	Hint       string
+	DidYouMean []string
+}
+
+type Problem struct {
+	Type         string   `json:"type"`
+	Code         string   `json:"code"`
+	Title        string   `json:"title"`
+	Detail       string   `json:"detail"`
+	ExitCode     int      `json:"exit_code"`
+	SuggestedFix string   `json:"suggested_fix,omitempty"`
+	DidYouMean   []string `json:"did_you_mean,omitempty"`
+	DocsURL      string   `json:"docs_url,omitempty"`
+}
+
+func (e *ClassifiedError) Error() string {
+	if e == nil {
+		return ""
+	}
+	detail := strings.TrimSpace(e.Detail)
+	if detail == "" && e.Err != nil {
+		detail = e.Err.Error()
+	}
+	hint := strings.TrimSpace(e.Hint)
+	if hint == "" {
+		return detail
+	}
+	return detail + "\n" + hint
+}
+
+func (e *ClassifiedError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func NewValidationError(detail string, hint string, didYouMean []string) error {
+	return &ClassifiedError{
+		Err:        WrapValidation(errors.New(detail)),
+		Code:       errorCodeValidation,
+		Detail:     detail,
+		Hint:       hint,
+		DidYouMean: compactStrings(didYouMean),
+	}
+}
+
+func NewClassifiedError(err error, code string, detail string, hint string, didYouMean []string) error {
+	if err == nil {
+		err = errors.New(detail)
+	}
+	return &ClassifiedError{
+		Err:        err,
+		Code:       code,
+		Detail:     detail,
+		Hint:       hint,
+		DidYouMean: compactStrings(didYouMean),
+	}
+}
+
+func ProblemForError(err error) Problem {
+	code := classifyErrorCode(err)
+	detail := ErrorDetail(err)
+	didYouMean := ErrorDidYouMean(err)
+	problem := Problem{
+		Type:         "https://detent.dev/errors/" + code,
+		Code:         code,
+		Title:        errorTitle(code),
+		Detail:       detail,
+		ExitCode:     problemExitCode(err, code),
+		SuggestedFix: ErrorHint(err),
+		DidYouMean:   didYouMean,
+		DocsURL:      "https://detent.dev/docs/cli#" + code,
+	}
+	if problem.SuggestedFix == "" {
+		problem.SuggestedFix = defaultSuggestedFix(code, didYouMean)
+	}
+	return problem
+}
+
+func ProblemForCommandError(cmd *cobra.Command, err error) Problem {
+	problem := ProblemForError(err)
+	if problem.Code != errorCodeUnknownCommand || len(problem.DidYouMean) > 0 {
+		return problem
+	}
+	input := unknownCommandName(problem.Detail)
+	if input == "" || cmd == nil {
+		return problem
+	}
+	suggestions := cmd.SuggestionsFor(input)
+	if len(suggestions) == 0 {
+		return problem
+	}
+	problem.DidYouMean = suggestions
+	problem.SuggestedFix = defaultSuggestedFix(problem.Code, suggestions)
+	return problem
+}
+
+func problemExitCode(err error, code string) int {
+	switch code {
+	case errorCodeGitHubAuth:
+		return ExitAuth
+	case errorCodeValidation, errorCodeUnknownCommand, errorCodeUnknownFlag:
+		return ExitValidation
+	case errorCodeConfigExists, errorCodeProjectExists, errorCodeProjectNotFound:
+		return ExitNotFoundOrConfig
+	default:
+		return ExitCode(err)
+	}
+}
+
+func ErrorDetail(err error) string {
+	var classified *ClassifiedError
+	if errors.As(err, &classified) && strings.TrimSpace(classified.Detail) != "" {
+		return strings.TrimSpace(classified.Detail)
+	}
+	if err == nil {
+		return ""
+	}
+	return firstNonEmptyLine(err.Error())
+}
+
+func ErrorHint(err error) string {
+	var classified *ClassifiedError
+	if errors.As(err, &classified) {
+		return strings.TrimSpace(classified.Hint)
+	}
+	if hint, _, ok := HintFor(err); ok {
+		return strings.TrimSpace(hint)
+	}
+	return ""
+}
+
+func ErrorDidYouMean(err error) []string {
+	var classified *ClassifiedError
+	if errors.As(err, &classified) {
+		return compactStrings(classified.DidYouMean)
+	}
+	if hint, _, ok := HintFor(err); ok {
+		return parseDidYouMean(hint)
+	}
+	if err == nil {
+		return nil
+	}
+	return parseDidYouMean(err.Error())
+}
+
+func WriteProblemJSON(out io.Writer, problem Problem) error {
+	return WriteJSON(out, problem)
+}
+
+func WritePrettyError(out io.Writer, err error) error {
+	if out == nil {
+		return nil
+	}
+	if _, writeErr := fmt.Fprintf(out, "Error: %s\n", ErrorDetail(err)); writeErr != nil {
+		return writeErr
+	}
+	if hint := ErrorHint(err); hint != "" {
+		_, writeErr := fmt.Fprintf(out, "Hint: %s\n", hint)
+		return writeErr
+	}
+	return nil
+}
+
+func classifyErrorCode(err error) string {
+	var classified *ClassifiedError
+	if errors.As(err, &classified) && classified.Code != "" {
+		return classified.Code
+	}
+	var hinted *HintedError
+	if errors.As(err, &hinted) && hinted.Err == nil {
+		return errorCodeValidation
+	}
+	switch {
+	case errors.Is(err, ErrGitHubAuth):
+		return errorCodeGitHubAuth
+	case errors.Is(err, ErrConfigExists):
+		return errorCodeConfigExists
+	case errors.Is(err, ErrProjectExists):
+		return errorCodeProjectExists
+	case errors.Is(err, ErrProjectNotFound):
+		return errorCodeProjectNotFound
+	case errors.Is(err, ErrDoctorFailed):
+		return errorCodeDoctorFailed
+	case errors.Is(err, ErrShutdownForced), errors.Is(err, ErrShutdownTimeout):
+		return errorCodeShutdown
+	}
+	text := ""
+	if err != nil {
+		text = err.Error()
+	}
+	switch {
+	case strings.Contains(text, "unknown command"):
+		return errorCodeUnknownCommand
+	case strings.Contains(text, "unknown flag"):
+		return errorCodeUnknownFlag
+	case strings.Contains(text, githubAuthHint), strings.Contains(text, "github_token"):
+		return errorCodeGitHubAuth
+	case errors.Is(err, ErrValidation), errors.Is(err, ErrInvalidOutputFormat):
+		return errorCodeValidation
+	default:
+		return errorCodeGeneral
+	}
+}
+
+func errorTitle(code string) string {
+	switch code {
+	case errorCodeValidation:
+		return "Validation failed"
+	case errorCodeUnknownCommand:
+		return "Unknown command"
+	case errorCodeUnknownFlag:
+		return "Unknown flag"
+	case errorCodeGitHubAuth:
+		return "GitHub authentication required"
+	case errorCodeConfigExists:
+		return "Global config already exists"
+	case errorCodeProjectExists:
+		return "Project already exists"
+	case errorCodeProjectNotFound:
+		return "Project not found"
+	case errorCodeDoctorFailed:
+		return "Doctor checks failed"
+	case errorCodeShutdown:
+		return "Shutdown failed"
+	default:
+		return "Command failed"
+	}
+}
+
+func defaultSuggestedFix(code string, didYouMean []string) string {
+	switch {
+	case code == errorCodeUnknownCommand && len(didYouMean) > 0:
+		return "Run detent " + didYouMean[0] + " instead."
+	case code == errorCodeUnknownFlag && len(didYouMean) > 0:
+		return "Use " + didYouMean[0] + " instead."
+	default:
+		return ""
+	}
+}
+
+func firstNonEmptyLine(text string) string {
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" {
+			return line
+		}
+	}
+	return strings.TrimSpace(text)
+}
+
+func parseDidYouMean(text string) []string {
+	lines := strings.Split(text, "\n")
+	for index, line := range lines {
+		if !strings.Contains(strings.ToLower(line), "did you mean") {
+			continue
+		}
+		var suggestions []string
+		for _, candidate := range lines[index+1:] {
+			candidate = strings.TrimSpace(candidate)
+			if candidate == "" {
+				continue
+			}
+			suggestions = append(suggestions, candidate)
+		}
+		return compactStrings(suggestions)
+	}
+	if start := strings.Index(strings.ToLower(text), "did you mean "); start >= 0 {
+		candidate := strings.TrimSpace(text[start+len("did you mean "):])
+		if strings.HasPrefix(candidate, "\"") {
+			candidate = strings.TrimPrefix(candidate, "\"")
+			if end := strings.Index(candidate, "\""); end >= 0 {
+				candidate = candidate[:end]
+			}
+		} else if fields := strings.Fields(candidate); len(fields) > 0 {
+			candidate = fields[0]
+		}
+		candidate = strings.Trim(candidate, "?`\"")
+		return compactStrings([]string{candidate})
+	}
+	return nil
+}
+
+func unknownCommandName(detail string) string {
+	const prefix = "unknown command "
+	detail = strings.TrimSpace(detail)
+	if !strings.HasPrefix(detail, prefix) {
+		return ""
+	}
+	remainder := strings.TrimSpace(strings.TrimPrefix(detail, prefix))
+	if !strings.HasPrefix(remainder, "\"") {
+		return ""
+	}
+	remainder = strings.TrimPrefix(remainder, "\"")
+	index := strings.Index(remainder, "\"")
+	if index < 0 {
+		return ""
+	}
+	return remainder[:index]
+}
+
+func compactStrings(values []string) []string {
+	var compacted []string
+	seen := map[string]bool{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		compacted = append(compacted, value)
+	}
+	return compacted
+}

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -7,9 +7,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/spf13/pflag"
 )
 
 type OutputFormat string
@@ -34,6 +36,30 @@ type commandOutputOptions struct {
 type CommandOutput struct {
 	Format OutputFormat
 	Out    io.Writer
+}
+
+type CommandCatalog struct {
+	Commands []CommandCatalogEntry `json:"commands"`
+}
+
+type CommandCatalogEntry struct {
+	Name    string               `json:"name"`
+	Use     string               `json:"use"`
+	Short   string               `json:"short"`
+	Args    string               `json:"args,omitempty"`
+	Example string               `json:"example"`
+	Flags   []CommandCatalogFlag `json:"flags,omitempty"`
+}
+
+type CommandCatalogFlag struct {
+	Name      string `json:"name"`
+	Shorthand string `json:"shorthand,omitempty"`
+	Usage     string `json:"usage"`
+	Default   string `json:"default,omitempty"`
+}
+
+func AddFormatFlag(cmd *cobra.Command, value *string) {
+	cmd.PersistentFlags().StringVar(value, outputFormatFlag, "", "output format: pretty or json (default: pretty on TTY, json when piped; DETENT_FORMAT overrides)")
 }
 
 func withCommandOutputOptions(ctx context.Context, opts commandOutputOptions) context.Context {
@@ -75,6 +101,24 @@ func OutputForCommand(cmd *cobra.Command) (CommandOutput, error) {
 	return CommandOutput{Format: format, Out: out}, nil
 }
 
+func ResolveCommandOutputFormat(cmd *cobra.Command, lookupEnv func(string) string, stdoutTTY bool) (OutputFormat, error) {
+	value, set := outputFormatFlagValue(cmd)
+	envValue := ""
+	if lookupEnv == nil {
+		lookupEnv = os.Getenv
+	}
+	envValue = lookupEnv(outputFormatEnv)
+	return ResolveOutputFormat(value, set, envValue, stdoutTTY)
+}
+
+func ResolveOutputFormatFromArgs(args []string, lookupEnv func(string) string, stdoutTTY bool) (OutputFormat, error) {
+	value, set := outputFormatArg(args)
+	if lookupEnv == nil {
+		lookupEnv = os.Getenv
+	}
+	return ResolveOutputFormat(value, set, lookupEnv(outputFormatEnv), stdoutTTY)
+}
+
 func ResolveOutputFormat(flagValue string, flagSet bool, envValue string, stdoutTTY bool) (OutputFormat, error) {
 	if flagSet {
 		return parseOutputFormat(flagValue, "--"+outputFormatFlag)
@@ -86,17 +130,6 @@ func ResolveOutputFormat(flagValue string, flagSet bool, envValue string, stdout
 		return OutputFormatPretty, nil
 	}
 	return OutputFormatJSON, nil
-}
-
-func parseOutputFormat(value string, source string) (OutputFormat, error) {
-	switch OutputFormat(strings.ToLower(strings.TrimSpace(value))) {
-	case OutputFormatPretty:
-		return OutputFormatPretty, nil
-	case OutputFormatJSON:
-		return OutputFormatJSON, nil
-	default:
-		return "", fmt.Errorf("%w for %s: %q (want pretty or json)", ErrInvalidOutputFormat, source, value)
-	}
 }
 
 func (o CommandOutput) IsJSON() bool {
@@ -123,10 +156,56 @@ func (o CommandOutput) WriteJSON(value any) error {
 	return writeJSON(o.Out, value)
 }
 
-func writeJSON(out io.Writer, value any) error {
-	encoder := json.NewEncoder(out)
-	encoder.SetIndent("", "  ")
-	return encoder.Encode(value)
+func WriteCommandOutput(out io.Writer, format OutputFormat, value any, pretty func(io.Writer) error) error {
+	return CommandOutput{Format: format, Out: out}.Write(pretty, value)
+}
+
+func WriteJSON(out io.Writer, value any) error {
+	if out == nil {
+		out = io.Discard
+	}
+	return writeJSON(out, value)
+}
+
+func WriterIsTTY(w io.Writer) bool {
+	file, ok := w.(*os.File)
+	if !ok {
+		return false
+	}
+	info, err := file.Stat()
+	return err == nil && info.Mode()&os.ModeCharDevice != 0
+}
+
+func NewCommandCatalog(root *cobra.Command) CommandCatalog {
+	var catalog CommandCatalog
+	walkCommandCatalog(root, root.CommandPath(), &catalog)
+	return catalog
+}
+
+func commandOutputFormat(cmd *cobra.Command, opts options) (OutputFormat, error) {
+	stdoutTTY := false
+	if opts.stdoutTTY != nil {
+		stdoutTTY = opts.stdoutTTY()
+	}
+	return ResolveCommandOutputFormat(cmd, opts.lookupEnv, stdoutTTY)
+}
+
+func parseOutputFormat(value string, source string) (OutputFormat, error) {
+	switch OutputFormat(strings.ToLower(strings.TrimSpace(value))) {
+	case OutputFormatPretty:
+		return OutputFormatPretty, nil
+	case OutputFormatJSON:
+		return OutputFormatJSON, nil
+	default:
+		detail := fmt.Sprintf("%s must be pretty or json", source)
+		return "", NewClassifiedError(
+			WrapValidation(fmt.Errorf("%w: %s", ErrInvalidOutputFormat, detail)),
+			errorCodeValidation,
+			detail,
+			"Use --format pretty for human-readable output or --format json for machine-readable output.",
+			nil,
+		)
+	}
 }
 
 func outputFormatFlagValue(cmd *cobra.Command) (string, bool) {
@@ -149,11 +228,97 @@ func outputFormatFlagValue(cmd *cobra.Command) (string, bool) {
 	return flag.Value.String(), flag.Changed
 }
 
-func WriterIsTTY(w io.Writer) bool {
-	file, ok := w.(*os.File)
-	if !ok {
-		return false
+func outputFormatArg(args []string) (string, bool) {
+	for index := 0; index < len(args); index++ {
+		arg := args[index]
+		if arg == "--" {
+			return "", false
+		}
+		if arg == "--format" {
+			if index+1 >= len(args) {
+				return "", true
+			}
+			return args[index+1], true
+		}
+		if strings.HasPrefix(arg, "--format=") {
+			return strings.TrimPrefix(arg, "--format="), true
+		}
 	}
-	info, err := file.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
+	return "", false
+}
+
+func writeJSON(out io.Writer, value any) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetIndent("", "  ")
+	return encoder.Encode(value)
+}
+
+func walkCommandCatalog(cmd *cobra.Command, rootPath string, catalog *CommandCatalog) {
+	if cmd == nil || cmd.Hidden {
+		return
+	}
+	catalog.Commands = append(catalog.Commands, catalogEntry(cmd, rootPath))
+	for _, child := range cmd.Commands() {
+		if child.Name() == "completion" {
+			continue
+		}
+		walkCommandCatalog(child, rootPath, catalog)
+	}
+}
+
+func catalogEntry(cmd *cobra.Command, rootPath string) CommandCatalogEntry {
+	name := cmd.CommandPath()
+	if rootPath != "" && name != rootPath {
+		name = strings.TrimPrefix(name, rootPath+" ")
+	}
+	return CommandCatalogEntry{
+		Name:    name,
+		Use:     cmd.UseLine(),
+		Short:   strings.TrimSpace(cmd.Short),
+		Args:    commandArgsDisplay(cmd),
+		Example: strings.TrimSpace(cmd.Example),
+		Flags:   catalogFlags(cmd),
+	}
+}
+
+func commandArgsDisplay(cmd *cobra.Command) string {
+	use := strings.TrimSpace(cmd.Use)
+	name := strings.TrimSpace(cmd.Name())
+	if use == "" || name == "" || use == name {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(use, name))
+}
+
+func catalogFlags(cmd *cobra.Command) []CommandCatalogFlag {
+	seen := map[string]CommandCatalogFlag{}
+	addFlags := func(flags *pflag.FlagSet) {
+		if flags == nil {
+			return
+		}
+		flags.VisitAll(func(flag *pflag.Flag) {
+			if flag.Hidden {
+				return
+			}
+			seen[flag.Name] = CommandCatalogFlag{
+				Name:      flag.Name,
+				Shorthand: flag.Shorthand,
+				Usage:     flag.Usage,
+				Default:   flag.DefValue,
+			}
+		})
+	}
+
+	addFlags(cmd.InheritedFlags())
+	addFlags(cmd.PersistentFlags())
+	addFlags(cmd.LocalFlags())
+
+	flags := make([]CommandCatalogFlag, 0, len(seen))
+	for _, flag := range seen {
+		flags = append(flags, flag)
+	}
+	sort.Slice(flags, func(i, j int) bool {
+		return flags[i].Name < flags[j].Name
+	})
+	return flags
 }

--- a/internal/cli/suggestions.go
+++ b/internal/cli/suggestions.go
@@ -1,10 +1,8 @@
 package cli
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
-	"io"
 	"sort"
 	"strings"
 
@@ -13,116 +11,54 @@ import (
 )
 
 const (
-	outputFormatFlagName      = "format"
-	outputFormatPretty        = "pretty"
-	outputFormatJSON          = "json"
 	flagSuggestionMaxDistance = 2
 	didYouMeanHeading         = "Did you mean this?"
-	unknownCommandErrorPrefix = `unknown command "`
-	unknownFlagErrorPrefix    = "unknown flag: "
-	commandFailedErrorCode    = "command_failed"
-	unknownCommandErrorCode   = "unknown_command"
-	unknownFlagErrorCode      = "unknown_flag"
 )
 
-type outputFormatValue struct {
-	value *string
-}
-
-func newOutputFormatValue(value *string) outputFormatValue {
-	if value != nil && strings.TrimSpace(*value) == "" {
-		*value = outputFormatPretty
-	}
-	return outputFormatValue{value: value}
-}
-
-func (v outputFormatValue) String() string {
-	if v.value == nil || strings.TrimSpace(*v.value) == "" {
-		return outputFormatPretty
-	}
-	return *v.value
-}
-
-func (v outputFormatValue) Set(value string) error {
-	value = strings.ToLower(strings.TrimSpace(value))
-	switch value {
-	case outputFormatPretty, outputFormatJSON:
-		if v.value != nil {
-			*v.value = value
-		}
-		return nil
-	default:
-		return fmt.Errorf("output format must be %q or %q", outputFormatPretty, outputFormatJSON)
-	}
-}
-
-func (v outputFormatValue) Type() string {
-	return "format"
-}
-
-func CommandOutputIsJSON(cmd *cobra.Command) bool {
-	if cmd == nil {
-		return false
-	}
-	root := cmd.Root()
+func ConfigureCommandSuggestions(root *cobra.Command) {
 	if root == nil {
-		root = cmd
+		return
 	}
-	flag := root.PersistentFlags().Lookup(outputFormatFlagName)
-	if flag == nil {
-		flag = root.Flags().Lookup(outputFormatFlagName)
-	}
-	return flag != nil && strings.EqualFold(flag.Value.String(), outputFormatJSON)
+	root.SuggestionsMinimumDistance = flagSuggestionMaxDistance
+	root.SetFlagErrorFunc(func(cmd *cobra.Command, err error) error {
+		return WrapValidation(flagSuggestionError(cmd, err))
+	})
+	setSuggestFor(root, "remove-project", "rm", "delete", "remove")
+	setSuggestFor(root, "add-project", "add", "new")
+	setSuggestFor(root, "unpause", "resume", "start")
+	setSuggestFor(root, "pause", "stop")
+	setSuggestFor(root, "promote", "prioritize")
 }
 
-type commandErrorResponse struct {
-	Error commandError `json:"error"`
+func setSuggestFor(root *cobra.Command, name string, suggestions ...string) {
+	cmd := findCommandByName(root, name)
+	if cmd != nil {
+		seen := map[string]bool{}
+		for _, suggestion := range cmd.SuggestFor {
+			seen[suggestion] = true
+		}
+		for _, suggestion := range suggestions {
+			if !seen[suggestion] {
+				cmd.SuggestFor = append(cmd.SuggestFor, suggestion)
+				seen[suggestion] = true
+			}
+		}
+	}
 }
 
-type commandError struct {
-	Code       string   `json:"code"`
-	ExitCode   int      `json:"exit_code"`
-	Input      string   `json:"input,omitempty"`
-	DidYouMean []string `json:"did_you_mean,omitempty"`
-	Message    string   `json:"message,omitempty"`
-}
-
-func WriteCommandErrorJSON(out io.Writer, err error) error {
-	if out == nil {
-		out = io.Discard
+func findCommandByName(cmd *cobra.Command, name string) *cobra.Command {
+	if cmd == nil {
+		return nil
 	}
-	encoder := json.NewEncoder(out)
-	return encoder.Encode(commandErrorResponseFromError(err))
-}
-
-func commandErrorResponseFromError(err error) commandErrorResponse {
-	message := ""
-	if err != nil {
-		message = err.Error()
+	if cmd.Name() == name {
+		return cmd
 	}
-	exitCode := ExitCode(err)
-
-	if input, ok := unknownCommandInput(message); ok {
-		return commandErrorResponse{Error: commandError{
-			Code:       unknownCommandErrorCode,
-			ExitCode:   exitCode,
-			Input:      input,
-			DidYouMean: didYouMeanSuggestions(message),
-		}}
+	for _, child := range cmd.Commands() {
+		if found := findCommandByName(child, name); found != nil {
+			return found
+		}
 	}
-	if input, ok := unknownFlagInput(message); ok {
-		return commandErrorResponse{Error: commandError{
-			Code:       unknownFlagErrorCode,
-			ExitCode:   exitCode,
-			Input:      input,
-			DidYouMean: didYouMeanSuggestions(message),
-		}}
-	}
-	return commandErrorResponse{Error: commandError{
-		Code:     commandFailedErrorCode,
-		ExitCode: exitCode,
-		Message:  firstErrorLine(message),
-	}}
+	return nil
 }
 
 func suggestedNoArgs(cmd *cobra.Command, args []string) error {
@@ -141,7 +77,7 @@ func commandSuggestionText(cmd *cobra.Command, typedName string) string {
 		return ""
 	}
 	if cmd.SuggestionsMinimumDistance <= 0 {
-		cmd.SuggestionsMinimumDistance = 2
+		cmd.SuggestionsMinimumDistance = flagSuggestionMaxDistance
 	}
 	var builder strings.Builder
 	if suggestions := cmd.SuggestionsFor(typedName); len(suggestions) > 0 {
@@ -246,50 +182,4 @@ func knownFlagNames(cmd *cobra.Command) []string {
 	}
 	sort.Strings(names)
 	return names
-}
-
-func unknownCommandInput(message string) (string, bool) {
-	if !strings.HasPrefix(message, unknownCommandErrorPrefix) {
-		return "", false
-	}
-	rest := strings.TrimPrefix(message, unknownCommandErrorPrefix)
-	end := strings.Index(rest, `"`)
-	if end < 0 {
-		return "", false
-	}
-	return rest[:end], true
-}
-
-func unknownFlagInput(message string) (string, bool) {
-	line := firstErrorLine(message)
-	if !strings.HasPrefix(line, unknownFlagErrorPrefix) {
-		return "", false
-	}
-	rest := strings.TrimSpace(strings.TrimPrefix(line, unknownFlagErrorPrefix))
-	fields := strings.Fields(rest)
-	if len(fields) == 0 {
-		return "", false
-	}
-	return fields[0], true
-}
-
-func didYouMeanSuggestions(message string) []string {
-	index := strings.Index(message, didYouMeanHeading)
-	if index < 0 {
-		return nil
-	}
-	rest := message[index+len(didYouMeanHeading):]
-	var suggestions []string
-	for _, line := range strings.Split(rest, "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" {
-			suggestions = append(suggestions, line)
-		}
-	}
-	return suggestions
-}
-
-func firstErrorLine(message string) string {
-	line, _, _ := strings.Cut(message, "\n")
-	return strings.TrimSpace(line)
 }


### PR DESCRIPTION
## Summary

- Add shared `--format pretty|json` and `DETENT_FORMAT` resolution with JSON defaults for non-TTY command output.
- Add structured command results, problem+json error envelopes, typo/flag suggestions, and a JSON help catalog for agent consumers.
- Preserve pretty-mode output and existing hint behavior while routing process-level failures through semantic exit codes.

Fixes #410

## Test Plan

- [x] `make check`