### PR TITLE
feat(connector): push down auth fetch hints

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -18,6 +18,17 @@ type Connector interface {
 	SetField(context.Context, string, string, string) error
 }
 
+type IssueFilterHint struct {
+	Authors      []string
+	Assignees    []string
+	LabelInclude []string
+	LabelExclude []string
+}
+
+type CandidateIssuesFilterFetcher interface {
+	FetchCandidateIssuesByStatesWithFilter(context.Context, []string, IssueFilterHint) ([]Issue, error)
+}
+
 type Closer interface {
 	Close() error
 }

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -922,6 +922,14 @@ func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue
 }
 
 func (c *Connector) FetchCandidateIssuesByStates(ctx context.Context, stateNames []string) ([]connector.Issue, error) {
+	return c.FetchCandidateIssuesByStatesWithFilter(ctx, stateNames, connector.IssueFilterHint{})
+}
+
+func (c *Connector) FetchCandidateIssuesByStatesWithFilter(
+	ctx context.Context,
+	stateNames []string,
+	hint connector.IssueFilterHint,
+) ([]connector.Issue, error) {
 	stateNames = normalizeStateList(stateNames, nil)
 	if len(stateNames) == 0 {
 		return []connector.Issue{}, nil
@@ -937,7 +945,7 @@ func (c *Connector) FetchCandidateIssuesByStates(ctx context.Context, stateNames
 		return issues, nil
 	}
 	if c.usesIssueFieldStatus() {
-		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, 0)
+		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, 0, hint)
 		if err != nil {
 			return nil, err
 		}
@@ -988,7 +996,7 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 		return issues, nil
 	}
 	if c.usesIssueFieldStatus() {
-		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, 0)
+		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, 0, connector.IssueFilterHint{})
 		if err != nil {
 			return nil, err
 		}
@@ -1063,7 +1071,7 @@ func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []s
 		return issues, nil
 	}
 	if c.usesIssueFieldStatus() {
-		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, limit)
+		issues, err := c.fetchIssueFieldIssuesByStates(ctx, stateNames, limit, connector.IssueFilterHint{})
 		if err != nil {
 			return nil, err
 		}
@@ -1121,7 +1129,7 @@ func (c *Connector) FetchIssueStateProbe(ctx context.Context, stateNames []strin
 		return c.fetchLabelIssuesByStates(ctx, stateNames, limit)
 	}
 	if c.usesIssueFieldStatus() {
-		return c.fetchIssueFieldIssuesByStates(ctx, stateNames, limit)
+		return c.fetchIssueFieldIssuesByStates(ctx, stateNames, limit, connector.IssueFilterHint{})
 	}
 	if c.projectID == "" {
 		return nil, ErrMissingProject

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -100,6 +100,46 @@ func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchCandidateIssuesWithFilterIgnoresProjectV2(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","content":{"__typename":"Issue","id":"I_kw1","number":26,"title":"GitHub adapter","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/26","labels":{"nodes":[{"name":"enhancement"}]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Ready"}}]}}}}`,
+	}, {
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+		body:   `[]`,
+	}})
+
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:  "PVT_1",
+		ActiveStates: []string{"Todo"},
+		StateMap:     map[string]string{"Todo": "Ready"},
+	})
+
+	got, err := c.FetchCandidateIssuesByStatesWithFilter(context.Background(), []string{"Todo"}, connector.IssueFilterHint{
+		Authors:      []string{"alice"},
+		Assignees:    []string{"worker-1"},
+		LabelInclude: []string{"ready"},
+		LabelExclude: []string{"blocked"},
+	})
+	if err != nil {
+		t.Fatalf("FetchCandidateIssuesByStatesWithFilter() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchCandidateIssuesByStatesWithFilter() len = %d, want 1", len(got))
+	}
+
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want project query and pull request list", len(requests))
+	}
+	variables := requests[0]["variables"].(map[string]any)
+	if variables["query"] != "status:Ready" {
+		t.Fatalf("query = %v, want status-only ProjectV2 query", variables["query"])
+	}
+}
+
 func TestAllAssigneeLogins(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/issuefield.go
+++ b/internal/connector/github/issuefield.go
@@ -223,6 +223,7 @@ func (c *Connector) fetchIssueFieldIssuesByStates(
 	ctx context.Context,
 	stateNames []string,
 	limit int,
+	hint connector.IssueFilterHint,
 ) ([]connector.Issue, error) {
 	if !validPullRequestRepo(c.repository) {
 		return nil, ErrMissingRepository
@@ -242,7 +243,8 @@ func (c *Connector) fetchIssueFieldIssuesByStates(
 	allIssues := []connector.Issue{}
 	for page := 1; ; page++ {
 		var response restIssueSearchResponse
-		if err := c.client.REST(ctx, http.MethodGet, restIssueFieldSearchPath(c.repository, c.statusField, githubStates, page), nil, &response); err != nil {
+		path := restIssueFieldSearchPath(c.repository, c.statusField, githubStates, hint, page)
+		if err := c.client.REST(ctx, http.MethodGet, path, nil, &response); err != nil {
 			return nil, fmt.Errorf("search github issue field values: %w", err)
 		}
 		for _, item := range response.Items {
@@ -753,17 +755,70 @@ func restIssueFieldValueString(value restIssueFieldValue) string {
 	return ""
 }
 
-func restIssueFieldSearchPath(repo pullRequestRepo, fieldName string, values []string, page int) string {
+func restIssueFieldSearchPath(repo pullRequestRepo, fieldName string, values []string, hint connector.IssueFilterHint, page int) string {
 	params := url.Values{}
-	query := strings.Join([]string{
+	terms := []string{
 		"repo:" + repo.Owner + "/" + repo.Name,
 		"is:issue",
 		issueFieldSearchQualifier(fieldName, values),
-	}, " ")
+	}
+	terms = append(terms, issueFilterSearchQualifiers(hint)...)
+	query := strings.Join(terms, " ")
 	params.Set("q", query)
 	params.Set("per_page", strconv.Itoa(issueSearchPageSize))
 	params.Set("page", strconv.Itoa(page))
 	return "/search/issues?" + params.Encode()
+}
+
+func issueFilterSearchQualifiers(hint connector.IssueFilterHint) []string {
+	qualifiers := []string{}
+	if author := githubSearchAnyQualifier("author", hint.Authors); author != "" {
+		qualifiers = append(qualifiers, author)
+	}
+	if assignee := githubSearchAnyQualifier("assignee", hint.Assignees); assignee != "" {
+		qualifiers = append(qualifiers, assignee)
+	}
+	for _, label := range githubSearchTokens(hint.LabelInclude) {
+		qualifiers = append(qualifiers, "label:"+label)
+	}
+	for _, label := range githubSearchTokens(hint.LabelExclude) {
+		qualifiers = append(qualifiers, "-label:"+label)
+	}
+	return qualifiers
+}
+
+func githubSearchAnyQualifier(name string, values []string) string {
+	tokens := githubSearchTokens(values)
+	if len(tokens) == 0 {
+		return ""
+	}
+	if len(tokens) == 1 {
+		return name + ":" + tokens[0]
+	}
+
+	parts := make([]string, 0, len(tokens))
+	for _, token := range tokens {
+		parts = append(parts, name+":"+token)
+	}
+	return "(" + strings.Join(parts, " OR ") + ")"
+}
+
+func githubSearchTokens(values []string) []string {
+	tokens := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		token := githubSearchToken(value)
+		if token == "" {
+			continue
+		}
+		key := strings.ToLower(token)
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		tokens = append(tokens, token)
+	}
+	return tokens
 }
 
 func issueFieldSearchQualifier(fieldName string, values []string) string {
@@ -791,7 +846,7 @@ func githubSearchToken(value string) string {
 		if r >= '0' && r <= '9' {
 			continue
 		}
-		if r == '_' || r == '-' || r == '.' {
+		if r == '_' || r == '-' || r == '.' || r == '/' || r == '@' {
 			continue
 		}
 		return strconv.Quote(value)

--- a/internal/connector/github/issuefield.go
+++ b/internal/connector/github/issuefield.go
@@ -762,9 +762,13 @@ func restIssueFieldSearchPath(repo pullRequestRepo, fieldName string, values []s
 		"is:issue",
 		issueFieldSearchQualifier(fieldName, values),
 	}
-	terms = append(terms, issueFilterSearchQualifiers(hint)...)
+	filterQualifiers := issueFilterSearchQualifiers(hint)
+	terms = append(terms, filterQualifiers...)
 	query := strings.Join(terms, " ")
 	params.Set("q", query)
+	if githubSearchNeedsAdvanced(filterQualifiers) {
+		params.Set("advanced_search", "true")
+	}
 	params.Set("per_page", strconv.Itoa(issueSearchPageSize))
 	params.Set("page", strconv.Itoa(page))
 	return "/search/issues?" + params.Encode()
@@ -801,6 +805,15 @@ func githubSearchAnyQualifier(name string, values []string) string {
 		parts = append(parts, name+":"+token)
 	}
 	return "(" + strings.Join(parts, " OR ") + ")"
+}
+
+func githubSearchNeedsAdvanced(terms []string) bool {
+	for _, term := range terms {
+		if strings.Contains(term, " OR ") || strings.Contains(term, "(") || strings.Contains(term, ")") {
+			return true
+		}
+	}
+	return false
 }
 
 func githubSearchTokens(values []string) []string {

--- a/internal/connector/github/issuefield_test.go
+++ b/internal/connector/github/issuefield_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"net/url"
 	"reflect"
 	"strings"
 	"testing"
@@ -88,6 +89,75 @@ func TestConnectorIssueFieldFetchIssuesByStates(t *testing.T) {
 	for _, want := range []string{"repo%3Adigitaldrywood%2Fdetent", "is%3Aissue", "field.Status%3AReady%2CWorking"} {
 		if !strings.Contains(searchPath, want) {
 			t.Fatalf("search path = %q, missing %q", searchPath, want)
+		}
+	}
+}
+
+func TestConnectorIssueFieldFetchCandidateIssuesWithFilterAddsSearchQualifiers(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/orgs/digitaldrywood/issue-fields?per_page=100",
+			body:   `[{"id":10,"node_id":"IFSS_status","name":"Status","data_type":"single_select","options":[{"id":1,"name":"Ready","color":"green"}]}]`,
+		},
+		{
+			method: http.MethodGet,
+			body:   `{"total_count":1,"items":[{"node_id":"I_1","number":1,"title":"Ready issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1","user":{"login":"alice"},"assignees":[{"node_id":"U_1","login":"worker-1"}],"labels":[{"name":"ready"}]}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues/1/issue-field-values?per_page=100",
+			body:   `[{"issue_field_id":10,"node_id":"IFV_1","data_type":"single_select","value":1,"single_select_option":{"id":1,"name":"Ready","color":"green"}}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceIssueField,
+		Repository:         "digitaldrywood/detent",
+		StatusField:        "Status",
+		StateMap:           map[string]string{"Todo": "Ready"},
+	})
+
+	got, err := c.FetchCandidateIssuesByStatesWithFilter(context.Background(), []string{"Todo"}, connector.IssueFilterHint{
+		Authors:      []string{"alice", "bob", "alice"},
+		Assignees:    []string{"worker-1"},
+		LabelInclude: []string{"ready", "help wanted"},
+		LabelExclude: []string{"blocked"},
+	})
+	if err != nil {
+		t.Fatalf("FetchCandidateIssuesByStatesWithFilter() error = %v", err)
+	}
+	if len(got) != 1 || got[0].AuthorID != "alice" {
+		t.Fatalf("FetchCandidateIssuesByStatesWithFilter() = %#v, want alice issue", got)
+	}
+
+	requests := server.requests()
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want metadata, search, field read, and pull request list", len(requests))
+	}
+	searchURL, err := url.Parse(requests[1]["path"].(string))
+	if err != nil {
+		t.Fatalf("parse search path: %v", err)
+	}
+	query := searchURL.Query().Get("q")
+	for _, want := range []string{
+		"repo:digitaldrywood/detent",
+		"is:issue",
+		"field.Status:Ready",
+		"(author:alice OR author:bob)",
+		"assignee:worker-1",
+		"label:ready",
+		`label:"help wanted"`,
+		"-label:blocked",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("search query = %q, missing %q", query, want)
 		}
 	}
 }

--- a/internal/connector/github/issuefield_test.go
+++ b/internal/connector/github/issuefield_test.go
@@ -146,6 +146,9 @@ func TestConnectorIssueFieldFetchCandidateIssuesWithFilterAddsSearchQualifiers(t
 		t.Fatalf("parse search path: %v", err)
 	}
 	query := searchURL.Query().Get("q")
+	if got := searchURL.Query().Get("advanced_search"); got != "true" {
+		t.Fatalf("advanced_search = %q, want true", got)
+	}
 	for _, want := range []string{
 		"repo:digitaldrywood/detent",
 		"is:issue",

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -10,6 +10,8 @@ import (
 	"sort"
 	"strings"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
 )
 
 type ReadinessStatus string
@@ -393,7 +395,7 @@ func (c githubReadinessChecker) issueFieldIssuesReadCheck(ctx context.Context, s
 			Detail: "skipped because no active or observed tracker states are configured",
 		}
 	}
-	issues, err := c.connector.fetchIssueFieldIssuesByStates(ctx, states, 5)
+	issues, err := c.connector.fetchIssueFieldIssuesByStates(ctx, states, 5, connector.IssueFilterHint{})
 	if err != nil {
 		return ReadinessCheck{
 			Name:   "GitHub issue field issue read",

--- a/internal/connector/github/statuslabel_test.go
+++ b/internal/connector/github/statuslabel_test.go
@@ -57,6 +57,50 @@ func TestConnectorFetchCandidateIssuesUsesStatusLabels(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchCandidateIssuesWithFilterIgnoresStatusLabels(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/issues?labels=detent%3Aready&page=1&per_page=100&state=all",
+			body:   `[{"node_id":"I_485","number":485,"title":"Installer packages","body":"Ship packages","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/485","assignees":[],"labels":[{"name":"detent:ready"},{"name":"enhancement"}]}]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent/pulls?direction=desc&page=1&per_page=100&sort=updated&state=all",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+		ActiveStates:       []string{"Todo"},
+		StateMap:           map[string]string{"Todo": "Ready"},
+	})
+
+	got, err := c.FetchCandidateIssuesByStatesWithFilter(context.Background(), []string{"Todo"}, connector.IssueFilterHint{
+		Authors:      []string{"alice"},
+		Assignees:    []string{"worker-1"},
+		LabelInclude: []string{"ready"},
+		LabelExclude: []string{"blocked"},
+	})
+	if err != nil {
+		t.Fatalf("FetchCandidateIssuesByStatesWithFilter() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchCandidateIssuesByStatesWithFilter() len = %d, want 1", len(got))
+	}
+
+	requests := server.requests()
+	if len(requests) != 2 {
+		t.Fatalf("request count = %d, want label issue list and pull request list", len(requests))
+	}
+	if requests[0]["path"] != "/repos/digitaldrywood/detent/issues?labels=detent%3Aready&page=1&per_page=100&state=all" {
+		t.Fatalf("label issue path = %q, want status label only", requests[0]["path"])
+	}
+}
+
 func TestConnectorFetchStatusDriftReportsUntrackedAndOpenTerminalIssues(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -364,6 +364,190 @@ func TestDispatchableFiltersUnauthorizedCandidates(t *testing.T) {
 	}
 }
 
+func TestAuthorizationFilterHintUsesTopLevelSelectorFields(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		auth selector.Selector
+		ctx  selector.Context
+		want connector.IssueFilterHint
+	}{
+		{
+			name: "resolves identities and labels",
+			auth: selector.Selector{
+				AuthorIn:   []string{" alice ", "@me", "ALICE"},
+				AssigneeIn: []string{" team-a ", "@me"},
+				Labels: selector.Labels{
+					Include: []string{" ready ", "READY"},
+					Exclude: []string{" blocked "},
+				},
+			},
+			ctx: selector.Context{
+				InstanceLogin: "worker-1",
+				Persona:       "release-captain",
+			},
+			want: connector.IssueFilterHint{
+				Authors:      []string{"alice", "worker-1", "release-captain"},
+				Assignees:    []string{"team-a", "worker-1", "release-captain"},
+				LabelInclude: []string{"ready"},
+				LabelExclude: []string{"blocked"},
+			},
+		},
+		{
+			name: "ignores nested selectors",
+			auth: selector.Selector{
+				And: []selector.Selector{{
+					AuthorIn: []string{"nested-author"},
+					Labels:   selector.Labels{Include: []string{"nested-label"}},
+				}},
+				Or: []selector.Selector{{
+					AssigneeIn: []string{"nested-assignee"},
+					Labels:     selector.Labels{Exclude: []string{"nested-exclude"}},
+				}},
+			},
+			want: connector.IssueFilterHint{},
+		},
+		{
+			name: "drops unresolved me token",
+			auth: selector.Selector{
+				AuthorIn:   []string{"@me"},
+				AssigneeIn: []string{"@me"},
+			},
+			want: connector.IssueFilterHint{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := authorizationFilterHint(tt.auth, tt.ctx)
+			assertIssueFilterHint(t, got, tt.want)
+		})
+	}
+}
+
+func TestFetchCandidateIssuesForTickPassesAuthorizationFilterHint(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		ActiveStates: []string{"Todo", "In Progress"},
+		Authorization: selector.Selector{
+			AuthorIn:   []string{"@me", "alice"},
+			AssigneeIn: []string{"worker-2"},
+			Labels: selector.Labels{
+				Include: []string{"ready"},
+				Exclude: []string{"blocked"},
+			},
+		},
+		SelectorContext: selector.Context{
+			InstanceLogin: "worker-1",
+			Persona:       "release-captain",
+		},
+	})
+	tracker := &filterFetchConnector{
+		issues: []connector.Issue{dispatchTestIssue("issue-authorized", "Todo")},
+	}
+	orch := Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	got, err := orch.fetchCandidateIssuesForTick(context.Background(), &state)
+	if err != nil {
+		t.Fatalf("fetchCandidateIssuesForTick() error = %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "issue-authorized" {
+		t.Fatalf("fetchCandidateIssuesForTick() = %#v, want authorized issue", got)
+	}
+	if tracker.baseFetches != 0 {
+		t.Fatalf("FetchCandidateIssues calls = %d, want 0", tracker.baseFetches)
+	}
+	if !slices.Equal(tracker.states, []string{"todo", "in progress"}) {
+		t.Fatalf("states = %#v, want todo/in progress", tracker.states)
+	}
+	assertIssueFilterHint(t, tracker.hint, connector.IssueFilterHint{
+		Authors:      []string{"worker-1", "release-captain", "alice"},
+		Assignees:    []string{"worker-2"},
+		LabelInclude: []string{"ready"},
+		LabelExclude: []string{"blocked"},
+	})
+}
+
+func TestDispatchPlanMatchesWithAndWithoutAuthorizationPushdown(t *testing.T) {
+	t.Parallel()
+
+	authorMatch := dispatchTestIssue("issue-author-match", "Todo")
+	authorMatch.AuthorID = "alice"
+	authorMiss := dispatchTestIssue("issue-author-miss", "Todo")
+	authorMiss.AuthorID = "bob"
+
+	combinedMatch := dispatchTestIssue("issue-combined-match", "Todo")
+	combinedMatch.AuthorID = "worker-1"
+	combinedMatch.Assignees = []string{"release-captain"}
+	combinedMatch.Labels = []string{"ready", "team-a"}
+	combinedMiss := dispatchTestIssue("issue-combined-miss", "Todo")
+	combinedMiss.AuthorID = "worker-1"
+	combinedMiss.Assignees = []string{"release-captain"}
+	combinedMiss.Labels = []string{"blocked", "ready"}
+
+	tests := []struct {
+		name       string
+		auth       selector.Selector
+		ctx        selector.Context
+		all        []connector.Issue
+		pushedDown []connector.Issue
+		want       []string
+	}{
+		{
+			name:       "author hint",
+			auth:       selector.Selector{AuthorIn: []string{"alice"}},
+			all:        []connector.Issue{authorMatch, authorMiss},
+			pushedDown: []connector.Issue{authorMatch},
+			want:       []string{authorMatch.ID},
+		},
+		{
+			name: "combined top-level hint",
+			auth: selector.Selector{
+				AuthorIn:   []string{"@me"},
+				AssigneeIn: []string{"release-captain"},
+				Labels: selector.Labels{
+					Include: []string{"ready"},
+					Exclude: []string{"blocked"},
+				},
+			},
+			ctx: selector.Context{
+				InstanceLogin: "worker-1",
+				Persona:       "release-captain",
+			},
+			all:        []connector.Issue{combinedMatch, combinedMiss},
+			pushedDown: []connector.Issue{combinedMatch},
+			want:       []string{combinedMatch.ID},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := Config{
+				MaxConcurrentAgents: 10,
+				ActiveStates:        []string{"Todo"},
+				TerminalStates:      []string{"Done"},
+				Authorization:       tt.auth,
+				SelectorContext:     tt.ctx,
+			}
+			withoutPushdown := dispatchPlanIssueIDs(cfg, tt.all)
+			withPushdown := dispatchPlanIssueIDs(cfg, tt.pushedDown)
+			if !slices.Equal(withoutPushdown, withPushdown) {
+				t.Fatalf("dispatch IDs without pushdown = %#v, with pushdown = %#v", withoutPushdown, withPushdown)
+			}
+			if !slices.Equal(withPushdown, tt.want) {
+				t.Fatalf("dispatch IDs = %#v, want %#v", withPushdown, tt.want)
+			}
+		})
+	}
+}
+
 func TestMemoryConnectorOrchestratorsPartitionSharedIssuesByAuthorization(t *testing.T) {
 	t.Parallel()
 
@@ -1576,6 +1760,89 @@ func dispatchTestIssueWithUnknownUnavailablePullRequestHydration(id, state strin
 		HydrationUnavailableReason: "rest_budget_reserved",
 	}
 	return issue
+}
+
+func assertIssueFilterHint(t *testing.T, got connector.IssueFilterHint, want connector.IssueFilterHint) {
+	t.Helper()
+
+	if !slices.Equal(got.Authors, want.Authors) {
+		t.Fatalf("Authors = %#v, want %#v", got.Authors, want.Authors)
+	}
+	if !slices.Equal(got.Assignees, want.Assignees) {
+		t.Fatalf("Assignees = %#v, want %#v", got.Assignees, want.Assignees)
+	}
+	if !slices.Equal(got.LabelInclude, want.LabelInclude) {
+		t.Fatalf("LabelInclude = %#v, want %#v", got.LabelInclude, want.LabelInclude)
+	}
+	if !slices.Equal(got.LabelExclude, want.LabelExclude) {
+		t.Fatalf("LabelExclude = %#v, want %#v", got.LabelExclude, want.LabelExclude)
+	}
+}
+
+func dispatchPlanIssueIDs(cfg Config, candidates []connector.Issue) []string {
+	cfg = normalizeConfig(cfg)
+	state := newState(cfg)
+	plan := newDispatchPlanner(cfg).plan(&state, candidates, time.Now(), dispatchPlanHooks{})
+	ids := make([]string, 0, len(plan.Dispatches))
+	for _, dispatch := range plan.Dispatches {
+		ids = append(ids, dispatch.IssueID)
+	}
+	return ids
+}
+
+type filterFetchConnector struct {
+	issues      []connector.Issue
+	states      []string
+	hint        connector.IssueFilterHint
+	baseFetches int
+}
+
+func (c *filterFetchConnector) Name() string {
+	return "filter-fetch"
+}
+
+func (c *filterFetchConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.baseFetches++
+	return cloneIssues(c.issues), nil
+}
+
+func (c *filterFetchConnector) FetchCandidateIssuesByStatesWithFilter(
+	_ context.Context,
+	states []string,
+	hint connector.IssueFilterHint,
+) ([]connector.Issue, error) {
+	c.states = append([]string(nil), states...)
+	c.hint = connector.IssueFilterHint{
+		Authors:      append([]string(nil), hint.Authors...),
+		Assignees:    append([]string(nil), hint.Assignees...),
+		LabelInclude: append([]string(nil), hint.LabelInclude...),
+		LabelExclude: append([]string(nil), hint.LabelExclude...),
+	}
+	return cloneIssues(c.issues), nil
+}
+
+func (c *filterFetchConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *filterFetchConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *filterFetchConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *filterFetchConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c *filterFetchConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *filterFetchConnector) SetField(context.Context, string, string, string) error {
+	return nil
 }
 
 type budgetRefusalComment struct {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -310,6 +311,13 @@ func (o *Orchestrator) fetchTickIssues(
 }
 
 func (o *Orchestrator) fetchCandidateIssuesForTick(ctx context.Context, state *State) ([]connector.Issue, error) {
+	if fetcher, ok := o.connector.(connector.CandidateIssuesFilterFetcher); ok {
+		states := o.candidateFetchStatesForTick(state)
+		if len(states) == 0 {
+			return []connector.Issue{}, nil
+		}
+		return fetcher.FetchCandidateIssuesByStatesWithFilter(ctx, states, o.authorizationFilterHint())
+	}
 	if fetcher, ok := o.connector.(connector.CandidateIssuesByStatesFetcher); ok {
 		states := o.candidateFetchStatesForTick(state)
 		if len(states) == 0 {
@@ -318,6 +326,60 @@ func (o *Orchestrator) fetchCandidateIssuesForTick(ctx context.Context, state *S
 		return fetcher.FetchCandidateIssuesByStates(ctx, states)
 	}
 	return o.connector.FetchCandidateIssues(ctx)
+}
+
+func (o *Orchestrator) authorizationFilterHint() connector.IssueFilterHint {
+	return authorizationFilterHint(o.cfg.Authorization, o.cfg.SelectorContext)
+}
+
+func authorizationFilterHint(auth selector.Selector, ctx selector.Context) connector.IssueFilterHint {
+	return connector.IssueFilterHint{
+		Authors:      resolveFilterHintIdentities(auth.AuthorIn, ctx),
+		Assignees:    resolveFilterHintIdentities(auth.AssigneeIn, ctx),
+		LabelInclude: filterHintStrings(auth.Labels.Include),
+		LabelExclude: filterHintStrings(auth.Labels.Exclude),
+	}
+}
+
+func resolveFilterHintIdentities(values []string, ctx selector.Context) []string {
+	out := []string{}
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			continue
+		}
+		if strings.EqualFold(value, "@me") {
+			for _, resolved := range []string{ctx.InstanceLogin, ctx.Persona} {
+				appendFilterHintString(&out, seen, resolved)
+			}
+			continue
+		}
+		appendFilterHintString(&out, seen, value)
+	}
+	return out
+}
+
+func filterHintStrings(values []string) []string {
+	out := []string{}
+	seen := map[string]struct{}{}
+	for _, value := range values {
+		appendFilterHintString(&out, seen, value)
+	}
+	return out
+}
+
+func appendFilterHintString(out *[]string, seen map[string]struct{}, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return
+	}
+	key := strings.ToLower(value)
+	if _, ok := seen[key]; ok {
+		return
+	}
+	seen[key] = struct{}{}
+	*out = append(*out, value)
 }
 
 func (o *Orchestrator) refreshStatusDrift(


### PR DESCRIPTION
## Summary

- Adds connector-neutral authorization filter hints and an optional fetch capability while preserving post-fetch selector enforcement.
- Routes candidate fetch through the optional capability and applies GitHub issue-field search qualifiers for author, assignee, and label hints.
- Leaves ProjectV2 and label status fetches unchanged when hints cannot be safely pushed down.

Fixes #912

## Test Plan

- [x] `go test ./internal/connector ./internal/connector/github ./internal/orchestrator`
- [x] `go test -race ./internal/project -run TestGitRefWorkflowWatcherReloadsWhenRefAdvances -count=1 -v`
- [x] `make check`
