### PR TITLE
fix(snapshot): clear terminal sessions without worktree

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -333,6 +333,11 @@ func publishSnapshotOnce(
 		}
 		state, err := orch.State(ctx)
 		if err != nil {
+			slog.Default().Warn(
+				"project telemetry snapshot skipped",
+				slog.String("project_id", string(trackedProject.ID())),
+				slog.String("error", err.Error()),
+			)
 			continue
 		}
 		snapshot := state.Snapshot(now)

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -32,6 +32,9 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 		if !o.shouldReapWorkspaceIssue(issue, now) {
 			continue
 		}
+		if o.completeRunningIssueFromWorkspaceCleanup(ctx, state, issue, now) {
+			continue
+		}
 		o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates))
 	}
 }
@@ -109,6 +112,33 @@ func workspaceReapReason(issue connector.Issue, terminalStates []string) string 
 	default:
 		return "idle"
 	}
+}
+
+func (o *Orchestrator) completeRunningIssueFromWorkspaceCleanup(ctx context.Context, state *State, issue connector.Issue, now time.Time) bool {
+	if !workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+		return false
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return false
+	}
+	running, ok := state.Running[issueID]
+	if !ok {
+		return false
+	}
+
+	running.Issue = mergeIssueTrackerFields(running.Issue, issue)
+	if o.logger != nil {
+		o.logger.Info(
+			"completed running issue during workspace cleanup",
+			slog.String("issue_id", issueID),
+			slog.String("issue_identifier", running.Issue.Identifier),
+			slog.String("state", running.Issue.State),
+			slog.String("reason", workspaceReapReason(running.Issue, o.cfg.TerminalStates)),
+		)
+	}
+	o.completeTerminalRunning(ctx, state, issueID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
+	return true
 }
 
 func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue connector.Issue, reason string) {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -231,6 +231,97 @@ func TestTickReapsTerminalRunningIssue(t *testing.T) {
 	}
 }
 
+func TestTickCompletesTerminalRunningIssueDuringWorkspaceCleanupSweep(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 14, 15, 15, 0, 0, time.UTC)
+	startedAt := now.Add(-12 * time.Minute)
+	terminalAt := now.Add(-30 * time.Second)
+	prior := connector.Issue{
+		ID:         "issue-merged",
+		Identifier: "digitaldrywood/detent#453",
+		Title:      "Release snapshot",
+		State:      "Merging",
+		URL:        "https://github.com/digitaldrywood/detent/issues/453",
+	}
+	done := cloneIssue(prior)
+	done.State = "Done"
+	done.StageUpdatedAt = &terminalAt
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	cfg := normalizeConfig(Config{
+		PollInterval:                  time.Minute,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Human Review", "Rework", "Merging"},
+		ObservedStates:                []string{"Human Review", "Merging"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		WorkspaceCleanupSweepInterval: time.Hour,
+	})
+	state := newState(cfg)
+	state.LastRunningReconcileAt = now.Add(-time.Second)
+	state.Running[prior.ID] = Running{
+		Issue:       cloneIssue(prior),
+		StartedAt:   startedAt,
+		LastMessage: "GoReleaser Snapshot remains in progress; continuing to wait.",
+		Tokens:      CodexTotals{TotalTokens: 42, RuntimeSeconds: 90},
+		cancel:      cancel,
+	}
+	state.Claimed[prior.ID] = Claimed{Issue: cloneIssue(prior), ClaimedAt: startedAt, Owner: "worker-1"}
+
+	tracker := &runningStateConnector{issuesByState: []connector.Issue{done}}
+	reaper := &cleanupSweepReaper{}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if _, ok := state.Running[prior.ID]; ok {
+		t.Fatalf("Running[%q] present after terminal cleanup sweep", prior.ID)
+	}
+	if _, ok := state.Claimed[prior.ID]; ok {
+		t.Fatalf("Claimed[%q] present after terminal cleanup sweep", prior.ID)
+	}
+	completed, ok := state.Completed[prior.ID]
+	if !ok {
+		t.Fatalf("Completed[%q] missing after terminal cleanup sweep", prior.ID)
+	}
+	if completed.Issue.State != "Done" || completed.FinalState != "Done" {
+		t.Fatalf("Completed[%q] state = (%q, %q), want Done/Done", prior.ID, completed.Issue.State, completed.FinalState)
+	}
+	if !completed.CompletedAt.Equal(terminalAt) {
+		t.Fatalf("Completed[%q].CompletedAt = %v, want %v", prior.ID, completed.CompletedAt, terminalAt)
+	}
+	if completed.Tokens.TotalTokens != 42 {
+		t.Fatalf("Completed[%q].Tokens.TotalTokens = %d, want 42", prior.ID, completed.Tokens.TotalTokens)
+	}
+	if !slices.Equal(tracker.requestedIDs, nil) {
+		t.Fatalf("FetchIssueStatesByIDs() ids = %#v, want no throttled running reconcile", tracker.requestedIDs)
+	}
+	if len(reaper.issues) != 1 || reaper.issues[0].ID != prior.ID || reaper.issues[0].State != "Done" {
+		t.Fatalf("reaped issues = %#v, want terminal Done issue", reaper.issues)
+	}
+	select {
+	case <-runCtx.Done():
+	default:
+		t.Fatal("running context was not cancelled")
+	}
+
+	snapshot := state.Snapshot(now.Add(time.Second))
+	if !snapshot.GeneratedAt.Equal(now.Add(time.Second)) {
+		t.Fatalf("snapshot GeneratedAt = %v, want fresh publish time", snapshot.GeneratedAt)
+	}
+	if snapshot.Counts.Running != 0 || len(snapshot.Running) != 0 {
+		t.Fatalf("snapshot running count = %d len = %d, want 0", snapshot.Counts.Running, len(snapshot.Running))
+	}
+	if snapshot.Counts.Completed != 1 || len(snapshot.Completed) != 1 || snapshot.Completed[0].State != "Done" {
+		t.Fatalf("snapshot completed = %#v, want terminal Done row", snapshot.Completed)
+	}
+}
+
 func TestTerminalCompletedAtUsesTerminalConditionTimestamp(t *testing.T) {
 	t.Parallel()
 
@@ -344,9 +435,10 @@ func TestMergeIssueTrackerFieldsDistinguishesMissingAndEmptyMetadata(t *testing.
 }
 
 type runningStateConnector struct {
-	issues       []connector.Issue
-	err          error
-	requestedIDs []string
+	issues        []connector.Issue
+	issuesByState []connector.Issue
+	err           error
+	requestedIDs  []string
 }
 
 func (c *runningStateConnector) Name() string {
@@ -358,7 +450,7 @@ func (c *runningStateConnector) FetchCandidateIssues(context.Context) ([]connect
 }
 
 func (c *runningStateConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
-	return []connector.Issue{}, nil
+	return cloneIssues(c.issuesByState), nil
 }
 
 func (c *runningStateConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
@@ -383,4 +475,13 @@ func (c *runningStateConnector) SetAssignee(context.Context, string, string) err
 
 func (c *runningStateConnector) SetField(context.Context, string, string, string) error {
 	return nil
+}
+
+type cleanupSweepReaper struct {
+	issues []connector.Issue
+}
+
+func (r *cleanupSweepReaper) ReapWorkspace(_ context.Context, issue connector.Issue) (WorkspaceReapResult, error) {
+	r.issues = append(r.issues, cloneIssue(issue))
+	return WorkspaceReapResult{}, nil
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -345,6 +345,22 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 
 	diffStat, err := r.workspace.DiffStat(ctx, info, workspaceIssue)
 	if err != nil {
+		if workspace.IsMissingWorkspaceError(err) {
+			r.logger.Info(
+				"workspace final diff stat skipped",
+				slog.String("issue_id", workspaceIssue.ID),
+				slog.String("issue_identifier", workspaceIssue.Identifier),
+				slog.String("workspace_path", info.Path),
+				slog.String("phase", "final"),
+				slog.String("error", err.Error()),
+			)
+			finishedAt := r.now().UTC()
+			result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
+			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1); err != nil {
+				return result, err
+			}
+			return result, nil
+		}
 		result.FinalState = FinalStateFailed
 		finishedAt := r.now().UTC()
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
@@ -695,10 +711,23 @@ func (r *Runner) liveDiffStats(
 	progress.diffStatsCheckedAt = eventAt
 	stat, err := r.workspace.DiffStat(ctx, info, issue)
 	if err != nil {
+		if workspace.IsMissingWorkspaceError(err) {
+			r.logger.Info(
+				"workspace live diff stat skipped",
+				slog.String("issue_id", issue.ID),
+				slog.String("issue_identifier", issue.Identifier),
+				slog.String("workspace_path", info.Path),
+				slog.String("phase", "live"),
+				slog.String("error", err.Error()),
+			)
+			return progress.cachedDiffStats()
+		}
 		r.logger.Warn(
 			"workspace live diff stat failed",
 			slog.String("issue_id", issue.ID),
 			slog.String("issue_identifier", issue.Identifier),
+			slog.String("workspace_path", info.Path),
+			slog.String("phase", "live"),
 			slog.String("error", err.Error()),
 		)
 		return progress.cachedDiffStats()

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -519,7 +519,7 @@ func TestRunnerRunTreatsMissingWorkspaceFinalDiffAsCompleted(t *testing.T) {
 	completedAt := startedAt.Add(4 * time.Second)
 	workspaceBackend := &fakeWorkspaceBackend{
 		info:    workspace.Info{Path: filepath.Join(t.TempDir(), "missing-worktree"), Key: "issue-453", Branch: "detent/issue-453"},
-		diffErr: os.ErrNotExist,
+		diffErr: errors.Join(workspace.ErrMissingWorkspace, os.ErrNotExist),
 	}
 	codexClient := &fakeCodexClient{
 		updates: []AgentUpdate{{

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -511,6 +511,82 @@ func TestRunnerRunFinishesFailedSessionAndAfterRunOnCodexError(t *testing.T) {
 	}
 }
 
+func TestRunnerRunTreatsMissingWorkspaceFinalDiffAsCompleted(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	startedAt := time.Date(2026, 6, 14, 15, 10, 0, 0, time.UTC)
+	completedAt := startedAt.Add(4 * time.Second)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info:    workspace.Info{Path: filepath.Join(t.TempDir(), "missing-worktree"), Key: "issue-453", Branch: "detent/issue-453"},
+		diffErr: os.ErrNotExist,
+	}
+	codexClient := &fakeCodexClient{
+		updates: []AgentUpdate{{
+			Type:     AgentUpdateTokenUsage,
+			ThreadID: "thread-453",
+			TurnID:   "turn-1",
+			Tokens: AgentTokenUsage{
+				InputTokens:  100,
+				OutputTokens: 25,
+				TotalTokens:  125,
+			},
+		}},
+		result: AgentTurnResult{ThreadID: "thread-453", TurnID: "turn-1", SessionID: "thread-453-turn-1"},
+	}
+	sessionStore := &fakeSessionStore{sessionID: 453}
+	now := newFakeClock(
+		startedAt,
+		startedAt.Add(time.Second),
+		completedAt,
+		completedAt,
+	)
+
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
+		Store:        sessionStore,
+		Now:          now.Now,
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-453",
+			Identifier: "digitaldrywood/detent#453",
+			Title:      "Release snapshot",
+		},
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v, want completed run despite missing workspace diff", err)
+	}
+	if result.FinalState != FinalStateCompleted {
+		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
+	}
+	if result.DiffStats != (DiffStats{}) {
+		t.Fatalf("DiffStats = %#v, want empty when workspace disappeared", result.DiffStats)
+	}
+	if sessionStore.finished.FinalState != FinalStateCompleted {
+		t.Fatalf("SessionFinish.FinalState = %q, want %q", sessionStore.finished.FinalState, FinalStateCompleted)
+	}
+	logOutput := logs.String()
+	for _, want := range []string{
+		"workspace final diff stat skipped",
+		"issue_id=issue-453",
+		"issue_identifier=digitaldrywood/detent#453",
+		"workspace_path=" + workspaceBackend.info.Path,
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("log output missing %q:\n%s", want, logOutput)
+		}
+	}
+}
+
 func TestRunnerRunUsesFreshContextForAfterRunCleanup(t *testing.T) {
 	t.Parallel()
 
@@ -586,6 +662,7 @@ type fakeWorkspaceBackend struct {
 	info          workspace.Info
 	diffStat      workspace.DiffStat
 	diffStats     []workspace.DiffStat
+	diffErr       error
 	created       bool
 	beforeRun     bool
 	afterRun      bool
@@ -625,6 +702,9 @@ func (b *fakeWorkspaceBackend) AfterRun(ctx context.Context, _ workspace.Info, _
 
 func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspace.Issue) (workspace.DiffStat, error) {
 	b.diffed = true
+	if b.diffErr != nil {
+		return workspace.DiffStat{}, b.diffErr
+	}
 	if len(b.diffStats) > 0 {
 		index := b.diffCalls
 		if index >= len(b.diffStats) {

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -35,6 +35,12 @@ func GitDiffStat(ctx context.Context, workspacePath string) (DiffStat, error) {
 	if strings.TrimSpace(workspacePath) == "" {
 		return DiffStat{}, errors.New("workspace path is required")
 	}
+	if _, err := os.Stat(workspacePath); err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return DiffStat{}, fmt.Errorf("%w: %s: %w", ErrMissingWorkspace, workspacePath, err)
+		}
+		return DiffStat{}, fmt.Errorf("stat workspace path: %w", err)
+	}
 
 	output, err := gitDiffStatOutput(ctx, workspacePath)
 	if err != nil {

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -2,6 +2,7 @@ package workspace
 
 import (
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -114,5 +115,20 @@ func TestLocalGitDiffStat(t *testing.T) {
 	status := runGit(t, info.Path, "status", "--short")
 	if !strings.Contains(status, "?? added.txt") {
 		t.Fatalf("git status = %q, want added.txt to remain untracked", status)
+	}
+}
+
+func TestGitDiffStatMissingWorkspaceIsClassified(t *testing.T) {
+	t.Parallel()
+
+	_, err := GitDiffStat(context.Background(), filepath.Join(t.TempDir(), "missing-worktree"))
+	if err == nil {
+		t.Fatal("GitDiffStat() error = nil, want missing workspace error")
+	}
+	if !IsMissingWorkspaceError(err) {
+		t.Fatalf("IsMissingWorkspaceError(%v) = false, want true", err)
+	}
+	if !errors.Is(err, ErrMissingWorkspace) {
+		t.Fatalf("GitDiffStat() error = %v, want ErrMissingWorkspace", err)
 	}
 }

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -132,3 +132,12 @@ func TestGitDiffStatMissingWorkspaceIsClassified(t *testing.T) {
 		t.Fatalf("GitDiffStat() error = %v, want ErrMissingWorkspace", err)
 	}
 }
+
+func TestIsMissingWorkspaceErrorIgnoresUnmarkedNotExist(t *testing.T) {
+	t.Parallel()
+
+	err := &os.PathError{Op: "read", Path: filepath.Join(t.TempDir(), "index"), Err: os.ErrNotExist}
+	if IsMissingWorkspaceError(err) {
+		t.Fatalf("IsMissingWorkspaceError(%v) = true, want false", err)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -178,7 +178,7 @@ func IsMissingWorkspaceError(err error) bool {
 	if err == nil {
 		return false
 	}
-	if errors.Is(err, ErrMissingWorkspace) || errors.Is(err, os.ErrNotExist) {
+	if errors.Is(err, ErrMissingWorkspace) {
 		return true
 	}
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -28,6 +28,7 @@ const hookOutputTailBytes = 16 * 1024
 
 var (
 	ErrHookFailed         = errors.New("workspace hook failed")
+	ErrMissingWorkspace   = errors.New("workspace missing")
 	ErrUnsafePath         = errors.New("unsafe workspace path")
 	ErrUnsupportedBackend = errors.New("unsupported workspace backend")
 )
@@ -171,6 +172,22 @@ func (e *CommandError) Error() string {
 
 func (e *CommandError) Unwrap() error {
 	return e.Err
+}
+
+func IsMissingWorkspaceError(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, ErrMissingWorkspace) || errors.Is(err, os.ErrNotExist) {
+		return true
+	}
+
+	var commandErr *CommandError
+	if !errors.As(err, &commandErr) {
+		return false
+	}
+	output := strings.ToLower(commandErr.Output)
+	return strings.Contains(output, "cannot change to") && strings.Contains(output, "no such file or directory")
 }
 
 func NewBackend(kind string, opts LocalGitOptions) (Backend, error) {


### PR DESCRIPTION
## Summary

- Complete terminal running sessions discovered during workspace cleanup sweeps so snapshots stop reporting stale running rows.
- Treat missing workspace diff stats as non-fatal while logging skipped live/final diff collection with issue and workspace context.
- Log project snapshot skips when orchestrator state cannot be read.

Fixes #462

## Test Plan

- [x] `go test ./internal/orchestrator -run TestTickCompletesTerminalRunningIssueDuringWorkspaceCleanupSweep -count=1`
- [x] `go test ./internal/runner -run TestRunnerRunTreatsMissingWorkspaceFinalDiffAsCompleted -count=1`
- [x] `go test ./internal/orchestrator ./internal/runner ./internal/workspace ./internal/cli`
- [x] `make check`
