### PR TITLE
feat(web): scope dashboard to authorized issues

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1312,6 +1312,8 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	state.PollInterval = cfg.PollInterval
 	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
 	state.Instance = instanceSnapshot(cfg)
+	state.Authorization = cloneSelector(cfg.Authorization)
+	state.SelectorContext = cfg.SelectorContext
 	if !state.LastRefreshAt.IsZero() && cfg.PollInterval > 0 {
 		state.NextRefreshAt = state.LastRefreshAt.Add(cfg.PollInterval)
 	}

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -32,6 +32,9 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	} else {
 		refresh.Status = telemetry.RefreshStatusReady
 	}
+	boardIssues := authorizedSnapshotIssues(s.BoardIssues, s.Authorization, s.SelectorContext)
+	pipeline := authorizedSnapshotIssues(s.Pipeline, s.Authorization, s.SelectorContext)
+	statusDrift := authorizedStatusDrift(s.StatusDrift, s.Authorization, s.SelectorContext)
 	snapshot := telemetry.Snapshot{
 		GeneratedAt:        now,
 		Instance:           s.Instance,
@@ -39,9 +42,9 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Shutdown:           shutdownSnapshot(s),
 		Events:             cloneActivityEvents(s.RecentEvents),
 		Refresh:            refresh,
-		TrackerDrift:       statusDriftSnapshot(s.StatusDrift, s.AutoPromoteQuietDuration, s.PollInterval, now),
-		BoardIssues:        issueSnapshots(s.BoardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now),
-		Pipeline:           pipelineSnapshots(s.Pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now),
+		TrackerDrift:       statusDriftSnapshot(statusDrift, s.AutoPromoteQuietDuration, s.PollInterval, now),
+		BoardIssues:        issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now),
+		Pipeline:           pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now),
 		Running:            runningSnapshots(s.Running, s.Claimed, s.MergeTimings, now),
 		WorkAttempts:       cloneTelemetryWorkAttempts(s.WorkAttempts),
 		SchedulerDecisions: cloneTelemetrySchedulerDecisions(s.SchedulerDecisions),
@@ -61,6 +64,29 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Completed: len(snapshot.Completed),
 	}
 	return snapshot
+}
+
+func authorizedSnapshotIssues(issues []connector.Issue, authorization selector.Selector, ctx selector.Context) []connector.Issue {
+	if !authorization.Configured() {
+		return issues
+	}
+	out := make([]connector.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if selector.Match(issue, authorization, ctx) {
+			out = append(out, issue)
+		}
+	}
+	return out
+}
+
+func authorizedStatusDrift(drift connector.StatusDrift, authorization selector.Selector, ctx selector.Context) connector.StatusDrift {
+	if !authorization.Configured() {
+		return drift
+	}
+	return connector.StatusDrift{
+		UntrackedOpen: authorizedSnapshotIssues(drift.UntrackedOpen, authorization, ctx),
+		OpenTerminal:  authorizedSnapshotIssues(drift.OpenTerminal, authorization, ctx),
+	}
 }
 
 func statusDriftSnapshot(

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"slices"
 	"testing"
 	"time"
 
@@ -104,6 +105,147 @@ func TestStateSnapshotIncludesInstanceIdentityAndScope(t *testing.T) {
 	wantScope := "assignee in @me (detent-bot, release-captain); labels include release"
 	if snapshot.Instance.AuthorizationScope != wantScope {
 		t.Fatalf("Instance.AuthorizationScope = %q, want %q", snapshot.Instance.AuthorizationScope, wantScope)
+	}
+}
+
+func TestStateSnapshotFiltersIssueListsByAuthorization(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 5, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name              string
+		cfg               Config
+		boardIssues       []connector.Issue
+		pipeline          []connector.Issue
+		statusDrift       connector.StatusDrift
+		wantBoard         []string
+		wantPipeline      []string
+		wantUntrackedOpen []string
+		wantOpenTerminal  []string
+	}{
+		{
+			name: "no authorization leaves board and pipeline unchanged",
+			cfg:  Config{},
+			boardIssues: []connector.Issue{
+				{ID: "mine", AuthorID: "detent-bot", State: "Todo"},
+				{ID: "teammate", AuthorID: "teammate", State: "In Progress"},
+			},
+			pipeline: []connector.Issue{
+				{ID: "review", AuthorID: "teammate", State: "Human Review"},
+			},
+			statusDrift: connector.StatusDrift{
+				UntrackedOpen: []connector.Issue{
+					{ID: "drift-mine", AuthorID: "detent-bot", State: "Backlog"},
+					{ID: "drift-teammate", AuthorID: "teammate", State: "Backlog"},
+				},
+				OpenTerminal: []connector.Issue{
+					{ID: "done-teammate", AuthorID: "teammate", State: "Done"},
+				},
+			},
+			wantBoard:         []string{"mine", "teammate"},
+			wantPipeline:      []string{"review"},
+			wantUntrackedOpen: []string{"drift-mine", "drift-teammate"},
+			wantOpenTerminal:  []string{"done-teammate"},
+		},
+		{
+			name: "author selector keeps only matching board and pipeline issues",
+			cfg: Config{
+				Authorization: selector.Selector{
+					AuthorIn: []string{"@me"},
+				},
+				SelectorContext: selector.Context{
+					InstanceLogin: "detent-bot",
+					Persona:       "release-captain",
+				},
+			},
+			boardIssues: []connector.Issue{
+				{ID: "mine", AuthorID: "detent-bot", State: "Todo"},
+				{ID: "persona", AuthorID: "release-captain", State: "In Progress"},
+				{ID: "teammate", AuthorID: "teammate", State: "Todo"},
+			},
+			pipeline: []connector.Issue{
+				{ID: "review-mine", AuthorID: "detent-bot", State: "Human Review"},
+				{ID: "review-teammate", AuthorID: "teammate", State: "Human Review"},
+			},
+			statusDrift: connector.StatusDrift{
+				UntrackedOpen: []connector.Issue{
+					{ID: "drift-mine", AuthorID: "detent-bot", State: "Backlog"},
+					{ID: "drift-persona", AuthorID: "release-captain", State: "Backlog"},
+					{ID: "drift-teammate", AuthorID: "teammate", State: "Backlog"},
+				},
+				OpenTerminal: []connector.Issue{
+					{ID: "done-mine", AuthorID: "detent-bot", State: "Done"},
+					{ID: "done-teammate", AuthorID: "teammate", State: "Done"},
+				},
+			},
+			wantBoard:         []string{"mine", "persona"},
+			wantPipeline:      []string{"review-mine"},
+			wantUntrackedOpen: []string{"drift-mine", "drift-persona"},
+			wantOpenTerminal:  []string{"done-mine"},
+		},
+		{
+			name: "compound selector uses selector match semantics",
+			cfg: Config{
+				Authorization: selector.Selector{
+					Labels:     selector.Labels{Include: []string{"release"}},
+					AssigneeIn: []string{"@me"},
+				},
+				SelectorContext: selector.Context{
+					InstanceLogin: "detent-bot",
+				},
+			},
+			boardIssues: []connector.Issue{
+				{ID: "assigned-release", Labels: []string{"release"}, Assignees: []string{"detent-bot"}, State: "Todo"},
+				{ID: "assigned-other-label", Labels: []string{"bug"}, Assignees: []string{"detent-bot"}, State: "Todo"},
+				{ID: "release-unassigned", Labels: []string{"release"}, Assignees: []string{"teammate"}, State: "Todo"},
+			},
+			pipeline: []connector.Issue{
+				{ID: "pipeline-release", Labels: []string{"release"}, Assignees: []string{"detent-bot"}, State: "Merging"},
+				{ID: "pipeline-other", Labels: []string{"release"}, Assignees: []string{"teammate"}, State: "Merging"},
+			},
+			statusDrift: connector.StatusDrift{
+				UntrackedOpen: []connector.Issue{
+					{ID: "drift-release", Labels: []string{"release"}, Assignees: []string{"detent-bot"}, State: "Backlog"},
+					{ID: "drift-other-label", Labels: []string{"bug"}, Assignees: []string{"detent-bot"}, State: "Backlog"},
+					{ID: "drift-unassigned", Labels: []string{"release"}, Assignees: []string{"teammate"}, State: "Backlog"},
+				},
+				OpenTerminal: []connector.Issue{
+					{ID: "done-release", Labels: []string{"release"}, Assignees: []string{"detent-bot"}, State: "Done"},
+					{ID: "done-unassigned", Labels: []string{"release"}, Assignees: []string{"teammate"}, State: "Done"},
+				},
+			},
+			wantBoard:         []string{"assigned-release"},
+			wantPipeline:      []string{"pipeline-release"},
+			wantUntrackedOpen: []string{"drift-release"},
+			wantOpenTerminal:  []string{"done-release"},
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			state := newState(normalizeConfig(tt.cfg))
+			state.BoardIssues = tt.boardIssues
+			state.Pipeline = tt.pipeline
+			state.StatusDrift = tt.statusDrift
+
+			snapshot := state.Snapshot(now)
+
+			if got := telemetryIssueIDs(snapshot.BoardIssues); !slices.Equal(got, tt.wantBoard) {
+				t.Fatalf("BoardIssues ids = %#v, want %#v", got, tt.wantBoard)
+			}
+			if got := telemetryIssueIDs(snapshot.Pipeline); !slices.Equal(got, tt.wantPipeline) {
+				t.Fatalf("Pipeline ids = %#v, want %#v", got, tt.wantPipeline)
+			}
+			if got := telemetryIssueIDs(snapshot.TrackerDrift.UntrackedOpen); !slices.Equal(got, tt.wantUntrackedOpen) {
+				t.Fatalf("TrackerDrift.UntrackedOpen ids = %#v, want %#v", got, tt.wantUntrackedOpen)
+			}
+			if got := telemetryIssueIDs(snapshot.TrackerDrift.OpenTerminal); !slices.Equal(got, tt.wantOpenTerminal) {
+				t.Fatalf("TrackerDrift.OpenTerminal ids = %#v, want %#v", got, tt.wantOpenTerminal)
+			}
+		})
 	}
 }
 
@@ -740,4 +882,12 @@ func TestStateSnapshotDeterministicOrdering(t *testing.T) {
 		t.Fatalf("Running order = [%s,%s,%s], want [a,b,c]",
 			first.Running[0].ID, first.Running[1].ID, first.Running[2].ID)
 	}
+}
+
+func telemetryIssueIDs(issues []telemetry.Issue) []string {
+	out := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		out = append(out, issue.ID)
+	}
+	return out
 }

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -9,6 +9,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -17,6 +18,8 @@ type State struct {
 	MaxConcurrentAgents      int
 	AutoPromoteQuietDuration time.Duration
 	Instance                 telemetry.Instance
+	Authorization            selector.Selector
+	SelectorContext          selector.Context
 	Draining                 bool
 	DrainStartedAt           time.Time
 	LastRefreshAt            time.Time
@@ -145,6 +148,8 @@ func newState(cfg Config) State {
 		MaxConcurrentAgents:      cfg.MaxConcurrentAgents,
 		AutoPromoteQuietDuration: cfg.AutoPromote.QuietDuration,
 		Instance:                 instanceSnapshot(cfg),
+		Authorization:            cloneSelector(cfg.Authorization),
+		SelectorContext:          cfg.SelectorContext,
 		Running:                  map[string]Running{},
 		Claimed:                  map[string]Claimed{},
 		Blocked:                  map[string]Blocked{},
@@ -167,6 +172,8 @@ func (s State) clone() State {
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,
 		AutoPromoteQuietDuration: s.AutoPromoteQuietDuration,
 		Instance:                 s.Instance,
+		Authorization:            cloneSelector(s.Authorization),
+		SelectorContext:          s.SelectorContext,
 		Draining:                 s.Draining,
 		DrainStartedAt:           s.DrainStartedAt,
 		LastRefreshAt:            s.LastRefreshAt,
@@ -241,6 +248,30 @@ func (s State) clone() State {
 	maps.Copy(cloned.planRework, s.planRework)
 
 	return cloned
+}
+
+func cloneSelector(in selector.Selector) selector.Selector {
+	out := in
+	out.AssigneeIn = cloneStringSlice(in.AssigneeIn)
+	out.AuthorIn = cloneStringSlice(in.AuthorIn)
+	out.PriorityIn = append([]int(nil), in.PriorityIn...)
+	out.Labels.Include = cloneStringSlice(in.Labels.Include)
+	out.Labels.Exclude = cloneStringSlice(in.Labels.Exclude)
+	out.Fields = append([]selector.FieldEquals(nil), in.Fields...)
+	out.And = cloneSelectors(in.And)
+	out.Or = cloneSelectors(in.Or)
+	return out
+}
+
+func cloneSelectors(in []selector.Selector) []selector.Selector {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make([]selector.Selector, 0, len(in))
+	for _, item := range in {
+		out = append(out, cloneSelector(item))
+	}
+	return out
 }
 
 func clonePriorAttempts(in map[string]runpkg.PriorAttempt) map[string]runpkg.PriorAttempt {


### PR DESCRIPTION
## Summary

- Filter board-facing tracker snapshot issues through the configured authorization selector before publishing dashboard telemetry.
- Preserve selector/context in orchestrator state so snapshot renders use current scope while the existing dashboard scope label explains the active filter.
- Apply the same authorization filtering to tracker drift rows so untracked/open-terminal issue telemetry stays scoped.

Fixes #911

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestStateSnapshotFiltersIssueListsByAuthorization|TestStateSnapshotIncludesStatusDrift'`
- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/web/templates -run 'TestDashboardRendersTelemetrySnapshot|TestDashboardSnapshotSSESurface|TestBoardSnapshotRenders|TestDashboardIssueCellsDoNotRenderHoverPopovers'`
- [x] `make check`