### PR TITLE
feat(orchestrator): bound rework loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -1509,7 +1509,9 @@ of that state is controlled by the workflow:
   auto-promotion; verdicts below `min_score` or with severities in `block_on`
   route the issue to `Rework`.
 - `agent.auto_promote.rework_limit` bounds repeated `Human Review` to `Rework`
-  loops using persisted lane events; `0` leaves the loop unlimited.
+  loops using persisted lane events; `0` leaves the loop unlimited. Positive
+  limits require `Blocked` in a configured tracker state list and route the next
+  over-limit rework decision there with repeated reasons summarized for handoff.
 - `gate.kind: human_review` requires a linked open PR plus the configured
   `approval_label` on the issue.
 

--- a/README.md
+++ b/README.md
@@ -683,6 +683,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
+    rework_limit: 0
   skills:
     enabled: true
     path: .detent/skills
@@ -1507,6 +1508,8 @@ of that state is controlled by the workflow:
 - `gate.validator.enabled: true` runs a validator-agent review before
   auto-promotion; verdicts below `min_score` or with severities in `block_on`
   route the issue to `Rework`.
+- `agent.auto_promote.rework_limit` bounds repeated `Human Review` to `Rework`
+  loops using persisted lane events; `0` leaves the loop unlimited.
 - `gate.kind: human_review` requires a linked open PR plus the configured
   `approval_label` on the issue.
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2089,8 +2089,9 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    to `Rework`. Failed or cancelled current-head CI also routes the item to
    `Rework` by default; set `ci_failure_action: skip` only when red CI should
    stay parked in `Human Review`. `agent.auto_promote.rework_limit: 0` leaves
-   repeated rework unlimited; a positive value blocks the next lap after that
-   many persisted Rework entries. Pending CI stays parked. The quiet
+   repeated rework unlimited; a positive value requires `Blocked` in a configured
+   tracker state list and blocks the next lap after that many persisted Rework
+   entries. Pending CI stays parked. The quiet
    period resets on observed issue updates, Project
    status updates, automated PR review submission, and linked PR activity such
    as a fresh push to the PR head. With `gate.validator.enabled: true`, a

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2036,7 +2036,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    policy, and dependency policy selected by the human. Verify:
 
    ```sh
-   rg -n 'max_concurrent_agents: <max>|Merging: 1|dispatch_priority_by_label:|auto_promote:|dependency_auto_unblock:|enabled: <true|false>|quiet_seconds: <seconds>|optout_label: <label>|allowed_issue_labels:|source_states:|target_state:|readiness:' \
+   rg -n 'max_concurrent_agents: <max>|Merging: 1|dispatch_priority_by_label:|auto_promote:|dependency_auto_unblock:|enabled: <true|false>|quiet_seconds: <seconds>|optout_label: <label>|allowed_issue_labels:|rework_limit:|source_states:|target_state:|readiness:' \
      <source-root>/WORKFLOW.md
    ```
 
@@ -2065,6 +2065,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
        quiet_seconds: 600
        optout_label: requires-human-review
        allowed_issue_labels: []
+       rework_limit: 0
    ```
 
    Criteria-based auto-promote example:
@@ -2077,6 +2078,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
        optout_label: <optout-label>
        allowed_issue_labels:
          - <allowed-label>
+       rework_limit: <0-or-max-rework-laps>
    ```
 
    For a command gate, auto-promote requires a linked open PR, green CI, no P1
@@ -2086,7 +2088,9 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    not required to exist, but any observed P1 bot findings still route the item
    to `Rework`. Failed or cancelled current-head CI also routes the item to
    `Rework` by default; set `ci_failure_action: skip` only when red CI should
-   stay parked in `Human Review`. Pending CI stays parked. The quiet
+   stay parked in `Human Review`. `agent.auto_promote.rework_limit: 0` leaves
+   repeated rework unlimited; a positive value blocks the next lap after that
+   many persisted Rework entries. Pending CI stays parked. The quiet
    period resets on observed issue updates, Project
    status updates, automated PR review submission, and linked PR activity such
    as a fresh push to the PR head. With `gate.validator.enabled: true`, a

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -71,6 +71,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
+    rework_limit: 0
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -71,6 +71,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
+    rework_limit: 0
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -71,6 +71,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
+    rework_limit: 0
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -36,6 +36,7 @@ agent:
     source_state: Review
     pass_state: Ready for Pickup
     rework_state: Rework
+    rework_limit: 0
 
 gate:
   kind: artifact

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -70,6 +70,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
+    rework_limit: 0
   skills:
     enabled: true
     path: .detent/skills

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -946,6 +946,17 @@ func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.C
 			Hint:   "Add " + reworkState + " to tracker.active_states or tracker.terminal_states.",
 		}
 	}
+	if cfg.Agent.AutoPromote.ReworkLimit > 0 &&
+		!doctorStateInList("Blocked", cfg.Tracker.ActiveStates) &&
+		!doctorStateInList("Blocked", cfg.Tracker.ObservedStates) &&
+		!doctorStateInList("Blocked", cfg.Tracker.TerminalStates) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorFail,
+			Detail: "agent.auto_promote.rework_limit is greater than 0 but Blocked is not configured in tracker.active_states, tracker.observed_states, or tracker.terminal_states",
+			Hint:   "Add Blocked to a tracker state list so rework-limit handoff status writes can be provisioned and verified.",
+		}
+	}
 	if !doctorTrackerUsesGitHubReads(cfg.Tracker.Kind) {
 		return doctorCheck{
 			Name:   name,
@@ -999,13 +1010,21 @@ func checkDoctorAutoPromoteLive(
 	if passState == "" {
 		passState = "Merging"
 	}
+	reworkState := strings.TrimSpace(cfg.Agent.AutoPromote.ReworkState)
+	if reworkState == "" {
+		reworkState = "Rework"
+	}
 	if verifier, ok := projectConnector.(doctorStatusOptionVerifier); ok {
-		if err := verifier.VerifyStatusOptions(ctx, []string{sourceState, passState}); err != nil {
+		verifyStates := []string{sourceState, passState, reworkState}
+		if cfg.Agent.AutoPromote.ReworkLimit > 0 {
+			verifyStates = append(verifyStates, "Blocked")
+		}
+		if err := verifier.VerifyStatusOptions(ctx, verifyStates); err != nil {
 			return doctorCheck{
 				Name:   name,
 				Status: doctorFail,
 				Detail: fmt.Sprintf("status option verification failed: %v", err),
-				Hint:   "Ensure source_state and pass_state resolve through tracker.state_map to existing GitHub Project Status options.",
+				Hint:   "Ensure auto-promote source, pass, rework, and rework-limit target states resolve through tracker.state_map to existing GitHub Project Status options.",
 			}
 		}
 	}
@@ -1226,6 +1245,7 @@ func doctorAutoPromoteConfig(cfg workflowconfig.Config) orchestrator.AutoPromote
 		SourceState:        cfg.Agent.AutoPromote.SourceState,
 		PassState:          cfg.Agent.AutoPromote.PassState,
 		ReworkState:        cfg.Agent.AutoPromote.ReworkState,
+		ReworkLimit:        cfg.Agent.AutoPromote.ReworkLimit,
 		Gate:               cfg.Gate,
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -450,6 +450,17 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 			wantDetails: []string{"tracker.active_states", "Merging"},
 		},
 		{
+			name: "missing blocked state with rework limit",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorAutoPromoteWorkflow()
+				cfg.Agent.AutoPromote.ReworkLimit = 1
+				cfg.Tracker.ObservedStates = []string{"Human Review"}
+				return cfg
+			}(),
+			want:        doctorFail,
+			wantDetails: []string{"agent.auto_promote.rework_limit", "Blocked", "tracker.observed_states"},
+		},
+		{
 			name: "status option verification fails",
 			cfg:  validDoctorAutoPromoteWorkflow(),
 			connector: &fakeDoctorAutoPromoteConnector{
@@ -516,6 +527,28 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCheckDoctorAutoPromoteVerifiesBlockedStatusWhenReworkLimitEnabled(t *testing.T) {
+	t.Parallel()
+
+	cfg := validDoctorAutoPromoteWorkflow()
+	cfg.Agent.AutoPromote.ReworkLimit = 1
+	fake := &fakeDoctorAutoPromoteConnector{}
+	got := checkDoctorAutoPromote(context.Background(), "alpha", cfg, doctorDeps{
+		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+			return fake, nil
+		},
+	}, time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC))
+
+	if got.Status != doctorOK {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorOK, got)
+	}
+	for _, want := range []string{"Human Review", "Merging", "Rework", "Blocked"} {
+		if !stringSliceContains(fake.verifyStates, want) {
+			t.Fatalf("VerifyStatusOptions states = %#v, want %q", fake.verifyStates, want)
+		}
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -265,6 +265,7 @@ type AutoPromote struct {
 	SourceState        string   `yaml:"source_state,omitempty"`
 	PassState          string   `yaml:"pass_state,omitempty"`
 	ReworkState        string   `yaml:"rework_state,omitempty"`
+	ReworkLimit        int      `yaml:"rework_limit,omitempty"`
 }
 
 type Lessons struct {
@@ -1387,6 +1388,9 @@ func (a *AutoPromote) validate(prefix string, problems *[]string) {
 	}
 	if strings.TrimSpace(a.ReworkState) == "" {
 		*problems = append(*problems, prefix+".rework_state must not be blank")
+	}
+	if a.ReworkLimit < 0 {
+		*problems = append(*problems, prefix+".rework_limit must be greater than or equal to 0")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -810,6 +810,7 @@ func (c *Config) Validate() error {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
 	}
 	c.Agent.validate("agent", &problems)
+	c.validateAutoPromoteReworkLimit(&problems)
 	c.Agents.validate(&problems)
 	c.Codex.validate(&problems)
 	problems = append(problems, gate.Validate("gate", c.Gate)...)
@@ -1009,6 +1010,18 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.github_rest_fanout_max_requests", c.Tracker.GitHubRESTFanoutMaxRequests, problems)
 	*problems = append(*problems, c.Tracker.Claims.Validate("tracker.claims")...)
 	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
+}
+
+func (c *Config) validateAutoPromoteReworkLimit(problems *[]string) {
+	if c.Agent.AutoPromote.ReworkLimit <= 0 {
+		return
+	}
+	if stateListContains(c.Tracker.ActiveStates, "Blocked") ||
+		stateListContains(c.Tracker.ObservedStates, "Blocked") ||
+		stateListContains(c.Tracker.TerminalStates, "Blocked") {
+		return
+	}
+	*problems = append(*problems, "tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.rework_limit is greater than 0")
 }
 
 func (l *LocalSQLite) Normalize() {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1681,6 +1681,30 @@ Prompt
 			},
 		},
 		{
+			name: "auto promote rework limit requires blocked state",
+			raw: `---
+tracker:
+  kind: memory
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Human Review
+  terminal_states:
+    - Done
+agent:
+  auto_promote:
+    rework_limit: 1
+---
+Prompt
+`,
+			want: []string{
+				"tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.rework_limit is greater than 0",
+			},
+		},
+		{
 			name: "invalid paths and priority map",
 			raw: `---
 tracker:

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -100,6 +100,7 @@ agent:
     enabled: true
     quiet_seconds: 0
     optout_label: Requires-Human-Review
+    rework_limit: 3
     allowed_issue_labels:
       - enhancement
   lessons:
@@ -288,6 +289,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Agent.AutoPromote.OptoutLabel != "requires-human-review" {
 		t.Fatalf("Agent.AutoPromote.OptoutLabel = %q", cfg.Agent.AutoPromote.OptoutLabel)
+	}
+	if cfg.Agent.AutoPromote.ReworkLimit != 3 {
+		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want 3", cfg.Agent.AutoPromote.ReworkLimit)
 	}
 	if !cfg.Codex.ApprovalPolicy.IsString || cfg.Codex.ApprovalPolicy.String != "never" {
 		t.Fatalf("Codex.ApprovalPolicy = %#v, want string never", cfg.Codex.ApprovalPolicy)
@@ -549,6 +553,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.Skills.Path != ".detent/skills" {
 		t.Fatalf("Agent.Skills.Path = %q", cfg.Agent.Skills.Path)
+	}
+	if cfg.Agent.AutoPromote.ReworkLimit != 0 {
+		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want unlimited default", cfg.Agent.AutoPromote.ReworkLimit)
 	}
 	if !cfg.Codex.ApprovalPolicy.IsMap {
 		t.Fatalf("Codex.ApprovalPolicy = %#v, want map default", cfg.Codex.ApprovalPolicy)
@@ -1656,6 +1663,21 @@ Prompt
 `,
 			want: []string{
 				"gate.transient_ci_retry_limit must be greater than or equal to 0",
+			},
+		},
+		{
+			name: "invalid auto promote rework limit",
+			raw: `---
+tracker:
+  kind: memory
+agent:
+  auto_promote:
+    rework_limit: -1
+---
+Prompt
+`,
+			want: []string{
+				"agent.auto_promote.rework_limit must be greater than or equal to 0",
 			},
 		},
 		{

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -16,6 +16,7 @@ type AutoPromoteConfig struct {
 	SourceState        string
 	PassState          string
 	ReworkState        string
+	ReworkLimit        int
 	Gate               gate.Config
 }
 
@@ -146,6 +147,9 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	cfg.ReworkState = strings.TrimSpace(cfg.ReworkState)
 	if cfg.ReworkState == "" {
 		cfg.ReworkState = autoPromoteReworkState
+	}
+	if cfg.ReworkLimit < 0 {
+		cfg.ReworkLimit = 0
 	}
 	cfg.Gate = gate.Effective(cfg.Gate)
 	return cfg

--- a/internal/orchestrator/autopromote_integration_test.go
+++ b/internal/orchestrator/autopromote_integration_test.go
@@ -11,6 +11,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestRunAutoPromotesQuietHumanReviewIssueThroughMemoryConnector(t *testing.T) {
@@ -152,6 +154,115 @@ func TestRunAutoPromoteUsesRuntimeQuietDurationUpdate(t *testing.T) {
 			}
 		case <-deadline:
 			t.Fatal("timed out waiting for auto-promote after quiet duration update")
+		}
+	}
+}
+
+func TestRunAutoPromoteBlocksAfterPersistedReworkLimitSurvivesRestart(t *testing.T) {
+	t.Parallel()
+
+	reviewedAt := time.Now().Add(-20 * time.Minute)
+	issue := testIssue("issue-auto-promote-rework-limit", "digitaldrywood/detent#857", "Human Review")
+	issue.Labels = []string{"bug"}
+	issue.PullRequest = &connector.PullRequest{
+		Number:                 857,
+		URL:                    "https://github.com/digitaldrywood/detent/pull/857",
+		State:                  "OPEN",
+		CIStatus:               "pass",
+		CodexReviewState:       "P1",
+		CodexReviewSubmittedAt: &reviewedAt,
+		CodexReviewFindings: []connector.PullRequestFinding{{
+			Body: "Validator found the same failing acceptance criterion.",
+			URL:  "https://github.com/digitaldrywood/detent/pull/857#pullrequestreview-1",
+		}},
+	}
+
+	ctx := context.Background()
+	dbPath := t.TempDir() + "/detent.db"
+	seedStore, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store.Open() seed error = %v", err)
+	}
+	if _, err := seedStore.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+		ProjectID:    "detent",
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Rework",
+		Reason:       string(orchestrator.AutoPromoteReasonP1Findings),
+		Status:       "entered",
+		StartedAt:    time.Now().Add(-2 * time.Hour),
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	if err := seedStore.Close(); err != nil {
+		t.Fatalf("seed store Close() error = %v", err)
+	}
+
+	restartedStore, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store.Open() restart error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := restartedStore.Close(); err != nil {
+			t.Fatalf("restart store Close() error = %v", err)
+		}
+	})
+
+	events := make(chan memory.Event, 4)
+	tracker := memory.New(memory.Config{
+		Issues: []connector.Issue{issue},
+		EventSink: func(event memory.Event) {
+			events <- event
+		},
+	})
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Hour,
+		MaxConcurrentAgents: 1,
+		Project:             scheduler.ProjectCandidate{ID: "detent", Weight: 1},
+		AutoPromote: orchestrator.AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			ReworkLimit:   1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Human Review"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	}, orchestrator.Dependencies{
+		Connector:       tracker,
+		Runner:          &staticRunner{},
+		WorkflowMetrics: restartedStore,
+		Logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	var gotStateUpdate bool
+	var gotComment bool
+	deadline := time.After(time.Second)
+	for !gotStateUpdate || !gotComment {
+		select {
+		case event := <-events:
+			switch event.Kind {
+			case memory.EventKindStateUpdate:
+				if event.IssueID == issue.ID && event.State == "Blocked" {
+					gotStateUpdate = true
+				}
+			case memory.EventKindComment:
+				if event.IssueID == issue.ID &&
+					strings.Contains(event.Body, "Rework limit was reached") &&
+					strings.Contains(event.Body, "repeated_rework_reasons: p1_findings x1") &&
+					strings.Contains(event.Body, "Validator found the same failing acceptance criterion.") {
+					gotComment = true
+				}
+			}
+		case <-deadline:
+			t.Fatalf("timed out waiting for Blocked auto-promote events; state_update=%v comment=%v", gotStateUpdate, gotComment)
 		}
 	}
 }

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2,13 +2,16 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -28,6 +31,17 @@ type autoPromoteTickResult struct {
 type staleMergingPullRequestDecision struct {
 	targetState string
 	reason      string
+}
+
+type autoPromoteReworkLimitSummary struct {
+	Limit        int
+	Count        int
+	ReasonCounts []autoPromoteReworkReasonCount
+}
+
+type autoPromoteReworkReasonCount struct {
+	Reason string
+	Count  int
 }
 
 func (o *Orchestrator) autoPromoteHumanReviewIssues(
@@ -1152,7 +1166,32 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
+	transitionReason := string(decision.Reason)
+	body := autoPromoteComment(summary, decision, displayStateName(issue.State), targetState)
+	if decision.Action == AutoPromoteActionRework {
+		limit, err := o.autoPromoteReworkLimit(ctx, issue)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn(
+					"auto promote rework limit check failed",
+					"issue_id", issueID,
+					"identifier", issue.Identifier,
+					"action", decision.Action,
+					"reason", decision.Reason,
+					"target_state", targetState,
+					"error", err,
+				)
+			}
+			return false
+		}
+		if limit.Exceeded() {
+			targetState = blockedStatusState
+			transitionReason = "rework_limit"
+			body = autoPromoteReworkLimitComment(summary, decision, displayStateName(issue.State), limit)
+		}
+	}
+
+	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, transitionReason); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"auto promote transition failed",
@@ -1167,7 +1206,6 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 		return false
 	}
 
-	body := autoPromoteComment(summary, decision, displayStateName(issue.State), targetState)
 	if strings.TrimSpace(body) != "" {
 		if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
 			o.logger.Warn(
@@ -1189,6 +1227,80 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 		Message: "auto-promoted " + issueLabel(issue) + " from " + autoPromoteSourceState + " to " + targetState,
 	})
 	return true
+}
+
+func (s autoPromoteReworkLimitSummary) Exceeded() bool {
+	return s.Limit > 0 && s.Count >= s.Limit
+}
+
+func (o *Orchestrator) autoPromoteReworkLimit(
+	ctx context.Context,
+	issue connector.Issue,
+) (autoPromoteReworkLimitSummary, error) {
+	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	summary := autoPromoteReworkLimitSummary{Limit: cfg.ReworkLimit}
+	if cfg.ReworkLimit <= 0 {
+		return summary, nil
+	}
+	if normalizeState(issue.State) == normalizeState(cfg.ReworkState) {
+		return summary, nil
+	}
+	reader, ok := o.workflowMetrics.(WorkflowMetricsTimelineReader)
+	if !ok || reader == nil {
+		return summary, errors.New("workflow metrics timeline reader unavailable")
+	}
+
+	timeline, err := reader.IssueWorkflowTimeline(ctx, store.IssueIdentity{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		IssueURL:   issue.URL,
+	})
+	if err != nil {
+		return summary, err
+	}
+	entries := autoPromoteReworkLaneEntries(timeline.Events, cfg.ReworkState)
+	summary.Count = len(entries)
+	summary.ReasonCounts = autoPromoteReworkReasonCounts(entries)
+	return summary, nil
+}
+
+func autoPromoteReworkLaneEntries(events []store.WorkflowPhaseEvent, reworkState string) []store.WorkflowPhaseEvent {
+	reworkState = normalizeState(reworkState)
+	entries := make([]store.WorkflowPhaseEvent, 0, len(events))
+	for _, event := range events {
+		if event.PhaseType != store.WorkflowPhaseTypeLane {
+			continue
+		}
+		if normalizeState(event.PhaseName) != reworkState {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			continue
+		}
+		entries = append(entries, event)
+	}
+	return entries
+}
+
+func autoPromoteReworkReasonCounts(events []store.WorkflowPhaseEvent) []autoPromoteReworkReasonCount {
+	counts := map[string]int{}
+	order := make([]string, 0, len(events))
+	for _, event := range events {
+		reason := strings.TrimSpace(event.Reason)
+		if reason == "" {
+			reason = "state_transition"
+		}
+		if _, ok := counts[reason]; !ok {
+			order = append(order, reason)
+		}
+		counts[reason]++
+	}
+
+	out := make([]autoPromoteReworkReasonCount, 0, len(order))
+	for _, reason := range order {
+		out = append(out, autoPromoteReworkReasonCount{Reason: reason, Count: counts[reason]})
+	}
+	return out
 }
 
 func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision AutoPromoteDecision, targetState string) {
@@ -1303,6 +1415,70 @@ func autoPromoteComment(
 	}
 
 	return b.String()
+}
+
+func autoPromoteReworkLimitComment(
+	summary AutoPromoteSummary,
+	decision AutoPromoteDecision,
+	sourceState string,
+	limit autoPromoteReworkLimitSummary,
+) string {
+	var b strings.Builder
+	sourceState = displayStateName(sourceState)
+	if sourceState == "" {
+		sourceState = autoPromoteSourceState
+	}
+	b.WriteString("Auto-promote routed this issue from ")
+	b.WriteString(sourceState)
+	b.WriteString(" to Blocked because the Rework limit was reached.")
+	b.WriteString("\n\n")
+	b.WriteString("- rework_limit: ")
+	b.WriteString(strconv.Itoa(limit.Limit))
+	b.WriteString("\n- prior_rework_transitions: ")
+	b.WriteString(strconv.Itoa(limit.Count))
+	b.WriteString("\n- current_rework_reason: ")
+	b.WriteString(string(decision.Reason))
+	if reasons := autoPromoteReworkReasonsText(limit.ReasonCounts); reasons != "" {
+		b.WriteString("\n- repeated_rework_reasons: ")
+		b.WriteString(reasons)
+	}
+	if summary.PullRequestURL != "" {
+		b.WriteString("\n- pull request: ")
+		b.WriteString(summary.PullRequestURL)
+	}
+	if summary.MergeableState != "" {
+		b.WriteString("\n- mergeable_state: ")
+		b.WriteString(summary.MergeableState)
+	}
+	if decision.CIStatus != "" {
+		b.WriteString("\n- ci_status: ")
+		b.WriteString(decision.CIStatus)
+	}
+	if failedChecks := strings.Join(summary.FailedChecks, ", "); failedChecks != "" {
+		b.WriteString("\n- failed_checks: ")
+		b.WriteString(failedChecks)
+	}
+
+	if len(decision.Findings) > 0 {
+		b.WriteString("\n\nCurrent findings:")
+		for _, finding := range decision.Findings {
+			b.WriteString("\n- ")
+			b.WriteString(autoPromoteFindingText(finding))
+		}
+	}
+
+	return b.String()
+}
+
+func autoPromoteReworkReasonsText(counts []autoPromoteReworkReasonCount) string {
+	parts := make([]string, 0, len(counts))
+	for _, count := range counts {
+		if strings.TrimSpace(count.Reason) == "" || count.Count <= 0 {
+			continue
+		}
+		parts = append(parts, fmt.Sprintf("%s x%d", count.Reason, count.Count))
+	}
+	return strings.Join(parts, ", ")
 }
 
 func autoPromoteFindingText(finding AutoPromoteFinding) string {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
@@ -106,6 +107,7 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			cfg: AutoPromoteConfig{
 				Enabled:       true,
 				QuietDuration: 10 * time.Minute,
+				ReworkLimit:   0,
 			},
 			issue: autoPromoteTickIssue("issue-p1", []string{"bug"}, &connector.PullRequest{
 				Number:                 43,
@@ -313,6 +315,91 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestTickAutoPromoteBlocksWhenReworkLimitReached(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 2, 16, 10, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-rework-limit", []string{"bug"}, &connector.PullRequest{
+		Number:                 43,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/43",
+		State:                  "OPEN",
+		CIStatus:               "pass",
+		CodexReviewState:       "P1",
+		CodexReviewSubmittedAt: &oldReview,
+		CodexReviewFindings: []connector.PullRequestFinding{{
+			Body: "![P1 Badge](https://example.test/p1.svg) Unsafe migration.",
+			URL:  "https://github.test/digitaldrywood/detent/pull/43#pullrequestreview-1",
+		}},
+	})
+	issue.Identifier = "digitaldrywood/detent#857"
+	issue.URL = "https://github.test/digitaldrywood/detent/issues/857"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			ReworkLimit:   1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Rework",
+		Reason:       string(AutoPromoteReasonP1Findings),
+		Status:       "entered",
+		StartedAt:    now.Add(-2 * time.Hour),
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	orch := &Orchestrator{
+		cfg:             cfg,
+		connector:       tracker,
+		workflowMetrics: metrics,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Blocked"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one Blocked handoff comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Auto-promote routed this issue from Human Review to Blocked because the Rework limit was reached.",
+		"rework_limit: 1",
+		"prior_rework_transitions: 1",
+		"current_rework_reason: p1_findings",
+		"repeated_rework_reasons: p1_findings x1",
+		"Unsafe migration.",
+		"https://github.test/digitaldrywood/detent/pull/43#pullrequestreview-1",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	events := metrics.snapshot()
+	if len(events) != 3 {
+		t.Fatalf("workflow metric events = %#v, want prior Rework plus exit/Blocked enter", events)
+	}
+	blocked := events[2]
+	if blocked.PhaseName != "Blocked" || blocked.Status != "entered" || blocked.Reason != "rework_limit" {
+		t.Fatalf("blocked metric = %#v, want Blocked entered with rework_limit reason", blocked)
 	}
 }
 
@@ -2935,6 +3022,47 @@ type autoPromoteTickHydration struct {
 	issueID    string
 	repository string
 	number     int
+}
+
+type autoPromoteWorkflowMetricsRecorder struct {
+	mu     sync.Mutex
+	events []store.WorkflowPhaseEvent
+}
+
+func (r *autoPromoteWorkflowMetricsRecorder) RecordWorkflowPhaseEvent(_ context.Context, event store.WorkflowPhaseEvent) (int64, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.events = append(r.events, event)
+	return int64(len(r.events)), nil
+}
+
+func (r *autoPromoteWorkflowMetricsRecorder) IssueWorkflowTimeline(_ context.Context, identity store.IssueIdentity) (store.WorkflowTimeline, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	events := make([]store.WorkflowPhaseEvent, 0, len(r.events))
+	for _, event := range r.events {
+		if event.IssueID != "" && event.IssueID == identity.IssueID {
+			events = append(events, event)
+			continue
+		}
+		if event.Identifier != "" && event.Identifier == identity.Identifier {
+			events = append(events, event)
+			continue
+		}
+		if event.IssueURL != "" && event.IssueURL == identity.IssueURL {
+			events = append(events, event)
+		}
+	}
+	return store.WorkflowTimeline{Events: events}, nil
+}
+
+func (r *autoPromoteWorkflowMetricsRecorder) snapshot() []store.WorkflowPhaseEvent {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	return append([]store.WorkflowPhaseEvent(nil), r.events...)
 }
 
 type autoPromoteTickConnector struct {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -33,6 +33,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.QuietSeconds = 30
 	cfg.Agent.AutoPromote.OptoutLabel = " Requires-Human-Review "
 	cfg.Agent.AutoPromote.AllowedIssueLabels = []string{" Docs ", "docs", "Chore"}
+	cfg.Agent.AutoPromote.ReworkLimit = 2
 	cfg.Identity.Name = "release-captain"
 	cfg.Identity.GitHubLogin = "detent-bot"
 	cfg.Tracker.Authorization = selector.Selector{
@@ -74,6 +75,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 		got.AutoPromote.AllowedIssueLabels[0] != "docs" ||
 		got.AutoPromote.AllowedIssueLabels[1] != "chore" {
 		t.Fatalf("AutoPromote.AllowedIssueLabels = %#v, want docs and chore", got.AutoPromote.AllowedIssueLabels)
+	}
+	if got.AutoPromote.ReworkLimit != 2 {
+		t.Fatalf("AutoPromote.ReworkLimit = %d, want 2", got.AutoPromote.ReworkLimit)
 	}
 	if got.SelectorContext.InstanceLogin != "detent-bot" {
 		t.Fatalf("SelectorContext.InstanceLogin = %q, want detent-bot", got.SelectorContext.InstanceLogin)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -197,6 +197,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			SourceState:        cfg.Agent.AutoPromote.SourceState,
 			PassState:          cfg.Agent.AutoPromote.PassState,
 			ReworkState:        cfg.Agent.AutoPromote.ReworkState,
+			ReworkLimit:        cfg.Agent.AutoPromote.ReworkLimit,
 			Gate:               gate.Effective(cfg.Gate),
 		}),
 		Plan: gate.EffectivePlan(cfg.Plan),

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -15,6 +15,10 @@ type WorkflowMetricsRecorder interface {
 	RecordWorkflowPhaseEvent(context.Context, store.WorkflowPhaseEvent) (int64, error)
 }
 
+type WorkflowMetricsTimelineReader interface {
+	IssueWorkflowTimeline(context.Context, store.IssueIdentity) (store.WorkflowTimeline, error)
+}
+
 func (o *Orchestrator) updateIssueState(
 	ctx context.Context,
 	issue connector.Issue,


### PR DESCRIPTION
## Summary

- Add `agent.auto_promote.rework_limit` with `0` preserving unlimited rework behavior.
- Count prior Rework lane entries from persisted workflow metrics and route over-limit rework decisions to Blocked with repeated-reason context.
- Document the default in workflow templates and README/ONBOARDING.

Fixes #857

## Test Plan

- [x] `go test ./internal/config`
- [x] `go test ./internal/orchestrator`
- [x] `make check`