### PR TITLE
fix(budget): price cache reads at provider rates

### DIFF
--- a/internal/budget/pricing.go
+++ b/internal/budget/pricing.go
@@ -2,6 +2,7 @@ package budget
 
 import (
 	"fmt"
+	"log/slog"
 	"os"
 	"strconv"
 	"strings"
@@ -12,56 +13,60 @@ import (
 const DefaultPricingPath = "priv/pricing/models.yaml"
 
 type ModelPricing struct {
-	USDPerInputToken       float64
+	USDPerInputToken float64
+	// Cache-write premiums are not modeled until telemetry records cache creation
+	// tokens separately.
 	USDPerCachedInputToken float64
 	USDPerOutputToken      float64
 }
 
 type PricingTable map[string]ModelPricing
 
-// DefaultPricingTable returns published API token rates. Under subscription auth,
-// computed USD is notional but still used for budget pacing.
+// DefaultPricingTable returns published API token rates. Cached input rates are
+// provider cache-read prices and must be verified against published pricing
+// when models are added or updated. Under subscription auth, computed USD is
+// notional but still used for budget pacing.
 func DefaultPricingTable() PricingTable {
 	claudeFable5 := ModelPricing{
 		USDPerInputToken:       0.000010,
-		USDPerCachedInputToken: 0.000010,
+		USDPerCachedInputToken: 0.000001,
 		USDPerOutputToken:      0.000050,
 	}
 	claudeOpus48 := ModelPricing{
 		USDPerInputToken:       0.000005,
-		USDPerCachedInputToken: 0.000005,
+		USDPerCachedInputToken: 0.0000005,
 		USDPerOutputToken:      0.000025,
 	}
 	claudeSonnet5 := ModelPricing{
-		USDPerInputToken:       0.000002,
-		USDPerCachedInputToken: 0.000002,
-		USDPerOutputToken:      0.000010,
+		USDPerInputToken:       0.000003,
+		USDPerCachedInputToken: 0.0000003,
+		USDPerOutputToken:      0.000015,
 	}
 	claudeHaiku45 := ModelPricing{
 		USDPerInputToken:       0.000001,
-		USDPerCachedInputToken: 0.000001,
+		USDPerCachedInputToken: 0.0000001,
 		USDPerOutputToken:      0.000005,
 	}
 
 	return PricingTable{
 		"gpt-5.5": {
 			USDPerInputToken:       0.000005,
-			USDPerCachedInputToken: 0.000005,
+			USDPerCachedInputToken: 0.0000005,
 			USDPerOutputToken:      0.000030,
 		},
 		"gpt-5.4": {
 			USDPerInputToken:       0.0000025,
-			USDPerCachedInputToken: 0.0000025,
+			USDPerCachedInputToken: 0.00000025,
 			USDPerOutputToken:      0.000015,
 		},
 		"gpt-5.4-mini": {
 			USDPerInputToken:       0.00000075,
-			USDPerCachedInputToken: 0.00000075,
+			USDPerCachedInputToken: 0.000000075,
 			USDPerOutputToken:      0.0000045,
 		},
 		"gpt-5.3-codex": {
 			USDPerInputToken:       0.00000175,
-			USDPerCachedInputToken: 0.00000175,
+			USDPerCachedInputToken: 0.000000175,
 			USDPerOutputToken:      0.000014,
 		},
 		"claude-fable-5":   claudeFable5,
@@ -117,7 +122,7 @@ func DecodePricing(raw []byte) (PricingTable, error) {
 		if model == "" {
 			continue
 		}
-		modelPricing, ok := normalizePricingRow(row)
+		modelPricing, ok := normalizePricingRow(model, row)
 		if !ok {
 			continue
 		}
@@ -148,7 +153,7 @@ func UsageCostUSD(pricing PricingTable, model string, inputTokens int64, cachedI
 		float64(nonNegative(outputTokens))*modelPricing.USDPerOutputToken, true
 }
 
-func normalizePricingRow(value any) (ModelPricing, bool) {
+func normalizePricingRow(model string, value any) (ModelPricing, bool) {
 	row := mapValue(value)
 	if row == nil {
 		return ModelPricing{}, false
@@ -168,7 +173,8 @@ func normalizePricingRow(value any) (ModelPricing, bool) {
 	if !cachedOK {
 		cached, cachedOK = perTokenFromMillion(row["cached_input_usd_per_1m_tokens"])
 	}
-	if !cachedOK {
+	if !cachedOK && inputOK {
+		slog.Warn("pricing row missing cached input rate; using input rate", "model", model)
 		cached = input
 		cachedOK = true
 	}

--- a/internal/budget/pricing_test.go
+++ b/internal/budget/pricing_test.go
@@ -1,8 +1,11 @@
 package budget
 
 import (
+	"bytes"
+	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -20,73 +23,73 @@ func TestDefaultPricingTable(t *testing.T) {
 		{
 			model:      " GPT-5.5 ",
 			wantInput:  0.000005,
-			wantCached: 0.000005,
+			wantCached: 0.0000005,
 			wantOutput: 0.000030,
 		},
 		{
 			model:      "gpt-5.4",
 			wantInput:  0.0000025,
-			wantCached: 0.0000025,
+			wantCached: 0.00000025,
 			wantOutput: 0.000015,
 		},
 		{
 			model:      "gpt-5.4-mini",
 			wantInput:  0.00000075,
-			wantCached: 0.00000075,
+			wantCached: 0.000000075,
 			wantOutput: 0.0000045,
 		},
 		{
 			model:      "gpt-5.3-codex",
 			wantInput:  0.00000175,
-			wantCached: 0.00000175,
+			wantCached: 0.000000175,
 			wantOutput: 0.000014,
 		},
 		{
 			model:      "claude-fable-5",
 			wantInput:  0.000010,
-			wantCached: 0.000010,
+			wantCached: 0.000001,
 			wantOutput: 0.000050,
 		},
 		{
 			model:      "fable",
 			wantInput:  0.000010,
-			wantCached: 0.000010,
+			wantCached: 0.000001,
 			wantOutput: 0.000050,
 		},
 		{
 			model:      "claude-opus-4-8",
 			wantInput:  0.000005,
-			wantCached: 0.000005,
+			wantCached: 0.0000005,
 			wantOutput: 0.000025,
 		},
 		{
 			model:      "opus",
 			wantInput:  0.000005,
-			wantCached: 0.000005,
+			wantCached: 0.0000005,
 			wantOutput: 0.000025,
 		},
 		{
 			model:      "claude-sonnet-5",
-			wantInput:  0.000002,
-			wantCached: 0.000002,
-			wantOutput: 0.000010,
+			wantInput:  0.000003,
+			wantCached: 0.0000003,
+			wantOutput: 0.000015,
 		},
 		{
 			model:      "sonnet",
-			wantInput:  0.000002,
-			wantCached: 0.000002,
-			wantOutput: 0.000010,
+			wantInput:  0.000003,
+			wantCached: 0.0000003,
+			wantOutput: 0.000015,
 		},
 		{
 			model:      "claude-haiku-4-5",
 			wantInput:  0.000001,
-			wantCached: 0.000001,
+			wantCached: 0.0000001,
 			wantOutput: 0.000005,
 		},
 		{
 			model:      "haiku",
 			wantInput:  0.000001,
-			wantCached: 0.000001,
+			wantCached: 0.0000001,
 			wantOutput: 0.000005,
 		},
 	}
@@ -103,6 +106,16 @@ func TestDefaultPricingTable(t *testing.T) {
 			assertInDelta(t, row.USDPerCachedInputToken, tt.wantCached)
 			assertInDelta(t, row.USDPerOutputToken, tt.wantOutput)
 		})
+	}
+}
+
+func TestDefaultPricingTableCachedInputRatesAreDiscounted(t *testing.T) {
+	t.Parallel()
+
+	for model, row := range DefaultPricingTable() {
+		if row.USDPerCachedInputToken >= row.USDPerInputToken {
+			t.Fatalf("%s cached input rate = %.12f, want less than input rate %.12f", model, row.USDPerCachedInputToken, row.USDPerInputToken)
+		}
 	}
 }
 
@@ -166,6 +179,39 @@ models:
 	}
 }
 
+func TestDecodePricingWarnsWhenCachedInputRateMissing(t *testing.T) {
+	var logs bytes.Buffer
+	previous := slog.Default()
+	slog.SetDefault(slog.New(slog.NewTextHandler(&logs, nil)))
+	t.Cleanup(func() {
+		slog.SetDefault(previous)
+	})
+
+	raw := []byte(`
+models:
+  gpt-fallback:
+    usd_per_input_token: 0.04
+    usd_per_output_token: 0.05
+`)
+
+	pricing, err := DecodePricing(raw)
+	if err != nil {
+		t.Fatalf("DecodePricing() error = %v", err)
+	}
+
+	row, ok := pricing.Lookup("gpt-fallback")
+	if !ok {
+		t.Fatal("pricing.Lookup(gpt-fallback) ok = false, want true")
+	}
+	assertInDelta(t, row.USDPerCachedInputToken, 0.04)
+
+	output := logs.String()
+	if !strings.Contains(output, "pricing row missing cached input rate; using input rate") ||
+		!strings.Contains(output, "model=gpt-fallback") {
+		t.Fatalf("log output = %q, want missing cached input warning", output)
+	}
+}
+
 func TestLoadPricing(t *testing.T) {
 	t.Parallel()
 
@@ -175,6 +221,7 @@ func TestLoadPricing(t *testing.T) {
 models:
   gpt-file:
     usd_per_input_token: 0.03
+    usd_per_cached_input_token: 0.003
     usd_per_output_token: 0.04
 `), 0o600); err != nil {
 		t.Fatalf("WriteFile() error = %v", err)
@@ -189,7 +236,7 @@ models:
 		t.Fatal("pricing.Lookup(gpt-file) ok = false, want true")
 	}
 	assertInDelta(t, row.USDPerInputToken, 0.03)
-	assertInDelta(t, row.USDPerCachedInputToken, 0.03)
+	assertInDelta(t, row.USDPerCachedInputToken, 0.003)
 	assertInDelta(t, row.USDPerOutputToken, 0.04)
 
 	if _, err := LoadPricing(filepath.Join(dir, "missing.yaml")); err == nil {
@@ -298,6 +345,43 @@ func TestUsageCostUSD(t *testing.T) {
 	}
 }
 
+func TestUsageCostUSDDefaultGPT55CachedSession(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name              string
+		model             string
+		inputTokens       int64
+		cachedInputTokens int64
+		outputTokens      int64
+		want              float64
+	}{
+		{
+			name:              "prices live cached session near provider cost",
+			model:             "gpt-5.5",
+			inputTokens:       12_590_000,
+			cachedInputTokens: 12_380_000,
+			outputTokens:      41_000,
+			want:              8.47,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := UsageCostUSD(nil, tt.model, tt.inputTokens, tt.cachedInputTokens, tt.outputTokens)
+			if !ok {
+				t.Fatal("UsageCostUSD() ok = false, want true")
+			}
+			assertInDelta(t, got, tt.want)
+			if got >= 60 {
+				t.Fatalf("UsageCostUSD() = %.2f, want cached-rate pricing", got)
+			}
+		})
+	}
+}
+
 func TestUsageCostUSDDefaultClaudePricing(t *testing.T) {
 	t.Parallel()
 
@@ -328,12 +412,12 @@ func TestUsageCostUSDDefaultClaudePricing(t *testing.T) {
 		},
 		{
 			model:  "claude-sonnet-5",
-			want:   12,
+			want:   18,
 			wantOK: true,
 		},
 		{
 			model:  "sonnet",
-			want:   12,
+			want:   18,
 			wantOK: true,
 		},
 		{

--- a/priv/pricing/README.md
+++ b/priv/pricing/README.md
@@ -1,0 +1,25 @@
+# Pricing Overrides
+
+Detent uses the embedded default pricing table when `budget.pricing_path` is empty or set to `priv/pricing/models.yaml`. To override model pricing, point `budget.pricing_path` at a YAML file with a `models` map.
+
+Each model row must include input, cached-input, and output rates. Use either per-token keys:
+
+```yaml
+models:
+  gpt-example:
+    usd_per_input_token: 0.000005
+    usd_per_cached_input_token: 0.0000005
+    usd_per_output_token: 0.000030
+```
+
+or per-million-token keys:
+
+```yaml
+models:
+  gpt-example:
+    input_usd_per_1m_tokens: 5.00
+    cached_input_usd_per_1m_tokens: 0.50
+    output_usd_per_1m_tokens: 30.00
+```
+
+`cached_input_usd_per_1m_tokens` and `usd_per_cached_input_token` are cache-read prices, not cache-write prices. Verify all three columns against the provider's published pricing when adding or changing a model. If an override row omits the cached-input rate, Detent logs a warning and falls back to the input rate so the model does not silently price cache reads at zero.


### PR DESCRIPTION
## Summary
- set default cached-input token prices to provider cache-read rates for OpenAI and Claude rows
- warn when YAML pricing overrides omit cached-input rates and fall back to input rate
- document pricing override cached-rate columns and add budget pricing coverage for the #883-shaped session

Fixes #902

## Test Plan
- `go test ./internal/budget -count=1`
- `make check` (first run hit transient local timeouts in unrelated CLI/workspace coverage tests; targeted reruns passed; full rerun passed with 76.4% coverage)