### PR TITLE
[codex] add GitHub label status source

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -56,6 +56,7 @@ const (
 var (
 	requiredProjectV2GitHubScopes  = []string{"repo", "read:org", "read:project", "project"}
 	requiredIssueFieldGitHubScopes = []string{"repo", "read:org"}
+	requiredLabelGitHubScopes      = []string{"repo"}
 )
 
 const (
@@ -2002,6 +2003,7 @@ func defaultDoctorAutoPromoteConnector(cfg workflowconfig.Config) (doctorAutoPro
 		ProjectSlug:             cfg.Tracker.ProjectSlug,
 		Repository:              cfg.Tracker.Repository,
 		StatusField:             cfg.Tracker.StatusField,
+		StatusLabelPrefix:       cfg.Tracker.StatusLabelPrefix,
 		ActiveStates:            cfg.Tracker.ActiveStates,
 		ObservedStates:          cfg.Tracker.ObservedStates,
 		TerminalStates:          cfg.Tracker.TerminalStates,
@@ -2056,6 +2058,7 @@ func doctorGitHubConnectorConfig(cfg workflowconfig.Config) ghconnector.Config {
 		ProjectSlug:             cfg.Tracker.ProjectSlug,
 		Repository:              cfg.Tracker.Repository,
 		StatusField:             cfg.Tracker.StatusField,
+		StatusLabelPrefix:       cfg.Tracker.StatusLabelPrefix,
 		ActiveStates:            cfg.Tracker.ActiveStates,
 		ObservedStates:          cfg.Tracker.ObservedStates,
 		TerminalStates:          cfg.Tracker.TerminalStates,
@@ -2088,6 +2091,7 @@ func doctorGitHubReadinessConfig(
 		RequirePullRequestChecks:      doctorRequiresPullRequestChecksRead(cfg),
 		RequireProjectStatusWrite:     doctorRequiresProjectStatusWrite(cfg),
 		RequireIssueFieldStatusWrite:  doctorRequiresIssueFieldStatusWrite(cfg),
+		RequireLabelStatusWrite:       doctorRequiresLabelStatusWrite(cfg),
 		RequireIssueComments:          doctorRequiresIssueCommentWrite(cfg),
 		RequireAssigneeWrite:          doctorRequiresAssigneeWrite(cfg),
 		RequireIssueClose:             doctorRequiresIssueClose(cfg),
@@ -2139,11 +2143,15 @@ func doctorRequiredGitHubReadStates(cfg workflowconfig.Config) []string {
 }
 
 func doctorRequiresProjectRead(cfg workflowconfig.Config) bool {
-	return cfg.Tracker.GitHubStatusSource != workflowconfig.GitHubStatusSourceIssueField
+	return cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceProjectV2
 }
 
 func doctorRequiresIssueFieldRead(cfg workflowconfig.Config) bool {
 	return cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceIssueField
+}
+
+func doctorRequiresLabelRead(cfg workflowconfig.Config) bool {
+	return cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceLabel
 }
 
 func doctorRequiresStatusWrite(cfg workflowconfig.Config) bool {
@@ -2158,6 +2166,10 @@ func doctorRequiresProjectStatusWrite(cfg workflowconfig.Config) bool {
 
 func doctorRequiresIssueFieldStatusWrite(cfg workflowconfig.Config) bool {
 	return doctorRequiresIssueFieldRead(cfg) && doctorRequiresStatusWrite(cfg)
+}
+
+func doctorRequiresLabelStatusWrite(cfg workflowconfig.Config) bool {
+	return doctorRequiresLabelRead(cfg) && doctorRequiresStatusWrite(cfg)
 }
 
 func doctorRequiresIssueCommentWrite(cfg workflowconfig.Config) bool {
@@ -2215,7 +2227,7 @@ func doctorRequiresPullRequestChecksRead(cfg workflowconfig.Config) bool {
 }
 
 func doctorRequiredProjectFieldWrites(cfg workflowconfig.Config) []ghconnector.ReadinessProjectFieldWrite {
-	if cfg.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceIssueField {
+	if !doctorRequiresProjectRead(cfg) {
 		return nil
 	}
 	if !cfg.Tracker.Claims.Enabled {
@@ -2688,11 +2700,14 @@ func doctorRequiredGitHubScopes(cfg *globalconfig.Config, deps doctorDeps) []str
 		if trackerHasGitHubAppCredentials(workflow.Config.Tracker, deps.lookupEnv) {
 			continue
 		}
-		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceIssueField {
+		switch workflow.Config.Tracker.GitHubStatusSource {
+		case workflowconfig.GitHubStatusSourceIssueField:
 			add(requiredIssueFieldGitHubScopes)
-			continue
+		case workflowconfig.GitHubStatusSourceLabel:
+			add(requiredLabelGitHubScopes)
+		default:
+			add(requiredProjectV2GitHubScopes)
 		}
-		add(requiredProjectV2GitHubScopes)
 	}
 	if len(required) == 0 {
 		return append([]string{}, requiredProjectV2GitHubScopes...)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1301,6 +1301,38 @@ func TestCheckDoctorGitHubScopesSkipAppBackedWorkflows(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorGitHubScopesLabelModeRequiresRepoOnly(t *testing.T) {
+	t.Parallel()
+
+	workflow := validDoctorWorkflow("/repo")
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	workflow.Tracker.APIKey = "$GITHUB_TOKEN"
+	workflow.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+	workflow.Tracker.ProjectSlug = ""
+	workflow.Tracker.Repository = "digitaldrywood/detent"
+	cfg := &globalconfig.Config{Projects: []globalconfig.Project{{ID: "detent", Workflow: "workflow.md"}}}
+
+	got := checkDoctorGitHub(context.Background(), cfg, RuntimeSecret{Value: "token", Source: "GITHUB_TOKEN"}, doctorDeps{
+		loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+			return workflowconfig.Workflow{Config: workflow}, nil
+		},
+		githubScopes: func(context.Context, string) ([]string, error) {
+			return []string{"repo"}, nil
+		},
+	})
+	if got.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorOK, got)
+	}
+	if !strings.Contains(got.Detail, "repo") {
+		t.Fatalf("Detail = %q, want repo scope", got.Detail)
+	}
+	for _, forbidden := range []string{"read:org", "read:project", ", project"} {
+		if strings.Contains(got.Detail, forbidden) {
+			t.Fatalf("Detail = %q, want no %s scope requirement in label mode", got.Detail, forbidden)
+		}
+	}
+}
+
 func TestExpandDoctorWorkspacePath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -25,6 +25,7 @@ const (
 
 	GitHubStatusSourceProjectV2  = "project_v2"
 	GitHubStatusSourceIssueField = "issue_field"
+	GitHubStatusSourceLabel      = "label"
 
 	DependencyReadinessTerminal         = "terminal"
 	DependencyReadinessTerminalOrMerged = "terminal_or_merged"
@@ -85,6 +86,7 @@ type Tracker struct {
 	ProjectSlug                string                `yaml:"project_slug"`
 	Repository                 string                `yaml:"repository"`
 	StatusField                string                `yaml:"status_field"`
+	StatusLabelPrefix          string                `yaml:"status_label_prefix,omitempty"`
 	WriteProbeIssue            string                `yaml:"write_probe_issue,omitempty"`
 	Assignee                   string                `yaml:"assignee"`
 	ActiveStates               []string              `yaml:"active_states"`
@@ -507,6 +509,7 @@ func Default() Config {
 			GitHubGraphQLWarnRemaining: 500,
 			GitHubStatusSource:         GitHubStatusSourceProjectV2,
 			StatusField:                "Status",
+			StatusLabelPrefix:          "detent:",
 			ActiveStates:               []string{"Todo", "In Progress"},
 			ObservedStates:             []string{"Backlog", "Human Review", "Blocked"},
 			TerminalStates:             []string{"Closed", "Cancelled", "Canceled", "Duplicate", "Done"},
@@ -661,6 +664,10 @@ func (c *Config) normalize() {
 	if c.Tracker.StatusField == "" {
 		c.Tracker.StatusField = "Status"
 	}
+	c.Tracker.StatusLabelPrefix = strings.TrimSpace(c.Tracker.StatusLabelPrefix)
+	if c.Tracker.StatusLabelPrefix == "" {
+		c.Tracker.StatusLabelPrefix = "detent:"
+	}
 	c.Tracker.WriteProbeIssue = strings.TrimSpace(c.Tracker.WriteProbeIssue)
 	c.Tracker.Claims.Normalize()
 	c.Tracker.DependencyAutoUnblock.Normalize()
@@ -719,8 +726,16 @@ func (t *Tracker) validateGitHubStatusSource(problems *[]string) {
 		if strings.TrimSpace(t.Repository) != "" && !validRepositoryName(t.Repository) {
 			*problems = append(*problems, "tracker.repository must be owner/name")
 		}
+	case GitHubStatusSourceLabel:
+		validateRequired("tracker.repository", t.Repository, " for github label", problems)
+		if strings.TrimSpace(t.Repository) != "" && !validRepositoryName(t.Repository) {
+			*problems = append(*problems, "tracker.repository must be owner/name")
+		}
+		if strings.TrimSpace(t.StatusLabelPrefix) == "" {
+			*problems = append(*problems, "tracker.status_label_prefix is required for github label")
+		}
 	default:
-		*problems = append(*problems, "tracker.github_status_source must be one of project_v2, issue_field")
+		*problems = append(*problems, "tracker.github_status_source must be one of project_v2, issue_field, label")
 	}
 }
 
@@ -756,6 +771,8 @@ func normalizeGitHubStatusSource(value string) string {
 		return GitHubStatusSourceProjectV2
 	case GitHubStatusSourceIssueField, "issuefield", "issues":
 		return GitHubStatusSourceIssueField
+	case GitHubStatusSourceLabel, "labels", "issue_label", "issue_labels":
+		return GitHubStatusSourceLabel
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -302,6 +302,44 @@ Prompt
 	}
 }
 
+func TestParseWorkflowGitHubLabelTracker(t *testing.T) {
+	t.Parallel()
+
+	raw := []byte(`---
+tracker:
+  kind: github
+  api_key: $GITHUB_TOKEN
+  github_status_source: label
+  repository: digitaldrywood/detent
+  status_label_prefix: "detent:"
+  active_states:
+    - Todo
+---
+Prompt
+`)
+
+	workflow, err := ParseWorkflow(raw)
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	cfg := workflow.Config
+	if err := cfg.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if cfg.Tracker.GitHubStatusSource != GitHubStatusSourceLabel {
+		t.Fatalf("GitHubStatusSource = %q, want %q", cfg.Tracker.GitHubStatusSource, GitHubStatusSourceLabel)
+	}
+	if cfg.Tracker.Repository != "digitaldrywood/detent" {
+		t.Fatalf("Repository = %q, want digitaldrywood/detent", cfg.Tracker.Repository)
+	}
+	if cfg.Tracker.StatusLabelPrefix != "detent:" {
+		t.Fatalf("StatusLabelPrefix = %q, want detent:", cfg.Tracker.StatusLabelPrefix)
+	}
+	if cfg.Tracker.ProjectSlug != "" {
+		t.Fatalf("ProjectSlug = %q, want empty for label source", cfg.Tracker.ProjectSlug)
+	}
+}
+
 func TestValidateGitHubProjectV2StillRequiresProjectSlug(t *testing.T) {
 	t.Parallel()
 
@@ -332,6 +370,35 @@ func TestValidateGitHubIssueFieldRequiresRepository(t *testing.T) {
 	}
 	if err != nil && strings.Contains(err.Error(), "tracker.project_slug") {
 		t.Fatalf("Validate() error = %v, want no project_slug requirement in issue_field mode", err)
+	}
+}
+
+func TestValidateGitHubLabelRequiresRepository(t *testing.T) {
+	t.Parallel()
+
+	cfg := Default()
+	cfg.Tracker.Kind = TrackerGitHub
+	cfg.Tracker.APIKey = "token"
+	cfg.Tracker.GitHubStatusSource = GitHubStatusSourceLabel
+	cfg.Tracker.ProjectSlug = ""
+	cfg.Tracker.Repository = ""
+
+	err := cfg.Validate()
+	if err == nil || !strings.Contains(err.Error(), "tracker.repository") {
+		t.Fatalf("Validate() error = %v, want repository requirement", err)
+	}
+	if err != nil && strings.Contains(err.Error(), "tracker.project_slug") {
+		t.Fatalf("Validate() error = %v, want no project_slug requirement in label mode", err)
+	}
+}
+
+func TestNormalizeGitHubLabelStatusSourceAliases(t *testing.T) {
+	t.Parallel()
+
+	for _, value := range []string{"label", "labels", "issue_label", "issue_labels"} {
+		if got := normalizeGitHubStatusSource(value); got != GitHubStatusSourceLabel {
+			t.Fatalf("normalizeGitHubStatusSource(%q) = %q, want %q", value, got, GitHubStatusSourceLabel)
+		}
 	}
 }
 

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -33,6 +33,7 @@ type Config struct {
 	ProjectSlug             string
 	Repository              string
 	StatusField             string
+	StatusLabelPrefix       string
 	ActiveStates            []string
 	ObservedStates          []string
 	TerminalStates          []string
@@ -65,6 +66,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 			ProjectSlug:             cfg.ProjectSlug,
 			Repository:              cfg.Repository,
 			StatusField:             cfg.StatusField,
+			StatusLabelPrefix:       cfg.StatusLabelPrefix,
 			ActiveStates:            cfg.ActiveStates,
 			ObservedStates:          cfg.ObservedStates,
 			TerminalStates:          cfg.TerminalStates,

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -134,6 +134,22 @@ func TestFactoryGitHubIssueFieldConnectorRequiresRepositoryForPolling(t *testing
 	}
 }
 
+func TestFactoryGitHubLabelConnectorRequiresRepositoryForPolling(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromConfig(Config{
+		Kind:               "github",
+		GitHubStatusSource: githubconnector.GitHubStatusSourceLabel,
+	})
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+
+	if _, err := c.FetchCandidateIssues(context.Background()); !errors.Is(err, githubconnector.ErrMissingRepository) {
+		t.Fatalf("FetchCandidateIssues() error = %v, want ErrMissingRepository", err)
+	}
+}
+
 func TestFactoryGitHubConnectorImplementsAuthenticator(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -225,6 +225,48 @@ query DetentGitHubIssueTrackedIssues($issueId: ID!, $after: String) {
   rateLimit { limit used remaining cost resetAt }
 }`
 
+const issueSubIssuesLabelQuery = `
+query DetentGitHubIssueSubIssuesLabel($issueId: ID!, $after: String) {
+  node(id: $issueId) {
+    ... on Issue {
+      subIssues(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          number
+          title
+          state
+          url
+          labels(first: 20) { nodes { name } }
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
+const issueTrackedIssuesLabelQuery = `
+query DetentGitHubIssueTrackedIssuesLabel($issueId: ID!, $after: String) {
+  node(id: $issueId) {
+    ... on Issue {
+      trackedIssues(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          id
+          number
+          title
+          state
+          url
+          labels(first: 20) { nodes { name } }
+          repository { nameWithOwner }
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
+
 const issueParentsQuery = `
 query DetentGitHubIssueParents(
   $issueId: ID!
@@ -380,6 +422,73 @@ fragment DetentGitHubIssueParent on Issue {
           }
         }
       }
+    }
+  }
+}`
+
+const issueParentsLabelQuery = `
+query DetentGitHubIssueParentsLabel(
+  $issueId: ID!
+  $trackedInAfter: String
+  $linkedIssuesFirst: Int!
+) {
+  node(id: $issueId) {
+    ... on Issue {
+      id
+      number
+      repository { nameWithOwner }
+      parent {
+        ...DetentGitHubIssueParentLabel
+      }
+      trackedInIssues(first: 100, after: $trackedInAfter) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          ...DetentGitHubIssueParentLabel
+        }
+      }
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}
+
+fragment DetentGitHubIssueParentLabel on Issue {
+  __typename
+  id
+  number
+  title
+  body
+  state
+  stateReason
+  url
+  createdAt
+  updatedAt
+  author { login }
+  assignees(first: 100) { nodes { id login } }
+  labels(first: 20) { nodes { name } }
+  repository { nameWithOwner }
+  closedByPullRequestsReferences(first: 5) { nodes { number url state repository { nameWithOwner } } }
+  subIssues(first: $linkedIssuesFirst) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      number
+      title
+      state
+      url
+      labels(first: 20) { nodes { name } }
+      repository { nameWithOwner }
+    }
+  }
+  trackedIssues(first: $linkedIssuesFirst) {
+    pageInfo { hasNextPage endCursor }
+    nodes {
+      id
+      number
+      title
+      state
+      url
+      labels(first: 20) { nodes { name } }
+      repository { nameWithOwner }
     }
   }
 }`
@@ -557,6 +666,7 @@ type linkedIssue struct {
 	Title        string                  `json:"title"`
 	State        string                  `json:"state"`
 	URL          string                  `json:"url"`
+	Labels       nodeConnection[label]   `json:"labels"`
 	Repository   repository              `json:"repository"`
 	ProjectItems *projectItemsConnection `json:"projectItems"`
 }
@@ -643,6 +753,7 @@ type restIssue struct {
 	User        *actor         `json:"user"`
 	Assignees   []restAssignee `json:"assignees"`
 	Labels      []label        `json:"labels"`
+	PullRequest *struct{}      `json:"pull_request"`
 }
 
 type restIssueSearchResponse struct {
@@ -737,6 +848,16 @@ type projectField struct {
 }
 
 func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	if c.usesLabelStatus() {
+		issues, err := c.fetchLabelIssuesByStates(ctx, c.activeStates, 0)
+		if err != nil {
+			return nil, err
+		}
+		if err := c.attachPullRequests(ctx, issues); err != nil {
+			return nil, err
+		}
+		return issues, nil
+	}
 	if c.usesIssueFieldStatus() {
 		issues, err := c.fetchIssueFieldIssuesByStates(ctx, c.activeStates, 0)
 		if err != nil {
@@ -767,6 +888,23 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 	wantedStates := normalizedStateSet(stateNames)
 	if len(wantedStates) == 0 {
 		return []connector.Issue{}, nil
+	}
+	if c.usesLabelStatus() {
+		issues, err := c.fetchLabelIssuesByStates(ctx, stateNames, 0)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
+			if err := c.populateBlockerReasons(ctx, issues); err != nil {
+				return nil, err
+			}
+		}
+		if attachPullRequestsForStates(wantedStates) {
+			if err := c.attachPullRequests(ctx, issues); err != nil {
+				return nil, err
+			}
+		}
+		return issues, nil
 	}
 	if c.usesIssueFieldStatus() {
 		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, 0)
@@ -817,6 +955,23 @@ func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []s
 	if len(wantedStates) == 0 {
 		return []connector.Issue{}, nil
 	}
+	if c.usesLabelStatus() {
+		issues, err := c.fetchLabelIssuesByStates(ctx, stateNames, limit)
+		if err != nil {
+			return nil, err
+		}
+		if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
+			if err := c.populateBlockerReasons(ctx, issues); err != nil {
+				return nil, err
+			}
+		}
+		if attachPullRequestsForStates(wantedStates) {
+			if err := c.attachPullRequests(ctx, issues); err != nil {
+				return nil, err
+			}
+		}
+		return issues, nil
+	}
 	if c.usesIssueFieldStatus() {
 		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, limit)
 		if err != nil {
@@ -859,6 +1014,9 @@ func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []s
 }
 
 func (c *Connector) VerifyStatusOptions(ctx context.Context, stateNames []string) error {
+	if c.usesLabelStatus() {
+		return c.verifyLabelStatusOptions(ctx, stateNames)
+	}
 	if c.usesIssueFieldStatus() {
 		return c.verifyIssueFieldStatusOptions(ctx, stateNames)
 	}
@@ -891,6 +1049,29 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 	ids := uniqueNonBlank(issueIDs)
 	if len(ids) == 0 {
 		return []connector.Issue{}, nil
+	}
+	if c.usesLabelStatus() {
+		refs, err := c.issueRefsForIDs(ctx, ids, graphQLQueryRunningStates)
+		if err != nil {
+			return nil, err
+		}
+
+		issues := make([]connector.Issue, 0, len(ids))
+		for _, id := range ids {
+			ref, ok := refs[id]
+			if !ok {
+				continue
+			}
+			issue, ok, err := c.fetchLabelIssueByRef(ctx, ref)
+			if err != nil {
+				return nil, fmt.Errorf("fetch github issue states by ids: %w", err)
+			}
+			if ok {
+				issues = append(issues, issue)
+			}
+		}
+		sortIssuesByRequestedIDs(issues, ids)
+		return issues, nil
 	}
 	if c.usesIssueFieldStatus() {
 		refs, err := c.issueRefsForIDs(ctx, ids, graphQLQueryRunningStates)
@@ -980,7 +1161,8 @@ func (c *Connector) FetchIssueParents(ctx context.Context, issueID string) ([]co
 		var response struct {
 			Node *issueParentsNode `json:"node"`
 		}
-		if err := c.client.GraphQLWithType(ctx, graphQLQueryIssueParents, issueParentsQuery, map[string]any{
+		query := issueParentsQuery
+		variables := map[string]any{
 			"issueId":                           issueID,
 			"trackedInAfter":                    after,
 			"projectItemsFirst":                 projectItemsPerIssue,
@@ -988,7 +1170,16 @@ func (c *Connector) FetchIssueParents(ctx context.Context, issueID string) ([]co
 			"linkedIssuesFirst":                 linkedIssuePageSize,
 			"linkedProjectItemsFirst":           linkedIssueProjectItemsPageSize,
 			"linkedProjectItemFieldValuesFirst": linkedIssueProjectItemFieldValuesPageSize,
-		}, &response); err != nil {
+		}
+		if c.usesLabelStatus() {
+			query = issueParentsLabelQuery
+			variables = map[string]any{
+				"issueId":           issueID,
+				"trackedInAfter":    after,
+				"linkedIssuesFirst": linkedIssuePageSize,
+			}
+		}
+		if err := c.client.GraphQLWithType(ctx, graphQLQueryIssueParents, query, variables, &response); err != nil {
 			return nil, fmt.Errorf("fetch github issue parents: %w", err)
 		}
 		if response.Node == nil {
@@ -1055,11 +1246,18 @@ func (c *Connector) appendBodyReferencedIssueParents(
 			if !ok || sameIssueRef(ref, childRef) {
 				continue
 			}
-			issue, ok, err := c.fetchProjectIssueByRef(ctx, ref)
+			var issue connector.Issue
+			var found bool
+			var err error
+			if c.usesLabelStatus() || c.usesIssueFieldStatus() {
+				issue, found, err = c.fetchIssueByRef(ctx, ref)
+			} else {
+				issue, found, err = c.fetchProjectIssueByRef(ctx, ref)
+			}
 			if err != nil {
 				return nil, err
 			}
-			if !ok || !githubEpicIssue(issue) {
+			if !found || !githubEpicIssue(issue) {
 				continue
 			}
 			if !bodyReferencesIssue(issue.Description, issueRepo(issue.Identifier), childIdentifier) {
@@ -1113,12 +1311,18 @@ func (c *Connector) FetchIssueChildren(ctx context.Context, issueID string) ([]c
 
 	seen := map[string]struct{}{}
 	children := []connector.BlockedRef{}
-	subIssues, err := c.fetchLinkedIssueRefs(ctx, issueID, issueSubIssuesQuery, "subIssues")
+	subIssuesQuery := issueSubIssuesQuery
+	trackedIssuesQuery := issueTrackedIssuesQuery
+	if c.usesLabelStatus() {
+		subIssuesQuery = issueSubIssuesLabelQuery
+		trackedIssuesQuery = issueTrackedIssuesLabelQuery
+	}
+	subIssues, err := c.fetchLinkedIssueRefs(ctx, issueID, subIssuesQuery, "subIssues")
 	if err != nil {
 		return nil, err
 	}
 	children = appendUniqueLinkedIssueRefs(children, seen, subIssues)
-	trackedIssues, err := c.fetchLinkedIssueRefs(ctx, issueID, issueTrackedIssuesQuery, "trackedIssues")
+	trackedIssues, err := c.fetchLinkedIssueRefs(ctx, issueID, trackedIssuesQuery, "trackedIssues")
 	if err != nil {
 		return nil, err
 	}
@@ -1272,6 +1476,9 @@ func (c *Connector) fetchIssueRefsByID(ctx context.Context, ids []string, queryT
 }
 
 func (c *Connector) fetchIssueByRef(ctx context.Context, ref issueRef) (connector.Issue, bool, error) {
+	if c.usesLabelStatus() {
+		return c.fetchLabelIssueByRef(ctx, ref)
+	}
 	if c.usesIssueFieldStatus() {
 		return c.fetchIssueFieldIssueByRef(ctx, ref)
 	}
@@ -1462,6 +1669,30 @@ func (c *Connector) CloseIssue(ctx context.Context, issueID string) error {
 }
 
 func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateName string) error {
+	if c.usesLabelStatus() {
+		ref, ok, err := c.issueRefForID(ctx, strings.TrimSpace(issueID), graphQLQueryIssueLookup)
+		if err != nil {
+			return err
+		}
+		if !ok {
+			return ErrStatusUpdateFailed
+		}
+		issue, err := c.fetchRESTIssue(ctx, ref)
+		if err != nil {
+			return err
+		}
+		if strings.TrimSpace(issue.ID) == "" {
+			return ErrStatusUpdateFailed
+		}
+		currentStatus := c.labelStatusFromLabels(issue.Labels)
+		if currentStatus == "" {
+			currentStatus = c.githubIssueStateToDetentState(issue.State)
+		}
+		if c.terminalStatusUpdateBlocked(currentStatus, stateName) {
+			return nil
+		}
+		return c.updateIssueStatusLabel(ctx, ref, issue, stateName)
+	}
 	if c.usesIssueFieldStatus() {
 		ref, ok, err := c.issueRefForID(ctx, strings.TrimSpace(issueID), graphQLQueryIssueLookup)
 		if err != nil {
@@ -2218,6 +2449,13 @@ func (c *Connector) normalizeIssueNode(ctx context.Context, issue githubIssueNod
 	if issue.TypeName != "Issue" {
 		return connector.Issue{}, false, nil
 	}
+	if c.usesLabelStatus() {
+		statusName := c.labelStatusFromLabels(issue.Labels)
+		if statusName == "" {
+			statusName = c.githubIssueStateToDetentState(issue.State)
+		}
+		return c.buildIssue(issue, statusName, "", nil, map[string]string{c.statusField: statusName}), true, nil
+	}
 	stateName, priorityName, statusUpdatedAt, fields, ok, err := c.resolveIssueProjectFields(ctx, issue.ID, issue.ProjectItems)
 	if err != nil {
 		return connector.Issue{}, false, err
@@ -2365,6 +2603,13 @@ func (c *Connector) appendLinkedChildIssues(
 }
 
 func (c *Connector) linkedChildIssueState(child linkedIssue) string {
+	if c.usesLabelStatus() {
+		statusName := c.labelStatusFromLabels(child.Labels)
+		if statusName != "" {
+			return c.githubToDetentState(statusName)
+		}
+		return c.githubIssueStateToDetentState(child.State)
+	}
 	state := c.githubIssueStateToDetentState(child.State)
 	if stateName, _, _, _, ok := c.projectFields(child.ID, child.ProjectItems); ok {
 		if stateName = strings.TrimSpace(stateName); stateName != "" {

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -22,9 +22,11 @@ query DetentGitHubAuthenticate($projectId: ID!) {
 }`
 
 const (
-	GitHubStatusSourceProjectV2   = "project_v2"
-	GitHubStatusSourceIssueField  = "issue_field"
-	defaultGitHubIssueStatusField = "Status"
+	GitHubStatusSourceProjectV2    = "project_v2"
+	GitHubStatusSourceIssueField   = "issue_field"
+	GitHubStatusSourceLabel        = "label"
+	defaultGitHubIssueStatusField  = "Status"
+	defaultGitHubStatusLabelPrefix = "detent:"
 )
 
 const (
@@ -58,6 +60,7 @@ type Config struct {
 	ProjectSlug             string
 	Repository              string
 	StatusField             string
+	StatusLabelPrefix       string
 	ActiveStates            []string
 	ObservedStates          []string
 	TerminalStates          []string
@@ -73,22 +76,23 @@ type Config struct {
 }
 
 type Connector struct {
-	client         *Client
-	statusSource   string
-	projectID      string
-	repository     pullRequestRepo
-	statusField    string
-	activeStates   []string
-	observedStates []string
-	terminalStates []string
-	stateMap       map[string]string
-	priorityMap    map[string]*int
-	statusCache    *statusCache
-	issueFields    *issueFieldCache
-	projectCache   *projectCache
-	mu             sync.RWMutex
-	writeMu        sync.Mutex
-	instanceLogin  string
+	client            *Client
+	statusSource      string
+	projectID         string
+	repository        pullRequestRepo
+	statusField       string
+	statusLabelPrefix string
+	activeStates      []string
+	observedStates    []string
+	terminalStates    []string
+	stateMap          map[string]string
+	priorityMap       map[string]*int
+	statusCache       *statusCache
+	issueFields       *issueFieldCache
+	projectCache      *projectCache
+	mu                sync.RWMutex
+	writeMu           sync.Mutex
+	instanceLogin     string
 }
 
 func NewConnector(cfg Config) (*Connector, error) {
@@ -127,22 +131,27 @@ func NewConnector(cfg Config) (*Connector, error) {
 	if statusField == "" {
 		statusField = defaultGitHubIssueStatusField
 	}
+	statusLabelPrefix := strings.TrimSpace(cfg.StatusLabelPrefix)
+	if statusLabelPrefix == "" {
+		statusLabelPrefix = defaultGitHubStatusLabelPrefix
+	}
 	repository, _ := pullRequestRepoFromName(cfg.Repository)
 
 	return &Connector{
-		client:         client,
-		statusSource:   normalizeGitHubStatusSource(cfg.GitHubStatusSource),
-		projectID:      strings.TrimSpace(cfg.ProjectSlug),
-		repository:     repository,
-		statusField:    statusField,
-		activeStates:   normalizeStateList(cfg.ActiveStates, []string{"Todo", "In Progress"}),
-		observedStates: normalizeStateList(cfg.ObservedStates, nil),
-		terminalStates: normalizeStateList(cfg.TerminalStates, []string{"Done", "Cancelled", "Canceled", "Closed"}),
-		stateMap:       cloneStateMap(cfg.StateMap),
-		priorityMap:    clonePriorityMapWithDefault(cfg.PriorityMap),
-		statusCache:    newStatusCache(githubCacheTTL, cfg.Now),
-		issueFields:    newIssueFieldCache(githubCacheTTL, cfg.Now),
-		projectCache:   newProjectCache(githubCacheTTL, cfg.Now),
+		client:            client,
+		statusSource:      normalizeGitHubStatusSource(cfg.GitHubStatusSource),
+		projectID:         strings.TrimSpace(cfg.ProjectSlug),
+		repository:        repository,
+		statusField:       statusField,
+		statusLabelPrefix: statusLabelPrefix,
+		activeStates:      normalizeStateList(cfg.ActiveStates, []string{"Todo", "In Progress"}),
+		observedStates:    normalizeStateList(cfg.ObservedStates, nil),
+		terminalStates:    normalizeStateList(cfg.TerminalStates, []string{"Done", "Cancelled", "Canceled", "Closed"}),
+		stateMap:          cloneStateMap(cfg.StateMap),
+		priorityMap:       clonePriorityMapWithDefault(cfg.PriorityMap),
+		statusCache:       newStatusCache(githubCacheTTL, cfg.Now),
+		issueFields:       newIssueFieldCache(githubCacheTTL, cfg.Now),
+		projectCache:      newProjectCache(githubCacheTTL, cfg.Now),
 	}, nil
 }
 
@@ -177,7 +186,7 @@ func (c *Connector) Close() error {
 }
 
 func (c *Connector) Authenticate(ctx context.Context) error {
-	if c.usesIssueFieldStatus() {
+	if c.usesIssueFieldStatus() || c.usesLabelStatus() {
 		return c.authenticateIssueField(ctx)
 	}
 	if c.projectID == "" {
@@ -216,6 +225,8 @@ func normalizeGitHubStatusSource(value string) string {
 		return GitHubStatusSourceProjectV2
 	case GitHubStatusSourceIssueField, "issuefield", "issues":
 		return GitHubStatusSourceIssueField
+	case GitHubStatusSourceLabel, "labels", "issue_label", "issue_labels":
+		return GitHubStatusSourceLabel
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}
@@ -223,6 +234,10 @@ func normalizeGitHubStatusSource(value string) string {
 
 func (c *Connector) usesIssueFieldStatus() bool {
 	return c != nil && c.statusSource == GitHubStatusSourceIssueField
+}
+
+func (c *Connector) usesLabelStatus() bool {
+	return c != nil && c.statusSource == GitHubStatusSourceLabel
 }
 
 func (c *Connector) InstanceLogin() string {

--- a/internal/connector/github/provision.go
+++ b/internal/connector/github/provision.go
@@ -129,6 +129,9 @@ func (c *Connector) Provision(ctx context.Context) error {
 }
 
 func (c *Connector) EnsureStateOptions(ctx context.Context) error {
+	if c.usesLabelStatus() {
+		return c.EnsureLabelStateOptions(ctx)
+	}
 	if c.usesIssueFieldStatus() {
 		return c.EnsureIssueFieldStateOptions(ctx)
 	}

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -43,6 +43,7 @@ type ReadinessConfig struct {
 	RequirePullRequestChecks      bool
 	RequireProjectStatusWrite     bool
 	RequireIssueFieldStatusWrite  bool
+	RequireLabelStatusWrite       bool
 	RequireIssueComments          bool
 	RequireAssigneeWrite          bool
 	RequireIssueClose             bool
@@ -94,7 +95,12 @@ func (c githubReadinessChecker) Check(ctx context.Context, cfg ReadinessConfig) 
 	if hasGitHubAppCredentials(c.cfg, c.cfg.LookupEnv) {
 		checks = append(checks, c.appInstallationCheck(ctx, cfg))
 	}
-	if c.connector.usesIssueFieldStatus() {
+	if c.connector.usesLabelStatus() {
+		checks = append(checks,
+			c.labelStatusOptionsCheck(ctx, cfg.StatusStates),
+			c.labelIssuesReadCheck(ctx, cfg.ReadStates),
+		)
+	} else if c.connector.usesIssueFieldStatus() {
 		checks = append(checks,
 			c.issueFieldAccessCheck(ctx),
 			c.issueFieldStatusOptionsCheck(ctx, cfg.StatusStates),
@@ -360,6 +366,55 @@ func (c githubReadinessChecker) issueFieldIssuesReadCheck(ctx context.Context, s
 		Name:   "GitHub issue field issue read",
 		Status: ReadinessOK,
 		Detail: fmt.Sprintf("read issues for %d configured state(s); sampled %d issue(s)", len(states), len(issues)),
+	}
+}
+
+func (c githubReadinessChecker) labelStatusOptionsCheck(ctx context.Context, states []string) ReadinessCheck {
+	states = uniqueNonBlank(states)
+	if len(states) == 0 {
+		return ReadinessCheck{
+			Name:   "GitHub status label mappings",
+			Status: ReadinessOK,
+			Detail: "skipped because no tracker states are configured",
+		}
+	}
+	if err := c.connector.verifyLabelStatusOptions(ctx, states); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub status label mappings",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("cannot resolve required status labels in %s/%s: %v", c.connector.repository.Owner, c.connector.repository.Name, err),
+			Hint:   "Run Detent provisioning or create the missing repository labels, then rerun detent doctor.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub status label mappings",
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("resolved %d configured status label(s) with prefix %q", len(states), c.connector.statusLabelPrefix),
+	}
+}
+
+func (c githubReadinessChecker) labelIssuesReadCheck(ctx context.Context, states []string) ReadinessCheck {
+	states = uniqueNonBlank(states)
+	if len(states) == 0 {
+		return ReadinessCheck{
+			Name:   "GitHub status label issue read",
+			Status: ReadinessOK,
+			Detail: "skipped because no active or observed tracker states are configured",
+		}
+	}
+	issues, err := c.connector.fetchLabelIssuesByStates(ctx, states, 5)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub status label issue read",
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("cannot read issues for configured status labels in %s/%s: %v", c.connector.repository.Owner, c.connector.repository.Name, err),
+			Hint:   "Grant Issues repository read permission and confirm status labels exist.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub status label issue read",
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("read issues for %d configured label state(s); sampled %d issue(s)", len(states), len(issues)),
 	}
 }
 
@@ -648,7 +703,7 @@ func (c githubReadinessChecker) resolveWriteProbe(ctx context.Context, cfg Readi
 			Name:   "GitHub write probe target",
 			Status: ReadinessFail,
 			Detail: probeID + ": " + err.Error(),
-			Hint:   "Set tracker.write_probe_issue to a scratch issue that belongs to the configured ProjectV2 board.",
+			Hint:   "Set tracker.write_probe_issue to a scratch issue in the configured repository.",
 		}
 		return readinessProbeIssue{}, false, &check
 	}
@@ -668,6 +723,8 @@ func (cfg ReadinessConfig) requiresProbeIssue() bool {
 
 func (cfg ReadinessConfig) requiresWriteProbe() bool {
 	return cfg.RequireProjectStatusWrite ||
+		cfg.RequireLabelStatusWrite ||
+		cfg.RequireIssueFieldStatusWrite ||
 		cfg.RequireIssueComments ||
 		cfg.RequireAssigneeWrite ||
 		cfg.RequireIssueClose ||
@@ -761,6 +818,9 @@ func (c githubReadinessChecker) writeChecks(ctx context.Context, cfg ReadinessCo
 	}
 	if cfg.RequireIssueFieldStatusWrite {
 		checks = append(checks, c.issueFieldStatusWriteCheck(ctx, probe, hasProbe))
+	}
+	if cfg.RequireLabelStatusWrite {
+		checks = append(checks, c.labelStatusWriteCheck(ctx, probe, hasProbe))
 	}
 	if cfg.RequireIssueComments {
 		checks = append(checks, c.issueCommentWriteCheck(ctx, probe, hasProbe))
@@ -920,6 +980,43 @@ func (c githubReadinessChecker) issueFieldStatusWriteCheck(ctx context.Context, 
 		Name:   "GitHub issue field Status update",
 		Status: ReadinessOK,
 		Detail: "reapplied existing issue field Status value on the write probe issue",
+	}
+}
+
+func (c githubReadinessChecker) labelStatusWriteCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
+	if !hasProbe {
+		return unprovenWriteCheck("GitHub status label update")
+	}
+	issue, err := c.connector.fetchRESTIssue(ctx, probe.Ref)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub status label update",
+			Status: ReadinessFail,
+			Detail: "token cannot read current labels for probe issue: " + err.Error(),
+			Hint:   "Grant Issues repository read permission for the probe issue repository.",
+		}
+	}
+	statusName := c.connector.labelStatusFromLabels(issue.Labels)
+	if strings.TrimSpace(statusName) == "" {
+		return ReadinessCheck{
+			Name:   "GitHub status label update",
+			Status: ReadinessWarn,
+			Detail: "write probe issue has no current Detent status label; label update was not executed",
+			Hint:   "Set one configured status label on the scratch issue, then rerun detent doctor.",
+		}
+	}
+	if err := c.connector.updateIssueStatusLabel(ctx, probe.Ref, issue, statusName); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub status label update",
+			Status: ReadinessFail,
+			Detail: "token cannot update status labels: " + err.Error(),
+			Hint:   "Grant Issues repository write permission for the probe issue repository.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub status label update",
+		Status: ReadinessOK,
+		Detail: "reapplied existing status label on the write probe issue",
 	}
 }
 
@@ -1132,7 +1229,7 @@ func missingInstallationPermissions(details InstallationTokenDetails, cfg Readin
 		missing = append(missing, "Issue Fields: read")
 	}
 	issueLevel := "read"
-	if cfg.RequireIssueFieldStatusWrite || cfg.RequireIssueComments || cfg.RequireAssigneeWrite || cfg.RequireIssueClose {
+	if cfg.RequireIssueFieldStatusWrite || cfg.RequireLabelStatusWrite || cfg.RequireIssueComments || cfg.RequireAssigneeWrite || cfg.RequireIssueClose {
 		issueLevel = "write"
 	}
 	if !permissionAllows(details.Permissions["issues"], issueLevel) {

--- a/internal/connector/github/readiness_test.go
+++ b/internal/connector/github/readiness_test.go
@@ -386,6 +386,56 @@ func TestReadinessGitHubAppInstallationIssueFieldModeSkipsProjectsPermission(t *
 	}
 }
 
+func TestReadinessGitHubAppInstallationLabelModeSkipsProjectAndIssueFieldPermissions(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 13, 12, 0, 0, 0, time.UTC)
+	privateKey := testPrivateKeyPEM(t)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/app/installations/987/access_tokens" {
+			t.Fatalf("path = %s, want installation token path", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		response := map[string]any{
+			"token":                "installation-token",
+			"expires_at":           now.Add(time.Hour).Format(time.RFC3339),
+			"repository_selection": "all",
+			"permissions": map[string]string{
+				"issues": "read",
+			},
+		}
+		if err := json.NewEncoder(w).Encode(response); err != nil {
+			t.Fatalf("Encode() error = %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	checker := githubReadinessChecker{cfg: Config{
+		Endpoint:                server.URL + "/graphql",
+		HTTPClient:              server.Client(),
+		GitHubAppID:             "123",
+		GitHubAppInstallationID: "987",
+		GitHubAppPrivateKey:     privateKey,
+		Now:                     func() time.Time { return now },
+	}}
+
+	got := checker.appInstallationCheck(context.Background(), ReadinessConfig{
+		RequireLabelStatusWrite: true,
+		Repositories:            []string{"digitaldrywood/detent"},
+	})
+	if got.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessFail, got)
+	}
+	if !strings.Contains(got.Detail, "Issues: write") {
+		t.Fatalf("Detail = %q, want Issues write requirement", got.Detail)
+	}
+	for _, forbidden := range []string{"Projects", "Issue Fields"} {
+		if strings.Contains(got.Detail, forbidden) {
+			t.Fatalf("Detail = %q, want no %s permission requirement in label mode", got.Detail, forbidden)
+		}
+	}
+}
+
 func TestReadinessUnconfiguredProbeIssueWarns(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -1,0 +1,308 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"net/url"
+	"strconv"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const repositoryIssuesPageSize = 100
+
+func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []string, limit int) ([]connector.Issue, error) {
+	if !validPullRequestRepo(c.repository) {
+		return nil, ErrMissingRepository
+	}
+	stateLabels := c.statusLabelStates(stateNames)
+	if len(stateLabels) == 0 {
+		return []connector.Issue{}, nil
+	}
+
+	issues := []connector.Issue{}
+	seen := map[string]struct{}{}
+	for _, stateName := range stateNames {
+		labelName := c.statusLabelForState(stateName)
+		externalState, ok := stateLabels[normalizeLabelName(labelName)]
+		if !ok {
+			continue
+		}
+		for page := 1; ; page++ {
+			var response []restIssue
+			if err := c.client.REST(ctx, http.MethodGet, restRepositoryIssuesByLabelPath(c.repository, labelName, page), nil, &response); err != nil {
+				return nil, fmt.Errorf("fetch github label issues: %w", err)
+			}
+			if len(response) == 0 {
+				break
+			}
+			for _, item := range response {
+				if item.PullRequest != nil {
+					continue
+				}
+				ref := issueRef{Owner: c.repository.Owner, Name: c.repository.Name, Number: item.Number}
+				issue := githubIssueNodeFromREST(ref, item)
+				if strings.TrimSpace(issue.ID) == "" {
+					continue
+				}
+				if githubIssueClosed(issue.State) && !stateInList(c.githubToDetentState(externalState), c.terminalStates) {
+					continue
+				}
+				if _, ok := seen[issue.ID]; ok {
+					continue
+				}
+				seen[issue.ID] = struct{}{}
+				c.cacheIssueRef(issue)
+				issues = append(issues, c.buildIssue(issue, externalState, "", nil, map[string]string{
+					c.statusField: externalState,
+				}))
+				if limit > 0 && len(issues) >= limit {
+					resolveBlockedByProjectState(issues)
+					return issues, nil
+				}
+			}
+			if len(response) < repositoryIssuesPageSize {
+				break
+			}
+		}
+	}
+	resolveBlockedByProjectState(issues)
+	return issues, nil
+}
+
+func (c *Connector) fetchLabelIssueByRef(ctx context.Context, ref issueRef) (connector.Issue, bool, error) {
+	issue, err := c.fetchRESTIssue(ctx, ref)
+	if err != nil {
+		return connector.Issue{}, false, err
+	}
+	if strings.TrimSpace(issue.ID) == "" {
+		return connector.Issue{}, false, nil
+	}
+	c.cacheIssueRef(issue)
+	statusName := c.labelStatusFromLabels(issue.Labels)
+	if statusName == "" {
+		statusName = c.githubIssueStateToDetentState(issue.State)
+	}
+	return c.buildIssue(issue, statusName, "", nil, map[string]string{c.statusField: statusName}), true, nil
+}
+
+func (c *Connector) updateIssueStatusLabel(ctx context.Context, ref issueRef, issue githubIssueNode, targetState string) error {
+	targetLabel := c.statusLabelForState(targetState)
+	if targetLabel == "" {
+		return ErrStatusUpdateFailed
+	}
+
+	currentLabels := labelNames(issue.Labels)
+	for _, labelName := range currentLabels {
+		if !c.isStatusLabel(labelName) || strings.EqualFold(labelName, targetLabel) {
+			continue
+		}
+		var response []label
+		if err := c.client.REST(ctx, http.MethodDelete, restIssueLabelPath(ref, labelName), nil, &response); err != nil {
+			return fmt.Errorf("remove github status label: %w", err)
+		}
+	}
+	if stringSliceContainsFold(currentLabels, targetLabel) {
+		return nil
+	}
+
+	var response []label
+	if err := c.client.REST(ctx, http.MethodPost, restIssueLabelsPath(ref), map[string]any{
+		"labels": []string{targetLabel},
+	}, &response); err != nil {
+		return fmt.Errorf("add github status label: %w", err)
+	}
+	if len(response) == 0 {
+		return ErrStatusUpdateFailed
+	}
+	return nil
+}
+
+func (c *Connector) EnsureLabelStateOptions(ctx context.Context) error {
+	if !validPullRequestRepo(c.repository) {
+		return ErrMissingRepository
+	}
+	existing, err := fetchRESTList[label](ctx, c.client, restRepositoryLabelsListPath(c.repository))
+	if err != nil {
+		return fmt.Errorf("fetch github labels: %w", err)
+	}
+	seen := map[string]struct{}{}
+	for _, label := range existing {
+		seen[normalizeLabelName(label.Name)] = struct{}{}
+	}
+	for _, stateName := range c.configuredStatusStates() {
+		labelName := c.statusLabelForState(stateName)
+		if labelName == "" {
+			continue
+		}
+		if _, ok := seen[normalizeLabelName(labelName)]; ok {
+			continue
+		}
+		option := statusOptionDefaults(stateName)
+		var response label
+		if err := c.client.REST(ctx, http.MethodPost, restRepositoryLabelsPath(c.repository), map[string]any{
+			"name":        labelName,
+			"color":       statusLabelColor(option.Color),
+			"description": strings.TrimSpace(option.Description),
+		}, &response); err != nil {
+			return fmt.Errorf("create github status label: %w", err)
+		}
+		if strings.TrimSpace(response.Name) == "" {
+			return ErrStatusOptionNotFound
+		}
+		seen[normalizeLabelName(labelName)] = struct{}{}
+	}
+	return nil
+}
+
+func (c *Connector) verifyLabelStatusOptions(ctx context.Context, stateNames []string) error {
+	if !validPullRequestRepo(c.repository) {
+		return ErrMissingRepository
+	}
+	existing, err := fetchRESTList[label](ctx, c.client, restRepositoryLabelsListPath(c.repository))
+	if err != nil {
+		return fmt.Errorf("fetch github labels: %w", err)
+	}
+	seen := map[string]struct{}{}
+	for _, label := range existing {
+		seen[normalizeLabelName(label.Name)] = struct{}{}
+	}
+	for _, stateName := range stateNames {
+		labelName := c.statusLabelForState(stateName)
+		if labelName == "" {
+			continue
+		}
+		if _, ok := seen[normalizeLabelName(labelName)]; !ok {
+			return fmt.Errorf("%w: %s maps to %s", ErrStatusOptionNotFound, stateName, labelName)
+		}
+	}
+	return nil
+}
+
+func (c *Connector) statusLabelStates(stateNames []string) map[string]string {
+	out := map[string]string{}
+	for _, stateName := range stateNames {
+		stateName = strings.TrimSpace(stateName)
+		if stateName == "" {
+			continue
+		}
+		externalState := c.detentToGitHubState(stateName)
+		labelName := c.statusLabelForExternalState(externalState)
+		if labelName == "" {
+			continue
+		}
+		out[normalizeLabelName(labelName)] = externalState
+	}
+	return out
+}
+
+func (c *Connector) labelStatusFromLabels(labels nodeConnection[label]) string {
+	statesByLabel := c.statusLabelStates(c.configuredStatusStates())
+	for _, labelName := range labelNames(labels) {
+		if stateName, ok := statesByLabel[normalizeLabelName(labelName)]; ok {
+			return stateName
+		}
+	}
+	return ""
+}
+
+func (c *Connector) configuredStatusStates() []string {
+	return appendStatusStates(nil, c.activeStates, c.observedStates, c.terminalStates, []string{defaultProjectItemStatusState})
+}
+
+func (c *Connector) statusLabelForState(stateName string) string {
+	return c.statusLabelForExternalState(c.detentToGitHubState(stateName))
+}
+
+func (c *Connector) statusLabelForExternalState(stateName string) string {
+	slug := statusLabelSlug(stateName)
+	if slug == "" {
+		return ""
+	}
+	return c.statusLabelPrefix + slug
+}
+
+func (c *Connector) isStatusLabel(labelName string) bool {
+	return strings.HasPrefix(strings.ToLower(strings.TrimSpace(labelName)), strings.ToLower(c.statusLabelPrefix))
+}
+
+func statusLabelSlug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastSeparator := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastSeparator = false
+		default:
+			if b.Len() == 0 || lastSeparator {
+				continue
+			}
+			b.WriteByte('-')
+			lastSeparator = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func statusLabelColor(color string) string {
+	switch strings.ToUpper(strings.TrimSpace(color)) {
+	case "RED":
+		return "d73a4a"
+	case "ORANGE":
+		return "d93f0b"
+	case "YELLOW":
+		return "fbca04"
+	case "PURPLE":
+		return "6f42c1"
+	case "GREEN":
+		return "0e8a16"
+	case "BLUE":
+		return "5319e7"
+	default:
+		return "cfd3d7"
+	}
+}
+
+func normalizeLabelName(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func stringSliceContainsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(want)) {
+			return true
+		}
+	}
+	return false
+}
+
+func restRepositoryLabelsPath(repo pullRequestRepo) string {
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/labels"
+}
+
+func restRepositoryLabelsListPath(repo pullRequestRepo) string {
+	values := url.Values{}
+	values.Set("per_page", "100")
+	return restRepositoryLabelsPath(repo) + "?" + values.Encode()
+}
+
+func restRepositoryIssuesByLabelPath(repo pullRequestRepo, labelName string, page int) string {
+	values := url.Values{}
+	values.Set("state", "all")
+	values.Set("labels", labelName)
+	values.Set("per_page", strconv.Itoa(repositoryIssuesPageSize))
+	values.Set("page", strconv.Itoa(page))
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/issues?" + values.Encode()
+}
+
+func restIssueLabelsPath(ref issueRef) string {
+	return restIssuePath(ref) + "/labels"
+}
+
+func restIssueLabelPath(ref issueRef, labelName string) string {
+	return restIssueLabelsPath(ref) + "/" + url.PathEscape(labelName)
+}

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -1,0 +1,243 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorFetchCandidateIssuesUsesStatusLabels(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Aready&page=1&per_page=100&state=all",
+			body:   `[{"node_id":"I_485","number":485,"title":"Installer packages","body":"Ship packages","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:ready"},{"name":"enhancement"}]}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo"},
+		StateMap:           map[string]string{"Todo": "Ready"},
+	})
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
+	}
+	want := connector.Issue{
+		ID:               "I_485",
+		Identifier:       "digitaldrywood/detent#485",
+		Title:            "Installer packages",
+		Description:      "Ship packages",
+		State:            "Todo",
+		URL:              "https://github.com/digitaldrywood/detent/issues/485",
+		BlockedBy:        []connector.BlockedRef{},
+		Labels:           []string{"detent:ready", "enhancement"},
+		Assignees:        []string{},
+		Fields:           map[string]string{"Status": "Ready"},
+		AssignedToWorker: true,
+	}
+	if !reflect.DeepEqual(got[0], want) {
+		t.Fatalf("FetchCandidateIssues()[0] = %#v, want %#v", got[0], want)
+	}
+}
+
+func TestConnectorUpdateIssueStateReplacesStatusLabels(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_485","number":485,"repository":{"nameWithOwner":"digitaldrywood/detent"}}]}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/485",
+			body:   `{"node_id":"I_485","number":485,"title":"Installer packages","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:todo"},{"name":"bug"}]}`,
+		},
+		{
+			method: http.MethodDelete,
+			path:   "/repos/digitaldrywood/detent/issues/485/labels/detent:todo",
+			body:   `[{"name":"bug"}]`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/repos/digitaldrywood/detent/issues/485/labels",
+			body:   `[{"name":"detent:in-progress"}]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo", "In Progress"},
+	})
+
+	if err := c.UpdateIssueState(context.Background(), "I_485", "In Progress"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want 4", len(requests))
+	}
+	body := requests[3]["body"].(map[string]any)
+	labels := body["labels"].([]any)
+	if !reflect.DeepEqual(labels, []any{"detent:in-progress"}) {
+		t.Fatalf("labels body = %#v, want detent:in-progress", labels)
+	}
+}
+
+func TestConnectorEnsureLabelStateOptionsCreatesMissingLabels(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/labels?per_page=100",
+			body:   `[{"name":"detent:todo"}]`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/repos/digitaldrywood/detent/labels",
+			body:   `{"name":"detent:in-progress"}`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/repos/digitaldrywood/detent/labels",
+			body:   `{"name":"detent:reviewing"}`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/repos/digitaldrywood/detent/labels",
+			body:   `{"name":"detent:done"}`,
+		},
+		{
+			method: http.MethodPost,
+			path:   "/repos/digitaldrywood/detent/labels",
+			body:   `{"name":"detent:backlog"}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo", "In Progress"},
+		ObservedStates:     []string{"Human Review"},
+		TerminalStates:     []string{"Done"},
+		StateMap:           map[string]string{"Human Review": "Reviewing"},
+	})
+
+	if err := c.EnsureStateOptions(context.Background()); err != nil {
+		t.Fatalf("EnsureStateOptions() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 5 {
+		t.Fatalf("request count = %d, want 5", len(requests))
+	}
+	got := []string{}
+	for _, request := range requests[1:] {
+		body := request["body"].(map[string]any)
+		got = append(got, body["name"].(string))
+	}
+	want := []string{"detent:in-progress", "detent:reviewing", "detent:done", "detent:backlog"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("created labels = %#v, want %#v", got, want)
+	}
+}
+
+func TestConnectorFetchIssueChildrenLabelModeAvoidsProjectItems(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"subIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"I_done","number":251,"title":"Done child","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/251","labels":{"nodes":[{"name":"detent:done"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"}}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"trackedIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"I_todo","number":252,"title":"Todo child","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/252","labels":{"nodes":[{"name":"detent:todo"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"}}]}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo"},
+		TerminalStates:     []string{"Done"},
+	})
+
+	got, err := c.FetchIssueChildren(context.Background(), "I_parent")
+	if err != nil {
+		t.Fatalf("FetchIssueChildren() error = %v", err)
+	}
+	want := []connector.BlockedRef{
+		{ID: "I_done", Identifier: "digitaldrywood/detent#251", State: "Done"},
+		{ID: "I_todo", Identifier: "digitaldrywood/detent#252", State: "Todo"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("FetchIssueChildren() = %#v, want %#v", got, want)
+	}
+
+	for index, request := range server.requests() {
+		if query := request["query"].(string); containsProjectItems(query) {
+			t.Fatalf("request %d query contains projectItems:\n%s", index, query)
+		}
+	}
+}
+
+func TestConnectorFetchIssueParentsLabelModeAvoidsProjectItems(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"id":"I_child","number":251,"repository":{"nameWithOwner":"digitaldrywood/detent"},"parent":{"__typename":"Issue","id":"I_parent","number":258,"title":"Epic: Parent","body":"- [ ] #251","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/258","createdAt":null,"updatedAt":null,"author":{"login":"corylanou"},"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"detent:todo"},{"name":"epic"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]},"subIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"I_child","number":251,"title":"Child","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/251","labels":{"nodes":[{"name":"detent:done"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"}}]},"trackedIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}},"trackedInIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/search/issues?page=1&per_page=100&q=user%3Adigitaldrywood+is%3Aissue+is%3Aopen+251",
+			body:   `{"total_count":0,"items":[]}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo"},
+		TerminalStates:     []string{"Done"},
+	})
+
+	got, err := c.FetchIssueParents(context.Background(), "I_child")
+	if err != nil {
+		t.Fatalf("FetchIssueParents() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssueParents() len = %d, want 1", len(got))
+	}
+	if got[0].ID != "I_parent" || got[0].State != "Todo" {
+		t.Fatalf("parent = %#v, want label-backed Todo parent", got[0])
+	}
+	if got[0].ChildIssues[0] != (connector.BlockedRef{ID: "I_child", Identifier: "digitaldrywood/detent#251", State: "Done"}) {
+		t.Fatalf("parent child issue = %#v, want label-backed Done child", got[0].ChildIssues[0])
+	}
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want parent query and body-reference search", len(requests))
+	}
+	if query := requests[0]["query"].(string); containsProjectItems(query) {
+		t.Fatalf("parent query contains projectItems:\n%s", query)
+	}
+}
+
+func containsProjectItems(query string) bool {
+	return strings.Contains(query, "projectItems")
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -880,6 +880,7 @@ func defaultConnectorFactory(cfg workflowconfig.Config) (connector.Connector, er
 		ProjectSlug:             cfg.Tracker.ProjectSlug,
 		Repository:              cfg.Tracker.Repository,
 		StatusField:             cfg.Tracker.StatusField,
+		StatusLabelPrefix:       cfg.Tracker.StatusLabelPrefix,
 		ActiveStates:            cfg.Tracker.ActiveStates,
 		ObservedStates:          cfg.Tracker.ObservedStates,
 		TerminalStates:          cfg.Tracker.TerminalStates,


### PR DESCRIPTION
## Summary

- Add `github_status_source: label` for repo-label backed GitHub status tracking.
- Derive status labels from configured workflow states and `state_map` using `status_label_prefix`.
- Let Kanban/status moves replace mutually exclusive Detent status labels.
- Update doctor readiness and scope checks so label mode only requires repo-scoped issue access, not ProjectV2 or org issue-field permissions.
- Add lightweight label-mode dependency metadata queries that avoid ProjectV2 field traversal.

## Validation

- `go test ./...`
- `detent doctor --config ~/.detent/global.yaml --timeout 20s`

## Notes

- The local dogfood workflow config was updated separately in the detent-orchestration repo to use label mode; that file is outside this repository and is not part of this PR.
