### PR TITLE
fix(kanban): keep completed sessions out of lanes

### DIFF
--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -142,8 +142,8 @@ func demoScenarioDefinitions() []demoScenario {
 		{ID: "kanban-dense-overflow", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "dense-kanban", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
 		{ID: "kanban-transition-blocked", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "transition-blocked", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
 		{ID: "kanban-terminal-states", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "terminal", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
-		{ID: "kanban-handoff-window", Route: "/projects/dogfood/kanban", WaitSelector: "#project-kanban", Page: "kanban", Variant: "handoff-window", ProjectID: demoPrimaryProjectID, KanbanMode: workflowconfig.KanbanModeIntegration},
 		{ID: "runs-active-work", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "healthy", ProjectID: demoPrimaryProjectID},
+		{ID: "runs-tracker-refresh-gap", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "tracker-refresh-gap", ProjectID: demoPrimaryProjectID},
 		{ID: "runs-idle", Route: "/projects/agent-lab/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "project-empty", ProjectID: "agent-lab"},
 		{ID: "runs-backoff-heavy", Route: "/projects/dogfood/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "backoff-heavy", ProjectID: demoPrimaryProjectID},
 		{ID: "runs-blocked-heavy", Route: "/projects/billing-api/runs", WaitSelector: "#snapshot", Page: "runs", Variant: "blocked-heavy", ProjectID: "billing-api"},
@@ -669,8 +669,8 @@ func demoSnapshotForScenario(scenario demoScenario) telemetry.Snapshot {
 		snapshot = demoDenseSnapshot()
 	case "hot-path", "model-heavy", "filtered-project":
 		snapshot = demoHotPathSnapshot()
-	case "handoff-window":
-		snapshot = demoHandoffWindowSnapshot()
+	case "tracker-refresh-gap":
+		snapshot = demoTrackerRefreshGapSnapshot()
 	}
 	if scenario.Variant == "terminal" {
 		snapshot.BoardIssues = append(snapshot.BoardIssues, demoIssue(demoPrimaryProjectID, "demo-cancelled", "digitaldrywood/detent-core#5259", "Cancelled alternate dashboard theme", "Cancelled", 48))
@@ -934,13 +934,13 @@ func demoHotPathSnapshot() telemetry.Snapshot {
 	return snapshot
 }
 
-func demoHandoffWindowSnapshot() telemetry.Snapshot {
+func demoTrackerRefreshGapSnapshot() telemetry.Snapshot {
 	snapshot := demoHealthySnapshot()
-	handoff := demoCompleted(demoPrimaryProjectID, "demo-handoff-window", "digitaldrywood/detent-core#5294", "Keep completed implementation visible during tracker refresh", "completed", 3, "gpt-5-codex", 41000)
-	handoff.PullRequest = &telemetry.PullRequest{
+	completed := demoCompleted(demoPrimaryProjectID, "demo-tracker-refresh-gap", "digitaldrywood/detent-core#5294", "Keep completed implementation visible during tracker refresh", "completed", 3, "gpt-5-codex", 41000)
+	completed.PullRequest = &telemetry.PullRequest{
 		Number:             5294,
-		URL:                demoPRURL(handoff.Identifier, 5294),
-		BranchName:         "detent/demo-handoff-window",
+		URL:                demoPRURL(completed.Identifier, 5294),
+		BranchName:         "detent/demo-tracker-refresh-gap",
 		State:              "OPEN",
 		MergeableState:     "clean",
 		CIStatus:           "success",
@@ -949,7 +949,7 @@ func demoHandoffWindowSnapshot() telemetry.Snapshot {
 		CIDurationSeconds:  260,
 		CodexReviewState:   "CLEAN",
 	}
-	snapshot.Completed = append([]telemetry.Completed{handoff}, snapshot.Completed...)
+	snapshot.Completed = append([]telemetry.Completed{completed}, snapshot.Completed...)
 	snapshot.Counts.Completed = len(snapshot.Completed)
 	for i := range snapshot.Projects {
 		if snapshot.Projects[i].Project.ID == demoPrimaryProjectID {

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -818,7 +818,7 @@ func kanbanAllowedTransitions(cfg workflowconfig.Config, states []string) map[st
 }
 
 func snapshotKanbanIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
-	issues := make([]telemetry.Issue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked)+len(snapshot.Completed))
+	issues := make([]telemetry.Issue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked))
 	issues = append(issues, snapshot.BoardIssues...)
 	issues = append(issues, snapshot.Pipeline...)
 	for _, row := range snapshot.Running {
@@ -828,9 +828,6 @@ func snapshotKanbanIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
 		issues = append(issues, row.Issue)
 	}
 	for _, row := range snapshot.Blocked {
-		issues = append(issues, row.Issue)
-	}
-	for _, row := range snapshot.Completed {
 		issues = append(issues, row.Issue)
 	}
 	return issues

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -1,0 +1,72 @@
+package web
+
+import (
+	"slices"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestKanbanStateNamesIgnoreCompletedSessionStates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  workflowconfig.Config
+		want []string
+	}{
+		{
+			name: "unconfigured completed handoff ignored",
+			cfg: workflowconfig.Config{
+				Tracker: workflowconfig.Tracker{
+					ObservedStates: []string{"Backlog", "Blocked", "Human Review"},
+					ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+					TerminalStates: []string{"Done", "Cancelled"},
+				},
+			},
+			want: []string{"Backlog", "Blocked", "Human Review", "Todo", "In Progress", "Rework", "Merging", "Done", "Cancelled", "Needs Triage"},
+		},
+		{
+			name: "configured handoff preserved",
+			cfg: workflowconfig.Config{
+				Tracker: workflowconfig.Tracker{
+					ObservedStates: []string{"Backlog", "Handoff"},
+					ActiveStates:   []string{"Todo"},
+					TerminalStates: []string{"Done"},
+				},
+			},
+			want: []string{"Backlog", "Handoff", "Todo", "Done", "Needs Triage"},
+		},
+	}
+
+	snapshot := telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{
+			{ID: "tracker-extra", State: "Needs Triage"},
+		},
+		Completed: []telemetry.Completed{
+			{
+				Issue: telemetry.Issue{
+					ID:    "completed-open-pr",
+					State: "Handoff",
+					PullRequest: &telemetry.PullRequest{
+						Number: 554,
+						State:  "OPEN",
+					},
+				},
+				FinalState: "completed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := kanbanStateNames(tt.cfg, snapshot)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("kanbanStateNames() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2420,7 +2420,7 @@ func prunePRPipelineCards(cardsByLane map[string][]prPipelineCard) {
 
 func prPipelineLaneID(state string) string {
 	switch strings.ToLower(strings.ReplaceAll(strings.TrimSpace(state), " ", "")) {
-	case "humanreview", "review", "inreview":
+	case "humanreview", "review", "inreview", "handoff", "pendingtrackerrefresh":
 		return "human-review"
 	case "merging":
 		return "merging"

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -25,9 +25,6 @@ const (
 	kanbanActionDialogID        = "kanban-action-dialog"
 	kanbanDialogContentID       = "kanban-dialog-content"
 	projectKanbanLaneWidthClass = "w-[var(--project-kanban-lane-width,18rem)] min-w-[var(--project-kanban-lane-width,18rem)] max-w-[var(--project-kanban-lane-width,18rem)] basis-[var(--project-kanban-lane-width,18rem)] shrink-0"
-	handoffVisibilityWindow     = 15 * time.Minute
-	handoffState                = "Handoff"
-	handoffWaitDetail           = "waiting for tracker refresh"
 )
 
 type DashboardData struct {
@@ -1404,8 +1401,6 @@ func projectKanbanCardsByState(data DashboardData) map[string][]projectKanbanCar
 
 func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 	byIssue := map[string]projectKanbanIssueCard{}
-	currentIssues := currentWorkflowIssueKeys(snapshot)
-	now := pipelineNow(snapshot)
 	nextIndex := 0
 	appendIssue := func(issue telemetry.Issue, state string, stageAt time.Time, rank int) {
 		state = strings.TrimSpace(state)
@@ -1448,13 +1443,6 @@ func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 			stageAt = *row.BlockedAt
 		}
 		appendIssue(row.Issue, issueState(row.Issue, "Blocked"), stageAt, 40)
-	}
-	for _, row := range snapshot.Completed {
-		issue, stageAt, ok := completedHandoffIssue(row, currentIssues, now)
-		if !ok {
-			continue
-		}
-		appendIssue(issue, handoffState, stageAt, 1)
 	}
 
 	issues := make([]projectKanbanIssueCard, 0, len(byIssue))
@@ -1948,7 +1936,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		PullRequestLabel: projectKanbanPullRequestLabel(issue),
 		TimeInStage:      prPipelineAge(stageAt, now),
 		TimeInStageTitle: prPipelineAgeTitle(state, stageAt, now),
-		WaitDetail:       workflowWaitDetail(state, issue),
+		WaitDetail:       prPipelineWaitDetail(issue),
 		Stage:            chartText(state, "n/a"),
 		StageAt:          stageAt.UTC(),
 		Labels:           uniqueStrings(issue.Labels),
@@ -2321,7 +2309,6 @@ func prPipelineLanes(snapshot telemetry.Snapshot) []prPipelineLane {
 		"done-today":   {},
 	}
 	seen := map[string]struct{}{}
-	currentIssues := currentWorkflowIssueKeys(snapshot)
 	now := pipelineNow(snapshot)
 
 	for _, issue := range snapshot.Pipeline {
@@ -2343,13 +2330,6 @@ func prPipelineLanes(snapshot telemetry.Snapshot) []prPipelineLane {
 			stageAt = *row.BlockedAt
 		}
 		appendPRPipelineCard(cardsByLane, seen, row.Issue, issueState(row.Issue, "Blocked"), stageAt, now)
-	}
-	for _, row := range snapshot.Completed {
-		issue, stageAt, ok := completedHandoffIssue(row, currentIssues, now)
-		if !ok {
-			continue
-		}
-		appendPRPipelineCard(cardsByLane, seen, issue, handoffState, stageAt, now)
 	}
 
 	prunePRPipelineCards(cardsByLane)
@@ -2442,8 +2422,6 @@ func prPipelineLaneID(state string) string {
 	switch strings.ToLower(strings.ReplaceAll(strings.TrimSpace(state), " ", "")) {
 	case "humanreview", "review", "inreview":
 		return "human-review"
-	case "handoff", "pendingtrackerrefresh":
-		return "human-review"
 	case "merging":
 		return "merging"
 	case "done", "complete", "completed", "closed", "cancelled", "canceled":
@@ -2468,21 +2446,10 @@ func prPipelineCardForIssue(issue telemetry.Issue, state string, laneID string, 
 		CodexReviewClass: prPipelineCodexReviewClass(codexReview),
 		TimeInStage:      prPipelineAge(stageAt, now),
 		TimeInStageTitle: prPipelineAgeTitle(state, stageAt, now),
-		WaitDetail:       workflowWaitDetail(state, issue),
+		WaitDetail:       prPipelineWaitDetail(issue),
 		Stage:            chartText(state, "n/a"),
 		StageAt:          stageAt.UTC(),
 	}
-}
-
-func workflowWaitDetail(state string, issue telemetry.Issue) string {
-	parts := []string{}
-	if projectKanbanStateKey(state) == projectKanbanStateKey(handoffState) {
-		parts = append(parts, handoffWaitDetail)
-	}
-	if detail := prPipelineWaitDetail(issue); detail != "" {
-		parts = append(parts, detail)
-	}
-	return strings.Join(parts, " / ")
 }
 
 func prPipelineWaitDetail(issue telemetry.Issue) string {
@@ -2565,85 +2532,6 @@ func pipelineNow(snapshot telemetry.Snapshot) time.Time {
 		}
 	}
 	return latest.UTC()
-}
-
-func currentWorkflowIssueKeys(snapshot telemetry.Snapshot) map[string]struct{} {
-	out := map[string]struct{}{}
-	add := func(issue telemetry.Issue) {
-		key := workflowIssueKey(issue)
-		if key != "" {
-			out[key] = struct{}{}
-		}
-	}
-	for _, issue := range snapshot.BoardIssues {
-		add(issue)
-	}
-	for _, issue := range snapshot.Pipeline {
-		add(issue)
-	}
-	for _, row := range snapshot.Running {
-		add(row.Issue)
-	}
-	for _, row := range snapshot.Queue {
-		add(row.Issue)
-	}
-	for _, row := range snapshot.Blocked {
-		add(row.Issue)
-	}
-	return out
-}
-
-func workflowIssueKey(issue telemetry.Issue) string {
-	if id := strings.TrimSpace(issue.ID); id != "" {
-		return "id:" + id
-	}
-	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" {
-		return "identifier:" + identifier
-	}
-	return ""
-}
-
-func completedHandoffIssue(row telemetry.Completed, currentIssues map[string]struct{}, now time.Time) (telemetry.Issue, time.Time, bool) {
-	if !completedHandoffFinalState(row.FinalState) {
-		return telemetry.Issue{}, time.Time{}, false
-	}
-	if !openLinkedPullRequest(row.PullRequest) {
-		return telemetry.Issue{}, time.Time{}, false
-	}
-	if completedHandoffExpired(row.CompletedAt, now) {
-		return telemetry.Issue{}, time.Time{}, false
-	}
-	if key := workflowIssueKey(row.Issue); key != "" {
-		if _, ok := currentIssues[key]; ok {
-			return telemetry.Issue{}, time.Time{}, false
-		}
-	}
-	issue := row.Issue
-	issue.State = handoffState
-	return issue, row.CompletedAt, true
-}
-
-func completedHandoffFinalState(state string) bool {
-	return strings.EqualFold(strings.TrimSpace(state), "completed")
-}
-
-func completedHandoffExpired(completedAt time.Time, now time.Time) bool {
-	if completedAt.IsZero() || now.IsZero() {
-		return false
-	}
-	return now.UTC().Sub(completedAt.UTC()) > handoffVisibilityWindow
-}
-
-func openLinkedPullRequest(pr *telemetry.PullRequest) bool {
-	if pr == nil {
-		return false
-	}
-	switch strings.ToUpper(strings.TrimSpace(pr.State)) {
-	case "CLOSED", "MERGED":
-		return false
-	default:
-		return pr.Number > 0 || strings.TrimSpace(pr.URL) != ""
-	}
 }
 
 func pipelineIssueStageTime(issue telemetry.Issue) time.Time {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1428,6 +1428,54 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 	}
 }
 
+func TestPRPipelineLanesPreserveTrackerRefreshRows(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	stageAt := now.Add(-2 * time.Minute)
+	tests := []struct {
+		name  string
+		state string
+	}{
+		{name: "handoff", state: "Handoff"},
+		{name: "pending tracker refresh", state: "Pending Tracker Refresh"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := collectPipelineCards(prPipelineLanes(telemetry.Snapshot{
+				GeneratedAt: now,
+				Pipeline: []telemetry.Issue{
+					{
+						ID:             "issue-550",
+						Identifier:     "digitaldrywood/detent#550",
+						Title:          "Keep tracker row visible",
+						State:          tt.state,
+						StageUpdatedAt: &stageAt,
+						PullRequest: &telemetry.PullRequest{
+							Number:           552,
+							State:            "OPEN",
+							CIStatus:         "success",
+							CodexReviewState: "clean",
+						},
+					},
+				},
+			}))
+			want := []pipelineCardSnapshot{
+				{Lane: "Human Review", IssueNumber: "#552", Title: "Keep tracker row visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2m 0s"},
+			}
+			if len(got) != len(want) {
+				t.Fatalf("pipeline cards len = %d, want %d; got %#v", len(got), len(want), got)
+			}
+			if got[0] != want[0] {
+				t.Fatalf("pipeline card = %#v, want %#v", got[0], want[0])
+			}
+		})
+	}
+}
+
 func TestPRPipelineLanesDoNotTreatCompletedSessionAsCurrentDone(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -687,6 +687,10 @@ func TestAgentTimelineRows(t *testing.T) {
 					ID:         "issue-3",
 					Identifier: "DD-3",
 					Title:      "Completed issue",
+					PullRequest: &telemetry.PullRequest{
+						Number: 3,
+						State:  "OPEN",
+					},
 				},
 				StartedAt:   now.Add(-10 * time.Minute),
 				CompletedAt: now.Add(-2 * time.Minute),
@@ -714,6 +718,9 @@ func TestAgentTimelineRows(t *testing.T) {
 		if rows[i].Identifier != want {
 			t.Fatalf("row %d identifier = %q, want %q; rows = %#v", i, rows[i].Identifier, want, rows)
 		}
+	}
+	if rows[1].Title != "Completed issue" || rows[1].State != "completed" {
+		t.Fatalf("completed open PR timeline row = %#v", rows[1])
 	}
 
 	tests := []struct {
@@ -1040,13 +1047,13 @@ func TestProjectKanbanBoardDoesNotTreatCompletedSessionsAsCurrentDone(t *testing
 	}
 }
 
-func TestProjectKanbanBoardShowsCompletedOpenPRHandoff(t *testing.T) {
+func TestProjectKanbanBoardDoesNotProjectCompletedOpenPRSession(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
 	board := projectKanbanBoardView(DashboardData{
 		Kanban: KanbanData{
-			States: []string{"Todo", "Human Review", "Merging", "Done"},
+			States: []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework", "Merging", "Done", "Cancelled"},
 		},
 		Snapshot: telemetry.Snapshot{
 			GeneratedAt: now,
@@ -1056,7 +1063,7 @@ func TestProjectKanbanBoardShowsCompletedOpenPRHandoff(t *testing.T) {
 						ID:         "issue-550",
 						Identifier: "digitaldrywood/detent#550",
 						URL:        "https://github.com/digitaldrywood/detent/issues/550",
-						Title:      "Keep completed handoff visible",
+						Title:      "Keep completed implementation visible",
 						PullRequest: &telemetry.PullRequest{
 							Number:           552,
 							URL:              "https://github.com/digitaldrywood/detent/pull/552",
@@ -1073,28 +1080,52 @@ func TestProjectKanbanBoardShowsCompletedOpenPRHandoff(t *testing.T) {
 	})
 
 	got := collectKanbanCards(board.Lanes)
-	want := []kanbanCardSnapshot{
-		{
-			Lane:             "Handoff",
-			IssueNumber:      "#550",
-			Title:            "Keep completed handoff visible",
-			URL:              "https://github.com/digitaldrywood/detent/issues/550",
-			CIStatus:         "pass",
-			CodexReviewState: "clean",
-			TimeInStage:      "2m 0s",
-			WaitDetail:       "waiting for tracker refresh",
-			Metadata:         "PR #552",
-		},
+	if len(got) != 0 {
+		t.Fatalf("kanban cards len = %d, want 0; got %#v", len(got), got)
 	}
-	if len(got) != len(want) {
-		t.Fatalf("kanban cards len = %d, want %d; got %#v", len(got), len(want), got)
-	}
-	if got[0] != want[0] {
-		t.Fatalf("kanban card = %#v, want %#v", got[0], want[0])
+	if got := collectKanbanLaneTitles(board.AllLanes); containsString(got, "Handoff") {
+		t.Fatalf("all lanes = %#v, want no unconfigured Handoff lane", got)
 	}
 }
 
-func TestProjectKanbanBoardSuppressesCompletedHandoffWhenTrackerOwnsIssue(t *testing.T) {
+func TestProjectKanbanBoardLeavesConfiguredHandoffLaneEmptyForCompletedSession(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
+	board := projectKanbanBoardView(DashboardData{
+		Kanban: KanbanData{
+			States: []string{"Todo", "Handoff", "Done"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Completed: []telemetry.Completed{
+				{
+					Issue: telemetry.Issue{
+						ID:         "issue-550",
+						Identifier: "digitaldrywood/detent#550",
+						Title:      "Keep completed implementation visible",
+						PullRequest: &telemetry.PullRequest{
+							Number: 552,
+							State:  "OPEN",
+						},
+					},
+					CompletedAt: now.Add(-2 * time.Minute),
+					FinalState:  "completed",
+				},
+			},
+		},
+	})
+
+	got := collectKanbanCards(board.Lanes)
+	if len(got) != 0 {
+		t.Fatalf("kanban cards len = %d, want 0; got %#v", len(got), got)
+	}
+	if got := collectKanbanLaneTitles(board.EmptyLanes); !containsString(got, "Handoff") {
+		t.Fatalf("empty lanes = %#v, want configured Handoff lane", got)
+	}
+}
+
+func TestProjectKanbanBoardUsesTrackerStateWhenCompletedSessionAlsoExists(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
@@ -1109,7 +1140,7 @@ func TestProjectKanbanBoardSuppressesCompletedHandoffWhenTrackerOwnsIssue(t *tes
 				{
 					ID:             "issue-550",
 					Identifier:     "digitaldrywood/detent#550",
-					Title:          "Keep completed handoff visible",
+					Title:          "Keep completed implementation visible",
 					State:          "Human Review",
 					StageUpdatedAt: &stageAt,
 					PullRequest: &telemetry.PullRequest{
@@ -1125,7 +1156,7 @@ func TestProjectKanbanBoardSuppressesCompletedHandoffWhenTrackerOwnsIssue(t *tes
 					Issue: telemetry.Issue{
 						ID:         "issue-550",
 						Identifier: "digitaldrywood/detent#550",
-						Title:      "Keep completed handoff visible",
+						Title:      "Keep completed implementation visible",
 						PullRequest: &telemetry.PullRequest{
 							Number:           552,
 							State:            "OPEN",
@@ -1142,7 +1173,7 @@ func TestProjectKanbanBoardSuppressesCompletedHandoffWhenTrackerOwnsIssue(t *tes
 
 	got := collectKanbanCards(board.Lanes)
 	want := []kanbanCardSnapshot{
-		{Lane: "Human Review", IssueNumber: "#550", Title: "Keep completed handoff visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s", Metadata: "PR #552"},
+		{Lane: "Human Review", IssueNumber: "#550", Title: "Keep completed implementation visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s", Metadata: "PR #552"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("kanban cards len = %d, want %d; got %#v", len(got), len(want), got)
@@ -1152,7 +1183,7 @@ func TestProjectKanbanBoardSuppressesCompletedHandoffWhenTrackerOwnsIssue(t *tes
 	}
 }
 
-func TestCompletedOpenPRHandoffExpires(t *testing.T) {
+func TestCompletedOpenPRSessionDoesNotCreateWorkflowCards(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
@@ -1163,29 +1194,22 @@ func TestCompletedOpenPRHandoffExpires(t *testing.T) {
 				Issue: telemetry.Issue{
 					ID:         "issue-550",
 					Identifier: "digitaldrywood/detent#550",
-					Title:      "Keep completed handoff visible",
+					Title:      "Keep completed implementation visible",
 					PullRequest: &telemetry.PullRequest{
 						Number:   552,
 						State:    "OPEN",
 						CIStatus: "success",
 					},
 				},
-				CompletedAt: now.Add(-handoffVisibilityWindow - time.Second),
+				CompletedAt: now.Add(-2 * time.Minute),
 				FinalState:  "completed",
 			},
 		},
 	}
 
-	board := projectKanbanBoardView(DashboardData{
-		Kanban: KanbanData{
-			States: []string{"Todo", "Human Review", "Merging", "Done"},
-		},
-		Snapshot: snapshot,
-	})
-	if got := collectKanbanCards(board.Lanes); len(got) != 0 {
-		t.Fatalf("kanban cards len = %d, want 0; got %#v", len(got), got)
+	if got := projectKanbanIssues(snapshot); len(got) != 0 {
+		t.Fatalf("projectKanbanIssues() len = %d, want 0; got %#v", len(got), got)
 	}
-
 	if got := collectPipelineCards(prPipelineLanes(snapshot)); len(got) != 0 {
 		t.Fatalf("pipeline cards len = %d, want 0; got %#v", len(got), got)
 	}
@@ -1439,7 +1463,7 @@ func TestPRPipelineLanesDoNotTreatCompletedSessionAsCurrentDone(t *testing.T) {
 	}
 }
 
-func TestPRPipelineLanesShowCompletedOpenPRHandoff(t *testing.T) {
+func TestPRPipelineLanesDoNotProjectCompletedOpenPRSession(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
@@ -1450,7 +1474,7 @@ func TestPRPipelineLanesShowCompletedOpenPRHandoff(t *testing.T) {
 				Issue: telemetry.Issue{
 					ID:         "issue-550",
 					Identifier: "digitaldrywood/detent#550",
-					Title:      "Keep completed handoff visible",
+					Title:      "Keep completed implementation visible",
 					PullRequest: &telemetry.PullRequest{
 						Number:           552,
 						URL:              "https://github.com/digitaldrywood/detent/pull/552",
@@ -1466,26 +1490,12 @@ func TestPRPipelineLanesShowCompletedOpenPRHandoff(t *testing.T) {
 	}
 
 	got := collectPipelineCards(prPipelineLanes(snapshot))
-	want := []pipelineCardSnapshot{
-		{
-			Lane:             "Human Review",
-			IssueNumber:      "#552",
-			Title:            "Keep completed handoff visible",
-			CIStatus:         "pass",
-			CodexReviewState: "clean",
-			TimeInStage:      "2m 0s",
-			WaitDetail:       "waiting for tracker refresh",
-		},
-	}
-	if len(got) != len(want) {
-		t.Fatalf("pipeline cards len = %d, want %d; got %#v", len(got), len(want), got)
-	}
-	if got[0] != want[0] {
-		t.Fatalf("pipeline card = %#v, want %#v", got[0], want[0])
+	if len(got) != 0 {
+		t.Fatalf("pipeline cards len = %d, want 0; got %#v", len(got), got)
 	}
 }
 
-func TestPRPipelineLanesSuppressCompletedHandoffWhenTrackerOwnsIssue(t *testing.T) {
+func TestPRPipelineLanesUseTrackerStateWhenCompletedSessionAlsoExists(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 20, 13, 0, 0, 0, time.UTC)
@@ -1496,7 +1506,7 @@ func TestPRPipelineLanesSuppressCompletedHandoffWhenTrackerOwnsIssue(t *testing.
 			{
 				ID:             "issue-550",
 				Identifier:     "digitaldrywood/detent#550",
-				Title:          "Keep completed handoff visible",
+				Title:          "Keep completed implementation visible",
 				State:          "Merging",
 				StageUpdatedAt: &stageAt,
 				PullRequest: &telemetry.PullRequest{
@@ -1512,7 +1522,7 @@ func TestPRPipelineLanesSuppressCompletedHandoffWhenTrackerOwnsIssue(t *testing.
 				Issue: telemetry.Issue{
 					ID:         "issue-550",
 					Identifier: "digitaldrywood/detent#550",
-					Title:      "Keep completed handoff visible",
+					Title:      "Keep completed implementation visible",
 					PullRequest: &telemetry.PullRequest{
 						Number:           552,
 						State:            "OPEN",
@@ -1528,7 +1538,7 @@ func TestPRPipelineLanesSuppressCompletedHandoffWhenTrackerOwnsIssue(t *testing.
 
 	got := collectPipelineCards(prPipelineLanes(snapshot))
 	want := []pipelineCardSnapshot{
-		{Lane: "Merging", IssueNumber: "#552", Title: "Keep completed handoff visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s"},
+		{Lane: "Merging", IssueNumber: "#552", Title: "Keep completed implementation visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("pipeline cards len = %d, want %d; got %#v", len(got), len(want), got)
@@ -1676,4 +1686,13 @@ func collectKanbanLaneTitles(lanes []projectKanbanLane) []string {
 		out = append(out, lane.Title)
 	}
 	return out
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- Keep Kanban lane discovery and project board cards sourced from configured/tracker workflow rows, not completed session history.
- Remove completed/open-PR session projection from PR pipeline lanes and move the demo visibility case to Runs.
- Add regressions for label-mode completed sessions, explicitly configured Handoff, and Agent Activity visibility.

Fixes #587

## Test Plan

- [x] `go test ./internal/web ./internal/web/templates`
- [x] `make check`
