### PR TITLE
fix(cli): preserve parent shutdown cancellation

### DIFF
--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -172,6 +172,9 @@ func runWithShutdown(ctx context.Context, cfg runningShutdownConfig, serve shutd
 	for {
 		select {
 		case err := <-serveErrs:
+			if ctx.Err() != nil && unexpectedShutdownServeError(err) == nil {
+				return ctx.Err()
+			}
 			return unexpectedShutdownServeError(err)
 		case <-ctx.Done():
 			cancelServe()


### PR DESCRIPTION
## Summary
- return the parent context cancellation when shutdown serving exits cleanly after the parent context is already canceled
- stabilize the macOS portability failure in TestRunWithShutdownMarksControllerActive before the next patch release

## Tests
- go test ./internal/cli -run TestRunWithShutdownMarksControllerActive -count=100 -v
- go test ./internal/cli -race -run TestRunWithShutdownMarksControllerActive -count=20 -v
- go test ./internal/cli -run 'TestRunWithShutdown|TestShutdownController|TestRequestTerminalShutdownInterrupt' -count=5\n- go test ./internal/cli -count=1\n- git diff --check