### PR TITLE
feat(runner): prototype thread resume

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -36,6 +36,10 @@ INSERT INTO codex_sessions (
   identifier,
   issue_url,
   started_at,
+  requested_model,
+  agent_backend_id,
+  agent_backend_kind,
+  agent_role,
   completed_at,
   turns,
   input_tokens,
@@ -46,8 +50,11 @@ INSERT INTO codex_sessions (
   model_context_window,
   runtime_seconds,
   final_state,
-  model
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  model,
+  provider_thread_id,
+  provider_session_id,
+  resumed_from_session_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 RETURNING *;
 
 -- name: GetCodexSession :one
@@ -57,18 +64,48 @@ WHERE id = ?;
 
 -- name: FinishCodexSession :execrows
 UPDATE codex_sessions
-SET completed_at = ?,
-    turns = ?,
-    input_tokens = ?,
-    cached_input_tokens = ?,
-    output_tokens = ?,
-    reasoning_output_tokens = ?,
-    total_tokens = ?,
-    model_context_window = COALESCE(?, model_context_window),
-    runtime_seconds = ?,
-    final_state = ?,
-    model = COALESCE(?, model)
-WHERE id = ?;
+SET completed_at = sqlc.arg(completed_at),
+    turns = sqlc.arg(turns),
+    input_tokens = sqlc.arg(input_tokens),
+    cached_input_tokens = sqlc.narg(cached_input_tokens),
+    output_tokens = sqlc.arg(output_tokens),
+    reasoning_output_tokens = sqlc.narg(reasoning_output_tokens),
+    total_tokens = sqlc.arg(total_tokens),
+    model_context_window = COALESCE(sqlc.narg(model_context_window), model_context_window),
+    runtime_seconds = sqlc.arg(runtime_seconds),
+    final_state = sqlc.narg(final_state),
+    model = COALESCE(sqlc.narg(model), model),
+    provider_thread_id = COALESCE(sqlc.narg(provider_thread_id), provider_thread_id),
+    provider_session_id = COALESCE(sqlc.narg(provider_session_id), provider_session_id),
+    resumed_from_session_id = COALESCE(sqlc.narg(resumed_from_session_id), resumed_from_session_id)
+WHERE id = sqlc.arg(id);
+
+-- name: GetLatestCompletedAgentResumeState :one
+SELECT
+  id,
+  CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
+  CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
+  CAST(COALESCE(requested_model, '') AS TEXT) AS requested_model,
+  CAST(COALESCE(model, '') AS TEXT) AS model,
+  CAST(COALESCE(agent_backend_id, '') AS TEXT) AS agent_backend_id,
+  CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
+  CAST(COALESCE(agent_role, '') AS TEXT) AS agent_role,
+  CAST(completed_at AS TEXT) AS completed_at
+FROM codex_sessions
+WHERE completed_at IS NOT NULL
+  AND lower(trim(COALESCE(final_state, ''))) = 'completed'
+  AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
+  AND COALESCE(agent_backend_id, '') = sqlc.arg(agent_backend_id)
+  AND COALESCE(agent_backend_kind, '') = sqlc.arg(agent_backend_kind)
+  AND COALESCE(agent_role, '') = sqlc.arg(agent_role)
+  AND COALESCE(NULLIF(requested_model, ''), COALESCE(model, '')) = sqlc.arg(requested_model)
+  AND (
+    (sqlc.arg(issue_id) != '' AND COALESCE(issue_id, '') = sqlc.arg(issue_id))
+    OR (sqlc.arg(identifier) != '' AND COALESCE(identifier, '') = sqlc.arg(identifier))
+    OR (sqlc.arg(issue_url) != '' AND COALESCE(issue_url, '') = sqlc.arg(issue_url))
+  )
+ORDER BY completed_at DESC, id DESC
+LIMIT 1;
 
 -- name: ListRecentCodexSessions :many
 SELECT *

--- a/docs/thread-resume-spike.md
+++ b/docs/thread-resume-spike.md
@@ -1,0 +1,50 @@
+# Thread Resume Spike
+
+Issue: digitaldrywood/detent#859
+
+## Recommendation
+
+Adapt the prototype behind `agent.experimental_thread_resume`, then enable it only after dogfood Detent is running the #852 cache telemetry migration. The backend resume surfaces are present and can be wired safely with fresh fallback semantics, but the cache-read delta cannot be verified from the live dogfood store available during this spike.
+
+## Backend Support
+
+Codex CLI `codex-cli 0.142.5` exposes `thread/resume` in the experimental app-server protocol. The generated v2 schema accepts `threadId` plus the same execution overrides Detent already uses for fresh threads: `cwd`, model, model provider, service tier, approval policy, and sandbox mode. The prototype sends `thread/resume` when a stored provider thread ID exists, then starts the next turn on the resumed thread.
+
+Claude Code `2.1.199` exposes `-r, --resume [value]` for print-mode sessions. The same help output also exposes `--fork-session` and `--no-session-persistence`; the prototype uses only `--resume <session_id>` so continuation behavior stays aligned with the CLI default.
+
+## Lifetime Limits
+
+Neither verified CLI surface publishes a durable TTL in the command help or generated schema. Codex describes `thread/resume` as loading a thread from disk by `threadId` or rejoining a running thread; Claude describes resuming by session ID. Treat stored provider IDs as opportunistic local cache keys:
+
+- Resume only from Detent sessions that completed successfully.
+- Force fresh dispatch when the requested model, backend ID, backend kind, or agent role changes.
+- Fall back to a fresh thread only when the resume attempt fails before a new turn starts.
+- Keep per-issue handoff notes as the durable cross-machine fallback, because provider thread/session IDs can expire, be pruned, or be unavailable on another host.
+
+## Prototype Shape
+
+The migration adds resume metadata to `codex_sessions`: requested model, backend identity, agent role, provider thread/session IDs, and the Detent session ID used as a resume source. The runner looks up the newest completed matching code session only when `agent.experimental_thread_resume` is true, passes an `AgentResume` field into the backend request, and clears the source state before retrying fresh if the resumed attempt fails before a turn starts.
+
+With the flag off, Detent does not look up resume state and does not pass resume arguments to either backend. The schema is still extended so the feature can be enabled without another storage change.
+
+## Measurement
+
+The required #852 cache-read columns were not available in the live dogfood store inspectable from this workspace on 2026-07-02. The local store reported goose versions only through 6 and `usage_events` did not contain `cached_input_tokens`, `reasoning_output_tokens`, or `model_context_window`, so no dogfood cache-read fraction delta could be measured from persisted rows.
+
+The issue body records the prior Prometheus audit estimate of a 50-80% input reduction on continuation sessions, but this branch does not independently validate that estimate. Before broad adoption, rerun one implement/rework or implement/merge dogfood issue with:
+
+1. dogfood Detent migrated through #852 telemetry,
+2. `agent.experimental_thread_resume` disabled for the baseline dispatch,
+3. the same issue resumed with the flag enabled, and
+4. cache-read fraction compared from #852's usage report columns.
+
+## Validation
+
+The prototype is covered by focused tests for:
+
+- Codex app-server sending `thread/resume` before `turn/start`.
+- Claude Code adding `--resume <session_id>`.
+- Flag-off runner behavior avoiding resume lookup and backend resume args.
+- Resume handshake failure falling back to a fresh backend attempt.
+- Resumed turn failure not retrying after the turn has started.
+- Store lookup selecting only completed code sessions matching issue identity, backend identity, and requested model.

--- a/internal/claudecode/backend_test.go
+++ b/internal/claudecode/backend_test.go
@@ -342,6 +342,55 @@ func TestAgentBackendBuildsCommandArgumentsAndWritesPromptToStdin(t *testing.T) 
 	}
 }
 
+func TestAgentBackendAddsResumeSessionArgument(t *testing.T) {
+	t.Parallel()
+
+	observedPath := filepath.Join(t.TempDir(), "observed.json")
+	backend := newTestBackend(t, Options{
+		CommandFactory: func(ctx context.Context) *exec.Cmd {
+			cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestClaudeCodeHelperProcess", "--")
+			cmd.Env = append(os.Environ(),
+				"CLAUDECODE_HELPER=argv",
+				"CLAUDECODE_OBSERVED_PATH="+observedPath,
+			)
+			return cmd
+		},
+	})
+
+	_, err := backend.RunTurn(context.Background(), runner.AgentTurnRequest{
+		Workspace: t.TempDir(),
+		Prompt:    "continue from prior session",
+		Model:     "fable",
+		Resume: runner.AgentResume{
+			SessionID: "session-existing",
+		},
+	}, nil)
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	var observed helperObservation
+	raw, err := os.ReadFile(observedPath)
+	if err != nil {
+		t.Fatalf("ReadFile() error = %v", err)
+	}
+	if err := json.Unmarshal(raw, &observed); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+
+	wantArgs := []string{
+		"-p", "--output-format", "stream-json", "--verbose",
+		"--model", "fable",
+		"--resume", "session-existing",
+	}
+	if !reflect.DeepEqual(observed.Args, wantArgs) {
+		t.Fatalf("args = %#v, want %#v", observed.Args, wantArgs)
+	}
+	if observed.Stdin != "continue from prior session" {
+		t.Fatalf("stdin = %q, want resume prompt", observed.Stdin)
+	}
+}
+
 func TestAgentBackendRequestTurnTimeoutOverridesOptions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/claudecode/process.go
+++ b/internal/claudecode/process.go
@@ -120,6 +120,9 @@ func (b *AgentBackend) argv(req runner.AgentTurnRequest) []string {
 	if model := strings.TrimSpace(req.Model); model != "" {
 		args = append(args, "--model", model)
 	}
+	if sessionID := strings.TrimSpace(req.Resume.SessionID); sessionID != "" {
+		args = append(args, "--resume", sessionID)
+	}
 	if mode := strings.TrimSpace(b.options.PermissionMode); mode != "" {
 		args = append(args, "--permission-mode", mode)
 	}

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -12,10 +12,11 @@ import (
 )
 
 const (
-	initializeRequestID  = 1
-	threadStartRequestID = 2
-	turnStartRequestID   = 3
-	methodNotFoundCode   = -32601
+	initializeRequestID   = 1
+	threadStartRequestID  = 2
+	turnStartRequestID    = 3
+	threadResumeRequestID = 4
+	methodNotFoundCode    = -32601
 
 	defaultClientName    = "detent-orchestrator"
 	defaultClientTitle   = "Detent Orchestrator"
@@ -49,6 +50,7 @@ type ClientInfo struct {
 type RunTurnRequest struct {
 	Workspace         string
 	Prompt            string
+	ResumeThreadID    string
 	ApprovalPolicy    any
 	ThreadSandbox     string
 	TurnSandboxPolicy any
@@ -203,9 +205,18 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		return RunTurnResult{}, err
 	}
 
-	threadID, model, err := s.startThread(ctx, transport, req, onUpdate)
-	if err != nil {
-		return RunTurnResult{}, err
+	threadID := strings.TrimSpace(req.ResumeThreadID)
+	var model string
+	if threadID != "" {
+		threadID, model, err = s.resumeThread(ctx, transport, req, threadID, onUpdate)
+		if err != nil {
+			return RunTurnResult{}, err
+		}
+	} else {
+		threadID, model, err = s.startThread(ctx, transport, req, onUpdate)
+		if err != nil {
+			return RunTurnResult{}, err
+		}
 	}
 
 	turnID, err := s.startTurn(ctx, transport, req, threadID, onUpdate)
@@ -314,6 +325,71 @@ func (s *AppServer) startThread(
 		response.Model,
 		response.ResolvedModel,
 		response.ModelID,
+	)
+
+	return response.Thread.ID, model, nil
+}
+
+func (s *AppServer) resumeThread(
+	ctx context.Context,
+	transport Transport,
+	req RunTurnRequest,
+	threadID string,
+	onUpdate UpdateHandler,
+) (string, string, error) {
+	params := map[string]any{
+		"threadId": threadID,
+		"cwd":      req.Workspace,
+	}
+	setOptional(params, "approvalPolicy", req.ApprovalPolicy)
+	if req.ThreadSandbox != "" {
+		params["sandbox"] = req.ThreadSandbox
+	}
+	if req.Model != "" {
+		params["model"] = req.Model
+	}
+	if req.ModelProvider != "" {
+		params["modelProvider"] = req.ModelProvider
+	}
+	if req.ServiceTier != "" {
+		params["serviceTier"] = req.ServiceTier
+	}
+
+	if err := sendRequest(ctx, transport, threadResumeRequestID, "thread/resume", params); err != nil {
+		return "", "", err
+	}
+
+	result, err := s.awaitResponse(ctx, transport, threadResumeRequestID, onUpdate)
+	if err != nil {
+		return "", "", err
+	}
+
+	var response struct {
+		Thread struct {
+			ID            string `json:"id"`
+			Model         string `json:"model"`
+			ModelID       string `json:"model_id"`
+			ResolvedModel string `json:"resolvedModel"`
+		} `json:"thread"`
+		Model         string `json:"model"`
+		ModelID       string `json:"model_id"`
+		ResolvedModel string `json:"resolvedModel"`
+	}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return "", "", fmt.Errorf("%w: decode thread/resume result: %w", ErrInvalidResponse, err)
+	}
+	if response.Thread.ID == "" {
+		return "", "", fmt.Errorf("%w: thread/resume result missing thread id", ErrInvalidResponse)
+	}
+
+	model := firstNonBlank(
+		response.Thread.Model,
+		response.Thread.ResolvedModel,
+		response.Thread.ModelID,
+		response.Model,
+		response.ResolvedModel,
+		response.ModelID,
+		req.Model,
 	)
 
 	return response.Thread.ID, model, nil
@@ -726,6 +802,8 @@ func requestName(id int) string {
 		return "thread/start"
 	case turnStartRequestID:
 		return "turn/start"
+	case threadResumeRequestID:
+		return "thread/resume"
 	default:
 		return strconv.Itoa(id)
 	}

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -161,6 +161,64 @@ func TestAppServerRunTurnStartsLifecycleAndStreamsUpdates(t *testing.T) {
 	}
 }
 
+func TestAppServerRunTurnResumesThreadBeforeStartingTurn(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.142.5"}`),
+		responseMessage(t, 4, `{"thread":{"id":"thread-existing","model":"gpt-5-codex-resumed"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-2"}}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-existing","turn":{"id":"turn-2","status":"completed"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	var updates []Update
+	result, err := server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace:      "/tmp/detent-workspace",
+		Prompt:         "Continue issue #18",
+		ResumeThreadID: "thread-existing",
+		Model:          "gpt-5-codex",
+	}, func(update Update) error {
+		updates = append(updates, update)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+	if result.ThreadID != "thread-existing" || result.TurnID != "turn-2" || result.SessionID != "thread-existing-turn-2" {
+		t.Fatalf("RunTurn() result = %#v, want resumed thread and new turn", result)
+	}
+
+	sent := transport.sentMessages()
+	if len(sent) != 4 {
+		t.Fatalf("sent messages = %d, want 4", len(sent))
+	}
+	assertRequest(t, sent[0], 1, "initialize")
+	if sent[1].Method != "initialized" || len(sent[1].ID) != 0 {
+		t.Fatalf("sent[1] = %#v, want initialized notification", sent[1])
+	}
+	assertRequest(t, sent[2], 4, "thread/resume")
+	assertJSONContains(t, sent[2].Params, "threadId", "thread-existing")
+	assertJSONContains(t, sent[2].Params, "cwd", "/tmp/detent-workspace")
+	assertJSONContains(t, sent[2].Params, "model", "gpt-5-codex")
+	assertRequest(t, sent[3], 3, "turn/start")
+	assertJSONContains(t, sent[3].Params, "threadId", "thread-existing")
+	assertJSONContains(t, sent[3].Params, "input.0.text", "Continue issue #18")
+
+	if len(updates) != 2 {
+		t.Fatalf("updates = %d, want turn started and completed: %#v", len(updates), updates)
+	}
+	if updates[0].Type != UpdateTurnStarted || updates[0].ThreadID != "thread-existing" || updates[0].TurnID != "turn-2" || updates[0].Model != "gpt-5-codex-resumed" {
+		t.Fatalf("updates[0] = %#v, want resumed turn started", updates[0])
+	}
+}
+
 func TestAppServerRunTurnRequestTurnTimeoutOverridesDefault(t *testing.T) {
 	t.Parallel()
 

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -35,6 +35,7 @@ func (b *AgentBackend) RunTurn(
 	result, err := b.client.RunTurn(ctx, RunTurnRequest{
 		Workspace:         req.Workspace,
 		Prompt:            req.Prompt,
+		ResumeThreadID:    req.Resume.ThreadID,
 		ApprovalPolicy:    b.options.ApprovalPolicy,
 		ThreadSandbox:     b.options.ThreadSandbox,
 		TurnSandboxPolicy: turnSandboxPolicyForWorkspace(b.options.ThreadSandbox, b.options.TurnSandboxPolicy, req.ExtraWritableRoots),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -193,6 +193,7 @@ type Agent struct {
 	MaxSessionContextMultiplier  float64        `yaml:"max_session_context_multiplier"`
 	MaxSessionTokenOverrideLabel string         `yaml:"max_session_token_override_label"`
 	MaxSessionTokenOverrideField string         `yaml:"max_session_token_override_field"`
+	ExperimentalThreadResume     bool           `yaml:"experimental_thread_resume"`
 	Shutdown                     Shutdown       `yaml:"shutdown"`
 	MaxConcurrentAgentsByState   map[string]int `yaml:"max_concurrent_agents_by_state"`
 	DispatchPriorityByState      []string       `yaml:"dispatch_priority_by_state"`

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -89,6 +89,7 @@ agent:
   max_session_context_multiplier: 3.5
   max_session_token_override_label: Allow-Large-Session
   max_session_token_override_field: Token Override
+  experimental_thread_resume: true
   shutdown:
     drain_timeout_ms: 300000
   max_concurrent_agents_by_state:
@@ -293,6 +294,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Agent.MaxSessionTokenOverrideField != "Token Override" {
 		t.Fatalf("Agent.MaxSessionTokenOverrideField = %q, want Token Override", cfg.Agent.MaxSessionTokenOverrideField)
+	}
+	if !cfg.Agent.ExperimentalThreadResume {
+		t.Fatal("Agent.ExperimentalThreadResume = false, want true")
 	}
 	if cfg.Agent.Shutdown.DrainTimeoutMS != 300000 {
 		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want 300000", cfg.Agent.Shutdown.DrainTimeoutMS)
@@ -569,6 +573,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.MergeFastPath.Enabled {
 		t.Fatal("Agent.MergeFastPath.Enabled = true, want false default")
+	}
+	if cfg.Agent.ExperimentalThreadResume {
+		t.Fatal("Agent.ExperimentalThreadResume = true, want disabled default")
 	}
 	if cfg.Agent.Shutdown.DrainTimeoutMS != DefaultShutdownDrainTimeoutMS {
 		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want %d", cfg.Agent.Shutdown.DrainTimeoutMS, DefaultShutdownDrainTimeoutMS)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -392,6 +392,115 @@ func (r *Runner) prepareMergeFastPath(
 	}
 }
 
+type agentTurnExecution struct {
+	turnResult  AgentTurnResult
+	result      RunResult
+	err         error
+	turnStarted bool
+}
+
+func (r *Runner) runAgentTurn(
+	ctx context.Context,
+	backend AgentBackend,
+	turnRequest AgentTurnRequest,
+	runRequest RunRequest,
+	info workspace.Info,
+	workspaceIssue workspace.Issue,
+	agentConfig config.Agent,
+	runStartedAt time.Time,
+) agentTurnExecution {
+	result := RunResult{FinalState: FinalStateCompleted}
+	progress := newAgentRunProgress()
+	turnStarted := false
+	turnResult, turnErr := backend.RunTurn(ctx, turnRequest, func(update AgentUpdate) error {
+		if update.Type == AgentUpdateTurnStarted || strings.TrimSpace(update.TurnID) != "" {
+			turnStarted = true
+		}
+		r.logAgentUpdate(runRequest.Issue, update)
+		applyAgentUpdate(&result, update)
+		eventAt := r.now()
+		progress.apply(update, eventAt)
+		if err := r.publishRunUpdate(ctx, runRequest, info, workspaceIssue, progress, result, eventAt, runStartedAt); err != nil {
+			return err
+		}
+		if err := r.enforceSessionTokenCeiling(agentConfig, runRequest.Issue, info.Path, update, eventAt); err != nil {
+			return err
+		}
+		return nil
+	})
+	result.Output = progress.outputText()
+	if turnErr != nil {
+		result.FinalState = finalStateForTurnError(turnErr)
+	}
+	return agentTurnExecution{
+		turnResult:  turnResult,
+		result:      result,
+		err:         turnErr,
+		turnStarted: turnStarted,
+	}
+}
+
+func (r *Runner) agentResumeState(
+	ctx context.Context,
+	cfg config.Agent,
+	issue connector.Issue,
+	model string,
+	backendID string,
+	backendKind string,
+	agentRole string,
+) store.AgentResumeState {
+	if !cfg.ExperimentalThreadResume {
+		return store.AgentResumeState{}
+	}
+	model = strings.TrimSpace(model)
+	backendID = strings.TrimSpace(backendID)
+	backendKind = strings.TrimSpace(backendKind)
+	agentRole = strings.TrimSpace(agentRole)
+	if model == "" || backendID == "" || backendKind == "" || agentRole == "" {
+		return store.AgentResumeState{}
+	}
+	resumeStore, ok := r.store.(store.AgentResumeStore)
+	if !ok {
+		return store.AgentResumeState{}
+	}
+	state, err := resumeStore.LatestCompletedAgentResumeState(ctx, store.AgentResumeLookup{
+		IssueID:          issue.ID,
+		Identifier:       issue.Identifier,
+		IssueURL:         issue.URL,
+		RequestedModel:   model,
+		AgentBackendID:   backendID,
+		AgentBackendKind: backendKind,
+		AgentRole:        agentRole,
+	})
+	if err != nil {
+		if !errors.Is(err, store.ErrNotFound) {
+			r.logger.Warn(
+				"agent resume state lookup failed",
+				slog.String("issue_id", issue.ID),
+				slog.String("issue_identifier", issue.Identifier),
+				slog.String("model", model),
+				slog.String("backend_id", backendID),
+				slog.String("backend_kind", backendKind),
+				slog.String("agent_role", agentRole),
+				slog.Any("error", err),
+			)
+		}
+		return store.AgentResumeState{}
+	}
+	return state
+}
+
+func agentResumeFromState(state store.AgentResumeState) AgentResume {
+	return AgentResume{
+		ThreadID:  strings.TrimSpace(state.ProviderThreadID),
+		SessionID: strings.TrimSpace(state.ProviderSessionID),
+	}
+}
+
+func agentResumeEmpty(resume AgentResume) bool {
+	return strings.TrimSpace(resume.ThreadID) == "" && strings.TrimSpace(resume.SessionID) == ""
+}
+
 func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if ctx == nil {
 		ctx = context.Background()
@@ -488,7 +597,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		)
 		return result, nil
 	}
-	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, sessionModel)
+	resumeState := r.agentResumeState(ctx, workflow.Config.Agent, req.Issue, sessionModel, selection.BackendID, backendKind, RoleCode)
+	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, sessionModel, selection.BackendID, backendKind, RoleCode)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -501,31 +611,31 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"model", sessionModel,
 		"mode", mode,
 	)
-	result := RunResult{FinalState: FinalStateCompleted}
-	progress := newAgentRunProgress()
-	turnResult, turnErr := backend.RunTurn(ctx, AgentTurnRequest{
+	turnRequest := AgentTurnRequest{
 		Workspace:          info.Path,
 		Prompt:             prompt,
 		Model:              selectedModel,
+		Resume:             agentResumeFromState(resumeState),
 		ExtraWritableRoots: extraWritableRootsForWorkspace(ctx, info.Path, r.logger),
-	}, func(update AgentUpdate) error {
-		r.logAgentUpdate(req.Issue, update)
-		applyAgentUpdate(&result, update)
-		eventAt := r.now()
-		progress.apply(update, eventAt)
-		if err := r.publishRunUpdate(ctx, req, info, workspaceIssue, progress, result, eventAt, runStartedAt); err != nil {
-			return err
-		}
-		if err := r.enforceSessionTokenCeiling(workflow.Config.Agent, req.Issue, info.Path, update, eventAt); err != nil {
-			return err
-		}
-		return nil
-	})
-	_ = turnResult
-	result.Output = progress.outputText()
-	if turnErr != nil {
-		result.FinalState = finalStateForTurnError(turnErr)
 	}
+	execution := r.runAgentTurn(ctx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, runStartedAt)
+	if execution.err != nil && !agentResumeEmpty(turnRequest.Resume) && !execution.turnStarted {
+		r.logWorkerEvent(req.Issue, "worker_resume_failed_fallback",
+			"workspace_path", info.Path,
+			"backend_id", selection.BackendID,
+			"route", selection.RouteName,
+			"role", RoleCode,
+			"thread_id", turnRequest.Resume.ThreadID,
+			"provider_session_id", turnRequest.Resume.SessionID,
+			"error", errorString(execution.err),
+		)
+		turnRequest.Resume = AgentResume{}
+		resumeState = store.AgentResumeState{}
+		execution = r.runAgentTurn(ctx, backend, turnRequest, req, info, workspaceIssue, workflow.Config.Agent, runStartedAt)
+	}
+	turnResult := execution.turnResult
+	turnErr := execution.err
+	result := execution.result
 	r.logWorkerEvent(req.Issue, "worker_command_finished",
 		"workspace_path", info.Path,
 		"backend_id", selection.BackendID,
@@ -552,7 +662,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("run agent turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1, turnResult, resumeState.DetentSessionID),
 		)
 	}
 
@@ -569,7 +679,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			)
 			finishedAt := r.now().UTC()
 			result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1); err != nil {
+			if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1, turnResult, resumeState.DetentSessionID); err != nil {
 				return result, err
 			}
 			return result, nil
@@ -582,14 +692,14 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
 		return result, errors.Join(
 			fmt.Errorf("workspace diff stat: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1, turnResult, resumeState.DetentSessionID),
 		)
 	}
 
 	result.DiffStats = diffStatsFromWorkspace(diffStat)
 	finishedAt := r.now().UTC()
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, finishedAt)
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, result, sessionModel, backendKind, 1, turnResult, resumeState.DetentSessionID); err != nil {
 		return result, err
 	}
 	return result, nil
@@ -702,7 +812,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		startedAt = r.now().UTC()
 	}
 	runStartedAt := r.now()
-	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, sessionModel)
+	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, sessionModel, selection.BackendID, backendKind, RoleValidator)
 	if err != nil {
 		return gate.ValidatorResult{}, err
 	}
@@ -745,7 +855,6 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		}
 		return nil
 	})
-	_ = turnResult
 	r.logWorkerEvent(req.Issue, "worker_check_finished",
 		"workspace_path", info.Path,
 		"backend_id", selection.BackendID,
@@ -768,7 +877,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = finalStateForTurnError(turnErr)
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("run validator turn: %w", turnErr),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendKind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendKind, 1, turnResult, 0),
 		)
 	}
 
@@ -777,10 +886,10 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		runResult.FinalState = FinalStateFailed
 		return gate.ValidatorResult{}, errors.Join(
 			fmt.Errorf("parse validator result: %w", err),
-			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendKind, 1),
+			r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendKind, 1, turnResult, 0),
 		)
 	}
-	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendKind, 1); err != nil {
+	if err := r.finishSession(ctx, sessionID, sessionStarted, req.Issue, startedAt, finishedAt, runResult, sessionModel, backendKind, 1, turnResult, 0); err != nil {
 		return gate.ValidatorResult{}, err
 	}
 	return validation, nil
@@ -1010,17 +1119,24 @@ func (r *Runner) startSession(
 	issue connector.Issue,
 	startedAt time.Time,
 	model string,
+	backendID string,
+	backendKind string,
+	agentRole string,
 ) (int64, bool, error) {
 	if r.store == nil {
 		return 0, false, nil
 	}
 
 	sessionID, err := r.store.StartSession(ctx, store.SessionStart{
-		IssueID:    issue.ID,
-		Identifier: issue.Identifier,
-		IssueURL:   issue.URL,
-		StartedAt:  startedAt,
-		Model:      model,
+		IssueID:          issue.ID,
+		Identifier:       issue.Identifier,
+		IssueURL:         issue.URL,
+		StartedAt:        startedAt,
+		Model:            model,
+		RequestedModel:   model,
+		AgentBackendID:   backendID,
+		AgentBackendKind: backendKind,
+		AgentRole:        agentRole,
 	})
 	if err != nil {
 		return 0, false, fmt.Errorf("start agent session: %w", err)
@@ -1043,6 +1159,8 @@ func (r *Runner) finishSession(
 	model string,
 	backendKind string,
 	turns int64,
+	turnResult AgentTurnResult,
+	resumedFromSessionID int64,
 ) error {
 	if !started {
 		return nil
@@ -1064,6 +1182,9 @@ func (r *Runner) finishSession(
 		RuntimeSeconds:        int64(math.Round(result.Tokens.RuntimeSeconds)),
 		FinalState:            result.FinalState,
 		Model:                 model,
+		ProviderThreadID:      turnResult.ThreadID,
+		ProviderSessionID:     turnResult.SessionID,
+		ResumedFromSessionID:  resumedFromSessionID,
 	}); err != nil {
 		return fmt.Errorf("finish agent session: %w", err)
 	}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -246,11 +246,14 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 			t.Fatalf("codex prompt missing %q:\n%s", want, codexClient.request.Prompt)
 		}
 	}
-	if sessionStore.started.Identifier != "digitaldrywood/detent#22" || sessionStore.started.Model != "gpt-5-codex-high" {
-		t.Fatalf("SessionStart = %#v, want issue identity and model", sessionStore.started)
+	if sessionStore.started.Identifier != "digitaldrywood/detent#22" || sessionStore.started.Model != "gpt-5-codex-high" || sessionStore.started.AgentRole != RoleCode {
+		t.Fatalf("SessionStart = %#v, want issue identity, model, and code role", sessionStore.started)
 	}
 	if sessionStore.finished.FinalState != FinalStateCompleted || sessionStore.finished.TotalTokens != 125 || sessionStore.finished.Turns != 1 || sessionStore.finished.Model != "gpt-5-codex-resolved" {
 		t.Fatalf("SessionFinish = %#v, want completed session with tokens", sessionStore.finished)
+	}
+	if sessionStore.finished.ProviderThreadID != "thread-1" || sessionStore.finished.ProviderSessionID != "thread-1-turn-1" {
+		t.Fatalf("SessionFinish provider IDs = %#v, want thread-1/thread-1-turn-1", sessionStore.finished)
 	}
 	if sessionStore.finished.CachedInputTokens != 40 || sessionStore.finished.ReasoningOutputTokens != 7 {
 		t.Fatalf("SessionFinish cached/reasoning = %#v, want 40/7", sessionStore.finished)
@@ -396,6 +399,186 @@ func TestRunnerRunRefusesDispatchWhenBudgetExceeded(t *testing.T) {
 	}
 	if estimator.model != "gpt-budget" {
 		t.Fatalf("estimator model = %q, want gpt-budget", estimator.model)
+	}
+}
+
+func TestRunnerRunLeavesThreadResumeDisabledByDefault(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 2, 16, 0, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-859", Branch: "detent/issue-859"},
+	}
+	agentBackend := &fakeCodexClient{
+		result: AgentTurnResult{ThreadID: "thread-fresh", TurnID: "turn-1", SessionID: "thread-fresh-turn-1"},
+	}
+	sessionStore := &fakeSessionStore{
+		sessionID: 859,
+		resumeState: store.AgentResumeState{
+			DetentSessionID:   100,
+			ProviderThreadID:  "thread-old",
+			ProviderSessionID: "session-old",
+		},
+	}
+
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: config.Config{}, Prompt: "Work"},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		Store:        sessionStore,
+		Now:          newFakeClock(startedAt, startedAt.Add(time.Second)).Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-859",
+			Identifier:    "digitaldrywood/detent#859",
+			Title:         "Thread resume spike",
+			ModelOverride: "gpt-5-codex",
+		},
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if sessionStore.resumeLookups != 0 {
+		t.Fatalf("resume lookups = %d, want 0 with flag disabled", sessionStore.resumeLookups)
+	}
+	if !agentResumeEmpty(agentBackend.request.Resume) {
+		t.Fatalf("AgentTurnRequest.Resume = %#v, want empty with flag disabled", agentBackend.request.Resume)
+	}
+}
+
+func TestRunnerRunFallsBackFreshWhenResumeFails(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 2, 16, 30, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-859", Branch: "detent/issue-859"},
+	}
+	agentBackend := &resumeFallbackAgentBackend{}
+	sessionStore := &fakeSessionStore{
+		sessionID: 860,
+		resumeState: store.AgentResumeState{
+			DetentSessionID:   100,
+			ProviderThreadID:  "thread-old",
+			ProviderSessionID: "session-old",
+		},
+	}
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agent: config.Agent{ExperimentalThreadResume: true},
+			},
+			Prompt: "Work",
+		},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		Store:        sessionStore,
+		Now:          newFakeClock(startedAt, startedAt.Add(time.Second)).Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-859",
+			Identifier:    "digitaldrywood/detent#859",
+			Title:         "Thread resume spike",
+			ModelOverride: "gpt-5-codex",
+		},
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v, want fresh fallback success", err)
+	}
+	if result.FinalState != FinalStateCompleted {
+		t.Fatalf("FinalState = %q, want completed", result.FinalState)
+	}
+	if sessionStore.resumeLookups != 1 {
+		t.Fatalf("resume lookups = %d, want 1", sessionStore.resumeLookups)
+	}
+	if sessionStore.resumeLookup.AgentRole != RoleCode {
+		t.Fatalf("resume lookup role = %q, want code", sessionStore.resumeLookup.AgentRole)
+	}
+	if len(agentBackend.requests) != 2 {
+		t.Fatalf("backend requests = %d, want resumed attempt plus fresh fallback", len(agentBackend.requests))
+	}
+	if agentBackend.requests[0].Resume.ThreadID != "thread-old" || agentBackend.requests[0].Resume.SessionID != "session-old" {
+		t.Fatalf("first request resume = %#v, want stored resume IDs", agentBackend.requests[0].Resume)
+	}
+	if !agentResumeEmpty(agentBackend.requests[1].Resume) {
+		t.Fatalf("second request resume = %#v, want fresh fallback", agentBackend.requests[1].Resume)
+	}
+	if sessionStore.finished.ProviderThreadID != "thread-fresh" || sessionStore.finished.ProviderSessionID != "session-fresh" {
+		t.Fatalf("SessionFinish provider IDs = %#v, want fresh IDs", sessionStore.finished)
+	}
+	if sessionStore.finished.ResumedFromSessionID != 0 {
+		t.Fatalf("SessionFinish.ResumedFromSessionID = %d, want 0 after fallback", sessionStore.finished.ResumedFromSessionID)
+	}
+}
+
+func TestRunnerRunDoesNotFallbackAfterResumedTurnStarts(t *testing.T) {
+	t.Parallel()
+
+	startedAt := time.Date(2026, 7, 2, 16, 45, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-859", Branch: "detent/issue-859"},
+	}
+	agentBackend := &resumeStartedFailureAgentBackend{}
+	sessionStore := &fakeSessionStore{
+		sessionID: 861,
+		resumeState: store.AgentResumeState{
+			DetentSessionID:   100,
+			ProviderThreadID:  "thread-old",
+			ProviderSessionID: "session-old",
+		},
+	}
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agent: config.Agent{ExperimentalThreadResume: true},
+			},
+			Prompt: "Work",
+		},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		Store:        sessionStore,
+		Now:          newFakeClock(startedAt, startedAt.Add(time.Second)).Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:            "issue-859",
+			Identifier:    "digitaldrywood/detent#859",
+			Title:         "Thread resume spike",
+			ModelOverride: "gpt-5-codex",
+		},
+		StartedAt: startedAt,
+	})
+	if err == nil {
+		t.Fatal("Run() error = nil, want resumed turn failure")
+	}
+	if len(agentBackend.requests) != 1 {
+		t.Fatalf("backend requests = %d, want no fresh fallback after turn start", len(agentBackend.requests))
+	}
+	if agentBackend.requests[0].Resume.ThreadID != "thread-old" || agentBackend.requests[0].Resume.SessionID != "session-old" {
+		t.Fatalf("request resume = %#v, want stored resume IDs", agentBackend.requests[0].Resume)
+	}
+	if sessionStore.finished.FinalState != FinalStateFailed {
+		t.Fatalf("SessionFinish.FinalState = %q, want failed", sessionStore.finished.FinalState)
+	}
+	if sessionStore.finished.ResumedFromSessionID != 100 {
+		t.Fatalf("SessionFinish.ResumedFromSessionID = %d, want resumed source", sessionStore.finished.ResumedFromSessionID)
 	}
 }
 
@@ -2190,6 +2373,52 @@ func (c *fakeCodexClient) RunTurn(_ context.Context, req AgentTurnRequest, onUpd
 	return c.result, c.err
 }
 
+type resumeFallbackAgentBackend struct {
+	requests []AgentTurnRequest
+}
+
+func (b *resumeFallbackAgentBackend) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	b.requests = append(b.requests, req)
+	if !agentResumeEmpty(req.Resume) {
+		return AgentTurnResult{}, errors.New("resume failed")
+	}
+	if onUpdate != nil {
+		if err := onUpdate(AgentUpdate{
+			Type:     AgentUpdateTokenUsage,
+			ThreadID: "thread-fresh",
+			TurnID:   "turn-fresh",
+			Model:    "gpt-5-codex",
+			Tokens: AgentTokenUsage{
+				InputTokens:  10,
+				OutputTokens: 5,
+				TotalTokens:  15,
+			},
+		}); err != nil {
+			return AgentTurnResult{}, err
+		}
+	}
+	return AgentTurnResult{ThreadID: "thread-fresh", TurnID: "turn-fresh", SessionID: "session-fresh"}, nil
+}
+
+type resumeStartedFailureAgentBackend struct {
+	requests []AgentTurnRequest
+}
+
+func (b *resumeStartedFailureAgentBackend) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	b.requests = append(b.requests, req)
+	if onUpdate != nil {
+		if err := onUpdate(AgentUpdate{
+			Type:     AgentUpdateTurnStarted,
+			ThreadID: "thread-old",
+			TurnID:   "turn-old",
+			Model:    "gpt-5-codex",
+		}); err != nil {
+			return AgentTurnResult{}, err
+		}
+	}
+	return AgentTurnResult{ThreadID: "thread-old", TurnID: "turn-old", SessionID: "session-old"}, errors.New("resumed turn failed")
+}
+
 type cancelingCodexClient struct {
 	cancel context.CancelFunc
 }
@@ -2200,14 +2429,18 @@ func (c *cancelingCodexClient) RunTurn(context.Context, AgentTurnRequest, AgentU
 }
 
 type fakeSessionStore struct {
-	sessionID   int64
-	started     store.SessionStart
-	finished    store.SessionFinish
-	usage       store.UsageEvent
-	phase       store.WorkflowPhaseEvent
-	startCalls  int
-	finishCalls int
-	usageCalls  int
+	sessionID     int64
+	started       store.SessionStart
+	finished      store.SessionFinish
+	usage         store.UsageEvent
+	phase         store.WorkflowPhaseEvent
+	startCalls    int
+	finishCalls   int
+	usageCalls    int
+	resumeState   store.AgentResumeState
+	resumeErr     error
+	resumeLookups int
+	resumeLookup  store.AgentResumeLookup
 }
 
 func (s *fakeSessionStore) StartSession(_ context.Context, attrs store.SessionStart) (int64, error) {
@@ -2275,6 +2508,18 @@ func (s *fakeRunnerBudgetSpendStore) DailyTokenSpend(context.Context, time.Time)
 func (s *fakeRunnerBudgetSpendStore) IssueTokenSpend(context.Context, store.IssueIdentity) (store.TokenSpend, error) {
 	s.issueCalls++
 	return s.issue, nil
+}
+
+func (s *fakeSessionStore) LatestCompletedAgentResumeState(_ context.Context, attrs store.AgentResumeLookup) (store.AgentResumeState, error) {
+	s.resumeLookups++
+	s.resumeLookup = attrs
+	if s.resumeErr != nil {
+		return store.AgentResumeState{}, s.resumeErr
+	}
+	if s.resumeState.DetentSessionID == 0 && s.resumeState.ProviderThreadID == "" && s.resumeState.ProviderSessionID == "" {
+		return store.AgentResumeState{}, store.ErrNotFound
+	}
+	return s.resumeState, nil
 }
 
 type fakeClock struct {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -54,8 +54,14 @@ type AgentTurnRequest struct {
 	Workspace          string
 	Prompt             string
 	Model              string
+	Resume             AgentResume
 	TurnTimeout        time.Duration
 	ExtraWritableRoots []string
+}
+
+type AgentResume struct {
+	ThreadID  string
+	SessionID string
 }
 
 type AgentTurnResult struct {

--- a/internal/store/migrations/00009_add_agent_resume_state.sql
+++ b/internal/store/migrations/00009_add_agent_resume_state.sql
@@ -1,0 +1,48 @@
+-- +goose Up
+ALTER TABLE codex_sessions
+ADD COLUMN requested_model TEXT;
+
+ALTER TABLE codex_sessions
+ADD COLUMN agent_backend_id TEXT;
+
+ALTER TABLE codex_sessions
+ADD COLUMN agent_backend_kind TEXT;
+
+ALTER TABLE codex_sessions
+ADD COLUMN agent_role TEXT;
+
+ALTER TABLE codex_sessions
+ADD COLUMN provider_thread_id TEXT;
+
+ALTER TABLE codex_sessions
+ADD COLUMN provider_session_id TEXT;
+
+ALTER TABLE codex_sessions
+ADD COLUMN resumed_from_session_id INTEGER;
+
+CREATE INDEX codex_sessions_resume_lookup_idx
+ON codex_sessions(identifier, issue_id, issue_url, agent_backend_id, agent_backend_kind, agent_role, requested_model, completed_at DESC, id DESC);
+
+-- +goose Down
+DROP INDEX IF EXISTS codex_sessions_resume_lookup_idx;
+
+ALTER TABLE codex_sessions
+DROP COLUMN resumed_from_session_id;
+
+ALTER TABLE codex_sessions
+DROP COLUMN provider_session_id;
+
+ALTER TABLE codex_sessions
+DROP COLUMN provider_thread_id;
+
+ALTER TABLE codex_sessions
+DROP COLUMN agent_backend_kind;
+
+ALTER TABLE codex_sessions
+DROP COLUMN agent_role;
+
+ALTER TABLE codex_sessions
+DROP COLUMN agent_backend_id;
+
+ALTER TABLE codex_sessions
+DROP COLUMN requested_model;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -26,6 +26,13 @@ type CodexSession struct {
 	CachedInputTokens     sql.NullInt64  `json:"cached_input_tokens"`
 	ReasoningOutputTokens sql.NullInt64  `json:"reasoning_output_tokens"`
 	ModelContextWindow    sql.NullInt64  `json:"model_context_window"`
+	RequestedModel        sql.NullString `json:"requested_model"`
+	AgentBackendID        sql.NullString `json:"agent_backend_id"`
+	AgentBackendKind      sql.NullString `json:"agent_backend_kind"`
+	AgentRole             sql.NullString `json:"agent_role"`
+	ProviderThreadID      sql.NullString `json:"provider_thread_id"`
+	ProviderSessionID     sql.NullString `json:"provider_session_id"`
+	ResumedFromSessionID  sql.NullInt64  `json:"resumed_from_session_id"`
 }
 
 type DetentRun struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -193,6 +193,10 @@ INSERT INTO codex_sessions (
   identifier,
   issue_url,
   started_at,
+  requested_model,
+  agent_backend_id,
+  agent_backend_kind,
+  agent_role,
   completed_at,
   turns,
   input_tokens,
@@ -203,9 +207,12 @@ INSERT INTO codex_sessions (
   model_context_window,
   runtime_seconds,
   final_state,
-  model
-) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window
+  model,
+  provider_thread_id,
+  provider_session_id,
+  resumed_from_session_id
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id
 `
 
 type CreateCodexSessionParams struct {
@@ -214,6 +221,10 @@ type CreateCodexSessionParams struct {
 	Identifier            sql.NullString `json:"identifier"`
 	IssueURL              sql.NullString `json:"issue_url"`
 	StartedAt             sql.NullString `json:"started_at"`
+	RequestedModel        sql.NullString `json:"requested_model"`
+	AgentBackendID        sql.NullString `json:"agent_backend_id"`
+	AgentBackendKind      sql.NullString `json:"agent_backend_kind"`
+	AgentRole             sql.NullString `json:"agent_role"`
 	CompletedAt           sql.NullString `json:"completed_at"`
 	Turns                 int64          `json:"turns"`
 	InputTokens           int64          `json:"input_tokens"`
@@ -225,6 +236,9 @@ type CreateCodexSessionParams struct {
 	RuntimeSeconds        int64          `json:"runtime_seconds"`
 	FinalState            sql.NullString `json:"final_state"`
 	Model                 sql.NullString `json:"model"`
+	ProviderThreadID      sql.NullString `json:"provider_thread_id"`
+	ProviderSessionID     sql.NullString `json:"provider_session_id"`
+	ResumedFromSessionID  sql.NullInt64  `json:"resumed_from_session_id"`
 }
 
 func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSessionParams) (CodexSession, error) {
@@ -234,6 +248,10 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		arg.Identifier,
 		arg.IssueURL,
 		arg.StartedAt,
+		arg.RequestedModel,
+		arg.AgentBackendID,
+		arg.AgentBackendKind,
+		arg.AgentRole,
 		arg.CompletedAt,
 		arg.Turns,
 		arg.InputTokens,
@@ -245,6 +263,9 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		arg.RuntimeSeconds,
 		arg.FinalState,
 		arg.Model,
+		arg.ProviderThreadID,
+		arg.ProviderSessionID,
+		arg.ResumedFromSessionID,
 	)
 	var i CodexSession
 	err := row.Scan(
@@ -265,6 +286,13 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.CachedInputTokens,
 		&i.ReasoningOutputTokens,
 		&i.ModelContextWindow,
+		&i.RequestedModel,
+		&i.AgentBackendID,
+		&i.AgentBackendKind,
+		&i.AgentRole,
+		&i.ProviderThreadID,
+		&i.ProviderSessionID,
+		&i.ResumedFromSessionID,
 	)
 	return i, err
 }
@@ -830,18 +858,21 @@ func (q *Queries) DailyTokenSpend(ctx context.Context, completedAt sql.NullStrin
 
 const finishCodexSession = `-- name: FinishCodexSession :execrows
 UPDATE codex_sessions
-SET completed_at = ?,
-    turns = ?,
-    input_tokens = ?,
-    cached_input_tokens = ?,
-    output_tokens = ?,
-    reasoning_output_tokens = ?,
-    total_tokens = ?,
-    model_context_window = COALESCE(?, model_context_window),
-    runtime_seconds = ?,
-    final_state = ?,
-    model = COALESCE(?, model)
-WHERE id = ?
+SET completed_at = ?1,
+    turns = ?2,
+    input_tokens = ?3,
+    cached_input_tokens = ?4,
+    output_tokens = ?5,
+    reasoning_output_tokens = ?6,
+    total_tokens = ?7,
+    model_context_window = COALESCE(?8, model_context_window),
+    runtime_seconds = ?9,
+    final_state = ?10,
+    model = COALESCE(?11, model),
+    provider_thread_id = COALESCE(?12, provider_thread_id),
+    provider_session_id = COALESCE(?13, provider_session_id),
+    resumed_from_session_id = COALESCE(?14, resumed_from_session_id)
+WHERE id = ?15
 `
 
 type FinishCodexSessionParams struct {
@@ -856,6 +887,9 @@ type FinishCodexSessionParams struct {
 	RuntimeSeconds        int64          `json:"runtime_seconds"`
 	FinalState            sql.NullString `json:"final_state"`
 	Model                 sql.NullString `json:"model"`
+	ProviderThreadID      sql.NullString `json:"provider_thread_id"`
+	ProviderSessionID     sql.NullString `json:"provider_session_id"`
+	ResumedFromSessionID  sql.NullInt64  `json:"resumed_from_session_id"`
 	ID                    int64          `json:"id"`
 }
 
@@ -872,6 +906,9 @@ func (q *Queries) FinishCodexSession(ctx context.Context, arg FinishCodexSession
 		arg.RuntimeSeconds,
 		arg.FinalState,
 		arg.Model,
+		arg.ProviderThreadID,
+		arg.ProviderSessionID,
+		arg.ResumedFromSessionID,
 		arg.ID,
 	)
 	if err != nil {
@@ -881,7 +918,7 @@ func (q *Queries) FinishCodexSession(ctx context.Context, arg FinishCodexSession
 }
 
 const getCodexSession = `-- name: GetCodexSession :one
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id
 FROM codex_sessions
 WHERE id = ?
 `
@@ -907,6 +944,13 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.CachedInputTokens,
 		&i.ReasoningOutputTokens,
 		&i.ModelContextWindow,
+		&i.RequestedModel,
+		&i.AgentBackendID,
+		&i.AgentBackendKind,
+		&i.AgentRole,
+		&i.ProviderThreadID,
+		&i.ProviderSessionID,
+		&i.ResumedFromSessionID,
 	)
 	return i, err
 }
@@ -931,6 +975,81 @@ func (q *Queries) GetDetentRun(ctx context.Context, id int64) (DetentRun, error)
 		&i.OutputTokens,
 		&i.TotalTokens,
 		&i.RuntimeSeconds,
+	)
+	return i, err
+}
+
+const getLatestCompletedAgentResumeState = `-- name: GetLatestCompletedAgentResumeState :one
+SELECT
+  id,
+  CAST(COALESCE(provider_thread_id, '') AS TEXT) AS provider_thread_id,
+  CAST(COALESCE(provider_session_id, '') AS TEXT) AS provider_session_id,
+  CAST(COALESCE(requested_model, '') AS TEXT) AS requested_model,
+  CAST(COALESCE(model, '') AS TEXT) AS model,
+  CAST(COALESCE(agent_backend_id, '') AS TEXT) AS agent_backend_id,
+  CAST(COALESCE(agent_backend_kind, '') AS TEXT) AS agent_backend_kind,
+  CAST(COALESCE(agent_role, '') AS TEXT) AS agent_role,
+  CAST(completed_at AS TEXT) AS completed_at
+FROM codex_sessions
+WHERE completed_at IS NOT NULL
+  AND lower(trim(COALESCE(final_state, ''))) = 'completed'
+  AND (COALESCE(provider_thread_id, '') != '' OR COALESCE(provider_session_id, '') != '')
+  AND COALESCE(agent_backend_id, '') = ?1
+  AND COALESCE(agent_backend_kind, '') = ?2
+  AND COALESCE(agent_role, '') = ?3
+  AND COALESCE(NULLIF(requested_model, ''), COALESCE(model, '')) = ?4
+  AND (
+    (?5 != '' AND COALESCE(issue_id, '') = ?5)
+    OR (?6 != '' AND COALESCE(identifier, '') = ?6)
+    OR (?7 != '' AND COALESCE(issue_url, '') = ?7)
+  )
+ORDER BY completed_at DESC, id DESC
+LIMIT 1
+`
+
+type GetLatestCompletedAgentResumeStateParams struct {
+	AgentBackendID   sql.NullString `json:"agent_backend_id"`
+	AgentBackendKind sql.NullString `json:"agent_backend_kind"`
+	AgentRole        sql.NullString `json:"agent_role"`
+	RequestedModel   sql.NullString `json:"requested_model"`
+	IssueID          interface{}    `json:"issue_id"`
+	Identifier       interface{}    `json:"identifier"`
+	IssueURL         interface{}    `json:"issue_url"`
+}
+
+type GetLatestCompletedAgentResumeStateRow struct {
+	ID                int64  `json:"id"`
+	ProviderThreadID  string `json:"provider_thread_id"`
+	ProviderSessionID string `json:"provider_session_id"`
+	RequestedModel    string `json:"requested_model"`
+	Model             string `json:"model"`
+	AgentBackendID    string `json:"agent_backend_id"`
+	AgentBackendKind  string `json:"agent_backend_kind"`
+	AgentRole         string `json:"agent_role"`
+	CompletedAt       string `json:"completed_at"`
+}
+
+func (q *Queries) GetLatestCompletedAgentResumeState(ctx context.Context, arg GetLatestCompletedAgentResumeStateParams) (GetLatestCompletedAgentResumeStateRow, error) {
+	row := q.db.QueryRowContext(ctx, getLatestCompletedAgentResumeState,
+		arg.AgentBackendID,
+		arg.AgentBackendKind,
+		arg.AgentRole,
+		arg.RequestedModel,
+		arg.IssueID,
+		arg.Identifier,
+		arg.IssueURL,
+	)
+	var i GetLatestCompletedAgentResumeStateRow
+	err := row.Scan(
+		&i.ID,
+		&i.ProviderThreadID,
+		&i.ProviderSessionID,
+		&i.RequestedModel,
+		&i.Model,
+		&i.AgentBackendID,
+		&i.AgentBackendKind,
+		&i.AgentRole,
+		&i.CompletedAt,
 	)
 	return i, err
 }
@@ -1329,7 +1448,7 @@ func (q *Queries) ListFairShareUsage(ctx context.Context) ([]FairShareUsage, err
 }
 
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?
@@ -1362,6 +1481,13 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.CachedInputTokens,
 			&i.ReasoningOutputTokens,
 			&i.ModelContextWindow,
+			&i.RequestedModel,
+			&i.AgentBackendID,
+			&i.AgentBackendKind,
+			&i.AgentRole,
+			&i.ProviderThreadID,
+			&i.ProviderSessionID,
+			&i.ResumedFromSessionID,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -186,17 +186,28 @@ func (s *sqliteStore) StartSession(ctx context.Context, attrs SessionStart) (int
 	if err != nil {
 		return 0, err
 	}
+	requestedModel := strings.TrimSpace(attrs.RequestedModel)
+	if requestedModel == "" {
+		requestedModel = strings.TrimSpace(attrs.Model)
+	}
 
 	session, err := s.queries.CreateCodexSession(ctx, sqlc.CreateCodexSessionParams{
-		RunID:              nullPositiveInt64(attrs.RunID),
-		IssueID:            nullString(attrs.IssueID),
-		Identifier:         nullString(attrs.Identifier),
-		IssueURL:           nullString(attrs.IssueURL),
-		StartedAt:          sql.NullString{String: startedAt, Valid: true},
-		CompletedAt:        sql.NullString{},
-		ModelContextWindow: sql.NullInt64{},
-		FinalState:         sql.NullString{},
-		Model:              nullString(attrs.Model),
+		RunID:                nullPositiveInt64(attrs.RunID),
+		IssueID:              nullString(attrs.IssueID),
+		Identifier:           nullString(attrs.Identifier),
+		IssueURL:             nullString(attrs.IssueURL),
+		StartedAt:            sql.NullString{String: startedAt, Valid: true},
+		RequestedModel:       nullString(requestedModel),
+		AgentBackendID:       nullString(attrs.AgentBackendID),
+		AgentBackendKind:     nullString(attrs.AgentBackendKind),
+		AgentRole:            nullString(attrs.AgentRole),
+		CompletedAt:          sql.NullString{},
+		ModelContextWindow:   sql.NullInt64{},
+		FinalState:           sql.NullString{},
+		Model:                nullString(attrs.Model),
+		ProviderThreadID:     sql.NullString{},
+		ProviderSessionID:    sql.NullString{},
+		ResumedFromSessionID: sql.NullInt64{},
 	})
 	if err != nil {
 		return 0, fmt.Errorf("starting codex session: %w", err)
@@ -222,12 +233,68 @@ func (s *sqliteStore) FinishSession(ctx context.Context, sessionID int64, attrs 
 		RuntimeSeconds:        nonNegative(attrs.RuntimeSeconds),
 		FinalState:            nullString(attrs.FinalState),
 		Model:                 nullString(attrs.Model),
+		ProviderThreadID:      nullString(attrs.ProviderThreadID),
+		ProviderSessionID:     nullString(attrs.ProviderSessionID),
+		ResumedFromSessionID:  nullPositiveInt64(attrs.ResumedFromSessionID),
 		ID:                    sessionID,
 	})
 	if err != nil {
 		return fmt.Errorf("finishing codex session: %w", err)
 	}
 	return requireAffected(rows, "codex session", sessionID)
+}
+
+func (s *sqliteStore) LatestCompletedAgentResumeState(ctx context.Context, attrs AgentResumeLookup) (AgentResumeState, error) {
+	attrs = normalizeAgentResumeLookup(attrs)
+	if attrs.RequestedModel == "" || attrs.AgentBackendID == "" || attrs.AgentBackendKind == "" || attrs.AgentRole == "" {
+		return AgentResumeState{}, ErrNotFound
+	}
+	if attrs.IssueID == "" && attrs.Identifier == "" && attrs.IssueURL == "" {
+		return AgentResumeState{}, ErrNotFound
+	}
+
+	row, err := s.queries.GetLatestCompletedAgentResumeState(ctx, sqlc.GetLatestCompletedAgentResumeStateParams{
+		AgentBackendID:   nullString(attrs.AgentBackendID),
+		AgentBackendKind: nullString(attrs.AgentBackendKind),
+		AgentRole:        nullString(attrs.AgentRole),
+		RequestedModel:   nullString(attrs.RequestedModel),
+		IssueID:          attrs.IssueID,
+		Identifier:       attrs.Identifier,
+		IssueURL:         attrs.IssueURL,
+	})
+	if err != nil {
+		if errors.Is(err, sql.ErrNoRows) {
+			return AgentResumeState{}, ErrNotFound
+		}
+		return AgentResumeState{}, fmt.Errorf("reading latest agent resume state: %w", err)
+	}
+	completedAt, err := parseTimestamp("completed_at", row.CompletedAt)
+	if err != nil {
+		return AgentResumeState{}, err
+	}
+	return AgentResumeState{
+		DetentSessionID:   row.ID,
+		ProviderThreadID:  strings.TrimSpace(row.ProviderThreadID),
+		ProviderSessionID: strings.TrimSpace(row.ProviderSessionID),
+		RequestedModel:    strings.TrimSpace(row.RequestedModel),
+		Model:             strings.TrimSpace(row.Model),
+		AgentBackendID:    strings.TrimSpace(row.AgentBackendID),
+		AgentBackendKind:  strings.TrimSpace(row.AgentBackendKind),
+		AgentRole:         strings.TrimSpace(row.AgentRole),
+		CompletedAt:       completedAt,
+	}, nil
+}
+
+func normalizeAgentResumeLookup(attrs AgentResumeLookup) AgentResumeLookup {
+	return AgentResumeLookup{
+		IssueID:          strings.TrimSpace(attrs.IssueID),
+		Identifier:       strings.TrimSpace(attrs.Identifier),
+		IssueURL:         strings.TrimSpace(attrs.IssueURL),
+		RequestedModel:   strings.TrimSpace(attrs.RequestedModel),
+		AgentBackendID:   strings.TrimSpace(attrs.AgentBackendID),
+		AgentBackendKind: strings.TrimSpace(attrs.AgentBackendKind),
+		AgentRole:        strings.TrimSpace(attrs.AgentRole),
+	}
 }
 
 func (s *sqliteStore) RecordUsageEvent(ctx context.Context, attrs UsageEvent) (int64, error) {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -31,6 +31,7 @@ type Store interface {
 	WorkAttemptStore
 	ValidatorMemoStore
 	RuntimeEvidenceStore
+	AgentResumeStore
 	Queries() *sqlc.Queries
 	Close() error
 }
@@ -84,6 +85,10 @@ type ValidatorMemoStore interface {
 
 type RuntimeEvidenceStore interface {
 	RuntimeEvidence(context.Context, RuntimeEvidenceQuery) (RuntimeEvidence, error)
+}
+
+type AgentResumeStore interface {
+	LatestCompletedAgentResumeState(context.Context, AgentResumeLookup) (AgentResumeState, error)
 }
 
 type RuntimeEvidenceQuery struct {
@@ -180,12 +185,16 @@ type RunStop struct {
 }
 
 type SessionStart struct {
-	RunID      int64
-	IssueID    string
-	Identifier string
-	IssueURL   string
-	StartedAt  time.Time
-	Model      string
+	RunID            int64
+	IssueID          string
+	Identifier       string
+	IssueURL         string
+	StartedAt        time.Time
+	Model            string
+	RequestedModel   string
+	AgentBackendID   string
+	AgentBackendKind string
+	AgentRole        string
 }
 
 type SessionFinish struct {
@@ -200,6 +209,31 @@ type SessionFinish struct {
 	RuntimeSeconds        int64
 	FinalState            string
 	Model                 string
+	ProviderThreadID      string
+	ProviderSessionID     string
+	ResumedFromSessionID  int64
+}
+
+type AgentResumeLookup struct {
+	IssueID          string
+	Identifier       string
+	IssueURL         string
+	RequestedModel   string
+	AgentBackendID   string
+	AgentBackendKind string
+	AgentRole        string
+}
+
+type AgentResumeState struct {
+	DetentSessionID   int64
+	ProviderThreadID  string
+	ProviderSessionID string
+	RequestedModel    string
+	Model             string
+	AgentBackendID    string
+	AgentBackendKind  string
+	AgentRole         string
+	CompletedAt       time.Time
 }
 
 type UsageEvent struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -3,6 +3,7 @@ package store
 import (
 	"context"
 	"database/sql"
+	"errors"
 	"math"
 	"path/filepath"
 	"strings"
@@ -108,6 +109,53 @@ VALUES ('detent', 'agent_session', 'agent_active', '2026-05-31T13:00:00Z', 5, '2
 		assertColumnAbsent(t, db, table, "cached_input_tokens")
 		assertColumnAbsent(t, db, table, "reasoning_output_tokens")
 		assertColumnAbsent(t, db, table, "model_context_window")
+	}
+}
+
+func TestAgentResumeStateMigrationUpDown(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "detent.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	if err := configureSQLite(ctx, db, 0); err != nil {
+		t.Fatalf("configureSQLite() error = %v", err)
+	}
+
+	migrationMu.Lock()
+	defer migrationMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	defer goose.SetBaseFS(nil)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("goose.SetDialect() error = %v", err)
+	}
+	if err := goose.UpToContext(ctx, db, "migrations", 8); err != nil {
+		t.Fatalf("goose.UpToContext(8) error = %v", err)
+	}
+
+	for _, column := range []string{"requested_model", "agent_backend_id", "agent_backend_kind", "agent_role", "provider_thread_id", "provider_session_id", "resumed_from_session_id"} {
+		assertColumnAbsent(t, db, "codex_sessions", column)
+	}
+
+	if err := goose.UpToContext(ctx, db, "migrations", 9); err != nil {
+		t.Fatalf("goose.UpToContext(9) error = %v", err)
+	}
+	for _, column := range []string{"requested_model", "agent_backend_id", "agent_backend_kind", "agent_role", "provider_thread_id", "provider_session_id", "resumed_from_session_id"} {
+		assertColumnPresent(t, db, "codex_sessions", column)
+	}
+
+	if err := goose.DownToContext(ctx, db, "migrations", 8); err != nil {
+		t.Fatalf("goose.DownToContext(8) error = %v", err)
+	}
+	for _, column := range []string{"requested_model", "agent_backend_id", "agent_backend_kind", "agent_role", "provider_thread_id", "provider_session_id", "resumed_from_session_id"} {
+		assertColumnAbsent(t, db, "codex_sessions", column)
 	}
 }
 
@@ -637,6 +685,151 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				t.Fatalf("LifetimeTotals() sessions/runs = %#v, want 1/1", lifetime)
 			}
 		})
+	}
+}
+
+func TestLatestCompletedAgentResumeStateMatchesIssueBackendAndModel(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	startedAt := time.Date(2026, 7, 2, 17, 0, 0, 0, time.UTC)
+	failedID, err := backend.StartSession(ctx, SessionStart{
+		IssueID:          "issue-859",
+		Identifier:       "digitaldrywood/detent#859",
+		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
+		StartedAt:        startedAt,
+		Model:            "gpt-5-codex",
+		RequestedModel:   "gpt-5-codex",
+		AgentBackendID:   "codex",
+		AgentBackendKind: "codex",
+		AgentRole:        "code",
+	})
+	if err != nil {
+		t.Fatalf("StartSession(failed) error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, failedID, SessionFinish{
+		CompletedAt:       startedAt.Add(time.Minute),
+		FinalState:        "failed",
+		Model:             "gpt-5-codex",
+		ProviderThreadID:  "thread-failed",
+		ProviderSessionID: "session-failed",
+	}); err != nil {
+		t.Fatalf("FinishSession(failed) error = %v", err)
+	}
+
+	firstID, err := backend.StartSession(ctx, SessionStart{
+		IssueID:          "issue-859",
+		Identifier:       "digitaldrywood/detent#859",
+		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
+		StartedAt:        startedAt.Add(2 * time.Minute),
+		Model:            "gpt-5-codex",
+		RequestedModel:   "gpt-5-codex",
+		AgentBackendID:   "codex",
+		AgentBackendKind: "codex",
+		AgentRole:        "code",
+	})
+	if err != nil {
+		t.Fatalf("StartSession(first) error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, firstID, SessionFinish{
+		CompletedAt:       startedAt.Add(3 * time.Minute),
+		FinalState:        "completed",
+		Model:             "gpt-5-codex-resolved",
+		ProviderThreadID:  "thread-first",
+		ProviderSessionID: "session-first",
+	}); err != nil {
+		t.Fatalf("FinishSession(first) error = %v", err)
+	}
+
+	secondID, err := backend.StartSession(ctx, SessionStart{
+		IssueID:          "issue-859",
+		Identifier:       "digitaldrywood/detent#859",
+		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
+		StartedAt:        startedAt.Add(4 * time.Minute),
+		Model:            "gpt-5-codex",
+		RequestedModel:   "gpt-5-codex",
+		AgentBackendID:   "codex",
+		AgentBackendKind: "codex",
+		AgentRole:        "code",
+	})
+	if err != nil {
+		t.Fatalf("StartSession(second) error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, secondID, SessionFinish{
+		CompletedAt:          startedAt.Add(5 * time.Minute),
+		FinalState:           "completed",
+		Model:                "gpt-5-codex-resolved",
+		ProviderThreadID:     "thread-second",
+		ProviderSessionID:    "session-second",
+		ResumedFromSessionID: firstID,
+	}); err != nil {
+		t.Fatalf("FinishSession(second) error = %v", err)
+	}
+
+	validatorID, err := backend.StartSession(ctx, SessionStart{
+		IssueID:          "issue-859",
+		Identifier:       "digitaldrywood/detent#859",
+		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
+		StartedAt:        startedAt.Add(6 * time.Minute),
+		Model:            "gpt-5-codex",
+		RequestedModel:   "gpt-5-codex",
+		AgentBackendID:   "codex",
+		AgentBackendKind: "codex",
+		AgentRole:        "validator",
+	})
+	if err != nil {
+		t.Fatalf("StartSession(validator) error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, validatorID, SessionFinish{
+		CompletedAt:       startedAt.Add(7 * time.Minute),
+		FinalState:        "completed",
+		Model:             "gpt-5-codex-resolved",
+		ProviderThreadID:  "thread-validator",
+		ProviderSessionID: "session-validator",
+	}); err != nil {
+		t.Fatalf("FinishSession(validator) error = %v", err)
+	}
+
+	got, err := backend.LatestCompletedAgentResumeState(ctx, AgentResumeLookup{
+		IssueID:          "issue-859",
+		Identifier:       "digitaldrywood/detent#859",
+		IssueURL:         "https://github.com/digitaldrywood/detent/issues/859",
+		RequestedModel:   "gpt-5-codex",
+		AgentBackendID:   "codex",
+		AgentBackendKind: "codex",
+		AgentRole:        "code",
+	})
+	if err != nil {
+		t.Fatalf("LatestCompletedAgentResumeState() error = %v", err)
+	}
+	if got.DetentSessionID != secondID || got.ProviderThreadID != "thread-second" || got.ProviderSessionID != "session-second" {
+		t.Fatalf("resume state = %#v, want newest completed second session", got)
+	}
+	if got.RequestedModel != "gpt-5-codex" || got.Model != "gpt-5-codex-resolved" || got.AgentRole != "code" {
+		t.Fatalf("resume models = %#v, want requested and resolved model", got)
+	}
+
+	_, err = backend.LatestCompletedAgentResumeState(ctx, AgentResumeLookup{
+		IssueID:          "issue-859",
+		RequestedModel:   "gpt-5-codex-mini",
+		AgentBackendID:   "codex",
+		AgentBackendKind: "codex",
+		AgentRole:        "code",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("LatestCompletedAgentResumeState(model mismatch) error = %v, want ErrNotFound", err)
+	}
+
+	_, err = backend.LatestCompletedAgentResumeState(ctx, AgentResumeLookup{
+		IssueID:          "issue-859",
+		RequestedModel:   "gpt-5-codex",
+		AgentBackendID:   "codex",
+		AgentBackendKind: "codex",
+		AgentRole:        "merge",
+	})
+	if !errors.Is(err, ErrNotFound) {
+		t.Fatalf("LatestCompletedAgentResumeState(role mismatch) error = %v, want ErrNotFound", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add a flag-gated runner prototype for resuming Codex threads and Claude Code sessions.
- Persist provider thread/session metadata by issue, backend, and requested model with fresh fallback on resume failure.
- Add the spike design note with backend support, lifetime assumptions, validation, and the dogfood measurement caveat.

Fixes #859

## Test Plan

- [x] `go test ./...`
- [x] `make check`