### PR TITLE
fix(github): cool down pr hydration

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -718,6 +718,8 @@ type pullRequestNode struct {
 	HeadRefName                string                            `json:"headRefName"`
 	HeadSHA                    string                            `json:"headSHA"`
 	HydrationUnavailableReason string                            `json:"-"`
+	HydrationDegradedReason    string                            `json:"-"`
+	HydrationNextRetryAt       *time.Time                        `json:"-"`
 	Commits                    nodeConnection[pullRequestCommit] `json:"commits"`
 	LatestReviews              nodeConnection[pullRequestReview] `json:"latestReviews"`
 	CodexReviews               pullRequestCodexReviews           `json:"-"`
@@ -1948,10 +1950,14 @@ func (c *Connector) attachPullRequestsWithCache(ctx context.Context, issues []co
 		if !hasUnattachedBranchPullRequestCandidates(issues, byRepo[repo]) {
 			continue
 		}
+		if state, ok := c.currentPullRequestHydrationState(repo); ok {
+			markPullRequestHydrationUnavailableForCandidates(issues, byRepo[repo], repo, state)
+			continue
+		}
 		pullRequests, err := c.fetchRepositoryPullRequests(ctx, repo)
 		if err != nil {
-			if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
-				markPullRequestHydrationUnavailableForCandidates(issues, byRepo[repo], repo, reason)
+			if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
+				markPullRequestHydrationUnavailableForCandidates(issues, byRepo[repo], repo, state)
 				continue
 			}
 			return err
@@ -2103,21 +2109,25 @@ func (c *Connector) attachLinkedPullRequests(
 		if strings.TrimSpace(pullRequestRepo.Owner) == "" || strings.TrimSpace(pullRequestRepo.Name) == "" {
 			pullRequestRepo = repo
 		}
+		if state, ok := c.currentPullRequestHydrationState(pullRequestRepo); ok {
+			attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber, state)
+			continue
+		}
 		key := pullRequestKey{Repo: pullRequestRepo, Number: candidate.PullRequestNumber}
 		pullRequest, ok := pullRequests[key]
 		if !ok {
 			var err error
 			pullRequest, err = c.fetchRepositoryPullRequest(ctx, pullRequestRepo, candidate.PullRequestNumber)
 			if err != nil {
-				if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
-					attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber, reason)
+				if state := c.pullRequestHydrationStateForError(pullRequestRepo, err); state.Reason != "" {
+					attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber, state)
 					continue
 				}
 				return err
 			}
 			if err := c.populatePullRequestStatus(ctx, pullRequestRepo, &pullRequest, useStatusCache); err != nil {
-				if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
-					pullRequest.HydrationUnavailableReason = reason
+				if state := c.pullRequestHydrationStateForError(pullRequestRepo, err); state.Reason != "" {
+					applyPullRequestHydrationUnavailableState(&pullRequest, state)
 				} else {
 					return err
 				}
@@ -2156,17 +2166,22 @@ func (c *Connector) attachMatchingPullRequests(
 				var err error
 				hydratedPullRequest, err = c.fetchRepositoryPullRequest(ctx, repo, pullRequest.Number)
 				if err != nil {
-					if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
-						pullRequest.HydrationUnavailableReason = reason
+					if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
+						applyPullRequestHydrationUnavailableState(&pullRequest, state)
 						hydrated[pullRequest.Number] = pullRequest
 						attachPullRequestToIssue(&issues[candidate.Index], repo, pullRequest)
-						continue
+						markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
+						return nil
 					}
 					return err
 				}
 				if err := c.populatePullRequestStatus(ctx, repo, &hydratedPullRequest, useStatusCache); err != nil {
-					if reason := pullRequestHydrationUnavailableReason(err); reason != "" {
-						hydratedPullRequest.HydrationUnavailableReason = reason
+					if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
+						applyPullRequestHydrationUnavailableState(&hydratedPullRequest, state)
+						hydrated[pullRequest.Number] = hydratedPullRequest
+						attachPullRequestToIssue(&issues[candidate.Index], repo, hydratedPullRequest)
+						markPullRequestHydrationUnavailableForCandidates(issues, candidates, repo, state)
+						return nil
 					} else {
 						return err
 					}
@@ -2212,6 +2227,8 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		ActivityAt:                   cloneGitHubTime(pullRequest.ActivityAt),
 		HeadSHA:                      strings.TrimSpace(pullRequest.HeadSHA),
 		HydrationUnavailableReason:   strings.TrimSpace(pullRequest.HydrationUnavailableReason),
+		HydrationDegradedReason:      strings.TrimSpace(pullRequest.HydrationDegradedReason),
+		HydrationNextRetryAt:         cloneGitHubTime(pullRequest.HydrationNextRetryAt),
 		CIStatus:                     normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
 		CheckRunCount:                pullRequest.CI.CheckRunCount,
 		StatusContextCount:           pullRequest.CI.StatusContextCount,
@@ -2238,7 +2255,7 @@ func markPullRequestHydrationUnavailableForCandidates(
 	issues []connector.Issue,
 	candidates []issuePullRequestCandidate,
 	defaultRepo pullRequestRepo,
-	reason string,
+	state pullRequestHydrationState,
 ) {
 	for _, candidate := range candidates {
 		if issues[candidate.Index].PullRequest != nil {
@@ -2248,13 +2265,12 @@ func markPullRequestHydrationUnavailableForCandidates(
 		if strings.TrimSpace(repo.Owner) == "" || strings.TrimSpace(repo.Name) == "" {
 			repo = defaultRepo
 		}
-		attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], repo, candidate.PullRequestNumber, reason)
+		attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], repo, candidate.PullRequestNumber, state)
 	}
 }
 
-func attachPullRequestHydrationUnavailableToIssue(issue *connector.Issue, repo pullRequestRepo, number int, reason string) {
-	reason = strings.TrimSpace(reason)
-	if reason == "" {
+func attachPullRequestHydrationUnavailableToIssue(issue *connector.Issue, repo pullRequestRepo, number int, state pullRequestHydrationState) {
+	if strings.TrimSpace(state.Reason) == "" {
 		return
 	}
 	if issue.PullRequest == nil {
@@ -2263,7 +2279,8 @@ func attachPullRequestHydrationUnavailableToIssue(issue *connector.Issue, repo p
 	if number > 0 {
 		issue.PullRequest.Number = number
 	}
-	issue.PullRequest.HydrationUnavailableReason = reason
+	issue.PullRequest.HydrationUnavailableReason = strings.TrimSpace(state.Reason)
+	issue.PullRequest.HydrationNextRetryAt = cloneGitHubTime(state.NextRetryAt)
 	if issue.PRNumber == nil && number > 0 {
 		issue.PRNumber = &number
 	}
@@ -2272,15 +2289,71 @@ func attachPullRequestHydrationUnavailableToIssue(issue *connector.Issue, repo p
 	}
 }
 
-func pullRequestHydrationUnavailableReason(err error) string {
+func applyPullRequestHydrationUnavailableState(pullRequest *pullRequestNode, state pullRequestHydrationState) {
+	if pullRequest == nil || strings.TrimSpace(state.Reason) == "" {
+		return
+	}
+	pullRequest.HydrationUnavailableReason = strings.TrimSpace(state.Reason)
+	pullRequest.HydrationNextRetryAt = cloneGitHubTime(state.NextRetryAt)
+}
+
+func (c *Connector) currentPullRequestHydrationState(repo pullRequestRepo) (pullRequestHydrationState, bool) {
+	if c == nil || c.prHydration == nil {
+		return pullRequestHydrationState{}, false
+	}
+	return c.prHydration.Current(repo)
+}
+
+func (c *Connector) pullRequestHydrationStateForError(repo pullRequestRepo, err error) pullRequestHydrationState {
 	switch {
 	case errors.Is(err, ErrRESTBudgetReserved):
-		return connector.PullRequestHydrationReasonRESTBudgetReserved
+		return pullRequestHydrationState{Reason: connector.PullRequestHydrationReasonRESTBudgetReserved}
 	case errors.Is(err, ErrRateLimited):
-		return connector.PullRequestHydrationReasonRateLimited
+		var statusErr *StatusError
+		if errors.As(err, &statusErr) {
+			switch statusErr.RateLimitKind {
+			case restRateLimitKindSecondaryThrottled:
+				return c.tripPullRequestHydrationCircuit(repo, statusErr.RetryAfter)
+			case restRateLimitKindPrimaryExhausted:
+				return newPullRequestHydrationState(
+					connector.PullRequestHydrationReasonPrimaryExhausted,
+					c.pullRequestHydrationRetryAt(statusErr),
+				)
+			}
+		}
+		return pullRequestHydrationState{Reason: connector.PullRequestHydrationReasonRateLimited}
 	default:
-		return ""
+		return pullRequestHydrationState{}
 	}
+}
+
+func (c *Connector) tripPullRequestHydrationCircuit(repo pullRequestRepo, retryAfter time.Duration) pullRequestHydrationState {
+	reason := connector.PullRequestHydrationReasonSecondaryThrottled
+	if c == nil || c.prHydration == nil {
+		return pullRequestHydrationState{Reason: reason}
+	}
+	state := c.prHydration.Trip(repo, reason, retryAfter)
+	if strings.TrimSpace(state.Reason) == "" {
+		return pullRequestHydrationState{Reason: reason}
+	}
+	return state
+}
+
+func (c *Connector) pullRequestHydrationRetryAt(statusErr *StatusError) time.Time {
+	if statusErr == nil {
+		return time.Time{}
+	}
+	now := time.Now()
+	if c != nil && c.prHydration != nil && c.prHydration.now != nil {
+		now = c.prHydration.now()
+	}
+	if statusErr.RetryAfter > 0 {
+		return now.Add(statusErr.RetryAfter)
+	}
+	if statusErr.ResetAt.After(now) {
+		return statusErr.ResetAt
+	}
+	return time.Time{}
 }
 
 func pullRequestRepoName(repo pullRequestRepo) string {
@@ -2304,7 +2377,8 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	if strings.TrimSpace(pullRequest.HeadSHA) != "" {
 		ci, err := c.fetchPullRequestCI(ctx, repo, pullRequest.HeadSHA)
 		if err != nil {
-			if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, err) {
+			state := c.pullRequestHydrationStateForError(repo, err)
+			if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, state) {
 				return nil
 			}
 			return err
@@ -2313,7 +2387,8 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	}
 	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number, pullRequest.HeadSHA)
 	if err != nil {
-		if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, err) {
+		state := c.pullRequestHydrationStateForError(repo, err)
+		if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, state) {
 			return nil
 		}
 		return err
@@ -2326,11 +2401,11 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	return nil
 }
 
-func (c *Connector) applyCachedPullRequestStatusAfterThrottle(repo pullRequestRepo, pullRequest *pullRequestNode, err error) bool {
+func (c *Connector) applyCachedPullRequestStatusAfterThrottle(repo pullRequestRepo, pullRequest *pullRequestNode, state pullRequestHydrationState) bool {
 	if c.pullRequests == nil || pullRequest == nil {
 		return false
 	}
-	if !errors.Is(err, ErrRESTBudgetReserved) && !errors.Is(err, ErrRateLimited) {
+	if strings.TrimSpace(state.Reason) == "" {
 		return false
 	}
 	status, ok := c.pullRequests.Get(repo, pullRequest.Number, pullRequest.HeadSHA)
@@ -2338,6 +2413,8 @@ func (c *Connector) applyCachedPullRequestStatusAfterThrottle(repo pullRequestRe
 		return false
 	}
 	applyPullRequestStatus(pullRequest, status)
+	pullRequest.HydrationDegradedReason = connector.PullRequestHydrationReasonStaleCachedPullData
+	pullRequest.HydrationNextRetryAt = cloneGitHubTime(state.NextRetryAt)
 	return true
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -871,6 +871,93 @@ func TestConnectorFetchCandidateIssuesMarksBranchPullRequestHydrationUnavailable
 	}
 }
 
+func TestConnectorFetchCandidateIssuesStopsBranchPullRequestHydrationAfterSecondaryThrottle(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 13, 0, 0, 0, time.UTC)
+	projectBody := `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_182","content":{"__typename":"Issue","id":"I_182","number":182,"title":"First issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/182","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Todo"},"priorityValue":null},{"id":"PVTI_183","content":{"__typename":"Issue","id":"I_183","number":183,"title":"Second issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/183","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: projectBody},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-187"}},{"number":188,"html_url":"https://github.com/digitaldrywood/detent/pull/188","state":"open","head":{"ref":"detent/digitaldrywood_detent_183","sha":"sha-188"}}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls/187",
+			body:   `{"number":187,"html_url":"https://github.com/digitaldrywood/detent/pull/187","state":"open","head":{"ref":"detent/digitaldrywood_detent_182","sha":"sha-187"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/sha-187/check-runs?per_page=100",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"Retry-After":           "120",
+				"X-RateLimit-Limit":     "5000",
+				"X-RateLimit-Used":      "264",
+				"X-RateLimit-Remaining": "4736",
+				"X-RateLimit-Resource":  "core",
+			},
+			body: `{"message":"secondary rate limit"}`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	got, err := c.FetchCandidateIssues(context.Background())
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 2", len(got))
+	}
+
+	byID := map[string]connector.Issue{}
+	for _, issue := range got {
+		byID[issue.ID] = issue
+	}
+	for _, id := range []string{"I_182", "I_183"} {
+		pr := byID[id].PullRequest
+		if pr == nil {
+			t.Fatalf("%s PullRequest = nil, want hydration marker", id)
+		}
+		if pr.HydrationUnavailableReason != connector.PullRequestHydrationReasonSecondaryThrottled {
+			t.Fatalf("%s HydrationUnavailableReason = %q, want secondary_throttled", id, pr.HydrationUnavailableReason)
+		}
+		if pr.HydrationNextRetryAt == nil || !pr.HydrationNextRetryAt.After(now.Add(120*time.Second)) {
+			t.Fatalf("%s HydrationNextRetryAt = %v, want retry-after plus jitter", id, pr.HydrationNextRetryAt)
+		}
+	}
+	if byID["I_182"].PullRequest.Number != 187 {
+		t.Fatalf("I_182 PullRequest.Number = %d, want hydrated PR number 187", byID["I_182"].PullRequest.Number)
+	}
+	if byID["I_183"].PullRequest.Number != 0 {
+		t.Fatalf("I_183 PullRequest.Number = %d, want no second PR hydration after circuit trip", byID["I_183"].PullRequest.Number)
+	}
+
+	requests := server.requests()
+	checkRunRequests := 0
+	for _, request := range requests {
+		path, _ := request["path"].(string)
+		if strings.Contains(path, "/pulls/188") || strings.Contains(path, "sha-188") {
+			t.Fatalf("unexpected request after circuit trip: %#v", request)
+		}
+		if strings.Contains(path, "/check-runs") {
+			checkRunRequests++
+		}
+	}
+	if checkRunRequests != 1 {
+		t.Fatalf("check-runs requests = %d, want only first PR status attempt; requests = %#v", checkRunRequests, requests)
+	}
+}
+
 func TestConnectorFetchIssuesByStatesRechecksPullRequestStatusForPromotion(t *testing.T) {
 	t.Parallel()
 
@@ -935,6 +1022,7 @@ func TestConnectorFetchIssuesByStatesRechecksPullRequestStatusForPromotion(t *te
 func TestConnectorFetchIssuesByStatesUsesCachedPullRequestStatusAfterRateLimit(t *testing.T) {
 	t.Parallel()
 
+	now := time.Date(2026, 6, 25, 10, 0, 0, 0, time.UTC)
 	projectBody := `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_401","content":{"__typename":"Issue","id":"I_401","number":401,"title":"Human review issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/401","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":411,"url":"https://github.com/digitaldrywood/detent/pull/411","state":"OPEN","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`
 	pullBody := `{"number":411,"html_url":"https://github.com/digitaldrywood/detent/pull/411","state":"open","head":{"ref":"detent/digitaldrywood_detent_401","sha":"head-current"}}`
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
@@ -950,16 +1038,22 @@ func TestConnectorFetchIssuesByStatesUsesCachedPullRequestStatusAfterRateLimit(t
 			path:   "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100",
 			status: http.StatusTooManyRequests,
 			headers: map[string]string{
-				"Retry-After":          "120",
-				"X-RateLimit-Limit":    "5000",
-				"X-RateLimit-Used":     "264",
-				"X-RateLimit-Resource": "core",
+				"Retry-After":           "120",
+				"X-RateLimit-Limit":     "5000",
+				"X-RateLimit-Used":      "264",
+				"X-RateLimit-Remaining": "4736",
+				"X-RateLimit-Resource":  "core",
 			},
 			body: `{"message":"secondary rate limit"}`,
 		},
 	})
 
-	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+		Now: func() time.Time {
+			return now
+		},
+	})
 
 	first, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
 	if err != nil {
@@ -980,14 +1074,121 @@ func TestConnectorFetchIssuesByStatesUsesCachedPullRequestStatusAfterRateLimit(t
 	if pr.HydrationUnavailableReason != "" {
 		t.Fatalf("HydrationUnavailableReason = %q, want cached status without unavailable marker", pr.HydrationUnavailableReason)
 	}
+	if pr.HydrationDegradedReason != connector.PullRequestHydrationReasonStaleCachedPullData {
+		t.Fatalf("HydrationDegradedReason = %q, want stale cached pull request marker", pr.HydrationDegradedReason)
+	}
+	if pr.HydrationNextRetryAt == nil || !pr.HydrationNextRetryAt.After(now.Add(120*time.Second)) {
+		t.Fatalf("HydrationNextRetryAt = %v, want retry-after plus jitter", pr.HydrationNextRetryAt)
+	}
 	if pr.CIStatus != "pass" {
 		t.Fatalf("CIStatus = %q, want cached pass", pr.CIStatus)
 	}
 }
 
-func TestConnectorFetchIssuesByStatesMarksLinkedPullRequestHydrationRateLimited(t *testing.T) {
+func TestConnectorFetchIssuesByStatesCircuitBreaksPullRequestHydrationAfterSecondaryThrottle(t *testing.T) {
 	t.Parallel()
 
+	now := time.Date(2026, 6, 25, 11, 0, 0, 0, time.UTC)
+	projectBody := `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_401","content":{"__typename":"Issue","id":"I_401","number":401,"title":"Human review issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/401","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":411,"url":"https://github.com/digitaldrywood/detent/pull/411","state":"OPEN","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`
+	pullBody := `{"number":411,"html_url":"https://github.com/digitaldrywood/detent/pull/411","state":"open","head":{"ref":"detent/digitaldrywood_detent_401","sha":"head-current"}}`
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{body: projectBody},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411", body: pullBody},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100",
+			status: http.StatusTooManyRequests,
+			headers: map[string]string{
+				"Retry-After":           "120",
+				"X-RateLimit-Limit":     "5000",
+				"X-RateLimit-Used":      "264",
+				"X-RateLimit-Remaining": "4736",
+				"X-RateLimit-Resource":  "core",
+			},
+			body: `{"message":"secondary rate limit"}`,
+		},
+		{body: projectBody},
+		{body: projectBody},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411", body: pullBody},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/check-runs?per_page=100", body: `{"check_runs":[{"status":"completed","conclusion":"success"}]}`},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/commits/head-current/statuses?per_page=100", body: `[]`},
+		{method: http.MethodGet, path: "/repos/digitaldrywood/detent/pulls/411/reviews?per_page=100", body: `[]`},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	first, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() first error = %v", err)
+	}
+	if len(first) != 1 || first[0].PullRequest == nil {
+		t.Fatalf("FetchIssuesByStates() first = %#v, want PR hydration marker", first)
+	}
+	pr := first[0].PullRequest
+	if pr.HydrationUnavailableReason != "secondary_throttled" {
+		t.Fatalf("HydrationUnavailableReason = %q, want secondary_throttled", pr.HydrationUnavailableReason)
+	}
+	if pr.HydrationNextRetryAt == nil {
+		t.Fatal("HydrationNextRetryAt = nil, want retry deadline")
+	}
+	retryAt := *pr.HydrationNextRetryAt
+	if !retryAt.After(now.Add(120*time.Second)) || retryAt.After(now.Add(151*time.Second)) {
+		t.Fatalf("HydrationNextRetryAt = %v, want retry-after plus jitter", retryAt)
+	}
+
+	beforeCooldownRequests := len(server.requests())
+	second, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() second error = %v", err)
+	}
+	if len(second) != 1 || second[0].PullRequest == nil {
+		t.Fatalf("FetchIssuesByStates() second = %#v, want PR hydration marker", second)
+	}
+	if second[0].PullRequest.HydrationUnavailableReason != "secondary_throttled" {
+		t.Fatalf("second HydrationUnavailableReason = %q, want secondary_throttled", second[0].PullRequest.HydrationUnavailableReason)
+	}
+	if len(server.requests()) != beforeCooldownRequests+1 {
+		t.Fatalf("request count after cooldown skip = %d, want one project refresh; requests = %#v", len(server.requests()), server.requests())
+	}
+
+	now = retryAt.Add(time.Second)
+	third, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() third error = %v", err)
+	}
+	if len(third) != 1 || third[0].PullRequest == nil {
+		t.Fatalf("FetchIssuesByStates() third = %#v, want hydrated PR", third)
+	}
+	pr = third[0].PullRequest
+	if pr.HydrationUnavailableReason != "" || pr.HydrationNextRetryAt != nil {
+		t.Fatalf("third hydration state = reason %q retry %v, want cleared", pr.HydrationUnavailableReason, pr.HydrationNextRetryAt)
+	}
+	if pr.CIStatus != "pass" {
+		t.Fatalf("third CIStatus = %q, want pass", pr.CIStatus)
+	}
+
+	requests := server.requests()
+	checkRunRequests := 0
+	for _, request := range requests {
+		path, _ := request["path"].(string)
+		if strings.Contains(path, "/check-runs") {
+			checkRunRequests++
+		}
+	}
+	if checkRunRequests != 2 {
+		t.Fatalf("check-runs requests = %d, want one failing call and one retry after cooldown; requests = %#v", checkRunRequests, requests)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesMarksLinkedPullRequestHydrationSecondaryThrottled(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
 	projectBody := `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_401","content":{"__typename":"Issue","id":"I_401","number":401,"title":"Human review issue","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/401","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[{"number":411,"url":"https://github.com/digitaldrywood/detent/pull/411","state":"OPEN","repository":{"nameWithOwner":"digitaldrywood/detent"}}]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{body: projectBody},
@@ -996,16 +1197,22 @@ func TestConnectorFetchIssuesByStatesMarksLinkedPullRequestHydrationRateLimited(
 			path:   "/repos/digitaldrywood/detent/pulls/411",
 			status: http.StatusTooManyRequests,
 			headers: map[string]string{
-				"Retry-After":          "120",
-				"X-RateLimit-Limit":    "5000",
-				"X-RateLimit-Used":     "264",
-				"X-RateLimit-Resource": "core",
+				"Retry-After":           "120",
+				"X-RateLimit-Limit":     "5000",
+				"X-RateLimit-Used":      "264",
+				"X-RateLimit-Remaining": "4736",
+				"X-RateLimit-Resource":  "core",
 			},
 			body: `{"message":"secondary rate limit"}`,
 		},
 	})
 
-	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug: "PVT_1",
+		Now: func() time.Time {
+			return now
+		},
+	})
 
 	got, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
 	if err != nil {
@@ -1021,8 +1228,11 @@ func TestConnectorFetchIssuesByStatesMarksLinkedPullRequestHydrationRateLimited(
 	if pr.Number != 411 {
 		t.Fatalf("PullRequest.Number = %d, want 411", pr.Number)
 	}
-	if pr.HydrationUnavailableReason != "rate_limited" {
-		t.Fatalf("HydrationUnavailableReason = %q, want rate_limited", pr.HydrationUnavailableReason)
+	if pr.HydrationUnavailableReason != connector.PullRequestHydrationReasonSecondaryThrottled {
+		t.Fatalf("HydrationUnavailableReason = %q, want secondary_throttled", pr.HydrationUnavailableReason)
+	}
+	if pr.HydrationNextRetryAt == nil || !pr.HydrationNextRetryAt.After(now.Add(120*time.Second)) {
+		t.Fatalf("HydrationNextRetryAt = %v, want retry-after plus jitter", pr.HydrationNextRetryAt)
 	}
 	if got[0].PRNumber == nil || *got[0].PRNumber != 411 {
 		t.Fatalf("PRNumber = %v, want 411", got[0].PRNumber)

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -26,6 +26,11 @@ const (
 	maxErrorBodyBytes      = 1000
 )
 
+const (
+	restRateLimitKindPrimaryExhausted   = "primary_exhausted"
+	restRateLimitKindSecondaryThrottled = "secondary_throttled"
+)
+
 var defaultRESTBackoffs = newRESTBackoffRegistry()
 
 type HTTPClient interface {
@@ -174,7 +179,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 	headerRateLimit := c.recordRateLimitFromHeaders(resp.Header, receivedAt)
 
 	if resp.StatusCode != http.StatusOK {
-		err := classifyStatus(resp.StatusCode, resp.Header, raw)
+		err := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
 		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
 			return c.graphQLWithType(ctx, queryType, query, variables, out, false)
 		}
@@ -273,7 +278,8 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	if err != nil {
 		return restProbeResult{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
-	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, time.Now())
+	receivedAt := time.Now()
+	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt)
 	result := restProbeResult{
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header.Clone(),
@@ -281,7 +287,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 		FullBody:   string(bytes.TrimSpace(raw)),
 	}
 	if resp.StatusCode == http.StatusUnauthorized || resp.StatusCode == http.StatusForbidden {
-		err := classifyStatus(resp.StatusCode, resp.Header, raw)
+		err := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
 		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
 			return c.restProbeWithTokenRefresh(ctx, method, path, body, false)
 		}
@@ -354,9 +360,10 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	if err != nil {
 		return nil, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
-	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, time.Now())
+	receivedAt := time.Now()
+	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt)
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
-		err := classifyStatus(resp.StatusCode, resp.Header, raw)
+		err := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
 		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
 			return c.restWithTokenRefresh(ctx, method, path, body, out, false)
 		}
@@ -494,7 +501,12 @@ func (c *Client) restBackoffError(backoffKey string, now time.Time) error {
 	if backoffUntil.IsZero() || !backoffUntil.After(now) {
 		return nil
 	}
-	return &StatusError{StatusCode: http.StatusTooManyRequests, Err: ErrRateLimited}
+	return &StatusError{
+		StatusCode:    http.StatusTooManyRequests,
+		Err:           ErrRateLimited,
+		RateLimitKind: restRateLimitKindPrimaryExhausted,
+		RetryAfter:    backoffUntil.Sub(now),
+	}
 }
 
 func normalizeRESTBudgetPolicy(policy RESTBudgetPolicy) RESTBudgetPolicy {
@@ -599,6 +611,8 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 	retryAfter, hasRetryAfter := parseRetryAfter(headers.Get("Retry-After"), now)
 	resource := strings.TrimSpace(headers.Get("X-RateLimit-Resource"))
 	rateLimited := restStatusRateLimited(status, headers)
+	family := restEndpointFamily(method, path)
+	sharedBackoff := rateLimited && restShouldApplySharedBackoff(family, remaining, hasRemaining)
 
 	var resetAt time.Time
 	if hasReset {
@@ -633,7 +647,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 		snapshot.Resource = resource
 		hasSnapshot = true
 	}
-	if hasRetryAfter {
+	if hasRetryAfter && sharedBackoff {
 		snapshot.RetryAfter = retryAfter
 		hasSnapshot = true
 	} else if hasSnapshot {
@@ -645,7 +659,6 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 		c.hasRestRateLimit = true
 	}
 
-	family := restEndpointFamily(method, path)
 	if c.restRequests == nil {
 		c.restRequests = make(map[string]connector.RESTEndpointUsage)
 	}
@@ -674,7 +687,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 	}
 	c.restRequests[family] = request
 
-	if rateLimited {
+	if sharedBackoff {
 		backoffUntil := restBackoffUntil(now, retryAfter, hasRetryAfter, resetAt, hasReset, remaining, hasRemaining)
 		if c.restBackoffUntil.IsZero() || backoffUntil.After(c.restBackoffUntil) {
 			c.restBackoffUntil = backoffUntil
@@ -1026,6 +1039,10 @@ func requestPath(value *url.URL) string {
 }
 
 func classifyStatus(status int, headers http.Header, body []byte) error {
+	return classifyStatusAt(status, headers, body, time.Now())
+}
+
+func classifyStatusAt(status int, headers http.Header, body []byte, now time.Time) error {
 	base := ErrUnexpectedStatus
 	switch {
 	case status == http.StatusUnauthorized:
@@ -1044,11 +1061,19 @@ func classifyStatus(status int, headers http.Header, body []byte) error {
 		base = ErrTransient
 	}
 
-	return &StatusError{
+	statusErr := &StatusError{
 		StatusCode: status,
 		Body:       summarizeBody(body),
 		Err:        base,
 	}
+	if errors.Is(base, ErrRateLimited) {
+		statusErr.RateLimitKind = restRateLimitKindFromHeaders(status, headers)
+		statusErr.RetryAfter, _ = parseRetryAfter(headers.Get("Retry-After"), now)
+		if reset, ok := int64Header(headers, "X-RateLimit-Reset"); ok {
+			statusErr.ResetAt = time.Unix(reset, 0).UTC()
+		}
+	}
+	return statusErr
 }
 
 func restStatusRateLimited(status int, headers http.Header) bool {
@@ -1060,6 +1085,23 @@ func restStatusRateLimited(status int, headers http.Header) bool {
 	default:
 		return false
 	}
+}
+
+func restRateLimitKindFromHeaders(status int, headers http.Header) string {
+	if !restStatusRateLimited(status, headers) {
+		return ""
+	}
+	if remaining, ok := int64Header(headers, "X-RateLimit-Remaining"); ok && remaining <= 0 {
+		return restRateLimitKindPrimaryExhausted
+	}
+	return restRateLimitKindSecondaryThrottled
+}
+
+func restShouldApplySharedBackoff(family string, remaining int64, hasRemaining bool) bool {
+	if !restFanoutEndpointFamily(family) {
+		return true
+	}
+	return hasRemaining && remaining <= 0
 }
 
 func restBackoffUntil(

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -307,8 +307,8 @@ func TestClientRESTAggregatesUsageAndBacksOffAfterRateLimit(t *testing.T) {
 			w.Header().Set("Content-Type", "application/json")
 			w.Header().Set("Retry-After", "120")
 			w.Header().Set("X-RateLimit-Limit", "5000")
-			w.Header().Set("X-RateLimit-Used", "122")
-			w.Header().Set("X-RateLimit-Remaining", "4878")
+			w.Header().Set("X-RateLimit-Used", "5000")
+			w.Header().Set("X-RateLimit-Remaining", "0")
 			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
 			w.Header().Set("X-RateLimit-Resource", "core")
 			w.WriteHeader(http.StatusForbidden)
@@ -352,8 +352,8 @@ func TestClientRESTAggregatesUsageAndBacksOffAfterRateLimit(t *testing.T) {
 	if usage.TotalRequests != 2 || !usage.RateLimited {
 		t.Fatalf("FlushRESTRateLimitUsage() totals = requests %d rate_limited %v, want 2 true", usage.TotalRequests, usage.RateLimited)
 	}
-	if usage.RateLimit.Remaining != 4878 || usage.RateLimit.RetryAfter != 2*time.Minute || usage.RateLimit.Resource != "core" {
-		t.Fatalf("FlushRESTRateLimitUsage().RateLimit = %#v, want remaining 4878 retry-after 2m core", usage.RateLimit)
+	if usage.RateLimit.Remaining != 0 || usage.RateLimit.RetryAfter != 2*time.Minute || usage.RateLimit.Resource != "core" {
+		t.Fatalf("FlushRESTRateLimitUsage().RateLimit = %#v, want remaining 0 retry-after 2m core", usage.RateLimit)
 	}
 	if usage.BackoffUntil.IsZero() {
 		t.Fatal("FlushRESTRateLimitUsage().BackoffUntil is zero, want backoff deadline")
@@ -363,6 +363,81 @@ func TestClientRESTAggregatesUsageAndBacksOffAfterRateLimit(t *testing.T) {
 	}
 	if got := restEndpointUsageCount(usage.Requests, "issue comments"); got != 1 {
 		t.Fatalf("issue comments usage count = %d, want 1; usage = %#v", got, usage.Requests)
+	}
+}
+
+func TestClientRESTDoesNotGloballyBackOffAfterSecondaryFanoutThrottle(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2026, 6, 1, 13, 0, 0, 0, time.UTC)
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch call := calls.Add(1); call {
+		case 1:
+			if r.URL.Path != "/repos/digitaldrywood/detent/commits/abc/check-runs" {
+				t.Fatalf("first path = %s, want check-runs path", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("Retry-After", "120")
+			w.Header().Set("X-RateLimit-Limit", "5000")
+			w.Header().Set("X-RateLimit-Used", "122")
+			w.Header().Set("X-RateLimit-Remaining", "4878")
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
+			w.Header().Set("X-RateLimit-Resource", "core")
+			w.WriteHeader(http.StatusTooManyRequests)
+			_, _ = w.Write([]byte(`{"message":"secondary rate limit"}`))
+		case 2:
+			if r.URL.Path != "/repos/digitaldrywood/detent/issues" {
+				t.Fatalf("second path = %s, want label issues path", r.URL.Path)
+			}
+			if got := r.URL.Query().Get("labels"); got != "detent:todo" {
+				t.Fatalf("labels query = %q, want detent:todo", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-RateLimit-Limit", "5000")
+			w.Header().Set("X-RateLimit-Used", "123")
+			w.Header().Set("X-RateLimit-Remaining", "4877")
+			w.Header().Set("X-RateLimit-Reset", strconv.FormatInt(resetAt.Unix(), 10))
+			w.Header().Set("X-RateLimit-Resource", "core")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected REST call %d to %s", call, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	err = client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/commits/abc/check-runs", nil, nil)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("REST() check-runs error = %v, want ErrRateLimited", err)
+	}
+	var issues []restIssue
+	if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/issues?labels=detent%3Atodo", nil, &issues); err != nil {
+		t.Fatalf("REST() label issues after secondary throttle error = %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("REST calls = %d, want secondary throttle not to block label issues", calls.Load())
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+	if usage.RateLimit.RetryAfter != 0 {
+		t.Fatalf("RateLimit.RetryAfter = %s, want no global REST retry-after", usage.RateLimit.RetryAfter)
+	}
+	if !usage.BackoffUntil.IsZero() {
+		t.Fatalf("BackoffUntil = %v, want no global REST backoff", usage.BackoffUntil)
+	}
+	checkRuns := restEndpointUsage(usage.Requests, "check runs")
+	if !checkRuns.RateLimited || checkRuns.RetryAfter != 2*time.Minute {
+		t.Fatalf("check runs usage = %#v, want endpoint retry-after", checkRuns)
 	}
 }
 
@@ -568,6 +643,15 @@ func restEndpointUsageCount(usages []connector.RESTEndpointUsage, family string)
 		}
 	}
 	return 0
+}
+
+func restEndpointUsage(usages []connector.RESTEndpointUsage, family string) connector.RESTEndpointUsage {
+	for _, usage := range usages {
+		if usage.EndpointFamily == family {
+			return usage
+		}
+	}
+	return connector.RESTEndpointUsage{}
 }
 
 func TestClientGraphQLCapturesRateLimitSnapshot(t *testing.T) {

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -93,6 +93,7 @@ type Connector struct {
 	issueFields       *issueFieldCache
 	projectCache      *projectCache
 	pullRequests      *pullRequestStatusCache
+	prHydration       *pullRequestHydrationCircuitBreaker
 	mu                sync.RWMutex
 	writeMu           sync.Mutex
 	instanceLogin     string
@@ -160,6 +161,7 @@ func NewConnector(cfg Config) (*Connector, error) {
 		issueFields:       newIssueFieldCache(githubCacheTTL, cfg.Now),
 		projectCache:      newProjectCache(githubCacheTTL, cfg.Now),
 		pullRequests:      newPullRequestStatusCache(githubCacheTTL, cfg.Now),
+		prHydration:       newPullRequestHydrationCircuitBreaker(cfg.Now),
 	}, nil
 }
 

--- a/internal/connector/github/errors.go
+++ b/internal/connector/github/errors.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 )
 
 var (
@@ -69,9 +70,12 @@ func (e *GraphQLErrorList) Unwrap() error {
 }
 
 type StatusError struct {
-	StatusCode int
-	Body       string
-	Err        error
+	StatusCode    int
+	Body          string
+	Err           error
+	RateLimitKind string
+	RetryAfter    time.Duration
+	ResetAt       time.Time
 }
 
 func (e *StatusError) Error() string {

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -1,11 +1,17 @@
 package github
 
 import (
+	"hash/fnv"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const (
+	defaultPullRequestHydrationCooldown = time.Minute
+	maxPullRequestHydrationJitter       = 30 * time.Second
 )
 
 type pullRequestStatusCache struct {
@@ -31,6 +37,22 @@ type pullRequestStatus struct {
 	reviews pullRequestCodexReviews
 }
 
+type pullRequestHydrationState struct {
+	Reason      string
+	NextRetryAt *time.Time
+}
+
+type pullRequestHydrationCircuitBreaker struct {
+	mu      sync.Mutex
+	now     func() time.Time
+	entries map[string]pullRequestHydrationCircuitEntry
+}
+
+type pullRequestHydrationCircuitEntry struct {
+	reason      string
+	nextRetryAt time.Time
+}
+
 func newPullRequestStatusCache(ttl time.Duration, now func() time.Time) *pullRequestStatusCache {
 	if now == nil {
 		now = time.Now
@@ -40,6 +62,97 @@ func newPullRequestStatusCache(ttl time.Duration, now func() time.Time) *pullReq
 		now:     now,
 		entries: map[pullRequestStatusCacheKey]pullRequestStatusCacheEntry{},
 	}
+}
+
+func newPullRequestHydrationCircuitBreaker(now func() time.Time) *pullRequestHydrationCircuitBreaker {
+	if now == nil {
+		now = time.Now
+	}
+	return &pullRequestHydrationCircuitBreaker{
+		now:     now,
+		entries: map[string]pullRequestHydrationCircuitEntry{},
+	}
+}
+
+func (c *pullRequestHydrationCircuitBreaker) Current(repo pullRequestRepo) (pullRequestHydrationState, bool) {
+	if c == nil {
+		return pullRequestHydrationState{}, false
+	}
+	key := pullRequestHydrationCircuitKey(repo)
+	if key == "" {
+		return pullRequestHydrationState{}, false
+	}
+	now := c.now()
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry, ok := c.entries[key]
+	if !ok {
+		return pullRequestHydrationState{}, false
+	}
+	if !entry.nextRetryAt.After(now) {
+		delete(c.entries, key)
+		return pullRequestHydrationState{}, false
+	}
+	return newPullRequestHydrationState(entry.reason, entry.nextRetryAt), true
+}
+
+func (c *pullRequestHydrationCircuitBreaker) Trip(repo pullRequestRepo, reason string, retryAfter time.Duration) pullRequestHydrationState {
+	if c == nil {
+		return pullRequestHydrationState{}
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		return pullRequestHydrationState{}
+	}
+	key := pullRequestHydrationCircuitKey(repo)
+	if key == "" {
+		return pullRequestHydrationState{}
+	}
+	if retryAfter <= 0 {
+		retryAfter = defaultPullRequestHydrationCooldown
+	}
+
+	now := c.now()
+	nextRetryAt := now.Add(retryAfter + pullRequestHydrationJitter(key, reason))
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	entry := c.entries[key]
+	if entry.nextRetryAt.After(nextRetryAt) {
+		return newPullRequestHydrationState(entry.reason, entry.nextRetryAt)
+	}
+	c.entries[key] = pullRequestHydrationCircuitEntry{
+		reason:      reason,
+		nextRetryAt: nextRetryAt,
+	}
+	return newPullRequestHydrationState(reason, nextRetryAt)
+}
+
+func newPullRequestHydrationState(reason string, nextRetryAt time.Time) pullRequestHydrationState {
+	if nextRetryAt.IsZero() {
+		return pullRequestHydrationState{Reason: strings.TrimSpace(reason)}
+	}
+	next := nextRetryAt.UTC()
+	return pullRequestHydrationState{
+		Reason:      strings.TrimSpace(reason),
+		NextRetryAt: &next,
+	}
+}
+
+func pullRequestHydrationCircuitKey(repo pullRequestRepo) string {
+	return strings.TrimSpace(pullRequestRepoName(repo))
+}
+
+func pullRequestHydrationJitter(key string, reason string) time.Duration {
+	hash := fnv.New32a()
+	_, _ = hash.Write([]byte(strings.TrimSpace(key)))
+	_, _ = hash.Write([]byte{0})
+	_, _ = hash.Write([]byte(strings.TrimSpace(reason)))
+	seconds := hash.Sum32()%uint32(maxPullRequestHydrationJitter/time.Second) + 1
+	return time.Duration(seconds) * time.Second
 }
 
 func (c *pullRequestStatusCache) Get(repo pullRequestRepo, number int, headSHA string) (pullRequestStatus, bool) {

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -52,6 +52,8 @@ type PullRequest struct {
 	ActivityAt                   *time.Time           `json:"activity_at,omitempty" yaml:"activity_at,omitempty"`
 	HeadSHA                      string               `json:"head_sha,omitempty" yaml:"head_sha,omitempty"`
 	HydrationUnavailableReason   string               `json:"hydration_unavailable_reason,omitempty" yaml:"hydration_unavailable_reason,omitempty"`
+	HydrationDegradedReason      string               `json:"hydration_degraded_reason,omitempty" yaml:"hydration_degraded_reason,omitempty"`
+	HydrationNextRetryAt         *time.Time           `json:"hydration_next_retry_at,omitempty" yaml:"hydration_next_retry_at,omitempty"`
 	CIStatus                     string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
 	CheckRunCount                int                  `json:"check_run_count,omitempty" yaml:"check_run_count,omitempty"`
 	StatusContextCount           int                  `json:"status_context_count,omitempty" yaml:"status_context_count,omitempty"`
@@ -67,8 +69,11 @@ type PullRequest struct {
 }
 
 const (
-	PullRequestHydrationReasonRateLimited        = "rate_limited"
-	PullRequestHydrationReasonRESTBudgetReserved = "rest_budget_reserved"
+	PullRequestHydrationReasonRateLimited         = "rate_limited"
+	PullRequestHydrationReasonSecondaryThrottled  = "secondary_throttled"
+	PullRequestHydrationReasonPrimaryExhausted    = "primary_exhausted"
+	PullRequestHydrationReasonRESTBudgetReserved  = "rest_budget_reserved"
+	PullRequestHydrationReasonStaleCachedPullData = "stale_cached_pull_request"
 )
 
 type PullRequestCheck struct {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -346,6 +346,12 @@ func mergeWorkerLogAttrs(issue connector.Issue, attrs ...any) []any {
 		if reason := pullRequestHydrationUnavailableReason(issue.PullRequest); reason != "" {
 			out = append(out, "pull_request_hydration_reason", reason)
 		}
+		if reason := strings.TrimSpace(issue.PullRequest.HydrationDegradedReason); reason != "" {
+			out = append(out, "pull_request_hydration_degraded_reason", reason)
+		}
+		if issue.PullRequest.HydrationNextRetryAt != nil && !issue.PullRequest.HydrationNextRetryAt.IsZero() {
+			out = append(out, "pull_request_hydration_next_retry_at", issue.PullRequest.HydrationNextRetryAt.UTC().Format(time.RFC3339))
+		}
 	}
 	return append(out, attrs...)
 }
@@ -893,6 +899,12 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 		}
 		if reason := pullRequestHydrationUnavailableReason(issue.PullRequest); reason != "" {
 			attrs = append(attrs, "pull_request_hydration_reason", reason)
+		}
+		if reason := strings.TrimSpace(issue.PullRequest.HydrationDegradedReason); reason != "" {
+			attrs = append(attrs, "pull_request_hydration_degraded_reason", reason)
+		}
+		if issue.PullRequest.HydrationNextRetryAt != nil && !issue.PullRequest.HydrationNextRetryAt.IsZero() {
+			attrs = append(attrs, "pull_request_hydration_next_retry_at", issue.PullRequest.HydrationNextRetryAt.UTC().Format(time.RFC3339))
 		}
 	}
 	if decision.QuietRemaining > 0 {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -402,6 +402,80 @@ func TestTickAutoPromoteDefersWhenPullRequestHydrationRateLimited(t *testing.T) 
 	}
 }
 
+func TestLogAutoPromoteDecisionIncludesHydrationReasons(t *testing.T) {
+	t.Parallel()
+
+	retryAt := time.Date(2026, 6, 25, 12, 5, 0, 0, time.UTC)
+	tests := []struct {
+		name        string
+		pullRequest *connector.PullRequest
+		want        []string
+	}{
+		{
+			name: "primary exhausted",
+			pullRequest: &connector.PullRequest{
+				Number:                     77,
+				HydrationUnavailableReason: connector.PullRequestHydrationReasonPrimaryExhausted,
+			},
+			want: []string{"pull_request_hydration_reason=primary_exhausted"},
+		},
+		{
+			name: "secondary throttled",
+			pullRequest: &connector.PullRequest{
+				Number:                     77,
+				HydrationUnavailableReason: connector.PullRequestHydrationReasonSecondaryThrottled,
+				HydrationNextRetryAt:       &retryAt,
+			},
+			want: []string{
+				"pull_request_hydration_reason=secondary_throttled",
+				"pull_request_hydration_next_retry_at=2026-06-25T12:05:00Z",
+			},
+		},
+		{
+			name: "rest budget reserved",
+			pullRequest: &connector.PullRequest{
+				Number:                     77,
+				HydrationUnavailableReason: connector.PullRequestHydrationReasonRESTBudgetReserved,
+			},
+			want: []string{"pull_request_hydration_reason=rest_budget_reserved"},
+		},
+		{
+			name: "stale cached data",
+			pullRequest: &connector.PullRequest{
+				Number:                  77,
+				HydrationDegradedReason: connector.PullRequestHydrationReasonStaleCachedPullData,
+				HydrationNextRetryAt:    &retryAt,
+			},
+			want: []string{
+				"pull_request_hydration_degraded_reason=stale_cached_pull_request",
+				"pull_request_hydration_next_retry_at=2026-06-25T12:05:00Z",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs strings.Builder
+			orch := &Orchestrator{
+				logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+			}
+			issue := autoPromoteTickIssue("issue-hydration-log", []string{"bug"}, tt.pullRequest)
+			orch.logAutoPromoteDecision(issue, AutoPromoteDecision{
+				Action: AutoPromoteActionSkip,
+				Reason: AutoPromoteReasonPullRequestHydrationUnavailable,
+			}, "")
+
+			for _, fragment := range tt.want {
+				if !strings.Contains(logs.String(), fragment) {
+					t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+				}
+			}
+		})
+	}
+}
+
 func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -301,6 +301,8 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		State:                      pullRequest.State,
 		MergeableState:             pullRequest.MergeableState,
 		HydrationUnavailableReason: pullRequest.HydrationUnavailableReason,
+		HydrationDegradedReason:    pullRequest.HydrationDegradedReason,
+		HydrationNextRetryAt:       cloneTime(pullRequest.HydrationNextRetryAt),
 		CIStatus:                   pullRequest.CIStatus,
 		CheckRunCount:              pullRequest.CheckRunCount,
 		StatusContextCount:         pullRequest.StatusContextCount,
@@ -310,6 +312,14 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		RunningChecks:              append([]string(nil), pullRequest.RunningChecks...),
 		CodexReviewState:           pullRequest.CodexReviewState,
 	}
+}
+
+func cloneTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func telemetryPullRequestChecks(checks []connector.PullRequestCheck) []telemetry.PullRequestCheck {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -206,6 +206,7 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	completedAt := now.Add(-time.Minute)
 	blockedAt := now.Add(-3 * time.Minute)
 	pipelineUpdatedAt := now.Add(-4 * time.Minute)
+	prHydrationRetryAt := now.Add(5 * time.Minute)
 
 	state := newState(normalizeConfig(Config{}))
 	state.LastRefreshAt = now.Add(-30 * time.Second)
@@ -230,11 +231,13 @@ func TestStateSnapshotPopulated(t *testing.T) {
 			BlockedBy:  []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415", State: "Done"}},
 			UpdatedAt:  &pipelineUpdatedAt,
 			PullRequest: &connector.PullRequest{
-				Number:            142,
-				URL:               "https://github.com/digitaldrywood/detent/pull/142",
-				State:             "OPEN",
-				CIStatus:          "pending",
-				CIDurationSeconds: 900,
+				Number:                  142,
+				URL:                     "https://github.com/digitaldrywood/detent/pull/142",
+				State:                   "OPEN",
+				CIStatus:                "pending",
+				CIDurationSeconds:       900,
+				HydrationDegradedReason: connector.PullRequestHydrationReasonStaleCachedPullData,
+				HydrationNextRetryAt:    &prHydrationRetryAt,
 				SlowChecks: []connector.PullRequestCheck{
 					{Name: "GoReleaser Snapshot", DurationSeconds: 247},
 				},
@@ -324,6 +327,12 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	}
 	if pipeline.PullRequest.CIDurationSeconds != 900 {
 		t.Fatalf("Pipeline[0].PullRequest.CIDurationSeconds = %d, want 900", pipeline.PullRequest.CIDurationSeconds)
+	}
+	if pipeline.PullRequest.HydrationDegradedReason != connector.PullRequestHydrationReasonStaleCachedPullData {
+		t.Fatalf("Pipeline[0].PullRequest.HydrationDegradedReason = %q, want stale cached data", pipeline.PullRequest.HydrationDegradedReason)
+	}
+	if pipeline.PullRequest.HydrationNextRetryAt == nil || !pipeline.PullRequest.HydrationNextRetryAt.Equal(prHydrationRetryAt) {
+		t.Fatalf("Pipeline[0].PullRequest.HydrationNextRetryAt = %v, want %v", pipeline.PullRequest.HydrationNextRetryAt, prHydrationRetryAt)
 	}
 	if len(pipeline.PullRequest.SlowChecks) != 1 || pipeline.PullRequest.SlowChecks[0].Name != "GoReleaser Snapshot" {
 		t.Fatalf("Pipeline[0].PullRequest.SlowChecks = %#v", pipeline.PullRequest.SlowChecks)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -221,6 +221,10 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 			submittedAt := *issue.PullRequest.LatestCodexReviewSubmittedAt
 			pullRequest.LatestCodexReviewSubmittedAt = &submittedAt
 		}
+		if issue.PullRequest.HydrationNextRetryAt != nil {
+			nextRetryAt := *issue.PullRequest.HydrationNextRetryAt
+			pullRequest.HydrationNextRetryAt = &nextRetryAt
+		}
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		cloned.PullRequest = &pullRequest
 	}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -502,6 +502,7 @@ func retainUnavailablePullRequests(current []connector.Issue, previous []connect
 		}
 		retained := cloneIssue(prior).PullRequest
 		retained.HydrationUnavailableReason = reason
+		retained.HydrationNextRetryAt = cloneTime(issue.PullRequest.HydrationNextRetryAt)
 		out[index].PullRequest = retained
 		if out[index].PRNumber == nil && prior.PRNumber != nil {
 			prNumber := *prior.PRNumber

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -212,6 +212,8 @@ type PullRequest struct {
 	State                      string             `json:"state,omitempty"`
 	MergeableState             string             `json:"mergeable_state,omitempty"`
 	HydrationUnavailableReason string             `json:"hydration_unavailable_reason,omitempty"`
+	HydrationDegradedReason    string             `json:"hydration_degraded_reason,omitempty"`
+	HydrationNextRetryAt       *time.Time         `json:"hydration_next_retry_at,omitempty"`
 	CIStatus                   string             `json:"ci_status,omitempty"`
 	CheckRunCount              int                `json:"check_run_count,omitempty"`
 	StatusContextCount         int                `json:"status_context_count,omitempty"`

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2813,7 +2813,11 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		return ""
 	}
 	parts := []string{}
-	if hydration := pullRequestHydrationWaitDetail(issue.PullRequest.HydrationUnavailableReason); hydration != "" {
+	if hydration := pullRequestHydrationWaitDetail(
+		issue.PullRequest.HydrationUnavailableReason,
+		issue.PullRequest.HydrationDegradedReason,
+		issue.PullRequest.HydrationNextRetryAt,
+	); hydration != "" {
 		parts = append(parts, hydration)
 	}
 	if issue.PullRequest.QuietWaitSeconds > 0 {
@@ -2831,15 +2835,28 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 	return strings.Join(parts, " / ")
 }
 
-func pullRequestHydrationWaitDetail(reason string) string {
-	switch strings.TrimSpace(reason) {
+func pullRequestHydrationWaitDetail(unavailableReason string, degradedReason string, nextRetryAt *time.Time) string {
+	detail := ""
+	switch strings.TrimSpace(unavailableReason) {
 	case "rate_limited":
-		return "PR hydration rate-limited"
+		detail = "PR hydration rate-limited"
+	case "secondary_throttled":
+		detail = "PR hydration secondary throttled"
+	case "primary_exhausted":
+		detail = "PR hydration primary exhausted"
 	case "rest_budget_reserved":
-		return "PR hydration waiting for REST budget"
-	default:
+		detail = "PR hydration waiting for REST budget"
+	}
+	if detail == "" && strings.TrimSpace(degradedReason) == "stale_cached_pull_request" {
+		detail = "PR hydration using stale cached data"
+	}
+	if detail == "" {
 		return ""
 	}
+	if nextRetryAt != nil && !nextRetryAt.IsZero() {
+		detail += " until " + nextRetryAt.UTC().Format("15:04 UTC")
+	}
+	return detail
 }
 
 func prPipelineSlowChecks(checks []telemetry.PullRequestCheck) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1453,6 +1453,7 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 	mergeAt := now.Add(-15 * time.Minute)
 	doneAt := now.Add(-45 * time.Minute)
 	oldDoneAt := now.Add(-25 * time.Hour)
+	retryAt := now.Add(5 * time.Minute)
 
 	tests := []struct {
 		name     string
@@ -1471,11 +1472,12 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 						State:      "Human Review",
 						UpdatedAt:  &reviewAt,
 						PullRequest: &telemetry.PullRequest{
-							Number:                     142,
-							URL:                        "https://github.com/digitaldrywood/detent/pull/142",
-							CIStatus:                   "success",
-							CodexReviewState:           "clean",
-							HydrationUnavailableReason: "rate_limited",
+							Number:                  142,
+							URL:                     "https://github.com/digitaldrywood/detent/pull/142",
+							CIStatus:                "success",
+							CodexReviewState:        "clean",
+							HydrationDegradedReason: "stale_cached_pull_request",
+							HydrationNextRetryAt:    &retryAt,
 						},
 					},
 					{
@@ -1541,7 +1543,7 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 				},
 			},
 			want: []pipelineCardSnapshot{
-				{Lane: "Human Review", IssueNumber: "#142", Title: "Review lane PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2h 0m", WaitDetail: "PR hydration rate-limited"},
+				{Lane: "Human Review", IssueNumber: "#142", Title: "Review lane PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2h 0m", WaitDetail: "PR hydration using stale cached data until 15:05 UTC"},
 				{Lane: "Merging", IssueNumber: "#143", Title: "Merge lane PR", CIStatus: "pending", CodexReviewState: "P2", TimeInStage: "15m 0s", WaitDetail: "quiet 10m 0s / CI 8m 30s / slow GoReleaser Snapshot 4m 7s / running Test Coverage"},
 				{Lane: "Done today", IssueNumber: "#144", Title: "Done lane PR", CIStatus: "pass", CodexReviewState: "P1", TimeInStage: "45m 0s"},
 				{Lane: "Done today", IssueNumber: "#145", Title: "Done lane unverified PR", CIStatus: "pending", CodexReviewState: "clean", TimeInStage: "45m 0s"},


### PR DESCRIPTION
## Summary

- Add repo-scoped PR hydration circuit breaker with retry-after cooldown and deterministic jitter after secondary REST throttles.
- Keep secondary PR/check-run throttles out of global REST backoff so unrelated Todo dispatch can continue.
- Surface stale cached PR hydration and next retry times through connector, telemetry, dashboard data, and auto-promote logs.

Fixes #702

## Test Plan

- [x] `go test ./internal/connector/github ./internal/orchestrator ./internal/web/templates`
- [x] `make check`
