### PR TITLE
fix(orchestrator): recover stale CI handoffs

### DIFF
--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -30,6 +30,7 @@ var (
 	ErrResponseError   = errors.New("codex response error")
 	ErrInvalidResponse = errors.New("invalid codex response")
 	ErrTurnFailed      = errors.New("codex turn failed")
+	ErrTransportClose  = errors.New("close codex app-server transport")
 )
 
 type ResponseError struct {
@@ -57,6 +58,28 @@ func (e *ResponseError) Error() string {
 
 func (e *ResponseError) Unwrap() error {
 	return ErrResponseError
+}
+
+type TransportCloseError struct {
+	Err error
+}
+
+func (e *TransportCloseError) Error() string {
+	if e == nil || e.Err == nil {
+		return ErrTransportClose.Error()
+	}
+	return ErrTransportClose.Error() + ": " + e.Err.Error()
+}
+
+func (e *TransportCloseError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *TransportCloseError) Is(target error) bool {
+	return target == ErrTransportClose
 }
 
 func (e *ResponseError) BackendErrorBody() string {
@@ -1029,7 +1052,7 @@ func closeTransport(ctx context.Context, transport Transport, timeout time.Durat
 		defer cancel()
 	}
 	if err := transport.Close(ctx); err != nil {
-		return fmt.Errorf("close codex app-server transport: %w", err)
+		return &TransportCloseError{Err: err}
 	}
 	return nil
 }

--- a/internal/codex/backend.go
+++ b/internal/codex/backend.go
@@ -48,6 +48,13 @@ func (b *AgentBackend) RunTurn(
 		return onUpdate(agentUpdateFromCodex(update))
 	})
 	if err != nil {
+		if errors.Is(err, ErrTransportClose) && result.ThreadID != "" && result.TurnID != "" {
+			return runner.AgentTurnResult{
+				ThreadID:  result.ThreadID,
+				TurnID:    result.TurnID,
+				SessionID: result.SessionID,
+			}, runner.NewAgentTurnCleanupError(err)
+		}
 		return runner.AgentTurnResult{}, err
 	}
 	return runner.AgentTurnResult{

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -873,15 +873,16 @@ type restCommitStatus struct {
 }
 
 type pullRequestCI struct {
-	State              string
-	CheckRunCount      int
-	StatusContextCount int
-	CIQueueSeconds     int64
-	CIDurationSeconds  int64
-	SlowChecks         []connector.PullRequestCheck
-	RunningChecks      []string
-	RequiredFailures   []connector.PullRequestCheck
-	TransientFailures  []connector.PullRequestCheck
+	State                 string
+	CheckRunCount         int
+	StatusContextCount    int
+	CIQueueSeconds        int64
+	CIDurationSeconds     int64
+	SlowChecks            []connector.PullRequestCheck
+	RunningChecks         []string
+	StaleSuccessfulChecks []connector.PullRequestCheck
+	RequiredFailures      []connector.PullRequestCheck
+	TransientFailures     []connector.PullRequestCheck
 }
 
 type checkRunTelemetrySummary struct {
@@ -2622,6 +2623,7 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		CIDurationSeconds:            pullRequest.CI.CIDurationSeconds,
 		SlowChecks:                   append([]connector.PullRequestCheck(nil), pullRequest.CI.SlowChecks...),
 		RunningChecks:                append([]string(nil), pullRequest.CI.RunningChecks...),
+		StaleSuccessfulChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.StaleSuccessfulChecks...),
 		RequiredCheckFailures:        append([]connector.PullRequestCheck(nil), pullRequest.CI.RequiredFailures...),
 		TransientFailedChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.TransientFailures...),
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
@@ -2867,21 +2869,24 @@ func (c *Connector) fetchPullRequestCI(ctx context.Context, repo pullRequestRepo
 		return pullRequestCI{}, fmt.Errorf("fetch github commit statuses: %w", err)
 	}
 	telemetry := checkRunTelemetry(checkRuns, workflowRuns)
+	staleSuccessfulChecks := staleSuccessfulCheckRuns(checkRuns)
+	c.logStaleSuccessfulCheckRuns(ctx, repo, sha, staleSuccessfulChecks)
 	requiredFailures := requiredStatusCheckFailures(checkRuns, statuses, c.requiredChecks)
 	state := combinedCIState(checkRunsState(checkRuns), commitStatusesState(statuses))
 	if requiredState := requiredStatusCheckState(requiredFailures); requiredState != "" {
 		state = combinedCIState(requiredState, state)
 	}
 	return pullRequestCI{
-		State:              state,
-		CheckRunCount:      len(checkRuns),
-		StatusContextCount: len(statuses),
-		CIQueueSeconds:     telemetry.QueueSeconds,
-		CIDurationSeconds:  telemetry.DurationSeconds,
-		SlowChecks:         telemetry.SlowChecks,
-		RunningChecks:      telemetry.RunningChecks,
-		RequiredFailures:   requiredFailures,
-		TransientFailures:  c.transientCheckRunFailures(ctx, repo, checkRuns),
+		State:                 state,
+		CheckRunCount:         len(checkRuns),
+		StatusContextCount:    len(statuses),
+		CIQueueSeconds:        telemetry.QueueSeconds,
+		CIDurationSeconds:     telemetry.DurationSeconds,
+		SlowChecks:            telemetry.SlowChecks,
+		RunningChecks:         telemetry.RunningChecks,
+		StaleSuccessfulChecks: staleSuccessfulChecks,
+		RequiredFailures:      requiredFailures,
+		TransientFailures:     c.transientCheckRunFailures(ctx, repo, checkRuns),
 	}, nil
 }
 
@@ -2917,8 +2922,21 @@ func (c *Connector) transientCheckRunFailures(ctx context.Context, repo pullRequ
 	return failures
 }
 
+func (c *Connector) logStaleSuccessfulCheckRuns(ctx context.Context, repo pullRequestRepo, sha string, checks []connector.PullRequestCheck) {
+	if c == nil || c.logger == nil || len(checks) == 0 {
+		return
+	}
+	c.logger.WarnContext(ctx, "github check runs reported stale successful status; treating completed successful check-runs as passed",
+		"repository", pullRequestRepoName(repo),
+		"head_sha", strings.TrimSpace(sha),
+		"reason", "stale_successful_check_run",
+		"checks", strings.Join(pullRequestCheckNames(checks), ", "),
+		"action", "normalize_success",
+	)
+}
+
 func completedFailedCheckRun(checkRun restCheckRun) bool {
-	if strings.ToLower(strings.TrimSpace(checkRun.Status)) != "completed" {
+	if normalizedCheckRunStatus(checkRun) != "completed" {
 		return false
 	}
 	switch strings.ToLower(strings.TrimSpace(checkRun.Conclusion)) {
@@ -2927,6 +2945,41 @@ func completedFailedCheckRun(checkRun restCheckRun) bool {
 	default:
 		return true
 	}
+}
+
+func staleSuccessfulCheckRuns(checkRuns []restCheckRun) []connector.PullRequestCheck {
+	checks := make([]connector.PullRequestCheck, 0)
+	for _, checkRun := range checkRuns {
+		if !staleSuccessfulCheckRun(checkRun) {
+			continue
+		}
+		checks = append(checks, connector.PullRequestCheck{
+			ID:            checkRun.ID,
+			WorkflowRunID: checkRunWorkflowRunID(checkRun),
+			Name:          strings.TrimSpace(checkRun.Name),
+			Status:        strings.ToLower(strings.TrimSpace(checkRun.Status)),
+			Conclusion:    strings.ToLower(strings.TrimSpace(checkRun.Conclusion)),
+			DetailsURL:    firstNonBlank(checkRun.DetailsURL, checkRun.HTMLURL),
+		})
+	}
+	return checks
+}
+
+func staleSuccessfulCheckRun(checkRun restCheckRun) bool {
+	status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+	return status != "" &&
+		status != "completed" &&
+		strings.ToLower(strings.TrimSpace(checkRun.Conclusion)) == "success" &&
+		checkRun.CompletedAt != nil
+}
+
+func normalizedCheckRunStatus(checkRun restCheckRun) string {
+	status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+	conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
+	if status != "" && status != "completed" && conclusion != "" && checkRun.CompletedAt != nil {
+		return "completed"
+	}
+	return status
 }
 
 func checkRunTransientText(checkRun restCheckRun) string {
@@ -4649,7 +4702,7 @@ func checkRunsState(checkRuns []restCheckRun) string {
 	}
 	pending := false
 	for _, checkRun := range checkRuns {
-		status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+		status := normalizedCheckRunStatus(checkRun)
 		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
 		if status != "" && status != "completed" {
 			pending = true
@@ -4714,7 +4767,7 @@ func requiredStatusCheckFailures(checkRuns []restCheckRun, statuses []restCommit
 }
 
 func requiredCheckRunFailure(name string, checkRun restCheckRun) (connector.PullRequestCheck, bool) {
-	status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+	status := normalizedCheckRunStatus(checkRun)
 	conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
 	if status != "" && status != "completed" {
 		return connector.PullRequestCheck{
@@ -4812,7 +4865,7 @@ func checkRunTelemetry(checkRuns []restCheckRun, workflowRuns []restWorkflowRun)
 		completedAt = latestGitHubTime(completedAt, checkRun.CompletedAt)
 
 		name := strings.TrimSpace(checkRun.Name)
-		status := strings.ToLower(strings.TrimSpace(checkRun.Status))
+		status := normalizedCheckRunStatus(checkRun)
 		conclusion := strings.ToLower(strings.TrimSpace(checkRun.Conclusion))
 		if status != "completed" || conclusion == "" {
 			hasRunning = true
@@ -5386,6 +5439,14 @@ func uniqueNonBlank(values []string) []string {
 		out = append(out, value)
 	}
 	return out
+}
+
+func pullRequestCheckNames(checks []connector.PullRequestCheck) []string {
+	names := make([]string, 0, len(checks))
+	for _, check := range checks {
+		names = append(names, check.Name)
+	}
+	return uniqueNonBlank(names)
 }
 
 func sortIssuesByRequestedIDs(issues []connector.Issue, ids []string) {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1602,6 +1602,32 @@ func TestCheckRunTelemetryReportsQueueAndCompletedSpan(t *testing.T) {
 	}
 }
 
+func TestCheckRunsStateTreatsStaleSuccessfulCheckRunAsSuccess(t *testing.T) {
+	t.Parallel()
+
+	started := time.Date(2026, 7, 7, 0, 45, 0, 0, time.UTC)
+	completed := time.Date(2026, 7, 7, 0, 49, 24, 0, time.UTC)
+
+	checkRuns := []restCheckRun{{
+		Name:        "Installer Smoke (ubuntu-latest)",
+		Status:      "in_progress",
+		Conclusion:  "success",
+		StartedAt:   &started,
+		CompletedAt: &completed,
+	}}
+
+	if got := checkRunsState(checkRuns); got != "success" {
+		t.Fatalf("checkRunsState() = %q, want success", got)
+	}
+	telemetry := checkRunTelemetry(checkRuns, nil)
+	if len(telemetry.RunningChecks) != 0 {
+		t.Fatalf("RunningChecks = %#v, want none", telemetry.RunningChecks)
+	}
+	if telemetry.DurationSeconds != 264 {
+		t.Fatalf("DurationSeconds = %d, want 264", telemetry.DurationSeconds)
+	}
+}
+
 func TestCheckRunTelemetryUsesWorkflowRunTimingForQueue(t *testing.T) {
 	t.Parallel()
 
@@ -1627,6 +1653,7 @@ func TestCheckRunTelemetryUsesWorkflowRunTimingForQueue(t *testing.T) {
 func TestRequiredStatusCheckFailures(t *testing.T) {
 	t.Parallel()
 
+	staleCompleted := time.Date(2026, 7, 7, 0, 49, 24, 0, time.UTC)
 	tests := []struct {
 		name       string
 		checkRuns  []restCheckRun
@@ -1639,6 +1666,16 @@ func TestRequiredStatusCheckFailures(t *testing.T) {
 			name:      "all required check runs succeeded",
 			checkRuns: []restCheckRun{{Name: "Lint", Status: "completed", Conclusion: "success"}},
 			required:  []string{"Lint"},
+		},
+		{
+			name: "stale successful required check run succeeded",
+			checkRuns: []restCheckRun{{
+				Name:        "Installer Smoke (ubuntu-latest)",
+				Status:      "in_progress",
+				Conclusion:  "success",
+				CompletedAt: &staleCompleted,
+			}},
+			required: []string{"Installer Smoke (ubuntu-latest)"},
 		},
 		{
 			name:      "missing required check blocks as pending",
@@ -3042,6 +3079,76 @@ func TestConnectorHydratePullRequestRefreshesCurrentStatus(t *testing.T) {
 	}
 	if got.PRRepository != "example/repo" {
 		t.Fatalf("PRRepository = %q, want example/repo", got.PRRepository)
+	}
+}
+
+func TestConnectorHydratePullRequestNormalizesStaleSuccessfulWorkflowCheckRun(t *testing.T) {
+	t.Parallel()
+
+	var logs bytes.Buffer
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/970",
+			body:   `{"number":970,"html_url":"https://github.com/example/repo/pull/970","state":"open","mergeable_state":"clean","draft":false,"head":{"ref":"detent/example_repo_970","sha":"head-sha"},"base":{"sha":"base-sha"},"updated_at":"2026-07-07T00:50:00Z"}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/check-runs?per_page=100",
+			body:   `{"check_runs":[{"id":97001,"name":"Installer Smoke (ubuntu-latest)","status":"in_progress","conclusion":"success","details_url":"https://github.com/example/repo/actions/runs/28833549023/job/97001","started_at":"2026-07-07T00:45:00Z","completed_at":"2026-07-07T00:49:24Z"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/actions/runs/28833549023",
+			body:   `{"id":28833549023,"status":"completed","conclusion":"success","created_at":"2026-07-07T00:44:00Z","run_started_at":"2026-07-07T00:45:00Z","updated_at":"2026-07-07T00:49:24Z"}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/commits/head-sha/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/example/repo/pulls/970/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	})
+	prNumber := 970
+	issue := connector.Issue{
+		ID:         "I_kw970",
+		Identifier: "example/repo#970",
+		PRNumber:   &prNumber,
+	}
+
+	got, err := c.HydratePullRequest(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("HydratePullRequest() error = %v", err)
+	}
+
+	pr := got.PullRequest
+	if pr == nil {
+		t.Fatalf("PullRequest = nil, want hydrated pull request")
+	}
+	if pr.CIStatus != "pass" {
+		t.Fatalf("CIStatus = %q, want pass", pr.CIStatus)
+	}
+	if len(pr.RunningChecks) != 0 {
+		t.Fatalf("RunningChecks = %#v, want none", pr.RunningChecks)
+	}
+	if len(pr.StaleSuccessfulChecks) != 1 || pr.StaleSuccessfulChecks[0].Name != "Installer Smoke (ubuntu-latest)" {
+		t.Fatalf("StaleSuccessfulChecks = %#v, want Installer Smoke anomaly", pr.StaleSuccessfulChecks)
+	}
+	for _, fragment := range []string{
+		"stale_successful_check_run",
+		"Installer Smoke (ubuntu-latest)",
+		"action=normalize_success",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
 	}
 }
 

--- a/internal/connector/github/pullrequestcache.go
+++ b/internal/connector/github/pullrequestcache.go
@@ -225,15 +225,16 @@ func clonePullRequestStatus(status pullRequestStatus) pullRequestStatus {
 
 func clonePullRequestCI(ci pullRequestCI) pullRequestCI {
 	return pullRequestCI{
-		State:              ci.State,
-		CheckRunCount:      ci.CheckRunCount,
-		StatusContextCount: ci.StatusContextCount,
-		CIQueueSeconds:     ci.CIQueueSeconds,
-		CIDurationSeconds:  ci.CIDurationSeconds,
-		SlowChecks:         append([]connector.PullRequestCheck(nil), ci.SlowChecks...),
-		RunningChecks:      append([]string(nil), ci.RunningChecks...),
-		RequiredFailures:   append([]connector.PullRequestCheck(nil), ci.RequiredFailures...),
-		TransientFailures:  append([]connector.PullRequestCheck(nil), ci.TransientFailures...),
+		State:                 ci.State,
+		CheckRunCount:         ci.CheckRunCount,
+		StatusContextCount:    ci.StatusContextCount,
+		CIQueueSeconds:        ci.CIQueueSeconds,
+		CIDurationSeconds:     ci.CIDurationSeconds,
+		SlowChecks:            append([]connector.PullRequestCheck(nil), ci.SlowChecks...),
+		RunningChecks:         append([]string(nil), ci.RunningChecks...),
+		StaleSuccessfulChecks: append([]connector.PullRequestCheck(nil), ci.StaleSuccessfulChecks...),
+		RequiredFailures:      append([]connector.PullRequestCheck(nil), ci.RequiredFailures...),
+		TransientFailures:     append([]connector.PullRequestCheck(nil), ci.TransientFailures...),
 	}
 }
 

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -64,6 +64,7 @@ type PullRequest struct {
 	CIDurationSeconds            int64                `json:"ci_duration_seconds,omitempty" yaml:"ci_duration_seconds,omitempty"`
 	SlowChecks                   []PullRequestCheck   `json:"slow_checks,omitempty" yaml:"slow_checks,omitempty"`
 	RunningChecks                []string             `json:"running_checks,omitempty" yaml:"running_checks,omitempty"`
+	StaleSuccessfulChecks        []PullRequestCheck   `json:"stale_successful_checks,omitempty" yaml:"stale_successful_checks,omitempty"`
 	RequiredCheckFailures        []PullRequestCheck   `json:"required_check_failures,omitempty" yaml:"required_check_failures,omitempty"`
 	TransientFailedChecks        []PullRequestCheck   `json:"transient_failed_checks,omitempty" yaml:"transient_failed_checks,omitempty"`
 	CodexReviewState             string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1383,6 +1383,19 @@ func autoPromoteFailedChecksFromPullRequest(pullRequest *connector.PullRequest) 
 	return uniqueStrings(checks)
 }
 
+func autoPromoteStaleSuccessfulChecks(pullRequest *connector.PullRequest) []string {
+	if pullRequest == nil {
+		return nil
+	}
+	checks := make([]string, 0, len(pullRequest.StaleSuccessfulChecks))
+	for _, check := range pullRequest.StaleSuccessfulChecks {
+		if name := strings.TrimSpace(check.Name); name != "" {
+			checks = append(checks, name)
+		}
+	}
+	return uniqueStrings(checks)
+}
+
 func autoPromoteCheckFailed(check connector.PullRequestCheck) bool {
 	switch strings.ToLower(strings.TrimSpace(check.Conclusion)) {
 	case "failure", "failed", "error", "timed_out", "startup_failure", "action_required", "cancelled", "canceled", "missing", "skipped", "neutral":
@@ -1618,6 +1631,13 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 		}
 		if failedChecks := strings.Join(autoPromoteFailedChecksFromPullRequest(issue.PullRequest), ", "); failedChecks != "" {
 			attrs = append(attrs, "failed_checks", failedChecks)
+		}
+		if staleSuccessfulChecks := strings.Join(autoPromoteStaleSuccessfulChecks(issue.PullRequest), ", "); staleSuccessfulChecks != "" {
+			attrs = append(attrs,
+				"ci_anomaly", "stale_successful_check_run",
+				"stale_successful_checks", staleSuccessfulChecks,
+				"ci_anomaly_action", "treated_completed_successful_check_runs_as_passed",
+			)
 		}
 	}
 	if decision.QuietRemaining > 0 {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -851,6 +851,23 @@ func TestLogAutoPromoteDecisionIncludesHydrationReasons(t *testing.T) {
 				"pull_request_hydration_next_retry_at=2026-06-25T12:05:00Z",
 			},
 		},
+		{
+			name: "stale successful check run",
+			pullRequest: &connector.PullRequest{
+				Number:   77,
+				CIStatus: "pass",
+				StaleSuccessfulChecks: []connector.PullRequestCheck{{
+					Name:       "Installer Smoke (ubuntu-latest)",
+					Status:     "in_progress",
+					Conclusion: "success",
+				}},
+			},
+			want: []string{
+				"ci_anomaly=stale_successful_check_run",
+				"stale_successful_checks=\"Installer Smoke (ubuntu-latest)\"",
+				"ci_anomaly_action=treated_completed_successful_check_runs_as_passed",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -338,6 +338,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 		}
 		pullRequest.SlowChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.SlowChecks...)
 		pullRequest.RunningChecks = append([]string(nil), issue.PullRequest.RunningChecks...)
+		pullRequest.StaleSuccessfulChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.StaleSuccessfulChecks...)
 		pullRequest.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), issue.PullRequest.RequiredCheckFailures...)
 		pullRequest.TransientFailedChecks = append([]connector.PullRequestCheck(nil), issue.PullRequest.TransientFailedChecks...)
 		pullRequest.CodexReviewFindings = append([]connector.PullRequestFinding(nil), issue.PullRequest.CodexReviewFindings...)

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -679,6 +679,9 @@ func applyPullRequestHydrationBlock(target *connector.PullRequest, source connec
 	if len(target.RequiredCheckFailures) == 0 {
 		target.RequiredCheckFailures = append([]connector.PullRequestCheck(nil), source.RequiredCheckFailures...)
 	}
+	if len(target.StaleSuccessfulChecks) == 0 {
+		target.StaleSuccessfulChecks = append([]connector.PullRequestCheck(nil), source.StaleSuccessfulChecks...)
+	}
 }
 
 func retainUnavailablePullRequests(current []connector.Issue, previous []connector.Issue) []connector.Issue {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -396,6 +396,7 @@ type agentTurnExecution struct {
 	turnResult  AgentTurnResult
 	result      RunResult
 	err         error
+	cleanupErr  error
 	turnStarted bool
 }
 
@@ -429,6 +430,10 @@ func (r *Runner) runAgentTurn(
 		return nil
 	})
 	result.Output = progress.outputText()
+	cleanupErr := agentTurnCleanupError(turnErr, turnResult)
+	if cleanupErr != nil {
+		turnErr = nil
+	}
 	if turnErr != nil {
 		result.FinalState = finalStateForTurnError(turnErr)
 	}
@@ -436,6 +441,7 @@ func (r *Runner) runAgentTurn(
 		turnResult:  turnResult,
 		result:      result,
 		err:         turnErr,
+		cleanupErr:  cleanupErr,
 		turnStarted: turnStarted,
 	}
 }
@@ -636,6 +642,7 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 	}
 	turnResult := execution.turnResult
 	turnErr := execution.err
+	cleanupErr := execution.cleanupErr
 	result := execution.result
 	commandFinishedAttrs := []any{
 		"workspace_path", info.Path,
@@ -647,7 +654,13 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		"error", errorString(turnErr),
 	}
 	commandFinishedAttrs = append(commandFinishedAttrs, backendErrorAttrs(turnErr)...)
-	if turnErr != nil {
+	if cleanupErr != nil {
+		commandFinishedAttrs = append(commandFinishedAttrs,
+			"cleanup_error", errorString(cleanupErr),
+			"cleanup_class", "agent_turn_cleanup",
+		)
+	}
+	if turnErr != nil || cleanupErr != nil {
 		r.logWorkerEventLevel(slog.LevelWarn, req.Issue, "worker_command_finished", commandFinishedAttrs...)
 	} else {
 		r.logWorkerEvent(req.Issue, "worker_command_finished", commandFinishedAttrs...)
@@ -1405,6 +1418,16 @@ func finalStateForTurnError(err error) string {
 		return FinalStateTokenCeilingExceeded
 	}
 	return FinalStateFailed
+}
+
+func agentTurnCleanupError(err error, result AgentTurnResult) error {
+	if err == nil || !errors.Is(err, ErrAgentTurnCleanup) {
+		return nil
+	}
+	if strings.TrimSpace(result.ThreadID) == "" || strings.TrimSpace(result.TurnID) == "" {
+		return nil
+	}
+	return err
 }
 
 func durationFromMillis(ms int) time.Duration {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1209,6 +1209,62 @@ func TestRunnerRunLogsLifecycleWithoutPromptOrMessageBody(t *testing.T) {
 	}
 }
 
+func TestRunnerRunCompletesSuccessfulTurnWithCleanupError(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	var logs bytes.Buffer
+	sessionStore := &fakeSessionStore{sessionID: 970}
+	codexClient := &fakeCodexClient{
+		updates: []AgentUpdate{
+			{Type: AgentUpdateTurnStarted, ThreadID: "thread-970", TurnID: "turn-1"},
+			{Type: AgentUpdateTurnCompleted, ThreadID: "thread-970", TurnID: "turn-1", Status: "completed"},
+		},
+		result: AgentTurnResult{ThreadID: "thread-970", TurnID: "turn-1", SessionID: "thread-970-turn-1"},
+		err:    NewAgentTurnCleanupError(errors.New("close codex app-server transport: operation not permitted")),
+	}
+	runner, err := NewRunner(Dependencies{
+		Workflow: config.Workflow{Config: config.Config{}},
+		Workspace: &fakeWorkspaceBackend{
+			info: workspace.Info{Path: workspacePath, Key: "issue-970", Branch: "detent/issue-970"},
+		},
+		AgentBackend: codexClient,
+		Store:        sessionStore,
+		Logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})),
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-970",
+			Identifier: "digitaldrywood/detent#970",
+			Title:      "Handle stale successful CI checks",
+			State:      "Todo",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.FinalState != FinalStateCompleted {
+		t.Fatalf("FinalState = %q, want completed", result.FinalState)
+	}
+	if sessionStore.finished.FinalState != FinalStateCompleted {
+		t.Fatalf("SessionFinish.FinalState = %q, want completed", sessionStore.finished.FinalState)
+	}
+
+	logText := logs.String()
+	if !strings.Contains(logText, "cleanup_error") || !strings.Contains(logText, "operation not permitted") {
+		t.Fatalf("logs missing cleanup warning:\n%s", logText)
+	}
+	if strings.Contains(logText, "outcome=failed") {
+		t.Fatalf("logs reported failed outcome for cleanup-only error:\n%s", logText)
+	}
+}
+
 func TestRunnerPlanModeCapturesOutputAndConstrainsPrompt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -26,7 +26,10 @@ const (
 	RunOutputMergeFastPathClean = "merge_fast_path_clean"
 )
 
-var ErrSessionTokenCeilingExceeded = errors.New("session token ceiling exceeded")
+var (
+	ErrSessionTokenCeilingExceeded = errors.New("session token ceiling exceeded")
+	ErrAgentTurnCleanup            = errors.New("agent turn cleanup failed")
+)
 
 type Backend interface {
 	Run(context.Context, RunRequest) (RunResult, error)
@@ -68,6 +71,35 @@ type AgentTurnResult struct {
 	ThreadID  string
 	TurnID    string
 	SessionID string
+}
+
+type AgentTurnCleanupError struct {
+	Err error
+}
+
+func NewAgentTurnCleanupError(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &AgentTurnCleanupError{Err: err}
+}
+
+func (e *AgentTurnCleanupError) Error() string {
+	if e == nil || e.Err == nil {
+		return ErrAgentTurnCleanup.Error()
+	}
+	return fmt.Sprintf("%s: %v", ErrAgentTurnCleanup, e.Err)
+}
+
+func (e *AgentTurnCleanupError) Unwrap() error {
+	if e == nil {
+		return nil
+	}
+	return e.Err
+}
+
+func (e *AgentTurnCleanupError) Is(target error) bool {
+	return target == ErrAgentTurnCleanup
 }
 
 type AgentUpdateHandler func(AgentUpdate) error


### PR DESCRIPTION
## Summary

- Normalize stale successful GitHub check-runs so auto-promotion treats completed successful checks as passing and logs the anomaly.
- Preserve successful Codex handoffs when app-server transport close fails after the turn completes, logging cleanup separately from implementation failure.
- Add regression coverage for stale successful CI state and post-handoff cleanup errors.

Fixes #970

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make check`