### PR TITLE
fix(doctor): avoid hard-coded model patch

### DIFF
--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -15,6 +15,8 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"time"
+	"unicode"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
@@ -36,6 +38,7 @@ const (
 	doctorWorkflowRunawayMedianMultiplier = 4.0
 	doctorWorkflowReworkLapThreshold      = 1
 	doctorWorkflowRecentSessionLimit      = 50
+	doctorWorkflowRecentSessionWindow     = 24 * time.Hour
 	doctorWorkflowEmptyModelMinFraction   = 0.20
 	doctorWorkflowBudgetEstimateTotal     = int64(170_000)
 	doctorWorkflowBudgetDriftRatio        = 1.50
@@ -369,7 +372,8 @@ SELECT
   COALESCE(s.output_tokens, 0),
   COALESCE(s.model, ''),
   COALESCE(s.final_state, ''),
-  COALESCE(NULLIF(s.identifier, ''), NULLIF(s.issue_id, ''), NULLIF(s.issue_url, ''), 'unassigned')
+  COALESCE(NULLIF(s.identifier, ''), NULLIF(s.issue_id, ''), NULLIF(s.issue_url, ''), 'unassigned'),
+  COALESCE(s.completed_at, '')
 FROM codex_sessions s
 WHERE s.completed_at IS NOT NULL
   AND (
@@ -390,6 +394,7 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 	metrics := doctorWorkflowSessionMetrics{
 		issueSessionCounts: map[string]int64{},
 	}
+	var recentCutoff time.Time
 	for rows.Next() {
 		var totalTokens int64
 		var inputTokens int64
@@ -398,7 +403,12 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		var model string
 		var finalState string
 		var issueKey string
-		if err := rows.Scan(&totalTokens, &inputTokens, &cachedInputTokens, &outputTokens, &model, &finalState, &issueKey); err != nil {
+		var completedAtRaw string
+		if err := rows.Scan(&totalTokens, &inputTokens, &cachedInputTokens, &outputTokens, &model, &finalState, &issueKey, &completedAtRaw); err != nil {
+			return doctorWorkflowSessionMetrics{}, err
+		}
+		completedAt, err := doctorWorkflowSessionTimestamp(completedAtRaw)
+		if err != nil {
 			return doctorWorkflowSessionMetrics{}, err
 		}
 		metrics.count++
@@ -410,7 +420,10 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 			metrics.totalTokensBySession = append(metrics.totalTokensBySession, totalTokens)
 		}
 		metrics.issueSessionCounts[issueKey]++
-		if metrics.recentSessionCount < doctorWorkflowRecentSessionLimit {
+		if metrics.count == 1 {
+			recentCutoff = completedAt.Add(-doctorWorkflowRecentSessionWindow)
+		}
+		if metrics.recentSessionCount < doctorWorkflowRecentSessionLimit && !completedAt.Before(recentCutoff) {
 			metrics.recentSessionCount++
 			if strings.TrimSpace(model) == "" {
 				metrics.emptyModelRecentSessions++
@@ -424,6 +437,14 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		return doctorWorkflowSessionMetrics{}, err
 	}
 	return metrics, nil
+}
+
+func doctorWorkflowSessionTimestamp(value string) (time.Time, error) {
+	completedAt, err := time.Parse(time.RFC3339, strings.TrimSpace(value))
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse codex session completed_at: %w", err)
+	}
+	return completedAt, nil
 }
 
 func doctorWorkflowUsageTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) (doctorWorkflowUsageMetrics, error) {
@@ -593,20 +614,24 @@ func doctorWorkflowOptimizationFindings(
 		))
 	}
 	if metrics.RecentSessionCount > 0 && metrics.EmptyModelRecentSessions > 0 && metrics.EmptyModelRecentFraction >= doctorWorkflowEmptyModelMinFraction {
-		patches := []doctorWorkflowOptimizationPatch{}
-		if !doctorWorkflowHasDefaultRouteModel(cfg) {
-			patches = append(patches, doctorWorkflowOptimizationPatch{Path: "agents.routes.default.model", Value: "gpt-5-codex"})
+		detail := fmt.Sprintf("%d of %d recent sessions have an empty model", metrics.EmptyModelRecentSessions, metrics.RecentSessionCount)
+		evidence := map[string]any{
+			"recent_session_count":        metrics.RecentSessionCount,
+			"empty_model_recent_sessions": metrics.EmptyModelRecentSessions,
+			"empty_model_recent_fraction": doctorRoundedFloat(metrics.EmptyModelRecentFraction, 2),
+		}
+		if modelConfig, ok := doctorWorkflowDefaultRouteModelConfig(cfg); ok {
+			detail += "; workflow model is configured via " + modelConfig.Source
+			evidence["configured_model_source"] = modelConfig.Source
+			if modelConfig.Model != "" {
+				evidence["configured_model"] = modelConfig.Model
+			}
 		}
 		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleEmptyModelTelemetry,
 			"Session model telemetry is incomplete",
-			fmt.Sprintf("%d of %d recent sessions have an empty model", metrics.EmptyModelRecentSessions, metrics.RecentSessionCount),
+			detail,
 			0,
-			map[string]any{
-				"recent_session_count":        metrics.RecentSessionCount,
-				"empty_model_recent_sessions": metrics.EmptyModelRecentSessions,
-				"empty_model_recent_fraction": doctorRoundedFloat(metrics.EmptyModelRecentFraction, 2),
-			},
-			patches...,
+			evidence,
 		))
 	}
 	if metrics.P90SessionTokens > 0 && metrics.BudgetEstimateDriftRatio >= doctorWorkflowBudgetDriftRatio {
@@ -672,16 +697,136 @@ func doctorWorkflowFinding(
 }
 
 func doctorWorkflowHasDefaultRouteModel(cfg workflowconfig.Config) bool {
+	_, ok := doctorWorkflowDefaultRouteModelConfig(cfg)
+	return ok
+}
+
+type doctorWorkflowModelConfig struct {
+	Model  string
+	Source string
+}
+
+func doctorWorkflowDefaultRouteModelConfig(cfg workflowconfig.Config) (doctorWorkflowModelConfig, bool) {
+	backends := doctorWorkflowBackendConfigsByID(cfg)
 	for _, route := range cfg.AgentRouteConfigs() {
 		role := strings.ToLower(strings.TrimSpace(route.Role))
 		if role != "" && role != "code" {
 			continue
 		}
-		if route.Default && strings.TrimSpace(route.Model) != "" {
-			return true
+		if !route.Default {
+			continue
+		}
+		if model := strings.TrimSpace(route.Model); model != "" {
+			return doctorWorkflowModelConfig{
+				Model:  model,
+				Source: "agents.routes.model",
+			}, true
+		}
+		if strings.TrimSpace(route.ModelField) != "" {
+			return doctorWorkflowModelConfig{
+				Source: "agents.routes.model_field",
+			}, true
+		}
+		backend, ok := backends[strings.TrimSpace(route.Backend)]
+		if !ok {
+			continue
+		}
+		if model := doctorWorkflowBackendCommandModel(backend); model != "" {
+			return doctorWorkflowModelConfig{
+				Model:  model,
+				Source: "agents.backends.command",
+			}, true
 		}
 	}
-	return false
+	return doctorWorkflowModelConfig{}, false
+}
+
+func doctorWorkflowBackendConfigsByID(cfg workflowconfig.Config) map[string]workflowconfig.AgentBackend {
+	backends := cfg.AgentBackendConfigs()
+	byID := make(map[string]workflowconfig.AgentBackend, len(backends))
+	for _, backend := range backends {
+		byID[strings.TrimSpace(backend.ID)] = backend
+	}
+	return byID
+}
+
+func doctorWorkflowBackendCommandModel(backend workflowconfig.AgentBackend) string {
+	if strings.TrimSpace(backend.Kind) != workflowconfig.AgentBackendCodex {
+		return ""
+	}
+	return doctorWorkflowCommandConfigModel(backend.Command)
+}
+
+func doctorWorkflowCommandConfigModel(command string) string {
+	fields := doctorWorkflowCommandFields(command)
+	for index, field := range fields {
+		field = strings.TrimSpace(field)
+		if field == "--config" {
+			if index+1 >= len(fields) {
+				continue
+			}
+			if model := doctorWorkflowConfigModel(fields[index+1]); model != "" {
+				return model
+			}
+			continue
+		}
+		if value, ok := strings.CutPrefix(field, "--config="); ok {
+			if model := doctorWorkflowConfigModel(value); model != "" {
+				return model
+			}
+		}
+	}
+	return ""
+}
+
+func doctorWorkflowConfigModel(value string) string {
+	key, model, ok := strings.Cut(strings.TrimSpace(value), "=")
+	if !ok || strings.TrimSpace(key) != "model" {
+		return ""
+	}
+	return strings.Trim(strings.TrimSpace(model), `"'`)
+}
+
+func doctorWorkflowCommandFields(command string) []string {
+	var fields []string
+	var field strings.Builder
+	var quote rune
+	escaped := false
+	flush := func() {
+		if field.Len() == 0 {
+			return
+		}
+		fields = append(fields, field.String())
+		field.Reset()
+	}
+	for _, r := range command {
+		if escaped {
+			field.WriteRune(r)
+			escaped = false
+			continue
+		}
+		if r == '\\' {
+			escaped = true
+			continue
+		}
+		if quote == 0 && unicode.IsSpace(r) {
+			flush()
+			continue
+		}
+		switch {
+		case quote == 0 && (r == '\'' || r == '"'):
+			quote = r
+		case quote != 0 && r == quote:
+			quote = 0
+		default:
+			field.WriteRune(r)
+		}
+	}
+	if escaped {
+		field.WriteRune('\\')
+	}
+	flush()
+	return fields
 }
 
 func doctorWorkflowOptimizationWorkflowPath(project globalconfig.Project) (string, error) {

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -274,8 +274,269 @@ func TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow(t *testing.T) {
 	if workflow.Config.Budget.PerIssueMaxUSD != 8.82 {
 		t.Fatalf("Budget.PerIssueMaxUSD = %v, want 8.82", workflow.Config.Budget.PerIssueMaxUSD)
 	}
+	if doctorWorkflowHasDefaultRouteModel(workflow.Config) {
+		t.Fatalf("workflow gained unexpected default route model after write: %#v", workflow.Config.Agents.Routes)
+	}
+}
+
+func TestDoctorWorkflowOptimizationEmptyModelTelemetryRespectsBackendCommandModel(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := workflowconfig.ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-main
+      kind: codex
+      command: codex --config 'model="gpt-5.5"' app-server
+  routes:
+    - name: default
+      backend: codex-main
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
 	if !doctorWorkflowHasDefaultRouteModel(workflow.Config) {
-		t.Fatalf("workflow missing default route model after write: %#v", workflow.Config.Agents.Routes)
+		t.Fatal("doctorWorkflowHasDefaultRouteModel() = false, want true for backend command model")
+	}
+
+	findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", workflow.Config, doctorWorkflowOptimizationMetrics{
+		RecentSessionCount:       50,
+		EmptyModelRecentSessions: 48,
+		EmptyModelRecentFraction: 0.96,
+		TotalTokens:              100_000,
+	})
+	emptyModel := doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleEmptyModelTelemetry)
+	if len(emptyModel.Patch) != 0 {
+		t.Fatalf("empty model telemetry patch = %#v, want none for configured backend command model", emptyModel.Patch)
+	}
+	if got := emptyModel.Evidence["configured_model"]; got != "gpt-5.5" {
+		t.Fatalf("configured_model evidence = %#v, want gpt-5.5", got)
+	}
+}
+
+func TestDoctorWorkflowOptimizationEmptyModelTelemetryHasNoHardcodedModelPatch(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := workflowconfig.ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+codex:
+  command: codex app-server
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", workflow.Config, doctorWorkflowOptimizationMetrics{
+		RecentSessionCount:       50,
+		EmptyModelRecentSessions: 48,
+		EmptyModelRecentFraction: 0.96,
+		TotalTokens:              100_000,
+	})
+	emptyModel := doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleEmptyModelTelemetry)
+	if len(emptyModel.Patch) != 0 {
+		t.Fatalf("empty model telemetry patch = %#v, want none when configured model is unknown", emptyModel.Patch)
+	}
+}
+
+func TestDoctorWorkflowSessionTelemetryBoundsRecentEmptyModelsByLatestSessionWindow(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "detent.db")
+	backend, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    dbPath,
+	})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+
+	base := time.Date(2026, 7, 3, 18, 0, 0, 0, time.UTC)
+	recordSession := func(completedAt time.Time, model string) {
+		t.Helper()
+
+		startedAt := completedAt.Add(-5 * time.Minute)
+		sessionID, err := backend.StartSession(ctx, store.SessionStart{
+			Identifier: "digitaldrywood/detent#890",
+			StartedAt:  startedAt,
+			Model:      model,
+		})
+		if err != nil {
+			t.Fatalf("StartSession() error = %v", err)
+		}
+		if err := backend.FinishSession(ctx, sessionID, store.SessionFinish{
+			CompletedAt:       completedAt,
+			Turns:             1,
+			InputTokens:       900,
+			CachedInputTokens: 450,
+			OutputTokens:      100,
+			TotalTokens:       1000,
+			RuntimeSeconds:    300,
+			FinalState:        "completed",
+			Model:             model,
+		}); err != nil {
+			t.Fatalf("FinishSession() error = %v", err)
+		}
+		if _, err := backend.RecordUsageEvent(ctx, store.UsageEvent{
+			ProjectID:         "detent",
+			SessionID:         sessionID,
+			Identifier:        "digitaldrywood/detent#890",
+			Model:             model,
+			InputTokens:       900,
+			CachedInputTokens: 450,
+			OutputTokens:      100,
+			TotalTokens:       1000,
+			RuntimeSeconds:    300,
+			StartedAt:         startedAt,
+			FinishedAt:        completedAt,
+			Outcome:           "completed",
+		}); err != nil {
+			t.Fatalf("RecordUsageEvent() error = %v", err)
+		}
+	}
+
+	for index := range 48 {
+		recordSession(base.Add(-doctorWorkflowRecentSessionWindow-time.Hour-time.Duration(index)*time.Minute), "")
+	}
+	recordSession(base.Add(-time.Minute), "gpt-5.5")
+	recordSession(base, "gpt-5.5")
+
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	db, err := openDoctorSQLiteReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	metrics, err := doctorWorkflowSessionTelemetry(ctx, db, "detent")
+	if err != nil {
+		t.Fatalf("doctorWorkflowSessionTelemetry() error = %v", err)
+	}
+	if metrics.count != 50 {
+		t.Fatalf("count = %d, want 50", metrics.count)
+	}
+	if metrics.recentSessionCount != 2 {
+		t.Fatalf("recentSessionCount = %d, want 2", metrics.recentSessionCount)
+	}
+	if metrics.emptyModelRecentSessions != 0 {
+		t.Fatalf("emptyModelRecentSessions = %d, want 0", metrics.emptyModelRecentSessions)
+	}
+}
+
+func TestDoctorWorkflowDefaultRouteModelConfigSources(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		raw       string
+		wantOK    bool
+		wantModel string
+	}{
+		{
+			name: "route model",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-main
+      kind: codex
+      command: codex app-server
+  routes:
+    - name: default
+      backend: codex-main
+      model: gpt-5-route
+      default: true
+---
+Prompt
+`,
+			wantOK:    true,
+			wantModel: "gpt-5-route",
+		},
+		{
+			name: "backend command config model",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-main
+      kind: codex
+      command: codex --config=model=\"gpt-5.5\" app-server
+  routes:
+    - name: default
+      backend: codex-main
+      default: true
+---
+Prompt
+`,
+			wantOK:    true,
+			wantModel: "gpt-5.5",
+		},
+		{
+			name: "route model field",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-main
+      kind: codex
+      command: codex app-server
+  routes:
+    - name: default
+      backend: codex-main
+      model_field: Model
+      default: true
+---
+Prompt
+`,
+			wantOK: true,
+		},
+		{
+			name: "no model source",
+			raw: `---
+tracker:
+  kind: memory
+codex:
+  command: codex app-server
+---
+Prompt
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflow, err := workflowconfig.ParseWorkflow([]byte(tt.raw))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			got, ok := doctorWorkflowDefaultRouteModelConfig(workflow.Config)
+			if ok != tt.wantOK {
+				t.Fatalf("doctorWorkflowDefaultRouteModelConfig() ok = %v, want %v; config = %#v", ok, tt.wantOK, got)
+			}
+			if got.Model != tt.wantModel {
+				t.Fatalf("doctorWorkflowDefaultRouteModelConfig() model = %q, want %q", got.Model, tt.wantModel)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Recognize doctor model configuration from default route models, route model fields, and Codex backend command `--config model=...` entries.
- Stop `empty_model_telemetry` from writing a hard-coded `agents.routes.default.model` patch when the model source is already configured or cannot be determined.
- Bound the recent empty-model telemetry sample by a 24-hour window anchored at the latest completed session so stale historical rows age out.

Fixes #890

## Test Plan

- [x] `go test ./internal/cli -run 'TestDoctorWorkflowOptimizationEmptyModelTelemetry(RespectsBackendCommandModel|HasNoHardcodedModelPatch)|TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow|TestDoctorWorkflowDefaultRouteModelConfigSources|TestDoctorWorkflowSessionTelemetryBoundsRecentEmptyModelsByLatestSessionWindow'`
- [x] `go test ./internal/cli`
- [x] `make check`
