### PR TITLE
feat(test): add isolated dev runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -481,6 +481,25 @@ service owns the port; use `detent doctor --port 0` for the same config,
 toolchain, token, and database preflight without the port collision, then verify
 the live service with `/health`.
 
+For Detent dogfood/self-tests that need a running server, start an isolated mock
+runtime instead of stopping or reusing the live process on `127.0.0.1:4000`:
+
+```sh
+detent dev-runtime \
+  --port 0 \
+  --home "$(mktemp -d)" \
+  --db ':memory:' \
+  --tracker memory \
+  --fixture testdata/dogfood/autopromote.yaml
+```
+
+The command prints `Mode: isolated dev runtime`, the selected dashboard URL,
+temp home, DB mode, tracker mode, and fixture path. By default it uses a temp
+config/workspace home, an in-memory SQLite database, a stateful fixture-backed
+memory tracker, and a fake runner; it does not call GitHub or mutate a real
+ProjectV2 board. It refuses the live dogfood port and live
+`~/.detent/detent.db` unless explicitly overridden.
+
 6. Start Detent:
 
 ```sh

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -196,6 +196,8 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		Logger:             logger,
 		GlobalDispatchGate: globalDispatchGate,
 		GitHubToken:        runtimeGitHubToken.get(),
+		ConnectorFactory:   cfg.ConnectorFactory,
+		Runner:             cfg.Runner,
 	}, runtimeStore, nil, runtimeGitHubToken.get)
 	manager, err := project.NewManager(managerConfigWithRuntimeGitHubToken(cfg.Global, runtimeGitHubToken.get()), project.ManagerDependencies{
 		ProjectFactory: projectFactory,
@@ -544,6 +546,9 @@ func openRuntimeStore(ctx context.Context, cfg BootConfig) (store.Store, error) 
 }
 
 func runtimeStorePath(cfg BootConfig) string {
+	if path := strings.TrimSpace(cfg.RuntimeDBPath); path != "" {
+		return path
+	}
 	path := filepath.Join(filepath.Dir(cfg.Global.Path), "detent.db")
 	if strings.TrimSpace(cfg.Global.Path) == "" {
 		path = filepath.Join(mustGetwd(), ".detent", "detent.db")
@@ -552,6 +557,9 @@ func runtimeStorePath(cfg BootConfig) string {
 }
 
 func runtimeLogPath(cfg BootConfig) string {
+	if path := strings.TrimSpace(cfg.RuntimeLogPath); path != "" {
+		return path
+	}
 	return filepath.Join(filepath.Dir(runtimeStorePath(cfg)), "detent.log")
 }
 
@@ -747,11 +755,11 @@ func printBootBanner(cfg BootConfig, displayURL string) error {
 	if out == nil {
 		out = os.Stdout
 	}
-	_, err := io.WriteString(out, bootBanner(cfg.Version, displayURL))
+	_, err := io.WriteString(out, bootBanner(cfg.Version, displayURL, cfg.Isolated))
 	return err
 }
 
-func bootBanner(version string, displayURL string) string {
+func bootBanner(version string, displayURL string, isolated *IsolatedRuntimeInfo) string {
 	version = strings.TrimSpace(version)
 	if version == "" {
 		version = "dev"
@@ -771,7 +779,29 @@ func bootBanner(version string, displayURL string) string {
 	out.WriteString("Dashboard: ")
 	out.WriteString(displayURL)
 	out.WriteByte('\n')
+	if isolated != nil {
+		out.WriteString("Mode: isolated dev runtime\n")
+		writeBootBannerLine(&out, "Home", isolated.Home)
+		writeBootBannerLine(&out, "Config", isolated.ConfigPath)
+		writeBootBannerLine(&out, "Workflow", isolated.WorkflowPath)
+		writeBootBannerLine(&out, "Workspace root", isolated.WorkspaceRoot)
+		writeBootBannerLine(&out, "DB", isolated.DBPath)
+		writeBootBannerLine(&out, "DB mode", isolated.DBMode)
+		writeBootBannerLine(&out, "Tracker", isolated.TrackerMode)
+		writeBootBannerLine(&out, "Fixture", isolated.FixturePath)
+	}
 	return out.String()
+}
+
+func writeBootBannerLine(out *strings.Builder, label string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	out.WriteString(label)
+	out.WriteString(": ")
+	out.WriteString(value)
+	out.WriteByte('\n')
 }
 
 func mustGetwd() string {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/buildinfo"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
 )
 
@@ -130,19 +131,35 @@ const (
 )
 
 type BootConfig struct {
-	Mode           BootMode
-	Global         globalconfig.Config
-	ConfigPathRule globalconfig.PathRule
-	Runtime        RuntimeSettings
-	WorkflowPath   string
-	Host           string
-	Port           *int
-	Version        string
-	Build          buildinfo.Info
-	Headless       bool
-	StdoutTTY      bool
-	Output         io.Writer
-	Shutdown       *ShutdownController
+	Mode             BootMode
+	Global           globalconfig.Config
+	ConfigPathRule   globalconfig.PathRule
+	Runtime          RuntimeSettings
+	WorkflowPath     string
+	Host             string
+	Port             *int
+	RuntimeDBPath    string
+	RuntimeLogPath   string
+	Isolated         *IsolatedRuntimeInfo
+	Version          string
+	Build            buildinfo.Info
+	Headless         bool
+	StdoutTTY        bool
+	Output           io.Writer
+	Shutdown         *ShutdownController
+	Runner           orchestrator.Runner
+	ConnectorFactory project.ConnectorFactory
+}
+
+type IsolatedRuntimeInfo struct {
+	Home          string
+	ConfigPath    string
+	WorkflowPath  string
+	WorkspaceRoot string
+	DBPath        string
+	DBMode        string
+	TrackerMode   string
+	FixturePath   string
 }
 
 type BootFunc func(context.Context, BootConfig) error
@@ -334,6 +351,7 @@ detent --format json config path`),
 	AddFormatFlag(cmd, &format)
 	cmd.AddCommand(
 		newDoctorCommand(&configPath, &env, &logLevel, &host, &port, opts),
+		newDevRuntimeCommand(&host, &port, opts),
 		newInitCommand(&configPath, opts),
 		newAddProjectCommand(&configPath, opts),
 		newEditProjectCommand(&configPath, opts, OperationPauseProject, "pause", "Pause a project", func(project *globalconfig.Project) error {

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -33,7 +33,7 @@ func TestRootCommandHelpListsAdminCommands(t *testing.T) {
 	}
 
 	output := stdout.String()
-	for _, want := range []string{"detent", "agent orchestrator", "doctor", "init", "add-project", "pause", "unpause", "promote", "remove-project"} {
+	for _, want := range []string{"detent", "agent orchestrator", "doctor", "dev-runtime", "init", "add-project", "pause", "unpause", "promote", "remove-project"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("help output missing %q:\n%s", want, output)
 		}
@@ -159,6 +159,53 @@ func TestRootCommandBootsFromGlobalConfig(t *testing.T) {
 	}
 	if got.ConfigPathRule != globalconfig.PathRuleFlag {
 		t.Fatalf("config path rule = %q, want %q", got.ConfigPathRule, globalconfig.PathRuleFlag)
+	}
+}
+
+func TestDevRuntimeCommandBuildsIsolatedBootConfig(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--host", "127.0.0.2",
+		"--port", "0",
+		"dev-runtime",
+		"--home", home,
+		"--db", "fixture.db",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if got.Isolated == nil {
+		t.Fatal("Isolated = nil, want isolated runtime metadata")
+	}
+	if got.Runner == nil {
+		t.Fatal("Runner = nil, want fake runner override")
+	}
+	if got.ConnectorFactory == nil {
+		t.Fatal("ConnectorFactory = nil, want stateful memory connector factory")
+	}
+	if got.Host != "127.0.0.2" {
+		t.Fatalf("Host = %q, want 127.0.0.2", got.Host)
+	}
+	if got.Port == nil || *got.Port != 0 {
+		t.Fatalf("Port = %v, want 0", got.Port)
+	}
+	if got.RuntimeDBPath != filepath.Join(home, "fixture.db") {
+		t.Fatalf("RuntimeDBPath = %q, want fixture DB under home", got.RuntimeDBPath)
+	}
+	if got.Isolated.DBMode != "file" || got.Isolated.TrackerMode != "memory" {
+		t.Fatalf("isolated metadata = %#v, want file DB and memory tracker", got.Isolated)
 	}
 }
 

--- a/internal/cli/dev_runtime.go
+++ b/internal/cli/dev_runtime.go
@@ -28,9 +28,10 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	var allowProductionPort bool
 
 	cmd := &cobra.Command{
-		Use:   "dev-runtime",
-		Short: "Run an isolated mock Detent runtime for dogfood-safe e2e tests",
-		Args:  NoArgs,
+		Use:     "dev-runtime",
+		Short:   "Run an isolated mock Detent runtime for dogfood-safe e2e tests",
+		Example: devRuntimeExampleCommand,
+		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			if _, err := OutputForCommand(cmd); err != nil {
 				return err

--- a/internal/cli/dev_runtime.go
+++ b/internal/cli/dev_runtime.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/devruntime"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+)
+
+const devRuntimeExampleCommand = "detent dev-runtime --port 0"
+
+func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command {
+	var home string
+	var dbPath string
+	var trackerMode string
+	var fixturePath string
+	var allowLiveDB bool
+	var allowProductionPort bool
+
+	cmd := &cobra.Command{
+		Use:   "dev-runtime",
+		Short: "Run an isolated mock Detent runtime for dogfood-safe e2e tests",
+		Args:  NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if _, err := OutputForCommand(cmd); err != nil {
+				return err
+			}
+
+			runtimePort := derefInt(port, -1)
+			if flagChanged(cmd, "port") {
+				if runtimePort < 0 {
+					return WrapValidation(hintedError(nil, "--port must be greater than or equal to 0", exampleHint(devRuntimeExampleCommand), devRuntimeExampleCommand))
+				}
+			} else {
+				runtimePort = 0
+			}
+
+			runtime, err := devruntime.Build(devruntime.Config{
+				Home:                home,
+				DBPath:              dbPath,
+				TrackerMode:         trackerMode,
+				FixturePath:         fixturePath,
+				Port:                runtimePort,
+				AllowLiveDatabase:   allowLiveDB,
+				AllowProductionPort: allowProductionPort,
+			})
+			if err != nil {
+				return devRuntimeError(err)
+			}
+
+			return opts.boot(cmd.Context(), devRuntimeBootConfig(runtime, derefString(host), opts, cmd.OutOrStdout()))
+		},
+	}
+	cmd.Flags().StringVar(&home, "home", "", "isolated runtime home; a temp directory is created when omitted")
+	cmd.Flags().StringVar(&dbPath, "db", "", "isolated SQLite path or :memory:; relative paths are resolved inside --home")
+	cmd.Flags().StringVar(&trackerMode, "tracker", devruntime.TrackerMemory, "isolated tracker backend")
+	cmd.Flags().StringVar(&fixturePath, "fixture", "", "YAML fixture with mock issues and pull requests")
+	cmd.Flags().BoolVar(&allowLiveDB, "allow-live-db", false, "allow --db to point at the operator's live ~/.detent/detent.db")
+	cmd.Flags().BoolVar(&allowProductionPort, "allow-production-port", false, "allow binding the isolated runtime to the live dogfood port")
+	return cmd
+}
+
+func devRuntimeBootConfig(runtime devruntime.Runtime, host string, opts options, output io.Writer) BootConfig {
+	runtimePort := runtime.Port
+	runtimeHost := strings.TrimSpace(host)
+	if runtimeHost == "" {
+		runtimeHost = defaultWebHost
+	}
+	return BootConfig{
+		Mode:           BootModeRunning,
+		Global:         runtime.Global,
+		ConfigPathRule: globalconfig.PathRuleFlag,
+		Runtime: RuntimeSettings{
+			ConfigPath: RuntimeValue{Value: runtime.ConfigPath, Source: runtimeSourceFlag},
+			Env:        RuntimeValue{Value: "dev", Source: runtimeSourceDefault},
+			LogLevel:   RuntimeValue{Value: "info", Source: runtimeSourceDefault},
+			Port:       RuntimeIntValue{Value: runtimePort, Source: runtimeSourceFlag},
+			GitHubToken: RuntimeSecret{
+				Required: false,
+			},
+		},
+		WorkflowPath:     runtime.WorkflowPath,
+		Host:             runtimeHost,
+		Port:             &runtimePort,
+		RuntimeDBPath:    runtime.DBPath,
+		RuntimeLogPath:   filepath.Join(runtime.Home, "detent.log"),
+		Isolated:         devRuntimeIsolationInfo(runtime),
+		Version:          opts.version,
+		Build:            opts.build,
+		Headless:         true,
+		StdoutTTY:        false,
+		Output:           output,
+		Runner:           orchestrator.FakeRunner{},
+		ConnectorFactory: devRuntimeConnectorFactory,
+	}
+}
+
+func devRuntimeIsolationInfo(runtime devruntime.Runtime) *IsolatedRuntimeInfo {
+	return &IsolatedRuntimeInfo{
+		Home:          runtime.Home,
+		ConfigPath:    runtime.ConfigPath,
+		WorkflowPath:  runtime.WorkflowPath,
+		WorkspaceRoot: runtime.WorkspaceRoot,
+		DBPath:        runtime.DBPath,
+		DBMode:        runtime.DBMode,
+		TrackerMode:   runtime.TrackerMode,
+		FixturePath:   runtime.FixturePath,
+	}
+}
+
+func devRuntimeConnectorFactory(cfg workflowconfig.Config) (connector.Connector, error) {
+	if cfg.Tracker.Kind != workflowconfig.TrackerMemory {
+		return nil, fmt.Errorf("%w: %s", devruntime.ErrUnsupportedTracker, cfg.Tracker.Kind)
+	}
+	return memory.New(memory.Config{
+		Issues:   cfg.Tracker.Issues,
+		Stateful: true,
+	}), nil
+}
+
+func devRuntimeError(err error) error {
+	if err == nil {
+		return nil
+	}
+	switch {
+	case errors.Is(err, devruntime.ErrLivePort):
+		return WrapValidation(hintedError(err, err.Error(), exampleHint(devRuntimeExampleCommand), devRuntimeExampleCommand))
+	case errors.Is(err, devruntime.ErrLiveDatabase):
+		return WrapValidation(hintedError(err, err.Error(), "Use the default :memory: DB or a path under --home for isolated tests.", "detent dev-runtime --db :memory:"))
+	default:
+		return err
+	}
+}

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -1,0 +1,148 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/devruntime"
+)
+
+func TestStartIsolatedRuntimeAutoPromotesFixtureAndStopsOnCancel(t *testing.T) {
+	runtime, err := devruntime.Build(devruntime.Config{Home: t.TempDir(), Port: 0})
+	if err != nil {
+		t.Fatalf("devruntime.Build() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	output := &lockedBuffer{}
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, devRuntimeBootConfig(runtime, "127.0.0.1", defaultOptions(), output))
+	}()
+	t.Cleanup(cancel)
+
+	url := waitForIsolatedRuntimeURL(t, output, done)
+	if banner := output.String(); !strings.Contains(banner, "Mode: isolated dev runtime") || !strings.Contains(banner, "DB mode: memory") {
+		t.Fatalf("isolated runtime banner missing isolation details:\n%s", banner)
+	}
+	waitForDashboard(t, url+"/health", done)
+	postRuntimeRefresh(t, url, done)
+
+	body := waitForDashboardCondition(t, url+"/api/v1/state", done, "mock issue promoted to Merging", func(body string) bool {
+		return boardStateCountFromBody(t, body, "Merging") == 1
+	})
+	if !strings.Contains(body, `"status":"running"`) {
+		t.Fatalf("state response missing running status:\n%s", body)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for isolated runtime to stop")
+	}
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+func waitForIsolatedRuntimeURL(t *testing.T, output *lockedBuffer, done <-chan error) string {
+	t.Helper()
+
+	deadline := time.After(10 * time.Second)
+	for {
+		select {
+		case err := <-done:
+			t.Fatalf("isolated runtime stopped before banner: %v", err)
+		case <-deadline:
+			t.Fatalf("timed out waiting for isolated runtime banner:\n%s", output.String())
+		default:
+		}
+
+		for _, line := range strings.Split(output.String(), "\n") {
+			url, ok := strings.CutPrefix(line, "Dashboard: ")
+			if ok && strings.TrimSpace(url) != "" {
+				return strings.TrimSpace(url)
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+}
+
+func postRuntimeRefresh(t *testing.T, url string, done <-chan error) {
+	t.Helper()
+
+	client := http.Client{Timeout: time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for ctx.Err() == nil {
+		select {
+		case err := <-done:
+			t.Fatalf("isolated runtime stopped before refresh: %v", err)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, url+"/api/v1/refresh", nil)
+		if err != nil {
+			t.Fatalf("NewRequestWithContext() error = %v", err)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			if closeErr := resp.Body.Close(); closeErr != nil {
+				t.Fatalf("Body.Close() error = %v", closeErr)
+			}
+			if resp.StatusCode == http.StatusAccepted {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out posting runtime refresh to %s", url)
+}
+
+func boardStateCountFromBody(t *testing.T, body string, state string) int {
+	t.Helper()
+
+	var payload struct {
+		Board struct {
+			StateDistribution []struct {
+				State string `json:"state"`
+				Count int    `json:"count"`
+			} `json:"state_distribution"`
+		} `json:"board"`
+	}
+	if err := json.Unmarshal([]byte(body), &payload); err != nil {
+		return 0
+	}
+	for _, entry := range payload.Board.StateDistribution {
+		if entry.State == state {
+			return entry.Count
+		}
+	}
+	return 0
+}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -54,9 +54,13 @@ func withRunnerFactory(
 			workflow.Config.Identity.Normalize()
 		}
 
-		run, err := buildRunner(workflow, cfg.ID, cfg.Workdir, sessionStore, deps.Logger)
-		if err != nil {
-			return nil, fmt.Errorf("build project runner %s: %w", cfg.ID, err)
+		run := deps.Runner
+		if run == nil {
+			var err error
+			run, err = buildRunner(workflow, cfg.ID, cfg.Workdir, sessionStore, deps.Logger)
+			if err != nil {
+				return nil, fmt.Errorf("build project runner %s: %w", cfg.ID, err)
+			}
 		}
 
 		projectDeps := deps

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -3,6 +3,7 @@ package memory
 import (
 	"context"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -34,11 +35,16 @@ type EventSink func(Event)
 type Config struct {
 	Issues    []connector.Issue
 	EventSink EventSink
+	Stateful  bool
+	Now       func() time.Time
 }
 
 type Connector struct {
 	issues    []connector.Issue
 	eventSink EventSink
+	stateful  bool
+	now       func() time.Time
+	mu        sync.RWMutex
 }
 
 var _ connector.Connector = (*Connector)(nil)
@@ -49,9 +55,15 @@ var _ connector.IssueParentResolver = (*Connector)(nil)
 var _ connector.IssueReferenceResolver = (*Connector)(nil)
 
 func New(cfg Config) *Connector {
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
 	return &Connector{
 		issues:    cloneIssues(cfg.Issues),
 		eventSink: cfg.EventSink,
+		stateful:  cfg.Stateful,
+		now:       now,
 	}
 }
 
@@ -64,10 +76,16 @@ func (c *Connector) InstanceLogin() string {
 }
 
 func (c *Connector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	return cloneIssues(c.issues), nil
 }
 
 func (c *Connector) FetchIssuesByStates(_ context.Context, stateNames []string) ([]connector.Issue, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	wantedStates := make(map[string]struct{}, len(stateNames))
 	for _, stateName := range stateNames {
 		wantedStates[normalizeState(stateName)] = struct{}{}
@@ -84,6 +102,9 @@ func (c *Connector) FetchIssuesByStates(_ context.Context, stateNames []string) 
 }
 
 func (c *Connector) FetchIssueStatesByIDs(_ context.Context, issueIDs []string) ([]connector.Issue, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	wantedIDs := make(map[string]struct{}, len(issueIDs))
 	for _, issueID := range issueIDs {
 		wantedIDs[issueID] = struct{}{}
@@ -100,6 +121,9 @@ func (c *Connector) FetchIssueStatesByIDs(_ context.Context, issueIDs []string) 
 }
 
 func (c *Connector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	wantedIdentifiers := make(map[string]struct{}, len(identifiers))
 	for _, identifier := range identifiers {
 		wantedIdentifiers[normalizeState(identifier)] = struct{}{}
@@ -116,6 +140,9 @@ func (c *Connector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers
 }
 
 func (c *Connector) FetchIssueParents(_ context.Context, issueID string) ([]connector.Issue, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	issueID = strings.TrimSpace(issueID)
 	if issueID == "" {
 		return []connector.Issue{}, nil
@@ -153,6 +180,9 @@ func (c *Connector) FetchIssueParents(_ context.Context, issueID string) ([]conn
 }
 
 func (c *Connector) FetchIssueChildren(_ context.Context, issueID string) ([]connector.BlockedRef, error) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
 	for _, issue := range c.issues {
 		if issue.ID == issueID {
 			return append([]connector.BlockedRef(nil), issue.ChildIssues...), nil
@@ -167,23 +197,68 @@ func (c *Connector) CreateComment(_ context.Context, issueID string, body string
 }
 
 func (c *Connector) CloseIssue(_ context.Context, issueID string) error {
+	c.applyIssue(issueID, func(issue *connector.Issue, now time.Time) {
+		issue.Closed = true
+		issue.UpdatedAt = &now
+	})
 	c.send(Event{Kind: EventKindClose, IssueID: issueID})
 	return nil
 }
 
 func (c *Connector) UpdateIssueState(_ context.Context, issueID string, stateName string) error {
+	c.applyIssue(issueID, func(issue *connector.Issue, now time.Time) {
+		issue.State = stateName
+		issue.StageUpdatedAt = &now
+		issue.UpdatedAt = &now
+		if issue.Fields == nil {
+			issue.Fields = map[string]string{}
+		}
+		issue.Fields["Status"] = stateName
+	})
 	c.send(Event{Kind: EventKindStateUpdate, IssueID: issueID, State: stateName})
 	return nil
 }
 
 func (c *Connector) SetAssignee(_ context.Context, issueID string, login string) error {
+	c.applyIssue(issueID, func(issue *connector.Issue, now time.Time) {
+		issue.AssigneeID = login
+		if !stringSliceContains(issue.Assignees, login) {
+			issue.Assignees = append(issue.Assignees, login)
+		}
+		issue.UpdatedAt = &now
+	})
 	c.send(Event{Kind: EventKindAssigneeUpdate, IssueID: issueID, Login: login})
 	return nil
 }
 
 func (c *Connector) SetField(_ context.Context, issueID string, fieldName string, value string) error {
+	c.applyIssue(issueID, func(issue *connector.Issue, now time.Time) {
+		if issue.Fields == nil {
+			issue.Fields = map[string]string{}
+		}
+		issue.Fields[fieldName] = value
+		issue.UpdatedAt = &now
+	})
 	c.send(Event{Kind: EventKindFieldUpdate, IssueID: issueID, FieldName: fieldName, FieldValue: value})
 	return nil
+}
+
+func (c *Connector) applyIssue(issueID string, update func(*connector.Issue, time.Time)) {
+	if !c.stateful {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	now := c.now()
+	for index := range c.issues {
+		if c.issues[index].ID != issueID {
+			continue
+		}
+		update(&c.issues[index], now)
+		return
+	}
 }
 
 func (c *Connector) send(event Event) {
@@ -304,4 +379,13 @@ func cloneTime(value *time.Time) *time.Time {
 
 	cloned := *value
 	return &cloned
+}
+
+func stringSliceContains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/connector/memory/memory_test.go
+++ b/internal/connector/memory/memory_test.go
@@ -279,6 +279,61 @@ func TestConnectorMutationsMatchElixirMemoryAdapter(t *testing.T) {
 	}
 }
 
+func TestConnectorStatefulMutationsUpdateFixtureState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 14, 12, 30, 0, 0, time.UTC)
+	c := New(Config{
+		Issues: []connector.Issue{{
+			ID:        "issue-1",
+			State:     "Human Review",
+			Assignees: []string{"worker-0"},
+			Fields:    map[string]string{"Status": "Human Review"},
+		}},
+		Stateful: true,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	if err := c.UpdateIssueState(context.Background(), "issue-1", "Merging"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+	if err := c.SetAssignee(context.Background(), "issue-1", "worker-1"); err != nil {
+		t.Fatalf("SetAssignee() error = %v", err)
+	}
+	if err := c.SetField(context.Background(), "issue-1", "Train", "ready"); err != nil {
+		t.Fatalf("SetField() error = %v", err)
+	}
+	if err := c.CloseIssue(context.Background(), "issue-1"); err != nil {
+		t.Fatalf("CloseIssue() error = %v", err)
+	}
+
+	issues, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	got := issues[0]
+	if got.State != "Merging" {
+		t.Fatalf("State = %q, want Merging", got.State)
+	}
+	if !got.Closed {
+		t.Fatal("Closed = false, want true")
+	}
+	if got.Fields["Status"] != "Merging" || got.Fields["Train"] != "ready" {
+		t.Fatalf("Fields = %#v, want updated Status and Train", got.Fields)
+	}
+	if !reflect.DeepEqual(got.Assignees, []string{"worker-0", "worker-1"}) {
+		t.Fatalf("Assignees = %#v, want worker-0 and worker-1", got.Assignees)
+	}
+	if got.UpdatedAt == nil || !got.UpdatedAt.Equal(now) {
+		t.Fatalf("UpdatedAt = %v, want %v", got.UpdatedAt, now)
+	}
+	if got.StageUpdatedAt == nil || !got.StageUpdatedAt.Equal(now) {
+		t.Fatalf("StageUpdatedAt = %v, want %v", got.StageUpdatedAt, now)
+	}
+}
+
 func TestConnectorMutationsNoopWithoutEventSink(t *testing.T) {
 	t.Parallel()
 

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -3,6 +3,7 @@ package devruntime
 import (
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -166,10 +167,42 @@ func runtimeDBPath(home string, path string, allowLive bool) (string, error) {
 			path = filepath.Join(home, path)
 		}
 	}
-	if !allowLive && samePath(path, liveDatabasePath()) {
+	guardPath := path
+	if uriPath, ok := sqliteURIFilePath(path); ok {
+		guardPath = uriPath
+	}
+	if !allowLive && samePath(guardPath, liveDatabasePath()) {
 		return "", fmt.Errorf("%w: %s", ErrLiveDatabase, path)
 	}
 	return path, nil
+}
+
+func sqliteURIFilePath(path string) (string, bool) {
+	path = strings.TrimSpace(path)
+	if !strings.HasPrefix(strings.ToLower(path), "file:") {
+		return "", false
+	}
+	parsed, err := url.Parse(path)
+	if err != nil {
+		return "", false
+	}
+	if strings.EqualFold(parsed.Query().Get("mode"), "memory") {
+		return "", false
+	}
+
+	candidate := parsed.Path
+	if candidate == "" {
+		candidate = parsed.Opaque
+	}
+	candidate = strings.TrimSpace(candidate)
+	if candidate == "" || strings.HasPrefix(candidate, ":memory:") {
+		return "", false
+	}
+	unescaped, err := url.PathUnescape(candidate)
+	if err == nil {
+		candidate = unescaped
+	}
+	return filepath.FromSlash(candidate), true
 }
 
 func liveDatabasePath() string {

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -1,0 +1,472 @@
+package devruntime
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const (
+	TrackerMemory = "memory"
+
+	defaultProjectID    = "dogfood"
+	defaultInstanceName = "detent-dev-runtime"
+	defaultHost         = "127.0.0.1"
+	defaultDBPath       = ":memory:"
+	liveDogfoodPort     = 4000
+)
+
+var (
+	ErrUnsupportedTracker = errors.New("unsupported isolated runtime tracker")
+	ErrLiveDatabase       = errors.New("isolated runtime refuses the live Detent database")
+	ErrLivePort           = errors.New("isolated runtime refuses the live Detent port")
+	ErrInvalidPort        = errors.New("isolated runtime port must be greater than or equal to 0")
+)
+
+type Config struct {
+	Home                string
+	DBPath              string
+	TrackerMode         string
+	FixturePath         string
+	Port                int
+	AllowLiveDatabase   bool
+	AllowProductionPort bool
+}
+
+type Runtime struct {
+	Home          string
+	ConfigPath    string
+	WorkflowPath  string
+	WorkspaceRoot string
+	SourceRoot    string
+	DBPath        string
+	DBMode        string
+	TrackerMode   string
+	FixturePath   string
+	Port          int
+	Global        globalconfig.Config
+	Issues        []connector.Issue
+}
+
+func Build(cfg Config) (Runtime, error) {
+	if cfg.Port < 0 {
+		return Runtime{}, fmt.Errorf("%w: %d", ErrInvalidPort, cfg.Port)
+	}
+	if cfg.Port == liveDogfoodPort && !cfg.AllowProductionPort {
+		return Runtime{}, fmt.Errorf("%w: port %d is reserved for the live dogfood instance; use --port 0", ErrLivePort, liveDogfoodPort)
+	}
+
+	trackerMode := strings.ToLower(strings.TrimSpace(cfg.TrackerMode))
+	if trackerMode == "" {
+		trackerMode = TrackerMemory
+	}
+	if trackerMode != TrackerMemory {
+		return Runtime{}, fmt.Errorf("%w: %s", ErrUnsupportedTracker, trackerMode)
+	}
+
+	home, err := runtimeHome(cfg.Home)
+	if err != nil {
+		return Runtime{}, err
+	}
+	if err := os.MkdirAll(home, 0o755); err != nil {
+		return Runtime{}, fmt.Errorf("create isolated runtime home: %w", err)
+	}
+
+	dbPath, err := runtimeDBPath(home, cfg.DBPath, cfg.AllowLiveDatabase)
+	if err != nil {
+		return Runtime{}, err
+	}
+	workspaceRoot := filepath.Join(home, "workspaces")
+	sourceRoot := filepath.Join(home, "source")
+	for _, dir := range []string{workspaceRoot, sourceRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return Runtime{}, fmt.Errorf("create isolated runtime directory %s: %w", dir, err)
+		}
+	}
+
+	issues, fixturePath, err := runtimeIssues(cfg.FixturePath)
+	if err != nil {
+		return Runtime{}, err
+	}
+
+	workflowPath := filepath.Join(home, "WORKFLOW.md")
+	if err := writeWorkflow(workflowPath, workflowInput{
+		TrackerMode:   trackerMode,
+		WorkspaceRoot: workspaceRoot,
+		SourceRoot:    sourceRoot,
+		Port:          cfg.Port,
+		Issues:        issues,
+	}); err != nil {
+		return Runtime{}, err
+	}
+
+	configPath := filepath.Join(home, "global.yaml")
+	global := globalConfig(configPath, workflowPath, sourceRoot, cfg.Port)
+	if err := globalconfig.Write(configPath, global); err != nil {
+		return Runtime{}, fmt.Errorf("write isolated global config: %w", err)
+	}
+	global.Path = configPath
+
+	return Runtime{
+		Home:          home,
+		ConfigPath:    configPath,
+		WorkflowPath:  workflowPath,
+		WorkspaceRoot: workspaceRoot,
+		SourceRoot:    sourceRoot,
+		DBPath:        dbPath,
+		DBMode:        dbMode(dbPath),
+		TrackerMode:   trackerMode,
+		FixturePath:   fixturePath,
+		Port:          cfg.Port,
+		Global:        global,
+		Issues:        append([]connector.Issue(nil), issues...),
+	}, nil
+}
+
+func runtimeHome(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		home, err := os.MkdirTemp("", "detent-dev-runtime-*")
+		if err != nil {
+			return "", fmt.Errorf("create isolated runtime home: %w", err)
+		}
+		return home, nil
+	}
+	expanded, err := expandHome(path)
+	if err != nil {
+		return "", err
+	}
+	absolute, err := filepath.Abs(expanded)
+	if err != nil {
+		return "", fmt.Errorf("resolve isolated runtime home: %w", err)
+	}
+	return absolute, nil
+}
+
+func runtimeDBPath(home string, path string, allowLive bool) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = defaultDBPath
+	}
+	if path != defaultDBPath && !strings.HasPrefix(path, "file:") {
+		expanded, err := expandHome(path)
+		if err != nil {
+			return "", err
+		}
+		path = expanded
+		if !filepath.IsAbs(path) {
+			path = filepath.Join(home, path)
+		}
+	}
+	if !allowLive && samePath(path, liveDatabasePath()) {
+		return "", fmt.Errorf("%w: %s", ErrLiveDatabase, path)
+	}
+	return path, nil
+}
+
+func liveDatabasePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || strings.TrimSpace(home) == "" {
+		return ""
+	}
+	return filepath.Join(home, ".detent", "detent.db")
+}
+
+func samePath(left string, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if left == "" || right == "" {
+		return false
+	}
+	leftAbs, leftErr := filepath.Abs(left)
+	rightAbs, rightErr := filepath.Abs(right)
+	if leftErr == nil {
+		left = leftAbs
+	}
+	if rightErr == nil {
+		right = rightAbs
+	}
+	return filepath.Clean(left) == filepath.Clean(right)
+}
+
+func expandHome(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "~" || strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve user home: %w", err)
+		}
+		if path == "~" {
+			return home, nil
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	return path, nil
+}
+
+type fixtureFile struct {
+	Issues []connector.Issue `yaml:"issues"`
+}
+
+func runtimeIssues(path string) ([]connector.Issue, string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return defaultIssues(), "", nil
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("read isolated runtime fixture: %w", err)
+	}
+	var fixture fixtureFile
+	if err := yaml.Unmarshal(raw, &fixture); err != nil {
+		return nil, "", fmt.Errorf("decode isolated runtime fixture: %w", err)
+	}
+	if len(fixture.Issues) == 0 {
+		return nil, "", fmt.Errorf("decode isolated runtime fixture: issues must not be empty")
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return nil, "", fmt.Errorf("resolve isolated runtime fixture: %w", err)
+	}
+	return fixture.Issues, absolute, nil
+}
+
+func defaultIssues() []connector.Issue {
+	reviewedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	updatedAt := reviewedAt
+	p1Line := 42
+	return []connector.Issue{
+		{
+			ID:               "mock-issue-autopromote",
+			Identifier:       "digitaldrywood/detent#9001",
+			Title:            "Dogfood auto-promote fixture",
+			Description:      "Safe fixture issue for isolated runtime auto-promote validation.",
+			State:            "Human Review",
+			URL:              "https://github.test/digitaldrywood/detent/issues/9001",
+			Labels:           []string{"enhancement", "stage:s7"},
+			AssignedToWorker: true,
+			UpdatedAt:        &updatedAt,
+			StageUpdatedAt:   &updatedAt,
+			PullRequest: &connector.PullRequest{
+				Number:                 9001,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/9001",
+				BranchName:             "detent/mock-issue-autopromote",
+				State:                  "OPEN",
+				CIStatus:               "success",
+				CodexReviewState:       "COMMENTED",
+				CodexReviewSubmittedAt: &reviewedAt,
+			},
+		},
+		{
+			ID:               "mock-issue-review-finding",
+			Identifier:       "digitaldrywood/detent#9002",
+			Title:            "Dogfood review finding fixture",
+			State:            "Human Review",
+			URL:              "https://github.test/digitaldrywood/detent/issues/9002",
+			Labels:           []string{"bug", "stage:s7"},
+			AssignedToWorker: true,
+			UpdatedAt:        &updatedAt,
+			StageUpdatedAt:   &updatedAt,
+			PullRequest: &connector.PullRequest{
+				Number:                 9002,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/9002",
+				BranchName:             "detent/mock-issue-review-finding",
+				State:                  "OPEN",
+				CIStatus:               "success",
+				CodexReviewState:       "P1",
+				CodexReviewSubmittedAt: &reviewedAt,
+				CodexReviewFindings: []connector.PullRequestFinding{{
+					Body: "P1 mock finding",
+					URL:  "https://github.test/digitaldrywood/detent/pull/9002#discussion_r1",
+					Path: "internal/mock.go",
+					Line: p1Line,
+				}},
+			},
+		},
+		{
+			ID:               "mock-issue-resume",
+			Identifier:       "digitaldrywood/detent#9003",
+			Title:            "Dogfood restart resume fixture",
+			State:            "In Progress",
+			URL:              "https://github.test/digitaldrywood/detent/issues/9003",
+			Labels:           []string{"enhancement", "stage:s7"},
+			AssignedToWorker: true,
+			UpdatedAt:        &updatedAt,
+			StageUpdatedAt:   &updatedAt,
+			PullRequest: &connector.PullRequest{
+				Number:     9003,
+				URL:        "https://github.test/digitaldrywood/detent/pull/9003",
+				BranchName: "detent/mock-issue-resume",
+				State:      "OPEN",
+				CIStatus:   "pending",
+			},
+		},
+		{
+			ID:               "mock-issue-merged",
+			Identifier:       "digitaldrywood/detent#9004",
+			Title:            "Dogfood merged PR fixture",
+			State:            "Done",
+			URL:              "https://github.test/digitaldrywood/detent/issues/9004",
+			Labels:           []string{"enhancement", "stage:s7"},
+			AssignedToWorker: true,
+			Closed:           true,
+			UpdatedAt:        &updatedAt,
+			StageUpdatedAt:   &updatedAt,
+			PullRequest: &connector.PullRequest{
+				Number:     9004,
+				URL:        "https://github.test/digitaldrywood/detent/pull/9004",
+				BranchName: "detent/mock-issue-merged",
+				State:      "MERGED",
+				CIStatus:   "success",
+			},
+		},
+	}
+}
+
+type workflowInput struct {
+	TrackerMode   string
+	WorkspaceRoot string
+	SourceRoot    string
+	Port          int
+	Issues        []connector.Issue
+}
+
+type workflowFrontmatter struct {
+	Tracker   workflowTracker   `yaml:"tracker"`
+	Polling   workflowPolling   `yaml:"polling"`
+	Workspace workflowWorkspace `yaml:"workspace"`
+	Agent     workflowAgent     `yaml:"agent"`
+	Gate      workflowGate      `yaml:"gate"`
+	Server    workflowServer    `yaml:"server"`
+}
+
+type workflowTracker struct {
+	Kind           string            `yaml:"kind"`
+	ActiveStates   []string          `yaml:"active_states"`
+	ObservedStates []string          `yaml:"observed_states"`
+	TerminalStates []string          `yaml:"terminal_states"`
+	StateMap       map[string]string `yaml:"state_map"`
+	Issues         []connector.Issue `yaml:"issues"`
+}
+
+type workflowPolling struct {
+	IntervalMS int `yaml:"interval_ms"`
+}
+
+type workflowWorkspace struct {
+	Root       string `yaml:"root"`
+	SourceRoot string `yaml:"source_root"`
+	AutoBranch bool   `yaml:"auto_branch"`
+}
+
+type workflowAgent struct {
+	MaxConcurrentAgents        int                 `yaml:"max_concurrent_agents"`
+	MaxConcurrentAgentsByState map[string]int      `yaml:"max_concurrent_agents_by_state"`
+	AutoPromote                workflowAutoPromote `yaml:"auto_promote"`
+}
+
+type workflowAutoPromote struct {
+	Enabled      bool   `yaml:"enabled"`
+	QuietSeconds int    `yaml:"quiet_seconds"`
+	OptoutLabel  string `yaml:"optout_label"`
+}
+
+type workflowGate struct {
+	Kind                   string `yaml:"kind"`
+	Run                    string `yaml:"run"`
+	RequireAutomatedReview bool   `yaml:"require_automated_review"`
+}
+
+type workflowServer struct {
+	Host string `yaml:"host"`
+	Port *int   `yaml:"port"`
+}
+
+func writeWorkflow(path string, input workflowInput) error {
+	port := input.Port
+	frontmatter := workflowFrontmatter{
+		Tracker: workflowTracker{
+			Kind:           input.TrackerMode,
+			ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+			ObservedStates: []string{"Backlog", "Human Review", "Blocked", "Merging", "Done"},
+			TerminalStates: []string{"Done", "Cancelled", "Canceled"},
+			StateMap:       map[string]string{},
+			Issues:         append([]connector.Issue(nil), input.Issues...),
+		},
+		Polling: workflowPolling{IntervalMS: 60000},
+		Workspace: workflowWorkspace{
+			Root:       input.WorkspaceRoot,
+			SourceRoot: input.SourceRoot,
+			AutoBranch: true,
+		},
+		Agent: workflowAgent{
+			MaxConcurrentAgents:        2,
+			MaxConcurrentAgentsByState: map[string]int{"Merging": 1},
+			AutoPromote: workflowAutoPromote{
+				Enabled:      true,
+				QuietSeconds: 0,
+				OptoutLabel:  "requires-human-review",
+			},
+		},
+		Gate: workflowGate{
+			Kind:                   "command",
+			Run:                    "true",
+			RequireAutomatedReview: true,
+		},
+		Server: workflowServer{
+			Host: defaultHost,
+			Port: &port,
+		},
+	}
+	raw, err := yaml.Marshal(frontmatter)
+	if err != nil {
+		return fmt.Errorf("marshal isolated workflow: %w", err)
+	}
+	content := "---\n" + string(raw) + "---\nIsolated mock Detent runtime for dogfood-safe e2e validation.\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write isolated workflow: %w", err)
+	}
+	return nil
+}
+
+func globalConfig(path string, workflowPath string, sourceRoot string, port int) globalconfig.Config {
+	return globalconfig.Config{
+		Path:         path,
+		APIVersion:   globalconfig.APIVersion,
+		Kind:         globalconfig.Kind,
+		Port:         &port,
+		InstanceName: defaultInstanceName,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 2,
+			Scheduling:          globalconfig.SchedulingWeighted,
+			Startup: map[string]any{
+				"jitter_seconds":       0,
+				"max_spawn_per_second": 100,
+			},
+		},
+		Projects: []globalconfig.Project{{
+			ID:       defaultProjectID,
+			Workflow: workflowPath,
+			Workdir:  sourceRoot,
+			Weight:   1,
+			Priority: 1,
+		}},
+	}
+}
+
+func dbMode(path string) string {
+	path = strings.TrimSpace(path)
+	if path == defaultDBPath || strings.Contains(path, "mode=memory") {
+		return "memory"
+	}
+	return "file"
+}

--- a/internal/devruntime/runtime_test.go
+++ b/internal/devruntime/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -113,6 +114,11 @@ func TestBuildRejectsUnsafeRuntimeInputs(t *testing.T) {
 			cfg:  Config{Home: t.TempDir(), DBPath: liveDatabasePath()},
 			want: ErrLiveDatabase,
 		},
+		{
+			name: "live database sqlite file uri",
+			cfg:  Config{Home: t.TempDir(), DBPath: sqliteLiveDatabaseURI()},
+			want: ErrLiveDatabase,
+		},
 	}
 
 	for _, tt := range tests {
@@ -143,4 +149,24 @@ func TestBuildAllowsExplicitUnsafeOverrides(t *testing.T) {
 	if runtime.Port != liveDogfoodPort {
 		t.Fatalf("Port = %d, want %d", runtime.Port, liveDogfoodPort)
 	}
+}
+
+func TestBuildAllowsNamedSharedMemoryURI(t *testing.T) {
+	t.Parallel()
+
+	dbPath := "file:detent-dev-runtime?mode=memory&cache=shared"
+	runtime, err := Build(Config{
+		Home:   t.TempDir(),
+		DBPath: dbPath,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if runtime.DBPath != dbPath || runtime.DBMode != "memory" {
+		t.Fatalf("DB = %q mode %q, want shared memory URI", runtime.DBPath, runtime.DBMode)
+	}
+}
+
+func sqliteLiveDatabaseURI() string {
+	return "file:" + strings.ReplaceAll(filepath.ToSlash(liveDatabasePath()), " ", "%20") + "?mode=rw"
 }

--- a/internal/devruntime/runtime_test.go
+++ b/internal/devruntime/runtime_test.go
@@ -1,0 +1,146 @@
+package devruntime
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestBuildCreatesIsolatedRuntimeDefaults(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := Build(Config{Home: t.TempDir(), Port: 0})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+
+	if runtime.DBPath != defaultDBPath || runtime.DBMode != "memory" {
+		t.Fatalf("DB = %q mode %q, want :memory: memory", runtime.DBPath, runtime.DBMode)
+	}
+	if runtime.TrackerMode != TrackerMemory {
+		t.Fatalf("TrackerMode = %q, want %q", runtime.TrackerMode, TrackerMemory)
+	}
+	if runtime.Global.Path != runtime.ConfigPath {
+		t.Fatalf("Global.Path = %q, want %q", runtime.Global.Path, runtime.ConfigPath)
+	}
+	for _, path := range []string{runtime.Home, runtime.ConfigPath, runtime.WorkflowPath, runtime.WorkspaceRoot, runtime.SourceRoot} {
+		if _, err := os.Stat(path); err != nil {
+			t.Fatalf("Stat(%s) error = %v", path, err)
+		}
+	}
+	if samePath(runtime.Home, filepath.Dir(runtime.ConfigPath)) != true {
+		t.Fatalf("config path %s is not under home %s", runtime.ConfigPath, runtime.Home)
+	}
+
+	workflow, err := workflowconfig.LoadWorkflow(runtime.WorkflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if workflow.Config.Tracker.Kind != workflowconfig.TrackerMemory {
+		t.Fatalf("workflow tracker = %q, want memory", workflow.Config.Tracker.Kind)
+	}
+	if workflow.Config.Workspace.Root != runtime.WorkspaceRoot {
+		t.Fatalf("workspace root = %q, want %q", workflow.Config.Workspace.Root, runtime.WorkspaceRoot)
+	}
+	if len(workflow.Config.Tracker.Issues) < 4 {
+		t.Fatalf("fixture issues = %d, want default dogfood coverage", len(workflow.Config.Tracker.Issues))
+	}
+}
+
+func TestBuildLoadsFixtureIssues(t *testing.T) {
+	t.Parallel()
+
+	fixture := filepath.Join(t.TempDir(), "fixture.yaml")
+	raw, err := yaml.Marshal(struct {
+		Issues []connector.Issue `yaml:"issues"`
+	}{
+		Issues: []connector.Issue{{
+			ID:         "fixture-issue",
+			Identifier: "digitaldrywood/detent#42",
+			State:      "Human Review",
+			PullRequest: &connector.PullRequest{
+				Number:   42,
+				State:    "OPEN",
+				CIStatus: "success",
+			},
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+	if err := os.WriteFile(fixture, raw, 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	runtime, err := Build(Config{Home: t.TempDir(), FixturePath: fixture})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if runtime.FixturePath == "" {
+		t.Fatal("FixturePath is blank, want resolved fixture path")
+	}
+	if len(runtime.Issues) != 1 || runtime.Issues[0].ID != "fixture-issue" {
+		t.Fatalf("Issues = %#v, want fixture issue", runtime.Issues)
+	}
+}
+
+func TestBuildRejectsUnsafeRuntimeInputs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  Config
+		want error
+	}{
+		{
+			name: "live dogfood port",
+			cfg:  Config{Home: t.TempDir(), Port: liveDogfoodPort},
+			want: ErrLivePort,
+		},
+		{
+			name: "unsupported tracker",
+			cfg:  Config{Home: t.TempDir(), TrackerMode: "github"},
+			want: ErrUnsupportedTracker,
+		},
+		{
+			name: "live database",
+			cfg:  Config{Home: t.TempDir(), DBPath: liveDatabasePath()},
+			want: ErrLiveDatabase,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := Build(tt.cfg)
+			if !errors.Is(err, tt.want) {
+				t.Fatalf("Build() error = %v, want %v", err, tt.want)
+			}
+		})
+	}
+}
+
+func TestBuildAllowsExplicitUnsafeOverrides(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := Build(Config{
+		Home:                t.TempDir(),
+		Port:                liveDogfoodPort,
+		DBPath:              liveDatabasePath(),
+		AllowProductionPort: true,
+		AllowLiveDatabase:   true,
+	})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if runtime.Port != liveDogfoodPort {
+		t.Fatalf("Port = %d, want %d", runtime.Port, liveDogfoodPort)
+	}
+}

--- a/testdata/dogfood/autopromote.yaml
+++ b/testdata/dogfood/autopromote.yaml
@@ -1,0 +1,80 @@
+issues:
+  - id: mock-issue-autopromote
+    identifier: digitaldrywood/detent#9001
+    title: Dogfood auto-promote fixture
+    description: Safe fixture issue for isolated runtime auto-promote validation.
+    state: Human Review
+    url: https://github.test/digitaldrywood/detent/issues/9001
+    labels:
+      - enhancement
+      - stage:s7
+    assigned_to_worker: true
+    updated_at: 2026-06-01T12:00:00Z
+    stage_updated_at: 2026-06-01T12:00:00Z
+    pull_request:
+      number: 9001
+      url: https://github.test/digitaldrywood/detent/pull/9001
+      branch_name: detent/mock-issue-autopromote
+      state: OPEN
+      ci_status: success
+      codex_review_state: COMMENTED
+      codex_review_submitted_at: 2026-06-01T12:00:00Z
+  - id: mock-issue-review-finding
+    identifier: digitaldrywood/detent#9002
+    title: Dogfood review finding fixture
+    state: Human Review
+    url: https://github.test/digitaldrywood/detent/issues/9002
+    labels:
+      - bug
+      - stage:s7
+    assigned_to_worker: true
+    updated_at: 2026-06-01T12:00:00Z
+    stage_updated_at: 2026-06-01T12:00:00Z
+    pull_request:
+      number: 9002
+      url: https://github.test/digitaldrywood/detent/pull/9002
+      branch_name: detent/mock-issue-review-finding
+      state: OPEN
+      ci_status: success
+      codex_review_state: P1
+      codex_review_submitted_at: 2026-06-01T12:00:00Z
+      codex_review_findings:
+        - body: P1 mock finding
+          url: https://github.test/digitaldrywood/detent/pull/9002#discussion_r1
+          path: internal/mock.go
+          line: 42
+  - id: mock-issue-resume
+    identifier: digitaldrywood/detent#9003
+    title: Dogfood restart resume fixture
+    state: In Progress
+    url: https://github.test/digitaldrywood/detent/issues/9003
+    labels:
+      - enhancement
+      - stage:s7
+    assigned_to_worker: true
+    updated_at: 2026-06-01T12:00:00Z
+    stage_updated_at: 2026-06-01T12:00:00Z
+    pull_request:
+      number: 9003
+      url: https://github.test/digitaldrywood/detent/pull/9003
+      branch_name: detent/mock-issue-resume
+      state: OPEN
+      ci_status: pending
+  - id: mock-issue-merged
+    identifier: digitaldrywood/detent#9004
+    title: Dogfood merged PR fixture
+    state: Done
+    url: https://github.test/digitaldrywood/detent/issues/9004
+    labels:
+      - enhancement
+      - stage:s7
+    assigned_to_worker: true
+    closed: true
+    updated_at: 2026-06-01T12:00:00Z
+    stage_updated_at: 2026-06-01T12:00:00Z
+    pull_request:
+      number: 9004
+      url: https://github.test/digitaldrywood/detent/pull/9004
+      branch_name: detent/mock-issue-merged
+      state: MERGED
+      ci_status: success


### PR DESCRIPTION
## Summary

- Add `detent dev-runtime` for an isolated mock runtime on port 0 with temp home/workspaces, safe DB defaults, fixture-backed memory tracker, fake runner, and live DB/port guardrails.
- Add a stateful opt-in mode for the memory connector plus dogfood fixtures modeling statuses, PR CI, reviews/findings, quiet-window activity, and merged PR state.
- Document dogfood-safe self-test usage in README.

Fixes #425

## Test Plan

- [x] `go test ./internal/connector/memory ./internal/devruntime ./internal/cli`
- [x] `go test ./internal/project ./internal/orchestrator ./internal/web`
- [x] `go test ./...`
- [x] `make check`