### PR TITLE
refactor(runner): make AgentTurnRequest backend-neutral

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -187,7 +187,7 @@ func buildCodexAgentBackend(cfg workflowconfig.Codex) (runnerpkg.AgentBackend, e
 	if err != nil {
 		return nil, fmt.Errorf("create codex app-server: %w", err)
 	}
-	backend, err := codex.NewAgentBackend(client)
+	backend, err := codex.NewAgentBackend(client, codex.OptionsFromConfig(cfg))
 	if err != nil {
 		return nil, fmt.Errorf("create codex backend: %w", err)
 	}

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -13,14 +13,18 @@ import (
 var ErrMissingAppServer = errors.New("codex app-server is required")
 
 type AgentBackend struct {
-	client *AppServer
+	client  *AppServer
+	options Options
 }
 
-func NewAgentBackend(client *AppServer) (*AgentBackend, error) {
+func NewAgentBackend(client *AppServer, options Options) (*AgentBackend, error) {
 	if client == nil {
 		return nil, ErrMissingAppServer
 	}
-	return &AgentBackend{client: client}, nil
+	return &AgentBackend{
+		client:  client,
+		options: options,
+	}, nil
 }
 
 func (b *AgentBackend) RunTurn(
@@ -31,12 +35,10 @@ func (b *AgentBackend) RunTurn(
 	result, err := b.client.RunTurn(ctx, RunTurnRequest{
 		Workspace:         req.Workspace,
 		Prompt:            req.Prompt,
-		ApprovalPolicy:    req.ApprovalPolicy,
-		ThreadSandbox:     req.ThreadSandbox,
-		TurnSandboxPolicy: req.TurnSandboxPolicy,
+		ApprovalPolicy:    b.options.ApprovalPolicy,
+		ThreadSandbox:     b.options.ThreadSandbox,
+		TurnSandboxPolicy: turnSandboxPolicyForWorkspace(b.options.ThreadSandbox, b.options.TurnSandboxPolicy, req.ExtraWritableRoots),
 		Model:             req.Model,
-		ModelProvider:     req.ModelProvider,
-		ServiceTier:       req.ServiceTier,
 	}, func(update Update) error {
 		if onUpdate == nil {
 			return nil

--- a/internal/codex/backend_test.go
+++ b/internal/codex/backend_test.go
@@ -1,0 +1,66 @@
+package codex
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestAgentBackendAppliesOptionsAndExtraWritableRoots(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+	backend, err := NewAgentBackend(server, Options{
+		ApprovalPolicy: "never",
+		ThreadSandbox:  "workspace-write",
+		TurnSandboxPolicy: map[string]any{
+			"type":          "workspaceWrite",
+			"networkAccess": true,
+			"writableRoots": []string{"/existing"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewAgentBackend() error = %v", err)
+	}
+
+	_, err = backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace:          "/tmp/detent-workspace",
+		Prompt:             "Ship issue #820",
+		Model:              "gpt-5-codex",
+		ExtraWritableRoots: []string{"/extra", "/existing", " "},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	sent := transport.sentMessages()
+	if len(sent) != 4 {
+		t.Fatalf("sent messages = %d, want 4", len(sent))
+	}
+
+	assertRequest(t, sent[2], 2, "thread/start")
+	assertJSONContains(t, sent[2].Params, "approvalPolicy", "never")
+	assertJSONContains(t, sent[2].Params, "sandbox", "workspace-write")
+	assertJSONContains(t, sent[2].Params, "model", "gpt-5-codex")
+
+	assertRequest(t, sent[3], 3, "turn/start")
+	assertJSONContains(t, sent[3].Params, "approvalPolicy", "never")
+	assertJSONContains(t, sent[3].Params, "sandboxPolicy.type", "workspaceWrite")
+	assertJSONContains(t, sent[3].Params, "sandboxPolicy.networkAccess", true)
+	assertJSONContains(t, sent[3].Params, "sandboxPolicy.writableRoots", []any{"/existing", "/extra"})
+	assertJSONContains(t, sent[3].Params, "model", "gpt-5-codex")
+}

--- a/internal/codex/sandbox.go
+++ b/internal/codex/sandbox.go
@@ -1,0 +1,177 @@
+package codex
+
+import (
+	"encoding/json"
+	"maps"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/config"
+)
+
+type Options struct {
+	ApprovalPolicy    any
+	ThreadSandbox     string
+	TurnSandboxPolicy any
+}
+
+func OptionsFromConfig(cfg config.Codex) Options {
+	return Options{
+		ApprovalPolicy:    stringOrMapValue(cfg.ApprovalPolicy),
+		ThreadSandbox:     cfg.ThreadSandbox,
+		TurnSandboxPolicy: cfg.TurnSandboxPolicy,
+	}
+}
+
+func turnSandboxPolicyForWorkspace(threadSandbox string, policy any, extraWritableRoots []string) any {
+	policyMap, ok := workspaceWriteSandboxPolicyMap(threadSandbox, policy)
+	if !ok {
+		return policy
+	}
+	if len(extraWritableRoots) == 0 {
+		return policy
+	}
+	return mergeSandboxWritableRoots(policyMap, extraWritableRoots)
+}
+
+func workspaceWriteSandboxPolicyMap(threadSandbox string, policy any) (map[string]any, bool) {
+	policyMap, ok := sandboxPolicyMap(policy)
+	if !ok {
+		return nil, false
+	}
+	policyKind := strings.TrimSpace(policyType(policyMap))
+	if isWorkspaceWriteSandboxName(policyKind) {
+		return policyMap, true
+	}
+	if policyKind != "" || !isWorkspaceWriteSandboxName(threadSandbox) {
+		return nil, false
+	}
+	policyMap["type"] = "workspaceWrite"
+	return policyMap, true
+}
+
+func sandboxPolicyMap(policy any) (map[string]any, bool) {
+	if policy == nil {
+		return map[string]any{}, true
+	}
+	switch value := policy.(type) {
+	case map[string]any:
+		out := make(map[string]any, len(value))
+		maps.Copy(out, value)
+		return out, true
+	case json.RawMessage:
+		return decodeSandboxPolicyMap(value)
+	case []byte:
+		return decodeSandboxPolicyMap(value)
+	case string:
+		return decodeSandboxPolicyMap([]byte(value))
+	default:
+		raw, err := json.Marshal(value)
+		if err != nil {
+			return nil, false
+		}
+		return decodeSandboxPolicyMap(raw)
+	}
+}
+
+func decodeSandboxPolicyMap(raw []byte) (map[string]any, bool) {
+	var policy map[string]any
+	if err := json.Unmarshal(raw, &policy); err != nil {
+		return nil, false
+	}
+	if policy == nil {
+		policy = map[string]any{}
+	}
+	return policy, true
+}
+
+func policyType(policy map[string]any) string {
+	value, ok := policy["type"]
+	if !ok {
+		return ""
+	}
+	text, ok := value.(string)
+	if !ok {
+		return ""
+	}
+	return text
+}
+
+func isWorkspaceWriteSandboxName(value string) bool {
+	normalized := strings.ToLower(strings.TrimSpace(value))
+	normalized = strings.ReplaceAll(normalized, "_", "-")
+	return normalized == "workspace-write" || normalized == "workspacewrite"
+}
+
+func mergeSandboxWritableRoots(policy map[string]any, roots []string) map[string]any {
+	merged := []string{}
+	merged = appendPolicyStringSlice(merged, policy["writableRoots"])
+	merged = appendPolicyStringSlice(merged, policy["writable_roots"])
+	merged = appendUniqueStrings(merged, roots...)
+	if strings.TrimSpace(policyType(policy)) == "" {
+		policy["type"] = "workspaceWrite"
+	}
+	policy["writableRoots"] = merged
+	delete(policy, "writable_roots")
+	return policy
+}
+
+func appendPolicyStringSlice(out []string, value any) []string {
+	switch values := value.(type) {
+	case []string:
+		return appendUniqueStrings(out, values...)
+	case []any:
+		for _, item := range values {
+			text, ok := item.(string)
+			if !ok {
+				continue
+			}
+			out = appendUniqueStrings(out, text)
+		}
+	}
+	return out
+}
+
+func appendUniqueStrings(out []string, values ...string) []string {
+	seen := make(map[string]struct{}, len(out)+len(values))
+	for _, value := range out {
+		seen[value] = struct{}{}
+	}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func stringOrMapValue(value config.StringOrMap) any {
+	if value.IsMap {
+		return cloneMap(value.Map)
+	}
+	if value.IsString {
+		return value.String
+	}
+	return nil
+}
+
+func cloneMap(value map[string]any) map[string]any {
+	if value == nil {
+		return nil
+	}
+
+	data, err := json.Marshal(value)
+	if err != nil {
+		return value
+	}
+	var cloned map[string]any
+	if err := json.Unmarshal(data, &cloned); err != nil {
+		return value
+	}
+	return cloned
+}

--- a/internal/codex/sandbox_test.go
+++ b/internal/codex/sandbox_test.go
@@ -1,0 +1,95 @@
+package codex
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/config"
+)
+
+func TestTurnSandboxPolicyForWorkspaceMergesExtraWritableRoots(t *testing.T) {
+	t.Parallel()
+
+	policy := map[string]any{
+		"networkAccess": true,
+		"writableRoots": []string{"/existing"},
+		"writable_roots": []any{
+			"/legacy",
+			42,
+		},
+	}
+
+	got, ok := turnSandboxPolicyForWorkspace("workspace-write", policy, []string{"/extra", "/existing", " "}).(map[string]any)
+	if !ok {
+		t.Fatalf("turnSandboxPolicyForWorkspace() = %T, want map", got)
+	}
+
+	if got["type"] != "workspaceWrite" {
+		t.Fatalf("policy type = %#v, want workspaceWrite", got["type"])
+	}
+	if got["networkAccess"] != true {
+		t.Fatalf("policy networkAccess = %#v, want true", got["networkAccess"])
+	}
+	if roots, ok := got["writableRoots"].([]string); !ok || !reflect.DeepEqual(roots, []string{"/existing", "/legacy", "/extra"}) {
+		t.Fatalf("policy writableRoots = %#v, want merged roots", got["writableRoots"])
+	}
+	if _, ok := got["writable_roots"]; ok {
+		t.Fatalf("policy writable_roots = %#v, want absent", got["writable_roots"])
+	}
+	if _, ok := policy["type"]; ok {
+		t.Fatalf("original policy type = %#v, want absent", policy["type"])
+	}
+}
+
+func TestWorkspaceWriteSandboxPolicyMapSkipsExplicitNonWorkspacePolicy(t *testing.T) {
+	t.Parallel()
+
+	policy := map[string]any{
+		"type":          "dangerFullAccess",
+		"networkAccess": true,
+	}
+
+	got, ok := workspaceWriteSandboxPolicyMap("workspace-write", policy)
+	if ok {
+		t.Fatalf("workspaceWriteSandboxPolicyMap() = %#v, true; want false for explicit non-workspace policy", got)
+	}
+	if policy["type"] != "dangerFullAccess" {
+		t.Fatalf("policy type = %#v, want dangerFullAccess", policy["type"])
+	}
+	if _, ok := policy["writableRoots"]; ok {
+		t.Fatalf("policy writableRoots = %#v, want absent", policy["writableRoots"])
+	}
+}
+
+func TestOptionsFromConfigClonesApprovalPolicy(t *testing.T) {
+	t.Parallel()
+
+	rawPolicy := map[string]any{
+		"reject": map[string]any{
+			"rules": true,
+		},
+	}
+	options := OptionsFromConfig(config.Codex{
+		ApprovalPolicy: config.MapValue(rawPolicy),
+		ThreadSandbox:  "workspace-write",
+		TurnSandboxPolicy: map[string]any{
+			"type": "workspaceWrite",
+		},
+	})
+	rawPolicy["reject"].(map[string]any)["rules"] = false
+
+	policy, ok := options.ApprovalPolicy.(map[string]any)
+	if !ok {
+		t.Fatalf("ApprovalPolicy = %T, want map", options.ApprovalPolicy)
+	}
+	reject, ok := policy["reject"].(map[string]any)
+	if !ok {
+		t.Fatalf("ApprovalPolicy.reject = %T, want map", policy["reject"])
+	}
+	if reject["rules"] != true {
+		t.Fatalf("ApprovalPolicy.reject.rules = %#v, want cloned true", reject["rules"])
+	}
+	if options.ThreadSandbox != "workspace-write" {
+		t.Fatalf("ThreadSandbox = %q, want workspace-write", options.ThreadSandbox)
+	}
+}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -148,8 +148,9 @@ func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
 }
 
 type agentRuntime struct {
-	backends map[string]AgentBackend
-	router   *Router
+	backends     map[string]AgentBackend
+	backendKinds map[string]string
+	router       *Router
 }
 
 func newAgentRuntime(
@@ -159,10 +160,12 @@ func newAgentRuntime(
 ) (agentRuntime, error) {
 	backendConfigs := effectiveAgentBackendConfigs(workflow.Config)
 	backends := make(map[string]AgentBackend, len(backendConfigs))
+	backendKinds := make(map[string]string, len(backendConfigs))
 	for _, backendConfig := range backendConfigs {
 		if strings.TrimSpace(backendConfig.ID) == "" {
 			continue
 		}
+		backendKinds[backendConfig.ID] = backendConfig.Kind
 		if factory != nil {
 			backend, err := factory.NewAgentBackend(backendConfig)
 			if err != nil {
@@ -192,8 +195,9 @@ func newAgentRuntime(
 	}
 
 	return agentRuntime{
-		backends: backends,
-		router:   router,
+		backends:     backends,
+		backendKinds: backendKinds,
+		router:       router,
 	}, nil
 }
 
@@ -229,20 +233,24 @@ func routesFromConfig(routes []config.AgentRoute) []Route {
 	return out
 }
 
-func (r agentRuntime) selectBackend(issue connector.Issue, ctx selector.Context) (RouteSelection, AgentBackend, error) {
+func (r agentRuntime) selectBackend(issue connector.Issue, ctx selector.Context) (RouteSelection, AgentBackend, string, error) {
 	return r.selectBackendForRole(issue, ctx, RoleCode)
 }
 
-func (r agentRuntime) selectBackendForRole(issue connector.Issue, ctx selector.Context, role string) (RouteSelection, AgentBackend, error) {
+func (r agentRuntime) selectBackendForRole(issue connector.Issue, ctx selector.Context, role string) (RouteSelection, AgentBackend, string, error) {
 	selection, err := r.router.RouteForRole(issue, ctx, role)
 	if err != nil {
-		return RouteSelection{}, nil, err
+		return RouteSelection{}, nil, "", err
 	}
 	backend, ok := r.backends[selection.BackendID]
 	if !ok {
-		return RouteSelection{}, nil, fmt.Errorf("%w: %s", ErrMissingAgentBackend, selection.BackendID)
+		return RouteSelection{}, nil, "", fmt.Errorf("%w: %s", ErrMissingAgentBackend, selection.BackendID)
 	}
-	return selection, backend, nil
+	backendKind, ok := r.backendKinds[selection.BackendID]
+	if !ok {
+		return RouteSelection{}, nil, "", fmt.Errorf("agent backend kind not found: %s", selection.BackendID)
+	}
+	return selection, backend, backendKind, nil
 }
 
 func cloneAgentBackends(in map[string]AgentBackend) map[string]AgentBackend {
@@ -330,7 +338,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
 	}
-	selection, backend, err := agentRuntime.selectBackend(req.Issue, selectorContext(req.SelectorContext, workflow))
+	selection, backend, backendKind, err := agentRuntime.selectBackend(req.Issue, selectorContext(req.SelectorContext, workflow))
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -395,7 +403,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("run agent turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendKind, 1),
 		)
 	}
 
@@ -412,7 +420,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			)
 			finishedAt := r.now().UTC()
 			result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1); err != nil {
+			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendKind, 1); err != nil {
 				return result, err
 			}
 			return result, nil
@@ -422,14 +430,14 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("workspace diff stat: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendKind, 1),
 		)
 	}
 
 	result.DiffStats = diffStatsFromWorkspace(diffStat)
 	finishedAt := r.now().UTC()
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendConfig.Kind, 1); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, model, backendKind, 1); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -470,7 +478,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		WorkspacePath: info.Path,
 		Branch:        info.Branch,
 	})
-	selection, backend, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), RoleValidator)
+	selection, backend, backendKind, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), RoleValidator)
 	if err != nil {
 		return gate.ValidatorResult{}, err
 	}
@@ -547,7 +555,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = FinalStateFailed
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("run validator turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendConfig.Kind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendKind, 1),
 		)
 	}
 
@@ -556,10 +564,10 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = FinalStateFailed
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("parse validator result: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendConfig.Kind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendKind, 1),
 		)
 	}
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendConfig.Kind, 1); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendKind, 1); err != nil {
 		return gate.ValidatorResult{}, err
 	}
 	return validation, nil

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -148,9 +148,8 @@ func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
 }
 
 type agentRuntime struct {
-	backends       map[string]AgentBackend
-	backendConfigs map[string]config.AgentBackend
-	router         *Router
+	backends map[string]AgentBackend
+	router   *Router
 }
 
 func newAgentRuntime(
@@ -160,12 +159,10 @@ func newAgentRuntime(
 ) (agentRuntime, error) {
 	backendConfigs := effectiveAgentBackendConfigs(workflow.Config)
 	backends := make(map[string]AgentBackend, len(backendConfigs))
-	configsByID := make(map[string]config.AgentBackend, len(backendConfigs))
 	for _, backendConfig := range backendConfigs {
 		if strings.TrimSpace(backendConfig.ID) == "" {
 			continue
 		}
-		configsByID[backendConfig.ID] = backendConfig
 		if factory != nil {
 			backend, err := factory.NewAgentBackend(backendConfig)
 			if err != nil {
@@ -195,9 +192,8 @@ func newAgentRuntime(
 	}
 
 	return agentRuntime{
-		backends:       backends,
-		backendConfigs: configsByID,
-		router:         router,
+		backends: backends,
+		router:   router,
 	}, nil
 }
 
@@ -233,24 +229,20 @@ func routesFromConfig(routes []config.AgentRoute) []Route {
 	return out
 }
 
-func (r agentRuntime) selectBackend(issue connector.Issue, ctx selector.Context) (RouteSelection, AgentBackend, config.AgentBackend, error) {
+func (r agentRuntime) selectBackend(issue connector.Issue, ctx selector.Context) (RouteSelection, AgentBackend, error) {
 	return r.selectBackendForRole(issue, ctx, RoleCode)
 }
 
-func (r agentRuntime) selectBackendForRole(issue connector.Issue, ctx selector.Context, role string) (RouteSelection, AgentBackend, config.AgentBackend, error) {
+func (r agentRuntime) selectBackendForRole(issue connector.Issue, ctx selector.Context, role string) (RouteSelection, AgentBackend, error) {
 	selection, err := r.router.RouteForRole(issue, ctx, role)
 	if err != nil {
-		return RouteSelection{}, nil, config.AgentBackend{}, err
+		return RouteSelection{}, nil, err
 	}
 	backend, ok := r.backends[selection.BackendID]
 	if !ok {
-		return RouteSelection{}, nil, config.AgentBackend{}, fmt.Errorf("%w: %s", ErrMissingAgentBackend, selection.BackendID)
+		return RouteSelection{}, nil, fmt.Errorf("%w: %s", ErrMissingAgentBackend, selection.BackendID)
 	}
-	backendConfig, ok := r.backendConfigs[selection.BackendID]
-	if !ok {
-		return RouteSelection{}, nil, config.AgentBackend{}, fmt.Errorf("agent backend config not found: %s", selection.BackendID)
-	}
-	return selection, backend, backendConfig, nil
+	return selection, backend, nil
 }
 
 func cloneAgentBackends(in map[string]AgentBackend) map[string]AgentBackend {
@@ -280,139 +272,15 @@ func normalizeRunMode(mode string) string {
 	}
 }
 
-func turnSandboxPolicyForWorkspace(ctx context.Context, workspacePath string, threadSandbox string, policy any, logger *slog.Logger) any {
-	policyMap, ok := workspaceWriteSandboxPolicyMap(threadSandbox, policy)
-	if !ok {
-		return policy
-	}
+func extraWritableRootsForWorkspace(ctx context.Context, workspacePath string, logger *slog.Logger) []string {
 	roots, err := workspace.GitMetadataWritableRoots(ctx, workspacePath)
 	if err != nil {
 		if logger != nil {
 			logger.Warn("workspace git metadata writable roots unavailable", slog.String("workspace_path", workspacePath), slog.Any("error", err))
 		}
-		return policy
+		return nil
 	}
-	if len(roots) == 0 {
-		return policy
-	}
-	return mergeSandboxWritableRoots(policyMap, roots)
-}
-
-func workspaceWriteSandboxPolicyMap(threadSandbox string, policy any) (map[string]any, bool) {
-	policyMap, ok := sandboxPolicyMap(policy)
-	if !ok {
-		return nil, false
-	}
-	policyKind := strings.TrimSpace(policyType(policyMap))
-	if isWorkspaceWriteSandboxName(policyKind) {
-		return policyMap, true
-	}
-	if policyKind != "" || !isWorkspaceWriteSandboxName(threadSandbox) {
-		return nil, false
-	}
-	policyMap["type"] = "workspaceWrite"
-	return policyMap, true
-}
-
-func sandboxPolicyMap(policy any) (map[string]any, bool) {
-	if policy == nil {
-		return map[string]any{}, true
-	}
-	switch value := policy.(type) {
-	case map[string]any:
-		out := make(map[string]any, len(value))
-		maps.Copy(out, value)
-		return out, true
-	case json.RawMessage:
-		return decodeSandboxPolicyMap(value)
-	case []byte:
-		return decodeSandboxPolicyMap(value)
-	case string:
-		return decodeSandboxPolicyMap([]byte(value))
-	default:
-		raw, err := json.Marshal(value)
-		if err != nil {
-			return nil, false
-		}
-		return decodeSandboxPolicyMap(raw)
-	}
-}
-
-func decodeSandboxPolicyMap(raw []byte) (map[string]any, bool) {
-	var policy map[string]any
-	if err := json.Unmarshal(raw, &policy); err != nil {
-		return nil, false
-	}
-	if policy == nil {
-		policy = map[string]any{}
-	}
-	return policy, true
-}
-
-func policyType(policy map[string]any) string {
-	value, ok := policy["type"]
-	if !ok {
-		return ""
-	}
-	text, ok := value.(string)
-	if !ok {
-		return ""
-	}
-	return text
-}
-
-func isWorkspaceWriteSandboxName(value string) bool {
-	normalized := strings.ToLower(strings.TrimSpace(value))
-	normalized = strings.ReplaceAll(normalized, "_", "-")
-	return normalized == "workspace-write" || normalized == "workspacewrite"
-}
-
-func mergeSandboxWritableRoots(policy map[string]any, roots []string) map[string]any {
-	merged := []string{}
-	merged = appendPolicyStringSlice(merged, policy["writableRoots"])
-	merged = appendPolicyStringSlice(merged, policy["writable_roots"])
-	merged = appendUniqueStrings(merged, roots...)
-	if strings.TrimSpace(policyType(policy)) == "" {
-		policy["type"] = "workspaceWrite"
-	}
-	policy["writableRoots"] = merged
-	delete(policy, "writable_roots")
-	return policy
-}
-
-func appendPolicyStringSlice(out []string, value any) []string {
-	switch values := value.(type) {
-	case []string:
-		return appendUniqueStrings(out, values...)
-	case []any:
-		for _, item := range values {
-			text, ok := item.(string)
-			if !ok {
-				continue
-			}
-			out = appendUniqueStrings(out, text)
-		}
-	}
-	return out
-}
-
-func appendUniqueStrings(out []string, values ...string) []string {
-	seen := make(map[string]struct{}, len(out)+len(values))
-	for _, value := range out {
-		seen[value] = struct{}{}
-	}
-	for _, value := range values {
-		value = strings.TrimSpace(value)
-		if value == "" {
-			continue
-		}
-		if _, ok := seen[value]; ok {
-			continue
-		}
-		seen[value] = struct{}{}
-		out = append(out, value)
-	}
-	return out
+	return roots
 }
 
 func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
@@ -462,7 +330,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
 	}
-	selection, backend, backendConfig, err := agentRuntime.selectBackend(req.Issue, selectorContext(req.SelectorContext, workflow))
+	selection, backend, err := agentRuntime.selectBackend(req.Issue, selectorContext(req.SelectorContext, workflow))
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -489,12 +357,10 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	result := RunResult{FinalState: FinalStateCompleted}
 	progress := newAgentRunProgress()
 	turnResult, turnErr := backend.RunTurn(ctx, AgentTurnRequest{
-		Workspace:         info.Path,
-		Prompt:            prompt,
-		ApprovalPolicy:    stringOrMapValue(backendConfig.Options.ApprovalPolicy),
-		ThreadSandbox:     backendConfig.Options.ThreadSandbox,
-		TurnSandboxPolicy: turnSandboxPolicyForWorkspace(ctx, info.Path, backendConfig.Options.ThreadSandbox, backendConfig.Options.TurnSandboxPolicy, r.logger),
-		Model:             model,
+		Workspace:          info.Path,
+		Prompt:             prompt,
+		Model:              model,
+		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
 	}, func(update AgentUpdate) error {
 		r.logAgentUpdate(req.Issue, update)
 		applyAgentUpdate(&result, update)
@@ -604,7 +470,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		WorkspacePath: info.Path,
 		Branch:        info.Branch,
 	})
-	selection, backend, backendConfig, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), RoleValidator)
+	selection, backend, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), RoleValidator)
 	if err != nil {
 		return gate.ValidatorResult{}, err
 	}
@@ -641,12 +507,10 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	progress := newAgentRunProgress()
 	var output strings.Builder
 	turnResult, turnErr := backend.RunTurn(ctx, AgentTurnRequest{
-		Workspace:         info.Path,
-		Prompt:            prompt,
-		ApprovalPolicy:    stringOrMapValue(backendConfig.Options.ApprovalPolicy),
-		ThreadSandbox:     backendConfig.Options.ThreadSandbox,
-		TurnSandboxPolicy: turnSandboxPolicyForWorkspace(ctx, info.Path, backendConfig.Options.ThreadSandbox, backendConfig.Options.TurnSandboxPolicy, r.logger),
-		Model:             model,
+		Workspace:          info.Path,
+		Prompt:             prompt,
+		Model:              model,
+		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
 	}, func(update AgentUpdate) error {
 		r.logAgentUpdate(req.Issue, update)
 		if update.Type == AgentUpdateMessageDelta {
@@ -1257,32 +1121,6 @@ func diffStatsFromWorkspace(stat workspace.DiffStat) DiffStats {
 		RemovedLines: stat.Removed,
 		Status:       status,
 	}
-}
-
-func stringOrMapValue(value config.StringOrMap) any {
-	if value.IsMap {
-		return cloneMap(value.Map)
-	}
-	if value.IsString {
-		return value.String
-	}
-	return nil
-}
-
-func cloneMap(value map[string]any) map[string]any {
-	if value == nil {
-		return nil
-	}
-
-	data, err := json.Marshal(value)
-	if err != nil {
-		return value
-	}
-	var cloned map[string]any
-	if err := json.Unmarshal(data, &cloned); err != nil {
-		return value
-	}
-	return cloned
 }
 
 func (r *Runner) logWorkerEvent(issue connector.Issue, event string, attrs ...any) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -100,14 +100,6 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 						MaxSkillsInPrompt: 10,
 					},
 				},
-				Codex: config.Codex{
-					ApprovalPolicy: config.StringValue("never"),
-					ThreadSandbox:  "workspace-write",
-					TurnSandboxPolicy: map[string]any{
-						"type":          "workspaceWrite",
-						"networkAccess": true,
-					},
-				},
 			},
 			Prompt: "Work on {{ issue.identifier }} attempt {{ attempt }}",
 		},
@@ -279,7 +271,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 }
 
-func TestRunnerRunAddsGitMetadataWritableRootsForManagedWorkspace(t *testing.T) {
+func TestRunnerRunAddsGitMetadataExtraRootsForManagedWorkspace(t *testing.T) {
 	t.Parallel()
 
 	source := initRunnerSourceRepo(t)
@@ -296,15 +288,7 @@ func TestRunnerRunAddsGitMetadataWritableRootsForManagedWorkspace(t *testing.T) 
 	agentBackend := &committingAgentBackend{}
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
-			Config: config.Config{
-				Codex: config.Codex{
-					ThreadSandbox: "workspace-write",
-					TurnSandboxPolicy: map[string]any{
-						"type":          "workspaceWrite",
-						"networkAccess": true,
-					},
-				},
-			},
+			Config: config.Config{},
 			Prompt: "Work on {{ issue.identifier }}",
 		},
 		Workspace:    workspaceBackend,
@@ -333,38 +317,14 @@ func TestRunnerRunAddsGitMetadataWritableRootsForManagedWorkspace(t *testing.T) 
 	if err != nil {
 		t.Fatalf("GitMetadataWritableRoots() error = %v", err)
 	}
-	gotRoots := sandboxPolicyWritableRoots(t, agentBackend.request.TurnSandboxPolicy)
+	gotRoots := agentBackend.request.ExtraWritableRoots
 	for _, want := range wantRoots {
 		if !containsRunnerString(gotRoots, want) {
-			t.Fatalf("sandbox writableRoots = %#v, missing %q", gotRoots, want)
+			t.Fatalf("extra roots = %#v, missing %q", gotRoots, want)
 		}
-	}
-	policy := sandboxPolicyMapForTest(t, agentBackend.request.TurnSandboxPolicy)
-	if policy["networkAccess"] != true {
-		t.Fatalf("sandboxPolicy.networkAccess = %#v, want true", policy["networkAccess"])
 	}
 	if got := strings.TrimSpace(runRunnerGit(t, agentBackend.request.Workspace, "log", "-1", "--pretty=%s")); got != "agent commit" {
 		t.Fatalf("latest commit subject = %q, want agent commit", got)
-	}
-}
-
-func TestWorkspaceWriteSandboxPolicyMapSkipsExplicitNonWorkspacePolicy(t *testing.T) {
-	t.Parallel()
-
-	policy := map[string]any{
-		"type":          "dangerFullAccess",
-		"networkAccess": true,
-	}
-
-	got, ok := workspaceWriteSandboxPolicyMap("workspace-write", policy)
-	if ok {
-		t.Fatalf("workspaceWriteSandboxPolicyMap() = %#v, true; want false for explicit non-workspace policy", got)
-	}
-	if policy["type"] != "dangerFullAccess" {
-		t.Fatalf("policy type = %#v, want dangerFullAccess", policy["type"])
-	}
-	if _, ok := policy["writableRoots"]; ok {
-		t.Fatalf("policy writableRoots = %#v, want absent", policy["writableRoots"])
 	}
 }
 
@@ -452,9 +412,7 @@ func TestRunnerPlanModeCapturesOutputAndConstrainsPrompt(t *testing.T) {
 	}
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
-			Config: config.Config{
-				Codex: config.Codex{ThreadSandbox: "workspace-write"},
-			},
+			Config: config.Config{},
 			Prompt: "Implement {{ issue.identifier }}",
 		},
 		Workspace:    workspaceBackend,
@@ -637,9 +595,7 @@ func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
 	codexClient := &fakeCodexClient{}
 	runner, err := NewRunner(Dependencies{
 		Workflow: config.Workflow{
-			Config: config.Config{
-				Codex: config.Codex{ThreadSandbox: "workspace-write"},
-			},
+			Config: config.Config{},
 			Prompt: "initial {{ issue.identifier }}",
 		},
 		Workspace:    workspaceBackend,
@@ -650,9 +606,7 @@ func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
 	}
 
 	runner.UpdateWorkflow(config.Workflow{
-		Config: config.Config{
-			Codex: config.Codex{ThreadSandbox: "danger-full-access"},
-		},
+		Config: config.Config{},
 		Prompt: "reloaded {{ issue.identifier }}",
 	})
 
@@ -669,9 +623,6 @@ func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
 
 	if !strings.Contains(codexClient.request.Prompt, "reloaded digitaldrywood/detent#41") {
 		t.Fatalf("codex prompt = %q, want reloaded workflow prompt", codexClient.request.Prompt)
-	}
-	if codexClient.request.ThreadSandbox != "danger-full-access" {
-		t.Fatalf("ThreadSandbox = %q, want danger-full-access", codexClient.request.ThreadSandbox)
 	}
 }
 
@@ -1063,39 +1014,6 @@ func runRunnerGit(t *testing.T, dir string, args ...string) string {
 		t.Fatalf("git %s failed: %v\n%s", strings.Join(cmd.Args[1:], " "), err, output)
 	}
 	return string(output)
-}
-
-func sandboxPolicyWritableRoots(t *testing.T, policy any) []string {
-	t.Helper()
-
-	policyMap := sandboxPolicyMapForTest(t, policy)
-	values, ok := policyMap["writableRoots"].([]string)
-	if ok {
-		return values
-	}
-	rawValues, ok := policyMap["writableRoots"].([]any)
-	if !ok {
-		t.Fatalf("sandboxPolicy.writableRoots = %#v, want string list", policyMap["writableRoots"])
-	}
-	roots := make([]string, 0, len(rawValues))
-	for _, raw := range rawValues {
-		root, ok := raw.(string)
-		if !ok {
-			t.Fatalf("sandboxPolicy.writableRoots item = %#v, want string", raw)
-		}
-		roots = append(roots, root)
-	}
-	return roots
-}
-
-func sandboxPolicyMapForTest(t *testing.T, policy any) map[string]any {
-	t.Helper()
-
-	policyMap, ok := policy.(map[string]any)
-	if !ok {
-		t.Fatalf("TurnSandboxPolicy = %T, want map[string]any", policy)
-	}
-	return policyMap
 }
 
 func containsRunnerString(values []string, want string) bool {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -41,14 +41,10 @@ type AgentBackend interface {
 }
 
 type AgentTurnRequest struct {
-	Workspace         string
-	Prompt            string
-	ApprovalPolicy    any
-	ThreadSandbox     string
-	TurnSandboxPolicy any
-	Model             string
-	ModelProvider     string
-	ServiceTier       string
+	Workspace          string
+	Prompt             string
+	Model              string
+	ExtraWritableRoots []string
 }
 
 type AgentTurnResult struct {


### PR DESCRIPTION
## Summary

- Shrink `runner.AgentTurnRequest` to backend-neutral fields and pass git metadata roots as `ExtraWritableRoots`.
- Move Codex sandbox-policy merge helpers and tests into `internal/codex`.
- Store Codex approval/sandbox options on the Codex backend at construction time.

Fixes #820

## Test Plan

- [x] `go test ./internal/codex ./internal/runner ./internal/cli`
- [x] `make check`