### PR TITLE
fix(doctor): avoid inflated token impact

### DIFF
--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -600,7 +600,7 @@ func doctorWorkflowOptimizationFindings(
 		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleEmptyModelTelemetry,
 			"Session model telemetry is incomplete",
 			fmt.Sprintf("%d of %d recent sessions have an empty model", metrics.EmptyModelRecentSessions, metrics.RecentSessionCount),
-			int64(float64(metrics.TotalTokens)*metrics.EmptyModelRecentFraction),
+			0,
 			map[string]any{
 				"recent_session_count":        metrics.RecentSessionCount,
 				"empty_model_recent_sessions": metrics.EmptyModelRecentSessions,
@@ -635,7 +635,7 @@ func doctorWorkflowOptimizationFindings(
 		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleSchedulerSkipRate,
 			"Scheduler skip rate is high",
 			fmt.Sprintf("%.0f%% of recent scheduler decisions skipped dispatch", metrics.SchedulerSkipRate*100),
-			metrics.SchedulerSkippedDecisions*metrics.MedianSessionTokens,
+			0,
 			map[string]any{
 				"scheduler_decision_count":    metrics.SchedulerDecisionCount,
 				"scheduler_skipped_decisions": metrics.SchedulerSkippedDecisions,

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -111,6 +111,49 @@ func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
 	}
 }
 
+func TestDoctorWorkflowOptimizationFindingsTokenImpactIsAvoidable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		ruleID  string
+		metrics doctorWorkflowOptimizationMetrics
+	}{
+		{
+			name:   "empty model telemetry does not charge historical usage",
+			ruleID: doctorWorkflowRuleEmptyModelTelemetry,
+			metrics: doctorWorkflowOptimizationMetrics{
+				TotalTokens:              4_720_170_000,
+				RecentSessionCount:       50,
+				EmptyModelRecentSessions: 48,
+				EmptyModelRecentFraction: 0.96,
+			},
+		},
+		{
+			name:   "scheduler skips do not charge full agent sessions",
+			ruleID: doctorWorkflowRuleSchedulerSkipRate,
+			metrics: doctorWorkflowOptimizationMetrics{
+				MedianSessionTokens:       7_710_440,
+				SchedulerDecisionCount:    1_704,
+				SchedulerSkippedDecisions: 1_136,
+				SchedulerSkipRate:         0.67,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", workflowconfig.Config{}, tt.metrics)
+			finding := doctorWorkflowFindingByRule(t, findings, tt.ruleID)
+			if finding.EstimatedTokenImpact != 0 {
+				t.Fatalf("EstimatedTokenImpact = %d, want 0", finding.EstimatedTokenImpact)
+			}
+		})
+	}
+}
+
 func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Set empty model telemetry findings to zero avoidable token impact because missing model attribution is observability-only.
- Set scheduler skip-rate findings to zero avoidable token impact because skipped decisions do not start agent sessions.
- Add table-driven regression coverage using issue-scale metrics that previously produced inflated estimates.

Fixes #888

## Test Plan

- [x] `go test ./internal/cli -run 'TestDoctorWorkflowOptimization' -count=1`
- [x] `make check`