### PR TITLE
docs(onboarding): recommend kanban integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -712,19 +712,18 @@ Use `tracker.authorization.labels.*`, `projects[].authorization`, and
 `agent.dispatch_priority_by_label` for selecting or ranking work by ordinary
 labels such as `documentation`, `bug`, or `enhancement`.
 
-Kanban display is read-only by default. Keep that default for observers,
-shared dashboards, the top-level `/kanban` fleet board, and initial rollout.
-Project-specific Kanban pages can use integration mode when operators are
-allowed to move cards and post issue or PR comments from Detent, and only after
-`detent doctor` proves ProjectV2 status write, issue-field status write, or
-status-label update for the selected status source, plus issue/PR comment
-write:
+The fleet `/kanban` board stays read-only, as do observer dashboards and
+shared dashboards where users should not mutate GitHub from Detent. For a
+trusted operator project board, set `server.kanban.mode: integration` after
+`detent doctor` proves writes: ProjectV2 status write, issue-field status
+write, or status-label update for the selected status source, plus issue/PR
+comment write:
 
 ```yaml
 server:
   kanban:
-    mode: read_only
-    # mode: integration
+    mode: integration
+    # Use mode: read_only for observer/shared dashboards or until write probes pass.
     # allowed_transitions:
     #   In Progress: [Blocked, Cancelled]
     #   Rework: [Blocked, Cancelled]
@@ -732,8 +731,8 @@ server:
     #   QA: [Blocked, Human Review]
 ```
 
-When `allowed_transitions` is omitted, integration mode keeps a conservative
-default for manual moves from execution states: active work such as
+When `allowed_transitions` is omitted, integration mode keeps conservative
+defaults for manual moves from execution states: active work such as
 `In Progress`, `Rework`, and `Merging` can only move to configured exception
 states such as `Blocked` or `Cancelled`. Add source-specific entries to allow a
 project workflow to expose extra manual moves without changing Detent's UI code.
@@ -1119,6 +1118,9 @@ repo is a real, working instance of this setup to copy from.
    [`WORKFLOW.project_v2.md`](docs/templates/WORKFLOW.project_v2.md),
    [`WORKFLOW.issue_field.md`](docs/templates/WORKFLOW.issue_field.md), and
    [`WORKFLOW.label.md`](docs/templates/WORKFLOW.label.md).
+   They set `server.kanban.mode: integration` for trusted project boards;
+   change that to `read_only` for an observer or shared dashboard, or until
+   doctor write probes pass.
 
    For ProjectV2 mode, set `tracker.project_slug` (your `PVT_` id). For
    boardless issue-field mode, set `tracker.github_status_source:
@@ -1327,15 +1329,14 @@ You choose where GitHub status lives; Detent fills in the rest.
 
 ### Kanban Modes
 
-Boardless projects use Detent's own dashboard as the day-to-day board. Keep
-Kanban in `read_only` mode by default: operators can inspect lanes, linked PRs,
-CI, review state, blockers, labels, and assignees without granting dashboard
-write access. Enable `integration` mode only in a release that supports it and
-only for trusted operators who should move cards and post comments from the
-dashboard. Integration mode needs the same GitHub write permissions that
-`detent doctor` probes: ProjectV2 status write in ProjectV2 mode, issue-field
-status write in issue-field mode, status-label update in label mode, and
-issue/PR comment write for comment forms.
+Boardless projects use Detent's own dashboard as the day-to-day board. The
+fleet `/kanban` board stays read-only because it is a cross-project observer
+surface. A trusted operator project board should use `integration` after
+`detent doctor` proves writes, so operators can move cards and post comments
+from `/projects/<id>/kanban`. Keep `read_only` for an observer or shared
+dashboard, or until doctor proves ProjectV2 status write in ProjectV2 mode,
+issue-field status write in issue-field mode, status-label update in label mode,
+and issue/PR comment write for comment forms.
 
 ### Migration Notes
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -668,10 +668,12 @@ mutations. Record explicit answers in `$ONBOARDING_DIR/answers.env`.
    rg '^STATUS_LABEL_PREFIX=' "$ONBOARDING_DIR/answers.env"
    ```
 
-5. **Kanban interaction.** Ask: "Should Detent's Kanban be read-only or allow
-   GitHub mutations from the dashboard?" Recommend `read_only`. Use
-   `integration` only in a Detent release that supports it and only when trusted
-   operators should move cards and post issue or PR comments from Detent.
+5. **Kanban interaction.** Ask: "Should Detent's project Kanban be read-only or
+   allow GitHub mutations from the dashboard?" Keep fleet `/kanban` read-only.
+   For a project-scoped board on an operator-owned local or private Detent
+   instance, recommend `integration` after `detent doctor` proves the relevant
+   write probes. For a shared observer dashboard, or when write probes are
+   missing or failing, recommend `read_only` until writes are proven.
    Integration mode requires doctor to prove ProjectV2 status write or
    issue-field status write, or status-label update, plus issue/PR comment
    write. Verify:
@@ -1426,19 +1428,27 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
 3. **Set Kanban interaction mode when supported.** Do not add this block to
    current releases unless the Detent binary supports Kanban interaction
-   configuration. When supported, keep `read_only` as the default and enable
-   `integration` only for trusted operators after doctor proves status write and
+   configuration. Maintained templates set project boards to `integration` for
+   a trusted operator-owned local or private Detent instance. Keep fleet
+   `/kanban` read-only; this setting only controls `/projects/<id>/kanban`.
+   For a shared observer dashboard, or when write probes are not configured or
+   not passing, set `read_only` until `detent doctor` proves status write and
    issue/PR comment write. Verify:
 
    ```yaml
    server:
      kanban:
-       mode: read_only
-       # mode: integration
+       mode: integration
+       # Use mode: read_only for observer/shared dashboards or until write probes pass.
+       # Optional allowed_transitions expose broader manual status editing.
+       # allowed_transitions:
+       #   In Progress: [Blocked, Cancelled]
+       #   Rework: [Blocked, Cancelled]
+       #   Merging: [Blocked, Cancelled]
    ```
 
    ```sh
-   rg -n 'kanban:|mode: read_only|mode: integration' <source-root>/WORKFLOW.md || true
+   rg -n 'kanban:|mode: read_only|mode: integration|allowed_transitions' <source-root>/WORKFLOW.md || true
    ```
 
 4. **Set the dashboard bind from the interview.** This writes the default
@@ -2183,7 +2193,7 @@ apply to issues only, so linked PR cards derive status from the linked issue.
 | Boardless repository | `tracker.repository` in `WORKFLOW.md` for issue-field and label modes. |
 | Boardless issue field | `tracker.status_field` in `WORKFLOW.md`; defaults to `Status` when omitted. |
 | Status label prefix | `tracker.status_label_prefix` in `WORKFLOW.md`; defaults to `detent:` for label mode. |
-| Kanban interaction | Keep read-only by default; use integration only in supporting releases after doctor proves write permissions. |
+| Kanban interaction | Fleet and observer boards stay read-only; trusted project boards use `integration` after doctor proves write permissions. |
 | Project scheduling priority | `projects[].priority` in `global.yaml`. |
 | Project scheduling weight | `projects[].weight` in `global.yaml`. |
 | Project color | Optional `projects[].color` in `global.yaml`; missing colors are deterministic and appear in the sidebar and multi-project Kanban. |

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1447,8 +1447,12 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
        #   Merging: [Blocked, Cancelled]
    ```
 
+   Apply the recorded Phase 2 answer before running doctor:
+
    ```sh
-   rg -n 'kanban:|mode: read_only|mode: integration|allowed_transitions' <source-root>/WORKFLOW.md || true
+   KANBAN_MODE="${KANBAN_MODE:?set KANBAN_MODE to read_only or integration from answers.env}"
+   perl -0pi -e "s#(?m)^    mode: (read_only|integration)$#    mode: ${KANBAN_MODE}#" <source-root>/WORKFLOW.md
+   rg -n "kanban:|mode: ${KANBAN_MODE}|allowed_transitions" <source-root>/WORKFLOW.md
    ```
 
 4. **Set the dashboard bind from the interview.** This writes the default

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -80,6 +80,14 @@ gate:
 server:
   host: 127.0.0.1
   port: 4000
+  kanban:
+    mode: integration
+    # Use mode: read_only for observer/shared dashboards or until write probes pass.
+    # Optional allowed_transitions expose broader manual status editing.
+    # allowed_transitions:
+    #   In Progress: [Blocked, Cancelled]
+    #   Rework: [Blocked, Cancelled]
+    #   Merging: [Blocked, Cancelled]
 hooks:
   timeout_ms: 60000
 ---

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -80,6 +80,14 @@ gate:
 server:
   host: 127.0.0.1
   port: 4000
+  kanban:
+    mode: integration
+    # Use mode: read_only for observer/shared dashboards or until write probes pass.
+    # Optional allowed_transitions expose broader manual status editing.
+    # allowed_transitions:
+    #   In Progress: [Blocked, Cancelled]
+    #   Rework: [Blocked, Cancelled]
+    #   Merging: [Blocked, Cancelled]
 hooks:
   timeout_ms: 60000
 ---

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -79,6 +79,14 @@ gate:
 server:
   host: 127.0.0.1
   port: 4000
+  kanban:
+    mode: integration
+    # Use mode: read_only for observer/shared dashboards or until write probes pass.
+    # Optional allowed_transitions expose broader manual status editing.
+    # allowed_transitions:
+    #   In Progress: [Blocked, Cancelled]
+    #   Rework: [Blocked, Cancelled]
+    #   Merging: [Blocked, Cancelled]
 hooks:
   timeout_ms: 60000
 ---

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -80,6 +80,54 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	assertContains(t, readme, "Ask and record `GITHUB_MODE` explicitly")
 }
 
+func TestOnboardingDocsRecommendProjectKanbanIntegrationAfterWriteProbes(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+
+	for _, want := range []string{
+		"Keep fleet `/kanban` read-only",
+		"operator-owned local or private Detent instance",
+		"recommend `integration` after `detent doctor` proves the relevant write probes",
+		"shared observer dashboard",
+		"recommend `read_only` until writes are proven",
+	} {
+		assertContainsWords(t, onboarding, want)
+	}
+
+	for _, want := range []string{
+		"fleet `/kanban` board stays read-only",
+		"trusted operator project board should use `integration` after `detent doctor` proves writes",
+		"observer or shared dashboard",
+		"server.kanban.mode: integration",
+	} {
+		assertContainsWords(t, readme, want)
+	}
+
+	for _, path := range []string{
+		"docs/templates/WORKFLOW.project_v2.md",
+		"docs/templates/WORKFLOW.issue_field.md",
+		"docs/templates/WORKFLOW.label.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			content := readRepositoryTextFile(t, path)
+			assertContains(t, content, "mode: integration")
+			assertContains(t, content, "allowed_transitions")
+
+			workflow, err := workflowconfig.ParseWorkflow([]byte(content))
+			if err != nil {
+				t.Fatalf("ParseWorkflow(%s) error = %v", path, err)
+			}
+			if workflow.Config.Server.Kanban.Mode != workflowconfig.KanbanModeIntegration {
+				t.Fatalf("Kanban mode = %q, want %q", workflow.Config.Server.Kanban.Mode, workflowconfig.KanbanModeIntegration)
+			}
+		})
+	}
+}
+
 func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 	t.Parallel()
 

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -92,6 +92,8 @@ func TestOnboardingDocsRecommendProjectKanbanIntegrationAfterWriteProbes(t *test
 		"recommend `integration` after `detent doctor` proves the relevant write probes",
 		"shared observer dashboard",
 		"recommend `read_only` until writes are proven",
+		`KANBAN_MODE="${KANBAN_MODE:?set KANBAN_MODE to read_only or integration from answers.env}"`,
+		"mode: ${KANBAN_MODE}",
 	} {
 		assertContainsWords(t, onboarding, want)
 	}


### PR DESCRIPTION
## Summary

- Recommend project-scoped Kanban integration for trusted operator instances after doctor write probes pass.
- Keep fleet, observer, and shared dashboard boards read-only in onboarding guidance.
- Update maintained WORKFLOW templates and add docs regression coverage.

Fixes #564

## Test Plan

- [x] `go test ./... -run TestOnboardingDocsRecommendProjectKanbanIntegrationAfterWriteProbes`
- [x] `make check`