### PR TITLE
fix(doctor): keep advisory findings passing

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -90,6 +90,7 @@ type doctorReport struct {
 	WorkflowOptimization doctorWorkflowOptimizationReport `json:"workflow_optimization"`
 	Summary              doctorSummary                    `json:"summary"`
 	Result               string                           `json:"result"`
+	strict               bool
 }
 
 type doctorScope struct {
@@ -237,6 +238,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	allowWriteProbes := false
 	workflowDiff := false
 	workflowWrite := false
+	strict := false
 	projectID := ""
 	cmd := &cobra.Command{
 		Use:          "doctor",
@@ -268,6 +270,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 					Port:     runtimeIntFlag{Value: derefInt(port, -1), Set: flagChanged(cmd, "port")},
 				},
 			}, opts, deps)
+			report.strict = strict
 			if workflowWrite {
 				if err := confirmDoctorWorkflowOptimizationWrite(cmd, report.WorkflowOptimization); err != nil {
 					return err
@@ -283,7 +286,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 			}, newDoctorOutputReport(report)); err != nil {
 				return err
 			}
-			if report.HasFailures() {
+			if report.hasExitFailure() {
 				return ErrDoctorFailed
 			}
 			return nil
@@ -293,6 +296,7 @@ func newDoctorCommandWithDeps(configPath *string, env *string, logLevel *string,
 	cmd.Flags().BoolVar(&allowWriteProbes, "allow-write-probes", false, "run configured GitHub write probes")
 	cmd.Flags().BoolVar(&workflowDiff, "diff", false, "print proposed WORKFLOW.md frontmatter changes for workflow optimization findings")
 	cmd.Flags().BoolVar(&workflowWrite, "write", false, "apply proposed WORKFLOW.md frontmatter changes after confirmation")
+	cmd.Flags().BoolVar(&strict, "strict", false, "fail when checks warn or workflow optimization findings exist")
 	cmd.Flags().StringVar(&projectID, "project", "", "limit project checks to the selected project id")
 	cmd.SetContext(withCommandOutputOptions(context.Background(), commandOutputOptions{
 		lookupEnv: opts.lookupEnv,
@@ -541,7 +545,30 @@ func (r doctorReport) HasFailures() bool {
 			return true
 		}
 	}
+	return false
+}
+
+func (r doctorReport) HasStrictFailures() bool {
+	for _, check := range r.Checks {
+		if check.Status == doctorFail || check.Status == doctorWarn {
+			return true
+		}
+	}
 	return len(r.WorkflowOptimization.Findings) > 0
+}
+
+func (r doctorReport) hasExitFailure() bool {
+	if r.strict {
+		return r.HasStrictFailures()
+	}
+	return r.HasFailures()
+}
+
+func (r doctorReport) result() string {
+	if r.hasExitFailure() {
+		return "FAIL"
+	}
+	return "PASS"
 }
 
 func (r doctorReport) counts() map[doctorStatus]int {
@@ -563,10 +590,7 @@ func (r doctorReport) withSummary() doctorReport {
 		Warn: counts[doctorWarn],
 		Fail: counts[doctorFail],
 	}
-	r.Result = "PASS"
-	if r.Summary.Fail > 0 || len(r.WorkflowOptimization.Findings) > 0 {
-		r.Result = "FAIL"
-	}
+	r.Result = r.result()
 	return r
 }
 
@@ -655,10 +679,6 @@ func writeDoctorReport(out io.Writer, report doctorReport, format ...OutputForma
 
 func newDoctorOutputReport(report doctorReport) doctorOutputReport {
 	counts := report.counts()
-	result := "PASS"
-	if counts[doctorFail] > 0 || len(report.WorkflowOptimization.Findings) > 0 {
-		result = "FAIL"
-	}
 	return doctorOutputReport{
 		Checks:               report.Checks,
 		Scope:                report.Scope,
@@ -668,7 +688,7 @@ func newDoctorOutputReport(report doctorReport) doctorOutputReport {
 			Warn: counts[doctorWarn],
 			Fail: counts[doctorFail],
 		},
-		Result: result,
+		Result: report.result(),
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1445,6 +1445,66 @@ func TestRunDoctorHostWideIncludesAllProjectFailures(t *testing.T) {
 	assertDoctorCheck(t, report, "Project beta workflow", doctorFail, "beta workflow is broken")
 }
 
+func TestDoctorReportFailurePredicates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		report     doctorReport
+		want       bool
+		wantStrict bool
+	}{
+		{
+			name: "ok checks pass",
+			report: doctorReport{Checks: []doctorCheck{{
+				Name:   "Config resolution",
+				Status: doctorOK,
+			}}},
+		},
+		{
+			name: "warnings are advisory by default",
+			report: doctorReport{Checks: []doctorCheck{{
+				Name:   "Workflow optimization",
+				Status: doctorWarn,
+			}}},
+			wantStrict: true,
+		},
+		{
+			name: "workflow findings are advisory by default",
+			report: doctorReport{
+				WorkflowOptimization: doctorWorkflowOptimizationReport{
+					Findings: []doctorWorkflowOptimizationFinding{{
+						RuleID: "advisory",
+					}},
+				},
+			},
+			wantStrict: true,
+		},
+		{
+			name: "fail checks fail by default",
+			report: doctorReport{Checks: []doctorCheck{{
+				Name:   "SQLite database",
+				Status: doctorFail,
+			}}},
+			want:       true,
+			wantStrict: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := tt.report.HasFailures(); got != tt.want {
+				t.Fatalf("HasFailures() = %v, want %v", got, tt.want)
+			}
+			if got := tt.report.HasStrictFailures(); got != tt.wantStrict {
+				t.Fatalf("HasStrictFailures() = %v, want %v", got, tt.wantStrict)
+			}
+		})
+	}
+}
+
 func TestDoctorCommandProjectFlagScopesJSONReport(t *testing.T) {
 	t.Setenv("DETENT_FORMAT", "json")
 
@@ -2584,6 +2644,7 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 
 	tests := []struct {
 		name       string
+		args       []string
 		deps       doctorDeps
 		wantErr    error
 		wantOutput string
@@ -2592,6 +2653,13 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 			name:       "passes with warnings only",
 			deps:       successfulDoctorDeps(),
 			wantOutput: "Result: PASS",
+		},
+		{
+			name:       "strict fails with warnings only",
+			args:       []string{"--strict"},
+			deps:       successfulDoctorDeps(),
+			wantErr:    ErrDoctorFailed,
+			wantOutput: "Result: FAIL",
 		},
 		{
 			name: "fails when any check fails",
@@ -2627,6 +2695,7 @@ func TestDoctorCommandExitStatus(t *testing.T) {
 			}
 
 			cmd := newDoctorCommandWithDeps(&configPath, &env, &logLevel, &host, &port, opts, deps)
+			cmd.SetArgs(tt.args)
 			var stdout bytes.Buffer
 			cmd.SetOut(&stdout)
 			cmd.SetErr(&bytes.Buffer{})

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -261,8 +261,8 @@ func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 	if err := json.Unmarshal(output.Bytes(), &got); err != nil {
 		t.Fatalf("Unmarshal() error = %v\n%s", err, output.String())
 	}
-	if got.Result != "FAIL" {
-		t.Fatalf("Result = %q, want FAIL for nonzero findings", got.Result)
+	if got.Result != "PASS" {
+		t.Fatalf("Result = %q, want PASS for advisory findings", got.Result)
 	}
 	if got.WorkflowOptimization.StorePath != "/tmp/detent.db" {
 		t.Fatalf("StorePath = %q, want /tmp/detent.db", got.WorkflowOptimization.StorePath)
@@ -358,9 +358,8 @@ func TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow(t *testing.T) {
 	cmd.SetOut(&stdout)
 	cmd.SetErr(&stderr)
 
-	err := cmd.Execute()
-	if !errors.Is(err, ErrDoctorFailed) {
-		t.Fatalf("Execute() error = %v, want ErrDoctorFailed for nonzero findings\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v, want nil for advisory findings\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
 	}
 
 	workflow, err := workflowconfig.LoadWorkflow(paths.workflow)
@@ -387,6 +386,41 @@ func TestDoctorWorkflowOptimizationWriteRoundTripsWorkflow(t *testing.T) {
 	}
 	if doctorWorkflowHasDefaultRouteModel(workflow.Config) {
 		t.Fatalf("workflow gained unexpected default route model after write: %#v", workflow.Config.Agents.Routes)
+	}
+}
+
+func TestDoctorWorkflowOptimizationStrictFailsOnAdvisoryFindings(t *testing.T) {
+	t.Parallel()
+
+	paths := seedDoctorWorkflowOptimizationFixture(t)
+	configPath := filepath.Join(paths.dir, "global.yaml")
+	global := doctorWorkflowOptimizationGlobal(paths)
+	global.Path = configPath
+
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = workflowconfig.LoadWorkflow
+	deps.openSQLiteReadOnly = openDoctorSQLiteReadOnly
+
+	configFlag := configPath
+	envFlag := ""
+	logLevelFlag := ""
+	hostFlag := "127.0.0.1"
+	portFlag := 0
+	cmd := newDoctorCommandWithDeps(&configFlag, &envFlag, &logLevelFlag, &hostFlag, &portFlag, successfulDoctorOptionsWithConfig(configPath, global), deps)
+	cmd.SetArgs([]string{"--project", "detent", "--strict"})
+	var stdout bytes.Buffer
+	var stderr bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&stderr)
+
+	err := cmd.Execute()
+	if !errors.Is(err, ErrDoctorFailed) {
+		t.Fatalf("Execute() error = %v, want ErrDoctorFailed for strict advisory findings\nstdout:\n%s\nstderr:\n%s", err, stdout.String(), stderr.String())
+	}
+	for _, want := range []string{"Workflow Optimization", "Summary:", "0 FAIL", "Result: FAIL"} {
+		if !strings.Contains(stdout.String(), want) {
+			t.Fatalf("stdout missing %q:\n%s", want, stdout.String())
+		}
 	}
 }
 
@@ -733,6 +767,15 @@ tracker:
   kind: memory
   local_sqlite:
     project_id: detent-local
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Backlog
+    - Human Review
+    - Blocked
 polling:
   interval_ms: 60000
 agent:


### PR DESCRIPTION
## Summary

- Make default doctor failure and result semantics depend only on FAIL checks.
- Add `detent doctor --strict` for automation that wants WARN checks or workflow optimization findings to fail.
- Keep advisory workflow optimization findings visible in text and JSON reports while advisory-only default runs pass.

Fixes #900

## Test Plan

- [x] `go test ./internal/cli -run 'TestDoctor(ReportFailurePredicates|CommandExitStatus|WorkflowOptimization(JSONReportSchema|WriteRoundTripsWorkflow|StrictFailsOnAdvisoryFindings))' -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `make check`