### PR TITLE
docs(onboarding): add boardless GitHub setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,15 +50,17 @@ advance when a gate is cleared.
 
 ## What is this
 
-Detent is board-driven agentic work orchestration, shipped as a single Go
-binary, with code as its first proven domain. Today it watches a GitHub Projects
-board, and for every code issue you mark ready it creates an isolated Git
-worktree, dispatches a Codex coding agent against a workflow contract you wrote,
-runs your validation gate, opens a pull request, waits for review, and merges
-through a serialized train — with all of it live on a web dashboard and a
-terminal UI. The same board-to-gated-review-to-done shape is the trajectory for
-non-code work: validation gates are now pluggable, while non-git or non-PR
-deliverables remain follow-up work described in
+Detent is status-driven agentic work orchestration, shipped as a single Go
+binary, with code as its first proven domain. Today it can use a GitHub
+ProjectV2 board as the source of truth, or it can run boardless from a
+repository's GitHub issue `Status` field while Detent supplies the Kanban view.
+For every code issue you mark ready it creates an isolated Git worktree,
+dispatches a Codex coding agent against a workflow contract you wrote, runs
+your validation gate, opens a pull request, waits for review, and merges through
+a serialized train — with all of it live on a web dashboard and a terminal UI.
+The same status-to-gated-review-to-done shape is the trajectory for non-code
+work: validation gates are now pluggable, while non-git or non-PR deliverables
+remain follow-up work described in
 [Execution Seams](docs/execution-seams.md).
 
 It is a **system, not an agent.** You specify the work — the issues, acceptance
@@ -77,7 +79,8 @@ agent-executable [Project Onboarding](docs/ONBOARDING.md) runbook.
 
 ## How it works
 
-The board is the state machine; board status drives everything.
+Configured GitHub status is the state machine; ProjectV2 board status or the
+boardless issue field drives everything.
 
 1. **You write the contract.** Each project has a `WORKFLOW.md`: the tracker
    binding, board states, the agent prompt, the validation gate, and the review
@@ -232,11 +235,12 @@ Requirements:
 - The [OpenAI Codex CLI](https://github.com/openai/codex) installed and signed
   in, so `codex app-server` runs on the host that dispatches agents. Detent
   drives every agent through this app-server. Verify with `codex --version`.
-- The [GitHub CLI](https://cli.github.com) (`gh`) for authentication and board
+- The [GitHub CLI](https://cli.github.com) (`gh`) for authentication and GitHub
   lookups (optional but assumed throughout this guide).
-- A GitHub token with access to the target ProjectV2 board. For organization
-  projects, `repo`, `read:org`, `read:project`, and write `project` scopes are
-  usually required.
+- A GitHub token for the selected tracker mode. ProjectV2 mode usually needs
+  `repo`, `read:org`, `read:project`, and write `project`. Boardless
+  issue-field mode needs repository issue access plus organization issue-field
+  read access; classic PATs use `repo` and `read:org`.
 
 macOS and Linux hosts can install the latest release with the shell installer:
 
@@ -360,12 +364,15 @@ packaging tail.
 
 ## Quick Start
 
-The quickest production-shaped setup is one GitHub ProjectV2 board and one
-local repository checkout.
+The quickest compatibility setup is one GitHub ProjectV2 board and one local
+repository checkout. New projects can also run boardless: Detent reads and
+writes a repository's organization-level GitHub issue `Status` field and shows
+workflow visibility in Detent's own Kanban/dashboard surface.
 
-1. Authenticate GitHub access:
+1. Authenticate GitHub access for the mode you want:
 
 ```sh
+# ProjectV2-backed board mode.
 gh auth login --scopes "repo,read:org,read:project,project"
 # For existing auth:
 gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
@@ -374,10 +381,26 @@ gh auth status 2>&1 | rg '\brepo\b'
 gh auth status 2>&1 | rg '\bread:org\b'
 gh auth status 2>&1 | rg '\bread:project\b'
 gh auth status 2>&1 | rg "(^|[[:space:],'\"])project([[:space:],'\"]|$)"
+
+# Boardless issue-field mode with a classic PAT.
+gh auth login --scopes "repo,read:org"
+gh auth status 2>&1 | rg '\brepo\b'
+gh auth status 2>&1 | rg '\bread:org\b'
 ```
 
-2. Find the GitHub ProjectV2 node id. Use the `id` field, which starts with
-   `PVT_`, as `tracker.project_slug`:
+Fine-grained PATs and GitHub Apps should grant Issues repository read/write
+when Detent will move work or post comments, Pull requests read/checks read for
+PR gates, and Issue Fields organization read for boardless status discovery.
+Issue-field writes use the issue field values API and require issue or pull
+request repository write permission plus push access to the repository. If
+Kanban integration mode is enabled in a release that supports it, comment
+submission also requires issue/PR comment write.
+
+2. Choose the GitHub status source.
+
+For the current/default compatibility path, use a GitHub ProjectV2 board. Find
+the node id and use the `id` field, which starts with `PVT_`, as
+`tracker.project_slug`:
 
 ```sh
 gh project list --owner <org-or-user> --format json --limit 20
@@ -394,12 +417,24 @@ GitHub uses single-select option order as board column order; Detent keeps the
 known status options in canonical board order and leaves extra custom options
 after the required Detent states.
 
-3. Create a `WORKFLOW.md` in the repository you want Detent to work on:
+For boardless mode, create or reuse an organization-level single-select issue
+field named `Status` and make sure it is available to the repository. GitHub
+issue fields are issue-only: linked PR cards in Detent derive status from the
+linked issue, not from a PR field. Discover the field and options with:
+
+```sh
+gh api /orgs/<org>/issue-fields --jq '.[] | select(.name == "Status")'
+```
+
+3. Create a `WORKFLOW.md` in the repository you want Detent to work on.
+
+ProjectV2-backed board mode:
 
 ```markdown
 ---
 tracker:
   kind: github
+  github_status_source: project_v2
   project_slug: PVT_replace_with_project_id
   write_probe_issue: owner/repo#123
   http_max_idle_conns: 100
@@ -488,6 +523,56 @@ scoped to the issue, run the project validation gate, and prepare the work for
 human review.
 ```
 
+Boardless issue-field mode:
+
+```markdown
+---
+tracker:
+  kind: github
+  github_status_source: issue_field
+  repository: owner/repo
+  status_field: Status
+  write_probe_issue: owner/repo#123
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
+  terminal_states:
+    - Done
+    - Cancelled
+  state_map:
+    Cancelled: Done
+workspace:
+  root: /absolute/path/to/detent-workspaces
+  source_root: /absolute/path/to/project-checkout
+agent:
+  max_concurrent_agents_by_state:
+    Merging: 1
+gate:
+  kind: command
+  run: make check
+---
+You are working on {{ issue.identifier }}: {{ issue.title }}.
+```
+
+Kanban display is read-only by default. Keep that default for observers,
+shared dashboards, and initial rollout. In a Detent release that includes
+Kanban integration mode, enable integration only when operators are allowed to
+move cards and post issue or PR comments from Detent, and only after
+`detent doctor` proves issue-field status write and issue/PR comment write:
+
+```yaml
+server:
+  kanban:
+    mode: read_only
+    # mode: integration
+```
+
 `workspace.source_root` is the checked-out repository Detent uses for
 `git worktree add`; `workspace.root` is where per-issue worktrees are created.
 If `workspace.source_root` is omitted, Detent falls back to the project
@@ -563,16 +648,21 @@ port: 4000
    ```
 
 `detent doctor` is a preflight check: config resolution, the SQLite database,
-the `codex` binary, GitHub auth mode, GitHub ProjectV2 and repository
-readiness, git, and whether the server port is free. Before starting Detent, fix
-any `FAIL` (missing `github_token: gh` or an unauthenticated `codex` are the
-usual culprits). Configure `tracker.write_probe_issue` with a scratch issue on
-the project board when you want doctor to prove ProjectV2 and issue write
-capabilities instead of reporting WARN for unproven writes. If Detent is already
-running on the configured port, the server-port check can fail because the live
-service owns the port; use `detent doctor --port 0` for the same config,
-toolchain, token, and database preflight without the port collision, then verify
-the live service with `/health`.
+the `codex` binary, GitHub auth mode, GitHub tracker readiness, git, and
+whether the server port is free. In ProjectV2 mode it checks project access,
+Status options, board item reads, repository issue/PR access, write probes, and
+rate-limit visibility. In boardless mode it checks repository access, issue
+field discovery, Status option discovery, issue reads by field value, optional
+issue-field write probes, issue/PR comment write when integration-capable
+features are configured, and REST/GraphQL rate-limit visibility. Before
+starting Detent, fix any `FAIL` (missing `github_token: gh` or an
+unauthenticated `codex` are the usual culprits). Configure
+`tracker.write_probe_issue` with a scratch issue when you want doctor to prove
+write capabilities instead of reporting WARN for unproven writes. If Detent is
+already running on the configured port, the server-port check can fail because
+the live service owns the port; use `detent doctor --port 0` for the same
+config, toolchain, token, and database preflight without the port collision,
+then verify the live service with `/health`.
 
 For Detent dogfood/self-tests that need a running server, start an isolated mock
 runtime instead of stopping or reusing the live process on `127.0.0.1:4000`:
@@ -642,15 +732,20 @@ repo is a real, working instance of this setup to copy from.
    platform installer from [Install](#install). Verify: `detent version`.
 
 2. **Install and authenticate the GitHub CLI.** Install
-   [`gh`](https://cli.github.com), then:
+   [`gh`](https://cli.github.com), then choose scopes for the tracker mode:
 
    ```sh
+   # ProjectV2-backed board mode.
    gh auth login --scopes "repo,read:org,read:project,project"
    # For existing auth:
    gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
+
+   # Boardless issue-field mode.
+   gh auth login --scopes "repo,read:org"
    ```
 
-   Verify each required scope independently:
+   Verify the required classic PAT scopes independently. Boardless mode does
+   not require `read:project` or `project`.
 
    ```sh
    gh auth status 2>&1 | rg '\brepo\b'
@@ -666,8 +761,9 @@ repo is a real, working instance of this setup to copy from.
    [OpenAI Codex CLI](https://github.com/openai/codex) and sign in. Detent
    dispatches every agent through `codex app-server`. Verify: `codex --version`.
 
-4. **Choose the GitHub ProjectV2 board** Detent will drive and get its node id
-   (starts with `PVT_`):
+4. **Choose the GitHub status source.** For the current/default compatibility
+   path, choose the GitHub ProjectV2 board Detent will drive and get its node
+   id (starts with `PVT_`):
 
    ```sh
    gh project list --owner <org-or-user> --format json --limit 50
@@ -679,6 +775,13 @@ repo is a real, working instance of this setup to copy from.
    `Priority` options on first run. The option names must match your
    `WORKFLOW.md` states, and Detent keeps known `Status` options in canonical
    board order.
+
+   For boardless mode, skip ProjectV2 board creation and instead confirm the
+   repository's organization has a single-select issue field named `Status`:
+
+   ```sh
+   gh api /orgs/<org>/issue-fields --jq '.[] | select(.name == "Status")'
+   ```
 
 5. **Clone the repository you want Detent to work on** (its checkout becomes
    `workspace.source_root`):
@@ -697,7 +800,10 @@ repo is a real, working instance of this setup to copy from.
      -o <source-root>/WORKFLOW.md
    ```
 
-   Set `tracker.project_slug` (your `PVT_` id), `workspace.source_root`
+   For ProjectV2 mode, set `tracker.project_slug` (your `PVT_` id). For
+   boardless mode, set `tracker.github_status_source: issue_field`,
+   `tracker.repository: <repo-owner>/<repo-name>`, and optionally
+   `tracker.status_field`. In both modes, set `workspace.source_root`
    (`<source-root>`), `workspace.root` (a worktrees directory), and the prompt
    body. The full field reference is in [Quick Start](#quick-start).
 
@@ -765,19 +871,29 @@ repo is a real, working instance of this setup to copy from.
 ### Connectors
 
 Detent isolates tracker integration behind a connector interface. The current
-production connector is GitHub Projects. A memory connector is available for
-local development, and the connector boundary is where GitLab and Jira support
-will land later.
+production connector is GitHub. It supports the current ProjectV2-backed board
+mode and boardless issue-field mode. A memory connector is available for local
+development, and the connector boundary is where GitLab and Jira support will
+land later.
 
 GitHub configuration lives in each project's `WORKFLOW.md` frontmatter. The
-`project_slug` value is the GitHub ProjectV2 node id. Detent reads issue
-state, priority, labels, blockers, and assignment from the board, then writes
-comments and state transitions back through the connector.
+default `github_status_source: project_v2` mode uses `project_slug` as the
+GitHub ProjectV2 node id. Detent reads issue state, priority, labels, blockers,
+and assignment from the board, then writes comments and state transitions back
+through the connector. Boardless `github_status_source: issue_field` mode uses
+`repository: owner/name` and an organization issue field such as
+`status_field: Status`; Detent reads issues by issue-field value and updates
+that field for state transitions.
 Set `tracker.write_probe_issue` to a scratch issue already present on that
-ProjectV2 board if `detent doctor` should prove write operations by replaying
-existing values and sending non-mutating validation probes. Without a probe
-issue, doctor reports required write capabilities as WARN instead of inferring
-that broad token scopes are enough.
+ProjectV2 board or in the boardless repository if `detent doctor` should prove
+write operations by replaying existing values and sending non-mutating
+validation probes. Without a probe issue, doctor reports required write
+capabilities as WARN instead of inferring that broad token scopes are enough.
+
+GitHub issue fields apply to issues, not pull requests. Detent still displays
+linked PR state and can comment on PRs through GitHub's shared issue-comment
+endpoints, but boardless status comes from the linked issue. A PR-only card
+without a linked issue is not movable by an issue-field status update.
 
 The GitHub connector uses one pooled keep-alive HTTP client for GraphQL and
 GitHub App REST token requests. Tune `tracker.http_max_idle_conns`,
@@ -832,11 +948,11 @@ Codex/ChatGPT/Claude GitHub PR review. If automated PR review is required and
 the PR head changes after a review, request or wait for a fresh automated review
 before expecting auto-promotion.
 
-### Set up the board
+### Set up status
 
-You bring the board; Detent fills in the rest.
+You choose where GitHub status lives; Detent fills in the rest.
 
-- **You create** a GitHub **Projects v2** board (org or user) and point
+- **ProjectV2 mode:** create a GitHub **Projects v2** board (org or user) and point
   `tracker.project_slug` at its node id — the `PVT_…` id from
   `gh project list --owner <org-or-user> --format json`. The board has a default
   **`Status`** field; add a **`Priority`** single-select if you rank work.
@@ -849,12 +965,45 @@ You bring the board; Detent fills in the rest.
   status options are preserved after the configured Detent states. It provisions
   the options, not the board or the fields themselves, so create the board (and
   the `Priority` field if used) first.
+- **Boardless issue-field mode:** create or reuse an organization issue field,
+  normally a single-select `Status` field, and make it available to the
+  repository. Configure `tracker.github_status_source: issue_field`,
+  `tracker.repository: owner/name`, and optionally `tracker.status_field` when
+  the field is not named `Status`. Detent's Kanban/dashboard view becomes the
+  board surface; no GitHub ProjectV2 board or `tracker.project_slug` is needed.
 - **Blank `Status` values are not `Backlog`.** In the current release, an issue
-  with no Project `Status` value is not dispatchable through the board state
+  with no configured `Status` value is not dispatchable through the state
   machine. Put unready work in the `Backlog` option explicitly.
 - **Detent reads** status, priority, labels, blockers, assignees, and linked
   pull requests from each issue, and **writes back** status transitions and a
   `## Codex Workpad` comment as the agent works.
+
+### Kanban Modes
+
+Boardless projects use Detent's own dashboard as the day-to-day board. Keep
+Kanban in `read_only` mode by default: operators can inspect lanes, linked PRs,
+CI, review state, blockers, labels, and assignees without granting dashboard
+write access. Enable `integration` mode only in a release that supports it and
+only for trusted operators who should move cards and post comments from the
+dashboard. Integration mode needs the same GitHub write permissions that
+`detent doctor` probes: ProjectV2 status write in ProjectV2 mode, issue-field
+status write in boardless mode, and issue/PR comment write for comment forms.
+
+### Migration Notes
+
+Existing users do not need to migrate. Leaving
+`tracker.github_status_source` unset keeps ProjectV2 as the source of truth,
+and existing `tracker.project_slug` workflows remain valid. This is the
+compatibility path when the GitHub Project board is where humans already plan,
+rank, and move work.
+
+To switch a repository to boardless mode, create the organization issue
+`Status` field and options, copy current issue statuses from the ProjectV2 board
+manually or with a one-off script outside Detent, then change the workflow to
+`github_status_source: issue_field` with `repository: owner/name`. Detent does
+not automatically migrate ProjectV2 items to issue fields. After the switch,
+run `detent doctor --port 0` and fix field discovery, option discovery,
+write-probe, comment-write, and rate-limit checks before dispatching.
 
 ### Dependency workflows
 
@@ -871,16 +1020,17 @@ the wait should be visible on the board.
   your team wants dependency-waiting issues to sit in a waiting column. Detent
   only moves issues that have explicit `Depends on:` or `Blocked by:` references.
   When all blockers are terminal, closed, or have a merged linked PR under the
-  configured `readiness` rule, Detent updates the ProjectV2 `Status` to
-  `target_state` and posts an audit comment. Without
+  configured `readiness` rule, Detent updates the configured GitHub status
+  source to `target_state` and posts an audit comment. Without
   `tracker.dependency_auto_unblock.enabled: true`, a `Blocked` issue is observed
   for display but will not be moved back to `Todo`. Human blockers without
   explicit dependency references stay blocked.
 
 Before you dispatch anything, run **`detent doctor`** — it checks config
 resolution, the database, the `codex` binary, GitHub auth mode, configured
-ProjectV2 access, repository issue/PR access, required write proofs, git, and
-the server port. A clean pre-start `doctor` clears Detent's direct preflight.
+tracker access, repository issue/PR access, required write proofs, rate-limit
+visibility, git, and the server port. A clean pre-start `doctor` clears
+Detent's direct preflight.
 When a running Detent process already owns the configured port,
 `detent doctor --port 0` validates the config, database, tools, and token
 without treating the live listener as a blocker; pair it with `/health` on the

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -14,9 +14,12 @@ Use these placeholders consistently:
 | `<repo-name>` | GitHub repository name. |
 | `<source-root>` | Local checkout of `<repo-owner>/<repo-name>`. |
 | `<worktree-root>` | Directory where Detent will create issue worktrees. |
+| `<github-mode>` | `project_v2` for GitHub ProjectV2-backed status, or `issue_field` for boardless repository issue-field status. |
 | `<project-owner>` | GitHub org or user that owns the ProjectV2 board. |
 | `<project-number>` | ProjectV2 number shown by `gh project list`. |
 | `<project-node-id>` | ProjectV2 node id, starting with `PVT_`. |
+| `<status-field-name>` | Organization issue field Detent uses as status in boardless mode, usually `Status`. |
+| `<write-probe-issue>` | Scratch issue reference such as `<repo-owner>/<repo-name>#123` for doctor write probes. |
 | `<detent-project-id>` | Local `global.yaml` project id, such as `api`. |
 
 ## Start Here — Determine The Mode
@@ -98,18 +101,28 @@ rg -n 'id: <detent-project-id>|workflow: .*<repo-name>|workdir: .*<repo-name>' \
    detent --format pretty config path
    ```
 
-2. **Confirm GitHub CLI auth and scopes.** Detent needs a token that can read
-   the repo, org, and ProjectV2 board, plus write ProjectV2 status fields. For
-   first-time auth, request every required scope:
+2. **Confirm GitHub CLI auth and scopes.** Detent needs GitHub auth for the
+   selected tracker mode. ProjectV2 mode needs repository, organization, and
+   ProjectV2 read/write scopes. Boardless issue-field mode needs repository
+   issue access plus organization issue-field read access; classic PATs use
+   `repo` and `read:org`.
+
+   For ProjectV2 mode, request:
 
    ```sh
    gh auth login --scopes "repo,read:org,read:project,project"
    ```
 
-   If any scope check fails for existing auth, refresh the token:
+   If any ProjectV2 scope check fails for existing auth, refresh the token:
 
    ```sh
    gh auth refresh -h github.com --scopes "repo,read:org,read:project,project"
+   ```
+
+   For boardless issue-field mode with a classic PAT, request:
+
+   ```sh
+   gh auth login --scopes "repo,read:org"
    ```
 
    In a remote or headless shell, avoid launching a remote GUI browser while
@@ -128,15 +141,23 @@ rg -n 'id: <detent-project-id>|workflow: .*<repo-name>|workdir: .*<repo-name>' \
    gh auth status
    gh auth status 2>&1 | rg '\brepo\b'
    gh auth status 2>&1 | rg '\bread:org\b'
+   # ProjectV2 mode only:
    gh auth status 2>&1 | rg '\bread:project\b'
    gh auth status 2>&1 | rg "(^|[[:space:],'\"])project([[:space:],'\"]|$)"
+   # ProjectV2 mode only:
    gh project list --owner <project-owner> --format json --limit 1
+   # Boardless mode:
+   gh api /orgs/<repo-owner>/issue-fields --jq '.[] | select(.name == "<status-field-name>")'
    ```
 
    `gh project list` verifies the `read:project` board discovery path. Defer
    write `project` verification until the first intentional ProjectV2 mutation,
    such as creating or linking a board, creating fields, or editing the status
-   of a real existing item.
+   of a real existing item. The issue-field discovery command verifies
+   organization issue-field read access for boardless mode. Fine-grained PATs
+   and GitHub Apps should grant Issue Fields organization read, Issues
+   repository read/write when status moves or comments are enabled, Pull
+   requests read/checks read for PR gates, and selected repository access.
 
 3. **Confirm Codex is installed and signed in.** Detent dispatches agents
    through the Codex app-server. Verify:
@@ -163,6 +184,11 @@ ProjectV2 is GraphQL-backed, so `gh project list`, `field-list`, `item-list`,
 as Detent's GitHub connector. When `github_token: gh` is configured, the
 operator shell, Detent, and spawned Codex agents all use the same `gh` user
 token and therefore the same user-token GraphQL bucket.
+
+Boardless issue-field mode uses REST for field discovery and issue-field value
+writes. GitHub still reports REST and GraphQL budgets separately, and
+`detent doctor` surfaces both so operators can see whether boardless work is
+healthy without spending ProjectV2 GraphQL inventory budget.
 
 GitHub's documented primary GraphQL limit for user-backed tokens is 5,000
 points per hour. GitHub App installation tokens receive their own
@@ -411,11 +437,28 @@ recommendation, and default-if-silent. Record answers in
    rg '^DETENT_ONBOARDING_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-1. **Board.** Ask: "Reuse an existing ProjectV2 board or create a new one?"
-   List the boards from `$ONBOARDING_DIR/projects.json`.
-   Recommendation source: matching board title, owner, item count, and whether
-   the board already has repo work. Default if silent: reuse the strongest
-   matching board; if none match, create `<repo-name>`. Verify:
+1. **GitHub status source.** Ask: "Use the current/default ProjectV2 board mode
+   or boardless issue-field mode?" Recommend ProjectV2 when the team already
+   plans and ranks work on a GitHub Project board, or when preserving an
+   existing Detent setup is more important than reducing setup. Recommend
+   boardless issue-field mode when the repository already uses GitHub Issues as
+   the source of truth and the Detent dashboard should be the Kanban surface.
+   Default if silent: ProjectV2 for existing Detent installs, boardless for a
+   new project with no matching board. Verify:
+
+   ```sh
+   printf '%s\n' \
+     'GITHUB_MODE=<project_v2|issue_field>' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^GITHUB_MODE=' "$ONBOARDING_DIR/answers.env"
+   ```
+
+2. **ProjectV2 board.** Ask this only when `GITHUB_MODE=project_v2`: "Reuse an
+   existing ProjectV2 board or create a new one?" List the boards from
+   `$ONBOARDING_DIR/projects.json`. Recommendation source: matching board title,
+   owner, item count, and whether the board already has repo work. Default if
+   silent: reuse the strongest matching board; if none match, create
+   `<repo-name>`. Verify:
 
    ```sh
    printf '%s\n' \
@@ -427,7 +470,37 @@ recommendation, and default-if-silent. Record answers in
    rg '^BOARD_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-2. **Scheduling.** Ask: "What `global.yaml` `priority` from 1-4 and `weight`
+3. **Boardless issue field.** Ask this only when `GITHUB_MODE=issue_field`:
+   "Which organization issue field should Detent use for status?" Recommend
+   `Status` unless inspection found a different single-select workflow field.
+   Confirm that GitHub issue fields are issue-only: linked PR cards derive
+   status from the linked issue, and PR-only cards cannot be moved by
+   issue-field status writes. Verify:
+
+   ```sh
+   printf '%s\n' \
+     'STATUS_FIELD_NAME=<status-field-name>' \
+     >> "$ONBOARDING_DIR/answers.env"
+   gh api /orgs/<repo-owner>/issue-fields \
+     --jq '.[] | select(.name == "<status-field-name>") | {name,data_type,options}'
+   rg '^STATUS_FIELD_NAME=' "$ONBOARDING_DIR/answers.env"
+   ```
+
+4. **Kanban interaction.** Ask: "Should Detent's Kanban be read-only or allow
+   GitHub mutations from the dashboard?" Recommend `read_only`. Use
+   `integration` only in a Detent release that supports it and only when trusted
+   operators should move cards and post issue or PR comments from Detent.
+   Integration mode requires doctor to prove ProjectV2 status write or
+   issue-field status write, plus issue/PR comment write. Verify:
+
+   ```sh
+   printf '%s\n' \
+     'KANBAN_MODE=<read_only|integration>' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^KANBAN_MODE=' "$ONBOARDING_DIR/answers.env"
+   ```
+
+5. **Scheduling.** Ask: "What `global.yaml` `priority` from 1-4 and `weight`
    should this project receive?" Show `$ONBOARDING_DIR/global-projects.txt`.
    Disambiguate this from the board `Priority` field: `global.yaml` `priority`
    ranks projects on the host; the board `Priority` field ranks issues inside
@@ -443,7 +516,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^GLOBAL_(PRIORITY|WEIGHT)=' "$ONBOARDING_DIR/answers.env"
    ```
 
-3. **Dispatch label ordering.** Ask: "When two issues have the same board
+6. **Dispatch label ordering.** Ask: "When two issues have the same board
    `Priority`, should labels break the tie before age?" Show the label counts
    from `$ONBOARDING_DIR/issue-counts.json` and recommend an ordered list from
    labels that represent work type or risk, such as `bug`, `regression`, then
@@ -458,7 +531,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^DISPATCH_PRIORITY_BY_LABEL=' "$ONBOARDING_DIR/answers.env"
    ```
 
-4. **Instance name.** Ask: "What optional instance name should appear in
+7. **Instance name.** Ask: "What optional instance name should appear in
    Detent browser tabs and the navbar?" Recommendation source: the short
    hostname, existing `global.identity.name`, and any operator naming
    convention for this host. Default if silent: the short hostname. Verify:
@@ -471,7 +544,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^INSTANCE_NAME=' "$ONBOARDING_DIR/answers.env"
    ```
 
-5. **Authorization filters.** Ask: "Should Detent consider all board items or
+8. **Authorization filters.** Ask: "Should Detent consider all board items or
    only items matching a filter?" Offer `none`, `labels.include`,
    `labels.exclude`, `assignee_in`, `author_in`, and `priority_in`.
    Recommendation source: live counts in `$ONBOARDING_DIR/issue-counts.json`
@@ -490,7 +563,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^AUTHORIZATION_' "$ONBOARDING_DIR/answers.env"
    ```
 
-6. **Dashboard bind.** Ask: "How should the Detent dashboard bind:
+9. **Dashboard bind.** Ask: "How should the Detent dashboard bind:
    localhost-only, a private/Tailscale IP, or all interfaces?" Recommendation
    source: the operator's access path, whether SSH tunnels or VPN/Tailscale are
    expected, the host firewall, and any known private interface addresses.
@@ -507,7 +580,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^DASHBOARD_' "$ONBOARDING_DIR/answers.env"
    ```
 
-7. **Validation gate.** Ask: "Use the detected command, a custom command, or a
+10. **Validation gate.** Ask: "Use the detected command, a custom command, or a
    human review label gate? If this is a command gate, should auto-promotion
    require an automated GitHub PR review from a bot?" Recommendation source:
    `$ONBOARDING_DIR/gate.txt`, detected manifests, task runners, CI workflow
@@ -527,7 +600,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^GATE_' "$ONBOARDING_DIR/answers.env"
    ```
 
-8. **Concurrency.** Ask: "How many agents may this project run at once?"
+11. **Concurrency.** Ask: "How many agents may this project run at once?"
    Recommendation source: host capacity, existing `global.yaml` projects, and
    the repo's gate cost. Default if silent: `agent.max_concurrent_agents: 5`
    for an active code repo, lower for expensive gates. State that
@@ -555,7 +628,7 @@ recommendation, and default-if-silent. Record answers in
    repository. For multiple instances sharing one board/repo, serialization
    comes from `tracker.claims`, not the per-state cap.
 
-9. **Review policy.** Ask: "Should Detent hard-stop at `Human Review`, or may
+12. **Review policy.** Ask: "Should Detent hard-stop at `Human Review`, or may
    it auto-promote to `Merging` after the human-defined criteria are true?"
    Recommendation source: repo risk, issue labels, review requirements, and how
    much trust the human wants to delegate. Default if silent:
@@ -583,7 +656,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^AUTO_PROMOTE_' "$ONBOARDING_DIR/answers.env"
    ```
 
-10. **Dependency waiting policy.** Ask: "Should dependency-waiting issues stay
+13. **Dependency waiting policy.** Ask: "Should dependency-waiting issues stay
    in `Todo` and be gated by Detent, or should they sit in `Blocked` and be
    auto-unblocked when dependencies clear?" Default if silent:
    `tracker.dependency_auto_unblock.enabled: false`. Use the `Blocked`
@@ -603,7 +676,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^DEPENDENCY_AUTO_UNBLOCK_' "$ONBOARDING_DIR/answers.env"
    ```
 
-11. **Prompt body.** Ask: "Use the template prompt or add repo-specific
+14. **Prompt body.** Ask: "Use the template prompt or add repo-specific
    instructions?" Recommendation source: `CLAUDE.md`, `AGENTS.md`,
    `CONTRIBUTING.md`, README development commands, manifests, and CI workflows
    in `<source-root>`. Default if silent: template prompt plus any repo
@@ -629,7 +702,7 @@ recommendation, and default-if-silent. Record answers in
    rg '^PROMPT_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-12. **Issue intake.** Ask: "Which issue filter should be bulk-added, should the
+15. **Issue intake.** Ask: "Which issue filter should be bulk-added, should the
    initial `Status` be `Backlog` or `Todo`, and should the human enable the
    auto-add workflow?" Recommendation source: `$ONBOARDING_DIR/issue-counts.json`
    and the authorization answer. Default if silent: bulk-add the narrowest safe
@@ -645,10 +718,14 @@ recommendation, and default-if-silent. Record answers in
    rg '^(INTAKE_GH_FLAGS|INITIAL_STATUS|ENABLE_AUTO_ADD)=' "$ONBOARDING_DIR/answers.env"
    ```
 
-## Phase 3 — Create Or Adopt The Board
+## Phase 3 — Create Or Adopt The Status Source
+
+Run the ProjectV2 steps only when `GITHUB_MODE=project_v2`. When
+`GITHUB_MODE=issue_field`, skip board creation/linking and run the boardless
+issue-field verification step instead.
 
 1. **Adopt an existing board when the answer says reuse.** Record the number
-   and node id for later commands. Verify:
+   and node id for later commands. Skip when `GITHUB_MODE=issue_field`. Verify:
 
    ```sh
    gh project view <project-number> --owner <project-owner> --format json \
@@ -656,8 +733,9 @@ recommendation, and default-if-silent. Record answers in
    jq -e '.id | startswith("PVT_")' "$ONBOARDING_DIR/project.json"
    ```
 
-2. **Create a board when the answer says create.** GitHub creates the default
-   `Status` field; Detent still needs you to create the board itself. Verify:
+2. **Create a board when the answer says create.** Skip when
+   `GITHUB_MODE=issue_field`. GitHub creates the default `Status` field; Detent
+   still needs you to create the board itself. Verify:
 
    ```sh
    gh project create --owner <project-owner> --title "<project-title>" --format json \
@@ -665,11 +743,11 @@ recommendation, and default-if-silent. Record answers in
    jq -e '.number and (.id | startswith("PVT_"))' "$ONBOARDING_DIR/project.json"
    ```
 
-3. **Ensure the `Priority` field exists.** Detent can add missing options
-   inside an existing field, but it never creates the field. Reused boards can
-   already have this field, so check before creating it. If `Priority` exists
-   but is not a single-select field, stop and ask the human to rename the
-   conflicting field or choose another board. Verify:
+3. **Ensure the `Priority` field exists.** Skip when `GITHUB_MODE=issue_field`.
+   Detent can add missing options inside an existing field, but it never
+   creates the field. Reused boards can already have this field, so check before
+   creating it. If `Priority` exists but is not a single-select field, stop and
+   ask the human to rename the conflicting field or choose another board. Verify:
 
    ```sh
    PROJECT_NUMBER="$(jq -r '.number' "$ONBOARDING_DIR/project.json")"
@@ -692,25 +770,26 @@ recommendation, and default-if-silent. Record answers in
      | jq -e '.fields[] | select(.name == "Priority" and (.options | type == "array"))'
    ```
 
-4. **Link the repository to the board.** This keeps the project discoverable
-   from the repo. Verify:
+4. **Link the repository to the board.** Skip when `GITHUB_MODE=issue_field`.
+   This keeps the project discoverable from the repo. Verify:
 
    ```sh
    gh project link "$PROJECT_NUMBER" --owner <project-owner> --repo <repo-name>
    gh project view "$PROJECT_NUMBER" --owner <project-owner> --format json --jq '.url'
    ```
 
-5. **Confirm required fields.** Detent auto-provisions missing `Status` and
-   `Priority` options on first run, but never the board or fields themselves.
-   Verify:
+5. **Confirm required ProjectV2 fields.** Skip when `GITHUB_MODE=issue_field`.
+   Detent auto-provisions missing `Status` and `Priority` options on first run,
+   but never the board or fields themselves. Verify:
 
    ```sh
    gh project field-list "$PROJECT_NUMBER" --owner <project-owner> --format json \
      | jq -e '[.fields[].name] as $names | all(["Status","Priority"][]; . as $want | $names | index($want))'
    ```
 
-6. **Clean up inherited statuses before first Detent dispatch.** Reused boards
-   often carry status options and stale item placements from a predecessor
+6. **Clean up inherited ProjectV2 statuses before first Detent dispatch.** Skip
+   when `GITHUB_MODE=issue_field`. Reused boards often carry status options and
+   stale item placements from a predecessor
    orchestrator. Inventory the board before the first Detent start so the
    operator can distinguish intentional custom lanes from old active or
    terminal columns. Verify:
@@ -820,6 +899,33 @@ recommendation, and default-if-silent. Record answers in
    done
    ```
 
+7. **Verify the boardless issue field when selected.** Run this only when
+   `GITHUB_MODE=issue_field`. Detent needs an organization-level single-select
+   issue field and options matching the configured workflow states. Issue
+   fields are issue-only, so linked PR cards will use their linked issue's
+   status. Verify:
+
+   ```sh
+   STATUS_FIELD_NAME="<status-field-name>"
+   gh api /orgs/<repo-owner>/issue-fields > "$ONBOARDING_DIR/issue-fields.json"
+   jq --arg name "$STATUS_FIELD_NAME" -e '.[] | select(.name == $name)' \
+     "$ONBOARDING_DIR/issue-fields.json" > "$ONBOARDING_DIR/issue-field.json"
+   jq -e '.data_type == "single_select"' "$ONBOARDING_DIR/issue-field.json"
+   jq -r '.options[].name' "$ONBOARDING_DIR/issue-field.json" \
+     > "$ONBOARDING_DIR/issue-field-status-options.txt"
+   printf '%s\n' \
+     Backlog Todo 'In Progress' Blocked 'Human Review' Rework Merging Done Cancelled \
+     > "$ONBOARDING_DIR/detent-status-options.txt"
+   sort "$ONBOARDING_DIR/detent-status-options.txt" > "$ONBOARDING_DIR/detent-status-options.sorted.txt"
+   sort "$ONBOARDING_DIR/issue-field-status-options.txt" > "$ONBOARDING_DIR/issue-field-status-options.sorted.txt"
+   comm -23 "$ONBOARDING_DIR/detent-status-options.sorted.txt" "$ONBOARDING_DIR/issue-field-status-options.sorted.txt"
+   ```
+
+   If the `comm` output is not empty, add the missing issue-field options in
+   GitHub before starting Detent, or change the workflow states to match the
+   existing options. Do not create or link a GitHub ProjectV2 board for this
+   mode.
+
 ## Phase 4 — Author WORKFLOW.md
 
 1. **Fetch the canonical template.** Read the existing file first if one is
@@ -833,20 +939,65 @@ recommendation, and default-if-silent. Record answers in
    rg -n '^tracker:|^workspace:|^agent:' <source-root>/WORKFLOW.md
    ```
 
-2. **Substitute the board and workspace answers.** Use the ProjectV2 node id as
-   `tracker.project_slug`; use absolute paths for `workspace.source_root` and
-   `workspace.root`. Verify:
+2. **Substitute the tracker and workspace answers.** In ProjectV2 mode, use the
+   ProjectV2 node id as `tracker.project_slug`. In boardless mode, remove
+   `project_slug` and configure the repository issue field. In both modes, use
+   absolute paths for `workspace.source_root` and `workspace.root`. Verify the
+   selected tracker block:
 
-   ```sh
-   PROJECT_NODE_ID="$(jq -r '.id' "$ONBOARDING_DIR/project.json")"
-   perl -0pi -e "s/project_slug: \"?PVT_[^\"\\n]+\"?/project_slug: \"$PROJECT_NODE_ID\"/" <source-root>/WORKFLOW.md
-   perl -0pi -e 's#(?m)^  source_root: .*$#  source_root: <source-root>#' <source-root>/WORKFLOW.md
-   perl -0pi -e 's#(?m)^  root: .*$#  root: <worktree-root>#' <source-root>/WORKFLOW.md
-   rg -n "project_slug: \"$PROJECT_NODE_ID\"|source_root: <source-root>|root: <worktree-root>" \
-     <source-root>/WORKFLOW.md
+   ProjectV2 tracker snippet:
+
+   ```yaml
+   tracker:
+     kind: github
+     github_status_source: project_v2
+     project_slug: <project-node-id>
+     write_probe_issue: <write-probe-issue>
    ```
 
-3. **Set the dashboard bind from the interview.** This writes the default
+   Boardless issue-field tracker snippet:
+
+   ```yaml
+   tracker:
+     kind: github
+     github_status_source: issue_field
+     repository: <repo-owner>/<repo-name>
+     status_field: <status-field-name>
+     write_probe_issue: <write-probe-issue>
+   ```
+
+   ```sh
+   # ProjectV2 mode:
+   PROJECT_NODE_ID="$(jq -r '.id' "$ONBOARDING_DIR/project.json")"
+   rg -n 'github_status_source: project_v2|project_slug: <project-node-id>|write_probe_issue:' <source-root>/WORKFLOW.md
+
+   # Boardless mode:
+   rg -n 'github_status_source: issue_field|repository: <repo-owner>/<repo-name>|status_field: <status-field-name>|write_probe_issue:' <source-root>/WORKFLOW.md
+
+   # Both modes:
+   perl -0pi -e 's#(?m)^  source_root: .*$#  source_root: <source-root>#' <source-root>/WORKFLOW.md
+   perl -0pi -e 's#(?m)^  root: .*$#  root: <worktree-root>#' <source-root>/WORKFLOW.md
+   rg -n 'source_root: <source-root>|root: <worktree-root>' <source-root>/WORKFLOW.md
+   ```
+
+3. **Set Kanban interaction mode when supported.** Do not add this block to
+   current releases unless the Detent binary supports Kanban interaction
+   configuration. When supported, keep `read_only` as the default and enable
+   `integration` only for trusted operators after doctor proves status write and
+   issue/PR comment write. Verify:
+
+   ```yaml
+   server:
+     kanban:
+       mode: read_only
+       # mode: integration
+   ```
+
+   ```sh
+   rg -n 'kanban:|mode: read_only|mode: integration' <source-root>/WORKFLOW.md || true
+   ```
+
+4. **Set the dashboard bind from the interview.** This writes the default
    `server.host` used when Detent starts without an explicit `--host`. Service
    managers can still override it in `ExecStart` with the same selected host.
    Verify:
@@ -856,7 +1007,7 @@ recommendation, and default-if-silent. Record answers in
    rg -n '^server:|host: <dashboard-host>|port:' <source-root>/WORKFLOW.md
    ```
 
-4. **Set the gate from the interview.** For command gates, include the command
+5. **Set the gate from the interview.** For command gates, include the command
    and whether an automated GitHub PR review is required for auto-promotion.
    For human gates, include the approval label. Verify:
 
@@ -882,7 +1033,7 @@ recommendation, and default-if-silent. Record answers in
      approval_label: <approval-label>
    ```
 
-5. **Set dispatch ordering, review policy, dependency waiting policy, and
+6. **Set dispatch ordering, review policy, dependency waiting policy, and
    concurrency.** Keep `Merging: 1`. Use the dispatch label ordering, review
    policy, and dependency policy selected by the human. Verify:
 
@@ -958,7 +1109,7 @@ recommendation, and default-if-silent. Record answers in
    `Blocked` is an observed/display state and dependency completion will not
    move issues back to `Todo`.
 
-6. **Write the prompt body.** Keep the `## Codex Workpad` instruction, include
+7. **Write the prompt body.** Keep the `## Codex Workpad` instruction, include
    repo authority files discovered in Phase 2, and state the validation gate.
    Verify:
 
@@ -967,7 +1118,7 @@ recommendation, and default-if-silent. Record answers in
      | rg 'Codex Workpad|CLAUDE.md|AGENTS.md|CONTRIBUTING.md|<gate-command>|<repo-owner>/<repo-name>'
    ```
 
-7. **Check the workflow contract before registration.** This is a structural
+8. **Check the workflow contract before registration.** This is a structural
    check; `detent doctor` in Phase 5 is the full preflight. Verify:
 
    ```sh
@@ -1024,10 +1175,12 @@ recommendation, and default-if-silent. Record answers in
 
 3. **Set or preserve runtime keys in `global.yaml`.** For local onboarding,
    prefer `github_token: gh` so Detent resolves the token from `gh auth token`
-   at startup. This shares the operator's GraphQL budget with Detent and spawned
-   agents; for production or high-volume boards, prefer GitHub App installation
-   authentication in `WORKFLOW.md`. Set `instance_name` to the interview answer
-   or the short hostname on new installs. For existing installs, preserve
+   at startup. In ProjectV2 mode this shares the operator's GraphQL budget with
+   Detent and spawned agents; in boardless mode it still shares REST issue-field
+   and comment write limits. For production or high-volume projects, prefer
+   GitHub App installation authentication in `WORKFLOW.md`. Set `instance_name`
+   to the interview answer or the short hostname on new installs. For existing
+   installs, preserve
    `env`, `log_level`, `github_token`, `port`, and `instance_name` unless the
    human selected different values. Use a non-4000 port if another Detent
    instance is already running; keep the dashboard host in `WORKFLOW.md`
@@ -1065,7 +1218,13 @@ recommendation, and default-if-silent. Record answers in
    `github_app_private_key` or `github_app_private_key_path`.
 
 4. **Run preflight until every check passes.** Fix every `FAIL`; do not
-   dispatch work from a failed doctor run. Verify:
+   dispatch work from a failed doctor run. In ProjectV2 mode, confirm doctor
+   reports project access, Status option discovery, repository issue/PR access,
+   write probes when configured, and rate-limit visibility. In boardless mode,
+   confirm repository access, issue field discovery, option discovery, issue
+   reads by field value, optional issue-field write probe, issue/PR comment
+   write when integration-capable features are configured, and rate-limit
+   visibility. Verify:
 
    ```sh
    detent doctor
@@ -1108,20 +1267,26 @@ recommendation, and default-if-silent. Record answers in
 
 ## Phase 6 — Issue Intake
 
-1. **Confirm the selected initial status option exists.** If this fails on a
-   fresh board, start Detent once with no dispatchable items so it can
-   auto-provision missing options, then repeat this verification. Verify:
+1. **Confirm the selected initial status option exists.** In ProjectV2 mode, if
+   this fails on a fresh board, start Detent once with no dispatchable items so
+   it can auto-provision missing options, then repeat this verification.
+   Verify:
 
    ```sh
+   # ProjectV2 mode:
    gh project field-list <project-number> --owner <project-owner> --format json \
      --jq '.fields[] | select(.name == "Status") | .options[].name' | rg -x '<initial-status>'
+
+   # Boardless mode:
+   jq -r '.options[].name' "$ONBOARDING_DIR/issue-field.json" | rg -x '<initial-status>'
    ```
 
-2. **Bulk-add issues by the selected filter and set initial `Status`.** Use
-   the exact `gh issue list` flags from the intake answer. Use `Backlog` for
-   broad intake and `Todo` only for work that should dispatch immediately.
-   This verifies the write `project` scope if no earlier board creation,
-   linking, field creation, or item edit has already done so.
+2. **ProjectV2 intake: bulk-add issues by the selected filter and set initial
+   `Status`.** Run only when `GITHUB_MODE=project_v2`. Use the exact
+   `gh issue list` flags from the intake answer. Use `Backlog` for broad intake
+   and `Todo` only for work that should dispatch immediately. This verifies the
+   write `project` scope if no earlier board creation, linking, field creation,
+   or item edit has already done so.
    `gh project item-add` and `gh project item-edit` are GraphQL mutations, so
    do not start a broad intake when the budget warning from Phase 1 is still
    unresolved. Verify with one cached inventory after the mutations finish:
@@ -1150,9 +1315,33 @@ recommendation, and default-if-silent. Record answers in
      "$ONBOARDING_DIR/project-items.after-intake.json"
    ```
 
-3. **Optionally enable auto-add.** This is a **human UI step** because GitHub's
+3. **Boardless intake: set initial issue-field Status on selected issues.** Run
+   only when `GITHUB_MODE=issue_field`. Use `Backlog` for broad intake and
+   `Todo` only for work that should dispatch immediately. Issue-field writes
+   can trigger notifications and secondary rate limits, so keep broad edits
+   deliberate and use `detent doctor` to prove the write probe first. Verify:
+
+   ```sh
+   STATUS_FIELD_ID="$(jq -r '.id' "$ONBOARDING_DIR/issue-field.json")"
+   gh issue list --repo <repo-owner>/<repo-name> --state open <chosen-gh-issue-list-flags> \
+     --limit 1000 --json number --jq '.[].number' |
+   while IFS= read -r issue_number; do
+     jq -n --argjson field_id "$STATUS_FIELD_ID" --arg value "<initial-status>" \
+       '{issue_field_values: [{field_id: $field_id, value: $value}]}' |
+     gh api --method POST \
+       "/repos/<repo-owner>/<repo-name>/issues/${issue_number}/issue-field-values" \
+       --input - >/dev/null
+   done
+
+   gh issue list --repo <repo-owner>/<repo-name> --state open <chosen-gh-issue-list-flags> \
+     --limit 1000 --json number,url > "$ONBOARDING_DIR/issues.after-intake.json"
+   jq '. | length' "$ONBOARDING_DIR/issues.after-intake.json"
+   ```
+
+4. **Optionally enable ProjectV2 auto-add.** Run only when
+   `GITHUB_MODE=project_v2`. This is a **human UI step** because GitHub's
    built-in ProjectV2 auto-add workflows are not configurable through the API.
-   Click: Project → ⋯ → Workflows → Auto-add to project. Configure the same
+   Click: Project -> ... -> Workflows -> Auto-add to project. Configure the same
    repo and filter chosen in the interview. Verify:
 
    ```sh
@@ -1199,17 +1388,24 @@ recommendation, and default-if-silent. Record answers in
    curl -fsS http://<tailscale-or-private-ip>:<port>/api/v1/state
    ```
 
-2. **Check the GraphQL budget before smoke dispatch.** This is the last stop
-   before Detent and the spawned agent start spending GraphQL budget for
-   polling, workpad, status, PR, and review work. Verify:
+2. **Check rate-limit budget before smoke dispatch.** In ProjectV2 mode, this
+   is the last stop before Detent and the spawned agent start spending GraphQL
+   budget for polling, workpad, status, PR, and review work. In boardless mode,
+   review REST core and GraphQL visibility from `detent doctor`; issue-field
+   polling and status writes are REST-backed, while PR relationship checks can
+   still use GraphQL. Verify:
 
    ```sh
+   # ProjectV2 mode:
    gh api rate_limit --jq '.resources.graphql | {limit, used, remaining, reset}' \
      > "$ONBOARDING_DIR/graphql-rate-limit.before-smoke.json"
    jq -r '"graphql remaining=\(.remaining) reset=\(.reset)"' \
      "$ONBOARDING_DIR/graphql-rate-limit.before-smoke.json"
    jq -e '.remaining >= 500' "$ONBOARDING_DIR/graphql-rate-limit.before-smoke.json" \
      || printf 'WARNING: low GitHub GraphQL budget; defer smoke dispatch or use GitHub App auth\n'
+
+   # Boardless mode:
+   detent doctor --port 0 | rg 'GitHub API rate limit|GitHub issue field'
    ```
 
 3. **Move one real issue to `Todo`.** Use a real issue that matches the
@@ -1217,6 +1413,7 @@ recommendation, and default-if-silent. Record answers in
    edit; switch to the local Detent API in the next step. Verify:
 
    ```sh
+   # ProjectV2 mode:
    gh project field-list <project-number> --owner <project-owner> --format json \
      > "$ONBOARDING_DIR/project-fields.smoke.json"
    TODO_OPTION_ID="$(jq -r '.fields[] | select(.name == "Status") | .options[] | select(.name == "Todo") | .id' "$ONBOARDING_DIR/project-fields.smoke.json")"
@@ -1234,12 +1431,20 @@ recommendation, and default-if-silent. Record answers in
      --project-id "$PROJECT_NODE_ID" \
      --field-id "$STATUS_FIELD_ID" \
      --single-select-option-id "$TODO_OPTION_ID"
+
+   # Boardless mode:
+   STATUS_FIELD_ID="$(jq -r '.id' "$ONBOARDING_DIR/issue-field.json")"
+   jq -n --argjson field_id "$STATUS_FIELD_ID" --arg value "Todo" \
+     '{issue_field_values: [{field_id: $field_id, value: $value}]}' |
+   gh api --method POST \
+     "/repos/<repo-owner>/<repo-name>/issues/<issue-number>/issue-field-values" \
+     --input -
    ```
 
 4. **Verify the issue dispatches locally.** Onboarding is not complete until
    the issue appears under Running on the dashboard. Once it does, stop
-   operator GitHub ProjectV2 polling; the spawned agent owns GitHub work from
-   here. Verify:
+   operator ProjectV2 or issue-field polling; the spawned agent owns GitHub
+   work from here. Verify:
 
    ```sh
    curl -fsS http://127.0.0.1:<port>/api/v1/state \
@@ -1308,11 +1513,42 @@ changing `global.yaml` or `WORKFLOW.md`.
 
 ## Appendix
 
+### ProjectV2 And Boardless Migration Notes
+
+Existing ProjectV2 workflows remain valid. Leaving
+`tracker.github_status_source` unset keeps `project_v2` as the default
+compatibility path, and `tracker.project_slug` remains required only for that
+mode. Choose this path when humans still use the GitHub Project board as the
+source of truth for planning, ranking, and status changes.
+
+Switch to boardless issue-field mode only after the repository has an
+organization issue `Status` field with options matching the Detent workflow.
+Change `WORKFLOW.md` to:
+
+```yaml
+tracker:
+  kind: github
+  github_status_source: issue_field
+  repository: <repo-owner>/<repo-name>
+  status_field: <status-field-name>
+```
+
+Detent does not automatically migrate ProjectV2 item statuses into issue
+fields. Copy existing statuses manually or with a one-off script outside
+Detent, then run `detent doctor --port 0` and fix repository access, issue
+field discovery, option discovery, write-probe, comment-write, and rate-limit
+checks before dispatching. GitHub issue fields apply to issues only, so linked
+PR cards derive status from the linked issue.
+
 ### Interview Answers To Config Keys
 
 | Interview answer | Config or system target |
 | --- | --- |
-| Board node id | `tracker.project_slug` in `WORKFLOW.md`. |
+| GitHub status source | `tracker.github_status_source: project_v2` or `issue_field` in `WORKFLOW.md`. |
+| Board node id | `tracker.project_slug` in `WORKFLOW.md` for ProjectV2 mode only. |
+| Boardless repository | `tracker.repository` in `WORKFLOW.md` for issue-field mode. |
+| Boardless issue field | `tracker.status_field` in `WORKFLOW.md`; defaults to `Status` when omitted. |
+| Kanban interaction | Keep read-only by default; use integration only in supporting releases after doctor proves write permissions. |
 | Project scheduling priority | `projects[].priority` in `global.yaml`. |
 | Project scheduling weight | `projects[].weight` in `global.yaml`. |
 | Dispatch label ordering | `agent.dispatch_priority_by_label` in `WORKFLOW.md`. |
@@ -1327,7 +1563,7 @@ changing `global.yaml` or `WORKFLOW.md`.
 | Criteria-based auto-promote | `agent.auto_promote.enabled`, `quiet_seconds`, `optout_label`, and `allowed_issue_labels` in `WORKFLOW.md`. |
 | Prompt body | Markdown body after the closing frontmatter `---` in `WORKFLOW.md`. |
 | Intake filter | `gh issue list` flags and optional GitHub Project auto-add workflow. |
-| Initial issue status | ProjectV2 `Status` field value, usually `Backlog` or `Todo`. |
+| Initial issue status | ProjectV2 or issue-field `Status` value, usually `Backlog` or `Todo`. |
 
 ### What A Good Detent Issue Looks Like
 

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -53,7 +53,10 @@ const (
 	doctorFail doctorStatus = "FAIL"
 )
 
-var requiredGitHubScopes = []string{"repo", "read:org", "read:project", "project"}
+var (
+	requiredProjectV2GitHubScopes  = []string{"repo", "read:org", "read:project", "project"}
+	requiredIssueFieldGitHubScopes = []string{"repo", "read:org"}
+)
 
 const (
 	doctorAutoPromoteSampleLimit           = 5
@@ -2074,6 +2077,8 @@ func doctorGitHubReadinessConfig(
 		Repositories:                  doctorGitHubRepositories(ctx, project, cfg, deps, sourceRoot),
 		StatusStates:                  doctorRequiredGitHubStatusStates(cfg),
 		ReadStates:                    doctorRequiredGitHubReadStates(cfg),
+		RequireProjectRead:            doctorRequiresProjectRead(cfg),
+		RequireIssueFieldRead:         doctorRequiresIssueFieldRead(cfg),
 		RequireIssueCommentsRead:      doctorRequiresIssueCommentsRead(cfg),
 		RequireDependencyMetadataRead: doctorRequiresDependencyMetadataRead(cfg),
 		RequireIssueChildrenRead:      doctorRequiresIssueChildrenRead(cfg),
@@ -2082,6 +2087,7 @@ func doctorGitHubReadinessConfig(
 		RequirePullRequestReviews:     doctorRequiresPullRequestReviewsRead(cfg),
 		RequirePullRequestChecks:      doctorRequiresPullRequestChecksRead(cfg),
 		RequireProjectStatusWrite:     doctorRequiresProjectStatusWrite(cfg),
+		RequireIssueFieldStatusWrite:  doctorRequiresIssueFieldStatusWrite(cfg),
 		RequireIssueComments:          doctorRequiresIssueCommentWrite(cfg),
 		RequireAssigneeWrite:          doctorRequiresAssigneeWrite(cfg),
 		RequireIssueClose:             doctorRequiresIssueClose(cfg),
@@ -2132,10 +2138,26 @@ func doctorRequiredGitHubReadStates(cfg workflowconfig.Config) []string {
 	return uniqueDoctorStrings(append(append([]string{}, cfg.Tracker.ActiveStates...), cfg.Tracker.ObservedStates...))
 }
 
-func doctorRequiresProjectStatusWrite(cfg workflowconfig.Config) bool {
+func doctorRequiresProjectRead(cfg workflowconfig.Config) bool {
+	return cfg.Tracker.GitHubStatusSource != workflowconfig.GitHubStatusSourceIssueField
+}
+
+func doctorRequiresIssueFieldRead(cfg workflowconfig.Config) bool {
+	return cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceIssueField
+}
+
+func doctorRequiresStatusWrite(cfg workflowconfig.Config) bool {
 	return len(cfg.Tracker.ActiveStates) > 0 ||
 		cfg.Agent.AutoPromote.Enabled ||
 		cfg.Tracker.DependencyAutoUnblock.Enabled
+}
+
+func doctorRequiresProjectStatusWrite(cfg workflowconfig.Config) bool {
+	return doctorRequiresProjectRead(cfg) && doctorRequiresStatusWrite(cfg)
+}
+
+func doctorRequiresIssueFieldStatusWrite(cfg workflowconfig.Config) bool {
+	return doctorRequiresIssueFieldRead(cfg) && doctorRequiresStatusWrite(cfg)
 }
 
 func doctorRequiresIssueCommentWrite(cfg workflowconfig.Config) bool {
@@ -2193,6 +2215,9 @@ func doctorRequiresPullRequestChecksRead(cfg workflowconfig.Config) bool {
 }
 
 func doctorRequiredProjectFieldWrites(cfg workflowconfig.Config) []ghconnector.ReadinessProjectFieldWrite {
+	if cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceIssueField {
+		return nil
+	}
 	if !cfg.Tracker.Claims.Enabled {
 		return nil
 	}
@@ -2567,7 +2592,8 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 			Detail: fmt.Sprintf("%s did not expose classic OAuth scopes; treating as fine-grained or resource-scoped token and relying on operation checks", source),
 		}
 	}
-	missing := missingGitHubScopes(scopes)
+	requiredScopes := doctorRequiredGitHubScopes(cfg, deps)
+	missing := missingGitHubScopes(scopes, requiredScopes)
 	if len(missing) > 0 {
 		return doctorCheck{
 			Name:   "GitHub token",
@@ -2580,7 +2606,7 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 	return doctorCheck{
 		Name:   "GitHub token",
 		Status: doctorOK,
-		Detail: fmt.Sprintf("%s has classic PAT scopes: %s; operation checks still verify resource access", source, strings.Join(requiredGitHubScopes, ", ")),
+		Detail: fmt.Sprintf("%s has classic PAT scopes: %s; operation checks still verify resource access", source, strings.Join(requiredScopes, ", ")),
 	}
 }
 
@@ -2640,7 +2666,48 @@ func validEnvName(name string) bool {
 	return true
 }
 
-func missingGitHubScopes(scopes []string) []string {
+func doctorRequiredGitHubScopes(cfg *globalconfig.Config, deps doctorDeps) []string {
+	if cfg == nil {
+		return append([]string{}, requiredProjectV2GitHubScopes...)
+	}
+	required := []string{}
+	add := func(scopes []string) {
+		for _, scope := range scopes {
+			scope = strings.TrimSpace(scope)
+			if scope == "" || doctorStringSliceContains(required, scope) {
+				continue
+			}
+			required = append(required, scope)
+		}
+	}
+	for _, project := range cfg.Projects {
+		workflow, err := deps.loadWorkflow(project.Workflow)
+		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+			continue
+		}
+		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceIssueField {
+			add(requiredIssueFieldGitHubScopes)
+			continue
+		}
+		add(requiredProjectV2GitHubScopes)
+	}
+	if len(required) == 0 {
+		return append([]string{}, requiredProjectV2GitHubScopes...)
+	}
+	return required
+}
+
+func doctorStringSliceContains(values []string, want string) bool {
+	want = strings.TrimSpace(want)
+	for _, value := range values {
+		if strings.TrimSpace(value) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func missingGitHubScopes(scopes []string, requiredScopes []string) []string {
 	have := make(map[string]struct{}, len(scopes))
 	for _, scope := range scopes {
 		scope = strings.ToLower(strings.TrimSpace(scope))
@@ -2650,7 +2717,7 @@ func missingGitHubScopes(scopes []string) []string {
 	}
 
 	var missing []string
-	for _, scope := range requiredGitHubScopes {
+	for _, scope := range requiredScopes {
 		if !hasEffectiveGitHubScope(have, scope) {
 			missing = append(missing, scope)
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2685,6 +2685,9 @@ func doctorRequiredGitHubScopes(cfg *globalconfig.Config, deps doctorDeps) []str
 		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 			continue
 		}
+		if trackerHasGitHubAppCredentials(workflow.Config.Tracker, deps.lookupEnv) {
+			continue
+		}
 		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceIssueField {
 			add(requiredIssueFieldGitHubScopes)
 			continue

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -920,6 +920,68 @@ func TestCheckDoctorProjectBuildsGitHubReadinessInventory(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorProjectBuildsGitHubIssueFieldReadinessInventory(t *testing.T) {
+	t.Parallel()
+
+	workflow := validDoctorWorkflow("/repo")
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	workflow.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceIssueField
+	workflow.Tracker.ProjectSlug = ""
+	workflow.Tracker.Repository = "digitaldrywood/detent"
+	workflow.Tracker.StatusField = "Status"
+	workflow.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+	workflow.Tracker.ObservedStates = []string{"Backlog", "Human Review", "Blocked"}
+	workflow.Tracker.TerminalStates = []string{"Done", "Cancelled"}
+	workflow.Tracker.WriteProbeIssue = "digitaldrywood/detent#1"
+	var gotConnector ghconnector.Config
+	var gotReadiness ghconnector.ReadinessConfig
+
+	checks := checkDoctorProject(context.Background(), globalconfig.Project{
+		ID:       "alpha",
+		Workflow: "WORKFLOW.md",
+	}, doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: workflow}, nil
+		},
+		gitWorkTree: func(context.Context, string) error {
+			return nil
+		},
+		gitRemoteURL: func(context.Context, string) (string, error) {
+			return "git@github.com:digitaldrywood/detent.git", nil
+		},
+		githubReadiness: func(_ context.Context, connectorCfg ghconnector.Config, readinessCfg ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+			gotConnector = connectorCfg
+			gotReadiness = readinessCfg
+			return []ghconnector.ReadinessCheck{{Name: "GitHub issue field access", Status: ghconnector.ReadinessOK, Detail: "read Status"}}, nil
+		},
+	}, RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"})
+
+	if gotConnector.ProjectSlug != "" {
+		t.Fatalf("connector ProjectSlug = %q, want empty in issue_field mode", gotConnector.ProjectSlug)
+	}
+	if gotConnector.Repository != "digitaldrywood/detent" {
+		t.Fatalf("connector Repository = %q, want digitaldrywood/detent", gotConnector.Repository)
+	}
+	if gotConnector.GitHubStatusSource != workflowconfig.GitHubStatusSourceIssueField {
+		t.Fatalf("connector GitHubStatusSource = %q, want issue_field", gotConnector.GitHubStatusSource)
+	}
+	if gotReadiness.RequireProjectRead || gotReadiness.RequireProjectStatusWrite {
+		t.Fatalf("project requirements = %#v, want no ProjectV2 requirements in issue_field mode", gotReadiness)
+	}
+	if !gotReadiness.RequireIssueFieldRead || !gotReadiness.RequireIssueFieldStatusWrite {
+		t.Fatalf("issue-field requirements = %#v, want issue-field read and status write", gotReadiness)
+	}
+	if !gotReadiness.RequireIssueComments {
+		t.Fatalf("RequireIssueComments = false, want comment write probe for integration-capable workflow")
+	}
+	if len(gotReadiness.Repositories) != 1 || gotReadiness.Repositories[0] != "digitaldrywood/detent" {
+		t.Fatalf("Repositories = %#v, want digitaldrywood/detent", gotReadiness.Repositories)
+	}
+	if len(checks) < 3 || checks[len(checks)-1].Status != doctorOK {
+		t.Fatalf("checks = %#v, want readiness OK check appended", checks)
+	}
+}
+
 func TestCheckDoctorRuntimeSettingsReportsSources(t *testing.T) {
 	t.Parallel()
 
@@ -1127,6 +1189,23 @@ func TestCheckDoctorGitHub(t *testing.T) {
 			scopes:     []string{"project", "read:project", "read:org", "repo"},
 			want:       doctorOK,
 			wantDetail: "PROJECT_TOKEN has classic PAT scopes",
+		},
+		{
+			name: "boardless workflow token does not require project scopes",
+			cfg: &globalconfig.Config{Projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			}},
+			workflow: func() workflowconfig.Config {
+				cfg := githubWorkflow
+				cfg.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceIssueField
+				cfg.Tracker.ProjectSlug = ""
+				cfg.Tracker.Repository = "digitaldrywood/detent"
+				return cfg
+			}(),
+			token:      RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"},
+			scopes:     []string{"repo", "read:org"},
+			want:       doctorOK,
+			wantDetail: "GITHUB_TOKEN has classic PAT scopes: repo, read:org",
 		},
 		{
 			name:       "environment token has required scopes",

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1253,6 +1253,54 @@ func TestCheckDoctorGitHub(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorGitHubScopesSkipAppBackedWorkflows(t *testing.T) {
+	t.Parallel()
+
+	boardlessWorkflow := validDoctorWorkflow("/repo")
+	boardlessWorkflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	boardlessWorkflow.Tracker.APIKey = "$GITHUB_TOKEN"
+	boardlessWorkflow.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceIssueField
+	boardlessWorkflow.Tracker.ProjectSlug = ""
+	boardlessWorkflow.Tracker.Repository = "digitaldrywood/detent"
+
+	appWorkflow := githubAppWorkflow()
+	workflows := map[string]workflowconfig.Config{
+		"boardless.md": boardlessWorkflow,
+		"projectv2.md": appWorkflow,
+	}
+	cfg := &globalconfig.Config{Projects: []globalconfig.Project{
+		{ID: "boardless", Workflow: "boardless.md"},
+		{ID: "projectv2", Workflow: "projectv2.md"},
+	}}
+
+	got := checkDoctorGitHub(context.Background(), cfg, RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"}, doctorDeps{
+		lookupEnv: mapLookup(map[string]string{
+			"APP_ID":           "12345",
+			"INSTALLATION_ID":  "67890",
+			"PRIVATE_KEY_PATH": ".detent/github-app.pem",
+		}),
+		loadWorkflow: func(path string) (workflowconfig.Workflow, error) {
+			workflow, ok := workflows[path]
+			if !ok {
+				t.Fatalf("unexpected workflow path %q", path)
+			}
+			return workflowconfig.Workflow{Config: workflow}, nil
+		},
+		githubScopes: func(context.Context, string) ([]string, error) {
+			return []string{"repo", "read:org"}, nil
+		},
+	})
+	if got.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorOK, got)
+	}
+	if !strings.Contains(got.Detail, "repo, read:org") {
+		t.Fatalf("Detail = %q, want boardless PAT scopes", got.Detail)
+	}
+	if strings.Contains(got.Detail, "read:project") || strings.Contains(got.Detail, ", project") {
+		t.Fatalf("Detail = %q, want no ProjectV2 PAT scopes for app-backed workflow", got.Detail)
+	}
+}
+
 func TestExpandDoctorWorkspacePath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -316,6 +316,25 @@ func TestValidateGitHubProjectV2StillRequiresProjectSlug(t *testing.T) {
 	}
 }
 
+func TestValidateGitHubIssueFieldRequiresRepository(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Tracker.Kind = TrackerGitHub
+	cfg.Tracker.APIKey = "token"
+	cfg.Tracker.GitHubStatusSource = GitHubStatusSourceIssueField
+	cfg.Tracker.ProjectSlug = ""
+	cfg.Tracker.Repository = ""
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "tracker.repository") {
+		t.Fatalf("Validate() error = %v, want repository requirement", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "tracker.project_slug") {
+		t.Fatalf("Validate() error = %v, want no project_slug requirement in issue_field mode", err)
+	}
+}
+
 func TestParseWorkflowDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -32,6 +32,8 @@ type ReadinessConfig struct {
 	Repositories                  []string
 	StatusStates                  []string
 	ReadStates                    []string
+	RequireProjectRead            bool
+	RequireIssueFieldRead         bool
 	RequireIssueCommentsRead      bool
 	RequireDependencyMetadataRead bool
 	RequireIssueChildrenRead      bool
@@ -40,6 +42,7 @@ type ReadinessConfig struct {
 	RequirePullRequestReviews     bool
 	RequirePullRequestChecks      bool
 	RequireProjectStatusWrite     bool
+	RequireIssueFieldStatusWrite  bool
 	RequireIssueComments          bool
 	RequireAssigneeWrite          bool
 	RequireIssueClose             bool
@@ -112,6 +115,7 @@ func (c githubReadinessChecker) Check(ctx context.Context, cfg ReadinessConfig) 
 	}
 	checks = append(checks, c.probeReadChecks(ctx, cfg, probe, hasProbe)...)
 	checks = append(checks, c.writeChecks(ctx, cfg, probe, hasProbe)...)
+	checks = append(checks, c.rateLimitCheck(ctx))
 	return checks
 }
 
@@ -753,11 +757,10 @@ func (c githubReadinessChecker) issueParentsReadCheck(ctx context.Context, probe
 func (c githubReadinessChecker) writeChecks(ctx context.Context, cfg ReadinessConfig, probe readinessProbeIssue, hasProbe bool) []ReadinessCheck {
 	checks := []ReadinessCheck{}
 	if cfg.RequireProjectStatusWrite {
-		if c.connector.usesIssueFieldStatus() {
-			checks = append(checks, c.issueFieldStatusWriteCheck(ctx, probe, hasProbe))
-		} else {
-			checks = append(checks, c.projectStatusWriteCheck(ctx, probe, hasProbe))
-		}
+		checks = append(checks, c.projectStatusWriteCheck(ctx, probe, hasProbe))
+	}
+	if cfg.RequireIssueFieldStatusWrite {
+		checks = append(checks, c.issueFieldStatusWriteCheck(ctx, probe, hasProbe))
 	}
 	if cfg.RequireIssueComments {
 		checks = append(checks, c.issueCommentWriteCheck(ctx, probe, hasProbe))
@@ -772,6 +775,70 @@ func (c githubReadinessChecker) writeChecks(ctx context.Context, cfg ReadinessCo
 		checks = append(checks, c.issueCloseWriteCheck(ctx, probe, hasProbe))
 	}
 	return checks
+}
+
+type restRateLimitResponse struct {
+	Resources struct {
+		Core    restRateLimitResource `json:"core"`
+		GraphQL restRateLimitResource `json:"graphql"`
+	} `json:"resources"`
+}
+
+type restRateLimitResource struct {
+	Limit     int64 `json:"limit"`
+	Used      int64 `json:"used"`
+	Remaining int64 `json:"remaining"`
+	Reset     int64 `json:"reset"`
+}
+
+func (c githubReadinessChecker) rateLimitCheck(ctx context.Context) ReadinessCheck {
+	var response restRateLimitResponse
+	if err := c.connector.client.REST(ctx, http.MethodGet, "/rate_limit", nil, &response); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub API rate limit",
+			Status: ReadinessWarn,
+			Detail: "rate-limit endpoint could not be read: " + err.Error(),
+			Hint:   "Rerun detent doctor when GitHub API access is available.",
+		}
+	}
+	details := []string{}
+	if response.Resources.Core.Limit > 0 {
+		details = append(details, rateLimitResourceDetail("REST core", response.Resources.Core))
+	}
+	if response.Resources.GraphQL.Limit > 0 {
+		details = append(details, rateLimitResourceDetail("GraphQL", response.Resources.GraphQL))
+	}
+	if len(details) == 0 {
+		return ReadinessCheck{
+			Name:   "GitHub API rate limit",
+			Status: ReadinessWarn,
+			Detail: "rate-limit endpoint returned no REST core or GraphQL resource details",
+			Hint:   "Check GitHub API compatibility and rerun detent doctor.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub API rate limit",
+		Status: ReadinessOK,
+		Detail: strings.Join(details, "; "),
+	}
+}
+
+func rateLimitResourceDetail(name string, resource restRateLimitResource) string {
+	return fmt.Sprintf(
+		"%s remaining %d/%d; used %d; resets %s",
+		name,
+		resource.Remaining,
+		resource.Limit,
+		resource.Used,
+		rateLimitResetDetail(resource.Reset),
+	)
+}
+
+func rateLimitResetDetail(reset int64) string {
+	if reset <= 0 {
+		return "unknown"
+	}
+	return time.Unix(reset, 0).UTC().Format(time.RFC3339)
 }
 
 func (c githubReadinessChecker) projectStatusWriteCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
@@ -1052,15 +1119,20 @@ func unprovenWriteCheck(name string) ReadinessCheck {
 
 func missingInstallationPermissions(details InstallationTokenDetails, cfg ReadinessConfig) []string {
 	var missing []string
-	projectLevel := "read"
-	if cfg.RequireProjectStatusWrite || len(cfg.ProjectFieldWrites) > 0 {
-		projectLevel = "write"
+	if cfg.RequireProjectRead || cfg.RequireProjectStatusWrite || len(cfg.ProjectFieldWrites) > 0 {
+		projectLevel := "read"
+		if cfg.RequireProjectStatusWrite || len(cfg.ProjectFieldWrites) > 0 {
+			projectLevel = "write"
+		}
+		if !hasAnyPermission(details.Permissions, []string{"organization_projects", "repository_projects", "projects"}, projectLevel) {
+			missing = append(missing, "Projects: "+projectLevel)
+		}
 	}
-	if !hasAnyPermission(details.Permissions, []string{"organization_projects", "repository_projects", "projects"}, projectLevel) {
-		missing = append(missing, "Projects: "+projectLevel)
+	if cfg.RequireIssueFieldRead && !hasAnyPermission(details.Permissions, []string{"organization_issue_fields", "issue_fields"}, "read") {
+		missing = append(missing, "Issue Fields: read")
 	}
 	issueLevel := "read"
-	if cfg.RequireIssueComments || cfg.RequireAssigneeWrite || cfg.RequireIssueClose {
+	if cfg.RequireIssueFieldStatusWrite || cfg.RequireIssueComments || cfg.RequireAssigneeWrite || cfg.RequireIssueClose {
 		issueLevel = "write"
 	}
 	if !permissionAllows(details.Permissions["issues"], issueLevel) {

--- a/internal/connector/github/readiness_test.go
+++ b/internal/connector/github/readiness_test.go
@@ -93,6 +93,11 @@ func TestReadinessIssueFieldCheckUsesBoardlessStatusSource(t *testing.T) {
 			method: http.MethodGet,
 			body:   `{"total_count":0,"items":[]}`,
 		},
+		{
+			method: http.MethodGet,
+			path:   "/rate_limit",
+			body:   `{"resources":{"core":{"limit":5000,"used":100,"remaining":4900,"reset":1781560800},"graphql":{"limit":5000,"used":20,"remaining":4980,"reset":1781560800}}}`,
+		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		GitHubStatusSource: GitHubStatusSourceIssueField,
@@ -105,8 +110,8 @@ func TestReadinessIssueFieldCheckUsesBoardlessStatusSource(t *testing.T) {
 		StatusStates: []string{"Todo"},
 		ReadStates:   []string{"Todo"},
 	})
-	if len(got) != 5 {
-		t.Fatalf("checks len = %d, want auth, access, mappings, read, repository warning: %#v", len(got), got)
+	if len(got) != 6 {
+		t.Fatalf("checks len = %d, want auth, access, mappings, read, repository warning, rate limit: %#v", len(got), got)
 	}
 	for _, check := range got {
 		if strings.Contains(check.Name, "project") {
@@ -121,6 +126,12 @@ func TestReadinessIssueFieldCheckUsesBoardlessStatusSource(t *testing.T) {
 	}
 	if got[3].Name != "GitHub issue field issue read" || got[3].Status != ReadinessOK {
 		t.Fatalf("issue field read check = %#v, want OK", got[3])
+	}
+	if got[5].Name != "GitHub API rate limit" || got[5].Status != ReadinessOK {
+		t.Fatalf("rate limit check = %#v, want OK", got[5])
+	}
+	if !strings.Contains(got[5].Detail, "REST core remaining 4900/5000") || !strings.Contains(got[5].Detail, "GraphQL remaining 4980/5000") {
+		t.Fatalf("rate limit detail = %q, want REST and GraphQL visibility", got[5].Detail)
 	}
 }
 
@@ -318,6 +329,60 @@ func TestReadinessGitHubAppInstallationReportsMissingPermissions(t *testing.T) {
 		if !strings.Contains(got.Detail, want) {
 			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
 		}
+	}
+}
+
+func TestReadinessGitHubAppInstallationIssueFieldModeSkipsProjectsPermission(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	privateKey := testPrivateKeyPEM(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations/987/access_tokens" {
+			t.Fatalf("path = %s, want installation token path", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		response := map[string]any{
+			"token":                "installation-token",
+			"expires_at":           now.Add(time.Hour).Format(time.RFC3339),
+			"repository_selection": "all",
+			"permissions": map[string]string{
+				"issues": "read",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	checker := githubReadinessChecker{cfg: Config{
+		Endpoint:                server.URL + "/graphql",
+		HTTPClient:              server.Client(),
+		GitHubAppID:             "123",
+		GitHubAppInstallationID: "987",
+		GitHubAppPrivateKey:     privateKey,
+		Now:                     func() time.Time { return now },
+	}}
+
+	got := checker.appInstallationCheck(context.Background(), ReadinessConfig{
+		RequireIssueFieldRead:        true,
+		RequireIssueFieldStatusWrite: true,
+		RequireIssueComments:         true,
+		RequirePullRequestRead:       true,
+		RequirePullRequestChecks:     true,
+		Repositories:                 []string{"digitaldrywood/detent"},
+	})
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	for _, want := range []string{"Issue Fields: read", "Issues: write"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+		}
+	}
+	if strings.Contains(got.Detail, "Projects") {
+		t.Fatalf("Detail = %q, want no Projects permission requirement in issue_field mode", got.Detail)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Document ProjectV2-backed and boardless issue-field GitHub setup paths, permissions, Kanban guidance, safety language, and migration notes.
- Update doctor/readiness checks so boardless mode skips ProjectV2 scopes and permissions while reporting issue-field, comment, repository, and rate-limit checks.
- Add focused tests for boardless config validation, doctor inventory, token scopes, GitHub App permissions, and rate-limit visibility.

Fixes #480

## Test Plan

- [x] `go test ./internal/config`
- [x] `go test ./internal/cli ./internal/connector/github`
- [x] `make check`