### PR TITLE
feat: add shared prompt knowledge

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,9 +41,10 @@ const (
 	defaultLinearEndpoint = "https://api.linear.app/graphql"
 	defaultGitHubEndpoint = "https://api.github.com/graphql"
 
-	DefaultAgentBackendID  = "codex"
-	AgentBackendCodex      = "codex"
-	AgentBackendClaudeCode = "claude_code"
+	DefaultAgentBackendID    = "codex"
+	AgentBackendCodex        = "codex"
+	AgentBackendClaudeCode   = "claude_code"
+	DefaultKnowledgeMaxBytes = 64 * 1024
 
 	DefaultPollingIntervalMS      = 120000
 	MinPollingIntervalMS          = 60000
@@ -203,6 +204,7 @@ type Agent struct {
 	AutoPromote                  AutoPromote    `yaml:"auto_promote"`
 	Budget                       Budget         `yaml:"budget"`
 	Lessons                      Lessons        `yaml:"lessons"`
+	Knowledge                    Knowledge      `yaml:"knowledge"`
 	Skills                       Skills         `yaml:"skills"`
 }
 
@@ -285,6 +287,18 @@ type Lessons struct {
 	MaxEntries          int    `yaml:"max_entries"`
 	RecallN             int    `yaml:"recall_n"`
 	PostmortemMaxTokens int    `yaml:"postmortem_max_tokens"`
+}
+
+type Knowledge struct {
+	Enabled    bool              `yaml:"enabled"`
+	MaxBytes   int               `yaml:"max_bytes"`
+	Sources    []KnowledgeSource `yaml:"sources"`
+	Configured bool              `yaml:"-"`
+}
+
+type KnowledgeSource struct {
+	Name string `yaml:"name,omitempty"`
+	Path string `yaml:"path"`
 }
 
 type Skills struct {
@@ -686,10 +700,12 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 		}
 		normalizeTrackerIDFields(root)
 		gitHubStatusSourceSet := trackerFieldSet(root, "github_status_source")
+		knowledgeConfigured := nestedFieldSet(root, "agent", "knowledge")
 		if err := root.Decode(&cfg); err != nil {
 			return Workflow{}, fmt.Errorf("decode YAML frontmatter: %w", err)
 		}
 		cfg.Tracker.gitHubStatusSourceSet = gitHubStatusSourceSet
+		cfg.Agent.Knowledge.Configured = knowledgeConfigured
 	}
 
 	cfg.normalize()
@@ -764,9 +780,10 @@ func Default() Config {
 				PassState:          "Merging",
 				ReworkState:        "Rework",
 			},
-			Budget:  budget,
-			Lessons: defaultLessons(),
-			Skills:  defaultSkills(),
+			Budget:    budget,
+			Lessons:   defaultLessons(),
+			Knowledge: defaultKnowledge(),
+			Skills:    defaultSkills(),
 		},
 		Codex: Codex{
 			Command: "codex app-server",
@@ -980,6 +997,7 @@ func (c *Config) normalize() {
 	if c.Agent.AutoPromote.ReworkState == "" {
 		c.Agent.AutoPromote.ReworkState = "Rework"
 	}
+	c.Agent.Knowledge.Normalize()
 	c.Agents.normalize()
 	c.Codex.Shell = commandshell.Normalize(c.Codex.Shell)
 	c.Gate = gate.Effective(c.Gate)
@@ -1220,6 +1238,7 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	a.AutoPromote.validate(prefix+".auto_promote", problems)
 	a.Budget.validate(prefix+".budget", problems)
 	a.Lessons.validate(prefix+".lessons", problems)
+	a.Knowledge.validate(prefix+".knowledge", problems)
 	a.Skills.validate(prefix+".skills", problems)
 }
 
@@ -1441,6 +1460,55 @@ func (l *Lessons) validate(prefix string, problems *[]string) {
 	validatePositive(prefix+".postmortem_max_tokens", l.PostmortemMaxTokens, problems)
 }
 
+func (k *Knowledge) Normalize() {
+	if k == nil {
+		return
+	}
+	if (k.Enabled || len(k.Sources) > 0) && k.MaxBytes <= 0 {
+		k.MaxBytes = DefaultKnowledgeMaxBytes
+	}
+	for index := range k.Sources {
+		k.Sources[index].Name = strings.Join(strings.Fields(k.Sources[index].Name), " ")
+		k.Sources[index].Path = strings.TrimSpace(k.Sources[index].Path)
+	}
+}
+
+func (k Knowledge) validate(prefix string, problems *[]string) {
+	if k.Enabled || len(k.Sources) > 0 {
+		validatePositive(prefix+".max_bytes", k.MaxBytes, problems)
+	}
+	for index, source := range k.Sources {
+		sourcePrefix := prefix + ".sources[" + strconv.Itoa(index) + "]"
+		if strings.TrimSpace(source.Path) == "" {
+			*problems = append(*problems, sourcePrefix+".path must not be blank")
+		}
+		if strings.ContainsAny(source.Name, "\r\n") {
+			*problems = append(*problems, sourcePrefix+".name must be a single line")
+		}
+		if strings.ContainsAny(source.Path, "\r\n") {
+			*problems = append(*problems, sourcePrefix+".path must be a single line")
+		}
+	}
+}
+
+func KnowledgeWithSources(scopes ...Knowledge) Knowledge {
+	out := defaultKnowledge()
+	out.Sources = nil
+	for _, scope := range scopes {
+		if !scope.Enabled {
+			continue
+		}
+		scope.Normalize()
+		if len(scope.Sources) > 0 {
+			out.Sources = append(out.Sources, scope.Sources...)
+		}
+		if scope.Configured || len(scope.Sources) > 0 {
+			out.MaxBytes = scope.MaxBytes
+		}
+	}
+	return out
+}
+
 func (s *Skills) validate(prefix string, problems *[]string) {
 	validateWorkspaceRelativePath(prefix+".path", s.Path, problems)
 	validatePositive(prefix+".max_skills_in_prompt", s.MaxSkillsInPrompt, problems)
@@ -1645,6 +1713,17 @@ func trackerFieldSet(root *yaml.Node, key string) bool {
 	return mappingValue(tracker, key) != nil
 }
 
+func nestedFieldSet(root *yaml.Node, keys ...string) bool {
+	current := root
+	for _, key := range keys {
+		if current == nil || current.Kind != yaml.MappingNode {
+			return false
+		}
+		current = mappingValue(current, key)
+	}
+	return current != nil
+}
+
 func mappingValue(node *yaml.Node, key string) *yaml.Node {
 	if node.Kind != yaml.MappingNode {
 		return nil
@@ -1762,6 +1841,13 @@ func defaultLessons() Lessons {
 		MaxEntries:          50,
 		RecallN:             10,
 		PostmortemMaxTokens: 1024,
+	}
+}
+
+func defaultKnowledge() Knowledge {
+	return Knowledge{
+		Enabled:  true,
+		MaxBytes: DefaultKnowledgeMaxBytes,
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -115,6 +115,12 @@ agent:
     max_entries: 5
     recall_n: 2
     postmortem_max_tokens: 256
+  knowledge:
+    enabled: true
+    max_bytes: 2048
+    sources:
+      - name: Team standards
+        path: ../knowledge/team.md
   skills:
     enabled: true
     path: ".detent/skills"
@@ -304,6 +310,18 @@ Ticket prompt {{ issue.title }}
 	}
 	if !cfg.Agent.ExperimentalThreadResume {
 		t.Fatal("Agent.ExperimentalThreadResume = false, want true")
+	}
+	if !cfg.Agent.Knowledge.Enabled {
+		t.Fatal("Agent.Knowledge.Enabled = false, want true")
+	}
+	if cfg.Agent.Knowledge.MaxBytes != 2048 {
+		t.Fatalf("Agent.Knowledge.MaxBytes = %d, want 2048", cfg.Agent.Knowledge.MaxBytes)
+	}
+	if len(cfg.Agent.Knowledge.Sources) != 1 {
+		t.Fatalf("Agent.Knowledge.Sources len = %d, want 1", len(cfg.Agent.Knowledge.Sources))
+	}
+	if source := cfg.Agent.Knowledge.Sources[0]; source.Name != "Team standards" || source.Path != "../knowledge/team.md" {
+		t.Fatalf("Agent.Knowledge.Sources[0] = %#v, want team standards source", source)
 	}
 	if !cfg.Agent.Skills.Creation.Enabled {
 		t.Fatal("Agent.Skills.Creation.Enabled = false, want true")
@@ -602,6 +620,15 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if cfg.Agent.Skills.Path != ".detent/skills" {
 		t.Fatalf("Agent.Skills.Path = %q", cfg.Agent.Skills.Path)
 	}
+	if !cfg.Agent.Knowledge.Enabled {
+		t.Fatal("Agent.Knowledge.Enabled = false, want true default")
+	}
+	if cfg.Agent.Knowledge.MaxBytes != DefaultKnowledgeMaxBytes {
+		t.Fatalf("Agent.Knowledge.MaxBytes = %d, want %d", cfg.Agent.Knowledge.MaxBytes, DefaultKnowledgeMaxBytes)
+	}
+	if len(cfg.Agent.Knowledge.Sources) != 0 {
+		t.Fatalf("Agent.Knowledge.Sources = %#v, want empty default", cfg.Agent.Knowledge.Sources)
+	}
 	if !cfg.Agent.Skills.Creation.Enabled {
 		t.Fatal("Agent.Skills.Creation.Enabled = false, want true default")
 	}
@@ -643,6 +670,57 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Plan.Enabled || cfg.Plan.Review != gate.PlanReviewHuman || cfg.Plan.ApprovalLabel != gate.DefaultPlanApprovalLabel || cfg.Plan.Stop != gate.DefaultPlanStop {
 		t.Fatalf("Plan = %#v, want disabled human review plan default", cfg.Plan)
+	}
+}
+
+func TestParseWorkflowMarksAgentKnowledgeConfigured(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+agent:
+  knowledge:
+    max_bytes: 2048
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+
+	if !workflow.Config.Agent.Knowledge.Configured {
+		t.Fatal("Agent.Knowledge.Configured = false, want true")
+	}
+	if workflow.Config.Agent.Knowledge.MaxBytes != 2048 {
+		t.Fatalf("Agent.Knowledge.MaxBytes = %d, want 2048", workflow.Config.Agent.Knowledge.MaxBytes)
+	}
+}
+
+func TestKnowledgeWithSourcesAllowsSourceLessMaxBytesOverride(t *testing.T) {
+	t.Parallel()
+
+	workflowDefault := defaultKnowledge()
+	got := KnowledgeWithSources(
+		Knowledge{
+			Enabled:  true,
+			MaxBytes: 4096,
+			Sources: []KnowledgeSource{{
+				Name: "Global",
+				Path: "global.md",
+			}},
+		},
+		Knowledge{
+			Enabled:    true,
+			MaxBytes:   1024,
+			Configured: true,
+		},
+		workflowDefault,
+	)
+
+	if got.MaxBytes != 1024 {
+		t.Fatalf("MaxBytes = %d, want 1024", got.MaxBytes)
+	}
+	if len(got.Sources) != 1 || got.Sources[0].Path != "global.md" {
+		t.Fatalf("Sources = %#v, want inherited global source", got.Sources)
 	}
 }
 
@@ -1826,6 +1904,9 @@ tracker:
 agent:
   lessons:
     path: ../lessons.md
+  knowledge:
+    sources:
+      - path: ""
   skills:
     path: /tmp/skills
     creation:
@@ -1837,6 +1918,7 @@ Prompt
 				"tracker.priority_map option names must not be blank",
 				"tracker.priority_map ranks must be integers 1 through 4 or null",
 				"agent.lessons.path must be a relative path inside the workspace",
+				"agent.knowledge.sources[0].path must not be blank",
 				"agent.skills.path must be a relative path inside the workspace",
 				"agent.skills.creation.max_drafts_per_run must be greater than 0",
 			},

--- a/internal/config/global/config.go
+++ b/internal/config/global/config.go
@@ -74,25 +74,30 @@ type Settings struct {
 	MaxConcurrentAgents int            `yaml:"max_concurrent_agents"`
 	Scheduling          string         `yaml:"scheduling"`
 	Identity            Identity       `yaml:"identity,omitempty"`
+	Knowledge           Knowledge      `yaml:"knowledge,omitempty"`
 	FairShare           map[string]any `yaml:"fair_share,omitempty"`
 	Startup             map[string]any `yaml:"startup,omitempty"`
 }
 
 type Project struct {
-	ID            string            `yaml:"id"`
-	Workflow      string            `yaml:"workflow"`
-	WorkflowRef   string            `yaml:"workflow_ref,omitempty"`
-	Workdir       string            `yaml:"workdir"`
-	Color         string            `yaml:"color,omitempty"`
-	Weight        int               `yaml:"weight"`
-	Priority      int               `yaml:"priority"`
-	Paused        bool              `yaml:"paused,omitempty"`
-	CredentialRef string            `yaml:"credential_ref,omitempty"`
-	Authorization selector.Selector `yaml:"authorization,omitempty"`
-	Identity      Identity          `yaml:"-"`
+	ID              string            `yaml:"id"`
+	Workflow        string            `yaml:"workflow"`
+	WorkflowRef     string            `yaml:"workflow_ref,omitempty"`
+	Workdir         string            `yaml:"workdir"`
+	Color           string            `yaml:"color,omitempty"`
+	Knowledge       Knowledge         `yaml:"knowledge,omitempty"`
+	Weight          int               `yaml:"weight"`
+	Priority        int               `yaml:"priority"`
+	Paused          bool              `yaml:"paused,omitempty"`
+	CredentialRef   string            `yaml:"credential_ref,omitempty"`
+	Authorization   selector.Selector `yaml:"authorization,omitempty"`
+	Identity        Identity          `yaml:"-"`
+	GlobalKnowledge Knowledge         `yaml:"-"`
 }
 
 type Identity = workflowconfig.Identity
+type Knowledge = workflowconfig.Knowledge
+type KnowledgeSource = workflowconfig.KnowledgeSource
 
 type Option func(*options)
 
@@ -716,6 +721,7 @@ func globalErrors(value any) []string {
 	problems = append(problems, schedulingErrors(global["scheduling"])...)
 	problems = append(problems, optionalMapErrors(global, "identity")...)
 	problems = append(problems, identityErrors(global["identity"], "global.identity")...)
+	problems = append(problems, knowledgeErrors(global["knowledge"], "global.knowledge")...)
 	problems = append(problems, optionalMapErrors(global, "fair_share")...)
 	problems = append(problems, optionalMapErrors(global, "startup")...)
 
@@ -810,6 +816,7 @@ func projectErrors(value any, index int, opts options) []string {
 	problems = append(problems, positiveIntegerError(project["weight"], prefix+".weight")...)
 	problems = append(problems, integerError(project["priority"], prefix+".priority")...)
 	problems = append(problems, pausedErrors(project, prefix)...)
+	problems = append(problems, knowledgeErrors(project["knowledge"], prefix+".knowledge")...)
 	problems = append(problems, credentialRefErrors(project, prefix)...)
 	problems = append(problems, authorizationErrors(project["authorization"], prefix+".authorization")...)
 
@@ -830,6 +837,53 @@ func identityErrors(value any, prefix string) []string {
 	}
 	identity.Normalize()
 	return identity.Validate(prefix)
+}
+
+func knowledgeErrors(value any, prefix string) []string {
+	if value == nil {
+		return nil
+	}
+	knowledge, ok := value.(map[string]any)
+	if !ok {
+		return []string{prefix + ": must be a mapping"}
+	}
+
+	var problems []string
+	if enabled, ok := knowledge["enabled"]; ok {
+		if _, ok := enabled.(bool); !ok {
+			problems = append(problems, prefix+".enabled: must be a boolean")
+		}
+	}
+	if maxBytes, ok := knowledge["max_bytes"]; ok && !positiveInteger(maxBytes) {
+		problems = append(problems, prefix+".max_bytes: must be a positive integer")
+	}
+	if sources, ok := knowledge["sources"]; ok {
+		problems = append(problems, knowledgeSourceErrors(sources, prefix+".sources")...)
+	}
+	return problems
+}
+
+func knowledgeSourceErrors(value any, prefix string) []string {
+	sources, ok := value.([]any)
+	if !ok {
+		return []string{prefix + ": must be a list"}
+	}
+
+	var problems []string
+	for index, item := range sources {
+		source, ok := item.(map[string]any)
+		sourcePrefix := fmt.Sprintf("%s[%d]", prefix, index)
+		if !ok {
+			problems = append(problems, sourcePrefix+": must be a mapping")
+			continue
+		}
+		problems = append(problems, prefixErrors(requiredErrors(source, []string{"path"}), sourcePrefix)...)
+		problems = append(problems, stringErrors(source, "name", sourcePrefix)...)
+		problems = append(problems, singleLineStringErrors(source, "name", sourcePrefix)...)
+		problems = append(problems, stringErrors(source, "path", sourcePrefix)...)
+		problems = append(problems, singleLineStringErrors(source, "path", sourcePrefix)...)
+	}
+	return problems
 }
 
 func authorizationErrors(value any, prefix string) []string {
@@ -1184,7 +1238,7 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
-	settings, err := buildSettings(global)
+	settings, err := buildSettings(global, opts)
 	if err != nil {
 		return Config{}, buildValidationError(path, err)
 	}
@@ -1210,7 +1264,7 @@ func build(attrs map[string]any, path string, opts options) (Config, error) {
 	}, nil
 }
 
-func buildSettings(attrs map[string]any) (Settings, error) {
+func buildSettings(attrs map[string]any, opts options) (Settings, error) {
 	settings := defaultSettings()
 	maxConcurrentAgents, err := intValue(attrs["max_concurrent_agents"], "global.max_concurrent_agents")
 	if err != nil {
@@ -1232,10 +1286,15 @@ func buildSettings(attrs map[string]any) (Settings, error) {
 	if err != nil {
 		return Settings{}, err
 	}
+	knowledge, err := buildKnowledge(attrs["knowledge"], "global.knowledge", opts)
+	if err != nil {
+		return Settings{}, err
+	}
 
 	settings.MaxConcurrentAgents = maxConcurrentAgents
 	settings.Scheduling = scheduling
 	settings.Identity = identity
+	settings.Knowledge = knowledge
 	settings.FairShare = fairShare
 	settings.Startup = startup
 	return settings, nil
@@ -1313,6 +1372,10 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 		if err != nil {
 			return nil, err
 		}
+		knowledge, err := buildKnowledge(project["knowledge"], prefix+".knowledge", opts)
+		if err != nil {
+			return nil, err
+		}
 
 		out = append(out, Project{
 			ID:            strings.TrimSpace(id),
@@ -1320,6 +1383,7 @@ func buildProjects(projects []any, opts options) ([]Project, error) {
 			WorkflowRef:   strings.TrimSpace(workflowRef),
 			Workdir:       workdir,
 			Color:         color,
+			Knowledge:     knowledge,
 			Weight:        weight,
 			Priority:      priority,
 			Paused:        paused,
@@ -1346,6 +1410,39 @@ func buildIdentity(value any, field string) (Identity, error) {
 		return Identity{}, errors.New(strings.Join(problems, "; "))
 	}
 	return identity, nil
+}
+
+func buildKnowledge(value any, field string, opts options) (Knowledge, error) {
+	if value == nil {
+		return Knowledge{}, nil
+	}
+	if _, err := mapValue(value, field); err != nil {
+		return Knowledge{}, err
+	}
+
+	knowledge := Knowledge{
+		Enabled:    true,
+		MaxBytes:   workflowconfig.DefaultKnowledgeMaxBytes,
+		Configured: true,
+	}
+	if err := decodeYAMLValue(value, &knowledge); err != nil {
+		return Knowledge{}, fmt.Errorf("%s: %w", field, err)
+	}
+	if !opts.projectPathLiterals {
+		for index := range knowledge.Sources {
+			path := strings.TrimSpace(knowledge.Sources[index].Path)
+			if path == "" {
+				continue
+			}
+			expanded, err := expandPath(path, opts)
+			if err != nil {
+				return Knowledge{}, fmt.Errorf("%s.sources[%d].path: expand path: %w", field, index, err)
+			}
+			knowledge.Sources[index].Path = expanded
+		}
+	}
+	knowledge.Normalize()
+	return knowledge, nil
 }
 
 func buildAuthorization(value any, field string) (selector.Selector, error) {

--- a/internal/config/global/config_test.go
+++ b/internal/config/global/config_test.go
@@ -661,6 +661,53 @@ projects:
 	}
 }
 
+func TestReadParsesKnowledgeWithoutRequiringFiles(t *testing.T) {
+	paths := createProjectFiles(t)
+	configPath := filepath.Join(paths.root, "global.yaml")
+	writeFile(t, configPath, `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  knowledge:
+    max_bytes: 1024
+    sources:
+      - name: Global standards
+        path: ~/detent-knowledge/global.md
+projects:
+  - id: detent
+    workflow: `+paths.workflow+`
+    workdir: `+paths.workdir+`
+    weight: 5
+    priority: 50
+    knowledge:
+      sources:
+        - name: Project standards
+          path: ~/detent-knowledge/project.md
+`)
+
+	cfg, err := Read(configPath, WithHome(paths.home))
+	if err != nil {
+		t.Fatalf("Read() error = %v", err)
+	}
+
+	if cfg.Global.Knowledge.MaxBytes != 1024 {
+		t.Fatalf("Global.Knowledge.MaxBytes = %d, want 1024", cfg.Global.Knowledge.MaxBytes)
+	}
+	if len(cfg.Global.Knowledge.Sources) != 1 {
+		t.Fatalf("Global.Knowledge.Sources len = %d, want 1", len(cfg.Global.Knowledge.Sources))
+	}
+	if source := cfg.Global.Knowledge.Sources[0]; source.Name != "Global standards" || source.Path != filepath.Join(paths.home, "detent-knowledge", "global.md") {
+		t.Fatalf("Global.Knowledge.Sources[0] = %#v", source)
+	}
+	if len(cfg.Projects[0].Knowledge.Sources) != 1 {
+		t.Fatalf("Project.Knowledge.Sources len = %d, want 1", len(cfg.Projects[0].Knowledge.Sources))
+	}
+	if source := cfg.Projects[0].Knowledge.Sources[0]; source.Name != "Project standards" || source.Path != filepath.Join(paths.home, "detent-knowledge", "project.md") {
+		t.Fatalf("Project.Knowledge.Sources[0] = %#v", source)
+	}
+}
+
 func TestReadWithProjectPathLiteralsPreservesYAMLLiterals(t *testing.T) {
 	paths := createProjectFiles(t)
 	configPath := filepath.Join(paths.root, "global.yaml")
@@ -907,6 +954,38 @@ projects:
 				"global.identity.name must not be blank",
 				"global.identity.owner_field is required when global.identity.ownership_mode is field",
 				"projects[0].authorization.fields[0].name must not be blank",
+			},
+		},
+		{
+			name: "invalid knowledge",
+			raw: `apiVersion: detent/v1
+kind: GlobalConfig
+global:
+  max_concurrent_agents: 8
+  scheduling: weighted
+  knowledge:
+    enabled: yes
+    max_bytes: 0
+    sources:
+      - name: |-
+          global
+          source
+        path: ""
+projects:
+  - id: detent
+    workflow: ` + paths.workflow + `
+    workdir: ` + paths.workdir + `
+    weight: 5
+    priority: 50
+    knowledge:
+      sources: {}
+`,
+			want: []string{
+				"global.knowledge.enabled: must be a boolean",
+				"global.knowledge.max_bytes: must be a positive integer",
+				"global.knowledge.sources[0].name: must be a single line",
+				"global.knowledge.sources[0].path: must not be blank",
+				"projects[0].knowledge.sources: must be a list",
 			},
 		},
 		{

--- a/internal/knowledge/knowledge.go
+++ b/internal/knowledge/knowledge.go
@@ -1,0 +1,157 @@
+package knowledge
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+const DefaultMaxBytes = 64 * 1024
+
+type Source struct {
+	Name string
+	Path string
+}
+
+type Options struct {
+	MaxBytes int
+}
+
+func BuildBlock(sources []Source, opts Options) (string, error) {
+	maxBytes := maxBytes(opts.MaxBytes)
+	var b strings.Builder
+	wroteDocument := false
+
+	for _, source := range sources {
+		source = normalizeSource(source)
+		if source.Path == "" {
+			continue
+		}
+
+		content, err := readSource(source.Path)
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return "", fmt.Errorf("read shared knowledge %s: %w", source.Path, err)
+		}
+		content = normalizeContent(content)
+		if content == "" {
+			continue
+		}
+
+		if !wroteDocument {
+			b.WriteString("## Team knowledge\n\n")
+			b.WriteString("Shared context supplied by Detent configuration. Treat it as durable team guidance, but verify it against repository, issue, and pull request evidence when they conflict.\n")
+			wroteDocument = true
+		}
+
+		sectionPrefix := "\n### " + sourceTitle(source) + "\n\n_Source: `" + source.Path + "`_\n\n"
+		remaining := maxBytes - b.Len() - len(sectionPrefix) - 1
+		if remaining <= 0 {
+			break
+		}
+
+		if len(content) > remaining {
+			content = head(content, remaining)
+		}
+		if content == "" {
+			break
+		}
+
+		b.WriteString(sectionPrefix)
+		b.WriteString(content)
+		b.WriteString("\n")
+	}
+
+	if !wroteDocument {
+		return "", nil
+	}
+	return strings.TrimRight(b.String(), " \t\r\n"), nil
+}
+
+func readSource(path string) (string, error) {
+	path, err := expandHome(path)
+	if err != nil {
+		return "", err
+	}
+	content, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
+}
+
+func expandHome(path string) (string, error) {
+	switch {
+	case path == "~" || path == "~/":
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return home, nil
+	case strings.HasPrefix(path, "~/"):
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", fmt.Errorf("resolve home directory: %w", err)
+		}
+		return filepath.Join(home, strings.TrimPrefix(path, "~/")), nil
+	default:
+		return path, nil
+	}
+}
+
+func normalizeSource(source Source) Source {
+	source.Name = strings.Join(strings.Fields(source.Name), " ")
+	source.Path = strings.TrimSpace(source.Path)
+	return source
+}
+
+func normalizeContent(content string) string {
+	content = strings.ReplaceAll(content, "\r\n", "\n")
+	content = strings.ReplaceAll(content, "\r", "\n")
+	return strings.TrimSpace(content)
+}
+
+func sourceTitle(source Source) string {
+	if source.Name != "" {
+		return source.Name
+	}
+	base := strings.TrimSpace(filepath.Base(source.Path))
+	if base != "" && base != "." && base != string(filepath.Separator) {
+		return base
+	}
+	return "Shared knowledge"
+}
+
+func head(text string, limit int) string {
+	if limit <= 0 || text == "" {
+		return ""
+	}
+	if len(text) <= limit {
+		return text
+	}
+	marker := "[truncated to first " + limitLabel(limit) + "]\n"
+	remaining := limit - len(marker)
+	if remaining <= 0 {
+		return ""
+	}
+	return marker + text[:remaining]
+}
+
+func limitLabel(limit int) string {
+	if limit >= 1024 && limit%1024 == 0 {
+		return strconv.Itoa(limit/1024) + " KiB"
+	}
+	return strconv.Itoa(limit) + " bytes"
+}
+
+func maxBytes(value int) int {
+	if value <= 0 {
+		return DefaultMaxBytes
+	}
+	return value
+}

--- a/internal/knowledge/knowledge_test.go
+++ b/internal/knowledge/knowledge_test.go
@@ -1,0 +1,94 @@
+package knowledge
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestBuildBlockReadsSourcesInOrderAndIgnoresMissingFiles(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	globalPath := filepath.Join(root, "global.md")
+	projectPath := filepath.Join(root, "project.md")
+	if err := os.WriteFile(globalPath, []byte("Global standard\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(global) error = %v", err)
+	}
+	if err := os.WriteFile(projectPath, []byte("Project rule\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(project) error = %v", err)
+	}
+
+	block, err := BuildBlock([]Source{
+		{Name: "Global", Path: globalPath},
+		{Name: "Missing", Path: filepath.Join(root, "missing.md")},
+		{Name: "Project", Path: projectPath},
+	}, Options{})
+	if err != nil {
+		t.Fatalf("BuildBlock() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"## Team knowledge",
+		"### Global",
+		"Global standard",
+		"### Project",
+		"Project rule",
+	} {
+		if !strings.Contains(block, want) {
+			t.Fatalf("block missing %q:\n%s", want, block)
+		}
+	}
+	if strings.Contains(block, "### Missing") {
+		t.Fatalf("block includes missing source:\n%s", block)
+	}
+	if strings.Index(block, "Global standard") > strings.Index(block, "Project rule") {
+		t.Fatalf("block order = %q, want global before project", block)
+	}
+}
+
+func TestBuildBlockReturnsEmptyForNoReadableKnowledge(t *testing.T) {
+	t.Parallel()
+
+	block, err := BuildBlock([]Source{{Name: "Missing", Path: filepath.Join(t.TempDir(), "missing.md")}}, Options{})
+	if err != nil {
+		t.Fatalf("BuildBlock() error = %v", err)
+	}
+	if block != "" {
+		t.Fatalf("BuildBlock() = %q, want empty", block)
+	}
+}
+
+func TestBuildBlockFailsForUnreadableConfiguredSource(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildBlock([]Source{{Name: "Directory", Path: t.TempDir()}}, Options{})
+	if err == nil {
+		t.Fatal("BuildBlock() error = nil, want error")
+	}
+	if !strings.Contains(err.Error(), "read shared knowledge") {
+		t.Fatalf("BuildBlock() error = %v, want shared knowledge context", err)
+	}
+}
+
+func TestBuildBlockCapsRenderedOutput(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "large.md")
+	if err := os.WriteFile(path, []byte(strings.Repeat("a", 4096)), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
+	}
+
+	block, err := BuildBlock([]Source{{Name: "Large", Path: path}}, Options{MaxBytes: 512})
+	if err != nil {
+		t.Fatalf("BuildBlock() error = %v", err)
+	}
+
+	if len(block) > 512 {
+		t.Fatalf("len(block) = %d, want <= 512", len(block))
+	}
+	if !strings.Contains(block, "[truncated to first") {
+		t.Fatalf("block missing truncation marker:\n%s", block)
+	}
+}

--- a/internal/project/connector_config_test.go
+++ b/internal/project/connector_config_test.go
@@ -59,6 +59,79 @@ func TestWorkflowConfigWithProjectPathsResolvesArtifactWorkflowPaths(t *testing.
 	}
 }
 
+func TestWorkflowConfigWithProjectKnowledgeMergesGlobalProjectAndWorkflowSources(t *testing.T) {
+	t.Parallel()
+
+	workdir := t.TempDir()
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Agent.Knowledge = workflowconfig.Knowledge{
+		Enabled:  true,
+		MaxBytes: 4096,
+		Sources: []workflowconfig.KnowledgeSource{{
+			Name: "Workflow",
+			Path: "docs/workflow.md",
+		}},
+	}
+
+	got := workflowConfigWithProjectIdentity(globalconfig.Project{
+		Workdir: workdir,
+		GlobalKnowledge: workflowconfig.Knowledge{
+			Enabled:  true,
+			MaxBytes: 1024,
+			Sources: []workflowconfig.KnowledgeSource{{
+				Name: "Global",
+				Path: "/shared/global.md",
+			}},
+		},
+		Knowledge: workflowconfig.Knowledge{
+			Enabled:  true,
+			MaxBytes: 2048,
+			Sources: []workflowconfig.KnowledgeSource{{
+				Name: "Project",
+				Path: "/shared/project.md",
+			}},
+		},
+	}, cfg)
+
+	if got.Agent.Knowledge.MaxBytes != 4096 {
+		t.Fatalf("Knowledge.MaxBytes = %d, want 4096", got.Agent.Knowledge.MaxBytes)
+	}
+	want := []workflowconfig.KnowledgeSource{
+		{Name: "Global", Path: "/shared/global.md"},
+		{Name: "Project", Path: "/shared/project.md"},
+		{Name: "Workflow", Path: filepath.Join(workdir, "docs", "workflow.md")},
+	}
+	if !reflect.DeepEqual(got.Agent.Knowledge.Sources, want) {
+		t.Fatalf("Knowledge.Sources = %#v, want %#v", got.Agent.Knowledge.Sources, want)
+	}
+}
+
+func TestWorkflowConfigWithProjectKnowledgeAllowsWorkflowOptOut(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	cfg.Agent.Knowledge = workflowconfig.Knowledge{Enabled: false}
+
+	got := workflowConfigWithProjectIdentity(globalconfig.Project{
+		GlobalKnowledge: workflowconfig.Knowledge{
+			Enabled: true,
+			Sources: []workflowconfig.KnowledgeSource{{
+				Name: "Global",
+				Path: "/shared/global.md",
+			}},
+		},
+	}, cfg)
+
+	if got.Agent.Knowledge.Enabled {
+		t.Fatal("Knowledge.Enabled = true, want workflow opt-out")
+	}
+	if len(got.Agent.Knowledge.Sources) != 0 {
+		t.Fatalf("Knowledge.Sources = %#v, want none", got.Agent.Knowledge.Sources)
+	}
+}
+
 func TestTrackerPriorityMapConvertsWorkflowMap(t *testing.T) {
 	t.Parallel()
 

--- a/internal/project/manager.go
+++ b/internal/project/manager.go
@@ -80,9 +80,14 @@ type Manager struct {
 }
 
 func ManagerConfigFromGlobal(cfg globalconfig.Config) ManagerConfig {
+	projects := append([]globalconfig.Project(nil), cfg.Projects...)
+	for index := range projects {
+		projects[index].GlobalKnowledge = cfg.Global.Knowledge
+	}
+
 	return normalizeManagerConfig(ManagerConfig{
 		Identity: cfg.Global.Identity,
-		Projects: cfg.Projects,
+		Projects: projects,
 		Startup: StartupConfig{
 			Jitter:              time.Duration(startupInt(cfg.Global.Startup, "jitter_seconds")) * time.Second,
 			MaxSpawnPerSecond:   startupInt(cfg.Global.Startup, "max_spawn_per_second"),
@@ -748,6 +753,8 @@ func startupInt(values map[string]any, key string) int {
 func normalizeManagerProjectConfig(cfg globalconfig.Project) globalconfig.Project {
 	cfg.ID = string(normalizeProjectID(ID(cfg.ID)))
 	cfg.Identity.Normalize()
+	cfg.GlobalKnowledge.Normalize()
+	cfg.Knowledge.Normalize()
 	return cfg
 }
 

--- a/internal/project/manager_test.go
+++ b/internal/project/manager_test.go
@@ -1421,6 +1421,13 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 				Name:        "release-captain",
 				GitHubLogin: "detent-bot",
 			},
+			Knowledge: workflowconfig.Knowledge{
+				Enabled: true,
+				Sources: []workflowconfig.KnowledgeSource{{
+					Name: "Global",
+					Path: "/shared/global.md",
+				}},
+			},
 			Startup: map[string]any{
 				"jitter_seconds":        3,
 				"max_spawn_per_second":  4,
@@ -1448,6 +1455,9 @@ func TestManagerConfigFromGlobal(t *testing.T) {
 	}
 	if got.Projects[0].Identity.GitHubLogin != "detent-bot" {
 		t.Fatalf("Projects[0].Identity.GitHubLogin = %q, want detent-bot", got.Projects[0].Identity.GitHubLogin)
+	}
+	if len(got.Projects[0].GlobalKnowledge.Sources) != 1 || got.Projects[0].GlobalKnowledge.Sources[0].Name != "Global" {
+		t.Fatalf("Projects[0].GlobalKnowledge = %#v, want global source", got.Projects[0].GlobalKnowledge)
 	}
 }
 

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -832,6 +832,15 @@ func workflowConfigWithProjectIdentity(
 	workflow workflowconfig.Config,
 ) workflowconfig.Config {
 	workflow = workflowConfigWithProjectPaths(project, workflow)
+	if workflow.Agent.Knowledge.Enabled {
+		workflow.Agent.Knowledge = workflowconfig.KnowledgeWithSources(
+			project.GlobalKnowledge,
+			project.Knowledge,
+			workflow.Agent.Knowledge,
+		)
+	} else {
+		workflow.Agent.Knowledge.Normalize()
+	}
 	if !project.Identity.Configured() {
 		return workflow
 	}
@@ -857,7 +866,15 @@ func workflowConfigWithProjectPaths(project globalconfig.Project, workflow workf
 	if workflow.Deliverable.Kind == workflowconfig.DeliverableArtifact {
 		workflow.Deliverable.OutputRoot = projectRelativePath(workdir, workflow.Deliverable.OutputRoot)
 	}
+	workflow.Agent.Knowledge = knowledgeWithProjectRelativePaths(workdir, workflow.Agent.Knowledge)
 	return workflow
+}
+
+func knowledgeWithProjectRelativePaths(base string, cfg workflowconfig.Knowledge) workflowconfig.Knowledge {
+	for index := range cfg.Sources {
+		cfg.Sources[index].Path = projectRelativePath(base, cfg.Sources[index].Path)
+	}
+	return cfg
 }
 
 func projectRelativePath(base string, path string) string {

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -11,6 +11,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/knowledge"
 	"github.com/digitaldrywood/detent/internal/lessons"
 	"github.com/digitaldrywood/detent/internal/notes"
 	"github.com/digitaldrywood/detent/internal/pathsafe"
@@ -85,6 +86,11 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 		return "", err
 	}
 
+	rendered, err = appendKnowledgeBlock(rendered, workflow.Config.Agent.Knowledge)
+	if err != nil {
+		return "", err
+	}
+
 	rendered, err = appendNotesBlock(rendered, opts.WorkspacePath)
 	if err != nil {
 		return "", err
@@ -137,6 +143,10 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 
 	prompt := prependWorkspaceIsolationBlock(b.String(), workflow.Config, opts.WorkspacePath, opts.Branch)
 	var err error
+	prompt, err = appendKnowledgeBlock(prompt, workflow.Config.Agent.Knowledge)
+	if err != nil {
+		return "", err
+	}
 	prompt, err = appendNotesBlock(prompt, opts.WorkspacePath)
 	if err != nil {
 		return "", err
@@ -486,6 +496,35 @@ func appendLessonsBlock(prompt string, cfg config.Lessons, workspacePath string)
 	}
 
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Lessons from prior runs\n\n" + strings.Join(entries, "\n\n"), nil
+}
+
+func appendKnowledgeBlock(prompt string, cfg config.Knowledge) (string, error) {
+	if !cfg.Enabled || len(cfg.Sources) == 0 {
+		return prompt, nil
+	}
+
+	sources := make([]knowledge.Source, 0, len(cfg.Sources))
+	for _, source := range cfg.Sources {
+		if strings.TrimSpace(source.Path) == "" {
+			continue
+		}
+		sources = append(sources, knowledge.Source{
+			Name: source.Name,
+			Path: source.Path,
+		})
+	}
+	if len(sources) == 0 {
+		return prompt, nil
+	}
+
+	block, err := knowledge.BuildBlock(sources, knowledge.Options{MaxBytes: cfg.MaxBytes})
+	if err != nil {
+		return "", err
+	}
+	if strings.TrimSpace(block) == "" {
+		return prompt, nil
+	}
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + block, nil
 }
 
 func appendNotesBlock(prompt string, workspacePath string) (string, error) {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -206,6 +206,97 @@ func TestBuildPromptSkillCreationInstructionsAreConfigurable(t *testing.T) {
 	}
 }
 
+func TestBuildPromptAppendsTeamKnowledge(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workspace := filepath.Join(root, "workspace")
+	globalPath := filepath.Join(root, "global.md")
+	projectPath := filepath.Join(root, "project.md")
+	if err := os.MkdirAll(workspace, 0o755); err != nil {
+		t.Fatalf("MkdirAll(workspace) error = %v", err)
+	}
+	if err := os.WriteFile(globalPath, []byte("Use allowlist terminology.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(global) error = %v", err)
+	}
+	if err := os.WriteFile(projectPath, []byte("Run project smoke tests.\n"), 0o600); err != nil {
+		t.Fatalf("WriteFile(project) error = %v", err)
+	}
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Config: config.Config{
+			Agent: config.Agent{
+				Knowledge: config.Knowledge{
+					Enabled:  true,
+					MaxBytes: 4096,
+					Sources: []config.KnowledgeSource{
+						{Name: "Global", Path: globalPath},
+						{Name: "Missing", Path: filepath.Join(root, "missing.md")},
+						{Name: "Project", Path: projectPath},
+					},
+				},
+			},
+		},
+		Prompt: "Base prompt",
+	}, connector.Issue{
+		Identifier: "digitaldrywood/detent#930",
+		Title:      "Knowledge",
+	}, PromptOptions{
+		WorkspacePath: workspace,
+	})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"## Team knowledge",
+		"Shared context supplied by Detent configuration.",
+		"### Global",
+		"Use allowlist terminology.",
+		"### Project",
+		"Run project smoke tests.",
+		"## Handoff notes",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+	if strings.Contains(prompt, "### Missing") {
+		t.Fatalf("prompt includes missing knowledge source:\n%s", prompt)
+	}
+	if strings.Index(prompt, "Use allowlist terminology.") > strings.Index(prompt, "Run project smoke tests.") {
+		t.Fatalf("prompt knowledge order = %q, want global before project", prompt)
+	}
+	if strings.Index(prompt, "## Team knowledge") > strings.Index(prompt, "## Handoff notes") {
+		t.Fatalf("prompt places handoff notes before team knowledge:\n%s", prompt)
+	}
+}
+
+func TestBuildPromptReturnsKnowledgeReadError(t *testing.T) {
+	t.Parallel()
+
+	_, err := BuildPrompt(config.Workflow{
+		Config: config.Config{
+			Agent: config.Agent{
+				Knowledge: config.Knowledge{
+					Enabled: true,
+					Sources: []config.KnowledgeSource{{
+						Name: "Directory",
+						Path: t.TempDir(),
+					}},
+				},
+			},
+		},
+		Prompt: "Base prompt",
+	}, connector.Issue{Identifier: "digitaldrywood/detent#930"}, PromptOptions{})
+	if err == nil {
+		t.Fatal("BuildPrompt() error = nil, want knowledge read error")
+	}
+	if !strings.Contains(err.Error(), "read shared knowledge") {
+		t.Fatalf("BuildPrompt() error = %v, want knowledge context", err)
+	}
+}
+
 func TestBuildPromptAppendsNotesAndPriorAttempt(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add shared knowledge configuration at workflow, global, and project scope.
- Read scoped plain-file knowledge sources with deterministic ordering, missing-file tolerance, and prompt-size caps.
- Inject team knowledge into normal and merge fallback prompts with focused coverage for config, project merging, and prompt behavior.

Fixes #930

## Test Plan
- `go test ./internal/knowledge ./internal/config ./internal/config/global ./internal/project ./internal/runner`
- `make check`