### PR TITLE
fix(shutdown): hard exit forced interrupts

### DIFF
--- a/cmd/detent/main.go
+++ b/cmd/detent/main.go
@@ -28,7 +28,7 @@ func runCLI(ctx context.Context, args []string, stdout io.Writer, stderr io.Writ
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 	shutdownController := cli.NewShutdownController()
-	stopSignals := notifyShutdownRequests(shutdownController, cancel, stderr)
+	stopSignals := notifyShutdownRequests(shutdownController, cancel, stderr, os.Exit)
 	defer stopSignals()
 
 	cmd := newRootCommand(ctx, shutdownController)

--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -334,6 +334,70 @@ func TestWriteSignalShutdownNotice(t *testing.T) {
 	}
 }
 
+func TestHandleShutdownSignalHardExitsOnForceInterrupt(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	interrupts := &shutdownInterruptStub{
+		requests: []cli.ShutdownRequest{
+			cli.ShutdownRequestDrain,
+			cli.ShutdownRequestForce,
+		},
+	}
+	var output bytes.Buffer
+	var exits []int
+
+	if done := handleShutdownSignal(interrupts, cancel, &output, func(code int) {
+		exits = append(exits, code)
+	}); done {
+		t.Fatal("first interrupt stopped signal loop")
+	}
+	if len(exits) != 0 {
+		t.Fatalf("first interrupt exit codes = %v, want none", exits)
+	}
+	select {
+	case <-ctx.Done():
+		t.Fatal("first interrupt canceled root context")
+	default:
+	}
+
+	if done := handleShutdownSignal(interrupts, cancel, &output, func(code int) {
+		exits = append(exits, code)
+	}); !done {
+		t.Fatal("force interrupt did not stop signal loop")
+	}
+	if len(exits) != 1 || exits[0] != cli.ExitGeneral {
+		t.Fatalf("force interrupt exit codes = %v, want [%d]", exits, cli.ExitGeneral)
+	}
+
+	notice := output.String()
+	for _, want := range []string{
+		"shutdown requested; draining sessions, press Ctrl+C again to force quit",
+		"force quit requested; interrupting sessions",
+	} {
+		if !strings.Contains(notice, want) {
+			t.Fatalf("notice missing %q:\n%s", want, notice)
+		}
+	}
+}
+
+type shutdownInterruptStub struct {
+	requests []cli.ShutdownRequest
+	calls    int
+}
+
+func (s *shutdownInterruptStub) RequestInterruptKind() (cli.ShutdownRequest, bool) {
+	if s.calls >= len(s.requests) {
+		s.calls++
+		return 0, false
+	}
+	request := s.requests[s.calls]
+	s.calls++
+	return request, request != 0
+}
+
 func collectCommandsWithoutExamples(cmd *cobra.Command, missing *[]string) {
 	name := cmd.CommandPath()
 	if name == "" {

--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -15,48 +15,31 @@ func newSignalContext(parent context.Context) (context.Context, context.CancelFu
 	return signal.NotifyContext(parent, shutdownSignals()...)
 }
 
-func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot context.CancelFunc, noticeOut io.Writer) func() {
+type shutdownInterruptRequester interface {
+	RequestInterruptKind() (cli.ShutdownRequest, bool)
+}
+
+func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot context.CancelFunc, noticeOut io.Writer, hardExit func(int)) func() {
 	if controller == nil {
 		return func() {}
 	}
 
 	stop := make(chan struct{})
 	done := make(chan struct{})
-	first := make(chan os.Signal, 1)
-	signal.Notify(first, shutdownSignals()...)
+	signals := make(chan os.Signal, 2)
+	signal.Notify(signals, shutdownSignals()...)
 
 	go func() {
 		defer close(done)
-		select {
-		case <-stop:
-			signal.Stop(first)
-			return
-		case <-first:
-			signal.Stop(first)
-			request, handled := controller.RequestInterruptKind()
-			writeSignalShutdownNotice(noticeOut, request)
-			if !handled {
-				if cancelRoot != nil {
-					cancelRoot()
+		defer signal.Stop(signals)
+		for {
+			select {
+			case <-stop:
+				return
+			case <-signals:
+				if handleShutdownSignal(controller, cancelRoot, noticeOut, hardExit) {
+					return
 				}
-				return
-			}
-		}
-
-		second := make(chan os.Signal, 1)
-		signal.Notify(second, shutdownSignals()...)
-		defer signal.Stop(second)
-		select {
-		case <-stop:
-			return
-		case <-second:
-			request, handled := controller.RequestInterruptKind()
-			writeSignalShutdownNotice(noticeOut, request)
-			if handled {
-				return
-			}
-			if cancelRoot != nil {
-				cancelRoot()
 			}
 		}
 	}()
@@ -65,10 +48,37 @@ func notifyShutdownRequests(controller *cli.ShutdownController, cancelRoot conte
 	return func() {
 		once.Do(func() {
 			close(stop)
-			signal.Stop(first)
+			signal.Stop(signals)
 			<-done
 		})
 	}
+}
+
+func handleShutdownSignal(controller shutdownInterruptRequester, cancelRoot context.CancelFunc, noticeOut io.Writer, hardExit func(int)) bool {
+	var request cli.ShutdownRequest
+	var handled bool
+	if controller != nil {
+		request, handled = controller.RequestInterruptKind()
+	}
+	writeSignalShutdownNotice(noticeOut, request)
+	if request == cli.ShutdownRequestForce {
+		hardExitSignal(hardExit)
+		return true
+	}
+	if handled {
+		return false
+	}
+	if cancelRoot != nil {
+		cancelRoot()
+	}
+	return true
+}
+
+func hardExitSignal(hardExit func(int)) {
+	if hardExit == nil {
+		hardExit = os.Exit
+	}
+	hardExit(cli.ExitGeneral)
 }
 
 func writeSignalShutdownNotice(out io.Writer, request cli.ShutdownRequest) {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -285,7 +285,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 				HardTimeout:      defaultShutdownHardTimeout,
 			}, func(ctx context.Context) error {
 				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, func() {
-					cfg.Shutdown.RequestInterrupt()
+					requestTerminalShutdownInterrupt(cfg.Shutdown, cfg.HardExit)
 				})
 			})
 		})
@@ -513,6 +513,24 @@ func unexpectedTerminalDashboardError(err error) error {
 
 func shouldLaunchTerminalDashboard(cfg BootConfig) bool {
 	return cfg.Mode == BootModeRunning && cfg.StdoutTTY && !cfg.Headless
+}
+
+func requestTerminalShutdownInterrupt(controller *ShutdownController, hardExit func(int)) bool {
+	request, handled := controller.RequestInterruptKind()
+	if !handled {
+		return false
+	}
+	if request == ShutdownRequestForce {
+		hardExitProcess(hardExit)
+	}
+	return true
+}
+
+func hardExitProcess(hardExit func(int)) {
+	if hardExit == nil {
+		hardExit = os.Exit
+	}
+	hardExit(ExitGeneral)
 }
 
 func redirectDefaultLogger(path string, level string) (func(), error) {

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -147,6 +147,7 @@ type BootConfig struct {
 	StdoutTTY        bool
 	Output           io.Writer
 	Shutdown         *ShutdownController
+	HardExit         func(int)
 	Runner           orchestrator.Runner
 	ConnectorFactory project.ConnectorFactory
 }

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -88,6 +88,39 @@ func TestShutdownControllerDrainMakesNextInterruptForce(t *testing.T) {
 	}
 }
 
+func TestRequestTerminalShutdownInterruptHardExitsOnSecondInterrupt(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	deactivate := controller.activate()
+	defer deactivate()
+
+	var exits []int
+	hardExit := func(code int) {
+		exits = append(exits, code)
+	}
+
+	if !requestTerminalShutdownInterrupt(controller, hardExit) {
+		t.Fatal("first interrupt was not handled")
+	}
+	if len(exits) != 0 {
+		t.Fatalf("first interrupt exit codes = %v, want none", exits)
+	}
+	if got := <-controller.Requests(); got != ShutdownRequestDrain {
+		t.Fatalf("first interrupt request = %v, want drain", got)
+	}
+
+	if !requestTerminalShutdownInterrupt(controller, hardExit) {
+		t.Fatal("second interrupt was not handled")
+	}
+	if got := <-controller.Requests(); got != ShutdownRequestForce {
+		t.Fatalf("second interrupt request = %v, want force", got)
+	}
+	if len(exits) != 1 || exits[0] != ExitGeneral {
+		t.Fatalf("second interrupt exit codes = %v, want [%d]", exits, ExitGeneral)
+	}
+}
+
 func TestRunWithShutdownZeroSessionsExitsGracefully(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Keep the shutdown signal listener installed across repeated interrupts.
- Make the second Ctrl+C/force interrupt call the configured hard exit immediately.
- Add regression coverage for OS signal and terminal dashboard force quit paths.

## Test Plan

- [x] `go build ./...`
- [x] `go test ./...`
- [x] `golangci-lint run --timeout=5m`
- [x] `make check`