### PR TITLE
fix(runner): allow git metadata writes in sandbox

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -280,6 +280,139 @@ func normalizeRunMode(mode string) string {
 	}
 }
 
+func turnSandboxPolicyForWorkspace(ctx context.Context, workspacePath string, threadSandbox string, policy any, logger *slog.Logger) any {
+	policyMap, ok := workspaceWriteSandboxPolicyMap(threadSandbox, policy)
+	if !ok {
+		return policy
+	}
+	roots, err := workspace.GitMetadataWritableRoots(ctx, workspacePath)
+	if err != nil {
+		if logger != nil {
+			logger.Warn("workspace git metadata writable roots unavailable", slog.String("workspace_path", workspacePath), slog.Any("error", err))
+		}
+		return policy
+	}
+	if len(roots) == 0 {
+		return policy
+	}
+	return mergeSandboxWritableRoots(policyMap, roots)
+}
+
+func workspaceWriteSandboxPolicyMap(threadSandbox string, policy any) (map[string]any, bool) {
+	policyMap, ok := sandboxPolicyMap(policy)
+	if ok && isWorkspaceWriteSandboxName(policyType(policyMap)) {
+		return policyMap, true
+	}
+	if !isWorkspaceWriteSandboxName(threadSandbox) || !ok {
+		return nil, false
+	}
+	if strings.TrimSpace(policyType(policyMap)) == "" {
+		policyMap["type"] = "workspaceWrite"
+	}
+	return policyMap, true
+}
+
+func sandboxPolicyMap(policy any) (map[string]any, bool) {
+	if policy == nil {
+		return map[string]any{}, true
+	}
+	switch value := policy.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(value))
+		maps.Copy(out, value)
+		return out, true
+	case json.RawMessage:
+		return decodeSandboxPolicyMap(value)
+	case []byte:
+		return decodeSandboxPolicyMap(value)
+	case string:
+		return decodeSandboxPolicyMap([]byte(value))
+	default:
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil, false
+		}
+		return decodeSandboxPolicyMap(raw)
+	}
+}
+
+func decodeSandboxPolicyMap(raw []byte) (map[string]any, bool) {
+	var policy map[string]any
+	if err := json.Unmarshal(raw, &policy); err != nil {
+		return nil, false
+	}
+	if policy == nil {
+		policy = map[string]any{}
+	}
+	return policy, true
+}
+
+func policyType(policy map[string]any) string {
+	value, ok := policy["type"]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return text
+}
+
+func isWorkspaceWriteSandboxName(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.ReplaceAll(normalized, "_", "-")
+	return normalized == "workspace-write" || normalized == "workspacewrite"
+}
+
+func mergeSandboxWritableRoots(policy map[string]any, roots []string) map[string]any {
+	merged := []string{}
+	merged = appendPolicyStringSlice(merged, policy["writableRoots"])
+	merged = appendPolicyStringSlice(merged, policy["writable_roots"])
+	merged = appendUniqueStrings(merged, roots...)
+	if strings.TrimSpace(policyType(policy)) == "" {
+		policy["type"] = "workspaceWrite"
+	}
+	policy["writableRoots"] = merged
+	delete(policy, "writable_roots")
+	return policy
+}
+
+func appendPolicyStringSlice(out []string, value any) []string {
+	switch values := value.(type) {
+	case []string:
+		return appendUniqueStrings(out, values...)
+	case []any:
+		for _, item := range values {
+			text, ok := item.(string)
+			if !ok {
+				continue
+			}
+			out = appendUniqueStrings(out, text)
+		}
+	}
+	return out
+}
+
+func appendUniqueStrings(out []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(out)+len(values))
+	for _, value := range out {
+		seen[value] = struct{}{}
+	}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
 func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -358,7 +491,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		Prompt:            prompt,
 		ApprovalPolicy:    stringOrMapValue(backendConfig.Options.ApprovalPolicy),
 		ThreadSandbox:     backendConfig.Options.ThreadSandbox,
-		TurnSandboxPolicy: backendConfig.Options.TurnSandboxPolicy,
+		TurnSandboxPolicy: turnSandboxPolicyForWorkspace(ctx, info.Path, backendConfig.Options.ThreadSandbox, backendConfig.Options.TurnSandboxPolicy, r.logger),
 		Model:             model,
 	}, func(update AgentUpdate) error {
 		r.logAgentUpdate(req.Issue, update)
@@ -510,7 +643,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		Prompt:            prompt,
 		ApprovalPolicy:    stringOrMapValue(backendConfig.Options.ApprovalPolicy),
 		ThreadSandbox:     backendConfig.Options.ThreadSandbox,
-		TurnSandboxPolicy: backendConfig.Options.TurnSandboxPolicy,
+		TurnSandboxPolicy: turnSandboxPolicyForWorkspace(ctx, info.Path, backendConfig.Options.ThreadSandbox, backendConfig.Options.TurnSandboxPolicy, r.logger),
 		Model:             model,
 	}, func(update AgentUpdate) error {
 		r.logAgentUpdate(req.Issue, update)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -300,15 +300,17 @@ func turnSandboxPolicyForWorkspace(ctx context.Context, workspacePath string, th
 
 func workspaceWriteSandboxPolicyMap(threadSandbox string, policy any) (map[string]any, bool) {
 	policyMap, ok := sandboxPolicyMap(policy)
-	if ok && isWorkspaceWriteSandboxName(policyType(policyMap)) {
-		return policyMap, true
-	}
-	if !isWorkspaceWriteSandboxName(threadSandbox) || !ok {
+	if !ok {
 		return nil, false
 	}
-	if strings.TrimSpace(policyType(policyMap)) == "" {
-		policyMap["type"] = "workspaceWrite"
+	policyKind := strings.TrimSpace(policyType(policyMap))
+	if isWorkspaceWriteSandboxName(policyKind) {
+		return policyMap, true
 	}
+	if policyKind != "" || !isWorkspaceWriteSandboxName(threadSandbox) {
+		return nil, false
+	}
+	policyMap["type"] = "workspaceWrite"
 	return policyMap, true
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -4,8 +4,10 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -271,6 +273,75 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if sessionStore.phase.Turns != 1 || sessionStore.phase.InputTokens != 100 || sessionStore.phase.OutputTokens != 25 || sessionStore.phase.TotalTokens != 125 {
 		t.Fatalf("WorkflowPhaseEvent usage = %#v, want turns and token totals", sessionStore.phase)
+	}
+}
+
+func TestRunnerRunAddsGitMetadataWritableRootsForManagedWorkspace(t *testing.T) {
+	t.Parallel()
+
+	source := initRunnerSourceRepo(t)
+	workspaceRoot := filepath.Join(t.TempDir(), "workspaces")
+	workspaceBackend, err := workspace.NewBackend(workspace.KindLocalGit, workspace.LocalGitOptions{
+		Root:       workspaceRoot,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	agentBackend := &committingAgentBackend{}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Codex: config.Codex{
+					ThreadSandbox: "workspace-write",
+					TurnSandboxPolicy: map[string]any{
+						"type":          "workspaceWrite",
+						"networkAccess": true,
+					},
+				},
+			},
+			Prompt: "Work on {{ issue.identifier }}",
+		},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-743",
+			Identifier: "digitaldrywood/detent#743",
+			Title:      "Managed workspace sandbox can prevent git add/commit",
+			BranchName: "detent/issue-743",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.FinalState != FinalStateCompleted {
+		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateCompleted)
+	}
+
+	wantRoots, err := workspace.GitMetadataWritableRoots(context.Background(), agentBackend.request.Workspace)
+	if err != nil {
+		t.Fatalf("GitMetadataWritableRoots() error = %v", err)
+	}
+	gotRoots := sandboxPolicyWritableRoots(t, agentBackend.request.TurnSandboxPolicy)
+	for _, want := range wantRoots {
+		if !containsRunnerString(gotRoots, want) {
+			t.Fatalf("sandbox writableRoots = %#v, missing %q", gotRoots, want)
+		}
+	}
+	policy := sandboxPolicyMapForTest(t, agentBackend.request.TurnSandboxPolicy)
+	if policy["networkAccess"] != true {
+		t.Fatalf("sandboxPolicy.networkAccess = %#v, want true", policy["networkAccess"])
+	}
+	if got := strings.TrimSpace(runRunnerGit(t, agentBackend.request.Workspace, "log", "-1", "--pretty=%s")); got != "agent commit" {
+		t.Fatalf("latest commit subject = %q, want agent commit", got)
 	}
 }
 
@@ -914,6 +985,103 @@ func TestRunnerReapWorkspaceUsesWorkspaceIssueCleanup(t *testing.T) {
 		workspaceBackend.cleanupIssue.BranchName != "detent/digitaldrywood_detent_311" {
 		t.Fatalf("CleanupIssue() issue = %#v", workspaceBackend.cleanupIssue)
 	}
+}
+
+type committingAgentBackend struct {
+	request AgentTurnRequest
+}
+
+func (b *committingAgentBackend) RunTurn(ctx context.Context, req AgentTurnRequest, _ AgentUpdateHandler) (AgentTurnResult, error) {
+	b.request = req
+	if err := os.WriteFile(filepath.Join(req.Workspace, "agent.txt"), []byte("agent edit\n"), 0o600); err != nil {
+		return AgentTurnResult{}, fmt.Errorf("write agent edit: %w", err)
+	}
+	if err := runAgentGit(ctx, req.Workspace, "add", "agent.txt"); err != nil {
+		return AgentTurnResult{}, err
+	}
+	if err := runAgentGit(ctx, req.Workspace, "commit", "-m", "agent commit"); err != nil {
+		return AgentTurnResult{}, err
+	}
+	return AgentTurnResult{ThreadID: "thread-743", TurnID: "turn-1", SessionID: "thread-743-turn-1"}, nil
+}
+
+func runAgentGit(ctx context.Context, dir string, args ...string) error {
+	gitArgs := append([]string{"-C", dir}, args...)
+	cmd := exec.CommandContext(ctx, "git", gitArgs...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("git %s failed: %w\n%s", strings.Join(gitArgs, " "), err, output)
+	}
+	return nil
+}
+
+func initRunnerSourceRepo(t *testing.T) string {
+	t.Helper()
+
+	dir := t.TempDir()
+	runRunnerGit(t, dir, "init", "-b", "main")
+	runRunnerGit(t, dir, "config", "core.autocrlf", "false")
+	runRunnerGit(t, dir, "config", "user.name", "Test User")
+	runRunnerGit(t, dir, "config", "user.email", "test@example.com")
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("source repo\n"), 0o600); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	runRunnerGit(t, dir, "add", "README.md")
+	runRunnerGit(t, dir, "commit", "-m", "initial")
+	return dir
+}
+
+func runRunnerGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(cmd.Args[1:], " "), err, output)
+	}
+	return string(output)
+}
+
+func sandboxPolicyWritableRoots(t *testing.T, policy any) []string {
+	t.Helper()
+
+	policyMap := sandboxPolicyMapForTest(t, policy)
+	values, ok := policyMap["writableRoots"].([]string)
+	if ok {
+		return values
+	}
+	rawValues, ok := policyMap["writableRoots"].([]any)
+	if !ok {
+		t.Fatalf("sandboxPolicy.writableRoots = %#v, want string list", policyMap["writableRoots"])
+	}
+	roots := make([]string, 0, len(rawValues))
+	for _, raw := range rawValues {
+		root, ok := raw.(string)
+		if !ok {
+			t.Fatalf("sandboxPolicy.writableRoots item = %#v, want string", raw)
+		}
+		roots = append(roots, root)
+	}
+	return roots
+}
+
+func sandboxPolicyMapForTest(t *testing.T, policy any) map[string]any {
+	t.Helper()
+
+	policyMap, ok := policy.(map[string]any)
+	if !ok {
+		t.Fatalf("TurnSandboxPolicy = %T, want map[string]any", policy)
+	}
+	return policyMap
+}
+
+func containsRunnerString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 type fakeWorkspaceBackend struct {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -345,6 +345,26 @@ func TestRunnerRunAddsGitMetadataWritableRootsForManagedWorkspace(t *testing.T) 
 	}
 }
 
+func TestWorkspaceWriteSandboxPolicyMapSkipsExplicitNonWorkspacePolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := map[string]any{
+		"type":          "dangerFullAccess",
+		"networkAccess": true,
+	}
+
+	got, ok := workspaceWriteSandboxPolicyMap("workspace-write", policy)
+	if ok {
+		t.Fatalf("workspaceWriteSandboxPolicyMap() = %#v, true; want false for explicit non-workspace policy", got)
+	}
+	if policy["type"] != "dangerFullAccess" {
+		t.Fatalf("policy type = %#v, want dangerFullAccess", policy["type"])
+	}
+	if _, ok := policy["writableRoots"]; ok {
+		t.Fatalf("policy writableRoots = %#v, want absent", policy["writableRoots"])
+	}
+}
+
 func TestRunnerRunLogsLifecycleWithoutPromptOrMessageBody(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -740,6 +740,147 @@ func gitCommonDir(ctx context.Context, dir string) (string, error) {
 	return canonicalExistingPath(commonDir)
 }
 
+func GitMetadataWritableRoots(ctx context.Context, workspacePath string) ([]string, error) {
+	workspaceRoot, err := canonicalExistingPath(workspacePath)
+	if err != nil {
+		return nil, fmt.Errorf("workspace path: %w", err)
+	}
+	commonDir, err := gitCommonDir(ctx, workspaceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("git common dir: %w", err)
+	}
+
+	roots := []string{}
+	seen := map[string]struct{}{}
+	addRoot := func(path string) {
+		if path == "" || path == commonDir || pathWithin(workspaceRoot, path) || !pathWithin(commonDir, path) {
+			return
+		}
+		if _, ok := seen[path]; ok {
+			return
+		}
+		seen[path] = struct{}{}
+		roots = append(roots, path)
+	}
+
+	gitDir, err := gitDir(ctx, workspaceRoot)
+	if err != nil {
+		return nil, fmt.Errorf("git dir: %w", err)
+	}
+	addRoot(gitDir)
+
+	objectsDir, err := gitExistingPath(ctx, workspaceRoot, "objects")
+	if err != nil {
+		return nil, fmt.Errorf("git objects dir: %w", err)
+	}
+	addRoot(objectsDir)
+
+	ref, err := gitSymbolicHead(ctx, workspaceRoot)
+	if err != nil {
+		var cmdErr *CommandError
+		if errors.As(err, &cmdErr) && cmdErr.ExitCode == 1 {
+			return roots, nil
+		}
+		return nil, fmt.Errorf("git symbolic head: %w", err)
+	}
+	if !strings.HasPrefix(ref, "refs/heads/") {
+		return roots, nil
+	}
+
+	refPath, err := gitPath(ctx, workspaceRoot, ref)
+	if err != nil {
+		return nil, fmt.Errorf("git branch ref path: %w", err)
+	}
+	refDir, err := canonicalExistingDir(filepath.Dir(refPath))
+	if err != nil {
+		return nil, fmt.Errorf("git branch ref dir: %w", err)
+	}
+	addRoot(refDir)
+
+	logPath, err := gitPath(ctx, workspaceRoot, "logs/"+ref)
+	if err != nil {
+		return nil, fmt.Errorf("git branch log path: %w", err)
+	}
+	logDir, err := canonicalExistingDir(filepath.Dir(logPath))
+	if err != nil {
+		return nil, fmt.Errorf("git branch log dir: %w", err)
+	}
+	addRoot(logDir)
+
+	return roots, nil
+}
+
+func gitDir(ctx context.Context, dir string) (string, error) {
+	output, err := runGitAt(ctx, dir, "rev-parse", "--git-dir")
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimSpace(output)
+	if path == "" {
+		return "", errors.New("git dir is empty")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(dir, path)
+	}
+	return canonicalExistingPath(path)
+}
+
+func gitExistingPath(ctx context.Context, dir string, name string) (string, error) {
+	path, err := gitPath(ctx, dir, name)
+	if err != nil {
+		return "", err
+	}
+	return canonicalExistingPath(path)
+}
+
+func gitPath(ctx context.Context, dir string, gitPath string) (string, error) {
+	output, err := runGitAt(ctx, dir, "rev-parse", "--git-path", gitPath)
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimSpace(output)
+	if path == "" {
+		return "", errors.New("git path is empty")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(dir, path)
+	}
+	return filepath.Clean(path), nil
+}
+
+func gitSymbolicHead(ctx context.Context, dir string) (string, error) {
+	output, err := runGitAt(ctx, dir, "symbolic-ref", "-q", "HEAD")
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(output), nil
+}
+
+func canonicalExistingDir(path string) (string, error) {
+	for {
+		canonical, err := canonicalExistingPath(path)
+		if err == nil {
+			return canonical, nil
+		}
+		if !errors.Is(err, fs.ErrNotExist) {
+			return "", err
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			return "", err
+		}
+		path = parent
+	}
+}
+
+func pathWithin(root string, path string) bool {
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
 func hookEnv(info Info, issue Issue) []string {
 	env := append([]string{}, os.Environ()...)
 	values := []struct {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -231,6 +231,56 @@ func TestLocalGitCreateAndCleanupWithoutHooks(t *testing.T) {
 	}
 }
 
+func TestGitMetadataWritableRootsForLinkedWorktree(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), Issue{Identifier: "DD-GIT-ROOTS"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+
+	roots, err := GitMetadataWritableRoots(context.Background(), info.Path)
+	if err != nil {
+		t.Fatalf("GitMetadataWritableRoots() error = %v", err)
+	}
+
+	wantRoots := []string{
+		mustCanonicalExistingPath(t, strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-dir"))),
+		mustCanonicalExistingPath(t, strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-path", "objects"))),
+		mustCanonicalExistingPath(t, filepath.Dir(strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-path", "refs/heads/detent/dd-git-roots")))),
+		mustCanonicalExistingPath(t, filepath.Dir(strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-path", "logs/refs/heads/detent/dd-git-roots")))),
+	}
+	for _, want := range wantRoots {
+		if !containsString(roots, want) {
+			t.Fatalf("GitMetadataWritableRoots() = %#v, missing %q", roots, want)
+		}
+	}
+	if commonDir := mustCanonicalExistingPath(t, strings.TrimSpace(runGit(t, info.Path, "rev-parse", "--git-common-dir"))); containsString(roots, commonDir) {
+		t.Fatalf("GitMetadataWritableRoots() = %#v, should not allow entire common git dir %q", roots, commonDir)
+	}
+
+	if err := os.WriteFile(filepath.Join(info.Path, "agent.txt"), []byte("agent edit\n"), 0o600); err != nil {
+		t.Fatalf("write agent edit: %v", err)
+	}
+	runGit(t, info.Path, "add", "agent.txt")
+	runGit(t, info.Path, "commit", "-m", "agent commit")
+	if got := strings.TrimSpace(runGit(t, info.Path, "log", "-1", "--pretty=%s")); got != "agent commit" {
+		t.Fatalf("latest commit subject = %q, want agent commit", got)
+	}
+}
+
 func TestLocalGitHooksUseNonLoginShell(t *testing.T) {
 	skipWindows(t)
 
@@ -866,6 +916,25 @@ func readFile(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(raw)
+}
+
+func mustCanonicalExistingPath(t *testing.T, path string) string {
+	t.Helper()
+
+	canonical, err := canonicalExistingPath(path)
+	if err != nil {
+		t.Fatalf("canonicalExistingPath(%q) error = %v", path, err)
+	}
+	return canonical
+}
+
+func containsString(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
 }
 
 func shellQuote(value string) string {


### PR DESCRIPTION
## Summary

- Add Git-derived writable roots to Codex `workspace-write` turn sandbox policies for linked worktree metadata, object storage, branch refs, and reflogs.
- Cover managed LocalGit workspaces with regression tests that edit, stage, commit, and assert the worker sandbox policy includes the required roots.

Fixes #743

## Test Plan

- [x] `go test ./internal/workspace ./internal/runner -count=1`
- [x] `make check`