### PR TITLE
feat(connector): add capability detection

### DIFF
--- a/internal/connector/capabilities.go
+++ b/internal/connector/capabilities.go
@@ -1,0 +1,58 @@
+package connector
+
+// Capabilities summarizes which write operations a connector supports.
+// Serializable so it can flow into template data and telemetry snapshots.
+type Capabilities struct {
+	UpdateIssueState      bool `json:"update_issue_state"`
+	SetAssignee           bool `json:"set_assignee"`
+	SetField              bool `json:"set_field"`
+	CreateComment         bool `json:"create_comment"`
+	CreateWorkItems       bool `json:"create_work_items"`
+	CloseIssues           bool `json:"close_issues"`
+	RemoveFromProject     bool `json:"remove_from_project"`
+	SetIssueFields        bool `json:"set_issue_fields"`
+	ClearIssueFields      bool `json:"clear_issue_fields"`
+	CommentOnPullRequests bool `json:"comment_on_pull_requests"`
+	UpdateComments        bool `json:"update_comments"`
+	DeleteComments        bool `json:"delete_comments"`
+}
+
+// CapabilityReporter lets a backend that only partially implements the base
+// Connector write methods declare what actually works. When implemented, the
+// reported value is authoritative and DetectCapabilities returns it verbatim.
+type CapabilityReporter interface {
+	Capabilities() Capabilities
+}
+
+func DetectCapabilities(c Connector) Capabilities {
+	if c == nil {
+		return Capabilities{}
+	}
+	if reporter, ok := c.(CapabilityReporter); ok {
+		return reporter.Capabilities()
+	}
+
+	_, canCreateWorkItems := c.(IssueUpserter)
+	_, canCloseIssues := c.(IssueCloser)
+	_, canRemoveFromProject := c.(ProjectRemover)
+	_, canSetIssueFields := c.(IssueFieldSetter)
+	_, canClearIssueFields := c.(IssueFieldClearer)
+	_, canCommentOnPullRequests := c.(PullRequestCommenter)
+	_, canUpdateComments := c.(IssueCommentUpdater)
+	_, canDeleteComments := c.(IssueCommentDeleter)
+
+	return Capabilities{
+		UpdateIssueState:      true,
+		SetAssignee:           true,
+		SetField:              true,
+		CreateComment:         true,
+		CreateWorkItems:       canCreateWorkItems,
+		CloseIssues:           canCloseIssues,
+		RemoveFromProject:     canRemoveFromProject,
+		SetIssueFields:        canSetIssueFields,
+		ClearIssueFields:      canClearIssueFields,
+		CommentOnPullRequests: canCommentOnPullRequests,
+		UpdateComments:        canUpdateComments,
+		DeleteComments:        canDeleteComments,
+	}
+}

--- a/internal/connector/capabilities_test.go
+++ b/internal/connector/capabilities_test.go
@@ -1,0 +1,180 @@
+package connector_test
+
+import (
+	"context"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+)
+
+func TestDetectCapabilities(t *testing.T) {
+	t.Parallel()
+
+	reported := connector.Capabilities{
+		DeleteComments: true,
+	}
+
+	tests := []struct {
+		name string
+		conn func(*testing.T) connector.Connector
+		want connector.Capabilities
+	}{
+		{
+			name: "nil connector",
+			conn: func(*testing.T) connector.Connector {
+				return nil
+			},
+			want: connector.Capabilities{},
+		},
+		{
+			name: "bare connector",
+			conn: func(*testing.T) connector.Connector {
+				return stubConnector{}
+			},
+			want: connector.Capabilities{
+				UpdateIssueState: true,
+				SetAssignee:      true,
+				SetField:         true,
+				CreateComment:    true,
+			},
+		},
+		{
+			name: "probed optional interfaces",
+			conn: func(*testing.T) connector.Connector {
+				return upsertingPullRequestCommenter{}
+			},
+			want: connector.Capabilities{
+				UpdateIssueState:      true,
+				SetAssignee:           true,
+				SetField:              true,
+				CreateComment:         true,
+				CreateWorkItems:       true,
+				CommentOnPullRequests: true,
+			},
+		},
+		{
+			name: "reported capabilities are authoritative",
+			conn: func(*testing.T) connector.Connector {
+				return reportingConnector{capabilities: reported}
+			},
+			want: reported,
+		},
+		{
+			name: "local sqlite connector",
+			conn: newLocalConnector,
+			want: connector.Capabilities{
+				UpdateIssueState:  true,
+				SetAssignee:       true,
+				SetField:          true,
+				CreateComment:     true,
+				CreateWorkItems:   true,
+				CloseIssues:       true,
+				RemoveFromProject: true,
+				SetIssueFields:    true,
+				ClearIssueFields:  true,
+				UpdateComments:    true,
+				DeleteComments:    true,
+			},
+		},
+		{
+			name: "memory connector",
+			conn: func(*testing.T) connector.Connector {
+				return memory.New(memory.Config{})
+			},
+			want: connector.Capabilities{
+				UpdateIssueState:      true,
+				SetAssignee:           true,
+				SetField:              true,
+				CreateComment:         true,
+				CloseIssues:           true,
+				RemoveFromProject:     true,
+				CommentOnPullRequests: true,
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := connector.DetectCapabilities(tt.conn(t))
+			if !reflect.DeepEqual(got, tt.want) {
+				t.Fatalf("DetectCapabilities() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+type stubConnector struct{}
+
+func (stubConnector) Name() string {
+	return "stub"
+}
+
+func (stubConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (stubConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (stubConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (stubConnector) CreateComment(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (stubConnector) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (stubConnector) SetAssignee(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (stubConnector) SetField(context.Context, string, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+type upsertingPullRequestCommenter struct {
+	stubConnector
+}
+
+func (upsertingPullRequestCommenter) UpsertIssues(context.Context, []connector.Issue) error {
+	return nil
+}
+
+func (upsertingPullRequestCommenter) CreatePullRequestComment(context.Context, string, int, string) error {
+	return nil
+}
+
+type reportingConnector struct {
+	upsertingPullRequestCommenter
+	capabilities connector.Capabilities
+}
+
+func (c reportingConnector) Capabilities() connector.Capabilities {
+	return c.capabilities
+}
+
+func newLocalConnector(t *testing.T) connector.Connector {
+	t.Helper()
+
+	c, err := local.New(local.Config{Path: filepath.Join(t.TempDir(), "detent.db")})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := c.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+	return c
+}

--- a/internal/connector/linear/connector.go
+++ b/internal/connector/linear/connector.go
@@ -68,6 +68,7 @@ type Connector struct {
 }
 
 var _ connector.Connector = (*Connector)(nil)
+var _ connector.CapabilityReporter = (*Connector)(nil)
 var _ connector.IssueCommentReader = (*Connector)(nil)
 
 func NewConnector(cfg Config) (*Connector, error) {
@@ -80,6 +81,10 @@ func NewConnector(cfg Config) (*Connector, error) {
 
 func (c *Connector) Name() string {
 	return connector.BackendLinear.String()
+}
+
+func (*Connector) Capabilities() connector.Capabilities {
+	return connector.Capabilities{CreateComment: true}
 }
 
 func (c *Connector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {

--- a/internal/connector/linear/connector_test.go
+++ b/internal/connector/linear/connector_test.go
@@ -165,6 +165,62 @@ func TestConnectorDoesNotExposePullRequestCommenter(t *testing.T) {
 	}
 }
 
+func TestConnectorCapabilities(t *testing.T) {
+	t.Parallel()
+
+	c := newLinearTestConnector(t, "https://api.linear.app/graphql")
+	want := connector.Capabilities{CreateComment: true}
+
+	t.Run("reported capabilities are authoritative", func(t *testing.T) {
+		t.Parallel()
+
+		got := connector.DetectCapabilities(c)
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("DetectCapabilities() = %#v, want %#v", got, want)
+		}
+		if reported := c.Capabilities(); !reflect.DeepEqual(reported, want) {
+			t.Fatalf("Capabilities() = %#v, want %#v", reported, want)
+		}
+	})
+
+	t.Run("optional interface probes match reported fields", func(t *testing.T) {
+		t.Parallel()
+
+		reported := c.Capabilities()
+		_, canCreateWorkItems := any(c).(connector.IssueUpserter)
+		_, canCloseIssues := any(c).(connector.IssueCloser)
+		_, canRemoveFromProject := any(c).(connector.ProjectRemover)
+		_, canSetIssueFields := any(c).(connector.IssueFieldSetter)
+		_, canClearIssueFields := any(c).(connector.IssueFieldClearer)
+		_, canCommentOnPullRequests := any(c).(connector.PullRequestCommenter)
+		_, canUpdateComments := any(c).(connector.IssueCommentUpdater)
+		_, canDeleteComments := any(c).(connector.IssueCommentDeleter)
+		probed := connector.Capabilities{
+			CreateWorkItems:       canCreateWorkItems,
+			CloseIssues:           canCloseIssues,
+			RemoveFromProject:     canRemoveFromProject,
+			SetIssueFields:        canSetIssueFields,
+			ClearIssueFields:      canClearIssueFields,
+			CommentOnPullRequests: canCommentOnPullRequests,
+			UpdateComments:        canUpdateComments,
+			DeleteComments:        canDeleteComments,
+		}
+		want := connector.Capabilities{
+			CreateWorkItems:       reported.CreateWorkItems,
+			CloseIssues:           reported.CloseIssues,
+			RemoveFromProject:     reported.RemoveFromProject,
+			SetIssueFields:        reported.SetIssueFields,
+			ClearIssueFields:      reported.ClearIssueFields,
+			CommentOnPullRequests: reported.CommentOnPullRequests,
+			UpdateComments:        reported.UpdateComments,
+			DeleteComments:        reported.DeleteComments,
+		}
+		if !reflect.DeepEqual(probed, want) {
+			t.Fatalf("optional interface probes = %#v, want %#v", probed, want)
+		}
+	})
+}
+
 func TestClientGraphQLReadsLargeSuccessfulResponse(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary
- Add a serializable connector capabilities contract and `DetectCapabilities` helper.
- Report Linear write capabilities authoritatively as comment-only.
- Cover detection, reporter override, local, memory, and Linear drift cases with table-driven tests.

Fixes #1013

## Test Plan
- `go test ./internal/connector ./internal/connector/linear`
- `go test ./internal/connector/local ./internal/connector/memory`
- `make check`