### PR TITLE
fix(orchestrator): retry failed cleanup sweeps

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1,8 +1,10 @@
 package orchestrator_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"maps"
 	"strings"
 	"sync"
@@ -1084,6 +1086,67 @@ func TestRunReapsIdleObservedWorkspacesWithoutTouchingActiveIssues(t *testing.T)
 	}
 }
 
+func TestRunRetriesTransientStartupCleanupFetchAndDispatchesCandidate(t *testing.T) {
+	t.Parallel()
+
+	candidate := testIssue("issue-cleanup-transient", "digitaldrywood/detent#640", "Todo")
+	transientErr := errors.New("fetch github pull request reviews: github transient error: status 504")
+	tracker := newTransientCleanupConnector(candidate, transientErr)
+	runner := newBlockingRunner()
+	logs := &lockedBuffer{}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:                  time.Hour,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		ObservedStates:                []string{"Human Review"},
+		WorkspaceCleanupIdleTTL:       time.Hour,
+		WorkspaceCleanupSweepInterval: time.Hour,
+	}, orchestrator.Dependencies{
+		Connector:       tracker,
+		Runner:          runner,
+		WorkspaceReaper: &fakeWorkspaceReaper{},
+		Logger:          slog.New(slog.NewTextHandler(logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != candidate.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, candidate.ID)
+	}
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		return recentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 504")
+	})
+	if got := state.Snapshot(time.Now()).Refresh.ReadinessStatus(); got != telemetry.RefreshStatusDegraded {
+		t.Fatalf("snapshot Refresh status = %q, want degraded", got)
+	}
+	if got := logs.String(); !strings.Contains(got, "fetch workspace cleanup candidates failed") || !strings.Contains(got, "status 504") {
+		t.Fatalf("logs = %q, want startup cleanup fetch failure", got)
+	}
+
+	if _, err := orch.RequestRefresh(context.Background()); err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	tracker.waitForCleanupAttempts(t, 2)
+
+	if got := tracker.cleanupAttempts(); got != 2 {
+		t.Fatalf("cleanup attempts = %d, want transient failure retried once", got)
+	}
+	state = waitForState(t, orch, func(state orchestrator.State) bool {
+		return tracker.cleanupAttempts() >= 2 && state.Snapshot(time.Now()).Refresh.ReadinessStatus() == telemetry.RefreshStatusReady
+	})
+	if state.LastRefreshError != "" || !state.LastRefreshErrorAt.IsZero() {
+		t.Fatalf("refresh error = %q at %v, want cleared after retry", state.LastRefreshError, state.LastRefreshErrorAt)
+	}
+	close(runner.release)
+}
+
 func TestRunFetchesOnlyActionableObservedStates(t *testing.T) {
 	t.Parallel()
 
@@ -1734,6 +1797,133 @@ func stateListIncludes(states []string, want string) bool {
 		}
 	}
 	return false
+}
+
+func recentEventContains(events []telemetry.ActivityEvent, event string, message string) bool {
+	for _, candidate := range events {
+		if candidate.Event == event && strings.Contains(candidate.Message, message) {
+			return true
+		}
+	}
+	return false
+}
+
+type transientCleanupConnector struct {
+	mu                  sync.Mutex
+	candidate           connector.Issue
+	cleanupErr          error
+	cleanupAttemptCount int
+	changed             chan struct{}
+}
+
+func newTransientCleanupConnector(candidate connector.Issue, cleanupErr error) *transientCleanupConnector {
+	return &transientCleanupConnector{
+		candidate:  candidate,
+		cleanupErr: cleanupErr,
+		changed:    make(chan struct{}, 8),
+	}
+}
+
+func (c *transientCleanupConnector) Name() string {
+	return "transient-cleanup"
+}
+
+func (c *transientCleanupConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return cloneIssues([]connector.Issue{c.candidate}), nil
+}
+
+func (c *transientCleanupConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if transientCleanupRequest(states) {
+		c.cleanupAttemptCount++
+		c.changed <- struct{}{}
+		if c.cleanupAttemptCount == 1 {
+			return nil, c.cleanupErr
+		}
+	}
+	return nil, nil
+}
+
+func (c *transientCleanupConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, id := range ids {
+		if id == c.candidate.ID {
+			return cloneIssues([]connector.Issue{c.candidate}), nil
+		}
+	}
+	return nil, nil
+}
+
+func (c *transientCleanupConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *transientCleanupConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c *transientCleanupConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *transientCleanupConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c *transientCleanupConnector) cleanupAttempts() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return c.cleanupAttemptCount
+}
+
+func (c *transientCleanupConnector) waitForCleanupAttempts(t *testing.T, want int) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		if c.cleanupAttempts() >= want {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for %d cleanup attempts; got %d", want, c.cleanupAttempts())
+		case <-c.changed:
+		}
+	}
+}
+
+func transientCleanupRequest(states []string) bool {
+	return stateListIncludes(states, "Done") &&
+		stateListIncludes(states, "Cancelled") &&
+		stateListIncludes(states, "Human Review")
+}
+
+type lockedBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockedBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.Write(p)
+}
+
+func (b *lockedBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	return b.buf.String()
 }
 
 type parallelFetchConnector struct {

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -21,8 +21,9 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 		return
 	}
 	if state.LastWorkspaceCleanupAt.IsZero() || !now.Before(state.LastWorkspaceCleanupAt.Add(o.cfg.WorkspaceCleanupSweepInterval)) {
-		state.LastWorkspaceCleanupAt = now
-		o.reapWorkspaceStates(ctx, state, states, now)
+		if o.reapWorkspaceStates(ctx, state, states, now) {
+			state.LastWorkspaceCleanupAt = now
+		}
 		return
 	}
 
@@ -33,12 +34,20 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 	o.reapWorkspaceStates(ctx, state, terminalStates, now)
 }
 
-func (o *Orchestrator) reapWorkspaceStates(ctx context.Context, state *State, states []string, now time.Time) {
+func (o *Orchestrator) reapWorkspaceStates(ctx context.Context, state *State, states []string, now time.Time) bool {
 	issues, err := o.connector.FetchIssuesByStates(ctx, states)
 	if err != nil {
 		o.logger.Warn("fetch workspace cleanup candidates failed", slog.Any("error", err))
-		return
+		message := workspaceCleanupFetchFailedMessage(states, err)
+		markRefreshError(state, message, cleanupEventAt(now))
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      cleanupEventAt(now),
+			Event:   "workspace_cleanup_fetch_failed",
+			Message: message,
+		})
+		return false
 	}
+	clearRefreshError(state)
 	for _, issue := range issues {
 		if !o.shouldReapWorkspaceIssue(issue, now) {
 			continue
@@ -48,6 +57,7 @@ func (o *Orchestrator) reapWorkspaceStates(ctx context.Context, state *State, st
 		}
 		o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates), now)
 	}
+	return true
 }
 
 func cleanupFetchStates(cfg Config) []string {
@@ -219,6 +229,22 @@ func cleanupEventAt(now time.Time) time.Time {
 	return now.UTC()
 }
 
+func markRefreshError(state *State, message string, at time.Time) {
+	if state == nil {
+		return
+	}
+	state.LastRefreshError = message
+	state.LastRefreshErrorAt = at
+}
+
+func clearRefreshError(state *State) {
+	if state == nil {
+		return
+	}
+	state.LastRefreshError = ""
+	state.LastRefreshErrorAt = time.Time{}
+}
+
 func workspaceReapSucceededMessage(issue connector.Issue, reason string, result WorkspaceReapResult) string {
 	return fmt.Sprintf(
 		"workspace cleanup succeeded for %s reason=%s worktrees=%d branches=%d processes=%d",
@@ -236,4 +262,8 @@ func workspaceReapFailedMessage(issue connector.Issue, reason string, err error)
 
 func workspaceReapUnverifiedMessage(issue connector.Issue, reason string) string {
 	return fmt.Sprintf("workspace cleanup could not be verified for %s reason=%s: workspace reaper unavailable", issueLabel(issue), reason)
+}
+
+func workspaceCleanupFetchFailedMessage(states []string, err error) string {
+	return fmt.Sprintf("workspace cleanup candidate fetch failed for states=%s: %v", strings.Join(states, ","), err)
 }

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -17,8 +17,12 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		PollIntervalSeconds: int64(s.PollInterval / time.Second),
 		LastRefreshAt:       timePointer(s.LastRefreshAt),
 		NextRefreshAt:       timePointer(s.NextRefreshAt),
+		LastError:           s.LastRefreshError,
+		LastErrorAt:         timePointer(s.LastRefreshErrorAt),
 	}
-	if refresh.LastRefreshAt == nil {
+	if refresh.LastError != "" || refresh.LastErrorAt != nil {
+		refresh.Status = telemetry.RefreshStatusDegraded
+	} else if refresh.LastRefreshAt == nil {
 		refresh.Status = telemetry.RefreshStatusInitializing
 	} else {
 		refresh.Status = telemetry.RefreshStatusReady

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -19,6 +19,8 @@ type State struct {
 	DrainStartedAt           time.Time
 	LastRefreshAt            time.Time
 	NextRefreshAt            time.Time
+	LastRefreshError         string
+	LastRefreshErrorAt       time.Time
 	LastRunningReconcileAt   time.Time
 	LastWorkspaceCleanupAt   time.Time
 	RecentEvents             []telemetry.ActivityEvent
@@ -126,6 +128,8 @@ func (s State) clone() State {
 		DrainStartedAt:           s.DrainStartedAt,
 		LastRefreshAt:            s.LastRefreshAt,
 		NextRefreshAt:            s.NextRefreshAt,
+		LastRefreshError:         s.LastRefreshError,
+		LastRefreshErrorAt:       s.LastRefreshErrorAt,
 		LastRunningReconcileAt:   s.LastRunningReconcileAt,
 		LastWorkspaceCleanupAt:   s.LastWorkspaceCleanupAt,
 		RecentEvents:             cloneActivityEvents(s.RecentEvents),


### PR DESCRIPTION
## Summary

- Keep startup workspace cleanup/review fetch failures isolated from candidate dispatch.
- Retry failed full cleanup sweeps on the next refresh and surface cleanup fetch failures as degraded refresh health.
- Add a regression test for a transient GitHub 504 during startup cleanup.

Fixes #640

## Test Plan

- [x] `go test ./internal/orchestrator -run TestRunRetriesTransientStartupCleanupFetchAndDispatchesCandidate -count=1`
- [x] `go test ./internal/orchestrator`
- [x] `make check`