### PR TITLE
fix(orchestrator): survive PR hydration backoff

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -2304,20 +2304,41 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	if strings.TrimSpace(pullRequest.HeadSHA) != "" {
 		ci, err := c.fetchPullRequestCI(ctx, repo, pullRequest.HeadSHA)
 		if err != nil {
+			if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, err) {
+				return nil
+			}
 			return err
 		}
 		status.ci = ci
 	}
 	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number, pullRequest.HeadSHA)
 	if err != nil {
+		if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, err) {
+			return nil
+		}
 		return err
 	}
 	status.reviews = reviews
-	if useStatusCache && c.pullRequests != nil {
+	if c.pullRequests != nil {
 		c.pullRequests.Set(repo, pullRequest.Number, pullRequest.HeadSHA, status)
 	}
 	applyPullRequestStatus(pullRequest, status)
 	return nil
+}
+
+func (c *Connector) applyCachedPullRequestStatusAfterThrottle(repo pullRequestRepo, pullRequest *pullRequestNode, err error) bool {
+	if c.pullRequests == nil || pullRequest == nil {
+		return false
+	}
+	if !errors.Is(err, ErrRESTBudgetReserved) && !errors.Is(err, ErrRateLimited) {
+		return false
+	}
+	status, ok := c.pullRequests.Get(repo, pullRequest.Number, pullRequest.HeadSHA)
+	if !ok {
+		return false
+	}
+	applyPullRequestStatus(pullRequest, status)
+	return true
 }
 
 func applyPullRequestStatus(pullRequest *pullRequestNode, status pullRequestStatus) {
@@ -4390,7 +4411,7 @@ func stateInList(state string, states []string) bool {
 }
 
 func attachPullRequestsForStates(states map[string]struct{}) bool {
-	for _, state := range []string{"Human Review", "Merging", "Done", "Blocked"} {
+	for _, state := range []string{"Human Review", "Merging", "Blocked"} {
 		if _, ok := states[normalizeStateName(state)]; ok {
 			return true
 		}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -932,6 +932,59 @@ func TestConnectorFetchIssuesByStatesRechecksPullRequestStatusForPromotion(t *te
 	}
 }
 
+func TestConnectorFetchIssuesByStatesUsesCachedPullRequestStatusAfterRateLimit(t *testing.T) {
+	t.Parallel()
+
+	projectBody := `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_401","content":{"__typename":"Issue","id":"I_401","number":401,"title":"Human review issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/401","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":411,"url":"https://github.com/digitaldrywood/detent/pull/411","state":"OPEN","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`
+	pullBody := `{"number":411,"html_url":"https://github.com/digitaldrywood/detent/pull/411","state":"open","head":{"ref":"detent/digitaldrywood_detent_401","sha":"head-current"}}`
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: projectBody},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411", body: pullBody},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"success"}]}`},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100", body: `[]`},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411/reviews?per_page=100", body: `[]`},
+		{body: projectBody},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411", body: pullBody},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"Retry-After":          "120",
+				"X-RateLimit-Limit":    "5000",
+				"X-RateLimit-Used":     "264",
+				"X-RateLimit-Resource": "core",
+			},
+			body: `{"message":"secondary rate limit"}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	first, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() first error = %v", err)
+	}
+	if len(first) != 1 || first[0].PullRequest == nil || first[0].PullRequest.CIStatus != "pass" {
+		t.Fatalf("FetchIssuesByStates() first = %#v, want cached hydrated PR", first)
+	}
+
+	second, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() second error = %v", err)
+	}
+	if len(second) != 1 || second[0].PullRequest == nil {
+		t.Fatalf("FetchIssuesByStates() second = %#v, want hydrated PR", second)
+	}
+	pr := second[0].PullRequest
+	if pr.HydrationUnavailableReason != "" {
+		t.Fatalf("HydrationUnavailableReason = %q, want cached status without unavailable marker", pr.HydrationUnavailableReason)
+	}
+	if pr.CIStatus != "pass" {
+		t.Fatalf("CIStatus = %q, want cached pass", pr.CIStatus)
+	}
+}
+
 func TestConnectorFetchIssuesByStatesMarksLinkedPullRequestHydrationRateLimited(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -151,11 +151,6 @@ func TestConnectorFetchLabelIssuesPrefersCanonicalDoneOverCancelledAlias(t *test
 			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Adone&page=1&per_page=100&state=all",
 			body:   `[{"node_id":"I_485","number":485,"title":"Installer packages","body":"","state":"closed","state_reason":"completed","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:done"},{"name":"release"}]}]`,
 		},
-		{
-			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
-			body:   `[]`,
-		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		GitHubStatusSource: GitHubStatusSourceLabel,
@@ -176,6 +171,9 @@ func TestConnectorFetchLabelIssuesPrefersCanonicalDoneOverCancelledAlias(t *test
 	}
 	if !got[0].Closed || got[0].ClosedReason != "completed" {
 		t.Fatalf("closed metadata = (%v, %q), want closed completed", got[0].Closed, got[0].ClosedReason)
+	}
+	if len(server.requests()) != 1 {
+		t.Fatalf("request count = %d, want only label issue fetch", len(server.requests()))
 	}
 }
 

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -313,7 +313,7 @@ func (p dispatchPlanner) dispatchableIssue(
 	if !stateIn(issue.State, p.cfg.ActiveStates) || stateIn(issue.State, p.cfg.TerminalStates) {
 		return false
 	}
-	if pullRequestHydrationUnavailableReason(issue.PullRequest) != "" {
+	if pullRequestHydrationBlocksDispatch(issue) {
 		return false
 	}
 	if duplicatePullRequestWork(issue) {
@@ -339,6 +339,20 @@ func (p dispatchPlanner) dispatchableIssue(
 	}
 
 	return p.slotsAvailable(issue, state, preferredWorkerHost)
+}
+
+func pullRequestHydrationBlocksDispatch(issue connector.Issue) bool {
+	pullRequest := issue.PullRequest
+	if pullRequestHydrationUnavailableReason(pullRequest) == "" {
+		return false
+	}
+	if normalizeState(issue.State) != "todo" {
+		return true
+	}
+	return pullRequest.Number > 0 ||
+		strings.TrimSpace(pullRequest.URL) != "" ||
+		strings.TrimSpace(pullRequest.BranchName) != "" ||
+		normalizePullRequestState(pullRequest.State) != ""
 }
 
 func (p dispatchPlanner) authorized(issue connector.Issue) bool {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -500,6 +500,11 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 			want:  false,
 		},
 		{
+			name:  "todo with unknown unavailable pull request hydration dispatches",
+			issue: dispatchTestIssueWithUnknownUnavailablePullRequestHydration("issue-todo-pr-unknown", "Todo"),
+			want:  true,
+		},
+		{
 			name:  "in progress with open pull request dispatches",
 			issue: dispatchTestIssueWithPullRequest("issue-progress-open-pr", "In Progress", "OPEN"),
 			want:  true,
@@ -957,6 +962,14 @@ func dispatchTestIssueWithPullRequest(id, state, prState string) connector.Issue
 func dispatchTestIssueWithUnavailablePullRequestHydration(id, state string) connector.Issue {
 	issue := dispatchTestIssueWithPullRequest(id, state, "OPEN")
 	issue.PullRequest.HydrationUnavailableReason = "rate_limited"
+	return issue
+}
+
+func dispatchTestIssueWithUnknownUnavailablePullRequestHydration(id, state string) connector.Issue {
+	issue := dispatchTestIssue(id, state)
+	issue.PullRequest = &connector.PullRequest{
+		HydrationUnavailableReason: "rest_budget_reserved",
+	}
 	return issue
 }
 


### PR DESCRIPTION
## Summary

- allow fresh Todo issues to dispatch when PR hydration only produced an unknown unavailable marker
- stop terminal workspace-cleanup fetches from hydrating PR/check/review data for Done issues
- cache successful current-head PR status and reuse it when later PR/check/review hydration hits REST budget or rate-limit errors

Fixes #701.
Mitigates #702.

## Verification

- go test ./internal/orchestrator ./internal/connector/github
- make check

## Incident context

Live Detent was running with no active agents while Todo work remained unassigned and Human Review auto-promote kept skipping with `pull_request_hydration_unavailable`. REST primary budget was not exhausted, but PR/check-run fanout repeatedly hit budget/rate-limit paths. This hotfix cuts the unnecessary terminal fanout and lets Detent keep dispatching safe Todo work while preserving PR safeguards for known PR work.