### PR TITLE
docs(onboarding): refresh workflow templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -1073,15 +1073,21 @@ repo is a real, working instance of this setup to copy from.
    git clone <repo-url> <source-root>
    ```
 
-6. **Author the project contract.** Copy the canonical example as a starting
-   point, then edit it. For from-zero board creation, interview questions, issue
-   intake, and the first-dispatch smoke test, follow
+6. **Author the project contract.** Copy the mode-specific template as a
+   starting point, then edit it. For from-zero board creation, interview
+   questions, issue intake, and the first-dispatch smoke test, follow
    [Project Onboarding](docs/ONBOARDING.md):
 
    ```sh
-   curl -fsSL https://raw.githubusercontent.com/digitaldrywood/detent-orchestration/main/WORKFLOW.md \
+   GITHUB_MODE="${GITHUB_MODE:?set GITHUB_MODE to project_v2, issue_field, or label}"
+   curl -fsSL "https://raw.githubusercontent.com/digitaldrywood/detent/main/docs/templates/WORKFLOW.${GITHUB_MODE}.md" \
      -o <source-root>/WORKFLOW.md
    ```
+
+   The maintained templates are
+   [`WORKFLOW.project_v2.md`](docs/templates/WORKFLOW.project_v2.md),
+   [`WORKFLOW.issue_field.md`](docs/templates/WORKFLOW.issue_field.md), and
+   [`WORKFLOW.label.md`](docs/templates/WORKFLOW.label.md).
 
    For ProjectV2 mode, set `tracker.project_slug` (your `PVT_` id). For
    boardless issue-field mode, set `tracker.github_status_source:
@@ -1090,8 +1096,10 @@ repo is a real, working instance of this setup to copy from.
    `tracker.github_status_source: label`, `tracker.repository:
    <repo-owner>/<repo-name>`, and `tracker.status_label_prefix`. In every mode,
    set `workspace.source_root` (`<source-root>`), `workspace.root` (a worktrees
-   directory), and the prompt body. The full field reference is in
-   [Quick Start](#quick-start).
+   directory), `write_probe_issue` when using write probes, and the prompt body.
+   Registered projects can use `github_token: gh` in `global.yaml`; leave
+   `tracker.api_key` out of the workflow unless you are intentionally using a
+   workflow-local token. The full field reference is in [Quick Start](#quick-start).
 
    Interactive alternative: when Detent starts without a resolved `global.yaml`
    and without a `WORKFLOW.md` in the current directory, it serves the

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1347,24 +1347,33 @@ rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"
 ```
 
-1. **Fetch the canonical template.** Read the existing file first if one is
+1. **Fetch the selected mode template.** Read the existing file first if one is
    present; this runbook is for from-zero repositories, so do not overwrite a
-   human-authored contract without explicit approval. Verify:
+   human-authored contract without explicit approval. The maintained templates
+   are `docs/templates/WORKFLOW.project_v2.md`,
+   `docs/templates/WORKFLOW.issue_field.md`, and
+   `docs/templates/WORKFLOW.label.md`. Verify:
 
    ```sh
    test ! -f <source-root>/WORKFLOW.md
-   curl -fsSL https://raw.githubusercontent.com/digitaldrywood/detent-orchestration/main/WORKFLOW.md \
+   GITHUB_MODE="$(sed -n 's/^GITHUB_MODE=//p' "$ONBOARDING_DIR/answers.env" | tail -n 1)"
+   case "$GITHUB_MODE" in
+     project_v2|issue_field|label) ;;
+     *) printf 'invalid GITHUB_MODE: %s\n' "$GITHUB_MODE" >&2; exit 1 ;;
+   esac
+   curl -fsSL "https://raw.githubusercontent.com/digitaldrywood/detent/main/docs/templates/WORKFLOW.${GITHUB_MODE}.md" \
      -o <source-root>/WORKFLOW.md
-   rg -n '^tracker:|^workspace:|^agent:' <source-root>/WORKFLOW.md
+   rg -n "github_status_source: ${GITHUB_MODE}|^tracker:|^workspace:|^agent:" <source-root>/WORKFLOW.md
    ```
 
 2. **Substitute the tracker and workspace answers.** In ProjectV2 mode, use the
    ProjectV2 node id as `tracker.project_slug`. In boardless issue-field mode,
-   remove `project_slug` and configure the repository issue field. In label
-   mode, remove `project_slug` and `status_field`, then configure the repository
-   and status-label prefix. In every mode, use absolute paths for
-   `workspace.source_root` and `workspace.root`. Verify the selected tracker
-   block:
+   set the repository and issue field. In label mode, set the repository and
+   status-label prefix. In every mode, set `write_probe_issue` when using write
+   probes, use absolute paths for `workspace.source_root` and `workspace.root`,
+   and leave `tracker.api_key` out unless this workflow intentionally carries a
+   workflow-local token instead of using `github_token: gh` from `global.yaml`.
+   Verify the selected tracker block:
 
    ProjectV2 tracker snippet:
 

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -1,0 +1,90 @@
+---
+tracker:
+  kind: github
+  github_status_source: issue_field
+  repository: <repo-owner>/<repo-name>
+  status_field: Status
+  write_probe_issue: <repo-owner>/<repo-name>#<issue-number>
+  http_max_idle_conns: 100
+  http_max_idle_conns_per_host: 32
+  http_idle_conn_timeout_ms: 90000
+  github_graphql_warn_remaining: 500
+  auto_provision: true
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
+  terminal_states:
+    - Done
+    - Cancelled
+  state_map:
+    Cancelled: Done
+  priority_map:
+    Urgent: 1
+    High: 2
+    Medium: 3
+    Low: 4
+    No priority: null
+  dependency_auto_unblock:
+    enabled: false
+    source_states:
+      - Blocked
+    target_state: Todo
+    readiness: terminal_or_merged
+polling:
+  interval_ms: 120000
+workspace:
+  root: <worktree-root>
+  source_root: <source-root>
+  auto_branch: true
+  cleanup_idle_ttl_ms: 86400000
+  cleanup_sweep_interval_ms: 600000
+agent:
+  max_concurrent_agents: 5
+  max_turns: 20
+  max_retry_backoff_ms: 300000
+  max_concurrent_agents_by_state:
+    Merging: 1
+  dispatch_priority_by_state:
+    - Merging
+    - Rework
+    - In Progress
+    - Todo
+  dispatch_priority_by_label: []
+  auto_promote:
+    enabled: false
+    quiet_seconds: 600
+    optout_label: requires-human-review
+    allowed_issue_labels: []
+  skills:
+    enabled: true
+    path: .detent/skills
+    max_skills_in_prompt: 50
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    networkAccess: true
+gate:
+  kind: command
+  run: make check
+  require_automated_review: true
+  ci_failure_action: skip
+server:
+  host: 127.0.0.1
+  port: 4000
+hooks:
+  timeout_ms: 60000
+---
+You are working on {{ issue.identifier }}: {{ issue.title }}.
+
+Follow repository instructions, keep changes scoped to the issue, update the
+persistent `## Codex Workpad` comment, run the validation gate, and prepare a
+pull request for human review.

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -1,0 +1,90 @@
+---
+tracker:
+  kind: github
+  github_status_source: label
+  repository: <repo-owner>/<repo-name>
+  status_label_prefix: "detent:"
+  write_probe_issue: <repo-owner>/<repo-name>#<issue-number>
+  http_max_idle_conns: 100
+  http_max_idle_conns_per_host: 32
+  http_idle_conn_timeout_ms: 90000
+  github_graphql_warn_remaining: 500
+  auto_provision: true
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
+  terminal_states:
+    - Done
+    - Cancelled
+  state_map:
+    Cancelled: Done
+  priority_map:
+    Urgent: 1
+    High: 2
+    Medium: 3
+    Low: 4
+    No priority: null
+  dependency_auto_unblock:
+    enabled: false
+    source_states:
+      - Blocked
+    target_state: Todo
+    readiness: terminal_or_merged
+polling:
+  interval_ms: 120000
+workspace:
+  root: <worktree-root>
+  source_root: <source-root>
+  auto_branch: true
+  cleanup_idle_ttl_ms: 86400000
+  cleanup_sweep_interval_ms: 600000
+agent:
+  max_concurrent_agents: 5
+  max_turns: 20
+  max_retry_backoff_ms: 300000
+  max_concurrent_agents_by_state:
+    Merging: 1
+  dispatch_priority_by_state:
+    - Merging
+    - Rework
+    - In Progress
+    - Todo
+  dispatch_priority_by_label: []
+  auto_promote:
+    enabled: false
+    quiet_seconds: 600
+    optout_label: requires-human-review
+    allowed_issue_labels: []
+  skills:
+    enabled: true
+    path: .detent/skills
+    max_skills_in_prompt: 50
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    networkAccess: true
+gate:
+  kind: command
+  run: make check
+  require_automated_review: true
+  ci_failure_action: skip
+server:
+  host: 127.0.0.1
+  port: 4000
+hooks:
+  timeout_ms: 60000
+---
+You are working on {{ issue.identifier }}: {{ issue.title }}.
+
+Follow repository instructions, keep changes scoped to the issue, update the
+persistent `## Codex Workpad` comment, run the validation gate, and prepare a
+pull request for human review.

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -1,0 +1,89 @@
+---
+tracker:
+  kind: github
+  github_status_source: project_v2
+  project_slug: <project-node-id>
+  write_probe_issue: <repo-owner>/<repo-name>#<issue-number>
+  http_max_idle_conns: 100
+  http_max_idle_conns_per_host: 32
+  http_idle_conn_timeout_ms: 90000
+  github_graphql_warn_remaining: 500
+  auto_provision: true
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
+  terminal_states:
+    - Done
+    - Cancelled
+  state_map:
+    Cancelled: Done
+  priority_map:
+    Urgent: 1
+    High: 2
+    Medium: 3
+    Low: 4
+    No priority: null
+  dependency_auto_unblock:
+    enabled: false
+    source_states:
+      - Blocked
+    target_state: Todo
+    readiness: terminal_or_merged
+polling:
+  interval_ms: 120000
+workspace:
+  root: <worktree-root>
+  source_root: <source-root>
+  auto_branch: true
+  cleanup_idle_ttl_ms: 86400000
+  cleanup_sweep_interval_ms: 600000
+agent:
+  max_concurrent_agents: 5
+  max_turns: 20
+  max_retry_backoff_ms: 300000
+  max_concurrent_agents_by_state:
+    Merging: 1
+  dispatch_priority_by_state:
+    - Merging
+    - Rework
+    - In Progress
+    - Todo
+  dispatch_priority_by_label: []
+  auto_promote:
+    enabled: false
+    quiet_seconds: 600
+    optout_label: requires-human-review
+    allowed_issue_labels: []
+  skills:
+    enabled: true
+    path: .detent/skills
+    max_skills_in_prompt: 50
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    networkAccess: true
+gate:
+  kind: command
+  run: make check
+  require_automated_review: true
+  ci_failure_action: skip
+server:
+  host: 127.0.0.1
+  port: 4000
+hooks:
+  timeout_ms: 60000
+---
+You are working on {{ issue.identifier }}: {{ issue.title }}.
+
+Follow repository instructions, keep changes scoped to the issue, update the
+persistent `## Codex Workpad` comment, run the validation gate, and prepare a
+pull request for human review.

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -138,7 +138,7 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 		t.Run(tt.source, func(t *testing.T) {
 			t.Parallel()
 
-			content := readRepositoryTextFile(t, tt.path)
+			content := strings.ReplaceAll(readRepositoryTextFile(t, tt.path), "\r\n", "\n")
 			for _, want := range tt.want {
 				assertContains(t, content, want)
 			}

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"strings"
 	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 )
 
 func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
@@ -76,6 +78,110 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	assertContains(t, readme, "Distinguish reference repositories from the target repository")
 	assertContains(t, readme, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`)
 	assertContains(t, readme, "Ask and record `GITHUB_MODE` explicitly")
+}
+
+func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+	staleCanonicalURL := "https://raw.githubusercontent.com/digitaldrywood/detent-orchestration/main/WORKFLOW.md"
+	if strings.Contains(onboarding, staleCanonicalURL) || strings.Contains(readme, staleCanonicalURL) {
+		t.Fatalf("docs still reference stale canonical template URL %q", staleCanonicalURL)
+	}
+
+	for _, path := range []string{
+		"docs/templates/WORKFLOW.project_v2.md",
+		"docs/templates/WORKFLOW.issue_field.md",
+		"docs/templates/WORKFLOW.label.md",
+	} {
+		assertContains(t, onboarding, path)
+		assertContains(t, readme, path)
+	}
+
+	tests := []struct {
+		path             string
+		source           string
+		want             []string
+		unwanted         []string
+		wantProjectSlug  bool
+		wantRepository   bool
+		wantStatusField  string
+		wantStatusPrefix string
+	}{
+		{
+			path:            "docs/templates/WORKFLOW.project_v2.md",
+			source:          workflowconfig.GitHubStatusSourceProjectV2,
+			want:            []string{"github_status_source: project_v2", "project_slug: <project-node-id>"},
+			unwanted:        []string{"repository: <repo-owner>/<repo-name>"},
+			wantProjectSlug: true,
+		},
+		{
+			path:            "docs/templates/WORKFLOW.issue_field.md",
+			source:          workflowconfig.GitHubStatusSourceIssueField,
+			want:            []string{"github_status_source: issue_field", "repository: <repo-owner>/<repo-name>", "status_field: Status"},
+			unwanted:        []string{"project_slug:"},
+			wantRepository:  true,
+			wantStatusField: "Status",
+		},
+		{
+			path:             "docs/templates/WORKFLOW.label.md",
+			source:           workflowconfig.GitHubStatusSourceLabel,
+			want:             []string{"github_status_source: label", "repository: <repo-owner>/<repo-name>", `status_label_prefix: "detent:"`},
+			unwanted:         []string{"project_slug:", "status_field:"},
+			wantRepository:   true,
+			wantStatusPrefix: "detent:",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.source, func(t *testing.T) {
+			t.Parallel()
+
+			content := readRepositoryTextFile(t, tt.path)
+			for _, want := range tt.want {
+				assertContains(t, content, want)
+			}
+			for _, unwanted := range append(tt.unwanted, "endpoint:", "api_key:", "interval_ms: 15000") {
+				if strings.Contains(content, unwanted) {
+					t.Fatalf("%s contains stale or wrong field %q:\n%s", tt.path, unwanted, content)
+				}
+			}
+
+			workflow, err := workflowconfig.ParseWorkflow([]byte(content))
+			if err != nil {
+				t.Fatalf("ParseWorkflow(%s) error = %v", tt.path, err)
+			}
+			cfg := workflow.Config
+			cfg.Tracker.APIKey = "test-token"
+			if err := cfg.Validate(); err != nil {
+				t.Fatalf("Validate(%s) error = %v", tt.path, err)
+			}
+
+			if cfg.Tracker.GitHubStatusSource != tt.source {
+				t.Fatalf("GitHubStatusSource = %q, want %q", cfg.Tracker.GitHubStatusSource, tt.source)
+			}
+			if cfg.Polling.IntervalMS != workflowconfig.DefaultPollingIntervalMS {
+				t.Fatalf("Polling.IntervalMS = %d, want %d", cfg.Polling.IntervalMS, workflowconfig.DefaultPollingIntervalMS)
+			}
+			assertContains(t, content, "max_concurrent_agents_by_state:\n    Merging: 1")
+			if cfg.Agent.MaxConcurrentAgentsByState["merging"] != 1 {
+				t.Fatalf("Merging concurrency = %d, want 1", cfg.Agent.MaxConcurrentAgentsByState["merging"])
+			}
+			if tt.wantProjectSlug && strings.TrimSpace(cfg.Tracker.ProjectSlug) == "" {
+				t.Fatal("ProjectSlug is blank")
+			}
+			if tt.wantRepository && strings.TrimSpace(cfg.Tracker.Repository) == "" {
+				t.Fatal("Repository is blank")
+			}
+			if tt.wantStatusField != "" && cfg.Tracker.StatusField != tt.wantStatusField {
+				t.Fatalf("StatusField = %q, want %q", cfg.Tracker.StatusField, tt.wantStatusField)
+			}
+			if tt.wantStatusPrefix != "" && cfg.Tracker.StatusLabelPrefix != tt.wantStatusPrefix {
+				t.Fatalf("StatusLabelPrefix = %q, want %q", cfg.Tracker.StatusLabelPrefix, tt.wantStatusPrefix)
+			}
+		})
+	}
 }
 
 func readRepositoryTextFile(t *testing.T, path string) string {


### PR DESCRIPTION
## Summary

- Add maintained mode-specific WORKFLOW templates for ProjectV2, issue-field, and label modes.
- Update README and onboarding Phase 4 to fetch the selected in-repo template instead of the stale detent-orchestration template.
- Add docs test coverage that validates the templates and guards against stale URL/defaults.

Fixes #555

## Test Plan

- [x] `go test ./... -run 'TestWorkflowTemplatesAreCurrentAndModeSpecific|TestOnboardingDocsRequire'`
- [x] `make check`