### PR TITLE
feat(cli): add JSON error envelopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,6 +290,54 @@ failure class.
 | 3 | Input validation error |
 | 4 | Not found or config conflict |
 
+## CLI JSON error envelopes
+
+When the resolved output format is JSON, command failures write one
+RFC 9457-style problem object to stderr. Human-readable pretty-mode errors are
+unchanged.
+
+```json
+{
+  "type": "https://detent.dev/errors/project_not_found",
+  "code": "project_not_found",
+  "title": "Project not found",
+  "detail": "project \"ap\" not found",
+  "exit_code": 4,
+  "suggested_fix": "available: api, web, infra\ndid you mean \"api\"? see `detent config path`, then retry",
+  "did_you_mean": ["api"],
+  "docs_url": "https://detent.dev/docs/cli#project-not-found"
+}
+```
+
+Envelope fields:
+
+| Field | Required | Meaning |
+| --- | --- | --- |
+| `type` | Yes | Stable problem type URL, using the code slug. |
+| `code` | Yes | Stable machine-readable slug. |
+| `title` | Yes | Short human title for the error class. |
+| `detail` | Yes | Specific failure detail. |
+| `exit_code` | Yes | Process exit code for the failure. |
+| `suggested_fix` | No | Actionable next step when Detent has a hint. |
+| `did_you_mean` | No | Candidate correction list when Detent has suggestions. |
+| `docs_url` | No | Documentation URL for the error class. |
+
+Stable JSON error codes:
+
+| Code | Type URL | Exit code | Source |
+| --- | --- | --- | --- |
+| <a id="general"></a>`general` | `https://detent.dev/errors/general` | 1 | Unexpected error. |
+| <a id="validation"></a>`validation` | `https://detent.dev/errors/validation` | 3 | Input validation, invalid config, or invalid output format. |
+| <a id="unknown-command"></a>`unknown_command` | `https://detent.dev/errors/unknown_command` | 3 | Unknown command. |
+| <a id="unknown-flag"></a>`unknown_flag` | `https://detent.dev/errors/unknown_flag` | 3 | Unknown flag. |
+| <a id="github-auth"></a>`github_auth` | `https://detent.dev/errors/github_auth` | 2 | GitHub token or authentication failure. |
+| <a id="config-exists"></a>`config_exists` | `https://detent.dev/errors/config_exists` | 4 | `ErrConfigExists`. |
+| <a id="project-exists"></a>`project_exists` | `https://detent.dev/errors/project_exists` | 4 | `ErrProjectExists`. |
+| <a id="project-not-found"></a>`project_not_found` | `https://detent.dev/errors/project_not_found` | 4 | `ErrProjectNotFound`. |
+| <a id="doctor-failed"></a>`doctor_failed` | `https://detent.dev/errors/doctor_failed` | 1 | `ErrDoctorFailed`. |
+| <a id="shutdown-forced"></a>`shutdown_forced` | `https://detent.dev/errors/shutdown_forced` | 1 | `ErrShutdownForced`. |
+| <a id="shutdown-timeout"></a>`shutdown_timeout` | `https://detent.dev/errors/shutdown_timeout` | 1 | `ErrShutdownTimeout`. |
+
 ## Release
 
 Cut releases from `main` by pushing a semver tag:

--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -177,6 +177,95 @@ func TestRunCLIWritesProblemJSONForUnknownFlag(t *testing.T) {
 	}
 }
 
+func TestRunCLIWritesProblemJSONForProjectNotFound(t *testing.T) {
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "WORKFLOW.md")
+	workdirPath := filepath.Join(root, "repo")
+	configPath := filepath.Join(root, "global.yaml")
+	if err := os.Mkdir(workdirPath, 0o755); err != nil {
+		t.Fatalf("Mkdir() error = %v", err)
+	}
+	if err := os.WriteFile(workflowPath, []byte("name: test\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile(workflow) error = %v", err)
+	}
+	config := fmt.Sprintf(`apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 1
+  scheduling: weighted
+projects:
+  - id: api
+    workflow: %s
+    workdir: %s
+    weight: 1
+    priority: 0
+  - id: web
+    workflow: %s
+    workdir: %s
+    weight: 1
+    priority: 0
+  - id: infra
+    workflow: %s
+    workdir: %s
+    weight: 1
+    priority: 0
+`, workflowPath, workdirPath, workflowPath, workdirPath, workflowPath, workdirPath)
+	if err := os.WriteFile(configPath, []byte(config), 0o644); err != nil {
+		t.Fatalf("WriteFile(config) error = %v", err)
+	}
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+
+	code := runCLI(context.Background(), []string{"--config", configPath, "--format", "json", "pause", "ap"}, &stdout, &stderr)
+	if code != cli.ExitNotFoundOrConfig {
+		t.Fatalf("exit code = %d, want %d\nstderr:\n%s", code, cli.ExitNotFoundOrConfig, stderr.String())
+	}
+	if stdout.Len() != 0 {
+		t.Fatalf("stdout = %q, want empty", stdout.String())
+	}
+
+	var got struct {
+		Type         string   `json:"type"`
+		Code         string   `json:"code"`
+		Title        string   `json:"title"`
+		Detail       string   `json:"detail"`
+		ExitCode     int      `json:"exit_code"`
+		SuggestedFix string   `json:"suggested_fix"`
+		DidYouMean   []string `json:"did_you_mean"`
+		DocsURL      string   `json:"docs_url"`
+	}
+	if err := json.Unmarshal(stderr.Bytes(), &got); err != nil {
+		t.Fatalf("stderr is not problem JSON: %v\n%s", err, stderr.String())
+	}
+	if got.Type != "https://detent.dev/errors/project_not_found" {
+		t.Fatalf("type = %q, want project_not_found", got.Type)
+	}
+	if got.Code != "project_not_found" {
+		t.Fatalf("code = %q, want project_not_found", got.Code)
+	}
+	if got.Title != "Project not found" {
+		t.Fatalf("title = %q, want Project not found", got.Title)
+	}
+	if got.Detail != `project "ap" not found` {
+		t.Fatalf("detail = %q, want project not found", got.Detail)
+	}
+	if got.ExitCode != code {
+		t.Fatalf("exit_code = %d, want %d", got.ExitCode, code)
+	}
+	for _, want := range []string{"available: api, web, infra", `did you mean "api"?`} {
+		if !strings.Contains(got.SuggestedFix, want) {
+			t.Fatalf("suggested_fix missing %q:\n%s", want, got.SuggestedFix)
+		}
+	}
+	if len(got.DidYouMean) != 1 || got.DidYouMean[0] != "api" {
+		t.Fatalf("did_you_mean = %#v, want api", got.DidYouMean)
+	}
+	if got.DocsURL != "https://detent.dev/docs/cli#project-not-found" {
+		t.Fatalf("docs_url = %q, want project-not-found docs", got.DocsURL)
+	}
+}
+
 func TestRunCLIPrettyUnknownCommandPrintsHint(t *testing.T) {
 	var stdout bytes.Buffer
 	var stderr bytes.Buffer

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -324,6 +324,14 @@ Output:
   DETENT_FORMAT can set the default format.
   When neither is set, Detent prints pretty output on a TTY and JSON otherwise.
 
+JSON errors:
+  JSON-mode failures write one problem object to stderr.
+  Fields: type, code, title, detail, exit_code, suggested_fix, did_you_mean, docs_url.
+  Optional fields: suggested_fix, did_you_mean, docs_url.
+  Stable codes: general, validation, unknown_command, unknown_flag, github_auth,
+  config_exists, project_exists, project_not_found, doctor_failed, shutdown_forced,
+  shutdown_timeout.
+
 Exit codes:
   0  success
   1  general or unexpected failure

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -1042,28 +1042,74 @@ func TestRootCommandClassifiesMistypedCommandSuggestion(t *testing.T) {
 	}
 }
 
-func TestProblemForErrorClassifiesSemanticFailures(t *testing.T) {
+func TestProblemForErrorBuildsStableEnvelope(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name string
-		err  error
-		want int
+		name      string
+		err       error
+		wantCode  string
+		wantTitle string
+		wantExit  int
 	}{
-		{name: "validation", err: cli.NewValidationError("--id is required", "Run detent add-project.", nil), want: cli.ExitValidation},
-		{name: "not found", err: fmt.Errorf("%w: api", cli.ErrProjectNotFound), want: cli.ExitNotFoundOrConfig},
-		{name: "auth", err: errors.New(`GITHUB_TOKEN is not set and github_token is not configured. Run gh auth login --scopes "repo,read:org,project" and set github_token: gh in global.yaml.`), want: cli.ExitAuth},
-		{name: "general", err: errors.New("disk is full"), want: cli.ExitGeneral},
+		{name: "general", err: errors.New("disk is full"), wantCode: "general", wantTitle: "Command failed", wantExit: cli.ExitGeneral},
+		{name: "validation", err: cli.NewValidationError("--id is required", "Run detent add-project.", nil), wantCode: "validation", wantTitle: "Validation failed", wantExit: cli.ExitValidation},
+		{name: "unknown command", err: errors.New(`unknown command "paues" for "detent"`), wantCode: "unknown_command", wantTitle: "Unknown command", wantExit: cli.ExitValidation},
+		{name: "unknown flag", err: errors.New("unknown flag: --hedless"), wantCode: "unknown_flag", wantTitle: "Unknown flag", wantExit: cli.ExitValidation},
+		{name: "auth", err: fmt.Errorf("wrapped: %w", cli.ErrGitHubAuth), wantCode: "github_auth", wantTitle: "GitHub authentication required", wantExit: cli.ExitAuth},
+		{name: "config exists", err: fmt.Errorf("%w: /tmp/global.yaml", cli.ErrConfigExists), wantCode: "config_exists", wantTitle: "Global config already exists", wantExit: cli.ExitNotFoundOrConfig},
+		{name: "project exists", err: fmt.Errorf("%w: api", cli.ErrProjectExists), wantCode: "project_exists", wantTitle: "Project already exists", wantExit: cli.ExitNotFoundOrConfig},
+		{name: "project not found", err: fmt.Errorf("%w: api", cli.ErrProjectNotFound), wantCode: "project_not_found", wantTitle: "Project not found", wantExit: cli.ExitNotFoundOrConfig},
+		{name: "doctor failed", err: cli.ErrDoctorFailed, wantCode: "doctor_failed", wantTitle: "Doctor checks failed", wantExit: cli.ExitGeneral},
+		{name: "shutdown forced", err: cli.ErrShutdownForced, wantCode: "shutdown_forced", wantTitle: "Shutdown forced", wantExit: cli.ExitGeneral},
+		{name: "shutdown timeout", err: cli.ErrShutdownTimeout, wantCode: "shutdown_timeout", wantTitle: "Shutdown timed out", wantExit: cli.ExitGeneral},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			if got := cli.ProblemForError(tt.err).ExitCode; got != tt.want {
-				t.Fatalf("ProblemForError().ExitCode = %d, want %d", got, tt.want)
+			got := cli.ProblemForError(tt.err)
+			if got.Code != tt.wantCode {
+				t.Fatalf("ProblemForError().Code = %q, want %q", got.Code, tt.wantCode)
+			}
+			if got.Type != "https://detent.dev/errors/"+tt.wantCode {
+				t.Fatalf("ProblemForError().Type = %q, want slug %q", got.Type, tt.wantCode)
+			}
+			if got.Title != tt.wantTitle {
+				t.Fatalf("ProblemForError().Title = %q, want %q", got.Title, tt.wantTitle)
+			}
+			if got.ExitCode != tt.wantExit {
+				t.Fatalf("ProblemForError().ExitCode = %d, want %d", got.ExitCode, tt.wantExit)
+			}
+			wantDocs := "https://detent.dev/docs/cli#" + strings.ReplaceAll(tt.wantCode, "_", "-")
+			if got.DocsURL != wantDocs {
+				t.Fatalf("ProblemForError().DocsURL = %q, want %q", got.DocsURL, wantDocs)
+			}
+			if strings.TrimSpace(got.Detail) == "" {
+				t.Fatal("ProblemForError().Detail is empty")
 			}
 		})
+	}
+}
+
+func TestProblemForErrorExtractsInlineDidYouMeanFromHint(t *testing.T) {
+	t.Parallel()
+
+	err := &cli.HintedError{
+		Err:     cli.ErrProjectNotFound,
+		Message: `project "ap" not found`,
+		Hint: "available: api, web, infra\n" +
+			"did you mean \"api\"? see `detent config path`, then retry",
+		Commands: []string{"detent config path"},
+	}
+
+	got := cli.ProblemForError(err)
+	if !reflect.DeepEqual(got.DidYouMean, []string{"api"}) {
+		t.Fatalf("ProblemForError().DidYouMean = %#v, want api", got.DidYouMean)
+	}
+	if got.SuggestedFix != err.Hint {
+		t.Fatalf("ProblemForError().SuggestedFix = %q, want %q", got.SuggestedFix, err.Hint)
 	}
 }
 

--- a/internal/cli/errors.go
+++ b/internal/cli/errors.go
@@ -19,7 +19,8 @@ const (
 	errorCodeProjectExists   = "project_exists"
 	errorCodeProjectNotFound = "project_not_found"
 	errorCodeDoctorFailed    = "doctor_failed"
-	errorCodeShutdown        = "shutdown"
+	errorCodeShutdownForced  = "shutdown_forced"
+	errorCodeShutdownTimeout = "shutdown_timeout"
 )
 
 type ClassifiedError struct {
@@ -87,18 +88,19 @@ func NewClassifiedError(err error, code string, detail string, hint string, didY
 }
 
 func ProblemForError(err error) Problem {
-	code := classifyErrorCode(err)
+	class := classifyError(err)
+	code := class.Slug
 	detail := ErrorDetail(err)
 	didYouMean := ErrorDidYouMean(err)
 	problem := Problem{
 		Type:         "https://detent.dev/errors/" + code,
 		Code:         code,
-		Title:        errorTitle(code),
+		Title:        class.Title,
 		Detail:       detail,
-		ExitCode:     problemExitCode(err, code),
+		ExitCode:     class.ExitCode,
 		SuggestedFix: ErrorHint(err),
 		DidYouMean:   didYouMean,
-		DocsURL:      "https://detent.dev/docs/cli#" + code,
+		DocsURL:      docsURLForErrorCode(code),
 	}
 	if problem.SuggestedFix == "" {
 		problem.SuggestedFix = defaultSuggestedFix(code, didYouMean)
@@ -122,19 +124,6 @@ func ProblemForCommandError(cmd *cobra.Command, err error) Problem {
 	problem.DidYouMean = suggestions
 	problem.SuggestedFix = defaultSuggestedFix(problem.Code, suggestions)
 	return problem
-}
-
-func problemExitCode(err error, code string) int {
-	switch code {
-	case errorCodeGitHubAuth:
-		return ExitAuth
-	case errorCodeValidation, errorCodeUnknownCommand, errorCodeUnknownFlag:
-		return ExitValidation
-	case errorCodeConfigExists, errorCodeProjectExists, errorCodeProjectNotFound:
-		return ExitNotFoundOrConfig
-	default:
-		return ExitCode(err)
-	}
 }
 
 func ErrorDetail(err error) string {
@@ -191,72 +180,6 @@ func WritePrettyError(out io.Writer, err error) error {
 	return nil
 }
 
-func classifyErrorCode(err error) string {
-	var classified *ClassifiedError
-	if errors.As(err, &classified) && classified.Code != "" {
-		return classified.Code
-	}
-	var hinted *HintedError
-	if errors.As(err, &hinted) && hinted.Err == nil {
-		return errorCodeValidation
-	}
-	switch {
-	case errors.Is(err, ErrGitHubAuth):
-		return errorCodeGitHubAuth
-	case errors.Is(err, ErrConfigExists):
-		return errorCodeConfigExists
-	case errors.Is(err, ErrProjectExists):
-		return errorCodeProjectExists
-	case errors.Is(err, ErrProjectNotFound):
-		return errorCodeProjectNotFound
-	case errors.Is(err, ErrDoctorFailed):
-		return errorCodeDoctorFailed
-	case errors.Is(err, ErrShutdownForced), errors.Is(err, ErrShutdownTimeout):
-		return errorCodeShutdown
-	}
-	text := ""
-	if err != nil {
-		text = err.Error()
-	}
-	switch {
-	case strings.Contains(text, "unknown command"):
-		return errorCodeUnknownCommand
-	case strings.Contains(text, "unknown flag"):
-		return errorCodeUnknownFlag
-	case strings.Contains(text, githubAuthHint), strings.Contains(text, "github_token"):
-		return errorCodeGitHubAuth
-	case errors.Is(err, ErrValidation), errors.Is(err, ErrInvalidOutputFormat):
-		return errorCodeValidation
-	default:
-		return errorCodeGeneral
-	}
-}
-
-func errorTitle(code string) string {
-	switch code {
-	case errorCodeValidation:
-		return "Validation failed"
-	case errorCodeUnknownCommand:
-		return "Unknown command"
-	case errorCodeUnknownFlag:
-		return "Unknown flag"
-	case errorCodeGitHubAuth:
-		return "GitHub authentication required"
-	case errorCodeConfigExists:
-		return "Global config already exists"
-	case errorCodeProjectExists:
-		return "Project already exists"
-	case errorCodeProjectNotFound:
-		return "Project not found"
-	case errorCodeDoctorFailed:
-		return "Doctor checks failed"
-	case errorCodeShutdown:
-		return "Shutdown failed"
-	default:
-		return "Command failed"
-	}
-}
-
 func defaultSuggestedFix(code string, didYouMean []string) string {
 	switch {
 	case code == errorCodeUnknownCommand && len(didYouMean) > 0:
@@ -278,11 +201,18 @@ func firstNonEmptyLine(text string) string {
 	return strings.TrimSpace(text)
 }
 
+func docsURLForErrorCode(code string) string {
+	return "https://detent.dev/docs/cli#" + strings.ReplaceAll(code, "_", "-")
+}
+
 func parseDidYouMean(text string) []string {
 	lines := strings.Split(text, "\n")
 	for index, line := range lines {
 		if !strings.Contains(strings.ToLower(line), "did you mean") {
 			continue
+		}
+		if suggestion := inlineDidYouMeanSuggestion(line); suggestion != "" {
+			return []string{suggestion}
 		}
 		var suggestions []string
 		for _, candidate := range lines[index+1:] {
@@ -294,20 +224,29 @@ func parseDidYouMean(text string) []string {
 		}
 		return compactStrings(suggestions)
 	}
-	if start := strings.Index(strings.ToLower(text), "did you mean "); start >= 0 {
-		candidate := strings.TrimSpace(text[start+len("did you mean "):])
-		if after, ok := strings.CutPrefix(candidate, "\""); ok {
-			candidate = after
-			if end := strings.Index(candidate, "\""); end >= 0 {
-				candidate = candidate[:end]
-			}
-		} else if fields := strings.Fields(candidate); len(fields) > 0 {
-			candidate = fields[0]
-		}
-		candidate = strings.Trim(candidate, "?`\"")
-		return compactStrings([]string{candidate})
-	}
 	return nil
+}
+
+func inlineDidYouMeanSuggestion(line string) string {
+	lower := strings.ToLower(line)
+	start := strings.Index(lower, "did you mean")
+	if start < 0 {
+		return ""
+	}
+	candidate := strings.TrimSpace(line[start+len("did you mean"):])
+	candidate = strings.TrimLeft(candidate, " :")
+	if candidate == "" || strings.HasPrefix(strings.ToLower(candidate), "this") {
+		return ""
+	}
+	if after, ok := strings.CutPrefix(candidate, "\""); ok {
+		if end := strings.Index(after, "\""); end >= 0 {
+			return strings.TrimSpace(after[:end])
+		}
+		candidate = after
+	} else if fields := strings.Fields(candidate); len(fields) > 0 {
+		candidate = fields[0]
+	}
+	return strings.Trim(candidate, "?`\"")
 }
 
 func unknownCommandName(detail string) string {

--- a/internal/cli/exitcode.go
+++ b/internal/cli/exitcode.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -31,38 +32,63 @@ type ErrorClass struct {
 	ExitCode int
 }
 
-var errorClassifiers = []struct {
-	class ErrorClass
+type errorClass struct {
+	ErrorClass
+	Title string
 	match func(error) bool
-}{
+}
+
+var (
+	successErrorClass = errorClass{ErrorClass: ErrorClass{Slug: "success", ExitCode: ExitSuccess}, Title: "Success"}
+	generalErrorClass = errorClass{ErrorClass: ErrorClass{Slug: errorCodeGeneral, ExitCode: ExitGeneral}, Title: "Command failed"}
+)
+
+var errorClassifiers = []errorClass{
 	{
-		class: ErrorClass{Slug: "github_auth", ExitCode: ExitAuth},
+		ErrorClass: ErrorClass{Slug: errorCodeUnknownCommand, ExitCode: ExitValidation},
+		Title:      "Unknown command",
+		match: func(err error) bool {
+			return errorTextContains(err, "unknown command")
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeUnknownFlag, ExitCode: ExitValidation},
+		Title:      "Unknown flag",
+		match: func(err error) bool {
+			return errorTextContains(err, "unknown flag")
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeGitHubAuth, ExitCode: ExitAuth},
+		Title:      "GitHub authentication required",
 		match: func(err error) bool {
 			return errors.Is(err, ErrGitHubAuth) ||
 				errors.Is(err, githubconnector.ErrMissingToken) ||
-				errors.Is(err, githubconnector.ErrAuthenticationFailed)
+				errors.Is(err, githubconnector.ErrAuthenticationFailed) ||
+				errorTextContains(err, githubAuthHint) ||
+				errorTextContains(err, "github_token")
 		},
 	},
 	{
-		class: ErrorClass{Slug: "validation", ExitCode: ExitValidation},
+		ErrorClass: ErrorClass{Slug: errorCodeConfigExists, ExitCode: ExitNotFoundOrConfig},
+		Title:      "Global config already exists",
 		match: func(err error) bool {
-			var globalValidation globalconfig.ValidationError
-			var globalParse globalconfig.ParseError
-			var workflowValidation workflowconfig.ValidationError
-			return errors.Is(err, ErrValidation) ||
-				errors.Is(err, ErrInvalidOutputFormat) ||
-				errors.As(err, &globalValidation) ||
-				errors.As(err, &globalParse) ||
-				errors.As(err, &workflowValidation)
+			return errors.Is(err, ErrConfigExists)
 		},
 	},
 	{
-		class: ErrorClass{Slug: "not_found_or_config", ExitCode: ExitNotFoundOrConfig},
+		ErrorClass: ErrorClass{Slug: errorCodeProjectExists, ExitCode: ExitNotFoundOrConfig},
+		Title:      "Project already exists",
 		match: func(err error) bool {
-			return errors.Is(err, ErrConfigExists) ||
-				errors.Is(err, ErrProjectExists) ||
-				errors.Is(err, ErrProjectNotFound) ||
-				errors.Is(err, project.ErrProjectExists) ||
+			return errors.Is(err, ErrProjectExists) ||
+				errors.Is(err, project.ErrProjectExists)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeProjectNotFound, ExitCode: ExitNotFoundOrConfig},
+		Title:      "Project not found",
+		match: func(err error) bool {
+			return errors.Is(err, ErrProjectNotFound) ||
 				errors.Is(err, project.ErrProjectNotFound) ||
 				errors.Is(err, githubconnector.ErrProjectNotFound) ||
 				errors.Is(err, githubconnector.ErrProjectItemNotFound) ||
@@ -72,22 +98,98 @@ var errorClassifiers = []struct {
 				errors.Is(err, githubconnector.ErrStatusOptionNotFound)
 		},
 	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeDoctorFailed, ExitCode: ExitGeneral},
+		Title:      "Doctor checks failed",
+		match: func(err error) bool {
+			return errors.Is(err, ErrDoctorFailed)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeShutdownForced, ExitCode: ExitGeneral},
+		Title:      "Shutdown forced",
+		match: func(err error) bool {
+			return errors.Is(err, ErrShutdownForced)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeShutdownTimeout, ExitCode: ExitGeneral},
+		Title:      "Shutdown timed out",
+		match: func(err error) bool {
+			return errors.Is(err, ErrShutdownTimeout)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeValidation, ExitCode: ExitValidation},
+		Title:      "Validation failed",
+		match: func(err error) bool {
+			var globalValidation globalconfig.ValidationError
+			var globalParse globalconfig.ParseError
+			var workflowValidation workflowconfig.ValidationError
+			var hinted *HintedError
+			return errors.Is(err, ErrValidation) ||
+				errors.Is(err, ErrInvalidOutputFormat) ||
+				(errors.As(err, &hinted) && hinted.Err == nil) ||
+				errors.As(err, &globalValidation) ||
+				errors.As(err, &globalParse) ||
+				errors.As(err, &workflowValidation)
+		},
+	},
 }
 
 func ClassifyError(err error) ErrorClass {
+	return classifyError(err).ErrorClass
+}
+
+func classifyError(err error) errorClass {
 	if err == nil || errors.Is(err, context.Canceled) {
-		return ErrorClass{Slug: "success", ExitCode: ExitSuccess}
+		return successErrorClass
 	}
-	for _, classifier := range errorClassifiers {
-		if classifier.match(err) {
-			return classifier.class
+
+	var classified *ClassifiedError
+	if errors.As(err, &classified) && classified.Code != "" {
+		if class, ok := errorClassForSlug(classified.Code); ok {
+			return class
+		}
+		exitCode := ExitGeneral
+		if classified.Err != nil {
+			exitCode = ClassifyError(classified.Err).ExitCode
+		}
+		return errorClass{
+			ErrorClass: ErrorClass{Slug: classified.Code, ExitCode: exitCode},
+			Title:      generalErrorClass.Title,
 		}
 	}
-	return ErrorClass{Slug: "general", ExitCode: ExitGeneral}
+
+	for _, classifier := range errorClassifiers {
+		if classifier.match(err) {
+			return classifier
+		}
+	}
+	return generalErrorClass
 }
 
 func ExitCode(err error) int {
 	return ClassifyError(err).ExitCode
+}
+
+func errorClassForSlug(slug string) (errorClass, bool) {
+	if slug == successErrorClass.Slug {
+		return successErrorClass, true
+	}
+	if slug == generalErrorClass.Slug {
+		return generalErrorClass, true
+	}
+	for _, class := range errorClassifiers {
+		if class.Slug == slug {
+			return class, true
+		}
+	}
+	return errorClass{}, false
+}
+
+func errorTextContains(err error, text string) bool {
+	return err != nil && text != "" && strings.Contains(err.Error(), text)
 }
 
 func NoArgs(cmd *cobra.Command, args []string) error {

--- a/internal/cli/exitcode.go
+++ b/internal/cli/exitcode.go
@@ -59,17 +59,6 @@ var errorClassifiers = []errorClass{
 		},
 	},
 	{
-		ErrorClass: ErrorClass{Slug: errorCodeGitHubAuth, ExitCode: ExitAuth},
-		Title:      "GitHub authentication required",
-		match: func(err error) bool {
-			return errors.Is(err, ErrGitHubAuth) ||
-				errors.Is(err, githubconnector.ErrMissingToken) ||
-				errors.Is(err, githubconnector.ErrAuthenticationFailed) ||
-				errorTextContains(err, githubAuthHint) ||
-				errorTextContains(err, "github_token")
-		},
-	},
-	{
 		ErrorClass: ErrorClass{Slug: errorCodeConfigExists, ExitCode: ExitNotFoundOrConfig},
 		Title:      "Global config already exists",
 		match: func(err error) bool {
@@ -133,6 +122,17 @@ var errorClassifiers = []errorClass{
 				errors.As(err, &globalValidation) ||
 				errors.As(err, &globalParse) ||
 				errors.As(err, &workflowValidation)
+		},
+	},
+	{
+		ErrorClass: ErrorClass{Slug: errorCodeGitHubAuth, ExitCode: ExitAuth},
+		Title:      "GitHub authentication required",
+		match: func(err error) bool {
+			return errors.Is(err, ErrGitHubAuth) ||
+				errors.Is(err, githubconnector.ErrMissingToken) ||
+				errors.Is(err, githubconnector.ErrAuthenticationFailed) ||
+				errorTextContains(err, githubAuthHint) ||
+				errorTextContains(err, "github_token")
 		},
 	},
 }

--- a/internal/cli/exitcode_test.go
+++ b/internal/cli/exitcode_test.go
@@ -32,6 +32,7 @@ func TestExitCodeClassifiesRepresentativeErrors(t *testing.T) {
 		{name: "validation", err: fmt.Errorf("wrapped: %w", cli.ErrValidation), want: cli.ExitValidation},
 		{name: "invalid output format", err: fmt.Errorf("wrapped: %w", cli.ErrInvalidOutputFormat), want: cli.ExitValidation},
 		{name: "global config validation", err: globalconfig.ValidationError{Problems: []string{"global bad"}}, want: cli.ExitValidation},
+		{name: "global config github token validation", err: globalconfig.ValidationError{Problems: []string{"github_token: must be a string"}}, want: cli.ExitValidation},
 		{name: "global config parse", err: globalconfig.ParseError{Path: "global.yaml", Err: errors.New("bad yaml")}, want: cli.ExitValidation},
 		{name: "workflow config validation", err: workflowconfig.ValidationError{Problems: []string{"workflow bad"}}, want: cli.ExitValidation},
 		{name: "cli project missing", err: fmt.Errorf("wrapped: %w", cli.ErrProjectNotFound), want: cli.ExitNotFoundOrConfig},


### PR DESCRIPTION
## Summary

- Centralize CLI error metadata so JSON-mode failures emit stable problem+json envelopes with per-class codes, titles, docs URLs, and matching exit codes.
- Preserve pretty-mode error text while populating suggested_fix and did_you_mean from existing hint and suggestion helpers.
- Document the envelope fields and stable error-code contract.

Fixes #407

## Test Plan

- [x] go test ./cmd/detent ./internal/cli
- [x] make check