### PR TITLE
fix(kanban): clear completed dependency blockers

### DIFF
--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -772,14 +772,23 @@ func applySnapshotKanbanIssues(snapshot *telemetry.Snapshot, apply func(*telemet
 
 func kanbanIssueStateIndex(snapshot telemetry.Snapshot) map[string]string {
 	states := map[string]string{}
-	for _, issue := range snapshotKanbanIssues(snapshot) {
-		state := strings.TrimSpace(issue.State)
+	addIssue := func(issue telemetry.Issue, state string) {
+		state = strings.TrimSpace(state)
 		if state == "" {
-			continue
+			state = strings.TrimSpace(issue.State)
+		}
+		if state == "" {
+			return
 		}
 		for _, key := range kanbanIssueStateKeys(issue.ID, issue.Identifier) {
 			states[key] = state
 		}
+	}
+	for _, row := range snapshot.Completed {
+		addIssue(row.Issue, row.State)
+	}
+	for _, issue := range snapshotKanbanIssues(snapshot) {
+		addIssue(issue, issue.State)
 	}
 	return states
 }

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -1,6 +1,8 @@
 package web
 
 import (
+	"bytes"
+	"context"
 	"slices"
 	"strings"
 	"testing"
@@ -117,6 +119,97 @@ func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 	}
 	if snapshot.BoardIssues[1].BlockedBy[0].State != "In Progress" {
 		t.Fatalf("source blocked ref state = %q, want original In Progress", snapshot.BoardIssues[1].BlockedBy[0].State)
+	}
+}
+
+func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefsFromCompletedRows(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	completedAt := time.Date(2026, 7, 7, 0, 37, 10, 0, time.UTC)
+	snapshot := telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		BoardIssues: []telemetry.Issue{
+			{
+				ID:         "dependent",
+				Identifier: "digitaldrywood/detent#953",
+				ProjectID:  "detent",
+				Title:      "Dependent card",
+				State:      "Merging",
+				BlockedBy: []telemetry.BlockedRef{
+					{ID: "blocker", Identifier: "digitaldrywood/detent#950"},
+				},
+			},
+		},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         "blocker",
+				Identifier: "digitaldrywood/detent#950",
+				ProjectID:  "detent",
+				Title:      "Dependency blocker",
+				State:      "Done",
+			},
+			CompletedAt: completedAt,
+			FinalState:  "Done",
+		}},
+	}
+
+	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+	if got.BoardIssues[0].BlockedBy[0].State != "Done" {
+		t.Fatalf("blocked ref state = %q, want Done", got.BoardIssues[0].BlockedBy[0].State)
+	}
+	var html bytes.Buffer
+	data := templates.DashboardData{
+		Snapshot: got,
+		Kanban: templates.KanbanData{
+			States:         []string{"Todo", "Merging", "Done"},
+			TerminalStates: []string{"Done"},
+		},
+	}
+	if err := templates.BoardSnapshot(data).Render(context.Background(), &html); err != nil {
+		t.Fatalf("render board snapshot: %v", err)
+	}
+	if strings.Contains(html.String(), "blocked — digitaldrywood/detent#950") {
+		t.Fatalf("completed dependency rendered as active blocker:\n%s", html.String())
+	}
+	if snapshot.BoardIssues[0].BlockedBy[0].State != "" {
+		t.Fatalf("source blocked ref state = %q, want original empty state", snapshot.BoardIssues[0].BlockedBy[0].State)
+	}
+}
+
+func TestKanbanSnapshotWithPendingStatesPrefersCompletedRowTrackerState(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	snapshot := telemetry.Snapshot{
+		Project: telemetry.Project{ID: "detent"},
+		BoardIssues: []telemetry.Issue{
+			{
+				ID:         "dependent",
+				Identifier: "digitaldrywood/detent#953",
+				ProjectID:  "detent",
+				Title:      "Dependent card",
+				State:      "Merging",
+				BlockedBy: []telemetry.BlockedRef{
+					{ID: "blocker", Identifier: "digitaldrywood/detent#950"},
+				},
+			},
+		},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         "blocker",
+				Identifier: "digitaldrywood/detent#950",
+				ProjectID:  "detent",
+				Title:      "Dependency blocker",
+				State:      "Human Review",
+			},
+			FinalState: "completed",
+		}},
+	}
+
+	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+	if got.BoardIssues[0].BlockedBy[0].State != "Human Review" {
+		t.Fatalf("blocked ref state = %q, want Human Review", got.BoardIssues[0].BlockedBy[0].State)
 	}
 }
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2557,7 +2557,7 @@ func projectKanbanLaneID(state string) string {
 }
 
 func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state string, stageAt time.Time, now time.Time) projectKanbanCard {
-	blockers, clearedBlockers := projectKanbanBlockerLabels(issue.BlockedBy, projectKanbanTerminalStateSetForIssue(data, issue))
+	blockers, clearedBlockers := projectKanbanBlockerLabels(issue.BlockedBy, projectKanbanTerminalStateSetForIssue(data, issue), state)
 	card := projectKanbanCard{
 		IssueNumber:           projectKanbanIssueNumber(issue),
 		Identity:              boardCardIdentityToken(issue.Identifier, issue.ID, projectKanbanIssueNumber(issue)),
@@ -2671,7 +2671,7 @@ func projectKanbanPullRequestConflictReason(issue telemetry.Issue) string {
 	return projectKanbanPullRequestLabel(issue) + " mergeStateStatus " + strings.ToUpper(mergeableState)
 }
 
-func projectKanbanBlockerLabels(refs []telemetry.BlockedRef, terminalStates map[string]struct{}) ([]string, []string) {
+func projectKanbanBlockerLabels(refs []telemetry.BlockedRef, terminalStates map[string]struct{}, issueState string) ([]string, []string) {
 	active := make([]string, 0, len(refs))
 	cleared := make([]string, 0, len(refs))
 	for _, ref := range refs {
@@ -2689,6 +2689,9 @@ func projectKanbanBlockerLabels(refs []telemetry.BlockedRef, terminalStates map[
 			cleared = append(cleared, label)
 			continue
 		}
+		if strings.TrimSpace(ref.State) == "" && !projectKanbanUnknownBlockerActive(issueState) {
+			continue
+		}
 		active = append(active, label)
 	}
 	return uniqueStrings(active), uniqueStrings(cleared)
@@ -2696,6 +2699,10 @@ func projectKanbanBlockerLabels(refs []telemetry.BlockedRef, terminalStates map[
 
 func projectKanbanBlockedRefCleared(ref telemetry.BlockedRef, terminalStates map[string]struct{}) bool {
 	return projectKanbanTerminalState(ref.State, terminalStates)
+}
+
+func projectKanbanUnknownBlockerActive(issueState string) bool {
+	return projectKanbanStateKey(issueState) == "blocked"
 }
 
 func projectKanbanTerminalStateSetForIssue(data DashboardData, issue telemetry.Issue) map[string]struct{} {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1720,6 +1720,13 @@ func TestProjectKanbanCardForIssueOnlyKeepsActiveBlockers(t *testing.T) {
 			},
 			wantBlockers: []string{"digitaldrywood/detent#431"},
 		},
+		{
+			name:  "unresolved dependency is not elevated outside blocked lane",
+			state: "Merging",
+			blockedBy: []telemetry.BlockedRef{
+				{Identifier: "digitaldrywood/detent#432"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- Resolve Kanban blocker refs from completed rows before compact card rendering.
- Suppress active red blocker chips for unknown dependency state outside the Blocked lane.

Fixes #972

## UI Surface Contract

- [x] Linked issue authorizes targeted compact Kanban blocker rendering behavior.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] No layout/style change; render regression verifies the completed dependency chip is omitted.

## Test Plan

- [x] `go test ./internal/web ./internal/web/templates`
- [x] `make check`