### PR TITLE
feat(tracker): add github local status backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -1277,9 +1277,11 @@ repo is a real, working instance of this setup to copy from.
 
    The maintained templates are
    [`WORKFLOW.project_v2.md`](docs/templates/WORKFLOW.project_v2.md),
-   [`WORKFLOW.issue_field.md`](docs/templates/WORKFLOW.issue_field.md), and
-   [`WORKFLOW.label.md`](docs/templates/WORKFLOW.label.md). Non-code artifact
-   workflows can start from
+   [`WORKFLOW.issue_field.md`](docs/templates/WORKFLOW.issue_field.md),
+   [`WORKFLOW.label.md`](docs/templates/WORKFLOW.label.md), and the CLI-only
+   local-status template
+   [`WORKFLOW.github_local.md`](docs/templates/WORKFLOW.github_local.md).
+   Non-code artifact workflows can start from
    [`WORKFLOW.non_code_artifact.md`](docs/templates/WORKFLOW.non_code_artifact.md).
    They set `server.kanban.mode: integration` for trusted project boards;
    change that to `read_only` only for an observer or shared dashboard,
@@ -1298,9 +1300,16 @@ repo is a real, working instance of this setup to copy from.
    issue_field`, `tracker.repository: <repo-owner>/<repo-name>`, and optionally
    `tracker.status_field`. For boardless label mode, set
    `tracker.github_status_source: label`, `tracker.repository:
-   <repo-owner>/<repo-name>`, and `tracker.status_label_prefix`. In every mode,
-   set `workspace.source_root` (`<source-root>`), `workspace.root` (a worktrees
-   directory), `write_probe_issue` when using write probes, and the prompt body.
+   <repo-owner>/<repo-name>`, and `tracker.status_label_prefix`. For
+   externally owned or open-source repositories where Detent must not pollute
+   issues, labels, fields, Projects, or issue comments, use
+   `tracker.kind: github_local` from `WORKFLOW.github_local.md`; do not set
+   `tracker.github_status_source`, configure `tracker.local_sqlite.path`, and
+   import explicit issue numbers with
+   `detent github-local import <project-id> <issue-number> --state Todo`. In
+   every mode, set `workspace.source_root` (`<source-root>`), `workspace.root`
+   (a worktrees directory), `write_probe_issue` when using write probes, and the
+   prompt body.
    If the repository already has a `WORKFLOW.md`, audit its prompt body for the
    same Required Execution Flow and `Current Detent status: {{ issue.state }}`
    line before dispatching Detent against it.
@@ -1367,11 +1376,12 @@ repo is a real, working instance of this setup to copy from.
    access; it is not limited to Tailscale.
 
 10. **Dispatch work.** Move an issue to `Todo` through the configured status
-    source: ProjectV2 `Status`, issue-field `Status`, or the `detent:todo`
-    status label. Detent claims it, creates an isolated worktree, dispatches an
-    agent, and the issue appears under Running on the dashboard. Drive the rest
-    through the configured status source (`Todo` → `In Progress` →
-    `Human Review` → `Merging` → `Done`).
+    source: ProjectV2 `Status`, issue-field `Status`, the `detent:todo` status
+    label, or the local SQLite state used by `github_local`. Detent claims it,
+    creates an isolated worktree, dispatches an agent, and the issue appears
+    under Running on the dashboard. Drive the rest through the configured
+    status source (`Todo` → `In Progress` → `Human Review` → `Merging` →
+    `Done`).
 
 ## Concepts
 
@@ -1379,9 +1389,9 @@ repo is a real, working instance of this setup to copy from.
 
 Detent isolates tracker integration behind a connector interface. The current
 production connector is GitHub. It supports the current ProjectV2-backed board
-mode, boardless issue-field mode, and boardless label mode. A memory connector
-is available for local development, and the connector boundary is where GitLab
-and Jira support will land later.
+mode, boardless issue-field mode, boardless label mode, and `github_local`
+hybrid mode. A memory connector is available for local development, and the
+connector boundary is where GitLab and Jira support will land later.
 
 GitHub configuration lives in each project's `WORKFLOW.md` frontmatter. The
 default `github_status_source: project_v2` mode uses `project_slug` as the
@@ -1394,6 +1404,14 @@ that field for state transitions. Boardless `github_status_source: label` mode
 uses `repository: owner/name` and repository labels named by
 `status_label_prefix`; Detent reads issues by configured status labels and
 updates state by replacing the previous status label with the target one.
+`tracker.kind: github_local` is a separate backend, not a fourth
+`tracker.github_status_source` value. GitHub is read-only for issue, dependency,
+parent/child, comment, PR, review, check, and rate-limit facts; Detent's SQLite
+database is the source of truth for workflow state, claim fields, audit-trail
+comments, priority, and local close decisions. In this mode Detent does not
+create or mutate GitHub Projects, issue fields, repository labels, status
+labels, GitHub issue comments, or GitHub issue close state. Pull request
+lifecycle writes for Detent-owned PRs remain allowlisted.
 Set `tracker.write_probe_issue` to a scratch issue already present on that
 ProjectV2 board or in the boardless repository if
 `detent doctor --allow-write-probes` should prove write operations by replaying
@@ -1538,6 +1556,15 @@ You choose where GitHub status lives; Detent fills in the rest.
   label at a time. Detent's Kanban/dashboard view becomes the board surface; no
   GitHub ProjectV2 board, `tracker.project_slug`, or organization issue field
   is needed.
+- **GitHub local-status mode:** configure `tracker.kind: github_local`,
+  `tracker.repository: owner/name`, and `tracker.local_sqlite.path`. Do not set
+  `tracker.github_status_source`. Import issues explicitly with
+  `detent github-local import <project-id> 123,456 --state Todo`; unimported
+  issues do not appear on Detent boards. Detent updates local workflow state
+  only, while GitHub remains the read-only source for issue text, labels,
+  assignees, dependencies, linked PRs, reviews, checks, and rate-limit health.
+  The board surfaces divergence such as an upstream-closed issue that is still
+  locally active.
 - **Blank `Status` values and missing status labels are not `Backlog`.** In the
   current release, an issue with no configured issue-field value or status label
   is not dispatchable through the state machine. Put unready work in the
@@ -1553,7 +1580,8 @@ You choose where GitHub status lives; Detent fills in the rest.
   label to untracked issues, and close or relabel stale-open terminal issues.
 - **Detent reads** status, priority, labels, blockers, assignees, and linked
   pull requests from each issue, and **writes back** status transitions and a
-  `## Codex Workpad` comment as the agent works.
+  `## Codex Workpad` comment as the agent works, except in `github_local`,
+  where those workflow writes are durable local records.
 
 ### Kanban Modes
 
@@ -1593,6 +1621,22 @@ one configured status label per issue, then change the workflow to
 ProjectV2 items or issue-field values into labels. After the switch, run
 `detent doctor --port 0 --allow-write-probes` and fix label mapping, issue reads
 by label, write-probe, comment-write, and rate-limit checks before dispatching.
+
+To switch a repository to local-only status mode, copy
+`docs/templates/WORKFLOW.github_local.md`, set `tracker.repository`,
+`tracker.local_sqlite.path`, workspace paths, and the prompt body, then import
+only the issue numbers Detent should see:
+
+```sh
+detent github-local import <project-id> 123,456 --state Todo
+detent doctor --project <project-id> --port 0
+```
+
+This mode does not migrate or mutate GitHub status data. Existing ProjectV2
+items, issue fields, labels, and GitHub issue comments stay untouched. If
+GitHub closes or transfers an imported issue while local state is still active,
+Detent keeps the local row and surfaces the divergence on the board instead of
+auto-resolving it.
 
 ### Dependency workflows
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1779,8 +1779,11 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    human-authored contract without explicit approval. The maintained templates
    are `docs/templates/WORKFLOW.project_v2.md`,
    `docs/templates/WORKFLOW.issue_field.md`, and
-   `docs/templates/WORKFLOW.label.md`. Non-code artifact projects can start
-   from `docs/templates/WORKFLOW.non_code_artifact.md`; the rest of this
+   `docs/templates/WORKFLOW.label.md`. The CLI-only local-status template is
+   `docs/templates/WORKFLOW.github_local.md`; use it when the target repository
+   must remain read-only and Detent status should live only in local SQLite.
+   Non-code artifact projects can start from
+   `docs/templates/WORKFLOW.non_code_artifact.md`; the rest of this
    onboarding flow remains GitHub-focused. The `/onboarding` web wizard can
    write the same tracker blocks interactively: choose **Repository labels**
    for `GITHUB_MODE=label`, enter the repository and status label prefix such
@@ -1853,6 +1856,24 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      write_probe_issue: <write-probe-issue>
    ```
 
+   GitHub local-status tracker snippet:
+
+   ```yaml
+   tracker:
+     kind: github_local
+     repository: <repo-owner>/<repo-name>
+     local_sqlite:
+       path: .detent/github-local-work-items.db
+   ```
+
+   Do not add `tracker.github_status_source` to `github_local`; it is a
+   composite backend, not a fourth GitHub status source. Import issues
+   explicitly after the project is registered:
+
+   ```sh
+   detent github-local import <local-detent-project-id> <issue-number>[,<issue-number>...] --state Todo
+   ```
+
    ```sh
    # ProjectV2 mode:
    PROJECT_NODE_ID="$(jq -r '.id' "$ONBOARDING_DIR/project.json")"
@@ -1863,6 +1884,9 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
 
    # Label mode:
    rg -n 'github_status_source: label|repository: <repo-owner>/<repo-name>|status_label_prefix: "<status-label-prefix>"|write_probe_issue:' <source-root>/WORKFLOW.md
+
+   # GitHub local-status mode:
+   rg -n 'kind: github_local|repository: <repo-owner>/<repo-name>|local_sqlite:|path: .detent/github-local-work-items.db' <source-root>/WORKFLOW.md
 
    # All modes:
    perl -0pi -e 's#(?m)^  source_root: .*$#  source_root: <source-root>#' <source-root>/WORKFLOW.md
@@ -2735,11 +2759,40 @@ write-probe, comment-write, and rate-limit checks before dispatching. GitHub
 status labels apply to issues only, so linked PR cards derive status from the
 linked issue.
 
+Use local-only GitHub status mode when GitHub issues and PRs should remain
+read-only inputs. Change `WORKFLOW.md` to:
+
+```yaml
+tracker:
+  kind: github_local
+  repository: <repo-owner>/<repo-name>
+  local_sqlite:
+    path: .detent/github-local-work-items.db
+```
+
+Do not set `tracker.github_status_source` for this mode. Detent reads issue
+bodies, labels, assignees, dependencies, linked pull requests, reviews, checks,
+and rate-limit health from GitHub, but stores Detent workflow state, priority,
+claim fields, audit comments, and local close decisions in SQLite. It does not
+create or mutate GitHub Projects, issue fields, repository labels, status
+labels, GitHub issue comments, or GitHub issue close state. Import explicit
+issues only:
+
+```sh
+detent github-local import <local-detent-project-id> 123,456 --state Todo
+detent doctor --project <local-detent-project-id> --port 0
+```
+
+Unimported issues stay invisible on Detent boards. If an imported issue is
+closed upstream while still locally active, Detent surfaces that divergence on
+the card instead of auto-resolving it.
+
 ### Interview Answers To Config Keys
 
 | Interview answer | Config or system target |
 | --- | --- |
 | GitHub status source | `tracker.github_status_source: project_v2`, `issue_field`, or `label` in `WORKFLOW.md`. |
+| GitHub local status | `tracker.kind: github_local`, `tracker.repository`, and `tracker.local_sqlite.path`; no `tracker.github_status_source`. |
 | Board node id | `tracker.project_slug` in `WORKFLOW.md` for ProjectV2 mode only. |
 | Boardless repository | `tracker.repository` in `WORKFLOW.md` for issue-field and label modes. |
 | Boardless issue field | `tracker.status_field` in `WORKFLOW.md`; defaults to `Status` when omitted. |

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -1,0 +1,168 @@
+---
+tracker:
+  kind: github_local
+  repository: <repo-owner>/<repo-name>
+  local_sqlite:
+    path: .detent/github-local-work-items.db
+    project_id: <local-detent-project-id>
+  http_max_idle_conns: 100
+  http_max_idle_conns_per_host: 32
+  http_idle_conn_timeout_ms: 90000
+  github_graphql_warn_remaining: 500
+  github_graphql_min_remaining_reserve: 1000
+  github_rest_min_remaining_reserve: 1000
+  github_rest_fanout_max_requests: 80
+  auto_provision: false
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
+  terminal_states:
+    - Done
+    - Cancelled
+  state_map:
+    Cancelled: Done
+  priority_map:
+    Urgent: 1
+    High: 2
+    Medium: 3
+    Low: 4
+    No priority: null
+  dependency_auto_unblock:
+    enabled: false
+    source_states:
+      - Blocked
+    target_state: Todo
+    readiness: terminal_or_merged
+  blocker_auto_promote:
+    enabled: false
+    blocker_states:
+      - Backlog
+      - Blocked
+      - Human Review
+    target_state: Todo
+polling:
+  interval_ms: 120000
+workspace:
+  root: <worktree-root>
+  source_root: <source-root>
+  auto_branch: true
+  cleanup_idle_ttl_ms: 86400000
+  cleanup_sweep_interval_ms: 600000
+agent:
+  max_concurrent_agents: 5
+  max_turns: 20
+  max_retry_backoff_ms: 300000
+  max_concurrent_agents_by_state:
+    Merging: 1
+  dispatch_priority_by_state:
+    - Merging
+    - Rework
+    - In Progress
+    - Todo
+  dispatch_priority_by_label: []
+  auto_promote:
+    enabled: false
+    quiet_seconds: 600
+    optout_label: requires-human-review
+    allowed_issue_labels: []
+  skills:
+    enabled: true
+    path: .detent/skills
+    max_skills_in_prompt: 50
+codex:
+  command: codex app-server
+  approval_policy: never
+  thread_sandbox: workspace-write
+  turn_sandbox_policy:
+    type: workspaceWrite
+    networkAccess: true
+gate:
+  kind: command
+  run: make check
+  require_automated_review: true
+  ci_failure_action: rework
+  transient_ci_retry_limit: 2
+  validator:
+    enabled: false
+    model: ""
+    min_score: 0.8
+    block_on:
+      - p1
+plan:
+  enabled: false
+  review: human
+  approval_label: plan-approved
+  stop: "Plan Review"
+server:
+  host: 127.0.0.1
+  port: 4000
+  kanban:
+    mode: integration
+hooks:
+  timeout_ms: 60000
+---
+You are working on {{ issue.identifier }}: {{ issue.title }}.
+Current Detent status: {{ issue.state }}.
+
+This workflow uses `tracker.kind: github_local`. GitHub issues and pull
+requests are read-only inputs. Detent status, claim fields, audit-trail
+comments, and close decisions stay in the local SQLite database configured by
+`tracker.local_sqlite.path`; do not add `tracker.github_status_source` to this
+file.
+
+Import issues explicitly before dispatching:
+
+```sh
+detent github-local import <local-detent-project-id> <issue-number>[,<issue-number>...] --state Todo
+detent doctor --project <local-detent-project-id> --port 0
+```
+
+Follow repository instructions, keep changes scoped to the issue, and keep the
+local `## Codex Workpad` record updated through Detent events. GitHub issue
+comments, labels, Projects, issue fields, and issue close state must remain
+untouched. Pull request comments and merges created by Detent are allowed for
+Detent-owned PR lifecycle work.
+
+## Required Execution Flow
+
+Use the current Detent state as the source of truth for which section applies.
+
+### For Todo
+
+1. Move the issue to `In Progress`.
+2. Fetch current `origin/main`, confirm this worktree is based on it, and
+   confirm every `Depends on:` or `Blocked by:` issue or pull request is merged
+   or otherwise terminal before coding.
+3. Reproduce or confirm the reported behavior before changing code when the
+   issue is a bug.
+4. Implement the smallest complete change that satisfies the issue.
+5. Run focused tests for touched packages, then run the configured validation
+   gate.
+6. Commit and push the branch.
+7. Open or update a pull request that references the issue.
+8. Move the issue to `Human Review` only after local validation passes and the
+   PR is ready.
+
+### For In Progress
+
+Continue implementation from the current repository state. If implementation is
+complete, run the validation gate, push the PR branch, and move the issue to
+`Human Review`.
+
+### For Rework
+
+Read all review feedback, fix the requested changes, rerun validation, push the
+branch, and move the issue back to `Human Review` only when the gate passes.
+
+### For Merging
+
+Rebase onto current `origin/main`, rerun the configured validation gate, push,
+watch current-head CI, merge with the configured PR workflow once green, and
+move the issue to `Done`. If an external blocker remains, keep the issue in
+`Merging` and record the exact blocker locally.

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -414,6 +414,7 @@ detent --format json config path`),
 			project.Paused = false
 			return nil
 		}),
+		newGitHubLocalCommand(&configPath, opts),
 		newConfigCommand(&configPath, opts),
 		newOnboardingCommand(&configPath, opts),
 		newPromoteCommand(&configPath, opts),

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -30,6 +30,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/factory"
 	ghconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/dependencyline"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
@@ -844,7 +845,7 @@ func checkDoctorProjectWithProgress(
 		setDoctorCurrentCheck("Project " + id + " auto-promote")
 		checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
 	}
-	if workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHub {
+	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		if workflow.Config.Tracker.GitHubStatusSource == workflowconfig.GitHubStatusSourceLabel {
 			setDoctorCurrentCheck("Project " + id + " label status drift")
 			checks = append(checks, checkDoctorLabelStatusDrift(ctx, id, workflow.Config, deps))
@@ -854,7 +855,7 @@ func checkDoctorProjectWithProgress(
 		setDoctorCurrentCheck("Project " + id + " blocked recovery")
 		checks = append(checks, checkDoctorBlockedRecovery(ctx, id, workflow.Config, deps))
 	}
-	if workflow.Config.Tracker.Kind == workflowconfig.TrackerLocalSQLite {
+	if workflow.Config.Tracker.Kind == workflowconfig.TrackerLocalSQLite || workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
 		setDoctorCurrentCheck("Project " + id + " local SQLite tracker")
 		checks = append(checks, checkDoctorLocalSQLiteTracker(ctx, id, project, workflow.Config, deps))
 	}
@@ -897,7 +898,7 @@ func checkDoctorProjectWithProgress(
 		Status: doctorOK,
 		Detail: expandedSourceRoot + " is a git worktree",
 	})
-	if workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHub {
+	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		setDoctorCurrentCheck("Project " + id + " GitHub readiness")
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
@@ -945,7 +946,7 @@ func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.C
 			Hint:   "Add " + reworkState + " to tracker.active_states or tracker.terminal_states.",
 		}
 	}
-	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
+	if !doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
@@ -1399,7 +1400,7 @@ type doctorDependencyDiagnostic struct {
 
 func checkDoctorBlockedRecovery(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
 	name := "Project " + id + " blocked recovery"
-	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
+	if !doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
@@ -1564,7 +1565,7 @@ func doctorBlockedRecoveryIssueLabel(candidate doctorBlockedRecoveryCandidateDia
 
 func checkDoctorDependencyAutoUnblock(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
 	name := "Project " + id + " dependency auto-unblock"
-	if cfg.Tracker.Kind != workflowconfig.TrackerGitHub {
+	if !doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
@@ -2314,8 +2315,16 @@ func closeDoctorAutoPromoteConnector(projectConnector doctorAutoPromoteConnector
 
 func defaultDoctorAutoPromoteConnector(cfg workflowconfig.Config) (doctorAutoPromoteConnector, error) {
 	return factory.NewFromConfig(factory.Config{
-		Kind:                        cfg.Tracker.Kind,
-		Memory:                      memory.Config{Issues: cfg.Tracker.Issues},
+		Kind:   cfg.Tracker.Kind,
+		Memory: memory.Config{Issues: cfg.Tracker.Issues},
+		LocalSQLite: local.Config{
+			Path:           cfg.Tracker.LocalSQLite.Path,
+			ProjectID:      cfg.Tracker.LocalSQLite.ProjectID,
+			Issues:         cfg.Tracker.Issues,
+			ActiveStates:   cfg.Tracker.ActiveStates,
+			ObservedStates: cfg.Tracker.ObservedStates,
+			TerminalStates: cfg.Tracker.TerminalStates,
+		},
 		Endpoint:                    cfg.Tracker.Endpoint,
 		APIKey:                      cfg.Tracker.APIKey,
 		HTTPMaxIdleConns:            cfg.Tracker.HTTPMaxIdleConns,
@@ -2445,6 +2454,20 @@ func doctorGitHubReadinessConfig(
 	githubToken RuntimeSecret,
 	sourceRoot string,
 ) ghconnector.ReadinessConfig {
+	if cfg.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
+		return ghconnector.ReadinessConfig{
+			AuthPath:                      doctorGitHubAuthPath(cfg, githubToken, deps.lookupEnv),
+			LocalStatusMode:               true,
+			Repositories:                  doctorGitHubRepositories(ctx, project, cfg, deps, sourceRoot),
+			RequireIssueCommentsRead:      true,
+			RequireDependencyMetadataRead: true,
+			RequireIssueChildrenRead:      doctorRequiresIssueChildrenRead(cfg),
+			RequireIssueParentsRead:       doctorRequiresIssueParentsRead(cfg),
+			RequirePullRequestRead:        true,
+			RequirePullRequestReviews:     true,
+			RequirePullRequestChecks:      true,
+		}
+	}
 	return ghconnector.ReadinessConfig{
 		AuthPath:                      doctorGitHubAuthPath(cfg, githubToken, deps.lookupEnv),
 		WriteProbeIssue:               cfg.Tracker.WriteProbeIssue,
@@ -2729,10 +2752,14 @@ func doctorTrackerStateMap(value workflowconfig.StringOrMap) map[string]string {
 
 func doctorWorkflowConfigWithRuntimeGitHubToken(cfg workflowconfig.Config, token string) workflowconfig.Config {
 	token = strings.TrimSpace(token)
-	if token != "" && cfg.Tracker.Kind == workflowconfig.TrackerGitHub {
+	if token != "" && doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) {
 		cfg.Tracker.APIKey = token
 	}
 	return cfg
+}
+
+func doctorTrackerUsesGitHubReads(kind string) bool {
+	return kind == workflowconfig.TrackerGitHub || kind == workflowconfig.TrackerGitHubLocal
 }
 
 func checkDoctorConfigReload(cfg globalconfig.Config) doctorCheck {
@@ -3223,7 +3250,7 @@ func doctorHasGitHubProject(ctx context.Context, cfg *globalconfig.Config, deps 
 	if cfg != nil {
 		for _, project := range cfg.Projects {
 			workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
-			if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+			if err != nil || !doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 				continue
 			}
 			return true
@@ -3238,7 +3265,7 @@ func doctorRequiresRuntimeGitHubToken(ctx context.Context, cfg *globalconfig.Con
 	}
 	for _, project := range cfg.Projects {
 		workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
-		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+		if err != nil || !doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 			continue
 		}
 		if trackerHasGitHubAppCredentials(workflow.Config.Tracker, deps.lookupEnv) {
@@ -3291,19 +3318,25 @@ func doctorRequiredGitHubScopes(ctx context.Context, cfg *globalconfig.Config, d
 	}
 	for _, project := range cfg.Projects {
 		workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
-		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+		if err != nil || !doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 			continue
 		}
 		if trackerHasGitHubAppCredentials(workflow.Config.Tracker, deps.lookupEnv) {
 			continue
 		}
+		if workflow.Config.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
+			add(requiredLabelGitHubScopes)
+			continue
+		}
 		switch workflow.Config.Tracker.GitHubStatusSource {
+		case workflowconfig.GitHubStatusSourceProjectV2:
+			add(requiredProjectV2GitHubScopes)
 		case workflowconfig.GitHubStatusSourceIssueField:
 			add(requiredIssueFieldGitHubScopes)
 		case workflowconfig.GitHubStatusSourceLabel:
 			add(requiredLabelGitHubScopes)
 		default:
-			add(requiredProjectV2GitHubScopes)
+			add(requiredLabelGitHubScopes)
 		}
 	}
 	if len(required) == 0 {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2189,6 +2189,32 @@ func TestCheckDoctorSQLite(t *testing.T) {
 	}
 }
 
+func TestDoctorGitHubLocalReadinessUsesLocalStatusMode(t *testing.T) {
+	t.Parallel()
+
+	workflow := validDoctorWorkflow("/repo")
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHubLocal
+	workflow.Tracker.Repository = "digitaldrywood/detent"
+	workflow.Tracker.LocalSQLite.Path = ".detent/work-items.db"
+	workflow.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+	workflow.Tracker.ObservedStates = []string{"Blocked", "Human Review"}
+	workflow.Tracker.TerminalStates = []string{"Done"}
+
+	got := doctorGitHubReadinessConfig(context.Background(), globalconfig.Project{Workdir: "/repo"}, workflow, doctorDeps{}, RuntimeSecret{}, "/repo")
+	if !got.LocalStatusMode {
+		t.Fatalf("LocalStatusMode = false, want true")
+	}
+	if got.RequireProjectRead || got.RequireProjectStatusWrite || got.RequireIssueFieldStatusWrite || got.RequireLabelStatusWrite || got.RequireIssueComments {
+		t.Fatalf("write/status requirements = %#v, want local-only status mode", got)
+	}
+	if !got.RequireIssueCommentsRead || !got.RequireDependencyMetadataRead || !got.RequirePullRequestRead || !got.RequirePullRequestReviews || !got.RequirePullRequestChecks {
+		t.Fatalf("read requirements = %#v, want GitHub issue/PR/check reads", got)
+	}
+	if len(got.Repositories) != 1 || got.Repositories[0] != "digitaldrywood/detent" {
+		t.Fatalf("Repositories = %#v, want digitaldrywood/detent", got.Repositories)
+	}
+}
+
 func TestCheckDoctorLocalSQLiteTrackerResolvesProjectRelativePath(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/github_local.go
+++ b/internal/cli/github_local.go
@@ -1,0 +1,302 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/factory"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+	projectpkg "github.com/digitaldrywood/detent/internal/project"
+)
+
+type githubLocalImportResult struct {
+	Status   string                     `json:"status"`
+	Project  string                     `json:"project"`
+	Imported []githubLocalImportedIssue `json:"imported"`
+}
+
+type githubLocalImportedIssue struct {
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
+	Title      string `json:"title"`
+	State      string `json:"state"`
+	URL        string `json:"url"`
+}
+
+type githubLocalImporter interface {
+	ImportIssues(context.Context, []int, string) ([]connector.Issue, error)
+	Close() error
+}
+
+func newGitHubLocalCommand(configPath *string, opts options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "github-local",
+		Short:   "Manage github_local tracker state",
+		Example: "detent github-local import detent 779 --state Todo",
+	}
+	cmd.AddCommand(newGitHubLocalImportCommand(configPath, opts))
+	return cmd
+}
+
+func newGitHubLocalImportCommand(configPath *string, opts options) *cobra.Command {
+	var state string
+	cmd := &cobra.Command{
+		Use:     "import PROJECT_ID ISSUE_NUMBER...",
+		Short:   "Import explicit GitHub issues into local tracker state",
+		Example: "detent github-local import detent 779 780,781 --state Todo",
+		Args: func(cmd *cobra.Command, args []string) error {
+			return WrapValidation(cobra.MinimumNArgs(2)(cmd, args))
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			numbers, err := parseGitHubLocalIssueNumbers(args[1:])
+			if err != nil {
+				return err
+			}
+			result, err := runGitHubLocalImport(cmd.Context(), *configPath, args[0], numbers, state, opts)
+			if err != nil {
+				return err
+			}
+			return out.Write(func(out io.Writer) error {
+				_, err := fmt.Fprintf(out, "imported %d issue(s) into %s\n", len(result.Imported), result.Project)
+				return err
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&state, "state", "", "local Detent state to assign to imported issues")
+	return cmd
+}
+
+func runGitHubLocalImport(ctx context.Context, configPath string, projectID string, numbers []int, state string, opts options) (result githubLocalImportResult, err error) {
+	resolution, err := resolveConfigPathResolution(configPath, opts)
+	if err != nil {
+		return result, err
+	}
+	cfg, _, err := opts.readProject(resolution.Path, projectID)
+	if err != nil {
+		return result, err
+	}
+	if len(cfg.Projects) == 0 {
+		return result, fmt.Errorf("%w: %s", ErrProjectNotFound, projectID)
+	}
+	project := cfg.Projects[0]
+	workflow, err := projectpkg.LoadWorkflowContext(ctx, project)
+	if err != nil {
+		return result, err
+	}
+	workflow.Config = githubLocalWorkflowConfig(project, workflow.Config)
+	workflow.Config, err = githubLocalWorkflowConfigWithGlobalToken(ctx, cfg, workflow.Config, opts)
+	if err != nil {
+		return result, err
+	}
+	if workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHubLocal {
+		return result, fmt.Errorf("project %q uses tracker.kind %q, want github_local", project.ID, workflow.Config.Tracker.Kind)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		return result, err
+	}
+
+	conn, err := githubLocalConnectorFromWorkflow(ctx, workflow.Config)
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		if closeErr := conn.Close(); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+
+	imported, err := conn.ImportIssues(ctx, numbers, state)
+	if err != nil {
+		return result, err
+	}
+	return githubLocalImportResult{
+		Status:   "ok",
+		Project:  project.ID,
+		Imported: githubLocalImportedIssues(imported),
+	}, nil
+}
+
+func parseGitHubLocalIssueNumbers(values []string) ([]int, error) {
+	out := []int{}
+	seen := map[int]struct{}{}
+	for _, value := range values {
+		for _, part := range strings.Split(value, ",") {
+			part = strings.TrimSpace(part)
+			if part == "" {
+				continue
+			}
+			number, err := strconv.Atoi(part)
+			if err != nil || number <= 0 {
+				return nil, WrapValidation(fmt.Errorf("issue number %q must be a positive integer", part))
+			}
+			if _, ok := seen[number]; ok {
+				continue
+			}
+			seen[number] = struct{}{}
+			out = append(out, number)
+		}
+	}
+	if len(out) == 0 {
+		return nil, WrapValidation(errors.New("at least one issue number is required"))
+	}
+	return out, nil
+}
+
+func githubLocalConnectorFromWorkflow(ctx context.Context, cfg workflowconfig.Config) (githubLocalImporter, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	conn, err := factory.NewFromConfig(factory.Config{
+		Kind: cfg.Tracker.Kind,
+		LocalSQLite: local.Config{
+			Path:           cfg.Tracker.LocalSQLite.Path,
+			ProjectID:      cfg.Tracker.LocalSQLite.ProjectID,
+			Issues:         cfg.Tracker.Issues,
+			ActiveStates:   cfg.Tracker.ActiveStates,
+			ObservedStates: cfg.Tracker.ObservedStates,
+			TerminalStates: cfg.Tracker.TerminalStates,
+		},
+		Endpoint:                    cfg.Tracker.Endpoint,
+		APIKey:                      cfg.Tracker.APIKey,
+		HTTPMaxIdleConns:            cfg.Tracker.HTTPMaxIdleConns,
+		HTTPMaxIdleConnsPerHost:     cfg.Tracker.HTTPMaxIdleConnsPerHost,
+		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
+		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
+		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
+		GitHubAppID:                 cfg.Tracker.GitHubAppID,
+		GitHubAppPrivateKey:         cfg.Tracker.GitHubAppPrivateKey,
+		GitHubAppPrivateKeyPath:     cfg.Tracker.GitHubAppPrivateKeyPath,
+		GitHubAppInstallationID:     cfg.Tracker.GitHubAppInstallationID,
+		Repository:                  cfg.Tracker.Repository,
+		StatusField:                 cfg.Tracker.StatusField,
+		StatusLabelPrefix:           cfg.Tracker.StatusLabelPrefix,
+		ActiveStates:                cfg.Tracker.ActiveStates,
+		ObservedStates:              cfg.Tracker.ObservedStates,
+		TerminalStates:              cfg.Tracker.TerminalStates,
+		StateMap:                    githubLocalTrackerStateMap(cfg.Tracker.StateMap),
+		PriorityMap:                 githubLocalTrackerPriorityMap(cfg.Tracker.PriorityMap),
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		if closer, ok := conn.(connector.Closer); ok {
+			return nil, errors.Join(err, closer.Close())
+		}
+		return nil, err
+	}
+	importer, ok := conn.(githubLocalImporter)
+	if !ok {
+		typeErr := fmt.Errorf("connector %T does not support github_local import", conn)
+		if closer, ok := conn.(connector.Closer); ok {
+			return nil, errors.Join(typeErr, closer.Close())
+		}
+		return nil, typeErr
+	}
+	return importer, nil
+}
+
+func githubLocalWorkflowConfig(project globalconfig.Project, cfg workflowconfig.Config) workflowconfig.Config {
+	workdir := strings.TrimSpace(project.Workdir)
+	if workdir == "" {
+		return cfg
+	}
+	if cfg.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
+		cfg.Tracker.LocalSQLite.Path = githubLocalProjectRelativePath(workdir, cfg.Tracker.LocalSQLite.Path)
+	}
+	return cfg
+}
+
+func githubLocalWorkflowConfigWithGlobalToken(ctx context.Context, global globalconfig.Config, cfg workflowconfig.Config, opts options) (workflowconfig.Config, error) {
+	if strings.TrimSpace(cfg.Tracker.APIKey) != "" || strings.TrimSpace(global.GitHubToken) == "" {
+		return cfg, nil
+	}
+	token, err := resolveConfiguredGitHubToken(ctx, global.GitHubToken, runtimeDeps{
+		lookupEnv:   opts.lookupEnv,
+		ghAuthToken: opts.ghAuthToken,
+	})
+	if err != nil {
+		return cfg, err
+	}
+	cfg.Tracker.APIKey = token.Value
+	return cfg, nil
+}
+
+func githubLocalProjectRelativePath(base string, path string) string {
+	path = strings.TrimSpace(path)
+	if path == "" || filepath.IsAbs(path) || path == "~" || strings.HasPrefix(path, "~/") {
+		return path
+	}
+	return filepath.Clean(filepath.Join(base, path))
+}
+
+func githubLocalImportedIssues(issues []connector.Issue) []githubLocalImportedIssue {
+	out := make([]githubLocalImportedIssue, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, githubLocalImportedIssue{
+			ID:         issue.ID,
+			Identifier: issue.Identifier,
+			Title:      issue.Title,
+			State:      issue.State,
+			URL:        issue.URL,
+		})
+	}
+	return out
+}
+
+func githubLocalTrackerStateMap(value workflowconfig.StringOrMap) map[string]string {
+	if !value.IsMap {
+		return nil
+	}
+	out := make(map[string]string, len(value.Map))
+	for state, mapped := range value.Map {
+		mappedState, ok := mapped.(string)
+		if !ok {
+			continue
+		}
+		state = strings.TrimSpace(state)
+		mappedState = strings.TrimSpace(mappedState)
+		if state != "" && mappedState != "" {
+			out[state] = mappedState
+		}
+	}
+	return out
+}
+
+func githubLocalTrackerPriorityMap(value workflowconfig.StringOrMap) map[string]*int {
+	if !value.IsMap {
+		return nil
+	}
+	out := make(map[string]*int, len(value.Map))
+	for name, rank := range value.Map {
+		name = strings.TrimSpace(name)
+		if name == "" {
+			continue
+		}
+		switch rank := rank.(type) {
+		case nil:
+			out[name] = nil
+		case int:
+			rankValue := rank
+			out[name] = &rankValue
+		}
+	}
+	return out
+}

--- a/internal/cli/github_local_test.go
+++ b/internal/cli/github_local_test.go
@@ -1,0 +1,123 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/cli"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+func TestGitHubLocalImportCommandImportsExplicitIssue(t *testing.T) {
+	t.Parallel()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch {
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent":
+			writeCLIJSON(t, w, map[string]any{"id": 123, "full_name": "digitaldrywood/detent"})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent/issues/779":
+			body := "Issue body"
+			writeCLIJSON(t, w, map[string]any{
+				"node_id":    "I_kwDOtest779",
+				"number":     779,
+				"title":      "Add local status mode",
+				"body":       body,
+				"state":      "open",
+				"html_url":   "https://github.com/digitaldrywood/detent/issues/779",
+				"created_at": "2026-07-01T12:00:00Z",
+				"updated_at": "2026-07-02T12:00:00Z",
+				"user":       map[string]any{"login": "octocat"},
+				"labels":     []map[string]string{{"name": "enhancement"}},
+			})
+		case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent/pulls":
+			writeCLIJSON(t, w, []map[string]any{})
+		default:
+			http.NotFound(w, r)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "repo")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	workflowPath := filepath.Join(workdir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(githubLocalWorkflow(server.URL)), 0o644); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+	configPath := filepath.Join(root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{{
+		ID:       "detent",
+		Workflow: workflowPath,
+		Workdir:  workdir,
+		Weight:   1,
+		Priority: 1,
+	}})
+
+	var out bytes.Buffer
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	cmd.SetOut(&out)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{"--config", configPath, "--format", "json", "github-local", "import", "detent", "779", "--state", "Todo"})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+
+	var result struct {
+		Status   string `json:"status"`
+		Project  string `json:"project"`
+		Imported []struct {
+			ID         string `json:"id"`
+			Identifier string `json:"identifier"`
+			State      string `json:"state"`
+		} `json:"imported"`
+	}
+	if err := json.Unmarshal(out.Bytes(), &result); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output=%s", err, out.String())
+	}
+	if result.Status != "ok" || result.Project != "detent" || len(result.Imported) != 1 {
+		t.Fatalf("result = %#v", result)
+	}
+	if result.Imported[0].ID != "github:123:779" ||
+		result.Imported[0].Identifier != "digitaldrywood/detent#779" ||
+		result.Imported[0].State != "Todo" {
+		t.Fatalf("imported issue = %#v", result.Imported[0])
+	}
+}
+
+func githubLocalWorkflow(serverURL string) string {
+	return `---
+tracker:
+  kind: github_local
+  endpoint: ` + serverURL + `/graphql
+  api_key: ghp_test
+  repository: digitaldrywood/detent
+  local_sqlite:
+    path: .detent/work-items.db
+  active_states:
+    - Todo
+    - In Progress
+  terminal_states:
+    - Done
+workspace:
+  root: .detent/workspaces
+  source_root: .
+---
+Prompt
+`
+}
+
+func writeCLIJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/internal/cli/runtime.go
+++ b/internal/cli/runtime.go
@@ -295,7 +295,7 @@ func trackerGitHubToken(ctx context.Context, cfg *globalconfig.Config, deps runt
 	requiresRuntimeToken := false
 	for _, project := range cfg.Projects {
 		workflow, err := loadRuntimeProjectWorkflow(ctx, project, deps)
-		if err != nil || workflow.Config.Tracker.Kind != workflowconfig.TrackerGitHub {
+		if err != nil || !trackerUsesGitHubToken(workflow.Config.Tracker.Kind) {
 			continue
 		}
 		if trackerHasGitHubAppCredentials(workflow.Config.Tracker, deps.lookupEnv) {
@@ -310,6 +310,10 @@ func trackerGitHubToken(ctx context.Context, cfg *globalconfig.Config, deps runt
 		requiresRuntimeToken = true
 	}
 	return RuntimeSecret{}, requiresRuntimeToken
+}
+
+func trackerUsesGitHubToken(kind string) bool {
+	return kind == workflowconfig.TrackerGitHub || kind == workflowconfig.TrackerGitHubLocal
 }
 
 func loadRuntimeProjectWorkflow(ctx context.Context, project globalconfig.Project, deps runtimeDeps) (workflowconfig.Workflow, error) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,7 @@ const (
 	TrackerLinear      = "linear"
 	TrackerMemory      = "memory"
 	TrackerLocalSQLite = "local_sqlite"
+	TrackerGitHubLocal = "github_local"
 
 	GitHubStatusSourceProjectV2  = "project_v2"
 	GitHubStatusSourceIssueField = "issue_field"
@@ -122,6 +123,8 @@ type Tracker struct {
 	Authorization               selector.Selector     `yaml:"authorization,omitempty"`
 	LocalSQLite                 LocalSQLite           `yaml:"local_sqlite,omitempty"`
 	Issues                      []connector.Issue     `yaml:"issues"`
+
+	gitHubStatusSourceSet bool
 }
 
 type LocalSQLite struct {
@@ -664,9 +667,11 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 			return Workflow{}, errors.New("workflow frontmatter must be a mapping")
 		}
 		normalizeTrackerIDFields(root)
+		gitHubStatusSourceSet := trackerFieldSet(root, "github_status_source")
 		if err := root.Decode(&cfg); err != nil {
 			return Workflow{}, fmt.Errorf("decode YAML frontmatter: %w", err)
 		}
+		cfg.Tracker.gitHubStatusSourceSet = gitHubStatusSourceSet
 	}
 
 	cfg.normalize()
@@ -914,7 +919,7 @@ func cloneYAMLNode(in *yaml.Node) *yaml.Node {
 func (c *Config) normalize() {
 	c.Identity.Normalize()
 	c.Tracker.Kind = strings.ToLower(strings.TrimSpace(c.Tracker.Kind))
-	if c.Tracker.Kind == TrackerGitHub && c.Tracker.Endpoint == defaultLinearEndpoint {
+	if (c.Tracker.Kind == TrackerGitHub || c.Tracker.Kind == TrackerGitHubLocal) && c.Tracker.Endpoint == defaultLinearEndpoint {
 		c.Tracker.Endpoint = defaultGitHubEndpoint
 	}
 	c.Tracker.GitHubStatusSource = normalizeGitHubStatusSource(c.Tracker.GitHubStatusSource)
@@ -975,11 +980,13 @@ func (c *Config) validateTracker(problems *[]string) {
 	case TrackerGitHub:
 		c.Tracker.validateGitHubAuth(problems)
 		c.Tracker.validateGitHubStatusSource(problems)
+	case TrackerGitHubLocal:
+		c.Tracker.validateGitHubLocal(problems)
 	case TrackerMemory:
 	case TrackerLocalSQLite:
 		*problems = append(*problems, c.Tracker.LocalSQLite.Validate("tracker.local_sqlite")...)
 	default:
-		*problems = append(*problems, "tracker.kind must be one of github, linear, memory, local_sqlite")
+		*problems = append(*problems, "tracker.kind must be one of github, github_local, linear, memory, local_sqlite")
 	}
 
 	validateStateList("tracker.active_states", c.Tracker.ActiveStates, problems)
@@ -1045,6 +1052,10 @@ func (t *Tracker) validateGitHubStatusSource(problems *[]string) {
 }
 
 func (t *Tracker) validateGitHubAuth(problems *[]string) {
+	t.validateGitHubAuthFor("github", problems)
+}
+
+func (t *Tracker) validateGitHubAuthFor(kind string, problems *[]string) {
 	if strings.TrimSpace(t.APIKey) != "" || t.hasGitHubAppCredentials() {
 		return
 	}
@@ -1053,7 +1064,7 @@ func (t *Tracker) validateGitHubAuth(problems *[]string) {
 		strings.TrimSpace(t.GitHubAppInstallationID) == "" &&
 		strings.TrimSpace(t.GitHubAppPrivateKey) == "" &&
 		strings.TrimSpace(t.GitHubAppPrivateKeyPath) == "" {
-		*problems = append(*problems, "tracker.api_key or GitHub App credentials are required for github")
+		*problems = append(*problems, "tracker.api_key or GitHub App credentials are required for "+kind)
 		return
 	}
 
@@ -1061,6 +1072,18 @@ func (t *Tracker) validateGitHubAuth(problems *[]string) {
 	validateRequired("tracker.github_app_installation_id", t.GitHubAppInstallationID, " for github app", problems)
 	if strings.TrimSpace(t.GitHubAppPrivateKey) == "" && strings.TrimSpace(t.GitHubAppPrivateKeyPath) == "" {
 		*problems = append(*problems, "tracker.github_app_private_key or tracker.github_app_private_key_path is required for github app")
+	}
+}
+
+func (t *Tracker) validateGitHubLocal(problems *[]string) {
+	t.validateGitHubAuthFor(TrackerGitHubLocal, problems)
+	validateRequired("tracker.repository", t.Repository, " for github_local", problems)
+	if strings.TrimSpace(t.Repository) != "" && !validRepositoryName(t.Repository) {
+		*problems = append(*problems, "tracker.repository must be owner/name")
+	}
+	*problems = append(*problems, t.LocalSQLite.Validate("tracker.local_sqlite")...)
+	if t.gitHubStatusSourceSet {
+		*problems = append(*problems, "tracker.github_status_source must be omitted when tracker.kind is github_local; Detent stores workflow status in tracker.local_sqlite")
 	}
 }
 
@@ -1565,6 +1588,14 @@ func normalizeTrackerIDFields(root *yaml.Node) {
 
 	normalizeScalarField(tracker, "github_app_id")
 	normalizeScalarField(tracker, "github_app_installation_id")
+}
+
+func trackerFieldSet(root *yaml.Node, key string) bool {
+	tracker := mappingValue(root, "tracker")
+	if tracker == nil || tracker.Kind != yaml.MappingNode {
+		return false
+	}
+	return mappingValue(tracker, key) != nil
 }
 
 func mappingValue(node *yaml.Node, key string) *yaml.Node {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1321,6 +1321,64 @@ Produce the video artifact.
 	}
 }
 
+func TestParseWorkflowGitHubLocalTracker(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: github_local
+  api_key: ghp_example
+  repository: digitaldrywood/detent
+  local_sqlite:
+    path: .detent/work-items.db
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	cfg := workflow.Config
+	if cfg.Tracker.Kind != TrackerGitHubLocal {
+		t.Fatalf("Tracker.Kind = %q, want %q", cfg.Tracker.Kind, TrackerGitHubLocal)
+	}
+	if cfg.Tracker.Endpoint != defaultGitHubEndpoint {
+		t.Fatalf("Tracker.Endpoint = %q, want %q", cfg.Tracker.Endpoint, defaultGitHubEndpoint)
+	}
+	if cfg.Tracker.GitHubStatusSource != GitHubStatusSourceProjectV2 {
+		t.Fatalf("GitHubStatusSource default changed to %q", cfg.Tracker.GitHubStatusSource)
+	}
+}
+
+func TestParseWorkflowGitHubLocalRejectsGitHubStatusSource(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: github_local
+  api_key: ghp_example
+  repository: digitaldrywood/detent
+  github_status_source: label
+  local_sqlite:
+    path: .detent/work-items.db
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	err = workflow.Config.Validate()
+	if err == nil {
+		t.Fatal("Validate() error = nil, want github_status_source rejection")
+	}
+	if !strings.Contains(err.Error(), "tracker.github_status_source must be omitted when tracker.kind is github_local") {
+		t.Fatalf("Validate() error = %q, want github_status_source rejection", err)
+	}
+}
+
 func TestParseWorkflowNormalizesGitHubAppIDs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/backend.go
+++ b/internal/connector/backend.go
@@ -6,6 +6,7 @@ const (
 	BackendMemory      Backend = "memory"
 	BackendLinear      Backend = "linear"
 	BackendGitHub      Backend = "github"
+	BackendGitHubLocal Backend = "github_local"
 	BackendLocalSQLite Backend = "local_sqlite"
 	BackendGitLab      Backend = "gitlab"
 	BackendJira        Backend = "jira"

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/connector/githublocal"
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 )
@@ -87,6 +88,52 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 			StateMap:                cfg.StateMap,
 			PriorityMap:             cfg.PriorityMap,
 		})
+	case connector.BackendGitHubLocal:
+		var tokenSource githubconnector.TokenSource
+		if strings.TrimSpace(cfg.APIKey) != "" && cfg.GitHubTokenRefresh != nil && !cfg.hasGitHubAppCredentials() {
+			tokenSource = githubconnector.NewRefreshableTokenSource(cfg.APIKey, cfg.GitHubTokenRefresh)
+		}
+		localCfg := cfg.LocalSQLite
+		if len(localCfg.ActiveStates) == 0 {
+			localCfg.ActiveStates = cloneStrings(cfg.ActiveStates)
+		}
+		if len(localCfg.ObservedStates) == 0 {
+			localCfg.ObservedStates = cloneStrings(cfg.ObservedStates)
+		}
+		if len(localCfg.TerminalStates) == 0 {
+			localCfg.TerminalStates = cloneStrings(cfg.TerminalStates)
+		}
+		return githublocal.New(githublocal.Config{
+			GitHub: githubconnector.Config{
+				Endpoint:    cfg.Endpoint,
+				APIKey:      cfg.APIKey,
+				TokenSource: tokenSource,
+				HTTPTransport: githubconnector.HTTPTransportConfig{
+					MaxIdleConns:        cfg.HTTPMaxIdleConns,
+					MaxIdleConnsPerHost: cfg.HTTPMaxIdleConnsPerHost,
+					IdleConnTimeout:     time.Duration(cfg.HTTPIdleConnTimeoutMS) * time.Millisecond,
+				},
+				RESTMinRemainingReserve: cfg.GitHubRESTMinReserve,
+				RESTFanoutMaxRequests:   cfg.GitHubRESTFanoutMaxRequests,
+				GitHubAppID:             cfg.GitHubAppID,
+				GitHubAppPrivateKey:     cfg.GitHubAppPrivateKey,
+				GitHubAppPrivateKeyPath: cfg.GitHubAppPrivateKeyPath,
+				GitHubAppInstallationID: cfg.GitHubAppInstallationID,
+				Repository:              cfg.Repository,
+				StatusField:             cfg.StatusField,
+				StatusLabelPrefix:       cfg.StatusLabelPrefix,
+				ActiveStates:            cfg.ActiveStates,
+				ObservedStates:          cfg.ObservedStates,
+				TerminalStates:          cfg.TerminalStates,
+				StateMap:                cfg.StateMap,
+				PriorityMap:             cfg.PriorityMap,
+			},
+			Local:          localCfg,
+			Repository:     cfg.Repository,
+			InitialState:   firstNonBlank(cfg.ActiveStates),
+			ActiveStates:   cfg.ActiveStates,
+			TerminalStates: cfg.TerminalStates,
+		})
 	case connector.BackendGitLab, connector.BackendJira:
 		return nil, fmt.Errorf("%w: %s", ErrBackendNotReady, kind)
 	default:
@@ -145,4 +192,17 @@ func normalizeKind(kind string) string {
 		return connector.BackendMemory.String()
 	}
 	return normalized
+}
+
+func cloneStrings(values []string) []string {
+	return append([]string(nil), values...)
+}
+
+func firstNonBlank(values []string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
 }

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 )
 
@@ -159,6 +160,39 @@ func TestFactoryGitHubConnectorImplementsAuthenticator(t *testing.T) {
 	}
 	if _, ok := c.(connector.Authenticator); !ok {
 		t.Fatalf("connector = %T, want connector.Authenticator", c)
+	}
+}
+
+func TestFactoryGitHubLocalConnectorSelection(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromConfig(Config{
+		Kind:       "github_local",
+		Repository: "digitaldrywood/detent",
+		LocalSQLite: local.Config{
+			Path: ":memory:",
+		},
+		ActiveStates:   []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done"},
+	})
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+	if closer, ok := c.(connector.Closer); ok {
+		t.Cleanup(func() {
+			if err := closer.Close(); err != nil {
+				t.Fatalf("Close() error = %v", err)
+			}
+		})
+	}
+	if c.Name() != "github_local" {
+		t.Fatalf("Name() = %q, want github_local", c.Name())
+	}
+	if _, ok := c.(connector.PullRequestCommenter); !ok {
+		t.Fatalf("connector = %T, want connector.PullRequestCommenter", c)
+	}
+	if _, ok := c.(connector.PullRequestMerger); !ok {
+		t.Fatalf("connector = %T, want connector.PullRequestMerger", c)
 	}
 }
 

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -29,6 +29,7 @@ type ReadinessCheck struct {
 
 type ReadinessConfig struct {
 	AuthPath                      string
+	LocalStatusMode               bool
 	WriteProbeIssue               string
 	Repositories                  []string
 	StatusStates                  []string
@@ -96,6 +97,18 @@ func (c githubReadinessChecker) Check(ctx context.Context, cfg ReadinessConfig) 
 	if hasGitHubAppCredentials(c.cfg, c.cfg.LookupEnv) {
 		checks = append(checks, c.appInstallationCheck(ctx, cfg))
 	}
+	if cfg.LocalStatusMode {
+		checks = append(checks, c.userCheck(ctx))
+		checks = append(checks, c.repositoryChecks(ctx, cfg.Repositories, cfg)...)
+		probe, hasProbe, probeCheck := c.resolveWriteProbe(ctx, cfg)
+		if probeCheck != nil {
+			checks = append(checks, *probeCheck)
+		}
+		checks = append(checks, c.probeReadChecks(ctx, cfg, probe, hasProbe)...)
+		checks = append(checks, c.localWriteAllowlistCheck())
+		checks = append(checks, c.rateLimitCheck(ctx))
+		return checks
+	}
 	if c.connector.usesLabelStatus() {
 		checks = append(checks,
 			c.labelStatusOptionsCheck(ctx, cfg.StatusStates),
@@ -161,6 +174,31 @@ func (c githubReadinessChecker) authPathCheck(cfg ReadinessConfig) ReadinessChec
 		Name:   "GitHub auth path",
 		Status: ReadinessOK,
 		Detail: authPath,
+	}
+}
+
+func (c githubReadinessChecker) userCheck(ctx context.Context) ReadinessCheck {
+	var user restAuthenticatedUser
+	if err := c.connector.client.REST(ctx, http.MethodGet, "/user", nil, &user); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub user",
+			Status: ReadinessFail,
+			Detail: "cannot read authenticated user: " + err.Error(),
+			Hint:   "Configure a GitHub token with read access for the target repository.",
+		}
+	}
+	if strings.TrimSpace(user.Login) == "" {
+		return ReadinessCheck{
+			Name:   "GitHub user",
+			Status: ReadinessFail,
+			Detail: "authenticated user response did not include a login",
+			Hint:   "Check GitHub API compatibility and rerun detent doctor.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub user",
+		Status: ReadinessOK,
+		Detail: "authenticated as " + strings.TrimSpace(user.Login),
 	}
 }
 
@@ -844,6 +882,14 @@ func (c githubReadinessChecker) writeChecks(ctx context.Context, cfg ReadinessCo
 		checks = append(checks, c.issueCloseWriteCheck(ctx, probe, hasProbe))
 	}
 	return checks
+}
+
+func (c githubReadinessChecker) localWriteAllowlistCheck() ReadinessCheck {
+	return ReadinessCheck{
+		Name:   "GitHub local write allowlist",
+		Status: ReadinessOK,
+		Detail: "issue status, fields, labels, projects, issue comments, and issue close stay local; PR comments and merge remain allowlisted",
+	}
 }
 
 type restRateLimitResponse struct {

--- a/internal/connector/github/repository.go
+++ b/internal/connector/github/repository.go
@@ -1,0 +1,41 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"strings"
+)
+
+type RepositoryInfo struct {
+	ID            int64
+	NameWithOwner string
+	HTMLURL       string
+}
+
+func (c *Connector) FetchRepositoryInfo(ctx context.Context, repository string) (RepositoryInfo, error) {
+	repository = strings.TrimSpace(repository)
+	if repository == "" {
+		return RepositoryInfo{}, ErrMissingRepository
+	}
+	var response struct {
+		ID       int64  `json:"id"`
+		FullName string `json:"full_name"`
+		HTMLURL  string `json:"html_url"`
+	}
+	if err := c.client.REST(ctx, http.MethodGet, restRepositoryPath(repository), nil, &response); err != nil {
+		return RepositoryInfo{}, fmt.Errorf("fetch github repository info: %w", err)
+	}
+	if response.ID == 0 {
+		return RepositoryInfo{}, ErrInvalidResponse
+	}
+	info := RepositoryInfo{
+		ID:            response.ID,
+		NameWithOwner: strings.TrimSpace(response.FullName),
+		HTMLURL:       strings.TrimSpace(response.HTMLURL),
+	}
+	if info.NameWithOwner == "" {
+		info.NameWithOwner = repository
+	}
+	return info, nil
+}

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -485,6 +485,8 @@ func (c *Connector) applyDivergence(issue connector.Issue) connector.Issue {
 	if issue.Closed && !c.isTerminalState(issue.State) {
 		metadata[MetadataDivergence] = DivergenceClosedUpstreamLocalActive
 		metadata[MetadataDivergenceDetail] = "closed upstream while locally active"
+		issue.Closed = false
+		issue.ClosedReason = ""
 	} else {
 		delete(metadata, MetadataDivergence)
 		delete(metadata, MetadataDivergenceDetail)

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -1,0 +1,693 @@
+package githublocal
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"maps"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+)
+
+const (
+	MetadataDivergence       = "github_local_divergence"
+	MetadataDivergenceDetail = "github_local_divergence_detail"
+
+	DivergenceClosedUpstreamLocalActive = "closed_upstream_local_active"
+)
+
+const disabledStatusLabelPrefix = "__detent_local_status_disabled__:"
+
+type Config struct {
+	GitHub         githubconnector.Config
+	Local          local.Config
+	Repository     string
+	InitialState   string
+	ActiveStates   []string
+	TerminalStates []string
+	Now            func() time.Time
+}
+
+type Connector struct {
+	github        *githubconnector.Connector
+	local         *local.Connector
+	repository    string
+	initialState  string
+	terminalState map[string]struct{}
+	now           func() time.Time
+}
+
+var _ connector.Connector = (*Connector)(nil)
+var _ connector.Authenticator = (*Connector)(nil)
+var _ connector.AuthHealthReporter = (*Connector)(nil)
+var _ connector.CandidateIssuesByStatesFetcher = (*Connector)(nil)
+var _ connector.Closer = (*Connector)(nil)
+var _ connector.RateLimitReporter = (*Connector)(nil)
+var _ connector.GraphQLRateLimitUsageReporter = (*Connector)(nil)
+var _ connector.InstanceIdentifier = (*Connector)(nil)
+var _ connector.IssueChildrenResolver = (*Connector)(nil)
+var _ connector.IssueCloser = (*Connector)(nil)
+var _ connector.IssueCommentReader = (*Connector)(nil)
+var _ connector.IssueFieldClearer = (*Connector)(nil)
+var _ connector.IssueFieldSetter = (*Connector)(nil)
+var _ connector.IssueParentResolver = (*Connector)(nil)
+var _ connector.IssueReferenceResolver = (*Connector)(nil)
+var _ connector.IssueStateProber = (*Connector)(nil)
+var _ connector.IssuesByStatesLimiter = (*Connector)(nil)
+var _ connector.ProjectRemover = (*Connector)(nil)
+var _ connector.PullRequestCommenter = (*Connector)(nil)
+var _ connector.PullRequestHydrator = (*Connector)(nil)
+var _ connector.PullRequestMerger = (*Connector)(nil)
+var _ connector.RESTRateLimitUsageReporter = (*Connector)(nil)
+var _ connector.StatusDriftReader = (*Connector)(nil)
+
+func New(cfg Config) (*Connector, error) {
+	repository := strings.TrimSpace(cfg.Repository)
+	if repository == "" {
+		repository = strings.TrimSpace(cfg.GitHub.Repository)
+	}
+	if repository == "" {
+		return nil, errors.New("github local repository is required")
+	}
+
+	localCfg := cfg.Local
+	if len(localCfg.ActiveStates) == 0 {
+		localCfg.ActiveStates = cloneStrings(cfg.ActiveStates)
+	}
+	if len(localCfg.TerminalStates) == 0 {
+		localCfg.TerminalStates = cloneStrings(cfg.TerminalStates)
+	}
+	if localCfg.Now == nil {
+		localCfg.Now = cfg.Now
+	}
+	localConn, err := local.New(localCfg)
+	if err != nil {
+		return nil, err
+	}
+
+	githubCfg := cfg.GitHub
+	githubCfg.Repository = repository
+	githubCfg.GitHubStatusSource = githubconnector.GitHubStatusSourceLabel
+	if strings.TrimSpace(githubCfg.StatusLabelPrefix) == "" {
+		githubCfg.StatusLabelPrefix = disabledStatusLabelPrefix
+	}
+	githubCfg.ActiveStates = cloneStrings(cfg.ActiveStates)
+	githubCfg.TerminalStates = cloneStrings(cfg.TerminalStates)
+	if githubCfg.Now == nil {
+		githubCfg.Now = cfg.Now
+	}
+	githubConn, err := githubconnector.NewConnector(githubCfg)
+	if err != nil {
+		return nil, errors.Join(err, localConn.Close())
+	}
+
+	now := cfg.Now
+	if now == nil {
+		now = time.Now
+	}
+	return &Connector{
+		github:        githubConn,
+		local:         localConn,
+		repository:    repository,
+		initialState:  defaultInitialState(cfg.InitialState, cfg.ActiveStates),
+		terminalState: normalizedStateSet(cfg.TerminalStates),
+		now:           now,
+	}, nil
+}
+
+func (c *Connector) Name() string {
+	return connector.BackendGitHubLocal.String()
+}
+
+func (c *Connector) Close() error {
+	if c == nil {
+		return nil
+	}
+	return errors.Join(closeIfPresent(c.github), closeIfPresent(c.local))
+}
+
+func (c *Connector) Authenticate(ctx context.Context) error {
+	return c.github.Authenticate(ctx)
+}
+
+func (c *Connector) InstanceLogin() string {
+	return c.github.InstanceLogin()
+}
+
+func (c *Connector) GraphQLRateLimit() (connector.GraphQLRateLimit, bool) {
+	return c.github.GraphQLRateLimit()
+}
+
+func (c *Connector) AuthHealth() (connector.AuthHealth, bool) {
+	return c.github.AuthHealth()
+}
+
+func (c *Connector) ResetGraphQLRateLimitUsage() {
+	c.github.ResetGraphQLRateLimitUsage()
+}
+
+func (c *Connector) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage {
+	return c.github.FlushGraphQLRateLimitUsage()
+}
+
+func (c *Connector) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
+	return c.github.FlushRESTRateLimitUsage()
+}
+
+func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {
+	issues, err := c.local.FetchCandidateIssues(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return c.hydrateLocalIssues(ctx, issues)
+}
+
+func (c *Connector) FetchCandidateIssuesByStates(ctx context.Context, states []string) ([]connector.Issue, error) {
+	issues, err := c.local.FetchCandidateIssuesByStates(ctx, states)
+	if err != nil {
+		return nil, err
+	}
+	return c.hydrateLocalIssues(ctx, issues)
+}
+
+func (c *Connector) FetchIssuesByStates(ctx context.Context, states []string) ([]connector.Issue, error) {
+	issues, err := c.local.FetchIssuesByStates(ctx, states)
+	if err != nil {
+		return nil, err
+	}
+	return c.hydrateLocalIssues(ctx, issues)
+}
+
+func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
+	issues, err := c.local.FetchIssuesByStatesLimit(ctx, states, limit)
+	if err != nil {
+		return nil, err
+	}
+	return c.hydrateLocalIssues(ctx, issues)
+}
+
+func (c *Connector) FetchIssueStateProbe(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
+	return c.FetchIssuesByStatesLimit(ctx, states, limit)
+}
+
+func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string) ([]connector.Issue, error) {
+	issues, err := c.local.FetchIssueStatesByIDs(ctx, issueIDs)
+	if err != nil {
+		return nil, err
+	}
+	return c.hydrateLocalIssues(ctx, issues)
+}
+
+func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) ([]connector.Issue, error) {
+	identifiers = uniqueNonBlank(identifiers)
+	if len(identifiers) == 0 {
+		return []connector.Issue{}, nil
+	}
+
+	localIssues, err := c.local.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		return nil, err
+	}
+	localByIdentifier := issuesByIdentifier(localIssues)
+
+	upstream, err := c.github.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		return nil, err
+	}
+	repoInfo, err := c.github.FetchRepositoryInfo(ctx, c.repository)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]connector.Issue, 0, len(upstream))
+	for _, issue := range upstream {
+		issue = c.withGitHubIdentity(issue, repoInfo)
+		if localIssue, ok := localByIdentifier[identifierKey(issue.Identifier)]; ok {
+			merged := c.mergeLocalWithGitHub(localIssue, issue)
+			if err := c.local.UpsertIssues(ctx, []connector.Issue{merged}); err != nil {
+				return nil, err
+			}
+			out = append(out, merged)
+			continue
+		}
+		out = append(out, issue)
+	}
+	return sortIssuesByIdentifiers(out, identifiers), nil
+}
+
+func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	githubComments, err := c.github.FetchIssueComments(ctx, issue)
+	if err != nil {
+		return nil, err
+	}
+	localComments, err := c.local.FetchIssueComments(ctx, issue)
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return githubComments, nil
+		}
+		return nil, err
+	}
+	return append(githubComments, localComments...), nil
+}
+
+func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
+	return c.local.CreateComment(ctx, issueID, body)
+}
+
+func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateName string) error {
+	return c.local.UpdateIssueState(ctx, issueID, stateName)
+}
+
+func (c *Connector) SetAssignee(ctx context.Context, issueID string, login string) error {
+	return c.local.SetAssignee(ctx, issueID, login)
+}
+
+func (c *Connector) SetField(ctx context.Context, issueID string, fieldName string, value string) error {
+	return c.local.SetField(ctx, issueID, fieldName, value)
+}
+
+func (c *Connector) SetIssueField(ctx context.Context, issueID string, fieldID int, value string) error {
+	return c.local.SetIssueField(ctx, issueID, fieldID, value)
+}
+
+func (c *Connector) ClearIssueField(ctx context.Context, issueID string, fieldID int) error {
+	return c.local.ClearIssueField(ctx, issueID, fieldID)
+}
+
+func (c *Connector) CloseIssue(ctx context.Context, issueID string) error {
+	return c.local.CloseIssue(ctx, issueID)
+}
+
+func (c *Connector) RemoveIssueFromProject(ctx context.Context, issueID string) error {
+	return c.local.RemoveIssueFromProject(ctx, issueID)
+}
+
+func (c *Connector) CreatePullRequestComment(ctx context.Context, repository string, number int, body string) error {
+	return c.github.CreatePullRequestComment(ctx, repository, number, body)
+}
+
+func (c *Connector) MergePullRequest(ctx context.Context, repository string, number int, headSHA string) error {
+	return c.github.MergePullRequest(ctx, repository, number, headSHA)
+}
+
+func (c *Connector) HydratePullRequest(ctx context.Context, issue connector.Issue) (connector.Issue, error) {
+	return c.github.HydratePullRequest(ctx, issue)
+}
+
+func (c *Connector) FetchIssueParents(ctx context.Context, issueID string) ([]connector.Issue, error) {
+	githubIssueID, err := c.githubIssueID(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	parents, err := c.github.FetchIssueParents(ctx, githubIssueID)
+	if err != nil {
+		return nil, err
+	}
+	return c.overlayLocalStatuses(ctx, parents)
+}
+
+func (c *Connector) FetchIssueChildren(ctx context.Context, issueID string) ([]connector.BlockedRef, error) {
+	githubIssueID, err := c.githubIssueID(ctx, issueID)
+	if err != nil {
+		return nil, err
+	}
+	children, err := c.github.FetchIssueChildren(ctx, githubIssueID)
+	if err != nil {
+		return nil, err
+	}
+	identifiers := make([]string, 0, len(children))
+	for _, child := range children {
+		identifiers = append(identifiers, child.Identifier)
+	}
+	localIssues, err := c.local.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		return nil, err
+	}
+	localByIdentifier := issuesByIdentifier(localIssues)
+	for index := range children {
+		if issue, ok := localByIdentifier[identifierKey(children[index].Identifier)]; ok {
+			children[index].ID = issue.ID
+			children[index].State = issue.State
+		}
+	}
+	return children, nil
+}
+
+func (c *Connector) FetchStatusDrift(ctx context.Context) (connector.StatusDrift, error) {
+	issues, err := c.local.FetchIssueStateProbe(ctx, nil, 0)
+	if err != nil {
+		return connector.StatusDrift{}, err
+	}
+	drift := connector.StatusDrift{}
+	for _, issue := range issues {
+		if strings.TrimSpace(issue.Metadata[MetadataDivergence]) != "" {
+			drift.OpenTerminal = append(drift.OpenTerminal, issue)
+		}
+	}
+	return drift, nil
+}
+
+func (c *Connector) ImportIssues(ctx context.Context, numbers []int, state string) ([]connector.Issue, error) {
+	numbers = uniquePositiveInts(numbers)
+	if len(numbers) == 0 {
+		return []connector.Issue{}, nil
+	}
+	state = strings.TrimSpace(state)
+	if state == "" {
+		state = c.initialState
+	}
+
+	repoInfo, err := c.github.FetchRepositoryInfo(ctx, c.repository)
+	if err != nil {
+		return nil, err
+	}
+	identifiers := make([]string, 0, len(numbers))
+	for _, number := range numbers {
+		identifiers = append(identifiers, c.repository+"#"+strconv.Itoa(number))
+	}
+	upstream, err := c.github.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		return nil, err
+	}
+	upstreamByNumber := map[int]connector.Issue{}
+	for _, issue := range upstream {
+		if number, ok := issueNumber(issue.Identifier); ok {
+			upstreamByNumber[number] = issue
+		}
+	}
+
+	imported := make([]connector.Issue, 0, len(numbers))
+	for _, number := range numbers {
+		issue, ok := upstreamByNumber[number]
+		if !ok {
+			return nil, fmt.Errorf("github local import: issue %s#%d not found", c.repository, number)
+		}
+		issue = c.withGitHubIdentity(issue, repoInfo)
+		issue.ID = localIssueID(repoInfo.ID, number)
+		issue.State = state
+		now := c.now().UTC()
+		issue.StageUpdatedAt = &now
+		issue = c.applyDivergence(issue)
+		imported = append(imported, issue)
+	}
+	if err := c.local.UpsertIssues(ctx, imported); err != nil {
+		return nil, err
+	}
+	return imported, nil
+}
+
+func (c *Connector) hydrateLocalIssues(ctx context.Context, issues []connector.Issue) ([]connector.Issue, error) {
+	if len(issues) == 0 {
+		return []connector.Issue{}, nil
+	}
+	identifiers := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		identifiers = append(identifiers, issue.Identifier)
+	}
+	upstream, err := c.github.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		return nil, err
+	}
+	repoInfo, err := c.github.FetchRepositoryInfo(ctx, c.repository)
+	if err != nil {
+		return nil, err
+	}
+	upstreamByIdentifier := issuesByIdentifier(upstream)
+	out := make([]connector.Issue, 0, len(issues))
+	changed := make([]connector.Issue, 0, len(issues))
+	for _, localIssue := range issues {
+		upstreamIssue, ok := upstreamByIdentifier[identifierKey(localIssue.Identifier)]
+		if !ok {
+			orphaned := localIssue
+			orphaned.Metadata = cloneMetadata(orphaned.Metadata)
+			orphaned.Metadata[local.MetadataGitHubOrphaned] = "true"
+			changed = append(changed, orphaned)
+			out = append(out, orphaned)
+			continue
+		}
+		upstreamIssue = c.withGitHubIdentity(upstreamIssue, repoInfo)
+		merged := c.mergeLocalWithGitHub(localIssue, upstreamIssue)
+		changed = append(changed, merged)
+		out = append(out, merged)
+	}
+	if len(changed) > 0 {
+		if err := c.local.UpsertIssues(ctx, changed); err != nil {
+			return nil, err
+		}
+	}
+	return out, nil
+}
+
+func (c *Connector) mergeLocalWithGitHub(localIssue connector.Issue, upstream connector.Issue) connector.Issue {
+	merged := upstream
+	merged.ID = localIssue.ID
+	if strings.TrimSpace(localIssue.Identifier) != "" {
+		merged.Identifier = localIssue.Identifier
+	}
+	merged.State = localIssue.State
+	merged.Priority = localIssue.Priority
+	merged.Fields = cloneMetadata(localIssue.Fields)
+	merged.Comments = cloneComments(localIssue.Comments)
+	merged.Deliverable = cloneDeliverable(localIssue.Deliverable)
+	merged.AssignedToWorker = localIssue.AssignedToWorker
+	merged.StageUpdatedAt = localIssue.StageUpdatedAt
+	merged.Metadata = mergeMetadata(upstream.Metadata, localIssue.Metadata)
+	if strings.TrimSpace(localIssue.ModelOverride) != "" {
+		merged.ModelOverride = localIssue.ModelOverride
+	}
+	return c.applyDivergence(merged)
+}
+
+func (c *Connector) withGitHubIdentity(issue connector.Issue, repo githubconnector.RepositoryInfo) connector.Issue {
+	metadata := cloneMetadata(issue.Metadata)
+	metadata[local.MetadataGitHubNodeID] = strings.TrimSpace(issue.ID)
+	metadata[local.MetadataGitHubRepositoryID] = strconv.FormatInt(repo.ID, 10)
+	if number, ok := issueNumber(issue.Identifier); ok {
+		metadata[local.MetadataGitHubIssueNumber] = strconv.Itoa(number)
+	}
+	if issue.Closed {
+		metadata[local.MetadataGitHubUpstreamState] = "closed"
+	} else {
+		metadata[local.MetadataGitHubUpstreamState] = "open"
+	}
+	delete(metadata, local.MetadataGitHubOrphaned)
+	issue.Metadata = metadata
+	return issue
+}
+
+func (c *Connector) applyDivergence(issue connector.Issue) connector.Issue {
+	metadata := cloneMetadata(issue.Metadata)
+	if issue.Closed && !c.isTerminalState(issue.State) {
+		metadata[MetadataDivergence] = DivergenceClosedUpstreamLocalActive
+		metadata[MetadataDivergenceDetail] = "closed upstream while locally active"
+	} else {
+		delete(metadata, MetadataDivergence)
+		delete(metadata, MetadataDivergenceDetail)
+	}
+	issue.Metadata = metadata
+	return issue
+}
+
+func (c *Connector) overlayLocalStatuses(ctx context.Context, issues []connector.Issue) ([]connector.Issue, error) {
+	if len(issues) == 0 {
+		return []connector.Issue{}, nil
+	}
+	identifiers := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		identifiers = append(identifiers, issue.Identifier)
+	}
+	localIssues, err := c.local.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		return nil, err
+	}
+	localByIdentifier := issuesByIdentifier(localIssues)
+	out := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if localIssue, ok := localByIdentifier[identifierKey(issue.Identifier)]; ok {
+			issue.ID = localIssue.ID
+			issue.State = localIssue.State
+			issue.Priority = localIssue.Priority
+			issue.Fields = cloneMetadata(localIssue.Fields)
+			issue.Metadata = mergeMetadata(localIssue.Metadata, issue.Metadata)
+		}
+		out = append(out, issue)
+	}
+	return out, nil
+}
+
+func (c *Connector) githubIssueID(ctx context.Context, issueID string) (string, error) {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return "", sql.ErrNoRows
+	}
+	issues, err := c.local.FetchIssueStatesByIDs(ctx, []string{issueID})
+	if err != nil {
+		return "", err
+	}
+	if len(issues) == 0 {
+		return issueID, nil
+	}
+	nodeID := strings.TrimSpace(issues[0].Metadata[local.MetadataGitHubNodeID])
+	if nodeID == "" {
+		return issueID, nil
+	}
+	return nodeID, nil
+}
+
+func (c *Connector) isTerminalState(state string) bool {
+	_, ok := c.terminalState[normalizedStateName(state)]
+	return ok
+}
+
+func closeIfPresent(value connector.Closer) error {
+	if value == nil {
+		return nil
+	}
+	return value.Close()
+}
+
+func defaultInitialState(configured string, activeStates []string) string {
+	if configured = strings.TrimSpace(configured); configured != "" {
+		return configured
+	}
+	for _, state := range activeStates {
+		if state = strings.TrimSpace(state); state != "" {
+			return state
+		}
+	}
+	return "Todo"
+}
+
+func localIssueID(repositoryID int64, number int) string {
+	if repositoryID > 0 {
+		return "github:" + strconv.FormatInt(repositoryID, 10) + ":" + strconv.Itoa(number)
+	}
+	return "github:unknown:" + strconv.Itoa(number)
+}
+
+func issueNumber(identifier string) (int, bool) {
+	_, number, ok := strings.Cut(strings.TrimSpace(identifier), "#")
+	if !ok {
+		return 0, false
+	}
+	parsed, err := strconv.Atoi(strings.TrimSpace(number))
+	if err != nil || parsed <= 0 {
+		return 0, false
+	}
+	return parsed, true
+}
+
+func issuesByIdentifier(issues []connector.Issue) map[string]connector.Issue {
+	out := make(map[string]connector.Issue, len(issues))
+	for _, issue := range issues {
+		key := identifierKey(issue.Identifier)
+		if key != "" {
+			out[key] = issue
+		}
+	}
+	return out
+}
+
+func identifierKey(identifier string) string {
+	return strings.ToLower(strings.TrimSpace(identifier))
+}
+
+func uniqueNonBlank(values []string) []string {
+	seen := map[string]struct{}{}
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		key := strings.ToLower(value)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func uniquePositiveInts(values []int) []int {
+	seen := map[int]struct{}{}
+	out := make([]int, 0, len(values))
+	for _, value := range values {
+		if value <= 0 {
+			continue
+		}
+		if _, ok := seen[value]; ok {
+			continue
+		}
+		seen[value] = struct{}{}
+		out = append(out, value)
+	}
+	return out
+}
+
+func normalizedStateSet(values []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		if value = normalizedStateName(value); value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func normalizedStateName(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), " "))
+}
+
+func cloneStrings(values []string) []string {
+	return append([]string(nil), values...)
+}
+
+func cloneMetadata(values map[string]string) map[string]string {
+	if values == nil {
+		return map[string]string{}
+	}
+	return maps.Clone(values)
+}
+
+func mergeMetadata(primary map[string]string, secondary map[string]string) map[string]string {
+	out := cloneMetadata(secondary)
+	for key, value := range primary {
+		out[key] = value
+	}
+	return out
+}
+
+func cloneComments(values []connector.IssueComment) []connector.IssueComment {
+	return append([]connector.IssueComment(nil), values...)
+}
+
+func cloneDeliverable(value *connector.Deliverable) *connector.Deliverable {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	cloned.Metadata = cloneMetadata(value.Metadata)
+	return &cloned
+}
+
+func sortIssuesByIdentifiers(issues []connector.Issue, identifiers []string) []connector.Issue {
+	position := make(map[string]int, len(identifiers))
+	for index, identifier := range identifiers {
+		position[identifierKey(identifier)] = index
+	}
+	for left := 0; left < len(issues); left++ {
+		for right := left + 1; right < len(issues); right++ {
+			if position[identifierKey(issues[right].Identifier)] < position[identifierKey(issues[left].Identifier)] {
+				issues[left], issues[right] = issues[right], issues[left]
+			}
+		}
+	}
+	return issues
+}

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -56,6 +56,9 @@ func TestConnectorImportPersistsAndDetectsClosedUpstreamDivergence(t *testing.T)
 	if imported[0].Metadata[MetadataDivergence] != DivergenceClosedUpstreamLocalActive {
 		t.Fatalf("divergence = %q, want %q", imported[0].Metadata[MetadataDivergence], DivergenceClosedUpstreamLocalActive)
 	}
+	if imported[0].Closed || imported[0].ClosedReason != "" {
+		t.Fatalf("imported closed metadata = (%v, %q), want active local issue", imported[0].Closed, imported[0].ClosedReason)
+	}
 
 	restarted, err := New(cfg)
 	if err != nil {
@@ -84,6 +87,9 @@ func TestConnectorImportPersistsAndDetectsClosedUpstreamDivergence(t *testing.T)
 	}
 	if issues[0].Metadata[MetadataDivergence] != DivergenceClosedUpstreamLocalActive {
 		t.Fatalf("divergence after restart = %q", issues[0].Metadata[MetadataDivergence])
+	}
+	if issues[0].Closed || issues[0].ClosedReason != "" {
+		t.Fatalf("closed metadata after restart = (%v, %q), want active local issue", issues[0].Closed, issues[0].ClosedReason)
 	}
 }
 

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -1,0 +1,248 @@
+package githublocal
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+)
+
+func TestConnectorImportPersistsAndDetectsClosedUpstreamDivergence(t *testing.T) {
+	t.Parallel()
+
+	server := newGitHubLocalTestServer(t)
+	dbPath := filepath.Join(t.TempDir(), "work-items.db")
+	cfg := Config{
+		GitHub: githubconnector.Config{
+			Endpoint: server.URL + "/graphql",
+			APIKey:   "ghp_test",
+		},
+		Local: local.Config{
+			Path: dbPath,
+		},
+		Repository:     "digitaldrywood/detent",
+		ActiveStates:   []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done"},
+		Now: func() time.Time {
+			return time.Date(2026, 7, 2, 12, 0, 0, 0, time.UTC)
+		},
+	}
+
+	conn, err := New(cfg)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	imported, err := conn.ImportIssues(context.Background(), []int{779}, "In Progress")
+	if err != nil {
+		t.Fatalf("ImportIssues() error = %v", err)
+	}
+	if err := conn.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	if len(imported) != 1 {
+		t.Fatalf("imported len = %d, want 1", len(imported))
+	}
+	if imported[0].ID != "github:123:779" {
+		t.Fatalf("imported ID = %q, want local surrogate", imported[0].ID)
+	}
+	if imported[0].Metadata[MetadataDivergence] != DivergenceClosedUpstreamLocalActive {
+		t.Fatalf("divergence = %q, want %q", imported[0].Metadata[MetadataDivergence], DivergenceClosedUpstreamLocalActive)
+	}
+
+	restarted, err := New(cfg)
+	if err != nil {
+		t.Fatalf("restart New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := restarted.Close(); err != nil {
+			t.Fatalf("restart Close() error = %v", err)
+		}
+	})
+	issues, err := restarted.FetchIssuesByStates(context.Background(), []string{"In Progress"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(issues))
+	}
+	if issues[0].ID != "github:123:779" || issues[0].State != "In Progress" {
+		t.Fatalf("issue identity/state = %q/%q, want local surrogate/In Progress", issues[0].ID, issues[0].State)
+	}
+	if issues[0].Title != "Closed upstream issue" {
+		t.Fatalf("Title = %q, want GitHub title", issues[0].Title)
+	}
+	if issues[0].Metadata[local.MetadataGitHubRepositoryID] != "123" || issues[0].Metadata[local.MetadataGitHubIssueNumber] != "779" {
+		t.Fatalf("GitHub identity metadata = %#v", issues[0].Metadata)
+	}
+	if issues[0].Metadata[MetadataDivergence] != DivergenceClosedUpstreamLocalActive {
+		t.Fatalf("divergence after restart = %q", issues[0].Metadata[MetadataDivergence])
+	}
+}
+
+func TestConnectorIssueMutatorsStayLocalAndPRLifecycleWritesPassThrough(t *testing.T) {
+	t.Parallel()
+
+	server := newGitHubLocalTestServer(t)
+	conn, err := New(Config{
+		GitHub: githubconnector.Config{
+			Endpoint: server.URL + "/graphql",
+			APIKey:   "ghp_test",
+		},
+		Local: local.Config{
+			Path: filepath.Join(t.TempDir(), "guard-work-items.db"),
+			Issues: []connector.Issue{{
+				ID:         "github:123:779",
+				Identifier: "digitaldrywood/detent#779",
+				Title:      "Local issue",
+				State:      "Todo",
+				Fields:     map[string]string{},
+				Metadata: map[string]string{
+					local.MetadataGitHubNodeID:       "I_kwDOtest779",
+					local.MetadataGitHubRepositoryID: "123",
+					local.MetadataGitHubIssueNumber:  "779",
+				},
+				AssignedToWorker: true,
+			}},
+			TerminalStates: []string{"Done"},
+		},
+		Repository:     "digitaldrywood/detent",
+		ActiveStates:   []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done"},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	if err := conn.CreateComment(context.Background(), "github:123:779", "local audit"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	if err := conn.UpdateIssueState(context.Background(), "github:123:779", "In Progress"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+	if err := conn.SetAssignee(context.Background(), "github:123:779", "detent-bot"); err != nil {
+		t.Fatalf("SetAssignee() error = %v", err)
+	}
+	if err := conn.SetField(context.Background(), "github:123:779", "lease", "agent-1"); err != nil {
+		t.Fatalf("SetField() error = %v", err)
+	}
+	if err := conn.SetIssueField(context.Background(), "github:123:779", 100, "claimed"); err != nil {
+		t.Fatalf("SetIssueField() error = %v", err)
+	}
+	if err := conn.ClearIssueField(context.Background(), "github:123:779", 100); err != nil {
+		t.Fatalf("ClearIssueField() error = %v", err)
+	}
+	if err := conn.CloseIssue(context.Background(), "github:123:779"); err != nil {
+		t.Fatalf("CloseIssue() error = %v", err)
+	}
+	if got := server.writeRequests(); len(got) != 0 {
+		t.Fatalf("issue mutators wrote to GitHub: %#v", got)
+	}
+
+	if err := conn.CreatePullRequestComment(context.Background(), "digitaldrywood/detent", 12, "ship it"); err != nil {
+		t.Fatalf("CreatePullRequestComment() error = %v", err)
+	}
+	if err := conn.MergePullRequest(context.Background(), "digitaldrywood/detent", 12, "head-sha"); err != nil {
+		t.Fatalf("MergePullRequest() error = %v", err)
+	}
+	got := server.writeRequests()
+	want := []githubLocalTestRequest{
+		{Method: http.MethodPost, Path: "/repos/digitaldrywood/detent/issues/12/comments"},
+		{Method: http.MethodPut, Path: "/repos/digitaldrywood/detent/pulls/12/merge"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("write request len = %d, want %d: %#v", len(got), len(want), got)
+	}
+	for index := range want {
+		if got[index].Method != want[index].Method || got[index].Path != want[index].Path {
+			t.Fatalf("write request[%d] = %#v, want %#v", index, got[index], want[index])
+		}
+	}
+}
+
+type githubLocalTestRequest struct {
+	Method string
+	Path   string
+}
+
+type githubLocalTestServer struct {
+	*httptest.Server
+	t        *testing.T
+	mu       sync.Mutex
+	requests []githubLocalTestRequest
+}
+
+func newGitHubLocalTestServer(t *testing.T) *githubLocalTestServer {
+	t.Helper()
+	testServer := &githubLocalTestServer{t: t}
+	server := httptest.NewServer(http.HandlerFunc(testServer.handle))
+	testServer.Server = server
+	t.Cleanup(server.Close)
+	return testServer
+}
+
+func (s *githubLocalTestServer) handle(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		s.mu.Lock()
+		s.requests = append(s.requests, githubLocalTestRequest{Method: r.Method, Path: r.URL.Path})
+		s.mu.Unlock()
+	}
+	w.Header().Set("Content-Type", "application/json")
+	switch {
+	case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent":
+		writeGitHubLocalJSON(s.t, w, map[string]any{
+			"id":        123,
+			"full_name": "digitaldrywood/detent",
+			"html_url":  "https://github.com/digitaldrywood/detent",
+		})
+	case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent/issues/779":
+		body := "Depends on: #1"
+		writeGitHubLocalJSON(s.t, w, map[string]any{
+			"node_id":      "I_kwDOtest779",
+			"number":       779,
+			"title":        "Closed upstream issue",
+			"body":         body,
+			"state":        "closed",
+			"state_reason": "completed",
+			"html_url":     "https://github.com/digitaldrywood/detent/issues/779",
+			"created_at":   "2026-07-01T12:00:00Z",
+			"updated_at":   "2026-07-02T12:00:00Z",
+			"user":         map[string]any{"login": "octocat"},
+			"assignees":    []map[string]any{{"node_id": "U_1", "login": "detent-bot"}},
+			"labels":       []map[string]string{{"name": "enhancement"}},
+		})
+	case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent/pulls":
+		writeGitHubLocalJSON(s.t, w, []map[string]any{})
+	case r.Method == http.MethodPost && r.URL.Path == "/repos/digitaldrywood/detent/issues/12/comments":
+		writeGitHubLocalJSON(s.t, w, map[string]any{"node_id": "comment-node"})
+	case r.Method == http.MethodPut && r.URL.Path == "/repos/digitaldrywood/detent/pulls/12/merge":
+		writeGitHubLocalJSON(s.t, w, map[string]any{"sha": "merge-sha", "merged": true, "message": "ok"})
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+func (s *githubLocalTestServer) writeRequests() []githubLocalTestRequest {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]githubLocalTestRequest(nil), s.requests...)
+}
+
+func writeGitHubLocalJSON(t *testing.T, w http.ResponseWriter, value any) {
+	t.Helper()
+	if err := json.NewEncoder(w).Encode(value); err != nil {
+		t.Fatalf("encode response: %v", err)
+	}
+}

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -23,6 +24,13 @@ const (
 	eventKindStateUpdate   = "state_update"
 	eventKindFieldUpdate   = "field_update"
 	eventKindProjectRemove = "project_remove"
+	eventKindClose         = "close"
+
+	MetadataGitHubNodeID        = "github_node_id"
+	MetadataGitHubRepositoryID  = "github_repository_id"
+	MetadataGitHubIssueNumber   = "github_issue_number"
+	MetadataGitHubUpstreamState = "github_upstream_state"
+	MetadataGitHubOrphaned      = "github_orphaned"
 )
 
 type Config struct {
@@ -47,7 +55,11 @@ type Connector struct {
 var _ connector.Connector = (*Connector)(nil)
 var _ connector.CandidateIssuesByStatesFetcher = (*Connector)(nil)
 var _ connector.IssuesByStatesLimiter = (*Connector)(nil)
+var _ connector.IssueCloser = (*Connector)(nil)
 var _ connector.IssueCommentReader = (*Connector)(nil)
+var _ connector.IssueFieldClearer = (*Connector)(nil)
+var _ connector.IssueFieldSetter = (*Connector)(nil)
+var _ connector.IssueReferenceResolver = (*Connector)(nil)
 var _ connector.IssueStateProber = (*Connector)(nil)
 var _ connector.ProjectRemover = (*Connector)(nil)
 
@@ -144,6 +156,24 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 	return out, nil
 }
 
+func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) ([]connector.Issue, error) {
+	wanted := normalizedIdentifierSet(identifiers)
+	if len(wanted) == 0 {
+		return []connector.Issue{}, nil
+	}
+	issues, err := c.fetchIssues(ctx, nil, 0)
+	if err != nil {
+		return nil, err
+	}
+	out := make([]connector.Issue, 0, len(identifiers))
+	for _, issue := range issues {
+		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
+}
+
 func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
 	rows, err := c.db.QueryContext(ctx, `
 select body from detent_work_item_events
@@ -218,6 +248,37 @@ where project_id = ? and id = ?`, fieldsJSON, formatTime(now), c.projectID, stri
 	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindFieldUpdate, "", "", map[string]string{fieldName: value})
 }
 
+func (c *Connector) SetIssueField(ctx context.Context, issueID string, fieldID int, value string) error {
+	if fieldID <= 0 {
+		return connector.ErrNotImplemented
+	}
+	return c.SetField(ctx, issueID, issueFieldKey(fieldID), value)
+}
+
+func (c *Connector) ClearIssueField(ctx context.Context, issueID string, fieldID int) error {
+	if fieldID <= 0 {
+		return connector.ErrNotImplemented
+	}
+	return c.clearField(ctx, issueID, issueFieldKey(fieldID))
+}
+
+func (c *Connector) CloseIssue(ctx context.Context, issueID string) error {
+	state := c.closedState()
+	issueID = strings.TrimSpace(issueID)
+	now := c.now().UTC()
+	result, err := c.db.ExecContext(ctx, `
+update detent_work_items
+set state = ?, stage_updated_at = ?, updated_at = ?
+where project_id = ? and id = ?`, state, formatTime(now), formatTime(now), c.projectID, issueID)
+	if err != nil {
+		return err
+	}
+	if rows, err := result.RowsAffected(); err == nil && rows == 0 {
+		return sql.ErrNoRows
+	}
+	return c.recordEvent(ctx, issueID, eventKindClose, state, "", nil)
+}
+
 func (c *Connector) RemoveIssueFromProject(ctx context.Context, issueID string) error {
 	issueID = strings.TrimSpace(issueID)
 	result, err := c.db.ExecContext(ctx, `
@@ -260,6 +321,11 @@ created_at text not null default '',
 updated_at text not null default '',
 stage_updated_at text not null default '',
 model_override text not null default '',
+github_node_id text not null default '',
+github_repository_id integer not null default 0,
+github_issue_number integer not null default 0,
+github_upstream_state text not null default '',
+github_orphaned integer not null default 0,
 primary key (project_id, id)
 )`,
 		`create table if not exists detent_work_item_events (
@@ -280,6 +346,53 @@ created_at text not null
 			return fmt.Errorf("migrate local sqlite connector: %w", err)
 		}
 	}
+	if err := c.addMissingWorkItemColumns(ctx); err != nil {
+		return fmt.Errorf("migrate local sqlite connector: %w", err)
+	}
+	return nil
+}
+
+func (c *Connector) addMissingWorkItemColumns(ctx context.Context) error {
+	rows, err := c.db.QueryContext(ctx, `pragma table_info(detent_work_items)`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	existing := map[string]struct{}{}
+	for rows.Next() {
+		var cid int
+		var name, typ string
+		var notNull int
+		var defaultValue sql.NullString
+		var pk int
+		if err := rows.Scan(&cid, &name, &typ, &notNull, &defaultValue, &pk); err != nil {
+			return err
+		}
+		existing[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return err
+	}
+
+	columns := []struct {
+		name       string
+		definition string
+	}{
+		{name: "github_node_id", definition: "text not null default ''"},
+		{name: "github_repository_id", definition: "integer not null default 0"},
+		{name: "github_issue_number", definition: "integer not null default 0"},
+		{name: "github_upstream_state", definition: "text not null default ''"},
+		{name: "github_orphaned", definition: "integer not null default 0"},
+	}
+	for _, column := range columns {
+		if _, ok := existing[column.name]; ok {
+			continue
+		}
+		if _, err := c.db.ExecContext(ctx, "alter table detent_work_items add column "+column.name+" "+column.definition); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 
@@ -290,6 +403,99 @@ func (c *Connector) seed(ctx context.Context, issues []connector.Issue) error {
 		}
 	}
 	return nil
+}
+
+func (c *Connector) UpsertIssues(ctx context.Context, issues []connector.Issue) error {
+	for _, issue := range issues {
+		if err := c.upsertIssue(ctx, issue); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (c *Connector) upsertIssue(ctx context.Context, issue connector.Issue) error {
+	id := strings.TrimSpace(issue.ID)
+	if id == "" {
+		id = strings.TrimSpace(issue.Identifier)
+	}
+	if id == "" {
+		return errors.New("local sqlite upsert issue id or identifier is required")
+	}
+	identifier := strings.TrimSpace(issue.Identifier)
+	if identifier == "" {
+		identifier = id
+	}
+	now := c.now().UTC()
+	createdAt := timeOrDefault(issue.CreatedAt, now)
+	updatedAt := timeOrDefault(issue.UpdatedAt, createdAt)
+	stageUpdatedAt := timeOrDefault(issue.StageUpdatedAt, updatedAt)
+	assigneesJSON, err := marshalStringSlice(issue.Assignees)
+	if err != nil {
+		return err
+	}
+	labelsJSON, err := marshalStringSlice(issue.Labels)
+	if err != nil {
+		return err
+	}
+	fieldsJSON, err := marshalStringMap(issue.Fields)
+	if err != nil {
+		return err
+	}
+	metadataJSON, err := marshalStringMap(issue.Metadata)
+	if err != nil {
+		return err
+	}
+	deliverableMetadataJSON := "{}"
+	deliverable := connector.Deliverable{}
+	if issue.Deliverable != nil {
+		deliverable = *issue.Deliverable
+		deliverableMetadataJSON, err = marshalStringMap(issue.Deliverable.Metadata)
+		if err != nil {
+			return err
+		}
+	}
+	githubIdentity := githubIdentityFromIssue(issue)
+	assigned := 0
+	if issue.AssignedToWorker {
+		assigned = 1
+	}
+	_, err = c.db.ExecContext(ctx, `
+insert into detent_work_items (
+project_id, id, identifier, title, description, priority, state, url,
+author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
+deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
+deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
+created_at, updated_at, stage_updated_at, model_override,
+github_node_id, github_repository_id, github_issue_number, github_upstream_state, github_orphaned
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+on conflict(project_id, id) do update set
+identifier = excluded.identifier,
+title = excluded.title,
+description = excluded.description,
+state = case when excluded.state <> '' then excluded.state else detent_work_items.state end,
+stage_updated_at = case when excluded.state <> '' and excluded.state <> detent_work_items.state then excluded.stage_updated_at else detent_work_items.stage_updated_at end,
+url = excluded.url,
+author_id = excluded.author_id,
+assignee_id = excluded.assignee_id,
+assignees_json = excluded.assignees_json,
+labels_json = excluded.labels_json,
+metadata_json = excluded.metadata_json,
+assigned_to_worker = excluded.assigned_to_worker,
+updated_at = excluded.updated_at,
+model_override = excluded.model_override,
+github_node_id = excluded.github_node_id,
+github_repository_id = excluded.github_repository_id,
+github_issue_number = excluded.github_issue_number,
+github_upstream_state = excluded.github_upstream_state,
+github_orphaned = excluded.github_orphaned`,
+		c.projectID, id, identifier, issue.Title, issue.Description, nullableInt(issue.Priority), issue.State, issue.URL,
+		issue.AuthorID, issue.AssigneeID, assigneesJSON, labelsJSON, fieldsJSON, metadataJSON,
+		deliverable.Kind, deliverable.Path, deliverable.ReviewURL, deliverable.ValidationStatus,
+		deliverable.ExternalID, deliverableMetadataJSON, assigned,
+		formatTime(createdAt), formatTime(updatedAt), formatTime(stageUpdatedAt), issue.ModelOverride,
+		githubIdentity.NodeID, githubIdentity.RepositoryID, githubIdentity.IssueNumber, githubIdentity.UpstreamState, boolInt(githubIdentity.Orphaned))
+	return err
 }
 
 func (c *Connector) insertSeedIssue(ctx context.Context, issue connector.Issue) error {
@@ -333,6 +539,7 @@ func (c *Connector) insertSeedIssue(ctx context.Context, issue connector.Issue) 
 			return err
 		}
 	}
+	githubIdentity := githubIdentityFromIssue(issue)
 	assigned := 0
 	if issue.AssignedToWorker {
 		assigned = 1
@@ -343,14 +550,16 @@ project_id, id, identifier, title, description, priority, state, url,
 author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
 deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
 deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
-created_at, updated_at, stage_updated_at, model_override
-) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+created_at, updated_at, stage_updated_at, model_override,
+github_node_id, github_repository_id, github_issue_number, github_upstream_state, github_orphaned
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 on conflict(project_id, id) do nothing`,
 		c.projectID, id, identifier, issue.Title, issue.Description, nullableInt(issue.Priority), issue.State, issue.URL,
 		issue.AuthorID, issue.AssigneeID, assigneesJSON, labelsJSON, fieldsJSON, metadataJSON,
 		deliverable.Kind, deliverable.Path, deliverable.ReviewURL, deliverable.ValidationStatus,
 		deliverable.ExternalID, deliverableMetadataJSON, assigned,
-		formatTime(createdAt), formatTime(updatedAt), formatTime(stageUpdatedAt), issue.ModelOverride)
+		formatTime(createdAt), formatTime(updatedAt), formatTime(stageUpdatedAt), issue.ModelOverride,
+		githubIdentity.NodeID, githubIdentity.RepositoryID, githubIdentity.IssueNumber, githubIdentity.UpstreamState, boolInt(githubIdentity.Orphaned))
 	return err
 }
 
@@ -359,7 +568,8 @@ func (c *Connector) fetchIssues(ctx context.Context, states []string, limit int)
 author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
 deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
 deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
-created_at, updated_at, stage_updated_at, model_override
+created_at, updated_at, stage_updated_at, model_override,
+github_node_id, github_repository_id, github_issue_number, github_upstream_state, github_orphaned
 from detent_work_items
 where project_id = ?`
 	args := []any{c.projectID}
@@ -428,6 +638,45 @@ values (?, ?, ?, ?, ?, ?, ?)`,
 	return err
 }
 
+func (c *Connector) clearField(ctx context.Context, issueID string, fieldName string) error {
+	issue, err := c.issueByID(ctx, issueID)
+	if err != nil {
+		return err
+	}
+	fieldName = strings.TrimSpace(fieldName)
+	if fieldName == "" {
+		return nil
+	}
+	delete(issue.Fields, fieldName)
+	fieldsJSON, err := marshalStringMap(issue.Fields)
+	if err != nil {
+		return err
+	}
+	now := c.now().UTC()
+	_, err = c.db.ExecContext(ctx, `
+update detent_work_items
+set fields_json = ?, updated_at = ?
+where project_id = ? and id = ?`, fieldsJSON, formatTime(now), c.projectID, strings.TrimSpace(issueID))
+	if err != nil {
+		return err
+	}
+	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindFieldUpdate, "", "", map[string]string{fieldName: ""})
+}
+
+func (c *Connector) closedState() string {
+	for _, state := range c.terminalStates {
+		if strings.EqualFold(strings.TrimSpace(state), "Done") {
+			return strings.TrimSpace(state)
+		}
+	}
+	for _, state := range c.terminalStates {
+		if state = strings.TrimSpace(state); state != "" {
+			return state
+		}
+	}
+	return "Done"
+}
+
 type issueScanner interface {
 	Scan(dest ...any) error
 }
@@ -441,12 +690,16 @@ func scanIssue(scanner issueScanner) (connector.Issue, error) {
 	var deliverableMetadataJSON string
 	var assigned int
 	var createdAt, updatedAt, stageUpdatedAt string
+	var githubNodeID, githubUpstreamState string
+	var githubRepositoryID, githubIssueNumber int64
+	var githubOrphaned int
 	err := scanner.Scan(
 		&projectID, &issue.ID, &issue.Identifier, &issue.Title, &issue.Description, &priority, &issue.State, &issue.URL,
 		&issue.AuthorID, &issue.AssigneeID, &assigneesJSON, &labelsJSON, &fieldsJSON, &metadataJSON,
 		&deliverable.Kind, &deliverable.Path, &deliverable.ReviewURL, &deliverable.ValidationStatus,
 		&deliverable.ExternalID, &deliverableMetadataJSON, &assigned,
 		&createdAt, &updatedAt, &stageUpdatedAt, &issue.ModelOverride,
+		&githubNodeID, &githubRepositoryID, &githubIssueNumber, &githubUpstreamState, &githubOrphaned,
 	)
 	if err != nil {
 		return connector.Issue{}, err
@@ -459,6 +712,13 @@ func scanIssue(scanner issueScanner) (connector.Issue, error) {
 	issue.Labels = unmarshalStringSlice(labelsJSON)
 	issue.Fields = unmarshalStringMap(fieldsJSON)
 	issue.Metadata = unmarshalStringMap(metadataJSON)
+	applyGitHubIdentityMetadata(&issue, githubIdentity{
+		NodeID:        githubNodeID,
+		RepositoryID:  githubRepositoryID,
+		IssueNumber:   githubIssueNumber,
+		UpstreamState: githubUpstreamState,
+		Orphaned:      githubOrphaned != 0,
+	})
 	issue.AssignedToWorker = assigned != 0
 	issue.CreatedAt = parseTimePointer(createdAt)
 	issue.UpdatedAt = parseTimePointer(updatedAt)
@@ -496,6 +756,89 @@ func normalizedSet(values []string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+func normalizedIdentifierSet(values []string) map[string]struct{} {
+	out := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.ToLower(strings.TrimSpace(value))
+		if value != "" {
+			out[value] = struct{}{}
+		}
+	}
+	return out
+}
+
+func issueFieldKey(fieldID int) string {
+	return "issue_field:" + strconv.Itoa(fieldID)
+}
+
+type githubIdentity struct {
+	NodeID        string
+	RepositoryID  int64
+	IssueNumber   int64
+	UpstreamState string
+	Orphaned      bool
+}
+
+func githubIdentityFromIssue(issue connector.Issue) githubIdentity {
+	metadata := issue.Metadata
+	return githubIdentity{
+		NodeID:        strings.TrimSpace(metadata[MetadataGitHubNodeID]),
+		RepositoryID:  int64Metadata(metadata, MetadataGitHubRepositoryID),
+		IssueNumber:   int64Metadata(metadata, MetadataGitHubIssueNumber),
+		UpstreamState: strings.TrimSpace(metadata[MetadataGitHubUpstreamState]),
+		Orphaned:      boolMetadata(metadata, MetadataGitHubOrphaned),
+	}
+}
+
+func applyGitHubIdentityMetadata(issue *connector.Issue, identity githubIdentity) {
+	if issue.Metadata == nil {
+		issue.Metadata = map[string]string{}
+	}
+	if identity.NodeID != "" {
+		issue.Metadata[MetadataGitHubNodeID] = identity.NodeID
+	}
+	if identity.RepositoryID != 0 {
+		issue.Metadata[MetadataGitHubRepositoryID] = strconv.FormatInt(identity.RepositoryID, 10)
+	}
+	if identity.IssueNumber != 0 {
+		issue.Metadata[MetadataGitHubIssueNumber] = strconv.FormatInt(identity.IssueNumber, 10)
+	}
+	if identity.UpstreamState != "" {
+		issue.Metadata[MetadataGitHubUpstreamState] = identity.UpstreamState
+	}
+	if identity.Orphaned {
+		issue.Metadata[MetadataGitHubOrphaned] = "true"
+	}
+}
+
+func int64Metadata(metadata map[string]string, key string) int64 {
+	value := strings.TrimSpace(metadata[key])
+	if value == "" {
+		return 0
+	}
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
+}
+
+func boolMetadata(metadata map[string]string, key string) bool {
+	switch strings.ToLower(strings.TrimSpace(metadata[key])) {
+	case "1", "true", "yes":
+		return true
+	default:
+		return false
+	}
+}
+
+func boolInt(value bool) int {
+	if value {
+		return 1
+	}
+	return 0
 }
 
 func cloneStrings(values []string) []string {

--- a/internal/connector/local/local_test.go
+++ b/internal/connector/local/local_test.go
@@ -136,3 +136,62 @@ func TestConnectorFetchIssuesByStatesLimit(t *testing.T) {
 		t.Fatalf("FetchIssuesByStatesLimit() len = %d, want 1", len(issues))
 	}
 }
+
+func TestConnectorUpsertGitHubIdentityAndLocalIssueFields(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := New(Config{
+		Path:           filepath.Join(t.TempDir(), "github-local.db"),
+		ProjectID:      "detent",
+		TerminalStates: []string{"Done"},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer store.Close()
+
+	issue := connector.NewIssue()
+	issue.ID = "github:123:779"
+	issue.Identifier = "digitaldrywood/detent#779"
+	issue.Title = "Add local status mode"
+	issue.State = "Todo"
+	issue.Metadata = map[string]string{
+		MetadataGitHubNodeID:        "I_kwDOtest779",
+		MetadataGitHubRepositoryID:  "123",
+		MetadataGitHubIssueNumber:   "779",
+		MetadataGitHubUpstreamState: "open",
+	}
+	if err := store.UpsertIssues(ctx, []connector.Issue{issue}); err != nil {
+		t.Fatalf("UpsertIssues() error = %v", err)
+	}
+	if err := store.SetIssueField(ctx, "github:123:779", 42, "agent-1"); err != nil {
+		t.Fatalf("SetIssueField() error = %v", err)
+	}
+	if err := store.ClearIssueField(ctx, "github:123:779", 42); err != nil {
+		t.Fatalf("ClearIssueField() error = %v", err)
+	}
+	if err := store.CloseIssue(ctx, "github:123:779"); err != nil {
+		t.Fatalf("CloseIssue() error = %v", err)
+	}
+
+	issues, err := store.FetchIssueStatesByIdentifiers(ctx, []string{"digitaldrywood/detent#779"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(issues))
+	}
+	got := issues[0]
+	if got.State != "Done" {
+		t.Fatalf("State = %q, want Done", got.State)
+	}
+	if got.Metadata[MetadataGitHubNodeID] != "I_kwDOtest779" ||
+		got.Metadata[MetadataGitHubRepositoryID] != "123" ||
+		got.Metadata[MetadataGitHubIssueNumber] != "779" {
+		t.Fatalf("GitHub metadata = %#v", got.Metadata)
+	}
+	if value, ok := got.Fields[issueFieldKey(42)]; ok || value != "" {
+		t.Fatalf("issue field persisted = %q, ok=%v; want cleared", value, ok)
+	}
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -844,7 +844,7 @@ func workflowConfigWithProjectPaths(project globalconfig.Project, workflow workf
 	if workdir == "" {
 		return workflow
 	}
-	if workflow.Tracker.Kind == workflowconfig.TrackerLocalSQLite {
+	if workflow.Tracker.Kind == workflowconfig.TrackerLocalSQLite || workflow.Tracker.Kind == workflowconfig.TrackerGitHubLocal {
 		workflow.Tracker.LocalSQLite.Path = projectRelativePath(workdir, workflow.Tracker.LocalSQLite.Path)
 	}
 	if workflow.Workspace.Kind == workflowconfig.WorkspaceFilesystem {
@@ -868,7 +868,7 @@ func projectRelativePath(base string, path string) string {
 
 func workflowConfigWithGitHubToken(workflow workflowconfig.Config, token string) workflowconfig.Config {
 	token = strings.TrimSpace(token)
-	if token != "" && workflow.Tracker.Kind == workflowconfig.TrackerGitHub {
+	if token != "" && (workflow.Tracker.Kind == workflowconfig.TrackerGitHub || workflow.Tracker.Kind == workflowconfig.TrackerGitHubLocal) {
 		workflow.Tracker.APIKey = token
 	}
 	return workflow

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -502,6 +502,8 @@ type projectKanbanCard struct {
 	TimeInStage      string
 	TimeInStageTitle string
 	WaitDetail       string
+	AttentionLabel   string
+	AttentionDetail  string
 	MergeLaneStatus  string
 	MergeLaneDetail  string
 	MergeLaneClass   string
@@ -519,6 +521,12 @@ type projectKanbanCard struct {
 	Movable          bool
 	DisabledText     string
 }
+
+const (
+	githubLocalDivergenceMetadataKey       = "github_local_divergence"
+	githubLocalDivergenceDetailMetadataKey = "github_local_divergence_detail"
+	githubLocalClosedUpstreamDivergence    = "closed_upstream_local_active"
+)
 
 type projectOverviewCard struct {
 	ID       string
@@ -2596,6 +2604,8 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		TimeInStage:      prPipelineAge(stageAt, now),
 		TimeInStageTitle: prPipelineAgeTitle(state, stageAt, now),
 		WaitDetail:       prPipelineWaitDetail(issue),
+		AttentionLabel:   projectKanbanAttentionLabel(issue),
+		AttentionDetail:  projectKanbanAttentionDetail(issue),
 		Stage:            chartText(state, "n/a"),
 		StageAt:          stageAt.UTC(),
 		Labels:           uniqueStrings(issue.Labels),
@@ -2653,6 +2663,9 @@ func projectKanbanCompactChips(card projectKanbanCard) []projectKanbanCompactChi
 	if strings.TrimSpace(card.ConflictReason) != "" {
 		chips = append(chips, newProjectKanbanCompactChip("Conflict", card.ConflictReason, "border-danger-soft bg-danger-soft text-danger"))
 	}
+	if strings.TrimSpace(card.AttentionLabel) != "" {
+		chips = append(chips, newProjectKanbanCompactChip(card.AttentionLabel, card.AttentionDetail, "border-warning-soft bg-warning-soft text-warning"))
+	}
 	if len(card.Blockers) > 0 {
 		chips = append(chips, newProjectKanbanCompactChip(projectKanbanCountLabel(len(card.Blockers), "blocker", "blockers"), strings.Join(card.Blockers, ", "), "border-danger-soft bg-danger-soft text-danger"))
 	}
@@ -2660,6 +2673,27 @@ func projectKanbanCompactChips(card projectKanbanCard) []projectKanbanCompactChi
 		chips = append(chips, newProjectKanbanCompactChip("Waits", card.WaitDetail, "border-warning-soft bg-warning-soft text-warning"))
 	}
 	return chips
+}
+
+func projectKanbanAttentionLabel(issue telemetry.Issue) string {
+	switch strings.TrimSpace(issue.Metadata[githubLocalDivergenceMetadataKey]) {
+	case githubLocalClosedUpstreamDivergence:
+		return "Upstream closed"
+	default:
+		return ""
+	}
+}
+
+func projectKanbanAttentionDetail(issue telemetry.Issue) string {
+	if detail := strings.TrimSpace(issue.Metadata[githubLocalDivergenceDetailMetadataKey]); detail != "" {
+		return detail
+	}
+	switch strings.TrimSpace(issue.Metadata[githubLocalDivergenceMetadataKey]) {
+	case githubLocalClosedUpstreamDivergence:
+		return "closed upstream while locally active"
+	default:
+		return ""
+	}
 }
 
 func newProjectKanbanCompactChip(label string, title string, class string) projectKanbanCompactChip {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1457,6 +1457,15 @@ func TestProjectKanbanCompactChipsSummarizeSecondaryMetadata(t *testing.T) {
 			want: []string{"3m 0s", "1 blocker"},
 		},
 		{
+			name: "upstream-divergence",
+			card: projectKanbanCard{
+				TimeInStage:     "3m 0s",
+				AttentionLabel:  "Upstream closed",
+				AttentionDetail: "closed upstream while locally active",
+			},
+			want: []string{"3m 0s", "Upstream closed"},
+		},
+		{
 			name: "review",
 			card: projectKanbanCard{
 				HasPullRequest:   true,

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -44,6 +44,44 @@ func TestOnboardingDocsRequireMutationAuthorization(t *testing.T) {
 	assertContains(t, readme, "Defaults are recommendations only")
 }
 
+func TestDocsCoverGitHubLocalTrackerMode(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	readme := readRepositoryTextFile(t, "README.md")
+	template := readRepositoryTextFile(t, "docs/templates/WORKFLOW.github_local.md")
+
+	for _, want := range []string{
+		"WORKFLOW.github_local.md",
+		"tracker.kind: github_local",
+		"Do not set `tracker.github_status_source`",
+		"detent github-local import",
+		"does not create or mutate GitHub Projects, issue fields, repository labels, status labels, GitHub issue comments, or GitHub issue close state",
+	} {
+		assertContainsWords(t, onboarding, want)
+	}
+	for _, want := range []string{
+		"WORKFLOW.github_local.md",
+		"`tracker.kind: github_local` is a separate backend, not a fourth",
+		"detent github-local import",
+		"GitHub closes or transfers an imported issue while local state is still active",
+	} {
+		assertContainsWords(t, readme, want)
+	}
+	for _, want := range []string{
+		"kind: github_local",
+		"repository: <repo-owner>/<repo-name>",
+		"local_sqlite:",
+		"path: .detent/github-local-work-items.db",
+		"do not add `tracker.github_status_source`",
+	} {
+		assertContainsWords(t, template, want)
+	}
+	if strings.Contains(template, "github_status_source:") {
+		t.Fatal("WORKFLOW.github_local.md must not set github_status_source")
+	}
+}
+
 func TestOnboardingDocsRequireIdentityGateBeforeDiscovery(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add `tracker.kind: github_local` as a composite GitHub-read/local-SQLite status backend
- add local import CLI, doctor/readiness support, local divergence board chip, and docs/template coverage
- extend local SQLite persistence for GitHub identity, local fields, close events, and restart-safe imports

Fixes #779

## Test Plan

- [x] `make check`