### PR TITLE
docs(install): promote release installers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,10 +118,105 @@ jobs:
       - name: Build command
         run: go build ./cmd/detent
 
+  installer-smoke:
+    name: Installer Smoke (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Smoke release installer
+        if: runner.os == 'Linux'
+        shell: bash
+        run: |
+          set -euo pipefail
+          export DETENT_INSTALL_DIR="$RUNNER_TEMP/detent/bin"
+          export DETENT_STATE_DIR="$RUNNER_TEMP/detent/state"
+          export DETENT_INSTALL_LOCK="$DETENT_STATE_DIR/install.lock"
+          export DETENT_INSTALL_MODE=release
+
+          output="$(sh ./install.sh)"
+          printf '%s\n' "$output"
+          grep -F "Verified checksum for detent_" <<< "$output"
+          grep -F "Installed Detent at $DETENT_INSTALL_DIR/detent" <<< "$output"
+          grep -F "Add $DETENT_INSTALL_DIR to PATH before running detent" <<< "$output"
+
+          test -x "$DETENT_INSTALL_DIR/detent"
+          grep -F "binary=$DETENT_INSTALL_DIR/detent" "$DETENT_INSTALL_LOCK"
+          grep -F "installed_at=" "$DETENT_INSTALL_LOCK"
+
+          "$DETENT_INSTALL_DIR/detent" version
+          "$DETENT_INSTALL_DIR/detent" update --check --json > "$RUNNER_TEMP/detent/update-check.json"
+          "$DETENT_INSTALL_DIR/detent" update --yes --json > "$RUNNER_TEMP/detent/update-yes.json"
+          jq -e '.install_source == "release" and .action == "up_to_date" and .update_available == false' "$RUNNER_TEMP/detent/update-check.json"
+          jq -e '.install_source == "release" and .action == "up_to_date" and .update_available == false' "$RUNNER_TEMP/detent/update-yes.json"
+
+      - name: Smoke release installer
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          $root = Join-Path $env:RUNNER_TEMP 'detent'
+          $env:DETENT_INSTALL_DIR = Join-Path $root 'bin'
+          $env:DETENT_STATE_DIR = Join-Path $root 'state'
+          $env:DETENT_INSTALL_LOCK = Join-Path $env:DETENT_STATE_DIR 'install.lock'
+          $env:DETENT_INSTALL_MODE = 'release'
+
+          $output = powershell.exe -NoProfile -ExecutionPolicy Bypass -File .\install.ps1 2>&1
+          $exitCode = $LASTEXITCODE
+          $output | ForEach-Object { Write-Host $_ }
+          if ($exitCode -ne 0) {
+            throw "install.ps1 failed with exit code $exitCode"
+          }
+          if (-not ($output -match 'Verified checksum for detent_.*_windows_.*\.zip')) {
+            throw 'install.ps1 did not report checksum verification'
+          }
+
+          $binary = Join-Path $env:DETENT_INSTALL_DIR 'detent.exe'
+          if (-not ($output -match [regex]::Escape("Installed Detent at $binary"))) {
+            throw 'install.ps1 did not report the requested install directory'
+          }
+          if (-not ($output -match [regex]::Escape("Added $env:DETENT_INSTALL_DIR to the user PATH"))) {
+            throw 'install.ps1 did not report PATH guidance'
+          }
+          if (-not (Test-Path -LiteralPath $binary -PathType Leaf)) {
+            throw "detent.exe was not installed at $binary"
+          }
+
+          $lock = Get-Content -LiteralPath $env:DETENT_INSTALL_LOCK -Raw
+          if ($lock -notmatch [regex]::Escape("binary=$binary")) {
+            throw 'install lock did not record the installed binary path'
+          }
+          if ($lock -notmatch 'installed_at=') {
+            throw 'install lock did not record installed_at'
+          }
+
+          & $binary version
+          $checkRaw = & $binary update --check --json
+          if ($LASTEXITCODE -ne 0) {
+            throw "detent update --check failed with exit code $LASTEXITCODE"
+          }
+          $yesRaw = & $binary update --yes --json
+          if ($LASTEXITCODE -ne 0) {
+            throw "detent update --yes failed with exit code $LASTEXITCODE"
+          }
+          $checkJSON = $checkRaw -join "`n"
+          $yesJSON = $yesRaw -join "`n"
+          $check = $checkJSON | ConvertFrom-Json
+          $yes = $yesJSON | ConvertFrom-Json
+          if ($check.install_source -ne 'release' -or $check.action -ne 'up_to_date' -or $check.update_available) {
+            throw "unexpected update --check status: $checkJSON"
+          }
+          if ($yes.install_source -ne 'release' -or $yes.action -ne 'up_to_date' -or $yes.update_available) {
+            throw "unexpected update --yes status: $yesJSON"
+          }
+
   goreleaser-snapshot:
     name: GoReleaser Snapshot
     runs-on: ubuntu-latest
-    needs: [lint, verify, test-cover, windows-core]
+    needs: [lint, verify, test-cover, windows-core, installer-smoke]
     steps:
       - name: Decide release packaging policy
         id: policy

--- a/README.md
+++ b/README.md
@@ -207,6 +207,11 @@ others as their automation terms allow.
 
 ## Install
 
+Use the release-asset installers for Windows and Linux first. They download the
+latest GitHub Release asset, verify the SHA-256 checksum, install the `detent`
+binary, and record installer metadata so `detent update` can safely manage the
+binary later. These paths do not require Homebrew or Go.
+
 Install the latest Windows release with PowerShell:
 
 ```powershell
@@ -215,19 +220,72 @@ irm https://raw.githubusercontent.com/digitaldrywood/detent/main/install.ps1 | i
 
 The PowerShell installer downloads the Windows release archive, verifies the
 SHA-256 checksum, installs `detent.exe` to `%LOCALAPPDATA%\detent\bin`, and
-adds that directory to the user PATH.
+adds that directory to the user PATH. Set `DETENT_INSTALL_DIR` to override the
+install directory.
 
-Install with Homebrew on macOS or Linux:
+Install the latest Linux release with the shell installer:
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/digitaldrywood/detent/main/install.sh | sh
+```
+
+The shell installer downloads the Linux release archive, verifies the SHA-256
+checksum, installs `detent` to `/usr/local/bin` when writable or
+`$HOME/.local/bin` otherwise, and prints PATH guidance when the chosen install
+directory is not already on PATH. Set `DETENT_INSTALL_DIR` to override the
+install directory. Source checkouts can also run the repository-local shell
+installer:
+
+```sh
+./install.sh
+```
+
+Fallback options:
+
+Homebrew on macOS or Linux:
 
 ```sh
 brew install digitaldrywood/tap/detent
 ```
 
-Install with Go on any platform:
+Go on any platform:
 
 ```sh
 go install github.com/digitaldrywood/detent/cmd/detent@latest
 ```
+
+After installing, check for updates with:
+
+```sh
+detent update --check
+```
+
+Release-installer installs can update with `detent update`; use
+`detent update --yes` for non-interactive automation and
+`detent update --format json` for machine-readable status. The legacy
+`detent update --json` flag remains supported. On Windows, replacement is
+staged and completes after the running `detent.exe` exits. Homebrew installs
+delegate to `brew upgrade digitaldrywood/tap/detent`. Go-installed binaries offer an
+interactive choice: run
+`go install github.com/digitaldrywood/detent/cmd/detent@latest`, switch to the
+checksum-verified release binary, or abort. `detent update --yes` runs the Go
+install command for go-installed binaries; `detent update --from-release`
+switches the detected Go-installed binary to the release asset and pins future
+updates to release-binary management. Source builds still print the recommended
+command instead of overwriting the binary.
+
+CI runs the `Installer Smoke` job on Ubuntu and Windows against the current
+GitHub Release assets. The job runs `install.sh` and `install.ps1` in release
+mode, checks checksum output, confirms the requested install directory and
+installer lock metadata, then runs `detent update --check` and
+`detent update --yes` from the release-installer install.
+
+Release self-updates verify SHA256 checksums fetched from GitHub releases. The
+checksum verifier supports detached minisign signature assets named
+`<checksum>.minisig`, but enforcement is gated until the binary embeds the
+pinned minisign public key for the release stream. Until that release signing
+key is provisioned in #337, update integrity still depends on GitHub TLS plus
+the published checksum file.
 
 Requirements:
 
@@ -241,45 +299,6 @@ Requirements:
   `repo`, `read:org`, `read:project`, and write `project`. Boardless
   issue-field mode needs repository issue access plus organization issue-field
   read access; classic PATs use `repo` and `read:org`.
-
-macOS and Linux hosts can install the latest release with the shell installer:
-
-```sh
-curl -fsSL https://raw.githubusercontent.com/digitaldrywood/detent/main/install.sh | sh
-```
-
-Source checkouts can also run the repository-local shell installer:
-
-```sh
-./install.sh
-```
-
-After installing, check for updates with:
-
-```sh
-detent update --check
-```
-
-Release-installer installs can update with `detent update`; use
-`detent update --yes` for non-interactive automation and
-`detent update --format json` for machine-readable status. The legacy
-`detent update --json` flag remains supported. On Windows, replacement is staged and completes
-after the running `detent.exe` exits. Homebrew installs delegate to
-`brew upgrade digitaldrywood/tap/detent`. Go-installed binaries offer an
-interactive choice: run
-`go install github.com/digitaldrywood/detent/cmd/detent@latest`, switch to the
-checksum-verified release binary, or abort. `detent update --yes` runs the Go
-install command for go-installed binaries; `detent update --from-release`
-switches the detected Go-installed binary to the release asset and pins future
-updates to release-binary management. Source builds still print the recommended
-command instead of overwriting the binary.
-
-Release self-updates verify SHA256 checksums fetched from GitHub releases. The
-checksum verifier supports detached minisign signature assets named
-`<checksum>.minisig`, but enforcement is gated until the binary embeds the
-pinned minisign public key for the release stream. Until that release signing
-key is provisioned in #337, update integrity still depends on GitHub TLS plus
-the published checksum file.
 
 ## CLI exit codes
 

--- a/install.sh
+++ b/install.sh
@@ -189,6 +189,7 @@ verify_checksum() {
 	if [ "$actual" != "$expected" ]; then
 		abort "Checksum mismatch for $asset_name: expected $expected, got $actual"
 	fi
+	printf 'Verified checksum for %s\n' "$asset_name"
 }
 
 install_release() {
@@ -331,3 +332,7 @@ install_binary
 
 cleanup_lock=false
 echo "Installed Detent at $target"
+case ":${PATH:-}:" in
+	*":$install_dir:"*) ;;
+	*) printf 'Add %s to PATH before running detent: export PATH="%s:$PATH"\n' "$install_dir" "$install_dir" ;;
+esac

--- a/install_ps1_static_test.go
+++ b/install_ps1_static_test.go
@@ -52,6 +52,48 @@ func TestWindowsInstallDocsExposeOneStepPowerShellInstall(t *testing.T) {
 	}
 }
 
+func TestInstallDocsPromoteReleaseInstallersBeforeFallbacks(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile("README.md")
+	if err != nil {
+		t.Fatalf("ReadFile(README.md) error = %v", err)
+	}
+
+	readme := string(raw)
+	installStart := strings.Index(readme, "## Install")
+	if installStart == -1 {
+		t.Fatal("README.md missing install section")
+	}
+	nextSection := strings.Index(readme[installStart+len("## Install"):], "\n## ")
+	if nextSection == -1 {
+		t.Fatal("README.md install section does not terminate before next section")
+	}
+	install := readme[installStart : installStart+len("## Install")+nextSection]
+
+	windows := strings.Index(install, "irm https://raw.githubusercontent.com/digitaldrywood/detent/main/install.ps1 | iex")
+	linux := strings.Index(install, "curl -fsSL https://raw.githubusercontent.com/digitaldrywood/detent/main/install.sh | sh")
+	homebrew := strings.Index(install, "brew install digitaldrywood/tap/detent")
+	goInstall := strings.Index(install, "go install github.com/digitaldrywood/detent/cmd/detent@latest")
+
+	for name, index := range map[string]int{
+		"windows installer": windows,
+		"linux installer":   linux,
+		"homebrew fallback": homebrew,
+		"go fallback":       goInstall,
+	} {
+		if index == -1 {
+			t.Fatalf("README.md install section missing %s", name)
+		}
+	}
+	if windows > homebrew || windows > goInstall {
+		t.Fatal("README.md presents Windows release installer after fallback options")
+	}
+	if linux > homebrew || linux > goInstall {
+		t.Fatal("README.md presents Linux release installer after fallback options")
+	}
+}
+
 func TestWindowsInstallScriptKeepsGeneric64BitOutOfTargetArchConverter(t *testing.T) {
 	t.Parallel()
 

--- a/install_test.go
+++ b/install_test.go
@@ -162,6 +162,9 @@ func TestInstallScriptInstallsReleaseArchive(t *testing.T) {
 	if result.err != nil {
 		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
 	}
+	if !strings.Contains(result.stdout, "Verified checksum for "+archiveName) {
+		t.Fatalf("install stdout = %q, want checksum verification", result.stdout)
+	}
 
 	binary := filepath.Join(installDir, "detent")
 	if _, err := os.Stat(binary); err != nil {
@@ -173,6 +176,41 @@ func TestInstallScriptInstallsReleaseArchive(t *testing.T) {
 	}
 	if stdout != "release-ok\n" {
 		t.Fatalf("installed release binary stdout = %q, want release-ok", stdout)
+	}
+}
+
+func TestInstallScriptReportsPathGuidanceWhenInstallDirIsMissingFromPath(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	tmp := t.TempDir()
+	source := filepath.Join(tmp, "source-detent")
+	if err := os.WriteFile(source, []byte("#!/usr/bin/env sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"PATH=/usr/bin:/bin",
+		"DETENT_INSTALL_SOURCE="+source,
+		"DETENT_INSTALL_DIR="+installDir,
+		"DETENT_STATE_DIR="+stateDir,
+		"DETENT_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+	)
+
+	result := runInstall(t, root, env)
+	if result.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	want := fmt.Sprintf("Add %s to PATH before running detent: export PATH=\"%s:$PATH\"", installDir, installDir)
+	if !strings.Contains(result.stdout, want) {
+		t.Fatalf("install stdout = %q, want PATH guidance %q", result.stdout, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Promote Windows PowerShell and Linux shell release-asset installers before Homebrew and Go fallback options in README.
- Add Linux installer checksum and PATH guidance output, plus root tests for installer docs and shell installer behavior.
- Add Ubuntu and Windows CI installer smoke coverage against current GitHub Release assets, including update check/apply behavior.

Fixes #485

## Test Plan

- [x] `go test -run 'TestInstallScript(InstallsReleaseArchive|ReportsPathGuidanceWhenInstallDirIsMissingFromPath|AbortsOnChecksumMismatch)|TestInstallDocsPromoteReleaseInstallersBeforeFallbacks|TestWindowsInstallDocsExposeOneStepPowerShellInstall' .`
- [x] `go test .`
- [x] `go test ./cmd/detent ./internal/update`
- [x] Linux-target release asset smoke: `install.sh` installed `detent_0.5.1_linux_amd64.tar.gz`, verified checksum output, wrote install lock, and printed PATH guidance under worktree `tmp/`.
- [x] Host executable release asset smoke: `install.sh` installed `detent_0.5.1_darwin_arm64.tar.gz`; with the installer lock env, `detent update --check --json` and `detent update --yes --json` returned `install_source: release`, `action: up_to_date`, `latest_tag: v0.5.1`.
- [x] `git diff --check`
- [x] workflow YAML parsed with Ruby `YAML.load_file`.
- [x] `make check`
