### PR TITLE
fix(onboarding): gate doctor write probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,9 +72,11 @@ with `detent version`, and defer `detent onboarding validate-answers` until the
 binary is available.
 
 For an existing install, find and verify the detent binary, config path, running
-service or dashboard, registered projects, GitHub auth, Codex auth, and doctor
-status before recommending changes. For a new install, follow the bootstrap flow
-and verify each step before moving on. For adding a project, treat existing
+service or dashboard, registered projects, GitHub auth, Codex auth, and
+read-only doctor status with `detent doctor --port 0` before recommending
+changes. Do not pass `--allow-write-probes` until the mutation gate passes and I
+explicitly confirm mutation. For a new install, follow the bootstrap flow and
+verify each step before moving on. For adding a project, treat existing
 registered projects as examples only; do not reuse tracker mode, status
 namespace, validation gate, dashboard bind, workspace root, scheduling priority,
 auto-promote policy, review policy, or mutation scope unless I explicitly
@@ -765,9 +767,9 @@ labels such as `documentation`, `bug`, or `enhancement`.
 The fleet `/kanban` board stays read-only, as do observer dashboards and
 shared dashboards where users should not mutate GitHub from Detent. For a
 trusted operator project board, set `server.kanban.mode: integration` after
-`detent doctor` proves writes: ProjectV2 status write, issue-field status
-write, or status-label update for the selected status source, plus issue/PR
-comment write:
+`detent doctor --allow-write-probes` proves writes: ProjectV2 status write,
+issue-field status write, or status-label update for the selected status
+source, plus issue/PR comment write:
 
 ```yaml
 server:
@@ -885,29 +887,34 @@ port: 4000
 5. Verify the setup before dispatching:
 
    ```sh
-   detent doctor
+   detent doctor --allow-write-probes
    ```
 
 `detent doctor` is a preflight check: config resolution, the SQLite database,
 the `codex` binary, GitHub auth mode, GitHub tracker readiness, git, and
 whether the server port is free. In ProjectV2 mode it checks project access,
-Status options, board item reads, repository issue/PR access, write probes, and
-rate-limit visibility. In issue-field mode it checks repository access, issue
-field discovery, Status option discovery, issue reads by field value, optional
-issue-field write probes, issue/PR comment write when integration-capable
-features are configured, and REST/GraphQL rate-limit visibility. In label mode
-it checks repository access, status label mappings, issue reads by configured
-status labels, optional status-label write probes, issue/PR comment write when
-integration-capable features are configured, and REST/GraphQL rate-limit
-visibility. Before
+Status options, board item reads, repository issue/PR access, and rate-limit
+visibility. In issue-field mode it checks repository access, issue field
+discovery, Status option discovery, issue reads by field value, and REST/GraphQL
+rate-limit visibility. In label mode it checks repository access, status label
+mappings, issue reads by configured status labels, and REST/GraphQL rate-limit
+visibility. By default doctor is read-only: if a configured workflow would run
+write probes, the report warns that they were skipped. Pass
+`--allow-write-probes` only after the onboarding mutation gate has passed and
+the operator has explicitly confirmed mutation. With that flag, ProjectV2 mode
+also checks write probes; issue-field mode checks optional issue-field write
+probes and issue/PR comment write when integration-capable features are
+configured; label mode checks optional status-label write probes and issue/PR
+comment write when integration-capable features are configured. Before
 starting Detent, fix any `FAIL` (missing `github_token: gh` or an
 unauthenticated `codex` are the usual culprits). Configure
-`tracker.write_probe_issue` with a scratch issue when you want doctor to prove
-write capabilities instead of reporting WARN for unproven writes. If Detent is
+`tracker.write_probe_issue` with a scratch issue when you want
+`detent doctor --allow-write-probes` to prove write capabilities. If Detent is
 already running on the configured port, the server-port check can fail because
 the live service owns the port; use `detent doctor --port 0` for the same
-config, toolchain, token, and database preflight without the port collision,
-then verify the live service with `/health`.
+read-only config, toolchain, token, and database preflight without the port
+collision, or `detent doctor --port 0 --allow-write-probes` after mutation
+authorization to prove writes, then verify the live service with `/health`.
 
 For Detent dogfood/self-tests that need a running server, start an isolated mock
 runtime instead of stopping or reusing the live process on `127.0.0.1:4000`:
@@ -1218,7 +1225,7 @@ repo is a real, working instance of this setup to copy from.
    [`WORKFLOW.label.md`](docs/templates/WORKFLOW.label.md).
    They set `server.kanban.mode: integration` for trusted project boards;
    change that to `read_only` for an observer or shared dashboard, or until
-   doctor write probes pass.
+   write probes pass under `detent doctor --allow-write-probes`.
 
    For ProjectV2 mode, set `tracker.project_slug` (your `PVT_` id). For
    boardless issue-field mode, set `tracker.github_status_source:
@@ -1258,7 +1265,7 @@ repo is a real, working instance of this setup to copy from.
 8. **Verify everything:**
 
    ```sh
-   detent doctor
+   detent doctor --allow-write-probes
    ```
 
    Every check must pass before starting Detent. If Detent is already running on
@@ -1267,7 +1274,7 @@ repo is a real, working instance of this setup to copy from.
    collision, then verify the running service:
 
    ```sh
-   detent doctor --port 0
+   detent doctor --port 0 --allow-write-probes
    curl -fsS http://127.0.0.1:4000/health | jq -e '.status == "ok" and .mode == "running"'
    ```
 
@@ -1319,12 +1326,13 @@ uses `repository: owner/name` and repository labels named by
 `status_label_prefix`; Detent reads issues by configured status labels and
 updates state by replacing the previous status label with the target one.
 Set `tracker.write_probe_issue` to a scratch issue already present on that
-ProjectV2 board or in the boardless repository if `detent doctor` should prove
-write operations by replaying existing values and sending non-mutating
-validation probes. In label mode, the probe issue must already have one
-configured status label so doctor can reapply it. Without a probe issue, doctor
-reports required write capabilities as WARN instead of inferring that broad
-token scopes are enough.
+ProjectV2 board or in the boardless repository if
+`detent doctor --allow-write-probes` should prove write operations by replaying
+existing values and sending validation probes. Plain `detent doctor` is
+read-only and reports that write probes were skipped. In label mode, the probe
+issue must already have one configured status label so doctor can reapply it.
+Without a probe issue, doctor reports required write capabilities as WARN
+instead of inferring that broad token scopes are enough.
 
 GitHub issue fields apply to issues, not pull requests. In issue-field mode,
 boardless status comes from the linked issue. In label mode, Detent treats
@@ -1469,11 +1477,12 @@ You choose where GitHub status lives; Detent fills in the rest.
 Boardless projects use Detent's own dashboard as the day-to-day board. The
 fleet `/kanban` board stays read-only because it is a cross-project observer
 surface. A trusted operator project board should use `integration` after
-`detent doctor` proves writes, so operators can move cards and post comments
-from `/projects/<id>/kanban`. Keep `read_only` for an observer or shared
-dashboard, or until doctor proves ProjectV2 status write in ProjectV2 mode,
-issue-field status write in issue-field mode, status-label update in label mode,
-and issue/PR comment write for comment forms.
+`detent doctor --allow-write-probes` proves writes, so operators can move cards
+and post comments from `/projects/<id>/kanban`. Keep `read_only` for an
+observer or shared dashboard, or until `detent doctor --allow-write-probes`
+proves ProjectV2 status write in ProjectV2 mode, issue-field status write in
+issue-field mode, status-label update in label mode, and issue/PR comment write
+for comment forms.
 
 ### Migration Notes
 
@@ -1488,9 +1497,9 @@ issue `Status` field and options, copy current issue statuses from the
 ProjectV2 board manually or with a one-off script outside Detent, then change
 the workflow to `github_status_source: issue_field` with `repository:
 owner/name`. Detent does not automatically migrate ProjectV2 items to issue
-fields. After the switch, run `detent doctor --port 0` and fix field discovery,
-option discovery, write-probe, comment-write, and rate-limit checks before
-dispatching.
+fields. After the switch, run `detent doctor --port 0 --allow-write-probes` and
+fix field discovery, option discovery, write-probe, comment-write, and
+rate-limit checks before dispatching.
 
 To switch a repository to boardless label mode, create status labels matching
 the effective workflow states, copy current issue statuses by applying exactly
@@ -1498,8 +1507,8 @@ one configured status label per issue, then change the workflow to
 `github_status_source: label` with `repository: owner/name` and
 `status_label_prefix: "detent:"`. Detent does not automatically migrate
 ProjectV2 items or issue-field values into labels. After the switch, run
-`detent doctor --port 0` and fix label mapping, issue reads by label,
-write-probe, comment-write, and rate-limit checks before dispatching.
+`detent doctor --port 0 --allow-write-probes` and fix label mapping, issue reads
+by label, write-probe, comment-write, and rate-limit checks before dispatching.
 
 ### Dependency workflows
 
@@ -1522,17 +1531,19 @@ the wait should be visible on the board.
   for display but will not be moved back to `Todo`. Human blockers without
   explicit dependency references stay blocked.
 
-Before you dispatch anything, run **`detent doctor`** — it checks config
+Before you dispatch anything, run **`detent doctor --allow-write-probes`** after
+mutation authorization — it checks config
 resolution, the database, the `codex` binary, GitHub auth mode, configured
 tracker access, repository issue/PR access, required write proofs, rate-limit
 visibility, git, and the server port. A clean pre-start `doctor` clears
 Detent's direct preflight.
 When a running Detent process already owns the configured port,
-`detent doctor --port 0` validates the config, database, tools, and token
-without treating the live listener as a blocker; pair it with `/health` on the
-actual service before dispatching more work. Do not dispatch from a failed
-doctor run unless the only failure is that expected live-port collision and
-`/health` is green. If Detent runs under a systemd user service, also verify the
+`detent doctor --port 0 --allow-write-probes` validates the config, database,
+tools, token, and write proofs without treating the live listener as a blocker;
+pair it with `/health` on the actual service before dispatching more work. Do
+not dispatch from a failed doctor run unless the only failure is that expected
+live-port collision and `/health` is green. If Detent runs under a systemd user
+service, also verify the
 service PATH resolves every command used by project hooks and validation gates;
 `doctor` checks Detent's direct dependencies, not repo-specific bootstrap tools.
 The onboarding runbook includes the service-context check.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -42,10 +42,11 @@ Classify the work into one of these modes:
   through tool installation and authentication, then continue with this runbook.
 - `existing-install`: Detent is already installed or a service/dashboard appears
   to be running. Verify the binary, config path, registered projects, service
-  health, GitHub auth, Codex auth, and `detent doctor` before proposing changes.
-  If the configured workflow has `tracker.write_probe_issue`, treat
-  `detent doctor` as mutating and defer that check until Phase 2.5 authorizes
-  GitHub mutations.
+  health, GitHub auth, Codex auth, and read-only `detent doctor --port 0`
+  before proposing changes. Do not pass `--allow-write-probes` during this
+  identity-safe verification; when a configured workflow has
+  `tracker.write_probe_issue`, defer doctor write probes until Phase 2.5
+  authorizes GitHub mutations.
 - `add-project`: An existing Detent install is present and the target repository
   is not registered yet. Reuse the existing `global.yaml`, preserve current
   runtime settings unless the human chooses otherwise, then create or adopt a
@@ -87,7 +88,8 @@ test -s "$ONBOARDING_DIR/mode-evidence.txt"
 
 If Detent appears to be running, verify the live service before changing config.
 Use the configured port when known, and use `detent doctor --port 0` when the
-live process already owns the dashboard port:
+live process already owns the dashboard port. This early doctor run is
+read-only; do not pass `--allow-write-probes` before Phase 2.5:
 
 ```sh
 detent doctor --port 0
@@ -766,12 +768,13 @@ mutations. Record explicit answers in `$ONBOARDING_DIR/answers.env`.
 5. **Kanban interaction.** Ask: "Should Detent's project Kanban be read-only or
    allow GitHub mutations from the dashboard?" Keep fleet `/kanban` read-only.
    For a project-scoped board on an operator-owned local or private Detent
-   instance, recommend `integration` after `detent doctor` proves the relevant
-   write probes. For a shared observer dashboard, or when write probes are
-   missing or failing, recommend `read_only` until writes are proven.
-   Integration mode requires doctor to prove ProjectV2 status write or
-   issue-field status write, or status-label update, plus issue/PR comment
-   write. Verify:
+   instance, recommend `integration` after
+   `detent doctor --allow-write-probes` proves the relevant write probes. For a
+   shared observer dashboard, or when write probes are missing or failing,
+   recommend `read_only` until writes are proven.
+   Integration mode requires `detent doctor --allow-write-probes` to prove
+   ProjectV2 status write or issue-field status write, or status-label update,
+   plus issue/PR comment write. Verify:
 
    ```sh
    printf '%s\n' \
@@ -1083,6 +1086,14 @@ case "$GITHUB_MODE" in
     exit 1
     ;;
 esac
+```
+
+Only after this gate passes and the operator has confirmed mutation may doctor
+run configured write probes. Use `--port 0` when an existing service already
+owns the dashboard port:
+
+```sh
+detent doctor --port 0 --allow-write-probes
 ```
 
 ## Phase 3 — Create Or Adopt The Status Source
@@ -1531,8 +1542,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    a trusted operator-owned local or private Detent instance. Keep fleet
    `/kanban` read-only; this setting only controls `/projects/<id>/kanban`.
    For a shared observer dashboard, or when write probes are not configured or
-   not passing, set `read_only` until `detent doctor` proves status write and
-   issue/PR comment write. Verify:
+   not passing, set `read_only` until `detent doctor --allow-write-probes`
+   proves status write and issue/PR comment write. Verify:
 
    ```yaml
    server:
@@ -1691,7 +1702,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    ```
 
 8. **Check the workflow contract before registration.** This is a structural
-   check; `detent doctor` in Phase 5 is the full preflight. Verify:
+   check; `detent doctor --allow-write-probes` in Phase 5 is the full
+   preflight. Verify:
 
    ```sh
    rg -n '^tracker:|project_slug:|^workspace:|source_root:|^agent:|max_concurrent_agents_by_state:|^gate:' \
@@ -1701,7 +1713,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 ## Phase 5 — Register The Project
 
 Before running `detent init`, `detent add-project`, mutating `global.yaml`, or
-running `detent doctor` with configured write probes, rerun:
+running `detent doctor --allow-write-probes` with configured write probes,
+rerun:
 
 ```sh
 test -f "$ONBOARDING_DIR/answers.env"
@@ -1806,7 +1819,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `github_app_id`, `github_app_installation_id`, and either
    `github_app_private_key` or `github_app_private_key_path`.
 
-4. **Run preflight until every check passes.** Fix every `FAIL`; do not
+4. **Run full preflight until every check passes.** Fix every `FAIL`; do not
    dispatch work from a failed doctor run. In ProjectV2 mode, confirm doctor
    reports project access, Status option discovery, repository issue/PR access,
    write probes when configured, and rate-limit visibility. In issue-field mode,
@@ -1822,7 +1835,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    permission without changing the issue's state. Verify:
 
    ```sh
-   detent doctor
+   detent doctor --allow-write-probes
    ```
 
 5. **Verify the systemd service PATH when Detent runs as a user service.**
@@ -1937,7 +1950,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    Run only when `GITHUB_MODE=issue_field`. Use `Backlog` for broad intake and
    `Todo` only for work that should dispatch immediately. Issue-field writes
    can trigger notifications and secondary rate limits, so keep broad edits
-   deliberate and use `detent doctor` to prove the write probe first. Verify:
+   deliberate and use `detent doctor --allow-write-probes` to prove the write
+   probe first. Verify:
 
    ```sh
    rg '^GITHUB_MODE=issue_field$' "$ONBOARDING_DIR/answers.env"
@@ -2079,8 +2093,9 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    is the last stop before Detent and the spawned agent start spending GraphQL
    budget for polling, workpad, status, PR, and review work. In boardless
    issue-field and label modes, review REST core and GraphQL visibility from
-   `detent doctor`; issue-field polling, status-label polling, and status writes
-   are REST-backed, while PR relationship checks can still use GraphQL. Verify:
+   read-only `detent doctor --port 0`; issue-field polling, status-label
+   polling, and status writes are REST-backed, while PR relationship checks can
+   still use GraphQL. Verify:
 
    ```sh
    # ProjectV2 mode:
@@ -2226,12 +2241,12 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    detent version
    ```
 
-2. **Run the preflight again.** `detent doctor` should pass before starting a
-   stopped instance because Phase 5 expects the configured server port to be
-   free:
+2. **Run the preflight again.** `detent doctor --allow-write-probes` should
+   pass before starting a stopped instance because Phase 5 expects the
+   configured server port to be free:
 
    ```sh
-   detent doctor
+   detent doctor --allow-write-probes
    ```
 
    If Detent is already running on the configured port, the server-port check
@@ -2240,7 +2255,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    verify the live service separately:
 
    ```sh
-   detent doctor --port 0
+   detent doctor --port 0 --allow-write-probes
    curl -fsS http://<dashboard-check-host>:<port>/health | jq -e '.status == "ok" and .mode == "running"'
    ```
 
@@ -2262,9 +2277,10 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `global config setting change requires restart` with the field name.
 
 4. **Hold dispatch on failed preflight.** Do not move new work to `Todo` from a
-   failed `detent doctor` run unless the only failure is the expected live-port
-   collision, `detent doctor --port 0` passes, and `/health` is green for the
-   running service.
+   failed `detent doctor --allow-write-probes` run unless the only failure is
+   the expected live-port collision,
+   `detent doctor --port 0 --allow-write-probes` passes, and `/health` is green
+   for the running service.
 
 ## Appendix
 
@@ -2290,10 +2306,10 @@ tracker:
 
 Detent does not automatically migrate ProjectV2 item statuses into issue
 fields. Copy existing statuses manually or with a one-off script outside
-Detent, then run `detent doctor --port 0` and fix repository access, issue
-field discovery, option discovery, write-probe, comment-write, and rate-limit
-checks before dispatching. GitHub issue fields apply to issues only, so linked
-PR cards derive status from the linked issue.
+Detent, then run `detent doctor --port 0 --allow-write-probes` and fix
+repository access, issue field discovery, option discovery, write-probe,
+comment-write, and rate-limit checks before dispatching. GitHub issue fields
+apply to issues only, so linked PR cards derive status from the linked issue.
 
 Switch to repository label mode only after the repository has status labels
 matching the effective workflow states. Change `WORKFLOW.md` to:
@@ -2310,10 +2326,11 @@ Detent does not automatically migrate ProjectV2 item statuses or issue-field
 values into labels. With `tracker.auto_provision` enabled, Detent creates
 missing prefixed status labels on startup, but it does not assign those labels
 to existing issues. Copy existing statuses by applying exactly one configured
-status label per issue, then run `detent doctor --port 0` and fix repository
-access, status label mappings, issue reads by label, write-probe,
-comment-write, and rate-limit checks before dispatching. GitHub status labels
-apply to issues only, so linked PR cards derive status from the linked issue.
+status label per issue, then run `detent doctor --port 0 --allow-write-probes`
+and fix repository access, status label mappings, issue reads by label,
+write-probe, comment-write, and rate-limit checks before dispatching. GitHub
+status labels apply to issues only, so linked PR cards derive status from the
+linked issue.
 
 ### Interview Answers To Config Keys
 
@@ -2324,7 +2341,7 @@ apply to issues only, so linked PR cards derive status from the linked issue.
 | Boardless repository | `tracker.repository` in `WORKFLOW.md` for issue-field and label modes. |
 | Boardless issue field | `tracker.status_field` in `WORKFLOW.md`; defaults to `Status` when omitted. |
 | Status label prefix | `tracker.status_label_prefix` in `WORKFLOW.md`; defaults to `detent:` for label mode. |
-| Kanban interaction | Fleet and observer boards stay read-only; trusted project boards use `integration` after doctor proves write permissions. |
+| Kanban interaction | Fleet and observer boards stay read-only; trusted project boards use `integration` after `detent doctor --allow-write-probes` proves write permissions. |
 | Project scheduling priority | `projects[].priority` in `global.yaml`. |
 | Project scheduling weight | `projects[].weight` in `global.yaml`. |
 | Project color | Optional `projects[].color` in `global.yaml`; missing colors are deterministic and appear in the sidebar and multi-project Kanban. |

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -152,12 +152,13 @@ func (p *doctorCheckProgress) Current() string {
 }
 
 type doctorConfig struct {
-	ConfigPath   string
-	Host         string
-	Flags        runtimeFlags
-	Output       io.Writer
-	CheckTimeout time.Duration
-	Build        buildinfo.Info
+	ConfigPath       string
+	Host             string
+	Flags            runtimeFlags
+	Output           io.Writer
+	CheckTimeout     time.Duration
+	Build            buildinfo.Info
+	AllowWriteProbes bool
 }
 
 type doctorStore interface {
@@ -201,6 +202,7 @@ func newDoctorCommand(configPath *string, env *string, logLevel *string, host *s
 
 func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
 	timeout := doctorCheckTimeout
+	allowWriteProbes := false
 	cmd := &cobra.Command{
 		Use:          "doctor",
 		Short:        "Run preflight health checks",
@@ -217,11 +219,12 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 				progressOut = cmd.ErrOrStderr()
 			}
 			report := runDoctor(cmd.Context(), doctorConfig{
-				ConfigPath:   derefString(configPath),
-				Host:         derefString(host),
-				Output:       progressOut,
-				CheckTimeout: timeout,
-				Build:        opts.build,
+				ConfigPath:       derefString(configPath),
+				Host:             derefString(host),
+				Output:           progressOut,
+				CheckTimeout:     timeout,
+				Build:            opts.build,
+				AllowWriteProbes: allowWriteProbes,
 				Flags: runtimeFlags{
 					Env:      runtimeStringFlag{Value: derefString(env), Set: flagChanged(cmd, "env")},
 					LogLevel: runtimeStringFlag{Value: derefString(logLevel), Set: flagChanged(cmd, "log-level")},
@@ -240,6 +243,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 		},
 	}
 	cmd.Flags().DurationVar(&timeout, "timeout", doctorCheckTimeout, "per-check timeout")
+	cmd.Flags().BoolVar(&allowWriteProbes, "allow-write-probes", false, "run configured GitHub write probes")
 	cmd.SetContext(withCommandOutputOptions(context.Background(), commandOutputOptions{
 		lookupEnv: opts.lookupEnv,
 		stdoutTTY: opts.stdoutTTY,
@@ -337,7 +341,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	if global != nil {
 		globalConfig := *global
 		githubToken := runtime.GitHubToken
-		jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken)...)
+		jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken, cfg.AllowWriteProbes)...)
 	}
 	jobs = append(jobs,
 		doctorCheckJob{
@@ -624,7 +628,7 @@ func checkDoctorDetentExecutable(build buildinfo.Info, deps doctorDeps) doctorCh
 	}
 }
 
-func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret) []doctorCheck {
+func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool) []doctorCheck {
 	if len(cfg.Projects) == 0 {
 		return []doctorCheck{
 			{
@@ -638,13 +642,13 @@ func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doct
 
 	checks := make([]doctorCheck, 0, len(cfg.Projects)*2)
 	for _, project := range cfg.Projects {
-		checks = append(checks, checkDoctorProject(ctx, project, deps, githubToken)...)
+		checks = append(checks, checkDoctorProject(ctx, project, deps, githubToken, allowWriteProbes)...)
 	}
 
 	return checks
 }
 
-func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret) []doctorCheckJob {
+func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool) []doctorCheckJob {
 	if len(cfg.Projects) == 0 {
 		return []doctorCheckJob{{
 			Name: "Project workflows",
@@ -669,15 +673,15 @@ func doctorProjectCheckJobs(cfg globalconfig.Config, deps doctorDeps, githubToke
 			Name:    "Project " + id + " checks",
 			Current: progress.Current,
 			Run: func(jobCtx context.Context) []doctorCheck {
-				return checkDoctorProjectWithProgress(jobCtx, project, deps, githubToken, progress.Set)
+				return checkDoctorProjectWithProgress(jobCtx, project, deps, githubToken, allowWriteProbes, progress.Set)
 			},
 		})
 	}
 	return jobs
 }
 
-func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps doctorDeps, githubToken RuntimeSecret) []doctorCheck {
-	return checkDoctorProjectWithProgress(ctx, project, deps, githubToken, nil)
+func checkDoctorProject(ctx context.Context, project globalconfig.Project, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool) []doctorCheck {
+	return checkDoctorProjectWithProgress(ctx, project, deps, githubToken, allowWriteProbes, nil)
 }
 
 func checkDoctorProjectWithProgress(
@@ -685,6 +689,7 @@ func checkDoctorProjectWithProgress(
 	project globalconfig.Project,
 	deps doctorDeps,
 	githubToken RuntimeSecret,
+	allowWriteProbes bool,
 	setCurrent func(string),
 ) []doctorCheck {
 	id := doctorProjectID(project)
@@ -783,7 +788,7 @@ func checkDoctorProjectWithProgress(
 	})
 	if workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHub {
 		setDoctorCurrentCheck("Project " + id + " GitHub readiness")
-		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot)...)
+		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
 }
@@ -2093,8 +2098,11 @@ func checkDoctorGitHubReadiness(
 	deps doctorDeps,
 	githubToken RuntimeSecret,
 	sourceRoot string,
+	allowWriteProbes bool,
 ) []doctorCheck {
-	checks, err := deps.githubReadiness(ctx, doctorGitHubConnectorConfig(cfg), doctorGitHubReadinessConfig(ctx, project, cfg, deps, githubToken, sourceRoot))
+	readiness := doctorGitHubReadinessConfig(ctx, project, cfg, deps, githubToken, sourceRoot)
+	readiness, writeProbeCheck := doctorGitHubReadinessWithWriteProbeAuthorization(id, readiness, allowWriteProbes)
+	checks, err := deps.githubReadiness(ctx, doctorGitHubConnectorConfig(cfg), readiness)
 	if err != nil {
 		return []doctorCheck{{
 			Name:   "Project " + id + " GitHub readiness",
@@ -2112,7 +2120,45 @@ func checkDoctorGitHubReadiness(
 			Hint:   check.Hint,
 		})
 	}
+	if writeProbeCheck != nil {
+		out = append(out, *writeProbeCheck)
+	}
 	return out
+}
+
+func doctorGitHubReadinessWithWriteProbeAuthorization(id string, cfg ghconnector.ReadinessConfig, allowWriteProbes bool) (ghconnector.ReadinessConfig, *doctorCheck) {
+	if allowWriteProbes || !doctorGitHubReadinessRequiresWrites(cfg) {
+		return cfg, nil
+	}
+
+	detail := "skipped; rerun detent doctor with --allow-write-probes after mutation authorization"
+	if probe := strings.TrimSpace(cfg.WriteProbeIssue); probe != "" {
+		detail = "skipped for tracker.write_probe_issue " + probe + "; rerun detent doctor with --allow-write-probes after mutation authorization"
+	}
+	check := doctorCheck{
+		Name:   "Project " + id + " GitHub write probes",
+		Status: doctorWarn,
+		Detail: detail,
+		Hint:   `Run detent onboarding validate-answers --phase mutation and get operator confirmation before enabling write probes.`,
+	}
+	cfg.RequireProjectStatusWrite = false
+	cfg.RequireIssueFieldStatusWrite = false
+	cfg.RequireLabelStatusWrite = false
+	cfg.RequireIssueComments = false
+	cfg.RequireAssigneeWrite = false
+	cfg.RequireIssueClose = false
+	cfg.ProjectFieldWrites = nil
+	return cfg, &check
+}
+
+func doctorGitHubReadinessRequiresWrites(cfg ghconnector.ReadinessConfig) bool {
+	return cfg.RequireProjectStatusWrite ||
+		cfg.RequireIssueFieldStatusWrite ||
+		cfg.RequireLabelStatusWrite ||
+		cfg.RequireIssueComments ||
+		cfg.RequireAssigneeWrite ||
+		cfg.RequireIssueClose ||
+		len(cfg.ProjectFieldWrites) > 0
 }
 
 func doctorGitHubConnectorConfig(cfg workflowconfig.Config) ghconnector.Config {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -156,7 +156,7 @@ func TestCheckDoctorProjects(t *testing.T) {
 				gitWorkTree: func(context.Context, string) error {
 					return tt.gitErr
 				},
-			}, RuntimeSecret{})
+			}, RuntimeSecret{}, false)
 			if len(got) != len(tt.wantStatus) {
 				t.Fatalf("len(checks) = %d, want %d: %#v", len(got), len(tt.wantStatus), got)
 			}
@@ -882,7 +882,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 			gotPath = path
 			return nil
 		},
-	}, RuntimeSecret{})
+	}, RuntimeSecret{}, false)
 
 	wantPath := filepath.Join(home, "repo")
 	if gotPath != wantPath {
@@ -890,6 +890,138 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	}
 	if len(checks) != 2 || checks[1].Status != doctorOK {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
+	}
+}
+
+func TestRunDoctorSkipsWriteProbesByDefaultForExistingConfiguredProject(t *testing.T) {
+	t.Parallel()
+
+	workflow := validDoctorWorkflow("/repo")
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	workflow.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+	workflow.Tracker.Repository = "digitaldrywood/detent"
+	workflow.Tracker.StatusLabelPrefix = "detent:"
+	workflow.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+	workflow.Tracker.ObservedStates = []string{"Human Review"}
+	workflow.Tracker.TerminalStates = []string{"Done"}
+	workflow.Tracker.WriteProbeIssue = "digitaldrywood/detent#1"
+	workflow.Server.Kanban.Mode = workflowconfig.KanbanModeIntegration
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	global := globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{{
+			ID:       "existing",
+			Workflow: "WORKFLOW.md",
+			Workdir:  "/repo",
+			Weight:   1,
+		}},
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+		return workflowconfig.Workflow{Config: workflow}, nil
+	}
+	deps.gitRemoteURL = func(context.Context, string) (string, error) {
+		return "https://github.com/digitaldrywood/detent.git", nil
+	}
+	deps.autoPromoteConnector = func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+		return &fakeDoctorAutoPromoteConnector{}, nil
+	}
+	var gotReadiness ghconnector.ReadinessConfig
+	deps.githubReadiness = func(_ context.Context, _ ghconnector.Config, readiness ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+		gotReadiness = readiness
+		return []ghconnector.ReadinessCheck{{
+			Name:   "GitHub status label issue read",
+			Status: ghconnector.ReadinessOK,
+			Detail: "read-only checks completed",
+		}}, nil
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:   configPath,
+		Output:       io.Discard,
+		CheckTimeout: time.Second,
+		Flags: runtimeFlags{
+			Port: runtimeIntFlag{Value: 0, Set: true},
+		},
+	}, successfulDoctorOptionsWithConfig(configPath, global), deps)
+
+	if doctorGitHubReadinessRequiresWrites(gotReadiness) {
+		t.Fatalf("readiness write requirements = %#v, want default doctor to skip write probes", gotReadiness)
+	}
+	assertDoctorCheck(t, report, "Project existing GitHub write probes", doctorWarn, "rerun detent doctor with --allow-write-probes after mutation authorization")
+}
+
+func TestDoctorCommandAllowWriteProbesFlagEnablesWriteReadiness(t *testing.T) {
+	t.Parallel()
+
+	workflow := validDoctorWorkflow("/repo")
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	workflow.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+	workflow.Tracker.Repository = "digitaldrywood/detent"
+	workflow.Tracker.StatusLabelPrefix = "detent:"
+	workflow.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+	workflow.Tracker.WriteProbeIssue = "digitaldrywood/detent#1"
+	workflow.Server.Kanban.Mode = workflowconfig.KanbanModeIntegration
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	global := globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{{
+			ID:       "existing",
+			Workflow: "WORKFLOW.md",
+			Workdir:  "/repo",
+			Weight:   1,
+		}},
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+		return workflowconfig.Workflow{Config: workflow}, nil
+	}
+	deps.gitRemoteURL = func(context.Context, string) (string, error) {
+		return "https://github.com/digitaldrywood/detent.git", nil
+	}
+	deps.autoPromoteConnector = func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+		return &fakeDoctorAutoPromoteConnector{}, nil
+	}
+	var gotReadiness ghconnector.ReadinessConfig
+	deps.githubReadiness = func(_ context.Context, _ ghconnector.Config, readiness ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+		gotReadiness = readiness
+		return []ghconnector.ReadinessCheck{{
+			Name:   "GitHub status label update",
+			Status: ghconnector.ReadinessOK,
+			Detail: "write probe requested",
+		}}, nil
+	}
+
+	configFlag := configPath
+	envFlag := ""
+	logLevelFlag := ""
+	hostFlag := ""
+	portFlag := 0
+	cmd := newDoctorCommandWithDeps(&configFlag, &envFlag, &logLevelFlag, &hostFlag, &portFlag, successfulDoctorOptionsWithConfig(configPath, global), deps)
+	cmd.SetArgs([]string{"--allow-write-probes"})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, stdout.String())
+	}
+	if !gotReadiness.RequireLabelStatusWrite || !gotReadiness.RequireIssueComments {
+		t.Fatalf("readiness write requirements = %#v, want write probes enabled by flag", gotReadiness)
 	}
 }
 
@@ -935,7 +1067,7 @@ func TestCheckDoctorProjectBuildsGitHubReadinessInventory(t *testing.T) {
 			gotReadiness = readinessCfg
 			return []ghconnector.ReadinessCheck{{Name: "GitHub auth path", Status: ghconnector.ReadinessOK, Detail: readinessCfg.AuthPath}}, nil
 		},
-	}, RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"})
+	}, RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"}, true)
 
 	if gotConnector.APIKey != "token" {
 		t.Fatalf("connector APIKey = %q, want injected runtime token", gotConnector.APIKey)
@@ -1008,7 +1140,7 @@ func TestCheckDoctorProjectBuildsGitHubIssueFieldReadinessInventory(t *testing.T
 			gotReadiness = readinessCfg
 			return []ghconnector.ReadinessCheck{{Name: "GitHub issue field access", Status: ghconnector.ReadinessOK, Detail: "read Status"}}, nil
 		},
-	}, RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"})
+	}, RuntimeSecret{Value: "token", Source: "github_token", ResolvedVia: "gh"}, true)
 
 	if gotConnector.ProjectSlug != "" {
 		t.Fatalf("connector ProjectSlug = %q, want empty in issue_field mode", gotConnector.ProjectSlug)
@@ -2125,7 +2257,7 @@ func TestDoctorProjectCheckJobTimeoutReportsCurrentInnerCheck(t *testing.T) {
 			<-releaseReadiness
 			return nil, nil
 		},
-	}, RuntimeSecret{Value: "token", Source: "github_token"})
+	}, RuntimeSecret{Value: "token", Source: "github_token"}, false)
 	if len(jobs) != 1 {
 		t.Fatalf("jobs len = %d, want 1", len(jobs))
 	}
@@ -2277,24 +2409,47 @@ func stringSliceContains(values []string, want string) bool {
 }
 
 func successfulDoctorOptions(configPath string) options {
+	return successfulDoctorOptionsWithConfig(configPath, globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{},
+	})
+}
+
+func successfulDoctorOptionsWithConfig(configPath string, cfg globalconfig.Config) options {
 	return options{
 		resolvePath: func(string) (globalconfig.PathResolution, error) {
 			return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
 		},
 		read: func(string) (globalconfig.Config, error) {
-			return globalconfig.Config{
-				Path:       configPath,
-				APIVersion: globalconfig.APIVersion,
-				Kind:       globalconfig.Kind,
-				Global: globalconfig.Settings{
-					MaxConcurrentAgents: 1,
-					Scheduling:          globalconfig.SchedulingWeighted,
-				},
-				Projects: []globalconfig.Project{},
-			}, nil
+			cfg.Path = configPath
+			return cfg, nil
 		},
 		stdoutTTY: func() bool { return true },
 	}
+}
+
+func assertDoctorCheck(t *testing.T, report doctorReport, name string, status doctorStatus, detail string) {
+	t.Helper()
+
+	for _, check := range report.Checks {
+		if check.Name != name {
+			continue
+		}
+		if check.Status != status {
+			t.Fatalf("%s status = %s, want %s", name, check.Status, status)
+		}
+		if !strings.Contains(check.Detail, detail) && !strings.Contains(check.Hint, detail) {
+			t.Fatalf("%s missing %q:\nDetail: %s\nHint: %s", name, detail, check.Detail, check.Hint)
+		}
+		return
+	}
+	t.Fatalf("missing doctor check %q in %#v", name, report.Checks)
 }
 
 func successfulDoctorDeps() doctorDeps {

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -28,10 +28,16 @@ func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
 	assertContains(t, onboarding, "rg '^PROJECT_NUMBER='")
 	assertContains(t, onboarding, "rg '^PROJECT_TITLE='")
 	assertContains(t, onboarding, "rg '^STATUS_LABEL_PREFIX='")
+	assertContainsWords(t, onboarding, "read-only `detent doctor --port 0` before proposing changes")
+	assertContainsWords(t, onboarding, "Do not pass `--allow-write-probes` during this identity-safe verification")
+	assertContainsWords(t, onboarding, "do not pass `--allow-write-probes` before Phase 2.5")
+	assertContains(t, onboarding, "detent doctor --port 0 --allow-write-probes")
 	assertMutationBlocksUseValidator(t, onboarding)
 
 	assertContains(t, readme, "do not create, link, mutate, or delete GitHub Projects, issue fields, labels")
 	assertContainsWords(t, readme, "until Phase 2 answers are recorded in `answers.env`")
+	assertContainsWords(t, readme, "read-only doctor status with `detent doctor --port 0` before recommending changes")
+	assertContains(t, readme, "Do not pass `--allow-write-probes` until the mutation gate passes")
 	assertContains(t, readme, "detent onboarding validate-answers")
 	assertContains(t, readme, "Defaults are recommendations only")
 }
@@ -154,7 +160,7 @@ func TestOnboardingDocsRecommendProjectKanbanIntegrationAfterWriteProbes(t *test
 	for _, want := range []string{
 		"Keep fleet `/kanban` read-only",
 		"operator-owned local or private Detent instance",
-		"recommend `integration` after `detent doctor` proves the relevant write probes",
+		"recommend `integration` after `detent doctor --allow-write-probes` proves the relevant write probes",
 		"shared observer dashboard",
 		"recommend `read_only` until writes are proven",
 		`KANBAN_MODE="${KANBAN_MODE:?set KANBAN_MODE to read_only or integration from answers.env}"`,
@@ -165,7 +171,7 @@ func TestOnboardingDocsRecommendProjectKanbanIntegrationAfterWriteProbes(t *test
 
 	for _, want := range []string{
 		"fleet `/kanban` board stays read-only",
-		"trusted operator project board should use `integration` after `detent doctor` proves writes",
+		"trusted operator project board should use `integration` after `detent doctor --allow-write-probes` proves writes",
 		"observer or shared dashboard",
 		"server.kanban.mode: integration",
 	} {


### PR DESCRIPTION
## Summary

- Add explicit `detent doctor --allow-write-probes` authorization and keep default doctor GitHub readiness read-only.
- Preserve read-only readiness evidence while warning when configured write probes are deferred.
- Update onboarding and README guidance plus regression coverage for the read-only/write-probe split.

Fixes #626

## Test Plan

- [x] `go test ./internal/cli -count=1`
- [x] `go test ./... -run 'TestOnboardingDocs' -count=1`
- [x] `make check`