### PR TITLE
fix(refresh): surface manual refresh outcomes

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -891,9 +891,30 @@ func mergeRefreshResponse(current web.RefreshResponse, next web.RefreshResponse)
 	current.Coalesced = current.Coalesced || next.Coalesced
 	if current.RequestedAt.IsZero() || (!next.RequestedAt.IsZero() && next.RequestedAt.Before(current.RequestedAt)) {
 		current.RequestedAt = next.RequestedAt
+		current.RequestID = next.RequestID
+	}
+	if current.RequestID == "" {
+		current.RequestID = next.RequestID
 	}
 	current.Operations = appendOperations(current.Operations, next.Operations)
+	current.Status = mergeRefreshResponseStatus(current, next)
 	return current
+}
+
+func mergeRefreshResponseStatus(current web.RefreshResponse, next web.RefreshResponse) telemetry.RefreshAttemptStatus {
+	if current.Coalesced || next.Coalesced {
+		return telemetry.RefreshAttemptStatusCoalesced
+	}
+	if current.Status != "" {
+		return current.Status
+	}
+	if next.Status != "" {
+		return next.Status
+	}
+	if current.Queued || next.Queued {
+		return telemetry.RefreshAttemptStatusInProgress
+	}
+	return ""
 }
 
 func appendOperations(operations []string, next []string) []string {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -743,6 +743,7 @@ func mergeRefresh(current, next telemetry.Refresh) telemetry.Refresh {
 		}
 	}
 	current.LastErrorAt = latestTime(current.LastErrorAt, next.LastErrorAt)
+	current.Manual = mergeRefreshAttempt(current.Manual, next.Manual)
 	switch {
 	case !currentHadSignal && nextHadSignal:
 		current.Status = next.ReadinessStatus()
@@ -766,7 +767,41 @@ func refreshHasSignal(refresh telemetry.Refresh) bool {
 		refresh.LastRefreshAt != nil ||
 		refresh.NextRefreshAt != nil ||
 		strings.TrimSpace(refresh.LastError) != "" ||
-		refresh.LastErrorAt != nil
+		refresh.LastErrorAt != nil ||
+		refresh.Manual != nil
+}
+
+func mergeRefreshAttempt(current *telemetry.RefreshAttempt, next *telemetry.RefreshAttempt) *telemetry.RefreshAttempt {
+	if current == nil {
+		return cloneRefreshAttemptPtr(next)
+	}
+	if next == nil {
+		return cloneRefreshAttemptPtr(current)
+	}
+	if refreshAttemptRequestedAt(next).After(refreshAttemptRequestedAt(current)) {
+		return cloneRefreshAttemptPtr(next)
+	}
+	return cloneRefreshAttemptPtr(current)
+}
+
+func refreshAttemptRequestedAt(attempt *telemetry.RefreshAttempt) time.Time {
+	if attempt == nil || attempt.RequestedAt == nil {
+		return time.Time{}
+	}
+	return attempt.RequestedAt.UTC()
+}
+
+func cloneRefreshAttemptPtr(attempt *telemetry.RefreshAttempt) *telemetry.RefreshAttempt {
+	if attempt == nil {
+		return nil
+	}
+	cloned := *attempt
+	cloned.RequestedAt = cloneTime(attempt.RequestedAt)
+	cloned.StartedAt = cloneTime(attempt.StartedAt)
+	cloned.CompletedAt = cloneTime(attempt.CompletedAt)
+	cloned.LastErrorAt = cloneTime(attempt.LastErrorAt)
+	cloned.Operations = append([]string(nil), attempt.Operations...)
+	return &cloned
 }
 
 func latestTime(current *time.Time, next *time.Time) *time.Time {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -8,6 +8,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
@@ -117,10 +118,11 @@ type Orchestrator struct {
 	drainRequests      chan drainRequest
 	forceRequests      chan forceRequest
 	configUpdates      chan configUpdateRequest
-	refreshes          chan time.Time
+	refreshes          chan manualRefreshRequest
 	runResults         chan runpkg.Completion
 	runUpdates         chan runUpdate
 	done               chan struct{}
+	refreshSeq         atomic.Uint64
 }
 
 type validatorStageResult struct {
@@ -252,7 +254,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		drainRequests:      make(chan drainRequest),
 		forceRequests:      make(chan forceRequest),
 		configUpdates:      make(chan configUpdateRequest),
-		refreshes:          make(chan time.Time, 1),
+		refreshes:          make(chan manualRefreshRequest, 1),
 		runResults:         make(chan runpkg.Completion),
 		runUpdates:         make(chan runUpdate, runUpdateBufferSize),
 		done:               make(chan struct{}),
@@ -280,8 +282,8 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		case now := <-ticker.C:
 			o.tick(ctx, &state, now)
 			resetTicker(ticker, state.PollInterval)
-		case now := <-o.refreshes:
-			o.tick(ctx, &state, now)
+		case request := <-o.refreshes:
+			o.tickManual(ctx, &state, request)
 			resetTicker(ticker, state.PollInterval)
 		case result := <-o.runResults:
 			o.handleRunResult(ctx, &state, result)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1550,6 +1550,128 @@ func TestRequestRefreshQueuesImmediateTick(t *testing.T) {
 	waitForFetchCalls(t, tracker, 2)
 }
 
+func TestRequestRefreshPublishesManualOutcome(t *testing.T) {
+	t.Parallel()
+
+	tracker := newFakeConnector()
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    &staticRunner{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForFetchCalls(t, tracker, 1)
+
+	refresh, err := orch.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	if refresh.RequestID == "" {
+		t.Fatal("RequestID is empty")
+	}
+	if refresh.Status != telemetry.RefreshAttemptStatusInProgress {
+		t.Fatalf("Status = %q, want %q", refresh.Status, telemetry.RefreshAttemptStatusInProgress)
+	}
+
+	waitForFetchCalls(t, tracker, 2)
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		snapshot := state.Snapshot(time.Now())
+		return snapshot.Refresh.Manual != nil &&
+			snapshot.Refresh.Manual.ID == refresh.RequestID &&
+			snapshot.Refresh.Manual.Status == telemetry.RefreshAttemptStatusSucceeded
+	})
+	manual := state.Snapshot(time.Now()).Refresh.Manual
+	if manual == nil {
+		t.Fatal("snapshot Refresh.Manual = nil")
+	}
+	if manual.RequestedAt == nil || !manual.RequestedAt.Equal(refresh.RequestedAt) {
+		t.Fatalf("Manual.RequestedAt = %v, want %v", manual.RequestedAt, refresh.RequestedAt)
+	}
+	if manual.CompletedAt == nil {
+		t.Fatal("Manual.CompletedAt = nil")
+	}
+	if len(manual.Operations) != 2 || manual.Operations[0] != "poll" || manual.Operations[1] != "reconcile" {
+		t.Fatalf("Manual.Operations = %#v, want poll/reconcile", manual.Operations)
+	}
+}
+
+func TestRequestRefreshPublishesFailureWhileDegradedPersists(t *testing.T) {
+	t.Parallel()
+
+	candidate := testIssue("issue-cleanup-persistent", "digitaldrywood/detent#681", "Todo")
+	transientErr := errors.New("fetch github pull request reviews: github transient error: status 504")
+	tracker := newPersistentCleanupConnector(candidate, transientErr)
+	runner := newBlockingRunner()
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:                  time.Hour,
+		MaxConcurrentAgents:           1,
+		ActiveStates:                  []string{"Todo", "In Progress", "Rework"},
+		TerminalStates:                []string{"Done", "Cancelled"},
+		ObservedStates:                []string{"Human Review"},
+		WorkspaceCleanupIdleTTL:       time.Hour,
+		WorkspaceCleanupSweepInterval: time.Hour,
+	}, orchestrator.Dependencies{
+		Connector:       tracker,
+		Runner:          runner,
+		WorkspaceReaper: &fakeWorkspaceReaper{},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	receiveRunRequest(t, runner.started)
+	first := waitForState(t, orch, func(state orchestrator.State) bool {
+		return recentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 504")
+	})
+	firstErrorAt := first.LastRefreshErrorAt
+	if firstErrorAt.IsZero() {
+		t.Fatal("initial LastRefreshErrorAt is zero")
+	}
+
+	refresh, err := orch.RequestRefresh(context.Background())
+	if err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	tracker.waitForCleanupAttempts(t, 2)
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		snapshot := state.Snapshot(time.Now())
+		return tracker.cleanupAttempts() >= 2 &&
+			snapshot.Refresh.Manual != nil &&
+			snapshot.Refresh.Manual.ID == refresh.RequestID &&
+			snapshot.Refresh.Manual.Status == telemetry.RefreshAttemptStatusFailed
+	})
+	manual := state.Snapshot(time.Now()).Refresh.Manual
+	if manual == nil {
+		t.Fatal("snapshot Refresh.Manual = nil")
+	}
+	if manual.LastError == "" || !strings.Contains(manual.LastError, "status 504") {
+		t.Fatalf("Manual.LastError = %q, want status 504", manual.LastError)
+	}
+	if manual.LastErrorAt == nil || !manual.LastErrorAt.After(firstErrorAt) {
+		t.Fatalf("Manual.LastErrorAt = %v, want after %v", manual.LastErrorAt, firstErrorAt)
+	}
+	if !state.LastRefreshErrorAt.After(firstErrorAt) {
+		t.Fatalf("LastRefreshErrorAt = %v, want after %v", state.LastRefreshErrorAt, firstErrorAt)
+	}
+	if !recentEventContains(state.RecentEvents, "workspace_cleanup_fetch_failed", "status 504") {
+		t.Fatalf("RecentEvents = %#v, want repeated cleanup failure event", state.RecentEvents)
+	}
+	close(runner.release)
+}
+
 func TestRequestRefreshCoalescesPendingTick(t *testing.T) {
 	t.Parallel()
 
@@ -1568,6 +1690,12 @@ func TestRequestRefreshCoalescesPendingTick(t *testing.T) {
 	}
 	if !second.Coalesced {
 		t.Fatalf("second RequestRefresh().Coalesced = false, want true")
+	}
+	if second.RequestID == "" {
+		t.Fatal("second RequestID is empty")
+	}
+	if second.Status != telemetry.RefreshAttemptStatusCoalesced {
+		t.Fatalf("second Status = %q, want %q", second.Status, telemetry.RefreshAttemptStatusCoalesced)
 	}
 }
 
@@ -2167,6 +2295,32 @@ func newTransientCleanupConnector(candidate connector.Issue, cleanupErr error) *
 		cleanupErr: cleanupErr,
 		changed:    make(chan struct{}, 8),
 	}
+}
+
+type persistentCleanupConnector struct {
+	*transientCleanupConnector
+}
+
+func newPersistentCleanupConnector(candidate connector.Issue, cleanupErr error) *persistentCleanupConnector {
+	return &persistentCleanupConnector{
+		transientCleanupConnector: newTransientCleanupConnector(candidate, cleanupErr),
+	}
+}
+
+func (c *persistentCleanupConnector) Name() string {
+	return "persistent-cleanup"
+}
+
+func (c *persistentCleanupConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if transientCleanupRequest(states) {
+		c.cleanupAttemptCount++
+		c.changed <- struct{}{}
+		return nil, c.cleanupErr
+	}
+	return nil, nil
 }
 
 func (c *transientCleanupConnector) Name() string {

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1639,6 +1639,7 @@ func TestRequestRefreshPublishesFailureWhileDegradedPersists(t *testing.T) {
 	if firstErrorAt.IsZero() {
 		t.Fatal("initial LastRefreshErrorAt is zero")
 	}
+	time.Sleep(25 * time.Millisecond)
 
 	refresh, err := orch.RequestRefresh(context.Background())
 	if err != nil {

--- a/internal/orchestrator/refresh.go
+++ b/internal/orchestrator/refresh.go
@@ -2,14 +2,25 @@ package orchestrator
 
 import (
 	"context"
+	"fmt"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type RefreshResponse struct {
-	Queued      bool      `json:"queued"`
-	Coalesced   bool      `json:"coalesced"`
-	RequestedAt time.Time `json:"requested_at"`
-	Operations  []string  `json:"operations"`
+	RequestID   string                         `json:"request_id,omitempty"`
+	Status      telemetry.RefreshAttemptStatus `json:"status,omitempty"`
+	Queued      bool                           `json:"queued"`
+	Coalesced   bool                           `json:"coalesced"`
+	RequestedAt time.Time                      `json:"requested_at"`
+	Operations  []string                       `json:"operations"`
+}
+
+type manualRefreshRequest struct {
+	id          string
+	requestedAt time.Time
+	operations  []string
 }
 
 func (o *Orchestrator) RequestRefresh(ctx context.Context) (RefreshResponse, error) {
@@ -17,9 +28,12 @@ func (o *Orchestrator) RequestRefresh(ctx context.Context) (RefreshResponse, err
 		ctx = context.Background()
 	}
 
+	requestedAt := time.Now().UTC()
 	response := RefreshResponse{
+		RequestID:   o.nextManualRefreshID(requestedAt),
+		Status:      telemetry.RefreshAttemptStatusInProgress,
 		Queued:      true,
-		RequestedAt: time.Now().UTC().Truncate(time.Second),
+		RequestedAt: requestedAt,
 		Operations:  []string{"poll", "reconcile"},
 	}
 
@@ -36,10 +50,19 @@ func (o *Orchestrator) RequestRefresh(ctx context.Context) (RefreshResponse, err
 		return RefreshResponse{}, ctx.Err()
 	case <-o.done:
 		return RefreshResponse{}, ErrStopped
-	case o.refreshes <- response.RequestedAt:
+	case o.refreshes <- manualRefreshRequest{
+		id:          response.RequestID,
+		requestedAt: response.RequestedAt,
+		operations:  append([]string(nil), response.Operations...),
+	}:
 		return response, nil
 	default:
 		response.Coalesced = true
+		response.Status = telemetry.RefreshAttemptStatusCoalesced
 		return response, nil
 	}
+}
+
+func (o *Orchestrator) nextManualRefreshID(requestedAt time.Time) string {
+	return fmt.Sprintf("manual-%d-%d", requestedAt.UnixNano(), o.refreshSeq.Add(1))
 }

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -20,6 +20,10 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		LastError:           s.LastRefreshError,
 		LastErrorAt:         timePointer(s.LastRefreshErrorAt),
 	}
+	if !s.ManualRefresh.IsZero() {
+		manual := cloneRefreshAttempt(s.ManualRefresh)
+		refresh.Manual = &manual
+	}
 	if refresh.LastError != "" || refresh.LastErrorAt != nil {
 		refresh.Status = telemetry.RefreshStatusDegraded
 	} else if refresh.LastRefreshAt == nil {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -21,6 +21,7 @@ type State struct {
 	NextRefreshAt            time.Time
 	LastRefreshError         string
 	LastRefreshErrorAt       time.Time
+	ManualRefresh            telemetry.RefreshAttempt
 	LastRunningReconcileAt   time.Time
 	LastWorkspaceCleanupAt   time.Time
 	RecentEvents             []telemetry.ActivityEvent
@@ -132,6 +133,7 @@ func (s State) clone() State {
 		NextRefreshAt:            s.NextRefreshAt,
 		LastRefreshError:         s.LastRefreshError,
 		LastRefreshErrorAt:       s.LastRefreshErrorAt,
+		ManualRefresh:            cloneRefreshAttempt(s.ManualRefresh),
 		LastRunningReconcileAt:   s.LastRunningReconcileAt,
 		LastWorkspaceCleanupAt:   s.LastWorkspaceCleanupAt,
 		RecentEvents:             cloneActivityEvents(s.RecentEvents),
@@ -241,6 +243,24 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	cloned.Assignees = cloneStringSlice(issue.Assignees)
 	cloned.Fields = cloneStringMap(issue.Fields)
 	return cloned
+}
+
+func cloneRefreshAttempt(attempt telemetry.RefreshAttempt) telemetry.RefreshAttempt {
+	cloned := attempt
+	cloned.RequestedAt = timePointerValue(attempt.RequestedAt)
+	cloned.StartedAt = timePointerValue(attempt.StartedAt)
+	cloned.CompletedAt = timePointerValue(attempt.CompletedAt)
+	cloned.LastErrorAt = timePointerValue(attempt.LastErrorAt)
+	cloned.Operations = append([]string(nil), attempt.Operations...)
+	return cloned
+}
+
+func timePointerValue(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := value.UTC()
+	return &cloned
 }
 
 func cloneIssueMap(issues map[string]connector.Issue) map[string]connector.Issue {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -2,9 +2,11 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type tickPreviousState struct {
@@ -29,9 +31,26 @@ type tickTransitionRefresh struct {
 }
 
 func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
+	o.tickWithManual(ctx, state, now, nil)
+}
+
+func (o *Orchestrator) tickManual(ctx context.Context, state *State, request manualRefreshRequest) {
+	o.tickWithManual(ctx, state, request.requestedAt, &request)
+}
+
+func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now time.Time, manual *manualRefreshRequest) {
+	if manual != nil {
+		startManualRefresh(state, *manual, now)
+	}
+	completed := false
 	previous := captureTickPreviousState(state)
 	o.markRefresh(state, now)
-	defer o.finishRefresh(state, now)
+	defer func() {
+		o.finishRefresh(state, now)
+		if manual != nil {
+			finishManualRefresh(state, *manual, completed)
+		}
+	}()
 
 	if pause := o.gitHubGraphQLPause(state, now); pause > 0 {
 		o.logger.Warn("github graphql polling paused", "remaining", gitHubGraphQLRemaining(state), "pause", pause)
@@ -93,6 +112,74 @@ func (o *Orchestrator) tick(ctx context.Context, state *State, now time.Time) {
 	)
 	state.BoardIssues = boardIssuesFromFetched(fetched)
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
+	completed = true
+}
+
+func startManualRefresh(state *State, request manualRefreshRequest, now time.Time) {
+	if state == nil {
+		return
+	}
+	requestedAt := request.requestedAt.UTC()
+	startedAt := now.UTC()
+	state.ManualRefresh = telemetry.RefreshAttempt{
+		ID:          request.id,
+		Status:      telemetry.RefreshAttemptStatusInProgress,
+		RequestedAt: &requestedAt,
+		StartedAt:   &startedAt,
+		Operations:  append([]string(nil), request.operations...),
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      startedAt,
+		Event:   "manual_refresh_started",
+		Message: "manual refresh " + request.id + " started",
+	})
+}
+
+func finishManualRefresh(state *State, request manualRefreshRequest, completed bool) {
+	if state == nil {
+		return
+	}
+	completedAt := time.Now().UTC()
+	manual := state.ManualRefresh
+	if strings.TrimSpace(manual.ID) != request.id {
+		manual = telemetry.RefreshAttempt{
+			ID:          request.id,
+			RequestedAt: timePointer(request.requestedAt),
+			StartedAt:   timePointer(request.requestedAt),
+			Operations:  append([]string(nil), request.operations...),
+		}
+	}
+	manual.CompletedAt = &completedAt
+	if completed && strings.TrimSpace(state.LastRefreshError) == "" && state.LastRefreshErrorAt.IsZero() {
+		manual.Status = telemetry.RefreshAttemptStatusSucceeded
+		manual.LastError = ""
+		manual.LastErrorAt = nil
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      completedAt,
+			Event:   "manual_refresh_succeeded",
+			Message: "manual refresh " + request.id + " succeeded",
+		})
+		state.ManualRefresh = manual
+		return
+	}
+
+	manual.Status = telemetry.RefreshAttemptStatusFailed
+	manual.LastError = strings.TrimSpace(state.LastRefreshError)
+	if manual.LastError == "" {
+		manual.LastError = "manual refresh did not complete"
+	}
+	errorAt := state.LastRefreshErrorAt
+	if errorAt.IsZero() {
+		errorAt = completedAt
+	}
+	errorAt = errorAt.UTC()
+	manual.LastErrorAt = &errorAt
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      completedAt,
+		Event:   "manual_refresh_failed",
+		Message: "manual refresh " + request.id + " failed: " + manual.LastError,
+	})
+	state.ManualRefresh = manual
 }
 
 func captureTickPreviousState(state *State) tickPreviousState {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -92,13 +92,47 @@ const (
 	RefreshStatusDegraded     RefreshStatus = "degraded"
 )
 
+type RefreshAttemptStatus string
+
+const (
+	RefreshAttemptStatusInProgress RefreshAttemptStatus = "in_progress"
+	RefreshAttemptStatusCoalesced  RefreshAttemptStatus = "coalesced"
+	RefreshAttemptStatusSucceeded  RefreshAttemptStatus = "succeeded"
+	RefreshAttemptStatusFailed     RefreshAttemptStatus = "failed"
+)
+
 type Refresh struct {
-	PollIntervalSeconds int64         `json:"poll_interval_seconds,omitempty"`
-	Status              RefreshStatus `json:"status,omitempty"`
-	LastRefreshAt       *time.Time    `json:"last_refresh_at,omitempty"`
-	NextRefreshAt       *time.Time    `json:"next_refresh_at,omitempty"`
-	LastError           string        `json:"last_error,omitempty"`
-	LastErrorAt         *time.Time    `json:"last_error_at,omitempty"`
+	PollIntervalSeconds int64           `json:"poll_interval_seconds,omitempty"`
+	Status              RefreshStatus   `json:"status,omitempty"`
+	LastRefreshAt       *time.Time      `json:"last_refresh_at,omitempty"`
+	NextRefreshAt       *time.Time      `json:"next_refresh_at,omitempty"`
+	LastError           string          `json:"last_error,omitempty"`
+	LastErrorAt         *time.Time      `json:"last_error_at,omitempty"`
+	Manual              *RefreshAttempt `json:"manual,omitempty"`
+}
+
+type RefreshAttempt struct {
+	ID          string               `json:"id,omitempty"`
+	Status      RefreshAttemptStatus `json:"status,omitempty"`
+	RequestedAt *time.Time           `json:"requested_at,omitempty"`
+	StartedAt   *time.Time           `json:"started_at,omitempty"`
+	CompletedAt *time.Time           `json:"completed_at,omitempty"`
+	Operations  []string             `json:"operations,omitempty"`
+	Coalesced   bool                 `json:"coalesced,omitempty"`
+	LastError   string               `json:"last_error,omitempty"`
+	LastErrorAt *time.Time           `json:"last_error_at,omitempty"`
+}
+
+func (a RefreshAttempt) IsZero() bool {
+	return strings.TrimSpace(a.ID) == "" &&
+		a.Status == "" &&
+		a.RequestedAt == nil &&
+		a.StartedAt == nil &&
+		a.CompletedAt == nil &&
+		len(a.Operations) == 0 &&
+		!a.Coalesced &&
+		strings.TrimSpace(a.LastError) == "" &&
+		a.LastErrorAt == nil
 }
 
 func (r Refresh) ReadinessStatus() RefreshStatus {

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -55,6 +55,7 @@ func (s *Server) apiState(c echo.Context) error {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
 	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
+	snapshot = s.withManualRefresh(snapshot)
 
 	return c.JSON(http.StatusOK, stateResponse(snapshot, generatedAt(snapshot, now), s.instanceName()))
 }
@@ -98,6 +99,7 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
 	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
+	snapshot = s.withManualRefresh(snapshot)
 	projects := s.projectSmallMultiples(c.Request().Context(), snapshot)
 	project, ok := s.dashboardProject(projectID, projects, snapshot)
 	if !ok {
@@ -197,8 +199,21 @@ func (s *Server) apiRefresh(c echo.Context) error {
 	if payload.RequestedAt.IsZero() {
 		payload.RequestedAt = apiNow()
 	}
+	if payload.RequestID == "" {
+		payload.RequestID = "manual-" + strconv.FormatInt(payload.RequestedAt.UnixNano(), 10)
+	}
+	if payload.Status == "" {
+		if payload.Coalesced {
+			payload.Status = telemetry.RefreshAttemptStatusCoalesced
+		} else if payload.Queued {
+			payload.Status = telemetry.RefreshAttemptStatusInProgress
+		}
+	}
 	if payload.Operations == nil {
 		payload.Operations = []string{}
+	}
+	if s.refreshes != nil {
+		s.refreshes.recordResponse(payload)
 	}
 
 	return c.JSON(http.StatusAccepted, payload)

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -99,7 +99,6 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 		return c.JSON(http.StatusOK, snapshotErrorResponse(now, "snapshot_unavailable", "Snapshot unavailable"))
 	}
 	snapshot = s.cachedEnrichedSnapshot(c.Request().Context(), snapshot)
-	snapshot = s.withManualRefresh(snapshot)
 	projects := s.projectSmallMultiples(c.Request().Context(), snapshot)
 	project, ok := s.dashboardProject(projectID, projects, snapshot)
 	if !ok {
@@ -110,6 +109,7 @@ func (s *Server) apiProjectState(c echo.Context, projectID string) error {
 		DisplayName: project.Name,
 		URL:         project.URL,
 	})
+	scopedSnapshot = s.withManualRefresh(scopedSnapshot)
 
 	return c.JSON(http.StatusOK, stateResponse(scopedSnapshot, generatedAt(scopedSnapshot, now), s.instanceName()))
 }

--- a/internal/web/refresh_tracker.go
+++ b/internal/web/refresh_tracker.go
@@ -1,0 +1,165 @@
+package web
+
+import (
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type manualRefreshTracker struct {
+	mu     sync.Mutex
+	latest *telemetry.RefreshAttempt
+}
+
+func newManualRefreshTracker() *manualRefreshTracker {
+	return &manualRefreshTracker{}
+}
+
+func (t *manualRefreshTracker) recordResponse(response RefreshResponse) {
+	if t == nil {
+		return
+	}
+	attempt := telemetry.RefreshAttempt{
+		ID:          strings.TrimSpace(response.RequestID),
+		Status:      response.Status,
+		RequestedAt: optionalRefreshTime(response.RequestedAt),
+		Operations:  append([]string(nil), response.Operations...),
+		Coalesced:   response.Coalesced,
+	}
+	if attempt.Status == "" {
+		if response.Coalesced {
+			attempt.Status = telemetry.RefreshAttemptStatusCoalesced
+		} else if response.Queued {
+			attempt.Status = telemetry.RefreshAttemptStatusInProgress
+		}
+	}
+	if attempt.IsZero() {
+		return
+	}
+	t.recordAttempt(attempt)
+}
+
+func (t *manualRefreshTracker) apply(snapshot telemetry.Snapshot) telemetry.Snapshot {
+	if t == nil {
+		return snapshot
+	}
+	if snapshot.Refresh.Manual != nil {
+		t.recordAttempt(*snapshot.Refresh.Manual)
+	}
+	t.mu.Lock()
+	latest := cloneRefreshAttemptPtr(t.latest)
+	t.mu.Unlock()
+	if latest == nil {
+		return snapshot
+	}
+	if snapshot.Refresh.Manual == nil || refreshAttemptNewer(latest, snapshot.Refresh.Manual) {
+		snapshot.Refresh.Manual = latest
+	}
+	return snapshot
+}
+
+func (t *manualRefreshTracker) recordAttempt(attempt telemetry.RefreshAttempt) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	if t.latest == nil || refreshAttemptNewer(&attempt, t.latest) {
+		t.latest = cloneRefreshAttemptPtr(&attempt)
+	}
+}
+
+func (s *Server) withManualRefresh(snapshot telemetry.Snapshot) telemetry.Snapshot {
+	if s == nil || s.refreshes == nil {
+		return snapshot
+	}
+	return s.refreshes.apply(snapshot)
+}
+
+func refreshAttemptNewer(candidate *telemetry.RefreshAttempt, current *telemetry.RefreshAttempt) bool {
+	if candidate == nil {
+		return false
+	}
+	if current == nil {
+		return true
+	}
+	if strings.TrimSpace(candidate.ID) != "" && strings.TrimSpace(candidate.ID) == strings.TrimSpace(current.ID) {
+		if refreshAttemptRank(candidate.Status) != refreshAttemptRank(current.Status) {
+			return refreshAttemptRank(candidate.Status) > refreshAttemptRank(current.Status)
+		}
+		return refreshAttemptLatestTime(candidate).After(refreshAttemptLatestTime(current))
+	}
+	return refreshAttemptSortTime(candidate).After(refreshAttemptSortTime(current))
+}
+
+func refreshAttemptRank(status telemetry.RefreshAttemptStatus) int {
+	switch status {
+	case telemetry.RefreshAttemptStatusSucceeded, telemetry.RefreshAttemptStatusFailed:
+		return 3
+	case telemetry.RefreshAttemptStatusCoalesced:
+		return 2
+	case telemetry.RefreshAttemptStatusInProgress:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func refreshAttemptSortTime(attempt *telemetry.RefreshAttempt) time.Time {
+	if attempt == nil {
+		return time.Time{}
+	}
+	for _, value := range []*time.Time{attempt.RequestedAt, attempt.StartedAt, attempt.CompletedAt, attempt.LastErrorAt} {
+		if value != nil && !value.IsZero() {
+			return value.UTC()
+		}
+	}
+	return time.Time{}
+}
+
+func refreshAttemptLatestTime(attempt *telemetry.RefreshAttempt) time.Time {
+	if attempt == nil {
+		return time.Time{}
+	}
+	latest := time.Time{}
+	for _, value := range []*time.Time{attempt.RequestedAt, attempt.StartedAt, attempt.CompletedAt, attempt.LastErrorAt} {
+		if value == nil || value.IsZero() {
+			continue
+		}
+		if latest.IsZero() || value.After(latest) {
+			latest = value.UTC()
+		}
+	}
+	return latest
+}
+
+func cloneRefreshAttemptPtr(attempt *telemetry.RefreshAttempt) *telemetry.RefreshAttempt {
+	if attempt == nil {
+		return nil
+	}
+	cloned := *attempt
+	cloned.RequestedAt = cloneTimePtr(attempt.RequestedAt)
+	cloned.StartedAt = cloneTimePtr(attempt.StartedAt)
+	cloned.CompletedAt = cloneTimePtr(attempt.CompletedAt)
+	cloned.LastErrorAt = cloneTimePtr(attempt.LastErrorAt)
+	cloned.Operations = append([]string(nil), attempt.Operations...)
+	return &cloned
+}
+
+func cloneTimePtr(value *time.Time) *time.Time {
+	if value == nil || value.IsZero() {
+		return nil
+	}
+	cloned := value.UTC()
+	return &cloned
+}
+
+func optionalRefreshTime(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -107,6 +107,7 @@ type Server struct {
 	projects            *projectSmallMultipleRecorder
 	snapshots           *snapshotEnrichmentCache
 	kanbanMutations     *kanbanMutationLocks
+	refreshes           *manualRefreshTracker
 	demo                *demoScenarioSet
 }
 
@@ -164,6 +165,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		projects:            newProjectSmallMultipleRecorder(),
 		snapshots:           newSnapshotEnrichmentCache(),
 		kanbanMutations:     newKanbanMutationLocks(),
+		refreshes:           newManualRefreshTracker(),
 		demo:                newDemoScenarioSet(cfg.Demo),
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
@@ -449,9 +451,9 @@ func (s *Server) sidebarProjectContext(selectedProjectID string, projects []temp
 func (s *Server) latestSnapshot(ctx context.Context) telemetry.Snapshot {
 	snapshot, ok := s.hub.Latest()
 	if !ok {
-		return s.enrichSnapshot(ctx, telemetry.Snapshot{})
+		return s.withManualRefresh(s.enrichSnapshot(ctx, telemetry.Snapshot{}))
 	}
-	return s.cachedEnrichedSnapshot(ctx, snapshot)
+	return s.withManualRefresh(s.cachedEnrichedSnapshot(ctx, snapshot))
 }
 
 func (s *Server) health(c echo.Context) error {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4965,6 +4965,66 @@ func TestServerAPIRoutes(t *testing.T) {
 	}
 }
 
+func TestAPIRefreshOverlaysManualRequestOnStaleDegradedState(t *testing.T) {
+	t.Parallel()
+
+	generatedAt := time.Date(2026, 6, 24, 14, 0, 0, 0, time.UTC)
+	requestedAt := generatedAt.Add(5 * time.Minute)
+	lastErrorAt := generatedAt.Add(-time.Minute)
+	snapshots := hub.New[telemetry.Snapshot]()
+	if err := snapshots.Publish(telemetry.Snapshot{
+		GeneratedAt: generatedAt,
+		Refresh: telemetry.Refresh{
+			Status:      telemetry.RefreshStatusDegraded,
+			LastError:   "fetch workspace cleanup candidates failed: status 504",
+			LastErrorAt: &lastErrorAt,
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	refresher := &refreshProbe{
+		response: web.RefreshResponse{
+			RequestID:   "manual-681",
+			Status:      telemetry.RefreshAttemptStatusInProgress,
+			Queued:      true,
+			RequestedAt: requestedAt,
+			Operations:  []string{"poll", "reconcile"},
+		},
+	}
+	deps := testDeps(t)
+	deps.Hub = snapshots
+	deps.Refresher = refresher
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	refresh := requestJSON(t, server, http.MethodPost, "/api/v1/refresh", http.StatusAccepted)
+	if refresh["request_id"] != "manual-681" || refresh["status"] != string(telemetry.RefreshAttemptStatusInProgress) {
+		t.Fatalf("refresh response = %#v, want correlated in-progress manual refresh", refresh)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	if state["generated_at"] != generatedAt.Format(time.RFC3339) {
+		t.Fatalf("generated_at = %#v, want stale snapshot timestamp %s", state["generated_at"], generatedAt.Format(time.RFC3339))
+	}
+	refreshState := state["refresh"].(map[string]any)
+	if refreshState["status"] != string(telemetry.RefreshStatusDegraded) {
+		t.Fatalf("refresh.status = %#v, want degraded", refreshState["status"])
+	}
+	manual := refreshState["manual"].(map[string]any)
+	if manual["id"] != "manual-681" || manual["status"] != string(telemetry.RefreshAttemptStatusInProgress) {
+		t.Fatalf("refresh.manual = %#v, want manual-681 in progress", manual)
+	}
+	if manual["requested_at"] != requestedAt.Format(time.RFC3339) {
+		t.Fatalf("manual.requested_at = %#v, want %s", manual["requested_at"], requestedAt.Format(time.RFC3339))
+	}
+	if operations := manual["operations"].([]any); len(operations) != 2 || operations[0] != "poll" || operations[1] != "reconcile" {
+		t.Fatalf("manual.operations = %#v, want poll/reconcile", manual["operations"])
+	}
+}
+
 func TestServerEnrichesBudgetBurnDownFromStoreAndRegistry(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -4979,6 +4979,16 @@ func TestAPIRefreshOverlaysManualRequestOnStaleDegradedState(t *testing.T) {
 			LastError:   "fetch workspace cleanup candidates failed: status 504",
 			LastErrorAt: &lastErrorAt,
 		},
+		Projects: []telemetry.ProjectSnapshot{
+			{
+				Project: telemetry.Project{ID: "detent", DisplayName: "Detent"},
+				Refresh: telemetry.Refresh{
+					Status:      telemetry.RefreshStatusDegraded,
+					LastError:   "fetch workspace cleanup candidates failed: status 504",
+					LastErrorAt: &lastErrorAt,
+				},
+			},
+		},
 	}); err != nil {
 		t.Fatalf("Publish() error = %v", err)
 	}
@@ -5022,6 +5032,13 @@ func TestAPIRefreshOverlaysManualRequestOnStaleDegradedState(t *testing.T) {
 	}
 	if operations := manual["operations"].([]any); len(operations) != 2 || operations[0] != "poll" || operations[1] != "reconcile" {
 		t.Fatalf("manual.operations = %#v, want poll/reconcile", manual["operations"])
+	}
+
+	projectState := requestJSON(t, server, http.MethodGet, "/api/v1/projects/detent/state", http.StatusOK)
+	projectRefresh := projectState["refresh"].(map[string]any)
+	projectManual := projectRefresh["manual"].(map[string]any)
+	if projectManual["id"] != "manual-681" || projectManual["status"] != string(telemetry.RefreshAttemptStatusInProgress) {
+		t.Fatalf("project refresh.manual = %#v, want manual-681 in progress", projectManual)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add manual refresh request IDs/status and publish terminal outcomes in refresh telemetry.
- Overlay the latest accepted manual refresh on stale state responses so degraded snapshots show in-progress/coalesced requests.
- Add regression coverage for stale degraded state, successful manual outcome, and repeated degraded failure metadata.

Fixes #681

## Test Plan

- [x] `go test ./internal/telemetry`
- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/web`
- [x] `go test ./internal/cli`
- [x] `make check`