### PR TITLE
test(orchestrator): avoid todo board race

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1360,7 +1360,7 @@ func TestRunFetchesOnlyActionableObservedStates(t *testing.T) {
 func TestRunPublishesBoardIssuesFromCandidatesAndObservedStates(t *testing.T) {
 	t.Parallel()
 
-	candidate := testIssue("issue-todo", "digitaldrywood/detent#91", "Todo")
+	candidate := testIssue("issue-progress", "digitaldrywood/detent#91", "In Progress")
 	backlog := testIssue("issue-backlog", "digitaldrywood/detent#92", "Backlog")
 	review := testIssue("issue-review", "digitaldrywood/detent#93", "Human Review")
 	tracker := newFakeConnector(candidate)
@@ -1397,9 +1397,9 @@ func TestRunPublishesBoardIssuesFromCandidatesAndObservedStates(t *testing.T) {
 		got[issue.ID] = issue.State
 	}
 	want := map[string]string{
-		"issue-todo":    "Todo",
-		"issue-backlog": "Backlog",
-		"issue-review":  "Human Review",
+		"issue-progress": "In Progress",
+		"issue-backlog":  "Backlog",
+		"issue-review":   "Human Review",
 	}
 	if !maps.Equal(got, want) {
 		t.Fatalf("BoardIssues = %#v, want %#v", got, want)


### PR DESCRIPTION
## Summary

- Make `TestRunPublishesBoardIssuesFromCandidatesAndObservedStates` use an already-active `In Progress` candidate.
- Keep the test focused on board publication from candidate plus observed fetches, without racing #670's Todo -> In Progress start transition.

Fixes #671

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestRunPublishesBoardIssuesFromCandidatesAndObservedStates|TestRunStartsLabelModeTodoIssueInProgress|TestRunCompletionTransitionsLabelModeIssueToHumanReview|TestDispatchReadyIssuesRechecksStartTransitionStateCapacity' -count=20`\n- [x] `make check`