### PR TITLE
fix(web): surface GraphQL rate exhaustion

### DIFF
--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -61,6 +61,7 @@ type Client struct {
 	rateLimit              connector.GraphQLRateLimit
 	queryCosts             map[string]connector.GraphQLQueryCost
 	hasRateLimit           bool
+	hasRateLimitUsage      bool
 	graphQLRateLimitStatus string
 	restRateLimit          connector.RESTRateLimit
 	restRequests           map[string]connector.RESTEndpointUsage
@@ -506,6 +507,7 @@ func (c *Client) ResetGraphQLRateLimitUsage() {
 
 	c.queryCosts = nil
 	c.graphQLRateLimitStatus = ""
+	c.hasRateLimitUsage = false
 }
 
 func (c *Client) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage {
@@ -513,10 +515,12 @@ func (c *Client) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage {
 	defer c.mu.Unlock()
 
 	usage := connector.GraphQLRateLimitUsage{
-		RateLimit:       c.rateLimit,
-		HasRateLimit:    c.hasRateLimit,
 		RateLimitStatus: c.graphQLRateLimitStatus,
 		QueryCosts:      sortedGraphQLQueryCosts(c.queryCosts),
+	}
+	if c.hasRateLimitUsage {
+		usage.RateLimit = c.rateLimit
+		usage.HasRateLimit = true
 	}
 	for _, cost := range usage.QueryCosts {
 		usage.TotalQueries += cost.Count
@@ -524,6 +528,7 @@ func (c *Client) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage {
 	}
 	c.queryCosts = nil
 	c.graphQLRateLimitStatus = ""
+	c.hasRateLimitUsage = false
 	return usage
 }
 
@@ -866,6 +871,7 @@ func (c *Client) recordRateLimitFromHeaders(headers http.Header, now time.Time) 
 		snapshot.UpdatedAt = now
 		c.rateLimit = snapshot
 		c.hasRateLimit = true
+		c.hasRateLimitUsage = true
 	}
 	return graphQLHeaderRateLimit{
 		Previous:           previous,
@@ -930,6 +936,7 @@ func (c *Client) setRateLimit(snapshot connector.GraphQLRateLimit) {
 
 	c.rateLimit = snapshot
 	c.hasRateLimit = true
+	c.hasRateLimitUsage = true
 }
 
 func (c *Client) addGraphQLQueryCost(queryType string, cost int64) {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -51,24 +51,25 @@ type RESTBudgetPolicy struct {
 }
 
 type Client struct {
-	endpoint         string
-	restEndpoint     string
-	tokenSource      TokenSource
-	httpClient       HTTPClient
-	restPolicy       RESTBudgetPolicy
-	logger           *slog.Logger
-	mu               sync.RWMutex
-	rateLimit        connector.GraphQLRateLimit
-	queryCosts       map[string]connector.GraphQLQueryCost
-	hasRateLimit     bool
-	restRateLimit    connector.RESTRateLimit
-	restRequests     map[string]connector.RESTEndpointUsage
-	restBackoffUntil time.Time
-	restBackoffKey   string
-	restBackoffs     *restBackoffRegistry
-	hasRestRateLimit bool
-	authHealth       connector.AuthHealth
-	hasAuthHealth    bool
+	endpoint               string
+	restEndpoint           string
+	tokenSource            TokenSource
+	httpClient             HTTPClient
+	restPolicy             RESTBudgetPolicy
+	logger                 *slog.Logger
+	mu                     sync.RWMutex
+	rateLimit              connector.GraphQLRateLimit
+	queryCosts             map[string]connector.GraphQLQueryCost
+	hasRateLimit           bool
+	graphQLRateLimitStatus string
+	restRateLimit          connector.RESTRateLimit
+	restRequests           map[string]connector.RESTEndpointUsage
+	restBackoffUntil       time.Time
+	restBackoffKey         string
+	restBackoffs           *restBackoffRegistry
+	hasRestRateLimit       bool
+	authHealth             connector.AuthHealth
+	hasAuthHealth          bool
 }
 
 type restProbeResult struct {
@@ -195,6 +196,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
 			return c.graphQLWithType(ctx, queryType, query, variables, out, false)
 		}
+		c.recordGraphQLRateLimitFailure(err, headerRateLimit)
 		return err
 	}
 
@@ -213,6 +215,7 @@ func (c *Client) graphQLWithType(ctx context.Context, queryType string, query st
 		if c.refreshAfterAuthFailure(ctx, err, allowTokenRefresh) {
 			return c.graphQLWithType(ctx, queryType, query, variables, out, false)
 		}
+		c.recordGraphQLRateLimitFailure(err, headerRateLimit)
 		return err
 	}
 	if out == nil {
@@ -502,6 +505,7 @@ func (c *Client) ResetGraphQLRateLimitUsage() {
 	defer c.mu.Unlock()
 
 	c.queryCosts = nil
+	c.graphQLRateLimitStatus = ""
 }
 
 func (c *Client) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage {
@@ -509,15 +513,17 @@ func (c *Client) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage {
 	defer c.mu.Unlock()
 
 	usage := connector.GraphQLRateLimitUsage{
-		RateLimit:    c.rateLimit,
-		HasRateLimit: c.hasRateLimit,
-		QueryCosts:   sortedGraphQLQueryCosts(c.queryCosts),
+		RateLimit:       c.rateLimit,
+		HasRateLimit:    c.hasRateLimit,
+		RateLimitStatus: c.graphQLRateLimitStatus,
+		QueryCosts:      sortedGraphQLQueryCosts(c.queryCosts),
 	}
 	for _, cost := range usage.QueryCosts {
 		usage.TotalQueries += cost.Count
 		usage.TotalCost += cost.Cost
 	}
 	c.queryCosts = nil
+	c.graphQLRateLimitStatus = ""
 	return usage
 }
 
@@ -964,6 +970,44 @@ func (c *Client) recordGraphQLQueryCostFromHeaders(queryType string, snapshot gr
 		cost = 0
 	}
 	c.addGraphQLQueryCost(queryType, cost)
+}
+
+func (c *Client) recordGraphQLRateLimitFailure(err error, snapshot graphQLHeaderRateLimit) {
+	status := graphQLRateLimitFailureStatus(err, snapshot)
+	if status == "" {
+		return
+	}
+
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.graphQLRateLimitStatus == connector.GraphQLRateLimitStatusExhausted {
+		return
+	}
+	c.graphQLRateLimitStatus = status
+}
+
+func graphQLRateLimitFailureStatus(err error, snapshot graphQLHeaderRateLimit) string {
+	if !errors.Is(err, ErrRateLimited) {
+		return ""
+	}
+
+	var statusErr *StatusError
+	if errors.As(err, &statusErr) {
+		switch statusErr.RateLimitKind {
+		case restRateLimitKindPrimaryExhausted:
+			return connector.GraphQLRateLimitStatusExhausted
+		case restRateLimitKindSecondaryThrottled:
+			return connector.GraphQLRateLimitStatusBackoff
+		}
+	}
+	if snapshot.HasPrimarySnapshot && snapshot.Current.Remaining <= 0 {
+		return connector.GraphQLRateLimitStatusExhausted
+	}
+	if snapshot.Current.RetryAfter > 0 {
+		return connector.GraphQLRateLimitStatusBackoff
+	}
+	return connector.GraphQLRateLimitStatusExhausted
 }
 
 func validateEndpoint(endpoint string) error {

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -855,6 +855,53 @@ func TestClientGraphQLRecordsRateLimitStatusWithoutSnapshot(t *testing.T) {
 	}
 }
 
+func TestClientGraphQLRateLimitFailureDoesNotPublishStaleSnapshot(t *testing.T) {
+	t.Parallel()
+
+	resetAt := time.Date(2026, 6, 1, 13, 0, 0, 0, time.UTC)
+	responses := make(chan string, 2)
+	responses <- `{"data":{"rateLimit":{"limit":5000,"used":120,"remaining":4880,"cost":2,"resetAt":"` + resetAt.Format(time.RFC3339) + `"}}}`
+	responses <- `{"errors":[{"type":"RATE_LIMITED","message":"API rate limit exceeded"}]}`
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(<-responses))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	if err := client.GraphQLWithType(context.Background(), "candidate_issues", "query { rateLimit { cost } }", nil, nil); err != nil {
+		t.Fatalf("GraphQLWithType() healthy query error = %v", err)
+	}
+	usage := client.FlushGraphQLRateLimitUsage()
+	if !usage.HasRateLimit || usage.RateLimit.Remaining != 4880 {
+		t.Fatalf("FlushGraphQLRateLimitUsage() = %#v, want healthy current bucket", usage)
+	}
+
+	err = client.GraphQLWithType(context.Background(), "issue_parent_metadata", "query { viewer { login } }", nil, nil)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("GraphQLWithType() error = %v, want ErrRateLimited", err)
+	}
+	usage = client.FlushGraphQLRateLimitUsage()
+	if usage.HasRateLimit {
+		t.Fatalf("FlushGraphQLRateLimitUsage().HasRateLimit = true, want false after failure with no fresh bucket: %#v", usage)
+	}
+	if usage.RateLimit != (connector.GraphQLRateLimit{}) {
+		t.Fatalf("FlushGraphQLRateLimitUsage().RateLimit = %#v, want zero stale bucket", usage.RateLimit)
+	}
+	if usage.RateLimitStatus != connector.GraphQLRateLimitStatusExhausted {
+		t.Fatalf("FlushGraphQLRateLimitUsage().RateLimitStatus = %q, want %q", usage.RateLimitStatus, connector.GraphQLRateLimitStatusExhausted)
+	}
+}
+
 func TestClientGraphQLInfersMutationCostsFromHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -817,6 +817,44 @@ func TestClientGraphQLAggregatesRateLimitCostsByQueryType(t *testing.T) {
 	}
 }
 
+func TestClientGraphQLRecordsRateLimitStatusWithoutSnapshot(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"errors":[{"type":"RATE_LIMITED","message":"API rate limit exceeded"}]}`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	err = client.GraphQLWithType(context.Background(), "issue_parent_metadata", "query { viewer { login } }", nil, nil)
+	if !errors.Is(err, ErrRateLimited) {
+		t.Fatalf("GraphQLWithType() error = %v, want ErrRateLimited", err)
+	}
+
+	usage := client.FlushGraphQLRateLimitUsage()
+	if usage.HasRateLimit {
+		t.Fatalf("FlushGraphQLRateLimitUsage().HasRateLimit = true, want false with no snapshot")
+	}
+	if usage.RateLimitStatus != connector.GraphQLRateLimitStatusExhausted {
+		t.Fatalf("FlushGraphQLRateLimitUsage().RateLimitStatus = %q, want %q", usage.RateLimitStatus, connector.GraphQLRateLimitStatusExhausted)
+	}
+
+	usage = client.FlushGraphQLRateLimitUsage()
+	if usage.RateLimitStatus != "" {
+		t.Fatalf("second FlushGraphQLRateLimitUsage().RateLimitStatus = %q, want cleared", usage.RateLimitStatus)
+	}
+}
+
 func TestClientGraphQLInfersMutationCostsFromHeaders(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/ratelimit.go
+++ b/internal/connector/ratelimit.go
@@ -2,6 +2,11 @@ package connector
 
 import "time"
 
+const (
+	GraphQLRateLimitStatusBackoff   = "backoff"
+	GraphQLRateLimitStatusExhausted = "exhausted"
+)
+
 type GraphQLRateLimit struct {
 	Limit      int64
 	Used       int64
@@ -19,11 +24,12 @@ type GraphQLQueryCost struct {
 }
 
 type GraphQLRateLimitUsage struct {
-	RateLimit    GraphQLRateLimit
-	HasRateLimit bool
-	QueryCosts   []GraphQLQueryCost
-	TotalQueries int64
-	TotalCost    int64
+	RateLimit       GraphQLRateLimit
+	HasRateLimit    bool
+	RateLimitStatus string
+	QueryCosts      []GraphQLQueryCost
+	TotalQueries    int64
+	TotalCost       int64
 }
 
 type RateLimitReporter interface {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -869,23 +869,27 @@ func (o *Orchestrator) captureConnectorRateLimits(state *State, now time.Time) g
 
 	var rateLimit connector.GraphQLRateLimit
 	hasRateLimit := usage.HasRateLimit
+	status := graphQLRateLimitTelemetryStatus(usage.RateLimitStatus)
 	if hasRateLimit {
 		rateLimit = usage.RateLimit
 	} else {
 		reporter, ok := o.connector.(connector.RateLimitReporter)
 		if !ok {
-			return graphQLRateLimitCycle{}
+			if status == "" {
+				return graphQLRateLimitCycle{}
+			}
+		} else {
+			var okRateLimit bool
+			rateLimit, okRateLimit = reporter.GraphQLRateLimit()
+			if !okRateLimit && status == "" {
+				return graphQLRateLimitCycle{}
+			}
+			hasRateLimit = okRateLimit
 		}
-		var okRateLimit bool
-		rateLimit, okRateLimit = reporter.GraphQLRateLimit()
-		if !okRateLimit {
-			return graphQLRateLimitCycle{}
-		}
-		hasRateLimit = true
 	}
 
 	cost := graphQLCostSummary(usage)
-	bucket := gitHubGraphQLBucket(rateLimit, now)
+	bucket := gitHubGraphQLBucket(rateLimit, now, status)
 	if cost != nil {
 		bucket.Cost = cost.TotalCost
 	}
@@ -1082,7 +1086,18 @@ func (o *Orchestrator) logGraphQLRateLimitCycle(cycle graphQLRateLimitCycle) {
 	}
 }
 
-func gitHubGraphQLBucket(rateLimit connector.GraphQLRateLimit, now time.Time) *telemetry.RateLimitBucket {
+func graphQLRateLimitTelemetryStatus(status string) string {
+	switch strings.TrimSpace(status) {
+	case connector.GraphQLRateLimitStatusExhausted:
+		return telemetry.RateLimitStatusExhausted
+	case connector.GraphQLRateLimitStatusBackoff:
+		return telemetry.RateLimitStatusBackoff
+	default:
+		return ""
+	}
+}
+
+func gitHubGraphQLBucket(rateLimit connector.GraphQLRateLimit, now time.Time, status string) *telemetry.RateLimitBucket {
 	var resetAt *time.Time
 	var resetInSeconds int64
 	if !rateLimit.ResetAt.IsZero() {
@@ -1098,15 +1113,29 @@ func gitHubGraphQLBucket(rateLimit connector.GraphQLRateLimit, now time.Time) *t
 		resetAt = &value
 		resetInSeconds = int64(rateLimit.RetryAfter.Round(time.Second) / time.Second)
 	}
+	if status == "" {
+		status = graphQLRateLimitStatusFromSnapshot(rateLimit)
+	}
 
 	return &telemetry.RateLimitBucket{
 		Remaining:      rateLimit.Remaining,
 		Used:           rateLimit.Used,
 		Limit:          rateLimit.Limit,
 		Cost:           rateLimit.Cost,
+		Status:         status,
 		ResetAt:        resetAt,
 		ResetInSeconds: resetInSeconds,
 	}
+}
+
+func graphQLRateLimitStatusFromSnapshot(rateLimit connector.GraphQLRateLimit) string {
+	if rateLimit.Limit > 0 && rateLimit.Remaining <= 0 {
+		return telemetry.RateLimitStatusExhausted
+	}
+	if rateLimit.RetryAfter > 0 {
+		return telemetry.RateLimitStatusBackoff
+	}
+	return ""
 }
 
 func (o *Orchestrator) adaptivePollInterval(state *State, now time.Time) time.Duration {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -872,16 +872,14 @@ func (o *Orchestrator) captureConnectorRateLimits(state *State, now time.Time) g
 	status := graphQLRateLimitTelemetryStatus(usage.RateLimitStatus)
 	if hasRateLimit {
 		rateLimit = usage.RateLimit
-	} else {
+	} else if status == "" {
 		reporter, ok := o.connector.(connector.RateLimitReporter)
 		if !ok {
-			if status == "" {
-				return graphQLRateLimitCycle{}
-			}
+			return graphQLRateLimitCycle{}
 		} else {
 			var okRateLimit bool
 			rateLimit, okRateLimit = reporter.GraphQLRateLimit()
-			if !okRateLimit && status == "" {
+			if !okRateLimit {
 				return graphQLRateLimitCycle{}
 			}
 			hasRateLimit = okRateLimit

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -205,6 +205,37 @@ func TestTickPublishesAndLogsGitHubGraphQLCostSummary(t *testing.T) {
 	}
 }
 
+func TestTickPublishesGitHubGraphQLExhaustionWithoutRateLimitSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        30 * time.Second,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &rateLimitConnector{
+		usage: connector.GraphQLRateLimitUsage{
+			RateLimitStatus: connector.GraphQLRateLimitStatusExhausted,
+		},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if state.RateLimits == nil || state.RateLimits.GitHubGraphQL == nil {
+		t.Fatalf("RateLimits = %#v, want GitHub GraphQL status bucket", state.RateLimits)
+	}
+	if state.RateLimits.GitHubGraphQL.Status != telemetry.RateLimitStatusExhausted {
+		t.Fatalf("GitHubGraphQL.Status = %q, want %q", state.RateLimits.GitHubGraphQL.Status, telemetry.RateLimitStatusExhausted)
+	}
+	if state.RateLimits.GitHubGraphQL.Limit != 0 || state.RateLimits.GitHubGraphQL.Remaining != 0 {
+		t.Fatalf("GitHubGraphQL = %#v, want status-only exhausted bucket", state.RateLimits.GitHubGraphQL)
+	}
+}
+
 func TestTickCarriesGitHubGraphQLCostRecordedBetweenRefreshes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -236,6 +236,46 @@ func TestTickPublishesGitHubGraphQLExhaustionWithoutRateLimitSnapshot(t *testing
 	}
 }
 
+func TestTickPublishesGitHubGraphQLFailureStatusWithoutStaleRateLimitSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	resetAt := now.Add(time.Hour)
+	cfg := normalizeConfig(Config{
+		PollInterval:        30 * time.Second,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &rateLimitConnector{
+		hasRateLimit: true,
+		rateLimit: connector.GraphQLRateLimit{
+			Limit:     5000,
+			Used:      120,
+			Remaining: 4880,
+			ResetAt:   resetAt,
+			UpdatedAt: now.Add(-time.Minute),
+		},
+		usage: connector.GraphQLRateLimitUsage{
+			RateLimitStatus: connector.GraphQLRateLimitStatusExhausted,
+		},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if state.RateLimits == nil || state.RateLimits.GitHubGraphQL == nil {
+		t.Fatalf("RateLimits = %#v, want GitHub GraphQL status bucket", state.RateLimits)
+	}
+	if state.RateLimits.GitHubGraphQL.Status != telemetry.RateLimitStatusExhausted {
+		t.Fatalf("GitHubGraphQL.Status = %q, want %q", state.RateLimits.GitHubGraphQL.Status, telemetry.RateLimitStatusExhausted)
+	}
+	if state.RateLimits.GitHubGraphQL.Limit != 0 || state.RateLimits.GitHubGraphQL.Remaining != 0 || state.RateLimits.GitHubGraphQL.Used != 0 {
+		t.Fatalf("GitHubGraphQL = %#v, want status-only bucket without stale quota", state.RateLimits.GitHubGraphQL)
+	}
+}
+
 func TestTickCarriesGitHubGraphQLCostRecordedBetweenRefreshes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -428,11 +428,17 @@ type RateLimits struct {
 	RESTUsage     *RESTUsage       `json:"rest_usage,omitempty"`
 }
 
+const (
+	RateLimitStatusBackoff   = "backoff"
+	RateLimitStatusExhausted = "exhausted"
+)
+
 type RateLimitBucket struct {
 	Remaining      int64      `json:"remaining,omitempty"`
 	Used           int64      `json:"used,omitempty"`
 	Limit          int64      `json:"limit,omitempty"`
 	Cost           int64      `json:"cost,omitempty"`
+	Status         string     `json:"status,omitempty"`
 	ResetAt        *time.Time `json:"reset_at,omitempty"`
 	ResetInSeconds int64      `json:"reset_in_seconds,omitempty"`
 	HasCredits     bool       `json:"has_credits,omitempty"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -3763,6 +3763,34 @@ func TestProjectStateAPIScopesSnapshot(t *testing.T) {
 	}
 }
 
+func TestStateAPIIncludesGitHubGraphQLRateLimitStatus(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 29, 15, 0, 0, 0, time.UTC),
+		RateLimits: &telemetry.RateLimits{
+			GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4608, Used: 392, Limit: 5000},
+			GitHubGraphQL: &telemetry.RateLimitBucket{Status: telemetry.RateLimitStatusExhausted},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	state := requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusOK)
+	if got := nestedString(t, state, "rate_limits", "github_rest", "remaining"); got != "4608" {
+		t.Fatalf("rate_limits.github_rest.remaining = %s, want 4608", got)
+	}
+	if got := nestedString(t, state, "rate_limits", "github_graphql", "status"); got != telemetry.RateLimitStatusExhausted {
+		t.Fatalf("rate_limits.github_graphql.status = %s, want %s", got, telemetry.RateLimitStatusExhausted)
+	}
+}
+
 func TestProjectStateAPIRendersConfiguredProjectWithoutTelemetryRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -5804,9 +5804,9 @@ func rateLimitRows(limits *telemetry.RateLimits) []rateLimitRow {
 		}
 		rows = append(rows, rateLimitRow{
 			Name:        name,
-			Remaining:   formatInt(bucket.Remaining) + " left",
+			Remaining:   rateLimitRemainingLabel(bucket),
 			Used:        rateLimitUsedLabel(bucket),
-			Limit:       formatLimit(bucket.Limit) + " limit",
+			Limit:       rateLimitLimitLabel(bucket),
 			Reset:       resetLabel(bucket),
 			UsedPercent: usedPercent(bucket),
 		})
@@ -5822,12 +5822,29 @@ func rateLimitRows(limits *telemetry.RateLimits) []rateLimitRow {
 	return rows
 }
 
+func rateLimitRemainingLabel(bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return "exhausted"
+	}
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusBackoff && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return "backoff"
+	}
+	return formatInt(bucket.Remaining) + " left"
+}
+
 func rateLimitUsedLabel(bucket *telemetry.RateLimitBucket) string {
 	label := formatInt(bucket.Used) + " used"
 	if bucket.Cost > 0 {
 		label += " / cost " + formatInt(bucket.Cost)
 	}
 	return label
+}
+
+func rateLimitLimitLabel(bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 {
+		return "limit unknown"
+	}
+	return formatLimit(bucket.Limit) + " limit"
 }
 
 func creditRateLimitRow(bucket *telemetry.RateLimitBucket) rateLimitRow {
@@ -5892,6 +5909,12 @@ func graphQLBudgetRemaining(limits *telemetry.RateLimits) string {
 		return "n/a"
 	}
 	bucket := limits.GitHubGraphQL
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return "exhausted"
+	}
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusBackoff && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return "backoff"
+	}
 	if bucket.Limit > 0 {
 		return formatInt(bucket.Remaining) + " / " + formatInt(bucket.Limit)
 	}
@@ -6069,6 +6092,13 @@ func gitHubAPIHealth(snapshot telemetry.Snapshot) gitHubAPIHealthView {
 		view.Detail = "Primary REST or GraphQL quota exhausted; " + gitHubAPIExhaustedReset(snapshot.RateLimits) + "."
 		return view
 	}
+	if gitHubAPIGraphQLBackoff(snapshot) {
+		view.State = gitHubAPIHealthStateBackoff
+		view.Label = "GitHub GraphQL backoff active"
+		view.Summary = primarySummary
+		view.Detail = "GitHub GraphQL requests are in backoff; " + gitHubAPIGraphQLBackoffReset(snapshot.RateLimits) + "."
+		return view
+	}
 	if gitHubAPIInBackoff(snapshot) {
 		families := gitHubAPIBackoffFamilyLabel(snapshot, snapshot.RateLimits.RESTUsage)
 		primaryContext := gitHubAPIRESTPrimaryContext(snapshot.RateLimits)
@@ -6084,6 +6114,14 @@ func gitHubAPIHealth(snapshot telemetry.Snapshot) gitHubAPIHealthView {
 		view.Label = "GitHub primary quota low"
 		view.Summary = primarySummary
 		view.Detail = "Primary quota is below the warning threshold; " + gitHubAPIWarningReset(snapshot.RateLimits) + "."
+		return view
+	}
+	if gitHubAPIGraphQLPrimaryUnknown(snapshot.RateLimits) {
+		restContext := gitHubAPIRESTPrimaryContext(snapshot.RateLimits)
+		view.State = gitHubAPIHealthStateUnknown
+		view.Label = "GitHub API GraphQL unknown"
+		view.Summary = restContext + ". GraphQL primary quota unavailable."
+		view.Detail = "REST primary quota is visible, but GraphQL primary quota is unavailable; doctor may still fail when GraphQL is exhausted."
 		return view
 	}
 
@@ -6120,7 +6158,8 @@ func gitHubAPIHasSnapshot(limits *telemetry.RateLimits) bool {
 
 func gitHubAPIBucketKnown(bucket *telemetry.RateLimitBucket) bool {
 	return bucket != nil &&
-		(bucket.Limit > 0 ||
+		(rateLimitBucketStatus(bucket) != "" ||
+			bucket.Limit > 0 ||
 			bucket.Remaining > 0 ||
 			bucket.Used > 0 ||
 			bucket.ResetAt != nil ||
@@ -6132,11 +6171,21 @@ func gitHubAPIPrimaryExhausted(limits *telemetry.RateLimits) bool {
 		return false
 	}
 	for _, bucket := range []*telemetry.RateLimitBucket{limits.GitHubREST, limits.GitHubGraphQL} {
-		if bucket != nil && bucket.Limit > 0 && bucket.Remaining <= 0 {
+		if gitHubAPIBucketExhausted(bucket) {
 			return true
 		}
 	}
 	return false
+}
+
+func gitHubAPIBucketExhausted(bucket *telemetry.RateLimitBucket) bool {
+	if bucket == nil {
+		return false
+	}
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted {
+		return true
+	}
+	return bucket.Limit > 0 && bucket.Remaining <= 0
 }
 
 func gitHubAPIPrimaryWarning(limits *telemetry.RateLimits) bool {
@@ -6152,7 +6201,7 @@ func gitHubAPIPrimaryWarning(limits *telemetry.RateLimits) bool {
 }
 
 func gitHubAPIBucketWarning(bucket *telemetry.RateLimitBucket) bool {
-	if bucket == nil || bucket.Limit <= 0 || bucket.Remaining <= 0 {
+	if bucket == nil || gitHubAPIBucketExhausted(bucket) || bucket.Limit <= 0 || bucket.Remaining <= 0 {
 		return false
 	}
 	if bucket.Remaining <= gitHubAPIWarningRemaining {
@@ -6180,6 +6229,20 @@ func gitHubAPIInBackoff(snapshot telemetry.Snapshot) bool {
 	return false
 }
 
+func gitHubAPIGraphQLBackoff(snapshot telemetry.Snapshot) bool {
+	if snapshot.RateLimits == nil {
+		return false
+	}
+	bucket := snapshot.RateLimits.GitHubGraphQL
+	if bucket == nil || rateLimitBucketStatus(bucket) != telemetry.RateLimitStatusBackoff {
+		return false
+	}
+	if bucket.ResetAt == nil {
+		return true
+	}
+	return gitHubAPIDeadlineActive(snapshot.GeneratedAt, bucket.ResetAt)
+}
+
 func gitHubAPIContributorBackedOff(snapshot telemetry.Snapshot, contributor telemetry.RESTUsageContributor, backoffUntil *time.Time) bool {
 	if !gitHubAPIContributorHasBackoffSignal(contributor) {
 		return false
@@ -6201,6 +6264,10 @@ func gitHubAPIDeadlineActive(generatedAt time.Time, deadline *time.Time) bool {
 	return deadline != nil && (generatedAt.IsZero() || deadline.After(generatedAt))
 }
 
+func gitHubAPIGraphQLPrimaryUnknown(limits *telemetry.RateLimits) bool {
+	return limits != nil && gitHubAPIBucketKnown(limits.GitHubREST) && !gitHubAPIBucketKnown(limits.GitHubGraphQL)
+}
+
 func gitHubAPIPrimarySummary(limits *telemetry.RateLimits) string {
 	if limits == nil {
 		return ""
@@ -6218,6 +6285,12 @@ func gitHubAPIPrimarySummary(limits *telemetry.RateLimits) string {
 }
 
 func gitHubAPIPrimaryBucketSummary(label string, bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return label + ": exhausted"
+	}
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusBackoff && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return label + ": backoff"
+	}
 	remaining := formatInt(bucket.Remaining) + " remaining"
 	if bucket.Limit > 0 {
 		return label + ": " + remaining + " / " + formatInt(bucket.Limit) + " total (" + formatInt(gitHubAPIPrimaryBucketUsed(bucket)) + " used)"
@@ -6297,7 +6370,7 @@ func gitHubAPIRESTPrimaryContext(limits *telemetry.RateLimits) string {
 	}
 	bucket := limits.GitHubREST
 	status := "healthy"
-	if bucket.Limit > 0 && bucket.Remaining <= 0 {
+	if gitHubAPIBucketExhausted(bucket) {
 		status = "exhausted"
 	} else if gitHubAPIBucketWarning(bucket) {
 		status = "low"
@@ -6316,11 +6389,35 @@ func gitHubAPIExhaustedReset(limits *telemetry.RateLimits) string {
 	if limits == nil {
 		return "reset time n/a"
 	}
-	reset := gitHubAPIEarliestReset(limits.GitHubREST, limits.GitHubGraphQL)
+	reset := gitHubAPIEarliestExhaustedReset(limits.GitHubREST, limits.GitHubGraphQL)
 	if reset != nil {
 		return "reset " + reset.UTC().Format("15:04 UTC")
 	}
 	return "reset time n/a"
+}
+
+func gitHubAPIEarliestExhaustedReset(buckets ...*telemetry.RateLimitBucket) *time.Time {
+	exhausted := make([]*telemetry.RateLimitBucket, 0, len(buckets))
+	for _, bucket := range buckets {
+		if gitHubAPIBucketExhausted(bucket) {
+			exhausted = append(exhausted, bucket)
+		}
+	}
+	return gitHubAPIEarliestReset(exhausted...)
+}
+
+func gitHubAPIGraphQLBackoffReset(limits *telemetry.RateLimits) string {
+	if limits == nil || limits.GitHubGraphQL == nil {
+		return "retry time n/a"
+	}
+	bucket := limits.GitHubGraphQL
+	if bucket.ResetAt != nil {
+		return "retry " + bucket.ResetAt.UTC().Format("15:04 UTC")
+	}
+	if bucket.ResetInSeconds > 0 {
+		return "retry in " + formatDuration(float64(bucket.ResetInSeconds))
+	}
+	return "retry time n/a"
 }
 
 func gitHubAPIWarningReset(limits *telemetry.RateLimits) string {
@@ -6371,10 +6468,23 @@ func gitHubAPIHealthBucketRows(limits *telemetry.RateLimits) []gitHubAPIHealthBu
 }
 
 func gitHubAPIHealthBucketRemaining(bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return "exhausted"
+	}
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusBackoff && bucket.Limit <= 0 && bucket.Remaining == 0 {
+		return "backoff"
+	}
 	if bucket.Limit > 0 {
 		return formatInt(bucket.Remaining) + " / " + formatInt(bucket.Limit) + " remaining"
 	}
 	return formatInt(bucket.Remaining) + " remaining"
+}
+
+func rateLimitBucketStatus(bucket *telemetry.RateLimitBucket) string {
+	if bucket == nil {
+		return ""
+	}
+	return strings.TrimSpace(bucket.Status)
 }
 
 func gitHubAPIHealthBucketReset(bucket *telemetry.RateLimitBucket) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -195,6 +195,50 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 			wantSummaryPart: "REST primary: 4,878 remaining / 5,000 total (122 used)",
 		},
 		{
+			name: "rest primary without graphql remains unknown",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST: &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+				},
+			},
+			wantState:       gitHubAPIHealthStateUnknown,
+			wantLabel:       "GitHub API GraphQL unknown",
+			wantSummaryPart: "GraphQL primary quota unavailable",
+			wantDetailParts: []string{
+				"REST primary quota is visible",
+				"GraphQL primary quota is unavailable",
+			},
+		},
+		{
+			name: "graphql exhausted status without numeric snapshot",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+					GitHubGraphQL: &telemetry.RateLimitBucket{Status: telemetry.RateLimitStatusExhausted},
+				},
+			},
+			wantState:       gitHubAPIHealthStateExhausted,
+			wantLabel:       "GitHub primary quota exhausted",
+			wantSummaryPart: "GraphQL primary: exhausted",
+			wantDetailParts: []string{"reset time n/a"},
+		},
+		{
+			name: "graphql backoff status without numeric snapshot",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+					GitHubGraphQL: &telemetry.RateLimitBucket{Status: telemetry.RateLimitStatusBackoff},
+				},
+			},
+			wantState:       gitHubAPIHealthStateBackoff,
+			wantLabel:       "GitHub GraphQL backoff active",
+			wantSummaryPart: "GraphQL primary: backoff",
+			wantDetailParts: []string{"GitHub GraphQL requests are in backoff", "retry time n/a"},
+		},
+		{
 			name: "warning for low primary remaining",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -509,6 +509,18 @@ func TestDashboardRendersGitHubAPIHealthPreservationMetadataForStates(t *testing
 			wantState: "exhausted",
 			wantLabel: "GitHub primary quota exhausted",
 		},
+		{
+			name: "graphql exhausted status",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+					GitHubGraphQL: &telemetry.RateLimitBucket{Status: telemetry.RateLimitStatusExhausted},
+				},
+			},
+			wantState: "exhausted",
+			wantLabel: "GitHub primary quota exhausted",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/web/templates/help.go
+++ b/internal/web/templates/help.go
@@ -86,7 +86,7 @@ var helpDefinitions = map[helpTerm]helpEntry{
 	helpPRPipeline:          {Label: "PR pipeline", Description: "Pull requests currently waiting for human review, merging, or marked done by the tracker today. Watch this lane to see whether the merge train is moving."},
 	helpProjectedSpend:      {Label: "Projected spend", Description: "Estimated additional USD for active work if it continues at the current pace. Use it before letting a busy queue keep running."},
 	helpQueue:               {Label: "Queue", Description: "Issues waiting to start or retry. A growing queue means demand is higher than the available agent capacity or retry cooldowns."},
-	helpRateLimits:          {Label: "Rate limits", Description: "Primary buckets show provider quota remaining and used before hourly reset. GitHub secondary REST backoff can still pause individual endpoint families even when REST and GraphQL primary quota remains."},
+	helpRateLimits:          {Label: "Rate limits", Description: "Primary buckets show provider quota remaining and used before hourly reset. GitHub REST and GraphQL primary buckets are separate, and secondary REST backoff can still pause individual endpoint families."},
 	helpRecentSessions:      {Label: "Recent sessions", Description: "The last completed Codex sessions Detent retained. Use it to audit what just happened without digging through logs."},
 	helpReportsEvents:       {Label: "Usage events", Description: "Completed ledger rows in the selected report window. Low counts can make spend and token trends look sparse or misleading."},
 	helpReportsModels:       {Label: "Models", Description: "How many model buckets appear in the report window. More buckets can explain mixed pricing or unexpected spend."},


### PR DESCRIPTION
## Summary

- Record GraphQL rate-limit failure status even when GitHub does not return a usable rateLimit bucket.
- Surface GraphQL exhausted, backoff, and unknown states in API/dashboard health so REST-only quota no longer appears fully healthy.

Fixes #773

## Test Plan

- [x] `go test ./internal/connector/github ./internal/orchestrator ./internal/web/templates ./internal/web -count=1`
- [x] `make check`