### PR TITLE
fix(web): restrict help icons to headings

### DIFF
--- a/internal/web/templates/dashboard.templ
+++ b/internal/web/templates/dashboard.templ
@@ -2367,19 +2367,19 @@ templ runningIssuesSection(data DashboardData) {
 								<th class="w-[30rem] px-3 py-3 font-medium">Issue</th>
 								<th class="w-[9rem] px-3 py-3 font-medium">State</th>
 								<th class="w-[11rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Runtime / turns", helpAgeTurn, "running-table", "")
+									@plainInlineLabel("Runtime / turns", "")
 								</th>
 								<th class="px-3 py-3 font-medium">
-									@helpInlineLabel("Codex update", helpEvent, "running-table", "")
+									@plainInlineLabel("Codex update", "")
 								</th>
 								<th class="w-[9rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Diff", helpDiff, "running-table", "")
+									@plainInlineLabel("Diff", "")
 								</th>
 								<th class="w-[11rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Tokens", helpTokens, "running-table", "")
+									@plainInlineLabel("Tokens", "")
 								</th>
 								<th class="w-[9rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Session", helpSession, "running-table", "")
+									@plainInlineLabel("Session", "")
 								</th>
 							</tr>
 						</thead>
@@ -3724,11 +3724,11 @@ templ ManualRefreshFeedbackWithID(id string, attempt *telemetry.RefreshAttempt) 
 	</div>
 }
 
-templ metricCard(label string, term helpTerm, value string, detail string, borderClass string, dotClass string) {
+templ metricCard(label string, value string, detail string, borderClass string, dotClass string) {
 	<article class={ "dashboard-metric-card min-w-0 rounded-md border border-border border-t-2 bg-card p-3 shadow-sm transition-colors hover:bg-muted/40 sm:p-4 " + borderClass }>
 		<div class="flex items-start justify-between gap-3">
 			<div class="grid min-w-0 gap-1">
-				@helpInlineLabel(label, term, "dashboard", "text-sm font-medium text-muted-foreground")
+				@plainInlineLabel(label, "text-sm font-medium text-muted-foreground")
 				<span class="text-xs text-muted-foreground">{ detail }</span>
 			</div>
 			<span class={ "h-2.5 w-2.5 shrink-0 rounded-full " + dotClass }></span>
@@ -3739,19 +3739,19 @@ templ metricCard(label string, term helpTerm, value string, detail string, borde
 
 templ statStrip(snapshot telemetry.Snapshot) {
 	<section class="dashboard-stat-strip grid min-w-0 gap-2 rounded-md border border-border bg-card p-2 shadow-sm sm:grid-cols-2 lg:grid-cols-6" aria-label="Dashboard statistics">
-		@statStripItem("Running", helpRunning, formatCount(runningCount(snapshot)), "Active issue sessions", "bg-accent")
-		@statStripItem("Queue", helpQueue, formatCount(queueCount(snapshot)), "Waiting or retrying", "bg-warning")
-		@statStripItem("Blocked", helpBlocked, formatCount(blockedCount(snapshot)), "Needs operator action", "bg-danger")
-		@statStripItem("Completed", helpCompleted, formatCount(completedCount(snapshot)), "Finished sessions", "bg-success")
-		@statStripItem("tps", helpThroughput, throughputRate(snapshot), "Rolling tokens/sec", "bg-accent")
-		@statStripItem("Uptime", helpRuntime, runtimeLabel(snapshot), "Aggregate agent uptime", "bg-success")
+		@statStripItem("Running", formatCount(runningCount(snapshot)), "Active issue sessions", "bg-accent")
+		@statStripItem("Queue", formatCount(queueCount(snapshot)), "Waiting or retrying", "bg-warning")
+		@statStripItem("Blocked", formatCount(blockedCount(snapshot)), "Needs operator action", "bg-danger")
+		@statStripItem("Completed", formatCount(completedCount(snapshot)), "Finished sessions", "bg-success")
+		@statStripItem("tps", throughputRate(snapshot), "Rolling tokens/sec", "bg-accent")
+		@statStripItem("Uptime", runtimeLabel(snapshot), "Aggregate agent uptime", "bg-success")
 	</section>
 }
 
-templ statStripItem(label string, term helpTerm, value string, detail string, dotClass string) {
+templ statStripItem(label string, value string, detail string, dotClass string) {
 	<div class="min-w-0 rounded-md bg-muted/60 px-3 py-2">
 		<div class="flex min-w-0 items-center justify-between gap-2">
-			@helpInlineLabel(label, term, "dashboard-stat-strip", "truncate text-xs font-medium uppercase text-muted-foreground")
+			@plainInlineLabel(label, "truncate text-xs font-medium uppercase text-muted-foreground")
 			<span class={ "h-2 w-2 shrink-0 rounded-full " + dotClass }></span>
 		</div>
 		<div class="mt-1 truncate font-mono text-lg font-semibold text-foreground">{ value }</div>
@@ -4438,15 +4438,15 @@ templ runningIssueMobileCard(row telemetry.Running, rowIndex int, generatedAt ti
 				<span class="rounded-full bg-accent-soft px-2 py-1 font-medium text-accent">{ issueState(row.Issue, "Running") }</span>
 			</div>
 			<div class="flex min-h-10 items-center justify-between gap-3">
-				@helpInlineLabel("Runtime / turns", helpAgeTurn, "running-mobile", "text-muted-foreground")
+				@plainInlineLabel("Runtime / turns", "text-muted-foreground")
 				<span class="font-mono text-foreground">{ runningRuntime(row, generatedAt) }</span>
 			</div>
 			<div class="flex min-h-10 items-center justify-between gap-3">
-				@helpInlineLabel("Diff", helpDiff, "running-mobile", "text-muted-foreground")
+				@plainInlineLabel("Diff", "text-muted-foreground")
 				<span class="font-mono text-foreground">{ formatDiffStat(row) }</span>
 			</div>
 			<div class="flex min-h-10 items-center justify-between gap-3">
-				@helpInlineLabel("Tokens", helpTokens, "running-mobile", "text-muted-foreground")
+				@plainInlineLabel("Tokens", "text-muted-foreground")
 				<span class="font-mono text-foreground">{ formatTokens(row.Tokens) }</span>
 			</div>
 		</div>
@@ -4998,7 +4998,7 @@ templ retryQueueSection(snapshot telemetry.Snapshot) {
 								<th class="w-[7rem] px-3 py-3 font-medium">Attempt</th>
 								<th class="w-[13rem] px-3 py-3 font-medium">Due time</th>
 								<th class="px-3 py-3 font-medium">
-									@helpInlineLabel("Error", helpEvent, "retry-table", "")
+									@plainInlineLabel("Error", "")
 								</th>
 							</tr>
 						</thead>
@@ -5177,14 +5177,14 @@ templ blockedSessionsSection(snapshot telemetry.Snapshot) {
 								<th class="w-[24rem] px-3 py-3 font-medium">Issue</th>
 								<th class="w-[9rem] px-3 py-3 font-medium">State</th>
 								<th class="w-[11rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Session", helpSession, "blocked-table", "")
+									@plainInlineLabel("Session", "")
 								</th>
 								<th class="w-[13rem] px-3 py-3 font-medium">Blocked time</th>
 								<th class="px-3 py-3 font-medium">
-									@helpInlineLabel("Last update", helpEvent, "blocked-table", "")
+									@plainInlineLabel("Last update", "")
 								</th>
 								<th class="w-[14rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Error", helpEvent, "blocked-table-error", "")
+									@plainInlineLabel("Error", "")
 								</th>
 							</tr>
 						</thead>
@@ -5279,15 +5279,15 @@ templ recentSessionsSection(snapshot telemetry.Snapshot) {
 								<th class="w-[24rem] px-3 py-3 font-medium">Issue</th>
 								<th class="w-[13rem] px-3 py-3 font-medium">Completed</th>
 								<th class="w-[11rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Runtime / turns", helpAgeTurn, "recent-table", "")
+									@plainInlineLabel("Runtime / turns", "")
 								</th>
 								<th class="w-[10rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Tokens", helpTokens, "recent-table", "")
+									@plainInlineLabel("Tokens", "")
 								</th>
 								<th class="w-[10rem] px-3 py-3 font-medium">Final state</th>
 								<th class="w-[11rem] px-3 py-3 font-medium">Model</th>
 								<th class="w-[11rem] px-3 py-3 font-medium">
-									@helpInlineLabel("Session", helpSession, "recent-table", "")
+									@plainInlineLabel("Session", "")
 								</th>
 							</tr>
 						</thead>
@@ -5331,11 +5331,11 @@ templ recentSessionMobileCard(row telemetry.Completed, rowIndex int) {
 				<span class="font-mono text-foreground">{ completedAtLabel(row) }</span>
 			</div>
 			<div class="flex min-h-10 items-center justify-between gap-3">
-				@helpInlineLabel("Runtime / turns", helpAgeTurn, "recent-mobile", "text-muted-foreground")
+				@plainInlineLabel("Runtime / turns", "text-muted-foreground")
 				<span class="font-mono text-foreground">{ completedRuntime(row) }</span>
 			</div>
 			<div class="flex min-h-10 items-center justify-between gap-3">
-				@helpInlineLabel("Tokens", helpTokens, "recent-mobile", "text-muted-foreground")
+				@plainInlineLabel("Tokens", "text-muted-foreground")
 				<span class="font-mono text-foreground">{ formatTokens(row.Tokens) }</span>
 			</div>
 			<div class="flex min-h-10 items-center justify-between gap-3">
@@ -5474,7 +5474,7 @@ templ budgetCard(snapshot telemetry.Snapshot) {
 		<div class="mt-5 grid gap-4 text-sm">
 			<div class="grid gap-2">
 				<div class="flex items-center justify-between gap-4">
-					@helpInlineLabel("Spend today", helpCurrentSpend, "budget-current-spend", "text-muted-foreground")
+					@plainInlineLabel("Spend today", "text-muted-foreground")
 					<strong class="font-mono font-medium text-foreground">{ budgetSpendTodayLabel(snapshot.Budget) }</strong>
 				</div>
 				<div class="h-2 overflow-hidden rounded-full bg-muted" aria-label="Daily budget usage">
@@ -5486,7 +5486,7 @@ templ budgetCard(snapshot telemetry.Snapshot) {
 			} else {
 				<div class="grid gap-3">
 					<div class="flex items-center justify-between gap-4">
-						@helpInlineLabel("Cost burn-down", helpProjectedSpend, "budget-burn-down", "font-medium text-muted-foreground")
+						@plainInlineLabel("Cost burn-down", "font-medium text-muted-foreground")
 						<span class="font-mono text-xs text-muted-foreground">{ budgetBurnDownView(snapshot).PeriodLabel }</span>
 					</div>
 					@BudgetProjectionChart(budgetBurnDownView(snapshot).Chart)
@@ -5502,7 +5502,7 @@ templ budgetCard(snapshot telemetry.Snapshot) {
 			} else {
 				<div class="grid gap-2">
 					<div class="flex items-center justify-between gap-4">
-						@helpInlineLabel("Budget history", helpBudgetHistory, "budget-history", "font-medium text-muted-foreground")
+						@plainInlineLabel("Budget history", "font-medium text-muted-foreground")
 						<span class="font-mono text-xs text-muted-foreground">{ budgetHistoryCount(snapshot.Budget) }</span>
 					</div>
 					<div class="grid h-12 grid-cols-7 items-end gap-1 rounded-md border border-border bg-muted px-2 py-2" aria-label="Spend over the last seven days">
@@ -5516,15 +5516,15 @@ templ budgetCard(snapshot telemetry.Snapshot) {
 			}
 			<div class="grid gap-3 border-t border-border pt-3">
 				<div class="flex items-center justify-between gap-4">
-					@helpInlineLabel("Projected", helpProjectedSpend, "budget-projected", "text-muted-foreground")
+					@plainInlineLabel("Projected", "text-muted-foreground")
 					<strong class="font-mono font-medium text-foreground">{ budgetBurnDownView(snapshot).ProjectionLabel }</strong>
 				</div>
 				<div class="flex items-center justify-between gap-4">
-					@helpInlineLabel("Daily cap", helpDailyCap, "budget-daily-cap", "text-muted-foreground")
+					@plainInlineLabel("Daily cap", "text-muted-foreground")
 					<strong class="font-mono font-medium text-foreground">{ optionalUSD(snapshot.Budget.PerDayMaxUSD) }</strong>
 				</div>
 				<div class="flex items-center justify-between gap-4">
-					@helpInlineLabel("Issue cap", helpIssueCap, "budget-issue-cap", "text-muted-foreground")
+					@plainInlineLabel("Issue cap", "text-muted-foreground")
 					<strong class="font-mono font-medium text-foreground">{ optionalUSD(snapshot.Budget.PerIssueMaxUSD) }</strong>
 				</div>
 			</div>
@@ -5547,7 +5547,7 @@ templ rateLimitsCard(limits *RateLimits) {
 				for _, row := range rateLimitRows(limits) {
 					<div class="grid gap-2">
 						<div class="flex items-center justify-between gap-3">
-							@helpInlineLabel(row.Name, rateLimitHelpTerm(row.Name), "rate-limit-"+helpIDPart(row.Name), "font-medium text-foreground")
+							@plainInlineLabel(row.Name, "font-medium text-foreground")
 							<span class="font-mono text-sm text-muted-foreground">{ row.Reset }</span>
 						</div>
 						<div class="h-2 overflow-hidden rounded-full bg-muted">
@@ -5657,7 +5657,7 @@ templ tokenCard(data DashboardData) {
 		</div>
 		<div class="mt-5">
 			<div class="mb-2 flex items-center justify-between gap-3 text-sm">
-				@helpInlineLabel("Token trend", helpTokenTrend, "tokens-card", "font-medium text-muted-foreground")
+				@plainInlineLabel("Token trend", "font-medium text-muted-foreground")
 				<span class="font-mono text-xs text-muted-foreground">{ formatDuration(data.Snapshot.Tokens.RuntimeSeconds) }</span>
 			</div>
 			if len(tokenTrendPoints(data.Snapshot)) == 0 {

--- a/internal/web/templates/dashboard_templ.go
+++ b/internal/web/templates/dashboard_templ.go
@@ -5540,7 +5540,7 @@ func runningIssuesSection(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Runtime / turns", helpAgeTurn, "running-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Runtime / turns", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -5548,7 +5548,7 @@ func runningIssuesSection(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Codex update", helpEvent, "running-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Codex update", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -5556,7 +5556,7 @@ func runningIssuesSection(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Diff", helpDiff, "running-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Diff", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -5564,7 +5564,7 @@ func runningIssuesSection(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Tokens", helpTokens, "running-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Tokens", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -5572,7 +5572,7 @@ func runningIssuesSection(data DashboardData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Session", helpSession, "running-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Session", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -9620,7 +9620,7 @@ func ManualRefreshFeedbackWithID(id string, attempt *telemetry.RefreshAttempt) t
 	})
 }
 
-func metricCard(label string, term helpTerm, value string, detail string, borderClass string, dotClass string) templ.Component {
+func metricCard(label string, value string, detail string, borderClass string, dotClass string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -9663,7 +9663,7 @@ func metricCard(label string, term helpTerm, value string, detail string, border
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel(label, term, "dashboard", "text-sm font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel(label, "text-sm font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -9748,27 +9748,27 @@ func statStrip(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = statStripItem("Running", helpRunning, formatCount(runningCount(snapshot)), "Active issue sessions", "bg-accent").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = statStripItem("Running", formatCount(runningCount(snapshot)), "Active issue sessions", "bg-accent").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = statStripItem("Queue", helpQueue, formatCount(queueCount(snapshot)), "Waiting or retrying", "bg-warning").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = statStripItem("Queue", formatCount(queueCount(snapshot)), "Waiting or retrying", "bg-warning").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = statStripItem("Blocked", helpBlocked, formatCount(blockedCount(snapshot)), "Needs operator action", "bg-danger").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = statStripItem("Blocked", formatCount(blockedCount(snapshot)), "Needs operator action", "bg-danger").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = statStripItem("Completed", helpCompleted, formatCount(completedCount(snapshot)), "Finished sessions", "bg-success").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = statStripItem("Completed", formatCount(completedCount(snapshot)), "Finished sessions", "bg-success").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = statStripItem("tps", helpThroughput, throughputRate(snapshot), "Rolling tokens/sec", "bg-accent").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = statStripItem("tps", throughputRate(snapshot), "Rolling tokens/sec", "bg-accent").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = statStripItem("Uptime", helpRuntime, runtimeLabel(snapshot), "Aggregate agent uptime", "bg-success").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = statStripItem("Uptime", runtimeLabel(snapshot), "Aggregate agent uptime", "bg-success").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -9780,7 +9780,7 @@ func statStrip(snapshot telemetry.Snapshot) templ.Component {
 	})
 }
 
-func statStripItem(label string, term helpTerm, value string, detail string, dotClass string) templ.Component {
+func statStripItem(label string, value string, detail string, dotClass string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -9805,7 +9805,7 @@ func statStripItem(label string, term helpTerm, value string, detail string, dot
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel(label, term, "dashboard-stat-strip", "truncate text-xs font-medium uppercase text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel(label, "truncate text-xs font-medium uppercase text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -12688,7 +12688,7 @@ func runningIssueMobileCard(row telemetry.Running, rowIndex int, generatedAt tim
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Runtime / turns", helpAgeTurn, "running-mobile", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Runtime / turns", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -12709,7 +12709,7 @@ func runningIssueMobileCard(row telemetry.Running, rowIndex int, generatedAt tim
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Diff", helpDiff, "running-mobile", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Diff", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -12730,7 +12730,7 @@ func runningIssueMobileCard(row telemetry.Running, rowIndex int, generatedAt tim
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Tokens", helpTokens, "running-mobile", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Tokens", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -15032,7 +15032,7 @@ func retryQueueSection(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Error", helpEvent, "retry-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Error", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -15646,7 +15646,7 @@ func blockedSessionsSection(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Session", helpSession, "blocked-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Session", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -15654,7 +15654,7 @@ func blockedSessionsSection(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Last update", helpEvent, "blocked-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Last update", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -15662,7 +15662,7 @@ func blockedSessionsSection(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Error", helpEvent, "blocked-table-error", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Error", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -15969,7 +15969,7 @@ func recentSessionsSection(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Runtime / turns", helpAgeTurn, "recent-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Runtime / turns", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -15977,7 +15977,7 @@ func recentSessionsSection(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Tokens", helpTokens, "recent-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Tokens", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -15985,7 +15985,7 @@ func recentSessionsSection(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Session", helpSession, "recent-table", "").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Session", "").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -16152,7 +16152,7 @@ func recentSessionMobileCard(row telemetry.Completed, rowIndex int) templ.Compon
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Runtime / turns", helpAgeTurn, "recent-mobile", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Runtime / turns", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -16173,7 +16173,7 @@ func recentSessionMobileCard(row telemetry.Completed, rowIndex int) templ.Compon
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Tokens", helpTokens, "recent-mobile", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Tokens", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -17108,7 +17108,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Spend today", helpCurrentSpend, "budget-current-spend", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Spend today", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -17152,7 +17152,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Cost burn-down", helpProjectedSpend, "budget-burn-down", "font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Cost burn-down", "font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -17231,7 +17231,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = helpInlineLabel("Budget history", helpBudgetHistory, "budget-history", "font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = plainInlineLabel("Budget history", "font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -17306,7 +17306,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Projected", helpProjectedSpend, "budget-projected", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Projected", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -17327,7 +17327,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Daily cap", helpDailyCap, "budget-daily-cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Daily cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -17348,7 +17348,7 @@ func budgetCard(snapshot telemetry.Snapshot) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Issue cap", helpIssueCap, "budget-issue-cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Issue cap", "text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -17442,7 +17442,7 @@ func rateLimitsCard(limits *RateLimits) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = helpInlineLabel(row.Name, rateLimitHelpTerm(row.Name), "rate-limit-"+helpIDPart(row.Name), "font-medium text-foreground").Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = plainInlineLabel(row.Name, "font-medium text-foreground").Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -17950,7 +17950,7 @@ func tokenCard(data DashboardData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel("Token trend", helpTokenTrend, "tokens-card", "font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel("Token trend", "font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -3501,22 +3501,28 @@ func TestDashboardRendersBudgetHistoryAndDailyCap(t *testing.T) {
 	for _, want := range []string{
 		"Spend today",
 		"$12.50 / $100.00",
-		`aria-label="Help: Current spend"`,
 		`aria-label="Daily budget usage"`,
 		`style="width: 13%;"`,
 		"Budget history",
-		`aria-label="Help: Budget history"`,
 		`aria-label="Spend over the last seven days"`,
 		`title="2026-05-25: $4.00"`,
 		`title="2026-05-30: $15.00"`,
 		`style="height: 100%;"`,
-		`aria-label="Help: Projected spend"`,
-		`aria-label="Help: Daily cap"`,
-		`aria-label="Help: Issue cap"`,
 		"$25.00",
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("dashboard missing %q:\n%s", want, html)
+		}
+	}
+	for _, forbidden := range []string{
+		`aria-label="Help: Current spend"`,
+		`aria-label="Help: Budget history"`,
+		`aria-label="Help: Projected spend"`,
+		`aria-label="Help: Daily cap"`,
+		`aria-label="Help: Issue cap"`,
+	} {
+		if strings.Contains(html, forbidden) {
+			t.Fatalf("dashboard rendered inline budget help %q:\n%s", forbidden, html)
 		}
 	}
 }
@@ -3569,13 +3575,10 @@ func TestDashboardRendersAccessibleHelpAffordances(t *testing.T) {
 		`aria-label="Help: Running"`,
 		`role="tooltip"`,
 		`aria-label="Help: Token throughput"`,
-		`aria-label="Help: Runtime"`,
 		`aria-label="Help: Backoff queue"`,
 		`aria-label="Help: Budget"`,
 		`aria-label="Help: Rate limits"`,
 		`aria-label="Help: Tokens"`,
-		`aria-label="Help: Diff"`,
-		`aria-label="Help: Session"`,
 		`tps`,
 		`USD`,
 	} {
@@ -3583,13 +3586,40 @@ func TestDashboardRendersAccessibleHelpAffordances(t *testing.T) {
 			t.Fatalf("dashboard missing %q:\n%s", want, html)
 		}
 	}
+	for _, headerCell := range regexp.MustCompile(`(?s)<th(?:\s|>)[^>]*>.*?</th>`).FindAllString(html, -1) {
+		if strings.Contains(headerCell, "data-help-trigger") {
+			t.Fatalf("dashboard rendered help trigger inside table header:\n%s", headerCell)
+		}
+	}
 	for _, forbidden := range []string{
 		`onmouseenter=`,
 		`onfocus=`,
 		`popovertarget=`,
+		`data-help-scope="dashboard"`,
+		`data-help-scope="dashboard-stat-strip"`,
+		`data-help-scope="running-table"`,
+		`data-help-scope="running-mobile"`,
+		`data-help-scope="retry-table"`,
+		`data-help-scope="blocked-table"`,
+		`data-help-scope="blocked-table-error"`,
+		`data-help-scope="recent-table"`,
+		`data-help-scope="recent-mobile"`,
+		`data-help-scope="budget-current-spend"`,
+		`data-help-scope="budget-burn-down"`,
+		`data-help-scope="budget-history"`,
+		`data-help-scope="budget-projected"`,
+		`data-help-scope="budget-daily-cap"`,
+		`data-help-scope="budget-issue-cap"`,
+		`data-help-scope="rate-limit-primary"`,
+		`aria-label="Help: Runtime / turns"`,
+		`aria-label="Help: Event"`,
+		`aria-label="Help: Diff"`,
+		`aria-label="Help: Session"`,
+		`aria-label="Help: Current spend"`,
+		`aria-label="Help: Token trend"`,
 	} {
 		if strings.Contains(html, forbidden) {
-			t.Fatalf("dashboard contains flicker-prone popover markup %q:\n%s", forbidden, html)
+			t.Fatalf("dashboard contains disallowed help or popover markup %q:\n%s", forbidden, html)
 		}
 	}
 }

--- a/internal/web/templates/help.go
+++ b/internal/web/templates/help.go
@@ -148,18 +148,3 @@ func helpIDPart(value string) string {
 	}
 	return result
 }
-
-func rateLimitHelpTerm(name string) helpTerm {
-	switch strings.ToLower(strings.TrimSpace(name)) {
-	case "primary":
-		return helpPrimaryRateBucket
-	case "secondary":
-		return helpSecondaryRateBucket
-	case "credits":
-		return helpCreditsRateBucket
-	case "github graphql":
-		return helpRateLimits
-	default:
-		return helpRateLimits
-	}
-}

--- a/internal/web/templates/help.templ
+++ b/internal/web/templates/help.templ
@@ -516,10 +516,9 @@ templ helpIcon(term helpTerm, scope string) {
 	}
 }
 
-templ helpInlineLabel(label string, term helpTerm, scope string, class string) {
+templ plainInlineLabel(label string, class string) {
 	<span class={ "inline-flex min-w-0 items-center gap-1.5 " + class }>
 		<span>{ label }</span>
-		@helpIcon(term, scope)
 	</span>
 }
 

--- a/internal/web/templates/help_templ.go
+++ b/internal/web/templates/help_templ.go
@@ -162,7 +162,7 @@ func helpIcon(term helpTerm, scope string) templ.Component {
 	})
 }
 
-func helpInlineLabel(label string, term helpTerm, scope string, class string) templ.Component {
+func plainInlineLabel(label string, class string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -214,15 +214,7 @@ func helpInlineLabel(label string, term helpTerm, scope string, class string) te
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</span>")
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = helpIcon(term, scope).Render(ctx, templ_7745c5c3_Buffer)
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</span></span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -251,20 +243,20 @@ func helpHeading2(label string, term helpTerm, scope string) templ.Component {
 			templ_7745c5c3_Var13 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<h2 class=\"inline-flex min-w-0 items-center gap-2 text-lg font-semibold text-foreground\"><span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<h2 class=\"inline-flex min-w-0 items-center gap-2 text-lg font-semibold text-foreground\"><span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/help.templ`, Line: 528, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/help.templ`, Line: 527, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -272,7 +264,7 @@ func helpHeading2(label string, term helpTerm, scope string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "</h2>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</h2>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -301,20 +293,20 @@ func helpHeading3(label string, term helpTerm, scope string) templ.Component {
 			templ_7745c5c3_Var15 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<h3 class=\"inline-flex min-w-0 items-center gap-2 text-sm font-semibold text-foreground\"><span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<h3 class=\"inline-flex min-w-0 items-center gap-2 text-sm font-semibold text-foreground\"><span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var16 string
 		templ_7745c5c3_Var16, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/help.templ`, Line: 535, Col: 15}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/help.templ`, Line: 534, Col: 15}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var16))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</span>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -322,7 +314,7 @@ func helpHeading3(label string, term helpTerm, scope string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "</h3>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "</h3>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/help_test.go
+++ b/internal/web/templates/help_test.go
@@ -149,6 +149,36 @@ func TestHelpIconUsesSharedTooltipMetadata(t *testing.T) {
 	}
 }
 
+func TestPlainInlineLabelRendersPlainLabel(t *testing.T) {
+	t.Parallel()
+
+	var buf bytes.Buffer
+	if err := plainInlineLabel("Tokens", "text-muted-foreground").Render(context.Background(), &buf); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	html := buf.String()
+
+	for _, want := range []string{
+		"Tokens",
+		"text-muted-foreground",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("help inline label missing %q:\n%s", want, html)
+		}
+	}
+	for _, unwanted := range []string{
+		`data-help-trigger`,
+		`data-help-tip`,
+		`aria-label="Help: Tokens"`,
+		`<button`,
+		`?`,
+	} {
+		if strings.Contains(html, unwanted) {
+			t.Fatalf("help inline label rendered help affordance %q:\n%s", unwanted, html)
+		}
+	}
+}
+
 func TestHelpTooltipHostRendersSharedBodyTooltip(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/reports.templ
+++ b/internal/web/templates/reports.templ
@@ -29,10 +29,10 @@ templ Reports(data ReportsData) {
 				</section>
 			}
 			<section class="grid gap-3 sm:grid-cols-2 lg:grid-cols-4">
-				@reportsMetricCard("Total spend", helpReportsSpend, formatUSD(data.Day.Totals.SpendUSD), reportsWindowLabel(data), "border-t-accent", "bg-accent")
-				@reportsMetricCard("Tokens", helpReportsTokens, formatInt(data.Day.Totals.TotalTokens), reportInputOutputTotals(data.Day.Totals), "border-t-success", "bg-success")
-				@reportsMetricCard("Usage events", helpReportsEvents, formatInt(data.Day.Totals.Events), "Completed ledger rows", "border-t-warning", "bg-warning")
-				@reportsMetricCard("Models", helpReportsModels, reportsModelCount(data), "Distinct model buckets", "border-t-danger", "bg-danger")
+				@reportsMetricCard("Total spend", formatUSD(data.Day.Totals.SpendUSD), reportsWindowLabel(data), "border-t-accent", "bg-accent")
+				@reportsMetricCard("Tokens", formatInt(data.Day.Totals.TotalTokens), reportInputOutputTotals(data.Day.Totals), "border-t-success", "bg-success")
+				@reportsMetricCard("Usage events", formatInt(data.Day.Totals.Events), "Completed ledger rows", "border-t-warning", "bg-warning")
+				@reportsMetricCard("Models", reportsModelCount(data), "Distinct model buckets", "border-t-danger", "bg-danger")
 			</section>
 			<section class="grid min-w-0 gap-5 xl:grid-cols-2">
 				<article class="min-w-0 rounded-md border border-border bg-card p-4 shadow-sm sm:p-5">
@@ -104,11 +104,11 @@ templ Reports(data ReportsData) {
 	}
 }
 
-templ reportsMetricCard(label string, term helpTerm, value string, detail string, borderClass string, dotClass string) {
+templ reportsMetricCard(label string, value string, detail string, borderClass string, dotClass string) {
 	<article class={ "min-w-0 rounded-md border border-border border-t-2 bg-card p-4 shadow-sm transition-colors hover:bg-muted/40 " + borderClass }>
 		<div class="flex items-start justify-between gap-3">
 			<div class="grid min-w-0 gap-1">
-				@helpInlineLabel(label, term, "reports", "text-sm font-medium text-muted-foreground")
+				@plainInlineLabel(label, "text-sm font-medium text-muted-foreground")
 				<span class="text-xs text-muted-foreground">{ detail }</span>
 			</div>
 			<span class={ "h-2.5 w-2.5 shrink-0 rounded-full " + dotClass }></span>

--- a/internal/web/templates/reports_templ.go
+++ b/internal/web/templates/reports_templ.go
@@ -122,19 +122,19 @@ func Reports(data ReportsData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = reportsMetricCard("Total spend", helpReportsSpend, formatUSD(data.Day.Totals.SpendUSD), reportsWindowLabel(data), "border-t-accent", "bg-accent").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = reportsMetricCard("Total spend", formatUSD(data.Day.Totals.SpendUSD), reportsWindowLabel(data), "border-t-accent", "bg-accent").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = reportsMetricCard("Tokens", helpReportsTokens, formatInt(data.Day.Totals.TotalTokens), reportInputOutputTotals(data.Day.Totals), "border-t-success", "bg-success").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = reportsMetricCard("Tokens", formatInt(data.Day.Totals.TotalTokens), reportInputOutputTotals(data.Day.Totals), "border-t-success", "bg-success").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = reportsMetricCard("Usage events", helpReportsEvents, formatInt(data.Day.Totals.Events), "Completed ledger rows", "border-t-warning", "bg-warning").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = reportsMetricCard("Usage events", formatInt(data.Day.Totals.Events), "Completed ledger rows", "border-t-warning", "bg-warning").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = reportsMetricCard("Models", helpReportsModels, reportsModelCount(data), "Distinct model buckets", "border-t-danger", "bg-danger").Render(ctx, templ_7745c5c3_Buffer)
+			templ_7745c5c3_Err = reportsMetricCard("Models", reportsModelCount(data), "Distinct model buckets", "border-t-danger", "bg-danger").Render(ctx, templ_7745c5c3_Buffer)
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -298,7 +298,7 @@ func Reports(data ReportsData) templ.Component {
 	})
 }
 
-func reportsMetricCard(label string, term helpTerm, value string, detail string, borderClass string, dotClass string) templ.Component {
+func reportsMetricCard(label string, value string, detail string, borderClass string, dotClass string) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -341,7 +341,7 @@ func reportsMetricCard(label string, term helpTerm, value string, detail string,
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = helpInlineLabel(label, term, "reports", "text-sm font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = plainInlineLabel(label, "text-sm font-medium text-muted-foreground").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Render lower-level dashboard and report labels as plain text so contextual help buttons remain on section headings.
- Remove the obsolete rate-limit help-term mapper after rate-limit row labels stop owning help buttons.
- Add coverage for plain inline labels and dashboard help trigger placement.

Fixes #796

## Test Plan

- [x] `go test ./internal/web/templates -run 'TestHelpTermsCoverDashboardSectionsAndMetrics|TestPlainInlineLabelRendersPlainLabel|TestDashboardRendersAccessibleHelpAffordances|TestDashboardRendersBudgetHistoryAndDailyCap'`
- [x] `make check`