### PR TITLE
fix(workflow): harden dependency unblock refs

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -13,6 +13,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -37,6 +38,11 @@ var ErrDoctorFailed = errors.New("doctor found failed checks")
 const (
 	doctorCommandTimeout = 5 * time.Second
 	doctorCheckTimeout   = 5 * time.Second
+)
+
+var (
+	doctorDependencyIssueURLPattern = regexp.MustCompile(`https://github\.com/([^/\s]+/[^/\s]+)/(?:issues|pull)/(\d+)`)
+	doctorDependencyIssueRefPattern = regexp.MustCompile(`(?:^|[\s(,;:])([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)?#(\d+)\b`)
 )
 
 type doctorStatus string
@@ -1420,6 +1426,14 @@ func doctorDependencyDiagnostics(
 			})
 			continue
 		}
+		if len(hydrated.BlockedBy) > 0 && len(doctorDependencyTextBlockedRefs(hydrated)) == 0 {
+			diagnostics = append(diagnostics, doctorDependencyDiagnostic{
+				Code:       "dependency_metadata_missing",
+				Issue:      hydrated,
+				References: references,
+			})
+			continue
+		}
 		if len(hydrated.BlockedBy) == 0 {
 			diagnostics = append(diagnostics, doctorDependencyDiagnostic{
 				Code:       "dependency_reference_unresolved",
@@ -1458,7 +1472,8 @@ func hydrateDoctorDependencyIssue(
 	issue connector.Issue,
 	sourceStates []string,
 ) (connector.Issue, bool, error) {
-	if len(issue.BlockedBy) > 0 || strings.TrimSpace(issue.Identifier) == "" {
+	issue = doctorIssueWithTextDependencyRefs(issue)
+	if strings.TrimSpace(issue.Identifier) == "" {
 		return issue, doctorStateInList(issue.State, sourceStates), nil
 	}
 	resolver, ok := projectConnector.(connector.IssueReferenceResolver)
@@ -1471,7 +1486,11 @@ func hydrateDoctorDependencyIssue(
 	}
 	for _, hydrated := range issues {
 		if sameDoctorIssueIdentity(issue, hydrated) {
-			return mergeDoctorDependencyIssue(issue, hydrated), doctorStateInList(hydrated.State, sourceStates), nil
+			previousBlockedBy := append([]connector.BlockedRef(nil), issue.BlockedBy...)
+			merged := mergeDoctorDependencyIssue(issue, hydrated)
+			merged.BlockedBy = mergeDoctorDependencyBlockedRefs(previousBlockedBy, merged.BlockedBy)
+			merged = doctorIssueWithTextDependencyRefs(merged)
+			return merged, doctorStateInList(merged.State, sourceStates), nil
 		}
 	}
 	return issue, doctorStateInList(issue.State, sourceStates), nil
@@ -1631,6 +1650,9 @@ func doctorDependencyAutoUnblockHint(diagnostics []doctorDependencyDiagnostic) s
 	if _, ok := codes["dependency_reference_unresolved"]; ok {
 		hints = append(hints, "Fix issue content so Depends on: or Blocked by: references point to existing GitHub issues.")
 	}
+	if _, ok := codes["dependency_metadata_missing"]; ok {
+		hints = append(hints, "Add canonical Depends on: or Blocked by: lines to the blocked issue body before leaving dependency-blocked work in Blocked.")
+	}
 	if _, ok := codes["dependency_ready_but_still_blocked"]; ok {
 		hints = append(hints, "Check tracker.dependency_auto_unblock source_states, target_state, readiness, and GitHub Project Status mappings.")
 	}
@@ -1681,6 +1703,137 @@ func doctorDependencyLineReferences(body string) []string {
 		refs = append(refs, ref)
 	}
 	return refs
+}
+
+func doctorIssueWithTextDependencyRefs(issue connector.Issue) connector.Issue {
+	issue.BlockedBy = mergeDoctorDependencyBlockedRefs(issue.BlockedBy, doctorDependencyTextBlockedRefs(issue))
+	issue.BlockedBy = doctorDependencyBlockedRefsWithoutSelf(issue.BlockedBy, issue.Identifier)
+	return issue
+}
+
+func doctorDependencyTextBlockedRefs(issue connector.Issue) []connector.BlockedRef {
+	repo := doctorDependencyIssueRepo(issue.Identifier)
+	refs := []connector.BlockedRef{}
+	seen := map[string]struct{}{}
+	appendIdentifier := func(identifier string) {
+		identifier = strings.TrimSpace(identifier)
+		if identifier == "" {
+			return
+		}
+		key := strings.ToLower(identifier)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, connector.BlockedRef{Identifier: identifier})
+	}
+	for _, lineRef := range doctorDependencyLineReferences(issue.Description) {
+		identifiers := doctorDependencyIssueIdentifiersInText(lineRef, repo)
+		if len(identifiers) == 0 {
+			appendIdentifier(lineRef)
+			continue
+		}
+		for _, identifier := range identifiers {
+			appendIdentifier(identifier)
+		}
+	}
+	return refs
+}
+
+func mergeDoctorDependencyBlockedRefs(existing []connector.BlockedRef, incoming []connector.BlockedRef) []connector.BlockedRef {
+	if len(existing) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	merged := make([]connector.BlockedRef, 0, len(existing)+len(incoming))
+	seen := map[string]struct{}{}
+	appendRefs := func(refs []connector.BlockedRef) {
+		for _, ref := range refs {
+			key := strings.ToLower(strings.TrimSpace(ref.Identifier))
+			if key == "" {
+				key = strings.ToLower(strings.TrimSpace(ref.ID))
+			}
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, ref)
+		}
+	}
+	appendRefs(existing)
+	appendRefs(incoming)
+	return merged
+}
+
+func doctorDependencyBlockedRefsWithoutSelf(refs []connector.BlockedRef, identifier string) []connector.BlockedRef {
+	self := strings.ToLower(strings.TrimSpace(identifier))
+	if self == "" || len(refs) == 0 {
+		return refs
+	}
+	filtered := refs[:0]
+	for _, ref := range refs {
+		if strings.ToLower(strings.TrimSpace(ref.Identifier)) == self {
+			continue
+		}
+		filtered = append(filtered, ref)
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
+}
+
+func doctorDependencyIssueIdentifiersInText(text string, repo string) []string {
+	refs := []string{}
+	seen := map[string]struct{}{}
+	appendIdentifier := func(refRepo string, number string) {
+		identifier := doctorDependencyBlockerIdentifier(refRepo, number, repo)
+		if identifier == "" {
+			return
+		}
+		key := strings.ToLower(identifier)
+		if _, ok := seen[key]; ok {
+			return
+		}
+		seen[key] = struct{}{}
+		refs = append(refs, identifier)
+	}
+	for _, matches := range doctorDependencyIssueURLPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) == 3 {
+			appendIdentifier(matches[1], matches[2])
+		}
+	}
+	for _, matches := range doctorDependencyIssueRefPattern.FindAllStringSubmatch(text, -1) {
+		if len(matches) == 3 {
+			appendIdentifier(matches[1], matches[2])
+		}
+	}
+	return refs
+}
+
+func doctorDependencyIssueRepo(identifier string) string {
+	identifier = strings.TrimSpace(identifier)
+	index := strings.LastIndex(identifier, "#")
+	if index <= 0 {
+		return ""
+	}
+	return strings.TrimSpace(identifier[:index])
+}
+
+func doctorDependencyBlockerIdentifier(refRepo string, number string, repo string) string {
+	if strings.TrimSpace(number) == "" {
+		return ""
+	}
+	refRepo = strings.TrimSpace(refRepo)
+	if refRepo == "" {
+		if repo == "" {
+			return "#" + strings.TrimSpace(number)
+		}
+		refRepo = repo
+	}
+	return refRepo + "#" + strings.TrimSpace(number)
 }
 
 func doctorDependencyLineReference(line string) (string, bool) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -546,7 +546,11 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 			cfg:  validDoctorDependencyWorkflow(true),
 			connector: &fakeDoctorAutoPromoteConnector{
 				issues: []connector.Issue{
-					doctorDependencyIssue("issue-unresolved", []connector.BlockedRef{{Identifier: unresolvedRef}}),
+					func() connector.Issue {
+						issue := doctorDependencyIssueWithBody("issue-unresolved", "Depends on: "+unresolvedRef)
+						issue.BlockedBy = []connector.BlockedRef{{Identifier: unresolvedRef}}
+						return issue
+					}(),
 				},
 			},
 			want: doctorWarn,
@@ -555,6 +559,26 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 				"issue-unresolved",
 				unresolvedRef,
 				"Depends on:",
+			},
+		},
+		{
+			name: "dependency refs without body metadata warn with issue body fix",
+			cfg:  validDoctorDependencyWorkflow(true),
+			connector: &fakeDoctorAutoPromoteConnector{
+				issues: []connector.Issue{
+					doctorDependencyIssue("issue-416", []connector.BlockedRef{
+						{Identifier: "digitaldrywood/detent#415"},
+						{Identifier: "digitaldrywood/detent#416"},
+					}),
+				},
+			},
+			want: doctorWarn,
+			wantDetails: []string{
+				"dependency_metadata_missing",
+				"issue-416",
+				"digitaldrywood/detent#415",
+				"Depends on:",
+				"Blocked by:",
 			},
 		},
 		{
@@ -578,7 +602,11 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 			cfg:  validDoctorDependencyWorkflow(true),
 			connector: &fakeDoctorAutoPromoteConnector{
 				issues: []connector.Issue{
-					doctorDependencyIssue("issue-ready", []connector.BlockedRef{{Identifier: readyRef}}),
+					func() connector.Issue {
+						issue := doctorDependencyIssueWithBody("issue-ready", "Depends on: "+readyRef)
+						issue.BlockedBy = []connector.BlockedRef{{Identifier: readyRef}}
+						return issue
+					}(),
 				},
 				resolvedIssues: []connector.Issue{
 					doctorDependencyResolvedIssue("blocker-done", readyRef, "Done", false, nil),
@@ -590,6 +618,32 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 				"issue-ready",
 				readyRef,
 				"tracker.dependency_auto_unblock",
+			},
+		},
+		{
+			name: "hydrated body metadata is merged with connector refs",
+			cfg:  validDoctorDependencyWorkflow(true),
+			connector: &fakeDoctorAutoPromoteConnector{
+				issues: []connector.Issue{
+					doctorDependencyIssue("issue-416", []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415"}}),
+				},
+				hydratedIssues: []connector.Issue{
+					doctorDependencyIssueWithBody("issue-416", strings.Join([]string{
+						"Depends on: #414",
+						"Depends on: #415",
+					}, "\n")),
+				},
+				resolvedIssues: []connector.Issue{
+					doctorDependencyResolvedIssue("blocker-414", "digitaldrywood/detent#414", "Done", false, nil),
+					doctorDependencyResolvedIssue("blocker-415", "digitaldrywood/detent#415", "Done", false, nil),
+				},
+			},
+			want: doctorWarn,
+			wantDetails: []string{
+				"dependency_ready_but_still_blocked",
+				"issue-416",
+				"digitaldrywood/detent#414",
+				"digitaldrywood/detent#415",
 			},
 		},
 	}
@@ -1798,6 +1852,7 @@ func doctorDependencyResolvedIssue(id string, identifier string, state string, c
 
 type fakeDoctorAutoPromoteConnector struct {
 	issues         []connector.Issue
+	hydratedIssues []connector.Issue
 	resolvedIssues []connector.Issue
 	verifyErr      error
 	verifyStates   []string
@@ -1818,8 +1873,8 @@ func (c *fakeDoctorAutoPromoteConnector) FetchIssueStatesByIdentifiers(_ context
 	for _, identifier := range identifiers {
 		wanted[strings.ToLower(strings.TrimSpace(identifier))] = struct{}{}
 	}
-	issues := make([]connector.Issue, 0, len(c.resolvedIssues))
-	for _, issue := range c.resolvedIssues {
+	issues := make([]connector.Issue, 0, len(c.hydratedIssues)+len(c.resolvedIssues))
+	for _, issue := range append(c.hydratedIssues, c.resolvedIssues...) {
 		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
 			issues = append(issues, issue)
 		}

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -1266,9 +1266,11 @@ func (c *Connector) populateBlockerReasons(ctx context.Context, issues []connect
 			return fmt.Errorf("fetch github issue comments: %w", err)
 		}
 		node := githubIssueNode{
-			ID:       issues[index].ID,
-			Body:     issues[index].Description,
-			Comments: nodeConnection[issueComment]{Nodes: comments},
+			ID:         issues[index].ID,
+			Number:     ref.Number,
+			Body:       issues[index].Description,
+			Repository: repository{NameWithOwner: ref.Owner + "/" + ref.Name},
+			Comments:   nodeConnection[issueComment]{Nodes: comments},
 		}
 		if len(issues[index].BlockedBy) == 0 {
 			issues[index].BlockedBy = parseBlockedByFromIssueText(node, issueRepo(issues[index].Identifier))
@@ -3460,12 +3462,20 @@ func parseBlockerReason(issue githubIssueNode) string {
 }
 
 func parseBlockedByFromIssueText(issue githubIssueNode, repo string) []connector.BlockedRef {
+	repo = strings.TrimSpace(repo)
+	if repo == "" {
+		repo = strings.TrimSpace(issue.Repository.NameWithOwner)
+	}
+	self := normalizedIssueIdentifier(buildIdentifier(repo, issue.Number))
 	blockers := []connector.BlockedRef{}
 	seen := map[string]struct{}{}
 	appendBlockers := func(refs []connector.BlockedRef) {
 		for _, ref := range refs {
 			key := normalizedIssueIdentifier(ref.Identifier)
 			if key == "" {
+				continue
+			}
+			if self != "" && key == self {
 				continue
 			}
 			if _, ok := seen[key]; ok {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1053,7 +1053,7 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadBlockedByRefs(t *testing.T) 
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/issues/416/comments?per_page=100",
-			body:   `[{"body":"## Codex Workpad\n\n### Blockers\n- Blocked by: #415\n- Waiting for digitaldrywood/agent-runtime#25\n\n### Validation\n- Pending."}]`,
+			body:   `[{"body":"## Codex Workpad\n\n### Blockers\n- Blocked by: #415\n- Waiting for digitaldrywood/agent-runtime#25\n- Human action needed: merge #415, then move #416 back to Todo.\n\n### Validation\n- Pending."}]`,
 		},
 	})
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -85,12 +85,12 @@ func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(
 	sourceStates []string,
 ) (connector.Issue, bool) {
 	issue = issueWithTextDependencyRefs(issue)
-	if len(issue.BlockedBy) > 0 || strings.TrimSpace(issue.Identifier) == "" {
+	if strings.TrimSpace(issue.Identifier) == "" {
 		return issue, stateIn(issue.State, sourceStates)
 	}
 	resolver, ok := o.connector.(connector.IssueReferenceResolver)
 	if !ok {
-		return issue, true
+		return issue, stateIn(issue.State, sourceStates)
 	}
 	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, []string{issue.Identifier})
 	if err != nil {
@@ -103,19 +103,64 @@ func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(
 		if !sameIssueIdentity(issue, hydrated) {
 			continue
 		}
+		previousBlockedBy := append([]connector.BlockedRef(nil), issue.BlockedBy...)
 		merged := mergeIssueTrackerFields(issue, hydrated)
+		merged.BlockedBy = mergeDependencyBlockedRefs(previousBlockedBy, merged.BlockedBy)
 		merged = issueWithTextDependencyRefs(merged)
 		return merged, stateIn(merged.State, sourceStates)
 	}
-	return issue, true
+	return issue, stateIn(issue.State, sourceStates)
 }
 
 func issueWithTextDependencyRefs(issue connector.Issue) connector.Issue {
-	if len(issue.BlockedBy) > 0 {
-		return issue
-	}
-	issue.BlockedBy = dependencyRefsFromIssueText(issue)
+	issue.BlockedBy = mergeDependencyBlockedRefs(issue.BlockedBy, dependencyRefsFromIssueText(issue))
+	issue.BlockedBy = dependencyBlockedRefsWithoutSelf(issue.BlockedBy, issue.Identifier)
 	return issue
+}
+
+func mergeDependencyBlockedRefs(existing []connector.BlockedRef, incoming []connector.BlockedRef) []connector.BlockedRef {
+	if len(existing) == 0 && len(incoming) == 0 {
+		return nil
+	}
+	merged := make([]connector.BlockedRef, 0, len(existing)+len(incoming))
+	seen := map[string]struct{}{}
+	appendRefs := func(refs []connector.BlockedRef) {
+		for _, ref := range refs {
+			key := strings.ToLower(strings.TrimSpace(ref.Identifier))
+			if key == "" {
+				key = strings.ToLower(strings.TrimSpace(ref.ID))
+			}
+			if key == "" {
+				continue
+			}
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			merged = append(merged, ref)
+		}
+	}
+	appendRefs(existing)
+	appendRefs(incoming)
+	return merged
+}
+
+func dependencyBlockedRefsWithoutSelf(refs []connector.BlockedRef, identifier string) []connector.BlockedRef {
+	self := strings.ToLower(strings.TrimSpace(identifier))
+	if self == "" || len(refs) == 0 {
+		return refs
+	}
+	filtered := refs[:0]
+	for _, ref := range refs {
+		if strings.ToLower(strings.TrimSpace(ref.Identifier)) == self {
+			continue
+		}
+		filtered = append(filtered, ref)
+	}
+	if len(filtered) == 0 {
+		return nil
+	}
+	return filtered
 }
 
 func dependencyRefsFromIssueText(issue connector.Issue) []connector.BlockedRef {

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -120,8 +120,8 @@ func TestTickAutoUnblocksDependencyFromIssueBody(t *testing.T) {
 	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
 		t.Fatalf("updates = %#v, want Blocked issue moved to Todo", got)
 	}
-	if got, want := tracker.identifierCalls, []string{"digitaldrywood/detent#415"}; !slices.Equal(got, want) {
-		t.Fatalf("identifier calls = %#v, want %#v", got, want)
+	if !slices.Contains(tracker.identifierCalls, "digitaldrywood/detent#415") {
+		t.Fatalf("identifier calls = %#v, want dependency lookup", tracker.identifierCalls)
 	}
 }
 
@@ -149,8 +149,8 @@ func TestTickAutoUnblocksDependencyFromBlockedReason(t *testing.T) {
 	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
 		t.Fatalf("updates = %#v, want Blocked issue moved to Todo", got)
 	}
-	if got, want := tracker.identifierCalls, []string{"digitaldrywood/detent#415"}; !slices.Equal(got, want) {
-		t.Fatalf("identifier calls = %#v, want %#v", got, want)
+	if !slices.Contains(tracker.identifierCalls, "digitaldrywood/detent#415") {
+		t.Fatalf("identifier calls = %#v, want dependency lookup", tracker.identifierCalls)
 	}
 	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "digitaldrywood/detent#415") {
 		t.Fatalf("comments = %#v, want recovery comment with blocked reason dependency", tracker.comments)
@@ -302,6 +302,86 @@ func TestTickLeavesDependencyBlockedPRIssueBlocked(t *testing.T) {
 	}
 }
 
+func TestTickMergesHydratedTextDependenciesWithConnectorRefs(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-416", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415"}}
+	hydratedWaiting := waiting
+	hydratedWaiting.Description = strings.Join([]string{
+		"Depends on: #414",
+		"Depends on: #415",
+	}, "\n")
+	readyBlocker := dependencyAutoUnblockIssue("issue-415", "Done")
+	readyBlocker.Identifier = "digitaldrywood/detent#415"
+	unreadyBlocker := dependencyAutoUnblockIssue("issue-414", "In Progress")
+	unreadyBlocker.Identifier = "digitaldrywood/detent#414"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues:    []connector.Issue{waiting},
+		hydratedIssues: []connector.Issue{hydratedWaiting},
+		blockers:       []connector.Issue{readyBlocker, unreadyBlocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 8, 30, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none while hydrated body dependency is not ready", tracker.updates)
+	}
+	if !slices.Contains(tracker.identifierCalls, "digitaldrywood/detent#416") {
+		t.Fatalf("identifier calls = %#v, want hydration lookup for waiting issue", tracker.identifierCalls)
+	}
+	if !slices.Contains(tracker.identifierCalls, "digitaldrywood/detent#414") {
+		t.Fatalf("identifier calls = %#v, want body dependency lookup", tracker.identifierCalls)
+	}
+	if _, ok := state.Blocked[waiting.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing for unresolved hydrated body dependency", waiting.ID)
+	}
+}
+
+func TestTickIgnoresSelfReferenceFromConnectorRefs(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-416", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{
+		{Identifier: "digitaldrywood/detent#415"},
+		{Identifier: "digitaldrywood/detent#416"},
+	}
+	hydratedWaiting := waiting
+	hydratedWaiting.Description = strings.Join([]string{
+		"Depends on: #414",
+		"Depends on: #415",
+	}, "\n")
+	firstBlocker := dependencyAutoUnblockIssue("issue-414", "Done")
+	firstBlocker.Identifier = "digitaldrywood/detent#414"
+	secondBlocker := dependencyAutoUnblockIssue("issue-415", "Done")
+	secondBlocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues:    []connector.Issue{waiting},
+		hydratedIssues: []connector.Issue{hydratedWaiting},
+		blockers:       []connector.Issue{firstBlocker, secondBlocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 8, 45, 0, time.UTC))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
+		t.Fatalf("updates = %#v, want self-reference ignored and issue moved to Todo", got)
+	}
+}
+
 func TestTickLeavesTextDependencyBlockedPRIssueBlocked(t *testing.T) {
 	t.Parallel()
 
@@ -334,8 +414,8 @@ func TestTickLeavesTextDependencyBlockedPRIssueBlocked(t *testing.T) {
 	if len(tracker.updates) != 0 {
 		t.Fatalf("updates = %#v, want none while text dependency is not ready", tracker.updates)
 	}
-	if got, want := tracker.identifierCalls, []string{"digitaldrywood/detent#415"}; !slices.Equal(got, want) {
-		t.Fatalf("identifier calls = %#v, want %#v", got, want)
+	if !slices.Contains(tracker.identifierCalls, "digitaldrywood/detent#415") {
+		t.Fatalf("identifier calls = %#v, want dependency lookup", tracker.identifierCalls)
 	}
 	if _, ok := state.Blocked[waiting.ID]; !ok {
 		t.Fatalf("Blocked[%q] missing for unresolved text dependency blocker", waiting.ID)


### PR DESCRIPTION
## Summary

- merge issue-body dependency refs with connector/workpad refs during dependency auto-unblock hydration
- ignore self-references parsed from Workpad blocker prose so an issue cannot block itself
- add doctor warnings for dependency refs that are missing canonical issue-body metadata

## Validation

- go test ./internal/connector/github ./internal/orchestrator ./internal/cli
- make check

## Dogfood

- Added canonical dependency metadata to #407 and #416 without manually changing project status.
- Detent moved #407 out of Blocked; #416 exposed the self-reference parser bug fixed here.
