### PR TITLE
feat(claudecode): add headless backend

### DIFF
--- a/internal/claudecode/backend.go
+++ b/internal/claudecode/backend.go
@@ -1,0 +1,68 @@
+package claudecode
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+const (
+	defaultMaxScanTokenSize = 10 * 1024 * 1024
+	defaultStderrTailBytes  = 64 * 1024
+)
+
+var (
+	ErrNilCommand     = errors.New("claude command factory returned nil command")
+	ErrMissingResult  = errors.New("claude result event missing")
+	ErrStreamStalled  = errors.New("claude stream stalled")
+	ErrTurnFailed     = errors.New("claude turn failed")
+	ErrUpdateRejected = errors.New("claude update rejected")
+)
+
+type CommandFactory func(context.Context) *exec.Cmd
+
+type Options struct {
+	CommandFactory         CommandFactory
+	PermissionMode         string
+	AllowedTools           []string
+	DisallowedTools        []string
+	IncludePartialMessages bool
+	ExtraArgs              []string
+	TurnTimeout            time.Duration
+	StallTimeout           time.Duration
+	MaxScanTokenSize       int
+	StderrTailBytes        int
+}
+
+type AgentBackend struct {
+	options Options
+}
+
+var _ runner.AgentBackend = (*AgentBackend)(nil)
+
+func NewAgentBackend(options Options) (*AgentBackend, error) {
+	if options.CommandFactory == nil {
+		options.CommandFactory = defaultCommandFactory
+	}
+	if options.MaxScanTokenSize <= 0 {
+		options.MaxScanTokenSize = defaultMaxScanTokenSize
+	}
+	if options.StderrTailBytes <= 0 {
+		options.StderrTailBytes = defaultStderrTailBytes
+	}
+	return &AgentBackend{options: options}, nil
+}
+
+func defaultCommandFactory(ctx context.Context) *exec.Cmd {
+	return exec.CommandContext(contextOrBackground(ctx), "claude")
+}
+
+func contextOrBackground(ctx context.Context) context.Context {
+	if ctx == nil {
+		return context.Background()
+	}
+	return ctx
+}

--- a/internal/claudecode/backend_test.go
+++ b/internal/claudecode/backend_test.go
@@ -1,0 +1,429 @@
+package claudecode
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestAgentBackendRunTurnSuccess(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestBackend(t, Options{
+		CommandFactory: fixtureCommand(t, "success.jsonl", "", 0),
+		StallTimeout:   time.Second,
+	})
+
+	var updates []runner.AgentUpdate
+	result, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "ship it",
+		Model:     "fable",
+	}, appendUpdate(&updates))
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ThreadID != "session-success" || result.TurnID != "session-success" || result.SessionID != "session-success" {
+		t.Fatalf("RunTurn() result = %#v, want session-success IDs", result)
+	}
+
+	wantTypes := []runner.AgentUpdateType{
+		runner.AgentUpdateProcessStarted,
+		runner.AgentUpdateTurnStarted,
+		runner.AgentUpdateMessageDelta,
+		runner.AgentUpdateMessageDelta,
+		runner.AgentUpdateTokenUsage,
+		runner.AgentUpdateTokenUsage,
+		runner.AgentUpdateTurnCompleted,
+	}
+	if got := updateTypes(updates); !reflect.DeepEqual(got, wantTypes) {
+		t.Fatalf("update types = %#v, want %#v", got, wantTypes)
+	}
+	firstDelta := requireUpdate(t, updates, 2)
+	secondDelta := requireUpdate(t, updates, 3)
+	if firstDelta.Delta != "hello " || secondDelta.Delta != "world" {
+		t.Fatalf("message deltas = %q %q, want hello/world", firstDelta.Delta, secondDelta.Delta)
+	}
+	if got := requireUpdate(t, updates, 4).Tokens; got.InputTokens != 10 || got.CachedInputTokens != 5 || got.OutputTokens != 4 || got.TotalTokens != 14 {
+		t.Fatalf("message token usage = %#v, want 10 input, 5 cached, 4 output, 14 total", got)
+	}
+	if got := requireUpdate(t, updates, 5).Tokens; got.InputTokens != 12 || got.CachedInputTokens != 6 || got.OutputTokens != 6 || got.TotalTokens != 18 {
+		t.Fatalf("final token usage = %#v, want 12 input, 6 cached, 6 output, 18 total", got)
+	}
+	if got := requireUpdate(t, updates, 6); got.Status != runner.FinalStateCompleted {
+		t.Fatalf("TurnCompleted status = %q, want completed", got.Status)
+	}
+}
+
+func TestAgentBackendRunTurnErrorResult(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestBackend(t, Options{
+		CommandFactory: fixtureCommand(t, "error_result.jsonl", "claude stderr tail", 0),
+	})
+
+	var updates []runner.AgentUpdate
+	result, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "hit max turns",
+		Model:     "fable",
+	}, appendUpdate(&updates))
+	if !errors.Is(err, ErrTurnFailed) {
+		t.Fatalf("RunTurn() error = %v, want ErrTurnFailed", err)
+	}
+	for _, want := range []string{"error_max_turns", "claude stderr tail"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("RunTurn() error = %q, want %q", err.Error(), want)
+		}
+	}
+	if result.SessionID != "session-error" {
+		t.Fatalf("RunTurn() result SessionID = %q, want session-error", result.SessionID)
+	}
+	if got := requireLastUpdate(t, updates); got.Type != runner.AgentUpdateTurnCompleted || got.Status != runner.FinalStateFailed {
+		t.Fatalf("last update = %#v, want failed TurnCompleted", got)
+	}
+}
+
+func TestAgentBackendRunTurnSkipsMalformedLines(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestBackend(t, Options{
+		CommandFactory: fixtureCommand(t, "malformed.jsonl", "", 0),
+	})
+
+	var updates []runner.AgentUpdate
+	result, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "continue after malformed",
+		Model:     "fable",
+	}, appendUpdate(&updates))
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.SessionID != "session-malformed" {
+		t.Fatalf("RunTurn() SessionID = %q, want session-malformed", result.SessionID)
+	}
+	if got := joinedDeltas(updates); got != "after malformed" {
+		t.Fatalf("message output = %q, want after malformed", got)
+	}
+}
+
+func TestAgentBackendRunTurnReadsOversizedLine(t *testing.T) {
+	t.Parallel()
+
+	longText := strings.Repeat("x", 70*1024)
+	fixture := strings.Join([]string{
+		`{"type":"system","subtype":"init","session_id":"session-oversized","model":"fable"}`,
+		fmt.Sprintf(`{"type":"assistant","session_id":"session-oversized","message":{"id":"msg-oversized","type":"message","role":"assistant","model":"fable","content":[{"type":"text","text":%q}],"usage":{"input_tokens":1,"output_tokens":1}}}`, longText),
+		`{"type":"result","subtype":"success","session_id":"session-oversized","usage":{"input_tokens":1,"output_tokens":1}}`,
+	}, "\n")
+	fixturePath := filepath.Join(t.TempDir(), "oversized.jsonl")
+	if err := os.WriteFile(fixturePath, []byte(fixture), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	backend := newTestBackend(t, Options{
+		CommandFactory: catCommand(fixturePath, "", 0),
+	})
+
+	var updates []runner.AgentUpdate
+	_, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "large line",
+		Model:     "fable",
+	}, appendUpdate(&updates))
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if got := joinedDeltas(updates); got != longText {
+		t.Fatalf("message output length = %d, want %d", len(got), len(longText))
+	}
+}
+
+func TestAgentBackendRunTurnMissingSessionID(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestBackend(t, Options{
+		CommandFactory: fixtureCommand(t, "missing_session.jsonl", "", 0),
+	})
+
+	var updates []runner.AgentUpdate
+	result, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "missing session",
+		Model:     "fable",
+	}, appendUpdate(&updates))
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.SessionID != "" || result.ThreadID != "" || result.TurnID != "" {
+		t.Fatalf("RunTurn() result = %#v, want empty IDs", result)
+	}
+	for _, update := range updates {
+		if update.Type == runner.AgentUpdateTurnStarted {
+			t.Fatalf("unexpected TurnStarted update without session id: %#v", update)
+		}
+	}
+	if got := joinedDeltas(updates); got != "no session" {
+		t.Fatalf("message output = %q, want no session", got)
+	}
+}
+
+func TestAgentBackendRunTurnPartialMessages(t *testing.T) {
+	t.Parallel()
+
+	backend := newTestBackend(t, Options{
+		CommandFactory:         fixtureCommand(t, "partial.jsonl", "", 0),
+		IncludePartialMessages: true,
+	})
+
+	var updates []runner.AgentUpdate
+	result, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "stream partials",
+		Model:     "fable",
+	}, appendUpdate(&updates))
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.SessionID != "session-partial" {
+		t.Fatalf("RunTurn() SessionID = %q, want session-partial", result.SessionID)
+	}
+	if got := joinedDeltas(updates); got != "partial text" {
+		t.Fatalf("message output = %q, want partial text", got)
+	}
+}
+
+func TestAgentBackendBuildsCommandArgumentsAndWritesPromptToStdin(t *testing.T) {
+	t.Parallel()
+
+	observedPath := filepath.Join(t.TempDir(), "observed.json")
+	workspace := t.TempDir()
+	backend := newTestBackend(t, Options{
+		CommandFactory: func(ctx context.Context) *exec.Cmd {
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestClaudeCodeHelperProcess", "--")
+			cmd.Env = append(os.Environ(),
+				"CLAUDECODE_HELPER=argv",
+				"CLAUDECODE_OBSERVED_PATH="+observedPath,
+			)
+			return cmd
+		},
+		PermissionMode:         "plan",
+		AllowedTools:           []string{"Bash(git *)", "Edit"},
+		DisallowedTools:        []string{"WebFetch"},
+		IncludePartialMessages: true,
+		ExtraArgs:              []string{"--custom", "value"},
+	})
+
+	_, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace:          workspace,
+		Prompt:             "prompt from stdin",
+		Model:              "fable",
+		ExtraWritableRoots: []string{"/tmp/root-a", " ", "/tmp/root-b"},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	var observed helperObservation
+	raw, err := os.ReadFile(observedPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if err := json.Unmarshal(raw, &observed); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	wantArgs := []string{
+		"-p", "--output-format", "stream-json", "--verbose",
+		"--model", "fable",
+		"--permission-mode", "plan",
+		"--allowedTools", "Bash(git *)", "Edit",
+		"--disallowedTools", "WebFetch",
+		"--include-partial-messages",
+		"--add-dir", "/tmp/root-a",
+		"--add-dir", "/tmp/root-b",
+		"--custom", "value",
+	}
+	if !reflect.DeepEqual(observed.Args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", observed.Args, wantArgs)
+	}
+	if observed.Stdin != "prompt from stdin" {
+		t.Fatalf("stdin = %q, want prompt from stdin", observed.Stdin)
+	}
+	if got, want := canonicalPath(t, observed.Workdir), canonicalPath(t, workspace); got != want {
+		t.Fatalf("workdir = %q, want %q", got, want)
+	}
+}
+
+func TestClaudeCodeHelperProcess(t *testing.T) {
+	if os.Getenv("CLAUDECODE_HELPER") != "argv" {
+		return
+	}
+
+	stdin, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		os.Exit(2)
+	}
+	workdir, err := os.Getwd()
+	if err != nil {
+		os.Exit(3)
+	}
+	observed := helperObservation{
+		Args:    argsAfterDashDash(os.Args),
+		Stdin:   string(stdin),
+		Workdir: workdir,
+	}
+	raw, err := json.Marshal(observed)
+	if err != nil {
+		os.Exit(4)
+	}
+	if err := os.WriteFile(os.Getenv("CLAUDECODE_OBSERVED_PATH"), raw, 0o600); err != nil {
+		os.Exit(5)
+	}
+	fmt.Fprintln(os.Stdout, `{"type":"system","subtype":"init","session_id":"session-argv","model":"fable"}`)
+	fmt.Fprintln(os.Stdout, `{"type":"result","subtype":"success","session_id":"session-argv"}`)
+	os.Exit(0)
+}
+
+func TestPackageDoesNotImportConfigOrCLI(t *testing.T) {
+	t.Parallel()
+
+	entries, err := os.ReadDir(".")
+	if err != nil {
+		t.Fatalf("ReadDir() error = %v", err)
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".go") || strings.HasSuffix(entry.Name(), "_test.go") {
+			continue
+		}
+		file, err := parser.ParseFile(token.NewFileSet(), entry.Name(), nil, parser.ImportsOnly)
+		if err != nil {
+			t.Fatalf("ParseFile(%s) error = %v", entry.Name(), err)
+		}
+		for _, imported := range file.Imports {
+			path := strings.Trim(imported.Path.Value, `"`)
+			if path == "github.com/digitaldrywood/detent/internal/config" ||
+				path == "github.com/digitaldrywood/detent/internal/cli" {
+				t.Fatalf("%s imports forbidden package %s", entry.Name(), path)
+			}
+		}
+	}
+}
+
+type helperObservation struct {
+	Args    []string `json:"args"`
+	Stdin   string   `json:"stdin"`
+	Workdir string   `json:"workdir"`
+}
+
+func newTestBackend(t *testing.T, options Options) *AgentBackend {
+	t.Helper()
+
+	backend, err := NewAgentBackend(options)
+	if err != nil {
+		t.Fatalf("NewAgentBackend() error = %v", err)
+	}
+	return backend
+}
+
+func fixtureCommand(t *testing.T, name string, stderr string, exitCode int) CommandFactory {
+	t.Helper()
+
+	path, err := filepath.Abs(filepath.Join("testdata", name))
+	if err != nil {
+		t.Fatalf("Abs() error = %v", err)
+	}
+	return catCommand(path, stderr, exitCode)
+}
+
+func catCommand(path string, stderr string, exitCode int) CommandFactory {
+	return func(ctx context.Context) *exec.Cmd {
+		script := "cat " + shellQuote(path)
+		if stderr != "" {
+			script += "; printf '%s' " + shellQuote(stderr) + " >&2"
+		}
+		if exitCode != 0 {
+			script += fmt.Sprintf("; exit %d", exitCode)
+		}
+		return exec.CommandContext(ctx, "sh", "-c", script)
+	}
+}
+
+func appendUpdate(updates *[]runner.AgentUpdate) runner.AgentUpdateHandler {
+	return func(update runner.AgentUpdate) error {
+		*updates = append(*updates, update)
+		return nil
+	}
+}
+
+func updateTypes(updates []runner.AgentUpdate) []runner.AgentUpdateType {
+	types := make([]runner.AgentUpdateType, 0, len(updates))
+	for _, update := range updates {
+		types = append(types, update.Type)
+	}
+	return types
+}
+
+func requireUpdate(t *testing.T, updates []runner.AgentUpdate, index int) runner.AgentUpdate {
+	t.Helper()
+
+	if len(updates) <= index {
+		t.Fatalf("updates len = %d, want index %d", len(updates), index)
+	}
+	return updates[index]
+}
+
+func requireLastUpdate(t *testing.T, updates []runner.AgentUpdate) runner.AgentUpdate {
+	t.Helper()
+
+	if len(updates) == 0 {
+		t.Fatal("updates len = 0, want at least one update")
+	}
+	return updates[len(updates)-1]
+}
+
+func joinedDeltas(updates []runner.AgentUpdate) string {
+	var out strings.Builder
+	for _, update := range updates {
+		if update.Type == runner.AgentUpdateMessageDelta {
+			out.WriteString(update.Delta)
+		}
+	}
+	return out.String()
+}
+
+func argsAfterDashDash(args []string) []string {
+	for i, arg := range args {
+		if arg == "--" {
+			return append([]string(nil), args[i+1:]...)
+		}
+	}
+	return nil
+}
+
+func shellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+func canonicalPath(t *testing.T, path string) string {
+	t.Helper()
+
+	canonical, err := filepath.EvalSymlinks(path)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q) error = %v", path, err)
+	}
+	return canonical
+}

--- a/internal/claudecode/leak_test.go
+++ b/internal/claudecode/leak_test.go
@@ -1,0 +1,11 @@
+package claudecode
+
+import (
+	"testing"
+
+	"go.uber.org/goleak"
+)
+
+func TestMain(m *testing.M) {
+	goleak.VerifyTestMain(m)
+}

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -1,0 +1,283 @@
+package claudecode
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os/exec"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/procgroup"
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+func (b *AgentBackend) RunTurn(
+	ctx context.Context,
+	req runner.AgentTurnRequest,
+	onUpdate runner.AgentUpdateHandler,
+) (runner.AgentTurnResult, error) {
+	ctx = contextOrBackground(ctx)
+	if b.options.TurnTimeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, b.options.TurnTimeout)
+		defer cancel()
+	}
+
+	cmd, err := b.command(ctx, req)
+	if err != nil {
+		return runner.AgentTurnResult{}, err
+	}
+
+	stderr := newTailBuffer(b.options.StderrTailBytes)
+	cmd.Stderr = stderr
+	cmd.Stdin = strings.NewReader(req.Prompt)
+
+	stdout, err := cmd.StdoutPipe()
+	if err != nil {
+		return runner.AgentTurnResult{}, fmt.Errorf("create stdout pipe: %w", err)
+	}
+
+	procgroup.Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		return runner.AgentTurnResult{}, fmt.Errorf("start claude command: %w", err)
+	}
+	processGroupID := procgroup.GroupID(cmd)
+
+	processIdentity := "claude-" + strconv.Itoa(cmd.Process.Pid)
+	if err := emitUpdate(onUpdate, runner.AgentUpdate{
+		Type:            runner.AgentUpdateProcessStarted,
+		ProcessIdentity: processIdentity,
+	}); err != nil {
+		err = terminateWithCause(cmd, processGroupID, err)
+		if waitErr := waitAndCleanup(cmd, processGroupID); waitErr != nil {
+			err = errors.Join(err, fmt.Errorf("wait after terminating claude command: %w", waitErr))
+		}
+		return runner.AgentTurnResult{}, err
+	}
+
+	state, streamErr := b.consumeStream(ctx, cmd, processGroupID, stdout, onUpdate)
+	waitErr := waitAndCleanup(cmd, processGroupID)
+
+	result := runner.AgentTurnResult{
+		ThreadID:  state.sessionID,
+		TurnID:    state.sessionID,
+		SessionID: state.sessionID,
+	}
+
+	if streamErr != nil {
+		return result, streamErr
+	}
+
+	finalErr := finalTurnError(state, waitErr, stderr.String())
+	status := runner.FinalStateCompleted
+	if finalErr != nil {
+		status = runner.FinalStateFailed
+	}
+
+	if err := emitUpdate(onUpdate, runner.AgentUpdate{
+		Type:     runner.AgentUpdateTurnCompleted,
+		ThreadID: state.sessionID,
+		TurnID:   state.sessionID,
+		Status:   status,
+	}); err != nil {
+		return result, err
+	}
+
+	return result, finalErr
+}
+
+func (b *AgentBackend) command(ctx context.Context, req runner.AgentTurnRequest) (*exec.Cmd, error) {
+	cmd := b.options.CommandFactory(ctx)
+	if cmd == nil {
+		return nil, ErrNilCommand
+	}
+	cmd.Dir = req.Workspace
+	if len(cmd.Args) == 0 {
+		cmd.Args = []string{cmd.Path}
+	}
+	cmd.Args = append(cmd.Args, b.argv(req)...)
+	return cmd, nil
+}
+
+func (b *AgentBackend) argv(req runner.AgentTurnRequest) []string {
+	args := []string{"-p", "--output-format", "stream-json", "--verbose"}
+	if model := strings.TrimSpace(req.Model); model != "" {
+		args = append(args, "--model", model)
+	}
+	if mode := strings.TrimSpace(b.options.PermissionMode); mode != "" {
+		args = append(args, "--permission-mode", mode)
+	}
+	if tools := nonEmptyStrings(b.options.AllowedTools); len(tools) > 0 {
+		args = append(args, "--allowedTools")
+		args = append(args, tools...)
+	}
+	if tools := nonEmptyStrings(b.options.DisallowedTools); len(tools) > 0 {
+		args = append(args, "--disallowedTools")
+		args = append(args, tools...)
+	}
+	if b.options.IncludePartialMessages {
+		args = append(args, "--include-partial-messages")
+	}
+	for _, root := range req.ExtraWritableRoots {
+		root = strings.TrimSpace(root)
+		if root == "" {
+			continue
+		}
+		args = append(args, "--add-dir", root)
+	}
+	args = append(args, b.options.ExtraArgs...)
+	return args
+}
+
+func (b *AgentBackend) consumeStream(
+	ctx context.Context,
+	cmd *exec.Cmd,
+	processGroupID int,
+	stdout io.Reader,
+	onUpdate runner.AgentUpdateHandler,
+) (turnState, error) {
+	items := scanClaudeStream(ctx, stdout, b.options.MaxScanTokenSize)
+	state := turnState{}
+	var streamErr error
+	ctxDone := ctx.Done()
+	stallTimer := newStallTimer(b.options.StallTimeout)
+	stallC := stallTimerChannel(stallTimer)
+	defer stopStallTimer(stallTimer)
+
+	for items != nil {
+		select {
+		case <-ctxDone:
+			streamErr = ctx.Err()
+			streamErr = terminateWithCause(cmd, processGroupID, streamErr)
+			ctxDone = nil
+			stallC = nil
+		case <-stallC:
+			streamErr = fmt.Errorf("%w after %s", ErrStreamStalled, b.options.StallTimeout)
+			streamErr = terminateWithCause(cmd, processGroupID, streamErr)
+			stallC = nil
+			ctxDone = nil
+		case item, ok := <-items:
+			if !ok {
+				items = nil
+				continue
+			}
+			if streamErr != nil {
+				continue
+			}
+			if item.err != nil {
+				streamErr = item.err
+				streamErr = terminateWithCause(cmd, processGroupID, streamErr)
+				ctxDone = nil
+				stallC = nil
+				continue
+			}
+			resetStallTimer(stallTimer, b.options.StallTimeout)
+			if err := state.apply(item.event, b.options.IncludePartialMessages, onUpdate); err != nil {
+				streamErr = err
+				streamErr = terminateWithCause(cmd, processGroupID, streamErr)
+				ctxDone = nil
+				stallC = nil
+			}
+		}
+	}
+
+	return state, streamErr
+}
+
+func terminateWithCause(cmd *exec.Cmd, processGroupID int, cause error) error {
+	if err := procgroup.TerminateTree(cmd, processGroupID); err != nil {
+		return errors.Join(cause, fmt.Errorf("terminate claude process tree: %w", err))
+	}
+	return cause
+}
+
+func newStallTimer(timeout time.Duration) *time.Timer {
+	if timeout <= 0 {
+		return nil
+	}
+	return time.NewTimer(timeout)
+}
+
+func stallTimerChannel(timer *time.Timer) <-chan time.Time {
+	if timer == nil {
+		return nil
+	}
+	return timer.C
+}
+
+func resetStallTimer(timer *time.Timer, timeout time.Duration) {
+	if timer == nil || timeout <= 0 {
+		return
+	}
+	stopStallTimer(timer)
+	timer.Reset(timeout)
+}
+
+func stopStallTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}
+
+func waitAndCleanup(cmd *exec.Cmd, processGroupID int) error {
+	err := cmd.Wait()
+	if cleanupErr := procgroup.Cleanup(processGroupID); cleanupErr != nil {
+		err = errors.Join(err, cleanupErr)
+	}
+	return err
+}
+
+func finalTurnError(state turnState, waitErr error, stderr string) error {
+	switch {
+	case !state.sawResult:
+		return withStderrTail(ErrMissingResult, stderr)
+	case state.resultIsError || !strings.EqualFold(strings.TrimSpace(state.resultSubtype), "success"):
+		subtype := strings.TrimSpace(state.resultSubtype)
+		if subtype == "" {
+			subtype = "unknown"
+		}
+		return withStderrTail(fmt.Errorf("%w: result subtype %q", ErrTurnFailed, subtype), stderr)
+	case waitErr != nil:
+		return withStderrTail(fmt.Errorf("%w: process exited: %w", ErrTurnFailed, waitErr), stderr)
+	default:
+		return nil
+	}
+}
+
+func withStderrTail(err error, stderr string) error {
+	stderr = strings.TrimSpace(stderr)
+	if stderr == "" {
+		return err
+	}
+	return fmt.Errorf("%w: stderr: %s", err, stderr)
+}
+
+func emitUpdate(onUpdate runner.AgentUpdateHandler, update runner.AgentUpdate) error {
+	if onUpdate == nil {
+		return nil
+	}
+	if err := onUpdate(update); err != nil {
+		return fmt.Errorf("%w: %w", ErrUpdateRejected, err)
+	}
+	return nil
+}
+
+func nonEmptyStrings(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}

--- a/internal/claudecode/process_unix_test.go
+++ b/internal/claudecode/process_unix_test.go
@@ -1,0 +1,113 @@
+//go:build unix
+
+package claudecode
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+func TestRunTurnCancellationKillsChildProcessGroup(t *testing.T) {
+	t.Parallel()
+
+	pidPath := filepath.Join(t.TempDir(), "child.pid")
+	backend := newTestBackend(t, Options{
+		CommandFactory: func(ctx context.Context) *exec.Cmd {
+			script := "sleep 3600 & printf '%s\n' \"$!\" > " + shellQuote(pidPath) + "; wait"
+			return exec.CommandContext(ctx, "sh", "-c", script)
+		},
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	workspace := t.TempDir()
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := backend.RunTurn(ctx, runner.AgentTurnRequest{
+			Workspace: workspace,
+			Prompt:    "cancel",
+			Model:     "fable",
+		}, nil)
+		errCh <- err
+	}()
+
+	pid := waitForPIDFile(t, pidPath)
+	cancel()
+
+	select {
+	case err := <-errCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("RunTurn() error = %v, want context canceled", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("RunTurn() did not return after context cancellation")
+	}
+	waitForProcessExit(t, pid)
+}
+
+func waitForPIDFile(t *testing.T, path string) int {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	var lastErr error
+	var lastRaw string
+	for {
+		raw, err := os.ReadFile(path)
+		if err == nil {
+			lastRaw = string(raw)
+			pid, parseErr := strconv.Atoi(strings.TrimSpace(lastRaw))
+			if parseErr == nil && pid > 0 {
+				return pid
+			}
+			if parseErr != nil {
+				lastErr = parseErr
+			} else {
+				lastErr = errors.New("pid is not positive")
+			}
+		} else {
+			lastErr = err
+		}
+
+		select {
+		case <-deadline:
+			if lastRaw != "" {
+				t.Fatalf("timed out waiting for parseable pid file, last value %q: %v", lastRaw, lastErr)
+			}
+			t.Fatalf("timed out waiting for pid file: %v", lastErr)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func waitForProcessExit(t *testing.T, pid int) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	for {
+		if !processAlive(pid) {
+			return
+		}
+
+		select {
+		case <-deadline:
+			t.Fatalf("process %d is still alive", pid)
+		default:
+			time.Sleep(time.Millisecond)
+		}
+	}
+}
+
+func processAlive(pid int) bool {
+	err := syscall.Kill(pid, 0)
+	return err == nil || errors.Is(err, syscall.EPERM)
+}

--- a/internal/claudecode/stream.go
+++ b/internal/claudecode/stream.go
@@ -1,0 +1,277 @@
+package claudecode
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/runner"
+)
+
+type streamItem struct {
+	event claudeEvent
+	err   error
+}
+
+type claudeEvent struct {
+	Type         string         `json:"type"`
+	Subtype      string         `json:"subtype"`
+	SessionID    string         `json:"session_id"`
+	Model        string         `json:"model"`
+	Message      *claudeMessage `json:"message"`
+	Usage        *claudeUsage   `json:"usage"`
+	StreamEvent  *streamEvent   `json:"event"`
+	InputTokens  int64          `json:"input_tokens"`
+	OutputTokens int64          `json:"output_tokens"`
+	TotalTokens  int64          `json:"total_tokens"`
+	IsError      bool           `json:"is_error"`
+	DurationMS   int64          `json:"duration_ms"`
+	TotalCostUSD float64        `json:"total_cost_usd"`
+}
+
+type claudeMessage struct {
+	ID      string         `json:"id"`
+	Role    string         `json:"role"`
+	Model   string         `json:"model"`
+	Content []contentBlock `json:"content"`
+	Usage   *claudeUsage   `json:"usage"`
+}
+
+type contentBlock struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type streamEvent struct {
+	Type         string         `json:"type"`
+	Message      *claudeMessage `json:"message"`
+	ContentBlock *contentBlock  `json:"content_block"`
+	Delta        *streamDelta   `json:"delta"`
+	Usage        *claudeUsage   `json:"usage"`
+}
+
+type streamDelta struct {
+	Type string `json:"type"`
+	Text string `json:"text"`
+}
+
+type claudeUsage struct {
+	InputTokens              int64 `json:"input_tokens"`
+	OutputTokens             int64 `json:"output_tokens"`
+	TotalTokens              int64 `json:"total_tokens"`
+	CacheCreationInputTokens int64 `json:"cache_creation_input_tokens"`
+	CacheReadInputTokens     int64 `json:"cache_read_input_tokens"`
+	CachedInputTokens        int64 `json:"cached_input_tokens"`
+	ReasoningOutputTokens    int64 `json:"reasoning_output_tokens"`
+}
+
+type turnState struct {
+	sessionID       string
+	partialItemID   string
+	usage           runner.AgentTokenUsage
+	sawResult       bool
+	resultSubtype   string
+	resultIsError   bool
+	turnStartedSent bool
+}
+
+func scanClaudeStream(ctx context.Context, r io.Reader, maxTokenSize int) <-chan streamItem {
+	out := make(chan streamItem, 64)
+	go func() {
+		defer close(out)
+
+		scanner := bufio.NewScanner(r)
+		scanner.Buffer(make([]byte, 0, 64*1024), maxTokenSize)
+		for scanner.Scan() {
+			line := strings.TrimSpace(string(scanner.Bytes()))
+			if line == "" {
+				continue
+			}
+			var event claudeEvent
+			if err := json.Unmarshal([]byte(line), &event); err != nil {
+				continue
+			}
+			select {
+			case out <- streamItem{event: event}:
+			case <-ctx.Done():
+				return
+			}
+		}
+		if err := scanner.Err(); err != nil {
+			select {
+			case out <- streamItem{err: fmt.Errorf("scan claude stream: %w", err)}:
+			case <-ctx.Done():
+			}
+		}
+	}()
+	return out
+}
+
+func (s *turnState) apply(event claudeEvent, includePartialMessages bool, onUpdate runner.AgentUpdateHandler) error {
+	if event.SessionID != "" {
+		s.sessionID = event.SessionID
+	}
+
+	switch event.Type {
+	case "system", "init":
+		return s.applyInit(event, onUpdate)
+	case "assistant":
+		return s.applyAssistant(event, includePartialMessages, onUpdate)
+	case "stream_event":
+		return s.applyStreamEvent(event, includePartialMessages, onUpdate)
+	case "result":
+		return s.applyResult(event, onUpdate)
+	default:
+		return nil
+	}
+}
+
+func (s *turnState) applyInit(event claudeEvent, onUpdate runner.AgentUpdateHandler) error {
+	if event.Type == "system" && strings.TrimSpace(event.Subtype) != "init" {
+		return nil
+	}
+	if event.SessionID == "" || s.turnStartedSent {
+		return nil
+	}
+	s.turnStartedSent = true
+	return emitUpdate(onUpdate, runner.AgentUpdate{
+		Type:     runner.AgentUpdateTurnStarted,
+		ThreadID: event.SessionID,
+		TurnID:   event.SessionID,
+	})
+}
+
+func (s *turnState) applyAssistant(
+	event claudeEvent,
+	includePartialMessages bool,
+	onUpdate runner.AgentUpdateHandler,
+) error {
+	if event.Message == nil {
+		return nil
+	}
+	if event.Message.ID != "" {
+		s.partialItemID = event.Message.ID
+	}
+	if !includePartialMessages {
+		for _, block := range event.Message.Content {
+			if block.Type != "text" || block.Text == "" {
+				continue
+			}
+			if err := emitUpdate(onUpdate, runner.AgentUpdate{
+				Type:     runner.AgentUpdateMessageDelta,
+				ThreadID: s.sessionID,
+				TurnID:   s.sessionID,
+				ItemID:   event.Message.ID,
+				Delta:    block.Text,
+			}); err != nil {
+				return err
+			}
+		}
+	}
+	if event.Message.Usage != nil && !event.Message.Usage.empty() {
+		addUsage(&s.usage, *event.Message.Usage)
+		return s.emitUsage(onUpdate)
+	}
+	return nil
+}
+
+func (s *turnState) applyStreamEvent(
+	event claudeEvent,
+	includePartialMessages bool,
+	onUpdate runner.AgentUpdateHandler,
+) error {
+	if event.StreamEvent == nil {
+		return nil
+	}
+	if event.StreamEvent.Message != nil && event.StreamEvent.Message.ID != "" {
+		s.partialItemID = event.StreamEvent.Message.ID
+	}
+	if includePartialMessages && event.StreamEvent.Delta != nil &&
+		event.StreamEvent.Delta.Type == "text_delta" &&
+		event.StreamEvent.Delta.Text != "" {
+		if err := emitUpdate(onUpdate, runner.AgentUpdate{
+			Type:     runner.AgentUpdateMessageDelta,
+			ThreadID: s.sessionID,
+			TurnID:   s.sessionID,
+			ItemID:   s.partialItemID,
+			Delta:    event.StreamEvent.Delta.Text,
+		}); err != nil {
+			return err
+		}
+	}
+	if event.StreamEvent.Usage != nil && !event.StreamEvent.Usage.empty() {
+		addUsage(&s.usage, *event.StreamEvent.Usage)
+		return s.emitUsage(onUpdate)
+	}
+	return nil
+}
+
+func (s *turnState) applyResult(event claudeEvent, onUpdate runner.AgentUpdateHandler) error {
+	s.sawResult = true
+	s.resultSubtype = event.Subtype
+	s.resultIsError = event.IsError
+	// Non-goals: --resume continuity, rate-limit telemetry, and total_cost_usd budget ingest.
+	if event.Usage != nil && !event.Usage.empty() {
+		s.usage = event.Usage.agentUsage()
+		return s.emitUsage(onUpdate)
+	}
+	if usage := event.topLevelUsage(); !usage.empty() {
+		s.usage = usage.agentUsage()
+		return s.emitUsage(onUpdate)
+	}
+	return nil
+}
+
+func (s *turnState) emitUsage(onUpdate runner.AgentUpdateHandler) error {
+	return emitUpdate(onUpdate, runner.AgentUpdate{
+		Type:     runner.AgentUpdateTokenUsage,
+		ThreadID: s.sessionID,
+		TurnID:   s.sessionID,
+		Tokens:   s.usage,
+	})
+}
+
+func (e claudeEvent) topLevelUsage() claudeUsage {
+	return claudeUsage{
+		InputTokens:  e.InputTokens,
+		OutputTokens: e.OutputTokens,
+		TotalTokens:  e.TotalTokens,
+	}
+}
+
+func (u claudeUsage) empty() bool {
+	return u.InputTokens == 0 &&
+		u.OutputTokens == 0 &&
+		u.TotalTokens == 0 &&
+		u.CacheCreationInputTokens == 0 &&
+		u.CacheReadInputTokens == 0 &&
+		u.CachedInputTokens == 0 &&
+		u.ReasoningOutputTokens == 0
+}
+
+func (u claudeUsage) agentUsage() runner.AgentTokenUsage {
+	cached := u.CacheCreationInputTokens + u.CacheReadInputTokens + u.CachedInputTokens
+	total := u.TotalTokens
+	if total == 0 {
+		total = u.InputTokens + u.OutputTokens
+	}
+	return runner.AgentTokenUsage{
+		InputTokens:           u.InputTokens,
+		CachedInputTokens:     cached,
+		OutputTokens:          u.OutputTokens,
+		ReasoningOutputTokens: u.ReasoningOutputTokens,
+		TotalTokens:           total,
+	}
+}
+
+func addUsage(t *runner.AgentTokenUsage, u claudeUsage) {
+	next := u.agentUsage()
+	t.InputTokens += next.InputTokens
+	t.CachedInputTokens += next.CachedInputTokens
+	t.OutputTokens += next.OutputTokens
+	t.ReasoningOutputTokens += next.ReasoningOutputTokens
+	t.TotalTokens += next.TotalTokens
+}

--- a/internal/claudecode/tail_buffer.go
+++ b/internal/claudecode/tail_buffer.go
@@ -1,0 +1,33 @@
+package claudecode
+
+import "sync"
+
+type tailBuffer struct {
+	mu    sync.Mutex
+	limit int
+	buf   []byte
+}
+
+func newTailBuffer(limit int) *tailBuffer {
+	if limit <= 0 {
+		limit = defaultStderrTailBytes
+	}
+	return &tailBuffer{limit: limit}
+}
+
+func (b *tailBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	b.buf = append(b.buf, p...)
+	if len(b.buf) > b.limit {
+		b.buf = append([]byte(nil), b.buf[len(b.buf)-b.limit:]...)
+	}
+	return len(p), nil
+}
+
+func (b *tailBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return string(b.buf)
+}

--- a/internal/claudecode/testdata/error_result.jsonl
+++ b/internal/claudecode/testdata/error_result.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"session-error","model":"fable"}
+{"type":"assistant","session_id":"session-error","message":{"id":"msg-error","type":"message","role":"assistant","model":"fable","content":[{"type":"text","text":"working"}],"usage":{"input_tokens":7,"output_tokens":2}}}
+{"type":"result","subtype":"error_max_turns","session_id":"session-error","duration_ms":50,"total_cost_usd":0.0002,"usage":{"input_tokens":8,"output_tokens":3}}

--- a/internal/claudecode/testdata/malformed.jsonl
+++ b/internal/claudecode/testdata/malformed.jsonl
@@ -1,0 +1,5 @@
+this is not json
+{"type":"unknown","value":"ignored"}
+{"type":"system","subtype":"init","session_id":"session-malformed","model":"fable"}
+{"type":"assistant","session_id":"session-malformed","message":{"id":"msg-malformed","type":"message","role":"assistant","model":"fable","content":[{"type":"text","text":"after malformed"}],"usage":{"input_tokens":3,"output_tokens":2}}}
+{"type":"result","subtype":"success","session_id":"session-malformed","usage":{"input_tokens":4,"output_tokens":3}}

--- a/internal/claudecode/testdata/missing_session.jsonl
+++ b/internal/claudecode/testdata/missing_session.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","model":"fable"}
+{"type":"assistant","message":{"id":"msg-missing","type":"message","role":"assistant","model":"fable","content":[{"type":"text","text":"no session"}],"usage":{"input_tokens":2,"output_tokens":1}}}
+{"type":"result","subtype":"success","usage":{"input_tokens":2,"output_tokens":1}}

--- a/internal/claudecode/testdata/partial.jsonl
+++ b/internal/claudecode/testdata/partial.jsonl
@@ -1,0 +1,6 @@
+{"type":"system","subtype":"init","session_id":"session-partial","model":"fable"}
+{"type":"stream_event","session_id":"session-partial","event":{"type":"message_start","message":{"id":"msg-partial","type":"message","role":"assistant","model":"fable","content":[]}}}
+{"type":"stream_event","session_id":"session-partial","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"partial "}}}
+{"type":"stream_event","session_id":"session-partial","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"text"}}}
+{"type":"assistant","session_id":"session-partial","message":{"id":"msg-partial","type":"message","role":"assistant","model":"fable","content":[{"type":"text","text":"ignored full text"}],"usage":{"input_tokens":5,"output_tokens":2}}}
+{"type":"result","subtype":"success","session_id":"session-partial","usage":{"input_tokens":6,"output_tokens":3}}

--- a/internal/claudecode/testdata/success.jsonl
+++ b/internal/claudecode/testdata/success.jsonl
@@ -1,0 +1,3 @@
+{"type":"system","subtype":"init","session_id":"session-success","model":"fable"}
+{"type":"assistant","session_id":"session-success","message":{"id":"msg-success","type":"message","role":"assistant","model":"fable","content":[{"type":"text","text":"hello "},{"type":"text","text":"world"}],"usage":{"input_tokens":10,"cache_creation_input_tokens":2,"cache_read_input_tokens":3,"output_tokens":4}}}
+{"type":"result","subtype":"success","session_id":"session-success","duration_ms":1234,"total_cost_usd":0.001,"usage":{"input_tokens":12,"cache_creation_input_tokens":2,"cache_read_input_tokens":4,"output_tokens":6}}


### PR DESCRIPTION
## Summary

- Add `internal/claudecode` as a `runner.AgentBackend` that runs one `claude -p` process per turn with stdin prompt delivery.
- Decode Claude stream-json NDJSON into Detent agent updates for process start, turn start, message deltas, token usage, and turn completion.
- Add process-group cleanup, bounded stderr failure context, timeout/stall handling, fixture coverage, import guardrails, and Unix cancellation coverage.

Fixes #832

## Test Plan

- [x] `go test -race ./internal/claudecode`
- [x] `golangci-lint run ./internal/claudecode --timeout=5m`
- [x] `make check`
