### PR TITLE
feat(dev-runtime): add demo capture harness

### DIFF
--- a/README.md
+++ b/README.md
@@ -946,6 +946,38 @@ quick JSON smoke check looks like this:
 curl -H 'X-Detent-Demo-Scenario: fleet-healthy-parallel-work' "$DETENT_URL/api/v1/state"
 ```
 
+Use the capture harness when you need the canonical video-production artifact
+set from one command:
+
+```sh
+detent dev-runtime capture --out ./capture
+```
+
+The harness starts an isolated screenshots demo on an ephemeral local port,
+loads the scenario manifest, captures the canonical still set, and writes a
+deterministic terminal onboarding cast. It does not read or write the operator's
+real `~/.config/detent/global.yaml`. Stable output paths are:
+
+```text
+capture/demo-capture-v1.json
+capture/stills/v1/01-fleet-healthy-parallel-work.png
+capture/stills/v1/02-fleet-kanban-multiproject.png
+capture/stills/v1/03-kanban-full-integration.png
+capture/stills/v1/04-project-active-overview.png
+capture/stills/v1/05-reports-normal-window.png
+capture/stills/v1/06-onboarding-project-selection.png
+capture/terminal/v1/onboarding.cast
+```
+
+By default the browser viewport is `1920x1080` with
+`--device-scale-factor 2`, producing 4K PNGs. Pass `--scenario <id>` one or
+more times for a named subset, `--all-scenarios` for every browser-capturable
+GET scenario in the manifest, `--width`, `--height`, and
+`--device-scale-factor` for alternate framing, or `--demo-clock play` when a
+motion capture needs advancing counters. The PNG capture uses a local
+Chrome-family browser; pass `--browser <path>` or set `DETENT_CAPTURE_BROWSER`
+when auto-detection cannot find one.
+
 The CI browser visual gate runs Playwright when a PR changes UI-sensitive
 paths such as `.github/workflows/ci.yml`, `package.json`, `static/**`,
 `internal/web/**`, `internal/cli/dev_runtime*.go`, `internal/devruntime/**`,

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -220,6 +220,7 @@ type options struct {
 	lookupEnv     func(string) string
 	ghAuthToken   func(context.Context) (string, error)
 	configureLog  LoggerFunc
+	captureDemo   demoCaptureFunc
 	version       string
 	build         buildinfo.Info
 	stdoutTTY     func() bool
@@ -429,6 +430,7 @@ func defaultOptions() options {
 		signal:      noSignal,
 		lookupEnv:   os.Getenv,
 		ghAuthToken: defaultGHAuthToken,
+		captureDemo: runDemoCapture,
 		stdoutTTY:   stdoutIsTTY,
 	}
 }

--- a/internal/cli/dev_runtime.go
+++ b/internal/cli/dev_runtime.go
@@ -80,6 +80,7 @@ func newDevRuntimeCommand(host *string, port *int, opts options) *cobra.Command 
 	cmd.Flags().StringVar(&demoProjectID, "demo-project", "", "generated primary project ID for isolated demos; screenshots stays dogfood")
 	cmd.Flags().BoolVar(&allowLiveDB, "allow-live-db", false, "allow --db to point at the operator's live ~/.detent/detent.db")
 	cmd.Flags().BoolVar(&allowProductionPort, "allow-production-port", false, "allow binding the isolated runtime to the live dogfood port")
+	cmd.AddCommand(newDevRuntimeCaptureCommand(opts))
 	return cmd
 }
 

--- a/internal/cli/dev_runtime_capture.go
+++ b/internal/cli/dev_runtime_capture.go
@@ -1,0 +1,636 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/devruntime"
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+const (
+	demoCaptureVersion                  = "v1"
+	demoCaptureDefaultOut               = "tmp/demo-capture"
+	demoCaptureDefaultWidth             = 1920
+	demoCaptureDefaultHeight            = 1080
+	demoCaptureDefaultDeviceScaleFactor = 2
+	demoCaptureDefaultTimeout           = 30 * time.Second
+)
+
+var demoCaptureCanonicalScenarioIDs = []string{
+	"fleet-healthy-parallel-work",
+	"fleet-kanban-multiproject",
+	"kanban-full-integration",
+	"project-active-overview",
+	"reports-normal-window",
+	"onboarding-project-selection",
+}
+
+type demoCaptureFunc func(context.Context, demoCaptureConfig) (demoCaptureResult, error)
+
+type demoCaptureConfig struct {
+	OutDir            string
+	ScenarioIDs       []string
+	AllScenarios      bool
+	Width             int
+	Height            int
+	DeviceScaleFactor float64
+	BrowserPath       string
+	DemoClock         string
+	Timeout           time.Duration
+}
+
+type demoCaptureResult struct {
+	Version      string                    `json:"version"`
+	OutDir       string                    `json:"out_dir"`
+	ManifestPath string                    `json:"manifest_path"`
+	Stills       []demoCaptureStillResult  `json:"stills"`
+	Terminal     demoCaptureTerminalResult `json:"terminal"`
+}
+
+type demoCaptureStillResult struct {
+	ScenarioID        string  `json:"scenario_id"`
+	Route             string  `json:"route"`
+	Path              string  `json:"path"`
+	Width             int     `json:"width"`
+	Height            int     `json:"height"`
+	DeviceScaleFactor float64 `json:"device_scale_factor"`
+}
+
+type demoCaptureTerminalResult struct {
+	CastPath     string `json:"cast_path"`
+	ConfigPath   string `json:"config_path"`
+	WorkflowPath string `json:"workflow_path"`
+	SourceRoot   string `json:"source_root"`
+}
+
+type demoCaptureSelection struct {
+	ScenarioIDs  []string
+	AllScenarios bool
+}
+
+type demoStillCapture struct {
+	Scenario     web.DemoScenarioManifest
+	Path         string
+	RelativePath string
+}
+
+type demoCaptureScenarioResponse struct {
+	GeneratedAt time.Time                  `json:"generated_at"`
+	Header      string                     `json:"header"`
+	Clock       string                     `json:"clock"`
+	Scenarios   []web.DemoScenarioManifest `json:"scenarios"`
+}
+
+type demoCaptureManifest struct {
+	Version         string                    `json:"version"`
+	DemoGeneratedAt time.Time                 `json:"demo_generated_at"`
+	DemoClock       string                    `json:"demo_clock"`
+	ScenarioHeader  string                    `json:"scenario_header"`
+	Viewport        demoCaptureViewport       `json:"viewport"`
+	Stills          []demoCaptureManifestItem `json:"stills"`
+	Terminal        demoCaptureManifestItem   `json:"terminal"`
+}
+
+type demoCaptureViewport struct {
+	Width             int     `json:"width"`
+	Height            int     `json:"height"`
+	DeviceScaleFactor float64 `json:"device_scale_factor"`
+}
+
+type demoCaptureManifestItem struct {
+	ScenarioID   string            `json:"scenario_id,omitempty"`
+	Route        string            `json:"route,omitempty"`
+	Path         string            `json:"path"`
+	Headers      map[string]string `json:"headers,omitempty"`
+	WaitSelector string            `json:"wait_selector,omitempty"`
+}
+
+func newDevRuntimeCaptureCommand(opts options) *cobra.Command {
+	cfg := demoCaptureConfig{
+		OutDir:            demoCaptureDefaultOut,
+		Width:             demoCaptureDefaultWidth,
+		Height:            demoCaptureDefaultHeight,
+		DeviceScaleFactor: demoCaptureDefaultDeviceScaleFactor,
+		DemoClock:         web.DemoClockFrozen,
+		Timeout:           demoCaptureDefaultTimeout,
+	}
+	cmd := &cobra.Command{
+		Use:     "capture",
+		Short:   "Capture deterministic demo screenshots and terminal casts",
+		Example: "detent dev-runtime capture --out ./capture",
+		Args:    NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			if err := validateDemoCaptureConfig(cfg); err != nil {
+				return err
+			}
+			result, err := opts.captureDemo(cmd.Context(), cfg)
+			if err != nil {
+				return err
+			}
+			return out.Write(func(out io.Writer) error {
+				return writeDemoCapturePretty(out, result)
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&cfg.OutDir, "out", demoCaptureDefaultOut, "capture output directory")
+	cmd.Flags().StringArrayVar(&cfg.ScenarioIDs, "scenario", nil, "scenario ID to capture; repeat for a named subset")
+	cmd.Flags().BoolVar(&cfg.AllScenarios, "all-scenarios", false, "capture every browser-capturable GET scenario from the manifest")
+	cmd.Flags().IntVar(&cfg.Width, "width", demoCaptureDefaultWidth, "CSS viewport width")
+	cmd.Flags().IntVar(&cfg.Height, "height", demoCaptureDefaultHeight, "CSS viewport height")
+	cmd.Flags().Float64Var(&cfg.DeviceScaleFactor, "device-scale-factor", demoCaptureDefaultDeviceScaleFactor, "browser device scale factor")
+	cmd.Flags().StringVar(&cfg.BrowserPath, "browser", "", "Chrome or Chromium executable path")
+	cmd.Flags().StringVar(&cfg.DemoClock, "demo-clock", web.DemoClockFrozen, "screenshots demo clock mode (frozen, play)")
+	cmd.Flags().DurationVar(&cfg.Timeout, "timeout", demoCaptureDefaultTimeout, "capture startup and page wait timeout")
+	return cmd
+}
+
+func validateDemoCaptureConfig(cfg demoCaptureConfig) error {
+	switch {
+	case strings.TrimSpace(cfg.OutDir) == "":
+		return WrapValidation(hintedError(nil, "--out is required", exampleHint("detent dev-runtime capture --out ./capture"), "detent dev-runtime capture --out ./capture"))
+	case cfg.Width <= 0:
+		return WrapValidation(hintedError(nil, "--width must be positive", exampleHint("detent dev-runtime capture --width 1920"), "detent dev-runtime capture --width 1920"))
+	case cfg.Height <= 0:
+		return WrapValidation(hintedError(nil, "--height must be positive", exampleHint("detent dev-runtime capture --height 1080"), "detent dev-runtime capture --height 1080"))
+	case cfg.DeviceScaleFactor <= 0:
+		return WrapValidation(hintedError(nil, "--device-scale-factor must be positive", exampleHint("detent dev-runtime capture --device-scale-factor 2"), "detent dev-runtime capture --device-scale-factor 2"))
+	case cfg.Timeout <= 0:
+		return WrapValidation(hintedError(nil, "--timeout must be positive", exampleHint("detent dev-runtime capture --timeout 30s"), "detent dev-runtime capture --timeout 30s"))
+	default:
+		return nil
+	}
+}
+
+func runDemoCapture(ctx context.Context, cfg demoCaptureConfig) (demoCaptureResult, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	cfg.DemoClock = normalizeDemoCaptureClock(cfg.DemoClock)
+	outDir, err := filepath.Abs(cfg.OutDir)
+	if err != nil {
+		return demoCaptureResult{}, fmt.Errorf("resolve capture output directory: %w", err)
+	}
+	cfg.OutDir = outDir
+	if err := os.MkdirAll(outDir, 0o755); err != nil {
+		return demoCaptureResult{}, fmt.Errorf("create capture output directory %s: %w", outDir, err)
+	}
+
+	terminal, err := writeDemoTerminalCapture(outDir)
+	if err != nil {
+		return demoCaptureResult{}, err
+	}
+
+	runtimeHome, err := os.MkdirTemp("", "detent-demo-capture-runtime-*")
+	if err != nil {
+		return demoCaptureResult{}, fmt.Errorf("create demo capture runtime home: %w", err)
+	}
+	defer func() {
+		discardDemoCaptureError(os.RemoveAll(runtimeHome))
+	}()
+
+	runtime, err := devruntime.Build(devruntime.Config{
+		Home:      runtimeHome,
+		Demo:      devruntime.DemoScreenshots,
+		DemoClock: cfg.DemoClock,
+		Port:      0,
+	})
+	if err != nil {
+		return demoCaptureResult{}, devRuntimeError(err)
+	}
+
+	runtimeCtx, cancel := context.WithCancel(ctx)
+	output := &captureBuffer{}
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(runtimeCtx, devRuntimeBootConfig(runtime, "127.0.0.1", defaultOptions(), output))
+	}()
+	defer stopDemoCaptureRuntime(cancel, done)
+
+	baseURL, err := waitForDemoCaptureRuntimeURL(ctx, output, done, cfg.Timeout)
+	if err != nil {
+		return demoCaptureResult{}, err
+	}
+	manifest, err := fetchDemoCaptureManifest(ctx, baseURL, cfg.Timeout)
+	if err != nil {
+		return demoCaptureResult{}, err
+	}
+	plans, err := planDemoStillCaptures(outDir, manifest.Scenarios, demoCaptureSelection{
+		ScenarioIDs:  cfg.ScenarioIDs,
+		AllScenarios: cfg.AllScenarios,
+	})
+	if err != nil {
+		return demoCaptureResult{}, err
+	}
+
+	browser, err := startDemoCaptureBrowser(ctx, cfg)
+	if err != nil {
+		return demoCaptureResult{}, err
+	}
+	defer browser.Close()
+	page, err := browser.NewPage(ctx)
+	if err != nil {
+		return demoCaptureResult{}, err
+	}
+	defer page.Close()
+
+	stills := make([]demoCaptureStillResult, 0, len(plans))
+	for _, plan := range plans {
+		if err := page.CaptureScenario(ctx, baseURL, plan, cfg); err != nil {
+			return demoCaptureResult{}, err
+		}
+		stills = append(stills, demoCaptureStillResult{
+			ScenarioID:        plan.Scenario.ID,
+			Route:             plan.Scenario.Route,
+			Path:              plan.Path,
+			Width:             cfg.Width,
+			Height:            cfg.Height,
+			DeviceScaleFactor: cfg.DeviceScaleFactor,
+		})
+	}
+
+	manifestPath, err := writeDemoCaptureManifest(outDir, cfg, manifest, plans, terminal)
+	if err != nil {
+		return demoCaptureResult{}, err
+	}
+	return demoCaptureResult{
+		Version:      demoCaptureVersion,
+		OutDir:       outDir,
+		ManifestPath: manifestPath,
+		Stills:       stills,
+		Terminal:     terminal,
+	}, nil
+}
+
+func normalizeDemoCaptureClock(value string) string {
+	if strings.EqualFold(strings.TrimSpace(value), web.DemoClockPlay) {
+		return web.DemoClockPlay
+	}
+	return web.DemoClockFrozen
+}
+
+func writeDemoCapturePretty(out io.Writer, result demoCaptureResult) error {
+	if _, err := fmt.Fprintf(out, "capture: %s\nmanifest: %s\n", result.OutDir, result.ManifestPath); err != nil {
+		return err
+	}
+	if len(result.Stills) > 0 {
+		if _, err := fmt.Fprintln(out, "stills:"); err != nil {
+			return err
+		}
+		for _, still := range result.Stills {
+			if _, err := fmt.Fprintf(out, "  %s %s\n", still.ScenarioID, still.Path); err != nil {
+				return err
+			}
+		}
+	}
+	if strings.TrimSpace(result.Terminal.CastPath) != "" {
+		if _, err := fmt.Fprintf(out, "terminal: %s\n", result.Terminal.CastPath); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func waitForDemoCaptureRuntimeURL(ctx context.Context, output *captureBuffer, done <-chan error, timeout time.Duration) (string, error) {
+	waitCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	ticker := time.NewTicker(10 * time.Millisecond)
+	defer ticker.Stop()
+	for {
+		for line := range strings.SplitSeq(output.String(), "\n") {
+			if url, ok := strings.CutPrefix(line, "Dashboard: "); ok && strings.TrimSpace(url) != "" {
+				return strings.TrimSpace(url), nil
+			}
+		}
+		select {
+		case err := <-done:
+			return "", fmt.Errorf("demo capture runtime stopped before startup: %w\n%s", err, output.String())
+		case <-waitCtx.Done():
+			return "", fmt.Errorf("timed out waiting for demo capture runtime URL: %w\n%s", waitCtx.Err(), output.String())
+		case <-ticker.C:
+		}
+	}
+}
+
+func stopDemoCaptureRuntime(cancel context.CancelFunc, done <-chan error) {
+	if cancel != nil {
+		cancel()
+	}
+	select {
+	case <-done:
+	case <-time.After(5 * time.Second):
+	}
+}
+
+func fetchDemoCaptureManifest(ctx context.Context, baseURL string, timeout time.Duration) (demoCaptureScenarioResponse, error) {
+	manifestURL, err := url.JoinPath(baseURL, "/api/v1/demo/scenarios")
+	if err != nil {
+		return demoCaptureScenarioResponse{}, fmt.Errorf("build demo scenario manifest URL: %w", err)
+	}
+	requestCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	req, err := http.NewRequestWithContext(requestCtx, http.MethodGet, manifestURL, nil)
+	if err != nil {
+		return demoCaptureScenarioResponse{}, fmt.Errorf("create demo scenario manifest request: %w", err)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return demoCaptureScenarioResponse{}, fmt.Errorf("fetch demo scenario manifest: %w", err)
+	}
+	defer resp.Body.Close()
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return demoCaptureScenarioResponse{}, fmt.Errorf("read demo scenario manifest: %w", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return demoCaptureScenarioResponse{}, fmt.Errorf("fetch demo scenario manifest: %s: %s", resp.Status, body)
+	}
+	var manifest demoCaptureScenarioResponse
+	if err := json.Unmarshal(body, &manifest); err != nil {
+		return demoCaptureScenarioResponse{}, fmt.Errorf("decode demo scenario manifest: %w", err)
+	}
+	return manifest, nil
+}
+
+func planDemoStillCaptures(outDir string, manifest []web.DemoScenarioManifest, selection demoCaptureSelection) ([]demoStillCapture, error) {
+	if selection.AllScenarios && len(selection.ScenarioIDs) > 0 {
+		return nil, errors.New("--all-scenarios cannot be combined with --scenario")
+	}
+	byID := make(map[string]web.DemoScenarioManifest, len(manifest))
+	for _, scenario := range manifest {
+		byID[scenario.ID] = scenario
+	}
+
+	var ids []string
+	switch {
+	case len(selection.ScenarioIDs) > 0:
+		for _, id := range selection.ScenarioIDs {
+			if id = strings.TrimSpace(id); id != "" {
+				ids = append(ids, id)
+			}
+		}
+	case selection.AllScenarios:
+		for _, scenario := range manifest {
+			if demoCaptureScenarioMethod(scenario) == http.MethodGet {
+				ids = append(ids, scenario.ID)
+			}
+		}
+	default:
+		ids = append(ids, demoCaptureCanonicalScenarioIDs...)
+	}
+	if len(ids) == 0 {
+		return nil, errors.New("no demo capture scenarios selected")
+	}
+
+	captures := make([]demoStillCapture, 0, len(ids))
+	for i, id := range ids {
+		scenario, ok := byID[id]
+		if !ok {
+			return nil, fmt.Errorf("unknown demo capture scenario %q", id)
+		}
+		if method := demoCaptureScenarioMethod(scenario); method != http.MethodGet {
+			return nil, fmt.Errorf("demo capture scenario %q uses %s; screenshot capture supports GET scenarios", id, method)
+		}
+		name := fmt.Sprintf("%02d-%s.png", i+1, scenario.ID)
+		relativePath := filepath.ToSlash(filepath.Join("stills", demoCaptureVersion, name))
+		captures = append(captures, demoStillCapture{
+			Scenario:     scenario,
+			Path:         filepath.Join(outDir, "stills", demoCaptureVersion, name),
+			RelativePath: relativePath,
+		})
+	}
+	return captures, nil
+}
+
+func demoCaptureScenarioMethod(scenario web.DemoScenarioManifest) string {
+	method := strings.ToUpper(strings.TrimSpace(scenario.Method))
+	if method == "" {
+		return http.MethodGet
+	}
+	return method
+}
+
+func writeDemoCaptureManifest(outDir string, cfg demoCaptureConfig, source demoCaptureScenarioResponse, plans []demoStillCapture, terminal demoCaptureTerminalResult) (string, error) {
+	items := make([]demoCaptureManifestItem, 0, len(plans))
+	for _, plan := range plans {
+		items = append(items, demoCaptureManifestItem{
+			ScenarioID:   plan.Scenario.ID,
+			Route:        plan.Scenario.Route,
+			Path:         plan.RelativePath,
+			Headers:      plan.Scenario.Headers,
+			WaitSelector: plan.Scenario.WaitSelector,
+		})
+	}
+	terminalPath := filepath.ToSlash(filepath.Join("terminal", demoCaptureVersion, "onboarding.cast"))
+	if relative, err := filepath.Rel(outDir, terminal.CastPath); err == nil {
+		terminalPath = filepath.ToSlash(relative)
+	}
+	manifest := demoCaptureManifest{
+		Version:         demoCaptureVersion,
+		DemoGeneratedAt: source.GeneratedAt,
+		DemoClock:       source.Clock,
+		ScenarioHeader:  source.Header,
+		Viewport: demoCaptureViewport{
+			Width:             cfg.Width,
+			Height:            cfg.Height,
+			DeviceScaleFactor: cfg.DeviceScaleFactor,
+		},
+		Stills: items,
+		Terminal: demoCaptureManifestItem{
+			Path: terminalPath,
+		},
+	}
+	raw, err := json.MarshalIndent(manifest, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshal demo capture manifest: %w", err)
+	}
+	path := filepath.Join(outDir, "demo-capture-"+demoCaptureVersion+".json")
+	if err := os.WriteFile(path, append(raw, '\n'), 0o644); err != nil {
+		return "", fmt.Errorf("write demo capture manifest %s: %w", path, err)
+	}
+	return path, nil
+}
+
+func writeDemoTerminalCapture(outDir string) (demoCaptureTerminalResult, error) {
+	root := filepath.Join(outDir, "terminal", demoCaptureVersion)
+	configDir := filepath.Join(root, "config")
+	sourceRoot := filepath.Join(root, "source", "detent-demo")
+	workspaceRoot := filepath.Join(root, "workspaces")
+	for _, dir := range []string{configDir, sourceRoot, workspaceRoot} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return demoCaptureTerminalResult{}, fmt.Errorf("create terminal capture directory %s: %w", dir, err)
+		}
+	}
+	if err := writeDemoTerminalGitSkeleton(sourceRoot); err != nil {
+		return demoCaptureTerminalResult{}, err
+	}
+
+	workflowPath := filepath.Join(configDir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(demoTerminalWorkflowContent()), 0o600); err != nil {
+		return demoCaptureTerminalResult{}, fmt.Errorf("write terminal capture workflow: %w", err)
+	}
+	port := 0
+	configPath := filepath.Join(configDir, "global.yaml")
+	cfg := globalconfig.Config{
+		Path:         configPath,
+		APIVersion:   globalconfig.APIVersion,
+		Kind:         globalconfig.Kind,
+		Port:         &port,
+		InstanceName: "detent-demo-capture",
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{{
+			ID:       "detent-demo",
+			Workflow: "./terminal/v1/config/WORKFLOW.md",
+			Workdir:  "./terminal/v1/source/detent-demo",
+			Weight:   1,
+			Priority: 1,
+		}},
+	}
+	if err := globalconfig.Write(configPath, cfg, globalconfig.WithRelativeTo(outDir)); err != nil {
+		return demoCaptureTerminalResult{}, fmt.Errorf("write terminal capture global config: %w", err)
+	}
+
+	castPath := filepath.Join(root, "onboarding.cast")
+	if err := writeDemoTerminalCast(castPath); err != nil {
+		return demoCaptureTerminalResult{}, err
+	}
+	return demoCaptureTerminalResult{
+		CastPath:     castPath,
+		ConfigPath:   configPath,
+		WorkflowPath: workflowPath,
+		SourceRoot:   sourceRoot,
+	}, nil
+}
+
+func writeDemoTerminalGitSkeleton(sourceRoot string) error {
+	gitDir := filepath.Join(sourceRoot, ".git")
+	for _, dir := range []string{filepath.Join(gitDir, "branches"), filepath.Join(gitDir, "objects"), filepath.Join(gitDir, "refs", "heads")} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			return fmt.Errorf("create terminal capture git directory %s: %w", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0o644); err != nil {
+		return fmt.Errorf("write terminal capture git HEAD: %w", err)
+	}
+	config := "[core]\n\trepositoryformatversion = 0\n\tfilemode = true\n\tbare = false\n\tlogallrefupdates = true\n"
+	if err := os.WriteFile(filepath.Join(gitDir, "config"), []byte(config), 0o644); err != nil {
+		return fmt.Errorf("write terminal capture git config: %w", err)
+	}
+	return nil
+}
+
+func demoTerminalWorkflowContent() string {
+	return strings.TrimSpace(`---
+tracker:
+  kind: memory
+polling:
+  interval_ms: 60000
+workspace:
+  root: ./terminal/v1/workspaces
+  source_root: ./terminal/v1/source
+  auto_branch: true
+agent:
+  max_concurrent_agents: 1
+  max_concurrent_agents_by_state:
+    Merging: 1
+gate:
+  kind: command
+  run: "true"
+server:
+  host: 127.0.0.1
+  port: 0
+---
+Deterministic Detent demo capture workflow.
+`) + "\n"
+}
+
+func writeDemoTerminalCast(path string) error {
+	file, err := os.Create(path)
+	if err != nil {
+		return fmt.Errorf("create terminal capture cast %s: %w", path, err)
+	}
+	defer file.Close()
+
+	header := struct {
+		Version   int               `json:"version"`
+		Width     int               `json:"width"`
+		Height    int               `json:"height"`
+		Timestamp int64             `json:"timestamp"`
+		Env       map[string]string `json:"env"`
+	}{
+		Version:   2,
+		Width:     100,
+		Height:    28,
+		Timestamp: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC).Unix(),
+		Env: map[string]string{
+			"SHELL": "/bin/zsh",
+			"TERM":  "xterm-256color",
+		},
+	}
+	if err := writeAsciinemaLine(file, header); err != nil {
+		return fmt.Errorf("write terminal capture cast header: %w", err)
+	}
+	events := []struct {
+		at     float64
+		output string
+	}{
+		{0.10, "$ detent init --config ./terminal/v1/config/global.yaml\r\n"},
+		{0.45, "status: ok\r\npath: ./terminal/v1/config/global.yaml\r\nrule: --config\r\n"},
+		{0.90, "$ detent add-project --config ./terminal/v1/config/global.yaml --id detent-demo --workflow ./terminal/v1/config/WORKFLOW.md --workdir ./terminal/v1/source/detent-demo\r\n"},
+		{1.35, "status: ok\r\nid: detent-demo\r\nworkflow: ./terminal/v1/config/WORKFLOW.md\r\nworkdir: ./terminal/v1/source/detent-demo\r\n"},
+		{1.80, "$ detent doctor --config ./terminal/v1/config/global.yaml --port 0\r\n"},
+		{2.20, "Config resolution ... OK\r\nRuntime settings ... OK\r\nProject detent-demo workflow ... OK\r\nProject detent-demo source repository ... OK\r\nSQLite database ... OK\r\nGitHub token ... OK (skipped for memory tracker)\r\nServer port ... OK\r\nresult: PASS\r\n"},
+	}
+	for _, event := range events {
+		if err := writeAsciinemaLine(file, []any{event.at, "o", event.output}); err != nil {
+			return fmt.Errorf("write terminal capture cast event: %w", err)
+		}
+	}
+	return nil
+}
+
+func writeAsciinemaLine(out io.Writer, value any) error {
+	encoder := json.NewEncoder(out)
+	encoder.SetEscapeHTML(false)
+	return encoder.Encode(value)
+}
+
+func discardDemoCaptureError(error) {}
+
+type captureBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *captureBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *captureBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}

--- a/internal/cli/dev_runtime_capture.go
+++ b/internal/cli/dev_runtime_capture.go
@@ -389,7 +389,7 @@ func planDemoStillCaptures(outDir string, manifest []web.DemoScenarioManifest, s
 		}
 	case selection.AllScenarios:
 		for _, scenario := range manifest {
-			if demoCaptureScenarioMethod(scenario) == http.MethodGet {
+			if demoCaptureBrowserCapturableScenario(scenario) {
 				ids = append(ids, scenario.ID)
 			}
 		}
@@ -409,6 +409,9 @@ func planDemoStillCaptures(outDir string, manifest []web.DemoScenarioManifest, s
 		if method := demoCaptureScenarioMethod(scenario); method != http.MethodGet {
 			return nil, fmt.Errorf("demo capture scenario %q uses %s; screenshot capture supports GET scenarios", id, method)
 		}
+		if !demoCaptureBrowserCapturableScenario(scenario) {
+			return nil, fmt.Errorf("demo capture scenario %q is not browser-capturable", id)
+		}
 		name := fmt.Sprintf("%02d-%s.png", i+1, scenario.ID)
 		relativePath := filepath.ToSlash(filepath.Join("stills", demoCaptureVersion, name))
 		captures = append(captures, demoStillCapture{
@@ -418,6 +421,13 @@ func planDemoStillCaptures(outDir string, manifest []web.DemoScenarioManifest, s
 		})
 	}
 	return captures, nil
+}
+
+func demoCaptureBrowserCapturableScenario(scenario web.DemoScenarioManifest) bool {
+	if demoCaptureScenarioMethod(scenario) != http.MethodGet {
+		return false
+	}
+	return strings.TrimSpace(scenario.Route) != "/events"
 }
 
 func demoCaptureScenarioMethod(scenario web.DemoScenarioManifest) string {
@@ -548,7 +558,7 @@ polling:
   interval_ms: 60000
 workspace:
   root: ./terminal/v1/workspaces
-  source_root: ./terminal/v1/source
+  source_root: ./terminal/v1/source/detent-demo
   auto_branch: true
 agent:
   max_concurrent_agents: 1

--- a/internal/cli/dev_runtime_capture_browser.go
+++ b/internal/cli/dev_runtime_capture_browser.go
@@ -1,0 +1,555 @@
+package cli
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	goruntime "runtime"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"golang.org/x/net/websocket"
+
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+type demoCaptureBrowser struct {
+	cancel      context.CancelFunc
+	cmd         *exec.Cmd
+	port        int
+	output      *captureBuffer
+	userDataDir string
+}
+
+type demoCapturePage struct {
+	client *demoCaptureCDPClient
+}
+
+type demoCaptureCDPClient struct {
+	conn    *websocket.Conn
+	nextID  atomic.Int64
+	mu      sync.Mutex
+	pending map[int64]chan demoCaptureCDPResponse
+}
+
+type demoCaptureCDPResponse struct {
+	ID     int64           `json:"id"`
+	Result json.RawMessage `json:"result"`
+	Error  *demoCaptureCDPError
+}
+
+type demoCaptureCDPError struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func startDemoCaptureBrowser(ctx context.Context, cfg demoCaptureConfig) (*demoCaptureBrowser, error) {
+	browserPath, err := demoCaptureBrowserPath(cfg.BrowserPath)
+	if err != nil {
+		return nil, err
+	}
+	port, err := freeDemoCaptureTCPPort()
+	if err != nil {
+		return nil, err
+	}
+	userDataDir, err := os.MkdirTemp("", "detent-demo-capture-browser-*")
+	if err != nil {
+		return nil, fmt.Errorf("create browser user data directory: %w", err)
+	}
+	browserCtx, cancel := context.WithCancel(ctx)
+	args := []string{
+		"--headless=new",
+		"--disable-background-networking",
+		"--disable-default-apps",
+		"--disable-dev-shm-usage",
+		"--disable-gpu",
+		"--disable-popup-blocking",
+		"--no-default-browser-check",
+		"--no-first-run",
+		"--no-sandbox",
+		"--remote-allow-origins=*",
+		"--remote-debugging-address=127.0.0.1",
+		fmt.Sprintf("--remote-debugging-port=%d", port),
+		fmt.Sprintf("--window-size=%d,%d", cfg.Width, cfg.Height),
+		"--user-data-dir=" + userDataDir,
+		"about:blank",
+	}
+	cmd := exec.CommandContext(browserCtx, browserPath, args...) // #nosec G204 -- capture launches an explicit browser path with fixed headless CDP arguments.
+	output := &captureBuffer{}
+	cmd.Stdout = output
+	cmd.Stderr = output
+	if err := cmd.Start(); err != nil {
+		cancel()
+		discardDemoCaptureError(os.RemoveAll(userDataDir))
+		return nil, fmt.Errorf("start browser %s: %w", browserPath, err)
+	}
+	browser := &demoCaptureBrowser{cancel: cancel, cmd: cmd, port: port, output: output, userDataDir: userDataDir}
+	if err := browser.waitForVersion(ctx, cfg.Timeout); err != nil {
+		browser.Close()
+		return nil, err
+	}
+	return browser, nil
+}
+
+func demoCaptureBrowserPath(explicit string) (string, error) {
+	if path := strings.TrimSpace(explicit); path != "" {
+		if executableDemoCaptureFile(path) {
+			return path, nil
+		}
+		return "", fmt.Errorf("browser executable is not runnable: %s", path)
+	}
+	if path := strings.TrimSpace(os.Getenv("DETENT_CAPTURE_BROWSER")); path != "" {
+		if executableDemoCaptureFile(path) {
+			return path, nil
+		}
+		return "", fmt.Errorf("DETENT_CAPTURE_BROWSER is not runnable: %s", path)
+	}
+	for _, name := range demoCaptureBrowserNames() {
+		if path, err := exec.LookPath(name); err == nil && executableDemoCaptureFile(path) {
+			return path, nil
+		}
+	}
+	for _, path := range demoCaptureBrowserPaths() {
+		if executableDemoCaptureFile(path) {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("chrome or chromium was not found; pass --browser or set DETENT_CAPTURE_BROWSER")
+}
+
+func demoCaptureBrowserNames() []string {
+	switch goruntime.GOOS {
+	case "windows":
+		return []string{"chrome.exe", "msedge.exe"}
+	case "darwin":
+		return []string{"google-chrome", "chromium", "microsoft-edge"}
+	default:
+		return []string{"google-chrome-stable", "google-chrome", "chromium-browser", "chromium", "microsoft-edge"}
+	}
+}
+
+func demoCaptureBrowserPaths() []string {
+	switch goruntime.GOOS {
+	case "darwin":
+		return []string{
+			"/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+			"/Applications/Chromium.app/Contents/MacOS/Chromium",
+			"/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+		}
+	case "windows":
+		roots := []string{os.Getenv("PROGRAMFILES"), os.Getenv("PROGRAMFILES(X86)"), os.Getenv("LOCALAPPDATA")}
+		relatives := []string{
+			filepath.Join("Google", "Chrome", "Application", "chrome.exe"),
+			filepath.Join("Microsoft", "Edge", "Application", "msedge.exe"),
+		}
+		var paths []string
+		for _, root := range roots {
+			if strings.TrimSpace(root) == "" {
+				continue
+			}
+			for _, relative := range relatives {
+				paths = append(paths, filepath.Join(root, relative))
+			}
+		}
+		return paths
+	default:
+		return nil
+	}
+}
+
+func executableDemoCaptureFile(path string) bool {
+	info, err := os.Stat(path)
+	if err != nil {
+		return false
+	}
+	return !info.IsDir()
+}
+
+func freeDemoCaptureTCPPort() (int, error) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, fmt.Errorf("reserve browser debug port: %w", err)
+	}
+	defer func() {
+		discardDemoCaptureError(listener.Close())
+	}()
+	addr, ok := listener.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("browser debug listener address = %T, want *net.TCPAddr", listener.Addr())
+	}
+	return addr.Port, nil
+}
+
+func (b *demoCaptureBrowser) waitForVersion(ctx context.Context, timeout time.Duration) error {
+	client := http.Client{Timeout: 2 * time.Second}
+	deadline, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	versionURL := fmt.Sprintf("http://127.0.0.1:%d/json/version", b.port)
+	var lastErr error
+	for deadline.Err() == nil {
+		req, err := http.NewRequestWithContext(deadline, http.MethodGet, versionURL, nil)
+		if err != nil {
+			return fmt.Errorf("create browser version request: %w", err)
+		}
+		resp, err := client.Do(req)
+		if err == nil {
+			_, readErr := io.Copy(io.Discard, resp.Body)
+			closeErr := resp.Body.Close()
+			if readErr != nil {
+				return fmt.Errorf("read browser version response: %w", readErr)
+			}
+			if closeErr != nil {
+				return fmt.Errorf("close browser version response: %w", closeErr)
+			}
+			if resp.StatusCode == http.StatusOK {
+				return nil
+			}
+			lastErr = fmt.Errorf("status %s", resp.Status)
+		} else {
+			lastErr = err
+		}
+		time.Sleep(25 * time.Millisecond)
+	}
+	return fmt.Errorf("timed out waiting for browser CDP endpoint: %w\n%s", lastErr, b.output.String())
+}
+
+func (b *demoCaptureBrowser) NewPage(ctx context.Context) (*demoCapturePage, error) {
+	client := http.Client{Timeout: 10 * time.Second}
+	newPageURL := fmt.Sprintf("http://127.0.0.1:%d/json/new?%s", b.port, url.QueryEscape("about:blank"))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPut, newPageURL, nil)
+	if err != nil {
+		return nil, fmt.Errorf("create browser page request: %w", err)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("create browser page: %w", err)
+	}
+	body, readErr := io.ReadAll(resp.Body)
+	closeErr := resp.Body.Close()
+	if readErr != nil {
+		return nil, fmt.Errorf("read browser page response: %w", readErr)
+	}
+	if closeErr != nil {
+		return nil, fmt.Errorf("close browser page response: %w", closeErr)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("create browser page status = %s: %s", resp.Status, body)
+	}
+	var target struct {
+		WebSocketDebuggerURL string `json:"webSocketDebuggerUrl"`
+	}
+	if err := json.Unmarshal(body, &target); err != nil {
+		return nil, fmt.Errorf("decode browser page response: %w", err)
+	}
+	if target.WebSocketDebuggerURL == "" {
+		return nil, fmt.Errorf("browser page response missing webSocketDebuggerUrl: %s", body)
+	}
+	cdp, err := newDemoCaptureCDPClient(target.WebSocketDebuggerURL)
+	if err != nil {
+		return nil, fmt.Errorf("connect browser page CDP: %w", err)
+	}
+	page := &demoCapturePage{client: cdp}
+	if err := page.Call(ctx, "Page.enable", nil, nil); err != nil {
+		page.Close()
+		return nil, err
+	}
+	if err := page.Call(ctx, "Network.enable", nil, nil); err != nil {
+		page.Close()
+		return nil, err
+	}
+	return page, nil
+}
+
+func (b *demoCaptureBrowser) Close() {
+	if b == nil {
+		return
+	}
+	if b.cancel != nil {
+		b.cancel()
+	}
+	if b.cmd != nil && b.cmd.Process != nil {
+		discardDemoCaptureError(b.cmd.Process.Kill())
+		discardDemoCaptureError(b.cmd.Wait())
+	}
+	if b.userDataDir != "" {
+		discardDemoCaptureError(os.RemoveAll(b.userDataDir))
+	}
+}
+
+func (p *demoCapturePage) CaptureScenario(ctx context.Context, baseURL string, plan demoStillCapture, cfg demoCaptureConfig) error {
+	if err := os.MkdirAll(filepath.Dir(plan.Path), 0o755); err != nil {
+		return fmt.Errorf("create screenshot directory: %w", err)
+	}
+	pageCtx, cancel := context.WithTimeout(ctx, cfg.Timeout)
+	defer cancel()
+	if err := p.Call(pageCtx, "Emulation.setDeviceMetricsOverride", map[string]any{
+		"width":             cfg.Width,
+		"height":            cfg.Height,
+		"deviceScaleFactor": cfg.DeviceScaleFactor,
+		"mobile":            false,
+	}, nil); err != nil {
+		return fmt.Errorf("set browser viewport: %w", err)
+	}
+	headers := plan.Scenario.Headers
+	if len(headers) == 0 {
+		headers = map[string]string{web.DemoScenarioHeader: plan.Scenario.ID}
+	}
+	if err := p.Call(pageCtx, "Network.setExtraHTTPHeaders", map[string]any{"headers": headers}, nil); err != nil {
+		return fmt.Errorf("set demo scenario headers: %w", err)
+	}
+	targetURL, err := demoCaptureScenarioURL(baseURL, plan.Scenario.Route)
+	if err != nil {
+		return err
+	}
+	if err := p.Call(pageCtx, "Page.navigate", map[string]any{"url": targetURL}, nil); err != nil {
+		return fmt.Errorf("navigate to %s: %w", targetURL, err)
+	}
+	waitSelector := strings.TrimSpace(plan.Scenario.WaitSelector)
+	if waitSelector == "" {
+		waitSelector = "body"
+	}
+	if err := p.WaitForSelector(pageCtx, waitSelector); err != nil {
+		return fmt.Errorf("wait for scenario %s selector %s: %w", plan.Scenario.ID, waitSelector, err)
+	}
+	if err := p.WaitForFonts(pageCtx); err != nil {
+		return fmt.Errorf("wait for scenario %s fonts: %w", plan.Scenario.ID, err)
+	}
+	if err := p.Screenshot(pageCtx, plan.Path); err != nil {
+		return fmt.Errorf("capture scenario %s screenshot: %w", plan.Scenario.ID, err)
+	}
+	return nil
+}
+
+func demoCaptureScenarioURL(baseURL string, route string) (string, error) {
+	base, err := url.Parse(baseURL)
+	if err != nil {
+		return "", fmt.Errorf("parse demo runtime URL: %w", err)
+	}
+	ref, err := url.Parse(strings.TrimSpace(route))
+	if err != nil {
+		return "", fmt.Errorf("parse demo scenario route %q: %w", route, err)
+	}
+	return base.ResolveReference(ref).String(), nil
+}
+
+func (p *demoCapturePage) WaitForSelector(ctx context.Context, selector string) error {
+	expression := fmt.Sprintf(`(() => {
+		const element = document.querySelector(%s);
+		if (document.readyState === "loading" || !element) {
+			return false;
+		}
+		const style = window.getComputedStyle(element);
+		if (!style || style.display === "none" || style.visibility === "hidden") {
+			return false;
+		}
+		return Boolean(element.offsetWidth || element.offsetHeight || element.getClientRects().length);
+	})()`, strconv.Quote(selector))
+	ticker := time.NewTicker(25 * time.Millisecond)
+	defer ticker.Stop()
+	var lastErr error
+	for {
+		ok, err := p.EvalBool(ctx, expression)
+		if err == nil && ok {
+			return nil
+		}
+		if err != nil {
+			lastErr = err
+		}
+		select {
+		case <-ctx.Done():
+			if lastErr != nil {
+				return fmt.Errorf("%w: browser selector evaluation failed: %w", ctx.Err(), lastErr)
+			}
+			return ctx.Err()
+		case <-ticker.C:
+		}
+	}
+}
+
+func (p *demoCapturePage) WaitForFonts(ctx context.Context) error {
+	var ok bool
+	return p.Eval(ctx, `document.fonts ? document.fonts.ready.then(() => true) : true`, &ok)
+}
+
+func (p *demoCapturePage) Screenshot(ctx context.Context, path string) error {
+	var result struct {
+		Data string `json:"data"`
+	}
+	if err := p.Call(ctx, "Page.captureScreenshot", map[string]any{
+		"format":                "png",
+		"captureBeyondViewport": false,
+		"fromSurface":           true,
+	}, &result); err != nil {
+		return err
+	}
+	raw, err := base64.StdEncoding.DecodeString(result.Data)
+	if err != nil {
+		return fmt.Errorf("decode browser screenshot: %w", err)
+	}
+	if err := os.WriteFile(path, raw, 0o644); err != nil {
+		return fmt.Errorf("write browser screenshot %s: %w", path, err)
+	}
+	return nil
+}
+
+func (p *demoCapturePage) EvalBool(ctx context.Context, expression string) (bool, error) {
+	var got bool
+	if err := p.Eval(ctx, expression, &got); err != nil {
+		return false, err
+	}
+	return got, nil
+}
+
+func (p *demoCapturePage) Eval(ctx context.Context, expression string, out any) error {
+	var result struct {
+		Result struct {
+			Value json.RawMessage `json:"value"`
+		} `json:"result"`
+		ExceptionDetails json.RawMessage `json:"exceptionDetails"`
+	}
+	if err := p.Call(ctx, "Runtime.evaluate", map[string]any{
+		"expression":    expression,
+		"awaitPromise":  true,
+		"returnByValue": true,
+	}, &result); err != nil {
+		return err
+	}
+	if len(result.ExceptionDetails) > 0 {
+		return fmt.Errorf("runtime.evaluate exception for %s: %s", expression, result.ExceptionDetails)
+	}
+	if len(result.Result.Value) == 0 {
+		return fmt.Errorf("runtime.evaluate returned no value for %s", expression)
+	}
+	if err := json.Unmarshal(result.Result.Value, out); err != nil {
+		return fmt.Errorf("decode Runtime.evaluate value for %s: %w", expression, err)
+	}
+	return nil
+}
+
+func (p *demoCapturePage) Call(ctx context.Context, method string, params any, out any) error {
+	if p == nil || p.client == nil {
+		return fmt.Errorf("browser page is closed")
+	}
+	if err := p.client.Call(ctx, method, params, out); err != nil {
+		return fmt.Errorf("CDP %s: %w", method, err)
+	}
+	return nil
+}
+
+func (p *demoCapturePage) Close() {
+	if p == nil || p.client == nil {
+		return
+	}
+	p.client.Close()
+}
+
+func newDemoCaptureCDPClient(wsURL string) (*demoCaptureCDPClient, error) {
+	conn, err := websocket.Dial(wsURL, "", "http://127.0.0.1/")
+	if err != nil {
+		return nil, err
+	}
+	client := &demoCaptureCDPClient{
+		conn:    conn,
+		pending: make(map[int64]chan demoCaptureCDPResponse),
+	}
+	go client.readLoop()
+	return client, nil
+}
+
+func (c *demoCaptureCDPClient) Call(ctx context.Context, method string, params any, out any) error {
+	id := c.nextID.Add(1)
+	response := make(chan demoCaptureCDPResponse, 1)
+	c.mu.Lock()
+	c.pending[id] = response
+	c.mu.Unlock()
+
+	payload := map[string]any{
+		"id":     id,
+		"method": method,
+	}
+	if params != nil {
+		payload["params"] = params
+	}
+	if err := websocket.JSON.Send(c.conn, payload); err != nil {
+		c.deletePending(id)
+		return err
+	}
+
+	select {
+	case resp := <-response:
+		if resp.Error != nil {
+			return fmt.Errorf("%s (%d)", resp.Error.Message, resp.Error.Code)
+		}
+		if out != nil && len(resp.Result) > 0 {
+			if err := json.Unmarshal(resp.Result, out); err != nil {
+				return err
+			}
+		}
+		return nil
+	case <-ctx.Done():
+		c.deletePending(id)
+		return ctx.Err()
+	}
+}
+
+func (c *demoCaptureCDPClient) deletePending(id int64) {
+	c.mu.Lock()
+	delete(c.pending, id)
+	c.mu.Unlock()
+}
+
+func (c *demoCaptureCDPClient) readLoop() {
+	for {
+		var raw json.RawMessage
+		if err := websocket.JSON.Receive(c.conn, &raw); err != nil {
+			c.failPending(err)
+			return
+		}
+		var envelope struct {
+			ID     int64                `json:"id"`
+			Method string               `json:"method"`
+			Result json.RawMessage      `json:"result"`
+			Error  *demoCaptureCDPError `json:"error"`
+		}
+		if err := json.Unmarshal(raw, &envelope); err != nil {
+			continue
+		}
+		if envelope.ID == 0 {
+			continue
+		}
+		c.mu.Lock()
+		pending := c.pending[envelope.ID]
+		delete(c.pending, envelope.ID)
+		c.mu.Unlock()
+		if pending != nil {
+			pending <- demoCaptureCDPResponse{ID: envelope.ID, Result: envelope.Result, Error: envelope.Error}
+		}
+	}
+}
+
+func (c *demoCaptureCDPClient) failPending(err error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	for id, pending := range c.pending {
+		delete(c.pending, id)
+		pending <- demoCaptureCDPResponse{ID: id, Error: &demoCaptureCDPError{Message: err.Error()}}
+	}
+}
+
+func (c *demoCaptureCDPClient) Close() {
+	if c == nil || c.conn == nil {
+		return
+	}
+	discardDemoCaptureError(c.conn.Close())
+}

--- a/internal/cli/dev_runtime_capture_test.go
+++ b/internal/cli/dev_runtime_capture_test.go
@@ -123,6 +123,11 @@ func TestPlanDemoStillCapturesValidatesSelection(t *testing.T) {
 			selection: demoCaptureSelection{AllScenarios: true, ScenarioIDs: []string{"fleet-healthy-parallel-work"}},
 			wantErr:   "--all-scenarios cannot be combined with --scenario",
 		},
+		{
+			name:      "stream scenario",
+			selection: demoCaptureSelection{ScenarioIDs: []string{"events-play"}},
+			wantErr:   `demo capture scenario "events-play" is not browser-capturable`,
+		},
 	}
 
 	for _, tt := range tests {
@@ -134,6 +139,33 @@ func TestPlanDemoStillCapturesValidatesSelection(t *testing.T) {
 				t.Fatalf("planDemoStillCaptures() error = %v, want containing %q", err, tt.wantErr)
 			}
 		})
+	}
+}
+
+func TestPlanDemoStillCapturesAllScenariosSkipsStreams(t *testing.T) {
+	t.Parallel()
+
+	outDir := filepath.Join(t.TempDir(), "capture")
+	captures, err := planDemoStillCaptures(outDir, demoCaptureTestManifest(), demoCaptureSelection{AllScenarios: true})
+	if err != nil {
+		t.Fatalf("planDemoStillCaptures() error = %v", err)
+	}
+	var got []string
+	for _, capture := range captures {
+		got = append(got, capture.Scenario.ID)
+	}
+	if len(got) == 0 {
+		t.Fatal("all-scenarios returned no captures")
+	}
+	for _, forbidden := range []string{"api-kanban-move-success", "events-play"} {
+		for _, id := range got {
+			if id == forbidden {
+				t.Fatalf("all-scenarios included %q: %#v", forbidden, got)
+			}
+		}
+	}
+	if got[len(got)-1] != "settings-loaded-fleet" {
+		t.Fatalf("last all-scenarios capture = %q, want settings-loaded-fleet in manifest order", got[len(got)-1])
 	}
 }
 
@@ -213,6 +245,12 @@ func demoCaptureTestManifest() []web.DemoScenarioManifest {
 			Route:        "/settings",
 			Method:       "GET",
 			WaitSelector: "main",
+		},
+		web.DemoScenarioManifest{
+			ID:           "events-play",
+			Route:        "/events",
+			Method:       "GET",
+			WaitSelector: "#snapshot",
 		},
 	)
 	return manifest

--- a/internal/cli/dev_runtime_capture_test.go
+++ b/internal/cli/dev_runtime_capture_test.go
@@ -1,0 +1,219 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/web"
+)
+
+func TestDevRuntimeCaptureCommandPassesDefaultsToRunner(t *testing.T) {
+	t.Parallel()
+
+	outDir := filepath.Join(t.TempDir(), "capture")
+	var got demoCaptureConfig
+	cmd := NewRootCommand(context.Background(), func(opts *options) {
+		opts.captureDemo = func(_ context.Context, cfg demoCaptureConfig) (demoCaptureResult, error) {
+			got = cfg
+			return demoCaptureResult{
+				Version:      demoCaptureVersion,
+				OutDir:       cfg.OutDir,
+				ManifestPath: filepath.Join(cfg.OutDir, "demo-capture-"+demoCaptureVersion+".json"),
+				Stills: []demoCaptureStillResult{{
+					ScenarioID: "fleet-healthy-parallel-work",
+					Path:       filepath.Join(cfg.OutDir, "stills", demoCaptureVersion, "01-fleet-healthy-parallel-work.png"),
+				}},
+				Terminal: demoCaptureTerminalResult{
+					CastPath: filepath.Join(cfg.OutDir, "terminal", demoCaptureVersion, "onboarding.cast"),
+				},
+			}, nil
+		}
+	})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "dev-runtime", "capture", "--out", outDir})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	if got.OutDir != outDir {
+		t.Fatalf("OutDir = %q, want %q", got.OutDir, outDir)
+	}
+	if got.Width != 1920 || got.Height != 1080 || got.DeviceScaleFactor != 2 {
+		t.Fatalf("geometry = %dx%d dsf %.1f, want 1920x1080 dsf 2", got.Width, got.Height, got.DeviceScaleFactor)
+	}
+	if got.DemoClock != "frozen" {
+		t.Fatalf("DemoClock = %q, want frozen", got.DemoClock)
+	}
+	if len(got.ScenarioIDs) != 0 || got.AllScenarios {
+		t.Fatalf("scenario selection = %#v all=%v, want canonical default", got.ScenarioIDs, got.AllScenarios)
+	}
+
+	var payload demoCaptureResult
+	if err := json.Unmarshal(stdout.Bytes(), &payload); err != nil {
+		t.Fatalf("stdout is not capture result JSON: %v\n%s", err, stdout.String())
+	}
+	if payload.Version != demoCaptureVersion || len(payload.Stills) != 1 || payload.Terminal.CastPath == "" {
+		t.Fatalf("capture JSON = %#v, want version, still, and terminal cast", payload)
+	}
+}
+
+func TestPlanDemoStillCapturesUsesCanonicalStablePaths(t *testing.T) {
+	t.Parallel()
+
+	outDir := filepath.Join(t.TempDir(), "capture")
+	manifest := demoCaptureTestManifest()
+
+	captures, err := planDemoStillCaptures(outDir, manifest, demoCaptureSelection{})
+	if err != nil {
+		t.Fatalf("planDemoStillCaptures() error = %v", err)
+	}
+
+	want := []string{
+		"01-fleet-healthy-parallel-work.png",
+		"02-fleet-kanban-multiproject.png",
+		"03-kanban-full-integration.png",
+		"04-project-active-overview.png",
+		"05-reports-normal-window.png",
+		"06-onboarding-project-selection.png",
+	}
+	if len(captures) != len(want) {
+		t.Fatalf("captures length = %d, want %d", len(captures), len(want))
+	}
+	for i, name := range want {
+		if captures[i].Scenario.ID != strings.TrimSuffix(strings.TrimPrefix(name[3:], "-"), ".png") {
+			t.Fatalf("capture[%d] scenario = %q, want name %q", i, captures[i].Scenario.ID, name)
+		}
+		wantPath := filepath.Join(outDir, "stills", demoCaptureVersion, name)
+		if captures[i].Path != wantPath {
+			t.Fatalf("capture[%d] path = %q, want %q", i, captures[i].Path, wantPath)
+		}
+	}
+}
+
+func TestPlanDemoStillCapturesValidatesSelection(t *testing.T) {
+	t.Parallel()
+
+	outDir := filepath.Join(t.TempDir(), "capture")
+	manifest := demoCaptureTestManifest()
+	tests := []struct {
+		name      string
+		selection demoCaptureSelection
+		wantErr   string
+	}{
+		{
+			name:      "unknown scenario",
+			selection: demoCaptureSelection{ScenarioIDs: []string{"missing"}},
+			wantErr:   `unknown demo capture scenario "missing"`,
+		},
+		{
+			name:      "post scenario",
+			selection: demoCaptureSelection{ScenarioIDs: []string{"api-kanban-move-success"}},
+			wantErr:   `demo capture scenario "api-kanban-move-success" uses POST`,
+		},
+		{
+			name:      "all with explicit scenario",
+			selection: demoCaptureSelection{AllScenarios: true, ScenarioIDs: []string{"fleet-healthy-parallel-work"}},
+			wantErr:   "--all-scenarios cannot be combined with --scenario",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := planDemoStillCaptures(outDir, manifest, tt.selection)
+			if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("planDemoStillCaptures() error = %v, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestWriteDemoTerminalCaptureIsDeterministicAndIsolated(t *testing.T) {
+	t.Parallel()
+
+	outDir := filepath.Join(t.TempDir(), "capture")
+	got, err := writeDemoTerminalCapture(outDir)
+	if err != nil {
+		t.Fatalf("writeDemoTerminalCapture() error = %v", err)
+	}
+
+	if got.CastPath != filepath.Join(outDir, "terminal", demoCaptureVersion, "onboarding.cast") {
+		t.Fatalf("CastPath = %q, want stable terminal cast path", got.CastPath)
+	}
+	raw, err := os.ReadFile(got.CastPath)
+	if err != nil {
+		t.Fatalf("read cast: %v", err)
+	}
+	cast := string(raw)
+	for _, want := range []string{
+		`{"version":2,"width":100,"height":28`,
+		"detent init --config ./terminal/v1/config/global.yaml",
+		"detent add-project --config ./terminal/v1/config/global.yaml",
+		"detent doctor --config ./terminal/v1/config/global.yaml --port 0",
+		"result: PASS",
+	} {
+		if !strings.Contains(cast, want) {
+			t.Fatalf("cast missing %q:\n%s", want, cast)
+		}
+	}
+	for _, forbidden := range []string{"~/.config/detent/global.yaml", "/.config/detent/global.yaml", "/.detent/global.yaml"} {
+		if strings.Contains(cast, forbidden) {
+			t.Fatalf("cast contains non-isolated config reference %q:\n%s", forbidden, cast)
+		}
+	}
+
+	head, err := os.ReadFile(filepath.Join(got.SourceRoot, ".git", "HEAD"))
+	if err != nil {
+		t.Fatalf("read isolated source git HEAD: %v", err)
+	}
+	if string(head) != "ref: refs/heads/main\n" {
+		t.Fatalf("isolated source git HEAD = %q, want main ref", head)
+	}
+}
+
+func demoCaptureTestManifest() []web.DemoScenarioManifest {
+	ids := []string{
+		"fleet-healthy-parallel-work",
+		"fleet-kanban-multiproject",
+		"kanban-full-integration",
+		"project-active-overview",
+		"reports-normal-window",
+		"onboarding-project-selection",
+	}
+	manifest := make([]web.DemoScenarioManifest, 0, len(ids)+2)
+	for _, id := range ids {
+		manifest = append(manifest, web.DemoScenarioManifest{
+			ID:             id,
+			Route:          "/" + id,
+			Method:         "GET",
+			Headers:        map[string]string{web.DemoScenarioHeader: id},
+			Viewport:       web.DemoViewport{Width: 1440, Height: 1100},
+			ScreenshotName: id + ".png",
+			WaitSelector:   "main",
+		})
+	}
+	manifest = append(manifest,
+		web.DemoScenarioManifest{
+			ID:           "api-kanban-move-success",
+			Route:        "/api/v1/kanban/move",
+			Method:       "POST",
+			WaitSelector: "body",
+		},
+		web.DemoScenarioManifest{
+			ID:           "settings-loaded-fleet",
+			Route:        "/settings",
+			Method:       "GET",
+			WaitSelector: "main",
+		},
+	)
+	return manifest
+}


### PR DESCRIPTION
## Summary

- Add `detent dev-runtime capture` to start the screenshots demo, capture canonical v1 stills through Chrome CDP, and write a versioned capture manifest.
- Add deterministic terminal onboarding cast output with isolated config/workflow/source artifacts.
- Document the canonical command, stable output paths, resolution flags, and browser selection.

Fixes #585

## Test Plan

- [x] `go test ./internal/cli`
- [x] `go test ./...`
- [x] `go run ./cmd/detent --format json dev-runtime capture --out <tmp> --scenario fleet-healthy-parallel-work --width 800 --height 600 --device-scale-factor 1 --browser /Applications/Google Chrome.app/Contents/MacOS/Google Chrome --timeout 20s`
- [x] `make check`
