### PR TITLE
feat(demo): add screenshot scenarios

### DIFF
--- a/README.md
+++ b/README.md
@@ -782,10 +782,59 @@ pending, and failure states, Codex review clean and finding states, labels,
 assignees, blockers, and wait metadata. Issue and PR comments are captured by
 the memory connector with no external side effects.
 
+Use the screenshots demo when you need deterministic pages, HTMX fragments, API
+responses, reports, and SSE payloads for documentation screenshots, video
+recording, or visual e2e baselines:
+
+```sh
+detent dev-runtime --demo screenshots --port 0
+```
+
+The screenshots demo uses the same isolation model as the Kanban demo: memory
+tracker, fake runner, isolated home, isolated database, isolated workspaces,
+fake `https://github.test/...` URLs, no GitHub calls, no real ProjectV2
+mutation, and no live dogfood port by default. It freezes demo time at
+`2026-06-15T12:00:00Z` unless started with `--demo-clock play`, which advances
+SSE ticks and visible running-work counters for video capture. The boot banner
+prints the scenario manifest location:
+
+```text
+Scenario manifest: /api/v1/demo/scenarios
+```
+
+Select a scenario with `X-Detent-Demo-Scenario`; the visible URL stays on the
+normal page route:
+
+```ts
+const scenarios = [
+  ["fleet-healthy-parallel-work", "/"],
+  ["kanban-full-integration", "/projects/dogfood/kanban"],
+  ["reports-normal-window", "/reports"],
+];
+
+for (const [scenario, route] of scenarios) {
+  await page.setExtraHTTPHeaders({ "X-Detent-Demo-Scenario": scenario });
+  await page.goto(`${baseURL}${route}`);
+  await page.waitForLoadState("networkidle");
+  await expect(page).toHaveScreenshot(`${scenario}.png`);
+}
+```
+
+For visual comparisons, keep the screenshot environment stable: browser,
+viewport, fonts, OS rendering, device scale factor, and generated assets should
+match the baseline environment. The manifest includes each scenario ID, route,
+required header, recommended viewport, screenshot name, and wait selector. A
+quick JSON smoke check looks like this:
+
+```sh
+curl -H 'X-Detent-Demo-Scenario: fleet-healthy-parallel-work' "$DETENT_URL/api/v1/state"
+```
+
 Use the normal live runtime, `detent` with your global config, only when you
 intend to operate on the configured tracker and ProjectV2 board. Use
 `detent dev-runtime --fixture <path>` for focused fixture validation such as
-autopromote behavior, and use `--demo kanban` for safe board exploration.
+autopromote behavior, `--demo kanban` for safe board exploration, and
+`--demo screenshots` for deterministic page-addressable screenshots.
 
 6. Start Detent:
 

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -171,6 +171,11 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
+	if cfg.Isolated != nil && cfg.Isolated.Demo == "screenshots" {
+		if err := web.SeedDemoUsageEvents(runCtx, runtimeStore); err != nil {
+			return err
+		}
+	}
 	defer func() {
 		stop()
 		closeStarted := logShutdownBoundaryBegin(logger, "runtime_store_close", "component", "runtime_store")
@@ -248,6 +253,10 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		RuntimeDBPath:      runtimeStorePath(cfg),
 		RuntimeLogPath:     runtimeLogPath(cfg),
 		ServerAddress:      listener.Addr().String(),
+		Demo: web.DemoConfig{
+			Mode:  isolatedDemo(cfg),
+			Clock: isolatedDemoClock(cfg),
+		},
 	}, web.Dependencies{
 		Hub:       snapshotHub,
 		Store:     runtimeStore,
@@ -922,6 +931,20 @@ func printBootBanner(cfg BootConfig, displayURL string) error {
 	return err
 }
 
+func isolatedDemo(cfg BootConfig) string {
+	if cfg.Isolated == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Isolated.Demo)
+}
+
+func isolatedDemoClock(cfg BootConfig) string {
+	if cfg.Isolated == nil {
+		return ""
+	}
+	return strings.TrimSpace(cfg.Isolated.DemoClock)
+}
+
 func bootBanner(version string, displayURL string, isolated *IsolatedRuntimeInfo) string {
 	version = strings.TrimSpace(version)
 	if version == "" {
@@ -952,6 +975,8 @@ func bootBanner(version string, displayURL string, isolated *IsolatedRuntimeInfo
 		writeBootBannerLine(&out, "DB mode", isolated.DBMode)
 		writeBootBannerLine(&out, "Tracker", isolated.TrackerMode)
 		writeBootBannerLine(&out, "Demo", isolated.Demo)
+		writeBootBannerLine(&out, "Demo clock", isolated.DemoClock)
+		writeBootBannerLine(&out, "Scenario manifest", isolated.ManifestPath)
 		writeBootBannerLine(&out, "Fixture", isolated.FixturePath)
 	}
 	return out.String()

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -174,8 +174,6 @@ func TestTerminalDashboardError(t *testing.T) {
 }
 
 func TestResolveBootConfigUsesWorkflowRefForServerHost(t *testing.T) {
-	t.Parallel()
-
 	repo := initRuntimeWorkflowRepo(t)
 	writeBootHostWorkflow(t, filepath.Join(repo, "WORKFLOW.md"), "127.0.0.8")
 	commitRuntimeWorkflowRepo(t, repo, "initial workflow")

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -191,6 +191,8 @@ type IsolatedRuntimeInfo struct {
 	TrackerMode   string
 	FixturePath   string
 	Demo          string
+	DemoClock     string
+	ManifestPath  string
 }
 
 type BootFunc func(context.Context, BootConfig) error

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -279,6 +279,44 @@ func TestDevRuntimeCommandBuildsKanbanDemoBootConfig(t *testing.T) {
 	}
 }
 
+func TestDevRuntimeCommandBuildsScreenshotsDemoBootConfig(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--port", "0",
+		"dev-runtime",
+		"--home", home,
+		"--demo", "screenshots",
+		"--demo-clock", "play",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if got.Isolated == nil {
+		t.Fatal("Isolated = nil, want isolated runtime metadata")
+	}
+	if got.Isolated.Demo != "screenshots" || got.Isolated.DemoClock != "play" {
+		t.Fatalf("isolated demo metadata = %#v, want screenshots play", got.Isolated)
+	}
+	if got.Isolated.ManifestPath != "/api/v1/demo/scenarios" {
+		t.Fatalf("ManifestPath = %q, want demo scenario endpoint", got.Isolated.ManifestPath)
+	}
+	if len(got.Global.Projects) < 8 {
+		t.Fatalf("Global projects = %d, want screenshot fleet config", len(got.Global.Projects))
+	}
+}
+
 func TestConfigPathCommandPrintsResolvedPathAndRule(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/dev_runtime.go
+++ b/internal/cli/dev_runtime.go
@@ -25,6 +25,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	var trackerMode string
 	var fixturePath string
 	var demo string
+	var demoClock string
 	var allowLiveDB bool
 	var allowProductionPort bool
 
@@ -53,6 +54,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 				TrackerMode:         trackerMode,
 				FixturePath:         fixturePath,
 				Demo:                demo,
+				DemoClock:           demoClock,
 				Port:                runtimePort,
 				AllowLiveDatabase:   allowLiveDB,
 				AllowProductionPort: allowProductionPort,
@@ -68,7 +70,8 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	cmd.Flags().StringVar(&dbPath, "db", "", "isolated SQLite path or :memory:; relative paths are resolved inside --home")
 	cmd.Flags().StringVar(&trackerMode, "tracker", devruntime.TrackerMemory, "isolated tracker backend")
 	cmd.Flags().StringVar(&fixturePath, "fixture", "", "YAML fixture with mock issues and pull requests")
-	cmd.Flags().StringVar(&demo, "demo", "", "built-in isolated demo fixture (kanban)")
+	cmd.Flags().StringVar(&demo, "demo", "", "built-in isolated demo fixture (kanban, screenshots)")
+	cmd.Flags().StringVar(&demoClock, "demo-clock", "frozen", "demo clock mode for screenshots fixtures (frozen, play)")
 	cmd.Flags().BoolVar(&allowLiveDB, "allow-live-db", false, "allow --db to point at the operator's live ~/.detent/detent.db")
 	cmd.Flags().BoolVar(&allowProductionPort, "allow-production-port", false, "allow binding the isolated runtime to the live dogfood port")
 	return cmd
@@ -110,6 +113,10 @@ func devRuntimeBootConfig(runtime devruntime.Runtime, host string, opts options,
 }
 
 func devRuntimeIsolationInfo(runtime devruntime.Runtime) *IsolatedRuntimeInfo {
+	manifestPath := ""
+	if runtime.Demo == devruntime.DemoScreenshots {
+		manifestPath = "/api/v1/demo/scenarios"
+	}
 	return &IsolatedRuntimeInfo{
 		Home:          runtime.Home,
 		ConfigPath:    runtime.ConfigPath,
@@ -120,6 +127,8 @@ func devRuntimeIsolationInfo(runtime devruntime.Runtime) *IsolatedRuntimeInfo {
 		TrackerMode:   runtime.TrackerMode,
 		FixturePath:   runtime.FixturePath,
 		Demo:          runtime.Demo,
+		DemoClock:     runtime.DemoClock,
+		ManifestPath:  manifestPath,
 	}
 }
 
@@ -143,9 +152,9 @@ func devRuntimeError(err error) error {
 	case errors.Is(err, devruntime.ErrLiveDatabase):
 		return WrapValidation(hintedError(err, err.Error(), "Use the default :memory: DB or a path under --home for isolated tests.", "detent dev-runtime --db :memory:"))
 	case errors.Is(err, devruntime.ErrUnsupportedDemo):
-		return WrapValidation(hintedError(err, err.Error(), "Use --demo kanban or omit --demo.", "detent dev-runtime --demo kanban --port 0"))
+		return WrapValidation(hintedError(err, err.Error(), "Use --demo kanban, --demo screenshots, or omit --demo.", "detent dev-runtime --demo screenshots --port 0"))
 	case errors.Is(err, devruntime.ErrDemoFixtureConflict):
-		return WrapValidation(hintedError(err, err.Error(), "Use either --demo kanban or --fixture, not both.", "detent dev-runtime --demo kanban --port 0"))
+		return WrapValidation(hintedError(err, err.Error(), "Use either --demo or --fixture, not both.", "detent dev-runtime --demo screenshots --port 0"))
 	default:
 		return err
 	}

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -126,6 +126,57 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	}
 }
 
+func TestStartScreenshotsDemoServesScenarioManifestAndUsage(t *testing.T) {
+	runtime, err := devruntime.Build(devruntime.Config{Home: t.TempDir(), Port: 0, Demo: devruntime.DemoScreenshots})
+	if err != nil {
+		t.Fatalf("devruntime.Build() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	output := &lockedBuffer{}
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, devRuntimeBootConfig(runtime, "127.0.0.1", defaultOptions(), output))
+	}()
+	t.Cleanup(cancel)
+
+	dashboardURL := waitForIsolatedRuntimeURL(t, output, done)
+	if banner := output.String(); !strings.Contains(banner, "Demo: screenshots") || !strings.Contains(banner, "Scenario manifest: /api/v1/demo/scenarios") {
+		t.Fatalf("isolated runtime banner missing screenshots metadata:\n%s", banner)
+	}
+	waitForDashboard(t, dashboardURL+"/health", done)
+
+	manifest := waitForDashboard(t, dashboardURL+"/api/v1/demo/scenarios", done)
+	if !strings.Contains(manifest, "fleet-healthy-parallel-work") || !strings.Contains(manifest, "reports-normal-window") {
+		t.Fatalf("scenario manifest missing required scenarios:\n%s", manifest)
+	}
+
+	state := waitForDashboardHeader(t, dashboardURL+"/api/v1/state", done, "fleet-healthy-parallel-work")
+	if !strings.Contains(state, `"status":"running"`) || !strings.Contains(state, `"issue_id":"demo-running-core"`) {
+		t.Fatalf("scenario state response missing demo running issue:\n%s", state)
+	}
+
+	usage := waitForDashboardHeader(t, dashboardURL+"/api/v1/usage?by=project", done, "api-usage-populated")
+	if !strings.Contains(usage, `"events":84`) || !strings.Contains(usage, `"bucket":"billing-api"`) {
+		t.Fatalf("scenario usage response missing seeded ledger data:\n%s", usage)
+	}
+
+	onboarding := waitForDashboardHeader(t, dashboardURL+"/onboarding", done, "onboarding-write-success")
+	if !strings.Contains(onboarding, "Wrote WORKFLOW.md") {
+		t.Fatalf("onboarding scenario did not render success state:\n%s", onboarding)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for isolated runtime to stop")
+	}
+}
+
 type lockedBuffer struct {
 	mu  sync.Mutex
 	buf bytes.Buffer
@@ -164,6 +215,49 @@ func waitForIsolatedRuntimeURL(t *testing.T, output *lockedBuffer, done <-chan e
 		}
 		time.Sleep(10 * time.Millisecond)
 	}
+}
+
+func waitForDashboardHeader(t *testing.T, rawURL string, done <-chan error, scenario string) string {
+	t.Helper()
+
+	client := http.Client{Timeout: time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	var lastErr error
+	for ctx.Err() == nil {
+		select {
+		case err := <-done:
+			t.Fatalf("isolated runtime stopped before dashboard response: %v", err)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, rawURL, nil)
+		if err != nil {
+			t.Fatalf("NewRequestWithContext() error = %v", err)
+		}
+		req.Header.Set("X-Detent-Demo-Scenario", scenario)
+		resp, err := client.Do(req)
+		if err == nil {
+			body, readErr := io.ReadAll(resp.Body)
+			closeErr := resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("ReadAll() error = %v", readErr)
+			}
+			if closeErr != nil {
+				t.Fatalf("Body.Close() error = %v", closeErr)
+			}
+			if resp.StatusCode == http.StatusOK {
+				return string(body)
+			}
+			lastErr = errors.New(resp.Status)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out fetching %s with scenario %s: %v", rawURL, scenario, lastErr)
+	return ""
 }
 
 func postRuntimeRefresh(t *testing.T, url string, done <-chan error) {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -111,8 +111,6 @@ func TestResolveRuntimeSettingsPrecedence(t *testing.T) {
 }
 
 func TestResolveRuntimeSettingsUsesWorkflowRefForServerPort(t *testing.T) {
-	t.Parallel()
-
 	repo := initRuntimeWorkflowRepo(t)
 	writeRuntimeWorkflow(t, filepath.Join(repo, "WORKFLOW.md"), 4109)
 	commitRuntimeWorkflowRepo(t, repo, "initial workflow")

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -16,8 +16,9 @@ import (
 )
 
 const (
-	TrackerMemory = "memory"
-	DemoKanban    = "kanban"
+	TrackerMemory   = "memory"
+	DemoKanban      = "kanban"
+	DemoScreenshots = "screenshots"
 
 	defaultProjectID    = "dogfood"
 	defaultInstanceName = "detent-dev-runtime"
@@ -41,6 +42,7 @@ type Config struct {
 	TrackerMode         string
 	FixturePath         string
 	Demo                string
+	DemoClock           string
 	Port                int
 	AllowLiveDatabase   bool
 	AllowProductionPort bool
@@ -57,6 +59,7 @@ type Runtime struct {
 	TrackerMode   string
 	FixturePath   string
 	Demo          string
+	DemoClock     string
 	Port          int
 	Global        globalconfig.Config
 	Issues        []connector.Issue
@@ -81,6 +84,7 @@ func Build(cfg Config) (Runtime, error) {
 	if err != nil {
 		return Runtime{}, err
 	}
+	demoClock := runtimeDemoClock(cfg.DemoClock)
 
 	home, err := runtimeHome(cfg.Home)
 	if err != nil {
@@ -120,7 +124,7 @@ func Build(cfg Config) (Runtime, error) {
 	}
 
 	configPath := filepath.Join(home, "global.yaml")
-	global := globalConfig(configPath, workflowPath, sourceRoot, cfg.Port)
+	global := globalConfig(configPath, workflowPath, sourceRoot, cfg.Port, demo)
 	if err := globalconfig.Write(configPath, global); err != nil {
 		return Runtime{}, fmt.Errorf("write isolated global config: %w", err)
 	}
@@ -137,6 +141,7 @@ func Build(cfg Config) (Runtime, error) {
 		TrackerMode:   trackerMode,
 		FixturePath:   fixturePath,
 		Demo:          demo,
+		DemoClock:     demoClock,
 		Port:          cfg.Port,
 		Global:        global,
 		Issues:        append([]connector.Issue(nil), issues...),
@@ -146,11 +151,19 @@ func Build(cfg Config) (Runtime, error) {
 func runtimeDemo(value string) (string, error) {
 	value = strings.ToLower(strings.TrimSpace(value))
 	switch value {
-	case "", DemoKanban:
+	case "", DemoKanban, DemoScreenshots:
 		return value, nil
 	default:
 		return "", fmt.Errorf("%w: %s", ErrUnsupportedDemo, value)
 	}
+}
+
+func runtimeDemoClock(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	if value == "play" {
+		return "play"
+	}
+	return "frozen"
 }
 
 func runtimeHome(path string) (string, error) {
@@ -277,6 +290,9 @@ func runtimeIssues(path string, demo string) ([]connector.Issue, string, error) 
 	}
 	if demo == DemoKanban {
 		return kanbanDemoIssues(), "", nil
+	}
+	if demo == DemoScreenshots {
+		return screenshotDemoIssues(), "", nil
 	}
 	if path == "" {
 		return defaultIssues(), "", nil
@@ -501,6 +517,67 @@ func kanbanDemoIssues() []connector.Issue {
 	}
 }
 
+func screenshotDemoIssues() []connector.Issue {
+	issues := append([]connector.Issue(nil), kanbanDemoIssues()...)
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	at := func(hoursAgo int) *time.Time {
+		value := now.Add(-time.Duration(hoursAgo) * time.Hour)
+		return &value
+	}
+	issues = append(issues,
+		connector.Issue{
+			ID:             "screenshots-docs-run",
+			Identifier:     "digitaldrywood/docs-site#6401",
+			Title:          "Document screenshot scenario loading contract",
+			Description:    "Docs project card used by screenshot demos.",
+			State:          "Todo",
+			URL:            "https://github.test/digitaldrywood/docs-site/issues/6401",
+			Labels:         []string{"documentation", "demo"},
+			Assignees:      []string{"writer-a"},
+			UpdatedAt:      at(5),
+			StageUpdatedAt: at(5),
+		},
+		connector.Issue{
+			ID:             "screenshots-billing-blocked",
+			Identifier:     "digitaldrywood/billing-api#6402",
+			Title:          "Unblock budget ledger export fixture",
+			Description:    "Billing project blocked card used by screenshot demos.",
+			State:          "Blocked",
+			URL:            "https://github.test/digitaldrywood/billing-api/issues/6402",
+			Labels:         []string{"observability", "blocked"},
+			Assignees:      []string{"backend-a"},
+			BlockerReason:  "Depends on the usage export schema review.",
+			UpdatedAt:      at(14),
+			StageUpdatedAt: at(14),
+		},
+		connector.Issue{
+			ID:             "screenshots-release-merge",
+			Identifier:     "digitaldrywood/release-train#6403",
+			Title:          "Promote release train demo package",
+			Description:    "Release train card with a linked PR for pipeline screenshots.",
+			State:          "Merging",
+			URL:            "https://github.test/digitaldrywood/release-train/issues/6403",
+			Labels:         []string{"release", "merge-train"},
+			Assignees:      []string{"release-a"},
+			UpdatedAt:      at(1),
+			StageUpdatedAt: at(1),
+			PullRequest: &connector.PullRequest{
+				Number:            6403,
+				URL:               "https://github.test/digitaldrywood/release-train/pull/6403",
+				BranchName:        "detent/release-train-demo-package",
+				State:             "OPEN",
+				MergeableState:    "clean",
+				CIStatus:          "pending",
+				CheckRunCount:     8,
+				RunningChecks:     []string{"release-snapshot"},
+				CIDurationSeconds: 540,
+				CodexReviewState:  "CLEAN",
+			},
+		},
+	)
+	return issues
+}
+
 func defaultIssues() []connector.Issue {
 	reviewedAt := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
 	updatedAt := reviewedAt
@@ -672,7 +749,7 @@ func writeWorkflow(path string, input workflowInput) error {
 	}
 	var kanban *workflowKanban
 	body := "Isolated mock Detent runtime for dogfood-safe e2e validation.\n"
-	if input.Demo == DemoKanban {
+	if input.Demo == DemoKanban || input.Demo == DemoScreenshots {
 		activeStates = []string{"Cancelled"}
 		observedStates = []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"}
 		autoPromote.Enabled = false
@@ -681,6 +758,9 @@ func writeWorkflow(path string, input workflowInput) error {
 			AllowedTransitions: kanbanDemoAllowedTransitions(),
 		}
 		body = "Isolated Kanban demo runtime for dogfood-safe board evaluation.\n"
+		if input.Demo == DemoScreenshots {
+			body = "Isolated screenshot demo runtime for deterministic dashboard, API, and documentation capture.\n"
+		}
 	}
 	frontmatter := workflowFrontmatter{
 		Tracker: workflowTracker{
@@ -740,7 +820,17 @@ func kanbanDemoAllowedTransitions() map[string][]string {
 	}
 }
 
-func globalConfig(path string, workflowPath string, sourceRoot string, port int) globalconfig.Config {
+func globalConfig(path string, workflowPath string, sourceRoot string, port int, demo string) globalconfig.Config {
+	projects := []globalconfig.Project{{
+		ID:       defaultProjectID,
+		Workflow: workflowPath,
+		Workdir:  sourceRoot,
+		Weight:   1,
+		Priority: 1,
+	}}
+	if demo == DemoScreenshots {
+		projects = screenshotDemoProjects(workflowPath, sourceRoot)
+	}
 	return globalconfig.Config{
 		Path:         path,
 		APIVersion:   globalconfig.APIVersion,
@@ -755,14 +845,24 @@ func globalConfig(path string, workflowPath string, sourceRoot string, port int)
 				"max_spawn_per_second": 100,
 			},
 		},
-		Projects: []globalconfig.Project{{
-			ID:       defaultProjectID,
+		Projects: projects,
+	}
+}
+
+func screenshotDemoProjects(workflowPath string, sourceRoot string) []globalconfig.Project {
+	ids := []string{defaultProjectID, "docs-site", "billing-api", "mobile-client", "infra-platform", "release-train", "observability-console", "agent-lab"}
+	projects := make([]globalconfig.Project, 0, len(ids))
+	for i, id := range ids {
+		projects = append(projects, globalconfig.Project{
+			ID:       id,
 			Workflow: workflowPath,
 			Workdir:  sourceRoot,
-			Weight:   1,
-			Priority: 1,
-		}},
+			Weight:   max(10, 120-(i*10)),
+			Priority: 100 - i,
+			Paused:   id == "mobile-client",
+		})
 	}
+	return projects
 }
 
 func dbMode(path string) string {

--- a/internal/devruntime/runtime_test.go
+++ b/internal/devruntime/runtime_test.go
@@ -189,6 +189,38 @@ func TestBuildKanbanDemoCreatesIntegrationWorkflow(t *testing.T) {
 	}
 }
 
+func TestBuildScreenshotsDemoCreatesScenarioRuntime(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := Build(Config{Home: t.TempDir(), Demo: DemoScreenshots, DemoClock: "play", Port: 0})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if runtime.Demo != DemoScreenshots || runtime.DemoClock != "play" {
+		t.Fatalf("Demo = %q clock = %q, want screenshots play", runtime.Demo, runtime.DemoClock)
+	}
+	if len(runtime.Global.Projects) < 8 {
+		t.Fatalf("global projects = %d, want screenshot fleet coverage", len(runtime.Global.Projects))
+	}
+
+	workflow, err := workflowconfig.LoadWorkflow(runtime.WorkflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if workflow.Config.Server.Kanban.Mode != workflowconfig.KanbanModeIntegration {
+		t.Fatalf("Kanban mode = %q, want integration", workflow.Config.Server.Kanban.Mode)
+	}
+	if workflow.Config.Agent.AutoPromote.Enabled {
+		t.Fatal("AutoPromote.Enabled = true, want stable screenshots demo")
+	}
+	if got := workflow.Config.Tracker.ActiveStates; !slices.Equal(got, []string{"Cancelled"}) {
+		t.Fatalf("ActiveStates = %#v, want terminal-only screenshots demo", got)
+	}
+	if len(workflow.Config.Tracker.Issues) <= len(kanbanDemoIssues()) {
+		t.Fatalf("screenshot issues = %d, want more than kanban fixture", len(workflow.Config.Tracker.Issues))
+	}
+}
+
 func stateSet(states []string) map[string]struct{} {
 	out := make(map[string]struct{}, len(states))
 	for _, state := range states {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -25,6 +25,15 @@ type Refresher interface {
 type RefreshResponse = orchestrator.RefreshResponse
 
 func (s *Server) apiState(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		if scenario.ID == "api-state-no-snapshot" {
+			return c.JSON(http.StatusOK, snapshotErrorResponse(demoBaseTime, "snapshot_unavailable", "Snapshot unavailable"))
+		}
+		snapshot := demoSnapshotForScenario(scenario)
+		return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, demoBaseTime), s.instanceName()))
+	}
 	now := apiNow()
 	snapshot, ok := s.hub.Latest()
 	if !ok {
@@ -56,6 +65,18 @@ func projectAPIParam(c echo.Context, suffix string) (string, bool) {
 }
 
 func (s *Server) apiProjectState(c echo.Context, projectID string) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		snapshot := demoSnapshotForScenario(scenario)
+		projects := demoProjectsForVariant(scenario.Variant)
+		project, ok := demoProjectByID(projects, projectID)
+		if !ok {
+			return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
+		}
+		scoped := projectScopedSnapshotForProject(snapshot, telemetry.Project{ID: project.ID, DisplayName: project.Name, URL: project.URL})
+		return c.JSON(http.StatusOK, stateResponse(scoped, generatedAt(scoped, demoBaseTime), s.instanceName()))
+	}
 	now := apiNow()
 	snapshot, ok := s.hub.Latest()
 	if !ok {
@@ -81,6 +102,15 @@ func (s *Server) apiTimeSeries(c echo.Context) error {
 	if response != nil {
 		return c.JSON(status, response)
 	}
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		if scenario.Variant == "invalid-query" {
+			return c.JSON(http.StatusBadRequest, errorResponse("invalid_duration", "window must be a duration such as 10m or 30s"))
+		}
+		projects := demoProjectsForVariant(scenario.Variant)
+		return c.JSON(http.StatusOK, projectTimeSeriesResponse(projects, "", demoBaseTime, window, bucket))
+	}
 
 	snapshot := s.latestSnapshot(c.Request().Context())
 	projects := s.projectSmallMultiples(c.Request().Context(), snapshot)
@@ -91,6 +121,15 @@ func (s *Server) apiProjectTimeSeries(c echo.Context, projectID string) error {
 	window, bucket, response, status := timeSeriesQuery(c)
 	if response != nil {
 		return c.JSON(status, response)
+	}
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		projects := demoProjectsForVariant(scenario.Variant)
+		if _, ok := demoProjectByID(projects, projectID); !ok {
+			return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
+		}
+		return c.JSON(http.StatusOK, projectTimeSeriesResponse(projects, projectID, demoBaseTime, window, bucket))
 	}
 
 	snapshot := s.latestSnapshot(c.Request().Context())
@@ -103,6 +142,15 @@ func (s *Server) apiProjectTimeSeries(c echo.Context, projectID string) error {
 }
 
 func (s *Server) apiIssue(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		payload, found := issueResponse(issueIdentifier(c), demoSnapshotForScenario(scenario))
+		if !found {
+			return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
+		}
+		return c.JSON(http.StatusOK, payload)
+	}
 	snapshot, ok := s.hub.Latest()
 	if !ok {
 		return c.JSON(http.StatusNotFound, errorResponse("issue_not_found", "Issue not found"))
@@ -118,6 +166,11 @@ func (s *Server) apiIssue(c echo.Context) error {
 }
 
 func (s *Server) apiRefresh(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		return s.demoRefresh(c, scenario)
+	}
 	if s.refresher == nil {
 		return c.JSON(http.StatusServiceUnavailable, errorResponse("orchestrator_unavailable", "Orchestrator is unavailable"))
 	}
@@ -140,6 +193,16 @@ func (s *Server) apiUsage(c echo.Context) error {
 	query, response, status := usageReportQuery(c)
 	if response != nil {
 		return c.JSON(status, response)
+	}
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		if scenario.Variant == "invalid-date-range" {
+			return c.JSON(http.StatusBadRequest, errorResponse("invalid_date_range", "from must be on or before to"))
+		}
+		if scenario.Variant == "reports-empty" {
+			return c.JSON(http.StatusOK, usageReportResponse(store.UsageReport{By: query.By}, s.pricing))
+		}
 	}
 
 	report, err := s.store.UsageReport(c.Request().Context(), query)

--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -1,0 +1,1289 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/labstack/echo/v4"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web/templates"
+)
+
+const (
+	DemoScenarioHeader  = "X-Detent-Demo-Scenario"
+	DemoModeScreenshots = "screenshots"
+	DemoClockFrozen     = "frozen"
+	DemoClockPlay       = "play"
+
+	demoPrimaryProjectID   = "dogfood"
+	demoPrimaryProjectName = "detent-core"
+)
+
+var demoBaseTime = time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+
+var errDemoScenarioResponseWritten = errors.New("demo scenario response written")
+
+type DemoConfig struct {
+	Mode  string
+	Clock string
+}
+
+type DemoScenarioManifest struct {
+	ID             string            `json:"id"`
+	Route          string            `json:"route"`
+	Method         string            `json:"method"`
+	Headers        map[string]string `json:"headers"`
+	Viewport       DemoViewport      `json:"viewport"`
+	ScreenshotName string            `json:"screenshot_name"`
+	WaitSelector   string            `json:"wait_selector"`
+	KeySelectors   []string          `json:"key_selectors,omitempty"`
+}
+
+type DemoViewport struct {
+	Width  int `json:"width"`
+	Height int `json:"height"`
+}
+
+type demoScenarioSet struct {
+	clock     string
+	manifest  []DemoScenarioManifest
+	scenarios map[string]demoScenario
+}
+
+type demoScenario struct {
+	ID           string
+	Route        string
+	Method       string
+	WaitSelector string
+	Page         string
+	Variant      string
+	ProjectID    string
+	KanbanMode   string
+	Status       int
+}
+
+type demoScenariosResponse struct {
+	GeneratedAt time.Time              `json:"generated_at"`
+	Header      string                 `json:"header"`
+	Clock       string                 `json:"clock"`
+	Scenarios   []DemoScenarioManifest `json:"scenarios"`
+}
+
+func newDemoScenarioSet(cfg DemoConfig) *demoScenarioSet {
+	mode := strings.ToLower(strings.TrimSpace(cfg.Mode))
+	if mode != DemoModeScreenshots {
+		return nil
+	}
+	clock := strings.ToLower(strings.TrimSpace(cfg.Clock))
+	if clock != DemoClockPlay {
+		clock = DemoClockFrozen
+	}
+	defs := demoScenarioDefinitions()
+	scenarios := make(map[string]demoScenario, len(defs))
+	manifest := make([]DemoScenarioManifest, 0, len(defs))
+	for _, def := range defs {
+		method := strings.TrimSpace(def.Method)
+		if method == "" {
+			method = http.MethodGet
+		}
+		def.Method = method
+		scenarios[def.ID] = def
+		if demoScenarioInManifest(def) {
+			manifest = append(manifest, DemoScenarioManifest{
+				ID:             def.ID,
+				Route:          def.Route,
+				Method:         method,
+				Headers:        map[string]string{DemoScenarioHeader: def.ID},
+				Viewport:       DemoViewport{Width: 1440, Height: 1100},
+				ScreenshotName: def.ID + ".png",
+				WaitSelector:   def.WaitSelector,
+				KeySelectors:   demoKeySelectors(def),
+			})
+		}
+	}
+	return &demoScenarioSet{
+		clock:     clock,
+		manifest:  manifest,
+		scenarios: scenarios,
+	}
+}
+
+func demoScenarioInManifest(scenario demoScenario) bool {
+	return scenario.Route != "/events"
+}
+
+func demoScenarioDefinitions() []demoScenario {
+	return []demoScenario{
+		{ID: "fleet-empty-first-snapshot", Route: "/", WaitSelector: "#snapshot", Page: "fleet", Variant: "empty"},
+		{ID: "fleet-healthy-parallel-work", Route: "/", WaitSelector: "#snapshot", Page: "fleet", Variant: "healthy"},
+		{ID: "fleet-overloaded-rate-limited", Route: "/", WaitSelector: "#snapshot", Page: "fleet", Variant: "overloaded"},
+		{ID: "fleet-draining-shutdown", Route: "/", WaitSelector: "#snapshot", Page: "fleet", Variant: "draining"},
+		{ID: "fleet-dense-multiproject", Route: "/", WaitSelector: "#snapshot", Page: "fleet", Variant: "dense"},
+		{ID: "fleet-degraded-telemetry", Route: "/", WaitSelector: "#snapshot", Page: "fleet", Variant: "degraded"},
+		{ID: "project-active-overview", Route: "/projects/dogfood", WaitSelector: "#snapshot", Page: "project", Variant: "healthy", ProjectID: demoPrimaryProjectID},
+		{ID: "project-paused-overview", Route: "/projects/mobile-client", WaitSelector: "#snapshot", Page: "project", Variant: "paused", ProjectID: "mobile-client"},
+		{ID: "project-empty-overview", Route: "/projects/agent-lab", WaitSelector: "#snapshot", Page: "project", Variant: "project-empty", ProjectID: "agent-lab"},
+		{ID: "project-hot-path", Route: "/projects/billing-api", WaitSelector: "#snapshot", Page: "project", Variant: "hot-path", ProjectID: "billing-api"},
+		{ID: "project-not-found", Route: "/projects/missing-project", WaitSelector: "body", Page: "project", Variant: "not-found", ProjectID: "missing-project", Status: http.StatusNotFound},
+		{ID: "kanban-full-integration", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "healthy", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
+		{ID: "kanban-read-only", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "healthy", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeReadOnly},
+		{ID: "kanban-empty-lanes", Route: "/projects/agent-lab/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "project-empty", ProjectID: "agent-lab", KanbanMode: workflowconfig.KanbanModeIntegration},
+		{ID: "kanban-dense-overflow", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "dense-kanban", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
+		{ID: "kanban-transition-blocked", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "transition-blocked", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
+		{ID: "kanban-terminal-states", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "terminal", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
+		{ID: "runs-active-work", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "healthy", ProjectID: demoPrimaryProjectID},
+		{ID: "runs-idle", Route: "/projects/agent-lab/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "project-empty", ProjectID: "agent-lab"},
+		{ID: "runs-backoff-heavy", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "backoff-heavy", ProjectID: demoPrimaryProjectID},
+		{ID: "runs-blocked-heavy", Route: "/projects/billing-api/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "blocked-heavy", ProjectID: "billing-api"},
+		{ID: "runs-long-content", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "long-content", ProjectID: demoPrimaryProjectID},
+		{ID: "diagnostics-healthy", Route: "/projects/dogfood/diagnostics", WaitSelector: "#snapshot", Page: "diagnostics", Variant: "healthy", ProjectID: demoPrimaryProjectID},
+		{ID: "diagnostics-budget-refusals", Route: "/projects/dogfood/diagnostics", WaitSelector: "#snapshot", Page: "diagnostics", Variant: "budget-refusals", ProjectID: demoPrimaryProjectID},
+		{ID: "diagnostics-rate-limit-pressure", Route: "/projects/dogfood/diagnostics", WaitSelector: "#snapshot", Page: "diagnostics", Variant: "overloaded", ProjectID: demoPrimaryProjectID},
+		{ID: "diagnostics-no-history", Route: "/projects/agent-lab/diagnostics", WaitSelector: "#snapshot", Page: "diagnostics", Variant: "no-history", ProjectID: "agent-lab"},
+		{ID: "diagnostics-degraded", Route: "/projects/dogfood/diagnostics", WaitSelector: "#snapshot", Page: "diagnostics", Variant: "degraded", ProjectID: demoPrimaryProjectID},
+		{ID: "settings-loaded-fleet", Route: "/settings", WaitSelector: "main", Page: "settings", Variant: "healthy"},
+		{ID: "settings-empty-registry", Route: "/settings", WaitSelector: "main", Page: "settings", Variant: "settings-empty"},
+		{ID: "settings-long-paths", Route: "/settings", WaitSelector: "main", Page: "settings", Variant: "settings-long-paths"},
+		{ID: "settings-project-context", Route: "/projects/dogfood/configuration", WaitSelector: "main", Page: "settings", Variant: "healthy", ProjectID: demoPrimaryProjectID},
+		{ID: "settings-missing-runtime-values", Route: "/settings", WaitSelector: "main", Page: "settings", Variant: "settings-missing"},
+		{ID: "reports-empty-ledger", Route: "/reports", WaitSelector: "main", Page: "reports", Variant: "reports-empty"},
+		{ID: "reports-normal-window", Route: "/reports", WaitSelector: "main", Page: "reports", Variant: "healthy"},
+		{ID: "reports-high-spend-day", Route: "/reports", WaitSelector: "main", Page: "reports", Variant: "hot-path"},
+		{ID: "reports-model-heavy", Route: "/reports", WaitSelector: "main", Page: "reports", Variant: "model-heavy"},
+		{ID: "reports-filtered-project", Route: "/reports", WaitSelector: "main", Page: "reports", Variant: "filtered-project", ProjectID: demoPrimaryProjectID},
+		{ID: "reports-invalid-date-range", Route: "/reports", WaitSelector: "body", Page: "reports", Variant: "invalid-date-range", Status: http.StatusBadRequest},
+		{ID: "onboarding-tracker-choice", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "tracker"},
+		{ID: "onboarding-github-credentials", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "credentials"},
+		{ID: "onboarding-project-selection", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "project"},
+		{ID: "onboarding-agent-config", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "agent"},
+		{ID: "onboarding-write-summary", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "write"},
+		{ID: "onboarding-validation-errors", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "validation-errors"},
+		{ID: "onboarding-write-exists", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "write-exists"},
+		{ID: "onboarding-write-success", Route: "/onboarding", WaitSelector: "#onboarding-step", Page: "onboarding", Variant: "write-success"},
+		{ID: "api-kanban-move-dialog", Route: "/api/v1/kanban/move", Method: http.MethodGet, WaitSelector: "#kanban-dialog-content", Page: "api", Variant: "kanban-move-dialog", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-move-preselected-target", Route: "/api/v1/kanban/move", Method: http.MethodGet, WaitSelector: "#kanban-dialog-content", Page: "api", Variant: "kanban-move-dialog", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-move-missing-target", Route: "/api/v1/kanban/move", Method: http.MethodGet, WaitSelector: "#kanban-dialog-content", Page: "api", Variant: "kanban-move-missing-target", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-move-read-only", Route: "/api/v1/kanban/move", Method: http.MethodGet, WaitSelector: "#kanban-dialog-content", Page: "api", Variant: "kanban-read-only", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeReadOnly},
+		{ID: "api-kanban-move-success", Route: "/api/v1/kanban/move", Method: http.MethodPost, WaitSelector: "#kanban-feedback", Page: "api", Variant: "kanban-move-success", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-move-transition-blocked", Route: "/api/v1/kanban/move", Method: http.MethodPost, WaitSelector: "#kanban-feedback", Page: "api", Variant: "kanban-transition-blocked", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-move-connector-failure", Route: "/api/v1/kanban/move", Method: http.MethodPost, WaitSelector: "#kanban-feedback", Page: "api", Variant: "connector-failure", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-comment-issue-dialog", Route: "/api/v1/kanban/comment", Method: http.MethodGet, WaitSelector: "#kanban-dialog-content", Page: "api", Variant: "kanban-comment-issue", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-comment-pr-dialog", Route: "/api/v1/kanban/comment", Method: http.MethodGet, WaitSelector: "#kanban-dialog-content", Page: "api", Variant: "kanban-comment-pr", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-comment-invalid-target", Route: "/api/v1/kanban/comment", Method: http.MethodGet, WaitSelector: "#kanban-dialog-content", Page: "api", Variant: "kanban-comment-invalid-target", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-comment-success", Route: "/api/v1/kanban/comment", Method: http.MethodPost, WaitSelector: "#kanban-feedback", Page: "api", Variant: "kanban-comment-success", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-comment-empty-body", Route: "/api/v1/kanban/comment", Method: http.MethodPost, WaitSelector: "#kanban-feedback", Page: "api", Variant: "kanban-comment-empty-body", ProjectID: demoPrimaryProjectID},
+		{ID: "api-kanban-comment-connector-failure", Route: "/api/v1/kanban/comment", Method: http.MethodPost, WaitSelector: "#kanban-feedback", Page: "api", Variant: "connector-failure", ProjectID: demoPrimaryProjectID},
+		{ID: "api-refresh-accepted", Route: "/api/v1/refresh", Method: http.MethodPost, WaitSelector: "body", Page: "api", Variant: "refresh-accepted"},
+		{ID: "api-refresh-unavailable", Route: "/api/v1/refresh", Method: http.MethodPost, WaitSelector: "body", Page: "api", Variant: "refresh-unavailable", Status: http.StatusServiceUnavailable},
+		{ID: "api-state-full-snapshot", Route: "/api/v1/state", WaitSelector: "body", Page: "api", Variant: "healthy"},
+		{ID: "api-state-no-snapshot", Route: "/api/v1/state", WaitSelector: "body", Page: "api", Variant: "empty"},
+		{ID: "api-state-draining", Route: "/api/v1/state", WaitSelector: "body", Page: "api", Variant: "draining"},
+		{ID: "api-state-project-scoped", Route: "/api/v1/projects/dogfood/state", WaitSelector: "body", Page: "api", Variant: "healthy", ProjectID: demoPrimaryProjectID},
+		{ID: "api-timeseries-populated", Route: "/api/v1/timeseries?window=10m&bucket=1m", WaitSelector: "body", Page: "api", Variant: "healthy"},
+		{ID: "api-timeseries-empty", Route: "/api/v1/timeseries?window=10m&bucket=1m", WaitSelector: "body", Page: "api", Variant: "project-empty"},
+		{ID: "api-timeseries-invalid-query", Route: "/api/v1/timeseries?window=nope", WaitSelector: "body", Page: "api", Variant: "invalid-query", Status: http.StatusBadRequest},
+		{ID: "api-usage-populated", Route: "/api/v1/usage?by=day", WaitSelector: "body", Page: "api", Variant: "healthy"},
+		{ID: "api-usage-empty", Route: "/api/v1/usage?by=day", WaitSelector: "body", Page: "api", Variant: "reports-empty"},
+		{ID: "api-usage-invalid-range", Route: "/api/v1/usage?by=day&from=2026-06-16&to=2026-06-15", WaitSelector: "body", Page: "api", Variant: "invalid-date-range", Status: http.StatusBadRequest},
+		{ID: "api-issue-running", Route: "/api/v1/digitaldrywood/detent-core%235260", WaitSelector: "body", Page: "api", Variant: "healthy"},
+		{ID: "api-issue-queued", Route: "/api/v1/digitaldrywood/docs-site%235270", WaitSelector: "body", Page: "api", Variant: "healthy"},
+		{ID: "api-issue-blocked", Route: "/api/v1/digitaldrywood/billing-api%235280", WaitSelector: "body", Page: "api", Variant: "healthy"},
+		{ID: "api-issue-not-found", Route: "/api/v1/digitaldrywood/detent-core%239999", WaitSelector: "body", Page: "api", Variant: "healthy", Status: http.StatusNotFound},
+		{ID: "health-running-demo", Route: "/health", WaitSelector: "body", Page: "api", Variant: "healthy"},
+		{ID: "events-frozen", Route: "/events", WaitSelector: "#snapshot", Page: "api", Variant: "healthy"},
+		{ID: "events-play", Route: "/events", WaitSelector: "#snapshot", Page: "api", Variant: "play"},
+	}
+}
+
+func demoKeySelectors(def demoScenario) []string {
+	switch def.Page {
+	case "fleet":
+		return []string{"#snapshot", "[aria-label=\"Dashboard health\"]", "[aria-label=\"Project overview\"]"}
+	case "kanban":
+		return []string{"#project-kanban", "[data-kanban-card]", "[data-project-kanban-visibility-menu]"}
+	case "reports":
+		return []string{"main", "[aria-label=\"Usage reports\"]"}
+	case "settings":
+		return []string{"main", "[aria-label=\"Settings\"]"}
+	case "onboarding":
+		return []string{"#onboarding-step"}
+	default:
+		return []string{def.WaitSelector}
+	}
+}
+
+func (d *demoScenarioSet) scenario(r *http.Request) (demoScenario, bool, bool) {
+	if d == nil || r == nil {
+		return demoScenario{}, false, false
+	}
+	id := strings.TrimSpace(r.Header.Get(DemoScenarioHeader))
+	if id == "" {
+		return demoScenario{}, false, false
+	}
+	scenario, ok := d.scenarios[id]
+	return scenario, ok, !ok
+}
+
+func (s *Server) demoScenarioOrError(c echo.Context) (demoScenario, bool, error) {
+	if s.demo == nil {
+		return demoScenario{}, false, nil
+	}
+	scenario, ok, unknown := s.demo.scenario(c.Request())
+	if unknown {
+		if err := c.JSON(http.StatusNotFound, errorResponse("demo_scenario_not_found", "Demo scenario not found")); err != nil {
+			return demoScenario{}, false, err
+		}
+		return demoScenario{}, false, errDemoScenarioResponseWritten
+	}
+	return scenario, ok, nil
+}
+
+func (s *Server) apiDemoScenarios(c echo.Context) error {
+	if s.demo == nil {
+		return c.JSON(http.StatusNotFound, errorResponse("demo_scenarios_unavailable", "Demo scenarios are not enabled"))
+	}
+	return c.JSON(http.StatusOK, demoScenariosResponse{
+		GeneratedAt: demoBaseTime,
+		Header:      DemoScenarioHeader,
+		Clock:       s.demo.clock,
+		Scenarios:   append([]DemoScenarioManifest(nil), s.demo.manifest...),
+	})
+}
+
+func (s *Server) demoDashboard(c echo.Context, scenario demoScenario) error {
+	data := s.demoDashboardData(c.Request().Context(), scenario)
+	data.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
+	return render(c, templates.Dashboard(data))
+}
+
+func (s *Server) demoProjectDashboard(c echo.Context, scenario demoScenario, view string) error {
+	if scenario.Status == http.StatusNotFound || scenario.Variant == "not-found" {
+		return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
+	}
+	data, ok := s.demoProjectDashboardData(c.Request().Context(), scenario)
+	if !ok {
+		return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
+	}
+	data.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
+	switch view {
+	case "kanban":
+		data.ActiveNav = "kanban"
+		data.Title = s.projectPageTitle(data, "Kanban")
+		return render(c, templates.ProjectKanbanPage(data))
+	case "runs":
+		data.ActiveNav = "runs"
+		data.Title = s.projectPageTitle(data, "Runs")
+		return render(c, templates.ProjectRunsPage(data))
+	case "diagnostics":
+		data.ActiveNav = "diagnostics"
+		data.Title = s.projectPageTitle(data, "Diagnostics")
+		return render(c, templates.ProjectDiagnosticsPage(data))
+	case "configuration":
+		settingsData := s.demoSettingsData(c.Request().Context(), scenario, scenario.ProjectID)
+		settingsData.ActiveNav = "configuration"
+		settingsData.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
+		return render(c, templates.Settings(settingsData))
+	default:
+		return render(c, templates.Dashboard(data))
+	}
+}
+
+func (s *Server) demoReports(c echo.Context, scenario demoScenario) error {
+	if scenario.Variant == "invalid-date-range" {
+		return c.JSON(http.StatusBadRequest, errorResponse("invalid_date_range", "from must be on or before to"))
+	}
+	if scenario.Variant == "reports-empty" {
+		data := s.demoEmptyReportsData(c.Request().Context(), scenario)
+		data.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
+		return render(c, templates.Reports(data))
+	}
+	projectID := ""
+	if scenario.Variant == "filtered-project" {
+		projectID = scenario.ProjectID
+	}
+	data, err := s.reportsData(c.Request().Context(), time.Time{}, time.Time{}, projectID)
+	if err != nil {
+		return c.JSON(http.StatusInternalServerError, errorResponse("usage_reports_failed", "Usage reports failed"))
+	}
+	data.GeneratedAt = demoBaseTime
+	data.Projects = demoProjectsForVariant(scenario.Variant)
+	data.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
+	return render(c, templates.Reports(data))
+}
+
+func (s *Server) demoSettings(c echo.Context, scenario demoScenario, selectedProjectID string) error {
+	data := s.demoSettingsData(c.Request().Context(), scenario, selectedProjectID)
+	data.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
+	return render(c, templates.Settings(data))
+}
+
+func (s *Server) demoOnboarding(c echo.Context, scenario demoScenario) error {
+	return render(c, templates.OnboardingPage(s.demoOnboardingData(scenario)))
+}
+
+func (s *Server) demoDashboardData(ctx context.Context, scenario demoScenario) templates.DashboardData {
+	instanceName := s.instanceName()
+	snapshot := demoSnapshotForScenario(scenario)
+	return templates.DashboardData{
+		Title:           instancePageTitle(instanceName, "Detent"),
+		ApplicationName: applicationName(instanceName),
+		InstanceName:    instanceName,
+		Version:         s.version,
+		Build:           s.build,
+		ConnectorName:   s.connector.Name(),
+		DashboardURL:    s.dashboardURL,
+		Snapshot:        snapshot,
+		Projects:        demoProjectsForVariant(scenario.Variant),
+		Kanban:          demoKanbanData(scenario, ""),
+		Assets:          s.assets.templatePaths(),
+		ActiveNav:       "fleet",
+	}
+}
+
+func (s *Server) demoProjectDashboardData(ctx context.Context, scenario demoScenario) (templates.DashboardData, bool) {
+	projectID := strings.TrimSpace(scenario.ProjectID)
+	if projectID == "" {
+		projectID = demoPrimaryProjectID
+	}
+	snapshot := demoSnapshotForScenario(scenario)
+	projects := demoProjectsForVariant(scenario.Variant)
+	project, ok := demoProjectByID(projects, projectID)
+	if !ok {
+		return templates.DashboardData{}, false
+	}
+	scoped := projectScopedSnapshotForProject(snapshot, telemetry.Project{
+		ID:          project.ID,
+		DisplayName: project.Name,
+		URL:         project.URL,
+	})
+	instanceName := s.instanceName()
+	return templates.DashboardData{
+		Title:           instancePageTitle(instanceName, project.Name+" - Detent"),
+		ApplicationName: applicationName(instanceName),
+		InstanceName:    instanceName,
+		Version:         s.version,
+		Build:           s.build,
+		ConnectorName:   s.connector.Name(),
+		DashboardURL:    s.dashboardURL,
+		Snapshot:        scoped,
+		Projects:        projects,
+		Kanban:          demoKanbanData(scenario, project.ID),
+		Assets:          s.assets.templatePaths(),
+		ActiveNav:       "project",
+		ProjectID:       project.ID,
+		ProjectName:     project.Name,
+		ProjectPaused:   project.Paused,
+	}, true
+}
+
+func demoKanbanData(scenario demoScenario, projectID string) templates.KanbanData {
+	mode := strings.TrimSpace(scenario.KanbanMode)
+	if mode == "" {
+		mode = workflowconfig.KanbanModeIntegration
+	}
+	if projectID == "" {
+		mode = workflowconfig.KanbanModeReadOnly
+	}
+	states := []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"}
+	return templates.KanbanData{
+		Mode:               mode,
+		ProjectID:          projectID,
+		States:             states,
+		AllowedTransitions: demoKanbanTransitions(states),
+	}
+}
+
+func demoKanbanTransitions(states []string) map[string][]string {
+	transitions := map[string][]string{
+		"Backlog":      {"Todo", "Cancelled"},
+		"Todo":         {"In Progress", "Blocked", "Cancelled"},
+		"In Progress":  {"Blocked", "Human Review", "Rework", "Cancelled"},
+		"Blocked":      {"Todo", "In Progress", "Rework", "Cancelled"},
+		"Human Review": {"Rework", "Merging", "Blocked", "Cancelled"},
+		"Rework":       {"In Progress", "Human Review", "Blocked", "Cancelled"},
+		"Merging":      {"Done", "Blocked", "Rework", "Cancelled"},
+		"Done":         {},
+		"Cancelled":    {"Backlog"},
+	}
+	out := make(map[string][]string, len(states))
+	for _, state := range states {
+		out[state] = append([]string(nil), transitions[state]...)
+	}
+	return out
+}
+
+func (s *Server) demoSettingsData(ctx context.Context, scenario demoScenario, selectedProjectID string) templates.SettingsData {
+	instanceName := s.instanceName()
+	projects := demoSettingsProjects(scenario.Variant)
+	sidebarProjects := demoProjectsForVariant(scenario.Variant)
+	projectID, projectName := "", ""
+	if selectedProjectID != "" {
+		if project, ok := demoProjectByID(sidebarProjects, selectedProjectID); ok {
+			projectID = project.ID
+			projectName = project.Name
+		}
+	}
+	runtime := templates.SettingsRuntime{
+		DBPath:        "/tmp/detent-screenshots/detent.db",
+		LogPath:       "/tmp/detent-screenshots/detent.log",
+		ServerAddress: "127.0.0.1:0",
+	}
+	globalPath := "/tmp/detent-screenshots/global.yaml"
+	if scenario.Variant == "settings-long-paths" {
+		globalPath = "/Users/example/Library/Application Support/Detent/screenshot-demo/very/long/configuration/root/global.yaml"
+		runtime.DBPath = "/Users/example/Library/Application Support/Detent/screenshot-demo/very/long/runtime/database/detent.db"
+		runtime.LogPath = "/Users/example/Library/Logs/Detent/screenshot-demo/very/long/runtime/detent.log"
+	}
+	if scenario.Variant == "settings-missing" {
+		runtime = templates.SettingsRuntime{}
+		globalPath = ""
+	}
+	return templates.SettingsData{
+		Title:           instancePageTitle(instanceName, "Detent settings"),
+		ApplicationName: applicationName(instanceName),
+		InstanceName:    instanceName,
+		Version:         s.version,
+		Global: templates.SettingsGlobal{
+			ConfigPath: globalPath,
+			PathRule:   string(globalconfig.PathRuleFlag),
+		},
+		Projects:        projects,
+		Runtime:         runtime,
+		Assets:          s.assets.templatePaths(),
+		SidebarProjects: sidebarProjects,
+		ActiveNav:       "settings",
+		ProjectID:       projectID,
+		ProjectName:     projectName,
+	}
+}
+
+func demoSettingsProjects(variant string) []templates.SettingsProject {
+	if variant == "settings-empty" {
+		return nil
+	}
+	projects := []templates.SettingsProject{
+		{ID: demoPrimaryProjectID, WorkflowPath: "/tmp/detent-screenshots/WORKFLOW.md", Workdir: "/tmp/detent-screenshots/source/detent-core", WorktreeRoot: "/tmp/detent-screenshots/workspaces/detent-core", Weight: 120, Priority: 100, TrackerKind: "memory", TrackerProject: "digitaldrywood/detent-core", DependencyAutoUnblock: "enabled: Blocked -> Todo when terminal_or_merged"},
+		{ID: "docs-site", WorkflowPath: "/tmp/detent-screenshots/WORKFLOW.md", Workdir: "/tmp/detent-screenshots/source/docs-site", WorktreeRoot: "/tmp/detent-screenshots/workspaces/docs-site", Weight: 90, Priority: 80, TrackerKind: "memory", TrackerProject: "digitaldrywood/docs-site", DependencyAutoUnblock: "disabled: n/a -> n/a when terminal_or_merged"},
+		{ID: "billing-api", WorkflowPath: "/tmp/detent-screenshots/WORKFLOW.md", Workdir: "/tmp/detent-screenshots/source/billing-api", WorktreeRoot: "/tmp/detent-screenshots/workspaces/billing-api", Weight: 80, Priority: 95, TrackerKind: "memory", TrackerProject: "digitaldrywood/billing-api", DependencyAutoUnblock: "enabled: Blocked -> Rework when terminal_or_merged"},
+		{ID: "mobile-client", WorkflowPath: "/tmp/detent-screenshots/WORKFLOW.md", Workdir: "/tmp/detent-screenshots/source/mobile-client", WorktreeRoot: "/tmp/detent-screenshots/workspaces/mobile-client", Weight: 40, Priority: 20, Paused: true, TrackerKind: "memory", TrackerProject: "digitaldrywood/mobile-client", DependencyAutoUnblock: "disabled: n/a -> n/a when terminal_or_merged"},
+	}
+	if variant == "settings-long-paths" {
+		for i := range projects {
+			projects[i].WorkflowPath = "/Users/example/Library/Application Support/Detent/screenshot-demo/very/long/project/" + projects[i].ID + "/workflow/WORKFLOW.md"
+			projects[i].Workdir = "/Users/example/Development/digitaldrywood/products/detent/screenshot-demo/source/" + projects[i].ID + "/with/a/deep/path"
+			projects[i].WorktreeRoot = "/Users/example/Development/digitaldrywood/products/detent/screenshot-demo/worktrees/" + projects[i].ID + "/nested/workspaces"
+		}
+	}
+	if variant == "settings-missing" {
+		for i := range projects {
+			projects[i].WorkflowPath = ""
+			projects[i].Workdir = ""
+			projects[i].WorktreeRoot = ""
+			projects[i].TrackerProject = ""
+		}
+	}
+	return projects
+}
+
+func (s *Server) demoEmptyReportsData(ctx context.Context, scenario demoScenario) templates.ReportsData {
+	instanceName := s.instanceName()
+	empty := templates.UsageReportData{By: "day"}
+	return templates.ReportsData{
+		Title:           instancePageTitle(instanceName, "Detent reports"),
+		ApplicationName: applicationName(instanceName),
+		InstanceName:    instanceName,
+		ConnectorName:   s.connector.Name(),
+		GeneratedAt:     demoBaseTime,
+		Day:             empty,
+		Project:         templates.UsageReportData{By: "project"},
+		Issue:           templates.UsageReportData{By: "issue"},
+		PR:              templates.UsageReportData{By: "pr"},
+		Model:           templates.UsageReportData{By: "model"},
+		Assets:          s.assets.templatePaths(),
+		Projects:        demoProjectsForVariant(scenario.Variant),
+		ActiveNav:       "reports",
+	}
+}
+
+func (s *Server) demoOnboardingData(scenario demoScenario) templates.OnboardingData {
+	form := templates.OnboardingForm{
+		Step:                         onboardingStepTracker,
+		TrackerKind:                  workflowconfig.TrackerGitHub,
+		Endpoint:                     "https://api.github.test",
+		APIKey:                       "$GITHUB_TOKEN",
+		ProjectSlug:                  "digitaldrywood/detent-core",
+		Repo:                         "digitaldrywood/detent-core",
+		WorkspaceRoot:                "/tmp/detent-screenshots/workspaces",
+		MaxConcurrentAgents:          "6",
+		MaxTurns:                     "24",
+		PollingIntervalMS:            "60000",
+		MergingConcurrency:           "1",
+		DispatchPriorityState:        "Merging\nRework\nTodo",
+		DispatchPriorityLabel:        "stage:s6\nobservability",
+		DependencyAutoUnblockEnabled: "true",
+	}
+	var errors []string
+	result := templates.OnboardingResult{}
+	switch scenario.Variant {
+	case "credentials":
+		form.Step = onboardingStepCredentials
+	case "project":
+		form.Step = onboardingStepProject
+	case "agent":
+		form.Step = onboardingStepAgent
+	case "write":
+		form.Step = onboardingStepWrite
+	case "validation-errors":
+		form.Step = onboardingStepProject
+		form.Endpoint = "not a url"
+		form.Repo = "digitaldrywood"
+		errors = []string{"endpoint must be an absolute HTTP URL", "repo must look like owner/name", "max agents must be a positive integer"}
+	case "write-exists":
+		form.Step = onboardingStepWrite
+		result = templates.OnboardingResult{Kind: "exists", Message: "WORKFLOW.md already exists."}
+	case "write-success":
+		form.Step = onboardingStepWrite
+		result = templates.OnboardingResult{Kind: "success", Message: "Wrote WORKFLOW.md."}
+	default:
+		form.Step = onboardingStepTracker
+	}
+	instanceName := s.instanceName()
+	return templates.OnboardingData{
+		Title:           instancePageTitle(instanceName, "Detent onboarding"),
+		ApplicationName: applicationName(instanceName),
+		InstanceName:    instanceName,
+		WorkflowPath:    "WORKFLOW.md",
+		Step:            form.Step,
+		Form:            form,
+		Errors:          errors,
+		Result:          result,
+		Assets:          s.assets.templatePaths(),
+		Polling:         templates.PollingData{MinIntervalMS: minPollingIntervalMS},
+	}
+}
+
+func demoProjectByID(projects []templates.ProjectSmallMultiple, id string) (templates.ProjectSmallMultiple, bool) {
+	for _, project := range projects {
+		if strings.TrimSpace(project.ID) == strings.TrimSpace(id) {
+			return project, true
+		}
+	}
+	return templates.ProjectSmallMultiple{}, false
+}
+
+func demoSnapshotForScenario(scenario demoScenario) telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	switch scenario.Variant {
+	case "empty":
+		snapshot = demoEmptySnapshot()
+		snapshot.GeneratedAt = time.Time{}
+		snapshot.Project = telemetry.Project{}
+		snapshot.Projects = nil
+	case "project-empty", "reports-empty", "settings-empty", "no-history":
+		snapshot = demoEmptySnapshot()
+	case "overloaded", "backoff-heavy":
+		snapshot = demoOverloadedSnapshot()
+	case "draining":
+		snapshot = demoDrainingSnapshot()
+	case "degraded":
+		snapshot = demoDegradedSnapshot()
+	case "budget-refusals":
+		snapshot = demoBudgetRefusalsSnapshot()
+	case "blocked-heavy":
+		snapshot = demoBlockedHeavySnapshot()
+	case "long-content":
+		snapshot = demoLongContentSnapshot()
+	case "dense", "dense-kanban":
+		snapshot = demoDenseSnapshot()
+	case "hot-path", "model-heavy", "filtered-project":
+		snapshot = demoHotPathSnapshot()
+	}
+	if scenario.ProjectID != "" && scenario.ProjectID != demoPrimaryProjectID && scenario.Variant == "project-empty" {
+		snapshot.Projects = demoProjectSnapshots(demoProjectsForVariant("project-empty"))
+	}
+	return snapshot
+}
+
+func demoHealthySnapshot() telemetry.Snapshot {
+	now := demoBaseTime
+	dayMax := 42.0
+	issueMax := 8.0
+	leaseRenewed := now.Add(-90 * time.Second)
+	leaseExpires := now.Add(9 * time.Minute)
+	nextRefresh := now.Add(45 * time.Second)
+	lastRefresh := now.Add(-15 * time.Second)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt:  now,
+		Project:      telemetry.Project{DisplayName: "multiple projects"},
+		Instance:     telemetry.Instance{Name: "detent-demo-screenshots", GitHubLogin: "detent-bot", AuthorizationScope: "repo, read:project", AuthorizationConfigured: true},
+		Projects:     demoProjectSnapshots(demoProjectsForVariant("healthy")),
+		DashboardURL: "http://localhost:0",
+		Shutdown:     telemetry.Shutdown{Status: "running"},
+		Refresh:      telemetry.Refresh{PollIntervalSeconds: 60, LastRefreshAt: &lastRefresh, NextRefreshAt: &nextRefresh},
+		Counts:       telemetry.Counts{Running: 3, Queue: 3, Blocked: 2, Completed: 4},
+		BoardIssues: []telemetry.Issue{
+			demoIssue(demoPrimaryProjectID, "demo-backlog", "digitaldrywood/detent-core#5250", "Backlog observability fixture intake", "Backlog", 72),
+			demoIssue(demoPrimaryProjectID, "demo-todo", "digitaldrywood/detent-core#5251", "Add screenshot manifest smoke test", "Todo", 9),
+			demoIssue(demoPrimaryProjectID, "demo-cancelled", "digitaldrywood/detent-core#5259", "Cancelled alternate dashboard theme", "Cancelled", 48),
+			demoIssue("agent-lab", "agent-lab-todo", "digitaldrywood/agent-lab#111", "Try secondary runner routing", "Todo", 11),
+		},
+		Pipeline: []telemetry.Issue{
+			demoPipelineIssue(demoPrimaryProjectID, "demo-review", "digitaldrywood/detent-core#5290", "Review deterministic chart colors", "Human Review", 5290, "success", "clean", 2),
+			demoPipelineIssue(demoPrimaryProjectID, "demo-rework", "digitaldrywood/detent-core#5291", "Address visual diff finding", "Rework", 5291, "failure", "dirty", 12),
+			demoPipelineIssue("release-train", "demo-merging", "digitaldrywood/release-train#5292", "Merge release readiness bundle", "Merging", 5292, "pending", "clean", 1),
+			demoPipelineIssue(demoPrimaryProjectID, "demo-done-pr", "digitaldrywood/detent-core#5293", "Ship completed PR lane fixture", "Done", 5293, "success", "clean", 24),
+		},
+		Running: []telemetry.Running{
+			{
+				Issue:           demoIssue(demoPrimaryProjectID, "demo-running-core", "digitaldrywood/detent-core#5260", "Implement page-addressable screenshot scenarios", "In Progress", 1),
+				WorkerHost:      "demo-worker-a",
+				ProcessIdentity: "pid-5260",
+				WorkspacePath:   "/tmp/detent-screenshots/workspaces/detent-core/5260",
+				SessionID:       "thread-demo-core-5260",
+				TurnCount:       7,
+				StartedAt:       now.Add(-34 * time.Minute),
+				LastEventAt:     demoTimePtr(now.Add(-2 * time.Minute)),
+				LastEvent:       "agent_message",
+				LastMessage:     "Rendered manifest and route smoke checks.",
+				RecentEvents: []telemetry.ActivityEvent{
+					{At: now.Add(-4 * time.Minute), Event: "tool_call", Message: "go test ./internal/web"},
+					{At: now.Add(-2 * time.Minute), Event: "agent_message", Message: "Rendered manifest and route smoke checks."},
+				},
+				RuntimeSeconds: 2040,
+				DiffAdded:      812,
+				DiffRemoved:    96,
+				DiffFiles:      9,
+				DiffStatus:     "ok",
+				Tokens:         telemetry.Tokens{Input: 38240, Output: 12840, Total: 51080, RuntimeSeconds: 2040},
+			},
+			{
+				Issue:           demoIssue("docs-site", "demo-running-docs", "digitaldrywood/docs-site#5261", "Write direct loading documentation examples", "In Progress", 2),
+				WorkerHost:      "demo-worker-b",
+				ProcessIdentity: "pid-5261",
+				WorkspacePath:   "/tmp/detent-screenshots/workspaces/docs-site/5261",
+				SessionID:       "thread-demo-docs-5261",
+				TurnCount:       4,
+				StartedAt:       now.Add(-18 * time.Minute),
+				LastEventAt:     demoTimePtr(now.Add(-90 * time.Second)),
+				LastEvent:       "token_usage",
+				LastMessage:     "21,450 total tokens (15,200 in, 6,250 out)",
+				RuntimeSeconds:  1080,
+				DiffAdded:       210,
+				DiffRemoved:     18,
+				DiffFiles:       3,
+				DiffStatus:      "ok",
+				Tokens:          telemetry.Tokens{Input: 15200, Output: 6250, Total: 21450, RuntimeSeconds: 1080},
+			},
+			{
+				Issue:           demoIssue("infra-platform", "demo-running-infra", "digitaldrywood/infra-platform#5262", "Verify isolated runtime paths on ephemeral ports", "In Progress", 3),
+				WorkerHost:      "demo-worker-c",
+				ProcessIdentity: "pid-5262",
+				WorkspacePath:   "/tmp/detent-screenshots/workspaces/infra-platform/5262",
+				SessionID:       "thread-demo-infra-5262",
+				TurnCount:       5,
+				StartedAt:       now.Add(-21 * time.Minute),
+				LastEventAt:     demoTimePtr(now.Add(-3 * time.Minute)),
+				LastEvent:       "diff_stats",
+				LastMessage:     "5 files changed, +164 -22",
+				RuntimeSeconds:  1260,
+				DiffAdded:       164,
+				DiffRemoved:     22,
+				DiffFiles:       5,
+				DiffStatus:      "ok",
+				Tokens:          telemetry.Tokens{Input: 21100, Output: 8100, Total: 29200, RuntimeSeconds: 1260},
+			},
+		},
+		Queue: []telemetry.Queued{
+			demoQueued("docs-site", "demo-queued-docs", "digitaldrywood/docs-site#5270", "Capture reports screenshots", 1, now.Add(6*time.Minute), "waiting for weighted fair share slot"),
+			demoQueued("billing-api", "demo-queued-billing", "digitaldrywood/billing-api#5271", "Add budget refusal screenshot fixture", 2, now.Add(14*time.Minute), "previous attempt exceeded budget cap"),
+			demoQueued("mobile-client", "demo-queued-mobile", "digitaldrywood/mobile-client#5272", "Exercise compact lane overflow on mobile", 3, now.Add(28*time.Minute), "project paused until release train clears"),
+		},
+		Blocked: []telemetry.Blocked{
+			demoBlocked("billing-api", "demo-blocked-billing", "digitaldrywood/billing-api#5280", "Dependency issue waiting on ledger migration", "Depends on digitaldrywood/billing-api#5200", "Todo", 10),
+			demoBlocked(demoPrimaryProjectID, "demo-blocked-hook", "digitaldrywood/detent-core#5281", "Workspace hook error needs operator input", "after_create hook exited 2", "operator", 5),
+		},
+		Completed: []telemetry.Completed{
+			demoCompleted(demoPrimaryProjectID, "demo-complete-core", "digitaldrywood/detent-core#5240", "Complete dashboard density pass", "Done", 91, "gpt-5-codex", 64000),
+			demoCompleted("docs-site", "demo-complete-docs", "digitaldrywood/docs-site#5241", "Publish screenshot capture guide", "Human Review", 57, "gpt-5-codex", 38000),
+			demoCompleted("release-train", "demo-complete-release", "digitaldrywood/release-train#5242", "Prepare release note bundle", "Merging", 73, "gpt-5", 52000),
+			demoCompleted("mobile-client", "demo-complete-mobile", "digitaldrywood/mobile-client#5243", "Cancel stale mobile board experiment", "Cancelled", 11, "gpt-5-mini", 9000),
+		},
+		Budget: telemetry.Budget{
+			Enabled:           true,
+			PerDayMaxUSD:      &dayMax,
+			PerIssueMaxUSD:    &issueMax,
+			CurrentSpendUSD:   18.72,
+			ProjectedCostUSD:  5.44,
+			ProjectedSpendUSD: 24.16,
+			PeriodStart:       now.Truncate(24 * time.Hour),
+			PeriodEnd:         now.Truncate(24 * time.Hour).Add(24 * time.Hour),
+			SpendPoints:       demoBudgetSpendPoints(now, 18.72),
+			Days:              demoBudgetDays(),
+		},
+		RateLimits: &telemetry.RateLimits{
+			LimitID:       "codex-demo",
+			LimitName:     "Codex demo pool",
+			Primary:       &telemetry.RateLimitBucket{Remaining: 8200, Used: 1800, Limit: 10000, ResetAt: demoTimePtr(now.Add(48 * time.Minute)), ResetInSeconds: 2880},
+			Secondary:     &telemetry.RateLimitBucket{Remaining: 460, Used: 40, Limit: 500, ResetAt: demoTimePtr(now.Add(8 * time.Minute)), ResetInSeconds: 480},
+			Credits:       &telemetry.RateLimitBucket{HasCredits: true, Balance: "healthy"},
+			GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 4320, Used: 680, Limit: 5000, ResetAt: demoTimePtr(now.Add(42 * time.Minute)), ResetInSeconds: 2520},
+			GraphQLCost:   &telemetry.GraphQLCost{TotalQueries: 88, TotalCost: 680, Contributors: []telemetry.GraphQLCostContributor{{QueryType: "project_items", Count: 30, Cost: 300}, {QueryType: "pull_requests", Count: 18, Cost: 180}}},
+		},
+		Tokens:         telemetry.Tokens{Input: 74540, Output: 27190, Total: 101730, RuntimeSeconds: 4380},
+		Throughput:     telemetry.TokenThroughput{TokensPerSecond: 23.5, WindowSeconds: 600, Tokens: 14100},
+		LifetimeTotals: telemetry.LifetimeTotals{Available: true, InputTokens: 4410000, OutputTokens: 1390000, TotalTokens: 5800000, RuntimeSeconds: 242000, Sessions: 182, Runs: 37},
+		CycleTime:      demoCycleTime(now),
+		TokenTrend:     demoTokenTrend(now),
+	}
+	for i := range snapshot.Running {
+		snapshot.Running[i].LeaseRenewedAt = &leaseRenewed
+		snapshot.Running[i].LeaseExpiresAt = &leaseExpires
+	}
+	return snapshot
+}
+
+func demoEmptySnapshot() telemetry.Snapshot {
+	now := demoBaseTime
+	nextRefresh := now.Add(time.Minute)
+	return telemetry.Snapshot{
+		GeneratedAt:    now,
+		Project:        telemetry.Project{DisplayName: "multiple projects"},
+		Instance:       telemetry.Instance{Name: "detent-demo-screenshots", GitHubLogin: "detent-bot", AuthorizationScope: "repo, read:project", AuthorizationConfigured: true},
+		Projects:       demoProjectSnapshots(demoProjectsForVariant("project-empty")),
+		DashboardURL:   "http://localhost:0",
+		Shutdown:       telemetry.Shutdown{Status: "running"},
+		Refresh:        telemetry.Refresh{PollIntervalSeconds: 60, NextRefreshAt: &nextRefresh},
+		LifetimeTotals: telemetry.LifetimeTotals{Available: true},
+		CycleTime:      telemetry.CycleTimeReport{Available: false, DegradedReason: "no completed sessions in the selected window"},
+	}
+}
+
+func demoOverloadedSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	now := snapshot.GeneratedAt
+	dayMax := 42.0
+	snapshot.Queue = append(snapshot.Queue,
+		demoQueued(demoPrimaryProjectID, "demo-queued-overload-1", "digitaldrywood/detent-core#5273", "Retry overloaded visual comparison job", 4, now.Add(38*time.Minute), "secondary rate limit in effect"),
+		demoQueued("infra-platform", "demo-queued-overload-2", "digitaldrywood/infra-platform#5274", "Re-run isolated port smoke test", 5, now.Add(50*time.Minute), "rate-limit retry budget is low"),
+	)
+	snapshot.Counts.Queue = len(snapshot.Queue)
+	snapshot.Budget.CurrentSpendUSD = 39.85
+	snapshot.Budget.ProjectedCostUSD = 4.9
+	snapshot.Budget.ProjectedSpendUSD = 44.75
+	snapshot.Budget.PerDayMaxUSD = &dayMax
+	snapshot.RateLimits = &telemetry.RateLimits{
+		LimitID:       "codex-demo-pressure",
+		LimitName:     "Codex demo pool",
+		Primary:       &telemetry.RateLimitBucket{Remaining: 260, Used: 9740, Limit: 10000, ResetAt: demoTimePtr(now.Add(21 * time.Minute)), ResetInSeconds: 1260},
+		Secondary:     &telemetry.RateLimitBucket{Remaining: 4, Used: 496, Limit: 500, ResetAt: demoTimePtr(now.Add(9 * time.Minute)), ResetInSeconds: 540},
+		Credits:       &telemetry.RateLimitBucket{HasCredits: true, Balance: "low"},
+		GitHubGraphQL: &telemetry.RateLimitBucket{Remaining: 95, Used: 4905, Limit: 5000, ResetAt: demoTimePtr(now.Add(34 * time.Minute)), ResetInSeconds: 2040},
+		GraphQLCost:   &telemetry.GraphQLCost{TotalQueries: 410, TotalCost: 4905, Contributors: []telemetry.GraphQLCostContributor{{QueryType: "project_items", Count: 180, Cost: 2700}, {QueryType: "review_threads", Count: 90, Cost: 1260}, {QueryType: "rate_limit_probe", Count: 40, Cost: 480}}},
+	}
+	return snapshot
+}
+
+func demoDrainingSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	now := snapshot.GeneratedAt
+	snapshot.Shutdown = telemetry.Shutdown{Status: "draining", Draining: true, SessionsRemaining: 3, RequestedAt: demoTimePtr(now.Add(-7 * time.Minute))}
+	return snapshot
+}
+
+func demoDegradedSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	snapshot.LifetimeTotals = telemetry.LifetimeTotals{Available: false, DegradedReason: "usage ledger unavailable in this scenario"}
+	snapshot.CycleTime = telemetry.CycleTimeReport{Available: false, DegradedReason: "cycle-time query timed out"}
+	snapshot.Budget.DegradedReason = "budget history is partially unavailable"
+	return snapshot
+}
+
+func demoBudgetRefusalsSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	now := snapshot.GeneratedAt
+	capValue := 42.0
+	snapshot.Budget.CurrentSpendUSD = 41.15
+	snapshot.Budget.ProjectedCostUSD = 6.2
+	snapshot.Budget.ProjectedSpendUSD = 47.35
+	snapshot.Budget.PerDayMaxUSD = &capValue
+	snapshot.Budget.Refusals = []telemetry.BudgetRefusal{
+		{IssueID: "demo-refusal-1", Identifier: "digitaldrywood/billing-api#5310", Code: "daily_cap_exceeded", Message: "Projected spend would exceed the daily cap.", CurrentSpendUSD: 41.15, ProjectedCostUSD: 6.2, MaxUSD: &capValue, RefusedAt: now.Add(-18 * time.Minute), ResetAt: demoTimePtr(now.Truncate(24 * time.Hour).Add(24 * time.Hour))},
+	}
+	return snapshot
+}
+
+func demoBlockedHeavySnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	snapshot.Blocked = append(snapshot.Blocked,
+		demoBlocked("billing-api", "demo-blocked-human", "digitaldrywood/billing-api#5282", "Human approval required for billing migration", "waiting for operator approval", "human-review", 18),
+		demoBlocked("infra-platform", "demo-blocked-stale", "digitaldrywood/infra-platform#5283", "Stale lease after workspace hook timeout", "lease expired before worker heartbeat", "reclaim", 20),
+	)
+	snapshot.Counts.Blocked = len(snapshot.Blocked)
+	return snapshot
+}
+
+func demoLongContentSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	if len(snapshot.Running) > 0 {
+		snapshot.Running[0].Title = "Implement page-addressable screenshot scenarios with very long deterministic fixture names, wide workspace paths, detailed token accounting, and browser-friendly waiting selectors"
+		snapshot.Running[0].SessionID = "thread-demo-core-5260-very-long-session-id-for-wide-table-verification-0000000001"
+		snapshot.Running[0].WorkspacePath = "/tmp/detent-screenshots/workspaces/detent-core/5260/very/deep/generated/worktree/path/that/exercises/wrapping"
+		snapshot.Running[0].LastMessage = "Long message: scenario route loaded, manifest matched, Chart.js endpoint agreed with seeded ledger, and visual baseline is ready for capture."
+		snapshot.Running[0].Tokens = telemetry.Tokens{Input: 980000, Output: 214000, Total: 1194000, RuntimeSeconds: 9180}
+	}
+	return snapshot
+}
+
+func demoDenseSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	for i := 0; i < 12; i++ {
+		state := []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework"}[i%6]
+		snapshot.BoardIssues = append(snapshot.BoardIssues, demoIssue(demoPrimaryProjectID, fmt.Sprintf("demo-dense-%02d", i), fmt.Sprintf("digitaldrywood/detent-core#54%02d", i), fmt.Sprintf("Dense lane card %02d exercises compact chips and overflow", i+1), state, i+1))
+	}
+	return snapshot
+}
+
+func demoHotPathSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	snapshot.Projects = demoProjectSnapshots(demoProjectsForVariant("hot-path"))
+	snapshot.Tokens = telemetry.Tokens{Input: 180000, Output: 52000, Total: 232000, RuntimeSeconds: 6400}
+	snapshot.Budget.CurrentSpendUSD = 36.8
+	return snapshot
+}
+
+func demoIssue(projectID string, id string, identifier string, title string, state string, hoursAgo int) telemetry.Issue {
+	at := demoBaseTime.Add(-time.Duration(hoursAgo) * time.Hour)
+	return telemetry.Issue{
+		ID:             id,
+		Identifier:     identifier,
+		ProjectID:      projectID,
+		URL:            demoIssueURL(identifier),
+		Title:          title,
+		Description:    title + " for deterministic Detent screenshot scenarios.",
+		State:          state,
+		Labels:         []string{"enhancement", "demo"},
+		Assignees:      []string{"detent-bot"},
+		Owner:          "detent-bot",
+		UpdatedAt:      &at,
+		StageUpdatedAt: &at,
+	}
+}
+
+func demoPipelineIssue(projectID string, id string, identifier string, title string, state string, pr int, ci string, mergeable string, hoursAgo int) telemetry.Issue {
+	issue := demoIssue(projectID, id, identifier, title, state, hoursAgo)
+	issue.PullRequest = &telemetry.PullRequest{
+		Number:             pr,
+		URL:                demoPRURL(identifier, pr),
+		BranchName:         "detent/demo-" + id,
+		State:              "OPEN",
+		MergeableState:     mergeable,
+		CIStatus:           ci,
+		CheckRunCount:      5,
+		StatusContextCount: 1,
+		CIDurationSeconds:  int64(240 + hoursAgo*20),
+		QuietWaitSeconds:   int64(hoursAgo * 60),
+		RunningChecks:      []string{"make check"},
+		CodexReviewState:   "CLEAN",
+	}
+	if ci == "failure" {
+		issue.PullRequest.CodexReviewState = "P1"
+		issue.PullRequest.SlowChecks = []telemetry.PullRequestCheck{{Name: "go test -race", Status: "completed", Conclusion: "failure", DurationSeconds: 620}}
+	}
+	if state == "Done" {
+		issue.PullRequest.State = "MERGED"
+	}
+	return issue
+}
+
+func demoQueued(projectID string, id string, identifier string, title string, attempt int, dueAt time.Time, err string) telemetry.Queued {
+	dueIn := dueAt.Sub(demoBaseTime).Milliseconds()
+	return telemetry.Queued{
+		Issue:          demoIssue(projectID, id, identifier, title, "Todo", attempt+2),
+		Attempt:        attempt,
+		DueAt:          &dueAt,
+		DueInMillis:    dueIn,
+		Error:          err,
+		WorkerHost:     "demo-worker-queue",
+		WorkspacePath:  "/tmp/detent-screenshots/workspaces/" + projectID + "/" + id,
+		ProjectedSpend: float64(attempt) * 1.35,
+	}
+}
+
+func demoBlocked(projectID string, id string, identifier string, title string, err string, target string, hoursAgo int) telemetry.Blocked {
+	blockedAt := demoBaseTime.Add(-time.Duration(hoursAgo) * time.Hour)
+	lastAt := blockedAt.Add(20 * time.Minute)
+	return telemetry.Blocked{
+		Issue:          demoIssue(projectID, id, identifier, title, "Blocked", hoursAgo),
+		WorkerHost:     "demo-worker-blocked",
+		WorkspacePath:  "/tmp/detent-screenshots/workspaces/" + projectID + "/" + id,
+		SessionID:      "thread-" + id,
+		Error:          err,
+		RecoveryReason: err,
+		RecoveryTarget: target,
+		BlockedAt:      &blockedAt,
+		LastEventAt:    &lastAt,
+		LastEvent:      "blocked",
+		LastMessage:    err,
+	}
+}
+
+func demoCompleted(projectID string, id string, identifier string, title string, state string, minutesAgo int, model string, totalTokens int64) telemetry.Completed {
+	completedAt := demoBaseTime.Add(-time.Duration(minutesAgo) * time.Minute)
+	startedAt := completedAt.Add(-42 * time.Minute)
+	input := totalTokens * 72 / 100
+	output := totalTokens - input
+	return telemetry.Completed{
+		Issue:          demoIssue(projectID, id, identifier, title, state, minutesAgo/60+1),
+		SessionID:      "thread-" + id,
+		StartedAt:      startedAt,
+		CompletedAt:    completedAt,
+		Turns:          6,
+		RuntimeSeconds: completedAt.Sub(startedAt).Seconds(),
+		FinalState:     state,
+		Model:          model,
+		Tokens:         telemetry.Tokens{Input: input, Output: output, Total: totalTokens, RuntimeSeconds: completedAt.Sub(startedAt).Seconds()},
+	}
+}
+
+func demoIssueURL(identifier string) string {
+	repo, number, ok := strings.Cut(identifier, "#")
+	if !ok {
+		return "https://github.test/digitaldrywood/detent/issues/0"
+	}
+	return "https://github.test/" + repo + "/issues/" + number
+}
+
+func demoPRURL(identifier string, number int) string {
+	repo, _, ok := strings.Cut(identifier, "#")
+	if !ok {
+		repo = "digitaldrywood/detent"
+	}
+	return fmt.Sprintf("https://github.test/%s/pull/%d", repo, number)
+}
+
+func demoTimePtr(value time.Time) *time.Time {
+	return &value
+}
+
+func demoProjectsForVariant(variant string) []templates.ProjectSmallMultiple {
+	now := demoBaseTime
+	if variant == "empty" || variant == "settings-empty" {
+		return nil
+	}
+	projects := []templates.ProjectSmallMultiple{
+		demoProject(demoPrimaryProjectID, demoPrimaryProjectName, "https://github.test/digitaldrywood/detent-core", false, 1, 1, 1, 2, 101730, 18.72, now),
+		demoProject("docs-site", "docs-site", "https://github.test/digitaldrywood/docs-site", false, 1, 1, 0, 1, 59450, 6.1, now),
+		demoProject("billing-api", "billing-api", "https://github.test/digitaldrywood/billing-api", false, 0, 1, 1, 0, 48600, 9.4, now),
+		demoProject("mobile-client", "mobile-client", "https://github.test/digitaldrywood/mobile-client", true, 0, 1, 0, 1, 22000, 2.2, now),
+		demoProject("infra-platform", "infra-platform", "https://github.test/digitaldrywood/infra-platform", false, 1, 0, 0, 0, 29200, 4.7, now),
+		demoProject("release-train", "release-train", "https://github.test/digitaldrywood/release-train", false, 0, 0, 0, 1, 52000, 5.8, now),
+		demoProject("observability-console", "observability-console-with-long-name", "https://github.test/digitaldrywood/observability-console", false, 0, 0, 0, 0, 17000, 1.8, now),
+		demoProject("agent-lab", "agent-lab", "https://github.test/digitaldrywood/agent-lab", false, 0, 0, 0, 0, 0, 0, now),
+	}
+	switch variant {
+	case "project-empty", "reports-empty", "settings-empty", "no-history":
+		for i := range projects {
+			projects[i].Running = 0
+			projects[i].QueueCount = 0
+			projects[i].Blocked = 0
+			projects[i].Completed = 0
+			projects[i].TotalTokens = 0
+			projects[i].ThroughputTokensPerSecond = 0
+			projects[i].CurrentSpendUSD = 0
+			projects[i].Samples = nil
+		}
+	case "hot-path", "model-heavy", "filtered-project":
+		for i := range projects {
+			if projects[i].ID == "billing-api" {
+				projects[i].Running = 2
+				projects[i].QueueCount = 4
+				projects[i].Blocked = 2
+				projects[i].Completed = 8
+				projects[i].TotalTokens = 310000
+				projects[i].CurrentSpendUSD = 31.4
+				projects[i].Samples = demoSamples(now, 2, 4, 2, 8, 310000, 31.4)
+			}
+		}
+	}
+	return projects
+}
+
+func demoProject(id string, name string, url string, paused bool, running int, queue int, blocked int, completed int, tokens int64, spend float64, now time.Time) templates.ProjectSmallMultiple {
+	return templates.ProjectSmallMultiple{
+		ID:                        id,
+		Name:                      name,
+		URL:                       url,
+		Paused:                    paused,
+		Running:                   running,
+		QueueCount:                queue,
+		Blocked:                   blocked,
+		Completed:                 completed,
+		TotalTokens:               tokens,
+		ThroughputTokensPerSecond: float64(tokens%50000) / 600,
+		CurrentSpendUSD:           spend,
+		Samples:                   demoSamples(now, running, queue, blocked, completed, tokens, spend),
+	}
+}
+
+func demoSamples(now time.Time, running int, queue int, blocked int, completed int, tokens int64, spend float64) []templates.ProjectSmallMultipleSample {
+	samples := make([]templates.ProjectSmallMultipleSample, 0, 12)
+	for i := 11; i >= 0; i-- {
+		scale := int64(12 - i)
+		samples = append(samples, templates.ProjectSmallMultipleSample{
+			At:                        now.Add(-time.Duration(i) * time.Minute),
+			Running:                   max(0, running-(i%2)),
+			TotalTokens:               tokens - int64(i)*max(100, tokens/30),
+			ThroughputTokensPerSecond: float64(scale) * 1.8,
+			SpendUSD:                  spend * float64(scale) / 12,
+			QueueDepth:                max(0, queue-(i%3)),
+			Blocked:                   blocked,
+			Completed:                 max(0, completed-(i/4)),
+		})
+	}
+	return samples
+}
+
+func demoProjectSnapshots(projects []templates.ProjectSmallMultiple) []telemetry.ProjectSnapshot {
+	out := make([]telemetry.ProjectSnapshot, 0, len(projects))
+	for _, project := range projects {
+		out = append(out, telemetry.ProjectSnapshot{
+			Project: telemetry.Project{ID: project.ID, DisplayName: project.Name, URL: project.URL},
+			Counts:  telemetry.Counts{Running: project.Running, Queue: project.QueueCount, Blocked: project.Blocked, Completed: project.Completed},
+			Tokens:  telemetry.Tokens{Total: project.TotalTokens},
+			Throughput: telemetry.TokenThroughput{
+				TokensPerSecond: project.ThroughputTokensPerSecond,
+				WindowSeconds:   600,
+				Tokens:          int64(project.ThroughputTokensPerSecond * 600),
+			},
+		})
+	}
+	return out
+}
+
+func demoBudgetSpendPoints(now time.Time, total float64) []telemetry.BudgetSpendPoint {
+	points := make([]telemetry.BudgetSpendPoint, 0, 8)
+	for i := 7; i >= 0; i-- {
+		scale := float64(8 - i)
+		points = append(points, telemetry.BudgetSpendPoint{At: now.Add(-time.Duration(i) * time.Hour), SpendUSD: total * scale / 8})
+	}
+	return points
+}
+
+func demoBudgetDays() []telemetry.BudgetDay {
+	return []telemetry.BudgetDay{
+		{Date: "2026-06-09", SpendUSD: 8.4},
+		{Date: "2026-06-10", SpendUSD: 12.8},
+		{Date: "2026-06-11", SpendUSD: 15.2},
+		{Date: "2026-06-12", SpendUSD: 10.9},
+		{Date: "2026-06-13", SpendUSD: 22.4},
+		{Date: "2026-06-14", SpendUSD: 18.1},
+		{Date: "2026-06-15", SpendUSD: 18.72},
+	}
+}
+
+func demoCycleTime(now time.Time) telemetry.CycleTimeReport {
+	return telemetry.CycleTimeReport{
+		Available:      true,
+		AverageSeconds: int64(7 * time.Hour / time.Second),
+		Buckets: []telemetry.CycleTimeBucket{
+			{Label: "< 2h", MinSeconds: 0, MaxSeconds: int64(2 * time.Hour / time.Second), Count: 3},
+			{Label: "2h-8h", MinSeconds: int64(2 * time.Hour / time.Second), MaxSeconds: int64(8 * time.Hour / time.Second), Count: 7},
+			{Label: "8h-1d", MinSeconds: int64(8 * time.Hour / time.Second), MaxSeconds: int64(24 * time.Hour / time.Second), Count: 4},
+		},
+		Issues: []telemetry.CycleTimeIssue{
+			{Key: "digitaldrywood/detent-core#5240", StartedAt: now.Add(-9 * time.Hour), CompletedAt: now.Add(-2 * time.Hour), DurationSeconds: int64(7 * time.Hour / time.Second), Sessions: 1},
+			{Key: "digitaldrywood/docs-site#5241", StartedAt: now.Add(-13 * time.Hour), CompletedAt: now.Add(-5 * time.Hour), DurationSeconds: int64(8 * time.Hour / time.Second), Sessions: 2},
+		},
+	}
+}
+
+func demoTokenTrend(now time.Time) []telemetry.TokenTrendPoint {
+	points := make([]telemetry.TokenTrendPoint, 0, 10)
+	for i := 9; i >= 0; i-- {
+		input := int64(8000 + (9-i)*1400)
+		output := int64(2500 + (9-i)*550)
+		points = append(points, telemetry.TokenTrendPoint{At: now.Add(-time.Duration(i) * time.Minute), Input: input, Output: output, Total: input + output})
+	}
+	return points
+}
+
+func SeedDemoUsageEvents(ctx context.Context, backend store.Store) error {
+	if backend == nil {
+		return nil
+	}
+	for _, event := range DemoUsageEvents() {
+		if _, err := backend.RecordUsageEvent(ctx, event); err != nil {
+			return fmt.Errorf("seed demo usage event: %w", err)
+		}
+	}
+	return nil
+}
+
+func DemoUsageEvents() []store.UsageEvent {
+	events := make([]store.UsageEvent, 0, 24)
+	projects := []string{demoPrimaryProjectID, "docs-site", "billing-api", "mobile-client", "infra-platform", "release-train"}
+	models := []string{"gpt-5-codex", "gpt-5", "gpt-5-mini"}
+	for day := 13; day >= 0; day-- {
+		for i, projectID := range projects {
+			finished := demoBaseTime.AddDate(0, 0, -day).Add(time.Duration(i-6) * time.Hour)
+			tokens := int64(12000 + (14-day)*900 + i*1400)
+			if projectID == "billing-api" && day == 2 {
+				tokens *= 5
+			}
+			pr := int64(5200 + day*10 + i)
+			events = append(events, store.UsageEvent{
+				ProjectID:      projectID,
+				IssueID:        fmt.Sprintf("usage-%s-%02d", projectID, day),
+				Identifier:     fmt.Sprintf("digitaldrywood/%s#%d", demoUsageRepo(projectID), 5200+day*10+i),
+				PRNumber:       &pr,
+				Model:          models[(day+i)%len(models)],
+				InputTokens:    tokens * 7 / 10,
+				OutputTokens:   tokens * 3 / 10,
+				TotalTokens:    tokens,
+				CostUSD:        float64(tokens) / 100000,
+				RuntimeSeconds: int64(600 + i*90),
+				StartedAt:      finished.Add(-40 * time.Minute),
+				FinishedAt:     finished,
+				Outcome:        "completed",
+			})
+		}
+	}
+	return events
+}
+
+func demoUsageRepo(projectID string) string {
+	if projectID == demoPrimaryProjectID {
+		return demoPrimaryProjectName
+	}
+	return projectID
+}
+
+func (s *Server) demoRefresh(c echo.Context, scenario demoScenario) error {
+	if scenario.Variant == "refresh-unavailable" {
+		return c.JSON(http.StatusServiceUnavailable, errorResponse("orchestrator_unavailable", "Orchestrator is unavailable"))
+	}
+	return c.JSON(http.StatusAccepted, orchestrator.RefreshResponse{
+		Queued:      true,
+		RequestedAt: demoBaseTime,
+		Operations:  []string{"poll", "reconcile", "snapshot"},
+	})
+}
+
+func (s *Server) demoEvents(c echo.Context, scenario demoScenario) error {
+	flusher, ok := c.Response().Writer.(http.Flusher)
+	if !ok {
+		return echo.NewHTTPError(http.StatusInternalServerError, "streaming unsupported")
+	}
+	ctx := c.Request().Context()
+	selectedProjectID := strings.TrimSpace(c.QueryParam("project"))
+	selectedNav := staticSidebarNav(c.QueryParam("nav"))
+	selectedView := strings.ToLower(strings.TrimSpace(c.QueryParam("view")))
+	res := c.Response()
+	res.Header().Set(echo.HeaderContentType, "text/event-stream; charset=utf-8")
+	res.Header().Set(echo.HeaderCacheControl, "no-cache")
+	res.Header().Set("Connection", "keep-alive")
+	res.Header().Set("X-Accel-Buffering", "no")
+	res.WriteHeader(http.StatusOK)
+	if err := s.writeDemoSSE(ctx, res, scenario, demoBaseTime, selectedProjectID, selectedNav, selectedView); err != nil {
+		return err
+	}
+	flusher.Flush()
+	ticker := time.NewTicker(s.tickEvery)
+	defer ticker.Stop()
+	step := 1
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			now := demoBaseTime
+			if s.demo.clock == DemoClockPlay || scenario.Variant == "play" {
+				now = demoBaseTime.Add(time.Duration(step) * time.Minute)
+				step++
+			}
+			if err := writeSSEComponent(ctx, res.Writer, sseEventTick, templates.LiveTick(now)); err != nil {
+				return err
+			}
+			if s.demo.clock == DemoClockPlay || scenario.Variant == "play" {
+				if err := s.writeDemoSSE(ctx, res, scenario, now, selectedProjectID, selectedNav, selectedView); err != nil {
+					return err
+				}
+			}
+			flusher.Flush()
+		}
+	}
+}
+
+func (s *Server) writeDemoSSE(ctx context.Context, res *echo.Response, scenario demoScenario, now time.Time, selectedProjectID string, selectedNav string, selectedView string) error {
+	data := s.demoDashboardData(ctx, scenario)
+	if selectedProjectID == "" {
+		selectedProjectID = strings.TrimSpace(scenario.ProjectID)
+	}
+	if selectedProjectID != "" {
+		projectScenario := scenario
+		projectScenario.ProjectID = selectedProjectID
+		if projectData, ok := s.demoProjectDashboardData(ctx, projectScenario); ok {
+			data = projectData
+		}
+	}
+	if selectedNav != "" {
+		data.ActiveNav = selectedNav
+	}
+	if selectedView == "" {
+		selectedView = demoSSEViewForScenario(scenario)
+	}
+	data.Snapshot.GeneratedAt = now
+	if len(data.Snapshot.Running) > 0 && now.After(demoBaseTime) {
+		delta := int64(now.Sub(demoBaseTime).Minutes())
+		data.Snapshot.Running[0].TurnCount += int(delta)
+		data.Snapshot.Running[0].Tokens.Total += delta * 1200
+		data.Snapshot.Running[0].Tokens.Input += delta * 850
+		data.Snapshot.Running[0].Tokens.Output += delta * 350
+		data.Snapshot.Running[0].DiffAdded += int(delta * 8)
+		data.Snapshot.Running[0].DiffRemoved += int(delta)
+		data.Snapshot.Tokens.Total += delta * 1200
+	}
+	snapshotComponent := templates.SnapshotView(data)
+	switch selectedView {
+	case sseViewKanban:
+		data.ActiveNav = "kanban"
+		snapshotComponent = templates.ProjectKanbanSnapshot(data)
+	case sseViewRuns:
+		data.ActiveNav = "runs"
+		snapshotComponent = templates.ProjectRunsSnapshot(data)
+	case sseViewDiagnostics:
+		data.ActiveNav = "diagnostics"
+		snapshotComponent = templates.ProjectDiagnosticsSnapshot(data)
+	case sseViewConfiguration:
+		data.ActiveNav = "configuration"
+	}
+	if err := writeSSEComponent(ctx, res.Writer, sseEventSnapshot, snapshotComponent); err != nil {
+		return err
+	}
+	return writeSSEComponent(ctx, res.Writer, sseEventSidebar, templates.DashboardSidebarContent(templates.DashboardShellDataFromDashboard(data)))
+}
+
+func demoSSEViewForScenario(scenario demoScenario) string {
+	switch scenario.Page {
+	case "kanban":
+		return sseViewKanban
+	case "runs":
+		return sseViewRuns
+	case "diagnostics":
+		return sseViewDiagnostics
+	case "settings":
+		if scenario.ProjectID != "" {
+			return sseViewConfiguration
+		}
+	}
+	return ""
+}

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -143,6 +143,26 @@ func kanbanMutationStateKey(key string, issueID string) string {
 }
 
 func (s *Server) apiKanbanMoveDialog(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok && scenario.Page == "api" && strings.HasPrefix(scenario.ID, "api-kanban-move") {
+		switch scenario.Variant {
+		case "kanban-read-only":
+			return render(c, templates.KanbanDialogErrorContent("Kanban integration mode is not enabled."))
+		case "kanban-move-missing-target":
+			return render(c, templates.KanbanDialogErrorContent("Target state is required."))
+		default:
+			return render(c, templates.KanbanMoveDialogContent(templates.KanbanMoveDialogData{
+				ProjectID:    demoPrimaryProjectID,
+				IssueID:      "demo-todo",
+				Identifier:   "digitaldrywood/detent-core#5251",
+				Title:        "Add screenshot manifest smoke test",
+				CurrentState: "Todo",
+				TargetState:  "In Progress",
+				States:       []string{"In Progress", "Blocked", "Cancelled"},
+			}))
+		}
+	}
 	data, response := s.kanbanMoveDialogData(c, "")
 	if response != "" {
 		return render(c, templates.KanbanDialogErrorContent(response))
@@ -151,6 +171,20 @@ func (s *Server) apiKanbanMoveDialog(c echo.Context) error {
 }
 
 func (s *Server) apiKanbanMove(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok && scenario.Page == "api" && strings.HasPrefix(scenario.ID, "api-kanban-move") {
+		switch scenario.Variant {
+		case "kanban-transition-blocked":
+			return kanbanFeedback(c, http.StatusUnprocessableEntity, "Move from Done to Todo is not allowed by the Kanban transition policy.")
+		case "connector-failure":
+			return kanbanFeedback(c, http.StatusBadGateway, "Move failed: demo connector failure")
+		case "kanban-read-only":
+			return kanbanFeedback(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
+		default:
+			return kanbanFeedback(c, http.StatusOK, "Moved card to In Progress.")
+		}
+	}
 	req, response, status := parseKanbanMoveRequest(c)
 	if response != "" {
 		if kanbanDialogForm(c) {
@@ -244,6 +278,33 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 }
 
 func (s *Server) apiKanbanCommentDialog(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok && scenario.Page == "api" && strings.HasPrefix(scenario.ID, "api-kanban-comment") {
+		switch scenario.Variant {
+		case "kanban-comment-invalid-target":
+			return render(c, templates.KanbanDialogErrorContent("Comment target is not available on the current board."))
+		case "kanban-comment-pr":
+			return render(c, templates.KanbanCommentDialogContent(templates.KanbanCommentDialogData{
+				ProjectID:    demoPrimaryProjectID,
+				Target:       "pr",
+				PRRepository: "digitaldrywood/detent-core",
+				PRNumber:     5290,
+				Identifier:   "digitaldrywood/detent-core#5290",
+				Title:        "Review deterministic chart colors",
+				Body:         "Looks good for the screenshot demo.",
+			}))
+		default:
+			return render(c, templates.KanbanCommentDialogContent(templates.KanbanCommentDialogData{
+				ProjectID:  demoPrimaryProjectID,
+				Target:     "issue",
+				IssueID:    "demo-todo",
+				Identifier: "digitaldrywood/detent-core#5251",
+				Title:      "Add screenshot manifest smoke test",
+				Body:       "Please verify the screenshot manifest route.",
+			}))
+		}
+	}
 	data, response := s.kanbanCommentDialogData(c, "")
 	if response != "" {
 		return render(c, templates.KanbanDialogErrorContent(response))
@@ -252,6 +313,18 @@ func (s *Server) apiKanbanCommentDialog(c echo.Context) error {
 }
 
 func (s *Server) apiKanbanComment(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok && scenario.Page == "api" && strings.HasPrefix(scenario.ID, "api-kanban-comment") {
+		switch scenario.Variant {
+		case "kanban-comment-empty-body":
+			return kanbanFeedback(c, http.StatusBadRequest, "Comment body is required.")
+		case "connector-failure":
+			return kanbanFeedback(c, http.StatusBadGateway, "Comment failed: demo connector failure")
+		default:
+			return kanbanFeedback(c, http.StatusOK, "Comment submitted.")
+		}
+	}
 	req, response, status := parseKanbanCommentRequest(c)
 	if response != "" {
 		if kanbanDialogForm(c) {

--- a/internal/web/reports.go
+++ b/internal/web/reports.go
@@ -13,6 +13,11 @@ import (
 )
 
 func (s *Server) reports(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		return s.demoReports(c, scenario)
+	}
 	from, to, response, status := reportsDateRange(c)
 	if response != nil {
 		return c.JSON(status, response)

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -73,6 +73,7 @@ type Config struct {
 	RuntimeDBPath         string
 	RuntimeLogPath        string
 	ServerAddress         string
+	Demo                  DemoConfig
 }
 
 type Server struct {
@@ -102,6 +103,7 @@ type Server struct {
 	projects           *projectSmallMultipleRecorder
 	snapshots          *snapshotEnrichmentCache
 	kanbanMutations    *kanbanMutationLocks
+	demo               *demoScenarioSet
 }
 
 func NewServer(cfg Config, deps Dependencies) (*Server, error) {
@@ -154,6 +156,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		projects:           newProjectSmallMultipleRecorder(),
 		snapshots:          newSnapshotEnrichmentCache(),
 		kanbanMutations:    newKanbanMutationLocks(),
+		demo:               newDemoScenarioSet(cfg.Demo),
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
 	server.registerRoutes()
@@ -210,6 +213,7 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/onboarding/agent", s.onboardingAgent)
 	s.echo.POST("/onboarding/write", s.onboardingWrite)
 	s.echo.GET("/api/v1/state", s.apiState)
+	s.echo.GET("/api/v1/demo/scenarios", s.apiDemoScenarios)
 	s.echo.GET("/api/v1/timeseries", s.apiTimeSeries)
 	s.echo.GET("/api/v1/projects/*", s.apiProject)
 	s.echo.POST("/api/v1/refresh", s.apiRefresh)
@@ -223,6 +227,11 @@ func (s *Server) registerRoutes() {
 }
 
 func (s *Server) dashboard(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		return s.demoDashboard(c, scenario)
+	}
 	ctx := c.Request().Context()
 	data := s.dashboardData(ctx, s.latestSnapshot(ctx))
 	data.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
@@ -232,6 +241,14 @@ func (s *Server) dashboard(c echo.Context) error {
 func (s *Server) projectDashboard(c echo.Context) error {
 	ctx := c.Request().Context()
 	projectID, view := projectRouteViewParam(c)
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		if strings.TrimSpace(scenario.ProjectID) == "" {
+			scenario.ProjectID = projectID
+		}
+		return s.demoProjectDashboard(c, scenario, view)
+	}
 	data, ok := s.projectDashboardData(ctx, projectID, s.latestSnapshot(ctx))
 	if !ok {
 		return echo.NewHTTPError(http.StatusNotFound, "Project not found")
@@ -406,6 +423,9 @@ func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
 }
 
 func (s *Server) health(c echo.Context) error {
+	if _, _, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	}
 	status := "ok"
 	sessionsRemaining := 0
 	if s.hub != nil {
@@ -414,17 +434,22 @@ func (s *Server) health(c echo.Context) error {
 			sessionsRemaining = snapshot.Shutdown.SessionsRemaining
 		}
 	}
+	checks := map[string]string{
+		"hub":       configuredStatus(s.hub),
+		"store":     configuredStatus(s.store),
+		"registry":  configuredStatus(s.registry),
+		"connector": configuredStatus(s.connector),
+	}
+	if s.demo != nil {
+		checks["demo"] = DemoModeScreenshots
+		checks["demo_clock"] = s.demo.clock
+	}
 	return c.JSON(http.StatusOK, healthResponse{
 		Status:            status,
 		Mode:              string(s.mode),
 		Connector:         s.connectorName(),
 		SessionsRemaining: sessionsRemaining,
-		Checks: map[string]string{
-			"hub":       configuredStatus(s.hub),
-			"store":     configuredStatus(s.store),
-			"registry":  configuredStatus(s.registry),
-			"connector": configuredStatus(s.connector),
-		},
+		Checks:            checks,
 	})
 }
 
@@ -433,6 +458,11 @@ func (s *Server) redirectToOnboarding(c echo.Context) error {
 }
 
 func (s *Server) redirectToDashboard(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok && scenario.Page == "onboarding" {
+		return s.demoOnboarding(c, scenario)
+	}
 	return c.Redirect(http.StatusFound, "/")
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -187,6 +187,163 @@ func TestServerRoutes(t *testing.T) {
 	}
 }
 
+func TestDemoScenarioHeadersAreGatedToScreenshotsMode(t *testing.T) {
+	t.Parallel()
+
+	normal, err := web.NewServer(web.Config{}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	body := requestHTMLWithHeaders(t, normal.Handler(), http.MethodGet, "/", http.StatusOK, map[string]string{
+		web.DemoScenarioHeader: "fleet-healthy-parallel-work",
+	})
+	if !strings.Contains(body, "Detent") {
+		t.Fatalf("normal server did not ignore demo scenario header:\n%s", body)
+	}
+	requestJSONWithHeaders(t, normal, http.MethodGet, "/api/v1/demo/scenarios", http.StatusNotFound, nil)
+
+	demo, err := web.NewServer(web.Config{Demo: web.DemoConfig{Mode: "screenshots"}}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	payload := requestJSONWithHeaders(t, demo, http.MethodGet, "/", http.StatusNotFound, map[string]string{
+		web.DemoScenarioHeader: "missing-scenario",
+	})
+	if nestedString(t, payload, "error", "code") != "demo_scenario_not_found" {
+		t.Fatalf("unknown scenario payload = %#v", payload)
+	}
+}
+
+func TestDemoScenarioManifestPagesAndAPIs(t *testing.T) {
+	t.Parallel()
+
+	backend := openWebTestStore(t)
+	if err := web.SeedDemoUsageEvents(context.Background(), backend); err != nil {
+		t.Fatalf("SeedDemoUsageEvents() error = %v", err)
+	}
+	deps := testDeps(t)
+	deps.Store = backend
+	server, err := web.NewServer(web.Config{Demo: web.DemoConfig{Mode: "screenshots"}}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	manifest := requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/demo/scenarios", http.StatusOK, nil)
+	if manifest["header"] != web.DemoScenarioHeader || manifest["clock"] != "frozen" {
+		t.Fatalf("manifest metadata = %#v", manifest)
+	}
+	assertManifestContainsScenarios(t, manifest, []string{
+		"fleet-healthy-parallel-work",
+		"kanban-full-integration",
+		"reports-normal-window",
+		"onboarding-write-success",
+		"api-state-full-snapshot",
+	})
+	assertManifestOmitsScenarios(t, manifest, []string{"events-frozen", "events-play"})
+
+	page := requestHTMLWithHeaders(t, server.Handler(), http.MethodGet, "/", http.StatusOK, map[string]string{
+		web.DemoScenarioHeader: "fleet-healthy-parallel-work",
+	})
+	for _, want := range []string{"Implement page-addressable screenshot scenarios", "detent-core", "GraphQL"} {
+		if !strings.Contains(page, want) {
+			t.Fatalf("fleet scenario page missing %q:\n%s", want, page)
+		}
+	}
+
+	state := requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/state", http.StatusOK, map[string]string{
+		web.DemoScenarioHeader: "fleet-healthy-parallel-work",
+	})
+	if state["status"] != "running" {
+		t.Fatalf("state status = %#v, want running", state["status"])
+	}
+	counts := state["counts"].(map[string]any)
+	if counts["running"] != float64(3) || counts["retrying"] != float64(3) || counts["blocked"] != float64(2) {
+		t.Fatalf("state counts = %#v", counts)
+	}
+
+	usage := requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/usage?by=project", http.StatusOK, map[string]string{
+		web.DemoScenarioHeader: "api-usage-populated",
+	})
+	totals := usage["totals"].(map[string]any)
+	if totals["events"].(float64) == 0 {
+		t.Fatalf("usage totals = %#v, want seeded ledger events", totals)
+	}
+}
+
+func TestDemoScenarioEventsPreserveProjectSubview(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{Demo: web.DemoConfig{Mode: "screenshots"}}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	addr := startWebServer(t, server)
+	conn, body, reader := openRawEventStreamWithHeaders(t, addr, "/events?project=dogfood&view=kanban", map[string]string{
+		web.DemoScenarioHeader: "kanban-full-integration",
+	})
+	defer conn.Close()
+	defer body.Close()
+
+	event := readRawSSEEvent(t, conn, reader)
+	if event.name != "snapshot" {
+		t.Fatalf("event name = %q, want snapshot", event.name)
+	}
+	for _, want := range []string{`id="project-kanban"`, "Project Kanban", "Integration"} {
+		if !strings.Contains(event.data, want) {
+			t.Fatalf("demo Kanban SSE event missing %q:\n%s", want, event.data)
+		}
+	}
+	if strings.Contains(event.data, "Fleet grid") {
+		t.Fatalf("demo Kanban SSE event rendered fleet snapshot:\n%s", event.data)
+	}
+}
+
+func TestDemoScenarioKanbanFragments(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{Demo: web.DemoConfig{Mode: "screenshots"}}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := requestHTMLWithHeaders(t, server.Handler(), http.MethodGet, "/api/v1/kanban/move", http.StatusOK, map[string]string{
+		web.DemoScenarioHeader: "api-kanban-move-read-only",
+	})
+	if !strings.Contains(body, "Kanban integration mode is not enabled") {
+		t.Fatalf("read-only dialog body = %s", body)
+	}
+
+	rec := performDemoForm(t, server.Handler(), "/api/v1/kanban/move", "api-kanban-move-success", nil)
+	if rec.Code != http.StatusOK || !strings.Contains(rec.Body.String(), "Moved card to In Progress") {
+		t.Fatalf("move success status = %d body = %s", rec.Code, rec.Body.String())
+	}
+
+	rec = performDemoForm(t, server.Handler(), "/api/v1/kanban/comment", "api-kanban-comment-connector-failure", nil)
+	if rec.Code != http.StatusBadGateway || !strings.Contains(rec.Body.String(), "demo connector failure") {
+		t.Fatalf("comment failure status = %d body = %s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestSeedDemoUsageEventsPopulatesUsageReports(t *testing.T) {
+	t.Parallel()
+
+	backend := openWebTestStore(t)
+	ctx := context.Background()
+	if err := web.SeedDemoUsageEvents(ctx, backend); err != nil {
+		t.Fatalf("SeedDemoUsageEvents() error = %v", err)
+	}
+	report, err := backend.UsageReport(ctx, store.UsageReportQuery{By: store.UsageReportByProject})
+	if err != nil {
+		t.Fatalf("UsageReport() error = %v", err)
+	}
+	if report.Totals.Events == 0 || report.Totals.TotalTokens == 0 {
+		t.Fatalf("usage totals = %#v, want seeded usage", report.Totals)
+	}
+	if len(report.Rows) < 3 {
+		t.Fatalf("usage rows = %d, want multiple projects", len(report.Rows))
+	}
+}
+
 func TestKanbanActionsRejectReadOnlyMode(t *testing.T) {
 	t.Parallel()
 
@@ -4951,6 +5108,27 @@ func requestJSON(t *testing.T, server *web.Server, method string, path string, w
 	return payload
 }
 
+func requestJSONWithHeaders(t *testing.T, server *web.Server, method string, path string, wantStatus int, headers map[string]string) map[string]any {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != wantStatus {
+		t.Fatalf("%s %s status = %d, want %d; body = %s", method, path, rec.Code, wantStatus, rec.Body.String())
+	}
+
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal(%s %s) error = %v; body = %s", method, path, err, rec.Body.String())
+	}
+	return payload
+}
+
 func requestHTML(t *testing.T, handler http.Handler, method string, path string, wantStatus int) string {
 	t.Helper()
 
@@ -4962,6 +5140,81 @@ func requestHTML(t *testing.T, handler http.Handler, method string, path string,
 		t.Fatalf("%s %s status = %d, want %d; body = %s", method, path, rec.Code, wantStatus, rec.Body.String())
 	}
 	return rec.Body.String()
+}
+
+func requestHTMLWithHeaders(t *testing.T, handler http.Handler, method string, path string, wantStatus int, headers map[string]string) string {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, nil)
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != wantStatus {
+		t.Fatalf("%s %s status = %d, want %d; body = %s", method, path, rec.Code, wantStatus, rec.Body.String())
+	}
+	return rec.Body.String()
+}
+
+func assertManifestContainsScenarios(t *testing.T, manifest map[string]any, ids []string) {
+	t.Helper()
+
+	scenarios, ok := manifest["scenarios"].([]any)
+	if !ok {
+		t.Fatalf("manifest scenarios = %T, want list: %#v", manifest["scenarios"], manifest)
+	}
+	seen := map[string]struct{}{}
+	for _, raw := range scenarios {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("manifest scenario entry = %T, want object", raw)
+		}
+		id, ok := entry["id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("manifest scenario id = %#v", entry["id"])
+		}
+		seen[id] = struct{}{}
+		if entry["route"] == "" || entry["wait_selector"] == "" || entry["screenshot_name"] == "" {
+			t.Fatalf("manifest scenario missing route/wait/screenshot fields: %#v", entry)
+		}
+		headers, ok := entry["headers"].(map[string]any)
+		if !ok || headers[web.DemoScenarioHeader] != id {
+			t.Fatalf("manifest scenario headers = %#v, want %s=%s", entry["headers"], web.DemoScenarioHeader, id)
+		}
+	}
+	for _, id := range ids {
+		if _, ok := seen[id]; !ok {
+			t.Fatalf("manifest missing scenario %q", id)
+		}
+	}
+}
+
+func assertManifestOmitsScenarios(t *testing.T, manifest map[string]any, ids []string) {
+	t.Helper()
+
+	scenarios, ok := manifest["scenarios"].([]any)
+	if !ok {
+		t.Fatalf("manifest scenarios = %T, want list: %#v", manifest["scenarios"], manifest)
+	}
+	seen := map[string]struct{}{}
+	for _, raw := range scenarios {
+		entry, ok := raw.(map[string]any)
+		if !ok {
+			t.Fatalf("manifest scenario entry = %T, want object", raw)
+		}
+		id, ok := entry["id"].(string)
+		if !ok || id == "" {
+			t.Fatalf("manifest scenario id = %#v", entry["id"])
+		}
+		seen[id] = struct{}{}
+	}
+	for _, id := range ids {
+		if _, ok := seen[id]; ok {
+			t.Fatalf("manifest includes non-screenshot stream scenario %q", id)
+		}
+	}
 }
 
 func nestedString(t *testing.T, payload map[string]any, keys ...string) string {
@@ -5269,6 +5522,18 @@ func performForm(t *testing.T, handler http.Handler, method string, path string,
 	return rec
 }
 
+func performDemoForm(t *testing.T, handler http.Handler, path string, scenario string, form url.Values) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPost, path, strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	req.Header.Set(web.DemoScenarioHeader, scenario)
+	handler.ServeHTTP(rec, req)
+	return rec
+}
+
 func equalStateUpdates(left, right []kanbanStateUpdate) bool {
 	if len(left) != len(right) {
 		return false
@@ -5393,6 +5658,16 @@ func startWebServer(t *testing.T, server *web.Server) string {
 func openRawEventStream(t *testing.T, addr string, paths ...string) (net.Conn, io.ReadCloser, *bufio.Reader) {
 	t.Helper()
 
+	path := "/events"
+	if len(paths) > 0 {
+		path = paths[0]
+	}
+	return openRawEventStreamWithHeaders(t, addr, path, nil)
+}
+
+func openRawEventStreamWithHeaders(t *testing.T, addr string, path string, headers map[string]string) (net.Conn, io.ReadCloser, *bufio.Reader) {
+	t.Helper()
+
 	conn, err := net.Dial("tcp", addr)
 	if err != nil {
 		t.Fatalf("Dial() error = %v", err)
@@ -5404,11 +5679,15 @@ func openRawEventStream(t *testing.T, addr string, paths ...string) (net.Conn, i
 		}
 	})
 
-	path := "/events"
-	if len(paths) > 0 {
-		path = paths[0]
+	var request strings.Builder
+	request.WriteString("GET " + path + " HTTP/1.1\r\n")
+	request.WriteString("Host: " + addr + "\r\n")
+	request.WriteString("Accept: text/event-stream\r\n")
+	for key, value := range headers {
+		request.WriteString(key + ": " + value + "\r\n")
 	}
-	if _, err := io.WriteString(conn, "GET "+path+" HTTP/1.1\r\nHost: "+addr+"\r\nAccept: text/event-stream\r\n\r\n"); err != nil {
+	request.WriteString("\r\n")
+	if _, err := io.WriteString(conn, request.String()); err != nil {
 		t.Fatalf("WriteString() error = %v", err)
 	}
 	if err := conn.SetReadDeadline(time.Now().Add(time.Second)); err != nil {

--- a/internal/web/settings.go
+++ b/internal/web/settings.go
@@ -12,6 +12,11 @@ import (
 )
 
 func (s *Server) settings(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		return s.demoSettings(c, scenario, c.QueryParam("project"))
+	}
 	data := s.settingsData(c.Request().Context(), c.QueryParam("project"))
 	data.SidebarCollapsed = dashboardSidebarCollapsed(c.Request())
 	return render(c, templates.Settings(data))

--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -38,6 +38,11 @@ func staticSidebarNav(value string) string {
 }
 
 func (s *Server) events(c echo.Context) error {
+	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
+		return err
+	} else if ok {
+		return s.demoEvents(c, scenario)
+	}
 	flusher, ok := c.Response().Writer.(http.Flusher)
 	if !ok {
 		return echo.NewHTTPError(http.StatusInternalServerError, "streaming unsupported")


### PR DESCRIPTION
## Summary

- add `dev-runtime --demo screenshots` with frozen/play demo clocks, boot banner metadata, and manifest output
- add header-selected deterministic page/API/HTMX/SSE scenarios with seeded usage ledger data
- document direct Playwright/curl loading and add scenario/demo safety coverage

Fixes #526

## Test Plan

- [x] `make check`
- [x] `tmp/detent dev-runtime --demo screenshots --port 0`
- [x] Manifest/API smoke checks against isolated runtime
- [x] Captured viewport screenshots from manifest-selected page routes in `tmp/demo-screenshots`
