### PR TITLE
test(cli): move drag/drop e2e to visual gate

### DIFF
--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -53,6 +53,57 @@ func TestInstallerSmokeUsesAuthenticatedReleaseVersion(t *testing.T) {
 	}
 }
 
+func TestKanbanBrowserDragDropRunsInVisualGate(t *testing.T) {
+	t.Parallel()
+
+	browserTestRaw, err := os.ReadFile("internal/cli/dev_runtime_browser_e2e_test.go")
+	if err != nil {
+		t.Fatalf("ReadFile(internal/cli/dev_runtime_browser_e2e_test.go) error = %v", err)
+	}
+	browserTest := strings.ReplaceAll(string(browserTestRaw), "\r\n", "\n")
+	if !strings.HasPrefix(browserTest, "//go:build browser_e2e\n\n") {
+		t.Fatal("Kanban browser drag/drop Go CDP test must be behind the browser_e2e build tag")
+	}
+	if !strings.Contains(browserTest, "CI exercises Kanban drag/drop in the Playwright browser visual gate") {
+		t.Fatal("Kanban browser drag/drop Go CDP test must document why CI uses the visual gate")
+	}
+
+	workflowRaw, err := os.ReadFile(".github/workflows/ci.yml")
+	if err != nil {
+		t.Fatalf("ReadFile(.github/workflows/ci.yml) error = %v", err)
+	}
+	workflow := strings.ReplaceAll(string(workflowRaw), "\r\n", "\n")
+	visualJob := workflowBetween(t, workflow, "  browser-visual:", "\n  windows-core:")
+	for _, want := range []string{
+		"internal/cli/dev_runtime*.go",
+		"name: Upload browser visual evidence",
+		"tmp/playwright-evidence",
+		"name: Upload browser visual failure artifacts",
+		"tmp/playwright-report",
+		"tmp/playwright-results",
+	} {
+		if !strings.Contains(visualJob, want) {
+			t.Fatalf("browser visual job missing %q", want)
+		}
+	}
+
+	visualSpecRaw, err := os.ReadFile("tests/visual/layout.spec.js")
+	if err != nil {
+		t.Fatalf("ReadFile(tests/visual/layout.spec.js) error = %v", err)
+	}
+	visualSpec := strings.ReplaceAll(string(visualSpecRaw), "\r\n", "\n")
+	for _, want := range []string{
+		`test("direct Kanban blocked drag stays client-side"`,
+		`Move blocked by transition policy.`,
+		`expect(moveRequests).toHaveLength(0)`,
+		`#kanban-action-dialog`,
+	} {
+		if !strings.Contains(visualSpec, want) {
+			t.Fatalf("browser visual spec missing %q", want)
+		}
+	}
+}
+
 func workflowBetween(t *testing.T, content string, startMarker string, endMarker string) string {
 	t.Helper()
 

--- a/internal/cli/dev_runtime_browser_e2e_test.go
+++ b/internal/cli/dev_runtime_browser_e2e_test.go
@@ -1,3 +1,5 @@
+//go:build browser_e2e
+
 package cli
 
 import (
@@ -26,6 +28,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/devruntime"
 )
 
+// TestStartKanbanDemoBrowserDragDrop is a manual diagnostic for the Go CDP
+// harness. CI exercises Kanban drag/drop in the Playwright browser visual gate
+// because browser startup and drag/drop timing need browser-native artifacts
+// instead of ordinary go test coverage failures.
 func TestStartKanbanDemoBrowserDragDrop(t *testing.T) {
 	chromePath := chromeExecutable()
 	if chromePath == "" {

--- a/tests/visual/detent-runtime.js
+++ b/tests/visual/detent-runtime.js
@@ -14,6 +14,10 @@ async function startDetentRuntime(name, args) {
   }
 
   const home = fs.mkdtempSync(path.join(os.tmpdir(), `detent-${name}-`));
+  const evidenceDir = path.join(process.cwd(), "tmp", "playwright-evidence", name);
+  fs.mkdirSync(evidenceDir, { recursive: true });
+  const logPath = path.join(evidenceDir, "runtime.log");
+  fs.writeFileSync(logPath, "");
   const child = spawn(binary, ["dev-runtime", "--home", home, "--host", "127.0.0.1", "--port", "0", ...args], {
     cwd: process.cwd(),
     env: { ...process.env, NO_COLOR: "1" },
@@ -27,7 +31,9 @@ async function startDetentRuntime(name, args) {
     }, 30_000);
 
     function handleData(chunk) {
-      output += chunk.toString();
+      const text = chunk.toString();
+      output += text;
+      fs.appendFileSync(logPath, text);
       const match = output.match(/Dashboard:\s+(http:\/\/[^\s]+)/);
       if (match) {
         clearTimeout(timeout);
@@ -50,6 +56,7 @@ async function startDetentRuntime(name, args) {
   return {
     url,
     home,
+    logPath,
     output() {
       return output;
     },

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -31,6 +31,13 @@ test.afterAll(async () => {
   await Promise.all([screenshotsRuntime?.stop(), kanbanRuntime?.stop()]);
 });
 
+test.afterEach(async ({ page }, testInfo) => {
+  if (testInfo.status === testInfo.expectedStatus) {
+    return;
+  }
+  await attachFailureEvidence(page, testInfo);
+});
+
 test("screenshots manifest includes visual gate scenarios", async ({ request }) => {
   const response = await request.get(`${screenshotsRuntime.url}/api/v1/demo/scenarios`);
   expect(response.ok()).toBeTruthy();
@@ -234,6 +241,37 @@ test("sidebar active state survives Kanban refreshes", async ({ page }, testInfo
   });
 });
 
+test("direct Kanban blocked drag stays client-side", async ({ page }, testInfo) => {
+  await page.setViewportSize(desktopViewport);
+  await page.goto(`${kanbanRuntime.url}/projects/demo-project/kanban`, { waitUntil: "domcontentloaded" });
+  await page.request.post(`${kanbanRuntime.url}/api/v1/refresh`);
+  await expect(page.locator("#project-kanban")).toBeVisible();
+  await expect(page.locator("[data-kanban-issue-id='kanban-demo-backlog']")).toBeVisible();
+  await page.waitForFunction(() => Boolean(window.htmx && window.__detentKanbanDragHandlersRegistered));
+  await page.locator("[data-kanban-drop-state='Merging']").evaluate((lane) => {
+    lane.dataset.projectKanbanLaneVisible = "true";
+  });
+  await expect(page.locator("[data-kanban-drop-state='Merging']")).toBeVisible();
+
+  const moveRequests = [];
+  page.on("request", (request) => {
+    const url = new URL(request.url());
+    if (url.pathname === "/api/v1/kanban/move" && request.method() === "POST") {
+      moveRequests.push(request.url());
+    }
+  });
+
+  const accepted = await dragKanbanCardToLane(page, "kanban-demo-backlog", "Merging");
+  expect(accepted).toBe(false);
+  await expect(page.locator("#kanban-feedback")).toContainText("Move blocked by transition policy.");
+  expect(moveRequests).toHaveLength(0);
+  await expect(page.locator("[data-kanban-drop-state='Backlog'] [data-kanban-issue-id='kanban-demo-backlog']")).toHaveCount(1);
+  await expect(page.locator("[data-kanban-drop-state='Merging'] [data-kanban-issue-id='kanban-demo-backlog']")).toHaveCount(0);
+  await captureClipAndAttach(page, "#project-kanban", "project-kanban-drag-blocked-client-side.png", testInfo, {
+    maxHeight: 430,
+  });
+});
+
 test("direct Kanban drag success does not shift board layout", async ({ page }, testInfo) => {
   await page.setViewportSize(desktopViewport);
   await page.goto(`${kanbanRuntime.url}/projects/demo-project/kanban`, { waitUntil: "domcontentloaded" });
@@ -266,6 +304,12 @@ test("direct Kanban drag success does not shift board layout", async ({ page }, 
   await captureClipAndAttach(page, "#project-kanban", "project-kanban-drag-success-no-flash.png", testInfo, {
     maxHeight: 430,
   });
+  await expect(page.locator("#kanban-action-dialog")).not.toHaveAttribute("data-tui-dialog-open", "true");
+  await expect(page.locator("#kanban-dialog-content")).toHaveText("");
+
+  await page.locator("[data-kanban-card][data-kanban-issue-id='kanban-demo-backlog'] [aria-label^='Move ']").click();
+  await expect(page.locator("#kanban-action-dialog")).toHaveAttribute("data-tui-dialog-open", "true");
+  await expect(page.locator("#kanban-dialog-content")).toContainText("Move card");
 });
 
 test("project configuration page preserves project color layout", async ({ page }, testInfo) => {
@@ -318,6 +362,32 @@ async function compareAndAttach(locator, name, testInfo) {
   const evidencePath = path.join(evidenceDir, name);
   await locator.screenshot({ path: evidencePath, animations: "disabled", caret: "hide" });
   await testInfo.attach(name, { path: evidencePath, contentType: "image/png" });
+}
+
+async function attachFailureEvidence(page, testInfo) {
+  const evidenceDir = path.join(process.cwd(), "tmp", "playwright-evidence", testInfo.project.name);
+  fs.mkdirSync(evidenceDir, { recursive: true });
+  const baseName = artifactName(testInfo.title);
+  const htmlPath = path.join(evidenceDir, `${baseName}.html`);
+  const screenshotPath = path.join(evidenceDir, `${baseName}.png`);
+
+  try {
+    fs.writeFileSync(htmlPath, await page.content());
+    await testInfo.attach(`${baseName}.html`, { path: htmlPath, contentType: "text/html" });
+  } catch (error) {
+    await testInfo.attach(`${baseName}-html-error.txt`, { body: String(error), contentType: "text/plain" });
+  }
+
+  try {
+    await page.screenshot({ path: screenshotPath, animations: "disabled", caret: "hide" });
+    await testInfo.attach(`${baseName}.png`, { path: screenshotPath, contentType: "image/png" });
+  } catch (error) {
+    await testInfo.attach(`${baseName}-screenshot-error.txt`, { body: String(error), contentType: "text/plain" });
+  }
+}
+
+function artifactName(title) {
+  return title.toLowerCase().replace(/[^a-z0-9]+/g, "-").replace(/^-|-$/g, "") || "failure";
 }
 
 async function compareClipAndAttach(page, selector, name, testInfo, options) {


### PR DESCRIPTION
## Summary
- Move the custom Go CDP Kanban drag/drop browser test behind an opt-in `browser_e2e` build tag so default Go test and coverage jobs do not depend on Chrome startup timing.
- Add Playwright visual-gate coverage for blocked drag/drop, direct-move dialog behavior, and runtime/page failure evidence.
- Add a regression check that keeps this coverage in the browser visual gate and verifies CI artifact upload paths.

Fixes #605

## Test Plan
- `go test . -run TestKanbanBrowserDragDropRunsInVisualGate -count=1 -v`
- `go test ./internal/cli -run TestStartKanbanDemoBrowserDragDrop -count=1 -v`
- `make build`
- `npx playwright test tests/visual/layout.spec.js -g "direct Kanban"`
- `go test . -count=1`
- `go test ./internal/cli ./... -run 'TestKanbanBrowserDragDropRunsInVisualGate|TestStartKanbanDemoBrowserDragDrop' -count=1`
- `go test -tags browser_e2e ./internal/cli -run TestStartKanbanDemoBrowserDragDrop -count=1 -v`
- `npm run test:visual`
- `make check`