### PR TITLE
fix(kanban): ignore raw GitHub lanes

### DIFF
--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -1838,9 +1838,23 @@ func kanbanStateNames(cfg workflowconfig.Config, snapshot telemetry.Snapshot) []
 	}
 	add(cfg.KanbanStateNames()...)
 	for _, issue := range snapshotKanbanIssues(snapshot) {
+		if kanbanRawGitHubIssueState(issue.State) {
+			if _, ok := seen[normalizeKanbanState(issue.State)]; !ok {
+				continue
+			}
+		}
 		add(issue.State)
 	}
 	return states
+}
+
+func kanbanRawGitHubIssueState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "open", "closed":
+		return true
+	default:
+		return false
+	}
 }
 
 func kanbanAllowedTransitions(cfg workflowconfig.Config, states []string) map[string][]string {

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -76,6 +76,64 @@ func TestKanbanStateNamesIgnoreCompletedSessionStates(t *testing.T) {
 	}
 }
 
+func TestKanbanStateNamesIgnoreRawGitHubRuntimeStates(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Config{
+		Tracker: workflowconfig.Tracker{
+			ObservedStates: []string{"Backlog", "Human Review"},
+			ActiveStates:   []string{"Todo", "In Progress", "Merging"},
+			TerminalStates: []string{"Done"},
+		},
+	}
+	snapshot := telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{
+			{ID: "custom", State: "Needs Triage"},
+		},
+		Pipeline: []telemetry.Issue{
+			{ID: "pipeline-open", State: "Open"},
+		},
+		Running: []telemetry.Running{
+			{Issue: telemetry.Issue{ID: "running-open", State: "OPEN"}},
+		},
+		Queue: []telemetry.Queued{
+			{Issue: telemetry.Issue{ID: "queue-closed", State: "Closed"}},
+		},
+		Blocked: []telemetry.Blocked{
+			{Issue: telemetry.Issue{ID: "blocked-closed", State: "CLOSED"}},
+		},
+	}
+
+	got := kanbanStateNames(cfg, snapshot)
+	want := []string{"Backlog", "Human Review", "Todo", "In Progress", "Merging", "Done", "Needs Triage"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("kanbanStateNames() = %#v, want %#v", got, want)
+	}
+}
+
+func TestKanbanStateNamesAllowConfiguredOpenState(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Config{
+		Tracker: workflowconfig.Tracker{
+			ObservedStates: []string{"Open"},
+			ActiveStates:   []string{"In Progress"},
+			TerminalStates: []string{"Done"},
+		},
+	}
+	snapshot := telemetry.Snapshot{
+		Running: []telemetry.Running{
+			{Issue: telemetry.Issue{ID: "running-open", State: "OPEN"}},
+		},
+	}
+
+	got := kanbanStateNames(cfg, snapshot)
+	want := []string{"Open", "In Progress", "Done"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("kanbanStateNames() = %#v, want %#v", got, want)
+	}
+}
+
 func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2077,7 +2077,7 @@ func projectOverviewDiagnosticsDotClass(snapshot telemetry.Snapshot) string {
 }
 
 func projectKanbanCardsByState(data DashboardData) map[string][]projectKanbanCard {
-	issues := projectKanbanIssues(data.Snapshot)
+	issues := projectKanbanIssues(data.Snapshot, data.Kanban.States)
 	mergeStatuses := mergeLaneStatuses(data.Snapshot)
 	configured := projectKanbanConfiguredStateMap(data.Kanban.States)
 	cardsByState := map[string][]projectKanbanCard{}
@@ -2109,10 +2109,11 @@ func projectKanbanCardsByState(data DashboardData) map[string][]projectKanbanCar
 	return cardsByState
 }
 
-func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
+func projectKanbanIssues(snapshot telemetry.Snapshot, configuredStates []string) []projectKanbanIssueCard {
 	byIssue := map[string]projectKanbanIssueCard{}
+	configured := projectKanbanConfiguredStateMap(configuredStates)
 	nextIndex := 0
-	appendIssue := func(issue telemetry.Issue, state string, stageAt time.Time, rank int) {
+	appendIssue := func(issue telemetry.Issue, state string, stageAt time.Time, rank int, rawRuntimeState bool) {
 		state = strings.TrimSpace(state)
 		if state == "" {
 			return
@@ -2122,6 +2123,9 @@ func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 			key = "anonymous:" + strconv.Itoa(nextIndex)
 		}
 		current, ok := byIssue[key]
+		if ok && rawRuntimeState {
+			return
+		}
 		if ok && rank < current.rank {
 			return
 		}
@@ -2134,18 +2138,22 @@ func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 		}
 		nextIndex++
 	}
+	appendSnapshotIssue := func(issue telemetry.Issue, fallback string, stageAt time.Time, rank int) {
+		state, rawRuntimeState := projectKanbanSnapshotState(issue, fallback, configured)
+		appendIssue(issue, state, stageAt, rank, rawRuntimeState)
+	}
 
 	for _, issue := range snapshot.BoardIssues {
-		appendIssue(issue, issueState(issue, ""), projectKanbanIssueStageTime(issue, time.Time{}), 5)
+		appendSnapshotIssue(issue, "", projectKanbanIssueStageTime(issue, time.Time{}), 5)
 	}
 	for _, issue := range snapshot.Pipeline {
-		appendIssue(issue, issueState(issue, ""), pipelineIssueStageTime(issue), 10)
+		appendSnapshotIssue(issue, "", pipelineIssueStageTime(issue), 10)
 	}
 	for _, row := range snapshot.Queue {
-		appendIssue(row.Issue, issueState(row.Issue, "Todo"), projectKanbanIssueStageTime(row.Issue, time.Time{}), 20)
+		appendSnapshotIssue(row.Issue, "Todo", projectKanbanIssueStageTime(row.Issue, time.Time{}), 20)
 	}
 	for _, row := range snapshot.Running {
-		appendIssue(row.Issue, issueState(row.Issue, "In Progress"), projectKanbanIssueStageTime(row.Issue, row.StartedAt), 30)
+		appendSnapshotIssue(row.Issue, "In Progress", projectKanbanIssueStageTime(row.Issue, row.StartedAt), 30)
 	}
 	for _, row := range snapshot.Blocked {
 		stageAt := projectKanbanIssueStageTime(row.Issue, time.Time{})
@@ -2160,7 +2168,7 @@ func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 		issue.Metadata[projectKanbanBlockedSourceMetadataKey] = string(row.Source)
 		issue.Metadata[projectKanbanBlockedReasonMetadataKey] = row.Error
 		issue.Metadata[projectKanbanBlockedRecoveryReasonMetadataKey] = row.RecoveryReason
-		appendIssue(issue, issueState(issue, "Blocked"), stageAt, 40)
+		appendSnapshotIssue(issue, "Blocked", stageAt, 40)
 	}
 
 	issues := make([]projectKanbanIssueCard, 0, len(byIssue))
@@ -2171,6 +2179,21 @@ func projectKanbanIssues(snapshot telemetry.Snapshot) []projectKanbanIssueCard {
 		return issues[i].index < issues[j].index
 	})
 	return issues
+}
+
+func projectKanbanSnapshotState(issue telemetry.Issue, fallback string, configured map[string]string) (string, bool) {
+	state := strings.TrimSpace(issueState(issue, fallback))
+	if !projectKanbanRawGitHubIssueState(state) {
+		return state, false
+	}
+	if _, ok := configured[projectKanbanStateKey(state)]; ok {
+		return state, false
+	}
+	fallback = strings.TrimSpace(fallback)
+	if fallback != "" {
+		return fallback, true
+	}
+	return "", true
 }
 
 func projectKanbanIssueStageTime(issue telemetry.Issue, fallback time.Time) time.Time {
@@ -2390,6 +2413,9 @@ func projectKanbanStateOrder(configuredStates []string, cardsByState map[string]
 		if _, ok := seen[key]; ok {
 			continue
 		}
+		if projectKanbanRawGitHubIssueState(cards[0].Stage) {
+			continue
+		}
 		extras = append(extras, cards[0].Stage)
 	}
 	sort.SliceStable(extras, func(i, j int) bool {
@@ -2503,6 +2529,15 @@ func projectKanbanDisplayState(state string, configured map[string]string) strin
 		return "Cancelled"
 	default:
 		return display
+	}
+}
+
+func projectKanbanRawGitHubIssueState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "open", "closed":
+		return true
+	default:
+		return false
 	}
 }
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -2186,12 +2186,18 @@ func projectKanbanSnapshotState(issue telemetry.Issue, fallback string, configur
 	if !projectKanbanRawGitHubIssueState(state) {
 		return state, false
 	}
-	if _, ok := configured[projectKanbanStateKey(state)]; ok {
-		return state, false
+	key := projectKanbanStateKey(state)
+	if configuredDisplay, ok := configured[key]; ok {
+		return configuredDisplay, false
 	}
 	fallback = strings.TrimSpace(fallback)
 	if fallback != "" {
 		return fallback, true
+	}
+	for _, alias := range projectKanbanStateAliases(key) {
+		if configuredDisplay, ok := configured[alias]; ok {
+			return configuredDisplay, false
+		}
 	}
 	return "", true
 }

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1476,6 +1476,81 @@ func TestProjectKanbanBoardGroupsSnapshotRowsByConfiguredStates(t *testing.T) {
 	}
 }
 
+func TestProjectKanbanBoardPrefersConfiguredStateOverRawGitHubRuntimeState(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 13, 23, 54, 0, time.UTC)
+	reviewAt := now.Add(-9 * time.Minute)
+	board := projectKanbanBoardView(DashboardData{
+		Kanban: KanbanData{
+			States: []string{"Backlog", "Todo", "In Progress", "Human Review", "Merging", "Done"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			BoardIssues: []telemetry.Issue{
+				{
+					ID:             "issue-987",
+					Identifier:     "digitaldrywood/detent#987",
+					ProjectID:      "detent",
+					Title:          "Recover workspace reaping when cached files return permission denied",
+					State:          "Human Review",
+					Labels:         []string{"detent:human-review"},
+					StageUpdatedAt: &reviewAt,
+				},
+			},
+			Pipeline: []telemetry.Issue{
+				{
+					ID:         "issue-987",
+					Identifier: "digitaldrywood/detent#987",
+					ProjectID:  "detent",
+					Title:      "Recover workspace reaping when cached files return permission denied",
+					State:      "Open",
+				},
+			},
+			Running: []telemetry.Running{
+				{
+					Issue: telemetry.Issue{
+						ID:         "issue-987",
+						Identifier: "digitaldrywood/detent#987",
+						ProjectID:  "detent",
+						Title:      "Recover workspace reaping when cached files return permission denied",
+						State:      "OPEN",
+					},
+					StartedAt: now.Add(-2 * time.Minute),
+				},
+			},
+			Queue: []telemetry.Queued{
+				{
+					Issue: telemetry.Issue{
+						ID:         "issue-987",
+						Identifier: "digitaldrywood/detent#987",
+						ProjectID:  "detent",
+						Title:      "Recover workspace reaping when cached files return permission denied",
+						State:      "OPEN",
+					},
+					Attempt: 1,
+				},
+			},
+		},
+	})
+
+	if got := collectKanbanLaneTitles(board.AllLanes); containsString(got, "Open") {
+		t.Fatalf("all lanes = %#v, want no raw Open lane", got)
+	}
+	got := collectKanbanCards(board.AllLanes)
+	want := []kanbanCardSnapshot{
+		{Lane: "Human Review", IssueNumber: "#987", Title: "Recover workspace reaping when cached files return permission denied", TimeInStage: "9m 0s", WaitDetail: "waiting for linked PR", Labels: "detent:human-review", Metadata: "No linked PR"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("kanban cards len = %d, want %d; got %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("kanban card %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestProjectKanbanBoardShowsMergeLaneStatus(t *testing.T) {
 	t.Parallel()
 
@@ -1983,7 +2058,7 @@ func TestCompletedOpenPRSessionDoesNotCreateWorkflowCards(t *testing.T) {
 		},
 	}
 
-	if got := projectKanbanIssues(snapshot); len(got) != 0 {
+	if got := projectKanbanIssues(snapshot, nil); len(got) != 0 {
 		t.Fatalf("projectKanbanIssues() len = %d, want 0; got %#v", len(got), got)
 	}
 	if got := collectPipelineCards(prPipelineLanes(snapshot)); len(got) != 0 {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1551,6 +1551,47 @@ func TestProjectKanbanBoardPrefersConfiguredStateOverRawGitHubRuntimeState(t *te
 	}
 }
 
+func TestProjectKanbanBoardMapsRawClosedBoardIssueToConfiguredDoneLane(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 14, 5, 0, 0, time.UTC)
+	closedAt := now.Add(-3 * time.Minute)
+	board := projectKanbanBoardView(DashboardData{
+		Kanban: KanbanData{
+			States: []string{"Todo", "In Progress", "Done"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			BoardIssues: []telemetry.Issue{
+				{
+					ID:             "issue-991",
+					Identifier:     "digitaldrywood/detent#991",
+					ProjectID:      "detent",
+					Title:          "Closed board issue",
+					State:          "CLOSED",
+					StageUpdatedAt: &closedAt,
+				},
+			},
+		},
+	})
+
+	if got := collectKanbanLaneTitles(board.AllLanes); containsString(got, "Closed") {
+		t.Fatalf("all lanes = %#v, want no raw Closed lane", got)
+	}
+	got := collectKanbanCards(board.AllLanes)
+	want := []kanbanCardSnapshot{
+		{Lane: "Done", IssueNumber: "#991", Title: "Closed board issue", TimeInStage: "3m 0s", Metadata: "No linked PR"},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("kanban cards len = %d, want %d; got %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("kanban card %d = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}
+
 func TestProjectKanbanBoardShowsMergeLaneStatus(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Prevent unconfigured raw GitHub issue lifecycle states from expanding Kanban workflow lanes.
- Keep label-backed board state authoritative when runtime rows carry raw `OPEN` or `CLOSED`; runtime-only queue, running, and blocked rows still fall back to operational lanes.

Fixes #989

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.
  No visual layout changes; covered by Kanban data regression tests.

## Test Plan

- [x] `go test ./internal/web -run 'TestKanbanStateNames(IgnoreRawGitHubRuntimeStates|AllowConfiguredOpenState)' -count=1`
- [x] `go test ./internal/web/templates -run TestProjectKanbanBoardPrefersConfiguredStateOverRawGitHubRuntimeState -count=1`
- [x] `go test ./internal/web ./internal/web/templates -count=1`
- [x] `make check`