### PR TITLE
feat(linear): add issue comment support

### DIFF
--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -1,7 +1,6 @@
 package factory
 
 import (
-	"context"
 	"errors"
 	"fmt"
 	"log/slog"
@@ -11,6 +10,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	githubconnector "github.com/digitaldrywood/detent/internal/connector/github"
 	"github.com/digitaldrywood/detent/internal/connector/githublocal"
+	linearconnector "github.com/digitaldrywood/detent/internal/connector/linear"
 	"github.com/digitaldrywood/detent/internal/connector/local"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 )
@@ -60,7 +60,11 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 	case connector.BackendLocalSQLite:
 		return local.New(cfg.LocalSQLite)
 	case connector.BackendLinear:
-		return unimplementedConnector{name: kind}, nil
+		return linearconnector.NewConnector(linearconnector.Config{
+			Endpoint: cfg.Endpoint,
+			APIKey:   cfg.APIKey,
+			Logger:   cfg.Logger,
+		})
 	case connector.BackendGitHub:
 		var tokenSource githubconnector.TokenSource
 		if strings.TrimSpace(cfg.APIKey) != "" && cfg.GitHubTokenRefresh != nil && !cfg.hasGitHubAppCredentials() {
@@ -156,44 +160,6 @@ func (cfg Config) hasGitHubAppCredentials() bool {
 		strings.TrimSpace(cfg.GitHubAppInstallationID) != "" &&
 		(strings.TrimSpace(cfg.GitHubAppPrivateKey) != "" ||
 			strings.TrimSpace(cfg.GitHubAppPrivateKeyPath) != "")
-}
-
-type unimplementedConnector struct {
-	name string
-}
-
-var _ connector.Connector = unimplementedConnector{}
-
-func (c unimplementedConnector) Name() string {
-	return c.name
-}
-
-func (unimplementedConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
-	return nil, connector.ErrNotImplemented
-}
-
-func (unimplementedConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
-	return nil, connector.ErrNotImplemented
-}
-
-func (unimplementedConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
-	return nil, connector.ErrNotImplemented
-}
-
-func (unimplementedConnector) CreateComment(context.Context, string, string) error {
-	return connector.ErrNotImplemented
-}
-
-func (unimplementedConnector) UpdateIssueState(context.Context, string, string) error {
-	return connector.ErrNotImplemented
-}
-
-func (unimplementedConnector) SetAssignee(context.Context, string, string) error {
-	return connector.ErrNotImplemented
-}
-
-func (unimplementedConnector) SetField(context.Context, string, string, string) error {
-	return connector.ErrNotImplemented
 }
 
 func normalizeKind(kind string) string {

--- a/internal/connector/factory/factory_test.go
+++ b/internal/connector/factory/factory_test.go
@@ -169,6 +169,21 @@ func TestFactoryGitHubConnectorImplementsAuthenticator(t *testing.T) {
 	}
 }
 
+func TestFactoryLinearConnectorSupportsIssueCommentsOnly(t *testing.T) {
+	t.Parallel()
+
+	c, err := NewFromConfig(Config{Kind: "linear"})
+	if err != nil {
+		t.Fatalf("NewFromConfig() error = %v", err)
+	}
+	if _, ok := c.(connector.IssueCommentReader); !ok {
+		t.Fatalf("connector = %T, want connector.IssueCommentReader", c)
+	}
+	if _, ok := c.(connector.PullRequestCommenter); ok {
+		t.Fatalf("connector = %T, want no connector.PullRequestCommenter", c)
+	}
+}
+
 func TestFactoryGitHubLocalConnectorSelection(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/linear/client.go
+++ b/internal/connector/linear/client.go
@@ -95,16 +95,21 @@ func (c *Client) GraphQL(ctx context.Context, query string, variables map[string
 	}
 	defer resp.Body.Close()
 
-	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes+1))
-	if err != nil {
-		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
-	}
 	if resp.StatusCode != http.StatusOK {
+		raw, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes+1))
+		if err != nil {
+			return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+		}
 		return &StatusError{
 			StatusCode: resp.StatusCode,
 			Body:       strings.TrimSpace(string(raw)),
 			Err:        ErrUnexpectedStatus,
 		}
+	}
+
+	raw, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
 
 	var envelope struct {

--- a/internal/connector/linear/client.go
+++ b/internal/connector/linear/client.go
@@ -1,0 +1,148 @@
+package linear
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"strings"
+)
+
+const (
+	DefaultGraphQLEndpoint = "https://api.linear.app/graphql"
+	maxErrorBodyBytes      = 1000
+)
+
+type HTTPClient interface {
+	Do(*http.Request) (*http.Response, error)
+}
+
+type ClientConfig struct {
+	Endpoint   string
+	APIKey     string
+	HTTPClient HTTPClient
+	Logger     *slog.Logger
+}
+
+type Client struct {
+	endpoint   string
+	apiKey     string
+	httpClient HTTPClient
+	logger     *slog.Logger
+}
+
+func NewClient(cfg ClientConfig) (*Client, error) {
+	endpoint := strings.TrimSpace(cfg.Endpoint)
+	if endpoint == "" {
+		endpoint = DefaultGraphQLEndpoint
+	}
+	if err := validateEndpoint(endpoint); err != nil {
+		return nil, err
+	}
+
+	httpClient := cfg.HTTPClient
+	if httpClient == nil {
+		httpClient = http.DefaultClient
+	}
+
+	logger := cfg.Logger
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+
+	return &Client{
+		endpoint:   endpoint,
+		apiKey:     strings.TrimSpace(cfg.APIKey),
+		httpClient: httpClient,
+		logger:     logger,
+	}, nil
+}
+
+func (c *Client) GraphQL(ctx context.Context, query string, variables map[string]any, out any) error {
+	if strings.TrimSpace(c.apiKey) == "" {
+		return ErrMissingToken
+	}
+
+	payload := map[string]any{"query": query}
+	if variables != nil {
+		payload["variables"] = variables
+	}
+
+	var body bytes.Buffer
+	if err := json.NewEncoder(&body).Encode(payload); err != nil {
+		return fmt.Errorf("encode linear graphql request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, c.endpoint, &body)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidEndpoint, err)
+	}
+	req.Header.Set("Authorization", c.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	c.logger.DebugContext(ctx, "linear graphql request", "operation", firstLine(query), "variables_present", len(variables) > 0)
+
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		if ctxErr := ctx.Err(); ctxErr != nil {
+			return ctxErr
+		}
+		return fmt.Errorf("%w: %w", ErrTransient, err)
+	}
+	defer resp.Body.Close()
+
+	raw, err := io.ReadAll(io.LimitReader(resp.Body, maxErrorBodyBytes+1))
+	if err != nil {
+		return fmt.Errorf("%w: read response: %w", ErrTransient, err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return &StatusError{
+			StatusCode: resp.StatusCode,
+			Body:       strings.TrimSpace(string(raw)),
+			Err:        ErrUnexpectedStatus,
+		}
+	}
+
+	var envelope struct {
+		Data   json.RawMessage `json:"data"`
+		Errors []GraphQLError  `json:"errors"`
+	}
+	if err := json.Unmarshal(raw, &envelope); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
+	if len(envelope.Errors) > 0 {
+		return &GraphQLErrorList{Errors: envelope.Errors, Err: ErrGraphQLErrors}
+	}
+	if out == nil {
+		return nil
+	}
+	if len(envelope.Data) == 0 {
+		return ErrInvalidResponse
+	}
+	if err := json.Unmarshal(envelope.Data, out); err != nil {
+		return fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+	}
+
+	return nil
+}
+
+func validateEndpoint(endpoint string) error {
+	parsed, err := url.Parse(endpoint)
+	if err != nil || parsed.Scheme == "" || parsed.Host == "" {
+		return fmt.Errorf("%w: %s", ErrInvalidEndpoint, endpoint)
+	}
+	return nil
+}
+
+func firstLine(value string) string {
+	for _, line := range strings.Split(value, "\n") {
+		if line = strings.TrimSpace(line); line != "" {
+			return line
+		}
+	}
+	return ""
+}

--- a/internal/connector/linear/connector.go
+++ b/internal/connector/linear/connector.go
@@ -1,0 +1,285 @@
+package linear
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+const issueCommentsPageSize = 100
+
+const issueCommentsQuery = `
+query DetentLinearIssueComments($issueId: String!, $first: Int!, $after: String) {
+  issue(id: $issueId) {
+    comments(first: $first, after: $after, orderBy: createdAt) {
+      nodes {
+        id
+        body
+        url
+        createdAt
+        updatedAt
+        user {
+          id
+          name
+          displayName
+        }
+        externalUser {
+          id
+          name
+          displayName
+        }
+        botActor {
+          id
+          name
+          userDisplayName
+        }
+      }
+      pageInfo {
+        hasNextPage
+        endCursor
+      }
+    }
+  }
+}`
+
+const commentCreateMutation = `
+mutation DetentLinearCreateComment($issueId: String!, $body: String!) {
+  commentCreate(input: { issueId: $issueId, body: $body }) {
+    success
+    comment {
+      id
+    }
+  }
+}`
+
+type Config struct {
+	Endpoint   string
+	APIKey     string
+	HTTPClient HTTPClient
+	Logger     *slog.Logger
+}
+
+type Connector struct {
+	client *Client
+}
+
+var _ connector.Connector = (*Connector)(nil)
+var _ connector.IssueCommentReader = (*Connector)(nil)
+
+func NewConnector(cfg Config) (*Connector, error) {
+	client, err := NewClient(ClientConfig(cfg))
+	if err != nil {
+		return nil, err
+	}
+	return &Connector{client: client}, nil
+}
+
+func (c *Connector) Name() string {
+	return connector.BackendLinear.String()
+}
+
+func (c *Connector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *Connector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *Connector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	issueID := linearIssueID(issue)
+	if issueID == "" {
+		return []connector.IssueComment{}, nil
+	}
+
+	comments := []connector.IssueComment{}
+	var after *string
+	for {
+		page, err := c.fetchIssueCommentsPage(ctx, issueID, after)
+		if err != nil {
+			return nil, err
+		}
+		for _, comment := range page.Nodes {
+			comments = append(comments, connectorIssueComment(comment))
+		}
+		if !page.PageInfo.HasNextPage {
+			return comments, nil
+		}
+		cursor := strings.TrimSpace(page.PageInfo.EndCursor)
+		if cursor == "" {
+			return nil, ErrInvalidResponse
+		}
+		after = &cursor
+	}
+}
+
+func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return ErrMissingIssue
+	}
+
+	var response struct {
+		CommentCreate struct {
+			Success bool `json:"success"`
+			Comment *struct {
+				ID string `json:"id"`
+			} `json:"comment"`
+		} `json:"commentCreate"`
+	}
+	if err := c.client.GraphQL(ctx, commentCreateMutation, map[string]any{
+		"issueId": issueID,
+		"body":    body,
+	}, &response); err != nil {
+		return fmt.Errorf("create linear comment: %w", err)
+	}
+	if !response.CommentCreate.Success || response.CommentCreate.Comment == nil || strings.TrimSpace(response.CommentCreate.Comment.ID) == "" {
+		return ErrCommentCreateFailed
+	}
+
+	return nil
+}
+
+func (c *Connector) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *Connector) SetAssignee(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *Connector) SetField(context.Context, string, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (c *Connector) fetchIssueCommentsPage(ctx context.Context, issueID string, after *string) (linearCommentConnection, error) {
+	var response struct {
+		Issue *struct {
+			Comments linearCommentConnection `json:"comments"`
+		} `json:"issue"`
+	}
+	if err := c.client.GraphQL(ctx, issueCommentsQuery, map[string]any{
+		"issueId": issueID,
+		"first":   issueCommentsPageSize,
+		"after":   after,
+	}, &response); err != nil {
+		return linearCommentConnection{}, fmt.Errorf("fetch linear issue comments: %w", err)
+	}
+	if response.Issue == nil {
+		return linearCommentConnection{}, nil
+	}
+	return response.Issue.Comments, nil
+}
+
+type linearCommentConnection struct {
+	Nodes    []linearComment `json:"nodes"`
+	PageInfo pageInfo        `json:"pageInfo"`
+}
+
+type pageInfo struct {
+	HasNextPage bool   `json:"hasNextPage"`
+	EndCursor   string `json:"endCursor"`
+}
+
+type linearComment struct {
+	ID           string              `json:"id"`
+	Body         string              `json:"body"`
+	URL          string              `json:"url"`
+	CreatedAt    time.Time           `json:"createdAt"`
+	UpdatedAt    time.Time           `json:"updatedAt"`
+	User         *linearUser         `json:"user"`
+	ExternalUser *linearExternalUser `json:"externalUser"`
+	BotActor     *linearBotActor     `json:"botActor"`
+}
+
+type linearUser struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+
+type linearExternalUser struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+}
+
+type linearBotActor struct {
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	UserDisplayName string `json:"userDisplayName"`
+}
+
+func linearIssueID(issue connector.Issue) string {
+	for _, value := range []string{issue.ID, issue.Identifier} {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func connectorIssueComment(comment linearComment) connector.IssueComment {
+	return connector.IssueComment{
+		ID:                strings.TrimSpace(comment.ID),
+		Backend:           connector.BackendLinear.String(),
+		Body:              comment.Body,
+		URL:               strings.TrimSpace(comment.URL),
+		AuthorLogin:       linearAuthorLogin(comment),
+		AuthorDisplayName: linearAuthorDisplayName(comment),
+		CreatedAt:         linearTimePtr(comment.CreatedAt),
+		UpdatedAt:         linearTimePtr(comment.UpdatedAt),
+		TargetType:        connector.IssueCommentTargetIssue,
+	}
+}
+
+func linearAuthorLogin(comment linearComment) string {
+	if comment.User != nil {
+		return firstNonBlank(comment.User.DisplayName, comment.User.Name, comment.User.ID)
+	}
+	if comment.ExternalUser != nil {
+		return firstNonBlank(comment.ExternalUser.DisplayName, comment.ExternalUser.Name, comment.ExternalUser.ID)
+	}
+	if comment.BotActor != nil {
+		return firstNonBlank(comment.BotActor.UserDisplayName, comment.BotActor.Name, comment.BotActor.ID)
+	}
+	return ""
+}
+
+func linearAuthorDisplayName(comment linearComment) string {
+	if comment.User != nil {
+		return firstNonBlank(comment.User.Name, comment.User.DisplayName)
+	}
+	if comment.ExternalUser != nil {
+		return firstNonBlank(comment.ExternalUser.Name, comment.ExternalUser.DisplayName)
+	}
+	if comment.BotActor != nil {
+		return firstNonBlank(comment.BotActor.UserDisplayName, comment.BotActor.Name)
+	}
+	return ""
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func linearTimePtr(value time.Time) *time.Time {
+	if value.IsZero() {
+		return nil
+	}
+	value = value.UTC()
+	return &value
+}

--- a/internal/connector/linear/connector_test.go
+++ b/internal/connector/linear/connector_test.go
@@ -1,0 +1,241 @@
+package linear
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorFetchIssueCommentsMapsLinearMetadata(t *testing.T) {
+	t.Parallel()
+
+	createdAt := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	updatedAt := time.Date(2026, 7, 6, 12, 15, 0, 0, time.UTC)
+	server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
+		if !strings.Contains(request.Query, "DetentLinearIssueComments") {
+			t.Fatalf("query = %q, want issue comments query", request.Query)
+		}
+		if request.Variables["issueId"] != "LIN-123" {
+			t.Fatalf("issueId variable = %#v, want LIN-123", request.Variables["issueId"])
+		}
+		if request.Variables["first"] != float64(issueCommentsPageSize) {
+			t.Fatalf("first variable = %#v, want %d", request.Variables["first"], issueCommentsPageSize)
+		}
+		return map[string]any{
+			"data": map[string]any{
+				"issue": map[string]any{
+					"comments": map[string]any{
+						"nodes": []map[string]any{{
+							"id":        "comment-1",
+							"body":      "Root cause found.",
+							"url":       "https://linear.app/acme/issue/LIN-123#comment-1",
+							"createdAt": createdAt.Format(time.RFC3339),
+							"updatedAt": updatedAt.Format(time.RFC3339),
+							"user": map[string]any{
+								"id":          "user-1",
+								"name":        "Ada Lovelace",
+								"displayName": "ada",
+							},
+						}},
+						"pageInfo": map[string]any{
+							"hasNextPage": false,
+						},
+					},
+				},
+			},
+		}
+	})
+
+	c := newLinearTestConnector(t, server.URL)
+	got, err := c.FetchIssueComments(context.Background(), connector.Issue{Identifier: "LIN-123"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() error = %v", err)
+	}
+
+	want := []connector.IssueComment{{
+		ID:                "comment-1",
+		Backend:           connector.BackendLinear.String(),
+		Body:              "Root cause found.",
+		URL:               "https://linear.app/acme/issue/LIN-123#comment-1",
+		AuthorLogin:       "ada",
+		AuthorDisplayName: "Ada Lovelace",
+		CreatedAt:         &createdAt,
+		UpdatedAt:         &updatedAt,
+		TargetType:        connector.IssueCommentTargetIssue,
+	}}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("FetchIssueComments() = %#v, want %#v", got, want)
+	}
+}
+
+func TestConnectorFetchIssueCommentsPaginates(t *testing.T) {
+	t.Parallel()
+
+	var cursors []string
+	server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
+		after, _ := request.Variables["after"].(string)
+		cursors = append(cursors, after)
+		switch after {
+		case "":
+			return linearCommentsResponse([]map[string]any{linearCommentFixture("comment-1", "first")}, true, "cursor-1")
+		case "cursor-1":
+			return linearCommentsResponse([]map[string]any{linearCommentFixture("comment-2", "second")}, false, "")
+		default:
+			t.Fatalf("after variable = %q, want empty or cursor-1", after)
+			return nil
+		}
+	})
+
+	c := newLinearTestConnector(t, server.URL)
+	got, err := c.FetchIssueComments(context.Background(), connector.Issue{ID: "issue-uuid"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() error = %v", err)
+	}
+	if bodies := []string{got[0].Body, got[1].Body}; !reflect.DeepEqual(bodies, []string{"first", "second"}) {
+		t.Fatalf("comment bodies = %#v, want first and second", bodies)
+	}
+	if !reflect.DeepEqual(cursors, []string{"", "cursor-1"}) {
+		t.Fatalf("pagination cursors = %#v, want empty then cursor-1", cursors)
+	}
+}
+
+func TestConnectorCreateCommentCallsLinearMutation(t *testing.T) {
+	t.Parallel()
+
+	server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
+		if !strings.Contains(request.Query, "DetentLinearCreateComment") || !strings.Contains(request.Query, "commentCreate") {
+			t.Fatalf("query = %q, want create comment mutation", request.Query)
+		}
+		if request.Variables["issueId"] != "LIN-123" {
+			t.Fatalf("issueId variable = %#v, want LIN-123", request.Variables["issueId"])
+		}
+		if request.Variables["body"] != "Please verify the Linear path." {
+			t.Fatalf("body variable = %#v, want comment body", request.Variables["body"])
+		}
+		return map[string]any{
+			"data": map[string]any{
+				"commentCreate": map[string]any{
+					"success": true,
+					"comment": map[string]any{"id": "comment-created"},
+				},
+			},
+		}
+	})
+
+	c := newLinearTestConnector(t, server.URL)
+	if err := c.CreateComment(context.Background(), "LIN-123", "Please verify the Linear path."); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+}
+
+func TestConnectorCreateCommentReportsFailedMutation(t *testing.T) {
+	t.Parallel()
+
+	server := linearTestServer(t, func(t *testing.T, _ linearGraphQLRequest) any {
+		return map[string]any{
+			"data": map[string]any{
+				"commentCreate": map[string]any{
+					"success": false,
+					"comment": nil,
+				},
+			},
+		}
+	})
+
+	c := newLinearTestConnector(t, server.URL)
+	if err := c.CreateComment(context.Background(), "LIN-123", "body"); !errors.Is(err, ErrCommentCreateFailed) {
+		t.Fatalf("CreateComment() error = %v, want ErrCommentCreateFailed", err)
+	}
+}
+
+func TestConnectorDoesNotExposePullRequestCommenter(t *testing.T) {
+	t.Parallel()
+
+	c := newLinearTestConnector(t, "https://api.linear.app/graphql")
+	if _, ok := any(c).(connector.PullRequestCommenter); ok {
+		t.Fatalf("connector = %T, want no connector.PullRequestCommenter implementation", c)
+	}
+}
+
+type linearGraphQLRequest struct {
+	Query     string         `json:"query"`
+	Variables map[string]any `json:"variables"`
+}
+
+func linearTestServer(t *testing.T, handler func(*testing.T, linearGraphQLRequest) any) *httptest.Server {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "lin_api_test" {
+			t.Fatalf("Authorization = %q, want lin_api_test", got)
+		}
+
+		var request linearGraphQLRequest
+		if err := json.NewDecoder(r.Body).Decode(&request); err != nil {
+			t.Fatalf("decode request: %v", err)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(handler(t, request)); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+	return server
+}
+
+func newLinearTestConnector(t *testing.T, endpoint string) *Connector {
+	t.Helper()
+
+	c, err := NewConnector(Config{
+		Endpoint: endpoint,
+		APIKey:   "lin_api_test",
+	})
+	if err != nil {
+		t.Fatalf("NewConnector() error = %v", err)
+	}
+	return c
+}
+
+func linearCommentsResponse(nodes []map[string]any, hasNextPage bool, endCursor string) map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"issue": map[string]any{
+				"comments": map[string]any{
+					"nodes": nodes,
+					"pageInfo": map[string]any{
+						"hasNextPage": hasNextPage,
+						"endCursor":   endCursor,
+					},
+				},
+			},
+		},
+	}
+}
+
+func linearCommentFixture(id string, body string) map[string]any {
+	now := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	return map[string]any{
+		"id":        id,
+		"body":      body,
+		"url":       "https://linear.app/acme/issue/LIN-123#" + id,
+		"createdAt": now.Format(time.RFC3339),
+		"updatedAt": now.Format(time.RFC3339),
+		"botActor": map[string]any{
+			"id":              "bot-1",
+			"name":            "Detent",
+			"userDisplayName": "Detent Bot",
+		},
+	}
+}

--- a/internal/connector/linear/connector_test.go
+++ b/internal/connector/linear/connector_test.go
@@ -165,6 +165,52 @@ func TestConnectorDoesNotExposePullRequestCommenter(t *testing.T) {
 	}
 }
 
+func TestClientGraphQLReadsLargeSuccessfulResponse(t *testing.T) {
+	t.Parallel()
+
+	body := strings.Repeat("large response ", maxErrorBodyBytes)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Authorization"); got != "lin_api_test" {
+			t.Fatalf("Authorization = %q, want lin_api_test", got)
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(map[string]any{
+			"data": map[string]any{
+				"payload": map[string]any{
+					"body": body,
+				},
+			},
+		}); err != nil {
+			t.Fatalf("encode response: %v", err)
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint: server.URL,
+		APIKey:   "lin_api_test",
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	var got struct {
+		Payload struct {
+			Body string `json:"body"`
+		} `json:"payload"`
+	}
+	if err := client.GraphQL(context.Background(), "query Test { payload { body } }", nil, &got); err != nil {
+		t.Fatalf("GraphQL() error = %v", err)
+	}
+	if got.Payload.Body != body {
+		t.Fatalf("body length = %d, want %d", len(got.Payload.Body), len(body))
+	}
+}
+
 type linearGraphQLRequest struct {
 	Query     string         `json:"query"`
 	Variables map[string]any `json:"variables"`

--- a/internal/connector/linear/errors.go
+++ b/internal/connector/linear/errors.go
@@ -1,0 +1,66 @@
+package linear
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+var (
+	ErrCommentCreateFailed = errors.New("linear comment create failed")
+	ErrGraphQLErrors       = errors.New("linear graphql errors")
+	ErrInvalidEndpoint     = errors.New("linear endpoint is invalid")
+	ErrInvalidResponse     = errors.New("linear response is invalid")
+	ErrMissingIssue        = errors.New("linear issue is required")
+	ErrMissingToken        = errors.New("linear token is required")
+	ErrTransient           = errors.New("linear transient error")
+	ErrUnexpectedStatus    = errors.New("linear unexpected status")
+)
+
+type GraphQLError struct {
+	Message string `json:"message"`
+}
+
+type GraphQLErrorList struct {
+	Errors []GraphQLError
+	Err    error
+}
+
+func (e *GraphQLErrorList) Error() string {
+	if len(e.Errors) == 0 {
+		return e.Err.Error()
+	}
+
+	messages := make([]string, 0, len(e.Errors))
+	for _, err := range e.Errors {
+		if strings.TrimSpace(err.Message) != "" {
+			messages = append(messages, err.Message)
+		}
+	}
+	if len(messages) == 0 {
+		return e.Err.Error()
+	}
+
+	return fmt.Sprintf("%s: %s", e.Err, strings.Join(messages, "; "))
+}
+
+func (e *GraphQLErrorList) Unwrap() error {
+	return e.Err
+}
+
+type StatusError struct {
+	StatusCode int
+	Body       string
+	Err        error
+}
+
+func (e *StatusError) Error() string {
+	if strings.TrimSpace(e.Body) == "" {
+		return fmt.Sprintf("%s: status %d", e.Err, e.StatusCode)
+	}
+	return fmt.Sprintf("%s: status %d: %s", e.Err, e.StatusCode, e.Body)
+}
+
+func (e *StatusError) Unwrap() error {
+	return e.Err
+}

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -880,6 +880,12 @@ func (s *Server) apiKanbanComment(c echo.Context) error {
 		}
 		return kanbanFeedback(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
 	}
+	if req.target == "pr" && !kanbanSupportsPullRequestComments(target.connector) {
+		if kanbanDialogForm(c) {
+			return s.kanbanCommentDialogValidation(c, "Comment target is not available on the current board.")
+		}
+		return kanbanFeedback(c, http.StatusNotFound, "Comment target is not available on the current board.")
+	}
 	if !s.kanbanCommentTargetKnown(req) {
 		if kanbanDialogForm(c) {
 			return s.kanbanCommentDialogValidation(c, "Comment target is not available on the current board.")
@@ -1145,6 +1151,9 @@ func (s *Server) kanbanCommentDialogData(c echo.Context, message string) (templa
 	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
 		return data, "Kanban integration mode is not enabled."
 	}
+	if data.Target == "pr" && !kanbanSupportsPullRequestComments(target.connector) {
+		return data, "Comment target is not available on the current board."
+	}
 	return data, ""
 }
 
@@ -1317,13 +1326,14 @@ func (s *Server) dashboardKanbanData(ctx context.Context, projectID string, snap
 	}
 	states := kanbanStateNames(target.workflow, snapshot)
 	data := templates.KanbanData{
-		Mode:                    mode,
-		ProjectID:               strings.TrimSpace(projectID),
-		States:                  states,
-		TerminalStates:          target.workflow.Tracker.TerminalStates,
-		TerminalStatesByProject: s.kanbanTerminalStatesByProject(projectID),
-		AllowedTransitions:      kanbanAllowedTransitions(target.workflow, states),
-		ShowBlockedAlerts:       target.kanban.ShowBlockedAlerts,
+		Mode:                        mode,
+		ProjectID:                   strings.TrimSpace(projectID),
+		States:                      states,
+		TerminalStates:              target.workflow.Tracker.TerminalStates,
+		TerminalStatesByProject:     s.kanbanTerminalStatesByProject(projectID),
+		AllowedTransitions:          kanbanAllowedTransitions(target.workflow, states),
+		ShowBlockedAlerts:           target.kanban.ShowBlockedAlerts,
+		SupportsPullRequestComments: kanbanSupportsPullRequestComments(target.connector),
 	}
 	if strings.TrimSpace(projectID) == "" {
 		data.Projects = s.kanbanProjectsData(snapshot)
@@ -1354,17 +1364,26 @@ func (s *Server) kanbanProjectsData(snapshot telemetry.Snapshot) map[string]temp
 		}
 		states := kanbanStateNames(target.workflow, snapshot)
 		out[projectID] = templates.KanbanProjectData{
-			Mode:               target.kanban.Mode,
-			ProjectID:          projectID,
-			States:             states,
-			TerminalStates:     target.workflow.Tracker.TerminalStates,
-			AllowedTransitions: kanbanAllowedTransitions(target.workflow, states),
+			Mode:                        target.kanban.Mode,
+			ProjectID:                   projectID,
+			States:                      states,
+			TerminalStates:              target.workflow.Tracker.TerminalStates,
+			AllowedTransitions:          kanbanAllowedTransitions(target.workflow, states),
+			SupportsPullRequestComments: kanbanSupportsPullRequestComments(target.connector),
 		}
 	}
 	if len(out) == 0 {
 		return nil
 	}
 	return out
+}
+
+func kanbanSupportsPullRequestComments(c connector.Connector) bool {
+	if c == nil {
+		return false
+	}
+	_, ok := c.(connector.PullRequestCommenter)
+	return ok
 }
 
 func (s *Server) fleetKanbanSnapshotWithPendingStates(snapshot telemetry.Snapshot) telemetry.Snapshot {

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2722,6 +2722,64 @@ func TestBoardCardSheetShowsLocalCommentControlsOnly(t *testing.T) {
 	}
 }
 
+func TestKanbanActionsHidePullRequestCommentsWhenUnsupported(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, connectorProbe{name: "linear"})
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent"},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "LIN-123",
+			Identifier: "LIN-123",
+			ProjectID:  "detent",
+			Title:      "Linear commentable issue",
+			State:      "Todo",
+			PullRequest: &telemetry.PullRequest{
+				Number: 42,
+				URL:    "https://github.com/digitaldrywood/frontend/pull/42",
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := requestHTMLWithHeaders(t, server.Handler(), http.MethodGet, "/api/v1/board/card?project=detent&issue=LIN-123&scope=project&actions=board", http.StatusOK, map[string]string{
+		"HX-Request": "true",
+	})
+	if !strings.Contains(body, "Comment on issue") {
+		t.Fatalf("card sheet missing issue comment action:\n%s", body)
+	}
+	if strings.Contains(body, "Comment on PR") {
+		t.Fatalf("card sheet rendered unsupported PR comment action:\n%s", body)
+	}
+
+	prForm := url.Values{
+		"project_id":    {"detent"},
+		"target":        {"pr"},
+		"pr_repository": {"digitaldrywood/frontend"},
+		"pr_number":     {"42"},
+		"body":          {"Unsupported PR note"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/comment", prForm)
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusNotFound, rec.Body.String())
+	}
+	if !strings.Contains(rec.Body.String(), "Comment target is not available on the current board.") {
+		t.Fatalf("body missing unsupported target message: %s", rec.Body.String())
+	}
+}
+
 func TestKanbanCommentRejectsTargetsOutsideCurrentBoard(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -90,24 +90,26 @@ type Budget = telemetry.Budget
 type RateLimits = telemetry.RateLimits
 
 type KanbanData struct {
-	Mode                    string
-	ProjectID               string
-	States                  []string
-	TerminalStates          []string
-	TerminalStatesByProject map[string][]string
-	AllowedTransitions      map[string][]string
-	ShowBlockedAlerts       bool
-	Projects                map[string]KanbanProjectData
-	Feedback                string
-	FeedbackKind            string
+	Mode                        string
+	ProjectID                   string
+	States                      []string
+	TerminalStates              []string
+	TerminalStatesByProject     map[string][]string
+	AllowedTransitions          map[string][]string
+	ShowBlockedAlerts           bool
+	SupportsPullRequestComments bool
+	Projects                    map[string]KanbanProjectData
+	Feedback                    string
+	FeedbackKind                string
 }
 
 type KanbanProjectData struct {
-	Mode               string
-	ProjectID          string
-	States             []string
-	TerminalStates     []string
-	AllowedTransitions map[string][]string
+	Mode                        string
+	ProjectID                   string
+	States                      []string
+	TerminalStates              []string
+	AllowedTransitions          map[string][]string
+	SupportsPullRequestComments bool
 }
 
 type KanbanMoveDialogData struct {
@@ -2240,11 +2242,12 @@ func projectKanbanCardKanbanData(data DashboardData, card projectKanbanCard) Kan
 		projectID = configuredProjectID
 	}
 	return KanbanData{
-		Mode:               projectData.Mode,
-		ProjectID:          projectID,
-		States:             projectData.States,
-		TerminalStates:     projectData.TerminalStates,
-		AllowedTransitions: projectData.AllowedTransitions,
+		Mode:                        projectData.Mode,
+		ProjectID:                   projectID,
+		States:                      projectData.States,
+		TerminalStates:              projectData.TerminalStates,
+		AllowedTransitions:          projectData.AllowedTransitions,
+		SupportsPullRequestComments: projectData.SupportsPullRequestComments,
 	}
 }
 
@@ -2814,10 +2817,25 @@ func projectKanbanCardCanRemove(data DashboardData, card projectKanbanCard) bool
 }
 
 func projectKanbanCardCanComment(data DashboardData, card projectKanbanCard) bool {
-	if !snapshotReady(data.Snapshot) || !isProjectDashboard(data) || !kanbanIntegrationEnabled(data) {
+	if !projectKanbanCardCanUseComments(data, card) {
 		return false
 	}
-	return strings.TrimSpace(card.IssueID) != "" || (card.PRNumber > 0 && strings.TrimSpace(card.PRRepository) != "")
+	return strings.TrimSpace(card.IssueID) != "" || projectKanbanCardCanCommentOnPullRequest(data, card)
+}
+
+func projectKanbanCardCanCommentOnIssue(data DashboardData, card projectKanbanCard) bool {
+	return projectKanbanCardCanUseComments(data, card) && strings.TrimSpace(card.IssueID) != ""
+}
+
+func projectKanbanCardCanCommentOnPullRequest(data DashboardData, card projectKanbanCard) bool {
+	if !projectKanbanCardCanUseComments(data, card) || card.PRNumber <= 0 || strings.TrimSpace(card.PRRepository) == "" {
+		return false
+	}
+	return projectKanbanCardKanbanData(data, card).SupportsPullRequestComments
+}
+
+func projectKanbanCardCanUseComments(data DashboardData, card projectKanbanCard) bool {
+	return snapshotReady(data.Snapshot) && isProjectDashboard(data) && projectKanbanCardIntegrationEnabled(data, card)
 }
 
 func projectKanbanMoveTargetStates(data DashboardData, card projectKanbanCard) []string {

--- a/internal/web/templates/sheet.templ
+++ b/internal/web/templates/sheet.templ
@@ -124,10 +124,10 @@ templ BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions bo
 							>Move</button>
 						}
 					}
-					if card.IssueID != "" && projectKanbanCardCanComment(data, card) {
+					if projectKanbanCardCanCommentOnIssue(data, card) {
 						@sheetCommentTrigger(data, card, "issue", "Comment on issue")
 					}
-					if card.PRNumber > 0 && card.PRRepository != "" && projectKanbanCardCanComment(data, card) {
+					if projectKanbanCardCanCommentOnPullRequest(data, card) {
 						@sheetCommentTrigger(data, card, "pr", "Comment on PR")
 					}
 					if projectKanbanCardCanRemove(data, card) {

--- a/internal/web/templates/sheet_templ.go
+++ b/internal/web/templates/sheet_templ.go
@@ -454,13 +454,13 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 					return templ_7745c5c3_Err
 				}
 			}
-			if card.IssueID != "" && projectKanbanCardCanComment(data, card) {
+			if projectKanbanCardCanCommentOnIssue(data, card) {
 				templ_7745c5c3_Err = sheetCommentTrigger(data, card, "issue", "Comment on issue").Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			if card.PRNumber > 0 && card.PRRepository != "" && projectKanbanCardCanComment(data, card) {
+			if projectKanbanCardCanCommentOnPullRequest(data, card) {
 				templ_7745c5c3_Err = sheetCommentTrigger(data, card, "pr", "Comment on PR").Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err


### PR DESCRIPTION
## Summary

- Add a Linear GraphQL connector path for fetching and creating issue comments with normalized `connector.IssueComment` metadata.
- Wire the Linear connector through the factory and keep PR comment capability unsupported.
- Gate Kanban PR comment UI/actions on the generic `PullRequestCommenter` capability so Linear-backed cards hide unsupported PR comment controls.

Fixes #952

## Test Plan

- [x] `go test ./internal/connector/linear ./internal/connector/factory ./internal/web ./internal/web/templates`
- [x] `make check`