### PR TITLE
fix(doctor): suppress capped runaway finding

### DIFF
--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -589,19 +589,21 @@ func doctorWorkflowOptimizationFindings(
 		ratio := float64(metrics.MaxSessionTokens) / float64(metrics.MedianSessionTokens)
 		if ratio >= doctorWorkflowRunawayMedianMultiplier {
 			value := doctorRoundUpInt64(int64(float64(metrics.MedianSessionTokens)*doctorWorkflowRunawayMedianMultiplier), 1000)
-			findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleRunawaySessionTokens,
-				"Runaway session tail",
-				fmt.Sprintf("max session tokens are %.1fx the median", ratio),
-				metrics.MaxSessionTokens-metrics.MedianSessionTokens,
-				map[string]any{
-					"session_count":         metrics.SessionCount,
-					"median_session_tokens": metrics.MedianSessionTokens,
-					"p90_session_tokens":    metrics.P90SessionTokens,
-					"max_session_tokens":    metrics.MaxSessionTokens,
-					"max_to_median_ratio":   doctorRoundedFloat(ratio, 2),
-				},
-				doctorWorkflowOptimizationPatch{Path: "agent.max_session_tokens", Value: value},
-			))
+			if cfg.Agent.MaxSessionTokens <= 0 || cfg.Agent.MaxSessionTokens > value {
+				findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleRunawaySessionTokens,
+					"Runaway session tail",
+					fmt.Sprintf("max session tokens are %.1fx the median", ratio),
+					metrics.MaxSessionTokens-metrics.MedianSessionTokens,
+					map[string]any{
+						"session_count":         metrics.SessionCount,
+						"median_session_tokens": metrics.MedianSessionTokens,
+						"p90_session_tokens":    metrics.P90SessionTokens,
+						"max_session_tokens":    metrics.MaxSessionTokens,
+						"max_to_median_ratio":   doctorRoundedFloat(ratio, 2),
+					},
+					doctorWorkflowOptimizationPatch{Path: "agent.max_session_tokens", Value: value},
+				))
+			}
 		}
 	}
 	if metrics.MaxReworkLapsPerIssue > doctorWorkflowReworkLapThreshold && (cfg.Agent.AutoPromote.ReworkLimit == 0 || metrics.MaxReworkLapsPerIssue > int64(cfg.Agent.AutoPromote.ReworkLimit)) {

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -160,6 +160,63 @@ func TestDoctorWorkflowOptimizationFindingsTokenImpactIsAvoidable(t *testing.T) 
 	}
 }
 
+func TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap(t *testing.T) {
+	t.Parallel()
+
+	metrics := doctorWorkflowOptimizationMetrics{
+		SessionCount:        3,
+		MedianSessionTokens: 10000,
+		P90SessionTokens:    120000,
+		MaxSessionTokens:    300000,
+	}
+	tests := []struct {
+		name          string
+		configuredCap int64
+		wantFinding   bool
+	}{
+		{
+			name:        "uncapped",
+			wantFinding: true,
+		},
+		{
+			name:          "configured cap above suggested cap",
+			configuredCap: 50000,
+			wantFinding:   true,
+		},
+		{
+			name:          "configured cap equals suggested cap",
+			configuredCap: 40000,
+		},
+		{
+			name:          "configured cap below suggested cap",
+			configuredCap: 30000,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := workflowconfig.Default()
+			cfg.Agent.MaxSessionTokens = tt.configuredCap
+
+			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", cfg, metrics)
+			gotFinding := doctorWorkflowFindingExists(findings, doctorWorkflowRuleRunawaySessionTokens)
+			if gotFinding != tt.wantFinding {
+				t.Fatalf("runaway finding exists = %v, want %v: %#v", gotFinding, tt.wantFinding, findings)
+			}
+			if !tt.wantFinding {
+				return
+			}
+
+			runaway := doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleRunawaySessionTokens)
+			if got := runaway.Patch[0].Value; got != int64(40000) {
+				t.Fatalf("runaway patch value = %#v, want 40000", got)
+			}
+		})
+	}
+}
+
 func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Suppress `runaway_session_tokens` when `agent.max_session_tokens` is already configured at or below the doctor-suggested cap.
- Preserve the existing actionable finding and patch for uncapped workflows or caps still above the suggestion.
- Add regression coverage for uncapped, over-cap, equal-cap, and below-cap workflows.

Fixes #901

## Test Plan
- `go test ./internal/cli -run TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap -count=1 -v` failed before the fix for equal-cap and below-cap cases.
- `go test ./internal/cli -run "TestDoctorWorkflowOptimization(RunawaySessionTokensRespectsConfiguredCap|FindsFixtureRules|WriteRoundTripsWorkflow)$" -count=1 -v`
- `make check`