### PR TITLE
feat(doctor): add workflow optimization findings

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -80,13 +80,15 @@ type doctorCheck struct {
 	BlockedRecoveryCandidates []doctorBlockedRecoveryCandidateDiagnostic `json:"blocked_recovery_candidates,omitempty"`
 	UntrackedIssues           []doctorStatusDriftIssueDiagnostic         `json:"untracked_issues,omitempty"`
 	OpenTerminalIssues        []doctorStatusDriftIssueDiagnostic         `json:"open_terminal_issues,omitempty"`
+	WorkflowOptimization      doctorWorkflowOptimizationReport           `json:"-"`
 }
 
 type doctorReport struct {
-	Checks  []doctorCheck `json:"checks"`
-	Scope   doctorScope   `json:"scope,omitzero"`
-	Summary doctorSummary `json:"summary"`
-	Result  string        `json:"result"`
+	Checks               []doctorCheck                    `json:"checks"`
+	Scope                doctorScope                      `json:"scope,omitzero"`
+	WorkflowOptimization doctorWorkflowOptimizationReport `json:"workflow_optimization"`
+	Summary              doctorSummary                    `json:"summary"`
+	Result               string                           `json:"result"`
 }
 
 type doctorScope struct {
@@ -136,10 +138,11 @@ type doctorSummary struct {
 }
 
 type doctorOutputReport struct {
-	Checks  []doctorCheck `json:"checks"`
-	Scope   doctorScope   `json:"scope,omitzero"`
-	Summary doctorSummary `json:"summary"`
-	Result  string        `json:"result"`
+	Checks               []doctorCheck                    `json:"checks"`
+	Scope                doctorScope                      `json:"scope,omitzero"`
+	WorkflowOptimization doctorWorkflowOptimizationReport `json:"workflow_optimization"`
+	Summary              doctorSummary                    `json:"summary"`
+	Result               string                           `json:"result"`
 }
 
 type doctorCheckJob struct {
@@ -179,10 +182,17 @@ type doctorConfig struct {
 	CheckTimeout     time.Duration
 	Build            buildinfo.Info
 	AllowWriteProbes bool
+	WorkflowDiff     bool
 }
 
 type doctorStore interface {
 	Close() error
+}
+
+type doctorTelemetryStore interface {
+	doctorStore
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
 }
 
 type doctorAutoPromoteConnector interface {
@@ -210,6 +220,7 @@ type doctorDeps struct {
 	ghAuthToken          func(context.Context) (string, error)
 	listen               func(string, string) (net.Listener, error)
 	openSQLite           func(context.Context, string) (doctorStore, error)
+	openSQLiteReadOnly   func(context.Context, string) (doctorTelemetryStore, error)
 	gitWorkTree          func(context.Context, string) error
 	gitRemoteURL         func(context.Context, string) (string, error)
 	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
@@ -223,6 +234,8 @@ func newDoctorCommand(configPath *string, env *string, logLevel *string, host *s
 func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string, host *string, port *int, opts options, deps doctorDeps) *cobra.Command {
 	timeout := doctorCheckTimeout
 	allowWriteProbes := false
+	workflowDiff := false
+	workflowWrite := false
 	projectID := ""
 	cmd := &cobra.Command{
 		Use:          "doctor",
@@ -247,12 +260,23 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 				CheckTimeout:     timeout,
 				Build:            opts.build,
 				AllowWriteProbes: allowWriteProbes,
+				WorkflowDiff:     workflowDiff || workflowWrite,
 				Flags: runtimeFlags{
 					Env:      runtimeStringFlag{Value: derefString(env), Set: flagChanged(cmd, "env")},
 					LogLevel: runtimeStringFlag{Value: derefString(logLevel), Set: flagChanged(cmd, "log-level")},
 					Port:     runtimeIntFlag{Value: derefInt(port, -1), Set: flagChanged(cmd, "port")},
 				},
 			}, opts, deps)
+			if workflowWrite {
+				if err := confirmDoctorWorkflowOptimizationWrite(cmd, report.WorkflowOptimization); err != nil {
+					return err
+				}
+				written, err := writeDoctorWorkflowOptimizationPatches(report.WorkflowOptimization)
+				if err != nil {
+					return err
+				}
+				report.WorkflowOptimization.Written = written
+			}
 			if err := out.Write(func(out io.Writer) error {
 				return writeDoctorReport(out, report)
 			}, newDoctorOutputReport(report)); err != nil {
@@ -266,6 +290,8 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	}
 	cmd.Flags().DurationVar(&timeout, "timeout", doctorCheckTimeout, "per-check timeout")
 	cmd.Flags().BoolVar(&allowWriteProbes, "allow-write-probes", false, "run configured GitHub write probes")
+	cmd.Flags().BoolVar(&workflowDiff, "diff", false, "print proposed WORKFLOW.md frontmatter changes for workflow optimization findings")
+	cmd.Flags().BoolVar(&workflowWrite, "write", false, "apply proposed WORKFLOW.md frontmatter changes after confirmation")
 	cmd.Flags().StringVar(&projectID, "project", "", "limit project checks to the selected project id")
 	cmd.SetContext(withCommandOutputOptions(context.Background(), commandOutputOptions{
 		lookupEnv: opts.lookupEnv,
@@ -374,6 +400,12 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		if projectScopeCheck == nil {
 			jobs = append(jobs, doctorProjectCheckJobs(globalConfig, deps, githubToken, cfg.AllowWriteProbes)...)
 		}
+		jobs = append(jobs, doctorCheckJob{
+			Name: "Workflow optimization",
+			Run: func(jobCtx context.Context) []doctorCheck {
+				return []doctorCheck{checkDoctorWorkflowOptimization(jobCtx, resolution, globalConfig, deps, cfg.WorkflowDiff)}
+			},
+		})
 	}
 	jobs = append(jobs,
 		doctorCheckJob{
@@ -405,7 +437,9 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		},
 	)
 	for _, checks := range runDoctorChecks(ctx, jobs, timeout, progressOut) {
-		report.Checks = append(report.Checks, checks...)
+		for _, check := range checks {
+			report.Add(check)
+		}
 	}
 
 	return report
@@ -496,6 +530,7 @@ func writeDoctorProgressDone(out io.Writer, check doctorCheck) {
 }
 
 func (r *doctorReport) Add(check doctorCheck) {
+	r.WorkflowOptimization.Merge(check.WorkflowOptimization)
 	r.Checks = append(r.Checks, check)
 }
 
@@ -505,7 +540,7 @@ func (r doctorReport) HasFailures() bool {
 			return true
 		}
 	}
-	return false
+	return len(r.WorkflowOptimization.Findings) > 0
 }
 
 func (r doctorReport) counts() map[doctorStatus]int {
@@ -528,7 +563,7 @@ func (r doctorReport) withSummary() doctorReport {
 		Fail: counts[doctorFail],
 	}
 	r.Result = "PASS"
-	if r.Summary.Fail > 0 {
+	if r.Summary.Fail > 0 || len(r.WorkflowOptimization.Findings) > 0 {
 		r.Result = "FAIL"
 	}
 	return r
@@ -602,6 +637,9 @@ func writeDoctorReport(out io.Writer, report doctorReport, format ...OutputForma
 			}
 		}
 	}
+	if err := writeDoctorWorkflowOptimizationPretty(out, report.WorkflowOptimization); err != nil {
+		return err
+	}
 
 	if _, err := fmt.Fprintln(out); err != nil {
 		return err
@@ -617,12 +655,13 @@ func writeDoctorReport(out io.Writer, report doctorReport, format ...OutputForma
 func newDoctorOutputReport(report doctorReport) doctorOutputReport {
 	counts := report.counts()
 	result := "PASS"
-	if counts[doctorFail] > 0 {
+	if counts[doctorFail] > 0 || len(report.WorkflowOptimization.Findings) > 0 {
 		result = "FAIL"
 	}
 	return doctorOutputReport{
-		Checks: report.Checks,
-		Scope:  report.Scope,
+		Checks:               report.Checks,
+		Scope:                report.Scope,
+		WorkflowOptimization: report.WorkflowOptimization,
 		Summary: doctorSummary{
 			OK:   counts[doctorOK],
 			Warn: counts[doctorWarn],
@@ -3606,6 +3645,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.openSQLite == nil {
 		d.openSQLite = defaults.openSQLite
 	}
+	if d.openSQLiteReadOnly == nil {
+		d.openSQLiteReadOnly = defaults.openSQLiteReadOnly
+	}
 	if d.gitWorkTree == nil {
 		d.gitWorkTree = defaults.gitWorkTree
 	}
@@ -3633,6 +3675,7 @@ func defaultDoctorDeps() doctorDeps {
 		ghAuthToken:          defaultGHAuthToken,
 		listen:               net.Listen,
 		openSQLite:           openDoctorSQLite,
+		openSQLiteReadOnly:   openDoctorSQLiteReadOnly,
 		gitWorkTree:          defaultGitWorkTree,
 		gitRemoteURL:         defaultGitRemoteURL,
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -403,7 +403,7 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		jobs = append(jobs, doctorCheckJob{
 			Name: "Workflow optimization",
 			Run: func(jobCtx context.Context) []doctorCheck {
-				return []doctorCheck{checkDoctorWorkflowOptimization(jobCtx, resolution, globalConfig, deps, cfg.WorkflowDiff)}
+				return []doctorCheck{checkDoctorWorkflowOptimization(jobCtx, resolution, globalConfig, deps, githubToken, cfg.WorkflowDiff)}
 			},
 		})
 	}

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -1,0 +1,1300 @@
+package cli
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"gopkg.in/yaml.v3"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+)
+
+const (
+	doctorWorkflowOptimizationCheckName = "Workflow optimization"
+
+	doctorWorkflowRuleRunawaySessionTokens = "runaway_session_tokens"
+	doctorWorkflowRuleReworkLaps           = "rework_laps"
+	doctorWorkflowRuleValidatorModel       = "validator_model"
+	doctorWorkflowRuleEmptyModelTelemetry  = "empty_model_telemetry"
+	doctorWorkflowRuleBudgetEstimateDrift  = "budget_estimate_drift"
+	doctorWorkflowRuleSchedulerSkipRate    = "scheduler_skip_rate"
+
+	doctorWorkflowRunawayMedianMultiplier = 4.0
+	doctorWorkflowReworkLapThreshold      = 1
+	doctorWorkflowRecentSessionLimit      = 50
+	doctorWorkflowEmptyModelMinFraction   = 0.20
+	doctorWorkflowBudgetEstimateTotal     = int64(170_000)
+	doctorWorkflowBudgetDriftRatio        = 1.50
+	doctorWorkflowSchedulerMinDecisions   = int64(5)
+	doctorWorkflowSchedulerHighSkipRate   = 0.50
+	doctorWorkflowValidatorModel          = "gpt-5.4-mini"
+)
+
+var errDoctorTelemetryStoreUnavailable = errors.New("telemetry store unavailable")
+
+type doctorWorkflowOptimizationReport struct {
+	StorePath string                                    `json:"store_path,omitempty"`
+	Projects  []doctorWorkflowOptimizationProjectReport `json:"projects,omitempty"`
+	Findings  []doctorWorkflowOptimizationFinding       `json:"findings,omitempty"`
+	Diff      string                                    `json:"diff,omitempty"`
+	Written   []string                                  `json:"written,omitempty"`
+}
+
+type doctorWorkflowOptimizationProjectReport struct {
+	ProjectID    string                            `json:"project_id"`
+	WorkflowPath string                            `json:"workflow_path,omitempty"`
+	Metrics      doctorWorkflowOptimizationMetrics `json:"metrics"`
+	Error        string                            `json:"error,omitempty"`
+}
+
+type doctorWorkflowOptimizationMetrics struct {
+	SessionCount              int64   `json:"session_count"`
+	UsageEventCount           int64   `json:"usage_event_count"`
+	InputTokens               int64   `json:"input_tokens"`
+	CachedInputTokens         int64   `json:"cached_input_tokens"`
+	OutputTokens              int64   `json:"output_tokens"`
+	TotalTokens               int64   `json:"total_tokens"`
+	InputOutputRatio          float64 `json:"input_output_ratio"`
+	CacheReadFraction         float64 `json:"cache_read_fraction"`
+	MedianSessionTokens       int64   `json:"median_session_tokens"`
+	P90SessionTokens          int64   `json:"p90_session_tokens"`
+	MaxSessionTokens          int64   `json:"max_session_tokens"`
+	MaxSessionsPerIssue       int64   `json:"max_sessions_per_issue"`
+	MaxSessionsIssue          string  `json:"max_sessions_issue,omitempty"`
+	RecentSessionCount        int64   `json:"recent_session_count"`
+	EmptyModelRecentSessions  int64   `json:"empty_model_recent_sessions"`
+	EmptyModelRecentFraction  float64 `json:"empty_model_recent_fraction"`
+	MaxReworkLapsPerIssue     int64   `json:"max_rework_laps_per_issue"`
+	MaxReworkLapsIssue        string  `json:"max_rework_laps_issue,omitempty"`
+	FailureTokens             int64   `json:"failure_tokens"`
+	SchedulerDecisionCount    int64   `json:"scheduler_decision_count"`
+	SchedulerSkippedDecisions int64   `json:"scheduler_skipped_decisions"`
+	SchedulerSkipRate         float64 `json:"scheduler_skip_rate"`
+	LaneEventCount            int64   `json:"lane_event_count"`
+	LaneDwellP90Seconds       int64   `json:"lane_dwell_p90_seconds"`
+	SlowestLane               string  `json:"slowest_lane,omitempty"`
+	SlowestLaneP90Seconds     int64   `json:"slowest_lane_p90_seconds"`
+	BudgetEstimateTokens      int64   `json:"budget_estimate_tokens"`
+	BudgetEstimateDriftRatio  float64 `json:"budget_estimate_drift_ratio"`
+}
+
+type doctorWorkflowOptimizationFinding struct {
+	RuleID               string                            `json:"rule_id"`
+	ProjectID            string                            `json:"project_id,omitempty"`
+	WorkflowPath         string                            `json:"workflow_path,omitempty"`
+	Severity             string                            `json:"severity"`
+	Title                string                            `json:"title"`
+	Detail               string                            `json:"detail"`
+	EstimatedTokenImpact int64                             `json:"estimated_token_impact"`
+	Evidence             map[string]any                    `json:"evidence"`
+	Patch                []doctorWorkflowOptimizationPatch `json:"patch,omitempty"`
+}
+
+type doctorWorkflowOptimizationPatch struct {
+	Path  string `json:"path"`
+	Value any    `json:"value"`
+}
+
+type doctorWorkflowSessionMetrics struct {
+	count                    int64
+	inputTokens              int64
+	cachedInputTokens        int64
+	outputTokens             int64
+	totalTokens              int64
+	totalTokensBySession     []int64
+	issueSessionCounts       map[string]int64
+	recentSessionCount       int64
+	emptyModelRecentSessions int64
+	failureTokens            int64
+}
+
+type doctorWorkflowUsageMetrics struct {
+	count             int64
+	inputTokens       int64
+	cachedInputTokens int64
+	outputTokens      int64
+	totalTokens       int64
+	failureTokens     int64
+}
+
+type doctorWorkflowLaneMetrics struct {
+	count        int64
+	durations    []int64
+	laneDuration map[string][]int64
+	reworkLaps   map[string]int64
+}
+
+type doctorWorkflowSchedulerMetrics struct {
+	count   int64
+	skipped int64
+}
+
+func (r *doctorWorkflowOptimizationReport) Merge(next doctorWorkflowOptimizationReport) {
+	if next.StorePath != "" {
+		r.StorePath = next.StorePath
+	}
+	r.Projects = append(r.Projects, next.Projects...)
+	r.Findings = append(r.Findings, next.Findings...)
+	if r.Diff == "" {
+		r.Diff = next.Diff
+	} else if strings.TrimSpace(next.Diff) != "" {
+		r.Diff = strings.TrimRight(r.Diff, "\n") + "\n" + strings.TrimLeft(next.Diff, "\n")
+	}
+	r.Written = append(r.Written, next.Written...)
+}
+
+func checkDoctorWorkflowOptimization(
+	ctx context.Context,
+	resolution globalconfig.PathResolution,
+	cfg globalconfig.Config,
+	deps doctorDeps,
+	includeDiff bool,
+) doctorCheck {
+	if strings.TrimSpace(resolution.Path) == "" {
+		return doctorCheck{
+			Name:   doctorWorkflowOptimizationCheckName,
+			Status: doctorOK,
+			Detail: "skipped because global config path is unavailable",
+		}
+	}
+	if len(cfg.Projects) == 0 {
+		return doctorCheck{
+			Name:   doctorWorkflowOptimizationCheckName,
+			Status: doctorOK,
+			Detail: "skipped because no projects are configured",
+		}
+	}
+
+	deps = deps.withDefaults()
+	storePath := filepath.Join(filepath.Dir(resolution.Path), "detent.db")
+	db, err := deps.openSQLiteReadOnly(ctx, storePath)
+	if err != nil {
+		if errors.Is(err, errDoctorTelemetryStoreUnavailable) {
+			return doctorCheck{
+				Name:   doctorWorkflowOptimizationCheckName,
+				Status: doctorOK,
+				Detail: storePath + " has no telemetry yet",
+			}
+		}
+		return doctorCheck{
+			Name:   doctorWorkflowOptimizationCheckName,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("%s could not be read: %v", storePath, err),
+			Hint:   "Run detent after current migrations are applied, then rerun detent doctor.",
+		}
+	}
+	report, err := doctorWorkflowOptimization(ctx, db, storePath, cfg, deps, includeDiff)
+	closeErr := db.Close()
+	if err != nil {
+		return doctorCheck{
+			Name:   doctorWorkflowOptimizationCheckName,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("%s telemetry could not be analyzed: %v", storePath, err),
+			Hint:   "Confirm the runtime database is migrated through cached-token telemetry columns.",
+		}
+	}
+	if closeErr != nil {
+		return doctorCheck{
+			Name:   doctorWorkflowOptimizationCheckName,
+			Status: doctorWarn,
+			Detail: fmt.Sprintf("%s telemetry could not be closed: %v", storePath, closeErr),
+		}
+	}
+
+	check := doctorCheck{
+		Name:                 doctorWorkflowOptimizationCheckName,
+		Status:               doctorOK,
+		Detail:               fmt.Sprintf("0 findings across %d project(s)", len(report.Projects)),
+		WorkflowOptimization: report,
+	}
+	if len(report.Findings) == 0 {
+		return check
+	}
+
+	check.Status = doctorWarn
+	check.Detail = fmt.Sprintf("%d finding(s) across %d project(s); estimated token impact %d", len(report.Findings), len(report.Projects), doctorWorkflowEstimatedImpact(report.Findings))
+	check.Hint = "Review detent doctor --diff, then rerun with --write and confirm to apply frontmatter patches."
+	return check
+}
+
+func doctorWorkflowOptimization(
+	ctx context.Context,
+	db doctorTelemetryStore,
+	storePath string,
+	cfg globalconfig.Config,
+	deps doctorDeps,
+	includeDiff bool,
+) (doctorWorkflowOptimizationReport, error) {
+	report := doctorWorkflowOptimizationReport{StorePath: storePath}
+	for _, project := range cfg.Projects {
+		projectID := doctorProjectID(project)
+		workflowPath, workflowPathErr := doctorWorkflowOptimizationWorkflowPath(project)
+		workflow, err := loadDoctorProjectWorkflow(ctx, project, deps)
+		if err != nil {
+			report.Projects = append(report.Projects, doctorWorkflowOptimizationProjectReport{
+				ProjectID:    projectID,
+				WorkflowPath: workflowPath,
+				Error:        err.Error(),
+			})
+			continue
+		}
+		workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, "")
+		if err := workflow.Config.Validate(); err != nil {
+			report.Projects = append(report.Projects, doctorWorkflowOptimizationProjectReport{
+				ProjectID:    projectID,
+				WorkflowPath: workflowPath,
+				Error:        err.Error(),
+			})
+			continue
+		}
+		if workflowPathErr != nil {
+			workflowPath = ""
+		}
+
+		projectStoreID := doctorWorkflowOptimizationProjectStoreID(projectID, workflow.Config)
+		metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, projectStoreID, workflow.Config)
+		if err != nil {
+			return doctorWorkflowOptimizationReport{}, err
+		}
+		report.Projects = append(report.Projects, doctorWorkflowOptimizationProjectReport{
+			ProjectID:    projectID,
+			WorkflowPath: workflowPath,
+			Metrics:      metrics,
+		})
+		report.Findings = append(report.Findings, doctorWorkflowOptimizationFindings(projectID, workflowPath, workflow.Config, metrics)...)
+	}
+
+	sort.SliceStable(report.Findings, func(i, j int) bool {
+		left := report.Findings[i]
+		right := report.Findings[j]
+		if left.EstimatedTokenImpact != right.EstimatedTokenImpact {
+			return left.EstimatedTokenImpact > right.EstimatedTokenImpact
+		}
+		if left.ProjectID != right.ProjectID {
+			return left.ProjectID < right.ProjectID
+		}
+		return left.RuleID < right.RuleID
+	})
+	if includeDiff {
+		report.Diff = doctorWorkflowOptimizationDiff(report)
+	}
+	return report, nil
+}
+
+func doctorWorkflowOptimizationProjectStoreID(projectID string, cfg workflowconfig.Config) string {
+	if id := strings.TrimSpace(cfg.Tracker.LocalSQLite.ProjectID); id != "" {
+		return id
+	}
+	return strings.TrimSpace(projectID)
+}
+
+func doctorWorkflowOptimizationMetricsForProject(
+	ctx context.Context,
+	db doctorTelemetryStore,
+	projectID string,
+	cfg workflowconfig.Config,
+) (doctorWorkflowOptimizationMetrics, error) {
+	sessions, err := doctorWorkflowSessionTelemetry(ctx, db)
+	if err != nil {
+		return doctorWorkflowOptimizationMetrics{}, err
+	}
+	usage, err := doctorWorkflowUsageTelemetry(ctx, db, projectID)
+	if err != nil {
+		return doctorWorkflowOptimizationMetrics{}, err
+	}
+	lanes, err := doctorWorkflowLaneTelemetry(ctx, db, projectID, cfg.Agent.AutoPromote.ReworkState)
+	if err != nil {
+		return doctorWorkflowOptimizationMetrics{}, err
+	}
+	scheduler, err := doctorWorkflowSchedulerTelemetry(ctx, db, projectID)
+	if err != nil {
+		return doctorWorkflowOptimizationMetrics{}, err
+	}
+
+	metrics := doctorWorkflowOptimizationMetrics{
+		SessionCount:              sessions.count,
+		UsageEventCount:           usage.count,
+		InputTokens:               sessions.inputTokens,
+		CachedInputTokens:         sessions.cachedInputTokens,
+		OutputTokens:              sessions.outputTokens,
+		TotalTokens:               sessions.totalTokens,
+		MedianSessionTokens:       doctorPercentileInt64(sessions.totalTokensBySession, 0.50),
+		P90SessionTokens:          doctorPercentileInt64(sessions.totalTokensBySession, 0.90),
+		MaxSessionTokens:          doctorMaxInt64(sessions.totalTokensBySession),
+		RecentSessionCount:        sessions.recentSessionCount,
+		EmptyModelRecentSessions:  sessions.emptyModelRecentSessions,
+		MaxSessionsPerIssue:       doctorMaxMapValue(sessions.issueSessionCounts),
+		MaxSessionsIssue:          doctorMaxMapKey(sessions.issueSessionCounts),
+		FailureTokens:             sessions.failureTokens,
+		SchedulerDecisionCount:    scheduler.count,
+		SchedulerSkippedDecisions: scheduler.skipped,
+		LaneEventCount:            lanes.count,
+		LaneDwellP90Seconds:       doctorPercentileInt64(lanes.durations, 0.90),
+		MaxReworkLapsPerIssue:     doctorMaxMapValue(lanes.reworkLaps),
+		MaxReworkLapsIssue:        doctorMaxMapKey(lanes.reworkLaps),
+		BudgetEstimateTokens:      doctorWorkflowBudgetEstimateTotal,
+	}
+	if usage.count > 0 {
+		metrics.InputTokens = usage.inputTokens
+		metrics.CachedInputTokens = usage.cachedInputTokens
+		metrics.OutputTokens = usage.outputTokens
+		metrics.TotalTokens = usage.totalTokens
+		metrics.FailureTokens = usage.failureTokens
+	}
+	metrics.InputOutputRatio = doctorRatio(metrics.InputTokens, metrics.OutputTokens)
+	metrics.CacheReadFraction = doctorRatio(metrics.CachedInputTokens, metrics.InputTokens)
+	metrics.EmptyModelRecentFraction = doctorRatio(metrics.EmptyModelRecentSessions, metrics.RecentSessionCount)
+	metrics.SchedulerSkipRate = doctorRatio(metrics.SchedulerSkippedDecisions, metrics.SchedulerDecisionCount)
+	metrics.SlowestLane, metrics.SlowestLaneP90Seconds = doctorSlowestLane(lanes.laneDuration)
+	if metrics.P90SessionTokens > 0 {
+		metrics.BudgetEstimateDriftRatio = doctorRoundedFloat(float64(metrics.P90SessionTokens)/float64(doctorWorkflowBudgetEstimateTotal), 4)
+	}
+	return metrics, nil
+}
+
+func doctorWorkflowSessionTelemetry(ctx context.Context, db doctorTelemetryStore) (doctorWorkflowSessionMetrics, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  COALESCE(total_tokens, 0),
+  COALESCE(input_tokens, 0),
+  COALESCE(cached_input_tokens, 0),
+  COALESCE(output_tokens, 0),
+  COALESCE(model, ''),
+  COALESCE(final_state, ''),
+  COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned')
+FROM codex_sessions
+WHERE completed_at IS NOT NULL
+ORDER BY completed_at DESC, id DESC`)
+	if err != nil {
+		return doctorWorkflowSessionMetrics{}, fmt.Errorf("read codex session telemetry: %w", err)
+	}
+	defer rows.Close()
+
+	metrics := doctorWorkflowSessionMetrics{
+		issueSessionCounts: map[string]int64{},
+	}
+	for rows.Next() {
+		var totalTokens int64
+		var inputTokens int64
+		var cachedInputTokens int64
+		var outputTokens int64
+		var model string
+		var finalState string
+		var issueKey string
+		if err := rows.Scan(&totalTokens, &inputTokens, &cachedInputTokens, &outputTokens, &model, &finalState, &issueKey); err != nil {
+			return doctorWorkflowSessionMetrics{}, err
+		}
+		metrics.count++
+		metrics.inputTokens += inputTokens
+		metrics.cachedInputTokens += cachedInputTokens
+		metrics.outputTokens += outputTokens
+		metrics.totalTokens += totalTokens
+		if totalTokens > 0 {
+			metrics.totalTokensBySession = append(metrics.totalTokensBySession, totalTokens)
+		}
+		metrics.issueSessionCounts[issueKey]++
+		if metrics.recentSessionCount < doctorWorkflowRecentSessionLimit {
+			metrics.recentSessionCount++
+			if strings.TrimSpace(model) == "" {
+				metrics.emptyModelRecentSessions++
+			}
+		}
+		if doctorWorkflowSessionFailed(finalState) {
+			metrics.failureTokens += totalTokens
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return doctorWorkflowSessionMetrics{}, err
+	}
+	return metrics, nil
+}
+
+func doctorWorkflowUsageTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) (doctorWorkflowUsageMetrics, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  COALESCE(input_tokens, 0),
+  COALESCE(cached_input_tokens, 0),
+  COALESCE(output_tokens, 0),
+  COALESCE(total_tokens, 0),
+  COALESCE(outcome, '')
+FROM usage_events
+WHERE (? = '' OR project_id = ?)`, projectID, projectID)
+	if err != nil {
+		return doctorWorkflowUsageMetrics{}, fmt.Errorf("read usage telemetry: %w", err)
+	}
+	defer rows.Close()
+
+	var metrics doctorWorkflowUsageMetrics
+	for rows.Next() {
+		var inputTokens int64
+		var cachedInputTokens int64
+		var outputTokens int64
+		var totalTokens int64
+		var outcome string
+		if err := rows.Scan(&inputTokens, &cachedInputTokens, &outputTokens, &totalTokens, &outcome); err != nil {
+			return doctorWorkflowUsageMetrics{}, err
+		}
+		metrics.count++
+		metrics.inputTokens += inputTokens
+		metrics.cachedInputTokens += cachedInputTokens
+		metrics.outputTokens += outputTokens
+		metrics.totalTokens += totalTokens
+		if doctorWorkflowUsageFailed(outcome) {
+			metrics.failureTokens += totalTokens
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return doctorWorkflowUsageMetrics{}, err
+	}
+	return metrics, nil
+}
+
+func doctorWorkflowLaneTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reworkState string) (doctorWorkflowLaneMetrics, error) {
+	reworkState = strings.ToLower(strings.TrimSpace(reworkState))
+	if reworkState == "" {
+		reworkState = "rework"
+	}
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  COALESCE(phase_name, ''),
+  COALESCE(duration_seconds, 0),
+  COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned')
+FROM workflow_phase_events
+WHERE phase_type = 'lane'
+  AND finished_at IS NOT NULL
+  AND (? = '' OR project_id = ?)`, projectID, projectID)
+	if err != nil {
+		return doctorWorkflowLaneMetrics{}, fmt.Errorf("read workflow lane telemetry: %w", err)
+	}
+	defer rows.Close()
+
+	metrics := doctorWorkflowLaneMetrics{
+		laneDuration: map[string][]int64{},
+		reworkLaps:   map[string]int64{},
+	}
+	for rows.Next() {
+		var phaseName string
+		var durationSeconds int64
+		var issueKey string
+		if err := rows.Scan(&phaseName, &durationSeconds, &issueKey); err != nil {
+			return doctorWorkflowLaneMetrics{}, err
+		}
+		metrics.count++
+		if durationSeconds > 0 {
+			metrics.durations = append(metrics.durations, durationSeconds)
+			metrics.laneDuration[phaseName] = append(metrics.laneDuration[phaseName], durationSeconds)
+		}
+		if strings.ToLower(strings.TrimSpace(phaseName)) == reworkState {
+			metrics.reworkLaps[issueKey]++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return doctorWorkflowLaneMetrics{}, err
+	}
+	return metrics, nil
+}
+
+func doctorWorkflowSchedulerTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) (doctorWorkflowSchedulerMetrics, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT COALESCE(result, ''), COALESCE(selected, 0)
+FROM scheduler_decisions
+WHERE (? = '' OR project_id = ?)`, projectID, projectID)
+	if err != nil {
+		return doctorWorkflowSchedulerMetrics{}, fmt.Errorf("read scheduler decisions: %w", err)
+	}
+	defer rows.Close()
+
+	var metrics doctorWorkflowSchedulerMetrics
+	for rows.Next() {
+		var result string
+		var selected int64
+		if err := rows.Scan(&result, &selected); err != nil {
+			return doctorWorkflowSchedulerMetrics{}, err
+		}
+		metrics.count++
+		if strings.EqualFold(strings.TrimSpace(result), "skipped") || selected == 0 {
+			metrics.skipped++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return doctorWorkflowSchedulerMetrics{}, err
+	}
+	return metrics, nil
+}
+
+func doctorWorkflowOptimizationFindings(
+	projectID string,
+	workflowPath string,
+	cfg workflowconfig.Config,
+	metrics doctorWorkflowOptimizationMetrics,
+) []doctorWorkflowOptimizationFinding {
+	var findings []doctorWorkflowOptimizationFinding
+	if metrics.SessionCount >= 3 && metrics.MedianSessionTokens > 0 {
+		ratio := float64(metrics.MaxSessionTokens) / float64(metrics.MedianSessionTokens)
+		if ratio >= doctorWorkflowRunawayMedianMultiplier {
+			value := doctorRoundUpInt64(int64(float64(metrics.MedianSessionTokens)*doctorWorkflowRunawayMedianMultiplier), 1000)
+			findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleRunawaySessionTokens,
+				"Runaway session tail",
+				fmt.Sprintf("max session tokens are %.1fx the median", ratio),
+				metrics.MaxSessionTokens-metrics.MedianSessionTokens,
+				map[string]any{
+					"session_count":         metrics.SessionCount,
+					"median_session_tokens": metrics.MedianSessionTokens,
+					"p90_session_tokens":    metrics.P90SessionTokens,
+					"max_session_tokens":    metrics.MaxSessionTokens,
+					"max_to_median_ratio":   doctorRoundedFloat(ratio, 2),
+				},
+				doctorWorkflowOptimizationPatch{Path: "agent.max_session_tokens", Value: value},
+			))
+		}
+	}
+	if metrics.MaxReworkLapsPerIssue > doctorWorkflowReworkLapThreshold && (cfg.Agent.AutoPromote.ReworkLimit == 0 || metrics.MaxReworkLapsPerIssue > int64(cfg.Agent.AutoPromote.ReworkLimit)) {
+		value := int(math.Max(1, math.Min(float64(metrics.MaxReworkLapsPerIssue-1), 2)))
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleReworkLaps,
+			"Repeated rework laps",
+			fmt.Sprintf("issue %s entered rework %d times", metrics.MaxReworkLapsIssue, metrics.MaxReworkLapsPerIssue),
+			metrics.MedianSessionTokens*metrics.MaxReworkLapsPerIssue,
+			map[string]any{
+				"max_rework_laps_per_issue": metrics.MaxReworkLapsPerIssue,
+				"max_rework_laps_issue":     metrics.MaxReworkLapsIssue,
+				"configured_rework_limit":   cfg.Agent.AutoPromote.ReworkLimit,
+			},
+			doctorWorkflowOptimizationPatch{Path: "agent.auto_promote.rework_limit", Value: value},
+		))
+	}
+	if cfg.Gate.Validator.Enabled && strings.TrimSpace(cfg.Gate.Validator.Model) == "" {
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleValidatorModel,
+			"Validator model is implicit",
+			"gate.validator.enabled=true without a gate.validator.model override",
+			doctorMaxInt64([]int64{metrics.FailureTokens, metrics.MedianSessionTokens}),
+			map[string]any{
+				"validator_enabled": true,
+				"validator_model":   "",
+				"failure_tokens":    metrics.FailureTokens,
+			},
+			doctorWorkflowOptimizationPatch{Path: "gate.validator.model", Value: doctorWorkflowValidatorModel},
+		))
+	}
+	if metrics.RecentSessionCount > 0 && metrics.EmptyModelRecentSessions > 0 && metrics.EmptyModelRecentFraction >= doctorWorkflowEmptyModelMinFraction {
+		patches := []doctorWorkflowOptimizationPatch{}
+		if !doctorWorkflowHasDefaultRouteModel(cfg) {
+			patches = append(patches, doctorWorkflowOptimizationPatch{Path: "agents.routes.default.model", Value: "gpt-5-codex"})
+		}
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleEmptyModelTelemetry,
+			"Session model telemetry is incomplete",
+			fmt.Sprintf("%d of %d recent sessions have an empty model", metrics.EmptyModelRecentSessions, metrics.RecentSessionCount),
+			int64(float64(metrics.TotalTokens)*metrics.EmptyModelRecentFraction),
+			map[string]any{
+				"recent_session_count":        metrics.RecentSessionCount,
+				"empty_model_recent_sessions": metrics.EmptyModelRecentSessions,
+				"empty_model_recent_fraction": doctorRoundedFloat(metrics.EmptyModelRecentFraction, 2),
+			},
+			patches...,
+		))
+	}
+	if metrics.P90SessionTokens > 0 && metrics.BudgetEstimateDriftRatio >= doctorWorkflowBudgetDriftRatio {
+		value := doctorRoundedFloat(cfg.Budget.PerIssueMaxUSD*metrics.BudgetEstimateDriftRatio, 2)
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleBudgetEstimateDrift,
+			"Budget estimate is below observed p90",
+			fmt.Sprintf("observed p90 session tokens are %.2fx the default dispatch estimate", metrics.BudgetEstimateDriftRatio),
+			metrics.P90SessionTokens-doctorWorkflowBudgetEstimateTotal,
+			map[string]any{
+				"budget_estimate_tokens":      doctorWorkflowBudgetEstimateTotal,
+				"observed_p90_session_tokens": metrics.P90SessionTokens,
+				"drift_ratio":                 metrics.BudgetEstimateDriftRatio,
+				"current_per_issue_max_usd":   cfg.Budget.PerIssueMaxUSD,
+			},
+			doctorWorkflowOptimizationPatch{Path: "budget.per_issue_max_usd", Value: value},
+		))
+	}
+	if metrics.SchedulerDecisionCount >= doctorWorkflowSchedulerMinDecisions && metrics.SchedulerSkipRate >= doctorWorkflowSchedulerHighSkipRate {
+		value := cfg.Polling.IntervalMS * 2
+		if value < workflowconfig.DefaultPollingIntervalMS {
+			value = workflowconfig.DefaultPollingIntervalMS
+		}
+		if value > 600_000 {
+			value = 600_000
+		}
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleSchedulerSkipRate,
+			"Scheduler skip rate is high",
+			fmt.Sprintf("%.0f%% of recent scheduler decisions skipped dispatch", metrics.SchedulerSkipRate*100),
+			metrics.SchedulerSkippedDecisions*metrics.MedianSessionTokens,
+			map[string]any{
+				"scheduler_decision_count":    metrics.SchedulerDecisionCount,
+				"scheduler_skipped_decisions": metrics.SchedulerSkippedDecisions,
+				"scheduler_skip_rate":         doctorRoundedFloat(metrics.SchedulerSkipRate, 2),
+				"current_polling_interval_ms": cfg.Polling.IntervalMS,
+			},
+			doctorWorkflowOptimizationPatch{Path: "polling.interval_ms", Value: value},
+		))
+	}
+	return findings
+}
+
+func doctorWorkflowFinding(
+	projectID string,
+	workflowPath string,
+	ruleID string,
+	title string,
+	detail string,
+	impact int64,
+	evidence map[string]any,
+	patches ...doctorWorkflowOptimizationPatch,
+) doctorWorkflowOptimizationFinding {
+	return doctorWorkflowOptimizationFinding{
+		RuleID:               ruleID,
+		ProjectID:            projectID,
+		WorkflowPath:         workflowPath,
+		Severity:             "warning",
+		Title:                title,
+		Detail:               detail,
+		EstimatedTokenImpact: impact,
+		Evidence:             evidence,
+		Patch:                patches,
+	}
+}
+
+func doctorWorkflowHasDefaultRouteModel(cfg workflowconfig.Config) bool {
+	for _, route := range cfg.AgentRouteConfigs() {
+		role := strings.ToLower(strings.TrimSpace(route.Role))
+		if role != "" && role != "code" {
+			continue
+		}
+		if route.Default && strings.TrimSpace(route.Model) != "" {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorWorkflowOptimizationWorkflowPath(project globalconfig.Project) (string, error) {
+	if strings.TrimSpace(project.WorkflowRef) != "" {
+		return "", errors.New("workflow_ref-backed workflow cannot be patched locally")
+	}
+	return resolveDoctorProjectPath(project, project.Workflow)
+}
+
+func doctorWorkflowEstimatedImpact(findings []doctorWorkflowOptimizationFinding) int64 {
+	var total int64
+	for _, finding := range findings {
+		if finding.EstimatedTokenImpact > 0 {
+			total += finding.EstimatedTokenImpact
+		}
+	}
+	return total
+}
+
+func writeDoctorWorkflowOptimizationPretty(out io.Writer, report doctorWorkflowOptimizationReport) error {
+	if out == nil || len(report.Findings) == 0 && strings.TrimSpace(report.Diff) == "" && len(report.Written) == 0 {
+		return nil
+	}
+	if _, err := fmt.Fprintln(out); err != nil {
+		return err
+	}
+	if _, err := fmt.Fprintln(out, "Workflow Optimization"); err != nil {
+		return err
+	}
+	if strings.TrimSpace(report.StorePath) != "" {
+		if _, err := fmt.Fprintf(out, "Store: %s\n", report.StorePath); err != nil {
+			return err
+		}
+	}
+	for index, finding := range report.Findings {
+		if _, err := fmt.Fprintf(out, "%d. [%s] %s", index+1, finding.RuleID, finding.Title); err != nil {
+			return err
+		}
+		if finding.EstimatedTokenImpact > 0 {
+			if _, err := fmt.Fprintf(out, " (impact: %d tokens)", finding.EstimatedTokenImpact); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+		if finding.ProjectID != "" {
+			if _, err := fmt.Fprintf(out, "   Project: %s\n", finding.ProjectID); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintf(out, "   Detail: %s\n", finding.Detail); err != nil {
+			return err
+		}
+		if evidence := doctorWorkflowEvidenceLine(finding.Evidence); evidence != "" {
+			if _, err := fmt.Fprintf(out, "   Evidence: %s\n", evidence); err != nil {
+				return err
+			}
+		}
+		if patch := doctorWorkflowPatchLine(finding.Patch); patch != "" {
+			if _, err := fmt.Fprintf(out, "   Suggested patch: %s\n", patch); err != nil {
+				return err
+			}
+		}
+	}
+	if diff := strings.TrimSpace(report.Diff); diff != "" {
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out, "Proposed WORKFLOW.md Frontmatter Patch"); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintln(out, diff); err != nil {
+			return err
+		}
+	}
+	if len(report.Written) > 0 {
+		if _, err := fmt.Fprintln(out); err != nil {
+			return err
+		}
+		if _, err := fmt.Fprintf(out, "Updated WORKFLOW.md files: %s\n", strings.Join(report.Written, ", ")); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func doctorWorkflowEvidenceLine(evidence map[string]any) string {
+	if len(evidence) == 0 {
+		return ""
+	}
+	keys := make([]string, 0, len(evidence))
+	for key := range evidence {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys))
+	for _, key := range keys {
+		parts = append(parts, fmt.Sprintf("%s=%v", key, evidence[key]))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func doctorWorkflowPatchLine(patches []doctorWorkflowOptimizationPatch) string {
+	if len(patches) == 0 {
+		return ""
+	}
+	parts := make([]string, 0, len(patches))
+	for _, patch := range patches {
+		parts = append(parts, fmt.Sprintf("%s=%v", patch.Path, patch.Value))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func doctorWorkflowSessionFailed(finalState string) bool {
+	switch strings.ToLower(strings.TrimSpace(finalState)) {
+	case "failed", "failure", "cancelled", "canceled", "token_ceiling_exceeded":
+		return true
+	default:
+		return false
+	}
+}
+
+func doctorWorkflowUsageFailed(outcome string) bool {
+	switch strings.ToLower(strings.TrimSpace(outcome)) {
+	case "failed", "failure", "cancelled", "canceled", "token_ceiling_exceeded", "error":
+		return true
+	default:
+		return false
+	}
+}
+
+func doctorRatio(numerator int64, denominator int64) float64 {
+	if denominator <= 0 {
+		return 0
+	}
+	return doctorRoundedFloat(float64(numerator)/float64(denominator), 4)
+}
+
+func doctorRoundedFloat(value float64, places int) float64 {
+	scale := math.Pow10(places)
+	return math.Round(value*scale) / scale
+}
+
+func doctorPercentileInt64(values []int64, percentile float64) int64 {
+	if len(values) == 0 {
+		return 0
+	}
+	sorted := append([]int64(nil), values...)
+	sort.Slice(sorted, func(i, j int) bool { return sorted[i] < sorted[j] })
+	index := int(math.Ceil(percentile*float64(len(sorted)))) - 1
+	if index < 0 {
+		index = 0
+	}
+	if index >= len(sorted) {
+		index = len(sorted) - 1
+	}
+	return sorted[index]
+}
+
+func doctorMaxInt64(values []int64) int64 {
+	var max int64
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}
+
+func doctorMaxMapValue(values map[string]int64) int64 {
+	var max int64
+	for _, value := range values {
+		if value > max {
+			max = value
+		}
+	}
+	return max
+}
+
+func doctorMaxMapKey(values map[string]int64) string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var out string
+	var max int64
+	for _, key := range keys {
+		if values[key] > max {
+			out = key
+			max = values[key]
+		}
+	}
+	return out
+}
+
+func doctorSlowestLane(values map[string][]int64) (string, int64) {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	var lane string
+	var p90 int64
+	for _, key := range keys {
+		candidate := doctorPercentileInt64(values[key], 0.90)
+		if candidate > p90 {
+			lane = key
+			p90 = candidate
+		}
+	}
+	return lane, p90
+}
+
+func doctorRoundUpInt64(value int64, nearest int64) int64 {
+	if nearest <= 0 || value <= 0 {
+		return value
+	}
+	return ((value + nearest - 1) / nearest) * nearest
+}
+
+func openDoctorSQLiteReadOnly(ctx context.Context, path string) (doctorTelemetryStore, error) {
+	path = strings.TrimSpace(path)
+	if path == "" {
+		return nil, fmt.Errorf("%w: sqlite path is required", errDoctorTelemetryStoreUnavailable)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("%w: %s", errDoctorTelemetryStoreUnavailable, path)
+		}
+		return nil, err
+	}
+	if info.IsDir() {
+		return nil, fmt.Errorf("%w: %s is a directory", errDoctorTelemetryStoreUnavailable, path)
+	}
+
+	db, err := sql.Open("sqlite", doctorSQLiteReadOnlyDSN(path))
+	if err != nil {
+		return nil, fmt.Errorf("open sqlite read-only: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(ctx, "PRAGMA query_only = ON"); err != nil {
+		return nil, doctorSQLitePingError(fmt.Errorf("enable query_only: %w", err), db.Close())
+	}
+	if err := db.PingContext(ctx); err != nil {
+		return nil, doctorSQLitePingError(err, db.Close())
+	}
+	return db, nil
+}
+
+func doctorSQLiteReadOnlyDSN(path string) string {
+	uri := url.URL{Scheme: "file", Path: filepath.Clean(path)}
+	values := uri.Query()
+	values.Set("mode", "ro")
+	values.Set("cache", "shared")
+	uri.RawQuery = values.Encode()
+	return uri.String()
+}
+
+func confirmDoctorWorkflowOptimizationWrite(cmd *cobra.Command, report doctorWorkflowOptimizationReport) error {
+	patches := doctorWorkflowOptimizationPatchesByWorkflow(report)
+	if len(patches) == 0 {
+		return nil
+	}
+	total := 0
+	for _, patchSet := range patches {
+		total += len(patchSet)
+	}
+	if cmd == nil {
+		return errors.New("workflow optimization write confirmation requires a command")
+	}
+	if _, err := fmt.Fprintf(cmd.ErrOrStderr(), "Apply %d workflow optimization patch(es) to %d WORKFLOW.md file(s)? Type yes to continue: ", total, len(patches)); err != nil {
+		return err
+	}
+	answer, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return err
+	}
+	if strings.ToLower(strings.TrimSpace(answer)) != "yes" {
+		return errors.New("workflow optimization write cancelled")
+	}
+	return nil
+}
+
+func writeDoctorWorkflowOptimizationPatches(report doctorWorkflowOptimizationReport) ([]string, error) {
+	patches := doctorWorkflowOptimizationPatchesByWorkflow(report)
+	if len(patches) == 0 {
+		return nil, nil
+	}
+
+	paths := make([]string, 0, len(patches))
+	for path := range patches {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	written := make([]string, 0, len(paths))
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			return nil, fmt.Errorf("read workflow %s: %w", path, err)
+		}
+		updated, err := doctorApplyWorkflowOptimizationPatches(raw, patches[path])
+		if err != nil {
+			return nil, fmt.Errorf("patch workflow %s: %w", path, err)
+		}
+		workflow, err := workflowconfig.ParseWorkflow(updated)
+		if err != nil {
+			return nil, fmt.Errorf("validate patched workflow %s: %w", path, err)
+		}
+		if err := workflow.Config.Validate(); err != nil {
+			return nil, fmt.Errorf("validate patched workflow %s: %w", path, err)
+		}
+		info, err := os.Stat(path)
+		if err != nil {
+			return nil, fmt.Errorf("stat workflow %s: %w", path, err)
+		}
+		if bytes.Equal(raw, updated) {
+			continue
+		}
+		if err := os.WriteFile(path, updated, info.Mode().Perm()); err != nil {
+			return nil, fmt.Errorf("write workflow %s: %w", path, err)
+		}
+		written = append(written, path)
+	}
+	return written, nil
+}
+
+func doctorWorkflowOptimizationPatchesByWorkflow(report doctorWorkflowOptimizationReport) map[string][]doctorWorkflowOptimizationPatch {
+	out := map[string][]doctorWorkflowOptimizationPatch{}
+	seen := map[string]map[string]struct{}{}
+	for _, finding := range report.Findings {
+		workflowPath := strings.TrimSpace(finding.WorkflowPath)
+		if workflowPath == "" {
+			continue
+		}
+		if seen[workflowPath] == nil {
+			seen[workflowPath] = map[string]struct{}{}
+		}
+		for _, patch := range finding.Patch {
+			patch.Path = strings.TrimSpace(patch.Path)
+			if patch.Path == "" {
+				continue
+			}
+			if _, ok := seen[workflowPath][patch.Path]; ok {
+				continue
+			}
+			out[workflowPath] = append(out[workflowPath], patch)
+			seen[workflowPath][patch.Path] = struct{}{}
+		}
+	}
+	return out
+}
+
+func doctorWorkflowOptimizationDiff(report doctorWorkflowOptimizationReport) string {
+	patches := doctorWorkflowOptimizationPatchesByWorkflow(report)
+	if len(patches) == 0 {
+		return ""
+	}
+	paths := make([]string, 0, len(patches))
+	for path := range patches {
+		paths = append(paths, path)
+	}
+	sort.Strings(paths)
+
+	var builder strings.Builder
+	for _, path := range paths {
+		raw, err := os.ReadFile(path)
+		if err != nil {
+			continue
+		}
+		updated, err := doctorApplyWorkflowOptimizationPatches(raw, patches[path])
+		if err != nil || bytes.Equal(raw, updated) {
+			continue
+		}
+		before, _, err := doctorSplitWorkflowFrontmatter(raw)
+		if err != nil {
+			continue
+		}
+		after, _, err := doctorSplitWorkflowFrontmatter(updated)
+		if err != nil {
+			continue
+		}
+		if builder.Len() > 0 {
+			builder.WriteByte('\n')
+		}
+		builder.WriteString(doctorFrontmatterDiff(path, before, after))
+	}
+	return strings.TrimRight(builder.String(), "\n")
+}
+
+func doctorFrontmatterDiff(path string, before []byte, after []byte) string {
+	var builder strings.Builder
+	builder.WriteString("--- ")
+	builder.WriteString(path)
+	builder.WriteByte('\n')
+	builder.WriteString("+++ ")
+	builder.WriteString(path)
+	builder.WriteByte('\n')
+	builder.WriteString("@@ workflow frontmatter @@\n")
+	for _, line := range strings.Split(strings.TrimRight(string(before), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		builder.WriteByte('-')
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	for _, line := range strings.Split(strings.TrimRight(string(after), "\n"), "\n") {
+		if line == "" {
+			continue
+		}
+		builder.WriteByte('+')
+		builder.WriteString(line)
+		builder.WriteByte('\n')
+	}
+	return builder.String()
+}
+
+func doctorApplyWorkflowOptimizationPatches(raw []byte, patches []doctorWorkflowOptimizationPatch) ([]byte, error) {
+	frontmatter, prompt, err := doctorSplitWorkflowFrontmatter(raw)
+	if err != nil {
+		return nil, err
+	}
+
+	root, err := doctorWorkflowFrontmatterRoot(frontmatter)
+	if err != nil {
+		return nil, err
+	}
+	for _, patch := range patches {
+		if err := doctorApplyWorkflowOptimizationPatch(root, patch); err != nil {
+			return nil, err
+		}
+	}
+
+	frontmatter, err = yaml.Marshal(root)
+	if err != nil {
+		return nil, err
+	}
+	var out bytes.Buffer
+	out.WriteString("---\n")
+	out.Write(bytes.TrimRight(frontmatter, "\n"))
+	out.WriteString("\n---\n")
+	out.Write(prompt)
+	return out.Bytes(), nil
+}
+
+func doctorSplitWorkflowFrontmatter(raw []byte) ([]byte, []byte, error) {
+	normalized := strings.ReplaceAll(strings.TrimPrefix(string(raw), "\ufeff"), "\r\n", "\n")
+	if !strings.HasPrefix(normalized, "---\n") {
+		return nil, nil, errors.New("missing YAML frontmatter")
+	}
+	body := normalized[len("---\n"):]
+	if strings.HasPrefix(body, "---\n") {
+		return []byte{}, []byte(body[len("---\n"):]), nil
+	}
+	if body == "---" {
+		return []byte{}, []byte{}, nil
+	}
+	before, after, ok := strings.Cut(body, "\n---\n")
+	if ok {
+		return []byte(before), []byte(after), nil
+	}
+	if before, ok := strings.CutSuffix(body, "\n---"); ok {
+		return []byte(before), []byte{}, nil
+	}
+	return nil, nil, errors.New("unterminated YAML frontmatter")
+}
+
+func doctorWorkflowFrontmatterRoot(frontmatter []byte) (*yaml.Node, error) {
+	if len(bytes.TrimSpace(frontmatter)) == 0 {
+		return &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}, nil
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(frontmatter, &doc); err != nil {
+		return nil, err
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil, errors.New("workflow frontmatter must be a YAML document")
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, errors.New("workflow frontmatter must be a mapping")
+	}
+	return root, nil
+}
+
+func doctorApplyWorkflowOptimizationPatch(root *yaml.Node, patch doctorWorkflowOptimizationPatch) error {
+	switch strings.TrimSpace(patch.Path) {
+	case "agent.max_session_tokens", "agent.auto_promote.rework_limit", "gate.validator.model", "polling.interval_ms", "budget.per_issue_max_usd":
+		return doctorSetSimpleYAMLPath(root, strings.Split(patch.Path, "."), patch.Value)
+	case "agents.routes.default.model":
+		return doctorSetDefaultRouteModel(root, fmt.Sprint(patch.Value))
+	default:
+		return fmt.Errorf("unsupported workflow optimization patch path %q", patch.Path)
+	}
+}
+
+func doctorSetSimpleYAMLPath(root *yaml.Node, path []string, value any) error {
+	if len(path) == 0 {
+		return errors.New("empty YAML path")
+	}
+	current := root
+	for _, key := range path[:len(path)-1] {
+		current = doctorEnsureYAMLMapping(current, key)
+	}
+	doctorSetYAMLMappingValue(current, path[len(path)-1], doctorYAMLScalar(value))
+	return nil
+}
+
+func doctorSetDefaultRouteModel(root *yaml.Node, model string) error {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return errors.New("default route model is required")
+	}
+	agents := doctorEnsureYAMLMapping(root, "agents")
+	routes := doctorYAMLMappingValue(agents, "routes")
+	if routes == nil || routes.Kind != yaml.SequenceNode {
+		routes = &yaml.Node{Kind: yaml.SequenceNode, Tag: "!!seq"}
+		doctorSetYAMLMappingValue(agents, "routes", routes)
+	}
+	for _, route := range routes.Content {
+		if route.Kind != yaml.MappingNode {
+			continue
+		}
+		if doctorYAMLRouteIsDefault(route) {
+			doctorSetYAMLMappingValue(route, "model", doctorYAMLScalar(model))
+			return nil
+		}
+	}
+	routes.Content = append(routes.Content, doctorYAMLMapping(map[string]any{
+		"name":    "default",
+		"backend": workflowconfig.DefaultAgentBackendID,
+		"default": true,
+		"model":   model,
+	}))
+	return nil
+}
+
+func doctorYAMLRouteIsDefault(route *yaml.Node) bool {
+	defaultValue := doctorYAMLMappingValue(route, "default")
+	if defaultValue == nil || defaultValue.Kind != yaml.ScalarNode || defaultValue.Value != "true" {
+		return false
+	}
+	role := doctorYAMLMappingValue(route, "role")
+	return role == nil || strings.TrimSpace(role.Value) == "" || strings.EqualFold(strings.TrimSpace(role.Value), "code")
+}
+
+func doctorEnsureYAMLMapping(parent *yaml.Node, key string) *yaml.Node {
+	value := doctorYAMLMappingValue(parent, key)
+	if value != nil && value.Kind == yaml.MappingNode {
+		return value
+	}
+	value = &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	doctorSetYAMLMappingValue(parent, key, value)
+	return value
+}
+
+func doctorYAMLMappingValue(mapping *yaml.Node, key string) *yaml.Node {
+	if mapping == nil || mapping.Kind != yaml.MappingNode {
+		return nil
+	}
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value == key {
+			return mapping.Content[index+1]
+		}
+	}
+	return nil
+}
+
+func doctorSetYAMLMappingValue(mapping *yaml.Node, key string, value *yaml.Node) {
+	for index := 0; index+1 < len(mapping.Content); index += 2 {
+		if mapping.Content[index].Value == key {
+			mapping.Content[index+1] = value
+			return
+		}
+	}
+	mapping.Content = append(mapping.Content, doctorYAMLScalar(key), value)
+}
+
+func doctorYAMLMapping(values map[string]any) *yaml.Node {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	node := &yaml.Node{Kind: yaml.MappingNode, Tag: "!!map"}
+	for _, key := range keys {
+		node.Content = append(node.Content, doctorYAMLScalar(key), doctorYAMLScalar(values[key]))
+	}
+	return node
+}
+
+func doctorYAMLScalar(value any) *yaml.Node {
+	node := &yaml.Node{Kind: yaml.ScalarNode}
+	switch typed := value.(type) {
+	case bool:
+		node.Tag = "!!bool"
+		node.Value = strconv.FormatBool(typed)
+	case int:
+		node.Tag = "!!int"
+		node.Value = strconv.Itoa(typed)
+	case int64:
+		node.Tag = "!!int"
+		node.Value = strconv.FormatInt(typed, 10)
+	case float64:
+		node.Tag = "!!float"
+		node.Value = strconv.FormatFloat(typed, 'f', -1, 64)
+	case string:
+		node.Tag = "!!str"
+		node.Value = typed
+	default:
+		node.Tag = "!!str"
+		node.Value = fmt.Sprint(typed)
+	}
+	return node
+}

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -162,6 +162,7 @@ func checkDoctorWorkflowOptimization(
 	resolution globalconfig.PathResolution,
 	cfg globalconfig.Config,
 	deps doctorDeps,
+	githubToken RuntimeSecret,
 	includeDiff bool,
 ) doctorCheck {
 	if strings.TrimSpace(resolution.Path) == "" {
@@ -197,7 +198,7 @@ func checkDoctorWorkflowOptimization(
 			Hint:   "Run detent after current migrations are applied, then rerun detent doctor.",
 		}
 	}
-	report, err := doctorWorkflowOptimization(ctx, db, storePath, cfg, deps, includeDiff)
+	report, err := doctorWorkflowOptimization(ctx, db, storePath, cfg, deps, runtimeGlobalGitHubToken(githubToken), includeDiff)
 	closeErr := db.Close()
 	if err != nil {
 		return doctorCheck{
@@ -237,6 +238,7 @@ func doctorWorkflowOptimization(
 	storePath string,
 	cfg globalconfig.Config,
 	deps doctorDeps,
+	runtimeGitHubToken string,
 	includeDiff bool,
 ) (doctorWorkflowOptimizationReport, error) {
 	report := doctorWorkflowOptimizationReport{StorePath: storePath}
@@ -252,7 +254,7 @@ func doctorWorkflowOptimization(
 			})
 			continue
 		}
-		workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, "")
+		workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, runtimeGitHubToken)
 		if err := workflow.Config.Validate(); err != nil {
 			report.Projects = append(report.Projects, doctorWorkflowOptimizationProjectReport{
 				ProjectID:    projectID,
@@ -265,8 +267,7 @@ func doctorWorkflowOptimization(
 			workflowPath = ""
 		}
 
-		projectStoreID := doctorWorkflowOptimizationProjectStoreID(projectID, workflow.Config)
-		metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, projectStoreID, workflow.Config)
+		metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, projectID, workflow.Config)
 		if err != nil {
 			return doctorWorkflowOptimizationReport{}, err
 		}
@@ -295,20 +296,13 @@ func doctorWorkflowOptimization(
 	return report, nil
 }
 
-func doctorWorkflowOptimizationProjectStoreID(projectID string, cfg workflowconfig.Config) string {
-	if id := strings.TrimSpace(cfg.Tracker.LocalSQLite.ProjectID); id != "" {
-		return id
-	}
-	return strings.TrimSpace(projectID)
-}
-
 func doctorWorkflowOptimizationMetricsForProject(
 	ctx context.Context,
 	db doctorTelemetryStore,
 	projectID string,
 	cfg workflowconfig.Config,
 ) (doctorWorkflowOptimizationMetrics, error) {
-	sessions, err := doctorWorkflowSessionTelemetry(ctx, db)
+	sessions, err := doctorWorkflowSessionTelemetry(ctx, db, projectID)
 	if err != nil {
 		return doctorWorkflowOptimizationMetrics{}, err
 	}
@@ -366,19 +360,28 @@ func doctorWorkflowOptimizationMetricsForProject(
 	return metrics, nil
 }
 
-func doctorWorkflowSessionTelemetry(ctx context.Context, db doctorTelemetryStore) (doctorWorkflowSessionMetrics, error) {
+func doctorWorkflowSessionTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) (doctorWorkflowSessionMetrics, error) {
 	rows, err := db.QueryContext(ctx, `
 SELECT
-  COALESCE(total_tokens, 0),
-  COALESCE(input_tokens, 0),
-  COALESCE(cached_input_tokens, 0),
-  COALESCE(output_tokens, 0),
-  COALESCE(model, ''),
-  COALESCE(final_state, ''),
-  COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned')
-FROM codex_sessions
-WHERE completed_at IS NOT NULL
-ORDER BY completed_at DESC, id DESC`)
+  COALESCE(s.total_tokens, 0),
+  COALESCE(s.input_tokens, 0),
+  COALESCE(s.cached_input_tokens, 0),
+  COALESCE(s.output_tokens, 0),
+  COALESCE(s.model, ''),
+  COALESCE(s.final_state, ''),
+  COALESCE(NULLIF(s.identifier, ''), NULLIF(s.issue_id, ''), NULLIF(s.issue_url, ''), 'unassigned')
+FROM codex_sessions s
+WHERE s.completed_at IS NOT NULL
+  AND (
+    ? = ''
+    OR s.id IN (
+      SELECT DISTINCT session_id
+      FROM usage_events
+      WHERE session_id IS NOT NULL
+        AND project_id = ?
+    )
+  )
+ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 	if err != nil {
 		return doctorWorkflowSessionMetrics{}, fmt.Errorf("read codex session telemetry: %w", err)
 	}

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -1,0 +1,435 @@
+package cli
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	paths := seedDoctorWorkflowOptimizationFixture(t)
+	db, err := openDoctorSQLiteReadOnly(ctx, paths.db)
+	if err != nil {
+		t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	global := doctorWorkflowOptimizationGlobal(paths)
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = workflowconfig.LoadWorkflow
+	report, err := doctorWorkflowOptimization(ctx, db, paths.db, global, deps, true)
+	if err != nil {
+		t.Fatalf("doctorWorkflowOptimization() error = %v", err)
+	}
+
+	if len(report.Findings) < 5 {
+		t.Fatalf("findings len = %d, want at least 5: %#v", len(report.Findings), report.Findings)
+	}
+	if strings.TrimSpace(report.Diff) == "" {
+		t.Fatal("Diff is blank, want proposed frontmatter patch")
+	}
+	var pretty bytes.Buffer
+	if err := writeDoctorReport(&pretty, doctorReport{WorkflowOptimization: report}); err != nil {
+		t.Fatalf("writeDoctorReport() error = %v", err)
+	}
+	for _, want := range []string{
+		"Workflow Optimization",
+		"runaway_session_tokens",
+		"Evidence:",
+		"Suggested patch: agent.max_session_tokens=40000",
+		"@@ workflow frontmatter @@",
+	} {
+		if !strings.Contains(pretty.String(), want) {
+			t.Fatalf("pretty report missing %q:\n%s", want, pretty.String())
+		}
+	}
+
+	runaway := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleRunawaySessionTokens)
+	if got := evidenceInt64(t, runaway, "max_session_tokens"); got != 300000 {
+		t.Fatalf("runaway max_session_tokens = %d, want 300000", got)
+	}
+	if got := evidenceInt64(t, runaway, "median_session_tokens"); got != 10000 {
+		t.Fatalf("runaway median_session_tokens = %d, want 10000", got)
+	}
+	if got := evidenceFloat64(t, runaway, "max_to_median_ratio"); got != 30 {
+		t.Fatalf("runaway max_to_median_ratio = %v, want 30", got)
+	}
+
+	rework := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleReworkLaps)
+	if got := evidenceInt64(t, rework, "max_rework_laps_per_issue"); got != 3 {
+		t.Fatalf("rework laps = %d, want 3", got)
+	}
+
+	validator := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleValidatorModel)
+	if got := validator.Patch[0].Value; got != doctorWorkflowValidatorModel {
+		t.Fatalf("validator patch value = %#v, want %s", got, doctorWorkflowValidatorModel)
+	}
+
+	emptyModel := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleEmptyModelTelemetry)
+	if got := evidenceInt64(t, emptyModel, "empty_model_recent_sessions"); got != 4 {
+		t.Fatalf("empty model recent sessions = %d, want 4", got)
+	}
+	if got := evidenceFloat64(t, emptyModel, "empty_model_recent_fraction"); got != 0.8 {
+		t.Fatalf("empty model fraction = %v, want 0.8", got)
+	}
+
+	budget := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleBudgetEstimateDrift)
+	if got := evidenceInt64(t, budget, "observed_p90_session_tokens"); got != 300000 {
+		t.Fatalf("budget p90 = %d, want 300000", got)
+	}
+
+	scheduler := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleSchedulerSkipRate)
+	if got := evidenceFloat64(t, scheduler, "scheduler_skip_rate"); got != 0.67 {
+		t.Fatalf("scheduler skip rate = %v, want 0.67", got)
+	}
+}
+
+func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
+	t.Parallel()
+
+	report := doctorReport{
+		Checks: []doctorCheck{{
+			Name:   doctorWorkflowOptimizationCheckName,
+			Status: doctorWarn,
+			Detail: "1 finding",
+		}},
+		WorkflowOptimization: doctorWorkflowOptimizationReport{
+			StorePath: "/tmp/detent.db",
+			Findings: []doctorWorkflowOptimizationFinding{{
+				RuleID:               doctorWorkflowRuleRunawaySessionTokens,
+				ProjectID:            "detent",
+				Severity:             "warning",
+				Title:                "Runaway session tail",
+				Detail:               "max session tokens are high",
+				EstimatedTokenImpact: 290000,
+				Evidence: map[string]any{
+					"max_session_tokens": int64(300000),
+				},
+			}},
+		},
+	}
+
+	var output bytes.Buffer
+	if err := writeDoctorReport(&output, report, OutputFormatJSON); err != nil {
+		t.Fatalf("writeDoctorReport() error = %v", err)
+	}
+
+	var got struct {
+		Result               string `json:"result"`
+		WorkflowOptimization struct {
+			StorePath string `json:"store_path"`
+			Findings  []struct {
+				RuleID string         `json:"rule_id"`
+				Detail string         `json:"detail"`
+				Values map[string]any `json:"evidence"`
+			} `json:"findings"`
+		} `json:"workflow_optimization"`
+	}
+	if err := json.Unmarshal(output.Bytes(), &got); err != nil {
+		t.Fatalf("Unmarshal() error = %v\n%s", err, output.String())
+	}
+	if got.Result != "FAIL" {
+		t.Fatalf("Result = %q, want FAIL for nonzero findings", got.Result)
+	}
+	if got.WorkflowOptimization.StorePath != "/tmp/detent.db" {
+		t.Fatalf("StorePath = %q, want /tmp/detent.db", got.WorkflowOptimization.StorePath)
+	}
+	if len(got.WorkflowOptimization.Findings) != 1 || got.WorkflowOptimization.Findings[0].RuleID != doctorWorkflowRuleRunawaySessionTokens {
+		t.Fatalf("workflow optimization findings = %#v", got.WorkflowOptimization.Findings)
+	}
+}
+
+func TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow(t *testing.T) {
+	t.Parallel()
+
+	paths := seedDoctorWorkflowOptimizationFixture(t)
+	configPath := filepath.Join(paths.dir, "global.yaml")
+	global := doctorWorkflowOptimizationGlobal(paths)
+	global.Path = configPath
+
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = workflowconfig.LoadWorkflow
+	deps.openSQLiteReadOnly = openDoctorSQLiteReadOnly
+
+	configFlag := configPath
+	envFlag := ""
+	logLevelFlag := ""
+	hostFlag := "127.0.0.1"
+	portFlag := 0
+	cmd := newDoctorCommandWithDeps(&configFlag, &envFlag, &logLevelFlag, &hostFlag, &portFlag, successfulDoctorOptionsWithConfig(configPath, global), deps)
+	cmd.SetArgs([]string{"--project", "detent", "--write"})
+	cmd.SetIn(strings.NewReader("yes\n"))
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if !errors.Is(err, ErrDoctorFailed) {
+		t.Fatalf("Execute() error = %v, want ErrDoctorFailed for nonzero findings\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+
+	workflow, err := workflowconfig.LoadWorkflow(paths.workflow)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	if workflow.Config.Agent.MaxSessionTokens != 40000 {
+		t.Fatalf("Agent.MaxSessionTokens = %d, want 40000", workflow.Config.Agent.MaxSessionTokens)
+	}
+	if workflow.Config.Agent.AutoPromote.ReworkLimit != 2 {
+		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want 2", workflow.Config.Agent.AutoPromote.ReworkLimit)
+	}
+	if workflow.Config.Gate.Validator.Model != doctorWorkflowValidatorModel {
+		t.Fatalf("Gate.Validator.Model = %q, want %s", workflow.Config.Gate.Validator.Model, doctorWorkflowValidatorModel)
+	}
+	if workflow.Config.Polling.IntervalMS != 120000 {
+		t.Fatalf("Polling.IntervalMS = %d, want 120000", workflow.Config.Polling.IntervalMS)
+	}
+	if workflow.Config.Budget.PerIssueMaxUSD != 8.82 {
+		t.Fatalf("Budget.PerIssueMaxUSD = %v, want 8.82", workflow.Config.Budget.PerIssueMaxUSD)
+	}
+	if !doctorWorkflowHasDefaultRouteModel(workflow.Config) {
+		t.Fatalf("workflow missing default route model after write: %#v", workflow.Config.Agents.Routes)
+	}
+}
+
+type doctorWorkflowOptimizationFixturePaths struct {
+	dir      string
+	db       string
+	workflow string
+}
+
+func seedDoctorWorkflowOptimizationFixture(t *testing.T) doctorWorkflowOptimizationFixturePaths {
+	t.Helper()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(`---
+tracker:
+  kind: memory
+polling:
+  interval_ms: 60000
+agent:
+  auto_promote:
+    enabled: true
+gate:
+  kind: command
+  validator:
+    enabled: true
+---
+Prompt
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+	}
+
+	dbPath := filepath.Join(dir, "detent.db")
+	backend, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    dbPath,
+	})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+
+	now := time.Date(2026, 7, 2, 15, 0, 0, 0, time.UTC)
+	sessionTotals := []struct {
+		issue      string
+		total      int64
+		model      string
+		finalState string
+	}{
+		{issue: "digitaldrywood/detent#1", total: 10000, finalState: "completed"},
+		{issue: "digitaldrywood/detent#1", total: 10000, finalState: "completed"},
+		{issue: "digitaldrywood/detent#2", total: 10000, finalState: "completed"},
+		{issue: "digitaldrywood/detent#3", total: 120000, finalState: "completed"},
+		{issue: "digitaldrywood/detent#4", total: 300000, model: "gpt-5-codex", finalState: "failed"},
+	}
+	for index, session := range sessionTotals {
+		startedAt := now.Add(time.Duration(index-10) * time.Minute)
+		sessionID, err := backend.StartSession(ctx, store.SessionStart{
+			Identifier: session.issue,
+			StartedAt:  startedAt,
+			Model:      session.model,
+		})
+		if err != nil {
+			t.Fatalf("StartSession() error = %v", err)
+		}
+		outputTokens := int64(1000)
+		if err := backend.FinishSession(ctx, sessionID, store.SessionFinish{
+			CompletedAt:       startedAt.Add(5 * time.Minute),
+			Turns:             1,
+			InputTokens:       session.total - outputTokens,
+			CachedInputTokens: (session.total - outputTokens) / 2,
+			OutputTokens:      outputTokens,
+			TotalTokens:       session.total,
+			RuntimeSeconds:    300,
+			FinalState:        session.finalState,
+			Model:             session.model,
+		}); err != nil {
+			t.Fatalf("FinishSession() error = %v", err)
+		}
+		if _, err := backend.RecordUsageEvent(ctx, store.UsageEvent{
+			ProjectID:         "detent",
+			SessionID:         sessionID,
+			Identifier:        session.issue,
+			Model:             session.model,
+			InputTokens:       session.total - outputTokens,
+			CachedInputTokens: (session.total - outputTokens) / 2,
+			OutputTokens:      outputTokens,
+			TotalTokens:       session.total,
+			RuntimeSeconds:    300,
+			StartedAt:         startedAt,
+			FinishedAt:        startedAt.Add(5 * time.Minute),
+			Outcome:           session.finalState,
+		}); err != nil {
+			t.Fatalf("RecordUsageEvent() error = %v", err)
+		}
+	}
+
+	for index := range 3 {
+		if _, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+			ProjectID:       "detent",
+			Identifier:      "digitaldrywood/detent#2",
+			PhaseType:       store.WorkflowPhaseTypeLane,
+			PhaseName:       "Rework",
+			Status:          "completed",
+			StartedAt:       now.Add(time.Duration(index) * time.Hour),
+			FinishedAt:      now.Add(time.Duration(index)*time.Hour + 30*time.Minute),
+			DurationSeconds: int64((30 * time.Minute) / time.Second),
+		}); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent(rework) error = %v", err)
+		}
+	}
+	for index, duration := range []time.Duration{time.Hour, 3 * time.Hour, 6 * time.Hour} {
+		if _, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+			ProjectID:       "detent",
+			Identifier:      "digitaldrywood/detent#3",
+			PhaseType:       store.WorkflowPhaseTypeLane,
+			PhaseName:       "In Progress",
+			Status:          "completed",
+			StartedAt:       now.Add(time.Duration(index+4) * time.Hour),
+			FinishedAt:      now.Add(time.Duration(index+4)*time.Hour + duration),
+			DurationSeconds: int64(duration / time.Second),
+		}); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent(lane) error = %v", err)
+		}
+	}
+
+	for index := range 6 {
+		selected := index >= 4
+		result := store.SchedulerDecisionResultSkipped
+		if selected {
+			result = store.SchedulerDecisionResultSelected
+		}
+		if _, err := backend.RecordSchedulerDecision(ctx, store.SchedulerDecision{
+			ProjectID:  "detent",
+			Identifier: "digitaldrywood/detent#5",
+			Lane:       "Todo",
+			Result:     result,
+			Selected:   selected,
+			DecisionAt: now.Add(time.Duration(index) * time.Second),
+		}); err != nil {
+			t.Fatalf("RecordSchedulerDecision() error = %v", err)
+		}
+	}
+
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	return doctorWorkflowOptimizationFixturePaths{
+		dir:      dir,
+		db:       dbPath,
+		workflow: workflowPath,
+	}
+}
+
+func doctorWorkflowOptimizationGlobal(paths doctorWorkflowOptimizationFixturePaths) globalconfig.Config {
+	return globalconfig.Config{
+		Path:       filepath.Join(paths.dir, "global.yaml"),
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{{
+			ID:       "detent",
+			Workflow: paths.workflow,
+			Workdir:  paths.dir,
+			Weight:   1,
+		}},
+	}
+}
+
+func doctorWorkflowFindingByRule(t *testing.T, findings []doctorWorkflowOptimizationFinding, ruleID string) doctorWorkflowOptimizationFinding {
+	t.Helper()
+
+	for _, finding := range findings {
+		if finding.RuleID == ruleID {
+			return finding
+		}
+	}
+	t.Fatalf("missing finding %q in %#v", ruleID, findings)
+	return doctorWorkflowOptimizationFinding{}
+}
+
+func evidenceInt64(t *testing.T, finding doctorWorkflowOptimizationFinding, key string) int64 {
+	t.Helper()
+
+	value, ok := finding.Evidence[key]
+	if !ok {
+		t.Fatalf("%s evidence missing %q: %#v", finding.RuleID, key, finding.Evidence)
+	}
+	switch typed := value.(type) {
+	case int:
+		return int64(typed)
+	case int64:
+		return typed
+	case float64:
+		return int64(typed)
+	default:
+		t.Fatalf("%s evidence %q = %#v (%T), want integer", finding.RuleID, key, value, value)
+		return 0
+	}
+}
+
+func evidenceFloat64(t *testing.T, finding doctorWorkflowOptimizationFinding, key string) float64 {
+	t.Helper()
+
+	value, ok := finding.Evidence[key]
+	if !ok {
+		t.Fatalf("%s evidence missing %q: %#v", finding.RuleID, key, finding.Evidence)
+	}
+	switch typed := value.(type) {
+	case int:
+		return float64(typed)
+	case int64:
+		return float64(typed)
+	case float64:
+		return typed
+	default:
+		t.Fatalf("%s evidence %q = %#v (%T), want float", finding.RuleID, key, value, value)
+		return 0
+	}
+}

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -34,7 +34,7 @@ func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
 	global := doctorWorkflowOptimizationGlobal(paths)
 	deps := successfulDoctorDeps()
 	deps.loadWorkflow = workflowconfig.LoadWorkflow
-	report, err := doctorWorkflowOptimization(ctx, db, paths.db, global, deps, true)
+	report, err := doctorWorkflowOptimization(ctx, db, paths.db, global, deps, "", true)
 	if err != nil {
 		t.Fatalf("doctorWorkflowOptimization() error = %v", err)
 	}
@@ -98,6 +98,16 @@ func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
 	scheduler := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleSchedulerSkipRate)
 	if got := evidenceFloat64(t, scheduler, "scheduler_skip_rate"); got != 0.67 {
 		t.Fatalf("scheduler skip rate = %v, want 0.67", got)
+	}
+	if len(report.Projects) != 1 {
+		t.Fatalf("projects len = %d, want 1", len(report.Projects))
+	}
+	metrics := report.Projects[0].Metrics
+	if metrics.SessionCount != 5 || metrics.UsageEventCount != 5 {
+		t.Fatalf("metrics counts = sessions %d usage %d, want 5 and 5", metrics.SessionCount, metrics.UsageEventCount)
+	}
+	if metrics.MaxSessionTokens != 300000 {
+		t.Fatalf("MaxSessionTokens = %d, want 300000", metrics.MaxSessionTokens)
 	}
 }
 
@@ -213,6 +223,71 @@ func TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow(t *testing.T) {
 	}
 }
 
+func TestDoctorWorkflowOptimizationUsesRuntimeGitHubToken(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "detent.db")
+	backend, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    dbPath,
+	})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(`---
+tracker:
+  kind: github_local
+  repository: digitaldrywood/detent
+  local_sqlite:
+    path: `+dbPath+`
+---
+Prompt
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+	}
+
+	db, err := openDoctorSQLiteReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	global := globalconfig.Config{
+		Path:       filepath.Join(dir, "global.yaml"),
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Projects: []globalconfig.Project{{
+			ID:       "detent",
+			Workflow: workflowPath,
+			Workdir:  dir,
+			Weight:   1,
+		}},
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = workflowconfig.LoadWorkflow
+	report, err := doctorWorkflowOptimization(ctx, db, dbPath, global, deps, "runtime-token", false)
+	if err != nil {
+		t.Fatalf("doctorWorkflowOptimization() error = %v", err)
+	}
+	if len(report.Projects) != 1 {
+		t.Fatalf("projects len = %d, want 1", len(report.Projects))
+	}
+	if report.Projects[0].Error != "" {
+		t.Fatalf("project error = %q, want none", report.Projects[0].Error)
+	}
+}
+
 type doctorWorkflowOptimizationFixturePaths struct {
 	dir      string
 	db       string
@@ -228,6 +303,8 @@ func seedDoctorWorkflowOptimizationFixture(t *testing.T) doctorWorkflowOptimizat
 	if err := os.WriteFile(workflowPath, []byte(`---
 tracker:
   kind: memory
+  local_sqlite:
+    project_id: detent-local
 polling:
   interval_ms: 60000
 agent:
@@ -305,6 +382,42 @@ Prompt
 		}); err != nil {
 			t.Fatalf("RecordUsageEvent() error = %v", err)
 		}
+	}
+
+	otherStartedAt := now
+	otherSessionID, err := backend.StartSession(ctx, store.SessionStart{
+		Identifier: "digitaldrywood/other#99",
+		StartedAt:  otherStartedAt,
+	})
+	if err != nil {
+		t.Fatalf("StartSession(other) error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, otherSessionID, store.SessionFinish{
+		CompletedAt:       otherStartedAt.Add(5 * time.Minute),
+		Turns:             1,
+		InputTokens:       899000,
+		CachedInputTokens: 449500,
+		OutputTokens:      1000,
+		TotalTokens:       900000,
+		RuntimeSeconds:    300,
+		FinalState:        "failed",
+	}); err != nil {
+		t.Fatalf("FinishSession(other) error = %v", err)
+	}
+	if _, err := backend.RecordUsageEvent(ctx, store.UsageEvent{
+		ProjectID:         "other",
+		SessionID:         otherSessionID,
+		Identifier:        "digitaldrywood/other#99",
+		InputTokens:       899000,
+		CachedInputTokens: 449500,
+		OutputTokens:      1000,
+		TotalTokens:       900000,
+		RuntimeSeconds:    300,
+		StartedAt:         otherStartedAt,
+		FinishedAt:        otherStartedAt.Add(5 * time.Minute),
+		Outcome:           "failed",
+	}); err != nil {
+		t.Fatalf("RecordUsageEvent(other) error = %v", err)
 	}
 
 	for index := range 3 {


### PR DESCRIPTION
## Summary

- Adds read-only doctor telemetry analysis for workflow optimization findings, ranked by estimated token impact.
- Extends doctor pretty and JSON reports with rule evidence plus optional `--diff` and confirmed `--write` WORKFLOW.md patches.
- Covers fixture rule hits, JSON schema output, and write round-tripping through workflow validation.

Fixes #862

## Test Plan

- [x] `make check`