### PR TITLE
fix(config): reconcile startup reload gap

### DIFF
--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -234,6 +235,7 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 
 	provisionStarted := make(chan struct{})
 	provisionRelease := make(chan struct{})
+	var provisionStartedOnce sync.Once
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	done := make(chan error, 1)
@@ -246,7 +248,9 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 			ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
 				return bootProvisioningConnector{
 					provision: func(ctx context.Context) error {
-						close(provisionStarted)
+						provisionStartedOnce.Do(func() {
+							close(provisionStarted)
+						})
 						select {
 						case <-ctx.Done():
 							return ctx.Err()
@@ -345,6 +349,87 @@ func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for startRunning to stop")
+	}
+}
+
+func TestStartRunningReconcilesGlobalConfigChangedBeforeWatcherStarts(t *testing.T) {
+	host, port := freeLoopbackPort(t)
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	bravo := createBootProjectFiles(t)
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
+	})
+	global, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	provisionStarted := make(chan struct{})
+	provisionRelease := make(chan struct{})
+	var provisionStartedOnce sync.Once
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, BootConfig{
+			Mode:   BootModeRunning,
+			Global: global,
+			Host:   host,
+			Port:   &port,
+			ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
+				return bootProvisioningConnector{
+					provision: func(ctx context.Context) error {
+						provisionStartedOnce.Do(func() {
+							close(provisionStarted)
+						})
+						select {
+						case <-ctx.Done():
+							return ctx.Err()
+						case <-provisionRelease:
+							return nil
+						}
+					},
+				}, nil
+			},
+		})
+	}()
+
+	select {
+	case <-provisionStarted:
+	case err := <-done:
+		t.Fatalf("startRunning returned before provisioning blocked: %v", err)
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for project provisioning to start")
+	}
+
+	settingsURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port)) + "/settings"
+	body := waitForDashboard(t, settingsURL, done)
+	if !strings.Contains(body, "alpha") {
+		t.Fatalf("settings body missing alpha:\n%s", body)
+	}
+
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
+		{ID: "bravo", Workflow: bravo.workflowPath, Workdir: bravo.workdirPath, Weight: 1},
+	})
+	close(provisionRelease)
+
+	body = waitForDashboardCondition(t, settingsURL, done, "bravo added after startup write", func(body string) bool {
+		return strings.Contains(body, "bravo")
+	})
+	if !strings.Contains(body, "alpha") {
+		t.Fatalf("settings body missing alpha after startup write:\n%s", body)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
 			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
 		}
 	case <-time.After(10 * time.Second):

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"reflect"
 	"strings"
+	"time"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
@@ -74,6 +75,7 @@ func startGlobalConfigWatcher(
 	if len(onReload) > 0 {
 		reloader.onReload = onReload[0]
 	}
+	syncLatestGlobalConfig(ctx, path, reloader)
 	go func() {
 		defer close(done)
 		for {
@@ -89,6 +91,23 @@ func startGlobalConfigWatcher(
 		}
 	}()
 	return done
+}
+
+func syncLatestGlobalConfig(ctx context.Context, path string, reloader *globalConfigReloader) {
+	if reloader == nil {
+		return
+	}
+	latest, err := readGlobalConfig(path)
+	update := configwatcher.FileUpdate[globalconfig.Config]{
+		Path:  path,
+		Value: latest,
+		Err:   err,
+		At:    time.Now(),
+	}
+	if err == nil && reflect.DeepEqual(reloader.current, latest) {
+		return
+	}
+	reloader.handle(ctx, update)
 }
 
 func readGlobalConfig(path string) (globalconfig.Config, error) {


### PR DESCRIPTION
## Summary

- Re-read and reconcile the latest global config immediately after installing the startup watcher.
- Catch config writes that happen while startup is still completing and before fsnotify is subscribed.
- Add a deterministic regression test for the startup watcher gap that made main CI flaky.

## Test Plan

- [x] `go test ./internal/cli -run TestStartRunningReconcilesGlobalConfigChangedBeforeWatcherStarts -count=1 -v`
- [x] `go test ./internal/cli -run 'TestStartRunning(HotReloadsGlobalConfigProjects|ReconcilesGlobalConfigChangedBeforeWatcherStarts)' -count=5 -v`\n- [x] `go test -race ./internal/cli -count=1`\n- [x] `go test ./...`\n- [x] `make check`\n- [x] `goreleaser release --snapshot --clean` reached signing; local run only failed because `MINISIGN_KEY_FILE` is a CI secret/env var