### PR TITLE
fix(cli): bind demo runtime to wildcard host

### DIFF
--- a/README.md
+++ b/README.md
@@ -772,6 +772,13 @@ database state:
 detent dev-runtime --demo kanban --port 0
 ```
 
+Demo runtimes bind to `0.0.0.0` when `--host` is omitted so the selected
+random port can be reached from trusted network interfaces. From another
+machine on Tailscale, replace the local banner host with the Tailscale
+hostname, for example
+`http://prometheus:<port>/projects/dogfood/kanban`. Pass
+`--host 127.0.0.1` for a local-only demo run.
+
 The Kanban demo keeps the runtime isolated on the memory tracker, enables
 Kanban integration mode for the generated demo workflow, and includes explicit
 `server.kanban.allowed_transitions` such as `Backlog -> Todo` so drag/drop
@@ -790,7 +797,8 @@ recording, or visual e2e baselines:
 detent dev-runtime --demo screenshots --port 0
 ```
 
-The screenshots demo uses the same isolation model as the Kanban demo: memory
+The screenshots demo uses the same isolation model and demo bind default as the
+Kanban demo: memory
 tracker, fake runner, isolated home, isolated database, isolated workspaces,
 fake `https://github.test/...` URLs, no GitHub calls, no real ProjectV2
 mutation, and no live dogfood port by default. It freezes demo time at

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -264,6 +264,9 @@ func TestDevRuntimeCommandBuildsKanbanDemoBootConfig(t *testing.T) {
 	if got.Isolated.Demo != "kanban" {
 		t.Fatalf("Isolated.Demo = %q, want kanban", got.Isolated.Demo)
 	}
+	if got.Host != "0.0.0.0" {
+		t.Fatalf("Host = %q, want demo wildcard host", got.Host)
+	}
 	if got.Isolated.FixturePath != "" {
 		t.Fatalf("FixturePath = %q, want no external fixture for built-in demo", got.Isolated.FixturePath)
 	}
@@ -276,6 +279,62 @@ func TestDevRuntimeCommandBuildsKanbanDemoBootConfig(t *testing.T) {
 	}
 	if !workflow.Config.KanbanTransitionAllowed("Backlog", "Todo") {
 		t.Fatal("KanbanTransitionAllowed(Backlog, Todo) = false, want demo override")
+	}
+}
+
+func TestDevRuntimeCommandKeepsExplicitHostForDemo(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--host", "127.0.0.1",
+		"--port", "0",
+		"dev-runtime",
+		"--home", home,
+		"--demo", "kanban",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if got.Host != "127.0.0.1" {
+		t.Fatalf("Host = %q, want explicit demo host", got.Host)
+	}
+}
+
+func TestDevRuntimeCommandDefaultsNonDemoHostToLoopback(t *testing.T) {
+	t.Parallel()
+
+	home := t.TempDir()
+	booted := make(chan cli.BootConfig, 1)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithBootFunc(func(_ context.Context, cfg cli.BootConfig) error {
+		booted <- cfg
+		return nil
+	}))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--port", "0",
+		"dev-runtime",
+		"--home", home,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	got := <-booted
+	if got.Host != "127.0.0.1" {
+		t.Fatalf("Host = %q, want non-demo loopback host", got.Host)
 	}
 }
 
@@ -308,6 +367,9 @@ func TestDevRuntimeCommandBuildsScreenshotsDemoBootConfig(t *testing.T) {
 	}
 	if got.Isolated.Demo != "screenshots" || got.Isolated.DemoClock != "play" {
 		t.Fatalf("isolated demo metadata = %#v, want screenshots play", got.Isolated)
+	}
+	if got.Host != "0.0.0.0" {
+		t.Fatalf("Host = %q, want demo wildcard host", got.Host)
 	}
 	if got.Isolated.ManifestPath != "/api/v1/demo/scenarios" {
 		t.Fatalf("ManifestPath = %q, want demo scenario endpoint", got.Isolated.ManifestPath)

--- a/internal/cli/dev_runtime.go
+++ b/internal/cli/dev_runtime.go
@@ -17,7 +17,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 )
 
-const devRuntimeExampleCommand = "detent dev-runtime --port 0"
+const (
+	devRuntimeDemoHost       = "0.0.0.0"
+	devRuntimeExampleCommand = "detent dev-runtime --port 0"
+)
 
 func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command {
 	var home string
@@ -82,6 +85,9 @@ func devRuntimeBootConfig(runtime devruntime.Runtime, host string, opts options,
 	runtimeHost := strings.TrimSpace(host)
 	if runtimeHost == "" {
 		runtimeHost = defaultWebHost
+		if runtime.Demo != "" {
+			runtimeHost = devRuntimeDemoHost
+		}
 	}
 	return BootConfig{
 		Mode:           BootModeRunning,


### PR DESCRIPTION
## Summary

- Default built-in demo dev-runtime runs to `0.0.0.0` when `--host` is omitted.
- Preserve explicit host overrides and non-demo loopback defaults.
- Document Tailscale hostname access for demo dashboards.

Fixes #532

## Test Plan

- [x] `go test ./internal/cli -run 'TestDevRuntimeCommand(BuildsKanbanDemoBootConfig|KeepsExplicitHostForDemo|DefaultsNonDemoHostToLoopback|BuildsScreenshotsDemoBootConfig)'`
- [x] `go test ./internal/cli`
- [x] `make check`