### PR TITLE
fix(runner): record derived stage role

### DIFF
--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -571,8 +571,9 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	if err != nil {
 		return RunResult{}, fmt.Errorf("build prompt: %w", err)
 	}
-	role := agentRuntime.effectiveRunRole(runRole(req.Mode, req.Issue))
-	selection, backend, backendKind, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), role)
+	role := runRole(req.Mode, req.Issue)
+	routeRole := agentRuntime.effectiveRunRole(role)
+	selection, backend, backendKind, err := agentRuntime.selectBackendForRole(req.Issue, selectorContext(req.SelectorContext, workflow), routeRole)
 	if err != nil {
 		return RunResult{}, err
 	}

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -583,7 +583,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	runStartedAt := r.now()
 	selectedModel := selection.Model
-	sessionModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(RoleCode))
+	sessionModel := effectiveModel("", selectedModel, agentRuntime.defaultModelForRole(role))
 	if result, refused, err := r.checkDispatchBudget(ctx, budgetChecker, dispatchEstimator, req.Issue, sessionModel, startedAt); err != nil {
 		return RunResult{}, err
 	} else if refused {
@@ -591,14 +591,14 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			"workspace_path", info.Path,
 			"backend_id", selection.BackendID,
 			"route", selection.RouteName,
-			"role", RoleCode,
+			"role", role,
 			"model", sessionModel,
 			"code", result.BudgetRefusal.Code,
 		)
 		return result, nil
 	}
-	resumeState := r.agentResumeState(ctx, workflow.Config.Agent, req.Issue, sessionModel, selection.BackendID, backendKind, RoleCode)
-	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, sessionModel, selection.BackendID, backendKind, RoleCode)
+	resumeState := r.agentResumeState(ctx, workflow.Config.Agent, req.Issue, sessionModel, selection.BackendID, backendKind, role)
+	sessionID, sessionStarted, err := r.startSession(ctx, req.Issue, startedAt, sessionModel, selection.BackendID, backendKind, role)
 	if err != nil {
 		return RunResult{}, err
 	}
@@ -624,7 +624,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 			"workspace_path", info.Path,
 			"backend_id", selection.BackendID,
 			"route", selection.RouteName,
-			"role", RoleCode,
+			"role", role,
 			"thread_id", turnRequest.Resume.ThreadID,
 			"provider_session_id", turnRequest.Resume.SessionID,
 			"error", errorString(execution.err),

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -402,6 +402,81 @@ func TestRunnerRunRefusesDispatchWhenBudgetExceeded(t *testing.T) {
 	}
 }
 
+func TestRunnerRunLogsBudgetRefusalWithDerivedRole(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	now := time.Date(2026, 7, 4, 10, 0, 0, 0, time.UTC)
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-903", Branch: "detent/issue-903"},
+	}
+	agentBackend := &fakeCodexClient{}
+	checker := &fakeBudgetChecker{
+		refusal: budget.Refusal{
+			Code:      budget.ReasonPerDayMaxUSD,
+			Message:   "daily budget exceeded",
+			RefusedAt: now,
+		},
+	}
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agents: config.Agents{
+					Backends: []config.AgentBackend{{
+						ID:       "codex-rework",
+						Kind:     "codex",
+						Protocol: "app-server",
+						Command:  "codex app-server --profile rework",
+					}},
+					Routes: []config.AgentRoute{{
+						Name:    "rework",
+						Role:    RoleRework,
+						Backend: "codex-rework",
+						Model:   "gpt-5-rework",
+						Default: true,
+					}},
+				},
+			},
+			Prompt: "work {{ issue.identifier }}",
+		},
+		Workspace:     workspaceBackend,
+		AgentBackends: map[string]AgentBackend{"codex-rework": agentBackend},
+		BudgetChecker: checker,
+		Now:           newFakeClock(now).Now,
+		Logger:        slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-903",
+			Identifier: "digitaldrywood/detent#903",
+			State:      "Rework",
+		},
+		Mode:      RunModeImplement,
+		StartedAt: now,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.BudgetRefusal == nil {
+		t.Fatal("BudgetRefusal = nil, want refusal")
+	}
+	logText := logs.String()
+	if !strings.Contains(logText, "worker_budget_refused") {
+		t.Fatalf("logs missing worker_budget_refused:\n%s", logText)
+	}
+	if !strings.Contains(logText, "role=rework") {
+		t.Fatalf("budget refusal log = %q, want role=rework", logText)
+	}
+	if strings.Contains(logText, "worker_budget_refused") && strings.Contains(logText, "role=code") {
+		t.Fatalf("budget refusal log = %q, want no code role for rework refusal", logText)
+	}
+}
+
 func TestRunnerRunLeavesThreadResumeDisabledByDefault(t *testing.T) {
 	t.Parallel()
 
@@ -1226,11 +1301,12 @@ func TestRunnerRunRoutesPerStageRoles(t *testing.T) {
 		state       string
 		wantBackend string
 		wantModel   string
+		wantRole    string
 	}{
-		{name: "code default", state: "Todo", wantBackend: "codex-code", wantModel: "gpt-5-code"},
-		{name: "plan mode", mode: RunModePlan, state: "Todo", wantBackend: "codex-plan", wantModel: "gpt-5-plan"},
-		{name: "rework state", mode: RunModeImplement, state: "Rework", wantBackend: "codex-rework", wantModel: "gpt-5-rework"},
-		{name: "merge state", mode: RunModeImplement, state: "Merging", wantBackend: "codex-merge", wantModel: "gpt-5-merge"},
+		{name: "code default", state: "Todo", wantBackend: "codex-code", wantModel: "gpt-5-code", wantRole: RoleCode},
+		{name: "plan mode", mode: RunModePlan, state: "Todo", wantBackend: "codex-plan", wantModel: "gpt-5-plan", wantRole: RolePlan},
+		{name: "rework state", mode: RunModeImplement, state: "Rework", wantBackend: "codex-rework", wantModel: "gpt-5-rework", wantRole: RoleRework},
+		{name: "merge mode", mode: RunModeMerge, state: "Merging", wantBackend: "codex-merge", wantModel: "gpt-5-merge", wantRole: RoleMerge},
 	}
 
 	for _, tt := range tests {
@@ -1246,6 +1322,7 @@ func TestRunnerRunRoutesPerStageRoles(t *testing.T) {
 				"codex-rework": {},
 				"codex-merge":  {},
 			}
+			sessionStore := &fakeSessionStore{sessionID: 861}
 			runner, err := NewRunner(Dependencies{
 				Workflow: config.Workflow{
 					Config: config.Config{
@@ -1273,6 +1350,7 @@ func TestRunnerRunRoutesPerStageRoles(t *testing.T) {
 					"codex-rework": clients["codex-rework"],
 					"codex-merge":  clients["codex-merge"],
 				},
+				Store: sessionStore,
 			})
 			if err != nil {
 				t.Fatalf("NewRunner() error = %v", err)
@@ -1303,7 +1381,160 @@ func TestRunnerRunRoutesPerStageRoles(t *testing.T) {
 			if clients[tt.wantBackend].request.Model != tt.wantModel {
 				t.Fatalf("Model = %q, want %q", clients[tt.wantBackend].request.Model, tt.wantModel)
 			}
+			if sessionStore.started.AgentRole != tt.wantRole {
+				t.Fatalf("SessionStart.AgentRole = %q, want %q", sessionStore.started.AgentRole, tt.wantRole)
+			}
+			if sessionStore.started.Model != tt.wantModel {
+				t.Fatalf("SessionStart.Model = %q, want %q", sessionStore.started.Model, tt.wantModel)
+			}
+			if sessionStore.usage.SessionID != 861 {
+				t.Fatalf("UsageEvent.SessionID = %d, want role-bearing session 861", sessionStore.usage.SessionID)
+			}
+			if sessionStore.phase.SessionID != 861 {
+				t.Fatalf("WorkflowPhaseEvent.SessionID = %d, want role-bearing session 861", sessionStore.phase.SessionID)
+			}
 		})
+	}
+}
+
+func TestRunnerRunThreadResumeUsesDerivedRoleKey(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-903", Branch: "detent/issue-903"},
+	}
+	agentBackend := &fakeCodexClient{
+		result: AgentTurnResult{ThreadID: "thread-merge", TurnID: "turn-merge", SessionID: "session-merge"},
+	}
+	sessionStore := &fakeSessionStore{
+		sessionID: 903,
+		resumeStates: map[string]store.AgentResumeState{
+			RoleCode: {
+				DetentSessionID:   100,
+				ProviderThreadID:  "thread-code",
+				ProviderSessionID: "session-code",
+			},
+		},
+	}
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agent: config.Agent{ExperimentalThreadResume: true},
+				Agents: config.Agents{
+					Backends: []config.AgentBackend{
+						{ID: "codex-code", Kind: "codex", Protocol: "app-server", Command: "codex app-server"},
+						{ID: "codex-merge", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile merge"},
+					},
+					Routes: []config.AgentRoute{
+						{Name: "merge", Role: RoleMerge, Backend: "codex-merge", Model: "gpt-5-merge", Default: true},
+						{Name: "default", Backend: "codex-code", Model: "gpt-5-code", Default: true},
+					},
+				},
+			},
+			Prompt: "work {{ issue.identifier }}",
+		},
+		Workspace: workspaceBackend,
+		AgentBackends: map[string]AgentBackend{
+			"codex-code":  &fakeCodexClient{},
+			"codex-merge": agentBackend,
+		},
+		Store: sessionStore,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-903",
+			Identifier: "digitaldrywood/detent#903",
+			State:      "Merging",
+		},
+		Mode: RunModeMerge,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if sessionStore.resumeLookup.AgentRole != RoleMerge {
+		t.Fatalf("resume lookup role = %q, want %q", sessionStore.resumeLookup.AgentRole, RoleMerge)
+	}
+	if !agentResumeEmpty(agentBackend.request.Resume) {
+		t.Fatalf("AgentTurnRequest.Resume = %#v, want no implement resume state for merge", agentBackend.request.Resume)
+	}
+	if sessionStore.started.AgentRole != RoleMerge {
+		t.Fatalf("SessionStart.AgentRole = %q, want %q", sessionStore.started.AgentRole, RoleMerge)
+	}
+}
+
+func TestRunnerRunUsesStageDefaultModelForReworkFallback(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-903", Branch: "detent/issue-903"},
+	}
+	agentBackend := &fakeCodexClient{}
+	sessionStore := &fakeSessionStore{sessionID: 904}
+	checker := &fakeBudgetChecker{}
+	estimator := &fakeDispatchEstimator{}
+
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{
+			Config: config.Config{
+				Agents: config.Agents{
+					Backends: []config.AgentBackend{
+						{ID: "codex-code", Kind: "codex", Protocol: "app-server", Command: "codex app-server"},
+						{ID: "codex-rework", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile rework"},
+					},
+					Routes: []config.AgentRoute{
+						{
+							Name:    "rework-selector",
+							Role:    RoleRework,
+							Backend: "codex-rework",
+							Selector: selector.Selector{
+								Labels: selector.Labels{Include: []string{"needs-rework"}},
+							},
+						},
+						{Name: "rework-default", Role: RoleRework, Backend: "codex-rework", Model: "gpt-5-rework-default", Default: true},
+						{Name: "default", Backend: "codex-code", Model: "gpt-5-code-default", Default: true},
+					},
+				},
+			},
+			Prompt: "work {{ issue.identifier }}",
+		},
+		Workspace:         workspaceBackend,
+		AgentBackends:     map[string]AgentBackend{"codex-code": &fakeCodexClient{}, "codex-rework": agentBackend},
+		Store:             sessionStore,
+		BudgetChecker:     checker,
+		DispatchEstimator: estimator,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	_, err = runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-903",
+			Identifier: "digitaldrywood/detent#903",
+			State:      "Rework",
+			Labels:     []string{"needs-rework"},
+		},
+		Mode: RunModeImplement,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if estimator.model != "gpt-5-rework-default" {
+		t.Fatalf("dispatch estimate model = %q, want rework default", estimator.model)
+	}
+	if checker.model != "gpt-5-rework-default" {
+		t.Fatalf("budget check model = %q, want rework default", checker.model)
+	}
+	if sessionStore.started.Model != "gpt-5-rework-default" {
+		t.Fatalf("SessionStart.Model = %q, want rework default", sessionStore.started.Model)
+	}
+	if sessionStore.started.AgentRole != RoleRework {
+		t.Fatalf("SessionStart.AgentRole = %q, want %q", sessionStore.started.AgentRole, RoleRework)
 	}
 }
 
@@ -2438,6 +2669,7 @@ type fakeSessionStore struct {
 	finishCalls   int
 	usageCalls    int
 	resumeState   store.AgentResumeState
+	resumeStates  map[string]store.AgentResumeState
 	resumeErr     error
 	resumeLookups int
 	resumeLookup  store.AgentResumeLookup
@@ -2515,6 +2747,13 @@ func (s *fakeSessionStore) LatestCompletedAgentResumeState(_ context.Context, at
 	s.resumeLookup = attrs
 	if s.resumeErr != nil {
 		return store.AgentResumeState{}, s.resumeErr
+	}
+	if s.resumeStates != nil {
+		state := s.resumeStates[attrs.AgentRole]
+		if state.DetentSessionID == 0 && state.ProviderThreadID == "" && state.ProviderSessionID == "" {
+			return store.AgentResumeState{}, store.ErrNotFound
+		}
+		return state, nil
 	}
 	if s.resumeState.DetentSessionID == 0 && s.resumeState.ProviderThreadID == "" && s.resumeState.ProviderSessionID == "" {
 		return store.AgentResumeState{}, store.ErrNotFound

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1422,24 +1422,25 @@ func TestRunnerRunThreadResumeUsesDerivedRoleKey(t *testing.T) {
 			Config: config.Config{
 				Agent: config.Agent{ExperimentalThreadResume: true},
 				Agents: config.Agents{
-					Backends: []config.AgentBackend{
-						{ID: "codex-code", Kind: "codex", Protocol: "app-server", Command: "codex app-server"},
-						{ID: "codex-merge", Kind: "codex", Protocol: "app-server", Command: "codex app-server --profile merge"},
-					},
-					Routes: []config.AgentRoute{
-						{Name: "merge", Role: RoleMerge, Backend: "codex-merge", Model: "gpt-5-merge", Default: true},
-						{Name: "default", Backend: "codex-code", Model: "gpt-5-code", Default: true},
-					},
+					Backends: []config.AgentBackend{{
+						ID:       "codex-code",
+						Kind:     "codex",
+						Protocol: "app-server",
+						Command:  "codex app-server",
+					}},
+					Routes: []config.AgentRoute{{
+						Name:    "default",
+						Backend: "codex-code",
+						Model:   "gpt-5-code",
+						Default: true,
+					}},
 				},
 			},
 			Prompt: "work {{ issue.identifier }}",
 		},
-		Workspace: workspaceBackend,
-		AgentBackends: map[string]AgentBackend{
-			"codex-code":  &fakeCodexClient{},
-			"codex-merge": agentBackend,
-		},
-		Store: sessionStore,
+		Workspace:     workspaceBackend,
+		AgentBackends: map[string]AgentBackend{"codex-code": agentBackend},
+		Store:         sessionStore,
 	})
 	if err != nil {
 		t.Fatalf("NewRunner() error = %v", err)
@@ -1464,6 +1465,9 @@ func TestRunnerRunThreadResumeUsesDerivedRoleKey(t *testing.T) {
 	}
 	if sessionStore.started.AgentRole != RoleMerge {
 		t.Fatalf("SessionStart.AgentRole = %q, want %q", sessionStore.started.AgentRole, RoleMerge)
+	}
+	if sessionStore.started.Model != "gpt-5-code" {
+		t.Fatalf("SessionStart.Model = %q, want fallback code model", sessionStore.started.Model)
 	}
 }
 
@@ -1542,13 +1546,14 @@ func TestRunnerRunUnroutedStageRolesUseCodeDefaultRoute(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name  string
-		mode  string
-		state string
+		name     string
+		mode     string
+		state    string
+		wantRole string
 	}{
-		{name: "plan role", mode: RunModePlan, state: "Todo"},
-		{name: "rework role", mode: RunModeImplement, state: "Rework"},
-		{name: "merge role", mode: RunModeImplement, state: "Merging"},
+		{name: "plan role", mode: RunModePlan, state: "Todo", wantRole: RolePlan},
+		{name: "rework role", mode: RunModeImplement, state: "Rework", wantRole: RoleRework},
+		{name: "merge role", mode: RunModeImplement, state: "Merging", wantRole: RoleMerge},
 	}
 
 	for _, tt := range tests {
@@ -1559,6 +1564,7 @@ func TestRunnerRunUnroutedStageRolesUseCodeDefaultRoute(t *testing.T) {
 				info: workspace.Info{Path: t.TempDir(), Key: "issue-fallback", Branch: "detent/issue-fallback"},
 			}
 			backend := &fakeCodexClient{}
+			sessionStore := &fakeSessionStore{sessionID: 862}
 			runner, err := NewRunner(Dependencies{
 				Workflow: config.Workflow{
 					Config: config.Config{
@@ -1583,6 +1589,7 @@ func TestRunnerRunUnroutedStageRolesUseCodeDefaultRoute(t *testing.T) {
 				AgentBackends: map[string]AgentBackend{
 					"codex-code": backend,
 				},
+				Store: sessionStore,
 			})
 			if err != nil {
 				t.Fatalf("NewRunner() error = %v", err)
@@ -1606,6 +1613,12 @@ func TestRunnerRunUnroutedStageRolesUseCodeDefaultRoute(t *testing.T) {
 			}
 			if backend.request.Model != "gpt-5-code" {
 				t.Fatalf("Model = %q, want code default model", backend.request.Model)
+			}
+			if sessionStore.started.AgentRole != tt.wantRole {
+				t.Fatalf("SessionStart.AgentRole = %q, want %q", sessionStore.started.AgentRole, tt.wantRole)
+			}
+			if sessionStore.started.Model != "gpt-5-code" {
+				t.Fatalf("SessionStart.Model = %q, want fallback code model", sessionStore.started.Model)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Attribute run model fallback, budget-refusal logs, resume keys, session starts, and resume-fallback logs with the derived stage role.
- Cover plan, implement, rework, and merge dispatch role recording plus resume isolation, unrouted stage fallback attribution, rework model fallback, budget-refusal logging, and zero-config implement behavior.
- Existing rows are not migrated; pre-fix history recorded as `code` will continue to undercount non-code stages.

Fixes #903

## Test Plan

- [x] `go test ./internal/runner -run 'TestRunnerRun(RoutesPerStageRoles|UnroutedStageRolesUseCodeDefaultRoute|ThreadResumeUsesDerivedRoleKey|UsesStageDefaultModelForReworkFallback|LogsBudgetRefusalWithDerivedRole|RefusesDispatchWhenBudgetExceeded|PreparesWorkspaceRunsCodexAndRecordsSession|FallsBackFreshWhenResumeFails)'`
- [x] `go test ./internal/runner`
- [x] `go test ./internal/cli -run TestRuntimeGitHubTokenRefresherResolvesConfiguredGHSentinelWithoutActionsToken -count=1 -v`
- [x] `make check`