### PR TITLE
fix(orchestrator): reconcile merged linked PRs

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -59,6 +59,7 @@ const (
 	AutoPromoteReasonOptoutLabel                     AutoPromoteReason = "optout_label"
 	AutoPromoteReasonLabelNotAllowed                 AutoPromoteReason = "label_not_allowed"
 	AutoPromoteReasonMissingPullRequest              AutoPromoteReason = "missing_pull_request"
+	AutoPromoteReasonPullRequestMerged               AutoPromoteReason = "pull_request_merged"
 	AutoPromoteReasonPullRequestHydrationUnavailable AutoPromoteReason = "pull_request_hydration_unavailable"
 	AutoPromoteReasonMergeConflicts                  AutoPromoteReason = "merge_conflicts"
 	AutoPromoteReasonCINotGreen                      AutoPromoteReason = "ci_not_green"

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -847,6 +847,10 @@ func staleMergedPullRequestSummaryFromIssue(issue connector.Issue) AutoPromoteSu
 }
 
 func staleMergedPullRequestDecision(issue connector.Issue, summary AutoPromoteSummary) AutoPromoteDecision {
+	if strings.TrimSpace(summary.PullRequestHydrationUnavailableReason) != "" ||
+		strings.TrimSpace(summary.PullRequestHydrationDegradedReason) != "" {
+		return autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonPullRequestHydrationUnavailable)
+	}
 	if staleMergedPullRequestHasFailedCIEvidence(issue.PullRequest, summary) {
 		decision := autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonCINotGreen)
 		decision.CIStatus = strings.TrimSpace(summary.CIStatus)
@@ -862,6 +866,8 @@ func staleMergedPullRequestTargetState(decision AutoPromoteDecision, cfg AutoPro
 		return cfg.ReworkState
 	case AutoPromoteReasonPullRequestMerged:
 		return doneStateName(terminalStates)
+	case AutoPromoteReasonPullRequestHydrationUnavailable:
+		return cfg.SourceState
 	default:
 		return ""
 	}
@@ -942,6 +948,12 @@ func staleMergedPullRequestComment(
 		b.WriteString(" to ")
 		b.WriteString(targetState)
 		b.WriteString(" because its merged linked PR has failing CI evidence.")
+	case AutoPromoteReasonPullRequestHydrationUnavailable:
+		b.WriteString("Reconciled this issue from ")
+		b.WriteString(sourceState)
+		b.WriteString(" to ")
+		b.WriteString(targetState)
+		b.WriteString(" because linked PR status hydration is unavailable.")
 	case AutoPromoteReasonPullRequestMerged:
 		b.WriteString("Reconciled this issue from ")
 		b.WriteString(sourceState)
@@ -970,6 +982,14 @@ func staleMergedPullRequestComment(
 	if failedChecks := strings.Join(summary.FailedChecks, ", "); failedChecks != "" {
 		b.WriteString("\n- failed_checks: ")
 		b.WriteString(failedChecks)
+	}
+	if summary.PullRequestHydrationUnavailableReason != "" {
+		b.WriteString("\n- pull_request_hydration_unavailable_reason: ")
+		b.WriteString(summary.PullRequestHydrationUnavailableReason)
+	}
+	if summary.PullRequestHydrationDegradedReason != "" {
+		b.WriteString("\n- pull_request_hydration_degraded_reason: ")
+		b.WriteString(summary.PullRequestHydrationDegradedReason)
 	}
 	return b.String()
 }
@@ -1043,6 +1063,12 @@ func (o *Orchestrator) logStaleTodoPullRequestDecision(issue connector.Issue, de
 		}
 		if failedChecks := strings.Join(autoPromoteFailedChecksFromPullRequest(issue.PullRequest), ", "); failedChecks != "" {
 			attrs = append(attrs, "failed_checks", failedChecks)
+		}
+		if reason := pullRequestHydrationUnavailableReason(issue.PullRequest); reason != "" {
+			attrs = append(attrs, "pull_request_hydration_unavailable_reason", reason)
+		}
+		if reason := pullRequestHydrationDegradedReason(issue.PullRequest); reason != "" {
+			attrs = append(attrs, "pull_request_hydration_degraded_reason", reason)
 		}
 	}
 	if decision.WorkpadBlocker != "" {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -139,22 +139,51 @@ func (o *Orchestrator) hydrateAutoPromoteWorkpadDecision(
 	return issue, EvaluateAutoPromote(issue, summary, cfg, now)
 }
 
-func (o *Orchestrator) reconcileStaleTodoPullRequestIssues(
+func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
 	ctx context.Context,
 	state *State,
 	issues []connector.Issue,
 	now time.Time,
 ) map[string]struct{} {
 	transitioned := map[string]struct{}{}
-	for _, issue := range issuesInStates(issues, []string{"Todo"}) {
+	for _, issue := range issuesInStates(issues, o.cfg.ActiveStates) {
 		issueID := strings.TrimSpace(issue.ID)
-		if issueID == "" || issue.PullRequest == nil || normalizePullRequestState(issue.PullRequest.State) != "open" {
+		if issueID == "" || issue.PullRequest == nil {
+			continue
+		}
+		pullRequestState := normalizePullRequestState(issue.PullRequest.State)
+		if pullRequestState != "open" && pullRequestState != "merged" {
+			continue
+		}
+		if stateIn(issue.State, o.cfg.TerminalStates) {
 			continue
 		}
 		if staleTodoPullRequestAlreadyActive(state, issueID) {
 			continue
 		}
 
+		if pullRequestState == "merged" {
+			summary := staleMergedPullRequestSummaryFromIssue(issue)
+			decision := staleMergedPullRequestDecision(issue, summary)
+			targetState := staleMergedPullRequestTargetState(decision, o.cfg.AutoPromote, o.cfg.TerminalStates)
+			if targetState == "" {
+				o.logAutoPromoteDecision(issue, decision, "")
+				continue
+			}
+			if normalizeState(targetState) == normalizeState(issue.State) {
+				continue
+			}
+			if !o.applyStaleMergedPullRequestDecision(ctx, state, issue, summary, decision, targetState, now) {
+				continue
+			}
+			transitioned[issueID] = struct{}{}
+			o.clearAutoPromotedIssueDispatchMemory(state, issueID)
+			continue
+		}
+
+		if normalizeState(issue.State) != "todo" {
+			continue
+		}
 		summary := AutoPromoteSummaryFromIssue(issue)
 		if !summary.PullRequestPresent {
 			continue
@@ -796,6 +825,155 @@ func staleTodoPullRequestTargetState(decision AutoPromoteDecision, cfg AutoPromo
 	}
 }
 
+func staleMergedPullRequestSummaryFromIssue(issue connector.Issue) AutoPromoteSummary {
+	summary := AutoPromoteSummary{
+		LastActivityAt: autoPromoteLastActivityAt(issue),
+		ArtifactStatus: artifactStatusFromIssue(issue, gate.DefaultArtifactStatusField),
+	}
+	if issue.PullRequest == nil {
+		return summary
+	}
+	pullRequest := issue.PullRequest
+	summary.PullRequestPresent = true
+	summary.PullRequestURL = strings.TrimSpace(pullRequest.URL)
+	summary.PullRequestHydrationUnavailableReason = pullRequestHydrationUnavailableReason(pullRequest)
+	summary.PullRequestHydrationDegradedReason = pullRequestHydrationDegradedReason(pullRequest)
+	summary.MergeableState = strings.ToLower(strings.TrimSpace(pullRequest.MergeableState))
+	summary.CIStatus = strings.TrimSpace(pullRequest.CIStatus)
+	summary.ReviewState = pullRequest.CodexReviewState
+	summary.FailedChecks = autoPromoteFailedChecksFromPullRequest(pullRequest)
+	summary.P1Findings = autoPromoteFindingsFromPullRequest(pullRequest)
+	return summary
+}
+
+func staleMergedPullRequestDecision(issue connector.Issue, summary AutoPromoteSummary) AutoPromoteDecision {
+	if staleMergedPullRequestHasFailedCIEvidence(issue.PullRequest, summary) {
+		decision := autoPromoteDecision(AutoPromoteActionRework, AutoPromoteReasonCINotGreen)
+		decision.CIStatus = strings.TrimSpace(summary.CIStatus)
+		return decision
+	}
+	return autoPromoteDecision(AutoPromoteActionPromote, AutoPromoteReasonPullRequestMerged)
+}
+
+func staleMergedPullRequestTargetState(decision AutoPromoteDecision, cfg AutoPromoteConfig, terminalStates []string) string {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	switch decision.Reason {
+	case AutoPromoteReasonCINotGreen:
+		return cfg.ReworkState
+	case AutoPromoteReasonPullRequestMerged:
+		return doneStateName(terminalStates)
+	default:
+		return ""
+	}
+}
+
+func staleMergedPullRequestHasFailedCIEvidence(pullRequest *connector.PullRequest, summary AutoPromoteSummary) bool {
+	if pullRequest == nil {
+		return false
+	}
+	if staleMergingCIRed(pullRequest.CIStatus) {
+		return true
+	}
+	return len(summary.FailedChecks) > 0
+}
+
+func (o *Orchestrator) applyStaleMergedPullRequestDecision(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	summary AutoPromoteSummary,
+	decision AutoPromoteDecision,
+	targetState string,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"stale_merged_pr_reconciliation_failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"reason", decision.Reason,
+				"target_state", targetState,
+				"error", err,
+			)
+		}
+		return false
+	}
+
+	body := staleMergedPullRequestComment(summary, decision, displayStateName(issue.State), targetState)
+	if strings.TrimSpace(body) != "" {
+		if err := o.connector.CreateComment(ctx, issueID, body); err != nil && o.logger != nil {
+			o.logger.Warn(
+				"stale_merged_pr_reconciliation_comment_failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"reason", decision.Reason,
+				"target_state", targetState,
+				"error", err,
+			)
+		}
+	}
+
+	o.logStaleTodoPullRequestDecision(issue, decision, targetState)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "stale_merged_pr_reconciled",
+		Message: "reconciled merged linked PR for " + issueLabel(issue) + " from " + displayStateName(issue.State) + " to " + targetState + ": " + string(decision.Reason),
+	})
+	return true
+}
+
+func staleMergedPullRequestComment(
+	summary AutoPromoteSummary,
+	decision AutoPromoteDecision,
+	sourceState string,
+	targetState string,
+) string {
+	var b strings.Builder
+	sourceState = displayStateName(sourceState)
+	if sourceState == "" {
+		sourceState = "active"
+	}
+	switch decision.Reason {
+	case AutoPromoteReasonCINotGreen:
+		b.WriteString("Reconciled this issue from ")
+		b.WriteString(sourceState)
+		b.WriteString(" to ")
+		b.WriteString(targetState)
+		b.WriteString(" because its merged linked PR has failing CI evidence.")
+	case AutoPromoteReasonPullRequestMerged:
+		b.WriteString("Reconciled this issue from ")
+		b.WriteString(sourceState)
+		b.WriteString(" to ")
+		b.WriteString(targetState)
+		b.WriteString(" because its linked PR is already merged.")
+	default:
+		return ""
+	}
+
+	b.WriteString("\n\n")
+	b.WriteString("- reason: ")
+	b.WriteString(string(decision.Reason))
+	if summary.PullRequestURL != "" {
+		b.WriteString("\n- pull request: ")
+		b.WriteString(summary.PullRequestURL)
+	}
+	if summary.MergeableState != "" {
+		b.WriteString("\n- mergeable_state: ")
+		b.WriteString(summary.MergeableState)
+	}
+	if decision.CIStatus != "" {
+		b.WriteString("\n- ci_status: ")
+		b.WriteString(decision.CIStatus)
+	}
+	if failedChecks := strings.Join(summary.FailedChecks, ", "); failedChecks != "" {
+		b.WriteString("\n- failed_checks: ")
+		b.WriteString(failedChecks)
+	}
+	return b.String()
+}
+
 func (o *Orchestrator) applyStaleTodoPullRequestDecision(
 	ctx context.Context,
 	state *State,
@@ -859,6 +1037,12 @@ func (o *Orchestrator) logStaleTodoPullRequestDecision(issue connector.Issue, de
 		}
 		if mergeableState := strings.TrimSpace(issue.PullRequest.MergeableState); mergeableState != "" {
 			attrs = append(attrs, "mergeable_state", strings.ToLower(mergeableState))
+		}
+		if ciStatus := strings.TrimSpace(issue.PullRequest.CIStatus); ciStatus != "" {
+			attrs = append(attrs, "ci_status", ciStatus)
+		}
+		if failedChecks := strings.Join(autoPromoteFailedChecksFromPullRequest(issue.PullRequest), ", "); failedChecks != "" {
+			attrs = append(attrs, "failed_checks", failedChecks)
 		}
 	}
 	if decision.WorkpadBlocker != "" {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -980,6 +980,135 @@ func TestTickReconcilesStaleTodoLinkedPullRequests(t *testing.T) {
 	}
 }
 
+func TestTickReconcilesStaleTodoMergedPullRequestToDone(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 15, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-pyroapex-1462", []string{"bug"}, &connector.PullRequest{
+		Number:   1471,
+		URL:      "https://github.test/digitaldrywood/pyroapex/pull/1471",
+		State:    "MERGED",
+		CIStatus: "success",
+	})
+	issue.State = "Todo"
+	issue.Identifier = "digitaldrywood/pyroapex#1462"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	attempts := &recordingWorkAttemptStore{}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+
+	state := newState(cfg)
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Done"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one merged PR reconciliation comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Reconciled this issue from Todo to Done because its linked PR is already merged.",
+		"reason: pull_request_merged",
+		"https://github.test/digitaldrywood/pyroapex/pull/1471",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	if strings.Contains(logs.String(), "skip_reason=duplicate_pull_request_work") {
+		t.Fatalf("logs %q contain duplicate_pull_request_work skip", logs.String())
+	}
+	for _, decision := range attempts.decisions {
+		if decision.IssueID == issue.ID && decision.Reason == dispatchSkipDuplicatePullRequest {
+			t.Fatalf("scheduler decision = %#v, want merged PR reconciliation instead of duplicate skip", decision)
+		}
+	}
+}
+
+func TestTickReconcilesStaleTodoMergedPullRequestWithFailedChecksToRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 15, 10, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-pyroapex-1463", []string{"bug"}, &connector.PullRequest{
+		Number:   1470,
+		URL:      "https://github.test/digitaldrywood/pyroapex/pull/1470",
+		State:    "MERGED",
+		CIStatus: "fail",
+		RequiredCheckFailures: []connector.PullRequestCheck{{
+			Name:       "Tier-1 Race Tests",
+			Status:     "completed",
+			Conclusion: "failure",
+		}},
+	})
+	issue.State = "Todo"
+	issue.Identifier = "digitaldrywood/pyroapex#1463"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	attempts := &recordingWorkAttemptStore{}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+
+	state := newState(cfg)
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one failed merged PR reconciliation comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Reconciled this issue from Todo to Rework because its merged linked PR has failing CI evidence.",
+		"reason: ci_not_green",
+		"ci_status: fail",
+		"failed_checks: Tier-1 Race Tests",
+		"https://github.test/digitaldrywood/pyroapex/pull/1470",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	if strings.Contains(logs.String(), "skip_reason=duplicate_pull_request_work") {
+		t.Fatalf("logs %q contain duplicate_pull_request_work skip", logs.String())
+	}
+	for _, decision := range attempts.decisions {
+		if decision.IssueID == issue.ID && decision.Reason == dispatchSkipDuplicatePullRequest {
+			t.Fatalf("scheduler decision = %#v, want failed merged PR reconciliation instead of duplicate skip", decision)
+		}
+	}
+}
+
 func TestTickReconcilesStaleTodoHydratesWorkpadBlockerBeforePromotion(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1041,6 +1041,67 @@ func TestTickReconcilesStaleTodoMergedPullRequestToDone(t *testing.T) {
 	}
 }
 
+func TestTickParksStaleTodoMergedPullRequestWhenHydrationUnavailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 15, 5, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := autoPromoteTickIssue("issue-pyroapex-merged-stale", []string{"bug"}, &connector.PullRequest{
+		Number:                  1472,
+		URL:                     "https://github.test/digitaldrywood/pyroapex/pull/1472",
+		State:                   "MERGED",
+		CIStatus:                "success",
+		HydrationDegradedReason: connector.PullRequestHydrationReasonStaleCachedPullData,
+	})
+	issue.State = "Todo"
+	issue.Identifier = "digitaldrywood/pyroapex#1464"
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+
+	state := newState(cfg)
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Human Review"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one hydration reconciliation comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Reconciled this issue from Todo to Human Review because linked PR status hydration is unavailable.",
+		"reason: pull_request_hydration_unavailable",
+		"pull_request_hydration_degraded_reason: stale_cached_pull_request",
+		"https://github.test/digitaldrywood/pyroapex/pull/1472",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	for _, fragment := range []string{
+		"reason=pull_request_hydration_unavailable",
+		"pull_request_hydration_degraded_reason=stale_cached_pull_request",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}
+
 func TestTickReconcilesStaleTodoMergedPullRequestWithFailedChecksToRework(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -397,6 +397,7 @@ const (
 	dispatchSkipInactiveState            = "inactive_state"
 	dispatchSkipTerminalState            = "terminal_state"
 	dispatchSkipPullRequestHydration     = "pull_request_hydration_unavailable"
+	dispatchSkipMergedPullRequest        = "merged_pull_request_reconciliation_pending"
 	dispatchSkipDuplicatePullRequest     = "duplicate_pull_request_work"
 	dispatchSkipUnauthorized             = "unauthorized"
 	dispatchSkipBlockedByDependency      = "blocked_by_dependency"
@@ -429,6 +430,9 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	}
 	if pullRequestHydrationBlocksDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipPullRequestHydration}
+	}
+	if mergedPullRequestReconciliationPending(issue, p.cfg) {
+		return dispatchableDecision{reason: dispatchSkipMergedPullRequest}
 	}
 	if duplicatePullRequestWork(issue) {
 		return dispatchableDecision{reason: dispatchSkipDuplicatePullRequest}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -803,6 +803,20 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 			want:  false,
 		},
 		{
+			name: "rework with failed merged pull request dispatches",
+			issue: func() connector.Issue {
+				issue := dispatchTestIssueWithPullRequest("issue-rework-merged-pr-failed", "Rework", "MERGED")
+				issue.PullRequest.CIStatus = "fail"
+				issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{
+					Name:       "Test",
+					Status:     "completed",
+					Conclusion: "failure",
+				}}
+				return issue
+			}(),
+			want: true,
+		},
+		{
 			name:  "todo with closed unmerged pull request dispatches",
 			issue: dispatchTestIssueWithPullRequest("issue-todo-closed-pr", "Todo", "CLOSED"),
 			want:  true,
@@ -819,6 +833,51 @@ func TestDispatchableSkipsDuplicatePullRequestWork(t *testing.T) {
 				t.Fatalf("dispatchable() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestDispatchPlanReportsMergedPullRequestReconciliationPending(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 15, 30, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 3,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates:      []string{"Done"},
+	})
+	issues := []connector.Issue{
+		dispatchTestIssueWithPullRequest("issue-todo-merged-pr", "Todo", "MERGED"),
+		func() connector.Issue {
+			issue := dispatchTestIssueWithPullRequest("issue-todo-merged-pr-failed", "Todo", "MERGED")
+			issue.PullRequest.CIStatus = "fail"
+			issue.PullRequest.RequiredCheckFailures = []connector.PullRequestCheck{{
+				Name:       "Tier-1 Race Tests",
+				Status:     "completed",
+				Conclusion: "failure",
+			}}
+			return issue
+		}(),
+	}
+	state := newState(cfg)
+	decisions := make(map[string]dispatchPlanDecision)
+
+	newDispatchPlanner(cfg).plan(&state, issues, now, dispatchPlanHooks{
+		decision: func(decision dispatchPlanDecision) {
+			decisions[decision.Issue.ID] = decision
+		},
+	})
+
+	for _, issue := range issues {
+		decision, ok := decisions[issue.ID]
+		if !ok {
+			t.Fatalf("decision for %s missing", issue.ID)
+		}
+		if decision.Selected {
+			t.Fatalf("decision for %s selected = true, want reconciliation skip", issue.ID)
+		}
+		if decision.SkipReason != dispatchSkipMergedPullRequest {
+			t.Fatalf("decision for %s skip reason = %q, want %q", issue.ID, decision.SkipReason, dispatchSkipMergedPullRequest)
+		}
 	}
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -3061,12 +3061,22 @@ func duplicatePullRequestWork(issue connector.Issue) bool {
 	}
 	switch normalizePullRequestState(issue.PullRequest.State) {
 	case "merged":
-		return true
+		return !staleMergedPullRequestHasFailedCIEvidence(issue.PullRequest, staleMergedPullRequestSummaryFromIssue(issue))
 	case "open":
 		return normalizeState(issue.State) == "todo"
 	default:
 		return false
 	}
+}
+
+func mergedPullRequestReconciliationPending(issue connector.Issue, cfg Config) bool {
+	if issue.PullRequest == nil || normalizePullRequestState(issue.PullRequest.State) != "merged" {
+		return false
+	}
+	summary := staleMergedPullRequestSummaryFromIssue(issue)
+	decision := staleMergedPullRequestDecision(issue, summary)
+	targetState := staleMergedPullRequestTargetState(decision, cfg.AutoPromote, cfg.TerminalStates)
+	return targetState != "" && normalizeState(targetState) != normalizeState(issue.State)
 }
 
 func continuationDispatch(issue connector.Issue) bool {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -144,7 +144,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	fetched = filterReconciledTickIssues(
 		state,
 		fetched,
-		o.reconcileStaleTodoPullRequestIssues(ctx, state, fetched.candidates, now),
+		o.reconcileStaleLinkedPullRequestIssues(ctx, state, fetched.candidates, now),
 	)
 	completedTransitions := o.transitionCompletedActiveIssuesToReview(ctx, state, fetched.candidates, now)
 	fetched = filterReconciledTickIssues(


### PR DESCRIPTION
## Summary

- Reconcile open active issues with merged linked PRs before dispatch.
- Route merged PRs with failing CI or required-check evidence to Rework; otherwise move to Done.
- Park merged PRs with unavailable/degraded PR hydration in Human Review instead of making a terminal decision from stale status data.
- Add a scheduler fallback reason, `merged_pull_request_reconciliation_pending`, so merged PR candidates do not end as `duplicate_pull_request_work`.

Fixes #999

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestTick(ReconcilesStaleTodoMergedPullRequest|ParksStaleTodoMergedPullRequestWhenHydrationUnavailable)|TestDispatchableSkipsDuplicatePullRequestWork|TestDispatchPlanReportsMergedPullRequestReconciliationPending' -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`