### PR TITLE
feat(doctor): show auto-promote blockers

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -57,16 +57,31 @@ const (
 var doctorHealthCheckKeys = []string{"hub", "store", "registry", "connector"}
 
 type doctorCheck struct {
-	Name   string       `json:"name"`
-	Status doctorStatus `json:"status"`
-	Detail string       `json:"detail"`
-	Hint   string       `json:"hint,omitempty"`
+	Name                  string                                 `json:"name"`
+	Status                doctorStatus                           `json:"status"`
+	Detail                string                                 `json:"detail"`
+	Hint                  string                                 `json:"hint,omitempty"`
+	AutoPromoteCandidates []doctorAutoPromoteCandidateDiagnostic `json:"auto_promote_candidates,omitempty"`
 }
 
 type doctorReport struct {
 	Checks  []doctorCheck `json:"checks"`
 	Summary doctorSummary `json:"summary"`
 	Result  string        `json:"result"`
+}
+
+type doctorAutoPromoteCandidateDiagnostic struct {
+	IssueID                      string     `json:"issue_id,omitempty"`
+	IssueIdentifier              string     `json:"issue_identifier,omitempty"`
+	IssueURL                     string     `json:"issue_url,omitempty"`
+	PRNumber                     int        `json:"pr_number,omitempty"`
+	PRURL                        string     `json:"pr_url,omitempty"`
+	PRHeadSHA                    string     `json:"pr_head_sha,omitempty"`
+	LatestCodexReviewState       string     `json:"latest_codex_review_state,omitempty"`
+	LatestCodexReviewCommitSHA   string     `json:"latest_codex_review_commit_sha,omitempty"`
+	LatestCodexReviewSubmittedAt *time.Time `json:"latest_codex_review_submitted_at,omitempty"`
+	QuietRemainingSeconds        int64      `json:"quiet_remaining_seconds,omitempty"`
+	Reason                       string     `json:"reason"`
 }
 
 type doctorSummary struct {
@@ -780,22 +795,26 @@ func checkDoctorAutoPromoteLive(
 	}
 
 	autoPromoteCfg := doctorAutoPromoteConfig(cfg)
-	reasonCounts := map[orchestrator.AutoPromoteReason]int{}
+	reasonCounts := map[string]int{}
+	candidates := make([]doctorAutoPromoteCandidateDiagnostic, 0, len(issues))
 	var quietRemaining time.Duration
 	for _, issue := range issues {
 		summary := orchestrator.AutoPromoteSummaryFromIssue(issue)
 		decision := orchestrator.EvaluateAutoPromote(issue, summary, autoPromoteCfg, now)
-		reasonCounts[decision.Reason]++
+		candidate := doctorAutoPromoteCandidateDiagnosticFromIssue(issue, decision)
+		candidates = append(candidates, candidate)
+		reasonCounts[candidate.Reason]++
 		if decision.QuietRemaining > quietRemaining {
 			quietRemaining = decision.QuietRemaining
 		}
 		if decision.Reason == orchestrator.AutoPromoteReasonMissingPullRequest {
 			if prNumber, ok := doctorLinkedPullRequestNumber(issue); ok {
 				return doctorCheck{
-					Name:   name,
-					Status: doctorFail,
-					Detail: fmt.Sprintf("%s has linked PR #%d but auto-promote readiness reports missing_pull_request", doctorIssueLabel(issue), prNumber),
-					Hint:   "Verify GitHub PR attachment, branch prefix matching, and repository access for Human Review candidates.",
+					Name:                  name,
+					Status:                doctorFail,
+					Detail:                fmt.Sprintf("%s has linked PR #%d but auto-promote readiness reports missing_pull_request", doctorIssueLabel(issue), prNumber),
+					Hint:                  "Verify GitHub PR attachment, branch prefix matching, and repository access for Human Review candidates.",
+					AutoPromoteCandidates: []doctorAutoPromoteCandidateDiagnostic{candidate},
 				}
 			}
 		}
@@ -811,10 +830,14 @@ func checkDoctorAutoPromoteLive(
 	if quietRemaining > 0 {
 		detail += "; max_quiet_remaining=" + quietRemaining.Truncate(time.Second).String()
 	}
+	if len(candidates) > 0 {
+		detail += "; candidates: " + doctorAutoPromoteCandidateSummaries(candidates)
+	}
 	return doctorCheck{
-		Name:   name,
-		Status: doctorOK,
-		Detail: detail,
+		Name:                  name,
+		Status:                doctorOK,
+		Detail:                detail,
+		AutoPromoteCandidates: candidates,
 	}
 }
 
@@ -846,18 +869,147 @@ func doctorAutoPromoteConfig(cfg workflowconfig.Config) orchestrator.AutoPromote
 	}
 }
 
-func doctorAutoPromoteReasonCounts(counts map[orchestrator.AutoPromoteReason]int) string {
+func doctorAutoPromoteCandidateDiagnosticFromIssue(
+	issue connector.Issue,
+	decision orchestrator.AutoPromoteDecision,
+) doctorAutoPromoteCandidateDiagnostic {
+	diagnostic := doctorAutoPromoteCandidateDiagnostic{
+		IssueID:         strings.TrimSpace(issue.ID),
+		IssueIdentifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:        strings.TrimSpace(issue.URL),
+		Reason:          doctorAutoPromoteDiagnosticReason(issue, decision),
+	}
+	if decision.QuietRemaining > 0 {
+		diagnostic.QuietRemainingSeconds = int64(decision.QuietRemaining.Truncate(time.Second) / time.Second)
+	}
+	if prNumber, ok := doctorLinkedPullRequestNumber(issue); ok {
+		diagnostic.PRNumber = prNumber
+	}
+	if issue.PullRequest == nil {
+		return diagnostic
+	}
+
+	pullRequest := issue.PullRequest
+	if pullRequest.Number > 0 {
+		diagnostic.PRNumber = pullRequest.Number
+	}
+	diagnostic.PRURL = strings.TrimSpace(pullRequest.URL)
+	diagnostic.PRHeadSHA = strings.TrimSpace(pullRequest.HeadSHA)
+	diagnostic.LatestCodexReviewState = doctorLatestCodexReviewState(pullRequest)
+	diagnostic.LatestCodexReviewCommitSHA = strings.TrimSpace(pullRequest.LatestCodexReviewCommitSHA)
+	diagnostic.LatestCodexReviewSubmittedAt = doctorLatestCodexReviewSubmittedAt(pullRequest)
+	return diagnostic
+}
+
+func doctorAutoPromoteDiagnosticReason(issue connector.Issue, decision orchestrator.AutoPromoteDecision) string {
+	if decision.Reason == orchestrator.AutoPromoteReasonCodexReviewMissing && doctorPullRequestHasStaleCodexReview(issue.PullRequest) {
+		return "stale_automated_review"
+	}
+	if decision.Reason == orchestrator.AutoPromoteReasonCodexReviewNotQuiet {
+		return "quiet_period_remaining"
+	}
+	return string(decision.Reason)
+}
+
+func doctorPullRequestHasStaleCodexReview(pullRequest *connector.PullRequest) bool {
+	if pullRequest == nil {
+		return false
+	}
+	headSHA := strings.TrimSpace(pullRequest.HeadSHA)
+	reviewCommitSHA := strings.TrimSpace(pullRequest.LatestCodexReviewCommitSHA)
+	if headSHA == "" || reviewCommitSHA == "" {
+		return false
+	}
+	if doctorLatestCodexReviewState(pullRequest) == "" && pullRequest.LatestCodexReviewSubmittedAt == nil {
+		return false
+	}
+	return !strings.EqualFold(headSHA, reviewCommitSHA)
+}
+
+func doctorLatestCodexReviewState(pullRequest *connector.PullRequest) string {
+	if pullRequest == nil {
+		return ""
+	}
+	if state := strings.TrimSpace(pullRequest.LatestCodexReviewState); state != "" {
+		return state
+	}
+	return strings.TrimSpace(pullRequest.CodexReviewState)
+}
+
+func doctorLatestCodexReviewSubmittedAt(pullRequest *connector.PullRequest) *time.Time {
+	if pullRequest == nil {
+		return nil
+	}
+	if pullRequest.LatestCodexReviewSubmittedAt != nil {
+		return pullRequest.LatestCodexReviewSubmittedAt
+	}
+	return pullRequest.CodexReviewSubmittedAt
+}
+
+func doctorAutoPromoteCandidateSummaries(candidates []doctorAutoPromoteCandidateDiagnostic) string {
+	parts := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		parts = append(parts, doctorAutoPromoteCandidateSummary(candidate))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func doctorAutoPromoteCandidateSummary(candidate doctorAutoPromoteCandidateDiagnostic) string {
+	parts := []string{doctorAutoPromoteCandidateIssueLabel(candidate)}
+	if candidate.PRNumber > 0 {
+		parts = append(parts, fmt.Sprintf("PR #%d", candidate.PRNumber))
+	}
+	if candidate.PRURL != "" {
+		parts = append(parts, candidate.PRURL)
+	}
+	if candidate.PRHeadSHA != "" {
+		parts = append(parts, "head="+candidate.PRHeadSHA)
+	}
+	if candidate.LatestCodexReviewState != "" || candidate.LatestCodexReviewCommitSHA != "" {
+		review := strings.TrimSpace(candidate.LatestCodexReviewState)
+		if candidate.LatestCodexReviewCommitSHA != "" {
+			if review == "" {
+				review = "review"
+			}
+			review += "@" + candidate.LatestCodexReviewCommitSHA
+		}
+		parts = append(parts, "review="+review)
+	}
+	if candidate.LatestCodexReviewSubmittedAt != nil {
+		parts = append(parts, "submitted="+candidate.LatestCodexReviewSubmittedAt.UTC().Format(time.RFC3339))
+	}
+	if candidate.QuietRemainingSeconds > 0 {
+		parts = append(parts, "quiet_remaining="+(time.Duration(candidate.QuietRemainingSeconds)*time.Second).String())
+	}
+	parts = append(parts, "reason="+candidate.Reason)
+	return strings.Join(parts, " ")
+}
+
+func doctorAutoPromoteCandidateIssueLabel(candidate doctorAutoPromoteCandidateDiagnostic) string {
+	switch {
+	case candidate.IssueID != "" && candidate.IssueIdentifier != "":
+		return candidate.IssueID + " (" + candidate.IssueIdentifier + ")"
+	case candidate.IssueID != "":
+		return candidate.IssueID
+	case candidate.IssueIdentifier != "":
+		return candidate.IssueIdentifier
+	default:
+		return "sampled issue"
+	}
+}
+
+func doctorAutoPromoteReasonCounts(counts map[string]int) string {
 	reasons := make([]string, 0, len(counts))
 	for reason := range counts {
-		if strings.TrimSpace(string(reason)) != "" {
-			reasons = append(reasons, string(reason))
+		if strings.TrimSpace(reason) != "" {
+			reasons = append(reasons, reason)
 		}
 	}
 	sort.Strings(reasons)
 
 	parts := make([]string, 0, len(reasons))
 	for _, reason := range reasons {
-		parts = append(parts, fmt.Sprintf("%s=%d", reason, counts[orchestrator.AutoPromoteReason(reason)]))
+		parts = append(parts, fmt.Sprintf("%s=%d", reason, counts[reason]))
 	}
 	return strings.Join(parts, ", ")
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -360,6 +360,156 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorAutoPromoteCandidateDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		want  doctorAutoPromoteCandidateDiagnostic
+	}{
+		{
+			name: "missing review",
+			issue: doctorAutoPromoteIssue("issue-missing-review", &connector.PullRequest{
+				Number:   403,
+				URL:      "https://github.test/pull/403",
+				State:    "OPEN",
+				HeadSHA:  "head-missing-review",
+				CIStatus: "success",
+			}),
+			want: doctorAutoPromoteCandidateDiagnostic{
+				IssueID:         "issue-missing-review",
+				IssueIdentifier: "digitaldrywood/detent#399",
+				PRNumber:        403,
+				PRURL:           "https://github.test/pull/403",
+				PRHeadSHA:       "head-missing-review",
+				Reason:          "automated_review_missing",
+			},
+		},
+		{
+			name: "stale review",
+			issue: doctorAutoPromoteIssue("issue-stale-review", &connector.PullRequest{
+				Number:                       411,
+				URL:                          "https://github.test/pull/411",
+				State:                        "OPEN",
+				HeadSHA:                      "head-current",
+				CIStatus:                     "success",
+				LatestCodexReviewState:       "COMMENTED",
+				LatestCodexReviewCommitSHA:   "head-previous",
+				LatestCodexReviewSubmittedAt: &oldReview,
+			}),
+			want: doctorAutoPromoteCandidateDiagnostic{
+				IssueID:                      "issue-stale-review",
+				IssueIdentifier:              "digitaldrywood/detent#399",
+				PRNumber:                     411,
+				PRURL:                        "https://github.test/pull/411",
+				PRHeadSHA:                    "head-current",
+				LatestCodexReviewState:       "COMMENTED",
+				LatestCodexReviewCommitSHA:   "head-previous",
+				LatestCodexReviewSubmittedAt: &oldReview,
+				Reason:                       "stale_automated_review",
+			},
+		},
+		{
+			name: "ready current head review",
+			issue: doctorAutoPromoteIssue("issue-ready-review", &connector.PullRequest{
+				Number:                       398,
+				URL:                          "https://github.test/pull/398",
+				State:                        "OPEN",
+				HeadSHA:                      "head-ready",
+				CIStatus:                     "success",
+				CodexReviewState:             "COMMENTED",
+				CodexReviewSubmittedAt:       &oldReview,
+				LatestCodexReviewState:       "COMMENTED",
+				LatestCodexReviewCommitSHA:   "head-ready",
+				LatestCodexReviewSubmittedAt: &oldReview,
+			}),
+			want: doctorAutoPromoteCandidateDiagnostic{
+				IssueID:                      "issue-ready-review",
+				IssueIdentifier:              "digitaldrywood/detent#399",
+				PRNumber:                     398,
+				PRURL:                        "https://github.test/pull/398",
+				PRHeadSHA:                    "head-ready",
+				LatestCodexReviewState:       "COMMENTED",
+				LatestCodexReviewCommitSHA:   "head-ready",
+				LatestCodexReviewSubmittedAt: &oldReview,
+				Reason:                       "ready",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := checkDoctorAutoPromote(context.Background(), "alpha", validDoctorAutoPromoteWorkflow(), doctorDeps{
+				autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+					return &fakeDoctorAutoPromoteConnector{issues: []connector.Issue{tt.issue}}, nil
+				},
+			}, now)
+			if got.Status != doctorOK {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorOK, got)
+			}
+			if len(got.AutoPromoteCandidates) != 1 {
+				t.Fatalf("AutoPromoteCandidates len = %d, want 1: %#v", len(got.AutoPromoteCandidates), got.AutoPromoteCandidates)
+			}
+			if got.AutoPromoteCandidates[0] != tt.want {
+				t.Fatalf("AutoPromoteCandidates[0] = %#v, want %#v", got.AutoPromoteCandidates[0], tt.want)
+			}
+			for _, want := range []string{tt.want.IssueID, tt.want.PRHeadSHA, tt.want.Reason} {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+		})
+	}
+}
+
+func TestWriteDoctorJSONReportIncludesAutoPromoteCandidateDiagnostics(t *testing.T) {
+	t.Parallel()
+
+	reviewedAt := time.Date(2026, 6, 12, 11, 40, 0, 0, time.UTC)
+	report := doctorReport{Checks: []doctorCheck{{
+		Name:   "Project alpha auto-promote",
+		Status: doctorOK,
+		Detail: "sampled 1 Human Review candidate",
+		AutoPromoteCandidates: []doctorAutoPromoteCandidateDiagnostic{{
+			IssueID:                      "issue-stale-review",
+			IssueIdentifier:              "digitaldrywood/detent#399",
+			PRNumber:                     411,
+			PRURL:                        "https://github.test/pull/411",
+			PRHeadSHA:                    "head-current",
+			LatestCodexReviewState:       "COMMENTED",
+			LatestCodexReviewCommitSHA:   "head-previous",
+			LatestCodexReviewSubmittedAt: &reviewedAt,
+			Reason:                       "stale_automated_review",
+		}},
+	}}}
+
+	var output bytes.Buffer
+	if err := json.NewEncoder(&output).Encode(newDoctorOutputReport(report)); err != nil {
+		t.Fatalf("Encode() error = %v", err)
+	}
+
+	var got struct {
+		Checks []struct {
+			AutoPromoteCandidates []doctorAutoPromoteCandidateDiagnostic `json:"auto_promote_candidates"`
+		} `json:"checks"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &got); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v\n%s", err, output.String())
+	}
+	if len(got.Checks) != 1 || len(got.Checks[0].AutoPromoteCandidates) != 1 {
+		t.Fatalf("decoded candidates = %#v, want one candidate", got)
+	}
+	if got.Checks[0].AutoPromoteCandidates[0].Reason != "stale_automated_review" {
+		t.Fatalf("Reason = %q, want stale_automated_review", got.Checks[0].AutoPromoteCandidates[0].Reason)
+	}
+}
+
 func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -589,6 +589,7 @@ type pullRequestNode struct {
 	HeadSHA       string                            `json:"headSHA"`
 	Commits       nodeConnection[pullRequestCommit] `json:"commits"`
 	LatestReviews nodeConnection[pullRequestReview] `json:"latestReviews"`
+	CodexReviews  pullRequestCodexReviews           `json:"-"`
 }
 
 type pullRequestCommit struct {
@@ -610,6 +611,11 @@ type pullRequestReview struct {
 	Author      *actor     `json:"author"`
 	CommitID    string     `json:"commitId"`
 	SubmittedAt *time.Time `json:"submittedAt"`
+}
+
+type pullRequestCodexReviews struct {
+	CurrentHead []pullRequestReview
+	Latest      []pullRequestReview
 }
 
 type actor struct {
@@ -1677,14 +1683,18 @@ func pullRequestNodeFromREST(pullRequest restPullRequest) pullRequestNode {
 
 func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pullRequest pullRequestNode) {
 	issue.PullRequest = &connector.PullRequest{
-		Number:                 pullRequest.Number,
-		URL:                    strings.TrimSpace(pullRequest.URL),
-		BranchName:             strings.TrimSpace(pullRequest.HeadRefName),
-		State:                  strings.ToUpper(strings.TrimSpace(pullRequest.State)),
-		CIStatus:               normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
-		CodexReviewState:       pullRequestCodexReviewState(pullRequest),
-		CodexReviewSubmittedAt: pullRequestCodexReviewSubmittedAt(pullRequest),
-		CodexReviewFindings:    pullRequestCodexReviewFindings(pullRequest),
+		Number:                       pullRequest.Number,
+		URL:                          strings.TrimSpace(pullRequest.URL),
+		BranchName:                   strings.TrimSpace(pullRequest.HeadRefName),
+		State:                        strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+		HeadSHA:                      strings.TrimSpace(pullRequest.HeadSHA),
+		CIStatus:                     normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
+		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
+		CodexReviewSubmittedAt:       pullRequestCodexReviewSubmittedAt(pullRequest),
+		CodexReviewFindings:          pullRequestCodexReviewFindings(pullRequest),
+		LatestCodexReviewState:       pullRequestLatestCodexReviewState(pullRequest),
+		LatestCodexReviewCommitSHA:   pullRequestLatestCodexReviewCommitSHA(pullRequest),
+		LatestCodexReviewSubmittedAt: pullRequestLatestCodexReviewSubmittedAt(pullRequest),
 	}
 	if issue.PRNumber == nil && pullRequest.Number > 0 {
 		number := pullRequest.Number
@@ -1718,7 +1728,8 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	if err != nil {
 		return err
 	}
-	pullRequest.LatestReviews = nodeConnection[pullRequestReview]{Nodes: reviews}
+	pullRequest.LatestReviews = nodeConnection[pullRequestReview]{Nodes: reviews.CurrentHead}
+	pullRequest.CodexReviews = reviews
 	return nil
 }
 
@@ -1734,16 +1745,19 @@ func (c *Connector) fetchPullRequestCIState(ctx context.Context, repo pullReques
 	return combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses)), nil
 }
 
-func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int, headSHA string) ([]pullRequestReview, error) {
+func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int, headSHA string) (pullRequestCodexReviews, error) {
 	response, err := fetchRESTList[restReview](ctx, c.client, restPullRequestReviewsPath(repo, number))
 	if err != nil {
-		return nil, fmt.Errorf("fetch github pull request reviews: %w", err)
+		return pullRequestCodexReviews{}, fmt.Errorf("fetch github pull request reviews: %w", err)
 	}
-	review, ok := latestCodexReview(response, headSHA)
-	if !ok {
-		return nil, nil
+	reviews := pullRequestCodexReviews{}
+	if review, ok := latestCodexReview(response, headSHA); ok {
+		reviews.CurrentHead = []pullRequestReview{review}
 	}
-	return []pullRequestReview{review}, nil
+	if review, ok := latestCodexReview(response, ""); ok {
+		reviews.Latest = []pullRequestReview{review}
+	}
+	return reviews, nil
 }
 
 func (c *Connector) fetchProjectItems(ctx context.Context, queryType string, query string, keepIssue func(connector.Issue) bool) ([]connector.Issue, error) {
@@ -3188,9 +3202,17 @@ func pullRequestReviewAfter(left pullRequestReview, right pullRequestReview) boo
 }
 
 func pullRequestCodexReviewState(pullRequest pullRequestNode) string {
+	return pullRequestCodexReviewStateFromReviews(pullRequest.LatestReviews.Nodes)
+}
+
+func pullRequestLatestCodexReviewState(pullRequest pullRequestNode) string {
+	return pullRequestCodexReviewStateFromReviews(pullRequest.CodexReviews.Latest)
+}
+
+func pullRequestCodexReviewStateFromReviews(reviews []pullRequestReview) string {
 	hasP2 := false
 	reviewState := ""
-	for _, review := range pullRequest.LatestReviews.Nodes {
+	for _, review := range reviews {
 		if containsReviewSeverity(review.Body, "P1") {
 			return "P1"
 		}
@@ -3208,8 +3230,16 @@ func pullRequestCodexReviewState(pullRequest pullRequestNode) string {
 }
 
 func pullRequestCodexReviewSubmittedAt(pullRequest pullRequestNode) *time.Time {
+	return pullRequestCodexReviewSubmittedAtFromReviews(pullRequest.LatestReviews.Nodes)
+}
+
+func pullRequestLatestCodexReviewSubmittedAt(pullRequest pullRequestNode) *time.Time {
+	return pullRequestCodexReviewSubmittedAtFromReviews(pullRequest.CodexReviews.Latest)
+}
+
+func pullRequestCodexReviewSubmittedAtFromReviews(reviews []pullRequestReview) *time.Time {
 	var latest *time.Time
-	for _, review := range pullRequest.LatestReviews.Nodes {
+	for _, review := range reviews {
 		if review.SubmittedAt == nil {
 			continue
 		}
@@ -3219,6 +3249,15 @@ func pullRequestCodexReviewSubmittedAt(pullRequest pullRequestNode) *time.Time {
 		}
 	}
 	return latest
+}
+
+func pullRequestLatestCodexReviewCommitSHA(pullRequest pullRequestNode) string {
+	for _, review := range pullRequest.CodexReviews.Latest {
+		if commitID := strings.TrimSpace(review.CommitID); commitID != "" {
+			return commitID
+		}
+	}
+	return ""
 }
 
 func pullRequestCodexReviewFindings(pullRequest pullRequestNode) []connector.PullRequestFinding {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -720,6 +720,66 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssuesByStatesSurfacesStaleCodexReview(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_401","content":{"__typename":"Issue","id":"I_401","number":401,"title":"Human review issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/401","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"enhancement"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":411,"url":"https://github.com/digitaldrywood/detent/pull/411","state":"OPEN","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/411",
+			body:   `{"number":411,"html_url":"https://github.com/digitaldrywood/detent/pull/411","state":"open","head":{"ref":"detent/digitaldrywood_detent_401","sha":"head-current"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/411/reviews?per_page=100",
+			body:   `[{"body":"No blocking findings on an older head.","state":"COMMENTED","user":{"login":"chatgpt-codex-connector[bot]"},"commit_id":"head-previous","submitted_at":"2026-06-12T11:40:00Z"}]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	pr := got[0].PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want linked PR")
+	}
+	if pr.HeadSHA != "head-current" {
+		t.Fatalf("HeadSHA = %q, want head-current", pr.HeadSHA)
+	}
+	if pr.CIStatus != "pass" {
+		t.Fatalf("CIStatus = %q, want pass", pr.CIStatus)
+	}
+	if pr.CodexReviewState != "" || pr.CodexReviewSubmittedAt != nil {
+		t.Fatalf("current-head Codex review = %q at %v, want none", pr.CodexReviewState, pr.CodexReviewSubmittedAt)
+	}
+	if pr.LatestCodexReviewState != "COMMENTED" || pr.LatestCodexReviewCommitSHA != "head-previous" {
+		t.Fatalf("latest Codex review = state %q commit %q, want COMMENTED/head-previous", pr.LatestCodexReviewState, pr.LatestCodexReviewCommitSHA)
+	}
+	wantSubmittedAt := time.Date(2026, 6, 12, 11, 40, 0, 0, time.UTC)
+	if pr.LatestCodexReviewSubmittedAt == nil || !pr.LatestCodexReviewSubmittedAt.Equal(wantSubmittedAt) {
+		t.Fatalf("LatestCodexReviewSubmittedAt = %v, want %v", pr.LatestCodexReviewSubmittedAt, wantSubmittedAt)
+	}
+}
+
 func TestConnectorFetchIssuesByStatesLimitStopsAfterSample(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -42,14 +42,18 @@ type BlockedRef struct {
 }
 
 type PullRequest struct {
-	Number                 int                  `json:"number,omitempty" yaml:"number,omitempty"`
-	URL                    string               `json:"url,omitempty" yaml:"url,omitempty"`
-	BranchName             string               `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
-	State                  string               `json:"state,omitempty" yaml:"state,omitempty"`
-	CIStatus               string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
-	CodexReviewState       string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
-	CodexReviewSubmittedAt *time.Time           `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`
-	CodexReviewFindings    []PullRequestFinding `json:"codex_review_findings,omitempty" yaml:"codex_review_findings,omitempty"`
+	Number                       int                  `json:"number,omitempty" yaml:"number,omitempty"`
+	URL                          string               `json:"url,omitempty" yaml:"url,omitempty"`
+	BranchName                   string               `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
+	State                        string               `json:"state,omitempty" yaml:"state,omitempty"`
+	HeadSHA                      string               `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
+	CIStatus                     string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
+	CodexReviewState             string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
+	CodexReviewSubmittedAt       *time.Time           `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`
+	CodexReviewFindings          []PullRequestFinding `json:"codex_review_findings,omitempty" yaml:"codex_review_findings,omitempty"`
+	LatestCodexReviewState       string               `json:"latest_codex_review_state,omitempty" yaml:"latest_codex_review_state,omitempty"`
+	LatestCodexReviewCommitSHA   string               `json:"latest_codex_review_commit_sha,omitempty" yaml:"latest_codex_review_commit_sha,omitempty"`
+	LatestCodexReviewSubmittedAt *time.Time           `json:"latest_codex_review_submitted_at,omitempty" yaml:"latest_codex_review_submitted_at,omitempty"`
 }
 
 type PullRequestFinding struct {

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -255,6 +255,10 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 			submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
 			pullRequest.CodexReviewSubmittedAt = &submittedAt
 		}
+		if issue.PullRequest.LatestCodexReviewSubmittedAt != nil {
+			submittedAt := *issue.PullRequest.LatestCodexReviewSubmittedAt
+			pullRequest.LatestCodexReviewSubmittedAt = &submittedAt
+		}
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		issue.PullRequest = &pullRequest
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1468,6 +1468,10 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 				submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
 				pullRequest.CodexReviewSubmittedAt = &submittedAt
 			}
+			if issue.PullRequest.LatestCodexReviewSubmittedAt != nil {
+				submittedAt := *issue.PullRequest.LatestCodexReviewSubmittedAt
+				pullRequest.LatestCodexReviewSubmittedAt = &submittedAt
+			}
 			pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 			cloned[i].PullRequest = &pullRequest
 		}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -196,6 +196,10 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 			submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
 			pullRequest.CodexReviewSubmittedAt = &submittedAt
 		}
+		if issue.PullRequest.LatestCodexReviewSubmittedAt != nil {
+			submittedAt := *issue.PullRequest.LatestCodexReviewSubmittedAt
+			pullRequest.LatestCodexReviewSubmittedAt = &submittedAt
+		}
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		cloned.PullRequest = &pullRequest
 	}


### PR DESCRIPTION
## Summary

- Add per-candidate doctor diagnostics for Human Review auto-promote readiness.
- Surface PR head SHA plus latest Codex review state, reviewed commit, submitted time, and reason in text and JSON reports.
- Preserve current-head review gating while exposing stale latest Codex reviews from GitHub.

Fixes #418

## Test Plan

- [x] `go test ./internal/cli ./internal/connector/github ./internal/connector/memory ./internal/orchestrator`
- [x] `make check`