### PR TITLE
feat(onboarding): detect polluted gates

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -553,7 +553,24 @@ recommendations before asking what to change.
        2>/dev/null || true
    } > "$ONBOARDING_DIR/gate.txt"
    test -f "$ONBOARDING_DIR/gate.txt"
+   GATE_COMMAND="$(awk 'BEGIN {found=0} /^make check$/ {print; found=1; exit} /^make test$/ && candidate == "" {candidate=$0} END {if (!found && candidate != "") print candidate}' "$ONBOARDING_DIR/gate.txt")"
+   if test -n "$GATE_COMMAND"; then
+     detent --format json onboarding diagnose-gate \
+       --source-root "$PWD" \
+       --command "$GATE_COMMAND" \
+       > "$ONBOARDING_DIR/gate-diagnostic.json"
+   else
+     printf '{"status":"skipped","detail":"no candidate command"}\n' \
+       > "$ONBOARDING_DIR/gate-diagnostic.json"
+   fi
+   jq -e '.status == "pass" or .status == "env_polluted" or .status == "fail" or .status == "skipped"' \
+     "$ONBOARDING_DIR/gate-diagnostic.json"
    ```
+
+   If the diagnostic reports `status: env_polluted`, record the failing command,
+   `relevant_environment_keys`, and `passing_sanitized_command`. Use
+   `recommended_gate_command` as the gate recommendation because Detent proved it
+   passes with the polluted local environment removed.
 
 4. **Inspect existing global scheduling.** Show the current project table
    before recommending `priority` and `weight`. Recommend `weight: 1` and
@@ -681,7 +698,7 @@ recommendations before asking what to change.
      'scheduling: <priority/weight recommendation, from global-projects.txt>' \
      'authorization: <filter recommendation, from issue-counts.json and priority-counts.json>' \
      'dashboard_bind: <localhost/private-or-tailscale/all-interfaces recommendation>' \
-     'gate: <gate recommendation, from gate.txt>' \
+     'gate: <gate recommendation, from gate-diagnostic.json and gate.txt>' \
      'concurrency: <max agents and Merging cap recommendation>' \
      'review_policy: <hard stop or auto-promote recommendation>' \
      'prompt: <template or repo-specific recommendation, from repo docs>' \
@@ -926,12 +943,15 @@ mutations. Record explicit answers in `$ONBOARDING_DIR/answers.env`.
 13. **Validation gate.** Ask: "Use the detected command, a custom command, or a
    human review label gate? If this is a command gate, should auto-promotion
    require an automated GitHub PR review from a bot?" Recommendation source:
-   `$ONBOARDING_DIR/gate.txt`, detected manifests, task runners, CI workflow
-   commands, and the repo's review policy. Default if silent: detected
-   `make check` when present with `require_automated_review: true`; otherwise
-   use the strongest ecosystem-specific command from the repo evidence, or
-   `kind: human_review` with `approval_label: human-approved` when no reliable
-   local command exists. Verify:
+   `$ONBOARDING_DIR/gate-diagnostic.json`, `$ONBOARDING_DIR/gate.txt`, detected
+   manifests, task runners, CI workflow commands, and the repo's review policy.
+   Default if silent: `recommended_gate_command` from
+   `$ONBOARDING_DIR/gate-diagnostic.json` when it reports `pass` or
+   `env_polluted`; otherwise detected `make check` when present with
+   `require_automated_review: true`; otherwise use the strongest
+   ecosystem-specific command from the repo evidence, or `kind: human_review`
+   with `approval_label: human-approved` when no reliable local command exists.
+   Verify:
 
    ```sh
    printf '%s\n' \

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -109,6 +109,7 @@ func newOnboardingCommand(configPath *string, opts options) *cobra.Command {
 	cmd.AddCommand(
 		newOnboardingValidateAnswersCommand(),
 		newOnboardingDraftAnswersCommand(configPath, opts),
+		newOnboardingDiagnoseGateCommand(),
 	)
 	return cmd
 }

--- a/internal/cli/onboarding_gate.go
+++ b/internal/cli/onboarding_gate.go
@@ -1,0 +1,357 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
+)
+
+const (
+	onboardingGateDiagnosticStatusPass        = "pass"
+	onboardingGateDiagnosticStatusFail        = "fail"
+	onboardingGateDiagnosticStatusEnvPolluted = "env_polluted"
+	onboardingGateDiagnosticTimeout           = 2 * time.Minute
+)
+
+type onboardingGateDiagnosticConfig struct {
+	SourceRoot string
+	Command    string
+	Timeout    time.Duration
+}
+
+type onboardingGateDiagnosticResult struct {
+	Status                    string   `json:"status"`
+	SourceRoot                string   `json:"source_root"`
+	PassingCommand            string   `json:"passing_command,omitempty"`
+	FailingCommand            string   `json:"failing_command,omitempty"`
+	RelevantEnvironmentKeys   []string `json:"relevant_environment_keys,omitempty"`
+	CandidateEnvironmentFiles []string `json:"candidate_environment_files,omitempty"`
+	PassingSanitizedCommand   string   `json:"passing_sanitized_command,omitempty"`
+	RecommendedGateCommand    string   `json:"recommended_gate_command"`
+	Detail                    string   `json:"detail,omitempty"`
+}
+
+type onboardingGateCommandResult struct {
+	Passed bool
+	Detail string
+}
+
+func newOnboardingDiagnoseGateCommand() *cobra.Command {
+	var sourceRoot string
+	var gateCommand string
+	timeout := onboardingGateDiagnosticTimeout
+
+	cmd := &cobra.Command{
+		Use:          "diagnose-gate",
+		Short:        "Diagnose onboarding validation gate commands",
+		Example:      `detent onboarding diagnose-gate --source-root /path/to/repo --command "make test"`,
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, err := diagnoseOnboardingGate(cmd.Context(), onboardingGateDiagnosticConfig{
+				SourceRoot: sourceRoot,
+				Command:    gateCommand,
+				Timeout:    timeout,
+			})
+			if err != nil {
+				return err
+			}
+			return out.Write(func(w io.Writer) error {
+				return writeOnboardingGateDiagnosticPretty(w, result)
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&sourceRoot, "source-root", ".", "target repository checkout root")
+	cmd.Flags().StringVar(&gateCommand, "command", "", "validation gate command to run locally")
+	cmd.Flags().DurationVar(&timeout, "timeout", onboardingGateDiagnosticTimeout, "per-command timeout")
+	return cmd
+}
+
+func diagnoseOnboardingGate(ctx context.Context, cfg onboardingGateDiagnosticConfig) (onboardingGateDiagnosticResult, error) {
+	command := strings.TrimSpace(cfg.Command)
+	if command == "" {
+		return onboardingGateDiagnosticResult{}, NewValidationError(
+			"--command is required",
+			`Run detent onboarding diagnose-gate --source-root /path/to/repo --command "make test".`,
+			nil,
+		)
+	}
+	if cfg.Timeout <= 0 {
+		return onboardingGateDiagnosticResult{}, NewValidationError(
+			"--timeout must be greater than zero",
+			"Use a positive duration such as --timeout 2m.",
+			nil,
+		)
+	}
+
+	sourceRoot, err := resolveOnboardingGateSourceRoot(cfg.SourceRoot)
+	if err != nil {
+		return onboardingGateDiagnosticResult{}, err
+	}
+	result := onboardingGateDiagnosticResult{
+		SourceRoot:             sourceRoot,
+		RecommendedGateCommand: command,
+	}
+
+	run := runOnboardingGateCommand(ctx, sourceRoot, command, cfg.Timeout, nil)
+	if run.Passed {
+		result.Status = onboardingGateDiagnosticStatusPass
+		result.PassingCommand = command
+		result.Detail = "gate command passed with the current environment"
+		return result, nil
+	}
+
+	result.Status = onboardingGateDiagnosticStatusFail
+	result.FailingCommand = command
+	result.Detail = run.Detail
+
+	keys, files, err := onboardingCandidateEnvironmentKeys(sourceRoot)
+	if err != nil {
+		return onboardingGateDiagnosticResult{}, err
+	}
+	result.CandidateEnvironmentFiles = files
+	if len(keys) == 0 {
+		return result, nil
+	}
+
+	sanitizedRun := runOnboardingGateCommand(ctx, sourceRoot, command, cfg.Timeout, environmentWithoutKeys(keys))
+	if !sanitizedRun.Passed {
+		return result, nil
+	}
+
+	sanitizedCommand := onboardingSanitizedGateCommand(command, keys)
+	result.Status = onboardingGateDiagnosticStatusEnvPolluted
+	result.RelevantEnvironmentKeys = keys
+	result.PassingSanitizedCommand = sanitizedCommand
+	result.RecommendedGateCommand = sanitizedCommand
+	result.Detail = "gate command failed with the current environment but passed after unsetting candidate environment keys"
+	return result, nil
+}
+
+func resolveOnboardingGateSourceRoot(path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		path = "."
+	}
+	absolute, err := filepath.Abs(path)
+	if err != nil {
+		return "", fmt.Errorf("resolve source root %s: %w", path, err)
+	}
+	info, err := os.Stat(absolute)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return "", NewValidationError(
+				"source root not found: "+absolute,
+				"Pass --source-root with an existing repository checkout.",
+				nil,
+			)
+		}
+		return "", fmt.Errorf("inspect source root %s: %w", absolute, err)
+	}
+	if !info.IsDir() {
+		return "", NewValidationError(
+			"source root is not a directory: "+absolute,
+			"Pass --source-root with an existing repository checkout.",
+			nil,
+		)
+	}
+	return filepath.Clean(absolute), nil
+}
+
+func runOnboardingGateCommand(ctx context.Context, sourceRoot string, command string, timeout time.Duration, env []string) onboardingGateCommandResult {
+	commandCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+
+	cmd := commandshell.Command(commandCtx, command, "")
+	cmd.Dir = sourceRoot
+	if env != nil {
+		cmd.Env = env
+	}
+	output, err := cmd.CombinedOutput()
+	if commandCtx.Err() != nil {
+		err = commandCtx.Err()
+	}
+	detail := strings.TrimSpace(string(output))
+	if err != nil {
+		if detail != "" {
+			return onboardingGateCommandResult{Detail: err.Error() + ": " + detail}
+		}
+		return onboardingGateCommandResult{Detail: err.Error()}
+	}
+	return onboardingGateCommandResult{Passed: true, Detail: detail}
+}
+
+func onboardingCandidateEnvironmentKeys(sourceRoot string) ([]string, []string, error) {
+	files := []string{
+		filepath.Join(sourceRoot, ".envrc"),
+		filepath.Join(sourceRoot, ".env"),
+		filepath.Join(sourceRoot, ".env.local"),
+		filepath.Join(sourceRoot, ".env.test"),
+	}
+	seenFiles := make([]string, 0, len(files))
+	seenKeys := map[string]bool{}
+	for _, path := range files {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			if os.IsNotExist(err) {
+				continue
+			}
+			return nil, nil, fmt.Errorf("read environment candidate file %s: %w", path, err)
+		}
+		seenFiles = append(seenFiles, path)
+		for _, key := range parseOnboardingEnvironmentKeys(raw) {
+			if _, ok := os.LookupEnv(key); ok {
+				seenKeys[key] = true
+			}
+		}
+	}
+	keys := make([]string, 0, len(seenKeys))
+	for key := range seenKeys {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys, seenFiles, nil
+}
+
+func parseOnboardingEnvironmentKeys(raw []byte) []string {
+	var keys []string
+	seen := map[string]bool{}
+	scanner := bufio.NewScanner(bytes.NewReader(raw))
+	for scanner.Scan() {
+		for _, key := range onboardingEnvironmentKeysFromLine(scanner.Text()) {
+			if !seen[key] {
+				seen[key] = true
+				keys = append(keys, key)
+			}
+		}
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func onboardingEnvironmentKeysFromLine(line string) []string {
+	line = strings.TrimSpace(line)
+	if line == "" || strings.HasPrefix(line, "#") {
+		return nil
+	}
+	if index := strings.Index(line, "#"); index >= 0 {
+		line = strings.TrimSpace(line[:index])
+	}
+	if strings.HasPrefix(line, "export ") {
+		line = strings.TrimSpace(strings.TrimPrefix(line, "export "))
+	}
+	fields := strings.Fields(line)
+	keys := make([]string, 0, len(fields))
+	for _, field := range fields {
+		key := field
+		if before, _, ok := strings.Cut(field, "="); ok {
+			key = before
+		}
+		key = strings.TrimSpace(key)
+		if validOnboardingEnvironmentKey(key) {
+			keys = append(keys, key)
+		}
+	}
+	return keys
+}
+
+func validOnboardingEnvironmentKey(key string) bool {
+	if key == "" {
+		return false
+	}
+	for index, char := range key {
+		switch {
+		case char == '_':
+		case char >= 'A' && char <= 'Z':
+		case char >= 'a' && char <= 'z' && index == 0:
+		case char >= 'a' && char <= 'z':
+		case char >= '0' && char <= '9' && index > 0:
+		default:
+			return false
+		}
+	}
+	first := key[0]
+	return first == '_' || first >= 'A' && first <= 'Z' || first >= 'a' && first <= 'z'
+}
+
+func environmentWithoutKeys(keys []string) []string {
+	remove := make(map[string]bool, len(keys))
+	for _, key := range keys {
+		remove[key] = true
+	}
+	env := make([]string, 0, len(os.Environ()))
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && remove[key] {
+			continue
+		}
+		env = append(env, entry)
+	}
+	return env
+}
+
+func onboardingSanitizedGateCommand(command string, keys []string) string {
+	parts := []string{"env"}
+	for _, key := range keys {
+		parts = append(parts, "-u", key)
+	}
+	prefix := strings.Join(parts, " ")
+	if onboardingCommandNeedsShell(command) {
+		return prefix + " sh -c " + onboardingShellQuote(command)
+	}
+	return prefix + " " + strings.TrimSpace(command)
+}
+
+func onboardingCommandNeedsShell(command string) bool {
+	return strings.ContainsAny(command, "&;|<>$`'\"\n\r")
+}
+
+func onboardingShellQuote(value string) string {
+	if value == "" {
+		return "''"
+	}
+	return "'" + strings.ReplaceAll(value, "'", "'\\''") + "'"
+}
+
+func writeOnboardingGateDiagnosticPretty(w io.Writer, result onboardingGateDiagnosticResult) error {
+	lines := []string{
+		"gate diagnostic: " + result.Status,
+		"source_root: " + result.SourceRoot,
+		"recommended_gate_command: " + result.RecommendedGateCommand,
+	}
+	if result.FailingCommand != "" {
+		lines = append(lines, "failing_command: "+result.FailingCommand)
+	}
+	if result.PassingCommand != "" {
+		lines = append(lines, "passing_command: "+result.PassingCommand)
+	}
+	if len(result.RelevantEnvironmentKeys) > 0 {
+		lines = append(lines, "relevant_environment_keys: "+strings.Join(result.RelevantEnvironmentKeys, ","))
+	}
+	if result.PassingSanitizedCommand != "" {
+		lines = append(lines, "passing_sanitized_command: "+result.PassingSanitizedCommand)
+	}
+	if len(result.CandidateEnvironmentFiles) > 0 {
+		lines = append(lines, "candidate_environment_files: "+strings.Join(result.CandidateEnvironmentFiles, ","))
+	}
+	if result.Detail != "" {
+		lines = append(lines, "detail: "+result.Detail)
+	}
+	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))
+	return err
+}

--- a/internal/cli/onboarding_gate.go
+++ b/internal/cli/onboarding_gate.go
@@ -197,11 +197,9 @@ func runOnboardingGateCommand(ctx context.Context, sourceRoot string, command st
 }
 
 func onboardingCandidateEnvironmentKeys(sourceRoot string) ([]string, []string, error) {
-	files := []string{
-		filepath.Join(sourceRoot, ".envrc"),
-		filepath.Join(sourceRoot, ".env"),
-		filepath.Join(sourceRoot, ".env.local"),
-		filepath.Join(sourceRoot, ".env.test"),
+	files, err := onboardingCandidateEnvironmentFiles(sourceRoot)
+	if err != nil {
+		return nil, nil, err
 	}
 	seenFiles := make([]string, 0, len(files))
 	seenKeys := map[string]bool{}
@@ -226,6 +224,22 @@ func onboardingCandidateEnvironmentKeys(sourceRoot string) ([]string, []string, 
 	}
 	sort.Strings(keys)
 	return keys, seenFiles, nil
+}
+
+func onboardingCandidateEnvironmentFiles(sourceRoot string) ([]string, error) {
+	entries, err := os.ReadDir(sourceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("read source root %s: %w", sourceRoot, err)
+	}
+	files := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), ".env") {
+			continue
+		}
+		files = append(files, filepath.Join(sourceRoot, entry.Name()))
+	}
+	sort.Strings(files)
+	return files, nil
 }
 
 func parseOnboardingEnvironmentKeys(raw []byte) []string {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -702,6 +702,126 @@ func TestOnboardingDraftAnswersCommandWritesUnconfirmedAnswers(t *testing.T) {
 	}
 }
 
+func TestOnboardingDiagnoseGateDetectsEnvPollutedFailure(t *testing.T) {
+	tests := []struct {
+		name string
+		file string
+	}{
+		{
+			name: "envrc exports",
+			file: ".envrc",
+		},
+		{
+			name: "dotenv assignments",
+			file: ".env",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/creswoodcorners-phone.git")
+			writeOnboardingEnvOverrideModule(t, targetRoot)
+			if err := os.WriteFile(filepath.Join(targetRoot, tt.file), []byte(strings.Join([]string{
+				"export PUBLIC_BASE_URL=https://local.example.test",
+				"SUPPORT_PHONE=555-0100",
+				"",
+			}, "\n")), 0o600); err != nil {
+				t.Fatalf("WriteFile(%s) error = %v", tt.file, err)
+			}
+			t.Setenv("PUBLIC_BASE_URL", "https://local.example.test")
+			t.Setenv("SUPPORT_PHONE", "555-0100")
+			t.Setenv("UNRELATED_ENV", "kept")
+
+			cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+			var stdout bytes.Buffer
+			cmd.SetOut(&stdout)
+			cmd.SetErr(&bytes.Buffer{})
+			cmd.SetArgs([]string{
+				"--format", "json",
+				"onboarding", "diagnose-gate",
+				"--source-root", targetRoot,
+				"--command", "go test ./...",
+				"--timeout", "30s",
+			})
+
+			if err := cmd.Execute(); err != nil {
+				t.Fatalf("Execute() error = %v\nstdout:\n%s", err, stdout.String())
+			}
+
+			var got struct {
+				Status                    string   `json:"status"`
+				FailingCommand            string   `json:"failing_command"`
+				RelevantEnvironmentKeys   []string `json:"relevant_environment_keys"`
+				PassingSanitizedCommand   string   `json:"passing_sanitized_command"`
+				RecommendedGateCommand    string   `json:"recommended_gate_command"`
+				CandidateEnvironmentFiles []string `json:"candidate_environment_files"`
+			}
+			if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+				t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+			}
+			if got.Status != "env_polluted" {
+				t.Fatalf("status = %q, want env_polluted: %#v", got.Status, got)
+			}
+			if got.FailingCommand != "go test ./..." {
+				t.Fatalf("failing command = %q, want go test ./...", got.FailingCommand)
+			}
+			for _, want := range []string{"PUBLIC_BASE_URL", "SUPPORT_PHONE"} {
+				if !containsString(got.RelevantEnvironmentKeys, want) {
+					t.Fatalf("relevant environment keys = %#v, want %q", got.RelevantEnvironmentKeys, want)
+				}
+				if !strings.Contains(got.PassingSanitizedCommand, "-u "+want) {
+					t.Fatalf("passing sanitized command = %q, want unset %s", got.PassingSanitizedCommand, want)
+				}
+			}
+			if len(got.RelevantEnvironmentKeys) != 2 {
+				t.Fatalf("relevant environment keys = %#v, want only polluted keys", got.RelevantEnvironmentKeys)
+			}
+			if strings.Contains(got.PassingSanitizedCommand, "UNRELATED_ENV") {
+				t.Fatalf("passing sanitized command includes unrelated key: %q", got.PassingSanitizedCommand)
+			}
+			if got.RecommendedGateCommand != got.PassingSanitizedCommand {
+				t.Fatalf("recommended gate command = %q, want passing sanitized command %q", got.RecommendedGateCommand, got.PassingSanitizedCommand)
+			}
+			if !containsString(got.CandidateEnvironmentFiles, filepath.Join(targetRoot, tt.file)) {
+				t.Fatalf("candidate environment files = %#v, want %s", got.CandidateEnvironmentFiles, filepath.Join(targetRoot, tt.file))
+			}
+		})
+	}
+}
+
+func TestOnboardingDiagnoseGateKeepsPassingCommandRecommended(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	writeOnboardingEnvOverrideModule(t, targetRoot)
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"onboarding", "diagnose-gate",
+		"--source-root", targetRoot,
+		"--command", "go test ./...",
+		"--timeout", "30s",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout:\n%s", err, stdout.String())
+	}
+
+	var got struct {
+		Status                 string `json:"status"`
+		PassingCommand         string `json:"passing_command"`
+		RecommendedGateCommand string `json:"recommended_gate_command"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Status != "pass" || got.PassingCommand != "go test ./..." || got.RecommendedGateCommand != "go test ./..." {
+		t.Fatalf("diagnostic result = %#v, want passing command recommendation", got)
+	}
+}
+
 func validIdentityOnboardingAnswers(t *testing.T) string {
 	t.Helper()
 
@@ -735,6 +855,34 @@ func initOnboardingGitRepository(t *testing.T, remote string) string {
 	runGit(t, dir, "init")
 	runGit(t, dir, "remote", "add", "origin", remote)
 	return dir
+}
+
+func writeOnboardingEnvOverrideModule(t *testing.T, dir string) {
+	t.Helper()
+
+	if err := os.WriteFile(filepath.Join(dir, "go.mod"), []byte("module example.com/envpolluted\n\ngo 1.26\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(go.mod) error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "config_test.go"), []byte(strings.Join([]string{
+		"package envpolluted",
+		"",
+		"import (",
+		"\t\"os\"",
+		"\t\"testing\"",
+		")",
+		"",
+		"func TestConfigDefaults(t *testing.T) {",
+		"\tif value := os.Getenv(\"PUBLIC_BASE_URL\"); value != \"\" {",
+		"\t\tt.Fatalf(\"PUBLIC_BASE_URL = %q, want empty\", value)",
+		"\t}",
+		"\tif value := os.Getenv(\"SUPPORT_PHONE\"); value != \"\" {",
+		"\t\tt.Fatalf(\"SUPPORT_PHONE = %q, want empty\", value)",
+		"\t}",
+		"}",
+		"",
+	}, "\n")), 0o600); err != nil {
+		t.Fatalf("WriteFile(config_test.go) error = %v", err)
+	}
 }
 
 func writeOnboardingGlobalConfig(t *testing.T, projects []globalconfig.Project) string {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -715,6 +715,10 @@ func TestOnboardingDiagnoseGateDetectsEnvPollutedFailure(t *testing.T) {
 			name: "dotenv assignments",
 			file: ".env",
 		},
+		{
+			name: "dotenv variant assignments",
+			file: ".env.development",
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Add `detent onboarding diagnose-gate` for local gate diagnostics.
- Detect env-polluted gate failures by retrying with keys from `.envrc` and `.env*` files unset.
- Record the failing command, relevant env keys, passing sanitized command, and recommended gate command.
- Update the onboarding runbook to prefer the proven sanitized gate recommendation.

Fixes #645

## Test Plan

- [x] `go test ./internal/cli -run 'TestOnboardingDiagnoseGate'`
- [x] `go test ./internal/cli`
- [x] `go test ./...`
- [x] `make check`