### PR TITLE
fix(orchestrator): preserve unblock lifecycle

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1333,6 +1333,7 @@ func checkDoctorDependencyAutoUnblockLive(
 		states := append([]string(nil), dependencyCfg.SourceStates...)
 		if dependencyCfg.Enabled {
 			states = append(states, dependencyCfg.TargetState)
+			states = append(states, "Rework")
 		}
 		if len(states) > 0 {
 			if err := verifier.VerifyStatusOptions(ctx, states); err != nil {
@@ -1340,7 +1341,7 @@ func checkDoctorDependencyAutoUnblockLive(
 					Name:   name,
 					Status: doctorFail,
 					Detail: fmt.Sprintf("status option verification failed: %v", err),
-					Hint:   "Ensure dependency auto-unblock source_states and target_state resolve through tracker.state_map to existing GitHub Project Status options.",
+					Hint:   "Ensure dependency auto-unblock source_states, target_state, and Rework resolve through tracker.state_map to existing GitHub Project Status options.",
 				}
 			}
 		}

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -1291,6 +1291,14 @@ func checkDoctorDependencyAutoUnblock(ctx context.Context, id string, cfg workfl
 			Detail: "live dependency auto-unblock diagnostics skipped for " + cfg.Tracker.Kind + " tracker",
 		}
 	}
+	if cfg.Tracker.DependencyAutoUnblock.Enabled && !doctorStateInList("Rework", cfg.Tracker.ActiveStates) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "tracker.dependency_auto_unblock.enabled=true but tracker.active_states does not include Rework",
+			Hint:   "Add Rework to tracker.active_states so started dependency-unblocked issues can resume.",
+		}
+	}
 
 	if deps.autoPromoteConnector == nil {
 		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -675,6 +675,9 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 			if tt.cfg.Tracker.DependencyAutoUnblock.Enabled && !stringSliceContains(tt.connector.verifyStates, "Todo") {
 				t.Fatalf("VerifyStatusOptions states = %#v, want Todo", tt.connector.verifyStates)
 			}
+			if tt.cfg.Tracker.DependencyAutoUnblock.Enabled && !stringSliceContains(tt.connector.verifyStates, "Rework") {
+				t.Fatalf("VerifyStatusOptions states = %#v, want Rework", tt.connector.verifyStates)
+			}
 		})
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -682,6 +682,23 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorDependencyAutoUnblockRequiresActiveRework(t *testing.T) {
+	t.Parallel()
+
+	cfg := validDoctorDependencyWorkflow(true)
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+
+	got := checkDoctorDependencyAutoUnblock(context.Background(), "alpha", cfg, doctorDeps{})
+	if got.Status != doctorFail {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorFail, got)
+	}
+	for _, want := range []string{"tracker.active_states", "Rework"} {
+		if !strings.Contains(got.Detail, want) && !strings.Contains(got.Hint, want) {
+			t.Fatalf("check missing %q:\nDetail: %s\nHint: %s", want, got.Detail, got.Hint)
+		}
+	}
+}
+
 func TestCheckDoctorBlockedRecovery(t *testing.T) {
 	t.Parallel()
 
@@ -2143,6 +2160,7 @@ func validDoctorDependencyWorkflow(enabled bool) workflowconfig.Config {
 	cfg.Tracker.DependencyAutoUnblock.SourceStates = []string{"Blocked"}
 	cfg.Tracker.DependencyAutoUnblock.TargetState = "Todo"
 	cfg.Tracker.DependencyAutoUnblock.Readiness = workflowconfig.DependencyReadinessTerminalOrMerged
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress", "Rework"}
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -707,6 +707,9 @@ func (c *Config) validateTracker(problems *[]string) {
 	validateStateMap("tracker.state_map", c.Tracker.StateMap, problems)
 	validatePriorityMap("tracker.priority_map", c.Tracker.PriorityMap, problems)
 	*problems = append(*problems, c.Tracker.DependencyAutoUnblock.Validate("tracker.dependency_auto_unblock")...)
+	if c.Tracker.DependencyAutoUnblock.Enabled && !stateListContains(c.Tracker.ActiveStates, "Rework") {
+		*problems = append(*problems, "tracker.active_states must include Rework when tracker.dependency_auto_unblock.enabled is true")
+	}
 	validatePositive("tracker.http_max_idle_conns", c.Tracker.HTTPMaxIdleConns, problems)
 	validatePositive("tracker.http_max_idle_conns_per_host", c.Tracker.HTTPMaxIdleConnsPerHost, problems)
 	validatePositive("tracker.http_idle_conn_timeout_ms", c.Tracker.HTTPIdleConnTimeoutMS, problems)
@@ -1289,6 +1292,16 @@ func normalizeStateList(states []string) []string {
 
 func normalizeIssueState(state string) string {
 	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func stateListContains(states []string, want string) bool {
+	want = normalizeIssueState(want)
+	for _, state := range states {
+		if normalizeIssueState(state) == want {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeLabel(label string) string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -47,6 +47,7 @@ tracker:
   active_states:
     - Todo
     - In Progress
+    - Rework
   state_map:
     Cancelled: Done
   priority_map:
@@ -1145,6 +1146,28 @@ Prompt
 				"tracker.dependency_auto_unblock.source_states state names must not be blank",
 				"tracker.dependency_auto_unblock.target_state is required when tracker.dependency_auto_unblock.enabled is true",
 				"tracker.dependency_auto_unblock.readiness must be one of terminal, terminal_or_merged",
+				"tracker.active_states must include Rework when tracker.dependency_auto_unblock.enabled is true",
+			},
+		},
+		{
+			name: "dependency auto unblock requires active rework",
+			raw: `---
+tracker:
+  kind: memory
+  active_states:
+    - Todo
+    - In Progress
+  dependency_auto_unblock:
+    enabled: true
+    source_states:
+      - Blocked
+    target_state: Todo
+    readiness: terminal_or_merged
+---
+Prompt
+`,
+			want: []string{
+				"tracker.active_states must include Rework when tracker.dependency_auto_unblock.enabled is true",
 			},
 		},
 		{

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -68,7 +68,8 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if !dependencyBlockersReady(blockers, cfg, o.cfg.TerminalStates) {
 			continue
 		}
-		if !o.applyDependencyAutoUnblock(ctx, state, hydrated, blockers, cfg.TargetState, now) {
+		targetState := dependencyAutoUnblockTargetState(state, hydrated, cfg.TargetState)
+		if !o.applyDependencyAutoUnblock(ctx, state, hydrated, blockers, targetState, now) {
 			continue
 		}
 		transitioned[issueID] = struct{}{}
@@ -425,6 +426,57 @@ func dependencyBlockerReady(blocker dependencyBlocker, cfg DependencyAutoUnblock
 
 func pullRequestMerged(pullRequest *connector.PullRequest) bool {
 	return pullRequest != nil && normalizePullRequestState(pullRequest.State) == "merged"
+}
+
+func dependencyAutoUnblockTargetState(state *State, issue connector.Issue, configuredTarget string) string {
+	if dependencyAutoUnblockStarted(state, issue) {
+		return autoPromoteReworkState
+	}
+	return strings.TrimSpace(defaultString(configuredTarget, "Todo"))
+}
+
+func dependencyAutoUnblockStarted(state *State, issue connector.Issue) bool {
+	if dependencyAutoUnblockStartedSignal(issue) {
+		return true
+	}
+	if state == nil {
+		return false
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return false
+	}
+	if _, ok := state.Running[issueID]; ok {
+		return true
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		return true
+	}
+	if _, ok := state.Retry[issueID]; ok {
+		return true
+	}
+	if _, ok := state.Completed[issueID]; ok {
+		return true
+	}
+	if blocked, ok := state.Blocked[issueID]; ok {
+		return dependencyAutoUnblockStartedSignal(blocked.Issue)
+	}
+	return false
+}
+
+func dependencyAutoUnblockStartedSignal(issue connector.Issue) bool {
+	if strings.TrimSpace(issue.BranchName) != "" {
+		return true
+	}
+	if issue.PRNumber != nil && *issue.PRNumber > 0 {
+		return true
+	}
+	if issue.PullRequest == nil {
+		return false
+	}
+	return issue.PullRequest.Number > 0 ||
+		strings.TrimSpace(issue.PullRequest.URL) != "" ||
+		strings.TrimSpace(issue.PullRequest.BranchName) != ""
 }
 
 func (o *Orchestrator) applyDependencyAutoUnblock(

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -302,6 +302,71 @@ func TestTickLeavesDependencyBlockedPRIssueBlocked(t *testing.T) {
 	}
 }
 
+func TestTickAutoUnblocksDependencyBlockedPRIssueToRework(t *testing.T) {
+	t.Parallel()
+
+	prNumber := 430
+	waiting := dependencyAutoUnblockIssue("issue-ready-pr-blocked", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415", State: "Done"}}
+	waiting.PRNumber = &prNumber
+	waiting.PullRequest = &connector.PullRequest{
+		Number:     prNumber,
+		URL:        "https://github.com/digitaldrywood/detent/pull/430",
+		State:      "OPEN",
+		HeadSHA:    "sha-current",
+		BranchName: "detent/digitaldrywood_detent_429",
+	}
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 8, 15, 0, time.UTC))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Rework"}) {
+		t.Fatalf("updates = %#v, want dependency-unblocked PR issue moved to Rework", got)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "Blocked to Rework") {
+		t.Fatalf("comments = %#v, want dependency auto-unblock comment for Rework", tracker.comments)
+	}
+}
+
+func TestTickAutoUnblocksPreviouslyStartedDependencyIssueToRework(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-ready-started-blocked", "Blocked")
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415", State: "Done"}}
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	state := newState(orch.cfg)
+	state.Retry[waiting.ID] = Retry{Issue: waiting, Attempt: 1}
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 8, 20, 0, time.UTC))
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Rework"}) {
+		t.Fatalf("updates = %#v, want dependency-unblocked started issue moved to Rework", got)
+	}
+}
+
 func TestTickMergesHydratedTextDependenciesWithConnectorRefs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -5587,6 +5587,7 @@ func newSettingsTestProject(t *testing.T, cfg globalconfig.Project, worktreeRoot
 	workflowCfg.Tracker.DependencyAutoUnblock.SourceStates = []string{"Blocked", "Waiting"}
 	workflowCfg.Tracker.DependencyAutoUnblock.TargetState = "Todo"
 	workflowCfg.Tracker.DependencyAutoUnblock.Readiness = workflowconfig.DependencyReadinessTerminalOrMerged
+	workflowCfg.Tracker.ActiveStates = []string{"Todo", "In Progress", "Rework"}
 	workflowCfg.Workspace.Root = worktreeRoot
 	workflowCfg.Workspace.SourceRoot = cfg.Workdir
 


### PR DESCRIPTION
## Summary

- Preserve dependency auto-unblock lifecycle context by routing PR-backed or previously started blocked work to `Rework`.
- Keep never-started dependency-unblocked work on the configured target state, typically `Todo`.
- Require `Rework` to be an active state when dependency auto-unblock is enabled, and verify `Rework` in doctor checks.

Fixes #591

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestTick(AutoUnblocksDependencyBlockedPRIssueToRework|AutoUnblocksPreviouslyStartedDependencyIssueToRework|AutoUnblocksDependencyWaitingIssue|LeavesDependencyBlockedPRIssueBlocked)$'`
- [x] `go test ./internal/config -run 'Test(ParseWorkflowFrontmatter|ParseWorkflowValidationErrors)$'`
- [x] `go test ./internal/cli -run 'TestCheckDoctorDependencyAutoUnblock'`
- [x] `go test ./internal/web -run 'TestSettingsRendersConfigProjectsAndRuntimePaths$'`
- [x] `make check`