### PR TITLE
fix(web): show GraphQL quota at rest

### DIFF
--- a/internal/connector/ratelimit.go
+++ b/internal/connector/ratelimit.go
@@ -3,6 +3,7 @@ package connector
 import "time"
 
 const (
+	GraphQLRateLimitStatusUnknown   = "unknown"
 	GraphQLRateLimitStatusBackoff   = "backoff"
 	GraphQLRateLimitStatusExhausted = "exhausted"
 )

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1023,10 +1023,15 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 func gitHubRESTBucket(usage connector.RESTRateLimitUsage, now time.Time) *telemetry.RateLimitBucket {
 	rateLimit := usage.RateLimit
 	var resetAt *time.Time
+	var observedAt *time.Time
 	var resetInSeconds int64
 	if !rateLimit.ResetAt.IsZero() {
 		value := rateLimit.ResetAt
 		resetAt = &value
+	}
+	if !rateLimit.UpdatedAt.IsZero() {
+		value := rateLimit.UpdatedAt
+		observedAt = &value
 	}
 	if rateLimit.RetryAfter > 0 {
 		updatedAt := rateLimit.UpdatedAt
@@ -1049,6 +1054,7 @@ func gitHubRESTBucket(usage connector.RESTRateLimitUsage, now time.Time) *teleme
 		Limit:          rateLimit.Limit,
 		Cost:           usage.TotalRequests,
 		ResetAt:        resetAt,
+		ObservedAt:     observedAt,
 		ResetInSeconds: resetInSeconds,
 	}
 }
@@ -1143,6 +1149,8 @@ func (o *Orchestrator) logGraphQLRateLimitCycle(cycle graphQLRateLimitCycle) {
 
 func graphQLRateLimitTelemetryStatus(status string) string {
 	switch strings.TrimSpace(status) {
+	case connector.GraphQLRateLimitStatusUnknown:
+		return telemetry.RateLimitStatusUnknown
 	case connector.GraphQLRateLimitStatusExhausted:
 		return telemetry.RateLimitStatusExhausted
 	case connector.GraphQLRateLimitStatusBackoff:
@@ -1154,10 +1162,15 @@ func graphQLRateLimitTelemetryStatus(status string) string {
 
 func gitHubGraphQLBucket(rateLimit connector.GraphQLRateLimit, now time.Time, status string) *telemetry.RateLimitBucket {
 	var resetAt *time.Time
+	var observedAt *time.Time
 	var resetInSeconds int64
 	if !rateLimit.ResetAt.IsZero() {
 		value := rateLimit.ResetAt
 		resetAt = &value
+	}
+	if !rateLimit.UpdatedAt.IsZero() {
+		value := rateLimit.UpdatedAt
+		observedAt = &value
 	}
 	if rateLimit.RetryAfter > 0 {
 		updatedAt := rateLimit.UpdatedAt
@@ -1179,6 +1192,7 @@ func gitHubGraphQLBucket(rateLimit connector.GraphQLRateLimit, now time.Time, st
 		Cost:           rateLimit.Cost,
 		Status:         status,
 		ResetAt:        resetAt,
+		ObservedAt:     observedAt,
 		ResetInSeconds: resetInSeconds,
 	}
 }

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -185,6 +185,9 @@ func TestTickPublishesAndLogsGitHubGraphQLCostSummary(t *testing.T) {
 	if state.RateLimits.GitHubGraphQL.Cost != 8 {
 		t.Fatalf("GitHubGraphQL.Cost = %d, want cycle cost 8", state.RateLimits.GitHubGraphQL.Cost)
 	}
+	if state.RateLimits.GitHubGraphQL.ObservedAt == nil || !state.RateLimits.GitHubGraphQL.ObservedAt.Equal(now) {
+		t.Fatalf("GitHubGraphQL.ObservedAt = %v, want %v", state.RateLimits.GitHubGraphQL.ObservedAt, now)
+	}
 	if state.RateLimits.GraphQLCost.TotalCost != 8 || state.RateLimits.GraphQLCost.TotalQueries != 2 {
 		t.Fatalf("GraphQLCost = %#v, want cost 8 queries 2", state.RateLimits.GraphQLCost)
 	}
@@ -235,6 +238,37 @@ func TestTickPublishesGitHubGraphQLExhaustionWithoutRateLimitSnapshot(t *testing
 	}
 	if state.RateLimits.GitHubGraphQL.Limit != 0 || state.RateLimits.GitHubGraphQL.Remaining != 0 {
 		t.Fatalf("GitHubGraphQL = %#v, want status-only exhausted bucket", state.RateLimits.GitHubGraphQL)
+	}
+}
+
+func TestTickPublishesGitHubGraphQLUnknownWithoutRateLimitSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        30 * time.Second,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &rateLimitConnector{
+		usage: connector.GraphQLRateLimitUsage{
+			RateLimitStatus: connector.GraphQLRateLimitStatusUnknown,
+		},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if state.RateLimits == nil || state.RateLimits.GitHubGraphQL == nil {
+		t.Fatalf("RateLimits = %#v, want GitHub GraphQL status bucket", state.RateLimits)
+	}
+	if state.RateLimits.GitHubGraphQL.Status != telemetry.RateLimitStatusUnknown {
+		t.Fatalf("GitHubGraphQL.Status = %q, want %q", state.RateLimits.GitHubGraphQL.Status, telemetry.RateLimitStatusUnknown)
+	}
+	if state.RateLimits.GitHubGraphQL.Limit != 0 || state.RateLimits.GitHubGraphQL.Remaining != 0 {
+		t.Fatalf("GitHubGraphQL = %#v, want status-only unknown bucket", state.RateLimits.GitHubGraphQL)
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -431,6 +431,10 @@ func cloneRateLimitBucket(bucket *telemetry.RateLimitBucket) *telemetry.RateLimi
 		resetAt := *bucket.ResetAt
 		cloned.ResetAt = &resetAt
 	}
+	if bucket.ObservedAt != nil {
+		observedAt := *bucket.ObservedAt
+		cloned.ObservedAt = &observedAt
+	}
 	return &cloned
 }
 

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -452,6 +452,7 @@ type RateLimits struct {
 }
 
 const (
+	RateLimitStatusUnknown   = "unknown"
 	RateLimitStatusBackoff   = "backoff"
 	RateLimitStatusExhausted = "exhausted"
 )
@@ -463,6 +464,7 @@ type RateLimitBucket struct {
 	Cost           int64      `json:"cost,omitempty"`
 	Status         string     `json:"status,omitempty"`
 	ResetAt        *time.Time `json:"reset_at,omitempty"`
+	ObservedAt     *time.Time `json:"observed_at,omitempty"`
 	ResetInSeconds int64      `json:"reset_in_seconds,omitempty"`
 	HasCredits     bool       `json:"has_credits,omitempty"`
 	Unlimited      bool       `json:"unlimited,omitempty"`

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -5987,6 +5987,9 @@ func rateLimitRows(limits *telemetry.RateLimits) []rateLimitRow {
 }
 
 func rateLimitRemainingLabel(bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusUnknown {
+		return "unknown"
+	}
 	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
 		return "exhausted"
 	}
@@ -5997,6 +6000,9 @@ func rateLimitRemainingLabel(bucket *telemetry.RateLimitBucket) string {
 }
 
 func rateLimitUsedLabel(bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusUnknown {
+		return "usage unknown"
+	}
 	label := formatInt(bucket.Used) + " used"
 	if bucket.Cost > 0 {
 		label += " / cost " + formatInt(bucket.Cost)
@@ -6005,6 +6011,9 @@ func rateLimitUsedLabel(bucket *telemetry.RateLimitBucket) string {
 }
 
 func rateLimitLimitLabel(bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusUnknown {
+		return "limit unknown"
+	}
 	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 {
 		return "limit unknown"
 	}
@@ -6073,6 +6082,9 @@ func graphQLBudgetRemaining(limits *telemetry.RateLimits) string {
 		return "n/a"
 	}
 	bucket := limits.GitHubGraphQL
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusUnknown {
+		return "unknown"
+	}
 	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
 		return "exhausted"
 	}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -150,6 +150,7 @@ type gitHubAPIHealthState string
 
 const (
 	gitHubAPIHealthStateUnknown   gitHubAPIHealthState = "unknown"
+	gitHubAPIHealthStateAtRest    gitHubAPIHealthState = "at-rest"
 	gitHubAPIHealthStateHealthy   gitHubAPIHealthState = "healthy"
 	gitHubAPIHealthStateWarning   gitHubAPIHealthState = "warning"
 	gitHubAPIHealthStateBackoff   gitHubAPIHealthState = "backoff"
@@ -6291,19 +6292,26 @@ func gitHubAPIHealth(snapshot telemetry.Snapshot) gitHubAPIHealthView {
 		view.Detail = "Primary quota is below the warning threshold; " + gitHubAPIWarningReset(snapshot.RateLimits) + "."
 		return view
 	}
+	if gitHubAPIGraphQLAtRest(snapshot.RateLimits) {
+		view.State = gitHubAPIHealthStateAtRest
+		view.Label = "GitHub API at rest"
+		view.Summary = gitHubAPIAtRestSummary(snapshot.RateLimits)
+		view.Detail = "GraphQL quota is reported from live GraphQL traffic; none has occurred in this session. This is expected while boards are idle or when the status source is label-backed."
+		return view
+	}
 	if gitHubAPIGraphQLPrimaryUnknown(snapshot.RateLimits) {
 		restContext := gitHubAPIRESTPrimaryContext(snapshot.RateLimits)
 		view.State = gitHubAPIHealthStateUnknown
 		view.Label = "GitHub API GraphQL unknown"
 		view.Summary = restContext + ". GraphQL primary quota unavailable."
-		view.Detail = "REST primary quota is visible, but GraphQL primary quota is unavailable; doctor may still fail when GraphQL is exhausted."
+		view.Detail = "REST primary quota is visible, but GraphQL primary quota could not be determined after an observation attempt."
 		return view
 	}
 
 	view.State = gitHubAPIHealthStateHealthy
 	view.Label = "GitHub API healthy"
 	view.Summary = primarySummary
-	view.Detail = "Primary quota is available and no secondary REST backoff is active."
+	view.Detail = gitHubAPIHealthyDetail(snapshot)
 	return view
 }
 
@@ -6322,6 +6330,8 @@ func gitHubAPIHealthClass(snapshot telemetry.Snapshot) string {
 	switch gitHubAPIHealth(snapshot).State {
 	case gitHubAPIHealthStateHealthy:
 		return "border-success-soft bg-success-soft text-success"
+	case gitHubAPIHealthStateAtRest:
+		return "border-accent-soft bg-accent-soft text-accent"
 	case gitHubAPIHealthStateWarning, gitHubAPIHealthStateBackoff:
 		return "border-warning-soft bg-warning-soft text-warning"
 	case gitHubAPIHealthStateExhausted:
@@ -6335,6 +6345,8 @@ func gitHubAPIHealthDotClass(snapshot telemetry.Snapshot) string {
 	switch gitHubAPIHealth(snapshot).State {
 	case gitHubAPIHealthStateHealthy:
 		return "bg-success"
+	case gitHubAPIHealthStateAtRest:
+		return "bg-accent"
 	case gitHubAPIHealthStateWarning, gitHubAPIHealthStateBackoff:
 		return "bg-warning"
 	case gitHubAPIHealthStateExhausted:
@@ -6348,6 +6360,8 @@ func gitHubAPIHealthBadgeClass(snapshot telemetry.Snapshot) string {
 	switch gitHubAPIHealth(snapshot).State {
 	case gitHubAPIHealthStateHealthy:
 		return "border-success-soft bg-success-soft text-success"
+	case gitHubAPIHealthStateAtRest:
+		return "border-accent-soft bg-accent-soft text-accent"
 	case gitHubAPIHealthStateWarning, gitHubAPIHealthStateBackoff:
 		return "border-warning-soft bg-warning-soft text-warning"
 	case gitHubAPIHealthStateExhausted:
@@ -6361,6 +6375,8 @@ func gitHubAPIHealthStateLabel(snapshot telemetry.Snapshot) string {
 	switch gitHubAPIHealth(snapshot).State {
 	case gitHubAPIHealthStateHealthy:
 		return "Healthy"
+	case gitHubAPIHealthStateAtRest:
+		return "At rest"
 	case gitHubAPIHealthStateWarning:
 		return "Warning"
 	case gitHubAPIHealthStateBackoff:
@@ -6403,6 +6419,9 @@ func gitHubAPIHealthPrimaryQuotaLabel(snapshot telemetry.Snapshot) string {
 }
 
 func gitHubAPIHealthPrimaryQuotaDetail(snapshot telemetry.Snapshot) string {
+	if gitHubAPIGraphQLAtRest(snapshot.RateLimits) {
+		return "REST primary quota is shown below. GraphQL quota will appear after live GraphQL traffic is observed."
+	}
 	if gitHubAPIHasSnapshot(snapshot.RateLimits) {
 		return "REST and GraphQL primary buckets are shown below with remaining quota, usage, limits, and reset timing."
 	}
@@ -6445,6 +6464,7 @@ func gitHubAPIBucketKnown(bucket *telemetry.RateLimitBucket) bool {
 			bucket.Remaining > 0 ||
 			bucket.Used > 0 ||
 			bucket.ResetAt != nil ||
+			bucket.ObservedAt != nil ||
 			bucket.ResetInSeconds > 0)
 }
 
@@ -6490,6 +6510,15 @@ func gitHubAPIBucketWarning(bucket *telemetry.RateLimitBucket) bool {
 		return true
 	}
 	return float64(bucket.Remaining)/float64(bucket.Limit) <= gitHubAPIWarningRatio
+}
+
+func gitHubAPIGraphQLAtRest(limits *telemetry.RateLimits) bool {
+	return limits != nil &&
+		gitHubAPIBucketKnown(limits.GitHubREST) &&
+		!gitHubAPIBucketWarning(limits.GitHubREST) &&
+		!gitHubAPIBucketExhausted(limits.GitHubREST) &&
+		!gitHubAPIBucketKnown(limits.GitHubGraphQL) &&
+		(limits.GraphQLCost == nil || limits.GraphQLCost.TotalQueries == 0)
 }
 
 func gitHubAPIInBackoff(snapshot telemetry.Snapshot) bool {
@@ -6547,7 +6576,9 @@ func gitHubAPIDeadlineActive(generatedAt time.Time, deadline *time.Time) bool {
 }
 
 func gitHubAPIGraphQLPrimaryUnknown(limits *telemetry.RateLimits) bool {
-	return limits != nil && gitHubAPIBucketKnown(limits.GitHubREST) && !gitHubAPIBucketKnown(limits.GitHubGraphQL)
+	return limits != nil &&
+		gitHubAPIBucketKnown(limits.GitHubREST) &&
+		rateLimitBucketStatus(limits.GitHubGraphQL) == telemetry.RateLimitStatusUnknown
 }
 
 func gitHubAPIPrimarySummary(limits *telemetry.RateLimits) string {
@@ -6567,6 +6598,9 @@ func gitHubAPIPrimarySummary(limits *telemetry.RateLimits) string {
 }
 
 func gitHubAPIPrimaryBucketSummary(label string, bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusUnknown {
+		return label + ": unknown"
+	}
 	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
 		return label + ": exhausted"
 	}
@@ -6581,6 +6615,30 @@ func gitHubAPIPrimaryBucketSummary(label string, bucket *telemetry.RateLimitBuck
 		return label + ": " + remaining + " (" + formatInt(bucket.Used) + " used)"
 	}
 	return label + ": " + remaining
+}
+
+func gitHubAPIHealthyDetail(snapshot telemetry.Snapshot) string {
+	detail := "Primary quota is available and no secondary REST backoff is active."
+	freshness := gitHubAPIGraphQLObservationFreshness(snapshot)
+	if freshness == "" {
+		return detail
+	}
+	return detail + " GraphQL quota " + freshness + "."
+}
+
+func gitHubAPIAtRestSummary(limits *telemetry.RateLimits) string {
+	return "REST primary: " + gitHubAPIPrimaryBucketCompact(limits.GitHubREST) + ". No GraphQL usage this session."
+}
+
+func gitHubAPIGraphQLObservationFreshness(snapshot telemetry.Snapshot) string {
+	if snapshot.RateLimits == nil || snapshot.RateLimits.GitHubGraphQL == nil || snapshot.RateLimits.GitHubGraphQL.ObservedAt == nil {
+		return ""
+	}
+	observedAt := snapshot.RateLimits.GitHubGraphQL.ObservedAt.UTC()
+	if snapshot.GeneratedAt.IsZero() || observedAt.After(snapshot.GeneratedAt) {
+		return "observed " + timeLabel(observedAt)
+	}
+	return "observed " + formatDuration(snapshot.GeneratedAt.Sub(observedAt).Seconds()) + " ago"
 }
 
 func gitHubAPIPrimaryBucketUsed(bucket *telemetry.RateLimitBucket) int64 {
@@ -6750,6 +6808,9 @@ func gitHubAPIHealthBucketRows(limits *telemetry.RateLimits) []gitHubAPIHealthBu
 }
 
 func gitHubAPIHealthBucketRemaining(bucket *telemetry.RateLimitBucket) string {
+	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusUnknown {
+		return "unknown"
+	}
 	if rateLimitBucketStatus(bucket) == telemetry.RateLimitStatusExhausted && bucket.Limit <= 0 && bucket.Remaining == 0 {
 		return "exhausted"
 	}

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -161,6 +161,7 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 	lastRefresh := now.Add(-30 * time.Second)
 	nextRefresh := now.Add(90 * time.Second)
 	resetAt := now.Add(30 * time.Minute)
+	observedAt := now.Add(-3 * time.Hour)
 	backoffUntil := now.Add(5 * time.Minute)
 	expiredBackoffUntil := now.Add(-5 * time.Minute)
 
@@ -215,11 +216,50 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 			wantSummaryPart: "REST primary: 4,878 remaining / 5,000 total (122 used)",
 		},
 		{
-			name: "rest primary without graphql remains unknown",
+			name: "never observed graphql stays at rest",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,
 				RateLimits: &telemetry.RateLimits{
 					GitHubREST: &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+				},
+			},
+			wantState:       gitHubAPIHealthStateAtRest,
+			wantLabel:       "GitHub API at rest",
+			wantSummaryPart: "REST primary: 4,878/5,000 remaining. No GraphQL usage this session.",
+			wantDetailParts: []string{
+				"GraphQL quota is reported from live GraphQL traffic",
+				"none has occurred in this session",
+				"This is expected while boards are idle or when the status source is label-backed",
+			},
+			rejectDetailPart: "GraphQL unknown",
+		},
+		{
+			name: "observed then idle shows freshness",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST: &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+					GitHubGraphQL: &telemetry.RateLimitBucket{
+						Remaining:  4880,
+						Used:       120,
+						Limit:      5000,
+						ResetAt:    &resetAt,
+						ObservedAt: &observedAt,
+					},
+				},
+			},
+			wantState:       gitHubAPIHealthStateHealthy,
+			wantLabel:       "GitHub API healthy",
+			wantSummaryPart: "GraphQL primary: 4,880 remaining / 5,000 total (120 used)",
+			wantDetailParts: []string{"GraphQL quota observed 3h 0m ago"},
+		},
+		{
+			name: "probe failed keeps graphql unknown",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST:    &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+					GitHubGraphQL: &telemetry.RateLimitBucket{Status: telemetry.RateLimitStatusUnknown},
 				},
 			},
 			wantState:       gitHubAPIHealthStateUnknown,
@@ -227,7 +267,7 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 			wantSummaryPart: "GraphQL primary quota unavailable",
 			wantDetailParts: []string{
 				"REST primary quota is visible",
-				"GraphQL primary quota is unavailable",
+				"could not be determined after an observation attempt",
 			},
 		},
 		{

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -474,6 +474,30 @@ func TestGitHubAPIHealthDerivesStatus(t *testing.T) {
 	}
 }
 
+func TestGraphQLUnknownStatusFormatsBudgetLabels(t *testing.T) {
+	t.Parallel()
+
+	limits := &telemetry.RateLimits{
+		GitHubGraphQL: &telemetry.RateLimitBucket{Status: telemetry.RateLimitStatusUnknown},
+	}
+
+	if got := graphQLBudgetRemaining(limits); got != "unknown" {
+		t.Fatalf("graphQLBudgetRemaining() = %q, want unknown", got)
+	}
+
+	rows := rateLimitRows(limits)
+	if len(rows) != 1 {
+		t.Fatalf("rateLimitRows() len = %d, want 1: %#v", len(rows), rows)
+	}
+	row := rows[0]
+	if row.Name != "GitHub GraphQL" ||
+		row.Remaining != "unknown" ||
+		row.Used != "usage unknown" ||
+		row.Limit != "limit unknown" {
+		t.Fatalf("rateLimitRows()[0] = %#v, want unknown GraphQL labels", row)
+	}
+}
+
 func TestThroughputTrendPoints(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -619,6 +619,17 @@ func TestDashboardRendersSidebarGitHubAPIHealthStateMetadata(t *testing.T) {
 			wantLabel: "GitHub API healthy",
 		},
 		{
+			name: "at rest",
+			snapshot: telemetry.Snapshot{
+				GeneratedAt: now,
+				RateLimits: &telemetry.RateLimits{
+					GitHubREST: &telemetry.RateLimitBucket{Remaining: 4878, Used: 122, Limit: 5000, ResetAt: &resetAt},
+				},
+			},
+			wantState: "at-rest",
+			wantLabel: "GitHub API at rest",
+		},
+		{
 			name: "warning",
 			snapshot: telemetry.Snapshot{
 				GeneratedAt: now,
@@ -4717,6 +4728,8 @@ func gitHubAPIHealthStateTestLabel(state string) string {
 	switch state {
 	case "healthy":
 		return "Healthy"
+	case "at-rest":
+		return "At rest"
 	case "warning":
 		return "Warning"
 	case "backoff":


### PR DESCRIPTION
## Summary

- Render healthy REST-only GitHub API snapshots as a neutral at-rest state instead of GraphQL unknown.
- Carry GraphQL rate-limit observation timestamps into telemetry and show freshness when present.
- Preserve explicit Unknown handling for attempted GraphQL observation/probe failures, including generic budget labels.

Fixes #885

## Test Plan

- [x] `go test ./internal/web/templates ./internal/orchestrator -run 'TestGitHubAPIHealthDerivesStatus|TestDashboardRendersSidebarGitHubAPIHealthStateMetadata|TestTickPublishesAndLogsGitHubGraphQLCostSummary|TestTickPublishesGitHubGraphQLUnknownWithoutRateLimitSnapshot|TestTickPublishesGitHubGraphQLExhaustionWithoutRateLimitSnapshot|TestTickPausesUntilGitHubGraphQLResetWhenRemainingLow|TestTickPausesForGitHubGraphQLRetryAfterWithPrimaryRemaining'`
- [x] `go test ./internal/web/templates -run 'TestGitHubAPIHealthDerivesStatus|TestGraphQLUnknownStatusFormatsBudgetLabels|TestDashboardRendersSidebarGitHubAPIHealthStateMetadata'`
- [x] `go test ./internal/web/templates ./internal/orchestrator ./internal/telemetry ./internal/connector`
- [x] `make check`
