### PR TITLE
fix(gate): rework red human-review CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
-  ci_failure_action: skip
+  ci_failure_action: rework
   validator:
     enabled: false
     model: ""
@@ -737,7 +737,7 @@ agent:
 gate:
   kind: command
   run: make check
-  ci_failure_action: skip
+  ci_failure_action: rework
   validator:
     enabled: false
     model: ""
@@ -781,7 +781,7 @@ agent:
 gate:
   kind: command
   run: make check
-  ci_failure_action: skip
+  ci_failure_action: rework
   validator:
     enabled: false
     model: ""
@@ -851,10 +851,10 @@ current-head automated PR review before auto-promotion. Set
 auto-promote from `Human Review` after a linked open PR, green CI, no P1 bot
 review findings, and the quiet period. The quiet period resets on observed
 issue updates, Project status updates, automated PR review submission, and
-linked PR activity such as a fresh push to the PR head. Set
-`ci_failure_action: rework` when failed or cancelled current-head CI should move
-a `Human Review` item back to `Rework`; the default `skip` parks it in
-`Human Review`, and pending CI stays parked. Use
+linked PR activity such as a fresh push to the PR head. Failed or cancelled
+current-head CI moves a `Human Review` item back to
+`Rework` by default. Set `ci_failure_action: skip` only when red CI should park
+in `Human Review`; pending CI stays parked. Use
 `kind: human_review` with `approval_label` only when the workflow explicitly
 requires a human approval label to promote.
 
@@ -1462,8 +1462,9 @@ of that state is controlled by the workflow:
   PR, green CI, no-P1, and quiet-period checks but does not require a bot PR
   review to exist.
 - `gate.ci_failure_action: rework` routes failed or cancelled current-head CI
-  from `Human Review` back to `Rework`; the default `skip` leaves the item
-  parked while CI is not green.
+  from `Human Review` back to `Rework` by default; set
+  `gate.ci_failure_action: skip` only when non-green CI should leave the item
+  parked.
 - `gate.validator.enabled: true` runs a validator-agent review before
   auto-promotion; verdicts below `min_score` or with severities in `block_on`
   route the issue to `Rework`.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1999,9 +1999,9 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `require_automated_review: true`, it also requires a current-head automated
    GitHub PR review. With `require_automated_review: false`, bot PR review is
    not required to exist, but any observed P1 bot findings still route the item
-   to `Rework`. With `ci_failure_action: rework`, failed or cancelled
-   current-head CI also routes the item to `Rework`; the default `skip` leaves
-   non-green CI parked in `Human Review`. Pending CI stays parked. The quiet
+   to `Rework`. Failed or cancelled current-head CI also routes the item to
+   `Rework` by default; set `ci_failure_action: skip` only when red CI should
+   stay parked in `Human Review`. Pending CI stays parked. The quiet
    period resets on observed issue updates, Project
    status updates, automated PR review submission, and linked PR activity such
    as a fresh push to the PR head. With `gate.validator.enabled: true`, a

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -63,9 +63,10 @@ artifact workflows. GitHub PR delivery remains the default.
 - `gate.kind: command` with `require_automated_review: false` keeps the
   command, linked PR, green CI, no-P1, and quiet-period checks but does not
   require an automated GitHub PR review to exist before promotion.
-- `gate.kind: command` with `ci_failure_action: rework` routes failed or
-  cancelled current-head CI from `Human Review` back to `Rework`; the default
-  `skip` parks the item while CI is not green.
+- `gate.kind: command` routes failed or cancelled current-head CI from
+  `Human Review` back to `Rework` by default. Set
+  `ci_failure_action: skip` only when red CI should remain parked in
+  `Human Review`.
 - The quiet period resets on observed issue updates, Project status updates,
   automated PR review submission, and linked PR activity such as a fresh push
   to the PR head.

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -79,7 +79,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
-  ci_failure_action: skip
+  ci_failure_action: rework
   validator:
     enabled: false
     model: ""

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -79,7 +79,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
-  ci_failure_action: skip
+  ci_failure_action: rework
   validator:
     enabled: false
     model: ""

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -78,7 +78,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
-  ci_failure_action: skip
+  ci_failure_action: rework
   validator:
     enabled: false
     model: ""

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -6,12 +6,10 @@ import (
 	"errors"
 	"io"
 	"log/slog"
-	"net"
 	"net/http"
 	"net/url"
 	"os"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -344,7 +342,8 @@ func TestRegistryRefresherFallsBackWhenTargetRepositoryDoesNotMatch(t *testing.T
 }
 
 func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
-	host, port := freeLoopbackPort(t)
+	port := 0
+	output := newBootOutput()
 	globalPath := filepath.Join(t.TempDir(), "global.yaml")
 	global, err := globalconfig.DefaultAt(globalPath)
 	if err != nil {
@@ -358,12 +357,14 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 		done <- startRunning(ctx, BootConfig{
 			Mode:   BootModeRunning,
 			Global: global,
-			Host:   host,
+			Host:   "127.0.0.1",
 			Port:   &port,
+			Output: output,
 		})
 	}()
 
-	body := waitForDashboard(t, "http://"+net.JoinHostPort(host, strconv.Itoa(port))+"/", done)
+	baseURL := waitForBootDashboardURL(t, output, done)
+	body := waitForDashboard(t, baseURL+"/", done)
 	if !strings.Contains(body, "Detent") {
 		t.Fatalf("dashboard body missing Detent:\n%s", body)
 	}
@@ -380,7 +381,8 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 }
 
 func TestStartRunningUsesWorkflowKanbanModeForFleetActions(t *testing.T) {
-	host, port := freeLoopbackPort(t)
+	port := 0
+	output := newBootOutput()
 	configPath := filepath.Join(t.TempDir(), "global.yaml")
 	alpha := createBootProjectFiles(t)
 	writeBootKanbanWorkflow(t, alpha.workflowPath, workflowconfig.KanbanModeIntegration)
@@ -399,12 +401,13 @@ func TestStartRunningUsesWorkflowKanbanModeForFleetActions(t *testing.T) {
 		done <- startRunning(ctx, BootConfig{
 			Mode:   BootModeRunning,
 			Global: global,
-			Host:   host,
+			Host:   "127.0.0.1",
 			Port:   &port,
+			Output: output,
 		})
 	}()
 
-	baseURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port))
+	baseURL := waitForBootDashboardURL(t, output, done)
 	waitForDashboard(t, baseURL+"/kanban", done)
 	status, body := postDashboardForm(t, baseURL+"/api/v1/kanban/move", done, url.Values{
 		"issue_id":      {"issue-1"},
@@ -433,7 +436,8 @@ func TestStartRunningUsesWorkflowKanbanModeForFleetActions(t *testing.T) {
 }
 
 func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *testing.T) {
-	host, port := freeLoopbackPort(t)
+	port := 0
+	output := newBootOutput()
 	configPath := filepath.Join(t.TempDir(), "global.yaml")
 	alpha := createBootProjectFiles(t)
 	writeBootGlobalConfig(t, configPath, []globalconfig.Project{
@@ -454,8 +458,9 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 		done <- startRunning(ctx, BootConfig{
 			Mode:   BootModeRunning,
 			Global: global,
-			Host:   host,
+			Host:   "127.0.0.1",
 			Port:   &port,
+			Output: output,
 			ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
 				return bootProvisioningConnector{
 					provision: func(ctx context.Context) error {
@@ -482,7 +487,8 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 		t.Fatal("timed out waiting for project provisioning to start")
 	}
 
-	stateURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port)) + "/api/v1/state"
+	baseURL := waitForBootDashboardURL(t, output, done)
+	stateURL := baseURL + "/api/v1/state"
 	body := waitForDashboardCondition(t, stateURL, done, "startup snapshot", func(body string) bool {
 		return strings.Contains(body, `"generated_at"`) &&
 			strings.Contains(body, `"alpha"`) &&
@@ -505,7 +511,8 @@ func TestStartRunningPublishesStartupSnapshotBeforeProjectStartCompletes(t *test
 }
 
 func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
-	host, port := freeLoopbackPort(t)
+	port := 0
+	output := newBootOutput()
 	configPath := filepath.Join(t.TempDir(), "global.yaml")
 	alpha := createBootProjectFiles(t)
 	bravo := createBootProjectFiles(t)
@@ -524,12 +531,14 @@ func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
 		done <- startRunning(ctx, BootConfig{
 			Mode:   BootModeRunning,
 			Global: global,
-			Host:   host,
+			Host:   "127.0.0.1",
 			Port:   &port,
+			Output: output,
 		})
 	}()
 
-	settingsURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port)) + "/settings"
+	baseURL := waitForBootDashboardURL(t, output, done)
+	settingsURL := baseURL + "/settings"
 	body := waitForDashboard(t, settingsURL, done)
 	if !strings.Contains(body, "alpha") {
 		t.Fatalf("settings body missing alpha:\n%s", body)
@@ -568,7 +577,8 @@ func TestStartRunningHotReloadsGlobalConfigProjects(t *testing.T) {
 }
 
 func TestStartRunningReconcilesGlobalConfigChangedBeforeWatcherStarts(t *testing.T) {
-	host, port := freeLoopbackPort(t)
+	port := 0
+	output := newBootOutput()
 	configPath := filepath.Join(t.TempDir(), "global.yaml")
 	alpha := createBootProjectFiles(t)
 	bravo := createBootProjectFiles(t)
@@ -590,8 +600,9 @@ func TestStartRunningReconcilesGlobalConfigChangedBeforeWatcherStarts(t *testing
 		done <- startRunning(ctx, BootConfig{
 			Mode:   BootModeRunning,
 			Global: global,
-			Host:   host,
+			Host:   "127.0.0.1",
 			Port:   &port,
+			Output: output,
 			ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
 				return bootProvisioningConnector{
 					provision: func(ctx context.Context) error {
@@ -618,7 +629,8 @@ func TestStartRunningReconcilesGlobalConfigChangedBeforeWatcherStarts(t *testing
 		t.Fatal("timed out waiting for project provisioning to start")
 	}
 
-	settingsURL := "http://" + net.JoinHostPort(host, strconv.Itoa(port)) + "/settings"
+	baseURL := waitForBootDashboardURL(t, output, done)
+	settingsURL := baseURL + "/settings"
 	body := waitForDashboard(t, settingsURL, done)
 	if !strings.Contains(body, "alpha") {
 		t.Fatalf("settings body missing alpha:\n%s", body)
@@ -679,20 +691,50 @@ func TestRegistryRefresherReturnsProjectNotFoundWithoutOrchestrators(t *testing.
 	}
 }
 
-func freeLoopbackPort(t *testing.T) (string, int) {
+type bootOutput struct {
+	mu     sync.Mutex
+	buffer bytes.Buffer
+}
+
+func newBootOutput() *bootOutput {
+	return &bootOutput{}
+}
+
+func (o *bootOutput) Write(p []byte) (int, error) {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.buffer.Write(p)
+}
+
+func (o *bootOutput) String() string {
+	o.mu.Lock()
+	defer o.mu.Unlock()
+	return o.buffer.String()
+}
+
+func waitForBootDashboardURL(t *testing.T, output *bootOutput, done <-chan error) string {
 	t.Helper()
 
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		t.Fatalf("Listen() error = %v", err)
-	}
-	defer listener.Close()
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
 
-	addr, ok := listener.Addr().(*net.TCPAddr)
-	if !ok {
-		t.Fatalf("listener addr = %T, want *net.TCPAddr", listener.Addr())
+	for ctx.Err() == nil {
+		select {
+		case err := <-done:
+			t.Fatalf("startRunning returned before boot banner was written: %v", err)
+		default:
+		}
+
+		for _, line := range strings.Split(output.String(), "\n") {
+			url, ok := strings.CutPrefix(line, "Dashboard: ")
+			if ok && strings.TrimSpace(url) != "" {
+				return strings.TrimSpace(url)
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
 	}
-	return "127.0.0.1", addr.Port
+	t.Fatalf("timed out waiting for boot dashboard URL; output:\n%s", output.String())
+	return ""
 }
 
 func waitForDashboard(t *testing.T, url string, done <-chan error) string {

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -137,7 +137,7 @@ func DefaultConfig() Config {
 		Run:                    DefaultCommand,
 		ApprovalLabel:          DefaultApprovalLabel,
 		RequireAutomatedReview: new(true),
-		CIFailureAction:        CIFailureActionSkip,
+		CIFailureAction:        CIFailureActionRework,
 		Validator:              effectiveValidatorConfig(ValidatorConfig{}),
 		Artifact:               effectiveArtifactConfig(ArtifactConfig{}),
 	}
@@ -152,6 +152,7 @@ func DefaultPlanConfig() PlanConfig {
 }
 
 func Effective(cfg Config) Config {
+	ciFailureActionSpecified := strings.TrimSpace(cfg.CIFailureAction) != ""
 	cfg.Kind = NormalizeKind(cfg.Kind)
 	cfg.Run = strings.TrimSpace(cfg.Run)
 	cfg.ApprovalLabel = normalizeLabel(cfg.ApprovalLabel)
@@ -180,10 +181,17 @@ func Effective(cfg Config) Config {
 	if cfg.ApprovalLabel == "" {
 		cfg.ApprovalLabel = DefaultApprovalLabel
 	}
-	if cfg.CIFailureAction == "" {
-		cfg.CIFailureAction = CIFailureActionSkip
+	if !ciFailureActionSpecified {
+		cfg.CIFailureAction = defaultCIFailureAction(cfg.Kind)
 	}
 	return cfg
+}
+
+func defaultCIFailureAction(kind string) string {
+	if kind == KindCommand {
+		return CIFailureActionRework
+	}
+	return CIFailureActionSkip
 }
 
 func EffectivePlan(cfg PlanConfig) PlanConfig {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -17,17 +17,22 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 		{
 			name: "omitted gate defaults to make check command",
 			cfg:  Config{},
-			want: Config{Kind: KindCommand, Run: DefaultCommand, ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionSkip},
+			want: Config{Kind: KindCommand, Run: DefaultCommand, ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionRework},
 		},
 		{
 			name: "command keeps custom run",
 			cfg:  Config{Kind: " command ", Run: " make verify "},
-			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionSkip},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionRework},
 		},
 		{
 			name: "command can disable automated review requirement",
 			cfg:  Config{Kind: KindCommand, Run: "make verify", RequireAutomatedReview: new(false)},
-			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(false), CIFailureAction: CIFailureActionSkip},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(false), CIFailureAction: CIFailureActionRework},
+		},
+		{
+			name: "command can explicitly skip failed ci",
+			cfg:  Config{Kind: KindCommand, Run: "make verify", CIFailureAction: " skip "},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionSkip},
 		},
 		{
 			name: "command can route failed ci to rework",
@@ -72,7 +77,7 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 				Run:                    DefaultCommand,
 				ApprovalLabel:          DefaultApprovalLabel,
 				RequireAutomatedReview: new(true),
-				CIFailureAction:        CIFailureActionSkip,
+				CIFailureAction:        CIFailureActionRework,
 				Validator: ValidatorConfig{
 					MinScore: DefaultValidatorMinScore,
 					BlockOn:  []string{"p1"},
@@ -165,7 +170,16 @@ func TestEvaluate(t *testing.T) {
 			want:  Decision{Action: ActionSkip, Reason: ReasonMissingPullRequest},
 		},
 		{
-			name: "command gate skips red ci",
+			name: "command gate reworks red ci by default",
+			input: Summary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "red",
+			},
+			want: Decision{Action: ActionRework, Reason: ReasonCINotGreen, CIStatus: "red"},
+		},
+		{
+			name: "command gate skips red ci when configured",
+			cfg:  Config{Kind: KindCommand, CIFailureAction: CIFailureActionSkip},
 			input: Summary{
 				PullRequestURL: "https://github.test/pull/42",
 				CIStatus:       "red",

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -27,6 +27,7 @@ type AutoPromoteSummary struct {
 	MergeableState                        string
 	CIStatus                              string
 	ReviewState                           string
+	FailedChecks                          []string
 	P1Findings                            []AutoPromoteFinding
 	Validator                             gate.ValidatorResult
 	ArtifactStatus                        string

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -91,9 +91,28 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
-			name:  "red ci skips",
+			name:  "red ci reworks by default",
 			issue: autoPromoteTestIssue("issue-red-ci", nil),
 			cfg:   enabled,
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "red",
+			},
+			want: AutoPromoteDecision{
+				Action:   AutoPromoteActionRework,
+				Reason:   AutoPromoteReasonCINotGreen,
+				CIStatus: "red",
+			},
+		},
+		{
+			name:  "red ci skips when configured",
+			issue: autoPromoteTestIssue("issue-red-ci-skip", nil),
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				OptoutLabel:   "requires-human-review",
+				Gate:          gate.Config{Kind: gate.KindCommand, CIFailureAction: gate.CIFailureActionSkip},
+			},
 			input: AutoPromoteSummary{
 				PullRequestURL: "https://github.test/pull/42",
 				CIStatus:       "red",

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1016,6 +1016,7 @@ func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
 	summary.MergeableState = strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
 	summary.CIStatus = pullRequest.CIStatus
 	summary.ReviewState = pullRequest.CodexReviewState
+	summary.FailedChecks = autoPromoteFailedChecksFromPullRequest(pullRequest)
 	summary.P1Findings = autoPromoteFindingsFromPullRequest(pullRequest)
 	return summary
 }
@@ -1081,6 +1082,29 @@ func autoPromoteFindingsFromPullRequest(pullRequest *connector.PullRequest) []Au
 		})
 	}
 	return findings
+}
+
+func autoPromoteFailedChecksFromPullRequest(pullRequest *connector.PullRequest) []string {
+	if pullRequest == nil {
+		return nil
+	}
+	checks := make([]string, 0, len(pullRequest.SlowChecks))
+	for _, check := range pullRequest.SlowChecks {
+		if !autoPromoteCheckFailed(check) {
+			continue
+		}
+		checks = append(checks, check.Name)
+	}
+	return uniqueStrings(checks)
+}
+
+func autoPromoteCheckFailed(check connector.PullRequestCheck) bool {
+	switch strings.ToLower(strings.TrimSpace(check.Conclusion)) {
+	case "failure", "failed", "error", "timed_out", "startup_failure", "action_required", "cancelled", "canceled":
+		return true
+	default:
+		return false
+	}
 }
 
 func autoPromoteTargetState(action AutoPromoteAction, cfg AutoPromoteConfig) string {
@@ -1185,6 +1209,9 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 		if issue.PullRequest.HydrationNextRetryAt != nil && !issue.PullRequest.HydrationNextRetryAt.IsZero() {
 			attrs = append(attrs, "pull_request_hydration_next_retry_at", issue.PullRequest.HydrationNextRetryAt.UTC().Format(time.RFC3339))
 		}
+		if failedChecks := strings.Join(autoPromoteFailedChecksFromPullRequest(issue.PullRequest), ", "); failedChecks != "" {
+			attrs = append(attrs, "failed_checks", failedChecks)
+		}
 	}
 	if decision.QuietRemaining > 0 {
 		attrs = append(attrs, "quiet_remaining", decision.QuietRemaining)
@@ -1246,6 +1273,10 @@ func autoPromoteComment(
 	if decision.CIStatus != "" {
 		b.WriteString("\n- ci_status: ")
 		b.WriteString(decision.CIStatus)
+	}
+	if failedChecks := strings.Join(summary.FailedChecks, ", "); failedChecks != "" {
+		b.WriteString("\n- failed_checks: ")
+		b.WriteString(failedChecks)
 	}
 
 	if len(decision.Findings) > 0 {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -130,20 +130,21 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			},
 		},
 		{
-			name: "routes failing ci to rework when configured",
+			name: "routes failing ci to rework by default",
 			cfg: AutoPromoteConfig{
 				Enabled:       true,
 				QuietDuration: 10 * time.Minute,
-				Gate: gate.Config{
-					Kind:            gate.KindCommand,
-					CIFailureAction: gate.CIFailureActionRework,
-				},
 			},
 			issue: autoPromoteTickIssue("issue-red-ci", []string{"bug"}, &connector.PullRequest{
 				Number:   48,
 				URL:      "https://github.test/digitaldrywood/detent/pull/48",
 				State:    "OPEN",
 				CIStatus: "fail",
+				SlowChecks: []connector.PullRequestCheck{
+					{Name: "browser-e2e", Status: "completed", Conclusion: "failure"},
+					{Name: "lint", Status: "completed", Conclusion: "failure"},
+					{Name: "backend", Status: "completed", Conclusion: "success"},
+				},
 			}),
 			wantUpdates: []autoPromoteTickUpdate{{
 				issueID: "issue-red-ci",
@@ -153,7 +154,11 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 				"Auto-promote routed this issue from Human Review to Rework: current-head CI is failing.",
 				"reason: ci_not_green",
 				"ci_status: red",
+				"failed_checks: browser-e2e, lint",
 				"https://github.test/digitaldrywood/detent/pull/48",
+			},
+			wantLogFragments: []string{
+				"failed_checks=\"browser-e2e, lint\"",
 			},
 		},
 		{

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -550,7 +550,7 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	if hasDeliveryProfile {
 		writeScalar(&b, "  ", "require_automated_review", onboardingBool(settings.GateRequireAutomatedReview))
 	}
-	b.WriteString("  ci_failure_action: skip\n")
+	b.WriteString("  ci_failure_action: rework\n")
 	b.WriteString("  validator:\n")
 	b.WriteString("    enabled: false\n")
 	b.WriteString("    model: \"\"\n")

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -372,7 +372,7 @@ func TestOnboardingWriteGitHubWorkflows(t *testing.T) {
 				"codex:\n  command: codex app-server",
 				"gate:\n  kind: command\n  run: make check",
 				"require_automated_review: false",
-				"ci_failure_action: skip",
+				"ci_failure_action: rework",
 				"validator:\n    enabled: false\n    model: \"\"\n    min_score: 0.8\n    block_on:\n      - p1",
 				"hooks:\n  timeout_ms: 60000",
 				"max_concurrent_agents_by_state:\n    Merging: 1",

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -3725,10 +3725,13 @@ func prPipelineCardForIssue(issue telemetry.Issue, state string, laneID string, 
 }
 
 func prPipelineWaitDetail(issue telemetry.Issue) string {
-	if issue.PullRequest == nil && issue.MergeTiming == nil {
-		return ""
-	}
 	parts := []string{}
+	if reason := prPipelineHumanReviewWaitReason(issue); reason != "" {
+		parts = append(parts, reason)
+	}
+	if issue.PullRequest == nil && issue.MergeTiming == nil {
+		return strings.Join(parts, " / ")
+	}
 	if issue.PullRequest != nil {
 		if hydration := pullRequestHydrationWaitDetail(
 			issue.PullRequest.HydrationUnavailableReason,
@@ -3757,6 +3760,38 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		parts = append(parts, merge)
 	}
 	return strings.Join(parts, " / ")
+}
+
+func prPipelineHumanReviewWaitReason(issue telemetry.Issue) string {
+	if prPipelineLaneID(issue.State) != "human-review" {
+		return ""
+	}
+	if issue.PullRequest == nil {
+		return "waiting for linked PR"
+	}
+	if pullRequestHydrationWaitDetail(
+		issue.PullRequest.HydrationUnavailableReason,
+		issue.PullRequest.HydrationDegradedReason,
+		issue.PullRequest.HydrationNextRetryAt,
+	) != "" {
+		return ""
+	}
+	switch prPipelineCIStatus(issue, "human-review") {
+	case "fail":
+		return "CI failed; Rework routing pending"
+	case "pending":
+		return "waiting for CI"
+	}
+	switch strings.ToUpper(strings.TrimSpace(issue.PullRequest.CodexReviewState)) {
+	case "":
+		return "waiting for automated review"
+	case "P1":
+		return "P1 review finding blocks promotion"
+	}
+	if issue.PullRequest.QuietWaitSeconds > 0 {
+		return ""
+	}
+	return "waiting for auto-promote"
 }
 
 func prPipelineMergeWaitDetail(timing *telemetry.MergeTiming) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1356,7 +1356,7 @@ func TestProjectKanbanBoardGroupsSnapshotRowsByConfiguredStates(t *testing.T) {
 		{Lane: "Todo", IssueNumber: "#11", Title: "Todo issue", TimeInStage: "6m 0s", Metadata: "No linked PR"},
 		{Lane: "In Progress", IssueNumber: "#13", Title: "Running issue", TimeInStage: "5m 0s", Labels: "bug", Assignees: "bob", Metadata: "No linked PR"},
 		{Lane: "Blocked", IssueNumber: "#14", Title: "Blocked issue", TimeInStage: "4m 0s", Blockers: "digitaldrywood/detent#401 In Progress", Metadata: "No linked PR"},
-		{Lane: "Human Review", IssueNumber: "#12", Title: "Review lane PR", URL: "https://github.com/digitaldrywood/detent/issues/12", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "3m 0s", Labels: "enhancement, stage:s6", Assignees: "alice", ClearedBlockers: "digitaldrywood/detent#10 Done", Metadata: "PR #142"},
+		{Lane: "Human Review", IssueNumber: "#12", Title: "Review lane PR", URL: "https://github.com/digitaldrywood/detent/issues/12", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "3m 0s", WaitDetail: "waiting for auto-promote", Labels: "enhancement, stage:s6", Assignees: "alice", ClearedBlockers: "digitaldrywood/detent#10 Done", Metadata: "PR #142"},
 		{Lane: "Done", IssueNumber: "#15", Title: "Done lane PR", URL: "https://github.com/digitaldrywood/detent/issues/15", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2m 0s", Metadata: "PR #145"},
 	}
 	if len(got) != len(want) {
@@ -1937,7 +1937,7 @@ func TestProjectKanbanBoardUsesTrackerStateWhenCompletedSessionAlsoExists(t *tes
 
 	got := collectKanbanCards(board.Lanes)
 	want := []kanbanCardSnapshot{
-		{Lane: "Human Review", IssueNumber: "#550", Title: "Keep completed implementation visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s", Metadata: "PR #552"},
+		{Lane: "Human Review", IssueNumber: "#550", Title: "Keep completed implementation visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "30s", WaitDetail: "waiting for auto-promote", Metadata: "PR #552"},
 	}
 	if len(got) != len(want) {
 		t.Fatalf("kanban cards len = %d, want %d; got %#v", len(got), len(want), got)
@@ -2196,6 +2196,97 @@ func TestPRPipelineLanesMapSnapshotRows(t *testing.T) {
 	}
 }
 
+func TestPRPipelineWaitDetailExplainsHumanReviewReasons(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		issue telemetry.Issue
+		want  string
+	}{
+		{
+			name: "missing pull request",
+			issue: telemetry.Issue{
+				State: "Human Review",
+			},
+			want: "waiting for linked PR",
+		},
+		{
+			name: "pending ci",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus: "pending",
+				},
+			},
+			want: "waiting for CI",
+		},
+		{
+			name: "failed ci",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus: "failure",
+				},
+			},
+			want: "CI failed; Rework routing pending",
+		},
+		{
+			name: "missing automated review",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus: "success",
+				},
+			},
+			want: "waiting for automated review",
+		},
+		{
+			name: "blocking review finding",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus:         "success",
+					CodexReviewState: "P1",
+				},
+			},
+			want: "P1 review finding blocks promotion",
+		},
+		{
+			name: "ready for auto promote",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus:         "success",
+					CodexReviewState: "COMMENTED",
+				},
+			},
+			want: "waiting for auto-promote",
+		},
+		{
+			name: "hydration explains stale data instead",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				PullRequest: &telemetry.PullRequest{
+					CIStatus:                "success",
+					HydrationDegradedReason: "stale_cached_pull_request",
+				},
+			},
+			want: "PR hydration using stale cached data",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := prPipelineWaitDetail(tt.issue); got != tt.want {
+				t.Fatalf("prPipelineWaitDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestPRPipelineCardIncludesIssueAndPullRequestIdentity(t *testing.T) {
 	t.Parallel()
 
@@ -2320,7 +2411,7 @@ func TestPRPipelineLanesPreserveTrackerRefreshRows(t *testing.T) {
 				},
 			}))
 			want := []pipelineCardSnapshot{
-				{Lane: "Human Review", IssueNumber: "#552", Title: "Keep tracker row visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2m 0s"},
+				{Lane: "Human Review", IssueNumber: "#552", Title: "Keep tracker row visible", CIStatus: "pass", CodexReviewState: "clean", TimeInStage: "2m 0s", WaitDetail: "waiting for auto-promote"},
 			}
 			if len(got) != len(want) {
 				t.Fatalf("pipeline cards len = %d, want %d; got %#v", len(got), len(want), got)


### PR DESCRIPTION
## Summary

- Route default command-gate failed or cancelled CI in `Human Review` back to `Rework`, while preserving explicit `ci_failure_action: skip` and explicit human-review gates.
- Include failed check names in auto-promote comments/logs when check metadata is available.
- Surface Human Review wait reasons on dashboard cards and update generated workflow docs/templates.

Fixes #788

## Test Plan

- [x] `go test ./internal/gate ./internal/orchestrator ./internal/config ./internal/runner ./internal/web ./internal/web/templates -count=1`
- [x] `make check`