### PR TITLE
fix(orchestrator): defer rate-limited pr hydration

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -709,18 +709,19 @@ type pullRequest struct {
 }
 
 type pullRequestNode struct {
-	Number         int                               `json:"number"`
-	URL            string                            `json:"url"`
-	State          string                            `json:"state"`
-	MergeableState string                            `json:"mergeableState"`
-	Draft          bool                              `json:"draft"`
-	ActivityAt     *time.Time                        `json:"activityAt"`
-	HeadRefName    string                            `json:"headRefName"`
-	HeadSHA        string                            `json:"headSHA"`
-	Commits        nodeConnection[pullRequestCommit] `json:"commits"`
-	LatestReviews  nodeConnection[pullRequestReview] `json:"latestReviews"`
-	CodexReviews   pullRequestCodexReviews           `json:"-"`
-	CI             pullRequestCI                     `json:"-"`
+	Number                     int                               `json:"number"`
+	URL                        string                            `json:"url"`
+	State                      string                            `json:"state"`
+	MergeableState             string                            `json:"mergeableState"`
+	Draft                      bool                              `json:"draft"`
+	ActivityAt                 *time.Time                        `json:"activityAt"`
+	HeadRefName                string                            `json:"headRefName"`
+	HeadSHA                    string                            `json:"headSHA"`
+	HydrationUnavailableReason string                            `json:"-"`
+	Commits                    nodeConnection[pullRequestCommit] `json:"commits"`
+	LatestReviews              nodeConnection[pullRequestReview] `json:"latestReviews"`
+	CodexReviews               pullRequestCodexReviews           `json:"-"`
+	CI                         pullRequestCI                     `json:"-"`
 }
 
 type pullRequestCommit struct {
@@ -1949,7 +1950,8 @@ func (c *Connector) attachPullRequestsWithCache(ctx context.Context, issues []co
 		}
 		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
 		if err != nil {
-			if errors.Is(err, ErrRESTBudgetReserved) {
+			if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
+				markPullRequestHydrationUnavailableForCandidates(issues, byRepo[repo], repo, reason)
 				continue
 			}
 			return err
@@ -2107,14 +2109,16 @@ func (c *Connector) attachLinkedPullRequests(
 			var err error
 			pullRequest, err = c.fetchRepositoryPullRequest(ctx, pullRequestRepo, candidate.PullRequestNumber)
 			if err != nil {
-				if errors.Is(err, ErrRESTBudgetReserved) {
-					attachMinimalPullRequestToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber)
+				if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
+					attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber, reason)
 					continue
 				}
 				return err
 			}
 			if err := c.populatePullRequestStatus(ctx, pullRequestRepo, &pullRequest, useStatusCache); err != nil {
-				if !errors.Is(err, ErrRESTBudgetReserved) {
+				if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
+					pullRequest.HydrationUnavailableReason = reason
+				} else {
 					return err
 				}
 			}
@@ -2152,16 +2156,18 @@ func (c *Connector) attachMatchingPullRequests(
 				var err error
 				hydratedPullRequest, err = c.fetchRepositoryPullRequest(ctx, repo, pullRequest.Number)
 				if err != nil {
-					if errors.Is(err, ErrRESTBudgetReserved) {
-						hydratedPullRequest = pullRequest
-						hydrated[pullRequest.Number] = hydratedPullRequest
-						attachPullRequestToIssue(&issues[candidate.Index], repo, hydratedPullRequest)
+					if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
+						pullRequest.HydrationUnavailableReason = reason
+						hydrated[pullRequest.Number] = pullRequest
+						attachPullRequestToIssue(&issues[candidate.Index], repo, pullRequest)
 						continue
 					}
 					return err
 				}
 				if err := c.populatePullRequestStatus(ctx, repo, &hydratedPullRequest, useStatusCache); err != nil {
-					if !errors.Is(err, ErrRESTBudgetReserved) {
+					if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
+						hydratedPullRequest.HydrationUnavailableReason = reason
+					} else {
 						return err
 					}
 				}
@@ -2205,6 +2211,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		Draft:                        pullRequest.Draft,
 		ActivityAt:                   cloneGitHubTime(pullRequest.ActivityAt),
 		HeadSHA:                      strings.TrimSpace(pullRequest.HeadSHA),
+		HydrationUnavailableReason:   strings.TrimSpace(pullRequest.HydrationUnavailableReason),
 		CIStatus:                     normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
 		CheckRunCount:                pullRequest.CI.CheckRunCount,
 		StatusContextCount:           pullRequest.CI.StatusContextCount,
@@ -2227,13 +2234,52 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 	}
 }
 
-func attachMinimalPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, number int) {
-	issue.PullRequest = &connector.PullRequest{Number: number}
+func markPullRequestHydrationUnavailableForCandidates(
+	issues []connector.Issue,
+	candidates []issuePullRequestCandidate,
+	defaultRepo pullRequestRepo,
+	reason string,
+) {
+	for _, candidate := range candidates {
+		if issues[candidate.Index].PullRequest != nil {
+			continue
+		}
+		repo := candidate.PullRequestRepo
+		if strings.TrimSpace(repo.Owner) == "" || strings.TrimSpace(repo.Name) == "" {
+			repo = defaultRepo
+		}
+		attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], repo, candidate.PullRequestNumber, reason)
+	}
+}
+
+func attachPullRequestHydrationUnavailableToIssue(issue *connector.Issue, repo pullRequestRepo, number int, reason string) {
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return
+	}
+	if issue.PullRequest == nil {
+		issue.PullRequest = &connector.PullRequest{}
+	}
+	if number > 0 {
+		issue.PullRequest.Number = number
+	}
+	issue.PullRequest.HydrationUnavailableReason = reason
 	if issue.PRNumber == nil && number > 0 {
 		issue.PRNumber = &number
 	}
 	if issue.PRRepository == "" {
 		issue.PRRepository = pullRequestRepoName(repo)
+	}
+}
+
+func pullRequestHydrationUnavailableReason(err error) string {
+	switch {
+	case errors.Is(err, ErrRESTBudgetReserved):
+		return connector.PullRequestHydrationReasonRESTBudgetReserved
+	case errors.Is(err, ErrRateLimited):
+		return connector.PullRequestHydrationReasonRateLimited
+	default:
+		return ""
 	}
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -806,7 +806,7 @@ func TestConnectorCachesPullRequestStatusByHeadSHA(t *testing.T) {
 	}
 }
 
-func TestConnectorFetchCandidateIssuesSkipsBranchPullRequestMatchingWhenRESTBudgetReserved(t *testing.T) {
+func TestConnectorFetchCandidateIssuesMarksBranchPullRequestHydrationUnavailableWhenRESTBudgetReserved(t *testing.T) {
 	t.Parallel()
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
@@ -842,8 +842,14 @@ func TestConnectorFetchCandidateIssuesSkipsBranchPullRequestMatchingWhenRESTBudg
 	if len(got) != 1 {
 		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(got))
 	}
-	if got[0].PullRequest != nil {
-		t.Fatalf("PullRequest = %#v, want skipped branch match while REST budget is reserved", got[0].PullRequest)
+	if got[0].PullRequest == nil {
+		t.Fatal("PullRequest = nil, want hydration-unavailable marker")
+	}
+	if got[0].PullRequest.HydrationUnavailableReason != "rest_budget_reserved" {
+		t.Fatalf("HydrationUnavailableReason = %q, want rest_budget_reserved", got[0].PullRequest.HydrationUnavailableReason)
+	}
+	if got[0].PullRequest.Number != 0 {
+		t.Fatalf("PullRequest.Number = %d, want unknown PR number while branch matching is skipped", got[0].PullRequest.Number)
 	}
 
 	requests := server.requests()
@@ -923,6 +929,50 @@ func TestConnectorFetchIssuesByStatesRechecksPullRequestStatusForPromotion(t *te
 		if count != 2 {
 			t.Fatalf("%s request count = %d, want fresh status fetch each call; requests = %#v", pattern, count, requests)
 		}
+	}
+}
+
+func TestConnectorFetchIssuesByStatesMarksLinkedPullRequestHydrationRateLimited(t *testing.T) {
+	t.Parallel()
+
+	projectBody := `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_401","content":{"__typename":"Issue","id":"I_401","number":401,"title":"Human review issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/401","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":411,"url":"https://github.com/digitaldrywood/detent/pull/411","state":"OPEN","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: projectBody},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/411",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"Retry-After":          "120",
+				"X-RateLimit-Limit":    "5000",
+				"X-RateLimit-Used":     "264",
+				"X-RateLimit-Resource": "core",
+			},
+			body: `{"message":"secondary rate limit"}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	pr := got[0].PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want retained linked PR shell")
+	}
+	if pr.Number != 411 {
+		t.Fatalf("PullRequest.Number = %d, want 411", pr.Number)
+	}
+	if pr.HydrationUnavailableReason != "rate_limited" {
+		t.Fatalf("HydrationUnavailableReason = %q, want rate_limited", pr.HydrationUnavailableReason)
+	}
+	if got[0].PRNumber == nil || *got[0].PRNumber != 411 {
+		t.Fatalf("PRNumber = %v, want 411", got[0].PRNumber)
 	}
 }
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -51,6 +51,7 @@ type PullRequest struct {
 	Draft                        bool                 `json:"draft,omitempty" yaml:"draft,omitempty"`
 	ActivityAt                   *time.Time           `json:"activity_at,omitempty" yaml:"activity_at,omitempty"`
 	HeadSHA                      string               `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
+	HydrationUnavailableReason   string               `json:"hydration_unavailable_reason,omitempty" yaml:"hydration_unavailable_reason,omitempty"`
 	CIStatus                     string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
 	CheckRunCount                int                  `json:"check_run_count,omitempty" yaml:"check_run_count,omitempty"`
 	StatusContextCount           int                  `json:"status_context_count,omitempty" yaml:"status_context_count,omitempty"`
@@ -64,6 +65,11 @@ type PullRequest struct {
 	LatestCodexReviewCommitSHA   string               `json:"latest_codex_review_commit_sha,omitempty" yaml:"latest_codex_review_commit_sha,omitempty"`
 	LatestCodexReviewSubmittedAt *time.Time           `json:"latest_codex_review_submitted_at,omitempty" yaml:"latest_codex_review_submitted_at,omitempty"`
 }
+
+const (
+	PullRequestHydrationReasonRateLimited        = "rate_limited"
+	PullRequestHydrationReasonRESTBudgetReserved = "rest_budget_reserved"
+)
 
 type PullRequestCheck struct {
 	Name            string `json:"name,omitempty" yaml:"name,omitempty"`

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -17,14 +17,15 @@ type AutoPromoteConfig struct {
 }
 
 type AutoPromoteSummary struct {
-	PullRequestPresent bool
-	PullRequestURL     string
-	MergeableState     string
-	CIStatus           string
-	ReviewState        string
-	P1Findings         []AutoPromoteFinding
-	Validator          gate.ValidatorResult
-	LastActivityAt     *time.Time
+	PullRequestPresent                    bool
+	PullRequestURL                        string
+	PullRequestHydrationUnavailableReason string
+	MergeableState                        string
+	CIStatus                              string
+	ReviewState                           string
+	P1Findings                            []AutoPromoteFinding
+	Validator                             gate.ValidatorResult
+	LastActivityAt                        *time.Time
 }
 
 type AutoPromoteFinding struct {
@@ -46,22 +47,23 @@ const (
 type AutoPromoteReason string
 
 const (
-	AutoPromoteReasonReady                        AutoPromoteReason = "ready"
-	AutoPromoteReasonDisabled                     AutoPromoteReason = "disabled"
-	AutoPromoteReasonOptoutLabel                  AutoPromoteReason = "optout_label"
-	AutoPromoteReasonLabelNotAllowed              AutoPromoteReason = "label_not_allowed"
-	AutoPromoteReasonMissingPullRequest           AutoPromoteReason = "missing_pull_request"
-	AutoPromoteReasonMergeConflicts               AutoPromoteReason = "merge_conflicts"
-	AutoPromoteReasonCINotGreen                   AutoPromoteReason = "ci_not_green"
-	AutoPromoteReasonCodexReviewMissing           AutoPromoteReason = "automated_review_missing"
-	AutoPromoteReasonP1Findings                   AutoPromoteReason = "p1_findings"
-	AutoPromoteReasonCodexReviewNotQuiet          AutoPromoteReason = "codex_review_not_quiet"
-	AutoPromoteReasonHumanApprovalMissing         AutoPromoteReason = "human_approval_missing"
-	AutoPromoteReasonValidatorMissing             AutoPromoteReason = "validator_missing"
-	AutoPromoteReasonValidatorWait                AutoPromoteReason = "validator_wait"
-	AutoPromoteReasonValidatorRework              AutoPromoteReason = "validator_rework"
-	AutoPromoteReasonValidatorScoreBelowThreshold AutoPromoteReason = "validator_score_below_threshold"
-	AutoPromoteReasonValidatorBlockedSeverity     AutoPromoteReason = "validator_blocked_severity"
+	AutoPromoteReasonReady                           AutoPromoteReason = "ready"
+	AutoPromoteReasonDisabled                        AutoPromoteReason = "disabled"
+	AutoPromoteReasonOptoutLabel                     AutoPromoteReason = "optout_label"
+	AutoPromoteReasonLabelNotAllowed                 AutoPromoteReason = "label_not_allowed"
+	AutoPromoteReasonMissingPullRequest              AutoPromoteReason = "missing_pull_request"
+	AutoPromoteReasonPullRequestHydrationUnavailable AutoPromoteReason = "pull_request_hydration_unavailable"
+	AutoPromoteReasonMergeConflicts                  AutoPromoteReason = "merge_conflicts"
+	AutoPromoteReasonCINotGreen                      AutoPromoteReason = "ci_not_green"
+	AutoPromoteReasonCodexReviewMissing              AutoPromoteReason = "automated_review_missing"
+	AutoPromoteReasonP1Findings                      AutoPromoteReason = "p1_findings"
+	AutoPromoteReasonCodexReviewNotQuiet             AutoPromoteReason = "codex_review_not_quiet"
+	AutoPromoteReasonHumanApprovalMissing            AutoPromoteReason = "human_approval_missing"
+	AutoPromoteReasonValidatorMissing                AutoPromoteReason = "validator_missing"
+	AutoPromoteReasonValidatorWait                   AutoPromoteReason = "validator_wait"
+	AutoPromoteReasonValidatorRework                 AutoPromoteReason = "validator_rework"
+	AutoPromoteReasonValidatorScoreBelowThreshold    AutoPromoteReason = "validator_score_below_threshold"
+	AutoPromoteReasonValidatorBlockedSeverity        AutoPromoteReason = "validator_blocked_severity"
 )
 
 type AutoPromoteDecision struct {
@@ -91,6 +93,9 @@ func EvaluateAutoPromote(
 	}
 	if autoPromoteMergeConflicts(summary.MergeableState) {
 		return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonMergeConflicts)
+	}
+	if strings.TrimSpace(summary.PullRequestHydrationUnavailableReason) != "" {
+		return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable)
 	}
 	gateDecision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(summary), now, gate.EvaluationOptions{
 		QuietDuration: cfg.QuietDuration,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -142,6 +142,9 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 		}
 		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg.TerminalStates)
 		if decision.targetState == "" {
+			if strings.TrimSpace(decision.reason) != "" {
+				o.logStaleMergingPullRequestDeferred(issue, decision)
+			}
 			continue
 		}
 		if !o.applyStaleMergingPullRequestDecision(ctx, state, issue, decision, now) {
@@ -166,6 +169,9 @@ func staleMergingPullRequestDecisionForIssue(issue connector.Issue, terminalStat
 	pullRequest := issue.PullRequest
 	if pullRequest == nil {
 		return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: string(AutoPromoteReasonMissingPullRequest)}
+	}
+	if pullRequestHydrationUnavailableReason(pullRequest) != "" {
+		return staleMergingPullRequestDecision{reason: string(AutoPromoteReasonPullRequestHydrationUnavailable)}
 	}
 	switch normalizePullRequestState(pullRequest.State) {
 	case "merged":
@@ -266,6 +272,14 @@ func (o *Orchestrator) logStaleMergingPullRequestDecision(issue connector.Issue,
 	o.logger.Info("stale_merging_pr_reconciled", attrs...)
 }
 
+func (o *Orchestrator) logStaleMergingPullRequestDeferred(issue connector.Issue, decision staleMergingPullRequestDecision) {
+	if o.logger == nil {
+		return
+	}
+	attrs := mergeWorkerLogAttrs(issue, "reason", decision.reason)
+	o.logger.Info("stale_merging_pr_reconciliation_deferred", attrs...)
+}
+
 func (o *Orchestrator) logMergeWorkerPickup(issue connector.Issue, source string) {
 	if o.logger == nil || !mergeWorkerIssue(issue) {
 		return
@@ -328,6 +342,9 @@ func mergeWorkerLogAttrs(issue connector.Issue, attrs ...any) []any {
 		}
 		if headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA); headSHA != "" {
 			out = append(out, "head_sha", headSHA)
+		}
+		if reason := pullRequestHydrationUnavailableReason(issue.PullRequest); reason != "" {
+			out = append(out, "pull_request_hydration_reason", reason)
 		}
 	}
 	return append(out, attrs...)
@@ -723,6 +740,7 @@ func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	}
 
 	pullRequest := issue.PullRequest
+	summary.PullRequestHydrationUnavailableReason = pullRequestHydrationUnavailableReason(pullRequest)
 	if normalizePullRequestState(pullRequest.State) != "open" {
 		return summary
 	}
@@ -733,6 +751,13 @@ func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	summary.ReviewState = pullRequest.CodexReviewState
 	summary.P1Findings = autoPromoteFindingsFromPullRequest(pullRequest)
 	return summary
+}
+
+func pullRequestHydrationUnavailableReason(pullRequest *connector.PullRequest) string {
+	if pullRequest == nil {
+		return ""
+	}
+	return strings.TrimSpace(pullRequest.HydrationUnavailableReason)
 }
 
 func autoPromoteLastActivityAt(issue connector.Issue) *time.Time {
@@ -854,11 +879,17 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 		attrs = append(attrs, "ci_status", decision.CIStatus)
 	}
 	if issue.PullRequest != nil {
+		if issue.PullRequest.Number > 0 {
+			attrs = append(attrs, "pull_request_number", issue.PullRequest.Number)
+		}
 		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
 			attrs = append(attrs, "pull_request", url)
 		}
 		if mergeableState := strings.TrimSpace(issue.PullRequest.MergeableState); mergeableState != "" {
 			attrs = append(attrs, "mergeable_state", mergeableState)
+		}
+		if reason := pullRequestHydrationUnavailableReason(issue.PullRequest); reason != "" {
+			attrs = append(attrs, "pull_request_hydration_reason", reason)
 		}
 	}
 	if decision.QuietRemaining > 0 {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -403,6 +403,9 @@ func staleMergingIssueReadyForDispatch(issue connector.Issue) bool {
 		return false
 	}
 	pullRequest := issue.PullRequest
+	if pullRequestHydrationUnavailableReason(pullRequest) != "" {
+		return false
+	}
 	if normalizePullRequestState(pullRequest.State) != "open" {
 		return false
 	}

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -333,6 +333,75 @@ func TestTickAutoPromoteLogsNonTransitionDecisionsAtInfo(t *testing.T) {
 	}
 }
 
+func TestTickAutoPromoteDefersWhenPullRequestHydrationRateLimited(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 7, 24, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	prior := autoPromoteTickIssue("issue-rate-limited-pr", []string{"bug"}, &connector.PullRequest{
+		Number:                 77,
+		URL:                    "https://github.test/digitaldrywood/creswoodcorners-phone/pull/77",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	prior.Identifier = "digitaldrywood/creswoodcorners-phone#69"
+	current := autoPromoteTickIssue("issue-rate-limited-pr", []string{"bug"}, &connector.PullRequest{
+		Number:                     77,
+		HydrationUnavailableReason: "rate_limited",
+	})
+	current.Identifier = prior.Identifier
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{current}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+
+	state := newState(cfg)
+	state.Pipeline = []connector.Issue{prior}
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none", tracker.updates)
+	}
+	if strings.Contains(logs.String(), "reason=missing_pull_request") {
+		t.Fatalf("logs %q contain missing_pull_request", logs.String())
+	}
+	for _, fragment := range []string{
+		"reason=pull_request_hydration_unavailable",
+		"pull_request_hydration_reason=rate_limited",
+		"pull_request_number=77",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+	if len(state.Pipeline) != 1 || state.Pipeline[0].PullRequest == nil {
+		t.Fatalf("Pipeline = %#v, want retained pull request metadata", state.Pipeline)
+	}
+	pr := state.Pipeline[0].PullRequest
+	if pr.URL != "https://github.test/digitaldrywood/creswoodcorners-phone/pull/77" {
+		t.Fatalf("retained PullRequest.URL = %q, want prior URL", pr.URL)
+	}
+	if pr.HydrationUnavailableReason != "rate_limited" {
+		t.Fatalf("retained HydrationUnavailableReason = %q, want rate_limited", pr.HydrationUnavailableReason)
+	}
+}
+
 func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -973,6 +973,15 @@ func TestStaleMergingDispatchCandidatesFiltersUnsafePullRequests(t *testing.T) {
 				CIStatus:       "pending",
 			},
 		},
+		{
+			name: "hydration unavailable",
+			pullRequest: &connector.PullRequest{
+				State:                      "OPEN",
+				MergeableState:             "clean",
+				CIStatus:                   "success",
+				HydrationUnavailableReason: "rate_limited",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -313,6 +313,9 @@ func (p dispatchPlanner) dispatchableIssue(
 	if !stateIn(issue.State, p.cfg.ActiveStates) || stateIn(issue.State, p.cfg.TerminalStates) {
 		return false
 	}
+	if pullRequestHydrationUnavailableReason(issue.PullRequest) != "" {
+		return false
+	}
 	if duplicatePullRequestWork(issue) {
 		return false
 	}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -495,6 +495,11 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "todo with unavailable pull request hydration skips",
+			issue: dispatchTestIssueWithUnavailablePullRequestHydration("issue-todo-pr-rate-limited", "Todo"),
+			want:  false,
+		},
+		{
 			name:  "in progress with open pull request dispatches",
 			issue: dispatchTestIssueWithPullRequest("issue-progress-open-pr", "In Progress", "OPEN"),
 			want:  true,
@@ -503,6 +508,11 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 			name:  "rework with open pull request dispatches",
 			issue: dispatchTestIssueWithPullRequest("issue-rework-open-pr", "Rework", "OPEN"),
 			want:  true,
+		},
+		{
+			name:  "rework with unavailable pull request hydration skips",
+			issue: dispatchTestIssueWithUnavailablePullRequestHydration("issue-rework-pr-rate-limited", "Rework"),
+			want:  false,
 		},
 		{
 			name:  "merging with open pull request dispatches",
@@ -941,6 +951,12 @@ func dispatchTestIssueWithPullRequest(id, state, prState string) connector.Issue
 		BranchName: "detent/digitaldrywood_detent_187",
 		State:      prState,
 	}
+	return issue
+}
+
+func dispatchTestIssueWithUnavailablePullRequestHydration(id, state string) connector.Issue {
+	issue := dispatchTestIssueWithPullRequest(id, state, "OPEN")
+	issue.PullRequest.HydrationUnavailableReason = "rate_limited"
 	return issue
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -295,19 +295,20 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		pullRequest = &connector.PullRequest{Number: *prNumber}
 	}
 	return &telemetry.PullRequest{
-		Number:             pullRequest.Number,
-		URL:                pullRequest.URL,
-		BranchName:         pullRequest.BranchName,
-		State:              pullRequest.State,
-		MergeableState:     pullRequest.MergeableState,
-		CIStatus:           pullRequest.CIStatus,
-		CheckRunCount:      pullRequest.CheckRunCount,
-		StatusContextCount: pullRequest.StatusContextCount,
-		CIDurationSeconds:  pullRequest.CIDurationSeconds,
-		QuietWaitSeconds:   pullRequestQuietWaitSeconds(issue, quietDuration, pollInterval),
-		SlowChecks:         telemetryPullRequestChecks(pullRequest.SlowChecks),
-		RunningChecks:      append([]string(nil), pullRequest.RunningChecks...),
-		CodexReviewState:   pullRequest.CodexReviewState,
+		Number:                     pullRequest.Number,
+		URL:                        pullRequest.URL,
+		BranchName:                 pullRequest.BranchName,
+		State:                      pullRequest.State,
+		MergeableState:             pullRequest.MergeableState,
+		HydrationUnavailableReason: pullRequest.HydrationUnavailableReason,
+		CIStatus:                   pullRequest.CIStatus,
+		CheckRunCount:              pullRequest.CheckRunCount,
+		StatusContextCount:         pullRequest.StatusContextCount,
+		CIDurationSeconds:          pullRequest.CIDurationSeconds,
+		QuietWaitSeconds:           pullRequestQuietWaitSeconds(issue, quietDuration, pollInterval),
+		SlowChecks:                 telemetryPullRequestChecks(pullRequest.SlowChecks),
+		RunningChecks:              append([]string(nil), pullRequest.RunningChecks...),
+		CodexReviewState:           pullRequest.CodexReviewState,
 	}
 }
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -88,6 +88,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	if !ok {
 		return
 	}
+	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
 
 	transitions := o.refreshTransitionSets(ctx, state, fetched, previous)
 	completedEpics := o.resolveCompletedEpics(ctx, state, transitions, previous)
@@ -468,6 +469,49 @@ func boardIssuesFromFetched(fetched tickFetchedIssues) []connector.Issue {
 		issues = mergeIssueSlices(issues, fetched.status)
 	}
 	return issues
+}
+
+func retainUnavailablePullRequestsFromPrevious(fetched tickFetchedIssues, previous tickPreviousState) tickFetchedIssues {
+	previousIssues := mergeIssueSlices(previous.pipeline, previous.epicTransitionWatch)
+	fetched.candidates = retainUnavailablePullRequests(fetched.candidates, previousIssues)
+	fetched.status = retainUnavailablePullRequests(fetched.status, previousIssues)
+	return fetched
+}
+
+func retainUnavailablePullRequests(current []connector.Issue, previous []connector.Issue) []connector.Issue {
+	if len(current) == 0 || len(previous) == 0 {
+		return current
+	}
+	previousByKey := make(map[string]connector.Issue, len(previous))
+	for _, issue := range previous {
+		key := issueIdentityKey(issue)
+		if key == "" {
+			continue
+		}
+		previousByKey[key] = cloneIssue(issue)
+	}
+	out := cloneIssues(current)
+	for index, issue := range out {
+		reason := pullRequestHydrationUnavailableReason(issue.PullRequest)
+		if reason == "" {
+			continue
+		}
+		prior, ok := previousByKey[issueIdentityKey(issue)]
+		if !ok || prior.PullRequest == nil {
+			continue
+		}
+		retained := cloneIssue(prior).PullRequest
+		retained.HydrationUnavailableReason = reason
+		out[index].PullRequest = retained
+		if out[index].PRNumber == nil && prior.PRNumber != nil {
+			prNumber := *prior.PRNumber
+			out[index].PRNumber = &prNumber
+		}
+		if out[index].PRRepository == "" {
+			out[index].PRRepository = prior.PRRepository
+		}
+	}
+	return out
 }
 
 func (o *Orchestrator) dispatchTickIssues(

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -206,19 +206,20 @@ type BlockedRef struct {
 }
 
 type PullRequest struct {
-	Number             int                `json:"number,omitempty"`
-	URL                string             `json:"url,omitempty"`
-	BranchName         string             `json:"branch_name,omitempty"`
-	State              string             `json:"state,omitempty"`
-	MergeableState     string             `json:"mergeable_state,omitempty"`
-	CIStatus           string             `json:"ci_status,omitempty"`
-	CheckRunCount      int                `json:"check_run_count,omitempty"`
-	StatusContextCount int                `json:"status_context_count,omitempty"`
-	CIDurationSeconds  int64              `json:"ci_duration_seconds,omitempty"`
-	QuietWaitSeconds   int64              `json:"quiet_wait_seconds,omitempty"`
-	SlowChecks         []PullRequestCheck `json:"slow_checks,omitempty"`
-	RunningChecks      []string           `json:"running_checks,omitempty"`
-	CodexReviewState   string             `json:"codex_review_state,omitempty"`
+	Number                     int                `json:"number,omitempty"`
+	URL                        string             `json:"url,omitempty"`
+	BranchName                 string             `json:"branch_name,omitempty"`
+	State                      string             `json:"state,omitempty"`
+	MergeableState             string             `json:"mergeable_state,omitempty"`
+	HydrationUnavailableReason string             `json:"hydration_unavailable_reason,omitempty"`
+	CIStatus                   string             `json:"ci_status,omitempty"`
+	CheckRunCount              int                `json:"check_run_count,omitempty"`
+	StatusContextCount         int                `json:"status_context_count,omitempty"`
+	CIDurationSeconds          int64              `json:"ci_duration_seconds,omitempty"`
+	QuietWaitSeconds           int64              `json:"quiet_wait_seconds,omitempty"`
+	SlowChecks                 []PullRequestCheck `json:"slow_checks,omitempty"`
+	RunningChecks              []string           `json:"running_checks,omitempty"`
+	CodexReviewState           string             `json:"codex_review_state,omitempty"`
 }
 
 type PullRequestCheck struct {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2813,6 +2813,9 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		return ""
 	}
 	parts := []string{}
+	if hydration := pullRequestHydrationWaitDetail(issue.PullRequest.HydrationUnavailableReason); hydration != "" {
+		parts = append(parts, hydration)
+	}
 	if issue.PullRequest.QuietWaitSeconds > 0 {
 		parts = append(parts, "quiet "+formatDuration(float64(issue.PullRequest.QuietWaitSeconds)))
 	}
@@ -2826,6 +2829,17 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		parts = append(parts, "running "+runningChecks)
 	}
 	return strings.Join(parts, " / ")
+}
+
+func pullRequestHydrationWaitDetail(reason string) string {
+	switch strings.TrimSpace(reason) {
+	case "rate_limited":
+		return "PR hydration rate-limited"
+	case "rest_budget_reserved":
+		return "PR hydration waiting for REST budget"
+	default:
+		return ""
+	}
 }
 
 func prPipelineSlowChecks(checks []telemetry.PullRequestCheck) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1471,10 +1471,11 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 						State:      "Human Review",
 						UpdatedAt:  &reviewAt,
 						PullRequest: &telemetry.PullRequest{
-							Number:           142,
-							URL:              "https://github.com/digitaldrywood/detent/pull/142",
-							CIStatus:         "success",
-							CodexReviewState: "clean",
+							Number:                     142,
+							URL:                        "https://github.com/digitaldrywood/detent/pull/142",
+							CIStatus:                   "success",
+							CodexReviewState:           "clean",
+							HydrationUnavailableReason: "rate_limited",
 						},
 					},
 					{
@@ -1540,7 +1541,7 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 				},
 			},
 			want: []pipelineCardSnapshot{
-				{Lane: "Human Review", IssueNumber: "#142", Title: "Review lane PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2h 0m"},
+				{Lane: "Human Review", IssueNumber: "#142", Title: "Review lane PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2h 0m", WaitDetail: "PR hydration rate-limited"},
 				{Lane: "Merging", IssueNumber: "#143", Title: "Merge lane PR", CIStatus: "pending", CodexReviewState: "P2", TimeInStage: "15m 0s", WaitDetail: "quiet 10m 0s / CI 8m 30s / slow GoReleaser Snapshot 4m 7s / running Test Coverage"},
 				{Lane: "Done today", IssueNumber: "#144", Title: "Done lane PR", CIStatus: "pass", CodexReviewState: "P1", TimeInStage: "45m 0s"},
 				{Lane: "Done today", IssueNumber: "#145", Title: "Done lane unverified PR", CIStatus: "pending", CodexReviewState: "clean", TimeInStage: "45m 0s"},


### PR DESCRIPTION
## Summary

- Preserve partial/previous linked PR metadata when GitHub PR hydration is rate-limited or held by REST budget backoff.
- Defer auto-promote with `pull_request_hydration_unavailable` instead of treating transient PR/review 429s as `missing_pull_request`.
- Surface the hydration wait reason in snapshot telemetry and dashboard wait details.

Fixes #696

## Test Plan

- [x] `go test ./internal/connector/github -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/web/templates -count=1`
- [x] `go test ./...`
- [x] `make check`