### PR TITLE
Recover blocked CI dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -641,6 +641,13 @@ tracker:
       - Blocked
     target_state: Todo
     readiness: terminal_or_merged
+  blocker_auto_promote:
+    enabled: false
+    blocker_states:
+      - Backlog
+      - Blocked
+      - Human Review
+    target_state: Todo
 polling:
   interval_ms: 120000
 workspace:
@@ -685,6 +692,7 @@ gate:
   run: make check
   require_automated_review: true
   ci_failure_action: rework
+  transient_ci_retry_limit: 2
   validator:
     enabled: false
     model: ""
@@ -738,6 +746,7 @@ gate:
   kind: command
   run: make check
   ci_failure_action: rework
+  transient_ci_retry_limit: 2
   validator:
     enabled: false
     model: ""
@@ -782,6 +791,7 @@ gate:
   kind: command
   run: make check
   ci_failure_action: rework
+  transient_ci_retry_limit: 2
   validator:
     enabled: false
     model: ""
@@ -1465,6 +1475,10 @@ of that state is controlled by the workflow:
   from `Human Review` back to `Rework` by default; set
   `gate.ci_failure_action: skip` only when non-green CI should leave the item
   parked.
+- `gate.transient_ci_retry_limit` controls how many times Detent reruns
+  failed checks with transient runner or infrastructure signals such as
+  timeouts, startup failures, OOM kills, or `signal: killed` annotations before
+  red CI is treated as a hard failure.
 - `gate.validator.enabled: true` runs a validator-agent review before
   auto-promotion; verdicts below `min_score` or with severities in `block_on`
   route the issue to `Rework`.
@@ -1593,6 +1607,16 @@ the wait should be visible on the board.
   `tracker.dependency_auto_unblock.enabled: true`, a `Blocked` issue is observed
   for display but will not be moved back to `Todo`. Human blockers without
   explicit dependency references stay blocked.
+- **Queue fixable blockers automatically.** Enable
+  `tracker.blocker_auto_promote` alongside dependency auto-unblock when a
+  dependency-waiting issue should pull same-repository blockers out of inactive
+  states such as `Backlog`, `Blocked`, or `Human Review`. Detent promotes only
+  resolved, same-repository blockers to the configured `target_state`, respects
+  current local agent capacity, and posts an audit comment on the promoted
+  blocker. Agents that move work to `Blocked` because of another tracked issue
+  or pull request must ensure the issue body contains a machine-readable
+  `Blocked by:` or `Depends on:` line; Workpad mentions alone are not a durable
+  dependency contract.
 
 Before you dispatch anything, run **`detent doctor --allow-write-probes`** after
 mutation authorization — it checks config

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -39,6 +39,13 @@ tracker:
       - Blocked
     target_state: Todo
     readiness: terminal_or_merged
+  blocker_auto_promote:
+    enabled: false
+    blocker_states:
+      - Backlog
+      - Blocked
+      - Human Review
+    target_state: Todo
 polling:
   interval_ms: 120000
 workspace:
@@ -80,6 +87,7 @@ gate:
   run: make check
   require_automated_review: true
   ci_failure_action: rework
+  transient_ci_retry_limit: 2
   validator:
     enabled: false
     model: ""

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -39,6 +39,13 @@ tracker:
       - Blocked
     target_state: Todo
     readiness: terminal_or_merged
+  blocker_auto_promote:
+    enabled: false
+    blocker_states:
+      - Backlog
+      - Blocked
+      - Human Review
+    target_state: Todo
 polling:
   interval_ms: 120000
 workspace:
@@ -80,6 +87,7 @@ gate:
   run: make check
   require_automated_review: true
   ci_failure_action: rework
+  transient_ci_retry_limit: 2
   validator:
     enabled: false
     model: ""

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -38,6 +38,13 @@ tracker:
       - Blocked
     target_state: Todo
     readiness: terminal_or_merged
+  blocker_auto_promote:
+    enabled: false
+    blocker_states:
+      - Backlog
+      - Blocked
+      - Human Review
+    target_state: Todo
 polling:
   interval_ms: 120000
 workspace:
@@ -79,6 +86,7 @@ gate:
   run: make check
   require_automated_review: true
   ci_failure_action: rework
+  transient_ci_retry_limit: 2
   validator:
     enabled: false
     model: ""

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -108,6 +108,7 @@ type Tracker struct {
 	StateMap                    StringOrMap           `yaml:"state_map"`
 	PriorityMap                 StringOrMap           `yaml:"priority_map"`
 	DependencyAutoUnblock       DependencyAutoUnblock `yaml:"dependency_auto_unblock"`
+	BlockerAutoPromote          BlockerAutoPromote    `yaml:"blocker_auto_promote"`
 	AutoProvision               bool                  `yaml:"auto_provision"`
 	Claims                      Claims                `yaml:"claims,omitempty"`
 	Authorization               selector.Selector     `yaml:"authorization,omitempty"`
@@ -125,6 +126,13 @@ type DependencyAutoUnblock struct {
 	SourceStates []string `yaml:"source_states"`
 	TargetState  string   `yaml:"target_state"`
 	Readiness    string   `yaml:"readiness"`
+}
+
+type BlockerAutoPromote struct {
+	Enabled       bool     `yaml:"enabled"`
+	SourceStates  []string `yaml:"source_states"`
+	BlockerStates []string `yaml:"blocker_states"`
+	TargetState   string   `yaml:"target_state"`
 }
 
 type Identity struct {
@@ -475,6 +483,27 @@ func (d DependencyAutoUnblock) Validate(prefix string) []string {
 	return problems
 }
 
+func (b *BlockerAutoPromote) Normalize() {
+	if b == nil {
+		return
+	}
+	b.SourceStates = normalizeStateList(b.SourceStates)
+	b.BlockerStates = normalizeStateList(b.BlockerStates)
+	b.TargetState = strings.TrimSpace(b.TargetState)
+}
+
+func (b BlockerAutoPromote) Validate(prefix string) []string {
+	b.Normalize()
+
+	var problems []string
+	validateStateList(prefix+".source_states", b.SourceStates, &problems)
+	validateStateList(prefix+".blocker_states", b.BlockerStates, &problems)
+	if b.Enabled && strings.TrimSpace(b.TargetState) == "" {
+		problems = append(problems, prefix+".target_state is required when "+prefix+".enabled is true")
+	}
+	return problems
+}
+
 type StringOrMap struct {
 	IsString bool
 	String   string
@@ -554,6 +583,10 @@ func Default() Config {
 				SourceStates: []string{"Blocked"},
 				TargetState:  "Todo",
 				Readiness:    DependencyReadinessTerminalOrMerged,
+			},
+			BlockerAutoPromote: BlockerAutoPromote{
+				BlockerStates: []string{"Backlog", "Blocked", "Human Review"},
+				TargetState:   "Todo",
 			},
 			AutoProvision: true,
 		},
@@ -718,6 +751,7 @@ func (c *Config) normalize() {
 	c.Tracker.LocalSQLite.Normalize()
 	c.Tracker.Claims.Normalize()
 	c.Tracker.DependencyAutoUnblock.Normalize()
+	c.Tracker.BlockerAutoPromote.Normalize()
 	c.Tracker.Authorization.Normalize()
 	c.Workspace.Normalize()
 	c.Deliverable.Normalize()
@@ -776,6 +810,7 @@ func (c *Config) validateTracker(problems *[]string) {
 	if c.Tracker.DependencyAutoUnblock.Enabled && !stateListContains(c.Tracker.ActiveStates, "Rework") {
 		*problems = append(*problems, "tracker.active_states must include Rework when tracker.dependency_auto_unblock.enabled is true")
 	}
+	*problems = append(*problems, c.Tracker.BlockerAutoPromote.Validate("tracker.blocker_auto_promote")...)
 	validatePositive("tracker.http_max_idle_conns", c.Tracker.HTTPMaxIdleConns, problems)
 	validatePositive("tracker.http_max_idle_conns_per_host", c.Tracker.HTTPMaxIdleConnsPerHost, problems)
 	validatePositive("tracker.http_idle_conn_timeout_ms", c.Tracker.HTTPIdleConnTimeoutMS, problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,6 +63,15 @@ tracker:
       - Waiting
     target_state: Todo
     readiness: terminal_or_merged
+  blocker_auto_promote:
+    enabled: true
+    source_states:
+      - Blocked
+      - Rework
+    blocker_states:
+      - Backlog
+      - Human Review
+    target_state: Todo
 polling:
   interval_ms: 60000
 workspace:
@@ -252,6 +261,18 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Tracker.DependencyAutoUnblock.Readiness != DependencyReadinessTerminalOrMerged {
 		t.Fatalf("Tracker.DependencyAutoUnblock.Readiness = %q, want %q", cfg.Tracker.DependencyAutoUnblock.Readiness, DependencyReadinessTerminalOrMerged)
+	}
+	if !cfg.Tracker.BlockerAutoPromote.Enabled {
+		t.Fatal("Tracker.BlockerAutoPromote.Enabled = false, want true")
+	}
+	if got := cfg.Tracker.BlockerAutoPromote.SourceStates; !reflect.DeepEqual(got, []string{"blocked", "rework"}) {
+		t.Fatalf("Tracker.BlockerAutoPromote.SourceStates = %#v, want blocked/rework", got)
+	}
+	if got := cfg.Tracker.BlockerAutoPromote.BlockerStates; !reflect.DeepEqual(got, []string{"backlog", "human review"}) {
+		t.Fatalf("Tracker.BlockerAutoPromote.BlockerStates = %#v, want backlog/human review", got)
+	}
+	if cfg.Tracker.BlockerAutoPromote.TargetState != "Todo" {
+		t.Fatalf("Tracker.BlockerAutoPromote.TargetState = %q, want Todo", cfg.Tracker.BlockerAutoPromote.TargetState)
 	}
 	if got := cfg.Agent.MaxConcurrentAgentsByState["merging"]; got != 1 {
 		t.Fatalf("Agent.MaxConcurrentAgentsByState[merging] = %d, want 1", got)
@@ -477,6 +498,15 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Tracker.DependencyAutoUnblock.Readiness != DependencyReadinessTerminalOrMerged {
 		t.Fatalf("Tracker.DependencyAutoUnblock.Readiness = %q, want %q", cfg.Tracker.DependencyAutoUnblock.Readiness, DependencyReadinessTerminalOrMerged)
+	}
+	if cfg.Tracker.BlockerAutoPromote.Enabled {
+		t.Fatal("Tracker.BlockerAutoPromote.Enabled = true, want disabled by default")
+	}
+	if got := cfg.Tracker.BlockerAutoPromote.BlockerStates; !reflect.DeepEqual(got, []string{"backlog", "blocked", "human review"}) {
+		t.Fatalf("Tracker.BlockerAutoPromote.BlockerStates = %#v, want backlog/blocked/human review", got)
+	}
+	if cfg.Tracker.BlockerAutoPromote.TargetState != "Todo" {
+		t.Fatalf("Tracker.BlockerAutoPromote.TargetState = %q, want Todo", cfg.Tracker.BlockerAutoPromote.TargetState)
 	}
 	if cfg.Polling.IntervalMS != 120000 {
 		t.Fatalf("Polling.IntervalMS = %d", cfg.Polling.IntervalMS)
@@ -848,6 +878,7 @@ gate:
   kind: command
   run: make check
   ci_failure_action: rework
+  transient_ci_retry_limit: 3
 ---
 Prompt
 `))
@@ -861,6 +892,30 @@ Prompt
 	cfg := workflow.Config.Gate
 	if cfg.CIFailureAction != gate.CIFailureActionRework {
 		t.Fatalf("Gate.CIFailureAction = %q, want %q", cfg.CIFailureAction, gate.CIFailureActionRework)
+	}
+	if cfg.TransientCIRetryLimit == nil || *cfg.TransientCIRetryLimit != 3 {
+		t.Fatalf("Gate.TransientCIRetryLimit = %v, want 3", cfg.TransientCIRetryLimit)
+	}
+}
+
+func TestParseWorkflowGateTransientCIRetryLimitCanDisable(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+gate:
+  transient_ci_retry_limit: 0
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	cfg := workflow.Config.Gate
+	if cfg.TransientCIRetryLimit == nil || *cfg.TransientCIRetryLimit != 0 {
+		t.Fatalf("Gate.TransientCIRetryLimit = %v, want 0", cfg.TransientCIRetryLimit)
 	}
 }
 
@@ -1351,6 +1406,39 @@ Prompt
 `,
 			want: []string{
 				"tracker.active_states must include Rework when tracker.dependency_auto_unblock.enabled is true",
+			},
+		},
+		{
+			name: "invalid blocker auto promote config",
+			raw: `---
+tracker:
+  kind: memory
+  blocker_auto_promote:
+    enabled: true
+    source_states: [""]
+    blocker_states: [""]
+    target_state: ""
+---
+Prompt
+`,
+			want: []string{
+				"tracker.blocker_auto_promote.source_states state names must not be blank",
+				"tracker.blocker_auto_promote.blocker_states state names must not be blank",
+				"tracker.blocker_auto_promote.target_state is required when tracker.blocker_auto_promote.enabled is true",
+			},
+		},
+		{
+			name: "invalid transient ci retry limit",
+			raw: `---
+tracker:
+  kind: memory
+gate:
+  transient_ci_retry_limit: -1
+---
+Prompt
+`,
+			want: []string{
+				"gate.transient_ci_retry_limit must be greater than or equal to 0",
 			},
 		},
 		{

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -62,6 +62,10 @@ type PullRequestHydrator interface {
 	HydratePullRequest(context.Context, Issue) (Issue, error)
 }
 
+type PullRequestCheckRerunner interface {
+	RerunPullRequestChecks(context.Context, Issue, []PullRequestCheck) error
+}
+
 type IssueCommentReader interface {
 	FetchIssueComments(context.Context, Issue) ([]IssueComment, error)
 }

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -831,13 +831,29 @@ type restCheckRuns struct {
 }
 
 type restCheckRun struct {
-	Status      string     `json:"status"`
-	Conclusion  string     `json:"conclusion"`
-	Name        string     `json:"name"`
-	DetailsURL  string     `json:"details_url"`
-	CreatedAt   *time.Time `json:"created_at"`
-	StartedAt   *time.Time `json:"started_at"`
-	CompletedAt *time.Time `json:"completed_at"`
+	ID          int64          `json:"id"`
+	Status      string         `json:"status"`
+	Conclusion  string         `json:"conclusion"`
+	Name        string         `json:"name"`
+	DetailsURL  string         `json:"details_url"`
+	HTMLURL     string         `json:"html_url"`
+	Output      checkRunOutput `json:"output"`
+	CreatedAt   *time.Time     `json:"created_at"`
+	StartedAt   *time.Time     `json:"started_at"`
+	CompletedAt *time.Time     `json:"completed_at"`
+}
+
+type checkRunOutput struct {
+	Title   string `json:"title"`
+	Summary string `json:"summary"`
+	Text    string `json:"text"`
+}
+
+type restCheckRunAnnotation struct {
+	Path            string `json:"path"`
+	AnnotationLevel string `json:"annotation_level"`
+	Message         string `json:"message"`
+	RawDetails      string `json:"raw_details"`
 }
 
 type restWorkflowRun struct {
@@ -860,6 +876,7 @@ type pullRequestCI struct {
 	CIDurationSeconds  int64
 	SlowChecks         []connector.PullRequestCheck
 	RunningChecks      []string
+	TransientFailures  []connector.PullRequestCheck
 }
 
 type checkRunTelemetrySummary struct {
@@ -2226,6 +2243,42 @@ func (c *Connector) MergePullRequest(ctx context.Context, repository string, num
 	return nil
 }
 
+func (c *Connector) RerunPullRequestChecks(ctx context.Context, issue connector.Issue, checks []connector.PullRequestCheck) error {
+	repo, _, ok := hydratedPullRequestRef(issue)
+	if !ok {
+		return fmt.Errorf("rerun github pull request checks: missing pull request repository")
+	}
+	seenRuns := map[int64]struct{}{}
+	seenChecks := map[int64]struct{}{}
+	var errs []error
+	for _, check := range checks {
+		if check.WorkflowRunID > 0 {
+			if _, ok := seenRuns[check.WorkflowRunID]; ok {
+				continue
+			}
+			seenRuns[check.WorkflowRunID] = struct{}{}
+			if err := c.client.REST(ctx, http.MethodPost, restWorkflowRunRerunFailedJobsPath(repo, check.WorkflowRunID), nil, nil); err != nil {
+				errs = append(errs, fmt.Errorf("rerun workflow run %d: %w", check.WorkflowRunID, err))
+			}
+			continue
+		}
+		if check.ID <= 0 {
+			continue
+		}
+		if _, ok := seenChecks[check.ID]; ok {
+			continue
+		}
+		seenChecks[check.ID] = struct{}{}
+		if err := c.client.REST(ctx, http.MethodPost, restCheckRunRerequestPath(repo, check.ID), nil, nil); err != nil {
+			errs = append(errs, fmt.Errorf("rerequest check run %d: %w", check.ID, err))
+		}
+	}
+	if len(errs) > 0 {
+		return fmt.Errorf("rerun github pull request checks: %w", errors.Join(errs...))
+	}
+	return nil
+}
+
 func hydratedPullRequestRef(issue connector.Issue) (pullRequestRepo, int, bool) {
 	number := 0
 	if issue.PullRequest != nil && issue.PullRequest.Number > 0 {
@@ -2408,6 +2461,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		CIDurationSeconds:            pullRequest.CI.CIDurationSeconds,
 		SlowChecks:                   append([]connector.PullRequestCheck(nil), pullRequest.CI.SlowChecks...),
 		RunningChecks:                append([]string(nil), pullRequest.CI.RunningChecks...),
+		TransientFailedChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.TransientFailures...),
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
 		CodexReviewSubmittedAt:       pullRequestCodexReviewSubmittedAt(pullRequest),
 		CodexReviewFindings:          pullRequestCodexReviewFindings(pullRequest),
@@ -2659,7 +2713,114 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 		CIDurationSeconds:  telemetry.DurationSeconds,
 		SlowChecks:         telemetry.SlowChecks,
 		RunningChecks:      telemetry.RunningChecks,
+		TransientFailures:  c.transientCheckRunFailures(ctx, repo, checkRuns),
 	}, nil
+}
+
+func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequestRepo, checkRuns []restCheckRun) []connector.PullRequestCheck {
+	failures := make([]connector.PullRequestCheck, 0)
+	for _, checkRun := range checkRuns {
+		if !completedFailedCheckRun(checkRun) {
+			continue
+		}
+		text := checkRunTransientText(checkRun)
+		if checkRun.ID > 0 {
+			annotations, err := fetchRESTCheckRunAnnotations(ctx, c.client, restCheckRunAnnotationsPath(repo, checkRun.ID))
+			if err != nil {
+				if c.logger != nil {
+					c.logger.DebugContext(ctx, "fetch github check run annotations failed", "check_run_id", checkRun.ID, "check_run_name", checkRun.Name, "error", err)
+				}
+			} else {
+				text = strings.TrimSpace(text + "\n" + checkRunAnnotationTransientText(annotations))
+			}
+		}
+		if !transientCheckFailureText(text) && !transientCheckConclusion(checkRun.Conclusion) {
+			continue
+		}
+		failures = append(failures, connector.PullRequestCheck{
+			ID:            checkRun.ID,
+			WorkflowRunID: checkRunWorkflowRunID(checkRun),
+			Name:          strings.TrimSpace(checkRun.Name),
+			Status:        strings.ToLower(strings.TrimSpace(checkRun.Status)),
+			Conclusion:    strings.ToLower(strings.TrimSpace(checkRun.Conclusion)),
+			DetailsURL:    firstNonBlank(checkRun.DetailsURL, checkRun.HTMLURL),
+		})
+	}
+	return failures
+}
+
+func completedFailedCheckRun(checkRun restCheckRun) bool {
+	if strings.ToLower(strings.TrimSpace(checkRun.Status)) != "completed" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(checkRun.Conclusion)) {
+	case "", "success", "skipped", "neutral":
+		return false
+	default:
+		return true
+	}
+}
+
+func checkRunTransientText(checkRun restCheckRun) string {
+	return strings.Join([]string{
+		checkRun.Name,
+		checkRun.Conclusion,
+		checkRun.Output.Title,
+		checkRun.Output.Summary,
+		checkRun.Output.Text,
+	}, "\n")
+}
+
+func checkRunAnnotationTransientText(annotations []restCheckRunAnnotation) string {
+	parts := make([]string, 0, len(annotations)*3)
+	for _, annotation := range annotations {
+		parts = append(parts, annotation.Path, annotation.Message, annotation.RawDetails)
+	}
+	return strings.Join(parts, "\n")
+}
+
+func transientCheckConclusion(conclusion string) bool {
+	switch strings.ToLower(strings.TrimSpace(conclusion)) {
+	case "timed_out", "startup_failure":
+		return true
+	default:
+		return false
+	}
+}
+
+func transientCheckFailureText(text string) bool {
+	text = strings.ToLower(strings.Join(strings.Fields(text), " "))
+	if text == "" {
+		return false
+	}
+	for _, phrase := range []string{
+		"signal: killed",
+		"compile: signal: killed",
+		"out of memory",
+		"oom",
+		"oom-kill",
+		"oom killed",
+		"exit code 137",
+		"killed process",
+		"runner lost communication",
+		"the hosted runner",
+		"operation was canceled by the runner",
+		"no space left on device",
+	} {
+		if strings.Contains(text, phrase) {
+			return true
+		}
+	}
+	return false
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return ""
 }
 
 func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullRequestRepo, number int, headSHA string) (pullRequestCodexReviews, error) {
@@ -3778,6 +3939,20 @@ func restWorkflowRunPath(repo pullRequestRepo, runID int64) string {
 	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/actions/runs/" + strconv.FormatInt(runID, 10)
 }
 
+func restWorkflowRunRerunFailedJobsPath(repo pullRequestRepo, runID int64) string {
+	return restWorkflowRunPath(repo, runID) + "/rerun-failed-jobs"
+}
+
+func restCheckRunAnnotationsPath(repo pullRequestRepo, checkRunID int64) string {
+	values := url.Values{}
+	values.Set("per_page", "100")
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/check-runs/" + strconv.FormatInt(checkRunID, 10) + "/annotations?" + values.Encode()
+}
+
+func restCheckRunRerequestPath(repo pullRequestRepo, checkRunID int64) string {
+	return "/repos/" + url.PathEscape(repo.Owner) + "/" + url.PathEscape(repo.Name) + "/check-runs/" + strconv.FormatInt(checkRunID, 10) + "/rerequest"
+}
+
 func restCommitStatusesPath(repo pullRequestRepo, sha string) string {
 	values := url.Values{}
 	values.Set("per_page", "100")
@@ -3818,6 +3993,23 @@ func fetchRESTCheckRuns(ctx context.Context, client *Client, path string) ([]res
 	return checkRuns, nil
 }
 
+func fetchRESTCheckRunAnnotations(ctx context.Context, client *Client, path string) ([]restCheckRunAnnotation, error) {
+	annotations := []restCheckRunAnnotation{}
+	for path != "" {
+		var page []restCheckRunAnnotation
+		headers, err := client.rest(ctx, http.MethodGet, path, nil, &page)
+		if err != nil {
+			return nil, err
+		}
+		annotations = append(annotations, page...)
+		path, err = client.nextRESTPage(headers)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return annotations, nil
+}
+
 func fetchRESTWorkflowRunsForCheckRuns(ctx context.Context, client *Client, repo pullRequestRepo, checkRuns []restCheckRun) ([]restWorkflowRun, error) {
 	runIDs := checkRunWorkflowRunIDs(checkRuns)
 	runs := make([]restWorkflowRun, 0, len(runIDs))
@@ -3835,12 +4027,8 @@ func fetchRESTWorkflowRunsForCheckRuns(ctx context.Context, client *Client, repo
 func checkRunWorkflowRunIDs(checkRuns []restCheckRun) []int64 {
 	seen := map[int64]struct{}{}
 	for _, checkRun := range checkRuns {
-		match := actionRunURLPattern.FindStringSubmatch(strings.TrimSpace(checkRun.DetailsURL))
-		if len(match) != 2 {
-			continue
-		}
-		runID, err := strconv.ParseInt(match[1], 10, 64)
-		if err != nil || runID <= 0 {
+		runID := checkRunWorkflowRunID(checkRun)
+		if runID <= 0 {
 			continue
 		}
 		seen[runID] = struct{}{}
@@ -3853,6 +4041,20 @@ func checkRunWorkflowRunIDs(checkRuns []restCheckRun) []int64 {
 		return runIDs[i] < runIDs[j]
 	})
 	return runIDs
+}
+
+func checkRunWorkflowRunID(checkRun restCheckRun) int64 {
+	for _, value := range []string{checkRun.DetailsURL, checkRun.HTMLURL} {
+		match := actionRunURLPattern.FindStringSubmatch(strings.TrimSpace(value))
+		if len(match) != 2 {
+			continue
+		}
+		runID, err := strconv.ParseInt(match[1], 10, 64)
+		if err == nil && runID > 0 {
+			return runID
+		}
+	}
+	return 0
 }
 
 func githubIssueNodeFromREST(ref issueRef, issue restIssue) githubIssueNode {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2496,6 +2496,102 @@ func TestConnectorHydratePullRequestRefreshesCurrentStatus(t *testing.T) {
 	}
 }
 
+func TestConnectorHydratePullRequestDetectsTransientKilledCheck(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42",
+			body:   `{"number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","mergeable_state":"clean","head":{"ref":"detent/example","sha":"head-sha"},"base":{"sha":"base-sha"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"id":9001,"name":"Checks","status":"completed","conclusion":"failure","details_url":"https://github.com/example/repo/actions/runs/8001/job/9001"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/actions/runs/8001",
+			body:   `{"id":8001}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/check-runs/9001/annotations?per_page=100",
+			body:   `[{"path":"internal/web/page_templ.go","annotation_level":"failure","message":"compile: signal: killed (typecheck)"}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{})
+	prNumber := 42
+	issue := connector.Issue{
+		ID:         "I_kw42",
+		Identifier: "example/repo#1",
+		PRNumber:   &prNumber,
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+	if got.PullRequest == nil {
+		t.Fatal("PullRequest = nil, want hydrated pull request")
+	}
+	checks := got.PullRequest.TransientFailedChecks
+	if len(checks) != 1 {
+		t.Fatalf("TransientFailedChecks = %#v, want one killed check", checks)
+	}
+	if checks[0].ID != 9001 || checks[0].WorkflowRunID != 8001 || checks[0].Name != "Checks" {
+		t.Fatalf("TransientFailedChecks[0] = %#v, want check and workflow run IDs", checks[0])
+	}
+}
+
+func TestConnectorRerunPullRequestChecksUsesWorkflowRun(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodPost,
+			path:   "/repos/example/repo/actions/runs/8001/rerun-failed-jobs",
+			body:   `{}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{})
+	prNumber := 42
+	issue := connector.Issue{
+		ID:           "I_kw42",
+		Identifier:   "example/repo#1",
+		PRNumber:     &prNumber,
+		PRRepository: "example/repo",
+	}
+
+	err := c.RerunPullRequestChecks(context.Background(), issue, []connector.PullRequestCheck{{
+		ID:            9001,
+		WorkflowRunID: 8001,
+		Name:          "Checks",
+	}})
+	if err != nil {
+		t.Fatalf("RerunPullRequestChecks() error = %v", err)
+	}
+
+	requests := server.requests()
+	if len(requests) != 1 {
+		t.Fatalf("requests len = %d, want 1", len(requests))
+	}
+	if requests[0]["method"] != http.MethodPost || requests[0]["path"] != "/repos/example/repo/actions/runs/8001/rerun-failed-jobs" {
+		t.Fatalf("request = %#v, want workflow rerun", requests[0])
+	}
+}
+
 func TestConnectorSetIssueFieldUsesIssueFieldEndpoint(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -232,6 +232,7 @@ func clonePullRequestCI(ci pullRequestCI) pullRequestCI {
 		CIDurationSeconds:  ci.CIDurationSeconds,
 		SlowChecks:         append([]connector.PullRequestCheck(nil), ci.SlowChecks...),
 		RunningChecks:      append([]string(nil), ci.RunningChecks...),
+		TransientFailures:  append([]connector.PullRequestCheck(nil), ci.TransientFailures...),
 	}
 }
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -64,6 +64,7 @@ type PullRequest struct {
 	CIDurationSeconds            int64                `json:"ci_duration_seconds,omitempty" yaml:"ci_duration_seconds,omitempty"`
 	SlowChecks                   []PullRequestCheck   `json:"slow_checks,omitempty" yaml:"slow_checks,omitempty"`
 	RunningChecks                []string             `json:"running_checks,omitempty" yaml:"running_checks,omitempty"`
+	TransientFailedChecks        []PullRequestCheck   `json:"transient_failed_checks,omitempty" yaml:"transient_failed_checks,omitempty"`
 	CodexReviewState             string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
 	CodexReviewSubmittedAt       *time.Time           `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`
 	CodexReviewFindings          []PullRequestFinding `json:"codex_review_findings,omitempty" yaml:"codex_review_findings,omitempty"`
@@ -81,9 +82,12 @@ const (
 )
 
 type PullRequestCheck struct {
+	ID              int64  `json:"id,omitempty" yaml:"id,omitempty"`
+	WorkflowRunID   int64  `json:"workflow_run_id,omitempty" yaml:"workflow_run_id,omitempty"`
 	Name            string `json:"name,omitempty" yaml:"name,omitempty"`
 	Status          string `json:"status,omitempty" yaml:"status,omitempty"`
 	Conclusion      string `json:"conclusion,omitempty" yaml:"conclusion,omitempty"`
+	DetailsURL      string `json:"details_url,omitempty" yaml:"details_url,omitempty"`
 	QueueSeconds    int64  `json:"queue_seconds,omitempty" yaml:"queue_seconds,omitempty"`
 	DurationSeconds int64  `json:"duration_seconds,omitempty" yaml:"duration_seconds,omitempty"`
 }

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -16,6 +16,7 @@ const (
 	DefaultPlanStop            = "Plan Review"
 	DefaultValidatorMinScore   = 0.8
 	DefaultArtifactStatusField = "validation_status"
+	DefaultTransientCIRetries  = 2
 
 	CIFailureActionSkip   = "skip"
 	CIFailureActionRework = "rework"
@@ -31,6 +32,7 @@ type Config struct {
 	ApprovalLabel          string          `yaml:"approval_label"`
 	RequireAutomatedReview *bool           `yaml:"require_automated_review"`
 	CIFailureAction        string          `yaml:"ci_failure_action"`
+	TransientCIRetryLimit  *int            `yaml:"transient_ci_retry_limit"`
 	Validator              ValidatorConfig `yaml:"validator"`
 	Artifact               ArtifactConfig  `yaml:"artifact"`
 }
@@ -138,6 +140,7 @@ func DefaultConfig() Config {
 		ApprovalLabel:          DefaultApprovalLabel,
 		RequireAutomatedReview: new(true),
 		CIFailureAction:        CIFailureActionRework,
+		TransientCIRetryLimit:  newInt(DefaultTransientCIRetries),
 		Validator:              effectiveValidatorConfig(ValidatorConfig{}),
 		Artifact:               effectiveArtifactConfig(ArtifactConfig{}),
 	}
@@ -151,12 +154,19 @@ func DefaultPlanConfig() PlanConfig {
 	}
 }
 
+func newInt(value int) *int {
+	return &value
+}
+
 func Effective(cfg Config) Config {
 	ciFailureActionSpecified := strings.TrimSpace(cfg.CIFailureAction) != ""
 	cfg.Kind = NormalizeKind(cfg.Kind)
 	cfg.Run = strings.TrimSpace(cfg.Run)
 	cfg.ApprovalLabel = normalizeLabel(cfg.ApprovalLabel)
 	cfg.CIFailureAction = NormalizeCIFailureAction(cfg.CIFailureAction)
+	if cfg.TransientCIRetryLimit == nil {
+		cfg.TransientCIRetryLimit = newInt(DefaultTransientCIRetries)
+	}
 	cfg.Validator = effectiveValidatorConfig(cfg.Validator)
 	cfg.Artifact = effectiveArtifactConfig(cfg.Artifact)
 
@@ -258,6 +268,9 @@ func Validate(prefix string, cfg Config) []string {
 	case CIFailureActionSkip, CIFailureActionRework:
 	default:
 		problems = append(problems, prefix+".ci_failure_action must be one of skip, rework")
+	}
+	if cfg.TransientCIRetryLimit != nil && *cfg.TransientCIRetryLimit < 0 {
+		problems = append(problems, prefix+".transient_ci_retry_limit must be greater than or equal to 0")
 	}
 	problems = append(problems, validateValidator(prefix+".validator", cfg.Validator)...)
 	problems = append(problems, validateArtifact(prefix+".artifact", cfg.Artifact)...)

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -40,6 +40,11 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionRework},
 		},
 		{
+			name: "command can explicitly disable transient ci retries",
+			cfg:  Config{Kind: KindCommand, Run: "make verify", TransientCIRetryLimit: newInt(0)},
+			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionRework, TransientCIRetryLimit: newInt(0)},
+		},
+		{
 			name: "human review normalizes alias and approval label",
 			cfg:  Config{Kind: "human-review", Run: "make check", ApprovalLabel: " Human-Approved "},
 			want: Config{Kind: KindHumanReview, Run: "", ApprovalLabel: "human-approved", CIFailureAction: CIFailureActionSkip},
@@ -92,6 +97,9 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 
 			got := Effective(tt.cfg)
 			want := tt.want
+			if want.TransientCIRetryLimit == nil {
+				want.TransientCIRetryLimit = newInt(DefaultTransientCIRetries)
+			}
 			want.Validator = effectiveValidatorConfig(want.Validator)
 			want.Artifact = effectiveArtifactConfig(want.Artifact)
 			if !configsEqual(got, want) {
@@ -551,9 +559,17 @@ func configsEqual(left Config, right Config) bool {
 		left.Run == right.Run &&
 		left.ApprovalLabel == right.ApprovalLabel &&
 		left.CIFailureAction == right.CIFailureAction &&
+		intPointerEqual(left.TransientCIRetryLimit, right.TransientCIRetryLimit) &&
 		boolPointerEqual(left.RequireAutomatedReview, right.RequireAutomatedReview) &&
 		validatorConfigsEqual(left.Validator, right.Validator) &&
 		artifactConfigsEqual(left.Artifact, right.Artifact)
+}
+
+func intPointerEqual(left *int, right *int) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
 }
 
 func boolPointerEqual(left *bool, right *bool) bool {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -52,10 +52,6 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		}
 
 		summary := AutoPromoteSummaryFromIssue(issue)
-		if o.retryTransientPullRequestChecks(ctx, state, issue, now, string(AutoPromoteReasonCINotGreen)) {
-			o.logAutoPromoteDecision(issue, autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen), "")
-			continue
-		}
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
 		if decision.Reason == AutoPromoteReasonValidatorMissing {
 			validation, shouldComment, ok := o.validatorStageResult(issue)
@@ -70,6 +66,11 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 				o.markValidatorResultCommented(issue)
 			}
 			decision = EvaluateAutoPromote(issue, summary, cfg, now)
+		}
+		if decision.Reason == AutoPromoteReasonCINotGreen &&
+			o.retryTransientPullRequestChecks(ctx, state, issue, now, string(AutoPromoteReasonCINotGreen)) {
+			o.logAutoPromoteDecision(issue, autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen), "")
+			continue
 		}
 		targetState := autoPromoteTargetState(decision.Action, cfg)
 		if targetState == "" {
@@ -154,11 +155,12 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
 			continue
 		}
-		if o.retryTransientPullRequestChecks(ctx, state, issue, now, string(AutoPromoteReasonCINotGreen)) {
+		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg.TerminalStates)
+		if decision.reason == string(AutoPromoteReasonCINotGreen) &&
+			o.retryTransientPullRequestChecks(ctx, state, issue, now, decision.reason) {
 			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
 			continue
 		}
-		decision := staleMergingPullRequestDecisionForIssue(issue, o.cfg.TerminalStates)
 		if decision.targetState == "" {
 			if strings.TrimSpace(decision.reason) != "" {
 				o.logStaleMergingPullRequestDeferred(issue, decision)

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -52,6 +52,10 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		}
 
 		summary := AutoPromoteSummaryFromIssue(issue)
+		if o.retryTransientPullRequestChecks(ctx, state, issue, now, string(AutoPromoteReasonCINotGreen)) {
+			o.logAutoPromoteDecision(issue, autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen), "")
+			continue
+		}
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
 		if decision.Reason == AutoPromoteReasonValidatorMissing {
 			validation, shouldComment, ok := o.validatorStageResult(issue)
@@ -147,6 +151,10 @@ func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(
 			continue
 		}
 		if staleMergingPullRequestDispatchActive(state, issueID) {
+			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
+			continue
+		}
+		if o.retryTransientPullRequestChecks(ctx, state, issue, now, string(AutoPromoteReasonCINotGreen)) {
 			consumedRepositories = consumeMergeWorkerRepository(consumedRepositories, repository)
 			continue
 		}
@@ -1088,8 +1096,10 @@ func autoPromoteFailedChecksFromPullRequest(pullRequest *connector.PullRequest) 
 	if pullRequest == nil {
 		return nil
 	}
-	checks := make([]string, 0, len(pullRequest.SlowChecks))
-	for _, check := range pullRequest.SlowChecks {
+	allChecks := append([]connector.PullRequestCheck{}, pullRequest.SlowChecks...)
+	allChecks = append(allChecks, pullRequest.TransientFailedChecks...)
+	checks := make([]string, 0, len(allChecks))
+	for _, check := range allChecks {
 		if !autoPromoteCheckFailed(check) {
 			continue
 		}

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -319,13 +319,16 @@ func TestTickRetriesTransientHumanReviewCIBeforeRework(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 12, 14, 5, 0, 0, time.UTC)
+	reviewedAt := now.Add(-20 * time.Minute)
 	issue := autoPromoteTickIssue("issue-transient-ci", []string{"bug"}, &connector.PullRequest{
-		Number:     51,
-		URL:        "https://github.test/digitaldrywood/detent/pull/51",
-		State:      "OPEN",
-		HeadSHA:    "head-transient",
-		CIStatus:   "fail",
-		BranchName: "detent/transient-ci",
+		Number:                 51,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/51",
+		State:                  "OPEN",
+		HeadSHA:                "head-transient",
+		CIStatus:               "fail",
+		BranchName:             "detent/transient-ci",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &reviewedAt,
 		TransientFailedChecks: []connector.PullRequestCheck{{
 			ID:            9001,
 			WorkflowRunID: 8001,
@@ -371,6 +374,69 @@ func TestTickRetriesTransientHumanReviewCIBeforeRework(t *testing.T) {
 	}
 	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "Transient CI failure detected") {
 		t.Fatalf("comments = %#v, want transient CI retry audit comment", tracker.comments)
+	}
+}
+
+func TestTickDoesNotRetryTransientHumanReviewCIBeforeGateBlocksOnCI(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 14, 6, 0, 0, time.UTC)
+	reviewedAt := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-transient-ci-waiting-review", []string{"bug"}, &connector.PullRequest{
+		Number:                 53,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/53",
+		State:                  "OPEN",
+		HeadSHA:                "head-transient",
+		CIStatus:               "fail",
+		BranchName:             "detent/transient-ci",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &reviewedAt,
+		TransientFailedChecks: []connector.PullRequestCheck{{
+			ID:            9003,
+			WorkflowRunID: 8003,
+			Name:          "Checks",
+			Status:        "completed",
+			Conclusion:    "failure",
+			DetailsURL:    "https://github.test/digitaldrywood/detent/actions/runs/8003/job/9003",
+		}},
+	})
+	retryLimit := 2
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:            true,
+			AllowedIssueLabels: []string{"allowed"},
+			Gate: gate.Config{
+				Kind:                  gate.KindCommand,
+				CIFailureAction:       gate.CIFailureActionRework,
+				TransientCIRetryLimit: &retryLimit,
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{
+		stateIssues:        []connector.Issue{issue},
+		candidateIssuesSet: true,
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.reruns) != 0 {
+		t.Fatalf("reruns = %#v, want no reruns before CI is the blocking gate reason", tracker.reruns)
+	}
+	if len(state.TransientCheckRetries) != 0 {
+		t.Fatalf("TransientCheckRetries = %#v, want none before CI blocks promotion", state.TransientCheckRetries)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no Rework transition while label is disallowed", tracker.updates)
 	}
 }
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -315,6 +315,126 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 	}
 }
 
+func TestTickRetriesTransientHumanReviewCIBeforeRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 14, 5, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-transient-ci", []string{"bug"}, &connector.PullRequest{
+		Number:     51,
+		URL:        "https://github.test/digitaldrywood/detent/pull/51",
+		State:      "OPEN",
+		HeadSHA:    "head-transient",
+		CIStatus:   "fail",
+		BranchName: "detent/transient-ci",
+		TransientFailedChecks: []connector.PullRequestCheck{{
+			ID:            9001,
+			WorkflowRunID: 8001,
+			Name:          "Checks",
+			Status:        "completed",
+			Conclusion:    "failure",
+			DetailsURL:    "https://github.test/digitaldrywood/detent/actions/runs/8001/job/9001",
+		}},
+	})
+	retryLimit := 2
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate: gate.Config{
+				Kind:                  gate.KindCommand,
+				CIFailureAction:       gate.CIFailureActionRework,
+				TransientCIRetryLimit: &retryLimit,
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{
+		stateIssues:        []connector.Issue{issue},
+		candidateIssuesSet: true,
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.reruns) != 1 || tracker.reruns[0].issueID != issue.ID || len(tracker.reruns[0].checks) != 1 {
+		t.Fatalf("reruns = %#v, want one rerun for transient check", tracker.reruns)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no Rework transition while retrying transient CI", tracker.updates)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "Transient CI failure detected") {
+		t.Fatalf("comments = %#v, want transient CI retry audit comment", tracker.comments)
+	}
+}
+
+func TestTickRetriesTransientMergingCIBeforeRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 12, 14, 7, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-merging-transient-ci", []string{"bug"}, &connector.PullRequest{
+		Number:     52,
+		URL:        "https://github.test/digitaldrywood/detent/pull/52",
+		State:      "OPEN",
+		HeadSHA:    "head-transient",
+		CIStatus:   "fail",
+		BranchName: "detent/transient-ci",
+		TransientFailedChecks: []connector.PullRequestCheck{{
+			ID:            9002,
+			WorkflowRunID: 8002,
+			Name:          "Checks",
+			Status:        "completed",
+			Conclusion:    "failure",
+			DetailsURL:    "https://github.test/digitaldrywood/detent/actions/runs/8002/job/9002",
+		}},
+	})
+	issue.State = "Merging"
+	retryLimit := 2
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate: gate.Config{
+				Kind:                  gate.KindCommand,
+				CIFailureAction:       gate.CIFailureActionRework,
+				TransientCIRetryLimit: &retryLimit,
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{
+		stateIssues:        []connector.Issue{issue},
+		candidateIssuesSet: true,
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.reruns) != 1 || tracker.reruns[0].issueID != issue.ID || len(tracker.reruns[0].checks) != 1 {
+		t.Fatalf("reruns = %#v, want one rerun for transient check", tracker.reruns)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no Rework transition while retrying transient CI", tracker.updates)
+	}
+	if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, "Transient CI failure detected") {
+		t.Fatalf("comments = %#v, want transient CI retry audit comment", tracker.comments)
+	}
+}
+
 func TestObservedStatusFetchStatesForTickDoesNotThrottleCustomPassState(t *testing.T) {
 	t.Parallel()
 
@@ -2637,6 +2757,11 @@ type autoPromoteTickMerge struct {
 	headSHA    string
 }
 
+type autoPromoteTickRerun struct {
+	issueID string
+	checks  []connector.PullRequestCheck
+}
+
 type autoPromoteTickHydration struct {
 	issueID    string
 	repository string
@@ -2653,6 +2778,7 @@ type autoPromoteTickConnector struct {
 	comments              []autoPromoteTickComment
 	prComments            []autoPromoteTickComment
 	setFields             []autoPromoteTickSetField
+	reruns                []autoPromoteTickRerun
 }
 
 type autoPromoteTickMergeConnector struct {
@@ -2716,6 +2842,14 @@ func (c *autoPromoteTickConnector) CreateComment(_ context.Context, issueID stri
 
 func (c *autoPromoteTickConnector) CreatePullRequestComment(_ context.Context, repository string, number int, body string) error {
 	c.prComments = append(c.prComments, autoPromoteTickComment{issueID: repository, body: body})
+	return nil
+}
+
+func (c *autoPromoteTickConnector) RerunPullRequestChecks(_ context.Context, issue connector.Issue, checks []connector.PullRequestCheck) error {
+	c.reruns = append(c.reruns, autoPromoteTickRerun{
+		issueID: issue.ID,
+		checks:  append([]connector.PullRequestCheck(nil), checks...),
+	})
 	return nil
 }
 

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -25,6 +25,13 @@ type DependencyAutoUnblockConfig struct {
 	Readiness    string
 }
 
+type BlockerAutoPromoteConfig struct {
+	Enabled       bool
+	SourceStates  []string
+	BlockerStates []string
+	TargetState   string
+}
+
 type dependencyBlocker struct {
 	Ref      connector.BlockedRef
 	Issue    connector.Issue
@@ -41,6 +48,35 @@ func normalizeDependencyAutoUnblockConfig(cfg DependencyAutoUnblockConfig) Depen
 	cfg.TargetState = strings.TrimSpace(defaultString(cfg.TargetState, "Todo"))
 	cfg.Readiness = strings.ToLower(strings.TrimSpace(defaultString(cfg.Readiness, DependencyReadinessTerminalOrMerged)))
 	return cfg
+}
+
+func normalizeBlockerAutoPromoteConfig(
+	cfg BlockerAutoPromoteConfig,
+	activeStates []string,
+	autoUnblock DependencyAutoUnblockConfig,
+) BlockerAutoPromoteConfig {
+	sourceDefaults := mergeStateLists(activeStates, normalizeDependencyAutoUnblockConfig(autoUnblock).SourceStates)
+	cfg.SourceStates = normalizedStates(defaultStringSlice(cfg.SourceStates, sourceDefaults))
+	cfg.BlockerStates = normalizedStates(defaultStringSlice(cfg.BlockerStates, []string{"Backlog", "Blocked", "Human Review"}))
+	cfg.TargetState = strings.TrimSpace(defaultString(cfg.TargetState, "Todo"))
+	return cfg
+}
+
+func mergeStateLists(left []string, right []string) []string {
+	out := make([]string, 0, len(left)+len(right))
+	seen := map[string]struct{}{}
+	for _, state := range append(append([]string{}, left...), right...) {
+		key := normalizeState(state)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, displayStateName(state))
+	}
+	return out
 }
 
 func (o *Orchestrator) autoUnblockDependencyIssues(
@@ -78,6 +114,180 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		return nil
 	}
 	return transitioned
+}
+
+func (o *Orchestrator) autoPromoteBlockerIssues(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) map[string]struct{} {
+	cfg := normalizeBlockerAutoPromoteConfig(o.cfg.BlockerAutoPromote, o.cfg.ActiveStates, o.cfg.DependencyAutoUnblock)
+	if !cfg.Enabled {
+		return nil
+	}
+
+	remaining := o.blockerAutoPromoteCapacity(state, cfg.TargetState)
+	if remaining <= 0 {
+		return nil
+	}
+
+	transitioned := map[string]struct{}{}
+	seenBlockers := map[string]struct{}{}
+	for _, dependent := range issuesInStates(issues, cfg.SourceStates) {
+		if remaining <= 0 {
+			break
+		}
+		dependent = issueWithTextDependencyRefs(dependent)
+		if len(dependent.BlockedBy) == 0 {
+			continue
+		}
+		for _, blocker := range o.resolveDependencyBlockers(ctx, dependent) {
+			if remaining <= 0 {
+				break
+			}
+			if !blockerAutoPromoteEligible(dependent, blocker, cfg, o.cfg.TerminalStates) {
+				continue
+			}
+			key := strings.ToLower(strings.TrimSpace(firstNonBlank(blocker.Issue.ID, blocker.Issue.Identifier)))
+			if key == "" {
+				continue
+			}
+			if _, ok := seenBlockers[key]; ok {
+				continue
+			}
+			seenBlockers[key] = struct{}{}
+			if !o.applyBlockerAutoPromote(ctx, state, dependent, blocker.Issue, cfg.TargetState, now) {
+				continue
+			}
+			transitioned[blocker.Issue.ID] = struct{}{}
+			remaining--
+		}
+	}
+	if len(transitioned) == 0 {
+		return nil
+	}
+	return transitioned
+}
+
+func (o *Orchestrator) blockerAutoPromoteCapacity(state *State, targetState string) int {
+	if state == nil {
+		return 0
+	}
+	available := availableSlots(state)
+	stats := o.projectStateSlotStats(connector.Issue{State: targetState}, state)
+	if stats.available < available {
+		available = stats.available
+	}
+	if available < 0 {
+		return 0
+	}
+	return available
+}
+
+func blockerAutoPromoteEligible(
+	dependent connector.Issue,
+	blocker dependencyBlocker,
+	cfg BlockerAutoPromoteConfig,
+	terminalStates []string,
+) bool {
+	if !blocker.Resolved {
+		return false
+	}
+	issue := blocker.Issue
+	if strings.TrimSpace(issue.ID) == "" {
+		return false
+	}
+	if !stateIn(issue.State, cfg.BlockerStates) {
+		return false
+	}
+	if stateIn(issue.State, terminalStates) || issue.Closed || pullRequestMerged(issue.PullRequest) {
+		return false
+	}
+	if normalizeState(issue.State) == normalizeState(cfg.TargetState) {
+		return false
+	}
+	return sameDependencyRepository(dependent.Identifier, issue.Identifier)
+}
+
+func sameDependencyRepository(leftIdentifier string, rightIdentifier string) bool {
+	leftRepo := dependencyIssueRepo(leftIdentifier)
+	rightRepo := dependencyIssueRepo(rightIdentifier)
+	return leftRepo != "" && rightRepo != "" && strings.EqualFold(leftRepo, rightRepo)
+}
+
+func (o *Orchestrator) applyBlockerAutoPromote(
+	ctx context.Context,
+	state *State,
+	dependent connector.Issue,
+	blocker connector.Issue,
+	targetState string,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(blocker.ID)
+	if err := o.updateIssueStateByID(ctx, issueID, blocker, targetState, now, "blocker_auto_promote"); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"blocker auto-promote transition failed",
+				"issue_id", issueID,
+				"identifier", blocker.Identifier,
+				"dependent_identifier", dependent.Identifier,
+				"from_state", blocker.State,
+				"target_state", targetState,
+				"error", err,
+			)
+		}
+		return false
+	}
+
+	body := blockerAutoPromoteComment(dependent, blocker, targetState)
+	if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+		o.logger.Warn(
+			"blocker auto-promote comment failed",
+			"issue_id", issueID,
+			"identifier", blocker.Identifier,
+			"dependent_identifier", dependent.Identifier,
+			"target_state", targetState,
+			"error", err,
+		)
+	}
+
+	delete(state.Blocked, issueID)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "blocker_auto_promote_transition",
+		Message: "auto-promoted blocker " + issueLabel(blocker) + " from " + blocker.State + " to " + targetState + " for " + issueLabel(dependent),
+	})
+	if o.logger != nil {
+		o.logger.Info(
+			"blocker auto-promote transition",
+			"issue_id", issueID,
+			"identifier", blocker.Identifier,
+			"dependent_identifier", dependent.Identifier,
+			"from_state", blocker.State,
+			"target_state", targetState,
+		)
+	}
+	return true
+}
+
+func blockerAutoPromoteComment(dependent connector.Issue, blocker connector.Issue, targetState string) string {
+	var b strings.Builder
+	b.WriteString("Dependency blocker queued.")
+	if strings.TrimSpace(blocker.State) != "" && strings.TrimSpace(targetState) != "" {
+		b.WriteString(" Moved this blocker from ")
+		b.WriteString(strings.TrimSpace(blocker.State))
+		b.WriteString(" to ")
+		b.WriteString(strings.TrimSpace(targetState))
+		b.WriteString(".")
+	}
+	b.WriteString("\n\nDependent issue: ")
+	b.WriteString(issueLabel(dependent))
+	if url := strings.TrimSpace(dependent.URL); url != "" {
+		b.WriteString(" ")
+		b.WriteString(url)
+	}
+	return b.String()
 }
 
 func (o *Orchestrator) hydrateDependencyAutoUnblockIssue(

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -201,7 +201,7 @@ func blockerAutoPromoteEligible(
 	if !stateIn(issue.State, cfg.BlockerStates) {
 		return false
 	}
-	if stateIn(issue.State, terminalStates) || issue.Closed || pullRequestMerged(issue.PullRequest) {
+	if stateIn(issue.State, terminalStates) || issue.Closed || pullRequestMerged(issue.PullRequest) || pullRequestOpen(issue.PullRequest) {
 		return false
 	}
 	if normalizeState(issue.State) == normalizeState(cfg.TargetState) {
@@ -636,6 +636,10 @@ func dependencyBlockerReady(blocker dependencyBlocker, cfg DependencyAutoUnblock
 
 func pullRequestMerged(pullRequest *connector.PullRequest) bool {
 	return pullRequest != nil && normalizePullRequestState(pullRequest.State) == "merged"
+}
+
+func pullRequestOpen(pullRequest *connector.PullRequest) bool {
+	return pullRequest != nil && normalizePullRequestState(pullRequest.State) == "open"
 }
 
 func dependencyAutoUnblockTargetState(state *State, issue connector.Issue, configuredTarget string) string {

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -503,6 +503,78 @@ func TestTickLeavesTextDependencyBlockedPRIssueBlocked(t *testing.T) {
 	}
 }
 
+func TestTickAutoPromotesInactiveBlockerForDependencyWaitingIssue(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-416", "Blocked")
+	waiting.Description = "Blocked by #415"
+	blocker := dependencyAutoUnblockIssue("issue-415", "Backlog")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting, blocker},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	orch.cfg.BlockerAutoPromote = normalizeBlockerAutoPromoteConfig(BlockerAutoPromoteConfig{Enabled: true}, orch.cfg.ActiveStates, orch.cfg.DependencyAutoUnblock)
+	state := newState(orch.cfg)
+	now := time.Date(2026, 6, 12, 16, 9, 15, 0, time.UTC)
+
+	orch.tick(context.Background(), &state, now)
+
+	if got := tracker.updates; len(got) != 1 || got[0] != (dependencyAutoUnblockUpdate{issueID: blocker.ID, state: "Todo"}) {
+		t.Fatalf("updates = %#v, want Backlog blocker moved to Todo", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one blocker promotion comment", tracker.comments)
+	}
+	for _, want := range []string{"Dependency blocker queued.", "Backlog to Todo", "digitaldrywood/detent#416"} {
+		if !strings.Contains(tracker.comments[0].body, want) {
+			t.Fatalf("comment %q missing %q", tracker.comments[0].body, want)
+		}
+	}
+	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "blocker_auto_promote_transition" {
+		t.Fatalf("RecentEvents = %#v, want blocker auto-promote event", state.RecentEvents)
+	}
+}
+
+func TestTickAutoPromoteBlockerWaitsForAvailableCapacity(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-416", "Blocked")
+	waiting.Description = "Blocked by #415"
+	blocker := dependencyAutoUnblockIssue("issue-415", "Backlog")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting, blocker},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	orch.cfg.MaxConcurrentAgents = 1
+	orch.cfg.BlockerAutoPromote = normalizeBlockerAutoPromoteConfig(BlockerAutoPromoteConfig{Enabled: true}, orch.cfg.ActiveStates, orch.cfg.DependencyAutoUnblock)
+	state := newState(orch.cfg)
+	running := dependencyAutoUnblockIssue("issue-running", "In Progress")
+	state.Running[running.ID] = Running{Issue: running}
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 9, 30, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none without available capacity", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none without promotion", tracker.comments)
+	}
+}
+
 func TestDependencyAutoUnblockDoesNotChangeTodoDependencyGate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -542,6 +542,41 @@ func TestTickAutoPromotesInactiveBlockerForDependencyWaitingIssue(t *testing.T) 
 	}
 }
 
+func TestTickDoesNotAutoPromoteInactiveBlockerWithOpenPullRequest(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-416", "Blocked")
+	waiting.Description = "Blocked by #415"
+	blocker := dependencyAutoUnblockIssue("issue-415", "Human Review")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	blocker.PullRequest = &connector.PullRequest{
+		Number: 415,
+		State:  "OPEN",
+		URL:    "https://github.test/digitaldrywood/detent/pull/415",
+	}
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting, blocker},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	orch.cfg.BlockerAutoPromote = normalizeBlockerAutoPromoteConfig(BlockerAutoPromoteConfig{Enabled: true}, orch.cfg.ActiveStates, orch.cfg.DependencyAutoUnblock)
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 6, 12, 16, 9, 25, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none for blocker with open PR", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none without promotion", tracker.comments)
+	}
+}
+
 func TestTickAutoPromoteBlockerWaitsForAvailableCapacity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -63,6 +63,7 @@ type Config struct {
 	AutoPromote                   AutoPromoteConfig
 	Plan                          gate.PlanConfig
 	DependencyAutoUnblock         DependencyAutoUnblockConfig
+	BlockerAutoPromote            BlockerAutoPromoteConfig
 	ActiveStates                  []string
 	ObservedStates                []string
 	TerminalStates                []string
@@ -203,6 +204,12 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			TargetState:  cfg.Tracker.DependencyAutoUnblock.TargetState,
 			Readiness:    cfg.Tracker.DependencyAutoUnblock.Readiness,
 		}),
+		BlockerAutoPromote: BlockerAutoPromoteConfig{
+			Enabled:       cfg.Tracker.BlockerAutoPromote.Enabled,
+			SourceStates:  append([]string(nil), cfg.Tracker.BlockerAutoPromote.SourceStates...),
+			BlockerStates: append([]string(nil), cfg.Tracker.BlockerAutoPromote.BlockerStates...),
+			TargetState:   cfg.Tracker.BlockerAutoPromote.TargetState,
+		},
 		ActiveStates:                  append([]string(nil), cfg.Tracker.ActiveStates...),
 		ObservedStates:                append([]string(nil), cfg.Tracker.ObservedStates...),
 		TerminalStates:                append([]string(nil), cfg.Tracker.TerminalStates...),
@@ -446,6 +453,11 @@ func (o *Orchestrator) observedStatusFetchStates() []string {
 	cfg := normalizeDependencyAutoUnblockConfig(o.cfg.DependencyAutoUnblock)
 	if cfg.Enabled {
 		states = append(states, cfg.SourceStates...)
+	}
+	blockerCfg := normalizeBlockerAutoPromoteConfig(o.cfg.BlockerAutoPromote, o.cfg.ActiveStates, o.cfg.DependencyAutoUnblock)
+	if blockerCfg.Enabled {
+		states = append(states, blockerCfg.SourceStates...)
+		states = append(states, blockerCfg.BlockerStates...)
 	}
 	return displayStateNames(states)
 }
@@ -2605,6 +2617,7 @@ func normalizeConfig(cfg Config) Config {
 	cfg.AutoPromote = normalizeAutoPromoteConfig(cfg.AutoPromote)
 	cfg.Plan = gate.EffectivePlan(cfg.Plan)
 	cfg.DependencyAutoUnblock = normalizeDependencyAutoUnblockConfig(cfg.DependencyAutoUnblock)
+	cfg.BlockerAutoPromote = normalizeBlockerAutoPromoteConfig(cfg.BlockerAutoPromote, cfg.ActiveStates, cfg.DependencyAutoUnblock)
 	cfg.Authorization.Normalize()
 	cfg.SelectorContext.InstanceLogin = strings.TrimSpace(cfg.SelectorContext.InstanceLogin)
 	cfg.SelectorContext.Persona = strings.TrimSpace(cfg.SelectorContext.Persona)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -37,6 +37,7 @@ type State struct {
 	Completed                map[string]Completed
 	Retry                    map[string]Retry
 	MergeTimings             map[string]MergeTiming
+	TransientCheckRetries    map[string]TransientCheckRetry
 	BudgetRefusals           map[string]BudgetRefusal
 	DiffStats                map[string]DiffStats
 	ReapedWorkspaces         map[string]time.Time
@@ -125,6 +126,16 @@ type Retry struct {
 	WorkerHost string
 }
 
+type TransientCheckRetry struct {
+	IssueID       string
+	HeadSHA       string
+	CheckName     string
+	CheckID       int64
+	WorkflowRunID int64
+	Attempts      int
+	RetriedAt     time.Time
+}
+
 func newState(cfg Config) State {
 	return State{
 		PollInterval:             cfg.PollInterval,
@@ -137,6 +148,7 @@ func newState(cfg Config) State {
 		Completed:                map[string]Completed{},
 		Retry:                    map[string]Retry{},
 		MergeTimings:             map[string]MergeTiming{},
+		TransientCheckRetries:    map[string]TransientCheckRetry{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
 		DiffStats:                map[string]DiffStats{},
 		ReapedWorkspaces:         map[string]time.Time{},
@@ -173,6 +185,7 @@ func (s State) clone() State {
 		Completed:                make(map[string]Completed, len(s.Completed)),
 		Retry:                    make(map[string]Retry, len(s.Retry)),
 		MergeTimings:             maps.Clone(s.MergeTimings),
+		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		DiffStats:                make(map[string]DiffStats, len(s.DiffStats)),
 		ReapedWorkspaces:         make(map[string]time.Time, len(s.ReapedWorkspaces)),
@@ -260,6 +273,9 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 			nextRetryAt := *issue.PullRequest.HydrationNextRetryAt
 			pullRequest.HydrationNextRetryAt = &nextRetryAt
 		}
+		pullRequest.SlowChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.SlowChecks...)
+		pullRequest.RunningChecks = append([]string(nil), issue.PullRequest.RunningChecks...)
+		pullRequest.TransientFailedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.TransientFailedChecks...)
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		cloned.PullRequest = &pullRequest
 	}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -108,6 +108,11 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,
+			o.autoPromoteBlockerIssues(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now),
+		)
+		fetched = filterReconciledTickIssues(
+			state,
+			fetched,
 			o.autoUnblockDependencyIssues(ctx, state, fetched.status, now),
 		)
 		fetched = filterReconciledTickIssues(

--- a/internal/orchestrator/transient_ci_retry.go
+++ b/internal/orchestrator/transient_ci_retry.go
@@ -1,0 +1,167 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func (o *Orchestrator) retryTransientPullRequestChecks(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	now time.Time,
+	reason string,
+) bool {
+	rerunner, ok := o.connector.(connector.PullRequestCheckRerunner)
+	if !ok || state == nil || issue.PullRequest == nil {
+		return false
+	}
+	checks := transientPullRequestChecks(issue.PullRequest)
+	if len(checks) == 0 {
+		return false
+	}
+	limit := 0
+	if o.cfg.AutoPromote.Gate.TransientCIRetryLimit != nil {
+		limit = *o.cfg.AutoPromote.Gate.TransientCIRetryLimit
+	}
+	if limit <= 0 {
+		return false
+	}
+
+	retryable := make([]connector.PullRequestCheck, 0, len(checks))
+	for _, check := range checks {
+		key := transientCheckRetryKey(issue, check)
+		if key == "" {
+			continue
+		}
+		if state.TransientCheckRetries[key].Attempts >= limit {
+			continue
+		}
+		retryable = append(retryable, check)
+	}
+	if len(retryable) == 0 {
+		return false
+	}
+	if err := rerunner.RerunPullRequestChecks(ctx, issue, retryable); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("transient ci retry failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return false
+	}
+
+	for _, check := range retryable {
+		key := transientCheckRetryKey(issue, check)
+		entry := state.TransientCheckRetries[key]
+		entry.IssueID = issue.ID
+		entry.HeadSHA = transientCheckRetryHeadSHA(issue)
+		entry.CheckName = strings.TrimSpace(check.Name)
+		entry.CheckID = check.ID
+		entry.WorkflowRunID = check.WorkflowRunID
+		entry.Attempts++
+		entry.RetriedAt = now
+		state.TransientCheckRetries[key] = entry
+	}
+	body := transientCIRetryComment(issue, retryable, limit, reason)
+	if err := o.connector.CreateComment(ctx, issue.ID, body); err != nil && o.logger != nil {
+		o.logger.Warn("transient ci retry comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "transient_ci_retry",
+		Message: "reran transient CI checks for " + issueLabel(issue) + ": " + transientCheckNames(retryable),
+	})
+	return true
+}
+
+func transientPullRequestChecks(pullRequest *connector.PullRequest) []connector.PullRequestCheck {
+	if pullRequest == nil || !staleMergingCIRed(pullRequest.CIStatus) {
+		return nil
+	}
+	checks := make([]connector.PullRequestCheck, 0, len(pullRequest.TransientFailedChecks))
+	for _, check := range pullRequest.TransientFailedChecks {
+		if strings.TrimSpace(check.Name) == "" && check.ID <= 0 && check.WorkflowRunID <= 0 {
+			continue
+		}
+		checks = append(checks, check)
+	}
+	return checks
+}
+
+func transientCheckRetryKey(issue connector.Issue, check connector.PullRequestCheck) string {
+	issueID := strings.TrimSpace(issue.ID)
+	headSHA := transientCheckRetryHeadSHA(issue)
+	if issueID == "" || headSHA == "" {
+		return ""
+	}
+	identity := ""
+	switch {
+	case check.WorkflowRunID > 0:
+		identity = fmt.Sprintf("run:%d", check.WorkflowRunID)
+	case check.ID > 0:
+		identity = fmt.Sprintf("check:%d", check.ID)
+	default:
+		identity = "name:" + strings.ToLower(strings.TrimSpace(check.Name))
+	}
+	if identity == "name:" {
+		return ""
+	}
+	return issueID + ":" + headSHA + ":" + identity
+}
+
+func transientCheckRetryHeadSHA(issue connector.Issue) string {
+	if issue.PullRequest != nil {
+		if headSHA := strings.TrimSpace(issue.PullRequest.HeadSHA); headSHA != "" {
+			return headSHA
+		}
+	}
+	return strings.TrimSpace(issue.BranchName)
+}
+
+func transientCIRetryComment(issue connector.Issue, checks []connector.PullRequestCheck, limit int, reason string) string {
+	var b strings.Builder
+	b.WriteString("Transient CI failure detected; reran failed check")
+	if len(checks) != 1 {
+		b.WriteString("s")
+	}
+	b.WriteString(" before treating CI as a hard failure.")
+	if strings.TrimSpace(reason) != "" {
+		b.WriteString("\n\nReason: ")
+		b.WriteString(strings.TrimSpace(reason))
+	}
+	b.WriteString("\n\nRerun limit: ")
+	b.WriteString(fmt.Sprintf("%d", limit))
+	b.WriteString("\nChecks:")
+	for _, check := range checks {
+		b.WriteString("\n- ")
+		name := strings.TrimSpace(check.Name)
+		if name == "" {
+			name = "check run"
+		}
+		b.WriteString(name)
+		if check.WorkflowRunID > 0 {
+			b.WriteString(fmt.Sprintf(" (workflow run %d)", check.WorkflowRunID))
+		} else if check.ID > 0 {
+			b.WriteString(fmt.Sprintf(" (check run %d)", check.ID))
+		}
+		if url := strings.TrimSpace(check.DetailsURL); url != "" {
+			b.WriteString(" ")
+			b.WriteString(url)
+		}
+	}
+	return b.String()
+}
+
+func transientCheckNames(checks []connector.PullRequestCheck) string {
+	names := make([]string, 0, len(checks))
+	for _, check := range checks {
+		if name := strings.TrimSpace(check.Name); name != "" {
+			names = append(names, name)
+		}
+	}
+	return strings.Join(names, ", ")
+}

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -71,6 +71,7 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 	}
 
 	rendered = appendDeliverableBlock(rendered, workflow.Config, issue, opts.WorkspacePath)
+	rendered = appendBlockedHandoffBlock(rendered)
 	rendered = appendGateBlock(rendered, workflow.Config.Gate)
 	rendered = appendAvailableSkills(rendered, AvailableSkillsBlock(opts.AvailableSkills))
 	if promptDeliverableKind(workflow.Config.Deliverable) != config.DeliverablePullRequest {
@@ -258,6 +259,12 @@ func appendGateBlock(prompt string, cfg gate.Config) string {
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Validation gate\n\n" + instructions
 }
 
+func appendBlockedHandoffBlock(prompt string) string {
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Blocked handoff\n\n" +
+		"Before moving an issue to Blocked because it is waiting on another tracked GitHub issue or pull request, ensure the issue body contains a machine-readable dependency line such as `Blocked by: #123` or `Depends on: owner/repo#123`. " +
+		"Do not rely only on an issue mention in a Workpad comment. Use Blocked without dependency metadata only for blockers that require human action."
+}
+
 func appendClosingReferenceInstruction(prompt string, issue connector.Issue) string {
 	number := githubIssueNumber(issue.Identifier)
 	if number == "" {
@@ -356,12 +363,17 @@ func deliverableAssigns(cfg config.Deliverable) map[string]any {
 
 func gateAssigns(cfg gate.Config) map[string]any {
 	effective := gate.Effective(cfg)
+	transientCIRetryLimit := 0
+	if effective.TransientCIRetryLimit != nil {
+		transientCIRetryLimit = *effective.TransientCIRetryLimit
+	}
 	return map[string]any{
 		"kind":                     effective.Kind,
 		"run":                      effective.Run,
 		"approval_label":           effective.ApprovalLabel,
 		"require_automated_review": requireAutomatedReview(effective),
 		"ci_failure_action":        effective.CIFailureAction,
+		"transient_ci_retry_limit": transientCIRetryLimit,
 		"validator": map[string]any{
 			"enabled":   effective.Validator.Enabled,
 			"model":     effective.Validator.Model,

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -75,6 +75,8 @@ func TestBuildPromptRendersAssignsLessonsAndSkills(t *testing.T) {
 		"metadata=author-1 reviewer-1, reviewer-2 map[Status:Todo]",
 		"## Lessons from prior runs",
 		"Check generator aliases before editing.",
+		"## Blocked handoff",
+		"Blocked by: #123",
 		"## Validation gate",
 		"Run `make check` from the workspace root",
 		"In Merging, run a focused rebase/smoke gate after a clean rebase when the PR already passed current-head validation",


### PR DESCRIPTION
## Summary

- add blocker auto-promotion so active issues can queue inactive tracked blockers
- require machine-readable blocked handoff guidance in agent prompts
- retry transient killed/infra CI checks before routing PRs to Rework

Fixes #771

## Test Plan

- [x] `go test ./internal/config ./internal/gate ./internal/runner ./internal/connector/github ./internal/orchestrator`
- [x] `make check`