### PR TITLE
fix(label-mode): attach current Detent PR branches

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -3391,6 +3391,9 @@ func branchMatchesIssuePrefix(branchName string, prefix string) bool {
 				return true
 			}
 		}
+		if branchMatchesCurrentDetentPrefix(branchName, legacyPrefix) {
+			return true
+		}
 		if number := issueNumberFromBranchPrefix(legacyPrefix); number != "" {
 			if branchName == "detent/"+number {
 				return true
@@ -3403,6 +3406,18 @@ func branchMatchesIssuePrefix(branchName string, prefix string) bool {
 		}
 	}
 	return false
+}
+
+func branchMatchesCurrentDetentPrefix(branchName string, issueKey string) bool {
+	branchStem, ok := strings.CutPrefix(branchName, "detent/")
+	if !ok {
+		return false
+	}
+	digestSeparator := strings.LastIndex(branchStem, "-")
+	if digestSeparator <= 0 || digestSeparator == len(branchStem)-1 {
+		return false
+	}
+	return strings.HasSuffix(branchStem[:digestSeparator], "-"+issueKey)
 }
 
 func issueNumberFromBranchPrefix(prefix string) string {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -894,11 +894,23 @@ func TestBranchMatchesIssuePrefixAcceptsCurrentAgentBranchShape(t *testing.T) {
 		"detent/digitaldrywood_detent_506",
 		"detent/digitaldrywood_detent_506-fix",
 		"detent/detent-digitaldrywood_detent_506-6bd1bec3c6d3",
+		"detent/digitaldrywood-digitaldrywood_detent_506-6bd1bec3c6d3",
 		"detent/506",
 		"detent/506-fix",
 	} {
 		if !branchMatchesIssuePrefix(branch, prefix) {
 			t.Fatalf("branchMatchesIssuePrefix(%q, %q) = false, want true", branch, prefix)
+		}
+	}
+
+	for _, branch := range []string{
+		"detent/digitaldrywood-digitaldrywood_detent_5060-6bd1bec3c6d3",
+		"detent/digitaldrywood-digitaldrywood_detent_50-6bd1bec3c6d3",
+		"detent/foo-digitaldrywood_detent_506-digitaldrywood_detent_123-6bd1bec3c6d3",
+		"detent/digitaldrywood_detent_5060",
+	} {
+		if branchMatchesIssuePrefix(branch, prefix) {
+			t.Fatalf("branchMatchesIssuePrefix(%q, %q) = true, want false", branch, prefix)
 		}
 	}
 }

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -63,33 +63,33 @@ func TestConnectorFetchLabelIssuesByStatesAttachesCurrentAgentBranchPullRequest(
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Ahuman-review&page=1&per_page=100&state=all",
-			body:   `[{"node_id":"I_506","number":506,"title":"Shutdown diagnostics","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/506","assignees":[],"labels":[{"name":"detent:human-review"},{"name":"bug"}]}]`,
+			path:   "/repos/digitaldrywood/digitaldrywood/issues?labels=detent%3Ahuman-review&page=1&per_page=100&state=all",
+			body:   `[{"node_id":"I_433","number":433,"title":"Human Review issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/digitaldrywood/issues/433","assignees":[],"labels":[{"name":"detent:human-review"},{"name":"bug"}]}]`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
-			body:   `[{"number":508,"html_url":"https://github.com/digitaldrywood/detent/pull/508","state":"open","head":{"ref":"detent/detent-digitaldrywood_detent_506-6bd1bec3c6d3","sha":"sha-508"}}]`,
+			path:   "/repos/digitaldrywood/digitaldrywood/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[{"number":434,"html_url":"https://github.com/digitaldrywood/digitaldrywood/pull/434","state":"open","head":{"ref":"detent/digitaldrywood-digitaldrywood_digitaldrywood_433-a212db2634a4","sha":"sha-434"}}]`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/commits/sha-508/check-runs?per_page=100",
+			path:   "/repos/digitaldrywood/digitaldrywood/commits/sha-434/check-runs?per_page=100",
 			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/commits/sha-508/statuses?per_page=100",
+			path:   "/repos/digitaldrywood/digitaldrywood/commits/sha-434/statuses?per_page=100",
 			body:   `[]`,
 		},
 		{
 			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/pulls/508/reviews?per_page=100",
+			path:   "/repos/digitaldrywood/digitaldrywood/pulls/434/reviews?per_page=100",
 			body:   `[]`,
 		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		GitHubStatusSource: GitHubStatusSourceLabel,
-		Repository:         "digitaldrywood/detent",
+		Repository:         "digitaldrywood/digitaldrywood",
 	})
 
 	got, err := c.FetchIssuesByStatesLimit(context.Background(), []string{"Human Review"}, 1)
@@ -99,11 +99,11 @@ func TestConnectorFetchLabelIssuesByStatesAttachesCurrentAgentBranchPullRequest(
 	if len(got) != 1 {
 		t.Fatalf("FetchIssuesByStatesLimit() len = %d, want 1", len(got))
 	}
-	if got[0].PRNumber == nil || *got[0].PRNumber != 508 {
-		t.Fatalf("PRNumber = %v, want 508", got[0].PRNumber)
+	if got[0].PRNumber == nil || *got[0].PRNumber != 434 {
+		t.Fatalf("PRNumber = %v, want 434", got[0].PRNumber)
 	}
-	if got[0].PullRequest == nil || got[0].PullRequest.Number != 508 || got[0].PullRequest.CIStatus != "pass" {
-		t.Fatalf("PullRequest = %#v, want hydrated PR 508", got[0].PullRequest)
+	if got[0].PullRequest == nil || got[0].PullRequest.Number != 434 || got[0].PullRequest.CIStatus != "pass" {
+		t.Fatalf("PullRequest = %#v, want hydrated PR 434", got[0].PullRequest)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Recognize current Detent branch names of the form `detent/<project>-<identifier>-<digest>` when label-mode issues attach open PRs by branch.
- Update label-mode regression coverage with the reported DigitalDrywood issue/PR branch and add boundary checks for neighboring issue numbers.

Fixes #574

## Test Plan
- `go test ./internal/connector/github -run 'TestConnectorFetchLabelIssuesByStatesAttachesCurrentAgentBranchPullRequest|TestBranchMatchesIssuePrefixAcceptsCurrentAgentBranchShape' -count=1 -v`
- `go test ./internal/connector/github -count=1`
- `make check`
- `/Users/corylanou/code/detent-workspaces/detent-digitaldrywood_detent_574-3cca098fe42a/tmp/detent doctor --config /Users/corylanou/projects/digitaldrywood/detent-orchestration/global.yaml --port 0 --format pretty` passed for the local Detent config; this machine does not have a DigitalDrywood project config to run the exact reported project smoke.