### PR TITLE
fix(web): key cards by issue identity

### DIFF
--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -104,7 +104,13 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 		}
 	}
 
-	sheetURL := dashboardURL + "/api/v1/board/card?project=" + projectID + "&issue=9511&scope=project&actions=board"
+	sheetQuery := url.Values{
+		"project": {projectID},
+		"issue":   {"digitaldrywood/detent#9511"},
+		"scope":   {"project"},
+		"actions": {"board"},
+	}
+	sheetURL := dashboardURL + "/api/v1/board/card?" + sheetQuery.Encode()
 	waitForDashboardCondition(t, sheetURL, done, "board card detail sheet", func(body string) bool {
 		return strings.Contains(body, "Kanban demo backlog intake") &&
 			strings.Contains(body, `hx-get="/api/v1/kanban/move?`) &&
@@ -135,17 +141,17 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	for _, want := range []string{
 		`id="board-lanes"`,
 		"Moved card to Todo.",
-		`id="card-` + projectID + `-9511"`,
+		`id="card-digitaldrywood-detent-9511"`,
 	} {
 		if !strings.Contains(moveBody, want) {
 			t.Fatalf("immediate Kanban move response missing %q:\n%s", want, moveBody)
 		}
 	}
-	if got := strings.Count(moveBody, `id="card-`+projectID+`-9511"`); got != 1 {
+	if got := strings.Count(moveBody, `id="card-digitaldrywood-detent-9511"`); got != 1 {
 		t.Fatalf("immediate Kanban move response rendered moved card %d times, want 1:\n%s", got, moveBody)
 	}
 	postRuntimeRefresh(t, dashboardURL, done)
-	movedCardPattern := regexp.MustCompile(`data-board-lane="todo"[\s\S]*?id="card-` + projectID + `-9511"`)
+	movedCardPattern := regexp.MustCompile(`data-board-lane="todo"[\s\S]*?id="card-digitaldrywood-detent-9511"`)
 	waitForDashboardCondition(t, pageURL, done, "backlog card moved to todo", func(body string) bool {
 		return movedCardPattern.MatchString(body)
 	})

--- a/internal/web/board_card_test.go
+++ b/internal/web/board_card_test.go
@@ -37,7 +37,7 @@ func TestAPIBoardCardRendersDetailSheet(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=demo-project&issue=9510", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=demo-project&issue=digitaldrywood%2Fdetent%239510", nil)
 	server.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
@@ -52,6 +52,13 @@ func TestAPIBoardCardRendersDetailSheet(t *testing.T) {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("sheet missing %q:\n%s", want, rec.Body.String())
 		}
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=demo-project&issue=9510", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("legacy number status = %d, want 200; body = %s", rec.Code, rec.Body.String())
 	}
 
 	rec = httptest.NewRecorder()
@@ -73,7 +80,7 @@ func TestAPIBoardCardScopesDemoProjectSheets(t *testing.T) {
 	// A card opened from an integration-mode demo project board must keep its
 	// project-scoped Move/Remove actions, not fall back to fleet-scoped data.
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=dogfood&issue=5251&scope=project&actions=board", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=dogfood&issue=digitaldrywood%2Fdetent-core%235251&scope=project&actions=board", nil)
 	req.Header.Set(web.DemoScenarioHeader, "kanban-full-integration")
 	server.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
@@ -117,7 +124,7 @@ func TestAPIBoardCardPreservesProjectScope(t *testing.T) {
 	}
 
 	rec := httptest.NewRecorder()
-	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=42&scope=project&actions=board", nil)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=digitaldrywood%2Fdetent%2342&scope=project&actions=board", nil)
 	server.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
@@ -131,7 +138,7 @@ func TestAPIBoardCardPreservesProjectScope(t *testing.T) {
 	}
 
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=42&actions=board", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=digitaldrywood%2Fdetent%2342&actions=board", nil)
 	server.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("fleet status = %d, want 200; body = %s", rec.Code, rec.Body.String())
@@ -144,7 +151,7 @@ func TestAPIBoardCardPreservesProjectScope(t *testing.T) {
 	// must not offer inline kanban actions that would swap board lanes over
 	// the page the user is on.
 	rec = httptest.NewRecorder()
-	req = httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=42", nil)
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=digitaldrywood%2Fdetent%2342", nil)
 	server.Handler().ServeHTTP(rec, req)
 	if rec.Code != http.StatusOK {
 		t.Fatalf("no-actions status = %d, want 200; body = %s", rec.Code, rec.Body.String())

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1178,7 +1178,7 @@ func TestKanbanMoveSuccessResponseRefreshesFleetBoard(t *testing.T) {
 	if strings.Contains(body, `id="project-kanban"`) {
 		t.Fatalf("fleet move response rendered project board:\n%s", body)
 	}
-	if got := strings.Count(body, `id="card-detent-764"`); got != 1 {
+	if got := strings.Count(body, `id="card-digitaldrywood-detent-764"`); got != 1 {
 		t.Fatalf("card render count = %d, want 1:\n%s", got, body)
 	}
 	if got, want := actionConnector.stateUpdates(), []kanbanStateUpdate{{issueID: "I_kw764", state: "Todo"}}; !equalStateUpdates(got, want) {
@@ -2563,7 +2563,7 @@ func TestDashboardRendersLatestSnapshot(t *testing.T) {
 		"Dashboard templates",
 		"2 turns",
 		"tps",
-		`id="agent-35"`,
+		`id="agent-digitaldrywood-detent-35"`,
 	} {
 		if !strings.Contains(rec.Body.String(), want) {
 			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
@@ -3208,7 +3208,7 @@ func TestProjectKanbanRouteRendersOnlyLiveBoard(t *testing.T) {
 		`hx-swap="morph:innerHTML"`,
 		`id="board-lanes"`,
 		`data-board-key="project.detent"`,
-		`id="card-detent-490"`,
+		`id="card-digitaldrywood-detent-490"`,
 		`href="/projects/detent"`,
 		`href="/projects/detent/kanban"`,
 		"Add a live Kanban-only board view",
@@ -3263,7 +3263,7 @@ func TestProjectKanbanRouteHidesMutationControlsInReadOnlyMode(t *testing.T) {
 	}
 
 	body := requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
-	if !strings.Contains(body, `id="card-detent-490"`) {
+	if !strings.Contains(body, `id="card-digitaldrywood-detent-490"`) {
 		t.Fatalf("read-only Kanban page missing board card:\n%s", body)
 	}
 	for _, forbidden := range []string{
@@ -3352,8 +3352,8 @@ func TestBoardRouteRendersFleetBoard(t *testing.T) {
 		`data-board-key="fleet"`,
 		`data-board-lane="todo"`,
 		`data-board-lane="in-progress"`,
-		`id="card-detent-542"`,
-		`id="card-docs-site-12"`,
+		`id="card-digitaldrywood-detent-542"`,
+		`id="card-digitaldrywood-docs-site-12"`,
 		"Add top-level multi-project Kanban board",
 		"Document fleet Kanban",
 		`id="fig-running"`,
@@ -3372,7 +3372,7 @@ func TestBoardRouteRendersFleetBoard(t *testing.T) {
 			t.Fatalf("board page rendered forbidden %q:\n%s", forbidden, body)
 		}
 	}
-	if got := strings.Count(body, `id="card-detent-543"`); got != 1 {
+	if got := strings.Count(body, `id="card-digitaldrywood-detent-543"`); got != 1 {
 		t.Fatalf("done card render count = %d, want 1", got)
 	}
 }
@@ -3470,7 +3470,7 @@ func TestProjectKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 	}
 	for _, want := range []string{
 		`id="board-lanes"`,
-		`id="card-detent-490"`,
+		`id="card-digitaldrywood-detent-490"`,
 		"SSE board card",
 	} {
 		if !strings.Contains(event.data, want) {
@@ -3555,8 +3555,8 @@ func TestFleetKanbanEventsSendBoardOnlySnapshot(t *testing.T) {
 	for _, want := range []string{
 		`id="board-lanes"`,
 		`data-board-key="fleet"`,
-		`id="card-detent-542"`,
-		`id="card-docs-site-12"`,
+		`id="card-digitaldrywood-detent-542"`,
+		`id="card-digitaldrywood-docs-site-12"`,
 		"Fleet SSE board card",
 		"Docs SSE board card",
 	} {

--- a/internal/web/templates/board.templ
+++ b/internal/web/templates/board.templ
@@ -109,7 +109,7 @@ templ boardCardView2(card boardCardView) {
 		class={ boardCardClass(card) + " cursor-pointer hover:border-accent/50" }
 		role="button"
 		tabindex="0"
-		{ sheetOpenAttrs(card.Project, card.Number, card.Scope, true)... }
+		{ sheetOpenAttrs(card.Project, card.Identity, card.Scope, true)... }
 	>
 		<div class="flex items-center gap-1.5 font-mono text-2xs font-medium text-sec">
 			if card.Running {

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -38,6 +38,7 @@ type boardLaneView struct {
 // title, and AT MOST one extra signal (chip, status line, or none).
 type boardCardView struct {
 	DomID     string
+	Identity  string
 	Number    string
 	Project   string
 	Scope     string
@@ -179,8 +180,9 @@ func boardExceptions(data DashboardData, boardActions bool) []primitives.Excepti
 		if projectID == "" {
 			projectID = fallbackProjectID
 		}
+		identity := boardCardIdentityToken(row.Identifier, row.ID, projectKanbanIssueNumber(row.Issue))
 		exception := primitives.Exception{
-			ID:    "exception-" + boardCardSlug(projectID, projectKanbanIssueNumber(row.Issue)),
+			ID:    "exception-" + boardCardScopedSlug(projectID, identity),
 			Kind:  primitives.KindErr,
 			Title: "Session blocked",
 			Repo:  projectID,
@@ -188,7 +190,7 @@ func boardExceptions(data DashboardData, boardActions bool) []primitives.Excepti
 			Rest:  boardExceptionDetail(row, now),
 		}
 		exception.ActionLabel = "Review"
-		exception.ActionAttrs = sheetOpenAttrs(projectID, projectKanbanIssueNumber(row.Issue), projectKanbanBoardScope(data), boardActions)
+		exception.ActionAttrs = sheetOpenAttrs(projectID, identity, projectKanbanBoardScope(data), boardActions)
 		exceptions = append(exceptions, exception)
 	}
 	return exceptions
@@ -213,12 +215,14 @@ func boardCardViewFromCard(lane projectKanbanLane, card projectKanbanCard, termi
 	if projectID == "" {
 		projectID = fallbackProjectID
 	}
+	identity := boardCardIdentityToken(card.Identifier, card.IssueID, card.IssueNumber)
 	view := boardCardView{
-		DomID:   "card-" + boardCardSlug(projectID, card.IssueNumber),
-		Number:  card.IssueNumber,
-		Project: projectID,
-		Scope:   scope,
-		Running: strings.EqualFold(lane.Title, "In Progress"),
+		DomID:    "card-" + boardCardScopedSlug(projectID, identity),
+		Identity: identity,
+		Number:   card.IssueNumber,
+		Project:  projectID,
+		Scope:    scope,
+		Running:  strings.EqualFold(lane.Title, "In Progress"),
 		// Done drives the green ✓; other terminal states (Cancelled, Closed)
 		// are terminal but not done, so they suppress meta without claiming
 		// success.
@@ -376,16 +380,61 @@ func boardLaneShowsAge(title string) bool {
 	return true
 }
 
-func boardCardSlug(projectID string, number string) string {
-	slug := strings.TrimSpace(projectID) + "-" + strings.TrimPrefix(strings.TrimSpace(number), "#")
-	slug = strings.Map(func(r rune) rune {
+func boardCardIdentityToken(identifier string, issueID string, number string) string {
+	identifier = strings.TrimSpace(identifier)
+	if issueIdentifierHasNumber(identifier) {
+		return identifier
+	}
+	if issueID = strings.TrimSpace(issueID); issueID != "" {
+		return issueID
+	}
+	return strings.TrimSpace(number)
+}
+
+func issueIdentifierHasNumber(identifier string) bool {
+	index := strings.LastIndex(identifier, "#")
+	return index > 0 && index < len(identifier)-1
+}
+
+func issueIdentifierHasRepositoryNumber(identifier string) bool {
+	index := strings.LastIndex(identifier, "#")
+	return index > 0 && index < len(identifier)-1 && strings.Contains(identifier[:index], "/")
+}
+
+func boardCardScopedIdentityToken(projectID string, identity string) string {
+	projectID = strings.TrimSpace(projectID)
+	identity = strings.TrimSpace(identity)
+	if identity == "" || projectID == "" || issueIdentifierHasRepositoryNumber(identity) {
+		return identity
+	}
+	return projectID + ":" + identity
+}
+
+func boardCardScopedSlug(projectID string, identity string) string {
+	return boardCardSlug(boardCardScopedIdentityToken(projectID, identity))
+}
+
+func boardCardSlug(identity string) string {
+	var builder strings.Builder
+	lastDash := false
+	for _, r := range strings.TrimSpace(identity) {
 		switch {
 		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '-':
-			return r
+			builder.WriteRune(r)
+			lastDash = false
 		case r >= 'A' && r <= 'Z':
-			return r + ('a' - 'A')
+			builder.WriteRune(r + ('a' - 'A'))
+			lastDash = false
+		default:
+			if builder.Len() > 0 && !lastDash {
+				builder.WriteByte('-')
+				lastDash = true
+			}
 		}
-		return '-'
-	}, slug)
-	return strings.Trim(slug, "-")
+	}
+	slug := strings.Trim(builder.String(), "-")
+	if slug == "" {
+		return "unknown"
+	}
+	return slug
 }

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -102,7 +102,10 @@ func TestBoardViewLanes(t *testing.T) {
 	if card.MetaRight == "" {
 		t.Fatalf("running card should show elapsed time")
 	}
-	if card.DomID != "card-gopher-ai-185" {
+	if card.Identity != "gopherguides/gopher-ai#185" {
+		t.Fatalf("card identity = %q, want full identifier", card.Identity)
+	}
+	if card.DomID != "card-gopherguides-gopher-ai-185" {
 		t.Fatalf("card dom id = %q", card.DomID)
 	}
 
@@ -184,7 +187,7 @@ func TestBoardExceptions(t *testing.T) {
 	if exception.ActionLabel != "Review" {
 		t.Fatalf("exception should carry the Review action, got %+v", exception)
 	}
-	if got := exception.ActionAttrs["hx-get"]; got != "/api/v1/board/card?actions=board&issue=92&project=detent" {
+	if got := exception.ActionAttrs["hx-get"]; got != "/api/v1/board/card?actions=board&issue=digitaldrywood%2Fdetent%2392&project=detent" {
 		t.Fatalf("board exception review target = %v", got)
 	}
 
@@ -201,20 +204,61 @@ func TestBoardExceptions(t *testing.T) {
 	}
 }
 
-func TestBoardCardSlug(t *testing.T) {
+func TestBoardCardIdentityToken(t *testing.T) {
 	tests := []struct {
-		project string
-		number  string
-		want    string
+		name       string
+		identifier string
+		issueID    string
+		number     string
+		want       string
 	}{
-		{project: "gopher-ai", number: "#185", want: "gopher-ai-185"},
-		{project: "My Project", number: "#9", want: "my-project-9"},
-		{project: "", number: "#12", want: "12"},
+		{name: "full identifier", identifier: "digitaldrywood/detent#919", issueID: "I_kw919", number: "#919", want: "digitaldrywood/detent#919"},
+		{name: "tracker issue id", identifier: "MT-1", issueID: "memory-1", number: "MT-1", want: "memory-1"},
+		{name: "display number", number: "#12", want: "#12"},
 	}
 	for _, tt := range tests {
-		if got := boardCardSlug(tt.project, tt.number); got != tt.want {
-			t.Fatalf("boardCardSlug(%q, %q) = %q, want %q", tt.project, tt.number, got, tt.want)
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boardCardIdentityToken(tt.identifier, tt.issueID, tt.number); got != tt.want {
+				t.Fatalf("boardCardIdentityToken(%q, %q, %q) = %q, want %q", tt.identifier, tt.issueID, tt.number, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBoardCardSlug(t *testing.T) {
+	tests := []struct {
+		token string
+		want  string
+	}{
+		{token: "gopherguides/gopher-ai#185", want: "gopherguides-gopher-ai-185"},
+		{token: "My Project #9", want: "my-project-9"},
+		{token: "#12", want: "12"},
+		{token: "", want: "unknown"},
+	}
+	for _, tt := range tests {
+		if got := boardCardSlug(tt.token); got != tt.want {
+			t.Fatalf("boardCardSlug(%q) = %q, want %q", tt.token, got, tt.want)
 		}
+	}
+}
+
+func TestBoardCardScopedSlug(t *testing.T) {
+	tests := []struct {
+		name     string
+		project  string
+		identity string
+		want     string
+	}{
+		{name: "repository identity stays global", project: "detent", identity: "digitaldrywood/detent#919", want: "digitaldrywood-detent-919"},
+		{name: "local identity keeps project scope", project: "detent", identity: "issue-919", want: "detent-issue-919"},
+		{name: "missing project keeps identity", identity: "issue-919", want: "issue-919"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := boardCardScopedSlug(tt.project, tt.identity); got != tt.want {
+				t.Fatalf("boardCardScopedSlug(%q, %q) = %q, want %q", tt.project, tt.identity, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -242,13 +286,13 @@ func TestBoardCardFallsBackToDashboardProjectID(t *testing.T) {
 			}
 		}
 	}
-	if card.DomID != "card-detent-42" {
-		t.Fatalf("card dom id = %q, want card-detent-42", card.DomID)
+	if card.DomID != "card-digitaldrywood-detent-42" {
+		t.Fatalf("card dom id = %q, want card-digitaldrywood-detent-42", card.DomID)
 	}
 	if card.Project != "detent" {
 		t.Fatalf("card project = %q, want detent fallback", card.Project)
 	}
-	if got, _ := sheetOpenAttrs(card.Project, card.Number, card.Scope, true)["hx-get"].(string); !strings.Contains(got, "project=detent") {
+	if got, _ := sheetOpenAttrs(card.Project, card.Identity, card.Scope, true)["hx-get"].(string); !strings.Contains(got, "project=detent") {
 		t.Fatalf("card sheet link should carry the fallback project, got %q", got)
 	}
 
@@ -269,8 +313,52 @@ func TestBoardCardFallsBackToDashboardProjectID(t *testing.T) {
 	if got, _ := exceptions[0].ActionAttrs["hx-get"].(string); !strings.Contains(got, "project=detent") {
 		t.Fatalf("exception review link should carry the fallback project, got %q", got)
 	}
-	if exceptions[0].ID != "exception-detent-43" {
-		t.Fatalf("exception id = %q, want exception-detent-43", exceptions[0].ID)
+	if exceptions[0].ID != "exception-digitaldrywood-detent-43" {
+		t.Fatalf("exception id = %q, want exception-digitaldrywood-detent-43", exceptions[0].ID)
+	}
+}
+
+func TestFindBoardCardUsesIdentityBeforeDisplayNumber(t *testing.T) {
+	data := DashboardData{
+		ProjectID: "aggregate",
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: time.Date(2026, 7, 4, 16, 0, 0, 0, time.UTC),
+			BoardIssues: []telemetry.Issue{
+				{ID: "repo-a-7", Identifier: "digitaldrywood/repo-a#7", ProjectID: "aggregate", Title: "Repo A", State: "Todo"},
+				{ID: "repo-b-7", Identifier: "digitaldrywood/repo-b#7", ProjectID: "aggregate", Title: "Repo B", State: "Todo"},
+			},
+		},
+		Kanban: KanbanData{States: []string{"Todo"}},
+	}
+
+	view := boardViewFromDashboard(data)
+	var ids []string
+	for _, lane := range view.Lanes {
+		for _, card := range lane.Cards {
+			ids = append(ids, card.DomID)
+			if card.Number != "#7" {
+				t.Fatalf("visible card number = %q, want #7", card.Number)
+			}
+		}
+	}
+	if strings.Join(ids, ",") != "card-digitaldrywood-repo-a-7,card-digitaldrywood-repo-b-7" {
+		t.Fatalf("card dom ids = %v", ids)
+	}
+
+	card, ok := FindBoardCard(data, "aggregate", "digitaldrywood/repo-b#7")
+	if !ok {
+		t.Fatalf("FindBoardCard should match repo-b by identity")
+	}
+	if card.Identifier != "digitaldrywood/repo-b#7" {
+		t.Fatalf("FindBoardCard matched %q, want repo-b", card.Identifier)
+	}
+
+	legacy, ok := FindBoardCard(data, "aggregate", "7")
+	if !ok {
+		t.Fatalf("FindBoardCard should keep bare-number fallback")
+	}
+	if legacy.IssueNumber != "#7" {
+		t.Fatalf("legacy fallback issue number = %q, want #7", legacy.IssueNumber)
 	}
 }
 
@@ -368,7 +456,7 @@ func TestBoardSnapshotRenders(t *testing.T) {
 
 	for _, want := range []string{
 		`id="board-lanes"`,
-		`id="card-gopher-ai-185"`,
+		`id="card-gopherguides-gopher-ai-185"`,
 		`id="fig-running"`,
 		`id="fig-blocked"`,
 		"Session blocked",

--- a/internal/web/templates/board_templ.go
+++ b/internal/web/templates/board_templ.go
@@ -508,7 +508,7 @@ func boardCardView2(card boardCardView) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, sheetOpenAttrs(card.Project, card.Number, card.Scope, true))
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, sheetOpenAttrs(card.Project, card.Identity, card.Scope, true))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -427,6 +427,7 @@ type prPipelineLane struct {
 type prPipelineCard struct {
 	IssueNumber      string
 	Identity         issueIdentityView
+	IdentityToken    string
 	Identifier       string
 	ProjectID        string
 	Title            string
@@ -492,6 +493,7 @@ type projectKanbanLane struct {
 
 type projectKanbanCard struct {
 	IssueNumber      string
+	Identity         string
 	Identifier       string
 	ProjectID        string
 	ProjectColor     string
@@ -2531,6 +2533,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 	blockers, clearedBlockers := projectKanbanBlockerLabels(issue.BlockedBy, projectKanbanTerminalStateSetForIssue(data, issue))
 	card := projectKanbanCard{
 		IssueNumber:      projectKanbanIssueNumber(issue),
+		Identity:         boardCardIdentityToken(issue.Identifier, issue.ID, projectKanbanIssueNumber(issue)),
 		IssueID:          strings.TrimSpace(issue.ID),
 		Identifier:       issueIdentifier(issue),
 		ProjectID:        strings.TrimSpace(issue.ProjectID),
@@ -3331,10 +3334,8 @@ func appendPRPipelineCard(
 		return
 	}
 
-	key := laneID + ":" + issueIdentifier(issue)
-	if issue.ID != "" {
-		key = laneID + ":" + issue.ID
-	}
+	identity := boardCardIdentityToken(issue.Identifier, issue.ID, issueNumber(issue))
+	key := laneID + ":" + boardCardScopedIdentityToken(issue.ProjectID, identity)
 	if _, ok := seen[key]; ok {
 		return
 	}
@@ -3385,6 +3386,7 @@ func prPipelineCardForIssue(issue telemetry.Issue, state string, laneID string, 
 	return prPipelineCard{
 		IssueNumber:      issueNumber(issue),
 		Identity:         issueIdentity(issue),
+		IdentityToken:    boardCardIdentityToken(issue.Identifier, issue.ID, issueNumber(issue)),
 		Identifier:       issueIdentifier(issue),
 		ProjectID:        strings.TrimSpace(issue.ProjectID),
 		Title:            issueTitle(issue),

--- a/internal/web/templates/fleet_data.go
+++ b/internal/web/templates/fleet_data.go
@@ -114,15 +114,9 @@ func fleetAgentRows(snapshot telemetry.Snapshot) []fleetAgentRow {
 	rows := make([]fleetAgentRow, 0, len(snapshot.Running))
 	for _, running := range snapshot.Running {
 		repo, number := splitIssueIdentifier(issueIdentifier(running.Issue))
-		// Non-GitHub tracker identifiers (e.g. memory IDs like MT-1) have no
-		// #number, so fall back to the full identifier to keep each agent
-		// row's DOM id unique and stable for SSE morph/highlight targeting.
-		idKey := number
-		if strings.TrimSpace(idKey) == "" {
-			idKey = repo
-		}
+		identity := boardCardIdentityToken(running.Identifier, running.ID, projectKanbanIssueNumber(running.Issue))
 		row := fleetAgentRow{
-			ID:      "agent-" + boardCardSlug(running.ProjectID, idKey),
+			ID:      "agent-" + boardCardScopedSlug(running.ProjectID, identity),
 			Repo:    repo,
 			Number:  number,
 			Title:   issueTitle(running.Issue),
@@ -213,7 +207,7 @@ func fleetPRLanes(snapshot telemetry.Snapshot) []fleetPRLane {
 		}
 		for _, card := range lane.Cards {
 			view.Cards = append(view.Cards, fleetPRCard{
-				DomID:   "pr-card-" + boardCardSlug(card.ProjectID, card.IssueNumber),
+				DomID:   "pr-card-" + boardCardScopedSlug(card.ProjectID, card.IdentityToken),
 				Ref:     fleetPRCardRef(card),
 				Project: strings.TrimSpace(card.ProjectID),
 				Meta:    boardCompactAge(card.TimeInStage),

--- a/internal/web/templates/fleet_data_test.go
+++ b/internal/web/templates/fleet_data_test.go
@@ -51,6 +51,9 @@ func TestFleetAgentRows(t *testing.T) {
 	if row.Repo != "gopherguides/gopher-ai" || row.Number != "#185" {
 		t.Fatalf("identifier split = %q %q", row.Repo, row.Number)
 	}
+	if row.ID != "agent-gopherguides-gopher-ai-185" {
+		t.Fatalf("agent row id = %q, want full identifier slug", row.ID)
+	}
 	if !strings.Contains(row.Elapsed, "1 turn") {
 		t.Fatalf("elapsed = %q, want turn count", row.Elapsed)
 	}
@@ -66,6 +69,58 @@ func TestFleetAgentRows(t *testing.T) {
 	}
 }
 
+func TestFleetPRLanesUseIdentityIDs(t *testing.T) {
+	now := time.Date(2026, 7, 4, 16, 42, 7, 0, time.UTC)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Pipeline: []telemetry.Issue{
+			{
+				ID:         "issue-a-7",
+				Identifier: "digitaldrywood/repo-a#7",
+				ProjectID:  "aggregate",
+				Title:      "Repo A",
+				State:      "Human Review",
+			},
+			{
+				ID:         "issue-b-7",
+				Identifier: "digitaldrywood/repo-b#7",
+				ProjectID:  "aggregate",
+				Title:      "Repo B",
+				State:      "Human Review",
+			},
+		},
+	}
+
+	lanes := fleetPRLanes(snapshot)
+	if len(lanes) == 0 || len(lanes[0].Cards) != 2 {
+		t.Fatalf("expected two PR cards, got %+v", lanes)
+	}
+	if lanes[0].Cards[0].DomID != "pr-card-digitaldrywood-repo-a-7" ||
+		lanes[0].Cards[1].DomID != "pr-card-digitaldrywood-repo-b-7" {
+		t.Fatalf("PR card ids = %+v", lanes[0].Cards)
+	}
+}
+
+func TestFleetPRLanesScopeLocalIdentityIDs(t *testing.T) {
+	now := time.Date(2026, 7, 4, 16, 42, 7, 0, time.UTC)
+	snapshot := telemetry.Snapshot{
+		GeneratedAt: now,
+		Pipeline: []telemetry.Issue{
+			{ID: "issue-1", Identifier: "MT-1", ProjectID: "project-a", Title: "Project A", State: "Human Review"},
+			{ID: "issue-1", Identifier: "MT-1", ProjectID: "project-b", Title: "Project B", State: "Human Review"},
+		},
+	}
+
+	lanes := fleetPRLanes(snapshot)
+	if len(lanes) == 0 || len(lanes[0].Cards) != 2 {
+		t.Fatalf("expected two PR cards, got %+v", lanes)
+	}
+	if lanes[0].Cards[0].DomID != "pr-card-project-a-issue-1" ||
+		lanes[0].Cards[1].DomID != "pr-card-project-b-issue-1" {
+		t.Fatalf("PR card ids = %+v", lanes[0].Cards)
+	}
+}
+
 func TestFleetAgentRowsUniqueIDsForNonGitHubIdentifiers(t *testing.T) {
 	// Memory/non-GitHub tracker identifiers have no #number; each running
 	// session must still get a unique, stable DOM id for SSE morph targeting.
@@ -73,14 +128,20 @@ func TestFleetAgentRowsUniqueIDsForNonGitHubIdentifiers(t *testing.T) {
 		Running: []telemetry.Running{
 			{Issue: telemetry.Issue{Identifier: "MT-1", ProjectID: "detent"}},
 			{Issue: telemetry.Issue{Identifier: "MT-2", ProjectID: "detent"}},
+			{Issue: telemetry.Issue{ID: "issue-1", Identifier: "MT-3", ProjectID: "project-a"}},
+			{Issue: telemetry.Issue{ID: "issue-1", Identifier: "MT-3", ProjectID: "project-b"}},
 		},
 	}
 	rows := fleetAgentRows(snapshot)
-	if len(rows) != 2 {
-		t.Fatalf("expected two agent rows, got %d", len(rows))
+	if len(rows) != 4 {
+		t.Fatalf("expected four agent rows, got %d", len(rows))
 	}
-	if rows[0].ID == rows[1].ID {
-		t.Fatalf("non-GitHub agent rows share a DOM id: %q", rows[0].ID)
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		if _, ok := seen[row.ID]; ok {
+			t.Fatalf("non-GitHub agent rows share a DOM id: %q", row.ID)
+		}
+		seen[row.ID] = struct{}{}
 	}
 }
 

--- a/internal/web/templates/project_data.go
+++ b/internal/web/templates/project_data.go
@@ -62,22 +62,12 @@ type projectRunRow struct {
 // first. Per-run dollar cost is not part of the telemetry snapshot; the
 // column renders an em dash until usage data carries it (Reports has the
 // authoritative per-issue spend).
-// runRowIDKey keeps run-row DOM ids unique for non-GitHub tracker
-// identifiers (e.g. memory IDs like MT-1), whose split yields an empty
-// #number; it falls back to the full identifier as fleetAgentRows does.
-func runRowIDKey(repo string, number string) string {
-	if strings.TrimSpace(number) != "" {
-		return number
-	}
-	return repo
-}
-
 func projectRunRows(snapshot telemetry.Snapshot, limit int) []projectRunRow {
 	rows := make([]projectRunRow, 0, len(snapshot.Running)+len(snapshot.Completed))
 	for _, running := range snapshot.Running {
-		repo, number := splitIssueIdentifier(issueIdentifier(running.Issue))
+		identity := boardCardIdentityToken(running.Identifier, running.ID, projectKanbanIssueNumber(running.Issue))
 		rows = append(rows, projectRunRow{
-			DomID:     "run-" + boardCardSlug(running.ProjectID, runRowIDKey(repo, number)),
+			DomID:     "run-" + boardCardScopedSlug(running.ProjectID, identity),
 			Ref:       projectKanbanIssueNumber(running.Issue),
 			Title:     issueTitle(running.Issue),
 			StateKind: primitives.KindOK,
@@ -95,10 +85,10 @@ func projectRunRows(snapshot telemetry.Snapshot, limit int) []projectRunRow {
 		return completed[i].CompletedAt.After(completed[j].CompletedAt)
 	})
 	for _, session := range completed {
-		repo, number := splitIssueIdentifier(issueIdentifier(session.Issue))
+		identity := boardCardIdentityToken(session.Identifier, session.ID, projectKanbanIssueNumber(session.Issue))
 		kind, text := projectRunFinalState(session.FinalState)
 		rows = append(rows, projectRunRow{
-			DomID:     "run-" + boardCardSlug(session.ProjectID, runRowIDKey(repo, number)) + "-" + strings.TrimSpace(session.SessionID),
+			DomID:     "run-" + boardCardScopedSlug(session.ProjectID, identity) + "-" + strings.TrimSpace(session.SessionID),
 			Ref:       projectKanbanIssueNumber(session.Issue),
 			Title:     issueTitle(session.Issue),
 			StateKind: kind,

--- a/internal/web/templates/project_data_test.go
+++ b/internal/web/templates/project_data_test.go
@@ -17,14 +17,20 @@ func TestProjectRunRowsUniqueIDsForNonGitHubIdentifiers(t *testing.T) {
 		Running: []telemetry.Running{
 			{Issue: telemetry.Issue{Identifier: "MT-1", ProjectID: "detent"}},
 			{Issue: telemetry.Issue{Identifier: "MT-2", ProjectID: "detent"}},
+			{Issue: telemetry.Issue{ID: "issue-1", Identifier: "MT-3", ProjectID: "project-a"}},
+			{Issue: telemetry.Issue{ID: "issue-1", Identifier: "MT-3", ProjectID: "project-b"}},
 		},
 	}
 	rows := projectRunRows(snapshot, 0)
-	if len(rows) != 2 {
-		t.Fatalf("expected two run rows, got %d", len(rows))
+	if len(rows) != 4 {
+		t.Fatalf("expected four run rows, got %d", len(rows))
 	}
-	if rows[0].DomID == rows[1].DomID {
-		t.Fatalf("non-GitHub run rows share a DOM id: %q", rows[0].DomID)
+	seen := map[string]struct{}{}
+	for _, row := range rows {
+		if _, ok := seen[row.DomID]; ok {
+			t.Fatalf("non-GitHub run rows share a DOM id: %q", row.DomID)
+		}
+		seen[row.DomID] = struct{}{}
 	}
 }
 
@@ -95,8 +101,14 @@ func TestProjectRunRows(t *testing.T) {
 	if !rows[0].StateLive || rows[0].StateText != "In progress" {
 		t.Fatalf("first row should be the live session: %+v", rows[0])
 	}
+	if rows[0].DomID != "run-digitaldrywood-detent-502" {
+		t.Fatalf("running row id = %q, want full identifier slug", rows[0].DomID)
+	}
 	if rows[1].Ref != "#501" {
 		t.Fatalf("completed rows should be newest first, got %q", rows[1].Ref)
+	}
+	if rows[1].DomID != "run-digitaldrywood-detent-501-s-2" {
+		t.Fatalf("completed row id = %q, want full identifier slug plus session", rows[1].DomID)
 	}
 	if rows[1].StateKind != primitives.KindErr || rows[1].StateText != "Failed" {
 		t.Fatalf("failed run state = %q %q", rows[1].StateKind, rows[1].StateText)

--- a/internal/web/templates/sheet_data.go
+++ b/internal/web/templates/sheet_data.go
@@ -26,16 +26,12 @@ type sheetSession struct {
 }
 
 // FindBoardCard locates one card on the fleet board by project and issue
-// number so the detail sheet can render it.
-func FindBoardCard(data DashboardData, projectID string, issueNumber string) (projectKanbanCard, bool) {
+// identity so the detail sheet can render it.
+func FindBoardCard(data DashboardData, projectID string, issueIdentity string) (projectKanbanCard, bool) {
 	projectID = strings.TrimSpace(projectID)
-	issueNumber = strings.TrimSpace(issueNumber)
-	// GitHub-style cards render as "#92" while callers send "92"; non-GitHub
-	// tracker IDs (e.g. memory IDs like "MT-1") render bare and are sent bare.
-	// Match against both forms so neither kind 404s.
-	hashedNumber := issueNumber
-	if issueNumber != "" && !strings.HasPrefix(issueNumber, "#") {
-		hashedNumber = "#" + issueNumber
+	issueIdentity = strings.TrimSpace(issueIdentity)
+	if issueIdentity == "" {
+		return projectKanbanCard{}, false
 	}
 	// Legacy single-project snapshots can leave Issue.ProjectID empty, so a
 	// card matches when its project id equals the request or when the card
@@ -44,7 +40,7 @@ func FindBoardCard(data DashboardData, projectID string, issueNumber string) (pr
 	board := projectKanbanBoardView(data)
 	for _, lane := range board.AllLanes {
 		for _, card := range lane.Cards {
-			if card.IssueNumber != issueNumber && card.IssueNumber != hashedNumber {
+			if !boardCardMatchesIdentity(card, issueIdentity) {
 				continue
 			}
 			cardProjectID := strings.TrimSpace(card.ProjectID)
@@ -57,6 +53,34 @@ func FindBoardCard(data DashboardData, projectID string, issueNumber string) (pr
 		}
 	}
 	return projectKanbanCard{}, false
+}
+
+func boardCardMatchesIdentity(card projectKanbanCard, issueIdentity string) bool {
+	issueIdentity = strings.TrimSpace(issueIdentity)
+	if issueIdentity == "" {
+		return false
+	}
+	for _, candidate := range []string{card.Identity, card.Identifier, card.IssueID} {
+		if strings.TrimSpace(candidate) == issueIdentity {
+			return true
+		}
+	}
+	return boardCardMatchesLegacyIssueNumber(card.IssueNumber, issueIdentity)
+}
+
+func boardCardMatchesLegacyIssueNumber(cardNumber string, issueIdentity string) bool {
+	cardNumber = strings.TrimSpace(cardNumber)
+	issueIdentity = strings.TrimSpace(issueIdentity)
+	if cardNumber == "" || issueIdentity == "" {
+		return false
+	}
+	if cardNumber == issueIdentity {
+		return true
+	}
+	if strings.HasPrefix(cardNumber, "#") {
+		return strings.TrimPrefix(cardNumber, "#") == strings.TrimPrefix(issueIdentity, "#")
+	}
+	return false
 }
 
 func sheetSessionFor(snapshot telemetry.Snapshot, card projectKanbanCard) sheetSession {
@@ -115,12 +139,12 @@ func sheetSessionMatchesProject(sessionProjectID string, card projectKanbanCard)
 // The Fleet and project Overview pages show the exception strip but their
 // #snapshot holds other content, so their Review sheets omit those
 // actions rather than swap board lanes over the page the user is on.
-func boardCardSheetPath(projectID string, issueNumber string, scope string, boardActions bool) string {
+func boardCardSheetPath(projectID string, issueIdentity string, scope string, boardActions bool) string {
 	values := url.Values{}
 	if projectID = strings.TrimSpace(projectID); projectID != "" {
 		values.Set("project", projectID)
 	}
-	values.Set("issue", strings.TrimPrefix(strings.TrimSpace(issueNumber), "#"))
+	values.Set("issue", strings.TrimSpace(issueIdentity))
 	if scope = strings.TrimSpace(scope); scope != "" && scope != "fleet" {
 		values.Set("scope", scope)
 	}
@@ -130,9 +154,9 @@ func boardCardSheetPath(projectID string, issueNumber string, scope string, boar
 	return "/api/v1/board/card?" + values.Encode()
 }
 
-func sheetOpenAttrs(projectID string, issueNumber string, scope string, boardActions bool) templ.Attributes {
+func sheetOpenAttrs(projectID string, issueIdentity string, scope string, boardActions bool) templ.Attributes {
 	return templ.Attributes{
-		"hx-get":    boardCardSheetPath(projectID, issueNumber, scope, boardActions),
+		"hx-get":    boardCardSheetPath(projectID, issueIdentity, scope, boardActions),
 		"hx-target": "#detail-sheet-host",
 		"hx-swap":   "innerHTML",
 	}

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -197,7 +197,9 @@ test("project kanban board scopes cards to the project", async ({ page }, testIn
   await page.locator("#board-lanes").waitFor({ state: "visible" });
 
   await expect(page.locator('[data-board-key="project.demo-project"]')).toBeVisible();
-  const foreign = await page.locator("#board-lanes article[id^='card-']:not([id^='card-demo-project-'])").count();
+  const foreign = await page.locator("#board-lanes article[id^='card-']").evaluateAll((cards) =>
+    cards.filter((card) => !card.textContent.includes("demo-project")).length
+  );
   expect(foreign).toBe(0);
   await assertNoDocumentOverflow(page);
   await capturePageAndAttach(page, "project-kanban.png", testInfo);


### PR DESCRIPTION
## Summary

- Key dashboard card identity on issue identity tokens instead of project/display-number pairs.
- Thread identity through board ids, exception links, fleet/project run rows, PR pipeline cards, and detail-sheet lookup.
- Keep visible issue labels unchanged while preserving legacy bare and `#`-prefixed sheet links.
- Scope non-global local tracker tokens by project so multi-project local IDs stay unique.

Fixes #919

## Test Plan

- [x] `go test ./internal/web/templates`
- [x] `go test ./internal/web`
- [x] `go test ./internal/cli -run TestStartKanbanDemoRendersAndAppliesSafeActions`
- [x] `npm run test:visual -- --grep "project kanban board scopes cards to the project"`
- [x] `make check`
- [x] GitHub CI check-runs green on `905c37b3946e37c6b9e66ed2b818008df735ccdd`