### PR TITLE
feat(devruntime): add demo project override

### DIFF
--- a/README.md
+++ b/README.md
@@ -843,11 +843,18 @@ database state:
 detent dev-runtime --demo kanban --port 0
 ```
 
+Pass `--demo-project` to choose the generated project ID when you want generic
+demo URLs and labels instead of the default dogfood-safe ID:
+
+```sh
+detent dev-runtime --demo kanban --demo-project demo-project --port 0
+```
+
 Demo runtimes bind to `0.0.0.0` when `--host` is omitted so the selected
 random port can be reached from trusted network interfaces. From another
 machine on Tailscale, replace the local banner host with the Tailscale
-hostname, for example
-`http://prometheus:<port>/projects/dogfood/kanban`. Pass
+hostname. With the override above, open
+`http://prometheus:<port>/projects/demo-project/kanban`. Pass
 `--host 127.0.0.1` for a local-only demo run.
 
 The Kanban demo keeps the runtime isolated on the memory tracker, enables
@@ -875,7 +882,9 @@ fake `https://github.test/...` URLs, no GitHub calls, no real ProjectV2
 mutation, and no live dogfood port by default. It freezes demo time at
 `2026-06-15T12:00:00Z` unless started with `--demo-clock play`, which advances
 SSE ticks and visible running-work counters for video capture. The boot banner
-prints the scenario manifest location:
+prints the scenario manifest location. Screenshots mode intentionally keeps the
+primary project fixed at `dogfood` so page routes and visual baselines remain
+deterministic:
 
 ```text
 Scenario manifest: /api/v1/demo/scenarios

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -251,6 +251,7 @@ func TestDevRuntimeCommandBuildsKanbanDemoBootConfig(t *testing.T) {
 		"dev-runtime",
 		"--home", home,
 		"--demo", "kanban",
+		"--demo-project", "demo-project",
 	})
 
 	if err := cmd.Execute(); err != nil {
@@ -263,6 +264,12 @@ func TestDevRuntimeCommandBuildsKanbanDemoBootConfig(t *testing.T) {
 	}
 	if got.Isolated.Demo != "kanban" {
 		t.Fatalf("Isolated.Demo = %q, want kanban", got.Isolated.Demo)
+	}
+	if len(got.Global.Projects) != 1 {
+		t.Fatalf("Global projects = %d, want 1", len(got.Global.Projects))
+	}
+	if got.Global.Projects[0].ID != "demo-project" {
+		t.Fatalf("Global project ID = %q, want demo-project", got.Global.Projects[0].ID)
 	}
 	if got.Host != "0.0.0.0" {
 		t.Fatalf("Host = %q, want demo wildcard host", got.Host)

--- a/internal/cli/dev_runtime.go
+++ b/internal/cli/dev_runtime.go
@@ -29,6 +29,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	var fixturePath string
 	var demo string
 	var demoClock string
+	var demoProjectID string
 	var allowLiveDB bool
 	var allowProductionPort bool
 
@@ -58,6 +59,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 				FixturePath:         fixturePath,
 				Demo:                demo,
 				DemoClock:           demoClock,
+				DemoProjectID:       demoProjectID,
 				Port:                runtimePort,
 				AllowLiveDatabase:   allowLiveDB,
 				AllowProductionPort: allowProductionPort,
@@ -75,6 +77,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	cmd.Flags().StringVar(&fixturePath, "fixture", "", "YAML fixture with mock issues and pull requests")
 	cmd.Flags().StringVar(&demo, "demo", "", "built-in isolated demo fixture (kanban, screenshots)")
 	cmd.Flags().StringVar(&demoClock, "demo-clock", "frozen", "demo clock mode for screenshots fixtures (frozen, play)")
+	cmd.Flags().StringVar(&demoProjectID, "demo-project", "", "generated primary project ID for isolated demos; screenshots stays dogfood")
 	cmd.Flags().BoolVar(&allowLiveDB, "allow-live-db", false, "allow --db to point at the operator's live ~/.detent/detent.db")
 	cmd.Flags().BoolVar(&allowProductionPort, "allow-production-port", false, "allow binding the isolated runtime to the live dogfood port")
 	return cmd

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -56,7 +56,9 @@ func TestStartIsolatedRuntimeAutoPromotesFixtureAndStopsOnCancel(t *testing.T) {
 }
 
 func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
-	runtime, err := devruntime.Build(devruntime.Config{Home: t.TempDir(), Port: 0, Demo: devruntime.DemoKanban})
+	const projectID = "demo-project"
+
+	runtime, err := devruntime.Build(devruntime.Config{Home: t.TempDir(), Port: 0, Demo: devruntime.DemoKanban, DemoProjectID: projectID})
 	if err != nil {
 		t.Fatalf("devruntime.Build() error = %v", err)
 	}
@@ -76,12 +78,13 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	waitForDashboard(t, dashboardURL+"/health", done)
 	postRuntimeRefresh(t, dashboardURL, done)
 
-	pageURL := dashboardURL + "/projects/dogfood/kanban"
+	pageURL := dashboardURL + "/projects/" + projectID + "/kanban"
 	body := waitForDashboardCondition(t, pageURL, done, "kanban demo mutation controls", func(body string) bool {
 		return strings.Contains(body, "Kanban demo backlog intake") &&
 			strings.Contains(body, `data-kanban-action="move"`) &&
 			strings.Contains(body, `hx-get="/api/v1/kanban/comment?`) &&
-			strings.Contains(body, `data-kanban-drop-state="Todo"`)
+			strings.Contains(body, `data-kanban-drop-state="Todo"`) &&
+			strings.Contains(body, `name="project_id" value="`+projectID+`"`)
 	})
 	for _, want := range []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"} {
 		if !strings.Contains(body, want) {
@@ -90,7 +93,7 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	}
 
 	postRuntimeKanbanForm(t, dashboardURL+"/api/v1/kanban/move", done, url.Values{
-		"project_id":    {"dogfood"},
+		"project_id":    {projectID},
 		"issue_id":      {"kanban-demo-backlog"},
 		"current_state": {"Backlog"},
 		"target_state":  {"Todo"},
@@ -102,13 +105,13 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	})
 
 	postRuntimeKanbanForm(t, dashboardURL+"/api/v1/kanban/comment", done, url.Values{
-		"project_id": {"dogfood"},
+		"project_id": {projectID},
 		"target":     {"issue"},
 		"issue_id":   {"kanban-demo-backlog"},
 		"body":       {"Safe demo issue comment"},
 	})
 	postRuntimeKanbanForm(t, dashboardURL+"/api/v1/kanban/comment", done, url.Values{
-		"project_id":    {"dogfood"},
+		"project_id":    {projectID},
 		"target":        {"pr"},
 		"pr_repository": {"digitaldrywood/detent"},
 		"pr_number":     {"9515"},

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -43,6 +43,7 @@ type Config struct {
 	FixturePath         string
 	Demo                string
 	DemoClock           string
+	DemoProjectID       string
 	Port                int
 	AllowLiveDatabase   bool
 	AllowProductionPort bool
@@ -60,6 +61,7 @@ type Runtime struct {
 	FixturePath   string
 	Demo          string
 	DemoClock     string
+	DemoProjectID string
 	Port          int
 	Global        globalconfig.Config
 	Issues        []connector.Issue
@@ -85,6 +87,7 @@ func Build(cfg Config) (Runtime, error) {
 		return Runtime{}, err
 	}
 	demoClock := runtimeDemoClock(cfg.DemoClock)
+	demoProjectID := runtimeDemoProjectID(demo, cfg.DemoProjectID)
 
 	home, err := runtimeHome(cfg.Home)
 	if err != nil {
@@ -124,7 +127,7 @@ func Build(cfg Config) (Runtime, error) {
 	}
 
 	configPath := filepath.Join(home, "global.yaml")
-	global := globalConfig(configPath, workflowPath, sourceRoot, cfg.Port, demo)
+	global := globalConfig(configPath, workflowPath, sourceRoot, cfg.Port, demo, demoProjectID)
 	if err := globalconfig.Write(configPath, global); err != nil {
 		return Runtime{}, fmt.Errorf("write isolated global config: %w", err)
 	}
@@ -142,6 +145,7 @@ func Build(cfg Config) (Runtime, error) {
 		FixturePath:   fixturePath,
 		Demo:          demo,
 		DemoClock:     demoClock,
+		DemoProjectID: demoProjectID,
 		Port:          cfg.Port,
 		Global:        global,
 		Issues:        append([]connector.Issue(nil), issues...),
@@ -164,6 +168,17 @@ func runtimeDemoClock(value string) string {
 		return "play"
 	}
 	return "frozen"
+}
+
+func runtimeDemoProjectID(demo string, value string) string {
+	if demo == DemoScreenshots {
+		return defaultProjectID
+	}
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return defaultProjectID
+	}
+	return value
 }
 
 func runtimeHome(path string) (string, error) {
@@ -820,9 +835,9 @@ func kanbanDemoAllowedTransitions() map[string][]string {
 	}
 }
 
-func globalConfig(path string, workflowPath string, sourceRoot string, port int, demo string) globalconfig.Config {
+func globalConfig(path string, workflowPath string, sourceRoot string, port int, demo string, projectID string) globalconfig.Config {
 	projects := []globalconfig.Project{{
-		ID:       defaultProjectID,
+		ID:       projectID,
 		Workflow: workflowPath,
 		Workdir:  sourceRoot,
 		Weight:   1,

--- a/internal/devruntime/runtime_test.go
+++ b/internal/devruntime/runtime_test.go
@@ -53,6 +53,42 @@ func TestBuildCreatesIsolatedRuntimeDefaults(t *testing.T) {
 	if len(workflow.Config.Tracker.Issues) < 4 {
 		t.Fatalf("fixture issues = %d, want default dogfood coverage", len(workflow.Config.Tracker.Issues))
 	}
+	if len(runtime.Global.Projects) != 1 {
+		t.Fatalf("global projects = %d, want 1", len(runtime.Global.Projects))
+	}
+	if runtime.Global.Projects[0].ID != defaultProjectID {
+		t.Fatalf("global project ID = %q, want %q", runtime.Global.Projects[0].ID, defaultProjectID)
+	}
+}
+
+func TestBuildUsesCustomDemoProjectID(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := Build(Config{Home: t.TempDir(), Demo: DemoKanban, DemoProjectID: "demo-project", Port: 0})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(runtime.Global.Projects) != 1 {
+		t.Fatalf("global projects = %d, want 1", len(runtime.Global.Projects))
+	}
+	if runtime.Global.Projects[0].ID != "demo-project" {
+		t.Fatalf("global project ID = %q, want demo-project", runtime.Global.Projects[0].ID)
+	}
+}
+
+func TestBuildKeepsScreenshotsDemoProjectIDDeterministic(t *testing.T) {
+	t.Parallel()
+
+	runtime, err := Build(Config{Home: t.TempDir(), Demo: DemoScreenshots, DemoProjectID: "demo-project", Port: 0})
+	if err != nil {
+		t.Fatalf("Build() error = %v", err)
+	}
+	if len(runtime.Global.Projects) == 0 {
+		t.Fatal("global projects = 0, want screenshot fleet config")
+	}
+	if runtime.Global.Projects[0].ID != defaultProjectID {
+		t.Fatalf("primary screenshot project ID = %q, want %q", runtime.Global.Projects[0].ID, defaultProjectID)
+	}
 }
 
 func TestBuildLoadsFixtureIssues(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `dev-runtime --demo-project` to override the generated Kanban demo project ID.
- Keep screenshots demo project routes fixed at `dogfood` for deterministic baselines and document that behavior.
- Cover default, custom, and deterministic screenshot project ID behavior.

Fixes #538

## Test Plan

- [x] `go test ./internal/devruntime ./internal/cli`
- [x] `make check`