### PR TITLE
fix(dashboard): summarize degraded refresh

### DIFF
--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1114,6 +1114,9 @@ func snapshotDegraded(snapshot telemetry.Snapshot) bool {
 
 func snapshotReadinessTitle(snapshot telemetry.Snapshot) string {
 	if snapshotDegraded(snapshot) {
+		if snapshotHasPriorTrackerSnapshot(snapshot) {
+			return "Tracker refresh degraded."
+		}
 		return "Tracker refresh failed."
 	}
 	return "Loading tracker state..."
@@ -1121,22 +1124,140 @@ func snapshotReadinessTitle(snapshot telemetry.Snapshot) string {
 
 func snapshotReadinessDetail(snapshot telemetry.Snapshot) string {
 	if snapshotDegraded(snapshot) {
-		parts := []string{"Detent could not load the first tracker snapshot."}
-		if err := strings.TrimSpace(snapshot.Refresh.LastError); err != "" {
-			parts = append(parts, err)
+		if snapshotHasPriorTrackerSnapshot(snapshot) {
+			return snapshotDegradedRefreshDetail(snapshot)
 		}
-		if snapshot.Refresh.LastErrorAt != nil {
-			parts = append(parts, "Last error at "+timeLabel(*snapshot.Refresh.LastErrorAt)+".")
-		}
-		if snapshot.Refresh.LastRefreshAt != nil {
-			parts = append(parts, "Last successful refresh at "+timeLabel(*snapshot.Refresh.LastRefreshAt)+".")
-		}
-		return strings.Join(parts, " ")
+		return snapshotFirstRefreshFailureDetail(snapshot)
 	}
 	if snapshot.Refresh.NextRefreshAt != nil {
 		return "Detent is waiting for the first successful tracker snapshot. Next refresh is scheduled for " + timeLabel(*snapshot.Refresh.NextRefreshAt) + "."
 	}
 	return "Detent is waiting for the first successful tracker snapshot before showing board counts or empty states."
+}
+
+func snapshotHasPriorTrackerSnapshot(snapshot telemetry.Snapshot) bool {
+	if snapshot.Refresh.LastRefreshAt != nil ||
+		len(snapshot.BoardIssues) > 0 ||
+		len(snapshot.Pipeline) > 0 ||
+		len(snapshot.Running) > 0 ||
+		len(snapshot.Queue) > 0 ||
+		len(snapshot.Blocked) > 0 ||
+		len(snapshot.Completed) > 0 ||
+		snapshot.Counts != (telemetry.Counts{}) ||
+		snapshot.Tokens != (telemetry.Tokens{}) ||
+		snapshot.LifetimeTotals.Available ||
+		snapshot.CycleTime.Available ||
+		len(snapshot.TokenTrend) > 0 {
+		return true
+	}
+	for _, project := range snapshot.Projects {
+		if projectSnapshotHasPriorTrackerData(project) {
+			return true
+		}
+	}
+	return false
+}
+
+func projectSnapshotHasPriorTrackerData(project telemetry.ProjectSnapshot) bool {
+	return project.Refresh.LastRefreshAt != nil ||
+		project.Refresh.Status == telemetry.RefreshStatusReady ||
+		project.Counts != (telemetry.Counts{}) ||
+		project.Tokens != (telemetry.Tokens{}) ||
+		project.Throughput != (telemetry.TokenThroughput{})
+}
+
+func snapshotFirstRefreshFailureDetail(snapshot telemetry.Snapshot) string {
+	parts := []string{"Detent could not load the first tracker snapshot."}
+	if err := snapshotReadinessErrorSummary(snapshot.Refresh.LastError); err != "" {
+		parts = append(parts, err)
+	}
+	if snapshot.Refresh.LastErrorAt != nil {
+		parts = append(parts, "Last error at "+timeLabel(*snapshot.Refresh.LastErrorAt)+".")
+	}
+	return strings.Join(parts, " ")
+}
+
+func snapshotDegradedRefreshDetail(snapshot telemetry.Snapshot) string {
+	parts := []string{}
+	if err := snapshotReadinessErrorSummary(snapshot.Refresh.LastError); err != "" {
+		parts = append(parts, err)
+	} else {
+		parts = append(parts, "The latest tracker refresh failed. Detent will retry on the next refresh.")
+	}
+	if snapshot.Refresh.LastRefreshAt != nil {
+		parts = append(parts, "Last successful refresh: "+timeLabel(*snapshot.Refresh.LastRefreshAt)+".")
+	}
+	return strings.Join(parts, " ")
+}
+
+func snapshotReadinessErrorSummary(raw string) string {
+	err := strings.TrimSpace(raw)
+	if err == "" {
+		return ""
+	}
+	if status, ok := githubTransientStatus(err); ok {
+		return fmt.Sprintf("GitHub returned a transient %d while %s. Detent will retry on the next refresh.", status, githubTransientOperation(err))
+	}
+	return sanitizeReadinessError(err)
+}
+
+func githubTransientStatus(err string) (int, bool) {
+	lower := strings.ToLower(err)
+	marker := "github transient error: status "
+	index := strings.Index(lower, marker)
+	if index < 0 {
+		return 0, false
+	}
+	rest := lower[index+len(marker):]
+	status := 0
+	for _, char := range rest {
+		if char < '0' || char > '9' {
+			break
+		}
+		status = status*10 + int(char-'0')
+	}
+	return status, status >= 500 && status <= 599
+}
+
+func githubTransientOperation(err string) string {
+	lower := strings.ToLower(err)
+	switch {
+	case strings.Contains(lower, "workspace cleanup candidate fetch failed"):
+		return "fetching workspace cleanup candidates"
+	case strings.Contains(lower, "fetch github pull request reviews"):
+		return "fetching GitHub pull request reviews"
+	case strings.Contains(lower, "fetch github pull request"):
+		return "fetching GitHub pull request data"
+	case strings.Contains(lower, "fetch github issue"):
+		return "fetching GitHub issue data"
+	default:
+		return "refreshing tracker data"
+	}
+}
+
+func sanitizeReadinessError(err string) string {
+	err = strings.Join(strings.Fields(err), " ")
+	htmlIndex := firstHTMLIndex(err)
+	if htmlIndex < 0 {
+		return err
+	}
+	prefix := strings.TrimRight(strings.TrimSpace(err[:htmlIndex]), ": ")
+	if prefix == "" {
+		return "Upstream returned an HTML error page. Check logs for details."
+	}
+	return prefix + ". Check logs for details."
+}
+
+func firstHTMLIndex(value string) int {
+	lower := strings.ToLower(value)
+	first := -1
+	for _, marker := range []string{"<!doctype html", "<html", "<head", "<body"} {
+		index := strings.Index(lower, marker)
+		if index >= 0 && (first < 0 || index < first) {
+			first = index
+		}
+	}
+	return first
 }
 
 func snapshotReadinessDotClass(snapshot telemetry.Snapshot) string {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1143,11 +1143,7 @@ func snapshotHasPriorTrackerSnapshot(snapshot telemetry.Snapshot) bool {
 		len(snapshot.Queue) > 0 ||
 		len(snapshot.Blocked) > 0 ||
 		len(snapshot.Completed) > 0 ||
-		snapshot.Counts != (telemetry.Counts{}) ||
-		snapshot.Tokens != (telemetry.Tokens{}) ||
-		snapshot.LifetimeTotals.Available ||
-		snapshot.CycleTime.Available ||
-		len(snapshot.TokenTrend) > 0 {
+		snapshot.Counts != (telemetry.Counts{}) {
 		return true
 	}
 	for _, project := range snapshot.Projects {
@@ -1161,9 +1157,7 @@ func snapshotHasPriorTrackerSnapshot(snapshot telemetry.Snapshot) bool {
 func projectSnapshotHasPriorTrackerData(project telemetry.ProjectSnapshot) bool {
 	return project.Refresh.LastRefreshAt != nil ||
 		project.Refresh.Status == telemetry.RefreshStatusReady ||
-		project.Counts != (telemetry.Counts{}) ||
-		project.Tokens != (telemetry.Tokens{}) ||
-		project.Throughput != (telemetry.TokenThroughput{})
+		project.Counts != (telemetry.Counts{})
 }
 
 func snapshotFirstRefreshFailureDetail(snapshot telemetry.Snapshot) string {

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -1079,6 +1079,10 @@ func TestProjectSnapshotsRenderFirstRefreshFailureState(t *testing.T) {
 		},
 		Snapshot: telemetry.Snapshot{
 			GeneratedAt: now,
+			Project: telemetry.Project{
+				ID:          "detent",
+				DisplayName: "Detent",
+			},
 			Refresh: telemetry.Refresh{
 				Status:      telemetry.RefreshStatusDegraded,
 				LastError:   "github tracker unavailable",
@@ -1092,8 +1096,17 @@ func TestProjectSnapshotsRenderFirstRefreshFailureState(t *testing.T) {
 		"overview": renderDashboard(t, data),
 		"runs":     renderProjectRunsSnapshot(t, data),
 	} {
-		if !strings.Contains(html, "Tracker refresh failed.") || !strings.Contains(html, "github tracker unavailable") {
-			t.Fatalf("%s missing degraded state:\n%s", name, html)
+		for _, want := range []string{
+			"Tracker refresh failed.",
+			"Detent could not load the first tracker snapshot.",
+			"github tracker unavailable",
+		} {
+			if !strings.Contains(html, want) {
+				t.Fatalf("%s missing degraded state %q:\n%s", name, want, html)
+			}
+		}
+		if strings.Contains(html, "Tracker refresh degraded.") {
+			t.Fatalf("%s rendered prior-snapshot degraded copy for first refresh failure:\n%s", name, html)
 		}
 		for _, forbidden := range []string{
 			"No issues in this state.",
@@ -1104,6 +1117,115 @@ func TestProjectSnapshotsRenderFirstRefreshFailureState(t *testing.T) {
 			if strings.Contains(html, forbidden) {
 				t.Fatalf("%s rendered loaded state %q after first refresh failure:\n%s", name, forbidden, html)
 			}
+		}
+	}
+}
+
+func TestProjectSnapshotsRenderDegradedRefreshWithPriorSnapshotState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 22, 9, 25, 0, 0, time.UTC)
+	lastRefreshAt := now.Add(-30 * time.Second)
+	lastErrorAt := now.Add(-5 * time.Second)
+	data := templates.DashboardData{
+		Title:       "Detent",
+		ProjectID:   "detent",
+		ProjectName: "Detent",
+		Kanban: templates.KanbanData{
+			Mode:   "integration",
+			States: []string{"Todo", "In Progress"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Refresh: telemetry.Refresh{
+				Status:        telemetry.RefreshStatusDegraded,
+				LastRefreshAt: &lastRefreshAt,
+				LastError:     "workspace cleanup candidate fetch failed for states=done,cancelled: fetch github pull request: github transient error: status 502",
+				LastErrorAt:   &lastErrorAt,
+			},
+			BoardIssues: []telemetry.Issue{
+				{
+					ID:         "issue-680",
+					Identifier: "digitaldrywood/detent#680",
+					ProjectID:  "detent",
+					URL:        "https://github.com/digitaldrywood/detent/issues/680",
+					Title:      "Summarize degraded refresh errors",
+					State:      "Todo",
+				},
+			},
+		},
+	}
+
+	for name, html := range map[string]string{
+		"kanban":   renderProjectKanbanPage(t, data),
+		"overview": renderDashboard(t, data),
+		"runs":     renderProjectRunsSnapshot(t, data),
+	} {
+		for _, want := range []string{
+			"Tracker refresh degraded.",
+			"GitHub returned a transient 502 while fetching workspace cleanup candidates. Detent will retry on the next refresh.",
+			"Last successful refresh: Jun 22 09:24:30 UTC.",
+		} {
+			if !strings.Contains(html, want) {
+				t.Fatalf("%s missing degraded refresh copy %q:\n%s", name, want, html)
+			}
+		}
+		for _, forbidden := range []string{
+			"Detent could not load the first tracker snapshot.",
+			"Tracker refresh failed.",
+		} {
+			if strings.Contains(html, forbidden) {
+				t.Fatalf("%s rendered first-load copy %q for degraded refresh:\n%s", name, forbidden, html)
+			}
+		}
+	}
+}
+
+func TestProjectSnapshotsSummarizeGitHubTransientHTMLReadinessError(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 22, 9, 30, 0, 0, time.UTC)
+	lastRefreshAt := now.Add(-time.Minute)
+	lastErrorAt := now.Add(-5 * time.Second)
+	htmlBody := "<!DOCTYPE html><html><head><title>Unicorn! · GitHub</title></head><body>upstream unavailable</body></html>"
+	data := templates.DashboardData{
+		Title:       "Detent",
+		ProjectID:   "detent",
+		ProjectName: "Detent",
+		Kanban: templates.KanbanData{
+			Mode:   "read_only",
+			States: []string{"Todo", "In Progress"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Refresh: telemetry.Refresh{
+				Status:        telemetry.RefreshStatusDegraded,
+				LastRefreshAt: &lastRefreshAt,
+				LastError:     "workspace cleanup candidate fetch failed for states=done,cancelled: fetch github pull request: github transient error: status 502: " + htmlBody,
+				LastErrorAt:   &lastErrorAt,
+			},
+		},
+	}
+
+	html := renderDashboard(t, data)
+	for _, want := range []string{
+		"Tracker refresh degraded.",
+		"GitHub returned a transient 502 while fetching workspace cleanup candidates. Detent will retry on the next refresh.",
+		"Last successful refresh: Jun 22 09:29:00 UTC.",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("dashboard missing sanitized degraded refresh copy %q:\n%s", want, html)
+		}
+	}
+	for _, forbidden := range []string{
+		"<!DOCTYPE html>",
+		"&lt;!DOCTYPE html&gt;",
+		"Unicorn",
+		"upstream unavailable",
+		"github transient error",
+	} {
+		if strings.Contains(html, forbidden) {
+			t.Fatalf("dashboard rendered raw upstream error %q:\n%s", forbidden, html)
 		}
 	}
 }

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -1121,6 +1121,102 @@ func TestProjectSnapshotsRenderFirstRefreshFailureState(t *testing.T) {
 	}
 }
 
+func TestProjectSnapshotsKeepFirstRefreshFailureWithLocalStats(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 22, 9, 22, 0, 0, time.UTC)
+	lastErrorAt := now.Add(-5 * time.Second)
+	data := templates.DashboardData{
+		Title:       "Detent",
+		ProjectID:   "detent",
+		ProjectName: "Detent",
+		Kanban: templates.KanbanData{
+			Mode:   "integration",
+			States: []string{"Todo", "In Progress"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			Project: telemetry.Project{
+				ID:          "detent",
+				DisplayName: "Detent",
+			},
+			Projects: []telemetry.ProjectSnapshot{
+				{
+					Project: telemetry.Project{
+						ID:          "detent",
+						DisplayName: "Detent",
+					},
+					Refresh: telemetry.Refresh{
+						Status:      telemetry.RefreshStatusDegraded,
+						LastError:   "github tracker unavailable",
+						LastErrorAt: &lastErrorAt,
+					},
+					Tokens: telemetry.Tokens{
+						Input:  120,
+						Output: 30,
+						Total:  150,
+					},
+					Throughput: telemetry.TokenThroughput{
+						TokensPerSecond: 2.5,
+						WindowSeconds:   60,
+						Tokens:          150,
+					},
+				},
+			},
+			Refresh: telemetry.Refresh{
+				Status:      telemetry.RefreshStatusDegraded,
+				LastError:   "github tracker unavailable",
+				LastErrorAt: &lastErrorAt,
+			},
+			Tokens: telemetry.Tokens{
+				Input:  120,
+				Output: 30,
+				Total:  150,
+			},
+			LifetimeTotals: telemetry.LifetimeTotals{
+				Available:      true,
+				InputTokens:    120,
+				OutputTokens:   30,
+				TotalTokens:    150,
+				RuntimeSeconds: 45,
+				Sessions:       1,
+				Runs:           1,
+			},
+			CycleTime: telemetry.CycleTimeReport{
+				Available:      true,
+				AverageSeconds: 600,
+			},
+			TokenTrend: []telemetry.TokenTrendPoint{
+				{
+					At:     now,
+					Input:  120,
+					Output: 30,
+					Total:  150,
+				},
+			},
+		},
+	}
+
+	for name, html := range map[string]string{
+		"kanban":   renderProjectKanbanPage(t, data),
+		"overview": renderDashboard(t, data),
+		"runs":     renderProjectRunsSnapshot(t, data),
+	} {
+		for _, want := range []string{
+			"Tracker refresh failed.",
+			"Detent could not load the first tracker snapshot.",
+			"github tracker unavailable",
+		} {
+			if !strings.Contains(html, want) {
+				t.Fatalf("%s missing first-refresh failure copy %q:\n%s", name, want, html)
+			}
+		}
+		if strings.Contains(html, "Tracker refresh degraded.") {
+			t.Fatalf("%s rendered prior-snapshot degraded copy from local stats:\n%s", name, html)
+		}
+	}
+}
+
 func TestProjectSnapshotsRenderDegradedRefreshWithPriorSnapshotState(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Distinguish first tracker snapshot failures from degraded refreshes with a prior snapshot.
- Summarize transient GitHub 5xx readiness errors in dashboard copy without rendering upstream HTML bodies.
- Keep raw refresh error detail in telemetry/logs while sanitizing the readiness banner.

Fixes #680

## Test Plan
- go test ./internal/web/templates -run 'TestProjectSnapshots(RenderFirstRefreshFailureState|RenderDegradedRefreshWithPriorSnapshotState|SummarizeGitHubTransientHTMLReadinessError)'
- go test ./internal/web/templates ./internal/orchestrator
- make check
