### PR TITLE
fix(orchestrator): skip zero-second review stop

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1490,10 +1490,14 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 	}
 
 	o.logAutoPromoteDecision(issue, decision, targetState)
+	sourceState := displayStateName(issue.State)
+	if sourceState == "" {
+		sourceState = autoPromoteSourceState
+	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      now,
 		Event:   "auto_promote_transition",
-		Message: "auto-promoted " + issueLabel(issue) + " from " + autoPromoteSourceState + " to " + targetState,
+		Message: "auto-promoted " + issueLabel(issue) + " from " + sourceState + " to " + targetState,
 	})
 	return true
 }

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -3503,6 +3503,7 @@ type autoPromoteTickConnector struct {
 	prComments            []autoPromoteTickComment
 	setFields             []autoPromoteTickSetField
 	reruns                []autoPromoteTickRerun
+	updateErr             error
 }
 
 type autoPromoteTickMergeConnector struct {
@@ -3844,6 +3845,9 @@ func waitForGlobalDispatchSlot(t *testing.T, globalGate scheduler.ProjectDispatc
 
 func (c *autoPromoteTickConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
 	c.updates = append(c.updates, autoPromoteTickUpdate{issueID: issueID, state: state})
+	if c.updateErr != nil {
+		return c.updateErr
+	}
 	for index := range c.stateIssues {
 		if c.stateIssues[index].ID == issueID {
 			c.stateIssues[index].State = state

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -42,8 +42,8 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			continue
 		}
 
+		result.transitioned[issueID] = struct{}{}
 		if direct, promoted := o.tryDirectCompletedActiveAutoPromote(ctx, state, issue, targetState, cfg, now); direct {
-			result.transitioned[issueID] = struct{}{}
 			if mergeWorkerIssue(promoted) {
 				o.recordMergeQueueEntered(state, promoted, now, "completed_active_auto_promote")
 				result.dispatchCandidates = append(result.dispatchCandidates, promoted)
@@ -67,7 +67,6 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			continue
 		}
 
-		result.transitioned[issueID] = struct{}{}
 		o.finishCompletedActiveReviewTransition(ctx, state, issue, completed, targetState)
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      now,

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -14,12 +14,13 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 	state *State,
 	issues []connector.Issue,
 	now time.Time,
-) map[string]struct{} {
+) autoPromoteTickResult {
 	if len(state.Completed) == 0 || len(issues) == 0 {
-		return nil
+		return autoPromoteTickResult{}
 	}
 
-	handled := map[string]struct{}{}
+	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	result := autoPromoteTickResult{transitioned: map[string]struct{}{}}
 	for _, issue := range issues {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
@@ -34,14 +35,24 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			completed.FinalState,
 			o.cfg.ActiveStates,
 			o.cfg.TerminalStates,
-			normalizeAutoPromoteConfig(o.cfg.AutoPromote).SourceState,
-			gateRequiresPullRequest(o.cfg.AutoPromote.Gate),
+			cfg.SourceState,
+			gateRequiresPullRequest(cfg.Gate),
 		)
 		if targetState == "" {
 			continue
 		}
 
-		handled[issueID] = struct{}{}
+		if direct, promoted := o.tryDirectCompletedActiveAutoPromote(ctx, state, issue, targetState, cfg, now); direct {
+			result.transitioned[issueID] = struct{}{}
+			if mergeWorkerIssue(promoted) {
+				o.recordMergeQueueEntered(state, promoted, now, "completed_active_auto_promote")
+				result.dispatchCandidates = append(result.dispatchCandidates, promoted)
+				o.logMergeWorkerPickup(promoted, "completed_active_auto_promote")
+			}
+			o.finishCompletedActiveReviewTransition(ctx, state, issue, completed, promoted.State)
+			continue
+		}
+
 		if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "completed_active_review_transition"); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(
@@ -56,27 +67,72 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			continue
 		}
 
-		if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
-			o.logger.Warn("abandon completed review claim failed", "issue_id", issueID, "error", err)
-		}
-		updated := mergeIssueTrackerFields(completed.Issue, issue)
-		updated.State = targetState
-		completed.Issue = updated
-		state.Completed[issueID] = completed
-		delete(state.Claimed, issueID)
-		delete(state.Retry, issueID)
-		delete(state.BudgetRefusals, issueID)
-		delete(state.PriorAttempts, issueID)
+		result.transitioned[issueID] = struct{}{}
+		o.finishCompletedActiveReviewTransition(ctx, state, issue, completed, targetState)
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      now,
 			Event:   "completed_issue_review_transition",
 			Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState + " after successful completion",
 		})
 	}
-	if len(handled) == 0 {
-		return nil
+	if len(result.transitioned) == 0 {
+		return autoPromoteTickResult{}
 	}
-	return handled
+	return result
+}
+
+func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	reviewState string,
+	cfg AutoPromoteConfig,
+	now time.Time,
+) (bool, connector.Issue) {
+	if !cfg.Enabled || cfg.QuietDuration != 0 || normalizeState(reviewState) != normalizeState(cfg.SourceState) {
+		return false, connector.Issue{}
+	}
+
+	summary := AutoPromoteSummaryFromIssue(issue)
+	decision := EvaluateAutoPromote(issue, summary, cfg, now)
+	if decision.Action == AutoPromoteActionPromote {
+		issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, cfg, now)
+	}
+	if decision.Action != AutoPromoteActionPromote {
+		o.logAutoPromoteDecision(issue, decision, "")
+		return false, connector.Issue{}
+	}
+	targetState := autoPromoteTargetState(decision.Action, cfg)
+	if targetState == "" {
+		o.logAutoPromoteDecision(issue, decision, "")
+		return false, connector.Issue{}
+	}
+	if !o.applyAutoPromoteDecision(ctx, state, issue, summary, decision, targetState, now) {
+		return false, connector.Issue{}
+	}
+	promoted := promotedIssue(issue, targetState, now)
+	return true, promoted
+}
+
+func (o *Orchestrator) finishCompletedActiveReviewTransition(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	completed Completed,
+	targetState string,
+) {
+	issueID := strings.TrimSpace(issue.ID)
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("abandon completed review claim failed", "issue_id", issueID, "error", err)
+	}
+	updated := mergeIssueTrackerFields(completed.Issue, issue)
+	updated.State = targetState
+	completed.Issue = updated
+	state.Completed[issueID] = completed
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
 }
 
 func completedActiveReviewTargetState(

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"reflect"
 	"strings"
 	"testing"
@@ -195,6 +196,46 @@ func TestTransitionCompletedActiveIssuesKeepsHumanReviewForNonZeroQuietReview(t 
 	}
 	if got := state.Completed[issue.ID].Issue.State; got != "Human Review" {
 		t.Fatalf("Completed issue state = %q, want Human Review", got)
+	}
+}
+
+func TestTransitionCompletedActiveIssuesHandlesFailedReviewUpdate(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 14, 0, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	trackerErr := errors.New("tracker unavailable")
+	tracker := &autoPromoteTickConnector{
+		stateIssues: []connector.Issue{issue},
+		updateErr:   trackerErr,
+	}
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:      issue,
+		FinalState: FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing after failed update", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Human Review"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want attempted update %#v", got, want)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "In Progress" {
+		t.Fatalf("Completed issue state = %q, want original In Progress after failed update", got)
+	}
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatchCandidates = %#v, want none after failed update", result.dispatchCandidates)
+	}
+	if len(state.RecentEvents) != 0 {
+		t.Fatalf("RecentEvents = %#v, want no transition event after failed update", state.RecentEvents)
 	}
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -1,7 +1,11 @@
 package orchestrator
 
 import (
+	"context"
+	"reflect"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 )
@@ -81,6 +85,116 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 				t.Fatalf("completedActiveReviewTargetState() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestTransitionCompletedActiveIssuesDirectlyPromotesZeroQuietReview(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 14, 0, 0, 0, time.UTC)
+	reviewedAt := now.Add(-time.Minute)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.PullRequest = &connector.PullRequest{
+		Number:                 17,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/17",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &reviewedAt,
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 0,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:      issue,
+		FinalState: FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(result.dispatchCandidates) != 1 || result.dispatchCandidates[0].State != "Merging" {
+		t.Fatalf("dispatchCandidates = %#v, want one Merging issue", result.dispatchCandidates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one auto-promote audit comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Auto-promoted this issue from In Progress to Merging.",
+		"reason: ready",
+		"https://github.test/digitaldrywood/detent/pull/17",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing %q", tracker.comments[0].body, fragment)
+		}
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Merging" {
+		t.Fatalf("Completed issue state = %q, want Merging", got)
+	}
+	if len(state.RecentEvents) == 0 || !strings.Contains(state.RecentEvents[len(state.RecentEvents)-1].Message, "from In Progress to Merging") {
+		t.Fatalf("RecentEvents = %#v, want direct auto-promote audit event", state.RecentEvents)
+	}
+}
+
+func TestTransitionCompletedActiveIssuesKeepsHumanReviewForNonZeroQuietReview(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 14, 0, 0, 0, time.UTC)
+	reviewedAt := now.Add(-20 * time.Minute)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.PullRequest = &connector.PullRequest{
+		Number:                 18,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/18",
+		State:                  "OPEN",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &reviewedAt,
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:      issue,
+		FinalState: FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Human Review"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatchCandidates = %#v, want none", result.dispatchCandidates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want no auto-promote comment for Human Review transition", tracker.comments)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Human Review" {
+		t.Fatalf("Completed issue state = %q, want Human Review", got)
 	}
 }
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -146,10 +146,15 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched,
 		o.reconcileStaleTodoPullRequestIssues(ctx, state, fetched.candidates, now),
 	)
+	completedTransitions := o.transitionCompletedActiveIssuesToReview(ctx, state, fetched.candidates, now)
 	fetched = filterReconciledTickIssues(
 		state,
 		fetched,
-		o.transitionCompletedActiveIssuesToReview(ctx, state, fetched.candidates, now),
+		completedTransitions.transitioned,
+	)
+	fetched.candidates = mergeIssueSlices(
+		fetched.candidates,
+		completedTransitions.dispatchCandidates,
 	)
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
 	if refreshSucceeded(state) {


### PR DESCRIPTION
## Summary

- Route completed active issues directly to `Merging` when enabled auto-promotion has a zero-second quiet duration and the gate is ready.
- Reuse the existing auto-promote audit comment/log/event for direct promotions and hand those issues to merge dispatch candidates.
- Preserve non-zero quiet duration behavior so completed work still enters `Human Review`, including failed transition attempts that must remain handled for the current tick.

Fixes #991

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestTransitionCompletedActiveIssues(DirectlyPromotesZeroQuietReview|KeepsHumanReviewForNonZeroQuietReview)|TestTickAutoPromoteHumanReviewIssues' -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `go test ./internal/orchestrator -run 'TestTransitionCompletedActiveIssues(DirectlyPromotesZeroQuietReview|KeepsHumanReviewForNonZeroQuietReview|HandlesFailedReviewUpdate)|TestTickAutoPromoteHumanReviewIssues' -count=1`
- [x] `make check`