### PR TITLE
fix(orchestrator): isolate cleanup warnings

### DIFF
--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1307,8 +1307,8 @@ func TestRunRetriesTransientStartupCleanupFetchAndDispatchesCandidate(t *testing
 	state := waitForState(t, orch, func(state orchestrator.State) bool {
 		return recentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 504")
 	})
-	if got := state.Snapshot(time.Now()).Refresh.ReadinessStatus(); got != telemetry.RefreshStatusDegraded {
-		t.Fatalf("snapshot Refresh status = %q, want degraded", got)
+	if got := state.Snapshot(time.Now()).Refresh.ReadinessStatus(); got != telemetry.RefreshStatusReady {
+		t.Fatalf("snapshot Refresh status = %q, want ready", got)
 	}
 	if got := logs.String(); !strings.Contains(got, "fetch workspace cleanup candidates failed") || !strings.Contains(got, "status 504") {
 		t.Fatalf("logs = %q, want startup cleanup fetch failure", got)
@@ -1327,6 +1327,69 @@ func TestRunRetriesTransientStartupCleanupFetchAndDispatchesCandidate(t *testing
 	})
 	if state.LastRefreshError != "" || !state.LastRefreshErrorAt.IsZero() {
 		t.Fatalf("refresh error = %q at %v, want cleared after retry", state.LastRefreshError, state.LastRefreshErrorAt)
+	}
+	close(runner.release)
+}
+
+func TestRunKeepsRefreshReadyWhenTerminalCleanupFetchFailsAfterSnapshot(t *testing.T) {
+	t.Parallel()
+
+	candidate := testIssue("issue-cleanup-after-snapshot", "digitaldrywood/detent#682", "Todo")
+	transientErr := errors.New("fetch github pull request: github transient error: status 502")
+	tracker := newTransientCleanupConnector(candidate, transientErr).failCleanupOnAttempt(2)
+	runner := newBlockingRunner()
+	logs := &lockedBuffer{}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:                  time.Hour,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		ObservedStates:                []string{"Human Review"},
+		WorkspaceCleanupIdleTTL:       time.Hour,
+		WorkspaceCleanupSweepInterval: time.Hour,
+	}, orchestrator.Dependencies{
+		Connector:       tracker,
+		Runner:          runner,
+		WorkspaceReaper: &fakeWorkspaceReaper{},
+		Logger:          slog.New(slog.NewTextHandler(logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	request := receiveRunRequest(t, runner.started)
+	if request.Issue.ID != candidate.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, candidate.ID)
+	}
+	tracker.waitForCleanupAttempts(t, 1)
+
+	initialState := waitForState(t, orch, func(state orchestrator.State) bool {
+		return !state.LastRefreshAt.IsZero() &&
+			state.Snapshot(time.Now()).Refresh.ReadinessStatus() == telemetry.RefreshStatusReady
+	})
+	if initialState.LastRefreshError != "" || !initialState.LastRefreshErrorAt.IsZero() {
+		t.Fatalf("initial refresh error = %q at %v, want none", initialState.LastRefreshError, initialState.LastRefreshErrorAt)
+	}
+
+	if _, err := orch.RequestRefresh(context.Background()); err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	tracker.waitForCleanupAttempts(t, 2)
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		return recentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 502")
+	})
+	if got := state.Snapshot(time.Now()).Refresh.ReadinessStatus(); got != telemetry.RefreshStatusReady {
+		t.Fatalf("snapshot Refresh status = %q, want ready", got)
+	}
+	if state.LastRefreshError != "" || !state.LastRefreshErrorAt.IsZero() {
+		t.Fatalf("refresh error = %q at %v, want none for cleanup failure", state.LastRefreshError, state.LastRefreshErrorAt)
+	}
+	if got := logs.String(); !strings.Contains(got, "fetch workspace cleanup candidates failed") || !strings.Contains(got, "status 502") {
+		t.Fatalf("logs = %q, want terminal cleanup fetch failure", got)
 	}
 	close(runner.release)
 }
@@ -2287,14 +2350,16 @@ type transientCleanupConnector struct {
 	candidate           connector.Issue
 	cleanupErr          error
 	cleanupAttemptCount int
+	cleanupFailureAt    int
 	changed             chan struct{}
 }
 
 func newTransientCleanupConnector(candidate connector.Issue, cleanupErr error) *transientCleanupConnector {
 	return &transientCleanupConnector{
-		candidate:  candidate,
-		cleanupErr: cleanupErr,
-		changed:    make(chan struct{}, 8),
+		candidate:        candidate,
+		cleanupErr:       cleanupErr,
+		cleanupFailureAt: 1,
+		changed:          make(chan struct{}, 8),
 	}
 }
 
@@ -2324,6 +2389,11 @@ func (c *persistentCleanupConnector) FetchIssuesByStates(_ context.Context, stat
 	return nil, nil
 }
 
+func (c *transientCleanupConnector) failCleanupOnAttempt(attempt int) *transientCleanupConnector {
+	c.cleanupFailureAt = attempt
+	return c
+}
+
 func (c *transientCleanupConnector) Name() string {
 	return "transient-cleanup"
 }
@@ -2342,7 +2412,7 @@ func (c *transientCleanupConnector) FetchIssuesByStates(_ context.Context, state
 	if transientCleanupRequest(states) {
 		c.cleanupAttemptCount++
 		c.changed <- struct{}{}
-		if c.cleanupAttemptCount == 1 {
+		if c.cleanupAttemptCount == c.cleanupFailureAt {
 			return nil, c.cleanupErr
 		}
 	}
@@ -2403,8 +2473,7 @@ func (c *transientCleanupConnector) waitForCleanupAttempts(t *testing.T, want in
 
 func transientCleanupRequest(states []string) bool {
 	return stateListIncludes(states, "Done") &&
-		stateListIncludes(states, "Cancelled") &&
-		stateListIncludes(states, "Human Review")
+		stateListIncludes(states, "Cancelled")
 }
 
 type lockedBuffer struct {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1670,23 +1670,17 @@ func TestRequestRefreshPublishesManualOutcome(t *testing.T) {
 func TestRequestRefreshPublishesFailureWhileDegradedPersists(t *testing.T) {
 	t.Parallel()
 
-	candidate := testIssue("issue-cleanup-persistent", "digitaldrywood/detent#681", "Todo")
-	transientErr := errors.New("fetch github pull request reviews: github transient error: status 504")
-	tracker := newPersistentCleanupConnector(candidate, transientErr)
-	runner := newBlockingRunner()
+	transientErr := errors.New("fetch github issues: github transient error: status 504")
+	tracker := newFakeConnector()
 
 	orch, err := orchestrator.New(orchestrator.Config{
-		PollInterval:                  time.Hour,
-		MaxConcurrentAgents:           1,
-		ActiveStates:                  []string{"Todo", "In Progress", "Rework"},
-		TerminalStates:                []string{"Done", "Cancelled"},
-		ObservedStates:                []string{"Human Review"},
-		WorkspaceCleanupIdleTTL:       time.Hour,
-		WorkspaceCleanupSweepInterval: time.Hour,
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
 	}, orchestrator.Dependencies{
-		Connector:       tracker,
-		Runner:          runner,
-		WorkspaceReaper: &fakeWorkspaceReaper{},
+		Connector: tracker,
+		Runner:    &staticRunner{},
 	})
 	if err != nil {
 		t.Fatalf("New() error = %v", err)
@@ -1694,26 +1688,18 @@ func TestRequestRefreshPublishesFailureWhileDegradedPersists(t *testing.T) {
 	stop := runOrchestrator(t, orch)
 	defer stop()
 
-	receiveRunRequest(t, runner.started)
-	first := waitForState(t, orch, func(state orchestrator.State) bool {
-		return recentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 504")
-	})
-	firstErrorAt := first.LastRefreshErrorAt
-	if firstErrorAt.IsZero() {
-		t.Fatal("initial LastRefreshErrorAt is zero")
-	}
-	time.Sleep(25 * time.Millisecond)
+	waitForFetchCalls(t, tracker, 1)
+	tracker.setFetchCandidateError(transientErr, 2)
 
 	refresh, err := orch.RequestRefresh(context.Background())
 	if err != nil {
 		t.Fatalf("RequestRefresh() error = %v", err)
 	}
-	tracker.waitForCleanupAttempts(t, 2)
+	waitForFetchCalls(t, tracker, 2)
 
 	state := waitForState(t, orch, func(state orchestrator.State) bool {
 		snapshot := state.Snapshot(time.Now())
-		return tracker.cleanupAttempts() >= 2 &&
-			snapshot.Refresh.Manual != nil &&
+		return snapshot.Refresh.Manual != nil &&
 			snapshot.Refresh.Manual.ID == refresh.RequestID &&
 			snapshot.Refresh.Manual.Status == telemetry.RefreshAttemptStatusFailed
 	})
@@ -1724,16 +1710,15 @@ func TestRequestRefreshPublishesFailureWhileDegradedPersists(t *testing.T) {
 	if manual.LastError == "" || !strings.Contains(manual.LastError, "status 504") {
 		t.Fatalf("Manual.LastError = %q, want status 504", manual.LastError)
 	}
-	if manual.LastErrorAt == nil || !manual.LastErrorAt.After(firstErrorAt) {
-		t.Fatalf("Manual.LastErrorAt = %v, want after %v", manual.LastErrorAt, firstErrorAt)
+	if manual.LastErrorAt == nil || !manual.LastErrorAt.Equal(state.LastRefreshErrorAt) {
+		t.Fatalf("Manual.LastErrorAt = %v, want %v", manual.LastErrorAt, state.LastRefreshErrorAt)
 	}
-	if !state.LastRefreshErrorAt.After(firstErrorAt) {
-		t.Fatalf("LastRefreshErrorAt = %v, want after %v", state.LastRefreshErrorAt, firstErrorAt)
+	if state.LastRefreshError == "" || !strings.Contains(state.LastRefreshError, "fetch candidate issues failed") {
+		t.Fatalf("LastRefreshError = %q, want candidate fetch failure", state.LastRefreshError)
 	}
-	if !recentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 504") {
-		t.Fatalf("RecentEvents = %#v, want repeated cleanup failure event", state.RecentEvents)
+	if got := state.Snapshot(time.Now()).Refresh.ReadinessStatus(); got != telemetry.RefreshStatusDegraded {
+		t.Fatalf("snapshot Refresh status = %q, want degraded", got)
 	}
-	close(runner.release)
 }
 
 func TestRequestRefreshCoalescesPendingTick(t *testing.T) {
@@ -1953,6 +1938,8 @@ type fakeConnector struct {
 	setFields           []setFieldCall
 	comments            []commentCall
 	stateUpdates        []stateUpdateCall
+	fetchCandidateErr   error
+	fetchCandidateErrAt int
 	fetchByStatesErr    error
 	statusLabelPrefix   string
 }
@@ -2000,6 +1987,9 @@ func (c *fakeConnector) FetchCandidateIssues(context.Context) ([]connector.Issue
 	defer c.mu.Unlock()
 
 	c.fetchCandidateCount++
+	if c.fetchCandidateErr != nil && (c.fetchCandidateErrAt <= 0 || c.fetchCandidateCount >= c.fetchCandidateErrAt) {
+		return nil, c.fetchCandidateErr
+	}
 	return cloneIssues(c.candidates), nil
 }
 
@@ -2189,6 +2179,14 @@ func (c *fakeConnector) setStateIssues(issues ...connector.Issue) {
 	c.stateIssues = cloneIssues(issues)
 }
 
+func (c *fakeConnector) setFetchCandidateError(err error, atCall int) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	c.fetchCandidateErr = err
+	c.fetchCandidateErrAt = atCall
+}
+
 func (c *fakeConnector) applyIssueStateLocked(issueID string, state string) {
 	for i := range c.candidates {
 		if c.candidates[i].ID == issueID {
@@ -2361,32 +2359,6 @@ func newTransientCleanupConnector(candidate connector.Issue, cleanupErr error) *
 		cleanupFailureAt: 1,
 		changed:          make(chan struct{}, 8),
 	}
-}
-
-type persistentCleanupConnector struct {
-	*transientCleanupConnector
-}
-
-func newPersistentCleanupConnector(candidate connector.Issue, cleanupErr error) *persistentCleanupConnector {
-	return &persistentCleanupConnector{
-		transientCleanupConnector: newTransientCleanupConnector(candidate, cleanupErr),
-	}
-}
-
-func (c *persistentCleanupConnector) Name() string {
-	return "persistent-cleanup"
-}
-
-func (c *persistentCleanupConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
-	c.mu.Lock()
-	defer c.mu.Unlock()
-
-	if transientCleanupRequest(states) {
-		c.cleanupAttemptCount++
-		c.changed <- struct{}{}
-		return nil, c.cleanupErr
-	}
-	return nil, nil
 }
 
 func (c *transientCleanupConnector) failCleanupOnAttempt(attempt int) *transientCleanupConnector {

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"strings"
@@ -410,6 +411,52 @@ func TestReapWorkspacesVerifiesKnownWorkspaceIssueIDsBeforeStateSweep(t *testing
 	}
 }
 
+func TestReapWorkspacesFallsBackToStateSweepWhenKnownWorkspaceIssueIDFetchFails(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	running := connector.Issue{ID: "I_666", Identifier: "digitaldrywood/detent#666", State: "In Progress"}
+	terminal := connector.Issue{ID: "I_667", Identifier: "digitaldrywood/detent#667", State: "Done"}
+	cfg := normalizeConfig(Config{
+		PollInterval:                  30 * time.Second,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress"},
+		ObservedStates:                []string{"Human Review"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		WorkspaceCleanupSweepInterval: time.Minute,
+	})
+	state := newState(cfg)
+	state.Running[running.ID] = Running{
+		Issue:         running,
+		WorkspacePath: "/tmp/detent-workspaces/issue-666",
+		StartedAt:     now.Add(-time.Hour),
+	}
+	tracker := &rateLimitConnector{
+		fetchByIDErr: errors.New("github transient error: status 502"),
+		stateIssues:  []connector.Issue{terminal},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+	orch.reaper = rateLimitWorkspaceReaper{}
+
+	orch.reapWorkspacesIfDue(context.Background(), &state, now)
+
+	if tracker.fetchByIDCalls != 1 {
+		t.Fatalf("FetchIssueStatesByIDs() calls = %d, want 1", tracker.fetchByIDCalls)
+	}
+	if tracker.fetchByStatesCalls != 1 {
+		t.Fatalf("FetchIssuesByStates() calls = %d, want fallback state sweep", tracker.fetchByStatesCalls)
+	}
+	if _, ok := state.ReapedWorkspaces[terminal.ID]; !ok {
+		t.Fatalf("ReapedWorkspaces[%q] missing after fallback state sweep", terminal.ID)
+	}
+	if !rateLimitRecentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 502") {
+		t.Fatalf("RecentEvents = %#v, want cleanup fetch failure event", state.RecentEvents)
+	}
+	if state.LastRefreshError != "" || !state.LastRefreshErrorAt.IsZero() {
+		t.Fatalf("refresh error = %q at %v, want none for cleanup fallback", state.LastRefreshError, state.LastRefreshErrorAt)
+	}
+}
+
 func TestReapWorkspacesStillSweepsWhenKnownWorkspaceIsActive(t *testing.T) {
 	t.Parallel()
 
@@ -483,6 +530,15 @@ func newRateLimitTestOrchestrator(cfg Config, tracker connector.Connector) *Orch
 	}
 }
 
+func rateLimitRecentEventContains(events []telemetry.ActivityEvent, event string, message string) bool {
+	for _, candidate := range events {
+		if candidate.Event == event && strings.Contains(candidate.Message, message) {
+			return true
+		}
+	}
+	return false
+}
+
 type rateLimitConnector struct {
 	candidates              []connector.Issue
 	stateIssues             []connector.Issue
@@ -498,6 +554,7 @@ type rateLimitConnector struct {
 	fetchByStatesCalls      int
 	fetchByStatesLimitCalls int
 	fetchByIDCalls          int
+	fetchByIDErr            error
 }
 
 func (c *rateLimitConnector) Name() string {
@@ -521,6 +578,9 @@ func (c *rateLimitConnector) FetchIssuesByStatesLimit(context.Context, []string,
 
 func (c *rateLimitConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
 	c.fetchByIDCalls++
+	if c.fetchByIDErr != nil {
+		return nil, c.fetchByIDErr
+	}
 	return cloneIssues(c.issuesByID), nil
 }
 

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -16,16 +16,11 @@ func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, no
 		return
 	}
 
-	if state.LastRefreshError == "" {
-		if ids := workspaceCleanupIssueIDs(state); len(ids) > 0 {
-			ok, cleaned := o.reapWorkspaceIssueIDs(ctx, state, ids, now)
-			if !ok {
-				return
-			}
-			if cleaned {
-				state.LastWorkspaceCleanupAt = now
-				return
-			}
+	if ids := workspaceCleanupIssueIDs(state); len(ids) > 0 {
+		ok, cleaned := o.reapWorkspaceIssueIDs(ctx, state, ids, now)
+		if ok && cleaned {
+			state.LastWorkspaceCleanupAt = now
+			return
 		}
 	}
 

--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -52,7 +52,6 @@ func (o *Orchestrator) reapWorkspaceIssueIDs(ctx context.Context, state *State, 
 	if err != nil {
 		o.logger.Warn("fetch workspace cleanup issue IDs failed", slog.Any("error", err))
 		message := workspaceCleanupIssueIDsFetchFailedMessage(issueIDs, err)
-		markRefreshError(state, message, cleanupEventAt(now))
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      cleanupEventAt(now),
 			Event:   "workspace_cleanup_fetch_failed",
@@ -60,7 +59,6 @@ func (o *Orchestrator) reapWorkspaceIssueIDs(ctx context.Context, state *State, 
 		})
 		return false, false
 	}
-	clearRefreshError(state)
 	cleaned := false
 	for _, issue := range issues {
 		if !o.shouldReapWorkspaceIssue(issue, now) {
@@ -82,7 +80,6 @@ func (o *Orchestrator) reapWorkspaceStates(ctx context.Context, state *State, st
 	if err != nil {
 		o.logger.Warn("fetch workspace cleanup candidates failed", slog.Any("error", err))
 		message := workspaceCleanupFetchFailedMessage(states, err)
-		markRefreshError(state, message, cleanupEventAt(now))
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      cleanupEventAt(now),
 			Event:   "workspace_cleanup_fetch_failed",
@@ -90,7 +87,6 @@ func (o *Orchestrator) reapWorkspaceStates(ctx context.Context, state *State, st
 		})
 		return false
 	}
-	clearRefreshError(state)
 	for _, issue := range issues {
 		if !o.shouldReapWorkspaceIssue(issue, now) {
 			continue
@@ -300,22 +296,6 @@ func cleanupEventAt(now time.Time) time.Time {
 		return time.Now().UTC()
 	}
 	return now.UTC()
-}
-
-func markRefreshError(state *State, message string, at time.Time) {
-	if state == nil {
-		return
-	}
-	state.LastRefreshError = message
-	state.LastRefreshErrorAt = at
-}
-
-func clearRefreshError(state *State) {
-	if state == nil {
-		return
-	}
-	state.LastRefreshError = ""
-	state.LastRefreshErrorAt = time.Time{}
 }
 
 func workspaceReapSucceededMessage(issue connector.Issue, reason string, result WorkspaceReapResult) string {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -65,7 +65,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	if state.Draining {
 		return
 	}
-	fetched, ok := o.fetchTickIssues(ctx, state)
+	fetched, ok := o.fetchTickIssues(ctx, state, now)
 	if !ok {
 		return
 	}
@@ -198,12 +198,13 @@ func (o *Orchestrator) refreshActiveRuns(ctx context.Context, state *State, now 
 	o.heartbeatRunningClaims(ctx, state, now)
 }
 
-func (o *Orchestrator) fetchTickIssues(ctx context.Context, state *State) (tickFetchedIssues, bool) {
+func (o *Orchestrator) fetchTickIssues(ctx context.Context, state *State, now time.Time) (tickFetchedIssues, bool) {
 	observedStates := o.observedStatusFetchStates()
 
 	candidateIssues, err := o.connector.FetchCandidateIssues(ctx)
 	if err != nil {
 		o.logger.Warn("fetch candidate issues failed", "error", err)
+		markRefreshError(state, "fetch candidate issues failed: "+err.Error(), now)
 		return tickFetchedIssues{}, false
 	}
 
@@ -212,24 +213,52 @@ func (o *Orchestrator) fetchTickIssues(ctx context.Context, state *State) (tickF
 	}
 	if len(observedStates) == 0 {
 		fetched.statusOK = true
+		clearRefreshError(state)
 		return fetched, true
 	}
 	if !tickHasActiveWork(state, candidateIssues) && !o.observedWorkExists(ctx, observedStates) {
 		fetched.statusOK = true
+		clearRefreshError(state)
 		return fetched, true
 	}
 
 	statusIssues, statusErr := o.connector.FetchIssuesByStates(ctx, observedStates)
 	if statusErr != nil {
 		o.logger.Warn("fetch observed status issues failed", "error", statusErr)
+		markRefreshError(state, "fetch observed status issues failed: "+statusErr.Error(), now)
 		return fetched, true
 	}
 	fetched.status = cloneIssues(statusIssues)
 	fetched.statusOK = true
 	if !o.hydratePlanIssueComments(ctx, &fetched) {
+		markRefreshError(state, "fetch plan issue comments failed", now)
 		return tickFetchedIssues{}, false
 	}
+	clearRefreshError(state)
 	return fetched, true
+}
+
+func markRefreshError(state *State, message string, at time.Time) {
+	if state == nil {
+		return
+	}
+	message = strings.TrimSpace(message)
+	if message == "" {
+		message = "tracker refresh failed"
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	state.LastRefreshError = message
+	state.LastRefreshErrorAt = at.UTC()
+}
+
+func clearRefreshError(state *State) {
+	if state == nil {
+		return
+	}
+	state.LastRefreshError = ""
+	state.LastRefreshErrorAt = time.Time{}
 }
 
 func (o *Orchestrator) observedWorkExists(ctx context.Context, observedStates []string) bool {


### PR DESCRIPTION
## Summary

- Keep workspace cleanup candidate fetch failures out of tracker refresh readiness.
- Preserve cleanup diagnostics through the existing warning log and `workspace_cleanup_fetch_failed` activity event.
- Preserve fallback from known-workspace ID fetch failures into the by-state cleanup sweep without using tracker refresh errors as the fallback signal.
- Preserve degraded tracker readiness for primary tracker fetch failures.
- Add regression coverage for cleanup fetch 5xx after an initial usable snapshot remains ready.

Fixes #682

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestRequestRefreshPublishesFailureWhileDegradedPersists|TestRunRetriesTransientStartupCleanupFetchAndDispatchesCandidate|TestRunKeepsRefreshReadyWhenTerminalCleanupFetchFailsAfterSnapshot' -count=1 -v`
- [x] `go test -race ./internal/cli -run TestBuildWorkspaceBackendUsesProjectWorkdirAsSourceRoot -count=1 -v` (reran after one transient local git segfault during first full gate)
- [x] `make check`
- [x] Current-head PR CI for `d92055b5798124ee6eb26f189f4a86eb429055c6`: all 10 checks passed