### PR TITLE
feat(logging): add debug diagnostics

### DIFF
--- a/cmd/detent/slog.go
+++ b/cmd/detent/slog.go
@@ -4,6 +4,8 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
+	"runtime/debug"
 	"strings"
 	"time"
 
@@ -15,11 +17,12 @@ import (
 func setupLoggerFromEnv(stdout io.Writer, stderr io.Writer) *slog.Logger {
 	env, envSet := envValueWithPresence("ENV", "DETENT_ENV")
 	stdoutTTY := cli.WriterIsTTY(stdout)
-	return setupLoggerWithOutputs(env, envSet, envValue("LOG_LEVEL", "DETENT_LOG_LEVEL"), stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY))
+	addSource := logSourceSettingFromEnv()
+	return setupLoggerWithOutputsAndSource(env, envSet, envValue("LOG_LEVEL", "DETENT_LOG_LEVEL"), stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY), addSource)
 }
 
 func setupLoggerFromRuntime(settings cli.RuntimeSettings, stdout io.Writer, stderr io.Writer, stdoutTTY bool) {
-	setupLoggerWithOutputs(settings.Env.Value, strings.TrimSpace(settings.Env.Value) != "", settings.LogLevel.Value, stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY))
+	setupLoggerWithOutputsAndSource(settings.Env.Value, strings.TrimSpace(settings.Env.Value) != "", settings.LogLevel.Value, stdout, stderr, stdoutTTY, commandOutputJSONSelected(os.Args[1:], stdoutTTY), logSourceSettingFromEnv())
 }
 
 func setupLogger(env string, level string, w io.Writer) *slog.Logger {
@@ -27,11 +30,17 @@ func setupLogger(env string, level string, w io.Writer) *slog.Logger {
 }
 
 func setupLoggerWithOutputs(env string, envSet bool, level string, stdout io.Writer, stderr io.Writer, stdoutTTY bool, forceStderr bool) *slog.Logger {
+	return setupLoggerWithOutputsAndSource(env, envSet, level, stdout, stderr, stdoutTTY, forceStderr, logSourceSetting{})
+}
+
+func setupLoggerWithOutputsAndSource(env string, envSet bool, level string, stdout io.Writer, stderr io.Writer, stdoutTTY bool, forceStderr bool, addSource logSourceSetting) *slog.Logger {
 	w := stderr
 	if !forceStderr && useTextLogs(env, envSet, stdoutTTY) {
 		w = stdout
 	}
-	return setupLoggerForTerminal(env, envSet, level, w, stdoutTTY)
+	logger := slog.New(newLogHandlerForTerminalWithSource(env, envSet, level, w, stdoutTTY, addSource))
+	slog.SetDefault(logger)
+	return logger
 }
 
 func setupLoggerForTerminal(env string, envSet bool, level string, w io.Writer, stdoutTTY bool) *slog.Logger {
@@ -45,21 +54,29 @@ func newLogHandler(env string, level string, w io.Writer) slog.Handler {
 }
 
 func newLogHandlerForTerminal(env string, envSet bool, level string, w io.Writer, stdoutTTY bool) slog.Handler {
+	return newLogHandlerForTerminalWithSource(env, envSet, level, w, stdoutTTY, logSourceSetting{})
+}
+
+func newLogHandlerForTerminalWithSource(env string, envSet bool, level string, w io.Writer, stdoutTTY bool, addSource logSourceSetting) slog.Handler {
 	if w == nil {
 		w = io.Discard
 	}
 
 	logLevel := parseLogLevel(level)
+	source := addSource.enabled(logLevel)
 	if useTextLogs(env, envSet, stdoutTTY) {
 		return tint.NewHandler(w, &tint.Options{
-			Level:      logLevel,
-			TimeFormat: time.Kitchen,
-			AddSource:  logLevel == slog.LevelDebug,
+			Level:       logLevel,
+			TimeFormat:  time.Kitchen,
+			AddSource:   source,
+			ReplaceAttr: textLogReplaceAttr,
 		})
 	}
 
 	return slog.NewJSONHandler(w, &slog.HandlerOptions{
-		Level: logLevel,
+		Level:       logLevel,
+		AddSource:   source,
+		ReplaceAttr: sourceLogReplaceAttr,
 	})
 }
 
@@ -102,6 +119,110 @@ func parseLogLevel(level string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
+}
+
+type logSourceSetting struct {
+	value bool
+	set   bool
+}
+
+func (s logSourceSetting) enabled(level slog.Level) bool {
+	if s.set {
+		return s.value
+	}
+	return level == slog.LevelDebug
+}
+
+func logSourceSettingFromEnv() logSourceSetting {
+	value, ok := envValueWithPresence("LOG_ADD_SOURCE", "DETENT_LOG_ADD_SOURCE")
+	if !ok {
+		return logSourceSetting{}
+	}
+	return logSourceSetting{value: parseLogBool(value), set: true}
+}
+
+func parseLogBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "t", "true", "y", "yes", "on":
+		return true
+	default:
+		return false
+	}
+}
+
+func textLogReplaceAttr(groups []string, attr slog.Attr) slog.Attr {
+	attr = sourceLogReplaceAttr(groups, attr)
+	if err, ok := attr.Value.Any().(error); ok {
+		errAttr := tint.Err(err)
+		errAttr.Key = attr.Key
+		return errAttr
+	}
+	return attr
+}
+
+func sourceLogReplaceAttr(_ []string, attr slog.Attr) slog.Attr {
+	if attr.Key != slog.SourceKey {
+		return attr
+	}
+	source, ok := attr.Value.Any().(*slog.Source)
+	if !ok || source == nil {
+		return attr
+	}
+	copied := *source
+	copied.File = cleanSourcePath(copied.File)
+	return slog.Any(slog.SourceKey, &copied)
+}
+
+func cleanSourcePath(path string) string {
+	path = filepath.Clean(strings.TrimSpace(path))
+	if path == "." || path == "" {
+		return path
+	}
+	if rel, ok := relativeSourcePath(path, mustGetwdForLogSource()); ok {
+		return rel
+	}
+	if rel, ok := moduleRelativeSourcePath(path); ok {
+		return rel
+	}
+	return filepath.ToSlash(path)
+}
+
+func relativeSourcePath(path string, base string) (string, bool) {
+	if strings.TrimSpace(base) == "" {
+		return "", false
+	}
+	rel, err := filepath.Rel(base, path)
+	if err != nil || rel == "." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) || rel == ".." {
+		return "", false
+	}
+	return filepath.ToSlash(rel), true
+}
+
+func moduleRelativeSourcePath(path string) (string, bool) {
+	info, ok := debug.ReadBuildInfo()
+	if !ok || strings.TrimSpace(info.Main.Path) == "" {
+		return "", false
+	}
+	parts := strings.Split(strings.Trim(info.Main.Path, "/"), "/")
+	if len(parts) == 0 {
+		return "", false
+	}
+	module := parts[len(parts)-1]
+	normalized := filepath.ToSlash(path)
+	marker := "/" + module + "/"
+	index := strings.LastIndex(normalized, marker)
+	if index == -1 {
+		return "", false
+	}
+	return normalized[index+len(marker):], true
+}
+
+func mustGetwdForLogSource() string {
+	wd, err := os.Getwd()
+	if err != nil {
+		return string(filepath.Separator)
+	}
+	return wd
 }
 
 func isDevelopment(env string) bool {

--- a/cmd/detent/slog_test.go
+++ b/cmd/detent/slog_test.go
@@ -5,6 +5,8 @@ import (
 	"context"
 	"encoding/json"
 	"log/slog"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -104,6 +106,90 @@ func TestProductionLoggerWritesJSON(t *testing.T) {
 	}
 	if record["component"] != "test" {
 		t.Fatalf("component = %v, want test", record["component"])
+	}
+}
+
+func TestProductionDebugLoggerIncludesSourceByDefault(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	var out bytes.Buffer
+	logger := setupLogger("production", "debug", &out)
+	logger.Debug("ready")
+
+	var record map[string]any
+	if err := json.Unmarshal(out.Bytes(), &record); err != nil {
+		t.Fatalf("log output is not JSON: %v\n%s", err, out.String())
+	}
+	source, ok := record["source"].(map[string]any)
+	if !ok {
+		t.Fatalf("source = %#v, want object", record["source"])
+	}
+	file, ok := source["file"].(string)
+	if !ok || !strings.HasSuffix(file, "slog_test.go") {
+		t.Fatalf("source.file = %#v, want shortened slog_test.go path", source["file"])
+	}
+}
+
+func TestLogAddSourceEnablesInfoJSONSource(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	t.Setenv("ENV", "production")
+	t.Setenv("LOG_LEVEL", "info")
+	t.Setenv("LOG_ADD_SOURCE", "true")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	logger := setupLoggerFromEnv(&stdout, &stderr)
+	logger.Info("ready")
+
+	var record map[string]any
+	if err := json.Unmarshal(stderr.Bytes(), &record); err != nil {
+		t.Fatalf("stderr log output is not JSON: %v\n%s", err, stderr.String())
+	}
+	if _, ok := record["source"].(map[string]any); !ok {
+		t.Fatalf("source = %#v, want source object when LOG_ADD_SOURCE=true", record["source"])
+	}
+}
+
+func TestLogAddSourceFalseDisablesDebugJSONSource(t *testing.T) {
+	previous := slog.Default()
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+	t.Setenv("ENV", "production")
+	t.Setenv("LOG_LEVEL", "debug")
+	t.Setenv("LOG_ADD_SOURCE", "false")
+
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	logger := setupLoggerFromEnv(&stdout, &stderr)
+	logger.Debug("ready")
+
+	var record map[string]any
+	if err := json.Unmarshal(stderr.Bytes(), &record); err != nil {
+		t.Fatalf("stderr log output is not JSON: %v\n%s", err, stderr.String())
+	}
+	if _, ok := record["source"]; ok {
+		t.Fatalf("source = %#v, want omitted when LOG_ADD_SOURCE=false", record["source"])
+	}
+}
+
+func TestCleanSourcePathUsesWorkspaceRelativePath(t *testing.T) {
+	t.Parallel()
+
+	wd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd() error = %v", err)
+	}
+	path := filepath.Join(wd, "slog.go")
+
+	if got := cleanSourcePath(path); got != "slog.go" {
+		t.Fatalf("cleanSourcePath() = %q, want slog.go", got)
 	}
 }
 

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -627,8 +627,10 @@ func redirectDefaultLogger(path string, level string) (func(), error) {
 	}
 
 	previous := slog.Default()
+	logLevel := parseSlogLevel(level)
 	slog.SetDefault(slog.New(slog.NewJSONHandler(file, &slog.HandlerOptions{
-		Level: parseSlogLevel(level),
+		Level:     logLevel,
+		AddSource: runtimeLogAddSource(logLevel),
 	})))
 
 	return func() {
@@ -791,6 +793,32 @@ func parseSlogLevel(level string) slog.Level {
 		return slog.LevelError
 	default:
 		return slog.LevelInfo
+	}
+}
+
+func runtimeLogAddSource(level slog.Level) bool {
+	value, ok := lookupLogSourceEnv("LOG_ADD_SOURCE", "DETENT_LOG_ADD_SOURCE")
+	if ok {
+		return parseRuntimeLogBool(value)
+	}
+	return level == slog.LevelDebug
+}
+
+func lookupLogSourceEnv(keys ...string) (string, bool) {
+	for _, key := range keys {
+		if value, ok := os.LookupEnv(key); ok && strings.TrimSpace(value) != "" {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func parseRuntimeLogBool(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "t", "true", "y", "yes", "on":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -1978,6 +1978,7 @@ func (c *Connector) attachPullRequestsWithCache(ctx context.Context, issues []co
 			continue
 		}
 		if state, ok := c.currentPullRequestHydrationState(repo); ok {
+			c.logPullRequestHydrationSkip(ctx, repo, state, "shared_backoff")
 			markPullRequestHydrationUnavailableForCandidates(issues, byRepo[repo], repo, state)
 			continue
 		}
@@ -2137,6 +2138,7 @@ func (c *Connector) attachLinkedPullRequests(
 			pullRequestRepo = repo
 		}
 		if state, ok := c.currentPullRequestHydrationState(pullRequestRepo); ok {
+			c.logPullRequestHydrationSkip(ctx, pullRequestRepo, state, "linked_pull_request")
 			attachPullRequestHydrationUnavailableToIssue(&issues[candidate.Index], pullRequestRepo, candidate.PullRequestNumber, state)
 			continue
 		}
@@ -2398,9 +2400,11 @@ func pullRequestRepoName(repo pullRequestRepo) string {
 func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode, useStatusCache bool) error {
 	if useStatusCache && c.pullRequests != nil {
 		if status, ok := c.pullRequests.Get(repo, pullRequest.Number, pullRequest.HeadSHA); ok {
+			c.logPullRequestCache(ctx, repo, pullRequest, true, false, "")
 			applyPullRequestStatus(pullRequest, status)
 			return nil
 		}
+		c.logPullRequestCache(ctx, repo, pullRequest, false, false, "")
 	}
 
 	status := pullRequestStatus{}
@@ -2408,7 +2412,7 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 		ci, err := c.fetchPullRequestCI(ctx, repo, pullRequest.HeadSHA)
 		if err != nil {
 			state := c.pullRequestHydrationStateForError(repo, err)
-			if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, state) {
+			if c.applyCachedPullRequestStatusAfterThrottle(ctx, repo, pullRequest, state) {
 				return nil
 			}
 			return err
@@ -2418,7 +2422,7 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	reviews, err := c.fetchPullRequestReviews(ctx, repo, pullRequest.Number, pullRequest.HeadSHA)
 	if err != nil {
 		state := c.pullRequestHydrationStateForError(repo, err)
-		if c.applyCachedPullRequestStatusAfterThrottle(repo, pullRequest, state) {
+		if c.applyCachedPullRequestStatusAfterThrottle(ctx, repo, pullRequest, state) {
 			return nil
 		}
 		return err
@@ -2426,12 +2430,13 @@ func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequ
 	status.reviews = reviews
 	if c.pullRequests != nil {
 		c.pullRequests.Set(repo, pullRequest.Number, pullRequest.HeadSHA, status)
+		c.logPullRequestCache(ctx, repo, pullRequest, false, false, "stored")
 	}
 	applyPullRequestStatus(pullRequest, status)
 	return nil
 }
 
-func (c *Connector) applyCachedPullRequestStatusAfterThrottle(repo pullRequestRepo, pullRequest *pullRequestNode, state pullRequestHydrationState) bool {
+func (c *Connector) applyCachedPullRequestStatusAfterThrottle(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode, state pullRequestHydrationState) bool {
 	if c.pullRequests == nil || pullRequest == nil {
 		return false
 	}
@@ -2442,10 +2447,44 @@ func (c *Connector) applyCachedPullRequestStatusAfterThrottle(repo pullRequestRe
 	if !ok {
 		return false
 	}
+	c.logPullRequestCache(ctx, repo, pullRequest, true, true, state.Reason)
 	applyPullRequestStatus(pullRequest, status)
 	pullRequest.HydrationDegradedReason = connector.PullRequestHydrationReasonStaleCachedPullData
 	pullRequest.HydrationNextRetryAt = cloneGitHubTime(state.NextRetryAt)
 	return true
+}
+
+func (c *Connector) logPullRequestHydrationSkip(ctx context.Context, repo pullRequestRepo, state pullRequestHydrationState, purpose string) {
+	if c == nil || c.logger == nil {
+		return
+	}
+	c.logger.DebugContext(ctx, "github pull request hydration skipped",
+		"endpoint_family", "pull requests",
+		"request_purpose", "hydrate_pull_request",
+		"repository", pullRequestRepoName(repo),
+		"cache_hit", true,
+		"avoidable_request", true,
+		"backoff_reason", strings.TrimSpace(state.Reason),
+		"purpose", strings.TrimSpace(purpose),
+		"retry_at", state.NextRetryAt,
+	)
+}
+
+func (c *Connector) logPullRequestCache(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode, hit bool, staleFallback bool, reason string) {
+	if c == nil || c.logger == nil || pullRequest == nil {
+		return
+	}
+	c.logger.DebugContext(ctx, "github pull request status cache",
+		"endpoint_family", "pull_request_status_cache",
+		"request_purpose", "hydrate_pull_request_status",
+		"repository", pullRequestRepoName(repo),
+		"pr_number", pullRequest.Number,
+		"head_sha_known", strings.TrimSpace(pullRequest.HeadSHA) != "",
+		"cache_hit", hit,
+		"avoidable_request", hit,
+		"stale_fallback", staleFallback,
+		"backoff_reason", strings.TrimSpace(reason),
+	)
 }
 
 func applyPullRequestStatus(pullRequest *pullRequestNode, status pullRequestStatus) {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1,10 +1,12 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"reflect"
@@ -1383,6 +1385,50 @@ func TestCheckRunWorkflowRunIDs(t *testing.T) {
 	want := []int64{28196652213, 28196652214}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("checkRunWorkflowRunIDs() = %#v, want %#v", got, want)
+	}
+}
+
+func TestConnectorPullRequestStatusCacheDebugLog(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	var logs bytes.Buffer
+	c := &Connector{
+		pullRequests: newPullRequestStatusCache(time.Minute, func() time.Time { return now }),
+		logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	}
+	repo := pullRequestRepo{Owner: "digitaldrywood", Name: "detent"}
+	status := pullRequestStatus{
+		ci: pullRequestCI{
+			State:         "SUCCESS",
+			CheckRunCount: 2,
+		},
+	}
+	c.pullRequests.Set(repo, 726, "head-sha", status)
+	pullRequest := pullRequestNode{Number: 726, HeadSHA: "head-sha"}
+
+	if err := c.populatePullRequestStatus(context.Background(), repo, &pullRequest, true); err != nil {
+		t.Fatalf("populatePullRequestStatus() error = %v", err)
+	}
+
+	logText := logs.String()
+	for _, fragment := range []string{
+		"github pull request status cache",
+		"endpoint_family=pull_request_status_cache",
+		"request_purpose=hydrate_pull_request_status",
+		"repository=digitaldrywood/detent",
+		"pr_number=726",
+		"cache_hit=true",
+		"avoidable_request=true",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs missing %q:\n%s", fragment, logText)
+		}
+	}
+	if pullRequest.CI.CheckRunCount != 2 {
+		t.Fatalf("CheckRunCount = %d, want cached status", pullRequest.CI.CheckRunCount)
 	}
 }
 

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -154,7 +154,13 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 	req.Header.Set("X-GitHub-Api-Version", gitHubAPIVersion)
 
 	operation := firstLine(query)
-	c.logger.DebugContext(ctx, "github graphql request", "operation", operation, "live_connections", c.LiveConnections())
+	c.logger.DebugContext(ctx, "github graphql request",
+		"endpoint_family", "graphql",
+		"request_purpose", queryType,
+		"operation", operation,
+		"variables_present", len(variables) > 0,
+		"live_connections", c.LiveConnections(),
+	)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -169,7 +175,13 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 		}
 	}()
 
-	c.logger.DebugContext(ctx, "github graphql response", "operation", operation, "status", resp.StatusCode, "live_connections", c.LiveConnections())
+	c.logger.DebugContext(ctx, "github graphql response",
+		"endpoint_family", "graphql",
+		"request_purpose", queryType,
+		"operation", operation,
+		"status", resp.StatusCode,
+		"live_connections", c.LiveConnections(),
+	)
 
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -261,6 +273,14 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 		req.Header.Set("Content-Type", "application/json")
 	}
 
+	family := restEndpointFamily(method, path)
+	c.logger.DebugContext(ctx, "github rest probe request",
+		"method", strings.ToUpper(strings.TrimSpace(method)),
+		"path", path,
+		"endpoint_family", family,
+		"request_purpose", restRequestPurpose(method, path),
+		"body_present", body != nil,
+	)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -270,7 +290,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	}
 	defer func() {
 		if err := drainAndClose(resp.Body); err != nil {
-			c.logger.DebugContext(ctx, "github rest probe response body drain failed", "method", method, "path", path, "error", err)
+			c.logger.DebugContext(ctx, "github rest probe response body drain failed", "method", method, "path", path, "endpoint_family", family, "error", err)
 		}
 	}()
 
@@ -280,6 +300,13 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 	}
 	receivedAt := time.Now()
 	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt)
+	c.logger.DebugContext(ctx, "github rest probe response",
+		"method", strings.ToUpper(strings.TrimSpace(method)),
+		"path", path,
+		"endpoint_family", family,
+		"request_purpose", restRequestPurpose(method, path),
+		"status", resp.StatusCode,
+	)
 	result := restProbeResult{
 		StatusCode: resp.StatusCode,
 		Headers:    resp.Header.Clone(),
@@ -311,9 +338,24 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	backoffKey := c.restSharedBackoffKey(token)
 	c.rememberRESTBackoffKey(backoffKey)
 	if err := c.restBackoffError(backoffKey, time.Now()); err != nil {
+		c.logger.DebugContext(ctx, "github rest backoff active",
+			"method", strings.ToUpper(strings.TrimSpace(method)),
+			"path", path,
+			"endpoint_family", restEndpointFamily(method, path),
+			"request_purpose", restRequestPurpose(method, path),
+			"backoff_reason", restBackoffReason(err),
+			"retry_after_seconds", retryAfterSeconds(err),
+		)
 		return nil, err
 	}
 	if err := c.restBudgetPolicyError(method, path); err != nil {
+		c.logger.DebugContext(ctx, "github rest budget reserved",
+			"method", strings.ToUpper(strings.TrimSpace(method)),
+			"path", path,
+			"endpoint_family", restEndpointFamily(method, path),
+			"request_purpose", restRequestPurpose(method, path),
+			"backoff_reason", restBackoffReason(err),
+		)
 		return nil, err
 	}
 
@@ -341,7 +383,16 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		req.Header.Set("Content-Type", "application/json")
 	}
 
-	c.logger.DebugContext(ctx, "github rest request", "method", method, "path", path, "live_connections", c.LiveConnections())
+	family := restEndpointFamily(method, path)
+	purpose := restRequestPurpose(method, path)
+	c.logger.DebugContext(ctx, "github rest request",
+		"method", strings.ToUpper(strings.TrimSpace(method)),
+		"path", path,
+		"endpoint_family", family,
+		"request_purpose", purpose,
+		"body_present", body != nil,
+		"live_connections", c.LiveConnections(),
+	)
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
 		if ctxErr := ctx.Err(); ctxErr != nil {
@@ -351,11 +402,18 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	defer func() {
 		if err := drainAndClose(resp.Body); err != nil {
-			c.logger.DebugContext(ctx, "github rest response body drain failed", "method", method, "path", path, "error", err)
+			c.logger.DebugContext(ctx, "github rest response body drain failed", "method", method, "path", path, "endpoint_family", family, "error", err)
 		}
 	}()
 
-	c.logger.DebugContext(ctx, "github rest response", "method", method, "path", path, "status", resp.StatusCode, "live_connections", c.LiveConnections())
+	c.logger.DebugContext(ctx, "github rest response",
+		"method", strings.ToUpper(strings.TrimSpace(method)),
+		"path", path,
+		"endpoint_family", family,
+		"request_purpose", purpose,
+		"status", resp.StatusCode,
+		"live_connections", c.LiveConnections(),
+	)
 	raw, err := io.ReadAll(resp.Body)
 	if err != nil {
 		return nil, fmt.Errorf("%w: read response: %w", ErrTransient, err)
@@ -695,6 +753,16 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 		if c.restBackoffs != nil && backoffKey != "" {
 			c.restBackoffs.set(backoffKey, backoffUntil)
 		}
+		c.logger.Debug(
+			"github rest shared backoff recorded",
+			"method", strings.ToUpper(strings.TrimSpace(method)),
+			"path", path,
+			"endpoint_family", family,
+			"request_purpose", restRequestPurpose(method, path),
+			"backoff_reason", restRateLimitKindFromHeaders(status, headers),
+			"retry_after_seconds", int64(backoffUntil.Sub(now)/time.Second),
+			"remaining", remaining,
+		)
 	}
 }
 
@@ -1335,6 +1403,57 @@ func restEndpointFamily(method string, path string) string {
 	default:
 		return "other"
 	}
+}
+
+func restRequestPurpose(method string, path string) string {
+	family := restEndpointFamily(method, path)
+	switch family {
+	case "label issues":
+		return "fetch_issues_by_status_label"
+	case "issue reads":
+		return "hydrate_issue"
+	case "issue comments":
+		return "hydrate_issue_comments"
+	case "pull requests":
+		return "hydrate_pull_request"
+	case "reviews":
+		return "hydrate_pull_request_reviews"
+	case "check runs":
+		return "hydrate_pull_request_checks"
+	case "commit statuses":
+		return "hydrate_pull_request_statuses"
+	case "search":
+		return "search_issue_metadata"
+	case "mutations":
+		return "mutate_github_state"
+	default:
+		return strings.ReplaceAll(family, " ", "_")
+	}
+}
+
+func restBackoffReason(err error) string {
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) {
+		if strings.TrimSpace(statusErr.RateLimitKind) != "" {
+			return statusErr.RateLimitKind
+		}
+	}
+	switch {
+	case errors.Is(err, ErrRESTBudgetReserved):
+		return "rest_budget_reserved"
+	case errors.Is(err, ErrRateLimited):
+		return "rate_limited"
+	default:
+		return ""
+	}
+}
+
+func retryAfterSeconds(err error) int64 {
+	var statusErr *StatusError
+	if !errors.As(err, &statusErr) || statusErr.RetryAfter <= 0 {
+		return 0
+	}
+	return int64(statusErr.RetryAfter / time.Second)
 }
 
 func restFanoutEndpointFamily(family string) bool {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -1,13 +1,16 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"runtime"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -275,6 +278,57 @@ func TestClientRESTRefreshesTokenAfterAuthFailure(t *testing.T) {
 	}
 	if first, second := <-requests, <-requests; first != "Bearer stale-token" || second != "Bearer fresh-token" {
 		t.Fatalf("Authorization sequence = %q, %q; want stale then fresh", first, second)
+	}
+}
+
+func TestClientRESTDebugLogsEndpointPurposeWithoutSecrets(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/digitaldrywood/detent/commits/abc/check-runs" {
+			t.Fatalf("path = %s, want check-runs path", r.URL.Path)
+		}
+		if got := r.Header.Get("Authorization"); got != "Bearer super-secret-token" {
+			t.Fatalf("Authorization = %q, want bearer token", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"check_runs":[],"body_secret":"do-not-log-response-body"}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("super-secret-token"),
+		HTTPClient:  server.Client(),
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/commits/abc/check-runs", nil, nil); err != nil {
+		t.Fatalf("REST() error = %v", err)
+	}
+
+	logText := logs.String()
+	for _, fragment := range []string{
+		"github rest request",
+		"github rest response",
+		`endpoint_family="check runs"`,
+		"request_purpose=hydrate_pull_request_checks",
+		"body_present=false",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs missing %q:\n%s", fragment, logText)
+		}
+	}
+	for _, leaked := range []string{"super-secret-token", "do-not-log-response-body"} {
+		if strings.Contains(logText, leaked) {
+			t.Fatalf("logs leaked %q:\n%s", leaked, logText)
+		}
 	}
 }
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -94,6 +94,7 @@ type Connector struct {
 	projectCache      *projectCache
 	pullRequests      *pullRequestStatusCache
 	prHydration       *pullRequestHydrationCircuitBreaker
+	logger            *slog.Logger
 	mu                sync.RWMutex
 	writeMu           sync.Mutex
 	instanceLogin     string
@@ -134,6 +135,10 @@ func NewConnector(cfg Config) (*Connector, error) {
 	if err != nil {
 		return nil, err
 	}
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
 
 	statusField := strings.TrimSpace(cfg.StatusField)
 	if statusField == "" {
@@ -162,6 +167,7 @@ func NewConnector(cfg Config) (*Connector, error) {
 		projectCache:      newProjectCache(githubCacheTTL, cfg.Now),
 		pullRequests:      newPullRequestStatusCache(githubCacheTTL, cfg.Now),
 		prHydration:       newPullRequestHydrationCircuitBreaker(cfg.Now),
+		logger:            logger,
 	}, nil
 }
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -122,6 +122,11 @@ func NewConnector(cfg Config) (*Connector, error) {
 		})
 	}
 
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.Default()
+	}
+
 	client, err := NewClient(ClientConfig{
 		Endpoint:    cfg.Endpoint,
 		TokenSource: tokenSource,
@@ -130,14 +135,10 @@ func NewConnector(cfg Config) (*Connector, error) {
 			MinRemainingReserve: int64(cfg.RESTMinRemainingReserve),
 			FanoutMaxRequests:   int64(cfg.RESTFanoutMaxRequests),
 		},
-		Logger: cfg.Logger,
+		Logger: logger,
 	})
 	if err != nil {
 		return nil, err
-	}
-	logger := cfg.Logger
-	if logger == nil {
-		logger = slog.Default()
 	}
 
 	statusField := strings.TrimSpace(cfg.StatusField)

--- a/internal/connector/github/connector_test.go
+++ b/internal/connector/github/connector_test.go
@@ -1,12 +1,15 @@
 package github
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"strconv"
+	"strings"
 	"sync"
 	"sync/atomic"
 	"testing"
@@ -53,6 +56,51 @@ func TestConnectorAuthenticateValidatesViewerAndProject(t *testing.T) {
 	variables := payload["variables"].(map[string]any)
 	if variables["projectId"] != "PVT_1" {
 		t.Fatalf("projectId = %v, want PVT_1", variables["projectId"])
+	}
+}
+
+func TestConnectorUsesDefaultLoggerForClientDiagnostics(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/digitaldrywood/detent/commits/abc/check-runs" {
+			t.Fatalf("path = %s, want check-runs path", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"check_runs":[]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := NewConnector(Config{
+		Endpoint:   server.URL,
+		APIKey:     "token",
+		HTTPClient: server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+
+	if err := c.client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/commits/abc/check-runs", nil, nil); err != nil {
+		t.Fatalf("REST() error = %v", err)
+	}
+
+	logText := logs.String()
+	for _, fragment := range []string{
+		"github rest request",
+		"github rest response",
+		`endpoint_family="check runs"`,
+		"request_purpose=hydrate_pull_request_checks",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs missing %q:\n%s", fragment, logText)
+		}
 	}
 }
 

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -509,7 +509,7 @@ func TestDependencyAutoUnblockDoesNotChangeTodoDependencyGate(t *testing.T) {
 	}}
 
 	planner := newDispatchPlanner(cfg)
-	if _, ok := planner.dispatchAction(&state, issue, time.Date(2026, 6, 12, 16, 10, 0, 0, time.UTC)); ok {
+	if _, ok, _ := planner.dispatchAction(&state, issue, time.Date(2026, 6, 12, 16, 10, 0, 0, time.UTC)); ok {
 		t.Fatal("dispatchAction ok = true, want Todo issue blocked by dependency")
 	}
 	blocked, ok := state.Blocked[issue.ID]

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -1,0 +1,196 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+)
+
+const (
+	workerOutcomeSucceeded = "succeeded"
+	workerOutcomeFailed    = "failed"
+	workerOutcomeCancelled = "cancelled"
+	workerOutcomeTimedOut  = "timed_out"
+)
+
+func (o *Orchestrator) logDispatchPlanDecision(state *State, now time.Time, decision dispatchPlanDecision) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	result := "skipped"
+	reason := strings.TrimSpace(decision.SkipReason)
+	if decision.Selected {
+		result = "selected"
+		if reason == "" {
+			reason = "selected"
+		}
+	}
+	attrs := o.schedulerDecisionAttrs(state, now, decision.Issue,
+		"result", result,
+		"skip_reason", reason,
+		"queue_position", decision.QueuePosition,
+		"retry", decision.Retry,
+		"attempt", decision.Attempt,
+		"worker_host", strings.TrimSpace(decision.WorkerHost),
+	)
+	o.logger.Debug("scheduler_dispatch_decision", attrs...)
+}
+
+func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome string, decision scheduler.DispatchGateDecision, projectStats projectStateSlotStats) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	reason := strings.TrimSpace(decision.Reason)
+	if reason == "" {
+		reason = "slot_" + strings.TrimSpace(outcome)
+	}
+	attrs := o.issueLogAttrs(issue,
+		"outcome", strings.TrimSpace(outcome),
+		"reason", reason,
+		"project_id", strings.TrimSpace(o.cfg.Project.ID),
+		"project_weight", o.cfg.Project.Weight,
+		"project_priority", o.cfg.Project.Priority,
+		"global_capacity", decision.GlobalCapacity,
+		"global_used", decision.GlobalUsed,
+		"global_available", decision.GlobalAvailable,
+		"project_state_capacity", projectStats.capacity,
+		"project_state_used", projectStats.used,
+		"project_state_available", projectStats.available,
+		"selected_project_id", strings.TrimSpace(decision.SelectedProjectID),
+		"selected_state", strings.TrimSpace(decision.SelectedState),
+		"lower_priority_running", decision.LowerPriorityRunning,
+		"ready_projects", decision.ReadyProjects,
+		"running_projects", decision.RunningProjects,
+	)
+	o.logger.Debug("scheduler_dispatch_slot_decision", attrs...)
+}
+
+func (o *Orchestrator) logWorkerLifecycle(issue connector.Issue, event string, attrs ...any) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	all := o.issueLogAttrs(issue, "event", strings.TrimSpace(event))
+	all = append(all, attrs...)
+	o.logger.Debug(strings.TrimSpace(event), all...)
+}
+
+func (o *Orchestrator) schedulerDecisionAttrs(state *State, now time.Time, issue connector.Issue, attrs ...any) []any {
+	projectStats := o.projectStateSlotStats(issue, state)
+	globalCapacity := o.cfg.MaxConcurrentAgents
+	globalUsed := 0
+	if state != nil {
+		globalUsed = len(state.Running)
+	}
+	globalAvailable := globalCapacity - globalUsed
+	if globalAvailable < 0 {
+		globalAvailable = 0
+	}
+	all := o.issueLogAttrs(issue,
+		"lane", normalizeState(issue.State),
+		"project_id", strings.TrimSpace(o.cfg.Project.ID),
+		"project_weight", o.cfg.Project.Weight,
+		"project_priority", o.cfg.Project.Priority,
+		"project_state_capacity", projectStats.capacity,
+		"project_state_used", projectStats.used,
+		"project_state_available", projectStats.available,
+		"global_capacity", globalCapacity,
+		"global_used", globalUsed,
+		"global_available", globalAvailable,
+	)
+	all = append(all, snapshotAgeAttrs(issue, now)...)
+	all = append(all, pullRequestDiagnosticAttrs(issue, now)...)
+	all = append(all, attrs...)
+	return all
+}
+
+func (o *Orchestrator) issueLogAttrs(issue connector.Issue, attrs ...any) []any {
+	all := []any{
+		"issue_id", strings.TrimSpace(issue.ID),
+		"issue_identifier", strings.TrimSpace(issue.Identifier),
+		"issue_repo", issueRepository(issue),
+		"issue_state", strings.TrimSpace(issue.State),
+	}
+	all = append(all, attrs...)
+	return all
+}
+
+func snapshotAgeAttrs(issue connector.Issue, now time.Time) []any {
+	attrs := make([]any, 0, 4)
+	if !now.IsZero() {
+		if issue.UpdatedAt != nil && !issue.UpdatedAt.IsZero() {
+			attrs = append(attrs, "snapshot_age_seconds", int64(now.Sub(*issue.UpdatedAt)/time.Second))
+		}
+		if issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() {
+			attrs = append(attrs, "stage_snapshot_age_seconds", int64(now.Sub(*issue.StageUpdatedAt)/time.Second))
+		}
+	}
+	attrs = append(attrs,
+		"snapshot_known", issue.UpdatedAt != nil && !issue.UpdatedAt.IsZero(),
+		"stage_snapshot_known", issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero(),
+	)
+	return attrs
+}
+
+func pullRequestDiagnosticAttrs(issue connector.Issue, now time.Time) []any {
+	pr := issue.PullRequest
+	if pr == nil {
+		return []any{"pull_request_known", false}
+	}
+	attrs := []any{
+		"pull_request_known", true,
+		"pr_number", pr.Number,
+		"pr_state", strings.TrimSpace(pr.State),
+		"pr_mergeable_state", strings.TrimSpace(pr.MergeableState),
+		"pr_draft", pr.Draft,
+		"pr_head_sha_known", strings.TrimSpace(pr.HeadSHA) != "",
+		"pr_ci_status", strings.TrimSpace(pr.CIStatus),
+		"pr_check_run_count", pr.CheckRunCount,
+		"pr_status_context_count", pr.StatusContextCount,
+		"pr_running_check_count", len(pr.RunningChecks),
+		"pr_slow_check_count", len(pr.SlowChecks),
+		"pr_codex_review_state", strings.TrimSpace(pr.CodexReviewState),
+		"pr_latest_codex_review_state", strings.TrimSpace(pr.LatestCodexReviewState),
+		"pr_hydration_unavailable_reason", strings.TrimSpace(pr.HydrationUnavailableReason),
+		"pr_hydration_degraded_reason", strings.TrimSpace(pr.HydrationDegradedReason),
+	}
+	if pr.HydrationNextRetryAt != nil && !pr.HydrationNextRetryAt.IsZero() && !now.IsZero() {
+		attrs = append(attrs, "pr_hydration_next_retry_seconds", int64(pr.HydrationNextRetryAt.Sub(now)/time.Second))
+	}
+	return attrs
+}
+
+func issueRepository(issue connector.Issue) string {
+	if repo := strings.TrimSpace(issue.PRRepository); repo != "" {
+		return repo
+	}
+	if repo, _, ok := strings.Cut(strings.TrimSpace(issue.Identifier), "#"); ok && strings.Contains(repo, "/") {
+		return repo
+	}
+	if parsed, err := url.Parse(strings.TrimSpace(issue.URL)); err == nil {
+		parts := strings.Split(strings.Trim(parsed.Path, "/"), "/")
+		if len(parts) >= 2 {
+			return parts[0] + "/" + parts[1]
+		}
+	}
+	return ""
+}
+
+func workerOutcome(err error, finalState string) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return workerOutcomeCancelled
+	case errors.Is(err, context.DeadlineExceeded):
+		return workerOutcomeTimedOut
+	case err != nil:
+		return workerOutcomeFailed
+	case strings.EqualFold(strings.TrimSpace(finalState), FinalStateCompleted), strings.TrimSpace(finalState) == "":
+		return workerOutcomeSucceeded
+	default:
+		return strings.TrimSpace(finalState)
+	}
+}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -21,6 +21,7 @@ type dispatchPlanHooks struct {
 	dispatchFailed          func(connector.Issue) bool
 	retryDispatchFailed     func(connector.Issue, Retry)
 	preserveMissingDueRetry func(Retry) bool
+	decision                func(dispatchPlanDecision)
 }
 
 type dispatchAction struct {
@@ -28,6 +29,16 @@ type dispatchAction struct {
 	attempt    int
 	workerHost string
 	retry      bool
+}
+
+type dispatchPlanDecision struct {
+	Issue         connector.Issue
+	QueuePosition int
+	Attempt       int
+	WorkerHost    string
+	Retry         bool
+	Selected      bool
+	SkipReason    string
 }
 
 func newDispatchPlanner(cfg Config) dispatchPlanner {
@@ -49,12 +60,29 @@ func (p dispatchPlanner) plan(
 
 	plan := DispatchPlan{}
 	continuations := 0
-	for _, issue := range plannedCandidates {
+	for index, issue := range plannedCandidates {
+		queuePosition := index + 1
 		if retry, ok := dueRetries[issue.ID]; ok {
-			action, ok := p.retryAction(state, issue, retry, now)
+			action, ok, reason := p.retryAction(state, issue, retry, now)
 			if !ok {
+				p.logDecision(hooks, dispatchPlanDecision{
+					Issue:         issue,
+					QueuePosition: queuePosition,
+					Attempt:       retry.Attempt,
+					WorkerHost:    retry.WorkerHost,
+					Retry:         true,
+					SkipReason:    reason,
+				})
 				continue
 			}
+			p.logDecision(hooks, dispatchPlanDecision{
+				Issue:         action.issue,
+				QueuePosition: queuePosition,
+				Attempt:       action.attempt,
+				WorkerHost:    action.workerHost,
+				Retry:         true,
+				Selected:      true,
+			})
 			if p.applyDispatchAction(state, action, now, hooks) {
 				plan.Dispatches = append(plan.Dispatches, action.decision())
 			} else if hooks.retryDispatchFailed != nil {
@@ -63,17 +91,32 @@ func (p dispatchPlanner) plan(
 			continue
 		}
 		if availableSlots(state) == 0 {
+			p.logDecision(hooks, dispatchPlanDecision{
+				Issue:         issue,
+				QueuePosition: queuePosition,
+				SkipReason:    dispatchSkipGlobalCapacityFull,
+			})
 			break
 		}
 		if hooks.hydrate != nil {
 			var ok bool
 			issue, ok = hooks.hydrate(issue)
 			if !ok {
+				p.logDecision(hooks, dispatchPlanDecision{
+					Issue:         issue,
+					QueuePosition: queuePosition,
+					SkipReason:    dispatchSkipHydrationFailed,
+				})
 				continue
 			}
 		}
-		action, ok := p.dispatchAction(state, issue, now)
+		action, ok, reason := p.dispatchAction(state, issue, now)
 		if !ok {
+			p.logDecision(hooks, dispatchPlanDecision{
+				Issue:         issue,
+				QueuePosition: queuePosition,
+				SkipReason:    reason,
+			})
 			continue
 		}
 		continuationIndex := -1
@@ -82,8 +125,24 @@ func (p dispatchPlanner) plan(
 			continuations++
 		}
 		if hooks.beforeDispatch != nil && !hooks.beforeDispatch(action.issue, continuationIndex) {
+			p.logDecision(hooks, dispatchPlanDecision{
+				Issue:         action.issue,
+				QueuePosition: queuePosition,
+				Attempt:       action.attempt,
+				WorkerHost:    action.workerHost,
+				Retry:         action.retry,
+				SkipReason:    dispatchSkipDispatchBackoffCancelled,
+			})
 			break
 		}
+		p.logDecision(hooks, dispatchPlanDecision{
+			Issue:         action.issue,
+			QueuePosition: queuePosition,
+			Attempt:       action.attempt,
+			WorkerHost:    action.workerHost,
+			Retry:         action.retry,
+			Selected:      true,
+		})
 		if p.applyDispatchAction(state, action, now, hooks) {
 			plan.Dispatches = append(plan.Dispatches, action.decision())
 		} else if hooks.dispatchFailed != nil && !hooks.dispatchFailed(action.issue) {
@@ -96,6 +155,12 @@ func (p dispatchPlanner) plan(
 	plan.BudgetRefusals = budgetRefusalIDs(state.BudgetRefusals)
 	plan.Retry = retryIDs(state.Retry)
 	return plan
+}
+
+func (p dispatchPlanner) logDecision(hooks dispatchPlanHooks, decision dispatchPlanDecision) {
+	if hooks.decision != nil {
+		hooks.decision(decision)
+	}
 }
 
 func (p dispatchPlanner) applyDispatchAction(
@@ -116,32 +181,38 @@ func (p dispatchPlanner) retryAction(
 	issue connector.Issue,
 	retry Retry,
 	now time.Time,
-) (dispatchAction, bool) {
+) (dispatchAction, bool, string) {
 	delete(state.Retry, retry.Issue.ID)
 
-	if !p.dispatchableForRetry(issue, state, now, retry.WorkerHost) {
+	decision := p.dispatchableIssueDecision(issue, state, true, now, retry.WorkerHost)
+	if !decision.dispatchable {
 		if p.budgetCooldownActive(state, issue.ID, now) {
 			p.scheduleRetry(state, issue, retry.Attempt, now, "budget cooldown active", false, retry.WorkerHost)
-			return dispatchAction{}, false
+			return dispatchAction{}, false, decision.reason
 		}
 		if !p.slotsAvailable(issue, state, retry.WorkerHost) {
 			p.scheduleRetry(state, issue, retry.Attempt, now, "no available orchestrator slots", false, retry.WorkerHost)
-			return dispatchAction{}, false
+			return dispatchAction{}, false, decision.reason
 		}
 		if _, blocked := state.Blocked[issue.ID]; blocked {
 			p.releaseClaim(state, issue.ID)
-			return dispatchAction{}, false
+			return dispatchAction{}, false, decision.reason
 		}
 
 		p.releaseIssue(state, issue.ID)
-		return dispatchAction{}, false
+		return dispatchAction{}, false, decision.reason
 	}
 
-	return p.newDispatchAction(state, issue, retry.Attempt, retry.WorkerHost, true)
+	action, ok := p.newDispatchAction(state, issue, retry.Attempt, retry.WorkerHost, true)
+	if !ok {
+		return dispatchAction{}, false, dispatchSkipWorkerHostUnavailable
+	}
+	return action, true, ""
 }
 
-func (p dispatchPlanner) dispatchAction(state *State, issue connector.Issue, now time.Time) (dispatchAction, bool) {
-	if !p.dispatchable(issue, state, now) {
+func (p dispatchPlanner) dispatchAction(state *State, issue connector.Issue, now time.Time) (dispatchAction, bool, string) {
+	decision := p.dispatchableIssueDecision(issue, state, false, now, "")
+	if !decision.dispatchable {
 		if todoBlockedByNonTerminal(issue, p.cfg.TerminalStates) {
 			state.Blocked[issue.ID] = Blocked{
 				Issue:     cloneIssue(issue),
@@ -150,10 +221,14 @@ func (p dispatchPlanner) dispatchAction(state *State, issue connector.Issue, now
 				Source:    BlockedSourceDependency,
 			}
 		}
-		return dispatchAction{}, false
+		return dispatchAction{}, false, decision.reason
 	}
 
-	return p.newDispatchAction(state, issue, 0, "", false)
+	action, ok := p.newDispatchAction(state, issue, 0, "", false)
+	if !ok {
+		return dispatchAction{}, false, dispatchSkipWorkerHostUnavailable
+	}
+	return action, true, ""
 }
 
 func (p dispatchPlanner) newDispatchAction(
@@ -299,15 +374,6 @@ func (p dispatchPlanner) dispatchable(issue connector.Issue, state *State, now t
 	return p.dispatchableIssue(issue, state, false, now, "")
 }
 
-func (p dispatchPlanner) dispatchableForRetry(
-	issue connector.Issue,
-	state *State,
-	now time.Time,
-	preferredWorkerHost string,
-) bool {
-	return p.dispatchableIssue(issue, state, true, now, preferredWorkerHost)
-}
-
 func (p dispatchPlanner) dispatchableIssue(
 	issue connector.Issue,
 	state *State,
@@ -315,38 +381,77 @@ func (p dispatchPlanner) dispatchableIssue(
 	now time.Time,
 	preferredWorkerHost string,
 ) bool {
+	return p.dispatchableIssueDecision(issue, state, allowClaimed, now, preferredWorkerHost).dispatchable
+}
+
+type dispatchableDecision struct {
+	dispatchable bool
+	reason       string
+}
+
+const (
+	dispatchSkipInvalidCandidate         = "invalid_candidate"
+	dispatchSkipInactiveState            = "inactive_state"
+	dispatchSkipTerminalState            = "terminal_state"
+	dispatchSkipPullRequestHydration     = "pull_request_hydration_unavailable"
+	dispatchSkipDuplicatePullRequest     = "duplicate_pull_request_work"
+	dispatchSkipUnauthorized             = "unauthorized"
+	dispatchSkipBlockedByDependency      = "blocked_by_dependency"
+	dispatchSkipAlreadyRunning           = "already_running"
+	dispatchSkipAlreadyClaimed           = "already_claimed"
+	dispatchSkipBlocked                  = "blocked"
+	dispatchSkipBudgetCooldown           = "budget_cooldown"
+	dispatchSkipLocalSlotUnavailable     = "local_slot_unavailable"
+	dispatchSkipWorkerHostUnavailable    = "worker_host_unavailable"
+	dispatchSkipGlobalCapacityFull       = "global_capacity_full"
+	dispatchSkipHydrationFailed          = "hydrate_failed"
+	dispatchSkipDispatchBackoffCancelled = "dispatch_backoff_cancelled"
+)
+
+func (p dispatchPlanner) dispatchableIssueDecision(
+	issue connector.Issue,
+	state *State,
+	allowClaimed bool,
+	now time.Time,
+	preferredWorkerHost string,
+) dispatchableDecision {
 	if !validCandidate(issue) {
-		return false
+		return dispatchableDecision{reason: dispatchSkipInvalidCandidate}
 	}
-	if !stateIn(issue.State, p.cfg.ActiveStates) || stateIn(issue.State, p.cfg.TerminalStates) {
-		return false
+	if !stateIn(issue.State, p.cfg.ActiveStates) {
+		return dispatchableDecision{reason: dispatchSkipInactiveState}
+	}
+	if stateIn(issue.State, p.cfg.TerminalStates) {
+		return dispatchableDecision{reason: dispatchSkipTerminalState}
 	}
 	if pullRequestHydrationBlocksDispatch(issue) {
-		return false
+		return dispatchableDecision{reason: dispatchSkipPullRequestHydration}
 	}
 	if duplicatePullRequestWork(issue) {
-		return false
+		return dispatchableDecision{reason: dispatchSkipDuplicatePullRequest}
 	}
 	if !p.authorized(issue) {
-		return false
+		return dispatchableDecision{reason: dispatchSkipUnauthorized}
 	}
 	if todoBlockedByNonTerminal(issue, p.cfg.TerminalStates) {
-		return false
+		return dispatchableDecision{reason: dispatchSkipBlockedByDependency}
 	}
 	if _, ok := state.Running[issue.ID]; ok {
-		return false
+		return dispatchableDecision{reason: dispatchSkipAlreadyRunning}
 	}
 	if _, ok := state.Claimed[issue.ID]; ok && !allowClaimed {
-		return false
+		return dispatchableDecision{reason: dispatchSkipAlreadyClaimed}
 	}
 	if _, ok := state.Blocked[issue.ID]; ok {
-		return false
+		return dispatchableDecision{reason: dispatchSkipBlocked}
 	}
 	if p.budgetCooldownActive(state, issue.ID, now) {
-		return false
+		return dispatchableDecision{reason: dispatchSkipBudgetCooldown}
 	}
-
-	return p.slotsAvailable(issue, state, preferredWorkerHost)
+	if !p.slotsAvailable(issue, state, preferredWorkerHost) {
+		return dispatchableDecision{reason: dispatchSkipLocalSlotUnavailable}
+	}
+	return dispatchableDecision{dispatchable: true}
 }
 
 func pullRequestHydrationBlocksDispatch(issue connector.Issue) bool {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1016,6 +1016,76 @@ func TestDispatchReadyIssuesHydratesLightweightCandidateBeforeDependencyGate(t *
 	}
 }
 
+func TestDispatchReadyIssuesLogsDebugDecisionAndWorkerLifecycle(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 2,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done"},
+		Project:             scheduler.ProjectCandidate{ID: "detent", Weight: 2, Priority: 10},
+	})
+	runner := newWorkerHostRunner()
+	var logs strings.Builder
+	orch := Orchestrator{
+		cfg:        cfg,
+		connector:  hydratingDispatchConnector{},
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+		logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	}
+	state := newState(cfg)
+	running := dispatchTestIssueWithPullRequest("issue-running", "In Progress", "OPEN")
+	running.Fields = map[string]string{"Status": "In Progress"}
+	running.PullRequest.CIStatus = "pass"
+	running.PullRequest.CheckRunCount = 3
+	state.Running[running.ID] = Running{Issue: running, StartedAt: now.Add(-time.Minute)}
+	selected := dispatchTestIssue("issue-selected", "Todo")
+	selected.Fields = map[string]string{"Status": "Todo"}
+	selected.UpdatedAt = timePointer(now.Add(-2 * time.Minute))
+
+	ctx := t.Context()
+	orch.dispatchReadyIssues(ctx, &state, []connector.Issue{running, selected}, now)
+
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.Issue.ID != selected.ID {
+		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, selected.ID)
+	}
+	if state.Running[selected.ID].cancel == nil {
+		t.Fatalf("Running[%q].cancel = nil, want cancellation hook", selected.ID)
+	}
+	state.Running[selected.ID].cancel()
+	orch.handleRunResult(ctx, &state, runpkg.Completion{
+		IssueID:     selected.ID,
+		Request:     request,
+		Err:         context.Canceled,
+		CompletedAt: now.Add(time.Second),
+	})
+
+	logText := logs.String()
+	for _, fragment := range []string{
+		"scheduler_dispatch_decision",
+		"skip_reason=already_running",
+		"result=selected",
+		"queue_position=2",
+		"pr_ci_status=pass",
+		"pr_check_run_count=3",
+		"scheduler_dispatch_slot_decision",
+		"outcome=acquired",
+		"worker_slot_acquired",
+		"worker_attempt_started",
+		"worker_capacity_released",
+		"worker_cancelled",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs missing %q:\n%s", fragment, logText)
+		}
+	}
+}
+
 func TestDispatchReadyIssuesStaggersContinuationDispatches(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1376,6 +1376,9 @@ func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, is
 		preserveMissingDueRetry: func(retry Retry) bool {
 			return o.preserveMissingDueRetry(state, retry)
 		},
+		decision: func(decision dispatchPlanDecision) {
+			o.logDispatchPlanDecision(state, now, decision)
+		},
 	})
 }
 
@@ -1493,6 +1496,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 
 	globalSlot, ok, decision := o.acquireGlobalDispatchSlot(ctx, slotIssue, workerHost, now)
 	if !ok {
+		o.logSchedulerSlotDecision(issue, "waiting", decision, projectStats)
 		if mergeWorkerIssue(issue) {
 			o.logMergeWorkerSlotWait(issue, decision, projectStats)
 		} else {
@@ -1502,11 +1506,21 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		return dispatchIssueOutcome{reason: dispatchIssueFailureGlobalSlotUnavailable}
 	}
 	mergeTiming := o.markMergeWorkerSlotAcquired(state, issue, now)
+	o.logSchedulerSlotDecision(issue, "acquired", decision, projectStats)
 	o.logMergeWorkerSlotAcquired(issue, decision, projectStats, mergeTiming)
+	o.logWorkerLifecycle(issue, "worker_slot_acquired",
+		"attempt", attempt,
+		"worker_host", strings.TrimSpace(workerHost),
+	)
 
 	claimedIssue, claim, ok := o.claimIssue(ctx, issue, now)
 	if !ok {
 		o.releaseGlobalDispatchSlot(globalSlot)
+		o.logWorkerLifecycle(issue, "worker_capacity_released",
+			"attempt", attempt,
+			"worker_host", strings.TrimSpace(workerHost),
+			"reason", dispatchIssueFailureClaimFailed,
+		)
 		o.logMergeWorkerFailure(issue, "claim_failed", nil)
 		o.recordMergeFailed(state, issue, now, "claim_failed", nil)
 		return dispatchIssueOutcome{reason: dispatchIssueFailureClaimFailed}
@@ -1516,6 +1530,11 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	if targetState != "" {
 		if err := o.updateIssueState(ctx, issue, targetState, now, "dispatch_start"); err != nil {
 			o.releaseGlobalDispatchSlot(globalSlot)
+			o.logWorkerLifecycle(issue, "worker_capacity_released",
+				"attempt", attempt,
+				"worker_host", strings.TrimSpace(workerHost),
+				"reason", dispatchIssueFailureStartStateTransition,
+			)
 			if abandonErr := o.abandonClaim(ctx, issue.ID); abandonErr != nil && o.logger != nil {
 				o.logger.Warn("abandon claim after start state transition failed", "issue_id", issue.ID, "error", abandonErr)
 			}
@@ -1557,6 +1576,11 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		OnUsageUpdate:   o.usageUpdateHandler(runCtx, issue.ID),
 	}
 	o.logMergeWorkerAttempt(issue, attempt, workerHost)
+	o.logWorkerLifecycle(issue, "worker_attempt_started",
+		"attempt", attempt,
+		"worker_host", strings.TrimSpace(workerHost),
+		"mode", strings.TrimSpace(runMode),
+	)
 	o.supervisor.Dispatch(runCtx, request, o.runResults)
 	return dispatchIssueOutcome{dispatched: true}
 }
@@ -1771,6 +1795,11 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 	o.releaseGlobalDispatchSlot(running.globalSlot)
+	o.logWorkerLifecycle(running.Issue, "worker_capacity_released",
+		"attempt", running.Attempt,
+		"worker_host", strings.TrimSpace(running.WorkerHost),
+		"reason", "run_completed",
+	)
 	running.globalSlot = scheduler.Slot{}
 	if running.cancel != nil {
 		running.cancel()
@@ -1785,6 +1814,11 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		if diffStatsPresent(event.Result.DiffStats) {
 			running.DiffStats = event.Result.DiffStats
 		}
+		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
+			"attempt", running.Attempt,
+			"worker_host", strings.TrimSpace(running.WorkerHost),
+			"final_state", strings.TrimSpace(running.Issue.State),
+		)
 		o.completeTerminalRunning(context.Background(), state, event.IssueID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, event.CompletedAt), tokens)
 		if event.Result.RateLimits != nil {
 			state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
@@ -1793,6 +1827,13 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 
 	if event.Err != nil {
+		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
+			"attempt", running.Attempt,
+			"worker_host", strings.TrimSpace(running.WorkerHost),
+			"retry_attempt", event.RetryAttempt,
+			"retry_delay_seconds", int64(event.RetryDelay/time.Second),
+			"error", event.Err,
+		)
 		if mergeWorkerIssue(running.Issue) {
 			o.logMergeWorkerFailure(running.Issue, "runner_failed", event.Err)
 			o.recordMergeFailed(state, running.Issue, event.CompletedAt, "runner_failed", event.Err)
@@ -1823,6 +1864,12 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 
 	if event.Request.Mode == runpkg.RunModePlan {
+		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
+			"attempt", running.Attempt,
+			"worker_host", strings.TrimSpace(running.WorkerHost),
+			"mode", strings.TrimSpace(event.Request.Mode),
+			"final_state", strings.TrimSpace(event.Result.FinalState),
+		)
 		o.completePlanRunning(ctx, state, event, running)
 		return
 	}
@@ -1843,6 +1890,12 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if finalState == "" {
 		finalState = FinalStateCompleted
 	}
+	o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(nil, finalState),
+		"attempt", running.Attempt,
+		"worker_host", strings.TrimSpace(running.WorkerHost),
+		"mode", strings.TrimSpace(event.Request.Mode),
+		"final_state", strings.TrimSpace(finalState),
+	)
 
 	state.Completed[event.IssueID] = Completed{
 		Issue:       cloneIssue(running.Issue),

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -287,14 +287,22 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	workflow, agentRuntime := r.runtimeSnapshot()
 
 	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
+	r.logWorkerEvent(req.Issue, "worker_workspace_create_started")
 	info, err := r.workspace.Create(ctx, workspaceIssue)
 	if err != nil {
 		return RunResult{}, fmt.Errorf("create workspace: %w", err)
 	}
+	r.logWorkerEvent(req.Issue, "worker_workspace_created",
+		"workspace_path", info.Path,
+		"workspace_branch", info.Branch,
+	)
 
 	if err := r.workspace.BeforeRun(ctx, info, workspaceIssue); err != nil {
 		return RunResult{}, fmt.Errorf("workspace before_run: %w", err)
 	}
+	r.logWorkerEvent(req.Issue, "worker_before_run_finished",
+		"workspace_path", info.Path,
+	)
 
 	afterRunPending := true
 	defer func() {
@@ -335,6 +343,14 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return RunResult{}, err
 	}
 
+	r.logWorkerEvent(req.Issue, "worker_command_started",
+		"workspace_path", info.Path,
+		"backend_id", selection.BackendID,
+		"route", selection.RouteName,
+		"role", RoleCode,
+		"model", model,
+		"mode", normalizeRunMode(req.Mode),
+	)
 	result := RunResult{FinalState: FinalStateCompleted}
 	progress := newAgentRunProgress()
 	turnResult, turnErr := backend.RunTurn(ctx, AgentTurnRequest{
@@ -345,6 +361,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		TurnSandboxPolicy: backendConfig.Options.TurnSandboxPolicy,
 		Model:             model,
 	}, func(update AgentUpdate) error {
+		r.logAgentUpdate(req.Issue, update)
 		applyAgentUpdate(&result, update)
 		eventAt := r.now()
 		progress.apply(update, eventAt)
@@ -355,9 +372,21 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	})
 	_ = turnResult
 	result.Output = progress.outputText()
+	r.logWorkerEvent(req.Issue, "worker_command_finished",
+		"workspace_path", info.Path,
+		"backend_id", selection.BackendID,
+		"route", selection.RouteName,
+		"role", RoleCode,
+		"model", model,
+		"outcome", workerRunOutcome(turnErr, result.FinalState),
+		"error", errorString(turnErr),
+	)
 
 	r.afterRun(info, workspaceIssue)
 	afterRunPending = false
+	r.logWorkerEvent(req.Issue, "worker_after_run_finished",
+		"workspace_path", info.Path,
+	)
 
 	if turnErr != nil {
 		result.FinalState = FinalStateFailed
@@ -412,14 +441,22 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	workflow, agentRuntime := r.runtimeSnapshot()
 
 	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
+	r.logWorkerEvent(req.Issue, "worker_check_workspace_create_started")
 	info, err := r.workspace.Create(ctx, workspaceIssue)
 	if err != nil {
 		return gate.ValidatorResult{}, fmt.Errorf("create workspace: %w", err)
 	}
+	r.logWorkerEvent(req.Issue, "worker_check_workspace_created",
+		"workspace_path", info.Path,
+		"workspace_branch", info.Branch,
+	)
 
 	if err := r.workspace.BeforeRun(ctx, info, workspaceIssue); err != nil {
 		return gate.ValidatorResult{}, fmt.Errorf("workspace before_run: %w", err)
 	}
+	r.logWorkerEvent(req.Issue, "worker_check_before_run_finished",
+		"workspace_path", info.Path,
+	)
 
 	afterRunPending := true
 	defer func() {
@@ -452,6 +489,13 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		return gate.ValidatorResult{}, err
 	}
 
+	r.logWorkerEvent(req.Issue, "worker_check_started",
+		"workspace_path", info.Path,
+		"backend_id", selection.BackendID,
+		"route", selection.RouteName,
+		"role", RoleValidator,
+		"model", model,
+	)
 	runReq := RunRequest{
 		Issue:           req.Issue,
 		StartedAt:       req.StartedAt,
@@ -469,6 +513,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		TurnSandboxPolicy: backendConfig.Options.TurnSandboxPolicy,
 		Model:             model,
 	}, func(update AgentUpdate) error {
+		r.logAgentUpdate(req.Issue, update)
 		if update.Type == AgentUpdateMessageDelta {
 			output.WriteString(update.Delta)
 		}
@@ -481,9 +526,21 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		return nil
 	})
 	_ = turnResult
+	r.logWorkerEvent(req.Issue, "worker_check_finished",
+		"workspace_path", info.Path,
+		"backend_id", selection.BackendID,
+		"route", selection.RouteName,
+		"role", RoleValidator,
+		"model", model,
+		"outcome", workerRunOutcome(turnErr, runResult.FinalState),
+		"error", errorString(turnErr),
+	)
 
 	r.afterRun(info, workspaceIssue)
 	afterRunPending = false
+	r.logWorkerEvent(req.Issue, "worker_check_after_run_finished",
+		"workspace_path", info.Path,
+	)
 
 	finishedAt := r.now().UTC()
 	runResult.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
@@ -658,6 +715,10 @@ func (r *Runner) startSession(
 	if err != nil {
 		return 0, false, fmt.Errorf("start codex session: %w", err)
 	}
+	r.logWorkerEvent(issue, "worker_session_started",
+		"session_id", sessionID,
+		"model", model,
+	)
 	return sessionID, true, nil
 }
 
@@ -691,6 +752,12 @@ func (r *Runner) finishSession(
 	}); err != nil {
 		return fmt.Errorf("finish codex session: %w", err)
 	}
+	r.logWorkerEvent(issue, "worker_session_finished",
+		"session_id", sessionID,
+		"model", model,
+		"final_state", result.FinalState,
+		"turns", turns,
+	)
 	if _, err := r.store.RecordUsageEvent(ctx, store.UsageEvent{
 		ProjectID:      r.projectID,
 		SessionID:      sessionID,
@@ -1078,6 +1145,88 @@ func cloneMap(value map[string]any) map[string]any {
 		return value
 	}
 	return cloned
+}
+
+func (r *Runner) logWorkerEvent(issue connector.Issue, event string, attrs ...any) {
+	if r == nil || r.logger == nil {
+		return
+	}
+	all := []any{
+		"event", strings.TrimSpace(event),
+		"project_id", strings.TrimSpace(r.projectID),
+		"issue_id", strings.TrimSpace(issue.ID),
+		"issue_identifier", strings.TrimSpace(issue.Identifier),
+		"issue_state", strings.TrimSpace(issue.State),
+	}
+	all = append(all, attrs...)
+	r.logger.Debug(strings.TrimSpace(event), all...)
+}
+
+func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
+	event := strings.TrimSpace(string(update.Type))
+	if event == "" {
+		event = strings.TrimSpace(update.Method)
+	}
+	switch update.Type {
+	case AgentUpdateProcessStarted:
+		r.logWorkerEvent(issue, "worker_process_started",
+			"process_identity", strings.TrimSpace(update.ProcessIdentity),
+		)
+	case AgentUpdateTurnStarted:
+		r.logWorkerEvent(issue, "worker_turn_started",
+			"thread_id", strings.TrimSpace(update.ThreadID),
+			"turn_id", strings.TrimSpace(update.TurnID),
+		)
+	case AgentUpdateTurnCompleted:
+		r.logWorkerEvent(issue, "worker_turn_finished",
+			"thread_id", strings.TrimSpace(update.ThreadID),
+			"turn_id", strings.TrimSpace(update.TurnID),
+			"status", strings.TrimSpace(update.Status),
+		)
+	case AgentUpdateTokenUsage:
+		r.logWorkerEvent(issue, "worker_usage_updated",
+			"thread_id", strings.TrimSpace(update.ThreadID),
+			"turn_id", strings.TrimSpace(update.TurnID),
+			"total_tokens", update.Tokens.TotalTokens,
+			"input_tokens", update.Tokens.InputTokens,
+			"output_tokens", update.Tokens.OutputTokens,
+		)
+	case AgentUpdateRateLimits:
+		r.logWorkerEvent(issue, "worker_rate_limits_updated",
+			"thread_id", strings.TrimSpace(update.ThreadID),
+			"turn_id", strings.TrimSpace(update.TurnID),
+		)
+	default:
+		if event != "" && update.Type != AgentUpdateMessageDelta {
+			r.logWorkerEvent(issue, "worker_agent_update",
+				"agent_event", event,
+				"thread_id", strings.TrimSpace(update.ThreadID),
+				"turn_id", strings.TrimSpace(update.TurnID),
+			)
+		}
+	}
+}
+
+func workerRunOutcome(err error, finalState string) string {
+	switch {
+	case errors.Is(err, context.Canceled):
+		return "cancelled"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timed_out"
+	case err != nil:
+		return "failed"
+	case strings.EqualFold(strings.TrimSpace(finalState), FinalStateCompleted), strings.TrimSpace(finalState) == "":
+		return "succeeded"
+	default:
+		return strings.TrimSpace(finalState)
+	}
+}
+
+func errorString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return strings.TrimSpace(err.Error())
 }
 
 func runtimeSeconds(startedAt, completedAt time.Time) float64 {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -274,6 +274,76 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 }
 
+func TestRunnerRunLogsLifecycleWithoutPromptOrMessageBody(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	var logs bytes.Buffer
+	codexClient := &fakeCodexClient{
+		updates: []AgentUpdate{
+			{Type: AgentUpdateProcessStarted, ProcessIdentity: "pid-123"},
+			{Type: AgentUpdateTurnStarted, ThreadID: "thread-1", TurnID: "turn-1"},
+			{Type: AgentUpdateMessageDelta, Delta: "do not log this message body"},
+			{Type: AgentUpdateTokenUsage, ThreadID: "thread-1", TurnID: "turn-1", Tokens: AgentTokenUsage{InputTokens: 10, OutputTokens: 5, TotalTokens: 15}},
+			{Type: AgentUpdateTurnCompleted, ThreadID: "thread-1", TurnID: "turn-1", Status: "completed"},
+		},
+		result: AgentTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "session-1"},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{Config: config.Config{}},
+		Workspace: &fakeWorkspaceBackend{
+			info: workspace.Info{Path: workspacePath, Key: "issue-726", Branch: "detent/issue-726"},
+		},
+		AgentBackend: codexClient,
+		Store:        &fakeSessionStore{sessionID: 726},
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:          "issue-726",
+			Identifier:  "digitaldrywood/detent#726",
+			Title:       "Lifecycle diagnostics",
+			Description: "do not log this prompt body",
+			State:       "Todo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	logText := logs.String()
+	for _, fragment := range []string{
+		"worker_workspace_create_started",
+		"worker_workspace_created",
+		"worker_before_run_finished",
+		"worker_session_started",
+		"worker_command_started",
+		"worker_process_started",
+		"worker_turn_started",
+		"worker_usage_updated",
+		"worker_turn_finished",
+		"worker_command_finished",
+		"worker_after_run_finished",
+		"worker_session_finished",
+		"issue_id=issue-726",
+	} {
+		if !strings.Contains(logText, fragment) {
+			t.Fatalf("logs missing %q:\n%s", fragment, logText)
+		}
+	}
+	for _, leaked := range []string{"do not log this message body", "do not log this prompt body"} {
+		if strings.Contains(logText, leaked) {
+			t.Fatalf("logs leaked %q:\n%s", leaked, logText)
+		}
+	}
+}
+
 func TestRunnerPlanModeCapturesOutputAndConstrainsPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -143,6 +143,21 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 			completion.RetryAttempt = nextFailureAttempt(request.Attempt)
 			completion.RetryDelay = s.RetryDelay(completion.RetryAttempt)
 		}
+		s.logger.Debug(
+			"worker_attempt_finished",
+			slog.String("event", "worker_attempt_finished"),
+			slog.String("issue_id", request.Issue.ID),
+			slog.String("issue_identifier", request.Issue.Identifier),
+			slog.String("issue_state", request.Issue.State),
+			slog.Int("attempt", request.Attempt),
+			slog.String("worker_host", request.WorkerHost),
+			slog.String("mode", request.Mode),
+			slog.String("outcome", workerRunOutcome(completion.Err, completion.Result.FinalState)),
+			slog.Bool("retryable", completion.Retryable),
+			slog.Int("retry_attempt", completion.RetryAttempt),
+			slog.Int64("retry_delay_seconds", int64(completion.RetryDelay/time.Second)),
+			slog.Any("error", completion.Err),
+		)
 	}()
 
 	result, err := s.backend.Run(ctx, request)


### PR DESCRIPTION
## Summary

- Add LOG_ADD_SOURCE / DETENT_LOG_ADD_SOURCE support and default source locations for debug slog handlers.
- Add debug scheduler decision, worker lifecycle, and GitHub API/cache/backoff diagnostics without logging prompt bodies or credentials.
- Cover source logging, scheduler lifecycle logging, runner redaction, and GitHub diagnostics with tests.

Fixes #726

## Test Plan

- [x] `go test ./cmd/detent ./internal/cli ./internal/orchestrator ./internal/runner ./internal/connector/github`
- [x] `make check`