### PR TITLE
fix(scheduler): reserve merge lanes

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1098,9 +1098,11 @@ probes.
    per project orchestrator (`internal/orchestrator/dispatch_planner.go`
    `stateSlotsAvailable`) and per project scheduler
    (`internal/project/project.go` `CapacityByState`). The global settings
-   struct (`internal/config/global/config.go`) has no by-state field, and the
-   global dispatch gate (`internal/scheduler/global_gate.go`) is state-blind —
-   it only arbitrates total pool slots and weighted/fair-share selection.
+   struct (`internal/config/global/config.go`) has no by-state field. The global
+   dispatch gate (`internal/scheduler/global_gate.go`) still arbitrates total
+   pool slots and weighted/fair-share project selection, but it also receives
+   each project's current dispatch-state priority so waiting `Merging` work can
+   reserve the next released global slot ahead of lower-priority lanes.
 
    `Merging: 1` serializes merges **within one project only**; multiple
    projects merge concurrently because each merge train targets its own

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -317,6 +318,54 @@ func (o *Orchestrator) logMergeWorkerFailure(issue connector.Issue, reason strin
 		attrs = append(attrs, "error", err)
 	}
 	o.logger.Warn("merge_worker_failure", attrs...)
+}
+
+func (o *Orchestrator) logMergeWorkerSlotWait(
+	issue connector.Issue,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+) {
+	if o.logger == nil || !mergeWorkerIssue(issue) {
+		return
+	}
+	o.logger.Info("merge_worker_slot_wait", mergeWorkerSlotDecisionAttrs(issue, decision, projectStats)...)
+}
+
+func (o *Orchestrator) logMergeWorkerSlotAcquired(
+	issue connector.Issue,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+) {
+	if o.logger == nil || !mergeWorkerIssue(issue) {
+		return
+	}
+	o.logger.Info("merge_worker_slot_acquired", mergeWorkerSlotDecisionAttrs(issue, decision, projectStats)...)
+}
+
+func mergeWorkerSlotDecisionAttrs(
+	issue connector.Issue,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+) []any {
+	reason := strings.TrimSpace(decision.Reason)
+	if reason == "" {
+		reason = dispatchIssueFailureGlobalSlotUnavailable
+	}
+	attrs := mergeWorkerLogAttrs(issue,
+		"reason", reason,
+		"global_capacity", decision.GlobalCapacity,
+		"global_used", decision.GlobalUsed,
+		"global_available", decision.GlobalAvailable,
+		"project_state_capacity", projectStats.capacity,
+		"project_state_used", projectStats.used,
+		"project_state_available", projectStats.available,
+		"lower_priority_running", decision.LowerPriorityRunning,
+		"selected_project_id", strings.TrimSpace(decision.SelectedProjectID),
+		"selected_state", strings.TrimSpace(decision.SelectedState),
+		"ready_projects", decision.ReadyProjects,
+		"running_projects", decision.RunningProjects,
+	)
+	return attrs
 }
 
 func (o *Orchestrator) failStalledMergeWorkerStarts(state *State, now time.Time) {

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -18,6 +18,7 @@ type dispatchPlanHooks struct {
 	hydrate             func(connector.Issue) (connector.Issue, bool)
 	beforeDispatch      func(connector.Issue, int) bool
 	dispatch            func(connector.Issue, int, string) bool
+	dispatchFailed      func(connector.Issue) bool
 	retryDispatchFailed func(connector.Issue, Retry)
 }
 
@@ -84,6 +85,8 @@ func (p dispatchPlanner) plan(
 		}
 		if p.applyDispatchAction(state, action, now, hooks) {
 			plan.Dispatches = append(plan.Dispatches, action.decision())
+		} else if hooks.dispatchFailed != nil && !hooks.dispatchFailed(action.issue) {
+			break
 		}
 	}
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -3,7 +3,9 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"slices"
+	"strings"
 	"testing"
 	"time"
 
@@ -705,6 +707,165 @@ func TestDispatchIssueRequiresSharedGlobalSlot(t *testing.T) {
 	bravoRequest := receiveWorkerHostRunRequest(t, bravoRunner.started)
 	if bravoRequest.Issue.ID != bravoIssue.ID {
 		t.Fatalf("bravo RunRequest.Issue.ID = %q, want %q", bravoRequest.Issue.ID, bravoIssue.ID)
+	}
+}
+
+func TestDispatchReadyIssuesAllowsOneMergeWorkerPerProject(t *testing.T) {
+	t.Parallel()
+
+	globalGate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 2}))
+	now := time.Date(2026, 6, 25, 13, 0, 0, 0, time.UTC)
+	ctx := t.Context()
+
+	alphaRunner := newWorkerHostRunner()
+	alphaCfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		DispatchPriorityByState: []string{"Merging", "Rework", "Todo"},
+		ActiveStates:            []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:          []string{"Done"},
+		Project:                 scheduler.ProjectCandidate{ID: "alpha", Weight: 1},
+	})
+	alpha := Orchestrator{
+		cfg:                alphaCfg,
+		supervisor:         newTestSupervisor(t, alphaRunner, alphaCfg),
+		runResults:         make(chan runpkg.Completion),
+		globalDispatchGate: globalGate,
+	}
+	alphaState := newState(alphaCfg)
+	alphaFirst := dispatchTestIssueWithPullRequest("issue-alpha-first", "Merging", "OPEN")
+	alphaSecond := dispatchTestIssueWithPullRequest("issue-alpha-second", "Merging", "OPEN")
+
+	alpha.dispatchReadyIssues(ctx, &alphaState, []connector.Issue{alphaFirst, alphaSecond}, now)
+	alphaRequest := receiveWorkerHostRunRequest(t, alphaRunner.started)
+	if alphaRequest.Issue.ID != alphaFirst.ID {
+		t.Fatalf("alpha RunRequest.Issue.ID = %q, want %q", alphaRequest.Issue.ID, alphaFirst.ID)
+	}
+	if len(alphaState.Running) != 1 {
+		t.Fatalf("alpha Running len = %d, want 1", len(alphaState.Running))
+	}
+
+	bravoRunner := newWorkerHostRunner()
+	bravoCfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		DispatchPriorityByState: []string{"Merging", "Rework", "Todo"},
+		ActiveStates:            []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:          []string{"Done"},
+		Project:                 scheduler.ProjectCandidate{ID: "bravo", Weight: 1},
+	})
+	bravo := Orchestrator{
+		cfg:                bravoCfg,
+		supervisor:         newTestSupervisor(t, bravoRunner, bravoCfg),
+		runResults:         make(chan runpkg.Completion),
+		globalDispatchGate: globalGate,
+	}
+	bravoState := newState(bravoCfg)
+	bravoIssue := dispatchTestIssueWithPullRequest("issue-bravo", "Merging", "OPEN")
+
+	bravo.dispatchReadyIssues(ctx, &bravoState, []connector.Issue{bravoIssue}, now.Add(time.Second))
+	bravoRequest := receiveWorkerHostRunRequest(t, bravoRunner.started)
+	if bravoRequest.Issue.ID != bravoIssue.ID {
+		t.Fatalf("bravo RunRequest.Issue.ID = %q, want %q", bravoRequest.Issue.ID, bravoIssue.ID)
+	}
+	if len(bravoState.Running) != 1 {
+		t.Fatalf("bravo Running len = %d, want 1", len(bravoState.Running))
+	}
+
+	for _, running := range alphaState.Running {
+		if running.cancel != nil {
+			running.cancel()
+		}
+	}
+	for _, running := range bravoState.Running {
+		if running.cancel != nil {
+			running.cancel()
+		}
+	}
+}
+
+func TestDispatchReadyIssuesLogsMergeSlotDecisionAndStopsAfterGlobalWait(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 14, 0, 0, 0, time.UTC)
+	ctx := t.Context()
+	globalGate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1}))
+	lowerPriorityProject := scheduler.ProjectCandidate{ID: "alpha", Weight: 1}
+	lowerSlot, ok, decision, err := globalGate.TryAcquireWithDecision(ctx, lowerPriorityProject, scheduler.SlotRequest{
+		State:    "Todo",
+		Priority: 2,
+	}, now)
+	if err != nil {
+		t.Fatalf("lower-priority TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("lower-priority TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+	t.Cleanup(func() {
+		if err := globalGate.Release(lowerSlot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		DispatchPriorityByState: []string{"Merging", "Rework", "Todo"},
+		ActiveStates:            []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:          []string{"Done"},
+		Project:                 scheduler.ProjectCandidate{ID: "zulu", Weight: 1},
+	})
+	runner := newWorkerHostRunner()
+	var logs strings.Builder
+	orch := Orchestrator{
+		cfg:                cfg,
+		supervisor:         newTestSupervisor(t, runner, cfg),
+		runResults:         make(chan runpkg.Completion),
+		globalDispatchGate: globalGate,
+		logger:             slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	first := dispatchTestIssueWithPullRequest("issue-merge-first", "Merging", "OPEN")
+	second := dispatchTestIssueWithPullRequest("issue-merge-second", "Merging", "OPEN")
+
+	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{first, second}, now.Add(time.Second))
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected merge dispatch while global slot is held = %#v", request)
+	default:
+	}
+	if len(state.Running) != 0 {
+		t.Fatalf("Running len = %d, want 0", len(state.Running))
+	}
+	logText := logs.String()
+	if count := strings.Count(logText, "merge_worker_slot_wait"); count != 1 {
+		t.Fatalf("merge_worker_slot_wait count = %d, want 1; logs = %q", count, logText)
+	}
+	for _, fragment := range []string{
+		"reason=global_capacity_full",
+		"global_capacity=1",
+		"global_used=1",
+		"global_available=0",
+		"project_state_capacity=1",
+		"project_state_used=0",
+		"project_state_available=1",
+		"lower_priority_running=1",
+		"selected_project_id=zulu",
+		"selected_state=merging",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs %q missing fragment %q", logText, fragment)
+		}
+	}
+	if strings.Contains(logText, "merge_worker_failure") {
+		t.Fatalf("logs %q contain merge_worker_failure, want merge slot wait telemetry instead", logText)
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1317,6 +1317,7 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		return
 	}
 	planner := o.dispatchPlanner()
+	var lastDispatchFailure string
 	planner.plan(state, issues, now, dispatchPlanHooks{
 		hydrate: func(issue connector.Issue) (connector.Issue, bool) {
 			return o.hydrateDispatchIssue(ctx, issue)
@@ -1328,7 +1329,16 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 			return waitForDispatchBackoff(ctx, continuationDelay(continuationIndex))
 		},
 		dispatch: func(issue connector.Issue, attempt int, workerHost string) bool {
-			return o.dispatchIssue(ctx, state, issue, attempt, now, workerHost)
+			outcome := o.dispatchIssueWithOutcome(ctx, state, issue, attempt, now, workerHost)
+			if !outcome.dispatched {
+				lastDispatchFailure = outcome.reason
+			} else {
+				lastDispatchFailure = ""
+			}
+			return outcome.dispatched
+		},
+		dispatchFailed: func(issue connector.Issue) bool {
+			return !mergeWorkerIssue(issue) || lastDispatchFailure != dispatchIssueFailureGlobalSlotUnavailable
 		},
 		retryDispatchFailed: func(issue connector.Issue, retry Retry) {
 			planner.scheduleRetry(state, issue, retry.Attempt, now, "claim verification failed", false, retry.WorkerHost)
@@ -1390,6 +1400,19 @@ func (o *Orchestrator) dispatchable(issue connector.Issue, state *State, now tim
 	return o.dispatchPlanner().dispatchable(issue, state, now)
 }
 
+const (
+	dispatchIssueFailureLocalSlotUnavailable  = "local_slot_unavailable"
+	dispatchIssueFailureWorkerHostUnavailable = "worker_host_unavailable"
+	dispatchIssueFailureGlobalSlotUnavailable = "global_slot_unavailable"
+	dispatchIssueFailureClaimFailed           = "claim_failed"
+	dispatchIssueFailureStartStateTransition  = "start_state_transition_failed"
+)
+
+type dispatchIssueOutcome struct {
+	dispatched bool
+	reason     string
+}
+
 func (o *Orchestrator) dispatchIssue(
 	ctx context.Context,
 	state *State,
@@ -1398,6 +1421,17 @@ func (o *Orchestrator) dispatchIssue(
 	now time.Time,
 	preferredWorkerHost string,
 ) bool {
+	return o.dispatchIssueWithOutcome(ctx, state, issue, attempt, now, preferredWorkerHost).dispatched
+}
+
+func (o *Orchestrator) dispatchIssueWithOutcome(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	attempt int,
+	now time.Time,
+	preferredWorkerHost string,
+) dispatchIssueOutcome {
 	runMode := o.dispatchMode(state, issue)
 	targetState := dispatchStartTransitionState(issue, runMode, o.cfg.ActiveStates)
 	slotIssue := issue
@@ -1405,27 +1439,33 @@ func (o *Orchestrator) dispatchIssue(
 		slotIssue = cloneIssue(issue)
 		slotIssue.State = targetState
 		if !o.dispatchPlanner().slotsAvailable(slotIssue, state, preferredWorkerHost) {
-			return false
+			return dispatchIssueOutcome{reason: dispatchIssueFailureLocalSlotUnavailable}
 		}
 	}
+	projectStats := o.projectStateSlotStats(slotIssue, state)
 
 	workerHost, ok := o.selectWorkerHost(state, preferredWorkerHost)
 	if !ok {
 		o.logMergeWorkerFailure(issue, "worker_host_unavailable", nil)
-		return false
+		return dispatchIssueOutcome{reason: dispatchIssueFailureWorkerHostUnavailable}
 	}
 
-	globalSlot, ok := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now)
+	globalSlot, ok, decision := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now)
 	if !ok {
-		o.logMergeWorkerFailure(issue, "global_slot_unavailable", nil)
-		return false
+		if mergeWorkerIssue(issue) {
+			o.logMergeWorkerSlotWait(issue, decision, projectStats)
+		} else {
+			o.logMergeWorkerFailure(issue, "global_slot_unavailable", nil)
+		}
+		return dispatchIssueOutcome{reason: dispatchIssueFailureGlobalSlotUnavailable}
 	}
+	o.logMergeWorkerSlotAcquired(issue, decision, projectStats)
 
 	claimedIssue, claim, ok := o.claimIssue(ctx, issue, now)
 	if !ok {
 		o.releaseGlobalDispatchSlot(globalSlot)
 		o.logMergeWorkerFailure(issue, "claim_failed", nil)
-		return false
+		return dispatchIssueOutcome{reason: dispatchIssueFailureClaimFailed}
 	}
 
 	issue = cloneIssue(claimedIssue)
@@ -1439,7 +1479,7 @@ func (o *Orchestrator) dispatchIssue(
 				o.logger.Warn("start state transition failed", "issue_id", issue.ID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 			}
 			o.logMergeWorkerFailure(issue, "start_state_transition_failed", err)
-			return false
+			return dispatchIssueOutcome{reason: dispatchIssueFailureStartStateTransition}
 		}
 		issue.State = targetState
 	}
@@ -1472,7 +1512,7 @@ func (o *Orchestrator) dispatchIssue(
 	}
 	o.logMergeWorkerAttempt(issue, attempt, workerHost)
 	o.supervisor.Dispatch(runCtx, request, o.runResults)
-	return true
+	return dispatchIssueOutcome{dispatched: true}
 }
 
 func dispatchStartTransitionState(issue connector.Issue, mode string, activeStates []string) string {
@@ -1517,27 +1557,83 @@ func (o *Orchestrator) markGlobalProjectIdle() {
 	o.globalDispatchGate.MarkIdle(o.cfg.Project.ID)
 }
 
+type projectStateSlotStats struct {
+	capacity  int
+	used      int
+	available int
+}
+
+type detailedProjectDispatchGate interface {
+	TryAcquireWithDecision(context.Context, scheduler.ProjectCandidate, scheduler.SlotRequest, time.Time) (
+		scheduler.Slot,
+		bool,
+		scheduler.DispatchGateDecision,
+		error,
+	)
+}
+
 func (o *Orchestrator) acquireGlobalDispatchSlot(
 	ctx context.Context,
 	issue connector.Issue,
 	workerHost string,
 	now time.Time,
-) (scheduler.Slot, bool) {
+) (scheduler.Slot, bool, scheduler.DispatchGateDecision) {
 	if o.globalDispatchGate == nil {
-		return scheduler.Slot{}, true
+		return scheduler.Slot{}, true, scheduler.DispatchGateDecision{Reason: scheduler.DispatchGateReasonGranted}
 	}
 
-	slot, ok, err := o.globalDispatchGate.TryAcquire(ctx, o.cfg.Project, scheduler.SlotRequest{
-		State: issue.State,
-		Host:  workerHost,
-	}, now)
+	req := scheduler.SlotRequest{
+		State:    issue.State,
+		Host:     workerHost,
+		Priority: o.dispatchStatePriority(issue.State),
+	}
+	var (
+		slot     scheduler.Slot
+		ok       bool
+		decision scheduler.DispatchGateDecision
+		err      error
+	)
+	if detailed, hasDecision := o.globalDispatchGate.(detailedProjectDispatchGate); hasDecision {
+		slot, ok, decision, err = detailed.TryAcquireWithDecision(ctx, o.cfg.Project, req, now)
+	} else {
+		slot, ok, err = o.globalDispatchGate.TryAcquire(ctx, o.cfg.Project, req, now)
+		if ok {
+			decision.Reason = scheduler.DispatchGateReasonGranted
+		}
+	}
 	if err != nil {
 		if o.logger != nil {
 			o.logger.Warn("global dispatch slot unavailable", "project_id", o.cfg.Project.ID, "issue_id", issue.ID, "error", err)
 		}
-		return scheduler.Slot{}, false
+		return scheduler.Slot{}, false, decision
 	}
-	return slot, ok
+	return slot, ok, decision
+}
+
+func (o *Orchestrator) dispatchStatePriority(state string) int {
+	return stateDispatchRank(stateDispatchRanks(o.cfg.DispatchPriorityByState), state)
+}
+
+func (o *Orchestrator) projectStateSlotStats(issue connector.Issue, state *State) projectStateSlotStats {
+	limit := o.cfg.MaxConcurrentAgents
+	normalized := normalizeState(issue.State)
+	if stateLimit, ok := o.cfg.MaxConcurrentAgentsByState[normalized]; ok {
+		limit = stateLimit
+	}
+
+	used := 0
+	if state != nil {
+		for _, running := range state.Running {
+			if normalizeState(running.Issue.State) == normalized {
+				used++
+			}
+		}
+	}
+	available := limit - used
+	if available < 0 {
+		available = 0
+	}
+	return projectStateSlotStats{capacity: limit, used: used, available: available}
 }
 
 func (o *Orchestrator) releaseGlobalDispatchSlot(slot scheduler.Slot) {

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -34,8 +34,10 @@ type ProjectCandidate struct {
 }
 
 type RunningProject struct {
-	ProjectID string
-	Priority  int
+	ProjectID    string
+	Priority     int
+	State        string
+	SlotPriority int
 }
 
 type ProjectSelectionRequest struct {
@@ -110,6 +112,10 @@ func (s *globalScheduler) RequestSlot(ctx context.Context, req SlotRequest) (Slo
 
 func (s *globalScheduler) ReleaseSlot(slot Slot) error {
 	return s.sem.ReleaseSlot(slot)
+}
+
+func (s *globalScheduler) capacitySnapshot(state string) capacitySnapshot {
+	return s.sem.capacitySnapshot(state)
 }
 
 func (s *globalScheduler) SelectProject(ctx context.Context, req ProjectSelectionRequest) (ProjectSelection, error) {

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -8,12 +8,41 @@ import (
 	"time"
 )
 
+const (
+	DispatchGateReasonGranted                   = "granted"
+	DispatchGateReasonGlobalCapacityFull        = "global_capacity_full"
+	DispatchGateReasonReservedForHigherPriority = "reserved_for_higher_priority_state"
+	DispatchGateReasonSelectedProjectWaiting    = "selected_project_waiting"
+)
+
 type ProjectDispatchGate interface {
 	MarkReady(ProjectCandidate)
 	MarkIdle(string)
 	TryAcquire(context.Context, ProjectCandidate, SlotRequest, time.Time) (Slot, bool, error)
 	SetPreempt(Slot, func())
 	Release(Slot) error
+}
+
+type DispatchGateDecision struct {
+	ProjectID            string
+	State                string
+	SelectedProjectID    string
+	SelectedState        string
+	Reason               string
+	GlobalCapacity       int
+	GlobalUsed           int
+	GlobalAvailable      int
+	StateCapacity        int
+	StateUsed            int
+	StateAvailable       int
+	LowerPriorityRunning int
+	ReadyProjects        int
+	RunningProjects      int
+}
+
+type readyProjectSlot struct {
+	ProjectCandidate
+	request SlotRequest
 }
 
 type runningProjectSlot struct {
@@ -26,16 +55,17 @@ type GlobalDispatchGate struct {
 	global GlobalScheduler
 
 	mu          sync.Mutex
-	ready       map[string]ProjectCandidate
+	ready       map[string]readyProjectSlot
 	running     map[uint64]runningProjectSlot
 	selected    string
+	selectedReq SlotRequest
 	preemptions []RunningProject
 }
 
 func NewGlobalDispatchGate(global GlobalScheduler) *GlobalDispatchGate {
 	return &GlobalDispatchGate{
 		global:  global,
-		ready:   map[string]ProjectCandidate{},
+		ready:   map[string]readyProjectSlot{},
 		running: map[uint64]runningProjectSlot{},
 	}
 }
@@ -52,7 +82,9 @@ func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
-	g.ready[project.ID] = project
+	ready := g.ready[project.ID]
+	ready.ProjectCandidate = project
+	g.ready[project.ID] = ready
 }
 
 func (g *GlobalDispatchGate) MarkIdle(projectID string) {
@@ -70,6 +102,7 @@ func (g *GlobalDispatchGate) MarkIdle(projectID string) {
 	delete(g.ready, projectID)
 	if g.selected == projectID {
 		g.selected = ""
+		g.selectedReq = SlotRequest{}
 		g.preemptions = nil
 	}
 }
@@ -80,15 +113,29 @@ func (g *GlobalDispatchGate) TryAcquire(
 	req SlotRequest,
 	now time.Time,
 ) (Slot, bool, error) {
+	slot, ok, _, err := g.TryAcquireWithDecision(ctx, project, req, now)
+	return slot, ok, err
+}
+
+func (g *GlobalDispatchGate) TryAcquireWithDecision(
+	ctx context.Context,
+	project ProjectCandidate,
+	req SlotRequest,
+	now time.Time,
+) (Slot, bool, DispatchGateDecision, error) {
 	if g == nil || g.global == nil {
-		return Slot{}, true, nil
+		return Slot{}, true, DispatchGateDecision{Reason: DispatchGateReasonGranted}, nil
 	}
 	if ctx == nil {
 		ctx = context.Background()
 	}
 	project, ok := normalizeSingleProjectCandidate(project)
 	if !ok {
-		return Slot{}, false, ErrNoCandidates
+		return Slot{}, false, DispatchGateDecision{}, ErrNoCandidates
+	}
+	req, err := normalizeSlotRequest(req)
+	if err != nil {
+		return Slot{}, false, DispatchGateDecision{}, err
 	}
 
 	g.mu.Lock()
@@ -96,65 +143,72 @@ func (g *GlobalDispatchGate) TryAcquire(
 
 	select {
 	case <-ctx.Done():
-		return Slot{}, false, ctx.Err()
+		return Slot{}, false, DispatchGateDecision{}, ctx.Err()
 	default:
 	}
 
-	g.ready[project.ID] = project
+	g.ready[project.ID] = readyProjectSlot{ProjectCandidate: project, request: req}
+	if g.selected != "" {
+		if _, ok := g.ready[g.selected]; !ok {
+			g.clearSelectionLocked()
+		}
+	}
 	if g.selected == "" {
-		selection, err := g.global.SelectProject(ctx, ProjectSelectionRequest{
-			Projects: g.readyProjectsLocked(),
-			Running:  g.runningProjectsLocked(),
-			Now:      now,
-		})
+		selection, selectedReq, err := g.selectReadyProjectLocked(ctx, now, true)
 		if err != nil {
 			if errors.Is(err, ErrNoSlots) {
-				return Slot{}, false, nil
+				decision := g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull)
+				return Slot{}, false, decision, nil
 			}
-			return Slot{}, false, err
+			return Slot{}, false, DispatchGateDecision{}, err
 		}
 		g.selected = selection.Project.ID
+		g.selectedReq = selectedReq
 		g.preemptions = selection.Preemptions
 	}
 	if g.selected != project.ID {
-		return Slot{}, false, nil
+		reason := DispatchGateReasonSelectedProjectWaiting
+		if selected, ok := g.ready[g.selected]; ok && selected.request.Priority < req.Priority {
+			reason = DispatchGateReasonReservedForHigherPriority
+		}
+		return Slot{}, false, g.decisionLocked(project.ID, req, reason), nil
 	}
 	if err := g.preemptProjectsLocked(g.preemptions); err != nil {
-		g.selected = ""
-		g.preemptions = nil
-		return Slot{}, false, err
+		g.clearSelectionLocked()
+		return Slot{}, false, DispatchGateDecision{}, err
 	}
 
 	slot, err := g.global.RequestSlot(ctx, req)
 	if err != nil {
 		if errors.Is(err, ErrNoSlots) {
-			return Slot{}, false, nil
+			decision := g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull)
+			return Slot{}, false, decision, nil
 		}
-		g.selected = ""
-		g.preemptions = nil
-		return Slot{}, false, err
+		g.clearSelectionLocked()
+		return Slot{}, false, DispatchGateDecision{}, err
 	}
 	if err := g.global.RecordProjectDispatch(ctx, ProjectDispatch{
 		ProjectID:    project.ID,
 		Weight:       project.Weight,
 		DispatchedAt: now,
 	}); err != nil {
-		g.selected = ""
-		g.preemptions = nil
-		return Slot{}, false, errors.Join(err, g.global.ReleaseSlot(slot))
+		g.clearSelectionLocked()
+		return Slot{}, false, DispatchGateDecision{}, errors.Join(err, g.global.ReleaseSlot(slot))
 	}
 
+	decision := g.decisionLocked(project.ID, req, DispatchGateReasonGranted)
 	delete(g.ready, project.ID)
-	g.selected = ""
-	g.preemptions = nil
+	g.clearSelectionLocked()
 	g.running[slot.token] = runningProjectSlot{
 		RunningProject: RunningProject{
-			ProjectID: project.ID,
-			Priority:  project.Priority,
+			ProjectID:    project.ID,
+			Priority:     project.Priority,
+			State:        slot.State,
+			SlotPriority: slot.Priority,
 		},
 		slot: slot,
 	}
-	return slot, true, nil
+	return slot, true, decision, nil
 }
 
 func (g *GlobalDispatchGate) SetPreempt(slot Slot, preempt func()) {
@@ -215,15 +269,117 @@ func (g *GlobalDispatchGate) preemptProjectLocked(preemption RunningProject) err
 	return nil
 }
 
-func (g *GlobalDispatchGate) readyProjectsLocked() []ProjectCandidate {
+func (g *GlobalDispatchGate) selectReadyProjectLocked(
+	ctx context.Context,
+	now time.Time,
+	reserveWhenFull bool,
+) (ProjectSelection, SlotRequest, error) {
+	projects, requests := g.readyProjectsForSelectionLocked()
+	if len(projects) == 0 {
+		return ProjectSelection{}, SlotRequest{}, ErrNoCandidates
+	}
+
+	selection, err := g.global.SelectProject(ctx, ProjectSelectionRequest{
+		Projects: projects,
+		Running:  g.runningProjectsLocked(),
+		Now:      now,
+	})
+	if err == nil {
+		return selection, requests[selection.Project.ID], nil
+	}
+	if !reserveWhenFull || !errors.Is(err, ErrNoSlots) {
+		return ProjectSelection{}, SlotRequest{}, err
+	}
+
+	selection, reserveErr := g.global.SelectProject(ctx, ProjectSelectionRequest{
+		Projects: projects,
+		Now:      now,
+	})
+	if reserveErr != nil {
+		return ProjectSelection{}, SlotRequest{}, err
+	}
+	return selection, requests[selection.Project.ID], nil
+}
+
+func (g *GlobalDispatchGate) readyProjectsForSelectionLocked() ([]ProjectCandidate, map[string]SlotRequest) {
+	if len(g.ready) == 0 {
+		return nil, nil
+	}
+
+	bestPriority := 0
+	first := true
+	for _, ready := range g.ready {
+		if first || ready.request.Priority < bestPriority {
+			bestPriority = ready.request.Priority
+			first = false
+		}
+	}
+
 	projects := make([]ProjectCandidate, 0, len(g.ready))
-	for _, project := range g.ready {
-		projects = append(projects, project)
+	requests := make(map[string]SlotRequest, len(g.ready))
+	for _, ready := range g.ready {
+		if ready.request.Priority != bestPriority {
+			continue
+		}
+		projects = append(projects, ready.ProjectCandidate)
+		requests[ready.ID] = ready.request
 	}
 	sort.Slice(projects, func(i, j int) bool {
 		return projects[i].ID < projects[j].ID
 	})
-	return projects
+	return projects, requests
+}
+
+func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, reason string) DispatchGateDecision {
+	stats := g.capacitySnapshotLocked(req.State)
+	selectedProjectID := g.selected
+	selectedState := g.selectedReq.State
+	if selected, ok := g.ready[selectedProjectID]; ok {
+		selectedState = selected.request.State
+	}
+	if reason == "" {
+		reason = DispatchGateReasonSelectedProjectWaiting
+	}
+
+	return DispatchGateDecision{
+		ProjectID:            projectID,
+		State:                req.State,
+		SelectedProjectID:    selectedProjectID,
+		SelectedState:        selectedState,
+		Reason:               reason,
+		GlobalCapacity:       stats.globalCapacity,
+		GlobalUsed:           stats.globalUsed,
+		GlobalAvailable:      nonNegativeInt(stats.globalCapacity - stats.globalUsed),
+		StateCapacity:        stats.stateCapacity,
+		StateUsed:            stats.stateUsed,
+		StateAvailable:       nonNegativeInt(stats.stateCapacity - stats.stateUsed),
+		LowerPriorityRunning: g.lowerPriorityRunningLocked(req.Priority),
+		ReadyProjects:        len(g.ready),
+		RunningProjects:      len(g.running),
+	}
+}
+
+func (g *GlobalDispatchGate) capacitySnapshotLocked(state string) capacitySnapshot {
+	if snapshotter, ok := g.global.(interface{ capacitySnapshot(string) capacitySnapshot }); ok {
+		return snapshotter.capacitySnapshot(state)
+	}
+	return capacitySnapshot{}
+}
+
+func (g *GlobalDispatchGate) lowerPriorityRunningLocked(priority int) int {
+	count := 0
+	for _, running := range g.running {
+		if running.slot.Priority > priority {
+			count++
+		}
+	}
+	return count
+}
+
+func (g *GlobalDispatchGate) clearSelectionLocked() {
+	g.selected = ""
+	g.selectedReq = SlotRequest{}
+	g.preemptions = nil
 }
 
 func (g *GlobalDispatchGate) runningProjectsLocked() []RunningProject {
@@ -238,6 +394,26 @@ func (g *GlobalDispatchGate) runningProjectsLocked() []RunningProject {
 		return projects[i].Priority < projects[j].Priority
 	})
 	return projects
+}
+
+func normalizeSlotRequest(req SlotRequest) (SlotRequest, error) {
+	slot, err := normalizeRequest(req)
+	if err != nil {
+		return SlotRequest{}, err
+	}
+	return SlotRequest{
+		State:    slot.State,
+		Host:     slot.Host,
+		Weight:   slot.Weight,
+		Priority: slot.Priority,
+	}, nil
+}
+
+func nonNegativeInt(value int) int {
+	if value < 0 {
+		return 0
+	}
+	return value
 }
 
 func normalizeSingleProjectCandidate(project ProjectCandidate) (ProjectCandidate, bool) {

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -149,8 +149,14 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 
 	g.ready[project.ID] = readyProjectSlot{ProjectCandidate: project, request: req}
 	if g.selected != "" {
-		if _, ok := g.ready[g.selected]; !ok {
+		selected, ok := g.ready[g.selected]
+		if !ok {
 			g.clearSelectionLocked()
+		} else {
+			g.selectedReq = selected.request
+			if g.hasHigherPriorityReadyProjectLocked(selected.request.Priority) {
+				g.clearSelectionLocked()
+			}
 		}
 	}
 	if g.selected == "" {
@@ -374,6 +380,15 @@ func (g *GlobalDispatchGate) lowerPriorityRunningLocked(priority int) int {
 		}
 	}
 	return count
+}
+
+func (g *GlobalDispatchGate) hasHigherPriorityReadyProjectLocked(priority int) bool {
+	for _, ready := range g.ready {
+		if ready.request.Priority < priority {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *GlobalDispatchGate) clearSelectionLocked() {

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -2,6 +2,7 @@ package scheduler_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 	"time"
 
@@ -44,6 +45,145 @@ func TestGlobalDispatchGateUsesConfiguredProjectSelection(t *testing.T) {
 	}
 	if err := gate.Release(slot); err != nil {
 		t.Fatalf("bravo Release() error = %v", err)
+	}
+}
+
+func TestGlobalDispatchGateReservesFreedSlotForPendingMergeLane(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 25, 12, 0, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1}))
+	todoProject := scheduler.ProjectCandidate{ID: "alpha", Weight: 1}
+	mergeProject := scheduler.ProjectCandidate{ID: "zulu", Weight: 1}
+
+	todoSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, todoProject, scheduler.SlotRequest{
+		State:    "Todo",
+		Priority: 2,
+	}, now)
+	if err != nil {
+		t.Fatalf("todo TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("todo TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Priority: 0,
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("merge waiting TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("merge waiting TryAcquireWithDecision() ok = true while the global slot is held, want false")
+	} else if decision.SelectedProjectID != mergeProject.ID || decision.Reason != scheduler.DispatchGateReasonGlobalCapacityFull {
+		t.Fatalf("merge waiting decision = %#v, want selected merge with global capacity full", decision)
+	}
+
+	if err := gate.Release(todoSlot); err != nil {
+		t.Fatalf("todo Release() error = %v", err)
+	}
+
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, todoProject, scheduler.SlotRequest{
+		State:    "Rework",
+		Priority: 1,
+	}, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("rework TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("rework TryAcquireWithDecision() ok = true while pending merge has the reserved turn, want false")
+	} else {
+		if decision.SelectedProjectID != mergeProject.ID {
+			t.Fatalf("rework decision selected project = %q, want %q", decision.SelectedProjectID, mergeProject.ID)
+		}
+		if decision.SelectedState != "merging" {
+			t.Fatalf("rework decision selected state = %q, want merging", decision.SelectedState)
+		}
+		if decision.Reason != scheduler.DispatchGateReasonReservedForHigherPriority {
+			t.Fatalf("rework decision reason = %q, want %q", decision.Reason, scheduler.DispatchGateReasonReservedForHigherPriority)
+		}
+		if decision.GlobalCapacity != 1 || decision.GlobalUsed != 0 || decision.GlobalAvailable != 1 {
+			t.Fatalf("rework decision global capacity = %d used = %d available = %d, want 1/0/1",
+				decision.GlobalCapacity, decision.GlobalUsed, decision.GlobalAvailable)
+		}
+		if decision.LowerPriorityRunning != 0 {
+			t.Fatalf("rework decision lower-priority running = %d, want 0 after release", decision.LowerPriorityRunning)
+		}
+	}
+
+	mergeSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Priority: 0,
+	}, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("merge TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("merge TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+	if decision.Reason != scheduler.DispatchGateReasonGranted {
+		t.Fatalf("merge decision reason = %q, want %q", decision.Reason, scheduler.DispatchGateReasonGranted)
+	}
+	if err := gate.Release(mergeSlot); err != nil {
+		t.Fatalf("merge Release() error = %v", err)
+	}
+}
+
+func TestSchedulersAllowOneMergeLanePerProject(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 25, 12, 30, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 2}))
+	alphaProject := scheduler.ProjectCandidate{ID: "alpha", Weight: 1}
+	bravoProject := scheduler.ProjectCandidate{ID: "bravo", Weight: 1}
+	alphaLocal := scheduler.NewCountingSemaphore(scheduler.Config{
+		Capacity:        2,
+		CapacityByState: map[string]int{"Merging": 1},
+	})
+	bravoLocal := scheduler.NewCountingSemaphore(scheduler.Config{
+		Capacity:        2,
+		CapacityByState: map[string]int{"Merging": 1},
+	})
+	mergeReq := scheduler.SlotRequest{State: "Merging", Priority: 0}
+
+	alphaLocalSlot, err := alphaLocal.RequestSlot(ctx, mergeReq)
+	if err != nil {
+		t.Fatalf("alpha local RequestSlot() error = %v", err)
+	}
+	alphaGlobalSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, alphaProject, mergeReq, now)
+	if err != nil {
+		t.Fatalf("alpha global TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("alpha global TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+
+	bravoLocalSlot, err := bravoLocal.RequestSlot(ctx, mergeReq)
+	if err != nil {
+		t.Fatalf("bravo local RequestSlot() error = %v", err)
+	}
+	bravoGlobalSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, bravoProject, mergeReq, now.Add(time.Second))
+	if err != nil {
+		t.Fatalf("bravo global TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("bravo global TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+
+	if _, err := alphaLocal.RequestSlot(ctx, mergeReq); !errors.Is(err, scheduler.ErrNoSlots) {
+		t.Fatalf("alpha second local RequestSlot() error = %v, want ErrNoSlots", err)
+	}
+
+	if err := alphaLocal.ReleaseSlot(alphaLocalSlot); err != nil {
+		t.Fatalf("alpha local ReleaseSlot() error = %v", err)
+	}
+	if err := bravoLocal.ReleaseSlot(bravoLocalSlot); err != nil {
+		t.Fatalf("bravo local ReleaseSlot() error = %v", err)
+	}
+	if err := gate.Release(alphaGlobalSlot); err != nil {
+		t.Fatalf("alpha global Release() error = %v", err)
+	}
+	if err := gate.Release(bravoGlobalSlot); err != nil {
+		t.Fatalf("bravo global Release() error = %v", err)
 	}
 }
 

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -127,6 +127,79 @@ func TestGlobalDispatchGateReservesFreedSlotForPendingMergeLane(t *testing.T) {
 	}
 }
 
+func TestGlobalDispatchGateReselectsHigherPriorityWaitingLane(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 25, 12, 15, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1}))
+	todoProject := scheduler.ProjectCandidate{ID: "alpha", Weight: 1}
+	reworkProject := scheduler.ProjectCandidate{ID: "bravo", Weight: 1}
+	mergeProject := scheduler.ProjectCandidate{ID: "charlie", Weight: 1}
+
+	todoSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, todoProject, scheduler.SlotRequest{
+		State:    "Todo",
+		Priority: 2,
+	}, now)
+	if err != nil {
+		t.Fatalf("todo TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("todo TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, reworkProject, scheduler.SlotRequest{
+		State:    "Rework",
+		Priority: 1,
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("rework waiting TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("rework waiting TryAcquireWithDecision() ok = true while the global slot is held, want false")
+	} else if decision.SelectedProjectID != reworkProject.ID || decision.Reason != scheduler.DispatchGateReasonGlobalCapacityFull {
+		t.Fatalf("rework waiting decision = %#v, want selected rework with global capacity full", decision)
+	}
+
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Priority: 0,
+	}, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("merge waiting TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("merge waiting TryAcquireWithDecision() ok = true while the global slot is held, want false")
+	} else if decision.SelectedProjectID != mergeProject.ID || decision.Reason != scheduler.DispatchGateReasonGlobalCapacityFull {
+		t.Fatalf("merge waiting decision = %#v, want selected merge with global capacity full", decision)
+	}
+
+	if err := gate.Release(todoSlot); err != nil {
+		t.Fatalf("todo Release() error = %v", err)
+	}
+
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, reworkProject, scheduler.SlotRequest{
+		State:    "Rework",
+		Priority: 1,
+	}, now.Add(3*time.Second)); err != nil {
+		t.Fatalf("rework retry TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("rework retry TryAcquireWithDecision() ok = true while merge has the reserved turn, want false")
+	} else if decision.SelectedProjectID != mergeProject.ID || decision.Reason != scheduler.DispatchGateReasonReservedForHigherPriority {
+		t.Fatalf("rework retry decision = %#v, want merge reserved for higher-priority state", decision)
+	}
+
+	mergeSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Priority: 0,
+	}, now.Add(4*time.Second))
+	if err != nil {
+		t.Fatalf("merge TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("merge TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+	if err := gate.Release(mergeSlot); err != nil {
+		t.Fatalf("merge Release() error = %v", err)
+	}
+}
+
 func TestSchedulersAllowOneMergeLanePerProject(t *testing.T) {
 	t.Parallel()
 

--- a/internal/scheduler/scheduler.go
+++ b/internal/scheduler/scheduler.go
@@ -47,16 +47,18 @@ type Config struct {
 }
 
 type SlotRequest struct {
-	State  string
-	Host   string
-	Weight int
+	State    string
+	Host     string
+	Weight   int
+	Priority int
 }
 
 type Slot struct {
-	State  string
-	Host   string
-	Weight int
-	token  uint64
+	State    string
+	Host     string
+	Weight   int
+	Priority int
+	token    uint64
 }
 
 type Counters struct {
@@ -75,6 +77,13 @@ type CountingSemaphore struct {
 	usedByHost      map[string]int
 	active          map[uint64]Slot
 	nextToken       uint64
+}
+
+type capacitySnapshot struct {
+	globalCapacity int
+	globalUsed     int
+	stateCapacity  int
+	stateUsed      int
 }
 
 var _ Scheduler = (*CountingSemaphore)(nil)
@@ -187,6 +196,28 @@ func (s *CountingSemaphore) Counters() Counters {
 	}
 }
 
+func (s *CountingSemaphore) capacitySnapshot(state string) capacitySnapshot {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	state = normalizeState(state)
+	stateCapacity := s.capacity
+	stateUsed := s.used
+	if state != "" {
+		stateUsed = s.usedByState[state]
+		if capacity, ok := s.capacityByState[state]; ok {
+			stateCapacity = capacity
+		}
+	}
+
+	return capacitySnapshot{
+		globalCapacity: s.capacity,
+		globalUsed:     s.used,
+		stateCapacity:  stateCapacity,
+		stateUsed:      stateUsed,
+	}
+}
+
 func (s *CountingSemaphore) checkCapacity(slot Slot) error {
 	if slot.Weight > s.capacity {
 		return fmt.Errorf("%w: global capacity %d", ErrWeightExceedsCapacity, s.capacity)
@@ -233,10 +264,18 @@ func normalizeRequest(req SlotRequest) (Slot, error) {
 	}
 
 	return Slot{
-		State:  normalizeState(req.State),
-		Host:   normalizeHost(req.Host),
-		Weight: weight,
+		State:    normalizeState(req.State),
+		Host:     normalizeHost(req.Host),
+		Weight:   weight,
+		Priority: normalizeSlotPriority(req.Priority),
 	}, nil
+}
+
+func normalizeSlotPriority(priority int) int {
+	if priority < 0 {
+		return 0
+	}
+	return priority
 }
 
 func normalizedCapacities(values map[string]int) map[string]int {


### PR DESCRIPTION
## Summary
- Add state-priority-aware global dispatch gate decisions so ready Merging work reserves scarce global slots ahead of lower-priority lanes.
- Thread dispatch state priority from orchestrators into global slot requests and log merge slot wait/acquire telemetry with global and per-project capacity details.
- Add scheduler/orchestrator regression tests for merge priority, freed-slot reservation, per-project merge serialization, and log spam reduction.

Fixes #710

## Test Plan
- `go test ./internal/scheduler ./internal/orchestrator -count=1`
- `go test ./internal/project ./internal/cli -count=1`
- Dispatch-focused `go test ./... -run "TestDispatch|TestGlobalDispatch|TestManagerProjectsShareGlobalDispatchCap|TestConfigFromWorkflowIncludesDispatchControls|TestTickDispatchesStaleMergingIssue" -count=1`
- `make check`