### PR TITLE
feat(config): add claude_code backend kind

### DIFF
--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -39,6 +40,40 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	}
 	if _, ok := run.(*runnerpkg.Runner); !ok {
 		t.Fatalf("buildRunner() = %T, want *runner.Runner", run)
+	}
+}
+
+func TestBuildRunnerRejectsClaudeCodeBackendUntilFactoryWiring(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := workflowconfig.ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+workspace:
+  root: ` + strconv.Quote(t.TempDir()) + `
+agents:
+  backends:
+    - id: claude
+      kind: claude_code
+  routes:
+    - backend: claude
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	_, err = buildRunner(workflow, "alpha", "", nil, nil)
+	if err == nil {
+		t.Fatal("buildRunner() error = nil, want unsupported backend kind")
+	}
+	if !strings.Contains(err.Error(), `unsupported agent backend kind "claude_code"`) {
+		t.Fatalf("buildRunner() error = %v, want unsupported claude_code backend", err)
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -40,14 +40,22 @@ const (
 	defaultLinearEndpoint = "https://api.linear.app/graphql"
 	defaultGitHubEndpoint = "https://api.github.com/graphql"
 
-	DefaultAgentBackendID = "codex"
-	AgentBackendCodex     = "codex"
+	DefaultAgentBackendID  = "codex"
+	AgentBackendCodex      = "codex"
+	AgentBackendClaudeCode = "claude_code"
 
 	DefaultPollingIntervalMS      = 120000
 	MinPollingIntervalMS          = 60000
 	DefaultShutdownDrainTimeoutMS = 75000
 
-	defaultCodexProtocol = "app-server"
+	defaultCodexProtocol                      = "app-server"
+	defaultClaudeCodeProtocol                 = "headless"
+	defaultClaudeCodeCommand                  = "claude"
+	defaultClaudeCodePermissionMode           = "bypassPermissions"
+	claudeCodePermissionModeDefault           = "default"
+	claudeCodePermissionModeAcceptEdits       = "acceptEdits"
+	claudeCodePermissionModeBypassPermissions = "bypassPermissions"
+	claudeCodePermissionModePlan              = "plan"
 
 	IdentityOwnershipAssignee = "assignee"
 	IdentityOwnershipField    = "field"
@@ -204,9 +212,11 @@ type AgentBackend struct {
 	Command  string         `yaml:"command"`
 	Options  BackendOptions `yaml:"options"`
 
-	codexOptions    CodexOptions
-	codexOptionsSet bool
-	optionsErr      error
+	codexOptions         CodexOptions
+	codexOptionsSet      bool
+	claudeCodeOptions    ClaudeCodeOptions
+	claudeCodeOptionsSet bool
+	optionsErr           error
 }
 
 type BackendOptions struct {
@@ -221,6 +231,17 @@ type CodexOptions struct {
 	TurnTimeoutMS     int            `yaml:"turn_timeout_ms"`
 	ReadTimeoutMS     int            `yaml:"read_timeout_ms"`
 	StallTimeoutMS    int            `yaml:"stall_timeout_ms"`
+}
+
+type ClaudeCodeOptions struct {
+	PermissionMode         string   `yaml:"permission_mode"`
+	AllowedTools           []string `yaml:"allowed_tools"`
+	DisallowedTools        []string `yaml:"disallowed_tools"`
+	IncludePartialMessages bool     `yaml:"include_partial_messages"`
+	TurnTimeoutMS          int      `yaml:"turn_timeout_ms"`
+	StallTimeoutMS         int      `yaml:"stall_timeout_ms"`
+	Shell                  string   `yaml:"shell"`
+	ExtraArgs              []string `yaml:"extra_args"`
 }
 
 type AgentRoute struct {
@@ -389,21 +410,55 @@ func (b AgentBackend) decodedCodexOptions() (CodexOptions, error) {
 	return options, nil
 }
 
+func (b AgentBackend) ClaudeCodeOptions() ClaudeCodeOptions {
+	options, err := b.decodedClaudeCodeOptions()
+	if err != nil {
+		return ClaudeCodeOptions{}
+	}
+	return options
+}
+
+func (b AgentBackend) decodedClaudeCodeOptions() (ClaudeCodeOptions, error) {
+	if b.optionsErr != nil {
+		return ClaudeCodeOptions{}, b.optionsErr
+	}
+	if b.claudeCodeOptionsSet {
+		return b.claudeCodeOptions, nil
+	}
+
+	var options ClaudeCodeOptions
+	if err := b.Options.Decode(&options); err != nil {
+		return ClaudeCodeOptions{}, err
+	}
+	options.normalize()
+	return options, nil
+}
+
 func (b *AgentBackend) decodeOptions() {
 	b.codexOptions = CodexOptions{}
 	b.codexOptionsSet = false
+	b.claudeCodeOptions = ClaudeCodeOptions{}
+	b.claudeCodeOptionsSet = false
 	b.optionsErr = nil
-	if b.Kind != AgentBackendCodex {
-		return
-	}
 
-	options, err := b.decodedCodexOptions()
-	if err != nil {
-		b.optionsErr = err
-		return
+	switch b.Kind {
+	case AgentBackendCodex:
+		options, err := b.decodedCodexOptions()
+		if err != nil {
+			b.optionsErr = err
+			return
+		}
+		b.codexOptions = options
+		b.codexOptionsSet = true
+	case AgentBackendClaudeCode:
+		options, err := b.decodedClaudeCodeOptions()
+		if err != nil {
+			b.optionsErr = err
+			return
+		}
+		b.claudeCodeOptions = options
+		b.claudeCodeOptionsSet = true
 	}
-	b.codexOptions = options
-	b.codexOptionsSet = true
 }
 
 type Server struct {
@@ -1122,6 +1177,12 @@ func (a *Agents) normalize() {
 			backend.Protocol = defaultCodexProtocol
 		}
 		backend.Command = strings.TrimSpace(backend.Command)
+		if backend.Protocol == "" && backend.Kind == AgentBackendClaudeCode {
+			backend.Protocol = defaultClaudeCodeProtocol
+		}
+		if backend.Command == "" && backend.Kind == AgentBackendClaudeCode {
+			backend.Command = defaultClaudeCodeCommand
+		}
 		backend.decodeOptions()
 	}
 	for index := range a.Routes {
@@ -1161,12 +1222,19 @@ func (a *Agents) validate(problems *[]string) {
 		switch backend.Kind {
 		case "":
 			*problems = append(*problems, "agents.backends.kind is required")
-		case AgentBackendCodex:
+		case AgentBackendCodex, AgentBackendClaudeCode:
 		default:
-			*problems = append(*problems, "agents.backends.kind must be codex")
+			*problems = append(*problems, "agents.backends.kind must be one of codex, claude_code")
 		}
-		if backend.Kind == AgentBackendCodex && backend.Protocol != defaultCodexProtocol {
-			*problems = append(*problems, "agents.backends.protocol must be app-server for codex")
+		switch backend.Kind {
+		case AgentBackendCodex:
+			if backend.Protocol != defaultCodexProtocol {
+				*problems = append(*problems, "agents.backends.protocol must be app-server for codex")
+			}
+		case AgentBackendClaudeCode:
+			if backend.Protocol != defaultClaudeCodeProtocol {
+				*problems = append(*problems, "agents.backends.protocol must be headless for claude_code")
+			}
 		}
 		validateRequired("agents.backends.command", backend.Command, "", problems)
 		backend.validateOptions("agents.backends.options", problems)
@@ -1209,6 +1277,13 @@ func (b AgentBackend) validateOptions(prefix string, problems *[]string) {
 			return
 		}
 		options.validate(prefix, problems)
+	case AgentBackendClaudeCode:
+		options, err := b.decodedClaudeCodeOptions()
+		if err != nil {
+			*problems = append(*problems, prefix+" must decode for claude_code: "+err.Error())
+			return
+		}
+		options.validate(prefix, problems)
 	}
 }
 
@@ -1226,6 +1301,33 @@ func (o CodexOptions) validate(prefix string, problems *[]string) {
 	}
 	if o.ReadTimeoutMS < 0 {
 		*problems = append(*problems, prefix+".read_timeout_ms must be greater than or equal to 0")
+	}
+	if o.StallTimeoutMS < 0 {
+		*problems = append(*problems, prefix+".stall_timeout_ms must be greater than or equal to 0")
+	}
+}
+
+func (o *ClaudeCodeOptions) normalize() {
+	o.PermissionMode = strings.TrimSpace(o.PermissionMode)
+	if o.PermissionMode == "" {
+		o.PermissionMode = defaultClaudeCodePermissionMode
+	}
+	o.Shell = strings.TrimSpace(o.Shell)
+	if o.Shell != "" {
+		o.Shell = commandshell.Normalize(o.Shell)
+	}
+}
+
+func (o ClaudeCodeOptions) validate(prefix string, problems *[]string) {
+	switch o.PermissionMode {
+	case claudeCodePermissionModeDefault, claudeCodePermissionModeAcceptEdits, claudeCodePermissionModeBypassPermissions:
+	case claudeCodePermissionModePlan:
+		*problems = append(*problems, prefix+".permission_mode must not be plan for unattended workers")
+	default:
+		*problems = append(*problems, prefix+".permission_mode must be one of default, acceptEdits, bypassPermissions")
+	}
+	if o.TurnTimeoutMS < 0 {
+		*problems = append(*problems, prefix+".turn_timeout_ms must be greater than or equal to 0")
 	}
 	if o.StallTimeoutMS < 0 {
 		*problems = append(*problems, prefix+".stall_timeout_ms must be greater than or equal to 0")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -844,6 +844,81 @@ Prompt
 	}
 }
 
+func TestParseWorkflowClaudeCodeAgentBackendConfig(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: claude-worker
+      kind: claude_code
+      options:
+        allowed_tools:
+          - Bash
+          - Edit
+        disallowed_tools:
+          - WebFetch
+        include_partial_messages: true
+        turn_timeout_ms: 600000
+        stall_timeout_ms: 0
+        shell: bash
+        extra_args:
+          - --model
+          - claude-sonnet-4
+  routes:
+    - backend: claude-worker
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	backends := workflow.Config.AgentBackendConfigs()
+	if len(backends) != 1 {
+		t.Fatalf("AgentBackendConfigs() len = %d, want 1", len(backends))
+	}
+	backend := backends[0]
+	if backend.ID != "claude-worker" || backend.Kind != AgentBackendClaudeCode || backend.Protocol != "headless" {
+		t.Fatalf("backend identity = %#v, want claude-worker claude_code headless", backend)
+	}
+	if backend.Command != "claude" {
+		t.Fatalf("backend Command = %q, want default claude", backend.Command)
+	}
+
+	options := backend.ClaudeCodeOptions()
+	if options.PermissionMode != "bypassPermissions" {
+		t.Fatalf("permission mode = %q, want bypassPermissions", options.PermissionMode)
+	}
+	if !reflect.DeepEqual(options.AllowedTools, []string{"Bash", "Edit"}) {
+		t.Fatalf("allowed tools = %#v, want Bash/Edit", options.AllowedTools)
+	}
+	if !reflect.DeepEqual(options.DisallowedTools, []string{"WebFetch"}) {
+		t.Fatalf("disallowed tools = %#v, want WebFetch", options.DisallowedTools)
+	}
+	if !options.IncludePartialMessages {
+		t.Fatal("include partial messages = false, want true")
+	}
+	if options.TurnTimeoutMS != 600000 {
+		t.Fatalf("turn timeout = %d, want 600000", options.TurnTimeoutMS)
+	}
+	if options.StallTimeoutMS != 0 {
+		t.Fatalf("stall timeout = %d, want 0", options.StallTimeoutMS)
+	}
+	if options.Shell != "bash" {
+		t.Fatalf("shell = %q, want bash", options.Shell)
+	}
+	if !reflect.DeepEqual(options.ExtraArgs, []string{"--model", "claude-sonnet-4"}) {
+		t.Fatalf("extra args = %#v, want model args", options.ExtraArgs)
+	}
+}
+
 func TestAgentBackendConfigsMergesLegacyCodexDefaults(t *testing.T) {
 	t.Parallel()
 
@@ -1570,11 +1645,31 @@ agents:
 Prompt
 `,
 			want: []string{
-				"agents.backends.kind must be codex",
+				"agents.backends.kind must be one of codex, claude_code",
 				"agents.backends.command is required",
 				"agents.routes.backend must reference a configured backend",
 				"agents.routes.selector.priority_in values must be integers 1 through 4",
 				"agents.routes must not define multiple default routes for the same role",
+			},
+		},
+		{
+			name: "invalid claude code protocol",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: claude
+      kind: claude_code
+      protocol: app-server
+  routes:
+    - backend: claude
+      default: true
+---
+Prompt
+`,
+			want: []string{
+				"agents.backends.protocol must be headless for claude_code",
 			},
 		},
 		{
@@ -1598,6 +1693,71 @@ Prompt
 `,
 			want: []string{
 				"agents.backends.options must decode for codex",
+			},
+		},
+		{
+			name: "invalid claude code permission mode",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: claude
+      kind: claude_code
+      options:
+        permission_mode: ask
+  routes:
+    - backend: claude
+      default: true
+---
+Prompt
+`,
+			want: []string{
+				"agents.backends.options.permission_mode must be one of default, acceptEdits, bypassPermissions",
+			},
+		},
+		{
+			name: "invalid claude code plan permission mode",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: claude
+      kind: claude_code
+      options:
+        permission_mode: plan
+  routes:
+    - backend: claude
+      default: true
+---
+Prompt
+`,
+			want: []string{
+				"agents.backends.options.permission_mode must not be plan for unattended workers",
+			},
+		},
+		{
+			name: "invalid claude code option timeouts",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: claude
+      kind: claude_code
+      options:
+        turn_timeout_ms: -1
+        stall_timeout_ms: -1
+  routes:
+    - backend: claude
+      default: true
+---
+Prompt
+`,
+			want: []string{
+				"agents.backends.options.turn_timeout_ms must be greater than or equal to 0",
+				"agents.backends.options.stall_timeout_ms must be greater than or equal to 0",
 			},
 		},
 		{


### PR DESCRIPTION
## Summary

- Add the `claude_code` agent backend kind, headless/default command normalization, and typed Claude Code backend options.
- Validate Claude Code permission mode and timeout options while keeping runtime factory wiring unsupported for now.
- Cover valid defaults, invalid options, and the interim unsupported factory state with tests.

Fixes #831

## Test Plan

- [x] `go test ./internal/config ./internal/cli ./internal/runner`
- [x] `make check`