### PR TITLE
fix(doctor): suppress connector logs in progress

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/url"
@@ -2406,6 +2407,7 @@ func defaultDoctorAutoPromoteConnector(cfg workflowconfig.Config) (doctorAutoPro
 		TerminalStates:              cfg.Tracker.TerminalStates,
 		StateMap:                    doctorTrackerStateMap(cfg.Tracker.StateMap),
 		RequiredStatusChecks:        cfg.Gate.RequiredStatusChecks,
+		Logger:                      doctorConnectorLogger(),
 	})
 }
 
@@ -2505,7 +2507,12 @@ func doctorGitHubConnectorConfig(cfg workflowconfig.Config) ghconnector.Config {
 		ObservedStates:          cfg.Tracker.ObservedStates,
 		TerminalStates:          cfg.Tracker.TerminalStates,
 		StateMap:                doctorTrackerStateMap(cfg.Tracker.StateMap),
+		Logger:                  doctorConnectorLogger(),
 	}
+}
+
+func doctorConnectorLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
 }
 
 func doctorGitHubReadinessConfig(

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -1565,6 +1566,71 @@ func TestDoctorCommandAllowWriteProbesFlagEnablesWriteReadiness(t *testing.T) {
 	}
 	if !gotReadiness.RequireLabelStatusWrite || !gotReadiness.RequireIssueComments {
 		t.Fatalf("readiness write requirements = %#v, want write probes enabled by flag", gotReadiness)
+	}
+}
+
+func TestRunDoctorSuppressesConnectorLogsFromProgress(t *testing.T) {
+	workflow := validDoctorWorkflow("/repo")
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	workflow.Tracker.APIKey = "token"
+	workflow.Tracker.ProjectSlug = "PVT_1"
+	workflow.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+	workflow.Tracker.ObservedStates = []string{"Human Review", "Blocked"}
+	workflow.Tracker.TerminalStates = []string{"Done", "Cancelled"}
+
+	configPath := filepath.Join(t.TempDir(), "global.yaml")
+	global := validDoctorGlobalWithProjects(configPath, "alpha")
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = func(string) (workflowconfig.Workflow, error) {
+		return workflowconfig.Workflow{Config: workflow}, nil
+	}
+	deps.autoPromoteConnector = func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+		return &fakeDoctorAutoPromoteConnector{}, nil
+	}
+
+	var progress bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&progress, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})))
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	deps.githubReadiness = func(_ context.Context, connectorCfg ghconnector.Config, _ ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
+		logger := connectorCfg.Logger
+		if logger == nil {
+			logger = slog.Default()
+		}
+		logger.Warn(
+			"github rest budget preserved",
+			"method", "GET",
+			"path", "/repos/digitaldrywood/detent/pulls?state=all",
+			"endpoint_family", "pull requests",
+		)
+		return []ghconnector.ReadinessCheck{{
+			Name:   "GitHub readiness",
+			Status: ghconnector.ReadinessOK,
+			Detail: "ready",
+		}}, nil
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:   configPath,
+		Output:       &progress,
+		CheckTimeout: time.Second,
+		Flags: runtimeFlags{
+			Port: runtimeIntFlag{Value: 0, Set: true},
+		},
+	}, successfulDoctorOptionsWithConfig(configPath, global), deps)
+
+	assertDoctorCheck(t, report, "Project alpha GitHub readiness", doctorOK, "ready")
+	got := progress.String()
+	if strings.Contains(got, "github rest budget preserved") {
+		t.Fatalf("doctor progress contains connector log record:\n%s", got)
+	}
+	if !strings.Contains(got, "RUN    Project alpha checks") || !strings.Contains(got, "OK     Project alpha GitHub readiness") {
+		t.Fatalf("doctor progress missing expected check lines:\n%s", got)
 	}
 }
 

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"log/slog"
 	"strings"
 	"time"
 
@@ -47,6 +48,7 @@ type Config struct {
 	StateMap                    map[string]string
 	PriorityMap                 map[string]*int
 	RequiredStatusChecks        []string
+	Logger                      *slog.Logger
 }
 
 func NewFromConfig(cfg Config) (connector.Connector, error) {
@@ -91,6 +93,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 			StateMap:                cfg.StateMap,
 			PriorityMap:             cfg.PriorityMap,
 			RequiredStatusChecks:    cfg.RequiredStatusChecks,
+			Logger:                  cfg.Logger,
 		})
 	case connector.BackendGitHubLocal:
 		var tokenSource githubconnector.TokenSource
@@ -133,6 +136,7 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 				StateMap:                cfg.StateMap,
 				PriorityMap:             cfg.PriorityMap,
 				RequiredStatusChecks:    cfg.RequiredStatusChecks,
+				Logger:                  cfg.Logger,
 			},
 			Local:          localCfg,
 			Repository:     cfg.Repository,

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -1,9 +1,15 @@
 package factory
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/digitaldrywood/detent/internal/connector"
@@ -205,5 +211,56 @@ func TestFactoryGitHubConnectorImplementsProvisioner(t *testing.T) {
 	}
 	if _, ok := c.(connector.Provisioner); !ok {
 		t.Fatalf("connector = %T, want connector.Provisioner", c)
+	}
+}
+
+func TestFactoryGitHubConnectorUsesConfiguredLogger(t *testing.T) {
+	var defaultLogs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewJSONHandler(&defaultLogs, &slog.HandlerOptions{
+		Level: slog.LevelWarn,
+	})))
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/digitaldrywood/detent/issues" {
+			t.Fatalf("path = %s, want repository issues path", r.URL.Path)
+		}
+		if got := r.URL.Query().Get("state"); got != "open" {
+			t.Fatalf("state query = %q, want open", got)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`[]`))
+	}))
+	t.Cleanup(server.Close)
+
+	c, err := NewFromConfig(Config{
+		Kind:                        "github",
+		Endpoint:                    server.URL + "/graphql",
+		APIKey:                      "token",
+		GitHubStatusSource:          githubconnector.GitHubStatusSourceLabel,
+		Repository:                  "digitaldrywood/detent",
+		GitHubRESTFanoutMaxRequests: 1,
+		Logger:                      slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+
+	driftReader, ok := c.(connector.StatusDriftReader)
+	if !ok {
+		t.Fatalf("connector = %T, want connector.StatusDriftReader", c)
+	}
+	if _, err := driftReader.FetchStatusDrift(context.Background()); err != nil {
+		t.Fatalf("FetchStatusDrift() first error = %v", err)
+	}
+	_, err = driftReader.FetchStatusDrift(context.Background())
+	if !errors.Is(err, githubconnector.ErrRESTBudgetReserved) {
+		t.Fatalf("FetchStatusDrift() error = %v, want ErrRESTBudgetReserved", err)
+	}
+	if strings.Contains(defaultLogs.String(), "github rest budget preserved") {
+		t.Fatalf("default logger received connector warning:\n%s", defaultLogs.String())
 	}
 }


### PR DESCRIPTION
## Summary

- Suppress doctor-owned GitHub connector diagnostics from the pretty progress stream by using a doctor-local discard logger.
- Allow the connector factory to forward explicit loggers to GitHub and GitHub-local backends.
- Add regression coverage for doctor progress cleanliness and factory logger forwarding.

Fixes #891

## Test Plan

- [x] `go test ./internal/cli -run TestRunDoctorSuppressesConnectorLogsFromProgress -count=1`
- [x] `go test ./internal/connector/factory -run TestFactoryGitHubConnectorUsesConfiguredLogger -count=1`
- [x] `go test ./internal/cli ./internal/connector/factory -count=1`
- [x] `make check`