### PR TITLE
fix(github): isolate REST budget pools

### DIFF
--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -66,6 +66,7 @@ type Client struct {
 	hasRateLimitUsage      bool
 	graphQLRateLimitStatus string
 	restRateLimit          connector.RESTRateLimit
+	restRateLimits         map[string]connector.RESTRateLimit
 	restRequests           map[string]connector.RESTEndpointUsage
 	restBackoffUntil       time.Time
 	restBackoffKey         string
@@ -621,8 +622,9 @@ func (c *Client) restBudgetPolicyError(method string, path string) error {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	rateLimit, hasRateLimit := c.restRateLimitForResourceLocked(restEndpointRateLimitResource(family))
 	if c.restPolicy.FanoutMaxRequests > 0 && c.restFanoutRequestCountLocked() >= c.restPolicy.FanoutMaxRequests {
-		c.recordRESTBudgetThrottleLocked(method, path, family)
+		c.recordRESTBudgetThrottleLocked(method, path, family, rateLimit, hasRateLimit)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       "REST fanout request cap reached for " + family,
@@ -630,10 +632,10 @@ func (c *Client) restBudgetPolicyError(method string, path string) error {
 		}
 	}
 	if c.restPolicy.MinRemainingReserve > 0 &&
-		c.hasRestRateLimit &&
-		c.restRateLimit.Limit > 0 &&
-		c.restRateLimit.Remaining <= c.restPolicy.MinRemainingReserve {
-		c.recordRESTBudgetThrottleLocked(method, path, family)
+		hasRateLimit &&
+		rateLimit.Limit > 0 &&
+		rateLimit.Remaining <= c.restPolicy.MinRemainingReserve {
+		c.recordRESTBudgetThrottleLocked(method, path, family, rateLimit, hasRateLimit)
 		return &StatusError{
 			StatusCode: http.StatusTooManyRequests,
 			Body:       "REST remaining budget is reserved for shared GitHub work",
@@ -653,7 +655,20 @@ func (c *Client) restFanoutRequestCountLocked() int64 {
 	return count
 }
 
-func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, family string) {
+func (c *Client) restRateLimitForResourceLocked(resource string) (connector.RESTRateLimit, bool) {
+	resource = strings.TrimSpace(resource)
+	if resource != "" && c.restRateLimits != nil {
+		if rateLimit, ok := c.restRateLimits[resource]; ok {
+			return rateLimit, true
+		}
+	}
+	if c.hasRestRateLimit && (resource == "" || c.restRateLimit.Resource == "" || c.restRateLimit.Resource == resource) {
+		return c.restRateLimit, true
+	}
+	return connector.RESTRateLimit{}, false
+}
+
+func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, family string, rateLimit connector.RESTRateLimit, hasRateLimit bool) {
 	if c.restRequests == nil {
 		c.restRequests = make(map[string]connector.RESTEndpointUsage)
 	}
@@ -662,13 +677,13 @@ func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, fami
 	request.Count++
 	request.RateLimited = true
 	request.LastStatus = http.StatusTooManyRequests
-	if c.hasRestRateLimit {
-		request.Limit = c.restRateLimit.Limit
-		request.Used = c.restRateLimit.Used
-		request.Remaining = c.restRateLimit.Remaining
-		request.Resource = c.restRateLimit.Resource
-		request.ResetAt = c.restRateLimit.ResetAt
-		request.RetryAfter = c.restRateLimit.RetryAfter
+	if hasRateLimit {
+		request.Limit = rateLimit.Limit
+		request.Used = rateLimit.Used
+		request.Remaining = rateLimit.Remaining
+		request.Resource = rateLimit.Resource
+		request.ResetAt = rateLimit.ResetAt
+		request.RetryAfter = rateLimit.RetryAfter
 	}
 	c.restRequests[family] = request
 	c.logger.Warn(
@@ -676,7 +691,8 @@ func (c *Client) recordRESTBudgetThrottleLocked(method string, path string, fami
 		"method", strings.ToUpper(strings.TrimSpace(method)),
 		"path", path,
 		"endpoint_family", family,
-		"remaining", c.restRateLimit.Remaining,
+		"resource", rateLimit.Resource,
+		"remaining", rateLimit.Remaining,
 		"reserve", c.restPolicy.MinRemainingReserve,
 		"fanout_cap", c.restPolicy.FanoutMaxRequests,
 	)
@@ -702,9 +718,10 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 	remaining, hasRemaining := int64Header(headers, "X-RateLimit-Remaining")
 	reset, hasReset := int64Header(headers, "X-RateLimit-Reset")
 	retryAfter, hasRetryAfter := parseRetryAfter(headers.Get("Retry-After"), now)
-	resource := strings.TrimSpace(headers.Get("X-RateLimit-Resource"))
 	rateLimited := restStatusRateLimited(status, headers)
 	family := restEndpointFamily(method, path)
+	resourceHeader := strings.TrimSpace(headers.Get("X-RateLimit-Resource"))
+	resource := restRateLimitResourceName(resourceHeader, family)
 	sharedBackoff := rateLimited && restShouldApplySharedBackoff(family, remaining, hasRemaining)
 
 	var resetAt time.Time
@@ -719,6 +736,9 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 		c.restBackoffKey = backoffKey
 	}
 	snapshot := c.restRateLimit
+	if resource != "" && c.restRateLimits != nil {
+		snapshot = c.restRateLimits[resource]
+	}
 	hasSnapshot := false
 	if hasLimit {
 		snapshot.Limit = limit
@@ -736,19 +756,25 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 		snapshot.ResetAt = resetAt
 		hasSnapshot = true
 	}
-	if resource != "" {
-		snapshot.Resource = resource
-		hasSnapshot = true
-	}
 	if hasRetryAfter && sharedBackoff {
 		snapshot.RetryAfter = retryAfter
 		hasSnapshot = true
 	} else if hasSnapshot {
 		snapshot.RetryAfter = 0
 	}
+	if resource != "" && (hasSnapshot || resourceHeader != "") {
+		snapshot.Resource = resource
+		hasSnapshot = true
+	}
 	if hasSnapshot {
 		snapshot.UpdatedAt = now
 		c.restRateLimit = snapshot
+		if resource != "" {
+			if c.restRateLimits == nil {
+				c.restRateLimits = make(map[string]connector.RESTRateLimit)
+			}
+			c.restRateLimits[resource] = snapshot
+		}
 		c.hasRestRateLimit = true
 	}
 
@@ -772,7 +798,7 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 	if hasReset {
 		request.ResetAt = resetAt
 	}
-	if resource != "" {
+	if resource != "" && (hasLimit || hasUsed || hasRemaining || hasReset || hasRetryAfter || resourceHeader != "") {
 		request.Resource = resource
 	}
 	if hasRetryAfter {
@@ -1245,6 +1271,20 @@ func restShouldApplySharedBackoff(family string, remaining int64, hasRemaining b
 		return true
 	}
 	return hasRemaining && remaining <= 0
+}
+
+func restRateLimitResourceName(headerResource string, family string) string {
+	if headerResource != "" {
+		return headerResource
+	}
+	return restEndpointRateLimitResource(family)
+}
+
+func restEndpointRateLimitResource(family string) string {
+	if family == "search" {
+		return "search"
+	}
+	return "core"
 }
 
 func restBackoffUntil(

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -796,6 +796,71 @@ func TestClientRESTStopsFanoutBelowReserve(t *testing.T) {
 	}
 }
 
+func TestClientRESTAllowsCoreFanoutAfterSearchPoolBelowReserve(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		switch call := calls.Add(1); call {
+		case 1:
+			if r.URL.Path != "/search/issues" {
+				t.Fatalf("first path = %s, want search issues path", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-RateLimit-Limit", "30")
+			w.Header().Set("X-RateLimit-Used", "2")
+			w.Header().Set("X-RateLimit-Remaining", "28")
+			w.Header().Set("X-RateLimit-Resource", "search")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`{"total_count":0,"incomplete_results":false,"items":[]}`))
+		case 2:
+			if r.URL.Path != "/repos/digitaldrywood/detent/pulls" {
+				t.Fatalf("second path = %s, want pull requests path", r.URL.Path)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("X-RateLimit-Limit", "5000")
+			w.Header().Set("X-RateLimit-Used", "19")
+			w.Header().Set("X-RateLimit-Remaining", "4981")
+			w.Header().Set("X-RateLimit-Resource", "core")
+			w.WriteHeader(http.StatusOK)
+			_, _ = w.Write([]byte(`[]`))
+		default:
+			t.Fatalf("unexpected REST call %d to %s", call, r.URL.Path)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+		RESTPolicy:  RESTBudgetPolicy{MinRemainingReserve: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var search restIssueSearchResponse
+	if err := client.REST(context.Background(), http.MethodGet, "/search/issues?q=repo%3Adigitaldrywood%2Fdetent", nil, &search); err != nil {
+		t.Fatalf("REST() issue search error = %v", err)
+	}
+	var pulls []restPullRequest
+	if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/pulls?state=all", nil, &pulls); err != nil {
+		t.Fatalf("REST() pull requests after search budget error = %v", err)
+	}
+	if calls.Load() != 2 {
+		t.Fatalf("REST calls = %d, want search and pull requests sent", calls.Load())
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+	if usage.RateLimited {
+		t.Fatalf("RESTRateLimitUsage.RateLimited = true, want no reserved budget throttle")
+	}
+	if usage.RateLimit.Resource != "core" || usage.RateLimit.Remaining != 4981 {
+		t.Fatalf("RateLimit = %#v, want latest core pull request snapshot", usage.RateLimit)
+	}
+}
+
 func TestClientRESTBackoffAppliesAcrossClientsWithSharedToken(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Keep REST rate-limit snapshots per resource so search-pool headers do not gate core pull request fanout.
- Record synthetic REST budget throttles from the matching resource snapshot when available.

Fixes #887

## Test Plan

- [x] `go test ./internal/connector/github -run 'TestClientREST(AllowsCoreFanoutAfterSearchPoolBelowReserve|StopsFanoutBelowReserve|StopsFanoutAtRequestCap|CountsRepositoryIssuesAsFanout)' -count=1 -v`
- [x] `go test ./internal/connector/github -count=1`
- [x] `make check`