### PR TITLE
feat(dev-runtime): add kanban demo mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -748,12 +748,7 @@ For Detent dogfood/self-tests that need a running server, start an isolated mock
 runtime instead of stopping or reusing the live process on `127.0.0.1:4000`:
 
 ```sh
-detent dev-runtime \
-  --port 0 \
-  --home "$(mktemp -d)" \
-  --db ':memory:' \
-  --tracker memory \
-  --fixture testdata/dogfood/autopromote.yaml
+detent dev-runtime --port 0
 ```
 
 The command prints `Mode: isolated dev runtime`, the selected dashboard URL,
@@ -762,6 +757,29 @@ config/workspace home, an in-memory SQLite database, a stateful fixture-backed
 memory tracker, and a fake runner; it does not call GitHub or mutate a real
 ProjectV2 board. It refuses the live dogfood port and live
 `~/.detent/detent.db` unless explicitly overridden.
+
+Use the built-in Kanban demo when you want to evaluate the operator board and
+mutation dialogs without a GitHub token, a real ProjectV2 board, or production
+database state:
+
+```sh
+detent dev-runtime --demo kanban --port 0
+```
+
+The Kanban demo keeps the runtime isolated on the memory tracker, enables
+Kanban integration mode for the generated demo workflow, and includes explicit
+`server.kanban.allowed_transitions` such as `Backlog -> Todo` so drag/drop
+moves can be exercised without weakening production defaults. Demo cards cover
+Backlog, Todo, In Progress, Blocked, Human Review, Rework, Merging, Done, and
+Cancelled states, including issue-only cards, linked PR cards, CI pass,
+pending, and failure states, Codex review clean and finding states, labels,
+assignees, blockers, and wait metadata. Issue and PR comments are captured by
+the memory connector with no external side effects.
+
+Use the normal live runtime, `detent` with your global config, only when you
+intend to operate on the configured tracker and ProjectV2 board. Use
+`detent dev-runtime --fixture <path>` for focused fixture validation such as
+autopromote behavior, and use `--demo kanban` for safe board exploration.
 
 6. Start Detent:
 

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -908,6 +908,7 @@ func bootBanner(version string, displayURL string, isolated *IsolatedRuntimeInfo
 		writeBootBannerLine(&out, "DB", isolated.DBPath)
 		writeBootBannerLine(&out, "DB mode", isolated.DBMode)
 		writeBootBannerLine(&out, "Tracker", isolated.TrackerMode)
+		writeBootBannerLine(&out, "Demo", isolated.Demo)
 		writeBootBannerLine(&out, "Fixture", isolated.FixturePath)
 	}
 	return out.String()

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -189,6 +189,7 @@ type IsolatedRuntimeInfo struct {
 	DBMode        string
 	TrackerMode   string
 	FixturePath   string
+	Demo          string
 }
 
 type BootFunc func(context.Context, BootConfig) error

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/digitaldrywood/detent/internal/cli"
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/project"
 )
@@ -231,6 +232,50 @@ func TestDevRuntimeCommandBuildsIsolatedBootConfig(t *testing.T) {
 	}
 	if got.Isolated.DBMode != "file" || got.Isolated.TrackerMode != "memory" {
 		t.Fatalf("isolated metadata = %#v, want file DB and memory tracker", got.Isolated)
+	}
+}
+
+func TestDevRuntimeCommandBuildsKanbanDemoBootConfig(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--port", "0",
+		"dev-runtime",
+		"--home", home,
+		"--demo", "kanban",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if got.Isolated == nil {
+		t.Fatal("Isolated = nil, want isolated runtime metadata")
+	}
+	if got.Isolated.Demo != "kanban" {
+		t.Fatalf("Isolated.Demo = %q, want kanban", got.Isolated.Demo)
+	}
+	if got.Isolated.FixturePath != "" {
+		t.Fatalf("FixturePath = %q, want no external fixture for built-in demo", got.Isolated.FixturePath)
+	}
+	workflow, err := workflowconfig.LoadWorkflow(got.WorkflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if workflow.Config.Server.Kanban.Mode != workflowconfig.KanbanModeIntegration {
+		t.Fatalf("Kanban mode = %q, want integration", workflow.Config.Server.Kanban.Mode)
+	}
+	if !workflow.Config.KanbanTransitionAllowed("Backlog", "Todo") {
+		t.Fatal("KanbanTransitionAllowed(Backlog, Todo) = false, want demo override")
 	}
 }
 

--- a/internal/cli/dev_runtime.go
+++ b/internal/cli/dev_runtime.go
@@ -24,6 +24,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	var dbPath string
 	var trackerMode string
 	var fixturePath string
+	var demo string
 	var allowLiveDB bool
 	var allowProductionPort bool
 
@@ -51,6 +52,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 				DBPath:              dbPath,
 				TrackerMode:         trackerMode,
 				FixturePath:         fixturePath,
+				Demo:                demo,
 				Port:                runtimePort,
 				AllowLiveDatabase:   allowLiveDB,
 				AllowProductionPort: allowProductionPort,
@@ -66,6 +68,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	cmd.Flags().StringVar(&dbPath, "db", "", "isolated SQLite path or :memory:; relative paths are resolved inside --home")
 	cmd.Flags().StringVar(&trackerMode, "tracker", devruntime.TrackerMemory, "isolated tracker backend")
 	cmd.Flags().StringVar(&fixturePath, "fixture", "", "YAML fixture with mock issues and pull requests")
+	cmd.Flags().StringVar(&demo, "demo", "", "built-in isolated demo fixture (kanban)")
 	cmd.Flags().BoolVar(&allowLiveDB, "allow-live-db", false, "allow --db to point at the operator's live ~/.detent/detent.db")
 	cmd.Flags().BoolVar(&allowProductionPort, "allow-production-port", false, "allow binding the isolated runtime to the live dogfood port")
 	return cmd
@@ -116,6 +119,7 @@ func devRuntimeIsolationInfo(runtime devruntime.Runtime) *IsolatedRuntimeInfo {
 		DBMode:        runtime.DBMode,
 		TrackerMode:   runtime.TrackerMode,
 		FixturePath:   runtime.FixturePath,
+		Demo:          runtime.Demo,
 	}
 }
 
@@ -138,6 +142,10 @@ func devRuntimeError(err error) error {
 		return WrapValidation(hintedError(err, err.Error(), exampleHint(devRuntimeExampleCommand), devRuntimeExampleCommand))
 	case errors.Is(err, devruntime.ErrLiveDatabase):
 		return WrapValidation(hintedError(err, err.Error(), "Use the default :memory: DB or a path under --home for isolated tests.", "detent dev-runtime --db :memory:"))
+	case errors.Is(err, devruntime.ErrUnsupportedDemo):
+		return WrapValidation(hintedError(err, err.Error(), "Use --demo kanban or omit --demo.", "detent dev-runtime --demo kanban --port 0"))
+	case errors.Is(err, devruntime.ErrDemoFixtureConflict):
+		return WrapValidation(hintedError(err, err.Error(), "Use either --demo kanban or --fixture, not both.", "detent dev-runtime --demo kanban --port 0"))
 	default:
 		return err
 	}

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -5,7 +5,9 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"io"
 	"net/http"
+	"net/url"
 	"strings"
 	"sync"
 	"testing"
@@ -41,6 +43,77 @@ func TestStartIsolatedRuntimeAutoPromotesFixtureAndStopsOnCancel(t *testing.T) {
 	if !strings.Contains(body, `"status":"running"`) {
 		t.Fatalf("state response missing running status:\n%s", body)
 	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for isolated runtime to stop")
+	}
+}
+
+func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
+	runtime, err := devruntime.Build(devruntime.Config{Home: t.TempDir(), Port: 0, Demo: devruntime.DemoKanban})
+	if err != nil {
+		t.Fatalf("devruntime.Build() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	output := &lockedBuffer{}
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, devRuntimeBootConfig(runtime, "127.0.0.1", defaultOptions(), output))
+	}()
+	t.Cleanup(cancel)
+
+	dashboardURL := waitForIsolatedRuntimeURL(t, output, done)
+	if banner := output.String(); !strings.Contains(banner, "Demo: kanban") {
+		t.Fatalf("isolated runtime banner missing demo name:\n%s", banner)
+	}
+	waitForDashboard(t, dashboardURL+"/health", done)
+	postRuntimeRefresh(t, dashboardURL, done)
+
+	pageURL := dashboardURL + "/projects/dogfood/kanban"
+	body := waitForDashboardCondition(t, pageURL, done, "kanban demo mutation controls", func(body string) bool {
+		return strings.Contains(body, "Kanban demo backlog intake") &&
+			strings.Contains(body, `data-kanban-action="move"`) &&
+			strings.Contains(body, `hx-get="/api/v1/kanban/comment?`) &&
+			strings.Contains(body, `data-kanban-drop-state="Todo"`)
+	})
+	for _, want := range []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("kanban page missing lane %q:\n%s", want, body)
+		}
+	}
+
+	postRuntimeKanbanForm(t, dashboardURL+"/api/v1/kanban/move", done, url.Values{
+		"project_id":    {"dogfood"},
+		"issue_id":      {"kanban-demo-backlog"},
+		"current_state": {"Backlog"},
+		"target_state":  {"Todo"},
+	})
+	postRuntimeRefresh(t, dashboardURL, done)
+	waitForDashboardCondition(t, pageURL, done, "backlog card moved to todo", func(body string) bool {
+		return strings.Contains(body, `data-kanban-issue-id="kanban-demo-backlog"`) &&
+			strings.Contains(body, `data-kanban-current-state="Todo"`)
+	})
+
+	postRuntimeKanbanForm(t, dashboardURL+"/api/v1/kanban/comment", done, url.Values{
+		"project_id": {"dogfood"},
+		"target":     {"issue"},
+		"issue_id":   {"kanban-demo-backlog"},
+		"body":       {"Safe demo issue comment"},
+	})
+	postRuntimeKanbanForm(t, dashboardURL+"/api/v1/kanban/comment", done, url.Values{
+		"project_id":    {"dogfood"},
+		"target":        {"pr"},
+		"pr_repository": {"digitaldrywood/detent"},
+		"pr_number":     {"9515"},
+		"body":          {"Safe demo PR comment"},
+	})
 
 	cancel()
 	select {
@@ -123,6 +196,45 @@ func postRuntimeRefresh(t *testing.T, url string, done <-chan error) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out posting runtime refresh to %s", url)
+}
+
+func postRuntimeKanbanForm(t *testing.T, rawURL string, done <-chan error, form url.Values) {
+	t.Helper()
+
+	client := http.Client{Timeout: time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for ctx.Err() == nil {
+		select {
+		case err := <-done:
+			t.Fatalf("isolated runtime stopped before Kanban action: %v", err)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatalf("NewRequestWithContext() error = %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := client.Do(req)
+		if err == nil {
+			body, readErr := io.ReadAll(resp.Body)
+			closeErr := resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("ReadAll() error = %v", readErr)
+			}
+			if closeErr != nil {
+				t.Fatalf("Body.Close() error = %v", closeErr)
+			}
+			if resp.StatusCode == http.StatusOK {
+				return
+			}
+			t.Fatalf("Kanban action status = %d, want 200; body = %s", resp.StatusCode, string(body))
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out posting Kanban action to %s", rawURL)
 }
 
 func boardStateCountFromBody(t *testing.T, body string, state string) int {

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -12,21 +12,24 @@ import (
 )
 
 const (
-	EventKindComment        EventKind = "memory_tracker_comment"
-	EventKindStateUpdate    EventKind = "memory_tracker_state_update"
-	EventKindAssigneeUpdate EventKind = "memory_tracker_assignee_update"
-	EventKindFieldUpdate    EventKind = "memory_tracker_field_update"
-	EventKindClose          EventKind = "memory_tracker_close"
+	EventKindComment            EventKind = "memory_tracker_comment"
+	EventKindPullRequestComment EventKind = "memory_tracker_pull_request_comment"
+	EventKindStateUpdate        EventKind = "memory_tracker_state_update"
+	EventKindAssigneeUpdate     EventKind = "memory_tracker_assignee_update"
+	EventKindFieldUpdate        EventKind = "memory_tracker_field_update"
+	EventKindClose              EventKind = "memory_tracker_close"
 )
 
 type EventKind string
 
 type Event struct {
-	Kind    EventKind
-	IssueID string
-	Body    string
-	State   string
-	Login   string
+	Kind       EventKind
+	IssueID    string
+	Repository string
+	PRNumber   int
+	Body       string
+	State      string
+	Login      string
 
 	FieldName  string
 	FieldValue string
@@ -44,9 +47,11 @@ type Config struct {
 type Connector struct {
 	issues    []connector.Issue
 	eventSink EventSink
+	events    []Event
 	stateful  bool
 	now       func() time.Time
 	mu        sync.RWMutex
+	eventMu   sync.RWMutex
 }
 
 var _ connector.Connector = (*Connector)(nil)
@@ -55,6 +60,7 @@ var _ connector.IssueChildrenResolver = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
 var _ connector.IssueParentResolver = (*Connector)(nil)
 var _ connector.IssueReferenceResolver = (*Connector)(nil)
+var _ connector.PullRequestCommenter = (*Connector)(nil)
 
 func New(cfg Config) *Connector {
 	now := cfg.Now
@@ -198,6 +204,18 @@ func (c *Connector) CreateComment(_ context.Context, issueID string, body string
 	return nil
 }
 
+func (c *Connector) CreatePullRequestComment(_ context.Context, repository string, number int, body string) error {
+	c.send(Event{Kind: EventKindPullRequestComment, Repository: strings.TrimSpace(repository), PRNumber: number, Body: body})
+	return nil
+}
+
+func (c *Connector) Events() []Event {
+	c.eventMu.RLock()
+	defer c.eventMu.RUnlock()
+
+	return append([]Event(nil), c.events...)
+}
+
 func (c *Connector) CloseIssue(_ context.Context, issueID string) error {
 	c.applyIssue(issueID, func(issue *connector.Issue, now time.Time) {
 		issue.Closed = true
@@ -264,6 +282,10 @@ func (c *Connector) applyIssue(issueID string, update func(*connector.Issue, tim
 }
 
 func (c *Connector) send(event Event) {
+	c.eventMu.Lock()
+	c.events = append(c.events, event)
+	c.eventMu.Unlock()
+
 	if c.eventSink == nil {
 		return
 	}

--- a/internal/connector/memory/memory_test.go
+++ b/internal/connector/memory/memory_test.go
@@ -279,6 +279,27 @@ func TestConnectorMutationsMatchElixirMemoryAdapter(t *testing.T) {
 	}
 }
 
+func TestConnectorCapturesIssueAndPullRequestComments(t *testing.T) {
+	t.Parallel()
+
+	c := New(Config{})
+
+	if err := c.CreateComment(context.Background(), "issue-1", "issue comment"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	if err := c.CreatePullRequestComment(context.Background(), "digitaldrywood/detent", 42, "pr comment"); err != nil {
+		t.Fatalf("CreatePullRequestComment() error = %v", err)
+	}
+
+	want := []Event{
+		{Kind: EventKindComment, IssueID: "issue-1", Body: "issue comment"},
+		{Kind: EventKindPullRequestComment, Repository: "digitaldrywood/detent", PRNumber: 42, Body: "pr comment"},
+	}
+	if got := c.Events(); !reflect.DeepEqual(got, want) {
+		t.Fatalf("Events() = %#v, want %#v", got, want)
+	}
+}
+
 func TestConnectorStatefulMutationsUpdateFixtureState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -672,7 +672,7 @@ func writeWorkflow(path string, input workflowInput) error {
 	var kanban *workflowKanban
 	body := "Isolated mock Detent runtime for dogfood-safe e2e validation.\n"
 	if input.Demo == DemoKanban {
-		activeStates = nil
+		activeStates = []string{"Cancelled"}
 		observedStates = []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"}
 		autoPromote.Enabled = false
 		kanban = &workflowKanban{

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -17,6 +17,7 @@ import (
 
 const (
 	TrackerMemory = "memory"
+	DemoKanban    = "kanban"
 
 	defaultProjectID    = "dogfood"
 	defaultInstanceName = "detent-dev-runtime"
@@ -26,10 +27,12 @@ const (
 )
 
 var (
-	ErrUnsupportedTracker = errors.New("unsupported isolated runtime tracker")
-	ErrLiveDatabase       = errors.New("isolated runtime refuses the live Detent database")
-	ErrLivePort           = errors.New("isolated runtime refuses the live Detent port")
-	ErrInvalidPort        = errors.New("isolated runtime port must be greater than or equal to 0")
+	ErrUnsupportedTracker  = errors.New("unsupported isolated runtime tracker")
+	ErrLiveDatabase        = errors.New("isolated runtime refuses the live Detent database")
+	ErrLivePort            = errors.New("isolated runtime refuses the live Detent port")
+	ErrInvalidPort         = errors.New("isolated runtime port must be greater than or equal to 0")
+	ErrUnsupportedDemo     = errors.New("unsupported isolated runtime demo")
+	ErrDemoFixtureConflict = errors.New("isolated runtime demo cannot be combined with a fixture")
 )
 
 type Config struct {
@@ -37,6 +40,7 @@ type Config struct {
 	DBPath              string
 	TrackerMode         string
 	FixturePath         string
+	Demo                string
 	Port                int
 	AllowLiveDatabase   bool
 	AllowProductionPort bool
@@ -52,6 +56,7 @@ type Runtime struct {
 	DBMode        string
 	TrackerMode   string
 	FixturePath   string
+	Demo          string
 	Port          int
 	Global        globalconfig.Config
 	Issues        []connector.Issue
@@ -71,6 +76,10 @@ func Build(cfg Config) (Runtime, error) {
 	}
 	if trackerMode != TrackerMemory {
 		return Runtime{}, fmt.Errorf("%w: %s", ErrUnsupportedTracker, trackerMode)
+	}
+	demo, err := runtimeDemo(cfg.Demo)
+	if err != nil {
+		return Runtime{}, err
 	}
 
 	home, err := runtimeHome(cfg.Home)
@@ -93,7 +102,7 @@ func Build(cfg Config) (Runtime, error) {
 		}
 	}
 
-	issues, fixturePath, err := runtimeIssues(cfg.FixturePath)
+	issues, fixturePath, err := runtimeIssues(cfg.FixturePath, demo)
 	if err != nil {
 		return Runtime{}, err
 	}
@@ -105,6 +114,7 @@ func Build(cfg Config) (Runtime, error) {
 		SourceRoot:    sourceRoot,
 		Port:          cfg.Port,
 		Issues:        issues,
+		Demo:          demo,
 	}); err != nil {
 		return Runtime{}, err
 	}
@@ -126,10 +136,21 @@ func Build(cfg Config) (Runtime, error) {
 		DBMode:        dbMode(dbPath),
 		TrackerMode:   trackerMode,
 		FixturePath:   fixturePath,
+		Demo:          demo,
 		Port:          cfg.Port,
 		Global:        global,
 		Issues:        append([]connector.Issue(nil), issues...),
 	}, nil
+}
+
+func runtimeDemo(value string) (string, error) {
+	value = strings.ToLower(strings.TrimSpace(value))
+	switch value {
+	case "", DemoKanban:
+		return value, nil
+	default:
+		return "", fmt.Errorf("%w: %s", ErrUnsupportedDemo, value)
+	}
 }
 
 func runtimeHome(path string) (string, error) {
@@ -249,8 +270,14 @@ type fixtureFile struct {
 	Issues []connector.Issue `yaml:"issues"`
 }
 
-func runtimeIssues(path string) ([]connector.Issue, string, error) {
+func runtimeIssues(path string, demo string) ([]connector.Issue, string, error) {
 	path = strings.TrimSpace(path)
+	if demo != "" && path != "" {
+		return nil, "", ErrDemoFixtureConflict
+	}
+	if demo == DemoKanban {
+		return kanbanDemoIssues(), "", nil
+	}
 	if path == "" {
 		return defaultIssues(), "", nil
 	}
@@ -271,6 +298,207 @@ func runtimeIssues(path string) ([]connector.Issue, string, error) {
 		return nil, "", fmt.Errorf("resolve isolated runtime fixture: %w", err)
 	}
 	return fixture.Issues, absolute, nil
+}
+
+func kanbanDemoIssues() []connector.Issue {
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	at := func(hoursAgo int) *time.Time {
+		value := now.Add(-time.Duration(hoursAgo) * time.Hour)
+		return &value
+	}
+	fields := func(state string, owner string) map[string]string {
+		return map[string]string{
+			"Status": state,
+			"Owner":  owner,
+		}
+	}
+	return []connector.Issue{
+		{
+			ID:             "kanban-demo-backlog",
+			Identifier:     "digitaldrywood/detent#9511",
+			Title:          "Kanban demo backlog intake",
+			Description:    "Issue-only card for evaluating Backlog to Todo moves.",
+			State:          "Backlog",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9511",
+			Labels:         []string{"enhancement", "operator-demo"},
+			AssigneeID:     "operator-a",
+			Assignees:      []string{"operator-a"},
+			Fields:         fields("Backlog", "operations"),
+			UpdatedAt:      at(72),
+			StageUpdatedAt: at(72),
+		},
+		{
+			ID:             "kanban-demo-todo",
+			Identifier:     "digitaldrywood/detent#9512",
+			Title:          "Kanban demo todo ready card",
+			Description:    "Issue-only Todo card with labels and assignees.",
+			State:          "Todo",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9512",
+			Labels:         []string{"ui", "good-first-demo"},
+			AssigneeID:     "operator-b",
+			Assignees:      []string{"operator-b", "operator-c"},
+			Fields:         fields("Todo", "product"),
+			UpdatedAt:      at(8),
+			StageUpdatedAt: at(8),
+		},
+		{
+			ID:             "kanban-demo-progress",
+			Identifier:     "digitaldrywood/detent#9513",
+			Title:          "Kanban demo implementation in progress",
+			State:          "In Progress",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9513",
+			Labels:         []string{"enhancement", "backend"},
+			AssigneeID:     "agent-one",
+			Assignees:      []string{"agent-one"},
+			Fields:         fields("In Progress", "agents"),
+			UpdatedAt:      at(3),
+			StageUpdatedAt: at(3),
+			PullRequest: &connector.PullRequest{
+				Number:           9513,
+				URL:              "https://github.test/digitaldrywood/detent/pull/9513",
+				BranchName:       "detent/kanban-demo-progress",
+				State:            "OPEN",
+				CIStatus:         "pending",
+				RunningChecks:    []string{"make check"},
+				CheckRunCount:    1,
+				CodexReviewState: "CLEAN",
+			},
+		},
+		{
+			ID:             "kanban-demo-blocked",
+			Identifier:     "digitaldrywood/detent#9514",
+			Title:          "Kanban demo blocked dependency",
+			State:          "Blocked",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9514",
+			Labels:         []string{"blocked", "needs-dependency"},
+			AssigneeID:     "operator-d",
+			Assignees:      []string{"operator-d"},
+			BlockedBy:      []connector.BlockedRef{{ID: "kanban-demo-todo", Identifier: "digitaldrywood/detent#9512", State: "Todo"}},
+			BlockerReason:  "Depends on the Todo demo card before work can continue.",
+			Fields:         fields("Blocked", "operations"),
+			UpdatedAt:      at(28),
+			StageUpdatedAt: at(28),
+		},
+		{
+			ID:             "kanban-demo-review",
+			Identifier:     "digitaldrywood/detent#9515",
+			Title:          "Kanban demo human review candidate",
+			State:          "Human Review",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9515",
+			Labels:         []string{"enhancement", "requires-human-review"},
+			AssigneeID:     "reviewer-a",
+			Assignees:      []string{"reviewer-a"},
+			Fields:         fields("Human Review", "review"),
+			UpdatedAt:      at(2),
+			StageUpdatedAt: at(2),
+			PullRequest: &connector.PullRequest{
+				Number:                 9515,
+				URL:                    "https://github.test/digitaldrywood/detent/pull/9515",
+				BranchName:             "detent/kanban-demo-review",
+				State:                  "OPEN",
+				MergeableState:         "clean",
+				CIStatus:               "success",
+				CheckRunCount:          4,
+				StatusContextCount:     1,
+				CodexReviewState:       "CLEAN",
+				CodexReviewSubmittedAt: at(1),
+			},
+		},
+		{
+			ID:             "kanban-demo-rework",
+			Identifier:     "digitaldrywood/detent#9516",
+			Title:          "Kanban demo rework finding",
+			State:          "Rework",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9516",
+			Labels:         []string{"bug", "codex-review:p1"},
+			AssigneeID:     "agent-two",
+			Assignees:      []string{"agent-two"},
+			Fields:         fields("Rework", "agents"),
+			UpdatedAt:      at(10),
+			StageUpdatedAt: at(10),
+			PullRequest: &connector.PullRequest{
+				Number:           9516,
+				URL:              "https://github.test/digitaldrywood/detent/pull/9516",
+				BranchName:       "detent/kanban-demo-rework",
+				State:            "OPEN",
+				MergeableState:   "dirty",
+				CIStatus:         "failure",
+				CheckRunCount:    3,
+				CodexReviewState: "P1",
+				CodexReviewFindings: []connector.PullRequestFinding{{
+					Body: "P1 demo finding for operator review",
+					URL:  "https://github.test/digitaldrywood/detent/pull/9516#discussion_r1",
+					Path: "internal/demo.go",
+					Line: 37,
+				}},
+			},
+		},
+		{
+			ID:             "kanban-demo-merging",
+			Identifier:     "digitaldrywood/detent#9517",
+			Title:          "Kanban demo merging train",
+			State:          "Merging",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9517",
+			Labels:         []string{"release-readiness", "merge-train"},
+			AssigneeID:     "merger-a",
+			Assignees:      []string{"merger-a"},
+			Fields:         fields("Merging", "release"),
+			UpdatedAt:      at(1),
+			StageUpdatedAt: at(1),
+			PullRequest: &connector.PullRequest{
+				Number:            9517,
+				URL:               "https://github.test/digitaldrywood/detent/pull/9517",
+				BranchName:        "detent/kanban-demo-merging",
+				State:             "OPEN",
+				MergeableState:    "clean",
+				CIStatus:          "pending",
+				CIDurationSeconds: 780,
+				CheckRunCount:     5,
+				RunningChecks:     []string{"release-smoke"},
+				CodexReviewState:  "CLEAN",
+				SlowChecks:        []connector.PullRequestCheck{{Name: "go test -race", Status: "completed", Conclusion: "success", DurationSeconds: 620}},
+			},
+		},
+		{
+			ID:             "kanban-demo-done",
+			Identifier:     "digitaldrywood/detent#9518",
+			Title:          "Kanban demo completed PR",
+			State:          "Done",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9518",
+			Closed:         true,
+			ClosedReason:   "completed",
+			Labels:         []string{"enhancement", "shipped"},
+			AssigneeID:     "operator-e",
+			Assignees:      []string{"operator-e"},
+			Fields:         fields("Done", "release"),
+			UpdatedAt:      at(24),
+			StageUpdatedAt: at(24),
+			PullRequest: &connector.PullRequest{
+				Number:           9518,
+				URL:              "https://github.test/digitaldrywood/detent/pull/9518",
+				BranchName:       "detent/kanban-demo-done",
+				State:            "MERGED",
+				MergeableState:   "clean",
+				CIStatus:         "success",
+				CodexReviewState: "CLEAN",
+			},
+		},
+		{
+			ID:             "kanban-demo-cancelled",
+			Identifier:     "digitaldrywood/detent#9519",
+			Title:          "Kanban demo cancelled request",
+			State:          "Cancelled",
+			URL:            "https://github.test/digitaldrywood/detent/issues/9519",
+			Closed:         true,
+			ClosedReason:   "not_planned",
+			Labels:         []string{"cancelled", "operator-demo"},
+			AssigneeID:     "operator-f",
+			Assignees:      []string{"operator-f"},
+			Fields:         fields("Cancelled", "operations"),
+			UpdatedAt:      at(48),
+			StageUpdatedAt: at(48),
+		},
+	}
 }
 
 func defaultIssues() []connector.Issue {
@@ -371,6 +599,7 @@ type workflowInput struct {
 	SourceRoot    string
 	Port          int
 	Issues        []connector.Issue
+	Demo          string
 }
 
 type workflowFrontmatter struct {
@@ -420,18 +649,44 @@ type workflowGate struct {
 }
 
 type workflowServer struct {
-	Host string `yaml:"host"`
-	Port *int   `yaml:"port"`
+	Host   string          `yaml:"host"`
+	Port   *int            `yaml:"port"`
+	Kanban *workflowKanban `yaml:"kanban,omitempty"`
+}
+
+type workflowKanban struct {
+	Mode               string              `yaml:"mode,omitempty"`
+	AllowedTransitions map[string][]string `yaml:"allowed_transitions,omitempty"`
 }
 
 func writeWorkflow(path string, input workflowInput) error {
 	port := input.Port
+	activeStates := []string{"Todo", "In Progress", "Rework", "Merging"}
+	observedStates := []string{"Backlog", "Human Review", "Blocked", "Merging", "Done"}
+	terminalStates := []string{"Done", "Cancelled", "Canceled"}
+	autoPromote := workflowAutoPromote{
+		Enabled:      true,
+		QuietSeconds: 0,
+		OptoutLabel:  "requires-human-review",
+	}
+	var kanban *workflowKanban
+	body := "Isolated mock Detent runtime for dogfood-safe e2e validation.\n"
+	if input.Demo == DemoKanban {
+		activeStates = nil
+		observedStates = []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"}
+		autoPromote.Enabled = false
+		kanban = &workflowKanban{
+			Mode:               "integration",
+			AllowedTransitions: kanbanDemoAllowedTransitions(),
+		}
+		body = "Isolated Kanban demo runtime for dogfood-safe board evaluation.\n"
+	}
 	frontmatter := workflowFrontmatter{
 		Tracker: workflowTracker{
 			Kind:           input.TrackerMode,
-			ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
-			ObservedStates: []string{"Backlog", "Human Review", "Blocked", "Merging", "Done"},
-			TerminalStates: []string{"Done", "Cancelled", "Canceled"},
+			ActiveStates:   activeStates,
+			ObservedStates: observedStates,
+			TerminalStates: terminalStates,
 			StateMap:       map[string]string{},
 			Issues:         append([]connector.Issue(nil), input.Issues...),
 		},
@@ -444,11 +699,7 @@ func writeWorkflow(path string, input workflowInput) error {
 		Agent: workflowAgent{
 			MaxConcurrentAgents:        2,
 			MaxConcurrentAgentsByState: map[string]int{"Merging": 1},
-			AutoPromote: workflowAutoPromote{
-				Enabled:      true,
-				QuietSeconds: 0,
-				OptoutLabel:  "requires-human-review",
-			},
+			AutoPromote:                autoPromote,
 		},
 		Gate: workflowGate{
 			Kind:                   "command",
@@ -456,19 +707,35 @@ func writeWorkflow(path string, input workflowInput) error {
 			RequireAutomatedReview: true,
 		},
 		Server: workflowServer{
-			Host: defaultHost,
-			Port: &port,
+			Host:   defaultHost,
+			Port:   &port,
+			Kanban: kanban,
 		},
 	}
 	raw, err := yaml.Marshal(frontmatter)
 	if err != nil {
 		return fmt.Errorf("marshal isolated workflow: %w", err)
 	}
-	content := "---\n" + string(raw) + "---\nIsolated mock Detent runtime for dogfood-safe e2e validation.\n"
+	content := "---\n" + string(raw) + "---\n" + body
 	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
 		return fmt.Errorf("write isolated workflow: %w", err)
 	}
 	return nil
+}
+
+func kanbanDemoAllowedTransitions() map[string][]string {
+	return map[string][]string{
+		"Backlog":      {"Todo", "Cancelled"},
+		"Todo":         {"In Progress", "Blocked", "Cancelled"},
+		"In Progress":  {"Blocked", "Human Review", "Rework", "Cancelled"},
+		"Blocked":      {"Todo", "In Progress", "Rework", "Cancelled"},
+		"Human Review": {"Rework", "Merging", "Blocked", "Cancelled"},
+		"Rework":       {"In Progress", "Human Review", "Blocked", "Cancelled"},
+		"Merging":      {"Done", "Blocked", "Rework", "Cancelled"},
+		"Done":         {},
+		"Cancelled":    {"Backlog"},
+		"Canceled":     {},
+	}
 }
 
 func globalConfig(path string, workflowPath string, sourceRoot string, port int) globalconfig.Config {

--- a/internal/devruntime/runtime_test.go
+++ b/internal/devruntime/runtime_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 
@@ -115,6 +116,9 @@ func TestBuildKanbanDemoCreatesIntegrationWorkflow(t *testing.T) {
 	if workflow.Config.Server.Kanban.Mode != workflowconfig.KanbanModeIntegration {
 		t.Fatalf("Kanban mode = %q, want integration", workflow.Config.Server.Kanban.Mode)
 	}
+	if got := workflow.Config.Tracker.ActiveStates; !slices.Equal(got, []string{"Cancelled"}) {
+		t.Fatalf("ActiveStates = %#v, want terminal-only demo state", got)
+	}
 	if !workflow.Config.KanbanTransitionAllowed("Backlog", "Todo") {
 		t.Fatal("KanbanTransitionAllowed(Backlog, Todo) = false, want explicit demo transition")
 	}
@@ -126,10 +130,17 @@ func TestBuildKanbanDemoCreatesIntegrationWorkflow(t *testing.T) {
 	}
 
 	states := map[string]int{}
+	activeStates := stateSet(workflow.Config.Tracker.ActiveStates)
+	terminalStates := stateSet(workflow.Config.Tracker.TerminalStates)
 	var issueOnly, linkedPR, ciPass, ciPending, ciFail, reviewClean, reviewFinding bool
 	var labels, assignees, blockers, waitMetadata bool
 	for _, issue := range workflow.Config.Tracker.Issues {
 		states[issue.State]++
+		if _, active := activeStates[strings.ToLower(issue.State)]; active {
+			if _, terminal := terminalStates[strings.ToLower(issue.State)]; !terminal {
+				t.Fatalf("demo issue %q in state %q would be dispatchable", issue.ID, issue.State)
+			}
+		}
 		issueOnly = issueOnly || issue.PullRequest == nil
 		labels = labels || len(issue.Labels) > 0
 		assignees = assignees || len(issue.Assignees) > 0
@@ -176,6 +187,17 @@ func TestBuildKanbanDemoCreatesIntegrationWorkflow(t *testing.T) {
 			t.Fatalf("demo fixture missing %s coverage", name)
 		}
 	}
+}
+
+func stateSet(states []string) map[string]struct{} {
+	out := make(map[string]struct{}, len(states))
+	for _, state := range states {
+		state = strings.ToLower(strings.TrimSpace(state))
+		if state != "" {
+			out[state] = struct{}{}
+		}
+	}
+	return out
 }
 
 func TestBuildRejectsUnsafeRuntimeInputs(t *testing.T) {

--- a/internal/devruntime/runtime_test.go
+++ b/internal/devruntime/runtime_test.go
@@ -91,6 +91,93 @@ func TestBuildLoadsFixtureIssues(t *testing.T) {
 	}
 }
 
+func TestBuildKanbanDemoCreatesIntegrationWorkflow(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := Build(Config{Home: t.TempDir(), Demo: DemoKanban, Port: 0})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if runtime.Demo != DemoKanban {
+		t.Fatalf("Demo = %q, want %q", runtime.Demo, DemoKanban)
+	}
+	if runtime.TrackerMode != TrackerMemory || runtime.FixturePath != "" {
+		t.Fatalf("TrackerMode = %q FixturePath = %q, want memory demo without external fixture", runtime.TrackerMode, runtime.FixturePath)
+	}
+
+	workflow, err := workflowconfig.LoadWorkflow(runtime.WorkflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if workflow.Config.Tracker.Kind != workflowconfig.TrackerMemory {
+		t.Fatalf("workflow tracker = %q, want memory", workflow.Config.Tracker.Kind)
+	}
+	if workflow.Config.Server.Kanban.Mode != workflowconfig.KanbanModeIntegration {
+		t.Fatalf("Kanban mode = %q, want integration", workflow.Config.Server.Kanban.Mode)
+	}
+	if !workflow.Config.KanbanTransitionAllowed("Backlog", "Todo") {
+		t.Fatal("KanbanTransitionAllowed(Backlog, Todo) = false, want explicit demo transition")
+	}
+	if workflow.Config.KanbanTransitionAllowed("Done", "Todo") {
+		t.Fatal("KanbanTransitionAllowed(Done, Todo) = true, want terminal demo lane without active move")
+	}
+	if workflow.Config.Agent.AutoPromote.Enabled {
+		t.Fatal("AutoPromote.Enabled = true, want stable demo board")
+	}
+
+	states := map[string]int{}
+	var issueOnly, linkedPR, ciPass, ciPending, ciFail, reviewClean, reviewFinding bool
+	var labels, assignees, blockers, waitMetadata bool
+	for _, issue := range workflow.Config.Tracker.Issues {
+		states[issue.State]++
+		issueOnly = issueOnly || issue.PullRequest == nil
+		labels = labels || len(issue.Labels) > 0
+		assignees = assignees || len(issue.Assignees) > 0
+		blockers = blockers || len(issue.BlockedBy) > 0 || strings.TrimSpace(issue.BlockerReason) != ""
+		if issue.PullRequest == nil {
+			continue
+		}
+		linkedPR = true
+		switch strings.ToLower(strings.TrimSpace(issue.PullRequest.CIStatus)) {
+		case "success", "pass":
+			ciPass = true
+		case "pending", "in_progress":
+			ciPending = true
+		case "failure", "fail":
+			ciFail = true
+		}
+		reviewClean = reviewClean || strings.EqualFold(issue.PullRequest.CodexReviewState, "CLEAN")
+		reviewFinding = reviewFinding || strings.EqualFold(issue.PullRequest.CodexReviewState, "P1") || len(issue.PullRequest.CodexReviewFindings) > 0
+		waitMetadata = waitMetadata ||
+			issue.PullRequest.CIDurationSeconds > 0 ||
+			len(issue.PullRequest.SlowChecks) > 0 ||
+			len(issue.PullRequest.RunningChecks) > 0
+	}
+	for _, state := range []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"} {
+		if states[state] == 0 {
+			t.Fatalf("demo state %q count = 0; states = %#v", state, states)
+		}
+	}
+	checks := map[string]bool{
+		"issue-only":     issueOnly,
+		"linked PR":      linkedPR,
+		"CI pass":        ciPass,
+		"CI pending":     ciPending,
+		"CI fail":        ciFail,
+		"review clean":   reviewClean,
+		"review finding": reviewFinding,
+		"labels":         labels,
+		"assignees":      assignees,
+		"blockers":       blockers,
+		"wait metadata":  waitMetadata,
+	}
+	for name, ok := range checks {
+		if !ok {
+			t.Fatalf("demo fixture missing %s coverage", name)
+		}
+	}
+}
+
 func TestBuildRejectsUnsafeRuntimeInputs(t *testing.T) {
 	t.Parallel()
 
@@ -108,6 +195,16 @@ func TestBuildRejectsUnsafeRuntimeInputs(t *testing.T) {
 			name: "unsupported tracker",
 			cfg:  Config{Home: t.TempDir(), TrackerMode: "github"},
 			want: ErrUnsupportedTracker,
+		},
+		{
+			name: "unsupported demo",
+			cfg:  Config{Home: t.TempDir(), Demo: "unknown"},
+			want: ErrUnsupportedDemo,
+		},
+		{
+			name: "demo fixture conflict",
+			cfg:  Config{Home: t.TempDir(), Demo: DemoKanban, FixturePath: "fixture.yaml"},
+			want: ErrDemoFixtureConflict,
 		},
 		{
 			name: "live database",

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -630,7 +630,8 @@ func kanbanAllowedTransitions(cfg workflowconfig.Config, states []string) map[st
 }
 
 func snapshotKanbanIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
-	issues := make([]telemetry.Issue, 0, len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked)+len(snapshot.Completed))
+	issues := make([]telemetry.Issue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked)+len(snapshot.Completed))
+	issues = append(issues, snapshot.BoardIssues...)
 	issues = append(issues, snapshot.Pipeline...)
 	for _, row := range snapshot.Running {
 		issues = append(issues, row.Issue)


### PR DESCRIPTION
## Summary

- Add `detent dev-runtime --demo kanban` with a built-in memory-only Kanban fixture and demo workflow integration settings.
- Capture issue and PR comments in the memory connector and include board issues in Kanban mutation freshness checks.
- Document when to use the Kanban demo versus the live global-config runtime.

Fixes #512

## Test Plan

- [x] `go test ./internal/devruntime ./internal/connector/memory ./internal/web ./internal/cli`
- [x] `make check`