### PR TITLE
fix(orchestrator): recover stale blocked issues

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -52,16 +52,18 @@ var requiredGitHubScopes = []string{"repo", "read:org", "project"}
 const (
 	doctorAutoPromoteSampleLimit           = 5
 	doctorDependencyAutoUnblockSampleLimit = 5
+	doctorBlockedRecoverySampleLimit       = 5
 )
 
 var doctorHealthCheckKeys = []string{"hub", "store", "registry", "connector"}
 
 type doctorCheck struct {
-	Name                  string                                 `json:"name"`
-	Status                doctorStatus                           `json:"status"`
-	Detail                string                                 `json:"detail"`
-	Hint                  string                                 `json:"hint,omitempty"`
-	AutoPromoteCandidates []doctorAutoPromoteCandidateDiagnostic `json:"auto_promote_candidates,omitempty"`
+	Name                      string                                     `json:"name"`
+	Status                    doctorStatus                               `json:"status"`
+	Detail                    string                                     `json:"detail"`
+	Hint                      string                                     `json:"hint,omitempty"`
+	AutoPromoteCandidates     []doctorAutoPromoteCandidateDiagnostic     `json:"auto_promote_candidates,omitempty"`
+	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
 }
 
 type doctorReport struct {
@@ -82,6 +84,18 @@ type doctorAutoPromoteCandidateDiagnostic struct {
 	LatestCodexReviewSubmittedAt *time.Time `json:"latest_codex_review_submitted_at,omitempty"`
 	QuietRemainingSeconds        int64      `json:"quiet_remaining_seconds,omitempty"`
 	Reason                       string     `json:"reason"`
+}
+
+type doctorBlockedRecoveryCandidateDiagnostic struct {
+	IssueID         string `json:"issue_id,omitempty"`
+	IssueIdentifier string `json:"issue_identifier,omitempty"`
+	IssueURL        string `json:"issue_url,omitempty"`
+	PRNumber        int    `json:"pr_number,omitempty"`
+	PRURL           string `json:"pr_url,omitempty"`
+	PRHeadSHA       string `json:"pr_head_sha,omitempty"`
+	TargetState     string `json:"target_state,omitempty"`
+	Reason          string `json:"reason"`
+	Detail          string `json:"detail,omitempty"`
 }
 
 type doctorSummary struct {
@@ -663,6 +677,7 @@ func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps 
 	}
 	if workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHub {
 		checks = append(checks, checkDoctorDependencyAutoUnblock(ctx, id, workflow.Config, deps))
+		checks = append(checks, checkDoctorBlockedRecovery(ctx, id, workflow.Config, deps))
 	}
 
 	sourceRoot := projectSourceRoot(project, workflow.Config)
@@ -1030,6 +1045,171 @@ type doctorDependencyDiagnostic struct {
 	Code       string
 	Issue      connector.Issue
 	References []string
+}
+
+func checkDoctorBlockedRecovery(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
+	name := "Project " + id + " blocked recovery"
+	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "live blocked recovery diagnostics skipped for " + cfg.Tracker.Kind + " tracker",
+		}
+	}
+
+	if deps.autoPromoteConnector == nil {
+		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector
+	}
+	projectConnector, err := deps.autoPromoteConnector(cfg)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("create blocked recovery diagnostic connector: %v", err),
+			Hint:   "Fix GitHub tracker credentials and ProjectV2 configuration.",
+		}
+	}
+	if projectConnector == nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "create blocked recovery diagnostic connector: connector is nil",
+			Hint:   "Fix GitHub tracker configuration.",
+		}
+	}
+
+	check := checkDoctorBlockedRecoveryLive(ctx, name, projectConnector)
+	if err := closeDoctorAutoPromoteConnector(projectConnector); err != nil && check.Status != doctorFail {
+		check.Status = doctorWarn
+		check.Detail = check.Detail + "; connector close failed: " + err.Error()
+		check.Hint = "Rerun detent doctor and check local network resources."
+	}
+	return check
+}
+
+func checkDoctorBlockedRecoveryLive(
+	ctx context.Context,
+	name string,
+	projectConnector doctorAutoPromoteConnector,
+) doctorCheck {
+	if verifier, ok := projectConnector.(doctorStatusOptionVerifier); ok {
+		if err := verifier.VerifyStatusOptions(ctx, []string{"Blocked", "Rework"}); err != nil {
+			return doctorCheck{
+				Name:   name,
+				Status: doctorFail,
+				Detail: fmt.Sprintf("status option verification failed: %v", err),
+				Hint:   "Ensure Blocked and Rework resolve through tracker.state_map to existing GitHub Project Status options.",
+			}
+		}
+	}
+
+	issues, err := fetchDoctorBlockedRecoveryIssues(ctx, projectConnector)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("fetch blocked candidates: %v", err),
+			Hint:   "Check GitHub Project access, Status field options, and repository pull request access.",
+		}
+	}
+
+	candidates := []doctorBlockedRecoveryCandidateDiagnostic{}
+	for _, issue := range issues {
+		decision := orchestrator.EvaluateBlockedRecovery(issue)
+		if decision.Action != orchestrator.BlockedRecoveryActionRework {
+			continue
+		}
+		candidates = append(candidates, doctorBlockedRecoveryCandidateDiagnosticFromIssue(issue, decision))
+	}
+
+	detail := fmt.Sprintf("sampled %d Blocked candidate(s)", len(issues))
+	if len(candidates) == 0 {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: detail + "; no agent-recoverable blocked candidates found",
+		}
+	}
+	detail += "; " + doctorBlockedRecoveryCandidateSummaries(candidates)
+	return doctorCheck{
+		Name:                      name,
+		Status:                    doctorWarn,
+		Detail:                    detail,
+		Hint:                      "Detent can recover these Blocked issues to Rework because the next action is PR maintenance.",
+		BlockedRecoveryCandidates: candidates,
+	}
+}
+
+func fetchDoctorBlockedRecoveryIssues(
+	ctx context.Context,
+	projectConnector doctorAutoPromoteConnector,
+) ([]connector.Issue, error) {
+	if limited, ok := projectConnector.(doctorAutoPromoteLimitedConnector); ok {
+		return limited.FetchIssuesByStatesLimit(ctx, []string{"Blocked"}, doctorBlockedRecoverySampleLimit)
+	}
+	issues, err := projectConnector.FetchIssuesByStates(ctx, []string{"Blocked"})
+	if err != nil {
+		return nil, err
+	}
+	if len(issues) > doctorBlockedRecoverySampleLimit {
+		issues = issues[:doctorBlockedRecoverySampleLimit]
+	}
+	return issues, nil
+}
+
+func doctorBlockedRecoveryCandidateDiagnosticFromIssue(
+	issue connector.Issue,
+	decision orchestrator.BlockedRecoveryDecision,
+) doctorBlockedRecoveryCandidateDiagnostic {
+	diagnostic := doctorBlockedRecoveryCandidateDiagnostic{
+		IssueID:         strings.TrimSpace(issue.ID),
+		IssueIdentifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:        strings.TrimSpace(issue.URL),
+		TargetState:     strings.TrimSpace(decision.TargetState),
+		Reason:          string(decision.Reason),
+		Detail:          strings.TrimSpace(decision.Detail),
+	}
+	if issue.PullRequest == nil {
+		return diagnostic
+	}
+	pullRequest := issue.PullRequest
+	diagnostic.PRNumber = pullRequest.Number
+	diagnostic.PRURL = strings.TrimSpace(pullRequest.URL)
+	diagnostic.PRHeadSHA = strings.TrimSpace(pullRequest.HeadSHA)
+	return diagnostic
+}
+
+func doctorBlockedRecoveryCandidateSummaries(candidates []doctorBlockedRecoveryCandidateDiagnostic) string {
+	parts := make([]string, 0, len(candidates))
+	for _, candidate := range candidates {
+		summary := "pr_recoverable_blocked: " + doctorBlockedRecoveryIssueLabel(candidate)
+		if candidate.PRNumber > 0 {
+			summary += fmt.Sprintf(" PR #%d", candidate.PRNumber)
+		}
+		if candidate.Reason != "" {
+			summary += " reason=" + candidate.Reason
+		}
+		if candidate.TargetState != "" {
+			summary += " target=" + candidate.TargetState
+		}
+		parts = append(parts, summary)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func doctorBlockedRecoveryIssueLabel(candidate doctorBlockedRecoveryCandidateDiagnostic) string {
+	id := strings.TrimSpace(candidate.IssueID)
+	identifier := strings.TrimSpace(candidate.IssueIdentifier)
+	switch {
+	case id != "" && identifier != "":
+		return id + " (" + identifier + ")"
+	case id != "":
+		return id
+	case identifier != "":
+		return identifier
+	default:
+		return "sampled issue"
+	}
 }
 
 func checkDoctorDependencyAutoUnblock(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -625,6 +625,60 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorBlockedRecovery(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 426
+	humanPRNumber := 427
+	recoverable := doctorDependencyIssue("issue-recoverable", nil)
+	recoverable.PRNumber = &prNumber
+	recoverable.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		State:          "OPEN",
+		HeadSHA:        "head-current",
+		MergeableState: "dirty",
+	}
+	recoverable.BlockerReason = "PR #426 conflicts with main and needs agent maintenance."
+	humanOnly := doctorDependencyIssue("issue-human", nil)
+	humanOnly.PRNumber = &humanPRNumber
+	humanOnly.PullRequest = &connector.PullRequest{
+		Number:         humanPRNumber,
+		State:          "OPEN",
+		HeadSHA:        "head-current",
+		MergeableState: "dirty",
+	}
+	humanOnly.BlockerReason = "Waiting on explicit human approval."
+	fake := &fakeDoctorAutoPromoteConnector{
+		issues: []connector.Issue{recoverable, humanOnly},
+	}
+
+	got := checkDoctorBlockedRecovery(context.Background(), "alpha", validDoctorDependencyWorkflow(true), doctorDeps{
+		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+			return fake, nil
+		},
+	})
+
+	if got.Status != doctorWarn {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorWarn, got)
+	}
+	for _, want := range []string{
+		"pr_recoverable_blocked",
+		"issue-recoverable",
+		"merge_conflicts",
+		"Rework",
+	} {
+		if !strings.Contains(got.Detail, want) && !strings.Contains(got.Hint, want) {
+			t.Fatalf("check missing %q:\nDetail: %s\nHint: %s", want, got.Detail, got.Hint)
+		}
+	}
+	if strings.Contains(got.Detail, "issue-human") {
+		t.Fatalf("Detail = %q, want human blocker omitted from recoverable diagnostics", got.Detail)
+	}
+	if !stringSliceContains(fake.verifyStates, "Blocked") || !stringSliceContains(fake.verifyStates, "Rework") {
+		t.Fatalf("VerifyStatusOptions states = %#v, want Blocked and Rework", fake.verifyStates)
+	}
+}
+
 func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -3392,10 +3392,8 @@ func parseBlockedByFromIssueText(issue githubIssueNode, repo string) []connector
 		if !strings.Contains(strings.ToLower(comment.Body), "codex workpad") {
 			continue
 		}
-		for _, section := range []string{"Blockers", "Human Action Needed"} {
-			for _, identifier := range issueReferencesInText(markdownSectionText(comment.Body, section), repo) {
-				appendBlockers([]connector.BlockedRef{{Identifier: identifier}})
-			}
+		for _, identifier := range issueReferencesInText(markdownSectionText(comment.Body, "Blockers"), repo) {
+			appendBlockers([]connector.BlockedRef{{Identifier: identifier}})
 		}
 	}
 	return blockers

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -584,15 +584,18 @@ type pullRequest struct {
 }
 
 type pullRequestNode struct {
-	Number        int                               `json:"number"`
-	URL           string                            `json:"url"`
-	State         string                            `json:"state"`
-	ActivityAt    *time.Time                        `json:"activityAt"`
-	HeadRefName   string                            `json:"headRefName"`
-	HeadSHA       string                            `json:"headSHA"`
-	Commits       nodeConnection[pullRequestCommit] `json:"commits"`
-	LatestReviews nodeConnection[pullRequestReview] `json:"latestReviews"`
-	CodexReviews  pullRequestCodexReviews           `json:"-"`
+	Number         int                               `json:"number"`
+	URL            string                            `json:"url"`
+	State          string                            `json:"state"`
+	MergeableState string                            `json:"mergeableState"`
+	Draft          bool                              `json:"draft"`
+	ActivityAt     *time.Time                        `json:"activityAt"`
+	HeadRefName    string                            `json:"headRefName"`
+	HeadSHA        string                            `json:"headSHA"`
+	Commits        nodeConnection[pullRequestCommit] `json:"commits"`
+	LatestReviews  nodeConnection[pullRequestReview] `json:"latestReviews"`
+	CodexReviews   pullRequestCodexReviews           `json:"-"`
+	CI             pullRequestCI                     `json:"-"`
 }
 
 type pullRequestCommit struct {
@@ -651,12 +654,14 @@ type restAssignee struct {
 }
 
 type restPullRequest struct {
-	Number    int        `json:"number"`
-	HTMLURL   string     `json:"html_url"`
-	State     string     `json:"state"`
-	Head      restHead   `json:"head"`
-	UpdatedAt *time.Time `json:"updated_at"`
-	MergedAt  *string    `json:"merged_at"`
+	Number         int        `json:"number"`
+	HTMLURL        string     `json:"html_url"`
+	State          string     `json:"state"`
+	MergeableState string     `json:"mergeable_state"`
+	Draft          bool       `json:"draft"`
+	Head           restHead   `json:"head"`
+	UpdatedAt      *time.Time `json:"updated_at"`
+	MergedAt       *string    `json:"merged_at"`
 }
 
 type restHead struct {
@@ -686,6 +691,12 @@ type restCommitStatus struct {
 	Context   string     `json:"context"`
 	State     string     `json:"state"`
 	CreatedAt *time.Time `json:"created_at"`
+}
+
+type pullRequestCI struct {
+	State              string
+	CheckRunCount      int
+	StatusContextCount int
 }
 
 type restComment struct {
@@ -1251,6 +1262,9 @@ func (c *Connector) populateBlockerReasons(ctx context.Context, issues []connect
 			Body:     issues[index].Description,
 			Comments: nodeConnection[issueComment]{Nodes: comments},
 		}
+		if len(issues[index].BlockedBy) == 0 {
+			issues[index].BlockedBy = parseBlockedByFromIssueText(node, issueRepo(issues[index].Identifier))
+		}
 		if reason := parseBlockerReason(node); reason != "" {
 			issues[index].BlockerReason = reason
 		}
@@ -1439,6 +1453,9 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 		}
 		if owner, name, ok := splitRepositoryName(issue.PRRepository); ok {
 			linkedPullRequestRepo = pullRequestRepo{Owner: owner, Name: name}
+		}
+		if normalizeStateName(issue.State) == normalizeStateName("Blocked") && pullRequestNumber <= 0 {
+			branchPrefix = ""
 		}
 		if branchPrefix == "" && pullRequestNumber <= 0 {
 			continue
@@ -1676,12 +1693,14 @@ func hasUnattachedBranchPullRequestCandidates(issues []connector.Issue, candidat
 
 func pullRequestNodeFromREST(pullRequest restPullRequest) pullRequestNode {
 	return pullRequestNode{
-		Number:      pullRequest.Number,
-		URL:         pullRequest.HTMLURL,
-		State:       restPullRequestState(pullRequest),
-		ActivityAt:  cloneGitHubTime(pullRequest.UpdatedAt),
-		HeadRefName: pullRequest.Head.Ref,
-		HeadSHA:     pullRequest.Head.SHA,
+		Number:         pullRequest.Number,
+		URL:            pullRequest.HTMLURL,
+		State:          restPullRequestState(pullRequest),
+		MergeableState: strings.ToLower(strings.TrimSpace(pullRequest.MergeableState)),
+		Draft:          pullRequest.Draft,
+		ActivityAt:     cloneGitHubTime(pullRequest.UpdatedAt),
+		HeadRefName:    pullRequest.Head.Ref,
+		HeadSHA:        pullRequest.Head.SHA,
 	}
 }
 
@@ -1691,9 +1710,13 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		URL:                          strings.TrimSpace(pullRequest.URL),
 		BranchName:                   strings.TrimSpace(pullRequest.HeadRefName),
 		State:                        strings.ToUpper(strings.TrimSpace(pullRequest.State)),
+		MergeableState:               strings.ToLower(strings.TrimSpace(pullRequest.MergeableState)),
+		Draft:                        pullRequest.Draft,
 		ActivityAt:                   cloneGitHubTime(pullRequest.ActivityAt),
 		HeadSHA:                      strings.TrimSpace(pullRequest.HeadSHA),
 		CIStatus:                     normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
+		CheckRunCount:                pullRequest.CI.CheckRunCount,
+		StatusContextCount:           pullRequest.CI.StatusContextCount,
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
 		CodexReviewSubmittedAt:       pullRequestCodexReviewSubmittedAt(pullRequest),
 		CodexReviewFindings:          pullRequestCodexReviewFindings(pullRequest),
@@ -1721,12 +1744,13 @@ func pullRequestRepoName(repo pullRequestRepo) string {
 
 func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode) error {
 	if strings.TrimSpace(pullRequest.HeadSHA) != "" {
-		ciState, err := c.fetchPullRequestCIState(ctx, repo, pullRequest.HeadSHA)
+		ci, err := c.fetchPullRequestCI(ctx, repo, pullRequest.HeadSHA)
 		if err != nil {
 			return err
 		}
+		pullRequest.CI = ci
 		pullRequest.Commits = nodeConnection[pullRequestCommit]{Nodes: []pullRequestCommit{{
-			Commit: commitNode{StatusCheckRollup: &statusCheckRollup{State: ciState}},
+			Commit: commitNode{StatusCheckRollup: &statusCheckRollup{State: ci.State}},
 		}}}
 	}
 	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number, pullRequest.HeadSHA)
@@ -1738,16 +1762,20 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	return nil
 }
 
-func (c *Connector) fetchPullRequestCIState(ctx context.Context, repo pullRequestRepo, sha string) (string, error) {
+func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo, sha string) (pullRequestCI, error) {
 	checkRuns, err := fetchRESTCheckRuns(ctx, c.client, restCommitCheckRunsPath(repo, sha))
 	if err != nil {
-		return "", fmt.Errorf("fetch github check runs: %w", err)
+		return pullRequestCI{}, fmt.Errorf("fetch github check runs: %w", err)
 	}
 	statuses, err := fetchRESTList[restCommitStatus](ctx, c.client, restCommitStatusesPath(repo, sha))
 	if err != nil {
-		return "", fmt.Errorf("fetch github commit statuses: %w", err)
+		return pullRequestCI{}, fmt.Errorf("fetch github commit statuses: %w", err)
 	}
-	return combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses)), nil
+	return pullRequestCI{
+		State:              combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses)),
+		CheckRunCount:      len(checkRuns),
+		StatusContextCount: len(statuses),
+	}, nil
 }
 
 func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int, headSHA string) (pullRequestCodexReviews, error) {
@@ -3342,6 +3370,37 @@ func parseBlockerReason(issue githubIssueNode) string {
 	return markdownSectionText(issue.Body, "Human Action Needed")
 }
 
+func parseBlockedByFromIssueText(issue githubIssueNode, repo string) []connector.BlockedRef {
+	blockers := []connector.BlockedRef{}
+	seen := map[string]struct{}{}
+	appendBlockers := func(refs []connector.BlockedRef) {
+		for _, ref := range refs {
+			key := normalizedIssueIdentifier(ref.Identifier)
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			blockers = append(blockers, ref)
+		}
+	}
+	appendBlockers(parseBlockedBy(issue.Body, repo))
+	for _, comment := range issue.Comments.Nodes {
+		appendBlockers(parseBlockedBy(comment.Body, repo))
+		if !strings.Contains(strings.ToLower(comment.Body), "codex workpad") {
+			continue
+		}
+		for _, section := range []string{"Blockers", "Human Action Needed"} {
+			for _, identifier := range issueReferencesInText(markdownSectionText(comment.Body, section), repo) {
+				appendBlockers([]connector.BlockedRef{{Identifier: identifier}})
+			}
+		}
+	}
+	return blockers
+}
+
 func markdownSectionText(body string, title string) string {
 	want := normalizeSectionTitle(title)
 	inSection := false
@@ -3588,7 +3647,7 @@ func stateInList(state string, states []string) bool {
 }
 
 func attachPullRequestsForStates(states map[string]struct{}) bool {
-	for _, state := range []string{"Human Review", "Merging", "Done"} {
+	for _, state := range []string{"Human Review", "Merging", "Done", "Blocked"} {
 		if _, ok := states[normalizeStateName(state)]; ok {
 			return true
 		}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1004,6 +1004,91 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadHumanActionNeeded(t *testing
 	}
 }
 
+func TestConnectorFetchIssuesByStatesExtractsWorkpadBlockedByRefs(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw416","number":416,"title":"Blocked workpad dependency","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/416","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Blocked"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/416/comments?per_page=100",
+			body:   `[{"body":"## Codex Workpad\n\n### Blockers\n- Blocked by: #415\n- Waiting for digitaldrywood/agent-runtime#25\n\n### Validation\n- Pending."}]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Blocked"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	want := []connector.BlockedRef{
+		{Identifier: "digitaldrywood/detent#415"},
+		{Identifier: "digitaldrywood/agent-runtime#25"},
+	}
+	if !reflect.DeepEqual(got[0].BlockedBy, want) {
+		t.Fatalf("BlockedBy = %#v, want %#v", got[0].BlockedBy, want)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesAttachesBlockedPullRequest(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_396","content":{"__typename":"Issue","id":"I_396","number":396,"title":"Blocked PR maintenance","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/396","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"bug"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":426,"url":"https://github.com/digitaldrywood/detent/pull/426","state":"OPEN","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}},"statusValue":{"name":"Blocked"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/396/comments?per_page=100",
+			body:   `[{"body":"## Codex Workpad\n\n### Human Action Needed\n- PR #426 latest head has no check-runs and conflicts with main."}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/426",
+			body:   `{"number":426,"html_url":"https://github.com/digitaldrywood/detent/pull/426","state":"open","mergeable_state":"dirty","head":{"ref":"detent/digitaldrywood_detent_396","sha":"head-current"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100",
+			body:   `{"check_runs":[]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/426/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Blocked"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	pr := got[0].PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want linked blocked PR")
+	}
+	if pr.Number != 426 || pr.State != "OPEN" || pr.HeadSHA != "head-current" || pr.MergeableState != "dirty" || pr.CIStatus != "" || pr.CheckRunCount != 0 {
+		t.Fatalf("PullRequest = %#v, want dirty PR with no current-head checks", pr)
+	}
+}
+
 func TestConnectorFetchIssueStatesByIDsUsesProjectStatusAndRequestOrder(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1037,6 +1037,34 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadBlockedByRefs(t *testing.T) 
 	}
 }
 
+func TestConnectorFetchIssuesByStatesIgnoresHumanActionIssueMentions(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw417","number":417,"title":"Human blocked reference","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/417","repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Blocked"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/417/comments?per_page=100",
+			body:   `[{"body":"## Codex Workpad\n\n### Human Action Needed\n- Need product approval based on #123 before continuing.\n\n### Validation\n- Pending."}]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Blocked"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	if len(got[0].BlockedBy) != 0 {
+		t.Fatalf("BlockedBy = %#v, want no dependency refs from Human Action Needed prose", got[0].BlockedBy)
+	}
+}
+
 func TestConnectorFetchIssuesByStatesAttachesBlockedPullRequest(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -46,9 +46,13 @@ type PullRequest struct {
 	URL                          string               `json:"url,omitempty" yaml:"url,omitempty"`
 	BranchName                   string               `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	State                        string               `json:"state,omitempty" yaml:"state,omitempty"`
+	MergeableState               string               `json:"mergeable_state,omitempty" yaml:"mergeable_state,omitempty"`
+	Draft                        bool                 `json:"draft,omitempty" yaml:"draft,omitempty"`
 	ActivityAt                   *time.Time           `json:"activity_at,omitempty" yaml:"activity_at,omitempty"`
 	HeadSHA                      string               `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
 	CIStatus                     string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
+	CheckRunCount                int                  `json:"check_run_count,omitempty" yaml:"check_run_count,omitempty"`
+	StatusContextCount           int                  `json:"status_context_count,omitempty" yaml:"status_context_count,omitempty"`
 	CodexReviewState             string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
 	CodexReviewSubmittedAt       *time.Time           `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`
 	CodexReviewFindings          []PullRequestFinding `json:"codex_review_findings,omitempty" yaml:"codex_review_findings,omitempty"`

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -40,6 +40,7 @@ type BlockedRecoveryDecision struct {
 }
 
 func EvaluateBlockedRecovery(issue connector.Issue) BlockedRecoveryDecision {
+	issue = issueWithTextDependencyRefs(issue)
 	if normalizeState(issue.State) != "blocked" {
 		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonNotBlocked, "")
 	}

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -1,0 +1,278 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type BlockedRecoveryAction string
+
+const (
+	BlockedRecoveryActionNone   BlockedRecoveryAction = ""
+	BlockedRecoveryActionRework BlockedRecoveryAction = "rework"
+)
+
+type BlockedRecoveryReason string
+
+const (
+	BlockedRecoveryReasonNotBlocked             BlockedRecoveryReason = "not_blocked"
+	BlockedRecoveryReasonHumanBlocker           BlockedRecoveryReason = "human_blocker"
+	BlockedRecoveryReasonMissingPullRequest     BlockedRecoveryReason = "missing_pull_request"
+	BlockedRecoveryReasonPullRequestNotOpen     BlockedRecoveryReason = "pull_request_not_open"
+	BlockedRecoveryReasonNoRecoverableSignal    BlockedRecoveryReason = "no_recoverable_signal"
+	BlockedRecoveryReasonMergeConflicts         BlockedRecoveryReason = "merge_conflicts"
+	BlockedRecoveryReasonStaleBase              BlockedRecoveryReason = "stale_base"
+	BlockedRecoveryReasonMissingCurrentHeadCI   BlockedRecoveryReason = "missing_current_head_ci"
+	BlockedRecoveryReasonPullRequestMaintenance BlockedRecoveryReason = "pull_request_maintenance"
+)
+
+type BlockedRecoveryDecision struct {
+	Action      BlockedRecoveryAction
+	Reason      BlockedRecoveryReason
+	TargetState string
+	Detail      string
+}
+
+func EvaluateBlockedRecovery(issue connector.Issue) BlockedRecoveryDecision {
+	if normalizeState(issue.State) != "blocked" {
+		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonNotBlocked, "")
+	}
+	if blockedRecoveryHumanOnly(issue) {
+		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonHumanBlocker, "blocked reason requires a human")
+	}
+	if issue.PullRequest == nil {
+		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonMissingPullRequest, "")
+	}
+	pr := issue.PullRequest
+	if normalizePullRequestState(pr.State) != "open" {
+		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonPullRequestNotOpen, "")
+	}
+
+	switch strings.ToLower(strings.TrimSpace(pr.MergeableState)) {
+	case "dirty":
+		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonMergeConflicts, "linked PR has merge conflicts")
+	case "behind":
+		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonStaleBase, "linked PR branch is behind the base branch")
+	}
+
+	text := blockedRecoveryText(issue)
+	if blockedRecoveryNoCurrentHeadCI(pr) && (blockedRecoveryAgentText(text) || blockedRecoveryHasPriorSignal(pr)) {
+		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonMissingCurrentHeadCI, "latest PR head has no CI signal")
+	}
+	if blockedRecoveryAgentText(text) {
+		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonPullRequestMaintenance, "blocked reason describes agent-recoverable PR maintenance")
+	}
+	return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonNoRecoverableSignal, "")
+}
+
+func blockedRecoveryDecision(action BlockedRecoveryAction, reason BlockedRecoveryReason, detail string) BlockedRecoveryDecision {
+	decision := BlockedRecoveryDecision{
+		Action: action,
+		Reason: reason,
+		Detail: strings.TrimSpace(detail),
+	}
+	if action == BlockedRecoveryActionRework {
+		decision.TargetState = autoPromoteReworkState
+	}
+	return decision
+}
+
+func (o *Orchestrator) recoverBlockedIssues(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) map[string]struct{} {
+	transitioned := map[string]struct{}{}
+	for _, issue := range issuesInStates(issues, []string{blockedStatusState}) {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+		decision := EvaluateBlockedRecovery(issue)
+		if decision.Action != BlockedRecoveryActionRework {
+			continue
+		}
+		if !o.applyBlockedRecovery(ctx, state, issue, decision, now) {
+			continue
+		}
+		transitioned[issueID] = struct{}{}
+	}
+	if len(transitioned) == 0 {
+		return nil
+	}
+	return transitioned
+}
+
+func (o *Orchestrator) applyBlockedRecovery(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	decision BlockedRecoveryDecision,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	targetState := strings.TrimSpace(decision.TargetState)
+	if targetState == "" {
+		targetState = autoPromoteReworkState
+	}
+	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("blocked recovery transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason, "error", err)
+		}
+		return false
+	}
+
+	body := blockedRecoveryComment(issue, targetState, decision)
+	if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+		o.logger.Warn("blocked recovery comment failed", "issue_id", issueID, "identifier", issue.Identifier, "target_state", targetState, "reason", decision.Reason, "error", err)
+	}
+
+	delete(state.Blocked, issueID)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "blocked_recovery_transition",
+		Message: "recovered " + issueLabel(issue) + " from " + issue.State + " to " + targetState + ": " + string(decision.Reason),
+	})
+	if o.logger != nil {
+		o.logger.Info("blocked recovery transition", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason)
+	}
+	return true
+}
+
+func blockedRecoveryComment(issue connector.Issue, targetState string, decision BlockedRecoveryDecision) string {
+	var b strings.Builder
+	b.WriteString("PR maintenance is agent-recoverable.")
+	if strings.TrimSpace(issue.State) != "" && strings.TrimSpace(targetState) != "" {
+		b.WriteString(" Moved this issue from ")
+		b.WriteString(strings.TrimSpace(issue.State))
+		b.WriteString(" to ")
+		b.WriteString(strings.TrimSpace(targetState))
+		b.WriteString(".")
+	}
+	b.WriteString("\n\nReason: ")
+	b.WriteString(blockedRecoveryReasonLabel(decision.Reason))
+	if decision.Detail != "" {
+		b.WriteString(" (")
+		b.WriteString(decision.Detail)
+		b.WriteString(")")
+	}
+	if pr := issue.PullRequest; pr != nil && pr.Number > 0 {
+		b.WriteString(fmt.Sprintf("\nLinked PR: #%d", pr.Number))
+		if url := strings.TrimSpace(pr.URL); url != "" {
+			b.WriteString(" ")
+			b.WriteString(url)
+		}
+	}
+	return b.String()
+}
+
+func blockedRecoveryReasonLabel(reason BlockedRecoveryReason) string {
+	switch reason {
+	case BlockedRecoveryReasonMergeConflicts:
+		return "merge conflicts"
+	case BlockedRecoveryReasonStaleBase:
+		return "stale base"
+	case BlockedRecoveryReasonMissingCurrentHeadCI:
+		return "missing current-head CI"
+	case BlockedRecoveryReasonPullRequestMaintenance:
+		return "PR maintenance"
+	default:
+		return strings.ReplaceAll(string(reason), "_", " ")
+	}
+}
+
+func blockedRecoveryHumanOnly(issue connector.Issue) bool {
+	for _, label := range issue.Labels {
+		if normalizeLabel(label) == "requires-human-review" {
+			return true
+		}
+	}
+	text := blockedRecoveryReasonText(issue)
+	for _, phrase := range []string{
+		"missing credential",
+		"missing credentials",
+		"credential",
+		"secret",
+		"token",
+		"human approval",
+		"explicit human approval",
+		"requires human",
+		"requires-human-review",
+		"human review",
+		"product direction",
+		"ambiguous",
+		"approval required",
+		"manual approval",
+		"unresolved human-requested",
+		"human-requested review changes",
+		"requested changes from human",
+		"missing access",
+		"permission",
+	} {
+		if strings.Contains(text, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func blockedRecoveryAgentText(text string) bool {
+	for _, phrase := range []string{
+		"merge conflict",
+		"conflict with main",
+		"conflicts with main",
+		"stale base",
+		"behind main",
+		"rebase",
+		"retrigger",
+		"rerun check",
+		"rerun ci",
+		"no check-run",
+		"no check run",
+		"no check-runs",
+		"no check runs",
+		"missing check",
+		"latest head has no",
+		"push an empty commit",
+		"agent maintenance",
+		"pr maintenance",
+	} {
+		if strings.Contains(text, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func blockedRecoveryNoCurrentHeadCI(pr *connector.PullRequest) bool {
+	if pr == nil || strings.TrimSpace(pr.HeadSHA) == "" || strings.TrimSpace(pr.CIStatus) != "" {
+		return false
+	}
+	return pr.CheckRunCount == 0 && pr.StatusContextCount == 0
+}
+
+func blockedRecoveryHasPriorSignal(pr *connector.PullRequest) bool {
+	if pr == nil {
+		return false
+	}
+	headSHA := strings.TrimSpace(pr.HeadSHA)
+	latestReviewSHA := strings.TrimSpace(pr.LatestCodexReviewCommitSHA)
+	if headSHA == "" || latestReviewSHA == "" || strings.EqualFold(headSHA, latestReviewSHA) {
+		return false
+	}
+	return strings.TrimSpace(pr.LatestCodexReviewState) != "" || pr.LatestCodexReviewSubmittedAt != nil
+}
+
+func blockedRecoveryText(issue connector.Issue) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(issue.BlockerReason+" "+issue.Description)), " "))
+}
+
+func blockedRecoveryReasonText(issue connector.Issue) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(issue.BlockerReason)), " "))
+}

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -22,6 +22,7 @@ type BlockedRecoveryReason string
 const (
 	BlockedRecoveryReasonNotBlocked             BlockedRecoveryReason = "not_blocked"
 	BlockedRecoveryReasonHumanBlocker           BlockedRecoveryReason = "human_blocker"
+	BlockedRecoveryReasonDependencyBlocker      BlockedRecoveryReason = "dependency_blocker"
 	BlockedRecoveryReasonMissingPullRequest     BlockedRecoveryReason = "missing_pull_request"
 	BlockedRecoveryReasonPullRequestNotOpen     BlockedRecoveryReason = "pull_request_not_open"
 	BlockedRecoveryReasonNoRecoverableSignal    BlockedRecoveryReason = "no_recoverable_signal"
@@ -44,6 +45,9 @@ func EvaluateBlockedRecovery(issue connector.Issue) BlockedRecoveryDecision {
 	}
 	if blockedRecoveryHumanOnly(issue) {
 		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonHumanBlocker, "blocked reason requires a human")
+	}
+	if len(issue.BlockedBy) > 0 {
+		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonDependencyBlocker, "dependency blockers must clear first")
 	}
 	if issue.PullRequest == nil {
 		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonMissingPullRequest, "")

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"regexp"
 	"strings"
 	"time"
 
@@ -28,6 +29,12 @@ type dependencyBlocker struct {
 	Issue    connector.Issue
 	Resolved bool
 }
+
+var (
+	dependencyTextLinePattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*:\\s*(?:[*_`~]+)?\\s*(.+)\\s*$")
+	dependencyIssueRefPattern = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
+	dependencyIssueURLPattern = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
+)
 
 func normalizeDependencyAutoUnblockConfig(cfg DependencyAutoUnblockConfig) DependencyAutoUnblockConfig {
 	cfg.SourceStates = normalizedStates(defaultStringSlice(cfg.SourceStates, []string{blockedStatusState}))
@@ -77,6 +84,7 @@ func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(
 	issue connector.Issue,
 	sourceStates []string,
 ) (connector.Issue, bool) {
+	issue = issueWithTextDependencyRefs(issue)
 	if len(issue.BlockedBy) > 0 || strings.TrimSpace(issue.Identifier) == "" {
 		return issue, stateIn(issue.State, sourceStates)
 	}
@@ -96,9 +104,158 @@ func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(
 			continue
 		}
 		merged := mergeIssueTrackerFields(issue, hydrated)
+		merged = issueWithTextDependencyRefs(merged)
 		return merged, stateIn(merged.State, sourceStates)
 	}
 	return issue, true
+}
+
+func issueWithTextDependencyRefs(issue connector.Issue) connector.Issue {
+	if len(issue.BlockedBy) > 0 {
+		return issue
+	}
+	issue.BlockedBy = dependencyRefsFromIssueText(issue)
+	return issue
+}
+
+func dependencyRefsFromIssueText(issue connector.Issue) []connector.BlockedRef {
+	repo := dependencyIssueRepo(issue.Identifier)
+	refs := []connector.BlockedRef{}
+	seen := map[string]struct{}{}
+	appendRefs := func(incoming []connector.BlockedRef) {
+		for _, ref := range incoming {
+			key := strings.ToLower(strings.TrimSpace(ref.Identifier))
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			refs = append(refs, ref)
+		}
+	}
+	appendRefs(dependencyLineRefs(issue.Description, repo))
+	for _, section := range []string{"Blockers", "Human Action Needed"} {
+		appendRefs(dependencyRefsInText(dependencyMarkdownSectionText(issue.Description, section), repo))
+	}
+	appendRefs(dependencyRefsInText(issue.BlockerReason, repo))
+	return refs
+}
+
+func dependencyLineRefs(body string, repo string) []connector.BlockedRef {
+	refs := []connector.BlockedRef{}
+	for _, line := range strings.FieldsFunc(body, func(r rune) bool {
+		return r == '\n' || r == '\r'
+	}) {
+		lineMatches := dependencyTextLinePattern.FindStringSubmatch(line)
+		if len(lineMatches) != 2 {
+			continue
+		}
+		refs = append(refs, dependencyRefsInText(lineMatches[1], repo)...)
+	}
+	return refs
+}
+
+func dependencyRefsInText(text string, repo string) []connector.BlockedRef {
+	refs := []connector.BlockedRef{}
+	for _, identifier := range dependencyIssueIdentifiersInText(text, repo) {
+		refs = append(refs, connector.BlockedRef{Identifier: identifier})
+	}
+	return refs
+}
+
+func dependencyIssueIdentifiersInText(text string, repo string) []string {
+	refs := []string{}
+	seen := map[string]struct{}{}
+	add := func(refRepo string, number string) {
+		identifier := dependencyBlockerIdentifier(refRepo, number, repo)
+		if identifier == "" {
+			return
+		}
+		key := strings.ToLower(identifier)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, identifier)
+	}
+	for _, matches := range dependencyIssueURLPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) == 3 {
+			add(matches[1], matches[2])
+		}
+	}
+	for _, matches := range dependencyIssueRefPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) == 3 {
+			add(matches[1], matches[2])
+		}
+	}
+	return refs
+}
+
+func dependencyIssueRepo(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	index := strings.LastIndex(identifier, "#")
+	if index <= 0 {
+		return ""
+	}
+	return strings.TrimSpace(identifier[:index])
+}
+
+func dependencyBlockerIdentifier(refRepo string, number string, repo string) string {
+	if strings.TrimSpace(number) == "" {
+		return ""
+	}
+	refRepo = strings.TrimSpace(refRepo)
+	if refRepo == "" {
+		if repo == "" {
+			return "#" + strings.TrimSpace(number)
+		}
+		refRepo = repo
+	}
+	return refRepo + "#" + strings.TrimSpace(number)
+}
+
+func dependencyMarkdownSectionText(body string, title string) string {
+	want := dependencyNormalizeSectionTitle(title)
+	inSection := false
+	lines := []string{}
+	for line := range strings.SplitSeq(body, "\n") {
+		heading, ok := dependencyMarkdownHeadingTitle(line)
+		if ok {
+			if inSection {
+				break
+			}
+			inSection = dependencyNormalizeSectionTitle(heading) == want
+			continue
+		}
+		if inSection {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+func dependencyMarkdownHeadingTitle(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || line[0] != '#' {
+		return "", false
+	}
+	index := 0
+	for index < len(line) && line[index] == '#' {
+		index++
+	}
+	if index > 6 || index == len(line) {
+		return "", false
+	}
+	if line[index] != ' ' && line[index] != '\t' {
+		return "", false
+	}
+	return strings.Trim(strings.TrimSpace(line[index:]), "# \t"), true
+}
+
+func dependencyNormalizeSectionTitle(title string) string {
+	return strings.ToLower(strings.Join(strings.Fields(title), " "))
 }
 
 func sameIssueIdentity(left connector.Issue, right connector.Issue) bool {

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -136,10 +136,8 @@ func dependencyRefsFromIssueText(issue connector.Issue) []connector.BlockedRef {
 		}
 	}
 	appendRefs(dependencyLineRefs(issue.Description, repo))
-	for _, section := range []string{"Blockers", "Human Action Needed"} {
-		appendRefs(dependencyRefsInText(dependencyMarkdownSectionText(issue.Description, section), repo))
-	}
-	appendRefs(dependencyRefsInText(issue.BlockerReason, repo))
+	appendRefs(dependencyRefsInText(dependencyMarkdownSectionText(issue.Description, "Blockers"), repo))
+	appendRefs(dependencyReasonRefs(issue.BlockerReason, repo))
 	return refs
 }
 
@@ -163,6 +161,34 @@ func dependencyRefsInText(text string, repo string) []connector.BlockedRef {
 		refs = append(refs, connector.BlockedRef{Identifier: identifier})
 	}
 	return refs
+}
+
+func dependencyReasonRefs(reason string, repo string) []connector.BlockedRef {
+	refs := dependencyLineRefs(reason, repo)
+	if len(refs) > 0 {
+		return refs
+	}
+	if !dependencyReasonMentionsWaiting(reason) {
+		return nil
+	}
+	return dependencyRefsInText(reason, repo)
+}
+
+func dependencyReasonMentionsWaiting(reason string) bool {
+	reason = strings.ToLower(strings.Join(strings.Fields(reason), " "))
+	for _, phrase := range []string{
+		"waiting on",
+		"waited on",
+		"blocked by",
+		"depends on",
+		"dependency",
+		"blocker",
+	} {
+		if strings.Contains(reason, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 func dependencyIssueIdentifiersInText(text string, repo string) []string {

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -96,6 +96,67 @@ func TestTickAutoUnblocksLightweightDependencyWaitingIssue(t *testing.T) {
 	}
 }
 
+func TestTickAutoUnblocksDependencyFromIssueBody(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-body-blocked", "Blocked")
+	waiting.Description = "Depends on: #415"
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 3, 30, 0, time.UTC))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
+		t.Fatalf("updates = %#v, want Blocked issue moved to Todo", got)
+	}
+	if got, want := tracker.identifierCalls, []string{"digitaldrywood/detent#415"}; !slices.Equal(got, want) {
+		t.Fatalf("identifier calls = %#v, want %#v", got, want)
+	}
+}
+
+func TestTickAutoUnblocksDependencyFromBlockedReason(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-reason-blocked", "Blocked")
+	waiting.BlockerReason = "Blocked by: digitaldrywood/detent#415"
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 4, 0, 0, time.UTC))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
+		t.Fatalf("updates = %#v, want Blocked issue moved to Todo", got)
+	}
+	if got, want := tracker.identifierCalls, []string{"digitaldrywood/detent#415"}; !slices.Equal(got, want) {
+		t.Fatalf("identifier calls = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "digitaldrywood/detent#415") {
+		t.Fatalf("comments = %#v, want recovery comment with blocked reason dependency", tracker.comments)
+	}
+}
+
 func TestTickLeavesHumanBlockedIssueBlocked(t *testing.T) {
 	t.Parallel()
 
@@ -124,6 +185,82 @@ func TestTickLeavesHumanBlockedIssueBlocked(t *testing.T) {
 	}
 	if blocked.Reason != waiting.BlockerReason {
 		t.Fatalf("Blocked reason = %q, want %q", blocked.Reason, waiting.BlockerReason)
+	}
+}
+
+func TestTickRecoversPRBackedBlockedIssueToRework(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 426
+	waiting := dependencyAutoUnblockIssue("issue-pr-blocked", "Blocked")
+	waiting.PRNumber = &prNumber
+	waiting.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		URL:            "https://github.com/digitaldrywood/detent/pull/426",
+		State:          "OPEN",
+		HeadSHA:        "sha-current",
+		MergeableState: "dirty",
+	}
+	waiting.BlockerReason = "PR #426 conflicts with main and needs a rebase."
+	tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{waiting}}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 6, 0, 0, time.UTC))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Rework"}) {
+		t.Fatalf("updates = %#v, want Blocked issue moved to Rework", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one recovery comment", tracker.comments)
+	}
+	for _, want := range []string{"PR maintenance is agent-recoverable.", "Blocked to Rework", "merge conflicts", "#426"} {
+		if !strings.Contains(tracker.comments[0].body, want) {
+			t.Fatalf("comment %q missing %q", tracker.comments[0].body, want)
+		}
+	}
+	if _, ok := state.Blocked[waiting.ID]; ok {
+		t.Fatalf("Blocked[%q] present after PR recovery", waiting.ID)
+	}
+}
+
+func TestTickLeavesHumanOnlyPRBackedBlockedIssueBlocked(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 427
+	waiting := dependencyAutoUnblockIssue("issue-human-pr-blocked", "Blocked")
+	waiting.PRNumber = &prNumber
+	waiting.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		State:          "OPEN",
+		HeadSHA:        "sha-current",
+		MergeableState: "dirty",
+	}
+	waiting.BlockerReason = "Waiting on explicit human approval before continuing."
+	tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{waiting}}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 7, 0, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none", tracker.comments)
+	}
+	if _, ok := state.Blocked[waiting.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing for human-only blocker", waiting.ID)
 	}
 }
 

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -129,7 +129,7 @@ func TestTickAutoUnblocksDependencyFromBlockedReason(t *testing.T) {
 	t.Parallel()
 
 	waiting := dependencyAutoUnblockIssue("issue-reason-blocked", "Blocked")
-	waiting.BlockerReason = "Blocked by: digitaldrywood/detent#415"
+	waiting.BlockerReason = "Waiting on #415 before continuing."
 	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
 	blocker.Identifier = "digitaldrywood/detent#415"
 	tracker := &dependencyAutoUnblockConnector{
@@ -261,6 +261,44 @@ func TestTickLeavesHumanOnlyPRBackedBlockedIssueBlocked(t *testing.T) {
 	}
 	if _, ok := state.Blocked[waiting.ID]; !ok {
 		t.Fatalf("Blocked[%q] missing for human-only blocker", waiting.ID)
+	}
+}
+
+func TestTickLeavesDependencyBlockedPRIssueBlocked(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 428
+	waiting := dependencyAutoUnblockIssue("issue-dependent-pr-blocked", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415", State: "In Progress"}}
+	waiting.PRNumber = &prNumber
+	waiting.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		State:          "OPEN",
+		HeadSHA:        "sha-current",
+		MergeableState: "dirty",
+	}
+	waiting.BlockerReason = "Waiting on #415 before resolving PR conflicts."
+	blocker := dependencyAutoUnblockIssue("issue-in-progress", "In Progress")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 8, 0, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none while dependency is not ready", tracker.updates)
+	}
+	if _, ok := state.Blocked[waiting.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing for unresolved dependency blocker", waiting.ID)
 	}
 }
 

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -302,6 +302,46 @@ func TestTickLeavesDependencyBlockedPRIssueBlocked(t *testing.T) {
 	}
 }
 
+func TestTickLeavesTextDependencyBlockedPRIssueBlocked(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 429
+	waiting := dependencyAutoUnblockIssue("issue-text-dependent-pr-blocked", "Blocked")
+	waiting.PRNumber = &prNumber
+	waiting.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		State:          "OPEN",
+		HeadSHA:        "sha-current",
+		MergeableState: "dirty",
+	}
+	waiting.BlockerReason = "Waiting on #415 before resolving PR conflicts."
+	blocker := dependencyAutoUnblockIssue("issue-in-progress", "In Progress")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 9, 0, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none while text dependency is not ready", tracker.updates)
+	}
+	if got, want := tracker.identifierCalls, []string{"digitaldrywood/detent#415"}; !slices.Equal(got, want) {
+		t.Fatalf("identifier calls = %#v, want %#v", got, want)
+	}
+	if _, ok := state.Blocked[waiting.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing for unresolved text dependency blocker", waiting.ID)
+	}
+}
+
 func TestDependencyAutoUnblockDoesNotChangeTodoDependencyGate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -965,12 +965,15 @@ func (o *Orchestrator) trackBlockedStatusIssues(state *State, issues []connector
 		if issue.ID == "" {
 			continue
 		}
+		recovery := EvaluateBlockedRecovery(issue)
 		seenBlocked[issue.ID] = struct{}{}
 		state.Blocked[issue.ID] = Blocked{
-			Issue:     cloneIssue(issue),
-			Reason:    blockedStatusReason(issue),
-			BlockedAt: now,
-			Source:    BlockedSourceProjectStatus,
+			Issue:          cloneIssue(issue),
+			Reason:         blockedStatusReason(issue),
+			RecoveryReason: string(recovery.Reason),
+			RecoveryTarget: recovery.TargetState,
+			BlockedAt:      now,
+			Source:         BlockedSourceProjectStatus,
 		}
 	}
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -133,8 +133,10 @@ func blockedSnapshots(blocked map[string]Blocked, claims map[string]Claimed, now
 		issue := telemetryIssue(entry.Issue)
 		applyClaimSnapshot(&issue, claims[id], now)
 		item := telemetry.Blocked{
-			Issue: issue,
-			Error: entry.Reason,
+			Issue:          issue,
+			Error:          entry.Reason,
+			RecoveryReason: entry.RecoveryReason,
+			RecoveryTarget: entry.RecoveryTarget,
 		}
 		if !entry.BlockedAt.IsZero() {
 			blockedAt := entry.BlockedAt
@@ -228,12 +230,15 @@ func telemetryPullRequest(pullRequest *connector.PullRequest, prNumber *int) *te
 		pullRequest = &connector.PullRequest{Number: *prNumber}
 	}
 	return &telemetry.PullRequest{
-		Number:           pullRequest.Number,
-		URL:              pullRequest.URL,
-		BranchName:       pullRequest.BranchName,
-		State:            pullRequest.State,
-		CIStatus:         pullRequest.CIStatus,
-		CodexReviewState: pullRequest.CodexReviewState,
+		Number:             pullRequest.Number,
+		URL:                pullRequest.URL,
+		BranchName:         pullRequest.BranchName,
+		State:              pullRequest.State,
+		MergeableState:     pullRequest.MergeableState,
+		CIStatus:           pullRequest.CIStatus,
+		CheckRunCount:      pullRequest.CheckRunCount,
+		StatusContextCount: pullRequest.StatusContextCount,
+		CodexReviewState:   pullRequest.CodexReviewState,
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -70,10 +70,12 @@ const (
 )
 
 type Blocked struct {
-	Issue     connector.Issue
-	Reason    string
-	BlockedAt time.Time
-	Source    BlockedSource
+	Issue          connector.Issue
+	Reason         string
+	RecoveryReason string
+	RecoveryTarget string
+	BlockedAt      time.Time
+	Source         BlockedSource
 }
 
 type Completed struct {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -58,6 +58,11 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,
+			o.recoverBlockedIssues(ctx, state, fetched.status, now),
+		)
+		fetched = filterReconciledTickIssues(
+			state,
+			fetched,
 			o.autoUnblockDependencyIssues(ctx, state, fetched.status, now),
 		)
 		fetched = filterReconciledTickIssues(

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -88,12 +88,15 @@ type Issue struct {
 }
 
 type PullRequest struct {
-	Number           int    `json:"number,omitempty"`
-	URL              string `json:"url,omitempty"`
-	BranchName       string `json:"branch_name,omitempty"`
-	State            string `json:"state,omitempty"`
-	CIStatus         string `json:"ci_status,omitempty"`
-	CodexReviewState string `json:"codex_review_state,omitempty"`
+	Number             int    `json:"number,omitempty"`
+	URL                string `json:"url,omitempty"`
+	BranchName         string `json:"branch_name,omitempty"`
+	State              string `json:"state,omitempty"`
+	MergeableState     string `json:"mergeable_state,omitempty"`
+	CIStatus           string `json:"ci_status,omitempty"`
+	CheckRunCount      int    `json:"check_run_count,omitempty"`
+	StatusContextCount int    `json:"status_context_count,omitempty"`
+	CodexReviewState   string `json:"codex_review_state,omitempty"`
 }
 
 type ActivityEvent struct {
@@ -135,14 +138,16 @@ type Queued struct {
 
 type Blocked struct {
 	Issue
-	WorkerHost    string     `json:"worker_host,omitempty"`
-	WorkspacePath string     `json:"workspace_path,omitempty"`
-	SessionID     string     `json:"session_id,omitempty"`
-	Error         string     `json:"error,omitempty"`
-	BlockedAt     *time.Time `json:"blocked_at,omitempty"`
-	LastEventAt   *time.Time `json:"last_event_at,omitempty"`
-	LastEvent     string     `json:"last_event,omitempty"`
-	LastMessage   string     `json:"last_message,omitempty"`
+	WorkerHost     string     `json:"worker_host,omitempty"`
+	WorkspacePath  string     `json:"workspace_path,omitempty"`
+	SessionID      string     `json:"session_id,omitempty"`
+	Error          string     `json:"error,omitempty"`
+	RecoveryReason string     `json:"recovery_reason,omitempty"`
+	RecoveryTarget string     `json:"recovery_target,omitempty"`
+	BlockedAt      *time.Time `json:"blocked_at,omitempty"`
+	LastEventAt    *time.Time `json:"last_event_at,omitempty"`
+	LastEvent      string     `json:"last_event,omitempty"`
+	LastMessage    string     `json:"last_message,omitempty"`
 }
 
 type Completed struct {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -370,6 +370,8 @@ func blockedEntries(entries []telemetry.Blocked) []blockedAPIResponse {
 			BudgetAlert:      false,
 			State:            entry.State,
 			Error:            optionalString(entry.Error),
+			RecoveryReason:   optionalString(entry.RecoveryReason),
+			RecoveryTarget:   optionalString(entry.RecoveryTarget),
 			WorkerHost:       optionalString(entry.WorkerHost),
 			WorkspacePath:    optionalString(entry.WorkspacePath),
 			SessionID:        optionalString(entry.SessionID),
@@ -436,15 +438,17 @@ func retryIssueResponse(entry telemetry.Queued) *retryIssueAPIResponse {
 
 func blockedIssueResponse(entry telemetry.Blocked) *blockedIssueAPIResponse {
 	return &blockedIssueAPIResponse{
-		WorkerHost:    optionalString(entry.WorkerHost),
-		WorkspacePath: optionalString(entry.WorkspacePath),
-		SessionID:     optionalString(entry.SessionID),
-		State:         entry.State,
-		Error:         optionalString(entry.Error),
-		BlockedAt:     timestampStringPtr(entry.BlockedAt),
-		LastEvent:     optionalString(entry.LastEvent),
-		LastMessage:   optionalString(entry.LastMessage),
-		LastEventAt:   timestampStringPtr(entry.LastEventAt),
+		WorkerHost:     optionalString(entry.WorkerHost),
+		WorkspacePath:  optionalString(entry.WorkspacePath),
+		SessionID:      optionalString(entry.SessionID),
+		State:          entry.State,
+		Error:          optionalString(entry.Error),
+		RecoveryReason: optionalString(entry.RecoveryReason),
+		RecoveryTarget: optionalString(entry.RecoveryTarget),
+		BlockedAt:      timestampStringPtr(entry.BlockedAt),
+		LastEvent:      optionalString(entry.LastEvent),
+		LastMessage:    optionalString(entry.LastMessage),
+		LastEventAt:    timestampStringPtr(entry.LastEventAt),
 	}
 }
 
@@ -970,6 +974,8 @@ type blockedAPIResponse struct {
 	BudgetAlert      bool    `json:"budget_alert?"`
 	State            string  `json:"state"`
 	Error            *string `json:"error"`
+	RecoveryReason   *string `json:"recovery_reason"`
+	RecoveryTarget   *string `json:"recovery_target"`
 	WorkerHost       *string `json:"worker_host"`
 	WorkspacePath    *string `json:"workspace_path"`
 	SessionID        *string `json:"session_id"`
@@ -1140,15 +1146,17 @@ type retryIssueAPIResponse struct {
 }
 
 type blockedIssueAPIResponse struct {
-	WorkerHost    *string `json:"worker_host"`
-	WorkspacePath *string `json:"workspace_path"`
-	SessionID     *string `json:"session_id"`
-	State         string  `json:"state"`
-	Error         *string `json:"error"`
-	BlockedAt     *string `json:"blocked_at"`
-	LastEvent     *string `json:"last_event"`
-	LastMessage   *string `json:"last_message"`
-	LastEventAt   *string `json:"last_event_at"`
+	WorkerHost     *string `json:"worker_host"`
+	WorkspacePath  *string `json:"workspace_path"`
+	SessionID      *string `json:"session_id"`
+	State          string  `json:"state"`
+	Error          *string `json:"error"`
+	RecoveryReason *string `json:"recovery_reason"`
+	RecoveryTarget *string `json:"recovery_target"`
+	BlockedAt      *string `json:"blocked_at"`
+	LastEvent      *string `json:"last_event"`
+	LastMessage    *string `json:"last_message"`
+	LastEventAt    *string `json:"last_event_at"`
 }
 
 type logsAPIResponse struct {


### PR DESCRIPTION
## Summary

- Recover dependency-waiting Blocked issues from issue body, Workpad/comment, and blocker reason references when blockers are ready.
- Move PR-backed Blocked issues to Rework for agent-recoverable maintenance such as merge conflicts, stale bases, and missing current-head CI signals.
- Add doctor diagnostics and telemetry/API recovery details for blocked recovery decisions.

Fixes #453

## Test Plan

- [x] `make check`