### PR TITLE
fix(ui): clarify GitHub rate banner

### DIFF
--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3990,8 +3990,8 @@ func TestServerEventsStreamsGitHubAPIHealthChrome(t *testing.T) {
 	for _, want := range []string{
 		`id="github-api-health"`,
 		`data-preserve-details="github-api-health"`,
-		"GitHub API backoff: pull requests, check runs",
-		"Primary remaining: REST 4,878 / 5,000",
+		"GitHub secondary backoff: pull requests, check runs",
+		"REST primary: 4,878 remaining / 5,000 total (122 used)",
 		"retry 14:35 UTC",
 	} {
 		if !strings.Contains(event.data, want) {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -4980,24 +4980,24 @@ func gitHubAPIHealth(snapshot telemetry.Snapshot) gitHubAPIHealthView {
 		return view
 	}
 
-	primarySummary := gitHubAPIPrimarySummary(snapshot.RateLimits, false)
+	primarySummary := gitHubAPIPrimarySummary(snapshot.RateLimits)
 	if primarySummary == "" {
-		primarySummary = "Primary remaining unavailable"
+		primarySummary = "Primary quota unavailable"
 	}
 
 	if gitHubAPIPrimaryExhausted(snapshot.RateLimits) {
 		view.State = gitHubAPIHealthStateExhausted
-		view.Label = "GitHub API exhausted"
-		view.Summary = gitHubAPIPrimarySummary(snapshot.RateLimits, true)
-		view.Detail = "Primary quota exhausted; " + gitHubAPIExhaustedReset(snapshot.RateLimits) + "."
+		view.Label = "GitHub primary quota exhausted"
+		view.Summary = primarySummary
+		view.Detail = "Primary REST or GraphQL quota exhausted; " + gitHubAPIExhaustedReset(snapshot.RateLimits) + "."
 		return view
 	}
 	if gitHubAPIInBackoff(snapshot) {
 		families := gitHubAPIBackoffFamilySummary(snapshot, snapshot.RateLimits.RESTUsage)
 		view.State = gitHubAPIHealthStateBackoff
-		view.Label = "GitHub API backoff: " + families
-		view.Summary = "Primary remaining: " + primarySummary
-		view.Detail = "Secondary REST backoff for " + families + "; " + gitHubAPIRetryLabel(snapshot) + "."
+		view.Label = "GitHub secondary backoff: " + families
+		view.Summary = primarySummary + "; " + gitHubAPIRetryLabel(snapshot)
+		view.Detail = "Secondary endpoint-family REST backoff for " + families + "; " + gitHubAPIRetryLabel(snapshot) + "."
 		return view
 	}
 	if gitHubAPIPrimaryWarning(snapshot.RateLimits) {
@@ -5118,7 +5118,7 @@ func gitHubAPIDeadlineActive(generatedAt time.Time, deadline *time.Time) bool {
 	return deadline != nil && (generatedAt.IsZero() || deadline.After(generatedAt))
 }
 
-func gitHubAPIPrimarySummary(limits *telemetry.RateLimits, includePrimaryWord bool) string {
+func gitHubAPIPrimarySummary(limits *telemetry.RateLimits) string {
 	if limits == nil {
 		return ""
 	}
@@ -5127,19 +5127,32 @@ func gitHubAPIPrimarySummary(limits *telemetry.RateLimits, includePrimaryWord bo
 		if !gitHubAPIBucketKnown(bucket) {
 			return
 		}
-		label := name
-		if includePrimaryWord {
-			label += " primary"
-		}
-		if bucket.Limit > 0 {
-			parts = append(parts, label+" "+formatInt(bucket.Remaining)+" / "+formatInt(bucket.Limit))
-			return
-		}
-		parts = append(parts, label+" "+formatInt(bucket.Remaining)+" left")
+		parts = append(parts, gitHubAPIPrimaryBucketSummary(name+" primary", bucket))
 	}
 	appendBucket("REST", limits.GitHubREST)
 	appendBucket("GraphQL", limits.GitHubGraphQL)
-	return strings.Join(parts, " / ")
+	return strings.Join(parts, "; ")
+}
+
+func gitHubAPIPrimaryBucketSummary(label string, bucket *telemetry.RateLimitBucket) string {
+	remaining := formatInt(bucket.Remaining) + " remaining"
+	if bucket.Limit > 0 {
+		return label + ": " + remaining + " / " + formatInt(bucket.Limit) + " total (" + formatInt(gitHubAPIPrimaryBucketUsed(bucket)) + " used)"
+	}
+	if bucket.Used > 0 {
+		return label + ": " + remaining + " (" + formatInt(bucket.Used) + " used)"
+	}
+	return label + ": " + remaining
+}
+
+func gitHubAPIPrimaryBucketUsed(bucket *telemetry.RateLimitBucket) int64 {
+	if bucket.Used > 0 || bucket.Limit <= 0 {
+		return bucket.Used
+	}
+	if bucket.Remaining >= 0 && bucket.Remaining <= bucket.Limit {
+		return bucket.Limit - bucket.Remaining
+	}
+	return bucket.Used
 }
 
 func gitHubAPIBackoffFamilySummary(snapshot telemetry.Snapshot, usage *telemetry.RESTUsage) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -108,7 +108,7 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 			},
 			wantState:       gitHubAPIHealthStateHealthy,
 			wantLabel:       "GitHub API healthy",
-			wantSummaryPart: "REST 4,878 / 5,000",
+			wantSummaryPart: "REST primary: 4,878 remaining / 5,000 total (122 used)",
 		},
 		{
 			name: "warning for low primary remaining",
@@ -121,7 +121,7 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 			},
 			wantState:       gitHubAPIHealthStateWarning,
 			wantLabel:       "GitHub API warning",
-			wantSummaryPart: "REST 240 / 5,000",
+			wantSummaryPart: "REST primary: 240 remaining / 5,000 total (4,760 used)",
 		},
 		{
 			name: "secondary backoff preserves healthy primary context",
@@ -141,8 +141,8 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 				},
 			},
 			wantState:       gitHubAPIHealthStateBackoff,
-			wantLabel:       "GitHub API backoff: pull requests, check runs",
-			wantSummaryPart: "Primary remaining: REST 4,878 / 5,000",
+			wantLabel:       "GitHub secondary backoff: pull requests, check runs",
+			wantSummaryPart: "REST primary: 4,878 remaining / 5,000 total (122 used)",
 			wantBackoffPart: "retry 14:35 UTC",
 		},
 		{
@@ -163,7 +163,7 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 			},
 			wantState:       gitHubAPIHealthStateHealthy,
 			wantLabel:       "GitHub API healthy",
-			wantSummaryPart: "REST 4,878 / 5,000",
+			wantSummaryPart: "REST primary: 4,878 remaining / 5,000 total (122 used)",
 		},
 		{
 			name: "primary exhausted outranks secondary backoff",
@@ -176,8 +176,8 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 				},
 			},
 			wantState:       gitHubAPIHealthStateExhausted,
-			wantLabel:       "GitHub API exhausted",
-			wantSummaryPart: "REST primary 0 / 5,000",
+			wantLabel:       "GitHub primary quota exhausted",
+			wantSummaryPart: "REST primary: 0 remaining / 5,000 total (5,000 used)",
 			wantBackoffPart: "reset 15:00 UTC",
 		},
 	}

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -412,9 +412,9 @@ func TestDashboardRendersGitHubAPIHealthChrome(t *testing.T) {
 		`hx-swap="morph:outerHTML"`,
 		`aria-label="GitHub API health"`,
 		`data-preserve-details="github-api-health"`,
-		"GitHub API backoff: pull requests, check runs",
-		"Primary remaining: REST 4,878 / 5,000",
-		"GraphQL 4,880 / 5,000",
+		"GitHub secondary backoff: pull requests, check runs",
+		"REST primary: 4,878 remaining / 5,000 total (122 used)",
+		"GraphQL primary: 4,880 remaining / 5,000 total (120 used)",
 		"REST primary",
 		"GraphQL primary",
 		"4,878 / 5,000 remaining",
@@ -494,7 +494,7 @@ func TestDashboardRendersGitHubAPIHealthPreservationMetadataForStates(t *testing
 				},
 			},
 			wantState: "backoff",
-			wantLabel: "GitHub API backoff: pull requests",
+			wantLabel: "GitHub secondary backoff: pull requests",
 		},
 		{
 			name: "primary exhausted",
@@ -506,7 +506,7 @@ func TestDashboardRendersGitHubAPIHealthPreservationMetadataForStates(t *testing
 				},
 			},
 			wantState: "exhausted",
-			wantLabel: "GitHub API exhausted",
+			wantLabel: "GitHub primary quota exhausted",
 		},
 	}
 

--- a/internal/web/templates/help.go
+++ b/internal/web/templates/help.go
@@ -86,7 +86,7 @@ var helpDefinitions = map[helpTerm]helpEntry{
 	helpPRPipeline:          {Label: "PR pipeline", Description: "Pull requests currently waiting for human review, merging, or marked done by the tracker today. Watch this lane to see whether the merge train is moving."},
 	helpProjectedSpend:      {Label: "Projected spend", Description: "Estimated additional USD for active work if it continues at the current pace. Use it before letting a busy queue keep running."},
 	helpQueue:               {Label: "Queue", Description: "Issues waiting to start or retry. A growing queue means demand is higher than the available agent capacity or retry cooldowns."},
-	helpRateLimits:          {Label: "Rate limits", Description: "How much provider quota remains before requests get throttled. Watch it during heavy parallel work because low quota can slow or pause agents."},
+	helpRateLimits:          {Label: "Rate limits", Description: "Primary buckets show provider quota remaining and used before hourly reset. GitHub secondary REST backoff can still pause individual endpoint families even when REST and GraphQL primary quota remains."},
 	helpRecentSessions:      {Label: "Recent sessions", Description: "The last completed Codex sessions Detent retained. Use it to audit what just happened without digging through logs."},
 	helpReportsEvents:       {Label: "Usage events", Description: "Completed ledger rows in the selected report window. Low counts can make spend and token trends look sparse or misleading."},
 	helpReportsModels:       {Label: "Models", Description: "How many model buckets appear in the report window. More buckets can explain mixed pricing or unexpected spend."},

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -81,8 +81,8 @@ test("GitHub API health chrome covers key rate-limit states", async ({ page }, t
   const scenarios = [
     ["github-api-healthy", "GitHub API healthy"],
     ["github-api-warning", "GitHub API warning"],
-    ["github-api-secondary-backoff", "GitHub API backoff"],
-    ["github-api-primary-exhausted", "GitHub API exhausted"],
+    ["github-api-secondary-backoff", "GitHub secondary backoff"],
+    ["github-api-primary-exhausted", "GitHub primary quota exhausted"],
   ];
 
   for (const [scenario, label] of scenarios) {


### PR DESCRIPTION
## Summary

- Clarify the GitHub API health banner so REST and GraphQL primary quota values show remaining, total, and used.
- Separate secondary endpoint-family backoff copy from primary quota exhaustion and update the rate-limit tooltip explanation.

Fixes #734

## Test Plan

- [x] `go test ./internal/web/...`
- [x] `make check`
- [x] `DETENT_BINARY="$PWD/tmp/detent" node_modules/.bin/playwright test tests/visual/layout.spec.js --grep "GitHub API health chrome"`
