### PR TITLE
fix(onboarding): infer checkout identity

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,11 +39,23 @@ docs until the identity gate below is explicit and confirmed.
 Use the Detent source repository's docs/ONBOARDING.md as the interrogation
 guide. First determine which path applies: a new Detent install, an existing
 Detent install that must be found and verified, or a new repository/project
-being added to an existing Detent install. Distinguish reference repositories from the target repository being onboarded. Restate the customer/workstream id,
-Detent project id, target owner/name, absolute local source root, reference
-repositories, onboarding mode, and status-source options before
-repository-specific discovery. Record those identity answers in `answers.env`,
-set `IDENTITY_CONFIRMED=true` only after I confirm the restatement, then run
+being added to an existing Detent install. Distinguish reference repositories from the target repository being onboarded. In Phase 0.5, infer and restate an
+identity candidate from the current git checkout before asking for raw answer
+fields. Use only identity-safe local evidence first: `pwd`,
+`git rev-parse --show-toplevel`, `git remote get-url origin`, the canonical
+Detent source checkout identity, the installed Detent config path, and
+registered project ids. If the current working directory is a GitHub checkout
+and is not the canonical Detent source checkout, propose it as the target
+candidate. If the current working directory is the Detent source checkout, do
+not propose Detent as the target unless I explicitly say I am onboarding Detent
+itself. Derive the candidate target owner/name from the checkout origin, source
+root from the git top level, Detent project id from the repo name unless that id
+collides with an existing registered project, and customer/workstream id from
+the owner or a repo-name/workstream heuristic. Explain that the
+customer/workstream id is only a stable local workstream id. Present the
+candidate in human-facing language first, then show the `answers.env`
+representation. Record those identity answers in `answers.env`, set
+`IDENTITY_CONFIRMED=true` only after I confirm the restatement, then run
 `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`.
 If I volunteer a status-source answer before identity is confirmed, such as
 "use label for this repo", preserve it as a pending decision outside

--- a/README.md
+++ b/README.md
@@ -49,9 +49,12 @@ and is not the canonical Detent source checkout, propose it as the target
 candidate. If the current working directory is the Detent source checkout, do
 not propose Detent as the target unless I explicitly say I am onboarding Detent
 itself. Derive the candidate target owner/name from the checkout origin, source
-root from the git top level, Detent project id from the repo name unless that id
-collides with an existing registered project, and customer/workstream id from
-the owner or a repo-name/workstream heuristic. Explain that the
+root from the git top level, Detent project id from the repo name, and
+customer/workstream id from the owner or a repo-name/workstream heuristic. If
+the candidate project id already exists, first compare the registered
+repository, workdir, and workflow path to the current checkout; reuse the
+existing id when it is the same target, and propose a short non-colliding
+variant only when the id belongs to a different target. Explain that the
 customer/workstream id is only a stable local workstream id. Present the
 candidate in human-facing language first, then show the `answers.env`
 representation. Record those identity answers in `answers.env`, set

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -27,10 +27,13 @@ Use these placeholders consistently:
 
 ## Start Here — Determine The Mode
 
-Do not assume this is a fresh install, and do not infer the target project from
-the current directory or a pasted repository URL. You may inspect Detent
-installation evidence before the identity gate, but repository-specific
-discovery waits for Phase 0.5.
+Do not assume this is a fresh install, and do not silently choose the target
+project from the current directory or a pasted repository URL. In this runbook,
+`do not assume` means infer a candidate from identity-safe local evidence and
+confirm it with the operator; it does not mean ask for raw `answers.env` fields
+first. You may inspect Detent installation evidence and current-checkout
+identity before the identity gate, but repository-specific discovery waits for
+Phase 0.5.
 
 Classify the work into one of these modes:
 
@@ -48,13 +51,17 @@ Classify the work into one of these modes:
   runtime settings unless the human chooses otherwise, then create or adopt a
   board, author `WORKFLOW.md`, register the project, and smoke test.
 
-Record only Detent install/mode evidence before the identity interview:
+Record only Detent install/mode and identity-safe current-checkout evidence
+before the identity interview:
 
 ```sh
 ONBOARDING_DIR="${TMPDIR:-/tmp}/detent-onboarding-<repo-owner>-<repo-name>"
 mkdir -p "$ONBOARDING_DIR"
 
 {
+  pwd
+  git rev-parse --show-toplevel 2>/dev/null || true
+  git remote get-url origin 2>/dev/null || true
   command -v detent || true
   detent version 2>/dev/null || true
   detent --format pretty config path 2>/dev/null || true
@@ -203,7 +210,59 @@ customer/project identity record in `$ONBOARDING_DIR/answers.env`. This is an
 operator decision checkpoint, not a recommendation. Recommendations can cite
 evidence later, but they must not become selected answers.
 
-Ask for and record these answers:
+Infer an identity candidate first when the current shell is already inside a
+GitHub checkout. Use only identity-safe local evidence: `pwd`,
+`git rev-parse --show-toplevel`, `git remote get-url origin`, the canonical
+Detent source checkout identity, the installed Detent config path, and
+registered project ids. Do not inspect target labels, issues, boards,
+`WORKFLOW.md`, validation commands, runtime docs, or other target-specific
+content before this candidate is confirmed and validated.
+
+If the current working directory is a GitHub checkout and its git top level is
+not the canonical Detent source checkout, propose that checkout as the target
+candidate. Derive `TARGET_REPOSITORY` from the origin remote and
+`TARGET_SOURCE_ROOT` from `git rev-parse --show-toplevel`. Propose
+`DETENT_PROJECT_ID` from the repo name unless that id collides with an existing
+registered project id; on collision, propose a short non-colliding variant and
+explain the collision. Propose `CUSTOMER_ID` from the owner when that is the
+clearest stable workstream id, or from a repo-name/workstream heuristic when
+the owner is too broad. Explain that `CUSTOMER_ID` is only a stable local
+workstream id, not a billing account or GitHub organization requirement.
+
+If the current working directory is the canonical Detent source checkout, do not
+propose Detent as the target unless the operator explicitly says they are
+onboarding Detent itself. Ask for the target checkout or clone destination in
+human language instead of asking for raw environment variable names.
+
+Common `add-project` case:
+
+- Current directory is `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`.
+- Detent source checkout is `/home/loganlanou/projects/digitaldrywood/detent`.
+- Current checkout origin is `git@github.com:digitaldrywood/creswoodcorners-phone.git`.
+- Existing Detent config is present and does not register `creswoodcorners-phone`.
+- Onboarding mode is `add-project`.
+
+Restate the candidate in human-facing language before showing the
+`answers.env` representation:
+
+```text
+I found a likely target checkout from the current shell:
+
+Customer/workstream: `digitaldrywood`
+Project id: `creswoodcorners-phone`
+Target repository: `digitaldrywood/creswoodcorners-phone`
+Source checkout: `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`
+Reference repositories: `digitaldrywood/detent`
+Onboarding mode: `add-project`
+
+`CUSTOMER_ID` is only a stable local workstream id for this Detent install. I
+will not inspect target labels, issues, boards, `WORKFLOW.md`, validation
+commands, or runtime docs until you confirm this identity and the identity
+validator passes. Is this the target you want to onboard?
+```
+
+Only after the operator confirms or edits the human-facing candidate, record the
+answers:
 
 ```sh
 printf '%s\n' \
@@ -216,7 +275,7 @@ printf '%s\n' \
   > "$ONBOARDING_DIR/answers.env"
 ```
 
-Present the interpretation back to the operator before inspecting target
+Present the final interpretation back to the operator before inspecting target
 resources:
 
 ```text

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -222,12 +222,15 @@ If the current working directory is a GitHub checkout and its git top level is
 not the canonical Detent source checkout, propose that checkout as the target
 candidate. Derive `TARGET_REPOSITORY` from the origin remote and
 `TARGET_SOURCE_ROOT` from `git rev-parse --show-toplevel`. Propose
-`DETENT_PROJECT_ID` from the repo name unless that id collides with an existing
-registered project id; on collision, propose a short non-colliding variant and
-explain the collision. Propose `CUSTOMER_ID` from the owner when that is the
-clearest stable workstream id, or from a repo-name/workstream heuristic when
-the owner is too broad. Explain that `CUSTOMER_ID` is only a stable local
-workstream id, not a billing account or GitHub organization requirement.
+`DETENT_PROJECT_ID` from the repo name. If a registered project already uses
+that id, compare the registered repository, workdir, and workflow path to the
+candidate checkout before minting a new id. Reuse the existing project id when
+it is the same target repository or source root; propose a short non-colliding
+variant only when the id belongs to a different target, and explain the
+collision. Propose `CUSTOMER_ID` from the owner when that is the clearest
+stable workstream id, or from a repo-name/workstream heuristic when the owner
+is too broad. Explain that `CUSTOMER_ID` is only a stable local workstream id,
+not a billing account or GitHub organization requirement.
 
 If the current working directory is the canonical Detent source checkout, do not
 propose Detent as the target unless the operator explicitly says they are

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -105,6 +105,41 @@ func TestOnboardingDocsPreserveEarlyLabelStatusSourceDecision(t *testing.T) {
 	}
 }
 
+func TestOnboardingDocsInferCurrentCheckoutCandidateBeforeRawFields(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+
+	for _, want := range []string{
+		"infer and restate an identity candidate from the current git checkout",
+		"If the current working directory is a GitHub checkout and is not the canonical Detent source checkout, propose it as the target candidate",
+		"Present the candidate in human-facing language first, then show the `answers.env` representation",
+	} {
+		assertContainsWords(t, readme, want)
+	}
+
+	for _, want := range []string{
+		"`do not assume` means infer a candidate from identity-safe local evidence and confirm it",
+		"`pwd`, `git rev-parse --show-toplevel`, `git remote get-url origin`",
+		"Current directory is `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`",
+		"Detent source checkout is `/home/loganlanou/projects/digitaldrywood/detent`",
+		"Onboarding mode is `add-project`",
+		"Customer/workstream: `digitaldrywood`",
+		"Project id: `creswoodcorners-phone`",
+		"Target repository: `digitaldrywood/creswoodcorners-phone`",
+		"Source checkout: `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`",
+		"`CUSTOMER_ID` is only a stable local workstream id",
+	} {
+		assertContainsWords(t, onboarding, want)
+	}
+
+	assertOrder(t, onboarding, "Customer/workstream:", "CUSTOMER_ID=<customer-or-workstream-id>")
+	assertOrder(t, onboarding, "Project id:", "DETENT_PROJECT_ID=<local-detent-project-id>")
+	assertOrder(t, onboarding, "Target repository:", "TARGET_REPOSITORY=<repo-owner>/<repo-name>")
+	assertOrder(t, onboarding, "Source checkout:", "TARGET_SOURCE_ROOT=<absolute-local-checkout-path>")
+}
+
 func TestOnboardingDocsRecommendProjectKanbanIntegrationAfterWriteProbes(t *testing.T) {
 	t.Parallel()
 
@@ -283,6 +318,22 @@ func assertContainsWords(t *testing.T, text string, want string) {
 	normalizedText := strings.Join(strings.Fields(text), " ")
 	normalizedWant := strings.Join(strings.Fields(want), " ")
 	assertContains(t, normalizedText, normalizedWant)
+}
+
+func assertOrder(t *testing.T, text string, before string, after string) {
+	t.Helper()
+
+	beforeIndex := strings.Index(text, before)
+	if beforeIndex == -1 {
+		t.Fatalf("document missing %q", before)
+	}
+	afterIndex := strings.Index(text, after)
+	if afterIndex == -1 {
+		t.Fatalf("document missing %q", after)
+	}
+	if beforeIndex > afterIndex {
+		t.Fatalf("document places %q after %q", before, after)
+	}
 }
 
 func assertMutationBlocksUseValidator(t *testing.T, text string) {

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -122,6 +122,7 @@ func TestOnboardingDocsInferCurrentCheckoutCandidateBeforeRawFields(t *testing.T
 	for _, want := range []string{
 		"`do not assume` means infer a candidate from identity-safe local evidence and confirm it",
 		"`pwd`, `git rev-parse --show-toplevel`, `git remote get-url origin`",
+		"Reuse the existing project id when it is the same target repository or source root",
 		"Current directory is `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`",
 		"Detent source checkout is `/home/loganlanou/projects/digitaldrywood/detent`",
 		"Onboarding mode is `add-project`",


### PR DESCRIPTION
## Summary
- Update the Start With AI prompt to infer an identity candidate from the current checkout using identity-safe local evidence.
- Expand Phase 0.5 onboarding docs with candidate-first confirmation, Detent-source safeguards, and the common add-project/current-target case.
- Add a docs regression test that requires candidate inference guidance and human-facing identity restatement before raw `answers.env` fields.

Fixes #616

## Test Plan
- `go test -run TestOnboardingDocs ./`
- `git diff --check`
- `make check` (passed on retry after an initial parallel `golangci-lint` runner lock)
