### PR TITLE
Normalize issue comments across connector backends

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -708,8 +708,12 @@ type label struct {
 }
 
 type issueComment struct {
-	Body string `json:"body"`
-	URL  string `json:"url"`
+	ID        string  `json:"id"`
+	Body      string  `json:"body"`
+	URL       string  `json:"url"`
+	Author    *actor  `json:"author"`
+	CreatedAt *string `json:"createdAt"`
+	UpdatedAt *string `json:"updatedAt"`
 }
 
 type pullRequest struct {
@@ -888,8 +892,13 @@ type checkRunTelemetrySummary struct {
 }
 
 type restComment struct {
-	Body    string `json:"body"`
-	HTMLURL string `json:"html_url"`
+	ID        int64      `json:"id"`
+	NodeID    string     `json:"node_id"`
+	Body      string     `json:"body"`
+	HTMLURL   string     `json:"html_url"`
+	User      *actor     `json:"user"`
+	CreatedAt *time.Time `json:"created_at"`
+	UpdatedAt *time.Time `json:"updated_at"`
 }
 
 type repository struct {
@@ -1701,8 +1710,12 @@ func (c *Connector) fetchIssueComments(ctx context.Context, ref issueRef) ([]iss
 	comments := make([]issueComment, 0, len(response))
 	for _, comment := range response {
 		comments = append(comments, issueComment{
-			Body: comment.Body,
-			URL:  comment.HTMLURL,
+			ID:        restCommentID(comment),
+			Body:      comment.Body,
+			URL:       comment.HTMLURL,
+			Author:    comment.User,
+			CreatedAt: restTimeString(comment.CreatedAt),
+			UpdatedAt: restTimeString(comment.UpdatedAt),
 		})
 	}
 	return comments, nil
@@ -1723,10 +1736,7 @@ func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issu
 	}
 	out := make([]connector.IssueComment, 0, len(comments))
 	for _, comment := range comments {
-		out = append(out, connector.IssueComment{
-			Body: comment.Body,
-			URL:  comment.URL,
-		})
+		out = append(out, connectorIssueComment(comment))
 	}
 	return out, nil
 }
@@ -3375,12 +3385,22 @@ func connectorIssueComments(comments []issueComment) []connector.IssueComment {
 	}
 	out := make([]connector.IssueComment, 0, len(comments))
 	for _, comment := range comments {
-		out = append(out, connector.IssueComment{
-			Body: comment.Body,
-			URL:  comment.URL,
-		})
+		out = append(out, connectorIssueComment(comment))
 	}
 	return out
+}
+
+func connectorIssueComment(comment issueComment) connector.IssueComment {
+	return connector.IssueComment{
+		ID:          strings.TrimSpace(comment.ID),
+		Backend:     connector.BackendGitHub.String(),
+		Body:        comment.Body,
+		URL:         comment.URL,
+		AuthorLogin: actorLogin(comment.Author),
+		CreatedAt:   parseGitHubTime(comment.CreatedAt),
+		UpdatedAt:   parseGitHubTime(comment.UpdatedAt),
+		TargetType:  connector.IssueCommentTargetIssue,
+	}
 }
 
 func (c *Connector) linkedChildIssues(issue githubIssueNode, fallbackRepo string) []connector.BlockedRef {
@@ -4247,6 +4267,16 @@ func restTimeString(value *time.Time) *string {
 	}
 	formatted := value.UTC().Format(time.RFC3339)
 	return &formatted
+}
+
+func restCommentID(comment restComment) string {
+	if id := strings.TrimSpace(comment.NodeID); id != "" {
+		return id
+	}
+	if comment.ID > 0 {
+		return strconv.FormatInt(comment.ID, 10)
+	}
+	return ""
 }
 
 func restAssigneesConnection(values []restAssignee) nodeConnection[assignee] {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2669,6 +2669,44 @@ func TestConnectorFetchIssueParentsSkipsParentsOutsideProject(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssueCommentsMapsRESTMetadata(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		path:   "/repos/example/repo/issues/1/comments?per_page=100",
+		body:   `[{"id":101,"node_id":"IC_kw1","body":"First note","html_url":"https://github.com/example/repo/issues/1#issuecomment-101","user":{"login":"alice"},"created_at":"2026-07-06T12:00:00Z","updated_at":"2026-07-06T12:05:00Z"}]`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+
+	got, err := c.FetchIssueComments(context.Background(), connector.Issue{Identifier: "example/repo#1"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssueComments() len = %d, want 1", len(got))
+	}
+
+	comment := got[0]
+	if comment.ID != "IC_kw1" ||
+		comment.Backend != connector.BackendGitHub.String() ||
+		comment.Body != "First note" ||
+		comment.URL != "https://github.com/example/repo/issues/1#issuecomment-101" ||
+		comment.AuthorLogin != "alice" ||
+		comment.Local ||
+		comment.TargetType != connector.IssueCommentTargetIssue {
+		t.Fatalf("FetchIssueComments()[0] = %#v, want normalized GitHub metadata", comment)
+	}
+	createdAt := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 7, 6, 12, 5, 0, 0, time.UTC)
+	if comment.CreatedAt == nil || !comment.CreatedAt.Equal(createdAt) {
+		t.Fatalf("CreatedAt = %v, want %v", comment.CreatedAt, createdAt)
+	}
+	if comment.UpdatedAt == nil || !comment.UpdatedAt.Equal(updatedAt) {
+		t.Fatalf("UpdatedAt = %v, want %v", comment.UpdatedAt, updatedAt)
+	}
+}
+
 func TestConnectorCreateCommentCallsAddComment(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -263,7 +264,7 @@ func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issu
 		}
 		return nil, err
 	}
-	return append(githubComments, localComments...), nil
+	return mergeIssueComments(githubComments, localComments), nil
 }
 
 func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
@@ -467,7 +468,7 @@ func (c *Connector) mergeLocalWithGitHub(localIssue connector.Issue, upstream co
 	merged.State = localIssue.State
 	merged.Priority = localIssue.Priority
 	merged.Fields = cloneMetadata(localIssue.Fields)
-	merged.Comments = cloneComments(localIssue.Comments)
+	merged.Comments = mergeIssueComments(upstream.Comments, localIssue.Comments)
 	merged.Deliverable = cloneDeliverable(localIssue.Deliverable)
 	merged.AssignedToWorker = localIssue.AssignedToWorker
 	merged.StageUpdatedAt = localIssue.StageUpdatedAt
@@ -682,7 +683,56 @@ func mergeMetadata(primary map[string]string, secondary map[string]string) map[s
 }
 
 func cloneComments(values []connector.IssueComment) []connector.IssueComment {
-	return append([]connector.IssueComment(nil), values...)
+	out := make([]connector.IssueComment, len(values))
+	for index, value := range values {
+		out[index] = value
+		out[index].CreatedAt = cloneCommentTime(value.CreatedAt)
+		out[index].UpdatedAt = cloneCommentTime(value.UpdatedAt)
+	}
+	return out
+}
+
+func mergeIssueComments(primary []connector.IssueComment, secondary []connector.IssueComment) []connector.IssueComment {
+	out := make([]connector.IssueComment, 0, len(primary)+len(secondary))
+	out = append(out, cloneComments(primary)...)
+	out = append(out, cloneComments(secondary)...)
+	sort.SliceStable(out, func(i int, j int) bool {
+		return issueCommentLess(out[i], out[j])
+	})
+	return out
+}
+
+func issueCommentLess(left connector.IssueComment, right connector.IssueComment) bool {
+	if left.CreatedAt != nil && right.CreatedAt != nil && !left.CreatedAt.Equal(*right.CreatedAt) {
+		return left.CreatedAt.Before(*right.CreatedAt)
+	}
+	if (left.CreatedAt != nil) != (right.CreatedAt != nil) {
+		return left.CreatedAt != nil
+	}
+	if left.Local != right.Local {
+		return !left.Local
+	}
+	for _, pair := range [][2]string{
+		{left.Backend, right.Backend},
+		{left.ID, right.ID},
+		{left.URL, right.URL},
+		{left.Body, right.Body},
+	} {
+		leftValue := strings.TrimSpace(pair[0])
+		rightValue := strings.TrimSpace(pair[1])
+		if leftValue != rightValue {
+			return leftValue < rightValue
+		}
+	}
+	return false
+}
+
+func cloneCommentTime(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func cloneDeliverable(value *connector.Deliverable) *connector.Deliverable {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -221,6 +221,75 @@ func TestConnectorFetchIssueStatesByIdentifiersReturnsLocalOnlyIssues(t *testing
 	}
 }
 
+func TestConnectorFetchIssueCommentsMergesRemoteAndLocalInCreatedOrder(t *testing.T) {
+	t.Parallel()
+
+	server := newGitHubLocalTestServer(t)
+	localCreatedAt := time.Date(2026, 7, 2, 12, 3, 0, 0, time.UTC)
+	conn, err := New(Config{
+		GitHub: githubconnector.Config{
+			Endpoint: server.URL + "/graphql",
+			APIKey:   "ghp_test",
+		},
+		Local: local.Config{
+			Path: filepath.Join(t.TempDir(), "comments.db"),
+			Issues: []connector.Issue{{
+				ID:         "github:123:779",
+				Identifier: "digitaldrywood/detent#779",
+				Title:      "Local issue",
+				State:      "Todo",
+				Metadata: map[string]string{
+					local.MetadataGitHubNodeID:       "I_kwDOtest779",
+					local.MetadataGitHubRepositoryID: "123",
+					local.MetadataGitHubIssueNumber:  "779",
+				},
+				AssignedToWorker: true,
+			}},
+			Now: func() time.Time {
+				return localCreatedAt
+			},
+		},
+		Repository:     "digitaldrywood/detent",
+		ActiveStates:   []string{"Todo", "In Progress"},
+		TerminalStates: []string{"Done"},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	if err := conn.CreateComment(context.Background(), "github:123:779", "local note"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	got, err := conn.FetchIssueComments(context.Background(), connector.Issue{
+		ID:         "github:123:779",
+		Identifier: "digitaldrywood/detent#779",
+	})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() error = %v", err)
+	}
+
+	wantBodies := []string{"remote earlier", "local note", "remote later"}
+	if len(got) != len(wantBodies) {
+		t.Fatalf("FetchIssueComments() len = %d, want %d: %#v", len(got), len(wantBodies), got)
+	}
+	for index, want := range wantBodies {
+		if got[index].Body != want {
+			t.Fatalf("comment[%d].Body = %q, want %q; comments = %#v", index, got[index].Body, want, got)
+		}
+	}
+	if got[0].Local || !got[1].Local || got[2].Local {
+		t.Fatalf("comment locality = [%v %v %v], want remote/local/remote", got[0].Local, got[1].Local, got[2].Local)
+	}
+	if got[1].Backend != connector.BackendLocalSQLite.String() || got[0].Backend != connector.BackendGitHub.String() {
+		t.Fatalf("comment backends = %#v, want GitHub and local SQLite metadata", got)
+	}
+}
+
 type githubLocalTestRequest struct {
 	Method string
 	Path   string
@@ -271,6 +340,27 @@ func (s *githubLocalTestServer) handle(w http.ResponseWriter, r *http.Request) {
 			"user":         map[string]any{"login": "octocat"},
 			"assignees":    []map[string]any{{"node_id": "U_1", "login": "detent-bot"}},
 			"labels":       []map[string]string{{"name": "enhancement"}},
+		})
+	case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent/issues/779/comments":
+		writeGitHubLocalJSON(s.t, w, []map[string]any{
+			{
+				"id":         1001,
+				"node_id":    "IC_remote_early",
+				"body":       "remote earlier",
+				"html_url":   "https://github.com/digitaldrywood/detent/issues/779#issuecomment-1001",
+				"created_at": "2026-07-02T12:00:00Z",
+				"updated_at": "2026-07-02T12:00:00Z",
+				"user":       map[string]any{"login": "octocat"},
+			},
+			{
+				"id":         1002,
+				"node_id":    "IC_remote_late",
+				"body":       "remote later",
+				"html_url":   "https://github.com/digitaldrywood/detent/issues/779#issuecomment-1002",
+				"created_at": "2026-07-02T12:05:00Z",
+				"updated_at": "2026-07-02T12:05:00Z",
+				"user":       map[string]any{"login": "octocat"},
+			},
 		})
 	case r.Method == http.MethodGet && r.URL.Path == "/repos/digitaldrywood/detent/pulls":
 		writeGitHubLocalJSON(s.t, w, []map[string]any{})

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -100,9 +100,22 @@ type PullRequestFinding struct {
 	Line int    `json:"line,omitempty" yaml:"line,omitempty"`
 }
 
+const (
+	IssueCommentTargetIssue       = "issue"
+	IssueCommentTargetPullRequest = "pull_request"
+)
+
 type IssueComment struct {
-	Body string `json:"body,omitempty" yaml:"body,omitempty"`
-	URL  string `json:"url,omitempty" yaml:"url,omitempty"`
+	ID                string     `json:"id,omitempty" yaml:"id,omitempty"`
+	Backend           string     `json:"backend,omitempty" yaml:"backend,omitempty"`
+	Body              string     `json:"body,omitempty" yaml:"body,omitempty"`
+	URL               string     `json:"url,omitempty" yaml:"url,omitempty"`
+	AuthorLogin       string     `json:"author_login,omitempty" yaml:"author_login,omitempty"`
+	AuthorDisplayName string     `json:"author_display_name,omitempty" yaml:"author_display_name,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt         *time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	Local             bool       `json:"local,omitempty" yaml:"local,omitempty"`
+	TargetType        string     `json:"target_type,omitempty" yaml:"target_type,omitempty"`
 }
 
 type Deliverable struct {

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -176,7 +176,7 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 
 func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
 	rows, err := c.db.QueryContext(ctx, `
-select body from detent_work_item_events
+select id, body, created_at from detent_work_item_events
 where project_id = ? and item_id = ? and event_kind = ?
 order by id asc`, c.projectID, strings.TrimSpace(issue.ID), eventKindComment)
 	if err != nil {
@@ -186,11 +186,21 @@ order by id asc`, c.projectID, strings.TrimSpace(issue.ID), eventKindComment)
 
 	comments := []connector.IssueComment{}
 	for rows.Next() {
+		var id int64
 		var body string
-		if err := rows.Scan(&body); err != nil {
+		var createdAt string
+		if err := rows.Scan(&id, &body, &createdAt); err != nil {
 			return nil, err
 		}
-		comments = append(comments, connector.IssueComment{Body: body})
+		comments = append(comments, connector.IssueComment{
+			ID:          strconv.FormatInt(id, 10),
+			Backend:     connector.BackendLocalSQLite.String(),
+			Body:        body,
+			AuthorLogin: "detent",
+			CreatedAt:   parseTimePointer(createdAt),
+			Local:       true,
+			TargetType:  connector.IssueCommentTargetIssue,
+		})
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err

--- a/internal/connector/local/local_test.go
+++ b/internal/connector/local/local_test.go
@@ -106,6 +106,101 @@ func TestConnectorPersistsWorkItemStateAndEvents(t *testing.T) {
 	}
 }
 
+func TestConnectorFetchIssueCommentsReturnsEventMetadata(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	issue := connector.NewIssue()
+	issue.ID = "ad-1"
+	issue.Identifier = "store/ad-1"
+	issue.State = "Todo"
+
+	store, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "comments.db"),
+		ProjectID: "video",
+		Issues:    []connector.Issue{issue},
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateComment(ctx, "ad-1", "Ready for review."); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	got, err := store.FetchIssueComments(ctx, issue)
+	if err != nil {
+		t.Fatalf("FetchIssueComments() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssueComments() len = %d, want 1", len(got))
+	}
+	comment := got[0]
+	if comment.ID != "1" ||
+		comment.Backend != connector.BackendLocalSQLite.String() ||
+		comment.Body != "Ready for review." ||
+		comment.AuthorLogin != "detent" ||
+		!comment.Local ||
+		comment.TargetType != connector.IssueCommentTargetIssue {
+		t.Fatalf("FetchIssueComments()[0] = %#v, want normalized local metadata", comment)
+	}
+	if comment.CreatedAt == nil || !comment.CreatedAt.Equal(now) {
+		t.Fatalf("CreatedAt = %v, want %v", comment.CreatedAt, now)
+	}
+}
+
+func TestConnectorFetchIssueCommentsPreservesEventOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	timestamps := []time.Time{
+		time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 6, 12, 0, 0, 100_000_000, time.UTC),
+	}
+	next := 0
+	store, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "comment-order.db"),
+		ProjectID: "video",
+		Now: func() time.Time {
+			if next >= len(timestamps) {
+				return timestamps[len(timestamps)-1]
+			}
+			value := timestamps[next]
+			next++
+			return value
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateComment(ctx, "ad-1", "first exact-second comment"); err != nil {
+		t.Fatalf("CreateComment() first error = %v", err)
+	}
+	if err := store.CreateComment(ctx, "ad-1", "second fractional comment"); err != nil {
+		t.Fatalf("CreateComment() second error = %v", err)
+	}
+
+	got, err := store.FetchIssueComments(ctx, connector.Issue{ID: "ad-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() error = %v", err)
+	}
+	wantBodies := []string{"first exact-second comment", "second fractional comment"}
+	if len(got) != len(wantBodies) {
+		t.Fatalf("FetchIssueComments() len = %d, want %d", len(got), len(wantBodies))
+	}
+	for index, want := range wantBodies {
+		if got[index].Body != want {
+			t.Fatalf("comment[%d].Body = %q, want %q; comments = %#v", index, got[index].Body, want, got)
+		}
+	}
+}
+
 func TestConnectorFetchIssuesByStatesLimit(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -168,10 +168,10 @@ func (c *Connector) FetchIssueComments(_ context.Context, issue connector.Issue)
 	wantIdentifier := normalizeState(issue.Identifier)
 	for _, candidate := range c.issues {
 		if wantID != "" && strings.TrimSpace(candidate.ID) == wantID {
-			return cloneIssueComments(candidate.Comments), nil
+			return cloneIssueComments(candidate, candidate.Comments), nil
 		}
 		if wantIdentifier != "" && normalizeState(candidate.Identifier) == wantIdentifier {
-			return cloneIssueComments(candidate.Comments), nil
+			return cloneIssueComments(candidate, candidate.Comments), nil
 		}
 	}
 	return []connector.IssueComment{}, nil
@@ -231,7 +231,16 @@ func (c *Connector) FetchIssueChildren(_ context.Context, issueID string) ([]con
 
 func (c *Connector) CreateComment(_ context.Context, issueID string, body string) error {
 	c.applyIssue(issueID, func(issue *connector.Issue, now time.Time) {
-		issue.Comments = append(issue.Comments, connector.IssueComment{Body: body})
+		createdAt := now.UTC()
+		issue.Comments = append(issue.Comments, connector.IssueComment{
+			ID:          memoryCommentID(*issue, len(issue.Comments)+1),
+			Backend:     connector.BackendMemory.String(),
+			Body:        body,
+			AuthorLogin: "memory",
+			CreatedAt:   &createdAt,
+			Local:       true,
+			TargetType:  connector.IssueCommentTargetIssue,
+		})
 		issue.UpdatedAt = &now
 	})
 	c.send(Event{Kind: EventKindComment, IssueID: issueID, Body: body})
@@ -535,7 +544,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		issue.Labels = append([]string(nil), issue.Labels...)
 	}
 	if issue.Comments != nil {
-		issue.Comments = cloneIssueComments(issue.Comments)
+		issue.Comments = cloneIssueComments(issue, issue.Comments)
 	}
 	if issue.Assignees != nil {
 		issue.Assignees = cloneStringSlice(issue.Assignees)
@@ -553,8 +562,39 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	return issue
 }
 
-func cloneIssueComments(comments []connector.IssueComment) []connector.IssueComment {
-	return append([]connector.IssueComment(nil), comments...)
+func cloneIssueComments(issue connector.Issue, comments []connector.IssueComment) []connector.IssueComment {
+	out := make([]connector.IssueComment, len(comments))
+	for index, comment := range comments {
+		out[index] = normalizeIssueComment(issue, comment, index+1)
+	}
+	return out
+}
+
+func normalizeIssueComment(issue connector.Issue, comment connector.IssueComment, index int) connector.IssueComment {
+	if strings.TrimSpace(comment.ID) == "" {
+		comment.ID = memoryCommentID(issue, index)
+	}
+	if strings.TrimSpace(comment.Backend) == "" {
+		comment.Backend = connector.BackendMemory.String()
+	}
+	if strings.TrimSpace(comment.AuthorLogin) == "" {
+		comment.AuthorLogin = "memory"
+	}
+	if strings.TrimSpace(comment.TargetType) == "" {
+		comment.TargetType = connector.IssueCommentTargetIssue
+	}
+	comment.Local = true
+	comment.CreatedAt = cloneTime(comment.CreatedAt)
+	comment.UpdatedAt = cloneTime(comment.UpdatedAt)
+	return comment
+}
+
+func memoryCommentID(issue connector.Issue, index int) string {
+	key := memoryIssueKey(issue)
+	if key == "" {
+		key = "issue"
+	}
+	return "memory:" + key + ":" + strconv.Itoa(index)
 }
 
 func cloneStringSlice(values []string) []string {

--- a/internal/connector/memory/memory_test.go
+++ b/internal/connector/memory/memory_test.go
@@ -304,6 +304,42 @@ func TestConnectorCapturesIssueAndPullRequestComments(t *testing.T) {
 	}
 }
 
+func TestConnectorStatefulCommentUsesSyntheticMetadata(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 6, 12, 30, 0, 0, time.UTC)
+	c := New(Config{
+		Issues:   []connector.Issue{{ID: "issue-1", State: "Todo"}},
+		Stateful: true,
+		Now: func() time.Time {
+			return now
+		},
+	})
+
+	if err := c.CreateComment(context.Background(), "issue-1", "issue comment"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	got, err := c.FetchIssueComments(context.Background(), connector.Issue{ID: "issue-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssueComments() len = %d, want 1", len(got))
+	}
+	comment := got[0]
+	if comment.ID != "memory:id:issue-1:1" ||
+		comment.Backend != connector.BackendMemory.String() ||
+		comment.Body != "issue comment" ||
+		comment.AuthorLogin != "memory" ||
+		!comment.Local ||
+		comment.TargetType != connector.IssueCommentTargetIssue {
+		t.Fatalf("FetchIssueComments()[0] = %#v, want synthetic memory metadata", comment)
+	}
+	if comment.CreatedAt == nil || !comment.CreatedAt.Equal(now) {
+		t.Fatalf("CreatedAt = %v, want %v", comment.CreatedAt, now)
+	}
+}
+
 func TestConnectorMergePullRequestUpdatesStatefulFixture(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -413,8 +413,16 @@ func telemetryIssueComments(comments []connector.IssueComment) []telemetry.Issue
 	out := make([]telemetry.IssueComment, 0, len(comments))
 	for _, comment := range comments {
 		out = append(out, telemetry.IssueComment{
-			Body: comment.Body,
-			URL:  comment.URL,
+			ID:                comment.ID,
+			Backend:           comment.Backend,
+			Body:              comment.Body,
+			URL:               comment.URL,
+			AuthorLogin:       comment.AuthorLogin,
+			AuthorDisplayName: comment.AuthorDisplayName,
+			CreatedAt:         cloneTime(comment.CreatedAt),
+			UpdatedAt:         cloneTime(comment.UpdatedAt),
+			Local:             comment.Local,
+			TargetType:        comment.TargetType,
 		})
 	}
 	return out

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -253,6 +253,8 @@ func TestStateSnapshotCarriesIssueComments(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 6, 23, 12, 0, 0, 0, time.UTC)
+	commentCreatedAt := now.Add(-30 * time.Second)
+	commentUpdatedAt := now.Add(-15 * time.Second)
 	state := newState(normalizeConfig(Config{}))
 	state.Running["issue-1"] = Running{
 		Issue: connector.Issue{
@@ -260,8 +262,14 @@ func TestStateSnapshotCarriesIssueComments(t *testing.T) {
 			Identifier: "digitaldrywood/detent#1",
 			State:      "In Progress",
 			Comments: []connector.IssueComment{{
-				Body: "## Codex Workpad\n\n### Status\nIn Progress",
-				URL:  "https://github.test/comment/1",
+				ID:          "IC_1",
+				Backend:     connector.BackendGitHub.String(),
+				Body:        "## Codex Workpad\n\n### Status\nIn Progress",
+				URL:         "https://github.test/comment/1",
+				AuthorLogin: "detent-bot",
+				CreatedAt:   &commentCreatedAt,
+				UpdatedAt:   &commentUpdatedAt,
+				TargetType:  connector.IssueCommentTargetIssue,
 			}},
 		},
 		StartedAt: now.Add(-time.Minute),
@@ -276,8 +284,19 @@ func TestStateSnapshotCarriesIssueComments(t *testing.T) {
 	if len(comments) != 1 {
 		t.Fatalf("Running comments = %#v, want one comment", comments)
 	}
-	if comments[0].Body != "## Codex Workpad\n\n### Status\nIn Progress" || comments[0].URL != "https://github.test/comment/1" {
-		t.Fatalf("Running comment = %#v, want Workpad body and URL", comments[0])
+	if comments[0].ID != "IC_1" ||
+		comments[0].Backend != connector.BackendGitHub.String() ||
+		comments[0].Body != "## Codex Workpad\n\n### Status\nIn Progress" ||
+		comments[0].URL != "https://github.test/comment/1" ||
+		comments[0].AuthorLogin != "detent-bot" ||
+		comments[0].TargetType != connector.IssueCommentTargetIssue {
+		t.Fatalf("Running comment = %#v, want normalized Workpad metadata", comments[0])
+	}
+	if comments[0].CreatedAt == nil || !comments[0].CreatedAt.Equal(commentCreatedAt) {
+		t.Fatalf("Running comment CreatedAt = %v, want %v", comments[0].CreatedAt, commentCreatedAt)
+	}
+	if comments[0].UpdatedAt == nil || !comments[0].UpdatedAt.Equal(commentUpdatedAt) {
+		t.Fatalf("Running comment UpdatedAt = %v, want %v", comments[0].UpdatedAt, commentUpdatedAt)
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -410,7 +410,13 @@ func cloneIssueComments(comments []connector.IssueComment) []connector.IssueComm
 	if comments == nil {
 		return nil
 	}
-	return append([]connector.IssueComment{}, comments...)
+	out := make([]connector.IssueComment, len(comments))
+	for index, comment := range comments {
+		out[index] = comment
+		out[index].CreatedAt = timePointerValue(comment.CreatedAt)
+		out[index].UpdatedAt = timePointerValue(comment.UpdatedAt)
+	}
+	return out
 }
 
 func cloneStringMap(values map[string]string) map[string]string {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -214,8 +214,16 @@ type Issue struct {
 }
 
 type IssueComment struct {
-	Body string `json:"body,omitempty"`
-	URL  string `json:"url,omitempty"`
+	ID                string     `json:"id,omitempty"`
+	Backend           string     `json:"backend,omitempty"`
+	Body              string     `json:"body,omitempty"`
+	URL               string     `json:"url,omitempty"`
+	AuthorLogin       string     `json:"author_login,omitempty"`
+	AuthorDisplayName string     `json:"author_display_name,omitempty"`
+	CreatedAt         *time.Time `json:"created_at,omitempty"`
+	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
+	Local             bool       `json:"local,omitempty"`
+	TargetType        string     `json:"target_type,omitempty"`
 }
 
 type Deliverable struct {

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -662,7 +662,7 @@ func cloneKanbanIssue(issue telemetry.Issue) telemetry.Issue {
 	out := issue
 	out.Labels = append([]string(nil), issue.Labels...)
 	out.Assignees = append([]string(nil), issue.Assignees...)
-	out.Comments = append([]telemetry.IssueComment(nil), issue.Comments...)
+	out.Comments = cloneKanbanIssueComments(issue.Comments)
 	out.BlockedBy = append([]telemetry.BlockedRef(nil), issue.BlockedBy...)
 	out.Metadata = maps.Clone(issue.Metadata)
 	out.PullRequest = cloneKanbanPullRequest(issue.PullRequest)
@@ -674,6 +674,19 @@ func cloneKanbanIssue(issue telemetry.Issue) telemetry.Issue {
 	out.UpdatedAt = cloneKanbanTimePointer(issue.UpdatedAt)
 	out.StageUpdatedAt = cloneKanbanTimePointer(issue.StageUpdatedAt)
 	out.CurrentLaneEnteredAt = cloneKanbanTimePointer(issue.CurrentLaneEnteredAt)
+	return out
+}
+
+func cloneKanbanIssueComments(comments []telemetry.IssueComment) []telemetry.IssueComment {
+	if comments == nil {
+		return nil
+	}
+	out := make([]telemetry.IssueComment, len(comments))
+	for index, comment := range comments {
+		out[index] = comment
+		out[index].CreatedAt = cloneKanbanTimePointer(comment.CreatedAt)
+		out[index].UpdatedAt = cloneKanbanTimePointer(comment.UpdatedAt)
+	}
 	return out
 }
 


### PR DESCRIPTION
## Summary

- Normalize issue comment metadata across connector and telemetry models.
- Map GitHub, local SQLite, memory, and github_local comments into attributed ordered comments.
- Preserve existing comment submission behavior while adding focused backend coverage.

Fixes #949

## Test Plan

- [x] `go test ./internal/connector/...`
- [x] `go test ./internal/orchestrator ./internal/web ./internal/telemetry`
- [x] `make check`