### PR TITLE
feat(release): add Linux package artifacts

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -60,6 +60,37 @@ brews:
     test: |
       system "#{bin}/detent", "--version"
 
+nfpms:
+  - id: detent-linux-packages
+    ids:
+      - detent
+    package_name: detent
+    file_name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}{{ .ConventionalExtension }}"
+    vendor: Digital Drywood
+    homepage: https://github.com/digitaldrywood/detent
+    maintainer: Cory LaNou <cory@lanou.com>
+    description: Agent orchestrator for tracker-backed work queues
+    license: MIT
+    bindir: /usr/bin
+    section: utils
+    priority: optional
+    release: "1"
+    mtime: "{{ .CommitDate }}"
+    formats:
+      - deb
+      - rpm
+    contents:
+      - src: LICENSE
+        dst: /usr/share/doc/detent/copyright
+        file_info:
+          mode: 0644
+          mtime: "{{ .CommitDate }}"
+      - src: README.md
+        dst: /usr/share/doc/detent/README.md
+        file_info:
+          mode: 0644
+          mtime: "{{ .CommitDate }}"
+
 checksum:
   name_template: "{{ .ProjectName }}_{{ .Version }}_checksums.txt"
   algorithm: sha256

--- a/README.md
+++ b/README.md
@@ -240,6 +240,29 @@ installer:
 ./install.sh
 ```
 
+Use a native Linux package when you want apt, dnf, rpm, or another system
+package workflow to own the binary, removal, and upgrades:
+
+```sh
+DETENT_VERSION=0.5.2 # release version without leading v
+DETENT_ARCH=amd64 # or arm64
+curl -LO "https://github.com/digitaldrywood/detent/releases/download/v${DETENT_VERSION}/detent_${DETENT_VERSION}_linux_${DETENT_ARCH}.deb"
+sudo apt install "./detent_${DETENT_VERSION}_linux_${DETENT_ARCH}.deb"
+detent --version
+```
+
+```sh
+DETENT_VERSION=0.5.2 # release version without leading v
+DETENT_ARCH=amd64 # or arm64
+curl -LO "https://github.com/digitaldrywood/detent/releases/download/v${DETENT_VERSION}/detent_${DETENT_VERSION}_linux_${DETENT_ARCH}.rpm"
+sudo rpm -Uvh "./detent_${DETENT_VERSION}_linux_${DETENT_ARCH}.rpm"
+detent --version
+```
+
+Use the shell installer for a user-local install without sudo, for Linux
+distributions that do not use `.deb` or `.rpm`, or for bootstrap scripts that
+should fall back to `go install` when a release asset is unavailable.
+
 Fallback options:
 
 Homebrew on macOS or Linux:
@@ -265,7 +288,11 @@ Release-installer installs can update with `detent update`; use
 `detent update --format json` for machine-readable status. The legacy
 `detent update --json` flag remains supported. On Windows, replacement is
 staged and completes after the running `detent.exe` exits. Homebrew installs
-delegate to `brew upgrade digitaldrywood/tap/detent`. Go-installed binaries offer an
+delegate to `brew upgrade digitaldrywood/tap/detent`. Native Linux packages are
+owned by the system package manager; install a newer `.deb` with `sudo apt
+install ./detent_<version>_linux_<arch>.deb`, or a newer `.rpm` with `sudo rpm
+-Uvh ./detent_<version>_linux_<arch>.rpm` or the distro wrapper you normally
+use. Go-installed binaries offer an
 interactive choice: run
 `go install github.com/digitaldrywood/detent/cmd/detent@latest`, switch to the
 checksum-verified release binary, or abort. `detent update --yes` runs the Go


### PR DESCRIPTION
## Summary

- add GoReleaser nFPM packaging for Linux `.deb` and `.rpm` artifacts
- include package metadata and `/usr/bin/detent` installation path for amd64 and arm64 packages
- document native Linux package installation and package-manager upgrade expectations

Fixes #486

## Test Plan

- [x] `make check`
- [x] `goreleaser release --snapshot --clean` with worktree-local `GOBIN` and temporary minisign key
- [x] inspected generated `.deb` and `.rpm` payloads for `/usr/bin/detent` and snapshot version metadata
