### PR TITLE
fix(onboarding): preserve pending github mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,15 @@ repositories, onboarding mode, and status-source options before
 repository-specific discovery. Record those identity answers in `answers.env`,
 set `IDENTITY_CONFIRMED=true` only after I confirm the restatement, then run
 `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`.
+If I volunteer a status-source answer before identity is confirmed, such as
+"use label for this repo", preserve it as a pending decision outside
+`answers.env`. Restate it as pending in the conversation. For label mode, say:
+"I have your status-source choice as label mode. I will keep it pending until
+the identity gate validates, then append GITHUB_MODE=label and run the decision
+validator without asking again." Do not write `GITHUB_MODE` to `answers.env`
+until the identity phase passes; after identity validation succeeds, append
+`GITHUB_MODE=label` and run the decision validator without asking again. For
+non-label modes, carry the selected `GITHUB_MODE` value the same way.
 If the `detent` binary is not installed yet, follow the Detent source README's
 Install path or Bootstrap On A New Machine steps 1-3 first, verify the binary
 with `detent version`, and defer `detent onboarding validate-answers` until the

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -308,6 +308,15 @@ After identity is confirmed and before target-specific discovery, ask the
 GitHub status-source question. This is separate from identity confirmation, and
 it must still be an explicit operator answer.
 
+If the operator already volunteered a status-source answer before identity
+validation, do not ask the status-source question again. Keep the volunteered
+answer pending outside `answers.env` until identity validation succeeds. After
+`detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`
+passes, append the pending `GITHUB_MODE` answer and run
+`detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision`
+without re-asking. For an early "use label for this repo" answer, record
+`GITHUB_MODE=label` immediately after the identity gate passes.
+
 Ask: "Use ProjectV2 board mode, boardless issue-field mode, or repository label
 mode?" Explain that this answer maps to `tracker.github_status_source:
 project_v2`, `tracker.github_status_source: issue_field`, or

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -80,6 +80,31 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	assertContains(t, readme, "Ask and record `GITHUB_MODE` explicitly")
 }
 
+func TestOnboardingDocsPreserveEarlyLabelStatusSourceDecision(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+
+	for _, want := range []string{
+		"volunteer a status-source answer before identity is confirmed",
+		"preserve it as a pending decision outside `answers.env`",
+		"append `GITHUB_MODE=label` and run the decision validator without asking again",
+		"Do not write `GITHUB_MODE` to `answers.env` until the identity phase passes",
+	} {
+		assertContainsWords(t, readme, want)
+	}
+
+	for _, want := range []string{
+		"If the operator already volunteered a status-source answer before identity validation, do not ask the status-source question again",
+		"After `detent onboarding validate-answers --answers \"$ONBOARDING_DIR/answers.env\" --phase identity` passes, append the pending `GITHUB_MODE` answer",
+		"`GITHUB_MODE=label`",
+		"run `detent onboarding validate-answers --answers \"$ONBOARDING_DIR/answers.env\" --phase decision` without re-asking",
+	} {
+		assertContainsWords(t, onboarding, want)
+	}
+}
+
 func TestOnboardingDocsRecommendProjectKanbanIntegrationAfterWriteProbes(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Preserve early volunteered status-source choices as pending onboarding decisions until identity validation passes.
- Document that early label-mode input should be recorded after the identity gate without re-asking, with regression coverage for the prompt/runbook contract.

Fixes #618

## Test Plan

- [x] `go test -run TestOnboardingDocsPreserveEarlyLabelStatusSourceDecision ./...`
- [x] `go test -run 'TestOnboardingDocsPreserveEarlyLabelStatusSourceDecision|TestOnboardingValidateAnswersCommandRejectsGitHubModeBeforeIdentity' ./...`
- [x] `make check`