### PR TITLE
fix(shutdown): show interrupt notice

### DIFF
--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -28,7 +28,7 @@ func runCLI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writ
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	shutdownController := cli.NewShutdownController()
-	stopSignals := notifyShutdownRequests(shutdownController, cancel)
+	stopSignals := notifyShutdownRequests(shutdownController, cancel, stderr)
 	defer stopSignals()
 
 	cmd := newRootCommand(ctx, shutdownController)

--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -297,6 +297,43 @@ func TestSignalContextCancel(t *testing.T) {
 	}
 }
 
+func TestWriteSignalShutdownNotice(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		request cli.ShutdownRequest
+		want    string
+	}{
+		{
+			name:    "drain",
+			request: cli.ShutdownRequestDrain,
+			want:    "shutdown requested; draining sessions, press Ctrl+C again to force quit",
+		},
+		{
+			name:    "force",
+			request: cli.ShutdownRequestForce,
+			want:    "force quit requested; interrupting sessions",
+		},
+		{
+			name: "stopping",
+			want: "shutdown requested; stopping",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var output bytes.Buffer
+			writeSignalShutdownNotice(&output, tt.request)
+			if got := strings.TrimSpace(output.String()); got != tt.want {
+				t.Fatalf("notice = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func collectCommandsWithoutExamples(cmd *cobra.Command, missing *[]string) {
 	name := cmd.CommandPath()
 	if name == "" {

--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"os"
 	"os/signal"
 	"sync"
@@ -13,7 +15,7 @@ func newSignalContext(parent context.Context) (context.Context, context.CancelFu
 	return signal.NotifyContext(parent, shutdownSignals()...)
 }
 
-func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot context.CancelFunc) func() {
+func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot context.CancelFunc, noticeOut io.Writer) func() {
 	if controller == nil {
 		return func() {}
 	}
@@ -31,7 +33,9 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 			return
 		case <-first:
 			signal.Stop(first)
-			if !controller.RequestInterrupt() {
+			request, handled := controller.RequestInterruptKind()
+			writeSignalShutdownNotice(noticeOut, request)
+			if !handled {
 				if cancelRoot != nil {
 					cancelRoot()
 				}
@@ -46,7 +50,9 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 		case <-stop:
 			return
 		case <-second:
-			if controller.RequestInterrupt() {
+			request, handled := controller.RequestInterruptKind()
+			writeSignalShutdownNotice(noticeOut, request)
+			if handled {
 				return
 			}
 			if cancelRoot != nil {
@@ -62,5 +68,19 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 			signal.Stop(first)
 			<-done
 		})
+	}
+}
+
+func writeSignalShutdownNotice(out io.Writer, request cli.ShutdownRequest) {
+	if out == nil {
+		return
+	}
+	switch request {
+	case cli.ShutdownRequestDrain:
+		fmt.Fprintln(out, "shutdown requested; draining sessions, press Ctrl+C again to force quit")
+	case cli.ShutdownRequestForce:
+		fmt.Fprintln(out, "force quit requested; interrupting sessions")
+	default:
+		fmt.Fprintln(out, "shutdown requested; stopping")
 	}
 }

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -74,15 +74,20 @@ func (c *ShutdownController) Active() bool {
 }
 
 func (c *ShutdownController) RequestInterrupt() bool {
+	_, handled := c.RequestInterruptKind()
+	return handled
+}
+
+func (c *ShutdownController) RequestInterruptKind() (ShutdownRequest, bool) {
 	if c == nil || !c.Active() {
-		return false
+		return 0, false
 	}
 	if c.shutdownRequested.CompareAndSwap(false, true) {
 		c.request(ShutdownRequestDrain)
-		return true
+		return ShutdownRequestDrain, true
 	}
 	c.request(ShutdownRequestForce)
-	return true
+	return ShutdownRequestForce, true
 }
 
 func (c *ShutdownController) activate() func() {

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -38,19 +38,30 @@ func TestShutdownControllerInterruptRequestsDrainThenForce(t *testing.T) {
 	if controller.RequestInterrupt() {
 		t.Fatal("inactive interrupt was handled")
 	}
+	if request, handled := controller.RequestInterruptKind(); handled || request != 0 {
+		t.Fatalf("inactive interrupt kind = %v, %v, want 0, false", request, handled)
+	}
 
 	deactivate := controller.activate()
 	defer deactivate()
 
-	if !controller.RequestInterrupt() {
-		t.Fatal("active interrupt was not handled")
+	request, handled := controller.RequestInterruptKind()
+	if !handled {
+		t.Fatal("active interrupt kind was not handled")
+	}
+	if request != ShutdownRequestDrain {
+		t.Fatalf("first interrupt kind = %v, want drain", request)
 	}
 	if got := <-controller.Requests(); got != ShutdownRequestDrain {
 		t.Fatalf("first interrupt = %v, want drain", got)
 	}
 
-	if !controller.RequestInterrupt() {
-		t.Fatal("second interrupt was not handled")
+	request, handled = controller.RequestInterruptKind()
+	if !handled {
+		t.Fatal("second interrupt kind was not handled")
+	}
+	if request != ShutdownRequestForce {
+		t.Fatalf("second interrupt kind = %v, want force", request)
 	}
 	if got := <-controller.Requests(); got != ShutdownRequestForce {
 		t.Fatalf("second interrupt = %v, want force", got)

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -21,6 +21,11 @@ var ErrNilHub = errors.New("nil telemetry hub")
 
 const defaultDashboardURL = "http://localhost:4000"
 
+const (
+	shutdownDrainNotice = "shutdown requested; draining sessions, press Ctrl+C again to force quit"
+	shutdownForceNotice = "force quit requested; interrupting sessions"
+)
+
 type Option func(*options)
 
 type options struct {
@@ -39,6 +44,8 @@ type Model struct {
 	now          func() time.Time
 	build        buildinfo.Info
 	interrupt    func()
+	interrupts   int
+	shutdownNote string
 	styles       styles
 }
 
@@ -117,6 +124,12 @@ func (m Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		switch msg.String() {
 		case "ctrl+c":
 			if m.interrupt != nil {
+				m.interrupts++
+				if m.interrupts == 1 {
+					m.shutdownNote = shutdownDrainNotice
+				} else {
+					m.shutdownNote = shutdownForceNotice
+				}
 				m.interrupt()
 				return m, nil
 			}
@@ -166,15 +179,21 @@ func (m Model) renderWaiting() string {
 	lines := []string{
 		m.styles.title.Render("╭─ DETENT STATUS"),
 		"│ Dashboard: " + m.styles.info.Render(defaultDashboardURL),
-		"│ " + m.styles.muted.Render("Waiting for telemetry snapshot"),
-		closingBorder,
 	}
+	if m.shutdownNote != "" {
+		lines = append(lines, "│ Shutdown: "+m.styles.warn.Render(m.shutdownNote))
+	}
+	lines = append(lines, "│ "+m.styles.muted.Render("Waiting for telemetry snapshot"), closingBorder)
 
 	return strings.Join(lines, "\n")
 }
 
 func (m Model) renderSnapshot() string {
 	snapshot := m.snapshot
+	shutdownStatus := formatShutdown(snapshot.Shutdown, m.styles)
+	if m.shutdownNote != "" {
+		shutdownStatus = m.styles.warn.Render(m.shutdownNote)
+	}
 	lines := []string{
 		m.styles.title.Render("╭─ DETENT STATUS"),
 		"│ Generated: " + m.styles.muted.Render(formatTimestamp(snapshot.GeneratedAt)),
@@ -199,7 +218,7 @@ func (m Model) renderSnapshot() string {
 			m.styles.warn.Render("total "+formatCount(snapshot.Tokens.Total)),
 		"│ Budget: " + formatBudget(snapshot.Budget, m.styles),
 		"│ Rate Limits: " + formatRateLimits(snapshot.RateLimits, m.now, m.styles),
-		"│ Shutdown: " + formatShutdown(snapshot.Shutdown, m.styles),
+		"│ Shutdown: " + shutdownStatus,
 		"│ Project: " + formatOptionalInfo(formatProject(snapshot.Project), m.styles),
 		"│ Instance: " + formatOptionalInfo(formatInstance(snapshot.Instance), m.styles),
 		"│ Scope: " + formatOptionalInfo(formatAuthorizationScope(snapshot.Instance), m.styles),

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -309,6 +309,67 @@ func TestModelRequestsInterruptOnCtrlC(t *testing.T) {
 	}
 }
 
+func TestModelShowsShutdownNoticeOnCtrlC(t *testing.T) {
+	t.Parallel()
+
+	interrupts := 0
+	model := Model{
+		snapshot:    testSnapshot(),
+		hasSnapshot: true,
+		width:       defaultTerminalColumns,
+		now:         time.Now,
+		interrupt: func() {
+			interrupts++
+		},
+		styles: newStyles(),
+	}
+
+	next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd != nil {
+		t.Fatal("Update(first ctrl+c) returned command")
+	}
+	got := next.(Model)
+	if interrupts != 1 {
+		t.Fatalf("interrupts = %d, want 1", interrupts)
+	}
+	view := stripANSI(got.View())
+	if !strings.Contains(view, "Shutdown: "+shutdownDrainNotice) {
+		t.Fatalf("View() missing shutdown notice:\n%s", view)
+	}
+
+	next, cmd = got.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd != nil {
+		t.Fatal("Update(second ctrl+c) returned command")
+	}
+	got = next.(Model)
+	if interrupts != 2 {
+		t.Fatalf("interrupts = %d, want 2", interrupts)
+	}
+	view = stripANSI(got.View())
+	if !strings.Contains(view, "Shutdown: "+shutdownForceNotice) {
+		t.Fatalf("View() missing force shutdown notice:\n%s", view)
+	}
+}
+
+func TestModelShowsShutdownNoticeBeforeSnapshot(t *testing.T) {
+	t.Parallel()
+
+	model, err := NewModel(context.Background(), hub.New[telemetry.Snapshot](), WithInterruptFunc(func() {}))
+	if err != nil {
+		t.Fatalf("NewModel() error = %v", err)
+	}
+
+	next, cmd := model.Update(tea.KeyMsg{Type: tea.KeyCtrlC})
+	if cmd != nil {
+		t.Fatal("Update(ctrl+c) returned command")
+	}
+
+	view := stripANSI(next.(Model).View())
+	if !strings.Contains(view, "Shutdown: "+shutdownDrainNotice) {
+		t.Fatalf("View() missing shutdown notice before snapshot:\n%s", view)
+	}
+}
+
 func TestModelQuitsOnCtrlCWithoutInterruptHandler(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Show an immediate shutdown notice in the terminal dashboard after Ctrl+C
- Print the same interrupt notice for OS signal shutdown paths
- Add regression coverage for drain and force interrupt feedback

## Test Plan

- [x] `make check`
