### PR TITLE
chore(lint): enable additional linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,18 +9,24 @@ linters:
   default: none
   enable:
     - bodyclose
+    - containedctx
     - contextcheck
     - errcheck
     - errorlint
+    - fatcontext
     - gosec
     - govet
     - ineffassign
+    - intrange
     - misspell
+    - nilnil
     - noctx
+    - perfsprint
     - sqlclosecheck
     - staticcheck
     - unconvert
     - unused
+    - wastedassign
 
   settings:
     errcheck:

--- a/install_test.go
+++ b/install_test.go
@@ -8,6 +8,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -549,7 +550,7 @@ func detentArchive(t *testing.T, content string) []byte {
 
 func archiveChecksum(content []byte) string {
 	sum := sha256.Sum256(content)
-	return fmt.Sprintf("%x", sum)
+	return hex.EncodeToString(sum[:])
 }
 
 func newInstallReleaseServer(tag string, archiveName string, archive []byte, checksum string) *httptest.Server {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -755,7 +755,7 @@ func globalFairShareHalfLife(settings map[string]any) (time.Duration, error) {
 	case time.Duration:
 		return halfLife, nil
 	default:
-		return 0, fmt.Errorf("global.fair_share.half_life: must be a duration string")
+		return 0, errors.New("global.fair_share.half_life: must be a duration string")
 	}
 }
 

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -910,7 +910,7 @@ func newTerminalDashboardProgramProbe() *terminalDashboardProgramProbe {
 func (p *terminalDashboardProgramProbe) Run() (tea.Model, error) {
 	close(p.started)
 	<-p.killed
-	return nil, nil
+	return nil, nil //nolint:nilnil // Test probe exits without yielding another Bubble Tea model.
 }
 
 func (p *terminalDashboardProgramProbe) Kill() {

--- a/internal/cli/dev_runtime_capture_browser.go
+++ b/internal/cli/dev_runtime_capture_browser.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -125,7 +126,7 @@ func demoCaptureBrowserPath(explicit string) (string, error) {
 			return path, nil
 		}
 	}
-	return "", fmt.Errorf("chrome or chromium was not found; pass --browser or set DETENT_CAPTURE_BROWSER")
+	return "", errors.New("chrome or chromium was not found; pass --browser or set DETENT_CAPTURE_BROWSER")
 }
 
 func demoCaptureBrowserNames() []string {
@@ -439,7 +440,7 @@ func (p *demoCapturePage) Eval(ctx context.Context, expression string, out any) 
 
 func (p *demoCapturePage) Call(ctx context.Context, method string, params any, out any) error {
 	if p == nil || p.client == nil {
-		return fmt.Errorf("browser page is closed")
+		return errors.New("browser page is closed")
 	}
 	if err := p.client.Call(ctx, method, params, out); err != nil {
 		return fmt.Errorf("CDP %s: %w", method, err)

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -3133,7 +3133,7 @@ func checkDoctorGitHub(ctx context.Context, cfg *globalconfig.Config, token Runt
 		return doctorCheck{
 			Name:   "GitHub token",
 			Status: doctorOK,
-			Detail: fmt.Sprintf("%s did not expose classic OAuth scopes; treating as fine-grained or resource-scoped token and relying on operation checks", source),
+			Detail: source + " did not expose classic OAuth scopes; treating as fine-grained or resource-scoped token and relying on operation checks",
 		}
 	}
 	requiredScopes := doctorRequiredGitHubScopes(ctx, cfg, deps)

--- a/internal/cli/onboarding.go
+++ b/internal/cli/onboarding.go
@@ -14,6 +14,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -1027,7 +1028,7 @@ func onboardingDetentFreshnessPrettyLines(evidence onboardingDetentFreshnessEvid
 	lines := []string{
 		"",
 		"Detent source freshness:",
-		"source_checked: " + fmt.Sprint(evidence.SourceChecked),
+		"source_checked: " + strconv.FormatBool(evidence.SourceChecked),
 	}
 	if evidence.SourceRoot != "" {
 		lines = append(lines, "source_root: "+evidence.SourceRoot)
@@ -1039,9 +1040,9 @@ func onboardingDetentFreshnessPrettyLines(evidence onboardingDetentFreshnessEvid
 		lines = append(lines, "canonical_main: "+evidence.CanonicalMain)
 	}
 	lines = append(lines,
-		"source_matches_canonical: "+fmt.Sprint(evidence.SourceMatchesCanonical),
+		"source_matches_canonical: "+strconv.FormatBool(evidence.SourceMatchesCanonical),
 		"source_status: "+evidence.SourceStatus,
-		"binary_checked: "+fmt.Sprint(evidence.BinaryChecked),
+		"binary_checked: "+strconv.FormatBool(evidence.BinaryChecked),
 	)
 	if evidence.BinaryVersion != "" {
 		lines = append(lines, "binary_version: "+evidence.BinaryVersion)
@@ -1053,9 +1054,9 @@ func onboardingDetentFreshnessPrettyLines(evidence onboardingDetentFreshnessEvid
 		lines = append(lines, "binary_build_date: "+evidence.BinaryBuildDate)
 	}
 	lines = append(lines,
-		"binary_matches_canonical: "+fmt.Sprint(evidence.BinaryMatchesCanonical),
+		"binary_matches_canonical: "+strconv.FormatBool(evidence.BinaryMatchesCanonical),
 		"binary_status: "+evidence.BinaryStatus,
-		"phase2_recommendations_blocked: "+fmt.Sprint(evidence.Phase2RecommendationsBlocked),
+		"phase2_recommendations_blocked: "+strconv.FormatBool(evidence.Phase2RecommendationsBlocked),
 	)
 	if evidence.Phase2RecommendationsBlocked {
 		lines = append(lines, "phase2_stop: update/reinstall Detent or read docs from GitHub at the canonical head before Phase 2 recommendations.")

--- a/internal/cli/onboarding_test.go
+++ b/internal/cli/onboarding_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -1134,7 +1135,7 @@ func TestOnboardingDraftAnswersCommandBlocksFailedRemoteDetentDocsWithoutLocalCh
 					return "", fmt.Errorf("unexpected gh args: %s", strings.Join(args, " "))
 				}
 				ghRefRequested = true
-				return "", fmt.Errorf("gh auth failed")
+				return "", errors.New("gh auth failed")
 			}
 			return onboardingTestCommandRunner(detentVersionJSON("local"))(ctx, name, args...)
 		}),

--- a/internal/cli/output.go
+++ b/internal/cli/output.go
@@ -103,11 +103,10 @@ func OutputForCommand(cmd *cobra.Command) (CommandOutput, error) {
 
 func ResolveCommandOutputFormat(cmd *cobra.Command, lookupEnv func(string) string, stdoutTTY bool) (OutputFormat, error) {
 	value, set := outputFormatFlagValue(cmd)
-	envValue := ""
 	if lookupEnv == nil {
 		lookupEnv = os.Getenv
 	}
-	envValue = lookupEnv(outputFormatEnv)
+	envValue := lookupEnv(outputFormatEnv)
 	return ResolveOutputFormat(value, set, envValue, stdoutTTY)
 }
 
@@ -200,7 +199,7 @@ func parseOutputFormat(value string, source string) (OutputFormat, error) {
 	case OutputFormatJSON:
 		return OutputFormatJSON, nil
 	default:
-		detail := fmt.Sprintf("%s must be pretty or json", source)
+		detail := source + " must be pretty or json"
 		return "", NewClassifiedError(
 			WrapValidation(fmt.Errorf("%w: %s", ErrInvalidOutputFormat, detail)),
 			errorCodeValidation,

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os/exec"
@@ -165,7 +166,7 @@ func buildAgentBackend(backend workflowconfig.AgentBackend) (runnerpkg.AgentBack
 func buildCodexAgentBackend(cfg workflowconfig.Codex) (runnerpkg.AgentBackend, error) {
 	command := strings.TrimSpace(cfg.Command)
 	if command == "" {
-		return nil, fmt.Errorf("codex command is required")
+		return nil, errors.New("codex command is required")
 	}
 
 	factory, err := codex.NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -451,7 +451,7 @@ func handleServerRequest(ctx context.Context, transport Transport, msg Message) 
 	} else {
 		response.Error = &RPCError{
 			Code:    methodNotFoundCode,
-			Message: fmt.Sprintf("unsupported server request: %s", msg.Method),
+			Message: "unsupported server request: " + msg.Method,
 		}
 	}
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1388,7 +1388,7 @@ func decodeAnyNode(node *yaml.Node) (any, error) {
 func decodeScalarNode(node *yaml.Node) (any, error) {
 	switch node.Tag {
 	case "!!null":
-		return nil, nil
+		return nil, nil //nolint:nilnil // YAML null decodes to a nil scalar value with no error.
 	case "!!bool":
 		return strconv.ParseBool(node.Value)
 	case "!!int":

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -1383,7 +1383,7 @@ func optionalString(value any, field string) (string, error) {
 
 func optionalIntPointer(value any, field string) (*int, error) {
 	if value == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // Absent optional integer is represented as a nil pointer.
 	}
 	number, err := intValue(value, field)
 	if err != nil {

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -2246,7 +2246,7 @@ func (c *Connector) MergePullRequest(ctx context.Context, repository string, num
 func (c *Connector) RerunPullRequestChecks(ctx context.Context, issue connector.Issue, checks []connector.PullRequestCheck) error {
 	repo, _, ok := hydratedPullRequestRef(issue)
 	if !ok {
-		return fmt.Errorf("rerun github pull request checks: missing pull request repository")
+		return errors.New("rerun github pull request checks: missing pull request repository")
 	}
 	seenRuns := map[int64]struct{}{}
 	seenChecks := map[int64]struct{}{}

--- a/internal/connector/github/provision.go
+++ b/internal/connector/github/provision.go
@@ -247,7 +247,7 @@ func decodeProjectSingleSelectField(fieldName string, field *projectOptionsField
 
 func decodeOptionalProjectSingleSelectField(fieldName string, field *projectOptionsFieldResponse) (*projectSingleSelectField, error) {
 	if field == nil {
-		return nil, nil
+		return nil, nil //nolint:nilnil // Missing optional project field is represented as a nil field.
 	}
 	decoded, err := decodeProjectSingleSelectField(fieldName, field)
 	if err != nil {

--- a/internal/connector/github/transport_test.go
+++ b/internal/connector/github/transport_test.go
@@ -54,7 +54,7 @@ func TestPooledHTTPClientReusesSequentialConnections(t *testing.T) {
 
 			var freshConns int
 			var reusedConns int
-			for i := 0; i < tt.requests; i++ {
+			for i := range tt.requests {
 				trace := &httptrace.ClientTrace{
 					GotConn: func(info httptrace.GotConnInfo) {
 						if info.Reused {

--- a/internal/devruntime/runtime.go
+++ b/internal/devruntime/runtime.go
@@ -333,7 +333,7 @@ func runtimeIssues(path string, demo string) ([]connector.Issue, string, error) 
 		return nil, "", fmt.Errorf("decode isolated runtime fixture: %w", err)
 	}
 	if len(fixture.Issues) == 0 {
-		return nil, "", fmt.Errorf("decode isolated runtime fixture: issues must not be empty")
+		return nil, "", errors.New("decode isolated runtime fixture: issues must not be empty")
 	}
 	absolute, err := filepath.Abs(path)
 	if err != nil {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log/slog"
 	"slices"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -151,7 +152,7 @@ type drainRequest struct {
 }
 
 type forceRequest struct {
-	ctx   context.Context
+	ctx   context.Context //nolint:containedctx // ForceQuit carries caller cancellation through the event loop.
 	at    time.Time
 	reply chan error
 }
@@ -2335,7 +2336,7 @@ func mergeWorkerRetryExhaustedComment(issue connector.Issue, attempt int, err er
 	b.WriteString("\n\n- reason: runner_failed_retry_exhausted")
 	if attempt > 0 {
 		b.WriteString("\n- attempt: ")
-		b.WriteString(fmt.Sprintf("%d", attempt))
+		b.WriteString(strconv.Itoa(attempt))
 	}
 	if errText := errorString(err); errText != "" {
 		b.WriteString("\n- error: ")

--- a/internal/orchestrator/transient_ci_retry.go
+++ b/internal/orchestrator/transient_ci_retry.go
@@ -2,7 +2,7 @@ package orchestrator
 
 import (
 	"context"
-	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -98,12 +98,12 @@ func transientCheckRetryKey(issue connector.Issue, check connector.PullRequestCh
 	if issueID == "" || headSHA == "" {
 		return ""
 	}
-	identity := ""
+	var identity string
 	switch {
 	case check.WorkflowRunID > 0:
-		identity = fmt.Sprintf("run:%d", check.WorkflowRunID)
+		identity = "run:" + strconv.FormatInt(check.WorkflowRunID, 10)
 	case check.ID > 0:
-		identity = fmt.Sprintf("check:%d", check.ID)
+		identity = "check:" + strconv.FormatInt(check.ID, 10)
 	default:
 		identity = "name:" + strings.ToLower(strings.TrimSpace(check.Name))
 	}
@@ -134,7 +134,7 @@ func transientCIRetryComment(issue connector.Issue, checks []connector.PullReque
 		b.WriteString(strings.TrimSpace(reason))
 	}
 	b.WriteString("\n\nRerun limit: ")
-	b.WriteString(fmt.Sprintf("%d", limit))
+	b.WriteString(strconv.Itoa(limit))
 	b.WriteString("\nChecks:")
 	for _, check := range checks {
 		b.WriteString("\n- ")
@@ -144,9 +144,9 @@ func transientCIRetryComment(issue connector.Issue, checks []connector.PullReque
 		}
 		b.WriteString(name)
 		if check.WorkflowRunID > 0 {
-			b.WriteString(fmt.Sprintf(" (workflow run %d)", check.WorkflowRunID))
+			b.WriteString(" (workflow run " + strconv.FormatInt(check.WorkflowRunID, 10) + ")")
 		} else if check.ID > 0 {
-			b.WriteString(fmt.Sprintf(" (check run %d)", check.ID))
+			b.WriteString(" (check run " + strconv.FormatInt(check.ID, 10) + ")")
 		}
 		if url := strings.TrimSpace(check.DetailsURL); url != "" {
 			b.WriteString(" ")

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -87,7 +87,7 @@ func TestManagerStartRejectsNilProjectFactoryResult(t *testing.T) {
 		Projects: []globalconfig.Project{{ID: "alpha", Weight: 1}},
 	}, project.ManagerDependencies{
 		ProjectFactory: func(globalconfig.Project) (*project.Project, error) {
-			return nil, nil
+			return nil, nil //nolint:nilnil // Test verifies manager rejects a nil project without a factory error.
 		},
 	})
 	if err != nil {
@@ -914,7 +914,7 @@ func TestManagerReconcileKeepsRegistryWhenNewProjectFactoryReturnsNil(t *testing
 		Events: events,
 		ProjectFactory: func(cfg globalconfig.Project) (*project.Project, error) {
 			if cfg.ID == "bravo" {
-				return nil, nil
+				return nil, nil //nolint:nilnil // Test verifies reconcile keeps the registry when a new project factory returns nil.
 			}
 			return newManagerTestProject(t, cfg, events)
 		},

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -748,7 +748,7 @@ func TestNewRejectsInvalidProjectConfig(t *testing.T) {
 			},
 			deps: project.Dependencies{
 				ConnectorFactory: func(workflowconfig.Config) (connector.Connector, error) {
-					return nil, nil
+					return nil, nil //nolint:nilnil // Test verifies project construction rejects a nil connector without a factory error.
 				},
 			},
 			want: project.ErrMissingConnector,

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"math"
 	"sort"
+	"strconv"
 	"strings"
 	"time"
 
@@ -761,7 +762,7 @@ func formatCount(value int64) string {
 		value = -value
 	}
 
-	text := fmt.Sprintf("%d", value)
+	text := strconv.FormatInt(value, 10)
 	for i := len(text) - 3; i > 0; i -= 3 {
 		text = text[:i] + "," + text[i:]
 	}

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -9,6 +9,7 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -321,7 +322,7 @@ type Replacement struct {
 	Binary                []byte
 	Mode                  os.FileMode
 	GOOS                  string
-	Context               context.Context
+	Context               context.Context //nolint:containedctx // Replacement carries AfterReplace cancellation across Windows handoff.
 	StartProcess          ProcessStarter
 	Verify                BinaryVerifier
 	Sign                  BinarySigner
@@ -709,7 +710,7 @@ func VerifyChecksum(checksums []byte, assetName string, archive []byte) error {
 		return fmt.Errorf("checksum for %s not found", assetName)
 	}
 	sum := sha256.Sum256(archive)
-	actual := fmt.Sprintf("%x", sum)
+	actual := hex.EncodeToString(sum[:])
 	if !strings.EqualFold(actual, expected) {
 		return fmt.Errorf("checksum mismatch for %s: expected %s, got %s", assetName, expected, actual)
 	}

--- a/internal/web/chart/chart.go
+++ b/internal/web/chart/chart.go
@@ -183,7 +183,7 @@ func SmoothLinePath(points []ScaledPoint) string {
 	path.WriteString(FormatCoord(points[0].X))
 	path.WriteByte(' ')
 	path.WriteString(FormatCoord(points[0].Y))
-	for i := 0; i < len(points)-1; i++ {
+	for i := range len(points) - 1 {
 		p0 := boundedPoint(points, i-1)
 		p1 := boundedPoint(points, i)
 		p2 := boundedPoint(points, i+1)

--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -1036,7 +1036,7 @@ func demoLongContentSnapshot() telemetry.Snapshot {
 
 func demoDenseSnapshot() telemetry.Snapshot {
 	snapshot := demoHealthySnapshot()
-	for i := 0; i < 12; i++ {
+	for i := range 12 {
 		state := []string{"Backlog", "Todo", "In Progress", "Blocked", "Human Review", "Rework"}[i%6]
 		snapshot.BoardIssues = append(snapshot.BoardIssues, demoIssue(demoPrimaryProjectID, fmt.Sprintf("demo-dense-%02d", i), fmt.Sprintf("digitaldrywood/detent-core#54%02d", i), fmt.Sprintf("Dense lane card %02d exercises compact chips and overflow", i+1), state, i+1))
 	}

--- a/internal/web/ui/utils/templui.go
+++ b/internal/web/ui/utils/templui.go
@@ -4,12 +4,12 @@ package utils
 import (
 	"context"
 	"crypto/rand"
-	"fmt"
 	"io"
 	"io/fs"
 	"maps"
 	"net/http"
 	"path"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -63,12 +63,12 @@ func MergeAttributes(attrs ...templ.Attributes) templ.Attributes {
 // RandomID generates a random ID string.
 // Example: RandomID() → "id-1a2b3c"
 func RandomID() string {
-	return fmt.Sprintf("id-%s", rand.Text())
+	return "id-" + rand.Text()
 }
 
 // ScriptVersion is a timestamp generated at app start for cache busting.
 // Used in component script tags to append ?v=<timestamp> to script URLs.
-var ScriptVersion = fmt.Sprintf("%d", time.Now().Unix())
+var ScriptVersion = strconv.FormatInt(time.Now().Unix(), 10)
 
 // ScriptURL generates cache-busted script URLs.
 // Override this to use custom cache busting (CDN, content hashing, etc.)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"strconv"
 	"strings"
 	"time"
 
@@ -809,7 +810,7 @@ func hookOutputTail(output string, limit int) string {
 	if len(output) <= limit {
 		return output
 	}
-	return "[truncated to last " + fmt.Sprint(limit/1024) + " KiB]\n" + output[len(output)-limit:]
+	return "[truncated to last " + strconv.Itoa(limit/1024) + " KiB]\n" + output[len(output)-limit:]
 }
 
 func (l *LocalGit) runGit(ctx context.Context, args ...string) (string, error) {


### PR DESCRIPTION
## Summary

- Enable `containedctx`, `fatcontext`, `nilnil`, `wastedassign`, `intrange`, and `perfsprint` in golangci-lint.
- Apply mechanical lint fixes and targeted justified suppressions where nil/context is the existing contract.

Fixes #827

## Test Plan

- [x] `go test . ./internal/cli ./internal/codex ./internal/config ./internal/config/global ./internal/connector/github ./internal/devruntime ./internal/orchestrator ./internal/project ./internal/tui ./internal/update ./internal/web/chart ./internal/web/ui/utils ./internal/workspace`
- [x] `make check`