### PR TITLE
feat(api): add work-item submission auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -1782,6 +1782,7 @@ kind: GlobalConfig
 env: prod
 log_level: info
 github_token: gh
+api_token: detent_replace_with_random_secret
 port: 4000
 instance_name: buildbox
 global:
@@ -2157,8 +2158,63 @@ Useful endpoints:
 | `/api/v1/timeseries?window=10m&bucket=1m` | Fleet chart samples for running agents, tokens/sec, and completions. |
 | `/api/v1/projects/<id>/state` | Project-scoped JSON telemetry snapshot. |
 | `/api/v1/projects/<id>/timeseries?window=10m&bucket=1m` | Project chart samples for running agents, token spend, and board flow. |
+| `/api/v1/projects/<id>/work-items` | Create a runtime work item with `POST` for `local_sqlite` and `github_local` trackers. |
 | `/api/v1/refresh` | Request an orchestrator refresh with `POST`. |
 | `/api/v1/<issue>` | JSON detail for a running, retrying, or blocked issue. |
+
+### API Authentication And Work-Item Submission
+
+Configure a top-level `api_token` in `global.yaml`, or set
+`DETENT_API_TOKEN` to override it at runtime. Use a high-entropy value; the
+recommended shape is a `detent_` prefix followed by a random secret. Mutating
+API routes require `Authorization: Bearer <token>` or `X-API-Key: <token>`.
+When a token is configured, read-only `GET /api/v1/*` routes require it too.
+`GET /health` stays unauthenticated, and the GitHub webhook keeps its HMAC
+signature check.
+
+If Detent binds a non-loopback host such as `0.0.0.0` without an `api_token`,
+API routes fail closed and mutating routes return `403` until a token is
+configured. With no token on loopback, read-only API routes remain open for
+local development.
+
+Create a runtime work item:
+
+```sh
+curl -fsS -X POST "http://127.0.0.1:4000/api/v1/projects/digitaldrywood-video/work-items" \
+  -H "Authorization: Bearer $DETENT_API_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data '{
+    "title": "Author beat visuals",
+    "description": "Full markdown brief.",
+    "state": "Todo",
+    "labels": ["video-assets"],
+    "fields": {"render_status": "queued"},
+    "priority": 2,
+    "deliverable": {
+      "kind": "artifact",
+      "review_url": "http://127.0.0.1:8090/v/example/g/assets"
+    }
+  }'
+```
+
+The response is `201` with `{"id":"...","identifier":"...","url":"..."}`.
+Duplicate submitted identifiers return `409`, invalid states or missing title
+and description return `422`, unknown projects return `404`, and trackers other
+than `local_sqlite` or `github_local` return `501`.
+
+The CLI uses the same validation and writes through the configured tracker
+directly:
+
+```sh
+detent work-item add digitaldrywood-video \
+  --title "Author beat visuals" \
+  --body-file brief.md \
+  --label video-assets \
+  --field render_status=queued \
+  --priority 2 \
+  --deliverable-review-url "http://127.0.0.1:8090/v/example/g/assets" \
+  --format json
+```
 
 The terminal TUI renders the same telemetry snapshot model for terminal-first
 operator surfaces. The default binary path starts the web dashboard; embedding
@@ -2251,6 +2307,7 @@ Structured command objects:
 | `detent pause api` / `detent unpause api` | `{"status":"ok","project":"api","paused":true}` |
 | `detent promote api --priority 1` | `{"status":"ok","project":"api","priority":1}` |
 | `detent remove-project api` | `{"status":"ok","project":"api","removed":true}` |
+| `detent work-item add api --title "..." --body "..."` | `{"id":"wi-...","identifier":"wi-...","url":"/projects/api/kanban"}` |
 | `detent config path` | `{"path":"/path/global.yaml","rule":"--config"}` |
 | `detent doctor` | `{"checks":[{"name":"Config resolution","status":"OK","detail":"...","hint":"..."}],"summary":{"ok":8,"warn":0,"fail":0},"result":"PASS"}` |
 
@@ -2282,6 +2339,7 @@ Runtime settings resolve in this order: explicit flag, environment variable,
 | Log max size | | `LOG_MAX_SIZE_BYTES`, then `DETENT_LOG_MAX_SIZE_BYTES` | `log_max_size_bytes` | `52428800` |
 | Log backups | | `LOG_MAX_BACKUPS`, then `DETENT_LOG_MAX_BACKUPS` | `log_max_backups` | `5` |
 | GitHub token | | `GITHUB_TOKEN` | `github_token` | required for GitHub projects |
+| API token | | `DETENT_API_TOKEN` | `api_token` | open on loopback, fail closed on non-loopback |
 | Web port | `--port` | `PORT` | `port` | `4000` |
 | Instance name | | | `instance_name` | short hostname |
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -415,6 +415,7 @@ detent --format json config path`),
 			return nil
 		}),
 		newGitHubLocalCommand(&configPath, opts),
+		newWorkItemCommand(&configPath, opts),
 		newConfigCommand(&configPath, opts),
 		newOnboardingCommand(&configPath, opts),
 		newPromoteCommand(&configPath, opts),

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3112,7 +3112,7 @@ func TestDoctorProjectCheckJobTimeoutReportsCurrentInnerCheck(t *testing.T) {
 	if len(checks) != 1 {
 		t.Fatalf("checks len = %d, want 1", len(checks))
 	}
-	for _, want := range []string{"Project alpha checks", "Project alpha GitHub readiness", "timed out after 20ms"} {
+	for _, want := range []string{"Project alpha checks", "timed out after 20ms", "while running Project alpha "} {
 		if !strings.Contains(checks[0].Name+" "+checks[0].Detail, want) {
 			t.Fatalf("timeout check = %#v, want containing %q", checks[0], want)
 		}

--- a/internal/cli/work_item.go
+++ b/internal/cli/work_item.go
@@ -1,0 +1,260 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/factory"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+	projectpkg "github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/workitem"
+)
+
+func newWorkItemCommand(configPath *string, opts options) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:     "work-item",
+		Short:   "Manage runtime work items",
+		Example: `detent work-item add digitaldrywood-video --title "Author beat visuals" --body-file brief.md`,
+	}
+	cmd.AddCommand(newWorkItemAddCommand(configPath, opts))
+	return cmd
+}
+
+func newWorkItemAddCommand(configPath *string, opts options) *cobra.Command {
+	var title string
+	var body string
+	var bodyFile string
+	var state string
+	var labels []string
+	var fields []string
+	var priority int
+	var deliverableReviewURL string
+	cmd := &cobra.Command{
+		Use:     "add PROJECT_ID",
+		Short:   "Create a runtime work item",
+		Example: `detent work-item add digitaldrywood-video --title "Author beat visuals" --body-file brief.md --label video-assets --field render_status=queued`,
+		Args: func(cmd *cobra.Command, args []string) error {
+			return WrapValidation(cobra.ExactArgs(1)(cmd, args))
+		},
+		RunE: func(cmd *cobra.Command, args []string) error {
+			out, err := OutputForCommand(cmd)
+			if err != nil {
+				return err
+			}
+			description, err := workItemBody(body, bodyFile)
+			if err != nil {
+				return err
+			}
+			parsedFields, err := workItemFields(fields)
+			if err != nil {
+				return err
+			}
+			req := workitem.Request{
+				Title:       title,
+				Description: description,
+				State:       state,
+				Labels:      labels,
+				Fields:      parsedFields,
+			}
+			if flagChanged(cmd, "priority") {
+				req.Priority = &priority
+			}
+			if deliverableReviewURL = strings.TrimSpace(deliverableReviewURL); deliverableReviewURL != "" {
+				req.Deliverable = &connector.Deliverable{
+					Kind:      workflowconfig.DeliverableArtifact,
+					ReviewURL: deliverableReviewURL,
+				}
+			}
+			result, err := runWorkItemAdd(cmd.Context(), *configPath, args[0], req, opts)
+			if err != nil {
+				return cliWorkItemError(err)
+			}
+			return out.Write(func(out io.Writer) error {
+				_, err := fmt.Fprintf(out, "created work item %s\n", result.Identifier)
+				return err
+			}, result)
+		},
+	}
+	cmd.Flags().StringVar(&title, "title", "", "work item title")
+	cmd.Flags().StringVar(&body, "body", "", "work item description")
+	cmd.Flags().StringVar(&bodyFile, "body-file", "", "path to a markdown description")
+	cmd.Flags().StringVar(&state, "state", "", "initial tracker state")
+	cmd.Flags().StringArrayVar(&labels, "label", nil, "label to attach; repeat for multiple labels")
+	cmd.Flags().StringArrayVar(&fields, "field", nil, "field assignment key=value; repeat for multiple fields")
+	cmd.Flags().IntVar(&priority, "priority", 0, "work item priority")
+	cmd.Flags().StringVar(&deliverableReviewURL, "deliverable-review-url", "", "deliverable review URL")
+	return cmd
+}
+
+func runWorkItemAdd(ctx context.Context, configPath string, projectID string, req workitem.Request, opts options) (result workitem.Response, err error) {
+	resolution, err := resolveConfigPathResolution(configPath, opts)
+	if err != nil {
+		return result, err
+	}
+	cfg, _, err := opts.readProject(resolution.Path, projectID)
+	if err != nil {
+		return result, err
+	}
+	if len(cfg.Projects) == 0 {
+		return result, fmt.Errorf("%w: %s", ErrProjectNotFound, projectID)
+	}
+	projectConfig := cfg.Projects[0]
+	workflow, err := projectpkg.LoadWorkflowContext(ctx, projectConfig)
+	if err != nil {
+		return result, err
+	}
+	workflow.Config = workItemWorkflowConfig(projectConfig, workflow.Config)
+	workflow.Config, err = githubLocalWorkflowConfigWithGlobalToken(ctx, cfg, workflow.Config, opts)
+	if err != nil {
+		return result, err
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		return result, err
+	}
+	if !workitem.SupportsTracker(workflow.Config.Tracker.Kind) {
+		return workitem.Create(ctx, workitem.Target{
+			ProjectID: projectConfig.ID,
+			Workflow:  workflow.Config,
+		}, req)
+	}
+
+	conn, err := workItemConnectorFromWorkflow(ctx, workflow.Config)
+	if err != nil {
+		return result, err
+	}
+	defer func() {
+		if closeErr := closeWorkItemConnector(conn); closeErr != nil && err == nil {
+			err = closeErr
+		}
+	}()
+	return workitem.Create(ctx, workitem.Target{
+		ProjectID: projectConfig.ID,
+		Workflow:  workflow.Config,
+		Connector: conn,
+	}, req)
+}
+
+func workItemWorkflowConfig(project globalconfig.Project, cfg workflowconfig.Config) workflowconfig.Config {
+	workdir := strings.TrimSpace(project.Workdir)
+	if workdir == "" {
+		return cfg
+	}
+	switch cfg.Tracker.Kind {
+	case workflowconfig.TrackerLocalSQLite, workflowconfig.TrackerGitHubLocal:
+		cfg.Tracker.LocalSQLite.Path = githubLocalProjectRelativePath(workdir, cfg.Tracker.LocalSQLite.Path)
+	}
+	return cfg
+}
+
+func workItemConnectorFromWorkflow(ctx context.Context, cfg workflowconfig.Config) (connector.Connector, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	conn, err := factory.NewFromConfig(factory.Config{
+		Kind: cfg.Tracker.Kind,
+		LocalSQLite: local.Config{
+			Path:           cfg.Tracker.LocalSQLite.Path,
+			ProjectID:      cfg.Tracker.LocalSQLite.ProjectID,
+			Issues:         cfg.Tracker.Issues,
+			ActiveStates:   cfg.Tracker.ActiveStates,
+			ObservedStates: cfg.Tracker.ObservedStates,
+			TerminalStates: cfg.Tracker.TerminalStates,
+		},
+		Endpoint:                    cfg.Tracker.Endpoint,
+		APIKey:                      cfg.Tracker.APIKey,
+		HTTPMaxIdleConns:            cfg.Tracker.HTTPMaxIdleConns,
+		HTTPMaxIdleConnsPerHost:     cfg.Tracker.HTTPMaxIdleConnsPerHost,
+		HTTPIdleConnTimeoutMS:       cfg.Tracker.HTTPIdleConnTimeoutMS,
+		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
+		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
+		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,
+		GitHubAppID:                 cfg.Tracker.GitHubAppID,
+		GitHubAppPrivateKey:         cfg.Tracker.GitHubAppPrivateKey,
+		GitHubAppPrivateKeyPath:     cfg.Tracker.GitHubAppPrivateKeyPath,
+		GitHubAppInstallationID:     cfg.Tracker.GitHubAppInstallationID,
+		GitHubStatusSource:          cfg.Tracker.GitHubStatusSource,
+		Repository:                  cfg.Tracker.Repository,
+		StatusField:                 cfg.Tracker.StatusField,
+		StatusLabelPrefix:           cfg.Tracker.StatusLabelPrefix,
+		ActiveStates:                cfg.Tracker.ActiveStates,
+		ObservedStates:              cfg.Tracker.ObservedStates,
+		TerminalStates:              cfg.Tracker.TerminalStates,
+		StateMap:                    githubLocalTrackerStateMap(cfg.Tracker.StateMap),
+		PriorityMap:                 githubLocalTrackerPriorityMap(cfg.Tracker.PriorityMap),
+		RequiredStatusChecks:        cfg.Gate.RequiredStatusChecks,
+	})
+	if err != nil {
+		return nil, err
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, errors.Join(err, closeWorkItemConnector(conn))
+	}
+	return conn, nil
+}
+
+func closeWorkItemConnector(conn connector.Connector) error {
+	if closer, ok := conn.(connector.Closer); ok {
+		return closer.Close()
+	}
+	return nil
+}
+
+func workItemBody(body string, bodyFile string) (string, error) {
+	body = strings.TrimSpace(body)
+	bodyFile = strings.TrimSpace(bodyFile)
+	if body != "" && bodyFile != "" {
+		return "", WrapValidation(errors.New("--body and --body-file cannot both be set"))
+	}
+	if bodyFile != "" {
+		raw, err := os.ReadFile(bodyFile)
+		if err != nil {
+			return "", fmt.Errorf("read body file: %w", err)
+		}
+		body = strings.TrimSpace(string(raw))
+	}
+	if body == "" {
+		return "", WrapValidation(errors.New("--body or --body-file is required"))
+	}
+	return body, nil
+}
+
+func workItemFields(values []string) (map[string]string, error) {
+	fields := map[string]string{}
+	for _, value := range values {
+		key, fieldValue, ok := strings.Cut(value, "=")
+		key = strings.TrimSpace(key)
+		if !ok || key == "" {
+			return nil, WrapValidation(fmt.Errorf("field %q must use key=value", value))
+		}
+		fields[key] = strings.TrimSpace(fieldValue)
+	}
+	return fields, nil
+}
+
+func cliWorkItemError(err error) error {
+	var itemErr *workitem.Error
+	if !errors.As(err, &itemErr) {
+		return err
+	}
+	switch itemErr.Code {
+	case workitem.CodeMissingTitle,
+		workitem.CodeMissingDescription,
+		workitem.CodeInvalidState,
+		workitem.CodeInvalidFields:
+		return WrapValidation(itemErr)
+	default:
+		return itemErr
+	}
+}

--- a/internal/cli/work_item_test.go
+++ b/internal/cli/work_item_test.go
@@ -1,0 +1,121 @@
+package cli_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/cli"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+)
+
+func TestWorkItemAddCreatesLocalSQLiteItem(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "video")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	workflowPath := filepath.Join(workdir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(localSQLiteWorkItemWorkflow()), 0o600); err != nil {
+		t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+	}
+	configPath := filepath.Join(root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{{
+		ID:       "video",
+		Workflow: workflowPath,
+		Workdir:  workdir,
+		Weight:   1,
+		Priority: 0,
+	}})
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"--format", "json",
+		"work-item", "add", "video",
+		"--title", "Author beat visuals",
+		"--body", "Render storyboard frames",
+		"--label", "video-assets",
+		"--field", "render_status=queued",
+		"--priority", "2",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	var result struct {
+		ID         string `json:"id"`
+		Identifier string `json:"identifier"`
+		URL        string `json:"url"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
+		t.Fatalf("Unmarshal() error = %v; output = %s", err, stdout.String())
+	}
+	if result.ID == "" || result.Identifier == "" || result.URL == "" {
+		t.Fatalf("result missing id, identifier, or url: %#v", result)
+	}
+
+	conn, err := local.New(local.Config{
+		Path:           filepath.Join(workdir, ".detent", "work-items.db"),
+		ProjectID:      "video",
+		ActiveStates:   []string{"Todo", "In Progress"},
+		ObservedStates: []string{"Backlog", "Blocked"},
+		TerminalStates: []string{"Done"},
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	issues, err := conn.FetchIssuesByStates(context.Background(), []string{"Todo"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(issues))
+	}
+	issue := issues[0]
+	if issue.Title != "Author beat visuals" || issue.Description != "Render storyboard frames" {
+		t.Fatalf("issue text = %#v", issue)
+	}
+	if issue.Fields["render_status"] != "queued" {
+		t.Fatalf("Fields = %#v", issue.Fields)
+	}
+	if issue.Priority == nil || *issue.Priority != 2 {
+		t.Fatalf("Priority = %v, want 2", issue.Priority)
+	}
+}
+
+func localSQLiteWorkItemWorkflow() string {
+	return `---
+tracker:
+  kind: local_sqlite
+  local_sqlite:
+    path: .detent/work-items.db
+    project_id: video
+  active_states:
+    - Todo
+    - In Progress
+  observed_states:
+    - Backlog
+    - Blocked
+  terminal_states:
+    - Done
+workspace:
+  root: .detent/workspaces
+  source_root: .
+---
+Prompt
+`
+}

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -63,6 +63,7 @@ type Config struct {
 	LogMaxSizeBytes *int      `yaml:"log_max_size_bytes,omitempty"`
 	LogMaxBackups   *int      `yaml:"log_max_backups,omitempty"`
 	GitHubToken     string    `yaml:"github_token,omitempty"`
+	APIToken        string    `yaml:"api_token,omitempty"`
 	Port            *int      `yaml:"port,omitempty"`
 	InstanceName    string    `yaml:"instance_name,omitempty"`
 	Global          Settings  `yaml:"global"`
@@ -408,6 +409,9 @@ func (c Config) Validate(opts ...Option) error {
 	if strings.ContainsAny(c.InstanceName, "\r\n") {
 		problems = append(problems, "instance_name: must be a single line")
 	}
+	if strings.ContainsAny(c.APIToken, "\r\n") {
+		problems = append(problems, "api_token: must be a single line")
+	}
 
 	if c.Global.MaxConcurrentAgents <= 0 {
 		problems = append(problems, "global.max_concurrent_agents: must be a positive integer")
@@ -652,6 +656,8 @@ func validateRaw(attrs map[string]any, opts options) []string {
 	problems = append(problems, optionalNonNegativeIntegerError(attrs["log_max_size_bytes"], "log_max_size_bytes")...)
 	problems = append(problems, optionalNonNegativeIntegerError(attrs["log_max_backups"], "log_max_backups")...)
 	problems = append(problems, optionalStringTypeError(attrs, "github_token")...)
+	problems = append(problems, optionalStringTypeError(attrs, "api_token")...)
+	problems = append(problems, optionalSingleLineStringError(attrs, "api_token")...)
 	problems = append(problems, optionalStringTypeError(attrs, "instance_name")...)
 	problems = append(problems, optionalSingleLineStringError(attrs, "instance_name")...)
 	problems = append(problems, optionalNonNegativeIntegerError(attrs["port"], "port")...)
@@ -1166,6 +1172,10 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
+	apiToken, err := optionalString(attrs["api_token"], "api_token")
+	if err != nil {
+		return Config{}, buildValidationError(path, err)
+	}
 	instanceName, err := optionalString(attrs["instance_name"], "instance_name")
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
@@ -1192,6 +1202,7 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 		LogMaxSizeBytes: logMaxSizeBytes,
 		LogMaxBackups:   logMaxBackups,
 		GitHubToken:     githubToken,
+		APIToken:        apiToken,
 		Port:            port,
 		InstanceName:    instanceName,
 		Global:          settings,

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -244,6 +244,7 @@ log_level: debug
 log_max_size_bytes: 4096
 log_max_backups: 3
 github_token: gh
+api_token: detent_test_api_token
 port: 4100
 instance_name: " buildbox "
 global:
@@ -278,6 +279,9 @@ projects:
 	}
 	if cfg.GitHubToken != "gh" {
 		t.Fatalf("GitHubToken = %q, want gh", cfg.GitHubToken)
+	}
+	if cfg.APIToken != "detent_test_api_token" {
+		t.Fatalf("APIToken = %q, want detent_test_api_token", cfg.APIToken)
 	}
 	if cfg.Port == nil || *cfg.Port != 4100 {
 		t.Fatalf("Port = %v, want 4100", cfg.Port)
@@ -393,6 +397,7 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 		LogMaxSizeBytes: &logMaxSizeBytes,
 		LogMaxBackups:   &logMaxBackups,
 		GitHubToken:     "gh",
+		APIToken:        "detent_test_api_token",
 		Port:            &port,
 		Global: Settings{
 			MaxConcurrentAgents: 3,
@@ -450,6 +455,9 @@ func TestWriteRoundTripsConfig(t *testing.T) {
 	}
 	if got.GitHubToken != cfg.GitHubToken {
 		t.Fatalf("GitHubToken = %q, want %q", got.GitHubToken, cfg.GitHubToken)
+	}
+	if got.APIToken != cfg.APIToken {
+		t.Fatalf("APIToken = %q, want %q", got.APIToken, cfg.APIToken)
 	}
 	if got.Port == nil || *got.Port != *cfg.Port {
 		t.Fatalf("Port = %v, want %d", got.Port, *cfg.Port)

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -101,6 +101,10 @@ type IssueReferenceResolver interface {
 	FetchIssueStatesByIdentifiers(context.Context, []string) ([]Issue, error)
 }
 
+type IssueUpserter interface {
+	UpsertIssues(context.Context, []Issue) error
+}
+
 type IssueParentResolver interface {
 	FetchIssueParents(context.Context, string) ([]Issue, error)
 }

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -224,15 +224,26 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 	if err != nil {
 		return nil, err
 	}
-	out := make([]connector.Issue, 0, len(upstream))
+	out := make([]connector.Issue, 0, len(upstream)+len(localIssues))
+	seen := map[string]struct{}{}
 	for _, issue := range upstream {
 		issue = c.withGitHubIdentity(issue, repoInfo)
+		key := identifierKey(issue.Identifier)
 		if localIssue, ok := localByIdentifier[identifierKey(issue.Identifier)]; ok {
 			merged := c.mergeLocalWithGitHub(localIssue, issue)
 			if err := c.local.UpsertIssues(ctx, []connector.Issue{merged}); err != nil {
 				return nil, err
 			}
+			seen[key] = struct{}{}
 			out = append(out, merged)
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, issue)
+	}
+	for _, issue := range localIssues {
+		key := identifierKey(issue.Identifier)
+		if _, ok := seen[key]; ok {
 			continue
 		}
 		out = append(out, issue)

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -263,6 +263,10 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 	return c.local.UpdateIssueState(ctx, issueID, stateName)
 }
 
+func (c *Connector) UpsertIssues(ctx context.Context, issues []connector.Issue) error {
+	return c.local.UpsertIssues(ctx, issues)
+}
+
 func (c *Connector) SetAssignee(ctx context.Context, issueID string, login string) error {
 	return c.local.SetAssignee(ctx, issueID, login)
 }

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -178,6 +178,49 @@ func TestConnectorIssueMutatorsStayLocalAndPRLifecycleWritesPassThrough(t *testi
 	}
 }
 
+func TestConnectorFetchIssueStatesByIdentifiersReturnsLocalOnlyIssues(t *testing.T) {
+	t.Parallel()
+
+	server := newGitHubLocalTestServer(t)
+	conn, err := New(Config{
+		GitHub: githubconnector.Config{
+			Endpoint: server.URL + "/graphql",
+			APIKey:   "ghp_test",
+		},
+		Local: local.Config{
+			Path: filepath.Join(t.TempDir(), "local-only-work-items.db"),
+			Issues: []connector.Issue{{
+				ID:         "external-123",
+				Identifier: "external-123",
+				Title:      "Runtime item",
+				State:      "Todo",
+				Fields:     map[string]string{},
+			}},
+		},
+		Repository:   "digitaldrywood/detent",
+		ActiveStates: []string{"Todo", "In Progress"},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	issues, err := conn.FetchIssueStatesByIdentifiers(context.Background(), []string{"external-123"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1: %#v", len(issues), issues)
+	}
+	if issues[0].Identifier != "external-123" || issues[0].Title != "Runtime item" {
+		t.Fatalf("issue = %#v, want local-only runtime item", issues[0])
+	}
+}
+
 type githubLocalTestRequest struct {
 	Method string
 	Path   string

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,0 +1,113 @@
+package web
+
+import (
+	"crypto/subtle"
+	"net"
+	"net/http"
+	"os"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+)
+
+const apiTokenEnv = "DETENT_API_TOKEN"
+
+func (s *Server) apiAuth(mutating bool) echo.MiddlewareFunc {
+	return func(next echo.HandlerFunc) echo.HandlerFunc {
+		return func(c echo.Context) error {
+			authorized, err := s.authorizeAPIRequest(c, mutating)
+			if !authorized || err != nil {
+				return err
+			}
+			return next(c)
+		}
+	}
+}
+
+func (s *Server) authorizeAPIRequest(c echo.Context, mutating bool) (bool, error) {
+	token := s.apiToken()
+	if token != "" {
+		for _, candidate := range requestAPITokens(c.Request()) {
+			if constantTimeTokenEqual(candidate, token) {
+				return true, nil
+			}
+		}
+		return false, c.JSON(http.StatusUnauthorized, errorResponse("unauthorized", "Valid API token is required"))
+	}
+	if serverAddressLoopback(s.serverAddr) {
+		return true, nil
+	}
+	message := "configure api_token or DETENT_API_TOKEN to enable API access on non-loopback hosts"
+	if mutating {
+		message = "configure api_token or DETENT_API_TOKEN to enable API mutations on non-loopback hosts"
+	}
+	return false, c.JSON(http.StatusForbidden, errorResponse("api_token_required", message))
+}
+
+func (s *Server) apiToken() string {
+	if s == nil {
+		return ""
+	}
+	if token := strings.TrimSpace(s.lookupEnv(apiTokenEnv)); token != "" {
+		return token
+	}
+	cfg := s.globalConfig
+	if s.globalConfigSource != nil {
+		cfg = s.globalConfigSource()
+	}
+	return strings.TrimSpace(cfg.APIToken)
+}
+
+func (s *Server) warnIfAPITokenMissingOnNonLoopback() {
+	if s == nil || s.apiToken() != "" || serverAddressLoopback(s.serverAddr) {
+		return
+	}
+	s.logger.Warn("api_token is not configured; API routes will fail closed on non-loopback hosts", "addr", s.serverAddr)
+}
+
+func requestAPITokens(req *http.Request) []string {
+	if req == nil {
+		return nil
+	}
+	tokens := []string{}
+	auth := strings.TrimSpace(req.Header.Get("Authorization"))
+	if bearer, ok := strings.CutPrefix(auth, "Bearer "); ok {
+		if bearer = strings.TrimSpace(bearer); bearer != "" {
+			tokens = append(tokens, bearer)
+		}
+	}
+	if apiKey := strings.TrimSpace(req.Header.Get("X-API-Key")); apiKey != "" {
+		tokens = append(tokens, apiKey)
+	}
+	return tokens
+}
+
+func constantTimeTokenEqual(candidate string, token string) bool {
+	candidate = strings.TrimSpace(candidate)
+	token = strings.TrimSpace(token)
+	if candidate == "" || token == "" {
+		return false
+	}
+	return subtle.ConstantTimeCompare([]byte(candidate), []byte(token)) == 1
+}
+
+func serverAddressLoopback(addr string) bool {
+	addr = strings.TrimSpace(addr)
+	if addr == "" {
+		return true
+	}
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		host = addr
+	}
+	host = strings.Trim(strings.TrimSpace(host), "[]")
+	if strings.EqualFold(host, "localhost") {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
+func defaultLookupEnv(key string) string {
+	return os.Getenv(key)
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -1,7 +1,10 @@
 package web
 
 import (
+	"crypto/hmac"
+	"crypto/sha256"
 	"crypto/subtle"
+	"encoding/hex"
 	"net"
 	"net/http"
 	"os"
@@ -12,10 +15,21 @@ import (
 
 const apiTokenEnv = "DETENT_API_TOKEN"
 
+const uiAPICookieName = "detent_ui_api"
+
+type apiAuthOptions struct {
+	mutating      bool
+	allowUICookie bool
+}
+
 func (s *Server) apiAuth(mutating bool) echo.MiddlewareFunc {
+	return s.apiAuthWithOptions(apiAuthOptions{mutating: mutating})
+}
+
+func (s *Server) apiAuthWithOptions(opts apiAuthOptions) echo.MiddlewareFunc {
 	return func(next echo.HandlerFunc) echo.HandlerFunc {
 		return func(c echo.Context) error {
-			authorized, err := s.authorizeAPIRequest(c, mutating)
+			authorized, err := s.authorizeAPIRequest(c, opts)
 			if !authorized || err != nil {
 				return err
 			}
@@ -24,7 +38,7 @@ func (s *Server) apiAuth(mutating bool) echo.MiddlewareFunc {
 	}
 }
 
-func (s *Server) authorizeAPIRequest(c echo.Context, mutating bool) (bool, error) {
+func (s *Server) authorizeAPIRequest(c echo.Context, opts apiAuthOptions) (bool, error) {
 	token := s.apiToken()
 	if token != "" {
 		for _, candidate := range requestAPITokens(c.Request()) {
@@ -32,13 +46,16 @@ func (s *Server) authorizeAPIRequest(c echo.Context, mutating bool) (bool, error
 				return true, nil
 			}
 		}
+		if opts.allowUICookie && s.authorizeUIAPICookie(c) {
+			return true, nil
+		}
 		return false, c.JSON(http.StatusUnauthorized, errorResponse("unauthorized", "Valid API token is required"))
 	}
 	if serverAddressLoopback(s.serverAddr) {
 		return true, nil
 	}
 	message := "configure api_token or DETENT_API_TOKEN to enable API access on non-loopback hosts"
-	if mutating {
+	if opts.mutating {
 		message = "configure api_token or DETENT_API_TOKEN to enable API mutations on non-loopback hosts"
 	}
 	return false, c.JSON(http.StatusForbidden, errorResponse("api_token_required", message))
@@ -88,7 +105,9 @@ func constantTimeTokenEqual(candidate string, token string) bool {
 	if candidate == "" || token == "" {
 		return false
 	}
-	return subtle.ConstantTimeCompare([]byte(candidate), []byte(token)) == 1
+	candidateHash := sha256.Sum256([]byte(candidate))
+	tokenHash := sha256.Sum256([]byte(token))
+	return subtle.ConstantTimeCompare(candidateHash[:], tokenHash[:]) == 1
 }
 
 func serverAddressLoopback(addr string) bool {
@@ -110,4 +129,49 @@ func serverAddressLoopback(addr string) bool {
 
 func defaultLookupEnv(key string) string {
 	return os.Getenv(key)
+}
+
+func (s *Server) uiAPICookie(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		s.setUIAPICookie(c)
+		return next(c)
+	}
+}
+
+func (s *Server) setUIAPICookie(c echo.Context) {
+	if c == nil || c.Request() == nil || c.Request().Method != http.MethodGet {
+		return
+	}
+	if strings.HasPrefix(c.Request().URL.Path, "/api/") || s.uiAPIToken() == "" {
+		return
+	}
+	c.SetCookie(&http.Cookie{
+		Name:     uiAPICookieName,
+		Value:    s.uiAPIToken(),
+		Path:     "/api/v1/",
+		HttpOnly: true,
+		SameSite: http.SameSiteLaxMode,
+		Secure:   c.Request().TLS != nil,
+	})
+}
+
+func (s *Server) authorizeUIAPICookie(c echo.Context) bool {
+	if c == nil || c.Request() == nil || c.Request().Header.Get("HX-Request") != "true" {
+		return false
+	}
+	cookie, err := c.Cookie(uiAPICookieName)
+	if err != nil {
+		return false
+	}
+	return constantTimeTokenEqual(cookie.Value, s.uiAPIToken())
+}
+
+func (s *Server) uiAPIToken() string {
+	token := s.apiToken()
+	if token == "" {
+		return ""
+	}
+	mac := hmac.New(sha256.New, []byte(token))
+	_, _ = mac.Write([]byte("detent-ui-api-v1"))
+	return hex.EncodeToString(mac.Sum(nil))
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -75,6 +75,7 @@ type Config struct {
 	Pricing               budget.PricingTable
 	GlobalConfig          globalconfig.Config
 	GlobalConfigSource    func() globalconfig.Config
+	LookupEnv             func(string) string
 	Hostname              func() (string, error)
 	ConfigPathRule        globalconfig.PathRule
 	Kanban                workflowconfig.Kanban
@@ -106,6 +107,7 @@ type Server struct {
 	pricing             budget.PricingTable
 	globalConfig        globalconfig.Config
 	globalConfigSource  func() globalconfig.Config
+	lookupEnv           func(string) string
 	hostname            func() (string, error)
 	configRule          globalconfig.PathRule
 	kanban              workflowconfig.Kanban
@@ -168,6 +170,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		pricing:             cfg.pricing(),
 		globalConfig:        cfg.GlobalConfig,
 		globalConfigSource:  cfg.globalConfigSource(),
+		lookupEnv:           cfg.lookupEnv(),
 		hostname:            cfg.hostname(),
 		configRule:          cfg.ConfigPathRule,
 		kanban:              kanban,
@@ -186,6 +189,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
 	server.registerRoutes()
+	server.warnIfAPITokenMissingOnNonLoopback()
 
 	return server, nil
 }
@@ -242,22 +246,25 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/onboarding/project", s.onboardingProject)
 	s.echo.POST("/onboarding/agent", s.onboardingAgent)
 	s.echo.POST("/onboarding/write", s.onboardingWrite)
-	s.echo.GET("/api/v1/state", s.apiState)
-	s.echo.GET("/api/v1/demo/scenarios", s.apiDemoScenarios)
-	s.echo.GET("/api/v1/timeseries", s.apiTimeSeries)
-	s.echo.GET("/api/v1/projects/*", s.apiProject)
-	s.echo.POST("/api/v1/refresh", s.apiRefresh)
+	apiReadAuth := s.apiAuth(false)
+	apiMutateAuth := s.apiAuth(true)
+	s.echo.GET("/api/v1/state", s.apiState, apiReadAuth)
+	s.echo.GET("/api/v1/demo/scenarios", s.apiDemoScenarios, apiReadAuth)
+	s.echo.GET("/api/v1/timeseries", s.apiTimeSeries, apiReadAuth)
+	s.echo.POST("/api/v1/projects/:project_id/work-items", s.apiCreateWorkItem, apiMutateAuth)
+	s.echo.GET("/api/v1/projects/*", s.apiProject, apiReadAuth)
+	s.echo.POST("/api/v1/refresh", s.apiRefresh, apiMutateAuth)
 	s.echo.POST("/api/v1/webhooks/github", s.githubWebhook)
-	s.echo.GET("/api/v1/refresh", s.methodNotAllowed)
-	s.echo.GET("/api/v1/usage", s.apiUsage)
-	s.echo.GET("/api/v1/workflow/timeline", s.apiWorkflowTimeline)
-	s.echo.GET("/api/v1/board/card", s.apiBoardCard)
-	s.echo.GET("/api/v1/kanban/move", s.apiKanbanMoveDialog)
-	s.echo.POST("/api/v1/kanban/move", s.apiKanbanMove)
-	s.echo.POST("/api/v1/kanban/remove", s.apiKanbanRemove)
-	s.echo.GET("/api/v1/kanban/comment", s.apiKanbanCommentDialog)
-	s.echo.POST("/api/v1/kanban/comment", s.apiKanbanComment)
-	s.echo.GET("/api/v1/*", s.apiIssue)
+	s.echo.GET("/api/v1/refresh", s.methodNotAllowed, apiReadAuth)
+	s.echo.GET("/api/v1/usage", s.apiUsage, apiReadAuth)
+	s.echo.GET("/api/v1/workflow/timeline", s.apiWorkflowTimeline, apiReadAuth)
+	s.echo.GET("/api/v1/board/card", s.apiBoardCard, apiReadAuth)
+	s.echo.GET("/api/v1/kanban/move", s.apiKanbanMoveDialog, apiReadAuth)
+	s.echo.POST("/api/v1/kanban/move", s.apiKanbanMove, apiMutateAuth)
+	s.echo.POST("/api/v1/kanban/remove", s.apiKanbanRemove, apiMutateAuth)
+	s.echo.GET("/api/v1/kanban/comment", s.apiKanbanCommentDialog, apiReadAuth)
+	s.echo.POST("/api/v1/kanban/comment", s.apiKanbanComment, apiMutateAuth)
+	s.echo.GET("/api/v1/*", s.apiIssue, apiReadAuth)
 }
 
 func (s *Server) dashboard(c echo.Context) error {
@@ -750,6 +757,13 @@ func (cfg Config) dashboardURL() string {
 		return dashboardURL
 	}
 	return "http://localhost:4000"
+}
+
+func (cfg Config) lookupEnv() func(string) string {
+	if cfg.LookupEnv != nil {
+		return cfg.LookupEnv
+	}
+	return defaultLookupEnv
 }
 
 func (cfg Config) kanban() workflowconfig.Kanban {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -188,6 +188,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		demo:                newDemoScenarioSet(cfg.Demo),
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
+	e.Use(server.uiAPICookie)
 	server.registerRoutes()
 	server.warnIfAPITokenMissingOnNonLoopback()
 
@@ -248,22 +249,24 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/onboarding/write", s.onboardingWrite)
 	apiReadAuth := s.apiAuth(false)
 	apiMutateAuth := s.apiAuth(true)
+	apiUIReadAuth := s.apiAuthWithOptions(apiAuthOptions{allowUICookie: true})
+	apiUIMutateAuth := s.apiAuthWithOptions(apiAuthOptions{mutating: true, allowUICookie: true})
 	s.echo.GET("/api/v1/state", s.apiState, apiReadAuth)
 	s.echo.GET("/api/v1/demo/scenarios", s.apiDemoScenarios, apiReadAuth)
 	s.echo.GET("/api/v1/timeseries", s.apiTimeSeries, apiReadAuth)
 	s.echo.POST("/api/v1/projects/:project_id/work-items", s.apiCreateWorkItem, apiMutateAuth)
 	s.echo.GET("/api/v1/projects/*", s.apiProject, apiReadAuth)
-	s.echo.POST("/api/v1/refresh", s.apiRefresh, apiMutateAuth)
+	s.echo.POST("/api/v1/refresh", s.apiRefresh, apiUIMutateAuth)
 	s.echo.POST("/api/v1/webhooks/github", s.githubWebhook)
-	s.echo.GET("/api/v1/refresh", s.methodNotAllowed, apiReadAuth)
+	s.echo.GET("/api/v1/refresh", s.methodNotAllowed, apiUIReadAuth)
 	s.echo.GET("/api/v1/usage", s.apiUsage, apiReadAuth)
 	s.echo.GET("/api/v1/workflow/timeline", s.apiWorkflowTimeline, apiReadAuth)
-	s.echo.GET("/api/v1/board/card", s.apiBoardCard, apiReadAuth)
-	s.echo.GET("/api/v1/kanban/move", s.apiKanbanMoveDialog, apiReadAuth)
-	s.echo.POST("/api/v1/kanban/move", s.apiKanbanMove, apiMutateAuth)
-	s.echo.POST("/api/v1/kanban/remove", s.apiKanbanRemove, apiMutateAuth)
-	s.echo.GET("/api/v1/kanban/comment", s.apiKanbanCommentDialog, apiReadAuth)
-	s.echo.POST("/api/v1/kanban/comment", s.apiKanbanComment, apiMutateAuth)
+	s.echo.GET("/api/v1/board/card", s.apiBoardCard, apiUIReadAuth)
+	s.echo.GET("/api/v1/kanban/move", s.apiKanbanMoveDialog, apiUIReadAuth)
+	s.echo.POST("/api/v1/kanban/move", s.apiKanbanMove, apiUIMutateAuth)
+	s.echo.POST("/api/v1/kanban/remove", s.apiKanbanRemove, apiUIMutateAuth)
+	s.echo.GET("/api/v1/kanban/comment", s.apiKanbanCommentDialog, apiUIReadAuth)
+	s.echo.POST("/api/v1/kanban/comment", s.apiKanbanComment, apiUIMutateAuth)
 	s.echo.GET("/api/v1/*", s.apiIssue, apiReadAuth)
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2,12 +2,14 @@ package web_test
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -27,6 +29,7 @@ import (
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/hub"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
@@ -194,6 +197,237 @@ func TestServerRoutes(t *testing.T) {
 				t.Fatalf("body missing %q:\n%s", tt.wantContent, rec.Body.String())
 			}
 		})
+	}
+}
+
+func TestAPITokenAuthProtectsAPIRoutes(t *testing.T) {
+	t.Parallel()
+
+	server, err := web.NewServer(web.Config{
+		GlobalConfig: globalconfig.Config{APIToken: "detent_test_token"},
+	}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	requestJSON(t, server, http.MethodGet, "/health", http.StatusOK)
+	requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusUnauthorized)
+	requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/state", http.StatusUnauthorized, map[string]string{
+		"Authorization": "Bearer wrong",
+	})
+	requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/state", http.StatusOK, map[string]string{
+		"X-API-Key": "detent_test_token",
+	})
+}
+
+func TestAPITokenEnvOverride(t *testing.T) {
+	t.Setenv("DETENT_API_TOKEN", "detent_env_token")
+
+	server, err := web.NewServer(web.Config{
+		GlobalConfig: globalconfig.Config{APIToken: "detent_config_token"},
+	}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/state", http.StatusUnauthorized, map[string]string{
+		"Authorization": "Bearer detent_config_token",
+	})
+	requestJSONWithHeaders(t, server, http.MethodGet, "/api/v1/state", http.StatusOK, map[string]string{
+		"Authorization": "Bearer detent_env_token",
+	})
+}
+
+func TestAPIFailsClosedWithoutTokenOnNonLoopbackBind(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	server, err := web.NewServer(web.Config{
+		Logger:        slog.New(slog.NewTextHandler(&logs, nil)),
+		ServerAddress: "0.0.0.0:4000",
+	}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	requestJSON(t, server, http.MethodGet, "/api/v1/state", http.StatusForbidden)
+	requestJSON(t, server, http.MethodPost, "/api/v1/refresh", http.StatusForbidden)
+	if !strings.Contains(logs.String(), "api_token") {
+		t.Fatalf("startup warning missing api_token detail:\n%s", logs.String())
+	}
+}
+
+func TestAPITokenDoesNotLeakToLogs(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	server, err := web.NewServer(web.Config{
+		Logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+		GlobalConfig: globalconfig.Config{APIToken: "detent_real_token"},
+	}, testDeps(t))
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	requestJSONWithHeaders(t, server, http.MethodPost, "/api/v1/refresh", http.StatusUnauthorized, map[string]string{
+		"Authorization": "Bearer detent_wrong_token",
+		"X-API-Key":     "detent_wrong_key",
+	})
+	for _, secret := range []string{"detent_wrong_token", "detent_wrong_key", "detent_real_token"} {
+		if strings.Contains(logs.String(), secret) {
+			t.Fatalf("logs leaked token %q:\n%s", secret, logs.String())
+		}
+	}
+}
+
+func TestWorkItemAPICreatesLocalSQLiteItem(t *testing.T) {
+	t.Parallel()
+
+	server, conn, refresher := newWorkItemAPITestServer(t, "detent_test_token")
+	rec := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/projects/video/work-items", `{
+		"title": " Author beat visuals ",
+		"description": " Render storyboard frames ",
+		"labels": ["video-assets"],
+		"fields": {"render_status": "queued"},
+		"priority": 2,
+		"deliverable": {"kind": "artifact", "review_url": "http://127.0.0.1:8090/v/slug/g/assets"}
+	}`, map[string]string{
+		"Authorization": "Bearer detent_test_token",
+	})
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusCreated, rec.Body.String())
+	}
+	var payload map[string]any
+	if err := json.Unmarshal(rec.Body.Bytes(), &payload); err != nil {
+		t.Fatalf("Unmarshal() error = %v", err)
+	}
+	if payload["id"] == "" || payload["identifier"] == "" || payload["url"] == "" {
+		t.Fatalf("response missing id, identifier, or url: %#v", payload)
+	}
+	if refresher.calls != 1 {
+		t.Fatalf("refresh calls = %d, want 1", refresher.calls)
+	}
+	issues, err := conn.FetchIssuesByStates(context.Background(), []string{"Todo"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues len = %d, want 1", len(issues))
+	}
+	issue := issues[0]
+	if issue.Title != "Author beat visuals" || issue.Description != "Render storyboard frames" {
+		t.Fatalf("issue text = %#v", issue)
+	}
+	if issue.Fields["render_status"] != "queued" {
+		t.Fatalf("Fields = %#v", issue.Fields)
+	}
+	if issue.Priority == nil || *issue.Priority != 2 {
+		t.Fatalf("Priority = %v, want 2", issue.Priority)
+	}
+	if issue.Deliverable == nil || issue.Deliverable.ReviewURL != "http://127.0.0.1:8090/v/slug/g/assets" {
+		t.Fatalf("Deliverable = %#v", issue.Deliverable)
+	}
+}
+
+func TestWorkItemAPIErrors(t *testing.T) {
+	t.Parallel()
+
+	server, _, _ := newWorkItemAPITestServer(t, "detent_test_token")
+	tests := []struct {
+		name    string
+		path    string
+		body    string
+		headers map[string]string
+		want    int
+	}{
+		{
+			name: "missing token",
+			path: "/api/v1/projects/video/work-items",
+			body: `{"title":"title","description":"body"}`,
+			want: http.StatusUnauthorized,
+		},
+		{
+			name: "wrong token",
+			path: "/api/v1/projects/video/work-items",
+			body: `{"title":"title","description":"body"}`,
+			headers: map[string]string{
+				"Authorization": "Bearer wrong",
+			},
+			want: http.StatusUnauthorized,
+		},
+		{
+			name: "unknown project",
+			path: "/api/v1/projects/missing/work-items",
+			body: `{"title":"title","description":"body"}`,
+			headers: map[string]string{
+				"Authorization": "Bearer detent_test_token",
+			},
+			want: http.StatusNotFound,
+		},
+		{
+			name: "invalid state",
+			path: "/api/v1/projects/video/work-items",
+			body: `{"title":"title","description":"body","state":"Missing"}`,
+			headers: map[string]string{
+				"Authorization": "Bearer detent_test_token",
+			},
+			want: http.StatusUnprocessableEntity,
+		},
+		{
+			name: "invalid fields shape",
+			path: "/api/v1/projects/video/work-items",
+			body: `{"title":"title","description":"body","fields":{"render_status":42}}`,
+			headers: map[string]string{
+				"Authorization": "Bearer detent_test_token",
+			},
+			want: http.StatusUnprocessableEntity,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			rec := performJSON(t, server.Handler(), http.MethodPost, tt.path, tt.body, tt.headers)
+			if rec.Code != tt.want {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, tt.want, rec.Body.String())
+			}
+		})
+	}
+}
+
+func TestWorkItemAPIRejectsDuplicateIdentifier(t *testing.T) {
+	t.Parallel()
+
+	server, _, _ := newWorkItemAPITestServer(t, "detent_test_token")
+	body := `{"title":"title","description":"body","identifier":"external-123"}`
+	headers := map[string]string{"Authorization": "Bearer detent_test_token"}
+	first := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/projects/video/work-items", body, headers)
+	if first.Code != http.StatusCreated {
+		t.Fatalf("first status = %d, want %d; body = %s", first.Code, http.StatusCreated, first.Body.String())
+	}
+	second := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/projects/video/work-items", body, headers)
+	if second.Code != http.StatusConflict {
+		t.Fatalf("second status = %d, want %d; body = %s", second.Code, http.StatusConflict, second.Body.String())
+	}
+}
+
+func TestWorkItemAPIRejectsUnsupportedTracker(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	mustSetWebGitHubLabelProject(t, deps.Registry, "github", "digitaldrywood/detent")
+	server, err := web.NewServer(web.Config{
+		GlobalConfig: globalconfig.Config{APIToken: "detent_test_token"},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	rec := performJSON(t, server.Handler(), http.MethodPost, "/api/v1/projects/github/work-items", `{"title":"title","description":"body"}`, map[string]string{
+		"Authorization": "Bearer detent_test_token",
+	})
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusNotImplemented, rec.Body.String())
 	}
 }
 
@@ -6817,6 +7051,63 @@ func testDeps(t *testing.T) web.Dependencies {
 	}
 }
 
+func newWorkItemAPITestServer(t *testing.T, apiToken string) (*web.Server, *local.Connector, *refreshProbe) {
+	t.Helper()
+
+	conn, err := local.New(local.Config{
+		Path:           filepath.Join(t.TempDir(), "work-items.db"),
+		ProjectID:      "video",
+		ActiveStates:   []string{"Todo", "In Progress"},
+		ObservedStates: []string{"Backlog", "Blocked"},
+		TerminalStates: []string{"Done"},
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.Kind = workflowconfig.TrackerLocalSQLite
+	workflowCfg.Tracker.LocalSQLite.Path = filepath.Join(t.TempDir(), "unused.db")
+	workflowCfg.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+	workflowCfg.Tracker.ObservedStates = []string{"Backlog", "Blocked"}
+	workflowCfg.Tracker.TerminalStates = []string{"Done"}
+	trackedProject, err := project.New(project.Config{
+		Project: globalconfig.Project{ID: "video"},
+		Workflow: workflowconfig.Workflow{
+			Config: workflowCfg,
+			Prompt: "Work the issue.",
+		},
+	}, project.Dependencies{
+		Connector: conn,
+	})
+	if err != nil {
+		t.Fatalf("project.New() error = %v", err)
+	}
+
+	refresher := &refreshProbe{}
+	deps := testDeps(t)
+	deps.Connector = conn
+	deps.Refresher = refresher
+	if err := deps.Registry.Set(trackedProject); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{
+		DashboardURL: "http://127.0.0.1:4000",
+		GlobalConfig: globalconfig.Config{
+			APIToken: apiToken,
+		},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	return server, conn, refresher
+}
+
 func mustSetWebProject(t *testing.T, registry *project.Registry, id string, paused bool) {
 	t.Helper()
 
@@ -7145,6 +7436,19 @@ func requestJSONWithHeaders(t *testing.T, server *web.Server, method string, pat
 		t.Fatalf("Unmarshal(%s %s) error = %v; body = %s", method, path, err, rec.Body.String())
 	}
 	return payload
+}
+
+func performJSON(t *testing.T, handler http.Handler, method string, path string, body string, headers map[string]string) *httptest.ResponseRecorder {
+	t.Helper()
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(method, path, strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	for key, value := range headers {
+		req.Header.Set(key, value)
+	}
+	handler.ServeHTTP(rec, req)
+	return rec
 }
 
 func requestHTML(t *testing.T, handler http.Handler, method string, path string, wantStatus int) string {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -280,6 +280,98 @@ func TestAPITokenDoesNotLeakToLogs(t *testing.T) {
 	}
 }
 
+func TestAPITokenAllowsDashboardHTMXWithUICookie(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "github"}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, actionConnector)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent"},
+		Pipeline: []telemetry.Issue{{
+			ID:         "I_kw1",
+			Identifier: "digitaldrywood/detent#1",
+			ProjectID:  "detent",
+			Title:      "Dialog card",
+			State:      "Todo",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{
+		GlobalConfig: globalconfig.Config{APIToken: "detent_real_token"},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	dialogPath := "/api/v1/kanban/move?project_id=detent&issue_id=I_kw1&current_state=Todo&identifier=digitaldrywood%2Fdetent%231&title=Dialog+card"
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, dialogPath, nil)
+	req.Header.Set("HX-Request", "true")
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("dialog without cookie status = %d, want %d; body = %s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dashboard status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "detent_real_token") {
+		t.Fatalf("dashboard body leaked API token")
+	}
+	cookies := rec.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatalf("dashboard response did not set UI API cookie")
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/state", nil)
+	req.Header.Set("HX-Request", "true")
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusUnauthorized {
+		t.Fatalf("state with UI cookie status = %d, want %d; body = %s", rec.Code, http.StatusUnauthorized, rec.Body.String())
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, dialogPath, nil)
+	req.Header.Set("HX-Request", "true")
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("dialog with UI cookie status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	form := url.Values{
+		"kanban_dialog": {"true"},
+		"project_id":    {"detent"},
+		"issue_id":      {"I_kw1"},
+		"current_state": {"Todo"},
+	}
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodPost, "/api/v1/kanban/move", strings.NewReader(form.Encode()))
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("HX-Request", "true")
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("kanban post with UI cookie status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+}
+
 func TestWorkItemAPICreatesLocalSQLiteItem(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/work_items.go
+++ b/internal/web/work_items.go
@@ -1,0 +1,52 @@
+package web
+
+import (
+	"errors"
+	"net/http"
+	"strings"
+
+	"github.com/labstack/echo/v4"
+
+	"github.com/digitaldrywood/detent/internal/project"
+	"github.com/digitaldrywood/detent/internal/workitem"
+)
+
+func (s *Server) apiCreateWorkItem(c echo.Context) error {
+	projectID := strings.TrimSpace(c.Param("project_id"))
+	trackedProject, ok := s.registry.Get(project.ID(projectID))
+	if !ok {
+		return c.JSON(http.StatusNotFound, errorResponse("project_not_found", "Project not found"))
+	}
+	var req workitem.Request
+	if err := c.Bind(&req); err != nil {
+		return c.JSON(http.StatusUnprocessableEntity, errorResponse("invalid_request", "Request body must be valid JSON"))
+	}
+	response, err := workitem.Create(c.Request().Context(), workitem.Target{
+		ProjectID:    projectID,
+		Workflow:     trackedProject.Workflow().Config,
+		Connector:    trackedProject.Connector(),
+		DashboardURL: s.dashboardURL,
+	}, req)
+	if err != nil {
+		return workItemAPIError(c, err)
+	}
+	s.requestKanbanRefresh(c.Request().Context())
+	return c.JSON(http.StatusCreated, response)
+}
+
+func workItemAPIError(c echo.Context, err error) error {
+	var itemErr *workitem.Error
+	if !errors.As(err, &itemErr) {
+		return c.JSON(http.StatusBadGateway, errorResponse("work_item_create_failed", "Create work item failed"))
+	}
+	status := http.StatusUnprocessableEntity
+	switch itemErr.Code {
+	case workitem.CodeDuplicateIdentifier:
+		status = http.StatusConflict
+	case workitem.CodeUnsupportedTracker:
+		status = http.StatusNotImplemented
+	case workitem.CodeConnectorUnavailable, workitem.CodeSubmissionFailed:
+		status = http.StatusBadGateway
+	}
+	return c.JSON(status, errorResponse(string(itemErr.Code), itemErr.Error()))
+}

--- a/internal/workitem/workitem.go
+++ b/internal/workitem/workitem.go
@@ -1,0 +1,304 @@
+package workitem
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"errors"
+	"net/url"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+type ErrorCode string
+
+const (
+	CodeMissingTitle         ErrorCode = "missing_title"
+	CodeMissingDescription   ErrorCode = "missing_description"
+	CodeInvalidState         ErrorCode = "invalid_state"
+	CodeInvalidFields        ErrorCode = "invalid_fields"
+	CodeDuplicateIdentifier  ErrorCode = "duplicate_identifier"
+	CodeUnsupportedTracker   ErrorCode = "unsupported_tracker"
+	CodeConnectorUnavailable ErrorCode = "connector_unavailable"
+	CodeIdentifierGeneration ErrorCode = "identifier_generation_failed"
+	CodeSubmissionFailed     ErrorCode = "submission_failed"
+)
+
+type Error struct {
+	Code    ErrorCode
+	Message string
+	Err     error
+}
+
+func (e *Error) Error() string {
+	if e == nil {
+		return ""
+	}
+	if strings.TrimSpace(e.Message) != "" {
+		return e.Message
+	}
+	if e.Err != nil {
+		return e.Err.Error()
+	}
+	return string(e.Code)
+}
+
+func (e *Error) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+type Request struct {
+	Title         string                 `json:"title"`
+	Description   string                 `json:"description"`
+	State         string                 `json:"state,omitempty"`
+	Labels        []string               `json:"labels,omitempty"`
+	Fields        map[string]string      `json:"fields,omitempty"`
+	Priority      *int                   `json:"priority,omitempty"`
+	ModelOverride string                 `json:"model_override,omitempty"`
+	Deliverable   *connector.Deliverable `json:"deliverable,omitempty"`
+	Identifier    string                 `json:"identifier,omitempty"`
+}
+
+type Response struct {
+	ID         string `json:"id"`
+	Identifier string `json:"identifier"`
+	URL        string `json:"url"`
+}
+
+type Target struct {
+	ProjectID           string
+	Workflow            workflowconfig.Config
+	Connector           connector.Connector
+	DashboardURL        string
+	Now                 func() time.Time
+	IdentifierGenerator func() (string, error)
+}
+
+func Create(ctx context.Context, target Target, req Request) (Response, error) {
+	title := strings.TrimSpace(req.Title)
+	if title == "" {
+		return Response{}, &Error{Code: CodeMissingTitle, Message: "title is required"}
+	}
+	description := strings.TrimSpace(req.Description)
+	if description == "" {
+		return Response{}, &Error{Code: CodeMissingDescription, Message: "description is required"}
+	}
+	state, err := configuredState(target.Workflow, req.State)
+	if err != nil {
+		return Response{}, err
+	}
+	labels := trimNonBlank(req.Labels)
+	fields, err := cleanFields(req.Fields)
+	if err != nil {
+		return Response{}, err
+	}
+	if !SupportsTracker(target.Workflow.Tracker.Kind) {
+		return Response{}, &Error{Code: CodeUnsupportedTracker, Message: "tracker kind does not support runtime work-item creation"}
+	}
+	if target.Connector == nil {
+		return Response{}, &Error{Code: CodeConnectorUnavailable, Message: "connector is unavailable"}
+	}
+	upserter, ok := target.Connector.(connector.IssueUpserter)
+	if !ok {
+		return Response{}, &Error{Code: CodeUnsupportedTracker, Message: "tracker kind does not support runtime work-item creation"}
+	}
+
+	identifier, err := submissionIdentifier(ctx, target, req.Identifier)
+	if err != nil {
+		return Response{}, err
+	}
+	itemURL := WorkItemURL(target.DashboardURL, target.ProjectID)
+	now := target.now().UTC()
+	issue := connector.NewIssue()
+	issue.ID = identifier
+	issue.Identifier = identifier
+	issue.Title = title
+	issue.Description = description
+	issue.State = state
+	issue.Labels = labels
+	issue.Fields = fields
+	issue.Priority = req.Priority
+	issue.URL = itemURL
+	issue.ModelOverride = strings.TrimSpace(req.ModelOverride)
+	issue.Deliverable = cloneDeliverable(req.Deliverable)
+	issue.CreatedAt = &now
+	issue.UpdatedAt = &now
+	issue.StageUpdatedAt = &now
+
+	if err := upserter.UpsertIssues(ctx, []connector.Issue{issue}); err != nil {
+		return Response{}, &Error{Code: CodeSubmissionFailed, Message: "create work item failed", Err: err}
+	}
+	return Response{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL}, nil
+}
+
+func SupportsTracker(kind string) bool {
+	switch strings.TrimSpace(kind) {
+	case workflowconfig.TrackerLocalSQLite, workflowconfig.TrackerGitHubLocal:
+		return true
+	default:
+		return false
+	}
+}
+
+func WorkItemURL(base string, projectID string) string {
+	projectID = strings.TrimSpace(projectID)
+	path := "/kanban"
+	if projectID != "" {
+		path = "/projects/" + url.PathEscape(projectID) + "/kanban"
+	}
+	base = strings.TrimSpace(base)
+	if base == "" {
+		return path
+	}
+	parsed, err := url.Parse(base)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return path
+	}
+	parsed.Path = path
+	parsed.RawQuery = ""
+	parsed.Fragment = ""
+	return parsed.String()
+}
+
+func configuredState(cfg workflowconfig.Config, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested == "" {
+		for _, state := range cfg.Tracker.ActiveStates {
+			if state = strings.TrimSpace(state); state != "" {
+				return state, nil
+			}
+		}
+		return "", &Error{Code: CodeInvalidState, Message: "state is required because tracker.active_states is empty"}
+	}
+	for _, state := range configuredStates(cfg) {
+		if strings.EqualFold(strings.TrimSpace(state), requested) {
+			return strings.TrimSpace(state), nil
+		}
+	}
+	return "", &Error{Code: CodeInvalidState, Message: "state must be one of the configured tracker states"}
+}
+
+func configuredStates(cfg workflowconfig.Config) []string {
+	out := []string{}
+	out = append(out, cfg.Tracker.ActiveStates...)
+	out = append(out, cfg.Tracker.ObservedStates...)
+	out = append(out, cfg.Tracker.TerminalStates...)
+	return out
+}
+
+func submissionIdentifier(ctx context.Context, target Target, requested string) (string, error) {
+	requested = strings.TrimSpace(requested)
+	if requested != "" {
+		if err := ensureIdentifierAvailable(ctx, target.Connector, requested); err != nil {
+			return "", err
+		}
+		return requested, nil
+	}
+	for range 3 {
+		identifier, err := target.identifier()
+		if err != nil {
+			return "", &Error{Code: CodeIdentifierGeneration, Message: "generate work item identifier failed", Err: err}
+		}
+		identifier = strings.TrimSpace(identifier)
+		if identifier == "" {
+			return "", &Error{Code: CodeIdentifierGeneration, Message: "generate work item identifier failed"}
+		}
+		if err := ensureIdentifierAvailable(ctx, target.Connector, identifier); err != nil {
+			var itemErr *Error
+			if errors.As(err, &itemErr) && itemErr.Code == CodeDuplicateIdentifier {
+				continue
+			}
+			return "", err
+		}
+		return identifier, nil
+	}
+	return "", &Error{Code: CodeDuplicateIdentifier, Message: "identifier already exists"}
+}
+
+func ensureIdentifierAvailable(ctx context.Context, projectConnector connector.Connector, identifier string) error {
+	resolver, ok := projectConnector.(connector.IssueReferenceResolver)
+	if !ok {
+		return nil
+	}
+	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, []string{identifier})
+	if err != nil {
+		return &Error{Code: CodeSubmissionFailed, Message: "check duplicate identifier failed", Err: err}
+	}
+	for _, issue := range issues {
+		if strings.EqualFold(strings.TrimSpace(issue.Identifier), identifier) {
+			return &Error{Code: CodeDuplicateIdentifier, Message: "identifier already exists"}
+		}
+	}
+	return nil
+}
+
+func (target Target) now() time.Time {
+	if target.Now != nil {
+		return target.Now()
+	}
+	return time.Now()
+}
+
+func (target Target) identifier() (string, error) {
+	if target.IdentifierGenerator != nil {
+		return target.IdentifierGenerator()
+	}
+	var raw [12]byte
+	if _, err := rand.Read(raw[:]); err != nil {
+		return "", err
+	}
+	return "wi-" + hex.EncodeToString(raw[:]), nil
+}
+
+func trimNonBlank(values []string) []string {
+	out := make([]string, 0, len(values))
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			out = append(out, value)
+		}
+	}
+	return out
+}
+
+func cleanFields(fields map[string]string) (map[string]string, error) {
+	if fields == nil {
+		return map[string]string{}, nil
+	}
+	out := make(map[string]string, len(fields))
+	for key, value := range fields {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			return nil, &Error{Code: CodeInvalidFields, Message: "fields keys must not be blank"}
+		}
+		out[key] = strings.TrimSpace(value)
+	}
+	return out, nil
+}
+
+func cloneDeliverable(deliverable *connector.Deliverable) *connector.Deliverable {
+	if deliverable == nil {
+		return nil
+	}
+	out := *deliverable
+	out.Kind = strings.TrimSpace(out.Kind)
+	out.Path = strings.TrimSpace(out.Path)
+	out.ReviewURL = strings.TrimSpace(out.ReviewURL)
+	out.ValidationStatus = strings.TrimSpace(out.ValidationStatus)
+	out.ExternalID = strings.TrimSpace(out.ExternalID)
+	if len(deliverable.Metadata) > 0 {
+		out.Metadata = make(map[string]string, len(deliverable.Metadata))
+		for key, value := range deliverable.Metadata {
+			key = strings.TrimSpace(key)
+			if key != "" {
+				out.Metadata[key] = strings.TrimSpace(value)
+			}
+		}
+	}
+	return &out
+}

--- a/internal/workitem/workitem_test.go
+++ b/internal/workitem/workitem_test.go
@@ -1,0 +1,207 @@
+package workitem_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/workitem"
+)
+
+func TestCreateBuildsWorkItemWithDefaults(t *testing.T) {
+	t.Parallel()
+
+	conn := &creatorConnector{}
+	now := time.Date(2026, 7, 6, 16, 0, 0, 0, time.UTC)
+	got, err := workitem.Create(context.Background(), workitem.Target{
+		ProjectID:           "video",
+		Workflow:            localSQLiteWorkflow(),
+		Connector:           conn,
+		DashboardURL:        "http://127.0.0.1:4000",
+		Now:                 func() time.Time { return now },
+		IdentifierGenerator: func() (string, error) { return "wi-test", nil },
+	}, workitem.Request{
+		Title:       " Author beat visuals ",
+		Description: " Render storyboard frames ",
+		Labels:      []string{" video-assets ", ""},
+		Fields:      map[string]string{" render_status ": " queued "},
+	})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	if got.ID != "wi-test" || got.Identifier != "wi-test" {
+		t.Fatalf("Create() response = %#v, want generated identifier", got)
+	}
+	if got.URL != "http://127.0.0.1:4000/projects/video/kanban" {
+		t.Fatalf("URL = %q", got.URL)
+	}
+	if len(conn.upserts) != 1 {
+		t.Fatalf("upserts len = %d, want 1", len(conn.upserts))
+	}
+	issue := conn.upserts[0]
+	if issue.Title != "Author beat visuals" || issue.Description != "Render storyboard frames" {
+		t.Fatalf("issue text = %#v", issue)
+	}
+	if issue.State != "Todo" {
+		t.Fatalf("State = %q, want Todo", issue.State)
+	}
+	if len(issue.Labels) != 1 || issue.Labels[0] != "video-assets" {
+		t.Fatalf("Labels = %#v", issue.Labels)
+	}
+	if issue.Fields["render_status"] != "queued" {
+		t.Fatalf("Fields = %#v", issue.Fields)
+	}
+	if issue.CreatedAt == nil || !issue.CreatedAt.Equal(now) {
+		t.Fatalf("CreatedAt = %v, want %v", issue.CreatedAt, now)
+	}
+}
+
+func TestCreateRejectsInvalidInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		req  workitem.Request
+		want workitem.ErrorCode
+	}{
+		{
+			name: "missing title",
+			req:  workitem.Request{Description: "body"},
+			want: workitem.CodeMissingTitle,
+		},
+		{
+			name: "missing description",
+			req:  workitem.Request{Title: "title"},
+			want: workitem.CodeMissingDescription,
+		},
+		{
+			name: "invalid state",
+			req:  workitem.Request{Title: "title", Description: "body", State: "Missing"},
+			want: workitem.CodeInvalidState,
+		},
+		{
+			name: "blank field key",
+			req:  workitem.Request{Title: "title", Description: "body", Fields: map[string]string{" ": "value"}},
+			want: workitem.CodeInvalidFields,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := workitem.Create(context.Background(), workitem.Target{
+				Workflow:  localSQLiteWorkflow(),
+				Connector: &creatorConnector{},
+			}, tt.req)
+			var itemErr *workitem.Error
+			if !errors.As(err, &itemErr) {
+				t.Fatalf("Create() error = %v, want workitem.Error", err)
+			}
+			if itemErr.Code != tt.want {
+				t.Fatalf("error code = %q, want %q", itemErr.Code, tt.want)
+			}
+		})
+	}
+}
+
+func TestCreateRejectsDuplicateIdentifier(t *testing.T) {
+	t.Parallel()
+
+	conn := &creatorConnector{
+		existing: []connector.Issue{{ID: "existing", Identifier: "external-123"}},
+	}
+	_, err := workitem.Create(context.Background(), workitem.Target{
+		Workflow:  localSQLiteWorkflow(),
+		Connector: conn,
+	}, workitem.Request{
+		Title:       "title",
+		Description: "body",
+		Identifier:  "external-123",
+	})
+	var itemErr *workitem.Error
+	if !errors.As(err, &itemErr) {
+		t.Fatalf("Create() error = %v, want workitem.Error", err)
+	}
+	if itemErr.Code != workitem.CodeDuplicateIdentifier {
+		t.Fatalf("error code = %q, want %q", itemErr.Code, workitem.CodeDuplicateIdentifier)
+	}
+}
+
+func TestCreateRejectsUnsupportedTracker(t *testing.T) {
+	t.Parallel()
+
+	cfg := localSQLiteWorkflow()
+	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
+	_, err := workitem.Create(context.Background(), workitem.Target{
+		Workflow: cfg,
+	}, workitem.Request{
+		Title:       "title",
+		Description: "body",
+	})
+	var itemErr *workitem.Error
+	if !errors.As(err, &itemErr) {
+		t.Fatalf("Create() error = %v, want workitem.Error", err)
+	}
+	if itemErr.Code != workitem.CodeUnsupportedTracker {
+		t.Fatalf("error code = %q, want %q", itemErr.Code, workitem.CodeUnsupportedTracker)
+	}
+}
+
+func localSQLiteWorkflow() workflowconfig.Config {
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerLocalSQLite
+	cfg.Tracker.ActiveStates = []string{"Todo", "In Progress"}
+	cfg.Tracker.ObservedStates = []string{"Backlog", "Blocked"}
+	cfg.Tracker.TerminalStates = []string{"Done"}
+	return cfg
+}
+
+type creatorConnector struct {
+	upserts  []connector.Issue
+	existing []connector.Issue
+}
+
+func (c *creatorConnector) Name() string {
+	return connector.BackendLocalSQLite.String()
+}
+
+func (c *creatorConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *creatorConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *creatorConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *creatorConnector) FetchIssueStatesByIdentifiers(context.Context, []string) ([]connector.Issue, error) {
+	return append([]connector.Issue(nil), c.existing...), nil
+}
+
+func (c *creatorConnector) CreateComment(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *creatorConnector) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *creatorConnector) SetAssignee(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *creatorConnector) SetField(context.Context, string, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *creatorConnector) UpsertIssues(_ context.Context, issues []connector.Issue) error {
+	c.upserts = append(c.upserts, issues...)
+	return nil
+}


### PR DESCRIPTION
## Summary

- Add a runtime work-item creation path for local_sqlite and github_local trackers through HTTP and CLI entry points.
- Protect API routes with baseline static-token authentication, fail-closed behavior on non-loopback hosts, and token-safe request handling.
- Document api_token configuration, the submission endpoint, CLI usage, and response/error behavior.

Fixes #936

## Test Plan

- [x] `make check`