### PR TITLE
fix(cli): clean shutdown terminal output

### DIFF
--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/signal"
 	"sync"
@@ -60,6 +61,7 @@ func handleShutdownSignal(controller shutdownInterruptRequester, cancelRoot cont
 	if controller != nil {
 		request, handled = controller.RequestInterruptKind()
 	}
+	slog.Default().Debug("shutdown interrupt request", "operation", "shutdown_interrupt_request", "source", "signal", "request", request.String(), "handled", handled)
 	writeSignalShutdownNotice(noticeOut, request)
 	if request == cli.ShutdownRequestForce {
 		hardExitSignal(hardExit)

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -167,8 +167,12 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 	defer func() {
 		stop()
+		closeStarted := logShutdownBoundaryBegin(logger, "runtime_store_close", "component", "runtime_store")
 		if err := runtimeStore.Close(); err != nil {
+			logShutdownBoundaryEnd(logger, "runtime_store_close", closeStarted, err, "component", "runtime_store")
 			logger.Warn("close runtime store failed", "error", err)
+		} else {
+			logShutdownBoundaryEnd(logger, "runtime_store_close", closeStarted, nil, "component", "runtime_store")
 		}
 	}()
 
@@ -214,7 +218,9 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		stop()
 		select {
 		case globalWatcherDone := <-globalWatcherStarted:
+			waitStarted := logShutdownBoundaryBegin(logger, "global_config_watcher_wait", "component", "global_config_watcher")
 			waitGlobalConfigWatcher(globalWatcherDone)
+			logShutdownBoundaryEnd(logger, "global_config_watcher_wait", waitStarted, nil, "component", "global_config_watcher")
 		default:
 		}
 	}()
@@ -271,13 +277,14 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		}
 		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
 			return runWithShutdown(ctx, runningShutdownConfig{
-				Controller:     cfg.Shutdown,
-				Registry:       manager.Registry(),
-				SnapshotHub:    snapshotHub,
-				LifetimeSource: runtimeStore,
-				DashboardURL:   displayURL,
-				Output:         cfg.Output,
-				Logger:         logger,
+				Controller:        cfg.Shutdown,
+				Registry:          manager.Registry(),
+				SnapshotHub:       snapshotHub,
+				LifetimeSource:    runtimeStore,
+				DashboardURL:      displayURL,
+				Output:            cfg.Output,
+				Logger:            logger,
+				TerminalDashboard: true,
 				DrainTimeoutSource: func() time.Duration {
 					return shutdownDrainTimeout(manager.Registry())
 				},
@@ -364,6 +371,7 @@ func startOnboarding(ctx context.Context, cfg BootConfig) error {
 }
 
 func serve(ctx context.Context, server *web.Server, listener net.Listener) error {
+	logger := slog.Default()
 	errs := make(chan error, 1)
 	go func() {
 		errs <- server.StartListener(listener)
@@ -371,15 +379,23 @@ func serve(ctx context.Context, server *web.Server, listener net.Listener) error
 
 	select {
 	case <-ctx.Done():
+		contextStarted := logShutdownBoundaryBegin(logger, "serve_context_done", "component", "serve")
+		logShutdownBoundaryEnd(logger, "serve_context_done", contextStarted, nil, "component", "serve")
 		shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 		defer cancel()
+		shutdownStarted := logShutdownBoundaryBegin(logger, "web_server_shutdown", "component", "web_server", "timeout", 5*time.Second)
 		if err := server.Shutdown(shutdownCtx); err != nil {
+			logShutdownBoundaryEnd(logger, "web_server_shutdown", shutdownStarted, err, "component", "web_server", "timeout", 5*time.Second)
 			return err
 		}
+		logShutdownBoundaryEnd(logger, "web_server_shutdown", shutdownStarted, nil, "component", "web_server", "timeout", 5*time.Second)
+		waitStarted := logShutdownBoundaryBegin(logger, "web_server_listener_wait", "component", "web_server")
 		err := <-errs
 		if err != nil && !errors.Is(err, http.ErrServerClosed) {
+			logShutdownBoundaryEnd(logger, "web_server_listener_wait", waitStarted, err, "component", "web_server")
 			return err
 		}
+		logShutdownBoundaryEnd(logger, "web_server_listener_wait", waitStarted, nil, "component", "web_server")
 		return ctx.Err()
 	case err := <-errs:
 		if errors.Is(err, http.ErrServerClosed) {
@@ -517,6 +533,7 @@ func shouldLaunchTerminalDashboard(cfg BootConfig) bool {
 
 func requestTerminalShutdownInterrupt(controller *ShutdownController, hardExit func(int)) bool {
 	request, handled := controller.RequestInterruptKind()
+	slog.Default().Debug("shutdown interrupt request", "operation", "shutdown_interrupt_request", "source", "terminal_dashboard", "request", request.String(), "handled", handled)
 	if !handled {
 		return false
 	}

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -122,6 +122,7 @@ type runningShutdownConfig struct {
 	DashboardURL       string
 	Output             io.Writer
 	Logger             *slog.Logger
+	TerminalDashboard  bool
 	DrainTimeout       time.Duration
 	DrainTimeoutSource func() time.Duration
 	ProgressInterval   time.Duration
@@ -156,11 +157,12 @@ func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutd
 			return unexpectedShutdownServeError(err)
 		case <-ctx.Done():
 			cancelServe()
-			if err := waitForServeExit(context.Background(), serveErrs); err != nil {
+			if err := loggedWaitForServeExit(context.Background(), cfg, serveErrs); err != nil {
 				return err
 			}
 			return ctx.Err()
 		case request := <-cfg.Controller.Requests():
+			shutdownLogger(cfg).Debug("shutdown request received", "operation", "shutdown_request", "request", request.String())
 			switch request {
 			case ShutdownRequestDrain:
 				machine = machine.Apply(shutdownstate.EventDrainRequested)
@@ -181,7 +183,9 @@ func runDrainShutdown(
 	machine shutdownstate.Machine,
 ) error {
 	startedAt := shutdownNow(cfg)
+	inventoryStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "initial_running_session_inventory")
 	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
+	logShutdownBoundaryEnd(shutdownLogger(cfg), "initial_running_session_inventory", inventoryStarted, nil, "sessions", len(sessions))
 	writeShutdownBanner(shutdownOutput(cfg), sessions)
 	shutdownLogger(cfg).Info("shutdown requested", "sessions", len(sessions))
 
@@ -190,8 +194,8 @@ func runDrainShutdown(
 		hardTimeout = defaultShutdownHardTimeout
 	}
 	drainCtx, cancelDrain := context.WithTimeout(ctx, hardTimeout)
-	if err := runShutdownStep(drainCtx, func(stepCtx context.Context) error {
-		return drainProjects(stepCtx, cfg.Registry)
+	if err := runLoggedShutdownStep(drainCtx, cfg, "drain_projects", func(stepCtx context.Context) error {
+		return drainProjects(stepCtx, cfg.Registry, shutdownLogger(cfg))
 	}); err != nil {
 		shutdownLogger(cfg).Warn("drain projects during shutdown failed", "error", err)
 	}
@@ -233,11 +237,12 @@ func runDrainShutdown(
 			return unexpectedShutdownServeError(err)
 		case <-ctx.Done():
 			cancelServe()
-			if err := waitForServeExit(context.Background(), serveErrs); err != nil {
+			if err := loggedWaitForServeExit(context.Background(), cfg, serveErrs); err != nil {
 				return err
 			}
 			return ctx.Err()
 		case request := <-cfg.Controller.Requests():
+			shutdownLogger(cfg).Debug("shutdown request received", "operation", "shutdown_request", "request", request.String())
 			if request == ShutdownRequestForce {
 				machine = machine.Apply(shutdownstate.EventForceRequested)
 				return runForceShutdown(ctx, cfg, cancelServe, serveErrs, machine, "forced")
@@ -278,7 +283,9 @@ func runForceShutdownWithDeadline(
 	hardTimeout time.Duration,
 ) error {
 	startedAt := shutdownNow(cfg)
+	inventoryStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "force_running_session_inventory")
 	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
+	logShutdownBoundaryEnd(shutdownLogger(cfg), "force_running_session_inventory", inventoryStarted, nil, "sessions", len(sessions))
 	if result == "drain timeout" {
 		fmt.Fprintf(shutdownOutput(cfg), "drain timeout reached — interrupting %d %s\n", len(sessions), shutdownSessionNoun(len(sessions)))
 	} else {
@@ -287,8 +294,8 @@ func runForceShutdownWithDeadline(
 
 	forceCtx, cancel := context.WithTimeout(context.Background(), hardTimeout)
 	defer cancel()
-	if err := runShutdownStep(forceCtx, func(stepCtx context.Context) error {
-		return forceProjects(stepCtx, cfg.Registry)
+	if err := runLoggedShutdownStep(forceCtx, cfg, "force_projects", func(stepCtx context.Context) error {
+		return forceProjects(stepCtx, cfg.Registry, shutdownLogger(cfg))
 	}); err != nil {
 		shutdownLogger(cfg).Warn("force shutdown cleanup failed", "error", err)
 	}
@@ -315,14 +322,16 @@ func completeShutdown(
 	}
 	stopCtx, cancel := context.WithTimeout(ctx, hardTimeout)
 	defer cancel()
-	if err := runShutdownStep(stopCtx, func(stepCtx context.Context) error {
-		return stopProjects(stepCtx, cfg.Registry)
+	if err := runLoggedShutdownStep(stopCtx, cfg, "stop_projects", func(stepCtx context.Context) error {
+		return stopProjects(stepCtx, cfg.Registry, shutdownLogger(cfg))
 	}); err != nil {
 		shutdownLogger(cfg).Warn("stop projects during shutdown failed", "error", err)
 	}
 
+	cancelStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "serve_cancel", "component", "serve")
 	cancelServe()
-	if err := waitForServeExit(stopCtx, serveErrs); err != nil {
+	logShutdownBoundaryEnd(shutdownLogger(cfg), "serve_cancel", cancelStarted, nil, "component", "serve")
+	if err := loggedWaitForServeExit(stopCtx, cfg, serveErrs); err != nil {
 		if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
 			shutdownLogger(cfg).Warn("serve did not exit before shutdown deadline", "error", err)
 			return returnErr
@@ -333,6 +342,13 @@ func completeShutdown(
 	result := shutdownResultLabel(machine)
 	shutdownLogger(cfg).Info("shutdown complete ("+result+")", "duration", shutdownNow(cfg).Sub(startedAt))
 	return returnErr
+}
+
+func runLoggedShutdownStep(ctx context.Context, cfg runningShutdownConfig, operation string, step func(context.Context) error, attrs ...any) error {
+	started := logShutdownBoundaryBegin(shutdownLogger(cfg), operation, attrs...)
+	err := runShutdownStep(ctx, step)
+	logShutdownBoundaryEnd(shutdownLogger(cfg), operation, started, err, attrs...)
+	return err
 }
 
 func runShutdownStep(ctx context.Context, step func(context.Context) error) error {
@@ -363,7 +379,7 @@ func shutdownResultLabel(machine shutdownstate.Machine) string {
 	}
 }
 
-func drainProjects(ctx context.Context, registry *project.Registry) error {
+func drainProjects(ctx context.Context, registry *project.Registry, logger *slog.Logger) error {
 	if registry == nil {
 		return nil
 	}
@@ -375,14 +391,21 @@ func drainProjects(ctx context.Context, registry *project.Registry) error {
 		if orch == nil {
 			continue
 		}
-		if err := orch.Drain(ctx); err != nil && !errors.Is(err, orchestrator.ErrStopped) {
+		operationStarted := logShutdownBoundaryBegin(logger, "orchestrator_drain", "component", "orchestrator", "project_id", trackedProject.ID())
+		err := orch.Drain(ctx)
+		if errors.Is(err, orchestrator.ErrStopped) {
+			logShutdownBoundaryEndResult(logger, "orchestrator_drain", operationStarted, "stopped", nil, "component", "orchestrator", "project_id", trackedProject.ID())
+			continue
+		}
+		logShutdownBoundaryEnd(logger, "orchestrator_drain", operationStarted, err, "component", "orchestrator", "project_id", trackedProject.ID())
+		if err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func forceProjects(ctx context.Context, registry *project.Registry) error {
+func forceProjects(ctx context.Context, registry *project.Registry, logger *slog.Logger) error {
 	if registry == nil {
 		return nil
 	}
@@ -394,14 +417,21 @@ func forceProjects(ctx context.Context, registry *project.Registry) error {
 		if orch == nil {
 			continue
 		}
-		if err := orch.ForceQuit(ctx); err != nil && !errors.Is(err, orchestrator.ErrStopped) {
+		operationStarted := logShutdownBoundaryBegin(logger, "orchestrator_force_quit", "component", "orchestrator", "project_id", trackedProject.ID())
+		err := orch.ForceQuit(ctx)
+		if errors.Is(err, orchestrator.ErrStopped) {
+			logShutdownBoundaryEndResult(logger, "orchestrator_force_quit", operationStarted, "stopped", nil, "component", "orchestrator", "project_id", trackedProject.ID())
+			continue
+		}
+		logShutdownBoundaryEnd(logger, "orchestrator_force_quit", operationStarted, err, "component", "orchestrator", "project_id", trackedProject.ID())
+		if err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func stopProjects(ctx context.Context, registry *project.Registry) error {
+func stopProjects(ctx context.Context, registry *project.Registry, logger *slog.Logger) error {
 	if registry == nil {
 		return nil
 	}
@@ -409,7 +439,14 @@ func stopProjects(ctx context.Context, registry *project.Registry) error {
 		if !trackedProject.Running() {
 			continue
 		}
-		if err := trackedProject.Stop(ctx); err != nil && !errors.Is(err, project.ErrNotRunning) {
+		operationStarted := logShutdownBoundaryBegin(logger, "project_stop", "component", "project", "project_id", trackedProject.ID())
+		err := trackedProject.Stop(ctx)
+		if errors.Is(err, project.ErrNotRunning) {
+			logShutdownBoundaryEndResult(logger, "project_stop", operationStarted, "not_running", nil, "component", "project", "project_id", trackedProject.ID())
+			continue
+		}
+		logShutdownBoundaryEnd(logger, "project_stop", operationStarted, err, "component", "project", "project_id", trackedProject.ID())
+		if err != nil {
 			return err
 		}
 	}
@@ -450,12 +487,17 @@ func shutdownDrainTimeoutForConfig(cfg runningShutdownConfig) time.Duration {
 }
 
 func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now time.Time) {
+	started := logShutdownBoundaryBegin(shutdownLogger(cfg), "shutdown_snapshot_publish")
 	if cfg.Registry == nil || cfg.SnapshotHub == nil {
+		logShutdownBoundaryEndResult(shutdownLogger(cfg), "shutdown_snapshot_publish", started, "skipped", nil)
 		return
 	}
 	if err := publishSnapshotOnce(ctx, cfg.Registry, cfg.SnapshotHub, now, nil, cfg.LifetimeSource, cfg.DashboardURL); err != nil {
+		logShutdownBoundaryEnd(shutdownLogger(cfg), "shutdown_snapshot_publish", started, err)
 		shutdownLogger(cfg).Warn("publish shutdown telemetry snapshot failed", "error", err)
+		return
 	}
+	logShutdownBoundaryEnd(shutdownLogger(cfg), "shutdown_snapshot_publish", started, nil)
 }
 
 func shutdownDrainTimeout(registry *project.Registry) time.Duration {
@@ -574,6 +616,9 @@ func defaultShutdownString(value string, fallback string) string {
 }
 
 func shutdownOutput(cfg runningShutdownConfig) io.Writer {
+	if cfg.TerminalDashboard {
+		return io.Discard
+	}
 	if cfg.Output == nil {
 		return io.Discard
 	}
@@ -606,9 +651,71 @@ func waitForServeExit(ctx context.Context, serveErrs <-chan error) error {
 	}
 }
 
+func loggedWaitForServeExit(ctx context.Context, cfg runningShutdownConfig, serveErrs <-chan error) error {
+	started := logShutdownBoundaryBegin(shutdownLogger(cfg), "wait_for_serve_exit", "component", "serve")
+	err := waitForServeExit(ctx, serveErrs)
+	logShutdownBoundaryEnd(shutdownLogger(cfg), "wait_for_serve_exit", started, err, "component", "serve")
+	return err
+}
+
 func unexpectedShutdownServeError(err error) error {
 	if err == nil || errors.Is(err, context.Canceled) || errors.Is(err, http.ErrServerClosed) {
 		return nil
 	}
 	return err
+}
+
+func (request ShutdownRequest) String() string {
+	switch request {
+	case ShutdownRequestDrain:
+		return "drain"
+	case ShutdownRequestForce:
+		return "force"
+	default:
+		return "unknown"
+	}
+}
+
+func logShutdownBoundaryBegin(logger *slog.Logger, operation string, attrs ...any) time.Time {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	started := time.Now()
+	args := shutdownLogArgs(operation, append([]any{"phase", "begin"}, attrs...)...)
+	logger.Debug("shutdown boundary begin", args...)
+	return started
+}
+
+func logShutdownBoundaryEnd(logger *slog.Logger, operation string, started time.Time, err error, attrs ...any) {
+	result := "ok"
+	if err != nil {
+		result = "error"
+	}
+	logShutdownBoundaryEndResult(logger, operation, started, result, err, attrs...)
+}
+
+func logShutdownBoundaryEndResult(logger *slog.Logger, operation string, started time.Time, result string, err error, attrs ...any) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if result == "" {
+		result = "ok"
+	}
+	args := shutdownLogArgs(operation,
+		"phase", "end",
+		"duration", time.Since(started),
+		"result", result,
+	)
+	if err != nil {
+		args = append(args, "error", err)
+	}
+	args = append(args, attrs...)
+	logger.Debug("shutdown boundary end", args...)
+}
+
+func shutdownLogArgs(operation string, attrs ...any) []any {
+	args := make([]any, 0, 2+len(attrs))
+	args = append(args, "operation", operation)
+	args = append(args, attrs...)
+	return args
 }

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -164,6 +165,119 @@ func TestRunWithShutdownZeroSessionsExitsGracefully(t *testing.T) {
 	}
 	if got := output.String(); !strings.Contains(got, "shutdown requested — no agent sessions in flight") {
 		t.Fatalf("output missing zero-session notice:\n%s", got)
+	}
+}
+
+func TestRunWithShutdownTerminalDashboardSuppressesPlainOutput(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	var output bytes.Buffer
+	errs := make(chan error, 1)
+
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:        controller,
+			Registry:          projectpkg.NewRegistry(),
+			SnapshotHub:       hub.New[telemetry.Snapshot](),
+			Output:            &output,
+			TerminalDashboard: true,
+			HardTimeout:       time.Second,
+			Now: func() time.Time {
+				return time.Date(2026, 6, 16, 16, 0, 0, 0, time.UTC)
+			},
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestDrain()
+
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
+	}
+	if got := output.String(); got != "" {
+		t.Fatalf("terminal dashboard shutdown wrote plain output:\n%s", got)
+	}
+}
+
+func TestRunWithShutdownZeroSessionsLogsCleanupBoundaries(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	started := make(chan struct{})
+	var logs bytes.Buffer
+	errs := make(chan error, 1)
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:       controller,
+			Registry:         projectpkg.NewRegistry(),
+			SnapshotHub:      hub.New[telemetry.Snapshot](),
+			Output:           io.Discard,
+			Logger:           logger,
+			DrainTimeout:     time.Hour,
+			ProgressInterval: time.Hour,
+			HardTimeout:      time.Second,
+			Now: func() time.Time {
+				return time.Date(2026, 6, 16, 16, 0, 0, 0, time.UTC)
+			},
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	start := time.Now()
+	controller.RequestDrain()
+
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
+	}
+	if elapsed := time.Since(start); elapsed >= shutdownDrainPollInterval {
+		t.Fatalf("zero-session shutdown waited %s, want less than %s", elapsed, shutdownDrainPollInterval)
+	}
+
+	got := logs.String()
+	for _, want := range []string{
+		"operation=initial_running_session_inventory",
+		"operation=drain_projects",
+		"operation=shutdown_snapshot_publish",
+		"operation=stop_projects",
+		"operation=serve_cancel",
+		"operation=wait_for_serve_exit",
+		"sessions=0",
+		"duration=",
+		"result=ok",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("debug logs missing %q:\n%s", want, got)
+		}
 	}
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -536,14 +536,18 @@ func (p *Project) Wait(ctx context.Context) error {
 }
 
 func (p *Project) waitDone(ctx context.Context, done <-chan struct{}) error {
+	started := logProjectShutdownBoundaryBegin(p.logger, "project_wait_done", "component", "project", "project_id", p.id)
 	select {
 	case <-done:
 		p.mu.Lock()
 		defer p.mu.Unlock()
 
+		logProjectShutdownBoundaryEnd(p.logger, "project_wait_done", started, p.runErr, "component", "project", "project_id", p.id)
 		return p.runErr
 	case <-ctx.Done():
-		return ctx.Err()
+		err := ctx.Err()
+		logProjectShutdownBoundaryEnd(p.logger, "project_wait_done", started, err, "component", "project", "project_id", p.id)
+		return err
 	}
 }
 
@@ -551,10 +555,20 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	watcherCtx, stopWatcher := context.WithCancel(ctx)
 	watcherDone := p.startWorkflowWatcher(watcherCtx)
 
+	runStarted := logProjectShutdownBoundaryBegin(p.logger, "orchestrator_run", "component", "orchestrator", "project_id", p.id)
 	err := orch.Run(ctx)
+	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
+		logProjectShutdownBoundaryEndResult(p.logger, "orchestrator_run", runStarted, "canceled", nil, "component", "orchestrator", "project_id", p.id)
+	} else {
+		logProjectShutdownBoundaryEnd(p.logger, "orchestrator_run", runStarted, err, "component", "orchestrator", "project_id", p.id)
+	}
+	watcherStarted := logProjectShutdownBoundaryBegin(p.logger, "workflow_watcher_stop", "component", "workflow_watcher", "project_id", p.id)
 	stopWatcher()
 	if watcherDone != nil {
 		<-watcherDone
+		logProjectShutdownBoundaryEnd(p.logger, "workflow_watcher_stop", watcherStarted, nil, "component", "workflow_watcher", "project_id", p.id)
+	} else {
+		logProjectShutdownBoundaryEndResult(p.logger, "workflow_watcher_stop", watcherStarted, "skipped", nil, "component", "workflow_watcher", "project_id", p.id)
 	}
 	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
 		err = nil
@@ -579,6 +593,50 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	}
 
 	close(done)
+}
+
+func logProjectShutdownBoundaryBegin(logger *slog.Logger, operation string, attrs ...any) time.Time {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	started := time.Now()
+	args := projectShutdownLogArgs(operation, append([]any{"phase", "begin"}, attrs...)...)
+	logger.Debug("shutdown boundary begin", args...)
+	return started
+}
+
+func logProjectShutdownBoundaryEnd(logger *slog.Logger, operation string, started time.Time, err error, attrs ...any) {
+	result := "ok"
+	if err != nil {
+		result = "error"
+	}
+	logProjectShutdownBoundaryEndResult(logger, operation, started, result, err, attrs...)
+}
+
+func logProjectShutdownBoundaryEndResult(logger *slog.Logger, operation string, started time.Time, result string, err error, attrs ...any) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if result == "" {
+		result = "ok"
+	}
+	args := projectShutdownLogArgs(operation,
+		"phase", "end",
+		"duration", time.Since(started),
+		"result", result,
+	)
+	if err != nil {
+		args = append(args, "error", err)
+	}
+	args = append(args, attrs...)
+	logger.Debug("shutdown boundary end", args...)
+}
+
+func projectShutdownLogArgs(operation string, attrs ...any) []any {
+	args := make([]any, 0, 2+len(attrs))
+	args = append(args, "operation", operation)
+	args = append(args, attrs...)
+	return args
 }
 
 func (p *Project) startWorkflowWatcher(ctx context.Context) <-chan struct{} {


### PR DESCRIPTION
## Summary

- Suppress plain shutdown banner/progress output while the terminal dashboard owns the alt screen.
- Add debug shutdown boundary logs for interrupts, session inventory, project drain/stop internals, serve/web shutdown, and runtime store close.
- Add regression tests for terminal-dashboard output isolation and zero-session shutdown cleanup diagnostics.

Fixes #506

## Test Plan

- [x] `go test -count=1 -timeout=60s ./internal/cli ./internal/project ./cmd/detent`
- [x] `go test -race -count=1 -timeout=3m ./...`
- [x] `make check`