### PR TITLE
fix(github): clarify default status write context

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -3005,6 +3005,8 @@ func (c *Connector) defaultBlankProjectItemStatuses(ctx context.Context, itemIDs
 func (c *Connector) defaultBlankProjectItemStatusesAsync(parentCtx context.Context, itemIDs []string, statusName string) {
 	baseCtx := context.Background()
 	if parentCtx != nil {
+		// Default status repair is a must-finish write: detach cancellation
+		// while keeping caller values for logs and traces.
 		baseCtx = context.WithoutCancel(parentCtx)
 	}
 	ctx, cancel := context.WithTimeout(baseCtx, defaultProjectItemStatusWriteTimeout)

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -654,6 +654,7 @@ func TestConnectorFetchCandidateIssuesAttachesPullRequestByBranchPrefix(t *testi
 	pr := byID["I_182"].PullRequest
 	if pr == nil {
 		t.Fatal("I_182 PullRequest = nil, want matching open PR")
+		return
 	}
 	if pr.Number != 187 || pr.State != "OPEN" || pr.BranchName != "detent/digitaldrywood_detent_182_followup" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
 		t.Fatalf("I_182 PullRequest = %#v, want PR 187 open followup", pr)
@@ -721,6 +722,7 @@ func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix
 	pr := got[0].PullRequest
 	if pr == nil {
 		t.Fatal("PullRequest = nil, want linked PR")
+		return
 	}
 	if pr.Number != 376 || pr.URL != "https://github.com/corylanou/detent/pull/376" || pr.State != "OPEN" || pr.BranchName != "detent/detent-digitaldrywood_detent_370-e71678a9ca7e" || pr.CIStatus != "pass" || pr.CodexReviewState != "COMMENTED" {
 		t.Fatalf("PullRequest = %#v, want linked PR 376 with hydrated status", pr)
@@ -816,6 +818,7 @@ func TestConnectorFetchCandidateIssuesPaginatesPullRequestStatusRESTEndpoints(t 
 	pr := got[0].PullRequest
 	if pr == nil {
 		t.Fatal("PullRequest = nil, want matching PR")
+		return
 	}
 	if pr.CIStatus != "fail" || pr.CodexReviewState != "P1" {
 		t.Fatalf("PullRequest status = CI %q review %q, want fail/P1", pr.CIStatus, pr.CodexReviewState)
@@ -1004,6 +1007,7 @@ func TestConnectorFetchCandidateIssuesStopsBranchPullRequestHydrationAfterSecond
 		pr := byID[id].PullRequest
 		if pr == nil {
 			t.Fatalf("%s PullRequest = nil, want hydration marker", id)
+			continue
 		}
 		if pr.HydrationUnavailableReason != connector.PullRequestHydrationReasonSecondaryThrottled {
 			t.Fatalf("%s HydrationUnavailableReason = %q, want secondary_throttled", id, pr.HydrationUnavailableReason)
@@ -1301,6 +1305,7 @@ func TestConnectorFetchIssuesByStatesMarksLinkedPullRequestHydrationSecondaryThr
 	pr := got[0].PullRequest
 	if pr == nil {
 		t.Fatal("PullRequest = nil, want retained linked PR shell")
+		return
 	}
 	if pr.Number != 411 {
 		t.Fatalf("PullRequest.Number = %d, want 411", pr.Number)
@@ -1548,6 +1553,7 @@ func TestConnectorFetchIssuesByStatesSurfacesStaleCodexReview(t *testing.T) {
 	pr := got[0].PullRequest
 	if pr == nil {
 		t.Fatal("PullRequest = nil, want linked PR")
+		return
 	}
 	if pr.HeadSHA != "head-current" {
 		t.Fatalf("HeadSHA = %q, want head-current", pr.HeadSHA)
@@ -1922,6 +1928,7 @@ func TestConnectorFetchIssuesByStatesAttachesBlockedPullRequest(t *testing.T) {
 	pr := got[0].PullRequest
 	if pr == nil {
 		t.Fatal("PullRequest = nil, want linked blocked PR")
+		return
 	}
 	if pr.Number != 426 || pr.State != "OPEN" || pr.HeadSHA != "head-current" || pr.MergeableState != "dirty" || pr.CIStatus != "" || pr.CheckRunCount != 0 {
 		t.Fatalf("PullRequest = %#v, want dirty PR with no current-head checks", pr)

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -397,6 +397,77 @@ func TestConnectorFetchCandidateIssuesDoesNotBlockOnBlankProjectStatusDefaulting
 	}
 }
 
+func TestConnectorFetchCandidateIssuesDefaultStatusWriteSurvivesParentCancellation(t *testing.T) {
+	t.Parallel()
+
+	type traceContextKey struct{}
+	traceKey := traceContextKey{}
+	const traceValue = "trace-1"
+	contextValues := make(chan any, 3)
+	releaseDefaultWrite := make(chan struct{})
+	var releaseOnce sync.Once
+	release := func() {
+		releaseOnce.Do(func() {
+			close(releaseDefaultWrite)
+		})
+	}
+	defer release()
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null}]}}}}`,
+		},
+		{
+			release: releaseDefaultWrite,
+			body:    `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_todo","name":"Todo"}]}}}}`,
+		},
+		{
+			body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_blank"}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+		HTTPClient: contextValueCaptureClient{
+			base:   server.Client(),
+			key:    traceKey,
+			values: contextValues,
+		},
+	})
+
+	parentCtx, cancel := context.WithCancel(context.WithValue(context.Background(), traceKey, traceValue))
+	got, err := c.FetchCandidateIssues(parentCtx)
+	if err != nil {
+		t.Fatalf("FetchCandidateIssues() error = %v", err)
+	}
+	if len(got) != 0 {
+		t.Fatalf("FetchCandidateIssues() len = %d, want 0", len(got))
+	}
+
+	requests := waitForGraphQLRequests(t, server, 2)
+	if len(requests) != 2 {
+		t.Fatalf("request count before cancellation = %d, want 2", len(requests))
+	}
+	cancel()
+	release()
+
+	requests = waitForGraphQLRequests(t, server, 3)
+	updateVariables := requestVariables(t, requests[2])
+	if updateVariables["itemId"] != "PVTI_blank" || updateVariables["optionId"] != "OPT_backlog" {
+		t.Fatalf("update variables = %#v, want blank item moved to Backlog", updateVariables)
+	}
+
+	for i := range 3 {
+		select {
+		case got := <-contextValues:
+			if got != traceValue {
+				t.Fatalf("request context value %d = %#v, want %q", i, got, traceValue)
+			}
+		case <-time.After(time.Second):
+			t.Fatalf("request context value %d was not captured", i)
+		}
+	}
+}
+
 func TestConnectorFetchIssuesByStatesIgnoresBlankStatusDefaultWriteFailure(t *testing.T) {
 	t.Parallel()
 
@@ -3129,7 +3200,9 @@ func newGitHubTestConnector(t *testing.T, server *graphqlTestServer, cfg Config)
 
 	cfg.Endpoint = server.URL
 	cfg.APIKey = "token"
-	cfg.HTTPClient = server.Client()
+	if cfg.HTTPClient == nil {
+		cfg.HTTPClient = server.Client()
+	}
 	cfg.GHToken = func(context.Context, string) (string, error) {
 		t.Fatal("gh token fallback should not run")
 		return "", nil
@@ -3139,6 +3212,20 @@ func newGitHubTestConnector(t *testing.T, server *graphqlTestServer, cfg Config)
 		t.Fatalf("NewConnector() error = %v", err)
 	}
 	return c
+}
+
+type contextValueCaptureClient struct {
+	base   HTTPClient
+	key    any
+	values chan<- any
+}
+
+func (c contextValueCaptureClient) Do(req *http.Request) (*http.Response, error) {
+	select {
+	case c.values <- req.Context().Value(c.key):
+	default:
+	}
+	return c.base.Do(req)
 }
 
 func githubIssueIDs(issues []connector.Issue) []string {


### PR DESCRIPTION
## Summary

- Make default blank project status repair explicitly detach caller cancellation with `context.WithoutCancel` while preserving caller context values.
- Add regression coverage proving the async status write survives parent cancellation and still receives context metadata.

Fixes #828

## Test Plan

- [x] `go test ./internal/connector/github -run TestConnectorFetchCandidateIssuesDefaultStatusWriteSurvivesParentCancellation`
- [x] `make check`