### PR TITLE
feat(gate): add ci failure rework action

### DIFF
--- a/README.md
+++ b/README.md
@@ -579,6 +579,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
+  ci_failure_action: skip
 server:
   host: 127.0.0.1
   port: 4000
@@ -625,6 +626,7 @@ agent:
 gate:
   kind: command
   run: make check
+  ci_failure_action: skip
 ---
 You are working on {{ issue.identifier }}: {{ issue.title }}.
 ```
@@ -679,7 +681,10 @@ current-head automated PR review before auto-promotion. Set
 auto-promote from `Human Review` after a linked open PR, green CI, no P1 bot
 review findings, and the quiet period. The quiet period resets on observed
 issue updates, Project status updates, automated PR review submission, and
-linked PR activity such as a fresh push to the PR head. Use
+linked PR activity such as a fresh push to the PR head. Set
+`ci_failure_action: rework` when failed or cancelled current-head CI should move
+a `Human Review` item back to `Rework`; the default `skip` parks it in
+`Human Review`, and pending CI stays parked. Use
 `kind: human_review` with `approval_label` only when the workflow explicitly
 requires a human approval label to promote.
 
@@ -1029,6 +1034,9 @@ of that state is controlled by the workflow:
 - `gate.kind: command` with `require_automated_review: false` keeps the linked
   PR, green CI, no-P1, and quiet-period checks but does not require a bot PR
   review to exist.
+- `gate.ci_failure_action: rework` routes failed or cancelled current-head CI
+  from `Human Review` back to `Rework`; the default `skip` leaves the item
+  parked while CI is not green.
 - `gate.kind: human_review` requires a linked open PR plus the configured
   `approval_label` on the issue.
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1007,12 +1007,13 @@ issue-field verification step instead.
    rg -n '^server:|host: <dashboard-host>|port:' <source-root>/WORKFLOW.md
    ```
 
-5. **Set the gate from the interview.** For command gates, include the command
-   and whether an automated GitHub PR review is required for auto-promotion.
-   For human gates, include the approval label. Verify:
+5. **Set the gate from the interview.** For command gates, include the command,
+   whether an automated GitHub PR review is required for auto-promotion, and
+   whether failed current-head CI parks in `Human Review` or routes to
+   `Rework`. For human gates, include the approval label. Verify:
 
    ```sh
-   rg -n '^gate:|kind: <command|human_review>|run: <gate-command>|require_automated_review: <true|false>|approval_label: <label>' \
+   rg -n '^gate:|kind: <command|human_review>|run: <gate-command>|require_automated_review: <true|false>|ci_failure_action: <skip|rework>|approval_label: <label>' \
      <source-root>/WORKFLOW.md
    ```
 
@@ -1023,6 +1024,7 @@ issue-field verification step instead.
      kind: command
      run: <gate-command>
      require_automated_review: <true|false>
+     ci_failure_action: <skip|rework>
    ```
 
    Human review gate shape:
@@ -1086,7 +1088,10 @@ issue-field verification step instead.
    `require_automated_review: true`, it also requires a current-head automated
    GitHub PR review. With `require_automated_review: false`, bot PR review is
    not required to exist, but any observed P1 bot findings still route the item
-   to `Rework`. The quiet period resets on observed issue updates, Project
+   to `Rework`. With `ci_failure_action: rework`, failed or cancelled
+   current-head CI also routes the item to `Rework`; the default `skip` leaves
+   non-green CI parked in `Human Review`. Pending CI stays parked. The quiet
+   period resets on observed issue updates, Project
    status updates, automated PR review submission, and linked PR activity such
    as a fresh push to the PR head. `detent doctor --port 0` reports sampled
    `Human Review` candidates and reasons such as `automated_review_missing`
@@ -1556,6 +1561,7 @@ PR cards derive status from the linked issue.
 | Dashboard bind | `server.host` in `WORKFLOW.md`, or `--host` in the startup command or service `ExecStart`. |
 | Validation command | `gate.kind: command` and `gate.run` in `WORKFLOW.md`. |
 | Automated PR review requirement | `gate.kind: command` and `gate.require_automated_review` in `WORKFLOW.md`. |
+| Failed CI recovery | `gate.kind: command` and `gate.ci_failure_action` in `WORKFLOW.md`. |
 | Human validation label | `gate.kind: human_review` and `gate.approval_label` in `WORKFLOW.md`. |
 | Per-project concurrency | `agent.max_concurrent_agents` in `WORKFLOW.md`. |
 | Merge serialization | `agent.max_concurrent_agents_by_state.Merging: 1` in `WORKFLOW.md`. |

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -23,6 +23,9 @@ The execution edge still carries these code/git/PR assumptions.
 - `gate.kind: command` with `require_automated_review: false` keeps the
   command, linked PR, green CI, no-P1, and quiet-period checks but does not
   require an automated GitHub PR review to exist before promotion.
+- `gate.kind: command` with `ci_failure_action: rework` routes failed or
+  cancelled current-head CI from `Human Review` back to `Rework`; the default
+  `skip` parks the item while CI is not green.
 - The quiet period resets on observed issue updates, Project status updates,
   automated PR review submission, and linked PR activity such as a fresh push
   to the PR head.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -780,6 +780,32 @@ Prompt
 	}
 }
 
+func TestParseWorkflowCommandGateCIFailureAction(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+gate:
+  kind: command
+  run: make check
+  ci_failure_action: rework
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	cfg := workflow.Config.Gate
+	if cfg.CIFailureAction != gate.CIFailureActionRework {
+		t.Fatalf("Gate.CIFailureAction = %q, want %q", cfg.CIFailureAction, gate.CIFailureActionRework)
+	}
+}
+
 func TestParseWorkflowAgentRoutesCanUseLegacyCodexBackend(t *testing.T) {
 	t.Parallel()
 
@@ -1223,11 +1249,13 @@ tracker:
   kind: memory
 gate:
   kind: checklist
+  ci_failure_action: bounce
 ---
 Prompt
 `,
 			want: []string{
 				"gate.kind must be one of command, human_review",
+				"gate.ci_failure_action must be one of skip, rework",
 			},
 		},
 	}

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -646,6 +646,7 @@ type workflowGate struct {
 	Kind                   string `yaml:"kind"`
 	Run                    string `yaml:"run"`
 	RequireAutomatedReview bool   `yaml:"require_automated_review"`
+	CIFailureAction        string `yaml:"ci_failure_action"`
 }
 
 type workflowServer struct {
@@ -705,6 +706,7 @@ func writeWorkflow(path string, input workflowInput) error {
 			Kind:                   "command",
 			Run:                    "true",
 			RequireAutomatedReview: true,
+			CIFailureAction:        "skip",
 		},
 		Server: workflowServer{
 			Host:   defaultHost,

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -11,6 +11,9 @@ const (
 
 	DefaultCommand       = "make check"
 	DefaultApprovalLabel = "human-approved"
+
+	CIFailureActionSkip   = "skip"
+	CIFailureActionRework = "rework"
 )
 
 type Config struct {
@@ -18,6 +21,7 @@ type Config struct {
 	Run                    string `yaml:"run"`
 	ApprovalLabel          string `yaml:"approval_label"`
 	RequireAutomatedReview *bool  `yaml:"require_automated_review"`
+	CIFailureAction        string `yaml:"ci_failure_action"`
 }
 
 type Summary struct {
@@ -75,6 +79,7 @@ func DefaultConfig() Config {
 		Run:                    DefaultCommand,
 		ApprovalLabel:          DefaultApprovalLabel,
 		RequireAutomatedReview: new(true),
+		CIFailureAction:        CIFailureActionSkip,
 	}
 }
 
@@ -82,6 +87,7 @@ func Effective(cfg Config) Config {
 	cfg.Kind = NormalizeKind(cfg.Kind)
 	cfg.Run = strings.TrimSpace(cfg.Run)
 	cfg.ApprovalLabel = normalizeLabel(cfg.ApprovalLabel)
+	cfg.CIFailureAction = NormalizeCIFailureAction(cfg.CIFailureAction)
 
 	if cfg.Kind == "" {
 		cfg.Kind = KindCommand
@@ -101,6 +107,9 @@ func Effective(cfg Config) Config {
 	if cfg.ApprovalLabel == "" {
 		cfg.ApprovalLabel = DefaultApprovalLabel
 	}
+	if cfg.CIFailureAction == "" {
+		cfg.CIFailureAction = CIFailureActionSkip
+	}
 	return cfg
 }
 
@@ -115,13 +124,30 @@ func NormalizeKind(kind string) string {
 	}
 }
 
+func NormalizeCIFailureAction(action string) string {
+	switch strings.ToLower(strings.TrimSpace(action)) {
+	case "", CIFailureActionSkip:
+		return CIFailureActionSkip
+	case CIFailureActionRework:
+		return CIFailureActionRework
+	default:
+		return strings.ToLower(strings.TrimSpace(action))
+	}
+}
+
 func Validate(prefix string, cfg Config) []string {
+	var problems []string
 	switch NormalizeKind(cfg.Kind) {
 	case KindCommand, KindHumanReview:
-		return nil
 	default:
-		return []string{prefix + ".kind must be one of command, human_review"}
+		problems = append(problems, prefix+".kind must be one of command, human_review")
 	}
+	switch NormalizeCIFailureAction(cfg.CIFailureAction) {
+	case CIFailureActionSkip, CIFailureActionRework:
+	default:
+		problems = append(problems, prefix+".ci_failure_action must be one of skip, rework")
+	}
+	return problems
 }
 
 func Instructions(cfg Config) string {
@@ -157,9 +183,10 @@ func evaluateCommand(cfg Config, summary Summary, now time.Time, opts Evaluation
 	if missingPullRequest(summary) {
 		return decision(ActionSkip, ReasonMissingPullRequest)
 	}
-	if normalizedCIStatus(summary.CIStatus) != "green" {
-		out := decision(ActionSkip, ReasonCINotGreen)
-		out.CIStatus = normalizedCIStatus(summary.CIStatus)
+	ciStatus := normalizedCIStatus(summary.CIStatus)
+	if ciStatus != "green" {
+		out := decision(ciFailureAction(cfg, summary.CIStatus), ReasonCINotGreen)
+		out.CIStatus = ciStatus
 		return out
 	}
 	if automatedReviewHasP1(summary.ReviewState) || len(summary.P1Findings) > 0 {
@@ -209,6 +236,26 @@ func normalizedCIStatus(status string) string {
 		return "red"
 	default:
 		return strings.ToLower(strings.TrimSpace(status))
+	}
+}
+
+func ciFailureAction(cfg Config, status string) Action {
+	if cfg.CIFailureAction == CIFailureActionRework && definitiveCIFailure(status) {
+		return ActionRework
+	}
+	return ActionSkip
+}
+
+func definitiveCIFailure(status string) bool {
+	switch normalizedCIStatus(status) {
+	case "red":
+		return true
+	}
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "cancelled", "canceled", "error":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -17,27 +17,32 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 		{
 			name: "omitted gate defaults to make check command",
 			cfg:  Config{},
-			want: Config{Kind: KindCommand, Run: DefaultCommand, ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true)},
+			want: Config{Kind: KindCommand, Run: DefaultCommand, ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionSkip},
 		},
 		{
 			name: "command keeps custom run",
 			cfg:  Config{Kind: " command ", Run: " make verify "},
-			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true)},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionSkip},
 		},
 		{
 			name: "command can disable automated review requirement",
 			cfg:  Config{Kind: KindCommand, Run: "make verify", RequireAutomatedReview: new(false)},
-			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(false)},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(false), CIFailureAction: CIFailureActionSkip},
+		},
+		{
+			name: "command can route failed ci to rework",
+			cfg:  Config{Kind: KindCommand, Run: "make verify", CIFailureAction: " Rework "},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionRework},
 		},
 		{
 			name: "human review normalizes alias and approval label",
 			cfg:  Config{Kind: "human-review", Run: "make check", ApprovalLabel: " Human-Approved "},
-			want: Config{Kind: KindHumanReview, Run: "", ApprovalLabel: "human-approved"},
+			want: Config{Kind: KindHumanReview, Run: "", ApprovalLabel: "human-approved", CIFailureAction: CIFailureActionSkip},
 		},
 		{
 			name: "human review gets default approval label",
 			cfg:  Config{Kind: KindHumanReview},
-			want: Config{Kind: KindHumanReview, Run: "", ApprovalLabel: DefaultApprovalLabel},
+			want: Config{Kind: KindHumanReview, Run: "", ApprovalLabel: DefaultApprovalLabel, CIFailureAction: CIFailureActionSkip},
 		},
 	}
 
@@ -87,6 +92,33 @@ func TestEvaluate(t *testing.T) {
 				CIStatus:       "red",
 			},
 			want: Decision{Action: ActionSkip, Reason: ReasonCINotGreen, CIStatus: "red"},
+		},
+		{
+			name: "command gate reworks red ci when configured",
+			cfg:  Config{Kind: KindCommand, CIFailureAction: CIFailureActionRework},
+			input: Summary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "fail",
+			},
+			want: Decision{Action: ActionRework, Reason: ReasonCINotGreen, CIStatus: "red"},
+		},
+		{
+			name: "command gate reworks cancelled ci when configured",
+			cfg:  Config{Kind: KindCommand, CIFailureAction: CIFailureActionRework},
+			input: Summary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "cancelled",
+			},
+			want: Decision{Action: ActionRework, Reason: ReasonCINotGreen, CIStatus: "cancelled"},
+		},
+		{
+			name: "command gate skips pending ci when rework is configured",
+			cfg:  Config{Kind: KindCommand, CIFailureAction: CIFailureActionRework},
+			input: Summary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "pending",
+			},
+			want: Decision{Action: ActionSkip, Reason: ReasonCINotGreen, CIStatus: "pending"},
 		},
 		{
 			name: "command gate waits for automated review",
@@ -201,6 +233,7 @@ func configsEqual(left Config, right Config) bool {
 	return left.Kind == right.Kind &&
 		left.Run == right.Run &&
 		left.ApprovalLabel == right.ApprovalLabel &&
+		left.CIFailureAction == right.CIFailureAction &&
 		boolPointerEqual(left.RequireAutomatedReview, right.RequireAutomatedReview)
 }
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -214,7 +214,11 @@ func autoPromoteComment(
 	case autoPromoteMergingState:
 		b.WriteString("Auto-promoted this issue from Human Review to Merging.")
 	case autoPromoteReworkState:
-		b.WriteString("Auto-promote routed this issue from Human Review to Rework.")
+		b.WriteString("Auto-promote routed this issue from Human Review to Rework")
+		if decision.Reason == AutoPromoteReasonCINotGreen {
+			b.WriteString(": current-head CI is failing")
+		}
+		b.WriteString(".")
 	default:
 		return ""
 	}

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 )
 
 func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
@@ -98,6 +99,33 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 				"reason: p1_findings",
 				"Unsafe migration.",
 				"https://github.test/digitaldrywood/detent/pull/43#pullrequestreview-1",
+			},
+		},
+		{
+			name: "routes failing ci to rework when configured",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				Gate: gate.Config{
+					Kind:            gate.KindCommand,
+					CIFailureAction: gate.CIFailureActionRework,
+				},
+			},
+			issue: autoPromoteTickIssue("issue-red-ci", []string{"bug"}, &connector.PullRequest{
+				Number:   48,
+				URL:      "https://github.test/digitaldrywood/detent/pull/48",
+				State:    "OPEN",
+				CIStatus: "fail",
+			}),
+			wantUpdates: []autoPromoteTickUpdate{{
+				issueID: "issue-red-ci",
+				state:   "Rework",
+			}},
+			wantCommentFragments: []string{
+				"Auto-promote routed this issue from Human Review to Rework: current-head CI is failing.",
+				"reason: ci_not_green",
+				"ci_status: red",
+				"https://github.test/digitaldrywood/detent/pull/48",
 			},
 		},
 		{

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -182,6 +182,7 @@ func gateAssigns(cfg gate.Config) map[string]any {
 		"run":                      effective.Run,
 		"approval_label":           effective.ApprovalLabel,
 		"require_automated_review": requireAutomatedReview(effective),
+		"ci_failure_action":        effective.CIFailureAction,
 	}
 }
 

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -100,7 +100,7 @@ func TestBuildPromptRendersGateAssignsAndInstructions(t *testing.T) {
 				ApprovalLabel: "Approved-By-Human",
 			},
 		},
-		Prompt: "Gate {{ gate.kind }} label={{ gate.approval_label }} run={{ gate.run }}",
+		Prompt: "Gate {{ gate.kind }} label={{ gate.approval_label }} run={{ gate.run }} ci={{ gate.ci_failure_action }}",
 	}, connector.Issue{
 		Identifier: "digitaldrywood/detent#266",
 		Title:      "Gate prompt",
@@ -110,7 +110,7 @@ func TestBuildPromptRendersGateAssignsAndInstructions(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		"Gate human_review label=approved-by-human run=",
+		"Gate human_review label=approved-by-human run= ci=skip",
 		"## Validation gate",
 		"Keep the pull request in Human Review until a human applies label `approved-by-human`",
 	} {

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -435,6 +435,7 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	b.WriteString("gate:\n")
 	b.WriteString("  kind: command\n")
 	b.WriteString("  run: make check\n")
+	b.WriteString("  ci_failure_action: skip\n")
 	b.WriteString("hooks:\n")
 	b.WriteString("  timeout_ms: 60000\n")
 	b.WriteString("---\n\n")

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -181,7 +181,7 @@ func TestOnboardingWriteWorkflow(t *testing.T) {
 		"dependency_auto_unblock:\n    enabled: false\n    source_states:\n      - Blocked\n    target_state: Todo\n    readiness: terminal_or_merged",
 		"source_root: " + sourceRoot,
 		"codex:\n  command: codex app-server",
-		"gate:\n  kind: command\n  run: make check",
+		"gate:\n  kind: command\n  run: make check\n  ci_failure_action: skip",
 		"hooks:\n  timeout_ms: 60000",
 		"max_concurrent_agents_by_state:\n    Merging: 1",
 		"dispatch_priority_by_label:\n    - bug\n    - regression\n    - enhancement",


### PR DESCRIPTION
## Summary

- Add `gate.ci_failure_action` with default `skip` and opt-in `rework`.
- Route definitive failed or cancelled Human Review CI to Rework through the existing auto-promote path and workpad note.
- Document the config surface and emit the default in generated workflow examples.

Fixes #514

## Test Plan

- [x] `go test ./internal/gate ./internal/config ./internal/orchestrator ./internal/runner ./internal/web ./internal/devruntime`
- [x] `make check`
