### PR TITLE
docs: add Hyperagent to comparison matrix

### DIFF
--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -4,21 +4,22 @@ We build Detent as a self-hosted, board-native agent orchestrator for software d
 
 ## Feature Matrix
 
-| Capability | Detent | OpenAI Symphony | Copilot agent | Cursor | Hermes | OpenClaw |
-|---|---|---|---|---|---|---|
-| Self-hosted, no vendor control plane | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
-| Runs fully local / air-gappable | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ |
-| Board/tracker-native (issue→PR) | ✅ GH Projects, issue fields, or labels | ✅ Linear | ✅ GH Issues | ❌ | ❌ | ❌ |
-| Deterministic gated merge train | ✅ | 🟡 per spec | ❌ | ❌ | ❌ | ❌ |
-| Budget / cost caps | ✅ | ❌ | 🟡 | 🟡 | ❌ | ❌ |
-| Multi-project | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ |
-| Multi-instance fleet governance | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ |
-| Model-agnostic, BYO incl. local | 🟡 codex now, seam shipped | ❌ Codex | ✅ vendor-managed | ✅ vendor-managed | ✅ | ✅ |
-| Local skills / workflows (your e2e etc.) | ✅ | 🟡 | ❌ | 🟡 | ✅ | ✅ |
-| Open source | ✅ MIT | ✅ Apache-2.0 | ❌ | ❌ | ✅ MIT | ✅ MIT |
-| Free (BYO model cost) | ✅ | ✅ | ❌ paid | ❌ paid | ✅ | ✅ |
-| Single static binary | ✅ | ❌ Elixir/BEAM | — SaaS | — SaaS | ❌ gateway | ❌ gateway |
-| ~5-min setup | ✅ | ❌ | ✅ zero-install | ✅ | 🟡 | 🟡 |
+| Capability | Detent | OpenAI Symphony | Copilot agent | Cursor | Hermes | OpenClaw | Hyperagent |
+|---|---|---|---|---|---|---|---|
+| Self-hosted, no vendor control plane | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ hosted |
+| Runs fully local / air-gappable | ✅ | ✅ | ❌ | ❌ | ✅ | ✅ | ❌ cloud |
+| Board/tracker-native (issue→PR) | ✅ GH Projects, issue fields, or labels | ✅ Linear | ✅ GH Issues | ❌ | ❌ | ❌ | ❌ own workspace |
+| Deterministic gated merge train | ✅ | 🟡 per spec | ❌ | ❌ | ❌ | ❌ | ❌ |
+| Budget / cost caps | ✅ | ❌ | 🟡 | 🟡 | ❌ | ❌ | ✅ hosted controls |
+| Multi-project | ✅ | ❌ | ✅ | ✅ | ❌ | ❌ | 🟡 workspace-scoped |
+| Multi-instance fleet governance | ✅ | ❌ | ❌ | ❌ | ❌ | ❌ | 🟡 hosted agent controls |
+| Model-agnostic, BYO incl. local | 🟡 codex now, seam shipped | ❌ Codex | ✅ vendor-managed | ✅ vendor-managed | ✅ | ✅ | ❌ cloud-managed |
+| Local skills / workflows (your e2e etc.) | ✅ | 🟡 | ❌ | 🟡 | ✅ | ✅ | ✅ hosted skills/knowledge |
+| Multi-channel triggers | 🟡 tracker-driven | 🟡 Linear | 🟡 GitHub | 🟡 IDE/cloud tasks | ✅ messaging gateway | ✅ local gateway | ✅ Slack, schedules, webhooks, email, Telegram, Live Mode |
+| Open source | ✅ MIT | ✅ Apache-2.0 | ❌ | ❌ | ✅ MIT | ✅ MIT | ❌ closed-source |
+| Free (BYO model cost) | ✅ | ✅ | ❌ paid | ❌ paid | ✅ | ✅ | ❌ usage-billed |
+| Single static binary | ✅ | ❌ Elixir/BEAM | — SaaS | — SaaS | ❌ gateway | ❌ gateway | — SaaS |
+| ~5-min setup | ✅ | ❌ | ✅ zero-install | ✅ | 🟡 | 🟡 | 🟡 hosted onboarding |
 
 ## What Each One Is
 
@@ -28,9 +29,10 @@ We build Detent as a self-hosted, board-native agent orchestrator for software d
 - **Cursor**: [Cursor cloud agents](https://cursor.com/cloud) is an IDE-first agent product with cloud/background agents, automations, and optional self-hosted workers.
 - **Hermes**: [NousResearch/hermes-agent](https://github.com/NousResearch/hermes-agent) is Nous's MIT personal assistant with memory, skills, model providers, and messaging gateway.
 - **OpenClaw**: [openclaw/openclaw](https://github.com/openclaw/openclaw) is an MIT personal assistant centered on a local gateway and cross-channel automation.
+- **Hyperagent**: [Hyperagent](https://www.hyperagent.com/) is Airtable's closed-source, cloud-hosted agent OS / enterprise teammate platform ([confirmed by Browserbase](https://www.browserbase.com/blog/case-study-hyperagent)) for persistent agents with identity, tools, skills, knowledge, model/budget controls, multi-channel triggers, and a first-class [Library](https://www.hyperagent.com/docs/concepts/library) for artifacts.
 
 ## Where We're Different
 
 We own the orchestration loop: no Detent vendor control plane, GitHub-native status sources, Detent's own Kanban board, deterministic gates, and a serialized merge train. We also care about operating fleets, not just launching one agent: multi-instance ownership, budget checks, local skills, and a single static binary with a setup path we expect to be measured in minutes. Copilot and Cursor have closed much of the "runs near my code" gap and win zero-install inside their platforms, but they do not give us the same board-native release runtime under our control.
 
-_Last updated: June 19, 2026; verify vendor pricing/models before relying on them._
+_Last updated: July 6, 2026; verify vendor pricing/models before relying on them._


### PR DESCRIPTION
## Summary

- Add Hyperagent to the comparison matrix with hosted, cloud, cost, source, skills, and trigger contrasts.
- Add a Hyperagent description with links to product docs and Browserbase confirmation of the Airtable relationship.

Fixes #929

## Test Plan

- [x] `make check`
