### PR TITLE
fix(scheduler): use spare global slots

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -352,6 +352,56 @@ func (o *Orchestrator) logMergeWorkerSlotAcquired(
 	o.logger.Info("merge_worker_slot_acquired", mergeWorkerSlotDecisionAttrs(issue, decision, projectStats)...)
 }
 
+func (o *Orchestrator) logDispatchSlotWait(
+	issue connector.Issue,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+) {
+	if o.logger == nil {
+		return
+	}
+	o.logger.Info("dispatch_slot_wait", mergeWorkerSlotDecisionAttrs(issue, decision, projectStats)...)
+}
+
+func (o *Orchestrator) recordDispatchSlotWait(
+	state *State,
+	issue connector.Issue,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+	now time.Time,
+) {
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "dispatch_slot_wait",
+		Message: dispatchSlotWaitMessage(issue, decision, projectStats),
+	})
+}
+
+func dispatchSlotWaitMessage(
+	issue connector.Issue,
+	decision scheduler.DispatchGateDecision,
+	projectStats projectStateSlotStats,
+) string {
+	reason := strings.TrimSpace(decision.Reason)
+	if reason == "" {
+		reason = dispatchIssueFailureGlobalSlotUnavailable
+	}
+	return fmt.Sprintf(
+		"dispatch waiting for %s state=%s reason=%s global_capacity=%d global_used=%d global_available=%d project_state_capacity=%d project_state_used=%d project_state_available=%d selected_project_id=%s selected_state=%s",
+		issueLabel(issue),
+		strings.TrimSpace(issue.State),
+		reason,
+		decision.GlobalCapacity,
+		decision.GlobalUsed,
+		decision.GlobalAvailable,
+		projectStats.capacity,
+		projectStats.used,
+		projectStats.available,
+		strings.TrimSpace(decision.SelectedProjectID),
+		strings.TrimSpace(decision.SelectedState),
+	)
+}
+
 func mergeWorkerSlotDecisionAttrs(
 	issue connector.Issue,
 	decision scheduler.DispatchGateDecision,
@@ -362,6 +412,7 @@ func mergeWorkerSlotDecisionAttrs(
 		reason = dispatchIssueFailureGlobalSlotUnavailable
 	}
 	attrs := mergeWorkerLogAttrs(issue,
+		"state", strings.TrimSpace(issue.State),
 		"reason", reason,
 		"global_capacity", decision.GlobalCapacity,
 		"global_used", decision.GlobalUsed,

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -878,6 +878,100 @@ func TestDispatchReadyIssuesLogsMergeSlotDecisionAndStopsAfterGlobalWait(t *test
 	}
 }
 
+func TestDispatchReadyIssuesRecordsNonMergeSlotWaitTelemetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 10, 0, 0, 0, time.UTC)
+	ctx := t.Context()
+	globalGate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 1}))
+	lowerSlot, ok, decision, err := globalGate.TryAcquireWithDecision(ctx, scheduler.ProjectCandidate{ID: "alpha", Weight: 1}, scheduler.SlotRequest{
+		State:    "Todo",
+		Priority: 2,
+	}, now)
+	if err != nil {
+		t.Fatalf("lower-priority TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("lower-priority TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+	t.Cleanup(func() {
+		if err := globalGate.Release(lowerSlot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:     2,
+		DispatchPriorityByState: []string{"Merging", "Rework", "Todo"},
+		ActiveStates:            []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:          []string{"Done"},
+		Project:                 scheduler.ProjectCandidate{ID: "zulu", Weight: 1},
+	})
+	runner := newWorkerHostRunner()
+	var logs strings.Builder
+	orch := Orchestrator{
+		cfg:                cfg,
+		supervisor:         newTestSupervisor(t, runner, cfg),
+		runResults:         make(chan runpkg.Completion),
+		globalDispatchGate: globalGate,
+		logger:             slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	state := newState(cfg)
+	candidate := dispatchTestIssue("issue-rework", "Rework")
+
+	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{candidate}, now.Add(time.Second))
+
+	select {
+	case request := <-runner.started:
+		t.Fatalf("unexpected rework dispatch while global slot is held = %#v", request)
+	default:
+	}
+	if len(state.Running) != 0 {
+		t.Fatalf("Running len = %d, want 0", len(state.Running))
+	}
+	logText := logs.String()
+	for _, fragment := range []string{
+		"dispatch_slot_wait",
+		"issue_id=issue-rework",
+		"state=Rework",
+		"reason=global_capacity_full",
+		"global_capacity=1",
+		"global_used=1",
+		"global_available=0",
+		"project_state_capacity=2",
+		"project_state_used=0",
+		"project_state_available=2",
+		"selected_project_id=zulu",
+		"selected_state=rework",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs %q missing fragment %q", logText, fragment)
+		}
+	}
+	if strings.Contains(logText, "merge_worker_failure") {
+		t.Fatalf("logs %q contain merge_worker_failure, want dispatch slot wait telemetry instead", logText)
+	}
+	if len(state.RecentEvents) != 1 {
+		t.Fatalf("RecentEvents len = %d, want 1", len(state.RecentEvents))
+	}
+	event := state.RecentEvents[0]
+	if event.Event != "dispatch_slot_wait" {
+		t.Fatalf("RecentEvents[0].Event = %q, want dispatch_slot_wait", event.Event)
+	}
+	for _, fragment := range []string{
+		"digitaldrywood/detent#issue-rework",
+		"state=Rework",
+		"reason=global_capacity_full",
+		"global_available=0",
+		"project_state_available=2",
+		"selected_project_id=zulu",
+	} {
+		if !strings.Contains(event.Message, fragment) {
+			t.Fatalf("RecentEvents[0].Message %q missing fragment %q", event.Message, fragment)
+		}
+	}
+}
+
 func TestDispatchReadyIssuesHydratesLightweightCandidateBeforeDependencyGate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1492,7 +1492,8 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		if mergeWorkerIssue(issue) {
 			o.logMergeWorkerSlotWait(issue, decision, projectStats)
 		} else {
-			o.logMergeWorkerFailure(issue, "global_slot_unavailable", nil)
+			o.logDispatchSlotWait(issue, decision, projectStats)
+			o.recordDispatchSlotWait(state, issue, decision, projectStats, now)
 		}
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGlobalSlotUnavailable}
 	}

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -51,22 +51,27 @@ type runningProjectSlot struct {
 	preempt func()
 }
 
+type selectedProjectSlot struct {
+	ProjectCandidate
+	request     SlotRequest
+	preemptions []RunningProject
+}
+
 type GlobalDispatchGate struct {
 	global GlobalScheduler
 
-	mu          sync.Mutex
-	ready       map[string]readyProjectSlot
-	running     map[uint64]runningProjectSlot
-	selected    string
-	selectedReq SlotRequest
-	preemptions []RunningProject
+	mu       sync.Mutex
+	ready    map[string]readyProjectSlot
+	running  map[uint64]runningProjectSlot
+	selected map[string]selectedProjectSlot
 }
 
 func NewGlobalDispatchGate(global GlobalScheduler) *GlobalDispatchGate {
 	return &GlobalDispatchGate{
-		global:  global,
-		ready:   map[string]readyProjectSlot{},
-		running: map[uint64]runningProjectSlot{},
+		global:   global,
+		ready:    map[string]readyProjectSlot{},
+		running:  map[uint64]runningProjectSlot{},
+		selected: map[string]selectedProjectSlot{},
 	}
 }
 
@@ -100,11 +105,7 @@ func (g *GlobalDispatchGate) MarkIdle(projectID string) {
 	defer g.mu.Unlock()
 
 	delete(g.ready, projectID)
-	if g.selected == projectID {
-		g.selected = ""
-		g.selectedReq = SlotRequest{}
-		g.preemptions = nil
-	}
+	delete(g.selected, projectID)
 }
 
 func (g *GlobalDispatchGate) TryAcquire(
@@ -148,39 +149,22 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	}
 
 	g.ready[project.ID] = readyProjectSlot{ProjectCandidate: project, request: req}
-	if g.selected != "" {
-		selected, ok := g.ready[g.selected]
-		if !ok {
-			g.clearSelectionLocked()
-		} else {
-			g.selectedReq = selected.request
-			if g.hasHigherPriorityReadyProjectLocked(selected.request.Priority) {
-				g.clearSelectionLocked()
-			}
+	g.reconcileSelectionsLocked()
+	if err := g.fillSelectionsLocked(ctx, now, true); err != nil {
+		if errors.Is(err, ErrNoSlots) {
+			decision := g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull)
+			return Slot{}, false, decision, nil
 		}
+		return Slot{}, false, DispatchGateDecision{}, err
 	}
-	if g.selected == "" {
-		selection, selectedReq, err := g.selectReadyProjectLocked(ctx, now, true)
-		if err != nil {
-			if errors.Is(err, ErrNoSlots) {
-				decision := g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull)
-				return Slot{}, false, decision, nil
-			}
-			return Slot{}, false, DispatchGateDecision{}, err
-		}
-		g.selected = selection.Project.ID
-		g.selectedReq = selectedReq
-		g.preemptions = selection.Preemptions
-	}
-	if g.selected != project.ID {
-		reason := DispatchGateReasonSelectedProjectWaiting
-		if selected, ok := g.ready[g.selected]; ok && selected.request.Priority < req.Priority {
-			reason = DispatchGateReasonReservedForHigherPriority
-		}
+
+	selected, selectedOK := g.selected[project.ID]
+	if !selectedOK {
+		reason := g.waitReasonLocked(req)
 		return Slot{}, false, g.decisionLocked(project.ID, req, reason), nil
 	}
-	if err := g.preemptProjectsLocked(g.preemptions); err != nil {
-		g.clearSelectionLocked()
+	if err := g.preemptProjectsLocked(selected.preemptions); err != nil {
+		delete(g.selected, project.ID)
 		return Slot{}, false, DispatchGateDecision{}, err
 	}
 
@@ -190,7 +174,7 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 			decision := g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull)
 			return Slot{}, false, decision, nil
 		}
-		g.clearSelectionLocked()
+		delete(g.selected, project.ID)
 		return Slot{}, false, DispatchGateDecision{}, err
 	}
 	if err := g.global.RecordProjectDispatch(ctx, ProjectDispatch{
@@ -198,13 +182,13 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 		Weight:       project.Weight,
 		DispatchedAt: now,
 	}); err != nil {
-		g.clearSelectionLocked()
+		delete(g.selected, project.ID)
 		return Slot{}, false, DispatchGateDecision{}, errors.Join(err, g.global.ReleaseSlot(slot))
 	}
 
 	decision := g.decisionLocked(project.ID, req, DispatchGateReasonGranted)
 	delete(g.ready, project.ID)
-	g.clearSelectionLocked()
+	delete(g.selected, project.ID)
 	g.running[slot.token] = runningProjectSlot{
 		RunningProject: RunningProject{
 			ProjectID:    project.ID,
@@ -275,39 +259,75 @@ func (g *GlobalDispatchGate) preemptProjectLocked(preemption RunningProject) err
 	return nil
 }
 
-func (g *GlobalDispatchGate) selectReadyProjectLocked(
-	ctx context.Context,
-	now time.Time,
-	reserveWhenFull bool,
-) (ProjectSelection, SlotRequest, error) {
-	projects, requests := g.readyProjectsForSelectionLocked()
-	if len(projects) == 0 {
-		return ProjectSelection{}, SlotRequest{}, ErrNoCandidates
+func (g *GlobalDispatchGate) reconcileSelectionsLocked() {
+	for projectID, selected := range g.selected {
+		ready, ok := g.ready[projectID]
+		if !ok {
+			delete(g.selected, projectID)
+			continue
+		}
+		selected.ProjectCandidate = ready.ProjectCandidate
+		selected.request = ready.request
+		g.selected[projectID] = selected
 	}
 
-	selection, err := g.global.SelectProject(ctx, ProjectSelectionRequest{
-		Projects: projects,
-		Running:  g.runningProjectsLocked(),
-		Now:      now,
-	})
-	if err == nil {
-		return selection, requests[selection.Project.ID], nil
+	bestPriority, ok := g.bestReadyPriorityLocked()
+	if !ok {
+		return
 	}
-	if !reserveWhenFull || !errors.Is(err, ErrNoSlots) {
-		return ProjectSelection{}, SlotRequest{}, err
+	for projectID, selected := range g.selected {
+		if selected.request.Priority > bestPriority {
+			delete(g.selected, projectID)
+		}
 	}
-
-	selection, reserveErr := g.global.SelectProject(ctx, ProjectSelectionRequest{
-		Projects: projects,
-		Now:      now,
-	})
-	if reserveErr != nil {
-		return ProjectSelection{}, SlotRequest{}, err
-	}
-	return selection, requests[selection.Project.ID], nil
 }
 
-func (g *GlobalDispatchGate) readyProjectsForSelectionLocked() ([]ProjectCandidate, map[string]SlotRequest) {
+func (g *GlobalDispatchGate) fillSelectionsLocked(ctx context.Context, now time.Time, reserveWhenFull bool) error {
+	for {
+		excluded := g.selectedProjectIDsLocked()
+		projects, requests := g.readyProjectsForSelectionLocked(excluded, g.unreservedCapacityLocked())
+		if len(projects) == 0 {
+			if !reserveWhenFull || len(g.selected) > 0 {
+				return nil
+			}
+			projects, requests = g.readyProjectsForSelectionLocked(excluded, -1)
+			if len(projects) == 0 {
+				return nil
+			}
+		}
+
+		selection, err := g.global.SelectProject(ctx, ProjectSelectionRequest{
+			Projects: projects,
+			Running:  g.runningProjectsWithSelectionsLocked(),
+			Now:      now,
+		})
+		if err != nil {
+			if !reserveWhenFull || !errors.Is(err, ErrNoSlots) || len(g.selected) > 0 {
+				if errors.Is(err, ErrNoSlots) {
+					return nil
+				}
+				return err
+			}
+			reserved, reserveErr := g.global.SelectProject(ctx, ProjectSelectionRequest{
+				Projects: projects,
+				Now:      now,
+			})
+			if reserveErr != nil {
+				return err
+			}
+			selection = reserved
+		}
+
+		req := requests[selection.Project.ID]
+		g.selected[selection.Project.ID] = selectedProjectSlot{
+			ProjectCandidate: selection.Project,
+			request:          req,
+			preemptions:      selection.Preemptions,
+		}
+	}
+}
+
+func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string]struct{}, maxWeight int) ([]ProjectCandidate, map[string]SlotRequest) {
 	if len(g.ready) == 0 {
 		return nil, nil
 	}
@@ -315,15 +335,30 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked() ([]ProjectCandida
 	bestPriority := 0
 	first := true
 	for _, ready := range g.ready {
+		if _, ok := excluded[ready.ID]; ok {
+			continue
+		}
+		if maxWeight >= 0 && ready.request.Weight > maxWeight {
+			continue
+		}
 		if first || ready.request.Priority < bestPriority {
 			bestPriority = ready.request.Priority
 			first = false
 		}
 	}
+	if first {
+		return nil, nil
+	}
 
 	projects := make([]ProjectCandidate, 0, len(g.ready))
 	requests := make(map[string]SlotRequest, len(g.ready))
 	for _, ready := range g.ready {
+		if _, ok := excluded[ready.ID]; ok {
+			continue
+		}
+		if maxWeight >= 0 && ready.request.Weight > maxWeight {
+			continue
+		}
 		if ready.request.Priority != bestPriority {
 			continue
 		}
@@ -338,11 +373,8 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked() ([]ProjectCandida
 
 func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, reason string) DispatchGateDecision {
 	stats := g.capacitySnapshotLocked(req.State)
-	selectedProjectID := g.selected
-	selectedState := g.selectedReq.State
-	if selected, ok := g.ready[selectedProjectID]; ok {
-		selectedState = selected.request.State
-	}
+	selectedProjectID, selectedReq, _ := g.decisionSelectionLocked(projectID)
+	selectedState := selectedReq.State
 	if reason == "" {
 		reason = DispatchGateReasonSelectedProjectWaiting
 	}
@@ -365,11 +397,58 @@ func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, r
 	}
 }
 
+func (g *GlobalDispatchGate) waitReasonLocked(req SlotRequest) string {
+	_, selectedReq, ok := g.decisionSelectionLocked("")
+	if ok && selectedReq.Priority < req.Priority {
+		return DispatchGateReasonReservedForHigherPriority
+	}
+	return DispatchGateReasonSelectedProjectWaiting
+}
+
+func (g *GlobalDispatchGate) decisionSelectionLocked(projectID string) (string, SlotRequest, bool) {
+	if projectID != "" {
+		if selected, ok := g.selected[projectID]; ok {
+			return projectID, selected.request, true
+		}
+	}
+	if len(g.selected) == 0 {
+		return "", SlotRequest{}, false
+	}
+
+	selectedIDs := make([]string, 0, len(g.selected))
+	for projectID := range g.selected {
+		selectedIDs = append(selectedIDs, projectID)
+	}
+	sort.Slice(selectedIDs, func(i, j int) bool {
+		left := g.selected[selectedIDs[i]]
+		right := g.selected[selectedIDs[j]]
+		if left.request.Priority != right.request.Priority {
+			return left.request.Priority < right.request.Priority
+		}
+		return selectedIDs[i] < selectedIDs[j]
+	})
+	selected := g.selected[selectedIDs[0]]
+	return selectedIDs[0], selected.request, true
+}
+
 func (g *GlobalDispatchGate) capacitySnapshotLocked(state string) capacitySnapshot {
 	if snapshotter, ok := g.global.(interface{ capacitySnapshot(string) capacitySnapshot }); ok {
 		return snapshotter.capacitySnapshot(state)
 	}
 	return capacitySnapshot{}
+}
+
+func (g *GlobalDispatchGate) unreservedCapacityLocked() int {
+	stats := g.capacitySnapshotLocked("")
+	return nonNegativeInt(stats.globalCapacity - stats.globalUsed - g.selectedReservationWeightLocked())
+}
+
+func (g *GlobalDispatchGate) selectedReservationWeightLocked() int {
+	weight := 0
+	for _, selected := range g.selected {
+		weight += selected.request.Weight
+	}
+	return weight
 }
 
 func (g *GlobalDispatchGate) lowerPriorityRunningLocked(priority int) int {
@@ -382,33 +461,69 @@ func (g *GlobalDispatchGate) lowerPriorityRunningLocked(priority int) int {
 	return count
 }
 
-func (g *GlobalDispatchGate) hasHigherPriorityReadyProjectLocked(priority int) bool {
+func (g *GlobalDispatchGate) bestReadyPriorityLocked() (int, bool) {
+	bestPriority := 0
+	found := false
 	for _, ready := range g.ready {
-		if ready.request.Priority < priority {
-			return true
+		if !found || ready.request.Priority < bestPriority {
+			bestPriority = ready.request.Priority
+			found = true
 		}
 	}
-	return false
+	return bestPriority, found
 }
 
-func (g *GlobalDispatchGate) clearSelectionLocked() {
-	g.selected = ""
-	g.selectedReq = SlotRequest{}
-	g.preemptions = nil
+func (g *GlobalDispatchGate) selectedProjectIDsLocked() map[string]struct{} {
+	if len(g.selected) == 0 {
+		return nil
+	}
+	ids := make(map[string]struct{}, len(g.selected))
+	for projectID := range g.selected {
+		ids[projectID] = struct{}{}
+	}
+	return ids
+}
+
+func (g *GlobalDispatchGate) runningProjectsWithSelectionsLocked() []RunningProject {
+	projects := g.runningProjectsLocked()
+	for _, selected := range g.selected {
+		projects = appendRunningProjectWeight(projects, RunningProject{
+			ProjectID:    selected.ID,
+			Priority:     selected.Priority,
+			State:        selected.request.State,
+			SlotPriority: selected.request.Priority,
+		}, selected.request.Weight)
+	}
+	sortRunningProjects(projects)
+	return projects
 }
 
 func (g *GlobalDispatchGate) runningProjectsLocked() []RunningProject {
 	projects := make([]RunningProject, 0, len(g.running))
 	for _, project := range g.running {
-		projects = append(projects, project.RunningProject)
+		projects = appendRunningProjectWeight(projects, project.RunningProject, project.slot.Weight)
 	}
+	sortRunningProjects(projects)
+	return projects
+}
+
+func appendRunningProjectWeight(projects []RunningProject, project RunningProject, weight int) []RunningProject {
+	if weight <= 0 {
+		weight = 1
+	}
+	for range weight {
+		projects = append(projects, project)
+	}
+	return projects
+}
+
+func sortRunningProjects(projects []RunningProject) {
 	sort.Slice(projects, func(i, j int) bool {
 		if projects[i].ProjectID != projects[j].ProjectID {
 			return projects[i].ProjectID < projects[j].ProjectID
 		}
 		return projects[i].Priority < projects[j].Priority
 	})
-	return projects
 }
 
 func normalizeSlotRequest(req SlotRequest) (SlotRequest, error) {

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -200,6 +200,182 @@ func TestGlobalDispatchGateReselectsHigherPriorityWaitingLane(t *testing.T) {
 	}
 }
 
+func TestGlobalDispatchGateUsesUnreservedCapacityBehindPendingHigherPriorityLane(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 26, 9, 0, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 5}))
+
+	runningSlots := make([]scheduler.Slot, 0, 5)
+	for index, project := range []scheduler.ProjectCandidate{
+		{ID: "running-alpha", Weight: 1},
+		{ID: "running-bravo", Weight: 1},
+		{ID: "running-charlie", Weight: 1},
+		{ID: "running-delta", Weight: 1},
+		{ID: "running-echo", Weight: 1},
+	} {
+		slot, ok, decision, err := gate.TryAcquireWithDecision(ctx, project, scheduler.SlotRequest{
+			State:    "Todo",
+			Priority: 2,
+		}, now.Add(time.Duration(index)*time.Second))
+		if err != nil {
+			t.Fatalf("%s TryAcquireWithDecision() error = %v", project.ID, err)
+		}
+		if !ok {
+			t.Fatalf("%s TryAcquireWithDecision() ok = false, want true; decision = %#v", project.ID, decision)
+		}
+		runningSlots = append(runningSlots, slot)
+	}
+	t.Cleanup(func() {
+		for _, slot := range runningSlots {
+			if err := gate.Release(slot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+				t.Fatalf("Release() error = %v", err)
+			}
+		}
+	})
+
+	mergeProject := scheduler.ProjectCandidate{ID: "merge", Weight: 1}
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Priority: 0,
+	}, now.Add(5*time.Second)); err != nil {
+		t.Fatalf("merge waiting TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("merge waiting TryAcquireWithDecision() ok = true while all global slots are held, want false")
+	} else if decision.SelectedProjectID != mergeProject.ID || decision.Reason != scheduler.DispatchGateReasonGlobalCapacityFull {
+		t.Fatalf("merge waiting decision = %#v, want selected merge with global capacity full", decision)
+	}
+
+	for _, slot := range runningSlots[:3] {
+		if err := gate.Release(slot); err != nil {
+			t.Fatalf("Release() error = %v", err)
+		}
+	}
+
+	reworkProject := scheduler.ProjectCandidate{ID: "rework", Weight: 1}
+	reworkSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, reworkProject, scheduler.SlotRequest{
+		State:    "Rework",
+		Priority: 1,
+	}, now.Add(6*time.Second))
+	if err != nil {
+		t.Fatalf("rework TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("rework TryAcquireWithDecision() ok = false, want true with unreserved capacity; decision = %#v", decision)
+	}
+	if decision.Reason != scheduler.DispatchGateReasonGranted {
+		t.Fatalf("rework decision reason = %q, want %q", decision.Reason, scheduler.DispatchGateReasonGranted)
+	}
+	if decision.GlobalCapacity != 5 || decision.GlobalUsed != 3 || decision.GlobalAvailable != 2 {
+		t.Fatalf("rework decision global capacity = %d used = %d available = %d, want 5/3/2",
+			decision.GlobalCapacity, decision.GlobalUsed, decision.GlobalAvailable)
+	}
+	t.Cleanup(func() {
+		if err := gate.Release(reworkSlot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
+
+	mergeSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Priority: 0,
+	}, now.Add(7*time.Second))
+	if err != nil {
+		t.Fatalf("merge TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("merge TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+	t.Cleanup(func() {
+		if err := gate.Release(mergeSlot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
+}
+
+func TestGlobalDispatchGateReservesPendingSelectionWeight(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 6, 26, 9, 30, 0, 0, time.UTC)
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewWeightedFair(scheduler.Config{Capacity: 3}))
+	runningProject := scheduler.ProjectCandidate{ID: "running", Weight: 1}
+
+	runningSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, runningProject, scheduler.SlotRequest{
+		State:    "Todo",
+		Weight:   3,
+		Priority: 2,
+	}, now)
+	if err != nil {
+		t.Fatalf("running TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("running TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+	t.Cleanup(func() {
+		if err := gate.Release(runningSlot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
+
+	mergeProject := scheduler.ProjectCandidate{ID: "merge", Weight: 1}
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Weight:   2,
+		Priority: 0,
+	}, now.Add(time.Second)); err != nil {
+		t.Fatalf("merge waiting TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("merge waiting TryAcquireWithDecision() ok = true while all global slots are held, want false")
+	} else if decision.SelectedProjectID != mergeProject.ID || decision.Reason != scheduler.DispatchGateReasonGlobalCapacityFull {
+		t.Fatalf("merge waiting decision = %#v, want selected merge with global capacity full", decision)
+	}
+
+	if err := gate.Release(runningSlot); err != nil {
+		t.Fatalf("running Release() error = %v", err)
+	}
+
+	reworkProject := scheduler.ProjectCandidate{ID: "rework", Weight: 1}
+	if _, ok, decision, err := gate.TryAcquireWithDecision(ctx, reworkProject, scheduler.SlotRequest{
+		State:    "Rework",
+		Weight:   2,
+		Priority: 1,
+	}, now.Add(2*time.Second)); err != nil {
+		t.Fatalf("rework TryAcquireWithDecision() error = %v", err)
+	} else if ok {
+		t.Fatal("rework TryAcquireWithDecision() ok = true while only one unreserved slot remains, want false")
+	} else {
+		if decision.SelectedProjectID != mergeProject.ID {
+			t.Fatalf("rework decision selected project = %q, want %q", decision.SelectedProjectID, mergeProject.ID)
+		}
+		if decision.Reason != scheduler.DispatchGateReasonReservedForHigherPriority {
+			t.Fatalf("rework decision reason = %q, want %q", decision.Reason, scheduler.DispatchGateReasonReservedForHigherPriority)
+		}
+		if decision.GlobalCapacity != 3 || decision.GlobalUsed != 0 || decision.GlobalAvailable != 3 {
+			t.Fatalf("rework decision global capacity = %d used = %d available = %d, want 3/0/3",
+				decision.GlobalCapacity, decision.GlobalUsed, decision.GlobalAvailable)
+		}
+	}
+
+	mergeSlot, ok, decision, err := gate.TryAcquireWithDecision(ctx, mergeProject, scheduler.SlotRequest{
+		State:    "Merging",
+		Weight:   2,
+		Priority: 0,
+	}, now.Add(3*time.Second))
+	if err != nil {
+		t.Fatalf("merge TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok {
+		t.Fatalf("merge TryAcquireWithDecision() ok = false, want true; decision = %#v", decision)
+	}
+	t.Cleanup(func() {
+		if err := gate.Release(mergeSlot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+			t.Fatalf("Release() error = %v", err)
+		}
+	})
+}
+
 func TestSchedulersAllowOneMergeLanePerProject(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Allow the global dispatch gate to hold more than one pending project reservation so a waiting `Merging` lane reserves one slot without monopolizing all free global capacity.
- Add structured `dispatch_slot_wait` logs and state events for non-merge candidates that are eligible locally but waiting on the global gate.
- Cover the starvation scenario where `Rework` can dispatch while a higher-priority merge reservation remains pending.

Fixes #725

## Test Plan
- `go test ./internal/scheduler ./internal/orchestrator -run 'TestGlobalDispatchGate|TestDispatchReadyIssues(LogsMergeSlotDecisionAndStopsAfterGlobalWait|RecordsNonMergeSlotWaitTelemetry)' -count=1`
- `go test ./internal/scheduler ./internal/orchestrator -count=1`
- `make check`