### PR TITLE
fix(onboarding): ask automation policy first

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,7 +103,13 @@ Present findings with evidence and ask only the next necessary human decisions.
 Ask and record `GITHUB_MODE` explicitly after the identity phase and before
 target-specific discovery; never infer ProjectV2, issue-field, or label mode
 from existing projects. Recommendations can cite evidence, but they are not
-selected answers; do not create, link, mutate, or delete GitHub Projects, issue fields, labels,
+selected answers. Before recommending review, auto-promotion, dependency
+unblock, or merging settings, ask in plain English whether I want full
+autopilot, a Human Review gate, or conservative/manual approval. If I ask for
+maximum automation, map that to `DELIVERY_PROFILE=full_autopilot` and summarize
+the behavior before showing `answers.env` fields. Do not recommend
+`AUTO_PROMOTE_ENABLED=false` or stopping at Human Review unless I selected
+review gate or conservative/manual; do not create, link, mutate, or delete GitHub Projects, issue fields, labels,
 issues, PRs, `WORKFLOW.md`, or `global.yaml`, or dispatch agents, until Phase 2
 answers are recorded in `answers.env`, `detent onboarding validate-answers`
 passes for the selected phase, and I explicitly confirm the mutation step.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -853,60 +853,84 @@ probes.
    rg '^STATUS_LABEL_PREFIX=' "$ONBOARDING_DIR/answers.env"
    ```
 
-5. **Operator intent profile.** Ask: "Which operating model fits this project?"
-   Present these plain-English flavors before showing canonical
-   `answers.env` fields:
+5. **Automation policy.** Ask the customer-facing policy questions before
+   recommending review, auto-promotion, dependency unblock, Kanban mutation, or
+   Merging settings. Do not present raw `answers.env` keys as the primary
+   interface.
 
-   - Conservative review: stop at `Human Review` until a human explicitly
-     promotes work.
-   - Autonomous delivery: move Todo work through PR, CI/gates, Merging, and
-     Done without human review or quiet-window delay when there are no real
-     blockers.
+   Ask first:
+
+   ```text
+   How should Detent handle completed work after the validation gate passes?
+
+   1. Full autopilot: automatically promote work through Human Review and into Merging when gates pass.
+   2. Review gate: stop in Human Review until I approve, then continue merging.
+   3. Conservative/manual: stop before mutations or merging unless I explicitly approve each step.
+   ```
+
+   Then ask:
+
+   ```text
+   When blocked work becomes unblocked, should Detent automatically resume it when guardrails pass, or wait for human approval?
+   ```
+
+   And ask:
+
+   ```text
+   Should Detent automatically move eligible issues forward when the configured tests/checks pass?
+   ```
+
+   Present the operator's plain-English operating model first, then show the
+   canonical `answers.env` fields as a secondary implementation mapping:
+
+   - Full autopilot: promote through `Human Review` to `Merging` when linked
+     PRs, gates, CI, mergeability, dependency checks, and guardrails pass; also
+     auto-unblock dependency-waiting work when declared blockers clear.
+   - Review gate: stop at `Human Review` until a human explicitly approves
+     promotion to `Merging`; GitHub/config writes still require the separate
+     mutation confirmation.
+   - Conservative/manual: require explicit approval before promotion or
+     mutation; keep project Kanban mutations read-only unless the operator
+     later switches to a custom advanced policy.
    - Custom/advanced: expose the underlying fields for teams that need a mixed
      policy.
 
    When the operator says "no human review, no wait state, unblock
-   aggressively, only stop on real blockers," recommend `autonomous_delivery`.
-   Explain that autonomous delivery still requires linked PRs, green CI, clear
-   gates, and no blocking P1 automated findings; it does not bypass validation.
-   Also explain that onboarding mutation should use live reload or a
-   project-scoped refresh and verify running agents were not interrupted rather
-   than restarting Detent.
+   aggressively, only stop on real blockers," asks for maximum automation, or
+   says to auto-promote and auto-unblock as much as guardrails allow, recommend
+   `full_autopilot`. Explain that full autopilot still requires linked PRs,
+   green CI, clear gates, mergeability, satisfied dependencies, and no blocking
+   P1 automated findings; it does not bypass validation. Do not recommend
+   `AUTO_PROMOTE_ENABLED=false` unless the operator selected review gate or
+   conservative/manual. Do not recommend stopping at `Human Review` unless the
+   operator selected review gate or conservative/manual. Do not label an
+   unselected setup as a safety-default review posture.
 
-   After selecting `DELIVERY_PROFILE=autonomous_delivery`, do not ask the
-   Kanban interaction, validation-gate automated-review, Merging concurrency,
-   review policy, or dependency waiting policy questions again unless the
-   operator asks for an advanced override. Advanced override means the operator
-   switches to Custom/advanced after seeing the expansion; remove or omit
-   `DELIVERY_PROFILE` before recording a profile-supplied key with a different
-   value. Ask the remaining Phase 2 questions that are not supplied by the
-   selected profile.
+   Asking for automation policy does not authorize mutation. Phase 2.5 still
+   must approve the exact answers before creating labels, editing
+   `global.yaml`, writing `WORKFLOW.md`, or dispatching agents. Onboarding
+   mutation should use live reload or a project-scoped refresh and verify
+   running agents were not interrupted rather than restarting Detent.
 
-   For conservative review or autonomous delivery, write `DELIVERY_PROFILE`
-   first:
+   After selecting a named profile, do not ask the Kanban interaction,
+   validation-gate automated-review, Merging concurrency, review policy, or
+   dependency waiting policy questions again unless the operator asks for an
+   advanced override. Advanced override means the operator switches to
+   Custom/advanced after seeing the expansion; remove or omit `DELIVERY_PROFILE`
+   before recording a profile-supplied key with a different value. Ask the
+   remaining Phase 2 questions that are not supplied by the selected profile.
+
+   For full autopilot, review gate, or conservative/manual, write
+   `DELIVERY_PROFILE` first:
 
    ```sh
    printf '%s\n' \
-     'DELIVERY_PROFILE=<conservative_review|autonomous_delivery>' \
+     'DELIVERY_PROFILE=<full_autopilot|review_gate|conservative_manual>' \
      >> "$ONBOARDING_DIR/answers.env"
    rg '^DELIVERY_PROFILE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-   Conservative review expands to:
-
-   ```sh
-   printf '%s\n' \
-     'KANBAN_MODE=read_only' \
-     'AUTO_PROMOTE_ENABLED=false' \
-     'AUTO_PROMOTE_QUIET_SECONDS=600' \
-     'GATE_REQUIRE_AUTOMATED_REVIEW=true' \
-     'AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW=true' \
-     'DEPENDENCY_AUTO_UNBLOCK_ENABLED=false' \
-     'MERGING_CONCURRENCY=1' \
-     >> "$ONBOARDING_DIR/answers.env"
-   ```
-
-   Autonomous delivery expands to:
+   Full autopilot expands to:
 
    ```sh
    printf '%s\n' \
@@ -916,6 +940,34 @@ probes.
      'GATE_REQUIRE_AUTOMATED_REVIEW=false' \
      'AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW=false' \
      'DEPENDENCY_AUTO_UNBLOCK_ENABLED=true' \
+     'MERGING_CONCURRENCY=1' \
+     >> "$ONBOARDING_DIR/answers.env"
+   ```
+
+   Review gate expands to:
+
+   ```sh
+   printf '%s\n' \
+     'KANBAN_MODE=integration' \
+     'AUTO_PROMOTE_ENABLED=false' \
+     'AUTO_PROMOTE_QUIET_SECONDS=600' \
+     'GATE_REQUIRE_AUTOMATED_REVIEW=false' \
+     'AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW=false' \
+     'DEPENDENCY_AUTO_UNBLOCK_ENABLED=false' \
+     'MERGING_CONCURRENCY=1' \
+     >> "$ONBOARDING_DIR/answers.env"
+   ```
+
+   Conservative/manual expands to:
+
+   ```sh
+   printf '%s\n' \
+     'KANBAN_MODE=read_only' \
+     'AUTO_PROMOTE_ENABLED=false' \
+     'AUTO_PROMOTE_QUIET_SECONDS=600' \
+     'GATE_REQUIRE_AUTOMATED_REVIEW=true' \
+     'AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW=true' \
+     'DEPENDENCY_AUTO_UNBLOCK_ENABLED=false' \
      'MERGING_CONCURRENCY=1' \
      >> "$ONBOARDING_DIR/answers.env"
    ```
@@ -1115,8 +1167,10 @@ probes.
    "Should Detent hard-stop at `Human Review`, or may it auto-promote to
    `Merging` after the human-defined criteria are true?"
    Recommendation source: repo risk, issue labels, review requirements, and how
-   much trust the human wants to delegate. Default if silent:
-   `agent.auto_promote.enabled: false`, the safe hard stop. Both modes are
+   much trust the human wants to delegate. Default if silent: no review-policy
+   answer is recorded; ask again in plain English. Do not write
+   `AUTO_PROMOTE_ENABLED=false` unless the operator chose review gate,
+   conservative/manual, or explicitly chose a custom hard stop. Both modes are
    fully supported, and this is the human's call.
 
    For criteria-based auto-promote, use `agent.auto_promote.enabled`,

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -245,7 +245,7 @@ func newOnboardingExplainAnswersCommand() *cobra.Command {
 			if result.AnswersSummary == nil {
 				return NewValidationError(
 					"DELIVERY_PROFILE is required to explain onboarding answers",
-					"Record DELIVERY_PROFILE=conservative_review or DELIVERY_PROFILE=autonomous_delivery in answers.env, then rerun explain-answers.",
+					"Record DELIVERY_PROFILE=full_autopilot, DELIVERY_PROFILE=review_gate, or DELIVERY_PROFILE=conservative_manual in answers.env, then rerun explain-answers.",
 					nil,
 				)
 			}
@@ -293,7 +293,7 @@ func writeOnboardingAnswersExplanationPretty(w io.Writer, result onboardingAnswe
 	if summary == nil {
 		return NewValidationError(
 			"DELIVERY_PROFILE is required to explain onboarding answers",
-			"Record DELIVERY_PROFILE=conservative_review or DELIVERY_PROFILE=autonomous_delivery in answers.env, then rerun explain-answers.",
+			"Record DELIVERY_PROFILE=full_autopilot, DELIVERY_PROFILE=review_gate, or DELIVERY_PROFILE=conservative_manual in answers.env, then rerun explain-answers.",
 			nil,
 		)
 	}
@@ -1359,7 +1359,7 @@ func analyzeOnboardingDeliveryProfileAnswers(answers onboardingAnswers) onboardi
 	settings, ok := onboardingprofile.DeliveryProfile(profile)
 	if !ok {
 		return onboardingDeliveryProfileAnswerAnalysis{
-			Problems: []string{"DELIVERY_PROFILE must be conservative_review or autonomous_delivery"},
+			Problems: []string{"DELIVERY_PROFILE must be full_autopilot, review_gate, or conservative_manual"},
 		}
 	}
 	expansion, _ := onboardingprofile.DeliveryProfileAnswerExpansion(settings.ID)

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -180,7 +180,7 @@ func TestOnboardingValidateAnswersCommandRejectsMissingDeliveryProfileExpansionB
 
 	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=full_autopilot",
 		"STATUS_LABEL_PREFIX=detent:",
 		"MUTATION_CONFIRMED=true",
 		"",
@@ -195,8 +195,8 @@ func TestOnboardingValidateAnswersCommandRejectsMissingDeliveryProfileExpansionB
 		t.Fatal("Execute() error = nil, want missing delivery profile expansion validation error")
 	}
 	for _, want := range []string{
-		"AUTO_PROMOTE_ENABLED is required when DELIVERY_PROFILE=autonomous_delivery",
-		"KANBAN_MODE is required when DELIVERY_PROFILE=autonomous_delivery",
+		"AUTO_PROMOTE_ENABLED is required when DELIVERY_PROFILE=full_autopilot",
+		"KANBAN_MODE is required when DELIVERY_PROFILE=full_autopilot",
 		"detent onboarding normalize-answers --answers",
 	} {
 		if !strings.Contains(err.Error(), want) {
@@ -267,13 +267,13 @@ func TestOnboardingValidateAnswersCommandAcceptsLabelMode(t *testing.T) {
 	}
 }
 
-func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *testing.T) {
+func TestOnboardingValidateAnswersCommandExpandsFullAutopilotProfile(t *testing.T) {
 	t.Parallel()
 
-	profileAnswers := autonomousDeliveryProfileAnswers()
+	profileAnswers := fullAutopilotProfileAnswers()
 	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=full_autopilot",
 		"KANBAN_MODE=" + profileAnswers["KANBAN_MODE"],
 		"AUTO_PROMOTE_ENABLED=" + profileAnswers["AUTO_PROMOTE_ENABLED"],
 		"AUTO_PROMOTE_QUIET_SECONDS=" + profileAnswers["AUTO_PROMOTE_QUIET_SECONDS"],
@@ -313,18 +313,18 @@ func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *tes
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
 	}
-	if got.DeliveryProfile != "autonomous_delivery" {
-		t.Fatalf("DeliveryProfile = %q, want autonomous_delivery", got.DeliveryProfile)
+	if got.DeliveryProfile != "full_autopilot" {
+		t.Fatalf("DeliveryProfile = %q, want full_autopilot", got.DeliveryProfile)
 	}
 	for key, value := range profileAnswers {
 		if got.DeliveryProfileAnswers[key] != value {
 			t.Fatalf("DeliveryProfileAnswers[%q] = %q, want %q; all answers = %#v", key, got.DeliveryProfileAnswers[key], value, got.DeliveryProfileAnswers)
 		}
 	}
-	if got.AnswersSummary.EffectiveDeliveryProfile != "autonomous_delivery" ||
-		got.AnswersSummary.EffectiveDeliveryProfileLabel != "Autonomous delivery mode" ||
+	if got.AnswersSummary.EffectiveDeliveryProfile != "full_autopilot" ||
+		got.AnswersSummary.EffectiveDeliveryProfileLabel != "Full autopilot" ||
 		got.AnswersSummary.KanbanMode != "integration" {
-		t.Fatalf("AnswersSummary identity = %#v, want autonomous delivery integration summary", got.AnswersSummary)
+		t.Fatalf("AnswersSummary identity = %#v, want full autopilot integration summary", got.AnswersSummary)
 	}
 	summaryValues := []string{
 		got.AnswersSummary.GateBehavior,
@@ -335,7 +335,7 @@ func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *tes
 	}
 	for _, want := range []string{
 		"No automated GitHub PR review is required when the command gate is passing and the workflow says so.",
-		"Detent may promote from `Human Review` to `Merging` automatically when the linked PR, local gate, and CI requirements pass.",
+		"Detent automatically promotes eligible work from `Human Review` to `Merging` when the linked PR, local gate, CI, and guardrails pass.",
 		"There is no quiet-window delay before promotion.",
 		"Dependency-waiting `Blocked` issues can move back to `Todo` when declared blockers are terminal or merged.",
 		"`Merging` remains serialized for this project.",
@@ -349,12 +349,12 @@ func TestOnboardingValidateAnswersCommandExpandsAutonomousDeliveryProfile(t *tes
 	}
 }
 
-func TestOnboardingExplainAnswersCommandSummarizesAutonomousDelivery(t *testing.T) {
+func TestOnboardingExplainAnswersCommandSummarizesFullAutopilot(t *testing.T) {
 	t.Parallel()
 
 	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=full_autopilot",
 		"",
 	}, "\n"))
 	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
@@ -377,14 +377,14 @@ func TestOnboardingExplainAnswersCommandSummarizesAutonomousDelivery(t *testing.
 		t.Fatalf("summary appears after canonical keys:\n%s", output)
 	}
 	for _, want := range []string{
-		"Effective delivery profile: Autonomous delivery mode (`autonomous_delivery`).",
+		"Effective delivery profile: Full autopilot (`full_autopilot`).",
 		"No automated GitHub PR review is required when the command gate is passing and the workflow says so.",
-		"Detent may promote from `Human Review` to `Merging` automatically when the linked PR, local gate, and CI requirements pass.",
+		"Detent automatically promotes eligible work from `Human Review` to `Merging` when the linked PR, local gate, CI, and guardrails pass.",
 		"There is no quiet-window delay before promotion.",
 		"Dependency-waiting `Blocked` issues can move back to `Todo` when declared blockers are terminal or merged.",
 		"`Merging` remains serialized for this project.",
 		"Existing validation, CI, unresolved review feedback, dependency blockers, mergeability, and gate failures still stop progress.",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=full_autopilot",
 		"AUTO_PROMOTE_QUIET_SECONDS=0",
 		"GATE_REQUIRE_AUTOMATED_REVIEW=false",
 		"MERGING_CONCURRENCY=1",
@@ -395,12 +395,12 @@ func TestOnboardingExplainAnswersCommandSummarizesAutonomousDelivery(t *testing.
 	}
 }
 
-func TestOnboardingValidateAnswersCommandSummarizesConservativeReviewProfile(t *testing.T) {
+func TestOnboardingValidateAnswersCommandSummarizesReviewGateProfile(t *testing.T) {
 	t.Parallel()
 
 	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=conservative_review",
+		"DELIVERY_PROFILE=review_gate",
 		"",
 	}, "\n"))
 	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
@@ -433,14 +433,14 @@ func TestOnboardingValidateAnswersCommandSummarizesConservativeReviewProfile(t *
 		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
 	}
 	summary := got.AnswersSummary
-	if summary.EffectiveDeliveryProfile != "conservative_review" ||
-		summary.EffectiveDeliveryProfileLabel != "Conservative review mode" ||
-		summary.KanbanMode != "read_only" ||
-		!summary.GateRequiresAutomatedReview ||
+	if summary.EffectiveDeliveryProfile != "review_gate" ||
+		summary.EffectiveDeliveryProfileLabel != "Review gate" ||
+		summary.KanbanMode != "integration" ||
+		summary.GateRequiresAutomatedReview ||
 		summary.AutoPromoteEnabled ||
 		summary.AutoPromoteQuietSeconds != 600 ||
 		summary.DependencyAutoUnblockEnabled {
-		t.Fatalf("AnswersSummary = %#v, want conservative review defaults", summary)
+		t.Fatalf("AnswersSummary = %#v, want review gate defaults", summary)
 	}
 	summaryValues := []string{
 		summary.GateBehavior,
@@ -450,8 +450,8 @@ func TestOnboardingValidateAnswersCommandSummarizesConservativeReviewProfile(t *
 		summary.MergeConcurrencyBehavior,
 	}
 	for _, want := range []string{
-		"Automated GitHub PR review is required before the command gate and promotion checks can pass.",
-		"Detent will not promote from `Human Review` to `Merging` automatically; a human must move approved work forward.",
+		"No automated GitHub PR review is required when the command gate is passing and the workflow says so.",
+		"Detent stops in `Human Review` until an operator approves promotion to `Merging`.",
 		"Auto-promotion is disabled; the 600-second quiet window only matters if auto-promotion is enabled later.",
 		"Dependency-waiting `Blocked` issues remain `Blocked` until a human or workflow moves them.",
 		"`Merging` remains serialized for this project.",
@@ -462,12 +462,58 @@ func TestOnboardingValidateAnswersCommandSummarizesConservativeReviewProfile(t *
 	}
 }
 
-func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansion(t *testing.T) {
+func TestOnboardingValidateAnswersCommandSummarizesConservativeManualProfile(t *testing.T) {
 	t.Parallel()
 
 	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=conservative_manual",
+		"",
+	}, "\n"))
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--format", "json", "onboarding", "validate-answers", "--answers", answersPath, "--phase", "decision"})
+
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var got struct {
+		AnswersSummary struct {
+			EffectiveDeliveryProfile      string `json:"effective_delivery_profile"`
+			EffectiveDeliveryProfileLabel string `json:"effective_delivery_profile_label"`
+			KanbanMode                    string `json:"kanban_mode"`
+			GateRequiresAutomatedReview   bool   `json:"gate_requires_automated_review"`
+			AutoPromoteEnabled            bool   `json:"auto_promote_enabled"`
+			DependencyAutoUnblockEnabled  bool   `json:"dependency_auto_unblock_enabled"`
+			AutoPromotionBehavior         string `json:"auto_promotion_behavior"`
+		} `json:"answers_summary"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
+	}
+	summary := got.AnswersSummary
+	if summary.EffectiveDeliveryProfile != "conservative_manual" ||
+		summary.EffectiveDeliveryProfileLabel != "Conservative/manual" ||
+		summary.KanbanMode != "read_only" ||
+		!summary.GateRequiresAutomatedReview ||
+		summary.AutoPromoteEnabled ||
+		summary.DependencyAutoUnblockEnabled {
+		t.Fatalf("AnswersSummary = %#v, want conservative/manual defaults", summary)
+	}
+	if summary.AutoPromotionBehavior != "Detent stops in `Human Review` until an operator approves promotion to `Merging`." {
+		t.Fatalf("AutoPromotionBehavior = %q, want operator approval summary", summary.AutoPromotionBehavior)
+	}
+}
+
+func TestOnboardingNormalizeAnswersCommandWritesFullAutopilotProfileExpansion(t *testing.T) {
+	t.Parallel()
+
+	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
+		"GITHUB_MODE=label",
+		"DELIVERY_PROFILE=full_autopilot",
 		"STATUS_LABEL_PREFIX=detent:",
 		"",
 	}, "\n"))
@@ -492,8 +538,8 @@ func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansi
 	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
 		t.Fatalf("stdout is not JSON: %v\n%s", err, stdout.String())
 	}
-	if got.Status != "ok" || got.Path != answersPath || !got.Written || !got.Changed || got.DeliveryProfile != "autonomous_delivery" || got.MutationConfirmed {
-		t.Fatalf("normalization result = %#v, want written autonomous profile normalization", got)
+	if got.Status != "ok" || got.Path != answersPath || !got.Written || !got.Changed || got.DeliveryProfile != "full_autopilot" || got.MutationConfirmed {
+		t.Fatalf("normalization result = %#v, want written full autopilot profile normalization", got)
 	}
 
 	raw, err := os.ReadFile(answersPath)
@@ -501,7 +547,7 @@ func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansi
 		t.Fatalf("ReadFile() error = %v", err)
 	}
 	content := string(raw)
-	for key, value := range autonomousDeliveryProfileAnswers() {
+	for key, value := range fullAutopilotProfileAnswers() {
 		want := key + "=" + value
 		if !strings.Contains(content, want) {
 			t.Fatalf("answers.env missing %q:\n%s", want, content)
@@ -515,10 +561,10 @@ func TestOnboardingNormalizeAnswersCommandWritesAutonomousDeliveryProfileExpansi
 func TestOnboardingNormalizeAnswersCommandPreservesFinalMutationConfirmationWhenAlreadyCanonical(t *testing.T) {
 	t.Parallel()
 
-	profileAnswers := autonomousDeliveryProfileAnswers()
+	profileAnswers := fullAutopilotProfileAnswers()
 	answersPath := writeOnboardingAnswers(t, validIdentityOnboardingAnswers(t)+strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=full_autopilot",
 		"KANBAN_MODE=" + profileAnswers["KANBAN_MODE"],
 		"AUTO_PROMOTE_ENABLED=" + profileAnswers["AUTO_PROMOTE_ENABLED"],
 		"AUTO_PROMOTE_QUIET_SECONDS=" + profileAnswers["AUTO_PROMOTE_QUIET_SECONDS"],
@@ -569,7 +615,7 @@ func TestOnboardingNormalizeAnswersCommandRejectsStaleMutationConfirmation(t *te
 
 	content := validIdentityOnboardingAnswers(t) + strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=full_autopilot",
 		"STATUS_LABEL_PREFIX=detent:",
 		"MUTATION_CONFIRMED=true",
 		"",
@@ -607,7 +653,7 @@ func TestOnboardingNormalizeAnswersCommandRejectsDeliveryProfileExpansionConflic
 
 	content := validIdentityOnboardingAnswers(t) + strings.Join([]string{
 		"GITHUB_MODE=label",
-		"DELIVERY_PROFILE=autonomous_delivery",
+		"DELIVERY_PROFILE=full_autopilot",
 		"KANBAN_MODE=read_only",
 		"STATUS_LABEL_PREFIX=detent:",
 		"MUTATION_CONFIRMED=true",
@@ -623,7 +669,7 @@ func TestOnboardingNormalizeAnswersCommandRejectsDeliveryProfileExpansionConflic
 	if err == nil {
 		t.Fatal("Execute() error = nil, want delivery profile expansion conflict")
 	}
-	if !strings.Contains(err.Error(), "KANBAN_MODE=read_only conflicts with DELIVERY_PROFILE=autonomous_delivery, which expands KANBAN_MODE=integration") {
+	if !strings.Contains(err.Error(), "KANBAN_MODE=read_only conflicts with DELIVERY_PROFILE=full_autopilot, which expands KANBAN_MODE=integration") {
 		t.Fatalf("Execute() error missing profile conflict:\n%s", err.Error())
 	}
 	raw, readErr := os.ReadFile(answersPath)
@@ -1379,7 +1425,7 @@ func writeOnboardingAnswers(t *testing.T, content string) string {
 	return path
 }
 
-func autonomousDeliveryProfileAnswers() map[string]string {
+func fullAutopilotProfileAnswers() map[string]string {
 	return map[string]string{
 		"KANBAN_MODE":                           "integration",
 		"AUTO_PROMOTE_ENABLED":                  "true",

--- a/internal/onboarding/profile.go
+++ b/internal/onboarding/profile.go
@@ -49,9 +49,9 @@ func NormalizeDeliveryProfile(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
 	case "full", "full-autopilot", "full_autopilot", "autopilot", "maximum", "max", "autonomous", "autonomous-delivery", "autonomous_delivery":
 		return DeliveryProfileFullAutopilot
-	case "review", "review-gate", "review_gate", "human_review", "human-review":
+	case "review-gate", "review_gate":
 		return DeliveryProfileReviewGate
-	case "conservative", "conservative-manual", "conservative_manual", "manual", "conservative-review", "conservative_review":
+	case "conservative", "conservative-manual", "conservative_manual", "manual", "review", "human_review", "human-review", "conservative-review", "conservative_review":
 		return DeliveryProfileConservativeManual
 	default:
 		return strings.ToLower(strings.TrimSpace(value))

--- a/internal/onboarding/profile.go
+++ b/internal/onboarding/profile.go
@@ -8,8 +8,11 @@ import (
 )
 
 const (
-	DeliveryProfileConservativeReview = "conservative_review"
-	DeliveryProfileAutonomousDelivery = "autonomous_delivery"
+	DeliveryProfileFullAutopilot      = "full_autopilot"
+	DeliveryProfileReviewGate         = "review_gate"
+	DeliveryProfileConservativeManual = "conservative_manual"
+	DeliveryProfileAutonomousDelivery = DeliveryProfileFullAutopilot
+	DeliveryProfileConservativeReview = DeliveryProfileConservativeManual
 )
 
 type DeliveryProfileSettings struct {
@@ -44,10 +47,12 @@ type DeliveryProfileSummary struct {
 
 func NormalizeDeliveryProfile(value string) string {
 	switch strings.ToLower(strings.TrimSpace(value)) {
-	case "", "conservative", "conservative-review", "review", "human_review", "human-review", DeliveryProfileConservativeReview:
-		return DeliveryProfileConservativeReview
-	case "autonomous", "autonomous-delivery", "delivery", DeliveryProfileAutonomousDelivery:
-		return DeliveryProfileAutonomousDelivery
+	case "full", "full-autopilot", "full_autopilot", "autopilot", "maximum", "max", "autonomous", "autonomous-delivery", "autonomous_delivery":
+		return DeliveryProfileFullAutopilot
+	case "review", "review-gate", "review_gate", "human_review", "human-review":
+		return DeliveryProfileReviewGate
+	case "conservative", "conservative-manual", "conservative_manual", "manual", "conservative-review", "conservative_review":
+		return DeliveryProfileConservativeManual
 	default:
 		return strings.ToLower(strings.TrimSpace(value))
 	}
@@ -55,26 +60,37 @@ func NormalizeDeliveryProfile(value string) string {
 
 func DeliveryProfile(value string) (DeliveryProfileSettings, bool) {
 	switch NormalizeDeliveryProfile(value) {
-	case DeliveryProfileConservativeReview:
+	case DeliveryProfileFullAutopilot:
 		return DeliveryProfileSettings{
-			ID:                           DeliveryProfileConservativeReview,
-			Label:                        "Conservative review mode",
-			KanbanMode:                   "read_only",
-			AutoPromoteEnabled:           false,
-			AutoPromoteQuietSeconds:      600,
-			GateRequireAutomatedReview:   true,
-			DependencyAutoUnblockEnabled: false,
-			MergingConcurrency:           1,
-		}, true
-	case DeliveryProfileAutonomousDelivery:
-		return DeliveryProfileSettings{
-			ID:                           DeliveryProfileAutonomousDelivery,
-			Label:                        "Autonomous delivery mode",
+			ID:                           DeliveryProfileFullAutopilot,
+			Label:                        "Full autopilot",
 			KanbanMode:                   "integration",
 			AutoPromoteEnabled:           true,
 			AutoPromoteQuietSeconds:      0,
 			GateRequireAutomatedReview:   false,
 			DependencyAutoUnblockEnabled: true,
+			MergingConcurrency:           1,
+		}, true
+	case DeliveryProfileReviewGate:
+		return DeliveryProfileSettings{
+			ID:                           DeliveryProfileReviewGate,
+			Label:                        "Review gate",
+			KanbanMode:                   "integration",
+			AutoPromoteEnabled:           false,
+			AutoPromoteQuietSeconds:      600,
+			GateRequireAutomatedReview:   false,
+			DependencyAutoUnblockEnabled: false,
+			MergingConcurrency:           1,
+		}, true
+	case DeliveryProfileConservativeManual:
+		return DeliveryProfileSettings{
+			ID:                           DeliveryProfileConservativeManual,
+			Label:                        "Conservative/manual",
+			KanbanMode:                   "read_only",
+			AutoPromoteEnabled:           false,
+			AutoPromoteQuietSeconds:      600,
+			GateRequireAutomatedReview:   true,
+			DependencyAutoUnblockEnabled: false,
 			MergingConcurrency:           1,
 		}, true
 	default:
@@ -159,9 +175,9 @@ func gateBehavior(settings DeliveryProfileSettings) string {
 
 func autoPromotionBehavior(settings DeliveryProfileSettings) string {
 	if settings.AutoPromoteEnabled {
-		return "Detent may promote from `Human Review` to `Merging` automatically when the linked PR, local gate, and CI requirements pass."
+		return "Detent automatically promotes eligible work from `Human Review` to `Merging` when the linked PR, local gate, CI, and guardrails pass."
 	}
-	return "Detent will not promote from `Human Review` to `Merging` automatically; a human must move approved work forward."
+	return "Detent stops in `Human Review` until an operator approves promotion to `Merging`."
 }
 
 func quietWindowBehavior(settings DeliveryProfileSettings) string {

--- a/internal/onboarding/profile_test.go
+++ b/internal/onboarding/profile_test.go
@@ -11,8 +11,8 @@ func TestDeliveryProfileAnswerExpansion(t *testing.T) {
 		want    map[string]string
 	}{
 		{
-			name:    "autonomous delivery",
-			profile: "autonomous_delivery",
+			name:    "full autopilot",
+			profile: "full_autopilot",
 			want: map[string]string{
 				"KANBAN_MODE":                           "integration",
 				"AUTO_PROMOTE_ENABLED":                  "true",
@@ -24,8 +24,21 @@ func TestDeliveryProfileAnswerExpansion(t *testing.T) {
 			},
 		},
 		{
-			name:    "conservative review alias",
-			profile: "conservative",
+			name:    "review gate",
+			profile: "review_gate",
+			want: map[string]string{
+				"KANBAN_MODE":                           "integration",
+				"AUTO_PROMOTE_ENABLED":                  "false",
+				"AUTO_PROMOTE_QUIET_SECONDS":            "600",
+				"GATE_REQUIRE_AUTOMATED_REVIEW":         "false",
+				"AUTO_PROMOTE_REQUIRE_AUTOMATED_REVIEW": "false",
+				"DEPENDENCY_AUTO_UNBLOCK_ENABLED":       "false",
+				"MERGING_CONCURRENCY":                   "1",
+			},
+		},
+		{
+			name:    "conservative manual",
+			profile: "conservative_manual",
 			want: map[string]string{
 				"KANBAN_MODE":                           "read_only",
 				"AUTO_PROMOTE_ENABLED":                  "false",
@@ -58,8 +71,8 @@ func TestDeliveryProfileAnswerExpansion(t *testing.T) {
 func TestDeliveryProfileRejectsUnknown(t *testing.T) {
 	t.Parallel()
 
-	if _, ok := DeliveryProfileAnswerExpansion("manual"); ok {
-		t.Fatal("DeliveryProfileAnswerExpansion(manual) ok = true, want false")
+	if _, ok := DeliveryProfileAnswerExpansion("safe_start"); ok {
+		t.Fatal("DeliveryProfileAnswerExpansion(safe_start) ok = true, want false")
 	}
 }
 
@@ -80,9 +93,9 @@ func TestSummarizeDeliveryProfile(t *testing.T) {
 		wantMergeConcurrencySummary string
 	}{
 		{
-			name:                        "autonomous delivery",
-			profile:                     "autonomous_delivery",
-			wantEffectiveProfile:        "autonomous_delivery",
+			name:                        "full autopilot",
+			profile:                     "full_autopilot",
+			wantEffectiveProfile:        "full_autopilot",
 			wantKanbanMode:              "integration",
 			wantGateRequiresReview:      false,
 			wantAutoPromoteEnabled:      true,
@@ -93,9 +106,22 @@ func TestSummarizeDeliveryProfile(t *testing.T) {
 			wantMergeConcurrencySummary: "`Merging` remains serialized for this project.",
 		},
 		{
-			name:                        "conservative review",
-			profile:                     "conservative_review",
-			wantEffectiveProfile:        "conservative_review",
+			name:                        "review gate",
+			profile:                     "review_gate",
+			wantEffectiveProfile:        "review_gate",
+			wantKanbanMode:              "integration",
+			wantGateRequiresReview:      false,
+			wantAutoPromoteEnabled:      false,
+			wantQuietWindow:             "Auto-promotion is disabled; the 600-second quiet window only matters if auto-promotion is enabled later.",
+			wantDependencyAutoUnblock:   false,
+			wantDependencyBehavior:      "Dependency-waiting `Blocked` issues remain `Blocked` until a human or workflow moves them.",
+			wantMergeConcurrency:        1,
+			wantMergeConcurrencySummary: "`Merging` remains serialized for this project.",
+		},
+		{
+			name:                        "conservative manual",
+			profile:                     "conservative_manual",
+			wantEffectiveProfile:        "conservative_manual",
 			wantKanbanMode:              "read_only",
 			wantGateRequiresReview:      true,
 			wantAutoPromoteEnabled:      false,

--- a/internal/onboarding/profile_test.go
+++ b/internal/onboarding/profile_test.go
@@ -76,6 +76,33 @@ func TestDeliveryProfileRejectsUnknown(t *testing.T) {
 	}
 }
 
+func TestNormalizeDeliveryProfilePreservesLegacyReviewAliases(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  string
+	}{
+		{name: "explicit review gate", value: "review_gate", want: "review_gate"},
+		{name: "hyphenated review gate", value: "review-gate", want: "review_gate"},
+		{name: "legacy review", value: "review", want: "conservative_manual"},
+		{name: "legacy human review", value: "human_review", want: "conservative_manual"},
+		{name: "legacy hyphenated human review", value: "human-review", want: "conservative_manual"},
+		{name: "legacy conservative review", value: "conservative_review", want: "conservative_manual"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := NormalizeDeliveryProfile(tt.value); got != tt.want {
+				t.Fatalf("NormalizeDeliveryProfile(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestSummarizeDeliveryProfile(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -54,7 +54,6 @@ func (s *Server) onboarding(c echo.Context) error {
 		PollingIntervalMS:            defaultPollingIntervalMS,
 		MergingConcurrency:           defaultMergingConcurrency,
 		DispatchPriorityState:        defaultDispatchPriorityText,
-		DeliveryProfile:              onboardingprofile.DeliveryProfileConservativeReview,
 		DependencyAutoUnblockEnabled: "false",
 		KanbanMode:                   config.KanbanModeIntegration,
 	}
@@ -329,6 +328,11 @@ func validateAgent(form templates.OnboardingForm) []string {
 	problems = append(problems, positiveIntegerProblem("polling interval", form.PollingIntervalMS)...)
 	problems = append(problems, minimumIntegerProblem("polling interval", form.PollingIntervalMS, config.MinPollingIntervalMS)...)
 	problems = append(problems, positiveIntegerProblem("merging concurrency", form.MergingConcurrency)...)
+	if strings.TrimSpace(form.DeliveryProfile) == "" {
+		problems = append(problems, "automation policy is required")
+	} else if _, ok := onboardingprofile.DeliveryProfile(form.DeliveryProfile); !ok {
+		problems = append(problems, "automation policy must be full_autopilot, review_gate, or conservative_manual")
+	}
 	for _, state := range dispatchPriorityStates(form) {
 		problems = append(problems, rejectNewlines("dispatch priority state", state)...)
 		if strings.TrimSpace(state) == "" {
@@ -448,6 +452,7 @@ func applyDeliveryProfile(form *templates.OnboardingForm) {
 	form.DeliveryProfile = settings.ID
 	form.MergingConcurrency = strconv.Itoa(settings.MergingConcurrency)
 	form.DependencyAutoUnblockEnabled = onboardingBool(settings.DependencyAutoUnblockEnabled)
+	form.KanbanMode = settings.KanbanMode
 }
 
 func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
@@ -455,6 +460,7 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	if hasDeliveryProfile {
 		form.MergingConcurrency = strconv.Itoa(settings.MergingConcurrency)
 		form.DependencyAutoUnblockEnabled = onboardingBool(settings.DependencyAutoUnblockEnabled)
+		form.KanbanMode = settings.KanbanMode
 	}
 	var b strings.Builder
 	b.WriteString("---\n")
@@ -635,10 +641,12 @@ func deliveryProfileWorkflowPrompt(form templates.OnboardingForm) string {
 		return ""
 	}
 	switch settings.ID {
-	case onboardingprofile.DeliveryProfileAutonomousDelivery:
-		return "\n\nAutonomous delivery still requires linked PRs, green CI, and clear gates.\nUse live reload or a project-scoped refresh after onboarding changes; do not restart Detent or interrupt running agents unless the operator explicitly authorizes it."
+	case onboardingprofile.DeliveryProfileFullAutopilot:
+		return "\n\nFull autopilot still requires linked PRs, green CI, clear gates, and no blocking P1 automated findings.\nUse live reload or a project-scoped refresh after onboarding changes; do not restart Detent or interrupt running agents unless the operator explicitly authorizes it."
+	case onboardingprofile.DeliveryProfileReviewGate:
+		return "\n\nReview gate mode stops completed work in Human Review until the operator approves promotion to Merging."
 	default:
-		return "\n\nConservative review mode keeps Detent parked at Human Review until the operator chooses promotion or merge."
+		return "\n\nConservative/manual mode keeps GitHub and project mutations read-only by default and requires explicit operator approval before promotion or mutation."
 	}
 }
 

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -100,7 +100,10 @@ func TestOnboardingRoutesProgressThroughWizard(t *testing.T) {
 				"Agent config",
 				onboardingStepBadge("agent"),
 				"name=\"delivery_profile\"",
-				"Autonomous delivery mode",
+				"How should Detent handle completed work after the validation gate passes?",
+				"Full autopilot",
+				"Review gate",
+				"Conservative/manual",
 				"name=\"max_concurrent_agents\"",
 				"name=\"workspace_root\"",
 				"name=\"dependency_auto_unblock_enabled\"",
@@ -124,6 +127,7 @@ func TestOnboardingRoutesProgressThroughWizard(t *testing.T) {
 				"merging_concurrency":        {"1"},
 				"dispatch_priority_by_state": {"Merging\nRework"},
 				"dispatch_priority_by_label": {"bug\nregression\nenhancement"},
+				"delivery_profile":           {"full_autopilot"},
 			},
 			wantStatus: http.StatusOK,
 			wantContent: []string{
@@ -366,7 +370,9 @@ func TestOnboardingWriteGitHubWorkflows(t *testing.T) {
 				"dependency_auto_unblock:\n    enabled: false\n    source_states:\n      - Blocked\n    target_state: Todo\n    readiness: terminal_or_merged",
 				"source_root: "+sourceRoot,
 				"codex:\n  command: codex app-server",
-				"gate:\n  kind: command\n  run: make check\n  ci_failure_action: skip",
+				"gate:\n  kind: command\n  run: make check",
+				"require_automated_review: false",
+				"ci_failure_action: skip",
 				"validator:\n    enabled: false\n    model: \"\"\n    min_score: 0.8\n    block_on:\n      - p1",
 				"hooks:\n  timeout_ms: 60000",
 				"max_concurrent_agents_by_state:\n    Merging: 1",
@@ -438,9 +444,9 @@ func TestOnboardingWriteLabelWorkflowKanbanMode(t *testing.T) {
 			wantMode: workflowconfig.KanbanModeIntegration,
 		},
 		{
-			name: "observer choice stays read only",
+			name: "conservative manual keeps kanban read only",
 			edit: func(form url.Values) {
-				form.Set("kanban_mode", workflowconfig.KanbanModeReadOnly)
+				form.Set("delivery_profile", "conservative_manual")
 			},
 			wantMode: workflowconfig.KanbanModeReadOnly,
 		},
@@ -477,7 +483,7 @@ func TestOnboardingWriteLabelWorkflowKanbanMode(t *testing.T) {
 				t.Fatalf("ReadFile() error = %v", err)
 			}
 			content := string(raw)
-			wantContent := "server:\n  kanban:\n    mode: " + tt.wantMode
+			wantContent := "kanban:\n    mode: " + tt.wantMode
 			if !strings.Contains(content, wantContent) {
 				t.Fatalf("workflow missing %q:\n%s", wantContent, content)
 			}
@@ -533,7 +539,7 @@ func TestOnboardingAgentStepExplainsKanbanWriteProbeRequirement(t *testing.T) {
 	}
 }
 
-func TestOnboardingProjectStepPreservesKanbanModeAfterAgentBack(t *testing.T) {
+func TestOnboardingProjectStepAppliesProfileKanbanModeAfterAgentBack(t *testing.T) {
 	t.Parallel()
 
 	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
@@ -545,8 +551,8 @@ func TestOnboardingProjectStepPreservesKanbanModeAfterAgentBack(t *testing.T) {
 	form := validOnboardingForm()
 	form.Set("github_status_source", workflowconfig.GitHubStatusSourceLabel)
 	form.Set("status_label_prefix", "detent:")
-	form.Set("kanban_mode", workflowconfig.KanbanModeReadOnly)
-	form.Set("delivery_profile", "autonomous_delivery")
+	form.Set("kanban_mode", workflowconfig.KanbanModeIntegration)
+	form.Set("delivery_profile", "conservative_manual")
 	form.Del("project_slug")
 
 	rec := httptest.NewRecorder()
@@ -560,7 +566,7 @@ func TestOnboardingProjectStepPreservesKanbanModeAfterAgentBack(t *testing.T) {
 	for _, want := range []string{
 		"Configure labels",
 		"name=\"kanban_mode\" value=\"read_only\"",
-		"name=\"delivery_profile\" value=\"autonomous_delivery\"",
+		"name=\"delivery_profile\" value=\"conservative_manual\"",
 	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
@@ -577,7 +583,7 @@ func TestOnboardingProjectStepPreservesKanbanModeAfterAgentBack(t *testing.T) {
 	}
 	for _, want := range []string{
 		"name=\"kanban_mode\" value=\"read_only\" checked",
-		"name=\"delivery_profile\" value=\"autonomous_delivery\" checked",
+		"name=\"delivery_profile\" value=\"conservative_manual\" checked",
 	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("agent body missing %q:\n%s", want, rec.Body.String())
@@ -595,7 +601,7 @@ func TestOnboardingWriteWorkflowCanEnableDependencyAutoUnblock(t *testing.T) {
 	}
 
 	form := validOnboardingForm()
-	form.Set("dependency_auto_unblock_enabled", "true")
+	form.Set("delivery_profile", "full_autopilot")
 	rec := httptest.NewRecorder()
 	req := onboardingRequest(http.MethodPost, "/onboarding/write", form)
 
@@ -613,7 +619,7 @@ func TestOnboardingWriteWorkflowCanEnableDependencyAutoUnblock(t *testing.T) {
 	}
 }
 
-func TestOnboardingWriteWorkflowAppliesAutonomousDeliveryProfile(t *testing.T) {
+func TestOnboardingWriteWorkflowAppliesFullAutopilotProfile(t *testing.T) {
 	t.Parallel()
 
 	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
@@ -623,7 +629,7 @@ func TestOnboardingWriteWorkflowAppliesAutonomousDeliveryProfile(t *testing.T) {
 	}
 
 	form := validOnboardingForm()
-	form.Set("delivery_profile", "autonomous_delivery")
+	form.Set("delivery_profile", "full_autopilot")
 	rec := httptest.NewRecorder()
 	req := onboardingRequest(http.MethodPost, "/onboarding/write", form)
 
@@ -632,8 +638,8 @@ func TestOnboardingWriteWorkflowAppliesAutonomousDeliveryProfile(t *testing.T) {
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "gates and CI still apply") {
-		t.Fatalf("body missing autonomous profile explanation:\n%s", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "gates, CI, and guardrails pass") {
+		t.Fatalf("body missing full autopilot profile explanation:\n%s", rec.Body.String())
 	}
 	raw, err := os.ReadFile(workflowPath)
 	if err != nil {
@@ -646,7 +652,7 @@ func TestOnboardingWriteWorkflowAppliesAutonomousDeliveryProfile(t *testing.T) {
 		"auto_promote:\n    enabled: true\n    quiet_seconds: 0",
 		"gate:\n  kind: command\n  run: make check\n  require_automated_review: false",
 		"server:\n  host: 127.0.0.1\n  kanban:\n    mode: integration",
-		"Autonomous delivery still requires linked PRs, green CI, and clear gates.",
+		"Full autopilot still requires linked PRs, green CI, clear gates, and no blocking P1 automated findings.",
 		"Use live reload or a project-scoped refresh after onboarding changes; do not restart Detent or interrupt running agents unless the operator explicitly authorizes it.",
 	} {
 		if !strings.Contains(content, want) {
@@ -1032,11 +1038,18 @@ func TestOnboardingWriteValidatesInput(t *testing.T) {
 			want: "polling interval must be at least 60000",
 		},
 		{
-			name: "invalid kanban mode",
+			name: "missing automation policy",
 			edit: func(form url.Values) {
-				form.Set("kanban_mode", "observer")
+				form.Del("delivery_profile")
 			},
-			want: "kanban mode must be read_only or integration",
+			want: "automation policy is required",
+		},
+		{
+			name: "invalid automation policy",
+			edit: func(form url.Values) {
+				form.Set("delivery_profile", "observer")
+			},
+			want: "automation policy must be full_autopilot, review_gate, or conservative_manual",
 		},
 	}
 
@@ -1079,6 +1092,7 @@ func validOnboardingForm() url.Values {
 		"merging_concurrency":             {"1"},
 		"dispatch_priority_by_state":      {"Merging\nRework"},
 		"dispatch_priority_by_label":      {"bug\nregression\nenhancement"},
+		"delivery_profile":                {"review_gate"},
 		"dependency_auto_unblock_enabled": {"false"},
 	}
 }

--- a/internal/web/templates/onboarding.templ
+++ b/internal/web/templates/onboarding.templ
@@ -117,28 +117,36 @@ func projectStepTitle(form OnboardingForm) string {
 
 func selectedDeliveryProfile(form OnboardingForm) string {
 	switch form.DeliveryProfile {
-	case "autonomous_delivery":
-		return "autonomous_delivery"
+	case "full_autopilot", "review_gate", "conservative_manual":
+		return form.DeliveryProfile
 	default:
-		return "conservative_review"
+		return ""
 	}
 }
 
 func deliveryProfileLabel(form OnboardingForm) string {
 	switch selectedDeliveryProfile(form) {
-	case "autonomous_delivery":
-		return "Autonomous delivery mode"
+	case "full_autopilot":
+		return "Full autopilot"
+	case "review_gate":
+		return "Review gate"
+	case "conservative_manual":
+		return "Conservative/manual"
 	default:
-		return "Conservative review mode"
+		return "Not selected"
 	}
 }
 
 func deliveryProfileExplanation(form OnboardingForm) string {
 	switch selectedDeliveryProfile(form) {
-	case "autonomous_delivery":
-		return "Autonomous delivery mode promotes validated work when gates and CI still apply, keeps Merging serialized, enables dependency auto-unblock, and prefers live reload or project refresh without interrupting running agents."
+	case "full_autopilot":
+		return "Full autopilot promotes validated work through Human Review to Merging when gates, CI, and guardrails pass, enables dependency auto-unblock, and keeps Merging serialized."
+	case "review_gate":
+		return "Review gate stops completed work in Human Review until the operator approves promotion to Merging."
+	case "conservative_manual":
+		return "Conservative/manual keeps GitHub and project mutations read-only by default and requires explicit approval before promotion or mutation."
 	default:
-		return "Conservative review mode keeps Detent parked at Human Review until the operator chooses the next step."
+		return "Choose an automation policy before writing WORKFLOW.md."
 	}
 }
 
@@ -347,9 +355,10 @@ templ agentStep(data OnboardingData) {
 		<form class="mt-5 grid gap-4 sm:grid-cols-2" hx-post="/onboarding/agent" hx-target="#onboarding-step" hx-swap="outerHTML">
 			@hiddenProject(data.Form)
 			<div class="grid gap-3 sm:col-span-2">
-				<span class="text-sm font-medium">Delivery profile</span>
-				@deliveryProfileChoice(data, "conservative_review", "Conservative review mode", "Stop at Human Review until the operator chooses promotion or merge.")
-				@deliveryProfileChoice(data, "autonomous_delivery", "Autonomous delivery mode", "Promote when linked PRs, gates, and CI pass; keep Merging serialized.")
+				<span class="text-sm font-medium">How should Detent handle completed work after the validation gate passes?</span>
+				@deliveryProfileChoice(data, "full_autopilot", "Full autopilot", "Automatically promote work through Human Review to Merging when gates, CI, and guardrails pass.")
+				@deliveryProfileChoice(data, "review_gate", "Review gate", "Stop in Human Review until the operator approves, then continue merging.")
+				@deliveryProfileChoice(data, "conservative_manual", "Conservative/manual", "Require explicit approval before promotion or mutation; keep writes off by default.")
 			</div>
 			<label class="block sm:col-span-2">
 				<span class="text-sm font-medium">Workspace root</span>

--- a/internal/web/templates/onboarding_templ.go
+++ b/internal/web/templates/onboarding_templ.go
@@ -125,28 +125,36 @@ func projectStepTitle(form OnboardingForm) string {
 
 func selectedDeliveryProfile(form OnboardingForm) string {
 	switch form.DeliveryProfile {
-	case "autonomous_delivery":
-		return "autonomous_delivery"
+	case "full_autopilot", "review_gate", "conservative_manual":
+		return form.DeliveryProfile
 	default:
-		return "conservative_review"
+		return ""
 	}
 }
 
 func deliveryProfileLabel(form OnboardingForm) string {
 	switch selectedDeliveryProfile(form) {
-	case "autonomous_delivery":
-		return "Autonomous delivery mode"
+	case "full_autopilot":
+		return "Full autopilot"
+	case "review_gate":
+		return "Review gate"
+	case "conservative_manual":
+		return "Conservative/manual"
 	default:
-		return "Conservative review mode"
+		return "Not selected"
 	}
 }
 
 func deliveryProfileExplanation(form OnboardingForm) string {
 	switch selectedDeliveryProfile(form) {
-	case "autonomous_delivery":
-		return "Autonomous delivery mode promotes validated work when gates and CI still apply, keeps Merging serialized, enables dependency auto-unblock, and prefers live reload or project refresh without interrupting running agents."
+	case "full_autopilot":
+		return "Full autopilot promotes validated work through Human Review to Merging when gates, CI, and guardrails pass, enables dependency auto-unblock, and keeps Merging serialized."
+	case "review_gate":
+		return "Review gate stops completed work in Human Review until the operator approves promotion to Merging."
+	case "conservative_manual":
+		return "Conservative/manual keeps GitHub and project mutations read-only by default and requires explicit approval before promotion or mutation."
 	default:
-		return "Conservative review mode keeps Detent parked at Human Review until the operator chooses the next step."
+		return "Choose an automation policy before writing WORKFLOW.md."
 	}
 }
 
@@ -190,7 +198,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var2 string
 		templ_7745c5c3_Var2, templ_7745c5c3_Err = templ.JoinStringErrs(applicationName(data.ApplicationName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 163, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 171, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var2))
 		if templ_7745c5c3_Err != nil {
@@ -203,7 +211,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs(data.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 164, Col: 22}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 172, Col: 22}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -216,7 +224,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var4 templ.SafeURL
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinURLErrs(faviconPath(data.Assets))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 165, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 173, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -229,7 +237,7 @@ func OnboardingPage(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var5 templ.SafeURL
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinURLErrs(stylesheetPath(data.Assets))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 166, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 174, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -300,7 +308,7 @@ func onboardingTopbarBrand(instanceName string) templ.Component {
 			var templ_7745c5c3_Var7 string
 			templ_7745c5c3_Var7, templ_7745c5c3_Err = templ.JoinStringErrs(instanceName)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 189, Col: 188}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 197, Col: 188}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var7))
 			if templ_7745c5c3_Err != nil {
@@ -389,7 +397,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var10 templ.SafeURL
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinURLErrs(href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 203, Col: 222}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 211, Col: 222}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -402,7 +410,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var11 string
 			templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 203, Col: 252}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 211, Col: 252}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 			if templ_7745c5c3_Err != nil {
@@ -420,7 +428,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var12 templ.SafeURL
 			templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinURLErrs(href)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 205, Col: 208}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 213, Col: 208}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 			if templ_7745c5c3_Err != nil {
@@ -433,7 +441,7 @@ func onboardingNavItem(active string, id string, href string, label string) temp
 			var templ_7745c5c3_Var13 string
 			templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 205, Col: 218}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 213, Col: 218}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 			if templ_7745c5c3_Err != nil {
@@ -499,7 +507,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var17 string
 			templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(item.Label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 214, Col: 69}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 222, Col: 69}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 			if templ_7745c5c3_Err != nil {
@@ -535,7 +543,7 @@ func OnboardingStep(data OnboardingData) templ.Component {
 				var templ_7745c5c3_Var18 string
 				templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(problem)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 224, Col: 19}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 232, Col: 19}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 				if templ_7745c5c3_Err != nil {
@@ -613,7 +621,7 @@ func onboardingStepBadge(step string) templ.Component {
 		var templ_7745c5c3_Var20 string
 		templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(step)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 246, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 254, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 		if templ_7745c5c3_Err != nil {
@@ -726,7 +734,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 267, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 275, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
@@ -749,7 +757,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 269, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 277, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
@@ -762,7 +770,7 @@ func trackerChoice(data OnboardingData, value string, label string, description 
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 270, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 278, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
@@ -840,7 +848,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var31 string
 			templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Endpoint)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 285, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 293, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 			if templ_7745c5c3_Err != nil {
@@ -875,7 +883,7 @@ func credentialsStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.APIKey)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 289, Col: 86}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 297, Col: 86}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
@@ -966,7 +974,7 @@ func projectStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var40 string
 		templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(projectStepTitle(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 302, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 310, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
 		if templ_7745c5c3_Err != nil {
@@ -1019,7 +1027,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var43 string
 			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 311, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 319, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 			if templ_7745c5c3_Err != nil {
@@ -1054,7 +1062,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var46 string
 			templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusField)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 315, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 323, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 			if templ_7745c5c3_Err != nil {
@@ -1094,7 +1102,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var49 string
 			templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 320, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 328, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 			if templ_7745c5c3_Err != nil {
@@ -1129,7 +1137,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var52 string
 			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusLabelPrefix)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 324, Col: 109}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 332, Col: 109}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 			if templ_7745c5c3_Err != nil {
@@ -1169,7 +1177,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var55 string
 			templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 329, Col: 96}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 337, Col: 96}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 			if templ_7745c5c3_Err != nil {
@@ -1204,7 +1212,7 @@ func projectStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var58 string
 			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 333, Col: 81}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 341, Col: 81}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 			if templ_7745c5c3_Err != nil {
@@ -1296,15 +1304,19 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<div class=\"grid gap-3 sm:col-span-2\"><span class=\"text-sm font-medium\">Delivery profile</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "<div class=\"grid gap-3 sm:col-span-2\"><span class=\"text-sm font-medium\">How should Detent handle completed work after the validation gate passes?</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = deliveryProfileChoice(data, "conservative_review", "Conservative review mode", "Stop at Human Review until the operator chooses promotion or merge.").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = deliveryProfileChoice(data, "full_autopilot", "Full autopilot", "Automatically promote work through Human Review to Merging when gates, CI, and guardrails pass.").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = deliveryProfileChoice(data, "autonomous_delivery", "Autonomous delivery mode", "Promote when linked PRs, gates, and CI pass; keep Merging serialized.").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = deliveryProfileChoice(data, "review_gate", "Review gate", "Stop in Human Review until the operator approves, then continue merging.").Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = deliveryProfileChoice(data, "conservative_manual", "Conservative/manual", "Require explicit approval before promotion or mutation; keep writes off by default.").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1337,7 +1349,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var66 string
 		templ_7745c5c3_Var66, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 356, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 365, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var66))
 		if templ_7745c5c3_Err != nil {
@@ -1372,7 +1384,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var69 string
 		templ_7745c5c3_Var69, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 360, Col: 122}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 369, Col: 122}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var69))
 		if templ_7745c5c3_Err != nil {
@@ -1407,7 +1419,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var72 string
 		templ_7745c5c3_Var72, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MaxTurns)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 364, Col: 99}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 373, Col: 99}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var72))
 		if templ_7745c5c3_Err != nil {
@@ -1442,7 +1454,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var75 string
 		templ_7745c5c3_Var75, templ_7745c5c3_Err = templ.JoinStringErrs(data.Polling.MinIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 368, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 377, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var75))
 		if templ_7745c5c3_Err != nil {
@@ -1455,7 +1467,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var76 string
 		templ_7745c5c3_Var76, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.PollingIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 368, Col: 145}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 377, Col: 145}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var76))
 		if templ_7745c5c3_Err != nil {
@@ -1490,7 +1502,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var79 string
 		templ_7745c5c3_Var79, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.MergingConcurrency)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 372, Col: 119}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 381, Col: 119}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var79))
 		if templ_7745c5c3_Err != nil {
@@ -1525,7 +1537,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var82 string
 		templ_7745c5c3_Var82, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.DispatchPriorityState)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 376, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 385, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var82))
 		if templ_7745c5c3_Err != nil {
@@ -1560,7 +1572,7 @@ func agentStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var85 string
 		templ_7745c5c3_Var85, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.DispatchPriorityLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 380, Col: 118}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 389, Col: 118}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var85))
 		if templ_7745c5c3_Err != nil {
@@ -1668,7 +1680,7 @@ func deliveryProfileChoice(data OnboardingData, value string, label string, desc
 		var templ_7745c5c3_Var91 string
 		templ_7745c5c3_Var91, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 407, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 416, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var91))
 		if templ_7745c5c3_Err != nil {
@@ -1691,7 +1703,7 @@ func deliveryProfileChoice(data OnboardingData, value string, label string, desc
 		var templ_7745c5c3_Var92 string
 		templ_7745c5c3_Var92, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 409, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 418, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var92))
 		if templ_7745c5c3_Err != nil {
@@ -1704,7 +1716,7 @@ func deliveryProfileChoice(data OnboardingData, value string, label string, desc
 		var templ_7745c5c3_Var93 string
 		templ_7745c5c3_Var93, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 410, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 419, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var93))
 		if templ_7745c5c3_Err != nil {
@@ -1746,7 +1758,7 @@ func kanbanModeChoice(form OnboardingForm, value string, label string, descripti
 		var templ_7745c5c3_Var95 string
 		templ_7745c5c3_Var95, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 417, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 426, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var95))
 		if templ_7745c5c3_Err != nil {
@@ -1769,7 +1781,7 @@ func kanbanModeChoice(form OnboardingForm, value string, label string, descripti
 		var templ_7745c5c3_Var96 string
 		templ_7745c5c3_Var96, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 419, Col: 68}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 428, Col: 68}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var96))
 		if templ_7745c5c3_Err != nil {
@@ -1782,7 +1794,7 @@ func kanbanModeChoice(form OnboardingForm, value string, label string, descripti
 		var templ_7745c5c3_Var97 string
 		templ_7745c5c3_Var97, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 420, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 429, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var97))
 		if templ_7745c5c3_Err != nil {
@@ -1824,7 +1836,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var99 string
 		templ_7745c5c3_Var99, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 429, Col: 87}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 438, Col: 87}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var99))
 		if templ_7745c5c3_Err != nil {
@@ -1837,7 +1849,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var100 string
 		templ_7745c5c3_Var100, templ_7745c5c3_Err = templ.JoinStringErrs(deliveryProfileLabel(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 430, Col: 106}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 439, Col: 106}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var100))
 		if templ_7745c5c3_Err != nil {
@@ -1855,7 +1867,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var101 string
 			templ_7745c5c3_Var101, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.ProjectSlug)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 432, Col: 90}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 441, Col: 90}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var101))
 			if templ_7745c5c3_Err != nil {
@@ -1874,7 +1886,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var102 string
 			templ_7745c5c3_Var102, templ_7745c5c3_Err = templ.JoinStringErrs(githubStatusSource(data.Form))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 435, Col: 102}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 444, Col: 102}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var102))
 			if templ_7745c5c3_Err != nil {
@@ -1893,7 +1905,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var103 string
 			templ_7745c5c3_Var103, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.Repo)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 438, Col: 78}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 447, Col: 78}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var103))
 			if templ_7745c5c3_Err != nil {
@@ -1912,7 +1924,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var104 string
 			templ_7745c5c3_Var104, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusField)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 441, Col: 93}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 450, Col: 93}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var104))
 			if templ_7745c5c3_Err != nil {
@@ -1931,7 +1943,7 @@ func writeStep(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var105 string
 			templ_7745c5c3_Var105, templ_7745c5c3_Err = templ.JoinStringErrs(data.Form.StatusLabelPrefix)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 444, Col: 106}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 453, Col: 106}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var105))
 			if templ_7745c5c3_Err != nil {
@@ -1949,7 +1961,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var106 string
 		templ_7745c5c3_Var106, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanMode(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 446, Col: 94}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 455, Col: 94}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var106))
 		if templ_7745c5c3_Err != nil {
@@ -1962,7 +1974,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var107 string
 		templ_7745c5c3_Var107, templ_7745c5c3_Err = templ.JoinStringErrs(data.WorkflowPath)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 447, Col: 82}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 456, Col: 82}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var107))
 		if templ_7745c5c3_Err != nil {
@@ -1975,7 +1987,7 @@ func writeStep(data OnboardingData) templ.Component {
 		var templ_7745c5c3_Var108 string
 		templ_7745c5c3_Var108, templ_7745c5c3_Err = templ.JoinStringErrs(deliveryProfileExplanation(data.Form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 448, Col: 67}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 457, Col: 67}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var108))
 		if templ_7745c5c3_Err != nil {
@@ -2052,7 +2064,7 @@ func resultPanel(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var112 string
 			templ_7745c5c3_Var112, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 461, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 470, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var112))
 			if templ_7745c5c3_Err != nil {
@@ -2078,7 +2090,7 @@ func resultPanel(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var113 string
 			templ_7745c5c3_Var113, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 466, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 475, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var113))
 			if templ_7745c5c3_Err != nil {
@@ -2104,7 +2116,7 @@ func resultPanel(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var114 string
 			templ_7745c5c3_Var114, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 471, Col: 35}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 480, Col: 35}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var114))
 			if templ_7745c5c3_Err != nil {
@@ -2152,7 +2164,7 @@ func resultPanel(data OnboardingData) templ.Component {
 			var templ_7745c5c3_Var117 string
 			templ_7745c5c3_Var117, templ_7745c5c3_Err = templ.JoinStringErrs(data.Result.Message)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 480, Col: 32}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 489, Col: 32}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var117))
 			if templ_7745c5c3_Err != nil {
@@ -2209,7 +2221,7 @@ func resultDetails(result OnboardingResult) templ.Component {
 				var templ_7745c5c3_Var119 string
 				templ_7745c5c3_Var119, templ_7745c5c3_Err = templ.JoinStringErrs(detail)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 490, Col: 16}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 499, Col: 16}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var119))
 				if templ_7745c5c3_Err != nil {
@@ -2257,7 +2269,7 @@ func hiddenTracker(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var121 string
 		templ_7745c5c3_Var121, templ_7745c5c3_Err = templ.JoinStringErrs(form.TrackerKind)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 497, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 506, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var121))
 		if templ_7745c5c3_Err != nil {
@@ -2270,7 +2282,7 @@ func hiddenTracker(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var122 string
 		templ_7745c5c3_Var122, templ_7745c5c3_Err = templ.JoinStringErrs(form.GitHubStatusSource)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 498, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 507, Col: 81}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var122))
 		if templ_7745c5c3_Err != nil {
@@ -2316,7 +2328,7 @@ func hiddenCredentials(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var124 string
 		templ_7745c5c3_Var124, templ_7745c5c3_Err = templ.JoinStringErrs(form.Endpoint)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 503, Col: 59}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 512, Col: 59}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var124))
 		if templ_7745c5c3_Err != nil {
@@ -2329,7 +2341,7 @@ func hiddenCredentials(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var125 string
 		templ_7745c5c3_Var125, templ_7745c5c3_Err = templ.JoinStringErrs(form.APIKey)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 504, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 513, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var125))
 		if templ_7745c5c3_Err != nil {
@@ -2375,7 +2387,7 @@ func hiddenProject(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var127 string
 		templ_7745c5c3_Var127, templ_7745c5c3_Err = templ.JoinStringErrs(form.ProjectSlug)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 509, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 518, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var127))
 		if templ_7745c5c3_Err != nil {
@@ -2388,7 +2400,7 @@ func hiddenProject(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var128 string
 		templ_7745c5c3_Var128, templ_7745c5c3_Err = templ.JoinStringErrs(form.Repo)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 510, Col: 51}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 519, Col: 51}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var128))
 		if templ_7745c5c3_Err != nil {
@@ -2401,7 +2413,7 @@ func hiddenProject(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var129 string
 		templ_7745c5c3_Var129, templ_7745c5c3_Err = templ.JoinStringErrs(form.StatusField)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 511, Col: 66}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 520, Col: 66}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var129))
 		if templ_7745c5c3_Err != nil {
@@ -2414,7 +2426,7 @@ func hiddenProject(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var130 string
 		templ_7745c5c3_Var130, templ_7745c5c3_Err = templ.JoinStringErrs(form.StatusLabelPrefix)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 512, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 521, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var130))
 		if templ_7745c5c3_Err != nil {
@@ -2489,7 +2501,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var133 string
 		templ_7745c5c3_Var133, templ_7745c5c3_Err = templ.JoinStringErrs(form.WorkspaceRoot)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 521, Col: 70}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 530, Col: 70}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var133))
 		if templ_7745c5c3_Err != nil {
@@ -2502,7 +2514,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var134 string
 		templ_7745c5c3_Var134, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxConcurrentAgents)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 522, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 531, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var134))
 		if templ_7745c5c3_Err != nil {
@@ -2515,7 +2527,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var135 string
 		templ_7745c5c3_Var135, templ_7745c5c3_Err = templ.JoinStringErrs(form.MaxTurns)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 523, Col: 60}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 532, Col: 60}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var135))
 		if templ_7745c5c3_Err != nil {
@@ -2528,7 +2540,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var136 string
 		templ_7745c5c3_Var136, templ_7745c5c3_Err = templ.JoinStringErrs(form.PollingIntervalMS)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 524, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 533, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var136))
 		if templ_7745c5c3_Err != nil {
@@ -2541,7 +2553,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var137 string
 		templ_7745c5c3_Var137, templ_7745c5c3_Err = templ.JoinStringErrs(form.MergingConcurrency)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 525, Col: 80}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 534, Col: 80}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var137))
 		if templ_7745c5c3_Err != nil {
@@ -2554,7 +2566,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var138 string
 		templ_7745c5c3_Var138, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityState)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 526, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 535, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var138))
 		if templ_7745c5c3_Err != nil {
@@ -2567,7 +2579,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var139 string
 		templ_7745c5c3_Var139, templ_7745c5c3_Err = templ.JoinStringErrs(form.DispatchPriorityLabel)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 527, Col: 90}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 536, Col: 90}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var139))
 		if templ_7745c5c3_Err != nil {
@@ -2580,7 +2592,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var140 string
 		templ_7745c5c3_Var140, templ_7745c5c3_Err = templ.JoinStringErrs(form.DeliveryProfile)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 528, Col: 74}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 537, Col: 74}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var140))
 		if templ_7745c5c3_Err != nil {
@@ -2593,7 +2605,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var141 string
 		templ_7745c5c3_Var141, templ_7745c5c3_Err = templ.JoinStringErrs(form.DependencyAutoUnblockEnabled)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 529, Col: 102}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 538, Col: 102}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var141))
 		if templ_7745c5c3_Err != nil {
@@ -2606,7 +2618,7 @@ func hiddenAgentFields(form OnboardingForm) templ.Component {
 		var templ_7745c5c3_Var142 string
 		templ_7745c5c3_Var142, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanMode(form))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 530, Col: 65}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/onboarding.templ`, Line: 539, Col: 65}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var142))
 		if templ_7745c5c3_Err != nil {

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -253,17 +253,25 @@ func TestOnboardingDocsPresentDeliveryProfilesBeforeAnswersEnvFields(t *testing.
 
 	for _, want := range []string{
 		"Present the operator's plain-English operating model first, then show the canonical `answers.env` fields.",
-		"Conservative review: stop at `Human Review` until a human explicitly promotes work.",
-		"Autonomous delivery: move Todo work through PR, CI/gates, Merging, and Done without human review or quiet-window delay when there are no real blockers.",
+		"How should Detent handle completed work after the validation gate passes?",
+		"Full autopilot: promote through `Human Review` to `Merging` when linked PRs, gates, CI, mergeability, dependency checks, and guardrails pass",
+		"Review gate: stop at `Human Review` until a human explicitly approves promotion to `Merging`",
+		"Conservative/manual: require explicit approval before promotion or mutation",
 		"Custom/advanced: expose the underlying fields for teams that need a mixed policy.",
-		"When the operator says \"no human review, no wait state, unblock aggressively, only stop on real blockers,\" recommend `autonomous_delivery`.",
+		"When the operator says \"no human review, no wait state, unblock aggressively, only stop on real blockers,\" asks for maximum automation, or says to auto-promote and auto-unblock as much as guardrails allow, recommend `full_autopilot`.",
+		"Do not recommend `AUTO_PROMOTE_ENABLED=false` unless the operator selected review gate or conservative/manual.",
+		"Phase 2.5 still must approve the exact answers before creating labels, editing `global.yaml`, writing `WORKFLOW.md`, or dispatching agents.",
 	} {
 		assertContainsWords(t, onboarding, want)
 	}
 
-	assertOrder(t, onboarding, "Conservative review:", "DELIVERY_PROFILE=<conservative_review|autonomous_delivery>")
-	assertOrder(t, onboarding, "Autonomous delivery:", "DELIVERY_PROFILE=<conservative_review|autonomous_delivery>")
-	assertOrder(t, onboarding, "Custom/advanced:", "DELIVERY_PROFILE=<conservative_review|autonomous_delivery>")
+	assertOrder(t, onboarding, "How should Detent handle completed work after the validation gate passes?", "DELIVERY_PROFILE=<full_autopilot|review_gate|conservative_manual>")
+	assertOrder(t, onboarding, "Full autopilot:", "DELIVERY_PROFILE=<full_autopilot|review_gate|conservative_manual>")
+	assertOrder(t, onboarding, "Review gate:", "DELIVERY_PROFILE=<full_autopilot|review_gate|conservative_manual>")
+	assertOrder(t, onboarding, "Conservative/manual:", "DELIVERY_PROFILE=<full_autopilot|review_gate|conservative_manual>")
+	assertOrder(t, onboarding, "Full autopilot expands to:", "AUTO_PROMOTE_ENABLED=true")
+	assertOrder(t, onboarding, "Review gate expands to:", "Conservative/manual expands to:")
+	assertOrder(t, onboarding, "Conservative/manual expands to:", "GATE_REQUIRE_AUTOMATED_REVIEW=true")
 }
 
 func TestOnboardingDocsSkipDuplicateProfileSuppliedQuestions(t *testing.T) {
@@ -272,7 +280,7 @@ func TestOnboardingDocsSkipDuplicateProfileSuppliedQuestions(t *testing.T) {
 	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
 
 	for _, want := range []string{
-		"After selecting `DELIVERY_PROFILE=autonomous_delivery`, do not ask the Kanban interaction, validation-gate automated-review, Merging concurrency, review policy, or dependency waiting policy questions again unless the operator asks for an advanced override.",
+		"After selecting a named profile, do not ask the Kanban interaction, validation-gate automated-review, Merging concurrency, review policy, or dependency waiting policy questions again unless the operator asks for an advanced override.",
 		"Advanced override means the operator switches to Custom/advanced after seeing the expansion; remove or omit `DELIVERY_PROFILE` before recording a profile-supplied key with a different value.",
 		"Ask the remaining Phase 2 questions that are not supplied by the selected profile.",
 	} {


### PR DESCRIPTION
## Summary

- Replace the old two-profile onboarding recommendation with full autopilot, review gate, and conservative/manual automation policies.
- Update Phase 2 docs, README prompt guidance, CLI validation/explain output, and the web wizard to ask the plain-English policy question before env mappings.
- Add tests for the three policy profiles and keep mutation confirmation separate from generated recommendations.

Fixes #760

## Test Plan

- [x] `go test ./internal/onboarding ./internal/cli ./internal/web .`
- [x] `make check`