### PR TITLE
fix(ci): run required checks fully

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,95 +105,37 @@ jobs:
     name: Browser Visual
     runs-on: ubuntu-latest
     steps:
-      - name: Decide browser visual policy
-        id: policy
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          set -euo pipefail
-
-          is_visual_input() {
-            case "$1" in
-              .github/workflows/ci.yml|package.json|package-lock.json|playwright.config.js|tests/visual/*|static/*|internal/web/*|internal/cli/dev_runtime*.go|internal/devruntime/*|*.templ|README.md|CONTRIBUTING.md|docs/*)
-                return 0
-                ;;
-            esac
-            return 1
-          }
-
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "visual=true" >> "$GITHUB_OUTPUT"
-            echo "reason=push to main" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          visual=false
-          reason="no UI-sensitive PR paths changed"
-          while IFS=$'\t' read -r path previous_path status; do
-            if is_visual_input "$path" || is_visual_input "$previous_path"; then
-              visual=true
-              reason="UI-sensitive PR change: $path"
-              break
-            fi
-            if [ "$status" = "removed" ] || [ "$status" = "renamed" ]; then
-              if is_visual_input "$path" || is_visual_input "$previous_path"; then
-                visual=true
-                reason="UI-sensitive PR change: $path"
-                break
-              fi
-            fi
-          done < <(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[] | [.filename, (.previous_filename // ""), .status] | @tsv')
-
-          echo "visual=$visual" >> "$GITHUB_OUTPUT"
-          echo "reason=$reason" >> "$GITHUB_OUTPUT"
-
-      - name: Skip browser visual gate
-        if: steps.policy.outputs.visual != 'true'
-        run: |
-          echo "Browser visual gate skipped: ${{ steps.policy.outputs.reason }}."
-
       - uses: actions/checkout@v5
-        if: steps.policy.outputs.visual == 'true'
 
       - uses: actions/setup-go@v6
-        if: steps.policy.outputs.visual == 'true'
         with:
           go-version: '1.26.4'
           cache: true
 
       - uses: actions/setup-node@v6
-        if: steps.policy.outputs.visual == 'true'
         with:
           node-version: '24'
           cache: npm
 
       - name: Install Node dependencies
-        if: steps.policy.outputs.visual == 'true'
         run: npm ci
 
       - name: Install Playwright browsers
-        if: steps.policy.outputs.visual == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Install visual build generators
-        if: steps.policy.outputs.visual == 'true'
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 
       - name: Build Detent visual test binary
-        if: steps.policy.outputs.visual == 'true'
         run: make build
 
       - name: Run browser visual gate
-        if: steps.policy.outputs.visual == 'true'
         env:
           DETENT_BINARY: ${{ github.workspace }}/tmp/detent
         run: npm run test:visual
 
       - name: Upload browser visual evidence
-        if: always() && steps.policy.outputs.visual == 'true'
+        if: always()
         uses: actions/upload-artifact@v7
         with:
           name: browser-visual-evidence
@@ -202,7 +144,7 @@ jobs:
           retention-days: 14
 
       - name: Upload browser visual failure artifacts
-        if: failure() && steps.policy.outputs.visual == 'true'
+        if: failure()
         uses: actions/upload-artifact@v7
         with:
           name: browser-visual-failure-artifacts
@@ -349,87 +291,24 @@ jobs:
     runs-on: ubuntu-latest
     needs: [lint, verify, test-cover, browser-visual, windows-core, installer-smoke]
     steps:
-      - name: Decide release packaging policy
-        id: policy
-        env:
-          EVENT_NAME: ${{ github.event_name }}
-          GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPOSITORY: ${{ github.repository }}
-        run: |
-          if [ "$EVENT_NAME" != "pull_request" ]; then
-            echo "snapshot=true" >> "$GITHUB_OUTPUT"
-            echo "reason=push to main" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          release_relevant=false
-          is_release_input() {
-            case "$1" in
-              .goreleaser.yaml|.github/workflows/ci.yml|.github/workflows/release.yml|Makefile|go.mod|go.sum|detent-release.pub|install.sh|install.ps1)
-                return 0
-                ;;
-            esac
-            return 1
-          }
-
-          while IFS= read -r file; do
-            path="$(jq -r '.[0]' <<< "$file")"
-            previous_path="$(jq -r '.[1]' <<< "$file")"
-            status="$(jq -r '.[2]' <<< "$file")"
-
-            if is_release_input "$path" || is_release_input "$previous_path"; then
-              release_relevant=true
-              break
-            fi
-
-            if [ "$status" = "removed" ] || [ "$status" = "renamed" ]; then
-              case "$path" in
-                README.md|LICENSE)
-                  release_relevant=true
-                  break
-                  ;;
-              esac
-              case "$previous_path" in
-                README.md|LICENSE)
-                  release_relevant=true
-                  break
-                  ;;
-              esac
-            fi
-          done < <(gh api "repos/$REPOSITORY/pulls/$PR_NUMBER/files" --paginate --jq '.[] | [.filename, (.previous_filename // ""), .status] | @json')
-
-          if [ "$release_relevant" = true ]; then
-            echo "snapshot=true" >> "$GITHUB_OUTPUT"
-            echo "reason=release-relevant PR change" >> "$GITHUB_OUTPUT"
-          else
-            echo "snapshot=false" >> "$GITHUB_OUTPUT"
-            echo "reason=ordinary PR change" >> "$GITHUB_OUTPUT"
-          fi
-
       - uses: actions/checkout@v5
-        if: steps.policy.outputs.snapshot == 'true'
         with:
           fetch-depth: 0
 
       - uses: actions/setup-go@v6
-        if: steps.policy.outputs.snapshot == 'true'
         with:
           go-version: '1.26.4'
           cache: true
 
       - name: Install minisign
-        if: steps.policy.outputs.snapshot == 'true'
         run: |
           sudo apt-get update
           sudo apt-get install -y minisign
 
       - name: Prepare minisign snapshot key
-        if: steps.policy.outputs.snapshot == 'true'
         run: minisign -G -W -s "$RUNNER_TEMP/detent-minisign.key" -p "$RUNNER_TEMP/detent-minisign.pub"
 
       - name: Run GoReleaser snapshot
-        if: steps.policy.outputs.snapshot == 'true'
         uses: goreleaser/goreleaser-action@v7
         with:
           distribution: goreleaser
@@ -439,8 +318,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MINISIGN_KEY_FILE: ${{ runner.temp }}/detent-minisign.key
           MINISIGN_PASSWORD: ""
-
-      - name: Skip GoReleaser snapshot
-        if: steps.policy.outputs.snapshot != 'true'
-        run: |
-          echo "GoReleaser snapshot skipped: ${{ steps.policy.outputs.reason }}."

--- a/README.md
+++ b/README.md
@@ -474,14 +474,11 @@ package-manager manifests. Scoop publishing targets
 skips publishing when `SCOOP_BUCKET_GITHUB_TOKEN` or `WINGET_GITHUB_TOKEN` is
 not configured.
 
-CI also runs `GoReleaser Snapshot` on every push to `main` so the current
-merge head remains release-package validated. Pull requests run that snapshot
-only when release packaging inputs change: `.goreleaser.yaml`, the CI or
-release workflows, `Makefile`, Go module files, installer scripts, the release
-public key, or removal/rename of the top-level `README.md` and `LICENSE` files
-that are bundled into release archives. Other pull requests keep the required
-lint, build, vet, test, race, coverage, and Windows checks without the release
-packaging tail.
+CI also runs `GoReleaser Snapshot` on every pull request and every push to
+`main` so the current merge head remains release-package validated before and
+after merge. Required branch checks must not pass as path- or event-dependent
+no-ops on pull requests when the same check name runs real validation on
+`main`.
 
 ## Quick Start
 
@@ -1586,7 +1583,8 @@ but the prebuilt `v2.1.6` binary targets an older Go toolchain than this repo an
 newer prebuilt lint releases change the enforced lint set. `GoReleaser Snapshot`
 continues to run on every PR in this workflow; moving it off PRs or making it
 path-based is a release-policy decision because it trades package coverage for
-merge latency.
+merge latency and requires a separate non-required check name or equivalent
+required companion validation.
 
 ## Multi-Project Operation
 

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -100,6 +100,7 @@ func TestMainProtectionDocumentationMatchesWorkflow(t *testing.T) {
 
 	for _, want := range []string{
 		"`required_status_checks.strict: true`",
+		"must not report success from a path- or event-dependent no-op",
 		"`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`",
 		"`Browser Visual`",
 	} {
@@ -117,6 +118,27 @@ func TestMainProtectionDocumentationMatchesWorkflow(t *testing.T) {
 		for _, marker := range check.markers {
 			if !strings.Contains(job, marker) {
 				t.Fatalf("workflow job for required check %q missing %q", check.name, marker)
+			}
+		}
+	}
+}
+
+func TestRequiredChecksDoNotUseEventDependentGreenNoops(t *testing.T) {
+	t.Parallel()
+
+	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
+	for _, check := range requiredMainStatusChecks {
+		job := workflowBetween(t, workflow, check.jobStart, check.jobEnd)
+		for _, forbidden := range []string{
+			"github.event_name",
+			"EVENT_NAME",
+			"pull_request",
+			"steps.policy.outputs",
+			"Skip ",
+			" skipped:",
+		} {
+			if strings.Contains(job, forbidden) {
+				t.Fatalf("required check %q contains green no-op marker %q", check.name, forbidden)
 			}
 		}
 	}
@@ -187,7 +209,7 @@ func TestKanbanBrowserDragDropRunsInVisualGate(t *testing.T) {
 	workflow := strings.ReplaceAll(string(workflowRaw), "\r\n", "\n")
 	visualJob := workflowBetween(t, workflow, "  browser-visual:", "\n  windows-core:")
 	for _, want := range []string{
-		"internal/cli/dev_runtime*.go",
+		"npm run test:visual",
 		"name: Upload browser visual evidence",
 		"tmp/playwright-evidence",
 		"name: Upload browser visual failure artifacts",

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -57,9 +57,9 @@ The execution edge still carries these code/git/PR assumptions.
 - The CI lint job keeps the project-pinned golangci-lint version and caches its
   binary so cache hits avoid a per-run `go install` without changing lint
   coverage.
-- `GoReleaser Snapshot` runs on every push to `main` and on PRs only when
-  release packaging inputs change, preserving release-package coverage without
-  charging docs-only and routine code PRs the full snapshot cost.
+- `GoReleaser Snapshot` runs on every PR and every push to `main` so the
+  required check exercises the same release-package path before and after
+  merge.
 
 ### Main Branch Protection
 
@@ -69,8 +69,9 @@ merge. The expected GitHub branch protection or ruleset setting is
 queue, the queue must provide equivalent current-base validation before merge.
 
 Required status checks must include every meaningful CI job directly. Do not
-depend on a downstream skipped job to protect an upstream gate. The required
-checks are:
+depend on a downstream skipped job to protect an upstream gate. A required
+check name must not report success from a path- or event-dependent no-op when
+the same named check runs real validation on `main`. The required checks are:
 
 - `Lint`
 - `Verify (ubuntu-latest)`
@@ -88,7 +89,7 @@ PR through `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
 Push runs, including consecutive pushes to `main`, use a unique run group and
 must not be cancelled by later pushes. The workflow test in
 `ci_workflow_test.go` checks this section against `.github/workflows/ci.yml` so
-job-name and required-check drift fails in local validation.
+job-name, required-check, and green no-op drift fails in local validation.
 
 ## Still Git/PR Coupled
 

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -193,6 +193,9 @@ func resolveGlobalRuntimeGitHubToken(ctx context.Context, cfg globalconfig.Confi
 	deps := runtimeDeps{}.withDefaults()
 	if strings.TrimSpace(cfg.GitHubToken) != "" {
 		deps.lookupEnv = withoutRuntimeGitHubTokenEnv(deps.lookupEnv)
+		if githubTokenSentinel(cfg.GitHubToken) {
+			deps.ghAuthToken = defaultGHAuthTokenWithoutRuntimeEnv
+		}
 	}
 	token, _, err := resolveRuntimeGitHubToken(ctx, &cfg, deps)
 	if err != nil {

--- a/internal/cli/global_reload.go
+++ b/internal/cli/global_reload.go
@@ -191,11 +191,23 @@ func (r *globalConfigReloader) runtimeGitHubToken(ctx context.Context, cfg globa
 
 func resolveGlobalRuntimeGitHubToken(ctx context.Context, cfg globalconfig.Config) (string, error) {
 	deps := runtimeDeps{}.withDefaults()
+	if strings.TrimSpace(cfg.GitHubToken) != "" {
+		deps.lookupEnv = withoutRuntimeGitHubTokenEnv(deps.lookupEnv)
+	}
 	token, _, err := resolveRuntimeGitHubToken(ctx, &cfg, deps)
 	if err != nil {
 		return "", err
 	}
 	return runtimeGlobalGitHubToken(token), nil
+}
+
+func withoutRuntimeGitHubTokenEnv(lookupEnv func(string) string) func(string) string {
+	return func(key string) string {
+		if key == "GITHUB_TOKEN" {
+			return ""
+		}
+		return lookupEnv(key)
+	}
 }
 
 func managerConfigWithRuntimeGitHubToken(cfg globalconfig.Config, token string) project.ManagerConfig {

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -478,6 +478,14 @@ func runtimeDepsFromOptions(opts options) runtimeDeps {
 }
 
 func defaultGHAuthToken(ctx context.Context) (string, error) {
+	return runGHAuthToken(ctx, nil)
+}
+
+func defaultGHAuthTokenWithoutRuntimeEnv(ctx context.Context) (string, error) {
+	return runGHAuthToken(ctx, environmentWithoutKeys([]string{"GITHUB_TOKEN"}))
+}
+
+func runGHAuthToken(ctx context.Context, env []string) (string, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -490,6 +498,9 @@ func defaultGHAuthToken(ctx context.Context) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(commandCtx, path, "auth", "token") // #nosec G204 -- gh path is PATH-resolved and arguments are fixed.
+	if env != nil {
+		cmd.Env = env
+	}
 	output, err := cmd.CombinedOutput()
 	if commandCtx.Err() != nil {
 		return "", commandCtx.Err()

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
@@ -564,6 +565,40 @@ func TestRuntimeGitHubTokenRefresherUsesCurrentGlobalConfig(t *testing.T) {
 	}
 }
 
+func TestRuntimeGitHubTokenRefresherResolvesConfiguredGHSentinelWithoutActionsToken(t *testing.T) {
+	t.Setenv("GITHUB_TOKEN", "actions-token")
+	fakeGHDir := t.TempDir()
+	writeFakeGHAuthToken(t, fakeGHDir)
+	t.Setenv("PATH", fakeGHDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	workflowPath := filepath.Join(t.TempDir(), "workflow.md")
+	if err := os.WriteFile(workflowPath, []byte("---\ntracker:\n  kind: github\n---\nPrompt\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	globalState := newGlobalConfigState(globalconfig.Config{})
+	tokenState := newRuntimeGitHubTokenState("")
+	refresh := runtimeGitHubTokenRefresher(globalState, tokenState)
+
+	globalState.set(globalconfig.Config{
+		GitHubToken: "gh",
+		Projects: []globalconfig.Project{{
+			ID:       "detent",
+			Workflow: workflowPath,
+			Workdir:  ".",
+		}},
+	})
+	got, err := refresh(context.Background())
+	if err != nil {
+		t.Fatalf("refresh() error = %v", err)
+	}
+	if got != "gh-token" {
+		t.Fatalf("refresh() = %q, want gh-token", got)
+	}
+	if tokenState.get() != "gh-token" {
+		t.Fatalf("runtime token state = %q, want gh-token", tokenState.get())
+	}
+}
+
 func githubRuntimeConfig(token string) globalconfig.Config {
 	return globalconfig.Config{
 		GitHubToken: token,
@@ -651,6 +686,21 @@ func runRuntimeWorkflowCommand(t *testing.T, dir string, name string, args ...st
 		t.Fatalf("%s %s error = %v\n%s", name, strings.Join(args, " "), err, output)
 	}
 	return string(output)
+}
+
+func writeFakeGHAuthToken(t *testing.T, dir string) {
+	t.Helper()
+
+	name := "gh"
+	body := "#!/bin/sh\nif [ \"$GITHUB_TOKEN\" = \"actions-token\" ]; then printf %s actions-token; else printf %s gh-token; fi\n"
+	if runtime.GOOS == "windows" {
+		name = "gh.bat"
+		body = "@echo off\r\nif \"%GITHUB_TOKEN%\"==\"actions-token\" (\r\n  echo actions-token\r\n) else (\r\n  echo gh-token\r\n)\r\n"
+	}
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o755); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
 }
 
 func mapLookup(values map[string]string) func(string) string {

--- a/internal/cli/runtime_test.go
+++ b/internal/cli/runtime_test.go
@@ -534,7 +534,7 @@ func TestRuntimeGlobalGitHubTokenSources(t *testing.T) {
 }
 
 func TestRuntimeGitHubTokenRefresherUsesCurrentGlobalConfig(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GITHUB_TOKEN", "actions-token")
 
 	workflowPath := filepath.Join(t.TempDir(), "workflow.md")
 	if err := os.WriteFile(workflowPath, []byte("---\ntracker:\n  kind: github\n---\nPrompt\n"), 0o644); err != nil {


### PR DESCRIPTION
## Summary

- Run required `Browser Visual` and `GoReleaser Snapshot` jobs fully on pull requests and pushes to `main`.
- Add a workflow policy test that rejects path- or event-dependent green no-op branches in documented required checks.
- Fix live global `github_token` refresh when Actions provides `GITHUB_TOKEN`, including configured `github_token: gh` sentinel refreshes.
- Document that required branch checks cannot be green no-ops when the same check name validates on `main`.

Fixes #659

## Test Plan

- [x] `go test ./internal/cli -run 'TestRuntimeGitHubTokenRefresher(UsesCurrentGlobalConfig|ResolvesConfiguredGHSentinelWithoutActionsToken)' -v -count=1`
- [x] `go test . -run 'Test(MainProtectionDocumentationMatchesWorkflow|RequiredChecksDoNotUseEventDependentGreenNoops|KanbanBrowserDragDropRunsInVisualGate)' -count=1`
- [x] `GITHUB_TOKEN=actions-token go test ./... -count=1`
- [x] `make check`
- [x] `GITHUB_TOKEN=actions-token MINISIGN_KEY_FILE=$PWD/tmp/detent-minisign.key MINISIGN_PASSWORD="" make release-snapshot`