### PR TITLE
feat(onboarding): verify live closeout

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -639,7 +639,7 @@ func (o *Orchestrator) reconcileRunningIssues(ctx context.Context, state *State,
 		}
 
 		running := state.Running[id]
-		running.Issue = mergeIssueTrackerFields(running.Issue, issue)
+		running.Issue = o.hydrateRunningIssueComments(ctx, mergeIssueTrackerFields(running.Issue, issue))
 		if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 			o.completeTerminalRunning(ctx, state, id, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
 			continue
@@ -662,6 +662,25 @@ func (o *Orchestrator) shouldReconcileRunningIssues(state *State, now time.Time)
 	}
 	interval := max(o.cfg.PollInterval, defaultRunningReconcileInterval)
 	return !now.Before(state.LastRunningReconcileAt.Add(interval))
+}
+
+func (o *Orchestrator) hydrateRunningIssueComments(ctx context.Context, issue connector.Issue) connector.Issue {
+	if len(issue.Comments) > 0 {
+		return issue
+	}
+	reader, ok := o.connector.(connector.IssueCommentReader)
+	if !ok {
+		return issue
+	}
+	comments, err := reader.FetchIssueComments(ctx, issue)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("fetch running issue comments failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return issue
+	}
+	issue.Comments = comments
+	return issue
 }
 
 func mergeIssueTrackerFields(current, refreshed connector.Issue) connector.Issue {
@@ -1364,6 +1383,9 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	}
 	if event.usage.ProcessIdentity != "" {
 		running.ProcessIdentity = event.usage.ProcessIdentity
+	}
+	if event.usage.WorkspacePath != "" {
+		running.WorkspacePath = event.usage.WorkspacePath
 	}
 	if diffStatsPresent(event.usage.DiffStats) {
 		running.DiffStats = event.usage.DiffStats

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -654,11 +654,12 @@ func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 	issue := testIssue("issue-live-usage", "digitaldrywood/detent#115", "In Progress")
 	tracker := newFakeConnector(issue)
 	runner := newUsageStreamingRunner(orchestrator.UsageUpdate{
-		SessionID:   "thread-live-turn-live",
-		TurnCount:   1,
-		LastEventAt: lastEventAt,
-		LastEvent:   "agent_message_delta",
-		LastMessage: "editing telemetry",
+		SessionID:     "thread-live-turn-live",
+		WorkspacePath: "/tmp/detent-workspaces/issue-live-usage",
+		TurnCount:     1,
+		LastEventAt:   lastEventAt,
+		LastEvent:     "agent_message_delta",
+		LastMessage:   "editing telemetry",
 		Tokens: orchestrator.CodexTotals{
 			InputTokens:    40,
 			OutputTokens:   12,
@@ -698,6 +699,9 @@ func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 	if running.SessionID != "thread-live-turn-live" || running.LastEvent != "agent_message_delta" || running.LastMessage != "editing telemetry" {
 		t.Fatalf("Running[%q] live activity = %#v", issue.ID, running)
 	}
+	if running.WorkspacePath != "/tmp/detent-workspaces/issue-live-usage" {
+		t.Fatalf("Running[%q].WorkspacePath = %q, want /tmp/detent-workspaces/issue-live-usage", issue.ID, running.WorkspacePath)
+	}
 	if !running.LastEventAt.Equal(lastEventAt) {
 		t.Fatalf("Running[%q].LastEventAt = %v, want %v", issue.ID, running.LastEventAt, lastEventAt)
 	}
@@ -709,6 +713,37 @@ func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 	}
 	if state.CodexTotals.TotalTokens != 0 {
 		t.Fatalf("CodexTotals.TotalTokens = %d, want completed totals only", state.CodexTotals.TotalTokens)
+	}
+
+	close(runner.release)
+}
+
+func TestRunRefreshHydratesRunningIssueComments(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-workpad", "digitaldrywood/detent#646", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := newBlockingRunner()
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	receiveRunRequest(t, runner.started)
+	tracker.setIssueComments(issue.ID, []connector.IssueComment{{
+		Body: "## Codex Workpad\n\n### Status\nIn Progress",
+		URL:  "https://github.test/comment/646",
+	}})
+	if _, err := orch.RequestRefresh(context.Background()); err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		running, ok := state.Running[issue.ID]
+		return ok && len(running.Issue.Comments) == 1
+	})
+	comments := state.Running[issue.ID].Issue.Comments
+	if comments[0].Body != "## Codex Workpad\n\n### Status\nIn Progress" || comments[0].URL != "https://github.test/comment/646" {
+		t.Fatalf("Running[%q].Comments = %#v, want Workpad comment", issue.ID, comments)
 	}
 
 	close(runner.release)
@@ -1712,6 +1747,23 @@ func (c *fakeConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) (
 	return cloneIssues(issues), nil
 }
 
+func (c *fakeConnector) FetchIssueComments(_ context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for _, candidate := range c.candidates {
+		if candidate.ID == issue.ID {
+			return cloneConnectorComments(candidate.Comments), nil
+		}
+	}
+	for _, stateIssue := range c.stateIssues {
+		if stateIssue.ID == issue.ID {
+			return cloneConnectorComments(stateIssue.Comments), nil
+		}
+	}
+	return nil, nil
+}
+
 func (c *fakeConnector) CreateComment(_ context.Context, issueID string, body string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
@@ -1790,6 +1842,22 @@ func (c *fakeConnector) stateUpdateCalls() []stateUpdateCall {
 	defer c.mu.Unlock()
 
 	return append([]stateUpdateCall(nil), c.stateUpdates...)
+}
+
+func (c *fakeConnector) setIssueComments(issueID string, comments []connector.IssueComment) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	for i := range c.candidates {
+		if c.candidates[i].ID == issueID {
+			c.candidates[i].Comments = cloneConnectorComments(comments)
+		}
+	}
+	for i := range c.stateIssues {
+		if c.stateIssues[i].ID == issueID {
+			c.stateIssues[i].Comments = cloneConnectorComments(comments)
+		}
+	}
 }
 
 func (c *fakeConnector) fetchCandidateCalls() int {
@@ -2388,10 +2456,15 @@ func cloneIssues(issues []connector.Issue) []connector.Issue {
 		}
 		cloned[i].BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
 		cloned[i].Labels = append([]string(nil), issue.Labels...)
+		cloned[i].Comments = cloneConnectorComments(issue.Comments)
 		if issue.Fields != nil {
 			cloned[i].Fields = make(map[string]string, len(issue.Fields))
 			maps.Copy(cloned[i].Fields, issue.Fields)
 		}
 	}
 	return cloned
+}
+
+func cloneConnectorComments(comments []connector.IssueComment) []connector.IssueComment {
+	return append([]connector.IssueComment(nil), comments...)
 }

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -100,6 +100,7 @@ func runningSnapshots(running map[string]Running, claims map[string]Claimed, now
 			Issue:           issue,
 			WorkerHost:      entry.WorkerHost,
 			ProcessIdentity: entry.ProcessIdentity,
+			WorkspacePath:   entry.WorkspacePath,
 			SessionID:       entry.SessionID,
 			StartedAt:       entry.StartedAt,
 			LastEventAt:     lastEventAt,
@@ -231,12 +232,24 @@ func telemetryIssue(issue connector.Issue, quietDuration time.Duration, pollInte
 		State:          issue.State,
 		Labels:         append([]string(nil), issue.Labels...),
 		Assignees:      append([]string(nil), issue.Assignees...),
+		Comments:       telemetryIssueComments(issue.Comments),
 		BlockedBy:      telemetryBlockedRefs(issue.BlockedBy),
 		PullRequest:    telemetryPullRequest(issue, quietDuration, pollInterval),
 		CreatedAt:      timePointerFromPtr(issue.CreatedAt),
 		UpdatedAt:      timePointerFromPtr(issue.UpdatedAt),
 		StageUpdatedAt: timePointerFromPtr(issue.StageUpdatedAt),
 	}
+}
+
+func telemetryIssueComments(comments []connector.IssueComment) []telemetry.IssueComment {
+	out := make([]telemetry.IssueComment, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, telemetry.IssueComment{
+			Body: comment.Body,
+			URL:  comment.URL,
+		})
+	}
+	return out
 }
 
 func telemetryBlockedRefs(refs []connector.BlockedRef) []telemetry.BlockedRef {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -74,6 +74,38 @@ func TestStateSnapshotIncludesInstanceIdentityAndScope(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotCarriesIssueComments(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	state := newState(normalizeConfig(Config{}))
+	state.Running["issue-1"] = Running{
+		Issue: connector.Issue{
+			ID:         "issue-1",
+			Identifier: "digitaldrywood/detent#1",
+			State:      "In Progress",
+			Comments: []connector.IssueComment{{
+				Body: "## Codex Workpad\n\n### Status\nIn Progress",
+				URL:  "https://github.test/comment/1",
+			}},
+		},
+		StartedAt: now.Add(-time.Minute),
+	}
+
+	snapshot := state.Snapshot(now)
+
+	if len(snapshot.Running) != 1 {
+		t.Fatalf("Running len = %d, want 1", len(snapshot.Running))
+	}
+	comments := snapshot.Running[0].Comments
+	if len(comments) != 1 {
+		t.Fatalf("Running comments = %#v, want one comment", comments)
+	}
+	if comments[0].Body != "## Codex Workpad\n\n### Status\nIn Progress" || comments[0].URL != "https://github.test/comment/1" {
+		t.Fatalf("Running comment = %#v, want Workpad body and URL", comments[0])
+	}
+}
+
 func TestStateSnapshotIncludesClaimLeaseState(t *testing.T) {
 	t.Parallel()
 
@@ -187,6 +219,7 @@ func TestStateSnapshotPopulated(t *testing.T) {
 		StartedAt:       startedAt,
 		WorkerHost:      "host-b",
 		ProcessIdentity: "4242",
+		WorkspacePath:   "/tmp/detent-workspaces/i-2",
 		SessionID:       "thread-2-turn-2",
 		TurnCount:       2,
 		LastEventAt:     now.Add(-10 * time.Second),
@@ -281,6 +314,9 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	}
 	if snapshot.Running[1].ProcessIdentity != "4242" {
 		t.Fatalf("Running[1].ProcessIdentity = %q, want 4242", snapshot.Running[1].ProcessIdentity)
+	}
+	if snapshot.Running[1].WorkspacePath != "/tmp/detent-workspaces/i-2" {
+		t.Fatalf("Running[1].WorkspacePath = %q, want /tmp/detent-workspaces/i-2", snapshot.Running[1].WorkspacePath)
 	}
 	if snapshot.Running[0].Identifier != "ISS-1" || snapshot.Running[0].Title != "One" {
 		t.Fatalf("Running[0] issue mapping = %#v", snapshot.Running[0].Issue)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -47,6 +47,7 @@ type Running struct {
 	StartedAt       time.Time
 	WorkerHost      string
 	ProcessIdentity string
+	WorkspacePath   string
 	SessionID       string
 	TurnCount       int
 	LastEventAt     time.Time

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -889,6 +889,7 @@ func (r *Runner) publishRunUpdate(
 	usage := UsageUpdate{
 		SessionID:       progress.sessionID,
 		ProcessIdentity: progress.processIdentity,
+		WorkspacePath:   info.Path,
 		TurnCount:       progress.turnCount(),
 		LastEventAt:     progress.lastEventAt,
 		LastEvent:       progress.lastEvent,

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -161,6 +161,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if usageUpdates[0].ProcessIdentity != "4242" {
 		t.Fatalf("first usage update ProcessIdentity = %q, want 4242", usageUpdates[0].ProcessIdentity)
 	}
+	if usageUpdates[0].WorkspacePath != workspacePath {
+		t.Fatalf("first usage update WorkspacePath = %q, want %q", usageUpdates[0].WorkspacePath, workspacePath)
+	}
 	if usageUpdates[0].LastEvent != "agent_message_delta" || usageUpdates[0].LastMessage != "hello" {
 		t.Fatalf("first usage update activity = %#v, want agent message", usageUpdates[0])
 	}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -123,6 +123,7 @@ type UsageUpdateHandler func(UsageUpdate) error
 type UsageUpdate struct {
 	SessionID       string
 	ProcessIdentity string
+	WorkspacePath   string
 	TurnCount       int
 	LastEventAt     time.Time
 	LastEvent       string

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -116,24 +116,30 @@ type Counts struct {
 }
 
 type Issue struct {
-	ID             string       `json:"issue_id"`
-	Identifier     string       `json:"identifier,omitempty"`
-	ProjectID      string       `json:"project_id,omitempty"`
-	URL            string       `json:"url,omitempty"`
-	Title          string       `json:"title,omitempty"`
-	Description    string       `json:"description,omitempty"`
-	State          string       `json:"state,omitempty"`
-	Labels         []string     `json:"labels,omitempty"`
-	Assignees      []string     `json:"assignees,omitempty"`
-	BlockedBy      []BlockedRef `json:"blocked_by,omitempty"`
-	PullRequest    *PullRequest `json:"pull_request,omitempty"`
-	Owner          string       `json:"owner,omitempty"`
-	LeaseRenewedAt *time.Time   `json:"lease_renewed_at,omitempty"`
-	LeaseExpiresAt *time.Time   `json:"lease_expires_at,omitempty"`
-	LeaseStale     bool         `json:"lease_stale,omitempty"`
-	CreatedAt      *time.Time   `json:"created_at,omitempty"`
-	UpdatedAt      *time.Time   `json:"updated_at,omitempty"`
-	StageUpdatedAt *time.Time   `json:"stage_updated_at,omitempty"`
+	ID             string         `json:"issue_id"`
+	Identifier     string         `json:"identifier,omitempty"`
+	ProjectID      string         `json:"project_id,omitempty"`
+	URL            string         `json:"url,omitempty"`
+	Title          string         `json:"title,omitempty"`
+	Description    string         `json:"description,omitempty"`
+	State          string         `json:"state,omitempty"`
+	Labels         []string       `json:"labels,omitempty"`
+	Assignees      []string       `json:"assignees,omitempty"`
+	Comments       []IssueComment `json:"comments,omitempty"`
+	BlockedBy      []BlockedRef   `json:"blocked_by,omitempty"`
+	PullRequest    *PullRequest   `json:"pull_request,omitempty"`
+	Owner          string         `json:"owner,omitempty"`
+	LeaseRenewedAt *time.Time     `json:"lease_renewed_at,omitempty"`
+	LeaseExpiresAt *time.Time     `json:"lease_expires_at,omitempty"`
+	LeaseStale     bool           `json:"lease_stale,omitempty"`
+	CreatedAt      *time.Time     `json:"created_at,omitempty"`
+	UpdatedAt      *time.Time     `json:"updated_at,omitempty"`
+	StageUpdatedAt *time.Time     `json:"stage_updated_at,omitempty"`
+}
+
+type IssueComment struct {
+	Body string `json:"body,omitempty"`
+	URL  string `json:"url,omitempty"`
 }
 
 type BlockedRef struct {

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -123,6 +123,7 @@ func (s *Server) onboardingWrite(c echo.Context) error {
 	if len(problems) > 0 {
 		return s.renderOnboardingStep(c, form, problems, templates.OnboardingResult{})
 	}
+	beforeCloseout, beforeCloseoutOK := s.onboardingCloseoutSnapshot()
 
 	content := renderWorkflow(form, workflowSourceRoot(s.workflow))
 	workflow, err := config.ParseWorkflow([]byte(content))
@@ -140,9 +141,15 @@ func (s *Server) onboardingWrite(c echo.Context) error {
 	err = writeWorkflowFile(s.workflow, content, c.FormValue("replace") == "true")
 	switch {
 	case err == nil:
+		closeout := s.runOnboardingCloseout(c.Request().Context(), form, beforeCloseout, beforeCloseoutOK)
 		result := templates.OnboardingResult{
 			Kind:    "success",
 			Message: "Wrote " + workflowDisplayPath(s.workflow) + ".",
+			Details: closeout.details,
+		}
+		if !closeout.ok {
+			result.Kind = "warning"
+			result.Message = "Wrote " + workflowDisplayPath(s.workflow) + ". Closeout verifier needs attention."
 		}
 		return s.renderOnboardingStep(c, form, nil, result)
 	case errors.Is(err, errWorkflowExists):

--- a/internal/web/onboarding_closeout.go
+++ b/internal/web/onboarding_closeout.go
@@ -1,0 +1,602 @@
+package web
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web/templates"
+)
+
+const onboardingCloseoutWait = 1500 * time.Millisecond
+
+type onboardingCloseoutReport struct {
+	ok      bool
+	details []string
+}
+
+func (s *Server) onboardingCloseoutSnapshot() (telemetry.Snapshot, bool) {
+	if s.hub == nil {
+		return telemetry.Snapshot{}, false
+	}
+	return s.hub.Latest()
+}
+
+func (s *Server) runOnboardingCloseout(
+	ctx context.Context,
+	form templates.OnboardingForm,
+	before telemetry.Snapshot,
+	beforeOK bool,
+) onboardingCloseoutReport {
+	report := onboardingCloseoutReport{
+		ok:      true,
+		details: []string{"Closeout verifier"},
+	}
+	if s.hub == nil || s.refresher == nil {
+		report.ok = false
+		report.details = append(report.details,
+			"reload: stalled (live runtime snapshot or refresher is unavailable)",
+			"refresh: stalled (cannot request /api/v1/refresh from this onboarding context)",
+			onboardingActiveAgentInventory(before),
+			"restart requires operator confirmation after reviewing active agents",
+		)
+		return report
+	}
+
+	projectID := s.onboardingCloseoutProjectID(before, beforeOK)
+	beforeRunning := onboardingRunningIDs(before.Running)
+	sub, err := s.hub.Subscribe(ctx)
+	if err != nil {
+		sub = nil
+	}
+	if sub != nil {
+		defer sub.Close()
+	}
+
+	response, err := s.refresher.RequestRefresh(ctx)
+	if err != nil {
+		after, ok := s.onboardingCloseoutSnapshot()
+		if !ok {
+			after = before
+		}
+		report.ok = false
+		report.details = append(report.details,
+			"reload: stalled (refresh request failed)",
+			"refresh: stalled ("+err.Error()+")",
+			onboardingDispatchDetail(beforeRunning, projectID, before, after),
+			onboardingActiveAgentInventory(after),
+			"restart requires operator confirmation after reviewing active agents",
+		)
+		return report
+	}
+
+	after := s.waitOnboardingCloseoutSnapshot(ctx, sub, before, projectID, beforeRunning, response.RequestedAt)
+	if projectID == "" {
+		projectID = s.onboardingCloseoutProjectID(after, true)
+	}
+	if !onboardingReloadObserved(before, beforeOK, after, projectID, response.RequestedAt) {
+		report.ok = false
+		report.details = append(report.details, "reload: stalled")
+	} else {
+		report.details = append(report.details, "reload: observed project "+projectID)
+	}
+
+	if !onboardingRefreshAdvanced(before, beforeOK, after, projectID, response.RequestedAt) {
+		report.ok = false
+		report.details = append(report.details, "refresh: stalled")
+	} else {
+		report.details = append(report.details, "refresh: advanced")
+	}
+
+	if detail, ok := onboardingCandidateCountsDetail(form, after, projectID); detail != "" {
+		if !ok {
+			report.ok = false
+		}
+		report.details = append(report.details, detail)
+	}
+
+	dispatchDetails, dispatchOK := onboardingDispatchDetails(beforeRunning, projectID, before, after)
+	if !dispatchOK {
+		report.ok = false
+	}
+	report.details = append(report.details, dispatchDetails...)
+
+	if onboardingRefreshReflected(after, projectID, response.RequestedAt) {
+		report.details = append(report.details, "/api/v1/refresh: reflected in project state")
+	} else {
+		report.ok = false
+		report.details = append(report.details, "/api/v1/refresh: not reflected in project state")
+	}
+
+	if !report.ok {
+		report.details = append(report.details,
+			onboardingActiveAgentInventory(after),
+			"restart requires operator confirmation after reviewing active agents",
+		)
+	}
+	return report
+}
+
+func (s *Server) waitOnboardingCloseoutSnapshot(
+	ctx context.Context,
+	sub interface {
+		C() <-chan telemetry.Snapshot
+	},
+	before telemetry.Snapshot,
+	projectID string,
+	beforeRunning map[string]struct{},
+	requestedAt time.Time,
+) telemetry.Snapshot {
+	if after, ok := s.onboardingCloseoutSnapshot(); ok &&
+		onboardingCloseoutObserved(before, after, projectID, beforeRunning, requestedAt) {
+		return after
+	}
+	if sub == nil {
+		if after, ok := s.onboardingCloseoutSnapshot(); ok {
+			return after
+		}
+		return before
+	}
+
+	timer := time.NewTimer(onboardingCloseoutWait)
+	defer timer.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			if after, ok := s.onboardingCloseoutSnapshot(); ok {
+				return after
+			}
+			return before
+		case after, ok := <-sub.C():
+			if !ok {
+				if latest, latestOK := s.onboardingCloseoutSnapshot(); latestOK {
+					return latest
+				}
+				return before
+			}
+			if onboardingCloseoutObserved(before, after, projectID, beforeRunning, requestedAt) {
+				return after
+			}
+		case <-timer.C:
+			if after, ok := s.onboardingCloseoutSnapshot(); ok {
+				return after
+			}
+			return before
+		}
+	}
+}
+
+func onboardingCloseoutObserved(
+	before telemetry.Snapshot,
+	after telemetry.Snapshot,
+	projectID string,
+	beforeRunning map[string]struct{},
+	requestedAt time.Time,
+) bool {
+	if onboardingRefreshAdvanced(before, true, after, projectID, requestedAt) {
+		return true
+	}
+	return len(onboardingNewRunning(beforeRunning, projectID, after.Running)) > 0
+}
+
+func (s *Server) onboardingCloseoutProjectID(snapshot telemetry.Snapshot, snapshotOK bool) string {
+	if id := s.onboardingCloseoutProjectIDFromRegistry(); id != "" {
+		return id
+	}
+	if id := onboardingCloseoutProjectIDFromConfig(s.globalConfigSource, s.globalConfig, s.workflow); id != "" {
+		return id
+	}
+	if !snapshotOK {
+		return ""
+	}
+	if len(snapshot.Projects) == 1 {
+		return projectID(snapshot.Projects[0].Project)
+	}
+	if id := projectID(snapshot.Project); id != "" && !strings.EqualFold(id, "multiple projects") {
+		return id
+	}
+	return ""
+}
+
+func (s *Server) onboardingCloseoutProjectIDFromRegistry() string {
+	if s.registry == nil {
+		return ""
+	}
+	for _, trackedProject := range s.registry.List() {
+		if trackedProject == nil {
+			continue
+		}
+		if sameOnboardingWorkflowPath(trackedProject.Config().Workflow, s.workflow) {
+			return strings.TrimSpace(string(trackedProject.ID()))
+		}
+	}
+	return ""
+}
+
+func onboardingCloseoutProjectIDFromConfig(
+	source func() globalconfig.Config,
+	fallback globalconfig.Config,
+	workflowPath string,
+) string {
+	cfg := fallback
+	if source != nil {
+		cfg = source()
+	}
+	for _, project := range cfg.Projects {
+		if sameOnboardingWorkflowPath(project.Workflow, workflowPath) {
+			return strings.TrimSpace(project.ID)
+		}
+	}
+	return ""
+}
+
+func sameOnboardingWorkflowPath(left string, right string) bool {
+	left = cleanOnboardingWorkflowPath(left)
+	right = cleanOnboardingWorkflowPath(right)
+	return left != "" && right != "" && left == right
+}
+
+func cleanOnboardingWorkflowPath(path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return ""
+	}
+	absolute, err := filepath.Abs(path)
+	if err == nil {
+		path = absolute
+	}
+	return filepath.Clean(path)
+}
+
+func onboardingReloadObserved(
+	before telemetry.Snapshot,
+	beforeOK bool,
+	after telemetry.Snapshot,
+	projectID string,
+	requestedAt time.Time,
+) bool {
+	if projectID == "" {
+		return false
+	}
+	if _, ok := onboardingProjectRefresh(after, projectID); !ok {
+		return false
+	}
+	if !beforeOK {
+		return true
+	}
+	return onboardingRefreshAdvanced(before, beforeOK, after, projectID, requestedAt)
+}
+
+func onboardingRefreshAdvanced(
+	before telemetry.Snapshot,
+	beforeOK bool,
+	after telemetry.Snapshot,
+	projectID string,
+	requestedAt time.Time,
+) bool {
+	afterRefresh, ok := onboardingProjectRefresh(after, projectID)
+	if !ok || afterRefresh.LastRefreshAt == nil {
+		return false
+	}
+	if !requestedAt.IsZero() && afterRefresh.LastRefreshAt.Before(requestedAt) {
+		return false
+	}
+	if !beforeOK {
+		return true
+	}
+	beforeRefresh, ok := onboardingProjectRefresh(before, projectID)
+	if !ok || beforeRefresh.LastRefreshAt == nil {
+		return true
+	}
+	return afterRefresh.LastRefreshAt.After(*beforeRefresh.LastRefreshAt)
+}
+
+func onboardingRefreshReflected(snapshot telemetry.Snapshot, projectID string, requestedAt time.Time) bool {
+	if requestedAt.IsZero() {
+		return true
+	}
+	refresh, ok := onboardingProjectRefresh(snapshot, projectID)
+	return ok && refresh.LastRefreshAt != nil && !refresh.LastRefreshAt.Before(requestedAt)
+}
+
+func onboardingProjectRefresh(snapshot telemetry.Snapshot, projectID string) (telemetry.Refresh, bool) {
+	projectID = strings.TrimSpace(projectID)
+	if projectID != "" {
+		if project, ok := projectSnapshotForID(snapshot, projectID); ok {
+			if projectSnapshotHasRefreshSignal(project) {
+				return project.Refresh, true
+			}
+		}
+		if telemetryProjectMatches(snapshot.Project, projectID) && refreshHasSignal(snapshot.Refresh) {
+			return snapshot.Refresh, true
+		}
+	}
+	if refreshHasSignal(snapshot.Refresh) {
+		return snapshot.Refresh, true
+	}
+	return telemetry.Refresh{}, false
+}
+
+func refreshHasSignal(refresh telemetry.Refresh) bool {
+	return refresh.PollIntervalSeconds != 0 ||
+		refresh.Status != "" ||
+		refresh.LastRefreshAt != nil ||
+		refresh.NextRefreshAt != nil ||
+		strings.TrimSpace(refresh.LastError) != "" ||
+		refresh.LastErrorAt != nil
+}
+
+func onboardingCandidateCountsDetail(
+	form templates.OnboardingForm,
+	snapshot telemetry.Snapshot,
+	projectID string,
+) (string, bool) {
+	if normalizedOnboardingGitHubStatusSource(form.GitHubStatusSource) != workflowconfig.GitHubStatusSourceLabel {
+		return "", true
+	}
+	prefix := strings.TrimSpace(form.StatusLabelPrefix)
+	if prefix == "" {
+		prefix = defaultStatusLabelPrefix
+	}
+	issues := onboardingProjectIssues(snapshot, projectID)
+	if len(issues) == 0 {
+		return "candidate counts: no issues observed for expected status labels", false
+	}
+	mismatches := []string{}
+	matches := 0
+	for _, issue := range issues {
+		label := onboardingStatusLabel(prefix, issue.State)
+		if label == "" {
+			continue
+		}
+		if onboardingIssueHasLabel(issue, label) {
+			matches++
+			continue
+		}
+		if onboardingIssueHasStatusPrefix(issue, prefix) {
+			mismatches = append(mismatches, onboardingIssueLabel(issue)+" expected "+label)
+		}
+	}
+	if len(mismatches) > 0 {
+		sort.Strings(mismatches)
+		return "candidate counts: status label mismatch (" + strings.Join(mismatches, "; ") + ")", false
+	}
+	if matches == 0 {
+		return "candidate counts: no issues observed for expected status labels", false
+	}
+	return "candidate counts: expected status labels matched", true
+}
+
+func onboardingProjectIssues(snapshot telemetry.Snapshot, projectID string) []telemetry.Issue {
+	issues := make([]telemetry.Issue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked))
+	for _, issue := range snapshot.BoardIssues {
+		if onboardingIssueMatchesProject(issue, projectID) {
+			issues = append(issues, issue)
+		}
+	}
+	for _, issue := range snapshot.Pipeline {
+		if onboardingIssueMatchesProject(issue, projectID) {
+			issues = append(issues, issue)
+		}
+	}
+	for _, running := range snapshot.Running {
+		if onboardingIssueMatchesProject(running.Issue, projectID) {
+			issues = append(issues, running.Issue)
+		}
+	}
+	for _, queued := range snapshot.Queue {
+		if onboardingIssueMatchesProject(queued.Issue, projectID) {
+			issues = append(issues, queued.Issue)
+		}
+	}
+	for _, blocked := range snapshot.Blocked {
+		if onboardingIssueMatchesProject(blocked.Issue, projectID) {
+			issues = append(issues, blocked.Issue)
+		}
+	}
+	return issues
+}
+
+func onboardingIssueMatchesProject(issue telemetry.Issue, projectID string) bool {
+	projectID = strings.TrimSpace(projectID)
+	return projectID == "" || strings.TrimSpace(issue.ProjectID) == "" || strings.TrimSpace(issue.ProjectID) == projectID
+}
+
+func onboardingIssueHasLabel(issue telemetry.Issue, label string) bool {
+	for _, candidate := range issue.Labels {
+		if strings.EqualFold(strings.TrimSpace(candidate), label) {
+			return true
+		}
+	}
+	return false
+}
+
+func onboardingIssueHasStatusPrefix(issue telemetry.Issue, prefix string) bool {
+	for _, label := range issue.Labels {
+		if strings.HasPrefix(strings.ToLower(strings.TrimSpace(label)), strings.ToLower(prefix)) {
+			return true
+		}
+	}
+	return false
+}
+
+func onboardingStatusLabel(prefix string, state string) string {
+	slug := onboardingStatusSlug(state)
+	if slug == "" {
+		return ""
+	}
+	return prefix + slug
+}
+
+func onboardingStatusSlug(value string) string {
+	value = strings.ToLower(strings.TrimSpace(value))
+	var b strings.Builder
+	lastSeparator := false
+	for _, r := range value {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastSeparator = false
+		default:
+			if b.Len() == 0 || lastSeparator {
+				continue
+			}
+			b.WriteByte('-')
+			lastSeparator = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
+}
+
+func onboardingRunningIDs(entries []telemetry.Running) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, entry := range entries {
+		key := onboardingRunningKey(entry)
+		if key != "" {
+			out[key] = struct{}{}
+		}
+	}
+	return out
+}
+
+func onboardingNewRunning(before map[string]struct{}, projectID string, after []telemetry.Running) []telemetry.Running {
+	out := []telemetry.Running{}
+	for _, entry := range after {
+		if !onboardingIssueMatchesProject(entry.Issue, projectID) {
+			continue
+		}
+		key := onboardingRunningKey(entry)
+		if key == "" {
+			continue
+		}
+		if _, ok := before[key]; ok {
+			continue
+		}
+		out = append(out, entry)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		return onboardingIssueLabel(out[i].Issue) < onboardingIssueLabel(out[j].Issue)
+	})
+	return out
+}
+
+func onboardingRunningKey(entry telemetry.Running) string {
+	if id := strings.TrimSpace(entry.ID); id != "" {
+		return id
+	}
+	if id := strings.TrimSpace(entry.Identifier); id != "" {
+		return id
+	}
+	return strings.TrimSpace(entry.SessionID)
+}
+
+func onboardingDispatchDetail(
+	beforeRunning map[string]struct{},
+	projectID string,
+	before telemetry.Snapshot,
+	after telemetry.Snapshot,
+) string {
+	details, _ := onboardingDispatchDetails(beforeRunning, projectID, before, after)
+	if len(details) == 0 {
+		return "dispatch: no new running issue observed"
+	}
+	return details[0]
+}
+
+func onboardingDispatchDetails(
+	beforeRunning map[string]struct{},
+	projectID string,
+	before telemetry.Snapshot,
+	after telemetry.Snapshot,
+) ([]string, bool) {
+	started := onboardingNewRunning(beforeRunning, projectID, after.Running)
+	if len(started) == 0 {
+		return []string{onboardingDispatchStallReason(before, after, projectID)}, false
+	}
+	details := []string{}
+	ok := true
+	for _, entry := range started {
+		label := onboardingIssueLabel(entry.Issue)
+		details = append(details, "dispatch: started "+label)
+		if strings.TrimSpace(entry.WorkspacePath) == "" {
+			ok = false
+			details = append(details, "worktree: missing for "+label)
+		} else {
+			details = append(details, "worktree: present for "+label)
+		}
+		if onboardingIssueHasWorkpad(entry.Issue) {
+			details = append(details, "Workpad: present for "+label)
+		} else {
+			ok = false
+			details = append(details, "Workpad: missing for "+label)
+		}
+	}
+	return details, ok
+}
+
+func onboardingDispatchStallReason(before telemetry.Snapshot, after telemetry.Snapshot, projectID string) string {
+	if after.Shutdown.Draining {
+		return "dispatch: no new running issue observed (runtime is draining)"
+	}
+	if len(onboardingProjectIssues(after, projectID)) == 0 {
+		return "dispatch: no new running issue observed (no candidate issues in project state)"
+	}
+	if after.Counts.Queue > before.Counts.Queue {
+		return "dispatch: no new running issue observed (issues queued for retry)"
+	}
+	if after.Counts.Blocked > before.Counts.Blocked {
+		return "dispatch: no new running issue observed (issues blocked)"
+	}
+	return "dispatch: no new running issue observed"
+}
+
+func onboardingIssueHasWorkpad(issue telemetry.Issue) bool {
+	for _, comment := range issue.Comments {
+		if strings.Contains(comment.Body, "## Codex Workpad") {
+			return true
+		}
+	}
+	return false
+}
+
+func onboardingIssueLabel(issue telemetry.Issue) string {
+	if identifier := strings.TrimSpace(issue.Identifier); identifier != "" {
+		return identifier
+	}
+	if id := strings.TrimSpace(issue.ID); id != "" {
+		return id
+	}
+	return "unknown issue"
+}
+
+func onboardingActiveAgentInventory(snapshot telemetry.Snapshot) string {
+	if len(snapshot.Running) == 0 {
+		return "active agents: none observed"
+	}
+	entries := make([]string, 0, len(snapshot.Running))
+	for _, running := range snapshot.Running {
+		entries = append(entries, fmt.Sprintf("%s session=%s pid=%s worker=%s worktree=%s",
+			onboardingIssueLabel(running.Issue),
+			onboardingInventoryValue(running.SessionID),
+			onboardingInventoryValue(running.ProcessIdentity),
+			onboardingInventoryValue(running.WorkerHost),
+			onboardingInventoryValue(running.WorkspacePath),
+		))
+	}
+	sort.Strings(entries)
+	return "active agents: " + strings.Join(entries, "; ")
+}
+
+func onboardingInventoryValue(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return "unknown"
+	}
+	return value
+}

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -1,6 +1,7 @@
 package web_test
 
 import (
+	"context"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -9,8 +10,13 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
@@ -693,6 +699,224 @@ func TestOnboardingWriteMemoryWorkflowSeedsSampleIssue(t *testing.T) {
 	}
 }
 
+func TestOnboardingWriteRunsCloseoutVerifierAfterMutation(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	snapshots := hub.New[telemetry.Snapshot]()
+	beforeRefresh := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+	requestedAt := beforeRefresh.Add(30 * time.Second)
+	afterRefresh := beforeRefresh.Add(time.Minute)
+	if err := snapshots.Publish(telemetry.Snapshot{
+		GeneratedAt: beforeRefresh,
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{{
+			Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+			Refresh: telemetry.Refresh{
+				Status:        telemetry.RefreshStatusReady,
+				LastRefreshAt: &beforeRefresh,
+			},
+		}},
+		Refresh: telemetry.Refresh{
+			Status:        telemetry.RefreshStatusReady,
+			LastRefreshAt: &beforeRefresh,
+		},
+		BoardIssues: []telemetry.Issue{
+			{
+				ID:         "issue-todo",
+				Identifier: "digitaldrywood/detent#646",
+				ProjectID:  "detent",
+				State:      "Todo",
+				Labels:     []string{"detent:todo", "enhancement"},
+			},
+			{
+				ID:         "issue-review",
+				Identifier: "digitaldrywood/detent#645",
+				ProjectID:  "detent",
+				State:      "Human Review",
+				Labels:     []string{"detent:human-review"},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	deps := testDeps(t)
+	deps.Hub = snapshots
+	deps.Registry = project.NewRegistry()
+	mustSetOnboardingProject(t, deps.Registry, "detent", workflowPath)
+	refresher := &publishSnapshotRefreshProbe{
+		hub: snapshots,
+		response: web.RefreshResponse{
+			Queued:      true,
+			RequestedAt: requestedAt,
+			Operations:  []string{"poll", "reconcile"},
+		},
+		snapshot: telemetry.Snapshot{
+			GeneratedAt: afterRefresh,
+			Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+			Projects: []telemetry.ProjectSnapshot{{
+				Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+				Counts:  telemetry.Counts{Running: 1},
+				Refresh: telemetry.Refresh{
+					Status:        telemetry.RefreshStatusReady,
+					LastRefreshAt: &afterRefresh,
+				},
+			}},
+			Refresh: telemetry.Refresh{
+				Status:        telemetry.RefreshStatusReady,
+				LastRefreshAt: &afterRefresh,
+			},
+			BoardIssues: []telemetry.Issue{
+				{
+					ID:         "issue-todo",
+					Identifier: "digitaldrywood/detent#646",
+					ProjectID:  "detent",
+					State:      "Todo",
+					Labels:     []string{"detent:todo", "enhancement"},
+				},
+				{
+					ID:         "issue-review",
+					Identifier: "digitaldrywood/detent#645",
+					ProjectID:  "detent",
+					State:      "Human Review",
+					Labels:     []string{"detent:human-review"},
+				},
+			},
+			Running: []telemetry.Running{{
+				Issue: telemetry.Issue{
+					ID:         "issue-running",
+					Identifier: "digitaldrywood/detent#647",
+					ProjectID:  "detent",
+					State:      "In Progress",
+					Labels:     []string{"detent:in-progress"},
+					Comments: []telemetry.IssueComment{{
+						Body: "## Codex Workpad\n\n### Status\nIn Progress",
+					}},
+				},
+				WorkspacePath:   filepath.Join(t.TempDir(), "detent-647"),
+				SessionID:       "session-647",
+				ProcessIdentity: "4242",
+				WorkerHost:      "worker-a",
+			}},
+		},
+	}
+	deps.Refresher = refresher
+	server, err := web.NewServer(web.Config{WorkflowPath: workflowPath}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := validOnboardingForm()
+	form.Set("github_status_source", workflowconfig.GitHubStatusSourceLabel)
+	form.Del("project_slug")
+	form.Set("status_label_prefix", "detent:")
+	rec := httptest.NewRecorder()
+	req := onboardingRequest(http.MethodPost, "/onboarding/write", form)
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if refresher.calls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", refresher.calls)
+	}
+	for _, want := range []string{
+		"Wrote WORKFLOW.md",
+		"Closeout verifier",
+		"reload: observed project detent",
+		"refresh: advanced",
+		"candidate counts: expected status labels matched",
+		"dispatch: started digitaldrywood/detent#647",
+		"worktree: present",
+		"Workpad: present",
+		"/api/v1/refresh: reflected in project state",
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
+		}
+	}
+}
+
+func TestOnboardingWriteCloseoutVerifierReportsStalledReload(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
+	snapshots := hub.New[telemetry.Snapshot]()
+	lastRefresh := time.Date(2026, 6, 23, 10, 0, 0, 0, time.UTC)
+	if err := snapshots.Publish(telemetry.Snapshot{
+		GeneratedAt: lastRefresh,
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{{
+			Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+			Refresh: telemetry.Refresh{
+				Status:        telemetry.RefreshStatusReady,
+				LastRefreshAt: &lastRefresh,
+			},
+		}},
+		Refresh: telemetry.Refresh{
+			Status:        telemetry.RefreshStatusReady,
+			LastRefreshAt: &lastRefresh,
+		},
+		Running: []telemetry.Running{{
+			Issue: telemetry.Issue{
+				ID:         "issue-active",
+				Identifier: "digitaldrywood/detent#640",
+				ProjectID:  "detent",
+				State:      "In Progress",
+			},
+			WorkspacePath:   "/tmp/detent-640",
+			SessionID:       "session-640",
+			ProcessIdentity: "31337",
+			WorkerHost:      "worker-b",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	deps := testDeps(t)
+	deps.Hub = snapshots
+	deps.Registry = project.NewRegistry()
+	mustSetOnboardingProject(t, deps.Registry, "detent", workflowPath)
+	deps.Refresher = &refreshProbe{
+		response: web.RefreshResponse{
+			Queued:      true,
+			RequestedAt: lastRefresh.Add(30 * time.Second),
+			Operations:  []string{"poll", "reconcile"},
+		},
+	}
+	server, err := web.NewServer(web.Config{WorkflowPath: workflowPath}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := validOnboardingForm()
+	form.Set("github_status_source", workflowconfig.GitHubStatusSourceLabel)
+	form.Del("project_slug")
+	form.Set("status_label_prefix", "detent:")
+	rec := httptest.NewRecorder()
+	req := onboardingRequest(http.MethodPost, "/onboarding/write", form)
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	for _, want := range []string{
+		"Closeout verifier",
+		"reload: stalled",
+		"refresh: stalled",
+		"dispatch: no new running issue observed",
+		"active agents: digitaldrywood/detent#640 session=session-640 pid=31337 worker=worker-b worktree=/tmp/detent-640",
+		"restart requires operator confirmation",
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
+		}
+	}
+}
+
 func TestOnboardingWriteDoesNotOverwriteWithoutReplace(t *testing.T) {
 	t.Parallel()
 
@@ -865,4 +1089,44 @@ func onboardingRequest(method string, path string, form url.Values) *http.Reques
 		req.Header.Set("HX-Request", "true")
 	}
 	return req
+}
+
+func mustSetOnboardingProject(t *testing.T, registry *project.Registry, id string, workflowPath string) {
+	t.Helper()
+
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.Kind = workflowconfig.TrackerMemory
+	trackedProject, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:       id,
+			Workflow: workflowPath,
+		},
+		Workflow: workflowconfig.Workflow{
+			Config: workflowCfg,
+			Prompt: "Work the issue.",
+		},
+	}, project.Dependencies{
+		Connector: connectorProbe{name: "memory"},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := registry.Set(trackedProject); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+}
+
+type publishSnapshotRefreshProbe struct {
+	hub      *hub.Hub[telemetry.Snapshot]
+	response web.RefreshResponse
+	snapshot telemetry.Snapshot
+	calls    int
+}
+
+func (p *publishSnapshotRefreshProbe) RequestRefresh(context.Context) (web.RefreshResponse, error) {
+	p.calls++
+	if err := p.hub.Publish(p.snapshot); err != nil {
+		return web.RefreshResponse{}, err
+	}
+	return p.response, nil
 }

--- a/internal/web/templates/onboarding.templ
+++ b/internal/web/templates/onboarding.templ
@@ -42,6 +42,7 @@ type OnboardingForm struct {
 type OnboardingResult struct {
 	Kind    string
 	Message string
+	Details []string
 }
 
 type onboardingProgressItem struct {
@@ -458,6 +459,12 @@ templ resultPanel(data OnboardingData) {
 	if data.Result.Kind == "success" {
 		<div class="mt-4 rounded-md border border-success bg-card p-4 text-sm text-success">
 			<strong>{ data.Result.Message }</strong>
+			@resultDetails(data.Result)
+		</div>
+	} else if data.Result.Kind == "warning" {
+		<div class="mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning">
+			<strong>{ data.Result.Message }</strong>
+			@resultDetails(data.Result)
 		</div>
 	} else if data.Result.Kind == "exists" {
 		<div class="mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning">
@@ -471,7 +478,18 @@ templ resultPanel(data OnboardingData) {
 	} else if data.Result.Kind == "error" {
 		<div class="mt-4 rounded-md border border-danger bg-card p-4 text-sm text-danger">
 			<strong>{ data.Result.Message }</strong>
+			@resultDetails(data.Result)
 		</div>
+	}
+}
+
+templ resultDetails(result OnboardingResult) {
+	if len(result.Details) > 0 {
+		<ul class="mt-3 list-disc space-y-1 pl-5">
+			for _, detail := range result.Details {
+				<li>{ detail }</li>
+			}
+		</ul>
 	}
 }
 

--- a/internal/web/templates/onboarding_templ.go
+++ b/internal/web/templates/onboarding_templ.go
@@ -50,6 +50,7 @@ type OnboardingForm struct {
 type OnboardingResult struct {
 	Kind    string
 	Message string
+	Details []string
 }
 
 type onboardingProgressItem struct {
@@ -189,7 +190,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(applicationName(data.ApplicationName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 162, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 163, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -202,7 +203,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 163, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 164, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -215,7 +216,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(faviconPath(data.Assets))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 164, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 165, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -228,7 +229,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var5 templ.SafeURL
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(stylesheetPath(data.Assets))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 165, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 166, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -299,7 +300,7 @@ func onboardingTopbarBrand(instanceName string) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(instanceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 188, Col: 188}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 189, Col: 188}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -388,7 +389,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var10 templ.SafeURL
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 202, Col: 222}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 203, Col: 222}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -401,7 +402,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 202, Col: 252}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 203, Col: 252}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -419,7 +420,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var12 templ.SafeURL
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 204, Col: 208}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 205, Col: 208}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -432,7 +433,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 204, Col: 218}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 205, Col: 218}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -498,7 +499,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(item.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 213, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 214, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -534,7 +535,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 				var templ_7745c5c3_Var18 string
 				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(problem)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 223, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 224, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
@@ -612,7 +613,7 @@ func onboardingStepBadge(step string) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(step)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 245, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 246, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -725,7 +726,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 266, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 267, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -748,7 +749,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 268, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 269, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -761,7 +762,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 269, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 270, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -839,7 +840,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var31 string
 			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Endpoint)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 284, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 285, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
@@ -874,7 +875,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.APIKey)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 288, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 289, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
@@ -965,7 +966,7 @@ func projectStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(projectStepTitle(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 301, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 302, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
@@ -1018,7 +1019,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var43 string
 			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 310, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 311, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 			if templ_7745c5c3_Err != nil {
@@ -1053,7 +1054,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusField)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 314, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 315, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -1093,7 +1094,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 319, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 320, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
@@ -1128,7 +1129,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var52 string
 			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusLabelPrefix)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 323, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 324, Col: 109}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 			if templ_7745c5c3_Err != nil {
@@ -1168,7 +1169,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var55 string
 			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 328, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 329, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 			if templ_7745c5c3_Err != nil {
@@ -1203,7 +1204,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var58 string
 			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 332, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 333, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 			if templ_7745c5c3_Err != nil {
@@ -1336,7 +1337,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var66 string
 		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 355, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 356, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 		if templ_7745c5c3_Err != nil {
@@ -1371,7 +1372,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var69 string
 		templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 359, Col: 122}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 360, Col: 122}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 		if templ_7745c5c3_Err != nil {
@@ -1406,7 +1407,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var72 string
 		templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxTurns)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 363, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 364, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 		if templ_7745c5c3_Err != nil {
@@ -1441,7 +1442,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var75 string
 		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(data.Polling.MinIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 367, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 368, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 		if templ_7745c5c3_Err != nil {
@@ -1454,7 +1455,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var76 string
 		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.PollingIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 367, Col: 145}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 368, Col: 145}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 		if templ_7745c5c3_Err != nil {
@@ -1489,7 +1490,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var79 string
 		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MergingConcurrency)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 371, Col: 119}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 372, Col: 119}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 		if templ_7745c5c3_Err != nil {
@@ -1524,7 +1525,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var82 string
 		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.DispatchPriorityState)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 375, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 376, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
@@ -1559,7 +1560,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var85 string
 		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.DispatchPriorityLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 379, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 380, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 		if templ_7745c5c3_Err != nil {
@@ -1667,7 +1668,7 @@ func deliveryProfileChoice(data OnboardingData, value string, label string, desc
 		var templ_7745c5c3_Var91 string
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 406, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 407, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
@@ -1690,7 +1691,7 @@ func deliveryProfileChoice(data OnboardingData, value string, label string, desc
 		var templ_7745c5c3_Var92 string
 		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 408, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 409, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 		if templ_7745c5c3_Err != nil {
@@ -1703,7 +1704,7 @@ func deliveryProfileChoice(data OnboardingData, value string, label string, desc
 		var templ_7745c5c3_Var93 string
 		templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 409, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 410, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 		if templ_7745c5c3_Err != nil {
@@ -1745,7 +1746,7 @@ func kanbanModeChoice(form OnboardingForm, value string, label string, descripti
 		var templ_7745c5c3_Var95 string
 		templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 416, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 417, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 		if templ_7745c5c3_Err != nil {
@@ -1768,7 +1769,7 @@ func kanbanModeChoice(form OnboardingForm, value string, label string, descripti
 		var templ_7745c5c3_Var96 string
 		templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 418, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 419, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
 		if templ_7745c5c3_Err != nil {
@@ -1781,7 +1782,7 @@ func kanbanModeChoice(form OnboardingForm, value string, label string, descripti
 		var templ_7745c5c3_Var97 string
 		templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 419, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 420, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 		if templ_7745c5c3_Err != nil {
@@ -1823,7 +1824,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var99 string
 		templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 428, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 429, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
 		if templ_7745c5c3_Err != nil {
@@ -1836,7 +1837,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var100 string
 		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(deliveryProfileLabel(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 429, Col: 106}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 430, Col: 106}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 		if templ_7745c5c3_Err != nil {
@@ -1854,7 +1855,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var101 string
 			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 431, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 432, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 			if templ_7745c5c3_Err != nil {
@@ -1873,7 +1874,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var102 string
 			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(githubStatusSource(data.Form))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 434, Col: 102}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 435, Col: 102}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 			if templ_7745c5c3_Err != nil {
@@ -1892,7 +1893,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var103 string
 			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 437, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 438, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 			if templ_7745c5c3_Err != nil {
@@ -1911,7 +1912,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var104 string
 			templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusField)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 440, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 441, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 			if templ_7745c5c3_Err != nil {
@@ -1930,7 +1931,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var105 string
 			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusLabelPrefix)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 443, Col: 106}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 444, Col: 106}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 			if templ_7745c5c3_Err != nil {
@@ -1948,7 +1949,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var106 string
 		templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanMode(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 445, Col: 94}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 446, Col: 94}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 		if templ_7745c5c3_Err != nil {
@@ -1961,7 +1962,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var107 string
 		templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(data.WorkflowPath)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 446, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 447, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 		if templ_7745c5c3_Err != nil {
@@ -1974,7 +1975,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var108 string
 		templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(deliveryProfileExplanation(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 447, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 448, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 		if templ_7745c5c3_Err != nil {
@@ -2051,31 +2052,65 @@ func resultPanel(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var112 string
 			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 460, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 461, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "</strong></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 151, "</strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-		} else if data.Result.Kind == "exists" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "<div class=\"mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning\"><p><strong>")
+			templ_7745c5c3_Err = resultDetails(data.Result).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 152, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if data.Result.Kind == "warning" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "<div class=\"mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning\"><strong>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var113 string
 			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 464, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 466, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 153, "</strong></p><form class=\"mt-3\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "</strong>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = resultDetails(data.Result).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if data.Result.Kind == "exists" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "<div class=\"mt-4 rounded-md border border-warning bg-card p-4 text-sm text-warning\"><p><strong>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var114 string
+			templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 471, Col: 35}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "</strong></p><form class=\"mt-3\" hx-post=\"/onboarding/write\" hx-target=\"#onboarding-step\" hx-swap=\"outerHTML\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2083,47 +2118,109 @@ func resultPanel(data OnboardingData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 154, "<input type=\"hidden\" name=\"replace\" value=\"true\"> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "<input type=\"hidden\" name=\"replace\" value=\"true\"> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var114 = []any{buttonClass()}
-			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var114...)
+			var templ_7745c5c3_Var115 = []any{buttonClass()}
+			templ_7745c5c3_Err = templ.RenderCSSItems(ctx, templ_7745c5c3_Buffer, templ_7745c5c3_Var115...)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 155, "<button class=\"")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			var templ_7745c5c3_Var115 string
-			templ_7745c5c3_Var115, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var114).String())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 1, Col: 0}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var115))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 156, "\" type=\"submit\">Overwrite</button></form></div>")
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-		} else if data.Result.Kind == "error" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 157, "<div class=\"mt-4 rounded-md border border-danger bg-card p-4 text-sm text-danger\"><strong>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "<button class=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var116 string
-			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
+			templ_7745c5c3_Var116, templ_7745c5c3_Err = templ.JoinStringErrs(templ.CSSClasses(templ_7745c5c3_Var115).String())
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 473, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 1, Col: 0}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var116))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 158, "</strong></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "\" type=\"submit\">Overwrite</button></form></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		} else if data.Result.Kind == "error" {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "<div class=\"mt-4 rounded-md border border-danger bg-card p-4 text-sm text-danger\"><strong>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			var templ_7745c5c3_Var117 string
+			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 480, Col: 32}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "</strong>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = resultDetails(data.Result).Render(ctx, templ_7745c5c3_Buffer)
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "</div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		return nil
+	})
+}
+
+func resultDetails(result OnboardingResult) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var118 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var118 == nil {
+			templ_7745c5c3_Var118 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		if len(result.Details) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "<ul class=\"mt-3 list-disc space-y-1 pl-5\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, detail := range result.Details {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "<li>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var119 string
+				templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(detail)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 490, Col: 16}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "</li>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "</ul>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -2148,38 +2245,38 @@ func hiddenTracker(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var117 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var117 == nil {
-			templ_7745c5c3_Var117 = templ.NopComponent
+		templ_7745c5c3_Var120 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var120 == nil {
+			templ_7745c5c3_Var120 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 159, "<input type=\"hidden\" name=\"tracker_kind\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "<input type=\"hidden\" name=\"tracker_kind\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var118 string
-		templ_7745c5c3_Var118, templ_7745c5c3_Err = templ.JoinStringErrs(form.TrackerKind)
+		var templ_7745c5c3_Var121 string
+		templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 479, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 497, Col: 66}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var118))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 160, "\"> <input type=\"hidden\" name=\"github_status_source\" value=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var119 string
-		templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(form.GitHubStatusSource)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 480, Col: 81}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "\"> <input type=\"hidden\" name=\"github_status_source\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 161, "\">")
+		var templ_7745c5c3_Var122 string
+		templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(form.GitHubStatusSource)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 498, Col: 81}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2203,42 +2300,42 @@ func hiddenCredentials(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var120 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var120 == nil {
-			templ_7745c5c3_Var120 = templ.NopComponent
+		templ_7745c5c3_Var123 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var123 == nil {
+			templ_7745c5c3_Var123 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = hiddenTracker(form).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 162, "<input type=\"hidden\" name=\"endpoint\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "<input type=\"hidden\" name=\"endpoint\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var121 string
-		templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(form.Endpoint)
+		var templ_7745c5c3_Var124 string
+		templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(form.Endpoint)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 485, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 503, Col: 59}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 163, "\"> <input type=\"hidden\" name=\"api_key\" value=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var122 string
-		templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(form.APIKey)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 486, Col: 56}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "\"> <input type=\"hidden\" name=\"api_key\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 164, "\">")
+		var templ_7745c5c3_Var125 string
+		templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(form.APIKey)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 504, Col: 56}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2262,68 +2359,68 @@ func hiddenProject(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var123 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var123 == nil {
-			templ_7745c5c3_Var123 = templ.NopComponent
+		templ_7745c5c3_Var126 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var126 == nil {
+			templ_7745c5c3_Var126 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = hiddenCredentials(form).Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 165, "<input type=\"hidden\" name=\"project_slug\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var124 string
-		templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(form.ProjectSlug)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 491, Col: 66}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 166, "\"> <input type=\"hidden\" name=\"repo\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var125 string
-		templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(form.Repo)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 492, Col: 51}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 167, "\"> <input type=\"hidden\" name=\"status_field\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var126 string
-		templ_7745c5c3_Var126, templ_7745c5c3_Err = templ.JoinStringErrs(form.StatusField)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 493, Col: 66}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var126))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 168, "\"> <input type=\"hidden\" name=\"status_label_prefix\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "<input type=\"hidden\" name=\"project_slug\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var127 string
-		templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(form.StatusLabelPrefix)
+		templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(form.ProjectSlug)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 494, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 509, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 169, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "\"> <input type=\"hidden\" name=\"repo\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var128 string
+		templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(form.Repo)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 510, Col: 51}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "\"> <input type=\"hidden\" name=\"status_field\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var129 string
+		templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(form.StatusField)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 511, Col: 66}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "\"> <input type=\"hidden\" name=\"status_label_prefix\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var130 string
+		templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(form.StatusLabelPrefix)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 512, Col: 79}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var130))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -2347,9 +2444,9 @@ func hiddenAgent(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var128 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var128 == nil {
-			templ_7745c5c3_Var128 = templ.NopComponent
+		templ_7745c5c3_Var131 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var131 == nil {
+			templ_7745c5c3_Var131 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		templ_7745c5c3_Err = hiddenProject(form).Render(ctx, templ_7745c5c3_Buffer)
@@ -2380,142 +2477,142 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var129 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var129 == nil {
-			templ_7745c5c3_Var129 = templ.NopComponent
+		templ_7745c5c3_Var132 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var132 == nil {
+			templ_7745c5c3_Var132 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 170, "<input type=\"hidden\" name=\"workspace_root\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var130 string
-		templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(form.WorkspaceRoot)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 503, Col: 70}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var130))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 171, "\"> <input type=\"hidden\" name=\"max_concurrent_agents\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var131 string
-		templ_7745c5c3_Var131, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxConcurrentAgents)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 504, Col: 83}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var131))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 172, "\"> <input type=\"hidden\" name=\"max_turns\" value=\"")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		var templ_7745c5c3_Var132 string
-		templ_7745c5c3_Var132, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxTurns)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 505, Col: 60}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var132))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 173, "\"> <input type=\"hidden\" name=\"polling_interval_ms\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "<input type=\"hidden\" name=\"workspace_root\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var133 string
-		templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(form.PollingIntervalMS)
+		templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 506, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 521, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 174, "\"> <input type=\"hidden\" name=\"merging_concurrency\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "\"> <input type=\"hidden\" name=\"max_concurrent_agents\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var134 string
-		templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(form.MergingConcurrency)
+		templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 507, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 522, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 175, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_state\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 181, "\"> <input type=\"hidden\" name=\"max_turns\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var135 string
-		templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityState)
+		templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxTurns)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 508, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 523, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 176, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_label\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 182, "\"> <input type=\"hidden\" name=\"polling_interval_ms\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var136 string
-		templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityLabel)
+		templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(form.PollingIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 509, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 524, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 177, "\"> <input type=\"hidden\" name=\"delivery_profile\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 183, "\"> <input type=\"hidden\" name=\"merging_concurrency\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var137 string
-		templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(form.DeliveryProfile)
+		templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(form.MergingConcurrency)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 510, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 525, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 178, "\"> <input type=\"hidden\" name=\"dependency_auto_unblock_enabled\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 184, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_state\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var138 string
-		templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(form.DependencyAutoUnblockEnabled)
+		templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityState)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 511, Col: 102}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 526, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 179, "\"> <input type=\"hidden\" name=\"kanban_mode\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 185, "\"> <input type=\"hidden\" name=\"dispatch_priority_by_label\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var139 string
-		templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanMode(form))
+		templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 512, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 527, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 180, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 186, "\"> <input type=\"hidden\" name=\"delivery_profile\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var140 string
+		templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(form.DeliveryProfile)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 528, Col: 74}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 187, "\"> <input type=\"hidden\" name=\"dependency_auto_unblock_enabled\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var141 string
+		templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinStringErrs(form.DependencyAutoUnblockEnabled)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 529, Col: 102}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var141))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 188, "\"> <input type=\"hidden\" name=\"kanban_mode\" value=\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		var templ_7745c5c3_Var142 string
+		templ_7745c5c3_Var142, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanMode(form))
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 530, Col: 65}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var142))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 189, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Add a non-disruptive onboarding closeout verifier after workflow mutation.
- Report live reload, refresh, label-count, dispatch, worktree, Workpad, and active-agent inventory evidence.
- Carry issue comments into telemetry snapshots so Workpad presence can be verified.

Fixes #646

## Test Plan

- [x] `make check`