### PR TITLE
fix(workspace): confine filesystem writes

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -56,6 +56,9 @@ linters:
       confidence: medium
       excludes:
         - G115
+        # Keep G304 excluded until read-only workspace paths such as
+        # internal/workspace/diffstat.go are migrated or separately justified.
+        # Issue #825 scopes os.Root enforcement to write/mutate paths.
         - G304
         - G306
         - G301

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -548,11 +548,13 @@ func assertLocalTransportClosed(t *testing.T, transport *localTransport, scenari
 
 	if transport == nil {
 		t.Fatalf("%s: captured transport is nil", scenario)
+		return
 	}
 	assertChannelClosed(t, transport.readDone, scenario, "readLoop")
 	assertChannelClosed(t, transport.done, scenario, "wait")
 	if transport.cmd == nil {
 		t.Fatalf("%s: command is nil, want reaped process", scenario)
+		return
 	}
 	if transport.cmd.ProcessState == nil {
 		t.Fatalf("%s: ProcessState is nil, want reaped process", scenario)

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1741,6 +1741,7 @@ func TestRequestRefreshPublishesManualOutcome(t *testing.T) {
 	manual := state.Snapshot(time.Now()).Refresh.Manual
 	if manual == nil {
 		t.Fatal("snapshot Refresh.Manual = nil")
+		return
 	}
 	if manual.RequestedAt == nil || !manual.RequestedAt.Equal(refresh.RequestedAt) {
 		t.Fatalf("Manual.RequestedAt = %v, want %v", manual.RequestedAt, refresh.RequestedAt)
@@ -1804,6 +1805,7 @@ func TestRequestRefreshPublishesFailureWhileDegradedPersists(t *testing.T) {
 	manual := state.Snapshot(time.Now()).Refresh.Manual
 	if manual == nil {
 		t.Fatal("snapshot Refresh.Manual = nil")
+		return
 	}
 	if manual.LastError == "" || !strings.Contains(manual.LastError, "status 504") {
 		t.Fatalf("Manual.LastError = %q, want status 504", manual.LastError)

--- a/internal/workspace/filesystem.go
+++ b/internal/workspace/filesystem.go
@@ -78,6 +78,11 @@ func (f *Filesystem) Create(ctx context.Context, issue Issue) (Info, error) {
 	if err != nil {
 		return Info{}, err
 	}
+	root, err := os.OpenRoot(f.root)
+	if err != nil {
+		return Info{}, fmt.Errorf("open filesystem workspace root: %w", err)
+	}
+	defer f.closeRoot("workspace", root)
 	exists, isDir, err := pathExists(info.Path)
 	if err != nil {
 		return Info{}, err
@@ -87,27 +92,31 @@ func (f *Filesystem) Create(ctx context.Context, issue Issue) (Info, error) {
 	}
 	created := false
 	if !exists {
-		if err := os.MkdirAll(info.Path, 0o700); err != nil {
+		if err := root.MkdirAll(info.Key, 0o700); err != nil {
 			return Info{}, fmt.Errorf("create filesystem workspace: %w", err)
 		}
 		created = true
 	}
-	if err := os.MkdirAll(filepath.Join(info.Path, "artifacts"), 0o700); err != nil {
+	if err := root.MkdirAll(filepath.Join(info.Key, "artifacts"), 0o700); err != nil {
 		return Info{}, fmt.Errorf("create artifact directory: %w", err)
 	}
 	if f.outputRoot != "" {
-		outputPath, err := validateWorkspacePath(f.outputRoot, filepath.Join(f.outputRoot, info.Key))
-		if err != nil {
+		if _, err := validateWorkspacePath(f.outputRoot, filepath.Join(f.outputRoot, info.Key)); err != nil {
 			return Info{}, err
 		}
-		if err := os.MkdirAll(outputPath, 0o700); err != nil {
+		outputRoot, err := os.OpenRoot(f.outputRoot)
+		if err != nil {
+			return Info{}, fmt.Errorf("open filesystem output root: %w", err)
+		}
+		defer f.closeRoot("output", outputRoot)
+		if err := outputRoot.MkdirAll(info.Key, 0o700); err != nil {
 			return Info{}, fmt.Errorf("create output workspace: %w", err)
 		}
 	}
 	info.Created = created
 	if created {
 		if err := f.runHook(ctx, "after_create", f.hooks.AfterCreate, info, issue); err != nil {
-			if cleanupErr := os.RemoveAll(info.Path); cleanupErr != nil {
+			if cleanupErr := root.RemoveAll(info.Key); cleanupErr != nil {
 				f.logger.Warn("failed to clean filesystem workspace after after_create hook error", slog.String("path", info.Path), slog.Any("error", cleanupErr))
 			}
 			return Info{}, err
@@ -126,6 +135,11 @@ func (f *Filesystem) CleanupIssue(ctx context.Context, issue Issue) (CleanupResu
 	if err != nil {
 		return CleanupResult{}, err
 	}
+	root, err := os.OpenRoot(f.root)
+	if err != nil {
+		return CleanupResult{}, fmt.Errorf("open filesystem workspace root: %w", err)
+	}
+	defer f.closeRoot("workspace", root)
 	result := CleanupResult{}
 	exists, _, err := pathExists(info.Path)
 	if err != nil {
@@ -138,7 +152,7 @@ func (f *Filesystem) CleanupIssue(ctx context.Context, issue Issue) (CleanupResu
 	if err := f.runHook(ctx, "before_remove", f.hooks.BeforeRemove, info, issue); err != nil {
 		f.logger.Warn("filesystem workspace before_remove hook failed", slog.String("path", info.Path), slog.Any("error", err))
 	}
-	if err := os.RemoveAll(info.Path); err != nil {
+	if err := root.RemoveAll(info.Key); err != nil {
 		return CleanupResult{}, fmt.Errorf("remove filesystem workspace: %w", err)
 	}
 	result.Worktrees = 1
@@ -296,11 +310,17 @@ func (f *Filesystem) runHook(ctx context.Context, name string, command string, i
 }
 
 func (f *Filesystem) writeHookLog(name string, command string, info Info, exitCode int, err error, output []byte) (string, error) {
-	dir := filepath.Join(f.root, ".detent", "hook-logs", SafeKey(info.Key))
-	if err := os.MkdirAll(dir, 0o700); err != nil {
+	root, rootErr := os.OpenRoot(f.root)
+	if rootErr != nil {
+		return "", fmt.Errorf("open filesystem workspace root: %w", rootErr)
+	}
+	defer f.closeRoot("workspace", root)
+	dir := filepath.Join(".detent", "hook-logs", SafeKey(info.Key))
+	if err := root.MkdirAll(dir, 0o700); err != nil {
 		return "", err
 	}
-	path := filepath.Join(dir, hookLogFileName(name, time.Now().UTC(), os.Getpid()))
+	relPath := filepath.Join(dir, hookLogFileName(name, time.Now().UTC(), os.Getpid()))
+	path := filepath.Join(f.root, relPath)
 	var buf bytes.Buffer
 	fmt.Fprintf(&buf, "hook: %s\n", name)
 	fmt.Fprintf(&buf, "command: %s\n", command)
@@ -314,8 +334,14 @@ func (f *Filesystem) writeHookLog(name string, command string, info Info, exitCo
 	if len(output) > 0 && output[len(output)-1] != '\n' {
 		fmt.Fprint(&buf, "\n")
 	}
-	if err := os.WriteFile(path, buf.Bytes(), 0o600); err != nil {
+	if err := root.WriteFile(relPath, buf.Bytes(), 0o600); err != nil {
 		return "", err
 	}
 	return path, nil
+}
+
+func (f *Filesystem) closeRoot(name string, root *os.Root) {
+	if err := root.Close(); err != nil {
+		f.logger.Warn("filesystem root close failed", slog.String("root", name), slog.Any("error", err))
+	}
 }

--- a/internal/workspace/filesystem_test.go
+++ b/internal/workspace/filesystem_test.go
@@ -61,3 +61,35 @@ func TestFilesystemWorkspaceCreatesArtifactWorkspaceAndOutputRoot(t *testing.T) 
 		t.Fatalf("workspace still exists or unexpected stat error: %v", err)
 	}
 }
+
+func TestFilesystemCreateRejectsArtifactSymlinkEscape(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	testRoot := t.TempDir()
+	root := filepath.Join(testRoot, "workspaces")
+	workspacePath := filepath.Join(root, "DD-SYM")
+	outside := filepath.Join(testRoot, "outside")
+	if err := os.MkdirAll(workspacePath, 0o700); err != nil {
+		t.Fatalf("mkdir workspace: %v", err)
+	}
+	if err := os.MkdirAll(outside, 0o700); err != nil {
+		t.Fatalf("mkdir outside: %v", err)
+	}
+	if err := os.Symlink(outside, filepath.Join(workspacePath, "artifacts")); err != nil {
+		t.Fatalf("create symlink: %v", err)
+	}
+
+	backend, err := NewFilesystem(FilesystemOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewFilesystem() error = %v", err)
+	}
+
+	_, err = backend.Create(context.Background(), Issue{Identifier: "DD-SYM"})
+	if err == nil {
+		t.Fatal("Create() error = nil, want symlink escape rejection")
+	}
+	if _, err := os.Lstat(filepath.Join(workspacePath, "artifacts")); err != nil {
+		t.Fatalf("symlink stat error = %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- Confine filesystem workspace create, cleanup, output-root, and hook-log writes through `os.Root`.
- Add a regression test for an `artifacts` symlink inside a filesystem workspace that points outside the workspace root.
- Document why gosec `G304` remains globally excluded for now: unrelated read-only workspace paths still trip it.
- Add explicit test nil-guard returns needed for CI staticcheck on the rebased merge ref.

Fixes #825

## Test Plan
- `go test ./internal/workspace -run TestFilesystemCreateRejectsArtifactSymlinkEscape -count=1`
- `go test ./internal/workspace`
- `golangci-lint run ./internal/workspace`
- `go test ./internal/codex ./internal/orchestrator`
- `golangci-lint run --timeout=5m ./internal/codex ./internal/orchestrator`
- `make check`