### PR TITLE
fix(kanban): dedupe merged issue rows

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -454,8 +454,20 @@ func projectSnapshotMetadata(trackedProject *project.Project) telemetry.Project 
 		ID:          id,
 		DisplayName: id,
 		URL:         projectURLFromWorkflow(workflow.Config),
+		Repository:  projectRepositoryFromWorkflow(workflow.Config),
 		Color:       projectcolor.ColorFor(id, cfg.Color),
 	}
+}
+
+func projectRepositoryFromWorkflow(cfg workflowconfig.Config) string {
+	if repository := strings.TrimSpace(cfg.Tracker.Repository); repository != "" {
+		return repository
+	}
+	repository, _, ok := strings.Cut(strings.TrimSpace(cfg.Tracker.WriteProbeIssue), "#")
+	if ok && strings.Contains(repository, "/") {
+		return strings.TrimSpace(repository)
+	}
+	return ""
 }
 
 func projectURLFromWorkflow(cfg workflowconfig.Config) string {
@@ -593,8 +605,8 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 	current.Queue = append(current.Queue, next.Queue...)
 	current.Blocked = append(current.Blocked, next.Blocked...)
 	current.Completed = append(current.Completed, next.Completed...)
-	current.BoardIssues = append(current.BoardIssues, next.BoardIssues...)
-	current.Pipeline = append(current.Pipeline, next.Pipeline...)
+	current.BoardIssues = mergeIssueRows(current.BoardIssues, next.BoardIssues, current.Projects)
+	current.Pipeline = mergeIssueRows(current.Pipeline, next.Pipeline, current.Projects)
 	current.Budget.Refusals = append(current.Budget.Refusals, next.Budget.Refusals...)
 
 	current.Counts.Running += next.Counts.Running
@@ -611,6 +623,76 @@ func mergeSnapshot(current, next telemetry.Snapshot) telemetry.Snapshot {
 		current.RateLimits = next.RateLimits
 	}
 	return current
+}
+
+func mergeIssueRows(current, next []telemetry.Issue, projects []telemetry.ProjectSnapshot) []telemetry.Issue {
+	if len(current) == 0 && len(next) == 0 {
+		return current
+	}
+
+	projectRepositories := projectRepositories(projects)
+	combined := make([]telemetry.Issue, 0, len(current)+len(next))
+	combined = append(combined, current...)
+	combined = append(combined, next...)
+
+	out := make([]telemetry.Issue, 0, len(combined))
+	seen := make(map[string]int, len(combined))
+	for _, issue := range combined {
+		id := strings.TrimSpace(issue.ID)
+		if id == "" {
+			out = append(out, issue)
+			continue
+		}
+
+		index, ok := seen[id]
+		if !ok {
+			seen[id] = len(out)
+			out = append(out, issue)
+			continue
+		}
+		if preferIssueProject(issue, out[index], projectRepositories) {
+			out[index] = issue
+		}
+	}
+	return out
+}
+
+func projectRepositories(projects []telemetry.ProjectSnapshot) map[string]string {
+	out := make(map[string]string, len(projects))
+	for _, snapshot := range projects {
+		projectID := strings.ToLower(strings.TrimSpace(snapshot.Project.ID))
+		repository := strings.ToLower(strings.TrimSpace(snapshot.Project.Repository))
+		if projectID != "" && repository != "" {
+			out[projectID] = repository
+		}
+	}
+	return out
+}
+
+func preferIssueProject(candidate, incumbent telemetry.Issue, projectRepositories map[string]string) bool {
+	candidateMatches := issueProjectMatchesRepository(candidate, projectRepositories)
+	incumbentMatches := issueProjectMatchesRepository(incumbent, projectRepositories)
+	return candidateMatches && !incumbentMatches
+}
+
+func issueProjectMatchesRepository(issue telemetry.Issue, projectRepositories map[string]string) bool {
+	repository := strings.ToLower(strings.TrimSpace(issueRepository(issue)))
+	if repository == "" {
+		return false
+	}
+	projectID := strings.ToLower(strings.TrimSpace(issue.ProjectID))
+	return projectID != "" && projectRepositories[projectID] == repository
+}
+
+func issueRepository(issue telemetry.Issue) string {
+	if issue.MergeTiming != nil && strings.TrimSpace(issue.MergeTiming.Repository) != "" {
+		return strings.TrimSpace(issue.MergeTiming.Repository)
+	}
+	repository, _, ok := strings.Cut(strings.TrimSpace(issue.Identifier), "#")
+	if ok && strings.Contains(repository, "/") {
+		return strings.TrimSpace(repository)
+	}
+	return ""
 }
 
 func stampSnapshotProjectID(snapshot telemetry.Snapshot) telemetry.Snapshot {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -604,6 +604,150 @@ func TestMergeSnapshotStampsProjectIDOnIssueRows(t *testing.T) {
 	}
 }
 
+func TestMergeSnapshotDeduplicatesIssueRowsByNodeID(t *testing.T) {
+	t.Parallel()
+
+	got := mergeSnapshot(telemetry.Snapshot{}, telemetry.Snapshot{
+		Project: telemetry.Project{ID: "digitaldrywood", DisplayName: "Digital Drywood"},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate board card",
+			State:      "In Progress",
+		}},
+		Pipeline: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate pipeline card",
+			State:      "Human Review",
+		}},
+	})
+	got = mergeSnapshot(got, telemetry.Snapshot{
+		Project: telemetry.Project{ID: "pyroapex", DisplayName: "Pyro Apex"},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate board card",
+			State:      "In Progress",
+		}},
+		Pipeline: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate pipeline card",
+			State:      "Human Review",
+		}},
+	})
+
+	if len(got.BoardIssues) != 1 {
+		t.Fatalf("BoardIssues len = %d, want 1: %#v", len(got.BoardIssues), got.BoardIssues)
+	}
+	if len(got.Pipeline) != 1 {
+		t.Fatalf("Pipeline len = %d, want 1: %#v", len(got.Pipeline), got.Pipeline)
+	}
+	if got.BoardIssues[0].ProjectID != "digitaldrywood" {
+		t.Fatalf("BoardIssues[0].ProjectID = %q, want first-seen project", got.BoardIssues[0].ProjectID)
+	}
+	if got.Pipeline[0].ProjectID != "digitaldrywood" {
+		t.Fatalf("Pipeline[0].ProjectID = %q, want first-seen project", got.Pipeline[0].ProjectID)
+	}
+}
+
+func TestMergeSnapshotPrefersRepositoryProjectForDuplicateIssueRows(t *testing.T) {
+	t.Parallel()
+
+	got := mergeSnapshot(telemetry.Snapshot{}, telemetry.Snapshot{
+		Project: telemetry.Project{
+			ID:          "digitaldrywood",
+			DisplayName: "Digital Drywood",
+			Repository:  "digitaldrywood/digitaldrywood",
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate board card",
+			State:      "In Progress",
+		}},
+		Pipeline: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate pipeline card",
+			State:      "Human Review",
+		}},
+	})
+	got = mergeSnapshot(got, telemetry.Snapshot{
+		Project: telemetry.Project{
+			ID:          "pyroapex",
+			DisplayName: "Pyro Apex",
+			Repository:  "digitaldrywood/pyroapex",
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate board card",
+			State:      "In Progress",
+		}},
+		Pipeline: []telemetry.Issue{{
+			ID:         "I_kwDORZINcs8AAAABHDv6cg",
+			Identifier: "digitaldrywood/pyroapex#1434",
+			Title:      "Duplicate pipeline card",
+			State:      "Human Review",
+		}},
+	})
+
+	if len(got.BoardIssues) != 1 {
+		t.Fatalf("BoardIssues len = %d, want 1: %#v", len(got.BoardIssues), got.BoardIssues)
+	}
+	if got.BoardIssues[0].ProjectID != "pyroapex" {
+		t.Fatalf("BoardIssues[0].ProjectID = %q, want repository-owning project", got.BoardIssues[0].ProjectID)
+	}
+	if len(got.Pipeline) != 1 {
+		t.Fatalf("Pipeline len = %d, want 1: %#v", len(got.Pipeline), got.Pipeline)
+	}
+	if got.Pipeline[0].ProjectID != "pyroapex" {
+		t.Fatalf("Pipeline[0].ProjectID = %q, want repository-owning project", got.Pipeline[0].ProjectID)
+	}
+}
+
+func TestProjectRepositoryFromWorkflow(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  workflowconfig.Config
+		want string
+	}{
+		{
+			name: "repository",
+			cfg: workflowconfig.Config{
+				Tracker: workflowconfig.Tracker{Repository: "digitaldrywood/detent"},
+			},
+			want: "digitaldrywood/detent",
+		},
+		{
+			name: "write probe issue",
+			cfg: workflowconfig.Config{
+				Tracker: workflowconfig.Tracker{WriteProbeIssue: "digitaldrywood/pyroapex#1434"},
+			},
+			want: "digitaldrywood/pyroapex",
+		},
+		{
+			name: "empty",
+			cfg:  workflowconfig.Config{},
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := projectRepositoryFromWorkflow(tt.cfg); got != tt.want {
+				t.Fatalf("projectRepositoryFromWorkflow() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeSnapshotMergesSchedulerRuntimeRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -47,6 +47,7 @@ type Project struct {
 	ID          string `json:"id,omitempty"`
 	DisplayName string `json:"display_name,omitempty"`
 	URL         string `json:"url,omitempty"`
+	Repository  string `json:"repository,omitempty"`
 	Color       string `json:"color,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

- Deduplicate merged fleet `BoardIssues` and `Pipeline` rows by GitHub issue node id.
- Prefer the project whose tracked repository matches the issue repository when duplicate project snapshots overlap; otherwise keep first-seen ownership.
- Carry project repository metadata from `tracker.repository` or ProjectV2 `write_probe_issue` into telemetry project snapshots.

Fixes #767

## Test Plan

- [x] `go test ./internal/cli -run 'TestMergeSnapshot(DeduplicatesIssueRowsByNodeID|PrefersRepositoryProjectForDuplicateIssueRows)|TestProjectRepositoryFromWorkflow' -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `make check`