### PR TITLE
fix(orchestrator): audit cancellation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -744,9 +744,9 @@ If `workspace.source_root` is omitted, Detent falls back to the project
 setups.
 
 `workspace.cleanup_idle_ttl_ms` controls how long non-active observed
-workspaces can sit idle before cleanup. Terminal issues are cleaned immediately
-when observed. `workspace.cleanup_sweep_interval_ms` controls the startup and
-periodic cleanup cadence.
+workspaces can sit idle before cleanup. Terminal issues are cleaned on the next
+poll when observed. `workspace.cleanup_sweep_interval_ms` controls the startup
+and periodic idle cleanup cadence.
 
 `polling.interval_ms` defaults to `120000` and must be at least `60000`.
 Detent work is async, so it does not need sub-minute board scans. Detent polls
@@ -1255,6 +1255,38 @@ The recommended GitHub Project board states are:
 | `Merging` | Final rebase, merge-gate check, CI watch, and merge. |
 | `Done` | Complete. |
 | `Cancelled` | Terminal state mapped to `Done` in the default release flow. |
+
+### Cancellation Lifecycle
+
+Manual `Cancelled` means Detent should stop managing the work item, not that
+GitHub issues or pull requests are automatically closed. On the next poll that
+observes the cancelled terminal state, Detent cancels any running agent context,
+releases the global dispatch slot, clears configured claim lease state, records
+the run as completed with final state `Cancelled`, and asks the workspace
+backend to remove the Detent worktree, prune git worktrees, delete the generated
+`detent/` branch when safe, and reap workspace processes.
+
+Terminal cleanup is attempted on each poll for terminal states so a cancelled
+non-running issue can still clean up an existing Detent workspace without
+waiting for the idle cleanup sweep. The idle sweep interval still controls
+non-terminal observed workspace cleanup.
+
+Detent emits cleanup diagnostics in `/api/v1/state` under `events` and in
+published telemetry snapshots. A successful cleanup records
+`workspace_reap_succeeded` with `worktrees=`, `branches=`, and `processes=`
+counts. Cleanup failures record `workspace_reap_failed`, leave the workspace
+eligible for a later retry, and keep the diagnostic visible in recent events.
+If Detent completes a terminal run but no workspace reaper is configured, it
+records `workspace_reap_unverified`.
+
+Detent does not close the GitHub issue when an item is manually cancelled. The
+configured tracker state is the source of truth; in label mode, the default
+`Cancelled: Done` state map means the repository label is `detent:done`.
+Operators remain responsible for closing the GitHub issue with `not_planned` or
+another reason when that is the desired repository record.
+
+Detent also leaves linked pull requests open. Operators should close, comment
+on, or reuse an open PR explicitly when cancelled work has one.
 
 ### Review gate
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2076,6 +2076,24 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      --jq '.[] | select(.body | startswith("## Codex Workpad")) | .html_url' | rg .
    ```
 
+6. **Verify cancellation cleanup when testing terminal moves.** Moving an item
+   to `Cancelled` is a Detent workflow transition; Detent does not close the
+   GitHub issue and does not close or comment on linked pull requests. Operators
+   own those repository-record decisions. Detent stops any running agent,
+   releases the dispatch slot and claim lease, records the run as terminal, and
+   reaps Detent-owned workspace resources on the next poll that observes the
+   cancelled terminal state. Confirm the cleanup diagnostic is visible:
+
+   ```sh
+   curl -fsS http://127.0.0.1:<port>/api/v1/state \
+     | jq -e '.events[] | select(.event == "workspace_reap_succeeded" and (.message | contains("reason=cancelled")) and (.message | contains("worktrees=")) and (.message | contains("branches=")) and (.message | contains("processes=")))'
+   ```
+
+   If cleanup fails, Detent records `workspace_reap_failed`, leaves the
+   workspace eligible for a later retry, and includes the cleanup error in the
+   event message. If no workspace reaper is configured for a terminal run,
+   Detent records `workspace_reap_unverified`.
+
 ## Reconfiguration Closeout
 
 Use this checklist after editing an existing Detent setup, especially after

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"slices"
 	"strings"
@@ -1452,6 +1453,13 @@ func (o *Orchestrator) completeTerminalRunning(
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+	if err := o.abandonClaim(ctx, issueID); err != nil {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(completedAt),
+			Event:   "claim_release_failed",
+			Message: fmt.Sprintf("claim lease release failed for %s: %v", issueLabel(running.Issue), err),
+		})
+	}
 	issue := o.ensureClosedCompletedRunningIssueDone(ctx, issueID, running.Issue)
 	finalState := strings.TrimSpace(issue.State)
 	if finalState == "" {
@@ -1468,7 +1476,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	if diffStatsPresent(running.DiffStats) {
 		state.DiffStats[issueID] = running.DiffStats
 	}
-	o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates))
+	o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates), completedAt)
 }
 
 func (o *Orchestrator) ensureClosedCompletedRunningIssueDone(ctx context.Context, issueID string, issue connector.Issue) connector.Issue {

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -2,27 +2,38 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, now time.Time) {
 	if o.reaper == nil {
 		return
 	}
-	if !state.LastWorkspaceCleanupAt.IsZero() && now.Before(state.LastWorkspaceCleanupAt.Add(o.cfg.WorkspaceCleanupSweepInterval)) {
-		return
-	}
-	state.LastWorkspaceCleanupAt = now
 
 	states := cleanupFetchStates(o.cfg)
 	if len(states) == 0 {
 		return
 	}
+	if state.LastWorkspaceCleanupAt.IsZero() || !now.Before(state.LastWorkspaceCleanupAt.Add(o.cfg.WorkspaceCleanupSweepInterval)) {
+		state.LastWorkspaceCleanupAt = now
+		o.reapWorkspaceStates(ctx, state, states, now)
+		return
+	}
 
+	terminalStates := cleanupTerminalFetchStates(o.cfg)
+	if len(terminalStates) == 0 {
+		return
+	}
+	o.reapWorkspaceStates(ctx, state, terminalStates, now)
+}
+
+func (o *Orchestrator) reapWorkspaceStates(ctx context.Context, state *State, states []string, now time.Time) {
 	issues, err := o.connector.FetchIssuesByStates(ctx, states)
 	if err != nil {
 		o.logger.Warn("fetch workspace cleanup candidates failed", slog.Any("error", err))
@@ -35,12 +46,16 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 		if o.completeRunningIssueFromWorkspaceCleanup(ctx, state, issue, now) {
 			continue
 		}
-		o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates))
+		o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates), now)
 	}
 }
 
 func cleanupFetchStates(cfg Config) []string {
 	return appendUniqueStates(cfg.TerminalStates, cfg.ObservedStates)
+}
+
+func cleanupTerminalFetchStates(cfg Config) []string {
+	return appendUniqueStates(cfg.TerminalStates)
 }
 
 func appendUniqueStates(groups ...[]string) []string {
@@ -103,6 +118,8 @@ func workspaceIssueIdleSince(issue connector.Issue) (time.Time, bool) {
 
 func workspaceReapReason(issue connector.Issue, terminalStates []string) string {
 	switch {
+	case stateIn(issue.State, terminalStates) && workspaceIssueCancelled(issue.State):
+		return "cancelled"
 	case issue.Closed:
 		return "closed"
 	case issue.PullRequest != nil && normalizePullRequestState(issue.PullRequest.State) == "merged":
@@ -111,6 +128,15 @@ func workspaceReapReason(issue connector.Issue, terminalStates []string) string 
 		return "terminal"
 	default:
 		return "idle"
+	}
+}
+
+func workspaceIssueCancelled(state string) bool {
+	switch normalizeState(state) {
+	case "cancelled", "canceled":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -141,8 +167,13 @@ func (o *Orchestrator) completeRunningIssueFromWorkspaceCleanup(ctx context.Cont
 	return true
 }
 
-func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue connector.Issue, reason string) {
+func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue connector.Issue, reason string, now time.Time) {
 	if o.reaper == nil {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(now),
+			Event:   "workspace_reap_unverified",
+			Message: workspaceReapUnverifiedMessage(issue, reason),
+		})
 		return
 	}
 	if _, ok := state.ReapedWorkspaces[issue.ID]; ok {
@@ -157,12 +188,19 @@ func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue co
 			slog.String("reason", reason),
 			slog.Any("error", err),
 		)
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(now),
+			Event:   "workspace_reap_failed",
+			Message: workspaceReapFailedMessage(issue, reason, err),
+		})
 		return
 	}
-	state.ReapedWorkspaces[issue.ID] = time.Now().UTC()
-	if result.Worktrees == 0 && result.Branches == 0 && result.Processes == 0 {
-		return
-	}
+	state.ReapedWorkspaces[issue.ID] = cleanupEventAt(now)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      cleanupEventAt(now),
+		Event:   "workspace_reap_succeeded",
+		Message: workspaceReapSucceededMessage(issue, reason, result),
+	})
 	o.logger.Info(
 		"workspace reaped",
 		slog.String("issue_id", issue.ID),
@@ -172,4 +210,30 @@ func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue co
 		slog.Int("branches", result.Branches),
 		slog.Int("processes", result.Processes),
 	)
+}
+
+func cleanupEventAt(now time.Time) time.Time {
+	if now.IsZero() {
+		return time.Now().UTC()
+	}
+	return now.UTC()
+}
+
+func workspaceReapSucceededMessage(issue connector.Issue, reason string, result WorkspaceReapResult) string {
+	return fmt.Sprintf(
+		"workspace cleanup succeeded for %s reason=%s worktrees=%d branches=%d processes=%d",
+		issueLabel(issue),
+		reason,
+		result.Worktrees,
+		result.Branches,
+		result.Processes,
+	)
+}
+
+func workspaceReapFailedMessage(issue connector.Issue, reason string, err error) string {
+	return fmt.Sprintf("workspace cleanup failed for %s reason=%s: %v", issueLabel(issue), reason, err)
+}
+
+func workspaceReapUnverifiedMessage(issue connector.Issue, reason string) string {
+	return fmt.Sprintf("workspace cleanup could not be verified for %s reason=%s: workspace reaper unavailable", issueLabel(issue), reason)
 }

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -228,6 +229,194 @@ func TestTickReapsTerminalRunningIssue(t *testing.T) {
 	}
 	if snapshot.Counts.Completed != 1 || len(snapshot.Completed) != 1 {
 		t.Fatalf("snapshot completed count = %d len = %d, want 1", snapshot.Counts.Completed, len(snapshot.Completed))
+	}
+}
+
+func TestTickCancelledRunningIssueAuditsWorkspaceCleanupAndReleasesLease(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 12, 0, 0, 0, time.UTC)
+	startedAt := now.Add(-10 * time.Minute)
+	cancelledAt := now.Add(-30 * time.Second)
+	issue := connector.Issue{
+		ID:         "issue-cancelled-running",
+		Identifier: "digitaldrywood/detent#586",
+		Title:      "Cancellation audit",
+		State:      "In Progress",
+		URL:        "https://github.com/digitaldrywood/detent/issues/586",
+	}
+	cancelled := cloneIssue(issue)
+	cancelled.State = "Cancelled"
+	cancelled.StageUpdatedAt = &cancelledAt
+
+	runCtx, cancel := context.WithCancel(context.Background())
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		Claiming: ClaimingConfig{
+			Enabled:           true,
+			OwnershipMode:     "field",
+			Owner:             "detent-test",
+			OwnerField:        "Owner",
+			LeaseField:        "Lease",
+			LeaseTTL:          time.Minute,
+			HeartbeatInterval: time.Hour,
+		},
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:                []string{"Human Review"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		WorkspaceCleanupSweepInterval: time.Hour,
+	})
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:     cloneIssue(issue),
+		StartedAt: startedAt,
+		Tokens:    CodexTotals{TotalTokens: 15, RuntimeSeconds: 90},
+		cancel:    cancel,
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: startedAt, Owner: "detent-test"}
+
+	tracker := &runningStateConnector{issuesByState: []connector.Issue{cancelled}}
+	reaper := &cleanupSweepReaper{result: WorkspaceReapResult{Worktrees: 1, Branches: 1, Processes: 2}}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after cancellation cleanup", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after cancellation cleanup", issue.ID)
+	}
+	completed, ok := state.Completed[issue.ID]
+	if !ok {
+		t.Fatalf("Completed[%q] missing after cancellation cleanup", issue.ID)
+	}
+	if completed.FinalState != "Cancelled" {
+		t.Fatalf("Completed[%q].FinalState = %q, want Cancelled", issue.ID, completed.FinalState)
+	}
+	if !completed.CompletedAt.Equal(cancelledAt) {
+		t.Fatalf("Completed[%q].CompletedAt = %v, want %v", issue.ID, completed.CompletedAt, cancelledAt)
+	}
+	select {
+	case <-runCtx.Done():
+	default:
+		t.Fatal("running context was not cancelled")
+	}
+	if !tracker.hasSetField(issue.ID, "Lease", "") {
+		t.Fatalf("SetField(%q, Lease, empty) not recorded; calls = %#v", issue.ID, tracker.setFieldCalls)
+	}
+	if len(reaper.issues) != 1 || reaper.issues[0].ID != issue.ID {
+		t.Fatalf("reaped issues = %#v, want cancelled issue", reaper.issues)
+	}
+
+	event, ok := recentStateEvent(state, "workspace_reap_succeeded")
+	if !ok {
+		t.Fatalf("RecentEvents = %#v, want workspace_reap_succeeded", state.RecentEvents)
+	}
+	for _, want := range []string{
+		"digitaldrywood/detent#586",
+		"reason=cancelled",
+		"worktrees=1",
+		"branches=1",
+		"processes=2",
+	} {
+		if !strings.Contains(event.Message, want) {
+			t.Fatalf("cleanup event message = %q, want %q", event.Message, want)
+		}
+	}
+	snapshot := state.Snapshot(now)
+	if len(snapshot.Events) != 1 || snapshot.Events[0].Event != "workspace_reap_succeeded" {
+		t.Fatalf("snapshot Events = %#v, want cleanup success event", snapshot.Events)
+	}
+}
+
+func TestTickCancelledNonRunningIssueReapsWorkspaceEvenBeforeNextSweep(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 12, 30, 0, 0, time.UTC)
+	cancelled := connector.Issue{
+		ID:         "issue-cancelled-non-running",
+		Identifier: "digitaldrywood/detent#587",
+		Title:      "Cancelled non-running work",
+		State:      "Cancelled",
+	}
+	cfg := normalizeConfig(Config{
+		PollInterval:                  time.Minute,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:                []string{"Human Review"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		WorkspaceCleanupSweepInterval: time.Hour,
+	})
+	state := newState(cfg)
+	state.LastWorkspaceCleanupAt = now.Add(-time.Minute)
+
+	tracker := &runningStateConnector{issuesByState: []connector.Issue{cancelled}}
+	reaper := &cleanupSweepReaper{result: WorkspaceReapResult{Worktrees: 1}}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(reaper.issues) != 1 || reaper.issues[0].ID != cancelled.ID {
+		t.Fatalf("reaped issues = %#v, want cancelled non-running issue before next sweep", reaper.issues)
+	}
+	if event, ok := recentStateEvent(state, "workspace_reap_succeeded"); !ok || !strings.Contains(event.Message, "digitaldrywood/detent#587") {
+		t.Fatalf("RecentEvents = %#v, want cancelled cleanup success event", state.RecentEvents)
+	}
+}
+
+func TestTickWorkspaceCleanupFailureRecordsDiagnosticEvent(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	cancelled := connector.Issue{
+		ID:         "issue-cancelled-failure",
+		Identifier: "digitaldrywood/detent#588",
+		Title:      "Cancelled cleanup failure",
+		State:      "Cancelled",
+	}
+	cfg := normalizeConfig(Config{
+		PollInterval:                  time.Minute,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:                []string{"Human Review"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		WorkspaceCleanupSweepInterval: time.Hour,
+	})
+	state := newState(cfg)
+	tracker := &runningStateConnector{issuesByState: []connector.Issue{cancelled}}
+	reaper := &cleanupSweepReaper{err: errors.New("remove worktree: permission denied")}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		reaper:    reaper,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if _, ok := state.ReapedWorkspaces[cancelled.ID]; ok {
+		t.Fatalf("ReapedWorkspaces[%q] present after failed cleanup", cancelled.ID)
+	}
+	event, ok := recentStateEvent(state, "workspace_reap_failed")
+	if !ok {
+		t.Fatalf("RecentEvents = %#v, want workspace_reap_failed", state.RecentEvents)
+	}
+	for _, want := range []string{"digitaldrywood/detent#588", "reason=cancelled", "permission denied"} {
+		if !strings.Contains(event.Message, want) {
+			t.Fatalf("cleanup failure event message = %q, want %q", event.Message, want)
+		}
 	}
 }
 
@@ -505,6 +694,7 @@ type runningStateConnector struct {
 	err           error
 	requestedIDs  []string
 	updates       []statusUpdate
+	setFieldCalls []reconcileSetFieldCall
 }
 
 func (c *runningStateConnector) Name() string {
@@ -515,8 +705,8 @@ func (c *runningStateConnector) FetchCandidateIssues(context.Context) ([]connect
 	return []connector.Issue{}, nil
 }
 
-func (c *runningStateConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
-	return cloneIssues(c.issuesByState), nil
+func (c *runningStateConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	return issuesInStates(c.issuesByState, states), nil
 }
 
 func (c *runningStateConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
@@ -540,15 +730,47 @@ func (c *runningStateConnector) SetAssignee(context.Context, string, string) err
 	return nil
 }
 
-func (c *runningStateConnector) SetField(context.Context, string, string, string) error {
+func (c *runningStateConnector) SetField(_ context.Context, issueID string, field string, value string) error {
+	c.setFieldCalls = append(c.setFieldCalls, reconcileSetFieldCall{issueID: issueID, field: field, value: value})
 	return nil
 }
 
+func (c *runningStateConnector) hasSetField(issueID string, field string, value string) bool {
+	for _, call := range c.setFieldCalls {
+		if call.issueID == issueID && call.field == field && call.value == value {
+			return true
+		}
+	}
+	return false
+}
+
+type reconcileSetFieldCall struct {
+	issueID string
+	field   string
+	value   string
+}
+
 type cleanupSweepReaper struct {
+	result WorkspaceReapResult
+	err    error
 	issues []connector.Issue
 }
 
 func (r *cleanupSweepReaper) ReapWorkspace(_ context.Context, issue connector.Issue) (WorkspaceReapResult, error) {
 	r.issues = append(r.issues, cloneIssue(issue))
-	return WorkspaceReapResult{}, nil
+	return r.result, r.err
+}
+
+func recentStateEvent(state State, event string) (telemetryEvent, bool) {
+	for _, candidate := range state.RecentEvents {
+		if candidate.Event == event {
+			return telemetryEvent{Event: candidate.Event, Message: candidate.Message}, true
+		}
+	}
+	return telemetryEvent{}, false
+}
+
+type telemetryEvent struct {
+	Event   string
+	Message string
 }

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -250,6 +250,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceN
 		Instance:       instanceResponse(snapshot.Instance, instanceName),
 		Projects:       projectsAPIResponse(snapshot),
 		Refresh:        snapshot.Refresh,
+		Events:         recentEventsFromTelemetry(snapshot.Events, nil, "", ""),
 		Counts:         countsResponse(snapshot),
 		Running:        runningEntries(snapshot.Running),
 		Retrying:       retryEntries(snapshot.Queue),
@@ -966,6 +967,7 @@ type stateAPIResponse struct {
 	Instance       instanceAPIResponse         `json:"instance"`
 	Projects       []telemetry.ProjectSnapshot `json:"projects,omitempty"`
 	Refresh        telemetry.Refresh           `json:"refresh"`
+	Events         []recentEventAPIResponse    `json:"events"`
 	Counts         countsAPIResponse           `json:"counts"`
 	Running        []runningAPIResponse        `json:"running"`
 	Retrying       []retryAPIResponse          `json:"retrying"`

--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -694,10 +694,16 @@ func demoHealthySnapshot() telemetry.Snapshot {
 		Shutdown:     telemetry.Shutdown{Status: "running"},
 		Refresh:      telemetry.Refresh{PollIntervalSeconds: 60, LastRefreshAt: &lastRefresh, NextRefreshAt: &nextRefresh},
 		Counts:       telemetry.Counts{Running: 3, Queue: 3, Blocked: 2, Completed: 4},
+		Events: []telemetry.ActivityEvent{
+			{
+				At:      now.Add(-3 * time.Minute),
+				Event:   "workspace_reap_succeeded",
+				Message: "workspace cleanup succeeded for digitaldrywood/mobile-client#5243 reason=cancelled worktrees=1 branches=1 processes=0",
+			},
+		},
 		BoardIssues: []telemetry.Issue{
 			demoIssue(demoPrimaryProjectID, "demo-backlog", "digitaldrywood/detent-core#5250", "Backlog observability fixture intake", "Backlog", 72),
 			demoIssue(demoPrimaryProjectID, "demo-todo", "digitaldrywood/detent-core#5251", "Add screenshot manifest smoke test", "Todo", 9),
-			demoIssue(demoPrimaryProjectID, "demo-cancelled", "digitaldrywood/detent-core#5259", "Cancelled alternate dashboard theme", "Cancelled", 48),
 			demoIssue("agent-lab", "agent-lab-todo", "digitaldrywood/agent-lab#111", "Try secondary runner routing", "Todo", 11),
 		},
 		Pipeline: []telemetry.Issue{

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -261,6 +261,16 @@ func TestDemoScenarioManifestPagesAndAPIs(t *testing.T) {
 	if counts["running"] != float64(3) || counts["retrying"] != float64(3) || counts["blocked"] != float64(2) {
 		t.Fatalf("state counts = %#v", counts)
 	}
+	if _, ok := boardStateCountOK(t, state, "Cancelled"); ok {
+		t.Fatalf("demo state includes Cancelled on the active board: %#v", state["board"])
+	}
+	cleanupEvents := state["events"].([]any)
+	if len(cleanupEvents) == 0 || cleanupEvents[0].(map[string]any)["event"] != "workspace_reap_succeeded" {
+		t.Fatalf("demo events = %#v, want cancellation cleanup event", cleanupEvents)
+	}
+	if !strings.Contains(cleanupEvents[0].(map[string]any)["message"].(string), "reason=cancelled") {
+		t.Fatalf("demo cleanup event = %#v, want cancellation reason", cleanupEvents[0])
+	}
 
 	usage := requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/usage?by=project", http.StatusOK, map[string]string{
 		web.DemoScenarioHeader: "api-usage-populated",
@@ -4501,6 +4511,13 @@ func TestServerAPIRoutes(t *testing.T) {
 	events := hub.New[telemetry.Snapshot]()
 	if err := events.Publish(telemetry.Snapshot{
 		GeneratedAt: generatedAt,
+		Events: []telemetry.ActivityEvent{
+			{
+				At:      generatedAt.Add(-20 * time.Second),
+				Event:   "workspace_reap_succeeded",
+				Message: "workspace cleanup succeeded for digitaldrywood/detent#586 reason=cancelled worktrees=1 branches=1 processes=2",
+			},
+		},
 		Running: []telemetry.Running{
 			{
 				Issue: telemetry.Issue{
@@ -4645,6 +4662,13 @@ func TestServerAPIRoutes(t *testing.T) {
 	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
 	if state["generated_at"] != generatedAt.Format(time.RFC3339) {
 		t.Fatalf("generated_at = %q, want %q", state["generated_at"], generatedAt.Format(time.RFC3339))
+	}
+	cleanupEvents := state["events"].([]any)
+	if len(cleanupEvents) != 1 || cleanupEvents[0].(map[string]any)["event"] != "workspace_reap_succeeded" {
+		t.Fatalf("events = %#v, want workspace cleanup event", cleanupEvents)
+	}
+	if !strings.Contains(cleanupEvents[0].(map[string]any)["message"].(string), "reason=cancelled") {
+		t.Fatalf("cleanup event message = %#v, want cancellation reason", cleanupEvents[0])
 	}
 	if got := nestedString(t, state, "counts", "running"); got != "1" {
 		t.Fatalf("counts.running = %s, want 1", got)


### PR DESCRIPTION
## Summary

- make cancellation cleanup record success, failure, and unverified telemetry events
- release claim leases and promptly reap terminal Cancelled workspaces outside the idle sweep cadence
- expose cleanup events in the state API and demo coverage, and document GitHub issue/PR behavior

Fixes #586

## Test Plan

- [x] `make check`