### PR TITLE
fix(kanban): hydrate off-board blockers

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -976,6 +976,9 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 			if err := c.populateBlockerReasons(ctx, issues); err != nil {
 				return nil, err
 			}
+			if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+				return nil, err
+			}
 		}
 		if attachPullRequestsForStates(wantedStates) {
 			if err := c.attachFreshPullRequests(ctx, issues); err != nil {
@@ -991,6 +994,9 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 		}
 		if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
 			if err := c.populateBlockerReasons(ctx, issues); err != nil {
+				return nil, err
+			}
+			if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
 				return nil, err
 			}
 		}
@@ -1014,6 +1020,9 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 	}
 	if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
 		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+			return nil, err
+		}
+		if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
 			return nil, err
 		}
 	}
@@ -1042,6 +1051,9 @@ func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []s
 			if err := c.populateBlockerReasons(ctx, issues); err != nil {
 				return nil, err
 			}
+			if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+				return nil, err
+			}
 		}
 		if attachPullRequestsForStates(wantedStates) {
 			if err := c.attachFreshPullRequests(ctx, issues); err != nil {
@@ -1057,6 +1069,9 @@ func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []s
 		}
 		if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
 			if err := c.populateBlockerReasons(ctx, issues); err != nil {
+				return nil, err
+			}
+			if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
 				return nil, err
 			}
 		}
@@ -1080,6 +1095,9 @@ func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []s
 	}
 	if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
 		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+			return nil, err
+		}
+		if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
 			return nil, err
 		}
 	}
@@ -2920,7 +2938,9 @@ func (c *Connector) fetchProjectItemsWithLimit(
 				issues := keptProjectIssues(allIssues, keepIssue, limit)
 				if len(issues) >= limit {
 					c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
-					resolveBlockedByProjectState(issues)
+					if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+						return nil, err
+					}
 					return issues, nil
 				}
 			}
@@ -2928,7 +2948,9 @@ func (c *Connector) fetchProjectItemsWithLimit(
 
 		if !response.Node.Items.PageInfo.HasNextPage {
 			c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
-			resolveBlockedByProjectState(allIssues)
+			if err := c.resolveBlockedByProjectState(ctx, allIssues); err != nil {
+				return nil, err
+			}
 			return keptProjectIssues(allIssues, keepIssue, limit), nil
 		}
 		cursor := strings.TrimSpace(response.Node.Items.PageInfo.EndCursor)
@@ -3072,7 +3094,7 @@ func joinErrors(errs <-chan error) error {
 	return joined
 }
 
-func resolveBlockedByProjectState(issues []connector.Issue) {
+func (c *Connector) resolveBlockedByProjectState(ctx context.Context, issues []connector.Issue) error {
 	byIdentifier := make(map[string]connector.Issue, len(issues))
 	for _, issue := range issues {
 		identifier := normalizedIssueIdentifier(issue.Identifier)
@@ -3081,18 +3103,78 @@ func resolveBlockedByProjectState(issues []connector.Issue) {
 		}
 	}
 
+	missing := []string{}
+	seenMissing := map[string]struct{}{}
 	for issueIndex := range issues {
 		for blockerIndex := range issues[issueIndex].BlockedBy {
 			identifier := normalizedIssueIdentifier(issues[issueIndex].BlockedBy[blockerIndex].Identifier)
 			blocker, ok := byIdentifier[identifier]
 			if !ok {
+				if identifier == "" || strings.TrimSpace(issues[issueIndex].BlockedBy[blockerIndex].State) != "" {
+					continue
+				}
+				if _, seen := seenMissing[identifier]; seen {
+					continue
+				}
+				seenMissing[identifier] = struct{}{}
+				missing = append(missing, issues[issueIndex].BlockedBy[blockerIndex].Identifier)
 				continue
 			}
-			issues[issueIndex].BlockedBy[blockerIndex].ID = blocker.ID
-			issues[issueIndex].BlockedBy[blockerIndex].Identifier = blocker.Identifier
-			issues[issueIndex].BlockedBy[blockerIndex].State = blocker.State
+			c.applyBlockedByIssueState(&issues[issueIndex].BlockedBy[blockerIndex], blocker)
 		}
 	}
+
+	resolved := make(map[string]connector.Issue, len(missing))
+	for _, identifier := range missing {
+		blocker, ok, err := c.fetchIssueByIdentifier(ctx, identifier)
+		if err != nil {
+			if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+				return fmt.Errorf("resolve blocked-by issue %s: %w", identifier, err)
+			}
+			c.logBlockedByHydrationError(ctx, identifier, err)
+			continue
+		}
+		if !ok {
+			continue
+		}
+		key := normalizedIssueIdentifier(identifier)
+		if key != "" {
+			resolved[key] = blocker
+		}
+	}
+
+	for issueIndex := range issues {
+		for blockerIndex := range issues[issueIndex].BlockedBy {
+			identifier := normalizedIssueIdentifier(issues[issueIndex].BlockedBy[blockerIndex].Identifier)
+			blocker, ok := resolved[identifier]
+			if !ok {
+				continue
+			}
+			c.applyBlockedByIssueState(&issues[issueIndex].BlockedBy[blockerIndex], blocker)
+		}
+	}
+	return nil
+}
+
+func (c *Connector) applyBlockedByIssueState(ref *connector.BlockedRef, blocker connector.Issue) {
+	if id := strings.TrimSpace(blocker.ID); id != "" {
+		ref.ID = id
+	}
+	if identifier := strings.TrimSpace(blocker.Identifier); identifier != "" {
+		ref.Identifier = identifier
+	}
+	state := strings.TrimSpace(blocker.State)
+	if blocker.Closed && !stateInList(state, c.terminalStates) {
+		state = c.closedIssueState()
+	}
+	ref.State = state
+}
+
+func (c *Connector) logBlockedByHydrationError(ctx context.Context, identifier string, err error) {
+	if c == nil || c.logger == nil {
+		return
+	}
+	c.logger.DebugContext(ctx, "github blocked-by hydration skipped", "identifier", identifier, "error", err)
 }
 
 func normalizedIssueIdentifier(identifier string) string {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1920,6 +1920,22 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadBlockedByRefs(t *testing.T) 
 			path:   "/repos/digitaldrywood/detent/issues/416/comments?per_page=100",
 			body:   `[{"body":"## Codex Workpad\n\n### Blockers\n- Blocked by: #415\n- Waiting for digitaldrywood/agent-runtime#25\n- Human action needed: merge #415, then move #416 back to Todo.\n\n### Validation\n- Pending."}]`,
 		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/415",
+			body:   `{"node_id":"I_kw415","number":415,"title":"Closed dependency","body":"","state":"CLOSED","html_url":"https://github.com/digitaldrywood/detent/issues/415","labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/agent-runtime/issues/25",
+			body:   `{"node_id":"I_runtime25","number":25,"title":"Open dependency","body":"","state":"OPEN","html_url":"https://github.com/digitaldrywood/agent-runtime/issues/25","labels":[]}`,
+		},
+		{
+			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
 	})
 
 	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
@@ -1933,9 +1949,93 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadBlockedByRefs(t *testing.T) 
 	}
 
 	want := []connector.BlockedRef{
-		{Identifier: "digitaldrywood/detent#415"},
-		{Identifier: "digitaldrywood/agent-runtime#25"},
+		{ID: "I_kw415", Identifier: "digitaldrywood/detent#415", State: "Done"},
+		{ID: "I_runtime25", Identifier: "digitaldrywood/agent-runtime#25", State: "Open"},
 	}
+	if !reflect.DeepEqual(got[0].BlockedBy, want) {
+		t.Fatalf("BlockedBy = %#v, want %#v", got[0].BlockedBy, want)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesResolvesBodyDependencyMissingFromSnapshot(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		restState string
+		wantState string
+	}{
+		{name: "closed dependency clears", restState: "CLOSED", wantState: "Done"},
+		{name: "open dependency stays active", restState: "OPEN", wantState: "Open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGraphQLTestServer(t, []graphqlTestResponse{
+				{
+					body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_163","content":{"__typename":"Issue","id":"I_163","number":163,"title":"Running with body dependency","body":"Depends on: #162","state":"OPEN","url":"https://github.com/digitaldrywood/creswoodcorners-phone/issues/163","repository":{"nameWithOwner":"digitaldrywood/creswoodcorners-phone"}},"statusValue":{"name":"In Progress"},"priorityValue":null}]}}}}`,
+				},
+				{
+					method: http.MethodGet,
+					path:   "/repos/digitaldrywood/creswoodcorners-phone/issues/162",
+					body:   `{"node_id":"I_162","number":162,"title":"Dependency","body":"","state":"` + tt.restState + `","html_url":"https://github.com/digitaldrywood/creswoodcorners-phone/issues/162","labels":[]}`,
+				},
+				{
+					body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+				},
+			})
+			c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+			got, err := c.FetchIssuesByStates(context.Background(), []string{"In Progress"})
+			if err != nil {
+				t.Fatalf("FetchIssuesByStates() error = %v", err)
+			}
+			if len(got) != 1 {
+				t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+			}
+			if len(got[0].BlockedBy) != 1 {
+				t.Fatalf("BlockedBy len = %d, want 1; got %#v", len(got[0].BlockedBy), got[0].BlockedBy)
+			}
+
+			want := connector.BlockedRef{
+				ID:         "I_162",
+				Identifier: "digitaldrywood/creswoodcorners-phone#162",
+				State:      tt.wantState,
+			}
+			if got[0].BlockedBy[0] != want {
+				t.Fatalf("BlockedBy[0] = %#v, want %#v", got[0].BlockedBy[0], want)
+			}
+		})
+	}
+}
+
+func TestConnectorFetchIssuesByStatesKeepsBodyDependencyWhenHydrationFails(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_163","content":{"__typename":"Issue","id":"I_163","number":163,"title":"Running with body dependency","body":"Depends on: #162","state":"OPEN","url":"https://github.com/digitaldrywood/creswoodcorners-phone/issues/163","repository":{"nameWithOwner":"digitaldrywood/creswoodcorners-phone"}},"statusValue":{"name":"In Progress"},"priorityValue":null}]}}}}`,
+		},
+		{
+			status: http.StatusInternalServerError,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/creswoodcorners-phone/issues/162",
+			body:   `{"message":"temporary github failure"}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"In Progress"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	want := []connector.BlockedRef{{Identifier: "digitaldrywood/creswoodcorners-phone#162"}}
 	if !reflect.DeepEqual(got[0].BlockedBy, want) {
 		t.Fatalf("BlockedBy = %#v, want %#v", got[0].BlockedBy, want)
 	}

--- a/internal/connector/github/issuefield.go
+++ b/internal/connector/github/issuefield.go
@@ -262,12 +262,16 @@ func (c *Connector) fetchIssueFieldIssuesByStates(
 			}
 			allIssues = append(allIssues, issue)
 			if limit > 0 && len(allIssues) >= limit {
-				resolveBlockedByProjectState(allIssues)
+				if err := c.resolveBlockedByProjectState(ctx, allIssues); err != nil {
+					return nil, err
+				}
 				return allIssues, nil
 			}
 		}
 		if len(response.Items) == 0 || page*issueSearchPageSize >= response.TotalCount {
-			resolveBlockedByProjectState(allIssues)
+			if err := c.resolveBlockedByProjectState(ctx, allIssues); err != nil {
+				return nil, err
+			}
 			return allIssues, nil
 		}
 	}

--- a/internal/connector/github/issuefield_test.go
+++ b/internal/connector/github/issuefield_test.go
@@ -34,6 +34,16 @@ func TestConnectorIssueFieldFetchIssuesByStates(t *testing.T) {
 			path:   "/repos/digitaldrywood/detent/issues/2/issue-field-values?per_page=100",
 			body:   `[{"issue_field_id":10,"node_id":"IFV_4","data_type":"single_select","value":3,"single_select_option":{"id":3,"name":"Working","color":"yellow"}}]`,
 		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/42",
+			body:   `{"node_id":"I_42","number":42,"title":"External dependency","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/42","assignees":[],"labels":[]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/42/issue-field-values?per_page=100",
+			body:   `[]`,
+		},
 	})
 	c := newGitHubTestConnector(t, server, Config{
 		GitHubStatusSource: GitHubStatusSourceIssueField,
@@ -66,13 +76,13 @@ func TestConnectorIssueFieldFetchIssuesByStates(t *testing.T) {
 	if got[0].AuthorID != "author-1" || got[0].AssigneeID != "worker-1" {
 		t.Fatalf("identity fields = author %q assignee %q", got[0].AuthorID, got[0].AssigneeID)
 	}
-	if !reflect.DeepEqual(got[0].BlockedBy, []connector.BlockedRef{{Identifier: "digitaldrywood/detent#42"}}) {
+	if !reflect.DeepEqual(got[0].BlockedBy, []connector.BlockedRef{{ID: "I_42", Identifier: "digitaldrywood/detent#42", State: "Open"}}) {
 		t.Fatalf("BlockedBy = %#v", got[0].BlockedBy)
 	}
 
 	requests := server.requests()
-	if len(requests) != 4 {
-		t.Fatalf("request count = %d, want metadata, search, and two field reads", len(requests))
+	if len(requests) != 6 {
+		t.Fatalf("request count = %d, want metadata, search, three issue field reads, and blocker issue fetch", len(requests))
 	}
 	searchPath := requests[1]["path"].(string)
 	for _, want := range []string{"repo%3Adigitaldrywood%2Fdetent", "is%3Aissue", "field.Status%3AReady%2CWorking"} {

--- a/internal/connector/github/statuslabel.go
+++ b/internal/connector/github/statuslabel.go
@@ -70,7 +70,9 @@ func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []s
 				c.cacheIssueRef(issue)
 				issues = append(issues, c.buildLabelIssue(issue, externalState))
 				if limit > 0 && len(issues) >= limit {
-					resolveBlockedByProjectState(issues)
+					if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+						return nil, err
+					}
 					return issues, nil
 				}
 			}
@@ -79,7 +81,9 @@ func (c *Connector) fetchLabelIssuesByStates(ctx context.Context, stateNames []s
 			}
 		}
 	}
-	resolveBlockedByProjectState(issues)
+	if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+		return nil, err
+	}
 	return issues, nil
 }
 


### PR DESCRIPTION
## Summary

- Resolve body-text and Workpad blocker refs that are absent from the fetched issue snapshot by hydrating their issue state before Kanban rendering.
- Treat GitHub-closed dependencies as terminal when fetched status is blank or non-terminal, while keeping open off-board dependencies active.
- Keep off-board blocker hydration best-effort so transient dependency lookup failures leave refs unresolved without failing the board fetch.

Fixes #883

## Test Plan

- [x] `go test ./internal/connector/github -count=1`
- [x] `go test ./internal/web/templates -run 'TestProjectKanbanCardForIssueOnlyKeepsActiveBlockers|TestDashboardProjectKanbanDoesNotRenderClearedBlockersAsActive' -count=1`
- [x] `make check`