### PR TITLE
fix(github): cap linked issue query budget

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -126,10 +126,16 @@ query DetentGitHubIssueIdentitiesByID($issueIds: [ID!]!) {
 }`
 
 const issueSubIssuesQuery = `
-query DetentGitHubIssueSubIssues($issueId: ID!, $after: String) {
+query DetentGitHubIssueSubIssues(
+  $issueId: ID!
+  $after: String
+  $linkedIssuesFirst: Int!
+  $linkedProjectItemsFirst: Int!
+  $linkedProjectItemFieldValuesFirst: Int!
+) {
   node(id: $issueId) {
     ... on Issue {
-      subIssues(first: 100, after: $after) {
+      subIssues(first: $linkedIssuesFirst, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -138,7 +144,7 @@ query DetentGitHubIssueSubIssues($issueId: ID!, $after: String) {
           state
           url
           repository { nameWithOwner }
-          projectItems(first: 100) {
+          projectItems(first: $linkedProjectItemsFirst) {
             pageInfo { hasNextPage endCursor }
             nodes {
               id
@@ -149,7 +155,7 @@ query DetentGitHubIssueSubIssues($issueId: ID!, $after: String) {
               priorityValue: fieldValueByName(name: "Priority") {
                 ... on ProjectV2ItemFieldSingleSelectValue { name }
               }
-              fieldValues(first: 100) {
+              fieldValues(first: $linkedProjectItemFieldValuesFirst) {
                 nodes {
                   __typename
                   ... on ProjectV2ItemFieldSingleSelectValue {
@@ -176,10 +182,16 @@ query DetentGitHubIssueSubIssues($issueId: ID!, $after: String) {
 }`
 
 const issueTrackedIssuesQuery = `
-query DetentGitHubIssueTrackedIssues($issueId: ID!, $after: String) {
+query DetentGitHubIssueTrackedIssues(
+  $issueId: ID!
+  $after: String
+  $linkedIssuesFirst: Int!
+  $linkedProjectItemsFirst: Int!
+  $linkedProjectItemFieldValuesFirst: Int!
+) {
   node(id: $issueId) {
     ... on Issue {
-      trackedIssues(first: 100, after: $after) {
+      trackedIssues(first: $linkedIssuesFirst, after: $after) {
         pageInfo { hasNextPage endCursor }
         nodes {
           id
@@ -188,7 +200,7 @@ query DetentGitHubIssueTrackedIssues($issueId: ID!, $after: String) {
           state
           url
           repository { nameWithOwner }
-          projectItems(first: 100) {
+          projectItems(first: $linkedProjectItemsFirst) {
             pageInfo { hasNextPage endCursor }
             nodes {
               id
@@ -199,7 +211,7 @@ query DetentGitHubIssueTrackedIssues($issueId: ID!, $after: String) {
               priorityValue: fieldValueByName(name: "Priority") {
                 ... on ProjectV2ItemFieldSingleSelectValue { name }
               }
-              fieldValues(first: 100) {
+              fieldValues(first: $linkedProjectItemFieldValuesFirst) {
                 nodes {
                   __typename
                   ... on ProjectV2ItemFieldSingleSelectValue {
@@ -285,7 +297,7 @@ query DetentGitHubIssueParents(
       parent {
         ...DetentGitHubIssueParent
       }
-      trackedInIssues(first: 100, after: $trackedInAfter) {
+      trackedInIssues(first: $linkedIssuesFirst, after: $trackedInAfter) {
         pageInfo { hasNextPage endCursor }
         nodes {
           ...DetentGitHubIssueParent
@@ -1390,8 +1402,11 @@ func (c *Connector) fetchLinkedIssuePage(
 		} `json:"node"`
 	}
 	if err := c.client.GraphQLWithType(ctx, graphQLQueryEpicChildren, query, map[string]any{
-		"issueId": issueID,
-		"after":   after,
+		"issueId":                           issueID,
+		"after":                             after,
+		"linkedIssuesFirst":                 linkedIssuePageSize,
+		"linkedProjectItemsFirst":           linkedIssueProjectItemsPageSize,
+		"linkedProjectItemFieldValuesFirst": linkedIssueProjectItemFieldValuesPageSize,
 	}, &response); err != nil {
 		return linkedIssuesConnection{}, fmt.Errorf("fetch github issue children: %w", err)
 	}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -191,6 +191,76 @@ func TestProjectStatusQueryFormatsMappedStatuses(t *testing.T) {
 	}
 }
 
+func TestLinkedIssueProjectQueriesStayUnderGitHubNodeLimit(t *testing.T) {
+	t.Parallel()
+
+	const githubStaticNodeLimit = 500000
+	tests := []struct {
+		name     string
+		query    string
+		required []string
+		budget   int
+	}{
+		{
+			name:  "sub issue project fields",
+			query: issueSubIssuesQuery,
+			required: []string{
+				"subIssues(first: $linkedIssuesFirst, after: $after)",
+				"projectItems(first: $linkedProjectItemsFirst)",
+				"fieldValues(first: $linkedProjectItemFieldValuesFirst)",
+			},
+			budget: linkedIssuePageSize * linkedIssueProjectItemsPageSize * linkedIssueProjectItemFieldValuesPageSize,
+		},
+		{
+			name:  "tracked issue project fields",
+			query: issueTrackedIssuesQuery,
+			required: []string{
+				"trackedIssues(first: $linkedIssuesFirst, after: $after)",
+				"projectItems(first: $linkedProjectItemsFirst)",
+				"fieldValues(first: $linkedProjectItemFieldValuesFirst)",
+			},
+			budget: linkedIssuePageSize * linkedIssueProjectItemsPageSize * linkedIssueProjectItemFieldValuesPageSize,
+		},
+		{
+			name:  "tracked in issue project fields",
+			query: issueParentsQuery,
+			required: []string{
+				"trackedInIssues(first: $linkedIssuesFirst, after: $trackedInAfter)",
+				"projectItems(first: $projectItemsFirst)",
+				"fieldValues(first: $projectItemFieldValuesFirst)",
+			},
+			budget: linkedIssuePageSize * projectItemsPerIssue * projectItemFieldValuesPageSize,
+		},
+		{
+			name:  "tracked in issue linked children",
+			query: issueParentsQuery,
+			required: []string{
+				"trackedInIssues(first: $linkedIssuesFirst, after: $trackedInAfter)",
+				"subIssues(first: $linkedIssuesFirst)",
+				"trackedIssues(first: $linkedIssuesFirst)",
+				"projectItems(first: $linkedProjectItemsFirst)",
+				"fieldValues(first: $linkedProjectItemFieldValuesFirst)",
+			},
+			budget: linkedIssuePageSize * linkedIssuePageSize * linkedIssueProjectItemsPageSize * linkedIssueProjectItemFieldValuesPageSize,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if tt.budget >= githubStaticNodeLimit {
+				t.Fatalf("GraphQL static node budget = %d, want < %d", tt.budget, githubStaticNodeLimit)
+			}
+			for _, want := range tt.required {
+				if !strings.Contains(tt.query, want) {
+					t.Fatalf("query missing %q:\n%s", want, tt.query)
+				}
+			}
+		})
+	}
+}
+
 func TestConnectorFetchCandidateIssuesRequestsRateLimitSnapshot(t *testing.T) {
 	t.Parallel()
 
@@ -1463,6 +1533,16 @@ func TestConnectorFetchIssueChildrenPaginatesLinkedIssues(t *testing.T) {
 	if len(requests) != 3 {
 		t.Fatalf("request count = %d, want 3", len(requests))
 	}
+	firstVariables := requests[0]["variables"].(map[string]any)
+	if firstVariables["linkedIssuesFirst"] != float64(linkedIssuePageSize) {
+		t.Fatalf("linkedIssuesFirst = %v, want %d", firstVariables["linkedIssuesFirst"], linkedIssuePageSize)
+	}
+	if firstVariables["linkedProjectItemsFirst"] != float64(linkedIssueProjectItemsPageSize) {
+		t.Fatalf("linkedProjectItemsFirst = %v, want %d", firstVariables["linkedProjectItemsFirst"], linkedIssueProjectItemsPageSize)
+	}
+	if firstVariables["linkedProjectItemFieldValuesFirst"] != float64(linkedIssueProjectItemFieldValuesPageSize) {
+		t.Fatalf("linkedProjectItemFieldValuesFirst = %v, want %d", firstVariables["linkedProjectItemFieldValuesFirst"], linkedIssueProjectItemFieldValuesPageSize)
+	}
 	secondVariables := requests[1]["variables"].(map[string]any)
 	if secondVariables["after"] != "sub-cursor-1" {
 		t.Fatalf("second after = %v, want sub-cursor-1", secondVariables["after"])
@@ -1514,6 +1594,9 @@ func TestConnectorFetchIssueParentsReturnsParentAndTrackedInIssues(t *testing.T)
 		if !strings.Contains(query, want) {
 			t.Fatalf("query missing %q:\n%s", want, query)
 		}
+	}
+	if variables["linkedIssuesFirst"] != float64(linkedIssuePageSize) {
+		t.Fatalf("linkedIssuesFirst = %v, want %d", variables["linkedIssuesFirst"], linkedIssuePageSize)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Reuse the bounded linked-issue GraphQL page-size parameters for ProjectV2 sub-issue and tracked-issue child queries.
- Cap the ProjectV2 tracked-in parent traversal with the linked issue page size so GitHub static node budgeting stays below 500,000.
- Add regression coverage for the static node products and request variables.

Fixes #629

## Test Plan

- [x] `go test ./internal/connector/github`
- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/connector/... ./internal/orchestrator`
- [x] `go run ./cmd/detent doctor --config /tmp/detent-projectv2-doctor.N8h358/global.yaml --port 0`
- [x] `make check`