### PR TITLE
feat(doctor): add project-scoped checks

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -213,6 +213,7 @@ type Option func(*options)
 type options struct {
 	resolvePath   func(string) (globalconfig.PathResolution, error)
 	read          func(string) (globalconfig.Config, error)
+	readProject   func(string, string) (globalconfig.Config, []string, error)
 	readOrDefault func(string) (globalconfig.Config, error)
 	write         func(string, globalconfig.Config) error
 	boot          BootFunc
@@ -419,6 +420,9 @@ func defaultOptions() options {
 		resolvePath: globalconfig.ResolvePath,
 		read: func(path string) (globalconfig.Config, error) {
 			return globalconfig.Read(path)
+		},
+		readProject: func(path string, projectID string) (globalconfig.Config, []string, error) {
+			return globalconfig.ReadProject(path, projectID)
 		},
 		readOrDefault: func(path string) (globalconfig.Config, error) {
 			return globalconfig.ReadOrDefault(path, globalconfig.WithProjectPathLiterals())

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -80,8 +80,14 @@ type doctorCheck struct {
 
 type doctorReport struct {
 	Checks  []doctorCheck `json:"checks"`
+	Scope   doctorScope   `json:"scope,omitzero"`
 	Summary doctorSummary `json:"summary"`
 	Result  string        `json:"result"`
+}
+
+type doctorScope struct {
+	SelectedProject string   `json:"selected_project,omitempty"`
+	SkippedProjects []string `json:"skipped_projects,omitempty"`
 }
 
 type doctorAutoPromoteCandidateDiagnostic struct {
@@ -119,6 +125,7 @@ type doctorSummary struct {
 
 type doctorOutputReport struct {
 	Checks  []doctorCheck `json:"checks"`
+	Scope   doctorScope   `json:"scope,omitzero"`
 	Summary doctorSummary `json:"summary"`
 	Result  string        `json:"result"`
 }
@@ -154,6 +161,7 @@ func (p *doctorCheckProgress) Current() string {
 type doctorConfig struct {
 	ConfigPath       string
 	Host             string
+	ProjectID        string
 	Flags            runtimeFlags
 	Output           io.Writer
 	CheckTimeout     time.Duration
@@ -203,10 +211,11 @@ func newDoctorCommand(configPath *string, env *string, logLevel *string, host *s
 func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
 	timeout := doctorCheckTimeout
 	allowWriteProbes := false
+	projectID := ""
 	cmd := &cobra.Command{
 		Use:          "doctor",
 		Short:        "Run preflight health checks",
-		Example:      "detent doctor --config ~/.config/detent/global.yaml",
+		Example:      "detent doctor --config ~/.config/detent/global.yaml\n  detent doctor --project example --port 0",
 		Args:         NoArgs,
 		SilenceUsage: true,
 		RunE: func(cmd *cobra.Command, _ []string) error {
@@ -221,6 +230,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 			report := runDoctor(cmd.Context(), doctorConfig{
 				ConfigPath:       derefString(configPath),
 				Host:             derefString(host),
+				ProjectID:        projectID,
 				Output:           progressOut,
 				CheckTimeout:     timeout,
 				Build:            opts.build,
@@ -244,6 +254,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	}
 	cmd.Flags().DurationVar(&timeout, "timeout", doctorCheckTimeout, "per-check timeout")
 	cmd.Flags().BoolVar(&allowWriteProbes, "allow-write-probes", false, "run configured GitHub write probes")
+	cmd.Flags().StringVar(&projectID, "project", "", "limit project checks to the selected project id")
 	cmd.SetContext(withCommandOutputOptions(context.Background(), commandOutputOptions{
 		lookupEnv: opts.lookupEnv,
 		stdoutTTY: opts.stdoutTTY,
@@ -260,11 +271,24 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	timeout := doctorNormalizedTimeout(cfg.CheckTimeout)
 	progressOut := cfg.Output
 
-	var report doctorReport
+	report := doctorReport{Scope: doctorScope{SelectedProject: strings.TrimSpace(cfg.ProjectID)}}
 	writeDoctorProgressStart(progressOut, "Config resolution")
 	resolution, global, configCheck := checkDoctorConfig(cfg.ConfigPath, opts)
 	writeDoctorProgressDone(progressOut, configCheck)
 	report.Add(configCheck)
+
+	var projectScopeCheck *doctorCheck
+	if global != nil {
+		scopedGlobal, scope, scopeCheck := scopeDoctorGlobalConfig(*global, cfg.ProjectID)
+		global = &scopedGlobal
+		report.Scope = scope
+		projectScopeCheck = scopeCheck
+	}
+	if projectScopeCheck != nil {
+		writeDoctorProgressStart(progressOut, projectScopeCheck.Name)
+		writeDoctorProgressDone(progressOut, *projectScopeCheck)
+		report.Add(*projectScopeCheck)
+	}
 
 	workflowPath := ""
 	if global != nil {
@@ -341,7 +365,9 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 	if global != nil {
 		globalConfig := *global
 		githubToken := runtime.GitHubToken
-		jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken, cfg.AllowWriteProbes)...)
+		if projectScopeCheck == nil {
+			jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken, cfg.AllowWriteProbes)...)
+		}
 	}
 	jobs = append(jobs,
 		doctorCheckJob{
@@ -505,6 +531,40 @@ func (r doctorReport) withSummary() doctorReport {
 	return r
 }
 
+func scopeDoctorGlobalConfig(cfg globalconfig.Config, projectID string) (globalconfig.Config, doctorScope, *doctorCheck) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return cfg, doctorScope{}, nil
+	}
+
+	scope := doctorScope{SelectedProject: projectID}
+	scoped := cfg
+	scoped.Projects = nil
+	for _, project := range cfg.Projects {
+		id := doctorProjectID(project)
+		if id == projectID {
+			scoped.Projects = append(scoped.Projects, project)
+			continue
+		}
+		scope.SkippedProjects = append(scope.SkippedProjects, id)
+	}
+	if len(scoped.Projects) > 0 {
+		return scoped, scope, nil
+	}
+
+	detail := "project " + projectID + " not found"
+	if len(scope.SkippedProjects) > 0 {
+		detail += "; configured projects: " + strings.Join(scope.SkippedProjects, ", ")
+	}
+	check := doctorCheck{
+		Name:   "Project scope",
+		Status: doctorFail,
+		Detail: detail,
+		Hint:   "Run detent doctor without --project to list host-wide project checks, or pass a configured project id.",
+	}
+	return scoped, scope, &check
+}
+
 func writeDoctorReport(out io.Writer, report doctorReport, format ...OutputFormat) error {
 	if out == nil {
 		out = io.Discard
@@ -518,6 +578,22 @@ func writeDoctorReport(out io.Writer, report doctorReport, format ...OutputForma
 	}
 	if _, err := fmt.Fprintln(out); err != nil {
 		return err
+	}
+	if report.Scope.SelectedProject != "" {
+		if _, err := fmt.Fprintf(out, "Scope: project %s", report.Scope.SelectedProject); err != nil {
+			return err
+		}
+		if len(report.Scope.SkippedProjects) > 0 {
+			if _, err := fmt.Fprintf(out, " (skipped: %s)", strings.Join(report.Scope.SkippedProjects, ", ")); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
 	}
 	if _, err := fmt.Fprintf(out, "%-5s  %-28s  %s\n", "STATUS", "CHECK", "DETAIL"); err != nil {
 		return err
@@ -552,6 +628,7 @@ func newDoctorOutputReport(report doctorReport) doctorOutputReport {
 	}
 	return doctorOutputReport{
 		Checks: report.Checks,
+		Scope:  report.Scope,
 		Summary: doctorSummary{
 			OK:   counts[doctorOK],
 			Warn: counts[doctorWarn],

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -273,17 +273,11 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 
 	report := doctorReport{Scope: doctorScope{SelectedProject: strings.TrimSpace(cfg.ProjectID)}}
 	writeDoctorProgressStart(progressOut, "Config resolution")
-	resolution, global, configCheck := checkDoctorConfig(cfg.ConfigPath, opts)
+	resolution, global, scope, projectScopeCheck, configCheck := checkDoctorConfig(cfg.ConfigPath, cfg.ProjectID, opts)
 	writeDoctorProgressDone(progressOut, configCheck)
+	report.Scope = scope
 	report.Add(configCheck)
 
-	var projectScopeCheck *doctorCheck
-	if global != nil {
-		scopedGlobal, scope, scopeCheck := scopeDoctorGlobalConfig(*global, cfg.ProjectID)
-		global = &scopedGlobal
-		report.Scope = scope
-		projectScopeCheck = scopeCheck
-	}
 	if projectScopeCheck != nil {
 		writeDoctorProgressStart(progressOut, projectScopeCheck.Name)
 		writeDoctorProgressDone(progressOut, *projectScopeCheck)
@@ -552,16 +546,7 @@ func scopeDoctorGlobalConfig(cfg globalconfig.Config, projectID string) (globalc
 		return scoped, scope, nil
 	}
 
-	detail := "project " + projectID + " not found"
-	if len(scope.SkippedProjects) > 0 {
-		detail += "; configured projects: " + strings.Join(scope.SkippedProjects, ", ")
-	}
-	check := doctorCheck{
-		Name:   "Project scope",
-		Status: doctorFail,
-		Detail: detail,
-		Hint:   "Run detent doctor without --project to list host-wide project checks, or pass a configured project id.",
-	}
+	check := missingDoctorProjectScopeCheck(scope)
 	return scoped, scope, &check
 }
 
@@ -638,10 +623,12 @@ func newDoctorOutputReport(report doctorReport) doctorOutputReport {
 	}
 }
 
-func checkDoctorConfig(configPath string, opts options) (globalconfig.PathResolution, *globalconfig.Config, doctorCheck) {
+func checkDoctorConfig(configPath string, projectID string, opts options) (globalconfig.PathResolution, *globalconfig.Config, doctorScope, *doctorCheck, doctorCheck) {
+	projectID = strings.TrimSpace(projectID)
+	scope := doctorScope{SelectedProject: projectID}
 	resolution, err := resolveConfigPathResolution(configPath, opts)
 	if err != nil {
-		return globalconfig.PathResolution{}, nil, doctorCheck{
+		return globalconfig.PathResolution{}, nil, scope, nil, doctorCheck{
 			Name:   "Config resolution",
 			Status: doctorFail,
 			Detail: err.Error(),
@@ -649,9 +636,16 @@ func checkDoctorConfig(configPath string, opts options) (globalconfig.PathResolu
 		}
 	}
 
-	cfg, err := opts.read(resolution.Path)
+	var cfg globalconfig.Config
+	if projectID == "" {
+		cfg, err = opts.read(resolution.Path)
+	} else {
+		var skippedProjects []string
+		cfg, skippedProjects, err = opts.readProject(resolution.Path, projectID)
+		scope.SkippedProjects = skippedProjects
+	}
 	if err != nil {
-		return resolution, nil, doctorCheck{
+		return resolution, nil, scope, nil, doctorCheck{
 			Name:   "Config resolution",
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s via %s; %v", resolution.Path, resolution.Rule, err),
@@ -659,10 +653,29 @@ func checkDoctorConfig(configPath string, opts options) (globalconfig.PathResolu
 		}
 	}
 
-	return resolution, &cfg, doctorCheck{
+	var projectScopeCheck *doctorCheck
+	if projectID != "" && len(cfg.Projects) == 0 {
+		check := missingDoctorProjectScopeCheck(scope)
+		projectScopeCheck = &check
+	}
+
+	return resolution, &cfg, scope, projectScopeCheck, doctorCheck{
 		Name:   "Config resolution",
 		Status: doctorOK,
 		Detail: fmt.Sprintf("%s via %s; %d project(s)", cfg.Path, resolution.Rule, len(cfg.Projects)),
+	}
+}
+
+func missingDoctorProjectScopeCheck(scope doctorScope) doctorCheck {
+	detail := "project " + scope.SelectedProject + " not found"
+	if len(scope.SkippedProjects) > 0 {
+		detail += "; configured projects: " + strings.Join(scope.SkippedProjects, ", ")
+	}
+	return doctorCheck{
+		Name:   "Project scope",
+		Status: doctorFail,
+		Detail: detail,
+		Hint:   "Run detent doctor without --project to list host-wide project checks, or pass a configured project id.",
 	}
 }
 
@@ -3122,6 +3135,9 @@ func doctorOptions(opts options) options {
 	}
 	if opts.read == nil {
 		opts.read = defaults.read
+	}
+	if opts.readProject == nil {
+		opts.readProject = defaults.readProject
 	}
 	return opts
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1012,6 +1012,77 @@ func TestRunDoctorWithProjectScopeSkipsUnrelatedProjectFailures(t *testing.T) {
 	}
 }
 
+func TestRunDoctorWithProjectScopeSkipsUnrelatedProjectPathValidation(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	alphaWorkdir := filepath.Join(root, "alpha")
+	if err := os.MkdirAll(alphaWorkdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	alphaWorkflow := filepath.Join(alphaWorkdir, "WORKFLOW.md")
+	if err := os.WriteFile(alphaWorkflow, []byte("Alpha workflow.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	configPath := filepath.Join(root, "global.yaml")
+	raw := strings.Join([]string{
+		"apiVersion: detent/v1",
+		"kind: GlobalConfig",
+		"global:",
+		"  max_concurrent_agents: 1",
+		"  scheduling: weighted",
+		"projects:",
+		"  - id: alpha",
+		"    workflow: " + alphaWorkflow,
+		"    workdir: " + alphaWorkdir,
+		"    weight: 1",
+		"    priority: 0",
+		"  - id: beta",
+		"    workflow: " + filepath.Join(root, "missing-beta", "WORKFLOW.md"),
+		"    workdir: " + filepath.Join(root, "missing-beta"),
+		"    weight: 1",
+		"    priority: 0",
+		"",
+	}, "\n")
+	if err := os.WriteFile(configPath, []byte(raw), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(path string) (workflowconfig.Workflow, error) {
+		if strings.Contains(path, "missing-beta") {
+			t.Fatalf("loadWorkflow(%q) called for skipped project", path)
+		}
+		return workflowconfig.Workflow{Config: validDoctorWorkflow(alphaWorkdir)}, nil
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:   configPath,
+		Output:       io.Discard,
+		CheckTimeout: time.Second,
+		ProjectID:    "alpha",
+		Flags: runtimeFlags{
+			Port: runtimeIntFlag{Value: 0, Set: true},
+		},
+	}, options{
+		resolvePath: func(string) (globalconfig.PathResolution, error) {
+			return globalconfig.PathResolution{Path: configPath, Rule: globalconfig.PathRuleFlag}, nil
+		},
+		stdoutTTY: func() bool { return true },
+	}, deps)
+
+	if report.HasFailures() {
+		t.Fatalf("HasFailures() = true, want scoped doctor to ignore beta path validation: %#v", report.Checks)
+	}
+	if report.Scope.SelectedProject != "alpha" {
+		t.Fatalf("SelectedProject = %q, want alpha", report.Scope.SelectedProject)
+	}
+	if !slices.Equal(report.Scope.SkippedProjects, []string{"beta"}) {
+		t.Fatalf("SkippedProjects = %#v, want beta", report.Scope.SkippedProjects)
+	}
+	assertDoctorMissingCheck(t, report, "Project beta workflow")
+}
+
 func TestRunDoctorWithMissingProjectScopeFails(t *testing.T) {
 	t.Parallel()
 
@@ -2633,6 +2704,11 @@ func successfulDoctorOptionsWithConfig(configPath string, cfg globalconfig.Confi
 		read: func(string) (globalconfig.Config, error) {
 			cfg.Path = configPath
 			return cfg, nil
+		},
+		readProject: func(_ string, projectID string) (globalconfig.Config, []string, error) {
+			scoped, scope, _ := scopeDoctorGlobalConfig(cfg, projectID)
+			scoped.Path = configPath
+			return scoped, scope.SkippedProjects, nil
 		},
 		stdoutTTY: func() bool { return true },
 	}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -958,6 +958,203 @@ func TestRunDoctorSkipsWriteProbesByDefaultForExistingConfiguredProject(t *testi
 	assertDoctorCheck(t, report, "Project existing GitHub write probes", doctorWarn, "rerun detent doctor with --allow-write-probes after mutation authorization")
 }
 
+func TestRunDoctorWithProjectScopeSkipsUnrelatedProjectFailures(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	global := globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Workflow: "alpha/WORKFLOW.md", Workdir: "/alpha", Weight: 1},
+			{ID: "beta", Workflow: "beta/WORKFLOW.md", Workdir: "/beta", Weight: 1},
+		},
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(path string) (workflowconfig.Workflow, error) {
+		if strings.Contains(path, "beta") {
+			return workflowconfig.Workflow{}, errors.New("beta workflow is broken")
+		}
+		return workflowconfig.Workflow{Config: validDoctorWorkflow("/alpha")}, nil
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:       configPath,
+		Output:           io.Discard,
+		CheckTimeout:     time.Second,
+		ProjectID:        "alpha",
+		AllowWriteProbes: false,
+		Flags: runtimeFlags{
+			Port: runtimeIntFlag{Value: 0, Set: true},
+		},
+	}, successfulDoctorOptionsWithConfig(configPath, global), deps)
+
+	if report.HasFailures() {
+		t.Fatalf("HasFailures() = true, want scoped doctor to ignore beta failures: %#v", report.Checks)
+	}
+	if report.Scope.SelectedProject != "alpha" {
+		t.Fatalf("SelectedProject = %q, want alpha", report.Scope.SelectedProject)
+	}
+	if !slices.Equal(report.Scope.SkippedProjects, []string{"beta"}) {
+		t.Fatalf("SkippedProjects = %#v, want beta", report.Scope.SkippedProjects)
+	}
+	assertDoctorCheck(t, report, "Project alpha workflow", doctorOK, "is valid")
+	assertDoctorMissingCheck(t, report, "Project beta workflow")
+
+	output := newDoctorOutputReport(report)
+	if output.Scope.SelectedProject != "alpha" || !slices.Equal(output.Scope.SkippedProjects, []string{"beta"}) {
+		t.Fatalf("JSON scope = %#v, want selected alpha and skipped beta", output.Scope)
+	}
+}
+
+func TestRunDoctorWithMissingProjectScopeFails(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	global := globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Workflow: "alpha/WORKFLOW.md", Workdir: "/alpha", Weight: 1},
+			{ID: "beta", Workflow: "beta/WORKFLOW.md", Workdir: "/beta", Weight: 1},
+		},
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:   configPath,
+		Output:       io.Discard,
+		CheckTimeout: time.Second,
+		ProjectID:    "missing",
+		Flags: runtimeFlags{
+			Port: runtimeIntFlag{Value: 0, Set: true},
+		},
+	}, successfulDoctorOptionsWithConfig(configPath, global), successfulDoctorDeps())
+
+	if !report.HasFailures() {
+		t.Fatalf("HasFailures() = false, want missing project to fail: %#v", report.Checks)
+	}
+	if report.Scope.SelectedProject != "missing" {
+		t.Fatalf("SelectedProject = %q, want missing", report.Scope.SelectedProject)
+	}
+	if !slices.Equal(report.Scope.SkippedProjects, []string{"alpha", "beta"}) {
+		t.Fatalf("SkippedProjects = %#v, want alpha and beta", report.Scope.SkippedProjects)
+	}
+	assertDoctorCheck(t, report, "Project scope", doctorFail, "project missing not found")
+	assertDoctorMissingCheck(t, report, "Project alpha workflow")
+	assertDoctorMissingCheck(t, report, "Project beta workflow")
+}
+
+func TestRunDoctorHostWideIncludesAllProjectFailures(t *testing.T) {
+	t.Parallel()
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	global := globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Workflow: "alpha/WORKFLOW.md", Workdir: "/alpha", Weight: 1},
+			{ID: "beta", Workflow: "beta/WORKFLOW.md", Workdir: "/beta", Weight: 1},
+		},
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(path string) (workflowconfig.Workflow, error) {
+		if strings.Contains(path, "beta") {
+			return workflowconfig.Workflow{}, errors.New("beta workflow is broken")
+		}
+		return workflowconfig.Workflow{Config: validDoctorWorkflow("/alpha")}, nil
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:   configPath,
+		Output:       io.Discard,
+		CheckTimeout: time.Second,
+		Flags: runtimeFlags{
+			Port: runtimeIntFlag{Value: 0, Set: true},
+		},
+	}, successfulDoctorOptionsWithConfig(configPath, global), deps)
+
+	if !report.HasFailures() {
+		t.Fatalf("HasFailures() = false, want host-wide doctor to include beta failure: %#v", report.Checks)
+	}
+	if report.Scope.SelectedProject != "" || len(report.Scope.SkippedProjects) != 0 {
+		t.Fatalf("Scope = %#v, want empty host-wide scope", report.Scope)
+	}
+	assertDoctorCheck(t, report, "Project alpha workflow", doctorOK, "is valid")
+	assertDoctorCheck(t, report, "Project beta workflow", doctorFail, "beta workflow is broken")
+}
+
+func TestDoctorCommandProjectFlagScopesJSONReport(t *testing.T) {
+	t.Setenv("DETENT_FORMAT", "json")
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	global := globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{
+			{ID: "alpha", Workflow: "alpha/WORKFLOW.md", Workdir: "/alpha", Weight: 1},
+			{ID: "beta", Workflow: "beta/WORKFLOW.md", Workdir: "/beta", Weight: 1},
+		},
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(path string) (workflowconfig.Workflow, error) {
+		if strings.Contains(path, "beta") {
+			return workflowconfig.Workflow{}, errors.New("beta workflow is broken")
+		}
+		return workflowconfig.Workflow{Config: validDoctorWorkflow("/alpha")}, nil
+	}
+	envFlag := ""
+	logLevelFlag := ""
+	hostFlag := "127.0.0.1"
+	portFlag := 0
+	cmd := newDoctorCommandWithDeps(&configPath, &envFlag, &logLevelFlag, &hostFlag, &portFlag, successfulDoctorOptionsWithConfig(configPath, global), deps)
+	cmd.SetArgs([]string{"--project", "alpha"})
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(io.Discard)
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\n%s", err, stdout.String())
+	}
+
+	var got struct {
+		Checks []struct {
+			Name string `json:"name"`
+		} `json:"checks"`
+		Scope doctorScope `json:"scope"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
+	}
+	if got.Scope.SelectedProject != "alpha" || !slices.Equal(got.Scope.SkippedProjects, []string{"beta"}) {
+		t.Fatalf("scope = %#v, want selected alpha and skipped beta", got.Scope)
+	}
+	for _, check := range got.Checks {
+		if strings.Contains(check.Name, "beta") {
+			t.Fatalf("check %q contains skipped project beta in JSON output:\n%s", check.Name, stdout.String())
+		}
+	}
+}
+
 func TestDoctorCommandAllowWriteProbesFlagEnablesWriteReadiness(t *testing.T) {
 	t.Parallel()
 
@@ -2093,6 +2290,13 @@ func TestDoctorCommandWritesJSONReport(t *testing.T) {
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("Unmarshal() error = %v\n%s", err, stdout.String())
 	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
+		t.Fatalf("Unmarshal() raw error = %v\n%s", err, stdout.String())
+	}
+	if _, ok := raw["scope"]; ok {
+		t.Fatalf("host-wide JSON includes scope, want scope omitted:\n%s", stdout.String())
+	}
 	if got.Result != "PASS" {
 		t.Fatalf("result = %q, want PASS", got.Result)
 	}
@@ -2450,6 +2654,16 @@ func assertDoctorCheck(t *testing.T, report doctorReport, name string, status do
 		return
 	}
 	t.Fatalf("missing doctor check %q in %#v", name, report.Checks)
+}
+
+func assertDoctorMissingCheck(t *testing.T, report doctorReport, name string) {
+	t.Helper()
+
+	for _, check := range report.Checks {
+		if check.Name == name {
+			t.Fatalf("found doctor check %q, want it skipped: %#v", name, check)
+		}
+	}
 }
 
 func successfulDoctorDeps() doctorDeps {

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -193,6 +193,25 @@ func Read(path string, opts ...Option) (Config, error) {
 	return Parse(raw, expandedPath, opts...)
 }
 
+func ReadProject(path string, projectID string, opts ...Option) (Config, []string, error) {
+	readOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&readOptions)
+	}
+
+	expandedPath, err := expandPath(path, readOptions)
+	if err != nil {
+		return Config{}, nil, err
+	}
+
+	raw, err := os.ReadFile(expandedPath)
+	if err != nil {
+		return Config{}, nil, MissingFileError{Path: expandedPath, Err: err}
+	}
+
+	return parseProject(raw, expandedPath, projectID, opts...)
+}
+
 func Write(path string, cfg Config, opts ...Option) error {
 	if strings.TrimSpace(path) == "" {
 		return errors.New("global config path is required")
@@ -261,16 +280,47 @@ func Parse(raw []byte, path string, opts ...Option) (Config, error) {
 		opt(&readOptions)
 	}
 
+	root, err := decodeConfigRoot(raw, path)
+	if err != nil {
+		return Config{}, err
+	}
+
+	return parseConfigRoot(root, path, readOptions, opts...)
+}
+
+func parseProject(raw []byte, path string, projectID string, opts ...Option) (Config, []string, error) {
+	readOptions := defaultOptions()
+	for _, opt := range opts {
+		opt(&readOptions)
+	}
+
+	root, err := decodeConfigRoot(raw, path)
+	if err != nil {
+		return Config{}, nil, err
+	}
+
+	skippedProjects := scopeRawProjects(root, projectID)
+	cfg, err := parseConfigRoot(root, path, readOptions, opts...)
+	if err != nil {
+		return Config{}, skippedProjects, err
+	}
+	return cfg, skippedProjects, nil
+}
+
+func decodeConfigRoot(raw []byte, path string) (map[string]any, error) {
 	var decoded any
 	if err := yaml.Unmarshal(raw, &decoded); err != nil {
-		return Config{}, ParseError{Path: path, Err: err}
+		return nil, ParseError{Path: path, Err: err}
 	}
 
 	root, ok := normalizeYAML(decoded).(map[string]any)
 	if !ok {
-		return Config{}, ValidationError{Path: path, Problems: []string{"root: must be a mapping"}}
+		return nil, ValidationError{Path: path, Problems: []string{"root: must be a mapping"}}
 	}
+	return root, nil
+}
 
+func parseConfigRoot(root map[string]any, path string, readOptions options, opts ...Option) (Config, error) {
 	if problems := validateRaw(root, readOptions); len(problems) > 0 {
 		return Config{}, ValidationError{Path: path, Problems: problems}
 	}
@@ -284,6 +334,45 @@ func Parse(raw []byte, path string, opts ...Option) (Config, error) {
 	}
 
 	return cfg, nil
+}
+
+func scopeRawProjects(root map[string]any, projectID string) []string {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return nil
+	}
+	projects, ok := root["projects"].([]any)
+	if !ok {
+		return nil
+	}
+
+	scopedProjects := make([]any, 0, len(projects))
+	skippedProjects := make([]string, 0, len(projects))
+	for _, item := range projects {
+		id := rawProjectID(item)
+		if id == projectID {
+			scopedProjects = append(scopedProjects, item)
+			continue
+		}
+		if id == "" {
+			id = "project"
+		}
+		skippedProjects = append(skippedProjects, id)
+	}
+	root["projects"] = scopedProjects
+	return skippedProjects
+}
+
+func rawProjectID(value any) string {
+	project, ok := value.(map[string]any)
+	if !ok {
+		return ""
+	}
+	id, ok := project["id"].(string)
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(id)
 }
 
 func (c Config) Validate(opts ...Option) error {


### PR DESCRIPTION
## Summary

- Add `detent doctor --project <id>` to scope project workflow, connector, and runtime-derived checks to one configured project.
- Include scoped JSON metadata with the selected project and skipped projects while leaving host-wide JSON unscoped.
- Keep missing project selection as a clear doctor failure without running unrelated project checks.

Fixes #642

## Test Plan

- [x] `go test ./internal/cli`
- [x] `make check`