### PR TITLE
fix(doctor): keep budget drift advisory

### DIFF
--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -40,7 +40,10 @@ const (
 	doctorWorkflowRecentSessionLimit      = 50
 	doctorWorkflowRecentSessionWindow     = 24 * time.Hour
 	doctorWorkflowEmptyModelMinFraction   = 0.20
-	doctorWorkflowBudgetEstimateTotal     = int64(170_000)
+	doctorWorkflowBudgetEstimateInput     = int64(150_000)
+	doctorWorkflowBudgetEstimateOutput    = int64(20_000)
+	doctorWorkflowBudgetEstimateTotal     = doctorWorkflowBudgetEstimateInput + doctorWorkflowBudgetEstimateOutput
+	doctorWorkflowBudgetEstimateBillable  = doctorWorkflowBudgetEstimateInput + doctorWorkflowBudgetEstimateOutput
 	doctorWorkflowBudgetDriftRatio        = 1.50
 	doctorWorkflowSchedulerMinDecisions   = int64(5)
 	doctorWorkflowSchedulerHighSkipRate   = 0.50
@@ -65,34 +68,37 @@ type doctorWorkflowOptimizationProjectReport struct {
 }
 
 type doctorWorkflowOptimizationMetrics struct {
-	SessionCount              int64   `json:"session_count"`
-	UsageEventCount           int64   `json:"usage_event_count"`
-	InputTokens               int64   `json:"input_tokens"`
-	CachedInputTokens         int64   `json:"cached_input_tokens"`
-	OutputTokens              int64   `json:"output_tokens"`
-	TotalTokens               int64   `json:"total_tokens"`
-	InputOutputRatio          float64 `json:"input_output_ratio"`
-	CacheReadFraction         float64 `json:"cache_read_fraction"`
-	MedianSessionTokens       int64   `json:"median_session_tokens"`
-	P90SessionTokens          int64   `json:"p90_session_tokens"`
-	MaxSessionTokens          int64   `json:"max_session_tokens"`
-	MaxSessionsPerIssue       int64   `json:"max_sessions_per_issue"`
-	MaxSessionsIssue          string  `json:"max_sessions_issue,omitempty"`
-	RecentSessionCount        int64   `json:"recent_session_count"`
-	EmptyModelRecentSessions  int64   `json:"empty_model_recent_sessions"`
-	EmptyModelRecentFraction  float64 `json:"empty_model_recent_fraction"`
-	MaxReworkLapsPerIssue     int64   `json:"max_rework_laps_per_issue"`
-	MaxReworkLapsIssue        string  `json:"max_rework_laps_issue,omitempty"`
-	FailureTokens             int64   `json:"failure_tokens"`
-	SchedulerDecisionCount    int64   `json:"scheduler_decision_count"`
-	SchedulerSkippedDecisions int64   `json:"scheduler_skipped_decisions"`
-	SchedulerSkipRate         float64 `json:"scheduler_skip_rate"`
-	LaneEventCount            int64   `json:"lane_event_count"`
-	LaneDwellP90Seconds       int64   `json:"lane_dwell_p90_seconds"`
-	SlowestLane               string  `json:"slowest_lane,omitempty"`
-	SlowestLaneP90Seconds     int64   `json:"slowest_lane_p90_seconds"`
-	BudgetEstimateTokens      int64   `json:"budget_estimate_tokens"`
-	BudgetEstimateDriftRatio  float64 `json:"budget_estimate_drift_ratio"`
+	SessionCount                     int64   `json:"session_count"`
+	UsageEventCount                  int64   `json:"usage_event_count"`
+	InputTokens                      int64   `json:"input_tokens"`
+	CachedInputTokens                int64   `json:"cached_input_tokens"`
+	OutputTokens                     int64   `json:"output_tokens"`
+	TotalTokens                      int64   `json:"total_tokens"`
+	InputOutputRatio                 float64 `json:"input_output_ratio"`
+	CacheReadFraction                float64 `json:"cache_read_fraction"`
+	MedianSessionTokens              int64   `json:"median_session_tokens"`
+	P90SessionTokens                 int64   `json:"p90_session_tokens"`
+	MaxSessionTokens                 int64   `json:"max_session_tokens"`
+	MaxSessionsPerIssue              int64   `json:"max_sessions_per_issue"`
+	MaxSessionsIssue                 string  `json:"max_sessions_issue,omitempty"`
+	RecentSessionCount               int64   `json:"recent_session_count"`
+	EmptyModelRecentSessions         int64   `json:"empty_model_recent_sessions"`
+	EmptyModelRecentFraction         float64 `json:"empty_model_recent_fraction"`
+	MaxReworkLapsPerIssue            int64   `json:"max_rework_laps_per_issue"`
+	MaxReworkLapsIssue               string  `json:"max_rework_laps_issue,omitempty"`
+	FailureTokens                    int64   `json:"failure_tokens"`
+	SchedulerDecisionCount           int64   `json:"scheduler_decision_count"`
+	SchedulerSkippedDecisions        int64   `json:"scheduler_skipped_decisions"`
+	SchedulerSkipRate                float64 `json:"scheduler_skip_rate"`
+	LaneEventCount                   int64   `json:"lane_event_count"`
+	LaneDwellP90Seconds              int64   `json:"lane_dwell_p90_seconds"`
+	SlowestLane                      string  `json:"slowest_lane,omitempty"`
+	SlowestLaneP90Seconds            int64   `json:"slowest_lane_p90_seconds"`
+	BudgetEstimateTokens             int64   `json:"budget_estimate_tokens"`
+	BudgetEstimateBillableTokens     int64   `json:"budget_estimate_billable_tokens"`
+	P90SessionBillableTokens         int64   `json:"p90_session_billable_tokens"`
+	BudgetEstimateBillableDriftRatio float64 `json:"budget_estimate_billable_drift_ratio"`
+	BudgetEstimateDriftRatio         float64 `json:"budget_estimate_drift_ratio"`
 }
 
 type doctorWorkflowOptimizationFinding struct {
@@ -119,6 +125,7 @@ type doctorWorkflowSessionMetrics struct {
 	outputTokens             int64
 	totalTokens              int64
 	totalTokensBySession     []int64
+	billableTokensBySession  []int64
 	issueSessionCounts       map[string]int64
 	recentSessionCount       int64
 	emptyModelRecentSessions int64
@@ -323,27 +330,29 @@ func doctorWorkflowOptimizationMetricsForProject(
 	}
 
 	metrics := doctorWorkflowOptimizationMetrics{
-		SessionCount:              sessions.count,
-		UsageEventCount:           usage.count,
-		InputTokens:               sessions.inputTokens,
-		CachedInputTokens:         sessions.cachedInputTokens,
-		OutputTokens:              sessions.outputTokens,
-		TotalTokens:               sessions.totalTokens,
-		MedianSessionTokens:       doctorPercentileInt64(sessions.totalTokensBySession, 0.50),
-		P90SessionTokens:          doctorPercentileInt64(sessions.totalTokensBySession, 0.90),
-		MaxSessionTokens:          doctorMaxInt64(sessions.totalTokensBySession),
-		RecentSessionCount:        sessions.recentSessionCount,
-		EmptyModelRecentSessions:  sessions.emptyModelRecentSessions,
-		MaxSessionsPerIssue:       doctorMaxMapValue(sessions.issueSessionCounts),
-		MaxSessionsIssue:          doctorMaxMapKey(sessions.issueSessionCounts),
-		FailureTokens:             sessions.failureTokens,
-		SchedulerDecisionCount:    scheduler.count,
-		SchedulerSkippedDecisions: scheduler.skipped,
-		LaneEventCount:            lanes.count,
-		LaneDwellP90Seconds:       doctorPercentileInt64(lanes.durations, 0.90),
-		MaxReworkLapsPerIssue:     doctorMaxMapValue(lanes.reworkLaps),
-		MaxReworkLapsIssue:        doctorMaxMapKey(lanes.reworkLaps),
-		BudgetEstimateTokens:      doctorWorkflowBudgetEstimateTotal,
+		SessionCount:                 sessions.count,
+		UsageEventCount:              usage.count,
+		InputTokens:                  sessions.inputTokens,
+		CachedInputTokens:            sessions.cachedInputTokens,
+		OutputTokens:                 sessions.outputTokens,
+		TotalTokens:                  sessions.totalTokens,
+		MedianSessionTokens:          doctorPercentileInt64(sessions.totalTokensBySession, 0.50),
+		P90SessionTokens:             doctorPercentileInt64(sessions.totalTokensBySession, 0.90),
+		P90SessionBillableTokens:     doctorPercentileInt64(sessions.billableTokensBySession, 0.90),
+		MaxSessionTokens:             doctorMaxInt64(sessions.totalTokensBySession),
+		RecentSessionCount:           sessions.recentSessionCount,
+		EmptyModelRecentSessions:     sessions.emptyModelRecentSessions,
+		MaxSessionsPerIssue:          doctorMaxMapValue(sessions.issueSessionCounts),
+		MaxSessionsIssue:             doctorMaxMapKey(sessions.issueSessionCounts),
+		FailureTokens:                sessions.failureTokens,
+		SchedulerDecisionCount:       scheduler.count,
+		SchedulerSkippedDecisions:    scheduler.skipped,
+		LaneEventCount:               lanes.count,
+		LaneDwellP90Seconds:          doctorPercentileInt64(lanes.durations, 0.90),
+		MaxReworkLapsPerIssue:        doctorMaxMapValue(lanes.reworkLaps),
+		MaxReworkLapsIssue:           doctorMaxMapKey(lanes.reworkLaps),
+		BudgetEstimateTokens:         doctorWorkflowBudgetEstimateTotal,
+		BudgetEstimateBillableTokens: doctorWorkflowBudgetEstimateBillable,
 	}
 	if usage.count > 0 {
 		metrics.InputTokens = usage.inputTokens
@@ -357,8 +366,9 @@ func doctorWorkflowOptimizationMetricsForProject(
 	metrics.EmptyModelRecentFraction = doctorRatio(metrics.EmptyModelRecentSessions, metrics.RecentSessionCount)
 	metrics.SchedulerSkipRate = doctorRatio(metrics.SchedulerSkippedDecisions, metrics.SchedulerDecisionCount)
 	metrics.SlowestLane, metrics.SlowestLaneP90Seconds = doctorSlowestLane(lanes.laneDuration)
-	if metrics.P90SessionTokens > 0 {
-		metrics.BudgetEstimateDriftRatio = doctorRoundedFloat(float64(metrics.P90SessionTokens)/float64(doctorWorkflowBudgetEstimateTotal), 4)
+	if metrics.P90SessionBillableTokens > 0 && metrics.BudgetEstimateBillableTokens > 0 {
+		metrics.BudgetEstimateBillableDriftRatio = doctorRoundedFloat(float64(metrics.P90SessionBillableTokens)/float64(metrics.BudgetEstimateBillableTokens), 4)
+		metrics.BudgetEstimateDriftRatio = metrics.BudgetEstimateBillableDriftRatio
 	}
 	return metrics, nil
 }
@@ -418,6 +428,9 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		metrics.totalTokens += totalTokens
 		if totalTokens > 0 {
 			metrics.totalTokensBySession = append(metrics.totalTokensBySession, totalTokens)
+		}
+		if billableTokens := doctorWorkflowBillableTokens(inputTokens, cachedInputTokens, outputTokens, totalTokens); billableTokens > 0 {
+			metrics.billableTokensBySession = append(metrics.billableTokensBySession, billableTokens)
 		}
 		metrics.issueSessionCounts[issueKey]++
 		if metrics.count == 1 {
@@ -634,19 +647,18 @@ func doctorWorkflowOptimizationFindings(
 			evidence,
 		))
 	}
-	if metrics.P90SessionTokens > 0 && metrics.BudgetEstimateDriftRatio >= doctorWorkflowBudgetDriftRatio {
-		value := doctorRoundedFloat(cfg.Budget.PerIssueMaxUSD*metrics.BudgetEstimateDriftRatio, 2)
+	if metrics.P90SessionBillableTokens > 0 && metrics.BudgetEstimateDriftRatio >= doctorWorkflowBudgetDriftRatio {
 		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleBudgetEstimateDrift,
 			"Budget estimate is below observed p90",
-			fmt.Sprintf("observed p90 session tokens are %.2fx the default dispatch estimate", metrics.BudgetEstimateDriftRatio),
-			metrics.P90SessionTokens-doctorWorkflowBudgetEstimateTotal,
+			fmt.Sprintf("observed p90 billable session tokens are %.2fx the default dispatch estimate", metrics.BudgetEstimateDriftRatio),
+			metrics.P90SessionBillableTokens-metrics.BudgetEstimateBillableTokens,
 			map[string]any{
-				"budget_estimate_tokens":      doctorWorkflowBudgetEstimateTotal,
-				"observed_p90_session_tokens": metrics.P90SessionTokens,
-				"drift_ratio":                 metrics.BudgetEstimateDriftRatio,
-				"current_per_issue_max_usd":   cfg.Budget.PerIssueMaxUSD,
+				"budget_estimate_billable_tokens":      metrics.BudgetEstimateBillableTokens,
+				"budget_estimate_tokens":               doctorWorkflowBudgetEstimateTotal,
+				"observed_p90_billable_session_tokens": metrics.P90SessionBillableTokens,
+				"observed_p90_session_tokens":          metrics.P90SessionTokens,
+				"drift_ratio":                          metrics.BudgetEstimateDriftRatio,
 			},
-			doctorWorkflowOptimizationPatch{Path: "budget.per_issue_max_usd", Value: value},
 		))
 	}
 	if metrics.SchedulerDecisionCount >= doctorWorkflowSchedulerMinDecisions && metrics.SchedulerSkipRate >= doctorWorkflowSchedulerHighSkipRate {
@@ -957,6 +969,23 @@ func doctorWorkflowUsageFailed(outcome string) bool {
 	default:
 		return false
 	}
+}
+
+func doctorWorkflowBillableTokens(inputTokens int64, cachedInputTokens int64, outputTokens int64, totalTokens int64) int64 {
+	inputTokens = doctorNonNegativeInt64(inputTokens)
+	cachedInputTokens = min(doctorNonNegativeInt64(cachedInputTokens), inputTokens)
+	outputTokens = doctorNonNegativeInt64(outputTokens)
+	if inputTokens == 0 && cachedInputTokens == 0 && outputTokens == 0 {
+		return doctorNonNegativeInt64(totalTokens)
+	}
+	return inputTokens - cachedInputTokens + outputTokens
+}
+
+func doctorNonNegativeInt64(value int64) int64 {
+	if value < 0 {
+		return 0
+	}
+	return value
 }
 
 func doctorRatio(numerator int64, denominator int64) float64 {

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -21,6 +21,7 @@ import (
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 )
@@ -312,7 +313,11 @@ func doctorWorkflowOptimizationMetricsForProject(
 	projectID string,
 	cfg workflowconfig.Config,
 ) (doctorWorkflowOptimizationMetrics, error) {
-	sessions, err := doctorWorkflowSessionTelemetry(ctx, db, projectID)
+	pricing, err := budget.PricingForConfig(budget.Config{PricingPath: cfg.Budget.PricingPath})
+	if err != nil {
+		return doctorWorkflowOptimizationMetrics{}, fmt.Errorf("load budget pricing: %w", err)
+	}
+	sessions, err := doctorWorkflowSessionTelemetry(ctx, db, projectID, pricing)
 	if err != nil {
 		return doctorWorkflowOptimizationMetrics{}, err
 	}
@@ -373,7 +378,7 @@ func doctorWorkflowOptimizationMetricsForProject(
 	return metrics, nil
 }
 
-func doctorWorkflowSessionTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) (doctorWorkflowSessionMetrics, error) {
+func doctorWorkflowSessionTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, pricing budget.PricingTable) (doctorWorkflowSessionMetrics, error) {
 	rows, err := db.QueryContext(ctx, `
 SELECT
   COALESCE(s.total_tokens, 0),
@@ -429,7 +434,7 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		if totalTokens > 0 {
 			metrics.totalTokensBySession = append(metrics.totalTokensBySession, totalTokens)
 		}
-		if billableTokens := doctorWorkflowBillableTokens(inputTokens, cachedInputTokens, outputTokens, totalTokens); billableTokens > 0 {
+		if billableTokens := doctorWorkflowBillableTokens(inputTokens, cachedInputTokens, outputTokens, totalTokens, model, pricing); billableTokens > 0 {
 			metrics.billableTokensBySession = append(metrics.billableTokensBySession, billableTokens)
 		}
 		metrics.issueSessionCounts[issueKey]++
@@ -971,12 +976,17 @@ func doctorWorkflowUsageFailed(outcome string) bool {
 	}
 }
 
-func doctorWorkflowBillableTokens(inputTokens int64, cachedInputTokens int64, outputTokens int64, totalTokens int64) int64 {
+func doctorWorkflowBillableTokens(inputTokens int64, cachedInputTokens int64, outputTokens int64, totalTokens int64, model string, pricing budget.PricingTable) int64 {
 	inputTokens = doctorNonNegativeInt64(inputTokens)
 	cachedInputTokens = min(doctorNonNegativeInt64(cachedInputTokens), inputTokens)
 	outputTokens = doctorNonNegativeInt64(outputTokens)
 	if inputTokens == 0 && cachedInputTokens == 0 && outputTokens == 0 {
 		return doctorNonNegativeInt64(totalTokens)
+	}
+	observedCost, observedOK := budget.UsageCostUSD(pricing, model, inputTokens, cachedInputTokens, outputTokens)
+	estimateCost, estimateOK := budget.UsageCostUSD(pricing, model, doctorWorkflowBudgetEstimateInput, 0, doctorWorkflowBudgetEstimateOutput)
+	if observedOK && estimateOK && estimateCost > 0 {
+		return int64(math.Round((observedCost / estimateCost) * float64(doctorWorkflowBudgetEstimateBillable)))
 	}
 	return inputTokens - cachedInputTokens + outputTokens
 }

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/budget"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -242,6 +243,26 @@ func TestDoctorWorkflowOptimizationBudgetDriftFindingIsAdvisory(t *testing.T) {
 	}
 }
 
+func TestDoctorWorkflowBillableTokensWeightsCachedInputCost(t *testing.T) {
+	t.Parallel()
+
+	pricing := budget.PricingTable{
+		"gpt-test": {
+			USDPerInputToken:       0.01,
+			USDPerCachedInputToken: 0.001,
+			USDPerOutputToken:      0.02,
+		},
+	}
+
+	got := doctorWorkflowBillableTokens(1_000_000, 900_000, 20_000, 1_020_000, "gpt-test", pricing)
+	if got != 205789 {
+		t.Fatalf("doctorWorkflowBillableTokens() = %d, want 205789", got)
+	}
+	if got <= doctorWorkflowBudgetEstimateBillable {
+		t.Fatalf("doctorWorkflowBillableTokens() = %d, want over default budget estimate", got)
+	}
+}
+
 func TestDoctorSQLiteReadOnlyDSNFormatsWindowsDrivePath(t *testing.T) {
 	t.Parallel()
 
@@ -456,7 +477,7 @@ func TestDoctorWorkflowSessionTelemetryBoundsRecentEmptyModelsByLatestSessionWin
 		}
 	})
 
-	metrics, err := doctorWorkflowSessionTelemetry(ctx, db, "detent")
+	metrics, err := doctorWorkflowSessionTelemetry(ctx, db, "detent", budget.DefaultPricingTable())
 	if err != nil {
 		t.Fatalf("doctorWorkflowSessionTelemetry() error = %v", err)
 	}

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -90,9 +90,8 @@ func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
 		t.Fatalf("empty model fraction = %v, want 0.8", got)
 	}
 
-	budget := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleBudgetEstimateDrift)
-	if got := evidenceInt64(t, budget, "observed_p90_session_tokens"); got != 300000 {
-		t.Fatalf("budget p90 = %d, want 300000", got)
+	if doctorWorkflowFindingExists(report.Findings, doctorWorkflowRuleBudgetEstimateDrift) {
+		t.Fatalf("budget drift finding should not be emitted for cached-heavy raw token drift: %#v", report.Findings)
 	}
 
 	scheduler := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRuleSchedulerSkipRate)
@@ -108,6 +107,12 @@ func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
 	}
 	if metrics.MaxSessionTokens != 300000 {
 		t.Fatalf("MaxSessionTokens = %d, want 300000", metrics.MaxSessionTokens)
+	}
+	if metrics.P90SessionBillableTokens != 150500 {
+		t.Fatalf("P90SessionBillableTokens = %d, want 150500", metrics.P90SessionBillableTokens)
+	}
+	if metrics.BudgetEstimateDriftRatio != 0.8853 {
+		t.Fatalf("BudgetEstimateDriftRatio = %v, want 0.8853", metrics.BudgetEstimateDriftRatio)
 	}
 }
 
@@ -209,6 +214,34 @@ func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 	}
 }
 
+func TestDoctorWorkflowOptimizationBudgetDriftFindingIsAdvisory(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	metrics := doctorWorkflowOptimizationMetrics{
+		P90SessionTokens:                 500000,
+		P90SessionBillableTokens:         300000,
+		BudgetEstimateTokens:             doctorWorkflowBudgetEstimateTotal,
+		BudgetEstimateBillableTokens:     doctorWorkflowBudgetEstimateBillable,
+		BudgetEstimateDriftRatio:         doctorRoundedFloat(float64(300000)/float64(doctorWorkflowBudgetEstimateBillable), 4),
+		BudgetEstimateBillableDriftRatio: doctorRoundedFloat(float64(300000)/float64(doctorWorkflowBudgetEstimateBillable), 4),
+	}
+	findings := doctorWorkflowOptimizationFindings("detent", "/tmp/WORKFLOW.md", cfg, metrics)
+	budget := doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleBudgetEstimateDrift)
+	if len(budget.Patch) != 0 {
+		t.Fatalf("budget drift patches = %#v, want advisory finding with no patches", budget.Patch)
+	}
+	if got := evidenceInt64(t, budget, "observed_p90_billable_session_tokens"); got != 300000 {
+		t.Fatalf("billable p90 = %d, want 300000", got)
+	}
+	if got := evidenceInt64(t, budget, "budget_estimate_billable_tokens"); got != doctorWorkflowBudgetEstimateBillable {
+		t.Fatalf("budget estimate billable tokens = %d, want %d", got, doctorWorkflowBudgetEstimateBillable)
+	}
+	if _, ok := budget.Evidence["current_per_issue_max_usd"]; ok {
+		t.Fatalf("budget drift evidence should not point at per_issue_max_usd: %#v", budget.Evidence)
+	}
+}
+
 func TestDoctorSQLiteReadOnlyDSNFormatsWindowsDrivePath(t *testing.T) {
 	t.Parallel()
 
@@ -271,8 +304,8 @@ func TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow(t *testing.T) {
 	if workflow.Config.Polling.IntervalMS != 120000 {
 		t.Fatalf("Polling.IntervalMS = %d, want 120000", workflow.Config.Polling.IntervalMS)
 	}
-	if workflow.Config.Budget.PerIssueMaxUSD != 8.82 {
-		t.Fatalf("Budget.PerIssueMaxUSD = %v, want 8.82", workflow.Config.Budget.PerIssueMaxUSD)
+	if workflow.Config.Budget.PerIssueMaxUSD != 5 {
+		t.Fatalf("Budget.PerIssueMaxUSD = %v, want unchanged default 5", workflow.Config.Budget.PerIssueMaxUSD)
 	}
 	if doctorWorkflowHasDefaultRouteModel(workflow.Config) {
 		t.Fatalf("workflow gained unexpected default route model after write: %#v", workflow.Config.Agents.Routes)
@@ -822,6 +855,15 @@ func doctorWorkflowFindingByRule(t *testing.T, findings []doctorWorkflowOptimiza
 	}
 	t.Fatalf("missing finding %q in %#v", ruleID, findings)
 	return doctorWorkflowOptimizationFinding{}
+}
+
+func doctorWorkflowFindingExists(findings []doctorWorkflowOptimizationFinding, ruleID string) bool {
+	for _, finding := range findings {
+		if finding.RuleID == ruleID {
+			return true
+		}
+	}
+	return false
 }
 
 func evidenceInt64(t *testing.T, finding doctorWorkflowOptimizationFinding, key string) int64 {


### PR DESCRIPTION
## Summary

- Compute budget-estimate drift from budget-cost-equivalent p90 usage so cached input reads do not inflate or disappear from the ratio.
- Keep the budget drift rule advisory instead of patching `budget.per_issue_max_usd`, and expose billable-token evidence in the report.
- Add regression coverage for cached-heavy doctor output, advisory budget drift findings, and cached input with nonzero configured cost.

Fixes #889

## Test Plan

- [x] `go test ./internal/cli -run 'TestDoctorWorkflowSessionTelemetryBoundsRecentEmptyModelsByLatestSessionWindow|TestDoctorWorkflowOptimization(FindsFixtureRules|BudgetDriftFindingIsAdvisory|WriteRoundTripsWorkflow)|TestDoctorWorkflowBillableTokensWeightsCachedInputCost' -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `make check` after rebase onto `origin/main` (`17413c81a8c2ab4b9192d3863000908396997f18`); coverage 76.4%