### PR TITLE
feat(orchestrator): deterministic merge fast-path for clean rebases

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -197,6 +197,7 @@ type Agent struct {
 	MaxConcurrentAgentsByState   map[string]int `yaml:"max_concurrent_agents_by_state"`
 	DispatchPriorityByState      []string       `yaml:"dispatch_priority_by_state"`
 	DispatchPriorityByLabel      []string       `yaml:"dispatch_priority_by_label"`
+	MergeFastPath                MergeFastPath  `yaml:"merge_fast_path"`
 	AutoPromote                  AutoPromote    `yaml:"auto_promote"`
 	Budget                       Budget         `yaml:"budget"`
 	Lessons                      Lessons        `yaml:"lessons"`
@@ -205,6 +206,10 @@ type Agent struct {
 
 type Shutdown struct {
 	DrainTimeoutMS int `yaml:"drain_timeout_ms"`
+}
+
+type MergeFastPath struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type Agents struct {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -567,6 +567,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if cfg.Agent.MaxSessionContextMultiplier != 0 {
 		t.Fatalf("Agent.MaxSessionContextMultiplier = %v, want disabled default", cfg.Agent.MaxSessionContextMultiplier)
 	}
+	if cfg.Agent.MergeFastPath.Enabled {
+		t.Fatal("Agent.MergeFastPath.Enabled = true, want false default")
+	}
 	if cfg.Agent.Shutdown.DrainTimeoutMS != DefaultShutdownDrainTimeoutMS {
 		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want %d", cfg.Agent.Shutdown.DrainTimeoutMS, DefaultShutdownDrainTimeoutMS)
 	}
@@ -633,6 +636,24 @@ func TestValidatePlanRejectsInvalidConfig(t *testing.T) {
 		if !strings.Contains(err.Error(), want) {
 			t.Fatalf("Validate() error = %v, want %q", err, want)
 		}
+	}
+}
+
+func TestParseWorkflowAgentMergeFastPath(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+agent:
+  merge_fast_path:
+    enabled: true
+---
+Body
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if !workflow.Config.Agent.MergeFastPath.Enabled {
+		t.Fatal("Agent.MergeFastPath.Enabled = false, want true")
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -34,6 +34,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.OptoutLabel = " Requires-Human-Review "
 	cfg.Agent.AutoPromote.AllowedIssueLabels = []string{" Docs ", "docs", "Chore"}
 	cfg.Agent.AutoPromote.ReworkLimit = 2
+	cfg.Agent.MergeFastPath.Enabled = true
 	cfg.Identity.Name = "release-captain"
 	cfg.Identity.GitHubLogin = "detent-bot"
 	cfg.Tracker.Authorization = selector.Selector{
@@ -78,6 +79,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if got.AutoPromote.ReworkLimit != 2 {
 		t.Fatalf("AutoPromote.ReworkLimit = %d, want 2", got.AutoPromote.ReworkLimit)
+	}
+	if !got.MergeFastPathEnabled {
+		t.Fatal("MergeFastPathEnabled = false, want true")
 	}
 	if got.SelectorContext.InstanceLogin != "detent-bot" {
 		t.Fatalf("SelectorContext.InstanceLogin = %q, want detent-bot", got.SelectorContext.InstanceLogin)
@@ -567,6 +571,29 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDispatchModeMergingFastPathFlag(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done"},
+	})
+	state := newState(cfg)
+	issue := dispatchTestIssueWithPullRequest("issue-merging", "Merging", "OPEN")
+
+	off := Orchestrator{cfg: cfg}
+	if got := off.dispatchMode(&state, issue); got != runpkg.RunModeImplement {
+		t.Fatalf("flag off dispatchMode = %q, want implement", got)
+	}
+
+	cfg.MergeFastPathEnabled = true
+	on := Orchestrator{cfg: cfg}
+	if got := on.dispatchMode(&state, issue); got != runpkg.RunModeMerge {
+		t.Fatalf("flag on dispatchMode = %q, want merge", got)
 	}
 }
 

--- a/internal/orchestrator/merge_fast_path_test.go
+++ b/internal/orchestrator/merge_fast_path_test.go
@@ -1,0 +1,277 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"reflect"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/workspace"
+)
+
+func TestMergingFastPathCleanPrecheckMergesWithoutAgentDispatch(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 13, 20, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:   1,
+		FailureRetryBaseDelay: time.Minute,
+		MaxRetryBackoff:       time.Hour,
+		MergeFastPathEnabled:  true,
+		MaxConcurrentAgentsByState: map[string]int{
+			"Merging": 1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates: []string{"Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-clean-fast-path", []string{"enhancement"}, &connector.PullRequest{
+		Number:         860,
+		URL:            "https://github.test/digitaldrywood/detent/pull/860",
+		BranchName:     "detent/detent-digitaldrywood_detent_860-030a2359de53",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "success",
+		HeadSHA:        "head-fast-path",
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/detent#860"
+	issue.PRRepository = "digitaldrywood/detent"
+	issue.BranchName = "detent/detent-digitaldrywood_detent_860-030a2359de53"
+
+	workspaceBackend := &mergeFastPathWorkspace{
+		info: workspace.Info{
+			Path:   t.TempDir(),
+			Key:    "digitaldrywood_detent_860",
+			Branch: issue.BranchName,
+		},
+		result: workspace.MergePrepareResult{
+			Status:   workspace.MergePrepareStatusClean,
+			DiffStat: workspace.DiffStat{},
+		},
+	}
+	agentBackend := &mergeFastPathAgentBackend{}
+	runner, err := runpkg.NewRunner(runpkg.Dependencies{
+		Workflow:     workflowconfig.Workflow{},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		Now: func() time.Time {
+			return now
+		},
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	tracker := &autoPromoteTickMergeConnector{
+		autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}},
+	}
+	orch := &Orchestrator{
+		cfg:        cfg,
+		connector:  tracker,
+		supervisor: newTestSupervisor(t, runner, cfg),
+		runResults: make(chan runpkg.Completion, 1),
+		logger:     slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	orch.dispatchReadyIssues(context.Background(), &state, []connector.Issue{issue}, now)
+
+	completion := receiveMergeFastPathCompletion(t, orch.runResults)
+	if completion.Err != nil {
+		t.Fatalf("completion.Err = %v", completion.Err)
+	}
+	if completion.Request.Mode != runpkg.RunModeMerge {
+		t.Fatalf("completion.Request.Mode = %q, want %q", completion.Request.Mode, runpkg.RunModeMerge)
+	}
+	orch.handleRunResult(context.Background(), &state, completion)
+
+	if got := workspaceBackend.prepareCalls.Load(); got != 1 {
+		t.Fatalf("PrepareMerge() calls = %d, want 1", got)
+	}
+	if got := workspaceBackend.afterRunCalls.Load(); got != 1 {
+		t.Fatalf("AfterRun() calls = %d, want 1", got)
+	}
+	if got := agentBackend.calls.Load(); got != 0 {
+		t.Fatalf("AgentBackend.RunTurn() calls = %d, want 0", got)
+	}
+	if got := tracker.merges; len(got) != 1 {
+		t.Fatalf("merges = %#v, want one programmatic merge", got)
+	}
+	if got := tracker.merges[0]; got.repository != "digitaldrywood/detent" || got.number != 860 || got.headSHA != "head-fast-path" {
+		t.Fatalf("merge request = %#v, want repository digitaldrywood/detent PR 860 head-fast-path", got)
+	}
+	if got := tracker.hydrations; !reflect.DeepEqual(got, []autoPromoteTickHydration{{
+		issueID:    issue.ID,
+		repository: "digitaldrywood/detent",
+		number:     860,
+	}}) {
+		t.Fatalf("hydrations = %#v, want fresh PR hydration", got)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Done"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after clean merge fast-path", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after clean merge fast-path", issue.ID)
+	}
+	completed, ok := state.Completed[issue.ID]
+	if !ok {
+		t.Fatalf("Completed[%q] missing after clean merge fast-path", issue.ID)
+	}
+	if completed.FinalState != "Done" {
+		t.Fatalf("Completed[%q].FinalState = %q, want Done", issue.ID, completed.FinalState)
+	}
+	if completed.Issue.PullRequest == nil || completed.Issue.PullRequest.State != "MERGED" {
+		t.Fatalf("Completed[%q].Issue.PullRequest = %#v, want merged PR", issue.ID, completed.Issue.PullRequest)
+	}
+}
+
+func TestMergingFastPathCleanPrecheckWaitsForCurrentHeadCI(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 26, 13, 25, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		FailureRetryBaseDelay:  time.Minute,
+		MaxRetryBackoff:        time.Hour,
+		ContinuationRetryDelay: 5 * time.Second,
+		MergeFastPathEnabled:   true,
+		ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:         []string{"Merging"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-clean-fast-path-ci", []string{"enhancement"}, &connector.PullRequest{
+		Number:         861,
+		URL:            "https://github.test/digitaldrywood/detent/pull/861",
+		BranchName:     "detent/merge-fast-path-ci",
+		State:          "OPEN",
+		MergeableState: "clean",
+		CIStatus:       "pending",
+		HeadSHA:        "head-fast-path-ci",
+	})
+	issue.State = "Merging"
+	issue.Identifier = "digitaldrywood/detent#861"
+	issue.PRRepository = "digitaldrywood/detent"
+	issue.BranchName = "detent/merge-fast-path-ci"
+
+	tracker := &autoPromoteTickMergeConnector{
+		autoPromoteTickConnector: &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.Running[issue.ID] = Running{
+		Issue:      cloneIssue(issue),
+		Attempt:    1,
+		StartedAt:  now.Add(-time.Minute),
+		WorkerHost: "worker-a",
+		Mode:       runpkg.RunModeMerge,
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: cloneIssue(issue), ClaimedAt: now.Add(-time.Minute)}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeMerge},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			Output:     runpkg.RunOutputMergeFastPathClean,
+		},
+	})
+
+	if len(tracker.merges) != 0 {
+		t.Fatalf("merges = %#v, want none while CI is pending", tracker.merges)
+	}
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no state transition while CI is pending", tracker.updates)
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after fast-path CI wait", issue.ID)
+	}
+	if _, ok := state.Completed[issue.ID]; ok {
+		t.Fatalf("Completed[%q] present while CI is pending", issue.ID)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok {
+		t.Fatalf("Retry[%q] missing while CI is pending", issue.ID)
+	}
+	if retry.Attempt != 1 || retry.WorkerHost != "worker-a" {
+		t.Fatalf("Retry[%q] = %#v, want same-attempt retry on worker-a", issue.ID, retry)
+	}
+	if !strings.Contains(retry.Error, "current-head CI") {
+		t.Fatalf("Retry[%q].Error = %q, want current-head CI wait", issue.ID, retry.Error)
+	}
+	if !retry.DueAt.Equal(now.Add(5 * time.Second)) {
+		t.Fatalf("Retry[%q].DueAt = %s, want continuation retry delay", issue.ID, retry.DueAt)
+	}
+	if _, ok := state.Claimed[issue.ID]; !ok {
+		t.Fatalf("Claimed[%q] missing while waiting for CI", issue.ID)
+	}
+}
+
+func receiveMergeFastPathCompletion(t *testing.T, completions <-chan runpkg.Completion) runpkg.Completion {
+	t.Helper()
+
+	select {
+	case completion := <-completions:
+		return completion
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for merge fast-path completion")
+	}
+	return runpkg.Completion{}
+}
+
+type mergeFastPathWorkspace struct {
+	info          workspace.Info
+	result        workspace.MergePrepareResult
+	prepareCalls  atomic.Int64
+	afterRunCalls atomic.Int64
+}
+
+func (w *mergeFastPathWorkspace) Create(context.Context, workspace.Issue) (workspace.Info, error) {
+	return w.info, nil
+}
+
+func (w *mergeFastPathWorkspace) Cleanup(context.Context, string) error {
+	return nil
+}
+
+func (w *mergeFastPathWorkspace) BeforeRun(context.Context, workspace.Info, workspace.Issue) error {
+	return nil
+}
+
+func (w *mergeFastPathWorkspace) AfterRun(context.Context, workspace.Info, workspace.Issue) {
+	w.afterRunCalls.Add(1)
+}
+
+func (w *mergeFastPathWorkspace) DiffStat(context.Context, workspace.Info, workspace.Issue) (workspace.DiffStat, error) {
+	return w.result.DiffStat, nil
+}
+
+func (w *mergeFastPathWorkspace) PrepareMerge(context.Context, workspace.Info, workspace.Issue, workspace.MergePrepareOptions) (workspace.MergePrepareResult, error) {
+	w.prepareCalls.Add(1)
+	return w.result, nil
+}
+
+type mergeFastPathAgentBackend struct {
+	calls atomic.Int64
+}
+
+func (b *mergeFastPathAgentBackend) RunTurn(context.Context, runpkg.AgentTurnRequest, runpkg.AgentUpdateHandler) (runpkg.AgentTurnResult, error) {
+	b.calls.Add(1)
+	return runpkg.AgentTurnResult{}, errors.New("agent backend should not run during clean merge fast-path")
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -57,6 +57,7 @@ type Config struct {
 	MaxConcurrentAgentsByState    map[string]int
 	DispatchPriorityByState       []string
 	DispatchPriorityByLabel       []string
+	MergeFastPathEnabled          bool
 	MaxConcurrentAgentsPerHost    int
 	MaxRetryBackoff               time.Duration
 	Project                       scheduler.ProjectCandidate
@@ -188,6 +189,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		MaxConcurrentAgentsByState: cloneStateLimits(cfg.Agent.MaxConcurrentAgentsByState),
 		DispatchPriorityByState:    append([]string(nil), cfg.Agent.DispatchPriorityByState...),
 		DispatchPriorityByLabel:    append([]string(nil), cfg.Agent.DispatchPriorityByLabel...),
+		MergeFastPathEnabled:       cfg.Agent.MergeFastPath.Enabled,
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
 		Claiming: ClaimingConfig{
@@ -1715,6 +1717,9 @@ func dispatchStartTransitionState(issue connector.Issue, mode string, activeStat
 }
 
 func (o *Orchestrator) dispatchMode(state *State, issue connector.Issue) string {
+	if normalizeState(issue.State) == normalizeState(autoPromoteMergingState) && o.cfg.MergeFastPathEnabled {
+		return runpkg.RunModeMerge
+	}
 	cfg := gate.EffectivePlan(o.cfg.Plan)
 	if !cfg.Enabled {
 		return runpkg.RunModeImplement
@@ -2146,6 +2151,10 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	}
 	issue = refreshedIssue
 	if !mergeWorkerProgrammaticMergeReady(issue) {
+		if mergeFastPathCleanResult(event) && mergeWorkerProgrammaticMergeWaiting(issue) {
+			o.waitForMergeWorkerCurrentHeadCI(ctx, state, event, running, issue)
+			return true
+		}
 		return false
 	}
 	merger, ok := o.connector.(connector.PullRequestMerger)
@@ -2209,6 +2218,30 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 	return true
 }
 
+func (o *Orchestrator) waitForMergeWorkerCurrentHeadCI(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	issue connector.Issue,
+) {
+	running.Issue = issue
+	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalSuccess, "", "", "waiting", "merge fast-path waiting for current-head CI")
+	attempt := running.Attempt
+	if attempt < 1 {
+		attempt = 1
+	}
+	o.scheduleRetry(state, issue, attempt, event.CompletedAt, "waiting for current-head CI", true, running.WorkerHost)
+	if o.logger != nil {
+		o.logger.Info("merge_worker_waiting_current_head_ci", mergeWorkerLogAttrs(issue, "attempt", attempt)...)
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "merge_worker_waiting_current_head_ci",
+		Message: "merge worker is waiting for current-head CI for " + issueLabel(issue),
+	})
+}
+
 func (o *Orchestrator) failProgrammaticMergeWorkerResult(
 	ctx context.Context,
 	state *State,
@@ -2246,6 +2279,11 @@ func mergeWorkerTurnSucceeded(event runpkg.Completion) bool {
 	return event.Err == nil && !strings.EqualFold(strings.TrimSpace(event.Result.FinalState), runpkg.FinalStateFailed)
 }
 
+func mergeFastPathCleanResult(event runpkg.Completion) bool {
+	return event.Request.Mode == runpkg.RunModeMerge &&
+		strings.TrimSpace(event.Result.Output) == runpkg.RunOutputMergeFastPathClean
+}
+
 func mergeWorkerProgrammaticMergeReady(issue connector.Issue) bool {
 	if strings.TrimSpace(issue.ID) == "" || issue.PullRequest == nil {
 		return false
@@ -2266,6 +2304,31 @@ func mergeWorkerProgrammaticMergeReady(issue connector.Issue) bool {
 	return pullRequestRepository(issue) != "" &&
 		pullRequestNumber(issue) > 0 &&
 		strings.TrimSpace(pullRequest.HeadSHA) != ""
+}
+
+func mergeWorkerProgrammaticMergeWaiting(issue connector.Issue) bool {
+	if strings.TrimSpace(issue.ID) == "" || issue.PullRequest == nil {
+		return false
+	}
+	pullRequest := issue.PullRequest
+	if pullRequestHydrationBlocksProgress(pullRequest) {
+		return false
+	}
+	if normalizePullRequestState(pullRequest.State) != "open" || pullRequest.Draft {
+		return false
+	}
+	if mergeable := strings.ToLower(strings.TrimSpace(pullRequest.MergeableState)); mergeable != "" && mergeable != "clean" && mergeable != "unknown" {
+		return false
+	}
+	if pullRequestRepository(issue) == "" || pullRequestNumber(issue) <= 0 || strings.TrimSpace(pullRequest.HeadSHA) == "" {
+		return false
+	}
+	switch strings.ToLower(strings.TrimSpace(pullRequest.CIStatus)) {
+	case "", "pending", "running", "queued", "in_progress", "waiting":
+		return true
+	default:
+		return false
+	}
 }
 
 func mergeWorkerCIGreen(status string) bool {

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -8,6 +8,8 @@ const FinalStateCompleted = runner.FinalStateCompleted
 
 const RunModePlan = runner.RunModePlan
 
+const RunModeMerge = runner.RunModeMerge
+
 type Runner = runner.Backend
 
 type Validator = runner.Validator

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -276,6 +276,8 @@ func normalizeRunMode(mode string) string {
 		return RunModeImplement
 	case RunModePlan:
 		return RunModePlan
+	case RunModeMerge:
+		return RunModeMerge
 	default:
 		return RunModeImplement
 	}
@@ -290,6 +292,43 @@ func extraWritableRootsForWorkspace(ctx context.Context, workspacePath string, l
 		return nil
 	}
 	return roots
+}
+
+func (r *Runner) prepareMergeFastPath(
+	ctx context.Context,
+	req RunRequest,
+	info workspace.Info,
+	issue workspace.Issue,
+) (RunResult, workspace.MergePrepareResult, bool, error) {
+	preparer, ok := r.workspace.(workspace.MergePreparer)
+	if !ok {
+		return RunResult{}, workspace.MergePrepareResult{}, false, nil
+	}
+	precheck, err := preparer.PrepareMerge(ctx, info, issue, workspace.MergePrepareOptions{})
+	if err != nil {
+		return RunResult{}, precheck, false, fmt.Errorf("merge fast-path precheck: %w", err)
+	}
+	switch precheck.Status {
+	case workspace.MergePrepareStatusClean:
+		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_clean",
+			"workspace_path", info.Path,
+			"workspace_branch", info.Branch,
+		)
+		return RunResult{
+			FinalState: FinalStateCompleted,
+			Output:     RunOutputMergeFastPathClean,
+			DiffStats:  diffStatsFromWorkspace(precheck.DiffStat),
+		}, precheck, true, nil
+	case workspace.MergePrepareStatusConflict, workspace.MergePrepareStatusDirty:
+		r.logWorkerEvent(req.Issue, "worker_merge_fast_path_fallback",
+			"workspace_path", info.Path,
+			"workspace_branch", info.Branch,
+			"status", string(precheck.Status),
+		)
+		return RunResult{}, precheck, false, nil
+	default:
+		return RunResult{}, precheck, false, fmt.Errorf("merge fast-path precheck returned unknown status %q", precheck.Status)
+	}
 }
 
 func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
@@ -323,19 +362,41 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		}
 	}()
 
+	mode := normalizeRunMode(req.Mode)
+	mergePrecheck := workspace.MergePrepareResult{}
+	mergeFallback := false
+	if mode == RunModeMerge {
+		precheckResult, precheck, handled, err := r.prepareMergeFastPath(ctx, req, info, workspaceIssue)
+		if err != nil {
+			return RunResult{}, err
+		}
+		mergePrecheck = precheck
+		if handled {
+			r.afterRun(info, workspaceIssue)
+			afterRunPending = false
+			r.logWorkerEvent(req.Issue, "worker_after_run_finished",
+				"workspace_path", info.Path,
+			)
+			return precheckResult, nil
+		}
+		mergeFallback = true
+	}
+
+	attempt := req.Attempt
 	availableSkills, err := r.availableSkills(workflow, info.Path)
 	if err != nil {
 		return RunResult{}, err
 	}
-
-	attempt := req.Attempt
 	prompt, err := BuildPrompt(workflow, req.Issue, PromptOptions{
-		Attempt:         &attempt,
-		PlanOnly:        normalizeRunMode(req.Mode) == RunModePlan,
-		WorkspacePath:   info.Path,
-		Branch:          info.Branch,
-		AvailableSkills: availableSkills,
-		PriorAttempt:    req.PriorAttempt,
+		Attempt:              &attempt,
+		PlanOnly:             mode == RunModePlan,
+		MergeFallback:        mergeFallback,
+		MergePrecheckStatus:  string(mergePrecheck.Status),
+		MergePrecheckMessage: mergePrecheck.Message,
+		WorkspacePath:        info.Path,
+		Branch:               info.Branch,
+		AvailableSkills:      availableSkills,
+		PriorAttempt:         req.PriorAttempt,
 	})
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
@@ -363,7 +424,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"route", selection.RouteName,
 		"role", RoleCode,
 		"model", sessionModel,
-		"mode", normalizeRunMode(req.Mode),
+		"mode", mode,
 	)
 	result := RunResult{FinalState: FinalStateCompleted}
 	progress := newAgentRunProgress()

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -37,13 +37,16 @@ var (
 )
 
 type PromptOptions struct {
-	Attempt         *int
-	PlanOnly        bool
-	WorkspacePath   string
-	Branch          string
-	AutoBranch      *bool
-	AvailableSkills []skills.Skill
-	PriorAttempt    PriorAttempt
+	Attempt              *int
+	PlanOnly             bool
+	MergeFallback        bool
+	MergePrecheckStatus  string
+	MergePrecheckMessage string
+	WorkspacePath        string
+	Branch               string
+	AutoBranch           *bool
+	AvailableSkills      []skills.Skill
+	PriorAttempt         PriorAttempt
 }
 
 type ValidatorPromptOptions struct {
@@ -57,6 +60,10 @@ type ValidatorPromptOptions struct {
 }
 
 func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOptions) (string, error) {
+	if opts.MergeFallback {
+		return BuildMergeFallbackPrompt(workflow, issue, opts)
+	}
+
 	template := workflow.Prompt
 	if strings.TrimSpace(template) == "" {
 		template = DefaultPromptTemplate
@@ -92,6 +99,52 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 		return rendered, nil
 	}
 	return appendClosingReferenceInstruction(rendered, issue), nil
+}
+
+func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOptions) (string, error) {
+	var b strings.Builder
+	b.WriteString("You are resolving a Detent merge-worker fallback for ")
+	b.WriteString(issue.Identifier)
+	if title := strings.TrimSpace(issue.Title); title != "" {
+		b.WriteString(": ")
+		b.WriteString(title)
+	}
+	b.WriteString(".\n\n")
+	if status := strings.TrimSpace(opts.MergePrecheckStatus); status != "" {
+		b.WriteString("Deterministic merge pre-check status: ")
+		b.WriteString(status)
+		b.WriteString("\n")
+	}
+	if message := strings.TrimSpace(opts.MergePrecheckMessage); message != "" {
+		b.WriteString("\nPre-check output:\n")
+		b.WriteString(message)
+		b.WriteString("\n")
+	}
+	if issue.PullRequest != nil && strings.TrimSpace(issue.PullRequest.URL) != "" {
+		b.WriteString("\nPull request: ")
+		b.WriteString(strings.TrimSpace(issue.PullRequest.URL))
+		b.WriteString("\n")
+	}
+	b.WriteString("\nYour task is only to finish the merge-worker handoff:\n")
+	b.WriteString("- Re-run the fetch/rebase onto the target branch if needed.\n")
+	b.WriteString("- Resolve merge conflicts or other rebase blockers without unrelated refactors.\n")
+	b.WriteString("- Run the focused merge gate when the branch is source-clean; run the full configured gate if you edit code, resolve conflicts, or validation state is stale.\n")
+	b.WriteString("- Push the branch with lease protection after a successful rebase; never use an unguarded force-push.\n")
+	b.WriteString("- Leave the issue in Merging with a concrete blocker if the merge cannot continue without human action.\n")
+
+	prompt := prependWorkspaceIsolationBlock(b.String(), workflow.Config, opts.WorkspacePath, opts.Branch)
+	var err error
+	prompt, err = appendNotesBlock(prompt, opts.WorkspacePath)
+	if err != nil {
+		return "", err
+	}
+	prompt = appendBlockedHandoffBlock(prompt)
+	prompt = appendGateBlock(prompt, workflow.Config.Gate)
+	prompt = appendAvailableSkills(prompt, AvailableSkillsBlock(opts.AvailableSkills))
+	if promptDeliverableKind(workflow.Config.Deliverable) != config.DeliverablePullRequest {
+		return prompt, nil
+	}
+	return appendClosingReferenceInstruction(prompt, issue), nil
 }
 
 func BuildValidatorPrompt(workflow config.Workflow, issue connector.Issue, opts ValidatorPromptOptions) string {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -613,6 +613,120 @@ func TestSessionTokenCeilingForUsageUsesTightestConfiguredLimit(t *testing.T) {
 	}
 }
 
+func TestRunnerMergeModeCleanPrecheckSkipsAgent(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	workspaceBackend := &fakeMergeWorkspaceBackend{
+		fakeWorkspaceBackend: fakeWorkspaceBackend{
+			info: workspace.Info{
+				Path:   workspacePath,
+				Key:    "digitaldrywood_detent_860",
+				Branch: "detent/digitaldrywood_detent_860",
+			},
+		},
+		prepareResult: workspace.MergePrepareResult{Status: workspace.MergePrepareStatusClean},
+	}
+	codexClient := &fakeCodexClient{}
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}},
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-860",
+			Identifier: "digitaldrywood/detent#860",
+			BranchName: "detent/digitaldrywood_detent_860",
+		},
+		Mode: RunModeMerge,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.FinalState != FinalStateCompleted {
+		t.Fatalf("FinalState = %q, want completed", result.FinalState)
+	}
+	if !workspaceBackend.prepareCalled {
+		t.Fatal("PrepareMerge() was not called")
+	}
+	if !workspaceBackend.afterRun {
+		t.Fatal("AfterRun() was not called")
+	}
+	if codexClient.request.Prompt != "" {
+		t.Fatalf("agent prompt = %q, want no agent dispatch", codexClient.request.Prompt)
+	}
+}
+
+func TestRunnerMergeModeConflictUsesFocusedPrompt(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	workspaceBackend := &fakeMergeWorkspaceBackend{
+		fakeWorkspaceBackend: fakeWorkspaceBackend{
+			info: workspace.Info{
+				Path:   workspacePath,
+				Key:    "digitaldrywood_detent_860",
+				Branch: "detent/digitaldrywood_detent_860",
+			},
+		},
+		prepareResult: workspace.MergePrepareResult{
+			Status:  workspace.MergePrepareStatusConflict,
+			Message: "CONFLICT (content): Merge conflict in README.md",
+		},
+	}
+	codexClient := &fakeCodexClient{
+		result: AgentTurnResult{ThreadID: "thread-merge", TurnID: "turn-1"},
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{},
+			Prompt: "Full implement workflow playbook for {{ issue.identifier }}",
+		},
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-860",
+			Identifier: "digitaldrywood/detent#860",
+			Title:      "Deterministic merge fast-path",
+			BranchName: "detent/digitaldrywood_detent_860",
+			PullRequest: &connector.PullRequest{
+				URL: "https://github.com/digitaldrywood/detent/pull/900",
+			},
+		},
+		Mode: RunModeMerge,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	prompt := codexClient.request.Prompt
+	for _, want := range []string{
+		"merge-worker fallback",
+		"Deterministic merge pre-check status: conflict",
+		"CONFLICT (content): Merge conflict in README.md",
+		"Re-run the fetch/rebase onto the target branch",
+		"https://github.com/digitaldrywood/detent/pull/900",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "Full implement workflow playbook") {
+		t.Fatalf("prompt included full workflow playbook:\n%s", prompt)
+	}
+}
+
 func TestRunnerRunAddsGitMetadataExtraRootsForManagedWorkspace(t *testing.T) {
 	t.Parallel()
 
@@ -1507,6 +1621,23 @@ func (b *fakeWorkspaceBackend) DiffStat(context.Context, workspace.Info, workspa
 		return b.diffStats[index], nil
 	}
 	return b.diffStat, nil
+}
+
+type fakeMergeWorkspaceBackend struct {
+	fakeWorkspaceBackend
+	prepareResult workspace.MergePrepareResult
+	prepareErr    error
+	prepareCalled bool
+}
+
+func (b *fakeMergeWorkspaceBackend) PrepareMerge(
+	context.Context,
+	workspace.Info,
+	workspace.Issue,
+	workspace.MergePrepareOptions,
+) (workspace.MergePrepareResult, error) {
+	b.prepareCalled = true
+	return b.prepareResult, b.prepareErr
 }
 
 type fakeCodexClient struct {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -21,6 +21,9 @@ const (
 
 	RunModeImplement = "implement"
 	RunModePlan      = "plan"
+	RunModeMerge     = "merge"
+
+	RunOutputMergeFastPathClean = "merge_fast_path_clean"
 )
 
 var ErrSessionTokenCeilingExceeded = errors.New("session token ceiling exceeded")

--- a/internal/workspace/merge.go
+++ b/internal/workspace/merge.go
@@ -1,0 +1,159 @@
+package workspace
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+const (
+	defaultMergeRemote       = "origin"
+	defaultMergeTargetBranch = "main"
+)
+
+func (l *LocalGit) PrepareMerge(
+	ctx context.Context,
+	info Info,
+	issue Issue,
+	opts MergePrepareOptions,
+) (MergePrepareResult, error) {
+	normalized, err := l.normalizeInfo(info, issue)
+	if err != nil {
+		return MergePrepareResult{}, err
+	}
+	remote := strings.TrimSpace(opts.Remote)
+	if remote == "" {
+		remote = defaultMergeRemote
+	}
+	targetBranch := strings.TrimSpace(opts.TargetBranch)
+	if targetBranch == "" {
+		targetBranch = defaultMergeTargetBranch
+	}
+	targetRef := remote + "/" + targetBranch
+
+	if _, err := runGitAt(ctx, normalized.Path, "fetch", remote, targetBranch); err != nil {
+		return MergePrepareResult{}, errors.Join(
+			fmt.Errorf("git fetch %s %s: %w", remote, targetBranch, err),
+			abortRebaseIfInProgress(ctx, normalized.Path),
+		)
+	}
+	if _, err := runGitAt(ctx, normalized.Path, "rebase", targetRef); err != nil {
+		abortErr := abortRebaseIfInProgress(ctx, normalized.Path)
+		if abortErr != nil {
+			return MergePrepareResult{}, errors.Join(
+				fmt.Errorf("git rebase %s: %w", targetRef, err),
+				abortErr,
+			)
+		}
+		return MergePrepareResult{
+			Status:  MergePrepareStatusConflict,
+			Message: commandErrorOutput(err),
+		}, nil
+	}
+
+	diffStat, err := l.DiffStat(ctx, normalized, issue)
+	if err != nil {
+		return MergePrepareResult{}, errors.Join(
+			fmt.Errorf("workspace diff stat after rebase: %w", err),
+			abortRebaseIfInProgress(ctx, normalized.Path),
+		)
+	}
+	if diffStat != (DiffStat{}) {
+		return MergePrepareResult{Status: MergePrepareStatusDirty, DiffStat: diffStat}, nil
+	}
+
+	branch := strings.TrimSpace(normalized.Branch)
+	if branch == "" {
+		return MergePrepareResult{}, errors.New("workspace branch is required for merge fast-path push")
+	}
+	remoteHead, remoteBranchExists, err := remoteBranchHead(ctx, normalized.Path, remote, branch)
+	if err != nil {
+		return MergePrepareResult{}, errors.Join(
+			fmt.Errorf("inspect remote branch %s/%s: %w", remote, branch, err),
+			abortRebaseIfInProgress(ctx, normalized.Path),
+		)
+	}
+	pushArgs := []string{"push"}
+	if remoteBranchExists {
+		pushArgs = append(pushArgs, "--force-with-lease=refs/heads/"+branch+":"+remoteHead)
+	}
+	pushArgs = append(pushArgs, remote, "HEAD:"+branch)
+	if _, err := runGitAt(ctx, normalized.Path, pushArgs...); err != nil {
+		return MergePrepareResult{}, errors.Join(
+			fmt.Errorf("git %s: %w", strings.Join(pushArgs, " "), err),
+			abortRebaseIfInProgress(ctx, normalized.Path),
+		)
+	}
+	return MergePrepareResult{Status: MergePrepareStatusClean, DiffStat: diffStat}, nil
+}
+
+func remoteBranchHead(ctx context.Context, workspacePath string, remote string, branch string) (string, bool, error) {
+	ref := "refs/heads/" + branch
+	output, err := runGitAt(ctx, workspacePath, "ls-remote", remote, ref)
+	if err != nil {
+		return "", false, err
+	}
+	for _, line := range strings.Split(output, "\n") {
+		fields := strings.Fields(line)
+		if len(fields) < 2 || fields[1] != ref {
+			continue
+		}
+		return fields[0], true, nil
+	}
+	return "", false, nil
+}
+
+func abortRebaseIfInProgress(ctx context.Context, workspacePath string) error {
+	inProgress, err := rebaseInProgress(ctx, workspacePath)
+	if err != nil {
+		return err
+	}
+	if !inProgress {
+		return nil
+	}
+	if _, err := runGitAt(ctx, workspacePath, "rebase", "--abort"); err != nil {
+		return fmt.Errorf("git rebase --abort: %w", err)
+	}
+	return nil
+}
+
+func rebaseInProgress(ctx context.Context, workspacePath string) (bool, error) {
+	for _, gitPath := range []string{"rebase-merge", "rebase-apply"} {
+		path, err := gitPathFor(ctx, workspacePath, gitPath)
+		if err != nil {
+			return false, err
+		}
+		if _, err := os.Stat(path); err == nil {
+			return true, nil
+		} else if !errors.Is(err, os.ErrNotExist) {
+			return false, err
+		}
+	}
+	return false, nil
+}
+
+func gitPathFor(ctx context.Context, workspacePath string, gitPath string) (string, error) {
+	output, err := runGitAt(ctx, workspacePath, "rev-parse", "--git-path", gitPath)
+	if err != nil {
+		return "", err
+	}
+	path := strings.TrimSpace(output)
+	if path == "" {
+		return "", errors.New("git path is empty")
+	}
+	if !filepath.IsAbs(path) {
+		path = filepath.Join(workspacePath, path)
+	}
+	return filepath.Clean(path), nil
+}
+
+func commandErrorOutput(err error) string {
+	var commandErr *CommandError
+	if errors.As(err, &commandErr) {
+		return strings.TrimSpace(commandErr.Output)
+	}
+	return strings.TrimSpace(err.Error())
+}

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -47,6 +47,29 @@ type Backend interface {
 	DiffStat(context.Context, Info, Issue) (DiffStat, error)
 }
 
+type MergePreparer interface {
+	PrepareMerge(context.Context, Info, Issue, MergePrepareOptions) (MergePrepareResult, error)
+}
+
+type MergePrepareOptions struct {
+	Remote       string
+	TargetBranch string
+}
+
+type MergePrepareResult struct {
+	Status   MergePrepareStatus
+	DiffStat DiffStat
+	Message  string
+}
+
+type MergePrepareStatus string
+
+const (
+	MergePrepareStatusClean    MergePrepareStatus = "clean"
+	MergePrepareStatusConflict MergePrepareStatus = "conflict"
+	MergePrepareStatusDirty    MergePrepareStatus = "dirty"
+)
+
 type CleanupResult struct {
 	Worktrees int
 	Branches  int

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -231,6 +231,130 @@ func TestLocalGitCreateAndCleanupWithoutHooks(t *testing.T) {
 	}
 }
 
+func TestLocalGitPrepareMergeRebasesAndPushesCleanBranch(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	preparer, ok := backend.(MergePreparer)
+	if !ok {
+		t.Fatal("backend does not implement MergePreparer")
+	}
+	issue := Issue{Identifier: "DD-MERGE"}
+	info, err := backend.Create(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "feature.txt"), []byte("feature\n"), 0o600); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	runGit(t, info.Path, "add", "feature.txt")
+	runGit(t, info.Path, "commit", "-m", "feature")
+	runGit(t, info.Path, "push", "origin", "HEAD:"+info.Branch)
+
+	if err := os.WriteFile(filepath.Join(source, "main.txt"), []byte("main\n"), 0o600); err != nil {
+		t.Fatalf("write main: %v", err)
+	}
+	runGit(t, source, "add", "main.txt")
+	runGit(t, source, "commit", "-m", "main change")
+	runGit(t, source, "push", "origin", "main")
+
+	result, err := preparer.PrepareMerge(context.Background(), info, issue, MergePrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareMerge() error = %v", err)
+	}
+	if result.Status != MergePrepareStatusClean {
+		t.Fatalf("PrepareMerge() status = %q, want clean", result.Status)
+	}
+	if result.DiffStat != (DiffStat{}) {
+		t.Fatalf("PrepareMerge() DiffStat = %#v, want zero", result.DiffStat)
+	}
+	if got := readFile(t, filepath.Join(info.Path, "main.txt")); got != "main\n" {
+		t.Fatalf("main.txt = %q, want rebased main file", got)
+	}
+	head := strings.TrimSpace(runGit(t, info.Path, "rev-parse", "HEAD"))
+	remoteHead := strings.Fields(runGit(t, source, "ls-remote", "origin", "refs/heads/"+info.Branch))
+	if len(remoteHead) == 0 || remoteHead[0] != head {
+		t.Fatalf("remote branch head = %#v, want %s", remoteHead, head)
+	}
+}
+
+func TestLocalGitPrepareMergeAbortsConflictingRebase(t *testing.T) {
+	t.Parallel()
+
+	source := initSourceRepo(t)
+	remote := initBareRemote(t)
+	runGit(t, source, "remote", "add", "origin", remote)
+	runGit(t, source, "push", "-u", "origin", "main")
+
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+	preparer, ok := backend.(MergePreparer)
+	if !ok {
+		t.Fatal("backend does not implement MergePreparer")
+	}
+	issue := Issue{Identifier: "DD-CONFLICT"}
+	info, err := backend.Create(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(info.Path, "README.md"), []byte("feature\n"), 0o600); err != nil {
+		t.Fatalf("write feature README: %v", err)
+	}
+	runGit(t, info.Path, "add", "README.md")
+	runGit(t, info.Path, "commit", "-m", "feature conflict")
+
+	if err := os.WriteFile(filepath.Join(source, "README.md"), []byte("main\n"), 0o600); err != nil {
+		t.Fatalf("write main README: %v", err)
+	}
+	runGit(t, source, "add", "README.md")
+	runGit(t, source, "commit", "-m", "main conflict")
+	runGit(t, source, "push", "origin", "main")
+
+	result, err := preparer.PrepareMerge(context.Background(), info, issue, MergePrepareOptions{})
+	if err != nil {
+		t.Fatalf("PrepareMerge() error = %v", err)
+	}
+	if result.Status != MergePrepareStatusConflict {
+		t.Fatalf("PrepareMerge() status = %q, want conflict", result.Status)
+	}
+	if got := strings.TrimSpace(runGit(t, info.Path, "status", "--short")); got != "" {
+		t.Fatalf("status after aborted rebase = %q, want clean", got)
+	}
+	if got := strings.TrimSpace(runGit(t, info.Path, "branch", "--show-current")); got != info.Branch {
+		t.Fatalf("branch after aborted rebase = %q, want %q", got, info.Branch)
+	}
+	if got := readFile(t, filepath.Join(info.Path, "README.md")); got != "feature\n" {
+		t.Fatalf("README after aborted rebase = %q, want feature branch content", got)
+	}
+	inProgress, err := rebaseInProgress(context.Background(), info.Path)
+	if err != nil {
+		t.Fatalf("rebaseInProgress() error = %v", err)
+	}
+	if inProgress {
+		t.Fatal("rebase still in progress after PrepareMerge conflict")
+	}
+}
+
 func TestGitMetadataWritableRootsForLinkedWorktree(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)
@@ -1061,6 +1185,14 @@ func initSourceRepo(t *testing.T) string {
 	runGit(t, dir, "add", "README.md")
 	runGit(t, dir, "commit", "-m", "initial")
 
+	return dir
+}
+
+func initBareRemote(t *testing.T) string {
+	t.Helper()
+
+	dir := filepath.Join(t.TempDir(), "origin.git")
+	runCommand(t, t.TempDir(), "git", "init", "--bare", "-b", "main", dir)
 	return dir
 }
 


### PR DESCRIPTION
## Summary
- Add a flag-gated merge run mode that performs a deterministic clean-rebase fast path before agent dispatch.
- Add LocalGit merge preparation with fetch, rebase, source-delta check, non-force push, and rebase abort handling.
- Add focused merge fallback prompting for conflict/dirty pre-checks instead of the full implement playbook.

Fixes #860

## Test Plan
- go test ./internal/config ./internal/workspace ./internal/runner ./internal/orchestrator
- make check