### PR TITLE
feat(comments): support local issue comment mutations

### DIFF
--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -81,6 +81,14 @@ type IssueCommentReader interface {
 	FetchIssueComments(context.Context, Issue) ([]IssueComment, error)
 }
 
+type IssueCommentUpdater interface {
+	UpdateIssueComment(context.Context, string, string, string) error
+}
+
+type IssueCommentDeleter interface {
+	DeleteIssueComment(context.Context, string, string) error
+}
+
 type IssueDraft struct {
 	Title  string
 	Body   string

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -54,7 +54,9 @@ var _ connector.GraphQLRateLimitUsageReporter = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
 var _ connector.IssueChildrenResolver = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
+var _ connector.IssueCommentDeleter = (*Connector)(nil)
 var _ connector.IssueCommentReader = (*Connector)(nil)
+var _ connector.IssueCommentUpdater = (*Connector)(nil)
 var _ connector.IssueFieldClearer = (*Connector)(nil)
 var _ connector.IssueFieldSetter = (*Connector)(nil)
 var _ connector.IssueParentResolver = (*Connector)(nil)
@@ -269,6 +271,14 @@ func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issu
 
 func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
 	return c.local.CreateComment(ctx, issueID, body)
+}
+
+func (c *Connector) UpdateIssueComment(ctx context.Context, issueID string, commentID string, body string) error {
+	return c.local.UpdateIssueComment(ctx, issueID, commentID, body)
+}
+
+func (c *Connector) DeleteIssueComment(ctx context.Context, issueID string, commentID string) error {
+	return c.local.DeleteIssueComment(ctx, issueID, commentID)
 }
 
 func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateName string) error {

--- a/internal/connector/githublocal/githublocal_test.go
+++ b/internal/connector/githublocal/githublocal_test.go
@@ -288,6 +288,48 @@ func TestConnectorFetchIssueCommentsMergesRemoteAndLocalInCreatedOrder(t *testin
 	if got[1].Backend != connector.BackendLocalSQLite.String() || got[0].Backend != connector.BackendGitHub.String() {
 		t.Fatalf("comment backends = %#v, want GitHub and local SQLite metadata", got)
 	}
+	if got[0].CanEdit || got[0].CanDelete || !got[1].CanEdit || !got[1].CanDelete || got[2].CanEdit || got[2].CanDelete {
+		t.Fatalf("comment mutation flags = [%v/%v %v/%v %v/%v], want remote read-only and local mutable",
+			got[0].CanEdit, got[0].CanDelete, got[1].CanEdit, got[1].CanDelete, got[2].CanEdit, got[2].CanDelete)
+	}
+
+	localCommentID := got[1].ID
+	if err := conn.UpdateIssueComment(context.Background(), "github:123:779", localCommentID, "edited local note"); err != nil {
+		t.Fatalf("UpdateIssueComment() error = %v", err)
+	}
+	got, err = conn.FetchIssueComments(context.Background(), connector.Issue{
+		ID:         "github:123:779",
+		Identifier: "digitaldrywood/detent#779",
+	})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() after edit error = %v", err)
+	}
+	wantBodies = []string{"remote earlier", "edited local note", "remote later"}
+	for index, want := range wantBodies {
+		if got[index].Body != want {
+			t.Fatalf("comment[%d].Body after edit = %q, want %q; comments = %#v", index, got[index].Body, want, got)
+		}
+	}
+
+	if err := conn.DeleteIssueComment(context.Background(), "github:123:779", localCommentID); err != nil {
+		t.Fatalf("DeleteIssueComment() error = %v", err)
+	}
+	got, err = conn.FetchIssueComments(context.Background(), connector.Issue{
+		ID:         "github:123:779",
+		Identifier: "digitaldrywood/detent#779",
+	})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() after delete error = %v", err)
+	}
+	wantBodies = []string{"remote earlier", "remote later"}
+	if len(got) != len(wantBodies) {
+		t.Fatalf("FetchIssueComments() after delete len = %d, want %d: %#v", len(got), len(wantBodies), got)
+	}
+	for index, want := range wantBodies {
+		if got[index].Body != want {
+			t.Fatalf("comment[%d].Body after delete = %q, want %q; comments = %#v", index, got[index].Body, want, got)
+		}
+	}
 }
 
 type githubLocalTestRequest struct {

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -115,6 +115,8 @@ type IssueComment struct {
 	CreatedAt         *time.Time `json:"created_at,omitempty" yaml:"created_at,omitempty"`
 	UpdatedAt         *time.Time `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
 	Local             bool       `json:"local,omitempty" yaml:"local,omitempty"`
+	CanEdit           bool       `json:"can_edit,omitempty" yaml:"can_edit,omitempty"`
+	CanDelete         bool       `json:"can_delete,omitempty" yaml:"can_delete,omitempty"`
 	TargetType        string     `json:"target_type,omitempty" yaml:"target_type,omitempty"`
 }
 

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -21,10 +21,16 @@ const (
 	defaultProjectID = "default"
 
 	eventKindComment       = "comment"
+	eventKindCommentEdit   = "comment_edit"
+	eventKindCommentDelete = "comment_delete"
 	eventKindStateUpdate   = "state_update"
 	eventKindFieldUpdate   = "field_update"
 	eventKindProjectRemove = "project_remove"
 	eventKindClose         = "close"
+
+	commentPayloadActor        = "actor"
+	commentPayloadCommentID    = "comment_id"
+	commentPayloadPreviousBody = "previous_body"
 
 	MetadataGitHubNodeID        = "github_node_id"
 	MetadataGitHubRepositoryID  = "github_repository_id"
@@ -56,7 +62,9 @@ var _ connector.Connector = (*Connector)(nil)
 var _ connector.CandidateIssuesByStatesFetcher = (*Connector)(nil)
 var _ connector.IssuesByStatesLimiter = (*Connector)(nil)
 var _ connector.IssueCloser = (*Connector)(nil)
+var _ connector.IssueCommentDeleter = (*Connector)(nil)
 var _ connector.IssueCommentReader = (*Connector)(nil)
+var _ connector.IssueCommentUpdater = (*Connector)(nil)
 var _ connector.IssueFieldClearer = (*Connector)(nil)
 var _ connector.IssueFieldSetter = (*Connector)(nil)
 var _ connector.IssueReferenceResolver = (*Connector)(nil)
@@ -176,40 +184,119 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 
 func (c *Connector) FetchIssueComments(ctx context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
 	rows, err := c.db.QueryContext(ctx, `
-select id, body, created_at from detent_work_item_events
-where project_id = ? and item_id = ? and event_kind = ?
-order by id asc`, c.projectID, strings.TrimSpace(issue.ID), eventKindComment)
+select id, event_kind, body, payload_json, created_at from detent_work_item_events
+where project_id = ? and item_id = ? and event_kind in (?, ?, ?)
+order by id asc`, c.projectID, strings.TrimSpace(issue.ID), eventKindComment, eventKindCommentEdit, eventKindCommentDelete)
 	if err != nil {
 		return nil, err
 	}
 	defer rows.Close()
 
-	comments := []connector.IssueComment{}
+	commentsByID := map[string]connector.IssueComment{}
+	order := []string{}
 	for rows.Next() {
 		var id int64
+		var kind string
 		var body string
+		var payloadJSON string
 		var createdAt string
-		if err := rows.Scan(&id, &body, &createdAt); err != nil {
+		if err := rows.Scan(&id, &kind, &body, &payloadJSON, &createdAt); err != nil {
 			return nil, err
 		}
-		comments = append(comments, connector.IssueComment{
-			ID:          strconv.FormatInt(id, 10),
-			Backend:     connector.BackendLocalSQLite.String(),
-			Body:        body,
-			AuthorLogin: "detent",
-			CreatedAt:   parseTimePointer(createdAt),
-			Local:       true,
-			TargetType:  connector.IssueCommentTargetIssue,
-		})
+		eventTime := parseTimePointer(createdAt)
+		switch kind {
+		case eventKindComment:
+			commentID := strconv.FormatInt(id, 10)
+			commentsByID[commentID] = connector.IssueComment{
+				ID:                commentID,
+				Backend:           connector.BackendLocalSQLite.String(),
+				Body:              body,
+				AuthorLogin:       "detent",
+				AuthorDisplayName: "Detent",
+				CreatedAt:         eventTime,
+				Local:             true,
+				CanEdit:           true,
+				CanDelete:         true,
+				TargetType:        connector.IssueCommentTargetIssue,
+			}
+			order = append(order, commentID)
+		case eventKindCommentEdit:
+			payload := unmarshalStringMap(payloadJSON)
+			commentID := strings.TrimSpace(payload[commentPayloadCommentID])
+			comment, ok := commentsByID[commentID]
+			if !ok {
+				continue
+			}
+			comment.Body = body
+			comment.UpdatedAt = eventTime
+			commentsByID[commentID] = comment
+		case eventKindCommentDelete:
+			payload := unmarshalStringMap(payloadJSON)
+			commentID := strings.TrimSpace(payload[commentPayloadCommentID])
+			delete(commentsByID, commentID)
+		}
 	}
 	if err := rows.Err(); err != nil {
 		return nil, err
+	}
+	comments := []connector.IssueComment{}
+	for _, commentID := range order {
+		comment, ok := commentsByID[commentID]
+		if ok {
+			comments = append(comments, comment)
+		}
 	}
 	return comments, nil
 }
 
 func (c *Connector) CreateComment(ctx context.Context, issueID string, body string) error {
 	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindComment, "", strings.TrimSpace(body), nil)
+}
+
+func (c *Connector) localIssueCommentByID(ctx context.Context, issueID string, commentID string) (connector.IssueComment, error) {
+	issueID = strings.TrimSpace(issueID)
+	commentID = strings.TrimSpace(commentID)
+	if issueID == "" || commentID == "" {
+		return connector.IssueComment{}, sql.ErrNoRows
+	}
+	comments, err := c.FetchIssueComments(ctx, connector.Issue{ID: issueID})
+	if err != nil {
+		return connector.IssueComment{}, err
+	}
+	for _, comment := range comments {
+		if strings.TrimSpace(comment.ID) == commentID {
+			return comment, nil
+		}
+	}
+	return connector.IssueComment{}, sql.ErrNoRows
+}
+
+func (c *Connector) UpdateIssueComment(ctx context.Context, issueID string, commentID string, body string) error {
+	body = strings.TrimSpace(body)
+	if body == "" {
+		return errors.New("local comment body is required")
+	}
+	comment, err := c.localIssueCommentByID(ctx, issueID, commentID)
+	if err != nil {
+		return err
+	}
+	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindCommentEdit, "", body, map[string]string{
+		commentPayloadActor:        "detent",
+		commentPayloadCommentID:    comment.ID,
+		commentPayloadPreviousBody: comment.Body,
+	})
+}
+
+func (c *Connector) DeleteIssueComment(ctx context.Context, issueID string, commentID string) error {
+	comment, err := c.localIssueCommentByID(ctx, issueID, commentID)
+	if err != nil {
+		return err
+	}
+	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindCommentDelete, "", "", map[string]string{
+		commentPayloadActor:        "detent",
+		commentPayloadCommentID:    comment.ID,
+		commentPayloadPreviousBody: comment.Body,
+	})
 }
 
 func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateName string) error {

--- a/internal/connector/local/local_test.go
+++ b/internal/connector/local/local_test.go
@@ -144,12 +144,124 @@ func TestConnectorFetchIssueCommentsReturnsEventMetadata(t *testing.T) {
 		comment.Backend != connector.BackendLocalSQLite.String() ||
 		comment.Body != "Ready for review." ||
 		comment.AuthorLogin != "detent" ||
+		comment.AuthorDisplayName != "Detent" ||
 		!comment.Local ||
+		!comment.CanEdit ||
+		!comment.CanDelete ||
 		comment.TargetType != connector.IssueCommentTargetIssue {
 		t.Fatalf("FetchIssueComments()[0] = %#v, want normalized local metadata", comment)
 	}
 	if comment.CreatedAt == nil || !comment.CreatedAt.Equal(now) {
 		t.Fatalf("CreatedAt = %v, want %v", comment.CreatedAt, now)
+	}
+}
+
+func TestConnectorUpdatesAndDeletesLocalIssueCommentsWithAuditEvents(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	timestamps := []time.Time{
+		time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC),
+		time.Date(2026, 7, 6, 12, 5, 0, 0, time.UTC),
+		time.Date(2026, 7, 6, 12, 10, 0, 0, time.UTC),
+	}
+	next := 0
+	store, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "comment-mutations.db"),
+		ProjectID: "video",
+		Now: func() time.Time {
+			if next >= len(timestamps) {
+				return timestamps[len(timestamps)-1]
+			}
+			value := timestamps[next]
+			next++
+			return value
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer store.Close()
+
+	if err := store.CreateComment(ctx, "ad-1", "Draft body"); err != nil {
+		t.Fatalf("CreateComment() error = %v", err)
+	}
+	comments, err := store.FetchIssueComments(ctx, connector.Issue{ID: "ad-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() after create error = %v", err)
+	}
+	if len(comments) != 1 {
+		t.Fatalf("comments after create len = %d, want 1", len(comments))
+	}
+	commentID := comments[0].ID
+
+	if err := store.UpdateIssueComment(ctx, "ad-1", commentID, "Edited body"); err != nil {
+		t.Fatalf("UpdateIssueComment() error = %v", err)
+	}
+	comments, err = store.FetchIssueComments(ctx, connector.Issue{ID: "ad-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() after edit error = %v", err)
+	}
+	if len(comments) != 1 || comments[0].Body != "Edited body" {
+		t.Fatalf("comments after edit = %#v, want edited body", comments)
+	}
+	if comments[0].UpdatedAt == nil || !comments[0].UpdatedAt.Equal(timestamps[1]) {
+		t.Fatalf("UpdatedAt = %v, want %v", comments[0].UpdatedAt, timestamps[1])
+	}
+
+	if err := store.DeleteIssueComment(ctx, "ad-1", commentID); err != nil {
+		t.Fatalf("DeleteIssueComment() error = %v", err)
+	}
+	comments, err = store.FetchIssueComments(ctx, connector.Issue{ID: "ad-1"})
+	if err != nil {
+		t.Fatalf("FetchIssueComments() after delete error = %v", err)
+	}
+	if len(comments) != 0 {
+		t.Fatalf("comments after delete = %#v, want none", comments)
+	}
+
+	rows, err := store.db.QueryContext(ctx, `
+select event_kind, body, payload_json from detent_work_item_events
+where project_id = ? and item_id = ?
+order by id asc`, "video", "ad-1")
+	if err != nil {
+		t.Fatalf("query events error = %v", err)
+	}
+	defer rows.Close()
+
+	type eventRow struct {
+		kind    string
+		body    string
+		payload map[string]string
+	}
+	got := []eventRow{}
+	for rows.Next() {
+		var row eventRow
+		var payloadJSON string
+		if err := rows.Scan(&row.kind, &row.body, &payloadJSON); err != nil {
+			t.Fatalf("scan event error = %v", err)
+		}
+		row.payload = unmarshalStringMap(payloadJSON)
+		got = append(got, row)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("rows error = %v", err)
+	}
+	if len(got) != 3 {
+		t.Fatalf("event rows len = %d, want 3: %#v", len(got), got)
+	}
+	if got[0].kind != eventKindComment || got[0].body != "Draft body" {
+		t.Fatalf("create event = %#v, want comment draft", got[0])
+	}
+	if got[1].kind != eventKindCommentEdit || got[1].body != "Edited body" ||
+		got[1].payload[commentPayloadCommentID] != commentID ||
+		got[1].payload[commentPayloadPreviousBody] != "Draft body" {
+		t.Fatalf("edit event = %#v, want comment id and previous body", got[1])
+	}
+	if got[2].kind != eventKindCommentDelete ||
+		got[2].payload[commentPayloadCommentID] != commentID ||
+		got[2].payload[commentPayloadPreviousBody] != "Edited body" {
+		t.Fatalf("delete event = %#v, want comment id and previous body", got[2])
 	}
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -422,6 +422,8 @@ func telemetryIssueComments(comments []connector.IssueComment) []telemetry.Issue
 			CreatedAt:         cloneTime(comment.CreatedAt),
 			UpdatedAt:         cloneTime(comment.UpdatedAt),
 			Local:             comment.Local,
+			CanEdit:           comment.CanEdit,
+			CanDelete:         comment.CanDelete,
 			TargetType:        comment.TargetType,
 		})
 	}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -223,6 +223,8 @@ type IssueComment struct {
 	CreatedAt         *time.Time `json:"created_at,omitempty"`
 	UpdatedAt         *time.Time `json:"updated_at,omitempty"`
 	Local             bool       `json:"local,omitempty"`
+	CanEdit           bool       `json:"can_edit,omitempty"`
+	CanDelete         bool       `json:"can_delete,omitempty"`
 	TargetType        string     `json:"target_type,omitempty"`
 }
 

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -2,6 +2,8 @@ package web
 
 import (
 	"context"
+	"database/sql"
+	"errors"
 	"fmt"
 	"html"
 	"maps"
@@ -73,6 +75,14 @@ type kanbanCommentRequest struct {
 	prRepository string
 	prNumber     int
 	body         string
+}
+
+type kanbanCommentMutationRequest struct {
+	projectID  string
+	issueID    string
+	commentID  string
+	body       string
+	mutateVerb string
 }
 
 const (
@@ -899,6 +909,119 @@ func (s *Server) apiKanbanComment(c echo.Context) error {
 	return kanbanFeedback(c, http.StatusOK, "Comment submitted.")
 }
 
+func (s *Server) apiKanbanCommentEdit(c echo.Context) error {
+	req, response, status := parseKanbanCommentMutationRequest(c, true)
+	if response != "" {
+		return kanbanFeedback(c, status, response)
+	}
+	req.mutateVerb = "edit"
+
+	target, response, status := s.kanbanActionTarget(req.projectID)
+	if response != "" {
+		return kanbanFeedback(c, status, response)
+	}
+	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
+		return kanbanFeedback(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
+	}
+	if !s.kanbanCommentCanMutate(req, true) {
+		return kanbanFeedback(c, http.StatusForbidden, "Only local Detent comments can be edited.")
+	}
+
+	err := s.kanbanMutations.withLock(target.key, func() error {
+		editor, ok := target.connector.(connector.IssueCommentUpdater)
+		if !ok {
+			return connector.ErrNotImplemented
+		}
+		return editor.UpdateIssueComment(c.Request().Context(), req.issueID, req.commentID, req.body)
+	})
+	if err != nil {
+		return s.kanbanCommentMutationError(c, req, err)
+	}
+	s.requestKanbanRefresh(c.Request().Context())
+	return s.kanbanCommentThreadResponse(c, target, req)
+}
+
+func (s *Server) apiKanbanCommentDelete(c echo.Context) error {
+	req, response, status := parseKanbanCommentMutationRequest(c, false)
+	if response != "" {
+		return kanbanFeedback(c, status, response)
+	}
+	req.mutateVerb = "delete"
+
+	target, response, status := s.kanbanActionTarget(req.projectID)
+	if response != "" {
+		return kanbanFeedback(c, status, response)
+	}
+	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
+		return kanbanFeedback(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
+	}
+	if !s.kanbanCommentCanMutate(req, false) {
+		return kanbanFeedback(c, http.StatusForbidden, "Only local Detent comments can be deleted.")
+	}
+
+	err := s.kanbanMutations.withLock(target.key, func() error {
+		deleter, ok := target.connector.(connector.IssueCommentDeleter)
+		if !ok {
+			return connector.ErrNotImplemented
+		}
+		return deleter.DeleteIssueComment(c.Request().Context(), req.issueID, req.commentID)
+	})
+	if err != nil {
+		return s.kanbanCommentMutationError(c, req, err)
+	}
+	s.requestKanbanRefresh(c.Request().Context())
+	return s.kanbanCommentThreadResponse(c, target, req)
+}
+
+func (s *Server) kanbanCommentMutationError(c echo.Context, req kanbanCommentMutationRequest, err error) error {
+	s.logger.WarnContext(c.Request().Context(), "kanban comment mutation failed", "project", req.projectID, "issue_id", req.issueID, "comment_id", req.commentID, "verb", req.mutateVerb, "error", err)
+	if errors.Is(err, sql.ErrNoRows) {
+		return kanbanFeedback(c, http.StatusNotFound, "Local comment is not available on the current board.")
+	}
+	if errors.Is(err, connector.ErrNotImplemented) {
+		return kanbanFeedback(c, http.StatusNotImplemented, "Local comment "+req.mutateVerb+" is not supported for this connector.")
+	}
+	return kanbanFeedback(c, http.StatusBadGateway, "Comment "+req.mutateVerb+" failed: "+err.Error())
+}
+
+func (s *Server) kanbanCommentThreadResponse(c echo.Context, target kanbanActionTarget, req kanbanCommentMutationRequest) error {
+	if c.Request().Header.Get("HX-Request") != "true" {
+		return c.JSON(http.StatusOK, map[string]any{"ok": true, "message": "Comment " + kanbanCommentMutationPastTense(req.mutateVerb) + "."})
+	}
+	ctx := c.Request().Context()
+	data, ok := s.projectDashboardData(ctx, req.projectID, s.latestSnapshot(ctx))
+	if !ok {
+		return kanbanFeedback(c, http.StatusNotFound, "Project is not available on the current board.")
+	}
+	card, ok := templates.FindBoardCard(data, req.projectID, req.issueID)
+	if !ok {
+		return kanbanFeedback(c, http.StatusNotFound, "Comment target is not available on the current board.")
+	}
+	reader, ok := target.connector.(connector.IssueCommentReader)
+	if ok {
+		comments, err := reader.FetchIssueComments(ctx, connector.Issue{
+			ID:         req.issueID,
+			Identifier: card.Identifier,
+		})
+		if err != nil {
+			return kanbanFeedback(c, http.StatusBadGateway, "Comment refresh failed: "+err.Error())
+		}
+		card = templates.WithKanbanCardComments(card, telemetryIssueComments(comments))
+	}
+	return render(c, templates.KanbanCommentThread(data, card, true))
+}
+
+func kanbanCommentMutationPastTense(verb string) string {
+	switch verb {
+	case "edit":
+		return "edited"
+	case "delete":
+		return "deleted"
+	default:
+		return strings.TrimSpace(verb)
+	}
+}
+
 func (s *Server) kanbanMoveDialogValidation(c echo.Context, message string) error {
 	c.Response().Header().Set("HX-Retarget", kanbanDialogContentTarget)
 	c.Response().Header().Set("HX-Reswap", "innerHTML")
@@ -1094,6 +1217,32 @@ func parseKanbanCommentRequest(c echo.Context) (kanbanCommentRequest, string, in
 		return kanbanCommentRequest{}, "Comment target must be issue or pr.", http.StatusBadRequest
 	}
 	return req, "", 0
+}
+
+func parseKanbanCommentMutationRequest(c echo.Context, requireBody bool) (kanbanCommentMutationRequest, string, int) {
+	req := kanbanCommentMutationRequest{
+		projectID: kanbanFormOrQueryValue(c, "project_id"),
+		issueID:   kanbanFormOrQueryValue(c, "issue_id"),
+		commentID: kanbanFormOrQueryValue(c, "comment_id"),
+		body:      strings.TrimSpace(c.FormValue("body")),
+	}
+	if req.issueID == "" {
+		return kanbanCommentMutationRequest{}, "Issue id is required.", http.StatusBadRequest
+	}
+	if req.commentID == "" {
+		return kanbanCommentMutationRequest{}, "Comment id is required.", http.StatusBadRequest
+	}
+	if requireBody && req.body == "" {
+		return kanbanCommentMutationRequest{}, "Comment body is required.", http.StatusBadRequest
+	}
+	return req, "", 0
+}
+
+func kanbanFormOrQueryValue(c echo.Context, key string) string {
+	if value := strings.TrimSpace(c.FormValue(key)); value != "" {
+		return value
+	}
+	return strings.TrimSpace(c.QueryParam(key))
 }
 
 func kanbanDialogForm(c echo.Context) bool {
@@ -1417,6 +1566,28 @@ func (s *Server) kanbanCommentTargetKnown(req kanbanCommentRequest) bool {
 	return false
 }
 
+func (s *Server) kanbanCommentCanMutate(req kanbanCommentMutationRequest, edit bool) bool {
+	snapshot, ok := s.hub.Latest()
+	if !ok {
+		return false
+	}
+	for _, issue := range snapshotKanbanIssues(snapshot) {
+		if !sameKanbanIssue(issue, req.projectID, req.issueID, snapshot.Project.ID) {
+			continue
+		}
+		for _, comment := range issue.Comments {
+			if strings.TrimSpace(comment.ID) != req.commentID || !comment.Local {
+				continue
+			}
+			if edit {
+				return comment.CanEdit
+			}
+			return comment.CanDelete
+		}
+	}
+	return false
+}
+
 func (s *Server) requestKanbanRefresh(ctx context.Context) {
 	if s.refresher == nil {
 		return
@@ -1424,6 +1595,27 @@ func (s *Server) requestKanbanRefresh(ctx context.Context) {
 	if _, err := s.refresher.RequestRefresh(ctx); err != nil {
 		s.logger.DebugContext(ctx, "kanban refresh request failed", "error", err)
 	}
+}
+
+func telemetryIssueComments(comments []connector.IssueComment) []telemetry.IssueComment {
+	out := make([]telemetry.IssueComment, 0, len(comments))
+	for _, comment := range comments {
+		out = append(out, telemetry.IssueComment{
+			ID:                comment.ID,
+			Backend:           comment.Backend,
+			Body:              comment.Body,
+			URL:               comment.URL,
+			AuthorLogin:       comment.AuthorLogin,
+			AuthorDisplayName: comment.AuthorDisplayName,
+			CreatedAt:         cloneKanbanTimePointer(comment.CreatedAt),
+			UpdatedAt:         cloneKanbanTimePointer(comment.UpdatedAt),
+			Local:             comment.Local,
+			CanEdit:           comment.CanEdit,
+			CanDelete:         comment.CanDelete,
+			TargetType:        comment.TargetType,
+		})
+	}
+	return out
 }
 
 func kanbanFeedback(c echo.Context, status int, message string) error {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -293,6 +293,8 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/api/v1/kanban/remove", s.apiKanbanRemove, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.GET("/api/v1/kanban/comment", s.apiKanbanCommentDialog, apiDashboardReadAuth, apiReadScope)
 	s.echo.POST("/api/v1/kanban/comment", s.apiKanbanComment, apiDashboardMutateAuth, apiProjectWriteScope)
+	s.echo.POST("/api/v1/kanban/comment/edit", s.apiKanbanCommentEdit, apiDashboardMutateAuth, apiProjectWriteScope)
+	s.echo.DELETE("/api/v1/kanban/comment", s.apiKanbanCommentDelete, apiDashboardMutateAuth, apiProjectWriteScope)
 	s.echo.GET("/api/v1/*", s.apiIssue, apiReadAuth, apiReadScope)
 }
 

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"crypto/sha256"
+	"database/sql"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -2567,6 +2568,157 @@ func TestKanbanActionsRouteCommentsToIssuesAndPullRequests(t *testing.T) {
 	}
 	if got, want := actionConnector.prComments(), []kanbanPRComment{{repository: "digitaldrywood/frontend", number: 42, body: "PR note"}}; !equalPRComments(got, want) {
 		t.Fatalf("pr comments = %#v, want %#v", got, want)
+	}
+}
+
+func TestKanbanCommentEditAndDeleteLocalComments(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	createdAt := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	actionConnector := &kanbanActionConnector{
+		name: "local_sqlite",
+		issueComments: map[string][]connector.IssueComment{
+			"I_kw1": {{
+				ID:          "1",
+				Backend:     connector.BackendLocalSQLite.String(),
+				Body:        "Original local note",
+				AuthorLogin: "detent",
+				CreatedAt:   &createdAt,
+				Local:       true,
+				CanEdit:     true,
+				CanDelete:   true,
+				TargetType:  connector.IssueCommentTargetIssue,
+			}},
+		},
+	}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, actionConnector)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 6, 12, 1, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent"},
+		Refresh:     telemetry.Refresh{Status: telemetry.RefreshStatusReady},
+		Pipeline: []telemetry.Issue{{
+			ID:         "I_kw1",
+			Identifier: "digitaldrywood/detent#1",
+			ProjectID:  "detent",
+			Title:      "Editable comment issue",
+			State:      "Todo",
+			Comments: []telemetry.IssueComment{{
+				ID:          "1",
+				Backend:     connector.BackendLocalSQLite.String(),
+				Body:        "Original local note",
+				AuthorLogin: "detent",
+				CreatedAt:   &createdAt,
+				Local:       true,
+				CanEdit:     true,
+				CanDelete:   true,
+				TargetType:  connector.IssueCommentTargetIssue,
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	editForm := url.Values{
+		"project_id": {"detent"},
+		"issue_id":   {"I_kw1"},
+		"comment_id": {"1"},
+		"body":       {"Updated local note"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/comment/edit", editForm)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("edit status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if body := rec.Body.String(); !strings.Contains(body, "Updated local note") || strings.Contains(body, "Original local note") {
+		t.Fatalf("edit response did not render updated thread: %s", body)
+	}
+	if got, want := actionConnector.commentUpdates(), []kanbanCommentEdit{{issueID: "I_kw1", commentID: "1", body: "Updated local note"}}; !equalCommentUpdates(got, want) {
+		t.Fatalf("comment updates = %#v, want %#v", got, want)
+	}
+
+	deleteForm := url.Values{
+		"project_id": {"detent"},
+		"issue_id":   {"I_kw1"},
+		"comment_id": {"1"},
+	}
+	rec = performForm(t, server.Handler(), http.MethodDelete, "/api/v1/kanban/comment?project_id=detent&issue_id=I_kw1&comment_id=1", deleteForm)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("delete status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if strings.Contains(rec.Body.String(), "Updated local note") {
+		t.Fatalf("delete response still rendered deleted comment: %s", rec.Body.String())
+	}
+	if got, want := actionConnector.commentRemovals(), []kanbanCommentDelete{{issueID: "I_kw1", commentID: "1"}}; !equalCommentDeletes(got, want) {
+		t.Fatalf("comment removals = %#v, want %#v", got, want)
+	}
+}
+
+func TestBoardCardSheetShowsLocalCommentControlsOnly(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "local_sqlite"}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, actionConnector)
+	createdAt := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 6, 12, 1, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent"},
+		Refresh:     telemetry.Refresh{Status: telemetry.RefreshStatusReady},
+		Pipeline: []telemetry.Issue{{
+			ID:         "I_kw1",
+			Identifier: "digitaldrywood/detent#1",
+			ProjectID:  "detent",
+			Title:      "Comment controls issue",
+			State:      "Todo",
+			Comments: []telemetry.IssueComment{
+				{
+					ID:          "remote-1",
+					Backend:     connector.BackendGitHub.String(),
+					Body:        "Remote note",
+					AuthorLogin: "octocat",
+					CreatedAt:   &createdAt,
+					TargetType:  connector.IssueCommentTargetIssue,
+				},
+				{
+					ID:          "local-1",
+					Backend:     connector.BackendLocalSQLite.String(),
+					Body:        "Local note",
+					AuthorLogin: "detent",
+					CreatedAt:   &createdAt,
+					Local:       true,
+					CanEdit:     true,
+					CanDelete:   true,
+					TargetType:  connector.IssueCommentTargetIssue,
+				},
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := requestHTML(t, server.Handler(), http.MethodGet, "/api/v1/board/card?project=detent&issue=I_kw1&scope=project&actions=board", http.StatusOK)
+	for _, want := range []string{"Remote note", "Local note"} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q: %s", want, body)
+		}
+	}
+	if got := strings.Count(body, `hx-post="/api/v1/kanban/comment/edit"`); got != 1 {
+		t.Fatalf("edit controls = %d, want 1 in body: %s", got, body)
+	}
+	if got := strings.Count(body, `hx-delete="/api/v1/kanban/comment?`); got != 1 {
+		t.Fatalf("delete controls = %d, want 1 in body: %s", got, body)
 	}
 }
 
@@ -8780,6 +8932,17 @@ type kanbanComment struct {
 	body    string
 }
 
+type kanbanCommentEdit struct {
+	issueID   string
+	commentID string
+	body      string
+}
+
+type kanbanCommentDelete struct {
+	issueID   string
+	commentID string
+}
+
 type kanbanPRComment struct {
 	repository string
 	number     int
@@ -8789,17 +8952,20 @@ type kanbanPRComment struct {
 type kanbanActionConnector struct {
 	name string
 
-	mu           sync.Mutex
-	states       []kanbanStateUpdate
-	fields       []kanbanIssueFieldUpdate
-	fieldClears  []kanbanIssueFieldUpdate
-	removes      []kanbanRemoval
-	commentLog   []kanbanComment
-	prCommentLog []kanbanPRComment
-	activeMoves  int
-	maxMoves     int
-	moveStarted  chan<- struct{}
-	releaseMove  <-chan struct{}
+	mu             sync.Mutex
+	states         []kanbanStateUpdate
+	fields         []kanbanIssueFieldUpdate
+	fieldClears    []kanbanIssueFieldUpdate
+	removes        []kanbanRemoval
+	commentLog     []kanbanComment
+	commentEdits   []kanbanCommentEdit
+	commentDeletes []kanbanCommentDelete
+	prCommentLog   []kanbanPRComment
+	issueComments  map[string][]connector.IssueComment
+	activeMoves    int
+	maxMoves       int
+	moveStarted    chan<- struct{}
+	releaseMove    <-chan struct{}
 }
 
 func (c *kanbanActionConnector) Name() string {
@@ -8824,6 +8990,48 @@ func (c *kanbanActionConnector) CreateComment(_ context.Context, issueID string,
 
 	c.commentLog = append(c.commentLog, kanbanComment{issueID: issueID, body: body})
 	return nil
+}
+
+func (c *kanbanActionConnector) FetchIssueComments(_ context.Context, issue connector.Issue) ([]connector.IssueComment, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return cloneTestIssueComments(c.issueComments[strings.TrimSpace(issue.ID)]), nil
+}
+
+func (c *kanbanActionConnector) UpdateIssueComment(_ context.Context, issueID string, commentID string, body string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	issueID = strings.TrimSpace(issueID)
+	commentID = strings.TrimSpace(commentID)
+	c.commentEdits = append(c.commentEdits, kanbanCommentEdit{issueID: issueID, commentID: commentID, body: body})
+	comments := c.issueComments[issueID]
+	for index := range comments {
+		if strings.TrimSpace(comments[index].ID) == commentID {
+			comments[index].Body = body
+			c.issueComments[issueID] = comments
+			return nil
+		}
+	}
+	return sql.ErrNoRows
+}
+
+func (c *kanbanActionConnector) DeleteIssueComment(_ context.Context, issueID string, commentID string) error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	issueID = strings.TrimSpace(issueID)
+	commentID = strings.TrimSpace(commentID)
+	c.commentDeletes = append(c.commentDeletes, kanbanCommentDelete{issueID: issueID, commentID: commentID})
+	comments := c.issueComments[issueID]
+	for index := range comments {
+		if strings.TrimSpace(comments[index].ID) == commentID {
+			c.issueComments[issueID] = append(comments[:index], comments[index+1:]...)
+			return nil
+		}
+	}
+	return sql.ErrNoRows
 }
 
 func (c *kanbanActionConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
@@ -8923,6 +9131,20 @@ func (c *kanbanActionConnector) comments() []kanbanComment {
 	defer c.mu.Unlock()
 
 	return append([]kanbanComment(nil), c.commentLog...)
+}
+
+func (c *kanbanActionConnector) commentUpdates() []kanbanCommentEdit {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([]kanbanCommentEdit(nil), c.commentEdits...)
+}
+
+func (c *kanbanActionConnector) commentRemovals() []kanbanCommentDelete {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	return append([]kanbanCommentDelete(nil), c.commentDeletes...)
 }
 
 func (c *kanbanActionConnector) prComments() []kanbanPRComment {
@@ -9057,6 +9279,30 @@ func equalComments(left, right []kanbanComment) bool {
 	return true
 }
 
+func equalCommentUpdates(left, right []kanbanCommentEdit) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
+func equalCommentDeletes(left, right []kanbanCommentDelete) bool {
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}
+
 func equalPRComments(left, right []kanbanPRComment) bool {
 	if len(left) != len(right) {
 		return false
@@ -9067,6 +9313,25 @@ func equalPRComments(left, right []kanbanPRComment) bool {
 		}
 	}
 	return true
+}
+
+func cloneTestIssueComments(comments []connector.IssueComment) []connector.IssueComment {
+	if comments == nil {
+		return nil
+	}
+	out := make([]connector.IssueComment, len(comments))
+	for index, comment := range comments {
+		out[index] = comment
+		if comment.CreatedAt != nil {
+			createdAt := *comment.CreatedAt
+			out[index].CreatedAt = &createdAt
+		}
+		if comment.UpdatedAt != nil {
+			updatedAt := *comment.UpdatedAt
+			out[index].UpdatedAt = &updatedAt
+		}
+	}
+	return out
 }
 
 type sseEvent struct {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -530,6 +530,7 @@ type projectKanbanCard struct {
 	StageAt               time.Time
 	Labels                []string
 	Assignees             []string
+	Comments              []projectKanbanComment
 	Blockers              []string
 	ClearedBlockers       []string
 	HasPullRequest        bool
@@ -539,6 +540,16 @@ type projectKanbanCard struct {
 	PRURL                 string
 	Movable               bool
 	DisabledText          string
+}
+
+type projectKanbanComment struct {
+	ID        string
+	Body      string
+	URL       string
+	Author    string
+	Meta      string
+	CanEdit   bool
+	CanDelete bool
 }
 
 const (
@@ -2276,6 +2287,11 @@ func projectKanbanCommentDialogPath(data DashboardData, card projectKanbanCard, 
 	return "/api/v1/kanban/comment?" + values.Encode()
 }
 
+func projectKanbanCommentDeletePath(data DashboardData, card projectKanbanCard, comment projectKanbanComment) string {
+	values := kanbanCommentMutationValues(projectKanbanCardProjectID(data, card), card.IssueID, comment.ID)
+	return "/api/v1/kanban/comment?" + values.Encode()
+}
+
 func kanbanMoveDialogValues(projectID string, issueID string, identifier string, title string, currentState string, targetState string, prNumber int, board string) url.Values {
 	values := url.Values{}
 	addQueryValue(values, "project_id", projectID)
@@ -2306,6 +2322,14 @@ func kanbanCommentDialogValues(projectID string, target string, issueID string, 
 			values.Set("pr_number", strconv.Itoa(prNumber))
 		}
 	}
+	return values
+}
+
+func kanbanCommentMutationValues(projectID string, issueID string, commentID string) url.Values {
+	values := url.Values{}
+	addQueryValue(values, "project_id", projectID)
+	addQueryValue(values, "issue_id", issueID)
+	addQueryValue(values, "comment_id", commentID)
 	return values
 }
 
@@ -2577,6 +2601,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		StageAt:               stageAt.UTC(),
 		Labels:                uniqueStrings(issue.Labels),
 		Assignees:             uniqueStrings(issue.Assignees),
+		Comments:              projectKanbanComments(issue.Comments),
 		Blockers:              blockers,
 		ClearedBlockers:       clearedBlockers,
 		HasPullRequest:        issue.PullRequest != nil,
@@ -2599,6 +2624,69 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		card.DisabledText = "Cannot move PR-only card"
 	}
 	return card
+}
+
+func projectKanbanComments(comments []telemetry.IssueComment) []projectKanbanComment {
+	out := make([]projectKanbanComment, 0, len(comments))
+	for _, comment := range comments {
+		if targetType := strings.TrimSpace(comment.TargetType); targetType != "" && targetType != "issue" {
+			continue
+		}
+		id := strings.TrimSpace(comment.ID)
+		if id == "" && strings.TrimSpace(comment.Body) == "" {
+			continue
+		}
+		out = append(out, projectKanbanComment{
+			ID:        id,
+			Body:      comment.Body,
+			URL:       strings.TrimSpace(comment.URL),
+			Author:    projectKanbanCommentAuthor(comment),
+			Meta:      projectKanbanCommentMeta(comment),
+			CanEdit:   comment.Local && comment.CanEdit && id != "",
+			CanDelete: comment.Local && comment.CanDelete && id != "",
+		})
+	}
+	return out
+}
+
+func WithKanbanCardComments(card projectKanbanCard, comments []telemetry.IssueComment) projectKanbanCard {
+	card.Comments = projectKanbanComments(comments)
+	return card
+}
+
+func projectKanbanCommentAuthor(comment telemetry.IssueComment) string {
+	for _, candidate := range []string{comment.AuthorDisplayName, comment.AuthorLogin, comment.Backend} {
+		if candidate = strings.TrimSpace(candidate); candidate != "" {
+			return candidate
+		}
+	}
+	if comment.Local {
+		return "local"
+	}
+	return "comment"
+}
+
+func projectKanbanCommentMeta(comment telemetry.IssueComment) string {
+	parts := []string{projectKanbanCommentAuthor(comment)}
+	if source := strings.TrimSpace(comment.Backend); source != "" {
+		parts = append(parts, source)
+	} else if comment.Local {
+		parts = append(parts, "local")
+	}
+	if comment.CreatedAt != nil && !comment.CreatedAt.IsZero() {
+		parts = append(parts, timeLabel(*comment.CreatedAt))
+	}
+	if comment.UpdatedAt != nil && !comment.UpdatedAt.IsZero() && !sameCommentTime(comment.CreatedAt, comment.UpdatedAt) {
+		parts = append(parts, "edited "+timeLabel(*comment.UpdatedAt))
+	}
+	return strings.Join(parts, " · ")
+}
+
+func sameCommentTime(left *time.Time, right *time.Time) bool {
+	if left == nil || right == nil {
+		return false
+	}
+	return left.Equal(*right)
 }
 
 func projectKanbanIssueNumber(issue telemetry.Issue) string {

--- a/internal/web/templates/sheet.templ
+++ b/internal/web/templates/sheet.templ
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"github.com/digitaldrywood/detent/internal/web/ui/components/dialog"
+	"github.com/digitaldrywood/detent/internal/web/ui/components/icon"
 	"github.com/digitaldrywood/detent/internal/web/ui/primitives"
 )
 
@@ -107,6 +108,7 @@ templ BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions bo
 				if len(card.Assignees) > 0 {
 					@sheetTagRow("Assignees", card.Assignees)
 				}
+				@KanbanCommentThread(data, card, boardActions)
 			</div>
 			if sheetHasActions(data, card, boardActions) {
 				<footer class="flex flex-none items-center gap-2 border-t border-line px-5 py-3">
@@ -147,6 +149,68 @@ templ BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions bo
 				</footer>
 			}
 		</aside>
+	</div>
+}
+
+templ KanbanCommentThread(data DashboardData, card projectKanbanCard, boardActions bool) {
+	<div id="kanban-comment-thread">
+		if len(card.Comments) > 0 {
+			<div class="flex flex-col gap-2">
+				<h3 class="text-2xs font-semibold uppercase tracking-[0.06em] text-dim">Comments</h3>
+				<div class="flex flex-col gap-2">
+					for _, comment := range card.Comments {
+						<article class="rounded-card border border-line bg-elev p-3 text-xs">
+							<div class="flex items-start gap-3">
+								<div class="min-w-0 flex-1">
+									<div class="flex min-w-0 items-center gap-2">
+										<span class="min-w-0 truncate font-medium text-text" title={ comment.Author }>{ comment.Author }</span>
+										<span class="min-w-0 truncate font-mono text-2xs text-sec" title={ comment.Meta }>{ comment.Meta }</span>
+									</div>
+									<p class="mt-2 whitespace-pre-wrap text-text">{ comment.Body }</p>
+									if comment.URL != "" {
+										<a href={ comment.URL } target="_blank" rel="noopener noreferrer" class="mt-2 inline-flex text-2xs font-medium text-accent hover:underline">Open comment</a>
+									}
+								</div>
+								if sheetCanMutateComment(data, card, boardActions, comment) {
+									<div class="flex flex-none items-center gap-1">
+										if comment.CanDelete {
+											<form class="inline-flex" hx-delete={ projectKanbanCommentDeletePath(data, card, comment) } hx-target="#kanban-comment-thread" hx-swap="outerHTML" hx-confirm="Delete this comment?">
+												<input type="hidden" name="project_id" value={ projectKanbanCardProjectID(data, card) }/>
+												<input type="hidden" name="issue_id" value={ card.IssueID }/>
+												<input type="hidden" name="comment_id" value={ comment.ID }/>
+												<button type="submit" class="rounded-chip p-1 text-sec hover:bg-err/15 hover:text-err" title="Delete comment" aria-label="Delete comment">
+													@icon.Trash2(icon.Props{Class: "size-3.5"})
+												</button>
+											</form>
+										}
+									</div>
+								}
+							</div>
+							if sheetCanEditComment(data, card, boardActions, comment) {
+								<details class="mt-3">
+									<summary class="inline-flex cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1.5 text-xs font-medium text-sec hover:border-accent hover:text-accent">
+										@icon.PencilLine(icon.Props{Class: "size-3.5"})
+										Edit
+									</summary>
+									<form class="mt-2 grid gap-2" hx-post="/api/v1/kanban/comment/edit" hx-target="#kanban-comment-thread" hx-swap="outerHTML">
+										<input type="hidden" name="project_id" value={ projectKanbanCardProjectID(data, card) }/>
+										<input type="hidden" name="issue_id" value={ card.IssueID }/>
+										<input type="hidden" name="comment_id" value={ comment.ID }/>
+										<textarea name="body" rows="4" class="min-h-24 w-full resize-y rounded-md border border-line bg-page px-3 py-2 text-xs text-text focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent">{ comment.Body }</textarea>
+										<div class="flex justify-end">
+											<button type="submit" class="inline-flex items-center gap-1.5 rounded-card border border-line px-2.5 py-1.5 text-xs font-medium text-text hover:border-accent hover:text-accent">
+												@icon.Save(icon.Props{Class: "size-3.5"})
+												Save
+											</button>
+										</div>
+									</form>
+								</details>
+							}
+						</article>
+					}
+				</div>
+			</div>
+		}
 	</div>
 }
 

--- a/internal/web/templates/sheet_data.go
+++ b/internal/web/templates/sheet_data.go
@@ -168,6 +168,17 @@ func sheetHasActions(data DashboardData, card projectKanbanCard, boardActions bo
 		projectKanbanCardCanComment(data, card))
 }
 
+func sheetCanMutateComment(data DashboardData, card projectKanbanCard, boardActions bool, comment projectKanbanComment) bool {
+	return boardActions &&
+		projectKanbanCardCanComment(data, card) &&
+		strings.TrimSpace(card.IssueID) != "" &&
+		(comment.CanEdit || comment.CanDelete)
+}
+
+func sheetCanEditComment(data DashboardData, card projectKanbanCard, boardActions bool, comment projectKanbanComment) bool {
+	return sheetCanMutateComment(data, card, boardActions, comment) && comment.CanEdit
+}
+
 func sheetAttentionLabel(card projectKanbanCard) string {
 	label := strings.TrimSpace(card.AttentionLabel)
 	if detail := strings.TrimSpace(card.AttentionDetail); detail != "" {

--- a/internal/web/templates/sheet_templ.go
+++ b/internal/web/templates/sheet_templ.go
@@ -10,6 +10,7 @@ import templruntime "github.com/a-h/templ/runtime"
 
 import (
 	"github.com/digitaldrywood/detent/internal/web/ui/components/dialog"
+	"github.com/digitaldrywood/detent/internal/web/ui/components/icon"
 	"github.com/digitaldrywood/detent/internal/web/ui/primitives"
 )
 
@@ -78,7 +79,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 		var templ_7745c5c3_Var3 string
 		templ_7745c5c3_Var3, templ_7745c5c3_Err = templ.JoinStringErrs("Details for " + card.IssueNumber)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 23, Col: 180}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 24, Col: 180}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var3))
 		if templ_7745c5c3_Err != nil {
@@ -91,7 +92,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 		var templ_7745c5c3_Var4 string
 		templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCardProjectID(data, card))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 27, Col: 69}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 28, Col: 69}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 		if templ_7745c5c3_Err != nil {
@@ -104,7 +105,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 		var templ_7745c5c3_Var5 string
 		templ_7745c5c3_Var5, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueNumber)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 28, Col: 58}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 29, Col: 58}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var5))
 		if templ_7745c5c3_Err != nil {
@@ -117,7 +118,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 		var templ_7745c5c3_Var6 string
 		templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(card.Title)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 30, Col: 72}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 31, Col: 72}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 		if templ_7745c5c3_Err != nil {
@@ -168,7 +169,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 			var templ_7745c5c3_Var10 string
 			templ_7745c5c3_Var10, templ_7745c5c3_Err = templ.JoinStringErrs(card.Stage)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 39, Col: 19}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 40, Col: 19}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var10))
 			if templ_7745c5c3_Err != nil {
@@ -314,7 +315,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 				var templ_7745c5c3_Var14 string
 				templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(session.State)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 83, Col: 24}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 84, Col: 24}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 				if templ_7745c5c3_Err != nil {
@@ -362,7 +363,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 				var templ_7745c5c3_Var15 string
 				templ_7745c5c3_Var15, templ_7745c5c3_Err = templ.JoinStringErrs(session.Error)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 99, Col: 43}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 100, Col: 43}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var15))
 				if templ_7745c5c3_Err != nil {
@@ -389,6 +390,10 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
+		}
+		templ_7745c5c3_Err = KanbanCommentThread(data, card, boardActions).Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</div>")
 		if templ_7745c5c3_Err != nil {
@@ -419,7 +424,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 					var templ_7745c5c3_Var17 string
 					templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanMoveDialogPath(data, card))
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 119, Col: 56}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 121, Col: 56}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 					if templ_7745c5c3_Err != nil {
@@ -432,7 +437,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 					var templ_7745c5c3_Var18 string
 					templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanDialogTargetSelector())
 					if templ_7745c5c3_Err != nil {
-						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 120, Col: 48}
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 122, Col: 48}
 					}
 					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 					if templ_7745c5c3_Err != nil {
@@ -469,7 +474,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 				var templ_7745c5c3_Var19 string
 				templ_7745c5c3_Var19, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCardProjectID(data, card))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 133, Col: 92}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 135, Col: 92}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var19))
 				if templ_7745c5c3_Err != nil {
@@ -482,7 +487,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 				var templ_7745c5c3_Var20 string
 				templ_7745c5c3_Var20, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 134, Col: 64}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 136, Col: 64}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var20))
 				if templ_7745c5c3_Err != nil {
@@ -495,7 +500,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 				var templ_7745c5c3_Var21 string
 				templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(card.Stage)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 135, Col: 67}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 137, Col: 67}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 				if templ_7745c5c3_Err != nil {
@@ -518,7 +523,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 				var templ_7745c5c3_Var22 templ.SafeURL
 				templ_7745c5c3_Var22, templ_7745c5c3_Err = templ.JoinURLErrs(card.URL)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 141, Col: 24}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 143, Col: 24}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var22))
 				if templ_7745c5c3_Err != nil {
@@ -541,7 +546,7 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 			var templ_7745c5c3_Var23 templ.SafeURL
 			templ_7745c5c3_Var23, templ_7745c5c3_Err = templ.JoinURLErrs(card.URL)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 146, Col: 23}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 148, Col: 23}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var23))
 			if templ_7745c5c3_Err != nil {
@@ -553,6 +558,301 @@ func BoardCardSheet(data DashboardData, card projectKanbanCard, boardActions boo
 			}
 		}
 		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</aside></div>")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		return nil
+	})
+}
+
+func KanbanCommentThread(data DashboardData, card projectKanbanCard, boardActions bool) templ.Component {
+	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
+		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
+			return templ_7745c5c3_CtxErr
+		}
+		templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
+		if !templ_7745c5c3_IsBuffer {
+			defer func() {
+				templ_7745c5c3_BufErr := templruntime.ReleaseBuffer(templ_7745c5c3_Buffer)
+				if templ_7745c5c3_Err == nil {
+					templ_7745c5c3_Err = templ_7745c5c3_BufErr
+				}
+			}()
+		}
+		ctx = templ.InitializeContext(ctx)
+		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var24 == nil {
+			templ_7745c5c3_Var24 = templ.NopComponent
+		}
+		ctx = templ.ClearChildren(ctx)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<div id=\"kanban-comment-thread\">")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		if len(card.Comments) > 0 {
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "<div class=\"flex flex-col gap-2\"><h3 class=\"text-2xs font-semibold uppercase tracking-[0.06em] text-dim\">Comments</h3><div class=\"flex flex-col gap-2\">")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			for _, comment := range card.Comments {
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "<article class=\"rounded-card border border-line bg-elev p-3 text-xs\"><div class=\"flex items-start gap-3\"><div class=\"min-w-0 flex-1\"><div class=\"flex min-w-0 items-center gap-2\"><span class=\"min-w-0 truncate font-medium text-text\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var25 string
+				templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(comment.Author)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 166, Col: 85}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var26 string
+				templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(comment.Author)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 166, Col: 104}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "</span> <span class=\"min-w-0 truncate font-mono text-2xs text-sec\" title=\"")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var27 string
+				templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(comment.Meta)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 167, Col: 89}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var28 string
+				templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(comment.Meta)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 167, Col: 106}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "</span></div><p class=\"mt-2 whitespace-pre-wrap text-text\">")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				var templ_7745c5c3_Var29 string
+				templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(comment.Body)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 169, Col: 69}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</p>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if comment.URL != "" {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<a href=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var30 templ.SafeURL
+					templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinURLErrs(comment.URL)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 171, Col: 31}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\" target=\"_blank\" rel=\"noopener noreferrer\" class=\"mt-2 inline-flex text-2xs font-medium text-accent hover:underline\">Open comment</a>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if sheetCanMutateComment(data, card, boardActions, comment) {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div class=\"flex flex-none items-center gap-1\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					if comment.CanDelete {
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "<form class=\"inline-flex\" hx-delete=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var31 string
+						templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCommentDeletePath(data, card, comment))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 177, Col: 100}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\" hx-target=\"#kanban-comment-thread\" hx-swap=\"outerHTML\" hx-confirm=\"Delete this comment?\"><input type=\"hidden\" name=\"project_id\" value=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var32 string
+						templ_7745c5c3_Var32, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCardProjectID(data, card))
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 178, Col: 97}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var32))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var33 string
+						templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 179, Col: 69}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\"> <input type=\"hidden\" name=\"comment_id\" value=\"")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						var templ_7745c5c3_Var34 string
+						templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(comment.ID)
+						if templ_7745c5c3_Err != nil {
+							return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 180, Col: 69}
+						}
+						_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\"> <button type=\"submit\" class=\"rounded-chip p-1 text-sec hover:bg-err/15 hover:text-err\" title=\"Delete comment\" aria-label=\"Delete comment\">")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = icon.Trash2(icon.Props{Class: "size-3.5"}).Render(ctx, templ_7745c5c3_Buffer)
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+						templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "</button></form>")
+						if templ_7745c5c3_Err != nil {
+							return templ_7745c5c3_Err
+						}
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</div>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</div>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				if sheetCanEditComment(data, card, boardActions, comment) {
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<details class=\"mt-3\"><summary class=\"inline-flex cursor-pointer list-none items-center gap-1.5 rounded-card border border-line px-2.5 py-1.5 text-xs font-medium text-sec hover:border-accent hover:text-accent\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = icon.PencilLine(icon.Props{Class: "size-3.5"}).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "Edit</summary><form class=\"mt-2 grid gap-2\" hx-post=\"/api/v1/kanban/comment/edit\" hx-target=\"#kanban-comment-thread\" hx-swap=\"outerHTML\"><input type=\"hidden\" name=\"project_id\" value=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var35 string
+					templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCardProjectID(data, card))
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 196, Col: 95}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "\"> <input type=\"hidden\" name=\"issue_id\" value=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var36 string
+					templ_7745c5c3_Var36, templ_7745c5c3_Err = templ.JoinStringErrs(card.IssueID)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 197, Col: 67}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var36))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "\"> <input type=\"hidden\" name=\"comment_id\" value=\"")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var37 string
+					templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(comment.ID)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 198, Col: 67}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "\"> <textarea name=\"body\" rows=\"4\" class=\"min-h-24 w-full resize-y rounded-md border border-line bg-page px-3 py-2 text-xs text-text focus:border-accent focus:outline-none focus:ring-2 focus:ring-accent\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					var templ_7745c5c3_Var38 string
+					templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(comment.Body)
+					if templ_7745c5c3_Err != nil {
+						return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 199, Col: 224}
+					}
+					_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "</textarea><div class=\"flex justify-end\"><button type=\"submit\" class=\"inline-flex items-center gap-1.5 rounded-card border border-line px-2.5 py-1.5 text-xs font-medium text-text hover:border-accent hover:text-accent\">")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = icon.Save(icon.Props{Class: "size-3.5"}).Render(ctx, templ_7745c5c3_Buffer)
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+					templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "Save</button></div></form></details>")
+					if templ_7745c5c3_Err != nil {
+						return templ_7745c5c3_Err
+					}
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</article>")
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</div></div>")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -578,12 +878,12 @@ func sheetCommentTrigger(data DashboardData, card projectKanbanCard, target stri
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var24 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var24 == nil {
-			templ_7745c5c3_Var24 = templ.NopComponent
+		templ_7745c5c3_Var39 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var39 == nil {
+			templ_7745c5c3_Var39 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Var25 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
+		templ_7745c5c3_Var40 := templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 			templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 			templ_7745c5c3_Buffer, templ_7745c5c3_IsBuffer := templruntime.GetBuffer(templ_7745c5c3_W)
 			if !templ_7745c5c3_IsBuffer {
@@ -595,80 +895,80 @@ func sheetCommentTrigger(data DashboardData, card projectKanbanCard, target stri
 				}()
 			}
 			ctx = templ.InitializeContext(ctx)
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<button type=\"button\" class=\"rounded-card border border-line px-3 py-1.5 text-xs font-medium text-text hover:border-accent hover:text-accent\" hx-get=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<button type=\"button\" class=\"rounded-card border border-line px-3 py-1.5 text-xs font-medium text-text hover:border-accent hover:text-accent\" hx-get=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var26 string
-			templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCommentDialogPath(data, card, target))
+			var templ_7745c5c3_Var41 string
+			templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs(projectKanbanCommentDialogPath(data, card, target))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 160, Col: 62}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 224, Col: 62}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\" hx-target=\"")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var27 string
-			templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanDialogTargetSelector())
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 161, Col: 43}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" hx-target=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "\" hx-swap=\"innerHTML\" aria-label=\"")
+			var templ_7745c5c3_Var42 string
+			templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(kanbanDialogTargetSelector())
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 225, Col: 43}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var28 string
-			templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs(label + " " + card.IssueNumber)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 163, Col: 46}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "\" hx-swap=\"innerHTML\" aria-label=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "\" title=\"")
+			var templ_7745c5c3_Var43 string
+			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(label + " " + card.IssueNumber)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 227, Col: 46}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var29 string
-			templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(label)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 164, Col: 16}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\">")
+			var templ_7745c5c3_Var44 string
+			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 228, Col: 16}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if target == "pr" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "Comment · PR")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "Comment · PR")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "Comment")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "Comment")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</button>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</button>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			return nil
 		})
-		templ_7745c5c3_Err = dialog.Trigger(dialog.TriggerProps{For: kanbanActionDialogID}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var25), templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = dialog.Trigger(dialog.TriggerProps{For: kanbanActionDialogID}).Render(templ.WithChildren(ctx, templ_7745c5c3_Var40), templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -692,33 +992,33 @@ func sheetRowText(label string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var30 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var30 == nil {
-			templ_7745c5c3_Var30 = templ.NopComponent
+		templ_7745c5c3_Var45 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var45 == nil {
+			templ_7745c5c3_Var45 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "<div class=\"flex items-center justify-between gap-3\"><span class=\"flex-none text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "<div class=\"flex items-center justify-between gap-3\"><span class=\"flex-none text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var31 string
-		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		var templ_7745c5c3_Var46 string
+		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 177, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 241, Col: 42}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "</span>")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templ_7745c5c3_Var30.Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</span>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</div>")
+		templ_7745c5c3_Err = templ_7745c5c3_Var45.Render(ctx, templ_7745c5c3_Buffer)
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -742,51 +1042,51 @@ func sheetRowValue(label string, value string, title string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var32 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var32 == nil {
-			templ_7745c5c3_Var32 = templ.NopComponent
+		templ_7745c5c3_Var47 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var47 == nil {
+			templ_7745c5c3_Var47 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "<div class=\"flex items-center justify-between gap-3\"><span class=\"flex-none text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<div class=\"flex items-center justify-between gap-3\"><span class=\"flex-none text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var33 string
-		templ_7745c5c3_Var33, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		var templ_7745c5c3_Var48 string
+		templ_7745c5c3_Var48, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 184, Col: 42}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 248, Col: 42}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var33))
-		if templ_7745c5c3_Err != nil {
-			return templ_7745c5c3_Err
-		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "</span> <span class=\"min-w-0 truncate font-mono text-text tabular-nums\" title=\"")
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var48))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var34 string
-		templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(title)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 185, Col: 79}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "</span> <span class=\"min-w-0 truncate font-mono text-text tabular-nums\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\">")
+		var templ_7745c5c3_Var49 string
+		templ_7745c5c3_Var49, templ_7745c5c3_Err = templ.JoinStringErrs(title)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 249, Col: 79}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var49))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var35 string
-		templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(value)
-		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 185, Col: 89}
-		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "</span></div>")
+		var templ_7745c5c3_Var50 string
+		templ_7745c5c3_Var50, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+		if templ_7745c5c3_Err != nil {
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 249, Col: 89}
+		}
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var50))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -810,80 +1110,80 @@ func sheetRowLink(label string, value string, href string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var36 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var36 == nil {
-			templ_7745c5c3_Var36 = templ.NopComponent
+		templ_7745c5c3_Var51 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var51 == nil {
+			templ_7745c5c3_Var51 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
 		if value != "" {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "<div class=\"flex items-center justify-between gap-3\"><span class=\"flex-none text-sec\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "<div class=\"flex items-center justify-between gap-3\"><span class=\"flex-none text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var37 string
-			templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+			var templ_7745c5c3_Var52 string
+			templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 192, Col: 43}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 256, Col: 43}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if href != "" {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<a class=\"min-w-0 truncate font-mono text-accent hover:underline\" href=\"")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<a class=\"min-w-0 truncate font-mono text-accent hover:underline\" href=\"")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var38 templ.SafeURL
-				templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinURLErrs(href)
+				var templ_7745c5c3_Var53 templ.SafeURL
+				templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinURLErrs(href)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 194, Col: 81}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 258, Col: 81}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
-				if templ_7745c5c3_Err != nil {
-					return templ_7745c5c3_Err
-				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\" target=\"_blank\" rel=\"noopener noreferrer\">")
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var39 string
-				templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(value)
-				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 194, Col: 133}
-				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "\" target=\"_blank\" rel=\"noopener noreferrer\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</a>")
+				var templ_7745c5c3_Var54 string
+				templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+				if templ_7745c5c3_Err != nil {
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 258, Col: 133}
+				}
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
+				if templ_7745c5c3_Err != nil {
+					return templ_7745c5c3_Err
+				}
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "</a>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			} else {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<span class=\"min-w-0 truncate font-mono text-text\">")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "<span class=\"min-w-0 truncate font-mono text-text\">")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				var templ_7745c5c3_Var40 string
-				templ_7745c5c3_Var40, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+				var templ_7745c5c3_Var55 string
+				templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 196, Col: 62}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 260, Col: 62}
 				}
-				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var40))
+				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -908,61 +1208,61 @@ func sheetTagRow(label string, values []string) templ.Component {
 			}()
 		}
 		ctx = templ.InitializeContext(ctx)
-		templ_7745c5c3_Var41 := templ.GetChildren(ctx)
-		if templ_7745c5c3_Var41 == nil {
-			templ_7745c5c3_Var41 = templ.NopComponent
+		templ_7745c5c3_Var56 := templ.GetChildren(ctx)
+		if templ_7745c5c3_Var56 == nil {
+			templ_7745c5c3_Var56 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<div class=\"flex flex-col gap-1.5\"><h3 class=\"text-2xs font-semibold uppercase tracking-[0.06em] text-dim\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "<div class=\"flex flex-col gap-1.5\"><h3 class=\"text-2xs font-semibold uppercase tracking-[0.06em] text-dim\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		var templ_7745c5c3_Var42 string
-		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(label)
+		var templ_7745c5c3_Var57 string
+		templ_7745c5c3_Var57, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 204, Col: 81}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 268, Col: 81}
 		}
-		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
+		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var57))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</h3><div class=\"flex flex-wrap gap-1.5\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</h3><div class=\"flex flex-wrap gap-1.5\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		for _, value := range values {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<span class=\"truncate rounded-chip bg-elev px-2 py-0.5 font-mono text-2xs text-sec\" title=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "<span class=\"truncate rounded-chip bg-elev px-2 py-0.5 font-mono text-2xs text-sec\" title=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var43 string
-			templ_7745c5c3_Var43, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+			var templ_7745c5c3_Var58 string
+			templ_7745c5c3_Var58, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 207, Col: 101}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 271, Col: 101}
 			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var43))
-			if templ_7745c5c3_Err != nil {
-				return templ_7745c5c3_Err
-			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "\">")
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var58))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			var templ_7745c5c3_Var44 string
-			templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(value)
-			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 207, Col: 111}
-			}
-			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</span>")
+			var templ_7745c5c3_Var59 string
+			templ_7745c5c3_Var59, templ_7745c5c3_Err = templ.JoinStringErrs(value)
+			if templ_7745c5c3_Err != nil {
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/sheet.templ`, Line: 271, Col: 111}
+			}
+			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var59))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "</div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}


### PR DESCRIPTION
## Summary

- Adds local issue comment edit/delete mutation interfaces and local SQLite event folding for current comment state.
- Exposes local edit/delete capability flags through connector and telemetry comment shapes.
- Renders Kanban sheet comment threads with local-only edit/delete controls and refreshed HTMX fragments.

Fixes #951

## Test Plan

- [x] `make generate`
- [x] `make check`