### PR TITLE
ci(detent): gate release snapshot packaging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,13 +138,24 @@ jobs:
           fi
 
           release_relevant=false
-          while IFS=$'\t' read -r path previous_path status; do
-            case "$path" in
+          is_release_input() {
+            case "$1" in
               .goreleaser.yaml|.github/workflows/ci.yml|.github/workflows/release.yml|Makefile|go.mod|go.sum|detent-release.pub|install.sh|install.ps1)
-                release_relevant=true
-                break
+                return 0
                 ;;
             esac
+            return 1
+          }
+
+          while IFS= read -r file; do
+            path="$(jq -r '.[0]' <<< "$file")"
+            previous_path="$(jq -r '.[1]' <<< "$file")"
+            status="$(jq -r '.[2]' <<< "$file")"
+
+            if is_release_input "$path" || is_release_input "$previous_path"; then
+              release_relevant=true
+              break
+            fi
 
             if [ "$status" = "removed" ] || [ "$status" = "renamed" ]; then
               case "$path" in
@@ -160,7 +171,7 @@ jobs:
                   ;;
               esac
             fi
-          done < <(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[] | [.filename, (.previous_filename // ""), .status] | @tsv')
+          done < <(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[] | [.filename, (.previous_filename // ""), .status] | @json')
 
           if [ "$release_relevant" = true ]; then
             echo "snapshot=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: read
+  pull-requests: read
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -37,6 +38,14 @@ jobs:
       - name: Install golangci-lint
         if: steps.golangci-lint-cache.outputs.cache-hit != 'true'
         run: go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.1.6
+
+      - name: Cache golangci-lint analysis
+        uses: actions/cache@v5
+        with:
+          path: ~/.cache/golangci-lint
+          key: golangci-lint-analysis-${{ runner.os }}-${{ hashFiles('.golangci.yml', 'go.sum') }}
+          restore-keys: |
+            golangci-lint-analysis-${{ runner.os }}-
 
       - name: Run golangci-lint
         run: ~/go/bin/golangci-lint run --timeout=5m
@@ -114,24 +123,76 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, verify, test-cover, windows-core]
     steps:
+      - name: Decide release packaging policy
+        id: policy
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPOSITORY: ${{ github.repository }}
+        run: |
+          if [ "$EVENT_NAME" != "pull_request" ]; then
+            echo "snapshot=true" >> "$GITHUB_OUTPUT"
+            echo "reason=push to main" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          release_relevant=false
+          while IFS=$'\t' read -r path previous_path status; do
+            case "$path" in
+              .goreleaser.yaml|.github/workflows/ci.yml|.github/workflows/release.yml|Makefile|go.mod|go.sum|detent-release.pub|install.sh|install.ps1)
+                release_relevant=true
+                break
+                ;;
+            esac
+
+            if [ "$status" = "removed" ] || [ "$status" = "renamed" ]; then
+              case "$path" in
+                README.md|LICENSE)
+                  release_relevant=true
+                  break
+                  ;;
+              esac
+              case "$previous_path" in
+                README.md|LICENSE)
+                  release_relevant=true
+                  break
+                  ;;
+              esac
+            fi
+          done < <(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[] | [.filename, (.previous_filename // ""), .status] | @tsv')
+
+          if [ "$release_relevant" = true ]; then
+            echo "snapshot=true" >> "$GITHUB_OUTPUT"
+            echo "reason=release-relevant PR change" >> "$GITHUB_OUTPUT"
+          else
+            echo "snapshot=false" >> "$GITHUB_OUTPUT"
+            echo "reason=ordinary PR change" >> "$GITHUB_OUTPUT"
+          fi
+
       - uses: actions/checkout@v5
+        if: steps.policy.outputs.snapshot == 'true'
         with:
           fetch-depth: 0
 
       - uses: actions/setup-go@v6
+        if: steps.policy.outputs.snapshot == 'true'
         with:
           go-version: '1.26.4'
           cache: true
 
       - name: Install minisign
+        if: steps.policy.outputs.snapshot == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y minisign
 
       - name: Prepare minisign snapshot key
+        if: steps.policy.outputs.snapshot == 'true'
         run: minisign -G -W -s "$RUNNER_TEMP/detent-minisign.key" -p "$RUNNER_TEMP/detent-minisign.pub"
 
       - name: Run GoReleaser snapshot
+        if: steps.policy.outputs.snapshot == 'true'
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
@@ -141,3 +202,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINISIGN_KEY_FILE: ${{ runner.temp }}/detent-minisign.key
           MINISIGN_PASSWORD: ""
+
+      - name: Skip GoReleaser snapshot
+        if: steps.policy.outputs.snapshot != 'true'
+        run: |
+          echo "GoReleaser snapshot skipped: ${{ steps.policy.outputs.reason }}."

--- a/README.md
+++ b/README.md
@@ -301,6 +301,15 @@ git tag v0.1.0 && git push origin v0.1.0
 Tags matching `v*` trigger the release workflow, which runs GoReleaser and
 publishes the GitHub Release archives and checksums.
 
+CI also runs `GoReleaser Snapshot` on every push to `main` so the current
+merge head remains release-package validated. Pull requests run that snapshot
+only when release packaging inputs change: `.goreleaser.yaml`, the CI or
+release workflows, `Makefile`, Go module files, installer scripts, the release
+public key, or removal/rename of the top-level `README.md` and `LICENSE` files
+that are bundled into release archives. Other pull requests keep the required
+lint, build, vet, test, race, coverage, and Windows checks without the release
+packaging tail.
+
 ## Quick Start
 
 The quickest production-shaped setup is one GitHub ProjectV2 board and one


### PR DESCRIPTION
## Summary

- Document the release packaging policy for tags, main pushes, and PR release-input changes.
- Keep the GoReleaser Snapshot check name while skipping expensive packaging for ordinary PRs.
- Cache the source-built golangci-lint v2.1.6 binary and analysis data without changing lint coverage.

Fixes #463

## Test Plan

- [x] `actionlint .github/workflows/ci.yml .github/workflows/release.yml`
- [x] `make check`