### PR TITLE
fix(orchestrator): throttle stale merge recovery

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -54,6 +54,10 @@ type IssuesByStatesLimiter interface {
 	FetchIssuesByStatesLimit(context.Context, []string, int) ([]Issue, error)
 }
 
+type CandidateIssuesByStatesFetcher interface {
+	FetchCandidateIssuesByStates(context.Context, []string) ([]Issue, error)
+}
+
 type IssueStateProber interface {
 	FetchIssueStateProbe(context.Context, []string, int) ([]Issue, error)
 }

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -882,8 +882,16 @@ type projectField struct {
 }
 
 func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	return c.FetchCandidateIssuesByStates(ctx, c.activeStates)
+}
+
+func (c *Connector) FetchCandidateIssuesByStates(ctx context.Context, stateNames []string) ([]connector.Issue, error) {
+	stateNames = normalizeStateList(stateNames, nil)
+	if len(stateNames) == 0 {
+		return []connector.Issue{}, nil
+	}
 	if c.usesLabelStatus() {
-		issues, err := c.fetchLabelIssuesByStates(ctx, c.activeStates, 0)
+		issues, err := c.fetchLabelIssuesByStates(ctx, stateNames, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -893,7 +901,7 @@ func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue
 		return issues, nil
 	}
 	if c.usesIssueFieldStatus() {
-		issues, err := c.fetchIssueFieldIssuesByStates(ctx, c.activeStates, 0)
+		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -906,8 +914,8 @@ func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue
 		return nil, ErrMissingProject
 	}
 
-	issues, err := c.fetchProjectItems(ctx, graphQLQueryCandidateIssues, c.projectStatusQuery(c.activeStates), func(issue connector.Issue) bool {
-		return stateInList(issue.State, c.activeStates)
+	issues, err := c.fetchProjectItems(ctx, graphQLQueryCandidateIssues, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
+		return stateInList(issue.State, stateNames)
 	})
 	if err != nil {
 		return nil, err

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -91,6 +91,10 @@ func (c *Connector) FetchCandidateIssues(context.Context) ([]connector.Issue, er
 	return cloneIssues(c.issues), nil
 }
 
+func (c *Connector) FetchCandidateIssuesByStates(ctx context.Context, stateNames []string) ([]connector.Issue, error) {
+	return c.FetchIssuesByStates(ctx, stateNames)
+}
+
 func (c *Connector) FetchIssuesByStates(_ context.Context, stateNames []string) ([]connector.Issue, error) {
 	c.mu.RLock()
 	defer c.mu.RUnlock()

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -17,6 +17,7 @@ const (
 	autoPromoteMergingState          = "Merging"
 	autoPromoteReworkState           = "Rework"
 	defaultMergeWorkerStartupTimeout = 2 * time.Minute
+	mergeWorkerProjectStateFull      = "project_state_capacity_full"
 )
 
 type autoPromoteTickResult struct {
@@ -483,6 +484,7 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 		return nil
 	}
 	out := make([]connector.Issue, 0, len(candidates))
+	selectedByState := map[string]int{}
 	for _, issue := range candidates {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
@@ -491,6 +493,25 @@ func (o *Orchestrator) mergeWorkerDispatchCandidates(state *State, issues []conn
 		if staleMergingPullRequestDispatchActive(state, issueID) {
 			continue
 		}
+		stateKey := normalizeState(issue.State)
+		projectStats := o.projectStateSlotStats(issue, state)
+		selected := selectedByState[stateKey]
+		if selected > 0 {
+			projectStats.used += selected
+			projectStats.available -= selected
+			if projectStats.available < 0 {
+				projectStats.available = 0
+			}
+		}
+		if projectStats.available <= 0 {
+			o.logMergeWorkerSlotWait(
+				issue,
+				scheduler.DispatchGateDecision{Reason: mergeWorkerProjectStateFull},
+				projectStats,
+			)
+			break
+		}
+		selectedByState[stateKey] = selected + 1
 		o.clearAutoPromotedIssueDispatchMemory(state, issueID)
 		o.logMergeWorkerPickup(issue, "stale_merging")
 		out = append(out, issue)

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1526,6 +1526,85 @@ func TestFetchTickIssuesSkipsMergingStatusHydrationWhenMergingLaneFull(t *testin
 	}
 }
 
+func TestTickPreservesDueMergingRetryWhenLaneFullAndMergingFetchOmitted(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 21, 7, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		FailureRetryBaseDelay: time.Minute,
+		MaxRetryBackoff:       time.Hour,
+		ActiveStates:          []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:        []string{"Done", "Cancelled"},
+	})
+	running := autoPromoteTickIssue("issue-running-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         72,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/72",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	running.State = "Merging"
+	retrying := autoPromoteTickIssue("issue-retrying-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         75,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/75",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	retrying.State = "Merging"
+	tracker := &autoPromoteTickConnector{
+		stateIssues:        []connector.Issue{running, retrying},
+		candidateIssues:    []connector.Issue{},
+		candidateIssuesSet: true,
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[running.ID] = Running{
+		Issue:     cloneIssue(running),
+		StartedAt: now.Add(-time.Minute),
+	}
+	state.Claimed[retrying.ID] = Claimed{
+		Issue:     cloneIssue(retrying),
+		ClaimedAt: now.Add(-time.Minute),
+	}
+	state.Retry[retrying.ID] = Retry{
+		Issue:   cloneIssue(retrying),
+		Attempt: 2,
+		DueAt:   now.Add(-time.Second),
+		Error:   "run agent turn: stream turn: EOF",
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.candidateByStates) != 1 {
+		t.Fatalf("FetchCandidateIssuesByStates requests = %#v, want one candidate fetch", tracker.candidateByStates)
+	}
+	for _, stateName := range tracker.candidateByStates[0] {
+		if normalizeState(stateName) == normalizeState(autoPromoteMergingState) {
+			t.Fatalf("FetchCandidateIssuesByStates states = %#v, want Merging omitted while lane is full", tracker.candidateByStates[0])
+		}
+	}
+	if retry, ok := state.Retry[retrying.ID]; !ok {
+		t.Fatalf("Retry[%q] missing while Merging lane is full", retrying.ID)
+	} else if retry.Attempt != 2 || retry.Error != "run agent turn: stream turn: EOF" {
+		t.Fatalf("Retry[%q] = %#v, want original retry preserved", retrying.ID, retry)
+	}
+	if _, ok := state.Claimed[retrying.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing while Merging lane is full", retrying.ID)
+	}
+	if _, ok := state.Running[retrying.ID]; ok {
+		t.Fatalf("Running[%q] present while Merging lane is full", retrying.ID)
+	}
+}
+
 func TestHandleRunResultReworksMergeWorkerAfterRepeatedRunnerFailures(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -279,8 +279,8 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			if len(tracker.fetchByStatesRequests) != 1 {
 				t.Fatalf("FetchIssuesByStates() calls = %d, want 1", len(tracker.fetchByStatesRequests))
 			}
-			if !autoPromoteTickStatesEqual(tracker.fetchByStatesRequests[0], []string{"Blocked", "Human Review", "Merging"}) {
-				t.Fatalf("FetchIssuesByStates() states = %#v, want Blocked/Human Review/Merging", tracker.fetchByStatesRequests[0])
+			if !autoPromoteTickStatesEqual(tracker.fetchByStatesRequests[0], []string{"Blocked", "Human Review"}) {
+				t.Fatalf("FetchIssuesByStates() states = %#v, want Blocked/Human Review", tracker.fetchByStatesRequests[0])
 			}
 			if len(tt.wantCommentFragments) == 0 {
 				if len(tracker.comments) != 0 {
@@ -1395,6 +1395,195 @@ func TestMergeWorkerDispatchCandidatesPreservesScheduledRetry(t *testing.T) {
 	}
 }
 
+func TestMergeWorkerDispatchCandidatesWaitsWhenMergingLaneFull(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 21, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	running := autoPromoteTickIssue("issue-running-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         72,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/72",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	running.State = "Merging"
+	waiting := autoPromoteTickIssue("issue-waiting-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         75,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/75",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	waiting.State = "Merging"
+	state := newState(cfg)
+	state.Running[running.ID] = Running{
+		Issue:     cloneIssue(running),
+		StartedAt: now.Add(-time.Minute),
+	}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+
+	got := orch.mergeWorkerDispatchCandidates(&state, []connector.Issue{waiting})
+	if len(got) != 0 {
+		t.Fatalf("mergeWorkerDispatchCandidates() = %#v, want none while Merging lane is full", got)
+	}
+	logText := logs.String()
+	for _, fragment := range []string{
+		"merge_worker_slot_wait",
+		"reason=project_state_capacity_full",
+		"project_state_capacity=1",
+		"project_state_used=1",
+		"project_state_available=0",
+		"pull_request_number=75",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs %q missing fragment %q", logText, fragment)
+		}
+	}
+	if strings.Contains(logText, "merge_worker_pickup") {
+		t.Fatalf("logs %q contain merge_worker_pickup, want wait telemetry without pickup", logText)
+	}
+}
+
+func TestFetchTickIssuesSkipsMergingStatusHydrationWhenMergingLaneFull(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 21, 5, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	running := autoPromoteTickIssue("issue-running-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         72,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/72",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	running.State = "Merging"
+	stale := autoPromoteTickIssue("issue-stale-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         75,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/75",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	stale.State = "Merging"
+	tracker := &autoPromoteTickConnector{
+		stateIssues:           []connector.Issue{running, stale},
+		candidateIssues:       []connector.Issue{},
+		candidateIssuesSet:    true,
+		fetchByStatesRequests: nil,
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[running.ID] = Running{
+		Issue:     cloneIssue(running),
+		StartedAt: now.Add(-time.Minute),
+	}
+
+	fetched, ok := orch.fetchTickIssues(context.Background(), &state, now, githubBudgetReserveDecision{})
+	if !ok {
+		t.Fatal("fetchTickIssues() ok = false, want true")
+	}
+	if !fetched.statusOK {
+		t.Fatal("fetchTickIssues().statusOK = false, want true")
+	}
+	if len(tracker.candidateByStates) != 1 {
+		t.Fatalf("FetchCandidateIssuesByStates requests = %#v, want one candidate fetch", tracker.candidateByStates)
+	}
+	for _, stateName := range tracker.candidateByStates[0] {
+		if normalizeState(stateName) == normalizeState(autoPromoteMergingState) {
+			t.Fatalf("FetchCandidateIssuesByStates states = %#v, want Merging omitted while lane is full", tracker.candidateByStates[0])
+		}
+	}
+	if len(tracker.fetchByStatesRequests) != 1 {
+		t.Fatalf("FetchIssuesByStates requests = %#v, want one observed status fetch", tracker.fetchByStatesRequests)
+	}
+	for _, stateName := range tracker.fetchByStatesRequests[0] {
+		if normalizeState(stateName) == normalizeState(autoPromoteMergingState) {
+			t.Fatalf("FetchIssuesByStates states = %#v, want Merging omitted while lane is full", tracker.fetchByStatesRequests[0])
+		}
+	}
+}
+
+func TestHandleRunResultReworksMergeWorkerAfterRepeatedRunnerFailures(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 25, 21, 10, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:   1,
+		FailureRetryBaseDelay: time.Minute,
+		MaxRetryBackoff:       time.Hour,
+		ActiveStates:          []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:        []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-exhausted-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         72,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/72",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.State = "Merging"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:     cloneIssue(issue),
+		Attempt:   3,
+		StartedAt: now.Add(-time.Minute),
+	}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Err:         errors.New("run agent turn: stream turn: EOF"),
+	})
+
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after exhausted merge runner failures", issue.ID)
+	}
+	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: issue.ID, state: autoPromoteReworkState}}) {
+		t.Fatalf("updates = %#v, want Rework transition", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one exhausted retry comment", tracker.comments)
+	}
+	for _, fragment := range []string{"runner_failed_retry_exhausted", "stream turn: EOF", "pull request"} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	if !strings.Contains(logs.String(), "merge_worker_failure") {
+		t.Fatalf("logs %q missing merge_worker_failure", logs.String())
+	}
+}
+
 func TestTickAutoPromoteMergingIssueDispatchesAndClearsStaleMemory(t *testing.T) {
 	t.Parallel()
 
@@ -1531,6 +1720,7 @@ type autoPromoteTickConnector struct {
 	stateIssues           []connector.Issue
 	candidateIssues       []connector.Issue
 	candidateIssuesSet    bool
+	candidateByStates     [][]string
 	fetchByStatesRequests [][]string
 	updates               []autoPromoteTickUpdate
 	comments              []autoPromoteTickComment
@@ -1541,11 +1731,16 @@ func (c *autoPromoteTickConnector) Name() string {
 	return "auto-promote-tick"
 }
 
-func (c *autoPromoteTickConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+func (c *autoPromoteTickConnector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	return c.FetchCandidateIssuesByStates(ctx, []string{"Todo", "In Progress", "Rework", "Merging"})
+}
+
+func (c *autoPromoteTickConnector) FetchCandidateIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	c.candidateByStates = append(c.candidateByStates, append([]string(nil), states...))
 	if c.candidateIssuesSet {
-		return cloneIssues(c.candidateIssues), nil
+		return issuesInStates(c.candidateIssues, states), nil
 	}
-	return issuesInStates(c.stateIssues, []string{"Todo", "In Progress", "Rework", "Merging"}), nil
+	return issuesInStates(c.stateIssues, states), nil
 }
 
 func (c *autoPromoteTickConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -15,11 +15,12 @@ type dispatchPlanner struct {
 }
 
 type dispatchPlanHooks struct {
-	hydrate             func(connector.Issue) (connector.Issue, bool)
-	beforeDispatch      func(connector.Issue, int) bool
-	dispatch            func(connector.Issue, int, string) bool
-	dispatchFailed      func(connector.Issue) bool
-	retryDispatchFailed func(connector.Issue, Retry)
+	hydrate                 func(connector.Issue) (connector.Issue, bool)
+	beforeDispatch          func(connector.Issue, int) bool
+	dispatch                func(connector.Issue, int, string) bool
+	dispatchFailed          func(connector.Issue) bool
+	retryDispatchFailed     func(connector.Issue, Retry)
+	preserveMissingDueRetry func(Retry) bool
 }
 
 type dispatchAction struct {
@@ -44,7 +45,7 @@ func (p dispatchPlanner) plan(
 	plannedCandidates := cloneIssues(candidates)
 	sortIssuesForDispatch(plannedCandidates, p.cfg.DispatchPriorityByState, p.cfg.DispatchPriorityByLabel)
 	dueRetries := dueRetriesByIssue(state, now)
-	p.releaseMissingDueRetries(state, plannedCandidates, dueRetries)
+	p.releaseMissingDueRetries(state, plannedCandidates, dueRetries, hooks)
 
 	plan := DispatchPlan{}
 	continuations := 0
@@ -269,6 +270,7 @@ func (p dispatchPlanner) releaseMissingDueRetries(
 	state *State,
 	issues []connector.Issue,
 	dueRetries map[string]Retry,
+	hooks dispatchPlanHooks,
 ) {
 	if len(dueRetries) == 0 {
 		return
@@ -279,8 +281,11 @@ func (p dispatchPlanner) releaseMissingDueRetries(
 		byID[issue.ID] = struct{}{}
 	}
 
-	for issueID := range dueRetries {
+	for issueID, retry := range dueRetries {
 		if _, ok := byID[issueID]; !ok {
+			if hooks.preserveMissingDueRetry != nil && hooks.preserveMissingDueRetry(retry) {
+				continue
+			}
 			if _, blocked := state.Blocked[issueID]; blocked {
 				p.releaseClaim(state, issueID)
 				continue

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1369,7 +1369,17 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		retryDispatchFailed: func(issue connector.Issue, retry Retry) {
 			planner.scheduleRetry(state, issue, retry.Attempt, now, "claim verification failed", false, retry.WorkerHost)
 		},
+		preserveMissingDueRetry: func(retry Retry) bool {
+			return o.preserveMissingDueRetry(state, retry)
+		},
 	})
+}
+
+func (o *Orchestrator) preserveMissingDueRetry(state *State, retry Retry) bool {
+	if normalizeState(retry.Issue.State) != normalizeState(autoPromoteMergingState) {
+		return false
+	}
+	return !o.mergeWorkerLocalSlotsAvailable(state)
 }
 
 func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector.Issue) (connector.Issue, bool) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -34,6 +34,7 @@ const (
 	defaultMaxRetryBackoff            = 5 * time.Minute
 	defaultContinuationRetry          = time.Second
 	defaultFailureRetryBaseDelay      = 10 * time.Second
+	maxMergeWorkerRunnerFailures      = 3
 	continuationDispatchBackoff       = 100 * time.Millisecond
 	runUpdateBufferSize               = 128
 	maxRecentEvents                   = 50
@@ -437,6 +438,31 @@ func (o *Orchestrator) observedStatusFetchStates() []string {
 		states = append(states, cfg.SourceStates...)
 	}
 	return displayStateNames(states)
+}
+
+func (o *Orchestrator) observedStatusFetchStatesForTick(state *State) []string {
+	states := o.observedStatusFetchStates()
+	if o.mergeWorkerLocalSlotsAvailable(state) {
+		return states
+	}
+	return statesWithoutState(states, autoPromoteMergingState)
+}
+
+func (o *Orchestrator) mergeWorkerLocalSlotsAvailable(state *State) bool {
+	stats := o.projectStateSlotStats(connector.Issue{State: autoPromoteMergingState}, state)
+	return stats.available > 0
+}
+
+func statesWithoutState(states []string, omit string) []string {
+	omit = normalizeState(omit)
+	out := make([]string, 0, len(states))
+	for _, state := range states {
+		if normalizeState(state) == omit {
+			continue
+		}
+		out = append(out, state)
+	}
+	return out
 }
 
 func prPipelineFetchStates() []string {
@@ -1754,6 +1780,11 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		if attempt < 1 {
 			attempt = nextAttempt(running.Attempt)
 		}
+		if mergeWorkerIssue(running.Issue) && attempt > maxMergeWorkerRunnerFailures {
+			if o.reworkExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, event.Err) {
+				return
+			}
+		}
 		delay := event.RetryDelay
 		if delay <= 0 {
 			delay = o.retryDelay(attempt, false)
@@ -1810,6 +1841,93 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
+}
+
+func (o *Orchestrator) reworkExhaustedMergeWorker(
+	ctx context.Context,
+	state *State,
+	running Running,
+	completedAt time.Time,
+	attempt int,
+	err error,
+) bool {
+	issueID := strings.TrimSpace(running.Issue.ID)
+	if issueID == "" || o.connector == nil {
+		return false
+	}
+	if err := o.connector.UpdateIssueState(ctx, issueID, autoPromoteReworkState); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"merge_worker_rework_failed",
+				"issue_id", issueID,
+				"identifier", running.Issue.Identifier,
+				"reason", "runner_failed_retry_exhausted",
+				"target_state", autoPromoteReworkState,
+				"error", err,
+			)
+		}
+		return false
+	}
+	if comment := mergeWorkerRetryExhaustedComment(running.Issue, attempt, err); strings.TrimSpace(comment) != "" {
+		if err := o.connector.CreateComment(ctx, issueID, comment); err != nil && o.logger != nil {
+			o.logger.Warn(
+				"merge_worker_rework_comment_failed",
+				"issue_id", issueID,
+				"identifier", running.Issue.Identifier,
+				"reason", "runner_failed_retry_exhausted",
+				"error", err,
+			)
+		}
+	}
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("abandon exhausted merge worker claim failed", "issue_id", issueID, "error", err)
+	}
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	delete(state.Completed, issueID)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      completedAt,
+		Event:   "merge_worker_retry_exhausted",
+		Message: "merge worker retries exhausted for " + issueLabel(running.Issue) + ": " + errorString(err),
+	})
+	return true
+}
+
+func mergeWorkerRetryExhaustedComment(issue connector.Issue, attempt int, err error) string {
+	var b strings.Builder
+	b.WriteString("Merge worker retries were exhausted; routed this issue from Merging to Rework.")
+	b.WriteString("\n\n- reason: runner_failed_retry_exhausted")
+	if attempt > 0 {
+		b.WriteString("\n- attempt: ")
+		b.WriteString(fmt.Sprintf("%d", attempt))
+	}
+	if errText := errorString(err); errText != "" {
+		b.WriteString("\n- error: ")
+		b.WriteString(errText)
+	}
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			b.WriteString("\n- pull request: ")
+			b.WriteString(url)
+		}
+		if mergeableState := strings.ToLower(strings.TrimSpace(issue.PullRequest.MergeableState)); mergeableState != "" {
+			b.WriteString("\n- mergeable_state: ")
+			b.WriteString(mergeableState)
+		}
+		if ciStatus := strings.TrimSpace(issue.PullRequest.CIStatus); ciStatus != "" {
+			b.WriteString("\n- ci_status: ")
+			b.WriteString(ciStatus)
+		}
+	}
+	return b.String()
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(err.Error())
 }
 
 func (o *Orchestrator) completePlanRunning(

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -249,9 +249,9 @@ func (o *Orchestrator) fetchTickIssues(
 	now time.Time,
 	reserve githubBudgetReserveDecision,
 ) (tickFetchedIssues, bool) {
-	observedStates := o.observedStatusFetchStates()
+	observedStates := o.observedStatusFetchStatesForTick(state)
 
-	candidateIssues, err := o.connector.FetchCandidateIssues(ctx)
+	candidateIssues, err := o.fetchCandidateIssuesForTick(ctx, state)
 	if err != nil {
 		o.logger.Warn("fetch candidate issues failed", "error", err)
 		markRefreshError(state, "fetch candidate issues failed: "+err.Error(), now)
@@ -297,6 +297,25 @@ func (o *Orchestrator) fetchTickIssues(
 	}
 	clearRefreshError(state)
 	return fetched, true
+}
+
+func (o *Orchestrator) fetchCandidateIssuesForTick(ctx context.Context, state *State) ([]connector.Issue, error) {
+	if fetcher, ok := o.connector.(connector.CandidateIssuesByStatesFetcher); ok {
+		states := o.candidateFetchStatesForTick(state)
+		if len(states) == 0 {
+			return []connector.Issue{}, nil
+		}
+		return fetcher.FetchCandidateIssuesByStates(ctx, states)
+	}
+	return o.connector.FetchCandidateIssues(ctx)
+}
+
+func (o *Orchestrator) candidateFetchStatesForTick(state *State) []string {
+	states := append([]string(nil), o.cfg.ActiveStates...)
+	if o.mergeWorkerLocalSlotsAvailable(state) {
+		return states
+	}
+	return statesWithoutState(states, autoPromoteMergingState)
 }
 
 func markRefreshError(state *State, message string, at time.Time) {
@@ -421,7 +440,7 @@ func (o *Orchestrator) refreshTransitionSets(
 	if fetched.statusOK {
 		transitionIssues = append(transitionIssues, fetched.status...)
 		state.Pipeline = issuesInStates(fetched.status, prPipelineFetchStates())
-		if !pipelineRefreshOK {
+		if !pipelineRefreshOK || !o.mergeWorkerLocalSlotsAvailable(state) {
 			state.Pipeline = mergeIssueSlices(state.Pipeline, previous.pipeline)
 		}
 	}


### PR DESCRIPTION
## Summary

- Gate stale Merging recovery on local merge-lane availability before logging pickup or dispatch candidates.
- Skip candidate/status Merging hydration while the local merge lane is occupied, retaining prior pipeline state for visibility.
- Preserve due Merging retry memory while lane-full fetch pruning omits Merging candidates.
- Route repeated merge runner failures to Rework with an operator-visible exhausted-retry reason.

Fixes #716

## Test Plan

- [x] `go test ./internal/orchestrator -run TestTickPreservesDueMergingRetryWhenLaneFullAndMergingFetchOmitted -count=1 -v`
- [x] `go test ./internal/orchestrator -run TestDispatchReadyIssuesPreservesBlockedStatusForMissingDueRetry -count=1 -v`
- [x] `go test ./internal/orchestrator -run TestFetchTickIssuesSkipsMergingStatusHydrationWhenMergingLaneFull -count=1 -v`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`