### PR TITLE
feat(runner): route per-stage roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -1962,10 +1962,13 @@ omitted, routes can reference the legacy `codex` backend built from the top-leve
 non-default selector match wins, then the single `default` route is used. A
 route can set a fixed `model`, read a model from a ProjectV2 field with
 `model_field`, or fall back to an issue model override when neither is set.
-Routes without `role` are code-agent routes. Set `role: validator` to give the
-validator-agent review its own backend/model route when
-`gate.validator.enabled` is true; if no validator route matches, Detent falls
-back to the code default route.
+Routes without `role` are code-agent routes. `Runner.Run` dispatches plan mode
+with `role: plan`, Rework-state issues with `role: rework`, Merging-state
+issues with `role: merge`, and all other implementation dispatches with
+`role: code`. Set `role: validator` to give the validator-agent review its own
+backend/model route when `gate.validator.enabled` is true. If a stage-specific
+route does not match, Detent falls back to that role's default route and then to
+the code default route, preserving the zero-config behavior.
 If the validator runs through the Codex backend, prefer setting
 `gate.validator.model: gpt-5.4-mini` as the cheap-tier override before adding a
 separate validator route. Treat rework-rate per validator model as the quality
@@ -1975,6 +1978,18 @@ that rate worsens.
 ```yaml
 agents:
   routes:
+    - name: plan-cheap
+      role: plan
+      backend: codex
+      model: gpt-5.4-mini
+    - name: rework-high-context
+      role: rework
+      backend: codex
+      model: gpt-5-codex-high
+    - name: merge-standard
+      role: merge
+      backend: codex
+      model: gpt-5-codex
     - name: high-context
       backend: codex
       model: gpt-5-codex-high

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -83,6 +83,25 @@ codex:
   turn_sandbox_policy:
     type: workspaceWrite
     networkAccess: true
+# Optional per-stage model routing. Unrouted roles fall back to the default code route.
+# agents:
+#   routes:
+#     - name: plan-cheap
+#       role: plan
+#       backend: codex
+#       model: gpt-5.4-mini
+#     - name: rework-high-context
+#       role: rework
+#       backend: codex
+#       model: gpt-5-codex-high
+#     - name: merge-standard
+#       role: merge
+#       backend: codex
+#       model: gpt-5-codex
+#     - name: default
+#       backend: codex
+#       model: gpt-5-codex
+#       default: true
 gate:
   kind: command
   run: make check

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -83,6 +83,25 @@ codex:
   turn_sandbox_policy:
     type: workspaceWrite
     networkAccess: true
+# Optional per-stage model routing. Unrouted roles fall back to the default code route.
+# agents:
+#   routes:
+#     - name: plan-cheap
+#       role: plan
+#       backend: codex
+#       model: gpt-5.4-mini
+#     - name: rework-high-context
+#       role: rework
+#       backend: codex
+#       model: gpt-5-codex-high
+#     - name: merge-standard
+#       role: merge
+#       backend: codex
+#       model: gpt-5-codex
+#     - name: default
+#       backend: codex
+#       model: gpt-5-codex
+#       default: true
 gate:
   kind: command
   run: make check

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -83,6 +83,25 @@ codex:
   turn_sandbox_policy:
     type: workspaceWrite
     networkAccess: true
+# Optional per-stage model routing. Unrouted roles fall back to the default code route.
+# agents:
+#   routes:
+#     - name: plan-cheap
+#       role: plan
+#       backend: codex
+#       model: gpt-5.4-mini
+#     - name: rework-high-context
+#       role: rework
+#       backend: codex
+#       model: gpt-5-codex-high
+#     - name: merge-standard
+#       role: merge
+#       backend: codex
+#       model: gpt-5-codex
+#     - name: default
+#       backend: codex
+#       model: gpt-5-codex
+#       default: true
 gate:
   kind: command
   run: make check

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -82,6 +82,25 @@ codex:
   turn_sandbox_policy:
     type: workspaceWrite
     networkAccess: true
+# Optional per-stage model routing. Unrouted roles fall back to the default code route.
+# agents:
+#   routes:
+#     - name: plan-cheap
+#       role: plan
+#       backend: codex
+#       model: gpt-5.4-mini
+#     - name: rework-high-context
+#       role: rework
+#       backend: codex
+#       model: gpt-5-codex-high
+#     - name: merge-standard
+#       role: merge
+#       backend: codex
+#       model: gpt-5-codex
+#     - name: default
+#       backend: codex
+#       model: gpt-5-codex
+#       default: true
 gate:
   kind: command
   run: make check

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -250,6 +250,14 @@ func (r agentRuntime) defaultModelForRole(role string) string {
 	return strings.TrimSpace(r.router.routes[index].Model)
 }
 
+func (r agentRuntime) effectiveRunRole(role string) string {
+	role = normalizeRole(role)
+	if role == RoleCode || r.router.HasRole(role) {
+		return role
+	}
+	return RoleCode
+}
+
 func cloneAgentBackends(in map[string]AgentBackend) map[string]AgentBackend {
 	if len(in) == 0 {
 		return nil
@@ -411,7 +419,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
 	}
-	role := runRole(req.Mode, req.Issue)
+	role := agentRuntime.effectiveRunRole(runRole(req.Mode, req.Issue))
 	selection, backend, backendKind, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), role)
 	if err != nil {
 		return RunResult{}, err

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -219,10 +219,6 @@ func routesFromConfig(routes []config.AgentRoute) []Route {
 	return out
 }
 
-func (r agentRuntime) selectBackend(issue connector.Issue, ctx selector.Context) (RouteSelection, AgentBackend, string, error) {
-	return r.selectBackendForRole(issue, ctx, RoleCode)
-}
-
 func (r agentRuntime) selectBackendForRole(issue connector.Issue, ctx selector.Context, role string) (RouteSelection, AgentBackend, string, error) {
 	selection, err := r.router.RouteForRole(issue, ctx, role)
 	if err != nil {
@@ -280,6 +276,20 @@ func normalizeRunMode(mode string) string {
 		return RunModeMerge
 	default:
 		return RunModeImplement
+	}
+}
+
+func runRole(mode string, issue connector.Issue) string {
+	if normalizeRunMode(mode) == RunModePlan {
+		return RolePlan
+	}
+	switch strings.ToLower(strings.TrimSpace(issue.State)) {
+	case RoleRework:
+		return RoleRework
+	case RoleMerge, "merging":
+		return RoleMerge
+	default:
+		return RoleCode
 	}
 }
 
@@ -401,7 +411,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
 	}
-	selection, backend, backendKind, err := agentRuntime.selectBackend(req.Issue, selectorContext(req.SelectorContext, workflow))
+	role := runRole(req.Mode, req.Issue)
+	selection, backend, backendKind, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), role)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -422,7 +433,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"workspace_path", info.Path,
 		"backend_id", selection.BackendID,
 		"route", selection.RouteName,
-		"role", RoleCode,
+		"role", role,
 		"model", sessionModel,
 		"mode", mode,
 	)
@@ -455,7 +466,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"workspace_path", info.Path,
 		"backend_id", selection.BackendID,
 		"route", selection.RouteName,
-		"role", RoleCode,
+		"role", role,
 		"model", effectiveModel(result.Model, sessionModel),
 		"outcome", workerRunOutcome(turnErr, result.FinalState),
 		"error", errorString(turnErr),

--- a/internal/runner/router.go
+++ b/internal/runner/router.go
@@ -16,6 +16,9 @@ var (
 
 const (
 	RoleCode      = "code"
+	RolePlan      = "plan"
+	RoleRework    = "rework"
+	RoleMerge     = "merge"
 	RoleValidator = "validator"
 )
 

--- a/internal/runner/router.go
+++ b/internal/runner/router.go
@@ -78,6 +78,19 @@ func (r *Router) Route(issue connector.Issue, ctx selector.Context) (RouteSelect
 	return r.RouteForRole(issue, ctx, RoleCode)
 }
 
+func (r *Router) HasRole(role string) bool {
+	if r == nil {
+		return false
+	}
+	role = normalizeRole(role)
+	for _, route := range r.routes {
+		if route.Role == role {
+			return true
+		}
+	}
+	return false
+}
+
 func (r *Router) RouteForRole(issue connector.Issue, ctx selector.Context, role string) (RouteSelection, error) {
 	if r == nil || len(r.routes) == 0 {
 		return RouteSelection{}, ErrMissingAgentRoutes

--- a/internal/runner/router_test.go
+++ b/internal/runner/router_test.go
@@ -188,6 +188,39 @@ func TestRouterRoutesValidatorRoleWithFallbackDefault(t *testing.T) {
 	}
 }
 
+func TestRouterNewStageRolesFallbackToCodeDefault(t *testing.T) {
+	t.Parallel()
+
+	router, err := NewRouter([]Route{{
+		Name:      "default",
+		BackendID: "codex",
+		Model:     "gpt-5-code",
+		Default:   true,
+	}})
+	if err != nil {
+		t.Fatalf("NewRouter() error = %v", err)
+	}
+
+	code, err := router.Route(connector.Issue{}, selector.Context{})
+	if err != nil {
+		t.Fatalf("Route(code) error = %v", err)
+	}
+
+	for _, role := range []string{RolePlan, RoleRework, RoleMerge} {
+		t.Run(role, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := router.RouteForRole(connector.Issue{}, selector.Context{}, role)
+			if err != nil {
+				t.Fatalf("RouteForRole(%s) error = %v", role, err)
+			}
+			if got != code {
+				t.Fatalf("RouteForRole(%s) = %#v, want code route %#v", role, got, code)
+			}
+		})
+	}
+}
+
 func TestRouterRejectsInvalidRoutes(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -905,6 +905,201 @@ func TestRunnerPlanModeCapturesOutputAndConstrainsPrompt(t *testing.T) {
 	}
 }
 
+func TestRunRoleDerivesStageFromModeAndState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		mode  string
+		state string
+		want  string
+	}{
+		{name: "empty mode todo uses code", state: "Todo", want: RoleCode},
+		{name: "implement mode in progress uses code", mode: RunModeImplement, state: "In Progress", want: RoleCode},
+		{name: "plan mode uses plan", mode: RunModePlan, state: "Todo", want: RolePlan},
+		{name: "plan mode overrides rework state", mode: RunModePlan, state: "Rework", want: RolePlan},
+		{name: "rework state uses rework", mode: RunModeImplement, state: "Rework", want: RoleRework},
+		{name: "rework state trims and folds case", mode: RunModeImplement, state: " reWORK ", want: RoleRework},
+		{name: "merging state uses merge", mode: RunModeImplement, state: "Merging", want: RoleMerge},
+		{name: "unknown mode normalizes to implement", mode: "unknown", state: "Merging", want: RoleMerge},
+		{name: "observed review state uses code", mode: RunModeImplement, state: "Human Review", want: RoleCode},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := runRole(tt.mode, connector.Issue{State: tt.state})
+			if got != tt.want {
+				t.Fatalf("runRole(%q, %q) = %q, want %q", tt.mode, tt.state, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRunnerRunRoutesPerStageRoles(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		mode        string
+		state       string
+		wantBackend string
+		wantModel   string
+	}{
+		{name: "code default", state: "Todo", wantBackend: "codex-code", wantModel: "gpt-5-code"},
+		{name: "plan mode", mode: RunModePlan, state: "Todo", wantBackend: "codex-plan", wantModel: "gpt-5-plan"},
+		{name: "rework state", mode: RunModeImplement, state: "Rework", wantBackend: "codex-rework", wantModel: "gpt-5-rework"},
+		{name: "merge state", mode: RunModeImplement, state: "Merging", wantBackend: "codex-merge", wantModel: "gpt-5-merge"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Key: "issue-stage", Branch: "detent/issue-stage"},
+			}
+			clients := map[string]*fakeCodexClient{
+				"codex-code":   {},
+				"codex-plan":   {},
+				"codex-rework": {},
+				"codex-merge":  {},
+			}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{
+						Agents: config.Agents{
+							Backends: []config.AgentBackend{
+								{ID: "codex-code", Kind: "codex", Protocol: "app-server", Command: "codex app-server"},
+								{ID: "codex-plan", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile plan"},
+								{ID: "codex-rework", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile rework"},
+								{ID: "codex-merge", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile merge"},
+							},
+							Routes: []config.AgentRoute{
+								{Name: "plan", Role: RolePlan, Backend: "codex-plan", Model: "gpt-5-plan"},
+								{Name: "rework", Role: RoleRework, Backend: "codex-rework", Model: "gpt-5-rework"},
+								{Name: "merge", Role: RoleMerge, Backend: "codex-merge", Model: "gpt-5-merge"},
+								{Name: "default", Backend: "codex-code", Model: "gpt-5-code", Default: true},
+							},
+						},
+					},
+					Prompt: "work {{ issue.identifier }}",
+				},
+				Workspace: workspaceBackend,
+				AgentBackends: map[string]AgentBackend{
+					"codex-code":   clients["codex-code"],
+					"codex-plan":   clients["codex-plan"],
+					"codex-rework": clients["codex-rework"],
+					"codex-merge":  clients["codex-merge"],
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			_, err = runner.Run(context.Background(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-stage",
+					Identifier: "digitaldrywood/detent#861",
+					Title:      "Per-stage roles",
+					State:      tt.state,
+				},
+				Mode: tt.mode,
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			for backendID, client := range clients {
+				wantCalls := 0
+				if backendID == tt.wantBackend {
+					wantCalls = 1
+				}
+				if client.calls != wantCalls {
+					t.Fatalf("%s calls = %d, want %d", backendID, client.calls, wantCalls)
+				}
+			}
+			if clients[tt.wantBackend].request.Model != tt.wantModel {
+				t.Fatalf("Model = %q, want %q", clients[tt.wantBackend].request.Model, tt.wantModel)
+			}
+		})
+	}
+}
+
+func TestRunnerRunUnroutedStageRolesUseCodeDefaultRoute(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		mode  string
+		state string
+	}{
+		{name: "plan role", mode: RunModePlan, state: "Todo"},
+		{name: "rework role", mode: RunModeImplement, state: "Rework"},
+		{name: "merge role", mode: RunModeImplement, state: "Merging"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Key: "issue-fallback", Branch: "detent/issue-fallback"},
+			}
+			backend := &fakeCodexClient{}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{
+						Agents: config.Agents{
+							Backends: []config.AgentBackend{{
+								ID:       "codex-code",
+								Kind:     "codex",
+								Protocol: "app-server",
+								Command:  "codex app-server",
+							}},
+							Routes: []config.AgentRoute{{
+								Name:    "default",
+								Backend: "codex-code",
+								Model:   "gpt-5-code",
+								Default: true,
+							}},
+						},
+					},
+					Prompt: "work {{ issue.identifier }}",
+				},
+				Workspace: workspaceBackend,
+				AgentBackends: map[string]AgentBackend{
+					"codex-code": backend,
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			_, err = runner.Run(context.Background(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-fallback",
+					Identifier: "digitaldrywood/detent#861",
+					Title:      "Per-stage fallback",
+					State:      tt.state,
+				},
+				Mode: tt.mode,
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			if backend.calls != 1 {
+				t.Fatalf("RunTurn calls = %d, want 1", backend.calls)
+			}
+			if backend.request.Model != "gpt-5-code" {
+				t.Fatalf("Model = %q, want code default model", backend.request.Model)
+			}
+		})
+	}
+}
+
 func TestRunnerUsageCostWarnsForUnknownModel(t *testing.T) {
 	t.Parallel()
 
@@ -1645,9 +1840,11 @@ type fakeCodexClient struct {
 	updates []AgentUpdate
 	result  AgentTurnResult
 	err     error
+	calls   int
 }
 
 func (c *fakeCodexClient) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	c.calls++
 	c.request = req
 	for _, update := range c.updates {
 		if err := onUpdate(update); err != nil {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1100,6 +1100,161 @@ func TestRunnerRunUnroutedStageRolesUseCodeDefaultRoute(t *testing.T) {
 	}
 }
 
+func TestRunnerRunUnroutedStageRolesUseCodeSelectorRoutes(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		mode  string
+		state string
+	}{
+		{name: "plan role", mode: RunModePlan, state: "Todo"},
+		{name: "rework role", mode: RunModeImplement, state: "Rework"},
+		{name: "merge role", mode: RunModeImplement, state: "Merging"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Key: "issue-selector", Branch: "detent/issue-selector"},
+			}
+			codeBackend := &fakeCodexClient{}
+			highBackend := &fakeCodexClient{}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{
+						Agents: config.Agents{
+							Backends: []config.AgentBackend{
+								{ID: "codex-code", Kind: "codex", Protocol: "app-server", Command: "codex app-server"},
+								{ID: "codex-high", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile high"},
+							},
+							Routes: []config.AgentRoute{
+								{
+									Name:    "high-label",
+									Backend: "codex-high",
+									Model:   "gpt-5-high",
+									Selector: selector.Selector{
+										Labels: selector.Labels{Include: []string{"tier:high"}},
+									},
+								},
+								{Name: "default", Backend: "codex-code", Model: "gpt-5-code", Default: true},
+							},
+						},
+					},
+					Prompt: "work {{ issue.identifier }}",
+				},
+				Workspace: workspaceBackend,
+				AgentBackends: map[string]AgentBackend{
+					"codex-code": codeBackend,
+					"codex-high": highBackend,
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			_, err = runner.Run(context.Background(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-selector",
+					Identifier: "digitaldrywood/detent#861",
+					Title:      "Per-stage selector fallback",
+					State:      tt.state,
+					Labels:     []string{"tier:high"},
+				},
+				Mode: tt.mode,
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			if highBackend.calls != 1 {
+				t.Fatalf("high backend calls = %d, want 1", highBackend.calls)
+			}
+			if codeBackend.calls != 0 {
+				t.Fatalf("code backend calls = %d, want 0", codeBackend.calls)
+			}
+			if highBackend.request.Model != "gpt-5-high" {
+				t.Fatalf("Model = %q, want code selector model", highBackend.request.Model)
+			}
+		})
+	}
+}
+
+func TestRunnerRunUnroutedStageRolesUseCodeModelFieldRouteWithoutDefault(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		mode  string
+		state string
+	}{
+		{name: "plan role", mode: RunModePlan, state: "Todo"},
+		{name: "rework role", mode: RunModeImplement, state: "Rework"},
+		{name: "merge role", mode: RunModeImplement, state: "Merging"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workspaceBackend := &fakeWorkspaceBackend{
+				info: workspace.Info{Path: t.TempDir(), Key: "issue-field", Branch: "detent/issue-field"},
+			}
+			backend := &fakeCodexClient{}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{
+					Config: config.Config{
+						Agents: config.Agents{
+							Backends: []config.AgentBackend{{
+								ID:       "codex-code",
+								Kind:     "codex",
+								Protocol: "app-server",
+								Command:  "codex app-server",
+							}},
+							Routes: []config.AgentRoute{{
+								Name:       "board-model",
+								Backend:    "codex-code",
+								ModelField: "Model",
+							}},
+						},
+					},
+					Prompt: "work {{ issue.identifier }}",
+				},
+				Workspace: workspaceBackend,
+				AgentBackends: map[string]AgentBackend{
+					"codex-code": backend,
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			_, err = runner.Run(context.Background(), RunRequest{
+				Issue: connector.Issue{
+					ID:         "issue-field",
+					Identifier: "digitaldrywood/detent#861",
+					Title:      "Per-stage model field fallback",
+					State:      tt.state,
+					Fields:     map[string]string{"Model": "gpt-5-field"},
+				},
+				Mode: tt.mode,
+			})
+			if err != nil {
+				t.Fatalf("Run() error = %v", err)
+			}
+
+			if backend.calls != 1 {
+				t.Fatalf("RunTurn calls = %d, want 1", backend.calls)
+			}
+			if backend.request.Model != "gpt-5-field" {
+				t.Fatalf("Model = %q, want code model_field model", backend.request.Model)
+			}
+		})
+	}
+}
+
 func TestRunnerUsageCostWarnsForUnknownModel(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add runner roles for plan, rework, and merge dispatches while preserving code-default fallback.
- Cover stage-role derivation, stage routing, and unrouted fallback with table-driven tests.
- Document per-stage routing examples in README and GitHub WORKFLOW templates.

Fixes #861

## Test Plan

- [x] `go test ./internal/runner`
- [x] `make check`