### PR TITLE
fix(orchestrator): close incomplete merge attempts

### DIFF
--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1962,6 +1962,271 @@ func TestHandleRunResultReworksMergeWorkerAfterRepeatedRunnerFailures(t *testing
 	}
 }
 
+func TestHandleRunResultRetriesMergeWorkerWhenRunCompletesWithoutTerminalState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 13, 15, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:   1,
+		FailureRetryBaseDelay: time.Minute,
+		MaxRetryBackoff:       time.Hour,
+		ActiveStates:          []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:        []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-incomplete-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         75,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/75",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.State = "Merging"
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:    cfg,
+		logger: slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:      cloneIssue(issue),
+		Attempt:    1,
+		StartedAt:  now.Add(-time.Minute),
+		WorkerHost: "worker-a",
+	}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	if _, ok := state.Completed[issue.ID]; ok {
+		t.Fatalf("Completed[%q] present after incomplete merge worker result", issue.ID)
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after incomplete merge worker result", issue.ID)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok {
+		t.Fatalf("Retry[%q] missing after incomplete merge worker result", issue.ID)
+	}
+	if retry.Attempt != 2 {
+		t.Fatalf("Retry[%q].Attempt = %d, want 2", issue.ID, retry.Attempt)
+	}
+	if retry.WorkerHost != "worker-a" {
+		t.Fatalf("Retry[%q].WorkerHost = %q, want worker-a", issue.ID, retry.WorkerHost)
+	}
+	if retry.Error != "merge worker completed without reaching a terminal issue or pull request state" {
+		t.Fatalf("Retry[%q].Error = %q", issue.ID, retry.Error)
+	}
+	if !retry.DueAt.Equal(now.Add(time.Minute * 2)) {
+		t.Fatalf("Retry[%q].DueAt = %v, want %v", issue.ID, retry.DueAt, now.Add(time.Minute*2))
+	}
+	for _, fragment := range []string{
+		"merge_worker_failure",
+		"reason=terminal_state_missing",
+		"completed without reaching a terminal issue or pull request state",
+		"pull_request_number=75",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}
+
+func TestHandleRunResultAbandonsIncompleteMergeWorkerWhileDraining(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 13, 16, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+		Claiming: ClaimingConfig{
+			Enabled:    true,
+			LeaseField: "Lease",
+		},
+	})
+	issue := autoPromoteTickIssue("issue-incomplete-merge-drain", []string{"bug"}, &connector.PullRequest{
+		Number:         75,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/75",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.State = "Merging"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	state.Draining = true
+	state.Running[issue.ID] = Running{
+		Issue:      cloneIssue(issue),
+		Attempt:    1,
+		StartedAt:  now.Add(-time.Minute),
+		WorkerHost: "worker-a",
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after draining incomplete merge worker result", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after draining incomplete merge worker result", issue.ID)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after draining incomplete merge worker result", issue.ID)
+	}
+	if got := tracker.setFields; !reflect.DeepEqual(got, []autoPromoteTickSetField{{
+		issueID: issue.ID,
+		field:   "Lease",
+		value:   "",
+	}}) {
+		t.Fatalf("set fields = %#v, want lease release", got)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none while draining", tracker.comments)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none while draining", tracker.updates)
+	}
+	if strings.Contains(logs.String(), "terminal_state_missing") {
+		t.Fatalf("logs %q contain terminal_state_missing", logs.String())
+	}
+}
+
+func TestHandleRunResultCompletesMergeWorkerWhenLatestIssueIsTerminal(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 13, 18, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	runningIssue := autoPromoteTickIssue("issue-terminal-merge", []string{"bug"}, &connector.PullRequest{
+		Number:         75,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/75",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	runningIssue.State = "Merging"
+	terminalIssue := cloneIssue(runningIssue)
+	terminalIssue.Closed = true
+	terminalIssue.ClosedReason = "completed"
+	terminalIssue.PullRequest.State = "MERGED"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{terminalIssue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	state.Running[runningIssue.ID] = Running{
+		Issue:     cloneIssue(runningIssue),
+		StartedAt: now.Add(-time.Minute),
+	}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     runningIssue.ID,
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	if _, ok := state.Running[runningIssue.ID]; ok {
+		t.Fatalf("Running[%q] present after terminal merge worker result", runningIssue.ID)
+	}
+	if _, ok := state.Retry[runningIssue.ID]; ok {
+		t.Fatalf("Retry[%q] present after terminal merge worker result", runningIssue.ID)
+	}
+	completed, ok := state.Completed[runningIssue.ID]
+	if !ok {
+		t.Fatalf("Completed[%q] missing after terminal merge worker result", runningIssue.ID)
+	}
+	if completed.FinalState != "Done" {
+		t.Fatalf("Completed[%q].FinalState = %q, want Done", runningIssue.ID, completed.FinalState)
+	}
+	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: runningIssue.ID, state: "Done"}}) {
+		t.Fatalf("updates = %#v, want Done reconciliation", got)
+	}
+	if !strings.Contains(logs.String(), "merge_worker_success") {
+		t.Fatalf("logs %q missing merge_worker_success", logs.String())
+	}
+	if strings.Contains(logs.String(), "terminal_state_missing") {
+		t.Fatalf("logs %q contain terminal_state_missing", logs.String())
+	}
+}
+
+func TestHandleRunResultReworksMergeWorkerAfterRepeatedIncompleteResults(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 13, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:   1,
+		FailureRetryBaseDelay: time.Minute,
+		MaxRetryBackoff:       time.Hour,
+		ActiveStates:          []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:        []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-incomplete-merge-exhausted", []string{"bug"}, &connector.PullRequest{
+		Number:         76,
+		URL:            "https://github.test/digitaldrywood/creswoodcorners-phone/pull/76",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.State = "Merging"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:     cloneIssue(issue),
+		Attempt:   3,
+		StartedAt: now.Add(-time.Minute),
+	}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result:      runpkg.RunResult{FinalState: runpkg.FinalStateCompleted},
+	})
+
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after repeated incomplete merge results", issue.ID)
+	}
+	if got := tracker.updates; !reflect.DeepEqual(got, []autoPromoteTickUpdate{{issueID: issue.ID, state: autoPromoteReworkState}}) {
+		t.Fatalf("updates = %#v, want Rework transition", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one exhausted retry comment", tracker.comments)
+	}
+	for _, fragment := range []string{"runner_failed_retry_exhausted", "terminal issue or pull request state", "pull request"} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	if !strings.Contains(logs.String(), "reason=terminal_state_missing") {
+		t.Fatalf("logs %q missing terminal_state_missing", logs.String())
+	}
+}
+
 func TestTickAutoPromoteMergingIssueDispatchesAndClearsStaleMemory(t *testing.T) {
 	t.Parallel()
 
@@ -2094,6 +2359,12 @@ type autoPromoteTickComment struct {
 	body    string
 }
 
+type autoPromoteTickSetField struct {
+	issueID string
+	field   string
+	value   string
+}
+
 type autoPromoteTickConnector struct {
 	stateIssues           []connector.Issue
 	candidateIssues       []connector.Issue
@@ -2103,6 +2374,7 @@ type autoPromoteTickConnector struct {
 	updates               []autoPromoteTickUpdate
 	comments              []autoPromoteTickComment
 	prComments            []autoPromoteTickComment
+	setFields             []autoPromoteTickSetField
 }
 
 func (c *autoPromoteTickConnector) Name() string {
@@ -2220,6 +2492,7 @@ func (c *autoPromoteTickConnector) SetAssignee(context.Context, string, string) 
 	return nil
 }
 
-func (c *autoPromoteTickConnector) SetField(context.Context, string, string, string) error {
+func (c *autoPromoteTickConnector) SetField(_ context.Context, issueID string, field string, value string) error {
+	c.setFields = append(c.setFields, autoPromoteTickSetField{issueID: issueID, field: field, value: value})
 	return nil
 }

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -41,6 +41,7 @@ const (
 	blockedStatusState                = "Blocked"
 	blockedReasonDependency           = "blocked by non-terminal dependency"
 	blockedReasonProjectStatus        = "blocked by project status"
+	mergeWorkerTerminalStateMissing   = "merge worker completed without reaching a terminal issue or pull request state"
 )
 
 var prPipelineStates = []string{"Human Review", "Merging"}
@@ -262,7 +263,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		forceRequests:      make(chan forceRequest),
 		configUpdates:      make(chan configUpdateRequest),
 		refreshes:          make(chan manualRefreshRequest, 1),
-		runResults:         make(chan runpkg.Completion),
+		runResults:         make(chan runpkg.Completion, max(cfg.MaxConcurrentAgents, 1)),
 		runUpdates:         make(chan runUpdate, runUpdateBufferSize),
 		done:               make(chan struct{}),
 	}, nil
@@ -1816,6 +1817,18 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 
+	if mergeWorkerIssue(running.Issue) {
+		if o.completeLatestTerminalMergeWorkerResult(ctx, state, event, running) {
+			return
+		}
+		if state.Draining {
+			o.cleanupDrainedRun(ctx, state, event.IssueID)
+			return
+		}
+		o.handleIncompleteMergeWorkerResult(ctx, state, event, running)
+		return
+	}
+
 	finalState := event.Result.FinalState
 	if finalState == "" {
 		finalState = FinalStateCompleted
@@ -1842,15 +1855,96 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 
 	if state.Draining {
-		if err := o.abandonClaim(ctx, event.IssueID); err != nil && o.logger != nil {
-			o.logger.Warn("abandon completed drain claim failed", "issue_id", event.IssueID, "error", err)
-		}
-		delete(state.Claimed, event.IssueID)
-		delete(state.Retry, event.IssueID)
-		delete(state.BudgetRefusals, event.IssueID)
+		o.cleanupDrainedRun(ctx, state, event.IssueID)
 		return
 	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
+}
+
+func (o *Orchestrator) cleanupDrainedRun(ctx context.Context, state *State, issueID string) {
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("abandon completed drain claim failed", "issue_id", issueID, "error", err)
+	}
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+}
+
+func (o *Orchestrator) completeLatestTerminalMergeWorkerResult(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	issueID := strings.TrimSpace(event.IssueID)
+	if issueID == "" || o.connector == nil {
+		return false
+	}
+	issues, err := o.connector.FetchIssueStatesByIDs(ctx, []string{issueID})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"merge_worker_terminal_state_refresh_failed",
+				"issue_id", issueID,
+				"identifier", running.Issue.Identifier,
+				"error", err,
+			)
+		}
+		return false
+	}
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.ID) != issueID {
+			continue
+		}
+		issue = mergeIssueTrackerFields(running.Issue, issue)
+		if !workspaceIssueTerminal(issue, o.cfg.TerminalStates) {
+			return false
+		}
+		tokens := event.Result.Tokens
+		if tokens == (CodexTotals{}) {
+			tokens = running.Tokens
+		}
+		if diffStatsPresent(event.Result.DiffStats) {
+			running.DiffStats = event.Result.DiffStats
+		}
+		running.Issue = issue
+		o.completeTerminalRunning(ctx, state, issueID, running, terminalCompletedAt(issue, o.cfg.TerminalStates, event.CompletedAt), tokens)
+		if event.Result.RateLimits != nil {
+			state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
+		}
+		return true
+	}
+	return false
+}
+
+func (o *Orchestrator) handleIncompleteMergeWorkerResult(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) {
+	err := errors.New(mergeWorkerTerminalStateMissing)
+	o.logMergeWorkerFailure(running.Issue, "terminal_state_missing", err)
+	attempt := nextAttempt(running.Attempt)
+	if attempt > maxMergeWorkerRunnerFailures {
+		if o.reworkExhaustedMergeWorker(ctx, state, running, event.CompletedAt, attempt, err) {
+			return
+		}
+	}
+	o.scheduleRetry(
+		state,
+		running.Issue,
+		attempt,
+		event.CompletedAt,
+		err.Error(),
+		false,
+		running.WorkerHost,
+	)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "merge_worker_terminal_state_missing",
+		Message: "merge worker completed without terminal state for " + issueLabel(running.Issue),
+	})
 }
 
 func (o *Orchestrator) reworkExhaustedMergeWorker(

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -13,6 +13,7 @@ import (
 const (
 	defaultSupervisorMaxRetryBackoff       = 5 * time.Minute
 	defaultSupervisorFailureRetryBaseDelay = 10 * time.Second
+	defaultCompletionDeliveryGrace         = 250 * time.Millisecond
 )
 
 var ErrMissingRunner = errors.New("runner backend is required")
@@ -88,9 +89,34 @@ func (s *Supervisor) UpdateConfig(cfg SupervisorConfig) {
 func (s *Supervisor) Dispatch(ctx context.Context, request RunRequest, completions chan<- Completion) {
 	go func() {
 		completion := s.Run(ctx, request)
+		if completions == nil {
+			return
+		}
 		select {
 		case completions <- completion:
+			return
+		default:
+		}
+		if ctx == nil {
+			completions <- completion
+			return
+		}
+		select {
+		case completions <- completion:
+			return
 		case <-ctx.Done():
+		}
+		timer := time.NewTimer(defaultCompletionDeliveryGrace)
+		defer timer.Stop()
+		select {
+		case completions <- completion:
+		case <-timer.C:
+			s.logger.Warn(
+				"runner completion delivery timed out after context cancellation",
+				slog.String("issue_id", request.Issue.ID),
+				slog.String("issue_identifier", request.Issue.Identifier),
+				slog.Any("error", completion.Err),
+			)
 		}
 	}()
 }

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -3,7 +3,9 @@ package runner
 import (
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -200,6 +202,119 @@ func TestSupervisorDispatchSendsCompletion(t *testing.T) {
 	}
 }
 
+func TestSupervisorDispatchDeliversCompletionAfterContextCancellation(t *testing.T) {
+	backend := &cancelCompletionBackend{
+		returning: make(chan struct{}),
+		release:   make(chan struct{}),
+	}
+	supervisor, err := NewSupervisor(backend, SupervisorConfig{
+		FailureRetryBaseDelay: time.Second,
+		MaxRetryBackoff:       time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	completions := make(chan Completion)
+	supervisor.Dispatch(ctx, RunRequest{
+		Issue: connector.Issue{ID: "issue-22", Identifier: "digitaldrywood/detent#22"},
+	}, completions)
+
+	cancel()
+	select {
+	case <-backend.returning:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not observe cancellation")
+	}
+	close(backend.release)
+
+	select {
+	case completion := <-completions:
+		if !errors.Is(completion.Err, context.Canceled) {
+			t.Fatalf("Completion.Err = %v, want context.Canceled", completion.Err)
+		}
+		if !completion.Retryable {
+			t.Fatal("Retryable = false, want true")
+		}
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for canceled completion")
+	}
+}
+
+func TestSupervisorDispatchStopsBlockedSendAfterCancellation(t *testing.T) {
+	t.Parallel()
+
+	returned := make(chan struct{})
+	logs := newSignalLog("runner completion delivery timed out after context cancellation")
+	supervisor, err := NewSupervisor(staticBackend{
+		result:   RunResult{FinalState: FinalStateCompleted},
+		returned: returned,
+	}, SupervisorConfig{
+		FailureRetryBaseDelay: time.Second,
+		MaxRetryBackoff:       time.Minute,
+		Logger:                slog.New(slog.NewTextHandler(logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	t.Cleanup(cancel)
+
+	supervisor.Dispatch(ctx, RunRequest{
+		Issue: connector.Issue{ID: "issue-22", Identifier: "digitaldrywood/detent#22"},
+	}, make(chan Completion))
+
+	select {
+	case <-returned:
+	case <-time.After(time.Second):
+		t.Fatal("backend did not return")
+	}
+	cancel()
+
+	select {
+	case <-logs.signal:
+	case <-time.After(time.Second):
+		t.Fatalf("logs %q missing blocked completion timeout", logs.String())
+	}
+}
+
+type signalLog struct {
+	mu       sync.Mutex
+	body     strings.Builder
+	fragment string
+	signal   chan struct{}
+	once     sync.Once
+}
+
+func newSignalLog(fragment string) *signalLog {
+	return &signalLog{
+		fragment: fragment,
+		signal:   make(chan struct{}),
+	}
+}
+
+func (l *signalLog) Write(p []byte) (int, error) {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	_, _ = l.body.Write(p)
+	if strings.Contains(l.body.String(), l.fragment) {
+		l.once.Do(func() {
+			close(l.signal)
+		})
+	}
+	return len(p), nil
+}
+
+func (l *signalLog) String() string {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	return l.body.String()
+}
+
 type panicBackend struct{}
 
 func (panicBackend) Run(context.Context, RunRequest) (RunResult, error) {
@@ -213,9 +328,25 @@ func (errorBackend) Run(context.Context, RunRequest) (RunResult, error) {
 }
 
 type staticBackend struct {
-	result RunResult
+	result   RunResult
+	returned chan struct{}
 }
 
 func (b staticBackend) Run(context.Context, RunRequest) (RunResult, error) {
+	if b.returned != nil {
+		close(b.returned)
+	}
 	return b.result, nil
+}
+
+type cancelCompletionBackend struct {
+	returning chan struct{}
+	release   chan struct{}
+}
+
+func (b *cancelCompletionBackend) Run(ctx context.Context, _ RunRequest) (RunResult, error) {
+	<-ctx.Done()
+	close(b.returning)
+	<-b.release
+	return RunResult{}, ctx.Err()
 }


### PR DESCRIPTION
## Summary

- Treat merge-worker runs that finish without a terminal PR/issue state as retryable failures instead of silent continuations.
- Refresh the issue state on merge-worker completion so real merges are recorded as success before fallback failure handling.
- Prefer runner completion delivery after cancellation and buffer orchestrator run results to avoid lost terminal state.

Fixes #723

## Test Plan

- [x] `go test ./internal/runner ./internal/orchestrator -count=1`
- [x] `go test ./... -count=1`
- [x] `make check`