### PR TITLE
fix(onboarding): detect stale Detent checkout

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,20 @@ relying on local files. Keep the Detent source repository separate from any
 target repository being onboarded; Detent may be a reference/source repository,
 not the target.
 
+Before reading local Detent docs or trusting local `detent` command
+recommendations, prove any local Detent source checkout is current with the
+canonical repository. Set `DETENT_SOURCE_ROOT` to the local Detent checkout,
+then run `git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main`,
+`git -C "$DETENT_SOURCE_ROOT" rev-parse HEAD`,
+`git -C "$DETENT_SOURCE_ROOT" rev-parse refs/remotes/origin/main`, and
+`detent --format json version`. Report the local source root, local `HEAD`,
+canonical `origin/main`, installed binary version, binary commit, binary build
+date, `DETENT_SOURCE_MATCHES_CANONICAL`, and
+`DETENT_BINARY_MATCHES_CANONICAL` in the initial evidence packet. If the local
+source checkout or installed binary is stale or cannot be proven current, stop
+before reading local docs or making Phase 2 recommendations; update/reinstall
+Detent or explicitly switch to reading docs from GitHub at the canonical head.
+
 From the Detent source repository, read README.md, CLAUDE.md or AGENTS.md if
 present, docs/ONBOARDING.md, CONTRIBUTING.md, build and language manifests,
 .github/workflows, install scripts, and any existing WORKFLOW.md or global.yaml
@@ -42,6 +56,9 @@ Detent install that must be found and verified, or a new repository/project
 being added to an existing Detent install. Distinguish reference repositories from the target repository being onboarded. In Phase 0.5, run
 `detent onboarding draft-answers --output pretty` from the target checkout, or
 pass `--target-source-root` if you are currently in the Detent source checkout.
+When a local Detent checkout is available, also pass
+`--detent-source-root "$DETENT_SOURCE_ROOT"` so the draft records source and
+binary freshness evidence.
 To write the candidate identity record, run
 `detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write`.
 Treat the draft as a candidate, not confirmation. The command should infer and

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -25,6 +25,57 @@ Use these placeholders consistently:
 | `<write-probe-issue>` | Scratch issue reference such as `<repo-owner>/<repo-name>#123` for doctor write probes. |
 | `<detent-project-id>` | Local `global.yaml` project id, such as `api`. |
 
+## Source Freshness Gate
+
+Before relying on a local copy of this runbook, local `README.md`, or local
+`detent` command recommendations, prove the local Detent source checkout is
+current with `digitaldrywood/detent`. If no local Detent source checkout is
+available, read docs from GitHub at the canonical head instead of local
+files.
+
+```sh
+ONBOARDING_DIR="${ONBOARDING_DIR:-${TMPDIR:-/tmp}/detent-onboarding-<repo-owner>-<repo-name>}"
+mkdir -p "$ONBOARDING_DIR"
+DETENT_SOURCE_ROOT="<absolute-local-detent-source-checkout>"
+
+git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main
+DETENT_SOURCE_HEAD="$(git -C "$DETENT_SOURCE_ROOT" rev-parse HEAD)"
+DETENT_CANONICAL_MAIN="$(git -C "$DETENT_SOURCE_ROOT" rev-parse refs/remotes/origin/main)"
+DETENT_VERSION_JSON="$(detent --format json version 2>/dev/null || true)"
+DETENT_BINARY_COMMIT="$(printf '%s\n' "$DETENT_VERSION_JSON" | jq -r '.commit // empty' 2>/dev/null || true)"
+
+if test "$DETENT_SOURCE_HEAD" = "$DETENT_CANONICAL_MAIN"; then
+  DETENT_SOURCE_MATCHES_CANONICAL=true
+else
+  DETENT_SOURCE_MATCHES_CANONICAL=false
+fi
+
+if test -n "$DETENT_BINARY_COMMIT" && test "$DETENT_BINARY_COMMIT" = "$DETENT_CANONICAL_MAIN"; then
+  DETENT_BINARY_MATCHES_CANONICAL=true
+else
+  DETENT_BINARY_MATCHES_CANONICAL=false
+fi
+
+{
+  printf 'DETENT_SOURCE_ROOT=%s\n' "$DETENT_SOURCE_ROOT"
+  printf 'DETENT_SOURCE_HEAD=%s\n' "$DETENT_SOURCE_HEAD"
+  printf 'DETENT_CANONICAL_MAIN=%s\n' "$DETENT_CANONICAL_MAIN"
+  printf 'DETENT_SOURCE_MATCHES_CANONICAL=%s\n' "$DETENT_SOURCE_MATCHES_CANONICAL"
+  printf 'DETENT_BINARY_COMMIT=%s\n' "$DETENT_BINARY_COMMIT"
+  printf 'DETENT_BINARY_MATCHES_CANONICAL=%s\n' "$DETENT_BINARY_MATCHES_CANONICAL"
+  printf 'DETENT_VERSION_JSON=%s\n' "$DETENT_VERSION_JSON"
+} > "$ONBOARDING_DIR/detent-source-freshness.env"
+
+test "$DETENT_SOURCE_MATCHES_CANONICAL" = true
+test "$DETENT_BINARY_MATCHES_CANONICAL" = true
+```
+
+If either check fails, stop before Phase 2 recommendations. Update the local
+source checkout and reinstall the binary, or explicitly read docs from GitHub
+at the canonical head. Include
+`$ONBOARDING_DIR/detent-source-freshness.env` in the initial evidence packet so
+the operator can see which runbook and binary version are being followed.
+
 ## Start Here — Determine The Mode
 
 Do not assume this is a fresh install, and do not silently choose the target
@@ -65,6 +116,7 @@ mkdir -p "$ONBOARDING_DIR"
   git remote get-url origin 2>/dev/null || true
   command -v detent || true
   detent version 2>/dev/null || true
+  cat "$ONBOARDING_DIR/detent-source-freshness.env" 2>/dev/null || true
   detent --format pretty config path 2>/dev/null || true
   gh auth status 2>&1 || true
   codex --version 2>/dev/null || true
@@ -216,15 +268,15 @@ Draft the first candidate from identity-safe local evidence. Run this from the
 target checkout:
 
 ```sh
-detent onboarding draft-answers --output pretty
-detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write
+detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --output pretty
+detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --answers "$ONBOARDING_DIR/answers.env" --write
 ```
 
 If you are currently in the Detent source checkout, pass the target explicitly:
 
 ```sh
-detent onboarding draft-answers --target-source-root <absolute-local-checkout-path> --output pretty
-detent onboarding draft-answers --target-source-root <absolute-local-checkout-path> --answers "$ONBOARDING_DIR/answers.env" --write
+detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --target-source-root <absolute-local-checkout-path> --output pretty
+detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --target-source-root <absolute-local-checkout-path> --answers "$ONBOARDING_DIR/answers.env" --write
 ```
 
 The draft command may inspect only local identity evidence: current working

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -201,6 +202,8 @@ type SignalFunc func(context.Context, Signal) error
 
 type LoggerFunc func(RuntimeSettings, io.Writer, io.Writer, bool)
 
+type CommandRunner func(context.Context, string, ...string) (string, error)
+
 type ProjectManager interface {
 	Add(context.Context, globalconfig.Project) error
 	Remove(context.Context, project.ID) error
@@ -220,6 +223,7 @@ type options struct {
 	signal        SignalFunc
 	lookupEnv     func(string) string
 	ghAuthToken   func(context.Context) (string, error)
+	runCommand    CommandRunner
 	configureLog  LoggerFunc
 	captureDemo   demoCaptureFunc
 	version       string
@@ -266,6 +270,14 @@ func WithStdoutTTY(stdoutTTY func() bool) Option {
 	return func(opts *options) {
 		if stdoutTTY != nil {
 			opts.stdoutTTY = stdoutTTY
+		}
+	}
+}
+
+func WithCommandRunner(run CommandRunner) Option {
+	return func(opts *options) {
+		if run != nil {
+			opts.runCommand = run
 		}
 	}
 }
@@ -434,9 +446,25 @@ func defaultOptions() options {
 		signal:      noSignal,
 		lookupEnv:   os.Getenv,
 		ghAuthToken: defaultGHAuthToken,
+		runCommand:  defaultCommandRunner,
 		captureDemo: runDemoCapture,
 		stdoutTTY:   stdoutIsTTY,
 	}
+}
+
+func defaultCommandRunner(ctx context.Context, name string, args ...string) (string, error) {
+	cmd := exec.CommandContext(ctx, name, args...)
+	output, err := cmd.CombinedOutput()
+	if ctx.Err() != nil {
+		return string(output), ctx.Err()
+	}
+	if err != nil {
+		if detail := strings.TrimSpace(string(output)); detail != "" {
+			return string(output), fmt.Errorf("%w: %s", err, detail)
+		}
+		return string(output), err
+	}
+	return string(output), nil
 }
 
 func newHelpCommand(root *cobra.Command, opts options) *cobra.Command {

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -572,7 +572,10 @@ func onboardingDetentFreshnessBlocksPhase2(evidence onboardingDetentFreshnessEvi
 	if evidence.SourceChecked && evidence.SourceStatus != "current" {
 		return true
 	}
-	return evidence.BinaryStatus == "stale"
+	if strings.TrimSpace(evidence.CanonicalMain) == "" {
+		return false
+	}
+	return evidence.BinaryStatus != "current"
 }
 
 func onboardingDetentFreshnessNotes(evidence onboardingDetentFreshnessEvidence) []string {
@@ -591,6 +594,9 @@ func onboardingDetentFreshnessNotes(evidence onboardingDetentFreshnessEvidence) 
 	}
 	if evidence.BinaryStatus == "stale" {
 		notes = append(notes, "installed Detent binary commit differs from fetched origin/main; reinstall before using local command recommendations")
+	}
+	if evidence.BinaryStatus == "not_found" || evidence.BinaryStatus == "error" || evidence.BinaryStatus == "unknown_commit" {
+		notes = append(notes, "installed Detent binary freshness could not be proven against fetched origin/main; install or reinstall before using local command recommendations")
 	}
 	return notes
 }

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -63,26 +64,53 @@ type onboardingAnswersNormalizationResult struct {
 }
 
 type onboardingDraftAnswersResult struct {
-	Status                         string   `json:"status"`
-	AnswersPath                    string   `json:"answers_path,omitempty"`
-	Written                        bool     `json:"written"`
-	CustomerIDCandidate            string   `json:"customer_id_candidate"`
-	CustomerIDSource               string   `json:"customer_id_source"`
-	CustomerIDConfidence           string   `json:"customer_id_confidence"`
-	CustomerIDReviewRequired       bool     `json:"customer_id_review_required"`
-	CustomerIDAlternatives         []string `json:"customer_id_alternatives"`
-	DetentProjectIDCandidate       string   `json:"detent_project_id_candidate"`
-	DetentProjectIDSource          string   `json:"detent_project_id_source"`
-	TargetRepositoryCandidate      string   `json:"target_repository_candidate"`
-	TargetSourceRootCandidate      string   `json:"target_source_root_candidate"`
-	ReferenceRepositoriesCandidate []string `json:"reference_repositories_candidate"`
-	DetentOnboardingModeCandidate  string   `json:"detent_onboarding_mode_candidate"`
-	ConfigPath                     string   `json:"config_path"`
-	ConfigPathRule                 string   `json:"config_path_rule"`
-	ConfigInstalled                bool     `json:"config_installed"`
-	RegisteredProjectIDs           []string `json:"registered_project_ids"`
-	Confidence                     string   `json:"confidence"`
-	Notes                          []string `json:"notes"`
+	Status                         string                            `json:"status"`
+	AnswersPath                    string                            `json:"answers_path,omitempty"`
+	Written                        bool                              `json:"written"`
+	CustomerIDCandidate            string                            `json:"customer_id_candidate"`
+	CustomerIDSource               string                            `json:"customer_id_source"`
+	CustomerIDConfidence           string                            `json:"customer_id_confidence"`
+	CustomerIDReviewRequired       bool                              `json:"customer_id_review_required"`
+	CustomerIDAlternatives         []string                          `json:"customer_id_alternatives"`
+	DetentProjectIDCandidate       string                            `json:"detent_project_id_candidate"`
+	DetentProjectIDSource          string                            `json:"detent_project_id_source"`
+	TargetRepositoryCandidate      string                            `json:"target_repository_candidate"`
+	TargetSourceRootCandidate      string                            `json:"target_source_root_candidate"`
+	ReferenceRepositoriesCandidate []string                          `json:"reference_repositories_candidate"`
+	DetentOnboardingModeCandidate  string                            `json:"detent_onboarding_mode_candidate"`
+	ConfigPath                     string                            `json:"config_path"`
+	ConfigPathRule                 string                            `json:"config_path_rule"`
+	ConfigInstalled                bool                              `json:"config_installed"`
+	RegisteredProjectIDs           []string                          `json:"registered_project_ids"`
+	DetentFreshness                onboardingDetentFreshnessEvidence `json:"detent_freshness"`
+	Confidence                     string                            `json:"confidence"`
+	Notes                          []string                          `json:"notes"`
+}
+
+type onboardingDetentFreshnessEvidence struct {
+	SourceChecked                bool   `json:"source_checked"`
+	SourceRoot                   string `json:"source_root,omitempty"`
+	SourceRemote                 string `json:"source_remote,omitempty"`
+	SourceRepository             string `json:"source_repository,omitempty"`
+	SourceHead                   string `json:"source_head,omitempty"`
+	CanonicalMain                string `json:"canonical_main,omitempty"`
+	SourceMatchesCanonical       bool   `json:"source_matches_canonical"`
+	SourceStatus                 string `json:"source_status"`
+	SourceError                  string `json:"source_error,omitempty"`
+	BinaryChecked                bool   `json:"binary_checked"`
+	BinaryVersion                string `json:"binary_version,omitempty"`
+	BinaryCommit                 string `json:"binary_commit,omitempty"`
+	BinaryBuildDate              string `json:"binary_build_date,omitempty"`
+	BinaryMatchesCanonical       bool   `json:"binary_matches_canonical"`
+	BinaryStatus                 string `json:"binary_status"`
+	BinaryError                  string `json:"binary_error,omitempty"`
+	Phase2RecommendationsBlocked bool   `json:"phase2_recommendations_blocked"`
+}
+
+type onboardingDetentVersionEvidence struct {
+	Version   string `json:"version"`
+	Commit    string `json:"commit"`
+	BuildDate string `json:"build_date"`
 }
 
 type onboardingAnswers struct {
@@ -333,13 +361,16 @@ func newOnboardingNormalizeAnswersCommand() *cobra.Command {
 
 func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfig) (onboardingDraftAnswersResult, error) {
 	opts := cfg.Options
-	if opts.resolvePath == nil || opts.read == nil {
+	if opts.resolvePath == nil || opts.read == nil || opts.runCommand == nil {
 		defaults := defaultOptions()
 		if opts.resolvePath == nil {
 			opts.resolvePath = defaults.resolvePath
 		}
 		if opts.read == nil {
 			opts.read = defaults.read
+		}
+		if opts.runCommand == nil {
+			opts.runCommand = defaults.runCommand
 		}
 	}
 
@@ -401,6 +432,8 @@ func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfi
 	result.Notes = append(result.Notes, customerCandidate.Notes...)
 
 	result.ReferenceRepositoriesCandidate = onboardingReferenceRepositoryCandidates(ctx, cfg.DetentSourceRoot, targetRepository, &result.Notes)
+	result.DetentFreshness = onboardingDetentFreshness(ctx, cfg.DetentSourceRoot, opts)
+	result.Notes = append(result.Notes, onboardingDetentFreshnessNotes(result.DetentFreshness)...)
 	global, installed, err := readOnboardingDraftConfigEvidence(resolution.Path, opts)
 	if err != nil {
 		return onboardingDraftAnswersResult{}, err
@@ -421,7 +454,169 @@ func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfi
 	if result.CustomerIDReviewRequired {
 		result.Confidence = "needs-review"
 	}
+	if result.DetentFreshness.Phase2RecommendationsBlocked {
+		result.Confidence = "needs-review"
+	}
 	return result, nil
+}
+
+func onboardingDetentFreshness(ctx context.Context, detentSourceRoot string, opts options) onboardingDetentFreshnessEvidence {
+	evidence := onboardingDetentFreshnessEvidence{
+		SourceStatus: "not_checked",
+		BinaryStatus: "not_checked",
+	}
+	sourceInput := strings.TrimSpace(detentSourceRoot)
+	if sourceInput != "" {
+		evidence = onboardingDetentSourceFreshness(ctx, sourceInput, opts)
+	}
+	evidence = onboardingDetentBinaryFreshness(ctx, opts, evidence)
+	evidence.Phase2RecommendationsBlocked = onboardingDetentFreshnessBlocksPhase2(evidence)
+	return evidence
+}
+
+func onboardingDetentSourceFreshness(ctx context.Context, sourceInput string, opts options) onboardingDetentFreshnessEvidence {
+	evidence := onboardingDetentFreshnessEvidence{
+		SourceChecked: true,
+		SourceStatus:  "error",
+		BinaryStatus:  "not_checked",
+	}
+	root, err := defaultGitTopLevel(ctx, sourceInput)
+	if err != nil {
+		evidence.SourceError = err.Error()
+		return evidence
+	}
+	evidence.SourceRoot = root
+	remote, err := defaultGitRemoteURL(ctx, root)
+	if err != nil {
+		evidence.SourceError = err.Error()
+		return evidence
+	}
+	evidence.SourceRemote = remote
+	if repository, ok := gitHubRepositoryFromRemote(remote); ok {
+		evidence.SourceRepository = repository
+	}
+	if _, err := onboardingRunCommand(ctx, opts, "git", "-C", root, "fetch", "origin", "main:refs/remotes/origin/main"); err != nil {
+		evidence.SourceError = err.Error()
+		return evidence
+	}
+	head, err := onboardingRunCommand(ctx, opts, "git", "-C", root, "rev-parse", "HEAD")
+	if err != nil {
+		evidence.SourceError = err.Error()
+		return evidence
+	}
+	canonical, err := onboardingRunCommand(ctx, opts, "git", "-C", root, "rev-parse", "refs/remotes/origin/main")
+	if err != nil {
+		evidence.SourceError = err.Error()
+		return evidence
+	}
+	evidence.SourceHead = strings.TrimSpace(head)
+	evidence.CanonicalMain = strings.TrimSpace(canonical)
+	evidence.SourceMatchesCanonical = onboardingCommitsMatch(evidence.SourceHead, evidence.CanonicalMain)
+	switch {
+	case evidence.SourceMatchesCanonical:
+		evidence.SourceStatus = "current"
+	case onboardingSourceIsBehind(ctx, opts, root):
+		evidence.SourceStatus = "stale"
+	default:
+		evidence.SourceStatus = "mismatch"
+	}
+	return evidence
+}
+
+func onboardingDetentBinaryFreshness(ctx context.Context, opts options, evidence onboardingDetentFreshnessEvidence) onboardingDetentFreshnessEvidence {
+	output, err := onboardingRunCommand(ctx, opts, "detent", "--format", "json", "version")
+	evidence.BinaryChecked = true
+	if err != nil {
+		evidence.BinaryStatus = "not_found"
+		evidence.BinaryError = err.Error()
+		return evidence
+	}
+	var version onboardingDetentVersionEvidence
+	if err := json.Unmarshal([]byte(output), &version); err != nil {
+		evidence.BinaryStatus = "error"
+		evidence.BinaryError = "parse detent version JSON: " + err.Error()
+		return evidence
+	}
+	evidence.BinaryVersion = strings.TrimSpace(version.Version)
+	evidence.BinaryCommit = strings.TrimSpace(version.Commit)
+	evidence.BinaryBuildDate = strings.TrimSpace(version.BuildDate)
+	if strings.TrimSpace(evidence.CanonicalMain) == "" {
+		evidence.BinaryStatus = "not_compared"
+		return evidence
+	}
+	if onboardingCommitUnknown(evidence.BinaryCommit) {
+		evidence.BinaryStatus = "unknown_commit"
+		return evidence
+	}
+	evidence.BinaryMatchesCanonical = onboardingCommitsMatch(evidence.BinaryCommit, evidence.CanonicalMain)
+	if evidence.BinaryMatchesCanonical {
+		evidence.BinaryStatus = "current"
+		return evidence
+	}
+	evidence.BinaryStatus = "stale"
+	return evidence
+}
+
+func onboardingRunCommand(ctx context.Context, opts options, name string, args ...string) (string, error) {
+	commandCtx, cancel := context.WithTimeout(ctx, doctorCommandTimeout)
+	defer cancel()
+	return opts.runCommand(commandCtx, name, args...)
+}
+
+func onboardingSourceIsBehind(ctx context.Context, opts options, root string) bool {
+	_, err := onboardingRunCommand(ctx, opts, "git", "-C", root, "merge-base", "--is-ancestor", "HEAD", "refs/remotes/origin/main")
+	return err == nil
+}
+
+func onboardingDetentFreshnessBlocksPhase2(evidence onboardingDetentFreshnessEvidence) bool {
+	if evidence.SourceChecked && evidence.SourceStatus != "current" {
+		return true
+	}
+	return evidence.BinaryStatus == "stale"
+}
+
+func onboardingDetentFreshnessNotes(evidence onboardingDetentFreshnessEvidence) []string {
+	var notes []string
+	if evidence.SourceChecked {
+		switch evidence.SourceStatus {
+		case "current":
+			notes = append(notes, "Detent source checkout matches fetched origin/main")
+		case "stale":
+			notes = append(notes, "Detent source checkout is behind fetched origin/main; update it or read onboarding docs from GitHub at the canonical head before Phase 2 recommendations")
+		case "mismatch":
+			notes = append(notes, "Detent source checkout does not match fetched origin/main; reconcile it or read onboarding docs from GitHub at the canonical head before Phase 2 recommendations")
+		default:
+			notes = append(notes, "could not prove Detent source checkout freshness; fetch/update it or read onboarding docs from GitHub at the canonical head before Phase 2 recommendations")
+		}
+	}
+	if evidence.BinaryStatus == "stale" {
+		notes = append(notes, "installed Detent binary commit differs from fetched origin/main; reinstall before using local command recommendations")
+	}
+	return notes
+}
+
+func onboardingCommitsMatch(left string, right string) bool {
+	left = strings.TrimSpace(left)
+	right = strings.TrimSpace(right)
+	if onboardingCommitUnknown(left) || onboardingCommitUnknown(right) {
+		return false
+	}
+	if left == right {
+		return true
+	}
+	if len(left) >= 7 && strings.HasPrefix(right, left) {
+		return true
+	}
+	return len(right) >= 7 && strings.HasPrefix(left, right)
+}
+
+func onboardingCommitUnknown(commit string) bool {
+	switch strings.TrimSpace(commit) {
+	case "", "none", "unknown", "(devel)":
+		return true
+	default:
+		return false
+	}
 }
 
 func onboardingGitCheckoutEvidence(ctx context.Context, path string) (string, string, error) {
@@ -704,12 +899,15 @@ func writeOnboardingDraftAnswersPretty(w io.Writer, result onboardingDraftAnswer
 		fmt.Sprintf("Source checkout: `%s`", result.TargetSourceRootCandidate),
 		fmt.Sprintf("Reference repositories: `%s`", strings.Join(result.ReferenceRepositoriesCandidate, ",")),
 		fmt.Sprintf("Onboarding mode: `%s`", result.DetentOnboardingModeCandidate),
-		"",
-		"customer_id_source=" + result.CustomerIDSource,
-		"customer_id_confidence=" + result.CustomerIDConfidence,
-		"detent_project_id_source=" + result.DetentProjectIDSource,
-		"confidence=" + result.Confidence,
 	}
+	lines = append(lines, onboardingDetentFreshnessPrettyLines(result.DetentFreshness)...)
+	lines = append(lines,
+		"",
+		"customer_id_source="+result.CustomerIDSource,
+		"customer_id_confidence="+result.CustomerIDConfidence,
+		"detent_project_id_source="+result.DetentProjectIDSource,
+		"confidence="+result.Confidence,
+	)
 	if len(result.CustomerIDAlternatives) > 0 {
 		lines = append(lines, "Customer/workstream alternatives: "+onboardingPrettyList(result.CustomerIDAlternatives))
 	}
@@ -742,6 +940,46 @@ func writeOnboardingDraftAnswersPretty(w io.Writer, result onboardingDraftAnswer
 	}
 	_, err := fmt.Fprintln(w, strings.Join(lines, "\n"))
 	return err
+}
+
+func onboardingDetentFreshnessPrettyLines(evidence onboardingDetentFreshnessEvidence) []string {
+	lines := []string{
+		"",
+		"Detent source freshness:",
+		"source_checked: " + fmt.Sprint(evidence.SourceChecked),
+	}
+	if evidence.SourceRoot != "" {
+		lines = append(lines, "source_root: "+evidence.SourceRoot)
+	}
+	if evidence.SourceHead != "" {
+		lines = append(lines, "source_head: "+evidence.SourceHead)
+	}
+	if evidence.CanonicalMain != "" {
+		lines = append(lines, "canonical_main: "+evidence.CanonicalMain)
+	}
+	lines = append(lines,
+		"source_matches_canonical: "+fmt.Sprint(evidence.SourceMatchesCanonical),
+		"source_status: "+evidence.SourceStatus,
+		"binary_checked: "+fmt.Sprint(evidence.BinaryChecked),
+	)
+	if evidence.BinaryVersion != "" {
+		lines = append(lines, "binary_version: "+evidence.BinaryVersion)
+	}
+	if evidence.BinaryCommit != "" {
+		lines = append(lines, "binary_commit: "+evidence.BinaryCommit)
+	}
+	if evidence.BinaryBuildDate != "" {
+		lines = append(lines, "binary_build_date: "+evidence.BinaryBuildDate)
+	}
+	lines = append(lines,
+		"binary_matches_canonical: "+fmt.Sprint(evidence.BinaryMatchesCanonical),
+		"binary_status: "+evidence.BinaryStatus,
+		"phase2_recommendations_blocked: "+fmt.Sprint(evidence.Phase2RecommendationsBlocked),
+	)
+	if evidence.Phase2RecommendationsBlocked {
+		lines = append(lines, "phase2_stop: update/reinstall Detent or read docs from GitHub at the canonical head before Phase 2 recommendations.")
+	}
+	return lines
 }
 
 func onboardingPrettyList(values []string) string {

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -968,6 +968,59 @@ func TestOnboardingDraftAnswersCommandReportsCurrentDetentSourceAndBinary(t *tes
 	}
 }
 
+func TestOnboardingDraftAnswersCommandBlocksUnprovenDetentBinary(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	sourceRoot, _, canonicalMain := initOnboardingDetentSourceCheckout(t, false)
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(onboardingTestCommandRunner(detentVersionJSON("none"))),
+	)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"--config", filepath.Join(t.TempDir(), "global.yaml"),
+		"onboarding", "draft-answers",
+		"--detent-source-root", sourceRoot,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Confidence      string `json:"confidence"`
+		DetentFreshness struct {
+			CanonicalMain                string `json:"canonical_main"`
+			SourceStatus                 string `json:"source_status"`
+			BinaryCommit                 string `json:"binary_commit"`
+			BinaryStatus                 string `json:"binary_status"`
+			Phase2RecommendationsBlocked bool   `json:"phase2_recommendations_blocked"`
+		} `json:"detent_freshness"`
+		Notes []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	freshness := got.DetentFreshness
+	if freshness.CanonicalMain != canonicalMain || freshness.SourceStatus != "current" {
+		t.Fatalf("freshness = %#v, want current source at %s", freshness, canonicalMain)
+	}
+	if freshness.BinaryCommit != "none" || freshness.BinaryStatus != "unknown_commit" {
+		t.Fatalf("freshness = %#v, want unknown binary commit", freshness)
+	}
+	if !freshness.Phase2RecommendationsBlocked || got.Confidence != "needs-review" {
+		t.Fatalf("freshness = %#v confidence = %q, want blocked needs-review", freshness, got.Confidence)
+	}
+	if !containsSubstring(got.Notes, "installed Detent binary freshness could not be proven against fetched origin/main") {
+		t.Fatalf("notes = %#v, want unproven binary stop guidance", got.Notes)
+	}
+}
+
 func TestOnboardingDraftAnswersCommandAcceptsIdentityOverrides(t *testing.T) {
 	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/creswoodcorners-phone.git")
 	answersPath := filepath.Join(t.TempDir(), "answers.env")

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -846,6 +846,128 @@ func TestOnboardingDraftAnswersCommandPrettyExplainsCustomerChoice(t *testing.T)
 	}
 }
 
+func TestOnboardingDraftAnswersCommandReportsStaleDetentSourceAndBinary(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	sourceRoot, sourceHead, canonicalMain := initOnboardingDetentSourceCheckout(t, true)
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(onboardingTestCommandRunner(detentVersionJSON(sourceHead))),
+	)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"--config", filepath.Join(t.TempDir(), "global.yaml"),
+		"onboarding", "draft-answers",
+		"--detent-source-root", sourceRoot,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		Confidence      string `json:"confidence"`
+		DetentFreshness struct {
+			SourceChecked                bool   `json:"source_checked"`
+			SourceHead                   string `json:"source_head"`
+			CanonicalMain                string `json:"canonical_main"`
+			SourceMatchesCanonical       bool   `json:"source_matches_canonical"`
+			SourceStatus                 string `json:"source_status"`
+			BinaryChecked                bool   `json:"binary_checked"`
+			BinaryCommit                 string `json:"binary_commit"`
+			BinaryMatchesCanonical       bool   `json:"binary_matches_canonical"`
+			BinaryStatus                 string `json:"binary_status"`
+			Phase2RecommendationsBlocked bool   `json:"phase2_recommendations_blocked"`
+		} `json:"detent_freshness"`
+		Notes []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	freshness := got.DetentFreshness
+	if !freshness.SourceChecked || freshness.SourceHead != sourceHead || freshness.CanonicalMain != canonicalMain {
+		t.Fatalf("source freshness = %#v, want stale source %s behind %s", freshness, sourceHead, canonicalMain)
+	}
+	if freshness.SourceMatchesCanonical || freshness.SourceStatus != "stale" {
+		t.Fatalf("source freshness = %#v, want stale mismatch", freshness)
+	}
+	if !freshness.BinaryChecked || freshness.BinaryCommit != sourceHead || freshness.BinaryMatchesCanonical || freshness.BinaryStatus != "stale" {
+		t.Fatalf("binary freshness = %#v, want stale binary at %s", freshness, sourceHead)
+	}
+	if !freshness.Phase2RecommendationsBlocked || got.Confidence != "needs-review" {
+		t.Fatalf("freshness = %#v confidence = %q, want blocked needs-review", freshness, got.Confidence)
+	}
+	if !containsSubstring(got.Notes, "read onboarding docs from GitHub at the canonical head before Phase 2 recommendations") {
+		t.Fatalf("notes = %#v, want stale source stop guidance", got.Notes)
+	}
+	if !containsSubstring(got.Notes, "installed Detent binary commit differs from fetched origin/main") {
+		t.Fatalf("notes = %#v, want stale binary reinstall guidance", got.Notes)
+	}
+}
+
+func TestOnboardingDraftAnswersCommandReportsCurrentDetentSourceAndBinary(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	sourceRoot, sourceHead, canonicalMain := initOnboardingDetentSourceCheckout(t, false)
+	t.Chdir(targetRoot)
+
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(onboardingTestCommandRunner(detentVersionJSON(canonicalMain))),
+	)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"--config", filepath.Join(t.TempDir(), "global.yaml"),
+		"onboarding", "draft-answers",
+		"--detent-source-root", sourceRoot,
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		DetentFreshness struct {
+			SourceHead                   string `json:"source_head"`
+			CanonicalMain                string `json:"canonical_main"`
+			SourceMatchesCanonical       bool   `json:"source_matches_canonical"`
+			SourceStatus                 string `json:"source_status"`
+			BinaryCommit                 string `json:"binary_commit"`
+			BinaryMatchesCanonical       bool   `json:"binary_matches_canonical"`
+			BinaryStatus                 string `json:"binary_status"`
+			Phase2RecommendationsBlocked bool   `json:"phase2_recommendations_blocked"`
+		} `json:"detent_freshness"`
+		Notes []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	freshness := got.DetentFreshness
+	if sourceHead != canonicalMain {
+		t.Fatalf("test setup source head = %s, canonical = %s, want equal", sourceHead, canonicalMain)
+	}
+	if freshness.SourceHead != sourceHead || freshness.CanonicalMain != canonicalMain || !freshness.SourceMatchesCanonical || freshness.SourceStatus != "current" {
+		t.Fatalf("source freshness = %#v, want current source %s", freshness, canonicalMain)
+	}
+	if freshness.BinaryCommit != canonicalMain || !freshness.BinaryMatchesCanonical || freshness.BinaryStatus != "current" {
+		t.Fatalf("binary freshness = %#v, want current binary %s", freshness, canonicalMain)
+	}
+	if freshness.Phase2RecommendationsBlocked {
+		t.Fatalf("freshness = %#v, want Phase 2 recommendations allowed", freshness)
+	}
+	if !containsSubstring(got.Notes, "Detent source checkout matches fetched origin/main") {
+		t.Fatalf("notes = %#v, want current source note", got.Notes)
+	}
+}
+
 func TestOnboardingDraftAnswersCommandAcceptsIdentityOverrides(t *testing.T) {
 	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/creswoodcorners-phone.git")
 	answersPath := filepath.Join(t.TempDir(), "answers.env")
@@ -1235,6 +1357,65 @@ func initOnboardingGitRepository(t *testing.T, remote string) string {
 	return dir
 }
 
+func initOnboardingDetentSourceCheckout(t *testing.T, stale bool) (string, string, string) {
+	t.Helper()
+
+	root := t.TempDir()
+	remote := filepath.Join(root, "detent.git")
+	runGitOutput(t, "", "init", "--bare", remote)
+
+	seed := filepath.Join(root, "seed")
+	if err := os.MkdirAll(seed, 0o755); err != nil {
+		t.Fatalf("MkdirAll(seed) error = %v", err)
+	}
+	runGit(t, seed, "init")
+	runGit(t, seed, "checkout", "-b", "main")
+	runGit(t, seed, "config", "user.email", "detent@example.test")
+	runGit(t, seed, "config", "user.name", "Detent Test")
+	writeOnboardingTestFile(t, filepath.Join(seed, "README.md"), "initial\n")
+	runGit(t, seed, "add", "README.md")
+	runGit(t, seed, "commit", "-m", "initial")
+	runGit(t, seed, "remote", "add", "origin", remote)
+	runGit(t, seed, "push", "-u", "origin", "main")
+	runGit(t, remote, "symbolic-ref", "HEAD", "refs/heads/main")
+
+	local := filepath.Join(root, "local")
+	runGitOutput(t, "", "clone", "-b", "main", remote, local)
+	sourceHead := runGitOutput(t, local, "rev-parse", "HEAD")
+	canonicalMain := sourceHead
+	if stale {
+		writeOnboardingTestFile(t, filepath.Join(seed, "README.md"), "updated\n")
+		runGit(t, seed, "add", "README.md")
+		runGit(t, seed, "commit", "-m", "update")
+		runGit(t, seed, "push", "origin", "main")
+		canonicalMain = runGitOutput(t, seed, "rev-parse", "HEAD")
+	}
+	return local, sourceHead, canonicalMain
+}
+
+func writeOnboardingTestFile(t *testing.T, path string, content string) {
+	t.Helper()
+
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile(%s) error = %v", path, err)
+	}
+}
+
+func detentVersionJSON(commit string) string {
+	return `{"version":"v0.11.1","commit":"` + commit + `","build_date":"2026-06-24T18:49:56Z","go_version":"go1.26.4","os":"linux","arch":"amd64"}` + "\n"
+}
+
+func onboardingTestCommandRunner(detentVersionOutput string) cli.CommandRunner {
+	return func(ctx context.Context, name string, args ...string) (string, error) {
+		if name == "detent" {
+			return detentVersionOutput, nil
+		}
+		cmd := exec.CommandContext(ctx, name, args...)
+		output, err := cmd.CombinedOutput()
+		return string(output), err
+	}
+}
+
 func writeOnboardingEnvOverrideModule(t *testing.T, dir string) {
 	t.Helper()
 
@@ -1313,9 +1494,20 @@ func containsString(values []string, want string) bool {
 func runGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 
-	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	runGitOutput(t, dir, args...)
+}
+
+func runGitOutput(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	commandArgs := append([]string(nil), args...)
+	if strings.TrimSpace(dir) != "" {
+		commandArgs = append([]string{"-C", dir}, args...)
+	}
+	cmd := exec.Command("git", commandArgs...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatalf("git %s error = %v\n%s", strings.Join(args, " "), err, output)
 	}
+	return strings.TrimSpace(string(output))
 }

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -70,8 +70,8 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		`detent onboarding draft-answers --output pretty`,
-		`detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write`,
+		`detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --output pretty`,
+		`detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --answers "$ONBOARDING_DIR/answers.env" --write`,
 		"CUSTOMER_ID=<customer-or-workstream-id>",
 		"DETENT_PROJECT_ID=<local-detent-project-id>",
 		"TARGET_REPOSITORY=<repo-owner>/<repo-name>",
@@ -90,6 +90,43 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	assertContains(t, readme, "Distinguish reference repositories from the target repository")
 	assertContains(t, readme, `detent onboarding validate-answers --answers "$ONBOARDING_DIR/answers.env" --phase identity`)
 	assertContains(t, readme, "Ask and record `GITHUB_MODE` explicitly")
+}
+
+func TestOnboardingDocsRequireDetentSourceFreshnessBeforeRunbook(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+
+	for _, want := range []string{
+		`git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main`,
+		`git -C "$DETENT_SOURCE_ROOT" rev-parse HEAD`,
+		`git -C "$DETENT_SOURCE_ROOT" rev-parse refs/remotes/origin/main`,
+		`detent --format json version`,
+		"DETENT_SOURCE_MATCHES_CANONICAL",
+		"DETENT_BINARY_MATCHES_CANONICAL",
+		"$ONBOARDING_DIR/detent-source-freshness.env",
+		"stop before Phase 2 recommendations",
+		"read docs from GitHub at the canonical head",
+	} {
+		assertContains(t, onboarding, want)
+	}
+
+	for _, want := range []string{
+		"Before reading local Detent docs or trusting local `detent` command recommendations",
+		`git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main`,
+		"`DETENT_SOURCE_MATCHES_CANONICAL`",
+		"`DETENT_BINARY_MATCHES_CANONICAL`",
+		"stop before reading local docs or making Phase 2 recommendations",
+		"reading docs from GitHub at the canonical head",
+		`--detent-source-root "$DETENT_SOURCE_ROOT"`,
+	} {
+		assertContainsWords(t, readme, want)
+	}
+
+	assertOrder(t, readme, "Before reading local Detent docs", "From the Detent source repository, read README.md")
+	assertOrder(t, onboarding, "## Source Freshness Gate", "## Start Here")
+	assertOrder(t, onboarding, "DETENT_SOURCE_MATCHES_CANONICAL", "## Phase 0.5")
 }
 
 func TestOnboardingDocsPreserveEarlyLabelStatusSourceDecision(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add Detent source and binary freshness evidence to onboarding draft discovery.
- Require README/runbook freshness checks before trusting local onboarding docs or Phase 2 recommendations.
- Cover stale and current source/binary detection plus documentation requirements.

Fixes #693

## Test Plan

- [x] `go test ./internal/cli`
- [x] `go test .`
- [x] `make check`