### PR TITLE
fix(workspace): remediate reaper cache permissions

### DIFF
--- a/internal/orchestrator/reaper.go
+++ b/internal/orchestrator/reaper.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -10,6 +11,11 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
+
+type workspaceCleanupDiagnostic interface {
+	WorkspacePath() string
+	Remediation() string
+}
 
 func (o *Orchestrator) reapWorkspacesIfDue(ctx context.Context, state *State, now time.Time) {
 	if o.reaper == nil {
@@ -254,13 +260,22 @@ func (o *Orchestrator) reapWorkspace(ctx context.Context, state *State, issue co
 	}
 	result, err := o.reaper.ReapWorkspace(ctx, issue)
 	if err != nil {
-		o.logger.Warn(
-			"workspace reap failed",
+		args := []any{
 			slog.String("issue_id", issue.ID),
 			slog.String("issue_identifier", issue.Identifier),
 			slog.String("reason", reason),
 			slog.Any("error", err),
-		)
+		}
+		var diagnostic workspaceCleanupDiagnostic
+		if errors.As(err, &diagnostic) {
+			if path := strings.TrimSpace(diagnostic.WorkspacePath()); path != "" {
+				args = append(args, slog.String("workspace_path", path))
+			}
+			if remediation := strings.TrimSpace(diagnostic.Remediation()); remediation != "" {
+				args = append(args, slog.String("remediation", remediation))
+			}
+		}
+		o.logger.Warn("workspace reap failed", args...)
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      cleanupEventAt(now),
 			Event:   "workspace_reap_failed",

--- a/internal/orchestrator/reconcile_test.go
+++ b/internal/orchestrator/reconcile_test.go
@@ -396,12 +396,19 @@ func TestTickWorkspaceCleanupFailureRecordsDiagnosticEvent(t *testing.T) {
 	})
 	state := newState(cfg)
 	tracker := &runningStateConnector{issuesByState: []connector.Issue{cancelled}}
-	reaper := &cleanupSweepReaper{err: errors.New("remove worktree: permission denied")}
+	workspacePath := "/tmp/detent-workspaces/digitaldrywood_detent_588"
+	remediation := "chmod workspace cache directories and rerun cleanup"
+	reaper := &cleanupSweepReaper{err: cleanupDiagnosticError{
+		message:     "remove worktree: permission denied",
+		path:        workspacePath,
+		remediation: remediation,
+	}}
+	var logs strings.Builder
 	orch := &Orchestrator{
 		cfg:       cfg,
 		connector: tracker,
 		reaper:    reaper,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		logger:    slog.New(slog.NewTextHandler(&logs, nil)),
 	}
 
 	orch.tick(context.Background(), &state, now)
@@ -416,6 +423,11 @@ func TestTickWorkspaceCleanupFailureRecordsDiagnosticEvent(t *testing.T) {
 	for _, want := range []string{"digitaldrywood/detent#588", "reason=cancelled", "permission denied"} {
 		if !strings.Contains(event.Message, want) {
 			t.Fatalf("cleanup failure event message = %q, want %q", event.Message, want)
+		}
+	}
+	for _, want := range []string{workspacePath, remediation} {
+		if !strings.Contains(logs.String(), want) {
+			t.Fatalf("cleanup failure logs = %q, want %q", logs.String(), want)
 		}
 	}
 }
@@ -759,6 +771,24 @@ type cleanupSweepReaper struct {
 func (r *cleanupSweepReaper) ReapWorkspace(_ context.Context, issue connector.Issue) (WorkspaceReapResult, error) {
 	r.issues = append(r.issues, cloneIssue(issue))
 	return r.result, r.err
+}
+
+type cleanupDiagnosticError struct {
+	message     string
+	path        string
+	remediation string
+}
+
+func (e cleanupDiagnosticError) Error() string {
+	return e.message
+}
+
+func (e cleanupDiagnosticError) WorkspacePath() string {
+	return e.path
+}
+
+func (e cleanupDiagnosticError) Remediation() string {
+	return e.remediation
 }
 
 func recentStateEvent(state State, event string) (telemetryEvent, bool) {

--- a/internal/workspace/filesystem.go
+++ b/internal/workspace/filesystem.go
@@ -116,7 +116,7 @@ func (f *Filesystem) Create(ctx context.Context, issue Issue) (Info, error) {
 	info.Created = created
 	if created {
 		if err := f.runHook(ctx, "after_create", f.hooks.AfterCreate, info, issue); err != nil {
-			if cleanupErr := root.RemoveAll(info.Key); cleanupErr != nil {
+			if cleanupErr := removeWorkspacePath(f.root, info.Path); cleanupErr != nil {
 				f.logger.Warn("failed to clean filesystem workspace after after_create hook error", slog.String("path", info.Path), slog.Any("error", cleanupErr))
 			}
 			return Info{}, err
@@ -135,11 +135,6 @@ func (f *Filesystem) CleanupIssue(ctx context.Context, issue Issue) (CleanupResu
 	if err != nil {
 		return CleanupResult{}, err
 	}
-	root, err := os.OpenRoot(f.root)
-	if err != nil {
-		return CleanupResult{}, fmt.Errorf("open filesystem workspace root: %w", err)
-	}
-	defer f.closeRoot("workspace", root)
 	result := CleanupResult{}
 	exists, _, err := pathExists(info.Path)
 	if err != nil {
@@ -152,7 +147,7 @@ func (f *Filesystem) CleanupIssue(ctx context.Context, issue Issue) (CleanupResu
 	if err := f.runHook(ctx, "before_remove", f.hooks.BeforeRemove, info, issue); err != nil {
 		f.logger.Warn("filesystem workspace before_remove hook failed", slog.String("path", info.Path), slog.Any("error", err))
 	}
-	if err := root.RemoveAll(info.Key); err != nil {
+	if err := removeWorkspacePath(f.root, info.Path); err != nil {
 		return CleanupResult{}, fmt.Errorf("remove filesystem workspace: %w", err)
 	}
 	result.Worktrees = 1

--- a/internal/workspace/filesystem_test.go
+++ b/internal/workspace/filesystem_test.go
@@ -62,6 +62,52 @@ func TestFilesystemWorkspaceCreatesArtifactWorkspaceAndOutputRoot(t *testing.T) 
 	}
 }
 
+func TestFilesystemCleanupRemediatesGeneratedCachePermissions(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	root := filepath.Join(t.TempDir(), "workspaces")
+	backend, err := NewFilesystem(FilesystemOptions{Root: root})
+	if err != nil {
+		t.Fatalf("NewFilesystem() error = %v", err)
+	}
+
+	issue := Issue{Identifier: "DD-CACHE-PERM"}
+	info, err := backend.Create(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	t.Cleanup(func() {
+		restoreWritableTree(t, info.Path)
+	})
+
+	cacheDir := filepath.Join(info.Path, "tmp", ".gomodcache-ignored", "modernc.org", "libc@v1.73.4")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	cacheFile := filepath.Join(cacheDir, "libc_amd64.go")
+	if err := os.WriteFile(cacheFile, []byte("package libc\n"), 0o600); err != nil {
+		t.Fatalf("write cache file: %v", err)
+	}
+	if err := os.Chmod(cacheFile, 0o444); err != nil {
+		t.Fatalf("chmod cache file: %v", err)
+	}
+	if err := os.Chmod(cacheDir, 0o555); err != nil {
+		t.Fatalf("chmod cache dir: %v", err)
+	}
+
+	result, err := backend.CleanupIssue(context.Background(), issue)
+	if err != nil {
+		t.Fatalf("CleanupIssue() error = %v", err)
+	}
+	if result.Worktrees != 1 {
+		t.Fatalf("CleanupIssue().Worktrees = %d, want 1", result.Worktrees)
+	}
+	if _, err := os.Stat(info.Path); !os.IsNotExist(err) {
+		t.Fatalf("workspace still exists or unexpected stat error: %v", err)
+	}
+}
+
 func TestFilesystemCreateRejectsArtifactSymlinkEscape(t *testing.T) {
 	t.Parallel()
 	skipWindows(t)

--- a/internal/workspace/workspace.go
+++ b/internal/workspace/workspace.go
@@ -14,6 +14,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"runtime"
 	"strconv"
 	"strings"
 	"time"
@@ -193,6 +194,28 @@ type CommandError struct {
 	ExitCode int
 	Output   string
 	Err      error
+}
+
+type workspaceRemovalError struct {
+	path        string
+	remediation string
+	err         error
+}
+
+func (e *workspaceRemovalError) Error() string {
+	return fmt.Sprintf("remove workspace path %q: %v; remediation: %s", e.path, e.err, e.remediation)
+}
+
+func (e *workspaceRemovalError) Unwrap() error {
+	return e.err
+}
+
+func (e *workspaceRemovalError) WorkspacePath() string {
+	return e.path
+}
+
+func (e *workspaceRemovalError) Remediation() string {
+	return e.remediation
 }
 
 func (e *CommandError) Error() string {
@@ -482,7 +505,7 @@ func (l *LocalGit) ensureWorktree(ctx context.Context, path string, branch strin
 			}
 		}
 		if exists {
-			if err := os.RemoveAll(path); err != nil {
+			if err := removeWorkspacePath(l.root, path); err != nil {
 				return false, fmt.Errorf("remove stale workspace path: %w", err)
 			}
 		}
@@ -695,16 +718,100 @@ func (l *LocalGit) removePath(ctx context.Context, path string) error {
 
 	if _, err := l.runGit(ctx, "worktree", "remove", "--force", path); err != nil {
 		if l.isSourceWorktree(ctx, path) {
-			return err
+			return l.retrySourceWorktreeRemoveAfterPermissionRemediation(ctx, path, err)
 		}
 		if l.isGitWorkspace(ctx, path) {
 			return fmt.Errorf("refusing to remove git workspace not managed by source: %s", path)
 		}
-		if err := os.RemoveAll(path); err != nil {
-			return fmt.Errorf("remove workspace path: %w", err)
+		if err := removeWorkspacePath(l.root, path); err != nil {
+			return err
 		}
 	}
 	return nil
+}
+
+const workspaceRemovalRemediation = "ensure the Detent user owns the workspace, chmod writable directories inside it, then remove it or rerun Detent cleanup"
+
+func (l *LocalGit) retrySourceWorktreeRemoveAfterPermissionRemediation(ctx context.Context, path string, removeErr error) error {
+	path, chmodErr := remediateWorkspacePathPermissions(l.root, path)
+	if chmodErr != nil {
+		return &workspaceRemovalError{
+			path:        path,
+			remediation: workspaceRemovalRemediation,
+			err:         errors.Join(removeErr, fmt.Errorf("remediate workspace permissions: %w", chmodErr)),
+		}
+	}
+	if _, retryErr := l.runGit(ctx, "worktree", "remove", "--force", path); retryErr != nil {
+		return &workspaceRemovalError{
+			path:        path,
+			remediation: workspaceRemovalRemediation,
+			err:         retryErr,
+		}
+	}
+	return nil
+}
+
+func removeWorkspacePath(root string, path string) error {
+	path, err := validateWorkspacePath(root, path)
+	if err != nil {
+		return err
+	}
+	if err := os.RemoveAll(path); err != nil {
+		if !errors.Is(err, fs.ErrPermission) {
+			return err
+		}
+		if chmodErr := makeWorkspaceTreeRemovable(path); chmodErr != nil {
+			return &workspaceRemovalError{
+				path:        path,
+				remediation: workspaceRemovalRemediation,
+				err:         errors.Join(err, fmt.Errorf("remediate workspace permissions: %w", chmodErr)),
+			}
+		}
+		if retryErr := os.RemoveAll(path); retryErr != nil {
+			return &workspaceRemovalError{
+				path:        path,
+				remediation: workspaceRemovalRemediation,
+				err:         retryErr,
+			}
+		}
+	}
+	return nil
+}
+
+func remediateWorkspacePathPermissions(root string, path string) (string, error) {
+	validated, err := validateWorkspacePath(root, path)
+	if err != nil {
+		return path, err
+	}
+	return validated, makeWorkspaceTreeRemovable(validated)
+}
+
+func makeWorkspaceTreeRemovable(path string) error {
+	return filepath.WalkDir(path, func(path string, entry fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		info, err := entry.Info()
+		if err != nil {
+			return fmt.Errorf("inspect %s: %w", path, err)
+		}
+		mode := info.Mode().Perm()
+		switch {
+		case entry.IsDir():
+			mode |= 0o700
+		case runtime.GOOS == "windows":
+			mode |= 0o600
+		default:
+			return nil
+		}
+		if err := os.Chmod(path, mode); err != nil {
+			return fmt.Errorf("chmod %s: %w", path, err)
+		}
+		return nil
+	})
 }
 
 func (l *LocalGit) runHook(ctx context.Context, name string, command string, info Info, issue Issue) error {

--- a/internal/workspace/workspace_test.go
+++ b/internal/workspace/workspace_test.go
@@ -1063,6 +1063,56 @@ func TestLocalGitCleanupRemovesOnlyTargetWorktree(t *testing.T) {
 	}
 }
 
+func TestLocalGitCleanupRemediatesGeneratedCachePermissions(t *testing.T) {
+	t.Parallel()
+	skipWindows(t)
+
+	source := initSourceRepo(t)
+	root := filepath.Join(t.TempDir(), "workspaces")
+
+	backend, err := NewBackend(KindLocalGit, LocalGitOptions{
+		Root:       root,
+		SourceRoot: source,
+		AutoBranch: true,
+	})
+	if err != nil {
+		t.Fatalf("NewBackend() error = %v", err)
+	}
+
+	info, err := backend.Create(context.Background(), Issue{Identifier: "DD-CACHE-PERM"})
+	if err != nil {
+		t.Fatalf("Create() error = %v", err)
+	}
+	t.Cleanup(func() {
+		restoreWritableTree(t, info.Path)
+	})
+
+	cacheDir := filepath.Join(info.Path, "tmp", "_validation-cache", "go-mod", "modernc.org", "libc@v1.73.4")
+	if err := os.MkdirAll(cacheDir, 0o755); err != nil {
+		t.Fatalf("mkdir cache dir: %v", err)
+	}
+	cacheFile := filepath.Join(cacheDir, "libc_amd64.go")
+	if err := os.WriteFile(cacheFile, []byte("package libc\n"), 0o600); err != nil {
+		t.Fatalf("write cache file: %v", err)
+	}
+	if err := os.Chmod(cacheFile, 0o444); err != nil {
+		t.Fatalf("chmod cache file: %v", err)
+	}
+	if err := os.Chmod(cacheDir, 0o555); err != nil {
+		t.Fatalf("chmod cache dir: %v", err)
+	}
+
+	if err := backend.Cleanup(context.Background(), "DD-CACHE-PERM"); err != nil {
+		t.Fatalf("Cleanup() error = %v", err)
+	}
+	if _, err := os.Stat(info.Path); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("workspace exists after cleanup, stat error = %v", err)
+	}
+	if branchExists(t, source, "detent/dd-cache-perm") {
+		t.Fatal("detent/dd-cache-perm branch still exists after cleanup")
+	}
+}
+
 func TestLocalGitCleanupRejectsForeignGitRepoWithoutBeforeRemove(t *testing.T) {
 	t.Parallel()
 
@@ -1237,6 +1287,29 @@ func readFile(t *testing.T, path string) string {
 		t.Fatalf("read %s: %v", path, err)
 	}
 	return string(raw)
+}
+
+func restoreWritableTree(t *testing.T, path string) {
+	t.Helper()
+
+	err := filepath.WalkDir(path, func(path string, entry os.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			if errors.Is(walkErr, os.ErrNotExist) {
+				return nil
+			}
+			return walkErr
+		}
+		if entry.Type()&os.ModeSymlink != 0 {
+			return nil
+		}
+		if entry.IsDir() {
+			return os.Chmod(path, 0o700)
+		}
+		return os.Chmod(path, 0o600)
+	})
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("restore writable tree: %v", err)
+	}
 }
 
 func mustCanonicalExistingPath(t *testing.T, path string) string {


### PR DESCRIPTION
## Summary

- Remediate read-only generated cache directories inside validated Detent workspaces before retrying cleanup removal.
- Share the cleanup helper across local-git and filesystem reapers and surface workspace path/remediation in failure logs.
- Add regressions for local-git/filesystem cleanup and reaper failure diagnostics.

Fixes #987

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual changes.

## Test Plan

- [x] `go test ./internal/workspace -run 'Test(LocalGitCleanupRemediatesGeneratedCachePermissions|FilesystemCleanupRemediatesGeneratedCachePermissions)' -count=1 -v`\n- [x] `go test ./internal/orchestrator -run TestTickWorkspaceCleanupFailureRecordsDiagnosticEvent -count=1 -v`\n- [x] `go test ./internal/workspace -count=1`\n- [x] `go test ./internal/orchestrator -count=1`\n- [x] `go test ./internal/runner -count=1`\n- [x] `make check`