### PR TITLE
fix(web): allow dashboard API key htmx

### DIFF
--- a/internal/web/api_keys.go
+++ b/internal/web/api_keys.go
@@ -59,6 +59,7 @@ func (s *Server) apiKeysPage(c echo.Context) error {
 		return c.JSON(http.StatusInternalServerError, errorResponse("api_keys_failed", "API keys page failed"))
 	}
 	applyAPIKeysPreferences(c.Request(), &data)
+	s.setAPIKeyDashboardCookie(c, data.DashboardManagementToken)
 	return render(c, templates.APIKeysPage(data))
 }
 
@@ -181,25 +182,33 @@ func (s *Server) apiKeysData(ctx context.Context, c echo.Context) (templates.API
 	activeRows, inactiveRows := apiKeyRows(keys, apiNow(), search, sortKey)
 	exampleProject := apiKeyExampleProject(s.registry)
 	return templates.APIKeysData{
-		Title:                   instancePageTitle(instanceName, "Detent API Keys"),
-		ApplicationName:         applicationName(instanceName),
-		InstanceName:            instanceName,
-		Version:                 s.version,
-		Build:                   s.build,
-		Snapshot:                snapshot,
-		Assets:                  s.assets.templatePaths(),
-		SidebarProjects:         sidebarProjects,
-		ActiveNav:               "api-keys",
-		Search:                  search,
-		Sort:                    sortKey,
-		ActiveRows:              activeRows,
-		InactiveRows:            inactiveRows,
-		ProjectOptions:          apiKeyProjectOptions(s.registry),
-		ShowStaticOnlyBanner:    !serverAddressLoopback(s.serverAddr) && s.apiToken() != "" && len(keys) == 0,
-		StaticTokenConfigured:   s.apiToken() != "",
-		WorkItemExampleProject:  exampleProject,
-		WorkItemExampleEndpoint: apiKeyExampleEndpoint(s.dashboardURL, exampleProject),
+		Title:                    instancePageTitle(instanceName, "Detent API Keys"),
+		ApplicationName:          applicationName(instanceName),
+		InstanceName:             instanceName,
+		Version:                  s.version,
+		Build:                    s.build,
+		Snapshot:                 snapshot,
+		Assets:                   s.assets.templatePaths(),
+		SidebarProjects:          sidebarProjects,
+		ActiveNav:                "api-keys",
+		Search:                   search,
+		Sort:                     sortKey,
+		ActiveRows:               activeRows,
+		InactiveRows:             inactiveRows,
+		ProjectOptions:           apiKeyProjectOptions(s.registry),
+		ShowStaticOnlyBanner:     !serverAddressLoopback(s.serverAddr) && s.apiToken() != "" && len(keys) == 0,
+		StaticTokenConfigured:    s.apiToken() != "",
+		DashboardManagementToken: s.apiKeyDashboardManagementToken(),
+		WorkItemExampleProject:   exampleProject,
+		WorkItemExampleEndpoint:  apiKeyExampleEndpoint(s.dashboardURL, exampleProject),
 	}, nil
+}
+
+func (s *Server) apiKeyDashboardManagementToken() string {
+	if s == nil || s.apiToken() != "" {
+		return ""
+	}
+	return s.apiKeyDashboardToken()
 }
 
 func apiKeyCreateRequest(c echo.Context) (apiKeyCreatePayload, error) {

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -3,7 +3,9 @@ package web
 import (
 	"context"
 	"crypto/hmac"
+	"crypto/rand"
 	"crypto/sha256"
+	"encoding/base64"
 	"encoding/hex"
 	"errors"
 	"net"
@@ -23,13 +25,17 @@ import (
 const apiTokenEnv = "DETENT_API_TOKEN"
 
 const uiAPICookieName = "detent_ui_api"
+const apiKeyDashboardCookieName = "detent_api_key_dashboard"
+const apiKeyDashboardHeader = "X-Detent-API-Key-Dashboard"
+const apiKeyDashboardTokenPayload = "detent-api-key-dashboard-v1"
 
 type apiCredentialContextKey struct{}
 
 type apiAuthOptions struct {
-	mutating           bool
-	allowUICookie      bool
-	allowDashboardHTMX bool
+	mutating                        bool
+	allowUICookie                   bool
+	allowDashboardHTMX              bool
+	requireDashboardManagementToken bool
 }
 
 func (s *Server) apiAuth(mutating bool) echo.MiddlewareFunc {
@@ -95,6 +101,9 @@ func (s *Server) authorizeAPIRequest(c echo.Context, opts apiAuthOptions) (apike
 	}
 
 	if opts.allowDashboardHTMX && token == "" && authorizeDashboardHTMX(c) {
+		if opts.requireDashboardManagementToken && !s.authorizeAPIKeyDashboardToken(c) {
+			return apikey.Credential{}, writeAPIAuthError(c, http.StatusForbidden, "dashboard_token_required", "open the API Keys page from the dashboard before managing API keys")
+		}
 		credential := apikey.StaticCredential()
 		s.setAPICredential(c, credential)
 		return credential, nil
@@ -359,6 +368,50 @@ func (s *Server) uiAPIToken() string {
 	mac := hmac.New(sha256.New, []byte(token))
 	_, _ = mac.Write([]byte("detent-ui-api-v1"))
 	return hex.EncodeToString(mac.Sum(nil))
+}
+
+func newDashboardAuthSecret() ([32]byte, error) {
+	var secret [32]byte
+	_, err := rand.Read(secret[:])
+	return secret, err
+}
+
+func (s *Server) apiKeyDashboardToken() string {
+	if s == nil {
+		return ""
+	}
+	mac := hmac.New(sha256.New, s.dashboardAuthSecret[:])
+	_, _ = mac.Write([]byte(apiKeyDashboardTokenPayload))
+	return apiKeyDashboardTokenPayload + "." + base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+func (s *Server) setAPIKeyDashboardCookie(c echo.Context, token string) {
+	if c == nil || c.Request() == nil || strings.TrimSpace(token) == "" {
+		return
+	}
+	c.SetCookie(&http.Cookie{
+		Name:     apiKeyDashboardCookieName,
+		Value:    token,
+		Path:     "/api/v1/keys",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+		Secure:   c.Request().TLS != nil,
+	})
+}
+
+func (s *Server) authorizeAPIKeyDashboardToken(c echo.Context) bool {
+	if c == nil || c.Request() == nil {
+		return false
+	}
+	candidate := strings.TrimSpace(c.Request().Header.Get(apiKeyDashboardHeader))
+	if candidate == "" || !apiStaticTokenEqual(candidate, s.apiKeyDashboardToken()) {
+		return false
+	}
+	cookie, err := c.Cookie(apiKeyDashboardCookieName)
+	if err != nil {
+		return false
+	}
+	return apiStaticTokenEqual(candidate, cookie.Value)
 }
 
 func apiStaticTokenEqual(candidate string, token string) bool {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -3,6 +3,7 @@ package web
 import (
 	"context"
 	"errors"
+	"fmt"
 	"log/slog"
 	"net"
 	"net/http"
@@ -127,6 +128,7 @@ type Server struct {
 	apiKeys             *apikey.Service
 	ipLimiter           *apiRateLimiter
 	keyLimiter          *apiRateLimiter
+	dashboardAuthSecret [32]byte
 }
 
 func NewServer(cfg Config, deps Dependencies) (*Server, error) {
@@ -153,6 +155,10 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	e.Server.IdleTimeout = cfg.httpIdleTimeout()
 	kanban := cfg.kanban()
 	kanbanWorkflow := cfg.kanbanWorkflow(kanban)
+	dashboardAuthSecret, err := newDashboardAuthSecret()
+	if err != nil {
+		return nil, fmt.Errorf("dashboard auth secret: %w", err)
+	}
 
 	server := &Server{
 		echo:                e,
@@ -193,6 +199,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		apiKeys:             apikey.NewService(deps.Store),
 		ipLimiter:           newAPIRateLimiter(300, 60),
 		keyLimiter:          newAPIRateLimiter(120, 30),
+		dashboardAuthSecret: dashboardAuthSecret,
 	}
 	e.HTTPErrorHandler = server.handleHTTPError
 	e.Use(server.uiAPICookie)
@@ -264,10 +271,10 @@ func (s *Server) registerRoutes() {
 	s.echo.POST("/onboarding/write", s.onboardingWrite)
 	apiReadAuth := s.apiAuth(false)
 	apiMutateAuth := s.apiAuth(true)
-	apiUIReadAuth := s.apiAuthWithOptions(apiAuthOptions{allowUICookie: true})
-	apiUIMutateAuth := s.apiAuthWithOptions(apiAuthOptions{mutating: true, allowUICookie: true})
 	apiDashboardReadAuth := s.apiAuthWithOptions(apiAuthOptions{allowUICookie: true, allowDashboardHTMX: true})
 	apiDashboardMutateAuth := s.apiAuthWithOptions(apiAuthOptions{mutating: true, allowUICookie: true, allowDashboardHTMX: true})
+	apiKeyDashboardReadAuth := s.apiAuthWithOptions(apiAuthOptions{allowUICookie: true, allowDashboardHTMX: true, requireDashboardManagementToken: true})
+	apiKeyDashboardMutateAuth := s.apiAuthWithOptions(apiAuthOptions{mutating: true, allowUICookie: true, allowDashboardHTMX: true, requireDashboardManagementToken: true})
 	apiReadScope := s.requireScope(apikey.ScopeRead)
 	apiWriteScope := s.requireScope(apikey.ScopeWrite)
 	apiAdminScope := s.requireScope(apikey.ScopeAdmin)
@@ -277,11 +284,11 @@ func (s *Server) registerRoutes() {
 	s.echo.GET("/api/v1/timeseries", s.apiTimeSeries, apiReadAuth, apiReadScope)
 	s.echo.POST("/api/v1/projects/:project_id/work-items", s.apiCreateWorkItem, apiMutateAuth, apiProjectWriteScope)
 	s.echo.GET("/api/v1/projects/*", s.apiProject, apiReadAuth, apiReadScope)
-	s.echo.GET("/api/v1/keys", s.apiKeysList, apiUIReadAuth, apiAdminScope)
-	s.echo.POST("/api/v1/keys", s.apiKeysCreate, apiUIMutateAuth, apiAdminScope)
-	s.echo.GET("/api/v1/keys/:id/rotate", s.apiKeysRotateDialog, apiUIReadAuth, apiAdminScope)
-	s.echo.POST("/api/v1/keys/:id/rotate", s.apiKeysRotate, apiUIMutateAuth, apiAdminScope)
-	s.echo.DELETE("/api/v1/keys/:id", s.apiKeysRevoke, apiUIMutateAuth, apiAdminScope)
+	s.echo.GET("/api/v1/keys", s.apiKeysList, apiKeyDashboardReadAuth, apiAdminScope)
+	s.echo.POST("/api/v1/keys", s.apiKeysCreate, apiKeyDashboardMutateAuth, apiAdminScope)
+	s.echo.GET("/api/v1/keys/:id/rotate", s.apiKeysRotateDialog, apiKeyDashboardReadAuth, apiAdminScope)
+	s.echo.POST("/api/v1/keys/:id/rotate", s.apiKeysRotate, apiKeyDashboardMutateAuth, apiAdminScope)
+	s.echo.DELETE("/api/v1/keys/:id", s.apiKeysRevoke, apiKeyDashboardMutateAuth, apiAdminScope)
 	s.echo.POST("/api/v1/refresh", s.apiRefresh, apiDashboardMutateAuth, apiWriteScope)
 	s.echo.POST("/api/v1/webhooks/github", s.githubWebhook)
 	s.echo.GET("/api/v1/refresh", s.methodNotAllowed, apiDashboardReadAuth, apiReadScope)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -9,6 +9,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"html"
 	"io"
 	"log/slog"
 	"net"
@@ -594,6 +595,227 @@ func TestDashboardHTMXAuthAllowsSameOriginDashboardOnWildcardBindWithoutToken(t 
 	}
 }
 
+func TestAPIKeyDashboardHTMXAuthAllowsSameOriginManagementWithoutToken(t *testing.T) {
+	t.Parallel()
+
+	origins := []struct {
+		name       string
+		host       string
+		remote     string
+		htmxTarget string
+	}{
+		{
+			name:       "localhost",
+			host:       "localhost:4000",
+			remote:     "127.0.0.1:49152",
+			htmxTarget: "api-keys-table",
+		},
+		{
+			name:       "private same-origin host",
+			host:       "100.95.107.50:4000",
+			remote:     "100.95.107.51:49152",
+			htmxTarget: "api-keys-table",
+		},
+	}
+
+	for _, origin := range origins {
+		origin := origin
+		t.Run(origin.name, func(t *testing.T) {
+			t.Parallel()
+
+			server, backend := newAPIKeyDashboardHTMXTestServer(t, "")
+			session := newAPIKeyDashboardSession(t, server.Handler(), origin.host, origin.remote)
+			baseRequest := dashboardHTMXRequest{
+				host:       origin.host,
+				remote:     origin.remote,
+				currentURL: "http://" + origin.host + "/api-keys",
+				htmxTarget: origin.htmxTarget,
+				headers:    session.headers,
+				cookies:    session.cookies,
+			}
+
+			list := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{
+				method:     http.MethodGet,
+				path:       "/api/v1/keys",
+				host:       baseRequest.host,
+				remote:     baseRequest.remote,
+				currentURL: baseRequest.currentURL,
+				htmxTarget: baseRequest.htmxTarget,
+				headers:    baseRequest.headers,
+				cookies:    baseRequest.cookies,
+			})
+			if list.Code != http.StatusOK {
+				t.Fatalf("list status = %d, want %d; body = %s", list.Code, http.StatusOK, list.Body.String())
+			}
+			if !strings.Contains(list.Body.String(), "Create your first key") {
+				t.Fatalf("list body missing empty state:\n%s", list.Body.String())
+			}
+
+			create := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{
+				method:     http.MethodPost,
+				path:       "/api/v1/keys",
+				host:       baseRequest.host,
+				remote:     baseRequest.remote,
+				currentURL: baseRequest.currentURL,
+				htmxTarget: "api-key-modal-body",
+				headers:    baseRequest.headers,
+				cookies:    baseRequest.cookies,
+				form: url.Values{
+					"name":         {"Dashboard client"},
+					"scopes":       {"write"},
+					"all_projects": {"true"},
+					"expires_in":   {"90d"},
+				},
+			})
+			if create.Code != http.StatusOK {
+				t.Fatalf("create status = %d, want %d; body = %s", create.Code, http.StatusOK, create.Body.String())
+			}
+			if create.Header().Get("HX-Trigger") != "apiKeyCreated" {
+				t.Fatalf("create HX-Trigger = %q, want apiKeyCreated", create.Header().Get("HX-Trigger"))
+			}
+			if body := create.Body.String(); !strings.Contains(body, "API key created") || !strings.Contains(body, apikey.TokenPrefix) {
+				t.Fatalf("create body missing reveal:\n%s", body)
+			}
+
+			keys, err := backend.ListAPIKeys(context.Background())
+			if err != nil {
+				t.Fatalf("ListAPIKeys() error = %v", err)
+			}
+			if len(keys) != 1 {
+				t.Fatalf("keys len = %d, want 1", len(keys))
+			}
+			keyID := keys[0].ID
+
+			rotateDialog := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{
+				method:     http.MethodGet,
+				path:       "/api/v1/keys/" + keyID + "/rotate",
+				host:       baseRequest.host,
+				remote:     baseRequest.remote,
+				currentURL: baseRequest.currentURL,
+				htmxTarget: "api-key-modal-body",
+				headers:    baseRequest.headers,
+				cookies:    baseRequest.cookies,
+			})
+			if rotateDialog.Code != http.StatusOK {
+				t.Fatalf("rotate dialog status = %d, want %d; body = %s", rotateDialog.Code, http.StatusOK, rotateDialog.Body.String())
+			}
+			if !strings.Contains(rotateDialog.Body.String(), "Rotate API key") {
+				t.Fatalf("rotate dialog body missing title:\n%s", rotateDialog.Body.String())
+			}
+
+			rotate := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{
+				method:     http.MethodPost,
+				path:       "/api/v1/keys/" + keyID + "/rotate",
+				host:       baseRequest.host,
+				remote:     baseRequest.remote,
+				currentURL: baseRequest.currentURL,
+				htmxTarget: "api-key-modal-body",
+				headers:    baseRequest.headers,
+				cookies:    baseRequest.cookies,
+				form: url.Values{
+					"grace": {"1h"},
+				},
+			})
+			if rotate.Code != http.StatusOK {
+				t.Fatalf("rotate status = %d, want %d; body = %s", rotate.Code, http.StatusOK, rotate.Body.String())
+			}
+			if rotate.Header().Get("HX-Trigger") != "apiKeyChanged" {
+				t.Fatalf("rotate HX-Trigger = %q, want apiKeyChanged", rotate.Header().Get("HX-Trigger"))
+			}
+			if body := rotate.Body.String(); !strings.Contains(body, "API key created") || !strings.Contains(body, apikey.TokenPrefix) {
+				t.Fatalf("rotate body missing reveal:\n%s", body)
+			}
+
+			revoke := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{
+				method:     http.MethodDelete,
+				path:       "/api/v1/keys/" + keyID,
+				host:       baseRequest.host,
+				remote:     baseRequest.remote,
+				currentURL: baseRequest.currentURL,
+				htmxTarget: "api-keys-table",
+				headers:    baseRequest.headers,
+				cookies:    baseRequest.cookies,
+			})
+			if revoke.Code != http.StatusOK {
+				t.Fatalf("revoke status = %d, want %d; body = %s", revoke.Code, http.StatusOK, revoke.Body.String())
+			}
+			if revoke.Header().Get("HX-Trigger") != "apiKeyChanged" {
+				t.Fatalf("revoke HX-Trigger = %q, want apiKeyChanged", revoke.Header().Get("HX-Trigger"))
+			}
+			revoked, err := backend.APIKey(context.Background(), keyID)
+			if err != nil {
+				t.Fatalf("APIKey() after revoke error = %v", err)
+			}
+			if revoked.RevokedAt == nil {
+				t.Fatalf("RevokedAt = nil, want timestamp")
+			}
+		})
+	}
+}
+
+func TestAPIKeyDashboardHTMXAuthAllowsConfiguredTokenUICookie(t *testing.T) {
+	t.Parallel()
+
+	server, backend := newAPIKeyDashboardHTMXTestServer(t, "detent_cookie_token")
+	request := dashboardHTMXRequest{
+		method:     http.MethodGet,
+		path:       "/api/v1/keys",
+		host:       "100.95.107.50:4000",
+		remote:     "100.95.107.51:49152",
+		currentURL: "http://100.95.107.50:4000/api-keys",
+		htmxTarget: "api-keys-table",
+	}
+
+	withoutCookie := performDashboardHTMXRequest(t, server.Handler(), request)
+	if withoutCookie.Code != http.StatusUnauthorized {
+		t.Fatalf("list without UI cookie status = %d, want %d; body = %s", withoutCookie.Code, http.StatusUnauthorized, withoutCookie.Body.String())
+	}
+
+	page := httptest.NewRecorder()
+	pageReq := httptest.NewRequest(http.MethodGet, "http://100.95.107.50:4000/api-keys", nil)
+	pageReq.Host = "100.95.107.50:4000"
+	server.Handler().ServeHTTP(page, pageReq)
+	if page.Code != http.StatusOK {
+		t.Fatalf("api keys page status = %d, want %d; body = %s", page.Code, http.StatusOK, page.Body.String())
+	}
+	cookies := page.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("api keys page did not set UI API cookie")
+	}
+
+	request.cookies = cookies
+	withCookie := performDashboardHTMXRequest(t, server.Handler(), request)
+	if withCookie.Code != http.StatusOK {
+		t.Fatalf("list with UI cookie status = %d, want %d; body = %s", withCookie.Code, http.StatusOK, withCookie.Body.String())
+	}
+
+	create := performDashboardHTMXRequest(t, server.Handler(), dashboardHTMXRequest{
+		method:     http.MethodPost,
+		path:       "/api/v1/keys",
+		host:       "100.95.107.50:4000",
+		remote:     "100.95.107.51:49152",
+		currentURL: "http://100.95.107.50:4000/api-keys",
+		htmxTarget: "api-key-modal-body",
+		cookies:    cookies,
+		form: url.Values{
+			"name":         {"Cookie client"},
+			"scopes":       {"read"},
+			"all_projects": {"true"},
+			"expires_in":   {"90d"},
+		},
+	})
+	if create.Code != http.StatusOK {
+		t.Fatalf("create with UI cookie status = %d, want %d; body = %s", create.Code, http.StatusOK, create.Body.String())
+	}
+	keys, err := backend.ListAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListAPIKeys() error = %v", err)
+	}
+	if len(keys) != 1 {
+		t.Fatalf("keys len = %d, want 1", len(keys))
+	}
+}
+
 func TestDashboardHTMXAuthRejectsUntrustedRequestsOnWildcardBindWithoutToken(t *testing.T) {
 	t.Parallel()
 
@@ -707,6 +929,115 @@ func TestDashboardHTMXAuthRejectsUntrustedRequestsOnWildcardBindWithoutToken(t *
 	}
 }
 
+func TestAPIKeyDashboardHTMXAuthRejectsUntrustedManagementWithoutToken(t *testing.T) {
+	t.Parallel()
+
+	server, backend := newAPIKeyDashboardHTMXTestServer(t, "")
+	createForm := url.Values{
+		"name":         {"Blocked client"},
+		"scopes":       {"read"},
+		"all_projects": {"true"},
+		"expires_in":   {"90d"},
+	}
+	tests := []struct {
+		name string
+		req  dashboardHTMXRequest
+	}{
+		{
+			name: "raw private host list denied",
+			req: dashboardHTMXRequest{
+				method: http.MethodGet,
+				path:   "/api/v1/keys",
+				host:   "100.95.107.50:4000",
+				remote: "100.95.107.51:49152",
+				noHX:   true,
+			},
+		},
+		{
+			name: "private host list without htmx target denied",
+			req: dashboardHTMXRequest{
+				method:     http.MethodGet,
+				path:       "/api/v1/keys",
+				host:       "100.95.107.50:4000",
+				remote:     "100.95.107.51:49152",
+				currentURL: "http://100.95.107.50:4000/api-keys",
+			},
+		},
+		{
+			name: "private host create with forged same origin htmx denied",
+			req: dashboardHTMXRequest{
+				method:     http.MethodPost,
+				path:       "/api/v1/keys",
+				host:       "100.95.107.50:4000",
+				remote:     "100.95.107.51:49152",
+				currentURL: "http://100.95.107.50:4000/api-keys",
+				htmxTarget: "api-key-modal-body",
+				form:       createForm,
+			},
+		},
+		{
+			name: "private host create with self minted dashboard token denied",
+			req: dashboardHTMXRequest{
+				method:     http.MethodPost,
+				path:       "/api/v1/keys",
+				host:       "100.95.107.50:4000",
+				remote:     "100.95.107.51:49152",
+				currentURL: "http://100.95.107.50:4000/api-keys",
+				htmxTarget: "api-key-modal-body",
+				headers: map[string]string{
+					"X-Detent-API-Key-Dashboard": "forged",
+				},
+				cookies: []*http.Cookie{{
+					Name:  "detent_api_key_dashboard",
+					Value: "forged",
+				}},
+				form: createForm,
+			},
+		},
+		{
+			name: "private host create with cross origin htmx source denied",
+			req: dashboardHTMXRequest{
+				method:     http.MethodPost,
+				path:       "/api/v1/keys",
+				host:       "100.95.107.50:4000",
+				remote:     "100.95.107.51:49152",
+				currentURL: "http://dashboard.example.test:4000/api-keys",
+				htmxTarget: "api-key-modal-body",
+				form:       createForm,
+			},
+		},
+		{
+			name: "spoofed localhost create from external peer denied",
+			req: dashboardHTMXRequest{
+				method:     http.MethodPost,
+				path:       "/api/v1/keys",
+				host:       "localhost:4000",
+				remote:     "203.0.113.10:49152",
+				currentURL: "http://localhost:4000/api-keys",
+				htmxTarget: "api-key-modal-body",
+				form:       createForm,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			rec := performDashboardHTMXRequest(t, server.Handler(), tt.req)
+			if rec.Code != http.StatusForbidden {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusForbidden, rec.Body.String())
+			}
+		})
+	}
+	keys, err := backend.ListAPIKeys(context.Background())
+	if err != nil {
+		t.Fatalf("ListAPIKeys() error = %v", err)
+	}
+	if len(keys) != 0 {
+		t.Fatalf("keys len = %d, want 0", len(keys))
+	}
+}
+
 type dashboardHTMXAuthFixture struct {
 	server          *web.Server
 	actionConnector *kanbanActionConnector
@@ -777,6 +1108,58 @@ func newDashboardHTMXAuthFixture(t *testing.T) dashboardHTMXAuthFixture {
 		server:          server,
 		actionConnector: actionConnector,
 		refresher:       refresher,
+	}
+}
+
+func newAPIKeyDashboardHTMXTestServer(t *testing.T, apiToken string) (*web.Server, store.Store) {
+	t.Helper()
+
+	backend := openWebTestStore(t)
+	deps := testDeps(t)
+	deps.Store = backend
+	cfg := web.Config{
+		ServerAddress: "0.0.0.0:4000",
+	}
+	if apiToken != "" {
+		cfg.GlobalConfig = globalconfig.Config{APIToken: apiToken}
+	}
+	server, err := web.NewServer(cfg, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+	return server, backend
+}
+
+type apiKeyDashboardSession struct {
+	headers map[string]string
+	cookies []*http.Cookie
+}
+
+func newAPIKeyDashboardSession(t *testing.T, handler http.Handler, host string, remote string) apiKeyDashboardSession {
+	t.Helper()
+
+	req := httptest.NewRequest(http.MethodGet, "http://"+host+"/api-keys", nil)
+	req.Host = host
+	req.RemoteAddr = remote
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("api keys page status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	body := html.UnescapeString(rec.Body.String())
+	match := regexp.MustCompile(`"X-Detent-API-Key-Dashboard":"([^"]+)"`).FindStringSubmatch(body)
+	if len(match) != 2 {
+		t.Fatalf("api keys page missing dashboard header token:\n%s", rec.Body.String())
+	}
+	cookies := rec.Result().Cookies()
+	if len(cookies) == 0 {
+		t.Fatal("api keys page did not set dashboard management cookie")
+	}
+	return apiKeyDashboardSession{
+		headers: map[string]string{
+			"X-Detent-API-Key-Dashboard": match[1],
+		},
+		cookies: cookies,
 	}
 }
 
@@ -8851,6 +9234,8 @@ type dashboardHTMXRequest struct {
 	form       url.Values
 	currentURL string
 	htmxTarget string
+	headers    map[string]string
+	cookies    []*http.Cookie
 	noHX       bool
 }
 
@@ -8890,6 +9275,12 @@ func performDashboardHTMXRequest(t *testing.T, handler http.Handler, input dashb
 		if htmxTarget := strings.TrimSpace(input.htmxTarget); htmxTarget != "" {
 			req.Header.Set("HX-Target", htmxTarget)
 		}
+	}
+	for _, cookie := range input.cookies {
+		req.AddCookie(cookie)
+	}
+	for key, value := range input.headers {
+		req.Header.Set(key, value)
 	}
 
 	rec := httptest.NewRecorder()

--- a/internal/web/templates/api_keys.templ
+++ b/internal/web/templates/api_keys.templ
@@ -32,6 +32,7 @@ templ APIKeysPage(data APIKeysData) {
 							hx-target="#api-keys-table"
 							hx-include="#api-key-sort"
 							hx-swap="innerHTML"
+							{ apiKeyDashboardRequestAttributes(data)... }
 						/>
 						<input id="api-key-sort" type="hidden" name="sort" value={ data.Sort }/>
 					</div>
@@ -46,6 +47,7 @@ templ APIKeysPage(data APIKeysData) {
 					hx-trigger="apiKeyChanged from:body, apiKeyCreated from:body"
 					hx-include="#api-key-search,#api-key-sort"
 					hx-swap="innerHTML"
+					{ apiKeyDashboardRequestAttributes(data)... }
 				>
 					@APIKeysTable(data)
 				</div>
@@ -81,7 +83,7 @@ templ APIKeysTable(data APIKeysData) {
 				<span class="text-right text-2xs font-semibold uppercase text-dim">Actions</span>
 			</div>
 			for _, row := range data.ActiveRows {
-				@apiKeyTableRow(row)
+				@apiKeyTableRow(row, data)
 			}
 			if len(data.InactiveRows) > 0 {
 				<details class="border-t border-line" data-preserve-details="api-keys-inactive">
@@ -90,9 +92,9 @@ templ APIKeysTable(data APIKeysData) {
 						@icon.ChevronDown(icon.Props{Class: "size-4 transition-transform open:rotate-180"})
 					</summary>
 					for _, row := range data.InactiveRows {
-						@apiKeyTableRow(row)
-					}
-				</details>
+					@apiKeyTableRow(row, data)
+				}
+			</details>
 			}
 		</section>
 	}
@@ -106,6 +108,7 @@ templ apiKeySortableHeader(sort string, label string, data APIKeysData) {
 		hx-target="#api-keys-table"
 		hx-include="#api-key-search"
 		hx-swap="innerHTML"
+		{ apiKeyDashboardRequestAttributes(data)... }
 	>
 		{ label }
 		if data.Sort == sort {
@@ -114,7 +117,7 @@ templ apiKeySortableHeader(sort string, label string, data APIKeysData) {
 	</a>
 }
 
-templ apiKeyTableRow(row APIKeyRow) {
+templ apiKeyTableRow(row APIKeyRow, data APIKeysData) {
 	<div class="grid grid-cols-[minmax(140px,1.1fr)_140px_90px_minmax(120px,1fr)_120px_120px_110px_130px] items-center gap-3.5 border-b border-line px-4 py-3 last:border-b-0">
 		<span class="min-w-0 truncate text-sm font-medium text-text" title={ row.Name }>{ row.Name }</span>
 		<code class="min-w-0 truncate font-mono text-xs text-sec" title={ row.PrefixLast4 }>{ row.PrefixLast4 }</code>
@@ -142,6 +145,7 @@ templ apiKeyTableRow(row APIKeyRow) {
 				hx-get={ "/api/v1/keys/" + row.ID + "/rotate" }
 				hx-target="#api-key-modal-body"
 				hx-swap="innerHTML"
+				{ apiKeyDashboardRequestAttributes(data)... }
 				aria-label={ "Rotate " + row.Name }
 				title="Rotate"
 			>
@@ -154,6 +158,7 @@ templ apiKeyTableRow(row APIKeyRow) {
 				hx-target="#api-keys-table"
 				hx-include="#api-key-search,#api-key-sort"
 				hx-swap="innerHTML"
+				{ apiKeyDashboardRequestAttributes(data)... }
 				data-api-key-revoke
 				data-api-key-name={ row.Name }
 				data-api-key-admin={ boolString(row.AdminConfirmName) }
@@ -178,7 +183,7 @@ templ APIKeyModalHost(data APIKeysData) {
 }
 
 templ APIKeyCreateForm(data APIKeysData) {
-	<form class="flex flex-col gap-5 p-5" hx-post="/api/v1/keys" hx-target="#api-key-modal-body" hx-swap="innerHTML">
+	<form class="flex flex-col gap-5 p-5" hx-post="/api/v1/keys" hx-target="#api-key-modal-body" hx-swap="innerHTML" { apiKeyDashboardRequestAttributes(data)... }>
 		<div class="flex items-start justify-between gap-4">
 			<div>
 				<h2 class="text-base font-semibold">Create API key</h2>
@@ -248,7 +253,7 @@ templ apiKeyScopeRadio(value string, label string, description string, checked b
 }
 
 templ APIKeyRotateDialog(data APIKeysData, row APIKeyRow) {
-	<form class="flex flex-col gap-5 p-5" hx-post={ "/api/v1/keys/" + row.ID + "/rotate" } hx-target="#api-key-modal-body" hx-swap="innerHTML">
+	<form class="flex flex-col gap-5 p-5" hx-post={ "/api/v1/keys/" + row.ID + "/rotate" } hx-target="#api-key-modal-body" hx-swap="innerHTML" { apiKeyDashboardRequestAttributes(data)... }>
 		<div class="flex items-start justify-between gap-4">
 			<div>
 				<h2 class="text-base font-semibold">Rotate API key</h2>

--- a/internal/web/templates/api_keys_data.go
+++ b/internal/web/templates/api_keys_data.go
@@ -4,34 +4,37 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/a-h/templ"
+
 	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 type APIKeysData struct {
-	Title                   string
-	ApplicationName         string
-	InstanceName            string
-	Version                 string
-	Build                   buildinfo.Info
-	Snapshot                telemetry.Snapshot
-	Assets                  AssetPaths
-	SidebarProjects         []ProjectSmallMultiple
-	ActiveNav               string
-	ProjectID               string
-	ProjectName             string
-	SidebarCollapsed        bool
-	Theme                   string
-	Density                 string
-	Search                  string
-	Sort                    string
-	ActiveRows              []APIKeyRow
-	InactiveRows            []APIKeyRow
-	ProjectOptions          []APIKeyProjectOption
-	ShowStaticOnlyBanner    bool
-	StaticTokenConfigured   bool
-	WorkItemExampleProject  string
-	WorkItemExampleEndpoint string
+	Title                    string
+	ApplicationName          string
+	InstanceName             string
+	Version                  string
+	Build                    buildinfo.Info
+	Snapshot                 telemetry.Snapshot
+	Assets                   AssetPaths
+	SidebarProjects          []ProjectSmallMultiple
+	ActiveNav                string
+	ProjectID                string
+	ProjectName              string
+	SidebarCollapsed         bool
+	Theme                    string
+	Density                  string
+	Search                   string
+	Sort                     string
+	ActiveRows               []APIKeyRow
+	InactiveRows             []APIKeyRow
+	ProjectOptions           []APIKeyProjectOption
+	ShowStaticOnlyBanner     bool
+	StaticTokenConfigured    bool
+	DashboardManagementToken string
+	WorkItemExampleProject   string
+	WorkItemExampleEndpoint  string
 }
 
 type APIKeyRow struct {
@@ -102,6 +105,16 @@ func apiKeyStatusClass(row APIKeyRow) string {
 		return row.StatusClass
 	}
 	return "text-sec"
+}
+
+func apiKeyDashboardRequestAttributes(data APIKeysData) templ.Attributes {
+	token := strings.TrimSpace(data.DashboardManagementToken)
+	if token == "" {
+		return templ.Attributes{}
+	}
+	return templ.Attributes{
+		"hx-headers": fmt.Sprintf(`{"X-Detent-API-Key-Dashboard":%q}`, token),
+	}
 }
 
 func apiKeyTableEmpty(data APIKeysData) bool {

--- a/internal/web/templates/api_keys_templ.go
+++ b/internal/web/templates/api_keys_templ.go
@@ -86,20 +86,28 @@ func APIKeysPage(data APIKeysData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" placeholder=\"Search by name\" class=\"h-9 w-full rounded-card border border-line bg-surface pl-9 pr-3 text-sm text-text outline-none focus:border-accent\" hx-get=\"/api/v1/keys\" hx-trigger=\"input changed delay:300ms, search\" hx-target=\"#api-keys-table\" hx-include=\"#api-key-sort\" hx-swap=\"innerHTML\"> <input id=\"api-key-sort\" type=\"hidden\" name=\"sort\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 6, "\" placeholder=\"Search by name\" class=\"h-9 w-full rounded-card border border-line bg-surface pl-9 pr-3 text-sm text-text outline-none focus:border-accent\" hx-get=\"/api/v1/keys\" hx-trigger=\"input changed delay:300ms, search\" hx-target=\"#api-keys-table\" hx-include=\"#api-key-sort\" hx-swap=\"innerHTML\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, apiKeyDashboardRequestAttributes(data))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "> <input id=\"api-key-sort\" type=\"hidden\" name=\"sort\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var4 string
 			templ_7745c5c3_Var4, templ_7745c5c3_Err = templ.JoinStringErrs(data.Sort)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 36, Col: 74}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 37, Col: 74}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var4))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 7, "\"></div><button type=\"button\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\" data-api-key-open-create>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "\"></div><button type=\"button\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\" data-api-key-open-create>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -107,7 +115,15 @@ func APIKeysPage(data APIKeysData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 8, "Create key</button></div><div id=\"api-keys-table\" hx-get=\"/api/v1/keys\" hx-trigger=\"apiKeyChanged from:body, apiKeyCreated from:body\" hx-include=\"#api-key-search,#api-key-sort\" hx-swap=\"innerHTML\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "Create key</button></div><div id=\"api-keys-table\" hx-get=\"/api/v1/keys\" hx-trigger=\"apiKeyChanged from:body, apiKeyCreated from:body\" hx-include=\"#api-key-search,#api-key-sort\" hx-swap=\"innerHTML\"")
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, apiKeyDashboardRequestAttributes(data))
+			if templ_7745c5c3_Err != nil {
+				return templ_7745c5c3_Err
+			}
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, ">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -115,7 +131,7 @@ func APIKeysPage(data APIKeysData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 9, "</div></div></main>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "</div></div></main>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -155,7 +171,7 @@ func APIKeysTable(data APIKeysData) templ.Component {
 		}
 		ctx = templ.ClearChildren(ctx)
 		if apiKeyTableEmpty(data) {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 10, "<section class=\"flex flex-none flex-col items-center justify-center gap-3 rounded-card border border-line bg-surface px-4 py-16 text-center\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "<section class=\"flex flex-none flex-col items-center justify-center gap-3 rounded-card border border-line bg-surface px-4 py-16 text-center\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -163,7 +179,7 @@ func APIKeysTable(data APIKeysData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 11, "<p class=\"text-sm text-text\">Create named API keys for external dispatchers and automation clients.</p><button type=\"button\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\" data-api-key-open-create>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<p class=\"text-sm text-text\">Create named API keys for external dispatchers and automation clients.</p><button type=\"button\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\" data-api-key-open-create>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -171,22 +187,22 @@ func APIKeysTable(data APIKeysData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 12, "Create your first key</button> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "Create your first key</button> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			if data.StaticTokenConfigured {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 13, "<p class=\"text-xs text-sec\"><code class=\"font-mono\">api_token</code> still works as break-glass access.</p>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<p class=\"text-xs text-sec\"><code class=\"font-mono\">api_token</code> still works as break-glass access.</p>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 14, "</section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		} else {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 15, "<section class=\"flex flex-none flex-col overflow-hidden rounded-card border border-line bg-surface\"><div class=\"grid grid-cols-[minmax(140px,1.1fr)_140px_90px_minmax(120px,1fr)_120px_120px_110px_130px] gap-3.5 border-b border-line px-4 py-2\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<section class=\"flex flex-none flex-col overflow-hidden rounded-card border border-line bg-surface\"><div class=\"grid grid-cols-[minmax(140px,1.1fr)_140px_90px_minmax(120px,1fr)_120px_120px_110px_130px] gap-3.5 border-b border-line px-4 py-2\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -194,7 +210,7 @@ func APIKeysTable(data APIKeysData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 16, "<span class=\"text-2xs font-semibold uppercase text-dim\">Key</span> <span class=\"text-2xs font-semibold uppercase text-dim\">Scope</span> <span class=\"text-2xs font-semibold uppercase text-dim\">Projects</span> <span class=\"text-2xs font-semibold uppercase text-dim\">Status</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<span class=\"text-2xs font-semibold uppercase text-dim\">Key</span> <span class=\"text-2xs font-semibold uppercase text-dim\">Scope</span> <span class=\"text-2xs font-semibold uppercase text-dim\">Projects</span> <span class=\"text-2xs font-semibold uppercase text-dim\">Status</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -206,31 +222,31 @@ func APIKeysTable(data APIKeysData) templ.Component {
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 17, "<span class=\"text-right text-2xs font-semibold uppercase text-dim\">Actions</span></div>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, "<span class=\"text-right text-2xs font-semibold uppercase text-dim\">Actions</span></div>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			for _, row := range data.ActiveRows {
-				templ_7745c5c3_Err = apiKeyTableRow(row).Render(ctx, templ_7745c5c3_Buffer)
+				templ_7745c5c3_Err = apiKeyTableRow(row, data).Render(ctx, templ_7745c5c3_Buffer)
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
 			if len(data.InactiveRows) > 0 {
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 18, "<details class=\"border-t border-line\" data-preserve-details=\"api-keys-inactive\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-sec marker:hidden\"><span>Show inactive (")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "<details class=\"border-t border-line\" data-preserve-details=\"api-keys-inactive\"><summary class=\"flex cursor-pointer list-none items-center justify-between gap-3 px-4 py-3 text-sm font-medium text-sec marker:hidden\"><span>Show inactive (")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				var templ_7745c5c3_Var6 string
 				templ_7745c5c3_Var6, templ_7745c5c3_Err = templ.JoinStringErrs(len(data.InactiveRows))
 				if templ_7745c5c3_Err != nil {
-					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 89, Col: 51}
+					return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 91, Col: 51}
 				}
 				_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var6))
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 19, ")</span>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, ")</span>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
@@ -238,22 +254,22 @@ func APIKeysTable(data APIKeysData) templ.Component {
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 20, "</summary> ")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</summary> ")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 				for _, row := range data.InactiveRows {
-					templ_7745c5c3_Err = apiKeyTableRow(row).Render(ctx, templ_7745c5c3_Buffer)
+					templ_7745c5c3_Err = apiKeyTableRow(row, data).Render(ctx, templ_7745c5c3_Buffer)
 					if templ_7745c5c3_Err != nil {
 						return templ_7745c5c3_Err
 					}
 				}
-				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 21, "</details>")
+				templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "</details>")
 				if templ_7745c5c3_Err != nil {
 					return templ_7745c5c3_Err
 				}
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 22, "</section>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "</section>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
@@ -283,33 +299,41 @@ func apiKeySortableHeader(sort string, label string, data APIKeysData) templ.Com
 			templ_7745c5c3_Var7 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 23, "<a href=\"#\" class=\"inline-flex items-center gap-1 text-2xs font-semibold uppercase text-dim hover:text-text\" hx-get=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, "<a href=\"#\" class=\"inline-flex items-center gap-1 text-2xs font-semibold uppercase text-dim hover:text-text\" hx-get=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var8 string
 		templ_7745c5c3_Var8, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/keys?sort=" + sort)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 105, Col: 38}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 107, Col: 38}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var8))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 24, "\" hx-target=\"#api-keys-table\" hx-include=\"#api-key-search\" hx-swap=\"innerHTML\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "\" hx-target=\"#api-keys-table\" hx-include=\"#api-key-search\" hx-swap=\"innerHTML\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, apiKeyDashboardRequestAttributes(data))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, ">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var9 string
 		templ_7745c5c3_Var9, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 110, Col: 9}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 113, Col: 9}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var9))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 25, " ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, " ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -319,7 +343,7 @@ func apiKeySortableHeader(sort string, label string, data APIKeysData) templ.Com
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 26, "</a>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</a>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -327,7 +351,7 @@ func apiKeySortableHeader(sort string, label string, data APIKeysData) templ.Com
 	})
 }
 
-func apiKeyTableRow(row APIKeyRow) templ.Component {
+func apiKeyTableRow(row APIKeyRow, data APIKeysData) templ.Component {
 	return templruntime.GeneratedTemplate(func(templ_7745c5c3_Input templruntime.GeneratedComponentInput) (templ_7745c5c3_Err error) {
 		templ_7745c5c3_W, ctx := templ_7745c5c3_Input.Writer, templ_7745c5c3_Input.Context
 		if templ_7745c5c3_CtxErr := ctx.Err(); templ_7745c5c3_CtxErr != nil {
@@ -348,59 +372,59 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 			templ_7745c5c3_Var10 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 27, "<div class=\"grid grid-cols-[minmax(140px,1.1fr)_140px_90px_minmax(120px,1fr)_120px_120px_110px_130px] items-center gap-3.5 border-b border-line px-4 py-3 last:border-b-0\"><span class=\"min-w-0 truncate text-sm font-medium text-text\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "<div class=\"grid grid-cols-[minmax(140px,1.1fr)_140px_90px_minmax(120px,1fr)_120px_120px_110px_130px] items-center gap-3.5 border-b border-line px-4 py-3 last:border-b-0\"><span class=\"min-w-0 truncate text-sm font-medium text-text\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var11 string
 		templ_7745c5c3_Var11, templ_7745c5c3_Err = templ.JoinStringErrs(row.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 119, Col: 79}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 122, Col: 79}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var11))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 28, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var12 string
 		templ_7745c5c3_Var12, templ_7745c5c3_Err = templ.JoinStringErrs(row.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 119, Col: 92}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 122, Col: 92}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var12))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 29, "</span> <code class=\"min-w-0 truncate font-mono text-xs text-sec\" title=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "</span> <code class=\"min-w-0 truncate font-mono text-xs text-sec\" title=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var13 string
 		templ_7745c5c3_Var13, templ_7745c5c3_Err = templ.JoinStringErrs(row.PrefixLast4)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 120, Col: 83}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 123, Col: 83}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var13))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 30, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var14 string
 		templ_7745c5c3_Var14, templ_7745c5c3_Err = templ.JoinStringErrs(row.PrefixLast4)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 120, Col: 103}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 123, Col: 103}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var14))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 31, "</code> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</code> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -409,7 +433,7 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 32, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -422,49 +446,49 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 33, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var17 string
 		templ_7745c5c3_Var17, templ_7745c5c3_Err = templ.JoinStringErrs(row.Scope)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 121, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 124, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var17))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 34, "</span> <span class=\"flex min-w-0 flex-wrap gap-1\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</span> <span class=\"flex min-w-0 flex-wrap gap-1\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(row.ProjectLabels) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 35, "<span class=\"text-xs text-sec\">All</span> ")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "<span class=\"text-xs text-sec\">All</span> ")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		for _, project := range row.ProjectLabels {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 36, "<span class=\"rounded-chip bg-elev px-2 py-0.5 font-mono text-2xs text-sec\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<span class=\"rounded-chip bg-elev px-2 py-0.5 font-mono text-2xs text-sec\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var18 string
 			templ_7745c5c3_Var18, templ_7745c5c3_Err = templ.JoinStringErrs(project)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 127, Col: 88}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 130, Col: 88}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var18))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 37, "</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 38, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -473,7 +497,7 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 39, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -486,20 +510,20 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 40, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var21 string
 		templ_7745c5c3_Var21, templ_7745c5c3_Err = templ.JoinStringErrs(row.Status)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 130, Col: 78}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 133, Col: 78}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var21))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 41, "</span> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, "</span> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -508,7 +532,7 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 42, "<span class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<span class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -521,69 +545,77 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 43, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var24 string
 		templ_7745c5c3_Var24, templ_7745c5c3_Err = templ.JoinStringErrs(row.LastUsed)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 132, Col: 17}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 135, Col: 17}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var24))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 44, " ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, " ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if row.UnusedBadge {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 45, "<span class=\"ml-1 rounded-chip bg-elev px-1.5 py-0.5 text-2xs text-dim\">unused</span>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "<span class=\"ml-1 rounded-chip bg-elev px-1.5 py-0.5 text-2xs text-dim\">unused</span>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 46, "</span> <span class=\"font-mono text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "</span> <span class=\"font-mono text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var25 string
 		templ_7745c5c3_Var25, templ_7745c5c3_Err = templ.JoinStringErrs(row.Created)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 137, Col: 56}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 140, Col: 56}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var25))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 47, "</span> <span class=\"flex justify-end gap-1.5\"><button type=\"button\" class=\"rounded-chip border border-line p-1.5 text-sec hover:border-accent hover:text-accent\" hx-get=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</span> <span class=\"flex justify-end gap-1.5\"><button type=\"button\" class=\"rounded-chip border border-line p-1.5 text-sec hover:border-accent hover:text-accent\" hx-get=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var26 string
 		templ_7745c5c3_Var26, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/keys/" + row.ID + "/rotate")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 142, Col: 49}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 145, Col: 49}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var26))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 48, "\" hx-target=\"#api-key-modal-body\" hx-swap=\"innerHTML\" aria-label=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" hx-target=\"#api-key-modal-body\" hx-swap=\"innerHTML\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, apiKeyDashboardRequestAttributes(data))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, " aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var27 string
 		templ_7745c5c3_Var27, templ_7745c5c3_Err = templ.JoinStringErrs("Rotate " + row.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 145, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 149, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var27))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 49, "\" title=\"Rotate\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\" title=\"Rotate\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -591,59 +623,67 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 50, "</button> <button type=\"button\" class=\"rounded-chip border border-line p-1.5 text-sec hover:border-err hover:text-err\" hx-delete=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "</button> <button type=\"button\" class=\"rounded-chip border border-line p-1.5 text-sec hover:border-err hover:text-err\" hx-delete=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var28 string
 		templ_7745c5c3_Var28, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/keys/" + row.ID)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 153, Col: 40}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 157, Col: 40}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var28))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 51, "\" hx-target=\"#api-keys-table\" hx-include=\"#api-key-search,#api-key-sort\" hx-swap=\"innerHTML\" data-api-key-revoke data-api-key-name=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "\" hx-target=\"#api-keys-table\" hx-include=\"#api-key-search,#api-key-sort\" hx-swap=\"innerHTML\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, apiKeyDashboardRequestAttributes(data))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, " data-api-key-revoke data-api-key-name=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var29 string
 		templ_7745c5c3_Var29, templ_7745c5c3_Err = templ.JoinStringErrs(row.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 158, Col: 32}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 163, Col: 32}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var29))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 52, "\" data-api-key-admin=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "\" data-api-key-admin=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var30 string
 		templ_7745c5c3_Var30, templ_7745c5c3_Err = templ.JoinStringErrs(boolString(row.AdminConfirmName))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 159, Col: 57}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 164, Col: 57}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var30))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 53, "\" aria-label=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "\" aria-label=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var31 string
 		templ_7745c5c3_Var31, templ_7745c5c3_Err = templ.JoinStringErrs("Revoke " + row.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 160, Col: 37}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 165, Col: 37}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var31))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 54, "\" title=\"Revoke\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "\" title=\"Revoke\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -651,7 +691,7 @@ func apiKeyTableRow(row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 55, "</button></span></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</button></span></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -680,7 +720,7 @@ func APIKeyModalHost(data APIKeysData) templ.Component {
 			templ_7745c5c3_Var32 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 56, "<template id=\"api-key-create-template\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "<template id=\"api-key-create-template\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -688,7 +728,7 @@ func APIKeyModalHost(data APIKeysData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 57, "</template><dialog id=\"api-key-modal\" class=\"w-full max-w-2xl rounded-card border border-line bg-page p-0 text-text shadow-lg backdrop:bg-black/50\"><div id=\"api-key-modal-body\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "</template><dialog id=\"api-key-modal\" class=\"w-full max-w-2xl rounded-card border border-line bg-page p-0 text-text shadow-lg backdrop:bg-black/50\"><div id=\"api-key-modal-body\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -696,7 +736,7 @@ func APIKeyModalHost(data APIKeysData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 58, "</div></dialog>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "</div></dialog>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -725,7 +765,15 @@ func APIKeyCreateForm(data APIKeysData) templ.Component {
 			templ_7745c5c3_Var33 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 59, "<form class=\"flex flex-col gap-5 p-5\" hx-post=\"/api/v1/keys\" hx-target=\"#api-key-modal-body\" hx-swap=\"innerHTML\"><div class=\"flex items-start justify-between gap-4\"><div><h2 class=\"text-base font-semibold\">Create API key</h2><p class=\"mt-1 text-xs text-sec\">The full token is shown once after creation.</p></div><button type=\"button\" class=\"rounded-chip p-1.5 text-sec hover:bg-elev hover:text-text\" data-api-modal-close aria-label=\"Close\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "<form class=\"flex flex-col gap-5 p-5\" hx-post=\"/api/v1/keys\" hx-target=\"#api-key-modal-body\" hx-swap=\"innerHTML\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, apiKeyDashboardRequestAttributes(data))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "><div class=\"flex items-start justify-between gap-4\"><div><h2 class=\"text-base font-semibold\">Create API key</h2><p class=\"mt-1 text-xs text-sec\">The full token is shown once after creation.</p></div><button type=\"button\" class=\"rounded-chip p-1.5 text-sec hover:bg-elev hover:text-text\" data-api-modal-close aria-label=\"Close\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -733,7 +781,7 @@ func APIKeyCreateForm(data APIKeysData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 60, "</button></div><label class=\"grid gap-1.5\"><span class=\"text-xs font-medium text-sec\">Name</span> <input id=\"api-key-name\" name=\"name\" required autofocus class=\"h-9 rounded-card border border-line bg-surface px-3 text-sm text-text outline-none focus:border-accent\"></label><div class=\"grid gap-2\"><span class=\"text-xs font-medium text-sec\">Scope</span><div class=\"grid gap-2 sm:grid-cols-3\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</button></div><label class=\"grid gap-1.5\"><span class=\"text-xs font-medium text-sec\">Name</span> <input id=\"api-key-name\" name=\"name\" required autofocus class=\"h-9 rounded-card border border-line bg-surface px-3 text-sm text-text outline-none focus:border-accent\"></label><div class=\"grid gap-2\"><span class=\"text-xs font-medium text-sec\">Scope</span><div class=\"grid gap-2 sm:grid-cols-3\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -749,49 +797,49 @@ func APIKeyCreateForm(data APIKeysData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 61, "</div></div><div class=\"grid gap-2\"><label class=\"flex items-center gap-2 text-sm text-text\"><input type=\"checkbox\" name=\"all_projects\" value=\"true\" class=\"accent-accent\" checked data-api-key-all-projects> All projects</label><div class=\"hidden grid max-h-36 gap-2 overflow-auto rounded-card border border-line bg-surface p-3\" data-api-key-project-picker>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "</div></div><div class=\"grid gap-2\"><label class=\"flex items-center gap-2 text-sm text-text\"><input type=\"checkbox\" name=\"all_projects\" value=\"true\" class=\"accent-accent\" checked data-api-key-all-projects> All projects</label><div class=\"hidden grid max-h-36 gap-2 overflow-auto rounded-card border border-line bg-surface p-3\" data-api-key-project-picker>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if len(data.ProjectOptions) == 0 {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 62, "<p class=\"text-xs text-sec\">No configured projects available.</p>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<p class=\"text-xs text-sec\">No configured projects available.</p>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
 		for _, project := range data.ProjectOptions {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 63, "<label class=\"flex items-center gap-2 text-xs text-text\"><input type=\"checkbox\" name=\"project_ids\" value=\"")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "<label class=\"flex items-center gap-2 text-xs text-text\"><input type=\"checkbox\" name=\"project_ids\" value=\"")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var34 string
 			templ_7745c5c3_Var34, templ_7745c5c3_Err = templ.JoinStringErrs(project.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 214, Col: 66}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 219, Col: 66}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var34))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 64, "\" class=\"accent-accent\"> <span class=\"font-mono\">")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, "\" class=\"accent-accent\"> <span class=\"font-mono\">")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var35 string
 			templ_7745c5c3_Var35, templ_7745c5c3_Err = templ.JoinStringErrs(project.ID)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 215, Col: 42}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 220, Col: 42}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var35))
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 65, "</span></label>")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, "</span></label>")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 66, "</div></div><label class=\"grid gap-1.5\"><span class=\"text-xs font-medium text-sec\">Expiry</span> <select name=\"expires_in\" class=\"h-9 rounded-card border border-line bg-surface px-3 text-sm text-text outline-none focus:border-accent\" data-api-key-expiry><option value=\"30d\">30 days</option> <option value=\"90d\" selected>90 days</option> <option value=\"365d\">365 days</option> <option value=\"never\">Never</option></select> <span class=\"hidden text-xs text-warn\" data-api-key-never-note>This key never expires.</span></label><div class=\"flex justify-end gap-2\"><button type=\"button\" class=\"h-9 rounded-card border border-line px-3 text-sm font-medium text-text hover:bg-elev\" data-api-modal-close>Cancel</button> <button type=\"submit\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</div></div><label class=\"grid gap-1.5\"><span class=\"text-xs font-medium text-sec\">Expiry</span> <select name=\"expires_in\" class=\"h-9 rounded-card border border-line bg-surface px-3 text-sm text-text outline-none focus:border-accent\" data-api-key-expiry><option value=\"30d\">30 days</option> <option value=\"90d\" selected>90 days</option> <option value=\"365d\">365 days</option> <option value=\"never\">Never</option></select> <span class=\"hidden text-xs text-warn\" data-api-key-never-note>This key never expires.</span></label><div class=\"flex justify-end gap-2\"><button type=\"button\" class=\"h-9 rounded-card border border-line px-3 text-sm font-medium text-text hover:bg-elev\" data-api-modal-close>Cancel</button> <button type=\"submit\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -799,7 +847,7 @@ func APIKeyCreateForm(data APIKeysData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 67, "Create</button></div></form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "Create</button></div></form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -828,56 +876,56 @@ func apiKeyScopeRadio(value string, label string, description string, checked bo
 			templ_7745c5c3_Var36 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 68, "<label class=\"grid cursor-pointer gap-1 rounded-card border border-line bg-surface p-3 text-sm text-text has-[:checked]:border-accent\"><span class=\"flex items-center gap-2 font-medium\"><input type=\"radio\" name=\"scopes\" value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<label class=\"grid cursor-pointer gap-1 rounded-card border border-line bg-surface p-3 text-sm text-text has-[:checked]:border-accent\"><span class=\"flex items-center gap-2 font-medium\"><input type=\"radio\" name=\"scopes\" value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var37 string
 		templ_7745c5c3_Var37, templ_7745c5c3_Err = templ.JoinStringErrs(value)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 243, Col: 50}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 248, Col: 50}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var37))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 69, "\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		if checked {
-			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 70, " checked")
+			templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, " checked")
 			if templ_7745c5c3_Err != nil {
 				return templ_7745c5c3_Err
 			}
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 71, " class=\"accent-accent\"> ")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, " class=\"accent-accent\"> ")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var38 string
 		templ_7745c5c3_Var38, templ_7745c5c3_Err = templ.JoinStringErrs(label)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 244, Col: 10}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 249, Col: 10}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var38))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 72, "</span> <span class=\"text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "</span> <span class=\"text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var39 string
 		templ_7745c5c3_Var39, templ_7745c5c3_Err = templ.JoinStringErrs(description)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 246, Col: 46}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 251, Col: 46}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var39))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 73, "</span></label>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "</span></label>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -906,33 +954,41 @@ func APIKeyRotateDialog(data APIKeysData, row APIKeyRow) templ.Component {
 			templ_7745c5c3_Var40 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 74, "<form class=\"flex flex-col gap-5 p-5\" hx-post=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "<form class=\"flex flex-col gap-5 p-5\" hx-post=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var41 string
 		templ_7745c5c3_Var41, templ_7745c5c3_Err = templ.JoinStringErrs("/api/v1/keys/" + row.ID + "/rotate")
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 251, Col: 85}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 256, Col: 85}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var41))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 75, "\" hx-target=\"#api-key-modal-body\" hx-swap=\"innerHTML\"><div class=\"flex items-start justify-between gap-4\"><div><h2 class=\"text-base font-semibold\">Rotate API key</h2><p class=\"mt-1 text-xs text-sec\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" hx-target=\"#api-key-modal-body\" hx-swap=\"innerHTML\"")
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templ.RenderAttributes(ctx, templ_7745c5c3_Buffer, apiKeyDashboardRequestAttributes(data))
+		if templ_7745c5c3_Err != nil {
+			return templ_7745c5c3_Err
+		}
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "><div class=\"flex items-start justify-between gap-4\"><div><h2 class=\"text-base font-semibold\">Rotate API key</h2><p class=\"mt-1 text-xs text-sec\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var42 string
 		templ_7745c5c3_Var42, templ_7745c5c3_Err = templ.JoinStringErrs(row.Name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 255, Col: 47}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 260, Col: 47}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var42))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 76, "</p></div><button type=\"button\" class=\"rounded-chip p-1.5 text-sec hover:bg-elev hover:text-text\" data-api-modal-close aria-label=\"Close\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</p></div><button type=\"button\" class=\"rounded-chip p-1.5 text-sec hover:bg-elev hover:text-text\" data-api-modal-close aria-label=\"Close\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -940,7 +996,7 @@ func APIKeyRotateDialog(data APIKeysData, row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 77, "</button></div><label class=\"grid gap-1.5\"><span class=\"text-xs font-medium text-sec\">Grace period</span> <select name=\"grace\" class=\"h-9 rounded-card border border-line bg-surface px-3 text-sm text-text outline-none focus:border-accent\"><option value=\"1h\">1 hour</option> <option value=\"24h\" selected>24 hours</option> <option value=\"7d\">7 days</option></select></label><div class=\"flex justify-end gap-2\"><button type=\"button\" class=\"h-9 rounded-card border border-line px-3 text-sm font-medium text-text hover:bg-elev\" data-api-modal-close>Cancel</button> <button type=\"submit\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</button></div><label class=\"grid gap-1.5\"><span class=\"text-xs font-medium text-sec\">Grace period</span> <select name=\"grace\" class=\"h-9 rounded-card border border-line bg-surface px-3 text-sm text-text outline-none focus:border-accent\"><option value=\"1h\">1 hour</option> <option value=\"24h\" selected>24 hours</option> <option value=\"7d\">7 days</option></select></label><div class=\"flex justify-end gap-2\"><button type=\"button\" class=\"h-9 rounded-card border border-line px-3 text-sm font-medium text-text hover:bg-elev\" data-api-modal-close>Cancel</button> <button type=\"submit\" class=\"inline-flex h-9 items-center justify-center gap-2 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -948,7 +1004,7 @@ func APIKeyRotateDialog(data APIKeysData, row APIKeyRow) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 78, "Rotate</button></div></form>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "Rotate</button></div></form>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -979,7 +1035,7 @@ func APIKeyReveal(data APIKeysData, token string) templ.Component {
 		ctx = templ.ClearChildren(ctx)
 		curlSnippet := apiKeyCurlSnippet(data, token)
 		promptSnippet := apiKeyPromptSnippet(data, token)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 79, "<div class=\"flex flex-col gap-5 p-5\"><div class=\"flex items-start justify-between gap-4\"><div><h2 class=\"text-base font-semibold\">API key created</h2><p class=\"mt-1 text-xs font-medium text-warn\">Copy it now — you won't be able to see it again.</p></div><button type=\"button\" class=\"rounded-chip p-1.5 text-sec hover:bg-elev hover:text-text\" data-api-modal-close aria-label=\"Close\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<div class=\"flex flex-col gap-5 p-5\"><div class=\"flex items-start justify-between gap-4\"><div><h2 class=\"text-base font-semibold\">API key created</h2><p class=\"mt-1 text-xs font-medium text-warn\">Copy it now — you won't be able to see it again.</p></div><button type=\"button\" class=\"rounded-chip p-1.5 text-sec hover:bg-elev hover:text-text\" data-api-modal-close aria-label=\"Close\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -987,46 +1043,46 @@ func APIKeyReveal(data APIKeysData, token string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 80, "</button></div><div class=\"grid gap-2\"><div class=\"flex min-w-0 items-center gap-2\"><code class=\"min-w-0 flex-1 overflow-x-auto rounded-card border border-line bg-surface px-3 py-2 font-mono text-xs blur-sm select-none\" data-api-secret data-real-value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</button></div><div class=\"grid gap-2\"><div class=\"flex min-w-0 items-center gap-2\"><code class=\"min-w-0 flex-1 overflow-x-auto rounded-card border border-line bg-surface px-3 py-2 font-mono text-xs blur-sm select-none\" data-api-secret data-real-value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var44 string
 		templ_7745c5c3_Var44, templ_7745c5c3_Err = templ.JoinStringErrs(token)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 294, Col: 179}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 299, Col: 179}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var44))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 81, "\" data-masked-value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "\" data-masked-value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var45 string
 		templ_7745c5c3_Var45, templ_7745c5c3_Err = templ.JoinStringErrs(token)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 294, Col: 207}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 299, Col: 207}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var45))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 82, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var46 string
 		templ_7745c5c3_Var46, templ_7745c5c3_Err = templ.JoinStringErrs(token)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 294, Col: 217}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 299, Col: 217}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var46))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 83, "</code> <button type=\"button\" class=\"rounded-chip border border-line p-2 text-sec hover:border-accent hover:text-accent\" data-api-toggle-secret aria-label=\"Show token\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "</code> <button type=\"button\" class=\"rounded-chip border border-line p-2 text-sec hover:border-accent hover:text-accent\" data-api-toggle-secret aria-label=\"Show token\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1034,20 +1090,20 @@ func APIKeyReveal(data APIKeysData, token string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 84, "</button> <button type=\"button\" class=\"inline-flex h-9 items-center gap-2 rounded-card border border-line px-3 text-sm font-medium text-text hover:bg-elev\" data-api-copy data-real-value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "</button> <button type=\"button\" class=\"inline-flex h-9 items-center gap-2 rounded-card border border-line px-3 text-sm font-medium text-text hover:bg-elev\" data-api-copy data-real-value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var47 string
 		templ_7745c5c3_Var47, templ_7745c5c3_Err = templ.JoinStringErrs(token)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 298, Col: 187}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 303, Col: 187}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var47))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 85, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1055,7 +1111,7 @@ func APIKeyReveal(data APIKeysData, token string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 86, "<span data-copy-label>Copy</span></button></div></div><div class=\"grid gap-3\"><div class=\"flex border-b border-line\" role=\"tablist\"><button type=\"button\" class=\"border-b-2 border-accent px-3 py-2 text-xs font-medium text-accent\" data-api-snippet-tab=\"curl\">curl</button> <button type=\"button\" class=\"border-b-2 border-transparent px-3 py-2 text-xs font-medium text-sec hover:text-text\" data-api-snippet-tab=\"prompt\">AI Prompt</button></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "<span data-copy-label>Copy</span></button></div></div><div class=\"grid gap-3\"><div class=\"flex border-b border-line\" role=\"tablist\"><button type=\"button\" class=\"border-b-2 border-accent px-3 py-2 text-xs font-medium text-accent\" data-api-snippet-tab=\"curl\">curl</button> <button type=\"button\" class=\"border-b-2 border-transparent px-3 py-2 text-xs font-medium text-sec hover:text-text\" data-api-snippet-tab=\"prompt\">AI Prompt</button></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1067,7 +1123,7 @@ func APIKeyReveal(data APIKeysData, token string) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 87, "</div><div class=\"flex justify-end\"><button type=\"button\" class=\"h-9 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\" data-api-key-done>Done</button></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "</div><div class=\"flex justify-end\"><button type=\"button\" class=\"h-9 rounded-card bg-accent px-3 text-sm font-medium text-page hover:bg-accent/90\" data-api-key-done>Done</button></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1102,7 +1158,7 @@ func apiKeySnippetPanel(name string, snippet string, token string, hidden bool) 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 88, "<div class=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "<div class=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1115,59 +1171,59 @@ func apiKeySnippetPanel(name string, snippet string, token string, hidden bool) 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 89, "\" data-api-snippet-panel=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "\" data-api-snippet-panel=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var51 string
 		templ_7745c5c3_Var51, templ_7745c5c3_Err = templ.JoinStringErrs(name)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 324, Col: 31}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 329, Col: 31}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var51))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 90, "\"><pre class=\"max-h-56 overflow-auto p-3 pr-20 text-xs\"><code data-api-snippet-code data-real-value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "\"><pre class=\"max-h-56 overflow-auto p-3 pr-20 text-xs\"><code data-api-snippet-code data-real-value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var52 string
 		templ_7745c5c3_Var52, templ_7745c5c3_Err = templ.JoinStringErrs(snippet)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 326, Col: 109}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 331, Col: 109}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var52))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 91, "\" data-masked-value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 98, "\" data-masked-value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var53 string
 		templ_7745c5c3_Var53, templ_7745c5c3_Err = templ.JoinStringErrs(apiKeyMaskedSnippet(snippet, token))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 326, Col: 167}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 331, Col: 167}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var53))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 92, "\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 99, "\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var54 string
 		templ_7745c5c3_Var54, templ_7745c5c3_Err = templ.JoinStringErrs(apiKeyMaskedSnippet(snippet, token))
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 326, Col: 207}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 331, Col: 207}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var54))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 93, "</code></pre><div class=\"absolute right-2 top-2 flex gap-1\"><button type=\"button\" class=\"rounded-chip border border-line bg-page p-1.5 text-sec hover:border-accent hover:text-accent\" data-api-toggle-snippet aria-label=\"Show snippet\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 100, "</code></pre><div class=\"absolute right-2 top-2 flex gap-1\"><button type=\"button\" class=\"rounded-chip border border-line bg-page p-1.5 text-sec hover:border-accent hover:text-accent\" data-api-toggle-snippet aria-label=\"Show snippet\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1175,20 +1231,20 @@ func apiKeySnippetPanel(name string, snippet string, token string, hidden bool) 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 94, "</button> <button type=\"button\" class=\"rounded-chip border border-line bg-page p-1.5 text-sec hover:border-accent hover:text-accent\" data-api-copy data-real-value=\"")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 101, "</button> <button type=\"button\" class=\"rounded-chip border border-line bg-page p-1.5 text-sec hover:border-accent hover:text-accent\" data-api-copy data-real-value=\"")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
 		var templ_7745c5c3_Var55 string
 		templ_7745c5c3_Var55, templ_7745c5c3_Err = templ.JoinStringErrs(snippet)
 		if templ_7745c5c3_Err != nil {
-			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 331, Col: 165}
+			return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/api_keys.templ`, Line: 336, Col: 165}
 		}
 		_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var55))
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 95, "\" aria-label=\"Copy snippet\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 102, "\" aria-label=\"Copy snippet\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1196,7 +1252,7 @@ func apiKeySnippetPanel(name string, snippet string, token string, hidden bool) 
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 96, "<span class=\"sr-only\" data-copy-label>Copy</span></button></div></div>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 103, "<span class=\"sr-only\" data-copy-label>Copy</span></button></div></div>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
@@ -1225,7 +1281,7 @@ func apiKeysScript() templ.Component {
 			templ_7745c5c3_Var56 = templ.NopComponent
 		}
 		ctx = templ.ClearChildren(ctx)
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 97, "<script>\n\t\t(function () {\n\t\t\tfunction modal() { return document.getElementById(\"api-key-modal\"); }\n\t\t\tfunction body() { return document.getElementById(\"api-key-modal-body\"); }\n\t\t\tfunction processHTMX(root) {\n\t\t\t\tif (window.htmx && root) window.htmx.process(root);\n\t\t\t}\n\t\t\tfunction openModal() {\n\t\t\t\tvar dialog = modal();\n\t\t\t\tif (!dialog) return;\n\t\t\t\tif (!dialog.open) dialog.showModal();\n\t\t\t\tvar name = document.getElementById(\"api-key-name\");\n\t\t\t\tif (name) name.focus();\n\t\t\t}\n\t\t\tfunction closeModal() {\n\t\t\t\tvar dialog = modal();\n\t\t\t\tif (dialog && dialog.open) dialog.close();\n\t\t\t}\n\t\t\tfunction restoreCreateForm() {\n\t\t\t\tvar template = document.getElementById(\"api-key-create-template\");\n\t\t\t\tvar target = body();\n\t\t\t\tif (!template || !target) return;\n\t\t\t\ttarget.innerHTML = template.innerHTML;\n\t\t\t\tprocessHTMX(target);\n\t\t\t}\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar openCreate = event.target.closest(\"[data-api-key-open-create]\");\n\t\t\t\tif (openCreate) {\n\t\t\t\t\trestoreCreateForm();\n\t\t\t\t\topenModal();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-api-modal-close]\")) {\n\t\t\t\t\tcloseModal();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-api-key-done]\")) {\n\t\t\t\t\tcloseModal();\n\t\t\t\t\tif (window.htmx) window.htmx.trigger(document.body, \"apiKeyChanged\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar bannerClose = event.target.closest(\"[data-api-key-dismiss-banner]\");\n\t\t\t\tif (bannerClose) {\n\t\t\t\t\tvar banner = bannerClose.closest(\"[data-api-key-banner]\");\n\t\t\t\t\tif (banner) banner.remove();\n\t\t\t\t\twindow.localStorage && window.localStorage.setItem(\"detent-api-key-banner-dismissed\", \"true\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar copy = event.target.closest(\"[data-api-copy]\");\n\t\t\t\tif (copy) {\n\t\t\t\t\tif (copy.dataset.copyBusy === \"true\") return;\n\t\t\t\t\tcopy.dataset.copyBusy = \"true\";\n\t\t\t\t\tvar value = copy.getAttribute(\"data-real-value\") || \"\";\n\t\t\t\t\tvar label = copy.querySelector(\"[data-copy-label]\");\n\t\t\t\t\tvar original = label ? label.textContent : \"\";\n\t\t\t\t\tvar done = function () {\n\t\t\t\t\t\tif (label) label.textContent = \"Copied ✓\";\n\t\t\t\t\t\twindow.setTimeout(function () {\n\t\t\t\t\t\t\tif (label) label.textContent = original || \"Copy\";\n\t\t\t\t\t\t\tdelete copy.dataset.copyBusy;\n\t\t\t\t\t\t}, 2000);\n\t\t\t\t\t};\n\t\t\t\t\tif (navigator.clipboard && navigator.clipboard.writeText) {\n\t\t\t\t\t\tnavigator.clipboard.writeText(value).then(done, done);\n\t\t\t\t\t} else {\n\t\t\t\t\t\tdone();\n\t\t\t\t\t}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar tokenToggle = event.target.closest(\"[data-api-toggle-secret]\");\n\t\t\t\tif (tokenToggle) {\n\t\t\t\t\tvar code = tokenToggle.parentElement && tokenToggle.parentElement.querySelector(\"[data-api-secret]\");\n\t\t\t\t\tif (!code) return;\n\t\t\t\t\tvar hidden = code.classList.toggle(\"blur-sm\");\n\t\t\t\t\tcode.classList.toggle(\"select-none\", hidden);\n\t\t\t\t\ttokenToggle.setAttribute(\"aria-label\", hidden ? \"Show token\" : \"Hide token\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar snippetToggle = event.target.closest(\"[data-api-toggle-snippet]\");\n\t\t\t\tif (snippetToggle) {\n\t\t\t\t\tvar panel = snippetToggle.closest(\"[data-api-snippet-panel]\");\n\t\t\t\t\tvar code = panel && panel.querySelector(\"[data-api-snippet-code]\");\n\t\t\t\t\tif (!code) return;\n\t\t\t\t\tvar real = code.getAttribute(\"data-real-value\") || \"\";\n\t\t\t\t\tvar masked = code.getAttribute(\"data-masked-value\") || \"\";\n\t\t\t\t\tvar showing = code.textContent === real;\n\t\t\t\t\tcode.textContent = showing ? masked : real;\n\t\t\t\t\tsnippetToggle.setAttribute(\"aria-label\", showing ? \"Show snippet\" : \"Hide snippet\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar tab = event.target.closest(\"[data-api-snippet-tab]\");\n\t\t\t\tif (tab) {\n\t\t\t\t\tvar name = tab.getAttribute(\"data-api-snippet-tab\");\n\t\t\t\t\tdocument.querySelectorAll(\"[data-api-snippet-tab]\").forEach(function (button) {\n\t\t\t\t\t\tvar active = button === tab;\n\t\t\t\t\t\tbutton.classList.toggle(\"border-accent\", active);\n\t\t\t\t\t\tbutton.classList.toggle(\"text-accent\", active);\n\t\t\t\t\t\tbutton.classList.toggle(\"border-transparent\", !active);\n\t\t\t\t\t\tbutton.classList.toggle(\"text-sec\", !active);\n\t\t\t\t\t});\n\t\t\t\t\tdocument.querySelectorAll(\"[data-api-snippet-panel]\").forEach(function (panel) {\n\t\t\t\t\t\tpanel.classList.toggle(\"hidden\", panel.getAttribute(\"data-api-snippet-panel\") !== name);\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar allProjects = event.target.closest(\"[data-api-key-all-projects]\");\n\t\t\t\tif (allProjects) {\n\t\t\t\t\tvar picker = document.querySelector(\"[data-api-key-project-picker]\");\n\t\t\t\t\tif (picker) picker.classList.toggle(\"hidden\", allProjects.checked);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar expiry = event.target.closest(\"[data-api-key-expiry]\");\n\t\t\t\tif (expiry) {\n\t\t\t\t\tvar note = document.querySelector(\"[data-api-key-never-note]\");\n\t\t\t\t\tif (note) note.classList.toggle(\"hidden\", expiry.value !== \"never\");\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSwap\", function (event) {\n\t\t\t\tif (event.detail && event.detail.target && event.detail.target.id === \"api-key-modal-body\") {\n\t\t\t\t\topenModal();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeRequest\", function (event) {\n\t\t\t\tvar button = event.detail && event.detail.elt;\n\t\t\t\tif (!(button instanceof Element) || !button.matches(\"[data-api-key-revoke]\")) return;\n\t\t\t\tvar name = button.getAttribute(\"data-api-key-name\") || \"\";\n\t\t\t\tvar message = \"Revoke \" + name + \"? Any client using it will immediately break.\";\n\t\t\t\tif (!window.confirm(message)) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (button.getAttribute(\"data-api-key-admin\") === \"true\") {\n\t\t\t\t\tvar typed = window.prompt(\"Type the key name to revoke this admin key.\");\n\t\t\t\t\tif (typed !== name) event.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tif (window.localStorage && window.localStorage.getItem(\"detent-api-key-banner-dismissed\") === \"true\") {\n\t\t\t\tvar banner = document.querySelector(\"[data-api-key-banner]\");\n\t\t\t\tif (banner) banner.remove();\n\t\t\t}\n\t\t})();\n\t</script>")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 104, "<script>\n\t\t(function () {\n\t\t\tfunction modal() { return document.getElementById(\"api-key-modal\"); }\n\t\t\tfunction body() { return document.getElementById(\"api-key-modal-body\"); }\n\t\t\tfunction processHTMX(root) {\n\t\t\t\tif (window.htmx && root) window.htmx.process(root);\n\t\t\t}\n\t\t\tfunction openModal() {\n\t\t\t\tvar dialog = modal();\n\t\t\t\tif (!dialog) return;\n\t\t\t\tif (!dialog.open) dialog.showModal();\n\t\t\t\tvar name = document.getElementById(\"api-key-name\");\n\t\t\t\tif (name) name.focus();\n\t\t\t}\n\t\t\tfunction closeModal() {\n\t\t\t\tvar dialog = modal();\n\t\t\t\tif (dialog && dialog.open) dialog.close();\n\t\t\t}\n\t\t\tfunction restoreCreateForm() {\n\t\t\t\tvar template = document.getElementById(\"api-key-create-template\");\n\t\t\t\tvar target = body();\n\t\t\t\tif (!template || !target) return;\n\t\t\t\ttarget.innerHTML = template.innerHTML;\n\t\t\t\tprocessHTMX(target);\n\t\t\t}\n\t\t\tdocument.addEventListener(\"click\", function (event) {\n\t\t\t\tvar openCreate = event.target.closest(\"[data-api-key-open-create]\");\n\t\t\t\tif (openCreate) {\n\t\t\t\t\trestoreCreateForm();\n\t\t\t\t\topenModal();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-api-modal-close]\")) {\n\t\t\t\t\tcloseModal();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (event.target.closest(\"[data-api-key-done]\")) {\n\t\t\t\t\tcloseModal();\n\t\t\t\t\tif (window.htmx) window.htmx.trigger(document.body, \"apiKeyChanged\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar bannerClose = event.target.closest(\"[data-api-key-dismiss-banner]\");\n\t\t\t\tif (bannerClose) {\n\t\t\t\t\tvar banner = bannerClose.closest(\"[data-api-key-banner]\");\n\t\t\t\t\tif (banner) banner.remove();\n\t\t\t\t\twindow.localStorage && window.localStorage.setItem(\"detent-api-key-banner-dismissed\", \"true\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar copy = event.target.closest(\"[data-api-copy]\");\n\t\t\t\tif (copy) {\n\t\t\t\t\tif (copy.dataset.copyBusy === \"true\") return;\n\t\t\t\t\tcopy.dataset.copyBusy = \"true\";\n\t\t\t\t\tvar value = copy.getAttribute(\"data-real-value\") || \"\";\n\t\t\t\t\tvar label = copy.querySelector(\"[data-copy-label]\");\n\t\t\t\t\tvar original = label ? label.textContent : \"\";\n\t\t\t\t\tvar done = function () {\n\t\t\t\t\t\tif (label) label.textContent = \"Copied ✓\";\n\t\t\t\t\t\twindow.setTimeout(function () {\n\t\t\t\t\t\t\tif (label) label.textContent = original || \"Copy\";\n\t\t\t\t\t\t\tdelete copy.dataset.copyBusy;\n\t\t\t\t\t\t}, 2000);\n\t\t\t\t\t};\n\t\t\t\t\tif (navigator.clipboard && navigator.clipboard.writeText) {\n\t\t\t\t\t\tnavigator.clipboard.writeText(value).then(done, done);\n\t\t\t\t\t} else {\n\t\t\t\t\t\tdone();\n\t\t\t\t\t}\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar tokenToggle = event.target.closest(\"[data-api-toggle-secret]\");\n\t\t\t\tif (tokenToggle) {\n\t\t\t\t\tvar code = tokenToggle.parentElement && tokenToggle.parentElement.querySelector(\"[data-api-secret]\");\n\t\t\t\t\tif (!code) return;\n\t\t\t\t\tvar hidden = code.classList.toggle(\"blur-sm\");\n\t\t\t\t\tcode.classList.toggle(\"select-none\", hidden);\n\t\t\t\t\ttokenToggle.setAttribute(\"aria-label\", hidden ? \"Show token\" : \"Hide token\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar snippetToggle = event.target.closest(\"[data-api-toggle-snippet]\");\n\t\t\t\tif (snippetToggle) {\n\t\t\t\t\tvar panel = snippetToggle.closest(\"[data-api-snippet-panel]\");\n\t\t\t\t\tvar code = panel && panel.querySelector(\"[data-api-snippet-code]\");\n\t\t\t\t\tif (!code) return;\n\t\t\t\t\tvar real = code.getAttribute(\"data-real-value\") || \"\";\n\t\t\t\t\tvar masked = code.getAttribute(\"data-masked-value\") || \"\";\n\t\t\t\t\tvar showing = code.textContent === real;\n\t\t\t\t\tcode.textContent = showing ? masked : real;\n\t\t\t\t\tsnippetToggle.setAttribute(\"aria-label\", showing ? \"Show snippet\" : \"Hide snippet\");\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar tab = event.target.closest(\"[data-api-snippet-tab]\");\n\t\t\t\tif (tab) {\n\t\t\t\t\tvar name = tab.getAttribute(\"data-api-snippet-tab\");\n\t\t\t\t\tdocument.querySelectorAll(\"[data-api-snippet-tab]\").forEach(function (button) {\n\t\t\t\t\t\tvar active = button === tab;\n\t\t\t\t\t\tbutton.classList.toggle(\"border-accent\", active);\n\t\t\t\t\t\tbutton.classList.toggle(\"text-accent\", active);\n\t\t\t\t\t\tbutton.classList.toggle(\"border-transparent\", !active);\n\t\t\t\t\t\tbutton.classList.toggle(\"text-sec\", !active);\n\t\t\t\t\t});\n\t\t\t\t\tdocument.querySelectorAll(\"[data-api-snippet-panel]\").forEach(function (panel) {\n\t\t\t\t\t\tpanel.classList.toggle(\"hidden\", panel.getAttribute(\"data-api-snippet-panel\") !== name);\n\t\t\t\t\t});\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"change\", function (event) {\n\t\t\t\tvar allProjects = event.target.closest(\"[data-api-key-all-projects]\");\n\t\t\t\tif (allProjects) {\n\t\t\t\t\tvar picker = document.querySelector(\"[data-api-key-project-picker]\");\n\t\t\t\t\tif (picker) picker.classList.toggle(\"hidden\", allProjects.checked);\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tvar expiry = event.target.closest(\"[data-api-key-expiry]\");\n\t\t\t\tif (expiry) {\n\t\t\t\t\tvar note = document.querySelector(\"[data-api-key-never-note]\");\n\t\t\t\t\tif (note) note.classList.toggle(\"hidden\", expiry.value !== \"never\");\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:afterSwap\", function (event) {\n\t\t\t\tif (event.detail && event.detail.target && event.detail.target.id === \"api-key-modal-body\") {\n\t\t\t\t\topenModal();\n\t\t\t\t}\n\t\t\t});\n\t\t\tdocument.addEventListener(\"htmx:beforeRequest\", function (event) {\n\t\t\t\tvar button = event.detail && event.detail.elt;\n\t\t\t\tif (!(button instanceof Element) || !button.matches(\"[data-api-key-revoke]\")) return;\n\t\t\t\tvar name = button.getAttribute(\"data-api-key-name\") || \"\";\n\t\t\t\tvar message = \"Revoke \" + name + \"? Any client using it will immediately break.\";\n\t\t\t\tif (!window.confirm(message)) {\n\t\t\t\t\tevent.preventDefault();\n\t\t\t\t\treturn;\n\t\t\t\t}\n\t\t\t\tif (button.getAttribute(\"data-api-key-admin\") === \"true\") {\n\t\t\t\t\tvar typed = window.prompt(\"Type the key name to revoke this admin key.\");\n\t\t\t\t\tif (typed !== name) event.preventDefault();\n\t\t\t\t}\n\t\t\t});\n\t\t\tif (window.localStorage && window.localStorage.getItem(\"detent-api-key-banner-dismissed\") === \"true\") {\n\t\t\t\tvar banner = document.querySelector(\"[data-api-key-banner]\");\n\t\t\t\tif (banner) banner.remove();\n\t\t\t}\n\t\t})();\n\t</script>")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/tests/visual/dashboard-auth.spec.js
+++ b/tests/visual/dashboard-auth.spec.js
@@ -100,6 +100,39 @@ for (const mode of authModes) {
   });
 }
 
+test("api keys page creates first key on wildcard bind without token", async ({ page }) => {
+  const runtime = await startDetentRuntime("dashboard-api-keys-no-token", [
+    "--demo",
+    "kanban",
+    "--demo-project",
+    "demo-project",
+  ], {
+    host: "0.0.0.0",
+    env: { DETENT_API_TOKEN: "" },
+  });
+  const unexpectedAPIResponses = collectUnexpectedAPIResponses(page);
+
+  try {
+    const dashboardURL = nonLoopbackDashboardURL(runtime.url);
+
+    await page.goto(`${dashboardURL}/api-keys`, { waitUntil: "domcontentloaded" });
+    await expect(page.getByRole("button", { name: "Create your first key" })).toBeVisible();
+    await page.getByRole("button", { name: "Create your first key" }).click();
+
+    const dialog = page.getByRole("dialog").first();
+    await expect(dialog.getByRole("heading", { name: "Create API key" })).toBeVisible();
+    await dialog.getByLabel("Name").fill("Playwright first key");
+    await dialog.getByRole("button", { name: /^Create$/ }).click();
+    await expect(dialog.getByRole("heading", { name: "API key created" })).toBeVisible();
+    await dialog.getByRole("button", { name: "Done" }).click();
+    await expect(page.locator("#api-keys-table")).toContainText("Playwright first key");
+
+    expect(unexpectedAPIResponses).toEqual([]);
+  } finally {
+    await runtime.stop();
+  }
+});
+
 test("wildcard dashboard denies non-local API access without token", async () => {
   const runtime = await startDetentRuntime("dashboard-auth-negative", [
     "--demo",
@@ -143,6 +176,20 @@ test("wildcard dashboard denies non-local API access without token", async () =>
       },
     });
     expect(deniedSpoofedSource).toBe(403);
+
+    const deniedRawKeyCreate = await rawHTTPStatus(runtime.url, {
+      method: "POST",
+      path: "/api/v1/keys",
+      headers: {
+        Host: dashboardURLHost,
+        "Content-Type": "application/x-www-form-urlencoded",
+        "HX-Request": "true",
+        "HX-Current-URL": `${dashboardURL}/api-keys`,
+        "HX-Target": "api-key-modal-body",
+      },
+      body: "name=Spoofed&scopes=read&all_projects=true&expires_in=90d",
+    });
+    expect(deniedRawKeyCreate).toBe(403);
 
     const deniedState = await rawHTTPStatus(runtime.url, {
       path: "/api/v1/state",


### PR DESCRIPTION
## Summary

- Route API key management endpoints through the dashboard HTMX-aware auth policy.
- Add Go regression coverage for same-origin no-token API key list/create/rotate/revoke and denied raw/spoofed requests.
- Add a Playwright regression for creating the first API key from `/api-keys` without `/api/v1/keys` 4xx responses.

Fixes #983

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Browser verification: `DETENT_BINARY="$(pwd)/tmp/detent" node_modules/.bin/playwright test tests/visual/dashboard-auth.spec.js`

## Test Plan

- [x] `go test ./internal/web -run 'TestAPIKeyDashboardHTMXAuth|TestDashboardHTMXAuthAllowsSameOriginDashboardOnWildcardBindWithoutToken|TestAPITokenAllowsDashboardHTMXWithUICookie' -count=1`
- [x] `DETENT_BINARY="$(pwd)/tmp/detent" node_modules/.bin/playwright test tests/visual/dashboard-auth.spec.js`
- [x] `make check`