### PR TITLE
feat(runtime): add output truncation policy

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -188,24 +188,25 @@ type Worker struct {
 }
 
 type Agent struct {
-	MaxConcurrentAgents          int            `yaml:"max_concurrent_agents"`
-	MaxTurns                     int            `yaml:"max_turns"`
-	MaxRetryBackoffMS            int            `yaml:"max_retry_backoff_ms"`
-	MaxSessionTokens             int64          `yaml:"max_session_tokens"`
-	MaxSessionContextMultiplier  float64        `yaml:"max_session_context_multiplier"`
-	MaxSessionTokenOverrideLabel string         `yaml:"max_session_token_override_label"`
-	MaxSessionTokenOverrideField string         `yaml:"max_session_token_override_field"`
-	ExperimentalThreadResume     bool           `yaml:"experimental_thread_resume"`
-	Shutdown                     Shutdown       `yaml:"shutdown"`
-	MaxConcurrentAgentsByState   map[string]int `yaml:"max_concurrent_agents_by_state"`
-	DispatchPriorityByState      []string       `yaml:"dispatch_priority_by_state"`
-	DispatchPriorityByLabel      []string       `yaml:"dispatch_priority_by_label"`
-	MergeFastPath                MergeFastPath  `yaml:"merge_fast_path"`
-	AutoPromote                  AutoPromote    `yaml:"auto_promote"`
-	Budget                       Budget         `yaml:"budget"`
-	Lessons                      Lessons        `yaml:"lessons"`
-	Knowledge                    Knowledge      `yaml:"knowledge"`
-	Skills                       Skills         `yaml:"skills"`
+	MaxConcurrentAgents          int              `yaml:"max_concurrent_agents"`
+	MaxTurns                     int              `yaml:"max_turns"`
+	MaxRetryBackoffMS            int              `yaml:"max_retry_backoff_ms"`
+	MaxSessionTokens             int64            `yaml:"max_session_tokens"`
+	MaxSessionContextMultiplier  float64          `yaml:"max_session_context_multiplier"`
+	MaxSessionTokenOverrideLabel string           `yaml:"max_session_token_override_label"`
+	MaxSessionTokenOverrideField string           `yaml:"max_session_token_override_field"`
+	ExperimentalThreadResume     bool             `yaml:"experimental_thread_resume"`
+	Shutdown                     Shutdown         `yaml:"shutdown"`
+	MaxConcurrentAgentsByState   map[string]int   `yaml:"max_concurrent_agents_by_state"`
+	DispatchPriorityByState      []string         `yaml:"dispatch_priority_by_state"`
+	DispatchPriorityByLabel      []string         `yaml:"dispatch_priority_by_label"`
+	MergeFastPath                MergeFastPath    `yaml:"merge_fast_path"`
+	AutoPromote                  AutoPromote      `yaml:"auto_promote"`
+	OutputTruncation             OutputTruncation `yaml:"output_truncation"`
+	Budget                       Budget           `yaml:"budget"`
+	Lessons                      Lessons          `yaml:"lessons"`
+	Knowledge                    Knowledge        `yaml:"knowledge"`
+	Skills                       Skills           `yaml:"skills"`
 }
 
 type Shutdown struct {
@@ -279,6 +280,10 @@ type AutoPromote struct {
 	PassState          string   `yaml:"pass_state,omitempty"`
 	ReworkState        string   `yaml:"rework_state,omitempty"`
 	ReworkLimit        int      `yaml:"rework_limit,omitempty"`
+}
+
+type OutputTruncation struct {
+	MaxBytes int `yaml:"max_bytes"`
 }
 
 type Lessons struct {
@@ -1237,6 +1242,7 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	validateStateList(prefix+".dispatch_priority_by_state", a.DispatchPriorityByState, problems)
 	validateLabelList(prefix+".dispatch_priority_by_label", a.DispatchPriorityByLabel, problems)
 	a.AutoPromote.validate(prefix+".auto_promote", problems)
+	a.OutputTruncation.validate(prefix+".output_truncation", problems)
 	a.Budget.validate(prefix+".budget", problems)
 	a.Lessons.validate(prefix+".lessons", problems)
 	a.Knowledge.validate(prefix+".knowledge", problems)
@@ -1449,6 +1455,12 @@ func (a *AutoPromote) validate(prefix string, problems *[]string) {
 	}
 	if a.ReworkLimit < 0 {
 		*problems = append(*problems, prefix+".rework_limit must be greater than or equal to 0")
+	}
+}
+
+func (o OutputTruncation) validate(prefix string, problems *[]string) {
+	if o.MaxBytes < 0 {
+		*problems = append(*problems, prefix+".max_bytes must be greater than or equal to 0")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -642,6 +642,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if cfg.Agent.AutoPromote.ReworkLimit != 0 {
 		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want unlimited default", cfg.Agent.AutoPromote.ReworkLimit)
 	}
+	if cfg.Agent.OutputTruncation.MaxBytes != 0 {
+		t.Fatalf("Agent.OutputTruncation.MaxBytes = %d, want disabled default", cfg.Agent.OutputTruncation.MaxBytes)
+	}
 	if !cfg.Codex.ApprovalPolicy.IsMap {
 		t.Fatalf("Codex.ApprovalPolicy = %#v, want map default", cfg.Codex.ApprovalPolicy)
 	}
@@ -765,6 +768,24 @@ Body
 	}
 	if !workflow.Config.Agent.MergeFastPath.Enabled {
 		t.Fatal("Agent.MergeFastPath.Enabled = false, want true")
+	}
+}
+
+func TestParseWorkflowAgentOutputTruncation(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+agent:
+  output_truncation:
+    max_bytes: 4096
+---
+Body
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if got := workflow.Config.Agent.OutputTruncation.MaxBytes; got != 4096 {
+		t.Fatalf("Agent.OutputTruncation.MaxBytes = %d, want 4096", got)
 	}
 }
 
@@ -1727,6 +1748,8 @@ agent:
   max_concurrent_agents: 0
   max_session_tokens: -1
   max_session_context_multiplier: -0.5
+  output_truncation:
+    max_bytes: -1
   max_concurrent_agents_by_state:
     Todo: 0
   dispatch_priority_by_state: ["Todo", "Todo"]
@@ -1763,6 +1786,7 @@ Prompt
 				"agent.max_concurrent_agents must be greater than 0",
 				"agent.max_session_tokens must be greater than or equal to 0",
 				"agent.max_session_context_multiplier must be greater than or equal to 0",
+				"agent.output_truncation.max_bytes must be greater than or equal to 0",
 				"agent.max_concurrent_agents_by_state limits must be positive integers",
 				"agent.dispatch_priority_by_state state names must be unique",
 				"agent.dispatch_priority_by_label labels must not be blank",

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
 
@@ -575,7 +576,7 @@ func (p dispatchPlanner) scheduleRetryAfter(
 		Issue:      issue,
 		Attempt:    attempt,
 		DueAt:      now.Add(delay),
-		Error:      err,
+		Error:      p.operatorText(err),
 		WorkerHost: workerHost,
 	}
 	if _, ok := state.Claimed[issue.ID]; !ok {
@@ -584,6 +585,10 @@ func (p dispatchPlanner) scheduleRetryAfter(
 			ClaimedAt: now,
 		}
 	}
+}
+
+func (p dispatchPlanner) operatorText(value string) string {
+	return runtimeoutput.Truncate(strings.TrimSpace(value), p.cfg.OutputTruncationMaxBytes).Value
 }
 
 func (p dispatchPlanner) retryDelay(attempt int, continuation bool) time.Duration {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -35,6 +35,7 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.AllowedIssueLabels = []string{" Docs ", "docs", "Chore"}
 	cfg.Agent.AutoPromote.ReworkLimit = 2
 	cfg.Agent.MergeFastPath.Enabled = true
+	cfg.Agent.OutputTruncation.MaxBytes = 4096
 	cfg.Identity.Name = "release-captain"
 	cfg.Identity.GitHubLogin = "detent-bot"
 	cfg.Tracker.Authorization = selector.Selector{
@@ -82,6 +83,9 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	}
 	if !got.MergeFastPathEnabled {
 		t.Fatal("MergeFastPathEnabled = false, want true")
+	}
+	if got.OutputTruncationMaxBytes != 4096 {
+		t.Fatalf("OutputTruncationMaxBytes = %d, want 4096", got.OutputTruncationMaxBytes)
 	}
 	if got.SelectorContext.InstanceLogin != "detent-bot" {
 		t.Fatalf("SelectorContext.InstanceLogin = %q, want detent-bot", got.SelectorContext.InstanceLogin)

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -16,6 +16,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -84,6 +85,7 @@ type Config struct {
 	GitHubGraphQLWarnRemaining    int64
 	GitHubGraphQLMinReserve       int64
 	GitHubRESTMinReserve          int64
+	OutputTruncationMaxBytes      int
 }
 
 type ClaimingConfig struct {
@@ -242,6 +244,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		GitHubGraphQLWarnRemaining:    int64(cfg.Tracker.GitHubGraphQLWarnRemaining),
 		GitHubGraphQLMinReserve:       int64(cfg.Tracker.GitHubGraphQLMinReserve),
 		GitHubRESTMinReserve:          int64(cfg.Tracker.GitHubRESTMinReserve),
+		OutputTruncationMaxBytes:      cfg.Agent.OutputTruncation.MaxBytes,
 	}
 }
 
@@ -1932,6 +1935,7 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 	}
 	if event.usage.LastMessage != "" {
 		running.LastMessage = event.usage.LastMessage
+		running.LastMessageTruncation = runtimeoutput.CloneTruncation(event.usage.LastMessageTruncation)
 	}
 	if len(event.usage.RecentEvents) > 0 {
 		running.RecentEvents = cloneActivityEvents(event.usage.RecentEvents)
@@ -1961,7 +1965,7 @@ func (o *Orchestrator) handleRunUpdate(state *State, event runUpdate) {
 				o.logger.Warn("work attempt usage heartbeat failed", "attempt_id", running.WorkAttemptID, "issue_id", event.issueID, "error", err)
 			}
 		} else {
-			o.applyWorkAttemptHeartbeatSnapshot(state, running.WorkAttemptID, heartbeat)
+			o.applyWorkAttemptHeartbeatSnapshot(state, running.WorkAttemptID, heartbeat, event.usage.LastMessageTruncation)
 		}
 	}
 }
@@ -2152,9 +2156,9 @@ func (o *Orchestrator) tripInstantFailureCircuitBreaker(
 	if state.InstantFailures == nil {
 		state.InstantFailures = map[string]InstantFailure{}
 	}
-	key := instantFailureErrorKey(event.Err)
+	key := o.operatorText(instantFailureErrorKey(event.Err))
 	if key == "" {
-		key = event.Err.Error()
+		key = o.operatorText(event.Err.Error())
 	}
 	failure := state.InstantFailures[event.IssueID]
 	if failure.Error != key {
@@ -2225,7 +2229,7 @@ func (o *Orchestrator) parkInstantFailure(
 		}
 	}
 	if o.connector != nil {
-		if err := o.connector.CreateComment(ctx, issue.ID, instantFailureComment(issue, event.Err, failure, attempt, targetState)); err != nil && o.logger != nil {
+		if err := o.connector.CreateComment(ctx, issue.ID, instantFailureComment(issue, event.Err, failure, attempt, targetState, o.cfg.OutputTruncationMaxBytes)); err != nil && o.logger != nil {
 			o.logger.Error("instant fail circuit breaker comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
 		}
 	}
@@ -2262,14 +2266,14 @@ func (o *Orchestrator) parkInstantFailure(
 			"target_state", targetState,
 			"error", event.Err,
 		}
-		if body := instantFailureErrorKey(event.Err); body != "" {
+		if body := o.operatorText(instantFailureErrorKey(event.Err)); body != "" {
 			attrs = append(attrs, "backend_error_body", body)
 		}
 		var carrier interface {
 			BackendErrorMessage() string
 		}
 		if errors.As(event.Err, &carrier) {
-			if message := strings.TrimSpace(carrier.BackendErrorMessage()); message != "" {
+			if message := o.operatorText(carrier.BackendErrorMessage()); message != "" {
 				attrs = append(attrs, "backend_error_message", message)
 			}
 		}
@@ -2281,7 +2285,7 @@ func (o *Orchestrator) instantFailureParkState() string {
 	return blockedStatusState
 }
 
-func instantFailureComment(issue connector.Issue, err error, failure InstantFailure, attempt int, targetState string) string {
+func instantFailureComment(issue connector.Issue, err error, failure InstantFailure, attempt int, targetState string, maxBytes int) string {
 	var b strings.Builder
 	b.WriteString("Detent stopped retrying this worker after ")
 	b.WriteString(strconv.Itoa(failure.Count))
@@ -2298,15 +2302,20 @@ func instantFailureComment(issue connector.Issue, err error, failure InstantFail
 	b.WriteString("\n- failure_window_seconds: ")
 	b.WriteString(strconv.FormatInt(int64(instantFailureMaxDuration/time.Second), 10))
 	b.WriteString("\n- error:\n\n```text\n")
-	b.WriteString(strings.TrimSpace(err.Error()))
+	errorText := runtimeoutput.Truncate(strings.TrimSpace(err.Error()), maxBytes).Value
+	b.WriteString(errorText)
 	b.WriteString("\n```")
-	if body := instantFailureErrorKey(err); body != "" && body != strings.TrimSpace(err.Error()) {
+	if body := runtimeoutput.Truncate(instantFailureErrorKey(err), maxBytes).Value; body != "" && body != errorText {
 		b.WriteString("\n\n- backend_error_body:\n\n```json\n")
 		b.WriteString(body)
 		b.WriteString("\n```")
 	}
 	b.WriteString("\n\nFix the pinned agent model or backend configuration, then move the issue back to Todo or Rework.")
 	return b.String()
+}
+
+func (o *Orchestrator) operatorText(value string) string {
+	return runtimeoutput.Truncate(strings.TrimSpace(value), o.cfg.OutputTruncationMaxBytes).Value
 }
 
 func (o *Orchestrator) cleanupDrainedRun(ctx context.Context, state *State, issueID string) {
@@ -2966,6 +2975,9 @@ func normalizeConfig(cfg Config) Config {
 	cfg.SelectorPersona = strings.TrimSpace(cfg.SelectorPersona)
 	if cfg.MaxConcurrentAgentsPerHost < 0 {
 		cfg.MaxConcurrentAgentsPerHost = 0
+	}
+	if cfg.OutputTruncationMaxBytes < 0 {
+		cfg.OutputTruncationMaxBytes = 0
 	}
 
 	return cfg

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -2156,15 +2156,21 @@ func (o *Orchestrator) tripInstantFailureCircuitBreaker(
 	if state.InstantFailures == nil {
 		state.InstantFailures = map[string]InstantFailure{}
 	}
-	key := o.operatorText(instantFailureErrorKey(event.Err))
-	if key == "" {
-		key = o.operatorText(event.Err.Error())
+	key := instantFailureErrorKey(event.Err)
+	displayError := o.operatorText(key)
+	if displayError == "" {
+		displayError = o.operatorText(event.Err.Error())
 	}
 	failure := state.InstantFailures[event.IssueID]
-	if failure.Error != key {
+	failureKey := failure.errorKey
+	if failureKey == "" {
+		failureKey = failure.Error
+	}
+	if failureKey != key {
 		failure = InstantFailure{
 			Issue:          cloneIssue(running.Issue),
-			Error:          key,
+			Error:          displayError,
+			errorKey:       key,
 			FirstFailureAt: event.CompletedAt,
 		}
 	}

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -1186,6 +1187,59 @@ func TestRunParksIssueAfterRepeatedInstantBackendFailures(t *testing.T) {
 	}
 	if !strings.Contains(comments[0].body, backendBody) || !strings.Contains(comments[0].body, "stopped retrying") {
 		t.Fatalf("comment body missing backend error:\n%s", comments[0].body)
+	}
+}
+
+func TestRunParksIssueAfterRepeatedInstantBackendFailuresTruncatesConfiguredOutput(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-instant-fail-truncated", "digitaldrywood/detent#978", "Todo")
+	tracker := newFakeConnector(issue)
+	backendBody := "0123456789abcdefghijklmnopqrstuvwxyz"
+	runner := &staticRunner{err: instantBackendError{body: backendBody}}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:             time.Millisecond,
+		MaxConcurrentAgents:      1,
+		MaxRetryBackoff:          time.Millisecond,
+		FailureRetryBaseDelay:    time.Millisecond,
+		ActiveStates:             []string{"Todo", "In Progress"},
+		ObservedStates:           []string{"Blocked"},
+		TerminalStates:           []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay:   time.Second,
+		OutputTruncationMaxBytes: len(runtimeoutput.Marker) + 10,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Blocked[issue.ID]
+		return ok
+	})
+
+	wantBody := "01234" + runtimeoutput.Marker + "vwxyz"
+	reason := state.Blocked[issue.ID].Reason
+	if !strings.Contains(reason, wantBody) {
+		t.Fatalf("Blocked[%q].Reason = %q, want truncated backend body %q", issue.ID, reason, wantBody)
+	}
+	if strings.Contains(reason, backendBody) {
+		t.Fatalf("Blocked[%q].Reason included unbounded backend body: %q", issue.ID, reason)
+	}
+	comments := tracker.commentCalls()
+	if len(comments) != 1 {
+		t.Fatalf("comments = %#v, want one circuit breaker comment", comments)
+	}
+	if !strings.Contains(comments[0].body, wantBody) {
+		t.Fatalf("comment body missing truncated backend error:\n%s", comments[0].body)
+	}
+	if strings.Contains(comments[0].body, backendBody) {
+		t.Fatalf("comment body included unbounded backend error:\n%s", comments[0].body)
 	}
 }
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1243,6 +1243,59 @@ func TestRunParksIssueAfterRepeatedInstantBackendFailuresTruncatesConfiguredOutp
 	}
 }
 
+func TestRunInstantFailureCircuitBreakerComparesFullBackendErrorKey(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-instant-fail-key", "digitaldrywood/detent#979", "Todo")
+	tracker := newFakeConnector(issue)
+	backendBodies := []string{
+		"01234" + strings.Repeat("a", 20) + "vwxyz",
+		"01234" + strings.Repeat("b", 20) + "vwxyz",
+	}
+	runner := &staticRunner{}
+	runner.onRun = func(orchestrator.RunRequest) {
+		call := runner.calls.Load()
+		runner.err = instantBackendError{body: backendBodies[int(call-1)%len(backendBodies)]}
+	}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:             time.Millisecond,
+		MaxConcurrentAgents:      1,
+		MaxRetryBackoff:          time.Millisecond,
+		FailureRetryBaseDelay:    time.Millisecond,
+		ActiveStates:             []string{"Todo", "In Progress"},
+		ObservedStates:           []string{"Blocked"},
+		TerminalStates:           []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay:   time.Second,
+		OutputTruncationMaxBytes: len(runtimeoutput.Marker) + 10,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		if _, ok := state.Blocked[issue.ID]; ok {
+			return true
+		}
+		return runner.calls.Load() >= 8
+	})
+
+	if _, ok := state.Blocked[issue.ID]; ok {
+		t.Fatalf("Blocked[%q] present after alternating backend errors with matching truncated text", issue.ID)
+	}
+	if got := runner.calls.Load(); got < 8 {
+		t.Fatalf("runner calls = %d, want at least 8", got)
+	}
+	if comments := tracker.commentCalls(); len(comments) != 0 {
+		t.Fatalf("comments = %#v, want none", comments)
+	}
+}
+
 func TestRunParksInstantBackendFailuresInBlockedWithDefaultStates(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -177,23 +178,24 @@ func runningSnapshots(running map[string]Running, claims map[string]Claimed, mer
 		applyMergeTimingSnapshot(&issue, entry.Issue, timing, now)
 		applyClaimSnapshot(&issue, claims[id], now)
 		out = append(out, telemetry.Running{
-			Issue:           issue,
-			WorkerHost:      entry.WorkerHost,
-			ProcessIdentity: entry.ProcessIdentity,
-			WorkspacePath:   entry.WorkspacePath,
-			SessionID:       entry.SessionID,
-			StartedAt:       entry.StartedAt,
-			LastEventAt:     lastEventAt,
-			LastEvent:       entry.LastEvent,
-			LastMessage:     entry.LastMessage,
-			RecentEvents:    cloneActivityEvents(entry.RecentEvents),
-			TurnCount:       entry.TurnCount,
-			RuntimeSeconds:  entry.Tokens.RuntimeSeconds,
-			DiffAdded:       entry.DiffStats.AddedLines,
-			DiffRemoved:     entry.DiffStats.RemovedLines,
-			DiffFiles:       entry.DiffStats.FilesChanged,
-			DiffStatus:      entry.DiffStats.Status,
-			Tokens:          tokensFromTokenTotals(entry.Tokens),
+			Issue:                 issue,
+			WorkerHost:            entry.WorkerHost,
+			ProcessIdentity:       entry.ProcessIdentity,
+			WorkspacePath:         entry.WorkspacePath,
+			SessionID:             entry.SessionID,
+			StartedAt:             entry.StartedAt,
+			LastEventAt:           lastEventAt,
+			LastEvent:             entry.LastEvent,
+			LastMessage:           entry.LastMessage,
+			LastMessageTruncation: runtimeoutput.CloneTruncation(entry.LastMessageTruncation),
+			RecentEvents:          cloneActivityEvents(entry.RecentEvents),
+			TurnCount:             entry.TurnCount,
+			RuntimeSeconds:        entry.Tokens.RuntimeSeconds,
+			DiffAdded:             entry.DiffStats.AddedLines,
+			DiffRemoved:           entry.DiffStats.RemovedLines,
+			DiffFiles:             entry.DiffStats.FilesChanged,
+			DiffStatus:            entry.DiffStats.Status,
+			Tokens:                tokensFromTokenTotals(entry.Tokens),
 		})
 	}
 	return out

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -8,6 +8,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -56,24 +57,25 @@ type State struct {
 }
 
 type Running struct {
-	Issue           connector.Issue
-	Attempt         int
-	WorkAttemptID   int64
-	Mode            string
-	StartedAt       time.Time
-	WorkerHost      string
-	ProcessIdentity string
-	WorkspacePath   string
-	SessionID       string
-	TurnCount       int
-	LastEventAt     time.Time
-	LastEvent       string
-	LastMessage     string
-	RecentEvents    []telemetry.ActivityEvent
-	DiffStats       DiffStats
-	Tokens          TokenTotals
-	globalSlot      scheduler.Slot
-	cancel          context.CancelFunc
+	Issue                 connector.Issue
+	Attempt               int
+	WorkAttemptID         int64
+	Mode                  string
+	StartedAt             time.Time
+	WorkerHost            string
+	ProcessIdentity       string
+	WorkspacePath         string
+	SessionID             string
+	TurnCount             int
+	LastEventAt           time.Time
+	LastEvent             string
+	LastMessage           string
+	LastMessageTruncation *runtimeoutput.Truncation
+	RecentEvents          []telemetry.ActivityEvent
+	DiffStats             DiffStats
+	Tokens                TokenTotals
+	globalSlot            scheduler.Slot
+	cancel                context.CancelFunc
 }
 
 type Claimed struct {
@@ -221,6 +223,7 @@ func (s State) clone() State {
 
 	for id, running := range s.Running {
 		running.Issue = cloneIssue(running.Issue)
+		running.LastMessageTruncation = runtimeoutput.CloneTruncation(running.LastMessageTruncation)
 		running.RecentEvents = cloneActivityEvents(running.RecentEvents)
 		running.globalSlot = scheduler.Slot{}
 		running.cancel = nil
@@ -435,6 +438,9 @@ func cloneActivityEvents(events []telemetry.ActivityEvent) []telemetry.ActivityE
 	}
 	out := make([]telemetry.ActivityEvent, len(events))
 	copy(out, events)
+	for index := range out {
+		out[index].Truncation = runtimeoutput.CloneTruncation(out[index].Truncation)
+	}
 	return out
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -138,6 +138,7 @@ type Retry struct {
 type InstantFailure struct {
 	Issue          connector.Issue
 	Error          string
+	errorKey       string
 	Count          int
 	FirstFailureAt time.Time
 	LastFailureAt  time.Time

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -143,7 +144,7 @@ func (o *Orchestrator) heartbeatRunningWorkAttempts(ctx context.Context, state *
 			}
 			continue
 		}
-		o.applyWorkAttemptHeartbeatSnapshot(state, running.WorkAttemptID, heartbeat)
+		o.applyWorkAttemptHeartbeatSnapshot(state, running.WorkAttemptID, heartbeat, running.LastMessageTruncation)
 	}
 }
 
@@ -179,9 +180,9 @@ func (o *Orchestrator) completeDurableWorkAttempt(
 		Status:                 store.WorkAttemptStatusTerminal,
 		TerminalState:          terminalState,
 		ErrorClass:             strings.TrimSpace(errorClass),
-		ErrorMessage:           strings.TrimSpace(errorMessage),
+		ErrorMessage:           o.operatorText(errorMessage),
 		Phase:                  phase,
-		StatusMessage:          statusMessage,
+		StatusMessage:          o.operatorText(statusMessage),
 		GitHubRateSnapshotJSON: o.githubRateSnapshotJSON(state),
 		CIState:                workAttemptCIState(running.Issue),
 		CapacitySnapshotJSON:   o.capacitySnapshotJSON(state, running.Issue),
@@ -211,7 +212,7 @@ func (o *Orchestrator) runningWorkAttemptHeartbeat(state *State, running Running
 		HeartbeatAt:            now,
 		LeaseExpiresAt:         o.workAttemptLeaseExpiresAt(now),
 		Phase:                  phase,
-		StatusMessage:          message,
+		StatusMessage:          o.operatorText(message),
 		WaitReason:             runningWorkAttemptWaitReason(running, state),
 		GitHubRateSnapshotJSON: o.githubRateSnapshotJSON(state),
 		CIState:                workAttemptCIState(running.Issue),
@@ -312,7 +313,12 @@ func upsertWorkAttemptSnapshot(state *State, item telemetry.WorkAttempt) {
 	}
 }
 
-func (o *Orchestrator) applyWorkAttemptHeartbeatSnapshot(state *State, attemptID int64, heartbeat store.WorkAttemptHeartbeat) {
+func (o *Orchestrator) applyWorkAttemptHeartbeatSnapshot(
+	state *State,
+	attemptID int64,
+	heartbeat store.WorkAttemptHeartbeat,
+	truncation *runtimeoutput.Truncation,
+) {
 	if state == nil || attemptID <= 0 {
 		return
 	}
@@ -325,6 +331,7 @@ func (o *Orchestrator) applyWorkAttemptHeartbeatSnapshot(state *State, attemptID
 		item.LeaseExpiresAt = timePointer(heartbeat.LeaseExpiresAt)
 		item.Phase = heartbeat.Phase
 		item.StatusMessage = heartbeat.StatusMessage
+		item.StatusMessageTruncation = runtimeoutput.CloneTruncation(truncation)
 		item.CurrentCommand = heartbeat.CurrentCommand
 		item.WaitReason = heartbeat.WaitReason
 		item.GitHubRateSnapshotJSON = heartbeat.GitHubRateSnapshotJSON

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -20,6 +20,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/lessons"
 	"github.com/digitaldrywood/detent/internal/notes"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/skills"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -411,7 +412,7 @@ func (r *Runner) runAgentTurn(
 	runStartedAt time.Time,
 ) agentTurnExecution {
 	result := RunResult{FinalState: FinalStateCompleted}
-	progress := newAgentRunProgress()
+	progress := newAgentRunProgress(runtimeoutput.Policy{MaxBytes: agentConfig.OutputTruncation.MaxBytes})
 	turnStarted := false
 	turnResult, turnErr := backend.RunTurn(ctx, turnRequest, func(update AgentUpdate) error {
 		if update.Type == AgentUpdateTurnStarted || strings.TrimSpace(update.TurnID) != "" {
@@ -851,7 +852,7 @@ func (r *Runner) Validate(ctx context.Context, req ValidatorRequest) (gate.Valid
 		OnUsageUpdate:   req.OnUsageUpdate,
 	}
 	runResult := RunResult{FinalState: FinalStateCompleted}
-	progress := newAgentRunProgress()
+	progress := newAgentRunProgress(runtimeoutput.Policy{MaxBytes: workflow.Config.Agent.OutputTruncation.MaxBytes})
 	var output strings.Builder
 	turnResult, turnErr := backend.RunTurn(ctx, AgentTurnRequest{
 		Workspace:          info.Path,
@@ -1479,24 +1480,29 @@ func applyAgentUpdate(result *RunResult, update AgentUpdate) {
 }
 
 type agentRunProgress struct {
-	sessionID          string
-	processIdentity    string
-	turnIDs            map[string]struct{}
-	messages           map[string]string
-	messageOrder       []string
-	lastEventAt        time.Time
-	lastEvent          string
-	lastMessage        string
-	recentEvents       []telemetry.ActivityEvent
-	diffStats          DiffStats
-	diffStatsCollected bool
-	diffStatsCheckedAt time.Time
+	sessionID             string
+	processIdentity       string
+	turnIDs               map[string]struct{}
+	messages              map[string]*runtimeoutput.Buffer
+	messageOrder          []string
+	outputPolicy          runtimeoutput.Policy
+	output                *runtimeoutput.Buffer
+	lastEventAt           time.Time
+	lastEvent             string
+	lastMessage           string
+	lastMessageTruncation *runtimeoutput.Truncation
+	recentEvents          []telemetry.ActivityEvent
+	diffStats             DiffStats
+	diffStatsCollected    bool
+	diffStatsCheckedAt    time.Time
 }
 
-func newAgentRunProgress() *agentRunProgress {
+func newAgentRunProgress(outputPolicy runtimeoutput.Policy) *agentRunProgress {
 	return &agentRunProgress{
-		turnIDs:  map[string]struct{}{},
-		messages: map[string]string{},
+		turnIDs:      map[string]struct{}{},
+		messages:     map[string]*runtimeoutput.Buffer{},
+		outputPolicy: outputPolicy,
+		output:       runtimeoutput.NewBuffer(outputPolicy),
 	}
 }
 
@@ -1516,22 +1522,34 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 	p.lastEventAt = eventAt.UTC()
 
 	eventMessage := ""
+	eventTruncation := (*runtimeoutput.Truncation)(nil)
 	switch update.Type {
 	case AgentUpdateMessageDelta:
 		key := update.ItemID
 		if key == "" {
 			key = update.TurnID
 		}
-		if _, ok := p.messages[key]; !ok {
+		message, ok := p.messages[key]
+		if !ok {
 			p.messageOrder = append(p.messageOrder, key)
+			message = runtimeoutput.NewBuffer(p.outputPolicy)
+			p.messages[key] = message
 		}
-		p.messages[key] += update.Delta
-		p.lastMessage = strings.TrimSpace(p.messages[key])
+		message.Append(update.Delta)
+		if p.output != nil {
+			p.output.Append(update.Delta)
+		}
+		text := message.Text()
+		p.lastMessage = strings.TrimSpace(text.Value)
+		p.lastMessageTruncation = runtimeoutput.CloneTruncation(text.Truncation)
 		eventMessage = p.lastMessage
+		eventTruncation = runtimeoutput.CloneTruncation(text.Truncation)
 	case AgentUpdateTurnStarted:
+		p.lastMessageTruncation = nil
 		p.lastMessage = "turn started"
 		eventMessage = p.lastMessage
 	case AgentUpdateTurnCompleted:
+		p.lastMessageTruncation = nil
 		status := update.Status
 		if status == "" {
 			status = "completed"
@@ -1551,9 +1569,10 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 	}
 
 	p.addRecentEvent(telemetry.ActivityEvent{
-		At:      p.lastEventAt,
-		Event:   p.lastEvent,
-		Message: eventMessage,
+		At:         p.lastEventAt,
+		Event:      p.lastEvent,
+		Message:    eventMessage,
+		Truncation: eventTruncation,
 	})
 }
 
@@ -1601,13 +1620,21 @@ func (p *agentRunProgress) recentActivity() []telemetry.ActivityEvent {
 	}
 	out := make([]telemetry.ActivityEvent, len(p.recentEvents))
 	copy(out, p.recentEvents)
+	for index := range out {
+		out[index].Truncation = runtimeoutput.CloneTruncation(out[index].Truncation)
+	}
 	return out
 }
 
 func (p *agentRunProgress) outputText() string {
+	if p.output != nil {
+		return p.output.String()
+	}
 	var out strings.Builder
 	for _, key := range p.messageOrder {
-		out.WriteString(p.messages[key])
+		if message := p.messages[key]; message != nil {
+			out.WriteString(message.String())
+		}
 	}
 	return out.String()
 }
@@ -1628,16 +1655,17 @@ func (r *Runner) publishRunUpdate(
 
 	result.Tokens.RuntimeSeconds = runtimeSeconds(runStartedAt, eventAt)
 	usage := UsageUpdate{
-		SessionID:       progress.sessionID,
-		ProcessIdentity: progress.processIdentity,
-		WorkspacePath:   info.Path,
-		TurnCount:       progress.turnCount(),
-		LastEventAt:     progress.lastEventAt,
-		LastEvent:       progress.lastEvent,
-		LastMessage:     progress.lastMessage,
-		RecentEvents:    progress.recentActivity(),
-		Tokens:          result.Tokens,
-		RateLimits:      result.RateLimits,
+		SessionID:             progress.sessionID,
+		ProcessIdentity:       progress.processIdentity,
+		WorkspacePath:         info.Path,
+		TurnCount:             progress.turnCount(),
+		LastEventAt:           progress.lastEventAt,
+		LastEvent:             progress.lastEvent,
+		LastMessage:           progress.lastMessage,
+		LastMessageTruncation: runtimeoutput.CloneTruncation(progress.lastMessageTruncation),
+		RecentEvents:          progress.recentActivity(),
+		Tokens:                result.Tokens,
+		RateLimits:            result.RateLimits,
 	}
 	diffStats, ok := r.liveDiffStats(ctx, info, issue, progress, eventAt)
 	if ok {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/notes"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -2365,6 +2366,80 @@ func TestRunnerRunRecordsFailedOutputTailNote(t *testing.T) {
 	}
 	if !strings.Contains(prompt, "useful failure tail") {
 		t.Fatalf("retry prompt missing failure tail:\n%s", prompt)
+	}
+}
+
+func TestRunnerRunTruncatesConfiguredAgentOutputTelemetry(t *testing.T) {
+	t.Parallel()
+
+	workspacePath := t.TempDir()
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: workspacePath, Key: "issue-output", Branch: "detent/issue-output"},
+	}
+	largeOutput := "0123456789abcdefghijklmnopqrstuvwxyz"
+	codexClient := &fakeCodexClient{
+		updates: []AgentUpdate{{
+			Type:     AgentUpdateMessageDelta,
+			ThreadID: "thread-1",
+			TurnID:   "turn-1",
+			ItemID:   "msg-1",
+			Delta:    largeOutput,
+		}},
+		result: AgentTurnResult{ThreadID: "thread-1", TurnID: "turn-1", SessionID: "thread-1-turn-1"},
+	}
+	workflowConfig := config.Default()
+	workflowConfig.Agent.OutputTruncation.MaxBytes = len(runtimeoutput.Marker) + 10
+
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Config: workflowConfig, Prompt: "Prompt"},
+		Workspace:    workspaceBackend,
+		AgentBackend: codexClient,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	var usageUpdates []UsageUpdate
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-output",
+			Identifier: "digitaldrywood/detent#978",
+			Title:      "Truncate runtime output",
+		},
+		OnUsageUpdate: func(update UsageUpdate) error {
+			usageUpdates = append(usageUpdates, update)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+
+	wantOutput := "01234" + runtimeoutput.Marker + "vwxyz"
+	if result.Output != wantOutput {
+		t.Fatalf("RunResult.Output = %q, want %q", result.Output, wantOutput)
+	}
+	if len(usageUpdates) == 0 {
+		t.Fatal("OnUsageUpdate was not called")
+	}
+	last := usageUpdates[len(usageUpdates)-1]
+	if last.LastMessage != wantOutput {
+		t.Fatalf("UsageUpdate.LastMessage = %q, want %q", last.LastMessage, wantOutput)
+	}
+	if last.LastMessageTruncation == nil || !last.LastMessageTruncation.Truncated {
+		t.Fatalf("UsageUpdate.LastMessageTruncation = %#v, want truncated metadata", last.LastMessageTruncation)
+	}
+	if last.LastMessageTruncation.OriginalBytes != len(largeOutput) {
+		t.Fatalf("OriginalBytes = %d, want %d", last.LastMessageTruncation.OriginalBytes, len(largeOutput))
+	}
+	if len(last.RecentEvents) != 1 {
+		t.Fatalf("RecentEvents length = %d, want 1", len(last.RecentEvents))
+	}
+	if last.RecentEvents[0].Message != wantOutput {
+		t.Fatalf("RecentEvents[0].Message = %q, want %q", last.RecentEvents[0].Message, wantOutput)
+	}
+	if last.RecentEvents[0].Truncation == nil || !last.RecentEvents[0].Truncation.Truncated {
+		t.Fatalf("RecentEvents[0].Truncation = %#v, want truncated metadata", last.RecentEvents[0].Truncation)
 	}
 }
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -199,17 +200,18 @@ type RunResult struct {
 type UsageUpdateHandler func(UsageUpdate) error
 
 type UsageUpdate struct {
-	SessionID       string
-	ProcessIdentity string
-	WorkspacePath   string
-	TurnCount       int
-	LastEventAt     time.Time
-	LastEvent       string
-	LastMessage     string
-	RecentEvents    []telemetry.ActivityEvent
-	Tokens          TokenTotals
-	DiffStats       DiffStats
-	RateLimits      *telemetry.RateLimits
+	SessionID             string
+	ProcessIdentity       string
+	WorkspacePath         string
+	TurnCount             int
+	LastEventAt           time.Time
+	LastEvent             string
+	LastMessage           string
+	LastMessageTruncation *runtimeoutput.Truncation
+	RecentEvents          []telemetry.ActivityEvent
+	Tokens                TokenTotals
+	DiffStats             DiffStats
+	RateLimits            *telemetry.RateLimits
 }
 
 type BudgetRefusal struct {

--- a/internal/runtimeoutput/truncation.go
+++ b/internal/runtimeoutput/truncation.go
@@ -1,0 +1,206 @@
+package runtimeoutput
+
+import (
+	"strings"
+	"unicode/utf8"
+)
+
+const (
+	Marker           = "\n...[truncated]...\n"
+	StrategyHeadTail = "head_tail"
+	StrategyPrefix   = "prefix"
+)
+
+type Policy struct {
+	MaxBytes int
+}
+
+type Text struct {
+	Value      string
+	Truncation *Truncation
+}
+
+type Truncation struct {
+	Truncated     bool   `json:"truncated"`
+	OriginalBytes int    `json:"original_bytes"`
+	StoredBytes   int    `json:"stored_bytes"`
+	LimitBytes    int    `json:"limit_bytes"`
+	OmittedBytes  int    `json:"omitted_bytes,omitempty"`
+	Strategy      string `json:"strategy,omitempty"`
+}
+
+type Buffer struct {
+	policy        Policy
+	full          strings.Builder
+	originalBytes int
+	truncated     bool
+	head          string
+	tail          string
+}
+
+func NewBuffer(policy Policy) *Buffer {
+	if policy.MaxBytes < 0 {
+		policy.MaxBytes = 0
+	}
+	return &Buffer{policy: policy}
+}
+
+func Truncate(value string, maxBytes int) Text {
+	buffer := NewBuffer(Policy{MaxBytes: maxBytes})
+	buffer.Append(value)
+	return buffer.Text()
+}
+
+func (p Policy) Apply(value string) Text {
+	return Truncate(value, p.MaxBytes)
+}
+
+func (b *Buffer) Append(value string) {
+	if b == nil || value == "" {
+		return
+	}
+	if b.policy.MaxBytes <= 0 {
+		b.full.WriteString(value)
+		b.originalBytes += len(value)
+		return
+	}
+
+	nextBytes := b.originalBytes + len(value)
+	if !b.truncated && nextBytes <= b.policy.MaxBytes {
+		b.full.WriteString(value)
+		b.originalBytes = nextBytes
+		return
+	}
+
+	headMax, tailMax, _ := segmentLimits(b.policy.MaxBytes)
+	if !b.truncated {
+		current := b.full.String()
+		b.head = validPrefix(current, headMax)
+		b.tail = validSuffix(current, tailMax)
+		b.full.Reset()
+		b.truncated = true
+	}
+
+	b.originalBytes = nextBytes
+	if missing := headMax - len(b.head); missing > 0 {
+		b.head += validPrefix(value, missing)
+	}
+	b.tail = appendSuffix(b.tail, value, tailMax)
+}
+
+func (b *Buffer) Text() Text {
+	if b == nil {
+		return Text{}
+	}
+	if !b.truncated {
+		return Text{Value: b.full.String()}
+	}
+
+	_, _, marker := segmentLimits(b.policy.MaxBytes)
+	strategy := StrategyHeadTail
+	value := b.head + marker + b.tail
+	if marker == "" {
+		strategy = StrategyPrefix
+		value = validPrefix(b.head, b.policy.MaxBytes)
+	}
+	storedBytes := len(value)
+	omittedBytes := b.originalBytes - storedBytes
+	if omittedBytes < 0 {
+		omittedBytes = 0
+	}
+
+	return Text{
+		Value: value,
+		Truncation: &Truncation{
+			Truncated:     true,
+			OriginalBytes: b.originalBytes,
+			StoredBytes:   storedBytes,
+			LimitBytes:    b.policy.MaxBytes,
+			OmittedBytes:  omittedBytes,
+			Strategy:      strategy,
+		},
+	}
+}
+
+func (b *Buffer) String() string {
+	return b.Text().Value
+}
+
+func (b *Buffer) Truncation() *Truncation {
+	text := b.Text()
+	if text.Truncation == nil {
+		return nil
+	}
+	return CloneTruncation(text.Truncation)
+}
+
+func CloneTruncation(meta *Truncation) *Truncation {
+	if meta == nil {
+		return nil
+	}
+	clone := *meta
+	return &clone
+}
+
+func segmentLimits(maxBytes int) (int, int, string) {
+	if maxBytes <= 0 {
+		return 0, 0, ""
+	}
+	if maxBytes <= len(Marker)+2 {
+		return maxBytes, 0, ""
+	}
+	contextBytes := maxBytes - len(Marker)
+	headBytes := contextBytes / 2
+	tailBytes := contextBytes - headBytes
+	return headBytes, tailBytes, Marker
+}
+
+func appendSuffix(current string, value string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) >= maxBytes {
+		return validSuffix(value, maxBytes)
+	}
+	return validSuffix(current+value, maxBytes)
+}
+
+func validPrefix(value string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+	end := 0
+	for end < len(value) {
+		_, size := utf8.DecodeRuneInString(value[end:])
+		if size <= 0 || end+size > maxBytes {
+			break
+		}
+		end += size
+	}
+	return value[:end]
+}
+
+func validSuffix(value string, maxBytes int) string {
+	if maxBytes <= 0 {
+		return ""
+	}
+	if len(value) <= maxBytes {
+		return value
+	}
+	start := len(value)
+	for start > 0 {
+		_, size := utf8.DecodeLastRuneInString(value[:start])
+		if size <= 0 {
+			break
+		}
+		next := start - size
+		if len(value)-next > maxBytes {
+			break
+		}
+		start = next
+	}
+	return value[start:]
+}

--- a/internal/runtimeoutput/truncation.go
+++ b/internal/runtimeoutput/truncation.go
@@ -35,6 +35,7 @@ type Buffer struct {
 	originalBytes int
 	truncated     bool
 	head          string
+	headSealed    bool
 	tail          string
 }
 
@@ -76,14 +77,19 @@ func (b *Buffer) Append(value string) {
 	if !b.truncated {
 		current := b.full.String()
 		b.head = validPrefix(current, headMax)
+		b.headSealed = len(b.head) < len(current) && len(b.head) < headMax
 		b.tail = validSuffix(current, tailMax)
 		b.full.Reset()
 		b.truncated = true
 	}
 
 	b.originalBytes = nextBytes
-	if missing := headMax - len(b.head); missing > 0 {
-		b.head += validPrefix(value, missing)
+	if missing := headMax - len(b.head); missing > 0 && !b.headSealed {
+		prefix := validPrefix(value, missing)
+		b.head += prefix
+		if len(prefix) < len(value) && len(b.head) < headMax {
+			b.headSealed = true
+		}
 	}
 	b.tail = appendSuffix(b.tail, value, tailMax)
 }

--- a/internal/runtimeoutput/truncation_test.go
+++ b/internal/runtimeoutput/truncation_test.go
@@ -1,0 +1,122 @@
+package runtimeoutput
+
+import (
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+func TestTruncate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		input         string
+		limit         int
+		want          string
+		wantTruncate  bool
+		wantStrategy  string
+		wantOriginal  int
+		wantStoredMax int
+	}{
+		{
+			name:  "disabled preserves output",
+			input: "hello world",
+			limit: 0,
+			want:  "hello world",
+		},
+		{
+			name:         "normal output under limit",
+			input:        "hello world",
+			limit:        64,
+			want:         "hello world",
+			wantOriginal: len("hello world"),
+		},
+		{
+			name:         "exact boundary output",
+			input:        "1234567890",
+			limit:        10,
+			want:         "1234567890",
+			wantOriginal: len("1234567890"),
+		},
+		{
+			name:          "oversized output preserves head and tail",
+			input:         "0123456789abcdefghijklmnopqrstuvwxyz",
+			limit:         len(Marker) + 10,
+			want:          "01234" + Marker + "vwxyz",
+			wantTruncate:  true,
+			wantStrategy:  StrategyHeadTail,
+			wantOriginal:  len("0123456789abcdefghijklmnopqrstuvwxyz"),
+			wantStoredMax: len(Marker) + 10,
+		},
+		{
+			name:          "multi-byte output remains valid utf8",
+			input:         strings.Repeat("界", 10) + "abcdef" + strings.Repeat("尾", 10),
+			limit:         len(Marker) + len("界界") + len("尾尾"),
+			want:          "界界" + Marker + "尾尾",
+			wantTruncate:  true,
+			wantStrategy:  StrategyHeadTail,
+			wantOriginal:  len(strings.Repeat("界", 10) + "abcdef" + strings.Repeat("尾", 10)),
+			wantStoredMax: len(Marker) + len("界界") + len("尾尾"),
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Truncate(tt.input, tt.limit)
+			if got.Value != tt.want {
+				t.Fatalf("Value = %q, want %q", got.Value, tt.want)
+			}
+			if !utf8.ValidString(got.Value) {
+				t.Fatalf("Value is not valid UTF-8: %q", got.Value)
+			}
+			if (got.Truncation != nil) != tt.wantTruncate {
+				t.Fatalf("Truncation present = %v, want %v", got.Truncation != nil, tt.wantTruncate)
+			}
+			if got.Truncation == nil {
+				return
+			}
+			if !got.Truncation.Truncated {
+				t.Fatal("Truncation.Truncated = false, want true")
+			}
+			if got.Truncation.OriginalBytes != tt.wantOriginal {
+				t.Fatalf("OriginalBytes = %d, want %d", got.Truncation.OriginalBytes, tt.wantOriginal)
+			}
+			if got.Truncation.StoredBytes != len(got.Value) {
+				t.Fatalf("StoredBytes = %d, want %d", got.Truncation.StoredBytes, len(got.Value))
+			}
+			if got.Truncation.StoredBytes > tt.wantStoredMax {
+				t.Fatalf("StoredBytes = %d, want at most %d", got.Truncation.StoredBytes, tt.wantStoredMax)
+			}
+			if got.Truncation.LimitBytes != tt.limit {
+				t.Fatalf("LimitBytes = %d, want %d", got.Truncation.LimitBytes, tt.limit)
+			}
+			if got.Truncation.Strategy != tt.wantStrategy {
+				t.Fatalf("Strategy = %q, want %q", got.Truncation.Strategy, tt.wantStrategy)
+			}
+		})
+	}
+}
+
+func TestBufferTruncatesIncrementalOutput(t *testing.T) {
+	t.Parallel()
+
+	buffer := NewBuffer(Policy{MaxBytes: len(Marker) + 10})
+	buffer.Append("0123")
+	buffer.Append("456789abcdefghijklmnopqrstuvwxyz")
+
+	got := buffer.Text()
+	want := "01234" + Marker + "vwxyz"
+	if got.Value != want {
+		t.Fatalf("Value = %q, want %q", got.Value, want)
+	}
+	if got.Truncation == nil {
+		t.Fatal("Truncation = nil, want metadata")
+	}
+	if got.Truncation.OriginalBytes != len("0123456789abcdefghijklmnopqrstuvwxyz") {
+		t.Fatalf("OriginalBytes = %d, want full input length", got.Truncation.OriginalBytes)
+	}
+}

--- a/internal/runtimeoutput/truncation_test.go
+++ b/internal/runtimeoutput/truncation_test.go
@@ -120,3 +120,27 @@ func TestBufferTruncatesIncrementalOutput(t *testing.T) {
 		t.Fatalf("OriginalBytes = %d, want full input length", got.Truncation.OriginalBytes)
 	}
 }
+
+func TestBufferDoesNotBackfillHeadAfterMultibyteBoundary(t *testing.T) {
+	t.Parallel()
+
+	buffer := NewBuffer(Policy{MaxBytes: len(Marker) + 10})
+	buffer.Append("abcd")
+	buffer.Append("界" + strings.Repeat("x", 30))
+	buffer.Append("tail!")
+
+	got := buffer.Text()
+	want := "abcd" + Marker + "tail!"
+	if got.Value != want {
+		t.Fatalf("Value = %q, want %q", got.Value, want)
+	}
+	if !utf8.ValidString(got.Value) {
+		t.Fatalf("Value is not valid UTF-8: %q", got.Value)
+	}
+	if got.Truncation == nil {
+		t.Fatal("Truncation = nil, want metadata")
+	}
+	if got.Truncation.StoredBytes > got.Truncation.LimitBytes {
+		t.Fatalf("StoredBytes = %d, want at most %d", got.Truncation.StoredBytes, got.Truncation.LimitBytes)
+	}
+}

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"time"
+
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 )
 
 type Snapshot struct {
@@ -297,61 +299,64 @@ type MergeTiming struct {
 }
 
 type ActivityEvent struct {
-	At      time.Time `json:"at"`
-	Event   string    `json:"event,omitempty"`
-	Message string    `json:"message,omitempty"`
+	At         time.Time                 `json:"at"`
+	Event      string                    `json:"event,omitempty"`
+	Message    string                    `json:"message,omitempty"`
+	Truncation *runtimeoutput.Truncation `json:"truncation,omitempty"`
 }
 
 type Running struct {
 	Issue
-	WorkerHost      string          `json:"worker_host,omitempty"`
-	ProcessIdentity string          `json:"process_identity,omitempty"`
-	WorkspacePath   string          `json:"workspace_path,omitempty"`
-	SessionID       string          `json:"session_id,omitempty"`
-	TurnCount       int             `json:"turn_count"`
-	StartedAt       time.Time       `json:"started_at"`
-	LastEventAt     *time.Time      `json:"last_event_at,omitempty"`
-	LastEvent       string          `json:"last_event,omitempty"`
-	LastMessage     string          `json:"last_message,omitempty"`
-	RecentEvents    []ActivityEvent `json:"recent_events,omitempty"`
-	RuntimeSeconds  float64         `json:"runtime_seconds"`
-	DiffAdded       int             `json:"diff_added"`
-	DiffRemoved     int             `json:"diff_removed"`
-	DiffFiles       int             `json:"diff_files"`
-	DiffStatus      string          `json:"diff_status,omitempty"`
-	Tokens          Tokens          `json:"tokens"`
+	WorkerHost            string                    `json:"worker_host,omitempty"`
+	ProcessIdentity       string                    `json:"process_identity,omitempty"`
+	WorkspacePath         string                    `json:"workspace_path,omitempty"`
+	SessionID             string                    `json:"session_id,omitempty"`
+	TurnCount             int                       `json:"turn_count"`
+	StartedAt             time.Time                 `json:"started_at"`
+	LastEventAt           *time.Time                `json:"last_event_at,omitempty"`
+	LastEvent             string                    `json:"last_event,omitempty"`
+	LastMessage           string                    `json:"last_message,omitempty"`
+	LastMessageTruncation *runtimeoutput.Truncation `json:"last_message_truncation,omitempty"`
+	RecentEvents          []ActivityEvent           `json:"recent_events,omitempty"`
+	RuntimeSeconds        float64                   `json:"runtime_seconds"`
+	DiffAdded             int                       `json:"diff_added"`
+	DiffRemoved           int                       `json:"diff_removed"`
+	DiffFiles             int                       `json:"diff_files"`
+	DiffStatus            string                    `json:"diff_status,omitempty"`
+	Tokens                Tokens                    `json:"tokens"`
 }
 
 type WorkAttempt struct {
-	AttemptID              int64      `json:"attempt_id"`
-	ProjectID              string     `json:"project_id,omitempty"`
-	IssueID                string     `json:"issue_id,omitempty"`
-	Identifier             string     `json:"identifier,omitempty"`
-	IssueURL               string     `json:"issue_url,omitempty"`
-	PRNumber               *int64     `json:"pr_number,omitempty"`
-	Repo                   string     `json:"repo,omitempty"`
-	WorkerType             string     `json:"worker_type,omitempty"`
-	WorkerHost             string     `json:"worker_host,omitempty"`
-	Lane                   string     `json:"lane,omitempty"`
-	AttemptNumber          int        `json:"attempt_number,omitempty"`
-	Status                 string     `json:"status,omitempty"`
-	StartedAt              time.Time  `json:"started_at,omitzero"`
-	LeaseExpiresAt         *time.Time `json:"lease_expires_at,omitempty"`
-	HeartbeatAt            *time.Time `json:"heartbeat_at,omitempty"`
-	CompletedAt            *time.Time `json:"completed_at,omitempty"`
-	TerminalState          string     `json:"terminal_state,omitempty"`
-	ErrorClass             string     `json:"error_class,omitempty"`
-	ErrorMessage           string     `json:"error_message,omitempty"`
-	Phase                  string     `json:"phase,omitempty"`
-	StatusMessage          string     `json:"status_message,omitempty"`
-	CurrentCommand         string     `json:"current_command,omitempty"`
-	WaitReason             string     `json:"wait_reason,omitempty"`
-	GitHubRateSnapshotJSON string     `json:"github_rate_snapshot_json,omitempty"`
-	CIState                string     `json:"ci_state,omitempty"`
-	CapacitySnapshotJSON   string     `json:"capacity_snapshot_json,omitempty"`
-	MetricsJSON            string     `json:"metrics_json,omitempty"`
-	NextAction             string     `json:"next_action,omitempty"`
-	Stale                  bool       `json:"stale,omitempty"`
+	AttemptID               int64                     `json:"attempt_id"`
+	ProjectID               string                    `json:"project_id,omitempty"`
+	IssueID                 string                    `json:"issue_id,omitempty"`
+	Identifier              string                    `json:"identifier,omitempty"`
+	IssueURL                string                    `json:"issue_url,omitempty"`
+	PRNumber                *int64                    `json:"pr_number,omitempty"`
+	Repo                    string                    `json:"repo,omitempty"`
+	WorkerType              string                    `json:"worker_type,omitempty"`
+	WorkerHost              string                    `json:"worker_host,omitempty"`
+	Lane                    string                    `json:"lane,omitempty"`
+	AttemptNumber           int                       `json:"attempt_number,omitempty"`
+	Status                  string                    `json:"status,omitempty"`
+	StartedAt               time.Time                 `json:"started_at,omitzero"`
+	LeaseExpiresAt          *time.Time                `json:"lease_expires_at,omitempty"`
+	HeartbeatAt             *time.Time                `json:"heartbeat_at,omitempty"`
+	CompletedAt             *time.Time                `json:"completed_at,omitempty"`
+	TerminalState           string                    `json:"terminal_state,omitempty"`
+	ErrorClass              string                    `json:"error_class,omitempty"`
+	ErrorMessage            string                    `json:"error_message,omitempty"`
+	Phase                   string                    `json:"phase,omitempty"`
+	StatusMessage           string                    `json:"status_message,omitempty"`
+	StatusMessageTruncation *runtimeoutput.Truncation `json:"status_message_truncation,omitempty"`
+	CurrentCommand          string                    `json:"current_command,omitempty"`
+	WaitReason              string                    `json:"wait_reason,omitempty"`
+	GitHubRateSnapshotJSON  string                    `json:"github_rate_snapshot_json,omitempty"`
+	CIState                 string                    `json:"ci_state,omitempty"`
+	CapacitySnapshotJSON    string                    `json:"capacity_snapshot_json,omitempty"`
+	MetricsJSON             string                    `json:"metrics_json,omitempty"`
+	NextAction              string                    `json:"next_action,omitempty"`
+	Stale                   bool                      `json:"stale,omitempty"`
 }
 
 type SchedulerDecision struct {

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -284,6 +284,9 @@ func formatRunningRowsWithLayout(running []telemetry.Running, layout runningTabl
 	lines := make([]string, 0, len(rows))
 	for _, row := range rows {
 		event := row.LastMessage
+		if row.LastMessageTruncation != nil && row.LastMessageTruncation.Truncated && strings.TrimSpace(event) != "" {
+			event += " [truncated]"
+		}
 		if strings.TrimSpace(event) == "" {
 			event = row.LastEvent
 		}

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/templates"
@@ -602,6 +603,7 @@ func runningEntries(entries []telemetry.Running) []runningAPIResponse {
 			TurnCount:             entry.TurnCount,
 			LastEvent:             optionalString(entry.LastEvent),
 			LastMessage:           optionalString(entry.LastMessage),
+			LastMessageTruncation: runtimeoutput.CloneTruncation(entry.LastMessageTruncation),
 			StartedAt:             timestampString(entry.StartedAt),
 			LastEventAt:           timestampStringPtr(entry.LastEventAt),
 			CurrentLaneEnteredAt:  timestampStringPtr(entry.CurrentLaneEnteredAt),
@@ -706,20 +708,21 @@ func recentSessionEntries(entries []telemetry.Completed) []recentSessionAPIRespo
 
 func runningIssueResponse(entry telemetry.Running) *runningIssueAPIResponse {
 	return &runningIssueAPIResponse{
-		WorkerHost:    optionalString(entry.WorkerHost),
-		WorkspacePath: optionalString(entry.WorkspacePath),
-		SessionID:     optionalString(entry.SessionID),
-		TurnCount:     entry.TurnCount,
-		State:         entry.State,
-		StartedAt:     timestampString(entry.StartedAt),
-		LastEvent:     optionalString(entry.LastEvent),
-		LastMessage:   optionalString(entry.LastMessage),
-		LastEventAt:   timestampStringPtr(entry.LastEventAt),
-		DiffAdded:     entry.DiffAdded,
-		DiffRemoved:   entry.DiffRemoved,
-		DiffFiles:     entry.DiffFiles,
-		DiffStatus:    diffStatus(entry.DiffStatus),
-		Tokens:        tokenCountsResponse(entry.Tokens),
+		WorkerHost:            optionalString(entry.WorkerHost),
+		WorkspacePath:         optionalString(entry.WorkspacePath),
+		SessionID:             optionalString(entry.SessionID),
+		TurnCount:             entry.TurnCount,
+		State:                 entry.State,
+		StartedAt:             timestampString(entry.StartedAt),
+		LastEvent:             optionalString(entry.LastEvent),
+		LastMessage:           optionalString(entry.LastMessage),
+		LastMessageTruncation: runtimeoutput.CloneTruncation(entry.LastMessageTruncation),
+		LastEventAt:           timestampStringPtr(entry.LastEventAt),
+		DiffAdded:             entry.DiffAdded,
+		DiffRemoved:           entry.DiffRemoved,
+		DiffFiles:             entry.DiffFiles,
+		DiffStatus:            diffStatus(entry.DiffStatus),
+		Tokens:                tokenCountsResponse(entry.Tokens),
 	}
 }
 
@@ -776,9 +779,10 @@ func recentEventsFromTelemetry(events []telemetry.ActivityEvent, fallbackAt *tim
 			continue
 		}
 		payload = append(payload, recentEventAPIResponse{
-			At:      *timestamp,
-			Event:   optionalString(event.Event),
-			Message: optionalString(event.Message),
+			At:         *timestamp,
+			Event:      optionalString(event.Event),
+			Message:    optionalString(event.Message),
+			Truncation: runtimeoutput.CloneTruncation(event.Truncation),
 		})
 	}
 	return payload
@@ -1374,32 +1378,33 @@ type countsAPIResponse struct {
 }
 
 type runningAPIResponse struct {
-	IssueID               string                   `json:"issue_id"`
-	IssueIdentifier       string                   `json:"issue_identifier"`
-	ProjectID             string                   `json:"project_id,omitempty"`
-	IssueURL              *string                  `json:"issue_url"`
-	IssueTitle            *string                  `json:"issue_title"`
-	IssueDescription      *string                  `json:"issue_description"`
-	PullRequestURL        *string                  `json:"pull_request_url"`
-	PullRequestNumber     *int                     `json:"pull_request_number"`
-	BudgetAlert           bool                     `json:"budget_alert?"`
-	State                 string                   `json:"state"`
-	WorkerHost            *string                  `json:"worker_host"`
-	WorkspacePath         *string                  `json:"workspace_path"`
-	SessionID             *string                  `json:"session_id"`
-	TurnCount             int                      `json:"turn_count"`
-	LastEvent             *string                  `json:"last_event"`
-	LastMessage           *string                  `json:"last_message"`
-	StartedAt             *string                  `json:"started_at"`
-	LastEventAt           *string                  `json:"last_event_at"`
-	CurrentLaneEnteredAt  *string                  `json:"current_lane_entered_at"`
-	CurrentLaneAgeSeconds int64                    `json:"current_lane_age_seconds"`
-	RecentEvents          []recentEventAPIResponse `json:"recent_events"`
-	DiffAdded             int                      `json:"diff_added"`
-	DiffRemoved           int                      `json:"diff_removed"`
-	DiffFiles             int                      `json:"diff_files"`
-	DiffStatus            string                   `json:"diff_status"`
-	Tokens                tokenCountsAPIResponse   `json:"tokens"`
+	IssueID               string                    `json:"issue_id"`
+	IssueIdentifier       string                    `json:"issue_identifier"`
+	ProjectID             string                    `json:"project_id,omitempty"`
+	IssueURL              *string                   `json:"issue_url"`
+	IssueTitle            *string                   `json:"issue_title"`
+	IssueDescription      *string                   `json:"issue_description"`
+	PullRequestURL        *string                   `json:"pull_request_url"`
+	PullRequestNumber     *int                      `json:"pull_request_number"`
+	BudgetAlert           bool                      `json:"budget_alert?"`
+	State                 string                    `json:"state"`
+	WorkerHost            *string                   `json:"worker_host"`
+	WorkspacePath         *string                   `json:"workspace_path"`
+	SessionID             *string                   `json:"session_id"`
+	TurnCount             int                       `json:"turn_count"`
+	LastEvent             *string                   `json:"last_event"`
+	LastMessage           *string                   `json:"last_message"`
+	LastMessageTruncation *runtimeoutput.Truncation `json:"last_message_truncation,omitempty"`
+	StartedAt             *string                   `json:"started_at"`
+	LastEventAt           *string                   `json:"last_event_at"`
+	CurrentLaneEnteredAt  *string                   `json:"current_lane_entered_at"`
+	CurrentLaneAgeSeconds int64                     `json:"current_lane_age_seconds"`
+	RecentEvents          []recentEventAPIResponse  `json:"recent_events"`
+	DiffAdded             int                       `json:"diff_added"`
+	DiffRemoved           int                       `json:"diff_removed"`
+	DiffFiles             int                       `json:"diff_files"`
+	DiffStatus            string                    `json:"diff_status"`
+	Tokens                tokenCountsAPIResponse    `json:"tokens"`
 }
 
 type retryAPIResponse struct {
@@ -1647,20 +1652,21 @@ type attemptsAPIResponse struct {
 }
 
 type runningIssueAPIResponse struct {
-	WorkerHost    *string                `json:"worker_host"`
-	WorkspacePath *string                `json:"workspace_path"`
-	SessionID     *string                `json:"session_id"`
-	TurnCount     int                    `json:"turn_count"`
-	State         string                 `json:"state"`
-	StartedAt     *string                `json:"started_at"`
-	LastEvent     *string                `json:"last_event"`
-	LastMessage   *string                `json:"last_message"`
-	LastEventAt   *string                `json:"last_event_at"`
-	DiffAdded     int                    `json:"diff_added"`
-	DiffRemoved   int                    `json:"diff_removed"`
-	DiffFiles     int                    `json:"diff_files"`
-	DiffStatus    string                 `json:"diff_status"`
-	Tokens        tokenCountsAPIResponse `json:"tokens"`
+	WorkerHost            *string                   `json:"worker_host"`
+	WorkspacePath         *string                   `json:"workspace_path"`
+	SessionID             *string                   `json:"session_id"`
+	TurnCount             int                       `json:"turn_count"`
+	State                 string                    `json:"state"`
+	StartedAt             *string                   `json:"started_at"`
+	LastEvent             *string                   `json:"last_event"`
+	LastMessage           *string                   `json:"last_message"`
+	LastMessageTruncation *runtimeoutput.Truncation `json:"last_message_truncation,omitempty"`
+	LastEventAt           *string                   `json:"last_event_at"`
+	DiffAdded             int                       `json:"diff_added"`
+	DiffRemoved           int                       `json:"diff_removed"`
+	DiffFiles             int                       `json:"diff_files"`
+	DiffStatus            string                    `json:"diff_status"`
+	Tokens                tokenCountsAPIResponse    `json:"tokens"`
 }
 
 type retryIssueAPIResponse struct {
@@ -1697,9 +1703,10 @@ type logAPIResponse struct {
 }
 
 type recentEventAPIResponse struct {
-	At      string  `json:"at"`
-	Event   *string `json:"event"`
-	Message *string `json:"message"`
+	At         string                    `json:"at"`
+	Event      *string                   `json:"event"`
+	Message    *string                   `json:"message"`
+	Truncation *runtimeoutput.Truncation `json:"truncation,omitempty"`
 }
 
 type apiErrorResponse struct {

--- a/internal/web/api_truncation_test.go
+++ b/internal/web/api_truncation_test.go
@@ -1,0 +1,58 @@
+package web
+
+import (
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestRunningEntriesIncludeOutputTruncationMetadata(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 7, 7, 14, 30, 0, 0, time.UTC)
+	truncation := &runtimeoutput.Truncation{
+		Truncated:     true,
+		OriginalBytes: 36,
+		StoredBytes:   29,
+		LimitBytes:    29,
+		OmittedBytes:  7,
+		Strategy:      runtimeoutput.StrategyHeadTail,
+	}
+
+	payload := runningEntries([]telemetry.Running{{
+		Issue: telemetry.Issue{
+			ID:         "issue-978",
+			Identifier: "digitaldrywood/detent#978",
+			State:      "running",
+		},
+		LastMessage:           "01234" + runtimeoutput.Marker + "vwxyz",
+		LastMessageTruncation: truncation,
+		RecentEvents: []telemetry.ActivityEvent{{
+			At:         at,
+			Event:      "agent_message_delta",
+			Message:    "01234" + runtimeoutput.Marker + "vwxyz",
+			Truncation: truncation,
+		}},
+	}})
+
+	if len(payload) != 1 {
+		t.Fatalf("runningEntries() len = %d, want 1", len(payload))
+	}
+	if payload[0].LastMessageTruncation == nil || !payload[0].LastMessageTruncation.Truncated {
+		t.Fatalf("LastMessageTruncation = %#v, want truncated metadata", payload[0].LastMessageTruncation)
+	}
+	if payload[0].LastMessageTruncation == truncation {
+		t.Fatal("LastMessageTruncation reused source pointer")
+	}
+	if len(payload[0].RecentEvents) != 1 {
+		t.Fatalf("RecentEvents len = %d, want 1", len(payload[0].RecentEvents))
+	}
+	if payload[0].RecentEvents[0].Truncation == nil || !payload[0].RecentEvents[0].Truncation.Truncated {
+		t.Fatalf("RecentEvents[0].Truncation = %#v, want truncated metadata", payload[0].RecentEvents[0].Truncation)
+	}
+	if payload[0].RecentEvents[0].Truncation == truncation {
+		t.Fatal("RecentEvents[0].Truncation reused source pointer")
+	}
+}

--- a/internal/web/templates/analytics_data.go
+++ b/internal/web/templates/analytics_data.go
@@ -124,7 +124,7 @@ func analyticsAttemptDetail(attempt telemetry.WorkAttempt) string {
 	if phase := strings.TrimSpace(attempt.Phase); phase != "" {
 		parts = append(parts, "phase "+phase)
 	}
-	if message := strings.TrimSpace(attempt.StatusMessage); message != "" {
+	if message := strings.TrimSpace(displayOutputText(attempt.StatusMessage, attempt.StatusMessageTruncation)); message != "" {
 		parts = append(parts, message)
 	}
 	if reason := strings.TrimSpace(attempt.WaitReason); reason != "" {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/buildinfo"
 	"github.com/digitaldrywood/detent/internal/projectcolor"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	webchart "github.com/digitaldrywood/detent/internal/web/chart"
 	"github.com/digitaldrywood/detent/internal/web/ui/primitives"
@@ -1859,7 +1860,7 @@ func runningRuntimeSeconds(row telemetry.Running, generatedAt time.Time) float64
 
 func lastCodexUpdate(row telemetry.Running) string {
 	if row.LastMessage != "" {
-		return row.LastMessage
+		return displayOutputText(row.LastMessage, row.LastMessageTruncation)
 	}
 	if row.LastEvent != "" {
 		return row.LastEvent
@@ -1924,10 +1925,17 @@ func runningActivityRows(row telemetry.Running) []runningActivityRow {
 		rows = append(rows, runningActivityRow{
 			At:      activityTimeLabel(event.At),
 			Event:   activityValue(event.Event, "event"),
-			Message: activityValue(event.Message, "No message recorded."),
+			Message: displayOutputText(activityValue(event.Message, "No message recorded."), event.Truncation),
 		})
 	}
 	return rows
+}
+
+func displayOutputText(value string, truncation *runtimeoutput.Truncation) string {
+	if strings.TrimSpace(value) == "" || truncation == nil || !truncation.Truncated {
+		return value
+	}
+	return value + " [truncated]"
 }
 
 func activityTimeLabel(at time.Time) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/projectcolor"
+	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -1112,6 +1113,36 @@ func TestRunningActivityRowsFallBackToLatestEvent(t *testing.T) {
 	}
 	if rows[0].At != "15:03:04 UTC" || rows[0].Event != "agent_message_delta" || rows[0].Message != "working through review feedback" {
 		t.Fatalf("runningActivityRows()[0] = %#v", rows[0])
+	}
+}
+
+func TestRunningActivityRowsMarkTruncatedOutput(t *testing.T) {
+	t.Parallel()
+
+	at := time.Date(2026, 5, 31, 15, 3, 4, 0, time.UTC)
+	truncation := &runtimeoutput.Truncation{Truncated: true}
+	row := telemetry.Running{
+		LastEventAt:           &at,
+		LastEvent:             "agent_message_delta",
+		LastMessage:           "01234" + runtimeoutput.Marker + "vwxyz",
+		LastMessageTruncation: truncation,
+		RecentEvents: []telemetry.ActivityEvent{{
+			At:         at,
+			Event:      "agent_message_delta",
+			Message:    "01234" + runtimeoutput.Marker + "vwxyz",
+			Truncation: truncation,
+		}},
+	}
+
+	if got, want := lastCodexUpdate(row), "01234"+runtimeoutput.Marker+"vwxyz [truncated]"; got != want {
+		t.Fatalf("lastCodexUpdate() = %q, want %q", got, want)
+	}
+	rows := runningActivityRows(row)
+	if len(rows) != 1 {
+		t.Fatalf("runningActivityRows() len = %d, want 1", len(rows))
+	}
+	if got, want := rows[0].Message, "01234"+runtimeoutput.Marker+"vwxyz [truncated]"; got != want {
+		t.Fatalf("runningActivityRows()[0].Message = %q, want %q", got, want)
 	}
 }
 

--- a/internal/web/templates/sheet_data.go
+++ b/internal/web/templates/sheet_data.go
@@ -95,7 +95,7 @@ func sheetSessionFor(snapshot telemetry.Snapshot, card projectKanbanCard) sheetS
 				Runtime:   formatDuration(running.RuntimeSeconds),
 				Turns:     formatCount(running.TurnCount),
 				LastEvent: strings.TrimSpace(running.LastEvent),
-				Message:   strings.TrimSpace(running.LastMessage),
+				Message:   strings.TrimSpace(displayOutputText(running.LastMessage, running.LastMessageTruncation)),
 			}
 			return session
 		}


### PR DESCRIPTION
## Summary

- Add `agent.output_truncation.max_bytes` and a UTF-8-safe head/tail truncation policy for runtime-ingested agent output.
- Bound runner progress, recent events, work-attempt/status/error text, backend error comments, telemetry/API fields, and UI/TUI indicators.
- Preserve default behavior with `max_bytes: 0`.

Fixes #978

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. Conditional truncation indicators are covered by template tests; there is no always-visible layout change.

## Test Plan

- [x] `go test ./internal/runtimeoutput`
- [x] `go test ./internal/config`
- [x] `go test ./internal/runner`
- [x] `go test ./internal/orchestrator`
- [x] `go test ./internal/web ./internal/web/templates ./internal/tui`
- [x] `make check`