### PR TITLE
fix(ui): refresh config-derived kanban

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -241,6 +241,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		return err
 	}
 	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, runtimeStore, displayURL, defaultSnapshotInterval, time.Now)
+	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger)
 	server, err := web.NewServer(web.Config{
 		Mode:               web.ModeRunning,
 		WorkflowPath:       firstWorkflowPath(cfg),
@@ -268,11 +269,15 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		return err
 	}
 
+	onGlobalReload := func(reloaded globalconfig.Config) {
+		globalConfigState.set(reloaded)
+		republishLatestSnapshot(snapshotHub, logger)
+	}
 	startProjects := func(ctx context.Context) error {
 		if err := manager.Start(ctx); err != nil {
 			return err
 		}
-		globalWatcherDone := startGlobalConfigWatcher(ctx, cfg.Global, manager, logger, runtimeGitHubToken, globalConfigState.set)
+		globalWatcherDone := startGlobalConfigWatcher(ctx, cfg.Global, manager, logger, runtimeGitHubToken, onGlobalReload)
 		select {
 		case globalWatcherStarted <- globalWatcherDone:
 		default:

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -231,6 +231,55 @@ func publishSnapshots(
 	}
 }
 
+func republishSnapshotsOnProjectEvents(
+	ctx context.Context,
+	events *hub.Hub[project.Event],
+	snapshotHub *hub.Hub[telemetry.Snapshot],
+	logger *slog.Logger,
+) {
+	if events == nil || snapshotHub == nil {
+		return
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	sub, err := events.Subscribe(ctx)
+	if err != nil {
+		if ctx.Err() == nil {
+			logger.Warn("subscribe project events for snapshot republish failed", "error", err)
+		}
+		return
+	}
+	defer sub.Close()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case _, ok := <-sub.C():
+			if !ok {
+				return
+			}
+			republishLatestSnapshot(snapshotHub, logger)
+		}
+	}
+}
+
+func republishLatestSnapshot(snapshotHub *hub.Hub[telemetry.Snapshot], logger *slog.Logger) {
+	if snapshotHub == nil {
+		return
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if err := snapshotHub.Republish(); err != nil {
+		logger.Warn("republish telemetry snapshot failed", "error", err)
+	}
+}
+
 func publishStartupSnapshotOnce(
 	ctx context.Context,
 	cfg globalconfig.Config,

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -222,6 +222,56 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	}
 }
 
+func TestRepublishSnapshotsOnProjectEventsPublishesLatestSnapshot(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[projectpkg.Event]()
+	snapshotHub := hub.New[telemetry.Snapshot](hub.WithBuffer(2))
+	now := time.Date(2026, 6, 20, 15, 30, 0, 0, time.UTC)
+	latest := telemetry.Snapshot{
+		GeneratedAt: now,
+		Counts:      telemetry.Counts{Running: 1},
+	}
+	if err := snapshotHub.Publish(latest); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	sub, err := snapshotHub.Subscribe(ctx)
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+	defer sub.Close()
+	receiveSnapshot(t, sub.C())
+
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		republishSnapshotsOnProjectEvents(ctx, events, snapshotHub, nil)
+	}()
+
+	if err := events.Publish(projectpkg.Event{
+		ProjectID: "alpha",
+		Kind:      projectpkg.EventWorkflowReloaded,
+		At:        now,
+	}); err != nil {
+		t.Fatalf("events.Publish() error = %v", err)
+	}
+
+	republished := receiveSnapshot(t, sub.C())
+	if !republished.GeneratedAt.Equal(now) || republished.Counts.Running != 1 {
+		t.Fatalf("republished snapshot = %#v, want latest snapshot", republished)
+	}
+
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for project event republisher to stop")
+	}
+}
+
 func TestPublishSnapshotOncePreservesPipeline(t *testing.T) {
 	t.Parallel()
 
@@ -586,4 +636,17 @@ func newRefreshProjectWithConnector(t *testing.T, id string, projectConnector co
 		t.Fatalf("project.New() error = %v", err)
 	}
 	return project
+}
+
+func receiveSnapshot(t *testing.T, ch <-chan telemetry.Snapshot) telemetry.Snapshot {
+	t.Helper()
+
+	select {
+	case snapshot := <-ch:
+		return snapshot
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for snapshot")
+	}
+
+	return telemetry.Snapshot{}
 }

--- a/internal/hub/hub.go
+++ b/internal/hub/hub.go
@@ -105,6 +105,23 @@ func (h *Hub[T]) Publish(value T) error {
 	return nil
 }
 
+func (h *Hub[T]) Republish() error {
+	h.mu.Lock()
+	defer h.mu.Unlock()
+
+	if h.closed {
+		return ErrClosed
+	}
+	if !h.hasLast {
+		return nil
+	}
+	for sub := range h.subscribers {
+		sendLatest(sub.ch, h.last)
+	}
+
+	return nil
+}
+
 func (h *Hub[T]) Latest() (T, bool) {
 	h.mu.Lock()
 	defer h.mu.Unlock()

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -83,6 +83,34 @@ func TestHubLatestReturnsLastEvent(t *testing.T) {
 	}
 }
 
+func TestHubRepublishFansOutLastEvent(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[string]()
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	if err := events.Republish(); err != nil {
+		t.Fatalf("Republish() before Publish error = %v", err)
+	}
+	assertNoEvent(t, sub.C())
+
+	if err := events.Publish("ready"); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	if got := receive(t, sub.C()); got != "ready" {
+		t.Fatalf("published event = %q, want ready", got)
+	}
+	if err := events.Republish(); err != nil {
+		t.Fatalf("Republish() error = %v", err)
+	}
+	if got := receive(t, sub.C()); got != "ready" {
+		t.Fatalf("republished event = %q, want ready", got)
+	}
+}
+
 func TestHubDropsOldestForSlowSubscriber(t *testing.T) {
 	t.Parallel()
 
@@ -178,6 +206,9 @@ func TestHubCloseClosesSubscribersAndRejectsOperations(t *testing.T) {
 	if err := events.Publish("ignored"); !errors.Is(err, hub.ErrClosed) {
 		t.Fatalf("Publish() error = %v, want %v", err, hub.ErrClosed)
 	}
+	if err := events.Republish(); !errors.Is(err, hub.ErrClosed) {
+		t.Fatalf("Republish() error = %v, want %v", err, hub.ErrClosed)
+	}
 	if _, err := events.Subscribe(context.Background()); !errors.Is(err, hub.ErrClosed) {
 		t.Fatalf("Subscribe() error = %v, want %v", err, hub.ErrClosed)
 	}
@@ -249,4 +280,14 @@ func receive[T any](t *testing.T, ch <-chan T) T {
 
 	var zero T
 	return zero
+}
+
+func assertNoEvent[T any](t *testing.T, ch <-chan T) {
+	t.Helper()
+
+	select {
+	case got := <-ch:
+		t.Fatalf("unexpected event = %#v", got)
+	case <-time.After(25 * time.Millisecond):
+	}
 }

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -33,10 +33,11 @@ var (
 )
 
 const (
-	EventStarted  EventKind = "project_started"
-	EventPaused   EventKind = "project_paused"
-	EventStopped  EventKind = "project_stopped"
-	EventUnpaused EventKind = "project_unpaused"
+	EventStarted          EventKind = "project_started"
+	EventPaused           EventKind = "project_paused"
+	EventStopped          EventKind = "project_stopped"
+	EventUnpaused         EventKind = "project_unpaused"
+	EventWorkflowReloaded EventKind = "project_workflow_reloaded"
 )
 
 type ID string
@@ -756,9 +757,18 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	p.scheduler = projectScheduler
 	p.orchConfig = runtimeConfig
 	p.orchDeps.Connector = projectConnector
+	publishEvents := p.lifecycleEvents
+	id := p.id
 	p.mu.Unlock()
 
 	p.logger.Info("workflow reloaded", "project_id", p.id, "path", update.Path)
+	if publishEvents {
+		p.publish(Event{
+			ProjectID: id,
+			Kind:      EventWorkflowReloaded,
+			At:        time.Now(),
+		})
+	}
 }
 
 func projectOrchestratorConfig(project globalconfig.Project, workflow workflowconfig.Config) orchestrator.Config {

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -473,9 +473,14 @@ func TestProjectHotReloadsWorkflowFileWithoutRestart(t *testing.T) {
 		t.Fatalf("orchestrator creations after reload = %d, want no restart", orchestratorCreates.Load())
 	}
 
+	reloaded := receiveEvent(t, sub.C())
+	if reloaded.ProjectID != got.ID() || reloaded.Kind != project.EventWorkflowReloaded {
+		t.Fatalf("workflow reload event = %#v, want project workflow reload", reloaded)
+	}
+
 	select {
 	case event := <-sub.C():
-		t.Fatalf("unexpected lifecycle event after hot reload = %#v", event)
+		t.Fatalf("unexpected extra event after hot reload = %#v", event)
 	case <-time.After(25 * time.Millisecond):
 	}
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3797,6 +3797,98 @@ func TestServerEventsPreserveProjectKanbanVisibilityMetadata(t *testing.T) {
 	}
 }
 
+func TestServerEventsProjectKanbanUsesReloadedConfigOnRepublishedSnapshot(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeReadOnly,
+	}, actionConnector)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 20, 15, 0, 0, 0, time.UTC),
+		Projects: []telemetry.ProjectSnapshot{
+			{
+				Project: telemetry.Project{
+					ID:          "detent",
+					DisplayName: "Detent",
+				},
+			},
+		},
+		BoardIssues: []telemetry.Issue{
+			{
+				ID:         "todo",
+				Identifier: "digitaldrywood/detent#565",
+				ProjectID:  "detent",
+				Title:      "Live reload Kanban mode",
+				State:      "Todo",
+			},
+		},
+	}
+	if err := deps.Hub.Publish(snapshot); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{SSETickInterval: time.Hour}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	addr := startWebServer(t, server)
+	conn, body, reader := openRawEventStream(t, addr, "/events?project=detent&view=kanban")
+	defer conn.Close()
+	defer body.Close()
+
+	event := readRawSSEEvent(t, conn, reader)
+	if event.name != "snapshot" {
+		t.Fatalf("event name = %q, want snapshot", event.name)
+	}
+	for _, want := range []string{
+		"Read-only",
+		"Read-only workflow lanes grouped by configured Detent states.",
+		"Live reload Kanban mode",
+	} {
+		if !strings.Contains(event.data, want) {
+			t.Fatalf("initial snapshot event missing %q:\n%s", want, event.data)
+		}
+	}
+	if strings.Contains(event.data, `hx-get="/api/v1/kanban/move?`) {
+		t.Fatalf("initial read-only snapshot rendered move controls:\n%s", event.data)
+	}
+	sidebarEvent := readRawSSEEvent(t, conn, reader)
+	if sidebarEvent.name != "sidebar" {
+		t.Fatalf("event name = %q, want sidebar", sidebarEvent.name)
+	}
+
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, actionConnector)
+	if err := deps.Hub.Publish(snapshot); err != nil {
+		t.Fatalf("republish snapshot error = %v", err)
+	}
+
+	event = readRawSSEEvent(t, conn, reader)
+	if event.name != "snapshot" {
+		t.Fatalf("event name = %q, want snapshot", event.name)
+	}
+	for _, want := range []string{
+		"Integration",
+		"Workflow lanes grouped by configured Detent states with operator actions enabled.",
+		`hx-get="/api/v1/kanban/move?`,
+		`hx-get="/api/v1/kanban/comment?`,
+		`draggable="true"`,
+		`data-kanban-drop-state="In Progress"`,
+		`data-kanban-allowed-targets=`,
+	} {
+		if !strings.Contains(event.data, want) {
+			t.Fatalf("reloaded snapshot event missing %q:\n%s", want, event.data)
+		}
+	}
+	if strings.Contains(event.data, "Read-only") {
+		t.Fatalf("reloaded snapshot event kept read-only UI:\n%s", event.data)
+	}
+}
+
 func TestServerEventsStreamsSidebarUpdates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/help.go
+++ b/internal/web/templates/help.go
@@ -80,7 +80,7 @@ var helpDefinitions = map[helpTerm]helpEntry{
 	helpLifetimeTotals:      {Label: "Lifetime totals", Description: "All-time local usage totals for tokens, sessions, runtime, and runs. Use them for capacity planning and sanity checks across restarts."},
 	helpModelBuckets:        {Label: "Model split", Description: "Token usage grouped by model. It shows which models drive cost and volume when a report window looks expensive."},
 	helpPrimaryRateBucket:   {Label: "Primary rate bucket", Description: "The main Codex API quota bucket for requests or tokens. When remaining capacity is low, agents may throttle until the reset."},
-	helpProjectKanban:       {Label: "Project Kanban", Description: "Read-only project board grouped by configured Detent workflow states. Empty configured lanes stay hidden unless pinned in lane visibility."},
+	helpProjectKanban:       {Label: "Project Kanban", Description: "Project board grouped by configured Detent workflow states. Empty configured lanes stay hidden unless pinned in lane visibility."},
 	helpProjectMultiples:    {Label: "Projects", Description: "Compact per-project throughput, spend, and queue depth. Use it to compare active repositories sharing the same Detent process."},
 	helpPRPipeline:          {Label: "PR pipeline", Description: "Pull requests currently waiting for human review, merging, or marked done by the tracker today. Watch this lane to see whether the merge train is moving."},
 	helpProjectedSpend:      {Label: "Projected spend", Description: "Estimated additional USD for active work if it continues at the current pace. Use it before letting a busy queue keep running."},


### PR DESCRIPTION
## Summary

- Emit a project workflow reload event and republish the latest telemetry snapshot when project/global config changes need existing SSE clients to re-render.
- Verify project Kanban SSE fragments update from read-only to integration mode using the current registry config.
- Make the Kanban help description mode-neutral so integration pages do not carry read-only metadata.

Fixes #565

## Test Plan

- [x] `make check`