### PR TITLE
fix(onboarding): require identity gate

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,22 +24,35 @@ present, docs/ONBOARDING.md, CONTRIBUTING.md, build and language manifests,
 .github/workflows, install scripts, and any existing WORKFLOW.md or global.yaml
 examples. Detent can drive any project with a clear workflow and validation
 gate, so use the repository evidence to identify the stack, tools, and commands
-instead of starting from one language. Do not ask setup questions until you have
-gathered local evidence.
+instead of starting from one language. Do not inspect a target repository's
+ProjectV2 boards, labels, issues, WORKFLOW.md, validation commands, or runtime
+docs until the identity gate below is explicit and confirmed.
 
 Use docs/ONBOARDING.md as the interrogation guide. First determine which path
 applies: a new Detent install, an existing Detent install that must be found and
 verified, or a new repository/project being added to an existing Detent install.
+Distinguish reference repositories from the target repository being onboarded.
+Restate the customer/workstream id, Detent project id, target owner/name,
+absolute local source root, reference repositories, onboarding mode, and
+status-source options before repository-specific discovery. Record those
+identity answers in `answers.env`, set `IDENTITY_CONFIRMED=true` only after I
+confirm the restatement, then run
+`detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`.
 
 For an existing install, find and verify the detent binary, config path, running
 service or dashboard, registered projects, GitHub auth, Codex auth, and doctor
 status before recommending changes. For a new install, follow the bootstrap flow
-and verify each step before moving on. For adding a project, inspect the target
-repository and existing global.yaml, then walk me through the board, workflow,
-registration, issue intake, and smoke-test decisions.
+and verify each step before moving on. For adding a project, treat existing
+registered projects as examples only; do not reuse tracker mode, status
+namespace, validation gate, dashboard bind, workspace root, scheduling priority,
+auto-promote policy, review policy, or mutation scope unless I explicitly
+accept that setting for this customer/project.
 
-Present findings with evidence, ask only the next necessary human decisions, and
-do not create, link, mutate, or delete GitHub Projects, issue fields, labels,
+Present findings with evidence and ask only the next necessary human decisions.
+Ask and record `GITHUB_MODE` explicitly after the identity phase and before
+target-specific discovery; never infer ProjectV2, issue-field, or label mode
+from existing projects. Recommendations can cite evidence, but they are not
+selected answers; do not create, link, mutate, or delete GitHub Projects, issue fields, labels,
 issues, PRs, `WORKFLOW.md`, or `global.yaml`, or dispatch agents, until Phase 2
 answers are recorded in `answers.env`, `detent onboarding validate-answers`
 passes for the selected phase, and I explicitly confirm the mutation step.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1,18 +1,20 @@
 # Agent-Executable Project Onboarding
 
 This runbook takes a target repository from zero Detent setup to one dispatched
-issue, or adds a new project to an existing Detent install. It assumes the human
-has named the target repository when project onboarding is needed and that the
-agent will inspect before asking questions. Replace every `<...>` placeholder
-before running a command.
+issue, or adds a new project to an existing Detent install. It starts with an
+identity gate so a reference repository, example setup, current shell directory,
+or existing Detent project cannot become the implicit target. Replace every
+`<...>` placeholder before running a command.
 
 Use these placeholders consistently:
 
 | Placeholder | Meaning |
 | --- | --- |
+| `<customer-id>` | Customer or workstream id being onboarded. |
 | `<repo-owner>` | GitHub owner of the target repository. |
 | `<repo-name>` | GitHub repository name. |
 | `<source-root>` | Local checkout of `<repo-owner>/<repo-name>`. |
+| `<reference-repositories>` | Comma-separated `owner/repo` list used only for docs, examples, or tooling, or empty. |
 | `<worktree-root>` | Directory where Detent will create issue worktrees. |
 | `<github-mode>` | `project_v2` for GitHub ProjectV2-backed status, `issue_field` for boardless repository issue-field status, or `label` for repository issue-label status. |
 | `<project-owner>` | GitHub org or user that owns the ProjectV2 board. |
@@ -25,8 +27,10 @@ Use these placeholders consistently:
 
 ## Start Here — Determine The Mode
 
-Do not assume this is a fresh install. Inspect first, write down the evidence,
-then ask the human to confirm only if the mode is still ambiguous.
+Do not assume this is a fresh install, and do not infer the target project from
+the current directory or a pasted repository URL. You may inspect Detent
+installation evidence before the identity gate, but repository-specific
+discovery waits for Phase 0.5.
 
 Classify the work into one of these modes:
 
@@ -44,7 +48,7 @@ Classify the work into one of these modes:
   runtime settings unless the human chooses otherwise, then create or adopt a
   board, author `WORKFLOW.md`, register the project, and smoke test.
 
-Record the mode evidence before the interview:
+Record only Detent install/mode evidence before the identity interview:
 
 ```sh
 ONBOARDING_DIR="${TMPDIR:-/tmp}/detent-onboarding-<repo-owner>-<repo-name>"
@@ -92,6 +96,11 @@ rg -n 'id: <detent-project-id>|workflow: .*<repo-name>|workdir: .*<repo-name>' \
   "$ONBOARDING_DIR/global-config.before.txt" 2>/dev/null || true
 ```
 
+Treat existing registered projects as examples only. Do not reuse tracker mode,
+status namespace, validation gate, workspace root, dashboard bind, scheduling
+priority or weight, auto-promote policy, review policy, or mutation scope unless
+the operator explicitly accepts that setting for this customer/project.
+
 ## Phase 0 — Preconditions
 
 1. **Confirm Detent is installed or intentionally new.** For `new-install`,
@@ -106,11 +115,16 @@ rg -n 'id: <detent-project-id>|workflow: .*<repo-name>|workdir: .*<repo-name>' \
    ```
 
 2. **Confirm GitHub CLI auth and scopes.** Detent needs GitHub auth for the
-   selected tracker mode. ProjectV2 mode needs repository, organization, and
-   ProjectV2 read/write scopes. Boardless issue-field mode needs repository
-   issue access plus organization issue-field read access; classic PATs use
-   `repo` and `read:org`. Label mode needs repository issue and label
-   read/write access; classic PATs can use `repo`.
+   selected tracker mode. Before the identity gate, verify only the local `gh`
+   auth state and token scopes. Do not list target ProjectV2 boards,
+   organization issue fields, repository labels, or target issues until Phase
+   0.5 identity is confirmed and Phase 2 records `GITHUB_MODE`.
+
+   ProjectV2 mode needs repository, organization, and ProjectV2 read/write
+   scopes. Boardless issue-field mode needs repository issue access plus
+   organization issue-field read access; classic PATs use `repo` and
+   `read:org`. Label mode needs repository issue and label read/write access;
+   classic PATs can use `repo`.
 
    For ProjectV2 mode, request:
 
@@ -155,24 +169,20 @@ rg -n 'id: <detent-project-id>|workflow: .*<repo-name>|workdir: .*<repo-name>' \
    # ProjectV2 mode only:
    gh auth status 2>&1 | rg '\bread:project\b'
    gh auth status 2>&1 | rg "(^|[[:space:],'\"])project([[:space:],'\"]|$)"
-   # ProjectV2 mode only:
-   gh project list --owner <project-owner> --format json --limit 1
-   # Boardless issue-field mode:
-   gh api /orgs/<repo-owner>/issue-fields --jq '.[] | select(.name == "<status-field-name>")'
-   # Label mode:
-   gh api repos/<repo-owner>/<repo-name>/labels --paginate --jq '.[].name'
    ```
 
-   `gh project list` verifies the `read:project` board discovery path. Defer
-   write `project` verification until the first intentional ProjectV2 mutation,
-   such as creating or linking a board, creating fields, or editing the status
-   of a real existing item. The issue-field discovery command verifies
-   organization issue-field read access for boardless mode. The label list
-   command verifies repository label read access for label mode. Fine-grained
-   PATs and GitHub Apps should grant Issue Fields organization read for
-   issue-field mode, repository label access for label mode, Issues repository
-   read/write when status moves or comments are enabled, Pull requests
-   read/checks read for PR gates, and selected repository access.
+   After Phase 0.5 identity confirmation and the explicit Phase 2
+   `GITHUB_MODE` answer, run only the selected mode's target-specific read
+   probe: `gh project list --owner <project-owner> --format json --limit 1`
+   for ProjectV2, `gh api /orgs/<repo-owner>/issue-fields` for issue-field
+   mode, or `gh api repos/<repo-owner>/<repo-name>/labels --paginate` for label
+   mode. Defer write `project` verification until the first intentional
+   ProjectV2 mutation, such as creating or linking a board, creating fields, or
+   editing the status of a real existing item. Fine-grained PATs and GitHub
+   Apps should grant Issue Fields organization read for issue-field mode,
+   repository label access for label mode, Issues repository read/write when
+   status moves or comments are enabled, Pull requests read/checks read for PR
+   gates, and selected repository access.
 
 3. **Confirm Codex is installed and signed in.** Detent dispatches agents
    through the Codex app-server. Verify:
@@ -181,15 +191,144 @@ rg -n 'id: <detent-project-id>|workflow: .*<repo-name>|workdir: .*<repo-name>' \
    codex --version
    ```
 
-4. **Confirm the target checkout exists when project work is in scope.** If
-   `<source-root>` does not exist, clone it from the repository named by the
-   human. For `existing-install` without project changes, record the existing
-   registered checkouts from `global.yaml` instead. Verify:
+4. **Stop before target-specific discovery.** Do not inspect target ProjectV2
+   boards, organization issue fields, repository labels, issues, `WORKFLOW.md`,
+   validation commands, deployment docs, or local target checkout contents until
+   Phase 0.5 identity answers are explicit and confirmed.
 
-   ```sh
-   git -C <source-root> remote get-url origin
-   git -C <source-root> rev-parse --show-toplevel
-   ```
+## Phase 0.5 — Identity Gate
+
+Before Phase 1 repository-specific discovery, create and validate a
+customer/project identity record in `$ONBOARDING_DIR/answers.env`. This is an
+operator decision checkpoint, not a recommendation. Recommendations can cite
+evidence later, but they must not become selected answers.
+
+Ask for and record these answers:
+
+```sh
+printf '%s\n' \
+  'CUSTOMER_ID=<customer-or-workstream-id>' \
+  'DETENT_PROJECT_ID=<local-detent-project-id>' \
+  'TARGET_REPOSITORY=<repo-owner>/<repo-name>' \
+  'TARGET_SOURCE_ROOT=<absolute-local-checkout-path>' \
+  'REFERENCE_REPOSITORIES=<comma-separated-owner/repo-list-or-empty>' \
+  'DETENT_ONBOARDING_MODE=<new-install|existing-install|add-project>' \
+  > "$ONBOARDING_DIR/answers.env"
+```
+
+Present the interpretation back to the operator before inspecting target
+resources:
+
+```text
+I will onboard project `<detent-project-id>` for customer/workstream
+`<customer-id>`. The target repository is `<repo-owner>/<repo-name>` at
+`<source-root>`. The following repositories are references only and will not be
+registered as the target: `<reference-repositories>`. The onboarding mode is
+`<new-install|existing-install|add-project>`. Is that correct?
+```
+
+Only after the operator confirms, append the identity confirmation:
+
+```sh
+printf '%s\n' \
+  'IDENTITY_CONFIRMED=true' \
+  >> "$ONBOARDING_DIR/answers.env"
+```
+
+Validate the identity gate:
+
+```sh
+test -f "$ONBOARDING_DIR/answers.env"
+rg '^CUSTOMER_ID=[A-Za-z0-9_.-]+$' "$ONBOARDING_DIR/answers.env"
+rg '^DETENT_PROJECT_ID=[A-Za-z0-9_.-]+$' "$ONBOARDING_DIR/answers.env"
+rg '^TARGET_REPOSITORY=[^/]+/[^/]+$' "$ONBOARDING_DIR/answers.env"
+rg '^TARGET_SOURCE_ROOT=/' "$ONBOARDING_DIR/answers.env"
+rg '^REFERENCE_REPOSITORIES=' "$ONBOARDING_DIR/answers.env"
+rg '^DETENT_ONBOARDING_MODE=(new-install|existing-install|add-project)$' "$ONBOARDING_DIR/answers.env"
+rg '^IDENTITY_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity
+```
+
+The CLI validator rejects missing customer/workstream id, missing Detent project
+id, malformed target repository, missing or relative target source root, a
+target source root that is not a git checkout for the target repository, missing
+reference repository separation, missing onboarding mode, missing
+`IDENTITY_CONFIRMED=true`, and `GITHUB_MODE` answers recorded before identity is
+valid.
+
+If `<source-root>` does not exist, clone the confirmed target repository there
+before validation:
+
+```sh
+git clone "https://github.com/<repo-owner>/<repo-name>.git" <source-root>
+```
+
+Confirm the target checkout only after identity is validated:
+
+```sh
+git -C <source-root> remote get-url origin
+git -C <source-root> rev-parse --show-toplevel
+```
+
+Do not use a reference or tooling repository as the target. A wrong target repository failure example looks like this: the operator mentions
+`digitaldrywood/detent-orchestration` as an example config and
+`customer/api` as the actual project, but the agent runs issue, label, board,
+or validation discovery against `digitaldrywood/detent-orchestration`. Stop,
+rewrite `TARGET_REPOSITORY=customer/api`, verify `TARGET_SOURCE_ROOT` points to
+that checkout, and rerun `detent onboarding validate-answers --phase identity`
+before discovery resumes.
+
+For repeated customer onboarding, a reviewable manifest may carry the same
+answers in addition to `answers.env`:
+
+```yaml
+apiVersion: detent.dev/onboarding/v1
+kind: OnboardingAnswers
+customer:
+  id: <customer-or-workstream-id>
+  display_name: <human-readable-name>
+project:
+  id: <local-detent-project-id>
+  repository: <repo-owner>/<repo-name>
+  source_root: <absolute-local-checkout-path>
+references:
+  repositories:
+    - <owner>/<repo-used-only-for-docs-or-examples>
+detent:
+  mode: add-project
+tracker:
+  github_status_source: <project_v2|issue_field|label>
+mutation:
+  confirmed: false
+```
+
+## Phase 0.6 — Status Source Decision
+
+After identity is confirmed and before target-specific discovery, ask the
+GitHub status-source question. This is separate from identity confirmation, and
+it must still be an explicit operator answer.
+
+Ask: "Use ProjectV2 board mode, boardless issue-field mode, or repository label
+mode?" Explain that this answer maps to `tracker.github_status_source:
+project_v2`, `tracker.github_status_source: issue_field`, or
+`tracker.github_status_source: label` in `WORKFLOW.md`. Do not choose label
+mode for the operator, and do not infer ProjectV2, issue-field, or label mode
+from existing registered projects.
+
+Record and validate the explicit answer:
+
+```sh
+printf '%s\n' \
+  'GITHUB_MODE=<project_v2|issue_field|label>' \
+  >> "$ONBOARDING_DIR/answers.env"
+rg '^GITHUB_MODE=' "$ONBOARDING_DIR/answers.env"
+detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision
+```
+
+Hard stop: do not inspect target ProjectV2 boards, organization issue fields,
+repository labels, target issues, `WORKFLOW.md`, validation commands, or
+deployment docs until this `GITHUB_MODE` answer is recorded and
+`detent onboarding validate-answers --phase decision` passes.
 
 ## GitHub GraphQL Rate-Budget Discipline
 
@@ -241,11 +380,12 @@ prints status and priority counts from cached data.
 
 ## Phase 1 — Discover And Recommend
 
-Do not ask questions in this phase. Inspect the actual setup, write one
-grounded recommendation per Phase 2 question, then interview the human. For an
-existing install, include the mode evidence, current config path, registered
-project table, and service health in the recommendations before asking what to
-change.
+Do not ask questions in this phase. First re-run the identity and decision
+validators, then inspect only the confirmed target setup and selected status
+source. Write one grounded recommendation per remaining Phase 2 question, then
+interview the human. For an existing install, include the mode evidence, current
+config path, registered project table, and service health in the
+recommendations before asking what to change.
 
 1. **Create an onboarding notes directory.** Keep all discovery artifacts in
    one place so recommendations can cite evidence. Verify:
@@ -254,21 +394,30 @@ change.
    ONBOARDING_DIR="${TMPDIR:-/tmp}/detent-onboarding-<repo-owner>-<repo-name>"
    mkdir -p "$ONBOARDING_DIR"
    test -d "$ONBOARDING_DIR"
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity
+   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision
    ```
 
-2. **Record the initial GitHub GraphQL budget.** Use the REST rate-limit
-   endpoint before the first ProjectV2 discovery command. If the remaining
-   budget is low, record the warning in the recommendation and avoid
-   GraphQL-heavy board inventory until reset or GitHub App auth is available.
-   Verify:
+2. **Record the initial GitHub GraphQL budget for ProjectV2 mode.** Use the
+   REST rate-limit endpoint before the first ProjectV2 discovery command. For
+   `GITHUB_MODE=issue_field` or `GITHUB_MODE=label`, record a skipped artifact
+   and do not spend GraphQL budget on board discovery. If the remaining budget
+   is low, record the warning in the recommendation and avoid GraphQL-heavy
+   board inventory until reset or GitHub App auth is available. Verify:
 
    ```sh
-   gh api rate_limit --jq '.resources.graphql | {limit, used, remaining, reset}' \
-     > "$ONBOARDING_DIR/graphql-rate-limit.before-discovery.json"
-   jq -r '"graphql remaining=\(.remaining) reset=\(.reset)"' \
-     "$ONBOARDING_DIR/graphql-rate-limit.before-discovery.json"
-   jq -e '.remaining >= 1000' "$ONBOARDING_DIR/graphql-rate-limit.before-discovery.json" \
-     || printf 'WARNING: low GitHub GraphQL budget; avoid ProjectV2 inventory loops before reset\n'
+   GITHUB_MODE="$(awk -F= '/^GITHUB_MODE=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+   if test "$GITHUB_MODE" = "project_v2"; then
+     gh api rate_limit --jq '.resources.graphql | {limit, used, remaining, reset}' \
+       > "$ONBOARDING_DIR/graphql-rate-limit.before-discovery.json"
+     jq -r '"graphql remaining=\(.remaining) reset=\(.reset)"' \
+       "$ONBOARDING_DIR/graphql-rate-limit.before-discovery.json"
+     jq -e '.remaining >= 1000' "$ONBOARDING_DIR/graphql-rate-limit.before-discovery.json" \
+       || printf 'WARNING: low GitHub GraphQL budget; avoid ProjectV2 inventory loops before reset\n'
+   else
+     printf '{"skipped":true,"reason":"GITHUB_MODE=%s"}\n' "$GITHUB_MODE" \
+       > "$ONBOARDING_DIR/graphql-rate-limit.before-discovery.json"
+   fi
    ```
 
 3. **Inspect the validation surface.** Prefer a repo-local release gate over an
@@ -338,27 +487,35 @@ change.
    jq -e '.total >= 0' "$ONBOARDING_DIR/issue-counts.json"
    ```
 
-6. **Inspect existing ProjectV2 boards.** Recommend reuse when a board clearly
-   belongs to this repo or workstream; otherwise recommend creating a new board
-   named after the repo or product. This is the ProjectV2 read verification.
-   Verify:
+6. **Inspect existing ProjectV2 boards only for ProjectV2 mode.** Recommend
+   reuse when a board clearly belongs to this repo or workstream; otherwise
+   recommend creating a new board named after the repo or product. Skip this
+   step for `GITHUB_MODE=issue_field` and `GITHUB_MODE=label`. This is the
+   ProjectV2 read verification. Verify:
 
    ```sh
-   gh project list --owner <project-owner> --format json --limit 50 \
-     > "$ONBOARDING_DIR/projects.json"
+   GITHUB_MODE="$(awk -F= '/^GITHUB_MODE=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
+   if test "$GITHUB_MODE" = "project_v2"; then
+     gh project list --owner <project-owner> --format json --limit 50 \
+       > "$ONBOARDING_DIR/projects.json"
+   else
+     printf '{"projects":[],"skipped":true,"reason":"GITHUB_MODE=%s"}\n' "$GITHUB_MODE" \
+       > "$ONBOARDING_DIR/projects.json"
+   fi
    jq -e '.projects | length >= 0' "$ONBOARDING_DIR/projects.json"
    ```
 
-7. **Inspect priority counts for reuse candidates.** `priority_in` depends on
-   the ProjectV2 `Priority` field, so gather counts from the strongest reuse
-   candidate with one paginated inventory pass saved to a local artifact. Do
-   not repeatedly call `gh project item-list --limit 1000`. For a new board,
-   record an empty count table and recommend no `priority_in` filter until
-   issues have been added and ranked. Verify:
+7. **Inspect priority counts for ProjectV2 reuse candidates.** `priority_in`
+   depends on the ProjectV2 `Priority` field, so gather counts from the
+   strongest reuse candidate with one paginated inventory pass saved to a local
+   artifact. Do not repeatedly call `gh project item-list --limit 1000`. For a
+   new board or non-ProjectV2 mode, record an empty count table and recommend no
+   `priority_in` filter until issues have been added and ranked. Verify:
 
    ```sh
+   GITHUB_MODE="$(awk -F= '/^GITHUB_MODE=/ {value=$2} END {print value}' "$ONBOARDING_DIR/answers.env")"
    REUSE_PROJECT_NODE_ID="<reuse-candidate-project-node-id-or-empty>"
-   if test -n "$REUSE_PROJECT_NODE_ID"; then
+   if test "$GITHUB_MODE" = "project_v2" && test -n "$REUSE_PROJECT_NODE_ID"; then
      PRIORITY_QUERY='
        query($project: ID!, $after: String) {
          node(id: $project) {
@@ -440,48 +597,21 @@ recommendation, and default-if-silent. Defaults are recommendations only; they
 do not authorize GitHub, issue, label, `WORKFLOW.md`, or `global.yaml`
 mutations. Record explicit answers in `$ONBOARDING_DIR/answers.env`.
 
-0. **Mode.** Ask only if inspection did not make the path obvious: "Are we
-   doing a new Detent install, verifying an existing install, or adding this
-   repository as a new project to an existing install?" Show
-   `$ONBOARDING_DIR/mode-evidence.txt` and `$ONBOARDING_DIR/global-projects.txt`
-   when present. Default if silent: use the mode with the strongest evidence.
-   Verify:
+0. **Mode.** `DETENT_ONBOARDING_MODE` was selected in Phase 0.5. If discovery
+   shows the chosen mode is wrong, stop, update the identity answers, present
+   the full interpretation again, and rerun
+   `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`.
+   Do not infer mode from an existing registered project or carry it forward as
+   a default.
 
-   ```sh
-   printf '%s\n' \
-     'DETENT_ONBOARDING_MODE=<new-install|existing-install|add-project>' \
-     >> "$ONBOARDING_DIR/answers.env"
-   rg '^DETENT_ONBOARDING_MODE=' "$ONBOARDING_DIR/answers.env"
-   ```
-
-1. **GitHub status source.** Ask: "Use the current/default ProjectV2 board
-   mode, boardless issue-field mode, or repository label mode?" Recommend
-   ProjectV2 when the team already plans and ranks work on a GitHub Project
-   board, or when preserving an existing Detent setup is more important than
-   reducing setup. Recommend boardless issue-field mode when the repository
-   already uses GitHub Issues as the source of truth, has an organization issue
-   `Status` field, and the Detent dashboard should be the Kanban surface.
-   Recommend label mode when the team wants GitHub Issues plus repository
-   labels only, with no ProjectV2 board and no organization issue fields.
-   This answer maps to `tracker.github_status_source: project_v2`,
-   `tracker.github_status_source: issue_field`, or
-   `tracker.github_status_source: label` in `WORKFLOW.md`.
-   Default if silent: ProjectV2 for existing Detent installs, label mode when
-   the operator explicitly asks for issues plus labels only, otherwise
-   boardless issue-field mode for a new project with an existing matching issue
-   field. Verify:
-
-   ```sh
-   printf '%s\n' \
-     'GITHUB_MODE=<project_v2|issue_field|label>' \
-     >> "$ONBOARDING_DIR/answers.env"
-   rg '^GITHUB_MODE=' "$ONBOARDING_DIR/answers.env"
-   detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision
-   ```
-
-   Hard stop: do not inspect your recommendation as if it selected the mode,
-   and do not continue to Phase 3, issue-field, label, `WORKFLOW.md`, or
-   `global.yaml` mutation without this explicit `GITHUB_MODE` answer.
+1. **GitHub status source.** `GITHUB_MODE` was selected in Phase 0.6. If
+   discovery shows the chosen status source is wrong, stop, update the explicit
+   answer, rerun
+   `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision`,
+   and repeat Phase 1 for the selected mode. Do not inspect your recommendation
+   as if it selected the mode, and do not continue to Phase 3, issue-field,
+   label, `WORKFLOW.md`, or `global.yaml` mutation without this explicit
+   `GITHUB_MODE` answer.
 
 2. **ProjectV2 board.** Ask this only when `GITHUB_MODE=project_v2`: "Reuse an
    existing ProjectV2 board or create a new one?" List the boards from

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -3,9 +3,13 @@ package cli
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"fmt"
 	"io"
+	"net/url"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -14,16 +18,29 @@ import (
 )
 
 const (
+	onboardingAnswersPhaseIdentity = "identity"
 	onboardingAnswersPhaseDecision = "decision"
 	onboardingAnswersPhaseMutation = "mutation"
 )
 
+var (
+	onboardingAnswerIdentifierPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+$`)
+	onboardingAnswerRepositoryPattern = regexp.MustCompile(`^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$`)
+)
+
 type onboardingAnswersValidationResult struct {
-	Status            string `json:"status"`
-	Path              string `json:"path"`
-	Phase             string `json:"phase"`
-	GitHubMode        string `json:"github_mode"`
-	MutationConfirmed bool   `json:"mutation_confirmed"`
+	Status                string   `json:"status"`
+	Path                  string   `json:"path"`
+	Phase                 string   `json:"phase"`
+	CustomerID            string   `json:"customer_id"`
+	DetentProjectID       string   `json:"detent_project_id"`
+	TargetRepository      string   `json:"target_repository"`
+	TargetSourceRoot      string   `json:"target_source_root"`
+	ReferenceRepositories []string `json:"reference_repositories"`
+	DetentOnboardingMode  string   `json:"detent_onboarding_mode"`
+	IdentityConfirmed     bool     `json:"identity_confirmed"`
+	GitHubMode            string   `json:"github_mode"`
+	MutationConfirmed     bool     `json:"mutation_confirmed"`
 }
 
 type onboardingAnswers struct {
@@ -67,7 +84,7 @@ func newOnboardingValidateAnswersCommand() *cobra.Command {
 		},
 	}
 	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
-	cmd.Flags().StringVar(&phase, "phase", onboardingAnswersPhaseMutation, "validation phase: decision or mutation")
+	cmd.Flags().StringVar(&phase, "phase", onboardingAnswersPhaseMutation, "validation phase: identity, decision, or mutation")
 	return cmd
 }
 
@@ -105,7 +122,7 @@ func validateOnboardingAnswersFile(path string, phase string) (onboardingAnswers
 	if len(problems) > 0 {
 		return onboardingAnswersValidationResult{}, NewValidationError(
 			strings.Join(problems, "; "),
-			"Ask the status-source question, record the explicit answer in answers.env, and rerun the validator before any mutation.",
+			onboardingAnswersValidationHint(normalizedPhase),
 			nil,
 		)
 	}
@@ -116,12 +133,14 @@ func normalizeOnboardingAnswersPhase(phase string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(phase)) {
 	case "", onboardingAnswersPhaseMutation:
 		return onboardingAnswersPhaseMutation, nil
+	case onboardingAnswersPhaseIdentity:
+		return onboardingAnswersPhaseIdentity, nil
 	case onboardingAnswersPhaseDecision:
 		return onboardingAnswersPhaseDecision, nil
 	default:
 		return "", NewValidationError(
-			"--phase must be decision or mutation",
-			"Use --phase decision after the status-source answer or --phase mutation before setup changes.",
+			"--phase must be identity, decision, or mutation",
+			"Use --phase identity before repository-specific discovery, --phase decision after the status-source answer, or --phase mutation before setup changes.",
 			nil,
 		)
 	}
@@ -186,6 +205,15 @@ func trimOnboardingAnswerValue(value string) string {
 
 func validateOnboardingAnswers(answers onboardingAnswers, phase string, result *onboardingAnswersValidationResult) []string {
 	problems := append([]string(nil), answers.Problems...)
+	identityProblems := validateOnboardingIdentityAnswers(answers, result)
+	problems = append(problems, identityProblems...)
+	if len(identityProblems) > 0 && strings.TrimSpace(answers.Values["GITHUB_MODE"]) != "" {
+		problems = append(problems, "GITHUB_MODE cannot be set before identity answers are valid")
+	}
+	if phase == onboardingAnswersPhaseIdentity {
+		return problems
+	}
+
 	mode := answers.Values["GITHUB_MODE"]
 	switch mode {
 	case workflowconfig.GitHubStatusSourceProjectV2, workflowconfig.GitHubStatusSourceIssueField, workflowconfig.GitHubStatusSourceLabel:
@@ -197,6 +225,156 @@ func validateOnboardingAnswers(answers onboardingAnswers, phase string, result *
 		problems = append(problems, validateOnboardingMutationAnswers(answers, mode, result)...)
 	}
 	return problems
+}
+
+func validateOnboardingIdentityAnswers(answers onboardingAnswers, result *onboardingAnswersValidationResult) []string {
+	var problems []string
+
+	customerID := strings.TrimSpace(answers.Values["CUSTOMER_ID"])
+	if customerID == "" {
+		problems = append(problems, "CUSTOMER_ID is required")
+	} else if !onboardingAnswerIdentifierPattern.MatchString(customerID) {
+		problems = append(problems, "CUSTOMER_ID must contain only letters, digits, underscore, dot, or hyphen")
+	} else {
+		result.CustomerID = customerID
+	}
+
+	projectID := strings.TrimSpace(answers.Values["DETENT_PROJECT_ID"])
+	if projectID == "" {
+		problems = append(problems, "DETENT_PROJECT_ID is required")
+	} else if !onboardingAnswerIdentifierPattern.MatchString(projectID) {
+		problems = append(problems, "DETENT_PROJECT_ID must contain only letters, digits, underscore, dot, or hyphen")
+	} else {
+		result.DetentProjectID = projectID
+	}
+
+	targetRepository := strings.TrimSpace(answers.Values["TARGET_REPOSITORY"])
+	targetRepositoryValid := false
+	if targetRepository == "" {
+		problems = append(problems, "TARGET_REPOSITORY is required")
+	} else if !onboardingAnswerRepositoryPattern.MatchString(targetRepository) {
+		problems = append(problems, "TARGET_REPOSITORY must look like owner/name")
+	} else {
+		targetRepositoryValid = true
+		result.TargetRepository = targetRepository
+	}
+
+	referenceRepositories, referenceProblems := validateOnboardingReferenceRepositories(answers, targetRepository)
+	problems = append(problems, referenceProblems...)
+	result.ReferenceRepositories = referenceRepositories
+
+	targetSourceRoot := strings.TrimSpace(answers.Values["TARGET_SOURCE_ROOT"])
+	sourceProblems := validateOnboardingTargetSourceRoot(targetSourceRoot, targetRepository, targetRepositoryValid)
+	problems = append(problems, sourceProblems...)
+	if len(sourceProblems) == 0 {
+		result.TargetSourceRoot = targetSourceRoot
+	}
+
+	mode := strings.TrimSpace(answers.Values["DETENT_ONBOARDING_MODE"])
+	switch mode {
+	case "new-install", "existing-install", "add-project":
+		result.DetentOnboardingMode = mode
+	case "":
+		problems = append(problems, "DETENT_ONBOARDING_MODE is required")
+	default:
+		problems = append(problems, "DETENT_ONBOARDING_MODE must be new-install, existing-install, or add-project")
+	}
+
+	result.IdentityConfirmed = answers.Values["IDENTITY_CONFIRMED"] == "true"
+	if !result.IdentityConfirmed {
+		problems = append(problems, "IDENTITY_CONFIRMED must be true")
+	}
+
+	return problems
+}
+
+func validateOnboardingReferenceRepositories(answers onboardingAnswers, targetRepository string) ([]string, []string) {
+	raw, ok := answers.Values["REFERENCE_REPOSITORIES"]
+	if !ok {
+		return nil, []string{"REFERENCE_REPOSITORIES is required"}
+	}
+
+	var repositories []string
+	var problems []string
+	for _, part := range strings.Split(raw, ",") {
+		repository := strings.TrimSpace(part)
+		if repository == "" {
+			continue
+		}
+		if !onboardingAnswerRepositoryPattern.MatchString(repository) {
+			problems = append(problems, "REFERENCE_REPOSITORIES entries must look like owner/name")
+			continue
+		}
+		if targetRepository != "" && strings.EqualFold(repository, targetRepository) {
+			problems = append(problems, "REFERENCE_REPOSITORIES must not include TARGET_REPOSITORY")
+			continue
+		}
+		repositories = append(repositories, repository)
+	}
+	return repositories, problems
+}
+
+func validateOnboardingTargetSourceRoot(path string, targetRepository string, targetRepositoryValid bool) []string {
+	if path == "" {
+		return []string{"TARGET_SOURCE_ROOT is required"}
+	}
+	if !filepath.IsAbs(path) {
+		return []string{"TARGET_SOURCE_ROOT must be absolute"}
+	}
+
+	var problems []string
+	if err := defaultGitWorkTree(context.Background(), path); err != nil {
+		return []string{"TARGET_SOURCE_ROOT must be a git checkout: " + err.Error()}
+	}
+	remote, err := defaultGitRemoteURL(context.Background(), path)
+	if err != nil {
+		return []string{"TARGET_SOURCE_ROOT must have an origin remote: " + err.Error()}
+	}
+	if targetRepositoryValid {
+		repository, ok := gitHubRepositoryFromRemote(remote)
+		if !ok || !strings.EqualFold(repository, targetRepository) {
+			problems = append(problems, "TARGET_SOURCE_ROOT origin remote must match TARGET_REPOSITORY "+targetRepository)
+		}
+	}
+	return problems
+}
+
+func gitHubRepositoryFromRemote(remote string) (string, bool) {
+	remote = strings.TrimSpace(remote)
+	if remote == "" {
+		return "", false
+	}
+
+	if strings.HasPrefix(remote, "git@github.com:") {
+		repository := strings.TrimPrefix(remote, "git@github.com:")
+		return normalizeGitHubRepositoryPath(repository)
+	}
+
+	parsed, err := url.Parse(remote)
+	if err != nil || !strings.EqualFold(parsed.Hostname(), "github.com") {
+		return "", false
+	}
+	return normalizeGitHubRepositoryPath(parsed.Path)
+}
+
+func normalizeGitHubRepositoryPath(path string) (string, bool) {
+	path = strings.Trim(strings.TrimSpace(path), "/")
+	path = strings.TrimSuffix(path, ".git")
+	if !onboardingAnswerRepositoryPattern.MatchString(path) {
+		return "", false
+	}
+	return path, true
+}
+
+func onboardingAnswersValidationHint(phase string) string {
+	switch phase {
+	case onboardingAnswersPhaseIdentity:
+		return "Ask the identity checkpoint questions, record confirmed CUSTOMER_ID, DETENT_PROJECT_ID, TARGET_REPOSITORY, TARGET_SOURCE_ROOT, REFERENCE_REPOSITORIES, DETENT_ONBOARDING_MODE, and IDENTITY_CONFIRMED=true, then rerun the validator before repository-specific discovery."
+	case onboardingAnswersPhaseDecision:
+		return "Complete and validate the identity phase first, then ask the status-source question, record the explicit GITHUB_MODE answer in answers.env, and rerun the validator before discovery recommendations become selected answers."
+	default:
+		return "Complete and validate the identity and status-source answers, record the explicit mutation confirmation in answers.env, and rerun the validator before any mutation."
+	}
 }
 
 func validateOnboardingMutationAnswers(answers onboardingAnswers, mode string, result *onboardingAnswersValidationResult) []string {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -15,7 +16,10 @@ import (
 func TestOnboardingValidateAnswersCommandRejectsMissingGitHubMode(t *testing.T) {
 	t.Parallel()
 
-	answersPath := writeOnboardingAnswers(t, "MUTATION_CONFIRMED=true\n")
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n"))
 	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
 	cmd.SetOut(&bytes.Buffer{})
 	cmd.SetErr(&bytes.Buffer{})
@@ -30,10 +34,104 @@ func TestOnboardingValidateAnswersCommandRejectsMissingGitHubMode(t *testing.T) 
 	}
 }
 
+func TestOnboardingValidateAnswersCommandAcceptsIdentityPhase(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "onboarding", "validate-answers", "--answers", answersPath, "--phase", "identity"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Status                string   `json:"status"`
+		Phase                 string   `json:"phase"`
+		CustomerID            string   `json:"customer_id"`
+		DetentProjectID       string   `json:"detent_project_id"`
+		TargetRepository      string   `json:"target_repository"`
+		TargetSourceRoot      string   `json:"target_source_root"`
+		ReferenceRepositories []string `json:"reference_repositories"`
+		DetentOnboardingMode  string   `json:"detent_onboarding_mode"`
+		IdentityConfirmed     bool     `json:"identity_confirmed"`
+		MutationConfirmed     bool     `json:"mutation_confirmed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Status != "ok" || got.Phase != "identity" || !got.IdentityConfirmed || got.MutationConfirmed {
+		t.Fatalf("validation result = %#v, want accepted identity phase", got)
+	}
+	if got.CustomerID != "digitaldrywood" || got.DetentProjectID != "detent" || got.TargetRepository != "digitaldrywood/detent" {
+		t.Fatalf("identity fields = %#v, want explicit target identity", got)
+	}
+	if got.TargetSourceRoot == "" || got.DetentOnboardingMode != "add-project" {
+		t.Fatalf("identity fields = %#v, want source root and onboarding mode", got)
+	}
+	if len(got.ReferenceRepositories) != 2 || got.ReferenceRepositories[0] != "digitaldrywood/detent-orchestration" || got.ReferenceRepositories[1] != "corylanou/website-template" {
+		t.Fatalf("reference repositories = %#v, want explicit references", got.ReferenceRepositories)
+	}
+}
+
+func TestOnboardingValidateAnswersCommandRejectsGitHubModeBeforeIdentity(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, "GITHUB_MODE=label\n")
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "validate-answers", "--answers", answersPath, "--phase", "decision"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want validation error")
+	}
+	for _, want := range []string{
+		"CUSTOMER_ID is required",
+		"GITHUB_MODE cannot be set before identity answers are valid",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Execute() error missing %q:\n%s", want, err.Error())
+		}
+	}
+}
+
+func TestOnboardingValidateAnswersCommandRejectsWrongTargetRemote(t *testing.T) {
+	t.Parallel()
+
+	sourceRoot := initOnboardingGitRepository(t, "https://github.com/example/other.git")
+	answersPath := writeOnboardingAnswers(t, strings.Join([]string{
+		"CUSTOMER_ID=digitaldrywood",
+		"DETENT_PROJECT_ID=detent",
+		"TARGET_REPOSITORY=digitaldrywood/detent",
+		"TARGET_SOURCE_ROOT=" + sourceRoot,
+		"REFERENCE_REPOSITORIES=",
+		"DETENT_ONBOARDING_MODE=add-project",
+		"IDENTITY_CONFIRMED=true",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "validate-answers", "--answers", answersPath, "--phase", "identity"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want validation error")
+	}
+	if !strings.Contains(err.Error(), "TARGET_SOURCE_ROOT origin remote must match TARGET_REPOSITORY digitaldrywood/detent") {
+		t.Fatalf("Execute() error missing remote mismatch validation:\n%s", err.Error())
+	}
+}
+
 func TestOnboardingValidateAnswersCommandRequiresFinalMutationConfirmation(t *testing.T) {
 	t.Parallel()
 
-	answersPath := writeOnboardingAnswers(t, strings.Join([]string{
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
 		"STATUS_LABEL_PREFIX=detent:",
 		"MUTATION_CONFIRMED=true",
@@ -57,7 +155,7 @@ func TestOnboardingValidateAnswersCommandRequiresFinalMutationConfirmation(t *te
 func TestOnboardingValidateAnswersCommandRequiresModeSpecificMutationAnswers(t *testing.T) {
 	t.Parallel()
 
-	answersPath := writeOnboardingAnswers(t, strings.Join([]string{
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=project_v2",
 		"MUTATION_CONFIRMED=true",
 		"",
@@ -79,7 +177,7 @@ func TestOnboardingValidateAnswersCommandRequiresModeSpecificMutationAnswers(t *
 func TestOnboardingValidateAnswersCommandAcceptsDecisionPhase(t *testing.T) {
 	t.Parallel()
 
-	answersPath := writeOnboardingAnswers(t, "GITHUB_MODE=issue_field\n")
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+"GITHUB_MODE=issue_field\n")
 	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
@@ -107,7 +205,7 @@ func TestOnboardingValidateAnswersCommandAcceptsDecisionPhase(t *testing.T) {
 func TestOnboardingValidateAnswersCommandAcceptsLabelMode(t *testing.T) {
 	t.Parallel()
 
-	answersPath := writeOnboardingAnswers(t, strings.Join([]string{
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
 		"STATUS_LABEL_PREFIX=detent:",
 		"MUTATION_CONFIRMED=true",
@@ -138,6 +236,22 @@ func TestOnboardingValidateAnswersCommandAcceptsLabelMode(t *testing.T) {
 	}
 }
 
+func validIdentityOnboardingAnswers(t *testing.T) string {
+	t.Helper()
+
+	sourceRoot := initOnboardingGitRepository(t, "git@github.com:digitaldrywood/detent.git")
+	return strings.Join([]string{
+		"CUSTOMER_ID=digitaldrywood",
+		"DETENT_PROJECT_ID=detent",
+		"TARGET_REPOSITORY=digitaldrywood/detent",
+		"TARGET_SOURCE_ROOT=" + sourceRoot,
+		"REFERENCE_REPOSITORIES=digitaldrywood/detent-orchestration,corylanou/website-template",
+		"DETENT_ONBOARDING_MODE=add-project",
+		"IDENTITY_CONFIRMED=true",
+		"",
+	}, "\n")
+}
+
 func writeOnboardingAnswers(t *testing.T, content string) string {
 	t.Helper()
 
@@ -146,4 +260,23 @@ func writeOnboardingAnswers(t *testing.T, content string) string {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 	return path
+}
+
+func initOnboardingGitRepository(t *testing.T, remote string) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "remote", "add", "origin", remote)
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s error = %v\n%s", strings.Join(args, " "), err, output)
+	}
 }

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -34,6 +34,50 @@ func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
 	assertContains(t, readme, "Defaults are recommendations only")
 }
 
+func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+
+	identityIndex := strings.Index(onboarding, "## Phase 0.5")
+	decisionIndex := strings.Index(onboarding, "## Phase 0.6")
+	discoveryIndex := strings.Index(onboarding, "## Phase 1")
+	if identityIndex < 0 {
+		t.Fatal("docs/ONBOARDING.md missing Phase 0.5 identity gate")
+	}
+	if decisionIndex < 0 {
+		t.Fatal("docs/ONBOARDING.md missing Phase 0.6 status-source decision")
+	}
+	if discoveryIndex < 0 {
+		t.Fatal("docs/ONBOARDING.md missing Phase 1 discovery")
+	}
+	if identityIndex > discoveryIndex {
+		t.Fatal("docs/ONBOARDING.md places identity gate after Phase 1 discovery")
+	}
+	if decisionIndex > discoveryIndex {
+		t.Fatal("docs/ONBOARDING.md places status-source decision after Phase 1 discovery")
+	}
+
+	for _, want := range []string{
+		"CUSTOMER_ID=<customer-or-workstream-id>",
+		"DETENT_PROJECT_ID=<local-detent-project-id>",
+		"TARGET_REPOSITORY=<repo-owner>/<repo-name>",
+		"TARGET_SOURCE_ROOT=<absolute-local-checkout-path>",
+		"REFERENCE_REPOSITORIES=<comma-separated-owner/repo-list-or-empty>",
+		"DETENT_ONBOARDING_MODE=<new-install|existing-install|add-project>",
+		"IDENTITY_CONFIRMED=true",
+		`detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`,
+		"wrong target repository",
+	} {
+		assertContains(t, onboarding, want)
+	}
+
+	assertContains(t, readme, "Distinguish reference repositories from the target repository")
+	assertContains(t, readme, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`)
+	assertContains(t, readme, "Ask and record `GITHUB_MODE` explicitly")
+}
+
 func readRepositoryTextFile(t *testing.T, path string) string {
 	t.Helper()
 


### PR DESCRIPTION
## Summary

- add an identity validation phase for onboarding answers before target-specific discovery
- require confirmed identity answers before status-source decision and mutation validation
- update onboarding docs and README prompt with reference-repository separation and wrong-target guardrails

Fixes #550

## Test Plan

- [x] `go test ./internal/cli -run OnboardingValidateAnswers`
- [x] `go test . -run OnboardingDocsRequire`
- [x] `go test ./internal/cli`
- [x] `go test .`
- [x] `make check`