### PR TITLE
fix(web): show completed PR handoffs

### DIFF
--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -142,6 +142,7 @@ func demoScenarioDefinitions() []demoScenario {
 		{ID: "kanban-dense-overflow", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "dense-kanban", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
 		{ID: "kanban-transition-blocked", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "transition-blocked", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
 		{ID: "kanban-terminal-states", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "terminal", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
+		{ID: "kanban-handoff-window", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "handoff-window", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
 		{ID: "runs-active-work", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "healthy", ProjectID: demoPrimaryProjectID},
 		{ID: "runs-idle", Route: "/projects/agent-lab/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "project-empty", ProjectID: "agent-lab"},
 		{ID: "runs-backoff-heavy", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "backoff-heavy", ProjectID: demoPrimaryProjectID},
@@ -619,6 +620,8 @@ func demoSnapshotForScenario(scenario demoScenario) telemetry.Snapshot {
 		snapshot = demoDenseSnapshot()
 	case "hot-path", "model-heavy", "filtered-project":
 		snapshot = demoHotPathSnapshot()
+	case "handoff-window":
+		snapshot = demoHandoffWindowSnapshot()
 	}
 	if scenario.ProjectID != "" && scenario.ProjectID != demoPrimaryProjectID && scenario.Variant == "project-empty" {
 		snapshot.Projects = demoProjectSnapshots(demoProjectsForVariant("project-empty"))
@@ -870,6 +873,31 @@ func demoHotPathSnapshot() telemetry.Snapshot {
 	snapshot.Projects = demoProjectSnapshots(demoProjectsForVariant("hot-path"))
 	snapshot.Tokens = telemetry.Tokens{Input: 180000, Output: 52000, Total: 232000, RuntimeSeconds: 6400}
 	snapshot.Budget.CurrentSpendUSD = 36.8
+	return snapshot
+}
+
+func demoHandoffWindowSnapshot() telemetry.Snapshot {
+	snapshot := demoHealthySnapshot()
+	handoff := demoCompleted(demoPrimaryProjectID, "demo-handoff-window", "digitaldrywood/detent-core#5294", "Keep completed implementation visible during tracker refresh", "completed", 3, "gpt-5-codex", 41000)
+	handoff.PullRequest = &telemetry.PullRequest{
+		Number:             5294,
+		URL:                demoPRURL(handoff.Identifier, 5294),
+		BranchName:         "detent/demo-handoff-window",
+		State:              "OPEN",
+		MergeableState:     "clean",
+		CIStatus:           "success",
+		CheckRunCount:      5,
+		StatusContextCount: 1,
+		CIDurationSeconds:  260,
+		CodexReviewState:   "CLEAN",
+	}
+	snapshot.Completed = append([]telemetry.Completed{handoff}, snapshot.Completed...)
+	snapshot.Counts.Completed = len(snapshot.Completed)
+	for i := range snapshot.Projects {
+		if snapshot.Projects[i].Project.ID == demoPrimaryProjectID {
+			snapshot.Projects[i].Counts.Completed++
+		}
+	}
 	return snapshot
 }
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -24,6 +24,9 @@ const (
 	prPipelineDoneTodayLimit = 10
 	kanbanActionDialogID     = "kanban-action-dialog"
 	kanbanDialogContentID    = "kanban-dialog-content"
+	handoffVisibilityWindow  = 15 * time.Minute
+	handoffState             = "Handoff"
+	handoffWaitDetail        = "waiting for tracker refresh"
 )
 
 type DashboardData struct {
@@ -1393,6 +1396,8 @@ func projectKanbanCardsByState(data DashboardData) map[string][]projectKanbanCar
 
 func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 	byIssue := map[string]projectKanbanIssueCard{}
+	currentIssues := currentWorkflowIssueKeys(snapshot)
+	now := pipelineNow(snapshot)
 	nextIndex := 0
 	appendIssue := func(issue telemetry.Issue, state string, stageAt time.Time, rank int) {
 		state = strings.TrimSpace(state)
@@ -1435,6 +1440,13 @@ func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 			stageAt = *row.BlockedAt
 		}
 		appendIssue(row.Issue, issueState(row.Issue, "Blocked"), stageAt, 40)
+	}
+	for _, row := range snapshot.Completed {
+		issue, stageAt, ok := completedHandoffIssue(row, currentIssues, now)
+		if !ok {
+			continue
+		}
+		appendIssue(issue, handoffState, stageAt, 1)
 	}
 
 	issues := make([]projectKanbanIssueCard, 0, len(byIssue))
@@ -1852,7 +1864,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		PullRequestLabel: projectKanbanPullRequestLabel(issue),
 		TimeInStage:      prPipelineAge(stageAt, now),
 		TimeInStageTitle: prPipelineAgeTitle(state, stageAt, now),
-		WaitDetail:       prPipelineWaitDetail(issue),
+		WaitDetail:       workflowWaitDetail(state, issue),
 		Stage:            chartText(state, "n/a"),
 		StageAt:          stageAt.UTC(),
 		Labels:           uniqueStrings(issue.Labels),
@@ -2224,6 +2236,7 @@ func prPipelineLanes(snapshot telemetry.Snapshot) []prPipelineLane {
 		"done-today":   {},
 	}
 	seen := map[string]struct{}{}
+	currentIssues := currentWorkflowIssueKeys(snapshot)
 	now := pipelineNow(snapshot)
 
 	for _, issue := range snapshot.Pipeline {
@@ -2245,6 +2258,13 @@ func prPipelineLanes(snapshot telemetry.Snapshot) []prPipelineLane {
 			stageAt = *row.BlockedAt
 		}
 		appendPRPipelineCard(cardsByLane, seen, row.Issue, issueState(row.Issue, "Blocked"), stageAt, now)
+	}
+	for _, row := range snapshot.Completed {
+		issue, stageAt, ok := completedHandoffIssue(row, currentIssues, now)
+		if !ok {
+			continue
+		}
+		appendPRPipelineCard(cardsByLane, seen, issue, handoffState, stageAt, now)
 	}
 
 	prunePRPipelineCards(cardsByLane)
@@ -2337,6 +2357,8 @@ func prPipelineLaneID(state string) string {
 	switch strings.ToLower(strings.ReplaceAll(strings.TrimSpace(state), " ", "")) {
 	case "humanreview", "review", "inreview":
 		return "human-review"
+	case "handoff", "pendingtrackerrefresh":
+		return "human-review"
 	case "merging":
 		return "merging"
 	case "done", "complete", "completed", "closed", "cancelled", "canceled":
@@ -2361,10 +2383,21 @@ func prPipelineCardForIssue(issue telemetry.Issue, state string, laneID string, 
 		CodexReviewClass: prPipelineCodexReviewClass(codexReview),
 		TimeInStage:      prPipelineAge(stageAt, now),
 		TimeInStageTitle: prPipelineAgeTitle(state, stageAt, now),
-		WaitDetail:       prPipelineWaitDetail(issue),
+		WaitDetail:       workflowWaitDetail(state, issue),
 		Stage:            chartText(state, "n/a"),
 		StageAt:          stageAt.UTC(),
 	}
+}
+
+func workflowWaitDetail(state string, issue telemetry.Issue) string {
+	parts := []string{}
+	if projectKanbanStateKey(state) == projectKanbanStateKey(handoffState) {
+		parts = append(parts, handoffWaitDetail)
+	}
+	if detail := prPipelineWaitDetail(issue); detail != "" {
+		parts = append(parts, detail)
+	}
+	return strings.Join(parts, " / ")
 }
 
 func prPipelineWaitDetail(issue telemetry.Issue) string {
@@ -2447,6 +2480,85 @@ func pipelineNow(snapshot telemetry.Snapshot) time.Time {
 		}
 	}
 	return latest.UTC()
+}
+
+func currentWorkflowIssueKeys(snapshot telemetry.Snapshot) map[string]struct{} {
+	out := map[string]struct{}{}
+	add := func(issue telemetry.Issue) {
+		key := workflowIssueKey(issue)
+		if key != "" {
+			out[key] = struct{}{}
+		}
+	}
+	for _, issue := range snapshot.BoardIssues {
+		add(issue)
+	}
+	for _, issue := range snapshot.Pipeline {
+		add(issue)
+	}
+	for _, row := range snapshot.Running {
+		add(row.Issue)
+	}
+	for _, row := range snapshot.Queue {
+		add(row.Issue)
+	}
+	for _, row := range snapshot.Blocked {
+		add(row.Issue)
+	}
+	return out
+}
+
+func workflowIssueKey(issue telemetry.Issue) string {
+	if id := strings.TrimSpace(issue.ID); id != "" {
+		return "id:" + id
+	}
+	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" {
+		return "identifier:" + identifier
+	}
+	return ""
+}
+
+func completedHandoffIssue(row telemetry.Completed, currentIssues map[string]struct{}, now time.Time) (telemetry.Issue, time.Time, bool) {
+	if !completedHandoffFinalState(row.FinalState) {
+		return telemetry.Issue{}, time.Time{}, false
+	}
+	if !openLinkedPullRequest(row.PullRequest) {
+		return telemetry.Issue{}, time.Time{}, false
+	}
+	if completedHandoffExpired(row.CompletedAt, now) {
+		return telemetry.Issue{}, time.Time{}, false
+	}
+	if key := workflowIssueKey(row.Issue); key != "" {
+		if _, ok := currentIssues[key]; ok {
+			return telemetry.Issue{}, time.Time{}, false
+		}
+	}
+	issue := row.Issue
+	issue.State = handoffState
+	return issue, row.CompletedAt, true
+}
+
+func completedHandoffFinalState(state string) bool {
+	return strings.EqualFold(strings.TrimSpace(state), "completed")
+}
+
+func completedHandoffExpired(completedAt time.Time, now time.Time) bool {
+	if completedAt.IsZero() || now.IsZero() {
+		return false
+	}
+	return now.UTC().Sub(completedAt.UTC()) > handoffVisibilityWindow
+}
+
+func openLinkedPullRequest(pr *telemetry.PullRequest) bool {
+	if pr == nil {
+		return false
+	}
+	switch strings.ToUpper(strings.TrimSpace(pr.State)) {
+	case "CLOSED", "MERGED":
+		return false
+	default:
+		return pr.Number > 0 || strings.TrimSpace(pr.URL) != ""
+	}
 }
 
 func pipelineIssueStageTime(issue telemetry.Issue) time.Time {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1040,6 +1040,157 @@ func TestProjectKanbanBoardDoesNotTreatCompletedSessionsAsCurrentDone(t *testing
 	}
 }
 
+func TestProjectKanbanBoardShowsCompletedOpenPRHandoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	board := projectKanbanBoardView(DashboardData{
+		Kanban: KanbanData{
+			States: []string{"Todo", "Human Review", "Merging", "Done"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Completed: []telemetry.Completed{
+				{
+					Issue: telemetry.Issue{
+						ID:         "issue-550",
+						Identifier: "digitaldrywood/detent#550",
+						URL:        "https://github.com/digitaldrywood/detent/issues/550",
+						Title:      "Keep completed handoff visible",
+						PullRequest: &telemetry.PullRequest{
+							Number:           552,
+							URL:              "https://github.com/digitaldrywood/detent/pull/552",
+							State:            "OPEN",
+							CIStatus:         "success",
+							CodexReviewState: "clean",
+						},
+					},
+					CompletedAt: now.Add(-2 * time.Minute),
+					FinalState:  "completed",
+				},
+			},
+		},
+	})
+
+	got := collectKanbanCards(board.Lanes)
+	want := []kanbanCardSnapshot{
+		{
+			Lane:             "Handoff",
+			IssueNumber:      "#550",
+			Title:            "Keep completed handoff visible",
+			URL:              "https://github.com/digitaldrywood/detent/issues/550",
+			CIStatus:         "pass",
+			CodexReviewState: "clean",
+			TimeInStage:      "2m 0s",
+			WaitDetail:       "waiting for tracker refresh",
+			Metadata:         "PR #552",
+		},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("kanban cards len = %d, want %d; got %#v", len(got), len(want), got)
+	}
+	if got[0] != want[0] {
+		t.Fatalf("kanban card = %#v, want %#v", got[0], want[0])
+	}
+}
+
+func TestProjectKanbanBoardSuppressesCompletedHandoffWhenTrackerOwnsIssue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	stageAt := now.Add(-30 * time.Second)
+	board := projectKanbanBoardView(DashboardData{
+		Kanban: KanbanData{
+			States: []string{"Todo", "Human Review", "Merging", "Done"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Pipeline: []telemetry.Issue{
+				{
+					ID:             "issue-550",
+					Identifier:     "digitaldrywood/detent#550",
+					Title:          "Keep completed handoff visible",
+					State:          "Human Review",
+					StageUpdatedAt: &stageAt,
+					PullRequest: &telemetry.PullRequest{
+						Number:           552,
+						State:            "OPEN",
+						CIStatus:         "success",
+						CodexReviewState: "clean",
+					},
+				},
+			},
+			Completed: []telemetry.Completed{
+				{
+					Issue: telemetry.Issue{
+						ID:         "issue-550",
+						Identifier: "digitaldrywood/detent#550",
+						Title:      "Keep completed handoff visible",
+						PullRequest: &telemetry.PullRequest{
+							Number:           552,
+							State:            "OPEN",
+							CIStatus:         "success",
+							CodexReviewState: "clean",
+						},
+					},
+					CompletedAt: now.Add(-2 * time.Minute),
+					FinalState:  "completed",
+				},
+			},
+		},
+	})
+
+	got := collectKanbanCards(board.Lanes)
+	want := []kanbanCardSnapshot{
+		{Lane: "Human Review", IssueNumber: "#550", Title: "Keep completed handoff visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s", Metadata: "PR #552"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("kanban cards len = %d, want %d; got %#v", len(got), len(want), got)
+	}
+	if got[0] != want[0] {
+		t.Fatalf("kanban card = %#v, want %#v", got[0], want[0])
+	}
+}
+
+func TestCompletedOpenPRHandoffExpires(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Completed: []telemetry.Completed{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-550",
+					Identifier: "digitaldrywood/detent#550",
+					Title:      "Keep completed handoff visible",
+					PullRequest: &telemetry.PullRequest{
+						Number:   552,
+						State:    "OPEN",
+						CIStatus: "success",
+					},
+				},
+				CompletedAt: now.Add(-handoffVisibilityWindow - time.Second),
+				FinalState:  "completed",
+			},
+		},
+	}
+
+	board := projectKanbanBoardView(DashboardData{
+		Kanban: KanbanData{
+			States: []string{"Todo", "Human Review", "Merging", "Done"},
+		},
+		Snapshot: snapshot,
+	})
+	if got := collectKanbanCards(board.Lanes); len(got) != 0 {
+		t.Fatalf("kanban cards len = %d, want 0; got %#v", len(got), got)
+	}
+
+	if got := collectPipelineCards(prPipelineLanes(snapshot)); len(got) != 0 {
+		t.Fatalf("pipeline cards len = %d, want 0; got %#v", len(got), got)
+	}
+}
+
 func TestProjectKanbanBoardMarksOnlyNonEmptyLanesVisibleByDefault(t *testing.T) {
 	t.Parallel()
 
@@ -1261,6 +1412,105 @@ func TestPRPipelineLanesDoNotTreatCompletedSessionAsCurrentDone(t *testing.T) {
 	}
 }
 
+func TestPRPipelineLanesShowCompletedOpenPRHandoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Completed: []telemetry.Completed{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-550",
+					Identifier: "digitaldrywood/detent#550",
+					Title:      "Keep completed handoff visible",
+					PullRequest: &telemetry.PullRequest{
+						Number:           552,
+						URL:              "https://github.com/digitaldrywood/detent/pull/552",
+						State:            "OPEN",
+						CIStatus:         "success",
+						CodexReviewState: "clean",
+					},
+				},
+				CompletedAt: now.Add(-2 * time.Minute),
+				FinalState:  "completed",
+			},
+		},
+	}
+
+	got := collectPipelineCards(prPipelineLanes(snapshot))
+	want := []pipelineCardSnapshot{
+		{
+			Lane:             "Human Review",
+			IssueNumber:      "#552",
+			Title:            "Keep completed handoff visible",
+			CIStatus:         "pass",
+			CodexReviewState: "clean",
+			TimeInStage:      "2m 0s",
+			WaitDetail:       "waiting for tracker refresh",
+		},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("pipeline cards len = %d, want %d; got %#v", len(got), len(want), got)
+	}
+	if got[0] != want[0] {
+		t.Fatalf("pipeline card = %#v, want %#v", got[0], want[0])
+	}
+}
+
+func TestPRPipelineLanesSuppressCompletedHandoffWhenTrackerOwnsIssue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	stageAt := now.Add(-30 * time.Second)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Pipeline: []telemetry.Issue{
+			{
+				ID:             "issue-550",
+				Identifier:     "digitaldrywood/detent#550",
+				Title:          "Keep completed handoff visible",
+				State:          "Merging",
+				StageUpdatedAt: &stageAt,
+				PullRequest: &telemetry.PullRequest{
+					Number:           552,
+					State:            "OPEN",
+					CIStatus:         "success",
+					CodexReviewState: "clean",
+				},
+			},
+		},
+		Completed: []telemetry.Completed{
+			{
+				Issue: telemetry.Issue{
+					ID:         "issue-550",
+					Identifier: "digitaldrywood/detent#550",
+					Title:      "Keep completed handoff visible",
+					PullRequest: &telemetry.PullRequest{
+						Number:           552,
+						State:            "OPEN",
+						CIStatus:         "success",
+						CodexReviewState: "clean",
+					},
+				},
+				CompletedAt: now.Add(-2 * time.Minute),
+				FinalState:  "completed",
+			},
+		},
+	}
+
+	got := collectPipelineCards(prPipelineLanes(snapshot))
+	want := []pipelineCardSnapshot{
+		{Lane: "Merging", IssueNumber: "#552", Title: "Keep completed handoff visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("pipeline cards len = %d, want %d; got %#v", len(got), len(want), got)
+	}
+	if got[0] != want[0] {
+		t.Fatalf("pipeline card = %#v, want %#v", got[0], want[0])
+	}
+}
+
 func TestPRPipelineLanesCapDoneTodayToRecentCards(t *testing.T) {
 	t.Parallel()
 
@@ -1355,6 +1605,7 @@ type kanbanCardSnapshot struct {
 	CIStatus         string
 	CodexReviewState string
 	TimeInStage      string
+	WaitDetail       string
 	Labels           string
 	Assignees        string
 	Blockers         string
@@ -1373,6 +1624,7 @@ func collectKanbanCards(lanes []projectKanbanLane) []kanbanCardSnapshot {
 				CIStatus:         card.CIStatus,
 				CodexReviewState: card.CodexReviewState,
 				TimeInStage:      card.TimeInStage,
+				WaitDetail:       card.WaitDetail,
 				Labels:           strings.Join(card.Labels, ", "),
 				Assignees:        strings.Join(card.Assignees, ", "),
 				Blockers:         strings.Join(card.Blockers, ", "),


### PR DESCRIPTION
## Summary

- Keep completed implementation sessions with open linked PRs visible as handoff cards until tracker state catches up.
- Suppress handoff cards once the same issue appears in live tracker, queue, running, or blocked rows.
- Add a handoff-window demo scenario for visual verification.

Fixes #553

## Test Plan

- [x] `go test ./internal/web/templates ./internal/web`
- [x] `make check`