### PR TITLE
feat(budget): add Claude pricing

### DIFF
--- a/internal/budget/pricing.go
+++ b/internal/budget/pricing.go
@@ -18,7 +18,26 @@ type ModelPricing struct {
 
 type PricingTable map[string]ModelPricing
 
+// DefaultPricingTable returns published API token rates. Under subscription auth,
+// computed USD is notional but still used for budget pacing.
 func DefaultPricingTable() PricingTable {
+	claudeFable5 := ModelPricing{
+		USDPerInputToken:  0.000010,
+		USDPerOutputToken: 0.000050,
+	}
+	claudeOpus48 := ModelPricing{
+		USDPerInputToken:  0.000005,
+		USDPerOutputToken: 0.000025,
+	}
+	claudeSonnet5 := ModelPricing{
+		USDPerInputToken:  0.000002,
+		USDPerOutputToken: 0.000010,
+	}
+	claudeHaiku45 := ModelPricing{
+		USDPerInputToken:  0.000001,
+		USDPerOutputToken: 0.000005,
+	}
+
 	return PricingTable{
 		"gpt-5.5": {
 			USDPerInputToken:  0.000005,
@@ -36,6 +55,14 @@ func DefaultPricingTable() PricingTable {
 			USDPerInputToken:  0.00000175,
 			USDPerOutputToken: 0.000014,
 		},
+		"claude-fable-5":   claudeFable5,
+		"fable":            claudeFable5,
+		"claude-opus-4-8":  claudeOpus48,
+		"opus":             claudeOpus48,
+		"claude-sonnet-5":  claudeSonnet5,
+		"sonnet":           claudeSonnet5,
+		"claude-haiku-4-5": claudeHaiku45,
+		"haiku":            claudeHaiku45,
 	}
 }
 

--- a/internal/budget/pricing_test.go
+++ b/internal/budget/pricing_test.go
@@ -10,12 +10,86 @@ func TestDefaultPricingTable(t *testing.T) {
 	t.Parallel()
 
 	pricing := DefaultPricingTable()
-	row, ok := pricing.Lookup(" GPT-5.5 ")
-	if !ok {
-		t.Fatal("DefaultPricingTable().Lookup() ok = false, want true")
+
+	tests := []struct {
+		model      string
+		wantInput  float64
+		wantOutput float64
+	}{
+		{
+			model:      " GPT-5.5 ",
+			wantInput:  0.000005,
+			wantOutput: 0.000030,
+		},
+		{
+			model:      "gpt-5.4",
+			wantInput:  0.0000025,
+			wantOutput: 0.000015,
+		},
+		{
+			model:      "gpt-5.4-mini",
+			wantInput:  0.00000075,
+			wantOutput: 0.0000045,
+		},
+		{
+			model:      "gpt-5.3-codex",
+			wantInput:  0.00000175,
+			wantOutput: 0.000014,
+		},
+		{
+			model:      "claude-fable-5",
+			wantInput:  0.000010,
+			wantOutput: 0.000050,
+		},
+		{
+			model:      "fable",
+			wantInput:  0.000010,
+			wantOutput: 0.000050,
+		},
+		{
+			model:      "claude-opus-4-8",
+			wantInput:  0.000005,
+			wantOutput: 0.000025,
+		},
+		{
+			model:      "opus",
+			wantInput:  0.000005,
+			wantOutput: 0.000025,
+		},
+		{
+			model:      "claude-sonnet-5",
+			wantInput:  0.000002,
+			wantOutput: 0.000010,
+		},
+		{
+			model:      "sonnet",
+			wantInput:  0.000002,
+			wantOutput: 0.000010,
+		},
+		{
+			model:      "claude-haiku-4-5",
+			wantInput:  0.000001,
+			wantOutput: 0.000005,
+		},
+		{
+			model:      "haiku",
+			wantInput:  0.000001,
+			wantOutput: 0.000005,
+		},
 	}
-	assertInDelta(t, row.USDPerInputToken, 0.000005)
-	assertInDelta(t, row.USDPerOutputToken, 0.000030)
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			t.Parallel()
+
+			row, ok := pricing.Lookup(tt.model)
+			if !ok {
+				t.Fatal("DefaultPricingTable().Lookup() ok = false, want true")
+			}
+			assertInDelta(t, row.USDPerInputToken, tt.wantInput)
+			assertInDelta(t, row.USDPerOutputToken, tt.wantOutput)
+		})
+	}
 }
 
 func TestDecodePricing(t *testing.T) {
@@ -154,6 +228,69 @@ func TestUsageCostUSD(t *testing.T) {
 			t.Parallel()
 
 			got, ok := UsageCostUSD(pricing, tt.model, tt.inputTokens, tt.outputTokens)
+			if ok != tt.wantOK {
+				t.Fatalf("UsageCostUSD() ok = %v, want %v", ok, tt.wantOK)
+			}
+			assertInDelta(t, got, tt.want)
+		})
+	}
+}
+
+func TestUsageCostUSDDefaultClaudePricing(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		model  string
+		want   float64
+		wantOK bool
+	}{
+		{
+			model:  "claude-fable-5",
+			want:   60,
+			wantOK: true,
+		},
+		{
+			model:  "fable",
+			want:   60,
+			wantOK: true,
+		},
+		{
+			model:  "claude-opus-4-8",
+			want:   30,
+			wantOK: true,
+		},
+		{
+			model:  "opus",
+			want:   30,
+			wantOK: true,
+		},
+		{
+			model:  "claude-sonnet-5",
+			want:   12,
+			wantOK: true,
+		},
+		{
+			model:  "sonnet",
+			want:   12,
+			wantOK: true,
+		},
+		{
+			model:  "claude-haiku-4-5",
+			want:   6,
+			wantOK: true,
+		},
+		{
+			model:  "haiku",
+			want:   6,
+			wantOK: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.model, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := UsageCostUSD(nil, tt.model, 1_000_000, 1_000_000)
 			if ok != tt.wantOK {
 				t.Fatalf("UsageCostUSD() ok = %v, want %v", ok, tt.wantOK)
 			}


### PR DESCRIPTION
## Summary

- Add default Claude API pricing entries for Fable 5, Opus 4.8, Sonnet 5, and Haiku 4.5 with Claude Code aliases.
- Keep custom pricing file behavior unchanged by adding built-in alias rows and documenting notional USD pacing for subscription auth.
- Pricing source verified July 2, 2026 from Anthropic Claude pricing: https://claude.com/pricing. Sonnet 5 uses the listed $2/$10 per MTok introductory input/output rates through August 31, 2026; Anthropic lists $3/$15 standard pricing thereafter.

Fixes #823

## Test Plan

- [x] `go test ./internal/budget`
- [x] `make check`