### PR TITLE
fix(tracker): enforce exclusive status labels

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -1866,7 +1866,7 @@ func (c *Connector) attachPullRequests(ctx context.Context, issues []connector.I
 		if owner, name, ok := splitRepositoryName(issue.PRRepository); ok {
 			linkedPullRequestRepo = pullRequestRepo{Owner: owner, Name: name}
 		}
-		if normalizeStateName(issue.State) == normalizeStateName("Blocked") && pullRequestNumber <= 0 {
+		if normalizeStateName(issue.State) == normalizeStateName("Blocked") && pullRequestNumber <= 0 && !statusLabelConflictIssue(issue) {
 			branchPrefix = ""
 		}
 		if branchPrefix == "" && pullRequestNumber <= 0 {
@@ -2478,11 +2478,7 @@ func (c *Connector) normalizeIssueNode(ctx context.Context, issue githubIssueNod
 		return connector.Issue{}, false, nil
 	}
 	if c.usesLabelStatus() {
-		statusName := c.labelStatusFromLabels(issue.Labels)
-		if statusName == "" {
-			statusName = c.githubIssueStateToDetentState(issue.State)
-		}
-		return c.buildIssue(issue, statusName, "", nil, map[string]string{c.statusField: statusName}), true, nil
+		return c.buildLabelIssue(issue, c.githubIssueStateToDetentState(issue.State)), true, nil
 	}
 	stateName, priorityName, statusUpdatedAt, fields, ok, err := c.resolveIssueProjectFields(ctx, issue.ID, issue.ProjectItems)
 	if err != nil {
@@ -2647,9 +2643,12 @@ func (c *Connector) appendLinkedChildIssues(
 
 func (c *Connector) linkedChildIssueState(child linkedIssue) string {
 	if c.usesLabelStatus() {
-		statusName := c.labelStatusFromLabels(child.Labels)
-		if statusName != "" {
-			return c.githubToDetentState(statusName)
+		resolution := c.labelStatusResolutionFromLabels(child.Labels)
+		if resolution.conflicted() {
+			return labelStatusConflictState
+		}
+		if resolution.Status != "" {
+			return c.githubToDetentState(resolution.Status)
 		}
 		return c.githubIssueStateToDetentState(child.State)
 	}

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -412,6 +412,14 @@ func (c githubReadinessChecker) labelIssuesReadCheck(ctx context.Context, states
 			Hint:   "Grant Issues repository read permission and confirm status labels exist.",
 		}
 	}
+	if conflicts := c.connector.labelStatusConflictSummaries(issues); len(conflicts) > 0 {
+		return ReadinessCheck{
+			Name:   "GitHub status label issue read",
+			Status: ReadinessWarn,
+			Detail: fmt.Sprintf("read issues for %d configured label state(s); sampled %d issue(s); status label conflicts: %s", len(states), len(issues), strings.Join(conflicts, "; ")),
+			Hint:   "Remove all but one configured status label from each conflicted issue, leaving only the label for the intended workflow state, then rerun detent doctor.",
+		}
+	}
 	return ReadinessCheck{
 		Name:   "GitHub status label issue read",
 		Status: ReadinessOK,

--- a/internal/connector/github/readiness_test.go
+++ b/internal/connector/github/readiness_test.go
@@ -174,6 +174,42 @@ func TestReadinessIssueFieldStatusWriteReappliesProbeValue(t *testing.T) {
 	}
 }
 
+func TestReadinessLabelIssueReadReportsStatusLabelConflicts(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Atodo&page=1&per_page=100&state=all",
+			body:   `[{"node_id":"I_604","number":604,"title":"Todo race","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/604","assignees":[],"labels":[{"name":"detent:todo"},{"name":"detent:in-progress"},{"name":"bug"}]}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Ain-progress&page=1&per_page=100&state=all",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo", "In Progress"},
+	})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.labelIssuesReadCheck(context.Background(), []string{"Todo", "In Progress"})
+	if got.Status != ReadinessWarn {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, ReadinessWarn, got)
+	}
+	for _, want := range []string{"#604", "detent:todo", "detent:in-progress"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+		}
+	}
+	if !strings.Contains(got.Hint, "Remove all but one") {
+		t.Fatalf("Hint = %q, want remediation guidance", got.Hint)
+	}
+}
+
 func TestReadinessIssueCommentReportsMissingAccess(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -5,13 +5,26 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 )
 
-const repositoryIssuesPageSize = 100
+const (
+	repositoryIssuesPageSize = 100
+	labelStatusConflictState = "Blocked"
+)
+
+type labelStatusResolution struct {
+	Status         string
+	ConflictLabels []string
+}
+
+func (r labelStatusResolution) conflicted() bool {
+	return len(r.ConflictLabels) > 1
+}
 
 func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []string, limit int) ([]connector.Issue, error) {
 	if !validPullRequestRepo(c.repository) {
@@ -55,9 +68,7 @@ func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []s
 				}
 				seen[issue.ID] = struct{}{}
 				c.cacheIssueRef(issue)
-				issues = append(issues, c.buildIssue(issue, externalState, "", nil, map[string]string{
-					c.statusField: externalState,
-				}))
+				issues = append(issues, c.buildLabelIssue(issue, externalState))
 				if limit > 0 && len(issues) >= limit {
 					resolveBlockedByProjectState(issues)
 					return issues, nil
@@ -81,11 +92,7 @@ func (c *Connector) fetchLabelIssueByRef(ctx context.Context, ref issueRef) (con
 		return connector.Issue{}, false, nil
 	}
 	c.cacheIssueRef(issue)
-	statusName := c.labelStatusFromLabels(issue.Labels)
-	if statusName == "" {
-		statusName = c.githubIssueStateToDetentState(issue.State)
-	}
-	return c.buildIssue(issue, statusName, "", nil, map[string]string{c.statusField: statusName}), true, nil
+	return c.buildLabelIssue(issue, c.githubIssueStateToDetentState(issue.State)), true, nil
 }
 
 func (c *Connector) updateIssueStatusLabel(ctx context.Context, ref issueRef, issue githubIssueNode, targetState string) error {
@@ -94,27 +101,30 @@ func (c *Connector) updateIssueStatusLabel(ctx context.Context, ref issueRef, is
 		return ErrStatusUpdateFailed
 	}
 
-	currentLabels := labelNames(issue.Labels)
-	for _, labelName := range currentLabels {
-		if !c.isStatusLabel(labelName) || strings.EqualFold(labelName, targetLabel) {
+	nextLabels := make([]string, 0, len(issue.Labels.Nodes)+1)
+	seen := map[string]struct{}{}
+	for _, label := range issue.Labels.Nodes {
+		labelName := strings.TrimSpace(label.Name)
+		if labelName == "" || c.isStatusLabel(labelName) {
 			continue
 		}
-		var response []label
-		if err := c.client.REST(ctx, http.MethodDelete, restIssueLabelPath(ref, labelName), nil, &response); err != nil {
-			return fmt.Errorf("remove github status label: %w", err)
+		key := normalizeLabelName(labelName)
+		if _, ok := seen[key]; ok {
+			continue
 		}
+		seen[key] = struct{}{}
+		nextLabels = append(nextLabels, labelName)
 	}
-	if stringSliceContainsFold(currentLabels, targetLabel) {
-		return nil
-	}
+	nextLabels = append(nextLabels, targetLabel)
 
 	var response []label
-	if err := c.client.REST(ctx, http.MethodPost, restIssueLabelsPath(ref), map[string]any{
-		"labels": []string{targetLabel},
+	if err := c.client.REST(ctx, http.MethodPut, restIssueLabelsPath(ref), map[string]any{
+		"labels": nextLabels,
 	}, &response); err != nil {
-		return fmt.Errorf("add github status label: %w", err)
+		return fmt.Errorf("replace github status labels: %w", err)
 	}
-	if len(response) == 0 {
+	resolution := c.labelStatusResolutionFromLabels(nodeConnection[label]{Nodes: response})
+	if len(response) == 0 || resolution.conflicted() || !stringSliceContainsFold(labelNames(nodeConnection[label]{Nodes: response}), targetLabel) {
 		return ErrStatusUpdateFailed
 	}
 	return nil
@@ -199,13 +209,92 @@ func (c *Connector) statusLabelStates(stateNames []string) map[string]string {
 }
 
 func (c *Connector) labelStatusFromLabels(labels nodeConnection[label]) string {
+	return c.labelStatusResolutionFromLabels(labels).Status
+}
+
+func (c *Connector) labelStatusResolutionFromLabels(labels nodeConnection[label]) labelStatusResolution {
+	return c.labelStatusResolutionFromNames(labelNames(labels))
+}
+
+func (c *Connector) labelStatusResolutionFromNames(names []string) labelStatusResolution {
 	statesByLabel := c.statusLabelStates(c.configuredStatusStates())
-	for _, labelName := range labelNames(labels) {
-		if stateName, ok := statesByLabel[normalizeLabelName(labelName)]; ok {
-			return stateName
+	seen := map[string]struct{}{}
+	matches := []string{}
+	statusName := ""
+	for _, labelName := range names {
+		key := normalizeLabelName(labelName)
+		if key == "" {
+			continue
+		}
+		stateName, ok := statesByLabel[key]
+		if !ok {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		matches = append(matches, key)
+		if statusName == "" {
+			statusName = stateName
 		}
 	}
-	return ""
+	if len(matches) <= 1 {
+		return labelStatusResolution{Status: statusName}
+	}
+	sort.Strings(matches)
+	return labelStatusResolution{
+		Status:         statusName,
+		ConflictLabels: matches,
+	}
+}
+
+func (c *Connector) buildLabelIssue(issue githubIssueNode, fallbackStatus string) connector.Issue {
+	resolution := c.labelStatusResolutionFromLabels(issue.Labels)
+	if resolution.conflicted() {
+		return c.buildStatusLabelConflictIssue(issue, resolution.ConflictLabels)
+	}
+	statusName := strings.TrimSpace(resolution.Status)
+	if statusName == "" {
+		statusName = strings.TrimSpace(fallbackStatus)
+	}
+	return c.buildIssue(issue, statusName, "", nil, map[string]string{c.statusField: statusName})
+}
+
+func (c *Connector) buildStatusLabelConflictIssue(issue githubIssueNode, labels []string) connector.Issue {
+	out := c.buildIssue(issue, labelStatusConflictState, "", nil, map[string]string{c.statusField: labelStatusConflictState})
+	out.BlockerReason = labelStatusConflictReason(labels)
+	return out
+}
+
+func labelStatusConflictReason(labels []string) string {
+	return "multiple configured Detent status labels: " + strings.Join(labels, ", ") + "; remove all but one status label"
+}
+
+func statusLabelConflictIssue(issue connector.Issue) bool {
+	return strings.Contains(issue.BlockerReason, "multiple configured Detent status labels")
+}
+
+func (c *Connector) labelStatusConflictSummaries(issues []connector.Issue) []string {
+	summaries := []string{}
+	for _, issue := range issues {
+		resolution := c.labelStatusResolutionFromNames(issue.Labels)
+		if !resolution.conflicted() {
+			continue
+		}
+		summaries = append(summaries, labelStatusConflictReference(issue)+" ("+strings.Join(resolution.ConflictLabels, ", ")+")")
+	}
+	return summaries
+}
+
+func labelStatusConflictReference(issue connector.Issue) string {
+	if _, number, ok := strings.Cut(strings.TrimSpace(issue.Identifier), "#"); ok && strings.TrimSpace(number) != "" {
+		return "#" + strings.TrimSpace(number)
+	}
+	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" {
+		return identifier
+	}
+	return strings.TrimSpace(issue.ID)
 }
 
 func (c *Connector) configuredStatusStates() []string {
@@ -301,8 +390,4 @@ func restRepositoryIssuesByLabelPath(repo pullRequestRepo, labelName string, pag
 
 func restIssueLabelsPath(ref issueRef) string {
 	return restIssuePath(ref) + "/labels"
-}
-
-func restIssueLabelPath(ref issueRef, labelName string) string {
-	return restIssueLabelsPath(ref) + "/" + url.PathEscape(labelName)
 }

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -101,6 +101,15 @@ func (c *Connector) updateIssueStatusLabel(ctx context.Context, ref issueRef, is
 		return ErrStatusUpdateFailed
 	}
 
+	latest, err := c.fetchRESTIssue(ctx, ref)
+	if err != nil {
+		return fmt.Errorf("fetch latest github status labels: %w", err)
+	}
+	if strings.TrimSpace(latest.ID) == "" {
+		return ErrStatusUpdateFailed
+	}
+	issue = latest
+
 	nextLabels := make([]string, 0, len(issue.Labels.Nodes)+1)
 	seen := map[string]struct{}{}
 	for _, label := range issue.Labels.Nodes {

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -192,14 +192,9 @@ func TestConnectorUpdateIssueStateReplacesStatusLabels(t *testing.T) {
 			body:   `{"node_id":"I_485","number":485,"title":"Installer packages","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:todo"},{"name":"bug"}]}`,
 		},
 		{
-			method: http.MethodDelete,
-			path:   "/repos/digitaldrywood/detent/issues/485/labels/detent:todo",
-			body:   `[{"name":"bug"}]`,
-		},
-		{
-			method: http.MethodPost,
+			method: http.MethodPut,
 			path:   "/repos/digitaldrywood/detent/issues/485/labels",
-			body:   `[{"name":"detent:in-progress"}]`,
+			body:   `[{"name":"bug"},{"name":"detent:in-progress"}]`,
 		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
@@ -213,13 +208,111 @@ func TestConnectorUpdateIssueStateReplacesStatusLabels(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 4 {
-		t.Fatalf("request count = %d, want 4", len(requests))
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
 	}
-	body := requests[3]["body"].(map[string]any)
+	body := requests[2]["body"].(map[string]any)
 	labels := body["labels"].([]any)
-	if !reflect.DeepEqual(labels, []any{"detent:in-progress"}) {
-		t.Fatalf("labels body = %#v, want detent:in-progress", labels)
+	if !reflect.DeepEqual(labels, []any{"bug", "detent:in-progress"}) {
+		t.Fatalf("labels body = %#v, want bug plus detent:in-progress", labels)
+	}
+}
+
+func TestConnectorUpdateIssueStateReplacesStaleStatusLabelRace(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"nodes":[{"__typename":"Issue","id":"I_606","number":606,"repository":{"nameWithOwner":"digitaldrywood/detent"}}]}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/606",
+			body:   `{"node_id":"I_606","number":606,"title":"Race issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/606","assignees":[],"labels":[{"name":"detent:in-progress"},{"name":"detent:todo"},{"name":"bug"}]}`,
+		},
+		{
+			method: http.MethodPut,
+			path:   "/repos/digitaldrywood/detent/issues/606/labels",
+			body:   `[{"name":"bug"},{"name":"detent:in-progress"}]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo", "In Progress"},
+	})
+
+	if err := c.UpdateIssueState(context.Background(), "I_606", "In Progress"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want 3", len(requests))
+	}
+	body := requests[2]["body"].(map[string]any)
+	labels := body["labels"].([]any)
+	if !reflect.DeepEqual(labels, []any{"bug", "detent:in-progress"}) {
+		t.Fatalf("labels body = %#v, want exactly one status label", labels)
+	}
+}
+
+func TestConnectorFetchCandidateIssuesSurfacesStatusLabelConflict(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Atodo&page=1&per_page=100&state=all",
+			body:   `[{"node_id":"I_606","number":606,"title":"Race issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/606","assignees":[],"labels":[{"name":"detent:todo"},{"name":"detent:in-progress"},{"name":"bug"}]}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Ain-progress&page=1&per_page=100&state=all",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[{"number":609,"html_url":"https://github.com/digitaldrywood/detent/pull/609","state":"open","head":{"ref":"detent/detent-digitaldrywood_detent_606-97bf7548e359","sha":"sha-609"}}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-609/check-runs?per_page=100",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-609/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/609/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo", "In Progress"},
+	})
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
+	}
+	if got[0].State != "Blocked" {
+		t.Fatalf("State = %q, want Blocked conflict instead of Todo", got[0].State)
+	}
+	if !strings.Contains(got[0].BlockerReason, "multiple configured Detent status labels") {
+		t.Fatalf("BlockerReason = %q, want explicit status-label conflict", got[0].BlockerReason)
+	}
+	if got[0].PRNumber == nil || *got[0].PRNumber != 609 {
+		t.Fatalf("PRNumber = %v, want linked PR 609", got[0].PRNumber)
 	}
 }
 

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -192,6 +192,11 @@ func TestConnectorUpdateIssueStateReplacesStatusLabels(t *testing.T) {
 			body:   `{"node_id":"I_485","number":485,"title":"Installer packages","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:todo"},{"name":"bug"}]}`,
 		},
 		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/485",
+			body:   `{"node_id":"I_485","number":485,"title":"Installer packages","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:todo"},{"name":"bug"}]}`,
+		},
+		{
 			method: http.MethodPut,
 			path:   "/repos/digitaldrywood/detent/issues/485/labels",
 			body:   `[{"name":"bug"},{"name":"detent:in-progress"}]`,
@@ -208,10 +213,10 @@ func TestConnectorUpdateIssueStateReplacesStatusLabels(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 3 {
-		t.Fatalf("request count = %d, want 3", len(requests))
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want 4", len(requests))
 	}
-	body := requests[2]["body"].(map[string]any)
+	body := requests[3]["body"].(map[string]any)
 	labels := body["labels"].([]any)
 	if !reflect.DeepEqual(labels, []any{"bug", "detent:in-progress"}) {
 		t.Fatalf("labels body = %#v, want bug plus detent:in-progress", labels)
@@ -231,9 +236,14 @@ func TestConnectorUpdateIssueStateReplacesStaleStatusLabelRace(t *testing.T) {
 			body:   `{"node_id":"I_606","number":606,"title":"Race issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/606","assignees":[],"labels":[{"name":"detent:in-progress"},{"name":"detent:todo"},{"name":"bug"}]}`,
 		},
 		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/606",
+			body:   `{"node_id":"I_606","number":606,"title":"Race issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/606","assignees":[],"labels":[{"name":"detent:in-progress"},{"name":"detent:todo"},{"name":"bug"},{"name":"stage:s6"}]}`,
+		},
+		{
 			method: http.MethodPut,
 			path:   "/repos/digitaldrywood/detent/issues/606/labels",
-			body:   `[{"name":"bug"},{"name":"detent:in-progress"}]`,
+			body:   `[{"name":"bug"},{"name":"stage:s6"},{"name":"detent:in-progress"}]`,
 		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
@@ -247,13 +257,13 @@ func TestConnectorUpdateIssueStateReplacesStaleStatusLabelRace(t *testing.T) {
 	}
 
 	requests := server.requests()
-	if len(requests) != 3 {
-		t.Fatalf("request count = %d, want 3", len(requests))
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want 4", len(requests))
 	}
-	body := requests[2]["body"].(map[string]any)
+	body := requests[3]["body"].(map[string]any)
 	labels := body["labels"].([]any)
-	if !reflect.DeepEqual(labels, []any{"bug", "detent:in-progress"}) {
-		t.Fatalf("labels body = %#v, want exactly one status label", labels)
+	if !reflect.DeepEqual(labels, []any{"bug", "stage:s6", "detent:in-progress"}) {
+		t.Fatalf("labels body = %#v, want latest non-status labels and exactly one status label", labels)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -992,16 +992,8 @@ func (o *Orchestrator) trackBlockedStatusIssues(state *State, issues []connector
 		if issue.ID == "" {
 			continue
 		}
-		recovery := EvaluateBlockedRecovery(issue)
 		seenBlocked[issue.ID] = struct{}{}
-		state.Blocked[issue.ID] = Blocked{
-			Issue:          cloneIssue(issue),
-			Reason:         blockedStatusReason(issue),
-			RecoveryReason: string(recovery.Reason),
-			RecoveryTarget: recovery.TargetState,
-			BlockedAt:      now,
-			Source:         BlockedSourceProjectStatus,
-		}
+		o.setBlockedStatusIssue(state, issue, now)
 	}
 
 	for issueID, blocked := range state.Blocked {
@@ -1011,6 +1003,27 @@ func (o *Orchestrator) trackBlockedStatusIssues(state *State, issues []connector
 		if _, ok := seenBlocked[issueID]; !ok {
 			delete(state.Blocked, issueID)
 		}
+	}
+}
+
+func (o *Orchestrator) upsertBlockedStatusIssues(state *State, issues []connector.Issue, now time.Time) {
+	for _, issue := range issues {
+		if issue.ID == "" {
+			continue
+		}
+		o.setBlockedStatusIssue(state, issue, now)
+	}
+}
+
+func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue, now time.Time) {
+	recovery := EvaluateBlockedRecovery(issue)
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          cloneIssue(issue),
+		Reason:         blockedStatusReason(issue),
+		RecoveryReason: string(recovery.Reason),
+		RecoveryTarget: recovery.TargetState,
+		BlockedAt:      now,
+		Source:         BlockedSourceProjectStatus,
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1159,6 +1159,54 @@ func TestRunPublishesBoardIssuesFromCandidatesAndObservedStates(t *testing.T) {
 	}
 }
 
+func TestRunTracksStatusLabelConflictCandidateAsBlocked(t *testing.T) {
+	t.Parallel()
+
+	conflict := testIssue("issue-conflict", "digitaldrywood/detent#606", "Blocked")
+	conflict.Labels = []string{"detent:todo", "detent:in-progress", "bug"}
+	conflict.BlockerReason = "multiple configured Detent status labels: detent:in-progress, detent:todo; remove all but one status label"
+	tracker := newFakeConnector(conflict)
+	runner := &staticRunner{}
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           5 * time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Hour,
+		FailureRetryBaseDelay:  time.Hour,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		ObservedStates:         []string{"Backlog", "Human Review", "Blocked"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Blocked[conflict.ID]
+		return ok
+	})
+	if got := runner.calls.Load(); got != 0 {
+		t.Fatalf("runner calls = %d, want 0", got)
+	}
+	blocked := state.Blocked[conflict.ID]
+	if !strings.Contains(blocked.Reason, "multiple configured Detent status labels") {
+		t.Fatalf("blocked reason = %q, want status-label conflict", blocked.Reason)
+	}
+	snapshot := state.Snapshot(time.Now())
+	if snapshot.Counts.Blocked != 1 {
+		t.Fatalf("snapshot blocked count = %d, want 1", snapshot.Counts.Blocked)
+	}
+	counts := telemetry.BoardStateCounts(snapshot)
+	if len(counts) != 1 || counts[0].State != "Blocked" || counts[0].Count != 1 {
+		t.Fatalf("board state counts = %#v, want one Blocked issue", counts)
+	}
+}
+
 func TestRunFetchesCandidatesAndObservedStatesConcurrently(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1166,6 +1166,7 @@ func TestRunTracksStatusLabelConflictCandidateAsBlocked(t *testing.T) {
 	conflict.Labels = []string{"detent:todo", "detent:in-progress", "bug"}
 	conflict.BlockerReason = "multiple configured Detent status labels: detent:in-progress, detent:todo; remove all but one status label"
 	tracker := newFakeConnector(conflict)
+	tracker.fetchByStatesErr = errors.New("status polling failed")
 	runner := &staticRunner{}
 	orch, err := orchestrator.New(orchestrator.Config{
 		PollInterval:           5 * time.Millisecond,
@@ -1512,6 +1513,7 @@ type fakeConnector struct {
 	setFields           []setFieldCall
 	comments            []commentCall
 	stateUpdates        []stateUpdateCall
+	fetchByStatesErr    error
 }
 
 type setFieldCall struct {
@@ -1552,6 +1554,9 @@ func (c *fakeConnector) FetchIssuesByStates(_ context.Context, states []string) 
 
 	c.fetchByStatesCount++
 	c.fetchByStatesLog = append(c.fetchByStatesLog, append([]string(nil), states...))
+	if c.fetchByStatesErr != nil {
+		return nil, c.fetchByStatesErr
+	}
 	wanted := make(map[string]struct{}, len(states))
 	for _, state := range states {
 		wanted[strings.ToLower(strings.TrimSpace(state))] = struct{}{}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -226,13 +226,16 @@ func (o *Orchestrator) dispatchTickIssues(
 	planner := o.dispatchPlanner()
 	planner.pruneBudgetRefusals(state, now)
 	planner.trackBlockedCandidates(state, issues, now)
+	candidateBlockedStatusIssues := issuesInStates(fetched.candidates, []string{blockedStatusState})
 	if fetched.statusOK {
-		currentBlockedStatusIssues := issuesInStates(fetched.candidates, []string{blockedStatusState})
+		currentBlockedStatusIssues := candidateBlockedStatusIssues
 		currentBlockedStatusIssues = mergeIssueSlices(currentBlockedStatusIssues, issuesInStates(fetched.status, []string{blockedStatusState}))
 		if !transitions.blockedRefreshOK {
 			currentBlockedStatusIssues = mergeIssueSlices(currentBlockedStatusIssues, previous.blockedStatusIssues)
 		}
 		o.trackBlockedStatusIssues(state, currentBlockedStatusIssues, now)
+	} else {
+		o.upsertBlockedStatusIssues(state, candidateBlockedStatusIssues, now)
 	}
 	o.dispatchReadyIssues(ctx, state, issues, now)
 }

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -227,7 +227,8 @@ func (o *Orchestrator) dispatchTickIssues(
 	planner.pruneBudgetRefusals(state, now)
 	planner.trackBlockedCandidates(state, issues, now)
 	if fetched.statusOK {
-		currentBlockedStatusIssues := issuesInStates(fetched.status, []string{blockedStatusState})
+		currentBlockedStatusIssues := issuesInStates(fetched.candidates, []string{blockedStatusState})
+		currentBlockedStatusIssues = mergeIssueSlices(currentBlockedStatusIssues, issuesInStates(fetched.status, []string{blockedStatusState}))
 		if !transitions.blockedRefreshOK {
 			currentBlockedStatusIssues = mergeIssueSlices(currentBlockedStatusIssues, previous.blockedStatusIssues)
 		}


### PR DESCRIPTION
## Summary

- Replace label-mode status transitions with one full issue-label replacement so exactly one Detent status label remains.
- Detect multiple configured status labels during label polling and surface them as blocked status-label conflicts with PR context.
- Report status-label conflicts in GitHub readiness/doctor diagnostics with issue numbers and remediation guidance.

Fixes #612

## Test Plan

- [x] go test ./internal/connector/github ./internal/orchestrator
- [x] make check