### PR TITLE
fix(tui): clarify lifecycle status

### DIFF
--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -190,9 +190,10 @@ func (m Model) renderWaiting() string {
 
 func (m Model) renderSnapshot() string {
 	snapshot := m.snapshot
-	shutdownStatus := formatShutdown(snapshot.Shutdown, m.styles)
+	lifecycleLabel, lifecycleStatus := formatLifecycle(snapshot.Shutdown, m.styles)
 	if m.shutdownNote != "" {
-		shutdownStatus = m.styles.warn.Render(m.shutdownNote)
+		lifecycleLabel = "Shutdown"
+		lifecycleStatus = m.styles.warn.Render(m.shutdownNote)
 	}
 	lines := []string{
 		m.styles.title.Render("╭─ DETENT STATUS"),
@@ -218,12 +219,12 @@ func (m Model) renderSnapshot() string {
 			m.styles.warn.Render("total "+formatCount(snapshot.Tokens.Total)),
 		"│ Budget: " + formatBudget(snapshot.Budget, m.styles),
 		"│ Rate Limits: " + formatRateLimits(snapshot.RateLimits, m.now, m.styles),
-		"│ Shutdown: " + shutdownStatus,
 		"│ Project: " + formatOptionalInfo(formatProject(snapshot.Project), m.styles),
 		"│ Instance: " + formatOptionalInfo(formatInstance(snapshot.Instance), m.styles),
 		"│ Scope: " + formatOptionalInfo(formatAuthorizationScope(snapshot.Instance), m.styles),
 		"│ Dashboard: " + m.styles.info.Render(formatDashboardURL(snapshot)),
 		"│ Next refresh: " + formatOptionalInfo(formatNextRefresh(snapshot.Refresh), m.styles),
+		"│ " + lifecycleLabel + ": " + lifecycleStatus,
 		m.styles.title.Render("├─ Running"),
 		"│",
 	}...)
@@ -242,15 +243,18 @@ func (m Model) renderSnapshot() string {
 	return strings.Join(lines, "\n")
 }
 
-func formatShutdown(shutdown telemetry.Shutdown, s styles) string {
+func formatLifecycle(shutdown telemetry.Shutdown, s styles) (string, string) {
 	if shutdown.Draining {
-		return s.warn.Render(fmt.Sprintf("draining (%d sessions remaining)", shutdown.SessionsRemaining))
+		return "Shutdown", s.warn.Render(fmt.Sprintf("draining (%d sessions remaining)", shutdown.SessionsRemaining))
 	}
 	status := strings.TrimSpace(shutdown.Status)
 	if status == "" {
 		status = "running"
 	}
-	return s.ok.Render(status)
+	if strings.EqualFold(status, "running") {
+		return "Lifecycle", s.ok.Render(status)
+	}
+	return "Shutdown", s.warn.Render(status)
 }
 
 func formatRunningRows(running []telemetry.Running, eventWidth int, s styles) []string {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -55,7 +55,7 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 		"Tokens: in 110 | out 220 | total 330",
 		"Budget: enabled current $12.50 | projected $0.75 | day max $50.00 | issue max $5.00",
 		"Rate Limits: codex-primary | primary 90/100 reset 60s | secondary 0/100 reset 30s | credits 0/1",
-		"Shutdown: running",
+		"Lifecycle: running",
 		"Running",
 		"PID",
 		"DD-44",
@@ -80,6 +80,12 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 	}
 	if strings.Contains(view, "worker-1") {
 		t.Fatalf("View() rendered worker host as process identity:\n%s", view)
+	}
+	if strings.Contains(view, "Shutdown: running") {
+		t.Fatalf("View() rendered confusing shutdown status:\n%s", view)
+	}
+	if strings.Index(view, "Lifecycle: running") < strings.Index(view, "Next refresh:") {
+		t.Fatalf("View() promoted lifecycle status above refresh details:\n%s", view)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace normal TUI `Shutdown: running` copy with `Lifecycle: running`.
- Keep active shutdown requests labeled as `Shutdown` and move the lifecycle line below refresh details.
- Add regression coverage for normal running copy, hierarchy, and shutdown-requested copy.

Fixes #470

## Test Plan

- [x] `go test ./internal/tui -count=1`
- [x] `make check`