### PR TITLE
feat(github): refresh stale auth

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -207,11 +207,14 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 	globalDispatchGate := scheduler.NewGlobalDispatchGate(globalScheduler)
 	runtimeGitHubToken := newRuntimeGitHubTokenState(runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken))
+	globalConfigState := newGlobalConfigState(cfg.Global)
+	refreshGitHubToken := runtimeGitHubTokenRefresher(globalConfigState, runtimeGitHubToken)
 	projectFactory := withRunnerFactory(project.Dependencies{
 		Events:             events,
 		Logger:             logger,
 		GlobalDispatchGate: globalDispatchGate,
 		GitHubToken:        runtimeGitHubToken.get(),
+		RefreshGitHubToken: refreshGitHubToken,
 		ConnectorFactory:   cfg.ConnectorFactory,
 		Runner:             cfg.Runner,
 	}, runtimeStore, nil, runtimeGitHubToken.get)
@@ -223,7 +226,6 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
-	globalConfigState := newGlobalConfigState(cfg.Global)
 	globalWatcherStarted := make(chan (<-chan struct{}), 1)
 	defer func() {
 		stop()

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -682,6 +682,7 @@ func projectSnapshot(snapshot telemetry.Snapshot) telemetry.ProjectSnapshot {
 		Counts:     snapshot.Counts,
 		Tokens:     snapshot.Tokens,
 		Throughput: snapshot.Throughput,
+		Auth:       snapshot.Auth,
 		Refresh:    snapshot.Refresh,
 	}
 }

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -416,6 +416,17 @@ func runtimeGlobalGitHubToken(token RuntimeSecret) string {
 	}
 }
 
+func runtimeGitHubTokenRefresher(globalState *globalConfigState, tokenState *runtimeGitHubTokenState) func(context.Context) (string, error) {
+	return func(ctx context.Context) (string, error) {
+		resolved, err := resolveGlobalRuntimeGitHubToken(ctx, globalState.get())
+		if err != nil {
+			return "", err
+		}
+		tokenState.set(resolved)
+		return resolved, nil
+	}
+}
+
 func runtimeGitHubTokenVersion(token string) string {
 	token = strings.TrimSpace(token)
 	if token == "" {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -533,6 +533,37 @@ func TestRuntimeGlobalGitHubTokenSources(t *testing.T) {
 	}
 }
 
+func TestRuntimeGitHubTokenRefresherUsesCurrentGlobalConfig(t *testing.T) {
+	t.Parallel()
+
+	workflowPath := filepath.Join(t.TempDir(), "workflow.md")
+	if err := os.WriteFile(workflowPath, []byte("---\ntracker:\n  kind: github\n---\nPrompt\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	globalState := newGlobalConfigState(globalconfig.Config{})
+	tokenState := newRuntimeGitHubTokenState("")
+	refresh := runtimeGitHubTokenRefresher(globalState, tokenState)
+
+	globalState.set(globalconfig.Config{
+		GitHubToken: "next-token",
+		Projects: []globalconfig.Project{{
+			ID:       "detent",
+			Workflow: workflowPath,
+			Workdir:  ".",
+		}},
+	})
+	got, err := refresh(context.Background())
+	if err != nil {
+		t.Fatalf("refresh() error = %v", err)
+	}
+	if got != "next-token" {
+		t.Fatalf("refresh() = %q, want next-token", got)
+	}
+	if tokenState.get() != "next-token" {
+		t.Fatalf("runtime token state = %q, want next-token", tokenState.get())
+	}
+}
+
 func githubRuntimeConfig(token string) globalconfig.Config {
 	return globalconfig.Config{
 		GitHubToken: token,

--- a/internal/connector/auth.go
+++ b/internal/connector/auth.go
@@ -1,0 +1,21 @@
+package connector
+
+import "time"
+
+type AuthStatus string
+
+const (
+	AuthStatusStale     AuthStatus = "stale"
+	AuthStatusRecovered AuthStatus = "recovered"
+)
+
+type AuthHealth struct {
+	Status          AuthStatus
+	LastError       string
+	LastErrorAt     time.Time
+	LastRecoveredAt time.Time
+}
+
+type AuthHealthReporter interface {
+	AuthHealth() (AuthHealth, bool)
+}

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -22,6 +22,7 @@ type Config struct {
 	Memory                  memory.Config
 	Endpoint                string
 	APIKey                  string
+	GitHubTokenRefresh      githubconnector.TokenRefreshFunc
 	HTTPMaxIdleConns        int
 	HTTPMaxIdleConnsPerHost int
 	HTTPIdleConnTimeoutMS   int
@@ -50,9 +51,14 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 	case connector.BackendLinear:
 		return unimplementedConnector{name: kind}, nil
 	case connector.BackendGitHub:
+		var tokenSource githubconnector.TokenSource
+		if strings.TrimSpace(cfg.APIKey) != "" && cfg.GitHubTokenRefresh != nil && !cfg.hasGitHubAppCredentials() {
+			tokenSource = githubconnector.NewRefreshableTokenSource(cfg.APIKey, cfg.GitHubTokenRefresh)
+		}
 		return githubconnector.NewConnector(githubconnector.Config{
-			Endpoint: cfg.Endpoint,
-			APIKey:   cfg.APIKey,
+			Endpoint:    cfg.Endpoint,
+			APIKey:      cfg.APIKey,
+			TokenSource: tokenSource,
 			HTTPTransport: githubconnector.HTTPTransportConfig{
 				MaxIdleConns:        cfg.HTTPMaxIdleConns,
 				MaxIdleConnsPerHost: cfg.HTTPMaxIdleConnsPerHost,
@@ -78,6 +84,13 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, kind)
 	}
+}
+
+func (cfg Config) hasGitHubAppCredentials() bool {
+	return strings.TrimSpace(cfg.GitHubAppID) != "" &&
+		strings.TrimSpace(cfg.GitHubAppInstallationID) != "" &&
+		(strings.TrimSpace(cfg.GitHubAppPrivateKey) != "" ||
+			strings.TrimSpace(cfg.GitHubAppPrivateKeyPath) != "")
 }
 
 type unimplementedConnector struct {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -36,15 +37,17 @@ type ClientConfig struct {
 }
 
 type Client struct {
-	endpoint     string
-	restEndpoint string
-	tokenSource  TokenSource
-	httpClient   HTTPClient
-	logger       *slog.Logger
-	mu           sync.RWMutex
-	rateLimit    connector.GraphQLRateLimit
-	queryCosts   map[string]connector.GraphQLQueryCost
-	hasRateLimit bool
+	endpoint      string
+	restEndpoint  string
+	tokenSource   TokenSource
+	httpClient    HTTPClient
+	logger        *slog.Logger
+	mu            sync.RWMutex
+	rateLimit     connector.GraphQLRateLimit
+	queryCosts    map[string]connector.GraphQLQueryCost
+	hasRateLimit  bool
+	authHealth    connector.AuthHealth
+	hasAuthHealth bool
 }
 
 type restProbeResult struct {
@@ -94,6 +97,10 @@ func (c *Client) GraphQL(ctx context.Context, query string, variables map[string
 }
 
 func (c *Client) GraphQLWithType(ctx context.Context, queryType string, query string, variables map[string]any, out any) error {
+	return c.graphQLWithType(ctx, queryType, query, variables, out, true)
+}
+
+func (c *Client) graphQLWithType(ctx context.Context, queryType string, query string, variables map[string]any, out any, allowTokenRefresh bool) error {
 	token, err := c.tokenSource.Token(ctx)
 	if err != nil {
 		return fmt.Errorf("resolve github token: %w", err)
@@ -149,7 +156,11 @@ func (c *Client) GraphQLWithType(ctx context.Context, queryType string, query st
 	headerRateLimit := c.recordRateLimitFromHeaders(resp.Header, receivedAt)
 
 	if resp.StatusCode != http.StatusOK {
-		return classifyStatus(resp.StatusCode, resp.Header, raw)
+		err := classifyStatus(resp.StatusCode, resp.Header, raw)
+		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
+			return c.graphQLWithType(ctx, queryType, query, variables, out, false)
+		}
+		return err
 	}
 
 	var envelope struct {
@@ -163,7 +174,11 @@ func (c *Client) GraphQLWithType(ctx context.Context, queryType string, query st
 		c.recordGraphQLQueryCostFromHeaders(queryType, headerRateLimit)
 	}
 	if len(envelope.Errors) > 0 {
-		return classifyGraphQLErrors(envelope.Errors)
+		err := classifyGraphQLErrors(envelope.Errors)
+		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
+			return c.graphQLWithType(ctx, queryType, query, variables, out, false)
+		}
+		return err
 	}
 	if out == nil {
 		return nil
@@ -184,6 +199,10 @@ func (c *Client) REST(ctx context.Context, method string, path string, body any,
 }
 
 func (c *Client) restProbe(ctx context.Context, method string, path string, body any) (restProbeResult, error) {
+	return c.restProbeWithTokenRefresh(ctx, method, path, body, true)
+}
+
+func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, path string, body any, allowTokenRefresh bool) (restProbeResult, error) {
 	token, err := c.tokenSource.Token(ctx)
 	if err != nil {
 		return restProbeResult{}, fmt.Errorf("resolve github token: %w", err)
@@ -234,15 +253,26 @@ func (c *Client) restProbe(ctx context.Context, method string, path string, body
 	if err != nil {
 		return restProbeResult{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
-	return restProbeResult{
+	result := restProbeResult{
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header.Clone(),
 		Body:       summarizeBody(raw),
 		FullBody:   string(bytes.TrimSpace(raw)),
-	}, nil
+	}
+	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
+		err := classifyStatus(resp.StatusCode, resp.Header, raw)
+		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
+			return c.restProbeWithTokenRefresh(ctx, method, path, body, false)
+		}
+	}
+	return result, nil
 }
 
 func (c *Client) rest(ctx context.Context, method string, path string, body any, out any) (http.Header, error) {
+	return c.restWithTokenRefresh(ctx, method, path, body, out, true)
+}
+
+func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path string, body any, out any, allowTokenRefresh bool) (http.Header, error) {
 	token, err := c.tokenSource.Token(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("resolve github token: %w", err)
@@ -296,7 +326,11 @@ func (c *Client) rest(ctx context.Context, method string, path string, body any,
 		return nil, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		return nil, classifyStatus(resp.StatusCode, resp.Header, raw)
+		err := classifyStatus(resp.StatusCode, resp.Header, raw)
+		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
+			return c.restWithTokenRefresh(ctx, method, path, body, out, false)
+		}
+		return nil, err
 	}
 	headers := resp.Header.Clone()
 	if out == nil || resp.StatusCode == http.StatusNoContent {
@@ -309,6 +343,56 @@ func (c *Client) rest(ctx context.Context, method string, path string, body any,
 		return nil, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
 	}
 	return headers, nil
+}
+
+func (c *Client) AuthHealth() (connector.AuthHealth, bool) {
+	c.mu.RLock()
+	defer c.mu.RUnlock()
+
+	return c.authHealth, c.hasAuthHealth
+}
+
+func (c *Client) refreshAfterAuthFailure(ctx context.Context, err error, allowTokenRefresh bool) bool {
+	if !errors.Is(err, ErrAuthenticationFailed) {
+		return false
+	}
+	c.recordAuthFailure(err, time.Now())
+	if !allowTokenRefresh {
+		return false
+	}
+	refresher, ok := c.tokenSource.(RefreshableTokenSource)
+	if !ok {
+		return false
+	}
+	if _, refreshErr := refresher.RefreshToken(ctx); refreshErr != nil {
+		c.logger.WarnContext(ctx, "github token refresh failed", "error", refreshErr)
+		return false
+	}
+	c.recordAuthRecovered(time.Now())
+	return true
+}
+
+func (c *Client) recordAuthFailure(err error, at time.Time) {
+	if err == nil {
+		return
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.authHealth.Status = connector.AuthStatusStale
+	c.authHealth.LastError = err.Error()
+	c.authHealth.LastErrorAt = at
+	c.authHealth.LastRecoveredAt = time.Time{}
+	c.hasAuthHealth = true
+}
+
+func (c *Client) recordAuthRecovered(at time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.authHealth.Status = connector.AuthStatusRecovered
+	c.authHealth.LastRecoveredAt = at
+	c.hasAuthHealth = true
 }
 
 func (c *Client) GraphQLRateLimit() (connector.GraphQLRateLimit, bool) {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strconv"
 	"sync"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -163,6 +164,156 @@ func TestClientGraphQLClassifiesFailures(t *testing.T) {
 				t.Fatalf("GraphQL() error = %v, want %v", err, tt.want)
 			}
 		})
+	}
+}
+
+func TestClientGraphQLRefreshesTokenAfterAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	source := newRefreshingTokenTestSource("stale-token", "fresh-token")
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		requests <- token
+		switch token {
+		case "Bearer stale-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+		case "Bearer fresh-token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"octocat"}}}`))
+		default:
+			t.Fatalf("Authorization = %q, want stale then fresh token", token)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: source,
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var got struct {
+		Viewer struct {
+			Login string `json:"login"`
+		} `json:"viewer"`
+	}
+	if err := client.GraphQL(context.Background(), "query { viewer { login } }", nil, &got); err != nil {
+		t.Fatalf("GraphQL() error = %v", err)
+	}
+	if got.Viewer.Login != "octocat" {
+		t.Fatalf("Viewer.Login = %q, want octocat", got.Viewer.Login)
+	}
+	if source.refreshes.Load() != 1 {
+		t.Fatalf("RefreshToken() calls = %d, want 1", source.refreshes.Load())
+	}
+	if first, second := <-requests, <-requests; first != "Bearer stale-token" || second != "Bearer fresh-token" {
+		t.Fatalf("Authorization sequence = %q, %q; want stale then fresh", first, second)
+	}
+	health, ok := client.AuthHealth()
+	if !ok {
+		t.Fatal("AuthHealth() ok = false, want true")
+	}
+	if health.Status != connector.AuthStatusRecovered {
+		t.Fatalf("AuthHealth().Status = %q, want %q", health.Status, connector.AuthStatusRecovered)
+	}
+	if health.LastError == "" || health.LastErrorAt.IsZero() || health.LastRecoveredAt.IsZero() {
+		t.Fatalf("AuthHealth() missing recovery detail: %#v", health)
+	}
+}
+
+func TestClientRESTRefreshesTokenAfterAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	source := newRefreshingTokenTestSource("stale-token", "fresh-token")
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		requests <- token
+		switch token {
+		case "Bearer stale-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+		case "Bearer fresh-token":
+			if r.URL.Path != "/repos/digitaldrywood/detent/issues" {
+				t.Fatalf("path = %s, want REST request path", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"ok":true}`))
+		default:
+			t.Fatalf("Authorization = %q, want stale then fresh token", token)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: source,
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var got struct {
+		OK bool `json:"ok"`
+	}
+	if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/issues", nil, &got); err != nil {
+		t.Fatalf("REST() error = %v", err)
+	}
+	if !got.OK {
+		t.Fatal("REST() response OK = false, want true")
+	}
+	if source.refreshes.Load() != 1 {
+		t.Fatalf("RefreshToken() calls = %d, want 1", source.refreshes.Load())
+	}
+	if first, second := <-requests, <-requests; first != "Bearer stale-token" || second != "Bearer fresh-token" {
+		t.Fatalf("Authorization sequence = %q, %q; want stale then fresh", first, second)
+	}
+}
+
+func TestClientReportsStaleAuthWhenRefreshFails(t *testing.T) {
+	t.Parallel()
+
+	source := newRefreshingTokenTestSource("stale-token", "")
+	source.refreshErr = errors.New("gh auth token failed")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: source,
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	err = client.GraphQL(context.Background(), "query { viewer { login } }", nil, nil)
+	if !errors.Is(err, ErrAuthenticationFailed) {
+		t.Fatalf("GraphQL() error = %v, want ErrAuthenticationFailed", err)
+	}
+	health, ok := client.AuthHealth()
+	if !ok {
+		t.Fatal("AuthHealth() ok = false, want true")
+	}
+	if health.Status != connector.AuthStatusStale {
+		t.Fatalf("AuthHealth().Status = %q, want %q", health.Status, connector.AuthStatusStale)
+	}
+	if health.LastError == "" || health.LastErrorAt.IsZero() {
+		t.Fatalf("AuthHealth() missing stale auth detail: %#v", health)
+	}
+	if health.LastRecoveredAt.IsZero() == false {
+		t.Fatalf("AuthHealth().LastRecoveredAt = %v, want zero", health.LastRecoveredAt)
 	}
 }
 
@@ -581,4 +732,39 @@ func TestClientGraphQLRejectsInvalidPayloads(t *testing.T) {
 			}
 		})
 	}
+}
+
+type refreshingTokenTestSource struct {
+	mu           sync.Mutex
+	token        string
+	refreshToken string
+	refreshErr   error
+	refreshes    atomic.Int64
+}
+
+func newRefreshingTokenTestSource(token string, refreshToken string) *refreshingTokenTestSource {
+	return &refreshingTokenTestSource{token: token, refreshToken: refreshToken}
+}
+
+func (s *refreshingTokenTestSource) Token(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.token, nil
+}
+
+func (s *refreshingTokenTestSource) RefreshToken(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	s.refreshes.Add(1)
+	if s.refreshErr != nil {
+		return "", s.refreshErr
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.token = s.refreshToken
+	return s.token, nil
 }

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -163,6 +163,13 @@ func (c *Connector) GraphQLRateLimit() (connector.GraphQLRateLimit, bool) {
 	return c.client.GraphQLRateLimit()
 }
 
+func (c *Connector) AuthHealth() (connector.AuthHealth, bool) {
+	if c == nil || c.client == nil {
+		return connector.AuthHealth{}, false
+	}
+	return c.client.AuthHealth()
+}
+
 func (c *Connector) ResetGraphQLRateLimitUsage() {
 	c.client.ResetGraphQLRateLimitUsage()
 }
@@ -261,3 +268,4 @@ var _ connector.PullRequestCommenter = (*Connector)(nil)
 var _ connector.Provisioner = (*Connector)(nil)
 var _ connector.RateLimitReporter = (*Connector)(nil)
 var _ connector.GraphQLRateLimitUsageReporter = (*Connector)(nil)
+var _ connector.AuthHealthReporter = (*Connector)(nil)

--- a/internal/connector/github/token.go
+++ b/internal/connector/github/token.go
@@ -15,6 +15,13 @@ type TokenSource interface {
 	Token(context.Context) (string, error)
 }
 
+type RefreshableTokenSource interface {
+	TokenSource
+	RefreshToken(context.Context) (string, error)
+}
+
+type TokenRefreshFunc func(context.Context) (string, error)
+
 type staticTokenSource string
 
 func StaticTokenSource(token string) TokenSource {
@@ -29,6 +36,53 @@ func (s staticTokenSource) Token(ctx context.Context) (string, error) {
 	if token == "" {
 		return "", ErrMissingToken
 	}
+	return token, nil
+}
+
+type refreshableTokenSource struct {
+	mu      sync.Mutex
+	token   string
+	refresh TokenRefreshFunc
+}
+
+func NewRefreshableTokenSource(token string, refresh TokenRefreshFunc) TokenSource {
+	return &refreshableTokenSource{
+		token:   strings.TrimSpace(token),
+		refresh: refresh,
+	}
+}
+
+func (s *refreshableTokenSource) Token(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	token := strings.TrimSpace(s.token)
+	if token == "" {
+		return "", ErrMissingToken
+	}
+	return token, nil
+}
+
+func (s *refreshableTokenSource) RefreshToken(ctx context.Context) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	if s.refresh == nil {
+		return "", ErrMissingToken
+	}
+	token, err := s.refresh(ctx)
+	if err != nil {
+		return "", err
+	}
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return "", ErrMissingToken
+	}
+	s.mu.Lock()
+	s.token = token
+	s.mu.Unlock()
 	return token, nil
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -781,6 +781,7 @@ func (o *Orchestrator) markRefresh(state *State, now time.Time) {
 }
 
 func (o *Orchestrator) finishRefresh(state *State, now time.Time) {
+	o.captureConnectorAuthHealth(state)
 	cycle := o.captureConnectorRateLimits(state, now)
 	o.logGraphQLRateLimitCycle(cycle)
 
@@ -791,6 +792,16 @@ func (o *Orchestrator) finishRefresh(state *State, now time.Time) {
 		return
 	}
 	state.NextRefreshAt = time.Time{}
+}
+
+func (o *Orchestrator) captureConnectorAuthHealth(state *State) {
+	if reporter, ok := o.connector.(connector.AuthHealthReporter); ok {
+		if health, ok := reporter.AuthHealth(); ok {
+			state.Auth = health
+			return
+		}
+	}
+	state.Auth = connector.AuthHealth{}
 }
 
 type graphQLRateLimitCycle struct {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -858,6 +858,61 @@ func TestUpdateRuntimeSwapsConnectorBeforeNextTick(t *testing.T) {
 	close(runner.release)
 }
 
+func TestUpdateRuntimeClearsAuthHealthWhenConnectorHasNoReport(t *testing.T) {
+	t.Parallel()
+
+	failedAt := time.Now().Add(-time.Minute)
+	initialTracker := &authHealthConnector{
+		fakeConnector: newFakeConnector(),
+		health: connector.AuthHealth{
+			Status:      connector.AuthStatusStale,
+			LastError:   "github authentication failed: status 401",
+			LastErrorAt: failedAt,
+		},
+		ok: true,
+	}
+	reloadedTracker := &authHealthConnector{fakeConnector: newFakeConnector()}
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        5 * time.Millisecond,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo"},
+		TerminalStates:      []string{"Done"},
+	}, orchestrator.Dependencies{
+		Connector: initialTracker,
+		Runner:    &staticRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		return state.Auth.Status == connector.AuthStatusStale
+	})
+
+	updateCtx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := orch.UpdateRuntime(updateCtx, orchestrator.RuntimeUpdate{
+		Config: orchestrator.Config{
+			PollInterval:        5 * time.Millisecond,
+			MaxConcurrentAgents: 1,
+			ActiveStates:        []string{"Todo"},
+			TerminalStates:      []string{"Done"},
+		},
+		Connector: reloadedTracker,
+	}); err != nil {
+		t.Fatalf("UpdateRuntime() error = %v", err)
+	}
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		return reloadedTracker.fetchCandidateCalls() > 0 && state.Auth == (connector.AuthHealth{})
+	})
+	if state.Auth != (connector.AuthHealth{}) {
+		t.Fatalf("Auth = %#v, want cleared", state.Auth)
+	}
+}
+
 func TestRunDispatchesByStateRankBeforePriorityAndAge(t *testing.T) {
 	t.Parallel()
 
@@ -1668,6 +1723,16 @@ type fakeConnector struct {
 	stateUpdates        []stateUpdateCall
 	fetchByStatesErr    error
 	statusLabelPrefix   string
+}
+
+type authHealthConnector struct {
+	*fakeConnector
+	health connector.AuthHealth
+	ok     bool
+}
+
+func (c *authHealthConnector) AuthHealth() (connector.AuthHealth, bool) {
+	return c.health, c.ok
 }
 
 type setFieldCall struct {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -30,6 +30,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	snapshot := telemetry.Snapshot{
 		GeneratedAt: now,
 		Instance:    s.Instance,
+		Auth:        telemetryAuthHealth(s.Auth),
 		Shutdown:    shutdownSnapshot(s),
 		Events:      cloneActivityEvents(s.RecentEvents),
 		Refresh:     refresh,
@@ -52,6 +53,22 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Completed: len(snapshot.Completed),
 	}
 	return snapshot
+}
+
+func telemetryAuthHealth(health connector.AuthHealth) telemetry.AuthHealth {
+	out := telemetry.AuthHealth{
+		Status:    telemetry.AuthStatus(health.Status),
+		LastError: health.LastError,
+	}
+	if !health.LastErrorAt.IsZero() {
+		value := health.LastErrorAt
+		out.LastErrorAt = &value
+	}
+	if !health.LastRecoveredAt.IsZero() {
+		value := health.LastRecoveredAt
+		out.LastRecoveredAt = &value
+	}
+	return out
 }
 
 func shutdownSnapshot(state State) telemetry.Shutdown {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -106,6 +106,36 @@ func TestStateSnapshotCarriesIssueComments(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotIncludesAuthHealth(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
+	failedAt := now.Add(-time.Minute)
+	recoveredAt := now.Add(-30 * time.Second)
+	state := newState(normalizeConfig(Config{}))
+	state.Auth = connector.AuthHealth{
+		Status:          connector.AuthStatusRecovered,
+		LastError:       "github authentication failed: status 401",
+		LastErrorAt:     failedAt,
+		LastRecoveredAt: recoveredAt,
+	}
+
+	snapshot := state.Snapshot(now)
+
+	if snapshot.Auth.Status != telemetry.AuthStatusRecovered {
+		t.Fatalf("snapshot Auth.Status = %q, want %q", snapshot.Auth.Status, telemetry.AuthStatusRecovered)
+	}
+	if snapshot.Auth.LastError != "github authentication failed: status 401" {
+		t.Fatalf("snapshot Auth.LastError = %q", snapshot.Auth.LastError)
+	}
+	if snapshot.Auth.LastErrorAt == nil || !snapshot.Auth.LastErrorAt.Equal(failedAt) {
+		t.Fatalf("snapshot Auth.LastErrorAt = %v, want %v", snapshot.Auth.LastErrorAt, failedAt)
+	}
+	if snapshot.Auth.LastRecoveredAt == nil || !snapshot.Auth.LastRecoveredAt.Equal(recoveredAt) {
+		t.Fatalf("snapshot Auth.LastRecoveredAt = %v, want %v", snapshot.Auth.LastRecoveredAt, recoveredAt)
+	}
+}
+
 func TestStateSnapshotIncludesClaimLeaseState(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -24,6 +24,7 @@ type State struct {
 	LastRunningReconcileAt   time.Time
 	LastWorkspaceCleanupAt   time.Time
 	RecentEvents             []telemetry.ActivityEvent
+	Auth                     connector.AuthHealth
 	BoardIssues              []connector.Issue
 	Pipeline                 []connector.Issue
 	Running                  map[string]Running
@@ -134,6 +135,7 @@ func (s State) clone() State {
 		LastRunningReconcileAt:   s.LastRunningReconcileAt,
 		LastWorkspaceCleanupAt:   s.LastWorkspaceCleanupAt,
 		RecentEvents:             cloneActivityEvents(s.RecentEvents),
+		Auth:                     s.Auth,
 		BoardIssues:              cloneIssues(s.BoardIssues),
 		Pipeline:                 cloneIssues(s.Pipeline),
 		Running:                  make(map[string]Running, len(s.Running)),

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -87,6 +87,7 @@ type Dependencies struct {
 	Events                 *hub.Hub[Event]
 	Logger                 *slog.Logger
 	GitHubToken            string
+	RefreshGitHubToken     func(context.Context) (string, error)
 }
 
 type Project struct {
@@ -911,7 +912,9 @@ func resolveConnectorFactory(deps Dependencies) ConnectorFactory {
 	if deps.ConnectorFactory != nil {
 		return deps.ConnectorFactory
 	}
-	return defaultConnectorFactory
+	return func(cfg workflowconfig.Config) (connector.Connector, error) {
+		return defaultConnectorFactoryWithRefresh(cfg, deps.RefreshGitHubToken)
+	}
 }
 
 func buildConnector(cfg workflowconfig.Config, connectorFactory ConnectorFactory) (connector.Connector, error) {
@@ -968,11 +971,16 @@ func defaultSchedulerFactory(cfg workflowconfig.Config) (scheduler.Scheduler, er
 }
 
 func defaultConnectorFactory(cfg workflowconfig.Config) (connector.Connector, error) {
+	return defaultConnectorFactoryWithRefresh(cfg, nil)
+}
+
+func defaultConnectorFactoryWithRefresh(cfg workflowconfig.Config, refreshGitHubToken func(context.Context) (string, error)) (connector.Connector, error) {
 	return factory.NewFromConfig(factory.Config{
 		Kind:                    cfg.Tracker.Kind,
 		Memory:                  memory.Config{Issues: cfg.Tracker.Issues},
 		Endpoint:                cfg.Tracker.Endpoint,
 		APIKey:                  cfg.Tracker.APIKey,
+		GitHubTokenRefresh:      refreshGitHubToken,
 		HTTPMaxIdleConns:        cfg.Tracker.HTTPMaxIdleConns,
 		HTTPMaxIdleConnsPerHost: cfg.Tracker.HTTPMaxIdleConnsPerHost,
 		HTTPIdleConnTimeoutMS:   cfg.Tracker.HTTPIdleConnTimeoutMS,

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"sync"
@@ -118,6 +120,75 @@ func TestNewBuildsProjectLifecycleDependencies(t *testing.T) {
 		}
 	case <-time.After(time.Second):
 		t.Fatal("timed out waiting for orchestrator dependencies")
+	}
+}
+
+func TestProjectGitHubRuntimeTokenRefreshesAfterAuthFailure(t *testing.T) {
+	t.Parallel()
+
+	requests := make(chan string, 2)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		token := r.Header.Get("Authorization")
+		requests <- token
+		switch token {
+		case "Bearer stale-token":
+			w.WriteHeader(http.StatusUnauthorized)
+			_, _ = w.Write([]byte(`{"message":"Bad credentials"}`))
+		case "Bearer fresh-token":
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"data":{"viewer":{"login":"detent-bot"},"node":{"__typename":"ProjectV2","id":"PVT_1"}}}`))
+		default:
+			t.Fatalf("Authorization = %q, want stale then fresh token", token)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	workflowCfg := workflowConfig("github")
+	workflowCfg.Tracker.Endpoint = server.URL
+	workflowCfg.Tracker.ProjectSlug = "PVT_1"
+	var refreshes atomic.Int64
+	got, err := project.New(project.Config{
+		Project: globalconfig.Project{
+			ID:     "detent",
+			Weight: 1,
+		},
+		Workflow: workflowconfig.Workflow{Config: workflowCfg},
+	}, project.Dependencies{
+		GitHubToken: "stale-token",
+		RefreshGitHubToken: func(context.Context) (string, error) {
+			refreshes.Add(1)
+			return "fresh-token", nil
+		},
+		Runner: orchestrator.FakeRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	authenticator, ok := got.Connector().(connector.Authenticator)
+	if !ok {
+		t.Fatalf("Connector() = %T, want connector.Authenticator", got.Connector())
+	}
+	if err := authenticator.Authenticate(context.Background()); err != nil {
+		t.Fatalf("Authenticate() error = %v", err)
+	}
+	if refreshes.Load() != 1 {
+		t.Fatalf("RefreshGitHubToken() calls = %d, want 1", refreshes.Load())
+	}
+	if first, second := <-requests, <-requests; first != "Bearer stale-token" || second != "Bearer fresh-token" {
+		t.Fatalf("Authorization sequence = %q, %q; want stale then fresh", first, second)
+	}
+	reporter, ok := got.Connector().(connector.AuthHealthReporter)
+	if !ok {
+		t.Fatalf("Connector() = %T, want connector.AuthHealthReporter", got.Connector())
+	}
+	health, ok := reporter.AuthHealth()
+	if !ok {
+		t.Fatal("AuthHealth() ok = false, want true")
+	}
+	if health.Status != connector.AuthStatusRecovered {
+		t.Fatalf("AuthHealth().Status = %q, want %q", health.Status, connector.AuthStatusRecovered)
 	}
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -11,6 +11,7 @@ type Snapshot struct {
 	Instance       Instance          `json:"instance"`
 	Projects       []ProjectSnapshot `json:"projects,omitempty"`
 	DashboardURL   string            `json:"dashboard_url,omitempty"`
+	Auth           AuthHealth        `json:"auth,omitzero"`
 	Shutdown       Shutdown          `json:"shutdown"`
 	Refresh        Refresh           `json:"refresh"`
 	Events         []ActivityEvent   `json:"events,omitempty"`
@@ -58,7 +59,29 @@ type ProjectSnapshot struct {
 	Counts     Counts          `json:"counts"`
 	Tokens     Tokens          `json:"tokens"`
 	Throughput TokenThroughput `json:"throughput"`
+	Auth       AuthHealth      `json:"auth,omitzero"`
 	Refresh    Refresh         `json:"refresh,omitzero"`
+}
+
+type AuthStatus string
+
+const (
+	AuthStatusStale     AuthStatus = "stale"
+	AuthStatusRecovered AuthStatus = "recovered"
+)
+
+type AuthHealth struct {
+	Status          AuthStatus `json:"status,omitempty"`
+	LastError       string     `json:"last_error,omitempty"`
+	LastErrorAt     *time.Time `json:"last_error_at,omitempty"`
+	LastRecoveredAt *time.Time `json:"last_recovered_at,omitempty"`
+}
+
+func (h AuthHealth) IsZero() bool {
+	return h.Status == "" &&
+		strings.TrimSpace(h.LastError) == "" &&
+		h.LastErrorAt == nil &&
+		h.LastRecoveredAt == nil
 }
 
 type RefreshStatus string

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -30,6 +30,10 @@ func TestSnapshotJSONShape(t *testing.T) {
 			AuthorizationConfigured: true,
 		},
 		DashboardURL: "http://localhost:4101",
+		Auth: telemetry.AuthHealth{
+			Status:    telemetry.AuthStatusRecovered,
+			LastError: "github authentication failed: status 401",
+		},
 		Refresh: telemetry.Refresh{
 			PollIntervalSeconds: 30,
 			NextRefreshAt:       new(generatedAt.Add(30 * time.Second)),
@@ -193,6 +197,7 @@ func TestSnapshotJSONShape(t *testing.T) {
 		"project",
 		"instance",
 		"dashboard_url",
+		"auth",
 		"refresh",
 		"counts",
 		"board_issues",
@@ -228,6 +233,10 @@ func TestSnapshotJSONShape(t *testing.T) {
 	}
 	if got["dashboard_url"] != "http://localhost:4101" {
 		t.Fatalf("dashboard_url = %#v", got["dashboard_url"])
+	}
+	auth := got["auth"].(map[string]any)
+	if auth["status"] != string(telemetry.AuthStatusRecovered) || auth["last_error"] != "github authentication failed: status 401" {
+		t.Fatalf("auth = %#v", auth)
 	}
 	refresh := got["refresh"].(map[string]any)
 	if refresh["poll_interval_seconds"] != float64(30) || refresh["next_refresh_at"] != "2026-05-30T22:15:30Z" {
@@ -308,6 +317,45 @@ func TestSnapshotJSONShape(t *testing.T) {
 	latest := trend[1].(map[string]any)
 	if latest["input_tokens"] != float64(110) || latest["output_tokens"] != float64(220) || latest["total_tokens"] != float64(330) {
 		t.Fatalf("token_trend[1] = %#v", latest)
+	}
+}
+
+func TestProjectSnapshotJSONIncludesAuthHealth(t *testing.T) {
+	t.Parallel()
+
+	failedAt := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
+	recoveredAt := failedAt.Add(30 * time.Second)
+	project := telemetry.ProjectSnapshot{
+		Project: telemetry.Project{ID: "detent"},
+		Auth: telemetry.AuthHealth{
+			Status:          telemetry.AuthStatusRecovered,
+			LastError:       "github authentication failed: status 401",
+			LastErrorAt:     &failedAt,
+			LastRecoveredAt: &recoveredAt,
+		},
+	}
+
+	data, err := json.Marshal(project)
+	if err != nil {
+		t.Fatalf("Marshal() error = %v", err)
+	}
+
+	var got map[string]any
+	if err := json.Unmarshal(data, &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	auth := got["auth"].(map[string]any)
+	if auth["status"] != string(telemetry.AuthStatusRecovered) {
+		t.Fatalf("auth.status = %#v", auth["status"])
+	}
+	if auth["last_error"] != "github authentication failed: status 401" {
+		t.Fatalf("auth.last_error = %#v", auth["last_error"])
+	}
+	if auth["last_error_at"] != "2026-06-23T14:00:00Z" {
+		t.Fatalf("auth.last_error_at = %#v", auth["last_error_at"])
+	}
+	if auth["last_recovered_at"] != "2026-06-23T14:00:30Z" {
+		t.Fatalf("auth.last_recovered_at = %#v", auth["last_recovered_at"])
 	}
 }
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -281,6 +281,7 @@ func projectsAPIResponse(snapshot telemetry.Snapshot) []telemetry.ProjectSnapsho
 			Counts:     snapshot.Counts,
 			Tokens:     snapshot.Tokens,
 			Throughput: snapshot.Throughput,
+			Auth:       snapshot.Auth,
 		},
 	}
 }

--- a/internal/web/project_scope.go
+++ b/internal/web/project_scope.go
@@ -74,6 +74,7 @@ func projectScopedSnapshotForProject(snapshot telemetry.Snapshot, selectedProjec
 		out.Counts = sourceProject.Counts
 		out.Tokens = sourceProject.Tokens
 		out.Throughput = sourceProject.Throughput
+		out.Auth = sourceProject.Auth
 		if projectSnapshotHasRefreshSignal(sourceProject) {
 			out.Refresh = sourceProject.Refresh
 		}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1574,6 +1574,79 @@ func TestServerRendersInstanceNameInPagesStateAndMetadata(t *testing.T) {
 	}
 }
 
+func TestAPIStateSurfacesProjectAuthHealth(t *testing.T) {
+	t.Parallel()
+
+	failedAt := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: failedAt,
+		Projects: []telemetry.ProjectSnapshot{
+			{
+				Project: telemetry.Project{ID: "detent", DisplayName: "detent"},
+				Auth: telemetry.AuthHealth{
+					Status:      telemetry.AuthStatusStale,
+					LastError:   "github authentication failed: status 401",
+					LastErrorAt: &failedAt,
+				},
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	projects := state["projects"].([]any)
+	project := projects[0].(map[string]any)
+	auth := project["auth"].(map[string]any)
+	if auth["status"] != string(telemetry.AuthStatusStale) {
+		t.Fatalf("auth.status = %#v", auth["status"])
+	}
+	if auth["last_error"] != "github authentication failed: status 401" {
+		t.Fatalf("auth.last_error = %#v", auth["last_error"])
+	}
+	if auth["last_error_at"] != "2026-06-23T14:00:00Z" {
+		t.Fatalf("auth.last_error_at = %#v", auth["last_error_at"])
+	}
+}
+
+func TestAPIStateSurfacesSingleProjectAuthHealth(t *testing.T) {
+	t.Parallel()
+
+	failedAt := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: failedAt,
+		Project:     telemetry.Project{ID: "detent", DisplayName: "detent"},
+		Auth: telemetry.AuthHealth{
+			Status:      telemetry.AuthStatusStale,
+			LastError:   "github authentication failed: status 401",
+			LastErrorAt: &failedAt,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	projects := state["projects"].([]any)
+	project := projects[0].(map[string]any)
+	auth := project["auth"].(map[string]any)
+	if auth["status"] != string(telemetry.AuthStatusStale) {
+		t.Fatalf("auth.status = %#v", auth["status"])
+	}
+	if auth["last_error"] != "github authentication failed: status 401" {
+		t.Fatalf("auth.last_error = %#v", auth["last_error"])
+	}
+}
+
 func TestServerUsesHostnameFallbackForInstanceName(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Refresh runtime GitHub token sources after authentication failures and retry the failed request once in process.
- Record stale and recovered connector auth health, then expose it through project snapshots and /api/v1/state.
- Wire runtime `github_token` and `GITHUB_TOKEN` refresh through project connector construction without restarting unrelated sessions.

Fixes #647

## Test Plan

- [x] `go test ./internal/connector/github ./internal/project ./internal/orchestrator ./internal/telemetry ./internal/web ./internal/cli ./internal/connector/factory`
- [x] `make check`