### PR TITLE
fix(ci): restore Windows release gate

### DIFF
--- a/internal/claudecode/backend_test.go
+++ b/internal/claudecode/backend_test.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"reflect"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -24,7 +25,6 @@ func TestAgentBackendRunTurnSuccess(t *testing.T) {
 
 	backend := newTestBackend(t, Options{
 		CommandFactory: fixtureCommand(t, "success.jsonl", "", 0),
-		StallTimeout:   time.Second,
 	})
 
 	var updates []runner.AgentUpdate
@@ -511,15 +511,39 @@ func fixtureCommand(t *testing.T, name string, stderr string, exitCode int) Comm
 
 func catCommand(path string, stderr string, exitCode int) CommandFactory {
 	return func(ctx context.Context) *exec.Cmd {
-		script := "cat " + shellQuote(path)
-		if stderr != "" {
-			script += "; printf '%s' " + shellQuote(stderr) + " >&2"
-		}
-		if exitCode != 0 {
-			script += fmt.Sprintf("; exit %d", exitCode)
-		}
-		return exec.CommandContext(ctx, "sh", "-c", script)
+		cmd := exec.CommandContext(ctx, os.Args[0], "-test.run=TestClaudeCodeFixtureProcess", "--")
+		cmd.Env = append(os.Environ(),
+			"CLAUDECODE_HELPER=fixture",
+			"CLAUDECODE_FIXTURE_PATH="+path,
+			"CLAUDECODE_FIXTURE_STDERR="+stderr,
+			fmt.Sprintf("CLAUDECODE_FIXTURE_EXIT_CODE=%d", exitCode),
+		)
+		return cmd
 	}
+}
+
+func TestClaudeCodeFixtureProcess(t *testing.T) {
+	if os.Getenv("CLAUDECODE_HELPER") != "fixture" {
+		return
+	}
+
+	raw, err := os.ReadFile(os.Getenv("CLAUDECODE_FIXTURE_PATH"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(2)
+	}
+	if _, err := os.Stdout.Write(raw); err != nil {
+		os.Exit(3)
+	}
+	if stderr := os.Getenv("CLAUDECODE_FIXTURE_STDERR"); stderr != "" {
+		fmt.Fprint(os.Stderr, stderr)
+	}
+	exitCode, err := strconv.Atoi(os.Getenv("CLAUDECODE_FIXTURE_EXIT_CODE"))
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		os.Exit(4)
+	}
+	os.Exit(exitCode)
 }
 
 func appendUpdate(updates *[]runner.AgentUpdate) runner.AgentUpdateHandler {

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -946,6 +946,9 @@ func doctorSQLiteURIPath(path string) string {
 	uriPath := filepath.ToSlash(cleaned)
 	if doctorWindowsDrivePath(uriPath) {
 		uriPath = strings.ReplaceAll(cleaned, `\`, "/")
+		if !strings.HasPrefix(uriPath, "/") {
+			uriPath = "/" + uriPath
+		}
 	}
 	return uriPath
 }

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -935,12 +935,32 @@ func openDoctorSQLiteReadOnly(ctx context.Context, path string) (doctorTelemetry
 }
 
 func doctorSQLiteReadOnlyDSN(path string) string {
-	uri := url.URL{Scheme: "file", Path: filepath.Clean(path)}
-	values := uri.Query()
+	values := url.Values{}
 	values.Set("mode", "ro")
 	values.Set("cache", "shared")
-	uri.RawQuery = values.Encode()
-	return uri.String()
+	return "file:" + doctorEscapeSQLiteURIPath(doctorSQLiteURIPath(path)) + "?" + values.Encode()
+}
+
+func doctorSQLiteURIPath(path string) string {
+	cleaned := filepath.Clean(path)
+	uriPath := filepath.ToSlash(cleaned)
+	if doctorWindowsDrivePath(uriPath) {
+		uriPath = strings.ReplaceAll(cleaned, `\`, "/")
+	}
+	return uriPath
+}
+
+func doctorWindowsDrivePath(path string) bool {
+	return len(path) >= 2 && path[1] == ':' &&
+		(path[0] >= 'A' && path[0] <= 'Z' || path[0] >= 'a' && path[0] <= 'z')
+}
+
+func doctorEscapeSQLiteURIPath(path string) string {
+	parts := strings.Split(path, "/")
+	for index, part := range parts {
+		parts[index] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
 }
 
 func confirmDoctorWorkflowOptimizationWrite(cmd *cobra.Command, report doctorWorkflowOptimizationReport) error {

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -166,6 +166,19 @@ func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 	}
 }
 
+func TestDoctorSQLiteReadOnlyDSNFormatsWindowsDrivePath(t *testing.T) {
+	t.Parallel()
+
+	dsn := doctorSQLiteReadOnlyDSN(`C:\Users\RUNNER~1\AppData\Local\Temp\detent db.sqlite`)
+	want := `file:C:/Users/RUNNER~1/AppData/Local/Temp/detent%20db.sqlite?cache=shared&mode=ro`
+	if dsn != want {
+		t.Fatalf("doctorSQLiteReadOnlyDSN() = %q, want %q", dsn, want)
+	}
+	if strings.Contains(dsn, "file://C:") || strings.Contains(dsn, "%5C") {
+		t.Fatalf("doctorSQLiteReadOnlyDSN() = %q, want no URI authority or escaped backslashes", dsn)
+	}
+}
+
 func TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -170,7 +170,7 @@ func TestDoctorSQLiteReadOnlyDSNFormatsWindowsDrivePath(t *testing.T) {
 	t.Parallel()
 
 	dsn := doctorSQLiteReadOnlyDSN(`C:\Users\RUNNER~1\AppData\Local\Temp\detent db.sqlite`)
-	want := `file:C:/Users/RUNNER~1/AppData/Local/Temp/detent%20db.sqlite?cache=shared&mode=ro`
+	want := `file:/C:/Users/RUNNER~1/AppData/Local/Temp/detent%20db.sqlite?cache=shared&mode=ro`
 	if dsn != want {
 		t.Fatalf("doctorSQLiteReadOnlyDSN() = %q, want %q", dsn, want)
 	}


### PR DESCRIPTION
## Summary

- Fix doctor SQLite read-only DSNs to use authority-free `file:` URIs with absolute Windows drive paths encoded as `/C:/...`.
- Make Claude Code backend JSONL fixtures run through the Go test binary instead of shelling out through `sh -c cat`.
- Add regression coverage for Windows drive-path SQLite URI formatting.

Fixes #879

## Test Plan

- [x] `go test ./internal/cli -run 'TestDoctor(SQLiteReadOnlyDSNFormatsWindowsDrivePath|WorkflowOptimization(FindsFixtureRules|WriteRoundTripsWorkflow|UsesRuntimeGitHubToken))$' -v -count=1`
- [x] `go test ./internal/claudecode -run 'TestAgentBackendRunTurnSuccess|TestAgentBackendRunTurnErrorResult|TestAgentBackendRunTurnReadsOversizedLine' -v -count=1`
- [x] `go test ./internal/cli ./internal/claudecode -count=1`
- [x] `make check`
- [x] PR CI run: https://github.com/digitaldrywood/detent/actions/runs/28633452632
- [x] Branch CI workflow_dispatch run with Windows gates: https://github.com/digitaldrywood/detent/actions/runs/28633574854