### PR TITLE
perf(startup): publish startup snapshots faster

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,6 +869,7 @@ global:
   startup:
     jitter_seconds: 10
     max_spawn_per_second: 2
+    max_concurrent_starts: 4
 projects:
   - id: detent
     workflow: /absolute/path/to/detent/WORKFLOW.md

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -271,14 +271,16 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		}
 		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
 			return runWithShutdown(ctx, runningShutdownConfig{
-				Controller:       cfg.Shutdown,
-				Registry:         manager.Registry(),
-				SnapshotHub:      snapshotHub,
-				LifetimeSource:   runtimeStore,
-				DashboardURL:     displayURL,
-				Output:           cfg.Output,
-				Logger:           logger,
-				DrainTimeout:     shutdownDrainTimeout(manager.Registry()),
+				Controller:     cfg.Shutdown,
+				Registry:       manager.Registry(),
+				SnapshotHub:    snapshotHub,
+				LifetimeSource: runtimeStore,
+				DashboardURL:   displayURL,
+				Output:         cfg.Output,
+				Logger:         logger,
+				DrainTimeoutSource: func() time.Duration {
+					return shutdownDrainTimeout(manager.Registry())
+				},
 				ProgressInterval: defaultShutdownProgressInterval,
 				HardTimeout:      defaultShutdownHardTimeout,
 			}, func(ctx context.Context) error {
@@ -299,14 +301,16 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 	return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
 		return runWithShutdown(ctx, runningShutdownConfig{
-			Controller:       cfg.Shutdown,
-			Registry:         manager.Registry(),
-			SnapshotHub:      snapshotHub,
-			LifetimeSource:   runtimeStore,
-			DashboardURL:     displayURL,
-			Output:           cfg.Output,
-			Logger:           logger,
-			DrainTimeout:     shutdownDrainTimeout(manager.Registry()),
+			Controller:     cfg.Shutdown,
+			Registry:       manager.Registry(),
+			SnapshotHub:    snapshotHub,
+			LifetimeSource: runtimeStore,
+			DashboardURL:   displayURL,
+			Output:         cfg.Output,
+			Logger:         logger,
+			DrainTimeoutSource: func() time.Duration {
+				return shutdownDrainTimeout(manager.Registry())
+			},
 			ProgressInterval: defaultShutdownProgressInterval,
 			HardTimeout:      defaultShutdownHardTimeout,
 		}, func(ctx context.Context) error {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -208,17 +208,21 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := manager.Start(runCtx); err != nil {
-		return err
-	}
 	globalConfigState := newGlobalConfigState(cfg.Global)
-	globalWatcherDone := startGlobalConfigWatcher(runCtx, cfg.Global, manager, logger, runtimeGitHubToken, globalConfigState.set)
+	globalWatcherStarted := make(chan (<-chan struct{}), 1)
 	defer func() {
 		stop()
-		waitGlobalConfigWatcher(globalWatcherDone)
+		select {
+		case globalWatcherDone := <-globalWatcherStarted:
+			waitGlobalConfigWatcher(globalWatcherDone)
+		default:
+		}
 	}()
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
+	if err := publishStartupSnapshotOnce(runCtx, cfg.Global, snapshotHub, runtimeStore, displayURL, time.Now()); err != nil {
+		return err
+	}
 	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, runtimeStore, displayURL, defaultSnapshotInterval, time.Now)
 	server, err := web.NewServer(web.Config{
 		Mode:               web.ModeRunning,
@@ -243,15 +247,58 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		return err
 	}
 
+	startProjects := func(ctx context.Context) error {
+		if err := manager.Start(ctx); err != nil {
+			return err
+		}
+		globalWatcherDone := startGlobalConfigWatcher(ctx, cfg.Global, manager, logger, runtimeGitHubToken, globalConfigState.set)
+		select {
+		case globalWatcherStarted <- globalWatcherDone:
+		default:
+		}
+		return nil
+	}
+
 	if useDashboard {
 		if err := printBootBanner(cfg, displayURL); err != nil {
 			return err
 		}
 		listenerOwned = false
 		if cfg.Shutdown == nil {
-			return serveWithTerminalDashboard(runCtx, server, listener, snapshotHub, cfg.Build, nil)
+			return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, nil)
+			})
 		}
-		return runWithShutdown(runCtx, runningShutdownConfig{
+		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+			return runWithShutdown(ctx, runningShutdownConfig{
+				Controller:       cfg.Shutdown,
+				Registry:         manager.Registry(),
+				SnapshotHub:      snapshotHub,
+				LifetimeSource:   runtimeStore,
+				DashboardURL:     displayURL,
+				Output:           cfg.Output,
+				Logger:           logger,
+				DrainTimeout:     shutdownDrainTimeout(manager.Registry()),
+				ProgressInterval: defaultShutdownProgressInterval,
+				HardTimeout:      defaultShutdownHardTimeout,
+			}, func(ctx context.Context) error {
+				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, func() {
+					cfg.Shutdown.RequestInterrupt()
+				})
+			})
+		})
+	}
+	if err := printBootBanner(cfg, displayURL); err != nil {
+		return err
+	}
+	listenerOwned = false
+	if cfg.Shutdown == nil {
+		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+			return serve(ctx, server, listener)
+		})
+	}
+	return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
+		return runWithShutdown(ctx, runningShutdownConfig{
 			Controller:       cfg.Shutdown,
 			Registry:         manager.Registry(),
 			SnapshotHub:      snapshotHub,
@@ -263,31 +310,8 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			ProgressInterval: defaultShutdownProgressInterval,
 			HardTimeout:      defaultShutdownHardTimeout,
 		}, func(ctx context.Context) error {
-			return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, func() {
-				cfg.Shutdown.RequestInterrupt()
-			})
+			return serve(ctx, server, listener)
 		})
-	}
-	if err := printBootBanner(cfg, displayURL); err != nil {
-		return err
-	}
-	listenerOwned = false
-	if cfg.Shutdown == nil {
-		return serve(runCtx, server, listener)
-	}
-	return runWithShutdown(runCtx, runningShutdownConfig{
-		Controller:       cfg.Shutdown,
-		Registry:         manager.Registry(),
-		SnapshotHub:      snapshotHub,
-		LifetimeSource:   runtimeStore,
-		DashboardURL:     displayURL,
-		Output:           cfg.Output,
-		Logger:           logger,
-		DrainTimeout:     shutdownDrainTimeout(manager.Registry()),
-		ProgressInterval: defaultShutdownProgressInterval,
-		HardTimeout:      defaultShutdownHardTimeout,
-	}, func(ctx context.Context) error {
-		return serve(ctx, server, listener)
 	})
 }
 
@@ -359,6 +383,67 @@ func serve(ctx context.Context, server *web.Server, listener net.Listener) error
 		}
 		return err
 	}
+}
+
+type startupServeResult struct {
+	name string
+	err  error
+}
+
+func runStartupAndServe(
+	ctx context.Context,
+	startup func(context.Context) error,
+	serveApp func(context.Context) error,
+) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	runCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	results := make(chan startupServeResult, 2)
+	go func() {
+		results <- startupServeResult{name: "startup", err: startup(runCtx)}
+	}()
+	go func() {
+		results <- startupServeResult{name: "serve", err: serveApp(runCtx)}
+	}()
+
+	startupDone := false
+	for {
+		result := <-results
+		switch result.name {
+		case "startup":
+			if result.err != nil {
+				cancel()
+				serveResult := <-results
+				if unexpected := unexpectedBootServeError(serveResult.err); unexpected != nil {
+					return errors.Join(result.err, unexpected)
+				}
+				return result.err
+			}
+			startupDone = true
+		case "serve":
+			cancel()
+			if !startupDone {
+				startupResult := <-results
+				if startupResult.err != nil {
+					if unexpected := unexpectedBootServeError(result.err); unexpected != nil {
+						return errors.Join(unexpected, startupResult.err)
+					}
+					return startupResult.err
+				}
+			}
+			return result.err
+		}
+	}
+}
+
+func unexpectedBootServeError(err error) error {
+	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) {
+		return nil
+	}
+	return err
 }
 
 func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listener net.Listener, snapshots *hub.Hub[telemetry.Snapshot], build buildinfo.Info, interrupt func()) error {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -16,6 +16,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/web"
@@ -219,6 +220,75 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 	}
 }
 
+func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *testing.T) {
+	host, port := freeLoopbackPort(t)
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
+	})
+	global, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	provisionStarted := make(chan struct{})
+	provisionRelease := make(chan struct{})
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, BootConfig{
+			Mode:   BootModeRunning,
+			Global: global,
+			Host:   host,
+			Port:   &port,
+			ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+				return bootProvisioningConnector{
+					provision: func(ctx context.Context) error {
+						close(provisionStarted)
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						case <-provisionRelease:
+							return nil
+						}
+					},
+				}, nil
+			},
+		})
+	}()
+
+	select {
+	case <-provisionStarted:
+	case err := <-done:
+		t.Fatalf("startRunning returned before provisioning blocked: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for project provisioning to start")
+	}
+
+	stateURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port)) + "/api/v1/state"
+	body := waitForDashboardCondition(t, stateURL, done, "startup snapshot", func(body string) bool {
+		return strings.Contains(body, `"generated_at"`) &&
+			strings.Contains(body, `"alpha"`) &&
+			!strings.Contains(body, "snapshot_unavailable")
+	})
+	if !strings.Contains(body, `"running":0`) {
+		t.Fatalf("startup snapshot body missing zero running count:\n%s", body)
+	}
+
+	close(provisionRelease)
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for startRunning to stop")
+	}
+}
+
 func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
 	host, port := freeLoopbackPort(t)
 	configPath := filepath.Join(t.TempDir(), "global.yaml")
@@ -366,14 +436,16 @@ func waitForDashboardCondition(t *testing.T, url string, done <-chan error, name
 	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
 	defer cancel()
 
+	lastBody := ""
 	for ctx.Err() == nil {
 		body := waitForDashboard(t, url, done)
+		lastBody = body
 		if ok(body) {
 			return body
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
-	t.Fatalf("timed out waiting for dashboard condition %q at %s", name, url)
+	t.Fatalf("timed out waiting for dashboard condition %q at %s; last body:\n%s", name, url, lastBody)
 	return ""
 }
 
@@ -477,4 +549,47 @@ func assertRefresh(t *testing.T, response web.RefreshResponse) {
 	if len(response.Operations) != 2 || response.Operations[0] != "poll" || response.Operations[1] != "reconcile" {
 		t.Fatalf("Operations = %#v, want poll/reconcile", response.Operations)
 	}
+}
+
+type bootProvisioningConnector struct {
+	provision func(context.Context) error
+}
+
+func (bootProvisioningConnector) Name() string {
+	return "boot"
+}
+
+func (bootProvisioningConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (bootProvisioningConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (bootProvisioningConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (bootProvisioningConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (bootProvisioningConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (bootProvisioningConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (bootProvisioningConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c bootProvisioningConnector) Provision(ctx context.Context) error {
+	if c.provision == nil {
+		return nil
+	}
+	return c.provision(ctx)
 }

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -230,6 +230,77 @@ func publishSnapshots(
 	}
 }
 
+func publishStartupSnapshotOnce(
+	ctx context.Context,
+	cfg globalconfig.Config,
+	snapshotHub *hub.Hub[telemetry.Snapshot],
+	lifetimeSource lifetimeTotalsSource,
+	dashboardURL string,
+	now time.Time,
+) error {
+	if snapshotHub == nil {
+		return nil
+	}
+	snapshot := startupSnapshot(ctx, cfg, lifetimeSource, dashboardURL, now)
+	if err := snapshotHub.Publish(snapshot); err != nil {
+		return fmt.Errorf("publish startup snapshot: %w", err)
+	}
+	return nil
+}
+
+func startupSnapshot(
+	ctx context.Context,
+	cfg globalconfig.Config,
+	lifetimeSource lifetimeTotalsSource,
+	dashboardURL string,
+	now time.Time,
+) telemetry.Snapshot {
+	nextRefreshAt := now
+	snapshot := telemetry.Snapshot{
+		GeneratedAt:    now,
+		Instance:       startupSnapshotInstance(cfg),
+		Projects:       startupProjectSnapshots(cfg.Projects),
+		DashboardURL:   cleanDashboardURL(dashboardURL),
+		Shutdown:       telemetry.Shutdown{Status: "running"},
+		Refresh:        telemetry.Refresh{NextRefreshAt: &nextRefreshAt},
+		LifetimeTotals: lifetimeTotals(ctx, lifetimeSource),
+	}
+	switch len(snapshot.Projects) {
+	case 0:
+	case 1:
+		snapshot.Project = snapshot.Projects[0].Project
+	default:
+		snapshot.Project = telemetry.Project{DisplayName: "multiple projects"}
+	}
+	return snapshot
+}
+
+func startupSnapshotInstance(cfg globalconfig.Config) telemetry.Instance {
+	identity := cfg.Global.Identity
+	identity.Normalize()
+	return telemetry.Instance{
+		Name:        identity.Name,
+		GitHubLogin: identity.GitHubLogin,
+	}
+}
+
+func startupProjectSnapshots(projects []globalconfig.Project) []telemetry.ProjectSnapshot {
+	out := make([]telemetry.ProjectSnapshot, 0, len(projects))
+	for _, cfg := range projects {
+		id := strings.TrimSpace(cfg.ID)
+		if id == "" {
+			continue
+		}
+		out = append(out, telemetry.ProjectSnapshot{
+			Project: telemetry.Project{
+				ID:          id,
+				DisplayName: id,
+			},
+		})
+	}
+	return out
+}
+
 func publishSnapshotOnce(
 	ctx context.Context,
 	registry *project.Registry,
@@ -240,8 +311,20 @@ func publishSnapshotOnce(
 	dashboardURL string,
 ) error {
 	merged := telemetry.Snapshot{GeneratedAt: now}
-	for _, trackedProject := range registry.List() {
+	trackedProjects := registry.List()
+	if len(trackedProjects) == 0 {
+		return nil
+	}
+	for _, trackedProject := range trackedProjects {
+		projectMetadata := projectSnapshotMetadata(trackedProject)
 		if !trackedProject.Running() {
+			nextRefreshAt := now
+			merged = mergeSnapshot(merged, telemetry.Snapshot{
+				Project:      projectMetadata,
+				DashboardURL: cleanDashboardURL(dashboardURL),
+				Shutdown:     telemetry.Shutdown{Status: "running"},
+				Refresh:      telemetry.Refresh{NextRefreshAt: &nextRefreshAt},
+			})
 			continue
 		}
 		orch := trackedProject.Orchestrator()
@@ -253,7 +336,7 @@ func publishSnapshotOnce(
 			continue
 		}
 		snapshot := state.Snapshot(now)
-		snapshot.Project = projectSnapshotMetadata(trackedProject)
+		snapshot.Project = projectMetadata
 		snapshot.DashboardURL = cleanDashboardURL(dashboardURL)
 		merged = mergeSnapshot(merged, snapshot)
 	}

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -110,17 +110,18 @@ func (c *ShutdownController) request(request ShutdownRequest) {
 type shutdownServeFunc func(context.Context) error
 
 type runningShutdownConfig struct {
-	Controller       *ShutdownController
-	Registry         *project.Registry
-	SnapshotHub      *hub.Hub[telemetry.Snapshot]
-	LifetimeSource   lifetimeTotalsSource
-	DashboardURL     string
-	Output           io.Writer
-	Logger           *slog.Logger
-	DrainTimeout     time.Duration
-	ProgressInterval time.Duration
-	HardTimeout      time.Duration
-	Now              func() time.Time
+	Controller         *ShutdownController
+	Registry           *project.Registry
+	SnapshotHub        *hub.Hub[telemetry.Snapshot]
+	LifetimeSource     lifetimeTotalsSource
+	DashboardURL       string
+	Output             io.Writer
+	Logger             *slog.Logger
+	DrainTimeout       time.Duration
+	DrainTimeoutSource func() time.Duration
+	ProgressInterval   time.Duration
+	HardTimeout        time.Duration
+	Now                func() time.Time
 }
 
 func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutdownServeFunc) error {
@@ -197,6 +198,7 @@ func runDrainShutdown(
 		return completeShutdown(ctx, cfg, cancelServe, serveErrs, startedAt, machine, nil)
 	}
 
+	drainTimeout := shutdownDrainTimeoutForConfig(cfg)
 	progressInterval := cfg.ProgressInterval
 	if progressInterval <= 0 {
 		progressInterval = defaultShutdownProgressInterval
@@ -208,8 +210,8 @@ func runDrainShutdown(
 
 	var timeout <-chan time.Time
 	var timeoutTimer *time.Timer
-	if cfg.DrainTimeout > 0 {
-		timeoutTimer = time.NewTimer(cfg.DrainTimeout)
+	if drainTimeout > 0 {
+		timeoutTimer = time.NewTimer(drainTimeout)
 		timeout = timeoutTimer.C
 		defer timeoutTimer.Stop()
 	}
@@ -433,6 +435,13 @@ func shutdownRunningSessions(ctx context.Context, registry *project.Registry, no
 		return shutdownIssueLabel(sessions[i]) < shutdownIssueLabel(sessions[j])
 	})
 	return sessions
+}
+
+func shutdownDrainTimeoutForConfig(cfg runningShutdownConfig) time.Duration {
+	if cfg.DrainTimeoutSource != nil {
+		return cfg.DrainTimeoutSource()
+	}
+	return cfg.DrainTimeout
 }
 
 func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now time.Time) {

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -9,6 +9,8 @@ import (
 	"testing"
 	"time"
 
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/hub"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -251,6 +253,32 @@ func TestRunWithShutdownForceReturnsForcedError(t *testing.T) {
 	}
 }
 
+func TestRunningShutdownConfigComputesDrainTimeoutFromCurrentRegistry(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	cfg := runningShutdownConfig{
+		Registry: registry,
+		DrainTimeoutSource: func() time.Duration {
+			return shutdownDrainTimeout(registry)
+		},
+	}
+
+	wantDefault := time.Duration(workflowconfig.DefaultShutdownDrainTimeoutMS) * time.Millisecond
+	if got := shutdownDrainTimeoutForConfig(cfg); got != wantDefault {
+		t.Fatalf("shutdownDrainTimeoutForConfig() = %v, want %v", got, wantDefault)
+	}
+
+	project := newShutdownProject(t, "alpha", 0)
+	if err := registry.Set(project); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+
+	if got := shutdownDrainTimeoutForConfig(cfg); got != 0 {
+		t.Fatalf("shutdownDrainTimeoutForConfig() after registry update = %v, want 0", got)
+	}
+}
+
 func TestShutdownBannerFormatsRunningSessions(t *testing.T) {
 	t.Parallel()
 
@@ -280,4 +308,24 @@ func TestShutdownBannerFormatsRunningSessions(t *testing.T) {
 			t.Fatalf("banner missing %q:\n%s", want, got)
 		}
 	}
+}
+
+func newShutdownProject(t *testing.T, id string, drainTimeoutMS int) *projectpkg.Project {
+	t.Helper()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Agent.Shutdown.DrainTimeoutMS = drainTimeoutMS
+	project, err := projectpkg.New(projectpkg.Config{
+		Project: globalconfig.Project{
+			ID:      id,
+			Workdir: t.TempDir(),
+			Weight:  1,
+		},
+		Workflow: workflowconfig.Workflow{Config: cfg, Prompt: "Test workflow prompt."},
+	}, projectpkg.Dependencies{})
+	if err != nil {
+		t.Fatalf("project.New() error = %v", err)
+	}
+	return project
 }

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -642,6 +642,9 @@ func startupErrors(startup map[string]any, prefix string) []string {
 	if value, ok := startup["max_spawn_per_second"]; ok && !positiveInteger(value) {
 		problems = append(problems, prefix+".max_spawn_per_second: must be a positive integer")
 	}
+	if value, ok := startup["max_concurrent_starts"]; ok && !positiveInteger(value) {
+		problems = append(problems, prefix+".max_concurrent_starts: must be a positive integer")
+	}
 	return problems
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -860,6 +860,28 @@ func TestRunFetchesOnlyActionableObservedStates(t *testing.T) {
 	}
 }
 
+func TestRunFetchesCandidatesAndObservedStatesConcurrently(t *testing.T) {
+	t.Parallel()
+
+	tracker := newParallelFetchConnector()
+	orch := newTestOrchestrator(t, tracker, &staticRunner{})
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	tracker.waitBothStarted(t)
+	tracker.releaseFetches()
+
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		return !state.LastRefreshAt.IsZero()
+	})
+	if got := tracker.candidateCalls.Load(); got != 1 {
+		t.Fatalf("FetchCandidateIssues() calls = %d, want 1", got)
+	}
+	if got := tracker.statusCalls.Load(); got != 1 {
+		t.Fatalf("FetchIssuesByStates() calls = %d, want 1", got)
+	}
+}
+
 func TestStateReturnsDefensiveCopies(t *testing.T) {
 	t.Parallel()
 
@@ -1290,6 +1312,103 @@ func (c *fakeConnector) setStateIssues(issues ...connector.Issue) {
 	defer c.mu.Unlock()
 
 	c.stateIssues = cloneIssues(issues)
+}
+
+type parallelFetchConnector struct {
+	candidateStarted chan struct{}
+	statusStarted    chan struct{}
+	release          chan struct{}
+	candidateOnce    sync.Once
+	statusOnce       sync.Once
+	releaseOnce      sync.Once
+	candidateCalls   atomic.Int64
+	statusCalls      atomic.Int64
+}
+
+func newParallelFetchConnector() *parallelFetchConnector {
+	return &parallelFetchConnector{
+		candidateStarted: make(chan struct{}),
+		statusStarted:    make(chan struct{}),
+		release:          make(chan struct{}),
+	}
+}
+
+func (c *parallelFetchConnector) Name() string {
+	return "parallel"
+}
+
+func (c *parallelFetchConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	c.candidateCalls.Add(1)
+	c.candidateOnce.Do(func() {
+		close(c.candidateStarted)
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.statusStarted:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.release:
+		return nil, nil
+	}
+}
+
+func (c *parallelFetchConnector) FetchIssuesByStates(ctx context.Context, _ []string) ([]connector.Issue, error) {
+	c.statusCalls.Add(1)
+	c.statusOnce.Do(func() {
+		close(c.statusStarted)
+	})
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.candidateStarted:
+	}
+	select {
+	case <-ctx.Done():
+		return nil, ctx.Err()
+	case <-c.release:
+		return nil, nil
+	}
+}
+
+func (c *parallelFetchConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *parallelFetchConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *parallelFetchConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c *parallelFetchConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *parallelFetchConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c *parallelFetchConnector) waitBothStarted(t *testing.T) {
+	t.Helper()
+
+	for _, ch := range []<-chan struct{}{c.candidateStarted, c.statusStarted} {
+		select {
+		case <-ch:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for candidate and observed status fetches to overlap")
+		}
+	}
+}
+
+func (c *parallelFetchConnector) releaseFetches() {
+	c.releaseOnce.Do(func() {
+		close(c.release)
+	})
 }
 
 type staticRunner struct {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	"github.com/digitaldrywood/detent/internal/connector"
 )
 
@@ -91,16 +93,33 @@ func (o *Orchestrator) refreshActiveRuns(ctx context.Context, state *State, now 
 }
 
 func (o *Orchestrator) fetchTickIssues(ctx context.Context) (tickFetchedIssues, bool) {
-	issues, err := o.connector.FetchCandidateIssues(ctx)
-	if err != nil {
-		o.logger.Warn("fetch candidate issues failed", "error", err)
+	var candidateIssues []connector.Issue
+	var candidateErr error
+	var statusIssues []connector.Issue
+	var statusErr error
+	observedStates := o.observedStatusFetchStates()
+
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(2)
+	group.Go(func() error {
+		candidateIssues, candidateErr = o.connector.FetchCandidateIssues(groupCtx)
+		return candidateErr
+	})
+	group.Go(func() error {
+		statusIssues, statusErr = o.connector.FetchIssuesByStates(groupCtx, observedStates)
+		return nil
+	})
+	if err := group.Wait(); err != nil && candidateErr == nil {
+		candidateErr = err
+	}
+	if candidateErr != nil {
+		o.logger.Warn("fetch candidate issues failed", "error", candidateErr)
 		return tickFetchedIssues{}, false
 	}
 
 	fetched := tickFetchedIssues{
-		candidates: cloneIssues(issues),
+		candidates: cloneIssues(candidateIssues),
 	}
-	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, o.observedStatusFetchStates())
 	if statusErr != nil {
 		o.logger.Warn("fetch observed status issues failed", "error", statusErr)
 		return fetched, true

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -11,6 +11,8 @@ import (
 	"sync"
 	"time"
 
+	"golang.org/x/sync/errgroup"
+
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/hub"
 )
@@ -21,11 +23,14 @@ var (
 	ErrProjectNotFound = errors.New("project not found")
 )
 
+const defaultMaxConcurrentStarts = 4
+
 type Factory func(globalconfig.Project) (*Project, error)
 
 type StartupConfig struct {
-	Jitter            time.Duration
-	MaxSpawnPerSecond int
+	Jitter              time.Duration
+	MaxSpawnPerSecond   int
+	MaxConcurrentStarts int
 }
 
 type ManagerConfig struct {
@@ -78,8 +83,9 @@ func ManagerConfigFromGlobal(cfg globalconfig.Config) ManagerConfig {
 		Identity: cfg.Global.Identity,
 		Projects: cfg.Projects,
 		Startup: StartupConfig{
-			Jitter:            time.Duration(startupInt(cfg.Global.Startup, "jitter_seconds")) * time.Second,
-			MaxSpawnPerSecond: startupInt(cfg.Global.Startup, "max_spawn_per_second"),
+			Jitter:              time.Duration(startupInt(cfg.Global.Startup, "jitter_seconds")) * time.Second,
+			MaxSpawnPerSecond:   startupInt(cfg.Global.Startup, "max_spawn_per_second"),
+			MaxConcurrentStarts: startupInt(cfg.Global.Startup, "max_concurrent_starts"),
 		},
 	})
 }
@@ -135,18 +141,54 @@ func (m *Manager) Start(ctx context.Context) error {
 	}
 
 	m.mu.Lock()
-	defer m.mu.Unlock()
-
 	if m.running {
+		m.mu.Unlock()
 		return ErrManagerRunning
 	}
 	m.running = true
 
+	projects := make([]*Project, 0, len(m.cfg.Projects))
+	registered := make([]ID, 0, len(m.cfg.Projects))
 	for _, cfg := range m.cfg.Projects {
-		if err := m.addLocked(ctx, cfg); err != nil {
+		id, project, err := m.createProjectLocked(cfg)
+		if err != nil {
+			for _, registeredID := range registered {
+				m.registry.Delete(registeredID)
+			}
 			m.running = false
-			return err
+			m.mu.Unlock()
+			return errors.Join(err, closeProjectSlice(ctx, projects))
 		}
+		if _, ok := m.registry.Get(id); ok {
+			for _, registeredID := range registered {
+				m.registry.Delete(registeredID)
+			}
+			m.running = false
+			m.mu.Unlock()
+			return errors.Join(ErrProjectExists, project.close(ctx, false), closeProjectSlice(ctx, projects))
+		}
+		if err := m.registry.Set(project); err != nil {
+			for _, registeredID := range registered {
+				m.registry.Delete(registeredID)
+			}
+			m.running = false
+			m.mu.Unlock()
+			return errors.Join(err, project.close(ctx, false), closeProjectSlice(ctx, projects))
+		}
+		registered = append(registered, id)
+		projects = append(projects, project)
+	}
+	startup := m.cfg.Startup
+	m.mu.Unlock()
+
+	started, err := m.startInitialProjects(ctx, projects, startup)
+	if err != nil {
+		return errors.Join(err, m.rollbackInitialStart(ctx, registered, projects, started))
+	}
+	if len(started) > 0 {
+		m.mu.Lock()
+		m.spawned = true
+		m.mu.Unlock()
 	}
 	return nil
 }
@@ -479,6 +521,113 @@ func (m *Manager) stopUncommittedStartedProjects(ctx context.Context, started []
 	return cleanupErr
 }
 
+func (m *Manager) startInitialProjects(
+	ctx context.Context,
+	projects []*Project,
+	startup StartupConfig,
+) ([]startedProject, error) {
+	group, groupCtx := errgroup.WithContext(ctx)
+	group.SetLimit(maxConcurrentStarts(startup, len(projects)))
+
+	limiter := startupLimiter{
+		startup: startup,
+		sleep:   m.sleep,
+		jitter:  m.jitter,
+	}
+	var startedMu sync.Mutex
+	started := make([]startedProject, 0, len(projects))
+	for _, project := range projects {
+		trackedProject := project
+		if trackedProject.Paused() {
+			continue
+		}
+		group.Go(func() error {
+			if err := limiter.wait(groupCtx); err != nil {
+				return err
+			}
+			if err := trackedProject.provision(groupCtx); err != nil {
+				return err
+			}
+			if err := groupCtx.Err(); err != nil {
+				return err
+			}
+			if err := trackedProject.start(ctx, startOptions{provision: false, publishEvents: true}); err != nil {
+				return err
+			}
+			startedMu.Lock()
+			started = append(started, startedProject{project: trackedProject})
+			startedMu.Unlock()
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return started, err
+	}
+	return started, nil
+}
+
+func (m *Manager) rollbackInitialStart(
+	ctx context.Context,
+	registered []ID,
+	projects []*Project,
+	started []startedProject,
+) error {
+	cleanupErr := m.stopUncommittedStartedProjects(ctx, started)
+	cleanupErr = errors.Join(cleanupErr, closeProjectSlice(ctx, projects))
+
+	m.mu.Lock()
+	defer m.mu.Unlock()
+
+	for _, id := range registered {
+		m.registry.Delete(id)
+	}
+	m.running = false
+	m.spawned = false
+	return cleanupErr
+}
+
+type startupLimiter struct {
+	startup StartupConfig
+	sleep   func(context.Context, time.Duration) error
+	jitter  func(time.Duration) time.Duration
+
+	mu      sync.Mutex
+	spawned bool
+}
+
+func (l *startupLimiter) wait(ctx context.Context) error {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	delay := spawnDelay(l.startup, l.spawned, l.jitter)
+	if delay > 0 {
+		if err := l.sleep(ctx, delay); err != nil {
+			return err
+		}
+	}
+	l.spawned = true
+	return nil
+}
+
+func maxConcurrentStarts(startup StartupConfig, projectCount int) int {
+	limit := startup.MaxConcurrentStarts
+	if limit <= 0 {
+		limit = defaultMaxConcurrentStarts
+	}
+	if projectCount > 0 && limit > projectCount {
+		return projectCount
+	}
+	return limit
+}
+
+func closeProjectSlice(ctx context.Context, projects []*Project) error {
+	var cleanupErr error
+	for _, project := range projects {
+		cleanupErr = errors.Join(cleanupErr, project.close(ctx, false))
+	}
+	return cleanupErr
+}
+
 func closePreparedProjects(ctx context.Context, prepared map[ID]*Project) error {
 	var cleanupErr error
 	for _, project := range prepared {
@@ -496,17 +645,25 @@ func closeStoppedProjects(ctx context.Context, stopped []rollbackProject) error 
 }
 
 func (m *Manager) waitBeforeSpawn(ctx context.Context) error {
-	delay := time.Duration(0)
-	if m.spawned && m.cfg.Startup.MaxSpawnPerSecond > 0 {
-		delay += time.Second / time.Duration(m.cfg.Startup.MaxSpawnPerSecond)
-	}
-	if m.cfg.Startup.Jitter > 0 {
-		delay += m.jitter(m.cfg.Startup.Jitter)
-	}
+	delay := spawnDelay(m.cfg.Startup, m.spawned, m.jitter)
 	if delay <= 0 {
 		return nil
 	}
 	return m.sleep(ctx, delay)
+}
+
+func spawnDelay(startup StartupConfig, spawned bool, jitter func(time.Duration) time.Duration) time.Duration {
+	if !spawned {
+		return 0
+	}
+	delay := time.Duration(0)
+	if startup.MaxSpawnPerSecond > 0 {
+		delay += time.Second / time.Duration(startup.MaxSpawnPerSecond)
+	}
+	if startup.Jitter > 0 && jitter != nil {
+		delay += jitter(startup.Jitter)
+	}
+	return delay
 }
 
 func startupInt(values map[string]any, key string) int {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"slices"
+	"sync"
 	"testing"
 	"time"
 
@@ -57,7 +59,7 @@ func TestManagerStartsProjectsWithStartupLimits(t *testing.T) {
 		t.Fatalf("Start() error = %v", err)
 	}
 
-	wantSleeps := []time.Duration{100 * time.Millisecond, 600 * time.Millisecond}
+	wantSleeps := []time.Duration{600 * time.Millisecond}
 	if !reflect.DeepEqual(slept, wantSleeps) {
 		t.Fatalf("sleep delays = %v, want %v", slept, wantSleeps)
 	}
@@ -66,11 +68,115 @@ func TestManagerStartsProjectsWithStartupLimits(t *testing.T) {
 		receiveEvent(t, sub.C()).ProjectID,
 		receiveEvent(t, sub.C()).ProjectID,
 	}
+	slices.Sort(started)
 	if !reflect.DeepEqual(started, []project.ID{"alpha", "bravo"}) {
 		t.Fatalf("started projects = %v, want [alpha bravo]", started)
 	}
 	if manager.Registry().Len() != 3 {
 		t.Fatalf("Registry().Len() = %d, want 3", manager.Registry().Len())
+	}
+}
+
+func TestManagerStartsProjectsWithBoundedConcurrency(t *testing.T) {
+	t.Parallel()
+
+	const maxConcurrentStarts = 2
+
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	release := make(chan struct{})
+	started := make(chan project.ID, 4)
+	var active int
+	var maxActive int
+	var mu sync.Mutex
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+			{ID: "charlie", Weight: 1},
+			{ID: "delta", Weight: 1},
+		},
+		Startup: project.StartupConfig{
+			MaxConcurrentStarts: maxConcurrentStarts,
+		},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			projectConnector := provisioningConnector{
+				provision: func(ctx context.Context) error {
+					mu.Lock()
+					active++
+					if active > maxActive {
+						maxActive = active
+					}
+					mu.Unlock()
+
+					started <- project.ID(cfg.ID)
+					select {
+					case <-ctx.Done():
+						return ctx.Err()
+					case <-release:
+					}
+
+					mu.Lock()
+					active--
+					mu.Unlock()
+					return nil
+				},
+			}
+			return project.New(project.Config{
+				Project:  cfg,
+				Workflow: workflowconfig.Workflow{Config: workflowConfig("memory")},
+			}, project.Dependencies{
+				Connector: projectConnector,
+				Events:    events,
+				Runner:    blockingRunner{},
+			})
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- manager.Start(context.Background())
+	}()
+
+	for range maxConcurrentStarts {
+		select {
+		case <-started:
+		case <-time.After(time.Second):
+			t.Fatal("timed out waiting for concurrent project startup")
+		}
+	}
+	select {
+	case id := <-started:
+		t.Fatalf("project %s started beyond concurrency limit", id)
+	default:
+	}
+
+	close(release)
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("Start() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for manager.Start")
+	}
+
+	mu.Lock()
+	gotMaxActive := maxActive
+	mu.Unlock()
+	if gotMaxActive != maxConcurrentStarts {
+		t.Fatalf("max active starts = %d, want %d", gotMaxActive, maxConcurrentStarts)
+	}
+	if manager.Registry().Len() != 4 {
+		t.Fatalf("Registry().Len() = %d, want 4", manager.Registry().Len())
 	}
 }
 
@@ -968,8 +1074,9 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 				GitHubLogin: "detent-bot",
 			},
 			Startup: map[string]any{
-				"jitter_seconds":       3,
-				"max_spawn_per_second": 4,
+				"jitter_seconds":        3,
+				"max_spawn_per_second":  4,
+				"max_concurrent_starts": 2,
 			},
 		},
 		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
@@ -981,6 +1088,9 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 	}
 	if got.Startup.MaxSpawnPerSecond != 4 {
 		t.Fatalf("Startup.MaxSpawnPerSecond = %d, want 4", got.Startup.MaxSpawnPerSecond)
+	}
+	if got.Startup.MaxConcurrentStarts != 2 {
+		t.Fatalf("Startup.MaxConcurrentStarts = %d, want 2", got.Startup.MaxConcurrentStarts)
 	}
 	if got.Identity.Name != "release-captain" {
 		t.Fatalf("Identity.Name = %q, want release-captain", got.Identity.Name)
@@ -1099,6 +1209,8 @@ func assertStartedProjects(t *testing.T, ch <-chan project.Event, want []project
 		}
 		got = append(got, event.ProjectID)
 	}
+	slices.Sort(got)
+	slices.Sort(want)
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("started projects = %v, want %v", got, want)
 	}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -185,6 +185,8 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceN
 		Status:         runtimeStatus(snapshot),
 		Shutdown:       shutdownResponse(snapshot.Shutdown),
 		Instance:       instanceResponse(snapshot.Instance, instanceName),
+		Projects:       projectsAPIResponse(snapshot),
+		Refresh:        snapshot.Refresh,
 		Counts:         countsResponse(snapshot),
 		Running:        runningEntries(snapshot.Running),
 		Retrying:       retryEntries(snapshot.Queue),
@@ -197,6 +199,23 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceN
 		RecentSessions: recentSessionEntries(snapshot.Completed),
 		RateLimits:     snapshot.RateLimits,
 		Budget:         budgetResponse(snapshot.Budget),
+	}
+}
+
+func projectsAPIResponse(snapshot telemetry.Snapshot) []telemetry.ProjectSnapshot {
+	if len(snapshot.Projects) > 0 {
+		return append([]telemetry.ProjectSnapshot(nil), snapshot.Projects...)
+	}
+	if snapshot.Project == (telemetry.Project{}) {
+		return nil
+	}
+	return []telemetry.ProjectSnapshot{
+		{
+			Project:    snapshot.Project,
+			Counts:     snapshot.Counts,
+			Tokens:     snapshot.Tokens,
+			Throughput: snapshot.Throughput,
+		},
 	}
 }
 
@@ -878,22 +897,24 @@ func snapshotErrorResponse(generatedAt time.Time, code string, message string) s
 }
 
 type stateAPIResponse struct {
-	GeneratedAt    time.Time                  `json:"generated_at"`
-	Status         string                     `json:"status"`
-	Shutdown       shutdownAPIResponse        `json:"shutdown"`
-	Instance       instanceAPIResponse        `json:"instance"`
-	Counts         countsAPIResponse          `json:"counts"`
-	Running        []runningAPIResponse       `json:"running"`
-	Retrying       []retryAPIResponse         `json:"retrying"`
-	Blocked        []blockedAPIResponse       `json:"blocked"`
-	Stats          statsAPIResponse           `json:"stats"`
-	Board          boardAPIResponse           `json:"board"`
-	CodexTotals    tokenTotalsAPIResponse     `json:"codex_totals"`
-	Throughput     throughputAPIResponse      `json:"throughput"`
-	LifetimeTotals lifetimeTotalsResponse     `json:"lifetime_totals"`
-	RecentSessions []recentSessionAPIResponse `json:"recent_sessions"`
-	RateLimits     *telemetry.RateLimits      `json:"rate_limits"`
-	Budget         budgetAPIResponse          `json:"budget"`
+	GeneratedAt    time.Time                   `json:"generated_at"`
+	Status         string                      `json:"status"`
+	Shutdown       shutdownAPIResponse         `json:"shutdown"`
+	Instance       instanceAPIResponse         `json:"instance"`
+	Projects       []telemetry.ProjectSnapshot `json:"projects,omitempty"`
+	Refresh        telemetry.Refresh           `json:"refresh"`
+	Counts         countsAPIResponse           `json:"counts"`
+	Running        []runningAPIResponse        `json:"running"`
+	Retrying       []retryAPIResponse          `json:"retrying"`
+	Blocked        []blockedAPIResponse        `json:"blocked"`
+	Stats          statsAPIResponse            `json:"stats"`
+	Board          boardAPIResponse            `json:"board"`
+	CodexTotals    tokenTotalsAPIResponse      `json:"codex_totals"`
+	Throughput     throughputAPIResponse       `json:"throughput"`
+	LifetimeTotals lifetimeTotalsResponse      `json:"lifetime_totals"`
+	RecentSessions []recentSessionAPIResponse  `json:"recent_sessions"`
+	RateLimits     *telemetry.RateLimits       `json:"rate_limits"`
+	Budget         budgetAPIResponse           `json:"budget"`
 }
 
 type shutdownAPIResponse struct {


### PR DESCRIPTION
## Summary

- Start the running web server and snapshot publisher before project startup completes.
- Publish a lightweight configured-project startup snapshot and keep registered-but-not-running projects visible with zero counts.
- Start projects with bounded concurrent provisioning, skip jitter before the first spawn, and parallelize independent candidate/status tick reads.
- Expose projects and refresh metadata in `/api/v1/state` so API clients can see startup progress.

Fixes #460

## Test Plan

- [x] `make check`