### PR TITLE
feat(orchestrator): persist validator verdicts

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -522,3 +522,49 @@ FROM scheduler_decisions
 WHERE sqlc.arg(filter_project_id) = '' OR project_id = sqlc.arg(filter_project_id)
 ORDER BY decision_at DESC, id DESC
 LIMIT sqlc.arg(limit);
+
+-- name: UpsertValidatorVerdict :one
+INSERT INTO validator_verdicts (
+  project_id,
+  issue_id,
+  head_sha,
+  identifier,
+  issue_url,
+  pr_number,
+  submitted,
+  verdict,
+  score,
+  summary,
+  findings_json,
+  commented,
+  recorded_at,
+  updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, issue_id, head_sha) DO UPDATE SET
+  identifier = excluded.identifier,
+  issue_url = excluded.issue_url,
+  pr_number = excluded.pr_number,
+  submitted = excluded.submitted,
+  verdict = excluded.verdict,
+  score = excluded.score,
+  summary = excluded.summary,
+  findings_json = excluded.findings_json,
+  commented = excluded.commented,
+  recorded_at = excluded.recorded_at,
+  updated_at = excluded.updated_at
+RETURNING *;
+
+-- name: GetValidatorVerdict :one
+SELECT *
+FROM validator_verdicts
+WHERE project_id = ?
+  AND issue_id = ?
+  AND head_sha = ?;
+
+-- name: MarkValidatorVerdictCommented :execrows
+UPDATE validator_verdicts
+SET commented = 1,
+    updated_at = ?
+WHERE project_id = ?
+  AND issue_id = ?
+  AND head_sha = ?;

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -215,6 +215,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		GlobalDispatchGate: globalDispatchGate,
 		WorkflowMetrics:    runtimeStore,
 		WorkAttempts:       runtimeStore,
+		ValidatorMemo:      runtimeStore,
 		GitHubToken:        runtimeGitHubToken.get(),
 		RefreshGitHubToken: refreshGitHubToken,
 		ConnectorFactory:   cfg.ConnectorFactory,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -899,6 +899,10 @@ func (o *Orchestrator) startValidatorStage(ctx context.Context, issue connector.
 	o.validatorMu.Unlock()
 
 	selectorContext := o.cfg.SelectorContext
+	retryConfig := Config{
+		MaxRetryBackoff:       o.cfg.MaxRetryBackoff,
+		FailureRetryBaseDelay: o.cfg.FailureRetryBaseDelay,
+	}
 	go func() {
 		defer o.validatorWG.Done()
 
@@ -915,7 +919,7 @@ func (o *Orchestrator) startValidatorStage(ctx context.Context, issue connector.
 			attempt := o.validatorFailures[identity.Key].Attempt + 1
 			o.validatorFailures[identity.Key] = validatorStageFailure{
 				Attempt:     attempt,
-				NextRetryAt: completedAt.Add(validatorStageRetryDelay(o.cfg, attempt)),
+				NextRetryAt: completedAt.Add(validatorStageRetryDelay(retryConfig, attempt)),
 				Error:       err.Error(),
 			}
 			failure := o.validatorFailures[identity.Key]

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -68,7 +68,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		summary := AutoPromoteSummaryFromIssue(issue)
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
 		if decision.Reason == AutoPromoteReasonValidatorMissing {
-			validation, shouldComment, ok := o.validatorStageResult(issue)
+			validation, shouldComment, ok := o.validatorStageResult(ctx, issue)
 			if !ok {
 				o.startValidatorStage(ctx, issue, now)
 				o.logAutoPromoteDecision(issue, decision, "")
@@ -77,7 +77,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 			summary.Validator = validation
 			if shouldComment {
 				o.commentValidatorResult(ctx, issue, validation)
-				o.markValidatorResultCommented(issue)
+				o.markValidatorResultCommented(ctx, issue)
 			}
 			decision = EvaluateAutoPromote(issue, summary, cfg, now)
 		}
@@ -854,8 +854,11 @@ func (o *Orchestrator) startValidatorStage(ctx context.Context, issue connector.
 		return
 	}
 
-	key := validatorStageKey(issue)
-	if key == "" {
+	identity := validatorStageIdentityForIssue(issue)
+	if identity.Key == "" {
+		return
+	}
+	if _, _, ok := o.validatorStageResult(ctx, issue); ok {
 		return
 	}
 
@@ -866,15 +869,32 @@ func (o *Orchestrator) startValidatorStage(ctx context.Context, issue connector.
 	if o.validatorResults == nil {
 		o.validatorResults = map[string]validatorStageResult{}
 	}
-	if _, ok := o.validatorRuns[key]; ok {
+	if o.validatorFailures == nil {
+		o.validatorFailures = map[string]validatorStageFailure{}
+	}
+	if _, ok := o.validatorRuns[identity.Key]; ok {
 		o.validatorMu.Unlock()
 		return
 	}
-	if _, ok := o.validatorResults[key]; ok {
+	if _, ok := o.validatorResults[identity.Key]; ok {
 		o.validatorMu.Unlock()
 		return
 	}
-	o.validatorRuns[key] = struct{}{}
+	if failure, ok := o.validatorFailures[identity.Key]; ok && failure.NextRetryAt.After(now) {
+		o.validatorMu.Unlock()
+		if o.logger != nil {
+			o.logger.Debug(
+				"validator stage backoff active",
+				"issue_id", identity.IssueID,
+				"identifier", issue.Identifier,
+				"head_sha", identity.HeadSHA,
+				"retry_at", failure.NextRetryAt,
+				"attempt", failure.Attempt,
+			)
+		}
+		return
+	}
+	o.validatorRuns[identity.Key] = struct{}{}
 	o.validatorWG.Add(1)
 	o.validatorMu.Unlock()
 
@@ -888,51 +908,81 @@ func (o *Orchestrator) startValidatorStage(ctx context.Context, issue connector.
 			SelectorContext: selectorContext,
 		})
 
+		completedAt := o.clockNow().UTC()
 		o.validatorMu.Lock()
-		defer o.validatorMu.Unlock()
-		delete(o.validatorRuns, key)
 		if err != nil {
+			delete(o.validatorRuns, identity.Key)
+			attempt := o.validatorFailures[identity.Key].Attempt + 1
+			o.validatorFailures[identity.Key] = validatorStageFailure{
+				Attempt:     attempt,
+				NextRetryAt: completedAt.Add(validatorStageRetryDelay(o.cfg, attempt)),
+				Error:       err.Error(),
+			}
+			failure := o.validatorFailures[identity.Key]
+			o.validatorMu.Unlock()
 			if o.logger != nil {
 				o.logger.Warn(
 					"validator stage failed",
 					"issue_id", strings.TrimSpace(issue.ID),
 					"identifier", issue.Identifier,
+					"head_sha", identity.HeadSHA,
+					"retry_at", failure.NextRetryAt,
+					"attempt", attempt,
 					"error", err,
 				)
 			}
 			return
 		}
-		o.validatorResults[key] = validatorStageResult{Result: result}
+		o.validatorMu.Unlock()
+		o.recordValidatorVerdict(ctx, issue, identity, result, completedAt)
+
+		o.validatorMu.Lock()
+		delete(o.validatorRuns, identity.Key)
+		delete(o.validatorFailures, identity.Key)
+		o.validatorResults[identity.Key] = validatorStageResult{Result: result}
+		o.validatorMu.Unlock()
 	}()
 }
 
-func (o *Orchestrator) validatorStageResult(issue connector.Issue) (gate.ValidatorResult, bool, bool) {
-	key := validatorStageKey(issue)
-	if key == "" {
+func (o *Orchestrator) validatorStageResult(ctx context.Context, issue connector.Issue) (gate.ValidatorResult, bool, bool) {
+	identity := validatorStageIdentityForIssue(issue)
+	if identity.Key == "" {
 		return gate.ValidatorResult{}, false, false
 	}
 	o.validatorMu.Lock()
-	defer o.validatorMu.Unlock()
-	result, ok := o.validatorResults[key]
+	result, ok := o.validatorResults[identity.Key]
+	o.validatorMu.Unlock()
 	if !ok {
-		return gate.ValidatorResult{}, false, false
+		var loaded bool
+		result, loaded = o.loadValidatorVerdict(ctx, issue, identity)
+		if !loaded {
+			return gate.ValidatorResult{}, false, false
+		}
+		o.validatorMu.Lock()
+		if o.validatorResults == nil {
+			o.validatorResults = map[string]validatorStageResult{}
+		}
+		o.validatorResults[identity.Key] = result
+		o.validatorMu.Unlock()
 	}
 	return result.Result, !result.Commented, true
 }
 
-func (o *Orchestrator) markValidatorResultCommented(issue connector.Issue) {
-	key := validatorStageKey(issue)
-	if key == "" {
+func (o *Orchestrator) markValidatorResultCommented(ctx context.Context, issue connector.Issue) {
+	identity := validatorStageIdentityForIssue(issue)
+	if identity.Key == "" {
 		return
 	}
 	o.validatorMu.Lock()
-	defer o.validatorMu.Unlock()
-	result, ok := o.validatorResults[key]
+	result, ok := o.validatorResults[identity.Key]
 	if !ok {
+		o.validatorMu.Unlock()
 		return
 	}
 	result.Commented = true
-	o.validatorResults[key] = result
+	o.validatorResults[identity.Key] = result
+	o.validatorMu.Unlock()
+	o.markValidatorVerdictCommented(ctx, identity)
 }
 
 func (o *Orchestrator) commentValidatorResult(ctx context.Context, issue connector.Issue, result gate.ValidatorResult) {
@@ -1005,10 +1055,16 @@ func pullRequestNumber(issue connector.Issue) int {
 	return 0
 }
 
-func validatorStageKey(issue connector.Issue) string {
+type validatorStageIdentity struct {
+	Key     string
+	IssueID string
+	HeadSHA string
+}
+
+func validatorStageIdentityForIssue(issue connector.Issue) validatorStageIdentity {
 	issueID := strings.TrimSpace(issue.ID)
 	if issueID == "" {
-		return ""
+		return validatorStageIdentity{}
 	}
 	headSHA := ""
 	if issue.PullRequest != nil {
@@ -1020,7 +1076,166 @@ func validatorStageKey(issue connector.Issue) string {
 	if headSHA == "" {
 		headSHA = strings.TrimSpace(issue.BranchName)
 	}
-	return issueID + ":" + headSHA
+	if headSHA == "" {
+		return validatorStageIdentity{}
+	}
+	return validatorStageIdentity{
+		Key:     issueID + ":" + headSHA,
+		IssueID: issueID,
+		HeadSHA: headSHA,
+	}
+}
+
+func validatorStageRetryDelay(cfg Config, attempt int) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	maxRetryBackoff := cfg.MaxRetryBackoff
+	if maxRetryBackoff <= 0 {
+		maxRetryBackoff = defaultMaxRetryBackoff
+	}
+	failureRetryBaseDelay := cfg.FailureRetryBaseDelay
+	if failureRetryBaseDelay <= 0 {
+		failureRetryBaseDelay = defaultFailureRetryBaseDelay
+	}
+	delay := failureRetryBaseDelay
+	for range attempt - 1 {
+		if delay >= maxRetryBackoff || delay > maxRetryBackoff/2 {
+			return maxRetryBackoff
+		}
+		delay *= 2
+	}
+	if delay > maxRetryBackoff {
+		return maxRetryBackoff
+	}
+	return delay
+}
+
+func (o *Orchestrator) loadValidatorVerdict(ctx context.Context, issue connector.Issue, identity validatorStageIdentity) (validatorStageResult, bool) {
+	if o.validatorMemo == nil {
+		return validatorStageResult{}, false
+	}
+	verdict, err := o.validatorMemo.ValidatorVerdict(ctx, store.ValidatorVerdictKey{
+		ProjectID: o.workflowMetricsProjectID(),
+		IssueID:   identity.IssueID,
+		HeadSHA:   identity.HeadSHA,
+	})
+	if err != nil {
+		if errors.Is(err, store.ErrNotFound) {
+			return validatorStageResult{}, false
+		}
+		if o.logger != nil {
+			o.logger.Warn(
+				"validator verdict lookup failed",
+				"issue_id", identity.IssueID,
+				"identifier", issue.Identifier,
+				"head_sha", identity.HeadSHA,
+				"error", err,
+			)
+		}
+		return validatorStageResult{}, false
+	}
+	return validatorStageResult{
+		Result: gate.ValidatorResult{
+			Submitted: verdict.Submitted,
+			Verdict:   verdict.Verdict,
+			Score:     verdict.Score,
+			Summary:   verdict.Summary,
+			Findings:  gateFindingsFromStore(verdict.Findings),
+		},
+		Commented: verdict.Commented,
+	}, true
+}
+
+func (o *Orchestrator) recordValidatorVerdict(
+	ctx context.Context,
+	issue connector.Issue,
+	identity validatorStageIdentity,
+	result gate.ValidatorResult,
+	recordedAt time.Time,
+) {
+	if o.validatorMemo == nil {
+		return
+	}
+	if recordedAt.IsZero() {
+		recordedAt = o.clockNow().UTC()
+	}
+	if err := o.validatorMemo.RecordValidatorVerdict(ctx, store.ValidatorVerdict{
+		ProjectID:  o.workflowMetricsProjectID(),
+		IssueID:    identity.IssueID,
+		HeadSHA:    identity.HeadSHA,
+		Identifier: issue.Identifier,
+		IssueURL:   issue.URL,
+		PRNumber:   workflowMetricsPRNumber(issue),
+		Submitted:  result.Submitted,
+		Verdict:    result.Verdict,
+		Score:      result.Score,
+		Summary:    result.Summary,
+		Findings:   storeFindingsFromGate(result.Findings),
+		RecordedAt: recordedAt,
+		UpdatedAt:  recordedAt,
+	}); err != nil && o.logger != nil {
+		o.logger.Warn(
+			"validator verdict persistence failed",
+			"issue_id", identity.IssueID,
+			"identifier", issue.Identifier,
+			"head_sha", identity.HeadSHA,
+			"error", err,
+		)
+	}
+}
+
+func (o *Orchestrator) markValidatorVerdictCommented(ctx context.Context, identity validatorStageIdentity) {
+	if o.validatorMemo == nil {
+		return
+	}
+	if err := o.validatorMemo.MarkValidatorVerdictCommented(ctx, store.ValidatorVerdictKey{
+		ProjectID: o.workflowMetricsProjectID(),
+		IssueID:   identity.IssueID,
+		HeadSHA:   identity.HeadSHA,
+	}, o.clockNow().UTC()); err != nil && !errors.Is(err, store.ErrNotFound) && o.logger != nil {
+		o.logger.Warn(
+			"validator verdict comment marker failed",
+			"issue_id", identity.IssueID,
+			"head_sha", identity.HeadSHA,
+			"error", err,
+		)
+	}
+}
+
+func (o *Orchestrator) clockNow() time.Time {
+	if o != nil && o.now != nil {
+		return o.now()
+	}
+	return time.Now()
+}
+
+func storeFindingsFromGate(findings []gate.Finding) []store.ValidatorFinding {
+	out := make([]store.ValidatorFinding, 0, len(findings))
+	for _, finding := range findings {
+		out = append(out, store.ValidatorFinding{
+			Severity: finding.Severity,
+			Body:     finding.Body,
+			URL:      finding.URL,
+			Path:     finding.Path,
+			Line:     finding.Line,
+		})
+	}
+	return out
+}
+
+func gateFindingsFromStore(findings []store.ValidatorFinding) []gate.Finding {
+	out := make([]gate.Finding, 0, len(findings))
+	for _, finding := range findings {
+		out = append(out, gate.Finding{
+			Severity: finding.Severity,
+			Body:     finding.Body,
+			URL:      finding.URL,
+			Path:     finding.Path,
+			Line:     finding.Line,
+		})
+	}
+	return out
 }
 
 func AutoPromoteSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"sync"
@@ -1047,6 +1048,201 @@ func TestTickAutoPromoteRunsValidatorStage(t *testing.T) {
 			t.Fatalf("pull request comment %q missing %q", tracker.prComments[0].body, fragment)
 		}
 	}
+}
+
+func TestTickAutoPromoteUsesPersistedValidatorVerdictAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	memo := openValidatorMemoStore(t)
+	now := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	cfg := autoPromoteValidatorTestConfig()
+	issue := autoPromoteTickIssue("issue-validator-restart", []string{"enhancement"}, &connector.PullRequest{
+		Number:                 858,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/858",
+		BranchName:             "detent/digitaldrywood_detent_858",
+		HeadSHA:                "head-validator-restart",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	validator := &autoPromoteTickValidator{
+		result: gate.ValidatorResult{
+			Submitted: true,
+			Verdict:   gate.ValidatorVerdictPass,
+			Score:     0.94,
+			Summary:   "Stored validator result.",
+			Findings: []gate.Finding{{
+				Severity: "p2",
+				Body:     "non-blocking note",
+				Path:     "internal/orchestrator/autopromote_tick.go",
+				Line:     12,
+			}},
+		},
+	}
+	orch := &Orchestrator{
+		cfg:           cfg,
+		connector:     &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}},
+		validator:     validator,
+		validatorMemo: memo,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now: func() time.Time {
+			return now
+		},
+	}
+	state := newState(cfg)
+	orch.tick(ctx, &state, now)
+	waitForValidatorRequests(t, validator, 1)
+	waitForPersistedValidatorVerdict(t, memo, store.ValidatorVerdictKey{
+		ProjectID: "detent",
+		IssueID:   issue.ID,
+		HeadSHA:   "head-validator-restart",
+	})
+
+	restartedValidator := &autoPromoteTickValidator{err: errors.New("validator should not dispatch")}
+	restartedTracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	restarted := &Orchestrator{
+		cfg:           cfg,
+		connector:     restartedTracker,
+		validator:     restartedValidator,
+		validatorMemo: memo,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now: func() time.Time {
+			return now.Add(time.Minute)
+		},
+	}
+	restartedState := newState(cfg)
+	mergingSlot := dispatchTestIssue("issue-validator-restart-merging-slot", "Merging")
+	restartedState.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
+	restarted.tick(ctx, &restartedState, now.Add(time.Minute))
+
+	if got := restartedValidator.Requests(); len(got) != 0 {
+		t.Fatalf("validator requests after restart = %#v, want none", got)
+	}
+	if got, want := restartedTracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates after restart = %#v, want %#v", got, want)
+	}
+	if len(restartedTracker.prComments) != 1 {
+		t.Fatalf("pull request comments after restart = %#v, want one validator result comment", restartedTracker.prComments)
+	}
+	for _, fragment := range []string{"Validator verdict: pass", "score: 0.94", "Stored validator result.", "non-blocking note"} {
+		if !strings.Contains(restartedTracker.prComments[0].body, fragment) {
+			t.Fatalf("pull request comment %q missing %q", restartedTracker.prComments[0].body, fragment)
+		}
+	}
+}
+
+func TestTickAutoPromoteValidatorVerdictHeadSHAInvalidatesMemo(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	memo := openValidatorMemoStore(t)
+	now := time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	cfg := autoPromoteValidatorTestConfig()
+	issue := autoPromoteTickIssue("issue-validator-new-head", []string{"enhancement"}, &connector.PullRequest{
+		Number:                 859,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/859",
+		BranchName:             "detent/digitaldrywood_detent_859",
+		HeadSHA:                "head-validator-old",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	if err := memo.RecordValidatorVerdict(ctx, store.ValidatorVerdict{
+		ProjectID:  "detent",
+		IssueID:    issue.ID,
+		HeadSHA:    "head-validator-old",
+		Identifier: issue.Identifier,
+		Submitted:  true,
+		Verdict:    gate.ValidatorVerdictPass,
+		Score:      0.99,
+		RecordedAt: now.Add(-time.Minute),
+		UpdatedAt:  now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("RecordValidatorVerdict() error = %v", err)
+	}
+
+	fresh := cloneIssue(issue)
+	fresh.PullRequest.HeadSHA = "head-validator-new"
+	validator := &autoPromoteTickValidator{
+		result: gate.ValidatorResult{
+			Submitted: true,
+			Verdict:   gate.ValidatorVerdictPass,
+			Score:     0.91,
+		},
+	}
+	orch := &Orchestrator{
+		cfg:           cfg,
+		connector:     &autoPromoteTickConnector{stateIssues: []connector.Issue{fresh}},
+		validator:     validator,
+		validatorMemo: memo,
+		logger:        slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now: func() time.Time {
+			return now
+		},
+	}
+	state := newState(cfg)
+	orch.tick(ctx, &state, now)
+
+	waitForValidatorRequests(t, validator, 1)
+	requests := validator.Requests()
+	if requests[0].Issue.PullRequest == nil || requests[0].Issue.PullRequest.HeadSHA != "head-validator-new" {
+		t.Fatalf("validator request head SHA = %#v, want new head", requests[0].Issue.PullRequest)
+	}
+}
+
+func TestTickAutoPromoteValidatorFailureBackoff(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	clock := newAutoPromoteTickClock(time.Date(2026, 6, 14, 10, 0, 0, 0, time.UTC))
+	oldReview := clock.Now().Add(-20 * time.Minute)
+	cfg := autoPromoteValidatorTestConfig()
+	cfg.FailureRetryBaseDelay = 30 * time.Second
+	cfg.MaxRetryBackoff = 2 * time.Minute
+	issue := autoPromoteTickIssue("issue-validator-backoff", []string{"enhancement"}, &connector.PullRequest{
+		Number:                 860,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/860",
+		BranchName:             "detent/digitaldrywood_detent_860",
+		HeadSHA:                "head-validator-backoff",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	validator := &autoPromoteTickValidator{err: errors.New("validator unavailable")}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		validator: validator,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		now:       clock.Now,
+	}
+	state := newState(cfg)
+
+	orch.tick(ctx, &state, clock.Now())
+	waitForValidatorRequests(t, validator, 1)
+	failure := waitForValidatorFailure(t, orch, issue, 1)
+	if got, want := failure.NextRetryAt, clock.Now().Add(30*time.Second); !got.Equal(want) {
+		t.Fatalf("NextRetryAt = %s, want %s", got, want)
+	}
+
+	immediate := clock.Now().Add(time.Second)
+	clock.Set(immediate)
+	orch.tick(ctx, &state, immediate)
+	if got := len(validator.Requests()); got != 1 {
+		t.Fatalf("validator requests during backoff = %d, want 1", got)
+	}
+
+	resumeAt := failure.NextRetryAt
+	clock.Set(resumeAt)
+	orch.tick(ctx, &state, resumeAt)
+	waitForValidatorRequests(t, validator, 2)
 }
 
 func TestRunDrainsInFlightValidatorStageOnShutdown(t *testing.T) {
@@ -3281,12 +3477,106 @@ func waitForValidatorResult(t *testing.T, orch *Orchestrator, issue connector.Is
 
 	deadline := time.Now().Add(time.Second)
 	for time.Now().Before(deadline) {
-		if _, _, ok := orch.validatorStageResult(issue); ok {
+		if _, _, ok := orch.validatorStageResult(context.Background(), issue); ok {
 			return
 		}
 		time.Sleep(time.Millisecond)
 	}
 	t.Fatal("validator result was not recorded")
+}
+
+func waitForPersistedValidatorVerdict(t *testing.T, memo store.ValidatorMemoStore, key store.ValidatorVerdictKey) {
+	t.Helper()
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := memo.ValidatorVerdict(context.Background(), key); err == nil {
+			return
+		} else if !errors.Is(err, store.ErrNotFound) {
+			t.Fatalf("ValidatorVerdict() error = %v", err)
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("validator verdict was not persisted for %#v", key)
+}
+
+func waitForValidatorFailure(t *testing.T, orch *Orchestrator, issue connector.Issue, attempt int) validatorStageFailure {
+	t.Helper()
+
+	identity := validatorStageIdentityForIssue(issue)
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		orch.validatorMu.Lock()
+		failure, ok := orch.validatorFailures[identity.Key]
+		orch.validatorMu.Unlock()
+		if ok && failure.Attempt >= attempt {
+			return failure
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("validator failure attempt %d was not recorded", attempt)
+	return validatorStageFailure{}
+}
+
+func openValidatorMemoStore(t *testing.T) store.Store {
+	t.Helper()
+
+	backend, err := store.Open(context.Background(), store.Config{
+		Backend: store.BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "detent.db"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	return backend
+}
+
+func autoPromoteValidatorTestConfig() Config {
+	return normalizeConfig(Config{
+		Project:             scheduler.ProjectCandidate{ID: "detent", Weight: 1},
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate: gate.Config{
+				Kind: gate.KindCommand,
+				Validator: gate.ValidatorConfig{
+					Enabled:  true,
+					MinScore: 0.8,
+					BlockOn:  []string{"p1"},
+				},
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+}
+
+type autoPromoteTickClock struct {
+	mu  sync.Mutex
+	now time.Time
+}
+
+func newAutoPromoteTickClock(now time.Time) *autoPromoteTickClock {
+	return &autoPromoteTickClock{now: now}
+}
+
+func (c *autoPromoteTickClock) Now() time.Time {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.now
+}
+
+func (c *autoPromoteTickClock) Set(now time.Time) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.now = now
 }
 
 func waitForGlobalDispatchSlot(t *testing.T, globalGate scheduler.ProjectDispatchGate, projectID string) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -99,7 +99,9 @@ type Dependencies struct {
 	WorkspaceReaper    WorkspaceReaper
 	WorkflowMetrics    WorkflowMetricsRecorder
 	WorkAttempts       store.WorkAttemptStore
+	ValidatorMemo      store.ValidatorMemoStore
 	GlobalDispatchGate scheduler.ProjectDispatchGate
+	Now                func() time.Time
 	Logger             *slog.Logger
 }
 
@@ -126,6 +128,9 @@ type Orchestrator struct {
 	validatorWG        sync.WaitGroup
 	validatorRuns      map[string]struct{}
 	validatorResults   map[string]validatorStageResult
+	validatorFailures  map[string]validatorStageFailure
+	validatorMemo      store.ValidatorMemoStore
+	now                func() time.Time
 	stateRequests      chan stateRequest
 	drainRequests      chan drainRequest
 	forceRequests      chan forceRequest
@@ -140,6 +145,12 @@ type Orchestrator struct {
 type validatorStageResult struct {
 	Result    gate.ValidatorResult
 	Commented bool
+}
+
+type validatorStageFailure struct {
+	Attempt     int
+	NextRetryAt time.Time
+	Error       string
 }
 
 type stateRequest struct {
@@ -254,10 +265,21 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	if logger == nil {
 		logger = slog.Default()
 	}
+	now := deps.Now
+	if now == nil {
+		now = time.Now
+	}
+	validatorMemo := deps.ValidatorMemo
+	if validatorMemo == nil {
+		if candidate, ok := deps.WorkflowMetrics.(store.ValidatorMemoStore); ok {
+			validatorMemo = candidate
+		}
+	}
 
 	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
 		MaxRetryBackoff:       cfg.MaxRetryBackoff,
 		FailureRetryBaseDelay: cfg.FailureRetryBaseDelay,
+		Now:                   now,
 		Logger:                logger,
 	})
 	if err != nil {
@@ -276,6 +298,9 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		globalDispatchGate: deps.GlobalDispatchGate,
 		validatorRuns:      map[string]struct{}{},
 		validatorResults:   map[string]validatorStageResult{},
+		validatorFailures:  map[string]validatorStageFailure{},
+		validatorMemo:      validatorMemo,
+		now:                now,
 		stateRequests:      make(chan stateRequest),
 		drainRequests:      make(chan drainRequest),
 		forceRequests:      make(chan forceRequest),

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -89,6 +89,7 @@ type Dependencies struct {
 	GlobalDispatchGate     scheduler.ProjectDispatchGate
 	WorkflowMetrics        orchestrator.WorkflowMetricsRecorder
 	WorkAttempts           store.WorkAttemptStore
+	ValidatorMemo          store.ValidatorMemoStore
 	Events                 *hub.Hub[Event]
 	Logger                 *slog.Logger
 	GitHubToken            string
@@ -179,6 +180,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		GlobalDispatchGate: deps.GlobalDispatchGate,
 		WorkflowMetrics:    deps.WorkflowMetrics,
 		WorkAttempts:       deps.WorkAttempts,
+		ValidatorMemo:      deps.ValidatorMemo,
 		Logger:             logger,
 	}
 	orch, err := orchestratorFactory(orchConfig, orchDeps)

--- a/internal/store/migrations/00007_create_validator_verdicts.sql
+++ b/internal/store/migrations/00007_create_validator_verdicts.sql
@@ -1,0 +1,25 @@
+-- +goose Up
+CREATE TABLE validator_verdicts (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  issue_id TEXT NOT NULL,
+  head_sha TEXT NOT NULL,
+  identifier TEXT,
+  issue_url TEXT,
+  pr_number INTEGER,
+  submitted INTEGER NOT NULL DEFAULT 0,
+  verdict TEXT NOT NULL,
+  score REAL NOT NULL DEFAULT 0,
+  summary TEXT,
+  findings_json TEXT NOT NULL DEFAULT '[]',
+  commented INTEGER NOT NULL DEFAULT 0,
+  recorded_at TEXT NOT NULL,
+  updated_at TEXT NOT NULL,
+  UNIQUE(project_id, issue_id, head_sha)
+);
+
+CREATE INDEX validator_verdicts_issue_idx
+ON validator_verdicts(project_id, issue_id, updated_at DESC, id DESC);
+
+-- +goose Down
+DROP TABLE IF EXISTS validator_verdicts;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -89,6 +89,24 @@ type UsageEvent struct {
 	CostUsd        float64        `json:"cost_usd"`
 }
 
+type ValidatorVerdict struct {
+	ID           int64          `json:"id"`
+	ProjectID    string         `json:"project_id"`
+	IssueID      string         `json:"issue_id"`
+	HeadSha      string         `json:"head_sha"`
+	Identifier   sql.NullString `json:"identifier"`
+	IssueURL     sql.NullString `json:"issue_url"`
+	PrNumber     sql.NullInt64  `json:"pr_number"`
+	Submitted    int64          `json:"submitted"`
+	Verdict      string         `json:"verdict"`
+	Score        float64        `json:"score"`
+	Summary      sql.NullString `json:"summary"`
+	FindingsJson string         `json:"findings_json"`
+	Commented    int64          `json:"commented"`
+	RecordedAt   string         `json:"recorded_at"`
+	UpdatedAt    string         `json:"updated_at"`
+}
+
 type WorkAttempt struct {
 	ID                     int64          `json:"id"`
 	ProjectID              string         `json:"project_id"`

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -912,6 +912,43 @@ func (q *Queries) GetUsageEvent(ctx context.Context, id int64) (UsageEvent, erro
 	return i, err
 }
 
+const getValidatorVerdict = `-- name: GetValidatorVerdict :one
+SELECT id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at
+FROM validator_verdicts
+WHERE project_id = ?
+  AND issue_id = ?
+  AND head_sha = ?
+`
+
+type GetValidatorVerdictParams struct {
+	ProjectID string `json:"project_id"`
+	IssueID   string `json:"issue_id"`
+	HeadSha   string `json:"head_sha"`
+}
+
+func (q *Queries) GetValidatorVerdict(ctx context.Context, arg GetValidatorVerdictParams) (ValidatorVerdict, error) {
+	row := q.db.QueryRowContext(ctx, getValidatorVerdict, arg.ProjectID, arg.IssueID, arg.HeadSha)
+	var i ValidatorVerdict
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.IssueID,
+		&i.HeadSha,
+		&i.Identifier,
+		&i.IssueURL,
+		&i.PrNumber,
+		&i.Submitted,
+		&i.Verdict,
+		&i.Score,
+		&i.Summary,
+		&i.FindingsJson,
+		&i.Commented,
+		&i.RecordedAt,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
 const getWorkAttempt = `-- name: GetWorkAttempt :one
 SELECT id, project_id, issue_id, identifier, issue_url, pr_number, repo, worker_type, worker_host, lane, attempt_number, status, started_at, lease_expires_at, heartbeat_at, completed_at, terminal_state, error_class, error_message, phase, status_message, current_step, total_steps, progress_percent, current_command, wait_reason, github_rate_snapshot_json, ci_state, capacity_snapshot_json, worker_metadata_json, metrics_json, next_action
 FROM work_attempts
@@ -1346,6 +1383,35 @@ func (q *Queries) ListRecentSchedulerDecisions(ctx context.Context, arg ListRece
 	return items, nil
 }
 
+const markValidatorVerdictCommented = `-- name: MarkValidatorVerdictCommented :execrows
+UPDATE validator_verdicts
+SET commented = 1,
+    updated_at = ?
+WHERE project_id = ?
+  AND issue_id = ?
+  AND head_sha = ?
+`
+
+type MarkValidatorVerdictCommentedParams struct {
+	UpdatedAt string `json:"updated_at"`
+	ProjectID string `json:"project_id"`
+	IssueID   string `json:"issue_id"`
+	HeadSha   string `json:"head_sha"`
+}
+
+func (q *Queries) MarkValidatorVerdictCommented(ctx context.Context, arg MarkValidatorVerdictCommentedParams) (int64, error) {
+	result, err := q.db.ExecContext(ctx, markValidatorVerdictCommented,
+		arg.UpdatedAt,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.HeadSha,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return result.RowsAffected()
+}
+
 const reclaimActiveWorkAttempts = `-- name: ReclaimActiveWorkAttempts :many
 UPDATE work_attempts
 SET status = ?,
@@ -1683,6 +1749,93 @@ func (q *Queries) UpsertFairShareUsage(ctx context.Context, arg UpsertFairShareU
 		&i.Weight,
 		&i.Dispatches,
 		&i.RuntimeSeconds,
+		&i.UpdatedAt,
+	)
+	return i, err
+}
+
+const upsertValidatorVerdict = `-- name: UpsertValidatorVerdict :one
+INSERT INTO validator_verdicts (
+  project_id,
+  issue_id,
+  head_sha,
+  identifier,
+  issue_url,
+  pr_number,
+  submitted,
+  verdict,
+  score,
+  summary,
+  findings_json,
+  commented,
+  recorded_at,
+  updated_at
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+ON CONFLICT(project_id, issue_id, head_sha) DO UPDATE SET
+  identifier = excluded.identifier,
+  issue_url = excluded.issue_url,
+  pr_number = excluded.pr_number,
+  submitted = excluded.submitted,
+  verdict = excluded.verdict,
+  score = excluded.score,
+  summary = excluded.summary,
+  findings_json = excluded.findings_json,
+  commented = excluded.commented,
+  recorded_at = excluded.recorded_at,
+  updated_at = excluded.updated_at
+RETURNING id, project_id, issue_id, head_sha, identifier, issue_url, pr_number, submitted, verdict, score, summary, findings_json, commented, recorded_at, updated_at
+`
+
+type UpsertValidatorVerdictParams struct {
+	ProjectID    string         `json:"project_id"`
+	IssueID      string         `json:"issue_id"`
+	HeadSha      string         `json:"head_sha"`
+	Identifier   sql.NullString `json:"identifier"`
+	IssueURL     sql.NullString `json:"issue_url"`
+	PrNumber     sql.NullInt64  `json:"pr_number"`
+	Submitted    int64          `json:"submitted"`
+	Verdict      string         `json:"verdict"`
+	Score        float64        `json:"score"`
+	Summary      sql.NullString `json:"summary"`
+	FindingsJson string         `json:"findings_json"`
+	Commented    int64          `json:"commented"`
+	RecordedAt   string         `json:"recorded_at"`
+	UpdatedAt    string         `json:"updated_at"`
+}
+
+func (q *Queries) UpsertValidatorVerdict(ctx context.Context, arg UpsertValidatorVerdictParams) (ValidatorVerdict, error) {
+	row := q.db.QueryRowContext(ctx, upsertValidatorVerdict,
+		arg.ProjectID,
+		arg.IssueID,
+		arg.HeadSha,
+		arg.Identifier,
+		arg.IssueURL,
+		arg.PrNumber,
+		arg.Submitted,
+		arg.Verdict,
+		arg.Score,
+		arg.Summary,
+		arg.FindingsJson,
+		arg.Commented,
+		arg.RecordedAt,
+		arg.UpdatedAt,
+	)
+	var i ValidatorVerdict
+	err := row.Scan(
+		&i.ID,
+		&i.ProjectID,
+		&i.IssueID,
+		&i.HeadSha,
+		&i.Identifier,
+		&i.IssueURL,
+		&i.PrNumber,
+		&i.Submitted,
+		&i.Verdict,
+		&i.Score,
+		&i.Summary,
+		&i.FindingsJson,
+		&i.Commented,
+		&i.RecordedAt,
 		&i.UpdatedAt,
 	)
 	return i, err

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -85,6 +85,7 @@ func (s *sqliteStore) RuntimeEvidence(ctx context.Context, query RuntimeEvidence
 		{name: "workflow_phase_events", projectScoped: true},
 		{name: "work_attempts", projectScoped: true},
 		{name: "scheduler_decisions", projectScoped: true},
+		{name: "validator_verdicts", projectScoped: true},
 	}
 	projectID := strings.TrimSpace(query.ProjectID)
 	for _, table := range tables {
@@ -650,6 +651,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM work_attempts WHERE project_id = ?", projectID)
 		case "scheduler_decisions":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_decisions WHERE project_id = ?", projectID)
+		case "validator_verdicts":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM validator_verdicts WHERE project_id = ?", projectID)
 		default:
 			return 0, fmt.Errorf("unsupported project-scoped runtime table %q", tableName)
 		}
@@ -669,6 +672,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM work_attempts")
 		case "scheduler_decisions":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_decisions")
+		case "validator_verdicts":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM validator_verdicts")
 		default:
 			return 0, fmt.Errorf("unsupported runtime table %q", tableName)
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -29,6 +29,7 @@ type Store interface {
 	BudgetCostStore
 	WorkflowMetricsStore
 	WorkAttemptStore
+	ValidatorMemoStore
 	RuntimeEvidenceStore
 	Queries() *sqlc.Queries
 	Close() error
@@ -72,6 +73,12 @@ type WorkAttemptStore interface {
 	ReclaimActiveWorkAttempts(context.Context, WorkAttemptReclaim) ([]WorkAttempt, error)
 	RecordSchedulerDecision(context.Context, SchedulerDecision) (int64, error)
 	ListRecentSchedulerDecisions(context.Context, SchedulerDecisionQuery) ([]SchedulerDecision, error)
+}
+
+type ValidatorMemoStore interface {
+	RecordValidatorVerdict(context.Context, ValidatorVerdict) error
+	ValidatorVerdict(context.Context, ValidatorVerdictKey) (ValidatorVerdict, error)
+	MarkValidatorVerdictCommented(context.Context, ValidatorVerdictKey, time.Time) error
 }
 
 type RuntimeEvidenceStore interface {
@@ -234,6 +241,37 @@ type WorkflowPhaseEvent struct {
 	TotalTokens       int64
 	EndpointFamily    string
 	MetadataJSON      string
+}
+
+type ValidatorVerdictKey struct {
+	ProjectID string
+	IssueID   string
+	HeadSHA   string
+}
+
+type ValidatorFinding struct {
+	Severity string `json:"severity,omitempty"`
+	Body     string `json:"body,omitempty"`
+	URL      string `json:"url,omitempty"`
+	Path     string `json:"path,omitempty"`
+	Line     int    `json:"line,omitempty"`
+}
+
+type ValidatorVerdict struct {
+	ProjectID  string
+	IssueID    string
+	HeadSHA    string
+	Identifier string
+	IssueURL   string
+	PRNumber   *int64
+	Submitted  bool
+	Verdict    string
+	Score      float64
+	Summary    string
+	Findings   []ValidatorFinding
+	Commented  bool
+	RecordedAt time.Time
+	UpdatedAt  time.Time
 }
 
 type WorkAttempt struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -42,8 +42,8 @@ func TestOpenSQLiteAppliesMigrationsAndPragmas(t *testing.T) {
 	if got := queryInt(t, sqliteBackend.db, "PRAGMA busy_timeout"); got != 5000 {
 		t.Fatalf("busy_timeout = %d, want 5000", got)
 	}
-	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('detent_runs', 'codex_sessions', 'fair_share_usage', 'usage_events', 'workflow_phase_events', 'work_attempts', 'scheduler_decisions')"); got != 7 {
-		t.Fatalf("migrated table count = %d, want 7", got)
+	if got := queryInt(t, sqliteBackend.db, "SELECT COUNT(*) FROM sqlite_master WHERE type = 'table' AND name IN ('detent_runs', 'codex_sessions', 'fair_share_usage', 'usage_events', 'workflow_phase_events', 'work_attempts', 'scheduler_decisions', 'validator_verdicts')"); got != 8 {
+		t.Fatalf("migrated table count = %d, want 8", got)
 	}
 }
 
@@ -99,7 +99,7 @@ func TestRuntimeEvidenceReportsSQLiteTelemetry(t *testing.T) {
 	if evidence.Backend != BackendSQLite || evidence.Path != dbPath || !evidence.Healthy {
 		t.Fatalf("RuntimeEvidence() = %#v, want healthy sqlite evidence for %q", evidence, dbPath)
 	}
-	if evidence.MigrationVersion < 6 || evidence.MigrationStatus == "" {
+	if evidence.MigrationVersion < 7 || evidence.MigrationStatus == "" {
 		t.Fatalf("migration evidence = version %d status %q, want applied version", evidence.MigrationVersion, evidence.MigrationStatus)
 	}
 	if got := runtimeEvidenceTableCount(evidence.Tables, "usage_events"); got != 1 {
@@ -116,6 +116,82 @@ func TestRuntimeEvidenceReportsSQLiteTelemetry(t *testing.T) {
 	}
 	if evidence.WorkflowPhaseEvents.NewestFinishedAt == nil || !evidence.WorkflowPhaseEvents.NewestFinishedAt.Equal(finishedAt) {
 		t.Fatalf("NewestFinishedAt = %#v, want %s", evidence.WorkflowPhaseEvents.NewestFinishedAt, finishedAt)
+	}
+}
+
+func TestSQLiteValidatorVerdictRoundTrip(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend, err := Open(ctx, Config{
+		Backend: BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "detent.db"),
+	})
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := backend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	recordedAt := time.Date(2026, 7, 2, 14, 0, 0, 0, time.UTC)
+	key := ValidatorVerdictKey{ProjectID: "detent", IssueID: "issue-858", HeadSHA: "abc123"}
+	if err := backend.RecordValidatorVerdict(ctx, ValidatorVerdict{
+		ProjectID:  key.ProjectID,
+		IssueID:    key.IssueID,
+		HeadSHA:    key.HeadSHA,
+		Identifier: "digitaldrywood/detent#858",
+		IssueURL:   "https://github.test/digitaldrywood/detent/issues/858",
+		PRNumber:   int64Pointer(875),
+		Submitted:  true,
+		Verdict:    "pass",
+		Score:      0.93,
+		Summary:    "acceptance criteria pass",
+		Findings: []ValidatorFinding{{
+			Severity: "p2",
+			Body:     "minor follow-up",
+			URL:      "https://github.test/digitaldrywood/detent/pull/875#discussion_r1",
+			Path:     "internal/orchestrator/autopromote_tick.go",
+			Line:     42,
+		}},
+		RecordedAt: recordedAt,
+		UpdatedAt:  recordedAt,
+	}); err != nil {
+		t.Fatalf("RecordValidatorVerdict() error = %v", err)
+	}
+
+	got, err := backend.ValidatorVerdict(ctx, key)
+	if err != nil {
+		t.Fatalf("ValidatorVerdict() error = %v", err)
+	}
+	if got.ProjectID != key.ProjectID || got.IssueID != key.IssueID || got.HeadSHA != key.HeadSHA {
+		t.Fatalf("verdict key = %#v, want %#v", got, key)
+	}
+	if !got.Submitted || got.Verdict != "pass" || got.Score != 0.93 || got.Summary != "acceptance criteria pass" {
+		t.Fatalf("verdict result = %#v, want submitted pass score", got)
+	}
+	if got.PRNumber == nil || *got.PRNumber != 875 {
+		t.Fatalf("PRNumber = %#v, want 875", got.PRNumber)
+	}
+	if len(got.Findings) != 1 || got.Findings[0].Severity != "p2" || got.Findings[0].Path != "internal/orchestrator/autopromote_tick.go" {
+		t.Fatalf("Findings = %#v, want persisted finding", got.Findings)
+	}
+	if got.Commented {
+		t.Fatalf("Commented = true, want false")
+	}
+
+	commentedAt := recordedAt.Add(time.Minute)
+	if err := backend.MarkValidatorVerdictCommented(ctx, key, commentedAt); err != nil {
+		t.Fatalf("MarkValidatorVerdictCommented() error = %v", err)
+	}
+	got, err = backend.ValidatorVerdict(ctx, key)
+	if err != nil {
+		t.Fatalf("ValidatorVerdict() after commented error = %v", err)
+	}
+	if !got.Commented || !got.UpdatedAt.Equal(commentedAt) {
+		t.Fatalf("commented verdict = %#v, want commented at %s", got, commentedAt)
 	}
 }
 
@@ -1608,6 +1684,10 @@ func assertUsageRows(t *testing.T, got []UsageReportRow, want []UsageReportRow) 
 
 func dateOnly(year int, month time.Month, day int) time.Time {
 	return time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+}
+
+func int64Pointer(value int64) *int64 {
+	return &value
 }
 
 func queryString(t *testing.T, db *sql.DB, query string) string {

--- a/internal/store/validator_memo.go
+++ b/internal/store/validator_memo.go
@@ -1,0 +1,182 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/store/sqlc"
+)
+
+func (s *sqliteStore) RecordValidatorVerdict(ctx context.Context, attrs ValidatorVerdict) error {
+	projectID := strings.TrimSpace(attrs.ProjectID)
+	if projectID == "" {
+		return errors.New("project_id is required")
+	}
+	issueID := strings.TrimSpace(attrs.IssueID)
+	if issueID == "" {
+		return errors.New("issue_id is required")
+	}
+	headSHA := strings.TrimSpace(attrs.HeadSHA)
+	if headSHA == "" {
+		return errors.New("head_sha is required")
+	}
+	recordedAt, err := requiredTimestamp("recorded_at", attrs.RecordedAt)
+	if err != nil {
+		return err
+	}
+	updatedAtValue := attrs.UpdatedAt
+	if updatedAtValue.IsZero() {
+		updatedAtValue = attrs.RecordedAt
+	}
+	updatedAt, err := requiredTimestamp("updated_at", updatedAtValue)
+	if err != nil {
+		return err
+	}
+	findingsJSON, err := validatorFindingsJSON(attrs.Findings)
+	if err != nil {
+		return err
+	}
+
+	if _, err := s.queries.UpsertValidatorVerdict(ctx, sqlc.UpsertValidatorVerdictParams{
+		ProjectID:    projectID,
+		IssueID:      issueID,
+		HeadSha:      headSHA,
+		Identifier:   nullString(attrs.Identifier),
+		IssueURL:     nullString(attrs.IssueURL),
+		PrNumber:     nullOptionalInt64(attrs.PRNumber),
+		Submitted:    boolInt64(attrs.Submitted),
+		Verdict:      strings.TrimSpace(attrs.Verdict),
+		Score:        nonNegativeFloat(attrs.Score),
+		Summary:      nullString(attrs.Summary),
+		FindingsJson: findingsJSON,
+		Commented:    boolInt64(attrs.Commented),
+		RecordedAt:   recordedAt,
+		UpdatedAt:    updatedAt,
+	}); err != nil {
+		return fmt.Errorf("recording validator verdict: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteStore) ValidatorVerdict(ctx context.Context, key ValidatorVerdictKey) (ValidatorVerdict, error) {
+	projectID := strings.TrimSpace(key.ProjectID)
+	if projectID == "" {
+		return ValidatorVerdict{}, errors.New("project_id is required")
+	}
+	issueID := strings.TrimSpace(key.IssueID)
+	if issueID == "" {
+		return ValidatorVerdict{}, errors.New("issue_id is required")
+	}
+	headSHA := strings.TrimSpace(key.HeadSHA)
+	if headSHA == "" {
+		return ValidatorVerdict{}, errors.New("head_sha is required")
+	}
+
+	row, err := s.queries.GetValidatorVerdict(ctx, sqlc.GetValidatorVerdictParams{
+		ProjectID: projectID,
+		IssueID:   issueID,
+		HeadSha:   headSHA,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return ValidatorVerdict{}, ErrNotFound
+		}
+		return ValidatorVerdict{}, fmt.Errorf("reading validator verdict: %w", err)
+	}
+	return validatorVerdictFromRow(row)
+}
+
+func (s *sqliteStore) MarkValidatorVerdictCommented(ctx context.Context, key ValidatorVerdictKey, at time.Time) error {
+	projectID := strings.TrimSpace(key.ProjectID)
+	if projectID == "" {
+		return errors.New("project_id is required")
+	}
+	issueID := strings.TrimSpace(key.IssueID)
+	if issueID == "" {
+		return errors.New("issue_id is required")
+	}
+	headSHA := strings.TrimSpace(key.HeadSHA)
+	if headSHA == "" {
+		return errors.New("head_sha is required")
+	}
+	updatedAt, err := requiredTimestamp("updated_at", at)
+	if err != nil {
+		return err
+	}
+
+	affected, err := s.queries.MarkValidatorVerdictCommented(ctx, sqlc.MarkValidatorVerdictCommentedParams{
+		UpdatedAt: updatedAt,
+		ProjectID: projectID,
+		IssueID:   issueID,
+		HeadSha:   headSHA,
+	})
+	if err != nil {
+		return fmt.Errorf("marking validator verdict commented: %w", err)
+	}
+	if affected == 0 {
+		return ErrNotFound
+	}
+	return nil
+}
+
+func validatorVerdictFromRow(row sqlc.ValidatorVerdict) (ValidatorVerdict, error) {
+	recordedAt, err := parseTimestamp("recorded_at", row.RecordedAt)
+	if err != nil {
+		return ValidatorVerdict{}, err
+	}
+	updatedAt, err := parseTimestamp("updated_at", row.UpdatedAt)
+	if err != nil {
+		return ValidatorVerdict{}, err
+	}
+	findings, err := validatorFindingsFromJSON(row.FindingsJson)
+	if err != nil {
+		return ValidatorVerdict{}, err
+	}
+
+	return ValidatorVerdict{
+		ProjectID:  row.ProjectID,
+		IssueID:    row.IssueID,
+		HeadSHA:    row.HeadSha,
+		Identifier: row.Identifier.String,
+		IssueURL:   row.IssueURL.String,
+		PRNumber:   optionalInt64Pointer(row.PrNumber),
+		Submitted:  row.Submitted != 0,
+		Verdict:    row.Verdict,
+		Score:      nonNegativeFloat(row.Score),
+		Summary:    row.Summary.String,
+		Findings:   findings,
+		Commented:  row.Commented != 0,
+		RecordedAt: recordedAt.UTC(),
+		UpdatedAt:  updatedAt.UTC(),
+	}, nil
+}
+
+func validatorFindingsJSON(findings []ValidatorFinding) (string, error) {
+	if findings == nil {
+		findings = []ValidatorFinding{}
+	}
+	data, err := json.Marshal(findings)
+	if err != nil {
+		return "", fmt.Errorf("encoding validator findings: %w", err)
+	}
+	return string(data), nil
+}
+
+func validatorFindingsFromJSON(value string) ([]ValidatorFinding, error) {
+	if strings.TrimSpace(value) == "" {
+		return []ValidatorFinding{}, nil
+	}
+	var findings []ValidatorFinding
+	if err := json.Unmarshal([]byte(value), &findings); err != nil {
+		return nil, fmt.Errorf("decoding validator findings: %w", err)
+	}
+	if findings == nil {
+		return []ValidatorFinding{}, nil
+	}
+	return findings, nil
+}


### PR DESCRIPTION
## Summary

- persist auto-promote validator verdicts by project, issue ID, and head SHA
- reuse persisted validator results after restart and keep changed heads isolated
- add per-key validator failure backoff before redispatching failed validator sessions

Fixes #858

## Test Plan

- [x] `go test ./internal/store`
- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/project`
- [x] `go test ./internal/cli`
- [x] `make check`
