### PR TITLE
docs: refresh kanban boardless guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -525,6 +525,8 @@ and prefixes it with `tracker.status_label_prefix`, which defaults to
 `detent:`. With the default release flow, the required labels are
 `detent:backlog`, `detent:todo`, `detent:in-progress`, `detent:blocked`,
 `detent:human-review`, `detent:rework`, `detent:merging`, and `detent:done`.
+With `tracker.auto_provision` enabled, Detent creates missing repository status
+labels for configured workflow states on startup.
 Discover existing labels with:
 
 ```sh
@@ -1676,6 +1678,11 @@ Useful endpoints:
 | `/kanban` | Read-only fleet Kanban board across all registered projects. The sidebar link appears only when more than one project is registered. |
 | `/projects/<id>` | Project-scoped dashboard overview. |
 | `/projects/<id>/kanban` | Project-scoped Kanban board; read-only or integration mode follows that project's workflow config. |
+| `/projects/<id>/runs` | Project running, retry, blocked, and recent session details. |
+| `/projects/<id>/configuration` | Project workflow and runtime configuration view. |
+| `/projects/<id>/diagnostics` | Project health, board flow, and telemetry diagnostics. |
+| `/settings` | Fleet settings and configuration summary. |
+| `/reports` | Usage reports for spend, tokens, projects, issues, PRs, and models. |
 | `/health` | Server health and configured dependency checks. |
 | `/events` | Server-sent dashboard updates. Use `?view=kanban` for the fleet board and `?project=<id>&view=kanban` for a project board. |
 | `/api/v1/state` | JSON telemetry snapshot. |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2157,10 +2157,13 @@ tracker:
 ```
 
 Detent does not automatically migrate ProjectV2 item statuses or issue-field
-values into labels. Copy existing statuses by applying exactly one configured
+values into labels. With `tracker.auto_provision` enabled, Detent creates
+missing prefixed status labels on startup, but it does not assign those labels
+to existing issues. Copy existing statuses by applying exactly one configured
 status label per issue, then run `detent doctor --port 0` and fix repository
 access, status label mappings, issue reads by label, write-probe,
-comment-write, and rate-limit checks before dispatching.
+comment-write, and rate-limit checks before dispatching. GitHub status labels
+apply to issues only, so linked PR cards derive status from the linked issue.
 
 ### Interview Answers To Config Keys
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -8,7 +8,7 @@ We build Detent as a self-hosted, board-native agent orchestrator for software d
 |---|---|---|---|---|---|---|
 | Self-hosted, no vendor control plane | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
 | Runs fully local / air-gappable | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
-| Board/tracker-native (issue→PR) | ✅ GH Projects | ✅ Linear | ✅ GH Issues | ❌ | ❌ | ❌ |
+| Board/tracker-native (issue→PR) | ✅ GH Projects, issue fields, or labels | ✅ Linear | ✅ GH Issues | ❌ | ❌ | ❌ |
 | Deterministic gated merge train | ✅ | 🟡 per spec | ❌ | ❌ | ❌ | ❌ |
 | Budget / cost caps | ✅ | ❌ | 🟡 | 🟡 | ❌ | ❌ |
 | Multi-project | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
@@ -22,7 +22,7 @@ We build Detent as a self-hosted, board-native agent orchestrator for software d
 
 ## What Each One Is
 
-- **Detent**: [digitaldrywood/detent](https://github.com/digitaldrywood/detent) is our single-binary Go orchestrator for GitHub Projects-driven issue-to-PR work.
+- **Detent**: [digitaldrywood/detent](https://github.com/digitaldrywood/detent) is our single-binary Go orchestrator for GitHub-native issue-to-PR work using ProjectV2 or boardless status sources.
 - **OpenAI Symphony**: [openai/symphony](https://github.com/openai/symphony) is our origin point: an Apache-2.0 spec plus Elixir reference implementation for Codex on Linear.
 - **GitHub Copilot coding agent**: [GitHub Copilot cloud agent](https://docs.github.com/en/copilot/concepts/agents/cloud-agent/about-cloud-agent) is GitHub's paid issue/prompt-to-branch-and-PR agent.
 - **Cursor**: [Cursor cloud agents](https://cursor.com/cloud) is an IDE-first agent product with cloud/background agents, automations, and optional self-hosted workers.
@@ -31,6 +31,6 @@ We build Detent as a self-hosted, board-native agent orchestrator for software d
 
 ## Where We're Different
 
-We own the orchestration loop: no Detent vendor control plane, GitHub Projects as the delivery board, deterministic gates, and a serialized merge train. We also care about operating fleets, not just launching one agent: multi-instance ownership, budget checks, local skills, and a single static binary with a setup path we expect to be measured in minutes. Copilot and Cursor have closed much of the "runs near my code" gap and win zero-install inside their platforms, but they do not give us the same board-native release runtime under our control.
+We own the orchestration loop: no Detent vendor control plane, GitHub-native status sources, Detent's own Kanban board, deterministic gates, and a serialized merge train. We also care about operating fleets, not just launching one agent: multi-instance ownership, budget checks, local skills, and a single static binary with a setup path we expect to be measured in minutes. Copilot and Cursor have closed much of the "runs near my code" gap and win zero-install inside their platforms, but they do not give us the same board-native release runtime under our control.
 
-_Last updated: June 2, 2026; verify vendor pricing/models before relying on them._
+_Last updated: June 19, 2026; verify vendor pricing/models before relying on them._

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -57,9 +57,9 @@ The execution edge still carries these code/git/PR assumptions.
 - The CI lint job keeps the project-pinned golangci-lint version and caches its
   binary so cache hits avoid a per-run `go install` without changing lint
   coverage.
-- Moving `GoReleaser Snapshot` off every PR or making it path-based is a
-  release-policy decision because it trades release-package coverage for merge
-  latency.
+- `GoReleaser Snapshot` runs on every push to `main` and on PRs only when
+  release packaging inputs change, preserving release-package coverage without
+  charging docs-only and routine code PRs the full snapshot cost.
 
 ## Still Git/PR Coupled
 

--- a/docs/parity-audit.md
+++ b/docs/parity-audit.md
@@ -7,12 +7,13 @@ audit work into feature implementation.
 ## Baseline
 
 - Audit issue: digitaldrywood/detent#145
-- Audit date: 2026-05-31
+- Audit date: 2026-06-19
 - Elixir dashboard reference:
   `elixir/lib/detent_elixir_web/live/dashboard_live.ex`
 - Elixir terminal reference:
   `elixir/lib/detent_elixir/status_dashboard.ex`
 - Go web dashboard: `internal/web/templates/dashboard.templ`
+- Go web project pages: overview, Kanban, runs, configuration, and diagnostics
 - Go terminal dashboard: `internal/tui/model.go`
 - Go telemetry model: `internal/telemetry/snapshot.go`
 
@@ -20,20 +21,20 @@ audit work into feature implementation.
 
 | Area | Elixir parity target | Go status | Gap issue | Notes |
 | --- | --- | --- | --- | --- |
-| Web summary counts | Running, retry pressure, blocked, tokens, spend today, runtime | Partial | digitaldrywood/detent#148, digitaldrywood/detent#149 | Go shows running, queue, blocked, completed, budget, rate limits, and tokens. It does not yet expose rolling TPS, lifetime totals, spend-today sparkline, or degraded stats. |
-| Web running sessions | Issue identity, state, session, runtime/turns, Codex update, diff, tokens | Partial | digitaldrywood/detent#147 | Go renders the core row data. Missing copy/open affordances, JSON detail links, and issue popovers from the Elixir dashboard. |
-| Web retry/backoff queue | Attempt, due time, and retry error | Gap | digitaldrywood/detent#147 | Go telemetry has queued rows, and the TUI renders them, but the web dashboard only exposes the queue count. |
-| Web blocked sessions | Blocked issue, state, session, blocked time, last update, error | Gap | digitaldrywood/detent#147 | Go telemetry has blocked rows, and the TUI renders them, but the web dashboard only exposes the blocked count. |
-| Web recent sessions | Completed time, runtime/turns, tokens, final state, model | Gap | digitaldrywood/detent#147 | Go telemetry has completed rows, and the TUI renders them, but the web dashboard only exposes the completed count. |
-| Web budget history | Spend today against cap plus seven-day sparkline | Partial | digitaldrywood/detent#149 | Go budget card shows current/projected spend and caps. Budget day history is present in telemetry but not rendered in the web template. |
-| Web health and density | Live/offline badges, stats degraded indicator, comfortable/compact density | Gap | digitaldrywood/detent#149 | Go shows connector and update time. Health/degraded state and density controls are not represented. |
+| Web summary counts | Running, retry pressure, blocked, tokens, spend today, runtime | Covered | Closed: digitaldrywood/detent#148, digitaldrywood/detent#149 | Overview and diagnostics render running, queue, blocked, completed, budget, rate limits, rolling throughput, lifetime totals, and degraded stats. |
+| Web running sessions | Issue identity, state, session, runtime/turns, Codex update, diff, tokens | Covered | Closed: digitaldrywood/detent#147 | Dedicated project runs page renders running-session rows, issue previews, links, JSON/detail affordances, session, diff, runtime, turns, and tokens. |
+| Web retry/backoff queue | Attempt, due time, and retry error | Covered | Closed: digitaldrywood/detent#147 | Project runs page renders retry rows with due time, attempt/error context, and issue detail links. |
+| Web blocked sessions | Blocked issue, state, session, blocked time, last update, error | Covered | Closed: digitaldrywood/detent#147 | Project runs page renders blocked rows with state, session, blocked time, last update, error, and dependency context. |
+| Web recent sessions | Completed time, runtime/turns, tokens, final state, model | Covered | Closed: digitaldrywood/detent#147 | Project runs page renders recent completed sessions with final state, model, runtime, turns, and tokens. |
+| Web budget history | Spend today against cap plus seven-day sparkline | Covered | Closed: digitaldrywood/detent#149 | Budget card renders current/projected spend, caps, burn-down projection, and daily history bars from telemetry. |
+| Web health and density | Live/offline badges, stats degraded indicator, comfortable/compact density | Covered | Closed: digitaldrywood/detent#149 | Dashboard and diagnostics render connector health, update time, degraded stats, and compact responsive cards. |
 | Rate limits | Primary, secondary, credits, reset details | Covered | None | Go web and TUI render Codex rate-limit snapshots, including credit availability. |
 | Token totals | Input, output, total tokens | Covered | None | Go web and TUI render token totals and running-session token totals. |
-| Throughput | Rolling tokens per second with throttled updates | Gap | digitaldrywood/detent#148 | Go web has a derived tokens/minute card. Go TUI does not yet render the Elixir throughput line. |
-| Runtime totals | Current run runtime and all-time runtime/session totals | Partial | digitaldrywood/detent#148 | Go has snapshot runtime seconds. Lifetime totals and degraded stats handling are missing from the telemetry contract. |
-| TUI running rows | ID, stage, PID, age/turn, tokens, session, event | Partial | digitaldrywood/detent#150 | Go renders ID, stage, host, age/turn, tokens, session, and event. PID/process identity is not modeled separately. |
+| Throughput | Rolling tokens per second with throttled updates | Covered | Closed: digitaldrywood/detent#148 | Go web and TUI render token throughput from the telemetry contract. |
+| Runtime totals | Current run runtime and all-time runtime/session totals | Covered | Closed: digitaldrywood/detent#148 | Telemetry includes lifetime totals and degraded reasons; web renders lifetime token, runtime, session, and run totals. |
+| TUI running rows | ID, stage, PID, age/turn, tokens, session, event | Covered | Closed: digitaldrywood/detent#150 | Go renders ID, stage, process identity/PID, age/turn, tokens, session, and event. |
 | TUI backoff queue | All queued retries sorted by due time | Covered | None | Covered by `internal/tui/status_dashboard_parity_test.go`. |
-| TUI project links | Project, dashboard URL, next refresh | Gap | digitaldrywood/detent#150 | Go TUI renders generated time but not project/dashboard/refresh lines. |
+| TUI project links | Project, dashboard URL, next refresh | Covered | Closed: digitaldrywood/detent#150 | Go TUI renders project URL, dashboard URL, generated time, and next refresh. |
 | Dispatch order | Elixir candidate filtering, priorities, state caps, blocked dependencies | Covered | None | Covered by `internal/orchestrator/dispatch_parity_test.go` and related orchestrator tests. |
 | Scheduler fairness | Weighted, strict priority, round-robin, fair-share project selection | Covered | None | Covered by `internal/scheduler/global_test.go` and project manager scheduler tests. |
 | Merge train serialization | `Merging` state intentionally capped to one active agent | Covered | None | Documented in `README.md` and generated onboarding workflow defaults. |
@@ -42,12 +43,12 @@ audit work into feature implementation.
 | GitHub Projects adapter | ProjectV2 state mapping, dependency parsing, status updates | Covered | None | Covered by `internal/connector/github/adapter_parity_test.go`. |
 | Shadow comparison | Go-vs-Elixir dispatch observation diffs | Covered | None | Covered by `internal/shadow` comparator tests. |
 
-## Gap Issues
+## Restored Gap Issues
 
-- digitaldrywood/detent#147: Restore web dashboard work queues and session detail parity.
-- digitaldrywood/detent#148: Add dashboard throughput and lifetime runtime parity.
-- digitaldrywood/detent#149: Add budget history and dashboard health indicators.
-- digitaldrywood/detent#150: Restore TUI project refresh and process identity parity.
+- digitaldrywood/detent#147: Restore web dashboard work queues and session detail parity. Closed.
+- digitaldrywood/detent#148: Add dashboard throughput and lifetime runtime parity. Closed.
+- digitaldrywood/detent#149: Add budget history and dashboard health indicators. Closed.
+- digitaldrywood/detent#150: Restore TUI project refresh and process identity parity. Closed.
 
 ## Milestone Audit Notes
 
@@ -57,3 +58,7 @@ audit work into feature implementation.
   backoff rows, rate-limit formatting, and token totals. The remaining gaps are
   dashboard presentation and telemetry fields rather than core dispatch
   behavior.
+- 2026-06-19: Web dashboard parity gaps #147, #148, and #149 are closed through
+  the project overview/runs/diagnostics split, budget history rendering,
+  throughput/lifetime telemetry, and degraded stats. TUI parity gap #150 is
+  closed through project/dashboard/refresh headers and process identity rows.


### PR DESCRIPTION
## Summary

- Refresh README and onboarding docs for v0.6.0 installers, boardless label mode, Kanban pages, integration endpoints, and demo/runtime setup.
- Correct GitHub auth guidance so label mode is documented as the lowest-permission boardless path without `read:org`.
- Update comparison, execution seams, and parity audit docs to match the current dashboard, Kanban, CI, and closed parity work.

Fixes: N/A

## Test Plan

- [x] `git diff --check`
- [x] Full PR CI matrix via `gh pr checks 520 --watch`
