### PR TITLE
feat(onboarding): improve draft id heuristics

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -250,8 +250,8 @@ project id when it is the same target repository or source root; use a short
 non-colliding variant only when the id belongs to a different target. The draft
 explains the collision. It proposes `CUSTOMER_ID` from the owner when that is
 the clearest stable workstream id, or from a repo-name/workstream heuristic when
-the owner is too broad. `CUSTOMER_ID` is only a stable local workstream id, not
-a billing account or GitHub organization requirement.
+the owner is too broad. `CUSTOMER_ID` is only a stable local grouping id, not a
+billing account or GitHub organization requirement.
 
 If the current working directory is the canonical Detent source checkout, do not
 propose Detent as the target unless the operator explicitly says they are
@@ -273,14 +273,20 @@ Present the candidate in human-facing language first, then show the
 ```text
 I found a likely target checkout from the current shell:
 
-Customer/workstream: `digitaldrywood`
+Customer/workstream: `creswoodcorners`
 Project id: `creswoodcorners-phone`
 Target repository: `digitaldrywood/creswoodcorners-phone`
 Source checkout: `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`
 Reference repositories: `digitaldrywood/detent`
 Onboarding mode: `add-project`
 
-`CUSTOMER_ID` is only a stable local workstream id for this Detent install. I
+customer_id_source=repo_prefix
+customer_id_confidence=medium
+detent_project_id_source=repo_name
+confidence=medium
+Customer/workstream alternatives: `digitaldrywood`
+
+`CUSTOMER_ID` is only a stable local grouping id for this Detent install. I
 will not inspect target labels, issues, boards, `WORKFLOW.md`, validation
 commands, or runtime docs until you confirm this identity and the identity
 validator passes. Is this the target you want to onboard?

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -53,7 +53,12 @@ type onboardingDraftAnswersResult struct {
 	AnswersPath                    string   `json:"answers_path,omitempty"`
 	Written                        bool     `json:"written"`
 	CustomerIDCandidate            string   `json:"customer_id_candidate"`
+	CustomerIDSource               string   `json:"customer_id_source"`
+	CustomerIDConfidence           string   `json:"customer_id_confidence"`
+	CustomerIDReviewRequired       bool     `json:"customer_id_review_required"`
+	CustomerIDAlternatives         []string `json:"customer_id_alternatives"`
 	DetentProjectIDCandidate       string   `json:"detent_project_id_candidate"`
+	DetentProjectIDSource          string   `json:"detent_project_id_source"`
 	TargetRepositoryCandidate      string   `json:"target_repository_candidate"`
 	TargetSourceRootCandidate      string   `json:"target_source_root_candidate"`
 	ReferenceRepositoriesCandidate []string `json:"reference_repositories_candidate"`
@@ -75,10 +80,21 @@ type onboardingAnswers struct {
 type onboardingDraftAnswersConfig struct {
 	AnswersPath      string
 	ConfigPath       string
+	CustomerID       string
+	DetentProjectID  string
 	TargetSourceRoot string
 	DetentSourceRoot string
 	Write            bool
 	Options          options
+}
+
+type onboardingCustomerIDCandidate struct {
+	ID             string
+	Source         string
+	Confidence     string
+	ReviewRequired bool
+	Alternatives   []string
+	Notes          []string
 }
 
 func newOnboardingCommand(configPath *string, opts options) *cobra.Command {
@@ -96,7 +112,9 @@ func newOnboardingCommand(configPath *string, opts options) *cobra.Command {
 
 func newOnboardingDraftAnswersCommand(configPath *string, opts options) *cobra.Command {
 	var answersPath string
+	var customerID string
 	var detentSourceRoot string
+	var detentProjectID string
 	var output string
 	var targetSourceRoot string
 	var write bool
@@ -119,6 +137,8 @@ func newOnboardingDraftAnswersCommand(configPath *string, opts options) *cobra.C
 			}
 			cfg := onboardingDraftAnswersConfig{
 				AnswersPath:      answersPath,
+				CustomerID:       customerID,
+				DetentProjectID:  detentProjectID,
 				TargetSourceRoot: targetSourceRoot,
 				DetentSourceRoot: detentSourceRoot,
 				Write:            write,
@@ -143,6 +163,8 @@ func newOnboardingDraftAnswersCommand(configPath *string, opts options) *cobra.C
 		},
 	}
 	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
+	cmd.Flags().StringVar(&customerID, "customer-id", "", "explicit customer/workstream id candidate")
+	cmd.Flags().StringVar(&detentProjectID, "detent-project-id", "", "explicit Detent project id candidate")
 	cmd.Flags().StringVar(&targetSourceRoot, "target-source-root", "", "explicit target git checkout root")
 	cmd.Flags().StringVar(&detentSourceRoot, "detent-source-root", "", "explicit Detent source checkout root")
 	cmd.Flags().StringVar(&output, "output", "", "output format: pretty or json")
@@ -217,11 +239,25 @@ func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfi
 		return onboardingDraftAnswersResult{}, err
 	}
 
+	customerCandidate, err := onboardingCustomerIDFromRepository(targetRepository, cfg.CustomerID)
+	if err != nil {
+		return onboardingDraftAnswersResult{}, err
+	}
+	projectIDCandidate, projectIDSource, err := onboardingDetentProjectIDFromRepository(targetRepository, cfg.DetentProjectID)
+	if err != nil {
+		return onboardingDraftAnswersResult{}, err
+	}
+
 	result := onboardingDraftAnswersResult{
 		Status:                    "draft",
 		AnswersPath:               strings.TrimSpace(cfg.AnswersPath),
-		CustomerIDCandidate:       repositoryOwner(targetRepository),
-		DetentProjectIDCandidate:  repositoryName(targetRepository),
+		CustomerIDCandidate:       customerCandidate.ID,
+		CustomerIDSource:          customerCandidate.Source,
+		CustomerIDConfidence:      customerCandidate.Confidence,
+		CustomerIDReviewRequired:  customerCandidate.ReviewRequired,
+		CustomerIDAlternatives:    customerCandidate.Alternatives,
+		DetentProjectIDCandidate:  projectIDCandidate,
+		DetentProjectIDSource:     projectIDSource,
 		TargetRepositoryCandidate: targetRepository,
 		TargetSourceRootCandidate: targetRoot,
 		ConfigPath:                resolution.Path,
@@ -232,6 +268,7 @@ func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfi
 			"review all candidates with the operator before setting IDENTITY_CONFIRMED=true",
 		},
 	}
+	result.Notes = append(result.Notes, customerCandidate.Notes...)
 
 	result.ReferenceRepositoriesCandidate = onboardingReferenceRepositoryCandidates(ctx, cfg.DetentSourceRoot, targetRepository, &result.Notes)
 	global, installed, err := readOnboardingDraftConfigEvidence(resolution.Path, opts)
@@ -249,6 +286,9 @@ func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfi
 		result.Notes = append(result.Notes, "no readable global config was found, so this looks like a new-install candidate")
 	}
 	if containsOnboardingReviewNote(result.Notes) {
+		result.Confidence = "needs-review"
+	}
+	if result.CustomerIDReviewRequired {
 		result.Confidence = "needs-review"
 	}
 	return result, nil
@@ -402,16 +442,150 @@ func repositoryName(repository string) string {
 	return name
 }
 
+func onboardingCustomerIDFromRepository(repository string, override string) (onboardingCustomerIDCandidate, error) {
+	override = strings.TrimSpace(override)
+	owner := repositoryOwner(repository)
+	name := repositoryName(repository)
+	if override != "" {
+		if !onboardingAnswerIdentifierPattern.MatchString(override) {
+			return onboardingCustomerIDCandidate{}, NewValidationError(
+				"--customer-id must contain only letters, digits, underscore, dot, or hyphen",
+				"Pass a stable local customer/workstream id such as --customer-id creswoodcorners.",
+				nil,
+			)
+		}
+		return onboardingCustomerIDCandidate{
+			ID:         override,
+			Source:     "override",
+			Confidence: "explicit",
+			Notes:      []string{fmt.Sprintf("customer id candidate %q came from --customer-id", override)},
+		}, nil
+	}
+
+	prefix, suffix, hasPrefix := repositoryCustomerPrefix(name)
+	if hasPrefix && !strings.EqualFold(prefix, owner) {
+		return onboardingCustomerIDCandidate{
+			ID:           prefix,
+			Source:       "repo_prefix",
+			Confidence:   "medium",
+			Alternatives: onboardingCandidateAlternatives(owner),
+			Notes: []string{
+				fmt.Sprintf("customer id candidate %q came from repository prefix before suffix %q", prefix, suffix),
+			},
+		}, nil
+	}
+
+	if ownerLooksSharedOperator(owner) {
+		return onboardingCustomerIDCandidate{
+			ID:             name,
+			Source:         "repo_name",
+			Confidence:     "needs-review",
+			ReviewRequired: true,
+			Alternatives:   onboardingCandidateAlternatives(owner),
+			Notes: []string{
+				fmt.Sprintf("customer id candidate needs operator review because owner %s looks like a shared operator", owner),
+			},
+		}, nil
+	}
+
+	return onboardingCustomerIDCandidate{
+		ID:         owner,
+		Source:     "owner",
+		Confidence: "medium",
+		Notes:      []string{fmt.Sprintf("customer id candidate %q came from repository owner", owner)},
+	}, nil
+}
+
+func onboardingDetentProjectIDFromRepository(repository string, override string) (string, string, error) {
+	override = strings.TrimSpace(override)
+	if override == "" {
+		return repositoryName(repository), "repo_name", nil
+	}
+	if !onboardingAnswerIdentifierPattern.MatchString(override) {
+		return "", "", NewValidationError(
+			"--detent-project-id must contain only letters, digits, underscore, dot, or hyphen",
+			"Pass a stable local Detent project id such as --detent-project-id phone.",
+			nil,
+		)
+	}
+	return override, "override", nil
+}
+
+func repositoryCustomerPrefix(name string) (string, string, bool) {
+	parts := strings.Split(strings.TrimSpace(name), "-")
+	if len(parts) < 2 {
+		return "", "", false
+	}
+	suffix := strings.ToLower(parts[len(parts)-1])
+	if !repositoryProductSuffix(suffix) {
+		return "", "", false
+	}
+	prefix := strings.Join(parts[:len(parts)-1], "-")
+	if prefix == "" || !onboardingAnswerIdentifierPattern.MatchString(prefix) {
+		return "", "", false
+	}
+	return prefix, suffix, true
+}
+
+func repositoryProductSuffix(suffix string) bool {
+	switch suffix {
+	case "admin", "agent", "api", "app", "backend", "bot", "cli", "dashboard", "docs", "frontend",
+		"hub", "infra", "ios", "mobile", "ops", "phone", "portal", "service", "site", "web",
+		"worker":
+		return true
+	default:
+		return false
+	}
+}
+
+func ownerLooksSharedOperator(owner string) bool {
+	owner = strings.ToLower(strings.TrimSpace(owner))
+	if owner == "digitaldrywood" || owner == "digital-drywood" {
+		return true
+	}
+	for _, marker := range []string{"agency", "consulting", "labs", "studio", "solutions"} {
+		if strings.Contains(owner, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+func onboardingCandidateAlternatives(candidates ...string) []string {
+	alternatives := make([]string, 0, len(candidates))
+	seen := make(map[string]bool, len(candidates))
+	for _, candidate := range candidates {
+		candidate = strings.TrimSpace(candidate)
+		if candidate == "" || seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		alternatives = append(alternatives, candidate)
+	}
+	return alternatives
+}
+
 func writeOnboardingDraftAnswersPretty(w io.Writer, result onboardingDraftAnswersResult) error {
 	lines := []string{
-		"Draft onboarding identity answers:",
-		"customer_id_candidate: " + result.CustomerIDCandidate,
-		"detent_project_id_candidate: " + result.DetentProjectIDCandidate,
-		"target_repository_candidate: " + result.TargetRepositoryCandidate,
-		"target_source_root_candidate: " + result.TargetSourceRootCandidate,
-		"reference_repositories_candidate: " + strings.Join(result.ReferenceRepositoriesCandidate, ","),
-		"detent_onboarding_mode_candidate: " + result.DetentOnboardingModeCandidate,
-		"confidence: " + result.Confidence,
+		"I found a likely target checkout from the current shell:",
+		"",
+		fmt.Sprintf("Customer/workstream: `%s`", result.CustomerIDCandidate),
+		fmt.Sprintf("Project id: `%s`", result.DetentProjectIDCandidate),
+		fmt.Sprintf("Target repository: `%s`", result.TargetRepositoryCandidate),
+		fmt.Sprintf("Source checkout: `%s`", result.TargetSourceRootCandidate),
+		fmt.Sprintf("Reference repositories: `%s`", strings.Join(result.ReferenceRepositoriesCandidate, ",")),
+		fmt.Sprintf("Onboarding mode: `%s`", result.DetentOnboardingModeCandidate),
+		"",
+		"customer_id_source=" + result.CustomerIDSource,
+		"customer_id_confidence=" + result.CustomerIDConfidence,
+		"detent_project_id_source=" + result.DetentProjectIDSource,
+		"confidence=" + result.Confidence,
+	}
+	if len(result.CustomerIDAlternatives) > 0 {
+		lines = append(lines, "Customer/workstream alternatives: "+onboardingPrettyList(result.CustomerIDAlternatives))
+	}
+	if result.CustomerIDReviewRequired {
+		lines = append(lines, "Customer/workstream requires operator review before identity confirmation.")
 	}
 	if result.ConfigPath != "" {
 		lines = append(lines, "config_path: "+result.ConfigPath)
@@ -422,7 +596,16 @@ func writeOnboardingDraftAnswersPretty(w io.Writer, result onboardingDraftAnswer
 	if result.Written {
 		lines = append(lines, "wrote_answers: "+result.AnswersPath)
 	}
+	lines = append(lines,
+		"",
+		"`CUSTOMER_ID` is only a stable local grouping id for this Detent install.",
+		"I will not inspect target labels, issues, boards, WORKFLOW.md, validation commands, or runtime docs until you confirm this identity and the identity validator passes.",
+		"",
+		"answers.env preview:",
+	)
+	lines = append(lines, strings.Split(strings.TrimSpace(buildOnboardingDraftAnswersContent(nil, result)), "\n")...)
 	if len(result.Notes) > 0 {
+		lines = append(lines, "")
 		lines = append(lines, "notes:")
 		for _, note := range result.Notes {
 			lines = append(lines, "- "+note)
@@ -430,6 +613,16 @@ func writeOnboardingDraftAnswersPretty(w io.Writer, result onboardingDraftAnswer
 	}
 	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))
 	return err
+}
+
+func onboardingPrettyList(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			quoted = append(quoted, "`"+value+"`")
+		}
+	}
+	return strings.Join(quoted, ", ")
 }
 
 func writeOnboardingDraftAnswers(path string, result onboardingDraftAnswersResult) error {

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -463,19 +463,18 @@ func onboardingCustomerIDFromRepository(repository string, override string) (onb
 	}
 
 	prefix, suffix, hasPrefix := repositoryCustomerPrefix(name)
-	if hasPrefix && !strings.EqualFold(prefix, owner) {
-		return onboardingCustomerIDCandidate{
-			ID:           prefix,
-			Source:       "repo_prefix",
-			Confidence:   "medium",
-			Alternatives: onboardingCandidateAlternatives(owner),
-			Notes: []string{
-				fmt.Sprintf("customer id candidate %q came from repository prefix before suffix %q", prefix, suffix),
-			},
-		}, nil
-	}
-
 	if ownerLooksSharedOperator(owner) {
+		if hasPrefix && !strings.EqualFold(prefix, owner) {
+			return onboardingCustomerIDCandidate{
+				ID:           prefix,
+				Source:       "repo_prefix",
+				Confidence:   "medium",
+				Alternatives: onboardingCandidateAlternatives(owner),
+				Notes: []string{
+					fmt.Sprintf("customer id candidate %q came from repository prefix before suffix %q", prefix, suffix),
+				},
+			}, nil
+		}
 		return onboardingCustomerIDCandidate{
 			ID:             name,
 			Source:         "repo_name",

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -335,6 +335,43 @@ func TestOnboardingDraftAnswersCommandPrefersRepoPrefixForSharedOwner(t *testing
 	}
 }
 
+func TestOnboardingDraftAnswersCommandKeepsNormalOwnerForProductSuffixRepo(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/payments-api.git")
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "--config", filepath.Join(t.TempDir(), "global.yaml"), "onboarding", "draft-answers"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		CustomerIDCandidate      string `json:"customer_id_candidate"`
+		CustomerIDSource         string `json:"customer_id_source"`
+		CustomerIDConfidence     string `json:"customer_id_confidence"`
+		CustomerIDReviewRequired bool   `json:"customer_id_review_required"`
+		DetentProjectIDCandidate string `json:"detent_project_id_candidate"`
+		DetentProjectIDSource    string `json:"detent_project_id_source"`
+		Confidence               string `json:"confidence"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.CustomerIDCandidate != "acme" || got.CustomerIDSource != "owner" {
+		t.Fatalf("customer id metadata = %#v, want normal owner candidate", got)
+	}
+	if got.CustomerIDConfidence != "medium" || got.CustomerIDReviewRequired || got.Confidence != "medium" {
+		t.Fatalf("confidence = customer %q review %t overall %q, want medium owner draft", got.CustomerIDConfidence, got.CustomerIDReviewRequired, got.Confidence)
+	}
+	if got.DetentProjectIDCandidate != "payments-api" || got.DetentProjectIDSource != "repo_name" {
+		t.Fatalf("project id metadata = %#v, want repo-name project", got)
+	}
+}
+
 func TestOnboardingDraftAnswersCommandMarksSharedOwnerAmbiguity(t *testing.T) {
 	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/service.git")
 	t.Chdir(targetRoot)

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -286,6 +286,190 @@ func TestOnboardingDraftAnswersCommandUsesCurrentNonDetentCheckoutAsTarget(t *te
 	}
 }
 
+func TestOnboardingDraftAnswersCommandPrefersRepoPrefixForSharedOwner(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/creswoodcorners-phone.git")
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "--config", filepath.Join(t.TempDir(), "global.yaml"), "onboarding", "draft-answers"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		CustomerIDCandidate       string   `json:"customer_id_candidate"`
+		CustomerIDSource          string   `json:"customer_id_source"`
+		CustomerIDConfidence      string   `json:"customer_id_confidence"`
+		CustomerIDReviewRequired  bool     `json:"customer_id_review_required"`
+		CustomerIDAlternatives    []string `json:"customer_id_alternatives"`
+		DetentProjectIDCandidate  string   `json:"detent_project_id_candidate"`
+		DetentProjectIDSource     string   `json:"detent_project_id_source"`
+		TargetRepositoryCandidate string   `json:"target_repository_candidate"`
+		Confidence                string   `json:"confidence"`
+		Notes                     []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.CustomerIDCandidate != "creswoodcorners" {
+		t.Fatalf("customer id candidate = %q, want repo prefix creswoodcorners", got.CustomerIDCandidate)
+	}
+	if got.CustomerIDSource != "repo_prefix" || got.CustomerIDConfidence != "medium" || got.CustomerIDReviewRequired {
+		t.Fatalf("customer id metadata = source %q confidence %q review %t, want repo_prefix medium without ambiguity", got.CustomerIDSource, got.CustomerIDConfidence, got.CustomerIDReviewRequired)
+	}
+	if !containsString(got.CustomerIDAlternatives, "digitaldrywood") {
+		t.Fatalf("customer id alternatives = %#v, want owner alternative", got.CustomerIDAlternatives)
+	}
+	if got.DetentProjectIDCandidate != "creswoodcorners-phone" || got.DetentProjectIDSource != "repo_name" {
+		t.Fatalf("project id metadata = %#v, want repo-name project", got)
+	}
+	if got.TargetRepositoryCandidate != "digitaldrywood/creswoodcorners-phone" || got.Confidence != "medium" {
+		t.Fatalf("draft result = %#v, want medium-confidence target repository draft", got)
+	}
+	if !containsSubstring(got.Notes, `customer id candidate "creswoodcorners" came from repository prefix before suffix "phone"`) {
+		t.Fatalf("notes = %#v, want repo-prefix explanation", got.Notes)
+	}
+}
+
+func TestOnboardingDraftAnswersCommandMarksSharedOwnerAmbiguity(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/service.git")
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "--config", filepath.Join(t.TempDir(), "global.yaml"), "onboarding", "draft-answers"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		CustomerIDCandidate      string   `json:"customer_id_candidate"`
+		CustomerIDSource         string   `json:"customer_id_source"`
+		CustomerIDConfidence     string   `json:"customer_id_confidence"`
+		CustomerIDReviewRequired bool     `json:"customer_id_review_required"`
+		CustomerIDAlternatives   []string `json:"customer_id_alternatives"`
+		Confidence               string   `json:"confidence"`
+		Notes                    []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.CustomerIDCandidate != "service" || got.CustomerIDSource != "repo_name" {
+		t.Fatalf("customer id metadata = %#v, want repo-name candidate for shared owner", got)
+	}
+	if got.CustomerIDConfidence != "needs-review" || !got.CustomerIDReviewRequired || got.Confidence != "needs-review" {
+		t.Fatalf("confidence = customer %q review %t overall %q, want needs-review ambiguity", got.CustomerIDConfidence, got.CustomerIDReviewRequired, got.Confidence)
+	}
+	if !containsString(got.CustomerIDAlternatives, "digitaldrywood") {
+		t.Fatalf("customer id alternatives = %#v, want shared owner alternative", got.CustomerIDAlternatives)
+	}
+	if !containsSubstring(got.Notes, "customer id candidate needs operator review because owner digitaldrywood looks like a shared operator") {
+		t.Fatalf("notes = %#v, want shared-owner ambiguity note", got.Notes)
+	}
+}
+
+func TestOnboardingDraftAnswersCommandPrettyExplainsCustomerChoice(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/creswoodcorners-phone.git")
+	wantTargetRoot := canonicalOnboardingTestPath(t, targetRoot)
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--output", "pretty", "--config", filepath.Join(t.TempDir(), "global.yaml"), "onboarding", "draft-answers"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	for _, want := range []string{
+		"I found a likely target checkout from the current shell:",
+		"Customer/workstream: `creswoodcorners`",
+		"customer_id_source=repo_prefix",
+		"customer_id_confidence=medium",
+		"Customer/workstream alternatives: `digitaldrywood`",
+		"`CUSTOMER_ID` is only a stable local grouping id for this Detent install.",
+		"answers.env preview:",
+		"CUSTOMER_ID=creswoodcorners",
+		"DETENT_PROJECT_ID=creswoodcorners-phone",
+		"TARGET_REPOSITORY=digitaldrywood/creswoodcorners-phone",
+		"TARGET_SOURCE_ROOT=" + wantTargetRoot,
+		"IDENTITY_CONFIRMED=false",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("pretty output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestOnboardingDraftAnswersCommandAcceptsIdentityOverrides(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/creswoodcorners-phone.git")
+	answersPath := filepath.Join(t.TempDir(), "answers.env")
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"--config", filepath.Join(t.TempDir(), "global.yaml"),
+		"onboarding", "draft-answers",
+		"--customer-id", "creswood",
+		"--detent-project-id", "phone",
+		"--answers", answersPath,
+		"--write",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		CustomerIDCandidate      string `json:"customer_id_candidate"`
+		CustomerIDSource         string `json:"customer_id_source"`
+		CustomerIDConfidence     string `json:"customer_id_confidence"`
+		CustomerIDReviewRequired bool   `json:"customer_id_review_required"`
+		DetentProjectIDCandidate string `json:"detent_project_id_candidate"`
+		DetentProjectIDSource    string `json:"detent_project_id_source"`
+		Confidence               string `json:"confidence"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.CustomerIDCandidate != "creswood" || got.CustomerIDSource != "override" || got.CustomerIDConfidence != "explicit" || got.CustomerIDReviewRequired {
+		t.Fatalf("customer override metadata = %#v, want explicit override", got)
+	}
+	if got.DetentProjectIDCandidate != "phone" || got.DetentProjectIDSource != "override" || got.Confidence != "medium" {
+		t.Fatalf("project override metadata = %#v, want explicit project override with medium draft", got)
+	}
+
+	raw, err := os.ReadFile(answersPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(raw)
+	for _, want := range []string{
+		"CUSTOMER_ID=creswood",
+		"DETENT_PROJECT_ID=phone",
+		"TARGET_REPOSITORY=digitaldrywood/creswoodcorners-phone",
+		"IDENTITY_CONFIRMED=false",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("answers.env missing %q:\n%s", want, content)
+		}
+	}
+}
+
 func TestOnboardingDraftAnswersCommandRequiresExplicitTargetFromDetentSourceCheckout(t *testing.T) {
 	sourceRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/detent.git")
 	t.Chdir(sourceRoot)
@@ -502,6 +686,15 @@ func canonicalOnboardingTestPath(t *testing.T, path string) string {
 func containsSubstring(values []string, want string) bool {
 	for _, value := range values {
 		if strings.Contains(value, want) {
+			return true
+		}
+	}
+	return false
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
 			return true
 		}
 	}

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -136,11 +136,14 @@ func TestOnboardingDocsInferCurrentCheckoutCandidateBeforeRawFields(t *testing.T
 		"Current directory is `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`",
 		"Detent source checkout is `/home/loganlanou/projects/digitaldrywood/detent`",
 		"Onboarding mode is `add-project`",
-		"Customer/workstream: `digitaldrywood`",
+		"Customer/workstream: `creswoodcorners`",
 		"Project id: `creswoodcorners-phone`",
 		"Target repository: `digitaldrywood/creswoodcorners-phone`",
 		"Source checkout: `/home/loganlanou/projects/digitaldrywood/creswoodcorners-phone`",
-		"`CUSTOMER_ID` is only a stable local workstream id",
+		"customer_id_source=repo_prefix",
+		"customer_id_confidence=medium",
+		"Customer/workstream alternatives: `digitaldrywood`",
+		"`CUSTOMER_ID` is only a stable local grouping id",
 	} {
 		assertContainsWords(t, onboarding, want)
 	}


### PR DESCRIPTION
## Summary

- Prefer repository product-prefix customer/workstream ids for shared operator owners.
- Add customer/project source and confidence metadata plus a pretty `answers.env` preview.
- Document the updated onboarding draft example.

Fixes #627

## Test Plan

- [x] `go test ./internal/cli`
- [x] `go test . -run TestOnboardingDocsInferCurrentCheckoutCandidateBeforeRawFields`
- [x] `make check`