### PR TITLE
fix(web): choose Kanban move defaults

### DIFF
--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -110,6 +110,21 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 		}
 	}
 
+	dragDialogValues := url.Values{
+		"project_id":    {projectID},
+		"issue_id":      {"kanban-demo-backlog"},
+		"current_state": {"Backlog"},
+		"target_state":  {"Todo"},
+		"identifier":    {"digitaldrywood/detent#9510"},
+		"title":         {"Kanban demo backlog intake"},
+	}
+	dragDialogURL := dashboardURL + "/api/v1/kanban/move?" + dragDialogValues.Encode()
+	waitForDashboardCondition(t, dragDialogURL, done, "kanban drag move dialog target", func(body string) bool {
+		return strings.Contains(body, `hx-post="/api/v1/kanban/move"`) &&
+			strings.Contains(body, `name="current_state" value="Backlog"`) &&
+			strings.Contains(body, `<option value="Todo" selected>`)
+	})
+
 	moveBody := postRuntimeKanbanForm(t, dashboardURL+"/api/v1/kanban/move", done, url.Values{
 		"project_id":    {projectID},
 		"issue_id":      {"kanban-demo-backlog"},

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -496,7 +496,44 @@ func (s *Server) kanbanMoveDialogData(c echo.Context, message string) (templates
 	if len(data.States) == 0 && data.CurrentState == "" {
 		data.States = kanbanStateNames(target.workflow, s.latestSnapshot(c.Request().Context()))
 	}
+	if data.TargetState == "" {
+		data.TargetState = kanbanMoveDialogDefaultTarget(data.CurrentState, data.States)
+	}
 	return data, ""
+}
+
+func kanbanMoveDialogDefaultTarget(source string, allowedTargets []string) string {
+	if len(allowedTargets) == 0 {
+		return ""
+	}
+	preferred := kanbanMoveDialogPreferredTarget(source)
+	if preferred != "" {
+		for _, target := range allowedTargets {
+			target = strings.TrimSpace(target)
+			if normalizeKanbanState(target) == normalizeKanbanState(preferred) {
+				return target
+			}
+		}
+	}
+	for _, target := range allowedTargets {
+		if target = strings.TrimSpace(target); target != "" {
+			return target
+		}
+	}
+	return ""
+}
+
+func kanbanMoveDialogPreferredTarget(source string) string {
+	switch normalizeKanbanState(source) {
+	case "backlog", "blocked":
+		return "Todo"
+	case "todo", "rework":
+		return "In Progress"
+	case "human review":
+		return "Merging"
+	default:
+		return ""
+	}
 }
 
 func (s *Server) kanbanCommentDialogData(c echo.Context, message string) (templates.KanbanCommentDialogData, string) {

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -529,6 +529,8 @@ func kanbanMoveDialogPreferredTarget(source string) string {
 		return "Todo"
 	case "todo", "rework":
 		return "In Progress"
+	case "in progress":
+		return "Human Review"
 	case "human review":
 		return "Merging"
 	default:

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -491,6 +491,112 @@ func TestKanbanDialogFragmentRoutesRenderForms(t *testing.T) {
 	}
 }
 
+func TestKanbanMoveDialogUsesWorkflowAwareTargetDefaults(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		currentState       string
+		targetState        string
+		allowedTransitions map[string][]string
+		wantSelected       string
+	}{
+		{
+			name:         "backlog defaults to todo",
+			currentState: "Backlog",
+			allowedTransitions: map[string][]string{
+				"Backlog": {"Blocked", "Todo"},
+			},
+			wantSelected: "Todo",
+		},
+		{
+			name:         "todo defaults to in progress",
+			currentState: "Todo",
+			allowedTransitions: map[string][]string{
+				"Todo": {"Backlog", "In Progress"},
+			},
+			wantSelected: "In Progress",
+		},
+		{
+			name:         "blocked defaults to todo",
+			currentState: "Blocked",
+			allowedTransitions: map[string][]string{
+				"Blocked": {"Cancelled", "Todo"},
+			},
+			wantSelected: "Todo",
+		},
+		{
+			name:         "human review defaults to merging",
+			currentState: "Human Review",
+			allowedTransitions: map[string][]string{
+				"Human Review": {"Blocked", "Merging"},
+			},
+			wantSelected: "Merging",
+		},
+		{
+			name:         "rework defaults to in progress",
+			currentState: "Rework",
+			allowedTransitions: map[string][]string{
+				"Rework": {"Done", "In Progress"},
+			},
+			wantSelected: "In Progress",
+		},
+		{
+			name:         "preferred target falls back to first allowed",
+			currentState: "Todo",
+			allowedTransitions: map[string][]string{
+				"Todo": {"Blocked", "Cancelled"},
+			},
+			wantSelected: "Blocked",
+		},
+		{
+			name:         "explicit target wins",
+			currentState: "Todo",
+			targetState:  "Blocked",
+			allowedTransitions: map[string][]string{
+				"Todo": {"In Progress", "Blocked"},
+			},
+			wantSelected: "Blocked",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			actionConnector := &kanbanActionConnector{name: "github"}
+			mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+				Mode:               workflowconfig.KanbanModeIntegration,
+				AllowedTransitions: tt.allowedTransitions,
+			}, actionConnector)
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			values := url.Values{
+				"project_id":    {"detent"},
+				"issue_id":      {"I_kw1"},
+				"current_state": {tt.currentState},
+				"identifier":    {"digitaldrywood/detent#1"},
+				"title":         {"Default dialog card"},
+			}
+			if tt.targetState != "" {
+				values.Set("target_state", tt.targetState)
+			}
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodGet, "/api/v1/kanban/move?"+values.Encode(), nil)
+			req.Header.Set("HX-Request", "true")
+			server.Handler().ServeHTTP(rec, req)
+			if rec.Code != http.StatusOK {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+			}
+			assertKanbanDialogSelectedTarget(t, rec.Body.String(), tt.wantSelected)
+		})
+	}
+}
+
 func TestKanbanDialogValidationErrorsRenderInsideDialog(t *testing.T) {
 	t.Parallel()
 
@@ -5847,6 +5953,23 @@ func performForm(t *testing.T, handler http.Handler, method string, path string,
 	req.Header.Set("HX-Request", "true")
 	handler.ServeHTTP(rec, req)
 	return rec
+}
+
+func assertKanbanDialogSelectedTarget(t *testing.T, body string, target string) {
+	t.Helper()
+
+	selectedOptions := regexp.MustCompile(`<option[^>]*\sselected[^>]*>`).FindAllString(body, -1)
+	if len(selectedOptions) != 1 {
+		t.Fatalf("selected options = %#v, want exactly one in:\n%s", selectedOptions, body)
+	}
+	optionPattern := regexp.MustCompile(`<option value="` + regexp.QuoteMeta(target) + `"[^>]*>`)
+	option := optionPattern.FindString(body)
+	if option == "" {
+		t.Fatalf("target option %q missing from dialog:\n%s", target, body)
+	}
+	if !strings.Contains(option, "selected") {
+		t.Fatalf("target option %q is not selected: %s\nbody:\n%s", target, option, body)
+	}
 }
 
 func performDemoForm(t *testing.T, handler http.Handler, path string, scenario string, form url.Values) *httptest.ResponseRecorder {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -526,6 +526,14 @@ func TestKanbanMoveDialogUsesWorkflowAwareTargetDefaults(t *testing.T) {
 			wantSelected: "Todo",
 		},
 		{
+			name:         "in progress defaults to human review",
+			currentState: "In Progress",
+			allowedTransitions: map[string][]string{
+				"In Progress": {"Blocked", "Human Review"},
+			},
+			wantSelected: "Human Review",
+		},
+		{
 			name:         "human review defaults to merging",
 			currentState: "Human Review",
 			allowedTransitions: map[string][]string{

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1596,6 +1596,11 @@ func kanbanMoveDialogTargetState(data KanbanMoveDialogData) string {
 	if target := strings.TrimSpace(data.TargetState); target != "" {
 		return target
 	}
+	for _, state := range data.States {
+		if state = strings.TrimSpace(state); state != "" {
+			return state
+		}
+	}
 	return strings.TrimSpace(data.CurrentState)
 }
 

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -1373,6 +1373,64 @@ func TestDashboardKanbanIntegrationFiltersMoveTargets(t *testing.T) {
 	}
 }
 
+func TestDashboardKanbanDragDropPropagatesTargetState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC)
+	html := renderProjectKanbanPage(t, templates.DashboardData{
+		Title:       "Detent",
+		ProjectID:   "detent",
+		ProjectName: "Detent",
+		Kanban: templates.KanbanData{
+			Mode:   "integration",
+			States: []string{"Todo", "In Progress", "Blocked"},
+			AllowedTransitions: map[string][]string{
+				"Todo": {"In Progress"},
+			},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+			Pipeline: []telemetry.Issue{
+				{
+					ID:         "I_kw1",
+					Identifier: "digitaldrywood/detent#1",
+					ProjectID:  "detent",
+					Title:      "Drag target card",
+					State:      "Todo",
+				},
+			},
+		},
+	})
+
+	card := compactKanbanCardSection(t, html, "Drag target card")
+	for _, want := range []string{
+		`data-kanban-allowed-targets="inprogress"`,
+		`data-kanban-drag-move-form`,
+		`name="target_state" value="" data-kanban-drag-target-state`,
+		`hx-get="/api/v1/kanban/move"`,
+		`name="current_state" value="Todo"`,
+	} {
+		if !strings.Contains(card, want) {
+			t.Fatalf("drag card missing %q:\n%s", want, card)
+		}
+	}
+
+	for _, want := range []string{
+		`const targetState = form ? form.querySelector("[data-kanban-drag-target-state]") : null;`,
+		`targetState.value = lane.dataset.kanbanDropState || "";`,
+		`feedback("Move blocked by transition policy.");`,
+		`lane.dataset.kanbanDropAllowed = allowed ? "true" : "false";`,
+		`lane.setAttribute("aria-disabled", allowed ? "false" : "true");`,
+		`openActionDialog();`,
+		`form.requestSubmit();`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("drag script missing %q:\n%s", want, html)
+		}
+	}
+}
+
 func TestDashboardPreservesSnapshotScrollContainersAcrossSSEMorph(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add workflow-aware default targets for the Kanban move dialog while preserving explicit target_state values from links and drag/drop.
- Keep the current confirmation-dialog drag/drop UX and add coverage for target propagation plus blocked-lane feedback.

Fixes #560

## Test Plan

- [x] `go test ./internal/web -run 'TestKanban(DialogFragmentRoutesRenderForms|MoveDialogUsesWorkflowAwareTargetDefaults|MoveAllowsConfiguredTransitionOverrides|MoveRejectsDefaultRestrictedActiveTransitions)' -count=1`
- [x] `go test ./internal/web/templates -run 'TestDashboardKanban(IntegrationControls|IntegrationFiltersMoveTargets|DragDropPropagatesTargetState)' -count=1`
- [x] `go test ./internal/cli -run TestStartKanbanDemoRendersAndAppliesSafeActions -count=1`
- [x] `go test ./internal/web ./internal/web/templates ./internal/cli`
- [x] `make check` (first run hit a one-off `internal/project` race-test flake; focused retry and the second full gate passed)
