### PR TITLE
fix(config): reject relative workflow paths

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -25,7 +25,7 @@ var (
 )
 
 const (
-	addProjectExampleCommand = "detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"
+	addProjectExampleCommand = "detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api"
 	configPathCommand        = "detent config path"
 	forceInitCommand         = "detent init --force"
 	ghAuthLoginCommand       = `gh auth login --scopes "repo,read:org,project"`
@@ -690,7 +690,7 @@ func newAddProjectCommand(configPath *string, opts options) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:     "add-project",
 		Short:   "Add a project to global config",
-		Example: "detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api --weight 2",
+		Example: "detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api --weight 2",
 		Args:    NoArgs,
 		RunE: func(cmd *cobra.Command, _ []string) error {
 			out, err := OutputForCommand(cmd)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -936,29 +936,29 @@ func TestCLIValidationErrorsCarryHints(t *testing.T) {
 			name:         "missing project id",
 			args:         []string{"--config", configPath, "add-project", "--workflow", "./WORKFLOW.md", "--workdir", "~/code/api"},
 			wantMessage:  "--id is required",
-			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api",
-			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"},
+			wantHint:     "e.g. detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api",
+			wantCommands: []string{"detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api"},
 		},
 		{
 			name:         "missing project workflow",
 			args:         []string{"--config", configPath, "add-project", "--id", "api", "--workdir", "~/code/api"},
 			wantMessage:  "--workflow is required",
-			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api",
-			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"},
+			wantHint:     "e.g. detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api",
+			wantCommands: []string{"detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api"},
 		},
 		{
 			name:         "missing project workdir",
 			args:         []string{"--config", configPath, "add-project", "--id", "api", "--workflow", "./WORKFLOW.md"},
 			wantMessage:  "--workdir is required",
-			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api",
-			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api"},
+			wantHint:     "e.g. detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api",
+			wantCommands: []string{"detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api"},
 		},
 		{
 			name:         "invalid project weight",
 			args:         []string{"--config", configPath, "add-project", "--id", "api", "--workflow", "./WORKFLOW.md", "--workdir", "~/code/api", "--weight", "0"},
 			wantMessage:  "--weight must be positive",
-			wantHint:     "e.g. detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api --weight 1",
-			wantCommands: []string{"detent add-project --id api --workflow ./WORKFLOW.md --workdir ~/code/api --weight 1"},
+			wantHint:     "e.g. detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api --weight 1",
+			wantCommands: []string{"detent add-project --id api --workflow ~/code/api/WORKFLOW.md --workdir ~/code/api --weight 1"},
 		},
 		{
 			name:         "invalid promote priority",
@@ -1168,6 +1168,45 @@ func TestAddProjectCommandEmitsJSONResult(t *testing.T) {
 	}
 }
 
+func TestAddProjectRejectsPlainRelativeWorkflowPath(t *testing.T) {
+	root := t.TempDir()
+	daemonDir := filepath.Join(root, "daemon")
+	projectDir := filepath.Join(root, "project")
+	writeWorkflow(t, filepath.Join(daemonDir, "WORKFLOW.md"), validWorkflowContent())
+	writeWorkflow(t, filepath.Join(projectDir, "WORKFLOW.md"), validWorkflowContent())
+	configPath := filepath.Join(root, "global.yaml")
+	writeGlobalConfig(t, configPath, nil)
+	t.Chdir(daemonDir)
+
+	cmd := cli.NewRootCommand(context.Background())
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"add-project",
+		"--id", "detent",
+		"--workflow", "WORKFLOW.md",
+		"--workdir", projectDir,
+	})
+
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want relative workflow validation error")
+	}
+	want := "projects[0].workflow: must be absolute or home-relative when workflow_ref is empty"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("Execute() error = %q, want substring %q", err, want)
+	}
+
+	cfg, err := globalconfig.Read(configPath)
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(cfg.Projects) != 0 {
+		t.Fatalf("Projects length = %d, want 0", len(cfg.Projects))
+	}
+}
+
 func TestRootCommandClassifiesMistypedCommandSuggestion(t *testing.T) {
 	t.Parallel()
 
@@ -1369,7 +1408,12 @@ func TestProjectAdminCommandsEditConfigAndSignalManager(t *testing.T) {
 func TestProjectAdminCommandsPreserveProjectPathLiterals(t *testing.T) {
 	t.Parallel()
 
-	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	root := t.TempDir()
+	configPath := filepath.Join(root, "global.yaml")
+	workflowPath := filepath.Join(root, "cli.go")
+	if err := os.WriteFile(workflowPath, []byte("package cli\n"), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
 	if err := os.WriteFile(configPath, []byte(`apiVersion: detent/v1
 kind: GlobalConfig
 global:
@@ -1377,12 +1421,12 @@ global:
   scheduling: weighted
 projects:
   - id: detent
-    workflow: cli.go
+    workflow: `+workflowPath+`
     workdir: .
     weight: 1
     priority: 0
   - id: docs
-    workflow: cli.go
+    workflow: `+workflowPath+`
     workdir: .
     weight: 2
     priority: 1
@@ -1419,8 +1463,8 @@ projects:
 		t.Fatalf("Projects length = %d, want 2", len(written.Projects))
 	}
 	for _, project := range written.Projects {
-		if project.Workflow != "cli.go" {
-			t.Fatalf("project %s workflow = %q, want cli.go", project.ID, project.Workflow)
+		if project.Workflow != workflowPath {
+			t.Fatalf("project %s workflow = %q, want %q", project.ID, project.Workflow, workflowPath)
 		}
 		if project.Workdir != "." {
 			t.Fatalf("project %s workdir = %q, want .", project.ID, project.Workdir)

--- a/internal/cli/dev_runtime_capture.go
+++ b/internal/cli/dev_runtime_capture.go
@@ -511,13 +511,13 @@ func writeDemoTerminalCapture(outDir string) (demoCaptureTerminalResult, error) 
 		},
 		Projects: []globalconfig.Project{{
 			ID:       "detent-demo",
-			Workflow: "./terminal/v1/config/WORKFLOW.md",
-			Workdir:  "./terminal/v1/source/detent-demo",
+			Workflow: "~/terminal/v1/config/WORKFLOW.md",
+			Workdir:  "~/terminal/v1/source/detent-demo",
 			Weight:   1,
 			Priority: 1,
 		}},
 	}
-	if err := globalconfig.Write(configPath, cfg, globalconfig.WithRelativeTo(outDir)); err != nil {
+	if err := globalconfig.Write(configPath, cfg, globalconfig.WithHome(outDir), globalconfig.WithRelativeTo(outDir)); err != nil {
 		return demoCaptureTerminalResult{}, fmt.Errorf("write terminal capture global config: %w", err)
 	}
 
@@ -607,8 +607,8 @@ func writeDemoTerminalCast(path string) error {
 	}{
 		{0.10, "$ detent init --config ./terminal/v1/config/global.yaml\r\n"},
 		{0.45, "status: ok\r\npath: ./terminal/v1/config/global.yaml\r\nrule: --config\r\n"},
-		{0.90, "$ detent add-project --config ./terminal/v1/config/global.yaml --id detent-demo --workflow ./terminal/v1/config/WORKFLOW.md --workdir ./terminal/v1/source/detent-demo\r\n"},
-		{1.35, "status: ok\r\nid: detent-demo\r\nworkflow: ./terminal/v1/config/WORKFLOW.md\r\nworkdir: ./terminal/v1/source/detent-demo\r\n"},
+		{0.90, "$ detent add-project --config ./terminal/v1/config/global.yaml --id detent-demo --workflow ~/terminal/v1/config/WORKFLOW.md --workdir ~/terminal/v1/source/detent-demo\r\n"},
+		{1.35, "status: ok\r\nid: detent-demo\r\nworkflow: ~/terminal/v1/config/WORKFLOW.md\r\nworkdir: ~/terminal/v1/source/detent-demo\r\n"},
 		{1.80, "$ detent doctor --config ./terminal/v1/config/global.yaml --port 0\r\n"},
 		{2.20, "Config resolution ... OK\r\nRuntime settings ... OK\r\nProject detent-demo workflow ... OK\r\nProject detent-demo source repository ... OK\r\nSQLite database ... OK\r\nGitHub token ... OK (skipped for memory tracker)\r\nServer port ... OK\r\nresult: PASS\r\n"},
 	}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -28,6 +28,8 @@ const (
 	configFileMode = 0o600
 )
 
+const plainWorkflowPathRequirement = "must be absolute or home-relative when workflow_ref is empty"
+
 var schedulingModes = []string{
 	SchedulingWeighted,
 	SchedulingStrict,
@@ -419,7 +421,7 @@ func (c Config) Validate(opts ...Option) error {
 		if strings.TrimSpace(project.Workflow) == "" {
 			problems = append(problems, prefix+".workflow: must not be blank")
 		} else if strings.TrimSpace(project.WorkflowRef) == "" {
-			problems = append(problems, projectPathErrors(project.Workflow, prefix+".workflow", readOptions, wantFile)...)
+			problems = append(problems, plainWorkflowPathErrors(project.Workflow, prefix+".workflow", readOptions, wantFile)...)
 		}
 		if strings.ContainsAny(project.WorkflowRef, "\r\n") {
 			problems = append(problems, prefix+".workflow_ref: must be a single line")
@@ -784,7 +786,7 @@ func projectErrors(value any, index int, opts options) []string {
 	problems = append(problems, singleLineStringErrors(project, "workflow_ref", prefix)...)
 	problems = append(problems, projectColorErrors(project, prefix)...)
 	if strings.TrimSpace(projectStringValue(project, "workflow_ref")) == "" {
-		problems = append(problems, pathErrors(project, "workflow", prefix, opts, wantFile)...)
+		problems = append(problems, plainWorkflowErrors(project, "workflow", prefix, opts, wantFile)...)
 	} else {
 		problems = append(problems, stringErrors(project, "workflow", prefix)...)
 	}
@@ -902,6 +904,29 @@ func pathErrors(attrs map[string]any, field string, prefix string, opts options,
 	return projectPathErrors(text, prefix+"."+field, opts, expected)
 }
 
+func plainWorkflowErrors(attrs map[string]any, field string, prefix string, opts options, expected pathExpectation) []string {
+	value, ok := attrs[field]
+	if !ok || value == nil {
+		return nil
+	}
+
+	text, ok := value.(string)
+	if !ok {
+		return []string{prefix + "." + field + ": must be a string"}
+	}
+	return plainWorkflowPathErrors(text, prefix+"."+field, opts, expected)
+}
+
+func plainWorkflowPathErrors(path string, field string, opts options, expected pathExpectation) []string {
+	if strings.TrimSpace(path) == "" {
+		return []string{field + ": must not be blank"}
+	}
+	if relativeWorkflowPathLiteral(path) {
+		return []string{field + ": " + plainWorkflowPathRequirement}
+	}
+	return projectPathErrors(path, field, opts, expected)
+}
+
 func projectPathErrors(path string, field string, opts options, expected pathExpectation) []string {
 	if strings.TrimSpace(path) == "" {
 		return []string{field + ": must not be blank"}
@@ -923,6 +948,15 @@ func projectPathErrors(path string, field string, opts options, expected pathExp
 		return []string{field + ": path does not exist"}
 	}
 	return nil
+}
+
+func relativeWorkflowPathLiteral(path string) bool {
+	path = strings.TrimSpace(path)
+	return !filepath.IsAbs(path) && !homePathLiteral(path)
+}
+
+func homePathLiteral(path string) bool {
+	return path == "~" || strings.HasPrefix(path, "~/")
 }
 
 func positiveIntegerError(value any, field string) []string {
@@ -1209,6 +1243,9 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 		}
 		if !opts.projectPathLiterals {
 			if strings.TrimSpace(workflowRef) == "" {
+				if relativeWorkflowPathLiteral(workflow) {
+					return nil, fmt.Errorf("%s.workflow: %s", prefix, plainWorkflowPathRequirement)
+				}
 				expandedWorkflow, err := expandPath(workflow, opts)
 				if err != nil {
 					return nil, fmt.Errorf("%s.workflow: expand path: %w", prefix, err)

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -318,6 +318,38 @@ projects:
 	}
 }
 
+func TestReadRejectsPlainRelativeWorkflowPath(t *testing.T) {
+	root := t.TempDir()
+	daemonDir := filepath.Join(root, "daemon")
+	projectDir := filepath.Join(root, "project")
+	writeFile(t, filepath.Join(daemonDir, "WORKFLOW.md"), "---\ntracker:\n  kind: memory\n---\ndaemon\n")
+	writeFile(t, filepath.Join(projectDir, "WORKFLOW.md"), "---\ntracker:\n  kind: memory\n---\nproject\n")
+	configPath := filepath.Join(root, "global.yaml")
+	writeFile(t, configPath, `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+projects:
+  - id: detent
+    workflow: WORKFLOW.md
+    workdir: `+projectDir+`
+    weight: 1
+    priority: 0
+`)
+
+	t.Chdir(daemonDir)
+
+	_, err := Read(configPath)
+	if err == nil {
+		t.Fatal("Read() error = nil, want relative workflow validation error")
+	}
+	want := "projects[0].workflow: must be absolute or home-relative when workflow_ref is empty"
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("Read() error = %q, want substring %q", err, want)
+	}
+}
+
 func TestReadOrDefaultUsesDefaultForMissingFile(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "missing", "global.yaml")
 

--- a/internal/project/workflow_source.go
+++ b/internal/project/workflow_source.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -17,6 +18,7 @@ import (
 
 var (
 	errMissingWorkflowRefRoot = errors.New("workflow_ref requires project workdir")
+	errRelativeWorkflowPath   = errors.New("workflow path must be absolute or home-relative when workflow_ref is empty")
 	errUnsafeWorkflowPath     = errors.New("workflow path must stay inside the source root")
 )
 
@@ -38,7 +40,11 @@ func LoadWorkflow(cfg globalconfig.Project) (workflowconfig.Workflow, error) {
 
 func LoadWorkflowContext(ctx context.Context, cfg globalconfig.Project) (workflowconfig.Workflow, error) {
 	if strings.TrimSpace(cfg.WorkflowRef) == "" {
-		return workflowconfig.LoadWorkflow(cfg.Workflow)
+		workflowPath, err := plainWorkflowPath(cfg.Workflow)
+		if err != nil {
+			return workflowconfig.Workflow{}, err
+		}
+		return workflowconfig.LoadWorkflow(workflowPath)
 	}
 	if ctx == nil {
 		ctx = context.Background()
@@ -76,6 +82,29 @@ func newWorkflowGitRefSource(cfg globalconfig.Project) (workflowGitRefSource, er
 		ref:        ref,
 		path:       workflowPath,
 	}, nil
+}
+
+func plainWorkflowPath(workflowPath string) (string, error) {
+	workflowPath = strings.TrimSpace(workflowPath)
+	if workflowPath == "" {
+		return "", errors.New("workflow path must not be blank")
+	}
+	if filepath.IsAbs(workflowPath) {
+		return filepath.Clean(workflowPath), nil
+	}
+
+	if workflowPath == "~" || strings.HasPrefix(workflowPath, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home workflow path: %w", err)
+		}
+		if workflowPath == "~" {
+			return filepath.Clean(home), nil
+		}
+		return filepath.Join(home, strings.TrimPrefix(workflowPath, "~/")), nil
+	}
+
+	return "", errRelativeWorkflowPath
 }
 
 func workflowRefPath(sourceRoot string, workflowPath string) (string, error) {

--- a/internal/project/workflow_source_test.go
+++ b/internal/project/workflow_source_test.go
@@ -33,6 +33,29 @@ func TestLoadWorkflowUsesWorkingTreeWhenWorkflowRefUnset(t *testing.T) {
 	}
 }
 
+func TestLoadWorkflowRejectsRelativeWorkflowWhenWorkflowRefUnset(t *testing.T) {
+	root := t.TempDir()
+	daemonDir := filepath.Join(root, "daemon")
+	projectDir := filepath.Join(root, "project")
+	if err := os.MkdirAll(daemonDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	if err := os.MkdirAll(projectDir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	writeWorkflowSourceFile(t, filepath.Join(daemonDir, "WORKFLOW.md"), "daemon")
+	writeWorkflowSourceFile(t, filepath.Join(projectDir, "WORKFLOW.md"), "project")
+	t.Chdir(daemonDir)
+
+	_, err := LoadWorkflow(globalconfig.Project{
+		Workflow: "WORKFLOW.md",
+		Workdir:  projectDir,
+	})
+	if !errors.Is(err, errRelativeWorkflowPath) {
+		t.Fatalf("LoadWorkflow() error = %v, want %v", err, errRelativeWorkflowPath)
+	}
+}
+
 func TestLoadWorkflowUsesConfiguredGitRef(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Reject plain file-backed project workflow paths that are relative to the daemon CWD while preserving repo-relative paths for workflow_ref.
- Add regressions for global config loading, add-project, and project workflow loading.
- Update add-project examples and the demo capture to use home-relative workflow paths.

Fixes #769

## Test Plan

- [x] `go test ./internal/config/global`
- [x] `go test ./internal/project`
- [x] `go test ./internal/cli`
- [x] `go test ./cmd/detent`
- [x] `make check`