### PR TITLE
fix(boot): load workflow kanban mode

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -242,6 +242,10 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err := publishStartupSnapshotOnce(runCtx, cfg.Global, snapshotHub, runtimeStore, displayURL, time.Now()); err != nil {
 		return err
 	}
+	kanbanWorkflow, err := bootKanbanWorkflow(runCtx, cfg)
+	if err != nil {
+		return err
+	}
 	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, runtimeStore, displayURL, defaultSnapshotInterval, time.Now)
 	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger)
 	server, err := web.NewServer(web.Config{
@@ -256,6 +260,8 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		RuntimeDBPath:      runtimeStorePath(cfg),
 		RuntimeLogPath:     runtimeLogPath(cfg),
 		ServerAddress:      listener.Addr().String(),
+		Kanban:             kanbanWorkflow.Server.Kanban,
+		KanbanWorkflow:     kanbanWorkflow,
 		Demo: web.DemoConfig{
 			Mode:  isolatedDemo(cfg),
 			Clock: isolatedDemoClock(cfg),
@@ -667,6 +673,36 @@ func globalConfigFromWorkflow(globalPath string, workflowPath string) (globalcon
 		},
 	}
 	return cfg, nil
+}
+
+func bootKanbanWorkflow(ctx context.Context, cfg BootConfig) (workflowconfig.Config, error) {
+	workflow, ok, err := bootWorkflow(ctx, cfg)
+	if err != nil || !ok {
+		return workflowconfig.Default(), err
+	}
+	workflow.Config.Server.Kanban.Normalize()
+	return workflow.Config, nil
+}
+
+func bootWorkflow(ctx context.Context, cfg BootConfig) (workflowconfig.Workflow, bool, error) {
+	firstProject := firstGlobalProject(cfg.Global)
+	if strings.TrimSpace(firstProject.Workflow) != "" {
+		workflow, err := loadRuntimeProjectWorkflow(ctx, firstProject, runtimeDeps{}.withDefaults())
+		if err != nil {
+			return workflowconfig.Workflow{}, false, fmt.Errorf("load boot workflow: %w", err)
+		}
+		return workflow, true, nil
+	}
+
+	path := strings.TrimSpace(cfg.WorkflowPath)
+	if path == "" {
+		return workflowconfig.Workflow{}, false, nil
+	}
+	workflow, err := workflowconfig.LoadWorkflow(path)
+	if err != nil {
+		return workflowconfig.Workflow{}, false, fmt.Errorf("load boot workflow: %w", err)
+	}
+	return workflow, true, nil
 }
 
 func buildGlobalScheduler(settings globalconfig.Settings, fairShareStore scheduler.FairShareStore) (scheduler.GlobalScheduler, error) {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -304,6 +305,59 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 	select {
 	case err := <-done:
 		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for startRunning to stop")
+	}
+}
+
+func TestStartRunningUsesWorkflowKanbanModeForFleetActions(t *testing.T) {
+	host, port := freeLoopbackPort(t)
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	alpha := createBootProjectFiles(t)
+	writeBootKanbanWorkflow(t, alpha.workflowPath, workflowconfig.KanbanModeIntegration)
+	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
+		{ID: "alpha", Workflow: alpha.workflowPath, Workdir: alpha.workdirPath, Weight: 1},
+	})
+	global, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	done := make(chan error, 1)
+	go func() {
+		done <- startRunning(ctx, BootConfig{
+			Mode:   BootModeRunning,
+			Global: global,
+			Host:   host,
+			Port:   &port,
+		})
+	}()
+
+	baseURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+	waitForDashboard(t, baseURL+"/kanban", done)
+	status, body := postDashboardForm(t, baseURL+"/api/v1/kanban/move", done, url.Values{
+		"issue_id":      {"issue-1"},
+		"current_state": {"Ready"},
+		"target_state":  {"Doing"},
+	})
+	if status == http.StatusForbidden && strings.Contains(body, "Kanban integration mode is not enabled.") {
+		t.Fatalf("move API stayed read-only after workflow integration mode; status = %d body = %s", status, body)
+	}
+	if strings.Contains(body, "Kanban integration mode is not enabled.") {
+		t.Fatalf("move API body kept read-only gate after workflow integration mode; status = %d body = %s", status, body)
+	}
+	if strings.Contains(body, "Target state is not configured for this board.") {
+		t.Fatalf("move API lost workflow Kanban states; status = %d body = %s", status, body)
+	}
+
+	cancel()
+	select {
+	case err := <-done:
+		if err != nil && !errors.Is(err, context.Canceled) {
 			t.Fatalf("startRunning() error = %v, want %v", err, context.Canceled)
 		}
 	case <-time.After(10 * time.Second):
@@ -632,6 +686,43 @@ func waitForDashboardCondition(t *testing.T, url string, done <-chan error, name
 	return ""
 }
 
+func postDashboardForm(t *testing.T, rawURL string, done <-chan error, form url.Values) (int, string) {
+	t.Helper()
+
+	client := http.Client{Timeout: time.Second}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	for ctx.Err() == nil {
+		select {
+		case err := <-done:
+			t.Fatalf("startRunning returned before form post completed: %v", err)
+		default:
+		}
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, rawURL, strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatalf("NewRequestWithContext() error = %v", err)
+		}
+		req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+		resp, err := client.Do(req)
+		if err == nil {
+			body, readErr := io.ReadAll(resp.Body)
+			closeErr := resp.Body.Close()
+			if readErr != nil {
+				t.Fatalf("ReadAll() error = %v", readErr)
+			}
+			if closeErr != nil {
+				t.Fatalf("Body.Close() error = %v", closeErr)
+			}
+			return resp.StatusCode, string(body)
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out posting form to %s", rawURL)
+	return 0, ""
+}
+
 type bootProjectFiles struct {
 	workflowPath string
 	workdirPath  string
@@ -653,6 +744,26 @@ Test workflow prompt.
 	return bootProjectFiles{
 		workflowPath: workflow,
 		workdirPath:  workdir,
+	}
+}
+
+func writeBootKanbanWorkflow(t *testing.T, path string, mode string) {
+	t.Helper()
+
+	content := `---
+tracker:
+  kind: memory
+  observed_states: [Backlog]
+  active_states: [Ready, Doing]
+  terminal_states: [Done]
+server:
+  kanban:
+    mode: ` + mode + `
+---
+Test workflow prompt.
+`
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
 	}
 }
 

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -705,14 +705,36 @@ func (s *Server) kanbanActionTarget(projectID string) (kanbanActionTarget, strin
 		}, "", 0
 	}
 
-	workflow := workflowconfig.Default()
-	workflow.Server.Kanban = s.kanban
+	workflow := s.kanbanWorkflow
+	actionConnector := s.connector
+	if trackedProject := s.firstKanbanActionProject(); trackedProject != nil {
+		workflow = trackedProject.Workflow().Config
+		workflow.Server.Kanban = s.kanban
+		if projectConnector := trackedProject.Connector(); projectConnector != nil {
+			actionConnector = projectConnector
+		}
+	}
+	if actionConnector == nil {
+		return kanbanActionTarget{}, "Connector not configured.", http.StatusServiceUnavailable
+	}
 	return kanbanActionTarget{
-		key:       "connector:" + s.connector.Name(),
-		connector: s.connector,
+		key:       "connector:" + actionConnector.Name(),
+		connector: actionConnector,
 		workflow:  workflow,
 		kanban:    s.kanban,
 	}, "", 0
+}
+
+func (s *Server) firstKanbanActionProject() *project.Project {
+	if s.registry == nil {
+		return nil
+	}
+	for _, trackedProject := range s.registry.List() {
+		if trackedProject != nil && trackedProject.Connector() != nil {
+			return trackedProject
+		}
+	}
+	return nil
 }
 
 func (s *Server) dashboardKanbanData(ctx context.Context, projectID string, snapshot telemetry.Snapshot) templates.KanbanData {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -70,6 +70,7 @@ type Config struct {
 	Hostname              func() (string, error)
 	ConfigPathRule        globalconfig.PathRule
 	Kanban                workflowconfig.Kanban
+	KanbanWorkflow        workflowconfig.Config
 	RuntimeDBPath         string
 	RuntimeLogPath        string
 	ServerAddress         string
@@ -96,6 +97,7 @@ type Server struct {
 	hostname           func() (string, error)
 	configRule         globalconfig.PathRule
 	kanban             workflowconfig.Kanban
+	kanbanWorkflow     workflowconfig.Config
 	dbPath             string
 	logPath            string
 	serverAddr         string
@@ -128,6 +130,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	e.HidePort = true
 	e.Server.ReadHeaderTimeout = cfg.httpReadHeaderTimeout()
 	e.Server.IdleTimeout = cfg.httpIdleTimeout()
+	kanban := cfg.kanban()
 
 	server := &Server{
 		echo:               e,
@@ -148,7 +151,8 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		globalConfigSource: cfg.globalConfigSource(),
 		hostname:           cfg.hostname(),
 		configRule:         cfg.ConfigPathRule,
-		kanban:             cfg.kanban(),
+		kanban:             kanban,
+		kanbanWorkflow:     cfg.kanbanWorkflow(kanban),
 		dbPath:             strings.TrimSpace(cfg.RuntimeDBPath),
 		logPath:            strings.TrimSpace(cfg.RuntimeLogPath),
 		serverAddr:         strings.TrimSpace(cfg.ServerAddress),
@@ -552,6 +556,18 @@ func (cfg Config) kanban() workflowconfig.Kanban {
 	kanban := cfg.Kanban
 	kanban.Normalize()
 	return kanban
+}
+
+func (cfg Config) kanbanWorkflow(kanban workflowconfig.Kanban) workflowconfig.Config {
+	workflow := cfg.KanbanWorkflow
+	if workflow.Tracker.Kind == "" &&
+		len(workflow.Tracker.ActiveStates) == 0 &&
+		len(workflow.Tracker.ObservedStates) == 0 &&
+		len(workflow.Tracker.TerminalStates) == 0 {
+		workflow = workflowconfig.Default()
+	}
+	workflow.Server.Kanban = kanban
+	return workflow
 }
 
 func (cfg Config) pricing() budget.PricingTable {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3077,6 +3077,56 @@ func TestFleetKanbanRouteRendersAllProjectsReadOnly(t *testing.T) {
 	}
 }
 
+func TestFleetKanbanActionUsesRegistryConnector(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	fallbackConnector := &kanbanActionConnector{name: "fallback"}
+	projectConnector := &kanbanActionConnector{name: "project"}
+	deps.Connector = fallbackConnector
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, projectConnector)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 16, 14, 55, 0, 0, time.UTC),
+		BoardIssues: []telemetry.Issue{
+			{
+				ID:         "I_kw542",
+				Identifier: "digitaldrywood/detent#542",
+				Title:      "Move from fleet board",
+				State:      "Todo",
+			},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{
+		Kanban: workflowconfig.Kanban{
+			Mode: workflowconfig.KanbanModeIntegration,
+		},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := url.Values{
+		"issue_id":      {"I_kw542"},
+		"current_state": {"Todo"},
+		"target_state":  {"In Progress"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got := projectConnector.stateUpdates(); len(got) != 1 || got[0].issueID != "I_kw542" || got[0].state != "In Progress" {
+		t.Fatalf("project connector state updates = %#v, want fleet move", got)
+	}
+	if got := fallbackConnector.stateUpdates(); len(got) != 0 {
+		t.Fatalf("fallback connector state updates = %#v, want none", got)
+	}
+}
+
 func TestProjectKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Load the first boot workflow's normalized Kanban config into the production running web server.
- Preserve the loaded workflow state policy for fleet/default Kanban actions and route empty-project actions through the registry connector instead of the construction-time fallback.
- Cover the production boot path so workflow integration mode no longer leaves the Kanban move API behind the read-only gate.

Fixes #635

## Test Plan

- [x] `go test ./internal/cli -run TestStartRunningUsesWorkflowKanbanModeForFleetActions -count=1`
- [x] `go test ./internal/web -run TestFleetKanbanActionUsesRegistryConnector -count=1`
- [x] `go test ./internal/cli ./internal/web -count=1`
- [x] `make check`