### PR TITLE
ci: shorten required merge checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,11 @@ name: CI
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
+  schedule:
+    - cron: '27 9 * * *'
+  workflow_dispatch:
 
 permissions:
   contents: read
@@ -51,18 +55,8 @@ jobs:
         run: ~/go/bin/golangci-lint run --timeout=5m
 
   verify:
-    name: Verify (${{ matrix.os }})
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - os: ubuntu-latest
-            race: true
-          - os: macos-latest
-            race: true
-          - os: windows-latest
-            race: true
+    name: Verify (ubuntu-latest)
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
 
@@ -84,7 +78,6 @@ jobs:
         run: go test ./...
 
       - name: Race test
-        if: matrix.race
         run: go test -race ./...
 
   test-cover:
@@ -106,33 +99,69 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
 
       - uses: actions/setup-go@v6
         with:
           go-version: '1.26.4'
           cache: true
 
+      - name: Detect visual-sensitive changes
+        id: visual-changes
+        shell: bash
+        run: |
+          set -euo pipefail
+          run_visual=true
+          if [ -n "${GITHUB_BASE_REF:-}" ]; then
+            git fetch --no-tags --depth=1 origin "$GITHUB_BASE_REF"
+            run_visual=false
+            while IFS= read -r changed_file; do
+              case "$changed_file" in
+                .github/workflows/ci.yml|.templui.json|package.json|package-lock.json|playwright.config.js|README.md|docs/ONBOARDING.md|static/*|tests/visual/*|internal/web/*|internal/cli/dev_runtime*.go|internal/devruntime/*)
+                  run_visual=true
+                  break
+                  ;;
+              esac
+            done < <(git diff --name-only "origin/$GITHUB_BASE_REF...HEAD")
+          fi
+          echo "run_visual=$run_visual" >> "$GITHUB_OUTPUT"
+
       - uses: actions/setup-node@v6
+        if: steps.visual-changes.outputs.run_visual == 'true'
         with:
           node-version: '24'
           cache: npm
 
       - name: Install Node dependencies
+        if: steps.visual-changes.outputs.run_visual == 'true'
         run: npm ci
 
       - name: Install Playwright browsers
+        if: steps.visual-changes.outputs.run_visual == 'true'
         run: npx playwright install --with-deps chromium
 
       - name: Install visual build generators
+        if: steps.visual-changes.outputs.run_visual == 'true'
         run: go install github.com/sqlc-dev/sqlc/cmd/sqlc@latest
 
       - name: Build Detent visual test binary
+        if: steps.visual-changes.outputs.run_visual == 'true'
         run: make build
 
-      - name: Run browser visual gate
+      - name: Run full browser visual gate
+        if: steps.visual-changes.outputs.run_visual == 'true'
         env:
           DETENT_BINARY: ${{ github.workspace }}/tmp/detent
         run: npm run test:visual
+
+      - name: Run browser smoke gate
+        if: steps.visual-changes.outputs.run_visual != 'true'
+        run: |
+          set -euo pipefail
+          mkdir -p tmp
+          go build -o tmp/detent ./cmd/detent
+          tmp/detent --help
 
       - name: Upload browser visual evidence
         if: always()
@@ -154,7 +183,39 @@ jobs:
           if-no-files-found: ignore
           retention-days: 14
 
+  portability-verify:
+    if: ${{ github.event_name != 'pull_request' }}
+    name: Portability Verify (${{ matrix.os }})
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [macos-latest, windows-latest]
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: '1.26.4'
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
+      - name: Build
+        run: go build ./...
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...
+
+      - name: Race test
+        run: go test -race ./...
+
   windows-core:
+    if: ${{ github.event_name != 'pull_request' }}
     name: Windows Core
     runs-on: windows-latest
     steps:
@@ -172,6 +233,7 @@ jobs:
         run: go build ./cmd/detent
 
   installer-smoke:
+    if: ${{ github.event_name != 'pull_request' }}
     name: Installer Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -265,9 +327,10 @@ jobs:
           & $binary version
 
   goreleaser-snapshot:
+    if: ${{ github.event_name != 'pull_request' }}
     name: GoReleaser Snapshot
     runs-on: ubuntu-latest
-    needs: [lint, verify, test-cover, browser-visual, windows-core, installer-smoke]
+    needs: [lint, verify, test-cover, browser-visual, portability-verify, windows-core, installer-smoke]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,7 +118,7 @@ jobs:
             run_visual=false
             while IFS= read -r changed_file; do
               case "$changed_file" in
-                .github/workflows/ci.yml|.templui.json|package.json|package-lock.json|playwright.config.js|README.md|docs/ONBOARDING.md|static/*|tests/visual/*|internal/web/*|internal/cli/dev_runtime*.go|internal/devruntime/*)
+                .github/workflows/ci.yml|.templui.json|go.mod|go.sum|package.json|package-lock.json|playwright.config.js|README.md|docs/ONBOARDING.md|static/*|tests/visual/*|internal/web/*|internal/cli/dev_runtime*.go|internal/devruntime/*)
                   run_visual=true
                   break
                   ;;

--- a/README.md
+++ b/README.md
@@ -1073,15 +1073,16 @@ motion capture needs advancing counters. The PNG capture uses a local
 Chrome-family browser; pass `--browser <path>` or set `DETENT_CAPTURE_BROWSER`
 when auto-detection cannot find one.
 
-The CI browser visual gate runs Playwright when a PR changes UI-sensitive
-paths such as `.github/workflows/ci.yml`, `package.json`, `static/**`,
-`internal/web/**`, `internal/cli/dev_runtime*.go`, `internal/devruntime/**`,
-Templ inputs, or screenshot/onboarding docs. It builds the PR's Detent binary,
-starts isolated `dev-runtime` instances on port `0`, captures current evidence
-under `tmp/playwright-evidence`, and uploads Playwright reports, traces,
-screenshots, and image diffs when assertions fail. PRs without UI-sensitive
-changes keep the required `Browser Visual` check fast by building the Detent
-binary and running a CLI smoke instead of starting Playwright.
+The CI browser visual gate runs Playwright when a PR changes UI-sensitive paths
+such as `.github/workflows/ci.yml`, `go.mod`, `go.sum`, `package.json`,
+`static/**`, `internal/web/**`, `internal/cli/dev_runtime*.go`,
+`internal/devruntime/**`, Templ inputs, or screenshot/onboarding docs. It builds
+the PR's Detent binary, starts isolated `dev-runtime` instances on port `0`,
+captures current evidence under `tmp/playwright-evidence`, and uploads
+Playwright reports, traces, screenshots, and image diffs when assertions fail.
+PRs without UI-sensitive changes keep the required `Browser Visual` check fast
+by building the Detent binary and running a CLI smoke instead of starting
+Playwright.
 
 Run the layout gate locally after installing Playwright's Chromium browser:
 

--- a/README.md
+++ b/README.md
@@ -387,11 +387,13 @@ switches the detected Go-installed binary to the release asset and pins future
 updates to release-binary management. Source builds still print the recommended
 command instead of overwriting the binary.
 
-CI runs the `Installer Smoke` job on Ubuntu and Windows against the current
-GitHub Release assets. The job runs `install.sh` and `install.ps1` in release
-mode, checks checksum output, confirms the requested install directory and
-installer lock metadata, then runs `detent update --check` and
-`detent update --yes` from the release-installer install.
+CI runs the `Installer Smoke` confidence job on Ubuntu and Windows against the
+current GitHub Release assets after merges to `main`, on release tags, on the
+nightly schedule, and from manual workflow dispatch. The job runs `install.sh`
+and `install.ps1` in release mode, checks checksum output, confirms the
+requested install directory and installer lock metadata, then runs
+`detent update --check` and `detent update --yes` from the release-installer
+install.
 
 Release self-updates verify SHA256 checksums fetched from GitHub releases. The
 checksum verifier supports detached minisign signature assets named
@@ -491,11 +493,11 @@ package-manager manifests. Scoop publishing targets
 skips publishing when `SCOOP_BUCKET_GITHUB_TOKEN` or `WINGET_GITHUB_TOKEN` is
 not configured.
 
-CI also runs `GoReleaser Snapshot` on every pull request and every push to
-`main` so the current merge head remains release-package validated before and
-after merge. Required branch checks must not pass as path- or event-dependent
-no-ops on pull requests when the same check name runs real validation on
-`main`.
+CI runs `GoReleaser Snapshot` after merges to `main`, on `v*` release tags, on
+the nightly schedule, and from manual workflow dispatch so release packaging is
+validated outside the normal PR merge lane. Required branch checks must not pass
+as path- or event-dependent no-ops on pull requests when the same check name
+runs real validation on `main`.
 
 ## Quick Start
 
@@ -1077,7 +1079,9 @@ paths such as `.github/workflows/ci.yml`, `package.json`, `static/**`,
 Templ inputs, or screenshot/onboarding docs. It builds the PR's Detent binary,
 starts isolated `dev-runtime` instances on port `0`, captures current evidence
 under `tmp/playwright-evidence`, and uploads Playwright reports, traces,
-screenshots, and image diffs when assertions fail.
+screenshots, and image diffs when assertions fail. PRs without UI-sensitive
+changes keep the required `Browser Visual` check fast by building the Detent
+binary and running a CLI smoke instead of starting Playwright.
 
 Run the layout gate locally after installing Playwright's Chromium browser:
 
@@ -1594,21 +1598,19 @@ configured gate again.
 
 CI waiting should poll current-head REST check runs with backoff, not loop on
 GraphQL-heavy PR status commands. Merge handoff telemetry should record the
-quiet-window wait, local merge-gate duration, current-head PR CI duration, slow
-check names, and whether post-merge `main` CI is still running. The quiet
-window, current-head required CI, and conflict/full-gate fallback are quality
-gates; repeated full local validation after a source-clean rebase, noisy status
-polling, uncached tool install, and duplicated post-merge work are optimization
-targets.
+quiet-window wait, GitHub queue/start wait, local merge-gate duration,
+current-head PR CI duration, active slow-check runtimes, and whether post-merge
+`main` CI is still running. The quiet window, current-head required CI, and
+conflict/full-gate fallback are quality gates; repeated full local validation
+after a source-clean rebase, noisy status polling, uncached tool install, and
+duplicated post-merge work are optimization targets.
 
 The repository CI caches the project-pinned golangci-lint binary and only builds
 it with `go install` on cache miss. The official prebuilt action was evaluated,
 but the prebuilt `v2.1.6` binary targets an older Go toolchain than this repo and
 newer prebuilt lint releases change the enforced lint set. `GoReleaser Snapshot`
-continues to run on every PR in this workflow; moving it off PRs or making it
-path-based is a release-policy decision because it trades package coverage for
-merge latency and requires a separate non-required check name or equivalent
-required companion validation.
+now runs as release confidence coverage outside normal PR merges so packaging
+signal remains available without extending the required merge lane.
 
 ## Multi-Project Operation
 

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -8,47 +8,55 @@ import (
 
 type requiredStatusCheck struct {
 	name     string
+	budget   string
 	jobStart string
 	jobEnd   string
 	markers  []string
 }
 
-var requiredMainStatusChecks = []requiredStatusCheck{
+var requiredPRStatusChecks = []requiredStatusCheck{
 	{
 		name:     "Lint",
+		budget:   "2m",
 		jobStart: "  lint:",
 		jobEnd:   "  verify:",
 		markers:  []string{"name: Lint"},
 	},
 	{
 		name:     "Verify (ubuntu-latest)",
+		budget:   "4m",
 		jobStart: "  verify:",
 		jobEnd:   "  test-cover:",
-		markers:  []string{"name: Verify (${{ matrix.os }})", "os: ubuntu-latest"},
-	},
-	{
-		name:     "Verify (macos-latest)",
-		jobStart: "  verify:",
-		jobEnd:   "  test-cover:",
-		markers:  []string{"name: Verify (${{ matrix.os }})", "os: macos-latest"},
-	},
-	{
-		name:     "Verify (windows-latest)",
-		jobStart: "  verify:",
-		jobEnd:   "  test-cover:",
-		markers:  []string{"name: Verify (${{ matrix.os }})", "os: windows-latest"},
+		markers:  []string{"name: Verify (ubuntu-latest)", "runs-on: ubuntu-latest"},
 	},
 	{
 		name:     "Test Coverage",
+		budget:   "4m",
 		jobStart: "  test-cover:",
 		jobEnd:   "  browser-visual:",
 		markers:  []string{"name: Test Coverage"},
 	},
 	{
 		name:     "Browser Visual",
+		budget:   "5m",
 		jobStart: "  browser-visual:",
+		jobEnd:   "  portability-verify:",
+		markers:  []string{"name: Browser Visual", "Run full browser visual gate", "Run browser smoke gate"},
+	},
+}
+
+var confidenceStatusChecks = []requiredStatusCheck{
+	{
+		name:     "Portability Verify (macos-latest)",
+		jobStart: "  portability-verify:",
 		jobEnd:   "  windows-core:",
-		markers:  []string{"name: Browser Visual"},
+		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]"},
+	},
+	{
+		name:     "Portability Verify (windows-latest)",
+		jobStart: "  portability-verify:",
+		jobEnd:   "  windows-core:",
+		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]"},
 	},
 	{
 		name:     "Windows Core",
@@ -103,14 +111,15 @@ func TestMainProtectionDocumentationMatchesWorkflow(t *testing.T) {
 		"must not report success from a path- or event-dependent no-op",
 		"`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`",
 		"`Browser Visual`",
+		"Release and portability confidence checks",
 	} {
 		if !strings.Contains(protection, want) {
 			t.Fatalf("main branch protection docs missing %q", want)
 		}
 	}
 
-	for _, check := range requiredMainStatusChecks {
-		if !strings.Contains(protection, "- `"+check.name+"`") {
+	for _, check := range requiredPRStatusChecks {
+		if !strings.Contains(protection, "- `"+check.name+"` - budget: `"+check.budget+"`") {
 			t.Fatalf("main branch protection docs missing required check %q", check.name)
 		}
 
@@ -121,13 +130,29 @@ func TestMainProtectionDocumentationMatchesWorkflow(t *testing.T) {
 			}
 		}
 	}
+
+	for _, check := range confidenceStatusChecks {
+		if !strings.Contains(protection, "- `"+check.name+"`") {
+			t.Fatalf("main branch protection docs missing confidence check %q", check.name)
+		}
+
+		job := workflowBetween(t, workflow, check.jobStart, check.jobEnd)
+		if !strings.Contains(job, "if: ${{ github.event_name != 'pull_request' }}") {
+			t.Fatalf("confidence check %q must stay outside the normal PR path", check.name)
+		}
+		for _, marker := range check.markers {
+			if !strings.Contains(job, marker) {
+				t.Fatalf("workflow job for confidence check %q missing %q", check.name, marker)
+			}
+		}
+	}
 }
 
 func TestRequiredChecksDoNotUseEventDependentGreenNoops(t *testing.T) {
 	t.Parallel()
 
 	workflow := readNormalizedFile(t, ".github/workflows/ci.yml")
-	for _, check := range requiredMainStatusChecks {
+	for _, check := range requiredPRStatusChecks {
 		job := workflowBetween(t, workflow, check.jobStart, check.jobEnd)
 		for _, forbidden := range []string{
 			"github.event_name",
@@ -207,9 +232,10 @@ func TestKanbanBrowserDragDropRunsInVisualGate(t *testing.T) {
 		t.Fatalf("ReadFile(.github/workflows/ci.yml) error = %v", err)
 	}
 	workflow := strings.ReplaceAll(string(workflowRaw), "\r\n", "\n")
-	visualJob := workflowBetween(t, workflow, "  browser-visual:", "\n  windows-core:")
+	visualJob := workflowBetween(t, workflow, "  browser-visual:", "\n  portability-verify:")
 	for _, want := range []string{
 		"npm run test:visual",
+		"tmp/detent --help",
 		"name: Upload browser visual evidence",
 		"tmp/playwright-evidence",
 		"name: Upload browser visual failure artifacts",

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -236,6 +236,7 @@ func TestKanbanBrowserDragDropRunsInVisualGate(t *testing.T) {
 	for _, want := range []string{
 		"npm run test:visual",
 		"tmp/detent --help",
+		"go.mod|go.sum",
 		"name: Upload browser visual evidence",
 		"tmp/playwright-evidence",
 		"name: Upload browser visual failure artifacts",

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -48,18 +48,18 @@ The execution edge still carries these code/git/PR assumptions.
   conflict resolution, stale validation, or unknown validation state.
 - Current-head CI waiting should use REST check-run polling with backoff and
   clear slow-check status rather than GraphQL-heavy PR polling loops.
-- Merge telemetry should report quiet-window wait, local merge-gate duration,
-  current-head PR CI duration, slow check names, and whether post-merge `main`
-  CI is still running.
+- Merge telemetry should report quiet-window wait, GitHub queue/start wait,
+  local merge-gate duration, current-head PR CI duration, active slow-check
+  runtimes, and whether post-merge `main` CI is still running.
 - Duplicate full local validation after a source-clean rebase, uncached tool
   install, noisy polling, and post-merge work that is not part of the merge
   decision are optimization targets.
 - The CI lint job keeps the project-pinned golangci-lint version and caches its
   binary so cache hits avoid a per-run `go install` without changing lint
   coverage.
-- `GoReleaser Snapshot` runs on every PR and every push to `main` so the
-  required check exercises the same release-package path before and after
-  merge.
+- `GoReleaser Snapshot` is a release confidence check that runs after merges to
+  `main`, on release tags, on the nightly CI schedule, and from manual
+  workflow dispatch instead of blocking the normal PR merge lane.
 
 ### Main Branch Protection
 
@@ -68,17 +68,26 @@ merge. The expected GitHub branch protection or ruleset setting is
 `required_status_checks.strict: true`; if the repository switches to merge
 queue, the queue must provide equivalent current-base validation before merge.
 
-Required status checks must include every meaningful CI job directly. Do not
-depend on a downstream skipped job to protect an upstream gate. A required
+Required status checks must include every merge-blocking CI job directly. Do
+not depend on a downstream skipped job to protect an upstream gate. A required
 check name must not report success from a path- or event-dependent no-op when
-the same named check runs real validation on `main`. The required checks are:
+the same named check runs real validation on `main`; `Browser Visual` is still a
+real gate because non-UI pull requests run a Detent binary smoke instead of a
+green no-op.
 
-- `Lint`
-- `Verify (ubuntu-latest)`
-- `Verify (macos-latest)`
-- `Verify (windows-latest)`
-- `Test Coverage`
-- `Browser Visual`
+Required PR merge checks:
+
+- `Lint` - budget: `2m`
+- `Verify (ubuntu-latest)` - budget: `4m`
+- `Test Coverage` - budget: `4m`
+- `Browser Visual` - budget: `5m`
+
+Release and portability confidence checks run after merges to `main`, on `v*`
+release tags, on the nightly CI schedule, and from manual workflow dispatch.
+They are not required for normal PR merge:
+
+- `Portability Verify (macos-latest)`
+- `Portability Verify (windows-latest)`
 - `Windows Core`
 - `Installer Smoke (ubuntu-latest)`
 - `Installer Smoke (windows-latest)`
@@ -86,10 +95,10 @@ the same named check runs real validation on `main`. The required checks are:
 
 The CI workflow keeps pull request runs cancellable by newer pushes to the same
 PR through `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.
-Push runs, including consecutive pushes to `main`, use a unique run group and
-must not be cancelled by later pushes. The workflow test in
-`ci_workflow_test.go` checks this section against `.github/workflows/ci.yml` so
-job-name, required-check, and green no-op drift fails in local validation.
+Push, tag, schedule, and manual runs use a unique run group and must not be
+cancelled by later runs. The workflow test in `ci_workflow_test.go` checks this
+section against `.github/workflows/ci.yml` so job-name, required-check, wall-time
+budget, confidence-check, and green no-op drift fails in local validation.
 
 ## Still Git/PR Coupled
 

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -815,6 +815,7 @@ type restCheckRun struct {
 	Status      string     `json:"status"`
 	Conclusion  string     `json:"conclusion"`
 	Name        string     `json:"name"`
+	CreatedAt   *time.Time `json:"created_at"`
 	StartedAt   *time.Time `json:"started_at"`
 	CompletedAt *time.Time `json:"completed_at"`
 }
@@ -829,9 +830,17 @@ type pullRequestCI struct {
 	State              string
 	CheckRunCount      int
 	StatusContextCount int
+	CIQueueSeconds     int64
 	CIDurationSeconds  int64
 	SlowChecks         []connector.PullRequestCheck
 	RunningChecks      []string
+}
+
+type checkRunTelemetrySummary struct {
+	QueueSeconds    int64
+	DurationSeconds int64
+	SlowChecks      []connector.PullRequestCheck
+	RunningChecks   []string
 }
 
 type restComment struct {
@@ -2232,6 +2241,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		CIStatus:                     normalizePullRequestCIStatus(pullRequestCIState(pullRequest)),
 		CheckRunCount:                pullRequest.CI.CheckRunCount,
 		StatusContextCount:           pullRequest.CI.StatusContextCount,
+		CIQueueSeconds:               pullRequest.CI.CIQueueSeconds,
 		CIDurationSeconds:            pullRequest.CI.CIDurationSeconds,
 		SlowChecks:                   append([]connector.PullRequestCheck(nil), pullRequest.CI.SlowChecks...),
 		RunningChecks:                append([]string(nil), pullRequest.CI.RunningChecks...),
@@ -2436,14 +2446,15 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	if err != nil {
 		return pullRequestCI{}, fmt.Errorf("fetch github commit statuses: %w", err)
 	}
-	durationSeconds, slowChecks, runningChecks := checkRunTelemetry(checkRuns)
+	telemetry := checkRunTelemetry(checkRuns)
 	return pullRequestCI{
 		State:              combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses)),
 		CheckRunCount:      len(checkRuns),
 		StatusContextCount: len(statuses),
-		CIDurationSeconds:  durationSeconds,
-		SlowChecks:         slowChecks,
-		RunningChecks:      runningChecks,
+		CIQueueSeconds:     telemetry.QueueSeconds,
+		CIDurationSeconds:  telemetry.DurationSeconds,
+		SlowChecks:         telemetry.SlowChecks,
+		RunningChecks:      telemetry.RunningChecks,
 	}, nil
 }
 
@@ -3872,7 +3883,8 @@ func checkRunsState(checkRuns []restCheckRun) string {
 	return "success"
 }
 
-func checkRunTelemetry(checkRuns []restCheckRun) (int64, []connector.PullRequestCheck, []string) {
+func checkRunTelemetry(checkRuns []restCheckRun) checkRunTelemetrySummary {
+	var createdAt *time.Time
 	var startedAt *time.Time
 	var completedAt *time.Time
 	hasRunning := false
@@ -3880,6 +3892,7 @@ func checkRunTelemetry(checkRuns []restCheckRun) (int64, []connector.PullRequest
 	runningChecks := make([]string, 0, len(checkRuns))
 
 	for _, checkRun := range checkRuns {
+		createdAt = earliestGitHubTime(createdAt, checkRun.CreatedAt)
 		startedAt = earliestGitHubTime(startedAt, checkRun.StartedAt)
 		completedAt = latestGitHubTime(completedAt, checkRun.CompletedAt)
 
@@ -3894,10 +3907,15 @@ func checkRunTelemetry(checkRuns []restCheckRun) (int64, []connector.PullRequest
 		if name == "" || checkRun.StartedAt == nil || checkRun.CompletedAt == nil || checkRun.CompletedAt.Before(*checkRun.StartedAt) {
 			continue
 		}
+		var queueSeconds int64
+		if checkRun.CreatedAt != nil && !checkRun.StartedAt.Before(*checkRun.CreatedAt) {
+			queueSeconds = int64(checkRun.StartedAt.Sub(*checkRun.CreatedAt) / time.Second)
+		}
 		slowChecks = append(slowChecks, connector.PullRequestCheck{
 			Name:            name,
 			Status:          status,
 			Conclusion:      conclusion,
+			QueueSeconds:    queueSeconds,
 			DurationSeconds: int64(checkRun.CompletedAt.Sub(*checkRun.StartedAt) / time.Second),
 		})
 	}
@@ -3921,7 +3939,16 @@ func checkRunTelemetry(checkRuns []restCheckRun) (int64, []connector.PullRequest
 	if !hasRunning && startedAt != nil && completedAt != nil && !completedAt.Before(*startedAt) {
 		durationSeconds = int64(completedAt.Sub(*startedAt) / time.Second)
 	}
-	return durationSeconds, slowChecks, runningChecks
+	var queueSeconds int64
+	if createdAt != nil && startedAt != nil && !startedAt.Before(*createdAt) {
+		queueSeconds = int64(startedAt.Sub(*createdAt) / time.Second)
+	}
+	return checkRunTelemetrySummary{
+		QueueSeconds:    queueSeconds,
+		DurationSeconds: durationSeconds,
+		SlowChecks:      slowChecks,
+		RunningChecks:   runningChecks,
+	}
 }
 
 func earliestGitHubTime(current *time.Time, candidate *time.Time) *time.Time {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -611,6 +611,7 @@ var (
 	issueURLPattern       = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
 	numberedListPattern   = regexp.MustCompile(`^\d+[.)]\s+`)
 	branchKeyPattern      = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+	actionRunURLPattern   = regexp.MustCompile(`/actions/runs/([0-9]+)(?:/|$)`)
 )
 
 type pageInfo struct {
@@ -815,9 +816,16 @@ type restCheckRun struct {
 	Status      string     `json:"status"`
 	Conclusion  string     `json:"conclusion"`
 	Name        string     `json:"name"`
+	DetailsURL  string     `json:"details_url"`
 	CreatedAt   *time.Time `json:"created_at"`
 	StartedAt   *time.Time `json:"started_at"`
 	CompletedAt *time.Time `json:"completed_at"`
+}
+
+type restWorkflowRun struct {
+	ID           int64      `json:"id"`
+	CreatedAt    *time.Time `json:"created_at"`
+	RunStartedAt *time.Time `json:"run_started_at"`
 }
 
 type restCommitStatus struct {
@@ -2442,11 +2450,15 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 	if err != nil {
 		return pullRequestCI{}, fmt.Errorf("fetch github check runs: %w", err)
 	}
+	workflowRuns, workflowRunErr := fetchRESTWorkflowRunsForCheckRuns(ctx, c.client, repo, checkRuns)
+	if workflowRunErr != nil {
+		workflowRuns = nil
+	}
 	statuses, err := fetchRESTList[restCommitStatus](ctx, c.client, restCommitStatusesPath(repo, sha))
 	if err != nil {
 		return pullRequestCI{}, fmt.Errorf("fetch github commit statuses: %w", err)
 	}
-	telemetry := checkRunTelemetry(checkRuns)
+	telemetry := checkRunTelemetry(checkRuns, workflowRuns)
 	return pullRequestCI{
 		State:              combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses)),
 		CheckRunCount:      len(checkRuns),
@@ -3543,6 +3555,10 @@ func restCommitCheckRunsPath(repo pullRequestRepo, sha string) string {
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/commits/" + url.PathEscape(sha) + "/check-runs?" + values.Encode()
 }
 
+func restWorkflowRunPath(repo pullRequestRepo, runID int64) string {
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/actions/runs/" + strconv.FormatInt(runID, 10)
+}
+
 func restCommitStatusesPath(repo pullRequestRepo, sha string) string {
 	values := url.Values{}
 	values.Set("per_page", "100")
@@ -3581,6 +3597,43 @@ func fetchRESTCheckRuns(ctx context.Context, client *Client, path string) ([]res
 		}
 	}
 	return checkRuns, nil
+}
+
+func fetchRESTWorkflowRunsForCheckRuns(ctx context.Context, client *Client, repo pullRequestRepo, checkRuns []restCheckRun) ([]restWorkflowRun, error) {
+	runIDs := checkRunWorkflowRunIDs(checkRuns)
+	runs := make([]restWorkflowRun, 0, len(runIDs))
+	for _, runID := range runIDs {
+		var run restWorkflowRun
+		_, err := client.rest(ctx, http.MethodGet, restWorkflowRunPath(repo, runID), nil, &run)
+		if err != nil {
+			return nil, err
+		}
+		runs = append(runs, run)
+	}
+	return runs, nil
+}
+
+func checkRunWorkflowRunIDs(checkRuns []restCheckRun) []int64 {
+	seen := map[int64]struct{}{}
+	for _, checkRun := range checkRuns {
+		match := actionRunURLPattern.FindStringSubmatch(strings.TrimSpace(checkRun.DetailsURL))
+		if len(match) != 2 {
+			continue
+		}
+		runID, err := strconv.ParseInt(match[1], 10, 64)
+		if err != nil || runID <= 0 {
+			continue
+		}
+		seen[runID] = struct{}{}
+	}
+	runIDs := make([]int64, 0, len(seen))
+	for runID := range seen {
+		runIDs = append(runIDs, runID)
+	}
+	sort.Slice(runIDs, func(i, j int) bool {
+		return runIDs[i] < runIDs[j]
+	})
+	return runIDs
 }
 
 func githubIssueNodeFromREST(ref issueRef, issue restIssue) githubIssueNode {
@@ -3883,17 +3936,24 @@ func checkRunsState(checkRuns []restCheckRun) string {
 	return "success"
 }
 
-func checkRunTelemetry(checkRuns []restCheckRun) checkRunTelemetrySummary {
-	var createdAt *time.Time
-	var startedAt *time.Time
+func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun) checkRunTelemetrySummary {
+	var queueCreatedAt *time.Time
+	var queueStartedAt *time.Time
+	var checkStartedAt *time.Time
 	var completedAt *time.Time
 	hasRunning := false
 	slowChecks := make([]connector.PullRequestCheck, 0, len(checkRuns))
 	runningChecks := make([]string, 0, len(checkRuns))
 
+	for _, run := range workflowRuns {
+		queueCreatedAt = earliestGitHubTime(queueCreatedAt, run.CreatedAt)
+		queueStartedAt = earliestGitHubTime(queueStartedAt, run.RunStartedAt)
+	}
+
 	for _, checkRun := range checkRuns {
-		createdAt = earliestGitHubTime(createdAt, checkRun.CreatedAt)
-		startedAt = earliestGitHubTime(startedAt, checkRun.StartedAt)
+		queueCreatedAt = earliestGitHubTime(queueCreatedAt, checkRun.CreatedAt)
+		queueStartedAt = earliestGitHubTime(queueStartedAt, checkRun.StartedAt)
+		checkStartedAt = earliestGitHubTime(checkStartedAt, checkRun.StartedAt)
 		completedAt = latestGitHubTime(completedAt, checkRun.CompletedAt)
 
 		name := strings.TrimSpace(checkRun.Name)
@@ -3936,12 +3996,12 @@ func checkRunTelemetry(checkRuns []restCheckRun) checkRunTelemetrySummary {
 	}
 
 	var durationSeconds int64
-	if !hasRunning && startedAt != nil && completedAt != nil && !completedAt.Before(*startedAt) {
-		durationSeconds = int64(completedAt.Sub(*startedAt) / time.Second)
+	if !hasRunning && checkStartedAt != nil && completedAt != nil && !completedAt.Before(*checkStartedAt) {
+		durationSeconds = int64(completedAt.Sub(*checkStartedAt) / time.Second)
 	}
 	var queueSeconds int64
-	if createdAt != nil && startedAt != nil && !startedAt.Before(*createdAt) {
-		queueSeconds = int64(startedAt.Sub(*createdAt) / time.Second)
+	if queueCreatedAt != nil && queueStartedAt != nil && !queueStartedAt.Before(*queueCreatedAt) {
+		queueSeconds = int64(queueStartedAt.Sub(*queueCreatedAt) / time.Second)
 	}
 	return checkRunTelemetrySummary{
 		QueueSeconds:    queueSeconds,

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1259,7 +1259,7 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/commits/sha-190/check-runs?per_page=100",
-			body:   `{"check_runs":[{"name":"Verify (ubuntu-latest)","status":"completed","conclusion":"success","started_at":"2026-06-05T11:00:00Z","completed_at":"2026-06-05T11:03:00Z"},{"name":"GoReleaser Snapshot","status":"completed","conclusion":"failure","started_at":"2026-06-05T11:03:30Z","completed_at":"2026-06-05T11:11:30Z"},{"name":"Windows Core","status":"in_progress","conclusion":"","started_at":"2026-06-05T11:05:00Z","completed_at":null}]}`,
+			body:   `{"check_runs":[{"name":"Verify (ubuntu-latest)","status":"completed","conclusion":"success","created_at":"2026-06-05T10:59:00Z","started_at":"2026-06-05T11:00:00Z","completed_at":"2026-06-05T11:03:00Z"},{"name":"GoReleaser Snapshot","status":"completed","conclusion":"failure","created_at":"2026-06-05T11:00:30Z","started_at":"2026-06-05T11:03:30Z","completed_at":"2026-06-05T11:11:30Z"},{"name":"Windows Core","status":"in_progress","conclusion":"","created_at":"2026-06-05T11:04:00Z","started_at":"2026-06-05T11:05:00Z","completed_at":null}]}`,
 		},
 		{
 			method: http.MethodGet,
@@ -1297,14 +1297,17 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	if pr.CIDurationSeconds != 0 {
 		t.Fatalf("CIDurationSeconds = %d, want 0 while checks are running", pr.CIDurationSeconds)
 	}
+	if pr.CIQueueSeconds != 60 {
+		t.Fatalf("CIQueueSeconds = %d, want 60", pr.CIQueueSeconds)
+	}
 	if len(pr.SlowChecks) != 2 {
 		t.Fatalf("SlowChecks len = %d, want 2: %#v", len(pr.SlowChecks), pr.SlowChecks)
 	}
-	if pr.SlowChecks[0].Name != "GoReleaser Snapshot" || pr.SlowChecks[0].DurationSeconds != 480 {
-		t.Fatalf("SlowChecks[0] = %#v, want GoReleaser Snapshot 480s", pr.SlowChecks[0])
+	if pr.SlowChecks[0].Name != "GoReleaser Snapshot" || pr.SlowChecks[0].DurationSeconds != 480 || pr.SlowChecks[0].QueueSeconds != 180 {
+		t.Fatalf("SlowChecks[0] = %#v, want GoReleaser Snapshot 480s active and 180s queued", pr.SlowChecks[0])
 	}
-	if pr.SlowChecks[1].Name != "Verify (ubuntu-latest)" || pr.SlowChecks[1].DurationSeconds != 180 {
-		t.Fatalf("SlowChecks[1] = %#v, want Verify 180s", pr.SlowChecks[1])
+	if pr.SlowChecks[1].Name != "Verify (ubuntu-latest)" || pr.SlowChecks[1].DurationSeconds != 180 || pr.SlowChecks[1].QueueSeconds != 60 {
+		t.Fatalf("SlowChecks[1] = %#v, want Verify 180s active and 60s queued", pr.SlowChecks[1])
 	}
 	if len(pr.RunningChecks) != 1 || pr.RunningChecks[0] != "Windows Core" {
 		t.Fatalf("RunningChecks = %#v, want Windows Core", pr.RunningChecks)
@@ -1316,27 +1319,32 @@ func TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest(t *testing.T) {
 	}
 }
 
-func TestCheckRunTelemetryReportsCompletedSpan(t *testing.T) {
+func TestCheckRunTelemetryReportsQueueAndCompletedSpan(t *testing.T) {
 	t.Parallel()
 
+	created := time.Date(2026, 6, 5, 10, 58, 0, 0, time.UTC)
 	start := time.Date(2026, 6, 5, 11, 0, 0, 0, time.UTC)
 	verifyDone := start.Add(3 * time.Minute)
+	snapshotCreated := start.Add(time.Minute)
 	snapshotStart := verifyDone.Add(30 * time.Second)
 	snapshotDone := snapshotStart.Add(8 * time.Minute)
 
-	durationSeconds, slowChecks, runningChecks := checkRunTelemetry([]restCheckRun{
-		{Name: "Verify (ubuntu-latest)", Status: "completed", Conclusion: "success", StartedAt: &start, CompletedAt: &verifyDone},
-		{Name: "GoReleaser Snapshot", Status: "completed", Conclusion: "success", StartedAt: &snapshotStart, CompletedAt: &snapshotDone},
+	summary := checkRunTelemetry([]restCheckRun{
+		{Name: "Verify (ubuntu-latest)", Status: "completed", Conclusion: "success", CreatedAt: &created, StartedAt: &start, CompletedAt: &verifyDone},
+		{Name: "GoReleaser Snapshot", Status: "completed", Conclusion: "success", CreatedAt: &snapshotCreated, StartedAt: &snapshotStart, CompletedAt: &snapshotDone},
 	})
 
-	if durationSeconds != 690 {
-		t.Fatalf("durationSeconds = %d, want 690", durationSeconds)
+	if summary.QueueSeconds != 120 {
+		t.Fatalf("QueueSeconds = %d, want 120", summary.QueueSeconds)
 	}
-	if len(slowChecks) != 2 || slowChecks[0].Name != "GoReleaser Snapshot" {
-		t.Fatalf("slowChecks = %#v, want snapshot first", slowChecks)
+	if summary.DurationSeconds != 690 {
+		t.Fatalf("DurationSeconds = %d, want 690", summary.DurationSeconds)
 	}
-	if len(runningChecks) != 0 {
-		t.Fatalf("runningChecks = %#v, want none", runningChecks)
+	if len(summary.SlowChecks) != 2 || summary.SlowChecks[0].Name != "GoReleaser Snapshot" || summary.SlowChecks[0].QueueSeconds != 150 {
+		t.Fatalf("SlowChecks = %#v, want snapshot first with queued runtime", summary.SlowChecks)
+	}
+	if len(summary.RunningChecks) != 0 {
+		t.Fatalf("RunningChecks = %#v, want none", summary.RunningChecks)
 	}
 }
 

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1332,7 +1332,7 @@ func TestCheckRunTelemetryReportsQueueAndCompletedSpan(t *testing.T) {
 	summary := checkRunTelemetry([]restCheckRun{
 		{Name: "Verify (ubuntu-latest)", Status: "completed", Conclusion: "success", CreatedAt: &created, StartedAt: &start, CompletedAt: &verifyDone},
 		{Name: "GoReleaser Snapshot", Status: "completed", Conclusion: "success", CreatedAt: &snapshotCreated, StartedAt: &snapshotStart, CompletedAt: &snapshotDone},
-	})
+	}, nil)
 
 	if summary.QueueSeconds != 120 {
 		t.Fatalf("QueueSeconds = %d, want 120", summary.QueueSeconds)
@@ -1345,6 +1345,44 @@ func TestCheckRunTelemetryReportsQueueAndCompletedSpan(t *testing.T) {
 	}
 	if len(summary.RunningChecks) != 0 {
 		t.Fatalf("RunningChecks = %#v, want none", summary.RunningChecks)
+	}
+}
+
+func TestCheckRunTelemetryUsesWorkflowRunTimingForQueue(t *testing.T) {
+	t.Parallel()
+
+	runCreated := time.Date(2026, 6, 5, 10, 58, 0, 0, time.UTC)
+	runStarted := runCreated.Add(90 * time.Second)
+	checkStarted := time.Date(2026, 6, 5, 11, 0, 0, 0, time.UTC)
+	checkCompleted := checkStarted.Add(3 * time.Minute)
+
+	summary := checkRunTelemetry([]restCheckRun{
+		{Name: "Verify (ubuntu-latest)", Status: "completed", Conclusion: "success", StartedAt: &checkStarted, CompletedAt: &checkCompleted},
+	}, []restWorkflowRun{
+		{ID: 28196652213, CreatedAt: &runCreated, RunStartedAt: &runStarted},
+	})
+
+	if summary.QueueSeconds != 90 {
+		t.Fatalf("QueueSeconds = %d, want 90", summary.QueueSeconds)
+	}
+	if summary.DurationSeconds != 180 {
+		t.Fatalf("DurationSeconds = %d, want 180", summary.DurationSeconds)
+	}
+}
+
+func TestCheckRunWorkflowRunIDs(t *testing.T) {
+	t.Parallel()
+
+	got := checkRunWorkflowRunIDs([]restCheckRun{
+		{DetailsURL: "https://github.com/digitaldrywood/detent/actions/runs/28196652213/job/83525095026"},
+		{DetailsURL: "https://github.com/digitaldrywood/detent/actions/runs/28196652213/job/83525095027"},
+		{DetailsURL: "https://github.com/digitaldrywood/detent/actions/runs/28196652214"},
+		{DetailsURL: "https://example.com/not-actions"},
+	})
+
+	want := []int64{28196652213, 28196652214}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("checkRunWorkflowRunIDs() = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -228,6 +228,7 @@ func clonePullRequestCI(ci pullRequestCI) pullRequestCI {
 		State:              ci.State,
 		CheckRunCount:      ci.CheckRunCount,
 		StatusContextCount: ci.StatusContextCount,
+		CIQueueSeconds:     ci.CIQueueSeconds,
 		CIDurationSeconds:  ci.CIDurationSeconds,
 		SlowChecks:         append([]connector.PullRequestCheck(nil), ci.SlowChecks...),
 		RunningChecks:      append([]string(nil), ci.RunningChecks...),

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -57,6 +57,7 @@ type PullRequest struct {
 	CIStatus                     string               `json:"ci_status,omitempty" yaml:"ci_status,omitempty"`
 	CheckRunCount                int                  `json:"check_run_count,omitempty" yaml:"check_run_count,omitempty"`
 	StatusContextCount           int                  `json:"status_context_count,omitempty" yaml:"status_context_count,omitempty"`
+	CIQueueSeconds               int64                `json:"ci_queue_seconds,omitempty" yaml:"ci_queue_seconds,omitempty"`
 	CIDurationSeconds            int64                `json:"ci_duration_seconds,omitempty" yaml:"ci_duration_seconds,omitempty"`
 	SlowChecks                   []PullRequestCheck   `json:"slow_checks,omitempty" yaml:"slow_checks,omitempty"`
 	RunningChecks                []string             `json:"running_checks,omitempty" yaml:"running_checks,omitempty"`
@@ -80,6 +81,7 @@ type PullRequestCheck struct {
 	Name            string `json:"name,omitempty" yaml:"name,omitempty"`
 	Status          string `json:"status,omitempty" yaml:"status,omitempty"`
 	Conclusion      string `json:"conclusion,omitempty" yaml:"conclusion,omitempty"`
+	QueueSeconds    int64  `json:"queue_seconds,omitempty" yaml:"queue_seconds,omitempty"`
 	DurationSeconds int64  `json:"duration_seconds,omitempty" yaml:"duration_seconds,omitempty"`
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -306,6 +306,7 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		CIStatus:                   pullRequest.CIStatus,
 		CheckRunCount:              pullRequest.CheckRunCount,
 		StatusContextCount:         pullRequest.StatusContextCount,
+		CIQueueSeconds:             pullRequest.CIQueueSeconds,
 		CIDurationSeconds:          pullRequest.CIDurationSeconds,
 		QuietWaitSeconds:           pullRequestQuietWaitSeconds(issue, quietDuration, pollInterval),
 		SlowChecks:                 telemetryPullRequestChecks(pullRequest.SlowChecks),
@@ -329,6 +330,7 @@ func telemetryPullRequestChecks(checks []connector.PullRequestCheck) []telemetry
 			Name:            check.Name,
 			Status:          check.Status,
 			Conclusion:      check.Conclusion,
+			QueueSeconds:    check.QueueSeconds,
 			DurationSeconds: check.DurationSeconds,
 		})
 	}

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -235,11 +235,12 @@ func TestStateSnapshotPopulated(t *testing.T) {
 				URL:                     "https://github.com/digitaldrywood/detent/pull/142",
 				State:                   "OPEN",
 				CIStatus:                "pending",
+				CIQueueSeconds:          120,
 				CIDurationSeconds:       900,
 				HydrationDegradedReason: connector.PullRequestHydrationReasonStaleCachedPullData,
 				HydrationNextRetryAt:    &prHydrationRetryAt,
 				SlowChecks: []connector.PullRequestCheck{
-					{Name: "GoReleaser Snapshot", DurationSeconds: 247},
+					{Name: "GoReleaser Snapshot", DurationSeconds: 247, QueueSeconds: 60},
 				},
 				RunningChecks:    []string{"Test Coverage"},
 				CodexReviewState: "P2",
@@ -327,6 +328,9 @@ func TestStateSnapshotPopulated(t *testing.T) {
 	}
 	if pipeline.PullRequest.CIDurationSeconds != 900 {
 		t.Fatalf("Pipeline[0].PullRequest.CIDurationSeconds = %d, want 900", pipeline.PullRequest.CIDurationSeconds)
+	}
+	if pipeline.PullRequest.CIQueueSeconds != 120 {
+		t.Fatalf("Pipeline[0].PullRequest.CIQueueSeconds = %d, want 120", pipeline.PullRequest.CIQueueSeconds)
 	}
 	if pipeline.PullRequest.HydrationDegradedReason != connector.PullRequestHydrationReasonStaleCachedPullData {
 		t.Fatalf("Pipeline[0].PullRequest.HydrationDegradedReason = %q, want stale cached data", pipeline.PullRequest.HydrationDegradedReason)
@@ -454,9 +458,10 @@ func TestStateSnapshotIncludesPullRequestMergeWaitTelemetry(t *testing.T) {
 				Number:                 461,
 				ActivityAt:             &prActivityAt,
 				CodexReviewSubmittedAt: &reviewSubmittedAt,
+				CIQueueSeconds:         120,
 				CIDurationSeconds:      480,
 				SlowChecks: []connector.PullRequestCheck{
-					{Name: "GoReleaser Snapshot", DurationSeconds: 247},
+					{Name: "GoReleaser Snapshot", DurationSeconds: 247, QueueSeconds: 60},
 				},
 				RunningChecks: []string{"Test Coverage"},
 			},
@@ -473,6 +478,9 @@ func TestStateSnapshotIncludesPullRequestMergeWaitTelemetry(t *testing.T) {
 	}
 	if pr.CIDurationSeconds != 480 {
 		t.Fatalf("CIDurationSeconds = %d, want 480", pr.CIDurationSeconds)
+	}
+	if pr.CIQueueSeconds != 120 {
+		t.Fatalf("CIQueueSeconds = %d, want 120", pr.CIQueueSeconds)
 	}
 	if len(pr.SlowChecks) != 1 || pr.SlowChecks[0].Name != "GoReleaser Snapshot" {
 		t.Fatalf("SlowChecks = %#v", pr.SlowChecks)

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -217,6 +217,7 @@ type PullRequest struct {
 	CIStatus                   string             `json:"ci_status,omitempty"`
 	CheckRunCount              int                `json:"check_run_count,omitempty"`
 	StatusContextCount         int                `json:"status_context_count,omitempty"`
+	CIQueueSeconds             int64              `json:"ci_queue_seconds,omitempty"`
 	CIDurationSeconds          int64              `json:"ci_duration_seconds,omitempty"`
 	QuietWaitSeconds           int64              `json:"quiet_wait_seconds,omitempty"`
 	SlowChecks                 []PullRequestCheck `json:"slow_checks,omitempty"`
@@ -228,6 +229,7 @@ type PullRequestCheck struct {
 	Name            string `json:"name,omitempty"`
 	Status          string `json:"status,omitempty"`
 	Conclusion      string `json:"conclusion,omitempty"`
+	QueueSeconds    int64  `json:"queue_seconds,omitempty"`
 	DurationSeconds int64  `json:"duration_seconds,omitempty"`
 }
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2871,6 +2871,9 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 	if issue.PullRequest.QuietWaitSeconds > 0 {
 		parts = append(parts, "quiet "+formatDuration(float64(issue.PullRequest.QuietWaitSeconds)))
 	}
+	if issue.PullRequest.CIQueueSeconds > 0 {
+		parts = append(parts, "queued "+formatDuration(float64(issue.PullRequest.CIQueueSeconds)))
+	}
 	if issue.PullRequest.CIDurationSeconds > 0 {
 		parts = append(parts, "CI "+formatDuration(float64(issue.PullRequest.CIDurationSeconds)))
 	}
@@ -2916,6 +2919,9 @@ func prPipelineSlowChecks(checks []telemetry.PullRequestCheck) string {
 		}
 		if check.DurationSeconds > 0 {
 			name += " " + formatDuration(float64(check.DurationSeconds))
+		}
+		if check.QueueSeconds > 0 {
+			name += " (queued " + formatDuration(float64(check.QueueSeconds)) + ")"
 		}
 		labels = append(labels, name)
 	}

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1624,10 +1624,11 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 						PullRequest: &telemetry.PullRequest{
 							Number:            143,
 							CIStatus:          "pending",
+							CIQueueSeconds:    120,
 							CIDurationSeconds: 510,
 							QuietWaitSeconds:  600,
 							SlowChecks: []telemetry.PullRequestCheck{
-								{Name: "GoReleaser Snapshot", DurationSeconds: 247},
+								{Name: "GoReleaser Snapshot", DurationSeconds: 247, QueueSeconds: 60},
 							},
 							RunningChecks:    []string{"Test Coverage"},
 							CodexReviewState: "P2",
@@ -1679,7 +1680,7 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 			},
 			want: []pipelineCardSnapshot{
 				{Lane: "Human Review", IssueNumber: "#142", Title: "Review lane PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2h 0m", WaitDetail: "PR hydration using stale cached data until 15:05 UTC"},
-				{Lane: "Merging", IssueNumber: "#143", Title: "Merge lane PR", CIStatus: "pending", CodexReviewState: "P2", TimeInStage: "15m 0s", WaitDetail: "quiet 10m 0s / CI 8m 30s / slow GoReleaser Snapshot 4m 7s / running Test Coverage"},
+				{Lane: "Merging", IssueNumber: "#143", Title: "Merge lane PR", CIStatus: "pending", CodexReviewState: "P2", TimeInStage: "15m 0s", WaitDetail: "quiet 10m 0s / queued 2m 0s / CI 8m 30s / slow GoReleaser Snapshot 4m 7s (queued 1m 0s) / running Test Coverage"},
 				{Lane: "Done today", IssueNumber: "#144", Title: "Done lane PR", CIStatus: "pass", CodexReviewState: "P1", TimeInStage: "45m 0s"},
 				{Lane: "Done today", IssueNumber: "#145", Title: "Done lane unverified PR", CIStatus: "pending", CodexReviewState: "clean", TimeInStage: "45m 0s"},
 				{Lane: "Done today", IssueNumber: "#146", Title: "Cancelled today PR", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "45m 0s"},


### PR DESCRIPTION
## Summary

- Narrow the normal PR-required CI gate to lint, Ubuntu verify, coverage, and Browser Visual with a non-UI smoke path.
- Move portability, installer, and GoReleaser snapshot checks to main/tag/nightly/manual confidence runs.
- Add check-run queue telemetry and required-check wall-time guardrails in docs/tests.

Fixes #712

## Test Plan

- [x] `go test ./... -run 'TestMainProtectionDocumentationMatchesWorkflow|TestRequiredChecksDoNotUseEventDependentGreenNoops|TestKanbanBrowserDragDropRunsInVisualGate|TestInstallerSmokeUsesAuthenticatedReleaseVersion|TestConnectorFetchIssuesByStatesAttachesPipelinePullRequest|TestCheckRunTelemetryReportsQueueAndCompletedSpan|TestCheckRunTelemetryUsesWorkflowRunTimingForQueue|TestCheckRunWorkflowRunIDs|TestStateSnapshot|TestProjectPipeline|TestProjectKanban|Test.*Pipeline'`
- [x] `go test ./... -run 'TestMainProtectionDocumentationMatchesWorkflow|TestRequiredChecksDoNotUseEventDependentGreenNoops|TestKanbanBrowserDragDropRunsInVisualGate|TestInstallerSmokeUsesAuthenticatedReleaseVersion'`
- [x] `make check`
- [x] Rebased on `origin/main` at `fac379a`; `make check` passed again.
- [x] REST check-runs polling for `236b49e574d016902abac0b2f8f72e837e164f8e` passed; active required jobs completed in about 2m29s.