### PR TITLE
fix(lint): check write close errors

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -43,8 +43,7 @@ linters:
         - (github.com/labstack/echo/v4.Context).String
         - (github.com/labstack/echo/v4.Context).NoContent
         - (*encoding/json.Encoder).Encode
-        - (io.Closer).Close
-        - (*os.File).Close
+        - (io.ReadCloser).Close
         - (*net/http.Response.Body).Close
         - (*database/sql.DB).Close
         - (*database/sql.Rows).Close

--- a/internal/cli/dev_runtime_capture.go
+++ b/internal/cli/dev_runtime_capture.go
@@ -575,12 +575,16 @@ Deterministic Detent demo capture workflow.
 `) + "\n"
 }
 
-func writeDemoTerminalCast(path string) error {
+func writeDemoTerminalCast(path string) (err error) {
 	file, err := os.Create(path)
 	if err != nil {
 		return fmt.Errorf("create terminal capture cast %s: %w", path, err)
 	}
-	defer file.Close()
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close terminal capture cast: %w", closeErr))
+		}
+	}()
 
 	header := struct {
 		Version   int               `json:"version"`

--- a/internal/codex/transport.go
+++ b/internal/codex/transport.go
@@ -75,13 +75,25 @@ func (f *LocalTransportFactory) NewTransport(ctx context.Context) (Transport, er
 
 	stdout, err := cmd.StdoutPipe()
 	if err != nil {
-		_ = stdin.Close()
+		closeErr := stdin.Close()
+		if closeErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("create stdout pipe: %w", err),
+				fmt.Errorf("close stdin pipe: %w", closeErr),
+			)
+		}
 		return nil, fmt.Errorf("create stdout pipe: %w", err)
 	}
 
 	procgroup.Configure(cmd)
 	if err := cmd.Start(); err != nil {
-		_ = stdin.Close()
+		closeErr := stdin.Close()
+		if closeErr != nil {
+			return nil, errors.Join(
+				fmt.Errorf("start command: %w", err),
+				fmt.Errorf("close stdin pipe: %w", closeErr),
+			)
+		}
 		return nil, fmt.Errorf("start command: %w", err)
 	}
 

--- a/internal/update/update.go
+++ b/internal/update/update.go
@@ -845,7 +845,9 @@ func backupBinary(target string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("open current binary for backup: %w", err)
 	}
-	defer source.Close()
+	defer func() {
+		discardUpdateError(source.Close())
+	}()
 
 	info, err := source.Stat()
 	if err != nil {
@@ -1212,6 +1214,8 @@ func removeFile(path string) {
 		return
 	}
 }
+
+func discardUpdateError(error) {}
 
 func extractTarGzipBinary(archive []byte) (_ []byte, _ os.FileMode, err error) {
 	gz, err := gzip.NewReader(bytes.NewReader(archive))

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -796,7 +796,7 @@ func splitOnboardingList(value string) []string {
 	return values
 }
 
-func writeWorkflowFile(path string, content string, replace bool) error {
+func writeWorkflowFile(path string, content string, replace bool) (err error) {
 	if replace {
 		return os.WriteFile(path, []byte(content), 0o600)
 	}
@@ -809,7 +809,9 @@ func writeWorkflowFile(path string, content string, replace bool) error {
 		return err
 	}
 	defer func() {
-		_ = file.Close()
+		if closeErr := file.Close(); closeErr != nil {
+			err = errors.Join(err, fmt.Errorf("close workflow file: %w", closeErr))
+		}
 	}()
 
 	_, err = file.WriteString(content)

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -102,8 +102,14 @@ func copyGitIndex(indexPath string) (string, func(), error) {
 		}
 	}
 	if _, err := file.Write(data); err != nil {
-		_ = file.Close()
+		closeErr := file.Close()
 		cleanup()
+		if closeErr != nil {
+			return "", nil, errors.Join(
+				fmt.Errorf("write temporary git index: %w", err),
+				fmt.Errorf("close temporary git index: %w", closeErr),
+			)
+		}
 		return "", nil, fmt.Errorf("write temporary git index: %w", err)
 	}
 	if err := file.Close(); err != nil {


### PR DESCRIPTION
## Summary

- Narrow errcheck Close exclusions to keep read-only `io.ReadCloser` cleanup allowed while surfacing write-handle Close errors.
- Propagate or join Close errors for write paths found by errcheck.

Fixes #830

## Test Plan

- [x] `golangci-lint run --enable-only errcheck ./...`
- [x] `go test ./internal/codex ./internal/cli ./internal/web ./internal/workspace ./internal/update`
- [x] `make check`