### PR TITLE
fix(doctor): tolerate runaway cap drift

### DIFF
--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -49,6 +49,7 @@ const (
 	doctorWorkflowSchedulerMinDecisions   = int64(5)
 	doctorWorkflowSchedulerHighSkipRate   = 0.50
 	doctorWorkflowValidatorModel          = "gpt-5.4-mini"
+	doctorWorkflowRunawayCapTolerance     = 1.25
 )
 
 var errDoctorTelemetryStoreUnavailable = errors.New("telemetry store unavailable")
@@ -589,7 +590,8 @@ func doctorWorkflowOptimizationFindings(
 		ratio := float64(metrics.MaxSessionTokens) / float64(metrics.MedianSessionTokens)
 		if ratio >= doctorWorkflowRunawayMedianMultiplier {
 			value := doctorRoundUpInt64(int64(float64(metrics.MedianSessionTokens)*doctorWorkflowRunawayMedianMultiplier), 1000)
-			if cfg.Agent.MaxSessionTokens <= 0 || cfg.Agent.MaxSessionTokens > value {
+			configuredCapLimit := int64(math.Ceil(float64(value) * doctorWorkflowRunawayCapTolerance))
+			if cfg.Agent.MaxSessionTokens <= 0 || cfg.Agent.MaxSessionTokens > configuredCapLimit {
 				findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleRunawaySessionTokens,
 					"Runaway session tail",
 					fmt.Sprintf("max session tokens are %.1fx the median", ratio),

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -179,9 +179,13 @@ func TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap(t *
 			wantFinding: true,
 		},
 		{
-			name:          "configured cap above suggested cap",
-			configuredCap: 50000,
+			name:          "configured cap above tolerance",
+			configuredCap: 51000,
 			wantFinding:   true,
+		},
+		{
+			name:          "configured cap within median drift tolerance",
+			configuredCap: 50000,
 		},
 		{
 			name:          "configured cap equals suggested cap",


### PR DESCRIPTION
## Summary

- Suppress the runaway session cap finding when the configured cap is within 25% of the live suggested cap.
- Keep the finding for missing caps and caps that are meaningfully above the tolerance band.

Fixes #908

## Test Plan

- [x] `go test ./internal/cli -run TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap -count=1 -v`
- [x] `go test ./internal/cli -count=1`
- [x] `make check`