### PR TITLE
fix(workspace): recover stale worktrees

### DIFF
--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -495,10 +495,18 @@ func (l *LocalGit) recoverStaleSourceWorktree(ctx context.Context, path string, 
 	if err != nil {
 		return fmt.Errorf("inspect stale workspace changes for branch %q, want %q: %w", currentBranch, expectedBranch, err)
 	}
-	if dirty {
+	unreferencedDetachedHead, err := l.unreferencedDetachedHead(ctx, path, currentBranch)
+	if err != nil {
+		return fmt.Errorf("inspect detached workspace HEAD for branch %q, want %q: %w", currentBranch, expectedBranch, err)
+	}
+	if dirty || unreferencedDetachedHead {
 		quarantinePath, err := l.quarantineWorktree(ctx, path)
 		if err != nil {
-			return fmt.Errorf("workspace path is on branch %q, want %q and has uncommitted changes; preserve it by moving or cleaning %s: %w", currentBranch, expectedBranch, path, err)
+			reason := "has uncommitted changes"
+			if unreferencedDetachedHead {
+				reason = "has a detached HEAD commit that is not reachable from a ref"
+			}
+			return fmt.Errorf("workspace path is on branch %q, want %q and %s; preserve it by moving or cleaning %s: %w", currentBranch, expectedBranch, reason, path, err)
 		}
 		l.logger.Warn(
 			"quarantined stale workspace",
@@ -506,7 +514,8 @@ func (l *LocalGit) recoverStaleSourceWorktree(ctx context.Context, path string, 
 			slog.String("quarantine_path", quarantinePath),
 			slog.String("current_branch", currentBranch),
 			slog.String("expected_branch", expectedBranch),
-			slog.Bool("dirty", true),
+			slog.Bool("dirty", dirty),
+			slog.Bool("unreferenced_detached_head", unreferencedDetachedHead),
 		)
 		return nil
 	}
@@ -530,6 +539,17 @@ func (l *LocalGit) worktreeHasChanges(ctx context.Context, path string) (bool, e
 		return false, fmt.Errorf("inspect workspace status: %w", err)
 	}
 	return strings.TrimSpace(output) != "", nil
+}
+
+func (l *LocalGit) unreferencedDetachedHead(ctx context.Context, path string, currentBranch string) (bool, error) {
+	if strings.TrimSpace(currentBranch) != "" {
+		return false, nil
+	}
+	output, err := runGitAt(ctx, path, "for-each-ref", "--contains", "HEAD", "--format=%(refname)")
+	if err != nil {
+		return false, fmt.Errorf("inspect refs containing HEAD: %w", err)
+	}
+	return strings.TrimSpace(output) == "", nil
 }
 
 func (l *LocalGit) removeCleanWorktree(ctx context.Context, path string) error {

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -418,24 +418,33 @@ func (l *LocalGit) ensureWorktree(ctx context.Context, path string, branch strin
 	if exists {
 		if isDir {
 			if l.isSourceWorktree(ctx, path) {
-				if err := l.ensureExpectedBranch(ctx, path, branch); err != nil {
+				matches, current, err := l.workspaceOnExpectedBranch(ctx, path, branch)
+				if err != nil {
 					return false, err
 				}
-				return false, nil
-			}
-			if l.isGitWorkspace(ctx, path) {
+				if matches {
+					return false, nil
+				}
+				if err := l.recoverStaleSourceWorktree(ctx, path, current, branch); err != nil {
+					return false, err
+				}
+				exists = false
+			} else if l.isGitWorkspace(ctx, path) {
 				return false, fmt.Errorf("workspace path is a git worktree not managed by source: %s", path)
-			}
-			empty, err := dirIsEmpty(path)
-			if err != nil {
-				return false, err
-			}
-			if !empty {
-				return false, fmt.Errorf("workspace path exists but is not a git worktree: %s", path)
+			} else {
+				empty, err := dirIsEmpty(path)
+				if err != nil {
+					return false, err
+				}
+				if !empty {
+					return false, fmt.Errorf("workspace path exists but is not a git worktree: %s", path)
+				}
 			}
 		}
-		if err := os.RemoveAll(path); err != nil {
-			return false, fmt.Errorf("remove stale workspace path: %w", err)
+		if exists {
+			if err := os.RemoveAll(path); err != nil {
+				return false, fmt.Errorf("remove stale workspace path: %w", err)
+			}
 		}
 	}
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
@@ -467,21 +476,106 @@ func (l *LocalGit) addBranchedWorktree(ctx context.Context, path string, branch 
 	return err
 }
 
-func (l *LocalGit) ensureExpectedBranch(ctx context.Context, path string, branch string) error {
+func (l *LocalGit) workspaceOnExpectedBranch(ctx context.Context, path string, branch string) (bool, string, error) {
 	branch = strings.TrimSpace(branch)
 	if !l.autoBranch || branch == "" {
-		return nil
+		return true, "", nil
 	}
 
 	output, err := runGitAt(ctx, path, "branch", "--show-current")
 	if err != nil {
-		return fmt.Errorf("inspect workspace branch: %w", err)
+		return false, "", fmt.Errorf("inspect workspace branch: %w", err)
 	}
 	current := strings.TrimSpace(output)
-	if current == branch {
+	return current == branch, current, nil
+}
+
+func (l *LocalGit) recoverStaleSourceWorktree(ctx context.Context, path string, currentBranch string, expectedBranch string) error {
+	dirty, err := l.worktreeHasChanges(ctx, path)
+	if err != nil {
+		return fmt.Errorf("inspect stale workspace changes for branch %q, want %q: %w", currentBranch, expectedBranch, err)
+	}
+	if dirty {
+		quarantinePath, err := l.quarantineWorktree(ctx, path)
+		if err != nil {
+			return fmt.Errorf("workspace path is on branch %q, want %q and has uncommitted changes; preserve it by moving or cleaning %s: %w", currentBranch, expectedBranch, path, err)
+		}
+		l.logger.Warn(
+			"quarantined stale workspace",
+			slog.String("path", path),
+			slog.String("quarantine_path", quarantinePath),
+			slog.String("current_branch", currentBranch),
+			slog.String("expected_branch", expectedBranch),
+			slog.Bool("dirty", true),
+		)
 		return nil
 	}
-	return fmt.Errorf("workspace path is on branch %q, want %q: %s", current, branch, path)
+
+	if err := l.removeCleanWorktree(ctx, path); err != nil {
+		return fmt.Errorf("recover stale clean workspace on branch %q, want %q: %w", currentBranch, expectedBranch, err)
+	}
+	l.logger.Info(
+		"removed stale clean workspace",
+		slog.String("path", path),
+		slog.String("current_branch", currentBranch),
+		slog.String("expected_branch", expectedBranch),
+		slog.Bool("dirty", false),
+	)
+	return nil
+}
+
+func (l *LocalGit) worktreeHasChanges(ctx context.Context, path string) (bool, error) {
+	output, err := runGitAt(ctx, path, "status", "--porcelain", "--untracked-files=all")
+	if err != nil {
+		return false, fmt.Errorf("inspect workspace status: %w", err)
+	}
+	return strings.TrimSpace(output) != "", nil
+}
+
+func (l *LocalGit) removeCleanWorktree(ctx context.Context, path string) error {
+	_, err := l.runGit(ctx, "worktree", "remove", path)
+	if err != nil {
+		return fmt.Errorf("remove stale clean worktree: %w", err)
+	}
+	return nil
+}
+
+func (l *LocalGit) quarantineWorktree(ctx context.Context, path string) (string, error) {
+	quarantinePath, err := l.nextQuarantinePath(path)
+	if err != nil {
+		return "", err
+	}
+	if err := os.MkdirAll(filepath.Dir(quarantinePath), 0o700); err != nil {
+		return "", fmt.Errorf("create quarantine parent: %w", err)
+	}
+	if _, err := l.runGit(ctx, "worktree", "move", path, quarantinePath); err != nil {
+		return "", fmt.Errorf("move stale worktree to quarantine: %w", err)
+	}
+	return quarantinePath, nil
+}
+
+func (l *LocalGit) nextQuarantinePath(path string) (string, error) {
+	parent := filepath.Join(l.root, ".detent", "quarantine")
+	base := SafeKey(filepath.Base(path))
+	stamp := time.Now().UTC().Format("20060102T150405.000000000Z")
+	for i := range 100 {
+		name := base + "-" + stamp
+		if i > 0 {
+			name += fmt.Sprintf("-%d", i)
+		}
+		candidate, err := validateWorkspacePath(l.root, filepath.Join(parent, name))
+		if err != nil {
+			return "", err
+		}
+		exists, _, err := pathExists(candidate)
+		if err != nil {
+			return "", err
+		}
+		if !exists {
+			return candidate, nil
+		}
+	}
+	return "", errors.New("exhausted quarantine workspace path attempts")
 }
 
 func (l *LocalGit) branchExists(ctx context.Context, branch string) (bool, error) {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -669,6 +669,76 @@ func TestLocalGitCreateQuarantinesDirtyDetachedWorktree(t *testing.T) {
 	}
 }
 
+func TestLocalGitCreateQuarantinesCleanDetachedUnreferencedCommit(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	var logs strings.Builder
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	first, err := backend.Create(context.Background(), Issue{Identifier: "DD-DETACHED-COMMIT"})
+	if err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+	runGit(t, first.Path, "switch", "--detach", "HEAD")
+	if err := os.WriteFile(filepath.Join(first.Path, "local-commit.txt"), []byte("keep\n"), 0o600); err != nil {
+		t.Fatalf("write local commit file: %v", err)
+	}
+	runGit(t, first.Path, "add", "local-commit.txt")
+	runGit(t, first.Path, "commit", "-m", "local detached commit")
+	if got := strings.TrimSpace(runGit(t, first.Path, "status", "--porcelain")); got != "" {
+		t.Fatalf("detached worktree status = %q, want clean", got)
+	}
+	if got := strings.TrimSpace(runGit(t, first.Path, "branch", "--show-current")); got != "" {
+		t.Fatalf("detached worktree branch = %q, want detached HEAD", got)
+	}
+
+	second, err := backend.Create(context.Background(), Issue{Identifier: "DD-DETACHED-COMMIT"})
+	if err != nil {
+		t.Fatalf("second Create() error = %v", err)
+	}
+
+	if !second.Created {
+		t.Fatal("second Create() Created = false, want true")
+	}
+	if got := strings.TrimSpace(runGit(t, second.Path, "branch", "--show-current")); got != "detent/dd-detached-commit" {
+		t.Fatalf("worktree branch = %q, want detent/dd-detached-commit", got)
+	}
+	if _, err := os.Stat(filepath.Join(second.Path, "local-commit.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("local commit file exists in fresh workspace, stat error = %v", err)
+	}
+
+	quarantineDir := filepath.Join(root, ".detent", "quarantine")
+	entries, err := os.ReadDir(quarantineDir)
+	if err != nil {
+		t.Fatalf("read quarantine dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("quarantine entries = %d, want 1", len(entries))
+	}
+	quarantinedPath := filepath.Join(quarantineDir, entries[0].Name())
+	if got := readFile(t, filepath.Join(quarantinedPath, "local-commit.txt")); got != "keep\n" {
+		t.Fatalf("quarantined local-commit.txt = %q, want keep", got)
+	}
+	if got := strings.TrimSpace(runGit(t, quarantinedPath, "branch", "--show-current")); got != "" {
+		t.Fatalf("quarantined worktree branch = %q, want detached HEAD", got)
+	}
+	if got := logs.String(); !strings.Contains(got, "quarantined stale workspace") || !strings.Contains(got, quarantinedPath) {
+		t.Fatalf("logs = %q, want quarantine report for %s", got, quarantinedPath)
+	}
+}
+
 func TestLocalGitBeforeAndAfterRunHooks(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -510,17 +510,68 @@ func TestLocalGitCreateReusesExistingWorktreeWithoutAfterCreate(t *testing.T) {
 	}
 }
 
-func TestLocalGitCreateRejectsReusedWorktreeOnUnexpectedBranch(t *testing.T) {
+func TestLocalGitCreateRecoversCleanDetachedWorktree(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)
 
 	source := initSourceRepo(t)
 	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "after-create.trace")
 
 	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
 		Root:       root,
 		SourceRoot: source,
 		AutoBranch: true,
+		Hooks: Hooks{
+			AfterCreate: "printf 'after-create\n' >> " + shellQuote(tracePath),
+			Timeout:     time.Second,
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	first, err := backend.Create(context.Background(), Issue{Identifier: "DD-DETACHED"})
+	if err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+	runGit(t, first.Path, "switch", "--detach", "HEAD")
+
+	second, err := backend.Create(context.Background(), Issue{Identifier: "DD-DETACHED"})
+	if err != nil {
+		t.Fatalf("second Create() error = %v", err)
+	}
+
+	if !second.Created {
+		t.Fatal("second Create() Created = false, want true")
+	}
+	if second.Path != first.Path {
+		t.Fatalf("second Create() Path = %q, want %q", second.Path, first.Path)
+	}
+	if got := strings.TrimSpace(runGit(t, second.Path, "branch", "--show-current")); got != "detent/dd-detached" {
+		t.Fatalf("worktree branch = %q, want detent/dd-detached", got)
+	}
+	if got := strings.Count(readFile(t, tracePath), "after-create"); got != 2 {
+		t.Fatalf("after_create runs = %d, want 2", got)
+	}
+}
+
+func TestLocalGitCreateRecoversCleanWrongBranchWorktree(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	tracePath := filepath.Join(t.TempDir(), "after-create.trace")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Hooks: Hooks{
+			AfterCreate: "printf 'after-create\n' >> " + shellQuote(tracePath),
+			Timeout:     time.Second,
+		},
 	})
 	if err != nil {
 		t.Fatalf("NewBackend() error = %v", err)
@@ -534,19 +585,87 @@ func TestLocalGitCreateRejectsReusedWorktreeOnUnexpectedBranch(t *testing.T) {
 	runGit(t, source, "branch", "detent/other")
 	runGit(t, info.Path, "switch", "detent/other")
 
-	_, err = backend.Create(context.Background(), Issue{Identifier: "DD-REUSE"})
-	if err == nil {
-		t.Fatal("second Create() error = nil, want branch mismatch")
+	second, err := backend.Create(context.Background(), Issue{Identifier: "DD-REUSE"})
+	if err != nil {
+		t.Fatalf("second Create() error = %v", err)
 	}
-	for _, want := range []string{
-		"workspace path is on branch",
-		"detent/other",
-		"detent/dd-reuse",
-		info.Path,
-	} {
-		if !strings.Contains(err.Error(), want) {
-			t.Fatalf("second Create() error = %q, want %q", err, want)
-		}
+
+	if !second.Created {
+		t.Fatal("second Create() Created = false, want true")
+	}
+	if second.Path != info.Path {
+		t.Fatalf("second Create() Path = %q, want %q", second.Path, info.Path)
+	}
+	if got := strings.TrimSpace(runGit(t, second.Path, "branch", "--show-current")); got != "detent/dd-reuse" {
+		t.Fatalf("worktree branch = %q, want detent/dd-reuse", got)
+	}
+	if got := strings.Count(readFile(t, tracePath), "after-create"); got != 2 {
+		t.Fatalf("after_create runs = %d, want 2", got)
+	}
+}
+
+func TestLocalGitCreateQuarantinesDirtyDetachedWorktree(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	var logs strings.Builder
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+		Logger:     slog.New(slog.NewTextHandler(&logs, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	first, err := backend.Create(context.Background(), Issue{Identifier: "DD-DIRTY-DETACHED"})
+	if err != nil {
+		t.Fatalf("first Create() error = %v", err)
+	}
+	runGit(t, first.Path, "switch", "--detach", "HEAD")
+	if err := os.WriteFile(filepath.Join(first.Path, "local-progress.txt"), []byte("keep\n"), 0o600); err != nil {
+		t.Fatalf("write local progress: %v", err)
+	}
+
+	second, err := backend.Create(context.Background(), Issue{Identifier: "DD-DIRTY-DETACHED"})
+	if err != nil {
+		t.Fatalf("second Create() error = %v", err)
+	}
+
+	if !second.Created {
+		t.Fatal("second Create() Created = false, want true")
+	}
+	if second.Path != first.Path {
+		t.Fatalf("second Create() Path = %q, want %q", second.Path, first.Path)
+	}
+	if got := strings.TrimSpace(runGit(t, second.Path, "branch", "--show-current")); got != "detent/dd-dirty-detached" {
+		t.Fatalf("worktree branch = %q, want detent/dd-dirty-detached", got)
+	}
+	if _, err := os.Stat(filepath.Join(second.Path, "local-progress.txt")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("local progress exists in fresh workspace, stat error = %v", err)
+	}
+
+	quarantineDir := filepath.Join(root, ".detent", "quarantine")
+	entries, err := os.ReadDir(quarantineDir)
+	if err != nil {
+		t.Fatalf("read quarantine dir: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("quarantine entries = %d, want 1", len(entries))
+	}
+	quarantinedPath := filepath.Join(quarantineDir, entries[0].Name())
+	if got := readFile(t, filepath.Join(quarantinedPath, "local-progress.txt")); got != "keep\n" {
+		t.Fatalf("quarantined local-progress.txt = %q, want keep", got)
+	}
+	if got := strings.TrimSpace(runGit(t, quarantinedPath, "branch", "--show-current")); got != "" {
+		t.Fatalf("quarantined worktree branch = %q, want detached HEAD", got)
+	}
+	if got := logs.String(); !strings.Contains(got, "quarantined stale workspace") || !strings.Contains(got, quarantinedPath) {
+		t.Fatalf("logs = %q, want quarantine report for %s", got, quarantinedPath)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Recover clean detached or wrong-branch Detent worktrees by recreating the expected branch worktree.
- Quarantine dirty stale worktrees and detached HEAD commits not reachable from any ref under the workspace root before creating a fresh expected worktree.
- Add regression coverage for clean detached, clean wrong-branch, dirty detached, and clean detached unreferenced-commit worktrees.

Fixes #746

## Test Plan

- [x] `go test ./internal/workspace -run "TestLocalGitCreate(RecoversCleanDetachedWorktree|RecoversCleanWrongBranchWorktree|QuarantinesDirtyDetachedWorktree|QuarantinesCleanDetachedUnreferencedCommit)" -count=1 -v`
- [x] `go test ./internal/workspace -count=1`
- [x] `make check`