### PR TITLE
chore(go): use new expr for pointer helpers

### DIFF
--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -263,7 +263,7 @@ func TestResolveRuntimeSettingsDoesNotRequireTokenForGitHubApp(t *testing.T) {
 	t.Parallel()
 
 	got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
-		Config: ptrGlobalConfig(githubRuntimeConfig("")),
+		Config: new(githubRuntimeConfig("")),
 	}, runtimeDeps{
 		lookupEnv: mapLookup(map[string]string{
 			"APP_ID":           "12345",
@@ -314,7 +314,7 @@ func TestResolveRuntimeSettingsSkipsConfigTokenWhenNoProjectNeedsRuntimeToken(t 
 
 			ghCalls := 0
 			got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
-				Config: ptrGlobalConfig(githubRuntimeConfig("gh")),
+				Config: new(githubRuntimeConfig("gh")),
 			}, runtimeDeps{
 				lookupEnv: mapLookup(tt.env),
 				ghAuthToken: func(context.Context) (string, error) {
@@ -345,7 +345,7 @@ func TestResolveRuntimeSettingsRequiresTokenForMissingGitHubAppEnvRefs(t *testin
 	t.Parallel()
 
 	_, err := resolveRuntimeSettings(context.Background(), runtimeInput{
-		Config: ptrGlobalConfig(githubRuntimeConfig("")),
+		Config: new(githubRuntimeConfig("")),
 	}, runtimeDeps{
 		lookupEnv: mapLookup(nil),
 		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
@@ -468,10 +468,6 @@ func githubAppWorkflow() workflowconfig.Config {
 	cfg.Tracker.GitHubAppInstallationID = "$INSTALLATION_ID"
 	cfg.Tracker.GitHubAppPrivateKeyPath = "$PRIVATE_KEY_PATH"
 	return cfg
-}
-
-func ptrGlobalConfig(cfg globalconfig.Config) *globalconfig.Config {
-	return &cfg
 }
 
 func mapLookup(values map[string]string) func(string) string {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -3656,14 +3656,10 @@ func clonePriorityMapWithDefault(values map[string]*int) map[string]*int {
 
 func defaultPriorityMap() map[string]*int {
 	return map[string]*int{
-		"Urgent":      intValue(1),
-		"High":        intValue(2),
-		"Medium":      intValue(3),
-		"Low":         intValue(4),
+		"Urgent":      new(1),
+		"High":        new(2),
+		"Medium":      new(3),
+		"Low":         new(4),
 		"No priority": nil,
 	}
-}
-
-func intValue(value int) *int {
-	return &value
 }

--- a/internal/connector/github/adapter_parity_test.go
+++ b/internal/connector/github/adapter_parity_test.go
@@ -54,10 +54,10 @@ func TestProjectsV2ParityGateMatchesElixirAdapterFlow(t *testing.T) {
 			"Cancelled":    "Done",
 		},
 		PriorityMap: map[string]*int{
-			"Urgent":      intPtr(1),
-			"High":        intPtr(2),
-			"Medium":      intPtr(3),
-			"Low":         intPtr(4),
+			"Urgent":      new(1),
+			"High":        new(2),
+			"Medium":      new(3),
+			"Low":         new(4),
 			"No priority": nil,
 		},
 	})

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -31,7 +31,7 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 		ProjectSlug:  "PVT_1",
 		ActiveStates: []string{"Todo"},
 		StateMap:     map[string]string{"Todo": "Ready"},
-		PriorityMap:  map[string]*int{"P0": intPtr(1), "No priority": nil},
+		PriorityMap:  map[string]*int{"P0": new(1), "No priority": nil},
 	})
 
 	got, err := c.FetchCandidateIssues(context.Background())
@@ -1035,7 +1035,7 @@ func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testi
 			"Todo":         "Ready",
 			"Human Review": "Reviewing",
 		},
-		PriorityMap: map[string]*int{"P1": intPtr(2), "No priority": nil},
+		PriorityMap: map[string]*int{"P1": new(2), "No priority": nil},
 	})
 
 	got, err := c.FetchIssueStatesByIDs(context.Background(), []string{"I_kw2", "I_kw1"})
@@ -1127,7 +1127,7 @@ func TestConnectorFetchIssueStatesByIDsPaginatesProjectItems(t *testing.T) {
 		StateMap: map[string]string{
 			"Human Review": "Reviewing",
 		},
-		PriorityMap: map[string]*int{"P2": intPtr(3)},
+		PriorityMap: map[string]*int{"P2": new(3)},
 	})
 
 	got, err := c.FetchIssueStatesByIDs(context.Background(), []string{"I_kw1"})
@@ -1974,8 +1974,4 @@ func githubIssueIDs(issues []connector.Issue) []string {
 		ids = append(ids, issue.ID)
 	}
 	return ids
-}
-
-func intPtr(value int) *int {
-	return &value
 }

--- a/internal/connector/github/provision_test.go
+++ b/internal/connector/github/provision_test.go
@@ -34,7 +34,7 @@ func TestConnectorEnsureStateOptionsCreatesMissingStatusAndPriorityOptions(t *te
 			"Cancelled":    "Done",
 		},
 		PriorityMap: map[string]*int{
-			"P0":          intPtr(1),
+			"P0":          new(1),
 			"No priority": nil,
 		},
 	})
@@ -144,7 +144,7 @@ func TestConnectorEnsureStateOptionsNoopsWhenOptionsPresent(t *testing.T) {
 		ActiveStates:   []string{"Todo"},
 		TerminalStates: []string{"Done"},
 		PriorityMap: map[string]*int{
-			"High":        intPtr(2),
+			"High":        new(2),
 			"No priority": nil,
 		},
 	})

--- a/internal/selector/match_test.go
+++ b/internal/selector/match_test.go
@@ -121,7 +121,7 @@ func TestMatch(t *testing.T) {
 		{
 			name: "priority in matches configured rank",
 			issue: &connector.Issue{
-				Priority: intPtr(2),
+				Priority: new(2),
 				Labels:   []string{},
 				Fields:   map[string]string{},
 			},
@@ -133,7 +133,7 @@ func TestMatch(t *testing.T) {
 		{
 			name: "priority in rejects different rank",
 			issue: &connector.Issue{
-				Priority: intPtr(3),
+				Priority: new(3),
 				Labels:   []string{},
 				Fields:   map[string]string{},
 			},
@@ -298,8 +298,4 @@ func TestDescribe(t *testing.T) {
 			}
 		})
 	}
-}
-
-func intPtr(value int) *int {
-	return &value
 }

--- a/internal/shadow/shadow_test.go
+++ b/internal/shadow/shadow_test.go
@@ -28,7 +28,7 @@ func TestRunComputesGoObservationAndReportsDiffs(t *testing.T) {
 					State:            "Todo",
 					Priority:         &priority,
 					CreatedAt:        now.Add(-time.Hour).Format(time.RFC3339),
-					AssignedToWorker: boolPtr(true),
+					AssignedToWorker: new(true),
 				},
 			},
 			Tokens: TokenAccounting{
@@ -173,8 +173,4 @@ func tokenDiffsContain(diffs []TokenDiff, field string) bool {
 		}
 	}
 	return false
-}
-
-func boolPtr(value bool) *bool {
-	return &value
 }

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -545,7 +545,7 @@ func TestUsageLedgerRoundTrip(t *testing.T) {
 				SessionID:      42,
 				IssueID:        " I_kwDOSskuwc8AAAABD6psJQ ",
 				Identifier:     " digitaldrywood/detent#117 ",
-				PRNumber:       int64Ptr(91),
+				PRNumber:       new(int64(91)),
 				Model:          " gpt-5-codex ",
 				InputTokens:    123,
 				OutputTokens:   45,
@@ -936,7 +936,7 @@ func seedUsageReportEvents(t *testing.T, ctx context.Context, backend Store) {
 			ProjectID:      "detent",
 			IssueID:        "issue-117",
 			Identifier:     "digitaldrywood/detent#117",
-			PRNumber:       int64Ptr(133),
+			PRNumber:       new(int64(133)),
 			Model:          "gpt-5.4",
 			InputTokens:    100,
 			OutputTokens:   50,
@@ -950,7 +950,7 @@ func seedUsageReportEvents(t *testing.T, ctx context.Context, backend Store) {
 			ProjectID:      "detent",
 			IssueID:        "issue-119",
 			Identifier:     "digitaldrywood/detent#119",
-			PRNumber:       int64Ptr(141),
+			PRNumber:       new(int64(141)),
 			Model:          "gpt-5.4",
 			InputTokens:    50,
 			OutputTokens:   25,
@@ -964,7 +964,7 @@ func seedUsageReportEvents(t *testing.T, ctx context.Context, backend Store) {
 			ProjectID:      "detent",
 			IssueID:        "issue-119",
 			Identifier:     "digitaldrywood/detent#119",
-			PRNumber:       int64Ptr(141),
+			PRNumber:       new(int64(141)),
 			Model:          "gpt-5.4-mini",
 			InputTokens:    70,
 			OutputTokens:   30,
@@ -976,7 +976,7 @@ func seedUsageReportEvents(t *testing.T, ctx context.Context, backend Store) {
 		},
 		{
 			ProjectID:      "pyroapex",
-			PRNumber:       int64Ptr(141),
+			PRNumber:       new(int64(141)),
 			Model:          "",
 			InputTokens:    5,
 			OutputTokens:   2,
@@ -1035,8 +1035,4 @@ func queryInt(t *testing.T, db *sql.DB, query string) int64 {
 		t.Fatalf("querying %q: %v", query, err)
 	}
 	return value
-}
-
-func int64Ptr(value int64) *int64 {
-	return &value
 }

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -32,7 +32,7 @@ func TestSnapshotJSONShape(t *testing.T) {
 		DashboardURL: "http://localhost:4101",
 		Refresh: telemetry.Refresh{
 			PollIntervalSeconds: 30,
-			NextRefreshAt:       timePointer(generatedAt.Add(30 * time.Second)),
+			NextRefreshAt:       new(generatedAt.Add(30 * time.Second)),
 		},
 		Counts: telemetry.Counts{
 			Running:   1,
@@ -289,10 +289,6 @@ func TestSnapshotJSONShape(t *testing.T) {
 	if latest["input_tokens"] != float64(110) || latest["output_tokens"] != float64(220) || latest["total_tokens"] != float64(330) {
 		t.Fatalf("token_trend[1] = %#v", latest)
 	}
-}
-
-func timePointer(value time.Time) *time.Time {
-	return &value
 }
 
 func TestBoardStateCountsAggregateSnapshotStates(t *testing.T) {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -354,7 +354,7 @@ func testSnapshot() telemetry.Snapshot {
 		Refresh: telemetry.Refresh{
 			PollIntervalSeconds: 30,
 			LastRefreshAt:       &generatedAt,
-			NextRefreshAt:       timePointer(generatedAt.Add(30 * time.Second)),
+			NextRefreshAt:       new(generatedAt.Add(30 * time.Second)),
 		},
 		Counts: telemetry.Counts{
 			Running:   1,
@@ -471,8 +471,4 @@ func testSnapshot() telemetry.Snapshot {
 func stripANSI(value string) string {
 	ansi := regexp.MustCompile(`\x1b\[[0-9;]*[A-Za-z]`)
 	return ansi.ReplaceAllString(value, "")
-}
-
-func timePointer(value time.Time) *time.Time {
-	return &value
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3077,7 +3077,7 @@ func seedUsageAPIEvents(t *testing.T, ctx context.Context, backend store.Store) 
 			ProjectID:      "detent",
 			IssueID:        "issue-119",
 			Identifier:     "digitaldrywood/detent#119",
-			PRNumber:       int64Ptr(141),
+			PRNumber:       new(int64(141)),
 			Model:          "gpt-report",
 			InputTokens:    100,
 			OutputTokens:   50,
@@ -3091,7 +3091,7 @@ func seedUsageAPIEvents(t *testing.T, ctx context.Context, backend store.Store) 
 			ProjectID:      "detent",
 			IssueID:        "issue-120",
 			Identifier:     "digitaldrywood/detent#120",
-			PRNumber:       int64Ptr(142),
+			PRNumber:       new(int64(142)),
 			Model:          "gpt-report-mini",
 			InputTokens:    50,
 			OutputTokens:   25,
@@ -3105,7 +3105,7 @@ func seedUsageAPIEvents(t *testing.T, ctx context.Context, backend store.Store) 
 			ProjectID:      "pyroapex",
 			IssueID:        "issue-119",
 			Identifier:     "digitaldrywood/detent#119",
-			PRNumber:       int64Ptr(141),
+			PRNumber:       new(int64(141)),
 			Model:          "gpt-report",
 			InputTokens:    70,
 			OutputTokens:   30,
@@ -3135,10 +3135,6 @@ func usageBucket(t *testing.T, rows []any, bucket string) map[string]any {
 	}
 	t.Fatalf("missing bucket %q in %#v", bucket, rows)
 	return nil
-}
-
-func int64Ptr(value int64) *int64 {
-	return &value
 }
 
 func requestJSON(t *testing.T, server *web.Server, method string, path string, wantStatus int) map[string]any {


### PR DESCRIPTION
## Summary

- Replace trivial pointer helper calls with Go 1.26 `new(expr)`.
- Remove now-unused pure pointer helper functions.

Fixes #433

## Test Plan

- [x] `go test ./internal/cli ./internal/connector/github ./internal/selector ./internal/shadow ./internal/store ./internal/telemetry ./internal/tui ./internal/web`
- [x] `make check`
- [x] `go test ./...`