### PR TITLE
fix(orchestrator): hold on workpad blockers

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -74,6 +74,8 @@ const (
 	AutoPromoteReasonArtifactStatusMissing           AutoPromoteReason = "artifact_status_missing"
 	AutoPromoteReasonArtifactStatusWait              AutoPromoteReason = "artifact_status_wait"
 	AutoPromoteReasonArtifactStatusRework            AutoPromoteReason = "artifact_status_rework"
+	AutoPromoteReasonWorkpadBlocker                  AutoPromoteReason = "workpad_blocker"
+	AutoPromoteReasonWorkpadHydrationUnavailable     AutoPromoteReason = "workpad_hydration_unavailable"
 )
 
 type AutoPromoteDecision struct {
@@ -82,6 +84,7 @@ type AutoPromoteDecision struct {
 	CIStatus       string
 	QuietRemaining time.Duration
 	Findings       []AutoPromoteFinding
+	WorkpadBlocker string
 }
 
 func EvaluateAutoPromote(
@@ -100,6 +103,11 @@ func EvaluateAutoPromote(
 	}
 	if !autoPromoteAllowedIssueLabel(issue, cfg) {
 		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonLabelNotAllowed)
+	}
+	if blocker := autoPromoteWorkpadBlockerReason(issue); blocker != "" {
+		decision := autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonWorkpadBlocker)
+		decision.WorkpadBlocker = blocker
+		return decision
 	}
 	if gateRequiresPullRequest(cfg.Gate) {
 		if autoPromoteMergeConflicts(summary.MergeableState) {
@@ -246,6 +254,179 @@ func artifactStatusFromIssue(issue connector.Issue, statusField string) string {
 		}
 	}
 	return ""
+}
+
+func autoPromoteWorkpadBlockerReason(issue connector.Issue) string {
+	if reason := autoPromoteNormalizeWorkpadBlockerText(issue.BlockerReason); reason != "" {
+		return reason
+	}
+	for index := len(issue.Comments) - 1; index >= 0; index-- {
+		body := issue.Comments[index].Body
+		if !strings.Contains(strings.ToLower(body), "codex workpad") {
+			continue
+		}
+		return autoPromoteWorkpadBlockerReasonFromBody(body)
+	}
+	return ""
+}
+
+func autoPromoteWorkpadBlockerReasonFromBody(body string) string {
+	sectionFound := false
+	for _, title := range []string{"Human Action Needed", "Blockers"} {
+		text, ok := autoPromoteMarkdownSectionText(body, title)
+		if !ok {
+			continue
+		}
+		sectionFound = true
+		if reason := autoPromoteNormalizeWorkpadBlockerText(text); reason != "" {
+			return reason
+		}
+	}
+	if sectionFound {
+		return ""
+	}
+	return autoPromoteWorkpadBlockerPhraseReason(body)
+}
+
+func autoPromoteWorkpadBlockerPhraseReason(body string) string {
+	for line := range strings.SplitSeq(body, "\n") {
+		if _, ok := autoPromoteMarkdownHeadingTitle(line); ok {
+			continue
+		}
+		line = autoPromoteNormalizeWorkpadLine(line)
+		if line == "" || autoPromoteWorkpadNonBlockerLine(line) {
+			continue
+		}
+		lower := strings.ToLower(line)
+		for _, phrase := range []string{
+			"human action needed",
+			"human approval",
+			"owner approval",
+			"owner listening approval",
+			"still required",
+			"still needed",
+			"still needs",
+			"required before",
+			"waiting for",
+			"blocked by:",
+			"depends on:",
+			"cannot proceed",
+			"cannot continue",
+		} {
+			if strings.Contains(lower, phrase) {
+				return line
+			}
+		}
+	}
+	return ""
+}
+
+func autoPromoteMarkdownSectionText(body string, title string) (string, bool) {
+	want := autoPromoteNormalizeSectionTitle(title)
+	inSection := false
+	found := false
+	lines := []string{}
+	for line := range strings.SplitSeq(body, "\n") {
+		heading, ok := autoPromoteMarkdownHeadingTitle(line)
+		if ok {
+			if inSection {
+				break
+			}
+			inSection = autoPromoteNormalizeSectionTitle(heading) == want
+			if inSection {
+				found = true
+			}
+			continue
+		}
+		if inSection {
+			lines = append(lines, line)
+		}
+	}
+	return strings.Join(lines, "\n"), found
+}
+
+func autoPromoteMarkdownHeadingTitle(line string) (string, bool) {
+	line = strings.TrimSpace(line)
+	if line == "" || line[0] != '#' {
+		return "", false
+	}
+	index := 0
+	for index < len(line) && line[index] == '#' {
+		index++
+	}
+	if index > 6 || index == len(line) {
+		return "", false
+	}
+	if line[index] != ' ' && line[index] != '\t' {
+		return "", false
+	}
+	return strings.Trim(strings.TrimSpace(line[index:]), "# \t"), true
+}
+
+func autoPromoteNormalizeSectionTitle(title string) string {
+	return strings.ToLower(strings.Join(strings.Fields(title), " "))
+}
+
+func autoPromoteNormalizeWorkpadBlockerText(text string) string {
+	parts := []string{}
+	for line := range strings.SplitSeq(text, "\n") {
+		line = autoPromoteNormalizeWorkpadLine(line)
+		if line == "" || autoPromoteWorkpadNonBlockerLine(line) {
+			continue
+		}
+		parts = append(parts, line)
+	}
+	return strings.Join(parts, "; ")
+}
+
+func autoPromoteNormalizeWorkpadLine(line string) string {
+	line = strings.TrimSpace(line)
+	line = strings.TrimPrefix(line, ">")
+	line = strings.TrimSpace(line)
+	for _, marker := range []string{"- ", "* ", "+ "} {
+		if after, ok := strings.CutPrefix(line, marker); ok {
+			line = strings.TrimSpace(after)
+			break
+		}
+	}
+	for _, marker := range []string{"[ ] ", "[x] ", "[X] "} {
+		if after, ok := strings.CutPrefix(line, marker); ok {
+			line = strings.TrimSpace(after)
+			break
+		}
+	}
+	if index := autoPromoteNumberedListMarkerEnd(line); index > 0 {
+		line = strings.TrimSpace(line[index:])
+	}
+	return strings.Join(strings.Fields(line), " ")
+}
+
+func autoPromoteNumberedListMarkerEnd(line string) int {
+	index := 0
+	for index < len(line) && line[index] >= '0' && line[index] <= '9' {
+		index++
+	}
+	if index == 0 || index >= len(line) {
+		return 0
+	}
+	if line[index] != '.' && line[index] != ')' {
+		return 0
+	}
+	if index+1 < len(line) && line[index+1] != ' ' && line[index+1] != '\t' {
+		return 0
+	}
+	return index + 1
+}
+
+func autoPromoteWorkpadNonBlockerLine(line string) bool {
+	line = strings.Trim(strings.ToLower(strings.TrimSpace(line)), ".:; ")
+	switch line {
+	case "", "none", "none currently", "n/a", "na", "not applicable", "nothing", "nothing currently",
+		"no blockers", "no known blockers", "no unresolved blockers", "no human action needed":
+		return true
+	default:
+		return false
+	}
 }
 
 func gateFindings(findings []AutoPromoteFinding) []gate.Finding {

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -156,6 +156,81 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
+			name: "workpad blocker awaits review",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-workpad-blocker", nil)
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Blockers\n- Gate A/B/C owner listening approval is still required before approved audio assets are copied and committed.",
+				}}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				OptoutLabel:   "requires-human-review",
+				Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonWorkpadBlocker,
+			},
+		},
+		{
+			name: "workpad no blocker promotes",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-workpad-no-blocker", nil)
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Blockers\n- None currently.\n\n### Validation\n- make check passed.",
+				}}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				OptoutLabel:   "requires-human-review",
+				Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+		{
+			name: "workpad blocker phrase awaits review",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-workpad-blocker-phrase", nil)
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Notes\n- Owner listening approval is still required before approved audio assets are copied and committed.",
+				}}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				OptoutLabel:   "requires-human-review",
+				Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonWorkpadBlocker,
+			},
+		},
+		{
 			name:  "P1 findings move to rework",
 			issue: autoPromoteTestIssue("issue-p1", nil),
 			cfg:   enabled,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -87,6 +87,9 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 			o.logAutoPromoteDecision(issue, autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen), "")
 			continue
 		}
+		if decision.Action == AutoPromoteActionPromote {
+			issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, cfg, now)
+		}
 		targetState := autoPromoteTargetState(decision.Action, cfg)
 		if targetState == "" {
 			o.logAutoPromoteDecision(issue, decision, "")
@@ -111,6 +114,31 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 	return result
 }
 
+func (o *Orchestrator) hydrateAutoPromoteWorkpadDecision(
+	ctx context.Context,
+	issue connector.Issue,
+	summary AutoPromoteSummary,
+	cfg AutoPromoteConfig,
+	now time.Time,
+) (connector.Issue, AutoPromoteDecision) {
+	if len(issue.Comments) == 0 && strings.TrimSpace(issue.BlockerReason) == "" {
+		reader, ok := o.connector.(connector.IssueCommentReader)
+		if !ok {
+			return issue, EvaluateAutoPromote(issue, summary, cfg, now)
+		}
+		comments, err := reader.FetchIssueComments(ctx, issue)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn("fetch auto-promote workpad comments failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+			}
+			return issue, autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonWorkpadHydrationUnavailable)
+		}
+		issue = cloneIssue(issue)
+		issue.Comments = comments
+	}
+	return issue, EvaluateAutoPromote(issue, summary, cfg, now)
+}
+
 func (o *Orchestrator) reconcileStaleTodoPullRequestIssues(
 	ctx context.Context,
 	state *State,
@@ -132,6 +160,9 @@ func (o *Orchestrator) reconcileStaleTodoPullRequestIssues(
 			continue
 		}
 		decision := staleTodoPullRequestDecision(issue, summary, o.cfg.AutoPromote, now)
+		if decision.Action == AutoPromoteActionPromote {
+			issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, o.cfg.AutoPromote, now)
+		}
 		targetState := staleTodoPullRequestTargetState(decision, o.cfg.AutoPromote)
 		if targetState == "" {
 			o.logAutoPromoteDecision(issue, decision, "")
@@ -829,6 +860,9 @@ func (o *Orchestrator) logStaleTodoPullRequestDecision(issue connector.Issue, de
 		if mergeableState := strings.TrimSpace(issue.PullRequest.MergeableState); mergeableState != "" {
 			attrs = append(attrs, "mergeable_state", strings.ToLower(mergeableState))
 		}
+	}
+	if decision.WorkpadBlocker != "" {
+		attrs = append(attrs, "workpad_blocker", decision.WorkpadBlocker)
 	}
 	o.logger.Info("stale_todo_pr_reconciled", attrs...)
 }
@@ -1588,6 +1622,9 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 	}
 	if decision.QuietRemaining > 0 {
 		attrs = append(attrs, "quiet_remaining", decision.QuietRemaining)
+	}
+	if decision.WorkpadBlocker != "" {
+		attrs = append(attrs, "workpad_blocker", decision.WorkpadBlocker)
 	}
 	if targetState != "" {
 		attrs = append(attrs, "target_state", targetState)

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -319,6 +319,65 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 	}
 }
 
+func TestTickAutoPromoteHydratesWorkpadBlockerBeforeTransition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 6, 15, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-workpad-blocker", []string{"bug"}, &connector.PullRequest{
+		Number:                 185,
+		URL:                    "https://github.test/digitaldrywood/creswoodcorners-phone/pull/185",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "pass",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{
+		stateIssues: []connector.Issue{issue},
+		issueComments: map[string][]connector.IssueComment{
+			issue.ID: {{
+				Body: "## Codex Workpad\n\n### Blockers\n- no generated seasonal MP3s were copied into `assets/audio/`\n- Gate A/B/C owner listening approval is still required before approved audio assets are copied and committed",
+			}},
+		},
+	}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no transition while Workpad blocker is present", tracker.updates)
+	}
+	if got, want := tracker.fetchComments, []string{issue.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FetchIssueComments issue IDs = %#v, want %#v", got, want)
+	}
+	for _, fragment := range []string{
+		"action=await_review",
+		"reason=workpad_blocker",
+		"workpad_blocker=\"no generated seasonal MP3s were copied into `assets/audio/`; Gate A/B/C owner listening approval is still required before approved audio assets are copied and committed\"",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}
+
 func TestTickAutoPromoteBlocksWhenReworkLimitReached(t *testing.T) {
 	t.Parallel()
 
@@ -897,6 +956,80 @@ func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 		"stale_todo_pr_reconciled",
 		"reason=ready",
 		"reason=merge_conflicts",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}
+
+func TestTickReconcilesStaleTodoHydratesWorkpadBlockerBeforePromotion(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 6, 16, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-stale-todo-workpad-blocker", []string{"bug"}, &connector.PullRequest{
+		Number:                 180,
+		URL:                    "https://github.test/digitaldrywood/creswoodcorners-phone/pull/180",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "pass",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	issue.State = "Todo"
+	issue.Identifier = "digitaldrywood/creswoodcorners-phone#175"
+	tracker := &autoPromoteTickConnector{
+		stateIssues: []connector.Issue{issue},
+		issueComments: map[string][]connector.IssueComment{
+			issue.ID: {{
+				Body: "## Codex Workpad\n\n### Blockers\n- Gate A/B/C owner listening approval is still required before approved audio assets are copied and committed.",
+			}},
+		},
+	}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+
+	state := newState(cfg)
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Human Review"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if got, want := tracker.fetchComments, []string{issue.ID}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FetchIssueComments issue IDs = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one stale Todo reconciliation comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Reconciled this issue from Todo to Human Review because it already has a linked PR.",
+		"reason: workpad_blocker",
+		"https://github.test/digitaldrywood/creswoodcorners-phone/pull/180",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	for _, fragment := range []string{
+		"reason=workpad_blocker",
+		"target_state=\"Human Review\"",
+		"workpad_blocker=\"Gate A/B/C owner listening approval is still required before approved audio assets are copied and committed.\"",
 	} {
 		if !strings.Contains(logs.String(), fragment) {
 			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
@@ -3346,6 +3479,8 @@ type autoPromoteTickConnector struct {
 	candidateIssuesSet    bool
 	candidateByStates     [][]string
 	fetchByStatesRequests [][]string
+	fetchComments         []string
+	issueComments         map[string][]connector.IssueComment
 	updates               []autoPromoteTickUpdate
 	comments              []autoPromoteTickComment
 	prComments            []autoPromoteTickComment
@@ -3391,6 +3526,11 @@ func (c *autoPromoteTickConnector) FetchIssuesByStates(_ context.Context, states
 		}
 	}
 	return issues, nil
+}
+
+func (c *autoPromoteTickConnector) FetchIssueComments(_ context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	c.fetchComments = append(c.fetchComments, strings.TrimSpace(issue.ID))
+	return cloneIssueComments(c.issueComments[strings.TrimSpace(issue.ID)]), nil
 }
 
 func (c *autoPromoteTickConnector) FetchIssueStatesByIDs(_ context.Context, ids []string) ([]connector.Issue, error) {


### PR DESCRIPTION
## Summary

- Hold auto-promotion when the latest Codex Workpad records explicit blockers or human action needed.
- Hydrate Workpad comments only for candidates that would otherwise promote from Human Review or stale Todo linked-PR reconciliation, then re-evaluate before transitioning.
- Add regressions for blocking Workpad text, non-blocking `None` blocker sections, scheduler hydration, and stale Todo direct-promotion protection.

Fixes #944

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestEvaluateAutoPromote|TestTickAutoPromoteHydratesWorkpadBlockerBeforeTransition' -count=1`
- [x] `go test ./internal/orchestrator -run 'TestEvaluateAutoPromote|TestTickAutoPromoteHydratesWorkpadBlockerBeforeTransition|TestTickReconcilesStaleTodoHydratesWorkpadBlockerBeforePromotion|TestTickReconcilesStaleTodoLinkedPullRequests' -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/connector/github -run 'TestConnectorFetchIssuesByStatesExtractsWorkpad|TestConnectorFetchIssuesByStatesIgnoresHumanActionIssueMentions' -count=1`
- [x] `make check`