### PR TITLE
feat(budget): gate dispatch by observed spend

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -149,6 +149,55 @@ WHERE issue_id = sqlc.arg(issue_id)
 GROUP BY COALESCE(model, '')
 ORDER BY COALESCE(model, '');
 
+-- name: RecentModelTokenQuantiles :one
+WITH recent AS (
+  SELECT
+    input_tokens,
+    COALESCE(cached_input_tokens, 0) AS cached_input_tokens,
+    output_tokens,
+    total_tokens
+  FROM codex_sessions
+  WHERE completed_at IS NOT NULL
+    AND lower(trim(COALESCE(model, ''))) = lower(trim(sqlc.arg(model)))
+  ORDER BY completed_at DESC, id DESC
+  LIMIT sqlc.arg(limit)
+),
+counts AS (
+  SELECT
+    CAST(COUNT(*) AS INTEGER) AS sessions
+  FROM recent
+),
+targets AS (
+  SELECT
+    sessions,
+    CAST((sessions + 1) / 2 AS INTEGER) AS p50_rank,
+    CAST(((sessions * 9) + 9) / 10 AS INTEGER) AS p90_rank
+  FROM counts
+),
+ranked AS (
+  SELECT
+    input_tokens,
+    cached_input_tokens,
+    output_tokens,
+    total_tokens,
+    ROW_NUMBER() OVER (ORDER BY input_tokens) AS input_rank,
+    ROW_NUMBER() OVER (ORDER BY cached_input_tokens) AS cached_input_rank,
+    ROW_NUMBER() OVER (ORDER BY output_tokens) AS output_rank,
+    ROW_NUMBER() OVER (ORDER BY total_tokens) AS total_rank
+  FROM recent
+)
+SELECT
+  CAST(targets.sessions AS INTEGER) AS sessions,
+  CAST(COALESCE((SELECT input_tokens FROM ranked WHERE input_rank = targets.p50_rank), 0) AS INTEGER) AS p50_input_tokens,
+  CAST(COALESCE((SELECT input_tokens FROM ranked WHERE input_rank = targets.p90_rank), 0) AS INTEGER) AS p90_input_tokens,
+  CAST(COALESCE((SELECT cached_input_tokens FROM ranked WHERE cached_input_rank = targets.p50_rank), 0) AS INTEGER) AS p50_cached_input_tokens,
+  CAST(COALESCE((SELECT cached_input_tokens FROM ranked WHERE cached_input_rank = targets.p90_rank), 0) AS INTEGER) AS p90_cached_input_tokens,
+  CAST(COALESCE((SELECT output_tokens FROM ranked WHERE output_rank = targets.p50_rank), 0) AS INTEGER) AS p50_output_tokens,
+  CAST(COALESCE((SELECT output_tokens FROM ranked WHERE output_rank = targets.p90_rank), 0) AS INTEGER) AS p90_output_tokens,
+  CAST(COALESCE((SELECT total_tokens FROM ranked WHERE total_rank = targets.p50_rank), 0) AS INTEGER) AS p50_total_tokens,
+  CAST(COALESCE((SELECT total_tokens FROM ranked WHERE total_rank = targets.p90_rank), 0) AS INTEGER) AS p90_total_tokens
+FROM targets;
+
 -- name: CreateUsageEvent :one
 INSERT INTO usage_events (
   project_id,

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -329,10 +329,11 @@ func (c *Checker) refusal(code ReasonCode, req DispatchRequest, now time.Time, c
 
 func (e TokenEstimate) normalized() TokenEstimate {
 	out := TokenEstimate{
-		InputTokens:  nonNegative(e.InputTokens),
-		OutputTokens: nonNegative(e.OutputTokens),
-		TotalTokens:  nonNegative(e.TotalTokens),
-		Sessions:     nonNegative(e.Sessions),
+		InputTokens:       nonNegative(e.InputTokens),
+		CachedInputTokens: nonNegative(e.CachedInputTokens),
+		OutputTokens:      nonNegative(e.OutputTokens),
+		TotalTokens:       nonNegative(e.TotalTokens),
+		Sessions:          nonNegative(e.Sessions),
 	}
 	if out.InputTokens == 0 && out.OutputTokens == 0 && out.TotalTokens == 0 {
 		return defaultTokenEstimate

--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -231,7 +231,7 @@ func (t *RefusalTracker) Record(refusal Refusal) (TrackedRefusal, bool) {
 
 	tracked := TrackedRefusal{
 		Refusal: refusal,
-		DueAt:   refusal.CooldownUntil.UTC(),
+		DueAt:   refusal.dueAt(),
 	}
 	t.entries[key] = tracked
 	return tracked, true
@@ -258,6 +258,7 @@ func (r Refusal) Comment() string {
 	if strings.TrimSpace(model) == "" {
 		model = "unknown"
 	}
+	dueAt := r.dueAt().Format(time.RFC3339)
 
 	switch r.Code {
 	case ReasonPerDayMaxUSD:
@@ -274,7 +275,7 @@ Projected daily spend: %s / %s
 Model: %s
 Daily budget resets at: %s
 This issue will be reconsidered after: %s
-`, currentSpend, projectedCost, projectedSpend, max, model, resetAt, r.CooldownUntil.UTC().Format(time.RFC3339)))
+`, currentSpend, projectedCost, projectedSpend, max, model, resetAt, dueAt))
 	case ReasonPerIssueMaxUSD:
 		return strings.TrimSpace(fmt.Sprintf(`
 Detent refused to dispatch this issue because the projected dispatch would exceed the per-issue budget.
@@ -285,7 +286,7 @@ Projected issue spend: %s / %s
 Model: %s
 The per-issue budget has no automatic reset.
 This issue will be reconsidered after: %s
-`, currentSpend, projectedCost, projectedSpend, max, model, r.CooldownUntil.UTC().Format(time.RFC3339)))
+`, currentSpend, projectedCost, projectedSpend, max, model, dueAt))
 	default:
 		return strings.TrimSpace(fmt.Sprintf(`
 Detent refused to dispatch this issue because the budget check failed.
@@ -295,8 +296,19 @@ Projected dispatch cost: %s
 Projected spend: %s / %s
 Model: %s
 This issue will be reconsidered after: %s
-`, currentSpend, projectedCost, projectedSpend, max, model, r.CooldownUntil.UTC().Format(time.RFC3339)))
+`, currentSpend, projectedCost, projectedSpend, max, model, dueAt))
 	}
+}
+
+func (r Refusal) dueAt() time.Time {
+	dueAt := r.CooldownUntil.UTC()
+	if r.ResetAt != nil {
+		resetAt := r.ResetAt.UTC()
+		if dueAt.IsZero() || resetAt.After(dueAt) {
+			dueAt = resetAt
+		}
+	}
+	return dueAt
 }
 
 func (c *Checker) refusal(code ReasonCode, req DispatchRequest, now time.Time, currentSpend float64, projectedCost float64, maxUSD float64, resetAt *time.Time) *Refusal {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -264,6 +264,34 @@ func TestCheckerUsesDefaultEstimate(t *testing.T) {
 	assertInDelta(t, decision.Refusal.ProjectedCostUSD, 0.19)
 }
 
+func TestRefusalCommentUsesEffectiveDueAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC)
+	resetAt := now.Add(14 * time.Hour)
+	cooldownUntil := now.Add(time.Hour)
+	maxUSD := 1.50
+	refusal := Refusal{
+		Code:              ReasonPerDayMaxUSD,
+		Model:             "gpt-test",
+		CurrentSpendUSD:   1.25,
+		ProjectedCostUSD:  0.50,
+		ProjectedSpendUSD: 1.75,
+		MaxUSD:            &maxUSD,
+		ResetAt:           &resetAt,
+		CooldownUntil:     cooldownUntil,
+	}
+
+	comment := refusal.Comment()
+	wantDueAt := "This issue will be reconsidered after: " + resetAt.Format(time.RFC3339)
+	if !strings.Contains(comment, wantDueAt) {
+		t.Fatalf("Refusal.Comment() = %q, want %q", comment, wantDueAt)
+	}
+	if strings.Contains(comment, "This issue will be reconsidered after: "+cooldownUntil.Format(time.RFC3339)) {
+		t.Fatalf("Refusal.Comment() = %q, want reconsideration after reset rather than cooldown", comment)
+	}
+}
+
 func TestRefusalTrackerRecordsOncePerCooldown(t *testing.T) {
 	t.Parallel()
 
@@ -304,6 +332,32 @@ func TestRefusalTrackerRecordsOncePerCooldown(t *testing.T) {
 	}
 	if third.DueAt != now.Add(2*time.Hour) {
 		t.Fatalf("third DueAt = %s, want %s", third.DueAt, now.Add(2*time.Hour))
+	}
+}
+
+func TestRefusalTrackerUsesResetAtWhenLaterThanCooldown(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 5, 20, 10, 0, 0, 0, time.UTC)
+	resetAt := now.Add(14 * time.Hour)
+	refusal := Refusal{
+		Code:          ReasonPerDayMaxUSD,
+		IssueID:       "issue-daily",
+		RefusedAt:     now,
+		ResetAt:       &resetAt,
+		CooldownUntil: now.Add(time.Hour),
+	}
+	tracker := NewRefusalTracker()
+
+	tracked, shouldComment := tracker.Record(refusal)
+	if !shouldComment {
+		t.Fatal("Record() shouldComment = false, want true")
+	}
+	if tracked.DueAt != resetAt {
+		t.Fatalf("DueAt = %s, want reset %s", tracked.DueAt, resetAt)
+	}
+	if !tracker.CooldownActive("issue-daily", now.Add(2*time.Hour)) {
+		t.Fatal("CooldownActive() after cooldown before reset = false, want true")
 	}
 }
 

--- a/internal/budget/estimate.go
+++ b/internal/budget/estimate.go
@@ -1,0 +1,91 @@
+package budget
+
+import (
+	"context"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+const (
+	DefaultDispatchEstimateMinSessions = 5
+	DefaultDispatchEstimateLimit       = 50
+)
+
+type DispatchEstimateStore interface {
+	RecentModelTokenQuantiles(context.Context, store.ModelTokenQuantileQuery) (store.ModelTokenQuantiles, error)
+}
+
+type DispatchEstimator struct {
+	store       DispatchEstimateStore
+	minSessions int64
+	limit       int64
+}
+
+type DispatchEstimatorOption func(*DispatchEstimator)
+
+func NewDispatchEstimator(store DispatchEstimateStore, opts ...DispatchEstimatorOption) *DispatchEstimator {
+	estimator := &DispatchEstimator{
+		store:       store,
+		minSessions: DefaultDispatchEstimateMinSessions,
+		limit:       DefaultDispatchEstimateLimit,
+	}
+	for _, opt := range opts {
+		opt(estimator)
+	}
+	if estimator.minSessions <= 0 {
+		estimator.minSessions = DefaultDispatchEstimateMinSessions
+	}
+	if estimator.limit <= 0 {
+		estimator.limit = DefaultDispatchEstimateLimit
+	}
+	return estimator
+}
+
+func WithDispatchEstimateMinSessions(minSessions int64) DispatchEstimatorOption {
+	return func(estimator *DispatchEstimator) {
+		estimator.minSessions = minSessions
+	}
+}
+
+func WithDispatchEstimateLimit(limit int64) DispatchEstimatorOption {
+	return func(estimator *DispatchEstimator) {
+		estimator.limit = limit
+	}
+}
+
+func (e *DispatchEstimator) EstimateDispatch(ctx context.Context, model string) (TokenEstimate, error) {
+	if e == nil || missingEstimateStore(e.store) || strings.TrimSpace(model) == "" {
+		return defaultTokenEstimate, nil
+	}
+
+	quantiles, err := e.store.RecentModelTokenQuantiles(ctx, store.ModelTokenQuantileQuery{
+		Model: model,
+		Limit: e.limit,
+	})
+	if err != nil {
+		return TokenEstimate{}, fmt.Errorf("recent model token quantiles: %w", err)
+	}
+	if quantiles.Sessions < e.minSessions {
+		return defaultTokenEstimate, nil
+	}
+
+	return TokenEstimate{
+		InputTokens:       quantiles.P90InputTokens,
+		CachedInputTokens: quantiles.P90CachedInputTokens,
+		OutputTokens:      quantiles.P90OutputTokens,
+		TotalTokens:       quantiles.P90TotalTokens,
+		Sessions:          quantiles.Sessions,
+	}.normalized(), nil
+}
+
+func missingEstimateStore(store DispatchEstimateStore) bool {
+	if store == nil {
+		return true
+	}
+
+	value := reflect.ValueOf(store)
+	return value.Kind() == reflect.Pointer && value.IsNil()
+}

--- a/internal/budget/estimate_test.go
+++ b/internal/budget/estimate_test.go
@@ -1,0 +1,111 @@
+package budget
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestDispatchEstimatorEstimateDispatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		store        *fakeDispatchEstimateStore
+		minSessions  int64
+		wantEstimate TokenEstimate
+		wantErr      string
+	}{
+		{
+			name:         "nil store uses static fallback",
+			wantEstimate: defaultTokenEstimate,
+		},
+		{
+			name: "insufficient sessions uses static fallback",
+			store: &fakeDispatchEstimateStore{
+				quantiles: store.ModelTokenQuantiles{
+					Sessions:       4,
+					P90InputTokens: 900,
+				},
+			},
+			minSessions:  5,
+			wantEstimate: defaultTokenEstimate,
+		},
+		{
+			name: "enough sessions uses p90 observed tokens",
+			store: &fakeDispatchEstimateStore{
+				quantiles: store.ModelTokenQuantiles{
+					Sessions:             5,
+					P50InputTokens:       300,
+					P90InputTokens:       900,
+					P50CachedInputTokens: 100,
+					P90CachedInputTokens: 400,
+					P50OutputTokens:      30,
+					P90OutputTokens:      90,
+					P50TotalTokens:       330,
+					P90TotalTokens:       990,
+				},
+			},
+			minSessions: 5,
+			wantEstimate: TokenEstimate{
+				InputTokens:       900,
+				CachedInputTokens: 400,
+				OutputTokens:      90,
+				TotalTokens:       990,
+				Sessions:          5,
+			},
+		},
+		{
+			name: "store error is wrapped",
+			store: &fakeDispatchEstimateStore{
+				err: errors.New("database unavailable"),
+			},
+			minSessions: 5,
+			wantErr:     "recent model token quantiles",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			estimator := NewDispatchEstimator(
+				tt.store,
+				WithDispatchEstimateMinSessions(tt.minSessions),
+				WithDispatchEstimateLimit(25),
+			)
+			got, err := estimator.EstimateDispatch(context.Background(), "gpt-test")
+			if tt.wantErr != "" {
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("EstimateDispatch() error = %v, want containing %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("EstimateDispatch() error = %v", err)
+			}
+			if got != tt.wantEstimate {
+				t.Fatalf("EstimateDispatch() = %#v, want %#v", got, tt.wantEstimate)
+			}
+			if tt.store != nil {
+				if tt.store.query.Model != "gpt-test" || tt.store.query.Limit != 25 {
+					t.Fatalf("query = %#v, want model gpt-test limit 25", tt.store.query)
+				}
+			}
+		})
+	}
+}
+
+type fakeDispatchEstimateStore struct {
+	query     store.ModelTokenQuantileQuery
+	quantiles store.ModelTokenQuantiles
+	err       error
+}
+
+func (s *fakeDispatchEstimateStore) RecentModelTokenQuantiles(_ context.Context, query store.ModelTokenQuantileQuery) (store.ModelTokenQuantiles, error) {
+	s.query = query
+	return s.quantiles, s.err
+}

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -101,9 +101,8 @@ func buildRunner(
 	if err != nil {
 		return nil, fmt.Errorf("load pricing: %w", err)
 	}
-	budgetChecker, dispatchEstimator, err := buildBudgetDispatchGuards(cfg.Budget, sessionStore, pricing)
-	if err != nil {
-		return nil, err
+	budgetGuardBuilder := func(cfg workflowconfig.Budget) (runnerpkg.BudgetChecker, runnerpkg.DispatchEstimator, error) {
+		return buildBudgetDispatchGuards(cfg, sessionStore, pricing)
 	}
 
 	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
@@ -113,8 +112,7 @@ func buildRunner(
 		AgentBackendFactory: runnerpkg.AgentBackendFactoryFunc(buildAgentBackend),
 		Store:               sessionStore,
 		Pricing:             pricing,
-		BudgetChecker:       budgetChecker,
-		DispatchEstimator:   dispatchEstimator,
+		BudgetGuardBuilder:  budgetGuardBuilder,
 		Logger:              logger,
 	})
 	if err != nil {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -101,6 +101,10 @@ func buildRunner(
 	if err != nil {
 		return nil, fmt.Errorf("load pricing: %w", err)
 	}
+	budgetChecker, dispatchEstimator, err := buildBudgetDispatchGuards(cfg.Budget, sessionStore, pricing)
+	if err != nil {
+		return nil, err
+	}
 
 	run, err := runnerpkg.NewRunner(runnerpkg.Dependencies{
 		ProjectID:           projectID,
@@ -109,12 +113,43 @@ func buildRunner(
 		AgentBackendFactory: runnerpkg.AgentBackendFactoryFunc(buildAgentBackend),
 		Store:               sessionStore,
 		Pricing:             pricing,
+		BudgetChecker:       budgetChecker,
+		DispatchEstimator:   dispatchEstimator,
 		Logger:              logger,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("create runner: %w", err)
 	}
 	return run, nil
+}
+
+func buildBudgetDispatchGuards(
+	cfg workflowconfig.Budget,
+	sessionStore runnerpkg.SessionStore,
+	pricing budget.PricingTable,
+) (runnerpkg.BudgetChecker, runnerpkg.DispatchEstimator, error) {
+	if !cfg.Enabled {
+		return nil, nil, nil
+	}
+
+	spendStore, ok := sessionStore.(budget.SpendStore)
+	if !ok {
+		return nil, nil, budget.ErrMissingSpendStore
+	}
+
+	checker := budget.NewChecker(budget.Config{
+		Enabled:         cfg.Enabled,
+		PerDayMaxUSD:    cfg.PerDayMaxUSD,
+		PerIssueMaxUSD:  cfg.PerIssueMaxUSD,
+		RefusalCooldown: time.Duration(cfg.RefusalCooldownSeconds) * time.Second,
+		PricingPath:     cfg.PricingPath,
+	}, spendStore, pricing)
+
+	estimateStore, ok := sessionStore.(budget.DispatchEstimateStore)
+	if !ok {
+		return checker, nil, nil
+	}
+	return checker, budget.NewDispatchEstimator(estimateStore), nil
 }
 
 func buildWorkspaceBackend(cfg workflowconfig.Config, sourceRootFallback string, logger *slog.Logger) (workspace.Backend, error) {

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -188,6 +189,48 @@ func TestBuildRunnerUsesTopLevelPricingPath(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "load pricing") {
 		t.Fatalf("buildRunner() error = %v, want load pricing error", err)
+	}
+}
+
+func TestBuildBudgetDispatchGuards(t *testing.T) {
+	t.Parallel()
+
+	disabled := workflowconfig.Default().Budget
+	checker, estimator, err := buildBudgetDispatchGuards(disabled, nil, nil)
+	if err != nil {
+		t.Fatalf("buildBudgetDispatchGuards(disabled) error = %v", err)
+	}
+	if checker != nil || estimator != nil {
+		t.Fatalf("disabled guards = %T/%T, want nil guards", checker, estimator)
+	}
+
+	enabled := disabled
+	enabled.Enabled = true
+	_, _, err = buildBudgetDispatchGuards(enabled, &runnerSessionStore{}, nil)
+	if !errors.Is(err, budget.ErrMissingSpendStore) {
+		t.Fatalf("buildBudgetDispatchGuards(missing spend store) error = %v, want ErrMissingSpendStore", err)
+	}
+
+	ctx := context.Background()
+	storeBackend, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    filepath.Join(t.TempDir(), "detent.db"),
+	})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := storeBackend.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	checker, estimator, err = buildBudgetDispatchGuards(enabled, storeBackend, nil)
+	if err != nil {
+		t.Fatalf("buildBudgetDispatchGuards(enabled) error = %v", err)
+	}
+	if checker == nil || estimator == nil {
+		t.Fatalf("enabled guards = %T/%T, want checker and estimator", checker, estimator)
 	}
 }
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -249,6 +249,66 @@ func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
 	}
 }
 
+func TestHandleRunResultRecordsBudgetRefusalAndComment(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 2, 10, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:    1,
+		ActiveStates:           []string{"Todo"},
+		TerminalStates:         []string{"Done"},
+		BudgetRefusalCooldown:  time.Hour,
+		ContinuationRetryDelay: time.Second,
+	})
+	commentConnector := &budgetRefusalCommentConnector{}
+	orch := Orchestrator{
+		cfg:       cfg,
+		connector: commentConnector,
+	}
+	state := newState(cfg)
+	issue := dispatchTestIssue("issue-budget-refused", "Todo")
+	state.Running[issue.ID] = Running{
+		Issue:      issue,
+		StartedAt:  now.Add(-time.Minute),
+		WorkerHost: "local",
+	}
+	maxUSD := 2.5
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: now,
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			BudgetRefusal: &runpkg.BudgetRefusal{
+				Code:             "per_day_max_usd",
+				Message:          "daily budget exceeded",
+				Comment:          "Detent refused to dispatch this issue because the projected dispatch would exceed the daily budget.",
+				CurrentSpendUSD:  2.40,
+				ProjectedCostUSD: 0.20,
+				MaxUSD:           &maxUSD,
+				RefusedAt:        now,
+			},
+		},
+	})
+
+	refusal, ok := state.BudgetRefusals[issue.ID]
+	if !ok {
+		t.Fatal("BudgetRefusals missing issue, want recorded refusal")
+	}
+	if refusal.Issue.ID != issue.ID || refusal.Code != "per_day_max_usd" || refusal.ProjectedCostUSD != 0.20 {
+		t.Fatalf("BudgetRefusal = %#v, want recorded issue and spend", refusal)
+	}
+	if orch.dispatchable(issue, &state, now.Add(time.Minute)) {
+		t.Fatal("dispatchable during budget cooldown = true, want false")
+	}
+	if len(commentConnector.comments) != 1 {
+		t.Fatalf("comments len = %d, want 1", len(commentConnector.comments))
+	}
+	if commentConnector.comments[0].issueID != issue.ID || !strings.Contains(commentConnector.comments[0].body, "projected dispatch would exceed the daily budget") {
+		t.Fatalf("comment = %#v, want budget refusal comment", commentConnector.comments[0])
+	}
+}
+
 func TestDispatchableFiltersUnauthorizedCandidates(t *testing.T) {
 	t.Parallel()
 
@@ -1517,6 +1577,50 @@ func dispatchTestIssueWithUnknownUnavailablePullRequestHydration(id, state strin
 	}
 	return issue
 }
+
+type budgetRefusalComment struct {
+	issueID string
+	body    string
+}
+
+type budgetRefusalCommentConnector struct {
+	comments []budgetRefusalComment
+}
+
+func (c *budgetRefusalCommentConnector) Name() string {
+	return "budget-refusal-comment"
+}
+
+func (c *budgetRefusalCommentConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *budgetRefusalCommentConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *budgetRefusalCommentConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *budgetRefusalCommentConnector) CreateComment(_ context.Context, issueID string, body string) error {
+	c.comments = append(c.comments, budgetRefusalComment{issueID: issueID, body: body})
+	return nil
+}
+
+func (c *budgetRefusalCommentConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c *budgetRefusalCommentConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *budgetRefusalCommentConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}
+
+var _ connector.Connector = (*budgetRefusalCommentConnector)(nil)
 
 type hydratingDispatchConnector struct {
 	issue connector.Issue

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2060,6 +2060,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		refusal := *event.Result.BudgetRefusal
 		refusal.Issue = cloneIssue(running.Issue)
 		state.BudgetRefusals[event.IssueID] = refusal
+		o.commentBudgetRefusal(ctx, event.IssueID, refusal)
 	}
 
 	if state.Draining {
@@ -2067,6 +2068,28 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
+}
+
+func (o *Orchestrator) commentBudgetRefusal(ctx context.Context, issueID string, refusal BudgetRefusal) {
+	if o.connector == nil {
+		return
+	}
+	body := strings.TrimSpace(refusal.Comment)
+	if body == "" {
+		body = strings.TrimSpace(refusal.Message)
+	}
+	if body == "" {
+		return
+	}
+	if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+		o.logger.Warn(
+			"budget refusal comment failed",
+			"issue_id", issueID,
+			"identifier", refusal.Issue.Identifier,
+			"code", refusal.Code,
+			"error", err,
+		)
+	}
 }
 
 func (o *Orchestrator) cleanupDrainedRun(ctx context.Context, state *State, issueID string) {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -45,6 +45,14 @@ type SessionStore interface {
 	RecordUsageEvent(context.Context, store.UsageEvent) (int64, error)
 }
 
+type BudgetChecker interface {
+	CheckDispatch(context.Context, budget.DispatchRequest) (budget.Decision, error)
+}
+
+type DispatchEstimator interface {
+	EstimateDispatch(context.Context, string) (budget.TokenEstimate, error)
+}
+
 type workflowPhaseStore interface {
 	RecordWorkflowPhaseEvent(context.Context, store.WorkflowPhaseEvent) (int64, error)
 }
@@ -68,6 +76,8 @@ type Dependencies struct {
 	AgentBackendFactory AgentBackendFactory
 	Store               SessionStore
 	Pricing             budget.PricingTable
+	BudgetChecker       BudgetChecker
+	DispatchEstimator   DispatchEstimator
 	Now                 func() time.Time
 	Logger              *slog.Logger
 	AfterRunTimeout     time.Duration
@@ -82,6 +92,8 @@ type Runner struct {
 	agentBackendFactory AgentBackendFactory
 	store               SessionStore
 	pricing             budget.PricingTable
+	budgetChecker       BudgetChecker
+	dispatchEstimator   DispatchEstimator
 	now                 func() time.Time
 	logger              *slog.Logger
 	afterRunTimeout     time.Duration
@@ -124,6 +136,8 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		agentBackendFactory: deps.AgentBackendFactory,
 		store:               deps.Store,
 		pricing:             deps.Pricing,
+		budgetChecker:       deps.BudgetChecker,
+		dispatchEstimator:   deps.DispatchEstimator,
 		now:                 deps.Now,
 		logger:              deps.Logger,
 		afterRunTimeout:     deps.AfterRunTimeout,
@@ -432,6 +446,19 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	runStartedAt := r.now()
 	selectedModel := selection.Model
 	sessionModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(RoleCode))
+	if result, refused, err := r.checkDispatchBudget(ctx, req.Issue, sessionModel, startedAt); err != nil {
+		return RunResult{}, err
+	} else if refused {
+		r.logWorkerEvent(req.Issue, "worker_budget_refused",
+			"workspace_path", info.Path,
+			"backend_id", selection.BackendID,
+			"route", selection.RouteName,
+			"role", RoleCode,
+			"model", sessionModel,
+			"code", result.BudgetRefusal.Code,
+		)
+		return result, nil
+	}
 	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, sessionModel)
 	if err != nil {
 		return RunResult{}, err
@@ -537,6 +564,63 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		return result, err
 	}
 	return result, nil
+}
+
+func (r *Runner) checkDispatchBudget(ctx context.Context, issue connector.Issue, model string, now time.Time) (RunResult, bool, error) {
+	if r.budgetChecker == nil {
+		return RunResult{}, false, nil
+	}
+
+	estimate := budget.TokenEstimate{}
+	if r.dispatchEstimator != nil {
+		var err error
+		estimate, err = r.dispatchEstimator.EstimateDispatch(ctx, model)
+		if err != nil {
+			return RunResult{}, false, fmt.Errorf("estimate dispatch budget: %w", err)
+		}
+	}
+	decision, err := r.budgetChecker.CheckDispatch(ctx, budget.DispatchRequest{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		IssueURL:   issue.URL,
+		Model:      model,
+		Now:        now,
+		Estimate:   estimate,
+	})
+	if err != nil {
+		return RunResult{}, false, fmt.Errorf("check dispatch budget: %w", err)
+	}
+	if decision.Allowed || decision.Refusal == nil {
+		return RunResult{}, false, nil
+	}
+	return RunResult{
+		FinalState:    FinalStateCompleted,
+		BudgetRefusal: budgetRefusalFromDecision(issue, *decision.Refusal),
+	}, true, nil
+}
+
+func budgetRefusalFromDecision(issue connector.Issue, refusal budget.Refusal) *BudgetRefusal {
+	var maxUSD *float64
+	if refusal.MaxUSD != nil {
+		value := *refusal.MaxUSD
+		maxUSD = &value
+	}
+	var resetAt *time.Time
+	if refusal.ResetAt != nil {
+		value := *refusal.ResetAt
+		resetAt = &value
+	}
+	return &BudgetRefusal{
+		Issue:            issue,
+		Code:             string(refusal.Code),
+		Message:          refusal.Message,
+		Comment:          refusal.Comment(),
+		CurrentSpendUSD:  refusal.CurrentSpendUSD,
+		ProjectedCostUSD: refusal.ProjectedCostUSD,
+		MaxUSD:           maxUSD,
+		ResetAt:          resetAt,
+		RefusedAt:        refusal.RefusedAt,
+	}
 }
 
 func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.ValidatorResult, error) {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -53,6 +53,8 @@ type DispatchEstimator interface {
 	EstimateDispatch(context.Context, string) (budget.TokenEstimate, error)
 }
 
+type BudgetGuardBuilder func(config.Budget) (BudgetChecker, DispatchEstimator, error)
+
 type workflowPhaseStore interface {
 	RecordWorkflowPhaseEvent(context.Context, store.WorkflowPhaseEvent) (int64, error)
 }
@@ -78,6 +80,7 @@ type Dependencies struct {
 	Pricing             budget.PricingTable
 	BudgetChecker       BudgetChecker
 	DispatchEstimator   DispatchEstimator
+	BudgetGuardBuilder  BudgetGuardBuilder
 	Now                 func() time.Time
 	Logger              *slog.Logger
 	AfterRunTimeout     time.Duration
@@ -94,6 +97,7 @@ type Runner struct {
 	pricing             budget.PricingTable
 	budgetChecker       BudgetChecker
 	dispatchEstimator   DispatchEstimator
+	budgetGuardBuilder  BudgetGuardBuilder
 	now                 func() time.Time
 	logger              *slog.Logger
 	afterRunTimeout     time.Duration
@@ -128,6 +132,15 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		return nil, err
 	}
 
+	budgetChecker := deps.BudgetChecker
+	dispatchEstimator := deps.DispatchEstimator
+	if deps.BudgetGuardBuilder != nil {
+		budgetChecker, dispatchEstimator, err = deps.BudgetGuardBuilder(deps.Workflow.Config.Budget)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return &Runner{
 		projectID:           projectID,
 		workflow:            deps.Workflow,
@@ -136,8 +149,9 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		agentBackendFactory: deps.AgentBackendFactory,
 		store:               deps.Store,
 		pricing:             deps.Pricing,
-		budgetChecker:       deps.BudgetChecker,
-		dispatchEstimator:   deps.DispatchEstimator,
+		budgetChecker:       budgetChecker,
+		dispatchEstimator:   dispatchEstimator,
+		budgetGuardBuilder:  deps.BudgetGuardBuilder,
 		now:                 deps.Now,
 		logger:              deps.Logger,
 		afterRunTimeout:     deps.AfterRunTimeout,
@@ -148,14 +162,29 @@ func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
 	r.mu.RLock()
 	currentBackends := cloneAgentBackends(r.agentRuntime.backends)
 	factory := r.agentBackendFactory
+	budgetGuardBuilder := r.budgetGuardBuilder
+	currentBudgetChecker := r.budgetChecker
+	currentDispatchEstimator := r.dispatchEstimator
 	r.mu.RUnlock()
 
 	runtime, err := newAgentRuntime(workflow, currentBackends, factory)
+	budgetChecker := currentBudgetChecker
+	dispatchEstimator := currentDispatchEstimator
+	var budgetErr error
+	if budgetGuardBuilder != nil {
+		budgetChecker, dispatchEstimator, budgetErr = budgetGuardBuilder(workflow.Config.Budget)
+	}
 
 	r.mu.Lock()
 	defer r.mu.Unlock()
 
 	r.workflow = workflow
+	if budgetErr != nil {
+		r.logger.Warn("reload budget dispatch guards failed", "error", budgetErr)
+	} else {
+		r.budgetChecker = budgetChecker
+		r.dispatchEstimator = dispatchEstimator
+	}
 	if err != nil {
 		r.logger.Warn("reload agent runtime failed", "error", err)
 		return
@@ -367,7 +396,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	workflow, agentRuntime := r.runtimeSnapshot()
+	workflow, agentRuntime, budgetChecker, dispatchEstimator := r.runtimeSnapshot()
 
 	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
 	r.logWorkerEvent(req.Issue, "worker_workspace_create_started")
@@ -446,7 +475,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	runStartedAt := r.now()
 	selectedModel := selection.Model
 	sessionModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(RoleCode))
-	if result, refused, err := r.checkDispatchBudget(ctx, req.Issue, sessionModel, startedAt); err != nil {
+	if result, refused, err := r.checkDispatchBudget(ctx, budgetChecker, dispatchEstimator, req.Issue, sessionModel, startedAt); err != nil {
 		return RunResult{}, err
 	} else if refused {
 		r.logWorkerEvent(req.Issue, "worker_budget_refused",
@@ -566,20 +595,20 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	return result, nil
 }
 
-func (r *Runner) checkDispatchBudget(ctx context.Context, issue connector.Issue, model string, now time.Time) (RunResult, bool, error) {
-	if r.budgetChecker == nil {
+func (r *Runner) checkDispatchBudget(ctx context.Context, checker BudgetChecker, estimator DispatchEstimator, issue connector.Issue, model string, now time.Time) (RunResult, bool, error) {
+	if checker == nil {
 		return RunResult{}, false, nil
 	}
 
 	estimate := budget.TokenEstimate{}
-	if r.dispatchEstimator != nil {
+	if estimator != nil {
 		var err error
-		estimate, err = r.dispatchEstimator.EstimateDispatch(ctx, model)
+		estimate, err = estimator.EstimateDispatch(ctx, model)
 		if err != nil {
 			return RunResult{}, false, fmt.Errorf("estimate dispatch budget: %w", err)
 		}
 	}
-	decision, err := r.budgetChecker.CheckDispatch(ctx, budget.DispatchRequest{
+	decision, err := checker.CheckDispatch(ctx, budget.DispatchRequest{
 		IssueID:    issue.ID,
 		Identifier: issue.Identifier,
 		IssueURL:   issue.URL,
@@ -627,7 +656,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 	if ctx == nil {
 		ctx = context.Background()
 	}
-	workflow, agentRuntime := r.runtimeSnapshot()
+	workflow, agentRuntime, _, _ := r.runtimeSnapshot()
 
 	workspaceIssue := workspaceIssue(r.projectID, req.Issue)
 	r.logWorkerEvent(req.Issue, "worker_check_workspace_create_started")
@@ -900,11 +929,11 @@ func (r *Runner) ReapWorkspace(ctx context.Context, issue connector.Issue) (Work
 	return WorkspaceReapResult{}, nil
 }
 
-func (r *Runner) runtimeSnapshot() (config.Workflow, agentRuntime) {
+func (r *Runner) runtimeSnapshot() (config.Workflow, agentRuntime, BudgetChecker, DispatchEstimator) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 
-	return r.workflow, r.agentRuntime
+	return r.workflow, r.agentRuntime, r.budgetChecker, r.dispatchEstimator
 }
 
 func (r *Runner) availableSkills(workflow config.Workflow, workspacePath string) ([]skills.Skill, error) {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1540,6 +1540,90 @@ func TestRunnerUpdateWorkflowAppliesToFutureRuns(t *testing.T) {
 	}
 }
 
+func TestRunnerUpdateWorkflowRefreshesBudgetGuards(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 2, 11, 0, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-42", Branch: "detent/issue-42"},
+	}
+	agentBackend := &fakeCodexClient{}
+	maxUSD := 2.0
+	checker := &fakeBudgetChecker{
+		refusal: budget.Refusal{
+			Code:              budget.ReasonPerDayMaxUSD,
+			Message:           "daily budget exceeded",
+			Model:             "gpt-budget",
+			CurrentSpendUSD:   1.90,
+			ProjectedCostUSD:  0.20,
+			ProjectedSpendUSD: 2.10,
+			MaxUSD:            &maxUSD,
+			RefusedAt:         now,
+			CooldownUntil:     now.Add(time.Hour),
+		},
+	}
+	estimator := &fakeDispatchEstimator{
+		estimate: budget.TokenEstimate{
+			InputTokens: 10,
+			TotalTokens: 10,
+			Sessions:    5,
+		},
+	}
+	var guardCalls []bool
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{},
+			Prompt: "initial {{ issue.identifier }}",
+		},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		BudgetGuardBuilder: func(cfg config.Budget) (BudgetChecker, DispatchEstimator, error) {
+			guardCalls = append(guardCalls, cfg.Enabled)
+			if !cfg.Enabled {
+				return nil, nil, nil
+			}
+			return checker, estimator, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	enabled := config.Config{}
+	enabled.Budget.Enabled = true
+	runner.UpdateWorkflow(config.Workflow{
+		Config: enabled,
+		Prompt: "reloaded {{ issue.identifier }}",
+	})
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-42",
+			Identifier:    "digitaldrywood/detent#42",
+			ModelOverride: "gpt-budget",
+		},
+		StartedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if len(guardCalls) != 2 || guardCalls[0] || !guardCalls[1] {
+		t.Fatalf("budget guard builder calls = %v, want [false true]", guardCalls)
+	}
+	if result.BudgetRefusal == nil || result.BudgetRefusal.Code != string(budget.ReasonPerDayMaxUSD) {
+		t.Fatalf("BudgetRefusal = %#v, want daily budget refusal", result.BudgetRefusal)
+	}
+	if checker.calls != 1 || checker.model != "gpt-budget" {
+		t.Fatalf("budget checker calls/model = %d/%q, want 1/gpt-budget", checker.calls, checker.model)
+	}
+	if estimator.model != "gpt-budget" {
+		t.Fatalf("estimator model = %q, want gpt-budget", estimator.model)
+	}
+	if agentBackend.calls != 0 {
+		t.Fatalf("RunTurn calls = %d, want 0 after budget refusal", agentBackend.calls)
+	}
+}
+
 func TestRunnerRunUsesSingleConfiguredBackendDefaultRoute(t *testing.T) {
 	t.Parallel()
 
@@ -2158,6 +2242,22 @@ type fakeDispatchEstimator struct {
 func (e *fakeDispatchEstimator) EstimateDispatch(_ context.Context, model string) (budget.TokenEstimate, error) {
 	e.model = model
 	return e.estimate, e.err
+}
+
+type fakeBudgetChecker struct {
+	refusal budget.Refusal
+	model   string
+	calls   int
+}
+
+func (c *fakeBudgetChecker) CheckDispatch(_ context.Context, req budget.DispatchRequest) (budget.Decision, error) {
+	c.calls++
+	c.model = req.Model
+	if c.refusal.Code == "" {
+		return budget.Decision{Allowed: true}, nil
+	}
+	refusal := c.refusal
+	return budget.Decision{Refusal: &refusal}, nil
 }
 
 type fakeRunnerBudgetSpendStore struct {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -302,6 +302,103 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 }
 
+func TestRunnerRunRefusesDispatchWhenBudgetExceeded(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	startedAt := time.Date(2026, 6, 2, 9, 0, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{
+			Path:   workspacePath,
+			Key:    "digitaldrywood_detent_855",
+			Branch: "detent/digitaldrywood_detent_855",
+		},
+	}
+	agentBackend := &fakeCodexClient{
+		updates: []AgentUpdate{
+			{Type: AgentUpdateMessageDelta, Delta: "should not run"},
+		},
+	}
+	spendStore := &fakeRunnerBudgetSpendStore{
+		daily: store.TokenSpend{
+			ByModel: []store.ModelTokenSpend{
+				{Model: "gpt-budget", InputTokens: 120},
+			},
+		},
+	}
+	checker := budget.NewChecker(budget.Config{
+		Enabled:         true,
+		PerDayMaxUSD:    1.25,
+		RefusalCooldown: time.Hour,
+	}, spendStore, budget.PricingTable{
+		"gpt-budget": {
+			USDPerInputToken:  0.01,
+			USDPerOutputToken: 0.02,
+		},
+	})
+	estimator := &fakeDispatchEstimator{
+		estimate: budget.TokenEstimate{
+			InputTokens:  10,
+			OutputTokens: 0,
+			TotalTokens:  10,
+			Sessions:     5,
+		},
+	}
+	sessionStore := &fakeSessionStore{sessionID: 855}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{},
+			Prompt: "Work on {{ issue.identifier }}",
+		},
+		Workspace:         workspaceBackend,
+		AgentBackend:      agentBackend,
+		Store:             sessionStore,
+		BudgetChecker:     checker,
+		DispatchEstimator: estimator,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-855",
+			Identifier:    "digitaldrywood/detent#855",
+			URL:           "https://github.com/digitaldrywood/detent/issues/855",
+			BranchName:    "detent/digitaldrywood_detent_855",
+			ModelOverride: "gpt-budget",
+		},
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.BudgetRefusal == nil {
+		t.Fatal("BudgetRefusal = nil, want refusal")
+	}
+	if result.BudgetRefusal.Code != string(budget.ReasonPerDayMaxUSD) || result.BudgetRefusal.Message != "daily budget exceeded" {
+		t.Fatalf("BudgetRefusal = %#v, want daily budget refusal", result.BudgetRefusal)
+	}
+	if !strings.Contains(result.BudgetRefusal.Comment, "projected dispatch would exceed the daily budget") {
+		t.Fatalf("BudgetRefusal.Comment = %q, want refusal comment", result.BudgetRefusal.Comment)
+	}
+	if agentBackend.calls != 0 {
+		t.Fatalf("RunTurn calls = %d, want 0", agentBackend.calls)
+	}
+	if sessionStore.startCalls != 0 || sessionStore.finishCalls != 0 || sessionStore.usageCalls != 0 {
+		t.Fatalf("session store calls = start %d finish %d usage %d, want none", sessionStore.startCalls, sessionStore.finishCalls, sessionStore.usageCalls)
+	}
+	if !workspaceBackend.afterRun {
+		t.Fatal("workspace AfterRun = false, want cleanup after refusal")
+	}
+	if spendStore.dailyCalls != 1 {
+		t.Fatalf("DailyTokenSpend calls = %d, want 1", spendStore.dailyCalls)
+	}
+	if estimator.model != "gpt-budget" {
+		t.Fatalf("estimator model = %q, want gpt-budget", estimator.model)
+	}
+}
+
 func TestRunnerRunKillsSessionAtTokenCeilingAndRecordsLesson(t *testing.T) {
 	t.Parallel()
 
@@ -2019,24 +2116,30 @@ func (c *cancelingCodexClient) RunTurn(context.Context, AgentTurnRequest, AgentU
 }
 
 type fakeSessionStore struct {
-	sessionID int64
-	started   store.SessionStart
-	finished  store.SessionFinish
-	usage     store.UsageEvent
-	phase     store.WorkflowPhaseEvent
+	sessionID   int64
+	started     store.SessionStart
+	finished    store.SessionFinish
+	usage       store.UsageEvent
+	phase       store.WorkflowPhaseEvent
+	startCalls  int
+	finishCalls int
+	usageCalls  int
 }
 
 func (s *fakeSessionStore) StartSession(_ context.Context, attrs store.SessionStart) (int64, error) {
+	s.startCalls++
 	s.started = attrs
 	return s.sessionID, nil
 }
 
 func (s *fakeSessionStore) FinishSession(_ context.Context, _ int64, attrs store.SessionFinish) error {
+	s.finishCalls++
 	s.finished = attrs
 	return nil
 }
 
 func (s *fakeSessionStore) RecordUsageEvent(_ context.Context, attrs store.UsageEvent) (int64, error) {
+	s.usageCalls++
 	s.usage = attrs
 	return 1, nil
 }
@@ -2044,6 +2147,34 @@ func (s *fakeSessionStore) RecordUsageEvent(_ context.Context, attrs store.Usage
 func (s *fakeSessionStore) RecordWorkflowPhaseEvent(_ context.Context, attrs store.WorkflowPhaseEvent) (int64, error) {
 	s.phase = attrs
 	return 1, nil
+}
+
+type fakeDispatchEstimator struct {
+	model    string
+	estimate budget.TokenEstimate
+	err      error
+}
+
+func (e *fakeDispatchEstimator) EstimateDispatch(_ context.Context, model string) (budget.TokenEstimate, error) {
+	e.model = model
+	return e.estimate, e.err
+}
+
+type fakeRunnerBudgetSpendStore struct {
+	daily      store.TokenSpend
+	issue      store.TokenSpend
+	dailyCalls int
+	issueCalls int
+}
+
+func (s *fakeRunnerBudgetSpendStore) DailyTokenSpend(context.Context, time.Time) (store.TokenSpend, error) {
+	s.dailyCalls++
+	return s.daily, nil
+}
+
+func (s *fakeRunnerBudgetSpendStore) IssueTokenSpend(context.Context, store.IssueIdentity) (store.TokenSpend, error) {
+	s.issueCalls++
+	return s.issue, nil
 }
 
 type fakeClock struct {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -176,6 +176,7 @@ type BudgetRefusal struct {
 	Issue            connector.Issue
 	Code             string
 	Message          string
+	Comment          string
 	CurrentSpendUSD  float64
 	ProjectedCostUSD float64
 	MaxUSD           *float64

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -1462,6 +1462,90 @@ func (q *Queries) MarkValidatorVerdictCommented(ctx context.Context, arg MarkVal
 	return result.RowsAffected()
 }
 
+const recentModelTokenQuantiles = `-- name: RecentModelTokenQuantiles :one
+WITH recent AS (
+  SELECT
+    input_tokens,
+    COALESCE(cached_input_tokens, 0) AS cached_input_tokens,
+    output_tokens,
+    total_tokens
+  FROM codex_sessions
+  WHERE completed_at IS NOT NULL
+    AND lower(trim(COALESCE(model, ''))) = lower(trim(?1))
+  ORDER BY completed_at DESC, id DESC
+  LIMIT ?2
+),
+counts AS (
+  SELECT
+    CAST(COUNT(*) AS INTEGER) AS sessions
+  FROM recent
+),
+targets AS (
+  SELECT
+    sessions,
+    CAST((sessions + 1) / 2 AS INTEGER) AS p50_rank,
+    CAST(((sessions * 9) + 9) / 10 AS INTEGER) AS p90_rank
+  FROM counts
+),
+ranked AS (
+  SELECT
+    input_tokens,
+    cached_input_tokens,
+    output_tokens,
+    total_tokens,
+    ROW_NUMBER() OVER (ORDER BY input_tokens) AS input_rank,
+    ROW_NUMBER() OVER (ORDER BY cached_input_tokens) AS cached_input_rank,
+    ROW_NUMBER() OVER (ORDER BY output_tokens) AS output_rank,
+    ROW_NUMBER() OVER (ORDER BY total_tokens) AS total_rank
+  FROM recent
+)
+SELECT
+  CAST(targets.sessions AS INTEGER) AS sessions,
+  CAST(COALESCE((SELECT input_tokens FROM ranked WHERE input_rank = targets.p50_rank), 0) AS INTEGER) AS p50_input_tokens,
+  CAST(COALESCE((SELECT input_tokens FROM ranked WHERE input_rank = targets.p90_rank), 0) AS INTEGER) AS p90_input_tokens,
+  CAST(COALESCE((SELECT cached_input_tokens FROM ranked WHERE cached_input_rank = targets.p50_rank), 0) AS INTEGER) AS p50_cached_input_tokens,
+  CAST(COALESCE((SELECT cached_input_tokens FROM ranked WHERE cached_input_rank = targets.p90_rank), 0) AS INTEGER) AS p90_cached_input_tokens,
+  CAST(COALESCE((SELECT output_tokens FROM ranked WHERE output_rank = targets.p50_rank), 0) AS INTEGER) AS p50_output_tokens,
+  CAST(COALESCE((SELECT output_tokens FROM ranked WHERE output_rank = targets.p90_rank), 0) AS INTEGER) AS p90_output_tokens,
+  CAST(COALESCE((SELECT total_tokens FROM ranked WHERE total_rank = targets.p50_rank), 0) AS INTEGER) AS p50_total_tokens,
+  CAST(COALESCE((SELECT total_tokens FROM ranked WHERE total_rank = targets.p90_rank), 0) AS INTEGER) AS p90_total_tokens
+FROM targets
+`
+
+type RecentModelTokenQuantilesParams struct {
+	Model string `json:"model"`
+	Limit int64  `json:"limit"`
+}
+
+type RecentModelTokenQuantilesRow struct {
+	Sessions             int64 `json:"sessions"`
+	P50InputTokens       int64 `json:"p50_input_tokens"`
+	P90InputTokens       int64 `json:"p90_input_tokens"`
+	P50CachedInputTokens int64 `json:"p50_cached_input_tokens"`
+	P90CachedInputTokens int64 `json:"p90_cached_input_tokens"`
+	P50OutputTokens      int64 `json:"p50_output_tokens"`
+	P90OutputTokens      int64 `json:"p90_output_tokens"`
+	P50TotalTokens       int64 `json:"p50_total_tokens"`
+	P90TotalTokens       int64 `json:"p90_total_tokens"`
+}
+
+func (q *Queries) RecentModelTokenQuantiles(ctx context.Context, arg RecentModelTokenQuantilesParams) (RecentModelTokenQuantilesRow, error) {
+	row := q.db.QueryRowContext(ctx, recentModelTokenQuantiles, arg.Model, arg.Limit)
+	var i RecentModelTokenQuantilesRow
+	err := row.Scan(
+		&i.Sessions,
+		&i.P50InputTokens,
+		&i.P90InputTokens,
+		&i.P50CachedInputTokens,
+		&i.P90CachedInputTokens,
+		&i.P50OutputTokens,
+		&i.P90OutputTokens,
+		&i.P50TotalTokens,
+		&i.P90TotalTokens,
+	)
+	return i, err
+}
+
 const reclaimActiveWorkAttempts = `-- name: ReclaimActiveWorkAttempts :many
 UPDATE work_attempts
 SET status = ?,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -524,6 +524,37 @@ func (s *sqliteStore) IssueTokenSpend(ctx context.Context, identity IssueIdentit
 	return spend, nil
 }
 
+func (s *sqliteStore) RecentModelTokenQuantiles(ctx context.Context, query ModelTokenQuantileQuery) (ModelTokenQuantiles, error) {
+	model := strings.TrimSpace(query.Model)
+	if model == "" {
+		return ModelTokenQuantiles{}, nil
+	}
+	limit := nonNegative(query.Limit)
+	if limit == 0 {
+		limit = 50
+	}
+
+	row, err := s.queries.RecentModelTokenQuantiles(ctx, sqlc.RecentModelTokenQuantilesParams{
+		Model: model,
+		Limit: limit,
+	})
+	if err != nil {
+		return ModelTokenQuantiles{}, fmt.Errorf("reading model token quantiles: %w", err)
+	}
+	return ModelTokenQuantiles{
+		Model:                model,
+		Sessions:             row.Sessions,
+		P50InputTokens:       row.P50InputTokens,
+		P90InputTokens:       row.P90InputTokens,
+		P50CachedInputTokens: row.P50CachedInputTokens,
+		P90CachedInputTokens: row.P90CachedInputTokens,
+		P50OutputTokens:      row.P50OutputTokens,
+		P90OutputTokens:      row.P90OutputTokens,
+		P50TotalTokens:       row.P50TotalTokens,
+		P90TotalTokens:       row.P90TotalTokens,
+	}, nil
+}
+
 func (s *sqliteStore) CycleTimeReport(ctx context.Context) (CycleTimeReport, error) {
 	rows, err := s.queries.CompletedIssueCycleRows(ctx)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -47,6 +47,7 @@ type StatsStore interface {
 	LifetimeTotals(context.Context) (LifetimeTotals, error)
 	DailyTokenSpend(context.Context, time.Time) (TokenSpend, error)
 	IssueTokenSpend(context.Context, IssueIdentity) (TokenSpend, error)
+	RecentModelTokenQuantiles(context.Context, ModelTokenQuantileQuery) (ModelTokenQuantiles, error)
 }
 
 type FairShareStore interface {
@@ -589,6 +590,24 @@ type TokenSpend struct {
 	TotalTokens           int64
 	Sessions              int64
 	ByModel               []ModelTokenSpend
+}
+
+type ModelTokenQuantileQuery struct {
+	Model string
+	Limit int64
+}
+
+type ModelTokenQuantiles struct {
+	Model                string
+	Sessions             int64
+	P50InputTokens       int64
+	P90InputTokens       int64
+	P50CachedInputTokens int64
+	P90CachedInputTokens int64
+	P50OutputTokens      int64
+	P90OutputTokens      int64
+	P50TotalTokens       int64
+	P90TotalTokens       int64
 }
 
 type LifetimeTotals struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -708,6 +708,66 @@ func TestBudgetCostEvents(t *testing.T) {
 	}
 }
 
+func TestRecentModelTokenQuantilesUsesRecentCompletedSessions(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	base := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+
+	seedQuantileSession(t, ctx, backend, "gpt-5", base, 1_000_000, 100_000, 100_000)
+	for index, inputTokens := range []int64{10, 20, 30, 40, 50} {
+		seedQuantileSession(
+			t,
+			ctx,
+			backend,
+			"gpt-5",
+			base.Add(time.Duration(index+1)*time.Minute),
+			inputTokens,
+			inputTokens/10,
+			inputTokens/5,
+		)
+	}
+	seedQuantileSession(t, ctx, backend, "other-model", base.Add(10*time.Minute), 9_000, 900, 900)
+	if _, err := backend.StartSession(ctx, SessionStart{
+		StartedAt: base.Add(11 * time.Minute),
+		Model:     "gpt-5",
+	}); err != nil {
+		t.Fatalf("StartSession() incomplete error = %v", err)
+	}
+
+	quantiles, err := backend.RecentModelTokenQuantiles(ctx, ModelTokenQuantileQuery{
+		Model: " GPT-5 ",
+		Limit: 5,
+	})
+	if err != nil {
+		t.Fatalf("RecentModelTokenQuantiles() error = %v", err)
+	}
+	if quantiles.Sessions != 5 {
+		t.Fatalf("Sessions = %d, want 5", quantiles.Sessions)
+	}
+	if quantiles.P50InputTokens != 30 || quantiles.P90InputTokens != 50 {
+		t.Fatalf("input quantiles = p50 %d p90 %d, want 30/50", quantiles.P50InputTokens, quantiles.P90InputTokens)
+	}
+	if quantiles.P50CachedInputTokens != 3 || quantiles.P90CachedInputTokens != 5 {
+		t.Fatalf("cached quantiles = p50 %d p90 %d, want 3/5", quantiles.P50CachedInputTokens, quantiles.P90CachedInputTokens)
+	}
+	if quantiles.P50OutputTokens != 6 || quantiles.P90OutputTokens != 10 {
+		t.Fatalf("output quantiles = p50 %d p90 %d, want 6/10", quantiles.P50OutputTokens, quantiles.P90OutputTokens)
+	}
+	if quantiles.P50TotalTokens != 36 || quantiles.P90TotalTokens != 60 {
+		t.Fatalf("total quantiles = p50 %d p90 %d, want 36/60", quantiles.P50TotalTokens, quantiles.P90TotalTokens)
+	}
+
+	empty, err := backend.RecentModelTokenQuantiles(ctx, ModelTokenQuantileQuery{Model: "missing", Limit: 5})
+	if err != nil {
+		t.Fatalf("RecentModelTokenQuantiles(missing) error = %v", err)
+	}
+	if empty.Sessions != 0 || empty.P90InputTokens != 0 {
+		t.Fatalf("missing quantiles = %#v, want zero values", empty)
+	}
+}
+
 func TestCycleTimeReportFromCompletedSessions(t *testing.T) {
 	t.Parallel()
 
@@ -1719,6 +1779,38 @@ func seedCycleSession(t *testing.T, ctx context.Context, backend Store, seed cyc
 		RuntimeSeconds: int64(seed.CompletedAt.Sub(seed.StartedAt) / time.Second),
 		FinalState:     seed.FinalState,
 		Model:          "gpt-5-codex",
+	}); err != nil {
+		t.Fatalf("FinishSession() error = %v", err)
+	}
+}
+
+func seedQuantileSession(
+	t *testing.T,
+	ctx context.Context,
+	backend Store,
+	model string,
+	completedAt time.Time,
+	inputTokens int64,
+	cachedInputTokens int64,
+	outputTokens int64,
+) {
+	t.Helper()
+
+	sessionID, err := backend.StartSession(ctx, SessionStart{
+		StartedAt: completedAt.Add(-time.Minute),
+		Model:     model,
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, sessionID, SessionFinish{
+		CompletedAt:       completedAt,
+		InputTokens:       inputTokens,
+		CachedInputTokens: cachedInputTokens,
+		OutputTokens:      outputTokens,
+		TotalTokens:       inputTokens + outputTokens,
+		FinalState:        "completed",
+		Model:             model,
 	}); err != nil {
 		t.Fatalf("FinishSession() error = %v", err)
 	}


### PR DESCRIPTION
## Summary

- Wire configured budget checks into runner dispatch before backend turns run.
- Add recent per-model p50/p90 session token quantiles and an observed p90 dispatch estimator with static fallback.
- Surface budget refusals through runner/orchestrator state and issue comments.

Fixes #855

## Test Plan

- [x] `go test ./internal/budget ./internal/store ./internal/runner ./internal/cli ./internal/orchestrator`
- [x] `make check`