### PR TITLE
fix(orchestrator): mark todo issues in progress

### DIFF
--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -577,6 +577,50 @@ func TestDispatchCandidatesClaimsDuplicateIssueWithinCycle(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesRechecksStartTransitionStateCapacity(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		MaxConcurrentAgentsByState: map[string]int{
+			"In Progress": 1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done"},
+	})
+	runner := newWorkerHostRunner()
+	orch := Orchestrator{
+		cfg:        cfg,
+		connector:  hydratingDispatchConnector{},
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion),
+	}
+	state := newState(cfg)
+	now := time.Now()
+	first := dispatchTestIssue("issue-first", "Todo")
+	first.Fields = map[string]string{"Status": "Todo"}
+	second := dispatchTestIssue("issue-second", "Todo")
+	second.Fields = map[string]string{"Status": "Todo"}
+
+	orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{first, second}, now)
+
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.Issue.ID != first.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, first.ID)
+	}
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected second dispatch = %#v", request)
+	default:
+	}
+	if len(state.Running) != 1 {
+		t.Fatalf("Running len = %d, want 1", len(state.Running))
+	}
+	if got := state.Running[first.ID].Issue.State; got != "In Progress" {
+		t.Fatalf("Running[%q].Issue.State = %q, want In Progress", first.ID, got)
+	}
+}
+
 func TestDispatchIssueRequiresSharedGlobalSlot(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1390,12 +1390,23 @@ func (o *Orchestrator) dispatchIssue(
 	now time.Time,
 	preferredWorkerHost string,
 ) bool {
+	runMode := o.dispatchMode(state, issue)
+	targetState := dispatchStartTransitionState(issue, runMode, o.cfg.ActiveStates)
+	slotIssue := issue
+	if targetState != "" {
+		slotIssue = cloneIssue(issue)
+		slotIssue.State = targetState
+		if !o.dispatchPlanner().slotsAvailable(slotIssue, state, preferredWorkerHost) {
+			return false
+		}
+	}
+
 	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
 	if !ok {
 		return false
 	}
 
-	globalSlot, ok := o.acquireGlobalDispatchSlot(ctx, issue, workerHost, now)
+	globalSlot, ok := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now)
 	if !ok {
 		return false
 	}
@@ -1407,6 +1418,19 @@ func (o *Orchestrator) dispatchIssue(
 	}
 
 	issue = cloneIssue(claimedIssue)
+	if targetState != "" {
+		if err := o.connector.UpdateIssueState(ctx, issue.ID, targetState); err != nil {
+			o.releaseGlobalDispatchSlot(globalSlot)
+			if abandonErr := o.abandonClaim(ctx, issue.ID); abandonErr != nil && o.logger != nil {
+				o.logger.Warn("abandon claim after start state transition failed", "issue_id", issue.ID, "error", abandonErr)
+			}
+			if o.logger != nil {
+				o.logger.Warn("start state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
+			}
+			return false
+		}
+		issue.State = targetState
+	}
 	claim.Issue = issue
 	runCtx, cancel := context.WithCancel(ctx)
 	state.Running[issue.ID] = Running{
@@ -1428,7 +1452,7 @@ func (o *Orchestrator) dispatchIssue(
 	request := RunRequest{
 		Issue:           issue,
 		Attempt:         attempt,
-		Mode:            o.dispatchMode(state, issue),
+		Mode:            runMode,
 		StartedAt:       now,
 		WorkerHost:      workerHost,
 		SelectorContext: o.selectorContext(),
@@ -1436,6 +1460,19 @@ func (o *Orchestrator) dispatchIssue(
 	}
 	o.supervisor.Dispatch(runCtx, request, o.runResults)
 	return true
+}
+
+func dispatchStartTransitionState(issue connector.Issue, mode string, activeStates []string) string {
+	if mode != runpkg.RunModeImplement {
+		return ""
+	}
+	if normalizeState(issue.State) != "todo" {
+		return ""
+	}
+	if !stateIn(planImplementationState, activeStates) {
+		return ""
+	}
+	return planImplementationState
 }
 
 func (o *Orchestrator) dispatchMode(state *State, issue connector.Issue) string {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -120,6 +120,13 @@ func TestRunCompletionTransitionsLabelModeIssueToHumanReview(t *testing.T) {
 	defer stop()
 
 	waitForStateUpdate(t, tracker, stateUpdateCall{issueID: issue.ID, state: "Human Review"})
+	wantUpdates := []stateUpdateCall{
+		{issueID: issue.ID, state: "In Progress"},
+		{issueID: issue.ID, state: "Human Review"},
+	}
+	if updates := tracker.stateUpdateCalls(); !stateUpdateCallsContainInOrder(updates, wantUpdates) {
+		t.Fatalf("state updates = %#v, want sequence %#v", updates, wantUpdates)
+	}
 
 	if got := runner.calls.Load(); got != 1 {
 		t.Fatalf("runner calls = %d, want 1", got)
@@ -133,6 +140,38 @@ func TestRunCompletionTransitionsLabelModeIssueToHumanReview(t *testing.T) {
 	}
 	if !labelListContains(got.Labels, "detent:human-review") {
 		t.Fatalf("Labels = %#v, want detent:human-review", got.Labels)
+	}
+}
+
+func TestRunStartsLabelModeTodoIssueInProgress(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-label-start", "digitaldrywood/detent#669", "Todo")
+	issue.Labels = []string{"detent:todo", "bug"}
+	tracker := newFakeLabelConnector(issue)
+	runner := newBlockingRunner()
+
+	orch := newTestOrchestrator(t, tracker, runner)
+	stop := runOrchestrator(t, orch)
+	defer stop()
+	defer close(runner.release)
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != issue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
+	}
+
+	waitForStateUpdate(t, tracker, stateUpdateCall{issueID: issue.ID, state: "In Progress"})
+
+	got := tracker.candidateIssue(issue.ID)
+	if got.State != "In Progress" {
+		t.Fatalf("State = %q, want In Progress", got.State)
+	}
+	if count := statusLabelCount(got.Labels, "detent:"); count != 1 {
+		t.Fatalf("detent status label count = %d in %#v, want 1", count, got.Labels)
+	}
+	if !labelListContains(got.Labels, "detent:in-progress") {
+		t.Fatalf("Labels = %#v, want detent:in-progress", got.Labels)
 	}
 }
 
@@ -2049,6 +2088,19 @@ func waitForStateUpdate(t *testing.T, tracker *fakeConnector, want stateUpdateCa
 			time.Sleep(time.Millisecond)
 		}
 	}
+}
+
+func stateUpdateCallsContainInOrder(got []stateUpdateCall, want []stateUpdateCall) bool {
+	index := 0
+	for _, update := range got {
+		if index >= len(want) {
+			return true
+		}
+		if update == want[index] {
+			index++
+		}
+	}
+	return index == len(want)
 }
 
 func statusLabelCount(labels []string, prefix string) int {


### PR DESCRIPTION
## Summary

- Move implementation dispatches from `Todo` to `In Progress` before starting the runner.
- Preserve plan-only dispatch behavior and keep label-backed regression coverage for `Todo -> In Progress -> Human Review`.
- Recheck dispatch capacity and global slot acquisition against the post-start target state.

Fixes #669

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestDispatchReadyIssuesRechecksStartTransitionStateCapacity|TestRunStartsLabelModeTodoIssueInProgress|TestRunCompletionTransitionsLabelModeIssueToHumanReview|TestRunPlanDispatchPostsPlanAndMovesToPlanReview' -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/connector/github -run 'TestConnectorUpdateIssueStateReplacesStatusLabels|TestConnectorUpdateIssueStateReplacesStaleStatusLabelRace' -count=1`
- [x] `make check`