### PR TITLE
fix(kanban): enable fleet card comments

### DIFF
--- a/internal/web/board_card_test.go
+++ b/internal/web/board_card_test.go
@@ -210,6 +210,24 @@ func TestAPIBoardCardRendersPullRequestCommentsWhenSupported(t *testing.T) {
 			t.Fatalf("sheet missing %q:\n%s", want, rec.Body.String())
 		}
 	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=digitaldrywood%2Fdetent%2342&actions=board", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fleet status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	for _, want := range []string{
+		`data-kanban-comment-tab="pr"`,
+		"PR comments",
+		"Reviewed implementation details",
+		"Comment · PR",
+		`name="kanban_board" value="fleet"`,
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("fleet sheet missing %q:\n%s", want, rec.Body.String())
+		}
+	}
 }
 
 func TestAPIBoardCardHidesPullRequestCommentsWhenUnsupported(t *testing.T) {
@@ -256,6 +274,22 @@ func TestAPIBoardCardHidesPullRequestCommentsWhenUnsupported(t *testing.T) {
 	} {
 		if strings.Contains(rec.Body.String(), unwanted) {
 			t.Fatalf("unsupported PR comments sheet contains %q:\n%s", unwanted, rec.Body.String())
+		}
+	}
+
+	rec = httptest.NewRecorder()
+	req = httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=digitaldrywood%2Fdetent%2342&actions=board", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("fleet status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	for _, unwanted := range []string{
+		`data-kanban-comment-tab="pr"`,
+		"PR comments",
+		"Comment · PR",
+	} {
+		if strings.Contains(rec.Body.String(), unwanted) {
+			t.Fatalf("unsupported fleet PR comments sheet contains %q:\n%s", unwanted, rec.Body.String())
 		}
 	}
 }
@@ -352,5 +386,123 @@ func TestAPIBoardCardPreservesProjectScope(t *testing.T) {
 	}
 	if strings.Contains(rec.Body.String(), "kanban_board=") {
 		t.Fatalf("sheet opened without board actions must omit kanban actions:\n%s", rec.Body.String())
+	}
+}
+
+func TestAPIBoardCardFleetSheetShowsIssueCommentControls(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, &kanbanActionConnector{name: "github"})
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 4, 16, 0, 0, 0, time.UTC),
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_fleet_comment",
+			Identifier: "digitaldrywood/detent#953",
+			ProjectID:  "detent",
+			Title:      "Fleet comment card",
+			State:      "Todo",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{StaticDir: t.TempDir()}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=digitaldrywood%2Fdetent%23953&actions=board", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	for _, want := range []string{
+		"Fleet comment card",
+		"Comment on issue",
+		`name="kanban_board" value="fleet"`,
+		`name="kanban_thread" value="true"`,
+		`hx-post="/api/v1/kanban/comment"`,
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("fleet sheet missing %q:\n%s", want, rec.Body.String())
+		}
+	}
+}
+
+func TestAPIBoardCardFleetReadOnlyShowsCommentsWithoutWriteControls(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{
+		name: "github",
+		issueComments: map[string][]connector.IssueComment{
+			"I_read_only_comment": {{
+				ID:          "IC_read_only",
+				Backend:     connector.BackendGitHub.String(),
+				Body:        "Existing read-only discussion",
+				AuthorLogin: "alice",
+				TargetType:  connector.IssueCommentTargetIssue,
+			}},
+		},
+	}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeReadOnly,
+	}, actionConnector)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 4, 16, 0, 0, 0, time.UTC),
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_read_only_comment",
+			Identifier: "digitaldrywood/detent#954",
+			ProjectID:  "detent",
+			Title:      "Read-only fleet comment card",
+			State:      "Todo",
+			Comments: []telemetry.IssueComment{{
+				ID:          "IC_read_only",
+				Backend:     connector.BackendGitHub.String(),
+				Body:        "Existing read-only discussion",
+				AuthorLogin: "alice",
+				TargetType:  connector.IssueCommentTargetIssue,
+			}},
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{StaticDir: t.TempDir()}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/board/card?project=detent&issue=digitaldrywood%2Fdetent%23954&actions=board", nil)
+	server.Handler().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body = %s", rec.Code, rec.Body.String())
+	}
+	for _, want := range []string{
+		"Read-only fleet comment card",
+		"Existing read-only discussion",
+		"alice",
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("read-only fleet sheet missing %q:\n%s", want, rec.Body.String())
+		}
+	}
+	for _, unwanted := range []string{
+		"Comment on issue",
+		`name="kanban_thread" value="true"`,
+		`hx-post="/api/v1/kanban/comment"`,
+	} {
+		if strings.Contains(rec.Body.String(), unwanted) {
+			t.Fatalf("read-only fleet sheet contains %q:\n%s", unwanted, rec.Body.String())
+		}
 	}
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2734,6 +2734,93 @@ func TestKanbanThreadCommentRefreshesIssueComments(t *testing.T) {
 	}
 }
 
+func TestKanbanFleetThreadCommentRoutesToOwningProject(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	fleetConnector := &kanbanActionConnector{name: "fleet"}
+	projectConnector := &kanbanActionConnector{name: "github"}
+	deps.Connector = fleetConnector
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, projectConnector)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC),
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "detent", DisplayName: "Detent"}},
+		},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_fleet_comment",
+			Identifier: "digitaldrywood/detent#953",
+			ProjectID:  "detent",
+			Title:      "Fleet commentable issue",
+			State:      "Todo",
+			PullRequest: &telemetry.PullRequest{
+				Number: 42,
+				URL:    "https://github.com/digitaldrywood/frontend/pull/42",
+			},
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := url.Values{
+		"kanban_thread":  {"true"},
+		"project_id":     {"detent"},
+		"kanban_board":   {"fleet"},
+		"board_actions":  {"true"},
+		"target":         {"issue"},
+		"issue_id":       {"I_fleet_comment"},
+		"identifier":     {"digitaldrywood/detent#953"},
+		"issue_identity": {"digitaldrywood/detent#953"},
+		"title":          {"Fleet commentable issue"},
+		"body":           {"Fleet issue note"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/comment", form)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got, want := projectConnector.comments(), []kanbanComment{{issueID: "I_fleet_comment", body: "Fleet issue note"}}; !equalComments(got, want) {
+		t.Fatalf("project comments = %#v, want %#v", got, want)
+	}
+	if got := fleetConnector.comments(); len(got) != 0 {
+		t.Fatalf("fleet connector comments = %#v, want none", got)
+	}
+	for _, want := range []string{
+		`id="kanban-issue-comments-panel"`,
+		"Fleet issue note",
+		"Comment submitted.",
+		`name="kanban_board" value="fleet"`,
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("thread response missing %q:\n%s", want, rec.Body.String())
+		}
+	}
+
+	prForm := url.Values{
+		"project_id":    {"detent"},
+		"kanban_board":  {"fleet"},
+		"target":        {"pr"},
+		"pr_repository": {"digitaldrywood/frontend"},
+		"pr_number":     {"42"},
+		"body":          {"Fleet PR note"},
+	}
+	rec = performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/comment", prForm)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("pr status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	if got, want := projectConnector.prComments(), []kanbanPRComment{{repository: "digitaldrywood/frontend", number: 42, body: "Fleet PR note"}}; !equalPRComments(got, want) {
+		t.Fatalf("project PR comments = %#v, want %#v", got, want)
+	}
+	if got := fleetConnector.prComments(); len(got) != 0 {
+		t.Fatalf("fleet connector PR comments = %#v, want none", got)
+	}
+}
+
 func TestBoardCardSheetShowsLocalCommentControlsOnly(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2754,7 +2754,7 @@ func projectKanbanCardCanCommentOnPullRequest(data DashboardData, card projectKa
 }
 
 func projectKanbanCardCanUseComments(data DashboardData, card projectKanbanCard) bool {
-	return snapshotReady(data.Snapshot) && isProjectDashboard(data) && projectKanbanCardIntegrationEnabled(data, card)
+	return snapshotReady(data.Snapshot) && projectKanbanCardIntegrationEnabled(data, card)
 }
 
 func projectKanbanMoveTargetStates(data DashboardData, card projectKanbanCard) []string {


### PR DESCRIPTION
## Summary

- Enable fleet Kanban card sheets to expose reusable issue comment controls when the owning project is integration-enabled.
- Keep read-only fleet cards comment-readable without write controls.
- Add fleet coverage for issue comments, PR comments, unsupported PR comments, and owning-project routing for submissions.

Fixes #953

## UI Surface Contract

- [x] N/A: reuses the existing card sheet comments UI authorized by #953; no new high-impact layout, density, first-viewport, or responsive visibility tradeoff.
- [x] N/A: this PR does not add persistent top-of-screen messaging.
- [x] N/A: this PR exposes existing controls in an existing sheet; rendered fragments are covered by handler/template tests.

## Test Plan

- [x] `go test ./internal/web -run 'TestAPIBoardCardRendersPullRequestCommentsWhenSupported|TestAPIBoardCardHidesPullRequestCommentsWhenUnsupported|TestAPIBoardCardFleetSheetShowsIssueCommentControls|TestAPIBoardCardFleetReadOnlyShowsCommentsWithoutWriteControls|TestKanbanFleetThreadCommentRoutesToOwningProject'`
- [x] `go test ./internal/web`
- [x] `make check`