### PR TITLE
feat(onboarding): explain answer behavior

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1146,11 +1146,18 @@ operator asks for an advanced override.
 
 Stop here before Phase 3 or any other command that can create, link, mutate, or
 delete GitHub Projects, issue fields, labels, issues, PRs, `WORKFLOW.md`, or
-`global.yaml`. Show the operator `$ONBOARDING_DIR/recommendations.md` and the
-complete `$ONBOARDING_DIR/answers.env`, then ask: "May I execute the selected
-mutation steps using these exact answers?" Defaults from Phase 2 are still only
-recommendations; an unanswered default must not authorize any external or local
-config mutation.
+`global.yaml`. Show the operator `$ONBOARDING_DIR/recommendations.md`, the
+plain-English behavior summary, and the complete `$ONBOARDING_DIR/answers.env`,
+then ask: "May I execute the selected mutation steps using these exact
+answers?" Defaults from Phase 2 are still only recommendations; an unanswered
+default must not authorize any external or local config mutation.
+
+```sh
+detent --format pretty onboarding explain-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision
+```
+
+Show this summary before the canonical `answers.env` keys so the operator
+approves the effective behavior, not only raw fields.
 
 Record the explicit confirmation only after the operator says yes. This removes
 stale confirmations first and appends the new confirmation as the final

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -35,20 +35,21 @@ var (
 )
 
 type onboardingAnswersValidationResult struct {
-	Status                 string            `json:"status"`
-	Path                   string            `json:"path"`
-	Phase                  string            `json:"phase"`
-	CustomerID             string            `json:"customer_id"`
-	DetentProjectID        string            `json:"detent_project_id"`
-	TargetRepository       string            `json:"target_repository"`
-	TargetSourceRoot       string            `json:"target_source_root"`
-	ReferenceRepositories  []string          `json:"reference_repositories"`
-	DetentOnboardingMode   string            `json:"detent_onboarding_mode"`
-	IdentityConfirmed      bool              `json:"identity_confirmed"`
-	GitHubMode             string            `json:"github_mode"`
-	DeliveryProfile        string            `json:"delivery_profile,omitempty"`
-	DeliveryProfileAnswers map[string]string `json:"delivery_profile_answers,omitempty"`
-	MutationConfirmed      bool              `json:"mutation_confirmed"`
+	Status                 string                                    `json:"status"`
+	Path                   string                                    `json:"path"`
+	Phase                  string                                    `json:"phase"`
+	CustomerID             string                                    `json:"customer_id"`
+	DetentProjectID        string                                    `json:"detent_project_id"`
+	TargetRepository       string                                    `json:"target_repository"`
+	TargetSourceRoot       string                                    `json:"target_source_root"`
+	ReferenceRepositories  []string                                  `json:"reference_repositories"`
+	DetentOnboardingMode   string                                    `json:"detent_onboarding_mode"`
+	IdentityConfirmed      bool                                      `json:"identity_confirmed"`
+	GitHubMode             string                                    `json:"github_mode"`
+	DeliveryProfile        string                                    `json:"delivery_profile,omitempty"`
+	DeliveryProfileAnswers map[string]string                         `json:"delivery_profile_answers,omitempty"`
+	AnswersSummary         *onboardingprofile.DeliveryProfileSummary `json:"answers_summary,omitempty"`
+	MutationConfirmed      bool                                      `json:"mutation_confirmed"`
 }
 
 type onboardingDraftAnswersResult struct {
@@ -108,6 +109,7 @@ func newOnboardingCommand(configPath *string, opts options) *cobra.Command {
 	}
 	cmd.AddCommand(
 		newOnboardingValidateAnswersCommand(),
+		newOnboardingExplainAnswersCommand(),
 		newOnboardingDraftAnswersCommand(configPath, opts),
 		newOnboardingDiagnoseGateCommand(),
 	)
@@ -176,6 +178,41 @@ func newOnboardingDraftAnswersCommand(configPath *string, opts options) *cobra.C
 	return cmd
 }
 
+func newOnboardingExplainAnswersCommand() *cobra.Command {
+	var answersPath string
+	var phase string
+	cmd := &cobra.Command{
+		Use:          "explain-answers",
+		Short:        "Explain onboarding answers as operational behavior",
+		Example:      `detent onboarding explain-answers --answers "$ONBOARDING_DIR/answers.env"`,
+		Args:         NoArgs,
+		SilenceUsage: true,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			result, err := validateOnboardingAnswersFile(answersPath, phase)
+			if err != nil {
+				return err
+			}
+			if result.AnswersSummary == nil {
+				return NewValidationError(
+					"DELIVERY_PROFILE is required to explain onboarding answers",
+					"Record DELIVERY_PROFILE=conservative_review or DELIVERY_PROFILE=autonomous_delivery in answers.env, then rerun explain-answers.",
+					nil,
+				)
+			}
+			return out.Write(func(w io.Writer) error {
+				return writeOnboardingAnswersExplanationPretty(w, result)
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
+	cmd.Flags().StringVar(&phase, "phase", onboardingAnswersPhaseDecision, "validation phase: identity, decision, or mutation")
+	return cmd
+}
+
 func newOnboardingValidateAnswersCommand() *cobra.Command {
 	var answersPath string
 	var phase string
@@ -203,6 +240,41 @@ func newOnboardingValidateAnswersCommand() *cobra.Command {
 	cmd.Flags().StringVar(&answersPath, "answers", "answers.env", "path to onboarding answers.env")
 	cmd.Flags().StringVar(&phase, "phase", onboardingAnswersPhaseMutation, "validation phase: identity, decision, or mutation")
 	return cmd
+}
+
+func writeOnboardingAnswersExplanationPretty(w io.Writer, result onboardingAnswersValidationResult) error {
+	summary := result.AnswersSummary
+	if summary == nil {
+		return NewValidationError(
+			"DELIVERY_PROFILE is required to explain onboarding answers",
+			"Record DELIVERY_PROFILE=conservative_review or DELIVERY_PROFILE=autonomous_delivery in answers.env, then rerun explain-answers.",
+			nil,
+		)
+	}
+	lines := []string{
+		"Onboarding answer behavior summary:",
+		fmt.Sprintf("- Effective delivery profile: %s (`%s`).", summary.EffectiveDeliveryProfileLabel, summary.EffectiveDeliveryProfile),
+		fmt.Sprintf("- Kanban mode: `%s`. %s", summary.KanbanMode, summary.KanbanBehavior),
+		"- Gate behavior: " + summary.GateBehavior,
+		"- Auto-promotion: " + summary.AutoPromotionBehavior,
+		"- Quiet window: " + summary.QuietWindowBehavior,
+		"- Dependency auto-unblock: " + summary.DependencyAutoUnblockBehavior,
+		fmt.Sprintf("- Merge concurrency: `%d`. %s", summary.MergingConcurrency, summary.MergeConcurrencyBehavior),
+		"- Stop conditions: " + summary.StopBehavior,
+		"",
+		"Canonical delivery answer keys:",
+	}
+	lines = append(lines, canonicalOnboardingDeliveryAnswerLines(result)...)
+	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))
+	return err
+}
+
+func canonicalOnboardingDeliveryAnswerLines(result onboardingAnswersValidationResult) []string {
+	lines := []string{"DELIVERY_PROFILE=" + result.DeliveryProfile}
+	for _, key := range onboardingprofile.SortedDeliveryProfileAnswerKeys(result.DeliveryProfileAnswers) {
+		lines = append(lines, key+"="+result.DeliveryProfileAnswers[key])
+	}
+	return lines
 }
 
 func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfig) (onboardingDraftAnswersResult, error) {
@@ -853,8 +925,10 @@ func validateOnboardingDeliveryProfileAnswers(answers onboardingAnswers, result 
 		return []string{"DELIVERY_PROFILE must be conservative_review or autonomous_delivery"}
 	}
 	expansion, _ := onboardingprofile.DeliveryProfileAnswerExpansion(settings.ID)
+	summary, _ := onboardingprofile.SummarizeDeliveryProfile(settings.ID)
 	result.DeliveryProfile = settings.ID
 	result.DeliveryProfileAnswers = expansion
+	result.AnswersSummary = &summary
 
 	var problems []string
 	for _, key := range onboardingprofile.SortedDeliveryProfileAnswerKeys(expansion) {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -260,6 +260,17 @@ func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *tes
 	var got struct {
 		DeliveryProfile        string            `json:"delivery_profile"`
 		DeliveryProfileAnswers map[string]string `json:"delivery_profile_answers"`
+		AnswersSummary         struct {
+			EffectiveDeliveryProfile      string   `json:"effective_delivery_profile"`
+			EffectiveDeliveryProfileLabel string   `json:"effective_delivery_profile_label"`
+			KanbanMode                    string   `json:"kanban_mode"`
+			GateBehavior                  string   `json:"gate_behavior"`
+			AutoPromotionBehavior         string   `json:"auto_promotion_behavior"`
+			QuietWindowBehavior           string   `json:"quiet_window_behavior"`
+			DependencyAutoUnblockBehavior string   `json:"dependency_auto_unblock_behavior"`
+			MergeConcurrencyBehavior      string   `json:"merge_concurrency_behavior"`
+			StopConditions                []string `json:"stop_conditions"`
+		} `json:"answers_summary"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
@@ -279,6 +290,145 @@ func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *tes
 	for key, value := range want {
 		if got.DeliveryProfileAnswers[key] != value {
 			t.Fatalf("DeliveryProfileAnswers[%q] = %q, want %q; all answers = %#v", key, got.DeliveryProfileAnswers[key], value, got.DeliveryProfileAnswers)
+		}
+	}
+	if got.AnswersSummary.EffectiveDeliveryProfile != "autonomous_delivery" ||
+		got.AnswersSummary.EffectiveDeliveryProfileLabel != "Autonomous delivery mode" ||
+		got.AnswersSummary.KanbanMode != "integration" {
+		t.Fatalf("AnswersSummary identity = %#v, want autonomous delivery integration summary", got.AnswersSummary)
+	}
+	summaryValues := []string{
+		got.AnswersSummary.GateBehavior,
+		got.AnswersSummary.AutoPromotionBehavior,
+		got.AnswersSummary.QuietWindowBehavior,
+		got.AnswersSummary.DependencyAutoUnblockBehavior,
+		got.AnswersSummary.MergeConcurrencyBehavior,
+	}
+	for _, want := range []string{
+		"No automated GitHub PR review is required when the command gate is passing and the workflow says so.",
+		"Detent may promote from `Human Review` to `Merging` automatically when the linked PR, local gate, and CI requirements pass.",
+		"There is no quiet-window delay before promotion.",
+		"Dependency-waiting `Blocked` issues can move back to `Todo` when declared blockers are terminal or merged.",
+		"`Merging` remains serialized for this project.",
+	} {
+		if !containsString(summaryValues, want) {
+			t.Fatalf("AnswersSummary missing %q: %#v", want, got.AnswersSummary)
+		}
+	}
+	if !containsString(got.AnswersSummary.StopConditions, "gate failures") {
+		t.Fatalf("StopConditions = %#v, want gate failures", got.AnswersSummary.StopConditions)
+	}
+}
+
+func TestOnboardingExplainAnswersCommandSummarizesAutonomousDelivery(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=autonomous_delivery",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "pretty", "onboarding", "explain-answers", "--answers", answersPath})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	output := stdout.String()
+	summaryIndex := strings.Index(output, "Onboarding answer behavior summary:")
+	canonicalIndex := strings.Index(output, "Canonical delivery answer keys:")
+	if summaryIndex < 0 || canonicalIndex < 0 {
+		t.Fatalf("output missing summary or canonical keys:\n%s", output)
+	}
+	if summaryIndex > canonicalIndex {
+		t.Fatalf("summary appears after canonical keys:\n%s", output)
+	}
+	for _, want := range []string{
+		"Effective delivery profile: Autonomous delivery mode (`autonomous_delivery`).",
+		"No automated GitHub PR review is required when the command gate is passing and the workflow says so.",
+		"Detent may promote from `Human Review` to `Merging` automatically when the linked PR, local gate, and CI requirements pass.",
+		"There is no quiet-window delay before promotion.",
+		"Dependency-waiting `Blocked` issues can move back to `Todo` when declared blockers are terminal or merged.",
+		"`Merging` remains serialized for this project.",
+		"Existing validation, CI, unresolved review feedback, dependency blockers, mergeability, and gate failures still stop progress.",
+		"DELIVERY_PROFILE=autonomous_delivery",
+		"AUTO_PROMOTE_QUIET_SECONDS=0",
+		"GATE_REQUIRE_AUTOMATED_REVIEW=false",
+		"MERGING_CONCURRENCY=1",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("output missing %q:\n%s", want, output)
+		}
+	}
+}
+
+func TestOnboardingValidateAnswersCommandSummarizesConservativeReviewProfile(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=conservative_review",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "onboarding", "validate-answers", "--answers", answersPath, "--phase", "decision"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		AnswersSummary struct {
+			EffectiveDeliveryProfile      string `json:"effective_delivery_profile"`
+			EffectiveDeliveryProfileLabel string `json:"effective_delivery_profile_label"`
+			KanbanMode                    string `json:"kanban_mode"`
+			GateRequiresAutomatedReview   bool   `json:"gate_requires_automated_review"`
+			GateBehavior                  string `json:"gate_behavior"`
+			AutoPromoteEnabled            bool   `json:"auto_promote_enabled"`
+			AutoPromoteQuietSeconds       int    `json:"auto_promote_quiet_seconds"`
+			AutoPromotionBehavior         string `json:"auto_promotion_behavior"`
+			QuietWindowBehavior           string `json:"quiet_window_behavior"`
+			DependencyAutoUnblockEnabled  bool   `json:"dependency_auto_unblock_enabled"`
+			DependencyAutoUnblockBehavior string `json:"dependency_auto_unblock_behavior"`
+			MergeConcurrencyBehavior      string `json:"merge_concurrency_behavior"`
+		} `json:"answers_summary"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	summary := got.AnswersSummary
+	if summary.EffectiveDeliveryProfile != "conservative_review" ||
+		summary.EffectiveDeliveryProfileLabel != "Conservative review mode" ||
+		summary.KanbanMode != "read_only" ||
+		!summary.GateRequiresAutomatedReview ||
+		summary.AutoPromoteEnabled ||
+		summary.AutoPromoteQuietSeconds != 600 ||
+		summary.DependencyAutoUnblockEnabled {
+		t.Fatalf("AnswersSummary = %#v, want conservative review defaults", summary)
+	}
+	summaryValues := []string{
+		summary.GateBehavior,
+		summary.AutoPromotionBehavior,
+		summary.QuietWindowBehavior,
+		summary.DependencyAutoUnblockBehavior,
+		summary.MergeConcurrencyBehavior,
+	}
+	for _, want := range []string{
+		"Automated GitHub PR review is required before the command gate and promotion checks can pass.",
+		"Detent will not promote from `Human Review` to `Merging` automatically; a human must move approved work forward.",
+		"Auto-promotion is disabled; the 600-second quiet window only matters if auto-promotion is enabled later.",
+		"Dependency-waiting `Blocked` issues remain `Blocked` until a human or workflow moves them.",
+		"`Merging` remains serialized for this project.",
+	} {
+		if !containsString(summaryValues, want) {
+			t.Fatalf("AnswersSummary missing %q: %#v", want, summary)
 		}
 	}
 }

--- a/internal/onboarding/profile.go
+++ b/internal/onboarding/profile.go
@@ -1,6 +1,7 @@
 package onboarding
 
 import (
+	"fmt"
 	"sort"
 	"strconv"
 	"strings"
@@ -20,6 +21,25 @@ type DeliveryProfileSettings struct {
 	GateRequireAutomatedReview   bool
 	DependencyAutoUnblockEnabled bool
 	MergingConcurrency           int
+}
+
+type DeliveryProfileSummary struct {
+	EffectiveDeliveryProfile      string   `json:"effective_delivery_profile"`
+	EffectiveDeliveryProfileLabel string   `json:"effective_delivery_profile_label"`
+	KanbanMode                    string   `json:"kanban_mode"`
+	KanbanBehavior                string   `json:"kanban_behavior"`
+	GateRequiresAutomatedReview   bool     `json:"gate_requires_automated_review"`
+	GateBehavior                  string   `json:"gate_behavior"`
+	AutoPromoteEnabled            bool     `json:"auto_promote_enabled"`
+	AutoPromoteQuietSeconds       int      `json:"auto_promote_quiet_seconds"`
+	AutoPromotionBehavior         string   `json:"auto_promotion_behavior"`
+	QuietWindowBehavior           string   `json:"quiet_window_behavior"`
+	DependencyAutoUnblockEnabled  bool     `json:"dependency_auto_unblock_enabled"`
+	DependencyAutoUnblockBehavior string   `json:"dependency_auto_unblock_behavior"`
+	MergingConcurrency            int      `json:"merging_concurrency"`
+	MergeConcurrencyBehavior      string   `json:"merge_concurrency_behavior"`
+	StopBehavior                  string   `json:"stop_behavior"`
+	StopConditions                []string `json:"stop_conditions"`
 }
 
 func NormalizeDeliveryProfile(value string) string {
@@ -62,6 +82,38 @@ func DeliveryProfile(value string) (DeliveryProfileSettings, bool) {
 	}
 }
 
+func SummarizeDeliveryProfile(value string) (DeliveryProfileSummary, bool) {
+	settings, ok := DeliveryProfile(value)
+	if !ok {
+		return DeliveryProfileSummary{}, false
+	}
+	return DeliveryProfileSummary{
+		EffectiveDeliveryProfile:      settings.ID,
+		EffectiveDeliveryProfileLabel: settings.Label,
+		KanbanMode:                    settings.KanbanMode,
+		KanbanBehavior:                kanbanBehavior(settings),
+		GateRequiresAutomatedReview:   settings.GateRequireAutomatedReview,
+		GateBehavior:                  gateBehavior(settings),
+		AutoPromoteEnabled:            settings.AutoPromoteEnabled,
+		AutoPromoteQuietSeconds:       settings.AutoPromoteQuietSeconds,
+		AutoPromotionBehavior:         autoPromotionBehavior(settings),
+		QuietWindowBehavior:           quietWindowBehavior(settings),
+		DependencyAutoUnblockEnabled:  settings.DependencyAutoUnblockEnabled,
+		DependencyAutoUnblockBehavior: dependencyAutoUnblockBehavior(settings),
+		MergingConcurrency:            settings.MergingConcurrency,
+		MergeConcurrencyBehavior:      mergeConcurrencyBehavior(settings),
+		StopBehavior:                  "Existing validation, CI, unresolved review feedback, dependency blockers, mergeability, and gate failures still stop progress.",
+		StopConditions: []string{
+			"validation failures",
+			"CI failures",
+			"unresolved review feedback",
+			"dependency blockers",
+			"mergeability problems",
+			"gate failures",
+		},
+	}, true
+}
+
 func DeliveryProfileAnswerExpansion(value string) (map[string]string, bool) {
 	settings, ok := DeliveryProfile(value)
 	if !ok {
@@ -85,4 +137,53 @@ func SortedDeliveryProfileAnswerKeys(answers map[string]string) []string {
 	}
 	sort.Strings(keys)
 	return keys
+}
+
+func kanbanBehavior(settings DeliveryProfileSettings) string {
+	switch settings.KanbanMode {
+	case "integration":
+		return "Detent can move issues through the configured workflow states instead of only observing them."
+	case "read_only":
+		return "Detent reads workflow status without mutating Kanban state."
+	default:
+		return fmt.Sprintf("Detent uses Kanban mode %q.", settings.KanbanMode)
+	}
+}
+
+func gateBehavior(settings DeliveryProfileSettings) string {
+	if settings.GateRequireAutomatedReview {
+		return "Automated GitHub PR review is required before the command gate and promotion checks can pass."
+	}
+	return "No automated GitHub PR review is required when the command gate is passing and the workflow says so."
+}
+
+func autoPromotionBehavior(settings DeliveryProfileSettings) string {
+	if settings.AutoPromoteEnabled {
+		return "Detent may promote from `Human Review` to `Merging` automatically when the linked PR, local gate, and CI requirements pass."
+	}
+	return "Detent will not promote from `Human Review` to `Merging` automatically; a human must move approved work forward."
+}
+
+func quietWindowBehavior(settings DeliveryProfileSettings) string {
+	if settings.AutoPromoteEnabled && settings.AutoPromoteQuietSeconds == 0 {
+		return "There is no quiet-window delay before promotion."
+	}
+	if settings.AutoPromoteEnabled {
+		return fmt.Sprintf("Detent waits %d seconds of quiet time before promotion after readiness checks pass.", settings.AutoPromoteQuietSeconds)
+	}
+	return fmt.Sprintf("Auto-promotion is disabled; the %d-second quiet window only matters if auto-promotion is enabled later.", settings.AutoPromoteQuietSeconds)
+}
+
+func dependencyAutoUnblockBehavior(settings DeliveryProfileSettings) string {
+	if settings.DependencyAutoUnblockEnabled {
+		return "Dependency-waiting `Blocked` issues can move back to `Todo` when declared blockers are terminal or merged."
+	}
+	return "Dependency-waiting `Blocked` issues remain `Blocked` until a human or workflow moves them."
+}
+
+func mergeConcurrencyBehavior(settings DeliveryProfileSettings) string {
+	if settings.MergingConcurrency == 1 {
+		return "`Merging` remains serialized for this project."
+	}
+	return fmt.Sprintf("Up to %d issues can be in `Merging` concurrently for this project.", settings.MergingConcurrency)
 }

--- a/internal/onboarding/profile_test.go
+++ b/internal/onboarding/profile_test.go
@@ -62,3 +62,89 @@ func TestDeliveryProfileRejectsUnknown(t *testing.T) {
 		t.Fatal("DeliveryProfileAnswerExpansion(manual) ok = true, want false")
 	}
 }
+
+func TestSummarizeDeliveryProfile(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                        string
+		profile                     string
+		wantEffectiveProfile        string
+		wantKanbanMode              string
+		wantGateRequiresReview      bool
+		wantAutoPromoteEnabled      bool
+		wantQuietWindow             string
+		wantDependencyAutoUnblock   bool
+		wantDependencyBehavior      string
+		wantMergeConcurrency        int
+		wantMergeConcurrencySummary string
+	}{
+		{
+			name:                        "autonomous delivery",
+			profile:                     "autonomous_delivery",
+			wantEffectiveProfile:        "autonomous_delivery",
+			wantKanbanMode:              "integration",
+			wantGateRequiresReview:      false,
+			wantAutoPromoteEnabled:      true,
+			wantQuietWindow:             "There is no quiet-window delay before promotion.",
+			wantDependencyAutoUnblock:   true,
+			wantDependencyBehavior:      "Dependency-waiting `Blocked` issues can move back to `Todo` when declared blockers are terminal or merged.",
+			wantMergeConcurrency:        1,
+			wantMergeConcurrencySummary: "`Merging` remains serialized for this project.",
+		},
+		{
+			name:                        "conservative review",
+			profile:                     "conservative_review",
+			wantEffectiveProfile:        "conservative_review",
+			wantKanbanMode:              "read_only",
+			wantGateRequiresReview:      true,
+			wantAutoPromoteEnabled:      false,
+			wantQuietWindow:             "Auto-promotion is disabled; the 600-second quiet window only matters if auto-promotion is enabled later.",
+			wantDependencyAutoUnblock:   false,
+			wantDependencyBehavior:      "Dependency-waiting `Blocked` issues remain `Blocked` until a human or workflow moves them.",
+			wantMergeConcurrency:        1,
+			wantMergeConcurrencySummary: "`Merging` remains serialized for this project.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := SummarizeDeliveryProfile(tt.profile)
+			if !ok {
+				t.Fatalf("SummarizeDeliveryProfile(%q) ok = false, want true", tt.profile)
+			}
+			if got.EffectiveDeliveryProfile != tt.wantEffectiveProfile {
+				t.Fatalf("EffectiveDeliveryProfile = %q, want %q", got.EffectiveDeliveryProfile, tt.wantEffectiveProfile)
+			}
+			if got.KanbanMode != tt.wantKanbanMode {
+				t.Fatalf("KanbanMode = %q, want %q", got.KanbanMode, tt.wantKanbanMode)
+			}
+			if got.GateRequiresAutomatedReview != tt.wantGateRequiresReview {
+				t.Fatalf("GateRequiresAutomatedReview = %t, want %t", got.GateRequiresAutomatedReview, tt.wantGateRequiresReview)
+			}
+			if got.AutoPromoteEnabled != tt.wantAutoPromoteEnabled {
+				t.Fatalf("AutoPromoteEnabled = %t, want %t", got.AutoPromoteEnabled, tt.wantAutoPromoteEnabled)
+			}
+			if got.QuietWindowBehavior != tt.wantQuietWindow {
+				t.Fatalf("QuietWindowBehavior = %q, want %q", got.QuietWindowBehavior, tt.wantQuietWindow)
+			}
+			if got.DependencyAutoUnblockEnabled != tt.wantDependencyAutoUnblock {
+				t.Fatalf("DependencyAutoUnblockEnabled = %t, want %t", got.DependencyAutoUnblockEnabled, tt.wantDependencyAutoUnblock)
+			}
+			if got.DependencyAutoUnblockBehavior != tt.wantDependencyBehavior {
+				t.Fatalf("DependencyAutoUnblockBehavior = %q, want %q", got.DependencyAutoUnblockBehavior, tt.wantDependencyBehavior)
+			}
+			if got.MergingConcurrency != tt.wantMergeConcurrency {
+				t.Fatalf("MergingConcurrency = %d, want %d", got.MergingConcurrency, tt.wantMergeConcurrency)
+			}
+			if got.MergeConcurrencyBehavior != tt.wantMergeConcurrencySummary {
+				t.Fatalf("MergeConcurrencyBehavior = %q, want %q", got.MergeConcurrencyBehavior, tt.wantMergeConcurrencySummary)
+			}
+			if len(got.StopConditions) == 0 || got.StopBehavior == "" {
+				t.Fatalf("stop summary = conditions %#v behavior %q, want populated stop behavior", got.StopConditions, got.StopBehavior)
+			}
+		})
+	}
+}

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -20,6 +20,8 @@ func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
 	assertContains(t, onboarding, "last == \"MUTATION_CONFIRMED=true\"")
 	assertContains(t, onboarding, "GITHUB_MODE=<project_v2|issue_field|label>")
 	assertContains(t, onboarding, "tracker.github_status_source: label")
+	assertContains(t, onboarding, `detent --format pretty onboarding explain-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision`)
+	assertContains(t, onboarding, "Show this summary before the canonical `answers.env` keys")
 	assertContains(t, onboarding, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase decision`)
 	assertContains(t, onboarding, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase mutation`)
 	assertContains(t, onboarding, "Do not choose label mode for the operator")


### PR DESCRIPTION
## Summary

- Add `detent onboarding explain-answers` for a plain-English behavior summary before canonical delivery keys.
- Add structured `answers_summary` JSON fields to validated onboarding answers.
- Update Phase 2.5 docs to require the summary before mutation authorization.

Fixes #675

## Test Plan

- [x] `go test ./internal/onboarding ./internal/cli -run 'Test(SummarizeDeliveryProfile|OnboardingExplainAnswersCommandSummarizesAutonomousDelivery|OnboardingValidateAnswersCommandSummarizesConservativeReviewProfile)$' -count=1`
- [x] `go test ./... -run TestOnboardingDocsRequireMutationAuthorization -count=1`
- [x] `make check`