### PR TITLE
fix(auto-promote): route conflicting PRs to rework

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -91,6 +91,7 @@ type doctorAutoPromoteCandidateDiagnostic struct {
 	PRNumber                     int        `json:"pr_number,omitempty"`
 	PRURL                        string     `json:"pr_url,omitempty"`
 	PRHeadSHA                    string     `json:"pr_head_sha,omitempty"`
+	PRMergeableState             string     `json:"pr_mergeable_state,omitempty"`
 	LatestCodexReviewState       string     `json:"latest_codex_review_state,omitempty"`
 	LatestCodexReviewCommitSHA   string     `json:"latest_codex_review_commit_sha,omitempty"`
 	LatestCodexReviewSubmittedAt *time.Time `json:"latest_codex_review_submitted_at,omitempty"`
@@ -979,6 +980,7 @@ func doctorAutoPromoteCandidateDiagnosticFromIssue(
 	}
 	diagnostic.PRURL = strings.TrimSpace(pullRequest.URL)
 	diagnostic.PRHeadSHA = strings.TrimSpace(pullRequest.HeadSHA)
+	diagnostic.PRMergeableState = strings.TrimSpace(pullRequest.MergeableState)
 	diagnostic.LatestCodexReviewState = doctorLatestCodexReviewState(pullRequest)
 	diagnostic.LatestCodexReviewCommitSHA = strings.TrimSpace(pullRequest.LatestCodexReviewCommitSHA)
 	diagnostic.LatestCodexReviewSubmittedAt = doctorLatestCodexReviewSubmittedAt(pullRequest)
@@ -1048,6 +1050,9 @@ func doctorAutoPromoteCandidateSummary(candidate doctorAutoPromoteCandidateDiagn
 	}
 	if candidate.PRHeadSHA != "" {
 		parts = append(parts, "head="+candidate.PRHeadSHA)
+	}
+	if candidate.PRMergeableState != "" {
+		parts = append(parts, "mergeable="+candidate.PRMergeableState)
 	}
 	if candidate.LatestCodexReviewState != "" || candidate.LatestCodexReviewCommitSHA != "" {
 		review := strings.TrimSpace(candidate.LatestCodexReviewState)

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -255,6 +255,12 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 		State:    "OPEN",
 		CIStatus: "success",
 	})
+	conflictingIssue := doctorAutoPromoteIssue("issue-conflicting", &connector.PullRequest{
+		Number:         45,
+		URL:            "https://github.test/pull/45",
+		State:          "OPEN",
+		MergeableState: "dirty",
+	})
 	linkedWithoutMetadata := doctorAutoPromoteIssue("issue-missing-pr", nil)
 	linkedWithoutMetadata.PRNumber = &prNumber
 	readyIssue := doctorAutoPromoteIssue("issue-ready", &connector.PullRequest{
@@ -326,6 +332,15 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 			},
 			want:        doctorOK,
 			wantDetails: []string{"automated_review_missing=1", "ci_not_green=1"},
+		},
+		{
+			name: "conflicting pull request reports merge conflict reason",
+			cfg:  validDoctorAutoPromoteWorkflow(),
+			connector: &fakeDoctorAutoPromoteConnector{
+				issues: []connector.Issue{conflictingIssue},
+			},
+			want:        doctorOK,
+			wantDetails: []string{"merge_conflicts=1", "issue-conflicting", "PR #45", "mergeable=dirty", "reason=merge_conflicts"},
 		},
 		{
 			name: "ready candidate passes with count",
@@ -438,6 +453,25 @@ func TestCheckDoctorAutoPromoteCandidateDiagnostics(t *testing.T) {
 				LatestCodexReviewCommitSHA:   "head-ready",
 				LatestCodexReviewSubmittedAt: &oldReview,
 				Reason:                       "ready",
+			},
+		},
+		{
+			name: "merge conflict",
+			issue: doctorAutoPromoteIssue("issue-conflicting", &connector.PullRequest{
+				Number:         614,
+				URL:            "https://github.test/pull/614",
+				State:          "OPEN",
+				HeadSHA:        "head-conflicting",
+				MergeableState: "dirty",
+			}),
+			want: doctorAutoPromoteCandidateDiagnostic{
+				IssueID:          "issue-conflicting",
+				IssueIdentifier:  "digitaldrywood/detent#399",
+				PRNumber:         614,
+				PRURL:            "https://github.test/pull/614",
+				PRHeadSHA:        "head-conflicting",
+				PRMergeableState: "dirty",
+				Reason:           "merge_conflicts",
 			},
 		},
 	}

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -2072,6 +2072,7 @@ func (c *Connector) attachMatchingPullRequests(
 	candidates []issuePullRequestCandidate,
 	pullRequests []pullRequestNode,
 ) error {
+	hydrated := map[int]pullRequestNode{}
 	for _, pullRequest := range pullRequests {
 		branchName := strings.TrimSpace(pullRequest.HeadRefName)
 		if branchName == "" {
@@ -2085,10 +2086,19 @@ func (c *Connector) attachMatchingPullRequests(
 				continue
 			}
 
-			if err := c.populatePullRequestStatus(ctx, repo, &pullRequest); err != nil {
-				return err
+			hydratedPullRequest, ok := hydrated[pullRequest.Number]
+			if !ok {
+				var err error
+				hydratedPullRequest, err = c.fetchRepositoryPullRequest(ctx, repo, pullRequest.Number)
+				if err != nil {
+					return err
+				}
+				if err := c.populatePullRequestStatus(ctx, repo, &hydratedPullRequest); err != nil {
+					return err
+				}
+				hydrated[pullRequest.Number] = hydratedPullRequest
 			}
-			attachPullRequestToIssue(&issues[candidate.Index], repo, pullRequest)
+			attachPullRequestToIssue(&issues[candidate.Index], repo, hydratedPullRequest)
 		}
 	}
 	return nil

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -467,6 +467,11 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 		},
 		{
 			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/187",
+			body:   `{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","updated_at":"2026-06-05T11:30:00Z","head":{"ref":"detent/digitaldrywood_detent_182_followup","sha":"sha-187"}}`,
+		},
+		{
+			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100",
 			body:   `{"check_runs":[]}`,
 		},
@@ -609,6 +614,11 @@ func TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints(t 
 			body:   `[{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-187"}}]`,
 		},
 		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/187",
+			body:   `{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-187"}}`,
+		},
+		{
 			method:  http.MethodGet,
 			path:    "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100",
 			headers: map[string]string{"Link": `</repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100&page=2>; rel="next"`},
@@ -670,7 +680,7 @@ func TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints(t 
 	}
 
 	requests := server.requests()
-	if len(requests) != 8 {
+	if len(requests) != 9 {
 		t.Fatalf("request count = %d, want project query plus paged PR REST requests", len(requests))
 	}
 }
@@ -686,6 +696,11 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
 			body:   `[{"number":190,"html_url":"https://github.com/digitaldrywood/detent/pull/190","state":"open","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-190"}}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/190",
+			body:   `{"number":190,"html_url":"https://github.com/digitaldrywood/detent/pull/190","state":"open","mergeable_state":"dirty","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-190"}}`,
 		},
 		{
 			method: http.MethodGet,
@@ -721,6 +736,9 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	pr := got[0].PullRequest
 	if pr == nil || pr.Number != 190 || pr.CIStatus != "fail" || pr.CodexReviewState != "P1" {
 		t.Fatalf("PullRequest = %#v, want PR 190 with failing CI and P1 review", pr)
+	}
+	if pr.MergeableState != "dirty" {
+		t.Fatalf("MergeableState = %q, want dirty from hydrated PR", pr.MergeableState)
 	}
 	if pr.CIDurationSeconds != 0 {
 		t.Fatalf("CIDurationSeconds = %d, want 0 while checks are running", pr.CIDurationSeconds)

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -73,6 +73,11 @@ func TestConnectorFetchLabelIssuesByStatesAttachesCurrentAgentBranchPullRequest(
 		},
 		{
 			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/digitaldrywood/pulls/434",
+			body:   `{"number":434,"html_url":"https://github.com/digitaldrywood/digitaldrywood/pull/434","state":"open","head":{"ref":"detent/digitaldrywood-digitaldrywood_digitaldrywood_433-a212db2634a4","sha":"sha-434"}}`,
+		},
+		{
+			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/digitaldrywood/commits/sha-434/check-runs?per_page=100",
 			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
 		},
@@ -285,6 +290,11 @@ func TestConnectorFetchCandidateIssuesSurfacesStatusLabelConflict(t *testing.T) 
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
 			body:   `[{"number":609,"html_url":"https://github.com/digitaldrywood/detent/pull/609","state":"open","head":{"ref":"detent/detent-digitaldrywood_detent_606-97bf7548e359","sha":"sha-609"}}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/609",
+			body:   `{"number":609,"html_url":"https://github.com/digitaldrywood/detent/pull/609","state":"open","head":{"ref":"detent/detent-digitaldrywood_detent_606-97bf7548e359","sha":"sha-609"}}`,
 		},
 		{
 			method: http.MethodGet,

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -19,6 +19,7 @@ type AutoPromoteConfig struct {
 type AutoPromoteSummary struct {
 	PullRequestPresent bool
 	PullRequestURL     string
+	MergeableState     string
 	CIStatus           string
 	ReviewState        string
 	P1Findings         []AutoPromoteFinding
@@ -50,6 +51,7 @@ const (
 	AutoPromoteReasonOptoutLabel                  AutoPromoteReason = "optout_label"
 	AutoPromoteReasonLabelNotAllowed              AutoPromoteReason = "label_not_allowed"
 	AutoPromoteReasonMissingPullRequest           AutoPromoteReason = "missing_pull_request"
+	AutoPromoteReasonMergeConflicts               AutoPromoteReason = "merge_conflicts"
 	AutoPromoteReasonCINotGreen                   AutoPromoteReason = "ci_not_green"
 	AutoPromoteReasonCodexReviewMissing           AutoPromoteReason = "automated_review_missing"
 	AutoPromoteReasonP1Findings                   AutoPromoteReason = "p1_findings"
@@ -86,6 +88,9 @@ func EvaluateAutoPromote(
 	}
 	if !autoPromoteAllowedIssueLabel(issue, cfg) {
 		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonLabelNotAllowed)
+	}
+	if autoPromoteMergeConflicts(summary.MergeableState) {
+		return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonMergeConflicts)
 	}
 	gateDecision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(summary), now, gate.EvaluationOptions{
 		QuietDuration: cfg.QuietDuration,
@@ -163,6 +168,15 @@ func normalizeLabels(labels []string) []string {
 		normalized = append(normalized, label)
 	}
 	return normalized
+}
+
+func autoPromoteMergeConflicts(mergeableState string) bool {
+	switch strings.ToLower(strings.TrimSpace(mergeableState)) {
+	case "dirty", "conflicting":
+		return true
+	default:
+		return false
+	}
 }
 
 func gateSummary(summary AutoPromoteSummary) gate.Summary {

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -329,6 +329,55 @@ func TestAutoPromoteWaitsForFreshPullRequestActivityWithoutAutomatedReview(t *te
 	}
 }
 
+func TestEvaluateAutoPromoteRoutesConflictingPullRequestToRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 22, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name           string
+		mergeableState string
+	}{
+		{
+			name:           "rest dirty state",
+			mergeableState: "dirty",
+		},
+		{
+			name:           "graphql conflicting state",
+			mergeableState: "CONFLICTING",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTestIssue("issue-conflicting", []string{"bug"})
+			issue.PullRequest = &connector.PullRequest{
+				Number:         614,
+				URL:            "https://github.test/digitaldrywood/detent/pull/614",
+				State:          "OPEN",
+				MergeableState: tt.mergeableState,
+			}
+
+			got := EvaluateAutoPromote(issue, AutoPromoteSummaryFromIssue(issue), AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 0,
+				OptoutLabel:   "requires-human-review",
+				Gate: gate.Config{
+					Kind:            gate.KindCommand,
+					CIFailureAction: gate.CIFailureActionRework,
+				},
+			}, now)
+			if got.Action != AutoPromoteActionRework {
+				t.Fatalf("Action = %q, want %q", got.Action, AutoPromoteActionRework)
+			}
+			if string(got.Reason) != "merge_conflicts" {
+				t.Fatalf("Reason = %q, want merge_conflicts", got.Reason)
+			}
+		})
+	}
+}
+
 func autoPromoteTestIssue(id string, labels []string) connector.Issue {
 	issue := connector.NewIssue()
 	issue.ID = id

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -263,6 +263,7 @@ func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	}
 	summary.PullRequestPresent = true
 	summary.PullRequestURL = strings.TrimSpace(pullRequest.URL)
+	summary.MergeableState = strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
 	summary.CIStatus = pullRequest.CIStatus
 	summary.ReviewState = pullRequest.CodexReviewState
 	summary.P1Findings = autoPromoteFindingsFromPullRequest(pullRequest)
@@ -387,6 +388,14 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 	if decision.CIStatus != "" {
 		attrs = append(attrs, "ci_status", decision.CIStatus)
 	}
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			attrs = append(attrs, "pull_request", url)
+		}
+		if mergeableState := strings.TrimSpace(issue.PullRequest.MergeableState); mergeableState != "" {
+			attrs = append(attrs, "mergeable_state", mergeableState)
+		}
+	}
 	if decision.QuietRemaining > 0 {
 		attrs = append(attrs, "quiet_remaining", decision.QuietRemaining)
 	}
@@ -395,7 +404,7 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 		o.logger.Info("auto promote decision", attrs...)
 		return
 	}
-	o.logger.Debug("auto promote decision", attrs...)
+	o.logger.Info("auto promote decision", attrs...)
 }
 
 func autoPromoteComment(
@@ -409,8 +418,11 @@ func autoPromoteComment(
 		b.WriteString("Auto-promoted this issue from Human Review to Merging.")
 	case autoPromoteReworkState:
 		b.WriteString("Auto-promote routed this issue from Human Review to Rework")
-		if decision.Reason == AutoPromoteReasonCINotGreen {
+		switch decision.Reason {
+		case AutoPromoteReasonCINotGreen:
 			b.WriteString(": current-head CI is failing")
+		case AutoPromoteReasonMergeConflicts:
+			b.WriteString(": linked PR has merge conflicts")
 		}
 		b.WriteString(".")
 	default:
@@ -423,6 +435,10 @@ func autoPromoteComment(
 	if summary.PullRequestURL != "" {
 		b.WriteString("\n- pull request: ")
 		b.WriteString(summary.PullRequestURL)
+	}
+	if summary.MergeableState != "" {
+		b.WriteString("\n- mergeable_state: ")
+		b.WriteString(summary.MergeableState)
 	}
 	if decision.CIStatus != "" {
 		b.WriteString("\n- ci_status: ")

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -130,6 +130,36 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			},
 		},
 		{
+			name: "routes conflicting pull request to rework",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 0,
+				Gate: gate.Config{
+					Kind:            gate.KindCommand,
+					CIFailureAction: gate.CIFailureActionRework,
+				},
+			},
+			issue: autoPromoteTickIssue("issue-conflicting-pr", []string{"bug"}, &connector.PullRequest{
+				Number:         49,
+				URL:            "https://github.test/digitaldrywood/detent/pull/49",
+				State:          "OPEN",
+				MergeableState: "dirty",
+			}),
+			wantUpdates: []autoPromoteTickUpdate{{
+				issueID: "issue-conflicting-pr",
+				state:   "Rework",
+			}},
+			wantCommentFragments: []string{
+				"Auto-promote routed this issue from Human Review to Rework: linked PR has merge conflicts.",
+				"reason: merge_conflicts",
+				"https://github.test/digitaldrywood/detent/pull/49",
+			},
+			wantLogFragments: []string{
+				"reason=merge_conflicts",
+				"target_state=Rework",
+			},
+		},
+		{
 			name: "waits for quiet period",
 			cfg: AutoPromoteConfig{
 				Enabled:       true,
@@ -248,6 +278,53 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTickAutoPromoteLogsNonTransitionDecisionsAtInfo(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 22, 14, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-missing-review", []string{"bug"}, &connector.PullRequest{
+		Number:     390,
+		URL:        "https://github.test/digitaldrywood/detent/pull/390",
+		BranchName: "detent/detent-digitaldrywood_detent_387-29d3e4765f21",
+		State:      "OPEN",
+		CIStatus:   "pass",
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+
+	state := newState(cfg)
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none", tracker.updates)
+	}
+	for _, fragment := range []string{
+		"level=INFO",
+		"auto promote decision",
+		"action=await_review",
+		"reason=automated_review_missing",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
 	}
 }
 

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -58,9 +58,10 @@ func EvaluateBlockedRecovery(issue connector.Issue) BlockedRecoveryDecision {
 		return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonPullRequestNotOpen, "")
 	}
 
-	switch strings.ToLower(strings.TrimSpace(pr.MergeableState)) {
-	case "dirty":
+	if autoPromoteMergeConflicts(pr.MergeableState) {
 		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonMergeConflicts, "linked PR has merge conflicts")
+	}
+	switch strings.ToLower(strings.TrimSpace(pr.MergeableState)) {
 	case "behind":
 		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonStaleBase, "linked PR branch is behind the base branch")
 	}


### PR DESCRIPTION
## Summary

- Route dirty/conflicting Human Review PRs to Rework with a `merge_conflicts` reason before CI gating collapses them to `ci_not_green`.
- Include PR mergeability in doctor diagnostics and log non-transition auto-promote decisions at INFO.
- Hydrate branch-matched PRs through the individual PR REST endpoint so `mergeable_state` is available even when the repository PR list omits it.
- Add regression coverage for evaluator, tick behavior, audit comments, logs, doctor output, and branch-matched PR mergeability.

Fixes #614

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestEvaluateAutoPromoteRoutesConflictingPullRequestToRework|TestTickAutoPromoteHumanReviewIssues|TestTickAutoPromoteLogsNonTransitionDecisionsAtInfo' -count=1`
- [x] `go test ./internal/cli -run 'TestCheckDoctorAutoPromote|TestCheckDoctorAutoPromoteCandidateDiagnostics' -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `go test ./internal/connector/github -run 'TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix|TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints|TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest' -count=1`
- [x] `go test ./internal/connector/github -count=1`
- [x] `make check`