### PR TITLE
fix(github): preserve done status

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -2987,12 +2987,29 @@ func (c *Connector) githubToDetentState(githubState string) string {
 	if githubState == "" {
 		return ""
 	}
+	if state := c.configuredDetentState(githubState); state != "" {
+		return state
+	}
 	for detentState, mapped := range c.stateMap {
-		if mapped == githubState {
-			return detentState
+		if normalizeStateName(mapped) == normalizeStateName(githubState) {
+			return strings.TrimSpace(detentState)
 		}
 	}
 	return githubState
+}
+
+func (c *Connector) configuredDetentState(stateName string) string {
+	stateName = normalizeStateName(stateName)
+	if stateName == "" {
+		return ""
+	}
+	for _, candidate := range c.configuredStatusStates() {
+		candidate = strings.TrimSpace(candidate)
+		if normalizeStateName(candidate) == stateName {
+			return candidate
+		}
+	}
+	return ""
 }
 
 func (c *Connector) githubIssueStateToDetentState(state string) string {

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -107,6 +107,78 @@ func TestConnectorFetchLabelIssuesByStatesAttachesCurrentAgentBranchPullRequest(
 	}
 }
 
+func TestConnectorFetchLabelIssuesPrefersCanonicalDoneOverCancelledAlias(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Adone&page=1&per_page=100&state=all",
+			body:   `[{"node_id":"I_485","number":485,"title":"Installer packages","body":"","state":"closed","state_reason":"completed","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:done"},{"name":"release"}]}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		TerminalStates:     []string{"Done", "Cancelled"},
+		StateMap:           map[string]string{"Cancelled": "Done"},
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Done"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	if got[0].State != "Done" {
+		t.Fatalf("State = %q, want Done", got[0].State)
+	}
+	if !got[0].Closed || got[0].ClosedReason != "completed" {
+		t.Fatalf("closed metadata = (%v, %q), want closed completed", got[0].Closed, got[0].ClosedReason)
+	}
+}
+
+func TestConnectorFetchLabelIssueStateByIDMapsClosedCompletedToDone(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_487","number":487,"repository":{"nameWithOwner":"digitaldrywood/detent"}}]}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/487",
+			body:   `{"node_id":"I_487","number":487,"title":"Windows packages","body":"","state":"closed","state_reason":"completed","html_url":"https://github.com/digitaldrywood/detent/issues/487","assignees":[],"labels":[{"name":"release"}]}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		TerminalStates:     []string{"Done", "Cancelled"},
+		StateMap:           map[string]string{"Cancelled": "Done"},
+	})
+
+	got, err := c.FetchIssueStatesByIDs(context.Background(), []string{"I_487"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIDs() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssueStatesByIDs() len = %d, want 1", len(got))
+	}
+	if got[0].State != "Done" {
+		t.Fatalf("State = %q, want Done", got[0].State)
+	}
+	if !got[0].Closed || got[0].ClosedReason != "completed" {
+		t.Fatalf("closed metadata = (%v, %q), want closed completed", got[0].Closed, got[0].ClosedReason)
+	}
+}
+
 func TestConnectorUpdateIssueStateReplacesStatusLabels(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -670,6 +670,9 @@ func mergeIssueTrackerFields(current, refreshed connector.Issue) connector.Issue
 		merged.URL = refreshed.URL
 	}
 	merged.Closed = refreshed.Closed
+	if refreshed.ClosedReason != "" {
+		merged.ClosedReason = refreshed.ClosedReason
+	}
 	if refreshed.PRNumber != nil {
 		merged.PRNumber = refreshed.PRNumber
 	}
@@ -1449,12 +1452,13 @@ func (o *Orchestrator) completeTerminalRunning(
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
-	finalState := strings.TrimSpace(running.Issue.State)
+	issue := o.ensureClosedCompletedRunningIssueDone(ctx, issueID, running.Issue)
+	finalState := strings.TrimSpace(issue.State)
 	if finalState == "" {
 		finalState = FinalStateCompleted
 	}
 	state.Completed[issueID] = Completed{
-		Issue:       cloneIssue(running.Issue),
+		Issue:       cloneIssue(issue),
 		StartedAt:   running.StartedAt,
 		CompletedAt: completedAt,
 		FinalState:  finalState,
@@ -1464,7 +1468,28 @@ func (o *Orchestrator) completeTerminalRunning(
 	if diffStatsPresent(running.DiffStats) {
 		state.DiffStats[issueID] = running.DiffStats
 	}
-	o.reapWorkspace(ctx, state, running.Issue, workspaceReapReason(running.Issue, o.cfg.TerminalStates))
+	o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates))
+}
+
+func (o *Orchestrator) ensureClosedCompletedRunningIssueDone(ctx context.Context, issueID string, issue connector.Issue) connector.Issue {
+	if !issue.Closed || !closedReasonCompleted(issue.ClosedReason) {
+		return issue
+	}
+	targetState := doneStateName(o.cfg.TerminalStates)
+	if strings.TrimSpace(targetState) == "" {
+		return issue
+	}
+	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("mark closed completed running issue done failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
+		}
+		return issue
+	}
+	if o.logger != nil {
+		o.logger.Info("marked closed completed running issue done", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState)
+	}
+	issue.State = targetState
+	return issue
 }
 
 func terminalCompletedAt(issue connector.Issue, terminalStates []string, fallback time.Time) time.Time {

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -231,6 +231,71 @@ func TestTickReapsTerminalRunningIssue(t *testing.T) {
 	}
 }
 
+func TestTickMarksClosedCompletedRunningIssueDoneBeforeReaping(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 16, 13, 43, 15, 0, time.UTC)
+	startedAt := now.Add(-15 * time.Minute)
+	closedAt := now.Add(-46 * time.Second)
+	issue := connector.Issue{
+		ID:         "issue-closed-completed",
+		Identifier: "digitaldrywood/detent#487",
+		Title:      "Windows package managers",
+		State:      "Merging",
+		URL:        "https://github.com/digitaldrywood/detent/issues/487",
+	}
+	closed := cloneIssue(issue)
+	closed.State = "Done"
+	closed.Closed = true
+	closed.ClosedReason = "completed"
+	closed.StageUpdatedAt = &closedAt
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Human Review", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:     cloneIssue(issue),
+		StartedAt: startedAt,
+		Tokens:    CodexTotals{TotalTokens: 42, RuntimeSeconds: 90},
+		cancel:    cancel,
+	}
+
+	tracker := &runningStateConnector{issues: []connector.Issue{closed}}
+	reaper := &cleanupSweepReaper{}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if got, want := tracker.updates, []statusUpdate{{issueID: issue.ID, state: "Done"}}; !slices.Equal(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	completed, ok := state.Completed[issue.ID]
+	if !ok {
+		t.Fatalf("Completed[%q] missing", issue.ID)
+	}
+	if completed.FinalState != "Done" || completed.Issue.State != "Done" {
+		t.Fatalf("completed state = (%q, %q), want Done/Done", completed.Issue.State, completed.FinalState)
+	}
+	if len(reaper.issues) != 1 || reaper.issues[0].State != "Done" {
+		t.Fatalf("reaped issues = %#v, want Done issue", reaper.issues)
+	}
+	select {
+	case <-runCtx.Done():
+	default:
+		t.Fatal("running context was not cancelled")
+	}
+}
+
 func TestTickCompletesTerminalRunningIssueDuringWorkspaceCleanupSweep(t *testing.T) {
 	t.Parallel()
 
@@ -439,6 +504,7 @@ type runningStateConnector struct {
 	issuesByState []connector.Issue
 	err           error
 	requestedIDs  []string
+	updates       []statusUpdate
 }
 
 func (c *runningStateConnector) Name() string {
@@ -465,7 +531,8 @@ func (c *runningStateConnector) CreateComment(context.Context, string, string) e
 	return nil
 }
 
-func (c *runningStateConnector) UpdateIssueState(context.Context, string, string) error {
+func (c *runningStateConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updates = append(c.updates, statusUpdate{issueID: issueID, state: state})
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Prefer canonical configured Detent states before reverse state-map aliases when reading GitHub status labels.
- Mark closed/completed running issues as Done before cancelling and reaping their workspaces.
- Preserve GitHub closed reasons during running issue state refresh.

## Validation
- go build ./...
- go test ./...
- golangci-lint run