### PR TITLE
docs(workflow): add UI surface guardrails

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -21,6 +21,19 @@ assignees: ""
 ## Actual Behavior
 
 
+## UI Surface Contract
+
+Complete this section when the bug fix changes a primary operator screen, persistent notification surface, layout density, first-viewport real estate, navigation, dashboard region, or responsive visibility. Use `N/A` for non-UI work or small copy, icon, and local styling changes that do not affect layout or persistent surfaces.
+
+- Affected screen and component area:
+- Current behavior:
+- Desired behavior:
+- Persistent global messaging allowed: yes/no
+- Information that must stay contextual on cards, rows, or details:
+- Compact/cozy density expectations:
+- Expected first viewport, screenshot, mockup, or text description:
+- Screenshot or browser verification expected:
+
 ## Environment
 
 - OS:

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -15,6 +15,19 @@ assignees: ""
 ## Proposed Behavior
 
 
+## UI Surface Contract
+
+Complete this section when the feature changes a primary operator screen, persistent notification surface, layout density, first-viewport real estate, navigation, dashboard region, or responsive visibility. Use `N/A` for non-UI work or small copy, icon, and local styling changes that do not affect layout or persistent surfaces.
+
+- Affected screen and component area:
+- Current behavior:
+- Desired behavior:
+- Persistent global messaging allowed: yes/no
+- Information that must stay contextual on cards, rows, or details:
+- Compact/cozy density expectations:
+- Expected first viewport, screenshot, mockup, or text description:
+- Screenshot or browser verification expected:
+
 ## Alternatives Considered
 
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -4,6 +4,12 @@
 
 Fixes #N
 
+## UI Surface Contract
+
+- [ ] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
+- [ ] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
+- [ ] Visual changes to primary operator screens include screenshot or browser verification below.
+
 ## Test Plan
 
 - [ ] `make check`

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -109,6 +109,24 @@ Commit generated output with the source change that produced it.
 - Use Templ, HTMX, and Tailwind v4 for server-rendered UI.
 - Prefer self-documenting code over comments.
 
+## UI Surface Guardrails
+
+High-impact UI changes require explicit issue authorization before implementation starts. If an issue does not describe the affected surface and real-estate tradeoff, choose a local or contextual treatment instead of a persistent global surface, or stop and ask for a more specific issue.
+
+A high-impact UI change adds or significantly alters any of the following:
+
+- Persistent banners, toasts, alerts, modals, drawers, or other elevated surfaces.
+- First-viewport real estate on primary operator screens such as Board, Fleet, Reports, Analytics, Health, API Keys, or Settings.
+- Kanban lane layout, card density, column spacing, sticky headers, or top-of-board summary regions.
+- Navigation, status counters, page chrome, or live dashboard regions.
+- Responsive behavior that changes what is visible on desktop, laptop, or mobile viewports.
+
+Issues that authorize high-impact UI work must include a UI surface contract covering the affected screen and component area, current and desired behavior, whether persistent global messaging is allowed, what information must stay contextual on cards, rows, or details, density expectations when relevant, an expected first-viewport screenshot, mockup, or text description, and the screenshot or browser verification expected.
+
+Persistent top-of-screen messages require explicit issue authorization. Do not infer permission for global banners, alerts, or notification rows from generic words like "alert", "blocked", "status", or "notify". Workflow state that is already visible in a Kanban card defaults to contextual card indicators instead of duplicated global messaging.
+
+Small copy changes, icon swaps, and local component styling do not need a heavyweight UI surface contract unless they affect layout, persistent surfaces, density, or viewport visibility. Visual changes to primary operator screens require screenshot or browser verification before review.
+
 ## Tests
 
 New or changed observable behavior needs tests.

--- a/internal/workspace/diffstat.go
+++ b/internal/workspace/diffstat.go
@@ -205,8 +205,8 @@ func gitDiffOutputWithinLimit(ctx context.Context, workspacePath string, env []s
 		return "", false, fmt.Errorf("git diff read: %w", readErr)
 	}
 	if truncated {
-		if killErr != nil && !errors.Is(killErr, os.ErrProcessDone) {
-			return "", false, fmt.Errorf("git diff stop after limit: %w", killErr)
+		if err := gitDiffStopError(killErr, waitErr); err != nil {
+			return "", false, err
 		}
 		return "", true, nil
 	}
@@ -230,6 +230,13 @@ func gitDiffOutputWithinLimit(ctx context.Context, workspacePath string, env []s
 		Output:   string(combined),
 		Err:      waitErr,
 	}
+}
+
+func gitDiffStopError(killErr error, waitErr error) error {
+	if killErr == nil || errors.Is(killErr, os.ErrProcessDone) || waitErr == nil {
+		return nil
+	}
+	return fmt.Errorf("git diff stop after limit: %w", killErr)
 }
 
 func ensureGitInfoExcludes(ctx context.Context, workspacePath string, patterns []string) error {

--- a/internal/workspace/diffstat_test.go
+++ b/internal/workspace/diffstat_test.go
@@ -221,6 +221,58 @@ func TestLocalGitDiffIsBounded(t *testing.T) {
 	}
 }
 
+func TestGitDiffStopErrorIgnoresCompletedProcess(t *testing.T) {
+	t.Parallel()
+
+	waitErr := errors.New("wait")
+
+	tests := []struct {
+		name    string
+		killErr error
+		waitErr error
+		wantErr bool
+	}{
+		{
+			name: "no kill error",
+		},
+		{
+			name:    "already done",
+			killErr: os.ErrProcessDone,
+			waitErr: waitErr,
+		},
+		{
+			name:    "kill denied after successful wait",
+			killErr: os.ErrPermission,
+		},
+		{
+			name:    "kill denied before failed wait",
+			killErr: os.ErrPermission,
+			waitErr: waitErr,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			err := gitDiffStopError(tt.killErr, tt.waitErr)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatal("gitDiffStopError() error = nil, want error")
+				}
+				if !errors.Is(err, tt.killErr) {
+					t.Fatalf("gitDiffStopError() error = %v, want wrapped %v", err, tt.killErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("gitDiffStopError() error = %v, want nil", err)
+			}
+		})
+	}
+}
+
 func TestLocalGitDiffUsesBaseRefForCleanBranch(t *testing.T) {
 	t.Parallel()
 

--- a/repository_guidance_test.go
+++ b/repository_guidance_test.go
@@ -1,0 +1,45 @@
+package detent
+
+import "testing"
+
+func TestRepositoryGuidanceRequiresUISurfaceContracts(t *testing.T) {
+	t.Parallel()
+
+	contributing := readRepositoryTextFile(t, "CONTRIBUTING.md")
+	featureTemplate := readRepositoryTextFile(t, ".github/ISSUE_TEMPLATE/feature_request.md")
+	bugTemplate := readRepositoryTextFile(t, ".github/ISSUE_TEMPLATE/bug_report.md")
+	prTemplate := readRepositoryTextFile(t, ".github/PULL_REQUEST_TEMPLATE.md")
+
+	for _, want := range []string{
+		"High-impact UI changes require explicit issue authorization before implementation starts",
+		"Persistent top-of-screen messages require explicit issue authorization",
+		"generic words like \"alert\", \"blocked\", \"status\", or \"notify\"",
+		"Workflow state that is already visible in a Kanban card defaults to contextual card indicators",
+		"Visual changes to primary operator screens require screenshot or browser verification before review",
+		"Small copy changes, icon swaps, and local component styling do not need a heavyweight UI surface contract",
+	} {
+		assertContainsWords(t, contributing, want)
+	}
+
+	for _, content := range []string{featureTemplate, bugTemplate} {
+		for _, want := range []string{
+			"## UI Surface Contract",
+			"primary operator screen, persistent notification surface, layout density, first-viewport real estate, navigation, dashboard region, or responsive visibility",
+			"Persistent global messaging allowed: yes/no",
+			"Information that must stay contextual on cards, rows, or details",
+			"Expected first viewport, screenshot, mockup, or text description",
+			"Screenshot or browser verification expected",
+		} {
+			assertContainsWords(t, content, want)
+		}
+	}
+
+	for _, want := range []string{
+		"## UI Surface Contract",
+		"the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff",
+		"Persistent top-of-screen messaging is explicitly authorized by the issue",
+		"Visual changes to primary operator screens include screenshot or browser verification below",
+	} {
+		assertContainsWords(t, prTemplate, want)
+	}
+}


### PR DESCRIPTION
## Summary

- Add contributor guidance that defines high-impact UI changes and requires explicit issue authorization for surface and real-estate tradeoffs.
- Add UI surface contract prompts to issue templates and PR review checkboxes for persistent messaging and visual verification.
- Add repository doc coverage for the UI guardrail language.
- Tolerate already-completed `git diff` processes when truncating bounded workspace diffs, fixing the Windows race-test failure seen on this PR.

Fixes #958

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test . -run TestRepositoryGuidanceRequiresUISurfaceContracts`
- [x] `go test ./internal/workspace`
- [x] `make check`