### PR TITLE
fix(orchestrator): reconcile stale merging

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -177,13 +177,10 @@ func staleMergingPullRequestDecisionForIssue(issue connector.Issue, terminalStat
 		if autoPromoteMergeConflicts(pullRequest.MergeableState) {
 			return staleMergingPullRequestDecision{targetState: autoPromoteReworkState, reason: string(AutoPromoteReasonMergeConflicts)}
 		}
-		if staleMergingCIGreen(pullRequest.CIStatus) {
-			return staleMergingPullRequestDecision{}
-		}
 		if staleMergingCIRed(pullRequest.CIStatus) {
 			return staleMergingPullRequestDecision{targetState: autoPromoteReworkState, reason: string(AutoPromoteReasonCINotGreen)}
 		}
-		return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: string(AutoPromoteReasonCINotGreen)}
+		return staleMergingPullRequestDecision{}
 	default:
 		return staleMergingPullRequestDecision{targetState: autoPromoteReworkState, reason: "pull_request_not_open"}
 	}

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -137,7 +137,7 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 		if issueID == "" {
 			continue
 		}
-		if staleMergingPullRequestAlreadyRunning(state, issueID) {
+		if staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
 		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg.TerminalStates)
@@ -333,12 +333,20 @@ func mergeWorkerLogAttrs(issue connector.Issue, attrs ...any) []any {
 	return append(out, attrs...)
 }
 
-func staleMergingPullRequestAlreadyRunning(state *State, issueID string) bool {
+func staleMergingPullRequestDispatchActive(state *State, issueID string) bool {
 	if state == nil {
 		return false
 	}
-	_, ok := state.Running[issueID]
-	return ok
+	if _, ok := state.Running[issueID]; ok {
+		return true
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		return true
+	}
+	if _, ok := state.Retry[issueID]; ok {
+		return true
+	}
+	return false
 }
 
 func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []connector.Issue) []connector.Issue {
@@ -352,7 +360,7 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 		if issueID == "" {
 			continue
 		}
-		if staleMergingPullRequestAlreadyRunning(state, issueID) {
+		if staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
 		o.clearAutoPromotedIssueDispatchMemory(state, issueID)

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -18,7 +18,13 @@ const (
 )
 
 type autoPromoteTickResult struct {
-	transitioned map[string]struct{}
+	transitioned       map[string]struct{}
+	dispatchCandidates []connector.Issue
+}
+
+type staleMergingPullRequestDecision struct {
+	targetState string
+	reason      string
 }
 
 func (o *Orchestrator) autoPromoteHumanReviewIssues(
@@ -68,6 +74,12 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		}
 		result.transitioned[issueID] = struct{}{}
 		o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+		if targetState == autoPromoteMergingState {
+			promoted := cloneIssue(issue)
+			promoted.State = targetState
+			result.dispatchCandidates = append(result.dispatchCandidates, promoted)
+			o.logMergeWorkerPickup(promoted, "auto_promote")
+		}
 	}
 	if len(result.transitioned) == 0 {
 		return autoPromoteTickResult{}
@@ -113,6 +125,246 @@ func (o *Orchestrator) reconcileStaleTodoPullRequestIssues(
 	return transitioned
 }
 
+func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) map[string]struct{} {
+	transitioned := map[string]struct{}{}
+	for _, issue := range issuesInStates(issues, []string{autoPromoteMergingState}) {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+		if staleMergingPullRequestAlreadyRunning(state, issueID) {
+			continue
+		}
+		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg.TerminalStates)
+		if decision.targetState == "" {
+			continue
+		}
+		if !o.applyStaleMergingPullRequestDecision(ctx, state, issue, decision, now) {
+			continue
+		}
+		transitioned[issueID] = struct{}{}
+		o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+	}
+	if len(transitioned) == 0 {
+		return nil
+	}
+	return transitioned
+}
+
+func staleMergingPullRequestDecisionForIssue(issue connector.Issue, terminalStates []string) staleMergingPullRequestDecision {
+	if strings.TrimSpace(issue.ID) == "" {
+		return staleMergingPullRequestDecision{}
+	}
+	if closedCompletedIssueNeedsStatusReconciliation(issue, terminalStates) {
+		return staleMergingPullRequestDecision{targetState: doneStateName(terminalStates), reason: "issue_closed_completed"}
+	}
+	pullRequest := issue.PullRequest
+	if pullRequest == nil {
+		return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: string(AutoPromoteReasonMissingPullRequest)}
+	}
+	switch normalizePullRequestState(pullRequest.State) {
+	case "merged":
+		return staleMergingPullRequestDecision{targetState: doneStateName(terminalStates), reason: "pull_request_merged"}
+	case "open":
+		if pullRequest.Draft {
+			return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: "draft_pull_request"}
+		}
+		if autoPromoteMergeConflicts(pullRequest.MergeableState) {
+			return staleMergingPullRequestDecision{targetState: autoPromoteReworkState, reason: string(AutoPromoteReasonMergeConflicts)}
+		}
+		if staleMergingCIGreen(pullRequest.CIStatus) {
+			return staleMergingPullRequestDecision{}
+		}
+		if staleMergingCIRed(pullRequest.CIStatus) {
+			return staleMergingPullRequestDecision{targetState: autoPromoteReworkState, reason: string(AutoPromoteReasonCINotGreen)}
+		}
+		return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: string(AutoPromoteReasonCINotGreen)}
+	default:
+		return staleMergingPullRequestDecision{targetState: autoPromoteReworkState, reason: "pull_request_not_open"}
+	}
+}
+
+func (o *Orchestrator) applyStaleMergingPullRequestDecision(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	decision staleMergingPullRequestDecision,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	if err := o.connector.UpdateIssueState(ctx, issueID, decision.targetState); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"stale_merging_pr_reconciliation_failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"reason", decision.reason,
+				"target_state", decision.targetState,
+				"error", err,
+			)
+		}
+		return false
+	}
+
+	body := staleMergingPullRequestComment(issue, decision)
+	if strings.TrimSpace(body) != "" {
+		if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+			o.logger.Warn(
+				"stale_merging_pr_reconciliation_comment_failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"reason", decision.reason,
+				"target_state", decision.targetState,
+				"error", err,
+			)
+		}
+	}
+
+	o.logStaleMergingPullRequestDecision(issue, decision)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "stale_merging_pr_reconciled",
+		Message: "reconciled stale Merging PR for " + issueLabel(issue) + " to " + decision.targetState + ": " + decision.reason,
+	})
+	return true
+}
+
+func staleMergingPullRequestComment(issue connector.Issue, decision staleMergingPullRequestDecision) string {
+	var b strings.Builder
+	b.WriteString("Reconciled this issue from Merging to ")
+	b.WriteString(decision.targetState)
+	b.WriteString(".")
+	b.WriteString("\n\n- reason: ")
+	b.WriteString(decision.reason)
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			b.WriteString("\n- pull request: ")
+			b.WriteString(url)
+		}
+		if mergeableState := strings.ToLower(strings.TrimSpace(issue.PullRequest.MergeableState)); mergeableState != "" {
+			b.WriteString("\n- mergeable_state: ")
+			b.WriteString(mergeableState)
+		}
+		if ciStatus := strings.TrimSpace(issue.PullRequest.CIStatus); ciStatus != "" {
+			b.WriteString("\n- ci_status: ")
+			b.WriteString(ciStatus)
+		}
+	}
+	return b.String()
+}
+
+func (o *Orchestrator) logStaleMergingPullRequestDecision(issue connector.Issue, decision staleMergingPullRequestDecision) {
+	if o.logger == nil {
+		return
+	}
+	attrs := mergeWorkerLogAttrs(issue,
+		"reason", decision.reason,
+		"target_state", decision.targetState,
+	)
+	o.logger.Info("stale_merging_pr_reconciled", attrs...)
+}
+
+func (o *Orchestrator) logMergeWorkerPickup(issue connector.Issue, source string) {
+	if o.logger == nil || !mergeWorkerIssue(issue) {
+		return
+	}
+	attrs := mergeWorkerLogAttrs(issue, "source", strings.TrimSpace(source))
+	o.logger.Info("merge_worker_pickup", attrs...)
+}
+
+func (o *Orchestrator) logMergeWorkerAttempt(issue connector.Issue, attempt int, workerHost string) {
+	if o.logger == nil || !mergeWorkerIssue(issue) {
+		return
+	}
+	attrs := mergeWorkerLogAttrs(issue,
+		"attempt", attempt,
+		"worker_host", strings.TrimSpace(workerHost),
+	)
+	o.logger.Info("merge_worker_attempt", attrs...)
+}
+
+func (o *Orchestrator) logMergeWorkerSuccess(issue connector.Issue, finalState string) {
+	if o.logger == nil || !mergeWorkerIssue(issue) {
+		return
+	}
+	attrs := mergeWorkerLogAttrs(issue, "final_state", strings.TrimSpace(finalState))
+	o.logger.Info("merge_worker_success", attrs...)
+}
+
+func (o *Orchestrator) logMergeWorkerFailure(issue connector.Issue, reason string, err error) {
+	if o.logger == nil || !mergeWorkerIssue(issue) {
+		return
+	}
+	attrs := mergeWorkerLogAttrs(issue, "reason", strings.TrimSpace(reason))
+	if err != nil {
+		attrs = append(attrs, "error", err)
+	}
+	o.logger.Warn("merge_worker_failure", attrs...)
+}
+
+func mergeWorkerIssue(issue connector.Issue) bool {
+	return normalizeState(issue.State) == normalizeState(autoPromoteMergingState)
+}
+
+func mergeWorkerLogAttrs(issue connector.Issue, attrs ...any) []any {
+	out := []any{
+		"issue_id", strings.TrimSpace(issue.ID),
+		"identifier", issue.Identifier,
+	}
+	if issue.PullRequest != nil {
+		if issue.PullRequest.Number > 0 {
+			out = append(out, "pull_request_number", issue.PullRequest.Number)
+		}
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			out = append(out, "pull_request", url)
+		}
+		if mergeableState := strings.TrimSpace(issue.PullRequest.MergeableState); mergeableState != "" {
+			out = append(out, "mergeable_state", strings.ToLower(mergeableState))
+		}
+		if ciStatus := strings.TrimSpace(issue.PullRequest.CIStatus); ciStatus != "" {
+			out = append(out, "ci_status", ciStatus)
+		}
+		if headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA); headSHA != "" {
+			out = append(out, "head_sha", headSHA)
+		}
+	}
+	return append(out, attrs...)
+}
+
+func staleMergingPullRequestAlreadyRunning(state *State, issueID string) bool {
+	if state == nil {
+		return false
+	}
+	_, ok := state.Running[issueID]
+	return ok
+}
+
+func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []connector.Issue) []connector.Issue {
+	candidates := staleMergingDispatchCandidates(issues)
+	if len(candidates) == 0 {
+		return nil
+	}
+	out := make([]connector.Issue, 0, len(candidates))
+	for _, issue := range candidates {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+		if staleMergingPullRequestAlreadyRunning(state, issueID) {
+			continue
+		}
+		o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+		o.logMergeWorkerPickup(issue, "stale_merging")
+		out = append(out, issue)
+	}
+	return out
+}
+
 func staleMergingDispatchCandidates(issues []connector.Issue) []connector.Issue {
 	candidates := []connector.Issue{}
 	for _, issue := range issuesInStates(issues, []string{autoPromoteMergingState}) {
@@ -144,6 +396,15 @@ func staleMergingIssueReadyForDispatch(issue connector.Issue) bool {
 func staleMergingCIGreen(status string) bool {
 	switch strings.ToLower(strings.TrimSpace(status)) {
 	case "green", "pass", "passed", "success", "successful":
+		return true
+	default:
+		return false
+	}
+}
+
+func staleMergingCIRed(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "red", "fail", "failed", "failure", "error", "cancelled", "canceled":
 		return true
 	default:
 		return false
@@ -260,9 +521,13 @@ func (o *Orchestrator) logStaleTodoPullRequestDecision(issue connector.Issue, de
 }
 
 func (o *Orchestrator) clearAutoPromotedIssueDispatchMemory(state *State, issueID string) {
+	if state == nil {
+		return
+	}
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.Blocked, issueID)
+	delete(state.Completed, issueID)
 }
 
 func (o *Orchestrator) startValidatorStage(ctx context.Context, issue connector.Issue, now time.Time) {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -715,6 +715,15 @@ func TestTickReconcilesStaleMergingPullRequestStates(t *testing.T) {
 	})
 	conflicting.State = "Merging"
 	conflicting.Identifier = "digitaldrywood/creswoodcorners-phone#64"
+	pending := autoPromoteTickIssue("issue-pending-merging", []string{"bug"}, &connector.PullRequest{
+		Number:         74,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/74",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "pending",
+	})
+	pending.State = "Merging"
+	pending.Identifier = "digitaldrywood/creswoodcorners-phone#66"
 	cfg := normalizeConfig(Config{
 		PollInterval:        time.Minute,
 		MaxConcurrentAgents: 1,
@@ -729,7 +738,7 @@ func TestTickReconcilesStaleMergingPullRequestStates(t *testing.T) {
 		TerminalStates: []string{"Done", "Cancelled"},
 	})
 	tracker := &autoPromoteTickConnector{
-		stateIssues:        []connector.Issue{merged, conflicting},
+		stateIssues:        []connector.Issue{merged, conflicting, pending},
 		candidateIssuesSet: true,
 	}
 	var logs strings.Builder

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -926,6 +926,53 @@ func TestStaleMergingDispatchCandidatesFiltersUnsafePullRequests(t *testing.T) {
 	}
 }
 
+func TestMergeWorkerDispatchCandidatesPreservesScheduledRetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 24, 20, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-retrying-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         74,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/74",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.State = "Merging"
+	state := newState(cfg)
+	state.Claimed[issue.ID] = Claimed{
+		Issue:     cloneIssue(issue),
+		ClaimedAt: now.Add(-time.Minute),
+	}
+	state.Retry[issue.ID] = Retry{
+		Issue:   cloneIssue(issue),
+		Attempt: 2,
+		DueAt:   now.Add(time.Hour),
+		Error:   "merge worker failed",
+	}
+	orch := &Orchestrator{cfg: cfg}
+
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{issue})
+	if len(got) != 0 {
+		t.Fatalf("mergeWorkerDispatchCandidates() = %#v, want none while retry is scheduled", got)
+	}
+	if claimed, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing after stale Merging dispatch candidate scan", issue.ID)
+	} else if claimed.Issue.ID != issue.ID {
+		t.Fatalf("Claimed[%q].Issue.ID = %q, want %q", issue.ID, claimed.Issue.ID, issue.ID)
+	}
+	if retry, ok := state.Retry[issue.ID]; !ok {
+		t.Fatalf("Retry[%q] missing after stale Merging dispatch candidate scan", issue.ID)
+	} else if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 2", issue.ID, retry.Attempt)
+	}
+}
+
 func TestTickAutoPromoteMergingIssueDispatchesAndClearsStaleMemory(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"reflect"
@@ -236,6 +237,8 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 				TerminalStates:      []string{"Done", "Cancelled"},
 			})
 			state := newState(cfg)
+			mergingSlot := dispatchTestIssue("issue-merging-slot", "Merging")
+			state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
 			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{tt.issue}}
 			var logs strings.Builder
 			orch := &Orchestrator{
@@ -546,6 +549,8 @@ func TestTickAutoPromoteRunsValidatorStage(t *testing.T) {
 		t.Fatalf("validator issue = %#v, want issue-validator", requests[0].Issue)
 	}
 
+	mergingSlot := dispatchTestIssue("issue-validator-merging-slot", "Merging")
+	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
 	orch.tick(context.Background(), &state, now.Add(time.Second))
 
 	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: "issue-validator", state: "Merging"}}; !reflect.DeepEqual(got, want) {
@@ -618,6 +623,222 @@ func TestTickRequeuesObservedStaleMergingIssueForDispatch(t *testing.T) {
 	}
 	if running := state.Running[issue.ID]; running.cancel != nil {
 		running.cancel()
+	}
+}
+
+func TestTickDispatchesFreshAutoPromotedMergingIssue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 24, 17, 27, 1, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-auto-promoted-merging", []string{"bug"}, &connector.PullRequest{
+		Number:                 70,
+		URL:                    "https://github.test/digitaldrywood/creswoodcorners-phone/pull/70",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	issue.Identifier = "digitaldrywood/creswoodcorners-phone#62"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	runner := newWorkerHostRunner()
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:        cfg,
+		connector:  tracker,
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+		logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+
+	orch.tick(context.Background(), &state, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.Issue.ID != issue.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
+	}
+	if request.Issue.State != "Merging" {
+		t.Fatalf("RunRequest.Issue.State = %q, want Merging", request.Issue.State)
+	}
+	for _, fragment := range []string{
+		"merge_worker_pickup",
+		"source=auto_promote",
+		"merge_worker_attempt",
+		"pull_request_number=70",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+	if running := state.Running[issue.ID]; running.cancel != nil {
+		running.cancel()
+	}
+}
+
+func TestTickReconcilesStaleMergingPullRequestStates(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 24, 18, 0, 0, 0, time.UTC)
+	merged := autoPromoteTickIssue("issue-merged-pr", []string{"bug"}, &connector.PullRequest{
+		Number:         71,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/71",
+		State:          "MERGED",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	merged.State = "Merging"
+	merged.Identifier = "digitaldrywood/creswoodcorners-phone#63"
+	conflicting := autoPromoteTickIssue("issue-conflicting-merging", []string{"bug"}, &connector.PullRequest{
+		Number:         72,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/72",
+		State:          "OPEN",
+		MergeableState: "DIRTY",
+		CIStatus:       "success",
+	})
+	conflicting.State = "Merging"
+	conflicting.Identifier = "digitaldrywood/creswoodcorners-phone#64"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	tracker := &autoPromoteTickConnector{
+		stateIssues:        []connector.Issue{merged, conflicting},
+		candidateIssuesSet: true,
+	}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:        cfg,
+		connector:  tracker,
+		supervisor: newTestSupervisor(t, newWorkerHostRunner(), cfg),
+		runResults: make(chan runpkg.Completion, 1),
+		logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []autoPromoteTickUpdate{
+		{issueID: "issue-merged-pr", state: "Done"},
+		{issueID: "issue-conflicting-merging", state: "Rework"},
+	}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if len(tracker.comments) != 2 {
+		t.Fatalf("comments = %#v, want two reconciliation comments", tracker.comments)
+	}
+	wantComments := map[string][]string{
+		"issue-merged-pr": {
+			"Reconciled this issue from Merging to Done.",
+			"reason: pull_request_merged",
+			"https://github.test/digitaldrywood/creswoodcorners-phone/pull/71",
+		},
+		"issue-conflicting-merging": {
+			"Reconciled this issue from Merging to Rework.",
+			"reason: merge_conflicts",
+			"mergeable_state: dirty",
+			"https://github.test/digitaldrywood/creswoodcorners-phone/pull/72",
+		},
+	}
+	for _, comment := range tracker.comments {
+		for _, fragment := range wantComments[comment.issueID] {
+			if !strings.Contains(comment.body, fragment) {
+				t.Fatalf("comment for %s = %q, missing %q", comment.issueID, comment.body, fragment)
+			}
+		}
+	}
+	for _, fragment := range []string{
+		"stale_merging_pr_reconciled",
+		"reason=pull_request_merged",
+		"reason=merge_conflicts",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}
+
+func TestMergeWorkerLogsRunResultSuccessAndFailure(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 24, 19, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-merge-log", []string{"bug"}, &connector.PullRequest{
+		Number:         73,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/73",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/creswoodcorners-phone#65"
+
+	var failureLogs strings.Builder
+	failureState := newState(cfg)
+	failureState.Running[issue.ID] = Running{Issue: cloneIssue(issue), StartedAt: now.Add(-time.Minute)}
+	failureOrch := &Orchestrator{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(&failureLogs, nil)),
+	}
+	failureOrch.handleRunResult(context.Background(), &failureState, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Err:         errors.New("merge command failed"),
+	})
+	for _, fragment := range []string{"merge_worker_failure", "reason=runner_failed", "merge command failed"} {
+		if !strings.Contains(failureLogs.String(), fragment) {
+			t.Fatalf("failure logs %q missing fragment %q", failureLogs.String(), fragment)
+		}
+	}
+
+	var successLogs strings.Builder
+	successIssue := cloneIssue(issue)
+	successIssue.Closed = true
+	successIssue.ClosedReason = "completed"
+	successState := newState(cfg)
+	successState.Running[successIssue.ID] = Running{Issue: cloneIssue(successIssue), StartedAt: now.Add(-time.Minute)}
+	successOrch := &Orchestrator{
+		cfg:       cfg,
+		connector: &autoPromoteTickConnector{stateIssues: []connector.Issue{successIssue}},
+		logger:    slog.New(slog.NewTextHandler(&successLogs, nil)),
+	}
+	successOrch.completeTerminalRunning(context.Background(), &successState, successIssue.ID, successState.Running[successIssue.ID], now, CodexTotals{})
+	for _, fragment := range []string{"merge_worker_success", "final_state=Done", "pull_request_number=73"} {
+		if !strings.Contains(successLogs.String(), fragment) {
+			t.Fatalf("success logs %q missing fragment %q", successLogs.String(), fragment)
+		}
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1411,17 +1411,20 @@ func (o *Orchestrator) dispatchIssue(
 
 	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
 	if !ok {
+		o.logMergeWorkerFailure(issue, "worker_host_unavailable", nil)
 		return false
 	}
 
 	globalSlot, ok := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now)
 	if !ok {
+		o.logMergeWorkerFailure(issue, "global_slot_unavailable", nil)
 		return false
 	}
 
 	claimedIssue, claim, ok := o.claimIssue(ctx, issue, now)
 	if !ok {
 		o.releaseGlobalDispatchSlot(globalSlot)
+		o.logMergeWorkerFailure(issue, "claim_failed", nil)
 		return false
 	}
 
@@ -1435,6 +1438,7 @@ func (o *Orchestrator) dispatchIssue(
 			if o.logger != nil {
 				o.logger.Warn("start state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 			}
+			o.logMergeWorkerFailure(issue, "start_state_transition_failed", err)
 			return false
 		}
 		issue.State = targetState
@@ -1466,6 +1470,7 @@ func (o *Orchestrator) dispatchIssue(
 		SelectorContext: o.selectorContext(),
 		OnUsageUpdate:   o.usageUpdateHandler(runCtx, issue.ID),
 	}
+	o.logMergeWorkerAttempt(issue, attempt, workerHost)
 	o.supervisor.Dispatch(runCtx, request, o.runResults)
 	return true
 }
@@ -1646,6 +1651,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 
 	if event.Err != nil {
+		if mergeWorkerIssue(running.Issue) {
+			o.logMergeWorkerFailure(running.Issue, "runner_failed", event.Err)
+		}
 		attempt := event.RetryAttempt
 		if attempt < 1 {
 			attempt = nextAttempt(running.Attempt)
@@ -1829,6 +1837,9 @@ func (o *Orchestrator) completeTerminalRunning(
 	state.CodexTotals = addCodexTotals(state.CodexTotals, tokens)
 	if diffStatsPresent(running.DiffStats) {
 		state.DiffStats[issueID] = running.DiffStats
+	}
+	if mergeWorkerIssue(running.Issue) {
+		o.logMergeWorkerSuccess(running.Issue, finalState)
 	}
 	o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates), completedAt)
 }

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -118,9 +118,18 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			fetched,
 			autoPromoted.transitioned,
 		)
+		fetched = filterReconciledTickIssues(
+			state,
+			fetched,
+			o.reconcileStaleMergingPullRequestIssues(ctx, state, fetched.status, now),
+		)
 		fetched.candidates = mergeIssueSlices(
 			fetched.candidates,
-			staleMergingDispatchCandidates(fetched.status),
+			autoPromoted.dispatchCandidates,
+		)
+		fetched.candidates = mergeIssueSlices(
+			fetched.candidates,
+			o.mergeWorkerDispatchCandidates(state, fetched.status),
 		)
 	}
 	fetched = filterReconciledTickIssues(


### PR DESCRIPTION
## Summary
- Dispatch freshly auto-promoted `Merging` issues in the same orchestrator tick instead of waiting for a later status poll.
- Reconcile stale `Merging` PR states: already-merged PRs move to `Done`, conflicting PRs move to `Rework`, and skipped preconditions get persisted issue comments.
- Add structured merge-worker logs for pickup, attempt, success, and failure.
- Keep pending/unknown-CI `Merging` PRs queued so the merge worker can continue waiting instead of emptying active Merging lanes.
- Preserve scheduled merge-worker retry and claim state during stale-status pickup.

Fixes #690

## Test Plan
- `go test ./internal/orchestrator -run 'TestMergeWorkerDispatchCandidatesPreservesScheduledRetry|TestTickDispatchesFreshAutoPromotedMergingIssue|TestTickReconcilesStaleMergingPullRequestStates|TestTickAutoPromoteMergingIssueDispatchesAndClearsStaleMemory|TestStaleMergingDispatchCandidatesFiltersUnsafePullRequests|TestMergeWorkerLogsRunResultSuccessAndFailure' -count=1`
- `go test ./internal/orchestrator -count=1`
- `go test ./...`
- `make check`
- `DETENT_BINARY="$(pwd)/tmp/detent" node_modules/.bin/playwright test tests/visual/layout.spec.js`