### PR TITLE
fix(ci): require release-critical PR checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,6 @@ jobs:
           retention-days: 14
 
   portability-verify:
-    if: ${{ github.event_name != 'pull_request' }}
     name: Portability Verify (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -215,7 +214,6 @@ jobs:
         run: go test -race ./...
 
   windows-core:
-    if: ${{ github.event_name != 'pull_request' }}
     name: Windows Core
     runs-on: windows-latest
     steps:
@@ -233,7 +231,6 @@ jobs:
         run: go build ./cmd/detent
 
   installer-smoke:
-    if: ${{ github.event_name != 'pull_request' }}
     name: Installer Smoke (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
     strategy:
@@ -327,10 +324,8 @@ jobs:
           & $binary version
 
   goreleaser-snapshot:
-    if: ${{ github.event_name != 'pull_request' }}
     name: GoReleaser Snapshot
     runs-on: ubuntu-latest
-    needs: [lint, verify, test-cover, browser-visual, portability-verify, windows-core, installer-smoke]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/README.md
+++ b/README.md
@@ -515,10 +515,10 @@ skips publishing when `SCOOP_BUCKET_GITHUB_TOKEN` or `WINGET_GITHUB_TOKEN` is
 not configured.
 
 CI runs `GoReleaser Snapshot` after merges to `main`, on `v*` release tags, on
-the nightly schedule, and from manual workflow dispatch so release packaging is
-validated outside the normal PR merge lane. Required branch checks must not pass
-as path- or event-dependent no-ops on pull requests when the same check name
-runs real validation on `main`.
+pull requests, on the nightly schedule, and from manual workflow dispatch so
+release packaging is validated before the PR merge lane and after it lands.
+Required branch checks must not pass as path- or event-dependent no-ops on pull
+requests when the same check name runs real validation on `main`.
 
 ## Quick Start
 
@@ -700,6 +700,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
+  required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:
@@ -757,6 +758,7 @@ agent:
 gate:
   kind: command
   run: make check
+  required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:
@@ -805,6 +807,7 @@ agent:
 gate:
   kind: command
   run: make check
+  required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:
@@ -885,6 +888,10 @@ current-head CI moves a `Human Review` item back to
 in `Human Review`; pending CI stays parked. Use
 `kind: human_review` with `approval_label` only when the workflow explicitly
 requires a human approval label to promote.
+Set `required_status_checks` to the exact branch-protection or ruleset check
+names that are release-blocking for the project. Detent treats a configured
+required check as non-green when it is missing, skipped, failed, cancelled,
+neutral, or still running on the current PR head.
 
 Set `gate.validator.enabled: true` to add a validator-agent review before
 auto-promotion. The validator inspects the PR diff against the issue acceptance
@@ -1512,6 +1519,9 @@ of that state is controlled by the workflow:
 - `gate.kind: command` with `require_automated_review: false` keeps the linked
   PR, green CI, no-P1, and quiet-period checks but does not require a bot PR
   review to exist.
+- `gate.required_status_checks` names release-blocking check runs or commit
+  status contexts that must be present, completed, and successful on the current
+  PR head.
 - `gate.ci_failure_action: rework` routes failed or cancelled current-head CI
   from `Human Review` back to `Rework` by default; set
   `gate.ci_failure_action: skip` only when non-green CI should leave the item
@@ -1730,20 +1740,22 @@ or cannot prove the final rebase was source-clean, it must run the full
 configured gate again.
 
 CI waiting should poll current-head REST check runs with backoff, not loop on
-GraphQL-heavy PR status commands. Merge handoff telemetry should record the
+GraphQL-heavy PR status commands. Required release checks must run on the PR
+head before merge; post-merge-only failures cannot be part of the merge
+decision. Merge handoff telemetry should record the
 quiet-window wait, GitHub queue/start wait, local merge-gate duration,
 current-head PR CI duration, active slow-check runtimes, and whether post-merge
 `main` CI is still running. The quiet window, current-head required CI, and
 conflict/full-gate fallback are quality gates; repeated full local validation
 after a source-clean rebase, noisy status polling, uncached tool install, and
-duplicated post-merge work are optimization targets.
+duplicated non-blocking post-merge work are optimization targets.
 
 The repository CI caches the project-pinned golangci-lint binary and only builds
 it with `go install` on cache miss. The official prebuilt action was evaluated,
 but the prebuilt `v2.1.6` binary targets an older Go toolchain than this repo and
 newer prebuilt lint releases change the enforced lint set. `GoReleaser Snapshot`
-now runs as release confidence coverage outside normal PR merges so packaging
-signal remains available without extending the required merge lane.
+now runs on pull requests, `main`, release tags, nightly schedule, and manual
+dispatch so packaging signal is available before and after merge.
 
 ## Multi-Project Operation
 

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -43,41 +43,44 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 		jobEnd:   "  portability-verify:",
 		markers:  []string{"name: Browser Visual", "Run full browser visual gate", "Run browser smoke gate"},
 	},
-}
-
-var confidenceStatusChecks = []requiredStatusCheck{
 	{
 		name:     "Portability Verify (macos-latest)",
+		budget:   "8m",
 		jobStart: "  portability-verify:",
 		jobEnd:   "  windows-core:",
 		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]"},
 	},
 	{
 		name:     "Portability Verify (windows-latest)",
+		budget:   "8m",
 		jobStart: "  portability-verify:",
 		jobEnd:   "  windows-core:",
 		markers:  []string{"name: Portability Verify (${{ matrix.os }})", "os: [macos-latest, windows-latest]"},
 	},
 	{
 		name:     "Windows Core",
+		budget:   "4m",
 		jobStart: "  windows-core:",
 		jobEnd:   "  installer-smoke:",
 		markers:  []string{"name: Windows Core"},
 	},
 	{
 		name:     "Installer Smoke (ubuntu-latest)",
+		budget:   "6m",
 		jobStart: "  installer-smoke:",
 		jobEnd:   "  goreleaser-snapshot:",
 		markers:  []string{"name: Installer Smoke (${{ matrix.os }})", "os: [ubuntu-latest, windows-latest]"},
 	},
 	{
 		name:     "Installer Smoke (windows-latest)",
+		budget:   "6m",
 		jobStart: "  installer-smoke:",
 		jobEnd:   "  goreleaser-snapshot:",
 		markers:  []string{"name: Installer Smoke (${{ matrix.os }})", "os: [ubuntu-latest, windows-latest]"},
 	},
 	{
 		name:     "GoReleaser Snapshot",
+		budget:   "8m",
 		jobStart: "  goreleaser-snapshot:",
 		jobEnd:   "",
 		markers:  []string{"name: GoReleaser Snapshot"},
@@ -109,9 +112,9 @@ func TestMainProtectionDocumentationMatchesWorkflow(t *testing.T) {
 	for _, want := range []string{
 		"`required_status_checks.strict: true`",
 		"must not report success from a path- or event-dependent no-op",
+		"`gate.required_status_checks`",
 		"`cancel-in-progress: ${{ github.event_name == 'pull_request' }}`",
 		"`Browser Visual`",
-		"Release and portability confidence checks",
 	} {
 		if !strings.Contains(protection, want) {
 			t.Fatalf("main branch protection docs missing %q", want)
@@ -127,22 +130,6 @@ func TestMainProtectionDocumentationMatchesWorkflow(t *testing.T) {
 		for _, marker := range check.markers {
 			if !strings.Contains(job, marker) {
 				t.Fatalf("workflow job for required check %q missing %q", check.name, marker)
-			}
-		}
-	}
-
-	for _, check := range confidenceStatusChecks {
-		if !strings.Contains(protection, "- `"+check.name+"`") {
-			t.Fatalf("main branch protection docs missing confidence check %q", check.name)
-		}
-
-		job := workflowBetween(t, workflow, check.jobStart, check.jobEnd)
-		if !strings.Contains(job, "if: ${{ github.event_name != 'pull_request' }}") {
-			t.Fatalf("confidence check %q must stay outside the normal PR path", check.name)
-		}
-		for _, marker := range check.markers {
-			if !strings.Contains(job, marker) {
-				t.Fatalf("workflow job for confidence check %q missing %q", check.name, marker)
 			}
 		}
 	}

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2089,9 +2089,13 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `require_automated_review: true`, it also requires a current-head automated
    GitHub PR review. With `require_automated_review: false`, bot PR review is
    not required to exist, but any observed P1 bot findings still route the item
-   to `Rework`. Failed or cancelled current-head CI also routes the item to
-   `Rework` by default; set `ci_failure_action: skip` only when red CI should
-   stay parked in `Human Review`. `agent.auto_promote.rework_limit: 0` leaves
+   to `Rework`. `gate.required_status_checks` should list every
+   release-blocking branch-protection or ruleset check name; Detent treats
+   missing, skipped, failed, cancelled, neutral, or still-running required
+   checks as non-green on the current PR head. Failed or cancelled current-head
+   CI also routes the item to `Rework` by default; set `ci_failure_action: skip`
+   only when red CI should stay parked in `Human Review`.
+   `agent.auto_promote.rework_limit: 0` leaves
    repeated rework unlimited; a positive value requires `Blocked` in a configured
    tracker state list and blocks the next lap after that many persisted Rework
    entries. Pending CI stays parked. The quiet
@@ -2814,6 +2818,7 @@ the card instead of auto-resolving it.
 | Dashboard bind | `server.host` in `WORKFLOW.md`, or `--host` in the startup command or service `ExecStart`. |
 | Validation command | `gate.kind: command` and `gate.run` in `WORKFLOW.md`. |
 | Automated PR review requirement | `gate.kind: command` and `gate.require_automated_review` in `WORKFLOW.md`. |
+| Release-blocking CI names | `gate.required_status_checks` in `WORKFLOW.md`; keep it aligned with branch protection or rulesets. |
 | Failed CI recovery | `gate.kind: command` and `gate.ci_failure_action` in `WORKFLOW.md`. |
 | Validator-agent review | `gate.validator.enabled`, `gate.validator.min_score`, and `gate.validator.block_on` in `WORKFLOW.md`. |
 | Human validation label | `gate.kind: human_review` and `gate.approval_label` in `WORKFLOW.md`. |

--- a/docs/execution-seams.md
+++ b/docs/execution-seams.md
@@ -63,6 +63,10 @@ artifact workflows. GitHub PR delivery remains the default.
 - `gate.kind: command` with `require_automated_review: false` keeps the
   command, linked PR, green CI, no-P1, and quiet-period checks but does not
   require an automated GitHub PR review to exist before promotion.
+- `gate.required_status_checks` lists release-blocking check-run names or
+  commit status contexts that must be present on the current PR head, completed,
+  and successful. Missing, skipped, failed, cancelled, neutral, or still-running
+  required checks keep CI non-green and block promotion.
 - `gate.kind: command` routes failed or cancelled current-head CI from
   `Human Review` back to `Rework` by default. Set
   `ci_failure_action: skip` only when red CI should remain parked in
@@ -103,9 +107,8 @@ artifact workflows. GitHub PR delivery remains the default.
 - The CI lint job keeps the project-pinned golangci-lint version and caches its
   binary so cache hits avoid a per-run `go install` without changing lint
   coverage.
-- `GoReleaser Snapshot` is a release confidence check that runs after merges to
-  `main`, on release tags, on the nightly CI schedule, and from manual
-  workflow dispatch instead of blocking the normal PR merge lane.
+- `GoReleaser Snapshot` is a release-blocking check that runs on pull requests,
+  `main`, release tags, the nightly CI schedule, and manual workflow dispatch.
 
 ### Main Branch Protection
 
@@ -121,23 +124,25 @@ the same named check runs real validation on `main`; `Browser Visual` is still a
 real gate because non-UI pull requests run a Detent binary smoke instead of a
 green no-op.
 
-Required PR merge checks:
+Required PR merge checks, branch protection/rulesets, and
+`gate.required_status_checks` must name the same release-blocking checks:
 
 - `Lint` - budget: `2m`
 - `Verify (ubuntu-latest)` - budget: `4m`
 - `Test Coverage` - budget: `4m`
 - `Browser Visual` - budget: `5m`
+- `Portability Verify (macos-latest)` - budget: `8m`
+- `Portability Verify (windows-latest)` - budget: `8m`
+- `Windows Core` - budget: `4m`
+- `Installer Smoke (ubuntu-latest)` - budget: `6m`
+- `Installer Smoke (windows-latest)` - budget: `6m`
+- `GoReleaser Snapshot` - budget: `8m`
 
-Release and portability confidence checks run after merges to `main`, on `v*`
-release tags, on the nightly CI schedule, and from manual workflow dispatch.
-They are not required for normal PR merge:
-
-- `Portability Verify (macos-latest)`
-- `Portability Verify (windows-latest)`
-- `Windows Core`
-- `Installer Smoke (ubuntu-latest)`
-- `Installer Smoke (windows-latest)`
-- `GoReleaser Snapshot`
+Release and portability checks also run on `main`, on `v*` release tags, on the
+nightly CI schedule, and from manual workflow dispatch. They are still
+release-blocking for pull requests; Detent must not promote or merge a PR head
+where one of these checks is missing, skipped, failed, cancelled, neutral, or
+still running.
 
 The CI workflow keeps pull request runs cancellable by newer pushes to the same
 PR through `cancel-in-progress: ${{ github.event_name == 'pull_request' }}`.

--- a/docs/local-models-ollama.md
+++ b/docs/local-models-ollama.md
@@ -153,6 +153,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
+  required_status_checks: []
   validator:
     enabled: true
     min_score: 0.8

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -110,6 +110,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
+  required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -110,6 +110,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
+  required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -110,6 +110,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
+  required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -109,6 +109,7 @@ gate:
   kind: command
   run: make check
   require_automated_review: true
+  required_status_checks: []
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:

--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -2405,6 +2405,7 @@ func defaultDoctorAutoPromoteConnector(cfg workflowconfig.Config) (doctorAutoPro
 		ObservedStates:              cfg.Tracker.ObservedStates,
 		TerminalStates:              cfg.Tracker.TerminalStates,
 		StateMap:                    doctorTrackerStateMap(cfg.Tracker.StateMap),
+		RequiredStatusChecks:        cfg.Gate.RequiredStatusChecks,
 	})
 }
 

--- a/internal/cli/github_local.go
+++ b/internal/cli/github_local.go
@@ -193,6 +193,7 @@ func githubLocalConnectorFromWorkflow(ctx context.Context, cfg workflowconfig.Co
 		TerminalStates:              cfg.Tracker.TerminalStates,
 		StateMap:                    githubLocalTrackerStateMap(cfg.Tracker.StateMap),
 		PriorityMap:                 githubLocalTrackerPriorityMap(cfg.Tracker.PriorityMap),
+		RequiredStatusChecks:        cfg.Gate.RequiredStatusChecks,
 	})
 	if err != nil {
 		return nil, err

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1121,6 +1121,33 @@ Prompt
 	}
 }
 
+func TestParseWorkflowGateRequiredStatusChecks(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+gate:
+  required_status_checks:
+    - " Lint "
+    - Windows Core
+    - Lint
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	want := []string{"Lint", "Windows Core"}
+	if !reflect.DeepEqual(workflow.Config.Gate.RequiredStatusChecks, want) {
+		t.Fatalf("Gate.RequiredStatusChecks = %#v, want %#v", workflow.Config.Gate.RequiredStatusChecks, want)
+	}
+}
+
 func TestParseWorkflowGateTransientCIRetryLimitCanDisable(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -46,6 +46,7 @@ type Config struct {
 	TerminalStates              []string
 	StateMap                    map[string]string
 	PriorityMap                 map[string]*int
+	RequiredStatusChecks        []string
 }
 
 func NewFromConfig(cfg Config) (connector.Connector, error) {
@@ -89,6 +90,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 			TerminalStates:          cfg.TerminalStates,
 			StateMap:                cfg.StateMap,
 			PriorityMap:             cfg.PriorityMap,
+			RequiredStatusChecks:    cfg.RequiredStatusChecks,
 		})
 	case connector.BackendGitHubLocal:
 		var tokenSource githubconnector.TokenSource
@@ -130,6 +132,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 				TerminalStates:          cfg.TerminalStates,
 				StateMap:                cfg.StateMap,
 				PriorityMap:             cfg.PriorityMap,
+				RequiredStatusChecks:    cfg.RequiredStatusChecks,
 			},
 			Local:          localCfg,
 			Repository:     cfg.Repository,

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -876,6 +876,7 @@ type pullRequestCI struct {
 	CIDurationSeconds  int64
 	SlowChecks         []connector.PullRequestCheck
 	RunningChecks      []string
+	RequiredFailures   []connector.PullRequestCheck
 	TransientFailures  []connector.PullRequestCheck
 }
 
@@ -2461,6 +2462,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		CIDurationSeconds:            pullRequest.CI.CIDurationSeconds,
 		SlowChecks:                   append([]connector.PullRequestCheck(nil), pullRequest.CI.SlowChecks...),
 		RunningChecks:                append([]string(nil), pullRequest.CI.RunningChecks...),
+		RequiredCheckFailures:        append([]connector.PullRequestCheck(nil), pullRequest.CI.RequiredFailures...),
 		TransientFailedChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.TransientFailures...),
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
 		CodexReviewSubmittedAt:       pullRequestCodexReviewSubmittedAt(pullRequest),
@@ -2705,14 +2707,20 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 		return pullRequestCI{}, fmt.Errorf("fetch github commit statuses: %w", err)
 	}
 	telemetry := checkRunTelemetry(checkRuns, workflowRuns)
+	requiredFailures := requiredStatusCheckFailures(checkRuns, statuses, c.requiredChecks)
+	state := combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses))
+	if requiredState := requiredStatusCheckState(requiredFailures); requiredState != "" {
+		state = combinedCIState(requiredState, state)
+	}
 	return pullRequestCI{
-		State:              combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses)),
+		State:              state,
 		CheckRunCount:      len(checkRuns),
 		StatusContextCount: len(statuses),
 		CIQueueSeconds:     telemetry.QueueSeconds,
 		CIDurationSeconds:  telemetry.DurationSeconds,
 		SlowChecks:         telemetry.SlowChecks,
 		RunningChecks:      telemetry.RunningChecks,
+		RequiredFailures:   requiredFailures,
 		TransientFailures:  c.transientCheckRunFailures(ctx, repo, checkRuns),
 	}, nil
 }
@@ -4359,6 +4367,128 @@ func checkRunsState(checkRuns []restCheckRun) string {
 	return "success"
 }
 
+func requiredStatusCheckFailures(checkRuns []restCheckRun, statuses []restCommitStatus, required []string) []connector.PullRequestCheck {
+	required = normalizeRequiredStatusChecks(required)
+	if len(required) == 0 {
+		return nil
+	}
+
+	checkRunsByName := make(map[string]restCheckRun, len(checkRuns))
+	for _, checkRun := range checkRuns {
+		name := strings.TrimSpace(checkRun.Name)
+		if name == "" {
+			continue
+		}
+		if _, ok := checkRunsByName[name]; !ok {
+			checkRunsByName[name] = checkRun
+		}
+	}
+	statusesByContext := latestCommitStatusesByContext(statuses)
+
+	failures := make([]connector.PullRequestCheck, 0, len(required))
+	for _, name := range required {
+		if checkRun, ok := checkRunsByName[name]; ok {
+			if failure, failed := requiredCheckRunFailure(name, checkRun); failed {
+				failures = append(failures, failure)
+			}
+			continue
+		}
+		if status, ok := statusesByContext[name]; ok {
+			if failure, failed := requiredCommitStatusFailure(name, status); failed {
+				failures = append(failures, failure)
+			}
+			continue
+		}
+		failures = append(failures, connector.PullRequestCheck{
+			Name:       name,
+			Status:     "missing",
+			Conclusion: "missing",
+		})
+	}
+	if len(failures) == 0 {
+		return nil
+	}
+	return failures
+}
+
+func requiredCheckRunFailure(name string, checkRun restCheckRun) (connector.PullRequestCheck, bool) {
+	status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+	conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+	if status != "" && status != "completed" {
+		return connector.PullRequestCheck{
+			ID:            checkRun.ID,
+			WorkflowRunID: checkRunWorkflowRunID(checkRun),
+			Name:          name,
+			Status:        status,
+			Conclusion:    conclusion,
+			DetailsURL:    firstNonBlank(checkRun.DetailsURL, checkRun.HTMLURL),
+		}, true
+	}
+	if conclusion == "success" {
+		return connector.PullRequestCheck{}, false
+	}
+	if conclusion == "" {
+		conclusion = "missing"
+	}
+	return connector.PullRequestCheck{
+		ID:            checkRun.ID,
+		WorkflowRunID: checkRunWorkflowRunID(checkRun),
+		Name:          name,
+		Status:        firstNonBlank(status, "completed"),
+		Conclusion:    conclusion,
+		DetailsURL:    firstNonBlank(checkRun.DetailsURL, checkRun.HTMLURL),
+	}, true
+}
+
+func requiredCommitStatusFailure(name string, status restCommitStatus) (connector.PullRequestCheck, bool) {
+	state := strings.ToLower(strings.TrimSpace(status.State))
+	if state == "success" {
+		return connector.PullRequestCheck{}, false
+	}
+	if state == "" {
+		state = "pending"
+	}
+	return connector.PullRequestCheck{
+		Name:       name,
+		Status:     state,
+		Conclusion: state,
+	}, true
+}
+
+func requiredStatusCheckState(failures []connector.PullRequestCheck) string {
+	if len(failures) == 0 {
+		return ""
+	}
+	pending := false
+	for _, failure := range failures {
+		status := strings.ToLower(strings.TrimSpace(failure.Status))
+		conclusion := strings.ToLower(strings.TrimSpace(failure.Conclusion))
+		switch {
+		case requiredStatusCheckPending(status, conclusion):
+			pending = true
+		default:
+			return "failure"
+		}
+	}
+	if pending {
+		return "pending"
+	}
+	return ""
+}
+
+func requiredStatusCheckPending(status string, conclusion string) bool {
+	switch conclusion {
+	case "missing", "":
+		return true
+	}
+	switch status {
+	case "missing", "pending", "queued", "waiting", "in_progress", "in progress", "requested", "expected":
+		return true
+	default:
+		return false
+	}
+}
+
 func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun) checkRunTelemetrySummary {
 	var queueCreatedAt *time.Time
 	var queueStartedAt *time.Time
@@ -4460,17 +4590,7 @@ func commitStatusesState(statuses []restCommitStatus) string {
 	if len(statuses) == 0 {
 		return ""
 	}
-	latestByContext := map[string]restCommitStatus{}
-	for index, status := range statuses {
-		context := strings.TrimSpace(status.Context)
-		if context == "" {
-			context = strconv.Itoa(index)
-		}
-		previous, ok := latestByContext[context]
-		if !ok || restCommitStatusAfter(status, previous) {
-			latestByContext[context] = status
-		}
-	}
+	latestByContext := latestCommitStatusesByContext(statuses)
 	pending := false
 	for _, status := range latestByContext {
 		switch strings.ToLower(strings.TrimSpace(status.State)) {
@@ -4489,6 +4609,21 @@ func commitStatusesState(statuses []restCommitStatus) string {
 	return "success"
 }
 
+func latestCommitStatusesByContext(statuses []restCommitStatus) map[string]restCommitStatus {
+	latestByContext := map[string]restCommitStatus{}
+	for index, status := range statuses {
+		context := strings.TrimSpace(status.Context)
+		if context == "" {
+			context = strconv.Itoa(index)
+		}
+		previous, ok := latestByContext[context]
+		if !ok || restCommitStatusAfter(status, previous) {
+			latestByContext[context] = status
+		}
+	}
+	return latestByContext
+}
+
 func restCommitStatusAfter(left restCommitStatus, right restCommitStatus) bool {
 	if left.CreatedAt == nil {
 		return false
@@ -4497,6 +4632,23 @@ func restCommitStatusAfter(left restCommitStatus, right restCommitStatus) bool {
 		return true
 	}
 	return left.CreatedAt.After(*right.CreatedAt)
+}
+
+func normalizeRequiredStatusChecks(checks []string) []string {
+	normalized := make([]string, 0, len(checks))
+	seen := make(map[string]struct{}, len(checks))
+	for _, check := range checks {
+		check = strings.TrimSpace(check)
+		if check == "" {
+			continue
+		}
+		if _, ok := seen[check]; ok {
+			continue
+		}
+		seen[check] = struct{}{}
+		normalized = append(normalized, check)
+	}
+	return normalized
 }
 
 func combinedCIState(checkRuns string, statuses string) string {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1452,6 +1452,93 @@ func TestCheckRunTelemetryUsesWorkflowRunTimingForQueue(t *testing.T) {
 	}
 }
 
+func TestRequiredStatusCheckFailures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		checkRuns  []restCheckRun
+		statuses   []restCommitStatus
+		required   []string
+		wantState  string
+		wantChecks []connector.PullRequestCheck
+	}{
+		{
+			name:      "all required check runs succeeded",
+			checkRuns: []restCheckRun{{Name: "Lint", Status: "completed", Conclusion: "success"}},
+			required:  []string{"Lint"},
+		},
+		{
+			name:      "missing required check blocks as pending",
+			checkRuns: []restCheckRun{{Name: "Lint", Status: "completed", Conclusion: "success"}},
+			required:  []string{"Lint", "Windows Core"},
+			wantState: "pending",
+			wantChecks: []connector.PullRequestCheck{{
+				Name:       "Windows Core",
+				Status:     "missing",
+				Conclusion: "missing",
+			}},
+		},
+		{
+			name:      "running required check blocks as pending",
+			checkRuns: []restCheckRun{{Name: "Windows Core", Status: "in_progress"}},
+			required:  []string{"Windows Core"},
+			wantState: "pending",
+			wantChecks: []connector.PullRequestCheck{{
+				Name:   "Windows Core",
+				Status: "in_progress",
+			}},
+		},
+		{
+			name:      "skipped required check fails",
+			checkRuns: []restCheckRun{{Name: "Windows Core", Status: "completed", Conclusion: "skipped"}},
+			required:  []string{"Windows Core"},
+			wantState: "failure",
+			wantChecks: []connector.PullRequestCheck{{
+				Name:       "Windows Core",
+				Status:     "completed",
+				Conclusion: "skipped",
+			}},
+		},
+		{
+			name:      "neutral required check fails",
+			checkRuns: []restCheckRun{{Name: "GoReleaser Snapshot", Status: "completed", Conclusion: "neutral"}},
+			required:  []string{"GoReleaser Snapshot"},
+			wantState: "failure",
+			wantChecks: []connector.PullRequestCheck{{
+				Name:       "GoReleaser Snapshot",
+				Status:     "completed",
+				Conclusion: "neutral",
+			}},
+		},
+		{
+			name:      "required commit status context fails",
+			statuses:  []restCommitStatus{{Context: "release/check", State: "failure"}},
+			required:  []string{"release/check"},
+			wantState: "failure",
+			wantChecks: []connector.PullRequestCheck{{
+				Name:       "release/check",
+				Status:     "failure",
+				Conclusion: "failure",
+			}},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotChecks := requiredStatusCheckFailures(tt.checkRuns, tt.statuses, tt.required)
+			if !reflect.DeepEqual(gotChecks, tt.wantChecks) {
+				t.Fatalf("requiredStatusCheckFailures() = %#v, want %#v", gotChecks, tt.wantChecks)
+			}
+			if gotState := requiredStatusCheckState(gotChecks); gotState != tt.wantState {
+				t.Fatalf("requiredStatusCheckState() = %q, want %q", gotState, tt.wantState)
+			}
+		})
+	}
+}
+
 func TestCheckRunWorkflowRunIDs(t *testing.T) {
 	t.Parallel()
 
@@ -2571,6 +2658,116 @@ func TestConnectorHydratePullRequestRefreshesCurrentStatus(t *testing.T) {
 	}
 	if got.PRRepository != "example/repo" {
 		t.Fatalf("PRRepository = %q, want example/repo", got.PRRepository)
+	}
+}
+
+func TestConnectorHydratePullRequestBlocksSkippedRequiredStatusCheck(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42",
+			body:   `{"number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","mergeable_state":"clean","draft":false,"head":{"ref":"detent/example_repo_1","sha":"head-sha"},"base":{"sha":"base-sha"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"name":"Lint","status":"completed","conclusion":"success"},{"name":"Windows Core","status":"completed","conclusion":"skipped"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{RequiredStatusChecks: []string{"Lint", "Windows Core"}})
+	prNumber := 42
+	issue := connector.Issue{
+		ID:         "I_kw42",
+		Identifier: "example/repo#1",
+		PRNumber:   &prNumber,
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+
+	pr := got.PullRequest
+	if pr == nil {
+		t.Fatalf("PullRequest = nil, want hydrated pull request")
+	}
+	if pr.CIStatus != "fail" {
+		t.Fatalf("CIStatus = %q, want fail for skipped required check", pr.CIStatus)
+	}
+	want := []connector.PullRequestCheck{{
+		Name:       "Windows Core",
+		Status:     "completed",
+		Conclusion: "skipped",
+	}}
+	if !reflect.DeepEqual(pr.RequiredCheckFailures, want) {
+		t.Fatalf("RequiredCheckFailures = %#v, want %#v", pr.RequiredCheckFailures, want)
+	}
+}
+
+func TestConnectorHydratePullRequestBlocksMissingRequiredStatusCheck(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42",
+			body:   `{"number":42,"html_url":"https://github.com/example/repo/pull/42","state":"open","mergeable_state":"clean","draft":false,"head":{"ref":"detent/example_repo_1","sha":"head-sha"},"base":{"sha":"base-sha"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"name":"Lint","status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/42/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{RequiredStatusChecks: []string{"Lint", "Windows Core"}})
+	prNumber := 42
+	issue := connector.Issue{
+		ID:         "I_kw42",
+		Identifier: "example/repo#1",
+		PRNumber:   &prNumber,
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+
+	pr := got.PullRequest
+	if pr == nil {
+		t.Fatalf("PullRequest = nil, want hydrated pull request")
+	}
+	if pr.CIStatus != "pending" {
+		t.Fatalf("CIStatus = %q, want pending for missing required check", pr.CIStatus)
+	}
+	want := []connector.PullRequestCheck{{
+		Name:       "Windows Core",
+		Status:     "missing",
+		Conclusion: "missing",
+	}}
+	if !reflect.DeepEqual(pr.RequiredCheckFailures, want) {
+		t.Fatalf("RequiredCheckFailures = %#v, want %#v", pr.RequiredCheckFailures, want)
 	}
 }
 

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -67,6 +67,7 @@ type Config struct {
 	TerminalStates          []string
 	StateMap                map[string]string
 	PriorityMap             map[string]*int
+	RequiredStatusChecks    []string
 	TokenSource             TokenSource
 	HTTPClient              HTTPClient
 	HTTPTransport           HTTPTransportConfig
@@ -91,6 +92,7 @@ type Connector struct {
 	terminalStates    []string
 	stateMap          map[string]string
 	priorityMap       map[string]*int
+	requiredChecks    []string
 	statusCache       *statusCache
 	issueFields       *issueFieldCache
 	projectCache      *projectCache
@@ -166,6 +168,7 @@ func NewConnector(cfg Config) (*Connector, error) {
 		terminalStates:    normalizeStateList(cfg.TerminalStates, []string{"Done", "Cancelled", "Canceled", "Closed"}),
 		stateMap:          cloneStateMap(cfg.StateMap),
 		priorityMap:       clonePriorityMapWithDefault(cfg.PriorityMap),
+		requiredChecks:    normalizeRequiredStatusChecks(cfg.RequiredStatusChecks),
 		statusCache:       newStatusCache(githubCacheTTL, cfg.Now),
 		issueFields:       newIssueFieldCache(githubCacheTTL, cfg.Now),
 		projectCache:      newProjectCache(githubCacheTTL, cfg.Now),

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -232,6 +232,7 @@ func clonePullRequestCI(ci pullRequestCI) pullRequestCI {
 		CIDurationSeconds:  ci.CIDurationSeconds,
 		SlowChecks:         append([]connector.PullRequestCheck(nil), ci.SlowChecks...),
 		RunningChecks:      append([]string(nil), ci.RunningChecks...),
+		RequiredFailures:   append([]connector.PullRequestCheck(nil), ci.RequiredFailures...),
 		TransientFailures:  append([]connector.PullRequestCheck(nil), ci.TransientFailures...),
 	}
 }

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -64,6 +64,7 @@ type PullRequest struct {
 	CIDurationSeconds            int64                `json:"ci_duration_seconds,omitempty" yaml:"ci_duration_seconds,omitempty"`
 	SlowChecks                   []PullRequestCheck   `json:"slow_checks,omitempty" yaml:"slow_checks,omitempty"`
 	RunningChecks                []string             `json:"running_checks,omitempty" yaml:"running_checks,omitempty"`
+	RequiredCheckFailures        []PullRequestCheck   `json:"required_check_failures,omitempty" yaml:"required_check_failures,omitempty"`
 	TransientFailedChecks        []PullRequestCheck   `json:"transient_failed_checks,omitempty" yaml:"transient_failed_checks,omitempty"`
 	CodexReviewState             string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
 	CodexReviewSubmittedAt       *time.Time           `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`

--- a/internal/gate/gate.go
+++ b/internal/gate/gate.go
@@ -32,6 +32,7 @@ type Config struct {
 	Run                    string          `yaml:"run"`
 	ApprovalLabel          string          `yaml:"approval_label"`
 	RequireAutomatedReview *bool           `yaml:"require_automated_review"`
+	RequiredStatusChecks   []string        `yaml:"required_status_checks"`
 	CIFailureAction        string          `yaml:"ci_failure_action"`
 	TransientCIRetryLimit  *int            `yaml:"transient_ci_retry_limit"`
 	Validator              ValidatorConfig `yaml:"validator"`
@@ -166,6 +167,7 @@ func Effective(cfg Config) Config {
 	cfg.Kind = NormalizeKind(cfg.Kind)
 	cfg.Run = strings.TrimSpace(cfg.Run)
 	cfg.ApprovalLabel = normalizeLabel(cfg.ApprovalLabel)
+	cfg.RequiredStatusChecks = NormalizeRequiredStatusChecks(cfg.RequiredStatusChecks)
 	cfg.CIFailureAction = NormalizeCIFailureAction(cfg.CIFailureAction)
 	if cfg.TransientCIRetryLimit == nil {
 		cfg.TransientCIRetryLimit = newInt(DefaultTransientCIRetries)
@@ -260,6 +262,23 @@ func NormalizeCIFailureAction(action string) string {
 	}
 }
 
+func NormalizeRequiredStatusChecks(checks []string) []string {
+	normalized := make([]string, 0, len(checks))
+	seen := make(map[string]struct{}, len(checks))
+	for _, check := range checks {
+		check = strings.TrimSpace(check)
+		if check == "" {
+			continue
+		}
+		if _, ok := seen[check]; ok {
+			continue
+		}
+		seen[check] = struct{}{}
+		normalized = append(normalized, check)
+	}
+	return normalized
+}
+
 func Validate(prefix string, cfg Config) []string {
 	var problems []string
 	switch NormalizeKind(cfg.Kind) {
@@ -274,6 +293,12 @@ func Validate(prefix string, cfg Config) []string {
 	}
 	if cfg.TransientCIRetryLimit != nil && *cfg.TransientCIRetryLimit < 0 {
 		problems = append(problems, prefix+".transient_ci_retry_limit must be greater than or equal to 0")
+	}
+	for _, check := range cfg.RequiredStatusChecks {
+		if strings.TrimSpace(check) == "" {
+			problems = append(problems, prefix+".required_status_checks must not contain blank names")
+			break
+		}
 	}
 	problems = append(problems, validateValidator(prefix+".validator", cfg.Validator)...)
 	problems = append(problems, validateArtifact(prefix+".artifact", cfg.Artifact)...)
@@ -305,6 +330,7 @@ func Instructions(cfg Config) string {
 	default:
 		instructions := "The validation gate is a command. Run `" + cfg.Run +
 			"` from the workspace root before Human Review; the pull request still needs green CI before promotion. " +
+			requiredStatusCheckInstructions(cfg.RequiredStatusChecks) +
 			"In Merging, run a focused rebase/smoke gate after a clean rebase when the PR already passed current-head validation and no source files changed during rebase. " +
 			"Run full `" + cfg.Run + "` in Merging when code changes, conflicts are resolved, or validation state is stale or unknown. " +
 			"Watch current-head CI with REST check-runs polling/backoff, report slow checks, and record merge wait telemetry in the Workpad: quiet-window wait, local merge-gate duration, PR CI duration, slow check names, and whether post-merge main CI is still running."
@@ -318,6 +344,14 @@ func Instructions(cfg Config) string {
 		}
 		return instructions
 	}
+}
+
+func requiredStatusCheckInstructions(checks []string) string {
+	checks = NormalizeRequiredStatusChecks(checks)
+	if len(checks) == 0 {
+		return ""
+	}
+	return "Configured required status checks must be present on the current PR head, completed, and successful; missing, skipped, failed, cancelled, or still-running required checks block promotion. "
 }
 
 func EvaluatePlan(cfg PlanConfig, labels []string, summary Summary) Decision {

--- a/internal/gate/gate_test.go
+++ b/internal/gate/gate_test.go
@@ -1,6 +1,7 @@
 package gate
 
 import (
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -43,6 +44,21 @@ func TestEffectiveSelectsGateDefaults(t *testing.T) {
 			name: "command can explicitly disable transient ci retries",
 			cfg:  Config{Kind: KindCommand, Run: "make verify", TransientCIRetryLimit: newInt(0)},
 			want: Config{Kind: KindCommand, Run: "make verify", ApprovalLabel: DefaultApprovalLabel, RequireAutomatedReview: new(true), CIFailureAction: CIFailureActionRework, TransientCIRetryLimit: newInt(0)},
+		},
+		{
+			name: "command normalizes required status checks",
+			cfg: Config{
+				Kind:                 KindCommand,
+				RequiredStatusChecks: []string{" Lint ", "Windows Core", "Lint", ""},
+			},
+			want: Config{
+				Kind:                   KindCommand,
+				Run:                    DefaultCommand,
+				ApprovalLabel:          DefaultApprovalLabel,
+				RequireAutomatedReview: new(true),
+				RequiredStatusChecks:   []string{"Lint", "Windows Core"},
+				CIFailureAction:        CIFailureActionRework,
+			},
 		},
 		{
 			name: "human review normalizes alias and approval label",
@@ -554,11 +570,31 @@ func TestInstructionsDescribeOptimizedMergingGate(t *testing.T) {
 	}
 }
 
+func TestInstructionsDescribeRequiredStatusChecks(t *testing.T) {
+	t.Parallel()
+
+	got := Instructions(Config{
+		Kind:                 KindCommand,
+		Run:                  "make check",
+		RequiredStatusChecks: []string{"Windows Core"},
+	})
+
+	for _, want := range []string{
+		"required status checks must be present on the current PR head",
+		"missing, skipped, failed, cancelled, or still-running required checks block promotion",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("Instructions() missing %q:\n%s", want, got)
+		}
+	}
+}
+
 func configsEqual(left Config, right Config) bool {
 	return left.Kind == right.Kind &&
 		left.Run == right.Run &&
 		left.ApprovalLabel == right.ApprovalLabel &&
 		left.CIFailureAction == right.CIFailureAction &&
+		slices.Equal(left.RequiredStatusChecks, right.RequiredStatusChecks) &&
 		intPointerEqual(left.TransientCIRetryLimit, right.TransientCIRetryLimit) &&
 		boolPointerEqual(left.RequireAutomatedReview, right.RequireAutomatedReview) &&
 		validatorConfigsEqual(left.Validator, right.Validator) &&

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1337,6 +1337,7 @@ func autoPromoteFailedChecksFromPullRequest(pullRequest *connector.PullRequest) 
 		return nil
 	}
 	allChecks := append([]connector.PullRequestCheck{}, pullRequest.SlowChecks...)
+	allChecks = append(allChecks, pullRequest.RequiredCheckFailures...)
 	allChecks = append(allChecks, pullRequest.TransientFailedChecks...)
 	checks := make([]string, 0, len(allChecks))
 	for _, check := range allChecks {
@@ -1350,7 +1351,7 @@ func autoPromoteFailedChecksFromPullRequest(pullRequest *connector.PullRequest) 
 
 func autoPromoteCheckFailed(check connector.PullRequestCheck) bool {
 	switch strings.ToLower(strings.TrimSpace(check.Conclusion)) {
-	case "failure", "failed", "error", "timed_out", "startup_failure", "action_required", "cancelled", "canceled":
+	case "failure", "failed", "error", "timed_out", "startup_failure", "action_required", "cancelled", "canceled", "missing", "skipped", "neutral":
 		return true
 	default:
 		return false

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -433,6 +433,7 @@ func telemetryPullRequest(issue connector.Issue, quietDuration time.Duration, po
 		QuietWaitSeconds:           pullRequestQuietWaitSeconds(issue, quietDuration, pollInterval),
 		SlowChecks:                 telemetryPullRequestChecks(pullRequest.SlowChecks),
 		RunningChecks:              append([]string(nil), pullRequest.RunningChecks...),
+		RequiredCheckFailures:      telemetryPullRequestChecks(pullRequest.RequiredCheckFailures),
 		CodexReviewState:           pullRequest.CodexReviewState,
 	}
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -292,6 +292,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		}
 		pullRequest.SlowChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.SlowChecks...)
 		pullRequest.RunningChecks = append([]string(nil), issue.PullRequest.RunningChecks...)
+		pullRequest.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), issue.PullRequest.RequiredCheckFailures...)
 		pullRequest.TransientFailedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.TransientFailedChecks...)
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)
 		cloned.PullRequest = &pullRequest

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -614,6 +614,9 @@ func applyPullRequestHydrationBlock(target *connector.PullRequest, source connec
 	if strings.TrimSpace(target.CIStatus) == "" {
 		target.CIStatus = source.CIStatus
 	}
+	if len(target.RequiredCheckFailures) == 0 {
+		target.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), source.RequiredCheckFailures...)
+	}
 }
 
 func retainUnavailablePullRequests(current []connector.Issue, previous []connector.Issue) []connector.Issue {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1054,6 +1054,7 @@ func defaultConnectorFactoryWithRefresh(cfg workflowconfig.Config, refreshGitHub
 		TerminalStates:              cfg.Tracker.TerminalStates,
 		StateMap:                    trackerStateMap(cfg.Tracker.StateMap),
 		PriorityMap:                 trackerPriorityMap(cfg.Tracker.PriorityMap),
+		RequiredStatusChecks:        cfg.Gate.RequiredStatusChecks,
 	})
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -252,6 +252,7 @@ type PullRequest struct {
 	QuietWaitSeconds           int64              `json:"quiet_wait_seconds,omitempty"`
 	SlowChecks                 []PullRequestCheck `json:"slow_checks,omitempty"`
 	RunningChecks              []string           `json:"running_checks,omitempty"`
+	RequiredCheckFailures      []PullRequestCheck `json:"required_check_failures,omitempty"`
 	CodexReviewState           string             `json:"codex_review_state,omitempty"`
 }
 

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -586,6 +586,7 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	b.WriteString("gate:\n")
 	b.WriteString("  kind: command\n")
 	b.WriteString("  run: make check\n")
+	b.WriteString("  required_status_checks: []\n")
 	if hasDeliveryProfile {
 		writeScalar(&b, "  ", "require_automated_review", onboardingBool(settings.GateRequireAutomatedReview))
 	}

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -657,7 +657,7 @@ func TestOnboardingWriteWorkflowAppliesFullAutopilotProfile(t *testing.T) {
 		"dependency_auto_unblock:\n    enabled: true",
 		"max_concurrent_agents_by_state:\n    Merging: 1",
 		"auto_promote:\n    enabled: true\n    quiet_seconds: 0",
-		"gate:\n  kind: command\n  run: make check\n  require_automated_review: false",
+		"gate:\n  kind: command\n  run: make check\n  required_status_checks: []\n  require_automated_review: false",
 		"server:\n  host: 127.0.0.1\n  kanban:\n    mode: integration",
 		"Full autopilot still requires linked PRs, green CI, clear gates, and no blocking P1 automated findings.",
 		"Use live reload or a project-scoped refresh after onboarding changes; do not restart Detent or interrupt running agents unless the operator explicitly authorizes it.",


### PR DESCRIPTION
## Summary

- run release-critical Windows, portability, installer, and snapshot CI on pull requests
- add `gate.required_status_checks` enforcement so Detent blocks missing, skipped, failed, neutral, cancelled, or pending required checks
- document release-blocking PR checks and add workflow/config regression coverage

Fixes #881

## Test Plan

- [x] `go test ./internal/web -run TestOnboardingWriteWorkflowAppliesFullAutopilotProfile -count=1`
- [x] `make check`