### PR TITLE
refactor(config): make backend options opaque

### DIFF
--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -157,20 +157,20 @@ func buildWorkspaceBackend(cfg workflowconfig.Config, sourceRootFallback string,
 func buildAgentBackend(backend workflowconfig.AgentBackend) (runnerpkg.AgentBackend, error) {
 	switch backend.Kind {
 	case workflowconfig.AgentBackendCodex:
-		return buildCodexAgentBackend(backend.CodexConfig(workflowconfig.Codex{}))
+		return buildCodexAgentBackend(backend.Command, backend.CodexOptions())
 	default:
 		return nil, fmt.Errorf("unsupported agent backend kind %q", backend.Kind)
 	}
 }
 
-func buildCodexAgentBackend(cfg workflowconfig.Codex) (runnerpkg.AgentBackend, error) {
-	command := strings.TrimSpace(cfg.Command)
+func buildCodexAgentBackend(command string, cfg workflowconfig.CodexOptions) (runnerpkg.AgentBackend, error) {
+	command = strings.TrimSpace(command)
 	if command == "" {
 		return nil, errors.New("codex command is required")
 	}
 
 	factory, err := codex.NewLocalTransportFactory(func(ctx context.Context) *exec.Cmd {
-		return buildCodexCommandFromConfig(ctx, cfg)
+		return buildCodexCommandFromConfig(ctx, command, cfg.Shell)
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create codex transport factory: %w", err)
@@ -196,11 +196,11 @@ func buildCodexAgentBackend(cfg workflowconfig.Codex) (runnerpkg.AgentBackend, e
 }
 
 func buildCodexCommand(ctx context.Context, cfg workflowconfig.Config) *exec.Cmd {
-	return buildCodexCommandFromConfig(ctx, cfg.Codex)
+	return buildCodexCommandFromConfig(ctx, cfg.Codex.Command, cfg.Codex.Shell)
 }
 
-func buildCodexCommandFromConfig(ctx context.Context, cfg workflowconfig.Codex) *exec.Cmd {
-	return commandshell.Command(ctx, strings.TrimSpace(cfg.Command), cfg.Shell)
+func buildCodexCommandFromConfig(ctx context.Context, command string, shell string) *exec.Cmd {
+	return commandshell.Command(ctx, strings.TrimSpace(command), shell)
 }
 
 // publishSnapshots ticks at interval, building a merged telemetry snapshot

--- a/internal/codex/sandbox.go
+++ b/internal/codex/sandbox.go
@@ -14,7 +14,7 @@ type Options struct {
 	TurnSandboxPolicy any
 }
 
-func OptionsFromConfig(cfg config.Codex) Options {
+func OptionsFromConfig(cfg config.CodexOptions) Options {
 	return Options{
 		ApprovalPolicy:    stringOrMapValue(cfg.ApprovalPolicy),
 		ThreadSandbox:     cfg.ThreadSandbox,

--- a/internal/codex/sandbox_test.go
+++ b/internal/codex/sandbox_test.go
@@ -69,7 +69,7 @@ func TestOptionsFromConfigClonesApprovalPolicy(t *testing.T) {
 			"rules": true,
 		},
 	}
-	options := OptionsFromConfig(config.Codex{
+	options := OptionsFromConfig(config.CodexOptions{
 		ApprovalPolicy: config.MapValue(rawPolicy),
 		ThreadSandbox:  "workspace-write",
 		TurnSandboxPolicy: map[string]any{

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -198,14 +198,22 @@ type Agents struct {
 }
 
 type AgentBackend struct {
-	ID       string              `yaml:"id"`
-	Kind     string              `yaml:"kind"`
-	Protocol string              `yaml:"protocol"`
-	Command  string              `yaml:"command"`
-	Options  AgentBackendOptions `yaml:"options"`
+	ID       string         `yaml:"id"`
+	Kind     string         `yaml:"kind"`
+	Protocol string         `yaml:"protocol"`
+	Command  string         `yaml:"command"`
+	Options  BackendOptions `yaml:"options"`
+
+	codexOptions    CodexOptions
+	codexOptionsSet bool
+	optionsErr      error
 }
 
-type AgentBackendOptions struct {
+type BackendOptions struct {
+	node *yaml.Node
+}
+
+type CodexOptions struct {
 	Shell             string         `yaml:"shell"`
 	ApprovalPolicy    StringOrMap    `yaml:"approval_policy"`
 	ThreadSandbox     string         `yaml:"thread_sandbox"`
@@ -272,6 +280,11 @@ func (c Config) AgentBackendConfigs() []AgentBackend {
 	if len(c.Agents.Backends) > 0 {
 		backends := make([]AgentBackend, len(c.Agents.Backends))
 		copy(backends, c.Agents.Backends)
+		for index := range backends {
+			if backends[index].Kind == AgentBackendCodex {
+				backends[index] = mergedCodexAgentBackend(c.Codex, backends[index])
+			}
+		}
 		return backends
 	}
 	return []AgentBackend{CodexAgentBackend(c.Codex)}
@@ -296,50 +309,101 @@ func (c Config) AgentRouteConfigs() []AgentRoute {
 }
 
 func CodexAgentBackend(codex Codex) AgentBackend {
+	options := CodexOptions{
+		Shell:             codex.Shell,
+		ApprovalPolicy:    codex.ApprovalPolicy,
+		ThreadSandbox:     codex.ThreadSandbox,
+		TurnSandboxPolicy: codex.TurnSandboxPolicy,
+		TurnTimeoutMS:     codex.TurnTimeoutMS,
+		ReadTimeoutMS:     codex.ReadTimeoutMS,
+		StallTimeoutMS:    codex.StallTimeoutMS,
+	}
+	options.normalize()
 	return AgentBackend{
 		ID:       DefaultAgentBackendID,
 		Kind:     AgentBackendCodex,
 		Protocol: defaultCodexProtocol,
 		Command:  strings.TrimSpace(codex.Command),
-		Options: AgentBackendOptions{
-			Shell:             codex.Shell,
-			ApprovalPolicy:    codex.ApprovalPolicy,
-			ThreadSandbox:     codex.ThreadSandbox,
-			TurnSandboxPolicy: codex.TurnSandboxPolicy,
-			TurnTimeoutMS:     codex.TurnTimeoutMS,
-			ReadTimeoutMS:     codex.ReadTimeoutMS,
-			StallTimeoutMS:    codex.StallTimeoutMS,
-		},
+		Options:  backendOptionsFrom(options),
+
+		codexOptions:    options,
+		codexOptionsSet: true,
 	}
 }
 
-func (b AgentBackend) CodexConfig(fallback Codex) Codex {
+func mergedCodexAgentBackend(fallback Codex, backend AgentBackend) AgentBackend {
 	cfg := fallback
-	if strings.TrimSpace(b.Command) != "" {
-		cfg.Command = strings.TrimSpace(b.Command)
+	if strings.TrimSpace(backend.Command) != "" {
+		cfg.Command = strings.TrimSpace(backend.Command)
 	}
-	if strings.TrimSpace(b.Options.Shell) != "" {
-		cfg.Shell = b.Options.Shell
+	options := backend.CodexOptions()
+	if strings.TrimSpace(options.Shell) != "" {
+		cfg.Shell = options.Shell
 	}
-	if b.Options.ApprovalPolicy.IsString || b.Options.ApprovalPolicy.IsMap {
-		cfg.ApprovalPolicy = b.Options.ApprovalPolicy
+	if options.ApprovalPolicy.IsString || options.ApprovalPolicy.IsMap {
+		cfg.ApprovalPolicy = options.ApprovalPolicy
 	}
-	if strings.TrimSpace(b.Options.ThreadSandbox) != "" {
-		cfg.ThreadSandbox = strings.TrimSpace(b.Options.ThreadSandbox)
+	if strings.TrimSpace(options.ThreadSandbox) != "" {
+		cfg.ThreadSandbox = strings.TrimSpace(options.ThreadSandbox)
 	}
-	if b.Options.TurnSandboxPolicy != nil {
-		cfg.TurnSandboxPolicy = b.Options.TurnSandboxPolicy
+	if options.TurnSandboxPolicy != nil {
+		cfg.TurnSandboxPolicy = options.TurnSandboxPolicy
 	}
-	if b.Options.TurnTimeoutMS > 0 {
-		cfg.TurnTimeoutMS = b.Options.TurnTimeoutMS
+	if options.TurnTimeoutMS > 0 {
+		cfg.TurnTimeoutMS = options.TurnTimeoutMS
 	}
-	if b.Options.ReadTimeoutMS > 0 {
-		cfg.ReadTimeoutMS = b.Options.ReadTimeoutMS
+	if options.ReadTimeoutMS > 0 {
+		cfg.ReadTimeoutMS = options.ReadTimeoutMS
 	}
-	if b.Options.StallTimeoutMS > 0 {
-		cfg.StallTimeoutMS = b.Options.StallTimeoutMS
+	if options.StallTimeoutMS > 0 {
+		cfg.StallTimeoutMS = options.StallTimeoutMS
 	}
-	return cfg
+	effective := CodexAgentBackend(cfg)
+	effective.ID = backend.ID
+	effective.Kind = backend.Kind
+	effective.Protocol = backend.Protocol
+	return effective
+}
+
+func (b AgentBackend) CodexOptions() CodexOptions {
+	options, err := b.decodedCodexOptions()
+	if err != nil {
+		return CodexOptions{}
+	}
+	return options
+}
+
+func (b AgentBackend) decodedCodexOptions() (CodexOptions, error) {
+	if b.optionsErr != nil {
+		return CodexOptions{}, b.optionsErr
+	}
+	if b.codexOptionsSet {
+		return b.codexOptions, nil
+	}
+
+	var options CodexOptions
+	if err := b.Options.Decode(&options); err != nil {
+		return CodexOptions{}, err
+	}
+	options.normalize()
+	return options, nil
+}
+
+func (b *AgentBackend) decodeOptions() {
+	b.codexOptions = CodexOptions{}
+	b.codexOptionsSet = false
+	b.optionsErr = nil
+	if b.Kind != AgentBackendCodex {
+		return
+	}
+
+	options, err := b.decodedCodexOptions()
+	if err != nil {
+		b.optionsErr = err
+		return
+	}
+	b.codexOptions = options
+	b.codexOptionsSet = true
 }
 
 type Server struct {
@@ -730,6 +794,68 @@ func (s *StringOrMap) UnmarshalYAML(value *yaml.Node) error {
 	}
 }
 
+func (s StringOrMap) MarshalYAML() (any, error) {
+	if s.IsString {
+		return s.String, nil
+	}
+	if s.IsMap {
+		return s.Map, nil
+	}
+	return yamlNullNode(), nil
+}
+
+func (o *BackendOptions) UnmarshalYAML(value *yaml.Node) error {
+	if value == nil || value.Kind == yaml.ScalarNode && value.Tag == "!!null" {
+		*o = BackendOptions{}
+		return nil
+	}
+	o.node = cloneYAMLNode(value)
+	return nil
+}
+
+func (o BackendOptions) MarshalYAML() (any, error) {
+	if o.node == nil {
+		return yamlNullNode(), nil
+	}
+	return o.node, nil
+}
+
+func (o BackendOptions) Decode(out any) error {
+	if o.node == nil {
+		return nil
+	}
+	return o.node.Decode(out)
+}
+
+func backendOptionsFrom(value any) BackendOptions {
+	var node yaml.Node
+	if err := node.Encode(value); err != nil {
+		return BackendOptions{}
+	}
+	return BackendOptions{node: &node}
+}
+
+func yamlNullNode() *yaml.Node {
+	return &yaml.Node{
+		Kind: yaml.ScalarNode,
+		Tag:  "!!null",
+	}
+}
+
+func cloneYAMLNode(in *yaml.Node) *yaml.Node {
+	if in == nil {
+		return nil
+	}
+	out := *in
+	if len(in.Content) > 0 {
+		out.Content = make([]*yaml.Node, len(in.Content))
+		for index := range in.Content {
+			out.Content[index] = cloneYAMLNode(in.Content[index])
+		}
+	}
+	return &out
+}
+
 func (c *Config) normalize() {
 	c.Identity.Normalize()
 	c.Tracker.Kind = strings.ToLower(strings.TrimSpace(c.Tracker.Kind))
@@ -996,11 +1122,7 @@ func (a *Agents) normalize() {
 			backend.Protocol = defaultCodexProtocol
 		}
 		backend.Command = strings.TrimSpace(backend.Command)
-		backend.Options.Shell = strings.TrimSpace(backend.Options.Shell)
-		if backend.Options.Shell != "" {
-			backend.Options.Shell = commandshell.Normalize(backend.Options.Shell)
-		}
-		backend.Options.ThreadSandbox = strings.TrimSpace(backend.Options.ThreadSandbox)
+		backend.decodeOptions()
 	}
 	for index := range a.Routes {
 		route := &a.Routes[index]
@@ -1047,7 +1169,7 @@ func (a *Agents) validate(problems *[]string) {
 			*problems = append(*problems, "agents.backends.protocol must be app-server for codex")
 		}
 		validateRequired("agents.backends.command", backend.Command, "", problems)
-		backend.Options.validate("agents.backends.options", problems)
+		backend.validateOptions("agents.backends.options", problems)
 	}
 
 	defaultRoutes := map[string]int{}
@@ -1078,7 +1200,27 @@ func normalizeAgentRouteRole(role string) string {
 	return role
 }
 
-func (o *AgentBackendOptions) validate(prefix string, problems *[]string) {
+func (b AgentBackend) validateOptions(prefix string, problems *[]string) {
+	switch b.Kind {
+	case AgentBackendCodex:
+		options, err := b.decodedCodexOptions()
+		if err != nil {
+			*problems = append(*problems, prefix+" must decode for codex: "+err.Error())
+			return
+		}
+		options.validate(prefix, problems)
+	}
+}
+
+func (o *CodexOptions) normalize() {
+	o.Shell = strings.TrimSpace(o.Shell)
+	if o.Shell != "" {
+		o.Shell = commandshell.Normalize(o.Shell)
+	}
+	o.ThreadSandbox = strings.TrimSpace(o.ThreadSandbox)
+}
+
+func (o CodexOptions) validate(prefix string, problems *[]string) {
 	if o.TurnTimeoutMS < 0 {
 		*problems = append(*problems, prefix+".turn_timeout_ms must be greater than or equal to 0")
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -810,14 +810,22 @@ Prompt
 	if backend.Command != "codex app-server --profile high" {
 		t.Fatalf("backend Command = %q, want configured command", backend.Command)
 	}
-	if backend.Options.Shell != "bash" {
-		t.Fatalf("backend shell = %q, want bash", backend.Options.Shell)
+	options := backend.CodexOptions()
+	if options.Shell != "bash" {
+		t.Fatalf("backend shell = %q, want bash", options.Shell)
 	}
-	if !backend.Options.ApprovalPolicy.IsString || backend.Options.ApprovalPolicy.String != "never" {
-		t.Fatalf("backend approval policy = %#v, want never", backend.Options.ApprovalPolicy)
+	if !options.ApprovalPolicy.IsString || options.ApprovalPolicy.String != "never" {
+		t.Fatalf("backend approval policy = %#v, want never", options.ApprovalPolicy)
 	}
-	if backend.Options.TurnSandboxPolicy["type"] != "dangerFullAccess" {
-		t.Fatalf("backend turn sandbox policy = %#v, want dangerFullAccess", backend.Options.TurnSandboxPolicy)
+	if options.TurnSandboxPolicy["type"] != "dangerFullAccess" {
+		t.Fatalf("backend turn sandbox policy = %#v, want dangerFullAccess", options.TurnSandboxPolicy)
+	}
+	var decoded CodexOptions
+	if err := backend.Options.Decode(&decoded); err != nil {
+		t.Fatalf("backend options Decode() error = %v", err)
+	}
+	if decoded.ReadTimeoutMS != 1000 {
+		t.Fatalf("decoded read timeout = %d, want 1000", decoded.ReadTimeoutMS)
 	}
 	if len(agents.Routes) != 4 {
 		t.Fatalf("Agents.Routes len = %d, want 4", len(agents.Routes))
@@ -833,6 +841,82 @@ Prompt
 	}
 	if !agents.Routes[3].Default {
 		t.Fatal("default route Default = false, want true")
+	}
+}
+
+func TestAgentBackendConfigsMergesLegacyCodexDefaults(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+codex:
+  command: codex app-server
+  shell: bash
+  approval_policy:
+    reject:
+      sandbox_approval: true
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+  turn_timeout_ms: 700000
+  read_timeout_ms: 7000
+  stall_timeout_ms: 70000
+agents:
+  backends:
+    - id: codex-custom
+      kind: codex
+      protocol: app-server
+      command: codex app-server --profile custom
+      options:
+        approval_policy: never
+        read_timeout_ms: 1000
+        stall_timeout_ms: 0
+  routes:
+    - backend: codex-custom
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	backends := workflow.Config.AgentBackendConfigs()
+	if len(backends) != 1 {
+		t.Fatalf("AgentBackendConfigs() len = %d, want 1", len(backends))
+	}
+	backend := backends[0]
+	if backend.ID != "codex-custom" {
+		t.Fatalf("backend ID = %q, want codex-custom", backend.ID)
+	}
+	if backend.Command != "codex app-server --profile custom" {
+		t.Fatalf("backend Command = %q, want configured command", backend.Command)
+	}
+	options := backend.CodexOptions()
+	if options.Shell != "bash" {
+		t.Fatalf("backend shell = %q, want legacy default", options.Shell)
+	}
+	if !options.ApprovalPolicy.IsString || options.ApprovalPolicy.String != "never" {
+		t.Fatalf("backend approval policy = %#v, want backend override", options.ApprovalPolicy)
+	}
+	if options.ThreadSandbox != "workspace-write" {
+		t.Fatalf("backend thread sandbox = %q, want legacy default", options.ThreadSandbox)
+	}
+	if got := options.TurnSandboxPolicy["type"]; got != "workspaceWrite" {
+		t.Fatalf("backend turn sandbox policy type = %v, want workspaceWrite", got)
+	}
+	if options.TurnTimeoutMS != 700000 {
+		t.Fatalf("backend turn timeout = %d, want legacy default", options.TurnTimeoutMS)
+	}
+	if options.ReadTimeoutMS != 1000 {
+		t.Fatalf("backend read timeout = %d, want backend override", options.ReadTimeoutMS)
+	}
+	if options.StallTimeoutMS != 70000 {
+		t.Fatalf("backend stall timeout = %d, want legacy default for zero backend value", options.StallTimeoutMS)
 	}
 }
 
@@ -1491,6 +1575,56 @@ Prompt
 				"agents.routes.backend must reference a configured backend",
 				"agents.routes.selector.priority_in values must be integers 1 through 4",
 				"agents.routes must not define multiple default routes for the same role",
+			},
+		},
+		{
+			name: "invalid agent backend options decode",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex
+      kind: codex
+      protocol: app-server
+      command: codex app-server
+      options:
+        approval_policy: [never]
+  routes:
+    - backend: codex
+      default: true
+---
+Prompt
+`,
+			want: []string{
+				"agents.backends.options must decode for codex",
+			},
+		},
+		{
+			name: "invalid agent backend option timeouts",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex
+      kind: codex
+      protocol: app-server
+      command: codex app-server
+      options:
+        turn_timeout_ms: -1
+        read_timeout_ms: -1
+        stall_timeout_ms: -1
+  routes:
+    - backend: codex
+      default: true
+---
+Prompt
+`,
+			want: []string{
+				"agents.backends.options.turn_timeout_ms must be greater than or equal to 0",
+				"agents.backends.options.read_timeout_ms must be greater than or equal to 0",
+				"agents.backends.options.stall_timeout_ms must be greater than or equal to 0",
 			},
 		},
 		{

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -158,7 +158,7 @@ func newAgentRuntime(
 	staticBackends map[string]AgentBackend,
 	factory AgentBackendFactory,
 ) (agentRuntime, error) {
-	backendConfigs := effectiveAgentBackendConfigs(workflow.Config)
+	backendConfigs := workflow.Config.AgentBackendConfigs()
 	backends := make(map[string]AgentBackend, len(backendConfigs))
 	backendKinds := make(map[string]string, len(backendConfigs))
 	for _, backendConfig := range backendConfigs {
@@ -199,22 +199,6 @@ func newAgentRuntime(
 		backendKinds: backendKinds,
 		router:       router,
 	}, nil
-}
-
-func effectiveAgentBackendConfigs(cfg config.Config) []config.AgentBackend {
-	configs := cfg.AgentBackendConfigs()
-	for index, backend := range configs {
-		if backend.Kind != config.AgentBackendCodex {
-			continue
-		}
-		effectiveCodex := backend.CodexConfig(cfg.Codex)
-		effective := config.CodexAgentBackend(effectiveCodex)
-		effective.ID = backend.ID
-		effective.Kind = backend.Kind
-		effective.Protocol = backend.Protocol
-		configs[index] = effective
-	}
-	return configs
 }
 
 func routesFromConfig(routes []config.AgentRoute) []Route {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -257,8 +257,8 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if sessionStore.phase.ProjectID != "detent" || sessionStore.phase.SessionID != 42 {
 		t.Fatalf("WorkflowPhaseEvent identity = %#v, want project detent and session 42", sessionStore.phase)
 	}
-	if sessionStore.phase.EndpointFamily != config.AgentBackendCodex {
-		t.Fatalf("WorkflowPhaseEvent EndpointFamily = %q, want %q", sessionStore.phase.EndpointFamily, config.AgentBackendCodex)
+	if sessionStore.phase.EndpointFamily != "codex" {
+		t.Fatalf("WorkflowPhaseEvent EndpointFamily = %q, want codex", sessionStore.phase.EndpointFamily)
 	}
 	if sessionStore.phase.PhaseType != store.WorkflowPhaseTypeAgentSession || sessionStore.phase.PhaseName != "agent_active" || sessionStore.phase.Status != FinalStateCompleted {
 		t.Fatalf("WorkflowPhaseEvent phase = %#v, want completed agent_active session", sessionStore.phase)
@@ -524,8 +524,8 @@ func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T
 				},
 				Agents: config.Agents{
 					Backends: []config.AgentBackend{
-						{ID: "codex-code", Kind: config.AgentBackendCodex, Protocol: "app-server", Command: "codex app-server"},
-						{ID: "codex-validator", Kind: config.AgentBackendCodex, Protocol: "app-server", Command: "codex app-server --profile validator"},
+						{ID: "codex-code", Kind: "codex", Protocol: "app-server", Command: "codex app-server"},
+						{ID: "codex-validator", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile validator"},
 					},
 					Routes: []config.AgentRoute{
 						{Name: "validator", Role: RoleValidator, Backend: "codex-validator", Model: "gpt-5-route-validator"},
@@ -639,7 +639,7 @@ func TestRunnerRunUsesSingleConfiguredBackendDefaultRoute(t *testing.T) {
 				Agents: config.Agents{
 					Backends: []config.AgentBackend{{
 						ID:       "codex-high",
-						Kind:     config.AgentBackendCodex,
+						Kind:     "codex",
 						Protocol: "app-server",
 						Command:  "codex app-server --profile high",
 					}},
@@ -738,7 +738,7 @@ func TestRunnerRunRoutesAtMeSelectorsWithContext(t *testing.T) {
 			cfg.Agents = config.Agents{
 				Backends: []config.AgentBackend{{
 					ID:       "codex",
-					Kind:     config.AgentBackendCodex,
+					Kind:     "codex",
 					Protocol: "app-server",
 					Command:  "codex app-server",
 				}},


### PR DESCRIPTION
## Summary

- Make agent backend options opaque and decode codex options per kind during config normalization and validation.
- Merge legacy top-level `codex:` defaults inside `AgentBackendConfigs()` so runner no longer special-cases codex backend config.
- Update codex backend construction to consume effective `CodexOptions()`.

Fixes #829

## Test Plan

- [x] `make check`