### PR TITLE
fix(runner): surface backend turn failures

### DIFF
--- a/internal/cli/doctor.go
+++ b/internal/cli/doctor.go
@@ -36,6 +36,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/dependencyline"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
+	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
 )
 
 var ErrDoctorFailed = errors.New("doctor found failed checks")
@@ -226,6 +227,7 @@ type doctorDeps struct {
 	gitWorkTree          func(context.Context, string) error
 	gitRemoteURL         func(context.Context, string) (string, error)
 	autoPromoteConnector func(workflowconfig.Config) (doctorAutoPromoteConnector, error)
+	modelProbe           func(context.Context, doctorRouteModelProbeRequest) error
 	executable           func() (string, error)
 }
 
@@ -445,6 +447,9 @@ func runDoctor(ctx context.Context, cfg doctorConfig, opts options, deps doctorD
 		for _, check := range checks {
 			report.Add(check)
 		}
+	}
+	if cfg.WorkflowDiff {
+		report.WorkflowOptimization.Diff = doctorWorkflowOptimizationDiff(report.WorkflowOptimization)
 	}
 
 	return report
@@ -901,6 +906,8 @@ func checkDoctorProjectWithProgress(
 			Detail: doctorWorkflowDetail(project.Workflow, project, workflow.Config),
 		},
 	}
+	setDoctorCurrentCheck("Project " + id + " pinned route models")
+	checks = append(checks, checkDoctorRouteModels(ctx, id, project, workflow.Config, deps))
 	if workflow.Config.Agent.AutoPromote.Enabled {
 		setDoctorCurrentCheck("Project " + id + " auto-promote")
 		checks = append(checks, checkDoctorAutoPromote(ctx, id, workflow.Config, deps, time.Now()))
@@ -963,6 +970,124 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
+}
+
+type doctorRouteModelProbeRequest struct {
+	ProjectID    string
+	Workspace    string
+	WorkflowPath string
+	RouteIndex   int
+	RouteName    string
+	RouteRole    string
+	Model        string
+	Backend      workflowconfig.AgentBackend
+}
+
+func checkDoctorRouteModels(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
+	if deps.modelProbe == nil {
+		deps.modelProbe = defaultDoctorRouteModelProbe
+	}
+	name := "Project " + id + " pinned route models"
+	backends := doctorWorkflowBackendConfigsByID(cfg)
+	workflowPath, workflowPathErr := doctorWorkflowOptimizationWorkflowPath(project)
+	workspacePath := projectSourceRoot(project, cfg)
+	if expanded, err := expandDoctorWorkspacePath(workspacePath); err == nil {
+		workspacePath = expanded
+	}
+
+	var probed int
+	var skipped int
+	var failures []string
+	var findings []doctorWorkflowOptimizationFinding
+	for index, route := range cfg.AgentRouteConfigs() {
+		model := strings.TrimSpace(route.Model)
+		if model == "" {
+			continue
+		}
+		backend, ok := backends[strings.TrimSpace(route.Backend)]
+		if !ok || strings.TrimSpace(backend.Kind) != workflowconfig.AgentBackendCodex {
+			skipped++
+			continue
+		}
+		probed++
+		routeName := doctorRouteModelName(route, index)
+		err := deps.modelProbe(ctx, doctorRouteModelProbeRequest{
+			ProjectID:    id,
+			Workspace:    workspacePath,
+			WorkflowPath: workflowPath,
+			RouteIndex:   index,
+			RouteName:    routeName,
+			RouteRole:    strings.TrimSpace(route.Role),
+			Model:        model,
+			Backend:      backend,
+		})
+		if err == nil {
+			continue
+		}
+		detail := fmt.Sprintf("project %s route %s model %s rejected by backend: %v", id, routeName, model, err)
+		failures = append(failures, detail)
+		if workflowPathErr != nil {
+			continue
+		}
+		findings = append(findings, doctorWorkflowOptimizationFinding{
+			RuleID:       doctorWorkflowRulePinnedRouteModelRejected,
+			ProjectID:    id,
+			WorkflowPath: workflowPath,
+			Severity:     "error",
+			Title:        "Pinned route model rejected",
+			Detail:       detail,
+			Evidence: map[string]any{
+				"backend": backend.ID,
+				"error":   err.Error(),
+				"model":   model,
+				"route":   routeName,
+			},
+			Patch: []doctorWorkflowOptimizationPatch{{
+				Path:  doctorWorkflowRouteModelPatchPath(index),
+				Value: "",
+			}},
+		})
+	}
+
+	if len(failures) == 0 {
+		detail := fmt.Sprintf("validated %d pinned Codex route model(s)", probed)
+		if skipped > 0 {
+			detail += fmt.Sprintf("; skipped %d non-Codex pinned route model(s)", skipped)
+		}
+		return doctorCheck{Name: name, Status: doctorOK, Detail: detail}
+	}
+	report := doctorWorkflowOptimizationReport{Findings: findings}
+	return doctorCheck{
+		Name:                 name,
+		Status:               doctorFail,
+		Detail:               strings.Join(failures, "; "),
+		Hint:                 "Remove the route model pin to inherit the Codex default, or update it to a backend-supported model.",
+		WorkflowOptimization: report,
+	}
+}
+
+func doctorRouteModelName(route workflowconfig.AgentRoute, index int) string {
+	if name := strings.TrimSpace(route.Name); name != "" {
+		return name
+	}
+	return fmt.Sprintf("routes[%d]", index)
+}
+
+func doctorWorkflowRouteModelPatchPath(index int) string {
+	return fmt.Sprintf("agents.routes[%d].model", index)
+}
+
+func defaultDoctorRouteModelProbe(ctx context.Context, req doctorRouteModelProbeRequest) error {
+	backend, err := buildAgentBackend(req.Backend)
+	if err != nil {
+		return err
+	}
+	_, err = backend.RunTurn(ctx, runnerpkg.AgentTurnRequest{
+		Workspace: strings.TrimSpace(req.Workspace),
+		Prompt:    "Reply exactly: OK",
+		Model:     strings.TrimSpace(req.Model),
+	}, nil)
+	return err
 }
 
 func doctorProjectID(project globalconfig.Project) string {
@@ -3687,6 +3812,9 @@ func (d doctorDeps) withDefaults() doctorDeps {
 	if d.autoPromoteConnector == nil {
 		d.autoPromoteConnector = defaults.autoPromoteConnector
 	}
+	if d.modelProbe == nil {
+		d.modelProbe = defaults.modelProbe
+	}
 	if d.executable == nil {
 		d.executable = defaults.executable
 	}
@@ -3709,6 +3837,7 @@ func defaultDoctorDeps() doctorDeps {
 		gitWorkTree:          defaultGitWorkTree,
 		gitRemoteURL:         defaultGitRemoteURL,
 		autoPromoteConnector: defaultDoctorAutoPromoteConnector,
+		modelProbe:           defaultDoctorRouteModelProbe,
 		executable:           os.Executable,
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -233,6 +233,95 @@ func TestRunDoctorAgentBinaryChecksFollowWorkflowBackends(t *testing.T) {
 	}
 }
 
+func TestRunDoctorFailsRejectedPinnedRouteModelAndDiffClearsPin(t *testing.T) {
+	t.Parallel()
+
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(`---
+tracker:
+  kind: memory
+workspace:
+  source_root: `+dir+`
+agents:
+  backends:
+    - id: codex-main
+      kind: codex
+      command: codex app-server
+  routes:
+    - name: default
+      backend: codex-main
+      default: true
+      model: gpt-5-codex
+---
+Prompt
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+	}
+	configPath := filepath.Join(dir, "global.yaml")
+	global := globalconfig.Config{
+		Path:       configPath,
+		APIVersion: globalconfig.APIVersion,
+		Kind:       globalconfig.Kind,
+		Global: globalconfig.Settings{
+			MaxConcurrentAgents: 1,
+			Scheduling:          globalconfig.SchedulingWeighted,
+		},
+		Projects: []globalconfig.Project{{
+			ID:       "pyroapex",
+			Workflow: workflowPath,
+			Workdir:  dir,
+			Weight:   1,
+		}},
+	}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = workflowconfig.LoadWorkflow
+	deps.modelProbe = func(_ context.Context, req doctorRouteModelProbeRequest) error {
+		if req.ProjectID != "pyroapex" || req.RouteName != "default" || req.Model != "gpt-5-codex" {
+			t.Fatalf("probe request = %#v, want pyroapex default gpt-5-codex", req)
+		}
+		return errors.New(`{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"model rejected"}}`)
+	}
+
+	report := runDoctor(context.Background(), doctorConfig{
+		ConfigPath:       configPath,
+		Output:           io.Discard,
+		CheckTimeout:     time.Second,
+		WorkflowDiff:     true,
+		AllowWriteProbes: false,
+		Flags: runtimeFlags{
+			Port: runtimeIntFlag{Value: 0, Set: true},
+		},
+	}, successfulDoctorOptionsWithConfig(configPath, global), deps)
+
+	assertDoctorCheck(t, report, "Project pyroapex pinned route models", doctorFail, "gpt-5-codex")
+	check := doctorCheckByName(t, report, "Project pyroapex pinned route models")
+	for _, want := range []string{"pyroapex", "default", "gpt-5-codex", "model rejected"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("route model detail missing %q:\n%s", want, check.Detail)
+		}
+	}
+	if !strings.Contains(report.WorkflowOptimization.Diff, "-      model: gpt-5-codex") ||
+		!strings.Contains(report.WorkflowOptimization.Diff, `model: ""`) {
+		t.Fatalf("diff did not clear model pin:\n%s", report.WorkflowOptimization.Diff)
+	}
+
+	written, err := writeDoctorWorkflowOptimizationPatches(report.WorkflowOptimization)
+	if err != nil {
+		t.Fatalf("writeDoctorWorkflowOptimizationPatches() error = %v", err)
+	}
+	if !slices.Equal(written, []string{workflowPath}) {
+		t.Fatalf("written = %#v, want workflow path", written)
+	}
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if got := workflow.Config.AgentRouteConfigs()[0].Model; got != "" {
+		t.Fatalf("route model after write = %q, want empty", got)
+	}
+}
+
 func TestCheckDoctorProjects(t *testing.T) {
 	t.Parallel()
 
@@ -275,8 +364,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorFail},
-			wantDetail: []string{"is valid", "not a git worktree"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorFail},
+			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "not a git worktree"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -284,8 +373,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK},
-			wantDetail: []string{"is valid", "is a git worktree"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK},
+			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "is a git worktree"},
 		},
 	}
 
@@ -1164,7 +1253,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	if gotPath != wantPath {
 		t.Fatalf("git path = %q, want %q", gotPath, wantPath)
 	}
-	if len(checks) != 2 || checks[1].Status != doctorOK {
+	if len(checks) != 3 || checks[2].Status != doctorOK {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
 	}
 }
@@ -3263,6 +3352,18 @@ func assertDoctorCheck(t *testing.T, report doctorReport, name string, status do
 		return
 	}
 	t.Fatalf("missing doctor check %q in %#v", name, report.Checks)
+}
+
+func doctorCheckByName(t *testing.T, report doctorReport, name string) doctorCheck {
+	t.Helper()
+
+	for _, check := range report.Checks {
+		if check.Name == name {
+			return check
+		}
+	}
+	t.Fatalf("missing doctor check %q in %#v", name, report.Checks)
+	return doctorCheck{}
 }
 
 func assertDoctorMissingCheck(t *testing.T, report doctorReport, name string) {

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -29,12 +29,13 @@ import (
 const (
 	doctorWorkflowOptimizationCheckName = "Workflow optimization"
 
-	doctorWorkflowRuleRunawaySessionTokens = "runaway_session_tokens"
-	doctorWorkflowRuleReworkLaps           = "rework_laps"
-	doctorWorkflowRuleValidatorModel       = "validator_model"
-	doctorWorkflowRuleEmptyModelTelemetry  = "empty_model_telemetry"
-	doctorWorkflowRuleBudgetEstimateDrift  = "budget_estimate_drift"
-	doctorWorkflowRuleSchedulerSkipRate    = "scheduler_skip_rate"
+	doctorWorkflowRuleRunawaySessionTokens     = "runaway_session_tokens"
+	doctorWorkflowRuleReworkLaps               = "rework_laps"
+	doctorWorkflowRuleValidatorModel           = "validator_model"
+	doctorWorkflowRuleEmptyModelTelemetry      = "empty_model_telemetry"
+	doctorWorkflowRulePinnedRouteModelRejected = "pinned_route_model_rejected"
+	doctorWorkflowRuleBudgetEstimateDrift      = "budget_estimate_drift"
+	doctorWorkflowRuleSchedulerSkipRate        = "scheduler_skip_rate"
 
 	doctorWorkflowRunawayMedianMultiplier = 4.0
 	doctorWorkflowReworkLapThreshold      = 1
@@ -1383,12 +1384,16 @@ func doctorWorkflowFrontmatterRoot(frontmatter []byte) (*yaml.Node, error) {
 }
 
 func doctorApplyWorkflowOptimizationPatch(root *yaml.Node, patch doctorWorkflowOptimizationPatch) error {
-	switch strings.TrimSpace(patch.Path) {
+	path := strings.TrimSpace(patch.Path)
+	switch path {
 	case "agent.max_session_tokens", "agent.auto_promote.rework_limit", "gate.validator.model", "polling.interval_ms", "budget.per_issue_max_usd":
 		return doctorSetSimpleYAMLPath(root, strings.Split(patch.Path, "."), patch.Value)
 	case "agents.routes.default.model":
 		return doctorSetDefaultRouteModel(root, fmt.Sprint(patch.Value))
 	default:
+		if index, ok := doctorWorkflowRouteModelPatchIndex(path); ok {
+			return doctorSetRouteModel(root, index, fmt.Sprint(patch.Value))
+		}
 		return fmt.Errorf("unsupported workflow optimization patch path %q", patch.Path)
 	}
 }
@@ -1431,6 +1436,41 @@ func doctorSetDefaultRouteModel(root *yaml.Node, model string) error {
 		"default": true,
 		"model":   model,
 	}))
+	return nil
+}
+
+func doctorWorkflowRouteModelPatchIndex(path string) (int, bool) {
+	path = strings.TrimSpace(path)
+	const prefix = "agents.routes["
+	const suffix = "].model"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return 0, false
+	}
+	value := strings.TrimSuffix(strings.TrimPrefix(path, prefix), suffix)
+	index, err := strconv.Atoi(value)
+	if err != nil || index < 0 {
+		return 0, false
+	}
+	return index, true
+}
+
+func doctorSetRouteModel(root *yaml.Node, index int, model string) error {
+	agents := doctorYAMLMappingValue(root, "agents")
+	if agents == nil || agents.Kind != yaml.MappingNode {
+		return errors.New("agents routes are not configured")
+	}
+	routes := doctorYAMLMappingValue(agents, "routes")
+	if routes == nil || routes.Kind != yaml.SequenceNode {
+		return errors.New("agents.routes are not configured")
+	}
+	if index < 0 || index >= len(routes.Content) {
+		return fmt.Errorf("agents.routes[%d] does not exist", index)
+	}
+	route := routes.Content[index]
+	if route.Kind != yaml.MappingNode {
+		return fmt.Errorf("agents.routes[%d] is not a mapping", index)
+	}
+	doctorSetYAMLMappingValue(route, "model", doctorYAMLScalar(strings.TrimSpace(model)))
 	return nil
 }
 

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -32,6 +32,85 @@ var (
 	ErrTurnFailed      = errors.New("codex turn failed")
 )
 
+type ResponseError struct {
+	Request string
+	Code    int
+	Message string
+	Body    string
+}
+
+func (e *ResponseError) Error() string {
+	request := strings.TrimSpace(e.Request)
+	if request == "" {
+		request = "response"
+	}
+	message := strings.TrimSpace(e.Message)
+	if message == "" {
+		message = "unknown error"
+	}
+	out := ErrResponseError.Error() + ": " + request + ": " + message
+	if body := strings.TrimSpace(e.Body); body != "" {
+		out += ": " + body
+	}
+	return out
+}
+
+func (e *ResponseError) Unwrap() error {
+	return ErrResponseError
+}
+
+func (e *ResponseError) BackendErrorBody() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Body)
+}
+
+func (e *ResponseError) BackendErrorMessage() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Message)
+}
+
+type TurnFailedError struct {
+	Status  string
+	Message string
+	Body    string
+}
+
+func (e *TurnFailedError) Error() string {
+	status := strings.TrimSpace(e.Status)
+	if status == "" {
+		status = "failed"
+	}
+	out := ErrTurnFailed.Error() + ": status " + status
+	if body := strings.TrimSpace(e.Body); body != "" {
+		out += ": " + body
+	} else if message := strings.TrimSpace(e.Message); message != "" {
+		out += ": " + message
+	}
+	return out
+}
+
+func (e *TurnFailedError) Unwrap() error {
+	return ErrTurnFailed
+}
+
+func (e *TurnFailedError) BackendErrorBody() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Body)
+}
+
+func (e *TurnFailedError) BackendErrorMessage() string {
+	if e == nil {
+		return ""
+	}
+	return strings.TrimSpace(e.Message)
+}
+
 type AppServer struct {
 	transportFactory TransportFactory
 	clientInfo       ClientInfo
@@ -80,18 +159,20 @@ const (
 )
 
 type Update struct {
-	Type            UpdateType
-	Method          string
-	ProcessIdentity string
-	ThreadID        string
-	TurnID          string
-	ItemID          string
-	Delta           string
-	Status          string
-	Model           string
-	Tokens          TokenUsage
-	RateLimits      *RateLimitSnapshot
-	Payload         json.RawMessage
+	Type                UpdateType
+	Method              string
+	ProcessIdentity     string
+	ThreadID            string
+	TurnID              string
+	ItemID              string
+	Delta               string
+	Status              string
+	Model               string
+	BackendErrorBody    string
+	BackendErrorMessage string
+	Tokens              TokenUsage
+	RateLimits          *RateLimitSnapshot
+	Payload             json.RawMessage
 }
 
 type TokenUsage struct {
@@ -460,7 +541,12 @@ func (s *AppServer) awaitResponse(
 
 		if requestIDMatches(msg.ID, requestID) {
 			if msg.Error != nil {
-				return nil, fmt.Errorf("%w: %s: %s", ErrResponseError, requestName(requestID), msg.Error.Message)
+				return nil, &ResponseError{
+					Request: requestName(requestID),
+					Code:    msg.Error.Code,
+					Message: msg.Error.Message,
+					Body:    string(rawPayload(msg)),
+				}
 			}
 			if len(msg.Result) == 0 {
 				return nil, fmt.Errorf("%w: %s response missing result", ErrInvalidResponse, requestName(requestID))
@@ -519,7 +605,11 @@ func (s *AppServer) streamTurn(ctx context.Context, transport Transport, turnTim
 		if update.Status == "" || update.Status == "completed" {
 			return nil
 		}
-		return fmt.Errorf("%w: status %s", ErrTurnFailed, update.Status)
+		return &TurnFailedError{
+			Status:  update.Status,
+			Message: update.BackendErrorMessage,
+			Body:    update.BackendErrorBody,
+		}
 	}
 }
 
@@ -681,26 +771,130 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 		var params struct {
 			ThreadID string `json:"threadId"`
 			Turn     struct {
-				ID     string `json:"id"`
-				Status string `json:"status"`
+				ID      string          `json:"id"`
+				Status  string          `json:"status"`
+				Error   json.RawMessage `json:"error"`
+				Message string          `json:"message"`
 			} `json:"turn"`
+			Type    string          `json:"type"`
+			Status  any             `json:"status"`
+			Error   json.RawMessage `json:"error"`
+			Message string          `json:"message"`
 		}
 		if len(msg.Params) > 0 {
 			if err := json.Unmarshal(msg.Params, &params); err != nil {
 				return Update{}, false, fmt.Errorf("%w: decode turn completed: %w", ErrInvalidResponse, err)
 			}
 		}
+		status := strings.TrimSpace(params.Turn.Status)
+		if status == "" {
+			status = turnCompletedTopLevelStatus(params.Status, params.Error, params.Type)
+		}
+		errorBody, errorMessage := turnCompletedBackendError(params.Error, params.Turn.Error, params.Message, params.Turn.Message, msg.Params)
 		return Update{
-			Type:     UpdateTurnCompleted,
-			Method:   msg.Method,
-			ThreadID: params.ThreadID,
-			TurnID:   params.Turn.ID,
-			Status:   params.Turn.Status,
-			Payload:  rawPayload(msg),
+			Type:                UpdateTurnCompleted,
+			Method:              msg.Method,
+			ThreadID:            params.ThreadID,
+			TurnID:              params.Turn.ID,
+			Status:              status,
+			BackendErrorBody:    errorBody,
+			BackendErrorMessage: errorMessage,
+			Payload:             rawPayload(msg),
 		}, true, nil
 	default:
 		return Update{}, false, nil
 	}
+}
+
+func turnCompletedTopLevelStatus(status any, errorBody json.RawMessage, eventType string) string {
+	switch value := status.(type) {
+	case string:
+		return strings.TrimSpace(value)
+	case float64:
+		if value >= 400 || len(bytes.TrimSpace(errorBody)) > 0 {
+			return "failed"
+		}
+	}
+	if len(bytes.TrimSpace(errorBody)) > 0 || strings.EqualFold(strings.TrimSpace(eventType), "error") {
+		return "failed"
+	}
+	return ""
+}
+
+func turnCompletedBackendError(
+	topLevelError json.RawMessage,
+	turnError json.RawMessage,
+	topLevelMessage string,
+	turnMessage string,
+	params json.RawMessage,
+) (string, string) {
+	if looksLikeErrorEvent(params) {
+		body := compactJSON(params)
+		message := firstNonBlank(errorMessageFromJSON(params), errorMessageFromJSON(topLevelError), errorMessageFromJSON(turnError), topLevelMessage, turnMessage)
+		return body, message
+	}
+	body := compactJSON(firstRawJSON(topLevelError, turnError))
+	message := firstNonBlank(errorMessageFromJSON(topLevelError), errorMessageFromJSON(turnError), topLevelMessage, turnMessage)
+	if body != "" {
+		if message != "" {
+			return body, message
+		}
+		return body, body
+	}
+	if strings.TrimSpace(message) != "" {
+		return compactJSON(params), message
+	}
+	return "", ""
+}
+
+func firstRawJSON(values ...json.RawMessage) json.RawMessage {
+	for _, value := range values {
+		if len(bytes.TrimSpace(value)) > 0 {
+			return value
+		}
+	}
+	return nil
+}
+
+func compactJSON(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	var buf bytes.Buffer
+	if err := json.Compact(&buf, raw); err != nil {
+		return string(raw)
+	}
+	return buf.String()
+}
+
+func errorMessageFromJSON(raw json.RawMessage) string {
+	raw = bytes.TrimSpace(raw)
+	if len(raw) == 0 {
+		return ""
+	}
+	var decoded struct {
+		Message string `json:"message"`
+		Error   struct {
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return ""
+	}
+	return firstNonBlank(decoded.Message, decoded.Error.Message)
+}
+
+func looksLikeErrorEvent(raw json.RawMessage) bool {
+	var decoded struct {
+		Type   string          `json:"type"`
+		Status any             `json:"status"`
+		Error  json.RawMessage `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &decoded); err != nil {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(decoded.Type), "error") || len(bytes.TrimSpace(decoded.Error)) > 0
 }
 
 type tokenUsageBreakdown struct {

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -320,6 +320,54 @@ func TestAppServerRunTurnReportsResponseErrors(t *testing.T) {
 	}
 }
 
+func TestAppServerRunTurnReportsTurnErrorBody(t *testing.T) {
+	t.Parallel()
+
+	backendError := `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"The 'gpt-5-codex' model is not supported when using Codex with a ChatGPT account."}}`
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.142.5"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1","model":"gpt-5-codex"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		notificationMessage(t, "turn/completed", backendError),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	var updates []Update
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: "/tmp/detent-workspace",
+		Prompt:    "Ship issue #927",
+		Model:     "gpt-5-codex",
+	}, func(update Update) error {
+		updates = append(updates, update)
+		return nil
+	})
+	if !errors.Is(err, ErrTurnFailed) {
+		t.Fatalf("RunTurn() error = %v, want ErrTurnFailed", err)
+	}
+	var turnErr *TurnFailedError
+	if !errors.As(err, &turnErr) {
+		t.Fatalf("RunTurn() error = %T, want TurnFailedError", err)
+	}
+	if turnErr.BackendErrorBody() != backendError {
+		t.Fatalf("BackendErrorBody = %q, want %q", turnErr.BackendErrorBody(), backendError)
+	}
+	if !strings.Contains(err.Error(), backendError) {
+		t.Fatalf("RunTurn() error = %v, want backend body", err)
+	}
+	if len(updates) != 2 {
+		t.Fatalf("updates = %#v, want turn started and failed turn completed", updates)
+	}
+	if updates[1].Status != "failed" || updates[1].BackendErrorBody != backendError {
+		t.Fatalf("failed update = %#v, want status failed with backend error", updates[1])
+	}
+}
+
 type staticTransportFactory struct {
 	transport Transport
 }

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -59,15 +59,17 @@ func (b *AgentBackend) RunTurn(
 
 func agentUpdateFromCodex(update Update) runner.AgentUpdate {
 	return runner.AgentUpdate{
-		Type:            runner.AgentUpdateType(update.Type),
-		Method:          update.Method,
-		ProcessIdentity: update.ProcessIdentity,
-		ThreadID:        update.ThreadID,
-		TurnID:          update.TurnID,
-		ItemID:          update.ItemID,
-		Delta:           update.Delta,
-		Status:          update.Status,
-		Model:           update.Model,
+		Type:                runner.AgentUpdateType(update.Type),
+		Method:              update.Method,
+		ProcessIdentity:     update.ProcessIdentity,
+		ThreadID:            update.ThreadID,
+		TurnID:              update.TurnID,
+		ItemID:              update.ItemID,
+		Delta:               update.Delta,
+		Status:              update.Status,
+		Model:               update.Model,
+		BackendErrorBody:    update.BackendErrorBody,
+		BackendErrorMessage: update.BackendErrorMessage,
 		Tokens: runner.AgentTokenUsage{
 			InputTokens:           update.Tokens.InputTokens,
 			CachedInputTokens:     update.Tokens.CachedInputTokens,

--- a/internal/codex/jsonrpc.go
+++ b/internal/codex/jsonrpc.go
@@ -70,10 +70,10 @@ func (c *Codec) ReadMessage() (Message, error) {
 
 	var msg Message
 	if err := json.Unmarshal([]byte(line), &msg); err != nil {
-		return Message{}, fmt.Errorf("%w: decode: %w", ErrInvalidFrame, err)
+		return Message{}, fmt.Errorf("%w: decode: %w: frame %s", ErrInvalidFrame, err, line)
 	}
 	if err := validateMessage(msg); err != nil {
-		return Message{}, err
+		return Message{}, fmt.Errorf("%w: frame %s", err, line)
 	}
 
 	return msg, nil

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2263,14 +2263,7 @@ func (o *Orchestrator) parkInstantFailure(
 }
 
 func (o *Orchestrator) instantFailureParkState() string {
-	if stateIn(blockedStatusState, o.cfg.ObservedStates) || stateIn(blockedStatusState, o.cfg.ActiveStates) || stateIn(blockedStatusState, o.cfg.TerminalStates) {
-		return blockedStatusState
-	}
-	reworkState := strings.TrimSpace(normalizeAutoPromoteConfig(o.cfg.AutoPromote).ReworkState)
-	if reworkState != "" && (stateIn(reworkState, o.cfg.ActiveStates) || stateIn(reworkState, o.cfg.ObservedStates)) {
-		return reworkState
-	}
-	return ""
+	return blockedStatusState
 }
 
 func instantFailureComment(issue connector.Issue, err error, failure InstantFailure, attempt int, targetState string) string {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -37,6 +37,9 @@ const (
 	defaultContinuationRetry          = time.Second
 	defaultFailureRetryBaseDelay      = 10 * time.Second
 	maxMergeWorkerRunnerFailures      = 3
+	instantFailureThreshold           = 5
+	instantFailureMaxDuration         = 10 * time.Second
+	instantFailureBlockedReasonPrefix = "instant fail circuit breaker: "
 	continuationDispatchBackoff       = 100 * time.Millisecond
 	runUpdateBufferSize               = 128
 	maxRecentEvents                   = 50
@@ -1354,6 +1357,14 @@ func (o *Orchestrator) upsertBlockedStatusIssues(state *State, issues []connecto
 }
 
 func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue, now time.Time) {
+	if existing, ok := state.Blocked[issue.ID]; ok &&
+		existing.Source == BlockedSourceProjectStatus &&
+		strings.HasPrefix(existing.Reason, instantFailureBlockedReasonPrefix) &&
+		strings.TrimSpace(issue.BlockerReason) == "" {
+		existing.Issue = cloneIssue(issue)
+		state.Blocked[issue.ID] = existing
+		return
+	}
 	recovery := EvaluateBlockedRecovery(issue)
 	state.Blocked[issue.ID] = Blocked{
 		Issue:          cloneIssue(issue),
@@ -1999,6 +2010,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 				return
 			}
 		}
+		if o.tripInstantFailureCircuitBreaker(ctx, state, event, running, attempt) {
+			return
+		}
 		delay := event.RetryDelay
 		if delay <= 0 {
 			delay = o.retryDelay(attempt, false)
@@ -2057,6 +2071,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		errorMessage = finalState
 	}
 	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, "completed", "worker completed")
+	delete(state.InstantFailures, event.IssueID)
 
 	state.Completed[event.IssueID] = Completed{
 		Issue:       cloneIssue(running.Issue),
@@ -2108,6 +2123,184 @@ func (o *Orchestrator) commentBudgetRefusal(ctx context.Context, issueID string,
 	}
 }
 
+func (o *Orchestrator) tripInstantFailureCircuitBreaker(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	attempt int,
+) bool {
+	if state == nil || event.Err == nil || !instantFailureDuration(running, event) {
+		delete(state.InstantFailures, event.IssueID)
+		return false
+	}
+	if state.InstantFailures == nil {
+		state.InstantFailures = map[string]InstantFailure{}
+	}
+	key := instantFailureErrorKey(event.Err)
+	if key == "" {
+		key = event.Err.Error()
+	}
+	failure := state.InstantFailures[event.IssueID]
+	if failure.Error != key {
+		failure = InstantFailure{
+			Issue:          cloneIssue(running.Issue),
+			Error:          key,
+			FirstFailureAt: event.CompletedAt,
+		}
+	}
+	failure.Count++
+	failure.Issue = cloneIssue(running.Issue)
+	failure.LastFailureAt = event.CompletedAt
+	state.InstantFailures[event.IssueID] = failure
+	if failure.Count < instantFailureThreshold {
+		return false
+	}
+
+	o.parkInstantFailure(ctx, state, event, running, failure, attempt)
+	return true
+}
+
+func instantFailureDuration(running Running, event runpkg.Completion) bool {
+	if !running.StartedAt.IsZero() && !event.CompletedAt.IsZero() {
+		duration := event.CompletedAt.Sub(running.StartedAt)
+		return duration >= 0 && duration < instantFailureMaxDuration
+	}
+	if event.Result.Tokens.RuntimeSeconds > 0 {
+		return event.Result.Tokens.RuntimeSeconds < instantFailureMaxDuration.Seconds()
+	}
+	return false
+}
+
+func instantFailureErrorKey(err error) string {
+	var carrier interface {
+		BackendErrorBody() string
+	}
+	if errors.As(err, &carrier) {
+		if body := strings.TrimSpace(carrier.BackendErrorBody()); body != "" {
+			return body
+		}
+	}
+	return strings.TrimSpace(err.Error())
+}
+
+func (o *Orchestrator) parkInstantFailure(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	failure InstantFailure,
+	attempt int,
+) {
+	targetState := o.instantFailureParkState()
+	issue := cloneIssue(running.Issue)
+	if targetState != "" {
+		if err := o.updateIssueState(ctx, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker"); err != nil {
+			if o.logger != nil {
+				o.logger.Error(
+					"instant fail circuit breaker state transition failed",
+					"issue_id", issue.ID,
+					"identifier", issue.Identifier,
+					"target_state", targetState,
+					"error", err,
+				)
+			}
+		} else {
+			issue.State = targetState
+		}
+	}
+	if o.connector != nil {
+		if err := o.connector.CreateComment(ctx, issue.ID, instantFailureComment(issue, event.Err, failure, attempt, targetState)); err != nil && o.logger != nil {
+			o.logger.Error("instant fail circuit breaker comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	if err := o.abandonClaim(ctx, issue.ID); err != nil && o.logger != nil {
+		o.logger.Error("instant fail circuit breaker claim release failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+	delete(state.Claimed, issue.ID)
+	delete(state.Retry, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+	delete(state.PriorAttempts, issue.ID)
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          issue,
+		Reason:         instantFailureBlockedReasonPrefix + failure.Error,
+		RecoveryReason: "fix the pinned agent model or backend configuration, then move the issue back to Todo or Rework",
+		RecoveryTarget: "Todo",
+		BlockedAt:      event.CompletedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "worker_instant_fail_circuit_breaker_tripped",
+		Message: "parked " + issueLabel(issue) + " after repeated instant worker failures: " + failure.Error,
+	})
+	if o.logger != nil {
+		attrs := []any{
+			"event", "worker_instant_fail_circuit_breaker_tripped",
+			"issue_id", issue.ID,
+			"issue_identifier", issue.Identifier,
+			"attempt", attempt,
+			"instant_failures", failure.Count,
+			"target_state", targetState,
+			"error", event.Err,
+		}
+		if body := instantFailureErrorKey(event.Err); body != "" {
+			attrs = append(attrs, "backend_error_body", body)
+		}
+		var carrier interface {
+			BackendErrorMessage() string
+		}
+		if errors.As(event.Err, &carrier) {
+			if message := strings.TrimSpace(carrier.BackendErrorMessage()); message != "" {
+				attrs = append(attrs, "backend_error_message", message)
+			}
+		}
+		o.logger.Error("worker instant fail circuit breaker tripped", attrs...)
+	}
+}
+
+func (o *Orchestrator) instantFailureParkState() string {
+	if stateIn(blockedStatusState, o.cfg.ObservedStates) || stateIn(blockedStatusState, o.cfg.ActiveStates) || stateIn(blockedStatusState, o.cfg.TerminalStates) {
+		return blockedStatusState
+	}
+	reworkState := strings.TrimSpace(normalizeAutoPromoteConfig(o.cfg.AutoPromote).ReworkState)
+	if reworkState != "" && (stateIn(reworkState, o.cfg.ActiveStates) || stateIn(reworkState, o.cfg.ObservedStates)) {
+		return reworkState
+	}
+	return ""
+}
+
+func instantFailureComment(issue connector.Issue, err error, failure InstantFailure, attempt int, targetState string) string {
+	var b strings.Builder
+	b.WriteString("Detent stopped retrying this worker after ")
+	b.WriteString(strconv.Itoa(failure.Count))
+	b.WriteString(" consecutive instant failures with the same backend error.")
+	if targetState = strings.TrimSpace(targetState); targetState != "" {
+		b.WriteString("\n\nIssue parked in `")
+		b.WriteString(targetState)
+		b.WriteString("`.")
+	}
+	b.WriteString("\n\n- issue: ")
+	b.WriteString(issueLabel(issue))
+	b.WriteString("\n- latest_attempt: ")
+	b.WriteString(strconv.Itoa(attempt))
+	b.WriteString("\n- failure_window_seconds: ")
+	b.WriteString(strconv.FormatInt(int64(instantFailureMaxDuration/time.Second), 10))
+	b.WriteString("\n- error:\n\n```text\n")
+	b.WriteString(strings.TrimSpace(err.Error()))
+	b.WriteString("\n```")
+	if body := instantFailureErrorKey(err); body != "" && body != strings.TrimSpace(err.Error()) {
+		b.WriteString("\n\n- backend_error_body:\n\n```json\n")
+		b.WriteString(body)
+		b.WriteString("\n```")
+	}
+	b.WriteString("\n\nFix the pinned agent model or backend configuration, then move the issue back to Todo or Rework.")
+	return b.String()
+}
+
 func (o *Orchestrator) cleanupDrainedRun(ctx context.Context, state *State, issueID string) {
 	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
 		o.logger.Warn("abandon completed drain claim failed", "issue_id", issueID, "error", err)
@@ -2116,6 +2309,7 @@ func (o *Orchestrator) cleanupDrainedRun(ctx context.Context, state *State, issu
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
 	delete(state.PriorAttempts, issueID)
+	delete(state.InstantFailures, issueID)
 }
 
 func (o *Orchestrator) completeLatestTerminalMergeWorkerResult(
@@ -2604,6 +2798,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	delete(state.Retry, issueID)
 	delete(state.BudgetRefusals, issueID)
 	delete(state.PriorAttempts, issueID)
+	delete(state.InstantFailures, issueID)
 	if err := o.abandonClaim(ctx, issueID); err != nil {
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      cleanupEventAt(completedAt),

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1189,6 +1189,57 @@ func TestRunParksIssueAfterRepeatedInstantBackendFailures(t *testing.T) {
 	}
 }
 
+func TestRunParksInstantBackendFailuresInBlockedWithDefaultStates(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-default-instant-fail", "digitaldrywood/detent#928", "Todo")
+	tracker := newFakeConnector(issue)
+	backendBody := `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"model rejected"}}`
+	runner := &staticRunner{err: instantBackendError{body: backendBody}}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		blocked, ok := state.Blocked[issue.ID]
+		return ok && strings.Contains(blocked.Reason, backendBody)
+	})
+
+	updates := tracker.stateUpdateCalls()
+	if len(updates) == 0 || updates[len(updates)-1] != (stateUpdateCall{issueID: issue.ID, state: "Blocked"}) {
+		t.Fatalf("state updates = %#v, want final Blocked transition", updates)
+	}
+	if got := state.Blocked[issue.ID].Issue.State; got != "Blocked" {
+		t.Fatalf("Blocked[%q].Issue.State = %q, want Blocked", issue.ID, got)
+	}
+	fetchesAtBlock := tracker.fetchByStatesCalls()
+	state = waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Blocked[issue.ID]
+		return ok && tracker.fetchByStatesCalls() > fetchesAtBlock
+	})
+	if _, ok := state.Blocked[issue.ID]; !ok {
+		t.Fatalf("Blocked[%q] missing after blocked-status refresh", issue.ID)
+	}
+	if got := runner.calls.Load(); got != 5 {
+		t.Fatalf("runner calls = %d, want 5", got)
+	}
+}
+
 func TestRunRedispatchesDueRetryWithExistingClaim(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1132,6 +1132,63 @@ func TestRunSchedulesRetryAfterRunnerPanic(t *testing.T) {
 	}
 }
 
+func TestRunParksIssueAfterRepeatedInstantBackendFailures(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-instant-fail", "digitaldrywood/detent#927", "Todo")
+	tracker := newFakeConnector(issue)
+	backendBody := `{"type":"error","status":400,"error":{"type":"invalid_request_error","message":"model rejected"}}`
+	runner := &staticRunner{err: instantBackendError{body: backendBody}}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		ObservedStates:         []string{"Blocked"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Blocked[issue.ID]
+		return ok
+	})
+
+	if got := runner.calls.Load(); got != 5 {
+		t.Fatalf("runner calls = %d, want 5", got)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after circuit breaker", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after circuit breaker", issue.ID)
+	}
+	if !strings.Contains(state.Blocked[issue.ID].Reason, backendBody) {
+		t.Fatalf("Blocked[%q].Reason = %q, want backend body", issue.ID, state.Blocked[issue.ID].Reason)
+	}
+	updates := tracker.stateUpdateCalls()
+	if len(updates) == 0 || updates[len(updates)-1] != (stateUpdateCall{issueID: issue.ID, state: "Blocked"}) {
+		t.Fatalf("state updates = %#v, want final Blocked transition", updates)
+	}
+	comments := tracker.commentCalls()
+	if len(comments) != 1 {
+		t.Fatalf("comments = %#v, want one circuit breaker comment", comments)
+	}
+	if !strings.Contains(comments[0].body, backendBody) || !strings.Contains(comments[0].body, "stopped retrying") {
+		t.Fatalf("comment body missing backend error:\n%s", comments[0].body)
+	}
+}
+
 func TestRunRedispatchesDueRetryWithExistingClaim(t *testing.T) {
 	t.Parallel()
 
@@ -2842,6 +2899,22 @@ func (r *staticRunner) Run(_ context.Context, request orchestrator.RunRequest) (
 		r.onRun(request)
 	}
 	return r.result, r.err
+}
+
+type instantBackendError struct {
+	body string
+}
+
+func (e instantBackendError) Error() string {
+	return "codex turn failed: status failed: " + e.body
+}
+
+func (e instantBackendError) BackendErrorBody() string {
+	return e.body
+}
+
+func (e instantBackendError) BackendErrorMessage() string {
+	return "model rejected"
 }
 
 func (r *staticRunner) requests() []orchestrator.RunRequest {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -45,6 +45,7 @@ type State struct {
 	TransientCheckRetries    map[string]TransientCheckRetry
 	BudgetRefusals           map[string]BudgetRefusal
 	PriorAttempts            map[string]runpkg.PriorAttempt
+	InstantFailures          map[string]InstantFailure
 	DiffStats                map[string]DiffStats
 	ReapedWorkspaces         map[string]time.Time
 	TokenTotals              TokenTotals
@@ -132,6 +133,14 @@ type Retry struct {
 	WorkerHost string
 }
 
+type InstantFailure struct {
+	Issue          connector.Issue
+	Error          string
+	Count          int
+	FirstFailureAt time.Time
+	LastFailureAt  time.Time
+}
+
 type TransientCheckRetry struct {
 	IssueID       string
 	HeadSHA       string
@@ -159,6 +168,7 @@ func newState(cfg Config) State {
 		TransientCheckRetries:    map[string]TransientCheckRetry{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
 		PriorAttempts:            map[string]runpkg.PriorAttempt{},
+		InstantFailures:          map[string]InstantFailure{},
 		DiffStats:                map[string]DiffStats{},
 		ReapedWorkspaces:         map[string]time.Time{},
 		planRework:               map[string]struct{}{},
@@ -199,6 +209,7 @@ func (s State) clone() State {
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		PriorAttempts:            clonePriorAttempts(s.PriorAttempts),
+		InstantFailures:          make(map[string]InstantFailure, len(s.InstantFailures)),
 		DiffStats:                make(map[string]DiffStats, len(s.DiffStats)),
 		ReapedWorkspaces:         make(map[string]time.Time, len(s.ReapedWorkspaces)),
 		TokenTotals:              s.TokenTotals,
@@ -230,6 +241,10 @@ func (s State) clone() State {
 	for id, retry := range s.Retry {
 		retry.Issue = cloneIssue(retry.Issue)
 		cloned.Retry[id] = retry
+	}
+	for id, failure := range s.InstantFailures {
+		failure.Issue = cloneIssue(failure.Issue)
+		cloned.InstantFailures[id] = failure
 	}
 	for id, refusal := range s.BudgetRefusals {
 		refusal.Issue = cloneIssue(refusal.Issue)

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -637,7 +637,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	turnResult := execution.turnResult
 	turnErr := execution.err
 	result := execution.result
-	r.logWorkerEvent(req.Issue, "worker_command_finished",
+	commandFinishedAttrs := []any{
 		"workspace_path", info.Path,
 		"backend_id", selection.BackendID,
 		"route", selection.RouteName,
@@ -645,7 +645,13 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"model", effectiveModel(result.Model, sessionModel),
 		"outcome", workerRunOutcome(turnErr, result.FinalState),
 		"error", errorString(turnErr),
-	)
+	}
+	commandFinishedAttrs = append(commandFinishedAttrs, backendErrorAttrs(turnErr)...)
+	if turnErr != nil {
+		r.logWorkerEventLevel(slog.LevelWarn, req.Issue, "worker_command_finished", commandFinishedAttrs...)
+	} else {
+		r.logWorkerEvent(req.Issue, "worker_command_finished", commandFinishedAttrs...)
+	}
 	failureNoteRecorded := false
 	if strings.EqualFold(strings.TrimSpace(result.FinalState), FinalStateFailed) {
 		r.recordFailedRunNote(info.Path, req.Issue, result, turnErr, r.now().UTC())
@@ -856,7 +862,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		}
 		return nil
 	})
-	r.logWorkerEvent(req.Issue, "worker_check_finished",
+	checkFinishedAttrs := []any{
 		"workspace_path", info.Path,
 		"backend_id", selection.BackendID,
 		"route", selection.RouteName,
@@ -864,7 +870,13 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		"model", effectiveModel(runResult.Model, sessionModel),
 		"outcome", workerRunOutcome(turnErr, runResult.FinalState),
 		"error", errorString(turnErr),
-	)
+	}
+	checkFinishedAttrs = append(checkFinishedAttrs, backendErrorAttrs(turnErr)...)
+	if turnErr != nil {
+		r.logWorkerEventLevel(slog.LevelWarn, req.Issue, "worker_check_finished", checkFinishedAttrs...)
+	} else {
+		r.logWorkerEvent(req.Issue, "worker_check_finished", checkFinishedAttrs...)
+	}
 
 	r.afterRun(info, workspaceIssue)
 	afterRunPending = false
@@ -1710,6 +1722,10 @@ func diffStatsFromWorkspace(stat workspace.DiffStat) DiffStats {
 }
 
 func (r *Runner) logWorkerEvent(issue connector.Issue, event string, attrs ...any) {
+	r.logWorkerEventLevel(slog.LevelDebug, issue, event, attrs...)
+}
+
+func (r *Runner) logWorkerEventLevel(level slog.Level, issue connector.Issue, event string, attrs ...any) {
 	if r == nil || r.logger == nil {
 		return
 	}
@@ -1721,7 +1737,17 @@ func (r *Runner) logWorkerEvent(issue connector.Issue, event string, attrs ...an
 		"issue_state", strings.TrimSpace(issue.State),
 	}
 	all = append(all, attrs...)
-	r.logger.Debug(strings.TrimSpace(event), all...)
+	message := strings.TrimSpace(event)
+	switch {
+	case level >= slog.LevelError:
+		r.logger.Error(message, all...)
+	case level >= slog.LevelWarn:
+		r.logger.Warn(message, all...)
+	case level >= slog.LevelInfo:
+		r.logger.Info(message, all...)
+	default:
+		r.logger.Debug(message, all...)
+	}
 }
 
 func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
@@ -1740,11 +1766,17 @@ func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
 			"turn_id", strings.TrimSpace(update.TurnID),
 		)
 	case AgentUpdateTurnCompleted:
-		r.logWorkerEvent(issue, "worker_turn_finished",
+		attrs := []any{
 			"thread_id", strings.TrimSpace(update.ThreadID),
 			"turn_id", strings.TrimSpace(update.TurnID),
 			"status", strings.TrimSpace(update.Status),
-		)
+		}
+		attrs = append(attrs, agentUpdateBackendErrorAttrs(update)...)
+		if failedAgentTurnStatus(update.Status) {
+			r.logWorkerEventLevel(slog.LevelWarn, issue, "worker_turn_finished", attrs...)
+		} else {
+			r.logWorkerEvent(issue, "worker_turn_finished", attrs...)
+		}
 	case AgentUpdateTokenUsage:
 		r.logWorkerEvent(issue, "worker_usage_updated",
 			"thread_id", strings.TrimSpace(update.ThreadID),
@@ -1767,6 +1799,42 @@ func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
 			)
 		}
 	}
+}
+
+type backendErrorCarrier interface {
+	BackendErrorBody() string
+	BackendErrorMessage() string
+}
+
+func backendErrorAttrs(err error) []any {
+	if err == nil {
+		return nil
+	}
+	var carrier backendErrorCarrier
+	if !errors.As(err, &carrier) {
+		return nil
+	}
+	return backendErrorStringsAttrs(carrier.BackendErrorBody(), carrier.BackendErrorMessage())
+}
+
+func agentUpdateBackendErrorAttrs(update AgentUpdate) []any {
+	return backendErrorStringsAttrs(update.BackendErrorBody, update.BackendErrorMessage)
+}
+
+func backendErrorStringsAttrs(body string, message string) []any {
+	attrs := []any{}
+	if body = strings.TrimSpace(body); body != "" {
+		attrs = append(attrs, "backend_error_body", body)
+	}
+	if message = strings.TrimSpace(message); message != "" {
+		attrs = append(attrs, "backend_error_message", message)
+	}
+	return attrs
+}
+
+func failedAgentTurnStatus(status string) bool {
+	status = strings.TrimSpace(status)
+	return status != "" && !strings.EqualFold(status, "completed")
 }
 
 func workerRunOutcome(err error, finalState string) string {

--- a/internal/runner/supervisor.go
+++ b/internal/runner/supervisor.go
@@ -143,21 +143,26 @@ func (s *Supervisor) Run(ctx context.Context, request RunRequest) (completion Co
 			completion.RetryAttempt = nextFailureAttempt(request.Attempt)
 			completion.RetryDelay = s.RetryDelay(completion.RetryAttempt)
 		}
-		s.logger.Debug(
-			"worker_attempt_finished",
-			slog.String("event", "worker_attempt_finished"),
-			slog.String("issue_id", request.Issue.ID),
-			slog.String("issue_identifier", request.Issue.Identifier),
-			slog.String("issue_state", request.Issue.State),
-			slog.Int("attempt", request.Attempt),
-			slog.String("worker_host", request.WorkerHost),
-			slog.String("mode", request.Mode),
-			slog.String("outcome", workerRunOutcome(completion.Err, completion.Result.FinalState)),
-			slog.Bool("retryable", completion.Retryable),
-			slog.Int("retry_attempt", completion.RetryAttempt),
-			slog.Int64("retry_delay_seconds", int64(completion.RetryDelay/time.Second)),
-			slog.Any("error", completion.Err),
-		)
+		attrs := []any{
+			"event", "worker_attempt_finished",
+			"issue_id", request.Issue.ID,
+			"issue_identifier", request.Issue.Identifier,
+			"issue_state", request.Issue.State,
+			"attempt", request.Attempt,
+			"worker_host", request.WorkerHost,
+			"mode", request.Mode,
+			"outcome", workerRunOutcome(completion.Err, completion.Result.FinalState),
+			"retryable", completion.Retryable,
+			"retry_attempt", completion.RetryAttempt,
+			"retry_delay_seconds", int64(completion.RetryDelay / time.Second),
+			"error", completion.Err,
+		}
+		attrs = append(attrs, backendErrorAttrs(completion.Err)...)
+		if completion.Err != nil {
+			s.logger.Warn("worker_attempt_finished", attrs...)
+		} else {
+			s.logger.Debug("worker_attempt_finished", attrs...)
+		}
 	}()
 
 	result, err := s.backend.Run(ctx, request)

--- a/internal/runner/supervisor_test.go
+++ b/internal/runner/supervisor_test.go
@@ -77,6 +77,40 @@ func TestSupervisorAppliesCappedBackoffForRunnerErrors(t *testing.T) {
 	}
 }
 
+func TestSupervisorLogsBackendErrorBodyForRunnerErrors(t *testing.T) {
+	t.Parallel()
+
+	var logs strings.Builder
+	supervisor, err := NewSupervisor(backendErrorRunner{}, SupervisorConfig{
+		FailureRetryBaseDelay: time.Second,
+		MaxRetryBackoff:       time.Second,
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	})
+	if err != nil {
+		t.Fatalf("NewSupervisor() error = %v", err)
+	}
+
+	completion := supervisor.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{ID: "issue-927", Identifier: "digitaldrywood/detent#927"},
+	})
+	if completion.Err == nil {
+		t.Fatal("Completion.Err = nil, want backend error")
+	}
+	logText := logs.String()
+	for _, want := range []string{
+		"level=WARN",
+		"worker_attempt_finished",
+		"backend_error_body",
+		`"{\"type\":\"error\",\"status\":400}"`,
+	} {
+		if !strings.Contains(logText, want) {
+			t.Fatalf("logs missing %q:\n%s", want, logText)
+		}
+	}
+}
+
 func TestSupervisorRetryDelayNeverOverflows(t *testing.T) {
 	t.Parallel()
 
@@ -325,6 +359,28 @@ type errorBackend struct{}
 
 func (errorBackend) Run(context.Context, RunRequest) (RunResult, error) {
 	return RunResult{}, errors.New("runner failed")
+}
+
+type backendErrorRunner struct{}
+
+func (backendErrorRunner) Run(context.Context, RunRequest) (RunResult, error) {
+	return RunResult{}, backendError{body: `{"type":"error","status":400}`}
+}
+
+type backendError struct {
+	body string
+}
+
+func (e backendError) Error() string {
+	return "codex turn failed: status failed: " + e.body
+}
+
+func (e backendError) BackendErrorBody() string {
+	return e.body
+}
+
+func (e backendError) BackendErrorMessage() string {
+	return "model rejected"
 }
 
 type staticBackend struct {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -84,17 +84,19 @@ const (
 )
 
 type AgentUpdate struct {
-	Type            AgentUpdateType
-	Method          string
-	ProcessIdentity string
-	ThreadID        string
-	TurnID          string
-	ItemID          string
-	Delta           string
-	Status          string
-	Model           string
-	Tokens          AgentTokenUsage
-	RateLimits      *telemetry.RateLimits
+	Type                AgentUpdateType
+	Method              string
+	ProcessIdentity     string
+	ThreadID            string
+	TurnID              string
+	ItemID              string
+	Delta               string
+	Status              string
+	Model               string
+	BackendErrorBody    string
+	BackendErrorMessage string
+	Tokens              AgentTokenUsage
+	RateLimits          *telemetry.RateLimits
 }
 
 type AgentTokenUsage struct {


### PR DESCRIPTION
## Summary

- Preserve Codex backend error payloads through failed turns, runner updates, and failed worker attempt logs.
- Stop repeated same-error instant worker failures by parking the issue and commenting the raw backend error.
- Validate pinned Codex route models in doctor and propose clearing rejected pins with workflow diff/write.

Fixes #927

## Test Plan

- [x] `go test ./internal/codex -count=1`
- [x] `go test ./internal/runner -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/cli -count=1`
- [x] `make check`