### PR TITLE
feat(gate): reset quiet on PR activity

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,9 +370,11 @@ plus green CI, no P1 automated PR review findings, a quiet window, and a
 current-head automated PR review before auto-promotion. Set
 `require_automated_review: false` on a command gate when the workflow should
 auto-promote from `Human Review` after a linked open PR, green CI, no P1 bot
-review findings, and the quiet period. Use `kind: human_review` with
-`approval_label` only when the workflow explicitly requires a human approval
-label to promote.
+review findings, and the quiet period. The quiet period resets on observed
+issue updates, Project status updates, automated PR review submission, and
+linked PR activity such as a fresh push to the PR head. Use
+`kind: human_review` with `approval_label` only when the workflow explicitly
+requires a human approval label to promote.
 
 For production, self-hosted, or multi-instance GitHub Projects, prefer GitHub
 App installation authentication instead of a shared personal access token. App
@@ -654,6 +656,10 @@ of that state is controlled by the workflow:
   review to exist.
 - `gate.kind: human_review` requires a linked open PR plus the configured
   `approval_label` on the issue.
+
+The quiet period resets on observed issue updates, Project status updates,
+automated PR review submission, and linked PR activity such as a fresh push to
+the PR head.
 
 A Codex coding session that created the PR is not the same signal as a
 Codex/ChatGPT/Claude GitHub PR review. If automated PR review is required and

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -443,9 +443,10 @@ recommendation, and default-if-silent. Record answers in
    For criteria-based auto-promote, use `agent.auto_promote.enabled`,
    `quiet_seconds`, `optout_label`, `allowed_issue_labels`, and the top-level
    command gate's `require_automated_review` setting. `quiet_seconds` is the
-   quiet period after observed issue/status/review activity, `optout_label` is
-   the per-issue escape hatch, and `allowed_issue_labels` is an allowlist such
-   as `documentation` for low-risk issue classes. When automated review is
+   quiet period after observed issue/status/review activity and linked PR
+   activity such as a fresh push to the PR head, `optout_label` is the
+   per-issue escape hatch, and `allowed_issue_labels` is an allowlist such as
+   `documentation` for low-risk issue classes. When automated review is
    required, a Codex/ChatGPT/Claude review on an older commit does not clear
    this gate. Verify:
 
@@ -787,9 +788,11 @@ recommendation, and default-if-silent. Record answers in
    `require_automated_review: true`, it also requires a current-head automated
    GitHub PR review. With `require_automated_review: false`, bot PR review is
    not required to exist, but any observed P1 bot findings still route the item
-   to `Rework`. `detent doctor --port 0` reports sampled `Human Review`
-   candidates and reasons such as `automated_review_missing` when that gate is
-   not met.
+   to `Rework`. The quiet period resets on observed issue updates, Project
+   status updates, automated PR review submission, and linked PR activity such
+   as a fresh push to the PR head. `detent doctor --port 0` reports sampled
+   `Human Review` candidates and reasons such as `automated_review_missing`
+   when that gate is not met.
 
    Dependency auto-unblock default:
 

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -23,6 +23,9 @@ The execution edge still carries these code/git/PR assumptions.
 - `gate.kind: command` with `require_automated_review: false` keeps the
   command, linked PR, green CI, no-P1, and quiet-period checks but does not
   require an automated GitHub PR review to exist before promotion.
+- The quiet period resets on observed issue updates, Project status updates,
+  automated PR review submission, and linked PR activity such as a fresh push
+  to the PR head.
 - `gate.kind: human_review` requires a PR plus `gate.approval_label`
   (`human-approved` by default) before promotion.
 - `internal/runner/prompt.go` renders gate variables and appends gate

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -585,6 +585,7 @@ type pullRequestNode struct {
 	Number        int                               `json:"number"`
 	URL           string                            `json:"url"`
 	State         string                            `json:"state"`
+	ActivityAt    *time.Time                        `json:"activityAt"`
 	HeadRefName   string                            `json:"headRefName"`
 	HeadSHA       string                            `json:"headSHA"`
 	Commits       nodeConnection[pullRequestCommit] `json:"commits"`
@@ -648,11 +649,12 @@ type restAssignee struct {
 }
 
 type restPullRequest struct {
-	Number   int      `json:"number"`
-	HTMLURL  string   `json:"html_url"`
-	State    string   `json:"state"`
-	Head     restHead `json:"head"`
-	MergedAt *string  `json:"merged_at"`
+	Number    int        `json:"number"`
+	HTMLURL   string     `json:"html_url"`
+	State     string     `json:"state"`
+	Head      restHead   `json:"head"`
+	UpdatedAt *time.Time `json:"updated_at"`
+	MergedAt  *string    `json:"merged_at"`
 }
 
 type restHead struct {
@@ -1549,6 +1551,7 @@ func attachMatchingPullRequestMergeStates(
 				URL:        strings.TrimSpace(pullRequest.URL),
 				BranchName: branchName,
 				State:      strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+				ActivityAt: cloneGitHubTime(pullRequest.ActivityAt),
 			}
 			if issues[candidate.Index].PRNumber == nil && pullRequest.Number > 0 {
 				number := pullRequest.Number
@@ -1676,6 +1679,7 @@ func pullRequestNodeFromREST(pullRequest restPullRequest) pullRequestNode {
 		Number:      pullRequest.Number,
 		URL:         pullRequest.HTMLURL,
 		State:       restPullRequestState(pullRequest),
+		ActivityAt:  cloneGitHubTime(pullRequest.UpdatedAt),
 		HeadRefName: pullRequest.Head.Ref,
 		HeadSHA:     pullRequest.Head.SHA,
 	}
@@ -1687,6 +1691,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		URL:                          strings.TrimSpace(pullRequest.URL),
 		BranchName:                   strings.TrimSpace(pullRequest.HeadRefName),
 		State:                        strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+		ActivityAt:                   cloneGitHubTime(pullRequest.ActivityAt),
 		HeadSHA:                      strings.TrimSpace(pullRequest.HeadSHA),
 		CIStatus:                     normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
@@ -3306,6 +3311,14 @@ func parseGitHubTime(value *string) *time.Time {
 		return nil
 	}
 	return &parsed
+}
+
+func cloneGitHubTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func parseModelOverride(body string) string {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -458,7 +458,7 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
-			body:   `[{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","head":{"ref":"detent/digitaldrywood_detent_182_followup","sha":"sha-187"}},{"number":188,"html_url":"https://github.com/digitaldrywood/detent/pull/188","state":"closed","head":{"ref":"detent/digitaldrywood_detent_181","sha":"sha-188"},"merged_at":"2026-06-01T00:00:00Z"}]`,
+			body:   `[{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","updated_at":"2026-06-05T11:30:00Z","head":{"ref":"detent/digitaldrywood_detent_182_followup","sha":"sha-187"}},{"number":188,"html_url":"https://github.com/digitaldrywood/detent/pull/188","state":"closed","head":{"ref":"detent/digitaldrywood_detent_181","sha":"sha-188"},"merged_at":"2026-06-01T00:00:00Z"}]`,
 		},
 		{
 			method: http.MethodGet,
@@ -500,6 +500,10 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 	}
 	if pr.Number != 187 || pr.State != "OPEN" || pr.BranchName != "detent/digitaldrywood_detent_182_followup" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
 		t.Fatalf("I_182 PullRequest = %#v, want PR 187 open followup", pr)
+	}
+	wantActivityAt := time.Date(2026, 6, 5, 11, 30, 0, 0, time.UTC)
+	if pr.ActivityAt == nil || !pr.ActivityAt.Equal(wantActivityAt) {
+		t.Fatalf("I_182 PullRequest.ActivityAt = %v, want %v", pr.ActivityAt, wantActivityAt)
 	}
 	wantReviewSubmittedAt := time.Date(2026, 6, 5, 11, 0, 0, 0, time.UTC)
 	if pr.CodexReviewSubmittedAt == nil || !pr.CodexReviewSubmittedAt.Equal(wantReviewSubmittedAt) {

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -46,6 +46,7 @@ type PullRequest struct {
 	URL                          string               `json:"url,omitempty" yaml:"url,omitempty"`
 	BranchName                   string               `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	State                        string               `json:"state,omitempty" yaml:"state,omitempty"`
+	ActivityAt                   *time.Time           `json:"activity_at,omitempty" yaml:"activity_at,omitempty"`
 	HeadSHA                      string               `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
 	CIStatus                     string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
 	CodexReviewState             string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -251,6 +251,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	if issue.PullRequest != nil {
 		pullRequest := *issue.PullRequest
+		pullRequest.ActivityAt = cloneTime(issue.PullRequest.ActivityAt)
 		if issue.PullRequest.CodexReviewSubmittedAt != nil {
 			submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
 			pullRequest.CodexReviewSubmittedAt = &submittedAt

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -291,6 +291,44 @@ func TestEvaluateAutoPromote(t *testing.T) {
 	}
 }
 
+func TestAutoPromoteWaitsForFreshPullRequestActivityWithoutAutomatedReview(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 15, 0, 0, 0, time.UTC)
+	oldActivity := now.Add(-30 * time.Minute)
+	recentPullRequestActivity := now.Add(-30 * time.Second)
+	issue := autoPromoteTestIssue("issue-fresh-pr-activity", []string{"bug"})
+	issue.UpdatedAt = &oldActivity
+	issue.PullRequest = &connector.PullRequest{
+		Number:     42,
+		URL:        "https://github.test/digitaldrywood/detent/pull/42",
+		State:      "OPEN",
+		CIStatus:   "pass",
+		ActivityAt: &recentPullRequestActivity,
+	}
+
+	summary := AutoPromoteSummaryFromIssue(issue)
+	if summary.LastActivityAt == nil || !summary.LastActivityAt.Equal(recentPullRequestActivity) {
+		t.Fatalf("LastActivityAt = %v, want pull request activity %v", summary.LastActivityAt, recentPullRequestActivity)
+	}
+
+	got := EvaluateAutoPromote(issue, summary, AutoPromoteConfig{
+		Enabled:       true,
+		QuietDuration: 10 * time.Minute,
+		OptoutLabel:   "requires-human-review",
+		Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+	}, now)
+	if got.Action != AutoPromoteActionAwaitReview {
+		t.Fatalf("Action = %q, want %q", got.Action, AutoPromoteActionAwaitReview)
+	}
+	if got.Reason != AutoPromoteReasonCodexReviewNotQuiet {
+		t.Fatalf("Reason = %q, want %q", got.Reason, AutoPromoteReasonCodexReviewNotQuiet)
+	}
+	if got.QuietRemaining != 570*time.Second {
+		t.Fatalf("QuietRemaining = %s, want 570s", got.QuietRemaining)
+	}
+}
+
 func autoPromoteTestIssue(id string, labels []string) connector.Issue {
 	issue := connector.NewIssue()
 	issue.ID = id

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -80,6 +80,7 @@ func autoPromoteLastActivityAt(issue connector.Issue) *time.Time {
 	latest = latestTime(latest, issue.StageUpdatedAt)
 	latest = latestTime(latest, issue.UpdatedAt)
 	if issue.PullRequest != nil {
+		latest = latestTime(latest, issue.PullRequest.ActivityAt)
 		latest = latestTime(latest, issue.PullRequest.CodexReviewSubmittedAt)
 	}
 	return latest

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1464,6 +1464,10 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 		}
 		if issue.PullRequest != nil {
 			pullRequest := *issue.PullRequest
+			if issue.PullRequest.ActivityAt != nil {
+				activityAt := *issue.PullRequest.ActivityAt
+				pullRequest.ActivityAt = &activityAt
+			}
 			if issue.PullRequest.CodexReviewSubmittedAt != nil {
 				submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
 				pullRequest.CodexReviewSubmittedAt = &submittedAt

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -192,6 +192,10 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	if issue.PullRequest != nil {
 		pullRequest := *issue.PullRequest
+		if issue.PullRequest.ActivityAt != nil {
+			activityAt := *issue.PullRequest.ActivityAt
+			pullRequest.ActivityAt = &activityAt
+		}
 		if issue.PullRequest.CodexReviewSubmittedAt != nil {
 			submittedAt := *issue.PullRequest.CodexReviewSubmittedAt
 			pullRequest.CodexReviewSubmittedAt = &submittedAt


### PR DESCRIPTION
## Summary
- Expose a connector PR activity timestamp from GitHub PR updated_at hydration.
- Include PR activity in the auto-promote quiet-window calculation.
- Document the activity that resets quiet_seconds.

Fixes #420

## Test Plan
- go test ./internal/connector/github ./internal/orchestrator
- make check
