### PR TITLE
fix(onboarding): prefer remote source docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,36 +21,44 @@ manual README skim.
 
 Treat https://github.com/digitaldrywood/detent as the canonical Detent source
 repository. Do not assume the current working directory is the Detent source
-checkout or the target repository being onboarded. If a local Detent checkout is
-present, inspect it; if not, inspect the repository on GitHub or clone it before
-relying on local files. Keep the Detent source repository separate from any
+checkout or the target repository being onboarded. Use GitHub as the
+first-class Detent documentation source when a verified local checkout is
+absent, stale, or not desired. Do not clone Detent by default; cloning is only
+an optional fallback when remote reads are unavailable or I explicitly ask for a
+local source checkout. Keep the Detent source repository separate from any
 target repository being onboarded; Detent may be a reference/source repository,
 not the target.
 
-Before reading local Detent docs or trusting local `detent` command
-recommendations, prove any local Detent source checkout is current with the
-canonical repository. Set `DETENT_SOURCE_ROOT` to the local Detent checkout,
-then run `git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main`,
-`git -C "$DETENT_SOURCE_ROOT" rev-parse HEAD`,
-`git -C "$DETENT_SOURCE_ROOT" rev-parse refs/remotes/origin/main`, and
-`detent --format json version`. Report the local source root, local `HEAD`,
-canonical `origin/main`, installed binary version, binary commit, binary build
-date, `DETENT_SOURCE_MATCHES_CANONICAL`, and
-`DETENT_BINARY_MATCHES_CANONICAL` in the initial evidence packet. If the local
-source checkout or installed binary is stale or cannot be proven current, stop
-before reading local docs or making Phase 2 recommendations; update/reinstall
-Detent or explicitly switch to reading docs from GitHub at the canonical head.
+Pin the Detent docs to a concrete canonical commit before relying on them. Run
+`DETENT_DOCS_COMMIT="$(gh api repos/digitaldrywood/detent/git/ref/heads/main --jq '.object.sha')"`
+and record `DETENT_DOCS_ACCESS_METHOD=github_api`,
+`DETENT_DOCS_REPOSITORY=digitaldrywood/detent`, `DETENT_DOCS_REF=main`, and
+`DETENT_DOCS_COMMIT` in the initial evidence packet. Also run
+`detent --format json version` when the binary is available and report installed
+binary version, binary commit, binary build date, and
+`DETENT_BINARY_MATCHES_CANONICAL` against `DETENT_DOCS_COMMIT`. If a verified
+local Detent checkout is present, you may additionally set `DETENT_SOURCE_ROOT`
+and run `git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main`,
+`git -C "$DETENT_SOURCE_ROOT" rev-parse HEAD`, and
+`git -C "$DETENT_SOURCE_ROOT" rev-parse refs/remotes/origin/main`; report the
+local source root, local `HEAD`, canonical `origin/main`, and
+`DETENT_SOURCE_MATCHES_CANONICAL`. If the local checkout is absent, stale, or
+cannot be proven current, read Detent docs from GitHub at `DETENT_DOCS_COMMIT`
+instead of cloning or relying on local files.
 
-From the Detent source repository, read README.md, CLAUDE.md or AGENTS.md if
-present, docs/ONBOARDING.md, CONTRIBUTING.md, build and language manifests,
-.github/workflows, install scripts, and any existing WORKFLOW.md or global.yaml
-examples. Detent can drive any project with a clear workflow and validation
-gate, so use the repository evidence to identify the stack, tools, and commands
-instead of starting from one language. Do not inspect a target repository's
+From the pinned Detent documentation source, read README.md, AGENTS.md and
+CLAUDE.md if present, docs/ONBOARDING.md, CONTRIBUTING.md, build and language
+manifests, .github/workflows, install scripts, docs/templates, workflow
+examples, and any existing WORKFLOW.md or global.yaml examples. Use
+`gh api repos/digitaldrywood/detent/contents/<path>?ref="$DETENT_DOCS_COMMIT"`
+or raw GitHub URLs pinned to the same commit. Detent can drive any project with
+a clear workflow and validation gate, so use the repository evidence to
+identify the stack, tools, and commands instead of starting from one language.
+Do not inspect a target repository's
 ProjectV2 boards, labels, issues, WORKFLOW.md, validation commands, or runtime
 docs until the identity gate below is explicit and confirmed.
 
-Use the Detent source repository's docs/ONBOARDING.md as the interrogation
+Use the pinned Detent documentation source's docs/ONBOARDING.md as the interrogation
 guide. First determine which path applies: a new Detent install, an existing
 Detent install that must be found and verified, or a new repository/project
 being added to an existing Detent install. Distinguish reference repositories from the target repository being onboarded. In Phase 0.5, run
@@ -64,8 +72,8 @@ To write the candidate identity record, run
 Treat the draft as a candidate, not confirmation. The command should infer and
 restate an identity candidate from the current git checkout before asking for
 raw answer fields, using only identity-safe local evidence first: `pwd`,
-`git rev-parse --show-toplevel`, `git remote get-url origin`, the canonical
-Detent source checkout identity, the installed Detent config path, and
+`git rev-parse --show-toplevel`, `git remote get-url origin`, the Detent
+documentation source identity, the installed Detent config path, and
 registered project ids. If the current working directory is a GitHub checkout
 and is not the canonical Detent source checkout, propose it as the target
 candidate. If the current working directory is the Detent source checkout, do

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -27,22 +27,85 @@ Use these placeholders consistently:
 
 ## Source Freshness Gate
 
-Before relying on a local copy of this runbook, local `README.md`, or local
-`detent` command recommendations, prove the local Detent source checkout is
-current with `digitaldrywood/detent`. If no local Detent source checkout is
-available, read docs from GitHub at the canonical head instead of local
-files.
+Before relying on this runbook, `README.md`, or `detent` command
+recommendations, pin the Detent documentation source to a concrete canonical
+commit from `digitaldrywood/detent`. A local Detent checkout is optional. Use
+the remote GitHub documentation source when a verified local checkout is absent,
+stale, or not desired. Do not clone Detent by default; cloning is only an
+optional fallback when remote reads are unavailable or the operator explicitly
+asks for a local source checkout.
+
+### Remote Detent Documentation Source
+
+Use GitHub as the first-class documentation source and record the pinned commit
+in the initial evidence packet:
 
 ```sh
 ONBOARDING_DIR="${ONBOARDING_DIR:-${TMPDIR:-/tmp}/detent-onboarding-<repo-owner>-<repo-name>}"
 mkdir -p "$ONBOARDING_DIR"
+DETENT_DOCS_ACCESS_METHOD=github_api
+DETENT_DOCS_REPOSITORY=digitaldrywood/detent
+DETENT_DOCS_REF=main
+DETENT_DOCS_COMMIT="$(
+  gh api repos/digitaldrywood/detent/git/ref/heads/main --jq '.object.sha'
+)"
+DETENT_VERSION_JSON="$(detent --format json version 2>/dev/null || true)"
+DETENT_BINARY_VERSION="$(printf '%s\n' "$DETENT_VERSION_JSON" | jq -r '.version // empty' 2>/dev/null || true)"
+DETENT_BINARY_COMMIT="$(printf '%s\n' "$DETENT_VERSION_JSON" | jq -r '.commit // empty' 2>/dev/null || true)"
+DETENT_BINARY_BUILD_DATE="$(printf '%s\n' "$DETENT_VERSION_JSON" | jq -r '.build_date // empty' 2>/dev/null || true)"
+
+if test -n "$DETENT_BINARY_COMMIT" && test "$DETENT_BINARY_COMMIT" = "$DETENT_DOCS_COMMIT"; then
+  DETENT_BINARY_MATCHES_CANONICAL=true
+else
+  DETENT_BINARY_MATCHES_CANONICAL=false
+fi
+
+{
+  printf 'DETENT_DOCS_ACCESS_METHOD=%s\n' "$DETENT_DOCS_ACCESS_METHOD"
+  printf 'DETENT_DOCS_REPOSITORY=%s\n' "$DETENT_DOCS_REPOSITORY"
+  printf 'DETENT_DOCS_REF=%s\n' "$DETENT_DOCS_REF"
+  printf 'DETENT_DOCS_COMMIT=%s\n' "$DETENT_DOCS_COMMIT"
+  printf 'DETENT_BINARY_VERSION=%s\n' "$DETENT_BINARY_VERSION"
+  printf 'DETENT_BINARY_COMMIT=%s\n' "$DETENT_BINARY_COMMIT"
+  printf 'DETENT_BINARY_BUILD_DATE=%s\n' "$DETENT_BINARY_BUILD_DATE"
+  printf 'DETENT_BINARY_MATCHES_CANONICAL=%s\n' "$DETENT_BINARY_MATCHES_CANONICAL"
+  printf 'DETENT_VERSION_JSON=%s\n' "$DETENT_VERSION_JSON"
+} > "$ONBOARDING_DIR/detent-source-freshness.env"
+
+test -n "$DETENT_DOCS_COMMIT"
+```
+
+Read required Detent files from GitHub at the pinned commit. Required file
+coverage is README.md AGENTS.md CLAUDE.md docs/ONBOARDING.md CONTRIBUTING.md,
+build and language manifests, .github/workflows docs/templates, install
+scripts, workflow examples, and any existing WORKFLOW.md or global.yaml
+examples.
+
+```sh
+for path in README.md AGENTS.md CLAUDE.md docs/ONBOARDING.md CONTRIBUTING.md Makefile go.mod; do
+  gh api "repos/$DETENT_DOCS_REPOSITORY/contents/$path?ref=$DETENT_DOCS_COMMIT" \
+    --jq '.content' 2>/dev/null | base64 --decode || true
+done
+
+gh api "repos/$DETENT_DOCS_REPOSITORY/contents/.github/workflows?ref=$DETENT_DOCS_COMMIT" \
+  --jq '.[].path' 2>/dev/null || true
+gh api "repos/$DETENT_DOCS_REPOSITORY/contents/docs/templates?ref=$DETENT_DOCS_COMMIT" \
+  --jq '.[].path' 2>/dev/null || true
+```
+
+### Local Detent Source Checkout
+
+If a local Detent checkout is explicitly known and verified, you may use it as
+a local documentation source. Keep it separate from the target repository, set
+`DETENT_SOURCE_ROOT` only after verifying the checkout root, then compare it to
+the canonical repository:
+
+```sh
 DETENT_SOURCE_ROOT="<absolute-local-detent-source-checkout>"
 
 git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main
 DETENT_SOURCE_HEAD="$(git -C "$DETENT_SOURCE_ROOT" rev-parse HEAD)"
 DETENT_CANONICAL_MAIN="$(git -C "$DETENT_SOURCE_ROOT" rev-parse refs/remotes/origin/main)"
-DETENT_VERSION_JSON="$(detent --format json version 2>/dev/null || true)"
-DETENT_BINARY_COMMIT="$(printf '%s\n' "$DETENT_VERSION_JSON" | jq -r '.commit // empty' 2>/dev/null || true)"
 
 if test "$DETENT_SOURCE_HEAD" = "$DETENT_CANONICAL_MAIN"; then
   DETENT_SOURCE_MATCHES_CANONICAL=true
@@ -50,31 +113,26 @@ else
   DETENT_SOURCE_MATCHES_CANONICAL=false
 fi
 
-if test -n "$DETENT_BINARY_COMMIT" && test "$DETENT_BINARY_COMMIT" = "$DETENT_CANONICAL_MAIN"; then
-  DETENT_BINARY_MATCHES_CANONICAL=true
-else
-  DETENT_BINARY_MATCHES_CANONICAL=false
-fi
-
 {
+  cat "$ONBOARDING_DIR/detent-source-freshness.env" 2>/dev/null || true
   printf 'DETENT_SOURCE_ROOT=%s\n' "$DETENT_SOURCE_ROOT"
   printf 'DETENT_SOURCE_HEAD=%s\n' "$DETENT_SOURCE_HEAD"
   printf 'DETENT_CANONICAL_MAIN=%s\n' "$DETENT_CANONICAL_MAIN"
   printf 'DETENT_SOURCE_MATCHES_CANONICAL=%s\n' "$DETENT_SOURCE_MATCHES_CANONICAL"
-  printf 'DETENT_BINARY_COMMIT=%s\n' "$DETENT_BINARY_COMMIT"
-  printf 'DETENT_BINARY_MATCHES_CANONICAL=%s\n' "$DETENT_BINARY_MATCHES_CANONICAL"
-  printf 'DETENT_VERSION_JSON=%s\n' "$DETENT_VERSION_JSON"
-} > "$ONBOARDING_DIR/detent-source-freshness.env"
-
-test "$DETENT_SOURCE_MATCHES_CANONICAL" = true
-test "$DETENT_BINARY_MATCHES_CANONICAL" = true
+} > "$ONBOARDING_DIR/detent-source-freshness.next.env"
+mv "$ONBOARDING_DIR/detent-source-freshness.next.env" "$ONBOARDING_DIR/detent-source-freshness.env"
 ```
 
-If either check fails, stop before Phase 2 recommendations. Update the local
-source checkout and reinstall the binary, or explicitly read docs from GitHub
-at the canonical head. Include
+If the local checkout is absent, stale, or cannot be proven current, do not read
+local Detent docs from it. Continue from the remote GitHub documentation source
+at `DETENT_DOCS_COMMIT` instead. Stop before Phase 2 recommendations only when
+neither a pinned remote documentation source nor a verified local documentation
+source is available, or when the installed binary must be present for a command
+recommendation and cannot be verified. Include
 `$ONBOARDING_DIR/detent-source-freshness.env` in the initial evidence packet so
-the operator can see which runbook and binary version are being followed.
+the operator can see the documentation repository, ref, commit SHA, access
+method, binary version/commit/build date when available, and whether the
+binary/docs match canonical.
 
 ## Start Here — Determine The Mode
 
@@ -268,11 +326,14 @@ Draft the first candidate from identity-safe local evidence. Run this from the
 target checkout:
 
 ```sh
-detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --output pretty
-detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --answers "$ONBOARDING_DIR/answers.env" --write
+detent onboarding draft-answers --output pretty
+detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write
 ```
 
-If you are currently in the Detent source checkout, pass the target explicitly:
+If a verified local Detent source checkout is available and you want the draft
+to include local source freshness evidence, add
+`--detent-source-root "$DETENT_SOURCE_ROOT"`. If you are currently in the Detent
+source checkout, pass the target explicitly:
 
 ```sh
 detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --target-source-root <absolute-local-checkout-path> --output pretty
@@ -281,7 +342,7 @@ detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --tar
 
 The draft command may inspect only local identity evidence: current working
 directory and git top-level, origin remote and parsed GitHub owner/name,
-canonical Detent source repository evidence, Detent config path and registered
+Detent documentation source evidence, Detent config path and registered
 project ids, and local installed binary/config/service evidence needed to
 recommend `new-install`, `existing-install`, or `add-project`. It must not
 inspect target ProjectV2 boards, organization issue fields, repository labels,
@@ -290,7 +351,7 @@ issues, `WORKFLOW.md`, validation commands, deployment docs, or runtime docs.
 The command should infer and restate an identity candidate from the current git
 checkout before asking for raw answer fields. Its local evidence includes
 `pwd`, `git rev-parse --show-toplevel`, `git remote get-url origin`, the
-canonical Detent source checkout identity, the installed Detent config path, and
+Detent documentation source identity, the installed Detent config path, and
 registered project ids. If the current working directory is a GitHub checkout
 and its git top level is not the canonical Detent source checkout, it proposes
 that checkout as the target candidate. It derives `TARGET_REPOSITORY` from the

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -28,6 +28,7 @@ const (
 	onboardingAnswersPhaseDecision = "decision"
 	onboardingAnswersPhaseMutation = "mutation"
 	onboardingDetentRepository     = "digitaldrywood/detent"
+	onboardingDetentCanonicalRef   = "main"
 )
 
 var (
@@ -88,23 +89,30 @@ type onboardingDraftAnswersResult struct {
 }
 
 type onboardingDetentFreshnessEvidence struct {
-	SourceChecked                bool   `json:"source_checked"`
-	SourceRoot                   string `json:"source_root,omitempty"`
-	SourceRemote                 string `json:"source_remote,omitempty"`
-	SourceRepository             string `json:"source_repository,omitempty"`
-	SourceHead                   string `json:"source_head,omitempty"`
-	CanonicalMain                string `json:"canonical_main,omitempty"`
-	SourceMatchesCanonical       bool   `json:"source_matches_canonical"`
-	SourceStatus                 string `json:"source_status"`
-	SourceError                  string `json:"source_error,omitempty"`
-	BinaryChecked                bool   `json:"binary_checked"`
-	BinaryVersion                string `json:"binary_version,omitempty"`
-	BinaryCommit                 string `json:"binary_commit,omitempty"`
-	BinaryBuildDate              string `json:"binary_build_date,omitempty"`
-	BinaryMatchesCanonical       bool   `json:"binary_matches_canonical"`
-	BinaryStatus                 string `json:"binary_status"`
-	BinaryError                  string `json:"binary_error,omitempty"`
-	Phase2RecommendationsBlocked bool   `json:"phase2_recommendations_blocked"`
+	SourceChecked                 bool   `json:"source_checked"`
+	SourceRoot                    string `json:"source_root,omitempty"`
+	SourceRemote                  string `json:"source_remote,omitempty"`
+	SourceRepository              string `json:"source_repository,omitempty"`
+	SourceHead                    string `json:"source_head,omitempty"`
+	CanonicalMain                 string `json:"canonical_main,omitempty"`
+	SourceMatchesCanonical        bool   `json:"source_matches_canonical"`
+	SourceStatus                  string `json:"source_status"`
+	SourceError                   string `json:"source_error,omitempty"`
+	DocumentationAccessMethod     string `json:"documentation_access_method,omitempty"`
+	DocumentationRepository       string `json:"documentation_repository,omitempty"`
+	DocumentationRef              string `json:"documentation_ref,omitempty"`
+	DocumentationCommit           string `json:"documentation_commit,omitempty"`
+	DocumentationMatchesCanonical bool   `json:"documentation_matches_canonical"`
+	DocumentationStatus           string `json:"documentation_status,omitempty"`
+	DocumentationError            string `json:"documentation_error,omitempty"`
+	BinaryChecked                 bool   `json:"binary_checked"`
+	BinaryVersion                 string `json:"binary_version,omitempty"`
+	BinaryCommit                  string `json:"binary_commit,omitempty"`
+	BinaryBuildDate               string `json:"binary_build_date,omitempty"`
+	BinaryMatchesCanonical        bool   `json:"binary_matches_canonical"`
+	BinaryStatus                  string `json:"binary_status"`
+	BinaryError                   string `json:"binary_error,omitempty"`
+	Phase2RecommendationsBlocked  bool   `json:"phase2_recommendations_blocked"`
 }
 
 type onboardingDetentVersionEvidence struct {
@@ -462,23 +470,73 @@ func draftOnboardingAnswers(ctx context.Context, cfg onboardingDraftAnswersConfi
 
 func onboardingDetentFreshness(ctx context.Context, detentSourceRoot string, opts options) onboardingDetentFreshnessEvidence {
 	evidence := onboardingDetentFreshnessEvidence{
-		SourceStatus: "not_checked",
-		BinaryStatus: "not_checked",
+		SourceStatus:        "not_checked",
+		DocumentationStatus: "not_checked",
+		BinaryStatus:        "not_checked",
 	}
 	sourceInput := strings.TrimSpace(detentSourceRoot)
 	if sourceInput != "" {
 		evidence = onboardingDetentSourceFreshness(ctx, sourceInput, opts)
+		if evidence.SourceStatus == "current" {
+			evidence = onboardingDetentLocalDocumentationFreshness(evidence)
+		}
+	} else {
+		evidence = onboardingDetentRemoteDocumentationFreshness(ctx, opts, evidence)
 	}
 	evidence = onboardingDetentBinaryFreshness(ctx, opts, evidence)
 	evidence.Phase2RecommendationsBlocked = onboardingDetentFreshnessBlocksPhase2(evidence)
 	return evidence
 }
 
+func onboardingDetentLocalDocumentationFreshness(evidence onboardingDetentFreshnessEvidence) onboardingDetentFreshnessEvidence {
+	evidence.DocumentationAccessMethod = "local_checkout"
+	evidence.DocumentationRepository = strings.TrimSpace(evidence.SourceRepository)
+	if evidence.DocumentationRepository == "" {
+		evidence.DocumentationRepository = onboardingDetentRepository
+	}
+	evidence.DocumentationRef = "HEAD"
+	evidence.DocumentationCommit = strings.TrimSpace(evidence.SourceHead)
+	evidence.DocumentationMatchesCanonical = onboardingCommitsMatch(evidence.DocumentationCommit, evidence.CanonicalMain)
+	evidence.DocumentationStatus = evidence.SourceStatus
+	return evidence
+}
+
+func onboardingDetentRemoteDocumentationFreshness(ctx context.Context, opts options, evidence onboardingDetentFreshnessEvidence) onboardingDetentFreshnessEvidence {
+	evidence.DocumentationAccessMethod = "github_api"
+	evidence.DocumentationRepository = onboardingDetentRepository
+	evidence.DocumentationRef = onboardingDetentCanonicalRef
+	evidence.DocumentationStatus = "error"
+	output, err := onboardingRunCommand(
+		ctx,
+		opts,
+		"gh",
+		"api",
+		"repos/"+onboardingDetentRepository+"/git/ref/heads/"+onboardingDetentCanonicalRef,
+		"--jq",
+		".object.sha",
+	)
+	if err != nil {
+		evidence.DocumentationError = err.Error()
+		return evidence
+	}
+	commit := strings.TrimSpace(output)
+	if commit == "" {
+		evidence.DocumentationError = "GitHub API returned blank canonical Detent commit"
+		return evidence
+	}
+	evidence.CanonicalMain = commit
+	evidence.DocumentationCommit = commit
+	evidence.DocumentationMatchesCanonical = true
+	evidence.DocumentationStatus = "current"
+	return evidence
+}
+
 func onboardingDetentSourceFreshness(ctx context.Context, sourceInput string, opts options) onboardingDetentFreshnessEvidence {
 	evidence := onboardingDetentFreshnessEvidence{
-		SourceChecked: true,
-		SourceStatus:  "error",
-		BinaryStatus:  "not_checked",
+		SourceChecked:       true,
+		SourceStatus:        "error",
+		DocumentationStatus: "not_checked",
+		BinaryStatus:        "not_checked",
 	}
 	root, err := defaultGitTopLevel(ctx, sourceInput)
 	if err != nil {
@@ -575,7 +633,10 @@ func onboardingDetentFreshnessBlocksPhase2(evidence onboardingDetentFreshnessEvi
 	if strings.TrimSpace(evidence.CanonicalMain) == "" {
 		return false
 	}
-	return evidence.BinaryStatus != "current"
+	if evidence.BinaryStatus == "stale" {
+		return true
+	}
+	return evidence.SourceChecked && evidence.BinaryStatus != "current"
 }
 
 func onboardingDetentFreshnessNotes(evidence onboardingDetentFreshnessEvidence) []string {
@@ -591,6 +652,17 @@ func onboardingDetentFreshnessNotes(evidence onboardingDetentFreshnessEvidence) 
 		default:
 			notes = append(notes, "could not prove Detent source checkout freshness; fetch/update it or read onboarding docs from GitHub at the canonical head before Phase 2 recommendations")
 		}
+	}
+	if evidence.DocumentationStatus == "current" {
+		switch evidence.DocumentationAccessMethod {
+		case "github_api":
+			notes = append(notes, "Detent source docs will be read from GitHub at digitaldrywood/detent main")
+		case "local_checkout":
+			notes = append(notes, "Detent source docs will be read from the verified local checkout")
+		}
+	}
+	if evidence.DocumentationStatus == "error" {
+		notes = append(notes, "could not read canonical Detent docs from GitHub; retry gh or use a verified local checkout before Phase 2 recommendations")
 	}
 	if evidence.BinaryStatus == "stale" {
 		notes = append(notes, "installed Detent binary commit differs from fetched origin/main; reinstall before using local command recommendations")

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -630,6 +630,9 @@ func onboardingDetentFreshnessBlocksPhase2(evidence onboardingDetentFreshnessEvi
 	if evidence.SourceChecked && evidence.SourceStatus != "current" {
 		return true
 	}
+	if !evidence.SourceChecked && evidence.DocumentationStatus != "current" {
+		return true
+	}
 	if strings.TrimSpace(evidence.CanonicalMain) == "" {
 		return false
 	}

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -689,7 +689,12 @@ func TestOnboardingDraftAnswersCommandPrefersRepoPrefixForSharedOwner(t *testing
 	targetRoot := initOnboardingGitRepository(t, "https://github.com/digitaldrywood/creswoodcorners-phone.git")
 	t.Chdir(targetRoot)
 
-	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	canonicalMain := "b6b8fc5d8f0f5ed413f6b0b9694970c0f02c6d7d"
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(onboardingTestCommandRunnerWithRemoteDetentDocs(detentVersionJSON(canonicalMain), canonicalMain)),
+	)
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
@@ -738,7 +743,12 @@ func TestOnboardingDraftAnswersCommandKeepsNormalOwnerForProductSuffixRepo(t *te
 	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/payments-api.git")
 	t.Chdir(targetRoot)
 
-	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	canonicalMain := "b6b8fc5d8f0f5ed413f6b0b9694970c0f02c6d7d"
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(onboardingTestCommandRunnerWithRemoteDetentDocs(detentVersionJSON(canonicalMain), canonicalMain)),
+	)
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
@@ -1197,7 +1207,12 @@ func TestOnboardingDraftAnswersCommandAcceptsIdentityOverrides(t *testing.T) {
 	answersPath := filepath.Join(t.TempDir(), "answers.env")
 	t.Chdir(targetRoot)
 
-	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	canonicalMain := "b6b8fc5d8f0f5ed413f6b0b9694970c0f02c6d7d"
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(onboardingTestCommandRunnerWithRemoteDetentDocs(detentVersionJSON(canonicalMain), canonicalMain)),
+	)
 	var stdout bytes.Buffer
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&bytes.Buffer{})
@@ -1637,6 +1652,20 @@ func onboardingTestCommandRunner(detentVersionOutput string) cli.CommandRunner {
 		cmd := exec.CommandContext(ctx, name, args...)
 		output, err := cmd.CombinedOutput()
 		return string(output), err
+	}
+}
+
+func onboardingTestCommandRunnerWithRemoteDetentDocs(detentVersionOutput string, canonicalMain string) cli.CommandRunner {
+	base := onboardingTestCommandRunner(detentVersionOutput)
+	return func(ctx context.Context, name string, args ...string) (string, error) {
+		if name == "gh" {
+			want := []string{"api", "repos/digitaldrywood/detent/git/ref/heads/main", "--jq", ".object.sha"}
+			if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+				return "", fmt.Errorf("unexpected gh args: %s", strings.Join(args, " "))
+			}
+			return canonicalMain + "\n", nil
+		}
+		return base(ctx, name, args...)
 	}
 }
 

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -965,6 +966,97 @@ func TestOnboardingDraftAnswersCommandReportsCurrentDetentSourceAndBinary(t *tes
 	}
 	if !containsSubstring(got.Notes, "Detent source checkout matches fetched origin/main") {
 		t.Fatalf("notes = %#v, want current source note", got.Notes)
+	}
+}
+
+func TestOnboardingDraftAnswersCommandUsesRemoteDetentDocsWithoutLocalCheckout(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	canonicalMain := "b6b8fc5d8f0f5ed413f6b0b9694970c0f02c6d7d"
+	t.Chdir(targetRoot)
+
+	ghRefRequested := false
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(func(ctx context.Context, name string, args ...string) (string, error) {
+			if name == "detent" {
+				return detentVersionJSON(canonicalMain), nil
+			}
+			if name == "gh" {
+				want := []string{"api", "repos/digitaldrywood/detent/git/ref/heads/main", "--jq", ".object.sha"}
+				if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+					return "", fmt.Errorf("unexpected gh args: %s", strings.Join(args, " "))
+				}
+				ghRefRequested = true
+				return canonicalMain + "\n", nil
+			}
+			return onboardingTestCommandRunner(detentVersionJSON(canonicalMain))(ctx, name, args...)
+		}),
+	)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"--config", filepath.Join(t.TempDir(), "global.yaml"),
+		"onboarding", "draft-answers",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !ghRefRequested {
+		t.Fatal("draft-answers did not request canonical Detent docs from GitHub")
+	}
+
+	var got struct {
+		Confidence      string `json:"confidence"`
+		DetentFreshness struct {
+			SourceChecked                 bool   `json:"source_checked"`
+			SourceStatus                  string `json:"source_status"`
+			CanonicalMain                 string `json:"canonical_main"`
+			DocumentationAccessMethod     string `json:"documentation_access_method"`
+			DocumentationRepository       string `json:"documentation_repository"`
+			DocumentationRef              string `json:"documentation_ref"`
+			DocumentationCommit           string `json:"documentation_commit"`
+			DocumentationMatchesCanonical bool   `json:"documentation_matches_canonical"`
+			DocumentationStatus           string `json:"documentation_status"`
+			BinaryVersion                 string `json:"binary_version"`
+			BinaryCommit                  string `json:"binary_commit"`
+			BinaryBuildDate               string `json:"binary_build_date"`
+			BinaryMatchesCanonical        bool   `json:"binary_matches_canonical"`
+			BinaryStatus                  string `json:"binary_status"`
+			Phase2RecommendationsBlocked  bool   `json:"phase2_recommendations_blocked"`
+		} `json:"detent_freshness"`
+		Notes []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	freshness := got.DetentFreshness
+	if freshness.SourceChecked || freshness.SourceStatus != "not_checked" {
+		t.Fatalf("local source freshness = %#v, want no local source checkout inspection", freshness)
+	}
+	if freshness.CanonicalMain != canonicalMain {
+		t.Fatalf("canonical main = %q, want %q", freshness.CanonicalMain, canonicalMain)
+	}
+	if freshness.DocumentationAccessMethod != "github_api" ||
+		freshness.DocumentationRepository != "digitaldrywood/detent" ||
+		freshness.DocumentationRef != "main" ||
+		freshness.DocumentationCommit != canonicalMain ||
+		!freshness.DocumentationMatchesCanonical ||
+		freshness.DocumentationStatus != "current" {
+		t.Fatalf("documentation freshness = %#v, want GitHub canonical docs at %s", freshness, canonicalMain)
+	}
+	if freshness.BinaryVersion == "" || freshness.BinaryCommit != canonicalMain || freshness.BinaryBuildDate == "" ||
+		!freshness.BinaryMatchesCanonical || freshness.BinaryStatus != "current" {
+		t.Fatalf("binary freshness = %#v, want binary matched to canonical docs", freshness)
+	}
+	if freshness.Phase2RecommendationsBlocked || got.Confidence != "medium" {
+		t.Fatalf("freshness = %#v confidence = %q, want remote docs path unblocked", freshness, got.Confidence)
+	}
+	if !containsSubstring(got.Notes, "Detent source docs will be read from GitHub at digitaldrywood/detent main") {
+		t.Fatalf("notes = %#v, want remote documentation note", got.Notes)
 	}
 }
 

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -1060,6 +1060,85 @@ func TestOnboardingDraftAnswersCommandUsesRemoteDetentDocsWithoutLocalCheckout(t
 	}
 }
 
+func TestOnboardingDraftAnswersCommandBlocksFailedRemoteDetentDocsWithoutLocalCheckout(t *testing.T) {
+	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
+	t.Chdir(targetRoot)
+
+	ghRefRequested := false
+	cmd := cli.NewRootCommand(
+		context.Background(),
+		cli.WithStdoutTTY(func() bool { return false }),
+		cli.WithCommandRunner(func(ctx context.Context, name string, args ...string) (string, error) {
+			if name == "detent" {
+				return detentVersionJSON("local"), nil
+			}
+			if name == "gh" {
+				want := []string{"api", "repos/digitaldrywood/detent/git/ref/heads/main", "--jq", ".object.sha"}
+				if strings.Join(args, "\x00") != strings.Join(want, "\x00") {
+					return "", fmt.Errorf("unexpected gh args: %s", strings.Join(args, " "))
+				}
+				ghRefRequested = true
+				return "", fmt.Errorf("gh auth failed")
+			}
+			return onboardingTestCommandRunner(detentVersionJSON("local"))(ctx, name, args...)
+		}),
+	)
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--format", "json",
+		"--config", filepath.Join(t.TempDir(), "global.yaml"),
+		"onboarding", "draft-answers",
+	})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	if !ghRefRequested {
+		t.Fatal("draft-answers did not request canonical Detent docs from GitHub")
+	}
+
+	var got struct {
+		Confidence      string `json:"confidence"`
+		DetentFreshness struct {
+			SourceChecked                bool   `json:"source_checked"`
+			SourceStatus                 string `json:"source_status"`
+			CanonicalMain                string `json:"canonical_main"`
+			DocumentationAccessMethod    string `json:"documentation_access_method"`
+			DocumentationRepository      string `json:"documentation_repository"`
+			DocumentationRef             string `json:"documentation_ref"`
+			DocumentationStatus          string `json:"documentation_status"`
+			DocumentationError           string `json:"documentation_error"`
+			Phase2RecommendationsBlocked bool   `json:"phase2_recommendations_blocked"`
+		} `json:"detent_freshness"`
+		Notes []string `json:"notes"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	freshness := got.DetentFreshness
+	if freshness.SourceChecked || freshness.SourceStatus != "not_checked" {
+		t.Fatalf("local source freshness = %#v, want no local source checkout inspection", freshness)
+	}
+	if freshness.CanonicalMain != "" {
+		t.Fatalf("canonical main = %q, want blank when remote docs cannot be pinned", freshness.CanonicalMain)
+	}
+	if freshness.DocumentationAccessMethod != "github_api" ||
+		freshness.DocumentationRepository != "digitaldrywood/detent" ||
+		freshness.DocumentationRef != "main" ||
+		freshness.DocumentationStatus != "error" ||
+		freshness.DocumentationError == "" {
+		t.Fatalf("documentation freshness = %#v, want failed GitHub canonical docs evidence", freshness)
+	}
+	if !freshness.Phase2RecommendationsBlocked || got.Confidence != "needs-review" {
+		t.Fatalf("freshness = %#v confidence = %q, want failed remote docs path blocked", freshness, got.Confidence)
+	}
+	if !containsSubstring(got.Notes, "could not read canonical Detent docs from GitHub") {
+		t.Fatalf("notes = %#v, want remote documentation error note", got.Notes)
+	}
+}
+
 func TestOnboardingDraftAnswersCommandBlocksUnprovenDetentBinary(t *testing.T) {
 	targetRoot := initOnboardingGitRepository(t, "https://github.com/acme/api.git")
 	sourceRoot, _, canonicalMain := initOnboardingDetentSourceCheckout(t, false)

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -70,8 +70,9 @@ func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	}
 
 	for _, want := range []string{
-		`detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --output pretty`,
-		`detent onboarding draft-answers --detent-source-root "$DETENT_SOURCE_ROOT" --answers "$ONBOARDING_DIR/answers.env" --write`,
+		`detent onboarding draft-answers --output pretty`,
+		`detent onboarding draft-answers --answers "$ONBOARDING_DIR/answers.env" --write`,
+		`If a verified local Detent source checkout is available and you want the draft`,
 		"CUSTOMER_ID=<customer-or-workstream-id>",
 		"DETENT_PROJECT_ID=<local-detent-project-id>",
 		"TARGET_REPOSITORY=<repo-owner>/<repo-name>",
@@ -99,6 +100,11 @@ func TestOnboardingDocsRequireDetentSourceFreshnessBeforeRunbook(t *testing.T) {
 	readme := readRepositoryTextFile(t, "README.md")
 
 	for _, want := range []string{
+		`gh api repos/digitaldrywood/detent/git/ref/heads/main --jq '.object.sha'`,
+		"DETENT_DOCS_ACCESS_METHOD=github_api",
+		"DETENT_DOCS_REPOSITORY=digitaldrywood/detent",
+		"DETENT_DOCS_REF=main",
+		"DETENT_DOCS_COMMIT",
 		`git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main`,
 		`git -C "$DETENT_SOURCE_ROOT" rev-parse HEAD`,
 		`git -C "$DETENT_SOURCE_ROOT" rev-parse refs/remotes/origin/main`,
@@ -106,27 +112,64 @@ func TestOnboardingDocsRequireDetentSourceFreshnessBeforeRunbook(t *testing.T) {
 		"DETENT_SOURCE_MATCHES_CANONICAL",
 		"DETENT_BINARY_MATCHES_CANONICAL",
 		"$ONBOARDING_DIR/detent-source-freshness.env",
-		"stop before Phase 2 recommendations",
-		"read docs from GitHub at the canonical head",
+		"Continue from the remote GitHub documentation source",
+		"documentation repository, ref, commit SHA, access",
 	} {
 		assertContains(t, onboarding, want)
 	}
 
 	for _, want := range []string{
-		"Before reading local Detent docs or trusting local `detent` command recommendations",
+		"Pin the Detent docs to a concrete canonical commit before relying on them",
+		"`DETENT_DOCS_ACCESS_METHOD=github_api`",
+		"`DETENT_DOCS_REPOSITORY=digitaldrywood/detent`",
+		"`DETENT_DOCS_REF=main`",
+		"`DETENT_DOCS_COMMIT`",
 		`git -C "$DETENT_SOURCE_ROOT" fetch origin main:refs/remotes/origin/main`,
 		"`DETENT_SOURCE_MATCHES_CANONICAL`",
 		"`DETENT_BINARY_MATCHES_CANONICAL`",
-		"stop before reading local docs or making Phase 2 recommendations",
-		"reading docs from GitHub at the canonical head",
+		"read Detent docs from GitHub at `DETENT_DOCS_COMMIT` instead of cloning or relying on local files",
 		`--detent-source-root "$DETENT_SOURCE_ROOT"`,
 	} {
 		assertContainsWords(t, readme, want)
 	}
 
-	assertOrder(t, readme, "Before reading local Detent docs", "From the Detent source repository, read README.md")
+	assertOrder(t, readme, "Pin the Detent docs", "From the pinned Detent documentation source, read README.md")
 	assertOrder(t, onboarding, "## Source Freshness Gate", "## Start Here")
-	assertOrder(t, onboarding, "DETENT_SOURCE_MATCHES_CANONICAL", "## Phase 0.5")
+	assertOrder(t, onboarding, "DETENT_DOCS_COMMIT", "## Phase 0.5")
+}
+
+func TestOnboardingDocsAllowRemoteDetentSourceInspectionWithoutLocalCheckout(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+
+	for _, want := range []string{
+		"Remote Detent Documentation Source",
+		"DETENT_DOCS_ACCESS_METHOD=github_api",
+		"DETENT_DOCS_REPOSITORY=digitaldrywood/detent",
+		"DETENT_DOCS_REF=main",
+		"DETENT_DOCS_COMMIT",
+		`gh api repos/digitaldrywood/detent/git/ref/heads/main --jq '.object.sha'`,
+		"README.md AGENTS.md CLAUDE.md docs/ONBOARDING.md CONTRIBUTING.md",
+		".github/workflows docs/templates",
+		"Do not clone Detent by default",
+	} {
+		assertContains(t, onboarding, want)
+	}
+
+	for _, want := range []string{
+		"Use GitHub as the first-class Detent documentation source when a verified local checkout is absent, stale, or not desired",
+		"gh api repos/digitaldrywood/detent/git/ref/heads/main --jq '.object.sha'",
+		"`DETENT_DOCS_ACCESS_METHOD=github_api`",
+		"`DETENT_DOCS_COMMIT`",
+		"Do not clone Detent by default",
+	} {
+		assertContainsWords(t, readme, want)
+	}
+
+	assertOrder(t, onboarding, "Remote Detent Documentation Source", "Local Detent Source Checkout")
+	assertOrder(t, readme, "Use GitHub as the", "If a verified")
 }
 
 func TestOnboardingDocsPreserveEarlyLabelStatusSourceDecision(t *testing.T) {


### PR DESCRIPTION
## Summary

- Treat GitHub at a pinned `digitaldrywood/detent` commit as the first-class Detent docs source for onboarding.
- Record remote documentation source metadata in `draft-answers` freshness evidence when no local Detent checkout is provided.
- Update docs tests and CLI tests for onboarding without a local Detent checkout.

Fixes #757

## Test Plan

- [x] `go test .`
- [x] `go test ./internal/cli`
- [x] `make check`