### PR TITLE
refactor(runner): attribute telemetry by backend

### DIFF
--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -753,7 +753,7 @@ func (r *shutdownBlockingRunner) Run(ctx context.Context, request orchestrator.R
 		if err := request.OnUsageUpdate(orchestrator.UsageUpdate{
 			SessionID:       "thread-641-turn-1",
 			ProcessIdentity: "4242",
-			Tokens: orchestrator.CodexTotals{
+			Tokens: orchestrator.TokenTotals{
 				RuntimeSeconds: 12,
 			},
 		}); err != nil {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1660,7 +1660,7 @@ func TestMergeWorkerLogsRunResultSuccessAndFailure(t *testing.T) {
 		connector: &autoPromoteTickConnector{stateIssues: []connector.Issue{successIssue}},
 		logger:    slog.New(slog.NewTextHandler(&successLogs, nil)),
 	}
-	successOrch.completeTerminalRunning(context.Background(), &successState, successIssue.ID, successState.Running[successIssue.ID], now, CodexTotals{})
+	successOrch.completeTerminalRunning(context.Background(), &successState, successIssue.ID, successState.Running[successIssue.ID], now, TokenTotals{})
 	for _, fragment := range []string{
 		"merge_completed",
 		"final_state=Done",

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1907,7 +1907,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 
 	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
 		tokens := event.Result.Tokens
-		if tokens == (CodexTotals{}) {
+		if tokens == (TokenTotals{}) {
 			tokens = running.Tokens
 		}
 		if diffStatsPresent(event.Result.DiffStats) {
@@ -2013,7 +2013,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		FinalState:  finalState,
 		Tokens:      event.Result.Tokens,
 	}
-	state.CodexTotals = addCodexTotals(state.CodexTotals, event.Result.Tokens)
+	state.TokenTotals = addTokenTotals(state.TokenTotals, event.Result.Tokens)
 	if event.Result.RateLimits != nil {
 		state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
 	}
@@ -2073,7 +2073,7 @@ func (o *Orchestrator) completeLatestTerminalMergeWorkerResult(
 			return o.completeProgrammaticMergeWorkerResult(ctx, state, event, running, issue)
 		}
 		tokens := event.Result.Tokens
-		if tokens == (CodexTotals{}) {
+		if tokens == (TokenTotals{}) {
 			tokens = running.Tokens
 		}
 		if diffStatsPresent(event.Result.DiffStats) {
@@ -2150,7 +2150,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	mergeTimingIssue := running.Issue
 	running.Issue = mergedIssue
 	tokens := event.Result.Tokens
-	if tokens == (CodexTotals{}) {
+	if tokens == (TokenTotals{}) {
 		tokens = running.Tokens
 	}
 	if diffStatsPresent(event.Result.DiffStats) {
@@ -2396,7 +2396,7 @@ func (o *Orchestrator) completePlanRunning(
 		FinalState:  cfg.Stop,
 		Tokens:      event.Result.Tokens,
 	}
-	state.CodexTotals = addCodexTotals(state.CodexTotals, event.Result.Tokens)
+	state.TokenTotals = addTokenTotals(state.TokenTotals, event.Result.Tokens)
 	if event.Result.RateLimits != nil {
 		state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
 	}
@@ -2455,7 +2455,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	issueID string,
 	running Running,
 	completedAt time.Time,
-	tokens CodexTotals,
+	tokens TokenTotals,
 ) {
 	o.completeDurableWorkAttempt(ctx, state, running, completedAt, store.WorkAttemptTerminalSuccess, "", "", "completed", "worker reached terminal state")
 	o.releaseGlobalDispatchSlot(running.globalSlot)
@@ -2490,7 +2490,7 @@ func (o *Orchestrator) completeTerminalRunning(
 		Tokens:      tokens,
 		MergeTiming: mergeTiming,
 	}
-	state.CodexTotals = addCodexTotals(state.CodexTotals, tokens)
+	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
 	if diffStatsPresent(running.DiffStats) {
 		state.DiffStats[issueID] = running.DiffStats
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -28,7 +28,7 @@ func TestRunDispatchesCandidateAndRecordsCompletion(t *testing.T) {
 	tracker := newFakeConnector(issue)
 	runner := &staticRunner{
 		result: orchestrator.RunResult{
-			Tokens: orchestrator.CodexTotals{
+			Tokens: orchestrator.TokenTotals{
 				InputTokens:    100,
 				OutputTokens:   25,
 				TotalTokens:    125,
@@ -69,8 +69,8 @@ func TestRunDispatchesCandidateAndRecordsCompletion(t *testing.T) {
 	if got := state.Retry[issue.ID].Attempt; got != 1 {
 		t.Fatalf("Retry[%q].Attempt = %d, want 1", issue.ID, got)
 	}
-	if got := state.CodexTotals.TotalTokens; got != 125 {
-		t.Fatalf("CodexTotals.TotalTokens = %d, want 125", got)
+	if got := state.TokenTotals.TotalTokens; got != 125 {
+		t.Fatalf("TokenTotals.TotalTokens = %d, want 125", got)
 	}
 	if got := state.DiffStats[issue.ID].AddedLines; got != 4 {
 		t.Fatalf("DiffStats[%q].AddedLines = %d, want 4", issue.ID, got)
@@ -785,7 +785,7 @@ func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 		LastEventAt:   lastEventAt,
 		LastEvent:     "agent_message_delta",
 		LastMessage:   "editing telemetry",
-		Tokens: orchestrator.CodexTotals{
+		Tokens: orchestrator.TokenTotals{
 			InputTokens:    40,
 			OutputTokens:   12,
 			TotalTokens:    52,
@@ -836,8 +836,8 @@ func TestRunAppliesUsageUpdateWhileRunnerIsInFlight(t *testing.T) {
 	if running.DiffStats.FilesChanged != 2 || running.DiffStats.AddedLines != 9 || running.DiffStats.RemovedLines != 1 || running.DiffStats.Status != "ok" {
 		t.Fatalf("Running[%q].DiffStats = %#v, want live diff stats", issue.ID, running.DiffStats)
 	}
-	if state.CodexTotals.TotalTokens != 0 {
-		t.Fatalf("CodexTotals.TotalTokens = %d, want completed totals only", state.CodexTotals.TotalTokens)
+	if state.TokenTotals.TotalTokens != 0 {
+		t.Fatalf("TokenTotals.TotalTokens = %d, want completed totals only", state.TokenTotals.TotalTokens)
 	}
 
 	close(runner.release)

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -171,7 +171,7 @@ func TestTickReapsTerminalRunningIssue(t *testing.T) {
 	state.Running[issue.ID] = Running{
 		Issue:      cloneIssue(issue),
 		StartedAt:  startedAt,
-		Tokens:     CodexTotals{InputTokens: 10, OutputTokens: 5, TotalTokens: 15, RuntimeSeconds: 90},
+		Tokens:     TokenTotals{InputTokens: 10, OutputTokens: 5, TotalTokens: 15, RuntimeSeconds: 90},
 		globalSlot: slot,
 		cancel:     cancel,
 	}
@@ -271,7 +271,7 @@ func TestTickCancelledRunningIssueAuditsWorkspaceCleanupAndReleasesLease(t *test
 	state.Running[issue.ID] = Running{
 		Issue:     cloneIssue(issue),
 		StartedAt: startedAt,
-		Tokens:    CodexTotals{TotalTokens: 15, RuntimeSeconds: 90},
+		Tokens:    TokenTotals{TotalTokens: 15, RuntimeSeconds: 90},
 		cancel:    cancel,
 	}
 	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: startedAt, Owner: "detent-test"}
@@ -450,7 +450,7 @@ func TestTickMarksClosedCompletedRunningIssueDoneBeforeReaping(t *testing.T) {
 	state.Running[issue.ID] = Running{
 		Issue:     cloneIssue(issue),
 		StartedAt: startedAt,
-		Tokens:    CodexTotals{TotalTokens: 42, RuntimeSeconds: 90},
+		Tokens:    TokenTotals{TotalTokens: 42, RuntimeSeconds: 90},
 		cancel:    cancel,
 	}
 
@@ -517,7 +517,7 @@ func TestTickCompletesTerminalRunningIssueDuringWorkspaceCleanupSweep(t *testing
 		Issue:       cloneIssue(prior),
 		StartedAt:   startedAt,
 		LastMessage: "GoReleaser Snapshot remains in progress; continuing to wait.",
-		Tokens:      CodexTotals{TotalTokens: 42, RuntimeSeconds: 90},
+		Tokens:      TokenTotals{TotalTokens: 42, RuntimeSeconds: 90},
 		cancel:      cancel,
 	}
 	state.Claimed[prior.ID] = Claimed{Issue: cloneIssue(prior), ClaimedAt: startedAt, Owner: "worker-1"}

--- a/internal/orchestrator/run_update_test.go
+++ b/internal/orchestrator/run_update_test.go
@@ -20,7 +20,7 @@ func TestUsageUpdateHandlerDoesNotBlockWhenBufferIsFull(t *testing.T) {
 	go func() {
 		done <- orch.usageUpdateHandler(context.Background(), "issue-1")(runpkg.UsageUpdate{
 			TurnCount: 1,
-			Tokens: runpkg.CodexTotals{
+			Tokens: runpkg.TokenTotals{
 				InputTokens:  10,
 				OutputTokens: 5,
 				TotalTokens:  15,

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -22,7 +22,7 @@ type BudgetRefusal = runner.BudgetRefusal
 
 type DiffStats = runner.DiffStats
 
-type CodexTotals = runner.CodexTotals
+type TokenTotals = runner.TokenTotals
 
 type UsageUpdate = runner.UsageUpdate
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -49,7 +49,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Blocked:            blockedSnapshots(s.Blocked, s.Claimed, now),
 		Completed:          completedSnapshots(s.Completed, s.Claimed, now),
 		RateLimits:         cloneRateLimits(s.RateLimits),
-		Tokens:             tokensFromCodexTotals(s.liveCodexTotals()),
+		Tokens:             tokensFromTokenTotals(s.liveTokenTotals()),
 		Budget: telemetry.Budget{
 			Refusals: budgetRefusalSnapshots(s.BudgetRefusals),
 		},
@@ -167,7 +167,7 @@ func runningSnapshots(running map[string]Running, claims map[string]Claimed, mer
 			DiffRemoved:     entry.DiffStats.RemovedLines,
 			DiffFiles:       entry.DiffStats.FilesChanged,
 			DiffStatus:      entry.DiffStats.Status,
-			Tokens:          tokensFromCodexTotals(entry.Tokens),
+			Tokens:          tokensFromTokenTotals(entry.Tokens),
 		})
 	}
 	return out
@@ -232,7 +232,7 @@ func completedSnapshots(completed map[string]Completed, claims map[string]Claime
 			CompletedAt:    entry.CompletedAt,
 			FinalState:     entry.FinalState,
 			RuntimeSeconds: entry.Tokens.RuntimeSeconds,
-			Tokens:         tokensFromCodexTotals(entry.Tokens),
+			Tokens:         tokensFromTokenTotals(entry.Tokens),
 		})
 	}
 	return out
@@ -500,7 +500,7 @@ func latestBefore(current *time.Time, candidate *time.Time, before time.Time) *t
 	return current
 }
 
-func tokensFromCodexTotals(totals CodexTotals) telemetry.Tokens {
+func tokensFromTokenTotals(totals TokenTotals) telemetry.Tokens {
 	return telemetry.Tokens{
 		Input:          totals.InputTokens,
 		Output:         totals.OutputTokens,
@@ -524,10 +524,10 @@ func timePointerFromPtr(value *time.Time) *time.Time {
 	return &cloned
 }
 
-func (s State) liveCodexTotals() CodexTotals {
-	totals := s.CodexTotals
+func (s State) liveTokenTotals() TokenTotals {
+	totals := s.TokenTotals
 	for _, running := range s.Running {
-		totals = addCodexTotals(totals, running.Tokens)
+		totals = addTokenTotals(totals, running.Tokens)
 	}
 	return totals
 }

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -339,14 +339,14 @@ func TestStateSnapshotPopulated(t *testing.T) {
 			{At: now.Add(-10 * time.Second), Event: "agent_message_delta", Message: "editing dashboard telemetry"},
 		},
 		DiffStats: DiffStats{FilesChanged: 3, AddedLines: 12, RemovedLines: 4, Status: "ok"},
-		Tokens:    CodexTotals{InputTokens: 20, OutputTokens: 8, TotalTokens: 28, RuntimeSeconds: 30},
+		Tokens:    TokenTotals{InputTokens: 20, OutputTokens: 8, TotalTokens: 28, RuntimeSeconds: 30},
 	}
 	state.Running["i-1"] = Running{
 		Issue:     connector.Issue{ID: "i-1", Identifier: "ISS-1", Title: "One", State: "In Progress"},
 		Attempt:   0,
 		StartedAt: startedAt,
 		TurnCount: 1,
-		Tokens:    CodexTotals{InputTokens: 2, OutputTokens: 1, TotalTokens: 3, RuntimeSeconds: 15},
+		Tokens:    TokenTotals{InputTokens: 2, OutputTokens: 1, TotalTokens: 3, RuntimeSeconds: 15},
 	}
 	state.Retry["i-3"] = Retry{
 		Issue:      connector.Issue{ID: "i-3", Identifier: "ISS-3", Title: "Three", State: "Todo"},
@@ -365,9 +365,9 @@ func TestStateSnapshotPopulated(t *testing.T) {
 		StartedAt:   startedAt,
 		CompletedAt: completedAt,
 		FinalState:  FinalStateCompleted,
-		Tokens:      CodexTotals{InputTokens: 10, OutputTokens: 5, TotalTokens: 15, RuntimeSeconds: 60},
+		Tokens:      TokenTotals{InputTokens: 10, OutputTokens: 5, TotalTokens: 15, RuntimeSeconds: 60},
 	}
-	state.CodexTotals = CodexTotals{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, RuntimeSeconds: 120}
+	state.TokenTotals = TokenTotals{InputTokens: 100, OutputTokens: 50, TotalTokens: 150, RuntimeSeconds: 120}
 	state.RateLimits = &telemetry.RateLimits{LimitID: "lim", LimitName: "name"}
 
 	snapshot := state.Snapshot(now)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -41,7 +41,7 @@ type State struct {
 	BudgetRefusals           map[string]BudgetRefusal
 	DiffStats                map[string]DiffStats
 	ReapedWorkspaces         map[string]time.Time
-	CodexTotals              CodexTotals
+	TokenTotals              TokenTotals
 	RateLimits               *telemetry.RateLimits
 	planRework               map[string]struct{}
 	epicTransitionWatch      []connector.Issue
@@ -64,7 +64,7 @@ type Running struct {
 	LastMessage     string
 	RecentEvents    []telemetry.ActivityEvent
 	DiffStats       DiffStats
-	Tokens          CodexTotals
+	Tokens          TokenTotals
 	globalSlot      scheduler.Slot
 	cancel          context.CancelFunc
 }
@@ -98,7 +98,7 @@ type Completed struct {
 	StartedAt   time.Time
 	CompletedAt time.Time
 	FinalState  string
-	Tokens      CodexTotals
+	Tokens      TokenTotals
 	MergeTiming MergeTiming
 }
 
@@ -189,7 +189,7 @@ func (s State) clone() State {
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		DiffStats:                make(map[string]DiffStats, len(s.DiffStats)),
 		ReapedWorkspaces:         make(map[string]time.Time, len(s.ReapedWorkspaces)),
-		CodexTotals:              s.CodexTotals,
+		TokenTotals:              s.TokenTotals,
 		RateLimits:               cloneRateLimits(s.RateLimits),
 		planRework:               make(map[string]struct{}, len(s.planRework)),
 		epicTransitionWatch:      cloneIssues(s.epicTransitionWatch),
@@ -465,8 +465,8 @@ func cloneTelemetrySchedulerDecisions(values []telemetry.SchedulerDecision) []te
 	return append([]telemetry.SchedulerDecision(nil), values...)
 }
 
-func addCodexTotals(left, right CodexTotals) CodexTotals {
-	return CodexTotals{
+func addTokenTotals(left, right TokenTotals) TokenTotals {
+	return TokenTotals{
 		InputTokens:    left.InputTokens + right.InputTokens,
 		OutputTokens:   left.OutputTokens + right.OutputTokens,
 		TotalTokens:    left.TotalTokens + right.TotalTokens,

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -529,7 +529,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("run agent turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1),
 		)
 	}
 
@@ -546,7 +546,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			)
 			finishedAt := r.now().UTC()
 			result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1); err != nil {
+			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1); err != nil {
 				return result, err
 			}
 			return result, nil
@@ -556,14 +556,14 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("workspace diff stat: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1),
 		)
 	}
 
 	result.DiffStats = diffStatsFromWorkspace(diffStat)
 	finishedAt := r.now().UTC()
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, 1); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -683,7 +683,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = FinalStateFailed
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("run validator turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendConfig.Kind, 1),
 		)
 	}
 
@@ -692,10 +692,10 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = FinalStateFailed
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("parse validator result: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendConfig.Kind, 1),
 		)
 	}
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, 1); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendConfig.Kind, 1); err != nil {
 		return gate.ValidatorResult{}, err
 	}
 	return validation, nil
@@ -848,7 +848,7 @@ func (r *Runner) startSession(
 		Model:      model,
 	})
 	if err != nil {
-		return 0, false, fmt.Errorf("start codex session: %w", err)
+		return 0, false, fmt.Errorf("start agent session: %w", err)
 	}
 	r.logWorkerEvent(issue, "worker_session_started",
 		"session_id", sessionID,
@@ -866,6 +866,7 @@ func (r *Runner) finishSession(
 	finishedAt time.Time,
 	result RunResult,
 	model string,
+	backendKind string,
 	turns int64,
 ) error {
 	if !started {
@@ -885,7 +886,7 @@ func (r *Runner) finishSession(
 		FinalState:     result.FinalState,
 		Model:          model,
 	}); err != nil {
-		return fmt.Errorf("finish codex session: %w", err)
+		return fmt.Errorf("finish agent session: %w", err)
 	}
 	r.logWorkerEvent(issue, "worker_session_finished",
 		"session_id", sessionID,
@@ -911,7 +912,7 @@ func (r *Runner) finishSession(
 	}); err != nil {
 		return fmt.Errorf("record usage event: %w", err)
 	}
-	if err := r.recordAgentSessionPhase(ctx, sessionID, issue, startedAt, finishedAt, result); err != nil {
+	if err := r.recordAgentSessionPhase(ctx, sessionID, issue, startedAt, finishedAt, result, backendKind); err != nil {
 		return err
 	}
 	return nil
@@ -924,6 +925,7 @@ func (r *Runner) recordAgentSessionPhase(
 	startedAt time.Time,
 	finishedAt time.Time,
 	result RunResult,
+	backendKind string,
 ) error {
 	phaseStore, ok := r.store.(workflowPhaseStore)
 	if !ok {
@@ -932,6 +934,7 @@ func (r *Runner) recordAgentSessionPhase(
 	if result.FinalState == "" {
 		result.FinalState = FinalStateCompleted
 	}
+	endpointFamily := strings.TrimSpace(backendKind)
 	if _, err := phaseStore.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
 		ProjectID:       r.projectID,
 		SessionID:       sessionID,
@@ -949,7 +952,7 @@ func (r *Runner) recordAgentSessionPhase(
 		InputTokens:     result.Tokens.InputTokens,
 		OutputTokens:    result.Tokens.OutputTokens,
 		TotalTokens:     result.Tokens.TotalTokens,
-		EndpointFamily:  "codex",
+		EndpointFamily:  endpointFamily,
 	}); err != nil {
 		return fmt.Errorf("record agent session phase: %w", err)
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -265,6 +265,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if sessionStore.phase.ProjectID != "detent" || sessionStore.phase.SessionID != 42 {
 		t.Fatalf("WorkflowPhaseEvent identity = %#v, want project detent and session 42", sessionStore.phase)
 	}
+	if sessionStore.phase.EndpointFamily != config.AgentBackendCodex {
+		t.Fatalf("WorkflowPhaseEvent EndpointFamily = %q, want %q", sessionStore.phase.EndpointFamily, config.AgentBackendCodex)
+	}
 	if sessionStore.phase.PhaseType != store.WorkflowPhaseTypeAgentSession || sessionStore.phase.PhaseName != "agent_active" || sessionStore.phase.Status != FinalStateCompleted {
 		t.Fatalf("WorkflowPhaseEvent phase = %#v, want completed agent_active session", sessionStore.phase)
 	}

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -113,7 +113,7 @@ type ValidatorRequest struct {
 type RunResult struct {
 	FinalState    string
 	Output        string
-	Tokens        CodexTotals
+	Tokens        TokenTotals
 	DiffStats     DiffStats
 	RateLimits    *telemetry.RateLimits
 	BudgetRefusal *BudgetRefusal
@@ -130,7 +130,7 @@ type UsageUpdate struct {
 	LastEvent       string
 	LastMessage     string
 	RecentEvents    []telemetry.ActivityEvent
-	Tokens          CodexTotals
+	Tokens          TokenTotals
 	DiffStats       DiffStats
 	RateLimits      *telemetry.RateLimits
 }
@@ -153,7 +153,7 @@ type DiffStats struct {
 	Status       string
 }
 
-type CodexTotals struct {
+type TokenTotals struct {
 	InputTokens    int64
 	OutputTokens   int64
 	TotalTokens    int64

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -449,7 +449,7 @@ func stateResponse(snapshot telemetry.Snapshot, generatedAt time.Time, instanceN
 		Blocked:         blockedEntries(snapshot.Blocked),
 		Stats:           statsAPIResponse{Status: "enabled"},
 		Board:           boardResponse(snapshot),
-		CodexTotals:     totalsResponse(snapshot.Tokens),
+		TokenTotals:     totalsResponse(snapshot.Tokens),
 		Throughput:      throughputResponse(snapshot.Throughput),
 		LifetimeTotals:  lifetimeTotalsResponseFromTelemetry(snapshot.LifetimeTotals),
 		WorkflowMetrics: snapshot.WorkflowMetrics,
@@ -1280,7 +1280,7 @@ type stateAPIResponse struct {
 	Blocked         []blockedAPIResponse        `json:"blocked"`
 	Stats           statsAPIResponse            `json:"stats"`
 	Board           boardAPIResponse            `json:"board"`
-	CodexTotals     tokenTotalsAPIResponse      `json:"codex_totals"`
+	TokenTotals     tokenTotalsAPIResponse      `json:"codex_totals"`
 	Throughput      throughputAPIResponse       `json:"throughput"`
 	LifetimeTotals  lifetimeTotalsResponse      `json:"lifetime_totals"`
 	WorkflowMetrics telemetry.WorkflowMetrics   `json:"workflow_metrics"`


### PR DESCRIPTION
## Summary

- Attribute agent session workflow telemetry to the routed backend kind instead of a hard-coded Codex family.
- Rename backend-neutral token-total DTOs from `CodexTotals` to `TokenTotals` while preserving JSON payload names.

Fixes #821

## Test Plan

- [x] `go test ./internal/runner`
- [x] `go test ./internal/orchestrator ./internal/web ./internal/cli`
- [x] `make check`