### PR TITLE
Fix stale merging hydration dispatch loop

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -20,6 +20,7 @@ type AutoPromoteSummary struct {
 	PullRequestPresent                    bool
 	PullRequestURL                        string
 	PullRequestHydrationUnavailableReason string
+	PullRequestHydrationDegradedReason    string
 	MergeableState                        string
 	CIStatus                              string
 	ReviewState                           string
@@ -94,7 +95,8 @@ func EvaluateAutoPromote(
 	if autoPromoteMergeConflicts(summary.MergeableState) {
 		return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonMergeConflicts)
 	}
-	if strings.TrimSpace(summary.PullRequestHydrationUnavailableReason) != "" {
+	if strings.TrimSpace(summary.PullRequestHydrationUnavailableReason) != "" ||
+		strings.TrimSpace(summary.PullRequestHydrationDegradedReason) != "" {
 		return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable)
 	}
 	gateDecision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(summary), now, gate.EvaluationOptions{

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -855,6 +855,7 @@ func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 
 	pullRequest := issue.PullRequest
 	summary.PullRequestHydrationUnavailableReason = pullRequestHydrationUnavailableReason(pullRequest)
+	summary.PullRequestHydrationDegradedReason = pullRequestHydrationDegradedReason(pullRequest)
 	if normalizePullRequestState(pullRequest.State) != "open" {
 		return summary
 	}

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -172,13 +172,17 @@ func staleMergingPullRequestDecisionForIssue(issue connector.Issue, terminalStat
 	if pullRequest == nil {
 		return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: string(AutoPromoteReasonMissingPullRequest)}
 	}
-	if pullRequestHydrationUnavailableReason(pullRequest) != "" {
+	pullRequestState := normalizePullRequestState(pullRequest.State)
+	if pullRequestState == "" && pullRequestHydrationBlocksProgress(pullRequest) {
 		return staleMergingPullRequestDecision{reason: string(AutoPromoteReasonPullRequestHydrationUnavailable)}
 	}
-	switch normalizePullRequestState(pullRequest.State) {
+	switch pullRequestState {
 	case "merged":
 		return staleMergingPullRequestDecision{targetState: doneStateName(terminalStates), reason: "pull_request_merged"}
 	case "open":
+		if pullRequestHydrationBlocksProgress(pullRequest) {
+			return staleMergingPullRequestDecision{reason: string(AutoPromoteReasonPullRequestHydrationUnavailable)}
+		}
 		if pullRequest.Draft {
 			return staleMergingPullRequestDecision{targetState: autoPromoteSourceState, reason: "draft_pull_request"}
 		}
@@ -510,7 +514,7 @@ func staleMergingIssueReadyForDispatch(issue connector.Issue) bool {
 		return false
 	}
 	pullRequest := issue.PullRequest
-	if pullRequestHydrationUnavailableReason(pullRequest) != "" {
+	if pullRequestHydrationBlocksProgress(pullRequest) {
 		return false
 	}
 	if normalizePullRequestState(pullRequest.State) != "open" {
@@ -868,6 +872,18 @@ func pullRequestHydrationUnavailableReason(pullRequest *connector.PullRequest) s
 		return ""
 	}
 	return strings.TrimSpace(pullRequest.HydrationUnavailableReason)
+}
+
+func pullRequestHydrationDegradedReason(pullRequest *connector.PullRequest) string {
+	if pullRequest == nil {
+		return ""
+	}
+	return strings.TrimSpace(pullRequest.HydrationDegradedReason)
+}
+
+func pullRequestHydrationBlocksProgress(pullRequest *connector.PullRequest) bool {
+	return pullRequestHydrationUnavailableReason(pullRequest) != "" ||
+		pullRequestHydrationDegradedReason(pullRequest) != ""
 }
 
 func autoPromoteLastActivityAt(issue connector.Issue) *time.Time {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -77,6 +77,30 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			},
 		},
 		{
+			name: "degraded pull request hydration waits",
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+			},
+			issue: autoPromoteTickIssue("issue-degraded-pr", []string{"bug"}, &connector.PullRequest{
+				Number:                  391,
+				URL:                     "https://github.test/digitaldrywood/detent/pull/391",
+				State:                   "OPEN",
+				MergeableState:          "clean",
+				CIStatus:                "success",
+				CodexReviewState:        "COMMENTED",
+				CodexReviewSubmittedAt:  &oldReview,
+				HydrationDegradedReason: connector.PullRequestHydrationReasonStaleCachedPullData,
+			}),
+			wantLogFragments: []string{
+				"reason=pull_request_hydration_unavailable",
+				"pull_request_hydration_degraded_reason=stale_cached_pull_request",
+			},
+			rejectLogFragments: []string{
+				"target_state=Merging",
+			},
+		},
+		{
 			name: "routes P1 findings to rework",
 			cfg: AutoPromoteConfig{
 				Enabled:       true,

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -781,6 +781,87 @@ func TestTickRequeuesObservedStaleMergingIssueForDispatch(t *testing.T) {
 	}
 }
 
+func TestTickDefersStaleMergingCandidateWhenObservedHydrationUnavailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 16, 4, 0, 0, time.UTC)
+	retryAt := now.Add(3 * time.Minute)
+	candidate := autoPromoteTickIssue("issue-stale-merging-rate-limited", []string{"bug"}, &connector.PullRequest{
+		Number:         80,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/80",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		HeadSHA:        "b8e85ef7554b4f9cf385adba88ed151e2f69a4f0",
+	})
+	candidate.State = "Merging"
+	candidate.Identifier = "digitaldrywood/creswoodcorners-phone#79"
+	observed := cloneIssue(candidate)
+	observed.PullRequest.HydrationUnavailableReason = connector.PullRequestHydrationReasonSecondaryThrottled
+	observed.PullRequest.HydrationNextRetryAt = &retryAt
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	tracker := &autoPromoteTickConnector{
+		stateIssues:        []connector.Issue{observed},
+		candidateIssues:    []connector.Issue{candidate},
+		candidateIssuesSet: true,
+	}
+	runner := newWorkerHostRunner()
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:        cfg,
+		connector:  tracker,
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+		logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none", tracker.updates)
+	}
+	if _, ok := state.Running[candidate.ID]; ok {
+		t.Fatalf("Running[%q] present, want no merge worker dispatch", candidate.ID)
+	}
+	if _, ok := state.Claimed[candidate.ID]; ok {
+		t.Fatalf("Claimed[%q] present, want no merge worker claim", candidate.ID)
+	}
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected merge worker dispatch = %#v", request)
+	default:
+	}
+	for _, fragment := range []string{
+		"stale_merging_pr_reconciliation_deferred",
+		"reason=pull_request_hydration_unavailable",
+		"pull_request_hydration_reason=secondary_throttled",
+		"pull_request_hydration_next_retry_at=2026-06-25T16:07:00Z",
+		"pull_request_number=80",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+	for _, fragment := range []string{"merge_worker_pickup", "merge_worker_attempt"} {
+		if strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q contain %q, want no merge worker pickup or attempt", logs.String(), fragment)
+		}
+	}
+}
+
 func TestTickFailsAndRetriesStaleMergingWithoutStartupTelemetry(t *testing.T) {
 	t.Parallel()
 
@@ -1210,6 +1291,15 @@ func TestStaleMergingDispatchCandidatesFiltersUnsafePullRequests(t *testing.T) {
 				MergeableState:             "clean",
 				CIStatus:                   "success",
 				HydrationUnavailableReason: "rate_limited",
+			},
+		},
+		{
+			name: "hydration degraded",
+			pullRequest: &connector.PullRequest{
+				State:                   "OPEN",
+				MergeableState:          "clean",
+				CIStatus:                "success",
+				HydrationDegradedReason: connector.PullRequestHydrationReasonStaleCachedPullData,
 			},
 		},
 	}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -346,7 +346,7 @@ func (p dispatchPlanner) dispatchableIssue(
 
 func pullRequestHydrationBlocksDispatch(issue connector.Issue) bool {
 	pullRequest := issue.PullRequest
-	if pullRequestHydrationUnavailableReason(pullRequest) == "" {
+	if !pullRequestHydrationBlocksProgress(pullRequest) {
 		return false
 	}
 	if normalizeState(issue.State) != "todo" {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -527,6 +527,15 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 			want:  true,
 		},
 		{
+			name: "merging with degraded pull request hydration skips",
+			issue: func() connector.Issue {
+				issue := dispatchTestIssueWithPullRequest("issue-merging-pr-degraded", "Merging", "OPEN")
+				issue.PullRequest.HydrationDegradedReason = connector.PullRequestHydrationReasonStaleCachedPullData
+				return issue
+			}(),
+			want: false,
+		},
+		{
 			name:  "todo with merged pull request skips",
 			issue: dispatchTestIssueWithPullRequest("issue-todo-merged-pr", "Todo", "MERGED"),
 			want:  false,

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -89,6 +89,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		return
 	}
 	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
+	fetched = applyStatusPullRequestHydrationBlocksToCandidates(fetched)
 
 	transitions := o.refreshTransitionSets(ctx, state, fetched, previous)
 	completedEpics := o.resolveCompletedEpics(ctx, state, transitions, previous)
@@ -477,6 +478,73 @@ func retainUnavailablePullRequestsFromPrevious(fetched tickFetchedIssues, previo
 	fetched.candidates = retainUnavailablePullRequests(fetched.candidates, previousIssues)
 	fetched.status = retainUnavailablePullRequests(fetched.status, previousIssues)
 	return fetched
+}
+
+func applyStatusPullRequestHydrationBlocksToCandidates(fetched tickFetchedIssues) tickFetchedIssues {
+	if len(fetched.candidates) == 0 || len(fetched.status) == 0 {
+		return fetched
+	}
+	statusByKey := make(map[string]connector.PullRequest, len(fetched.status))
+	for _, issue := range fetched.status {
+		key := issueIdentityKey(issue)
+		if key == "" || !pullRequestHydrationBlocksProgress(issue.PullRequest) {
+			continue
+		}
+		statusByKey[key] = *cloneIssue(issue).PullRequest
+	}
+	if len(statusByKey) == 0 {
+		return fetched
+	}
+	candidates := cloneIssues(fetched.candidates)
+	for index, issue := range candidates {
+		statusPullRequest, ok := statusByKey[issueIdentityKey(issue)]
+		if !ok {
+			continue
+		}
+		if candidates[index].PullRequest == nil {
+			candidates[index].PullRequest = &connector.PullRequest{}
+		}
+		applyPullRequestHydrationBlock(candidates[index].PullRequest, statusPullRequest)
+		if candidates[index].PRNumber == nil && statusPullRequest.Number > 0 {
+			prNumber := statusPullRequest.Number
+			candidates[index].PRNumber = &prNumber
+		}
+	}
+	fetched.candidates = candidates
+	return fetched
+}
+
+func applyPullRequestHydrationBlock(target *connector.PullRequest, source connector.PullRequest) {
+	if target == nil {
+		return
+	}
+	if reason := strings.TrimSpace(source.HydrationUnavailableReason); reason != "" {
+		target.HydrationUnavailableReason = reason
+	}
+	if reason := strings.TrimSpace(source.HydrationDegradedReason); reason != "" {
+		target.HydrationDegradedReason = reason
+	}
+	if source.HydrationNextRetryAt != nil {
+		target.HydrationNextRetryAt = cloneTime(source.HydrationNextRetryAt)
+	}
+	if target.Number == 0 && source.Number > 0 {
+		target.Number = source.Number
+	}
+	if strings.TrimSpace(target.URL) == "" {
+		target.URL = strings.TrimSpace(source.URL)
+	}
+	if strings.TrimSpace(target.BranchName) == "" {
+		target.BranchName = strings.TrimSpace(source.BranchName)
+	}
+	if normalizePullRequestState(target.State) == "" {
+		target.State = source.State
+	}
+	if strings.TrimSpace(target.MergeableState) == "" {
+		target.MergeableState = source.MergeableState
+	}
+	if strings.TrimSpace(target.CIStatus) == "" {
+		target.CIStatus = source.CIStatus
+	}
 }
 
 func retainUnavailablePullRequests(current []connector.Issue, previous []connector.Issue) []connector.Issue {


### PR DESCRIPTION
## Summary

- Copy observed PR hydration wait markers onto active candidates before dispatch planning.
- Treat unavailable and degraded cached PR hydration as stale-merging wait conditions instead of dispatching from stale cached status.
- Defer Human Review auto-promotion when PR hydration is degraded, so stale cached PR data cannot move work into Merging prematurely.
- Keep merged stale Merging PRs eligible for Done reconciliation even when nonessential hydration is unavailable.

Fixes #714

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestTickAutoPromoteHumanReviewIssues|TestEvaluateAutoPromote|TestTickDefersStaleMergingCandidateWhenObservedHydrationUnavailable|TestStaleMergingDispatchCandidatesFiltersUnsafePullRequests|TestDispatchableSkipsDuplicatePullRequestWork' -count=1`
- [x] `make check`