### PR TITLE
fix(github): fetch project backlog directly

### DIFF
--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -1028,7 +1028,21 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 		return nil, ErrMissingProject
 	}
 
-	issues, err := c.fetchProjectItems(ctx, graphQLQueryObservedStatus, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
+	issues := []connector.Issue{}
+	if stateSetContains(wantedStates, defaultProjectItemStatusState) {
+		backlogIssues, err := c.fetchProjectBacklogIssues(ctx, 0)
+		if err != nil {
+			return nil, err
+		}
+		issues = appendUniqueIssues(issues, backlogIssues, 0)
+		stateNames = stateListWithout(stateNames, defaultProjectItemStatusState)
+		wantedStates = normalizedStateSet(stateNames)
+		if len(wantedStates) == 0 {
+			return issues, nil
+		}
+	}
+
+	statusIssues, err := c.fetchProjectItems(ctx, graphQLQueryObservedStatus, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
 		_, ok := wantedStates[normalizeStateName(issue.State)]
 		return ok
 	})
@@ -1036,19 +1050,19 @@ func (c *Connector) FetchIssuesByStates(ctx context.Context, stateNames []string
 		return nil, err
 	}
 	if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
-		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+		if err := c.populateBlockerReasons(ctx, statusIssues); err != nil {
 			return nil, err
 		}
-		if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+		if err := c.resolveBlockedByProjectState(ctx, statusIssues); err != nil {
 			return nil, err
 		}
 	}
 	if attachPullRequestsForStates(wantedStates) {
-		if err := c.attachFreshPullRequests(ctx, issues); err != nil {
+		if err := c.attachFreshPullRequests(ctx, statusIssues); err != nil {
 			return nil, err
 		}
 	}
-	return issues, nil
+	return appendUniqueIssues(issues, statusIssues, 0), nil
 }
 
 func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []string, limit int) ([]connector.Issue, error) {
@@ -1103,27 +1117,44 @@ func (c *Connector) FetchIssuesByStatesLimit(ctx context.Context, stateNames []s
 		return nil, ErrMissingProject
 	}
 
-	issues, err := c.fetchProjectItemsWithPullRequestRefsLimit(ctx, graphQLQueryObservedStatus, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
+	issues := []connector.Issue{}
+	if stateSetContains(wantedStates, defaultProjectItemStatusState) {
+		backlogIssues, err := c.fetchProjectBacklogIssues(ctx, limit)
+		if err != nil {
+			return nil, err
+		}
+		issues = appendUniqueIssues(issues, backlogIssues, limit)
+		if len(issues) >= limit {
+			return issues, nil
+		}
+		stateNames = stateListWithout(stateNames, defaultProjectItemStatusState)
+		wantedStates = normalizedStateSet(stateNames)
+		if len(wantedStates) == 0 {
+			return issues, nil
+		}
+	}
+
+	statusIssues, err := c.fetchProjectItemsWithPullRequestRefsLimit(ctx, graphQLQueryObservedStatus, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
 		_, ok := wantedStates[normalizeStateName(issue.State)]
 		return ok
-	}, limit)
+	}, limit-len(issues))
 	if err != nil {
 		return nil, err
 	}
 	if _, ok := wantedStates[normalizeStateName("Blocked")]; ok {
-		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+		if err := c.populateBlockerReasons(ctx, statusIssues); err != nil {
 			return nil, err
 		}
-		if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+		if err := c.resolveBlockedByProjectState(ctx, statusIssues); err != nil {
 			return nil, err
 		}
 	}
 	if attachPullRequestsForStates(wantedStates) {
-		if err := c.attachFreshPullRequests(ctx, issues); err != nil {
+		if err := c.attachFreshPullRequests(ctx, statusIssues); err != nil {
 			return nil, err
 		}
 	}
-	return issues, nil
+	return appendUniqueIssues(issues, statusIssues, limit), nil
 }
 
 func (c *Connector) FetchIssueStateProbe(ctx context.Context, stateNames []string, limit int) ([]connector.Issue, error) {
@@ -1144,10 +1175,31 @@ func (c *Connector) FetchIssueStateProbe(ctx context.Context, stateNames []strin
 		return nil, ErrMissingProject
 	}
 
-	return c.fetchProjectItemsWithPullRequestRefsLimit(ctx, graphQLQueryObservedStatus, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
+	issues := []connector.Issue{}
+	if stateSetContains(wantedStates, defaultProjectItemStatusState) {
+		backlogIssues, err := c.fetchProjectBacklogIssues(ctx, limit)
+		if err != nil {
+			return nil, err
+		}
+		issues = appendUniqueIssues(issues, backlogIssues, limit)
+		if len(issues) >= limit {
+			return issues, nil
+		}
+		stateNames = stateListWithout(stateNames, defaultProjectItemStatusState)
+		wantedStates = normalizedStateSet(stateNames)
+		if len(wantedStates) == 0 {
+			return issues, nil
+		}
+	}
+
+	statusIssues, err := c.fetchProjectItemsWithPullRequestRefsLimit(ctx, graphQLQueryObservedStatus, c.projectStatusQuery(stateNames), func(issue connector.Issue) bool {
 		_, ok := wantedStates[normalizeStateName(issue.State)]
 		return ok
-	}, limit)
+	}, limit-len(issues))
+	if err != nil {
+		return nil, err
+	}
+	return appendUniqueIssues(issues, statusIssues, limit), nil
 }
 
 func (c *Connector) VerifyStatusOptions(ctx context.Context, stateNames []string) error {
@@ -2958,6 +3010,67 @@ func (c *Connector) fetchProjectItems(ctx context.Context, queryType string, que
 	return c.fetchProjectItemsLimit(ctx, queryType, query, keepIssue, 0)
 }
 
+func (c *Connector) fetchProjectBacklogIssues(ctx context.Context, limit int) ([]connector.Issue, error) {
+	backlogStates := []string{defaultProjectItemStatusState}
+	issues, err := c.fetchProjectItemsLimit(ctx, graphQLQueryCandidateIssues, c.projectStatusQuery(backlogStates), func(issue connector.Issue) bool {
+		return stateInList(issue.State, backlogStates)
+	}, limit)
+	if err != nil {
+		return nil, err
+	}
+	if limit > 0 && len(issues) >= limit {
+		return issues, nil
+	}
+
+	blankLimit := 0
+	if limit > 0 {
+		blankLimit = limit - len(issues)
+	}
+	blankIssues, err := c.fetchBlankProjectBacklogIssuesPage(ctx, blankLimit)
+	if err != nil {
+		return nil, err
+	}
+	return appendUniqueIssues(issues, blankIssues, limit), nil
+}
+
+func (c *Connector) fetchBlankProjectBacklogIssuesPage(ctx context.Context, limit int) ([]connector.Issue, error) {
+	var response struct {
+		Node *struct {
+			Items projectItemsConnection `json:"items"`
+		} `json:"node"`
+	}
+	if err := c.client.GraphQLWithType(ctx, graphQLQueryCandidateIssues, projectItemsQuery, map[string]any{
+		"projectId": c.projectID,
+		"first":     projectItemsPageSize,
+		"after":     nil,
+		"query":     nil,
+	}, &response); err != nil {
+		return nil, fmt.Errorf("fetch github project items: %w", err)
+	}
+	if response.Node == nil {
+		return nil, ErrProjectNotFound
+	}
+
+	issues := []connector.Issue{}
+	blankStatusItemIDs := []string{}
+	for _, item := range response.Node.Items.Nodes {
+		issue, ok, blankStatusItemID, err := c.normalizeProjectItem(item)
+		if err != nil {
+			return nil, err
+		}
+		if !ok || blankStatusItemID == "" {
+			continue
+		}
+		issues = append(issues, issue)
+		blankStatusItemIDs = append(blankStatusItemIDs, blankStatusItemID)
+		if limit > 0 && len(issues) >= limit {
+			break
+		}
+	}
+	c.defaultBlankProjectItemStatuses(ctx, blankStatusItemIDs)
+	return issues, nil
+}
+
 func (c *Connector) fetchProjectItemsLimit(
 	ctx context.Context,
 	queryType string,
@@ -3827,9 +3940,6 @@ func (c *Connector) detentToGitHubStates(stateNames []string) []string {
 }
 
 func (c *Connector) projectStatusQuery(stateNames []string) string {
-	if stateInList(defaultProjectItemStatusState, stateNames) {
-		return ""
-	}
 	states := c.detentToGitHubStates(stateNames)
 	if len(states) == 0 {
 		return ""
@@ -5328,6 +5438,33 @@ func normalizedStateSet(states []string) map[string]struct{} {
 	return out
 }
 
+func stateSetContains(states map[string]struct{}, state string) bool {
+	_, ok := states[normalizeStateName(state)]
+	return ok
+}
+
+func stateListWithout(states []string, excluded string) []string {
+	excluded = normalizeStateName(excluded)
+	if excluded == "" {
+		return normalizeStateList(states, nil)
+	}
+	out := make([]string, 0, len(states))
+	seen := map[string]struct{}{}
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		key := normalizeStateName(state)
+		if key == "" || key == excluded {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, state)
+	}
+	return out
+}
+
 func stateInList(state string, states []string) bool {
 	normalized := normalizeStateName(state)
 	if normalized == "" {
@@ -5339,6 +5476,38 @@ func stateInList(state string, states []string) bool {
 		}
 	}
 	return false
+}
+
+func appendUniqueIssues(issues []connector.Issue, additions []connector.Issue, limit int) []connector.Issue {
+	seen := make(map[string]struct{}, len(issues)+len(additions))
+	for _, issue := range issues {
+		key := issueKey(issue)
+		if key == "" {
+			continue
+		}
+		seen[key] = struct{}{}
+	}
+	for _, issue := range additions {
+		if limit > 0 && len(issues) >= limit {
+			return issues
+		}
+		key := issueKey(issue)
+		if key != "" {
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+		}
+		issues = append(issues, issue)
+	}
+	return issues
+}
+
+func issueKey(issue connector.Issue) string {
+	if key := strings.TrimSpace(issue.ID); key != "" {
+		return key
+	}
+	return strings.TrimSpace(issue.Identifier)
 }
 
 func attachPullRequestsForStates(states map[string]struct{}) bool {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -228,8 +228,8 @@ func TestProjectStatusQueryFormatsMappedStatuses(t *testing.T) {
 		}
 	}
 
-	if got := c.projectStatusQuery([]string{"Backlog"}); got != "" {
-		t.Fatalf("projectStatusQuery(Backlog) = %q, want empty query", got)
+	if got := c.projectStatusQuery([]string{"Backlog"}); got != "status:Backlog" {
+		t.Fatalf("projectStatusQuery(Backlog) = %q, want status:Backlog", got)
 	}
 }
 
@@ -335,7 +335,10 @@ func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesToBacklog(t *te
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
-			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null},{"id":"PVTI_todo","content":{"__typename":"Issue","id":"I_todo","number":31,"title":"Ready status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/31","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":true,"endCursor":"next"},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null},{"id":"PVTI_todo","content":{"__typename":"Issue","id":"I_todo","number":31,"title":"Ready status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/31","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":{"name":"Todo"},"priorityValue":null}]}}}}`,
 		},
 		{
 			body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_backlog","name":"Backlog"},{"id":"OPT_todo","name":"Todo"}]}}}}`,
@@ -361,16 +364,142 @@ func TestConnectorFetchIssuesByStatesDefaultsBlankProjectStatusesToBacklog(t *te
 		t.Fatalf("defaulted issue = %#v, want blank issue in Backlog", got[0])
 	}
 
-	requests := waitForGraphQLRequests(t, server, 3)
-	if len(requests) != 3 {
-		t.Fatalf("request count = %d, want 3", len(requests))
+	requests := waitForGraphQLRequests(t, server, 4)
+	if len(requests) != 4 {
+		t.Fatalf("request count = %d, want explicit Backlog query, bounded blank scan, and default write", len(requests))
 	}
-	updateVariables := requestVariables(t, requests[2])
+	variables := requestVariables(t, requests[0])
+	if variables["query"] != "status:Backlog" {
+		t.Fatalf("query = %v, want status:Backlog", variables["query"])
+	}
+	variables = requestVariables(t, requests[1])
+	if variables["query"] != nil || variables["after"] != nil {
+		t.Fatalf("blank repair variables = %#v, want first unfiltered page", variables)
+	}
+	if query := requests[1]["query"].(string); strings.Contains(query, "closedByPullRequestsReferences") {
+		t.Fatalf("blank repair query includes linked pull request refs:\n%s", query)
+	}
+	updateVariables := requestVariables(t, requests[3])
 	if updateVariables["projectId"] != "PVT_1" ||
 		updateVariables["itemId"] != "PVTI_blank" ||
 		updateVariables["fieldId"] != "PVTSSF_status" ||
 		updateVariables["optionId"] != "OPT_backlog" {
 		t.Fatalf("update variables = %#v, want blank item moved to Backlog", updateVariables)
+	}
+}
+
+func TestConnectorFetchIssuesByStatesQueriesExplicitBacklogStatusSeparately(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_backlog","content":{"__typename":"Issue","id":"I_backlog","number":40,"title":"Explicit backlog","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/40","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"},"priorityValue":null}]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		ProjectSlug:    "PVT_1",
+		ObservedStates: []string{"Backlog", "Human Review"},
+	})
+
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Backlog", "Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+	if got[0].ID != "I_backlog" || got[0].State != "Backlog" {
+		t.Fatalf("explicit backlog issue = %#v, want explicit Backlog issue", got[0])
+	}
+
+	requests := server.requests()
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want explicit Backlog query, bounded blank scan, and remaining observed-state query", len(requests))
+	}
+	variables := requestVariables(t, requests[0])
+	if variables["query"] != "status:Backlog" {
+		t.Fatalf("query = %v, want status:Backlog", variables["query"])
+	}
+	query := requests[0]["query"].(string)
+	if strings.Contains(query, "closedByPullRequestsReferences") {
+		t.Fatalf("project query includes linked pull request refs:\n%s", query)
+	}
+	variables = requestVariables(t, requests[1])
+	if variables["query"] != nil || variables["after"] != nil {
+		t.Fatalf("blank repair variables = %#v, want first unfiltered page", variables)
+	}
+	if query := requests[1]["query"].(string); strings.Contains(query, "closedByPullRequestsReferences") {
+		t.Fatalf("blank repair query includes linked pull request refs:\n%s", query)
+	}
+	variables = requestVariables(t, requests[2])
+	if variables["query"] != `status:"Human Review"` {
+		t.Fatalf("remaining query = %v, want status:\"Human Review\"", variables["query"])
+	}
+	if query := requests[2]["query"].(string); !strings.Contains(query, "closedByPullRequestsReferences") {
+		t.Fatalf("remaining observed query missing linked pull request refs:\n%s", query)
+	}
+}
+
+func TestConnectorBoundedBacklogFetchesUseExplicitLightweightQuery(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		fetch func(context.Context, *Connector) ([]connector.Issue, error)
+	}{
+		{
+			name: "FetchIssuesByStatesLimit",
+			fetch: func(ctx context.Context, c *Connector) ([]connector.Issue, error) {
+				return c.FetchIssuesByStatesLimit(ctx, []string{"Backlog", "Human Review"}, 1)
+			},
+		},
+		{
+			name: "FetchIssueStateProbe",
+			fetch: func(ctx context.Context, c *Connector) ([]connector.Issue, error) {
+				return c.FetchIssueStateProbe(ctx, []string{"Backlog", "Human Review"}, 1)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{
+				body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_backlog","content":{"__typename":"Issue","id":"I_backlog","number":40,"title":"Explicit backlog","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/40","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"}},"statusValue":{"name":"Backlog"},"priorityValue":null}]}}}}`,
+			}})
+			c := newGitHubTestConnector(t, server, Config{
+				ProjectSlug:    "PVT_1",
+				ObservedStates: []string{"Backlog", "Human Review"},
+			})
+
+			got, err := tt.fetch(context.Background(), c)
+			if err != nil {
+				t.Fatalf("%s() error = %v", tt.name, err)
+			}
+			if len(got) != 1 || got[0].ID != "I_backlog" || got[0].State != "Backlog" {
+				t.Fatalf("%s() = %#v, want explicit Backlog issue", tt.name, got)
+			}
+
+			requests := server.requests()
+			if len(requests) != 1 {
+				t.Fatalf("request count = %d, want one bounded Backlog query", len(requests))
+			}
+			variables := requestVariables(t, requests[0])
+			if variables["query"] != "status:Backlog" {
+				t.Fatalf("query = %v, want status:Backlog", variables["query"])
+			}
+			query := requests[0]["query"].(string)
+			if strings.Contains(query, "closedByPullRequestsReferences") {
+				t.Fatalf("project query includes linked pull request refs:\n%s", query)
+			}
+		})
 	}
 }
 
@@ -513,6 +642,9 @@ func TestConnectorFetchIssuesByStatesIgnoresBlankStatusDefaultWriteFailure(t *te
 
 	server := newGraphQLTestServer(t, []graphqlTestResponse{
 		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
 			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_blank","content":{"__typename":"Issue","id":"I_blank","number":30,"title":"Blank status","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/detent/issues/30","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[]},"repository":{"nameWithOwner":"digitaldrywood/detent"},"closedByPullRequestsReferences":{"nodes":[]}},"statusValue":null,"priorityValue":null}]}}}}`,
 		},
 		{
@@ -535,9 +667,9 @@ func TestConnectorFetchIssuesByStatesIgnoresBlankStatusDefaultWriteFailure(t *te
 		t.Fatalf("defaulted issue = %#v, want blank issue in Backlog", got[0])
 	}
 
-	requests := waitForGraphQLRequests(t, server, 2)
-	if len(requests) != 2 {
-		t.Fatalf("request count = %d, want 2", len(requests))
+	requests := waitForGraphQLRequests(t, server, 3)
+	if len(requests) != 3 {
+		t.Fatalf("request count = %d, want explicit Backlog query, bounded blank scan, and failed default lookup", len(requests))
 	}
 }
 


### PR DESCRIPTION
## Summary

- Fetch ProjectV2 Backlog issues through a separate lightweight `status:Backlog` project query.
- Keep remaining observed states on the existing enriched path for Blocked and PR-pipeline metadata.
- Cover full, limited, and probe Backlog fetches with regression tests.

Fixes #968

## UI Surface Contract

- [x] N/A; this PR only changes connector fetch behavior and tests.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/connector/github -run TestConnectorFetchIssuesByStatesQueriesExplicitBacklogStatusSeparately -count=1`
- [x] `go test ./internal/connector/github -count=1`
- [x] `go test ./internal/connector/... ./internal/orchestrator/... -count=1`
- [x] `make check`
