### PR TITLE
feat: make doctor verify GitHub operational permissions

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,7 @@ after the required Detent states.
 tracker:
   kind: github
   project_slug: PVT_replace_with_project_id
+  write_probe_issue: owner/repo#123
   http_max_idle_conns: 100
   http_max_idle_conns_per_host: 32
   http_idle_conn_timeout_ms: 90000
@@ -418,13 +419,16 @@ port: 4000
    ```
 
 `detent doctor` is a preflight check: config resolution, the SQLite database,
-the `codex` binary, the GitHub token and scopes, the git binary, and whether the
-server port is free. Before starting Detent, fix any `FAIL` (missing
-`github_token: gh` or an unauthenticated `codex` are the usual culprits). If
-Detent is already running on the configured port, the server-port check can fail
-because the live service owns the port; use `detent doctor --port 0` for the
-same config, toolchain, token, and database preflight without the port
-collision, then verify the live service with `/health`.
+the `codex` binary, GitHub auth mode, GitHub ProjectV2 and repository
+readiness, git, and whether the server port is free. Before starting Detent, fix
+any `FAIL` (missing `github_token: gh` or an unauthenticated `codex` are the
+usual culprits). Configure `tracker.write_probe_issue` with a scratch issue on
+the project board when you want doctor to prove ProjectV2 and issue write
+capabilities instead of reporting WARN for unproven writes. If Detent is already
+running on the configured port, the server-port check can fail because the live
+service owns the port; use `detent doctor --port 0` for the same config,
+toolchain, token, and database preflight without the port collision, then verify
+the live service with `/health`.
 
 6. Start Detent:
 
@@ -606,6 +610,11 @@ GitHub configuration lives in each project's `WORKFLOW.md` frontmatter. The
 `project_slug` value is the GitHub ProjectV2 node id. Detent reads issue
 state, priority, labels, blockers, and assignment from the board, then writes
 comments and state transitions back through the connector.
+Set `tracker.write_probe_issue` to a scratch issue already present on that
+ProjectV2 board if `detent doctor` should prove write operations by replaying
+existing values and sending non-mutating validation probes. Without a probe
+issue, doctor reports required write capabilities as WARN instead of inferring
+that broad token scopes are enough.
 
 The GitHub connector uses one pooled keep-alive HTTP client for GraphQL and
 GitHub App REST token requests. Tune `tracker.http_max_idle_conns`,
@@ -697,9 +706,10 @@ the wait should be visible on the board.
   explicit dependency references stay blocked.
 
 Before you dispatch anything, run **`detent doctor`** — it checks config
-resolution, the database, the `codex` binary, your GitHub token and scopes, git,
-and the server port. A clean pre-start `doctor` clears Detent's direct
-preflight. When a running Detent process already owns the configured port,
+resolution, the database, the `codex` binary, GitHub auth mode, configured
+ProjectV2 access, repository issue/PR access, required write proofs, git, and
+the server port. A clean pre-start `doctor` clears Detent's direct preflight.
+When a running Detent process already owns the configured port,
 `detent doctor --port 0` validates the config, database, tools, and token
 without treating the live listener as a blocker; pair it with `/health` on the
 actual service before dispatching more work. Do not dispatch from a failed

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -26,6 +27,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/factory"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 )
@@ -112,6 +114,8 @@ type doctorStatusOptionVerifier interface {
 	VerifyStatusOptions(context.Context, []string) error
 }
 
+type doctorGitHubReadinessFunc func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error)
+
 type doctorDeps struct {
 	loadWorkflow         func(string) (workflowconfig.Workflow, error)
 	lookupEnv            func(string) string
@@ -119,10 +123,12 @@ type doctorDeps struct {
 	runCommand           func(context.Context, string, ...string) error
 	httpDo               func(*http.Request) (*http.Response, error)
 	githubScopes         func(context.Context, string) ([]string, error)
+	githubReadiness      doctorGitHubReadinessFunc
 	ghAuthToken          func(context.Context) (string, error)
 	listen               func(string, string) (net.Listener, error)
 	openSQLite           func(context.Context, string) (doctorStore, error)
 	gitWorkTree          func(context.Context, string) error
+	gitRemoteURL         func(context.Context, string) (string, error)
 	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
 	executable           func() (string, error)
 }
@@ -266,7 +272,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	jobs := []doctorCheckJob{}
 	if global != nil {
 		globalConfig := *global
-		githubToken := runtimeGlobalGitHubToken(runtime.GitHubToken)
+		githubToken := runtime.GitHubToken
 		jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken)...)
 	}
 	jobs = append(jobs,
@@ -526,7 +532,7 @@ func checkDoctorDetentExecutable(build buildinfo.Info, deps doctorDeps) doctorCh
 	}
 }
 
-func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps, githubToken string) []doctorCheck {
+func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret) []doctorCheck {
 	if len(cfg.Projects) == 0 {
 		return []doctorCheck{
 			{
@@ -546,7 +552,7 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 	return checks
 }
 
-func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken string) []doctorCheckJob {
+func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret) []doctorCheckJob {
 	if len(cfg.Projects) == 0 {
 		return []doctorCheckJob{{
 			Name: "Project workflows",
@@ -577,7 +583,7 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 	return jobs
 }
 
-func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps doctorDeps, githubToken string) []doctorCheck {
+func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps doctorDeps, githubToken RuntimeSecret) []doctorCheck {
 	id := doctorProjectID(project)
 	workflow, err := deps.loadWorkflow(project.Workflow)
 	if err != nil {
@@ -596,7 +602,7 @@ func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps 
 			},
 		}
 	}
-	workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, githubToken)
+	workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, runtimeGlobalGitHubToken(githubToken))
 	if err := workflow.Config.Validate(); err != nil {
 		return []doctorCheck{
 			{
@@ -654,11 +660,15 @@ func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps 
 			Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
 		})
 	}
-	return append(checks, doctorCheck{
+	checks = append(checks, doctorCheck{
 		Name:   "Project " + id + " source repo",
 		Status: doctorOK,
 		Detail: expandedSourceRoot + " is a git worktree",
 	})
+	if workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHub {
+		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot)...)
+	}
+	return checks
 }
 
 func doctorProjectID(project globalconfig.Project) string {
@@ -1492,6 +1502,285 @@ func defaultDoctorAutoPromoteConnector(cfg workflowconfig.Config) (doctorAutoPro
 	})
 }
 
+func checkDoctorGitHubReadiness(
+	ctx context.Context,
+	id string,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+	githubToken RuntimeSecret,
+	sourceRoot string,
+) []doctorCheck {
+	checks, err := deps.githubReadiness(ctx, doctorGitHubConnectorConfig(cfg), doctorGitHubReadinessConfig(ctx, project, cfg, deps, githubToken, sourceRoot))
+	if err != nil {
+		return []doctorCheck{{
+			Name:   "Project " + id + " GitHub readiness",
+			Status: doctorFail,
+			Detail: "create GitHub readiness checker: " + err.Error(),
+			Hint:   "Fix GitHub tracker configuration and credentials.",
+		}}
+	}
+	out := make([]doctorCheck, 0, len(checks))
+	for _, check := range checks {
+		out = append(out, doctorCheck{
+			Name:   "Project " + id + " " + check.Name,
+			Status: doctorStatusFromGitHubReadiness(check.Status),
+			Detail: check.Detail,
+			Hint:   check.Hint,
+		})
+	}
+	return out
+}
+
+func doctorGitHubConnectorConfig(cfg workflowconfig.Config) ghconnector.Config {
+	return ghconnector.Config{
+		Endpoint: cfg.Tracker.Endpoint,
+		APIKey:   cfg.Tracker.APIKey,
+		HTTPTransport: ghconnector.HTTPTransportConfig{
+			MaxIdleConns:        cfg.Tracker.HTTPMaxIdleConns,
+			MaxIdleConnsPerHost: cfg.Tracker.HTTPMaxIdleConnsPerHost,
+			IdleConnTimeout:     time.Duration(cfg.Tracker.HTTPIdleConnTimeoutMS) * time.Millisecond,
+		},
+		GitHubAppID:             cfg.Tracker.GitHubAppID,
+		GitHubAppPrivateKey:     cfg.Tracker.GitHubAppPrivateKey,
+		GitHubAppPrivateKeyPath: cfg.Tracker.GitHubAppPrivateKeyPath,
+		GitHubAppInstallationID: cfg.Tracker.GitHubAppInstallationID,
+		ProjectSlug:             cfg.Tracker.ProjectSlug,
+		ActiveStates:            cfg.Tracker.ActiveStates,
+		ObservedStates:          cfg.Tracker.ObservedStates,
+		TerminalStates:          cfg.Tracker.TerminalStates,
+		StateMap:                doctorTrackerStateMap(cfg.Tracker.StateMap),
+	}
+}
+
+func doctorGitHubReadinessConfig(
+	ctx context.Context,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+	githubToken RuntimeSecret,
+	sourceRoot string,
+) ghconnector.ReadinessConfig {
+	return ghconnector.ReadinessConfig{
+		AuthPath:                      doctorGitHubAuthPath(cfg, githubToken, deps.lookupEnv),
+		WriteProbeIssue:               cfg.Tracker.WriteProbeIssue,
+		Repositories:                  doctorGitHubRepositories(ctx, project, cfg, deps, sourceRoot),
+		StatusStates:                  doctorRequiredGitHubStatusStates(cfg),
+		ReadStates:                    doctorRequiredGitHubReadStates(cfg),
+		RequireIssueCommentsRead:      doctorRequiresIssueCommentsRead(cfg),
+		RequireDependencyMetadataRead: doctorRequiresDependencyMetadataRead(cfg),
+		RequireIssueChildrenRead:      doctorRequiresIssueChildrenRead(cfg),
+		RequireIssueParentsRead:       doctorRequiresIssueParentsRead(cfg),
+		RequirePullRequestRead:        doctorRequiresPullRequestRead(cfg),
+		RequirePullRequestReviews:     doctorRequiresPullRequestReviewsRead(cfg),
+		RequirePullRequestChecks:      doctorRequiresPullRequestChecksRead(cfg),
+		RequireProjectStatusWrite:     doctorRequiresProjectStatusWrite(cfg),
+		RequireIssueComments:          doctorRequiresIssueCommentWrite(cfg),
+		RequireAssigneeWrite:          doctorRequiresAssigneeWrite(cfg),
+		RequireIssueClose:             doctorRequiresIssueClose(cfg),
+		ProjectFieldWrites:            doctorRequiredProjectFieldWrites(cfg),
+	}
+}
+
+func doctorStatusFromGitHubReadiness(status ghconnector.ReadinessStatus) doctorStatus {
+	switch status {
+	case ghconnector.ReadinessOK:
+		return doctorOK
+	case ghconnector.ReadinessWarn:
+		return doctorWarn
+	case ghconnector.ReadinessFail:
+		return doctorFail
+	default:
+		return doctorWarn
+	}
+}
+
+func doctorGitHubAuthPath(cfg workflowconfig.Config, token RuntimeSecret, lookupEnv func(string) string) string {
+	if trackerHasGitHubAppCredentials(cfg.Tracker, lookupEnv) {
+		return "GitHub App installation token"
+	}
+	if token.ResolvedVia == "gh" {
+		return "gh-resolved token"
+	}
+	switch strings.TrimSpace(token.Source) {
+	case "GITHUB_TOKEN":
+		return "GITHUB_TOKEN PAT"
+	case "github_token":
+		return "global github_token PAT"
+	case "":
+		if strings.TrimSpace(cfg.Tracker.APIKey) != "" {
+			return "workflow tracker.api_key"
+		}
+		return "GitHub token"
+	default:
+		return token.Source + " PAT"
+	}
+}
+
+func doctorRequiredGitHubStatusStates(cfg workflowconfig.Config) []string {
+	return uniqueDoctorStrings(append(append([]string{}, cfg.Tracker.ActiveStates...), append(cfg.Tracker.ObservedStates, cfg.Tracker.TerminalStates...)...))
+}
+
+func doctorRequiredGitHubReadStates(cfg workflowconfig.Config) []string {
+	return uniqueDoctorStrings(append(append([]string{}, cfg.Tracker.ActiveStates...), cfg.Tracker.ObservedStates...))
+}
+
+func doctorRequiresProjectStatusWrite(cfg workflowconfig.Config) bool {
+	return len(cfg.Tracker.ActiveStates) > 0 ||
+		cfg.Agent.AutoPromote.Enabled ||
+		cfg.Tracker.DependencyAutoUnblock.Enabled
+}
+
+func doctorRequiresIssueCommentWrite(cfg workflowconfig.Config) bool {
+	return cfg.Agent.AutoPromote.Enabled ||
+		cfg.Tracker.DependencyAutoUnblock.Enabled ||
+		doctorRequiresIssueClose(cfg)
+}
+
+func doctorRequiresIssueCommentsRead(cfg workflowconfig.Config) bool {
+	return doctorStateInList("Blocked", cfg.Tracker.ObservedStates) ||
+		doctorStateInList("Blocked", cfg.Tracker.ActiveStates) ||
+		doctorStateInList("Blocked", cfg.Tracker.DependencyAutoUnblock.SourceStates)
+}
+
+func doctorRequiresDependencyMetadataRead(cfg workflowconfig.Config) bool {
+	return len(cfg.Tracker.ActiveStates) > 0 ||
+		cfg.Tracker.DependencyAutoUnblock.Enabled ||
+		doctorRequiresIssueParentsRead(cfg)
+}
+
+func doctorRequiresIssueChildrenRead(cfg workflowconfig.Config) bool {
+	return doctorRequiresIssueClose(cfg)
+}
+
+func doctorRequiresIssueParentsRead(cfg workflowconfig.Config) bool {
+	return doctorRequiresIssueClose(cfg)
+}
+
+func doctorRequiresAssigneeWrite(cfg workflowconfig.Config) bool {
+	if !cfg.Tracker.Claims.Enabled {
+		return false
+	}
+	identity := cfg.Identity
+	identity.Normalize()
+	return identity.OwnershipMode != workflowconfig.IdentityOwnershipField
+}
+
+func doctorRequiresIssueClose(cfg workflowconfig.Config) bool {
+	return len(cfg.Tracker.TerminalStates) > 0
+}
+
+func doctorRequiresPullRequestRead(cfg workflowconfig.Config) bool {
+	return len(cfg.Tracker.ActiveStates) > 0 ||
+		cfg.Agent.AutoPromote.Enabled ||
+		doctorStateInList("Human Review", cfg.Tracker.ObservedStates) ||
+		doctorStateInList("Merging", cfg.Tracker.ActiveStates)
+}
+
+func doctorRequiresPullRequestReviewsRead(cfg workflowconfig.Config) bool {
+	return doctorRequiresPullRequestRead(cfg)
+}
+
+func doctorRequiresPullRequestChecksRead(cfg workflowconfig.Config) bool {
+	return doctorRequiresPullRequestRead(cfg)
+}
+
+func doctorRequiredProjectFieldWrites(cfg workflowconfig.Config) []ghconnector.ReadinessProjectFieldWrite {
+	if !cfg.Tracker.Claims.Enabled {
+		return nil
+	}
+	fields := []ghconnector.ReadinessProjectFieldWrite{}
+	if field := strings.TrimSpace(cfg.Tracker.Claims.LeaseField); field != "" {
+		fields = append(fields, ghconnector.ReadinessProjectFieldWrite{Name: field})
+	}
+	identity := cfg.Identity
+	identity.Normalize()
+	if identity.OwnershipMode == workflowconfig.IdentityOwnershipField {
+		if field := strings.TrimSpace(identity.OwnerField); field != "" {
+			fields = append(fields, ghconnector.ReadinessProjectFieldWrite{Name: field})
+		}
+	}
+	return fields
+}
+
+func doctorGitHubRepositories(
+	ctx context.Context,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+	sourceRoot string,
+) []string {
+	repositories := []string{}
+	if repo, ok := doctorGitHubRepositoryFromProbe(cfg.Tracker.WriteProbeIssue); ok {
+		repositories = append(repositories, repo)
+	}
+	if repo, ok := doctorGitHubRepositoryFromProbe(project.Workdir); ok {
+		repositories = append(repositories, repo)
+	}
+	if strings.TrimSpace(sourceRoot) != "" && deps.gitRemoteURL != nil {
+		if remote, err := deps.gitRemoteURL(ctx, sourceRoot); err == nil {
+			if repo, ok := doctorGitHubRepositoryFromRemoteURL(remote); ok {
+				repositories = append(repositories, repo)
+			}
+		}
+	}
+	return uniqueDoctorStrings(repositories)
+}
+
+func doctorGitHubRepositoryFromProbe(value string) (string, bool) {
+	repo, _, ok := strings.Cut(strings.TrimSpace(value), "#")
+	if !ok {
+		return "", false
+	}
+	owner, name, ok := strings.Cut(repo, "/")
+	if !ok || strings.TrimSpace(owner) == "" || strings.TrimSpace(name) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(owner) + "/" + strings.TrimSpace(name), true
+}
+
+func doctorGitHubRepositoryFromRemoteURL(remote string) (string, bool) {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return "", false
+	}
+	if strings.HasPrefix(remote, "git@github.com:") {
+		return doctorCleanGitHubRepository(strings.TrimPrefix(remote, "git@github.com:"))
+	}
+	if parsed, err := url.Parse(remote); err == nil && strings.EqualFold(parsed.Hostname(), "github.com") {
+		return doctorCleanGitHubRepository(strings.TrimPrefix(parsed.Path, "/"))
+	}
+	return "", false
+}
+
+func doctorCleanGitHubRepository(path string) (string, bool) {
+	path = strings.TrimSpace(strings.TrimSuffix(path, ".git"))
+	parts := strings.Split(path, "/")
+	if len(parts) != 2 || strings.TrimSpace(parts[0]) == "" || strings.TrimSpace(parts[1]) == "" {
+		return "", false
+	}
+	return strings.TrimSpace(parts[0]) + "/" + strings.TrimSpace(parts[1]), true
+}
+
+func uniqueDoctorStrings(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	sort.Strings(out)
+	return out
+}
+
 func doctorTrackerStateMap(value workflowconfig.StringOrMap) map[string]string {
 	if !value.IsMap {
 		return nil
@@ -1738,9 +2027,8 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 	if token.Value == "" && !requiresRuntimeToken && hasGitHubProject {
 		return doctorCheck{
 			Name:   "GitHub token",
-			Status: doctorWarn,
-			Detail: "GitHub App credentials configured; token scope check skipped",
-			Hint:   "Use GitHub App installation authentication or configure github_token for PAT-based projects.",
+			Status: doctorOK,
+			Detail: "GitHub App credentials configured; installation permissions checked per project",
 		}
 	}
 	if token.Value == "" {
@@ -1762,6 +2050,13 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 			Hint:   `Refresh the token with repo, read:org, and project scopes.`,
 		}
 	}
+	if len(scopes) == 0 {
+		return doctorCheck{
+			Name:   "GitHub token",
+			Status: doctorOK,
+			Detail: fmt.Sprintf("%s did not expose classic OAuth scopes; treating as fine-grained or resource-scoped token and relying on operation checks", source),
+		}
+	}
 	missing := missingGitHubScopes(scopes)
 	if len(missing) > 0 {
 		return doctorCheck{
@@ -1775,7 +2070,7 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 	return doctorCheck{
 		Name:   "GitHub token",
 		Status: doctorOK,
-		Detail: fmt.Sprintf("%s has required scopes: %s", source, strings.Join(requiredGitHubScopes, ", ")),
+		Detail: fmt.Sprintf("%s has classic PAT scopes: %s; operation checks still verify resource access", source, strings.Join(requiredGitHubScopes, ", ")),
 	}
 }
 
@@ -2032,6 +2327,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.githubScopes == nil {
 		d.githubScopes = defaults.githubScopes
 	}
+	if d.githubReadiness == nil {
+		d.githubReadiness = defaults.githubReadiness
+	}
 	if d.ghAuthToken == nil {
 		d.ghAuthToken = defaults.ghAuthToken
 	}
@@ -2043,6 +2341,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	}
 	if d.gitWorkTree == nil {
 		d.gitWorkTree = defaults.gitWorkTree
+	}
+	if d.gitRemoteURL == nil {
+		d.gitRemoteURL = defaults.gitRemoteURL
 	}
 	if d.autoPromoteConnector == nil {
 		d.autoPromoteConnector = defaults.autoPromoteConnector
@@ -2061,10 +2362,12 @@ func defaultDoctorDeps() doctorDeps {
 		runCommand:           runDoctorCommand,
 		httpDo:               defaultDoctorHTTPDo,
 		githubScopes:         defaultGitHubScopes,
+		githubReadiness:      ghconnector.CheckReadiness,
 		ghAuthToken:          defaultGHAuthToken,
 		listen:               net.Listen,
 		openSQLite:           openDoctorSQLite,
 		gitWorkTree:          defaultGitWorkTree,
+		gitRemoteURL:         defaultGitRemoteURL,
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
 		executable:           os.Executable,
 	}
@@ -2141,6 +2444,28 @@ func defaultGitWorkTree(ctx context.Context, path string) error {
 	return nil
 }
 
+func defaultGitRemoteURL(ctx context.Context, path string) (string, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, "git", "-C", path, "remote", "get-url", "origin") // #nosec G204 -- doctor runs fixed git preflight arguments against configured checkout paths.
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return "", commandCtx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return "", fmt.Errorf("%w: %s", err, detail)
+		}
+		return "", err
+	}
+	remote := strings.TrimSpace(string(output))
+	if remote == "" {
+		return "", errors.New("origin remote URL is blank")
+	}
+	return remote, nil
+}
+
 func defaultGitHubScopes(ctx context.Context, token string) ([]string, error) {
 	requestCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
 	defer cancel()
@@ -2170,9 +2495,6 @@ func defaultGitHubScopes(ctx context.Context, token string) ([]string, error) {
 	}
 
 	scopes := parseGitHubScopes(resp.Header.Get("X-OAuth-Scopes"))
-	if len(scopes) == 0 {
-		return nil, errors.New("GitHub did not report OAuth scopes")
-	}
 	return scopes, nil
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1769,12 +1769,3 @@ func doctorPortFromAddr(t *testing.T, addr net.Addr) int {
 	}
 	return port
 }
-
-func stringSliceContains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
-}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -21,6 +21,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
+	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
 
@@ -154,7 +155,7 @@ func TestCheckDoctorProjects(t *testing.T) {
 				gitWorkTree: func(context.Context, string) error {
 					return tt.gitErr
 				},
-			}, "")
+			}, RuntimeSecret{})
 			if len(got) != len(tt.wantStatus) {
 				t.Fatalf("len(checks) = %d, want %d: %#v", len(got), len(tt.wantStatus), got)
 			}
@@ -568,7 +569,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 			gotPath = path
 			return nil
 		},
-	}, "")
+	}, RuntimeSecret{})
 
 	wantPath := filepath.Join(home, "repo")
 	if gotPath != wantPath {
@@ -576,6 +577,87 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	}
 	if len(checks) != 2 || checks[1].Status != doctorOK {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
+	}
+}
+
+func TestCheckDoctorProjectBuildsGitHubReadinessInventory(t *testing.T) {
+	t.Parallel()
+
+	workflow := validDoctorWorkflow("/repo")
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	workflow.Tracker.ProjectSlug = "PVT_1"
+	workflow.Tracker.ActiveStates = []string{"Todo", "In Progress", "Merging"}
+	workflow.Tracker.ObservedStates = []string{"Backlog", "Human Review", "Blocked"}
+	workflow.Tracker.TerminalStates = []string{"Done", "Cancelled"}
+	workflow.Tracker.WriteProbeIssue = "digitaldrywood/detent#1"
+	workflow.Tracker.Claims = workflowconfig.Claims{
+		Enabled:          true,
+		LeaseField:       "Detent Lease",
+		TTLSeconds:       300,
+		HeartbeatSeconds: 60,
+	}
+	workflow.Identity = workflowconfig.Identity{
+		Name:          "release-captain",
+		OwnershipMode: workflowconfig.IdentityOwnershipField,
+		OwnerField:    "Owner",
+	}
+	var gotConnector ghconnector.Config
+	var gotReadiness ghconnector.ReadinessConfig
+
+	checks := checkDoctorProject(context.Background(), globalconfig.Project{
+		ID:       "alpha",
+		Workflow: "WORKFLOW.md",
+	}, doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: workflow}, nil
+		},
+		gitWorkTree: func(context.Context, string) error {
+			return nil
+		},
+		gitRemoteURL: func(context.Context, string) (string, error) {
+			return "git@github.com:digitaldrywood/detent.git", nil
+		},
+		githubReadiness: func(_ context.Context, connectorCfg ghconnector.Config, readinessCfg ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+			gotConnector = connectorCfg
+			gotReadiness = readinessCfg
+			return []ghconnector.ReadinessCheck{{Name: "GitHub auth path", Status: ghconnector.ReadinessOK, Detail: readinessCfg.AuthPath}}, nil
+		},
+	}, RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"})
+
+	if gotConnector.APIKey != "token" {
+		t.Fatalf("connector APIKey = %q, want injected runtime token", gotConnector.APIKey)
+	}
+	if gotConnector.ProjectSlug != "PVT_1" {
+		t.Fatalf("connector ProjectSlug = %q, want PVT_1", gotConnector.ProjectSlug)
+	}
+	if gotReadiness.AuthPath != "gh-resolved token" {
+		t.Fatalf("AuthPath = %q, want gh-resolved token", gotReadiness.AuthPath)
+	}
+	if gotReadiness.WriteProbeIssue != "digitaldrywood/detent#1" {
+		t.Fatalf("WriteProbeIssue = %q, want configured probe", gotReadiness.WriteProbeIssue)
+	}
+	if len(gotReadiness.Repositories) != 1 || gotReadiness.Repositories[0] != "digitaldrywood/detent" {
+		t.Fatalf("Repositories = %#v, want digitaldrywood/detent", gotReadiness.Repositories)
+	}
+	if !gotReadiness.RequireProjectStatusWrite || !gotReadiness.RequireIssueComments || gotReadiness.RequireAssigneeWrite || !gotReadiness.RequireIssueClose {
+		t.Fatalf("write/read requirements = %#v", gotReadiness)
+	}
+	if !gotReadiness.RequireIssueCommentsRead || !gotReadiness.RequireDependencyMetadataRead || !gotReadiness.RequireIssueChildrenRead || !gotReadiness.RequireIssueParentsRead {
+		t.Fatalf("issue read requirements = %#v", gotReadiness)
+	}
+	if !gotReadiness.RequirePullRequestRead || !gotReadiness.RequirePullRequestReviews || !gotReadiness.RequirePullRequestChecks {
+		t.Fatalf("pull request read requirements = %#v", gotReadiness)
+	}
+	if len(gotReadiness.ProjectFieldWrites) != 2 {
+		t.Fatalf("ProjectFieldWrites = %#v, want lease and owner fields", gotReadiness.ProjectFieldWrites)
+	}
+	for _, want := range []string{"Todo", "Human Review", "Done"} {
+		if !stringSliceContains(gotReadiness.StatusStates, want) {
+			t.Fatalf("StatusStates = %#v, want %q", gotReadiness.StatusStates, want)
+		}
+	}
+	if len(checks) < 3 || checks[len(checks)-1].Status != doctorOK {
+		t.Fatalf("checks = %#v, want readiness OK check appended", checks)
 	}
 }
 
@@ -722,6 +804,13 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			wantDetail: "read:org",
 		},
 		{
+			name:       "fine grained token has no classic scopes",
+			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
+			scopes:     []string{},
+			want:       doctorOK,
+			wantDetail: "fine-grained or resource-scoped token",
+		},
+		{
 			name: "non github projects skip token scopes",
 			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
@@ -741,7 +830,7 @@ func TestCheckDoctorGitHub(t *testing.T) {
 				"INSTALLATION_ID":  "67890",
 				"PRIVATE_KEY_PATH": ".detent/github-app.pem",
 			},
-			want:       doctorWarn,
+			want:       doctorOK,
 			wantDetail: "GitHub App credentials configured",
 		},
 		{
@@ -761,21 +850,21 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			token:      RuntimeSecret{Value: "token", Source: "PROJECT_TOKEN"},
 			scopes:     []string{"project", "read:org", "repo"},
 			want:       doctorOK,
-			wantDetail: "PROJECT_TOKEN has required scopes",
+			wantDetail: "PROJECT_TOKEN has classic PAT scopes",
 		},
 		{
 			name:       "environment token has required scopes",
 			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
 			scopes:     []string{"workflow", "project", "read:org", "repo"},
 			want:       doctorOK,
-			wantDetail: "GITHUB_TOKEN has required scopes",
+			wantDetail: "GITHUB_TOKEN has classic PAT scopes",
 		},
 		{
 			name:       "gh sentinel token has required scopes",
 			token:      RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"},
 			scopes:     []string{"project", "read:org", "repo"},
 			want:       doctorOK,
-			wantDetail: "github_token resolved via gh has required scopes",
+			wantDetail: "github_token resolved via gh has classic PAT scopes",
 		},
 	}
 
@@ -1568,6 +1657,11 @@ func successfulDoctorDeps() doctorDeps {
 		githubScopes: func(context.Context, string) ([]string, error) {
 			return []string{"repo", "read:org", "project"}, nil
 		},
+		githubReadiness: func(context.Context, ghconnector.Config, ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+			return []ghconnector.ReadinessCheck{
+				{Name: "GitHub readiness", Status: ghconnector.ReadinessOK, Detail: "ready"},
+			}, nil
+		},
 		listen: func(string, string) (net.Listener, error) {
 			return fakeDoctorListener{addr: fakeDoctorAddr("127.0.0.1:49152")}, nil
 		},
@@ -1674,4 +1768,13 @@ func doctorPortFromAddr(t *testing.T, addr net.Addr) int {
 		t.Fatalf("Atoi(%q) error = %v", portText, err)
 	}
 	return port
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -76,6 +76,7 @@ type Tracker struct {
 	GitHubAppPrivateKeyPath    string                `yaml:"github_app_private_key_path"`
 	GitHubAppInstallationID    string                `yaml:"github_app_installation_id"`
 	ProjectSlug                string                `yaml:"project_slug"`
+	WriteProbeIssue            string                `yaml:"write_probe_issue,omitempty"`
 	Assignee                   string                `yaml:"assignee"`
 	ActiveStates               []string              `yaml:"active_states"`
 	ObservedStates             []string              `yaml:"observed_states"`
@@ -634,6 +635,7 @@ func (c *Config) normalize() {
 	if c.Tracker.Kind == TrackerGitHub && c.Tracker.Endpoint == defaultLinearEndpoint {
 		c.Tracker.Endpoint = defaultGitHubEndpoint
 	}
+	c.Tracker.WriteProbeIssue = strings.TrimSpace(c.Tracker.WriteProbeIssue)
 	c.Tracker.Claims.Normalize()
 	c.Tracker.DependencyAutoUnblock.Normalize()
 	c.Tracker.Authorization.Normalize()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -23,6 +23,7 @@ tracker:
   kind: github
   api_key: $GITHUB_TOKEN
   project_slug: "PVT_project"
+  write_probe_issue: " digitaldrywood/detent#1 "
   http_max_idle_conns: 120
   http_max_idle_conns_per_host: 40
   http_idle_conn_timeout_ms: 120000
@@ -160,6 +161,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Tracker.Endpoint != "https://api.github.com/graphql" {
 		t.Fatalf("Tracker.Endpoint = %q", cfg.Tracker.Endpoint)
+	}
+	if cfg.Tracker.WriteProbeIssue != "digitaldrywood/detent#1" {
+		t.Fatalf("Tracker.WriteProbeIssue = %q, want digitaldrywood/detent#1", cfg.Tracker.WriteProbeIssue)
 	}
 	if cfg.Tracker.HTTPMaxIdleConns != 120 {
 		t.Fatalf("Tracker.HTTPMaxIdleConns = %d, want 120", cfg.Tracker.HTTPMaxIdleConns)

--- a/internal/connector/github/app_token.go
+++ b/internal/connector/github/app_token.go
@@ -49,6 +49,19 @@ type InstallationTokenSource struct {
 	mu             sync.Mutex
 	cachedToken    string
 	expiresAt      time.Time
+	details        InstallationTokenDetails
+}
+
+type InstallationTokenDetails struct {
+	Token               string
+	ExpiresAt           time.Time
+	Permissions         map[string]string
+	RepositorySelection string
+	Repositories        []InstallationRepository
+}
+
+type InstallationRepository struct {
+	FullName string
 }
 
 func NewInstallationTokenSource(cfg InstallationTokenConfig) (*InstallationTokenSource, error) {
@@ -95,8 +108,16 @@ func NewInstallationTokenSource(cfg InstallationTokenConfig) (*InstallationToken
 }
 
 func (s *InstallationTokenSource) Token(ctx context.Context) (string, error) {
-	if err := ctx.Err(); err != nil {
+	details, err := s.TokenDetails(ctx)
+	if err != nil {
 		return "", err
+	}
+	return details.Token, nil
+}
+
+func (s *InstallationTokenSource) TokenDetails(ctx context.Context) (InstallationTokenDetails, error) {
+	if err := ctx.Err(); err != nil {
+		return InstallationTokenDetails{}, err
 	}
 
 	s.mu.Lock()
@@ -104,22 +125,23 @@ func (s *InstallationTokenSource) Token(ctx context.Context) (string, error) {
 
 	now := s.now()
 	if s.cachedToken != "" && s.expiresAt.After(now.Add(tokenRefreshWindow)) {
-		return s.cachedToken, nil
+		return s.details, nil
 	}
 
 	jwt, err := s.jwt(now)
 	if err != nil {
-		return "", err
+		return InstallationTokenDetails{}, err
 	}
 
-	token, expiresAt, err := s.requestInstallationToken(ctx, jwt)
+	details, err := s.requestInstallationToken(ctx, jwt)
 	if err != nil {
-		return "", err
+		return InstallationTokenDetails{}, err
 	}
-	s.cachedToken = token
-	s.expiresAt = expiresAt
+	s.cachedToken = details.Token
+	s.expiresAt = details.ExpiresAt
+	s.details = details
 
-	return token, nil
+	return details, nil
 }
 
 func (s *InstallationTokenSource) jwt(now time.Time) (string, error) {
@@ -145,15 +167,15 @@ func (s *InstallationTokenSource) jwt(now time.Time) (string, error) {
 	return signingInput + "." + base64.RawURLEncoding.EncodeToString(signature), nil
 }
 
-func (s *InstallationTokenSource) requestInstallationToken(ctx context.Context, jwt string) (string, time.Time, error) {
+func (s *InstallationTokenSource) requestInstallationToken(ctx context.Context, jwt string) (InstallationTokenDetails, error) {
 	endpoint, err := installationTokenURL(s.endpoint, s.installationID)
 	if err != nil {
-		return "", time.Time{}, err
+		return InstallationTokenDetails{}, err
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint, bytes.NewReader([]byte("{}")))
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+		return InstallationTokenDetails{}, fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
 	}
 	req.Header.Set("Authorization", "Bearer "+jwt)
 	req.Header.Set("Accept", "application/vnd.github+json")
@@ -163,9 +185,9 @@ func (s *InstallationTokenSource) requestInstallationToken(ctx context.Context, 
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return "", time.Time{}, ctxErr
+			return InstallationTokenDetails{}, ctxErr
 		}
-		return "", time.Time{}, fmt.Errorf("%w: %w", ErrTransient, err)
+		return InstallationTokenDetails{}, fmt.Errorf("%w: %w", ErrTransient, err)
 	}
 	defer func() {
 		if err := drainAndClose(resp.Body); err != nil {
@@ -175,25 +197,50 @@ func (s *InstallationTokenSource) requestInstallationToken(ctx context.Context, 
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return "", time.Time{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
+		return InstallationTokenDetails{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
 
 	if resp.StatusCode != http.StatusOK && resp.StatusCode != http.StatusCreated {
-		return "", time.Time{}, classifyStatus(resp.StatusCode, resp.Header, raw)
+		return InstallationTokenDetails{}, classifyStatus(resp.StatusCode, resp.Header, raw)
 	}
 
 	var decoded struct {
-		Token     string    `json:"token"`
-		ExpiresAt time.Time `json:"expires_at"`
+		Token               string            `json:"token"`
+		ExpiresAt           time.Time         `json:"expires_at"`
+		Permissions         map[string]string `json:"permissions"`
+		RepositorySelection string            `json:"repository_selection"`
+		Repositories        []struct {
+			FullName string `json:"full_name"`
+		} `json:"repositories"`
 	}
 	if err := json.Unmarshal(raw, &decoded); err != nil {
-		return "", time.Time{}, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+		return InstallationTokenDetails{}, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
 	}
 	if strings.TrimSpace(decoded.Token) == "" || decoded.ExpiresAt.IsZero() {
-		return "", time.Time{}, ErrInvalidResponse
+		return InstallationTokenDetails{}, ErrInvalidResponse
 	}
 
-	return decoded.Token, decoded.ExpiresAt, nil
+	details := InstallationTokenDetails{
+		Token:               strings.TrimSpace(decoded.Token),
+		ExpiresAt:           decoded.ExpiresAt,
+		Permissions:         make(map[string]string, len(decoded.Permissions)),
+		RepositorySelection: strings.TrimSpace(decoded.RepositorySelection),
+		Repositories:        make([]InstallationRepository, 0, len(decoded.Repositories)),
+	}
+	for key, value := range decoded.Permissions {
+		key = strings.TrimSpace(key)
+		value = strings.TrimSpace(value)
+		if key != "" && value != "" {
+			details.Permissions[key] = value
+		}
+	}
+	for _, repo := range decoded.Repositories {
+		fullName := strings.TrimSpace(repo.FullName)
+		if fullName != "" {
+			details.Repositories = append(details.Repositories, InstallationRepository{FullName: fullName})
+		}
+	}
+	return details, nil
 }
 
 func privateKeyFromConfig(cfg InstallationTokenConfig, lookupEnv func(string) string) (string, error) {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -47,6 +47,12 @@ type Client struct {
 	hasRateLimit bool
 }
 
+type restProbeResult struct {
+	StatusCode int
+	Headers    http.Header
+	Body       string
+}
+
 func NewClient(cfg ClientConfig) (*Client, error) {
 	endpoint := strings.TrimSpace(cfg.Endpoint)
 	if endpoint == "" {
@@ -174,6 +180,64 @@ func (c *Client) GraphQLWithType(ctx context.Context, queryType string, query st
 func (c *Client) REST(ctx context.Context, method string, path string, body any, out any) error {
 	_, err := c.rest(ctx, method, path, body, out)
 	return err
+}
+
+func (c *Client) restProbe(ctx context.Context, method string, path string, body any) (restProbeResult, error) {
+	token, err := c.tokenSource.Token(ctx)
+	if err != nil {
+		return restProbeResult{}, fmt.Errorf("resolve github token: %w", err)
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return restProbeResult{}, ErrMissingToken
+	}
+
+	var requestBody io.Reader
+	if body != nil {
+		var encoded bytes.Buffer
+		if err := json.NewEncoder(&encoded).Encode(body); err != nil {
+			return restProbeResult{}, fmt.Errorf("encode github rest request: %w", err)
+		}
+		requestBody = &encoded
+	}
+
+	url, err := c.restURL(path)
+	if err != nil {
+		return restProbeResult{}, err
+	}
+	req, err := http.NewRequestWithContext(ctx, method, url, requestBody)
+	if err != nil {
+		return restProbeResult{}, fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	req.Header.Set("Authorization", "Bearer "+token)
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", gitHubAPIVersion)
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return restProbeResult{}, ctxErr
+		}
+		return restProbeResult{}, fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	defer func() {
+		if err := drainAndClose(resp.Body); err != nil {
+			c.logger.DebugContext(ctx, "github rest probe response body drain failed", "method", method, "path", path, "error", err)
+		}
+	}()
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return restProbeResult{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
+	}
+	return restProbeResult{
+		StatusCode: resp.StatusCode,
+		Headers:    resp.Header.Clone(),
+		Body:       summarizeBody(raw),
+	}, nil
 }
 
 func (c *Client) rest(ctx context.Context, method string, path string, body any, out any) (http.Header, error) {

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -1,0 +1,1097 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+	"time"
+)
+
+type ReadinessStatus string
+
+const (
+	ReadinessOK   ReadinessStatus = "OK"
+	ReadinessWarn ReadinessStatus = "WARN"
+	ReadinessFail ReadinessStatus = "FAIL"
+)
+
+type ReadinessCheck struct {
+	Name   string
+	Status ReadinessStatus
+	Detail string
+	Hint   string
+}
+
+type ReadinessConfig struct {
+	AuthPath                      string
+	WriteProbeIssue               string
+	Repositories                  []string
+	StatusStates                  []string
+	ReadStates                    []string
+	RequireIssueCommentsRead      bool
+	RequireDependencyMetadataRead bool
+	RequireIssueChildrenRead      bool
+	RequireIssueParentsRead       bool
+	RequirePullRequestRead        bool
+	RequirePullRequestReviews     bool
+	RequirePullRequestChecks      bool
+	RequireProjectStatusWrite     bool
+	RequireIssueComments          bool
+	RequireAssigneeWrite          bool
+	RequireIssueClose             bool
+	ProjectFieldWrites            []ReadinessProjectFieldWrite
+}
+
+type ReadinessProjectFieldWrite struct {
+	Name string
+}
+
+type readinessProbeIssue struct {
+	ID  string
+	Ref issueRef
+}
+
+func CheckReadiness(ctx context.Context, cfg Config, readiness ReadinessConfig) ([]ReadinessCheck, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg = readinessConnectorConfig(cfg)
+	connector, err := NewConnector(cfg)
+	if err != nil {
+		return nil, err
+	}
+
+	checker := githubReadinessChecker{
+		connector: connector,
+		cfg:       cfg,
+	}
+	checks := checker.Check(ctx, readiness)
+	if err := connector.Close(); err != nil {
+		checks = append(checks, ReadinessCheck{
+			Name:   "GitHub connector close",
+			Status: ReadinessWarn,
+			Detail: err.Error(),
+			Hint:   "Rerun detent doctor and check local network resources.",
+		})
+	}
+	return checks, nil
+}
+
+type githubReadinessChecker struct {
+	connector *Connector
+	cfg       Config
+}
+
+func (c githubReadinessChecker) Check(ctx context.Context, cfg ReadinessConfig) []ReadinessCheck {
+	checks := []ReadinessCheck{c.authPathCheck(cfg)}
+	if hasGitHubAppCredentials(c.cfg, c.cfg.LookupEnv) {
+		checks = append(checks, c.appInstallationCheck(ctx, cfg))
+	}
+	checks = append(checks,
+		c.projectAccessCheck(ctx),
+		c.statusOptionsCheck(ctx, cfg.StatusStates),
+		c.projectItemsReadCheck(ctx, cfg.ReadStates),
+	)
+	checks = append(checks, c.repositoryChecks(ctx, cfg.Repositories, cfg)...)
+
+	probe, hasProbe, probeCheck := c.resolveWriteProbe(ctx, cfg)
+	if probeCheck != nil {
+		checks = append(checks, *probeCheck)
+	}
+	checks = append(checks, c.probeReadChecks(ctx, cfg, probe, hasProbe)...)
+	checks = append(checks, c.writeChecks(ctx, cfg, probe, hasProbe)...)
+	return checks
+}
+
+func readinessConnectorConfig(cfg Config) Config {
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = NewPooledHTTPClient(cfg.HTTPTransport)
+	}
+	cfg.HTTPClient = httpClient
+	if cfg.TokenSource == nil {
+		cfg.TokenSource = NewTokenResolver(TokenResolverConfig{
+			Endpoint:                cfg.Endpoint,
+			APIKey:                  cfg.APIKey,
+			GitHubAppID:             cfg.GitHubAppID,
+			GitHubAppPrivateKey:     cfg.GitHubAppPrivateKey,
+			GitHubAppPrivateKeyPath: cfg.GitHubAppPrivateKeyPath,
+			GitHubAppInstallationID: cfg.GitHubAppInstallationID,
+			HTTPClient:              httpClient,
+			Now:                     cfg.Now,
+			LookupEnv:               cfg.LookupEnv,
+			GHToken:                 cfg.GHToken,
+		})
+	}
+	return cfg
+}
+
+func (c githubReadinessChecker) authPathCheck(cfg ReadinessConfig) ReadinessCheck {
+	authPath := strings.TrimSpace(cfg.AuthPath)
+	if authPath == "" {
+		authPath = "GitHub token"
+	}
+	return ReadinessCheck{
+		Name:   "GitHub auth path",
+		Status: ReadinessOK,
+		Detail: authPath,
+	}
+}
+
+func (c githubReadinessChecker) appInstallationCheck(ctx context.Context, cfg ReadinessConfig) ReadinessCheck {
+	source, err := NewInstallationTokenSource(InstallationTokenConfig{
+		Endpoint:       c.cfg.Endpoint,
+		AppID:          c.cfg.GitHubAppID,
+		InstallationID: c.cfg.GitHubAppInstallationID,
+		PrivateKey:     c.cfg.GitHubAppPrivateKey,
+		PrivateKeyPath: c.cfg.GitHubAppPrivateKeyPath,
+		HTTPClient:     c.cfg.HTTPClient,
+		Now:            c.cfg.Now,
+		LookupEnv:      c.cfg.LookupEnv,
+	})
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub App installation",
+			Status: ReadinessFail,
+			Detail: "installation token source could not be created: " + err.Error(),
+			Hint:   "Fix tracker.github_app_id, tracker.github_app_installation_id, and private key configuration.",
+		}
+	}
+	details, err := source.TokenDetails(ctx)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub App installation",
+			Status: ReadinessFail,
+			Detail: "installation permissions could not be read: " + err.Error(),
+			Hint:   "Ensure the GitHub App credentials can create an installation token.",
+		}
+	}
+	missing := missingInstallationPermissions(details, cfg)
+	missing = append(missing, missingInstallationRepositories(details, cfg.Repositories)...)
+	if len(missing) > 0 {
+		return ReadinessCheck{
+			Name:   "GitHub App installation",
+			Status: ReadinessFail,
+			Detail: "installation lacks " + strings.Join(missing, ", "),
+			Hint:   "Grant the GitHub App installation the listed repository and permission access, then rerun detent doctor.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub App installation",
+		Status: ReadinessOK,
+		Detail: installationPermissionDetail(details),
+	}
+}
+
+func (c githubReadinessChecker) projectAccessCheck(ctx context.Context) ReadinessCheck {
+	if err := c.connector.Authenticate(ctx); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub project access",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("cannot authenticate against ProjectV2 %s: %v", c.connector.projectID, err),
+			Hint:   "Grant the token or GitHub App access to the configured ProjectV2 board.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub project access",
+		Status: ReadinessOK,
+		Detail: "viewer can read ProjectV2 " + c.connector.projectID,
+	}
+}
+
+func (c githubReadinessChecker) statusOptionsCheck(ctx context.Context, states []string) ReadinessCheck {
+	states = uniqueNonBlank(states)
+	if len(states) == 0 {
+		return ReadinessCheck{
+			Name:   "GitHub project Status mappings",
+			Status: ReadinessOK,
+			Detail: "skipped because no tracker states are configured",
+		}
+	}
+	if err := c.connector.VerifyStatusOptions(ctx, states); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub project Status mappings",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("cannot resolve required Status options on project %s: %v", c.connector.projectID, err),
+			Hint:   "Add the missing ProjectV2 Status options or fix tracker.state_map.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub project Status mappings",
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("resolved %d configured Status option(s) on project %s", len(states), c.connector.projectID),
+	}
+}
+
+func (c githubReadinessChecker) projectItemsReadCheck(ctx context.Context, states []string) ReadinessCheck {
+	states = uniqueNonBlank(states)
+	if len(states) == 0 {
+		return ReadinessCheck{
+			Name:   "GitHub project item read",
+			Status: ReadinessOK,
+			Detail: "skipped because no active or observed tracker states are configured",
+		}
+	}
+	count, err := c.readProjectItemsSample(ctx, states)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub project item read",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("cannot read ProjectV2 items for configured states on project %s: %v", c.connector.projectID, err),
+			Hint:   "Grant ProjectV2 read access and repository issue/PR read access for the configured project.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub project item read",
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("read ProjectV2 items for %d configured state(s); sampled %d issue(s)", len(states), count),
+	}
+}
+
+func (c githubReadinessChecker) readProjectItemsSample(ctx context.Context, states []string) (int, error) {
+	var projectQuery *string
+	if query := c.connector.projectStatusQuery(states); query != "" {
+		projectQuery = &query
+	}
+	var response struct {
+		Node *struct {
+			Items projectItemsConnection `json:"items"`
+		} `json:"node"`
+	}
+	if err := c.connector.client.GraphQLWithType(ctx, graphQLQueryObservedStatus, observedStatusProjectItemsQuery, map[string]any{
+		"projectId": c.connector.projectID,
+		"first":     1,
+		"after":     nil,
+		"query":     projectQuery,
+	}, &response); err != nil {
+		return 0, fmt.Errorf("fetch github project items: %w", err)
+	}
+	if response.Node == nil {
+		return 0, ErrProjectNotFound
+	}
+	count := 0
+	for _, item := range response.Node.Items.Nodes {
+		if item.Content != nil && item.Content.TypeName == "Issue" {
+			count++
+		}
+	}
+	return count, nil
+}
+
+func (c githubReadinessChecker) repositoryChecks(ctx context.Context, repositories []string, cfg ReadinessConfig) []ReadinessCheck {
+	repositories = normalizedRepositories(repositories)
+	if len(repositories) == 0 {
+		return []ReadinessCheck{{
+			Name:   "GitHub repository access",
+			Status: ReadinessWarn,
+			Detail: "no source or target repository could be inferred for repository-level checks",
+			Hint:   "Ensure the project source checkout has a GitHub origin remote.",
+		}}
+	}
+	checks := make([]ReadinessCheck, 0, len(repositories)*8)
+	for _, repo := range repositories {
+		checks = append(checks, c.repositoryReadCheck(ctx, repo))
+		checks = append(checks, c.repositoryIssueReadCheck(ctx, repo))
+		if cfg.RequireIssueCommentsRead {
+			checks = append(checks, c.repositoryIssueCommentsReadCheck(ctx, repo))
+		}
+		if cfg.RequireDependencyMetadataRead {
+			checks = append(checks, c.repositoryDependencyMetadataCheck(ctx, repo))
+		}
+		if cfg.RequirePullRequestRead {
+			checks = append(checks, c.repositoryPullRequestReadCheck(ctx, repo))
+		}
+		if cfg.RequirePullRequestReviews {
+			checks = append(checks, c.repositoryPullRequestReviewsCheck(ctx, repo))
+		}
+		if cfg.RequirePullRequestChecks {
+			checks = append(checks, c.repositoryPullRequestChecksCheck(ctx, repo))
+		}
+	}
+	return checks
+}
+
+func (c githubReadinessChecker) repositoryReadCheck(ctx context.Context, repo string) ReadinessCheck {
+	var out struct {
+		FullName string `json:"full_name"`
+	}
+	if err := c.connector.client.REST(ctx, http.MethodGet, restRepositoryPath(repo), nil, &out); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub repository " + repo + " access",
+			Status: ReadinessFail,
+			Detail: "cannot read repository metadata: " + err.Error(),
+			Hint:   "Grant the token or GitHub App access to " + repo + ".",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub repository " + repo + " access",
+		Status: ReadinessOK,
+		Detail: "repository metadata is readable",
+	}
+}
+
+func (c githubReadinessChecker) repositoryIssueReadCheck(ctx context.Context, repo string) ReadinessCheck {
+	var out []restIssue
+	if err := c.connector.client.REST(ctx, http.MethodGet, restRepositoryIssuesPath(repo), nil, &out); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub issue metadata " + repo,
+			Status: ReadinessFail,
+			Detail: "cannot read repository issues: " + err.Error(),
+			Hint:   "Grant Issues read access for " + repo + ".",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub issue metadata " + repo,
+		Status: ReadinessOK,
+		Detail: "issue metadata endpoint is readable",
+	}
+}
+
+func (c githubReadinessChecker) repositoryIssueCommentsReadCheck(ctx context.Context, repo string) ReadinessCheck {
+	return c.restReadCheck(
+		ctx,
+		"GitHub issue comments read "+repo,
+		restRepositoryIssueCommentsPath(repo),
+		"repository issue comments endpoint is readable",
+		"Grant Issues read access for "+repo+".",
+	)
+}
+
+func (c githubReadinessChecker) repositoryDependencyMetadataCheck(ctx context.Context, repo string) ReadinessCheck {
+	return c.restReadCheck(
+		ctx,
+		"GitHub dependency metadata "+repo,
+		restRepositoryIssueSearchPath(repo),
+		"issue search and dependency metadata endpoint is readable",
+		"Grant repository issue search access for "+repo+".",
+	)
+}
+
+func (c githubReadinessChecker) repositoryPullRequestReadCheck(ctx context.Context, repo string) ReadinessCheck {
+	owner, name, ok := splitRepositoryName(repo)
+	if !ok {
+		return ReadinessCheck{
+			Name:   "GitHub pull request metadata " + repo,
+			Status: ReadinessFail,
+			Detail: "repository name is invalid",
+			Hint:   "Use owner/name repository identifiers.",
+		}
+	}
+	var out []restPullRequest
+	if err := c.connector.client.REST(ctx, http.MethodGet, restPullRequestsPath(pullRequestRepo{Owner: owner, Name: name}, 1), nil, &out); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub pull request metadata " + repo,
+			Status: ReadinessFail,
+			Detail: "cannot read repository pull requests: " + err.Error(),
+			Hint:   "Grant Pull requests read access for " + repo + ".",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub pull request metadata " + repo,
+		Status: ReadinessOK,
+		Detail: "pull request metadata endpoint is readable",
+	}
+}
+
+func (c githubReadinessChecker) repositoryPullRequestReviewsCheck(ctx context.Context, repo string) ReadinessCheck {
+	pr, ok, check := c.repositoryPullRequestSample(ctx, repo, "GitHub pull request reviews "+repo)
+	if check != nil {
+		return *check
+	}
+	if !ok {
+		return ReadinessCheck{
+			Name:   "GitHub pull request reviews " + repo,
+			Status: ReadinessWarn,
+			Detail: "no pull request was available to prove review metadata access",
+			Hint:   "Create or keep one scratch pull request if strict PR review readiness proof is required.",
+		}
+	}
+	return c.restReadCheck(
+		ctx,
+		"GitHub pull request reviews "+repo,
+		restPullRequestReviewsPath(pr.Repo, pr.Number),
+		"pull request reviews endpoint is readable",
+		"Grant Pull requests read access for "+repo+".",
+	)
+}
+
+func (c githubReadinessChecker) repositoryPullRequestChecksCheck(ctx context.Context, repo string) ReadinessCheck {
+	owner, name, ok := splitRepositoryName(repo)
+	if !ok {
+		return ReadinessCheck{
+			Name:   "GitHub CI state " + repo,
+			Status: ReadinessFail,
+			Detail: "repository name is invalid",
+			Hint:   "Use owner/name repository identifiers.",
+		}
+	}
+	defaultBranch, err := c.repositoryDefaultBranch(ctx, repo)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub CI state " + repo,
+			Status: ReadinessFail,
+			Detail: "cannot resolve repository default branch: " + err.Error(),
+			Hint:   "Grant repository metadata read access for " + repo + ".",
+		}
+	}
+	if defaultBranch == "" {
+		return ReadinessCheck{
+			Name:   "GitHub CI state " + repo,
+			Status: ReadinessWarn,
+			Detail: "repository default branch is blank; check-run and status endpoints were not probed",
+			Hint:   "Ensure " + repo + " has a default branch or validate CI state access with a scratch pull request.",
+		}
+	}
+	repoRef := pullRequestRepo{Owner: owner, Name: name}
+	checkRuns := c.restReadCheck(
+		ctx,
+		"GitHub check runs "+repo,
+		restCommitCheckRunsPath(repoRef, defaultBranch),
+		"check runs endpoint is readable",
+		"Grant Checks read access for "+repo+".",
+	)
+	if checkRuns.Status != ReadinessOK {
+		return checkRuns
+	}
+	statuses := c.restReadCheck(
+		ctx,
+		"GitHub commit statuses "+repo,
+		restCommitStatusesPath(repoRef, defaultBranch),
+		"commit statuses endpoint is readable",
+		"Grant commit status read access for "+repo+".",
+	)
+	if statuses.Status != ReadinessOK {
+		return statuses
+	}
+	return ReadinessCheck{
+		Name:   "GitHub CI state " + repo,
+		Status: ReadinessOK,
+		Detail: "check runs and commit statuses endpoints are readable",
+	}
+}
+
+type readinessPullRequestSample struct {
+	Repo   pullRequestRepo
+	Number int
+}
+
+func (c githubReadinessChecker) repositoryPullRequestSample(ctx context.Context, repo string, name string) (readinessPullRequestSample, bool, *ReadinessCheck) {
+	owner, repoName, ok := splitRepositoryName(repo)
+	if !ok {
+		check := ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "repository name is invalid",
+			Hint:   "Use owner/name repository identifiers.",
+		}
+		return readinessPullRequestSample{}, false, &check
+	}
+	repoRef := pullRequestRepo{Owner: owner, Name: repoName}
+	var out []restPullRequest
+	if err := c.connector.client.REST(ctx, http.MethodGet, restPullRequestsPath(repoRef, 1), nil, &out); err != nil {
+		check := ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "cannot read repository pull requests: " + err.Error(),
+			Hint:   "Grant Pull requests read access for " + repo + ".",
+		}
+		return readinessPullRequestSample{}, false, &check
+	}
+	for _, pr := range out {
+		if pr.Number > 0 {
+			return readinessPullRequestSample{Repo: repoRef, Number: pr.Number}, true, nil
+		}
+	}
+	return readinessPullRequestSample{}, false, nil
+}
+
+func (c githubReadinessChecker) repositoryDefaultBranch(ctx context.Context, repo string) (string, error) {
+	var out struct {
+		DefaultBranch string `json:"default_branch"`
+	}
+	if err := c.connector.client.REST(ctx, http.MethodGet, restRepositoryPath(repo), nil, &out); err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out.DefaultBranch), nil
+}
+
+func (c githubReadinessChecker) restReadCheck(ctx context.Context, name string, path string, okDetail string, hint string) ReadinessCheck {
+	result, err := c.connector.client.restProbe(ctx, http.MethodGet, path, nil)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "read probe failed: " + err.Error(),
+			Hint:   "Check GitHub credentials and network access, then rerun detent doctor.",
+		}
+	}
+	detailSuffix := acceptedPermissionsDetail(result.Headers)
+	if result.StatusCode >= http.StatusOK && result.StatusCode < http.StatusMultipleChoices {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessOK,
+			Detail: okDetail + detailSuffix,
+		}
+	}
+	if result.StatusCode == http.StatusUnauthorized || result.StatusCode == http.StatusForbidden || result.StatusCode == http.StatusNotFound {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("token cannot read endpoint: HTTP %d%s %s", result.StatusCode, detailSuffix, strings.TrimSpace(result.Body)),
+			Hint:   hint,
+		}
+	}
+	return ReadinessCheck{
+		Name:   name,
+		Status: ReadinessFail,
+		Detail: fmt.Sprintf("read probe returned HTTP %d%s %s", result.StatusCode, detailSuffix, strings.TrimSpace(result.Body)),
+		Hint:   "Check GitHub endpoint availability and repository access.",
+	}
+}
+
+func (c githubReadinessChecker) resolveWriteProbe(ctx context.Context, cfg ReadinessConfig) (readinessProbeIssue, bool, *ReadinessCheck) {
+	if !cfg.requiresProbeIssue() {
+		return readinessProbeIssue{}, false, nil
+	}
+	probeID := strings.TrimSpace(cfg.WriteProbeIssue)
+	if probeID == "" {
+		return readinessProbeIssue{}, false, nil
+	}
+	probe, err := c.resolveProbeIssue(ctx, probeID)
+	if err != nil {
+		check := ReadinessCheck{
+			Name:   "GitHub write probe target",
+			Status: ReadinessFail,
+			Detail: probeID + ": " + err.Error(),
+			Hint:   "Set tracker.write_probe_issue to a scratch issue that belongs to the configured ProjectV2 board.",
+		}
+		return readinessProbeIssue{}, false, &check
+	}
+	check := ReadinessCheck{
+		Name:   "GitHub write probe target",
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("%s resolves to %s#%d and node %s", probeID, probe.Ref.Owner+"/"+probe.Ref.Name, probe.Ref.Number, probe.ID),
+	}
+	return probe, true, &check
+}
+
+func (cfg ReadinessConfig) requiresProbeIssue() bool {
+	return cfg.requiresWriteProbe() ||
+		cfg.RequireIssueChildrenRead ||
+		cfg.RequireIssueParentsRead
+}
+
+func (cfg ReadinessConfig) requiresWriteProbe() bool {
+	return cfg.RequireProjectStatusWrite ||
+		cfg.RequireIssueComments ||
+		cfg.RequireAssigneeWrite ||
+		cfg.RequireIssueClose ||
+		len(cfg.ProjectFieldWrites) > 0
+}
+
+func (c githubReadinessChecker) resolveProbeIssue(ctx context.Context, value string) (readinessProbeIssue, error) {
+	if ref, ok := issueRefFromIdentifier(value); ok {
+		issue, err := c.connector.fetchRESTIssue(ctx, ref)
+		if err != nil {
+			return readinessProbeIssue{}, err
+		}
+		if strings.TrimSpace(issue.ID) == "" {
+			return readinessProbeIssue{}, ErrNotFound
+		}
+		c.connector.cacheIssueRef(issue)
+		return readinessProbeIssue{ID: strings.TrimSpace(issue.ID), Ref: ref}, nil
+	}
+	ref, ok, err := c.connector.issueRefForID(ctx, value, graphQLQueryIssueLookup)
+	if err != nil {
+		return readinessProbeIssue{}, err
+	}
+	if !ok {
+		return readinessProbeIssue{}, ErrNotFound
+	}
+	issue, err := c.connector.fetchRESTIssue(ctx, ref)
+	if err != nil {
+		return readinessProbeIssue{}, err
+	}
+	if strings.TrimSpace(issue.ID) == "" {
+		return readinessProbeIssue{}, ErrNotFound
+	}
+	return readinessProbeIssue{ID: strings.TrimSpace(issue.ID), Ref: ref}, nil
+}
+
+func (c githubReadinessChecker) probeReadChecks(ctx context.Context, cfg ReadinessConfig, probe readinessProbeIssue, hasProbe bool) []ReadinessCheck {
+	checks := []ReadinessCheck{}
+	if cfg.RequireIssueChildrenRead {
+		checks = append(checks, c.issueChildrenReadCheck(ctx, probe, hasProbe))
+	}
+	if cfg.RequireIssueParentsRead {
+		checks = append(checks, c.issueParentsReadCheck(ctx, probe, hasProbe))
+	}
+	return checks
+}
+
+func (c githubReadinessChecker) issueChildrenReadCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
+	if !hasProbe {
+		return unprovenProbeIssueCheck("GitHub issue children metadata")
+	}
+	children, err := c.connector.FetchIssueChildren(ctx, probe.ID)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub issue children metadata",
+			Status: ReadinessFail,
+			Detail: "cannot read issue sub-issue/tracked-issue metadata: " + err.Error(),
+			Hint:   "Grant GraphQL issue relationship read access for the probe issue repository and project.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub issue children metadata",
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("queried sub-issue and tracked-issue metadata for probe issue; found %d child link(s)", len(children)),
+	}
+}
+
+func (c githubReadinessChecker) issueParentsReadCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
+	if !hasProbe {
+		return unprovenProbeIssueCheck("GitHub issue parent metadata")
+	}
+	parents, err := c.connector.FetchIssueParents(ctx, probe.ID)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub issue parent metadata",
+			Status: ReadinessFail,
+			Detail: "cannot read issue parent/tracked-in metadata: " + err.Error(),
+			Hint:   "Grant GraphQL issue relationship and repository search access for the probe issue repository and project.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub issue parent metadata",
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("queried parent and tracked-in metadata for probe issue; found %d parent link(s)", len(parents)),
+	}
+}
+
+func (c githubReadinessChecker) writeChecks(ctx context.Context, cfg ReadinessConfig, probe readinessProbeIssue, hasProbe bool) []ReadinessCheck {
+	checks := []ReadinessCheck{}
+	if cfg.RequireProjectStatusWrite {
+		checks = append(checks, c.projectStatusWriteCheck(ctx, probe, hasProbe))
+	}
+	if cfg.RequireIssueComments {
+		checks = append(checks, c.issueCommentWriteCheck(ctx, probe, hasProbe))
+	}
+	if cfg.RequireAssigneeWrite {
+		checks = append(checks, c.assigneeWriteCheck(ctx, probe, hasProbe))
+	}
+	for _, field := range cfg.ProjectFieldWrites {
+		checks = append(checks, c.projectFieldWriteCheck(ctx, probe, hasProbe, field))
+	}
+	if cfg.RequireIssueClose {
+		checks = append(checks, c.issueCloseWriteCheck(ctx, probe, hasProbe))
+	}
+	return checks
+}
+
+func (c githubReadinessChecker) projectStatusWriteCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
+	if !hasProbe {
+		return unprovenWriteCheck("GitHub project status update")
+	}
+	item, err := c.connector.resolveProjectItem(ctx, probe.ID)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub project status update",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("token cannot resolve ProjectV2 item for probe issue on project %s: %v", c.connector.projectID, err),
+			Hint:   "Use a scratch issue that is present on the configured ProjectV2 board.",
+		}
+	}
+	statusName := strings.TrimSpace(item.StatusName)
+	if statusName == "" {
+		return ReadinessCheck{
+			Name:   "GitHub project status update",
+			Status: ReadinessWarn,
+			Detail: "write probe issue has no current Status value; updateProjectV2ItemFieldValue was not executed",
+			Hint:   "Set the scratch issue Status field, then rerun detent doctor.",
+		}
+	}
+	fieldID, optionID, err := c.connector.resolveStatusOption(ctx, statusName)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub project status update",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("token cannot resolve current Status option %q for project %s: %v", statusName, c.connector.projectID, err),
+			Hint:   "Fix ProjectV2 Status options or tracker.state_map.",
+		}
+	}
+	if err := c.connector.updateStatusFieldValue(ctx, item.ID, fieldID, optionID); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub project status update",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("token cannot update ProjectV2 item field value for project %s: %v", c.connector.projectID, err),
+			Hint:   "Grant Projects write access to the token or GitHub App installation.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub project status update",
+		Status: ReadinessOK,
+		Detail: "reapplied existing Status value on the write probe item",
+	}
+}
+
+func (c githubReadinessChecker) issueCommentWriteCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
+	if !hasProbe {
+		return unprovenWriteCheck("GitHub issue comments")
+	}
+	return c.invalidWriteProbe(ctx, "GitHub issue comments", http.MethodPost, restIssueCommentsPath(probe.Ref), map[string]any{"body": ""}, "create issue comments")
+}
+
+func (c githubReadinessChecker) assigneeWriteCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
+	if !hasProbe {
+		return unprovenWriteCheck("GitHub assignee update")
+	}
+	return c.invalidWriteProbe(ctx, "GitHub assignee update", http.MethodPost, restIssueAssigneesPath(probe.Ref), map[string]any{
+		"assignees": []string{"detent-doctor-permission-probe-not-a-real-user-" + time.Now().UTC().Format("20060102150405")},
+	}, "update issue assignees")
+}
+
+func (c githubReadinessChecker) issueCloseWriteCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
+	if !hasProbe {
+		return unprovenWriteCheck("GitHub issue close")
+	}
+	return c.invalidWriteProbe(ctx, "GitHub issue close", http.MethodPatch, restIssuePath(probe.Ref), map[string]any{
+		"state": "detent-doctor-invalid-state",
+	}, "close issues")
+}
+
+func (c githubReadinessChecker) invalidWriteProbe(ctx context.Context, name string, method string, path string, body any, capability string) ReadinessCheck {
+	result, err := c.connector.client.restProbe(ctx, method, path, body)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: capability + " permission probe failed: " + err.Error(),
+			Hint:   "Check GitHub credentials and network access, then rerun detent doctor.",
+		}
+	}
+	detailSuffix := acceptedPermissionsDetail(result.Headers)
+	switch result.StatusCode {
+	case http.StatusBadRequest, http.StatusUnprocessableEntity:
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessOK,
+			Detail: fmt.Sprintf("endpoint accepted auth and rejected the intentionally invalid probe with HTTP %d%s", result.StatusCode, detailSuffix),
+		}
+	case http.StatusUnauthorized, http.StatusForbidden, http.StatusNotFound:
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("token cannot %s: HTTP %d%s %s", capability, result.StatusCode, detailSuffix, strings.TrimSpace(result.Body)),
+			Hint:   "Grant the token or GitHub App installation the required repository write permission.",
+		}
+	default:
+		if result.StatusCode >= http.StatusOK && result.StatusCode < http.StatusMultipleChoices {
+			return ReadinessCheck{
+				Name:   name,
+				Status: ReadinessWarn,
+				Detail: fmt.Sprintf("permission probe unexpectedly returned HTTP %d%s", result.StatusCode, detailSuffix),
+				Hint:   "Inspect the scratch issue and rerun detent doctor with a different write probe target if needed.",
+			}
+		}
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("permission probe returned HTTP %d%s %s", result.StatusCode, detailSuffix, strings.TrimSpace(result.Body)),
+			Hint:   "Grant the required GitHub permission or check GitHub endpoint availability.",
+		}
+	}
+}
+
+func (c githubReadinessChecker) projectFieldWriteCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool, field ReadinessProjectFieldWrite) ReadinessCheck {
+	fieldName := strings.TrimSpace(field.Name)
+	name := "GitHub project field update"
+	if fieldName != "" {
+		name = "GitHub project field " + fieldName + " update"
+	}
+	if !hasProbe {
+		return unprovenWriteCheck(name)
+	}
+	if fieldName == "" {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessWarn,
+			Detail: "skipped because field name is blank",
+		}
+	}
+	item, err := c.connector.resolveProjectItem(ctx, probe.ID)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("token cannot resolve ProjectV2 item for probe issue on project %s: %v", c.connector.projectID, err),
+			Hint:   "Use a scratch issue that is present on the configured ProjectV2 board.",
+		}
+	}
+	_, _, _, fields, ok, err := c.connector.fetchProjectFieldsPage(ctx, probe.ID, nil)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "cannot read current project field values for probe issue: " + err.Error(),
+			Hint:   "Grant ProjectV2 read access for the configured project.",
+		}
+	}
+	if !ok {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "probe issue is not on the configured ProjectV2 board",
+			Hint:   "Use a scratch issue that is present on the configured ProjectV2 board.",
+		}
+	}
+	projectField, err := c.connector.fetchProjectField(ctx, fieldName)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "cannot resolve project field: " + err.Error(),
+			Hint:   "Create the configured ProjectV2 field or update the workflow identity/claims configuration.",
+		}
+	}
+	current, hasCurrent := fields[fieldName]
+	if projectTextField(projectField) {
+		if err := c.connector.updateProjectV2TextFieldValue(ctx, item.ID, projectField.ID, current, ErrProjectFieldUpdateFailed); err != nil {
+			return ReadinessCheck{
+				Name:   name,
+				Status: ReadinessFail,
+				Detail: "token cannot update ProjectV2 text field value: " + err.Error(),
+				Hint:   "Grant Projects write access to the token or GitHub App installation.",
+			}
+		}
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessOK,
+			Detail: "reapplied existing text field value on the write probe item",
+		}
+	}
+	if !hasCurrent || strings.TrimSpace(current) == "" {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessWarn,
+			Detail: "write probe issue has no current value for this single-select field; field update was not executed",
+			Hint:   "Set the field on the scratch issue, then rerun detent doctor.",
+		}
+	}
+	decoded, err := decodeProjectSingleSelectField(fieldName, &projectField)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "project field is not a supported text or single-select field: " + err.Error(),
+			Hint:   "Use a ProjectV2 text or single-select field for Detent ownership/lease fields.",
+		}
+	}
+	optionID := singleSelectOptionID(decoded.Options, current)
+	if optionID == "" {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("current probe field value %q is not an option on %s", current, fieldName),
+			Hint:   "Fix the ProjectV2 field options or choose a probe issue with a valid current value.",
+		}
+	}
+	if err := c.connector.updateProjectV2SingleSelectFieldValue(ctx, item.ID, decoded.ID, optionID, ErrProjectFieldUpdateFailed); err != nil {
+		return ReadinessCheck{
+			Name:   name,
+			Status: ReadinessFail,
+			Detail: "token cannot update ProjectV2 single-select field value: " + err.Error(),
+			Hint:   "Grant Projects write access to the token or GitHub App installation.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   name,
+		Status: ReadinessOK,
+		Detail: "reapplied existing single-select field value on the write probe item",
+	}
+}
+
+func unprovenProbeIssueCheck(name string) ReadinessCheck {
+	return ReadinessCheck{
+		Name:   name,
+		Status: ReadinessWarn,
+		Detail: "no tracker.write_probe_issue configured; issue-specific read capability not proven",
+		Hint:   "Configure tracker.write_probe_issue with a scratch issue on the configured project to prove this capability.",
+	}
+}
+
+func unprovenWriteCheck(name string) ReadinessCheck {
+	return ReadinessCheck{
+		Name:   name,
+		Status: ReadinessWarn,
+		Detail: "no tracker.write_probe_issue configured; write capability not proven",
+		Hint:   "Configure tracker.write_probe_issue with a scratch issue on the configured project to prove this write capability.",
+	}
+}
+
+func missingInstallationPermissions(details InstallationTokenDetails, cfg ReadinessConfig) []string {
+	var missing []string
+	projectLevel := "read"
+	if cfg.RequireProjectStatusWrite || len(cfg.ProjectFieldWrites) > 0 {
+		projectLevel = "write"
+	}
+	if !hasAnyPermission(details.Permissions, []string{"organization_projects", "repository_projects", "projects"}, projectLevel) {
+		missing = append(missing, "Projects: "+projectLevel)
+	}
+	issueLevel := "read"
+	if cfg.RequireIssueComments || cfg.RequireAssigneeWrite || cfg.RequireIssueClose {
+		issueLevel = "write"
+	}
+	if !permissionAllows(details.Permissions["issues"], issueLevel) {
+		missing = append(missing, "Issues: "+issueLevel)
+	}
+	if cfg.RequirePullRequestRead && !permissionAllows(details.Permissions["pull_requests"], "read") {
+		missing = append(missing, "Pull requests: read")
+	}
+	if cfg.RequirePullRequestChecks && !permissionAllows(details.Permissions["checks"], "read") {
+		missing = append(missing, "Checks: read")
+	}
+	return missing
+}
+
+func missingInstallationRepositories(details InstallationTokenDetails, repositories []string) []string {
+	if !strings.EqualFold(strings.TrimSpace(details.RepositorySelection), "selected") {
+		return nil
+	}
+	repositories = normalizedRepositories(repositories)
+	if len(repositories) == 0 {
+		return []string{"selected repository access for configured repositories"}
+	}
+	available := make(map[string]struct{}, len(details.Repositories))
+	for _, repo := range details.Repositories {
+		if normalized := normalizeRepository(repo.FullName); normalized != "" {
+			available[normalized] = struct{}{}
+		}
+	}
+	var missing []string
+	for _, repo := range repositories {
+		if _, ok := available[normalizeRepository(repo)]; !ok {
+			missing = append(missing, "repository access to "+repo)
+		}
+	}
+	return missing
+}
+
+func installationPermissionDetail(details InstallationTokenDetails) string {
+	parts := make([]string, 0, len(details.Permissions))
+	for key, value := range details.Permissions {
+		parts = append(parts, key+"="+value)
+	}
+	sort.Strings(parts)
+	selection := strings.TrimSpace(details.RepositorySelection)
+	if selection == "" {
+		selection = "unknown"
+	}
+	if len(parts) == 0 {
+		return "installation token created; repository_selection=" + selection
+	}
+	return "installation token created; repository_selection=" + selection + "; permissions " + strings.Join(parts, ", ")
+}
+
+func hasAnyPermission(permissions map[string]string, keys []string, required string) bool {
+	for _, key := range keys {
+		if permissionAllows(permissions[key], required) {
+			return true
+		}
+	}
+	return false
+}
+
+func permissionAllows(actual string, required string) bool {
+	actualRank := permissionRank(actual)
+	requiredRank := permissionRank(required)
+	return actualRank >= requiredRank && requiredRank > 0
+}
+
+func permissionRank(value string) int {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "read":
+		return 1
+	case "write":
+		return 2
+	case "admin":
+		return 3
+	default:
+		return 0
+	}
+}
+
+func hasGitHubAppCredentials(cfg Config, lookupEnv func(string) string) bool {
+	if lookupEnv == nil {
+		lookupEnv = func(string) string { return "" }
+	}
+	return resolveSecretValue(cfg.GitHubAppID, lookupEnv) != "" &&
+		resolveSecretValue(cfg.GitHubAppInstallationID, lookupEnv) != "" &&
+		(resolveSecretValue(cfg.GitHubAppPrivateKey, lookupEnv) != "" ||
+			resolveSecretValue(cfg.GitHubAppPrivateKeyPath, lookupEnv) != "")
+}
+
+func acceptedPermissionsDetail(headers http.Header) string {
+	value := strings.TrimSpace(headers.Get("X-Accepted-GitHub-Permissions"))
+	if value == "" {
+		return ""
+	}
+	return "; accepted permissions: " + value
+}
+
+func normalizedRepositories(repositories []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(repositories))
+	for _, repo := range repositories {
+		repo = normalizeRepository(repo)
+		if repo == "" {
+			continue
+		}
+		if _, ok := seen[strings.ToLower(repo)]; ok {
+			continue
+		}
+		seen[strings.ToLower(repo)] = struct{}{}
+		out = append(out, repo)
+	}
+	sort.Strings(out)
+	return out
+}
+
+func normalizeRepository(repo string) string {
+	owner, name, ok := splitRepositoryName(repo)
+	if !ok {
+		return ""
+	}
+	return owner + "/" + name
+}
+
+func restRepositoryPath(repo string) string {
+	owner, name, ok := splitRepositoryName(repo)
+	if !ok {
+		return "/repos/"
+	}
+	return "/repos/" + url.PathEscape(owner) + "/" + url.PathEscape(name)
+}
+
+func restRepositoryIssuesPath(repo string) string {
+	values := url.Values{}
+	values.Set("per_page", "1")
+	values.Set("state", "all")
+	return restRepositoryPath(repo) + "/issues?" + values.Encode()
+}
+
+func restRepositoryIssueCommentsPath(repo string) string {
+	values := url.Values{}
+	values.Set("per_page", "1")
+	return restRepositoryPath(repo) + "/issues/comments?" + values.Encode()
+}
+
+func restRepositoryIssueSearchPath(repo string) string {
+	values := url.Values{}
+	values.Set("q", "repo:"+repo+" is:issue")
+	values.Set("per_page", "1")
+	return "/search/issues?" + values.Encode()
+}

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"os"
 	"sort"
 	"strings"
 	"time"
@@ -112,6 +113,9 @@ func readinessConnectorConfig(cfg Config) Config {
 		httpClient = NewPooledHTTPClient(cfg.HTTPTransport)
 	}
 	cfg.HTTPClient = httpClient
+	if cfg.LookupEnv == nil {
+		cfg.LookupEnv = os.Getenv
+	}
 	if cfg.TokenSource == nil {
 		cfg.TokenSource = NewTokenResolver(TokenResolverConfig{
 			Endpoint:                cfg.Endpoint,
@@ -967,13 +971,13 @@ func missingInstallationRepositories(details InstallationTokenDetails, repositor
 	}
 	available := make(map[string]struct{}, len(details.Repositories))
 	for _, repo := range details.Repositories {
-		if normalized := normalizeRepository(repo.FullName); normalized != "" {
+		if normalized := strings.ToLower(normalizeRepository(repo.FullName)); normalized != "" {
 			available[normalized] = struct{}{}
 		}
 	}
 	var missing []string
 	for _, repo := range repositories {
-		if _, ok := available[normalizeRepository(repo)]; !ok {
+		if _, ok := available[strings.ToLower(normalizeRepository(repo))]; !ok {
 			missing = append(missing, "repository access to "+repo)
 		}
 	}

--- a/internal/connector/github/readiness_test.go
+++ b/internal/connector/github/readiness_test.go
@@ -1,0 +1,253 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadinessProjectItemsReadReportsMissingAccess(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		status: http.StatusForbidden,
+		body:   `{"message":"Resource not accessible by integration"}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+	})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.projectItemsReadCheck(context.Background(), []string{"Todo"})
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	if !strings.Contains(got.Detail, "cannot read ProjectV2 items") {
+		t.Fatalf("Detail = %q, want ProjectV2 read failure", got.Detail)
+	}
+}
+
+func TestReadinessProjectStatusWriteReportsMissingProjectWrite(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Todo"}}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_todo","name":"Todo"}]}}}}`,
+		},
+		{
+			status: http.StatusForbidden,
+			body:   `{"message":"Resource not accessible by integration"}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+	})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.projectStatusWriteCheck(context.Background(), readinessProbeIssue{
+		ID:  "I_kw1",
+		Ref: issueRef{Owner: "digitaldrywood", Name: "detent", Number: 1},
+	}, true)
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	if !strings.Contains(got.Detail, "cannot update ProjectV2 item field value") {
+		t.Fatalf("Detail = %q, want project write failure", got.Detail)
+	}
+}
+
+func TestReadinessIssueCommentReportsMissingAccess(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodPost,
+		path:   "/repos/digitaldrywood/detent/issues/1/comments",
+		status: http.StatusForbidden,
+		headers: map[string]string{
+			"X-Accepted-GitHub-Permissions": "issues=write",
+		},
+		body: `{"message":"Resource not accessible by integration"}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.issueCommentWriteCheck(context.Background(), readinessProbeIssue{
+		ID:  "I_kw1",
+		Ref: issueRef{Owner: "digitaldrywood", Name: "detent", Number: 1},
+	}, true)
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	for _, want := range []string{"create issue comments", "issues=write"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+		}
+	}
+}
+
+func TestReadinessAssigneeReportsMissingAccess(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodPost,
+		path:   "/repos/digitaldrywood/detent/issues/1/assignees",
+		status: http.StatusForbidden,
+		headers: map[string]string{
+			"X-Accepted-GitHub-Permissions": "issues=write",
+		},
+		body: `{"message":"Resource not accessible by integration"}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.assigneeWriteCheck(context.Background(), readinessProbeIssue{
+		ID:  "I_kw1",
+		Ref: issueRef{Owner: "digitaldrywood", Name: "detent", Number: 1},
+	}, true)
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	for _, want := range []string{"update issue assignees", "issues=write"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+		}
+	}
+}
+
+func TestReadinessPullRequestChecksReportsMissingAccess(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent",
+			body:   `{"default_branch":"main"}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/main/check-runs?per_page=100",
+			status: http.StatusForbidden,
+			headers: map[string]string{
+				"X-Accepted-GitHub-Permissions": "checks=read",
+			},
+			body: `{"message":"Resource not accessible by integration"}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.repositoryPullRequestChecksCheck(context.Background(), "digitaldrywood/detent")
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	for _, want := range []string{"checks=read", "token cannot read endpoint"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+		}
+	}
+}
+
+func TestReadinessGitHubAppInstallationReportsMissingPermissions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	privateKey := testPrivateKeyPEM(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations/987/access_tokens" {
+			t.Fatalf("path = %s, want installation token path", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		response := map[string]any{
+			"token":                "installation-token",
+			"expires_at":           now.Add(time.Hour).Format(time.RFC3339),
+			"repository_selection": "all",
+			"permissions": map[string]string{
+				"issues":                "read",
+				"organization_projects": "read",
+				"pull_requests":         "read",
+				"checks":                "read",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	checker := githubReadinessChecker{cfg: Config{
+		Endpoint:                server.URL + "/graphql",
+		HTTPClient:              server.Client(),
+		GitHubAppID:             "123",
+		GitHubAppInstallationID: "987",
+		GitHubAppPrivateKey:     privateKey,
+		Now:                     func() time.Time { return now },
+	}}
+
+	got := checker.appInstallationCheck(context.Background(), ReadinessConfig{
+		RequireProjectStatusWrite: true,
+		RequireIssueComments:      true,
+		RequirePullRequestRead:    true,
+		RequirePullRequestChecks:  true,
+		Repositories:              []string{"digitaldrywood/detent"},
+	})
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	for _, want := range []string{"Projects: write", "Issues: write"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+		}
+	}
+}
+
+func TestReadinessUnconfiguredProbeIssueWarns(t *testing.T) {
+	t.Parallel()
+
+	checker := githubReadinessChecker{}
+	got := checker.probeReadChecks(context.Background(), ReadinessConfig{
+		RequireIssueChildrenRead: true,
+		RequireIssueParentsRead:  true,
+	}, readinessProbeIssue{}, false)
+	if len(got) != 2 {
+		t.Fatalf("checks len = %d, want 2: %#v", len(got), got)
+	}
+	for _, check := range got {
+		if check.Status != ReadinessWarn {
+			t.Fatalf("%s Status = %s, want %s", check.Name, check.Status, ReadinessWarn)
+		}
+		if !strings.Contains(check.Detail, "issue-specific read capability not proven") {
+			t.Fatalf("%s Detail = %q, want unproven read detail", check.Name, check.Detail)
+		}
+	}
+}
+
+func TestReadinessUnconfiguredWriteProbeWarns(t *testing.T) {
+	t.Parallel()
+
+	checker := githubReadinessChecker{}
+	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		RequireProjectStatusWrite: true,
+		RequireIssueComments:      true,
+		RequireAssigneeWrite:      true,
+		RequireIssueClose:         true,
+		ProjectFieldWrites:        []ReadinessProjectFieldWrite{{Name: "Owner"}},
+	}, readinessProbeIssue{}, false)
+	if len(got) != 5 {
+		t.Fatalf("checks len = %d, want 5: %#v", len(got), got)
+	}
+	for _, check := range got {
+		if check.Status != ReadinessWarn {
+			t.Fatalf("%s Status = %s, want %s", check.Name, check.Status, ReadinessWarn)
+		}
+		if !strings.Contains(check.Detail, "write capability not proven") {
+			t.Fatalf("%s Detail = %q, want unproven write detail", check.Name, check.Detail)
+		}
+	}
+}

--- a/internal/connector/github/readiness_test.go
+++ b/internal/connector/github/readiness_test.go
@@ -31,6 +31,23 @@ func TestReadinessProjectItemsReadReportsMissingAccess(t *testing.T) {
 	}
 }
 
+func TestReadinessConnectorConfigDefaultsLookupEnvForAppCredentials(t *testing.T) {
+	t.Setenv("DETENT_TEST_GITHUB_APP_ID", "123")
+	t.Setenv("DETENT_TEST_GITHUB_APP_INSTALLATION_ID", "987")
+	t.Setenv("DETENT_TEST_GITHUB_APP_PRIVATE_KEY", "private-key")
+
+	cfg := readinessConnectorConfig(Config{
+		GitHubAppID:             "$DETENT_TEST_GITHUB_APP_ID",
+		GitHubAppInstallationID: "$DETENT_TEST_GITHUB_APP_INSTALLATION_ID",
+		GitHubAppPrivateKey:     "$DETENT_TEST_GITHUB_APP_PRIVATE_KEY",
+		TokenSource:             staticTokenSource("token"),
+	})
+
+	if !hasGitHubAppCredentials(cfg, cfg.LookupEnv) {
+		t.Fatal("hasGitHubAppCredentials() = false, want env-backed credentials detected")
+	}
+}
+
 func TestReadinessProjectStatusWriteReportsMissingProjectWrite(t *testing.T) {
 	t.Parallel()
 
@@ -151,6 +168,20 @@ func TestReadinessPullRequestChecksReportsMissingAccess(t *testing.T) {
 		if !strings.Contains(got.Detail, want) {
 			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
 		}
+	}
+}
+
+func TestReadinessGitHubAppSelectedRepositoriesAreCaseInsensitive(t *testing.T) {
+	t.Parallel()
+
+	got := missingInstallationRepositories(InstallationTokenDetails{
+		RepositorySelection: "selected",
+		Repositories: []InstallationRepository{{
+			FullName: "DigitalDryWood/Detent",
+		}},
+	}, []string{"digitaldrywood/detent"})
+	if len(got) != 0 {
+		t.Fatalf("missingInstallationRepositories() = %#v, want none", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add GitHub operation-level readiness checks to `detent doctor` for auth mode, ProjectV2 access, repository issue/PR reads, GitHub App installation permissions, and required write probes.
- Add `tracker.write_probe_issue` so doctor can safely prove ProjectV2 field/status updates, issue comments, assignee updates, and issue close operations against a scratch issue.
- Document the probe setting and add focused tests for missing GitHub read/write permissions and unconfigured probes.

Fixes #413

## Test Plan

- [x] `go test ./internal/cli ./internal/connector/github`
- [x] `make check`