### PR TITLE
fix(go): clear nilaway audit findings

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -71,6 +71,7 @@ make check
 - `make build`, which runs `make generate` before building `./tmp/detent`.
 - `golangci-lint run --timeout=5m` with golangci-lint v2.
 - `go vet ./...`.
+- `make nilaway-audit`.
 - `go test -race ./...`.
 - Coverage with a 70% minimum, excluding generated Templ output and sqlc output.
 

--- a/Makefile
+++ b/Makefile
@@ -93,7 +93,7 @@ vet:
 nilaway-audit:
 	$(NILAWAY) -include-pkgs=$(NILAWAY_INCLUDE_PKGS) ./...
 
-check: build lint vet test-race test-cover
+check: build lint vet nilaway-audit test-race test-cover
 	@echo "All checks passed."
 
 modernize-check:
@@ -139,7 +139,7 @@ help:
 	@echo "  test-race    Run Go tests with the race detector"
 	@echo "  test-cover   Run Go coverage with a $(COVERAGE_THRESHOLD)% minimum"
 	@echo "  lint         Run golangci-lint"
-	@echo "  check        Run the local validation gate"
+	@echo "  check        Run the local validation gate, including NilAway"
 	@echo "  modernize-check  Run the Go modernizer diff check"
 	@echo "  nilaway-audit  Run the local NilAway audit"
 	@echo "  release-snapshot  Build local GoReleaser snapshot archives"

--- a/README.md
+++ b/README.md
@@ -1227,8 +1227,8 @@ commit SHA and build date, rotates
 `tmp/air-combined.log`.
 
 `make check` runs the local release gate: build, `golangci-lint`, `go vet`,
-race tests, and the 70 percent coverage check. Run `make generate` before
-committing changes to Templ templates, sqlc queries, or Tailwind inputs.
+NilAway, race tests, and the 70 percent coverage check. Run `make generate`
+before committing changes to Templ templates, sqlc queries, or Tailwind inputs.
 `make modernize-check` runs the Go modernizer diff check with the repo's
 selected safe analyzer set.
 
@@ -1238,18 +1238,18 @@ race tests, and `make check` fail on unexpected goroutines. Add goleak ignores
 only in the package that needs them, and only after identifying the dependency
 or intentionally shared test goroutine.
 
-Nil safety is tracked separately with a local audit command:
+Nil safety is enforced by `make check` and can also be run directly while
+iterating:
 
 ```sh
 make nilaway-audit
 ```
 
-NilAway is not part of `make check` yet. The standalone audit currently reports
-first-party findings that need triage before it can become a CI gate, and its
-golangci-lint integration requires a custom module-plugin linter binary. Go
-1.26's experimental `runtime/pprof` `goroutineleak` profile remains a runtime
-audit aid behind `GOEXPERIMENT=goroutineleakprofile`; the stable CI coverage for
-now is the goleak-backed test gate.
+The project uses the standalone NilAway command instead of golangci-lint
+integration because the linter integration requires a custom module-plugin
+binary. Go 1.26's experimental `runtime/pprof` `goroutineleak` profile remains a
+runtime audit aid behind `GOEXPERIMENT=goroutineleakprofile`; the stable CI
+coverage for now is the goleak-backed test gate.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for the full contributor workflow.
 

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -176,6 +176,7 @@ func TestRegistryRefresherRequestsProjectOrchestrators(t *testing.T) {
 	refresher := refresherForRegistry(registry)
 	if refresher == nil {
 		t.Fatal("refresherForRegistry() = nil, want refresher")
+		return
 	}
 
 	response, err := refresher.RequestRefresh(context.Background())
@@ -444,6 +445,10 @@ func TestRegistryRefresherSkipsStoppedProjectOrchestrators(t *testing.T) {
 	mustSetProject(t, registry, newRefreshProject(t, "stopped"))
 
 	refresher := refresherForRegistry(registry)
+	if refresher == nil {
+		t.Fatal("refresherForRegistry() = nil, want refresher")
+		return
+	}
 	_, err := refresher.RequestRefresh(context.Background())
 	if !errors.Is(err, projectpkg.ErrProjectNotFound) {
 		t.Fatalf("RequestRefresh() error = %v, want %v", err, projectpkg.ErrProjectNotFound)
@@ -454,6 +459,10 @@ func TestRegistryRefresherReturnsProjectNotFoundWithoutOrchestrators(t *testing.
 	t.Parallel()
 
 	refresher := refresherForRegistry(projectpkg.NewRegistry())
+	if refresher == nil {
+		t.Fatal("refresherForRegistry() = nil, want refresher")
+		return
+	}
 	_, err := refresher.RequestRefresh(context.Background())
 	if !errors.Is(err, projectpkg.ErrProjectNotFound) {
 		t.Fatalf("RequestRefresh() error = %v, want %v", err, projectpkg.ErrProjectNotFound)

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -1015,7 +1015,7 @@ func levenshteinDistance(a string, b string) int {
 			if ra != rb {
 				cost = 1
 			}
-			current[j+1] = minInt(
+			current[j+1] = minInt3(
 				current[j]+1,
 				previous[j+1]+1,
 				previous[j]+cost,
@@ -1026,12 +1026,13 @@ func levenshteinDistance(a string, b string) int {
 	return previous[len(br)]
 }
 
-func minInt(values ...int) int {
-	min := values[0]
-	for _, value := range values[1:] {
-		if value < min {
-			min = value
-		}
+func minInt3(a int, b int, c int) int {
+	min := a
+	if b < min {
+		min = b
+	}
+	if c < min {
+		min = c
 	}
 	return min
 }

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -173,7 +173,10 @@ func WriterIsTTY(w io.Writer) bool {
 		return false
 	}
 	info, err := file.Stat()
-	return err == nil && info.Mode()&os.ModeCharDevice != 0
+	if err != nil || info == nil {
+		return false
+	}
+	return info.Mode()&os.ModeCharDevice != 0
 }
 
 func NewCommandCatalog(root *cobra.Command) CommandCatalog {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1763,6 +1763,10 @@ func TestConnectorVerifyStatusOptionsChecksMappedStatusOptions(t *testing.T) {
 	})
 
 	err := c.VerifyStatusOptions(context.Background(), []string{"Human Review", "Merging"})
+	if err == nil {
+		t.Fatal("VerifyStatusOptions() error = nil, want ErrStatusOptionNotFound")
+		return
+	}
 	if !errors.Is(err, ErrStatusOptionNotFound) {
 		t.Fatalf("VerifyStatusOptions() error = %v, want ErrStatusOptionNotFound", err)
 	}

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -311,7 +311,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 
 	for _, id := range result.Removed {
 		current, ok := m.registry.Get(id)
-		if !ok {
+		if !ok || current == nil {
 			return result, errors.Join(ErrProjectNotFound, rollback())
 		}
 		wasRunning := current.Running()
@@ -327,7 +327,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 	}
 	for _, id := range result.Changed {
 		current, ok := m.registry.Get(id)
-		if !ok {
+		if !ok || current == nil {
 			return result, errors.Join(ErrProjectNotFound, rollback())
 		}
 		wasRunning := current.Running()
@@ -337,7 +337,10 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 			}
 		}
 		stopped = append(stopped, rollbackProject{project: current, wasRunning: wasRunning})
-		preparedProject := prepared[id]
+		preparedProject, err := preparedProjectByID(prepared, id)
+		if err != nil {
+			return result, errors.Join(err, rollback())
+		}
 		didStart, err := m.startPreparedProjectLocked(ctx, preparedProject)
 		if err != nil {
 			return result, errors.Join(err, rollback())
@@ -350,7 +353,10 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		}
 	}
 	for _, id := range result.Added {
-		preparedProject := prepared[id]
+		preparedProject, err := preparedProjectByID(prepared, id)
+		if err != nil {
+			return result, errors.Join(err, rollback())
+		}
 		didStart, err := m.startPreparedProjectLocked(ctx, preparedProject)
 		if err != nil {
 			return result, errors.Join(err, rollback())
@@ -378,7 +384,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 
 func (m *Manager) removeLocked(ctx context.Context, id ID) error {
 	project, ok := m.registry.Get(id)
-	if !ok {
+	if !ok || project == nil {
 		return ErrProjectNotFound
 	}
 	if err := project.close(ctx, true); err != nil {
@@ -397,7 +403,7 @@ func (m *Manager) Pause(ctx context.Context, id ID) error {
 	defer m.mu.Unlock()
 
 	project, ok := m.registry.Get(id)
-	if !ok {
+	if !ok || project == nil {
 		return ErrProjectNotFound
 	}
 	return project.Pause(ctx)
@@ -412,7 +418,7 @@ func (m *Manager) Unpause(ctx context.Context, id ID) error {
 	defer m.mu.Unlock()
 
 	project, ok := m.registry.Get(id)
-	if !ok {
+	if !ok || project == nil {
 		return ErrProjectNotFound
 	}
 	if !project.Paused() {
@@ -457,10 +463,16 @@ func (m *Manager) createProjectLocked(cfg globalconfig.Project) (ID, *Project, e
 	if err != nil {
 		return "", nil, fmt.Errorf("create project %s: %w", id, err)
 	}
+	if project == nil {
+		return "", nil, ErrMissingProject
+	}
 	return id, project, nil
 }
 
 func (m *Manager) registerProjectLocked(ctx context.Context, id ID, project *Project) error {
+	if project == nil {
+		return ErrMissingProject
+	}
 	if err := m.registry.Set(project); err != nil {
 		return err
 	}
@@ -475,6 +487,9 @@ func (m *Manager) registerProjectLocked(ctx context.Context, id ID, project *Pro
 }
 
 func (m *Manager) startPreparedProjectLocked(ctx context.Context, project *Project) (bool, error) {
+	if project == nil {
+		return false, ErrMissingProject
+	}
 	if !m.running || project.Paused() {
 		return false, nil
 	}
@@ -489,6 +504,9 @@ func (m *Manager) startLocked(ctx context.Context, project *Project) error {
 }
 
 func (m *Manager) startProjectLocked(ctx context.Context, project *Project, publishEvents bool) error {
+	if project == nil {
+		return ErrMissingProject
+	}
 	if err := m.waitBeforeSpawn(ctx); err != nil {
 		return err
 	}
@@ -623,6 +641,9 @@ func maxConcurrentStarts(startup StartupConfig, projectCount int) int {
 func closeProjectSlice(ctx context.Context, projects []*Project) error {
 	var cleanupErr error
 	for _, project := range projects {
+		if project == nil {
+			continue
+		}
 		cleanupErr = errors.Join(cleanupErr, project.close(ctx, false))
 	}
 	return cleanupErr
@@ -631,6 +652,9 @@ func closeProjectSlice(ctx context.Context, projects []*Project) error {
 func closePreparedProjects(ctx context.Context, prepared map[ID]*Project) error {
 	var cleanupErr error
 	for _, project := range prepared {
+		if project == nil {
+			continue
+		}
 		cleanupErr = errors.Join(cleanupErr, project.close(ctx, false))
 	}
 	return cleanupErr
@@ -639,9 +663,20 @@ func closePreparedProjects(ctx context.Context, prepared map[ID]*Project) error 
 func closeStoppedProjects(ctx context.Context, stopped []rollbackProject) error {
 	var cleanupErr error
 	for _, item := range stopped {
+		if item.project == nil {
+			continue
+		}
 		cleanupErr = errors.Join(cleanupErr, item.project.close(ctx, false))
 	}
 	return cleanupErr
+}
+
+func preparedProjectByID(prepared map[ID]*Project, id ID) (*Project, error) {
+	project := prepared[id]
+	if project == nil {
+		return nil, ErrMissingProject
+	}
+	return project, nil
 }
 
 func (m *Manager) waitBeforeSpawn(ctx context.Context) error {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -77,6 +77,28 @@ func TestManagerStartsProjectsWithStartupLimits(t *testing.T) {
 	}
 }
 
+func TestManagerStartRejectsNilProjectFactoryResult(t *testing.T) {
+	t.Parallel()
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		ProjectFactory: func(globalconfig.Project) (*project.Project, error) {
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+
+	if err := manager.Start(context.Background()); !errors.Is(err, project.ErrMissingProject) {
+		t.Fatalf("Start() error = %v, want %v", err, project.ErrMissingProject)
+	}
+	if manager.Registry().Len() != 0 {
+		t.Fatalf("Registry().Len() = %d, want 0", manager.Registry().Len())
+	}
+}
+
 func TestManagerStartsProjectsWithBoundedConcurrency(t *testing.T) {
 	t.Parallel()
 
@@ -613,6 +635,52 @@ func TestManagerReconcileKeepsRegistryWhenNewProjectCannotBeCreated(t *testing.T
 	})
 }
 
+func TestManagerReconcileKeepsRegistryWhenNewProjectFactoryReturnsNil(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "bravo" {
+				return nil, nil
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+
+	_, err = manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	})
+	if !errors.Is(err, project.ErrMissingProject) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, project.ErrMissingProject)
+	}
+	assertNoProjectEvent(t, sub.C())
+	assertManagerProjectConfigs(t, manager, map[project.ID]globalconfig.Project{
+		"alpha": {ID: "alpha", Weight: 1},
+	})
+}
+
 func TestManagerReconcileKeepsChangedProjectWhenReplacementCannotBeCreated(t *testing.T) {
 	t.Parallel()
 
@@ -1011,6 +1079,11 @@ func TestManagerProjectsShareGlobalDispatchCap(t *testing.T) {
 		},
 	}, project.ManagerDependencies{
 		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			runner := runners[project.ID(cfg.ID)]
+			if runner == nil {
+				t.Fatalf("runner for project %q = nil, want runner", cfg.ID)
+				return nil, project.ErrMissingProject
+			}
 			workflowCfg := workflowConfigWithMemoryIssue("issue-" + cfg.ID)
 			workflowCfg.Agent.MaxConcurrentAgents = 2
 			workflowCfg.Tracker.Issues[0].State = "Todo"
@@ -1020,7 +1093,7 @@ func TestManagerProjectsShareGlobalDispatchCap(t *testing.T) {
 				Project:  cfg,
 				Workflow: workflowconfig.Workflow{Config: workflowCfg, Prompt: "Run test issue."},
 			}, project.Dependencies{
-				Runner:             runners[project.ID(cfg.ID)],
+				Runner:             runner,
 				GlobalDispatchGate: globalGate,
 			})
 		},
@@ -1046,12 +1119,23 @@ func TestManagerProjectsShareGlobalDispatchCap(t *testing.T) {
 		}
 	})
 
-	first := receiveFirstProjectRun(t, runners["alpha"].started, runners["bravo"].started)
+	alphaRunner := runners["alpha"]
+	if alphaRunner == nil {
+		t.Fatal("runner for project alpha = nil, want runner")
+		return
+	}
+	bravoRunner := runners["bravo"]
+	if bravoRunner == nil {
+		t.Fatal("runner for project bravo = nil, want runner")
+		return
+	}
+
+	first := receiveFirstProjectRun(t, alphaRunner.started, bravoRunner.started)
 	var blocked <-chan orchestrator.RunRequest
 	if first == "alpha" {
-		blocked = runners["bravo"].started
+		blocked = bravoRunner.started
 	} else {
-		blocked = runners["alpha"].started
+		blocked = alphaRunner.started
 	}
 	select {
 	case request := <-blocked:

--- a/internal/project/registry.go
+++ b/internal/project/registry.go
@@ -38,6 +38,9 @@ func (r *Registry) Get(id ID) (*Project, bool) {
 	defer r.mu.RUnlock()
 
 	project, ok := r.projects[normalizeProjectID(id)]
+	if project == nil {
+		return nil, false
+	}
 	return project, ok
 }
 


### PR DESCRIPTION
## Summary

- Harden project manager and registry nil boundaries found by NilAway.
- Clean up CLI and test-only NilAway assertion paths.
- Add NilAway to `make check` and update validation docs now that the audit is clean.

Fixes #451

## Test Plan

- [x] `go test ./internal/project ./internal/cli ./internal/connector/github`
- [x] `make nilaway-audit`
- [x] `make check`