### PR TITLE
fix(runner): quiet empty-model usage pricing

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -709,9 +709,14 @@ func (r *Runner) finishSession(
 }
 
 func (r *Runner) usageCostUSD(model string, inputTokens int64, outputTokens int64) float64 {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		r.logger.Debug("usage event model unavailable; skipping cost pricing")
+		return 0
+	}
 	cost, ok := budget.UsageCostUSD(r.pricing, model, inputTokens, outputTokens)
 	if !ok {
-		r.logger.Warn("usage event model pricing not found", "model", strings.TrimSpace(model))
+		r.logger.Warn("usage event model pricing not found", "model", model)
 		return 0
 	}
 	return cost

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -333,6 +333,30 @@ func TestRunnerUsageCostWarnsForUnknownModel(t *testing.T) {
 	}
 }
 
+func TestRunnerUsageCostSkipsPricingWarningForEmptyModel(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	runner := &Runner{
+		pricing: budget.PricingTable{},
+		logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	}
+
+	cost := runner.usageCostUSD(" \t", 10, 5)
+	if cost != 0 {
+		t.Fatalf("usageCostUSD() = %.12f, want 0", cost)
+	}
+	got := logs.String()
+	if strings.Contains(got, "level=WARN") || strings.Contains(got, "usage event model pricing not found") {
+		t.Fatalf("log output = %q, want no empty-model pricing warning", got)
+	}
+	if !strings.Contains(got, "usage event model unavailable; skipping cost pricing") {
+		t.Fatalf("log output = %q, want empty-model diagnostic", got)
+	}
+}
+
 func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Treat blank usage-event models as unavailable metadata and skip pricing at debug level instead of WARN.
- Preserve WARN logging for unknown non-empty model pricing misses.

Fixes #697

## Test Plan

- [x] `go test ./internal/runner -run 'TestRunnerUsageCost(WarnsForUnknownModel|SkipsPricingWarningForEmptyModel)' -count=1`
- [x] `go test ./internal/runner -count=1`
- [x] `make check`