### PR TITLE
chore(api): audit JSON omitzero fields

### DIFF
--- a/internal/shadow/shadow.go
+++ b/internal/shadow/shadow.go
@@ -25,9 +25,9 @@ type Input struct {
 
 type Scenario struct {
 	Config       DispatchConfig  `json:"config"`
-	InitialState InitialState    `json:"initial_state"`
+	InitialState InitialState    `json:"initial_state,omitzero"`
 	Candidates   []Issue         `json:"candidates,omitempty"`
-	Tokens       TokenAccounting `json:"tokens"`
+	Tokens       TokenAccounting `json:"tokens,omitzero"`
 }
 
 type DispatchConfig struct {

--- a/internal/shadow/shadow_test.go
+++ b/internal/shadow/shadow_test.go
@@ -1,6 +1,7 @@
 package shadow
 
 import (
+	"encoding/json"
 	"slices"
 	"testing"
 	"time"
@@ -154,6 +155,63 @@ func TestRunDiffsDispatchDetailsWhenBothReportsIncludeThem(t *testing.T) {
 	}
 	if !diffFieldsContain(report.Diff.Dispatch, "dispatch_details") {
 		t.Fatalf("Dispatch diffs = %#v, want dispatch_details", report.Diff.Dispatch)
+	}
+}
+
+func TestScenarioJSONOptionalStructs(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		scenario    Scenario
+		wantPresent []string
+		wantMissing []string
+	}{
+		{
+			name: "zero optional structs omitted",
+			scenario: Scenario{
+				Config: DispatchConfig{MaxConcurrentAgents: 1},
+			},
+			wantMissing: []string{"initial_state", "tokens"},
+		},
+		{
+			name: "populated optional structs emitted",
+			scenario: Scenario{
+				Config: DispatchConfig{MaxConcurrentAgents: 1},
+				InitialState: InitialState{
+					Running: []Running{{Issue: Issue{ID: "issue-running"}}},
+				},
+				Tokens: TokenAccounting{TotalTokens: 12},
+			},
+			wantPresent: []string{"initial_state", "tokens"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tt.scenario)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			for _, key := range tt.wantPresent {
+				if _, ok := got[key]; !ok {
+					t.Fatalf("scenario JSON missing %q: %s", key, string(data))
+				}
+			}
+			for _, key := range tt.wantMissing {
+				if _, ok := got[key]; ok {
+					t.Fatalf("scenario JSON includes %q: %s", key, string(data))
+				}
+			}
+		})
 	}
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -165,8 +165,8 @@ type Budget struct {
 	CurrentSpendUSD   float64            `json:"current_spend_usd"`
 	ProjectedCostUSD  float64            `json:"projected_cost_usd"`
 	ProjectedSpendUSD float64            `json:"projected_spend_usd,omitempty"`
-	PeriodStart       time.Time          `json:"period_start"`
-	PeriodEnd         time.Time          `json:"period_end"`
+	PeriodStart       time.Time          `json:"period_start,omitzero"`
+	PeriodEnd         time.Time          `json:"period_end,omitzero"`
 	SpendPoints       []BudgetSpendPoint `json:"spend_points,omitempty"`
 	Days              []BudgetDay        `json:"days,omitempty"`
 	Refusals          []BudgetRefusal    `json:"refusals,omitempty"`

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -291,6 +291,89 @@ func TestSnapshotJSONShape(t *testing.T) {
 	}
 }
 
+func TestSnapshotJSONZeroValueSemantics(t *testing.T) {
+	t.Parallel()
+
+	start := time.Date(2026, 6, 13, 0, 0, 0, 0, time.UTC)
+	end := start.Add(24 * time.Hour)
+
+	tests := []struct {
+		name              string
+		snapshot          telemetry.Snapshot
+		wantBudgetPresent []string
+		wantBudgetMissing []string
+	}{
+		{
+			name:              "zero budget period omitted",
+			snapshot:          telemetry.Snapshot{},
+			wantBudgetMissing: []string{"period_start", "period_end"},
+		},
+		{
+			name: "configured budget period emitted",
+			snapshot: telemetry.Snapshot{
+				Budget: telemetry.Budget{
+					Enabled:     true,
+					PeriodStart: start,
+					PeriodEnd:   end,
+				},
+			},
+			wantBudgetPresent: []string{"period_start", "period_end"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data, err := json.Marshal(tt.snapshot)
+			if err != nil {
+				t.Fatalf("Marshal() error = %v", err)
+			}
+
+			var got map[string]any
+			if err := json.Unmarshal(data, &got); err != nil {
+				t.Fatalf("Unmarshal() error = %v", err)
+			}
+
+			for _, key := range []string{"shutdown", "throughput", "cycle_time"} {
+				if _, ok := got[key]; !ok {
+					t.Fatalf("snapshot JSON missing %q: %s", key, string(data))
+				}
+			}
+
+			budget := got["budget"].(map[string]any)
+			for _, key := range tt.wantBudgetPresent {
+				if _, ok := budget[key]; !ok {
+					t.Fatalf("budget JSON missing %q: %s", key, string(data))
+				}
+			}
+			for _, key := range tt.wantBudgetMissing {
+				if _, ok := budget[key]; ok {
+					t.Fatalf("budget JSON includes %q: %s", key, string(data))
+				}
+			}
+		})
+	}
+}
+
+func TestProjectSnapshotJSONKeepsZeroThroughput(t *testing.T) {
+	t.Parallel()
+
+	data, err := json.Marshal(telemetry.ProjectSnapshot{})
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	if _, ok := got["throughput"]; !ok {
+		t.Fatalf("project snapshot JSON missing throughput: %s", string(data))
+	}
+}
+
 func TestBoardStateCountsAggregateSnapshotStates(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Clarify audited telemetry JSON tags by keeping stable snapshot objects always emitted and omitting zero budget period times with `omitzero`.
- Omit zero optional shadow scenario structs with `omitzero` while preserving populated output.
- Add regression tests for telemetry and shadow JSON zero-value behavior.

Fixes #435

## Test Plan

- [x] `go test ./internal/telemetry ./internal/shadow ./internal/web/...`
- [x] `make check`