### PR TITLE
feat(onboarding): draft identity answers

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,27 +39,24 @@ docs until the identity gate below is explicit and confirmed.
 Use the Detent source repository's docs/ONBOARDING.md as the interrogation
 guide. First determine which path applies: a new Detent install, an existing
 Detent install that must be found and verified, or a new repository/project
-being added to an existing Detent install. Distinguish reference repositories from the target repository being onboarded. In Phase 0.5, infer and restate an
-identity candidate from the current git checkout before asking for raw answer
-fields. Use only identity-safe local evidence first: `pwd`,
+being added to an existing Detent install. Distinguish reference repositories from the target repository being onboarded. In Phase 0.5, run
+`detent onboarding draft-answers --output pretty` from the target checkout, or
+pass `--target-source-root` if you are currently in the Detent source checkout.
+To write the candidate identity record, run
+`detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write`.
+Treat the draft as a candidate, not confirmation. The command should infer and
+restate an identity candidate from the current git checkout before asking for
+raw answer fields, using only identity-safe local evidence first: `pwd`,
 `git rev-parse --show-toplevel`, `git remote get-url origin`, the canonical
 Detent source checkout identity, the installed Detent config path, and
 registered project ids. If the current working directory is a GitHub checkout
 and is not the canonical Detent source checkout, propose it as the target
 candidate. If the current working directory is the Detent source checkout, do
 not propose Detent as the target unless I explicitly say I am onboarding Detent
-itself. Derive the candidate target owner/name from the checkout origin, source
-root from the git top level, Detent project id from the repo name, and
-customer/workstream id from the owner or a repo-name/workstream heuristic. If
-the candidate project id already exists, first compare the registered
-repository, workdir, and workflow path to the current checkout; reuse the
-existing id when it is the same target, and propose a short non-colliding
-variant only when the id belongs to a different target. Explain that the
-customer/workstream id is only a stable local workstream id. Present the
-candidate in human-facing language first, then show the `answers.env`
-representation. Record those identity answers in `answers.env`, set
-`IDENTITY_CONFIRMED=true` only after I confirm the restatement, then run
-`detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`.
+itself. Explain that the customer/workstream id is only a stable local
+workstream id. Present the candidate in human-facing language first, then show
+the `answers.env` representation. Set `IDENTITY_CONFIRMED=true` only after I
+confirm the restatement, then run `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`.
 If I volunteer a status-source answer before identity is confirmed, such as
 "use label for this repo", preserve it as a pending decision outside
 `answers.env`. Restate it as pending in the conversation. For label mode, say:

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -210,32 +210,52 @@ customer/project identity record in `$ONBOARDING_DIR/answers.env`. This is an
 operator decision checkpoint, not a recommendation. Recommendations can cite
 evidence later, but they must not become selected answers.
 
-Infer an identity candidate first when the current shell is already inside a
-GitHub checkout. Use only identity-safe local evidence: `pwd`,
-`git rev-parse --show-toplevel`, `git remote get-url origin`, the canonical
-Detent source checkout identity, the installed Detent config path, and
-registered project ids. Do not inspect target labels, issues, boards,
-`WORKFLOW.md`, validation commands, runtime docs, or other target-specific
-content before this candidate is confirmed and validated.
+Draft the first candidate from identity-safe local evidence. Run this from the
+target checkout:
 
-If the current working directory is a GitHub checkout and its git top level is
-not the canonical Detent source checkout, propose that checkout as the target
-candidate. Derive `TARGET_REPOSITORY` from the origin remote and
-`TARGET_SOURCE_ROOT` from `git rev-parse --show-toplevel`. Propose
-`DETENT_PROJECT_ID` from the repo name. If a registered project already uses
-that id, compare the registered repository, workdir, and workflow path to the
-candidate checkout before minting a new id. Reuse the existing project id when
-it is the same target repository or source root; propose a short non-colliding
-variant only when the id belongs to a different target, and explain the
-collision. Propose `CUSTOMER_ID` from the owner when that is the clearest
-stable workstream id, or from a repo-name/workstream heuristic when the owner
-is too broad. Explain that `CUSTOMER_ID` is only a stable local workstream id,
-not a billing account or GitHub organization requirement.
+```sh
+detent onboarding draft-answers --output pretty
+detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write
+```
+
+If you are currently in the Detent source checkout, pass the target explicitly:
+
+```sh
+detent onboarding draft-answers --target-source-root <absolute-local-checkout-path> --output pretty
+detent onboarding draft-answers --target-source-root <absolute-local-checkout-path> --answers "$ONBOARDING_DIR/answers.env" --write
+```
+
+The draft command may inspect only local identity evidence: current working
+directory and git top-level, origin remote and parsed GitHub owner/name,
+canonical Detent source repository evidence, Detent config path and registered
+project ids, and local installed binary/config/service evidence needed to
+recommend `new-install`, `existing-install`, or `add-project`. It must not
+inspect target ProjectV2 boards, organization issue fields, repository labels,
+issues, `WORKFLOW.md`, validation commands, deployment docs, or runtime docs.
+
+The command should infer and restate an identity candidate from the current git
+checkout before asking for raw answer fields. Its local evidence includes
+`pwd`, `git rev-parse --show-toplevel`, `git remote get-url origin`, the
+canonical Detent source checkout identity, the installed Detent config path, and
+registered project ids. If the current working directory is a GitHub checkout
+and its git top level is not the canonical Detent source checkout, it proposes
+that checkout as the target candidate. It derives `TARGET_REPOSITORY` from the
+origin remote and `TARGET_SOURCE_ROOT` from `git rev-parse --show-toplevel`,
+then proposes `DETENT_PROJECT_ID` from the repo name. If a registered project
+already uses that id, compare the registered repository, workdir, and workflow
+path to the candidate checkout before accepting the draft. Reuse the existing
+project id when it is the same target repository or source root; use a short
+non-colliding variant only when the id belongs to a different target. The draft
+explains the collision. It proposes `CUSTOMER_ID` from the owner when that is
+the clearest stable workstream id, or from a repo-name/workstream heuristic when
+the owner is too broad. `CUSTOMER_ID` is only a stable local workstream id, not
+a billing account or GitHub organization requirement.
 
 If the current working directory is the canonical Detent source checkout, do not
 propose Detent as the target unless the operator explicitly says they are
-onboarding Detent itself. Ask for the target checkout or clone destination in
-human language instead of asking for raw environment variable names.
+onboarding Detent itself. Pass `--target-source-root` or ask for the target
+checkout or clone destination in human language instead of asking for raw
+environment variable names.
 
 Common `add-project` case:
 
@@ -245,7 +265,7 @@ Common `add-project` case:
 - Existing Detent config is present and does not register `creswoodcorners-phone`.
 - Onboarding mode is `add-project`.
 
-Restate the candidate in human-facing language before showing the
+Present the candidate in human-facing language first, then show the
 `answers.env` representation:
 
 ```text
@@ -264,8 +284,8 @@ commands, or runtime docs until you confirm this identity and the identity
 validator passes. Is this the target you want to onboard?
 ```
 
-Only after the operator confirms or edits the human-facing candidate, record the
-answers:
+Review and correct the candidate answers before confirmation. The identity
+record must contain these answers:
 
 ```sh
 printf '%s\n' \
@@ -277,6 +297,10 @@ printf '%s\n' \
   'DETENT_ONBOARDING_MODE=<new-install|existing-install|add-project>' \
   > "$ONBOARDING_DIR/answers.env"
 ```
+
+When `draft-answers --write` creates or updates `answers.env`, it leaves
+`IDENTITY_CONFIRMED=false`. Do not change that value until the operator confirms
+the restatement.
 
 Present the final interpretation back to the operator before inspecting target
 resources:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -402,7 +402,7 @@ detent --format json config path`),
 			return nil
 		}),
 		newConfigCommand(&configPath, opts),
-		newOnboardingCommand(),
+		newOnboardingCommand(&configPath, opts),
 		newPromoteCommand(&configPath, opts),
 		newRemoveProjectCommand(&configPath, opts),
 	)

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -4,23 +4,28 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"regexp"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
 const (
 	onboardingAnswersPhaseIdentity = "identity"
 	onboardingAnswersPhaseDecision = "decision"
 	onboardingAnswersPhaseMutation = "mutation"
+	onboardingDetentRepository     = "digitaldrywood/detent"
 )
 
 var (
@@ -43,19 +48,105 @@ type onboardingAnswersValidationResult struct {
 	MutationConfirmed     bool     `json:"mutation_confirmed"`
 }
 
+type onboardingDraftAnswersResult struct {
+	Status                         string   `json:"status"`
+	AnswersPath                    string   `json:"answers_path,omitempty"`
+	Written                        bool     `json:"written"`
+	CustomerIDCandidate            string   `json:"customer_id_candidate"`
+	DetentProjectIDCandidate       string   `json:"detent_project_id_candidate"`
+	TargetRepositoryCandidate      string   `json:"target_repository_candidate"`
+	TargetSourceRootCandidate      string   `json:"target_source_root_candidate"`
+	ReferenceRepositoriesCandidate []string `json:"reference_repositories_candidate"`
+	DetentOnboardingModeCandidate  string   `json:"detent_onboarding_mode_candidate"`
+	ConfigPath                     string   `json:"config_path"`
+	ConfigPathRule                 string   `json:"config_path_rule"`
+	ConfigInstalled                bool     `json:"config_installed"`
+	RegisteredProjectIDs           []string `json:"registered_project_ids"`
+	Confidence                     string   `json:"confidence"`
+	Notes                          []string `json:"notes"`
+}
+
 type onboardingAnswers struct {
 	Values       map[string]string
 	LastNonblank string
 	Problems     []string
 }
 
-func newOnboardingCommand() *cobra.Command {
+type onboardingDraftAnswersConfig struct {
+	AnswersPath      string
+	ConfigPath       string
+	TargetSourceRoot string
+	DetentSourceRoot string
+	Write            bool
+	Options          options
+}
+
+func newOnboardingCommand(configPath *string, opts options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "onboarding",
-		Short:   "Validate onboarding setup decisions",
+		Short:   "Draft and validate onboarding setup decisions",
 		Example: `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env"`,
 	}
-	cmd.AddCommand(newOnboardingValidateAnswersCommand())
+	cmd.AddCommand(
+		newOnboardingValidateAnswersCommand(),
+		newOnboardingDraftAnswersCommand(configPath, opts),
+	)
+	return cmd
+}
+
+func newOnboardingDraftAnswersCommand(configPath *string, opts options) *cobra.Command {
+	var answersPath string
+	var detentSourceRoot string
+	var output string
+	var targetSourceRoot string
+	var write bool
+
+	cmd := &cobra.Command{
+		Use:          "draft-answers",
+		Short:        "Draft onboarding identity answers from local evidence",
+		Example:      `detent onboarding draft-answers --output pretty`,
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			if strings.TrimSpace(output) != "" {
+				if err := cmd.Root().PersistentFlags().Set(outputFormatFlag, output); err != nil {
+					return err
+				}
+			}
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			cfg := onboardingDraftAnswersConfig{
+				AnswersPath:      answersPath,
+				TargetSourceRoot: targetSourceRoot,
+				DetentSourceRoot: detentSourceRoot,
+				Write:            write,
+				Options:          opts,
+			}
+			if configPath != nil {
+				cfg.ConfigPath = *configPath
+			}
+			result, err := draftOnboardingAnswers(cmd.Context(), cfg)
+			if err != nil {
+				return err
+			}
+			if write {
+				if err := writeOnboardingDraftAnswers(result.AnswersPath, result); err != nil {
+					return err
+				}
+				result.Written = true
+			}
+			return out.Write(func(w io.Writer) error {
+				return writeOnboardingDraftAnswersPretty(w, result)
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
+	cmd.Flags().StringVar(&targetSourceRoot, "target-source-root", "", "explicit target git checkout root")
+	cmd.Flags().StringVar(&detentSourceRoot, "detent-source-root", "", "explicit Detent source checkout root")
+	cmd.Flags().StringVar(&output, "output", "", "output format: pretty or json")
+	cmd.Flags().BoolVar(&write, "write", false, "write drafted identity answers to answers.env")
 	return cmd
 }
 
@@ -86,6 +177,333 @@ func newOnboardingValidateAnswersCommand() *cobra.Command {
 	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
 	cmd.Flags().StringVar(&phase, "phase", onboardingAnswersPhaseMutation, "validation phase: identity, decision, or mutation")
 	return cmd
+}
+
+func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfig) (onboardingDraftAnswersResult, error) {
+	opts := cfg.Options
+	if opts.resolvePath == nil || opts.read == nil {
+		defaults := defaultOptions()
+		if opts.resolvePath == nil {
+			opts.resolvePath = defaults.resolvePath
+		}
+		if opts.read == nil {
+			opts.read = defaults.read
+		}
+	}
+
+	targetInput := strings.TrimSpace(cfg.TargetSourceRoot)
+	targetExplicit := targetInput != ""
+	if targetInput == "" {
+		wd, err := os.Getwd()
+		if err != nil {
+			return onboardingDraftAnswersResult{}, fmt.Errorf("resolve current directory: %w", err)
+		}
+		targetInput = wd
+	}
+	targetRoot, targetRepository, err := onboardingGitCheckoutEvidence(ctx, targetInput)
+	if err != nil {
+		return onboardingDraftAnswersResult{}, err
+	}
+	if !targetExplicit && strings.EqualFold(targetRepository, onboardingDetentRepository) {
+		return onboardingDraftAnswersResult{}, NewValidationError(
+			"current checkout is the Detent source repository; provide --target-source-root for the repository being onboarded",
+			"Run detent onboarding draft-answers from the target repository, or pass --target-source-root /path/to/target.",
+			nil,
+		)
+	}
+
+	resolution, err := resolveConfigPathResolution(cfg.ConfigPath, opts)
+	if err != nil {
+		return onboardingDraftAnswersResult{}, err
+	}
+
+	result := onboardingDraftAnswersResult{
+		Status:                    "draft",
+		AnswersPath:               strings.TrimSpace(cfg.AnswersPath),
+		CustomerIDCandidate:       repositoryOwner(targetRepository),
+		DetentProjectIDCandidate:  repositoryName(targetRepository),
+		TargetRepositoryCandidate: targetRepository,
+		TargetSourceRootCandidate: targetRoot,
+		ConfigPath:                resolution.Path,
+		ConfigPathRule:            string(resolution.Rule),
+		Confidence:                "medium",
+		Notes: []string{
+			"inferred target repository from the local origin remote",
+			"review all candidates with the operator before setting IDENTITY_CONFIRMED=true",
+		},
+	}
+
+	result.ReferenceRepositoriesCandidate = onboardingReferenceRepositoryCandidates(ctx, cfg.DetentSourceRoot, targetRepository, &result.Notes)
+	global, installed, err := readOnboardingDraftConfigEvidence(resolution.Path, opts)
+	if err != nil {
+		return onboardingDraftAnswersResult{}, err
+	}
+	result.ConfigInstalled = installed
+	if installed {
+		result.RegisteredProjectIDs = onboardingRegisteredProjectIDs(global.Projects)
+		mode, notes := onboardingModeCandidate(global.Projects, result.DetentProjectIDCandidate, targetRoot)
+		result.DetentOnboardingModeCandidate = mode
+		result.Notes = append(result.Notes, notes...)
+	} else {
+		result.DetentOnboardingModeCandidate = "new-install"
+		result.Notes = append(result.Notes, "no readable global config was found, so this looks like a new-install candidate")
+	}
+	if containsOnboardingReviewNote(result.Notes) {
+		result.Confidence = "needs-review"
+	}
+	return result, nil
+}
+
+func onboardingGitCheckoutEvidence(ctx context.Context, path string) (string, string, error) {
+	root, err := defaultGitTopLevel(ctx, path)
+	if err != nil {
+		return "", "", NewValidationError(
+			"target source root must be a git checkout: "+err.Error(),
+			"Run detent onboarding draft-answers from a GitHub checkout, or pass --target-source-root /path/to/target.",
+			nil,
+		)
+	}
+	remote, err := defaultGitRemoteURL(ctx, root)
+	if err != nil {
+		return "", "", NewValidationError(
+			"target source root must have an origin remote: "+err.Error(),
+			"Add a GitHub origin remote or pass a different --target-source-root.",
+			nil,
+		)
+	}
+	repository, ok := gitHubRepositoryFromRemote(remote)
+	if !ok {
+		return "", "", NewValidationError(
+			"target source root origin remote must be a GitHub owner/name repository",
+			"Use a checkout whose origin remote is hosted on github.com.",
+			nil,
+		)
+	}
+	return root, repository, nil
+}
+
+func defaultGitTopLevel(ctx context.Context, path string) (string, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(commandCtx, "git", "-C", path, "rev-parse", "--show-toplevel") // #nosec G204 -- onboarding uses fixed git arguments against a local checkout path.
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		return "", commandCtx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return "", fmt.Errorf("%w: %s", err, detail)
+		}
+		return "", err
+	}
+	root := strings.TrimSpace(string(output))
+	if root == "" {
+		return "", errors.New("git top-level is blank")
+	}
+	absolute, err := filepath.Abs(root)
+	if err != nil {
+		return "", fmt.Errorf("resolve git top-level %s: %w", root, err)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func onboardingReferenceRepositoryCandidates(ctx context.Context, detentSourceRoot string, targetRepository string, notes *[]string) []string {
+	repository := onboardingDetentRepository
+	if strings.TrimSpace(detentSourceRoot) != "" {
+		_, detected, err := onboardingGitCheckoutEvidence(ctx, detentSourceRoot)
+		if err == nil {
+			repository = detected
+			*notes = append(*notes, "inferred reference repository from --detent-source-root")
+		} else {
+			*notes = append(*notes, "could not inspect --detent-source-root; using canonical Detent source repository")
+		}
+	}
+	if strings.EqualFold(repository, targetRepository) {
+		return nil
+	}
+	return []string{repository}
+}
+
+func readOnboardingDraftConfigEvidence(path string, opts options) (globalconfig.Config, bool, error) {
+	global, err := opts.read(path)
+	if err == nil {
+		return global, true, nil
+	}
+	var missing globalconfig.MissingFileError
+	if errors.As(err, &missing) && errors.Is(missing.Err, os.ErrNotExist) {
+		return globalconfig.Config{}, false, nil
+	}
+	return globalconfig.Config{}, false, fmt.Errorf("read global config evidence %s: %w", path, err)
+}
+
+func onboardingRegisteredProjectIDs(projects []globalconfig.Project) []string {
+	ids := make([]string, 0, len(projects))
+	for _, project := range projects {
+		if id := strings.TrimSpace(project.ID); id != "" {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func onboardingModeCandidate(projects []globalconfig.Project, candidateProjectID string, targetRoot string) (string, []string) {
+	var notes []string
+	for _, project := range projects {
+		if sameOnboardingPath(project.Workdir, targetRoot) {
+			return "existing-install", []string{"target source root already matches a registered project workdir"}
+		}
+	}
+	if projectIndex(projects, candidateProjectID) >= 0 {
+		notes = append(notes, fmt.Sprintf("project id candidate %q already exists in global config and needs operator review", candidateProjectID))
+	}
+	return "add-project", notes
+}
+
+func sameOnboardingPath(left string, right string) bool {
+	leftAbs, leftErr := cleanOnboardingPath(left)
+	rightAbs, rightErr := cleanOnboardingPath(right)
+	if leftErr != nil || rightErr != nil {
+		return false
+	}
+	return leftAbs == rightAbs
+}
+
+func cleanOnboardingPath(path string) (string, error) {
+	absolute, err := filepath.Abs(strings.TrimSpace(path))
+	if err != nil {
+		return "", err
+	}
+	clean := filepath.Clean(absolute)
+	evaluated, err := filepath.EvalSymlinks(clean)
+	if err == nil {
+		return filepath.Clean(evaluated), nil
+	}
+	return clean, nil
+}
+
+func containsOnboardingReviewNote(notes []string) bool {
+	for _, note := range notes {
+		if strings.Contains(note, "needs operator review") || strings.Contains(note, "could not inspect") {
+			return true
+		}
+	}
+	return false
+}
+
+func repositoryOwner(repository string) string {
+	owner, _, _ := strings.Cut(repository, "/")
+	return owner
+}
+
+func repositoryName(repository string) string {
+	_, name, _ := strings.Cut(repository, "/")
+	return name
+}
+
+func writeOnboardingDraftAnswersPretty(w io.Writer, result onboardingDraftAnswersResult) error {
+	lines := []string{
+		"Draft onboarding identity answers:",
+		"customer_id_candidate: " + result.CustomerIDCandidate,
+		"detent_project_id_candidate: " + result.DetentProjectIDCandidate,
+		"target_repository_candidate: " + result.TargetRepositoryCandidate,
+		"target_source_root_candidate: " + result.TargetSourceRootCandidate,
+		"reference_repositories_candidate: " + strings.Join(result.ReferenceRepositoriesCandidate, ","),
+		"detent_onboarding_mode_candidate: " + result.DetentOnboardingModeCandidate,
+		"confidence: " + result.Confidence,
+	}
+	if result.ConfigPath != "" {
+		lines = append(lines, "config_path: "+result.ConfigPath)
+	}
+	if len(result.RegisteredProjectIDs) > 0 {
+		lines = append(lines, "registered_project_ids: "+strings.Join(result.RegisteredProjectIDs, ","))
+	}
+	if result.Written {
+		lines = append(lines, "wrote_answers: "+result.AnswersPath)
+	}
+	if len(result.Notes) > 0 {
+		lines = append(lines, "notes:")
+		for _, note := range result.Notes {
+			lines = append(lines, "- "+note)
+		}
+	}
+	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))
+	return err
+}
+
+func writeOnboardingDraftAnswers(path string, result onboardingDraftAnswersResult) error {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return NewValidationError(
+			"--answers is required when --write is set",
+			`Run detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write.`,
+			nil,
+		)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read existing onboarding answers %s: %w", path, err)
+	}
+	content := buildOnboardingDraftAnswersContent(raw, result)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return fmt.Errorf("create onboarding answers directory %s: %w", filepath.Dir(path), err)
+	}
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		return fmt.Errorf("write onboarding answers %s: %w", path, err)
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		return fmt.Errorf("restrict onboarding answers %s: %w", path, err)
+	}
+	return nil
+}
+
+func buildOnboardingDraftAnswersContent(raw []byte, result onboardingDraftAnswersResult) string {
+	replace := map[string]bool{
+		"CUSTOMER_ID":            true,
+		"DETENT_PROJECT_ID":      true,
+		"TARGET_REPOSITORY":      true,
+		"TARGET_SOURCE_ROOT":     true,
+		"REFERENCE_REPOSITORIES": true,
+		"DETENT_ONBOARDING_MODE": true,
+		"IDENTITY_CONFIRMED":     true,
+	}
+	lines := make([]string, 0)
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	for scanner.Scan() {
+		line := scanner.Text()
+		if key, ok := onboardingAnswerLineKey(line); ok && replace[key] {
+			continue
+		}
+		lines = append(lines, line)
+	}
+	for len(lines) > 0 && strings.TrimSpace(lines[len(lines)-1]) == "" {
+		lines = lines[:len(lines)-1]
+	}
+	if len(lines) > 0 {
+		lines = append(lines, "")
+	}
+	lines = append(lines,
+		"CUSTOMER_ID="+result.CustomerIDCandidate,
+		"DETENT_PROJECT_ID="+result.DetentProjectIDCandidate,
+		"TARGET_REPOSITORY="+result.TargetRepositoryCandidate,
+		"TARGET_SOURCE_ROOT="+result.TargetSourceRootCandidate,
+		"REFERENCE_REPOSITORIES="+strings.Join(result.ReferenceRepositoriesCandidate, ","),
+		"DETENT_ONBOARDING_MODE="+result.DetentOnboardingModeCandidate,
+		"IDENTITY_CONFIRMED=false",
+	)
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func onboardingAnswerLineKey(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return "", false
+	}
+	line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+	key, _, ok := strings.Cut(line, "=")
+	key = strings.TrimSpace(key)
+	return key, ok && validOnboardingAnswerKey(key)
 }
 
 func validateOnboardingAnswersFile(path string, phase string) (onboardingAnswersValidationResult, error) {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/digitaldrywood/detent/internal/cli"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
 func TestOnboardingValidateAnswersCommandRejectsMissingGitHubMode(t *testing.T) {
@@ -236,6 +237,204 @@ func TestOnboardingValidateAnswersCommandAcceptsLabelMode(t *testing.T) {
 	}
 }
 
+func TestOnboardingDraftAnswersCommandUsesCurrentNonDetentCheckoutAsTarget(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	wantTargetRoot := canonicalOnboardingTestPath(t, targetRoot)
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "--config", filepath.Join(t.TempDir(), "global.yaml"), "onboarding", "draft-answers"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Status                         string   `json:"status"`
+		CustomerIDCandidate            string   `json:"customer_id_candidate"`
+		DetentProjectIDCandidate       string   `json:"detent_project_id_candidate"`
+		TargetRepositoryCandidate      string   `json:"target_repository_candidate"`
+		TargetSourceRootCandidate      string   `json:"target_source_root_candidate"`
+		ReferenceRepositoriesCandidate []string `json:"reference_repositories_candidate"`
+		DetentOnboardingModeCandidate  string   `json:"detent_onboarding_mode_candidate"`
+		Confidence                     string   `json:"confidence"`
+		Notes                          []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Status != "draft" {
+		t.Fatalf("status = %q, want draft", got.Status)
+	}
+	if got.CustomerIDCandidate != "acme" || got.DetentProjectIDCandidate != "api" {
+		t.Fatalf("identity candidates = %#v, want customer acme and project api", got)
+	}
+	if got.TargetRepositoryCandidate != "acme/api" || got.TargetSourceRootCandidate != wantTargetRoot {
+		t.Fatalf("target candidates = %#v, want current checkout", got)
+	}
+	if len(got.ReferenceRepositoriesCandidate) != 1 || got.ReferenceRepositoriesCandidate[0] != "digitaldrywood/detent" {
+		t.Fatalf("reference repositories = %#v, want Detent source reference", got.ReferenceRepositoriesCandidate)
+	}
+	if got.DetentOnboardingModeCandidate != "new-install" {
+		t.Fatalf("detent onboarding mode = %q, want new-install", got.DetentOnboardingModeCandidate)
+	}
+	if got.Confidence == "" || len(got.Notes) == 0 {
+		t.Fatalf("confidence/notes = %q/%#v, want review guidance", got.Confidence, got.Notes)
+	}
+}
+
+func TestOnboardingDraftAnswersCommandRequiresExplicitTargetFromDetentSourceCheckout(t *testing.T) {
+	sourceRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/detent.git")
+	t.Chdir(sourceRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", filepath.Join(t.TempDir(), "global.yaml"), "onboarding", "draft-answers"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want explicit target validation error")
+	}
+	if !strings.Contains(err.Error(), "current checkout is the Detent source repository") ||
+		!strings.Contains(err.Error(), "--target-source-root") {
+		t.Fatalf("Execute() error = %q, want explicit target guidance", err.Error())
+	}
+}
+
+func TestOnboardingDraftAnswersCommandParsesGitHubRemoteFormats(t *testing.T) {
+	t.Chdir(t.TempDir())
+
+	tests := []struct {
+		name       string
+		remote     string
+		repository string
+	}{
+		{name: "ssh", remote: "git@github.com:acme/api.git", repository: "acme/api"},
+		{name: "https", remote: "https://github.com/acme/web.git", repository: "acme/web"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetRoot := initOnboardingGitRepository(t, tt.remote)
+			wantTargetRoot := canonicalOnboardingTestPath(t, targetRoot)
+			cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{
+				"--format", "json",
+				"--config", filepath.Join(t.TempDir(), "global.yaml"),
+				"onboarding", "draft-answers",
+				"--target-source-root", targetRoot,
+			})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v", err)
+			}
+
+			var got struct {
+				TargetRepositoryCandidate string `json:"target_repository_candidate"`
+				TargetSourceRootCandidate string `json:"target_source_root_candidate"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			if got.TargetRepositoryCandidate != tt.repository || got.TargetSourceRootCandidate != wantTargetRoot {
+				t.Fatalf("target candidates = %#v, want %s at %s", got, tt.repository, wantTargetRoot)
+			}
+		})
+	}
+}
+
+func TestOnboardingDraftAnswersCommandNotesProjectIDCollision(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	otherRoot := initOnboardingGitRepository(t, "https://github.com/acme/other.git")
+	configPath := writeOnboardingGlobalConfig(t, []globalconfig.Project{{
+		ID:          "api",
+		Workflow:    "WORKFLOW.md",
+		WorkflowRef: "origin/main",
+		Workdir:     otherRoot,
+		Weight:      1,
+	}})
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "--config", configPath, "onboarding", "draft-answers"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		DetentProjectIDCandidate      string   `json:"detent_project_id_candidate"`
+		DetentOnboardingModeCandidate string   `json:"detent_onboarding_mode_candidate"`
+		RegisteredProjectIDs          []string `json:"registered_project_ids"`
+		Notes                         []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.DetentProjectIDCandidate != "api" || got.DetentOnboardingModeCandidate != "add-project" {
+		t.Fatalf("draft = %#v, want colliding api candidate for add-project", got)
+	}
+	if len(got.RegisteredProjectIDs) != 1 || got.RegisteredProjectIDs[0] != "api" {
+		t.Fatalf("registered project ids = %#v, want api", got.RegisteredProjectIDs)
+	}
+	if !containsSubstring(got.Notes, `project id candidate "api" already exists`) {
+		t.Fatalf("notes = %#v, want project id collision note", got.Notes)
+	}
+}
+
+func TestOnboardingDraftAnswersCommandWritesUnconfirmedAnswers(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	wantTargetRoot := canonicalOnboardingTestPath(t, targetRoot)
+	answersPath := filepath.Join(t.TempDir(), "answers.env")
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"--config", filepath.Join(t.TempDir(), "global.yaml"),
+		"onboarding", "draft-answers",
+		"--answers", answersPath,
+		"--write",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	raw, err := os.ReadFile(answersPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(raw)
+	for _, want := range []string{
+		"CUSTOMER_ID=acme",
+		"DETENT_PROJECT_ID=api",
+		"TARGET_REPOSITORY=acme/api",
+		"TARGET_SOURCE_ROOT=" + wantTargetRoot,
+		"REFERENCE_REPOSITORIES=digitaldrywood/detent",
+		"DETENT_ONBOARDING_MODE=new-install",
+		"IDENTITY_CONFIRMED=false",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("answers.env missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, "IDENTITY_CONFIRMED=true") {
+		t.Fatalf("answers.env must not confirm identity:\n%s", content)
+	}
+}
+
 func validIdentityOnboardingAnswers(t *testing.T) string {
 	t.Helper()
 
@@ -269,6 +468,44 @@ func initOnboardingGitRepository(t *testing.T, remote string) string {
 	runGit(t, dir, "init")
 	runGit(t, dir, "remote", "add", "origin", remote)
 	return dir
+}
+
+func writeOnboardingGlobalConfig(t *testing.T, projects []globalconfig.Project) string {
+	t.Helper()
+
+	path := filepath.Join(t.TempDir(), "global.yaml")
+	cfg, err := globalconfig.DefaultAt(path)
+	if err != nil {
+		t.Fatalf("DefaultAt() error = %v", err)
+	}
+	cfg.Projects = projects
+	if err := globalconfig.Write(path, cfg, globalconfig.WithProjectPathLiterals()); err != nil {
+		t.Fatalf("Write() error = %v", err)
+	}
+	return path
+}
+
+func canonicalOnboardingTestPath(t *testing.T, path string) string {
+	t.Helper()
+
+	evaluated, err := filepath.EvalSymlinks(path)
+	if err == nil {
+		return filepath.Clean(evaluated)
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		t.Fatalf("Abs() error = %v", err)
+	}
+	return filepath.Clean(absolute)
+}
+
+func containsSubstring(values []string, want string) bool {
+	for _, value := range values {
+		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
 }
 
 func runGit(t *testing.T, dir string, args ...string) {

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -62,6 +62,8 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	}
 
 	for _, want := range []string{
+		`detent onboarding draft-answers --output pretty`,
+		`detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write`,
 		"CUSTOMER_ID=<customer-or-workstream-id>",
 		"DETENT_PROJECT_ID=<local-detent-project-id>",
 		"TARGET_REPOSITORY=<repo-owner>/<repo-name>",
@@ -75,6 +77,8 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 		assertContains(t, onboarding, want)
 	}
 
+	assertContains(t, readme, "detent onboarding draft-answers --output pretty")
+	assertContains(t, readme, `detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write`)
 	assertContains(t, readme, "Distinguish reference repositories from the target repository")
 	assertContains(t, readme, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`)
 	assertContains(t, readme, "Ask and record `GITHUB_MODE` explicitly")


### PR DESCRIPTION
## Summary

- Add `detent onboarding draft-answers` for local, non-mutating identity candidate inference.
- Support explicit target roots, SSH/HTTPS GitHub remotes, config project collision notes, and unconfirmed `answers.env` writes.
- Update README and Phase 0.5 onboarding docs to use the command instead of prose-only inference.

Fixes #617

## Test Plan

- [x] `go test ./internal/cli -run 'TestOnboarding(DraftAnswers|ValidateAnswers)Command'`
- [x] `go test . -run TestOnboardingDocs`
- [x] `go test ./internal/cli`
- [x] `make check`