### PR TITLE
feat(runner): add handoff notes

### DIFF
--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -2,6 +2,7 @@ package notes
 
 import (
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"regexp"
@@ -39,6 +40,10 @@ func WorkspacePath(workspacePath string) (string, error) {
 }
 
 func Append(path string, entry Entry, opts AppendOptions) error {
+	if err := rejectSymlinkedNotesPath(path); err != nil {
+		return err
+	}
+
 	now := opts.Now
 	if now.IsZero() {
 		now = time.Now().UTC()
@@ -54,6 +59,9 @@ func Append(path string, entry Entry, opts AppendOptions) error {
 	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
 		return err
 	}
+	if err := rejectSymlinkedNotesPath(path); err != nil {
+		return err
+	}
 	return os.WriteFile(path, []byte(strings.Join(entries, "\n\n")+"\n"), 0o600)
 }
 
@@ -67,6 +75,9 @@ func Read(path string, opts ReadOptions) (string, error) {
 }
 
 func ReadAll(path string) ([]string, error) {
+	if err := rejectSymlinkedNotesPath(path); err != nil {
+		return nil, err
+	}
 	content, err := os.ReadFile(path)
 	if errors.Is(err, os.ErrNotExist) {
 		return []string{}, nil
@@ -75,6 +86,22 @@ func ReadAll(path string) ([]string, error) {
 		return nil, err
 	}
 	return parseEntries(string(content)), nil
+}
+
+func rejectSymlinkedNotesPath(path string) error {
+	for _, candidate := range []string{filepath.Dir(path), path} {
+		info, err := os.Lstat(candidate)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return err
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			return fmt.Errorf("handoff notes path must not be a symlink: %s", candidate)
+		}
+	}
+	return nil
 }
 
 func Tail(text string, limit int) string {

--- a/internal/notes/notes.go
+++ b/internal/notes/notes.go
@@ -1,0 +1,183 @@
+package notes
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/pathsafe"
+)
+
+const (
+	DefaultPath      = ".detent/notes.md"
+	DefaultMaxBytes  = 64 * 1024
+	DefaultTailBytes = 16 * 1024
+)
+
+var entryHeadingPattern = regexp.MustCompile(`^## \d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z - `)
+
+type Entry struct {
+	Title string
+	Body  string
+}
+
+type AppendOptions struct {
+	Now      time.Time
+	MaxBytes int
+}
+
+type ReadOptions struct {
+	MaxBytes int
+}
+
+func WorkspacePath(workspacePath string) (string, error) {
+	return pathsafe.WorkspaceRelative(workspacePath, DefaultPath)
+}
+
+func Append(path string, entry Entry, opts AppendOptions) error {
+	now := opts.Now
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+
+	entries, err := ReadAll(path)
+	if err != nil {
+		return err
+	}
+	entries = append(entries, renderEntry(entry, now.UTC()))
+	entries = compactEntries(entries, maxBytes(opts.MaxBytes))
+
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(strings.Join(entries, "\n\n")+"\n"), 0o600)
+}
+
+func Read(path string, opts ReadOptions) (string, error) {
+	entries, err := ReadAll(path)
+	if err != nil {
+		return "", err
+	}
+	entries = compactEntries(entries, maxBytes(opts.MaxBytes))
+	return strings.Join(entries, "\n\n"), nil
+}
+
+func ReadAll(path string) ([]string, error) {
+	content, err := os.ReadFile(path)
+	if errors.Is(err, os.ErrNotExist) {
+		return []string{}, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	return parseEntries(string(content)), nil
+}
+
+func Tail(text string, limit int) string {
+	if limit <= 0 || text == "" {
+		return ""
+	}
+	if len(text) <= limit {
+		return text
+	}
+	return "[truncated to last " + tailLimitLabel(limit) + "]\n" + text[len(text)-limit:]
+}
+
+func tailLimitLabel(limit int) string {
+	if limit >= 1024 && limit%1024 == 0 {
+		return strconv.Itoa(limit/1024) + " KiB"
+	}
+	return strconv.Itoa(limit) + " bytes"
+}
+
+func renderEntry(entry Entry, now time.Time) string {
+	title := strings.Join(strings.Fields(entry.Title), " ")
+	if title == "" {
+		title = "Handoff note"
+	}
+	title = strings.ReplaceAll(title, "\n", " ")
+
+	body := normalizeBody(entry.Body)
+	if body == "" {
+		body = "_No details recorded._"
+	}
+
+	return "## " + now.Format("2006-01-02T15:04:05Z") + " - " + title + "\n\n" + body
+}
+
+func normalizeBody(body string) string {
+	body = strings.ReplaceAll(body, "\r\n", "\n")
+	body = strings.ReplaceAll(body, "\r", "\n")
+	return strings.TrimSpace(body)
+}
+
+func parseEntries(content string) []string {
+	normalized := strings.ReplaceAll(content, "\r\n", "\n")
+	lines := strings.Split(normalized, "\n")
+	entries := make([]string, 0)
+	var current []string
+
+	for _, line := range lines {
+		if entryHeadingPattern.MatchString(line) {
+			if entry := strings.TrimSpace(strings.Join(current, "\n")); entry != "" {
+				entries = append(entries, entry)
+			}
+			current = []string{line}
+			continue
+		}
+		current = append(current, line)
+	}
+	if entry := strings.TrimSpace(strings.Join(current, "\n")); entry != "" {
+		entries = append(entries, entry)
+	}
+
+	return entries
+}
+
+func compactEntries(entries []string, limit int) []string {
+	if len(entries) == 0 {
+		return []string{}
+	}
+	for len(entries) > 1 && entriesSize(entries) > limit {
+		entries = entries[1:]
+	}
+	if entriesSize(entries) <= limit {
+		return entries
+	}
+	return []string{trimEntry(entries[len(entries)-1], limit)}
+}
+
+func trimEntry(entry string, limit int) string {
+	if limit <= 0 || len(entry) <= limit {
+		return entry
+	}
+	heading, body, ok := strings.Cut(entry, "\n\n")
+	if !ok {
+		return Tail(entry, limit)
+	}
+	prefix := heading + "\n\n"
+	remaining := limit - len(prefix)
+	if remaining <= 0 {
+		return Tail(entry, limit)
+	}
+	return prefix + Tail(body, remaining)
+}
+
+func entriesSize(entries []string) int {
+	if len(entries) == 0 {
+		return 0
+	}
+	size := len(strings.Join(entries, "\n\n")) + 1
+	return size
+}
+
+func maxBytes(value int) int {
+	if value <= 0 {
+		return DefaultMaxBytes
+	}
+	return value
+}

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -1,0 +1,101 @@
+package notes
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadMissingNotesReturnsEmpty(t *testing.T) {
+	t.Parallel()
+
+	content, err := Read(filepath.Join(t.TempDir(), ".detent", "notes.md"), ReadOptions{})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if content != "" {
+		t.Fatalf("Read() = %q, want empty", content)
+	}
+}
+
+func TestAppendTimestampsAndDropsOldestEntriesFirst(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".detent", "notes.md")
+	at := time.Date(2026, 7, 2, 21, 45, 0, 0, time.UTC)
+	for _, entry := range []Entry{
+		{Title: "first", Body: strings.Repeat("one ", 16)},
+		{Title: "second", Body: strings.Repeat("two ", 16)},
+		{Title: "third", Body: strings.Repeat("three ", 16)},
+	} {
+		if err := Append(path, entry, AppendOptions{Now: at, MaxBytes: 260}); err != nil {
+			t.Fatalf("Append() error = %v", err)
+		}
+	}
+
+	content, err := Read(path, ReadOptions{MaxBytes: 260})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	if len(content) > 260 {
+		t.Fatalf("content len = %d, want <= 260:\n%s", len(content), content)
+	}
+	for _, want := range []string{
+		"## 2026-07-02T21:45:00Z - second",
+		"## 2026-07-02T21:45:00Z - third",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("notes missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, " - first") {
+		t.Fatalf("oldest entry was not dropped:\n%s", content)
+	}
+}
+
+func TestTailKeepsBoundedSuffix(t *testing.T) {
+	t.Parallel()
+
+	got := Tail("prefix-keep", 4)
+	if got != "[truncated to last 4 bytes]\nkeep" {
+		t.Fatalf("Tail() = %q", got)
+	}
+}
+
+func TestAppendPreservesUntimestampedNotes(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), ".detent", "notes.md")
+	if err := Append(path, Entry{Title: "first structured", Body: "structured"}, AppendOptions{
+		Now: time.Date(2026, 7, 2, 21, 45, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+	content := "manual note without detent timestamp\n\n- key file: internal/runner/prompt.go\n"
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatalf("write manual notes: %v", err)
+	}
+
+	if err := Append(path, Entry{Title: "second structured", Body: "new structured note"}, AppendOptions{
+		Now: time.Date(2026, 7, 2, 22, 0, 0, 0, time.UTC),
+	}); err != nil {
+		t.Fatalf("Append() error = %v", err)
+	}
+
+	got, err := Read(path, ReadOptions{})
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+	for _, want := range []string{
+		"manual note without detent timestamp",
+		"- key file: internal/runner/prompt.go",
+		"## 2026-07-02T22:00:00Z - second structured",
+		"new structured note",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("notes missing %q:\n%s", want, got)
+		}
+	}
+}

--- a/internal/notes/notes_test.go
+++ b/internal/notes/notes_test.go
@@ -1,6 +1,7 @@
 package notes
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"strings"
@@ -97,5 +98,78 @@ func TestAppendPreservesUntimestampedNotes(t *testing.T) {
 		if !strings.Contains(got, want) {
 			t.Fatalf("notes missing %q:\n%s", want, got)
 		}
+	}
+}
+
+func TestReadRejectsSymlinkNotesFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	notesDir := filepath.Join(root, ".detent")
+	if err := os.MkdirAll(notesDir, 0o700); err != nil {
+		t.Fatalf("mkdir notes dir: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(target, []byte("outside secret"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	path := filepath.Join(notesDir, "notes.md")
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if _, err := Read(path, ReadOptions{}); err == nil {
+		t.Fatal("Read() error = nil, want symlink rejection")
+	}
+}
+
+func TestAppendRejectsSymlinkNotesFile(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	notesDir := filepath.Join(root, ".detent")
+	if err := os.MkdirAll(notesDir, 0o700); err != nil {
+		t.Fatalf("mkdir notes dir: %v", err)
+	}
+	target := filepath.Join(t.TempDir(), "outside.md")
+	if err := os.WriteFile(target, []byte("outside original"), 0o600); err != nil {
+		t.Fatalf("write target: %v", err)
+	}
+	path := filepath.Join(notesDir, "notes.md")
+	if err := os.Symlink(target, path); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	if err := Append(path, Entry{Title: "blocked", Body: "must not write"}, AppendOptions{}); err == nil {
+		t.Fatal("Append() error = nil, want symlink rejection")
+	}
+	content, err := os.ReadFile(target)
+	if err != nil {
+		t.Fatalf("read target: %v", err)
+	}
+	if string(content) != "outside original" {
+		t.Fatalf("target content = %q, want unchanged", content)
+	}
+}
+
+func TestAppendRejectsSymlinkNotesDirectory(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	targetDir := filepath.Join(t.TempDir(), "outside-detent")
+	if err := os.MkdirAll(targetDir, 0o700); err != nil {
+		t.Fatalf("mkdir target dir: %v", err)
+	}
+	notesDir := filepath.Join(root, ".detent")
+	if err := os.Symlink(targetDir, notesDir); err != nil {
+		t.Skipf("symlink unavailable: %v", err)
+	}
+
+	err := Append(filepath.Join(notesDir, "notes.md"), Entry{Title: "blocked", Body: "must not write"}, AppendOptions{})
+	if err == nil {
+		t.Fatal("Append() error = nil, want symlink directory rejection")
+	}
+	if _, err := os.Stat(filepath.Join(targetDir, "notes.md")); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("target notes stat error = %v, want not exist", err)
 	}
 }

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -94,6 +95,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
 			continue
 		}
+		o.recordAutoPromoteReworkHandoff(state, issue, summary, decision, targetState)
 		result.transitioned[issueID] = struct{}{}
 		o.clearAutoPromotedIssueDispatchMemory(state, issueID)
 		if mergeWorkerIssue(promotedIssue(issue, targetState, now)) {
@@ -1520,6 +1522,30 @@ func autoPromoteReworkReasonCounts(events []store.WorkflowPhaseEvent) []autoProm
 		out = append(out, autoPromoteReworkReasonCount{Reason: reason, Count: counts[reason]})
 	}
 	return out
+}
+
+func (o *Orchestrator) recordAutoPromoteReworkHandoff(
+	state *State,
+	issue connector.Issue,
+	summary AutoPromoteSummary,
+	decision AutoPromoteDecision,
+	targetState string,
+) {
+	if state == nil || normalizeState(targetState) != normalizeState(autoPromoteReworkState) {
+		return
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return
+	}
+	if state.PriorAttempts == nil {
+		state.PriorAttempts = map[string]runpkg.PriorAttempt{}
+	}
+	state.PriorAttempts[issueID] = runpkg.PriorAttempt{
+		Source:    "auto_promote",
+		Reason:    string(decision.Reason),
+		Validator: summary.Validator,
+	}
 }
 
 func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision AutoPromoteDecision, targetState string) {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1245,6 +1245,85 @@ func TestTickAutoPromoteValidatorFailureBackoff(t *testing.T) {
 	waitForValidatorRequests(t, validator, 2)
 }
 
+func TestTickAutoPromoteRecordsValidatorReworkHandoff(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 14, 11, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate: gate.Config{
+				Kind: gate.KindCommand,
+				Validator: gate.ValidatorConfig{
+					Enabled:  true,
+					MinScore: 0.8,
+					BlockOn:  []string{"p1"},
+				},
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-validator-rework", []string{"enhancement"}, &connector.PullRequest{
+		Number:                 856,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/856",
+		BranchName:             "detent/digitaldrywood_detent_856",
+		HeadSHA:                "head-validator-rework",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	validator := &autoPromoteTickValidator{
+		result: gate.ValidatorResult{
+			Submitted: true,
+			Verdict:   gate.ValidatorVerdictRework,
+			Score:     0.42,
+			Summary:   "Missing deterministic rework context.",
+			Findings: []gate.Finding{{
+				Severity: "p1",
+				Body:     "Prior validator finding is absent from rework prompt.",
+				Path:     "internal/runner/prompt.go",
+				Line:     44,
+			}},
+		},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		validator: validator,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	state := newState(cfg)
+	orch.tick(context.Background(), &state, now)
+	waitForValidatorRequests(t, validator, 1)
+	waitForValidatorResult(t, orch, issue)
+	orch.tick(context.Background(), &state, now.Add(time.Second))
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: "issue-validator-rework", state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	handoff, ok := state.PriorAttempts[issue.ID]
+	if !ok {
+		t.Fatalf("PriorAttempts[%q] missing", issue.ID)
+	}
+	if handoff.Source != "auto_promote" || handoff.Reason != string(AutoPromoteReasonValidatorBlockedSeverity) {
+		t.Fatalf("handoff = %#v, want auto_promote validator_blocked_severity", handoff)
+	}
+	if handoff.Validator.Verdict != gate.ValidatorVerdictRework || handoff.Validator.Score != 0.42 {
+		t.Fatalf("handoff validator = %#v", handoff.Validator)
+	}
+	if len(handoff.Validator.Findings) != 1 || handoff.Validator.Findings[0].Path != "internal/runner/prompt.go" || handoff.Validator.Findings[0].Line != 44 {
+		t.Fatalf("handoff findings = %#v", handoff.Validator.Findings)
+	}
+}
+
 func TestRunDrainsInFlightValidatorStageOnShutdown(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -66,6 +66,7 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		delete(state.Claimed, issueID)
 		delete(state.Retry, issueID)
 		delete(state.BudgetRefusals, issueID)
+		delete(state.PriorAttempts, issueID)
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      now,
 			Event:   "completed_issue_review_transition",

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -608,6 +608,48 @@ func TestDispatchCandidatesClaimsDuplicateIssueWithinCycle(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesPassesPriorAttemptToRunner(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Rework"},
+		TerminalStates:      []string{"Done"},
+	})
+	runner := newWorkerHostRunner()
+	orch := Orchestrator{
+		cfg:        cfg,
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion),
+	}
+	state := newState(cfg)
+	now := time.Date(2026, 7, 2, 22, 0, 0, 0, time.UTC)
+	issue := dispatchTestIssue("issue-prior-attempt", "Rework")
+	state.PriorAttempts[issue.ID] = runpkg.PriorAttempt{
+		Source: "auto_promote",
+		Reason: "validator_rework",
+		Validator: gate.ValidatorResult{
+			Submitted: true,
+			Verdict:   gate.ValidatorVerdictRework,
+			Findings: []gate.Finding{{
+				Severity: "p1",
+				Body:     "Missing handoff.",
+				Path:     "internal/runner/prompt.go",
+				Line:     44,
+			}},
+		},
+	}
+
+	orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{issue}, now)
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.PriorAttempt.Reason != "validator_rework" {
+		t.Fatalf("PriorAttempt = %#v, want validator_rework", request.PriorAttempt)
+	}
+	if len(request.PriorAttempt.Validator.Findings) != 1 || request.PriorAttempt.Validator.Findings[0].Line != 44 {
+		t.Fatalf("PriorAttempt.Validator.Findings = %#v", request.PriorAttempt.Validator.Findings)
+	}
+}
+
 func TestDispatchReadyIssuesRechecksStartTransitionStateCapacity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1407,6 +1407,7 @@ func (o *Orchestrator) forceQuit(ctx context.Context, state *State, now time.Tim
 		delete(state.Claimed, issueID)
 		delete(state.Retry, issueID)
 		delete(state.BudgetRefusals, issueID)
+		delete(state.PriorAttempts, issueID)
 	}
 	o.markGlobalProjectIdle()
 	return err
@@ -1684,6 +1685,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		Attempt:         attempt,
 		WorkAttemptID:   workAttemptID,
 		Mode:            runMode,
+		PriorAttempt:    state.PriorAttempts[issue.ID],
 		StartedAt:       now,
 		WorkerHost:      workerHost,
 		SelectorContext: o.selectorContext(),
@@ -2069,6 +2071,7 @@ func (o *Orchestrator) cleanupDrainedRun(ctx context.Context, state *State, issu
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
 }
 
 func (o *Orchestrator) completeLatestTerminalMergeWorkerResult(
@@ -2347,6 +2350,7 @@ func (o *Orchestrator) reworkExhaustedMergeWorker(
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
 	delete(state.Completed, issueID)
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      completedAt,
@@ -2435,6 +2439,7 @@ func (o *Orchestrator) completePlanRunning(
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      event.CompletedAt,
 		Event:   "plan_review_created",
@@ -2476,6 +2481,7 @@ func (o *Orchestrator) releaseClaim(state *State, issueID string) {
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
 }
 
 func (o *Orchestrator) completeTerminalRunning(
@@ -2495,6 +2501,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	delete(state.Claimed, issueID)
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
 	if err := o.abandonClaim(ctx, issueID); err != nil {
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      cleanupEventAt(completedAt),

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -6,6 +6,8 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -39,6 +41,7 @@ type State struct {
 	MergeTimings             map[string]MergeTiming
 	TransientCheckRetries    map[string]TransientCheckRetry
 	BudgetRefusals           map[string]BudgetRefusal
+	PriorAttempts            map[string]runpkg.PriorAttempt
 	DiffStats                map[string]DiffStats
 	ReapedWorkspaces         map[string]time.Time
 	TokenTotals              TokenTotals
@@ -150,6 +153,7 @@ func newState(cfg Config) State {
 		MergeTimings:             map[string]MergeTiming{},
 		TransientCheckRetries:    map[string]TransientCheckRetry{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
+		PriorAttempts:            map[string]runpkg.PriorAttempt{},
 		DiffStats:                map[string]DiffStats{},
 		ReapedWorkspaces:         map[string]time.Time{},
 		planRework:               map[string]struct{}{},
@@ -187,6 +191,7 @@ func (s State) clone() State {
 		MergeTimings:             maps.Clone(s.MergeTimings),
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
+		PriorAttempts:            clonePriorAttempts(s.PriorAttempts),
 		DiffStats:                make(map[string]DiffStats, len(s.DiffStats)),
 		ReapedWorkspaces:         make(map[string]time.Time, len(s.ReapedWorkspaces)),
 		TokenTotals:              s.TokenTotals,
@@ -236,6 +241,18 @@ func (s State) clone() State {
 	maps.Copy(cloned.planRework, s.planRework)
 
 	return cloned
+}
+
+func clonePriorAttempts(in map[string]runpkg.PriorAttempt) map[string]runpkg.PriorAttempt {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]runpkg.PriorAttempt, len(in))
+	for key, value := range in {
+		value.Validator.Findings = append([]gate.Finding(nil), value.Validator.Findings...)
+		out[key] = value
+	}
+	return out
 }
 
 func cloneStatusDrift(drift connector.StatusDrift) connector.StatusDrift {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -19,6 +19,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/notes"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/skills"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -319,6 +320,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		WorkspacePath:   info.Path,
 		Branch:          info.Branch,
 		AvailableSkills: availableSkills,
+		PriorAttempt:    req.PriorAttempt,
 	})
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
@@ -369,6 +371,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	})
 	_ = turnResult
 	result.Output = progress.outputText()
+	if turnErr != nil {
+		result.FinalState = finalStateForTurnError(turnErr)
+	}
 	r.logWorkerEvent(req.Issue, "worker_command_finished",
 		"workspace_path", info.Path,
 		"backend_id", selection.BackendID,
@@ -378,6 +383,11 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"outcome", workerRunOutcome(turnErr, result.FinalState),
 		"error", errorString(turnErr),
 	)
+	failureNoteRecorded := false
+	if strings.EqualFold(strings.TrimSpace(result.FinalState), FinalStateFailed) {
+		r.recordFailedRunNote(info.Path, req.Issue, result, turnErr, r.now().UTC())
+		failureNoteRecorded = true
+	}
 
 	r.afterRun(info, workspaceIssue)
 	afterRunPending = false
@@ -386,7 +396,6 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	)
 
 	if turnErr != nil {
-		result.FinalState = finalStateForTurnError(turnErr)
 		finishedAt := r.now().UTC()
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
@@ -414,6 +423,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			return result, nil
 		}
 		result.FinalState = FinalStateFailed
+		if !failureNoteRecorded {
+			r.recordFailedRunNote(info.Path, req.Issue, result, err, r.now().UTC())
+		}
 		finishedAt := r.now().UTC()
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
@@ -743,6 +755,44 @@ func (r *Runner) afterRun(info workspace.Info, issue workspace.Issue) {
 	defer cancel()
 
 	r.workspace.AfterRun(ctx, info, issue)
+}
+
+func (r *Runner) recordFailedRunNote(workspacePath string, issue connector.Issue, result RunResult, runErr error, at time.Time) {
+	notesPath, err := notes.WorkspacePath(workspacePath)
+	if err != nil {
+		r.logger.Warn("resolve failed run note path failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		return
+	}
+	if err := notes.Append(notesPath, notes.Entry{
+		Title: "Failed run output tail",
+		Body:  failedRunNoteBody(result, runErr),
+	}, notes.AppendOptions{Now: at, MaxBytes: notes.DefaultMaxBytes}); err != nil {
+		r.logger.Warn("record failed run note failed", "issue_id", issue.ID, "identifier", issue.Identifier, "path", notesPath, "error", err)
+	}
+}
+
+func failedRunNoteBody(result RunResult, runErr error) string {
+	var b strings.Builder
+	finalState := strings.TrimSpace(result.FinalState)
+	if finalState == "" {
+		finalState = FinalStateFailed
+	}
+	b.WriteString("- final_state: ")
+	b.WriteString(finalState)
+	if runErr != nil {
+		b.WriteString("\n- error: ")
+		b.WriteString(strings.TrimSpace(runErr.Error()))
+	}
+	output := strings.TrimSpace(notes.Tail(result.Output, notes.DefaultTailBytes))
+	if output != "" {
+		b.WriteString("\n\nOutput tail:\n\n```text\n")
+		b.WriteString(output)
+		if !strings.HasSuffix(output, "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString("```")
+	}
+	return b.String()
 }
 
 func (r *Runner) startSession(

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -12,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/notes"
 	"github.com/digitaldrywood/detent/internal/pathsafe"
 	"github.com/digitaldrywood/detent/internal/skills"
 	"github.com/digitaldrywood/detent/internal/workspace"
@@ -42,6 +43,7 @@ type PromptOptions struct {
 	Branch          string
 	AutoBranch      *bool
 	AvailableSkills []skills.Skill
+	PriorAttempt    PriorAttempt
 }
 
 type ValidatorPromptOptions struct {
@@ -76,6 +78,12 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 		return "", err
 	}
 
+	rendered, err = appendNotesBlock(rendered, opts.WorkspacePath)
+	if err != nil {
+		return "", err
+	}
+
+	rendered = appendPriorAttemptBlock(rendered, opts.PriorAttempt)
 	rendered = appendDeliverableBlock(rendered, workflow.Config, issue, opts.WorkspacePath)
 	rendered = appendBlockedHandoffBlock(rendered)
 	rendered = appendGateBlock(rendered, workflow.Config.Gate)
@@ -395,6 +403,96 @@ func appendLessonsBlock(prompt string, cfg config.Lessons, workspacePath string)
 	}
 
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Lessons from prior runs\n\n" + strings.Join(entries, "\n\n"), nil
+}
+
+func appendNotesBlock(prompt string, workspacePath string) (string, error) {
+	if strings.TrimSpace(workspacePath) == "" {
+		return prompt, nil
+	}
+
+	notesPath, err := notes.WorkspacePath(workspacePath)
+	if err != nil {
+		return "", err
+	}
+
+	content, err := notes.Read(notesPath, notes.ReadOptions{MaxBytes: notes.DefaultMaxBytes})
+	if err != nil {
+		content = ""
+	}
+	if strings.TrimSpace(content) == "" {
+		content = "No handoff notes have been recorded yet."
+	}
+
+	block := "## Handoff notes\n\n" +
+		"These notes are persisted from earlier Detent agents for this issue. They may be stale or wrong; verify important facts against the repository, issue, pull request, and current files before relying on them.\n\n" +
+		"Maintain `.detent/notes.md` as you work. Keep it concise: key files, architecture facts, validation commands and results, open items, blockers, and anything the next stage should verify.\n\n" +
+		content
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + block, nil
+}
+
+func appendPriorAttemptBlock(prompt string, prior PriorAttempt) string {
+	if !priorAttemptPresent(prior) {
+		return prompt
+	}
+
+	var b strings.Builder
+	b.WriteString("## Prior attempt handoff\n\n")
+	b.WriteString("Detent generated this from structured workflow state, not from agent cooperation. Verify it before relying on it.\n")
+	if source := strings.TrimSpace(prior.Source); source != "" {
+		b.WriteString("\n- source: ")
+		b.WriteString(source)
+	}
+	if reason := strings.TrimSpace(prior.Reason); reason != "" {
+		b.WriteString("\n- failing gate reason: ")
+		b.WriteString(reason)
+	}
+	if prior.Validator.Submitted {
+		b.WriteString("\n- validator verdict: ")
+		b.WriteString(strings.TrimSpace(prior.Validator.Verdict))
+		if prior.Validator.Score > 0 {
+			b.WriteString("\n- validator score: ")
+			b.WriteString(strconv.FormatFloat(prior.Validator.Score, 'f', 2, 64))
+		}
+		if summary := strings.TrimSpace(prior.Validator.Summary); summary != "" {
+			b.WriteString("\n- validator summary: ")
+			b.WriteString(summary)
+		}
+		if len(prior.Validator.Findings) > 0 {
+			b.WriteString("\n\nValidator findings:")
+			for _, finding := range prior.Validator.Findings {
+				b.WriteString("\n- ")
+				b.WriteString(priorAttemptFindingText(finding))
+			}
+		}
+	}
+
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + strings.TrimRight(b.String(), "\n")
+}
+
+func priorAttemptPresent(prior PriorAttempt) bool {
+	return strings.TrimSpace(prior.Source) != "" ||
+		strings.TrimSpace(prior.Reason) != "" ||
+		prior.Validator.Submitted
+}
+
+func priorAttemptFindingText(finding gate.Finding) string {
+	severity := strings.TrimSpace(finding.Severity)
+	if severity == "" {
+		severity = "unspecified"
+	}
+	body := strings.Join(strings.Fields(finding.Body), " ")
+	if body == "" {
+		body = "Finding"
+	}
+	if finding.Path != "" && finding.Line > 0 {
+		body = body + " (" + finding.Path + ":" + strconv.Itoa(finding.Line) + ")"
+	} else if finding.Path != "" {
+		body = body + " (" + finding.Path + ")"
+	}
+	if finding.URL != "" {
+		body = body + " " + finding.URL
+	}
+	return severity + ": " + body
 }
 
 func promptAssigns(cfg config.Config, issue connector.Issue, opts PromptOptions) map[string]any {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/notes"
 	"github.com/digitaldrywood/detent/internal/skills"
 	"github.com/digitaldrywood/detent/internal/workspace"
 )
@@ -91,6 +92,66 @@ func TestBuildPromptRendersAssignsLessonsAndSkills(t *testing.T) {
 	}
 	if strings.Contains(prompt, "Add migrations.") {
 		t.Fatalf("prompt included skill description, want only when_to_use:\n%s", prompt)
+	}
+}
+
+func TestBuildPromptAppendsNotesAndPriorAttempt(t *testing.T) {
+	t.Parallel()
+
+	workspace := t.TempDir()
+	notesPath := filepath.Join(workspace, ".detent", "notes.md")
+	if err := notes.Append(notesPath, notes.Entry{
+		Title: "Implementation handoff",
+		Body:  "Key file: internal/runner/prompt.go\nValidation: go test ./internal/runner",
+	}, notes.AppendOptions{Now: time.Date(2026, 7, 2, 21, 45, 0, 0, time.UTC)}); err != nil {
+		t.Fatalf("append note: %v", err)
+	}
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Prompt: "Base prompt",
+	}, connector.Issue{
+		Identifier: "digitaldrywood/detent#856",
+		Title:      "Handoff notes",
+	}, PromptOptions{
+		WorkspacePath: workspace,
+		PriorAttempt: PriorAttempt{
+			Source: "auto_promote",
+			Reason: "validator_rework",
+			Validator: gate.ValidatorResult{
+				Submitted: true,
+				Verdict:   gate.ValidatorVerdictRework,
+				Score:     0.42,
+				Summary:   "Missing deterministic rework context.",
+				Findings: []gate.Finding{{
+					Severity: "p1",
+					Body:     "Rework prompt does not include validator findings.",
+					Path:     "internal/runner/prompt.go",
+					Line:     44,
+				}},
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"## Handoff notes",
+		"verify important facts against the repository",
+		"Maintain `.detent/notes.md`",
+		"## 2026-07-02T21:45:00Z - Implementation handoff",
+		"Key file: internal/runner/prompt.go",
+		"## Prior attempt handoff",
+		"- source: auto_promote",
+		"- failing gate reason: validator_rework",
+		"- validator verdict: rework",
+		"- validator score: 0.42",
+		"- validator summary: Missing deterministic rework context.",
+		"p1: Rework prompt does not include validator findings. (internal/runner/prompt.go:44)",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/notes"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -1130,6 +1131,79 @@ func TestRunnerRunFinishesFailedSessionAndAfterRunOnCodexError(t *testing.T) {
 	}
 	if sessionStore.finished.FinalState != FinalStateFailed {
 		t.Fatalf("SessionFinish.FinalState = %q, want %q", sessionStore.finished.FinalState, FinalStateFailed)
+	}
+}
+
+func TestRunnerRunRecordsFailedOutputTailNote(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: workspacePath, Key: "issue-856", Branch: "detent/issue-856"},
+	}
+	oldOutput := strings.Repeat("old output ", 2048)
+	codexClient := &fakeCodexClient{
+		updates: []AgentUpdate{{
+			Type:   AgentUpdateMessageDelta,
+			ItemID: "msg-1",
+			Delta:  oldOutput + "useful failure tail",
+		}},
+		err: errors.New("codex failed"),
+	}
+	nowValue := time.Date(2026, 7, 2, 21, 50, 0, 0, time.UTC)
+	now := newFakeClock(nowValue, nowValue, nowValue, nowValue, nowValue)
+
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
+		Now:          now.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-856",
+			Identifier: "digitaldrywood/detent#856",
+			Title:      "Failure handoff",
+		},
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want codex failure")
+	}
+
+	notesPath, err := notes.WorkspacePath(workspacePath)
+	if err != nil {
+		t.Fatalf("notes path: %v", err)
+	}
+	content, err := notes.Read(notesPath, notes.ReadOptions{})
+	if err != nil {
+		t.Fatalf("read notes: %v", err)
+	}
+	for _, want := range []string{
+		"## 2026-07-02T21:50:00Z - Failed run output tail",
+		"- final_state: failed",
+		"- error: codex failed",
+		"useful failure tail",
+	} {
+		if !strings.Contains(content, want) {
+			t.Fatalf("notes missing %q:\n%s", want, content)
+		}
+	}
+	if strings.Contains(content, oldOutput) {
+		t.Fatalf("notes included unbounded old output")
+	}
+
+	prompt, err := BuildPrompt(config.Workflow{Prompt: "Retry prompt"}, connector.Issue{
+		Identifier: "digitaldrywood/detent#856",
+	}, PromptOptions{WorkspacePath: workspacePath})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+	if !strings.Contains(prompt, "useful failure tail") {
+		t.Fatalf("retry prompt missing failure tail:\n%s", prompt)
 	}
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -128,6 +128,7 @@ type RunRequest struct {
 	Attempt         int
 	WorkAttemptID   int64
 	Mode            string
+	PriorAttempt    PriorAttempt
 	StartedAt       time.Time
 	WorkerHost      string
 	SelectorContext selector.Context
@@ -189,6 +190,12 @@ type TokenTotals struct {
 	OutputTokens   int64
 	TotalTokens    int64
 	RuntimeSeconds float64
+}
+
+type PriorAttempt struct {
+	Source    string
+	Reason    string
+	Validator gate.ValidatorResult
 }
 
 type FakeRunner struct{}

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -20,6 +20,11 @@ var (
 	diffStatRemovedPattern = regexp.MustCompile(`(\d+)\s+deletions?\(-\)`)
 )
 
+var detentHandoffDiffExcludes = []string{
+	".detent/lessons.md",
+	".detent/notes.md",
+}
+
 type DiffStat struct {
 	Files   int `json:"files"`
 	Added   int `json:"added"`
@@ -87,6 +92,9 @@ func GitDiffFrom(ctx context.Context, workspacePath string, baseRef string, maxB
 		}
 		return Diff{}, fmt.Errorf("stat workspace path: %w", err)
 	}
+	if err := ensureGitInfoExcludes(ctx, workspacePath, detentHandoffDiffExcludes); err != nil {
+		return Diff{}, err
+	}
 
 	indexPath, err := gitIndexPath(ctx, workspacePath)
 	if err != nil {
@@ -126,6 +134,9 @@ func GitDiffFrom(ctx context.Context, workspacePath string, baseRef string, maxB
 }
 
 func gitDiffStatOutput(ctx context.Context, workspacePath string) (string, error) {
+	if err := ensureGitInfoExcludes(ctx, workspacePath, detentHandoffDiffExcludes); err != nil {
+		return "", err
+	}
 	indexPath, err := gitIndexPath(ctx, workspacePath)
 	if err != nil {
 		return "", err
@@ -219,6 +230,64 @@ func gitDiffOutputWithinLimit(ctx context.Context, workspacePath string, env []s
 		Output:   string(combined),
 		Err:      waitErr,
 	}
+}
+
+func ensureGitInfoExcludes(ctx context.Context, workspacePath string, patterns []string) error {
+	if len(patterns) == 0 {
+		return nil
+	}
+	output, err := runGitAt(ctx, workspacePath, "rev-parse", "--git-path", "info/exclude")
+	if err != nil {
+		return fmt.Errorf("git info exclude path: %w", err)
+	}
+	excludePath := strings.TrimSpace(output)
+	if excludePath == "" {
+		return errors.New("git info exclude path is empty")
+	}
+	if !filepath.IsAbs(excludePath) {
+		excludePath = filepath.Join(workspacePath, excludePath)
+	}
+	excludePath = filepath.Clean(excludePath)
+
+	content, err := os.ReadFile(excludePath)
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return fmt.Errorf("read git info exclude: %w", err)
+	}
+	existing := map[string]struct{}{}
+	for _, line := range strings.Split(string(content), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		existing[line] = struct{}{}
+	}
+
+	var b strings.Builder
+	b.Write(content)
+	for _, pattern := range patterns {
+		pattern = strings.TrimSpace(pattern)
+		if pattern == "" {
+			continue
+		}
+		if _, ok := existing[pattern]; ok {
+			continue
+		}
+		if b.Len() > 0 && !strings.HasSuffix(b.String(), "\n") {
+			b.WriteString("\n")
+		}
+		b.WriteString(pattern)
+		b.WriteString("\n")
+	}
+	if b.String() == string(content) {
+		return nil
+	}
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0o700); err != nil {
+		return fmt.Errorf("create git info exclude directory: %w", err)
+	}
+	if err := os.WriteFile(excludePath, []byte(b.String()), 0o600); err != nil {
+		return fmt.Errorf("write git info exclude: %w", err)
+	}
+	return nil
 }
 
 func gitIndexPath(ctx context.Context, workspacePath string) (string, error) {

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -102,6 +102,14 @@ func TestLocalGitDiffStat(t *testing.T) {
 	if err := os.Remove(filepath.Join(info.Path, "README.md")); err != nil {
 		t.Fatalf("remove README.md: %v", err)
 	}
+	if err := os.MkdirAll(filepath.Join(info.Path, ".detent"), 0o700); err != nil {
+		t.Fatalf("mkdir .detent: %v", err)
+	}
+	for _, name := range []string{"notes.md", "lessons.md"} {
+		if err := os.WriteFile(filepath.Join(info.Path, ".detent", name), []byte("handoff\n"), 0o600); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
 
 	got, err := backend.DiffStat(context.Background(), info, Issue{Identifier: "DD-DIFF"})
 	if err != nil {
@@ -115,6 +123,14 @@ func TestLocalGitDiffStat(t *testing.T) {
 	status := runGit(t, info.Path, "status", "--short")
 	if !strings.Contains(status, "?? added.txt") {
 		t.Fatalf("git status = %q, want added.txt to remain untracked", status)
+	}
+	if strings.Contains(status, ".detent/notes.md") || strings.Contains(status, ".detent/lessons.md") {
+		t.Fatalf("git status = %q, want handoff files ignored", status)
+	}
+	for _, path := range []string{".detent/notes.md", ".detent/lessons.md"} {
+		if ignored := runGit(t, info.Path, "check-ignore", path); strings.TrimSpace(ignored) != path {
+			t.Fatalf("check-ignore %s = %q, want %s", path, ignored, path)
+		}
 	}
 }
 

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -280,6 +280,9 @@ func (l *LocalGit) Create(ctx context.Context, issue Issue) (Info, error) {
 		return Info{}, err
 	}
 	info.Created = created
+	if err := ensureGitInfoExcludes(ctx, info.Path, detentHandoffDiffExcludes); err != nil {
+		return Info{}, err
+	}
 
 	if created {
 		if err := l.runHook(ctx, "after_create", l.hooks.AfterCreate, info, issue); err != nil {


### PR DESCRIPTION
## Summary

- Add bounded per-issue handoff notes injected into runner prompts.
- Pass structured validator results into rework prompts and record failed-run output tails for retries.
- Exclude `.detent/notes.md` from workspace PR diffs alongside lessons.

Fixes #856

## Test Plan

- [x] `go test ./internal/notes ./internal/runner ./internal/workspace ./internal/orchestrator`
- [x] `make check`