### PR TITLE
fix(ci): harden installer smoke release lookup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,6 +239,19 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
+      - name: Resolve release installer version
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          tag="$(gh release view --repo "$GITHUB_REPOSITORY" --json tagName --jq .tagName)"
+          if [ -z "$tag" ]; then
+            echo "Could not resolve latest Detent release tag" >&2
+            exit 1
+          fi
+          echo "DETENT_VERSION=$tag" >> "$GITHUB_ENV"
+
       - name: Smoke release installer
         if: runner.os == 'Linux'
         shell: bash
@@ -249,8 +262,12 @@ jobs:
           export DETENT_INSTALL_LOCK="$DETENT_STATE_DIR/install.lock"
           export DETENT_INSTALL_MODE=release
 
-          output="$(sh ./install.sh)"
+          output="$(sh ./install.sh 2>&1)"
           printf '%s\n' "$output"
+          if grep -Fq "falling back to go install" <<< "$output"; then
+            echo "Release installer fell back to go install" >&2
+            exit 1
+          fi
           grep -F "Verified checksum for detent_" <<< "$output"
           grep -F "Installed Detent at $DETENT_INSTALL_DIR/detent" <<< "$output"
           grep -F "Add $DETENT_INSTALL_DIR to PATH before running detent" <<< "$output"
@@ -280,6 +297,9 @@ jobs:
           $output | ForEach-Object { Write-Host $_ }
           if ($exitCode -ne 0) {
             throw "install.ps1 failed with exit code $exitCode"
+          }
+          if ($output -match 'falling back to go install') {
+            throw 'Release installer fell back to go install'
           }
           if (-not ($output -match 'Verified checksum for detent_.*_windows_.*\.zip')) {
             throw 'install.ps1 did not report checksum verification'

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -1,0 +1,72 @@
+package detent_test
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestInstallerSmokeUsesAuthenticatedReleaseVersion(t *testing.T) {
+	t.Parallel()
+
+	raw, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("ReadFile(.github/workflows/ci.yml) error = %v", err)
+	}
+	workflow := string(raw)
+	job := workflowBetween(t, workflow, "  installer-smoke:", "\n  goreleaser-snapshot:")
+
+	for _, want := range []string{
+		"name: Resolve release installer version",
+		"GH_TOKEN: ${{ github.token }}",
+		"gh release view --repo \"$GITHUB_REPOSITORY\" --json tagName --jq .tagName",
+		"DETENT_VERSION=$tag",
+		"$GITHUB_ENV",
+	} {
+		if !strings.Contains(job, want) {
+			t.Fatalf("installer-smoke job missing %q", want)
+		}
+	}
+
+	linux := workflowBetween(t, job, "      - name: Smoke release installer\n        if: runner.os == 'Linux'", "      - name: Smoke release installer\n        if: runner.os == 'Windows'")
+	for _, want := range []string{
+		"2>&1",
+		"falling back to go install",
+		"Release installer fell back to go install",
+		"exit 1",
+		"Verified checksum for detent_",
+	} {
+		if !strings.Contains(linux, want) {
+			t.Fatalf("Linux installer smoke step missing %q", want)
+		}
+	}
+
+	windows := workflowBetween(t, job, "      - name: Smoke release installer\n        if: runner.os == 'Windows'", "")
+	for _, want := range []string{
+		"falling back to go install",
+		"Release installer fell back to go install",
+		"Verified checksum for detent_.*_windows_.*\\.zip",
+	} {
+		if !strings.Contains(windows, want) {
+			t.Fatalf("Windows installer smoke step missing %q", want)
+		}
+	}
+}
+
+func workflowBetween(t *testing.T, content string, startMarker string, endMarker string) string {
+	t.Helper()
+
+	start := strings.Index(content, startMarker)
+	if start == -1 {
+		t.Fatalf("workflow missing marker %q", startMarker)
+	}
+	section := content[start:]
+	if endMarker == "" {
+		return section
+	}
+	end := strings.Index(section[len(startMarker):], endMarker)
+	if end == -1 {
+		t.Fatalf("workflow missing end marker %q after %q", endMarker, startMarker)
+	}
+	return section[:len(startMarker)+end]
+}

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -13,7 +13,7 @@ func TestInstallerSmokeUsesAuthenticatedReleaseVersion(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ReadFile(.github/workflows/ci.yml) error = %v", err)
 	}
-	workflow := string(raw)
+	workflow := strings.ReplaceAll(string(raw), "\r\n", "\n")
 	job := workflowBetween(t, workflow, "  installer-smoke:", "\n  goreleaser-snapshot:")
 
 	for _, want := range []string{

--- a/install.sh
+++ b/install.sh
@@ -81,6 +81,31 @@ download_optional_file() {
 	curl -fsSL "$1" -o "$2" 2>/dev/null
 }
 
+github_api_token() {
+	if [ -n "${DETENT_GITHUB_TOKEN:-}" ]; then
+		printf '%s\n' "$DETENT_GITHUB_TOKEN"
+		return
+	fi
+	if [ -n "${GITHUB_TOKEN:-}" ]; then
+		printf '%s\n' "$GITHUB_TOKEN"
+		return
+	fi
+	printf ''
+}
+
+download_api_file() {
+	token="$(github_api_token)"
+	if [ -n "$token" ]; then
+		curl -fsSL \
+			-H "Accept: application/vnd.github+json" \
+			-H "Authorization: Bearer $token" \
+			-H "X-GitHub-Api-Version: 2022-11-28" \
+			"$1" -o "$2"
+		return
+	fi
+	download_file "$1" "$2"
+}
+
 release_tag() {
 	if [ -n "${DETENT_VERSION:-}" ]; then
 		printf '%s\n' "$DETENT_VERSION"
@@ -88,7 +113,7 @@ release_tag() {
 	fi
 
 	response="$tmp_dir/latest-release.json"
-	if ! download_file "$api_base/releases/latest" "$response"; then
+	if ! download_api_file "$api_base/releases/latest" "$response"; then
 		return 1
 	fi
 

--- a/install.sh
+++ b/install.sh
@@ -96,7 +96,7 @@ github_api_token() {
 download_api_file() {
 	token="$(github_api_token)"
 	if [ -n "$token" ]; then
-		curl -fsSL \
+		curl -fsS \
 			-H "Accept: application/vnd.github+json" \
 			-H "Authorization: Bearer $token" \
 			-H "X-GitHub-Api-Version: 2022-11-28" \

--- a/install_test.go
+++ b/install_test.go
@@ -248,6 +248,80 @@ func TestInstallScriptAuthenticatesLatestReleaseRequest(t *testing.T) {
 	}
 }
 
+func TestInstallScriptDoesNotForwardTokenAcrossLatestReleaseRedirect(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	const token = "ci-token"
+	leaked := make(chan string, 1)
+	redirectTarget := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		select {
+		case leaked <- r.Header.Get("Authorization"):
+		default:
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `{"tag_name":"v1.2.3"}`)
+	}))
+	defer redirectTarget.Close()
+
+	archiveName := "detent_1.2.3_linux_amd64.tar.gz"
+	archive := detentArchive(t, "#!/usr/bin/env sh\nprintf 'release-ok\\n'\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/latest":
+			if got, want := r.Header.Get("Authorization"), "Bearer "+token; got != want {
+				http.Error(w, "missing authorization", http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Location", redirectTarget.URL+"/latest")
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusFound)
+			fmt.Fprint(w, `{"tag_name":"v1.2.3"}`)
+		case "/v1.2.3/" + archiveName:
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archive)
+		case "/v1.2.3/detent_1.2.3_checksums.txt":
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%s  %s\n", archiveChecksum(archive), archiveName)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"GITHUB_TOKEN="+token,
+		"DETENT_GITHUB_TOKEN=",
+		"DETENT_VERSION=",
+		"DETENT_GITHUB_API_BASE="+server.URL,
+		"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"DETENT_INSTALL_DIR="+installDir,
+		"DETENT_INSTALL_MODE=release",
+		"DETENT_STATE_DIR="+stateDir,
+		"DETENT_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+		"DETENT_INSTALL_TEST_UNAME_S=Linux",
+		"DETENT_INSTALL_TEST_UNAME_M=x86_64",
+	)
+
+	result := runInstall(t, root, env)
+	if result.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	select {
+	case got := <-leaked:
+		t.Fatalf("redirect target received Authorization = %q", got)
+	default:
+	}
+}
+
 func TestInstallScriptReportsPathGuidanceWhenInstallDirIsMissingFromPath(t *testing.T) {
 	t.Parallel()
 

--- a/install_test.go
+++ b/install_test.go
@@ -179,6 +179,75 @@ func TestInstallScriptInstallsReleaseArchive(t *testing.T) {
 	}
 }
 
+func TestInstallScriptAuthenticatesLatestReleaseRequest(t *testing.T) {
+	t.Parallel()
+
+	root, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+
+	const token = "ci-token"
+	archiveName := "detent_1.2.3_linux_amd64.tar.gz"
+	archive := detentArchive(t, "#!/usr/bin/env sh\nprintf 'release-ok\\n'\n")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/releases/latest":
+			if got, want := r.Header.Get("Authorization"), "Bearer "+token; got != want {
+				http.Error(w, "missing authorization", http.StatusForbidden)
+				return
+			}
+			w.Header().Set("Content-Type", "application/json")
+			fmt.Fprint(w, `{"tag_name":"v1.2.3"}`)
+		case "/v1.2.3/" + archiveName:
+			w.Header().Set("Content-Type", "application/gzip")
+			_, _ = w.Write(archive)
+		case "/v1.2.3/detent_1.2.3_checksums.txt":
+			w.Header().Set("Content-Type", "text/plain")
+			fmt.Fprintf(w, "%s  %s\n", archiveChecksum(archive), archiveName)
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	defer server.Close()
+
+	tmp := t.TempDir()
+	fakeBin := filepath.Join(tmp, "fakebin")
+	if err := os.MkdirAll(fakeBin, 0o755); err != nil {
+		t.Fatalf("MkdirAll(fakebin) error = %v", err)
+	}
+	fakeGo := filepath.Join(fakeBin, "go")
+	if err := os.WriteFile(fakeGo, []byte("#!/usr/bin/env sh\nprintf 'unexpected go install fallback\\n' >&2\nexit 42\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile(fake go) error = %v", err)
+	}
+
+	installDir := filepath.Join(tmp, "bin")
+	stateDir := filepath.Join(tmp, "state")
+	env := append(os.Environ(),
+		"HOME="+tmp,
+		"PATH="+fakeBin+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"GITHUB_TOKEN="+token,
+		"DETENT_GITHUB_TOKEN=",
+		"DETENT_VERSION=",
+		"DETENT_GITHUB_API_BASE="+server.URL,
+		"DETENT_RELEASE_DOWNLOAD_BASE="+server.URL,
+		"DETENT_INSTALL_DIR="+installDir,
+		"DETENT_INSTALL_MODE=release",
+		"DETENT_STATE_DIR="+stateDir,
+		"DETENT_INSTALL_LOCK="+filepath.Join(stateDir, "install.lock"),
+		"DETENT_INSTALL_TEST_UNAME_S=Linux",
+		"DETENT_INSTALL_TEST_UNAME_M=x86_64",
+	)
+
+	result := runInstall(t, root, env)
+	if result.err != nil {
+		t.Fatalf("install error = %v\nstdout:\n%s\nstderr:\n%s", result.err, result.stdout, result.stderr)
+	}
+	if !strings.Contains(result.stdout, "Verified checksum for "+archiveName) {
+		t.Fatalf("install stdout = %q, want checksum verification", result.stdout)
+	}
+}
+
 func TestInstallScriptReportsPathGuidanceWhenInstallDirIsMissingFromPath(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Resolve the installer smoke release version with authenticated `gh release view` and export `DETENT_VERSION` for the smoke steps.
- Send an optional GitHub token from `install.sh` when querying the latest release API without forwarding it across redirects.
- Fail release smoke explicitly if it falls back to `go install`, with regression coverage for the workflow and installer API auth path.

Fixes #596

## Test Plan

- [x] `go test -run 'TestInstallScriptAuthenticatesLatestReleaseRequest|TestInstallScriptDoesNotForwardTokenAcrossLatestReleaseRedirect|TestInstallerSmokeUsesAuthenticatedReleaseVersion' .`
- [x] `go test .`
- [x] `go test -cover ./internal/cli -run TestStartKanbanDemoBrowserDragDrop -count=1`
- [x] `make check`
- [x] Current-head CI passed for `708b28fefc312713f811e8aa4acba59e758d59b8`