### PR TITLE
fix(shutdown): bound drain and log blockers

### DIFF
--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -201,9 +201,11 @@ func runDrainShutdown(
 	machine shutdownstate.Machine,
 ) error {
 	startedAt := shutdownNow(cfg)
+	drainTimeout := shutdownDrainTimeoutForConfig(cfg)
 	inventoryStarted := logShutdownBoundaryBegin(shutdownLogger(cfg), "initial_running_session_inventory")
 	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
 	logShutdownBoundaryEnd(shutdownLogger(cfg), "initial_running_session_inventory", inventoryStarted, nil, "sessions", len(sessions))
+	logShutdownDrainBlockers(cfg, "initial", sessions, drainTimeout)
 	writeShutdownBanner(shutdownOutput(cfg), sessions)
 	shutdownLogger(cfg).Info("shutdown requested", "sessions", len(sessions))
 
@@ -225,7 +227,6 @@ func runDrainShutdown(
 		return completeShutdown(ctx, cfg, cancelServe, serveErrs, startedAt, machine, nil)
 	}
 
-	drainTimeout := shutdownDrainTimeoutForConfig(cfg)
 	progressInterval := cfg.ProgressInterval
 	if progressInterval <= 0 {
 		progressInterval = defaultShutdownProgressInterval
@@ -267,9 +268,11 @@ func runDrainShutdown(
 			}
 		case <-poll.C:
 		case <-progress.C:
+			logShutdownDrainBlockers(cfg, "progress", sessions, drainTimeout)
 			writeShutdownProgress(shutdownOutput(cfg), sessions)
 		case <-timeout:
 			machine = machine.Apply(shutdownstate.EventDrainTimedOut)
+			logShutdownDrainTimeout(cfg, sessions, drainTimeout)
 			return runForceShutdownWithDeadline(ctx, cfg, cancelServe, serveErrs, machine, "drain timeout", ErrShutdownTimeout, hardTimeout)
 		}
 	}
@@ -498,10 +501,14 @@ func shutdownRunningSessions(ctx context.Context, registry *project.Registry, no
 }
 
 func shutdownDrainTimeoutForConfig(cfg runningShutdownConfig) time.Duration {
+	timeout := cfg.DrainTimeout
 	if cfg.DrainTimeoutSource != nil {
-		return cfg.DrainTimeoutSource()
+		timeout = cfg.DrainTimeoutSource()
 	}
-	return cfg.DrainTimeout
+	if timeout <= 0 {
+		return defaultShutdownDrainTimeout()
+	}
+	return timeout
 }
 
 func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now time.Time) {
@@ -521,15 +528,15 @@ func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now
 func shutdownDrainTimeout(registry *project.Registry) time.Duration {
 	timeoutMS := workflowconfig.DefaultShutdownDrainTimeoutMS
 	if registry == nil {
-		return time.Duration(timeoutMS) * time.Millisecond
+		return defaultShutdownDrainTimeout()
 	}
 
 	found := false
 	for _, trackedProject := range registry.List() {
 		workflow := trackedProject.Workflow()
 		next := workflow.Config.Agent.Shutdown.DrainTimeoutMS
-		if next == 0 {
-			return 0
+		if next <= 0 {
+			next = workflowconfig.DefaultShutdownDrainTimeoutMS
 		}
 		if !found || next > timeoutMS {
 			timeoutMS = next
@@ -537,6 +544,10 @@ func shutdownDrainTimeout(registry *project.Registry) time.Duration {
 		found = true
 	}
 	return time.Duration(timeoutMS) * time.Millisecond
+}
+
+func defaultShutdownDrainTimeout() time.Duration {
+	return time.Duration(workflowconfig.DefaultShutdownDrainTimeoutMS) * time.Millisecond
 }
 
 func writeShutdownBanner(out io.Writer, sessions []telemetry.Running) {
@@ -551,7 +562,12 @@ func writeShutdownBanner(out io.Writer, sessions []telemetry.Running) {
 
 	fmt.Fprintf(out, "shutdown requested — %d %s in flight\n", count, shutdownSessionNoun(count))
 	for _, session := range sessions {
-		fmt.Fprintf(out, "  %-30s %-14s %8s\n", shutdownIssueLabel(session), defaultShutdownString(session.State, "running"), formatShutdownDuration(session.RuntimeSeconds))
+		details := shutdownSessionDetail(session)
+		if details == "" {
+			fmt.Fprintf(out, "  %-30s %-14s %8s\n", shutdownIssueLabel(session), defaultShutdownString(session.State, "running"), formatShutdownDuration(session.RuntimeSeconds))
+			continue
+		}
+		fmt.Fprintf(out, "  %-30s %-14s %8s  %s\n", shutdownIssueLabel(session), defaultShutdownString(session.State, "running"), formatShutdownDuration(session.RuntimeSeconds), details)
 	}
 	fmt.Fprintln(out, "draining: no new work will be dispatched; waiting for running sessions to finish")
 	fmt.Fprintln(out, "press Ctrl+C again to force quit (sessions will be interrupted and issues re-queued)")
@@ -563,9 +579,75 @@ func writeShutdownProgress(out io.Writer, sessions []telemetry.Running) {
 	}
 	parts := make([]string, 0, len(sessions))
 	for _, session := range sessions {
-		parts = append(parts, fmt.Sprintf("%s (%s)", shutdownIssueNumber(session), formatShutdownDuration(session.RuntimeSeconds)))
+		details := shutdownSessionDetail(session)
+		if details == "" {
+			parts = append(parts, fmt.Sprintf("%s (%s)", shutdownIssueNumber(session), formatShutdownDuration(session.RuntimeSeconds)))
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s (%s, %s)", shutdownIssueNumber(session), formatShutdownDuration(session.RuntimeSeconds), details))
 	}
 	fmt.Fprintf(out, "%d %s remaining — %s\n", len(sessions), shutdownSessionNoun(len(sessions)), strings.Join(parts, ", "))
+}
+
+func logShutdownDrainBlockers(cfg runningShutdownConfig, phase string, sessions []telemetry.Running, timeout time.Duration) {
+	args := shutdownDrainBlockerLogArgs("shutdown_drain_blockers", phase, sessions, timeout)
+	shutdownLogger(cfg).Info("shutdown drain blockers", args...)
+}
+
+func logShutdownDrainTimeout(cfg runningShutdownConfig, sessions []telemetry.Running, timeout time.Duration) {
+	args := shutdownDrainBlockerLogArgs("shutdown_drain_timeout", "timeout", sessions, timeout)
+	shutdownLogger(cfg).Warn("shutdown drain timeout reached", args...)
+}
+
+func shutdownDrainBlockerLogArgs(operation string, phase string, sessions []telemetry.Running, timeout time.Duration) []any {
+	args := []any{
+		"operation", operation,
+		"phase", phase,
+		"blockers", len(sessions),
+	}
+	if timeout > 0 {
+		args = append(args, "timeout", timeout)
+	}
+	if len(sessions) > 0 {
+		args = append(args, "details", strings.Join(shutdownSessionSummaries(sessions), "; "))
+	}
+	return args
+}
+
+func shutdownSessionSummaries(sessions []telemetry.Running) []string {
+	summaries := make([]string, 0, len(sessions))
+	for _, session := range sessions {
+		summaries = append(summaries, shutdownSessionSummary(session))
+	}
+	return summaries
+}
+
+func shutdownSessionSummary(session telemetry.Running) string {
+	parts := []string{defaultShutdownString(session.Identifier, session.ID)}
+	if title := strings.TrimSpace(session.Title); title != "" {
+		parts = append(parts, "title="+title)
+	}
+	if state := strings.TrimSpace(session.State); state != "" {
+		parts = append(parts, "state="+state)
+	}
+	if details := shutdownSessionDetail(session); details != "" {
+		parts = append(parts, details)
+	}
+	return strings.Join(parts, " ")
+}
+
+func shutdownSessionDetail(session telemetry.Running) string {
+	parts := make([]string, 0, 3)
+	if sessionID := strings.TrimSpace(session.SessionID); sessionID != "" {
+		parts = append(parts, "session="+sessionID)
+	}
+	if process := strings.TrimSpace(session.ProcessIdentity); process != "" {
+		parts = append(parts, "process="+process)
+	}
+	if worker := strings.TrimSpace(session.WorkerHost); worker != "" {
+		parts = append(parts, "worker="+worker)
+	}
+	return strings.Join(parts, " ")
 }
 
 func shutdownIssueLabel(session telemetry.Running) string {

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -12,7 +12,9 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -315,15 +317,92 @@ func TestRunWithShutdownZeroSessionsLogsCleanupBoundaries(t *testing.T) {
 		"operation=initial_running_session_inventory",
 		"operation=drain_projects",
 		"operation=shutdown_snapshot_publish",
+		"operation=shutdown_drain_blockers",
 		"operation=stop_projects",
 		"operation=serve_cancel",
 		"operation=wait_for_serve_exit",
 		"sessions=0",
+		"blockers=0",
 		"duration=",
 		"result=ok",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("debug logs missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunWithShutdownRunningProjectNoActiveSessionsExitsGracefully(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	registry := projectpkg.NewRegistry()
+	project := newShutdownRuntimeProject(t, "detent", nil, orchestrator.FakeRunner{})
+	if err := registry.Set(project); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	if err := project.Start(context.Background()); err != nil {
+		t.Fatalf("Project.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := project.Close(); err != nil && !errors.Is(err, projectpkg.ErrNotRunning) {
+			t.Fatalf("Project.Close() error = %v", err)
+		}
+	})
+
+	started := make(chan struct{})
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	errs := make(chan error, 1)
+
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:       controller,
+			Registry:         registry,
+			SnapshotHub:      hub.New[telemetry.Snapshot](),
+			Output:           io.Discard,
+			Logger:           logger,
+			DrainTimeout:     time.Hour,
+			ProgressInterval: time.Hour,
+			HardTimeout:      time.Second,
+			Now: func() time.Time {
+				return time.Date(2026, 6, 23, 15, 0, 0, 0, time.UTC)
+			},
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	start := time.Now()
+	controller.RequestDrain()
+
+	select {
+	case err := <-errs:
+		if err != nil {
+			t.Fatalf("runWithShutdown() error = %v, want nil", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
+	}
+	if elapsed := time.Since(start); elapsed >= shutdownDrainPollInterval {
+		t.Fatalf("zero-session shutdown waited %s, want less than %s", elapsed, shutdownDrainPollInterval)
+	}
+	got := logs.String()
+	for _, want := range []string{
+		"operation=shutdown_drain_blockers",
+		"blockers=0",
+		"operation=project_stop",
+		"project_id=detent",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("logs missing %q:\n%s", want, got)
 		}
 	}
 }
@@ -366,6 +445,118 @@ func TestRunWithShutdownZeroSessionsExitsWhenServeIgnoresCancellation(t *testing
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for shutdown")
+	}
+}
+
+func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *testing.T) {
+	t.Parallel()
+
+	controller := NewShutdownController()
+	registry := projectpkg.NewRegistry()
+	runner := &shutdownBlockingRunner{
+		started:  make(chan struct{}, 1),
+		canceled: make(chan struct{}, 1),
+	}
+	project := newShutdownRuntimeProject(t, "detent", []connector.Issue{{
+		ID:               "issue-641",
+		Identifier:       "digitaldrywood/detent#641",
+		Title:            "service restart can hang while draining",
+		State:            "Todo",
+		AssignedToWorker: true,
+	}}, runner)
+	if err := registry.Set(project); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	if err := project.Start(context.Background()); err != nil {
+		t.Fatalf("Project.Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := project.Close(); err != nil && !errors.Is(err, projectpkg.ErrNotRunning) {
+			t.Fatalf("Project.Close() error = %v", err)
+		}
+	})
+
+	select {
+	case <-runner.started:
+	case <-time.After(time.Second):
+		t.Fatal("runner did not start")
+	}
+	waitForShutdownSession(t, registry, func(session telemetry.Running) bool {
+		return session.ProcessIdentity == "4242" && session.SessionID == "thread-641-turn-1"
+	})
+
+	started := make(chan struct{})
+	var output bytes.Buffer
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	errs := make(chan error, 1)
+
+	go func() {
+		errs <- runWithShutdown(context.Background(), runningShutdownConfig{
+			Controller:       controller,
+			Registry:         registry,
+			SnapshotHub:      hub.New[telemetry.Snapshot](),
+			Output:           &output,
+			Logger:           logger,
+			DrainTimeout:     20 * time.Millisecond,
+			ProgressInterval: 5 * time.Millisecond,
+			HardTimeout:      time.Second,
+			Now: func() time.Time {
+				return time.Date(2026, 6, 23, 15, 0, 0, 0, time.UTC)
+			},
+		}, func(ctx context.Context) error {
+			close(started)
+			<-ctx.Done()
+			return ctx.Err()
+		})
+	}()
+
+	select {
+	case <-started:
+	case <-time.After(time.Second):
+		t.Fatal("server did not start")
+	}
+	controller.RequestDrain()
+
+	select {
+	case err := <-errs:
+		if !errors.Is(err, ErrShutdownTimeout) {
+			t.Fatalf("runWithShutdown() error = %v, want ErrShutdownTimeout", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for shutdown")
+	}
+	select {
+	case <-runner.canceled:
+	case <-time.After(time.Second):
+		t.Fatal("runner was not canceled by forced shutdown")
+	}
+
+	gotOutput := output.String()
+	for _, want := range []string{
+		"shutdown requested — 1 agent session in flight",
+		"#641",
+		"process=4242",
+		"session=thread-641-turn-1",
+		"drain timeout reached — interrupting 1 agent session",
+	} {
+		if !strings.Contains(gotOutput, want) {
+			t.Fatalf("output missing %q:\n%s", want, gotOutput)
+		}
+	}
+
+	gotLogs := logs.String()
+	for _, want := range []string{
+		"operation=shutdown_drain_blockers",
+		"operation=shutdown_drain_timeout",
+		"blockers=1",
+		"process=4242",
+		"session=thread-641-turn-1",
+		"digitaldrywood/detent#641",
+	} {
+		if !strings.Contains(gotLogs, want) {
+			t.Fatalf("logs missing %q:\n%s", want, gotLogs)
+		}
 	}
 }
 
@@ -479,8 +670,8 @@ func TestRunningShutdownConfigComputesDrainTimeoutFromCurrentRegistry(t *testing
 		t.Fatalf("Registry.Set() error = %v", err)
 	}
 
-	if got := shutdownDrainTimeoutForConfig(cfg); got != 0 {
-		t.Fatalf("shutdownDrainTimeoutForConfig() after registry update = %v, want 0", got)
+	if got := shutdownDrainTimeoutForConfig(cfg); got != wantDefault {
+		t.Fatalf("shutdownDrainTimeoutForConfig() after registry update = %v, want %v", got, wantDefault)
 	}
 }
 
@@ -521,6 +712,23 @@ func newShutdownProject(t *testing.T, id string, drainTimeoutMS int) *projectpkg
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Agent.Shutdown.DrainTimeoutMS = drainTimeoutMS
+	return newShutdownRuntimeProjectWithConfig(t, id, cfg, orchestrator.FakeRunner{})
+}
+
+func newShutdownRuntimeProject(t *testing.T, id string, issues []connector.Issue, runner orchestrator.Runner) *projectpkg.Project {
+	t.Helper()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Tracker.Issues = issues
+	cfg.Polling.IntervalMS = 60000
+	cfg.Agent.MaxConcurrentAgents = 1
+	return newShutdownRuntimeProjectWithConfig(t, id, cfg, runner)
+}
+
+func newShutdownRuntimeProjectWithConfig(t *testing.T, id string, cfg workflowconfig.Config, runner orchestrator.Runner) *projectpkg.Project {
+	t.Helper()
+
 	project, err := projectpkg.New(projectpkg.Config{
 		Project: globalconfig.Project{
 			ID:      id,
@@ -528,9 +736,58 @@ func newShutdownProject(t *testing.T, id string, drainTimeoutMS int) *projectpkg
 			Weight:  1,
 		},
 		Workflow: workflowconfig.Workflow{Config: cfg, Prompt: "Test workflow prompt."},
-	}, projectpkg.Dependencies{})
+	}, projectpkg.Dependencies{Runner: runner})
 	if err != nil {
 		t.Fatalf("project.New() error = %v", err)
 	}
 	return project
+}
+
+type shutdownBlockingRunner struct {
+	started  chan struct{}
+	canceled chan struct{}
+}
+
+func (r *shutdownBlockingRunner) Run(ctx context.Context, request orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	if request.OnUsageUpdate != nil {
+		if err := request.OnUsageUpdate(orchestrator.UsageUpdate{
+			SessionID:       "thread-641-turn-1",
+			ProcessIdentity: "4242",
+			Tokens: orchestrator.CodexTotals{
+				RuntimeSeconds: 12,
+			},
+		}); err != nil {
+			return orchestrator.RunResult{}, err
+		}
+	}
+	select {
+	case r.started <- struct{}{}:
+	default:
+	}
+
+	<-ctx.Done()
+	select {
+	case r.canceled <- struct{}{}:
+	default:
+	}
+	return orchestrator.RunResult{}, ctx.Err()
+}
+
+func waitForShutdownSession(t *testing.T, registry *projectpkg.Registry, ready func(telemetry.Running) bool) telemetry.Running {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		for _, session := range shutdownRunningSessions(context.Background(), registry, time.Now()) {
+			if ready(session) {
+				return session
+			}
+		}
+
+		select {
+		case <-deadline:
+			t.Fatal("timed out waiting for shutdown session")
+		case <-time.After(time.Millisecond):
+		}
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -38,7 +38,7 @@ const (
 
 	DefaultPollingIntervalMS      = 120000
 	MinPollingIntervalMS          = 60000
-	DefaultShutdownDrainTimeoutMS = 600000
+	DefaultShutdownDrainTimeoutMS = 75000
 
 	defaultCodexProtocol = "app-server"
 


### PR DESCRIPTION
## Summary

- Bound default graceful shutdown drain behavior and make zero drain timeouts use the bounded default.
- Log pending shutdown drain blockers with session and process identifiers.
- Show session/process identifiers in shutdown banner and progress output, with tests for no-session and active-child-process shutdown paths.

Fixes #641

## Test Plan

- [x] `go test ./internal/cli ./internal/config -count=1`
- [x] `go test ./internal/orchestrator ./internal/project -count=1`
- [x] `make check`