### PR TITLE
test(go): add goleak validation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,11 @@ SQLC_CONFIG ?= sqlc/sqlc.yaml
 MIGRATIONS_DIR ?= internal/store/migrations
 GOOSE_DRIVER ?= sqlite3
 DATABASE_URL ?= tmp/detent.db
+NILAWAY_VERSION ?= v0.0.0-20260612163715-2d8907f431ca
+NILAWAY ?= go run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
+NILAWAY_INCLUDE_PKGS ?= github.com/digitaldrywood/detent
 
-.PHONY: dev generate css css-watch build test test-race test-cover lint vet check modernize-check release-snapshot sqlc db-migrate setup clean help
+.PHONY: dev generate css css-watch build test test-race test-cover lint vet check modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
 
 dev:
 	@mkdir -p tmp
@@ -87,6 +90,9 @@ lint:
 vet:
 	go vet ./...
 
+nilaway-audit:
+	$(NILAWAY) -include-pkgs=$(NILAWAY_INCLUDE_PKGS) ./...
+
 check: build lint vet test-race test-cover
 	@echo "All checks passed."
 
@@ -135,6 +141,7 @@ help:
 	@echo "  lint         Run golangci-lint"
 	@echo "  check        Run the local validation gate"
 	@echo "  modernize-check  Run the Go modernizer diff check"
+	@echo "  nilaway-audit  Run the local NilAway audit"
 	@echo "  release-snapshot  Build local GoReleaser snapshot archives"
 	@echo "  sqlc         Generate sqlc output"
 	@echo "  db-migrate   Run goose migrations"

--- a/README.md
+++ b/README.md
@@ -1107,6 +1107,25 @@ committing changes to Templ templates, sqlc queries, or Tailwind inputs.
 `make modernize-check` runs the Go modernizer diff check with the repo's
 selected safe analyzer set.
 
+Packages that own transport, hub, watcher, orchestrator, and runner goroutines
+also run `go.uber.org/goleak` from package-level tests, so `go test ./...`,
+race tests, and `make check` fail on unexpected goroutines. Add goleak ignores
+only in the package that needs them, and only after identifying the dependency
+or intentionally shared test goroutine.
+
+Nil safety is tracked separately with a local audit command:
+
+```sh
+make nilaway-audit
+```
+
+NilAway is not part of `make check` yet. The standalone audit currently reports
+first-party findings that need triage before it can become a CI gate, and its
+golangci-lint integration requires a custom module-plugin linter binary. Go
+1.26's experimental `runtime/pprof` `goroutineleak` profile remains a runtime
+audit aid behind `GOEXPERIMENT=goroutineleakprofile`; the stable CI coverage for
+now is the goleak-backed test gate.
+
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 
 ## Logging

--- a/go.mod
+++ b/go.mod
@@ -14,7 +14,9 @@ require (
 	github.com/lmittmann/tint v1.1.3
 	github.com/pressly/goose/v3 v3.27.1
 	github.com/spf13/cobra v1.10.2
+	github.com/spf13/pflag v1.0.9
 	github.com/templui/templui v1.12.0
+	go.uber.org/goleak v1.3.0
 	golang.org/x/crypto v0.50.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
@@ -45,7 +47,6 @@ require (
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	github.com/rivo/uniseg v0.4.7 // indirect
 	github.com/sethvargo/go-retry v0.3.0 // indirect
-	github.com/spf13/pflag v1.0.9 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect

--- a/go.sum
+++ b/go.sum
@@ -94,6 +94,8 @@ github.com/valyala/fasttemplate v1.2.2 h1:lxLXG0uE3Qnshl9QyaK6XJxMXlQZELvChBOCmQ
 github.com/valyala/fasttemplate v1.2.2/go.mod h1:KHLXt3tVN2HBp8eijSv/kGJopbvo7S+qRAEEKiv+SiQ=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e h1:JVG44RsyaB9T2KIHavMF/ppJZNG9ZpyihvCd0w101no=
 github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e/go.mod h1:RbqR21r5mrJuqunuUZ/Dhy/avygyECGrLceyNeo4LiM=
+go.uber.org/goleak v1.3.0 h1:2K3zAYmnTNqV73imy9J1T3WC+gmCePx2hEGkimedGto=
+go.uber.org/goleak v1.3.0/go.mod h1:CoHD4mav9JJNrW/WLlf7HGZPjdw8EucARQHekz1X6bE=
 go.uber.org/multierr v1.11.0 h1:blXXJkSxSSfBVBlC76pxqeO+LN3aDfLQo+309xJstO0=
 go.uber.org/multierr v1.11.0/go.mod h1:20+QtiLqy0Nd6FdQB9TLXag12DsQkrbs3htMFfDN80Y=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=

--- a/internal/codex/leak_test.go
+++ b/internal/codex/leak_test.go
@@ -1,0 +1,11 @@
+package codex
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/config/watcher/leak_test.go
+++ b/internal/config/watcher/leak_test.go
@@ -1,0 +1,11 @@
+package watcher
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/hub/leak_test.go
+++ b/internal/hub/leak_test.go
@@ -1,0 +1,11 @@
+package hub_test
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/orchestrator/leak_test.go
+++ b/internal/orchestrator/leak_test.go
@@ -1,0 +1,11 @@
+package orchestrator
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/runner/leak_test.go
+++ b/internal/runner/leak_test.go
@@ -1,0 +1,11 @@
+package runner
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}


### PR DESCRIPTION
## Summary

- Add package-level goleak checks for codex transport, hub, config watcher, orchestrator, and runner tests.
- Document leak checking in the development gate and add a pinned local `make nilaway-audit` command for NilAway evaluation.
- Keep NilAway audit-only for now because current first-party findings need separate triage in #451.

Fixes #436

## Test Plan

- [x] `go test ./internal/codex ./internal/hub ./internal/config/watcher ./internal/orchestrator ./internal/runner`
- [x] `go test -race ./internal/codex ./internal/hub ./internal/config/watcher ./internal/orchestrator ./internal/runner`
- [x] `make check`
- [x] `make nilaway-audit` (expected non-zero audit result; documented and tracked in #451)