### PR TITLE
fix(web): preserve pending kanban moves

### DIFF
--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -4,8 +4,10 @@ import (
 	"context"
 	"fmt"
 	"html"
+	"maps"
 	"net/http"
 	"net/url"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,6 +33,8 @@ type kanbanMutationLocks struct {
 type kanbanPendingState struct {
 	snapshot string
 	current  string
+	project  string
+	issue    telemetry.Issue
 }
 
 type kanbanPendingRemoval struct {
@@ -136,10 +140,15 @@ func (l *kanbanMutationLocks) cardState(key string, issueID string, snapshotStat
 	}
 }
 
-func (l *kanbanMutationLocks) noteCardState(key string, issueID string, snapshotState string, currentState string) {
-	stateKey := kanbanMutationStateKey(key, issueID)
+func (l *kanbanMutationLocks) noteCardState(key string, projectID string, issue telemetry.Issue, snapshotState string, currentState string) {
+	issue.ID = strings.TrimSpace(issue.ID)
+	stateKey := kanbanMutationStateKey(key, issue.ID)
 	if stateKey == "" || strings.TrimSpace(currentState) == "" {
 		return
+	}
+	projectID = strings.TrimSpace(projectID)
+	if strings.TrimSpace(issue.ProjectID) == "" {
+		issue.ProjectID = projectID
 	}
 
 	l.mu.Lock()
@@ -148,10 +157,78 @@ func (l *kanbanMutationLocks) noteCardState(key string, issueID string, snapshot
 	if pending, ok := l.states[stateKey]; ok && normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot) {
 		snapshotState = pending.snapshot
 	}
+	delete(l.removed, stateKey)
 	l.states[stateKey] = kanbanPendingState{
 		snapshot: strings.TrimSpace(snapshotState),
 		current:  strings.TrimSpace(currentState),
+		project:  projectID,
+		issue:    cloneKanbanIssue(issue),
 	}
+}
+
+func (l *kanbanMutationLocks) pendingMovedCards(key string, projectID string, snapshot telemetry.Snapshot) []telemetry.Issue {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	present := map[string]struct{}{}
+	for _, issue := range snapshotKanbanPendingIssues(snapshot) {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" || !sameKanbanProject(issue, projectID, snapshot.Project.ID) {
+			continue
+		}
+		stateKey := kanbanMutationStateKey(key, issueID)
+		pending, ok := l.states[stateKey]
+		if !ok {
+			continue
+		}
+		present[stateKey] = struct{}{}
+		snapshotState := strings.TrimSpace(issue.State)
+		switch {
+		case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot):
+		case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.current):
+			delete(l.states, stateKey)
+		default:
+			delete(l.states, stateKey)
+		}
+	}
+
+	projectID = strings.TrimSpace(projectID)
+	out := []telemetry.Issue{}
+	for stateKey, pending := range l.states {
+		if _, ok := present[stateKey]; ok {
+			continue
+		}
+		issueID := strings.TrimSpace(pending.issue.ID)
+		if issueID == "" || kanbanMutationStateKey(key, issueID) != stateKey {
+			continue
+		}
+		if projectID != "" && pending.project != "" && pending.project != projectID {
+			continue
+		}
+		if !sameKanbanProject(pending.issue, projectID, snapshot.Project.ID) {
+			continue
+		}
+		issue := cloneKanbanIssue(pending.issue)
+		if strings.TrimSpace(issue.ProjectID) == "" {
+			issue.ProjectID = projectID
+		}
+		issue.State = strings.TrimSpace(pending.current)
+		out = append(out, issue)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		left := strings.TrimSpace(out[i].Identifier)
+		right := strings.TrimSpace(out[j].Identifier)
+		if left != right {
+			return left < right
+		}
+		return strings.TrimSpace(out[i].ID) < strings.TrimSpace(out[j].ID)
+	})
+	return out
 }
 
 func (l *kanbanMutationLocks) cardRemoved(key string, issueID string, snapshotState string) bool {
@@ -185,6 +262,7 @@ func (l *kanbanMutationLocks) noteCardRemoved(key string, issueID string, snapsh
 	}
 
 	l.mu.Lock()
+	delete(l.states, stateKey)
 	l.removed[stateKey] = kanbanPendingRemoval{
 		snapshot:  strings.TrimSpace(snapshotState),
 		removedAt: time.Now(),
@@ -314,14 +392,14 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 				return err
 			}
 			s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move_field")
-			s.kanbanMutations.noteCardState(target.key, req.issueID, snapshotState, req.targetState)
+			s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState)
 			return nil
 		}
 		if err := target.connector.UpdateIssueState(c.Request().Context(), req.issueID, req.targetState); err != nil {
 			return err
 		}
 		s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move")
-		s.kanbanMutations.noteCardState(target.key, req.issueID, snapshotState, req.targetState)
+		s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState)
 		return nil
 	})
 	if feedback != "" {
@@ -473,6 +551,7 @@ func (s *Server) kanbanSnapshotWithPendingStates(lockKey string, projectID strin
 		}
 		return !s.kanbanMutations.cardRemoved(lockKey, issue.ID, issue.State)
 	})
+	pendingMovedCards := s.kanbanMutations.pendingMovedCards(lockKey, projectID, snapshot)
 	applySnapshotKanbanIssues(&snapshot, func(issue *telemetry.Issue) {
 		if issue == nil || strings.TrimSpace(issue.ID) == "" || !sameKanbanProject(*issue, projectID, snapshot.Project.ID) {
 			return
@@ -482,6 +561,9 @@ func (s *Server) kanbanSnapshotWithPendingStates(lockKey string, projectID strin
 			issue.State = state
 		}
 	})
+	if len(pendingMovedCards) > 0 {
+		snapshot.BoardIssues = append(snapshot.BoardIssues, pendingMovedCards...)
+	}
 	states := kanbanIssueStateIndex(snapshot)
 	applySnapshotKanbanIssues(&snapshot, func(issue *telemetry.Issue) {
 		if issue == nil || len(issue.BlockedBy) == 0 || !sameKanbanProject(*issue, projectID, snapshot.Project.ID) {
@@ -551,6 +633,71 @@ func cloneKanbanIssueSlices(snapshot telemetry.Snapshot) telemetry.Snapshot {
 	snapshot.Blocked = append([]telemetry.Blocked(nil), snapshot.Blocked...)
 	snapshot.Completed = append([]telemetry.Completed(nil), snapshot.Completed...)
 	return snapshot
+}
+
+func cloneKanbanIssue(issue telemetry.Issue) telemetry.Issue {
+	out := issue
+	out.Labels = append([]string(nil), issue.Labels...)
+	out.Assignees = append([]string(nil), issue.Assignees...)
+	out.Comments = append([]telemetry.IssueComment(nil), issue.Comments...)
+	out.BlockedBy = append([]telemetry.BlockedRef(nil), issue.BlockedBy...)
+	out.Metadata = maps.Clone(issue.Metadata)
+	out.PullRequest = cloneKanbanPullRequest(issue.PullRequest)
+	out.Deliverable = cloneKanbanDeliverable(issue.Deliverable)
+	out.MergeTiming = cloneKanbanMergeTiming(issue.MergeTiming)
+	out.LeaseRenewedAt = cloneKanbanTimePointer(issue.LeaseRenewedAt)
+	out.LeaseExpiresAt = cloneKanbanTimePointer(issue.LeaseExpiresAt)
+	out.CreatedAt = cloneKanbanTimePointer(issue.CreatedAt)
+	out.UpdatedAt = cloneKanbanTimePointer(issue.UpdatedAt)
+	out.StageUpdatedAt = cloneKanbanTimePointer(issue.StageUpdatedAt)
+	out.CurrentLaneEnteredAt = cloneKanbanTimePointer(issue.CurrentLaneEnteredAt)
+	return out
+}
+
+func cloneKanbanPullRequest(pr *telemetry.PullRequest) *telemetry.PullRequest {
+	if pr == nil {
+		return nil
+	}
+	out := *pr
+	out.HydrationNextRetryAt = cloneKanbanTimePointer(pr.HydrationNextRetryAt)
+	out.SlowChecks = append([]telemetry.PullRequestCheck(nil), pr.SlowChecks...)
+	out.RunningChecks = append([]string(nil), pr.RunningChecks...)
+	out.RequiredCheckFailures = append([]telemetry.PullRequestCheck(nil), pr.RequiredCheckFailures...)
+	return &out
+}
+
+func cloneKanbanDeliverable(deliverable *telemetry.Deliverable) *telemetry.Deliverable {
+	if deliverable == nil {
+		return nil
+	}
+	out := *deliverable
+	out.Metadata = maps.Clone(deliverable.Metadata)
+	return &out
+}
+
+func cloneKanbanMergeTiming(timing *telemetry.MergeTiming) *telemetry.MergeTiming {
+	if timing == nil {
+		return nil
+	}
+	out := *timing
+	out.EnteredMergingAt = cloneKanbanTimePointer(timing.EnteredMergingAt)
+	out.MergeWorkerSlotAcquiredAt = cloneKanbanTimePointer(timing.MergeWorkerSlotAcquiredAt)
+	out.MergeStartedAt = cloneKanbanTimePointer(timing.MergeStartedAt)
+	out.BaseRefreshStartedAt = cloneKanbanTimePointer(timing.BaseRefreshStartedAt)
+	out.BaseRefreshFinishedAt = cloneKanbanTimePointer(timing.BaseRefreshFinishedAt)
+	out.CIWaitStartedAt = cloneKanbanTimePointer(timing.CIWaitStartedAt)
+	out.CIWaitFinishedAt = cloneKanbanTimePointer(timing.CIWaitFinishedAt)
+	out.MergedAt = cloneKanbanTimePointer(timing.MergedAt)
+	out.MergeFailedAt = cloneKanbanTimePointer(timing.MergeFailedAt)
+	return &out
+}
+
+func cloneKanbanTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
 }
 
 func applySnapshotKanbanIssues(snapshot *telemetry.Snapshot, apply func(*telemetry.Issue)) {
@@ -1326,6 +1473,14 @@ func snapshotKanbanIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
 		issues = append(issues, row.Issue)
 	}
 	for _, row := range snapshot.Blocked {
+		issues = append(issues, row.Issue)
+	}
+	return issues
+}
+
+func snapshotKanbanPendingIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
+	issues := snapshotKanbanIssues(snapshot)
+	for _, row := range snapshot.Completed {
 		issues = append(issues, row.Issue)
 	}
 	return issues

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -176,7 +176,7 @@ func (l *kanbanMutationLocks) pendingMovedCards(key string, projectID string, sn
 	defer l.mu.Unlock()
 
 	present := map[string]struct{}{}
-	for _, issue := range snapshotKanbanPendingIssues(snapshot) {
+	for _, issue := range snapshotKanbanIssues(snapshot) {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" || !sameKanbanProject(issue, projectID, snapshot.Project.ID) {
 			continue
@@ -187,6 +187,29 @@ func (l *kanbanMutationLocks) pendingMovedCards(key string, projectID string, sn
 			continue
 		}
 		present[stateKey] = struct{}{}
+		snapshotState := strings.TrimSpace(issue.State)
+		switch {
+		case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot):
+		case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.current):
+			delete(l.states, stateKey)
+		default:
+			delete(l.states, stateKey)
+		}
+	}
+	for _, row := range snapshot.Completed {
+		issue := row.Issue
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" || !sameKanbanProject(issue, projectID, snapshot.Project.ID) {
+			continue
+		}
+		stateKey := kanbanMutationStateKey(key, issueID)
+		if _, ok := present[stateKey]; ok {
+			continue
+		}
+		pending, ok := l.states[stateKey]
+		if !ok {
+			continue
+		}
 		snapshotState := strings.TrimSpace(issue.State)
 		switch {
 		case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot):
@@ -1473,14 +1496,6 @@ func snapshotKanbanIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
 		issues = append(issues, row.Issue)
 	}
 	for _, row := range snapshot.Blocked {
-		issues = append(issues, row.Issue)
-	}
-	return issues
-}
-
-func snapshotKanbanPendingIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
-	issues := snapshotKanbanIssues(snapshot)
-	for _, row := range snapshot.Completed {
 		issues = append(issues, row.Issue)
 	}
 	return issues

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -120,6 +120,39 @@ func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 	}
 }
 
+func TestKanbanSnapshotWithPendingStatesIgnoresCompletedHistoryForMissingPendingMove(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	pendingIssue := telemetry.Issue{
+		ID:         "history-card",
+		Identifier: "digitaldrywood/detent#432",
+		ProjectID:  "detent",
+		Title:      "Completed history pending card",
+		State:      "Backlog",
+	}
+	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo")
+
+	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         "history-card",
+				Identifier: "digitaldrywood/detent#432",
+				ProjectID:  "detent",
+				Title:      "Completed history pending card",
+				State:      "Backlog",
+			},
+		}},
+	})
+	if len(got.BoardIssues) != 1 {
+		t.Fatalf("BoardIssues = %#v, want reinserted pending card", got.BoardIssues)
+	}
+	if got.BoardIssues[0].State != "Todo" {
+		t.Fatalf("pending state = %q, want Todo", got.BoardIssues[0].State)
+	}
+}
+
 func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -78,7 +78,13 @@ func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 	t.Parallel()
 
 	server := &Server{kanbanMutations: newKanbanMutationLocks()}
-	server.kanbanMutations.noteCardState("project:detent", "blocker", "In Progress", "Done")
+	server.kanbanMutations.noteCardState("project:detent", "detent", telemetry.Issue{
+		ID:         "blocker",
+		Identifier: "digitaldrywood/detent#429",
+		ProjectID:  "detent",
+		Title:      "Dependency blocker",
+		State:      "In Progress",
+	}, "In Progress", "Done")
 	snapshot := telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
 		BoardIssues: []telemetry.Issue{
@@ -111,6 +117,44 @@ func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 	}
 	if snapshot.BoardIssues[1].BlockedBy[0].State != "In Progress" {
 		t.Fatalf("source blocked ref state = %q, want original In Progress", snapshot.BoardIssues[1].BlockedBy[0].State)
+	}
+}
+
+func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	pendingIssue := telemetry.Issue{
+		ID:         "completed-card",
+		Identifier: "digitaldrywood/detent#431",
+		ProjectID:  "detent",
+		Title:      "Completed pending card",
+		State:      "Backlog",
+	}
+	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo")
+
+	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         "completed-card",
+				Identifier: "digitaldrywood/detent#431",
+				ProjectID:  "detent",
+				Title:      "Completed pending card",
+				State:      "Done",
+			},
+		}},
+	})
+	if len(got.BoardIssues) != 0 {
+		t.Fatalf("BoardIssues = %#v, want no reinserted pending card", got.BoardIssues)
+	}
+
+	got = server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
+		Project:     telemetry.Project{ID: "detent"},
+		BoardIssues: []telemetry.Issue{pendingIssue},
+	})
+	if got.BoardIssues[0].State != "Backlog" {
+		t.Fatalf("pending state = %q, want cleared Backlog", got.BoardIssues[0].State)
 	}
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -28,7 +28,9 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/store/sqlc"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -857,6 +859,245 @@ func TestKanbanMoveSuccessResponseRefreshesProjectBoard(t *testing.T) {
 	}
 	if got, want := actionConnector.stateUpdates(), []kanbanStateUpdate{{issueID: "I_kw559", state: "Todo"}}; !equalStateUpdates(got, want) {
 		t.Fatalf("state updates = %#v, want %#v", got, want)
+	}
+}
+
+func TestKanbanPendingMoveSurvivesMissingProjectRefresh(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "github"}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+		AllowedTransitions: map[string][]string{
+			"Backlog": {"Todo"},
+		},
+	}, actionConnector)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_kw922",
+			Identifier: "digitaldrywood/detent#922",
+			ProjectID:  "detent",
+			Title:      "Pending refresh card",
+			State:      "Backlog",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := url.Values{
+		"kanban_dialog": {"true"},
+		"project_id":    {"detent"},
+		"issue_id":      {"I_kw922"},
+		"current_state": {"Backlog"},
+		"target_state":  {"Todo"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if !regexp.MustCompile(`data-board-lane="todo"[\s\S]*Pending refresh card`).MatchString(rec.Body.String()) {
+		t.Fatalf("Todo lane missing moved card:\n%s", rec.Body.String())
+	}
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 1, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	body := requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+	if got := strings.Count(body, "Pending refresh card"); got != 1 {
+		t.Fatalf("pending card render count = %d, want 1:\n%s", got, body)
+	}
+	if !regexp.MustCompile(`data-board-lane="todo"[\s\S]*Pending refresh card`).MatchString(body) {
+		t.Fatalf("Todo lane missing pending card after refresh:\n%s", body)
+	}
+
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 2, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_kw922",
+			Identifier: "digitaldrywood/detent#922",
+			ProjectID:  "detent",
+			Title:      "Tracker confirmed card",
+			State:      "Todo",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	body = requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+	if !regexp.MustCompile(`data-board-lane="todo"[\s\S]*Tracker confirmed card`).MatchString(body) {
+		t.Fatalf("Todo lane missing tracker-confirmed card:\n%s", body)
+	}
+
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 3, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_kw922",
+			Identifier: "digitaldrywood/detent#922",
+			ProjectID:  "detent",
+			Title:      "Tracker source card",
+			State:      "Backlog",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	body = requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+	if !regexp.MustCompile(`data-board-lane="backlog"[\s\S]*Tracker source card`).MatchString(body) {
+		t.Fatalf("pending overlay did not clear after tracker target state:\n%s", body)
+	}
+}
+
+func TestKanbanPendingMoveSurvivesAuthorizationFilteredSnapshot(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "github"}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+		AllowedTransitions: map[string][]string{
+			"Backlog": {"Todo"},
+		},
+	}, actionConnector)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_auth922",
+			Identifier: "digitaldrywood/detent#923",
+			ProjectID:  "detent",
+			Title:      "Authorization filtered card",
+			State:      "Backlog",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := url.Values{
+		"kanban_dialog": {"true"},
+		"project_id":    {"detent"},
+		"issue_id":      {"I_auth922"},
+		"current_state": {"Backlog"},
+		"target_state":  {"Todo"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	filtered := orchestrator.State{
+		PollInterval:  time.Minute,
+		LastRefreshAt: time.Date(2026, 6, 15, 12, 1, 0, 0, time.UTC),
+		Authorization: selector.Selector{
+			Labels: selector.Labels{Include: []string{"authorized"}},
+		},
+		BoardIssues: []connector.Issue{{
+			ID:         "I_auth922",
+			Identifier: "digitaldrywood/detent#923",
+			Title:      "Authorization filtered card",
+			State:      "Todo",
+			Labels:     []string{"detent:todo"},
+		}},
+	}
+	if err := deps.Hub.Publish(filtered.Snapshot(time.Date(2026, 6, 15, 12, 1, 0, 0, time.UTC))); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	body := requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+	if got := strings.Count(body, "Authorization filtered card"); got != 1 {
+		t.Fatalf("pending card render count = %d, want 1:\n%s", got, body)
+	}
+	if !regexp.MustCompile(`data-board-lane="todo"[\s\S]*Authorization filtered card`).MatchString(body) {
+		t.Fatalf("Todo lane missing authorization-filtered pending card:\n%s", body)
+	}
+}
+
+func TestKanbanMoveFailureDoesNotInsertPendingCard(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+		AllowedTransitions: map[string][]string{
+			"Backlog": {"Todo"},
+		},
+	}, connectorProbe{name: "github"})
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_fail922",
+			Identifier: "digitaldrywood/detent#924",
+			ProjectID:  "detent",
+			Title:      "Failed move card",
+			State:      "Backlog",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := url.Values{
+		"kanban_dialog": {"true"},
+		"project_id":    {"detent"},
+		"issue_id":      {"I_fail922"},
+		"current_state": {"Backlog"},
+		"target_state":  {"Todo"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
+	if rec.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Move failed: "+connector.ErrNotImplemented.Error()) {
+		t.Fatalf("body missing visible move error: %s", rec.Body.String())
+	}
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 1, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent", DisplayName: "Detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+
+	body := requestHTML(t, server.Handler(), http.MethodGet, "/projects/detent/kanban", http.StatusOK)
+	if strings.Contains(body, "Failed move card") {
+		t.Fatalf("failed move inserted pending card:\n%s", body)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Store pending Kanban moves with cloned card data and project context.
- Reinsert successfully moved cards into the local board when a refreshed tracker/auth snapshot temporarily omits them.
- Clear pending overlays once the tracker returns the target state or a terminal/completed state, while keeping failed moves unchanged.

Fixes #922

## Test Plan

- [x] `go test ./internal/web -run 'TestKanban' -count=1`
- [x] `go test ./internal/web -count=1`
- [x] `make check`
