### PR TITLE
feat(runner): cap runaway session tokens

### DIFF
--- a/internal/claudecode/backend_test.go
+++ b/internal/claudecode/backend_test.go
@@ -268,6 +268,43 @@ func TestAgentBackendBuildsCommandArgumentsAndWritesPromptToStdin(t *testing.T) 
 	}
 }
 
+func TestAgentBackendRequestTurnTimeoutOverridesOptions(t *testing.T) {
+	t.Parallel()
+
+	observedPath := filepath.Join(t.TempDir(), "observed.json")
+	var gotRemaining time.Duration
+	backend := newTestBackend(t, Options{
+		CommandFactoryWithArgs: func(ctx context.Context, _ []string) *exec.Cmd {
+			deadline, ok := ctx.Deadline()
+			if ok {
+				gotRemaining = time.Until(deadline)
+			}
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestClaudeCodeHelperProcess", "--")
+			cmd.Env = append(os.Environ(),
+				"CLAUDECODE_HELPER=argv",
+				"CLAUDECODE_OBSERVED_PATH="+observedPath,
+			)
+			return cmd
+		},
+		TurnTimeout: time.Hour,
+	})
+
+	_, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace:   t.TempDir(),
+		Prompt:      "prompt from stdin",
+		TurnTimeout: 5 * time.Second,
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if gotRemaining == 0 {
+		t.Fatal("command context deadline is zero, want request turn timeout")
+	}
+	if gotRemaining <= 0 || gotRemaining > 10*time.Second {
+		t.Fatalf("command context deadline remaining = %v, want request timeout", gotRemaining)
+	}
+}
+
 func TestClaudeCodeHelperProcess(t *testing.T) {
 	if os.Getenv("CLAUDECODE_HELPER") != "argv" {
 		return

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -20,9 +20,13 @@ func (b *AgentBackend) RunTurn(
 	onUpdate runner.AgentUpdateHandler,
 ) (runner.AgentTurnResult, error) {
 	ctx = contextOrBackground(ctx)
-	if b.options.TurnTimeout > 0 {
+	turnTimeout := b.options.TurnTimeout
+	if req.TurnTimeout > 0 {
+		turnTimeout = req.TurnTimeout
+	}
+	if turnTimeout > 0 {
 		var cancel context.CancelFunc
-		ctx, cancel = context.WithTimeout(ctx, b.options.TurnTimeout)
+		ctx, cancel = context.WithTimeout(ctx, turnTimeout)
 		defer cancel()
 	}
 

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -54,6 +54,7 @@ type RunTurnRequest struct {
 	Model             string
 	ModelProvider     string
 	ServiceTier       string
+	TurnTimeout       time.Duration
 }
 
 type RunTurnResult struct {
@@ -225,7 +226,7 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		return RunTurnResult{}, err
 	}
 
-	if err := s.streamTurn(ctx, transport, onUpdate); err != nil {
+	if err := s.streamTurn(ctx, transport, req.turnTimeout(s.turnTimeout), onUpdate); err != nil {
 		return RunTurnResult{}, err
 	}
 
@@ -386,9 +387,16 @@ func (s *AppServer) awaitResponse(
 	}
 }
 
-func (s *AppServer) streamTurn(ctx context.Context, transport Transport, onUpdate UpdateHandler) error {
+func (r RunTurnRequest) turnTimeout(fallback time.Duration) time.Duration {
+	if r.TurnTimeout > 0 {
+		return r.TurnTimeout
+	}
+	return fallback
+}
+
+func (s *AppServer) streamTurn(ctx context.Context, transport Transport, turnTimeout time.Duration, onUpdate UpdateHandler) error {
 	for {
-		msg, err := receiveWithTimeout(ctx, transport, s.turnTimeout)
+		msg, err := receiveWithTimeout(ctx, transport, turnTimeout)
 		if err != nil {
 			return fmt.Errorf("stream turn: %w", err)
 		}

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -161,6 +161,39 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	}
 }
 
+func TestAppServerRunTurnRequestTurnTimeoutOverridesDefault(t *testing.T) {
+	t.Parallel()
+
+	transport := newBlockingAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-timeout"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-timeout"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Hour),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	startedAt := time.Now()
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace:   "/tmp/detent-workspace",
+		Prompt:      "timeout",
+		TurnTimeout: 10 * time.Millisecond,
+	}, nil)
+	if err == nil {
+		t.Fatal("RunTurn() error = nil, want request timeout")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("RunTurn() error = %v, want context deadline exceeded", err)
+	}
+	if elapsed := time.Since(startedAt); elapsed > time.Second {
+		t.Fatalf("RunTurn() elapsed = %v, want request timeout instead of default", elapsed)
+	}
+}
+
 func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
 	t.Parallel()
 
@@ -271,6 +304,24 @@ func (t *fakeAppServerTransport) ProcessIdentity() string {
 
 func (t *fakeAppServerTransport) sentMessages() []Message {
 	return append([]Message(nil), t.sent...)
+}
+
+type blockingAppServerTransport struct {
+	*fakeAppServerTransport
+}
+
+func newBlockingAppServerTransport(received []Message) *blockingAppServerTransport {
+	return &blockingAppServerTransport{fakeAppServerTransport: newFakeAppServerTransport(received)}
+}
+
+func (t *blockingAppServerTransport) Receive(ctx context.Context) (Message, error) {
+	if len(t.received) > 0 {
+		msg := t.received[0]
+		t.received = t.received[1:]
+		return msg, nil
+	}
+	<-ctx.Done()
+	return Message{}, ctx.Err()
 }
 
 func responseMessage(t *testing.T, id int, result string) Message {

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -39,6 +39,7 @@ func (b *AgentBackend) RunTurn(
 		ThreadSandbox:     b.options.ThreadSandbox,
 		TurnSandboxPolicy: turnSandboxPolicyForWorkspace(b.options.ThreadSandbox, b.options.TurnSandboxPolicy, req.ExtraWritableRoots),
 		Model:             req.Model,
+		TurnTimeout:       req.TurnTimeout,
 	}, func(update Update) error {
 		if onUpdate == nil {
 			return nil

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -186,17 +186,21 @@ type Worker struct {
 }
 
 type Agent struct {
-	MaxConcurrentAgents        int            `yaml:"max_concurrent_agents"`
-	MaxTurns                   int            `yaml:"max_turns"`
-	MaxRetryBackoffMS          int            `yaml:"max_retry_backoff_ms"`
-	Shutdown                   Shutdown       `yaml:"shutdown"`
-	MaxConcurrentAgentsByState map[string]int `yaml:"max_concurrent_agents_by_state"`
-	DispatchPriorityByState    []string       `yaml:"dispatch_priority_by_state"`
-	DispatchPriorityByLabel    []string       `yaml:"dispatch_priority_by_label"`
-	AutoPromote                AutoPromote    `yaml:"auto_promote"`
-	Budget                     Budget         `yaml:"budget"`
-	Lessons                    Lessons        `yaml:"lessons"`
-	Skills                     Skills         `yaml:"skills"`
+	MaxConcurrentAgents          int            `yaml:"max_concurrent_agents"`
+	MaxTurns                     int            `yaml:"max_turns"`
+	MaxRetryBackoffMS            int            `yaml:"max_retry_backoff_ms"`
+	MaxSessionTokens             int64          `yaml:"max_session_tokens"`
+	MaxSessionContextMultiplier  float64        `yaml:"max_session_context_multiplier"`
+	MaxSessionTokenOverrideLabel string         `yaml:"max_session_token_override_label"`
+	MaxSessionTokenOverrideField string         `yaml:"max_session_token_override_field"`
+	Shutdown                     Shutdown       `yaml:"shutdown"`
+	MaxConcurrentAgentsByState   map[string]int `yaml:"max_concurrent_agents_by_state"`
+	DispatchPriorityByState      []string       `yaml:"dispatch_priority_by_state"`
+	DispatchPriorityByLabel      []string       `yaml:"dispatch_priority_by_label"`
+	AutoPromote                  AutoPromote    `yaml:"auto_promote"`
+	Budget                       Budget         `yaml:"budget"`
+	Lessons                      Lessons        `yaml:"lessons"`
+	Skills                       Skills         `yaml:"skills"`
 }
 
 type Shutdown struct {
@@ -947,6 +951,8 @@ func (c *Config) normalize() {
 	c.Agent.MaxConcurrentAgentsByState = normalizeStateLimits(c.Agent.MaxConcurrentAgentsByState)
 	c.Agent.DispatchPriorityByState = normalizeStateList(c.Agent.DispatchPriorityByState)
 	c.Agent.DispatchPriorityByLabel = normalizeLabels(c.Agent.DispatchPriorityByLabel)
+	c.Agent.MaxSessionTokenOverrideLabel = normalizeLabel(c.Agent.MaxSessionTokenOverrideLabel)
+	c.Agent.MaxSessionTokenOverrideField = strings.TrimSpace(c.Agent.MaxSessionTokenOverrideField)
 	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
 	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
 	c.Agent.AutoPromote.SourceState = strings.TrimSpace(c.Agent.AutoPromote.SourceState)
@@ -1188,6 +1194,12 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	validatePositive(prefix+".max_concurrent_agents", a.MaxConcurrentAgents, problems)
 	validatePositive(prefix+".max_turns", a.MaxTurns, problems)
 	validatePositive(prefix+".max_retry_backoff_ms", a.MaxRetryBackoffMS, problems)
+	if a.MaxSessionTokens < 0 {
+		*problems = append(*problems, prefix+".max_session_tokens must be greater than or equal to 0")
+	}
+	if a.MaxSessionContextMultiplier < 0 {
+		*problems = append(*problems, prefix+".max_session_context_multiplier must be greater than or equal to 0")
+	}
 	a.Shutdown.validate(prefix+".shutdown", problems)
 	validateStateLimits(prefix+".max_concurrent_agents_by_state", a.MaxConcurrentAgentsByState, problems)
 	validateStateList(prefix+".dispatch_priority_by_state", a.DispatchPriorityByState, problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -85,6 +85,10 @@ worker:
   max_concurrent_agents_per_host: 2
 agent:
   max_concurrent_agents: 5
+  max_session_tokens: 10000000
+  max_session_context_multiplier: 3.5
+  max_session_token_override_label: Allow-Large-Session
+  max_session_token_override_field: Token Override
   shutdown:
     drain_timeout_ms: 300000
   max_concurrent_agents_by_state:
@@ -277,6 +281,18 @@ Ticket prompt {{ issue.title }}
 	}
 	if got := cfg.Agent.MaxConcurrentAgentsByState["merging"]; got != 1 {
 		t.Fatalf("Agent.MaxConcurrentAgentsByState[merging] = %d, want 1", got)
+	}
+	if cfg.Agent.MaxSessionTokens != 10000000 {
+		t.Fatalf("Agent.MaxSessionTokens = %d, want 10000000", cfg.Agent.MaxSessionTokens)
+	}
+	if cfg.Agent.MaxSessionContextMultiplier != 3.5 {
+		t.Fatalf("Agent.MaxSessionContextMultiplier = %v, want 3.5", cfg.Agent.MaxSessionContextMultiplier)
+	}
+	if cfg.Agent.MaxSessionTokenOverrideLabel != "allow-large-session" {
+		t.Fatalf("Agent.MaxSessionTokenOverrideLabel = %q, want allow-large-session", cfg.Agent.MaxSessionTokenOverrideLabel)
+	}
+	if cfg.Agent.MaxSessionTokenOverrideField != "Token Override" {
+		t.Fatalf("Agent.MaxSessionTokenOverrideField = %q, want Token Override", cfg.Agent.MaxSessionTokenOverrideField)
 	}
 	if cfg.Agent.Shutdown.DrainTimeoutMS != 300000 {
 		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want 300000", cfg.Agent.Shutdown.DrainTimeoutMS)
@@ -544,6 +560,12 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.MaxConcurrentAgents != 10 {
 		t.Fatalf("Agent.MaxConcurrentAgents = %d, want 10", cfg.Agent.MaxConcurrentAgents)
+	}
+	if cfg.Agent.MaxSessionTokens != 0 {
+		t.Fatalf("Agent.MaxSessionTokens = %d, want disabled default", cfg.Agent.MaxSessionTokens)
+	}
+	if cfg.Agent.MaxSessionContextMultiplier != 0 {
+		t.Fatalf("Agent.MaxSessionContextMultiplier = %v, want disabled default", cfg.Agent.MaxSessionContextMultiplier)
 	}
 	if cfg.Agent.Shutdown.DrainTimeoutMS != DefaultShutdownDrainTimeoutMS {
 		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want %d", cfg.Agent.Shutdown.DrainTimeoutMS, DefaultShutdownDrainTimeoutMS)
@@ -1097,6 +1119,7 @@ gate:
     enabled: true
     model: gpt-5-validator
     min_score: 0.85
+    turn_timeout_ms: 120000
     block_on:
       - P1
       - p2
@@ -1119,6 +1142,9 @@ Prompt
 	}
 	if validator.MinScore != 0.85 {
 		t.Fatalf("Gate.Validator.MinScore = %v, want 0.85", validator.MinScore)
+	}
+	if validator.TurnTimeoutMS != 120000 {
+		t.Fatalf("Gate.Validator.TurnTimeoutMS = %d, want 120000", validator.TurnTimeoutMS)
 	}
 	if got := validator.BlockOn; !reflect.DeepEqual(got, []string{"p1", "p2"}) {
 		t.Fatalf("Gate.Validator.BlockOn = %#v, want p1/p2", got)
@@ -1533,6 +1559,8 @@ workspace:
   cleanup_sweep_interval_ms: 0
 agent:
   max_concurrent_agents: 0
+  max_session_tokens: -1
+  max_session_context_multiplier: -0.5
   max_concurrent_agents_by_state:
     Todo: 0
   dispatch_priority_by_state: ["Todo", "Todo"]
@@ -1567,6 +1595,8 @@ Prompt
 				"workspace.cleanup_idle_ttl_ms must be greater than 0",
 				"workspace.cleanup_sweep_interval_ms must be greater than 0",
 				"agent.max_concurrent_agents must be greater than 0",
+				"agent.max_session_tokens must be greater than or equal to 0",
+				"agent.max_session_context_multiplier must be greater than or equal to 0",
 				"agent.max_concurrent_agents_by_state limits must be positive integers",
 				"agent.dispatch_priority_by_state state names must be unique",
 				"agent.dispatch_priority_by_label labels must not be blank",
@@ -1959,6 +1989,7 @@ gate:
   validator:
     enabled: true
     min_score: 1.2
+    turn_timeout_ms: -1
     block_on:
       - ""
 ---
@@ -1966,6 +1997,7 @@ Prompt
 `,
 			want: []string{
 				"gate.validator.min_score must be greater than 0 and less than or equal to 1",
+				"gate.validator.turn_timeout_ms must be greater than or equal to 0",
 			},
 		},
 	}

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -45,10 +45,11 @@ type ArtifactConfig struct {
 }
 
 type ValidatorConfig struct {
-	Enabled  bool     `yaml:"enabled"`
-	Model    string   `yaml:"model"`
-	MinScore float64  `yaml:"min_score"`
-	BlockOn  []string `yaml:"block_on"`
+	Enabled       bool     `yaml:"enabled"`
+	Model         string   `yaml:"model"`
+	MinScore      float64  `yaml:"min_score"`
+	BlockOn       []string `yaml:"block_on"`
+	TurnTimeoutMS int      `yaml:"turn_timeout_ms"`
 }
 
 type PlanConfig struct {
@@ -547,6 +548,9 @@ func validateValidator(prefix string, cfg ValidatorConfig) []string {
 			problems = append(problems, prefix+".block_on severities must not be blank")
 			break
 		}
+	}
+	if cfg.TurnTimeoutMS < 0 {
+		problems = append(problems, prefix+".turn_timeout_ms must be greater than or equal to 0")
 	}
 	cfg = effectiveValidatorConfig(cfg)
 	if !invalidScore && (cfg.MinScore <= 0 || cfg.MinScore > 1) {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -580,7 +580,11 @@ func boolPointerEqual(left *bool, right *bool) bool {
 }
 
 func validatorConfigsEqual(left ValidatorConfig, right ValidatorConfig) bool {
-	if left.Enabled != right.Enabled || left.Model != right.Model || left.MinScore != right.MinScore || len(left.BlockOn) != len(right.BlockOn) {
+	if left.Enabled != right.Enabled ||
+		left.Model != right.Model ||
+		left.MinScore != right.MinScore ||
+		left.TurnTimeoutMS != right.TurnTimeoutMS ||
+		len(left.BlockOn) != len(right.BlockOn) {
 		return false
 	}
 	for i := range left.BlockOn {

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 )
 
@@ -190,6 +191,8 @@ func workerOutcome(err error, finalState string) string {
 		return workerOutcomeCancelled
 	case errors.Is(err, context.DeadlineExceeded):
 		return workerOutcomeTimedOut
+	case errors.Is(err, runpkg.ErrSessionTokenCeilingExceeded):
+		return runpkg.FinalStateTokenCeilingExceeded
 	case err != nil:
 		return workerOutcomeFailed
 	case strings.EqualFold(strings.TrimSpace(finalState), FinalStateCompleted), strings.TrimSpace(finalState) == "":

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -18,6 +18,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/lessons"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/skills"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -358,6 +359,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		applyAgentUpdate(&result, update)
 		eventAt := r.now()
 		progress.apply(update, eventAt)
+		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {
+			return err
+		}
 		if err := r.publishRunUpdate(ctx, req, info, workspaceIssue, progress, result, eventAt, runStartedAt); err != nil {
 			return err
 		}
@@ -382,7 +386,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	)
 
 	if turnErr != nil {
-		result.FinalState = FinalStateFailed
+		result.FinalState = finalStateForTurnError(turnErr)
 		finishedAt := r.now().UTC()
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
@@ -502,6 +506,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		Workspace:          info.Path,
 		Prompt:             prompt,
 		Model:              model,
+		TurnTimeout:        durationFromMillis(workflow.Config.Gate.Validator.TurnTimeoutMS),
 		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
 	}, func(update AgentUpdate) error {
 		r.logAgentUpdate(req.Issue, update)
@@ -511,6 +516,9 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		applyAgentUpdate(&runResult, update)
 		eventAt := r.now()
 		progress.apply(update, eventAt)
+		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {
+			return err
+		}
 		if err := r.publishRunUpdate(ctx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt); err != nil {
 			return err
 		}
@@ -536,7 +544,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	finishedAt := r.now().UTC()
 	runResult.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 	if turnErr != nil {
-		runResult.FinalState = FinalStateFailed
+		runResult.FinalState = finalStateForTurnError(turnErr)
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("run validator turn: %w", turnErr),
 			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, model, backendKind, 1),
@@ -827,6 +835,128 @@ func (r *Runner) usageCostUSD(model string, inputTokens int64, outputTokens int6
 		return 0
 	}
 	return cost
+}
+
+type sessionTokenCeiling struct {
+	tokens             int64
+	source             string
+	modelContextWindow int64
+	contextMultiplier  float64
+}
+
+func (r *Runner) enforceSessionTokenCeiling(cfg config.Agent, issue connector.Issue, workspacePath string, update AgentUpdate, eventAt time.Time) error {
+	if update.Type != AgentUpdateTokenUsage || sessionTokenCeilingBypassed(cfg, issue) {
+		return nil
+	}
+	ceiling, ok := sessionTokenCeilingForUsage(cfg, update.Tokens)
+	if !ok || update.Tokens.TotalTokens <= ceiling.tokens {
+		return nil
+	}
+
+	err := &SessionTokenCeilingError{
+		TotalTokens:        update.Tokens.TotalTokens,
+		CeilingTokens:      ceiling.tokens,
+		Source:             ceiling.source,
+		ModelContextWindow: ceiling.modelContextWindow,
+		ContextMultiplier:  ceiling.contextMultiplier,
+	}
+	if appendErr := appendSessionTokenCeilingLesson(cfg.Lessons, issue, workspacePath, err, eventAt); appendErr != nil {
+		r.logger.Warn("session token ceiling lesson append failed", "error", appendErr)
+		return errors.Join(err, appendErr)
+	}
+	return err
+}
+
+func sessionTokenCeilingForUsage(cfg config.Agent, tokens AgentTokenUsage) (sessionTokenCeiling, bool) {
+	var ceiling sessionTokenCeiling
+	if cfg.MaxSessionTokens > 0 {
+		ceiling = sessionTokenCeiling{
+			tokens: cfg.MaxSessionTokens,
+			source: TokenCeilingSourceAbsolute,
+		}
+	}
+	if cfg.MaxSessionContextMultiplier > 0 && tokens.ModelContextWindow != nil && *tokens.ModelContextWindow > 0 {
+		limit := int64(math.Ceil(float64(*tokens.ModelContextWindow) * cfg.MaxSessionContextMultiplier))
+		if limit > 0 && (ceiling.tokens == 0 || limit < ceiling.tokens) {
+			ceiling = sessionTokenCeiling{
+				tokens:             limit,
+				source:             TokenCeilingSourceContextWindow,
+				modelContextWindow: *tokens.ModelContextWindow,
+				contextMultiplier:  cfg.MaxSessionContextMultiplier,
+			}
+		}
+	}
+	return ceiling, ceiling.tokens > 0
+}
+
+func sessionTokenCeilingBypassed(cfg config.Agent, issue connector.Issue) bool {
+	if label := strings.TrimSpace(cfg.MaxSessionTokenOverrideLabel); label != "" && issueHasLabel(issue, label) {
+		return true
+	}
+	if field := strings.TrimSpace(cfg.MaxSessionTokenOverrideField); field != "" {
+		value, ok := issueFieldValue(issue.Fields, field)
+		return ok && tokenCeilingOverrideEnabled(value)
+	}
+	return false
+}
+
+func issueHasLabel(issue connector.Issue, want string) bool {
+	want = strings.ToLower(strings.TrimSpace(want))
+	if want == "" {
+		return false
+	}
+	for _, label := range issue.Labels {
+		if strings.ToLower(strings.TrimSpace(label)) == want {
+			return true
+		}
+	}
+	return false
+}
+
+func tokenCeilingOverrideEnabled(value string) bool {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "1", "true", "yes", "y", "on", "allow", "allowed", "bypass", "disabled":
+		return true
+	default:
+		return false
+	}
+}
+
+func appendSessionTokenCeilingLesson(cfg config.Lessons, issue connector.Issue, workspacePath string, ceilingErr *SessionTokenCeilingError, eventAt time.Time) error {
+	if strings.TrimSpace(workspacePath) == "" {
+		return nil
+	}
+	path := cfg.Path
+	if strings.TrimSpace(path) == "" {
+		path = lessons.DefaultPath
+	}
+	lessonPath, err := promptWorkspaceRelativePath(workspacePath, path)
+	if err != nil {
+		return err
+	}
+	return lessons.Append(lessonPath, lessons.Entry{
+		IssueNumber: githubIssueNumber(issue.Identifier),
+		IssueRef:    issue.Identifier,
+		Title:       issue.Title,
+		FailureKind: FinalStateTokenCeilingExceeded,
+		Symptom:     fmt.Sprintf("session reached %d tokens, above configured ceiling %d", ceilingErr.TotalTokens, ceilingErr.CeilingTokens),
+		Hypothesis:  "the agent session is consuming tokens faster than the configured per-session ceiling permits",
+		Hint:        "retry with a narrower task split, stronger stop conditions, or a deliberate per-issue token ceiling override",
+	}, lessons.AppendOptions{Date: eventAt.UTC(), MaxEntries: cfg.MaxEntries})
+}
+
+func finalStateForTurnError(err error) string {
+	if errors.Is(err, ErrSessionTokenCeilingExceeded) {
+		return FinalStateTokenCeilingExceeded
+	}
+	return FinalStateFailed
+}
+
+func durationFromMillis(ms int) time.Duration {
+	if ms <= 0 {
+		return 0
+	}
+	return time.Duration(ms) * time.Millisecond
 }
 
 func workspaceIssue(projectID string, issue connector.Issue) workspace.Issue {
@@ -1181,6 +1311,8 @@ func workerRunOutcome(err error, finalState string) string {
 		return "cancelled"
 	case errors.Is(err, context.DeadlineExceeded):
 		return "timed_out"
+	case errors.Is(err, ErrSessionTokenCeilingExceeded):
+		return FinalStateTokenCeilingExceeded
 	case err != nil:
 		return "failed"
 	case strings.EqualFold(strings.TrimSpace(finalState), FinalStateCompleted), strings.TrimSpace(finalState) == "":

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -359,10 +359,10 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		applyAgentUpdate(&result, update)
 		eventAt := r.now()
 		progress.apply(update, eventAt)
-		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {
+		if err := r.publishRunUpdate(ctx, req, info, workspaceIssue, progress, result, eventAt, runStartedAt); err != nil {
 			return err
 		}
-		if err := r.publishRunUpdate(ctx, req, info, workspaceIssue, progress, result, eventAt, runStartedAt); err != nil {
+		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {
 			return err
 		}
 		return nil
@@ -516,10 +516,10 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		applyAgentUpdate(&runResult, update)
 		eventAt := r.now()
 		progress.apply(update, eventAt)
-		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {
+		if err := r.publishRunUpdate(ctx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt); err != nil {
 			return err
 		}
-		if err := r.publishRunUpdate(ctx, runReq, info, workspaceIssue, progress, runResult, eventAt, runStartedAt); err != nil {
+		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {
 			return err
 		}
 		return nil

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -271,6 +271,306 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 }
 
+func TestRunnerRunKillsSessionAtTokenCeilingAndRecordsLesson(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	startedAt := time.Date(2026, 7, 2, 14, 0, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: workspacePath, Key: "issue-853", Branch: "detent/issue-853"},
+	}
+	agentBackend := &fakeCodexClient{
+		updates: []AgentUpdate{
+			{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-853",
+				TurnID:   "turn-1",
+				Tokens: AgentTokenUsage{
+					InputTokens:  80,
+					OutputTokens: 10,
+					TotalTokens:  90,
+				},
+			},
+			{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-853",
+				TurnID:   "turn-1",
+				Tokens: AgentTokenUsage{
+					InputTokens:  100,
+					OutputTokens: 20,
+					TotalTokens:  120,
+				},
+			},
+		},
+	}
+	sessionStore := &fakeSessionStore{sessionID: 853}
+	clock := newFakeClock(
+		startedAt,
+		startedAt.Add(time.Second),
+		startedAt.Add(2*time.Second),
+		startedAt.Add(3*time.Second),
+	)
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agent: config.Agent{
+					MaxSessionTokens: 100,
+					Lessons: config.Lessons{
+						Path:       ".detent/lessons.md",
+						MaxEntries: 5,
+					},
+				},
+			},
+			Prompt: "Work on {{ issue.identifier }}",
+		},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		Store:        sessionStore,
+		Now:          clock.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-853",
+			Identifier: "digitaldrywood/detent#853",
+			Title:      "Per-session token ceiling",
+		},
+		StartedAt: startedAt,
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want token ceiling error")
+	}
+	if !errors.Is(err, ErrSessionTokenCeilingExceeded) {
+		t.Fatalf("Run() error = %v, want ErrSessionTokenCeilingExceeded", err)
+	}
+	var ceilingErr *SessionTokenCeilingError
+	if !errors.As(err, &ceilingErr) {
+		t.Fatalf("Run() error = %T, want SessionTokenCeilingError", err)
+	}
+	if ceilingErr.TotalTokens != 120 || ceilingErr.CeilingTokens != 100 || ceilingErr.Source != TokenCeilingSourceAbsolute {
+		t.Fatalf("ceiling error = %#v, want total 120 ceiling 100 absolute source", ceilingErr)
+	}
+	if result.FinalState != FinalStateTokenCeilingExceeded {
+		t.Fatalf("FinalState = %q, want %q", result.FinalState, FinalStateTokenCeilingExceeded)
+	}
+	if sessionStore.finished.FinalState != FinalStateTokenCeilingExceeded || sessionStore.finished.TotalTokens != 120 {
+		t.Fatalf("SessionFinish = %#v, want token ceiling final state and 120 tokens", sessionStore.finished)
+	}
+	if sessionStore.usage.Outcome != FinalStateTokenCeilingExceeded || sessionStore.usage.TotalTokens != 120 {
+		t.Fatalf("UsageEvent = %#v, want token ceiling outcome and 120 tokens", sessionStore.usage)
+	}
+	if sessionStore.phase.Status != FinalStateTokenCeilingExceeded || sessionStore.phase.TotalTokens != 120 {
+		t.Fatalf("WorkflowPhaseEvent = %#v, want token ceiling status and 120 tokens", sessionStore.phase)
+	}
+
+	lesson, err := os.ReadFile(filepath.Join(workspacePath, ".detent", "lessons.md"))
+	if err != nil {
+		t.Fatalf("ReadFile(lessons) error = %v", err)
+	}
+	for _, want := range []string{
+		"Failure kind:** token_ceiling_exceeded",
+		"session reached 120 tokens",
+		"configured ceiling 100",
+	} {
+		if !strings.Contains(string(lesson), want) {
+			t.Fatalf("lesson missing %q:\n%s", want, lesson)
+		}
+	}
+}
+
+func TestRunnerRunLeavesSessionTokenCeilingDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 2, 14, 30, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-default", Branch: "detent/issue-default"},
+	}
+	contextWindow := int64(100)
+	agentBackend := &fakeCodexClient{
+		updates: []AgentUpdate{{
+			Type:     AgentUpdateTokenUsage,
+			ThreadID: "thread-default",
+			TurnID:   "turn-1",
+			Tokens: AgentTokenUsage{
+				InputTokens:        1000000,
+				OutputTokens:       250000,
+				TotalTokens:        1250000,
+				ModelContextWindow: &contextWindow,
+			},
+		}},
+	}
+	clock := newFakeClock(startedAt, startedAt.Add(time.Second), startedAt.Add(2*time.Second))
+
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}, Prompt: "Work"},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		Now:          clock.Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-default",
+			Identifier: "digitaldrywood/detent#854",
+			Title:      "Default behavior",
+		},
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.FinalState != FinalStateCompleted || result.Tokens.TotalTokens != 1250000 {
+		t.Fatalf("Run() result = %#v, want completed with large token total", result)
+	}
+}
+
+func TestRunnerRunSessionTokenOverrideBypassesLimit(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		cfg   config.Agent
+		issue connector.Issue
+	}{
+		{
+			name: "label",
+			cfg: config.Agent{
+				MaxSessionTokens:             100,
+				MaxSessionTokenOverrideLabel: "allow-large-session",
+			},
+			issue: connector.Issue{
+				ID:         "issue-label",
+				Identifier: "digitaldrywood/detent#855",
+				Title:      "Large label session",
+				Labels:     []string{"Allow-Large-Session"},
+			},
+		},
+		{
+			name: "field",
+			cfg: config.Agent{
+				MaxSessionTokens:             100,
+				MaxSessionTokenOverrideField: "Token Override",
+			},
+			issue: connector.Issue{
+				ID:         "issue-field",
+				Identifier: "digitaldrywood/detent#856",
+				Title:      "Large field session",
+				Fields:     map[string]string{"Token Override": "true"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			startedAt := time.Date(2026, 7, 2, 15, 0, 0, 0, time.UTC)
+			agentBackend := &fakeCodexClient{
+				updates: []AgentUpdate{{
+					Type:     AgentUpdateTokenUsage,
+					ThreadID: "thread-override",
+					TurnID:   "turn-1",
+					Tokens: AgentTokenUsage{
+						InputTokens:  100,
+						OutputTokens: 20,
+						TotalTokens:  120,
+					},
+				}},
+			}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{Agent: tt.cfg},
+					Prompt: "Work",
+				},
+				Workspace: &fakeWorkspaceBackend{
+					info: workspace.Info{Path: t.TempDir(), Key: tt.issue.ID, Branch: "detent/" + tt.issue.ID},
+				},
+				AgentBackend: agentBackend,
+				Now:          newFakeClock(startedAt, startedAt.Add(time.Second), startedAt.Add(2*time.Second)).Now,
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			result, err := runner.Run(context.Background(), RunRequest{Issue: tt.issue, StartedAt: startedAt})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+			if result.FinalState != FinalStateCompleted || result.Tokens.TotalTokens != 120 {
+				t.Fatalf("Run() result = %#v, want completed with 120 tokens", result)
+			}
+		})
+	}
+}
+
+func TestSessionTokenCeilingForUsageUsesTightestConfiguredLimit(t *testing.T) {
+	t.Parallel()
+
+	contextWindow := int64(1000)
+	tests := []struct {
+		name   string
+		cfg    config.Agent
+		tokens AgentTokenUsage
+		want   sessionTokenCeiling
+		ok     bool
+	}{
+		{
+			name:   "disabled",
+			cfg:    config.Agent{},
+			tokens: AgentTokenUsage{TotalTokens: 1000000, ModelContextWindow: &contextWindow},
+		},
+		{
+			name:   "absolute",
+			cfg:    config.Agent{MaxSessionTokens: 5000},
+			tokens: AgentTokenUsage{ModelContextWindow: &contextWindow},
+			want:   sessionTokenCeiling{tokens: 5000, source: TokenCeilingSourceAbsolute},
+			ok:     true,
+		},
+		{
+			name:   "context multiplier",
+			cfg:    config.Agent{MaxSessionContextMultiplier: 2.5},
+			tokens: AgentTokenUsage{ModelContextWindow: &contextWindow},
+			want: sessionTokenCeiling{
+				tokens:             2500,
+				source:             TokenCeilingSourceContextWindow,
+				modelContextWindow: 1000,
+				contextMultiplier:  2.5,
+			},
+			ok: true,
+		},
+		{
+			name:   "tighter context multiplier",
+			cfg:    config.Agent{MaxSessionTokens: 5000, MaxSessionContextMultiplier: 2},
+			tokens: AgentTokenUsage{ModelContextWindow: &contextWindow},
+			want: sessionTokenCeiling{
+				tokens:             2000,
+				source:             TokenCeilingSourceContextWindow,
+				modelContextWindow: 1000,
+				contextMultiplier:  2,
+			},
+			ok: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := sessionTokenCeilingForUsage(tt.cfg, tt.tokens)
+			if ok != tt.ok || got != tt.want {
+				t.Fatalf("sessionTokenCeilingForUsage() = %#v, %v; want %#v, %v", got, ok, tt.want, tt.ok)
+			}
+		})
+	}
+}
+
 func TestRunnerRunAddsGitMetadataExtraRootsForManagedWorkspace(t *testing.T) {
 	t.Parallel()
 
@@ -516,10 +816,11 @@ func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T
 			Config: config.Config{
 				Gate: gate.Config{
 					Validator: gate.ValidatorConfig{
-						Enabled:  true,
-						Model:    "gpt-5-validator-override",
-						MinScore: 0.8,
-						BlockOn:  []string{"p1"},
+						Enabled:       true,
+						Model:         "gpt-5-validator-override",
+						MinScore:      0.8,
+						BlockOn:       []string{"p1"},
+						TurnTimeoutMS: 120000,
 					},
 				},
 				Agents: config.Agents{
@@ -572,6 +873,9 @@ func TestRunnerValidateUsesValidatorRouteModelOverrideAndParsesJSON(t *testing.T
 	}
 	if validatorBackend.request.Model != "gpt-5-validator-override" {
 		t.Fatalf("validator model = %q, want gate override", validatorBackend.request.Model)
+	}
+	if validatorBackend.request.TurnTimeout != 2*time.Minute {
+		t.Fatalf("validator turn timeout = %v, want 2m", validatorBackend.request.TurnTimeout)
 	}
 	if validatorBackend.request.Workspace != workspacePath {
 		t.Fatalf("validator workspace = %q, want %q", validatorBackend.request.Workspace, workspacePath)

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -333,6 +333,7 @@ func TestRunnerRunKillsSessionAtTokenCeilingAndRecordsLesson(t *testing.T) {
 		t.Fatalf("NewRunner() error = %v", err)
 	}
 
+	var usageUpdates []UsageUpdate
 	result, err := runner.Run(context.Background(), RunRequest{
 		Issue: connector.Issue{
 			ID:         "issue-853",
@@ -340,6 +341,10 @@ func TestRunnerRunKillsSessionAtTokenCeilingAndRecordsLesson(t *testing.T) {
 			Title:      "Per-session token ceiling",
 		},
 		StartedAt: startedAt,
+		OnUsageUpdate: func(update UsageUpdate) error {
+			usageUpdates = append(usageUpdates, update)
+			return nil
+		},
 	})
 	if err == nil {
 		t.Fatal("Run() error = nil, want token ceiling error")
@@ -365,6 +370,12 @@ func TestRunnerRunKillsSessionAtTokenCeilingAndRecordsLesson(t *testing.T) {
 	}
 	if sessionStore.phase.Status != FinalStateTokenCeilingExceeded || sessionStore.phase.TotalTokens != 120 {
 		t.Fatalf("WorkflowPhaseEvent = %#v, want token ceiling status and 120 tokens", sessionStore.phase)
+	}
+	if len(usageUpdates) != 2 {
+		t.Fatalf("usage update count = %d, want 2", len(usageUpdates))
+	}
+	if got := usageUpdates[len(usageUpdates)-1].Tokens.TotalTokens; got != 120 {
+		t.Fatalf("last live usage total tokens = %d, want ceiling-crossing 120", got)
 	}
 
 	lesson, err := os.ReadFile(filepath.Join(workspacePath, ".detent", "lessons.md"))

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -2,6 +2,8 @@ package runner
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -11,12 +13,17 @@ import (
 )
 
 const (
-	FinalStateCompleted = "completed"
-	FinalStateFailed    = "failed"
+	FinalStateCompleted             = "completed"
+	FinalStateFailed                = "failed"
+	FinalStateTokenCeilingExceeded  = "token_ceiling_exceeded"
+	TokenCeilingSourceAbsolute      = "max_session_tokens"
+	TokenCeilingSourceContextWindow = "max_session_context_multiplier"
 
 	RunModeImplement = "implement"
 	RunModePlan      = "plan"
 )
+
+var ErrSessionTokenCeilingExceeded = errors.New("session token ceiling exceeded")
 
 type Backend interface {
 	Run(context.Context, RunRequest) (RunResult, error)
@@ -44,6 +51,7 @@ type AgentTurnRequest struct {
 	Workspace          string
 	Prompt             string
 	Model              string
+	TurnTimeout        time.Duration
 	ExtraWritableRoots []string
 }
 
@@ -86,6 +94,33 @@ type AgentTokenUsage struct {
 	ReasoningOutputTokens int64
 	TotalTokens           int64
 	ModelContextWindow    *int64
+}
+
+type SessionTokenCeilingError struct {
+	TotalTokens        int64
+	CeilingTokens      int64
+	Source             string
+	ModelContextWindow int64
+	ContextMultiplier  float64
+}
+
+func (e *SessionTokenCeilingError) Error() string {
+	source := e.Source
+	if source == "" {
+		source = "unknown"
+	}
+	message := fmt.Sprintf("%s: total_tokens=%d ceiling_tokens=%d source=%s", ErrSessionTokenCeilingExceeded, e.TotalTokens, e.CeilingTokens, source)
+	if e.ModelContextWindow > 0 {
+		message += fmt.Sprintf(" model_context_window=%d", e.ModelContextWindow)
+	}
+	if e.ContextMultiplier > 0 {
+		message += fmt.Sprintf(" context_multiplier=%g", e.ContextMultiplier)
+	}
+	return message
+}
+
+func (e *SessionTokenCeilingError) Unwrap() error {
+	return ErrSessionTokenCeilingExceeded
 }
 
 type RunRequest struct {


### PR DESCRIPTION
## Summary

- Add configurable per-session token ceilings with absolute and context-window multiplier modes.
- Abort runaway sessions with a typed `token_ceiling_exceeded` outcome, store telemetry, and append retry lessons.
- Add per-issue override controls and validator-specific turn timeout plumbing.

Fixes #853

## Test Plan

- [x] `make check`