### PR TITLE
fix(onboarding): canonicalize profile answers

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1146,11 +1146,19 @@ operator asks for an advanced override.
 
 Stop here before Phase 3 or any other command that can create, link, mutate, or
 delete GitHub Projects, issue fields, labels, issues, PRs, `WORKFLOW.md`, or
-`global.yaml`. Show the operator `$ONBOARDING_DIR/recommendations.md`, the
-plain-English behavior summary, and the complete `$ONBOARDING_DIR/answers.env`,
-then ask: "May I execute the selected mutation steps using these exact
-answers?" Defaults from Phase 2 are still only recommendations; an unanswered
-default must not authorize any external or local config mutation.
+`global.yaml`. Canonicalize profile-derived answers before the final operator
+prompt so `$ONBOARDING_DIR/answers.env` visibly contains the exact low-level
+values mutation steps will read:
+
+```sh
+detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write
+```
+
+Show the operator `$ONBOARDING_DIR/recommendations.md`, the plain-English
+behavior summary, and the complete `$ONBOARDING_DIR/answers.env`, then ask:
+"May I execute the selected mutation steps using these exact answers?" Defaults
+from Phase 2 are still only recommendations; an unanswered default must not
+authorize any external or local config mutation.
 
 ```sh
 detent --format pretty onboarding explain-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision
@@ -1171,6 +1179,7 @@ mv "$CONFIRMATION_FILE" "$ONBOARDING_DIR/answers.env"
 printf '%s\n' \
   'MUTATION_CONFIRMED=true' \
   >> "$ONBOARDING_DIR/answers.env"
+detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write
 detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation
 rg '^MUTATION_CONFIRMED=true$' "$ONBOARDING_DIR/answers.env"
 awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOARDING_DIR/answers.env"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1169,8 +1169,11 @@ approves the effective behavior, not only raw fields.
 
 Record the explicit confirmation only after the operator says yes. This removes
 stale confirmations first and appends the new confirmation as the final
-nonblank line. If any Phase 2 answer changes later, rerun Phase 2.5 and record
-a fresh confirmation.
+nonblank line. The second normalization call below is an idempotence check. If
+it reports missing profile expansion after confirmation, remove the stale
+confirmation, rerun normalization, show the updated answer file to the operator,
+and record a fresh confirmation. If any Phase 2 answer changes later, rerun
+Phase 2.5 and record a fresh confirmation.
 
 ```sh
 CONFIRMATION_FILE="$(mktemp)"

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -52,6 +52,16 @@ type onboardingAnswersValidationResult struct {
 	MutationConfirmed      bool                                      `json:"mutation_confirmed"`
 }
 
+type onboardingAnswersNormalizationResult struct {
+	Status                 string            `json:"status"`
+	Path                   string            `json:"path"`
+	Written                bool              `json:"written"`
+	Changed                bool              `json:"changed"`
+	DeliveryProfile        string            `json:"delivery_profile,omitempty"`
+	DeliveryProfileAnswers map[string]string `json:"delivery_profile_answers,omitempty"`
+	MutationConfirmed      bool              `json:"mutation_confirmed"`
+}
+
 type onboardingDraftAnswersResult struct {
 	Status                         string   `json:"status"`
 	AnswersPath                    string   `json:"answers_path,omitempty"`
@@ -79,6 +89,13 @@ type onboardingAnswers struct {
 	Values       map[string]string
 	LastNonblank string
 	Problems     []string
+}
+
+type onboardingDeliveryProfileAnswerAnalysis struct {
+	Profile   string
+	Expansion map[string]string
+	Missing   []string
+	Problems  []string
 }
 
 type onboardingDraftAnswersConfig struct {
@@ -110,6 +127,7 @@ func newOnboardingCommand(configPath *string, opts options) *cobra.Command {
 	cmd.AddCommand(
 		newOnboardingValidateAnswersCommand(),
 		newOnboardingExplainAnswersCommand(),
+		newOnboardingNormalizeAnswersCommand(),
 		newOnboardingDraftAnswersCommand(configPath, opts),
 		newOnboardingDiagnoseGateCommand(),
 	)
@@ -275,6 +293,42 @@ func canonicalOnboardingDeliveryAnswerLines(result onboardingAnswersValidationRe
 		lines = append(lines, key+"="+result.DeliveryProfileAnswers[key])
 	}
 	return lines
+}
+
+func newOnboardingNormalizeAnswersCommand() *cobra.Command {
+	var answersPath string
+	var write bool
+	cmd := &cobra.Command{
+		Use:          "normalize-answers",
+		Short:        "Write canonical onboarding answers expanded from selected profiles",
+		Example:      `detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write`,
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, err := normalizeOnboardingAnswersFile(answersPath, write)
+			if err != nil {
+				return err
+			}
+			return out.Write(func(w io.Writer) error {
+				state := "already normalized"
+				if result.Changed {
+					state = "normalized"
+				}
+				if !result.Written {
+					state += " (preview only; rerun with --write to update answers.env)"
+				}
+				_, writeErr := fmt.Fprintf(w, "onboarding answers %s: %s\n", state, result.Path)
+				return writeErr
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
+	cmd.Flags().BoolVar(&write, "write", false, "write normalized answers back to answers.env")
+	return cmd
 }
 
 func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfig) (onboardingDraftAnswersResult, error) {
@@ -815,6 +869,118 @@ func validateOnboardingAnswersFile(path string, phase string) (onboardingAnswers
 	return result, nil
 }
 
+func normalizeOnboardingAnswersFile(path string, write bool) (onboardingAnswersNormalizationResult, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return onboardingAnswersNormalizationResult{}, NewValidationError(
+			"--answers is required",
+			`Run detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write.`,
+			nil,
+		)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return onboardingAnswersNormalizationResult{}, NewValidationError(
+				"answers file not found: "+path,
+				"Create answers.env from explicit human answers before continuing onboarding.",
+				nil,
+			)
+		}
+		return onboardingAnswersNormalizationResult{}, fmt.Errorf("read onboarding answers %s: %w", path, err)
+	}
+	answers := parseOnboardingAnswers(raw)
+	analysis := analyzeOnboardingDeliveryProfileAnswers(answers)
+	if len(analysis.Problems) > 0 {
+		return onboardingAnswersNormalizationResult{}, NewValidationError(
+			strings.Join(analysis.Problems, "; "),
+			`Resolve delivery profile conflicts or remove DELIVERY_PROFILE, then rerun detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write.`,
+			nil,
+		)
+	}
+	content := string(raw)
+	if len(analysis.Missing) > 0 {
+		content = buildOnboardingNormalizedAnswersContent(raw, analysis)
+	}
+	result := onboardingAnswersNormalizationResult{
+		Status:                 "ok",
+		Path:                   path,
+		Written:                write,
+		Changed:                content != string(raw),
+		DeliveryProfile:        analysis.Profile,
+		DeliveryProfileAnswers: analysis.Expansion,
+		MutationConfirmed:      answers.Values["MUTATION_CONFIRMED"] == "true" && answers.LastNonblank == "MUTATION_CONFIRMED=true",
+	}
+	if write && result.Changed {
+		if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+			return onboardingAnswersNormalizationResult{}, fmt.Errorf("write onboarding answers %s: %w", path, err)
+		}
+		if err := os.Chmod(path, 0o600); err != nil {
+			return onboardingAnswersNormalizationResult{}, fmt.Errorf("restrict onboarding answers %s: %w", path, err)
+		}
+	}
+	return result, nil
+}
+
+func buildOnboardingNormalizedAnswersContent(raw []byte, analysis onboardingDeliveryProfileAnswerAnalysis) string {
+	missing := make(map[string]bool, len(analysis.Missing))
+	additions := make([]string, 0, len(analysis.Missing))
+	for _, key := range analysis.Missing {
+		missing[key] = true
+		additions = append(additions, key+"="+analysis.Expansion[key])
+	}
+
+	lines := splitOnboardingAnswerLines(raw)
+	filtered := make([]string, 0, len(lines)+len(additions))
+	for _, line := range lines {
+		if key, ok := onboardingAnswerLineKey(line); ok && missing[key] {
+			continue
+		}
+		filtered = append(filtered, line)
+	}
+	return insertOnboardingAnswerLinesBeforeMutationConfirmation(filtered, additions)
+}
+
+func splitOnboardingAnswerLines(raw []byte) []string {
+	content := string(raw)
+	if content == "" {
+		return nil
+	}
+	content = strings.TrimSuffix(content, "\n")
+	return strings.Split(content, "\n")
+}
+
+func insertOnboardingAnswerLinesBeforeMutationConfirmation(lines []string, additions []string) string {
+	insertionIndex := len(lines)
+	foundMutationConfirmation := false
+	for index := len(lines) - 1; index >= 0; index-- {
+		line := strings.TrimSpace(lines[index])
+		if line == "" {
+			continue
+		}
+		if line == "MUTATION_CONFIRMED=true" {
+			insertionIndex = index
+			foundMutationConfirmation = true
+		}
+		break
+	}
+	if !foundMutationConfirmation {
+		for insertionIndex > 0 && strings.TrimSpace(lines[insertionIndex-1]) == "" {
+			insertionIndex--
+		}
+		lines = lines[:insertionIndex]
+	}
+
+	normalized := make([]string, 0, len(lines)+len(additions))
+	normalized = append(normalized, lines[:insertionIndex]...)
+	normalized = append(normalized, additions...)
+	normalized = append(normalized, lines[insertionIndex:]...)
+	for len(normalized) > 0 && strings.TrimSpace(normalized[len(normalized)-1]) == "" {
+		normalized = normalized[:len(normalized)-1]
+	}
+	return strings.Join(normalized, "\n") + "\n"
+}
+
 func normalizeOnboardingAnswersPhase(phase string) (string, error) {
 	switch strings.ToLower(strings.TrimSpace(phase)) {
 	case "", onboardingAnswersPhaseMutation:
@@ -900,7 +1066,7 @@ func validateOnboardingAnswers(answers onboardingAnswers, phase string, result *
 		return problems
 	}
 
-	problems = append(problems, validateOnboardingDeliveryProfileAnswers(answers, result)...)
+	problems = append(problems, validateOnboardingDeliveryProfileAnswers(answers, phase, result)...)
 
 	mode := answers.Values["GITHUB_MODE"]
 	switch mode {
@@ -915,33 +1081,52 @@ func validateOnboardingAnswers(answers onboardingAnswers, phase string, result *
 	return problems
 }
 
-func validateOnboardingDeliveryProfileAnswers(answers onboardingAnswers, result *onboardingAnswersValidationResult) []string {
-	profile := strings.TrimSpace(answers.Values["DELIVERY_PROFILE"])
-	if profile == "" {
-		return nil
-	}
-	settings, ok := onboardingprofile.DeliveryProfile(profile)
-	if !ok {
-		return []string{"DELIVERY_PROFILE must be conservative_review or autonomous_delivery"}
-	}
-	expansion, _ := onboardingprofile.DeliveryProfileAnswerExpansion(settings.ID)
-	summary, _ := onboardingprofile.SummarizeDeliveryProfile(settings.ID)
-	result.DeliveryProfile = settings.ID
-	result.DeliveryProfileAnswers = expansion
-	result.AnswersSummary = &summary
-
-	var problems []string
-	for _, key := range onboardingprofile.SortedDeliveryProfileAnswerKeys(expansion) {
-		existing := strings.TrimSpace(answers.Values[key])
-		if existing == "" {
-			answers.Values[key] = expansion[key]
-			continue
+func validateOnboardingDeliveryProfileAnswers(answers onboardingAnswers, phase string, result *onboardingAnswersValidationResult) []string {
+	analysis := analyzeOnboardingDeliveryProfileAnswers(answers)
+	if result != nil {
+		result.DeliveryProfile = analysis.Profile
+		result.DeliveryProfileAnswers = analysis.Expansion
+		if analysis.Profile != "" && len(analysis.Problems) == 0 {
+			summary, _ := onboardingprofile.SummarizeDeliveryProfile(analysis.Profile)
+			result.AnswersSummary = &summary
 		}
-		if existing != expansion[key] {
-			problems = append(problems, fmt.Sprintf("%s=%s conflicts with DELIVERY_PROFILE=%s, which expands %s=%s", key, existing, settings.ID, key, expansion[key]))
+	}
+	problems := append([]string(nil), analysis.Problems...)
+	if phase == onboardingAnswersPhaseMutation {
+		for _, key := range analysis.Missing {
+			problems = append(problems, fmt.Sprintf("%s is required when DELIVERY_PROFILE=%s; run detent onboarding normalize-answers --answers \"$ONBOARDING_DIR/answers.env\" --write before mutation validation", key, analysis.Profile))
 		}
 	}
 	return problems
+}
+
+func analyzeOnboardingDeliveryProfileAnswers(answers onboardingAnswers) onboardingDeliveryProfileAnswerAnalysis {
+	profile := strings.TrimSpace(answers.Values["DELIVERY_PROFILE"])
+	if profile == "" {
+		return onboardingDeliveryProfileAnswerAnalysis{}
+	}
+	settings, ok := onboardingprofile.DeliveryProfile(profile)
+	if !ok {
+		return onboardingDeliveryProfileAnswerAnalysis{
+			Problems: []string{"DELIVERY_PROFILE must be conservative_review or autonomous_delivery"},
+		}
+	}
+	expansion, _ := onboardingprofile.DeliveryProfileAnswerExpansion(settings.ID)
+	analysis := onboardingDeliveryProfileAnswerAnalysis{
+		Profile:   settings.ID,
+		Expansion: expansion,
+	}
+	for _, key := range onboardingprofile.SortedDeliveryProfileAnswerKeys(expansion) {
+		existing := strings.TrimSpace(answers.Values[key])
+		if existing == "" {
+			analysis.Missing = append(analysis.Missing, key)
+			continue
+		}
+		if existing != expansion[key] {
+			analysis.Problems = append(analysis.Problems, fmt.Sprintf("%s=%s conflicts with DELIVERY_PROFILE=%s, which expands %s=%s", key, existing, settings.ID, key, expansion[key]))
+		}
+	}
+	return analysis
 }
 
 func validateOnboardingIdentityAnswers(answers onboardingAnswers, result *onboardingAnswersValidationResult) []string {
@@ -1090,7 +1275,7 @@ func onboardingAnswersValidationHint(phase string) string {
 	case onboardingAnswersPhaseDecision:
 		return "Complete and validate the identity phase first, then ask the status-source question, record the explicit GITHUB_MODE answer in answers.env, and rerun the validator before discovery recommendations become selected answers."
 	default:
-		return "Complete and validate the identity and status-source answers, record the explicit mutation confirmation in answers.env, and rerun the validator before any mutation."
+		return `Complete and validate the identity and status-source answers, run detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write after selecting DELIVERY_PROFILE, record the explicit mutation confirmation in answers.env, and rerun the validator before any mutation.`
 	}
 }
 

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -898,6 +898,13 @@ func normalizeOnboardingAnswersFile(path string, write bool) (onboardingAnswersN
 			nil,
 		)
 	}
+	if len(analysis.Missing) > 0 && answers.Values["MUTATION_CONFIRMED"] == "true" {
+		return onboardingAnswersNormalizationResult{}, NewValidationError(
+			fmt.Sprintf("DELIVERY_PROFILE=%s is missing expanded answers (%s), but MUTATION_CONFIRMED=true is already present", analysis.Profile, strings.Join(analysis.Missing, ", ")),
+			`Remove MUTATION_CONFIRMED, rerun detent onboarding normalize-answers --answers "$ONBOARDING_DIR/answers.env" --write, show the updated answers.env to the operator, then record a fresh confirmation.`,
+			nil,
+		)
+	}
 	content := string(raw)
 	if len(analysis.Missing) > 0 {
 		content = buildOnboardingNormalizedAnswersContent(raw, analysis)

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -175,6 +175,36 @@ func TestOnboardingValidateAnswersCommandRequiresModeSpecificMutationAnswers(t *
 	}
 }
 
+func TestOnboardingValidateAnswersCommandRejectsMissingDeliveryProfileExpansionBeforeMutation(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=autonomous_delivery",
+		"STATUS_LABEL_PREFIX=detent:",
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "validate-answers", "--answers", answersPath})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want missing delivery profile expansion validation error")
+	}
+	for _, want := range []string{
+		"AUTO_PROMOTE_ENABLED is required when DELIVERY_PROFILE=autonomous_delivery",
+		"KANBAN_MODE is required when DELIVERY_PROFILE=autonomous_delivery",
+		"detent onboarding normalize-answers --answers",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Execute() error missing %q:\n%s", want, err.Error())
+		}
+	}
+}
+
 func TestOnboardingValidateAnswersCommandAcceptsDecisionPhase(t *testing.T) {
 	t.Parallel()
 
@@ -240,9 +270,17 @@ func TestOnboardingValidateAnswersCommandAcceptsLabelMode(t *testing.T) {
 func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *testing.T) {
 	t.Parallel()
 
+	profileAnswers := autonomousDeliveryProfileAnswers()
 	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
 		"DELIVERY_PROFILE=autonomous_delivery",
+		"KANBAN_MODE=" + profileAnswers["KANBAN_MODE"],
+		"AUTO_PROMOTE_ENABLED=" + profileAnswers["AUTO_PROMOTE_ENABLED"],
+		"AUTO_PROMOTE_QUIET_SECONDS=" + profileAnswers["AUTO_PROMOTE_QUIET_SECONDS"],
+		"GATE_REQUIRE_AUTOMATED_REVIEW=" + profileAnswers["GATE_REQUIRE_AUTOMATED_REVIEW"],
+		"AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW=" + profileAnswers["AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW"],
+		"DEPENDENCY_AUTO_UNBLOCK_ENABLED=" + profileAnswers["DEPENDENCY_AUTO_UNBLOCK_ENABLED"],
+		"MERGING_CONCURRENCY=" + profileAnswers["MERGING_CONCURRENCY"],
 		"STATUS_LABEL_PREFIX=detent:",
 		"MUTATION_CONFIRMED=true",
 		"",
@@ -278,16 +316,7 @@ func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *tes
 	if got.DeliveryProfile != "autonomous_delivery" {
 		t.Fatalf("DeliveryProfile = %q, want autonomous_delivery", got.DeliveryProfile)
 	}
-	want := map[string]string{
-		"KANBAN_MODE":                           "integration",
-		"AUTO_PROMOTE_ENABLED":                  "true",
-		"AUTO_PROMOTE_QUIET_SECONDS":            "0",
-		"GATE_REQUIRE_AUTOMATED_REVIEW":         "false",
-		"AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW": "false",
-		"DEPENDENCY_AUTO_UNBLOCK_ENABLED":       "true",
-		"MERGING_CONCURRENCY":                   "1",
-	}
-	for key, value := range want {
+	for key, value := range profileAnswers {
 		if got.DeliveryProfileAnswers[key] != value {
 			t.Fatalf("DeliveryProfileAnswers[%q] = %q, want %q; all answers = %#v", key, got.DeliveryProfileAnswers[key], value, got.DeliveryProfileAnswers)
 		}
@@ -430,6 +459,93 @@ func TestOnboardingValidateAnswersCommandSummarizesConservativeReviewProfile(t *
 		if !containsString(summaryValues, want) {
 			t.Fatalf("AnswersSummary missing %q: %#v", want, summary)
 		}
+	}
+}
+
+func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansion(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=autonomous_delivery",
+		"STATUS_LABEL_PREFIX=detent:",
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "onboarding", "normalize-answers", "--answers", answersPath, "--write"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout:\n%s", err, stdout.String())
+	}
+
+	var got struct {
+		Status            string `json:"status"`
+		Path              string `json:"path"`
+		Written           bool   `json:"written"`
+		Changed           bool   `json:"changed"`
+		DeliveryProfile   string `json:"delivery_profile"`
+		MutationConfirmed bool   `json:"mutation_confirmed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if got.Status != "ok" || got.Path != answersPath || !got.Written || !got.Changed || got.DeliveryProfile != "autonomous_delivery" || !got.MutationConfirmed {
+		t.Fatalf("normalization result = %#v, want written autonomous profile normalization", got)
+	}
+
+	raw, err := os.ReadFile(answersPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(raw)
+	for key, value := range autonomousDeliveryProfileAnswers() {
+		want := key + "=" + value
+		if !strings.Contains(content, want) {
+			t.Fatalf("answers.env missing %q:\n%s", want, content)
+		}
+	}
+	if last := lastNonblankOnboardingLine(content); last != "MUTATION_CONFIRMED=true" {
+		t.Fatalf("last nonblank line = %q, want MUTATION_CONFIRMED=true\n%s", last, content)
+	}
+	if strings.Index(content, "MERGING_CONCURRENCY=1") > strings.Index(content, "MUTATION_CONFIRMED=true") {
+		t.Fatalf("profile expansion was written after final mutation confirmation:\n%s", content)
+	}
+}
+
+func TestOnboardingNormalizeAnswersCommandRejectsDeliveryProfileExpansionConflict(t *testing.T) {
+	t.Parallel()
+
+	content := validIdentityOnboardingAnswers(t) + strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=autonomous_delivery",
+		"KANBAN_MODE=read_only",
+		"STATUS_LABEL_PREFIX=detent:",
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n")
+	answersPath := writeOnboardingAnswers(t, content)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "normalize-answers", "--answers", answersPath, "--write"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want delivery profile expansion conflict")
+	}
+	if !strings.Contains(err.Error(), "KANBAN_MODE=read_only conflicts with DELIVERY_PROFILE=autonomous_delivery, which expands KANBAN_MODE=integration") {
+		t.Fatalf("Execute() error missing profile conflict:\n%s", err.Error())
+	}
+	raw, readErr := os.ReadFile(answersPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(raw) != content {
+		t.Fatalf("answers.env changed after conflict:\n%s", string(raw))
 	}
 }
 
@@ -1000,6 +1116,28 @@ func writeOnboardingAnswers(t *testing.T, content string) string {
 		t.Fatalf("WriteFile() error = %v", err)
 	}
 	return path
+}
+
+func autonomousDeliveryProfileAnswers() map[string]string {
+	return map[string]string{
+		"KANBAN_MODE":                           "integration",
+		"AUTO_PROMOTE_ENABLED":                  "true",
+		"AUTO_PROMOTE_QUIET_SECONDS":            "0",
+		"GATE_REQUIRE_AUTOMATED_REVIEW":         "false",
+		"AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW": "false",
+		"DEPENDENCY_AUTO_UNBLOCK_ENABLED":       "true",
+		"MERGING_CONCURRENCY":                   "1",
+	}
+}
+
+func lastNonblankOnboardingLine(content string) string {
+	last := ""
+	for _, line := range strings.Split(content, "\n") {
+		if strings.TrimSpace(line) != "" {
+			last = strings.TrimSpace(line)
+		}
+	}
+	return last
 }
 
 func initOnboardingGitRepository(t *testing.T, remote string) string {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -469,7 +469,6 @@ func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansi
 		"GITHUB_MODE=label",
 		"DELIVERY_PROFILE=autonomous_delivery",
 		"STATUS_LABEL_PREFIX=detent:",
-		"MUTATION_CONFIRMED=true",
 		"",
 	}, "\n"))
 	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
@@ -493,7 +492,7 @@ func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansi
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
 	}
-	if got.Status != "ok" || got.Path != answersPath || !got.Written || !got.Changed || got.DeliveryProfile != "autonomous_delivery" || !got.MutationConfirmed {
+	if got.Status != "ok" || got.Path != answersPath || !got.Written || !got.Changed || got.DeliveryProfile != "autonomous_delivery" || got.MutationConfirmed {
 		t.Fatalf("normalization result = %#v, want written autonomous profile normalization", got)
 	}
 
@@ -508,11 +507,98 @@ func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansi
 			t.Fatalf("answers.env missing %q:\n%s", want, content)
 		}
 	}
+	if strings.Contains(content, "MUTATION_CONFIRMED=true") {
+		t.Fatalf("normalization must not add mutation confirmation:\n%s", content)
+	}
+}
+
+func TestOnboardingNormalizeAnswersCommandPreservesFinalMutationConfirmationWhenAlreadyCanonical(t *testing.T) {
+	t.Parallel()
+
+	profileAnswers := autonomousDeliveryProfileAnswers()
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=autonomous_delivery",
+		"KANBAN_MODE=" + profileAnswers["KANBAN_MODE"],
+		"AUTO_PROMOTE_ENABLED=" + profileAnswers["AUTO_PROMOTE_ENABLED"],
+		"AUTO_PROMOTE_QUIET_SECONDS=" + profileAnswers["AUTO_PROMOTE_QUIET_SECONDS"],
+		"GATE_REQUIRE_AUTOMATED_REVIEW=" + profileAnswers["GATE_REQUIRE_AUTOMATED_REVIEW"],
+		"AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW=" + profileAnswers["AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW"],
+		"DEPENDENCY_AUTO_UNBLOCK_ENABLED=" + profileAnswers["DEPENDENCY_AUTO_UNBLOCK_ENABLED"],
+		"MERGING_CONCURRENCY=" + profileAnswers["MERGING_CONCURRENCY"],
+		"STATUS_LABEL_PREFIX=detent:",
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "onboarding", "normalize-answers", "--answers", answersPath, "--write"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v\nstdout:\n%s", err, stdout.String())
+	}
+
+	var got struct {
+		Written           bool `json:"written"`
+		Changed           bool `json:"changed"`
+		MutationConfirmed bool `json:"mutation_confirmed"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	if !got.Written || got.Changed || !got.MutationConfirmed {
+		t.Fatalf("normalization result = %#v, want no-op write with final confirmation preserved", got)
+	}
+	raw, err := os.ReadFile(answersPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	content := string(raw)
 	if last := lastNonblankOnboardingLine(content); last != "MUTATION_CONFIRMED=true" {
 		t.Fatalf("last nonblank line = %q, want MUTATION_CONFIRMED=true\n%s", last, content)
 	}
 	if strings.Index(content, "MERGING_CONCURRENCY=1") > strings.Index(content, "MUTATION_CONFIRMED=true") {
 		t.Fatalf("profile expansion was written after final mutation confirmation:\n%s", content)
+	}
+}
+
+func TestOnboardingNormalizeAnswersCommandRejectsStaleMutationConfirmation(t *testing.T) {
+	t.Parallel()
+
+	content := validIdentityOnboardingAnswers(t) + strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=autonomous_delivery",
+		"STATUS_LABEL_PREFIX=detent:",
+		"MUTATION_CONFIRMED=true",
+		"",
+	}, "\n")
+	answersPath := writeOnboardingAnswers(t, content)
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"onboarding", "normalize-answers", "--answers", answersPath, "--write"})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want stale mutation confirmation validation error")
+	}
+	for _, want := range []string{
+		"MUTATION_CONFIRMED=true is already present",
+		"rerun detent onboarding normalize-answers",
+		"record a fresh confirmation",
+	} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("Execute() error missing %q:\n%s", want, err.Error())
+		}
+	}
+	raw, readErr := os.ReadFile(answersPath)
+	if readErr != nil {
+		t.Fatalf("ReadFile() error = %v", readErr)
+	}
+	if string(raw) != content {
+		t.Fatalf("answers.env changed after stale confirmation error:\n%s", string(raw))
 	}
 }
 


### PR DESCRIPTION
## Summary

- add `detent onboarding normalize-answers --answers ... --write` to materialize delivery profile expansion keys in `answers.env`
- reject mutation validation when `DELIVERY_PROFILE` expansion keys are missing from the approved answer file
- update onboarding docs and tests for canonicalization, final-line preservation, and conflict handling

Fixes #676

## Test Plan

- [x] `go test ./internal/cli`
- [x] `go test ./internal/onboarding`
- [x] `make check`