### PR TITLE
docs(onboarding): refine agnostic wording

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,10 +22,10 @@ manual README skim.
 Start by inspecting this repository. Read README.md, CLAUDE.md or AGENTS.md if
 present, docs/ONBOARDING.md, CONTRIBUTING.md, build and language manifests,
 .github/workflows, install scripts, and any existing WORKFLOW.md or global.yaml
-examples. Do not assume the target repository is a Go project; Detent can drive
-Elixir, Ruby, JavaScript, Python, static web, or any other project with a clear
-workflow and validation gate. Do not ask setup questions until you have gathered
-local evidence.
+examples. Detent can drive any project with a clear workflow and validation
+gate, so use the repository evidence to identify the stack, tools, and commands
+instead of starting from one language. Do not ask setup questions until you have
+gathered local evidence.
 
 Use docs/ONBOARDING.md as the interrogation guide. First determine which path
 applies: a new Detent install, an existing Detent install that must be found and

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -230,9 +230,9 @@ change.
    ```
 
 3. **Inspect the validation surface.** Prefer a repo-local release gate over an
-   invented command. Do not assume the target repository is written in Go. First
-   identify its manifests, package managers, task runners, CI workflows, and
-   existing release commands. If `make check` exists, recommend
+   invented command. Detent is stack-agnostic at the project boundary: identify
+   the target repository's manifests, package managers, task runners, CI
+   workflows, and existing release commands. If `make check` exists, recommend
    `gate.kind: command` with `gate.run: make check`. Otherwise recommend the
    closest local equivalent for the detected ecosystem, such as `mix test`,
    `bundle exec rspec`, `npm test`, `pnpm test`, `pytest`, `cargo test`,
@@ -1095,8 +1095,7 @@ recommendation, and default-if-silent. Record answers in
 
    Add every missing tool directory to the service PATH before dispatching. Use
    the directories required by the target repo's language manager and selected
-   validation gate; do not add Go or npm paths unless that repo needs them. For
-   example:
+   validation gate. For example:
 
    ```ini
    Environment=PATH=/home/<user>/.local/bin:/home/<user>/.asdf/shims:/home/<user>/.cargo/bin:/usr/local/bin:/usr/bin:/bin


### PR DESCRIPTION
## Summary

- Reframe the README AI prompt around Detent being stack-agnostic from the beginning
- Update onboarding guidance to identify target repo tools from evidence instead of warning against Go assumptions
- Remove service PATH wording that singles out Go/npm as special cases

Follow-up to #458

## Test Plan

- [x] `make check`
