### PR TITLE
chore(go): apply safe Go 1.26 modernizers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,7 @@ DEV_VERSION ?= dev
 COVERPROFILE := tmp/coverage.out
 COVERPROFILE_RAW := tmp/coverage.raw.out
 COVERAGE_THRESHOLD := 70.0
+MODERNIZE_FIX_FLAGS ?= -newexpr=false
 TEMPL ?= go run github.com/a-h/templ/cmd/templ@v0.3.1001
 TAILWIND_INPUT ?= static/css/input.css
 TAILWIND_OUTPUT ?= static/css/output.css
@@ -19,7 +20,7 @@ MIGRATIONS_DIR ?= internal/store/migrations
 GOOSE_DRIVER ?= sqlite3
 DATABASE_URL ?= tmp/detent.db
 
-.PHONY: dev generate css css-watch build test test-race test-cover lint vet check release-snapshot sqlc db-migrate setup clean help
+.PHONY: dev generate css css-watch build test test-race test-cover lint vet check modernize-check release-snapshot sqlc db-migrate setup clean help
 
 dev:
 	@mkdir -p tmp
@@ -89,6 +90,9 @@ vet:
 check: build lint vet test-race test-cover
 	@echo "All checks passed."
 
+modernize-check:
+	go fix -diff $(MODERNIZE_FIX_FLAGS) ./...
+
 release-snapshot:
 	goreleaser release --snapshot --clean
 
@@ -130,6 +134,7 @@ help:
 	@echo "  test-cover   Run Go coverage with a $(COVERAGE_THRESHOLD)% minimum"
 	@echo "  lint         Run golangci-lint"
 	@echo "  check        Run the local validation gate"
+	@echo "  modernize-check  Run the Go modernizer diff check"
 	@echo "  release-snapshot  Build local GoReleaser snapshot archives"
 	@echo "  sqlc         Generate sqlc output"
 	@echo "  db-migrate   Run goose migrations"

--- a/README.md
+++ b/README.md
@@ -1092,6 +1092,7 @@ Common development commands:
 make setup
 make dev
 make check
+make modernize-check
 ```
 
 `make dev` runs Air with `ENV=dev` and
@@ -1103,6 +1104,8 @@ commit SHA and build date, rotates
 `make check` runs the local release gate: build, `golangci-lint`, `go vet`,
 race tests, and the 70 percent coverage check. Run `make generate` before
 committing changes to Templ templates, sqlc queries, or Tailwind inputs.
+`make modernize-check` runs the Go modernizer diff check with the repo's
+selected safe analyzer set.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 

--- a/internal/buildinfo/buildinfo.go
+++ b/internal/buildinfo/buildinfo.go
@@ -191,7 +191,7 @@ func modulePathMatches(root string, modulePath string) bool {
 	if err != nil {
 		return false
 	}
-	for _, line := range strings.Split(string(data), "\n") {
+	for line := range strings.SplitSeq(string(data), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) >= 2 && fields[0] == "module" {
 			return strings.Trim(fields[1], `"`) == modulePath

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -645,12 +646,7 @@ func appendOperations(operations []string, next []string) []string {
 }
 
 func hasOperation(operations []string, operation string) bool {
-	for _, existing := range operations {
-		if existing == operation {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(operations, operation)
 }
 
 func firstWorkflowPath(cfg BootConfig) string {

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -83,7 +83,7 @@ func waitForIsolatedRuntimeURL(t *testing.T, output *lockedBuffer, done <-chan e
 		default:
 		}
 
-		for _, line := range strings.Split(output.String(), "\n") {
+		for line := range strings.SplitSeq(output.String(), "\n") {
 			url, ok := strings.CutPrefix(line, "Dashboard: ")
 			if ok && strings.TrimSpace(url) != "" {
 				return strings.TrimSpace(url)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -603,7 +603,6 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 
 	jobs := make([]doctorCheckJob, 0, len(cfg.Projects))
 	for _, project := range cfg.Projects {
-		project := project
 		id := doctorProjectID(project)
 		jobs = append(jobs, doctorCheckJob{
 			Name: "Project " + id + " checks",
@@ -1913,8 +1912,8 @@ func doctorGitHubRepositoryFromRemoteURL(remote string) (string, bool) {
 	if remote == "" {
 		return "", false
 	}
-	if strings.HasPrefix(remote, "git@github.com:") {
-		return doctorCleanGitHubRepository(strings.TrimPrefix(remote, "git@github.com:"))
+	if after, ok := strings.CutPrefix(remote, "git@github.com:"); ok {
+		return doctorCleanGitHubRepository(after)
 	}
 	if parsed, err := url.Parse(remote); err == nil && strings.EqualFold(parsed.Hostname(), "github.com") {
 		return doctorCleanGitHubRepository(strings.TrimPrefix(parsed.Path, "/"))

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"sync"
@@ -1758,12 +1759,7 @@ func (c *fakeDoctorAutoPromoteConnector) VerifyStatusOptions(_ context.Context, 
 }
 
 func stringSliceContains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, want)
 }
 
 func successfulDoctorOptions(configPath string) options {

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -269,7 +269,7 @@ func defaultSuggestedFix(code string, didYouMean []string) string {
 }
 
 func firstNonEmptyLine(text string) string {
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			return line
@@ -296,8 +296,8 @@ func parseDidYouMean(text string) []string {
 	}
 	if start := strings.Index(strings.ToLower(text), "did you mean "); start >= 0 {
 		candidate := strings.TrimSpace(text[start+len("did you mean "):])
-		if strings.HasPrefix(candidate, "\"") {
-			candidate = strings.TrimPrefix(candidate, "\"")
+		if after, ok := strings.CutPrefix(candidate, "\""); ok {
+			candidate = after
 			if end := strings.Index(candidate, "\""); end >= 0 {
 				candidate = candidate[:end]
 			}
@@ -321,11 +321,11 @@ func unknownCommandName(detail string) string {
 		return ""
 	}
 	remainder = strings.TrimPrefix(remainder, "\"")
-	index := strings.Index(remainder, "\"")
-	if index < 0 {
+	before, _, ok := strings.Cut(remainder, "\"")
+	if !ok {
 		return ""
 	}
-	return remainder[:index]
+	return before
 }
 
 func compactStrings(values []string) []string {

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -229,7 +229,7 @@ func outputFormatFlagValue(cmd *cobra.Command) (string, bool) {
 }
 
 func outputFormatArg(args []string) (string, bool) {
-	for index := 0; index < len(args); index++ {
+	for index := range args {
 		arg := args[index]
 		if arg == "--" {
 			return "", false
@@ -240,8 +240,8 @@ func outputFormatArg(args []string) (string, bool) {
 			}
 			return args[index+1], true
 		}
-		if strings.HasPrefix(arg, "--format=") {
-			return strings.TrimPrefix(arg, "--format="), true
+		if after, ok := strings.CutPrefix(arg, "--format="); ok {
+			return after, true
 		}
 	}
 	return "", false

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -303,8 +303,8 @@ func resolveRuntimeSecret(value string, lookupEnv func(string) string) (string, 
 	if value == "" {
 		return "", ""
 	}
-	if strings.HasPrefix(value, "$") {
-		name := strings.TrimPrefix(value, "$")
+	if after, ok := strings.CutPrefix(value, "$"); ok {
+		name := after
 		if validEnvName(name) {
 			return strings.TrimSpace(lookupEnv(name)), name
 		}

--- a/internal/codex/appserver_parity_test.go
+++ b/internal/codex/appserver_parity_test.go
@@ -105,12 +105,9 @@ func assertTranscriptBytes(t *testing.T, got []byte, want []byte) {
 func firstTranscriptMismatch(got []byte, want []byte) string {
 	gotLines := strings.Split(string(got), "\n")
 	wantLines := strings.Split(string(want), "\n")
-	maxLines := len(wantLines)
-	if len(gotLines) > maxLines {
-		maxLines = len(gotLines)
-	}
+	maxLines := max(len(gotLines), len(wantLines))
 
-	for i := 0; i < maxLines; i++ {
+	for i := range maxLines {
 		var gotLine string
 		if i < len(gotLines) {
 			gotLine = gotLines[i]

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -93,13 +93,7 @@ func rateLimitBucketFromCodex(window *RateLimitWindow) *telemetry.RateLimitBucke
 		return nil
 	}
 
-	used := int64(math.Round(window.UsedPercent))
-	if used < 0 {
-		used = 0
-	}
-	if used > 100 {
-		used = 100
-	}
+	used := min(max(int64(math.Round(window.UsedPercent)), 0), 100)
 
 	bucket := &telemetry.RateLimitBucket{
 		Limit:     100,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -917,13 +917,13 @@ func splitFrontmatter(raw []byte) ([]byte, []byte, error) {
 		return []byte{}, []byte{}, nil
 	}
 
-	closeIndex := strings.Index(body, "\n---\n")
-	if closeIndex >= 0 {
-		return []byte(body[:closeIndex]), []byte(body[closeIndex+len("\n---\n"):]), nil
+	before, after, ok := strings.Cut(body, "\n---\n")
+	if ok {
+		return []byte(before), []byte(after), nil
 	}
 
-	if strings.HasSuffix(body, "\n---") {
-		return []byte(strings.TrimSuffix(body, "\n---")), []byte{}, nil
+	if before, ok := strings.CutSuffix(body, "\n---"); ok {
+		return []byte(before), []byte{}, nil
 	}
 
 	return nil, nil, errors.New("unterminated YAML frontmatter")

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -3,8 +3,10 @@ package global
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 
 	"gopkg.in/yaml.v3"
@@ -614,12 +616,7 @@ func schedulingErrors(value any) []string {
 }
 
 func validSchedulingMode(mode string) bool {
-	for _, candidate := range schedulingModes {
-		if mode == candidate {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(schedulingModes, mode)
 }
 
 func optionalMapErrors(attrs map[string]any, field string) []string {
@@ -1131,9 +1128,7 @@ func decodeYAMLValue(value any, out any) error {
 
 func mergeMap(defaults map[string]any, value any, field string) (map[string]any, error) {
 	out := make(map[string]any, len(defaults))
-	for key, nestedValue := range defaults {
-		out[key] = nestedValue
-	}
+	maps.Copy(out, defaults)
 
 	if value == nil {
 		return out, nil
@@ -1143,9 +1138,7 @@ func mergeMap(defaults map[string]any, value any, field string) (map[string]any,
 	if err != nil {
 		return nil, err
 	}
-	for key, nestedValue := range source {
-		out[key] = nestedValue
-	}
+	maps.Copy(out, source)
 	return out, nil
 }
 

--- a/internal/config/watcher/file.go
+++ b/internal/config/watcher/file.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -214,12 +215,7 @@ func (w *FileWatcher[T]) refreshWatchPath(addDir func(string) error) {
 }
 
 func hasWatchDir(dirs []string, dir string) bool {
-	for _, candidate := range dirs {
-		if candidate == dir {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(dirs, dir)
 }
 
 func (w *FileWatcher[T]) reload(ctx context.Context) FileUpdate[T] {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -1138,9 +1139,7 @@ func (c *Connector) issueRefsForIDs(ctx context.Context, ids []string, queryType
 	if err != nil {
 		return nil, err
 	}
-	for id, ref := range fetched {
-		refs[id] = ref
-	}
+	maps.Copy(refs, fetched)
 	return refs, nil
 }
 
@@ -3347,7 +3346,7 @@ func markdownSectionText(body string, title string) string {
 	want := normalizeSectionTitle(title)
 	inSection := false
 	lines := []string{}
-	for _, line := range strings.Split(body, "\n") {
+	for line := range strings.SplitSeq(body, "\n") {
 		heading, ok := markdownHeadingTitle(line)
 		if ok {
 			if inSection {
@@ -3399,8 +3398,8 @@ func normalizeSectionLines(lines []string) string {
 func normalizeSectionLine(line string) string {
 	line = strings.TrimSpace(line)
 	for _, marker := range []string{"- ", "* ", "+ "} {
-		if strings.HasPrefix(line, marker) {
-			line = strings.TrimSpace(strings.TrimPrefix(line, marker))
+		if after, ok := strings.CutPrefix(line, marker); ok {
+			line = strings.TrimSpace(after)
 			break
 		}
 	}

--- a/internal/connector/github/app_token.go
+++ b/internal/connector/github/app_token.go
@@ -288,10 +288,10 @@ func installationTokenURL(endpoint string, installationID string) (string, error
 	basePath := strings.TrimRight(parsed.Path, "/")
 	if parsed.Host == "api.github.com" {
 		basePath = ""
-	} else if strings.HasSuffix(basePath, "/api/graphql") {
-		basePath = strings.TrimSuffix(basePath, "/api/graphql") + "/api/v3"
-	} else if strings.HasSuffix(basePath, "/graphql") {
-		basePath = strings.TrimSuffix(basePath, "/graphql")
+	} else if before, ok := strings.CutSuffix(basePath, "/api/graphql"); ok {
+		basePath = before + "/api/v3"
+	} else if before, ok := strings.CutSuffix(basePath, "/graphql"); ok {
+		basePath = before
 	}
 
 	parsed.Path = strings.TrimRight(basePath, "/") + "/app/installations/" + url.PathEscape(installationID) + "/access_tokens"

--- a/internal/connector/github/app_token_test.go
+++ b/internal/connector/github/app_token_test.go
@@ -79,7 +79,7 @@ func TestInstallationTokenSourceMintsAndCachesToken(t *testing.T) {
 		t.Fatalf("NewInstallationTokenSource() error = %v", err)
 	}
 
-	for i := 0; i < 2; i++ {
+	for range 2 {
 		token, err := source.Token(context.Background())
 		if err != nil {
 			t.Fatalf("Token() error = %v", err)

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -560,10 +560,10 @@ func restEndpointFromGraphQLEndpoint(endpoint string) (string, error) {
 	basePath := strings.TrimRight(parsed.Path, "/")
 	if parsed.Host == "api.github.com" {
 		basePath = ""
-	} else if strings.HasSuffix(basePath, "/api/graphql") {
-		basePath = strings.TrimSuffix(basePath, "/api/graphql") + "/api/v3"
-	} else if strings.HasSuffix(basePath, "/graphql") {
-		basePath = strings.TrimSuffix(basePath, "/graphql")
+	} else if before, ok := strings.CutSuffix(basePath, "/api/graphql"); ok {
+		basePath = before + "/api/v3"
+	} else if before, ok := strings.CutSuffix(basePath, "/graphql"); ok {
+		basePath = before
 	}
 
 	parsed.Path = strings.TrimRight(basePath, "/")
@@ -603,7 +603,7 @@ func (c *Client) nextRESTPage(headers http.Header) (string, error) {
 
 func nextRESTLink(headers http.Header) string {
 	for _, value := range headers.Values("Link") {
-		for _, part := range strings.Split(value, ",") {
+		for part := range strings.SplitSeq(value, ",") {
 			part = strings.TrimSpace(part)
 			if !strings.HasPrefix(part, "<") {
 				continue
@@ -621,7 +621,7 @@ func nextRESTLink(headers http.Header) string {
 }
 
 func linkHasRelNext(params string) bool {
-	for _, param := range strings.Split(params, ";") {
+	for param := range strings.SplitSeq(params, ";") {
 		key, value, ok := strings.Cut(strings.TrimSpace(param), "=")
 		if !ok || !strings.EqualFold(strings.TrimSpace(key), "rel") {
 			continue
@@ -771,7 +771,7 @@ func summarizeBody(body []byte) string {
 }
 
 func firstLine(text string) string {
-	for _, line := range strings.Split(text, "\n") {
+	for line := range strings.SplitSeq(text, "\n") {
 		line = strings.TrimSpace(line)
 		if line != "" {
 			return line

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -375,9 +375,7 @@ func TestClientGraphQLSerializesHeaderInferredMutationCosts(t *testing.T) {
 	for i := 1; i <= mutations; i++ {
 		used := int64(10 + i)
 		remaining := int64(5000) - used
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			headers := http.Header{}
 			headers.Set("X-RateLimit-Limit", "5000")
@@ -387,7 +385,7 @@ func TestClientGraphQLSerializesHeaderInferredMutationCosts(t *testing.T) {
 
 			snapshot := client.recordRateLimitFromHeaders(headers, now)
 			client.recordGraphQLQueryCostFromHeaders("mutation", snapshot)
-		}()
+		})
 	}
 	close(start)
 	wg.Wait()

--- a/internal/connector/github/connector_test.go
+++ b/internal/connector/github/connector_test.go
@@ -84,25 +84,21 @@ func TestConnectorInstanceLoginConcurrentAuthenticateAndRead(t *testing.T) {
 	start := make(chan struct{})
 	var wg sync.WaitGroup
 	for range 8 {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 			for range 25 {
 				if err := c.Authenticate(context.Background()); err != nil {
 					t.Errorf("Authenticate() error = %v", err)
 				}
 			}
-		}()
+		})
 	}
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		<-start
 		for range 200 {
 			_ = c.InstanceLogin()
 		}
-	}()
+	})
 
 	close(start)
 	wg.Wait()

--- a/internal/connector/github/statuscache.go
+++ b/internal/connector/github/statuscache.go
@@ -1,6 +1,7 @@
 package github
 
 import (
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -110,8 +111,6 @@ func cloneStringMap(values map[string]string) map[string]string {
 	}
 
 	cloned := make(map[string]string, len(values))
-	for key, value := range values {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, values)
 	return cloned
 }

--- a/internal/connector/github/token.go
+++ b/internal/connector/github/token.go
@@ -137,8 +137,8 @@ func resolveSecretValue(value string, lookupEnv func(string) string) string {
 	if value == "" {
 		return ""
 	}
-	if strings.HasPrefix(value, "$") {
-		name := strings.TrimPrefix(value, "$")
+	if after, ok := strings.CutPrefix(value, "$"); ok {
+		name := after
 		if envNamePattern.MatchString(name) {
 			return strings.TrimSpace(lookupEnv(name))
 		}

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -2,6 +2,8 @@ package memory
 
 import (
 	"context"
+	"maps"
+	"slices"
 	"strings"
 	"sync"
 	"time"
@@ -366,9 +368,7 @@ func cloneStringSlice(values []string) []string {
 
 func cloneStringMap(values map[string]string) map[string]string {
 	out := make(map[string]string, len(values))
-	for key, value := range values {
-		out[key] = value
-	}
+	maps.Copy(out, values)
 	return out
 }
 
@@ -382,10 +382,5 @@ func cloneTime(value *time.Time) *time.Time {
 }
 
 func stringSliceContains(values []string, want string) bool {
-	for _, value := range values {
-		if value == want {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(values, want)
 }

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -138,9 +138,7 @@ func TestHubConcurrentPublishAndConsumeIsRaceFree(t *testing.T) {
 
 	done := make(chan struct{})
 	var wg sync.WaitGroup
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
+	wg.Go(func() {
 		for {
 			select {
 			case _, ok := <-sub.C():
@@ -151,7 +149,7 @@ func TestHubConcurrentPublishAndConsumeIsRaceFree(t *testing.T) {
 				return
 			}
 		}
-	}()
+	})
 
 	for value := range 1000 {
 		if err := events.Publish(value); err != nil {

--- a/internal/orchestrator/claim_test.go
+++ b/internal/orchestrator/claim_test.go
@@ -31,8 +31,7 @@ func TestClaimingOverlappingOrchestratorsDispatchOnlyTieBreakWinner(t *testing.T
 		}
 	}
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	alphaRunner := newClaimBlockingRunner()
 	betaRunner := newClaimBlockingRunner()
@@ -90,8 +89,7 @@ func TestClaimingReclaimsStaleLease(t *testing.T) {
 	issue.Fields["Detent Lease"] = now.Add(-2 * time.Minute).Format(time.RFC3339Nano)
 	store := newClaimTestStore([]connector.Issue{issue})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	runner := newClaimBlockingRunner()
 	orch := newClaimTestOrchestrator(t, claimTestConfig("alpha", "alpha"), claimTestConnector{store: store, login: "alpha"}, runner)
@@ -122,8 +120,7 @@ func TestClaimingUsesConfiguredOwnerField(t *testing.T) {
 	issue.Fields["Detent Lease"] = now.Add(-2 * time.Minute).Format(time.RFC3339Nano)
 	store := newClaimTestStore([]connector.Issue{issue})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	runner := newClaimBlockingRunner()
 	cfg := claimTestConfig("alpha", "alpha")
@@ -152,8 +149,7 @@ func TestClaimingHeartbeatKeepsActiveLeaseFromReclaim(t *testing.T) {
 	issue.Fields["Detent Lease"] = now.Format(time.RFC3339Nano)
 	store := newClaimTestStore([]connector.Issue{issue})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	alphaRunner := newClaimBlockingRunner()
 	alpha := newClaimTestOrchestrator(t, claimTestConfig("alpha", "alpha"), claimTestConnector{store: store, login: "alpha"}, alphaRunner)
@@ -189,8 +185,7 @@ func TestClaimingHeartbeatReleasesLocalRunWhenOwnershipChanges(t *testing.T) {
 	issue.Fields["Detent Lease"] = now.Format(time.RFC3339Nano)
 	store := newClaimTestStore([]connector.Issue{issue})
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	alphaRunner := newClaimBlockingRunner()
 	alpha := newClaimTestOrchestrator(t, claimTestConfig("alpha", "alpha"), claimTestConnector{store: store, login: "alpha"}, alphaRunner)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"math"
+	"slices"
 	"strings"
 	"time"
 
@@ -388,10 +389,8 @@ func (p dispatchPlanner) selectWorkerHost(state *State, preferredWorkerHost stri
 
 	preferredWorkerHost = strings.TrimSpace(preferredWorkerHost)
 	if preferredWorkerHost != "" {
-		for _, host := range availableHosts {
-			if host == preferredWorkerHost {
-				return preferredWorkerHost, true
-			}
+		if slices.Contains(availableHosts, preferredWorkerHost) {
+			return preferredWorkerHost, true
 		}
 	}
 
@@ -461,10 +460,7 @@ func (p dispatchPlanner) retryDelay(attempt int, continuation bool) time.Duratio
 	if attempt < 1 {
 		attempt = 1
 	}
-	exponent := attempt - 1
-	if exponent > 30 {
-		exponent = 30
-	}
+	exponent := min(attempt-1, 30)
 
 	delay := p.cfg.FailureRetryBaseDelay * time.Duration(math.Pow(2, float64(exponent)))
 	if delay > p.cfg.MaxRetryBackoff {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"slices"
 	"testing"
 	"time"
 
@@ -556,8 +557,7 @@ func TestDispatchCandidatesClaimsDuplicateIssueWithinCycle(t *testing.T) {
 	now := time.Now()
 	candidate := dispatchTestIssue("issue-duplicate", "Todo")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	orch.dispatchCandidates(ctx, &state, []connector.Issue{candidate, candidate}, now)
 	request := receiveWorkerHostRunRequest(t, runner.started)
@@ -583,8 +583,7 @@ func TestDispatchIssueRequiresSharedGlobalSlot(t *testing.T) {
 	global := scheduler.NewRoundRobin(scheduler.Config{Capacity: 1})
 	globalGate := scheduler.NewGlobalDispatchGate(global)
 	now := time.Now()
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	alphaRunner := newWorkerHostRunner()
 	alphaCfg := normalizeConfig(Config{
@@ -677,8 +676,7 @@ func TestDispatchReadyIssuesHydratesLightweightCandidateBeforeDependencyGate(t *
 	state := newState(cfg)
 	now := time.Now()
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{candidate}, now)
 	select {
@@ -714,8 +712,7 @@ func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	first := dispatchTestIssueWithPullRequest("issue-first", "In Progress", "OPEN")
 	second := dispatchTestIssueWithPullRequest("issue-second", "In Progress", "OPEN")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	done := make(chan struct{})
 	go func() {
@@ -788,8 +785,7 @@ func TestDispatchCandidatesAssignsLeastLoadedWorkerHost(t *testing.T) {
 	state.Running[running.ID] = Running{Issue: running, WorkerHost: "worker-a"}
 	candidate := dispatchTestIssue("issue-candidate", "Todo")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	orch.dispatchCandidates(ctx, &state, []connector.Issue{candidate}, now)
 	request := receiveWorkerHostRunRequest(t, runner.started)
@@ -822,8 +818,7 @@ func TestDispatchIssueIncludesSelectorContext(t *testing.T) {
 	now := time.Now()
 	issue := dispatchTestIssue("issue-selector-context", "Todo")
 
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
+	ctx := t.Context()
 
 	orch.dispatchIssue(ctx, &state, issue, 0, now, "")
 	request := receiveWorkerHostRunRequest(t, runner.started)
@@ -922,10 +917,8 @@ func (c hydratingDispatchConnector) FetchIssuesByStates(context.Context, []strin
 }
 
 func (c hydratingDispatchConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
-	for _, id := range ids {
-		if id == c.issue.ID {
-			return []connector.Issue{c.issue}, nil
-		}
+	if slices.Contains(ids, c.issue.ID) {
+		return []connector.Issue{c.issue}, nil
 	}
 	return nil, nil
 }

--- a/internal/orchestrator/epic_test.go
+++ b/internal/orchestrator/epic_test.go
@@ -909,8 +909,8 @@ func epicTestIssue(id string, state string, closed bool, title string, labels []
 	issue := connector.NewIssue()
 	issue.ID = id
 	issue.Identifier = "digitaldrywood/detent#" + strings.TrimPrefix(id, "child-")
-	if strings.HasPrefix(id, "epic-") {
-		issue.Identifier = "digitaldrywood/detent#" + strings.TrimPrefix(id, "epic-")
+	if after, ok := strings.CutPrefix(id, "epic-"); ok {
+		issue.Identifier = "digitaldrywood/detent#" + after
 	}
 	issue.Title = title
 	issue.State = state

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"log/slog"
+	"slices"
 	"strings"
 	"time"
 
@@ -635,10 +636,7 @@ func (o *Orchestrator) shouldReconcileRunningIssues(state *State, now time.Time)
 	if state.LastRunningReconcileAt.IsZero() {
 		return true
 	}
-	interval := defaultRunningReconcileInterval
-	if o.cfg.PollInterval > interval {
-		interval = o.cfg.PollInterval
-	}
+	interval := max(o.cfg.PollInterval, defaultRunningReconcileInterval)
 	return !now.Before(state.LastRunningReconcileAt.Add(interval))
 }
 
@@ -1711,12 +1709,7 @@ func nextAttempt(attempt int) int {
 
 func stateIn(state string, states []string) bool {
 	normalized := normalizeState(state)
-	for _, candidate := range states {
-		if normalized == candidate {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(states, normalized)
 }
 
 func normalizedStates(states []string) []string {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -3,6 +3,7 @@ package orchestrator_test
 import (
 	"context"
 	"errors"
+	"maps"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -1483,9 +1484,7 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 		cloned[i].Labels = append([]string(nil), issue.Labels...)
 		if issue.Fields != nil {
 			cloned[i].Fields = make(map[string]string, len(issue.Fields))
-			for key, value := range issue.Fields {
-				cloned[i].Fields[key] = value
-			}
+			maps.Copy(cloned[i].Fields, issue.Fields)
 		}
 	}
 	return cloned

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"maps"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -170,12 +171,8 @@ func (s State) clone() State {
 		}
 		cloned.BudgetRefusals[id] = refusal
 	}
-	for id, diffStats := range s.DiffStats {
-		cloned.DiffStats[id] = diffStats
-	}
-	for id, reapedAt := range s.ReapedWorkspaces {
-		cloned.ReapedWorkspaces[id] = reapedAt
-	}
+	maps.Copy(cloned.DiffStats, s.DiffStats)
+	maps.Copy(cloned.ReapedWorkspaces, s.ReapedWorkspaces)
 
 	return cloned
 }
@@ -250,9 +247,7 @@ func cloneStringMap(values map[string]string) map[string]string {
 		return nil
 	}
 	out := make(map[string]string, len(values))
-	for key, value := range values {
-		out[key] = value
-	}
+	maps.Copy(out, values)
 	return out
 }
 

--- a/internal/pathsafe/workspace.go
+++ b/internal/pathsafe/workspace.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 )
 
@@ -41,12 +42,7 @@ func IsWorkspaceRelative(relativePath string) bool {
 }
 
 func escapesWorkspace(path string) bool {
-	for _, part := range strings.FieldsFunc(path, func(r rune) bool {
+	return slices.Contains(strings.FieldsFunc(path, func(r rune) bool {
 		return r == '/' || r == '\\'
-	}) {
-		if part == ".." {
-			return true
-		}
-	}
-	return false
+	}), "..")
 }

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -1,7 +1,7 @@
 package project
 
 import (
-	"sort"
+	"slices"
 	"sync"
 )
 
@@ -62,9 +62,7 @@ func (r *Registry) List() []*Project {
 	for id := range r.projects {
 		ids = append(ids, id)
 	}
-	sort.Slice(ids, func(i, j int) bool {
-		return ids[i] < ids[j]
-	})
+	slices.Sort(ids)
 
 	projects := make([]*Project, 0, len(ids))
 	for _, id := range ids {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"math"
 	"strconv"
 	"strings"
@@ -247,9 +248,7 @@ func cloneAgentBackends(in map[string]AgentBackend) map[string]AgentBackend {
 		return nil
 	}
 	out := make(map[string]AgentBackend, len(in))
-	for id, backend := range in {
-		out[id] = backend
-	}
+	maps.Copy(out, in)
 	return out
 }
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"strings"
 	"sync"
 	"time"
@@ -278,9 +279,7 @@ func decrement(values map[string]int, key string, value int) {
 
 func cloneIntMap(values map[string]int) map[string]int {
 	cloned := make(map[string]int, len(values))
-	for key, value := range values {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, values)
 	return cloned
 }
 

--- a/internal/scheduler/scheduler_test.go
+++ b/internal/scheduler/scheduler_test.go
@@ -291,9 +291,7 @@ func TestCountingSemaphoreSupportsConcurrentRequests(t *testing.T) {
 	var wg sync.WaitGroup
 
 	for range workers {
-		wg.Add(1)
-		go func() {
-			defer wg.Done()
+		wg.Go(func() {
 			<-start
 
 			slot, err := sched.RequestSlot(context.Background(), scheduler.SlotRequest{})
@@ -301,7 +299,7 @@ func TestCountingSemaphoreSupportsConcurrentRequests(t *testing.T) {
 				slots <- slot
 			}
 			results <- err
-		}()
+		})
 	}
 
 	close(start)

--- a/internal/selector/match.go
+++ b/internal/selector/match.go
@@ -2,6 +2,7 @@ package selector
 
 import (
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -261,12 +262,7 @@ func matchPriority(priority *int, allowed []int) bool {
 	if priority == nil {
 		return false
 	}
-	for _, allowedPriority := range allowed {
-		if *priority == allowedPriority {
-			return true
-		}
-	}
-	return false
+	return slices.Contains(allowed, *priority)
 }
 
 func issueAssignees(issue connector.Issue) []string {

--- a/internal/shadow/shadow.go
+++ b/internal/shadow/shadow.go
@@ -3,6 +3,7 @@ package shadow
 import (
 	"errors"
 	"fmt"
+	"maps"
 	"reflect"
 	"sort"
 	"strings"
@@ -24,9 +25,9 @@ type Input struct {
 
 type Scenario struct {
 	Config       DispatchConfig  `json:"config"`
-	InitialState InitialState    `json:"initial_state,omitempty"`
+	InitialState InitialState    `json:"initial_state"`
 	Candidates   []Issue         `json:"candidates,omitempty"`
-	Tokens       TokenAccounting `json:"tokens,omitempty"`
+	Tokens       TokenAccounting `json:"tokens"`
 }
 
 type DispatchConfig struct {
@@ -693,9 +694,7 @@ func trimStrings(values []string) []string {
 
 func cloneIntMap(values map[string]int) map[string]int {
 	cloned := make(map[string]int, len(values))
-	for key, value := range values {
-		cloned[key] = value
-	}
+	maps.Copy(cloned, values)
 	return cloned
 }
 

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -175,12 +175,12 @@ func splitFrontmatter(content []byte) ([]byte, error) {
 	if body == "---" {
 		return []byte{}, nil
 	}
-	closeIndex := strings.Index(body, "\n---\n")
-	if closeIndex >= 0 {
-		return []byte(body[:closeIndex]), nil
+	before, _, ok := strings.Cut(body, "\n---\n")
+	if ok {
+		return []byte(before), nil
 	}
-	if strings.HasSuffix(body, "\n---") {
-		return []byte(strings.TrimSuffix(body, "\n---")), nil
+	if before, ok := strings.CutSuffix(body, "\n---"); ok {
+		return []byte(before), nil
 	}
 
 	return nil, errors.New("missing closing front matter delimiter")

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -8,7 +8,7 @@ type Snapshot struct {
 	Instance       Instance          `json:"instance"`
 	Projects       []ProjectSnapshot `json:"projects,omitempty"`
 	DashboardURL   string            `json:"dashboard_url,omitempty"`
-	Shutdown       Shutdown          `json:"shutdown,omitempty"`
+	Shutdown       Shutdown          `json:"shutdown"`
 	Refresh        Refresh           `json:"refresh"`
 	Events         []ActivityEvent   `json:"events,omitempty"`
 	Counts         Counts            `json:"counts"`
@@ -22,7 +22,7 @@ type Snapshot struct {
 	Tokens         Tokens            `json:"tokens"`
 	Throughput     TokenThroughput   `json:"throughput"`
 	LifetimeTotals LifetimeTotals    `json:"lifetime_totals"`
-	CycleTime      CycleTimeReport   `json:"cycle_time,omitempty"`
+	CycleTime      CycleTimeReport   `json:"cycle_time"`
 	TokenTrend     []TokenTrendPoint `json:"token_trend,omitempty"`
 }
 
@@ -52,7 +52,7 @@ type ProjectSnapshot struct {
 	Project    Project         `json:"project"`
 	Counts     Counts          `json:"counts"`
 	Tokens     Tokens          `json:"tokens"`
-	Throughput TokenThroughput `json:"throughput,omitempty"`
+	Throughput TokenThroughput `json:"throughput"`
 }
 
 type Refresh struct {
@@ -165,8 +165,8 @@ type Budget struct {
 	CurrentSpendUSD   float64            `json:"current_spend_usd"`
 	ProjectedCostUSD  float64            `json:"projected_cost_usd"`
 	ProjectedSpendUSD float64            `json:"projected_spend_usd,omitempty"`
-	PeriodStart       time.Time          `json:"period_start,omitempty"`
-	PeriodEnd         time.Time          `json:"period_end,omitempty"`
+	PeriodStart       time.Time          `json:"period_start"`
+	PeriodEnd         time.Time          `json:"period_end"`
 	SpendPoints       []BudgetSpendPoint `json:"spend_points,omitempty"`
 	Days              []BudgetDay        `json:"days,omitempty"`
 	Refusals          []BudgetRefusal    `json:"refusals,omitempty"`

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -471,10 +471,7 @@ func formatReset(bucket *telemetry.RateLimitBucket, now func() time.Time) string
 		now = time.Now
 	}
 
-	seconds := int64(math.Ceil(bucket.ResetAt.Sub(now()).Seconds()))
-	if seconds < 0 {
-		seconds = 0
-	}
+	seconds := max(int64(math.Ceil(bucket.ResetAt.Sub(now()).Seconds())), 0)
 
 	return formatCount(seconds) + "s"
 }

--- a/internal/tui/status_dashboard_parity_test.go
+++ b/internal/tui/status_dashboard_parity_test.go
@@ -103,7 +103,7 @@ func parseStatusDashboardParity(content string) statusDashboardParity {
 	var parsed statusDashboardParity
 	section := ""
 
-	for _, line := range strings.Split(strings.TrimSpace(content), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSpace(content), "\n") {
 		line = strings.TrimRight(line, " ")
 		switch {
 		case strings.Contains(line, "├─ Running"):
@@ -244,7 +244,7 @@ func sideBySide(want string, got string) string {
 	out.WriteString("go internal/tui\n")
 
 	total := max(len(wantLines), len(gotLines))
-	for i := 0; i < total; i++ {
+	for i := range total {
 		var left, right string
 		if i < len(wantLines) {
 			left = wantLines[i]

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -18,6 +18,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -1128,7 +1129,7 @@ func verifyInstalledVersion(status Status, installed string) error {
 }
 
 func installedVersion(status Status, versionOutput string) string {
-	for _, line := range strings.Split(versionOutput, "\n") {
+	for line := range strings.SplitSeq(versionOutput, "\n") {
 		key, value, ok := strings.Cut(line, ":")
 		if ok && strings.EqualFold(strings.TrimSpace(key), "version") {
 			if version := strings.TrimSpace(value); version != "" {
@@ -1136,7 +1137,7 @@ func installedVersion(status Status, versionOutput string) string {
 			}
 		}
 	}
-	for _, line := range strings.Split(versionOutput, "\n") {
+	for line := range strings.SplitSeq(versionOutput, "\n") {
 		if value := strings.TrimSpace(line); value != "" {
 			return value
 		}
@@ -1251,7 +1252,7 @@ func extractZipBinary(archive []byte) ([]byte, os.FileMode, error) {
 }
 
 func expectedChecksum(checksums []byte, assetName string) (string, bool) {
-	for _, line := range strings.Split(string(checksums), "\n") {
+	for line := range strings.SplitSeq(string(checksums), "\n") {
 		fields := strings.Fields(line)
 		if len(fields) < 2 {
 			continue
@@ -1319,7 +1320,7 @@ func parseMinisignSignature(raw []byte) ([]byte, []byte, string, []byte, error) 
 }
 
 func firstMinisignPayloadLine(raw string) string {
-	for _, line := range strings.Split(strings.ReplaceAll(raw, "\r\n", "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.ReplaceAll(raw, "\r\n", "\n"), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" || strings.HasPrefix(line, "untrusted comment:") {
 			continue
@@ -1432,10 +1433,8 @@ func parseVersion(version string) (semVersion, error) {
 	var prereleaseParts []string
 	if hasPrerelease {
 		prereleaseParts = strings.Split(prerelease, ".")
-		for _, part := range prereleaseParts {
-			if part == "" {
-				return semVersion{}, fmt.Errorf("invalid semantic version: %s", version)
-			}
+		if slices.Contains(prereleaseParts, "") {
+			return semVersion{}, fmt.Errorf("invalid semantic version: %s", version)
 		}
 	}
 	return semVersion{major: major, minor: minor, patch: patch, prerelease: prereleaseParts}, nil
@@ -1578,7 +1577,7 @@ func readInstallLockBinary(path string) (string, bool) {
 	if err != nil {
 		return "", false
 	}
-	for _, line := range strings.Split(string(raw), "\n") {
+	for line := range strings.SplitSeq(string(raw), "\n") {
 		key, value, ok := strings.Cut(line, "=")
 		if !ok || strings.TrimSpace(key) != "binary" {
 			continue

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -182,7 +182,7 @@ func TestSelectReleaseAssetsAndVerifyChecksum(t *testing.T) {
 	signatureName := "detent_1.2.4_checksums.txt.minisig"
 	archive := []byte("archive")
 	sum := sha256.Sum256(archive)
-	checksums := []byte(fmt.Sprintf("%x  %s\n", sum, archiveName))
+	checksums := fmt.Appendf(nil, "%x  %s\n", sum, archiveName)
 
 	assets, err := SelectReleaseAssets(Release{
 		TagName: "v1.2.4",
@@ -1231,12 +1231,12 @@ func testMinisignSignature(t *testing.T, privateKey ed25519.PrivateKey, keyID []
 	packet := append([]byte("ED"), keyID...)
 	packet = append(packet, signature...)
 	globalSignature := ed25519.Sign(privateKey, append(signature, []byte(trustedComment)...))
-	return []byte(fmt.Sprintf(
+	return fmt.Appendf(nil,
 		"untrusted comment: signature from minisign secret key\n%s\ntrusted comment: %s\n%s\n",
 		base64.StdEncoding.EncodeToString(packet),
 		trustedComment,
 		base64.StdEncoding.EncodeToString(globalSignature),
-	))
+	)
 }
 
 func acceptChecksumSignature(context.Context, []byte, []byte) error {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -417,7 +417,6 @@ func TestServerStaticAssetsUseFingerprintsAndCacheHeaders(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 
@@ -461,7 +460,6 @@ func TestServerStaticAssetsUseFingerprintsAndCacheHeaders(t *testing.T) {
 		}
 
 		for _, tt := range tests {
-			tt := tt
 			t.Run(tt.name, func(t *testing.T) {
 				t.Parallel()
 

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -103,7 +103,7 @@ func writeSSEComponent(ctx context.Context, w io.Writer, event string, component
 	if _, err := fmt.Fprintf(w, "event: %s\n", event); err != nil {
 		return err
 	}
-	for _, line := range strings.Split(strings.TrimSuffix(body.String(), "\n"), "\n") {
+	for line := range strings.SplitSeq(strings.TrimSuffix(body.String(), "\n"), "\n") {
 		if _, err := fmt.Fprintf(w, "data: %s\n", line); err != nil {
 			return err
 		}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"maps"
 	"math"
 	"net/url"
 	"sort"
@@ -367,9 +368,7 @@ func sidebarProjectItemAttributes(item sidebarProjectItem) templ.Attributes {
 
 func sidebarProjectButtonAttributes(item sidebarProjectItem) templ.Attributes {
 	attrs := templ.Attributes{}
-	for name, value := range sidebarAriaCurrent(item.Active) {
-		attrs[name] = value
-	}
+	maps.Copy(attrs, sidebarAriaCurrent(item.Active))
 	return attrs
 }
 
@@ -1916,10 +1915,7 @@ func budgetHistoryCount(budget telemetry.Budget) string {
 func budgetHistoryHeightStyle(spend float64, maxSpend float64) string {
 	percent := 12
 	if spend > 0 && maxSpend > 0 {
-		percent = int(math.Round(spend / maxSpend * 100))
-		if percent < 12 {
-			percent = 12
-		}
+		percent = max(int(math.Round(spend/maxSpend*100)), 12)
 	}
 	if percent > 100 {
 		percent = 100
@@ -2180,8 +2176,8 @@ func pluralize(word string, count int64) string {
 	if count == 1 {
 		return word
 	}
-	if strings.HasSuffix(word, "y") {
-		return strings.TrimSuffix(word, "y") + "ies"
+	if before, ok := strings.CutSuffix(word, "y"); ok {
+		return before + "ies"
 	}
 	return word + "s"
 }

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -823,7 +823,7 @@ func TestPRPipelineLanesCapDoneTodayToRecentCards(t *testing.T) {
 
 	now := time.Date(2026, 6, 1, 15, 0, 0, 0, time.UTC)
 	issues := make([]telemetry.Issue, 0, 12)
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		updatedAt := now.Add(-time.Duration(11-i) * time.Minute)
 		issues = append(issues, telemetry.Issue{
 			ID:         "done-" + strconv.Itoa(i),

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -747,7 +747,7 @@ func TestDashboardRendersReadableAgentTimelineForConcurrentSessions(t *testing.T
 
 	now := time.Date(2026, 5, 31, 15, 0, 0, 0, time.UTC)
 	running := make([]telemetry.Running, 0, 5)
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		running = append(running, telemetry.Running{
 			Issue: telemetry.Issue{
 				ID:         "running-" + strconv.Itoa(i),

--- a/internal/web/templates/help_test.go
+++ b/internal/web/templates/help_test.go
@@ -39,7 +39,6 @@ func TestHelpTermsCoverDashboardSectionsAndMetrics(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		tt := tt
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 

--- a/internal/web/ui/utils/templui.go
+++ b/internal/web/ui/utils/templui.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"maps"
 	"net/http"
 	"path"
 	"strings"
@@ -54,9 +55,7 @@ func IfElse[T any](condition bool, trueValue T, falseValue T) T {
 func MergeAttributes(attrs ...templ.Attributes) templ.Attributes {
 	merged := templ.Attributes{}
 	for _, attr := range attrs {
-		for k, v := range attr {
-			merged[k] = v
-		}
+		maps.Copy(merged, attr)
 	}
 	return merged
 }

--- a/internal/workspace/process_unix.go
+++ b/internal/workspace/process_unix.go
@@ -95,7 +95,7 @@ func lsofWorkspaceProcessIDs(ctx context.Context, path string) ([]int, error) {
 
 	seen := map[int]struct{}{}
 	pids := []int{}
-	for _, line := range strings.Split(string(output), "\n") {
+	for line := range strings.SplitSeq(string(output), "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
 			continue


### PR DESCRIPTION
## Summary

- Apply Go 1.26 safe modernizer rewrites across maintained Go sources.
- Add make modernize-check for the selected local modernizer diff check.
- Leave generated templ/sqlc output untouched and keep newexpr out of the default check because it adds inline migration directives.

Fixes #434

## Test Plan

- [x] `make modernize-check`
- [x] `go test ./internal/buildinfo ./internal/cli ./internal/codex ./internal/config ./internal/config/global ./internal/config/watcher ./internal/connector/github ./internal/connector/memory ./internal/hub ./internal/orchestrator ./internal/pathsafe ./internal/project ./internal/runner ./internal/scheduler ./internal/selector ./internal/shadow ./internal/skills ./internal/telemetry ./internal/tui ./internal/update ./internal/web ./internal/web/templates ./internal/web/ui/utils ./internal/workspace`
- [x] `make check`