### PR TITLE
feat(core): support artifact workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -1261,7 +1261,9 @@ repo is a real, working instance of this setup to copy from.
    The maintained templates are
    [`WORKFLOW.project_v2.md`](docs/templates/WORKFLOW.project_v2.md),
    [`WORKFLOW.issue_field.md`](docs/templates/WORKFLOW.issue_field.md), and
-   [`WORKFLOW.label.md`](docs/templates/WORKFLOW.label.md).
+   [`WORKFLOW.label.md`](docs/templates/WORKFLOW.label.md). Non-code artifact
+   workflows can start from
+   [`WORKFLOW.non_code_artifact.md`](docs/templates/WORKFLOW.non_code_artifact.md).
    They set `server.kanban.mode: integration` for trusted project boards;
    change that to `read_only` only for an observer or shared dashboard,
    explicit no-writes choice, or failed post-authorization write probes. They

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1779,10 +1779,12 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    human-authored contract without explicit approval. The maintained templates
    are `docs/templates/WORKFLOW.project_v2.md`,
    `docs/templates/WORKFLOW.issue_field.md`, and
-   `docs/templates/WORKFLOW.label.md`. The `/onboarding` web wizard can write
-   the same tracker blocks interactively: choose **Repository labels** for
-   `GITHUB_MODE=label`, enter the repository and status label prefix such as
-   `detent:`, and it will generate `tracker.github_status_source: label`
+   `docs/templates/WORKFLOW.label.md`. Non-code artifact projects can start
+   from `docs/templates/WORKFLOW.non_code_artifact.md`; the rest of this
+   onboarding flow remains GitHub-focused. The `/onboarding` web wizard can
+   write the same tracker blocks interactively: choose **Repository labels**
+   for `GITHUB_MODE=label`, enter the repository and status label prefix such
+   as `detent:`, and it will generate `tracker.github_status_source: label`
    without ProjectV2 fields. Verify:
 
    ```sh

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -2,9 +2,49 @@
 
 Detent's orchestration loop is mostly domain-neutral: it reads board state,
 dispatches work, tracks retries and budgets, and serializes the `Merging` lane.
-The execution edge still carries these code/git/PR assumptions.
+The execution edge now has explicit seams for code workflows and local
+artifact workflows. GitHub PR delivery remains the default.
 
 ## Now Pluggable
+
+### Work Item Source And Status Store
+
+- `tracker.kind: github` remains the default production source for code
+  workflows.
+- `tracker.kind: local_sqlite` stores domain-neutral work items in a
+  Detent-owned SQLite database configured by `tracker.local_sqlite.path`.
+- Local SQLite work items persist status, fields, metadata, deliverable
+  metadata, timestamps, comments, and state-change events across restarts.
+- Kanban integration-mode moves continue to call the connector state update
+  contract, so local SQLite projects write card moves into the local status
+  store instead of GitHub Projects, labels, or issue fields.
+- Relative local SQLite paths resolve against the project `workdir` at runtime
+  so a non-code project can keep `WORKFLOW.md`, inputs, outputs, and state under
+  one production directory.
+
+### Workspace
+
+- `workspace.kind: local_git` is still the default and creates git worktrees
+  and branches.
+- `workspace.kind: filesystem` creates an isolated task directory under
+  `workspace.root` with an `artifacts/` subdirectory and no git branch or PR
+  contract.
+- `workspace.output_root` or `deliverable.output_root` can point at a durable
+  artifact handoff directory. Detent creates a per-work-item output directory
+  there for external production systems to consume.
+- Filesystem workspace paths are project-workdir relative when configured as
+  relative paths.
+
+### Deliverable
+
+- `deliverable.kind: pull_request` is the default and keeps existing GitHub PR
+  behavior.
+- `deliverable.kind: artifact` suppresses prompt instructions that require a
+  PR closing reference and adds artifact workspace/output/review metadata to
+  the agent prompt.
+- `connector.Issue.Deliverable` and telemetry snapshots can carry artifact
+  kind, path, review URL, validation status, external id, and metadata without
+  requiring PR fields.
 
 ### Agent Backend
 
@@ -31,6 +71,11 @@ The execution edge still carries these code/git/PR assumptions.
   to the PR head.
 - `gate.kind: human_review` requires a PR plus `gate.approval_label`
   (`human-approved` by default) before promotion.
+- `gate.kind: artifact` evaluates a status value from
+  `issue.deliverable.validation_status` or a configured work-item field such as
+  `render_status`. Passing statuses advance the item, waiting statuses leave it
+  in place, and rework statuses route it to rework without requiring PR, CI, or
+  automated PR review state.
 - `internal/runner/prompt.go` renders gate variables and appends gate
   instructions so `Todo`, `Rework`, and `Merging` agents see the configured
   validation contract.
@@ -102,35 +147,25 @@ budget, confidence-check, and green no-op drift fails in local validation.
 
 ## Still Git/PR Coupled
 
-### Workspace
-
-- `internal/workspace` currently provides `local_git` only.
-- `LocalGit` creates git worktrees, derives `detent/<issue-key>` branches,
-  runs hooks, computes git diff stats, and removes worktrees.
-- `internal/runner` depends on that backend interface, but no non-git backend is
-  implemented yet.
-
-### Deliverable
-
 - `internal/connector/github` discovers pull requests by issue branch prefix and
   reads PR state, CI status, check-run timing, slow checks, running checks, and
   automated review state.
-- `connector.Issue` stores `PRNumber` and `PullRequest` directly.
 - The dashboard and telemetry models render a PR pipeline for `Human Review`,
-  `Merging`, and terminal states.
-- `internal/runner/prompt.go` appends a GitHub `Fixes #N` PR instruction when it
-  can parse a GitHub issue identifier.
+  `Merging`, and terminal states for pull-request workflows.
+- Merge workers, CI polling, PR hydration, and branch cleanup still apply only
+  to `deliverable.kind: pull_request` and `workspace.kind: local_git`.
 
 ## Follow-Up Surface
 
-Non-git or non-PR deliverables should start with a small deliverable backend
-interface that can report:
+The local SQLite source is Detent-owned. External production systems can consume
+`detent_work_items` and `detent_work_item_events`, or watch a configured output
+directory. A future backend can map Detent status changes into an
+operator-provided SQLite schema or application database when a stable schema
+contract is known.
 
-- workspace identity and artifact location,
-- review target URL or equivalent,
-- validation status,
-- final integration or publish result.
-
-The default implementation should remain git worktree to PR so code, docs,
-design assets, notebooks, and CSV models keep working as files-in-repo
-deliverables.
+`docs/templates/WORKFLOW.non_code_artifact.md` shows a video-production
+workflow that uses local SQLite status, filesystem workspaces, artifact
+deliverables, and artifact gates. That mode is broader than the GitHub local
+status mode described by #779: #779 keeps GitHub issues as the catalog while
+Detent owns status locally; the artifact template does not require GitHub
+issues, PRs, branches, CI, or merge trains at all.

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -1,0 +1,111 @@
+---
+tracker:
+  kind: local_sqlite
+  local_sqlite:
+    path: .detent/work-items.db
+    project_id: video-production
+  active_states:
+    - Todo
+    - Production
+    - Rework
+  observed_states:
+    - Backlog
+    - Review
+    - Blocked
+  terminal_states:
+    - Ready for Pickup
+    - Done
+    - Cancelled
+
+workspace:
+  kind: filesystem
+  root: .detent/workspaces
+  source_root: .
+  output_root: output
+
+deliverable:
+  kind: artifact
+  output_root: output
+  review_url: http://127.0.0.1:8080/review
+
+agent:
+  auto_promote:
+    enabled: true
+    quiet_seconds: 0
+    optout_label: requires-human-review
+    source_state: Review
+    pass_state: Ready for Pickup
+    rework_state: Rework
+
+gate:
+  kind: artifact
+  artifact:
+    status_field: render_status
+    pass_statuses:
+      - approved
+      - valid
+    wait_statuses:
+      - queued
+      - rendering
+      - pending_review
+    rework_statuses:
+      - recut
+      - invalid
+      - missing_assets
+
+server:
+  kanban:
+    mode: integration
+    allowed_transitions:
+      Backlog:
+        - Todo
+      Todo:
+        - Production
+        - Blocked
+      Production:
+        - Review
+        - Blocked
+      Review:
+        - Ready for Pickup
+        - Rework
+        - Blocked
+      Rework:
+        - Production
+        - Blocked
+      Blocked:
+        - Todo
+        - Production
+      Ready for Pickup:
+        - Done
+      Done: []
+      Cancelled: []
+---
+# Non-Code Artifact Workflow
+
+You are working on a local production work item, not a GitHub issue-to-PR task.
+Use the filesystem workspace and configured output directory. Do not require a
+git branch, pull request, CI run, or merge train unless the work item explicitly
+asks for one.
+
+Read the work item title, description, fields, metadata, and deliverable data.
+Use the project source folder for instructions, scripts, media assets, product
+copy, and production constraints. If required source assets are missing, record
+the missing inputs clearly in the output manifest and set `render_status` to
+`missing_assets` through the local status store or handoff process.
+
+Produce a machine-readable artifact manifest under the work item output
+directory. For video ad production, include:
+
+- work item id and external id
+- source asset paths used
+- generated script or storyboard path
+- render instructions or render output paths
+- preview or review URL when available
+- validation status and validation notes
+- next external-system action
+
+When the artifact is ready for review, update or emit data so the local SQLite
+work item field `render_status` becomes `pending_review`. When a human or
+external renderer marks it `approved` or `valid`, Detent can auto-promote the
+item to `Ready for Pickup`. Use `recut`, `invalid`, or `missing_assets` when the
+item needs rework.

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -842,6 +842,15 @@ func checkDoctorProjectWithProgress(
 		setDoctorCurrentCheck("Project " + id + " blocked recovery")
 		checks = append(checks, checkDoctorBlockedRecovery(ctx, id, workflow.Config, deps))
 	}
+	if workflow.Config.Tracker.Kind == workflowconfig.TrackerLocalSQLite {
+		setDoctorCurrentCheck("Project " + id + " local SQLite tracker")
+		checks = append(checks, checkDoctorLocalSQLiteTracker(ctx, id, project, workflow.Config, deps))
+	}
+	if workflow.Config.Workspace.Kind == workflowconfig.WorkspaceFilesystem {
+		setDoctorCurrentCheck("Project " + id + " filesystem workspace")
+		checks = append(checks, checkDoctorFilesystemWorkspace(id, workflow.Config))
+		return checks
+	}
 
 	sourceRepoCheckName := "Project " + id + " source repo"
 	setDoctorCurrentCheck(sourceRepoCheckName)
@@ -900,12 +909,28 @@ func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.C
 			Detail: "agent.auto_promote.enabled=false; live candidate diagnostics disabled",
 		}
 	}
-	if !doctorStateInList("Merging", cfg.Tracker.ActiveStates) {
+	passState := strings.TrimSpace(cfg.Agent.AutoPromote.PassState)
+	if passState == "" {
+		passState = "Merging"
+	}
+	reworkState := strings.TrimSpace(cfg.Agent.AutoPromote.ReworkState)
+	if reworkState == "" {
+		reworkState = "Rework"
+	}
+	if !doctorStateInList(passState, cfg.Tracker.ActiveStates) && !doctorStateInList(passState, cfg.Tracker.TerminalStates) {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorFail,
-			Detail: "agent.auto_promote.enabled=true but tracker.active_states does not include Merging",
-			Hint:   "Add Merging to tracker.active_states so promoted issues can enter the merge lane.",
+			Detail: "agent.auto_promote.enabled=true but pass_state " + passState + " is not configured in tracker.active_states or tracker.terminal_states",
+			Hint:   "Add " + passState + " to tracker.active_states or tracker.terminal_states.",
+		}
+	}
+	if !doctorStateInList(reworkState, cfg.Tracker.ActiveStates) && !doctorStateInList(reworkState, cfg.Tracker.TerminalStates) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "agent.auto_promote.enabled=true but rework_state " + reworkState + " is not configured in tracker.active_states or tracker.terminal_states",
+			Hint:   "Add " + reworkState + " to tracker.active_states or tracker.terminal_states.",
 		}
 	}
 	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
@@ -953,23 +978,31 @@ func checkDoctorAutoPromoteLive(
 	projectConnector doctorAutoPromoteConnector,
 	now time.Time,
 ) doctorCheck {
+	sourceState := strings.TrimSpace(cfg.Agent.AutoPromote.SourceState)
+	if sourceState == "" {
+		sourceState = "Human Review"
+	}
+	passState := strings.TrimSpace(cfg.Agent.AutoPromote.PassState)
+	if passState == "" {
+		passState = "Merging"
+	}
 	if verifier, ok := projectConnector.(doctorStatusOptionVerifier); ok {
-		if err := verifier.VerifyStatusOptions(ctx, []string{"Human Review", "Merging"}); err != nil {
+		if err := verifier.VerifyStatusOptions(ctx, []string{sourceState, passState}); err != nil {
 			return doctorCheck{
 				Name:   name,
 				Status: doctorFail,
 				Detail: fmt.Sprintf("status option verification failed: %v", err),
-				Hint:   "Ensure Human Review and Merging resolve through tracker.state_map to existing GitHub Project Status options.",
+				Hint:   "Ensure source_state and pass_state resolve through tracker.state_map to existing GitHub Project Status options.",
 			}
 		}
 	}
 
-	issues, err := fetchDoctorAutoPromoteIssues(ctx, projectConnector, []string{"Human Review"})
+	issues, err := fetchDoctorAutoPromoteIssues(ctx, projectConnector, []string{sourceState})
 	if err != nil {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorFail,
-			Detail: fmt.Sprintf("fetch Human Review candidates: %v", err),
+			Detail: fmt.Sprintf("fetch %s candidates: %v", sourceState, err),
 			Hint:   "Check GitHub Project access, Status field options, and repository pull request access.",
 		}
 	}
@@ -1001,8 +1034,9 @@ func checkDoctorAutoPromoteLive(
 	}
 
 	detail := fmt.Sprintf(
-		"agent.auto_promote.enabled=true; status options resolved; sampled %d Human Review candidate(s)",
+		"agent.auto_promote.enabled=true; status options resolved; sampled %d %s candidate(s)",
 		len(issues),
+		sourceState,
 	)
 	if len(reasonCounts) > 0 {
 		detail += "; reasons: " + doctorAutoPromoteReasonCounts(reasonCounts)
@@ -1045,6 +1079,9 @@ func doctorAutoPromoteConfig(cfg workflowconfig.Config) orchestrator.AutoPromote
 		QuietDuration:      time.Duration(cfg.Agent.AutoPromote.QuietSeconds) * time.Second,
 		OptoutLabel:        cfg.Agent.AutoPromote.OptoutLabel,
 		AllowedIssueLabels: append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
+		SourceState:        cfg.Agent.AutoPromote.SourceState,
+		PassState:          cfg.Agent.AutoPromote.PassState,
+		ReworkState:        cfg.Agent.AutoPromote.ReworkState,
 		Gate:               cfg.Gate,
 	}
 }
@@ -2710,6 +2747,156 @@ func expandDoctorWorkspacePath(path string) (string, error) {
 		return "", fmt.Errorf("absolute path: %w", err)
 	}
 	return filepath.Clean(abs), nil
+}
+
+func checkDoctorLocalSQLiteTracker(
+	ctx context.Context,
+	id string,
+	project globalconfig.Project,
+	cfg workflowconfig.Config,
+	deps doctorDeps,
+) doctorCheck {
+	name := "Project " + id + " local SQLite tracker"
+	path := strings.TrimSpace(cfg.Tracker.LocalSQLite.Path)
+	if path == "" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "tracker.local_sqlite.path is not configured",
+			Hint:   "Set tracker.local_sqlite.path to a SQLite database path for local work items.",
+		}
+	}
+	resolved, err := resolveDoctorProjectPath(project, path)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s: %v", path, err),
+			Hint:   "Set tracker.local_sqlite.path to an absolute, home-relative, or project workdir-relative path.",
+		}
+	}
+	db, err := deps.openSQLite(ctx, resolved)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s: %v", resolved, err),
+			Hint:   "Check local SQLite directory permissions and database integrity.",
+		}
+	}
+	if err := db.Close(); err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s close failed: %v", resolved, err),
+			Hint:   "Check for filesystem or SQLite errors, then rerun detent doctor.",
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorOK,
+		Detail: resolved + " is reachable",
+	}
+}
+
+func checkDoctorFilesystemWorkspace(id string, cfg workflowconfig.Config) doctorCheck {
+	name := "Project " + id + " filesystem workspace"
+	root := strings.TrimSpace(cfg.Workspace.Root)
+	if root == "" {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "workspace.root is not configured",
+			Hint:   "Set workspace.root to a directory Detent can use for filesystem workspaces.",
+		}
+	}
+	resolved, err := expandDoctorWorkspacePath(root)
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s: %v", root, err),
+			Hint:   "Set workspace.root to an absolute or home-relative directory.",
+		}
+	}
+	if err := doctorPathDirectoryReady(resolved); err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: fmt.Sprintf("%s: %v", resolved, err),
+			Hint:   "Create workspace.root or its parent directory and ensure Detent can write there.",
+		}
+	}
+	if outputRoot := strings.TrimSpace(doctorFirstNonBlank(cfg.Workspace.OutputRoot, cfg.Deliverable.OutputRoot)); outputRoot != "" {
+		resolvedOutput, err := expandDoctorWorkspacePath(outputRoot)
+		if err != nil {
+			return doctorCheck{
+				Name:   name,
+				Status: doctorFail,
+				Detail: fmt.Sprintf("%s: %v", outputRoot, err),
+				Hint:   "Set workspace.output_root or deliverable.output_root to an absolute or home-relative directory.",
+			}
+		}
+		if err := doctorPathDirectoryReady(resolvedOutput); err != nil {
+			return doctorCheck{
+				Name:   name,
+				Status: doctorFail,
+				Detail: fmt.Sprintf("%s: %v", resolvedOutput, err),
+				Hint:   "Create the artifact output directory or its parent and ensure Detent can write there.",
+			}
+		}
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: resolved + " is usable; artifact output " + resolvedOutput + " is usable",
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorOK,
+		Detail: resolved + " is usable",
+	}
+}
+
+func resolveDoctorProjectPath(project globalconfig.Project, path string) (string, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return "", errors.New("path is required")
+	}
+	if filepath.IsAbs(path) || path == "~" || strings.HasPrefix(path, "~/") {
+		return expandDoctorWorkspacePath(path)
+	}
+	base := strings.TrimSpace(project.Workdir)
+	if base == "" {
+		return expandDoctorWorkspacePath(path)
+	}
+	expandedBase, err := expandDoctorWorkspacePath(base)
+	if err != nil {
+		return "", err
+	}
+	return filepath.Clean(filepath.Join(expandedBase, path)), nil
+}
+
+func doctorPathDirectoryReady(path string) error {
+	info, err := os.Stat(path)
+	if err == nil {
+		if !info.IsDir() {
+			return errors.New("path is not a directory")
+		}
+		return nil
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		return err
+	}
+	parent := filepath.Dir(path)
+	info, err = os.Stat(parent)
+	if err != nil {
+		return fmt.Errorf("parent directory is not available: %w", err)
+	}
+	if !info.IsDir() {
+		return errors.New("parent path is not a directory")
+	}
+	return nil
 }
 
 func checkDoctorSQLite(ctx context.Context, resolution globalconfig.PathResolution, deps doctorDeps) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1947,6 +1947,51 @@ func TestCheckDoctorSQLite(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorLocalSQLiteTrackerResolvesProjectRelativePath(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerLocalSQLite
+	cfg.Tracker.LocalSQLite.Path = ".detent/work-items.db"
+
+	var opened string
+	got := checkDoctorLocalSQLiteTracker(context.Background(), "video", globalconfig.Project{Workdir: workdir}, cfg, doctorDeps{
+		openSQLite: func(_ context.Context, path string) (doctorStore, error) {
+			opened = path
+			return fakeDoctorStore{}, nil
+		},
+	})
+	if got.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorOK, got)
+	}
+	want := filepath.Join(workdir, ".detent", "work-items.db")
+	if opened != want {
+		t.Fatalf("opened path = %q, want %q", opened, want)
+	}
+}
+
+func TestCheckDoctorFilesystemWorkspaceValidatesRootAndOutput(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	outputRoot := t.TempDir()
+	cfg := workflowconfig.Default()
+	cfg.Workspace.Kind = workflowconfig.WorkspaceFilesystem
+	cfg.Workspace.Root = root
+	cfg.Deliverable.OutputRoot = outputRoot
+
+	got := checkDoctorFilesystemWorkspace("video", cfg)
+	if got.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorOK, got)
+	}
+	for _, want := range []string{root, outputRoot, "artifact output"} {
+		if !strings.Contains(got.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+		}
+	}
+}
+
 func TestDoctorSQLitePingErrorWrapsPingAndCloseErrors(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -124,9 +124,18 @@ func buildWorkspaceBackend(cfg workflowconfig.Config, sourceRootFallback string,
 	if sourceRoot == "" {
 		sourceRoot = root
 	}
-	backend, err := workspace.NewBackend(workspace.KindLocalGit, workspace.LocalGitOptions{
+	workspaceKind := strings.TrimSpace(cfg.Workspace.Kind)
+	if workspaceKind == "" {
+		workspaceKind = workspace.KindLocalGit
+	}
+	outputRoot := strings.TrimSpace(cfg.Workspace.OutputRoot)
+	if outputRoot == "" {
+		outputRoot = strings.TrimSpace(cfg.Deliverable.OutputRoot)
+	}
+	backend, err := workspace.NewBackend(workspaceKind, workspace.LocalGitOptions{
 		Root:       root,
 		SourceRoot: sourceRoot,
+		OutputRoot: outputRoot,
 		AutoBranch: cfg.Workspace.AutoBranch,
 		Hooks: workspace.Hooks{
 			Shell:        cfg.Hooks.Shell,

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -19,13 +19,20 @@ import (
 )
 
 const (
-	TrackerGitHub = "github"
-	TrackerLinear = "linear"
-	TrackerMemory = "memory"
+	TrackerGitHub      = "github"
+	TrackerLinear      = "linear"
+	TrackerMemory      = "memory"
+	TrackerLocalSQLite = "local_sqlite"
 
 	GitHubStatusSourceProjectV2  = "project_v2"
 	GitHubStatusSourceIssueField = "issue_field"
 	GitHubStatusSourceLabel      = "label"
+
+	WorkspaceLocalGit   = "local_git"
+	WorkspaceFilesystem = "filesystem"
+
+	DeliverablePullRequest = "pull_request"
+	DeliverableArtifact    = "artifact"
 
 	DependencyReadinessTerminal         = "terminal"
 	DependencyReadinessTerminalOrMerged = "terminal_or_merged"
@@ -59,6 +66,7 @@ type Config struct {
 	Tracker       Tracker         `yaml:"tracker"`
 	Polling       Polling         `yaml:"polling"`
 	Workspace     Workspace       `yaml:"workspace"`
+	Deliverable   Deliverable     `yaml:"deliverable,omitempty"`
 	Worker        Worker          `yaml:"worker"`
 	Agent         Agent           `yaml:"agent"`
 	Agents        Agents          `yaml:"agents"`
@@ -103,7 +111,13 @@ type Tracker struct {
 	AutoProvision               bool                  `yaml:"auto_provision"`
 	Claims                      Claims                `yaml:"claims,omitempty"`
 	Authorization               selector.Selector     `yaml:"authorization,omitempty"`
+	LocalSQLite                 LocalSQLite           `yaml:"local_sqlite,omitempty"`
 	Issues                      []connector.Issue     `yaml:"issues"`
+}
+
+type LocalSQLite struct {
+	Path      string `yaml:"path"`
+	ProjectID string `yaml:"project_id,omitempty"`
 }
 
 type DependencyAutoUnblock struct {
@@ -132,11 +146,19 @@ type Claims struct {
 }
 
 type Workspace struct {
+	Kind                   string `yaml:"kind"`
 	Root                   string `yaml:"root"`
 	SourceRoot             string `yaml:"source_root"`
+	OutputRoot             string `yaml:"output_root"`
 	AutoBranch             bool   `yaml:"auto_branch"`
 	CleanupIdleTTLMS       int    `yaml:"cleanup_idle_ttl_ms"`
 	CleanupSweepIntervalMS int    `yaml:"cleanup_sweep_interval_ms"`
+}
+
+type Deliverable struct {
+	Kind       string `yaml:"kind"`
+	OutputRoot string `yaml:"output_root,omitempty"`
+	ReviewURL  string `yaml:"review_url,omitempty"`
 }
 
 type Worker struct {
@@ -200,6 +222,9 @@ type AutoPromote struct {
 	QuietSeconds       int      `yaml:"quiet_seconds"`
 	OptoutLabel        string   `yaml:"optout_label"`
 	AllowedIssueLabels []string `yaml:"allowed_issue_labels"`
+	SourceState        string   `yaml:"source_state,omitempty"`
+	PassState          string   `yaml:"pass_state,omitempty"`
+	ReworkState        string   `yaml:"rework_state,omitempty"`
 }
 
 type Lessons struct {
@@ -536,10 +561,14 @@ func Default() Config {
 			IntervalMS: DefaultPollingIntervalMS,
 		},
 		Workspace: Workspace{
+			Kind:                   WorkspaceLocalGit,
 			Root:                   filepath.Join(os.TempDir(), "detent_workspaces"),
 			AutoBranch:             true,
 			CleanupIdleTTLMS:       86400000,
 			CleanupSweepIntervalMS: 600000,
+		},
+		Deliverable: Deliverable{
+			Kind: DeliverablePullRequest,
 		},
 		Worker: Worker{
 			SSHHosts: []string{},
@@ -556,6 +585,9 @@ func Default() Config {
 				QuietSeconds:       600,
 				OptoutLabel:        "requires-human-review",
 				AllowedIssueLabels: []string{},
+				SourceState:        "Human Review",
+				PassState:          "Merging",
+				ReworkState:        "Rework",
 			},
 			Budget:  budget,
 			Lessons: defaultLessons(),
@@ -624,6 +656,7 @@ func (c *Config) Validate() error {
 	c.Codex.validate(&problems)
 	problems = append(problems, gate.Validate("gate", c.Gate)...)
 	problems = append(problems, gate.ValidatePlan("plan", c.Plan)...)
+	c.Deliverable.validate(&problems)
 	c.Server.validate(&problems)
 	c.Observability.validate(&problems)
 	c.Budget.validate("budget", &problems)
@@ -682,15 +715,30 @@ func (c *Config) normalize() {
 		c.Tracker.StatusLabelPrefix = "detent:"
 	}
 	c.Tracker.WriteProbeIssue = strings.TrimSpace(c.Tracker.WriteProbeIssue)
+	c.Tracker.LocalSQLite.Normalize()
 	c.Tracker.Claims.Normalize()
 	c.Tracker.DependencyAutoUnblock.Normalize()
 	c.Tracker.Authorization.Normalize()
+	c.Workspace.Normalize()
+	c.Deliverable.Normalize()
 
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
 	c.Agent.DispatchPriorityByState = normalizeStateList(c.Agent.DispatchPriorityByState)
 	c.Agent.DispatchPriorityByLabel = normalizeLabels(c.Agent.DispatchPriorityByLabel)
 	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
 	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
+	c.Agent.AutoPromote.SourceState = strings.TrimSpace(c.Agent.AutoPromote.SourceState)
+	if c.Agent.AutoPromote.SourceState == "" {
+		c.Agent.AutoPromote.SourceState = "Human Review"
+	}
+	c.Agent.AutoPromote.PassState = strings.TrimSpace(c.Agent.AutoPromote.PassState)
+	if c.Agent.AutoPromote.PassState == "" {
+		c.Agent.AutoPromote.PassState = "Merging"
+	}
+	c.Agent.AutoPromote.ReworkState = strings.TrimSpace(c.Agent.AutoPromote.ReworkState)
+	if c.Agent.AutoPromote.ReworkState == "" {
+		c.Agent.AutoPromote.ReworkState = "Rework"
+	}
 	c.Agents.normalize()
 	c.Codex.Shell = commandshell.Normalize(c.Codex.Shell)
 	c.Gate = gate.Effective(c.Gate)
@@ -713,8 +761,10 @@ func (c *Config) validateTracker(problems *[]string) {
 		c.Tracker.validateGitHubAuth(problems)
 		c.Tracker.validateGitHubStatusSource(problems)
 	case TrackerMemory:
+	case TrackerLocalSQLite:
+		*problems = append(*problems, c.Tracker.LocalSQLite.Validate("tracker.local_sqlite")...)
 	default:
-		*problems = append(*problems, "tracker.kind must be one of github, linear, memory")
+		*problems = append(*problems, "tracker.kind must be one of github, linear, memory, local_sqlite")
 	}
 
 	validateStateList("tracker.active_states", c.Tracker.ActiveStates, problems)
@@ -735,6 +785,22 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.github_rest_fanout_max_requests", c.Tracker.GitHubRESTFanoutMaxRequests, problems)
 	*problems = append(*problems, c.Tracker.Claims.Validate("tracker.claims")...)
 	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
+}
+
+func (l *LocalSQLite) Normalize() {
+	if l == nil {
+		return
+	}
+	l.Path = strings.TrimSpace(l.Path)
+	l.ProjectID = strings.TrimSpace(l.ProjectID)
+}
+
+func (l LocalSQLite) Validate(prefix string) []string {
+	l.Normalize()
+	if l.Path == "" {
+		return []string{prefix + ".path is required for local_sqlite"}
+	}
+	return nil
 }
 
 func (t *Tracker) validateGitHubStatusSource(problems *[]string) {
@@ -807,8 +873,62 @@ func validRepositoryName(value string) bool {
 }
 
 func (w *Workspace) validate(problems *[]string) {
+	switch w.Kind {
+	case "", WorkspaceLocalGit, WorkspaceFilesystem:
+	default:
+		*problems = append(*problems, "workspace.kind must be one of local_git, filesystem")
+	}
 	validatePositive("workspace.cleanup_idle_ttl_ms", w.CleanupIdleTTLMS, problems)
 	validatePositive("workspace.cleanup_sweep_interval_ms", w.CleanupSweepIntervalMS, problems)
+}
+
+func (w *Workspace) Normalize() {
+	if w == nil {
+		return
+	}
+	w.Kind = normalizeWorkspaceKind(w.Kind)
+	w.Root = strings.TrimSpace(w.Root)
+	w.SourceRoot = strings.TrimSpace(w.SourceRoot)
+	w.OutputRoot = strings.TrimSpace(w.OutputRoot)
+}
+
+func normalizeWorkspaceKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "", WorkspaceLocalGit, "git", "localgit":
+		return WorkspaceLocalGit
+	case WorkspaceFilesystem, "file_system", "file-system", "files":
+		return WorkspaceFilesystem
+	default:
+		return strings.ToLower(strings.TrimSpace(kind))
+	}
+}
+
+func (d *Deliverable) Normalize() {
+	if d == nil {
+		return
+	}
+	d.Kind = normalizeDeliverableKind(d.Kind)
+	d.OutputRoot = strings.TrimSpace(d.OutputRoot)
+	d.ReviewURL = strings.TrimSpace(d.ReviewURL)
+}
+
+func (d *Deliverable) validate(problems *[]string) {
+	switch d.Kind {
+	case "", DeliverablePullRequest, DeliverableArtifact:
+	default:
+		*problems = append(*problems, "deliverable.kind must be one of pull_request, artifact")
+	}
+}
+
+func normalizeDeliverableKind(kind string) string {
+	switch strings.ToLower(strings.TrimSpace(kind)) {
+	case "", DeliverablePullRequest, "pr", "pull-request":
+		return DeliverablePullRequest
+	case DeliverableArtifact, "artifacts", "file", "files":
+		return DeliverableArtifact
+	default:
+		return strings.ToLower(strings.TrimSpace(kind))
+	}
 }
 
 func (a *Agent) validate(prefix string, problems *[]string) {
@@ -956,6 +1076,15 @@ func (a *AutoPromote) validate(prefix string, problems *[]string) {
 			*problems = append(*problems, prefix+".allowed_issue_labels labels must not be blank")
 			return
 		}
+	}
+	if strings.TrimSpace(a.SourceState) == "" {
+		*problems = append(*problems, prefix+".source_state must not be blank")
+	}
+	if strings.TrimSpace(a.PassState) == "" {
+		*problems = append(*problems, prefix+".pass_state must not be blank")
+	}
+	if strings.TrimSpace(a.ReworkState) == "" {
+		*problems = append(*problems, prefix+".rework_state must not be blank")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1029,6 +1029,84 @@ Prompt
 	}
 }
 
+func TestParseWorkflowLocalSQLiteArtifactWorkflow(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: local_sqlite
+  local_sqlite:
+    path: .detent/work-items.db
+    project_id: video-production
+  active_states:
+    - Todo
+    - Production
+  observed_states:
+    - Review
+  terminal_states:
+    - Done
+workspace:
+  kind: filesystem
+  root: .detent/workspaces
+  source_root: assets
+  output_root: .detent/renders
+deliverable:
+  kind: artifact
+  output_root: .detent/renders
+  review_url: http://127.0.0.1:8080/review
+agent:
+  auto_promote:
+    enabled: true
+    source_state: Review
+    pass_state: Done
+    rework_state: Production
+gate:
+  kind: artifact
+  artifact:
+    status_field: render_status
+    pass_statuses:
+      - approved
+    wait_statuses:
+      - queued
+    rework_statuses:
+      - recut
+server:
+  kanban:
+    mode: integration
+---
+Produce the video artifact.
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	cfg := workflow.Config
+	if cfg.Tracker.Kind != TrackerLocalSQLite || cfg.Tracker.LocalSQLite.Path != ".detent/work-items.db" || cfg.Tracker.LocalSQLite.ProjectID != "video-production" {
+		t.Fatalf("Tracker local sqlite config = %#v", cfg.Tracker)
+	}
+	if cfg.Workspace.Kind != WorkspaceFilesystem || cfg.Workspace.Root != ".detent/workspaces" || cfg.Workspace.OutputRoot != ".detent/renders" {
+		t.Fatalf("Workspace = %#v", cfg.Workspace)
+	}
+	if cfg.Deliverable.Kind != DeliverableArtifact || cfg.Deliverable.OutputRoot != ".detent/renders" {
+		t.Fatalf("Deliverable = %#v", cfg.Deliverable)
+	}
+	if cfg.Agent.AutoPromote.SourceState != "Review" || cfg.Agent.AutoPromote.PassState != "Done" || cfg.Agent.AutoPromote.ReworkState != "Production" {
+		t.Fatalf("AutoPromote = %#v", cfg.Agent.AutoPromote)
+	}
+	if cfg.Gate.Kind != gate.KindArtifact ||
+		cfg.Gate.Artifact.StatusField != "render_status" ||
+		len(cfg.Gate.Artifact.PassStatuses) != 1 ||
+		cfg.Gate.Artifact.PassStatuses[0] != "approved" {
+		t.Fatalf("Gate = %#v", cfg.Gate)
+	}
+	if cfg.Server.Kanban.Mode != KanbanModeIntegration {
+		t.Fatalf("Kanban mode = %q, want %q", cfg.Server.Kanban.Mode, KanbanModeIntegration)
+	}
+}
+
 func TestParseWorkflowNormalizesGitHubAppIDs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/backend.go
+++ b/internal/connector/backend.go
@@ -3,11 +3,12 @@ package connector
 type Backend string
 
 const (
-	BackendMemory Backend = "memory"
-	BackendLinear Backend = "linear"
-	BackendGitHub Backend = "github"
-	BackendGitLab Backend = "gitlab"
-	BackendJira   Backend = "jira"
+	BackendMemory      Backend = "memory"
+	BackendLinear      Backend = "linear"
+	BackendGitHub      Backend = "github"
+	BackendLocalSQLite Backend = "local_sqlite"
+	BackendGitLab      Backend = "gitlab"
+	BackendJira        Backend = "jira"
 )
 
 func (b Backend) String() string {

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 )
 
@@ -20,6 +21,7 @@ var (
 type Config struct {
 	Kind                        string
 	Memory                      memory.Config
+	LocalSQLite                 local.Config
 	Endpoint                    string
 	APIKey                      string
 	GitHubTokenRefresh          githubconnector.TokenRefreshFunc
@@ -50,6 +52,8 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 	switch connector.Backend(kind) {
 	case connector.BackendMemory:
 		return memory.New(cfg.Memory), nil
+	case connector.BackendLocalSQLite:
+		return local.New(cfg.LocalSQLite)
 	case connector.BackendLinear:
 		return unimplementedConnector{name: kind}, nil
 	case connector.BackendGitHub:

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -29,6 +29,8 @@ type Issue struct {
 	Labels           []string          `json:"labels" yaml:"labels"`
 	Comments         []IssueComment    `json:"comments,omitempty" yaml:"comments,omitempty"`
 	Fields           map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Deliverable      *Deliverable      `json:"deliverable,omitempty" yaml:"deliverable,omitempty"`
 	AssignedToWorker bool              `json:"assigned_to_worker" yaml:"assigned_to_worker"`
 	CreatedAt        *time.Time        `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	UpdatedAt        *time.Time        `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
@@ -98,12 +100,22 @@ type IssueComment struct {
 	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
 }
 
+type Deliverable struct {
+	Kind             string            `json:"kind,omitempty" yaml:"kind,omitempty"`
+	Path             string            `json:"path,omitempty" yaml:"path,omitempty"`
+	ReviewURL        string            `json:"review_url,omitempty" yaml:"review_url,omitempty"`
+	ValidationStatus string            `json:"validation_status,omitempty" yaml:"validation_status,omitempty"`
+	ExternalID       string            `json:"external_id,omitempty" yaml:"external_id,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+}
+
 func NewIssue() Issue {
 	return Issue{
 		BlockedBy:        []BlockedRef{},
 		Labels:           []string{},
 		Assignees:        []string{},
 		Fields:           map[string]string{},
+		Metadata:         map[string]string{},
 		AssignedToWorker: true,
 	}
 }

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -1,0 +1,598 @@
+package local
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	_ "modernc.org/sqlite"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const (
+	defaultProjectID = "default"
+
+	eventKindComment       = "comment"
+	eventKindStateUpdate   = "state_update"
+	eventKindFieldUpdate   = "field_update"
+	eventKindProjectRemove = "project_remove"
+)
+
+type Config struct {
+	Path           string
+	ProjectID      string
+	Issues         []connector.Issue
+	ActiveStates   []string
+	ObservedStates []string
+	TerminalStates []string
+	Now            func() time.Time
+}
+
+type Connector struct {
+	db             *sql.DB
+	projectID      string
+	activeStates   []string
+	observedStates []string
+	terminalStates []string
+	now            func() time.Time
+}
+
+var _ connector.Connector = (*Connector)(nil)
+var _ connector.CandidateIssuesByStatesFetcher = (*Connector)(nil)
+var _ connector.IssuesByStatesLimiter = (*Connector)(nil)
+var _ connector.IssueCommentReader = (*Connector)(nil)
+var _ connector.IssueStateProber = (*Connector)(nil)
+var _ connector.ProjectRemover = (*Connector)(nil)
+
+func New(cfg Config) (*Connector, error) {
+	path := strings.TrimSpace(cfg.Path)
+	if path == "" {
+		return nil, errors.New("local sqlite path is required")
+	}
+	var err error
+	path, err = expandPath(path)
+	if err != nil {
+		return nil, err
+	}
+	if path != ":memory:" {
+		if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+			return nil, fmt.Errorf("create local sqlite parent: %w", err)
+		}
+	}
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		return nil, fmt.Errorf("open local sqlite: %w", err)
+	}
+	conn := &Connector{
+		db:             db,
+		projectID:      localProjectID(cfg.ProjectID),
+		activeStates:   cloneStrings(cfg.ActiveStates),
+		observedStates: cloneStrings(cfg.ObservedStates),
+		terminalStates: cloneStrings(cfg.TerminalStates),
+		now:            cfg.Now,
+	}
+	if conn.now == nil {
+		conn.now = time.Now
+	}
+	if err := conn.migrate(context.Background()); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	if err := conn.seed(context.Background(), cfg.Issues); err != nil {
+		_ = db.Close()
+		return nil, err
+	}
+	return conn, nil
+}
+
+func (c *Connector) Name() string {
+	return connector.BackendLocalSQLite.String()
+}
+
+func (c *Connector) Close() error {
+	if c == nil || c.db == nil {
+		return nil
+	}
+	return c.db.Close()
+}
+
+func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	if len(c.activeStates) == 0 {
+		return c.fetchIssues(ctx, nil, 0)
+	}
+	return c.FetchIssuesByStates(ctx, c.activeStates)
+}
+
+func (c *Connector) FetchCandidateIssuesByStates(ctx context.Context, states []string) ([]connector.Issue, error) {
+	return c.FetchIssuesByStates(ctx, states)
+}
+
+func (c *Connector) FetchIssuesByStates(ctx context.Context, states []string) ([]connector.Issue, error) {
+	return c.fetchIssues(ctx, states, 0)
+}
+
+func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
+	return c.fetchIssues(ctx, states, limit)
+}
+
+func (c *Connector) FetchIssueStateProbe(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
+	return c.FetchIssuesByStatesLimit(ctx, states, limit)
+}
+
+func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) ([]connector.Issue, error) {
+	ids := normalizedSet(issueIDs)
+	if len(ids) == 0 {
+		return []connector.Issue{}, nil
+	}
+	issues, err := c.fetchIssues(ctx, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]connector.Issue, 0, len(issueIDs))
+	for _, issue := range issues {
+		if _, ok := ids[strings.TrimSpace(issue.ID)]; ok {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
+func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	rows, err := c.db.QueryContext(ctx, `
+select body from detent_work_item_events
+where project_id = ? and item_id = ? and event_kind = ?
+order by id asc`, c.projectID, strings.TrimSpace(issue.ID), eventKindComment)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	comments := []connector.IssueComment{}
+	for rows.Next() {
+		var body string
+		if err := rows.Scan(&body); err != nil {
+			return nil, err
+		}
+		comments = append(comments, connector.IssueComment{Body: body})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return comments, nil
+}
+
+func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
+	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindComment, "", strings.TrimSpace(body), nil)
+}
+
+func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateName string) error {
+	issueID = strings.TrimSpace(issueID)
+	stateName = strings.TrimSpace(stateName)
+	now := c.now().UTC()
+	result, err := c.db.ExecContext(ctx, `
+update detent_work_items
+set state = ?, stage_updated_at = ?, updated_at = ?
+where project_id = ? and id = ?`, stateName, formatTime(now), formatTime(now), c.projectID, issueID)
+	if err != nil {
+		return err
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		return sql.ErrNoRows
+	}
+	return c.recordEvent(ctx, issueID, eventKindStateUpdate, stateName, "", nil)
+}
+
+func (c *Connector) SetAssignee(ctx context.Context, issueID string, login string) error {
+	return c.SetField(ctx, issueID, "assignee", login)
+}
+
+func (c *Connector) SetField(ctx context.Context, issueID string, fieldName string, value string) error {
+	issue, err := c.issueByID(ctx, issueID)
+	if err != nil {
+		return err
+	}
+	if issue.Fields == nil {
+		issue.Fields = map[string]string{}
+	}
+	fieldName = strings.TrimSpace(fieldName)
+	issue.Fields[fieldName] = strings.TrimSpace(value)
+	fieldsJSON, err := marshalStringMap(issue.Fields)
+	if err != nil {
+		return err
+	}
+	now := c.now().UTC()
+	_, err = c.db.ExecContext(ctx, `
+update detent_work_items
+set fields_json = ?, updated_at = ?
+where project_id = ? and id = ?`, fieldsJSON, formatTime(now), c.projectID, strings.TrimSpace(issueID))
+	if err != nil {
+		return err
+	}
+	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindFieldUpdate, "", "", map[string]string{fieldName: value})
+}
+
+func (c *Connector) RemoveIssueFromProject(ctx context.Context, issueID string) error {
+	issueID = strings.TrimSpace(issueID)
+	result, err := c.db.ExecContext(ctx, `
+delete from detent_work_items
+where project_id = ? and id = ?`, c.projectID, issueID)
+	if err != nil {
+		return err
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		return sql.ErrNoRows
+	}
+	return c.recordEvent(ctx, issueID, eventKindProjectRemove, "", "", nil)
+}
+
+func (c *Connector) migrate(ctx context.Context) error {
+	statements := []string{
+		`create table if not exists detent_work_items (
+project_id text not null,
+id text not null,
+identifier text not null,
+title text not null default '',
+description text not null default '',
+priority integer,
+state text not null default '',
+url text not null default '',
+author_id text not null default '',
+assignee_id text not null default '',
+assignees_json text not null default '[]',
+labels_json text not null default '[]',
+fields_json text not null default '{}',
+metadata_json text not null default '{}',
+deliverable_kind text not null default '',
+deliverable_path text not null default '',
+deliverable_review_url text not null default '',
+deliverable_validation_status text not null default '',
+deliverable_external_id text not null default '',
+deliverable_metadata_json text not null default '{}',
+assigned_to_worker integer not null default 1,
+created_at text not null default '',
+updated_at text not null default '',
+stage_updated_at text not null default '',
+model_override text not null default '',
+primary key (project_id, id)
+)`,
+		`create table if not exists detent_work_item_events (
+id integer primary key autoincrement,
+project_id text not null,
+item_id text not null,
+event_kind text not null,
+state text not null default '',
+body text not null default '',
+payload_json text not null default '{}',
+created_at text not null
+)`,
+		`create index if not exists idx_detent_work_items_project_state on detent_work_items(project_id, state)`,
+		`create index if not exists idx_detent_work_item_events_project_item on detent_work_item_events(project_id, item_id, id)`,
+	}
+	for _, statement := range statements {
+		if _, err := c.db.ExecContext(ctx, statement); err != nil {
+			return fmt.Errorf("migrate local sqlite connector: %w", err)
+		}
+	}
+	return nil
+}
+
+func (c *Connector) seed(ctx context.Context, issues []connector.Issue) error {
+	for _, issue := range issues {
+		if err := c.insertSeedIssue(ctx, issue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Connector) insertSeedIssue(ctx context.Context, issue connector.Issue) error {
+	id := strings.TrimSpace(issue.ID)
+	if id == "" {
+		id = strings.TrimSpace(issue.Identifier)
+	}
+	if id == "" {
+		return errors.New("local sqlite seed issue id or identifier is required")
+	}
+	identifier := strings.TrimSpace(issue.Identifier)
+	if identifier == "" {
+		identifier = id
+	}
+	now := c.now().UTC()
+	createdAt := timeOrDefault(issue.CreatedAt, now)
+	updatedAt := timeOrDefault(issue.UpdatedAt, createdAt)
+	stageUpdatedAt := timeOrDefault(issue.StageUpdatedAt, updatedAt)
+	assigneesJSON, err := marshalStringSlice(issue.Assignees)
+	if err != nil {
+		return err
+	}
+	labelsJSON, err := marshalStringSlice(issue.Labels)
+	if err != nil {
+		return err
+	}
+	fieldsJSON, err := marshalStringMap(issue.Fields)
+	if err != nil {
+		return err
+	}
+	metadataJSON, err := marshalStringMap(issue.Metadata)
+	if err != nil {
+		return err
+	}
+	deliverableMetadataJSON := "{}"
+	deliverable := connector.Deliverable{}
+	if issue.Deliverable != nil {
+		deliverable = *issue.Deliverable
+		deliverableMetadataJSON, err = marshalStringMap(issue.Deliverable.Metadata)
+		if err != nil {
+			return err
+		}
+	}
+	assigned := 0
+	if issue.AssignedToWorker {
+		assigned = 1
+	}
+	_, err = c.db.ExecContext(ctx, `
+insert into detent_work_items (
+project_id, id, identifier, title, description, priority, state, url,
+author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
+deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
+deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
+created_at, updated_at, stage_updated_at, model_override
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(project_id, id) do nothing`,
+		c.projectID, id, identifier, issue.Title, issue.Description, nullableInt(issue.Priority), issue.State, issue.URL,
+		issue.AuthorID, issue.AssigneeID, assigneesJSON, labelsJSON, fieldsJSON, metadataJSON,
+		deliverable.Kind, deliverable.Path, deliverable.ReviewURL, deliverable.ValidationStatus,
+		deliverable.ExternalID, deliverableMetadataJSON, assigned,
+		formatTime(createdAt), formatTime(updatedAt), formatTime(stageUpdatedAt), issue.ModelOverride)
+	return err
+}
+
+func (c *Connector) fetchIssues(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
+	query := `select project_id, id, identifier, title, description, priority, state, url,
+author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
+deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
+deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
+created_at, updated_at, stage_updated_at, model_override
+from detent_work_items
+where project_id = ?`
+	args := []any{c.projectID}
+	if len(normalizedSet(states)) > 0 {
+		placeholders := make([]string, 0, len(states))
+		for _, state := range states {
+			state = strings.TrimSpace(state)
+			if state == "" {
+				continue
+			}
+			placeholders = append(placeholders, "?")
+			args = append(args, state)
+		}
+		query += " and state in (" + strings.Join(placeholders, ",") + ")"
+	}
+	query += " order by updated_at desc, id asc"
+	if limit > 0 {
+		query += " limit ?"
+		args = append(args, limit)
+	}
+	rows, err := c.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	issues := []connector.Issue{}
+	for rows.Next() {
+		issue, err := scanIssue(rows)
+		if err != nil {
+			return nil, err
+		}
+		comments, err := c.FetchIssueComments(ctx, issue)
+		if err != nil {
+			return nil, err
+		}
+		issue.Comments = comments
+		issues = append(issues, issue)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return issues, nil
+}
+
+func (c *Connector) issueByID(ctx context.Context, issueID string) (connector.Issue, error) {
+	issues, err := c.FetchIssueStatesByIDs(ctx, []string{issueID})
+	if err != nil {
+		return connector.Issue{}, err
+	}
+	if len(issues) == 0 {
+		return connector.Issue{}, sql.ErrNoRows
+	}
+	return issues[0], nil
+}
+
+func (c *Connector) recordEvent(ctx context.Context, issueID string, kind string, state string, body string, payload map[string]string) error {
+	payloadJSON, err := marshalStringMap(payload)
+	if err != nil {
+		return err
+	}
+	_, err = c.db.ExecContext(ctx, `
+insert into detent_work_item_events(project_id, item_id, event_kind, state, body, payload_json, created_at)
+values (?, ?, ?, ?, ?, ?, ?)`,
+		c.projectID, issueID, kind, strings.TrimSpace(state), strings.TrimSpace(body), payloadJSON, formatTime(c.now().UTC()))
+	return err
+}
+
+type issueScanner interface {
+	Scan(dest ...any) error
+}
+
+func scanIssue(scanner issueScanner) (connector.Issue, error) {
+	var issue connector.Issue
+	var projectID string
+	var priority sql.NullInt64
+	var assigneesJSON, labelsJSON, fieldsJSON, metadataJSON string
+	var deliverable connector.Deliverable
+	var deliverableMetadataJSON string
+	var assigned int
+	var createdAt, updatedAt, stageUpdatedAt string
+	err := scanner.Scan(
+		&projectID, &issue.ID, &issue.Identifier, &issue.Title, &issue.Description, &priority, &issue.State, &issue.URL,
+		&issue.AuthorID, &issue.AssigneeID, &assigneesJSON, &labelsJSON, &fieldsJSON, &metadataJSON,
+		&deliverable.Kind, &deliverable.Path, &deliverable.ReviewURL, &deliverable.ValidationStatus,
+		&deliverable.ExternalID, &deliverableMetadataJSON, &assigned,
+		&createdAt, &updatedAt, &stageUpdatedAt, &issue.ModelOverride,
+	)
+	if err != nil {
+		return connector.Issue{}, err
+	}
+	if priority.Valid {
+		value := int(priority.Int64)
+		issue.Priority = &value
+	}
+	issue.Assignees = unmarshalStringSlice(assigneesJSON)
+	issue.Labels = unmarshalStringSlice(labelsJSON)
+	issue.Fields = unmarshalStringMap(fieldsJSON)
+	issue.Metadata = unmarshalStringMap(metadataJSON)
+	issue.AssignedToWorker = assigned != 0
+	issue.CreatedAt = parseTimePointer(createdAt)
+	issue.UpdatedAt = parseTimePointer(updatedAt)
+	issue.StageUpdatedAt = parseTimePointer(stageUpdatedAt)
+	deliverable.Metadata = unmarshalStringMap(deliverableMetadataJSON)
+	if deliverableHasContent(deliverable) {
+		issue.Deliverable = &deliverable
+	}
+	return issue, nil
+}
+
+func deliverableHasContent(deliverable connector.Deliverable) bool {
+	return strings.TrimSpace(deliverable.Kind) != "" ||
+		strings.TrimSpace(deliverable.Path) != "" ||
+		strings.TrimSpace(deliverable.ReviewURL) != "" ||
+		strings.TrimSpace(deliverable.ValidationStatus) != "" ||
+		strings.TrimSpace(deliverable.ExternalID) != "" ||
+		len(deliverable.Metadata) > 0
+}
+
+func localProjectID(projectID string) string {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return defaultProjectID
+	}
+	return projectID
+}
+
+func normalizedSet(values []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func cloneStrings(values []string) []string {
+	return append([]string(nil), values...)
+}
+
+func expandPath(path string) (string, error) {
+	if path == "~" {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return home, nil
+	}
+	if strings.HasPrefix(path, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	}
+	return path, nil
+}
+
+func nullableInt(value *int) any {
+	if value == nil {
+		return nil
+	}
+	return *value
+}
+
+func timeOrDefault(value *time.Time, fallback time.Time) time.Time {
+	if value == nil || value.IsZero() {
+		return fallback
+	}
+	return value.UTC()
+}
+
+func formatTime(value time.Time) string {
+	if value.IsZero() {
+		return ""
+	}
+	return value.UTC().Format(time.RFC3339Nano)
+}
+
+func parseTimePointer(value string) *time.Time {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, value)
+	if err != nil {
+		return nil
+	}
+	return &parsed
+}
+
+func marshalStringSlice(values []string) (string, error) {
+	if values == nil {
+		values = []string{}
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func marshalStringMap(values map[string]string) (string, error) {
+	if values == nil {
+		values = map[string]string{}
+	}
+	raw, err := json.Marshal(values)
+	if err != nil {
+		return "", err
+	}
+	return string(raw), nil
+}
+
+func unmarshalStringSlice(raw string) []string {
+	var values []string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &values); err != nil {
+		return []string{}
+	}
+	if values == nil {
+		return []string{}
+	}
+	return values
+}
+
+func unmarshalStringMap(raw string) map[string]string {
+	var values map[string]string
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &values); err != nil {
+		return map[string]string{}
+	}
+	if values == nil {
+		return map[string]string{}
+	}
+	return values
+}

--- a/internal/connector/local/local_test.go
+++ b/internal/connector/local/local_test.go
@@ -1,0 +1,138 @@
+package local
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorPersistsWorkItemStateAndEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	path := filepath.Join(t.TempDir(), "work-items.db")
+	issue := connector.NewIssue()
+	issue.ID = "ad-1"
+	issue.Identifier = "store/ad-1"
+	issue.Title = "Produce summer sale ad"
+	issue.Description = "Create a short video ad from approved assets."
+	issue.State = "Todo"
+	issue.Fields = map[string]string{"validation_status": "pending"}
+	issue.Metadata = map[string]string{"store": "creswood"}
+	issue.Deliverable = &connector.Deliverable{
+		Kind:             "video_ad",
+		Path:             "outputs/ad-1/manifest.json",
+		ValidationStatus: "pending",
+		ExternalID:       "creative-101",
+		Metadata:         map[string]string{"aspect_ratio": "9:16"},
+	}
+
+	store, err := New(Config{
+		Path:         path,
+		ProjectID:    "video",
+		Issues:       []connector.Issue{issue},
+		ActiveStates: []string{"Todo"},
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	candidates, err := store.FetchCandidateIssues(ctx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(candidates) != 1 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 1", len(candidates))
+	}
+	got := candidates[0]
+	if got.ID != "ad-1" || got.State != "Todo" || got.Fields["validation_status"] != "pending" || got.Metadata["store"] != "creswood" {
+		t.Fatalf("candidate = %#v", got)
+	}
+	if got.Deliverable == nil || got.Deliverable.ExternalID != "creative-101" || got.Deliverable.Metadata["aspect_ratio"] != "9:16" {
+		t.Fatalf("candidate deliverable = %#v", got.Deliverable)
+	}
+
+	if err := store.UpdateIssueState(ctx, "ad-1", "Review"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+	if err := store.SetField(ctx, "ad-1", "validation_status", "valid"); err != nil {
+		t.Fatalf("SetField() error = %v", err)
+	}
+	if err := store.CreateComment(ctx, "ad-1", "Manifest is ready for external pickup."); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	if err := store.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	reopened, err := New(Config{
+		Path:      path,
+		ProjectID: "video",
+	})
+	if err != nil {
+		t.Fatalf("reopen New() error = %v", err)
+	}
+	defer reopened.Close()
+
+	issues, err := reopened.FetchIssuesByStates(ctx, []string{"Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(issues))
+	}
+	got = issues[0]
+	if got.State != "Review" || got.Fields["validation_status"] != "valid" {
+		t.Fatalf("persisted issue = %#v", got)
+	}
+	if len(got.Comments) != 1 || got.Comments[0].Body != "Manifest is ready for external pickup." {
+		t.Fatalf("persisted comments = %#v", got.Comments)
+	}
+
+	if err := reopened.RemoveIssueFromProject(ctx, "ad-1"); err != nil {
+		t.Fatalf("RemoveIssueFromProject() error = %v", err)
+	}
+	if _, err := reopened.issueByID(ctx, "ad-1"); !errors.Is(err, sql.ErrNoRows) {
+		t.Fatalf("issueByID() error = %v, want sql.ErrNoRows", err)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesLimit(t *testing.T) {
+	t.Parallel()
+
+	first := connector.NewIssue()
+	first.ID = "ad-1"
+	first.Identifier = "store/ad-1"
+	first.State = "Todo"
+	second := connector.NewIssue()
+	second.ID = "ad-2"
+	second.Identifier = "store/ad-2"
+	second.State = "Todo"
+
+	store, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "limit.db"),
+		ProjectID: "video",
+		Issues:    []connector.Issue{first, second},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer store.Close()
+
+	issues, err := store.FetchIssuesByStatesLimit(context.Background(), []string{"Todo"}, 1)
+	if err != nil {
+		t.Fatalf("FetchIssuesByStatesLimit() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("FetchIssuesByStatesLimit() len = %d, want 1", len(issues))
+	}
+}

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -496,6 +496,11 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		issue.PullRequest = &pullRequest
 	}
+	if issue.Deliverable != nil {
+		deliverable := *issue.Deliverable
+		deliverable.Metadata = cloneStringMap(issue.Deliverable.Metadata)
+		issue.Deliverable = &deliverable
+	}
 	if issue.BlockedBy != nil {
 		issue.BlockedBy = append([]connector.BlockedRef(nil), issue.BlockedBy...)
 	}
@@ -513,6 +518,9 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	if issue.Fields != nil {
 		issue.Fields = cloneStringMap(issue.Fields)
+	}
+	if issue.Metadata != nil {
+		issue.Metadata = cloneStringMap(issue.Metadata)
 	}
 	issue.CreatedAt = cloneTime(issue.CreatedAt)
 	issue.UpdatedAt = cloneTime(issue.UpdatedAt)

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -8,12 +8,14 @@ import (
 const (
 	KindCommand     = "command"
 	KindHumanReview = "human_review"
+	KindArtifact    = "artifact"
 
-	DefaultCommand           = "make check"
-	DefaultApprovalLabel     = "human-approved"
-	DefaultPlanApprovalLabel = "plan-approved"
-	DefaultPlanStop          = "Plan Review"
-	DefaultValidatorMinScore = 0.8
+	DefaultCommand             = "make check"
+	DefaultApprovalLabel       = "human-approved"
+	DefaultPlanApprovalLabel   = "plan-approved"
+	DefaultPlanStop            = "Plan Review"
+	DefaultValidatorMinScore   = 0.8
+	DefaultArtifactStatusField = "validation_status"
 
 	CIFailureActionSkip   = "skip"
 	CIFailureActionRework = "rework"
@@ -30,6 +32,14 @@ type Config struct {
 	RequireAutomatedReview *bool           `yaml:"require_automated_review"`
 	CIFailureAction        string          `yaml:"ci_failure_action"`
 	Validator              ValidatorConfig `yaml:"validator"`
+	Artifact               ArtifactConfig  `yaml:"artifact"`
+}
+
+type ArtifactConfig struct {
+	StatusField    string   `yaml:"status_field"`
+	PassStatuses   []string `yaml:"pass_statuses"`
+	WaitStatuses   []string `yaml:"wait_statuses"`
+	ReworkStatuses []string `yaml:"rework_statuses"`
 }
 
 type ValidatorConfig struct {
@@ -53,6 +63,7 @@ type Summary struct {
 	ReviewState        string
 	P1Findings         []Finding
 	Validator          ValidatorResult
+	ArtifactStatus     string
 	LastActivityAt     *time.Time
 }
 
@@ -106,6 +117,9 @@ const (
 	ReasonValidatorRework              Reason = "validator_rework"
 	ReasonValidatorScoreBelowThreshold Reason = "validator_score_below_threshold"
 	ReasonValidatorBlockedSeverity     Reason = "validator_blocked_severity"
+	ReasonArtifactStatusMissing        Reason = "artifact_status_missing"
+	ReasonArtifactStatusWait           Reason = "artifact_status_wait"
+	ReasonArtifactStatusRework         Reason = "artifact_status_rework"
 	ReasonPlanDisabled                 Reason = "plan_disabled"
 )
 
@@ -125,6 +139,7 @@ func DefaultConfig() Config {
 		RequireAutomatedReview: new(true),
 		CIFailureAction:        CIFailureActionSkip,
 		Validator:              effectiveValidatorConfig(ValidatorConfig{}),
+		Artifact:               effectiveArtifactConfig(ArtifactConfig{}),
 	}
 }
 
@@ -142,6 +157,7 @@ func Effective(cfg Config) Config {
 	cfg.ApprovalLabel = normalizeLabel(cfg.ApprovalLabel)
 	cfg.CIFailureAction = NormalizeCIFailureAction(cfg.CIFailureAction)
 	cfg.Validator = effectiveValidatorConfig(cfg.Validator)
+	cfg.Artifact = effectiveArtifactConfig(cfg.Artifact)
 
 	if cfg.Kind == "" {
 		cfg.Kind = KindCommand
@@ -155,6 +171,9 @@ func Effective(cfg Config) Config {
 		if cfg.ApprovalLabel == "" {
 			cfg.ApprovalLabel = DefaultApprovalLabel
 		}
+	} else if cfg.Kind == KindArtifact {
+		cfg.Run = ""
+		cfg.RequireAutomatedReview = nil
 	} else if cfg.RequireAutomatedReview == nil {
 		cfg.RequireAutomatedReview = new(true)
 	}
@@ -189,6 +208,8 @@ func NormalizeKind(kind string) string {
 		return KindCommand
 	case KindHumanReview, "human-review", "humanreview":
 		return KindHumanReview
+	case KindArtifact, "artifact_status", "artifact-status", "domain":
+		return KindArtifact
 	default:
 		return strings.ToLower(strings.TrimSpace(kind))
 	}
@@ -221,9 +242,9 @@ func NormalizeCIFailureAction(action string) string {
 func Validate(prefix string, cfg Config) []string {
 	var problems []string
 	switch NormalizeKind(cfg.Kind) {
-	case KindCommand, KindHumanReview:
+	case KindCommand, KindHumanReview, KindArtifact:
 	default:
-		problems = append(problems, prefix+".kind must be one of command, human_review")
+		problems = append(problems, prefix+".kind must be one of command, human_review, artifact")
 	}
 	switch NormalizeCIFailureAction(cfg.CIFailureAction) {
 	case CIFailureActionSkip, CIFailureActionRework:
@@ -231,6 +252,7 @@ func Validate(prefix string, cfg Config) []string {
 		problems = append(problems, prefix+".ci_failure_action must be one of skip, rework")
 	}
 	problems = append(problems, validateValidator(prefix+".validator", cfg.Validator)...)
+	problems = append(problems, validateArtifact(prefix+".artifact", cfg.Artifact)...)
 	return problems
 }
 
@@ -253,6 +275,9 @@ func Instructions(cfg Config) string {
 	case KindHumanReview:
 		return "The validation gate is human review. Keep the pull request in Human Review until a human applies label `" +
 			cfg.ApprovalLabel + "`; do not move it to Merging before that label is present."
+	case KindArtifact:
+		return "The validation gate is artifact status. Detent evaluates `" + cfg.Artifact.StatusField +
+			"` from the work item fields or deliverable validation status. Passing statuses advance the item, waiting statuses keep it in place, and rework statuses route it to rework without requiring a pull request or CI."
 	default:
 		instructions := "The validation gate is a command. Run `" + cfg.Run +
 			"` from the workspace root before Human Review; the pull request still needs green CI before promotion. " +
@@ -300,6 +325,8 @@ func Evaluate(cfg Config, labels []string, summary Summary, now time.Time, opts 
 	switch cfg.Kind {
 	case KindHumanReview:
 		return evaluateHumanReview(cfg, labels, summary)
+	case KindArtifact:
+		return evaluateArtifact(cfg.Artifact, summary)
 	default:
 		return evaluateCommand(cfg, summary, now, opts)
 	}
@@ -344,6 +371,20 @@ func evaluateHumanReview(cfg Config, labels []string, summary Summary) Decision 
 		}
 	}
 	return decision(ActionWait, ReasonHumanApprovalMissing)
+}
+
+func evaluateArtifact(cfg ArtifactConfig, summary Summary) Decision {
+	status := normalizeArtifactStatus(summary.ArtifactStatus)
+	if status == "" {
+		return decision(ActionWait, ReasonArtifactStatusMissing)
+	}
+	if artifactStatusIn(status, cfg.ReworkStatuses) {
+		return decision(ActionRework, ReasonArtifactStatusRework)
+	}
+	if artifactStatusIn(status, cfg.PassStatuses) {
+		return decision(ActionPass, ReasonReady)
+	}
+	return decision(ActionWait, ReasonArtifactStatusWait)
 }
 
 func hasApprovalLabel(labels []string, approvalLabel string) bool {
@@ -453,6 +494,26 @@ func effectiveValidatorConfig(cfg ValidatorConfig) ValidatorConfig {
 	return cfg
 }
 
+func effectiveArtifactConfig(cfg ArtifactConfig) ArtifactConfig {
+	cfg.StatusField = strings.TrimSpace(cfg.StatusField)
+	if cfg.StatusField == "" {
+		cfg.StatusField = DefaultArtifactStatusField
+	}
+	cfg.PassStatuses = normalizeArtifactStatuses(cfg.PassStatuses)
+	if len(cfg.PassStatuses) == 0 {
+		cfg.PassStatuses = []string{"approved", "complete", "completed", "pass", "passed", "valid"}
+	}
+	cfg.WaitStatuses = normalizeArtifactStatuses(cfg.WaitStatuses)
+	if len(cfg.WaitStatuses) == 0 {
+		cfg.WaitStatuses = []string{"pending", "review", "reviewing", "waiting"}
+	}
+	cfg.ReworkStatuses = normalizeArtifactStatuses(cfg.ReworkStatuses)
+	if len(cfg.ReworkStatuses) == 0 {
+		cfg.ReworkStatuses = []string{"changes_requested", "failed", "invalid", "rework"}
+	}
+	return cfg
+}
+
 func validateValidator(prefix string, cfg ValidatorConfig) []string {
 	var problems []string
 	invalidScore := false
@@ -471,6 +532,57 @@ func validateValidator(prefix string, cfg ValidatorConfig) []string {
 		problems = append(problems, prefix+".min_score must be greater than 0 and less than or equal to 1")
 	}
 	return problems
+}
+
+func validateArtifact(prefix string, cfg ArtifactConfig) []string {
+	var problems []string
+	if strings.TrimSpace(cfg.StatusField) == "" && (len(cfg.PassStatuses) > 0 || len(cfg.WaitStatuses) > 0 || len(cfg.ReworkStatuses) > 0) {
+		problems = append(problems, prefix+".status_field must not be blank")
+	}
+	problems = append(problems, validateArtifactStatuses(prefix+".pass_statuses", cfg.PassStatuses)...)
+	problems = append(problems, validateArtifactStatuses(prefix+".wait_statuses", cfg.WaitStatuses)...)
+	problems = append(problems, validateArtifactStatuses(prefix+".rework_statuses", cfg.ReworkStatuses)...)
+	return problems
+}
+
+func validateArtifactStatuses(prefix string, values []string) []string {
+	for _, value := range values {
+		if strings.TrimSpace(value) == "" {
+			return []string{prefix + " values must not be blank"}
+		}
+	}
+	return nil
+}
+
+func normalizeArtifactStatuses(values []string) []string {
+	out := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		value = normalizeArtifactStatus(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func normalizeArtifactStatus(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
+}
+
+func artifactStatusIn(status string, values []string) bool {
+	status = normalizeArtifactStatus(status)
+	for _, value := range values {
+		if status == normalizeArtifactStatus(value) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeSeverities(values []string) []string {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -45,6 +45,26 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 			want: Config{Kind: KindHumanReview, Run: "", ApprovalLabel: DefaultApprovalLabel, CIFailureAction: CIFailureActionSkip},
 		},
 		{
+			name: "artifact gate gets status defaults and drops PR command settings",
+			cfg: Config{
+				Kind:                   "artifact-status",
+				Run:                    "make check",
+				RequireAutomatedReview: new(true),
+			},
+			want: Config{
+				Kind:            KindArtifact,
+				Run:             "",
+				ApprovalLabel:   DefaultApprovalLabel,
+				CIFailureAction: CIFailureActionSkip,
+				Artifact: ArtifactConfig{
+					StatusField:    DefaultArtifactStatusField,
+					PassStatuses:   []string{"approved", "complete", "completed", "pass", "passed", "valid"},
+					WaitStatuses:   []string{"pending", "review", "reviewing", "waiting"},
+					ReworkStatuses: []string{"changes_requested", "failed", "invalid", "rework"},
+				},
+			},
+		},
+		{
 			name: "validator defaults stay disabled with score threshold and p1 blocker",
 			cfg:  Config{Kind: KindCommand, Validator: ValidatorConfig{}},
 			want: Config{
@@ -68,6 +88,7 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 			got := Effective(tt.cfg)
 			want := tt.want
 			want.Validator = effectiveValidatorConfig(want.Validator)
+			want.Artifact = effectiveArtifactConfig(want.Artifact)
 			if !configsEqual(got, want) {
 				t.Fatalf("Effective() = %#v, want %#v", got, want)
 			}
@@ -353,6 +374,38 @@ func TestEvaluate(t *testing.T) {
 			labels: []string{" Approved-By-Human "},
 			want:   Decision{Action: ActionPass, Reason: ReasonReady},
 		},
+		{
+			name:  "artifact gate waits for missing status",
+			cfg:   Config{Kind: KindArtifact},
+			input: Summary{},
+			want:  Decision{Action: ActionWait, Reason: ReasonArtifactStatusMissing},
+		},
+		{
+			name:  "artifact gate waits for pending status without pull request",
+			cfg:   Config{Kind: KindArtifact},
+			input: Summary{ArtifactStatus: " Pending "},
+			want:  Decision{Action: ActionWait, Reason: ReasonArtifactStatusWait},
+		},
+		{
+			name:  "artifact gate routes rework status without pull request",
+			cfg:   Config{Kind: KindArtifact},
+			input: Summary{ArtifactStatus: "invalid"},
+			want:  Decision{Action: ActionRework, Reason: ReasonArtifactStatusRework},
+		},
+		{
+			name: "artifact gate passes custom valid status without pull request",
+			cfg: Config{
+				Kind: KindArtifact,
+				Artifact: ArtifactConfig{
+					StatusField:    "render_status",
+					PassStatuses:   []string{"ready"},
+					WaitStatuses:   []string{"queued"},
+					ReworkStatuses: []string{"recut"},
+				},
+			},
+			input: Summary{ArtifactStatus: "Ready"},
+			want:  Decision{Action: ActionPass, Reason: ReasonReady},
+		},
 	}
 
 	for _, tt := range tests {
@@ -485,7 +538,8 @@ func configsEqual(left Config, right Config) bool {
 		left.ApprovalLabel == right.ApprovalLabel &&
 		left.CIFailureAction == right.CIFailureAction &&
 		boolPointerEqual(left.RequireAutomatedReview, right.RequireAutomatedReview) &&
-		validatorConfigsEqual(left.Validator, right.Validator)
+		validatorConfigsEqual(left.Validator, right.Validator) &&
+		artifactConfigsEqual(left.Artifact, right.Artifact)
 }
 
 func boolPointerEqual(left *bool, right *bool) bool {
@@ -501,6 +555,25 @@ func validatorConfigsEqual(left ValidatorConfig, right ValidatorConfig) bool {
 	}
 	for i := range left.BlockOn {
 		if left.BlockOn[i] != right.BlockOn[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func artifactConfigsEqual(left ArtifactConfig, right ArtifactConfig) bool {
+	return left.StatusField == right.StatusField &&
+		stringSlicesEqual(left.PassStatuses, right.PassStatuses) &&
+		stringSlicesEqual(left.WaitStatuses, right.WaitStatuses) &&
+		stringSlicesEqual(left.ReworkStatuses, right.ReworkStatuses)
+}
+
+func stringSlicesEqual(left []string, right []string) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for i := range left {
+		if left[i] != right[i] {
 			return false
 		}
 	}

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -13,6 +13,9 @@ type AutoPromoteConfig struct {
 	QuietDuration      time.Duration
 	OptoutLabel        string
 	AllowedIssueLabels []string
+	SourceState        string
+	PassState          string
+	ReworkState        string
 	Gate               gate.Config
 }
 
@@ -26,6 +29,7 @@ type AutoPromoteSummary struct {
 	ReviewState                           string
 	P1Findings                            []AutoPromoteFinding
 	Validator                             gate.ValidatorResult
+	ArtifactStatus                        string
 	LastActivityAt                        *time.Time
 }
 
@@ -65,6 +69,9 @@ const (
 	AutoPromoteReasonValidatorRework                 AutoPromoteReason = "validator_rework"
 	AutoPromoteReasonValidatorScoreBelowThreshold    AutoPromoteReason = "validator_score_below_threshold"
 	AutoPromoteReasonValidatorBlockedSeverity        AutoPromoteReason = "validator_blocked_severity"
+	AutoPromoteReasonArtifactStatusMissing           AutoPromoteReason = "artifact_status_missing"
+	AutoPromoteReasonArtifactStatusWait              AutoPromoteReason = "artifact_status_wait"
+	AutoPromoteReasonArtifactStatusRework            AutoPromoteReason = "artifact_status_rework"
 )
 
 type AutoPromoteDecision struct {
@@ -92,12 +99,17 @@ func EvaluateAutoPromote(
 	if !autoPromoteAllowedIssueLabel(issue, cfg) {
 		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonLabelNotAllowed)
 	}
-	if autoPromoteMergeConflicts(summary.MergeableState) {
-		return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonMergeConflicts)
+	if gateRequiresPullRequest(cfg.Gate) {
+		if autoPromoteMergeConflicts(summary.MergeableState) {
+			return autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonMergeConflicts)
+		}
+		if strings.TrimSpace(summary.PullRequestHydrationUnavailableReason) != "" ||
+			strings.TrimSpace(summary.PullRequestHydrationDegradedReason) != "" {
+			return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable)
+		}
 	}
-	if strings.TrimSpace(summary.PullRequestHydrationUnavailableReason) != "" ||
-		strings.TrimSpace(summary.PullRequestHydrationDegradedReason) != "" {
-		return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable)
+	if strings.TrimSpace(summary.ArtifactStatus) == "" {
+		summary.ArtifactStatus = artifactStatusFromIssue(issue, cfg.Gate.Artifact.StatusField)
 	}
 	gateDecision := gate.Evaluate(cfg.Gate, issue.Labels, gateSummary(summary), now, gate.EvaluationOptions{
 		QuietDuration: cfg.QuietDuration,
@@ -122,6 +134,18 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	}
 	cfg.OptoutLabel = normalizeLabel(cfg.OptoutLabel)
 	cfg.AllowedIssueLabels = normalizeLabels(cfg.AllowedIssueLabels)
+	cfg.SourceState = strings.TrimSpace(cfg.SourceState)
+	if cfg.SourceState == "" {
+		cfg.SourceState = autoPromoteSourceState
+	}
+	cfg.PassState = strings.TrimSpace(cfg.PassState)
+	if cfg.PassState == "" {
+		cfg.PassState = autoPromoteMergingState
+	}
+	cfg.ReworkState = strings.TrimSpace(cfg.ReworkState)
+	if cfg.ReworkState == "" {
+		cfg.ReworkState = autoPromoteReworkState
+	}
 	cfg.Gate = gate.Effective(cfg.Gate)
 	return cfg
 }
@@ -194,8 +218,29 @@ func gateSummary(summary AutoPromoteSummary) gate.Summary {
 		ReviewState:        summary.ReviewState,
 		P1Findings:         gateFindings(summary.P1Findings),
 		Validator:          summary.Validator,
+		ArtifactStatus:     summary.ArtifactStatus,
 		LastActivityAt:     summary.LastActivityAt,
 	}
+}
+
+func gateRequiresPullRequest(cfg gate.Config) bool {
+	return gate.Effective(cfg).Kind != gate.KindArtifact
+}
+
+func artifactStatusFromIssue(issue connector.Issue, statusField string) string {
+	if issue.Deliverable != nil && strings.TrimSpace(issue.Deliverable.ValidationStatus) != "" {
+		return strings.TrimSpace(issue.Deliverable.ValidationStatus)
+	}
+	statusField = strings.TrimSpace(statusField)
+	if statusField == "" {
+		statusField = gate.DefaultArtifactStatusField
+	}
+	for key, value := range issue.Fields {
+		if strings.EqualFold(strings.TrimSpace(key), statusField) {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func gateFindings(findings []AutoPromoteFinding) []gate.Finding {
@@ -263,6 +308,12 @@ func autoPromoteReasonFromGate(reason gate.Reason) AutoPromoteReason {
 		return AutoPromoteReasonValidatorScoreBelowThreshold
 	case gate.ReasonValidatorBlockedSeverity:
 		return AutoPromoteReasonValidatorBlockedSeverity
+	case gate.ReasonArtifactStatusMissing:
+		return AutoPromoteReasonArtifactStatusMissing
+	case gate.ReasonArtifactStatusWait:
+		return AutoPromoteReasonArtifactStatusWait
+	case gate.ReasonArtifactStatusRework:
+		return AutoPromoteReasonArtifactStatusRework
 	default:
 		return AutoPromoteReasonDisabled
 	}

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -260,6 +260,78 @@ func TestEvaluateAutoPromote(t *testing.T) {
 				Reason: AutoPromoteReasonReady,
 			},
 		},
+		{
+			name: "artifact gate promotes from summary without pull request",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-artifact-summary", nil)
+				issue.PullRequest = nil
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindArtifact},
+			},
+			input: AutoPromoteSummary{
+				ArtifactStatus: "valid",
+				MergeableState: "dirty",
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+		{
+			name: "artifact gate promotes from configured work item field",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-artifact-field", nil)
+				issue.Fields = map[string]string{"render_status": "Ready"}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate: gate.Config{
+					Kind: gate.KindArtifact,
+					Artifact: gate.ArtifactConfig{
+						StatusField:    "render_status",
+						PassStatuses:   []string{"ready"},
+						WaitStatuses:   []string{"queued"},
+						ReworkStatuses: []string{"recut"},
+					},
+				},
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+		{
+			name: "artifact gate routes rework from deliverable validation status",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-artifact-deliverable", nil)
+				issue.Deliverable = &connector.Deliverable{ValidationStatus: "invalid"}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindArtifact},
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionRework,
+				Reason: AutoPromoteReasonArtifactStatusRework,
+			},
+		},
+		{
+			name:  "artifact gate waits when status is missing",
+			issue: autoPromoteTestIssue("issue-artifact-missing", nil),
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindArtifact},
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonArtifactStatusMissing,
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -45,7 +45,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 	}
 
 	result := autoPromoteTickResult{transitioned: map[string]struct{}{}}
-	for _, issue := range issuesInStates(issues, []string{autoPromoteSourceState}) {
+	for _, issue := range issuesInStates(issues, []string{cfg.SourceState}) {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
 			continue
@@ -67,7 +67,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 			}
 			decision = EvaluateAutoPromote(issue, summary, cfg, now)
 		}
-		targetState := autoPromoteTargetState(decision.Action)
+		targetState := autoPromoteTargetState(decision.Action, cfg)
 		if targetState == "" {
 			o.logAutoPromoteDecision(issue, decision, "")
 			continue
@@ -77,11 +77,8 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		}
 		result.transitioned[issueID] = struct{}{}
 		o.clearAutoPromotedIssueDispatchMemory(state, issueID)
-		if targetState == autoPromoteMergingState {
-			promoted := cloneIssue(issue)
-			promoted.State = targetState
-			promotedAt := now.UTC()
-			promoted.StageUpdatedAt = &promotedAt
+		if mergeWorkerIssue(promotedIssue(issue, targetState, now)) {
+			promoted := promotedIssue(issue, targetState, now)
 			o.recordMergeQueueEntered(state, promoted, now, "auto_promote")
 			result.dispatchCandidates = append(result.dispatchCandidates, promoted)
 			o.logMergeWorkerPickup(promoted, "auto_promote")
@@ -114,7 +111,7 @@ func (o *Orchestrator) reconcileStaleTodoPullRequestIssues(
 			continue
 		}
 		decision := staleTodoPullRequestDecision(issue, summary, o.cfg.AutoPromote, now)
-		targetState := staleTodoPullRequestTargetState(decision)
+		targetState := staleTodoPullRequestTargetState(decision, o.cfg.AutoPromote)
 		if targetState == "" {
 			o.logAutoPromoteDecision(issue, decision, "")
 			continue
@@ -729,15 +726,16 @@ func staleTodoPullRequestDecision(
 	return EvaluateAutoPromote(issue, summary, cfg, now)
 }
 
-func staleTodoPullRequestTargetState(decision AutoPromoteDecision) string {
-	if targetState := autoPromoteTargetState(decision.Action); targetState != "" {
+func staleTodoPullRequestTargetState(decision AutoPromoteDecision, cfg AutoPromoteConfig) string {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	if targetState := autoPromoteTargetState(decision.Action, cfg); targetState != "" {
 		return targetState
 	}
 	switch decision.Reason {
 	case AutoPromoteReasonMissingPullRequest:
 		return ""
 	default:
-		return autoPromoteSourceState
+		return cfg.SourceState
 	}
 }
 
@@ -1001,6 +999,7 @@ func validatorStageKey(issue connector.Issue) string {
 func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	summary := AutoPromoteSummary{
 		LastActivityAt: autoPromoteLastActivityAt(issue),
+		ArtifactStatus: artifactStatusFromIssue(issue, gate.DefaultArtifactStatusField),
 	}
 	if issue.PullRequest == nil {
 		return summary
@@ -1084,15 +1083,24 @@ func autoPromoteFindingsFromPullRequest(pullRequest *connector.PullRequest) []Au
 	return findings
 }
 
-func autoPromoteTargetState(action AutoPromoteAction) string {
+func autoPromoteTargetState(action AutoPromoteAction, cfg AutoPromoteConfig) string {
+	cfg = normalizeAutoPromoteConfig(cfg)
 	switch action {
 	case AutoPromoteActionPromote:
-		return autoPromoteMergingState
+		return cfg.PassState
 	case AutoPromoteActionRework:
-		return autoPromoteReworkState
+		return cfg.ReworkState
 	default:
 		return ""
 	}
+}
+
+func promotedIssue(issue connector.Issue, targetState string, now time.Time) connector.Issue {
+	promoted := cloneIssue(issue)
+	promoted.State = targetState
+	promotedAt := now.UTC()
+	promoted.StageUpdatedAt = &promotedAt
+	return promoted
 }
 
 func (o *Orchestrator) applyAutoPromoteDecision(

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -310,6 +310,43 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 	}
 }
 
+func TestObservedStatusFetchStatesForTickDoesNotThrottleCustomPassState(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			PassState:   "Ready for Pickup",
+			ReworkState: "Production Rework",
+			Gate: gate.Config{
+				Kind: gate.KindArtifact,
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Production Rework"},
+		ObservedStates: []string{"Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	state.Running["issue-merging"] = Running{
+		Issue: connector.Issue{
+			ID:    "issue-merging",
+			State: "Merging",
+		},
+	}
+	orch := Orchestrator{cfg: cfg}
+
+	got := orch.observedStatusFetchStatesForTick(&state)
+	want := []string{"Blocked", "Review", "Merging"}
+	if !autoPromoteTickStatesEqual(got, want) {
+		t.Fatalf("observedStatusFetchStatesForTick() = %#v, want %#v", got, want)
+	}
+}
+
 func TestTickAutoPromoteLogsNonTransitionDecisionsAtInfo(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -29,7 +29,14 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		if !ok {
 			continue
 		}
-		targetState := completedActiveReviewTargetState(issue, completed.FinalState, o.cfg.ActiveStates, o.cfg.TerminalStates)
+		targetState := completedActiveReviewTargetState(
+			issue,
+			completed.FinalState,
+			o.cfg.ActiveStates,
+			o.cfg.TerminalStates,
+			normalizeAutoPromoteConfig(o.cfg.AutoPromote).SourceState,
+			gateRequiresPullRequest(o.cfg.AutoPromote.Gate),
+		)
 		if targetState == "" {
 			continue
 		}
@@ -71,26 +78,40 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 	return handled
 }
 
-func completedActiveReviewTargetState(issue connector.Issue, finalState string, activeStates []string, terminalStates []string) string {
+func completedActiveReviewTargetState(
+	issue connector.Issue,
+	finalState string,
+	activeStates []string,
+	terminalStates []string,
+	reviewState string,
+	requirePullRequest bool,
+) string {
 	if !stateIn(issue.State, activeStates) || stateIn(issue.State, terminalStates) {
 		return ""
 	}
+	reviewState = strings.TrimSpace(reviewState)
+	if reviewState == "" {
+		reviewState = autoPromoteSourceState
+	}
 	switch normalizeState(issue.State) {
-	case normalizeState(autoPromoteSourceState), normalizeState(autoPromoteReworkState), normalizeState(autoPromoteMergingState):
+	case normalizeState(reviewState), normalizeState(autoPromoteReworkState), normalizeState(autoPromoteMergingState):
 		return ""
 	}
-	if !completedActiveIssueReadyForReview(issue) {
+	if !completedActiveIssueReadyForReview(issue, requirePullRequest) {
 		return ""
 	}
 	switch normalizeState(finalState) {
-	case "", normalizeState(FinalStateCompleted), normalizeState(autoPromoteSourceState):
-		return autoPromoteSourceState
+	case "", normalizeState(FinalStateCompleted), normalizeState(reviewState):
+		return reviewState
 	default:
 		return ""
 	}
 }
 
-func completedActiveIssueReadyForReview(issue connector.Issue) bool {
+func completedActiveIssueReadyForReview(issue connector.Issue, requirePullRequest bool) bool {
+	if !requirePullRequest {
+		return true
+	}
 	if issue.PullRequest == nil {
 		return false
 	}

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -10,37 +10,52 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name       string
-		issue      connector.Issue
-		finalState string
-		want       string
+		name               string
+		issue              connector.Issue
+		finalState         string
+		reviewState        string
+		requirePullRequest bool
+		want               string
 	}{
 		{
-			name:       "todo completed with open pull request advances to human review",
-			issue:      completionTransitionIssue("Todo", "OPEN"),
-			finalState: FinalStateCompleted,
-			want:       autoPromoteSourceState,
+			name:               "todo completed with open pull request advances to human review",
+			issue:              completionTransitionIssue("Todo", "OPEN"),
+			finalState:         FinalStateCompleted,
+			requirePullRequest: true,
+			want:               autoPromoteSourceState,
 		},
 		{
-			name:       "in progress completed with open pull request advances to human review",
-			issue:      completionTransitionIssue("In Progress", "OPEN"),
-			finalState: FinalStateCompleted,
-			want:       autoPromoteSourceState,
+			name:               "in progress completed with open pull request advances to human review",
+			issue:              completionTransitionIssue("In Progress", "OPEN"),
+			finalState:         FinalStateCompleted,
+			requirePullRequest: true,
+			want:               autoPromoteSourceState,
 		},
 		{
-			name:       "rework completed with open pull request waits for dispatch",
-			issue:      completionTransitionIssue("Rework", "OPEN"),
-			finalState: FinalStateCompleted,
+			name:               "artifact todo completed without pull request advances to configured review",
+			issue:              completionTransitionIssue("Todo", ""),
+			finalState:         FinalStateCompleted,
+			reviewState:        "Review",
+			requirePullRequest: false,
+			want:               "Review",
 		},
 		{
-			name:       "merging completed with open pull request waits for merge lifecycle",
-			issue:      completionTransitionIssue("Merging", "OPEN"),
-			finalState: FinalStateCompleted,
+			name:               "rework completed with open pull request waits for dispatch",
+			issue:              completionTransitionIssue("Rework", "OPEN"),
+			finalState:         FinalStateCompleted,
+			requirePullRequest: true,
 		},
 		{
-			name:       "todo completed without pull request waits",
-			issue:      completionTransitionIssue("Todo", ""),
-			finalState: FinalStateCompleted,
+			name:               "merging completed with open pull request waits for merge lifecycle",
+			issue:              completionTransitionIssue("Merging", "OPEN"),
+			finalState:         FinalStateCompleted,
+			requirePullRequest: true,
+		},
+		{
+			name:               "todo completed without pull request waits when pull request required",
+			issue:              completionTransitionIssue("Todo", ""),
+			finalState:         FinalStateCompleted,
+			requirePullRequest: true,
 		},
 	}
 
@@ -50,7 +65,18 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got := completedActiveReviewTargetState(tt.issue, tt.finalState, activeStates, terminalStates)
+			reviewState := tt.reviewState
+			if reviewState == "" {
+				reviewState = autoPromoteSourceState
+			}
+			got := completedActiveReviewTargetState(
+				tt.issue,
+				tt.finalState,
+				activeStates,
+				terminalStates,
+				reviewState,
+				tt.requirePullRequest,
+			)
 			if got != tt.want {
 				t.Fatalf("completedActiveReviewTargetState() = %q, want %q", got, tt.want)
 			}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -45,8 +45,6 @@ const (
 	mergeWorkerTerminalStateMissing   = "merge worker completed without reaching a terminal issue or pull request state"
 )
 
-var prPipelineStates = []string{"Human Review", "Merging"}
-
 var (
 	ErrMissingConnector = errors.New("orchestrator connector is required")
 	ErrStopped          = errors.New("orchestrator stopped")
@@ -193,6 +191,9 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			QuietDuration:      durationFromSeconds(cfg.Agent.AutoPromote.QuietSeconds),
 			OptoutLabel:        cfg.Agent.AutoPromote.OptoutLabel,
 			AllowedIssueLabels: append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
+			SourceState:        cfg.Agent.AutoPromote.SourceState,
+			PassState:          cfg.Agent.AutoPromote.PassState,
+			ReworkState:        cfg.Agent.AutoPromote.ReworkState,
 			Gate:               gate.Effective(cfg.Gate),
 		}),
 		Plan: gate.EffectivePlan(cfg.Plan),
@@ -437,7 +438,7 @@ func (o *Orchestrator) ForceQuit(ctx context.Context) error {
 }
 
 func (o *Orchestrator) observedStatusFetchStates() []string {
-	states := append([]string{blockedStatusState}, prPipelineFetchStates()...)
+	states := append([]string{blockedStatusState}, autoPromoteFetchStates(o.cfg.AutoPromote)...)
 	if cfg := gate.EffectivePlan(o.cfg.Plan); cfg.Enabled {
 		states = append(states, cfg.Stop)
 	}
@@ -451,7 +452,7 @@ func (o *Orchestrator) observedStatusFetchStates() []string {
 
 func (o *Orchestrator) observedStatusFetchStatesForTick(state *State) []string {
 	states := o.observedStatusFetchStates()
-	if o.mergeWorkerLocalSlotsAvailable(state) {
+	if !autoPromoteUsesMergePassState(o.cfg.AutoPromote) || o.mergeWorkerLocalSlotsAvailable(state) {
 		return states
 	}
 	return statesWithoutState(states, autoPromoteMergingState)
@@ -474,10 +475,20 @@ func statesWithoutState(states []string, omit string) []string {
 	return out
 }
 
-func prPipelineFetchStates() []string {
-	states := make([]string, 0, len(prPipelineStates))
-	seen := make(map[string]struct{}, len(prPipelineStates))
-	for _, state := range prPipelineStates {
+func autoPromoteUsesMergePassState(cfg AutoPromoteConfig) bool {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	return normalizeState(cfg.PassState) == normalizeState(autoPromoteMergingState)
+}
+
+func autoPromoteFetchStates(cfg AutoPromoteConfig) []string {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	candidates := []string{cfg.SourceState}
+	if autoPromoteUsesMergePassState(cfg) {
+		candidates = append(candidates, cfg.PassState)
+	}
+	states := make([]string, 0, len(candidates))
+	seen := make(map[string]struct{}, len(candidates))
+	for _, state := range candidates {
 		key := normalizeState(state)
 		if key == "" {
 			continue

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -327,11 +327,27 @@ func telemetryIssue(issue connector.Issue, quietDuration time.Duration, pollInte
 		Comments:              telemetryIssueComments(issue.Comments),
 		BlockedBy:             telemetryBlockedRefs(issue.BlockedBy),
 		PullRequest:           telemetryPullRequest(issue, quietDuration, pollInterval),
+		Deliverable:           telemetryDeliverable(issue.Deliverable),
+		Metadata:              cloneStringMap(issue.Metadata),
 		CreatedAt:             timePointerFromPtr(issue.CreatedAt),
 		UpdatedAt:             timePointerFromPtr(issue.UpdatedAt),
 		StageUpdatedAt:        timePointerFromPtr(issue.StageUpdatedAt),
 		CurrentLaneEnteredAt:  timePointerFromPtr(laneEnteredAt),
 		CurrentLaneAgeSeconds: telemetryIssueLaneAgeSeconds(laneEnteredAt, now),
+	}
+}
+
+func telemetryDeliverable(deliverable *connector.Deliverable) *telemetry.Deliverable {
+	if deliverable == nil {
+		return nil
+	}
+	return &telemetry.Deliverable{
+		Kind:             deliverable.Kind,
+		Path:             deliverable.Path,
+		ReviewURL:        deliverable.ReviewURL,
+		ValidationStatus: deliverable.ValidationStatus,
+		ExternalID:       deliverable.ExternalID,
+		Metadata:         cloneStringMap(deliverable.Metadata),
 	}
 }
 

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -106,6 +106,48 @@ func TestStateSnapshotCarriesIssueComments(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotCarriesArtifactDeliverableMetadata(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)
+	state := newState(normalizeConfig(Config{}))
+	state.Pipeline = []connector.Issue{{
+		ID:         "ad-1",
+		Identifier: "store/ad-1",
+		Title:      "Summer sale video ad",
+		State:      "Review",
+		Metadata:   map[string]string{"store": "creswood"},
+		Deliverable: &connector.Deliverable{
+			Kind:             "video_ad",
+			Path:             "outputs/ad-1/manifest.json",
+			ReviewURL:        "http://127.0.0.1:8080/review/ad-1",
+			ValidationStatus: "pending",
+			ExternalID:       "creative-101",
+			Metadata:         map[string]string{"aspect_ratio": "9:16"},
+		},
+	}}
+
+	snapshot := state.Snapshot(now)
+	if len(snapshot.Pipeline) != 1 {
+		t.Fatalf("Pipeline len = %d, want 1", len(snapshot.Pipeline))
+	}
+	got := snapshot.Pipeline[0]
+	if got.Metadata["store"] != "creswood" {
+		t.Fatalf("Metadata = %#v", got.Metadata)
+	}
+	if got.Deliverable == nil {
+		t.Fatal("Deliverable = nil, want artifact deliverable")
+	}
+	if got.Deliverable.Kind != "video_ad" ||
+		got.Deliverable.Path != "outputs/ad-1/manifest.json" ||
+		got.Deliverable.ReviewURL != "http://127.0.0.1:8080/review/ad-1" ||
+		got.Deliverable.ValidationStatus != "pending" ||
+		got.Deliverable.ExternalID != "creative-101" ||
+		got.Deliverable.Metadata["aspect_ratio"] != "9:16" {
+		t.Fatalf("Deliverable = %#v", got.Deliverable)
+	}
+}
+
 func TestStateSnapshotIncludesAuthHealth(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -254,6 +254,11 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		cloned.PullRequest = &pullRequest
 	}
+	if issue.Deliverable != nil {
+		deliverable := *issue.Deliverable
+		deliverable.Metadata = cloneStringMap(issue.Deliverable.Metadata)
+		cloned.Deliverable = &deliverable
+	}
 	if issue.CreatedAt != nil {
 		createdAt := *issue.CreatedAt
 		cloned.CreatedAt = &createdAt
@@ -272,6 +277,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	cloned.Comments = cloneIssueComments(issue.Comments)
 	cloned.Assignees = cloneStringSlice(issue.Assignees)
 	cloned.Fields = cloneStringMap(issue.Fields)
+	cloned.Metadata = cloneStringMap(issue.Metadata)
 	return cloned
 }
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -449,7 +449,7 @@ func (o *Orchestrator) refreshTransitionSets(
 	}
 	if fetched.statusOK {
 		transitionIssues = append(transitionIssues, fetched.status...)
-		state.Pipeline = issuesInStates(fetched.status, prPipelineFetchStates())
+		state.Pipeline = issuesInStates(fetched.status, autoPromoteFetchStates(o.cfg.AutoPromote))
 		if !pipelineRefreshOK || !o.mergeWorkerLocalSlotsAvailable(state) {
 			state.Pipeline = mergeIssueSlices(state.Pipeline, previous.pipeline)
 		}

--- a/internal/project/connector_config_test.go
+++ b/internal/project/connector_config_test.go
@@ -1,10 +1,12 @@
 package project
 
 import (
+	"path/filepath"
 	"reflect"
 	"testing"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
 
 func TestTrackerStateMapConvertsWorkflowMap(t *testing.T) {
@@ -22,6 +24,38 @@ func TestTrackerStateMapConvertsWorkflowMap(t *testing.T) {
 
 	if got := trackerStateMap(workflowconfig.StringValue("$STATE_MAP_JSON")); got != nil {
 		t.Fatalf("trackerStateMap(string) = %#v, want nil", got)
+	}
+}
+
+func TestWorkflowConfigWithProjectPathsResolvesArtifactWorkflowPaths(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerLocalSQLite
+	cfg.Tracker.LocalSQLite.Path = ".detent/work-items.db"
+	cfg.Workspace.Kind = workflowconfig.WorkspaceFilesystem
+	cfg.Workspace.Root = ".detent/workspaces"
+	cfg.Workspace.SourceRoot = "assets"
+	cfg.Workspace.OutputRoot = ".detent/output"
+	cfg.Deliverable.Kind = workflowconfig.DeliverableArtifact
+	cfg.Deliverable.OutputRoot = ".detent/deliverables"
+
+	got := workflowConfigWithProjectIdentity(globalconfig.Project{Workdir: workdir}, cfg)
+	if got.Tracker.LocalSQLite.Path != filepath.Join(workdir, ".detent", "work-items.db") {
+		t.Fatalf("Tracker.LocalSQLite.Path = %q", got.Tracker.LocalSQLite.Path)
+	}
+	if got.Workspace.Root != filepath.Join(workdir, ".detent", "workspaces") {
+		t.Fatalf("Workspace.Root = %q", got.Workspace.Root)
+	}
+	if got.Workspace.SourceRoot != filepath.Join(workdir, "assets") {
+		t.Fatalf("Workspace.SourceRoot = %q", got.Workspace.SourceRoot)
+	}
+	if got.Workspace.OutputRoot != filepath.Join(workdir, ".detent", "output") {
+		t.Fatalf("Workspace.OutputRoot = %q", got.Workspace.OutputRoot)
+	}
+	if got.Deliverable.OutputRoot != filepath.Join(workdir, ".detent", "deliverables") {
+		t.Fatalf("Deliverable.OutputRoot = %q", got.Deliverable.OutputRoot)
 	}
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"log/slog"
+	"path/filepath"
 	"strings"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	configwatcher "github.com/digitaldrywood/detent/internal/config/watcher"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/factory"
+	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
@@ -827,6 +829,7 @@ func workflowConfigWithProjectIdentity(
 	project globalconfig.Project,
 	workflow workflowconfig.Config,
 ) workflowconfig.Config {
+	workflow = workflowConfigWithProjectPaths(project, workflow)
 	if !project.Identity.Configured() {
 		return workflow
 	}
@@ -834,6 +837,33 @@ func workflowConfigWithProjectIdentity(
 	identity.Normalize()
 	workflow.Identity = identity
 	return workflow
+}
+
+func workflowConfigWithProjectPaths(project globalconfig.Project, workflow workflowconfig.Config) workflowconfig.Config {
+	workdir := strings.TrimSpace(project.Workdir)
+	if workdir == "" {
+		return workflow
+	}
+	if workflow.Tracker.Kind == workflowconfig.TrackerLocalSQLite {
+		workflow.Tracker.LocalSQLite.Path = projectRelativePath(workdir, workflow.Tracker.LocalSQLite.Path)
+	}
+	if workflow.Workspace.Kind == workflowconfig.WorkspaceFilesystem {
+		workflow.Workspace.Root = projectRelativePath(workdir, workflow.Workspace.Root)
+		workflow.Workspace.SourceRoot = projectRelativePath(workdir, workflow.Workspace.SourceRoot)
+		workflow.Workspace.OutputRoot = projectRelativePath(workdir, workflow.Workspace.OutputRoot)
+	}
+	if workflow.Deliverable.Kind == workflowconfig.DeliverableArtifact {
+		workflow.Deliverable.OutputRoot = projectRelativePath(workdir, workflow.Deliverable.OutputRoot)
+	}
+	return workflow
+}
+
+func projectRelativePath(base string, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || filepath.IsAbs(path) || path == "~" || strings.HasPrefix(path, "~/") {
+		return path
+	}
+	return filepath.Clean(filepath.Join(base, path))
 }
 
 func workflowConfigWithGitHubToken(workflow workflowconfig.Config, token string) workflowconfig.Config {
@@ -989,8 +1019,16 @@ func defaultConnectorFactory(cfg workflowconfig.Config) (connector.Connector, er
 
 func defaultConnectorFactoryWithRefresh(cfg workflowconfig.Config, refreshGitHubToken func(context.Context) (string, error)) (connector.Connector, error) {
 	return factory.NewFromConfig(factory.Config{
-		Kind:                        cfg.Tracker.Kind,
-		Memory:                      memory.Config{Issues: cfg.Tracker.Issues},
+		Kind:   cfg.Tracker.Kind,
+		Memory: memory.Config{Issues: cfg.Tracker.Issues},
+		LocalSQLite: local.Config{
+			Path:           cfg.Tracker.LocalSQLite.Path,
+			ProjectID:      cfg.Tracker.LocalSQLite.ProjectID,
+			Issues:         cfg.Tracker.Issues,
+			ActiveStates:   cfg.Tracker.ActiveStates,
+			ObservedStates: cfg.Tracker.ObservedStates,
+			TerminalStates: cfg.Tracker.TerminalStates,
+		},
 		Endpoint:                    cfg.Tracker.Endpoint,
 		APIKey:                      cfg.Tracker.APIKey,
 		GitHubTokenRefresh:          refreshGitHubToken,

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -60,7 +60,7 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 		return "", err
 	}
 
-	rendered = prependWorkspaceIsolationBlock(rendered, opts.WorkspacePath, opts.Branch)
+	rendered = prependWorkspaceIsolationBlock(rendered, workflow.Config, opts.WorkspacePath, opts.Branch)
 	if opts.PlanOnly {
 		rendered = appendPlanOnlyBlock(rendered, workflow.Config.Plan)
 	}
@@ -70,8 +70,12 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 		return "", err
 	}
 
+	rendered = appendDeliverableBlock(rendered, workflow.Config, issue, opts.WorkspacePath)
 	rendered = appendGateBlock(rendered, workflow.Config.Gate)
 	rendered = appendAvailableSkills(rendered, AvailableSkillsBlock(opts.AvailableSkills))
+	if promptDeliverableKind(workflow.Config.Deliverable) != config.DeliverablePullRequest {
+		return rendered, nil
+	}
 	return appendClosingReferenceInstruction(rendered, issue), nil
 }
 
@@ -126,10 +130,20 @@ func BuildValidatorPrompt(workflow config.Workflow, issue connector.Issue, opts 
 	return b.String()
 }
 
-func prependWorkspaceIsolationBlock(prompt string, workspacePath string, branch string) string {
+func prependWorkspaceIsolationBlock(prompt string, cfg config.Config, workspacePath string, branch string) string {
 	workspacePath = strings.TrimSpace(workspacePath)
 	branch = strings.TrimSpace(branch)
-	if workspacePath == "" || branch == "" {
+	if workspacePath == "" {
+		return prompt
+	}
+	if cfg.Workspace.Kind == config.WorkspaceFilesystem {
+		block := fmt.Sprintf("## Detent artifact workspace\n\n"+
+			"You are already isolated in a Detent-created filesystem workspace at `%s`. This workspace is authoritative and managed by Detent.\n\n"+
+			"Do not require a git branch, pull request, CI run, or merge train unless the workflow instructions explicitly ask for one.",
+			workspacePath)
+		return block + "\n\n" + strings.TrimLeft(prompt, " \t\r\n")
+	}
+	if branch == "" {
 		return prompt
 	}
 
@@ -140,6 +154,69 @@ func prependWorkspaceIsolationBlock(prompt string, workspacePath string, branch 
 		workspacePath, branch)
 
 	return block + "\n\n" + strings.TrimLeft(prompt, " \t\r\n")
+}
+
+func appendDeliverableBlock(prompt string, cfg config.Config, issue connector.Issue, workspacePath string) string {
+	deliverable := cfg.Deliverable
+	if promptDeliverableKind(deliverable) != config.DeliverableArtifact && issue.Deliverable == nil {
+		return prompt
+	}
+
+	var b strings.Builder
+	b.WriteString("## Deliverable\n\n")
+	if promptDeliverableKind(deliverable) == config.DeliverableArtifact {
+		b.WriteString("Produce artifact deliverables for this work item instead of a pull request.\n")
+	}
+	if workspacePath = strings.TrimSpace(workspacePath); workspacePath != "" {
+		b.WriteString("- workspace: `")
+		b.WriteString(workspacePath)
+		b.WriteString("`\n")
+	}
+	if outputRoot := strings.TrimSpace(deliverable.OutputRoot); outputRoot != "" {
+		b.WriteString("- configured output root: `")
+		b.WriteString(outputRoot)
+		b.WriteString("`\n")
+	}
+	if reviewURL := strings.TrimSpace(deliverable.ReviewURL); reviewURL != "" {
+		b.WriteString("- review URL: ")
+		b.WriteString(reviewURL)
+		b.WriteString("\n")
+	}
+	if issue.Deliverable != nil {
+		if kind := strings.TrimSpace(issue.Deliverable.Kind); kind != "" {
+			b.WriteString("- work item deliverable kind: ")
+			b.WriteString(kind)
+			b.WriteString("\n")
+		}
+		if path := strings.TrimSpace(issue.Deliverable.Path); path != "" {
+			b.WriteString("- work item artifact path: `")
+			b.WriteString(path)
+			b.WriteString("`\n")
+		}
+		if reviewURL := strings.TrimSpace(issue.Deliverable.ReviewURL); reviewURL != "" {
+			b.WriteString("- work item review URL: ")
+			b.WriteString(reviewURL)
+			b.WriteString("\n")
+		}
+		if externalID := strings.TrimSpace(issue.Deliverable.ExternalID); externalID != "" {
+			b.WriteString("- external id: ")
+			b.WriteString(externalID)
+			b.WriteString("\n")
+		}
+	}
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + strings.TrimRight(b.String(), "\n")
+}
+
+func promptDeliverableKind(cfg config.Deliverable) string {
+	kind := strings.ToLower(strings.TrimSpace(cfg.Kind))
+	switch kind {
+	case "", "pr", "pull-request":
+		return config.DeliverablePullRequest
+	case config.DeliverableArtifact, "artifacts", "file", "files":
+		return config.DeliverableArtifact
+	default:
+		return kind
+	}
 }
 
 func appendPlanOnlyBlock(prompt string, cfg gate.PlanConfig) string {
@@ -259,11 +336,21 @@ func promptAssigns(cfg config.Config, issue connector.Issue, opts PromptOptions)
 		},
 		"workspace": map[string]any{
 			"auto_branch": autoBranch,
+			"kind":        cfg.Workspace.Kind,
 			"path":        opts.WorkspacePath,
 			"branch":      opts.Branch,
 		},
-		"gate": gateAssigns(cfg.Gate),
-		"plan": planAssigns(cfg.Plan),
+		"deliverable": deliverableAssigns(cfg.Deliverable),
+		"gate":        gateAssigns(cfg.Gate),
+		"plan":        planAssigns(cfg.Plan),
+	}
+}
+
+func deliverableAssigns(cfg config.Deliverable) map[string]any {
+	return map[string]any{
+		"kind":        cfg.Kind,
+		"output_root": cfg.OutputRoot,
+		"review_url":  cfg.ReviewURL,
 	}
 }
 
@@ -315,10 +402,33 @@ func issueAssigns(issue connector.Issue) map[string]any {
 		"blocked_by":         issue.BlockedBy,
 		"labels":             issue.Labels,
 		"fields":             issue.Fields,
+		"metadata":           issue.Metadata,
+		"deliverable":        issueDeliverableAssigns(issue.Deliverable),
 		"assigned_to_worker": issue.AssignedToWorker,
 		"created_at":         timePointerValue(issue.CreatedAt),
 		"updated_at":         timePointerValue(issue.UpdatedAt),
 		"model_override":     issue.ModelOverride,
+	}
+}
+
+func issueDeliverableAssigns(deliverable *connector.Deliverable) map[string]any {
+	if deliverable == nil {
+		return map[string]any{
+			"kind":              "",
+			"path":              "",
+			"review_url":        "",
+			"validation_status": "",
+			"external_id":       "",
+			"metadata":          map[string]string{},
+		}
+	}
+	return map[string]any{
+		"kind":              deliverable.Kind,
+		"path":              deliverable.Path,
+		"review_url":        deliverable.ReviewURL,
+		"validation_status": deliverable.ValidationStatus,
+		"external_id":       deliverable.ExternalID,
+		"metadata":          deliverable.Metadata,
 	}
 }
 

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -219,6 +219,61 @@ func TestBuildPromptAppendsGitHubClosingReferenceInstruction(t *testing.T) {
 	}
 }
 
+func TestBuildPromptArtifactWorkflowOmitsPullRequestContract(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := filepath.Join(t.TempDir(), "ad-1")
+	prompt, err := BuildPrompt(config.Workflow{
+		Config: config.Config{
+			Workspace: config.Workspace{Kind: config.WorkspaceFilesystem},
+			Deliverable: config.Deliverable{
+				Kind:       config.DeliverableArtifact,
+				OutputRoot: "/tmp/detent-renders",
+				ReviewURL:  "http://127.0.0.1:8080/review/ad-1",
+			},
+			Gate: gate.Config{Kind: gate.KindArtifact},
+		},
+		Prompt: "Deliver {{ deliverable.kind }} from {{ workspace.kind }} status={{ issue.deliverable.validation_status }} store={{ issue.metadata.store }}",
+	}, connector.Issue{
+		Identifier: "digitaldrywood/detent#780",
+		Title:      "Artifact prompt",
+		Metadata:   map[string]string{"store": "creswood"},
+		Deliverable: &connector.Deliverable{
+			Kind:             "video_ad",
+			Path:             "outputs/ad-1/manifest.json",
+			ReviewURL:        "http://127.0.0.1:8080/review/ad-1",
+			ValidationStatus: "pending",
+			ExternalID:       "creative-101",
+		},
+	}, PromptOptions{
+		WorkspacePath: workspacePath,
+	})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"## Detent artifact workspace",
+		"filesystem workspace at `" + workspacePath + "`",
+		"Deliver artifact from filesystem status=pending store=creswood",
+		"## Deliverable",
+		"Produce artifact deliverables for this work item instead of a pull request.",
+		"- configured output root: `/tmp/detent-renders`",
+		"- work item artifact path: `outputs/ad-1/manifest.json`",
+		"## Validation gate",
+		"artifact status",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	for _, forbidden := range []string{"Fixes #780", "pull request in Human Review"} {
+		if strings.Contains(prompt, forbidden) {
+			t.Fatalf("prompt contains %q, want omitted:\n%s", forbidden, prompt)
+		}
+	}
+}
+
 func TestBuildPromptRejectsUnknownTemplateVariables(t *testing.T) {
 	t.Parallel()
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -177,33 +177,44 @@ type Counts struct {
 }
 
 type Issue struct {
-	ID                    string         `json:"issue_id"`
-	Identifier            string         `json:"identifier,omitempty"`
-	ProjectID             string         `json:"project_id,omitempty"`
-	URL                   string         `json:"url,omitempty"`
-	Title                 string         `json:"title,omitempty"`
-	Description           string         `json:"description,omitempty"`
-	State                 string         `json:"state,omitempty"`
-	Labels                []string       `json:"labels,omitempty"`
-	Assignees             []string       `json:"assignees,omitempty"`
-	Comments              []IssueComment `json:"comments,omitempty"`
-	BlockedBy             []BlockedRef   `json:"blocked_by,omitempty"`
-	PullRequest           *PullRequest   `json:"pull_request,omitempty"`
-	MergeTiming           *MergeTiming   `json:"merge_timing,omitempty"`
-	Owner                 string         `json:"owner,omitempty"`
-	LeaseRenewedAt        *time.Time     `json:"lease_renewed_at,omitempty"`
-	LeaseExpiresAt        *time.Time     `json:"lease_expires_at,omitempty"`
-	LeaseStale            bool           `json:"lease_stale,omitempty"`
-	CreatedAt             *time.Time     `json:"created_at,omitempty"`
-	UpdatedAt             *time.Time     `json:"updated_at,omitempty"`
-	StageUpdatedAt        *time.Time     `json:"stage_updated_at,omitempty"`
-	CurrentLaneEnteredAt  *time.Time     `json:"current_lane_entered_at,omitempty"`
-	CurrentLaneAgeSeconds int64          `json:"current_lane_age_seconds,omitempty"`
+	ID                    string            `json:"issue_id"`
+	Identifier            string            `json:"identifier,omitempty"`
+	ProjectID             string            `json:"project_id,omitempty"`
+	URL                   string            `json:"url,omitempty"`
+	Title                 string            `json:"title,omitempty"`
+	Description           string            `json:"description,omitempty"`
+	State                 string            `json:"state,omitempty"`
+	Labels                []string          `json:"labels,omitempty"`
+	Assignees             []string          `json:"assignees,omitempty"`
+	Comments              []IssueComment    `json:"comments,omitempty"`
+	BlockedBy             []BlockedRef      `json:"blocked_by,omitempty"`
+	PullRequest           *PullRequest      `json:"pull_request,omitempty"`
+	Deliverable           *Deliverable      `json:"deliverable,omitempty"`
+	Metadata              map[string]string `json:"metadata,omitempty"`
+	MergeTiming           *MergeTiming      `json:"merge_timing,omitempty"`
+	Owner                 string            `json:"owner,omitempty"`
+	LeaseRenewedAt        *time.Time        `json:"lease_renewed_at,omitempty"`
+	LeaseExpiresAt        *time.Time        `json:"lease_expires_at,omitempty"`
+	LeaseStale            bool              `json:"lease_stale,omitempty"`
+	CreatedAt             *time.Time        `json:"created_at,omitempty"`
+	UpdatedAt             *time.Time        `json:"updated_at,omitempty"`
+	StageUpdatedAt        *time.Time        `json:"stage_updated_at,omitempty"`
+	CurrentLaneEnteredAt  *time.Time        `json:"current_lane_entered_at,omitempty"`
+	CurrentLaneAgeSeconds int64             `json:"current_lane_age_seconds,omitempty"`
 }
 
 type IssueComment struct {
 	Body string `json:"body,omitempty"`
 	URL  string `json:"url,omitempty"`
+}
+
+type Deliverable struct {
+	Kind             string            `json:"kind,omitempty"`
+	Path             string            `json:"path,omitempty"`
+	ReviewURL        string            `json:"review_url,omitempty"`
+	ValidationStatus string            `json:"validation_status,omitempty"`
+	ExternalID       string            `json:"external_id,omitempty"`
+	Metadata         map[string]string `json:"metadata,omitempty"`
 }
 
 type BlockedRef struct {

--- a/internal/workspace/filesystem.go
+++ b/internal/workspace/filesystem.go
@@ -1,0 +1,321 @@
+package workspace
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	commandshell "github.com/digitaldrywood/detent/internal/shell"
+)
+
+type FilesystemOptions struct {
+	Root       string
+	SourceRoot string
+	OutputRoot string
+	Hooks      Hooks
+	Logger     *slog.Logger
+}
+
+type Filesystem struct {
+	root       string
+	sourceRoot string
+	outputRoot string
+	hooks      Hooks
+	logger     *slog.Logger
+}
+
+func NewFilesystem(opts FilesystemOptions) (*Filesystem, error) {
+	root, err := prepareRoot(opts.Root)
+	if err != nil {
+		return nil, err
+	}
+	sourceRoot := strings.TrimSpace(opts.SourceRoot)
+	if sourceRoot != "" {
+		sourceRoot, err = canonicalExistingPath(sourceRoot)
+		if err != nil {
+			return nil, fmt.Errorf("source root: %w", err)
+		}
+	}
+	outputRoot := strings.TrimSpace(opts.OutputRoot)
+	if outputRoot != "" {
+		outputRoot, err = prepareRoot(outputRoot)
+		if err != nil {
+			return nil, fmt.Errorf("output root: %w", err)
+		}
+	}
+	hooks := opts.Hooks
+	if hooks.Timeout == 0 {
+		hooks.Timeout = defaultHookTimeout
+	}
+	if hooks.Timeout < 0 {
+		return nil, errors.New("hooks timeout must be greater than or equal to 0")
+	}
+	hooks.Shell = commandshell.Normalize(hooks.Shell)
+	logger := opts.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Filesystem{
+		root:       root,
+		sourceRoot: sourceRoot,
+		outputRoot: outputRoot,
+		hooks:      hooks,
+		logger:     logger,
+	}, nil
+}
+
+func (f *Filesystem) Create(ctx context.Context, issue Issue) (Info, error) {
+	info, err := f.infoForIssue(issue)
+	if err != nil {
+		return Info{}, err
+	}
+	exists, isDir, err := pathExists(info.Path)
+	if err != nil {
+		return Info{}, err
+	}
+	if exists && !isDir {
+		return Info{}, fmt.Errorf("workspace path exists and is not a directory: %s", info.Path)
+	}
+	created := false
+	if !exists {
+		if err := os.MkdirAll(info.Path, 0o700); err != nil {
+			return Info{}, fmt.Errorf("create filesystem workspace: %w", err)
+		}
+		created = true
+	}
+	if err := os.MkdirAll(filepath.Join(info.Path, "artifacts"), 0o700); err != nil {
+		return Info{}, fmt.Errorf("create artifact directory: %w", err)
+	}
+	if f.outputRoot != "" {
+		outputPath, err := validateWorkspacePath(f.outputRoot, filepath.Join(f.outputRoot, info.Key))
+		if err != nil {
+			return Info{}, err
+		}
+		if err := os.MkdirAll(outputPath, 0o700); err != nil {
+			return Info{}, fmt.Errorf("create output workspace: %w", err)
+		}
+	}
+	info.Created = created
+	if created {
+		if err := f.runHook(ctx, "after_create", f.hooks.AfterCreate, info, issue); err != nil {
+			if cleanupErr := os.RemoveAll(info.Path); cleanupErr != nil {
+				f.logger.Warn("failed to clean filesystem workspace after after_create hook error", slog.String("path", info.Path), slog.Any("error", cleanupErr))
+			}
+			return Info{}, err
+		}
+	}
+	return info, nil
+}
+
+func (f *Filesystem) Cleanup(ctx context.Context, identifier string) error {
+	_, err := f.CleanupIssue(ctx, Issue{Identifier: identifier})
+	return err
+}
+
+func (f *Filesystem) CleanupIssue(ctx context.Context, issue Issue) (CleanupResult, error) {
+	info, err := f.infoForIssue(issue)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	result := CleanupResult{}
+	exists, _, err := pathExists(info.Path)
+	if err != nil {
+		return CleanupResult{}, err
+	}
+	if !exists {
+		return result, nil
+	}
+	result.Processes = reapWorkspaceProcesses(ctx, info.Path, f.logger)
+	if err := f.runHook(ctx, "before_remove", f.hooks.BeforeRemove, info, issue); err != nil {
+		f.logger.Warn("filesystem workspace before_remove hook failed", slog.String("path", info.Path), slog.Any("error", err))
+	}
+	if err := os.RemoveAll(info.Path); err != nil {
+		return CleanupResult{}, fmt.Errorf("remove filesystem workspace: %w", err)
+	}
+	result.Worktrees = 1
+	return result, nil
+}
+
+func (f *Filesystem) BeforeRun(ctx context.Context, info Info, issue Issue) error {
+	normalized, err := f.normalizeInfo(info, issue)
+	if err != nil {
+		return err
+	}
+	return f.runHook(ctx, "before_run", f.hooks.BeforeRun, normalized, issue)
+}
+
+func (f *Filesystem) AfterRun(ctx context.Context, info Info, issue Issue) {
+	normalized, err := f.normalizeInfo(info, issue)
+	if err != nil {
+		f.logger.Warn("filesystem workspace after_run path validation failed", slog.String("path", info.Path), slog.Any("error", err))
+		return
+	}
+	if err := f.runHook(ctx, "after_run", f.hooks.AfterRun, normalized, issue); err != nil {
+		f.logger.Warn("filesystem workspace after_run hook failed", slog.String("path", normalized.Path), slog.Any("error", err))
+	}
+}
+
+func (f *Filesystem) DiffStat(_ context.Context, info Info, issue Issue) (DiffStat, error) {
+	normalized, err := f.normalizeInfo(info, issue)
+	if err != nil {
+		return DiffStat{}, err
+	}
+	exists, isDir, err := pathExists(normalized.Path)
+	if err != nil {
+		return DiffStat{}, err
+	}
+	if !exists || !isDir {
+		return DiffStat{}, ErrMissingWorkspace
+	}
+	filesChanged := 0
+	err = filepath.WalkDir(normalized.Path, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.IsDir() && entry.Name() == ".detent" {
+			return filepath.SkipDir
+		}
+		if entry.IsDir() {
+			return nil
+		}
+		filesChanged++
+		return nil
+	})
+	if err != nil {
+		return DiffStat{}, err
+	}
+	return DiffStat{Files: filesChanged}, nil
+}
+
+func (f *Filesystem) infoForIssue(issue Issue) (Info, error) {
+	key := issueKey(issue)
+	path, err := validateWorkspacePath(f.root, filepath.Join(f.root, key))
+	if err != nil {
+		return Info{}, err
+	}
+	return Info{
+		Path: path,
+		Key:  key,
+	}, nil
+}
+
+func (f *Filesystem) normalizeInfo(info Info, issue Issue) (Info, error) {
+	key := info.Key
+	if key == "" {
+		key = issueKey(issue)
+	}
+	path := info.Path
+	if path == "" {
+		var err error
+		path, err = validateWorkspacePath(f.root, filepath.Join(f.root, key))
+		if err != nil {
+			return Info{}, err
+		}
+	} else {
+		var err error
+		path, err = validateWorkspacePath(f.root, path)
+		if err != nil {
+			return Info{}, err
+		}
+	}
+	info.Path = path
+	info.Key = key
+	info.Branch = ""
+	return info, nil
+}
+
+func (f *Filesystem) runHook(ctx context.Context, name string, command string, info Info, issue Issue) error {
+	if strings.TrimSpace(command) == "" {
+		return nil
+	}
+	timeout := f.hooks.Timeout
+	if timeout == 0 {
+		timeout = defaultHookTimeout
+	}
+	hookCtx := ctx
+	cancel := func() {}
+	if timeout > 0 {
+		hookCtx, cancel = context.WithTimeout(ctx, timeout)
+	}
+	defer cancel()
+
+	cmd := commandshell.Command(hookCtx, command, f.hooks.Shell)
+	cmd.Dir = info.Path
+	cmd.Env = hookEnv(info, issue)
+	cmd.WaitDelay = workspaceCommandWaitDelay
+	f.logger.Info("running filesystem workspace hook", slog.String("hook", name), slog.String("path", info.Path), slog.String("command", command))
+
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		return nil
+	}
+	if errors.Is(err, exec.ErrWaitDelay) && hookCtx.Err() == nil {
+		return nil
+	}
+	exitCode := -1
+	var exitErr *exec.ExitError
+	if errors.As(err, &exitErr) {
+		exitCode = exitErr.ExitCode()
+	}
+	if hookCtx.Err() != nil {
+		err = hookCtx.Err()
+	}
+	logPath, logErr := f.writeHookLog(name, command, info, exitCode, err, output)
+	hookErr := &HookError{
+		Hook:     name,
+		Command:  command,
+		Dir:      info.Path,
+		ExitCode: exitCode,
+		LogPath:  logPath,
+		Output:   string(output),
+		Err:      err,
+	}
+	if logErr != nil {
+		f.logger.Warn("filesystem workspace hook log write failed", slog.String("hook", name), slog.String("path", info.Path), slog.String("command", command), slog.Any("error", logErr))
+	}
+	f.logger.Warn(
+		"filesystem workspace hook failed",
+		slog.String("hook", name),
+		slog.String("path", info.Path),
+		slog.String("command", command),
+		slog.Int("exit_code", exitCode),
+		slog.String("log_path", logPath),
+		slog.String("output_tail", hookOutputTail(string(output), hookOutputTailBytes)),
+		slog.Any("error", err),
+	)
+	return hookErr
+}
+
+func (f *Filesystem) writeHookLog(name string, command string, info Info, exitCode int, err error, output []byte) (string, error) {
+	dir := filepath.Join(f.root, ".detent", "hook-logs", SafeKey(info.Key))
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		return "", err
+	}
+	path := filepath.Join(dir, hookLogFileName(name, time.Now().UTC(), os.Getpid()))
+	var buf bytes.Buffer
+	fmt.Fprintf(&buf, "hook: %s\n", name)
+	fmt.Fprintf(&buf, "command: %s\n", command)
+	fmt.Fprintf(&buf, "working_directory: %s\n", info.Path)
+	fmt.Fprintf(&buf, "exit_status: %d\n", exitCode)
+	if err != nil {
+		fmt.Fprintf(&buf, "error: %s\n", err)
+	}
+	fmt.Fprint(&buf, "\noutput:\n")
+	fmt.Fprint(&buf, string(output))
+	if len(output) > 0 && output[len(output)-1] != '\n' {
+		fmt.Fprint(&buf, "\n")
+	}
+	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+		return "", err
+	}
+	return path, nil
+}

--- a/internal/workspace/filesystem_test.go
+++ b/internal/workspace/filesystem_test.go
@@ -1,0 +1,63 @@
+package workspace
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestFilesystemWorkspaceCreatesArtifactWorkspaceAndOutputRoot(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join(t.TempDir(), "workspaces")
+	outputRoot := filepath.Join(t.TempDir(), "outputs")
+	backend, err := NewFilesystem(FilesystemOptions{
+		Root:       root,
+		OutputRoot: outputRoot,
+	})
+	if err != nil {
+		t.Fatalf("NewFilesystem() error = %v", err)
+	}
+
+	issue := Issue{
+		ProjectID:  "video",
+		ID:         "ad-1",
+		Identifier: "store/ad-1",
+	}
+	info, err := backend.Create(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if info.Path == "" || info.Key == "" || info.Branch != "" || !info.Created {
+		t.Fatalf("Info = %#v", info)
+	}
+	if _, err := os.Stat(filepath.Join(info.Path, "artifacts")); err != nil {
+		t.Fatalf("artifact directory missing: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(outputRoot, info.Key)); err != nil {
+		t.Fatalf("output directory missing: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "artifacts", "manifest.json"), []byte("{}\n"), 0o600); err != nil {
+		t.Fatalf("write artifact: %v", err)
+	}
+
+	stat, err := backend.DiffStat(context.Background(), info, issue)
+	if err != nil {
+		t.Fatalf("DiffStat() error = %v", err)
+	}
+	if stat.Files != 1 {
+		t.Fatalf("DiffStat().Files = %d, want 1", stat.Files)
+	}
+
+	result, err := backend.CleanupIssue(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("CleanupIssue() error = %v", err)
+	}
+	if result.Worktrees != 1 {
+		t.Fatalf("CleanupIssue().Worktrees = %d, want 1", result.Worktrees)
+	}
+	if _, err := os.Stat(info.Path); !os.IsNotExist(err) {
+		t.Fatalf("workspace still exists or unexpected stat error: %v", err)
+	}
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -20,7 +20,10 @@ import (
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
 )
 
-const KindLocalGit = "local_git"
+const (
+	KindLocalGit   = "local_git"
+	KindFilesystem = "filesystem"
+)
 
 const defaultHookTimeout = time.Minute
 const workspaceCommandWaitDelay = time.Second
@@ -79,6 +82,7 @@ type Hooks struct {
 type LocalGitOptions struct {
 	Root       string
 	SourceRoot string
+	OutputRoot string
 	AutoBranch bool
 	Hooks      Hooks
 	Logger     *slog.Logger
@@ -194,6 +198,14 @@ func NewBackend(kind string, opts LocalGitOptions) (Backend, error) {
 	switch strings.ToLower(strings.TrimSpace(kind)) {
 	case KindLocalGit:
 		return NewLocalGit(opts)
+	case KindFilesystem:
+		return NewFilesystem(FilesystemOptions{
+			Root:       opts.Root,
+			SourceRoot: opts.SourceRoot,
+			OutputRoot: opts.OutputRoot,
+			Hooks:      opts.Hooks,
+			Logger:     opts.Logger,
+		})
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, kind)
 	}


### PR DESCRIPTION
## Summary

- Add a local SQLite work-item tracker, filesystem workspace backend, and artifact deliverable metadata for non-code workflows.
- Add artifact gate evaluation, configurable auto-promote states, prompt generation without PR instructions, doctor validation, and Kanban/local status persistence coverage.
- Document a concrete non-code artifact workflow template and update execution-seam docs.

Fixes #780

## Test Plan

- [x] `go test ./internal/config ./internal/gate ./internal/connector/local ./internal/workspace ./internal/orchestrator ./internal/runner ./internal/cli ./internal/project ./internal/telemetry`
- [x] `make check`