### PR TITLE
fix(onboarding): guard status-source answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,10 @@ registration, issue intake, and smoke-test decisions.
 Present findings with evidence, ask only the next necessary human decisions, and
 do not create, link, mutate, or delete GitHub Projects, issue fields, labels,
 issues, PRs, `WORKFLOW.md`, or `global.yaml`, or dispatch agents, until Phase 2
-answers are recorded in `answers.env` and I explicitly confirm the mutation
-step. Defaults are recommendations only; never execute a defaulted GitHub or
-config mutation without my confirmation.
+answers are recorded in `answers.env`, `detent onboarding validate-answers`
+passes for the selected phase, and I explicitly confirm the mutation step.
+Defaults are recommendations only; never execute a defaulted GitHub or config
+mutation without my confirmation.
 ```
 
 A **detent** is the catch that holds a moving part at a fixed position until it

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -476,7 +476,12 @@ mutations. Record explicit answers in `$ONBOARDING_DIR/answers.env`.
      'GITHUB_MODE=<project_v2|issue_field|label>' \
      >> "$ONBOARDING_DIR/answers.env"
    rg '^GITHUB_MODE=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision
    ```
+
+   Hard stop: do not inspect your recommendation as if it selected the mode,
+   and do not continue to Phase 3, issue-field, label, `WORKFLOW.md`, or
+   `global.yaml` mutation without this explicit `GITHUB_MODE` answer.
 
 2. **ProjectV2 board.** Ask this only when `GITHUB_MODE=project_v2`: "Reuse an
    existing ProjectV2 board or create a new one?" List the boards from
@@ -514,8 +519,10 @@ mutations. Record explicit answers in `$ONBOARDING_DIR/answers.env`.
 4. **Repository status labels.** Ask this only when `GITHUB_MODE=label`: "What
    repository label prefix should Detent use for status?" Recommend `detent:`
    unless the repository already has an intentional Detent status-label
-   namespace. Explain that Detent maps each configured workflow state through
-   `tracker.state_map`, slugifies the resulting state name, and prefixes it:
+   namespace. Do not choose label mode for the operator; ask even if label mode
+   appears easiest for the repository. Explain that Detent maps each configured
+   workflow state through `tracker.state_map`, slugifies the resulting state name,
+   and prefixes it:
    `Todo` maps to `detent:todo`, `In Progress` maps to
    `detent:in-progress`, and with the default release flow
    `Cancelled: Done` state map, `Cancelled` maps to `detent:done`. These labels
@@ -808,12 +815,14 @@ printf '%s\n' \
   >> "$ONBOARDING_DIR/answers.env"
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 ```
 
 Run this gate before every mutating phase and before every one-off mutating
 command:
 
 ```sh
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 test -f "$ONBOARDING_DIR/answers.env"
 rg '^DETENT_ONBOARDING_MODE=' "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
@@ -827,6 +836,13 @@ case "$GITHUB_MODE" in
   project_v2)
     rg '^BOARD_MODE=(reuse|create)$' "$ONBOARDING_DIR/answers.env"
     rg '^PROJECT_OWNER=' "$ONBOARDING_DIR/answers.env"
+    BOARD_MODE="$(
+      awk -F= '/^BOARD_MODE=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env"
+    )"
+    case "$BOARD_MODE" in
+      reuse) rg '^PROJECT_NUMBER=' "$ONBOARDING_DIR/answers.env" ;;
+      create) rg '^PROJECT_TITLE=' "$ONBOARDING_DIR/answers.env" ;;
+    esac
     ;;
   issue_field)
     rg '^STATUS_FIELD_NAME=' "$ONBOARDING_DIR/answers.env"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -813,9 +813,9 @@ mv "$CONFIRMATION_FILE" "$ONBOARDING_DIR/answers.env"
 printf '%s\n' \
   'MUTATION_CONFIRMED=true' \
   >> "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
-detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 ```
 
 Run this gate before every mutating phase and before every one-off mutating
@@ -826,6 +826,7 @@ detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --pha
 test -f "$ONBOARDING_DIR/answers.env"
 rg '^DETENT_ONBOARDING_MODE=' "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -870,6 +871,7 @@ or label resources, rerun the Phase 2.5 gate:
 ```sh
 test -f "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
@@ -881,6 +883,7 @@ link`, `gh project field-create`, or `gh project item-edit`, also run:
 rg '^GITHUB_MODE=project_v2$' "$ONBOARDING_DIR/answers.env"
 rg '^BOARD_MODE=(reuse|create)$' "$ONBOARDING_DIR/answers.env"
 rg '^PROJECT_OWNER=' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
@@ -904,6 +907,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    rg '^BOARD_MODE=create$' "$ONBOARDING_DIR/answers.env"
    rg '^PROJECT_OWNER=' "$ONBOARDING_DIR/answers.env"
    rg '^PROJECT_TITLE=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -921,6 +925,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    ```sh
    rg '^GITHUB_MODE=project_v2$' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -950,6 +955,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    ```sh
    rg '^GITHUB_MODE=project_v2$' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1066,6 +1072,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    ```sh
    rg '^GITHUB_MODE=project_v2$' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1112,6 +1119,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    ```sh
    rg '^GITHUB_MODE=issue_field$' "$ONBOARDING_DIR/answers.env"
    rg '^STATUS_FIELD_NAME=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
    ```
@@ -1145,6 +1153,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    ```sh
    rg '^GITHUB_MODE=label$' "$ONBOARDING_DIR/answers.env"
    rg '^STATUS_LABEL_PREFIX=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
    ```
@@ -1203,6 +1212,7 @@ Before writing, overwriting, or editing `<source-root>/WORKFLOW.md`, rerun:
 ```sh
 test -f "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
@@ -1434,6 +1444,7 @@ running `detent doctor` with configured write probes, rerun:
 ```sh
 test -f "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
@@ -1462,6 +1473,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `weight` are the scheduling answers from Phase 2. Verify:
 
    ```sh
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1596,6 +1608,7 @@ test -f "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
 rg '^INTAKE_GH_FLAGS=' "$ONBOARDING_DIR/answers.env"
 rg '^INITIAL_STATUS=' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
@@ -1631,6 +1644,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    ```sh
    rg '^GITHUB_MODE=project_v2$' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1666,6 +1680,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    ```sh
    rg '^GITHUB_MODE=issue_field$' "$ONBOARDING_DIR/answers.env"
    rg '^STATUS_FIELD_NAME=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1695,6 +1710,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    ```sh
    rg '^GITHUB_MODE=label$' "$ONBOARDING_DIR/answers.env"
    rg '^STATUS_LABEL_PREFIX=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1735,6 +1751,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    ```sh
    rg '^GITHUB_MODE=project_v2$' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1752,6 +1769,7 @@ or moving a smoke-test issue to `Todo`, rerun:
 ```sh
 test -f "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
@@ -1763,6 +1781,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    it exposes every interface. Verify:
 
    ```sh
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1824,6 +1843,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    ```sh
    # ProjectV2 mode:
    rg '^GITHUB_MODE=project_v2$' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1848,6 +1868,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    # Boardless issue-field mode:
    rg '^GITHUB_MODE=issue_field$' "$ONBOARDING_DIR/answers.env"
    rg '^STATUS_FIELD_NAME=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1861,6 +1882,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    # Label mode:
    rg '^GITHUB_MODE=label$' "$ONBOARDING_DIR/answers.env"
    rg '^STATUS_LABEL_PREFIX=' "$ONBOARDING_DIR/answers.env"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
    rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
    awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 
@@ -1912,6 +1934,7 @@ write-probe preflight, or moves issues, rerun:
 ```sh
 test -f "$ONBOARDING_DIR/answers.env"
 rg '^GITHUB_MODE=(project_v2|issue_field|label)$' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -401,6 +401,7 @@ detent --format json config path`),
 			return nil
 		}),
 		newConfigCommand(&configPath, opts),
+		newOnboardingCommand(),
 		newPromoteCommand(&configPath, opts),
 		newRemoveProjectCommand(&configPath, opts),
 	)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -37,7 +37,7 @@ func TestRootCommandHelpListsAdminCommands(t *testing.T) {
 	if !strings.HasPrefix(output, "Examples:\n") {
 		t.Fatalf("help output does not lead with examples:\n%s", output)
 	}
-	for _, want := range []string{"detent", "agent orchestrator", "doctor", "dev-runtime", "init", "add-project", "pause", "unpause", "promote", "remove-project"} {
+	for _, want := range []string{"detent", "agent orchestrator", "doctor", "dev-runtime", "init", "add-project", "pause", "unpause", "onboarding", "promote", "remove-project"} {
 		if !strings.Contains(output, want) {
 			t.Fatalf("help output missing %q:\n%s", want, output)
 		}

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -1,0 +1,238 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+)
+
+const (
+	onboardingAnswersPhaseDecision = "decision"
+	onboardingAnswersPhaseMutation = "mutation"
+)
+
+type onboardingAnswersValidationResult struct {
+	Status            string `json:"status"`
+	Path              string `json:"path"`
+	Phase             string `json:"phase"`
+	GitHubMode        string `json:"github_mode"`
+	MutationConfirmed bool   `json:"mutation_confirmed"`
+}
+
+type onboardingAnswers struct {
+	Values       map[string]string
+	LastNonblank string
+	Problems     []string
+}
+
+func newOnboardingCommand() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "onboarding",
+		Short:   "Validate onboarding setup decisions",
+		Example: `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env"`,
+	}
+	cmd.AddCommand(newOnboardingValidateAnswersCommand())
+	return cmd
+}
+
+func newOnboardingValidateAnswersCommand() *cobra.Command {
+	var answersPath string
+	var phase string
+	cmd := &cobra.Command{
+		Use:          "validate-answers",
+		Short:        "Validate onboarding answers.env before setup mutation",
+		Example:      `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env"`,
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, err := validateOnboardingAnswersFile(answersPath, phase)
+			if err != nil {
+				return err
+			}
+			return out.Write(func(w io.Writer) error {
+				_, writeErr := fmt.Fprintf(w, "onboarding answers valid for %s phase: %s\n", result.Phase, result.Path)
+				return writeErr
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
+	cmd.Flags().StringVar(&phase, "phase", onboardingAnswersPhaseMutation, "validation phase: decision or mutation")
+	return cmd
+}
+
+func validateOnboardingAnswersFile(path string, phase string) (onboardingAnswersValidationResult, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return onboardingAnswersValidationResult{}, NewValidationError(
+			"--answers is required",
+			`Run detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env".`,
+			nil,
+		)
+	}
+	normalizedPhase, err := normalizeOnboardingAnswersPhase(phase)
+	if err != nil {
+		return onboardingAnswersValidationResult{}, err
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return onboardingAnswersValidationResult{}, NewValidationError(
+				"answers file not found: "+path,
+				"Create answers.env from explicit human answers before continuing onboarding.",
+				nil,
+			)
+		}
+		return onboardingAnswersValidationResult{}, fmt.Errorf("read onboarding answers %s: %w", path, err)
+	}
+	answers := parseOnboardingAnswers(raw)
+	result := onboardingAnswersValidationResult{
+		Status: "ok",
+		Path:   path,
+		Phase:  normalizedPhase,
+	}
+	problems := validateOnboardingAnswers(answers, normalizedPhase, &result)
+	if len(problems) > 0 {
+		return onboardingAnswersValidationResult{}, NewValidationError(
+			strings.Join(problems, "; "),
+			"Ask the status-source question, record the explicit answer in answers.env, and rerun the validator before any mutation.",
+			nil,
+		)
+	}
+	return result, nil
+}
+
+func normalizeOnboardingAnswersPhase(phase string) (string, error) {
+	switch strings.ToLower(strings.TrimSpace(phase)) {
+	case "", onboardingAnswersPhaseMutation:
+		return onboardingAnswersPhaseMutation, nil
+	case onboardingAnswersPhaseDecision:
+		return onboardingAnswersPhaseDecision, nil
+	default:
+		return "", NewValidationError(
+			"--phase must be decision or mutation",
+			"Use --phase decision after the status-source answer or --phase mutation before setup changes.",
+			nil,
+		)
+	}
+}
+
+func parseOnboardingAnswers(raw []byte) onboardingAnswers {
+	answers := onboardingAnswers{
+		Values: make(map[string]string),
+	}
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		answers.LastNonblank = line
+		if strings.HasPrefix(line, "#") {
+			continue
+		}
+		line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+		key, value, ok := strings.Cut(line, "=")
+		key = strings.TrimSpace(key)
+		if !ok || !validOnboardingAnswerKey(key) {
+			answers.Problems = append(answers.Problems, fmt.Sprintf("line %d must be KEY=VALUE", lineNumber))
+			continue
+		}
+		answers.Values[key] = trimOnboardingAnswerValue(value)
+	}
+	if err := scanner.Err(); err != nil {
+		answers.Problems = append(answers.Problems, "read answers.env: "+err.Error())
+	}
+	return answers
+}
+
+func validOnboardingAnswerKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for _, char := range key {
+		if char == '_' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' {
+			continue
+		}
+		return false
+	}
+	return true
+}
+
+func trimOnboardingAnswerValue(value string) string {
+	value = strings.TrimSpace(value)
+	if len(value) < 2 {
+		return value
+	}
+	first := value[0]
+	last := value[len(value)-1]
+	if first == last && (first == '\'' || first == '"') {
+		return value[1 : len(value)-1]
+	}
+	return value
+}
+
+func validateOnboardingAnswers(answers onboardingAnswers, phase string, result *onboardingAnswersValidationResult) []string {
+	problems := append([]string(nil), answers.Problems...)
+	mode := answers.Values["GITHUB_MODE"]
+	switch mode {
+	case workflowconfig.GitHubStatusSourceProjectV2, workflowconfig.GitHubStatusSourceIssueField, workflowconfig.GitHubStatusSourceLabel:
+		result.GitHubMode = mode
+	default:
+		problems = append(problems, "GITHUB_MODE must be project_v2, issue_field, or label")
+	}
+	if phase == onboardingAnswersPhaseMutation {
+		problems = append(problems, validateOnboardingMutationAnswers(answers, mode, result)...)
+	}
+	return problems
+}
+
+func validateOnboardingMutationAnswers(answers onboardingAnswers, mode string, result *onboardingAnswersValidationResult) []string {
+	var problems []string
+	switch mode {
+	case workflowconfig.GitHubStatusSourceProjectV2:
+		boardMode := answers.Values["BOARD_MODE"]
+		switch boardMode {
+		case "reuse":
+			problems = append(problems, requireOnboardingAnswers(answers, "PROJECT_OWNER", "PROJECT_NUMBER")...)
+		case "create":
+			problems = append(problems, requireOnboardingAnswers(answers, "PROJECT_OWNER", "PROJECT_TITLE")...)
+		default:
+			problems = append(problems, "BOARD_MODE must be reuse or create for GITHUB_MODE=project_v2")
+		}
+	case workflowconfig.GitHubStatusSourceIssueField:
+		problems = append(problems, requireOnboardingAnswers(answers, "STATUS_FIELD_NAME")...)
+	case workflowconfig.GitHubStatusSourceLabel:
+		problems = append(problems, requireOnboardingAnswers(answers, "STATUS_LABEL_PREFIX")...)
+	}
+	if answers.Values["MUTATION_CONFIRMED"] != "true" {
+		problems = append(problems, "MUTATION_CONFIRMED must be true")
+	}
+	if answers.LastNonblank != "MUTATION_CONFIRMED=true" {
+		problems = append(problems, "MUTATION_CONFIRMED=true must be the final nonblank line")
+	}
+	result.MutationConfirmed = answers.Values["MUTATION_CONFIRMED"] == "true" && answers.LastNonblank == "MUTATION_CONFIRMED=true"
+	return problems
+}
+
+func requireOnboardingAnswers(answers onboardingAnswers, keys ...string) []string {
+	var problems []string
+	for _, key := range keys {
+		if strings.TrimSpace(answers.Values[key]) == "" {
+			problems = append(problems, key+" is required")
+		}
+	}
+	return problems
+}

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -1,0 +1,149 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/cli"
+)
+
+func TestOnboardingValidateAnswersCommandRejectsMissingGitHubMode(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, "MUTATION_CONFIRMED=true\n")
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "validate-answers", "--answers", answersPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "GITHUB_MODE must be project_v2, issue_field, or label") {
+		t.Fatalf("Execute() error missing GITHUB_MODE validation:\n%s", err.Error())
+	}
+}
+
+func TestOnboardingValidateAnswersCommandRequiresFinalMutationConfirmation(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, strings.Join([]string{
+		"GITHUB_MODE=label",
+		"STATUS_LABEL_PREFIX=detent:",
+		"MUTATION_CONFIRMED=true",
+		"STATUS_LABEL_PREFIX=custom:",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "validate-answers", "--answers", answersPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "MUTATION_CONFIRMED=true must be the final nonblank line") {
+		t.Fatalf("Execute() error missing final confirmation validation:\n%s", err.Error())
+	}
+}
+
+func TestOnboardingValidateAnswersCommandRequiresModeSpecificMutationAnswers(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, strings.Join([]string{
+		"GITHUB_MODE=project_v2",
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "validate-answers", "--answers", answersPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "BOARD_MODE must be reuse or create for GITHUB_MODE=project_v2") {
+		t.Fatalf("Execute() error missing board mode validation:\n%s", err.Error())
+	}
+}
+
+func TestOnboardingValidateAnswersCommandAcceptsDecisionPhase(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, "GITHUB_MODE=issue_field\n")
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "onboarding", "validate-answers", "--answers", answersPath, "--phase", "decision"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Status            string `json:"status"`
+		Phase             string `json:"phase"`
+		GitHubMode        string `json:"github_mode"`
+		MutationConfirmed bool   `json:"mutation_confirmed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Status != "ok" || got.Phase != "decision" || got.GitHubMode != "issue_field" || got.MutationConfirmed {
+		t.Fatalf("validation result = %#v, want accepted decision phase", got)
+	}
+}
+
+func TestOnboardingValidateAnswersCommandAcceptsLabelMode(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, strings.Join([]string{
+		"GITHUB_MODE=label",
+		"STATUS_LABEL_PREFIX=detent:",
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "onboarding", "validate-answers", "--answers", answersPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Status            string `json:"status"`
+		Path              string `json:"path"`
+		Phase             string `json:"phase"`
+		GitHubMode        string `json:"github_mode"`
+		MutationConfirmed bool   `json:"mutation_confirmed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Status != "ok" || got.Path != answersPath || got.Phase != "mutation" || got.GitHubMode != "label" || !got.MutationConfirmed {
+		t.Fatalf("validation result = %#v, want accepted label mutation", got)
+	}
+}
+
+func writeOnboardingAnswers(t *testing.T, content string) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "answers.env")
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	return path
+}

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -18,12 +18,18 @@ func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
 	assertContains(t, onboarding, "last == \"MUTATION_CONFIRMED=true\"")
 	assertContains(t, onboarding, "GITHUB_MODE=<project_v2|issue_field|label>")
 	assertContains(t, onboarding, "tracker.github_status_source: label")
+	assertContains(t, onboarding, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision`)
+	assertContains(t, onboarding, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation`)
+	assertContains(t, onboarding, "Do not choose label mode for the operator")
 	assertContains(t, onboarding, "rg '^GITHUB_MODE=project_v2$'")
 	assertContains(t, onboarding, "rg '^BOARD_MODE=(reuse|create)$'")
+	assertContains(t, onboarding, "rg '^PROJECT_NUMBER='")
+	assertContains(t, onboarding, "rg '^PROJECT_TITLE='")
 	assertContains(t, onboarding, "rg '^STATUS_LABEL_PREFIX='")
 
 	assertContains(t, readme, "do not create, link, mutate, or delete GitHub Projects, issue fields, labels")
 	assertContainsWords(t, readme, "until Phase 2 answers are recorded in `answers.env`")
+	assertContains(t, readme, "detent onboarding validate-answers")
 	assertContains(t, readme, "Defaults are recommendations only")
 }
 

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -26,6 +26,7 @@ func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
 	assertContains(t, onboarding, "rg '^PROJECT_NUMBER='")
 	assertContains(t, onboarding, "rg '^PROJECT_TITLE='")
 	assertContains(t, onboarding, "rg '^STATUS_LABEL_PREFIX='")
+	assertMutationBlocksUseValidator(t, onboarding)
 
 	assertContains(t, readme, "do not create, link, mutate, or delete GitHub Projects, issue fields, labels")
 	assertContainsWords(t, readme, "until Phase 2 answers are recorded in `answers.env`")
@@ -57,4 +58,34 @@ func assertContainsWords(t *testing.T, text string, want string) {
 	normalizedText := strings.Join(strings.Fields(text), " ")
 	normalizedWant := strings.Join(strings.Fields(want), " ")
 	assertContains(t, normalizedText, normalizedWant)
+}
+
+func assertMutationBlocksUseValidator(t *testing.T, text string) {
+	t.Helper()
+
+	lines := strings.Split(text, "\n")
+	inFence := false
+	fenceStart := 0
+	var block []string
+	for index, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), "```") {
+			if !inFence {
+				inFence = true
+				fenceStart = index + 1
+				block = nil
+				continue
+			}
+			blockText := strings.Join(block, "\n")
+			if strings.Contains(blockText, "rg '^MUTATION_CONFIRMED=true$'") &&
+				!strings.Contains(blockText, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation`) {
+				t.Fatalf("mutation confirmation block starting at line %d missing validate-answers", fenceStart)
+			}
+			inFence = false
+			block = nil
+			continue
+		}
+		if inFence {
+			block = append(block, line)
+		}
+	}
 }


### PR DESCRIPTION
## Summary

- Add `detent onboarding validate-answers` to hard-stop onboarding unless `answers.env` records an explicit GitHub status source and final mutation confirmation.
- Update the onboarding runbook and README prompt to call the validator before setup mutation, with label-mode warning text.

Fixes #546

## Test Plan

- [x] `make check`