### PR TITLE
fix(ci): protect main validation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,8 @@ permissions:
   pull-requests: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   lint:

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -6,14 +6,126 @@ import (
 	"testing"
 )
 
+type requiredStatusCheck struct {
+	name     string
+	jobStart string
+	jobEnd   string
+	markers  []string
+}
+
+var requiredMainStatusChecks = []requiredStatusCheck{
+	{
+		name:     "Lint",
+		jobStart: "  lint:",
+		jobEnd:   "  verify:",
+		markers:  []string{"name: Lint"},
+	},
+	{
+		name:     "Verify (ubuntu-latest)",
+		jobStart: "  verify:",
+		jobEnd:   "  test-cover:",
+		markers:  []string{"name: Verify (${{ matrix.os }})", "os: ubuntu-latest"},
+	},
+	{
+		name:     "Verify (macos-latest)",
+		jobStart: "  verify:",
+		jobEnd:   "  test-cover:",
+		markers:  []string{"name: Verify (${{ matrix.os }})", "os: macos-latest"},
+	},
+	{
+		name:     "Verify (windows-latest)",
+		jobStart: "  verify:",
+		jobEnd:   "  test-cover:",
+		markers:  []string{"name: Verify (${{ matrix.os }})", "os: windows-latest"},
+	},
+	{
+		name:     "Test Coverage",
+		jobStart: "  test-cover:",
+		jobEnd:   "  browser-visual:",
+		markers:  []string{"name: Test Coverage"},
+	},
+	{
+		name:     "Browser Visual",
+		jobStart: "  browser-visual:",
+		jobEnd:   "  windows-core:",
+		markers:  []string{"name: Browser Visual"},
+	},
+	{
+		name:     "Windows Core",
+		jobStart: "  windows-core:",
+		jobEnd:   "  installer-smoke:",
+		markers:  []string{"name: Windows Core"},
+	},
+	{
+		name:     "Installer Smoke (ubuntu-latest)",
+		jobStart: "  installer-smoke:",
+		jobEnd:   "  goreleaser-snapshot:",
+		markers:  []string{"name: Installer Smoke (${{ matrix.os }})", "os: [ubuntu-latest, windows-latest]"},
+	},
+	{
+		name:     "Installer Smoke (windows-latest)",
+		jobStart: "  installer-smoke:",
+		jobEnd:   "  goreleaser-snapshot:",
+		markers:  []string{"name: Installer Smoke (${{ matrix.os }})", "os: [ubuntu-latest, windows-latest]"},
+	},
+	{
+		name:     "GoReleaser Snapshot",
+		jobStart: "  goreleaser-snapshot:",
+		jobEnd:   "",
+		markers:  []string{"name: GoReleaser Snapshot"},
+	},
+}
+
+func TestCIConcurrencyKeepsMainPushRuns(t *testing.T) {
+	t.Parallel()
+
+	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
+	concurrency := workflowBetween(t, workflow, "concurrency:\n", "\njobs:")
+	for _, want := range []string{
+		"group: ${{ github.workflow }}-${{ github.event_name == 'pull_request' && format('pr-{0}', github.event.pull_request.number) || github.run_id }}",
+		"cancel-in-progress: ${{ github.event_name == 'pull_request' }}",
+	} {
+		if !strings.Contains(concurrency, want) {
+			t.Fatalf("CI concurrency missing %q", want)
+		}
+	}
+}
+
+func TestMainProtectionDocumentationMatchesWorkflow(t *testing.T) {
+	t.Parallel()
+
+	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
+	docs := readNormalizedFile(t, "docs/execution-seams.md")
+	protection := workflowBetween(t, docs, "### Main Branch Protection\n", "\n## Still Git/PR Coupled")
+
+	for _, want := range []string{
+		"`required_status_checks.strict: true`",
+		"`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`",
+		"`Browser Visual`",
+	} {
+		if !strings.Contains(protection, want) {
+			t.Fatalf("main branch protection docs missing %q", want)
+		}
+	}
+
+	for _, check := range requiredMainStatusChecks {
+		if !strings.Contains(protection, "- `"+check.name+"`") {
+			t.Fatalf("main branch protection docs missing required check %q", check.name)
+		}
+
+		job := workflowBetween(t, workflow, check.jobStart, check.jobEnd)
+		for _, marker := range check.markers {
+			if !strings.Contains(job, marker) {
+				t.Fatalf("workflow job for required check %q missing %q", check.name, marker)
+			}
+		}
+	}
+}
+
 func TestInstallerSmokeUsesAuthenticatedReleaseVersion(t *testing.T) {
 	t.Parallel()
 
-	raw, err := os.ReadFile(".github/workflows/ci.yml")
-	if err != nil {
-		t.Fatalf("ReadFile(.github/workflows/ci.yml) error = %v", err)
-	}
-	workflow := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
 	job := workflowBetween(t, workflow, "  installer-smoke:", "\n  goreleaser-snapshot:")
 
 	for _, want := range []string{
@@ -102,6 +214,16 @@ func TestKanbanBrowserDragDropRunsInVisualGate(t *testing.T) {
 			t.Fatalf("browser visual spec missing %q", want)
 		}
 	}
+}
+
+func readNormalizedFile(t *testing.T, path string) string {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(%s) error = %v", path, err)
+	}
+	return strings.ReplaceAll(string(raw), "\r\n", "\n")
 }
 
 func workflowBetween(t *testing.T, content string, startMarker string, endMarker string) string {

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -61,6 +61,35 @@ The execution edge still carries these code/git/PR assumptions.
   release packaging inputs change, preserving release-package coverage without
   charging docs-only and routine code PRs the full snapshot cost.
 
+### Main Branch Protection
+
+The `main` branch must require pull requests and up-to-date validation before
+merge. The expected GitHub branch protection or ruleset setting is
+`required_status_checks.strict: true`; if the repository switches to merge
+queue, the queue must provide equivalent current-base validation before merge.
+
+Required status checks must include every meaningful CI job directly. Do not
+depend on a downstream skipped job to protect an upstream gate. The required
+checks are:
+
+- `Lint`
+- `Verify (ubuntu-latest)`
+- `Verify (macos-latest)`
+- `Verify (windows-latest)`
+- `Test Coverage`
+- `Browser Visual`
+- `Windows Core`
+- `Installer Smoke (ubuntu-latest)`
+- `Installer Smoke (windows-latest)`
+- `GoReleaser Snapshot`
+
+The CI workflow keeps pull request runs cancellable by newer pushes to the same
+PR through `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
+Push runs, including consecutive pushes to `main`, use a unique run group and
+must not be cancelled by later pushes. The workflow test in
+`ci_workflow_test.go` checks this section against `.github/workflows/ci.yml` so
+job-name and required-check drift fails in local validation.
+
 ## Still Git/PR Coupled
 
 ### Workspace

--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -35,9 +35,7 @@ func TestStartIsolatedRuntimeAutoPromotesFixtureAndStopsOnCancel(t *testing.T) {
 		t.Fatalf("isolated runtime banner missing isolation details:\n%s", banner)
 	}
 	waitForDashboard(t, url+"/health", done)
-	postRuntimeRefresh(t, url, done)
-
-	body := waitForDashboardCondition(t, url+"/api/v1/state", done, "mock issue promoted to Merging", func(body string) bool {
+	body := waitForDashboardConditionWithRefresh(t, url, url+"/api/v1/state", done, "mock issue promoted to Merging", func(body string) bool {
 		return boardStateCountFromBody(t, body, "Merging") == 1
 	})
 	if !strings.Contains(body, `"status":"running"`) {
@@ -339,6 +337,38 @@ func postRuntimeRefresh(t *testing.T, url string, done <-chan error) {
 		time.Sleep(10 * time.Millisecond)
 	}
 	t.Fatalf("timed out posting runtime refresh to %s", url)
+}
+
+func waitForDashboardConditionWithRefresh(
+	t *testing.T,
+	refreshURL string,
+	conditionURL string,
+	done <-chan error,
+	name string,
+	ok func(string) bool,
+) string {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 45*time.Second)
+	defer cancel()
+
+	lastBody := ""
+	nextRefresh := time.Time{}
+	for ctx.Err() == nil {
+		now := time.Now()
+		if !now.Before(nextRefresh) {
+			postRuntimeRefresh(t, refreshURL, done)
+			nextRefresh = now.Add(time.Second)
+		}
+		body := waitForDashboard(t, conditionURL, done)
+		lastBody = body
+		if ok(body) {
+			return body
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for dashboard condition %q at %s; last body:\n%s", name, conditionURL, lastBody)
+	return ""
 }
 
 func postRuntimeKanbanForm(t *testing.T, rawURL string, done <-chan error, form url.Values) string {


### PR DESCRIPTION
## Summary

- Make CI cancellation PR-only so consecutive `main` push runs are not cancelled.
- Document strict `main` branch protection and the exact required status checks, including `Browser Visual`.
- Add workflow tests that fail when required check names or the documented protection contract drift.
- Stabilize the dev-runtime refresh e2e wait that blocked the GoReleaser snapshot on the rebased head.

Fixes #604

## Test Plan

- [x] `go test -run TestStartIsolatedRuntimeAutoPromotesFixtureAndStopsOnCancel -count=10 -timeout=3m ./internal/cli`
- [x] `go test ./internal/cli`
- [x] `make check`
- [x] REST check-runs for `3412fe4790f1b4912f6e0edcfeb66dede0817efc`: all checks passed, including `Browser Visual` and `GoReleaser Snapshot`.