### PR TITLE
feat(cli): wire claude_code backend

### DIFF
--- a/internal/claudecode/backend.go
+++ b/internal/claudecode/backend.go
@@ -24,8 +24,11 @@ var (
 
 type CommandFactory func(context.Context) *exec.Cmd
 
+type CommandFactoryWithArgs func(context.Context, []string) *exec.Cmd
+
 type Options struct {
 	CommandFactory         CommandFactory
+	CommandFactoryWithArgs CommandFactoryWithArgs
 	PermissionMode         string
 	AllowedTools           []string
 	DisallowedTools        []string
@@ -44,7 +47,7 @@ type AgentBackend struct {
 var _ runner.AgentBackend = (*AgentBackend)(nil)
 
 func NewAgentBackend(options Options) (*AgentBackend, error) {
-	if options.CommandFactory == nil {
+	if options.CommandFactory == nil && options.CommandFactoryWithArgs == nil {
 		options.CommandFactory = defaultCommandFactory
 	}
 	if options.MaxScanTokenSize <= 0 {

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -90,7 +90,13 @@ func (b *AgentBackend) RunTurn(
 }
 
 func (b *AgentBackend) command(ctx context.Context, req runner.AgentTurnRequest) (*exec.Cmd, error) {
-	cmd := b.options.CommandFactory(ctx)
+	argv := b.argv(req)
+	var cmd *exec.Cmd
+	if b.options.CommandFactoryWithArgs != nil {
+		cmd = b.options.CommandFactoryWithArgs(ctx, argv)
+	} else {
+		cmd = b.options.CommandFactory(ctx)
+	}
 	if cmd == nil {
 		return nil, ErrNilCommand
 	}
@@ -98,7 +104,9 @@ func (b *AgentBackend) command(ctx context.Context, req runner.AgentTurnRequest)
 	if len(cmd.Args) == 0 {
 		cmd.Args = []string{cmd.Path}
 	}
-	cmd.Args = append(cmd.Args, b.argv(req)...)
+	if b.options.CommandFactoryWithArgs == nil {
+		cmd.Args = append(cmd.Args, argv...)
+	}
 	return cmd, nil
 }
 

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -177,8 +177,8 @@ func buildClaudeAgentBackend(command string, cfg workflowconfig.ClaudeCodeOption
 	}
 
 	backend, err := claudecode.NewAgentBackend(claudecode.Options{
-		CommandFactory: func(ctx context.Context) *exec.Cmd {
-			return buildClaudeCommandFromConfig(ctx, command, cfg.Shell)
+		CommandFactoryWithArgs: func(ctx context.Context, args []string) *exec.Cmd {
+			return buildClaudeCommandFromConfig(ctx, command, cfg.Shell, args)
 		},
 		PermissionMode:         cfg.PermissionMode,
 		AllowedTools:           cfg.AllowedTools,
@@ -234,8 +234,8 @@ func buildCodexCommandFromConfig(ctx context.Context, command string, shell stri
 	return commandshell.Command(ctx, strings.TrimSpace(command), shell)
 }
 
-func buildClaudeCommandFromConfig(ctx context.Context, command string, shell string) *exec.Cmd {
-	return commandshell.Command(ctx, strings.TrimSpace(command)+` "$0" "$@"`, shell)
+func buildClaudeCommandFromConfig(ctx context.Context, command string, shell string, args []string) *exec.Cmd {
+	return commandshell.CommandWithArgs(ctx, strings.TrimSpace(command), shell, args)
 }
 
 // publishSnapshots ticks at interval, building a merged telemetry snapshot

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/budget"
+	"github.com/digitaldrywood/detent/internal/claudecode"
 	"github.com/digitaldrywood/detent/internal/codex"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
@@ -158,9 +159,39 @@ func buildAgentBackend(backend workflowconfig.AgentBackend) (runnerpkg.AgentBack
 	switch backend.Kind {
 	case workflowconfig.AgentBackendCodex:
 		return buildCodexAgentBackend(backend.Command, backend.CodexOptions())
+	case workflowconfig.AgentBackendClaudeCode:
+		return buildClaudeAgentBackend(backend.Command, backend.ClaudeCodeOptions())
 	default:
-		return nil, fmt.Errorf("unsupported agent backend kind %q", backend.Kind)
+		return nil, fmt.Errorf("unsupported agent backend kind %q; supported kinds: %s, %s",
+			backend.Kind,
+			workflowconfig.AgentBackendCodex,
+			workflowconfig.AgentBackendClaudeCode,
+		)
 	}
+}
+
+func buildClaudeAgentBackend(command string, cfg workflowconfig.ClaudeCodeOptions) (runnerpkg.AgentBackend, error) {
+	command = strings.TrimSpace(command)
+	if command == "" {
+		return nil, errors.New("claude command is required")
+	}
+
+	backend, err := claudecode.NewAgentBackend(claudecode.Options{
+		CommandFactory: func(ctx context.Context) *exec.Cmd {
+			return buildClaudeCommandFromConfig(ctx, command, cfg.Shell)
+		},
+		PermissionMode:         cfg.PermissionMode,
+		AllowedTools:           cfg.AllowedTools,
+		DisallowedTools:        cfg.DisallowedTools,
+		IncludePartialMessages: cfg.IncludePartialMessages,
+		ExtraArgs:              cfg.ExtraArgs,
+		TurnTimeout:            durationFromMillis(cfg.TurnTimeoutMS),
+		StallTimeout:           durationFromMillis(cfg.StallTimeoutMS),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("create claude backend: %w", err)
+	}
+	return backend, nil
 }
 
 func buildCodexAgentBackend(command string, cfg workflowconfig.CodexOptions) (runnerpkg.AgentBackend, error) {
@@ -201,6 +232,10 @@ func buildCodexCommand(ctx context.Context, cfg workflowconfig.Config) *exec.Cmd
 
 func buildCodexCommandFromConfig(ctx context.Context, command string, shell string) *exec.Cmd {
 	return commandshell.Command(ctx, strings.TrimSpace(command), shell)
+}
+
+func buildClaudeCommandFromConfig(ctx context.Context, command string, shell string) *exec.Cmd {
+	return commandshell.Command(ctx, strings.TrimSpace(command)+` "$0" "$@"`, shell)
 }
 
 // publishSnapshots ticks at interval, building a merged telemetry snapshot

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/hub"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
@@ -43,23 +44,52 @@ func TestBuildRunnerReturnsRunner(t *testing.T) {
 	}
 }
 
-func TestBuildRunnerRejectsClaudeCodeBackendUntilFactoryWiring(t *testing.T) {
+func TestBuildRunnerSupportsClaudeCodeBackendRoutes(t *testing.T) {
 	t.Parallel()
+
+	source := initRunnerSourceRepo(t)
+	claudeCommand, argsPath, stdinPath := writeRunnerClaudeStub(t)
+	sessionStore := &runnerSessionStore{sessionID: 833}
+	startedAt := time.Date(2026, 7, 2, 13, 30, 0, 0, time.UTC)
 
 	workflow, err := workflowconfig.ParseWorkflow([]byte(`---
 tracker:
   kind: memory
 workspace:
-  root: ` + strconv.Quote(t.TempDir()) + `
+  root: ` + strconv.Quote(filepath.Join(t.TempDir(), "workspaces")) + `
 agents:
   backends:
-    - id: claude
+    - id: codex-main
+      kind: codex
+      command: codex app-server
+    - id: claude-worker
       kind: claude_code
+      command: ` + strconv.Quote(runnerShellQuote(claudeCommand)) + `
+      options:
+        permission_mode: acceptEdits
+        allowed_tools:
+          - Bash
+          - Edit
+        disallowed_tools:
+          - WebFetch
+        include_partial_messages: true
+        turn_timeout_ms: 60000
+        stall_timeout_ms: 10000
+        shell: sh
+        extra_args:
+          - --custom
+          - value
   routes:
-    - backend: claude
+    - name: validator-codex
+      role: validator
+      backend: codex-main
+      model: gpt-5-codex
+    - name: code-claude
+      backend: claude-worker
+      model: fable
       default: true
 ---
-Prompt
+Prompt {{ issue.identifier }}
 `))
 	if err != nil {
 		t.Fatalf("ParseWorkflow() error = %v", err)
@@ -68,12 +98,79 @@ Prompt
 		t.Fatalf("Validate() error = %v", err)
 	}
 
-	_, err = buildRunner(workflow, "alpha", "", nil, nil)
-	if err == nil {
-		t.Fatal("buildRunner() error = nil, want unsupported backend kind")
+	run, err := buildRunner(workflow, "detent", source, sessionStore, nil)
+	if err != nil {
+		t.Fatalf("buildRunner() error = %v", err)
 	}
-	if !strings.Contains(err.Error(), `unsupported agent backend kind "claude_code"`) {
-		t.Fatalf("buildRunner() error = %v, want unsupported claude_code backend", err)
+
+	result, err := run.Run(context.Background(), runnerpkg.RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-833",
+			Identifier: "digitaldrywood/detent#833",
+			Title:      "Wire claude_code into agent backend factory",
+			BranchName: "detent/issue-833",
+		},
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	if result.FinalState != runnerpkg.FinalStateCompleted || result.Output != "claude streamed" {
+		t.Fatalf("Run() result = %#v, want completed claude streamed output", result)
+	}
+	if result.Tokens.InputTokens != 11 || result.Tokens.OutputTokens != 5 || result.Tokens.TotalTokens != 16 {
+		t.Fatalf("Run() tokens = %#v, want final claude usage", result.Tokens)
+	}
+	if sessionStore.started.Model != "fable" || sessionStore.usage.Model != "fable" {
+		t.Fatalf("recorded models = start %q usage %q, want fable", sessionStore.started.Model, sessionStore.usage.Model)
+	}
+	if sessionStore.phase.EndpointFamily != workflowconfig.AgentBackendClaudeCode {
+		t.Fatalf("WorkflowPhaseEvent EndpointFamily = %q, want claude_code", sessionStore.phase.EndpointFamily)
+	}
+	if sessionStore.phase.TotalTokens != 16 {
+		t.Fatalf("WorkflowPhaseEvent TotalTokens = %d, want 16", sessionStore.phase.TotalTokens)
+	}
+
+	args := readRunnerLines(t, argsPath)
+	wantPrefix := []string{
+		"-p", "--output-format", "stream-json", "--verbose",
+		"--model", "fable",
+		"--permission-mode", "acceptEdits",
+		"--allowedTools", "Bash", "Edit",
+		"--disallowedTools", "WebFetch",
+		"--include-partial-messages",
+	}
+	if len(args) < len(wantPrefix) {
+		t.Fatalf("claude args = %#v, want prefix %#v", args, wantPrefix)
+	}
+	if !runnerStringPrefix(args, wantPrefix) {
+		t.Fatalf("claude args = %#v, want prefix %#v", args, wantPrefix)
+	}
+	if len(args) < 2 || args[len(args)-2] != "--custom" || args[len(args)-1] != "value" {
+		t.Fatalf("claude args = %#v, want extra args at end", args)
+	}
+	stdin := readRunnerFile(t, stdinPath)
+	if !strings.Contains(stdin, "Prompt digitaldrywood/detent#833") {
+		t.Fatalf("claude stdin = %q, want rendered issue prompt", stdin)
+	}
+}
+
+func TestBuildAgentBackendUnsupportedKindNamesSupportedKinds(t *testing.T) {
+	t.Parallel()
+
+	_, err := buildAgentBackend(workflowconfig.AgentBackend{
+		ID:      "local-llama",
+		Kind:    "llama",
+		Command: "llama",
+	})
+	if err == nil {
+		t.Fatal("buildAgentBackend() error = nil, want unsupported kind")
+	}
+	for _, want := range []string{"unsupported agent backend kind \"llama\"", "supported kinds: codex, claude_code"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("buildAgentBackend() error = %v, missing %q", err, want)
+		}
 	}
 }
 
@@ -893,6 +990,84 @@ func readRunnerFile(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(raw)
+}
+
+func readRunnerLines(t *testing.T, path string) []string {
+	t.Helper()
+
+	raw := strings.TrimSuffix(readRunnerFile(t, path), "\n")
+	if raw == "" {
+		return []string{}
+	}
+	return strings.Split(raw, "\n")
+}
+
+func runnerStringPrefix(values []string, prefix []string) bool {
+	if len(values) < len(prefix) {
+		return false
+	}
+	for index, want := range prefix {
+		if values[index] != want {
+			return false
+		}
+	}
+	return true
+}
+
+func writeRunnerClaudeStub(t *testing.T) (string, string, string) {
+	t.Helper()
+
+	dir := t.TempDir()
+	scriptPath := filepath.Join(dir, "claude-stub")
+	argsPath := filepath.Join(dir, "claude-args.txt")
+	stdinPath := filepath.Join(dir, "claude-stdin.txt")
+	lines := []string{
+		"#!/bin/sh",
+		"printf '%s\\n' \"$@\" > " + runnerShellQuote(argsPath),
+		"cat > " + runnerShellQuote(stdinPath),
+		"printf '%s\\n' " + runnerShellQuote(`{"type":"system","subtype":"init","session_id":"session-cli","model":"fable"}`),
+		"printf '%s\\n' " + runnerShellQuote(`{"type":"stream_event","session_id":"session-cli","event":{"type":"message_start","message":{"id":"msg-cli","type":"message","role":"assistant","model":"fable","content":[]}}}`),
+		"printf '%s\\n' " + runnerShellQuote(`{"type":"stream_event","session_id":"session-cli","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"claude "}}}`),
+		"printf '%s\\n' " + runnerShellQuote(`{"type":"stream_event","session_id":"session-cli","event":{"type":"content_block_delta","index":0,"delta":{"type":"text_delta","text":"streamed"}}}`),
+		"printf '%s\\n' " + runnerShellQuote(`{"type":"assistant","session_id":"session-cli","message":{"id":"msg-cli","type":"message","role":"assistant","model":"fable","content":[{"type":"text","text":"ignored full text"}],"usage":{"input_tokens":7,"output_tokens":3}}}`),
+		"printf '%s\\n' " + runnerShellQuote(`{"type":"result","subtype":"success","session_id":"session-cli","usage":{"input_tokens":11,"output_tokens":5}}`),
+	}
+	if err := os.WriteFile(scriptPath, []byte(strings.Join(lines, "\n")+"\n"), 0o700); err != nil {
+		t.Fatalf("write claude stub: %v", err)
+	}
+	return scriptPath, argsPath, stdinPath
+}
+
+func runnerShellQuote(value string) string {
+	return "'" + strings.ReplaceAll(value, "'", "'\"'\"'") + "'"
+}
+
+type runnerSessionStore struct {
+	sessionID int64
+	started   store.SessionStart
+	finished  store.SessionFinish
+	usage     store.UsageEvent
+	phase     store.WorkflowPhaseEvent
+}
+
+func (s *runnerSessionStore) StartSession(_ context.Context, attrs store.SessionStart) (int64, error) {
+	s.started = attrs
+	return s.sessionID, nil
+}
+
+func (s *runnerSessionStore) FinishSession(_ context.Context, _ int64, attrs store.SessionFinish) error {
+	s.finished = attrs
+	return nil
+}
+
+func (s *runnerSessionStore) RecordUsageEvent(_ context.Context, attrs store.UsageEvent) (int64, error) {
+	s.usage = attrs
+	return 1, nil
+}
+
+func (s *runnerSessionStore) RecordWorkflowPhaseEvent(_ context.Context, attrs store.WorkflowPhaseEvent) (int64, error) {
+	s.phase = attrs
+	return 1, nil
 }
 
 func newRefreshProjectWithConnector(t *testing.T, id string, projectConnector connector.Connector) *projectpkg.Project {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -45,6 +45,15 @@ func CommandForOS(ctx context.Context, command string, shellName string, goos st
 	return exec.CommandContext(ctx, spec.Name, spec.Args...) // #nosec G204 -- workflow shell and command are operator-supplied.
 }
 
+func CommandWithArgs(ctx context.Context, command string, shellName string, args []string) *exec.Cmd {
+	return CommandWithArgsForOS(ctx, command, shellName, args, runtime.GOOS)
+}
+
+func CommandWithArgsForOS(ctx context.Context, command string, shellName string, args []string, goos string) *exec.Cmd {
+	spec := CommandSpecWithArgsForOS(command, shellName, args, goos)
+	return exec.CommandContext(ctx, spec.Name, spec.Args...) // #nosec G204 -- workflow shell and command are operator-supplied.
+}
+
 func CommandSpecForOS(command string, shellName string, goos string) CommandSpec {
 	shellName = NormalizeForOS(shellName, goos)
 	if goos != "windows" {
@@ -64,10 +73,67 @@ func CommandSpecForOS(command string, shellName string, goos string) CommandSpec
 	}
 }
 
+func CommandSpecWithArgsForOS(command string, shellName string, args []string, goos string) CommandSpec {
+	return CommandSpecForOS(commandWithArgsForOS(command, shellName, args, goos), shellName, goos)
+}
+
+func commandWithArgsForOS(command string, shellName string, args []string, goos string) string {
+	if len(args) == 0 {
+		return command
+	}
+
+	quote := argQuoterForOS(shellName, goos)
+	parts := make([]string, 0, len(args)+1)
+	parts = append(parts, command)
+	for _, arg := range args {
+		parts = append(parts, quote(arg))
+	}
+	return strings.Join(parts, " ")
+}
+
+func argQuoterForOS(shellName string, goos string) func(string) string {
+	shellName = NormalizeForOS(shellName, goos)
+	base := shellBase(shellName)
+	if goos == "windows" {
+		switch {
+		case isPowerShell(base):
+			return quotePowerShellArg
+		case isPOSIXShell(base):
+			return quotePOSIXArg
+		default:
+			return quoteCmdArg
+		}
+	}
+	return quotePOSIXArg
+}
+
+func quotePOSIXArg(arg string) string {
+	return "'" + strings.ReplaceAll(arg, "'", "'\\''") + "'"
+}
+
+func quotePowerShellArg(arg string) string {
+	return "'" + strings.ReplaceAll(arg, "'", "''") + "'"
+}
+
+func quoteCmdArg(arg string) string {
+	arg = strings.ReplaceAll(arg, "%", "%%")
+	arg = strings.ReplaceAll(arg, `"`, `\"`)
+	return `"` + arg + `"`
+}
+
 func shellBase(name string) string {
 	name = strings.ReplaceAll(name, "\\", "/")
 	base := strings.ToLower(path.Base(name))
 	return strings.TrimSuffix(base, ".exe")
+}
+
+func isPowerShell(base string) bool {
+	switch base {
+	case "powershell", "pwsh":
+		return true
+	default:
+		return false
+	}
 }
 
 func isPOSIXShell(base string) bool {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -116,6 +116,60 @@ func TestCommandSpecUsesConfiguredShell(t *testing.T) {
 	}
 }
 
+func TestCommandSpecWithArgsQuotesForConfiguredShell(t *testing.T) {
+	t.Parallel()
+
+	args := []string{"-p", "--model", "fable", "Bash(git *)", "quoted'value", "percent%value"}
+	tests := []struct {
+		name     string
+		goos     string
+		shell    string
+		wantName string
+		wantArgs []string
+	}{
+		{
+			name:     "unix",
+			goos:     "linux",
+			wantName: "sh",
+			wantArgs: []string{"-c", "claude '-p' '--model' 'fable' 'Bash(git *)' 'quoted'\\''value' 'percent%value'"},
+		},
+		{
+			name:     "windows cmd",
+			goos:     "windows",
+			wantName: "cmd",
+			wantArgs: []string{"/C", `claude "-p" "--model" "fable" "Bash(git *)" "quoted'value" "percent%%value"`},
+		},
+		{
+			name:     "windows powershell",
+			goos:     "windows",
+			shell:    "pwsh",
+			wantName: "pwsh",
+			wantArgs: []string{"-NoLogo", "-NoProfile", "-NonInteractive", "-Command", "claude '-p' '--model' 'fable' 'Bash(git *)' 'quoted''value' 'percent%value'"},
+		},
+		{
+			name:     "windows posix shell",
+			goos:     "windows",
+			shell:    "bash",
+			wantName: "bash",
+			wantArgs: []string{"-c", "claude '-p' '--model' 'fable' 'Bash(git *)' 'quoted'\\''value' 'percent%value'"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := CommandSpecWithArgsForOS("claude", tt.shell, args, tt.goos)
+			if got.Name != tt.wantName {
+				t.Fatalf("Name = %q, want %q", got.Name, tt.wantName)
+			}
+			if !reflect.DeepEqual(got.Args, tt.wantArgs) {
+				t.Fatalf("Args = %#v, want %#v", got.Args, tt.wantArgs)
+			}
+		})
+	}
+}
+
 func TestCommandBuildsExecCommand(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Wire `claude_code` into the CLI agent backend factory switch.
- Map `ClaudeCodeOptions` into `claudecode.Options`, including command shell handling and timeouts.
- Add dual-backend runner coverage for Claude route execution and `endpoint_family = "claude_code"` telemetry.

Fixes #833

## Test Plan

- [x] `go test ./internal/cli`
- [x] `go test ./internal/cli ./internal/claudecode ./internal/runner`
- [x] `make check`