### PR TITLE
Allow dependency lines without colon

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -31,6 +31,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector/factory"
 	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/dependencyline"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 )
@@ -2192,30 +2193,7 @@ func doctorDependencyBlockerIdentifier(refRepo string, number string, repo strin
 }
 
 func doctorDependencyLineReference(line string) (string, bool) {
-	line = strings.TrimSpace(line)
-	for {
-		switch {
-		case strings.HasPrefix(line, ">"):
-			line = strings.TrimSpace(strings.TrimPrefix(line, ">"))
-		case strings.HasPrefix(line, "- "):
-			line = strings.TrimSpace(strings.TrimPrefix(line, "- "))
-		case strings.HasPrefix(line, "* "):
-			line = strings.TrimSpace(strings.TrimPrefix(line, "* "))
-		case strings.HasPrefix(line, "+ "):
-			line = strings.TrimSpace(strings.TrimPrefix(line, "+ "))
-		default:
-			goto trimmed
-		}
-	}
-trimmed:
-	lower := strings.ToLower(line)
-	for _, prefix := range []string{"depends on:", "depends-on:", "blocked by:"} {
-		if strings.HasPrefix(lower, prefix) {
-			ref := strings.TrimSpace(line[len(prefix):])
-			return ref, ref != ""
-		}
-	}
-	return "", false
+	return dependencyline.Match(line)
 }
 
 func doctorDependencyBlockerLabels(blockers []doctorDependencyBlocker) []string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -716,6 +716,48 @@ func TestCheckDoctorDependencyAutoUnblock(t *testing.T) {
 	}
 }
 
+func TestDoctorDependencyTextBlockedRefsAcceptsSharedDependencyLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		want []string
+	}{
+		{
+			name: "depends on no colon",
+			body: "Depends on #414",
+			want: []string{"digitaldrywood/detent#414"},
+		},
+		{
+			name: "blocked by no colon",
+			body: "Blocked by #415",
+			want: []string{"digitaldrywood/detent#415"},
+		},
+		{
+			name: "depends on colon",
+			body: "Depends on: #416",
+			want: []string{"digitaldrywood/detent#416"},
+		},
+		{
+			name: "depends hyphen owner repo",
+			body: "depends-on digitaldrywood/agent-runtime#27",
+			want: []string{"digitaldrywood/agent-runtime#27"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := doctorBlockedRefLabels(doctorDependencyTextBlockedRefs(doctorDependencyIssueWithBody("issue-416", tt.body)))
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("doctorDependencyTextBlockedRefs() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckDoctorDependencyAutoUnblockRequiresActiveRework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/dependencyline"
 )
 
 const (
@@ -615,13 +616,12 @@ mutation DetentGitHubDeleteProjectItem($projectId: ID!, $itemId: ID!) {
 }`
 
 var (
-	modelOverridePattern  = regexp.MustCompile(`(?i)<!--\s*model:\s*(\S+?)\s*-->`)
-	dependencyLinePattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*:\\s*(?:[*_`~]+)?\\s*(.+)\\s*$")
-	issueRefPattern       = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
-	issueURLPattern       = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
-	numberedListPattern   = regexp.MustCompile(`^\d+[.)]\s+`)
-	branchKeyPattern      = regexp.MustCompile(`[^A-Za-z0-9._-]`)
-	actionRunURLPattern   = regexp.MustCompile(`/actions/runs/([0-9]+)(?:/|$)`)
+	modelOverridePattern = regexp.MustCompile(`(?i)<!--\s*model:\s*(\S+?)\s*-->`)
+	issueRefPattern      = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
+	issueURLPattern      = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
+	numberedListPattern  = regexp.MustCompile(`^\d+[.)]\s+`)
+	branchKeyPattern     = regexp.MustCompile(`[^A-Za-z0-9._-]`)
+	actionRunURLPattern  = regexp.MustCompile(`/actions/runs/([0-9]+)(?:/|$)`)
 )
 
 type pageInfo struct {
@@ -4621,11 +4621,11 @@ func parseBlockedBy(body string, repo string) []connector.BlockedRef {
 	for _, line := range strings.FieldsFunc(body, func(r rune) bool {
 		return r == '\n' || r == '\r'
 	}) {
-		lineMatches := dependencyLinePattern.FindStringSubmatch(line)
-		if len(lineMatches) != 2 {
+		text, ok := dependencyline.Match(line)
+		if !ok {
 			continue
 		}
-		for _, identifier := range issueReferencesInText(lineMatches[1], repo) {
+		for _, identifier := range issueReferencesInText(text, repo) {
 			key := normalizedIssueIdentifier(identifier)
 			if key == "" {
 				continue

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -467,18 +467,22 @@ func TestParseBlockedByRecognizesIssueReferences(t *testing.T) {
 	t.Parallel()
 
 	body := strings.Join([]string{
-		"Depends on: #24",
-		"Blocked by: digitaldrywood/agent-runtime#25",
-		"Depends on: https://github.com/digitaldrywood/detent/issues/26",
-		"Depends on: https://github.com/digitaldrywood/detent/issues/26 and #24",
-		"Mention only: #27",
+		"Depends on #24",
+		"Blocked by #25",
+		"Depends on: #26",
+		"depends-on digitaldrywood/agent-runtime#27",
+		"Depends on: https://github.com/digitaldrywood/detent/issues/28",
+		"Depends on: https://github.com/digitaldrywood/detent/issues/28 and #24",
+		"Mention only: #29",
 	}, "\n")
 
 	got := parseBlockedBy(body, "digitaldrywood/detent")
 	want := []connector.BlockedRef{
 		{Identifier: "digitaldrywood/detent#24"},
-		{Identifier: "digitaldrywood/agent-runtime#25"},
+		{Identifier: "digitaldrywood/detent#25"},
 		{Identifier: "digitaldrywood/detent#26"},
+		{Identifier: "digitaldrywood/agent-runtime#27"},
+		{Identifier: "digitaldrywood/detent#28"},
 	}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("parseBlockedBy() = %#v, want %#v", got, want)

--- a/internal/dependencyline/dependencyline.go
+++ b/internal/dependencyline/dependencyline.go
@@ -1,0 +1,13 @@
+package dependencyline
+
+import "regexp"
+
+var pattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*(?::\\s*|\\s+)(?:[*_`~]+)?\\s*(.+)\\s*$")
+
+func Match(line string) (string, bool) {
+	matches := pattern.FindStringSubmatch(line)
+	if len(matches) != 2 {
+		return "", false
+	}
+	return matches[1], true
+}

--- a/internal/dependencyline/dependencyline_test.go
+++ b/internal/dependencyline/dependencyline_test.go
@@ -1,0 +1,35 @@
+package dependencyline
+
+import "testing"
+
+func TestMatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		line     string
+		wantText string
+		wantOK   bool
+	}{
+		{name: "depends on no colon", line: "Depends on #1443", wantText: "#1443", wantOK: true},
+		{name: "blocked by no colon", line: "Blocked by #1447", wantText: "#1447", wantOK: true},
+		{name: "depends on colon", line: "Depends on: #1443", wantText: "#1443", wantOK: true},
+		{name: "depends on colon no space", line: "Depends on:#1443", wantText: "#1443", wantOK: true},
+		{name: "depends hyphen owner repo", line: "depends-on digitaldrywood/detent#1443", wantText: "digitaldrywood/detent#1443", wantOK: true},
+		{name: "mention only", line: "Mention only #1443", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotText, gotOK := Match(tt.line)
+			if gotOK != tt.wantOK {
+				t.Fatalf("Match() ok = %v, want %v", gotOK, tt.wantOK)
+			}
+			if gotText != tt.wantText {
+				t.Fatalf("Match() text = %q, want %q", gotText, tt.wantText)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -9,6 +9,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/dependencyline"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -31,7 +32,6 @@ type dependencyBlocker struct {
 }
 
 var (
-	dependencyTextLinePattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*:\\s*(?:[*_`~]+)?\\s*(.+)\\s*$")
 	dependencyIssueRefPattern = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
 	dependencyIssueURLPattern = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
 )
@@ -192,11 +192,11 @@ func dependencyLineRefs(body string, repo string) []connector.BlockedRef {
 	for _, line := range strings.FieldsFunc(body, func(r rune) bool {
 		return r == '\n' || r == '\r'
 	}) {
-		lineMatches := dependencyTextLinePattern.FindStringSubmatch(line)
-		if len(lineMatches) != 2 {
+		text, ok := dependencyline.Match(line)
+		if !ok {
 			continue
 		}
-		refs = append(refs, dependencyRefsInText(lineMatches[1], repo)...)
+		refs = append(refs, dependencyRefsInText(text, repo)...)
 	}
 	return refs
 }

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -99,29 +99,45 @@ func TestTickAutoUnblocksLightweightDependencyWaitingIssue(t *testing.T) {
 func TestTickAutoUnblocksDependencyFromIssueBody(t *testing.T) {
 	t.Parallel()
 
-	waiting := dependencyAutoUnblockIssue("issue-body-blocked", "Blocked")
-	waiting.Description = "Depends on: #415"
-	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
-	blocker.Identifier = "digitaldrywood/detent#415"
-	tracker := &dependencyAutoUnblockConnector{
-		stateIssues: []connector.Issue{waiting},
-		blockers:    []connector.Issue{blocker},
+	tests := []struct {
+		name        string
+		description string
+	}{
+		{name: "depends on colon", description: "Depends on: #415"},
+		{name: "depends on no colon", description: "Depends on #415"},
+		{name: "blocked by no colon", description: "Blocked by #415"},
+		{name: "depends hyphen owner repo", description: "depends-on digitaldrywood/detent#415"},
 	}
-	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
-		Enabled:      true,
-		SourceStates: []string{"Blocked"},
-		TargetState:  "Todo",
-		Readiness:    DependencyReadinessTerminalOrMerged,
-	})
-	state := newState(orch.cfg)
 
-	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 3, 30, 0, time.UTC))
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
 
-	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
-		t.Fatalf("updates = %#v, want Blocked issue moved to Todo", got)
-	}
-	if !slices.Contains(tracker.identifierCalls, "digitaldrywood/detent#415") {
-		t.Fatalf("identifier calls = %#v, want dependency lookup", tracker.identifierCalls)
+			waiting := dependencyAutoUnblockIssue("issue-body-blocked", "Blocked")
+			waiting.Description = tt.description
+			blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+			blocker.Identifier = "digitaldrywood/detent#415"
+			tracker := &dependencyAutoUnblockConnector{
+				stateIssues: []connector.Issue{waiting},
+				blockers:    []connector.Issue{blocker},
+			}
+			orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+				Enabled:      true,
+				SourceStates: []string{"Blocked"},
+				TargetState:  "Todo",
+				Readiness:    DependencyReadinessTerminalOrMerged,
+			})
+			state := newState(orch.cfg)
+
+			orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 3, 30, 0, time.UTC))
+
+			if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: waiting.ID, state: "Todo"}) {
+				t.Fatalf("updates = %#v, want Blocked issue moved to Todo", got)
+			}
+			if !slices.Contains(tracker.identifierCalls, "digitaldrywood/detent#415") {
+				t.Fatalf("identifier calls = %#v, want dependency lookup", tracker.identifierCalls)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/epic.go
+++ b/internal/orchestrator/epic.go
@@ -8,13 +8,13 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/dependencyline"
 )
 
 var (
-	epicDependencyLinePattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*:\\s*(?:[*_`~]+)?\\s*(.+)\\s*$")
-	epicChecklistLinePattern  = regexp.MustCompile(`^\s*[-*+]\s+\[[ xX]\]\s+(.+)$`)
-	epicIssueRefPattern       = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
-	epicIssueURLPattern       = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
+	epicChecklistLinePattern = regexp.MustCompile(`^\s*[-*+]\s+\[[ xX]\]\s+(.+)$`)
+	epicIssueRefPattern      = regexp.MustCompile(`(?:([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+))?#(\d+)`)
+	epicIssueURLPattern      = regexp.MustCompile(`https?://github\.com/([A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+)/issues/(\d+)`)
 )
 
 type completedEpicPlan struct {
@@ -551,8 +551,8 @@ func parseEpicBodyChildRefs(body string, repo string) []connector.BlockedRef {
 	for _, line := range strings.FieldsFunc(body, func(r rune) bool {
 		return r == '\n' || r == '\r'
 	}) {
-		if matches := epicDependencyLinePattern.FindStringSubmatch(line); len(matches) == 2 {
-			children = append(children, parseEpicRefs(matches[1], repo)...)
+		if text, ok := dependencyline.Match(line); ok {
+			children = append(children, parseEpicRefs(text, repo)...)
 			continue
 		}
 		if matches := epicChecklistLinePattern.FindStringSubmatch(line); len(matches) == 2 {

--- a/internal/orchestrator/epic_test.go
+++ b/internal/orchestrator/epic_test.go
@@ -57,6 +57,8 @@ func TestEpicChildRefs(t *testing.T) {
 		"- [ ] #251",
 		"- [x] https://github.com/digitaldrywood/detent/issues/252",
 		"Depends on: #253 digitaldrywood/detent#253",
+		"Blocked by #256",
+		"depends-on digitaldrywood/detent#257",
 	}, "\n"))
 	issue.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#254"}}
 	issue.ChildIssues = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#255"}}
@@ -66,6 +68,8 @@ func TestEpicChildRefs(t *testing.T) {
 		{Identifier: "digitaldrywood/detent#251"},
 		{Identifier: "digitaldrywood/detent#252"},
 		{Identifier: "digitaldrywood/detent#253"},
+		{Identifier: "digitaldrywood/detent#256"},
+		{Identifier: "digitaldrywood/detent#257"},
 		{Identifier: "digitaldrywood/detent#254"},
 		{Identifier: "digitaldrywood/detent#255"},
 	}


### PR DESCRIPTION
## Summary

- Add a shared dependency-line matcher used by GitHub connector parsing, dependency auto-unblock, epic child parsing, and doctor dependency diagnostics.
- Accept no-colon `Depends on #N` and `Blocked by #N` lines, plus `depends-on owner/repo#N`, while preserving existing colon forms.
- Add focused coverage for the shared matcher, the parser consumers, and doctor text blocker extraction.

Fixes #772

## Test Plan

- [x] `go test ./internal/cli ./internal/dependencyline ./internal/connector/github ./internal/orchestrator -run 'TestDoctorDependencyTextBlockedRefsAcceptsSharedDependencyLines|TestCheckDoctorDependencyAutoUnblock|TestMatch|TestParseBlockedByRecognizesIssueReferences|TestTickAutoUnblocksDependencyFromIssueBody|TestEpicChildRefs'`
- [x] `make check`