### PR TITLE
fix(ci): stabilize installer smoke

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,11 +218,9 @@ jobs:
           grep -F "binary=$DETENT_INSTALL_DIR/detent" "$DETENT_INSTALL_LOCK"
           grep -F "installed_at=" "$DETENT_INSTALL_LOCK"
 
-          "$DETENT_INSTALL_DIR/detent" version
-          "$DETENT_INSTALL_DIR/detent" update --check --json > "$RUNNER_TEMP/detent/update-check.json"
-          "$DETENT_INSTALL_DIR/detent" update --yes --json > "$RUNNER_TEMP/detent/update-yes.json"
-          jq -e '.install_source == "release" and .action == "up_to_date" and .update_available == false' "$RUNNER_TEMP/detent/update-check.json"
-          jq -e '.install_source == "release" and .action == "up_to_date" and .update_available == false' "$RUNNER_TEMP/detent/update-yes.json"
+          version_output="$("$DETENT_INSTALL_DIR/detent" version)"
+          printf '%s\n' "$version_output"
+          grep -F "version: $DETENT_VERSION" <<< "$version_output"
 
       - name: Smoke release installer
         if: runner.os == 'Windows'
@@ -266,24 +264,14 @@ jobs:
             throw 'install lock did not record installed_at'
           }
 
-          & $binary version
-          $checkRaw = & $binary update --check --json
+          $versionOutput = & $binary version
           if ($LASTEXITCODE -ne 0) {
-            throw "detent update --check failed with exit code $LASTEXITCODE"
+            throw "detent version failed with exit code $LASTEXITCODE"
           }
-          $yesRaw = & $binary update --yes --json
-          if ($LASTEXITCODE -ne 0) {
-            throw "detent update --yes failed with exit code $LASTEXITCODE"
-          }
-          $checkJSON = $checkRaw -join "`n"
-          $yesJSON = $yesRaw -join "`n"
-          $check = $checkJSON | ConvertFrom-Json
-          $yes = $yesJSON | ConvertFrom-Json
-          if ($check.install_source -ne 'release' -or $check.action -ne 'up_to_date' -or $check.update_available) {
-            throw "unexpected update --check status: $checkJSON"
-          }
-          if ($yes.install_source -ne 'release' -or $yes.action -ne 'up_to_date' -or $yes.update_available) {
-            throw "unexpected update --yes status: $yesJSON"
+          $versionText = $versionOutput -join "`n"
+          Write-Host $versionText
+          if ($versionText -notmatch [regex]::Escape("version: $env:DETENT_VERSION")) {
+            throw "unexpected detent version output: $versionText"
           }
 
   goreleaser-snapshot:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,9 +218,13 @@ jobs:
           grep -F "binary=$DETENT_INSTALL_DIR/detent" "$DETENT_INSTALL_LOCK"
           grep -F "installed_at=" "$DETENT_INSTALL_LOCK"
 
-          version_output="$("$DETENT_INSTALL_DIR/detent" version)"
+          expected_version="${DETENT_VERSION#v}"
+          version_output="$("$DETENT_INSTALL_DIR/detent" --format pretty version)"
           printf '%s\n' "$version_output"
-          grep -F "version: $DETENT_VERSION" <<< "$version_output"
+          if ! grep -Fq "version: $DETENT_VERSION" <<< "$version_output" && ! grep -Fq "version: $expected_version" <<< "$version_output"; then
+            echo "Unexpected detent version output" >&2
+            exit 1
+          fi
 
       - name: Smoke release installer
         if: runner.os == 'Windows'
@@ -264,13 +268,18 @@ jobs:
             throw 'install lock did not record installed_at'
           }
 
-          $versionOutput = & $binary version
+          $versionOutput = & $binary --format pretty version
           if ($LASTEXITCODE -ne 0) {
             throw "detent version failed with exit code $LASTEXITCODE"
           }
           $versionText = $versionOutput -join "`n"
           Write-Host $versionText
-          if ($versionText -notmatch [regex]::Escape("version: $env:DETENT_VERSION")) {
+          $expectedVersion = $env:DETENT_VERSION
+          if ($expectedVersion.StartsWith('v')) {
+            $expectedVersion = $expectedVersion.Substring(1)
+          }
+          $versionMatches = $versionText.Contains("version: $env:DETENT_VERSION") -or $versionText.Contains("version: $expectedVersion")
+          if (-not $versionMatches) {
             throw "unexpected detent version output: $versionText"
           }
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -106,12 +106,14 @@ type GitHubClientConfig struct {
 	APIBase          string
 	HTTPClient       *http.Client
 	MaxDownloadBytes int64
+	AuthToken        string
 }
 
 type GitHubClient struct {
 	apiBase          string
 	http             *http.Client
 	maxDownloadBytes int64
+	authToken        string
 }
 
 func NewGitHubClient(cfg GitHubClientConfig) *GitHubClient {
@@ -127,7 +129,11 @@ func NewGitHubClient(cfg GitHubClientConfig) *GitHubClient {
 	if maxDownloadBytes <= 0 {
 		maxDownloadBytes = defaultMaxDownloadBytes
 	}
-	return &GitHubClient{apiBase: apiBase, http: httpClient, maxDownloadBytes: maxDownloadBytes}
+	authToken := strings.TrimSpace(cfg.AuthToken)
+	if authToken == "" {
+		authToken = githubAuthTokenFromEnv(os.Getenv)
+	}
+	return &GitHubClient{apiBase: apiBase, http: httpClient, maxDownloadBytes: maxDownloadBytes, authToken: authToken}
 }
 
 func (c *GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
@@ -137,6 +143,9 @@ func (c *GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
 	}
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("User-Agent", defaultRequestUserAgent)
+	if auth := githubAuthHeader(c.authToken); auth != "" {
+		req.Header.Set("Authorization", auth)
+	}
 
 	resp, err := c.http.Do(req)
 	if err != nil {
@@ -152,6 +161,27 @@ func (c *GitHubClient) ListReleases(ctx context.Context) ([]Release, error) {
 		return nil, fmt.Errorf("decode releases: %w", err)
 	}
 	return releases, nil
+}
+
+func githubAuthTokenFromEnv(getenv func(string) string) string {
+	for _, name := range []string{"DETENT_GITHUB_TOKEN", "GH_TOKEN", "GITHUB_TOKEN"} {
+		if token := strings.TrimSpace(getenv(name)); token != "" {
+			return token
+		}
+	}
+	return ""
+}
+
+func githubAuthHeader(token string) string {
+	token = strings.TrimSpace(token)
+	if token == "" {
+		return ""
+	}
+	lower := strings.ToLower(token)
+	if strings.HasPrefix(lower, "bearer ") || strings.HasPrefix(lower, "token ") {
+		return token
+	}
+	return "Bearer " + token
 }
 
 func (c *GitHubClient) Download(ctx context.Context, url string) ([]byte, error) {

--- a/internal/update/update_test.go
+++ b/internal/update/update_test.go
@@ -89,6 +89,69 @@ func TestSelectLatestReleasePrereleaseHandling(t *testing.T) {
 	}
 }
 
+func TestGitHubClientListReleasesUsesAuthToken(t *testing.T) {
+	t.Parallel()
+
+	authHeaders := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases" {
+			http.NotFound(w, r)
+			return
+		}
+		authHeaders <- r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewGitHubClient(GitHubClientConfig{
+		APIBase:    server.URL,
+		HTTPClient: server.Client(),
+		AuthToken:  "ghs_configured_token",
+	})
+	_, err := client.ListReleases(context.Background())
+	if err != nil {
+		t.Fatalf("ListReleases() error = %v", err)
+	}
+
+	got := <-authHeaders
+	if got != "Bearer ghs_configured_token" {
+		t.Fatalf("Authorization = %q, want Bearer token", got)
+	}
+}
+
+func TestGitHubClientListReleasesUsesEnvironmentAuthToken(t *testing.T) {
+	t.Setenv("DETENT_GITHUB_TOKEN", "")
+	t.Setenv("GH_TOKEN", "ghs_environment_token")
+	t.Setenv("GITHUB_TOKEN", "")
+
+	authHeaders := make(chan string, 1)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/releases" {
+			http.NotFound(w, r)
+			return
+		}
+		authHeaders <- r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprint(w, `[]`)
+	}))
+	t.Cleanup(server.Close)
+
+	client := NewGitHubClient(GitHubClientConfig{
+		APIBase:    server.URL,
+		HTTPClient: server.Client(),
+	})
+	_, err := client.ListReleases(context.Background())
+	if err != nil {
+		t.Fatalf("ListReleases() error = %v", err)
+	}
+
+	got := <-authHeaders
+	if got != "Bearer ghs_environment_token" {
+		t.Fatalf("Authorization = %q, want Bearer token", got)
+	}
+}
+
 func TestDetectInstallSource(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Stop installer smoke from running `detent update` through the previously published binary.
- Assert the installed release binary reports the resolved release tag on Linux and Windows.
- Authenticate update release-list requests with an explicit token or `DETENT_GITHUB_TOKEN`/`GH_TOKEN`/`GITHUB_TOKEN`.

Fixes #662

## Test Plan

- [x] `go test ./internal/update`
- [x] `actionlint .github/workflows/ci.yml`
- [x] `make check`