### PR TITLE
fix(runtime): reconcile live-added projects

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -371,6 +371,20 @@ func publishSnapshotOnce(
 	for _, trackedProject := range trackedProjects {
 		projectMetadata := projectSnapshotMetadata(trackedProject)
 		if !trackedProject.Running() {
+			if runtimeErr := trackedProject.RuntimeError(); runtimeErr.Message != "" {
+				lastErrorAt := runtimeErr.At
+				merged = mergeSnapshot(merged, telemetry.Snapshot{
+					Project:      projectMetadata,
+					DashboardURL: cleanDashboardURL(dashboardURL),
+					Shutdown:     telemetry.Shutdown{Status: "running"},
+					Refresh: telemetry.Refresh{
+						Status:      telemetry.RefreshStatusDegraded,
+						LastError:   runtimeErr.Message,
+						LastErrorAt: &lastErrorAt,
+					},
+				})
+				continue
+			}
 			if trackedProject.Paused() {
 				merged = mergeSnapshot(merged, telemetry.Snapshot{
 					Project:      projectMetadata,

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -371,6 +371,14 @@ func publishSnapshotOnce(
 	for _, trackedProject := range trackedProjects {
 		projectMetadata := projectSnapshotMetadata(trackedProject)
 		if !trackedProject.Running() {
+			if trackedProject.Paused() {
+				merged = mergeSnapshot(merged, telemetry.Snapshot{
+					Project:      projectMetadata,
+					DashboardURL: cleanDashboardURL(dashboardURL),
+					Shutdown:     telemetry.Shutdown{Status: "running"},
+				})
+				continue
+			}
 			if runtimeErr := trackedProject.RuntimeError(); runtimeErr.Message != "" {
 				lastErrorAt := runtimeErr.At
 				merged = mergeSnapshot(merged, telemetry.Snapshot{
@@ -382,14 +390,6 @@ func publishSnapshotOnce(
 						LastError:   runtimeErr.Message,
 						LastErrorAt: &lastErrorAt,
 					},
-				})
-				continue
-			}
-			if trackedProject.Paused() {
-				merged = mergeSnapshot(merged, telemetry.Snapshot{
-					Project:      projectMetadata,
-					DashboardURL: cleanDashboardURL(dashboardURL),
-					Shutdown:     telemetry.Shutdown{Status: "running"},
 				})
 				continue
 			}

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -351,6 +351,66 @@ func TestPublishSnapshotOnceSurfacesProjectStartupError(t *testing.T) {
 	}
 }
 
+func TestPublishSnapshotOncePausedProjectSuppressesStartupError(t *testing.T) {
+	t.Parallel()
+
+	provisionErr := errors.New("provision failed")
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Tracker.AutoProvision = true
+	failedProject, err := projectpkg.New(projectpkg.Config{
+		Project: globalconfig.Project{
+			ID:      "bravo",
+			Workdir: t.TempDir(),
+			Weight:  1,
+		},
+		Workflow: workflowconfig.Workflow{Config: cfg, Prompt: "Test workflow prompt."},
+	}, projectpkg.Dependencies{
+		Connector: bootProvisioningConnector{provision: func(context.Context) error {
+			return provisionErr
+		}},
+	})
+	if err != nil {
+		t.Fatalf("project.New() error = %v", err)
+	}
+	if err := failedProject.Start(context.Background()); !errors.Is(err, provisionErr) {
+		t.Fatalf("Project.Start() error = %v, want %v", err, provisionErr)
+	}
+	if err := failedProject.Pause(context.Background()); err != nil {
+		t.Fatalf("Project.Pause() error = %v", err)
+	}
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+	mustSetProject(t, registry, failedProject)
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	now := time.Date(2026, 6, 23, 14, 30, 0, 0, time.UTC)
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, now, nil, nil, "http://localhost:4101"); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+
+	snapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("snapshotHub.Latest() ok = false, want published snapshot")
+	}
+	if got := snapshot.Refresh.ReadinessStatus(); got != telemetry.RefreshStatusReady {
+		t.Fatalf("snapshot Refresh status = %q, want %q", got, telemetry.RefreshStatusReady)
+	}
+	var paused telemetry.ProjectSnapshot
+	for _, projectSnapshot := range snapshot.Projects {
+		if projectSnapshot.Project.ID == "bravo" {
+			paused = projectSnapshot
+			break
+		}
+	}
+	if paused.Project.ID == "" {
+		t.Fatalf("paused project snapshot missing: %#v", snapshot.Projects)
+	}
+	if refreshHasSignal(paused.Refresh) {
+		t.Fatalf("paused project Refresh = %#v, want no readiness signal", paused.Refresh)
+	}
+}
+
 func TestRepublishSnapshotsOnProjectEventsPublishesLatestSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -298,6 +298,59 @@ func TestPublishSnapshotOnceDoesNotLetPausedProjectsHoldFleetReadiness(t *testin
 	}
 }
 
+func TestPublishSnapshotOnceSurfacesProjectStartupError(t *testing.T) {
+	t.Parallel()
+
+	provisionErr := errors.New("provision failed")
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Tracker.AutoProvision = true
+	failedProject, err := projectpkg.New(projectpkg.Config{
+		Project: globalconfig.Project{
+			ID:      "bravo",
+			Workdir: t.TempDir(),
+			Weight:  1,
+		},
+		Workflow: workflowconfig.Workflow{Config: cfg, Prompt: "Test workflow prompt."},
+	}, projectpkg.Dependencies{
+		Connector: bootProvisioningConnector{provision: func(context.Context) error {
+			return provisionErr
+		}},
+	})
+	if err != nil {
+		t.Fatalf("project.New() error = %v", err)
+	}
+	if err := failedProject.Start(context.Background()); !errors.Is(err, provisionErr) {
+		t.Fatalf("Project.Start() error = %v, want %v", err, provisionErr)
+	}
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, failedProject)
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	now := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, now, nil, nil, "http://localhost:4101"); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+
+	snapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("snapshotHub.Latest() ok = false, want published snapshot")
+	}
+	if len(snapshot.Projects) != 1 {
+		t.Fatalf("snapshot.Projects len = %d, want 1", len(snapshot.Projects))
+	}
+	refresh := snapshot.Projects[0].Refresh
+	if got := refresh.ReadinessStatus(); got != telemetry.RefreshStatusDegraded {
+		t.Fatalf("project Refresh status = %q, want %q; refresh = %#v", got, telemetry.RefreshStatusDegraded, refresh)
+	}
+	if !strings.Contains(refresh.LastError, "provision failed") {
+		t.Fatalf("project Refresh LastError = %q, want provision failure", refresh.LastError)
+	}
+	if refresh.LastErrorAt == nil {
+		t.Fatal("project Refresh LastErrorAt = nil, want timestamp")
+	}
+}
+
 func TestRepublishSnapshotsOnProjectEventsPublishesLatestSnapshot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -365,7 +365,7 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		}
 		didStart, err := m.startPreparedProjectLocked(ctx, preparedProject)
 		if err != nil {
-			if len(result.Removed) > 0 || len(result.Changed) > 0 {
+			if len(result.Removed) > 0 || len(result.Changed) > 0 || !retainAddedProjectStartFailure(preparedProject, err) {
 				return result, errors.Join(err, rollback())
 			}
 			m.logProjectStartupFailure(id, err)
@@ -707,6 +707,16 @@ func (m *Manager) logProjectStartupFailure(id ID, err error) {
 		logger = slog.Default()
 	}
 	logger.Warn("project startup failed", "project_id", id, "error", err)
+}
+
+func retainAddedProjectStartFailure(project *Project, err error) bool {
+	if project == nil {
+		return false
+	}
+	if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+		return false
+	}
+	return project.RuntimeError().Message != ""
 }
 
 func spawnDelay(startup StartupConfig, spawned bool, jitter func(time.Duration) time.Duration) time.Duration {

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -73,6 +73,7 @@ type Manager struct {
 	factory  Factory
 	sleep    func(context.Context, time.Duration) error
 	jitter   func(time.Duration) time.Duration
+	logger   *slog.Logger
 
 	running bool
 	spawned bool
@@ -120,6 +121,10 @@ func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
 	if jitter == nil {
 		jitter = randomJitter
 	}
+	logger := deps.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
 
 	cfg = normalizeManagerConfig(cfg)
 	return &Manager{
@@ -128,6 +133,7 @@ func NewManager(cfg ManagerConfig, deps ManagerDependencies) (*Manager, error) {
 		factory:  factory,
 		sleep:    sleep,
 		jitter:   jitter,
+		logger:   logger,
 	}, nil
 }
 
@@ -359,7 +365,15 @@ func (m *Manager) Reconcile(ctx context.Context, cfg ManagerConfig) (ReconcileRe
 		}
 		didStart, err := m.startPreparedProjectLocked(ctx, preparedProject)
 		if err != nil {
-			return result, errors.Join(err, rollback())
+			if len(result.Removed) > 0 || len(result.Changed) > 0 {
+				return result, errors.Join(err, rollback())
+			}
+			m.logProjectStartupFailure(id, err)
+			if err := m.registry.Set(preparedProject); err != nil {
+				return result, errors.Join(err, rollback())
+			}
+			added[id] = struct{}{}
+			continue
 		}
 		if didStart {
 			started = append(started, startedProject{project: preparedProject})
@@ -685,6 +699,14 @@ func (m *Manager) waitBeforeSpawn(ctx context.Context) error {
 		return nil
 	}
 	return m.sleep(ctx, delay)
+}
+
+func (m *Manager) logProjectStartupFailure(id ID, err error) {
+	logger := m.logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+	logger.Warn("project startup failed", "project_id", id, "error", err)
 }
 
 func spawnDelay(startup StartupConfig, spawned bool, jitter func(time.Duration) time.Duration) time.Duration {

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -715,6 +715,59 @@ func TestManagerReconcileRecordsAddedProjectStartFailure(t *testing.T) {
 	}
 }
 
+func TestManagerReconcilePropagatesAddedProjectContextCancellation(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(4))
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+		Startup:  project.StartupConfig{MaxSpawnPerSecond: 1},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(ctx context.Context, _ time.Duration) error {
+			return ctx.Err()
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	t.Cleanup(func() {
+		for _, item := range manager.Registry().List() {
+			if !item.Running() {
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			if err := item.Stop(ctx); err != nil && !errors.Is(err, project.ErrNotRunning) {
+				cancel()
+				t.Fatalf("Stop(%s) error = %v", item.ID(), err)
+			}
+			cancel()
+		}
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err = manager.Reconcile(ctx, project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+		Startup: project.StartupConfig{MaxSpawnPerSecond: 1},
+	})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("Reconcile() error = %v, want %v", err, context.Canceled)
+	}
+	if _, ok := manager.Registry().Get("bravo"); ok {
+		t.Fatal("Registry().Get(bravo) ok = true after canceled reconcile, want false")
+	}
+}
+
 func TestManagerReconcileClosesPreparedProjectWhenLaterCreateFails(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -1,10 +1,13 @@
 package project_test
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"reflect"
 	"slices"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -501,6 +504,214 @@ func TestManagerReconcileProjects(t *testing.T) {
 			assertNoProjectEvent(t, sub.C())
 			assertManagerProjectConfigs(t, manager, tt.wantConfigs)
 		})
+	}
+}
+
+func TestManagerReconcileAddedProjectBeginsPolling(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	alphaRunner := newProjectBlockingRunner()
+	bravoRunner := newProjectBlockingRunner()
+	workflowWithIssue := func(issueID string, title string) workflowconfig.Workflow {
+		workflowCfg := workflowConfigWithMemoryIssue(issueID)
+		workflowCfg.Tracker.Issues[0].State = "Todo"
+		workflowCfg.Tracker.Issues[0].Title = title
+		workflowCfg.Tracker.Issues[0].AssignedToWorker = true
+		return workflowconfig.Workflow{Config: workflowCfg, Prompt: title + "."}
+	}
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			switch cfg.ID {
+			case "alpha":
+				return project.New(project.Config{
+					Project:  cfg,
+					Workflow: workflowWithIssue("issue-alpha", "Run alpha"),
+				}, project.Dependencies{
+					Events: events,
+					Runner: alphaRunner,
+				})
+			case "bravo":
+				return project.New(project.Config{
+					Project:  cfg,
+					Workflow: workflowWithIssue("issue-bravo", "Run bravo"),
+				}, project.Dependencies{
+					Events: events,
+					Runner: bravoRunner,
+				})
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+	alphaRequest := receiveRunRequest(t, alphaRunner.started)
+	if alphaRequest.Issue.ID != "issue-alpha" {
+		t.Fatalf("alpha dispatched issue ID = %q, want issue-alpha", alphaRequest.Issue.ID)
+	}
+	t.Cleanup(func() {
+		close(alphaRunner.release)
+		close(bravoRunner.release)
+		for _, item := range manager.Registry().List() {
+			if !item.Running() {
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			if err := item.Stop(ctx); err != nil && !errors.Is(err, project.ErrNotRunning) {
+				cancel()
+				t.Fatalf("Stop(%s) error = %v", item.ID(), err)
+			}
+			cancel()
+		}
+	})
+
+	got, err := manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	want := project.ReconcileResult{
+		Added:     []project.ID{"bravo"},
+		Unchanged: []project.ID{"alpha"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Reconcile() = %#v, want %#v", got, want)
+	}
+	assertProjectEvents(t, sub.C(), []project.Event{{ProjectID: "bravo", Kind: project.EventStarted}})
+	request := receiveRunRequest(t, bravoRunner.started)
+	if request.Issue.ID != "issue-bravo" {
+		t.Fatalf("dispatched issue ID = %q, want issue-bravo", request.Issue.ID)
+	}
+	alpha, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Registry().Get(alpha) ok = false, want true")
+	}
+	alphaState, err := alpha.Orchestrator().State(context.Background())
+	if err != nil {
+		t.Fatalf("alpha State() error = %v", err)
+	}
+	if _, ok := alphaState.Running["issue-alpha"]; !ok {
+		t.Fatalf("alpha running agents = %#v, want issue-alpha still running", alphaState.Running)
+	}
+}
+
+func TestManagerReconcileRecordsAddedProjectStartFailure(t *testing.T) {
+	t.Parallel()
+
+	provisionErr := errors.New("provision failed")
+	var logs bytes.Buffer
+	logger := slog.New(slog.NewTextHandler(&logs, nil))
+	events := hub.New[project.Event](hub.WithBuffer(8))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	manager, err := project.NewManager(project.ManagerConfig{
+		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
+	}, project.ManagerDependencies{
+		Events: events,
+		Logger: logger,
+		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
+			if cfg.ID == "bravo" {
+				workflowCfg := workflowConfig("memory")
+				workflowCfg.Tracker.AutoProvision = true
+				return project.New(project.Config{
+					Project:  cfg,
+					Workflow: workflowconfig.Workflow{Config: workflowCfg},
+				}, project.Dependencies{
+					Connector: provisioningConnector{provision: func(context.Context) error {
+						return provisionErr
+					}},
+					Events: events,
+					Runner: blockingRunner{},
+				})
+			}
+			return newManagerTestProject(t, cfg, events)
+		},
+		Sleep: func(context.Context, time.Duration) error {
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewManager() error = %v", err)
+	}
+	if err := manager.Start(context.Background()); err != nil {
+		t.Fatalf("Start() error = %v", err)
+	}
+	drainProjectEvents(t, sub.C(), 1)
+	t.Cleanup(func() {
+		for _, item := range manager.Registry().List() {
+			if !item.Running() {
+				continue
+			}
+			ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+			if err := item.Stop(ctx); err != nil && !errors.Is(err, project.ErrNotRunning) {
+				cancel()
+				t.Fatalf("Stop(%s) error = %v", item.ID(), err)
+			}
+			cancel()
+		}
+	})
+
+	got, err := manager.Reconcile(context.Background(), project.ManagerConfig{
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Weight: 1},
+			{ID: "bravo", Weight: 1},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Reconcile() error = %v", err)
+	}
+	want := project.ReconcileResult{
+		Added:     []project.ID{"bravo"},
+		Unchanged: []project.ID{"alpha"},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("Reconcile() = %#v, want %#v", got, want)
+	}
+	assertNoProjectEvent(t, sub.C())
+
+	alpha, ok := manager.Registry().Get("alpha")
+	if !ok {
+		t.Fatal("Registry().Get(alpha) ok = false, want true")
+	}
+	if !alpha.Running() {
+		t.Fatal("alpha Running() = false after failed bravo start, want true")
+	}
+	bravo, ok := manager.Registry().Get("bravo")
+	if !ok {
+		t.Fatal("Registry().Get(bravo) ok = false, want failed project retained")
+	}
+	if bravo.Running() {
+		t.Fatal("bravo Running() = true after failed start, want false")
+	}
+
+	gotLogs := logs.String()
+	for _, want := range []string{"project startup failed", "bravo", "provision failed"} {
+		if !strings.Contains(gotLogs, want) {
+			t.Fatalf("logs missing %q:\n%s", want, gotLogs)
+		}
 	}
 }
 
@@ -1341,6 +1552,18 @@ func receiveFirstProjectRun(
 		t.Fatal("timed out waiting for first project dispatch")
 	}
 	return ""
+}
+
+func receiveRunRequest(t *testing.T, requests <-chan orchestrator.RunRequest) orchestrator.RunRequest {
+	t.Helper()
+
+	select {
+	case request := <-requests:
+		return request
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for runner request")
+	}
+	return orchestrator.RunRequest{}
 }
 
 func runningProjects(t *testing.T, manager *project.Manager) int {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -51,6 +51,11 @@ type Event struct {
 	Error     string
 }
 
+type RuntimeError struct {
+	Message string
+	At      time.Time
+}
+
 type Config struct {
 	Project  globalconfig.Project
 	Workflow workflowconfig.Workflow
@@ -106,6 +111,7 @@ type Project struct {
 	cancel          context.CancelFunc
 	done            chan struct{}
 	runErr          error
+	runtimeErr      RuntimeError
 	started         bool
 	closed          bool
 	lifecycleEvents bool
@@ -246,6 +252,17 @@ func (p *Project) Events() *hub.Hub[Event] {
 	return p.events
 }
 
+func (p *Project) RuntimeError() RuntimeError {
+	if p == nil {
+		return RuntimeError{}
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	return p.runtimeErr
+}
+
 func (p *Project) Running() bool {
 	p.mu.Lock()
 	defer p.mu.Unlock()
@@ -286,6 +303,7 @@ func (p *Project) start(ctx context.Context, opts startOptions) error {
 
 	if opts.provision {
 		if err := p.provision(ctx); err != nil {
+			p.recordRuntimeError(err)
 			return err
 		}
 	}
@@ -307,10 +325,13 @@ func (p *Project) start(ctx context.Context, opts startOptions) error {
 		orch, err := p.orchFactory(p.orchConfig, p.orchDeps)
 		if err != nil {
 			p.mu.Unlock()
-			return fmt.Errorf("create project orchestrator: %w", err)
+			err := fmt.Errorf("create project orchestrator: %w", err)
+			p.recordRuntimeError(err)
+			return err
 		}
 		if orch == nil {
 			p.mu.Unlock()
+			p.recordRuntimeError(ErrMissingOrchestrator)
 			return ErrMissingOrchestrator
 		}
 		p.orchestrator = orch
@@ -321,6 +342,7 @@ func (p *Project) start(ctx context.Context, opts startOptions) error {
 	p.cancel = cancel
 	p.done = done
 	p.runErr = nil
+	p.runtimeErr = RuntimeError{}
 	p.started = true
 	p.lifecycleEvents = opts.publishEvents
 	p.mu.Unlock()
@@ -581,6 +603,9 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 		p.cancel = nil
 		p.done = nil
 		p.runErr = err
+		if err != nil {
+			p.runtimeErr = RuntimeError{Message: err.Error(), At: time.Now().UTC()}
+		}
 	}
 	p.mu.Unlock()
 
@@ -858,6 +883,17 @@ func (p *Project) publishStopped(err error) {
 		At:        time.Now(),
 		Error:     errorString(err),
 	})
+}
+
+func (p *Project) recordRuntimeError(err error) {
+	if p == nil || err == nil {
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.runtimeErr = RuntimeError{Message: err.Error(), At: time.Now().UTC()}
 }
 
 type workflowUpdater interface {


### PR DESCRIPTION
## Summary

- Start and dispatch live-added project runtimes during manager reconcile without interrupting existing running agents.
- Retain added projects that fail startup as degraded project runtimes, log the failure, and surface the error in state snapshots.
- Preserve context-cancellation behavior during reconcile and keep paused projects from reporting stale runtime errors.

Fixes #637

## Test Plan

- [x] `go test ./internal/project -run 'TestManagerReconcile(AddedProjectBeginsPolling|RecordsAddedProjectStartFailure|PropagatesAddedProjectContextCancellation|KeepsRegistryWhenAddedProjectStartFailsAfterRemoval)' -count=1`
- [x] `go test ./internal/cli -run 'TestPublishSnapshotOnce(SurfacesProjectStartupError|PausedProjectSuppressesStartupError)' -count=1`
- [x] `make check`