### PR TITLE
feat(config): load workflow from git ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -714,6 +714,7 @@ detent init
 detent add-project \
   --id <id> \
   --workflow /absolute/path/to/project-checkout/WORKFLOW.md \
+  --workflow-ref origin/main \
   --workdir /absolute/path/to/project-checkout
 ```
 
@@ -1217,6 +1218,7 @@ global:
 projects:
   - id: detent
     workflow: /absolute/path/to/detent/WORKFLOW.md
+    workflow_ref: origin/main
     workdir: /absolute/path/to/detent
     weight: 2
     priority: 1
@@ -1233,12 +1235,20 @@ larger dispatch share in weighted and fair-share scheduling modes. Project
 priority is a rank: `1` is highest, `4` is lowest, and `0` or an omitted value
 means no explicit priority.
 
+Set `projects[].workflow_ref` when the workflow file should be read from a git
+ref in the configured source checkout instead of the checkout's working-tree
+copy. `workflow` may be an absolute path under `workdir` or a repository
+relative path such as `WORKFLOW.md`. When the ref advances, Detent reloads the
+workflow content from that ref; when `workflow_ref` is omitted, Detent keeps
+reading the working-tree file.
+
 Use the project administration commands to edit `global.yaml`:
 
 ```sh
 detent add-project \
   --id <id> \
   --workflow <WORKFLOW.md> \
+  --workflow-ref origin/main \
   --workdir <dir> \
   --weight 1 \
   --priority 3
@@ -1540,7 +1550,7 @@ Structured command objects:
 | `detent version` | `{"version":"v0.1.0","commit":"abc1234","build_date":"2026-06-13T00:00:00Z","go_version":"go1.26.4","os":"linux","arch":"amd64"}` |
 | `detent update` | The update status object, including `current_version`, `latest_version`, `latest_tag`, `update_available`, `install_source`, `action`, `message`, and `command` when present. |
 | `detent init` | `{"status":"ok","path":"/path/global.yaml","rule":"--config"}` |
-| `detent add-project` | `{"id":"api","workflow":"/repo/WORKFLOW.md","workdir":"/repo","weight":1,"priority":0,"paused":false,"credential_ref":"github"}` |
+| `detent add-project` | `{"id":"api","workflow":"/repo/WORKFLOW.md","workflow_ref":"origin/main","workdir":"/repo","weight":1,"priority":0,"paused":false,"credential_ref":"github"}` |
 | `detent pause api` / `detent unpause api` | `{"status":"ok","project":"api","paused":true}` |
 | `detent promote api --priority 1` | `{"status":"ok","project":"api","priority":1}` |
 | `detent remove-project api` | `{"status":"ok","project":"api","removed":true}` |

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -65,7 +65,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 			Global:         cfg,
 			ConfigPathRule: resolution.Rule,
 			Runtime:        runtime,
-			Host:           bootHost(host, workflowPath),
+			Host:           bootHost(ctx, host, firstGlobalProject(cfg)),
 			Port:           &resolvedPort,
 			Version:        opts.version,
 			Build:          opts.build,
@@ -97,7 +97,7 @@ func resolveBootConfig(ctx context.Context, configPath string, host string, flag
 			ConfigPathRule: resolution.Rule,
 			Runtime:        runtime,
 			WorkflowPath:   workflowPath,
-			Host:           bootHost(host, workflowPath),
+			Host:           bootHost(ctx, host, firstGlobalProject(cfg)),
 			Port:           &resolvedPort,
 			Version:        opts.version,
 			Build:          opts.build,
@@ -784,23 +784,26 @@ func firstWorkflowPath(cfg BootConfig) string {
 }
 
 func firstGlobalWorkflowPath(cfg globalconfig.Config) string {
-	if len(cfg.Projects) == 0 {
-		return ""
-	}
-	return cfg.Projects[0].Workflow
+	return firstGlobalProject(cfg).Workflow
 }
 
-func bootHost(host string, workflowPath string) string {
+func firstGlobalProject(cfg globalconfig.Config) globalconfig.Project {
+	if len(cfg.Projects) == 0 {
+		return globalconfig.Project{}
+	}
+	return cfg.Projects[0]
+}
+
+func bootHost(ctx context.Context, host string, cfg globalconfig.Project) string {
 	resolvedHost := strings.TrimSpace(host)
 	if resolvedHost != "" {
 		return resolvedHost
 	}
 
-	workflowPath = strings.TrimSpace(workflowPath)
-	if workflowPath == "" {
+	if strings.TrimSpace(cfg.Workflow) == "" {
 		return ""
 	}
-	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	workflow, err := project.LoadWorkflowContext(ctx, cfg)
 	if err != nil {
 		return ""
 	}

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -166,6 +166,44 @@ func TestTerminalDashboardError(t *testing.T) {
 	}
 }
 
+func TestResolveBootConfigUsesWorkflowRefForServerHost(t *testing.T) {
+	t.Parallel()
+
+	repo := initRuntimeWorkflowRepo(t)
+	writeBootHostWorkflow(t, filepath.Join(repo, "WORKFLOW.md"), "127.0.0.8")
+	commitRuntimeWorkflowRepo(t, repo, "initial workflow")
+	updateRuntimeWorkflowRef(t, repo, "origin/main", "HEAD")
+	writeBootHostWorkflow(t, filepath.Join(repo, "WORKFLOW.md"), "127.0.0.9")
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	cfg, err := globalconfig.DefaultAt(configPath)
+	if err != nil {
+		t.Fatalf("DefaultAt() error = %v", err)
+	}
+	cfg.Projects = []globalconfig.Project{
+		{
+			ID:          "detent",
+			Workflow:    "WORKFLOW.md",
+			WorkflowRef: "origin/main",
+			Workdir:     repo,
+			Weight:      1,
+			Priority:    0,
+		},
+	}
+	if err := globalconfig.Write(configPath, cfg); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+
+	got, err := resolveBootConfig(context.Background(), configPath, "", runtimeFlags{}, defaultOptions())
+	if err != nil {
+		t.Fatalf("resolveBootConfig() error = %v", err)
+	}
+
+	if got.Host != "127.0.0.8" {
+		t.Fatalf("Host = %q, want ref-backed host", got.Host)
+	}
+}
+
 func TestRegistryRefresherRequestsProjectOrchestrators(t *testing.T) {
 	t.Parallel()
 
@@ -564,6 +602,22 @@ Test workflow prompt.
 	return bootProjectFiles{
 		workflowPath: workflow,
 		workdirPath:  workdir,
+	}
+}
+
+func writeBootHostWorkflow(t *testing.T, path string, host string) {
+	t.Helper()
+
+	content := `---
+tracker:
+  kind: memory
+server:
+  host: ` + host + `
+---
+Boot workflow.
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
 	}
 }
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -126,6 +126,7 @@ type configPathResult struct {
 type projectResult struct {
 	ID            string `json:"id"`
 	Workflow      string `json:"workflow"`
+	WorkflowRef   string `json:"workflow_ref,omitempty"`
 	Workdir       string `json:"workdir"`
 	Weight        int    `json:"weight"`
 	Priority      int    `json:"priority"`
@@ -662,6 +663,7 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 				return err
 			}
 			cfg.ID = strings.TrimSpace(cfg.ID)
+			cfg.WorkflowRef = strings.TrimSpace(cfg.WorkflowRef)
 			cfg.CredentialRef = strings.TrimSpace(cfg.CredentialRef)
 			if err := validateProjectFlags(cfg); err != nil {
 				return err
@@ -691,6 +693,7 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 	}
 	cmd.Flags().StringVar(&cfg.ID, "id", "", "project id")
 	cmd.Flags().StringVar(&cfg.Workflow, "workflow", "", "project workflow path")
+	cmd.Flags().StringVar(&cfg.WorkflowRef, "workflow-ref", "", "git ref for loading the workflow")
 	cmd.Flags().StringVar(&cfg.Workdir, "workdir", "", "project worktree root")
 	cmd.Flags().IntVar(&cfg.Weight, "weight", 1, "project scheduling weight")
 	cmd.Flags().IntVar(&cfg.Priority, "priority", 0, "project dispatch priority")
@@ -892,6 +895,7 @@ func newProjectResult(project globalconfig.Project) projectResult {
 	return projectResult{
 		ID:            project.ID,
 		Workflow:      project.Workflow,
+		WorkflowRef:   project.WorkflowRef,
 		Workdir:       project.Workdir,
 		Weight:        project.Weight,
 		Priority:      project.Priority,

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -972,6 +972,7 @@ func TestAddProjectWritesConfigAndSignalsManager(t *testing.T) {
 		"add-project",
 		"--id", " detent ",
 		"--workflow", paths.workflowPath,
+		"--workflow-ref", " origin/main ",
 		"--workdir", paths.workdirPath,
 		"--weight", "5",
 		"--priority", "50",
@@ -994,6 +995,7 @@ func TestAddProjectWritesConfigAndSignalsManager(t *testing.T) {
 	want := globalconfig.Project{
 		ID:            "detent",
 		Workflow:      paths.workflowPath,
+		WorkflowRef:   "origin/main",
 		Workdir:       paths.workdirPath,
 		Weight:        5,
 		Priority:      50,
@@ -1024,6 +1026,7 @@ func TestAddProjectCommandEmitsJSONResult(t *testing.T) {
 		"add-project",
 		"--id", "detent",
 		"--workflow", paths.workflowPath,
+		"--workflow-ref", "origin/main",
 		"--workdir", paths.workdirPath,
 		"--weight", "5",
 		"--paused",
@@ -1034,17 +1037,21 @@ func TestAddProjectCommandEmitsJSONResult(t *testing.T) {
 	}
 
 	var got struct {
-		ID       string `json:"id"`
-		Workflow string `json:"workflow"`
-		Workdir  string `json:"workdir"`
-		Weight   int    `json:"weight"`
-		Paused   bool   `json:"paused"`
+		ID          string `json:"id"`
+		Workflow    string `json:"workflow"`
+		WorkflowRef string `json:"workflow_ref"`
+		Workdir     string `json:"workdir"`
+		Weight      int    `json:"weight"`
+		Paused      bool   `json:"paused"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("add-project output is not JSON: %v\n%s", err, stdout.String())
 	}
 	if got.ID != "detent" || got.Workflow != paths.workflowPath || got.Workdir != paths.workdirPath {
 		t.Fatalf("project = %#v, want detent project", got)
+	}
+	if got.WorkflowRef != "origin/main" {
+		t.Fatalf("workflow_ref = %q, want origin/main", got.WorkflowRef)
 	}
 	if got.Weight != 5 || !got.Paused {
 		t.Fatalf("project weight/paused = %d/%v, want 5/true", got.Weight, got.Paused)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -32,6 +32,7 @@ import (
 	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	projectpkg "github.com/digitaldrywood/detent/internal/project"
 )
 
 var ErrDoctorFailed = errors.New("doctor found failed checks")
@@ -310,7 +311,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	}
 	if global != nil {
 		boot.Global = *global
-		boot.Host = bootHost(cfg.Host, firstGlobalWorkflowPath(*global))
+		boot.Host = bootHost(ctx, cfg.Host, firstGlobalProject(*global))
 		writeDoctorProgressStart(progressOut, "Global config reload")
 		check := checkDoctorConfigReload(*global)
 		writeDoctorProgressDone(progressOut, check)
@@ -693,7 +694,7 @@ func checkDoctorProjectWithProgress(
 	}
 	workflowCheckName := "Project " + id + " workflow"
 	setDoctorCurrentCheck(workflowCheckName)
-	workflow, err := deps.loadWorkflow(project.Workflow)
+	workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
 	if err != nil {
 		return []doctorCheck{
 			{
@@ -2628,8 +2629,8 @@ func checkDoctorBinary(ctx context.Context, deps doctorDeps, binary string, name
 }
 
 func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token RuntimeSecret, deps doctorDeps) doctorCheck {
-	hasGitHubProject := doctorHasGitHubProject(cfg, deps)
-	requiresRuntimeToken := doctorRequiresRuntimeGitHubToken(cfg, deps)
+	hasGitHubProject := doctorHasGitHubProject(ctx, cfg, deps)
+	requiresRuntimeToken := doctorRequiresRuntimeGitHubToken(ctx, cfg, deps)
 	if cfg != nil && !hasGitHubProject {
 		return doctorCheck{
 			Name:   "GitHub token",
@@ -2671,7 +2672,7 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 			Detail: fmt.Sprintf("%s did not expose classic OAuth scopes; treating as fine-grained or resource-scoped token and relying on operation checks", source),
 		}
 	}
-	requiredScopes := doctorRequiredGitHubScopes(cfg, deps)
+	requiredScopes := doctorRequiredGitHubScopes(ctx, cfg, deps)
 	missing := missingGitHubScopes(scopes, requiredScopes)
 	if len(missing) > 0 {
 		return doctorCheck{
@@ -2689,10 +2690,10 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 	}
 }
 
-func doctorHasGitHubProject(cfg *globalconfig.Config, deps doctorDeps) bool {
+func doctorHasGitHubProject(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps) bool {
 	if cfg != nil {
 		for _, project := range cfg.Projects {
-			workflow, err := deps.loadWorkflow(project.Workflow)
+			workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
 			if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 				continue
 			}
@@ -2702,12 +2703,12 @@ func doctorHasGitHubProject(cfg *globalconfig.Config, deps doctorDeps) bool {
 	return false
 }
 
-func doctorRequiresRuntimeGitHubToken(cfg *globalconfig.Config, deps doctorDeps) bool {
+func doctorRequiresRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps) bool {
 	if cfg == nil {
 		return true
 	}
 	for _, project := range cfg.Projects {
-		workflow, err := deps.loadWorkflow(project.Workflow)
+		workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
 		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 			continue
 		}
@@ -2745,7 +2746,7 @@ func validEnvName(name string) bool {
 	return true
 }
 
-func doctorRequiredGitHubScopes(cfg *globalconfig.Config, deps doctorDeps) []string {
+func doctorRequiredGitHubScopes(ctx context.Context, cfg *globalconfig.Config, deps doctorDeps) []string {
 	if cfg == nil {
 		return append([]string{}, requiredProjectV2GitHubScopes...)
 	}
@@ -2760,7 +2761,7 @@ func doctorRequiredGitHubScopes(cfg *globalconfig.Config, deps doctorDeps) []str
 		}
 	}
 	for _, project := range cfg.Projects {
-		workflow, err := deps.loadWorkflow(project.Workflow)
+		workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
 		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 			continue
 		}
@@ -2780,6 +2781,13 @@ func doctorRequiredGitHubScopes(cfg *globalconfig.Config, deps doctorDeps) []str
 		return append([]string{}, requiredProjectV2GitHubScopes...)
 	}
 	return required
+}
+
+func loadDoctorProjectWorkflow(ctx context.Context, project globalconfig.Project, deps doctorDeps) (workflowconfig.Workflow, error) {
+	if strings.TrimSpace(project.WorkflowRef) == "" {
+		return deps.loadWorkflow(project.Workflow)
+	}
+	return projectpkg.LoadWorkflowContext(ctx, project)
 }
 
 func doctorStringSliceContains(values []string, want string) bool {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -45,7 +45,7 @@ func withRunnerFactory(
 	githubTokenSource ...func() string,
 ) project.Factory {
 	return func(cfg globalconfig.Project) (*project.Project, error) {
-		workflow, err := workflowconfig.LoadWorkflow(cfg.Workflow)
+		workflow, err := project.LoadWorkflow(cfg)
 		if err != nil {
 			return nil, fmt.Errorf("load project workflow %s: %w", cfg.ID, err)
 		}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -14,6 +14,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	projectpkg "github.com/digitaldrywood/detent/internal/project"
 )
 
 const (
@@ -197,10 +198,29 @@ func resolveRuntimePort(ctx context.Context, input runtimeInput, deps runtimeDep
 	if input.Config != nil && input.Config.Port != nil {
 		return RuntimeIntValue{Value: *input.Config.Port, Source: runtimeSourceConfig}, nil
 	}
+	if input.Config != nil {
+		if port, ok := globalWorkflowServerPort(ctx, *input.Config, deps); ok {
+			return RuntimeIntValue{Value: port, Source: runtimeSourceWorkflow}, nil
+		}
+	}
 	if port, ok := workflowServerPort(ctx, input.Workflow, deps); ok {
 		return RuntimeIntValue{Value: port, Source: runtimeSourceWorkflow}, nil
 	}
 	return RuntimeIntValue{Value: defaultWebPort, Source: runtimeSourceDefault}, nil
+}
+
+func globalWorkflowServerPort(ctx context.Context, cfg globalconfig.Config, deps runtimeDeps) (int, bool) {
+	if err := ctx.Err(); err != nil {
+		return 0, false
+	}
+	for _, project := range cfg.Projects {
+		workflow, err := loadRuntimeProjectWorkflow(ctx, project, deps)
+		if err != nil || workflow.Config.Server.Port == nil {
+			continue
+		}
+		return *workflow.Config.Server.Port, true
+	}
+	return 0, false
 }
 
 func workflowServerPort(ctx context.Context, path string, deps runtimeDeps) (int, bool) {
@@ -223,7 +243,7 @@ func resolveRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Config, de
 		return RuntimeSecret{Value: token, Source: "GITHUB_TOKEN", Required: true}, nil, nil
 	}
 
-	token, requiresRuntimeToken := trackerGitHubToken(cfg, deps)
+	token, requiresRuntimeToken := trackerGitHubToken(ctx, cfg, deps)
 	if token.Value == "" && !requiresRuntimeToken {
 		return RuntimeSecret{Required: false}, nil, nil
 	}
@@ -266,14 +286,14 @@ func resolveConfiguredGitHubToken(ctx context.Context, token string, deps runtim
 	return RuntimeSecret{Value: strings.TrimSpace(token), Source: "github_token", Required: true}, nil
 }
 
-func trackerGitHubToken(cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecret, bool) {
+func trackerGitHubToken(ctx context.Context, cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecret, bool) {
 	if cfg == nil {
 		return RuntimeSecret{}, false
 	}
 
 	requiresRuntimeToken := false
 	for _, project := range cfg.Projects {
-		workflow, err := deps.loadWorkflow(project.Workflow)
+		workflow, err := loadRuntimeProjectWorkflow(ctx, project, deps)
 		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
 			continue
 		}
@@ -289,6 +309,13 @@ func trackerGitHubToken(cfg *globalconfig.Config, deps runtimeDeps) (RuntimeSecr
 		requiresRuntimeToken = true
 	}
 	return RuntimeSecret{}, requiresRuntimeToken
+}
+
+func loadRuntimeProjectWorkflow(ctx context.Context, project globalconfig.Project, deps runtimeDeps) (workflowconfig.Workflow, error) {
+	if strings.TrimSpace(project.WorkflowRef) == "" {
+		return deps.loadWorkflow(project.Workflow)
+	}
+	return projectpkg.LoadWorkflowContext(ctx, project)
 }
 
 func trackerHasGitHubAppCredentials(tracker workflowconfig.Tracker, lookupEnv func(string) string) bool {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -213,14 +213,15 @@ func globalWorkflowServerPort(ctx context.Context, cfg globalconfig.Config, deps
 	if err := ctx.Err(); err != nil {
 		return 0, false
 	}
-	for _, project := range cfg.Projects {
-		workflow, err := loadRuntimeProjectWorkflow(ctx, project, deps)
-		if err != nil || workflow.Config.Server.Port == nil {
-			continue
-		}
-		return *workflow.Config.Server.Port, true
+	project := firstGlobalProject(cfg)
+	if strings.TrimSpace(project.Workflow) == "" {
+		return 0, false
 	}
-	return 0, false
+	workflow, err := loadRuntimeProjectWorkflow(ctx, project, deps)
+	if err != nil || workflow.Config.Server.Port == nil {
+		return 0, false
+	}
+	return *workflow.Config.Server.Port, true
 }
 
 func workflowServerPort(ctx context.Context, path string, deps runtimeDeps) (int, bool) {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -3,6 +3,10 @@ package cli
 import (
 	"context"
 	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -103,6 +107,46 @@ func TestResolveRuntimeSettingsPrecedence(t *testing.T) {
 				t.Fatalf("Port = %#v, want %#v", got.Port, tt.wantPort)
 			}
 		})
+	}
+}
+
+func TestResolveRuntimeSettingsUsesWorkflowRefForServerPort(t *testing.T) {
+	t.Parallel()
+
+	repo := initRuntimeWorkflowRepo(t)
+	writeRuntimeWorkflow(t, filepath.Join(repo, "WORKFLOW.md"), 4109)
+	commitRuntimeWorkflowRepo(t, repo, "initial workflow")
+	updateRuntimeWorkflowRef(t, repo, "origin/main", "HEAD")
+	writeRuntimeWorkflow(t, filepath.Join(repo, "WORKFLOW.md"), 4999)
+
+	cfg := globalconfig.Config{
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{
+			{
+				ID:          "detent",
+				Workflow:    "WORKFLOW.md",
+				WorkflowRef: "origin/main",
+				Workdir:     repo,
+				Weight:      1,
+			},
+		},
+	}
+
+	got, err := resolveRuntimeSettings(context.Background(), runtimeInput{
+		Config: &cfg,
+	}, runtimeDeps{lookupEnv: mapLookup(nil)})
+	if err != nil {
+		t.Fatalf("resolveRuntimeSettings() error = %v", err)
+	}
+
+	if got.Port.Value != 4109 {
+		t.Fatalf("Port.Value = %d, want 4109", got.Port.Value)
+	}
+	if got.Port.Source != runtimeSourceWorkflow {
+		t.Fatalf("Port.Source = %q, want %q", got.Port.Source, runtimeSourceWorkflow)
 	}
 }
 
@@ -468,6 +512,65 @@ func githubAppWorkflow() workflowconfig.Config {
 	cfg.Tracker.GitHubAppInstallationID = "$INSTALLATION_ID"
 	cfg.Tracker.GitHubAppPrivateKeyPath = "$PRIVATE_KEY_PATH"
 	return cfg
+}
+
+func initRuntimeWorkflowRepo(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	runRuntimeWorkflowCommand(t, "", "git", "init", root)
+	runRuntimeWorkflowGit(t, root, "config", "user.email", "detent@example.com")
+	runRuntimeWorkflowGit(t, root, "config", "user.name", "Detent Test")
+	return root
+}
+
+func writeRuntimeWorkflow(t *testing.T, path string, port int) {
+	t.Helper()
+
+	content := `---
+tracker:
+  kind: memory
+server:
+  port: ` + strconv.Itoa(port) + `
+---
+Runtime workflow.
+`
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func commitRuntimeWorkflowRepo(t *testing.T, repo string, message string) {
+	t.Helper()
+
+	runRuntimeWorkflowGit(t, repo, "add", "WORKFLOW.md")
+	runRuntimeWorkflowGit(t, repo, "commit", "-m", message)
+}
+
+func updateRuntimeWorkflowRef(t *testing.T, repo string, ref string, value string) {
+	t.Helper()
+
+	runRuntimeWorkflowGit(t, repo, "update-ref", "refs/remotes/"+ref, value)
+}
+
+func runRuntimeWorkflowGit(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+
+	return runRuntimeWorkflowCommand(t, repo, "git", args...)
+}
+
+func runRuntimeWorkflowCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s error = %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+	return string(output)
 }
 
 func mapLookup(values map[string]string) func(string) string {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -150,6 +150,57 @@ func TestResolveRuntimeSettingsUsesWorkflowRefForServerPort(t *testing.T) {
 	}
 }
 
+func TestResolveRuntimePortUsesOnlyFirstGlobalProjectWorkflowPort(t *testing.T) {
+	t.Parallel()
+
+	secondPort := 4555
+	firstWorkflow := workflowconfig.Default()
+	firstWorkflow.Server.Port = nil
+	secondWorkflow := workflowconfig.Default()
+	secondWorkflow.Server.Port = &secondPort
+	calls := []string{}
+
+	cfg := globalconfig.Config{
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{
+			{ID: "first", Workflow: "first.md", Weight: 1},
+			{ID: "second", Workflow: "second.md", Weight: 1},
+		},
+	}
+
+	got, err := resolveRuntimePort(context.Background(), runtimeInput{
+		Config: &cfg,
+	}, runtimeDeps{
+		lookupEnv: mapLookup(nil),
+		loadWorkflow: func(path string) (workflowconfig.Workflow, error) {
+			calls = append(calls, path)
+			switch path {
+			case "first.md":
+				return workflowconfig.Workflow{Config: firstWorkflow}, nil
+			case "second.md":
+				return workflowconfig.Workflow{Config: secondWorkflow}, nil
+			default:
+				return workflowconfig.Workflow{}, errors.New("unexpected workflow path")
+			}
+		},
+	})
+	if err != nil {
+		t.Fatalf("resolveRuntimePort() error = %v", err)
+	}
+	if got.Value != defaultWebPort {
+		t.Fatalf("Port.Value = %d, want %d", got.Value, defaultWebPort)
+	}
+	if got.Source != runtimeSourceDefault {
+		t.Fatalf("Port.Source = %q, want %q", got.Source, runtimeSourceDefault)
+	}
+	if strings.Join(calls, ",") != "first.md" {
+		t.Fatalf("loadWorkflow calls = %#v, want [first.md]", calls)
+	}
+}
+
 func TestResolveRuntimeSettingsGitHubTokenPrecedence(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -75,6 +75,7 @@ type Settings struct {
 type Project struct {
 	ID            string            `yaml:"id"`
 	Workflow      string            `yaml:"workflow"`
+	WorkflowRef   string            `yaml:"workflow_ref,omitempty"`
 	Workdir       string            `yaml:"workdir"`
 	Weight        int               `yaml:"weight"`
 	Priority      int               `yaml:"priority"`
@@ -324,7 +325,14 @@ func (c Config) Validate(opts ...Option) error {
 		if strings.TrimSpace(project.ID) == "" {
 			problems = append(problems, prefix+".id: must not be blank")
 		}
-		problems = append(problems, projectPathErrors(project.Workflow, prefix+".workflow", readOptions, wantFile)...)
+		if strings.TrimSpace(project.Workflow) == "" {
+			problems = append(problems, prefix+".workflow: must not be blank")
+		} else if strings.TrimSpace(project.WorkflowRef) == "" {
+			problems = append(problems, projectPathErrors(project.Workflow, prefix+".workflow", readOptions, wantFile)...)
+		}
+		if strings.ContainsAny(project.WorkflowRef, "\r\n") {
+			problems = append(problems, prefix+".workflow_ref: must be a single line")
+		}
 		problems = append(problems, projectPathErrors(project.Workdir, prefix+".workdir", readOptions, wantDirectory)...)
 		if project.Weight <= 0 {
 			problems = append(problems, prefix+".weight: must be a positive integer")
@@ -676,7 +684,13 @@ func projectErrors(value any, index int, opts options) []string {
 	var problems []string
 	problems = append(problems, prefixErrors(requiredErrors(project, []string{"id", "workflow", "workdir", "weight", "priority"}), prefix)...)
 	problems = append(problems, stringErrors(project, "id", prefix)...)
-	problems = append(problems, pathErrors(project, "workflow", prefix, opts, wantFile)...)
+	problems = append(problems, stringErrors(project, "workflow_ref", prefix)...)
+	problems = append(problems, singleLineStringErrors(project, "workflow_ref", prefix)...)
+	if strings.TrimSpace(projectStringValue(project, "workflow_ref")) == "" {
+		problems = append(problems, pathErrors(project, "workflow", prefix, opts, wantFile)...)
+	} else {
+		problems = append(problems, stringErrors(project, "workflow", prefix)...)
+	}
 	problems = append(problems, pathErrors(project, "workdir", prefix, opts, wantDirectory)...)
 	problems = append(problems, positiveIntegerError(project["weight"], prefix+".weight")...)
 	problems = append(problems, integerError(project["priority"], prefix+".priority")...)
@@ -741,6 +755,34 @@ func stringErrors(attrs map[string]any, field string, prefix string) []string {
 		return []string{prefix + "." + field + ": must not be blank"}
 	}
 	return nil
+}
+
+func singleLineStringErrors(attrs map[string]any, field string, prefix string) []string {
+	value, ok := attrs[field]
+	if !ok || value == nil {
+		return nil
+	}
+
+	text, ok := value.(string)
+	if !ok {
+		return nil
+	}
+	if strings.ContainsAny(text, "\r\n") {
+		return []string{prefix + "." + field + ": must be a single line"}
+	}
+	return nil
+}
+
+func projectStringValue(attrs map[string]any, field string) string {
+	value, ok := attrs[field]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return text
 }
 
 type pathExpectation int
@@ -1030,20 +1072,26 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 		if err != nil {
 			return nil, err
 		}
+		workflowRef, err := optionalString(project["workflow_ref"], prefix+".workflow_ref")
+		if err != nil {
+			return nil, err
+		}
 		workdir, err := stringValue(project["workdir"], prefix+".workdir")
 		if err != nil {
 			return nil, err
 		}
 		if !opts.projectPathLiterals {
-			expandedWorkflow, err := expandPath(workflow, opts)
-			if err != nil {
-				return nil, fmt.Errorf("%s.workflow: expand path: %w", prefix, err)
+			if strings.TrimSpace(workflowRef) == "" {
+				expandedWorkflow, err := expandPath(workflow, opts)
+				if err != nil {
+					return nil, fmt.Errorf("%s.workflow: expand path: %w", prefix, err)
+				}
+				workflow = expandedWorkflow
 			}
 			expandedWorkdir, err := expandPath(workdir, opts)
 			if err != nil {
 				return nil, fmt.Errorf("%s.workdir: expand path: %w", prefix, err)
 			}
-			workflow = expandedWorkflow
 			workdir = expandedWorkdir
 		}
 		id, err := stringValue(project["id"], prefix+".id")
@@ -1073,7 +1121,8 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 
 		out = append(out, Project{
 			ID:            strings.TrimSpace(id),
-			Workflow:      workflow,
+			Workflow:      strings.TrimSpace(workflow),
+			WorkflowRef:   strings.TrimSpace(workflowRef),
 			Workdir:       workdir,
 			Weight:        weight,
 			Priority:      priority,

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -250,6 +250,7 @@ global:
 projects:
   - id: detent
     workflow: `+paths.workflow+`
+    workflow_ref: origin/main
     workdir: `+paths.workdir+`
     weight: 1
     priority: 0
@@ -274,6 +275,42 @@ projects:
 	}
 	if cfg.InstanceName != "buildbox" {
 		t.Fatalf("InstanceName = %q, want buildbox", cfg.InstanceName)
+	}
+	if cfg.Projects[0].WorkflowRef != "origin/main" {
+		t.Fatalf("Project.WorkflowRef = %q, want origin/main", cfg.Projects[0].WorkflowRef)
+	}
+}
+
+func TestReadAllowsRefBackedRelativeWorkflow(t *testing.T) {
+	t.Parallel()
+
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, configPath, `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects:
+  - id: detent
+    workflow: WORKFLOW.md
+    workflow_ref: origin/main
+    workdir: `+paths.workdir+`
+    weight: 1
+    priority: 0
+`)
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	got := cfg.Projects[0]
+	if got.Workflow != "WORKFLOW.md" {
+		t.Fatalf("Project.Workflow = %q, want WORKFLOW.md", got.Workflow)
+	}
+	if got.WorkflowRef != "origin/main" {
+		t.Fatalf("Project.WorkflowRef = %q, want origin/main", got.WorkflowRef)
 	}
 }
 
@@ -702,6 +739,7 @@ global:
 projects:
   - id: 123
     workflow: 456
+    workflow_ref: 789
     workdir: 789
     weight: 0
     priority: high
@@ -719,6 +757,7 @@ projects:
 				"global.startup.max_spawn_per_second: must be a positive integer",
 				"projects[0].id: must be a string",
 				"projects[0].workflow: must be a string",
+				"projects[0].workflow_ref: must be a string",
 				"projects[0].workdir: must be a string",
 				"projects[0].weight: must be a positive integer",
 				"projects[0].priority: must be an integer",

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -111,7 +111,7 @@ type Project struct {
 }
 
 func Load(cfg globalconfig.Project, deps Dependencies) (*Project, error) {
-	workflow, err := workflowconfig.LoadWorkflow(cfg.Workflow)
+	workflow, err := LoadWorkflow(cfg)
 	if err != nil {
 		return nil, fmt.Errorf("load project workflow: %w", err)
 	}
@@ -997,6 +997,11 @@ func resolveWorkflowWatcherFactory(
 ) WorkflowWatcherFactory {
 	if deps.WorkflowWatcherFactory != nil {
 		return deps.WorkflowWatcherFactory
+	}
+	if strings.TrimSpace(project.WorkflowRef) != "" {
+		return func(string) (WorkflowWatcher, error) {
+			return newGitRefWorkflowWatcher(project, 0, logger)
+		}
 	}
 	return func(path string) (WorkflowWatcher, error) {
 		return configwatcher.New(path,

--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -1,0 +1,229 @@
+package project
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
+)
+
+var (
+	errMissingWorkflowRefRoot = errors.New("workflow_ref requires project workdir")
+	errUnsafeWorkflowPath     = errors.New("workflow path must stay inside the source root")
+)
+
+type workflowGitRefSource struct {
+	sourceRoot string
+	ref        string
+	path       string
+}
+
+type gitRefWorkflowWatcher struct {
+	source   workflowGitRefSource
+	interval time.Duration
+	logger   *slog.Logger
+}
+
+func LoadWorkflow(cfg globalconfig.Project) (workflowconfig.Workflow, error) {
+	return LoadWorkflowContext(context.Background(), cfg)
+}
+
+func LoadWorkflowContext(ctx context.Context, cfg globalconfig.Project) (workflowconfig.Workflow, error) {
+	if strings.TrimSpace(cfg.WorkflowRef) == "" {
+		return workflowconfig.LoadWorkflow(cfg.Workflow)
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	source, err := newWorkflowGitRefSource(cfg)
+	if err != nil {
+		return workflowconfig.Workflow{}, err
+	}
+	workflow, _, err := source.load(ctx)
+	return workflow, err
+}
+
+func newWorkflowGitRefSource(cfg globalconfig.Project) (workflowGitRefSource, error) {
+	sourceRoot := strings.TrimSpace(cfg.Workdir)
+	if sourceRoot == "" {
+		return workflowGitRefSource{}, errMissingWorkflowRefRoot
+	}
+
+	workflowPath, err := workflowRefPath(sourceRoot, cfg.Workflow)
+	if err != nil {
+		return workflowGitRefSource{}, err
+	}
+
+	ref := strings.TrimSpace(cfg.WorkflowRef)
+	if ref == "" {
+		return workflowGitRefSource{}, errors.New("workflow_ref must not be blank")
+	}
+	if strings.ContainsAny(ref, "\r\n") {
+		return workflowGitRefSource{}, errors.New("workflow_ref must be a single line")
+	}
+
+	return workflowGitRefSource{
+		sourceRoot: sourceRoot,
+		ref:        ref,
+		path:       workflowPath,
+	}, nil
+}
+
+func workflowRefPath(sourceRoot string, workflowPath string) (string, error) {
+	workflowPath = strings.TrimSpace(workflowPath)
+	if workflowPath == "" {
+		return "", errors.New("workflow path must not be blank")
+	}
+
+	if filepath.IsAbs(workflowPath) {
+		sourceRoot, err := filepath.Abs(sourceRoot)
+		if err != nil {
+			return "", fmt.Errorf("resolve source root: %w", err)
+		}
+		workflowPath, err = filepath.Abs(workflowPath)
+		if err != nil {
+			return "", fmt.Errorf("resolve workflow path: %w", err)
+		}
+		rel, err := filepath.Rel(sourceRoot, workflowPath)
+		if err != nil {
+			return "", fmt.Errorf("relativize workflow path: %w", err)
+		}
+		workflowPath = rel
+	}
+
+	workflowPath = filepath.Clean(workflowPath)
+	if workflowPath == "." || workflowPath == ".." || strings.HasPrefix(workflowPath, ".."+string(filepath.Separator)) {
+		return "", errUnsafeWorkflowPath
+	}
+	return filepath.ToSlash(workflowPath), nil
+}
+
+func (s workflowGitRefSource) load(ctx context.Context) (workflowconfig.Workflow, string, error) {
+	revision, err := s.revision(ctx)
+	if err != nil {
+		return workflowconfig.Workflow{}, "", err
+	}
+
+	raw, err := runWorkflowGit(ctx, s.sourceRoot, "show", revision+":"+s.path)
+	if err != nil {
+		return workflowconfig.Workflow{}, revision, fmt.Errorf("load workflow from %s: %w", s.displayPath(), err)
+	}
+	workflow, err := workflowconfig.ParseWorkflow(raw)
+	if err != nil {
+		return workflowconfig.Workflow{}, revision, err
+	}
+	return workflow, revision, nil
+}
+
+func (s workflowGitRefSource) revision(ctx context.Context) (string, error) {
+	output, err := runWorkflowGit(ctx, s.sourceRoot, "rev-parse", "--verify", s.ref+"^{commit}")
+	if err != nil {
+		return "", fmt.Errorf("resolve workflow ref %s: %w", s.ref, err)
+	}
+	revision := strings.TrimSpace(string(output))
+	if revision == "" {
+		return "", fmt.Errorf("resolve workflow ref %s: empty revision", s.ref)
+	}
+	return revision, nil
+}
+
+func (s workflowGitRefSource) displayPath() string {
+	return s.ref + ":" + s.path
+}
+
+func runWorkflowGit(ctx context.Context, dir string, args ...string) ([]byte, error) {
+	cmd := exec.CommandContext(ctx, "git", append([]string{"-C", dir}, args...)...) // #nosec G204 -- workflow refs and paths are operator config and are passed as git arguments, not shell.
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("git -C %s %s: %w\n%s", dir, strings.Join(args, " "), err, output)
+	}
+	return output, nil
+}
+
+func newGitRefWorkflowWatcher(cfg globalconfig.Project, interval time.Duration, logger *slog.Logger) (*gitRefWorkflowWatcher, error) {
+	source, err := newWorkflowGitRefSource(cfg)
+	if err != nil {
+		return nil, err
+	}
+	if interval <= 0 {
+		interval = time.Duration(workflowconfig.DefaultPollingIntervalMS) * time.Millisecond
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	return &gitRefWorkflowWatcher{
+		source:   source,
+		interval: interval,
+		logger:   logger,
+	}, nil
+}
+
+func (w *gitRefWorkflowWatcher) Watch(ctx context.Context) (<-chan configwatcher.Update, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	updates := make(chan configwatcher.Update, 1)
+	go w.run(ctx, updates)
+	return updates, nil
+}
+
+func (w *gitRefWorkflowWatcher) run(ctx context.Context, updates chan<- configwatcher.Update) {
+	defer close(updates)
+
+	ticker := time.NewTicker(w.interval)
+	defer ticker.Stop()
+
+	lastRevision := ""
+	lastErr := ""
+	lastRevision, lastErr = w.reload(ctx, updates, lastRevision, lastErr)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			lastRevision, lastErr = w.reload(ctx, updates, lastRevision, lastErr)
+		}
+	}
+}
+
+func (w *gitRefWorkflowWatcher) reload(
+	ctx context.Context,
+	updates chan<- configwatcher.Update,
+	lastRevision string,
+	lastErr string,
+) (string, string) {
+	workflow, revision, err := w.source.load(ctx)
+	if err != nil {
+		message := err.Error()
+		if message != lastErr {
+			w.send(ctx, updates, configwatcher.Update{Path: w.source.displayPath(), Err: err, At: time.Now()})
+		}
+		return lastRevision, message
+	}
+	if revision == lastRevision {
+		return lastRevision, ""
+	}
+	w.send(ctx, updates, configwatcher.Update{
+		Path:     w.source.displayPath(),
+		Workflow: workflow,
+		At:       time.Now(),
+	})
+	return revision, ""
+}
+
+func (w *gitRefWorkflowWatcher) send(ctx context.Context, updates chan<- configwatcher.Update, update configwatcher.Update) {
+	select {
+	case updates <- update:
+	case <-ctx.Done():
+	}
+}

--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -183,9 +183,7 @@ func (w *gitRefWorkflowWatcher) run(ctx context.Context, updates chan<- configwa
 	ticker := time.NewTicker(w.interval)
 	defer ticker.Stop()
 
-	lastRevision := ""
-	lastErr := ""
-	lastRevision, lastErr = w.reload(ctx, updates, lastRevision, lastErr)
+	lastRevision, lastErr := w.seed(ctx, updates)
 	for {
 		select {
 		case <-ctx.Done():
@@ -194,6 +192,16 @@ func (w *gitRefWorkflowWatcher) run(ctx context.Context, updates chan<- configwa
 			lastRevision, lastErr = w.reload(ctx, updates, lastRevision, lastErr)
 		}
 	}
+}
+
+func (w *gitRefWorkflowWatcher) seed(ctx context.Context, updates chan<- configwatcher.Update) (string, string) {
+	_, revision, err := w.source.load(ctx)
+	if err != nil {
+		message := err.Error()
+		w.send(ctx, updates, configwatcher.Update{Path: w.source.displayPath(), Err: err, At: time.Now()})
+		return "", message
+	}
+	return revision, ""
 }
 
 func (w *gitRefWorkflowWatcher) reload(

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -1,0 +1,192 @@
+package project
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestLoadWorkflowUsesWorkingTreeWhenWorkflowRefUnset(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workflowPath := filepath.Join(root, "WORKFLOW.md")
+	writeWorkflowSourceFile(t, workflowPath, "working tree")
+
+	workflow, err := LoadWorkflow(globalconfig.Project{Workflow: workflowPath})
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(workflow.Prompt); got != "working tree" {
+		t.Fatalf("Prompt = %q, want working tree", got)
+	}
+}
+
+func TestLoadWorkflowUsesConfiguredGitRef(t *testing.T) {
+	t.Parallel()
+
+	repo := initWorkflowSourceRepo(t)
+	writeWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "from ref")
+	commitWorkflowSourceRepo(t, repo, "initial workflow")
+	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+	writeWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "working tree")
+
+	workflow, err := LoadWorkflow(globalconfig.Project{
+		Workflow:    "WORKFLOW.md",
+		WorkflowRef: "origin/main",
+		Workdir:     repo,
+	})
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(workflow.Prompt); got != "from ref" {
+		t.Fatalf("Prompt = %q, want from ref", got)
+	}
+}
+
+func TestLoadWorkflowUsesAbsolutePathUnderWorkdirWithConfiguredGitRef(t *testing.T) {
+	t.Parallel()
+
+	repo := initWorkflowSourceRepo(t)
+	workflowPath := filepath.Join(repo, "WORKFLOW.md")
+	writeWorkflowSourceFile(t, workflowPath, "from ref")
+	commitWorkflowSourceRepo(t, repo, "initial workflow")
+	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+	writeWorkflowSourceFile(t, workflowPath, "working tree")
+
+	workflow, err := LoadWorkflow(globalconfig.Project{
+		Workflow:    workflowPath,
+		WorkflowRef: "origin/main",
+		Workdir:     repo,
+	})
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+
+	if got := strings.TrimSpace(workflow.Prompt); got != "from ref" {
+		t.Fatalf("Prompt = %q, want from ref", got)
+	}
+}
+
+func TestLoadWorkflowRejectsRefPathOutsideWorkdir(t *testing.T) {
+	t.Parallel()
+
+	_, err := LoadWorkflow(globalconfig.Project{
+		Workflow:    filepath.Join(t.TempDir(), "WORKFLOW.md"),
+		WorkflowRef: "origin/main",
+		Workdir:     t.TempDir(),
+	})
+	if !errors.Is(err, errUnsafeWorkflowPath) {
+		t.Fatalf("LoadWorkflow() error = %v, want %v", err, errUnsafeWorkflowPath)
+	}
+}
+
+func TestGitRefWorkflowWatcherReloadsWhenRefAdvances(t *testing.T) {
+	t.Parallel()
+
+	repo := initWorkflowSourceRepo(t)
+	writeWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "first")
+	commitWorkflowSourceRepo(t, repo, "first workflow")
+	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+
+	watcher, err := newGitRefWorkflowWatcher(globalconfig.Project{
+		Workflow:    "WORKFLOW.md",
+		WorkflowRef: "origin/main",
+		Workdir:     repo,
+	}, 10*time.Millisecond, slog.New(slog.NewTextHandler(bytes.NewBuffer(nil), nil)))
+	if err != nil {
+		t.Fatalf("newGitRefWorkflowWatcher() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	updates, err := watcher.Watch(ctx)
+	if err != nil {
+		t.Fatalf("Watch() error = %v", err)
+	}
+
+	writeWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "second")
+	commitWorkflowSourceRepo(t, repo, "second workflow")
+	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
+
+	deadline := time.After(time.Second)
+	for {
+		select {
+		case update, ok := <-updates:
+			if !ok {
+				t.Fatal("updates closed before ref advance")
+			}
+			if update.Err != nil {
+				t.Fatalf("workflow update error = %v", update.Err)
+			}
+			if got := strings.TrimSpace(update.Workflow.Prompt); got == "second" {
+				return
+			}
+		case <-deadline:
+			t.Fatal("timed out waiting for workflow ref reload")
+		}
+	}
+}
+
+func initWorkflowSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	root := t.TempDir()
+	runWorkflowSourceCommand(t, "", "git", "init", root)
+	runWorkflowSourceGit(t, root, "config", "user.email", "detent@example.com")
+	runWorkflowSourceGit(t, root, "config", "user.name", "Detent Test")
+	return root
+}
+
+func writeWorkflowSourceFile(t *testing.T, path string, prompt string) {
+	t.Helper()
+
+	content := "---\ntracker:\n  kind: memory\n---\n" + prompt + "\n"
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+}
+
+func commitWorkflowSourceRepo(t *testing.T, repo string, message string) {
+	t.Helper()
+
+	runWorkflowSourceGit(t, repo, "add", "WORKFLOW.md")
+	runWorkflowSourceGit(t, repo, "commit", "-m", message)
+}
+
+func updateWorkflowSourceRef(t *testing.T, repo string, ref string, value string) {
+	t.Helper()
+
+	runWorkflowSourceGit(t, repo, "update-ref", "refs/remotes/"+ref, value)
+}
+
+func runWorkflowSourceGit(t *testing.T, repo string, args ...string) string {
+	t.Helper()
+
+	return runWorkflowSourceCommand(t, repo, "git", args...)
+}
+
+func runWorkflowSourceCommand(t *testing.T, dir string, name string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command(name, args...)
+	if dir != "" {
+		cmd.Dir = dir
+	}
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("%s %s error = %v\n%s", name, strings.Join(args, " "), err, output)
+	}
+	return string(output)
+}

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
 )
 
 func TestLoadWorkflowUsesWorkingTreeWhenWorkflowRefUnset(t *testing.T) {
@@ -111,31 +112,56 @@ func TestGitRefWorkflowWatcherReloadsWhenRefAdvances(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	updates, err := watcher.Watch(ctx)
-	if err != nil {
-		t.Fatalf("Watch() error = %v", err)
+	updates := make(chan configwatcher.Update, 1)
+
+	lastRevision, lastErr := watcher.seed(ctx, updates)
+	if lastErr != "" {
+		t.Fatalf("seed() error = %s", lastErr)
 	}
+	if lastRevision == "" {
+		t.Fatal("seed() revision = empty")
+	}
+	assertNoWorkflowSourceUpdate(t, updates)
 
 	writeWorkflowSourceFile(t, filepath.Join(repo, "WORKFLOW.md"), "second")
 	commitWorkflowSourceRepo(t, repo, "second workflow")
 	updateWorkflowSourceRef(t, repo, "origin/main", "HEAD")
 
-	deadline := time.After(time.Second)
-	for {
-		select {
-		case update, ok := <-updates:
-			if !ok {
-				t.Fatal("updates closed before ref advance")
-			}
-			if update.Err != nil {
-				t.Fatalf("workflow update error = %v", update.Err)
-			}
-			if got := strings.TrimSpace(update.Workflow.Prompt); got == "second" {
-				return
-			}
-		case <-deadline:
-			t.Fatal("timed out waiting for workflow ref reload")
-		}
+	lastRevision, lastErr = watcher.reload(ctx, updates, lastRevision, lastErr)
+	if lastErr != "" {
+		t.Fatalf("reload() error = %s", lastErr)
+	}
+	if lastRevision == "" {
+		t.Fatal("reload() revision = empty")
+	}
+	update := readWorkflowSourceUpdate(t, updates)
+	if update.Err != nil {
+		t.Fatalf("workflow update error = %v", update.Err)
+	}
+	if got := strings.TrimSpace(update.Workflow.Prompt); got != "second" {
+		t.Fatalf("Prompt = %q, want second", got)
+	}
+}
+
+func assertNoWorkflowSourceUpdate(t *testing.T, updates <-chan configwatcher.Update) {
+	t.Helper()
+
+	select {
+	case update := <-updates:
+		t.Fatalf("unexpected workflow update: %#v", update)
+	default:
+	}
+}
+
+func readWorkflowSourceUpdate(t *testing.T, updates <-chan configwatcher.Update) configwatcher.Update {
+	t.Helper()
+
+	select {
+	case update := <-updates:
+		return update
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for workflow update")
+		return configwatcher.Update{}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add optional `projects[].workflow_ref` config and CLI support.
- Load and watch workflow files from the configured git ref when set, while preserving working-tree loading when unset.
- Make boot, runtime, doctor, and runner project workflow loading ref-aware.

Fixes #516

## Test Plan

- [x] `go test ./internal/project ./internal/config/global ./internal/cli`
- [x] `make check`