### PR TITLE
fix(connector): report blocked state updates

### DIFF
--- a/internal/cli/doctor_self_improvement.go
+++ b/internal/cli/doctor_self_improvement.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"log/slog"
 	"os"
 	"sort"
 	"strconv"
@@ -387,7 +388,9 @@ func createDoctorWorkflowImprovementProposalIssues(
 			if err != nil {
 				return nil, err
 			}
-			if err := projectConnector.UpdateIssueState(ctx, issue.ID, doctorWorkflowProposalBacklogState); err != nil {
+			if err := projectConnector.UpdateIssueState(ctx, issue.ID, doctorWorkflowProposalBacklogState); errors.Is(err, connector.ErrStateUpdateBlocked) {
+				slog.Default().Debug("skip blocked self-improvement proposal state update", "issue_id", issue.ID, "target_state", doctorWorkflowProposalBacklogState, "error", err)
+			} else if err != nil {
 				return nil, err
 			}
 		}

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -216,6 +216,42 @@ func TestDoctorWorkflowOptimizationCreatesProposalIssuesWithMemoryTracker(t *tes
 	}
 }
 
+func TestDoctorWorkflowOptimizationContinuesWhenProposalStateUpdateBlocked(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	cfg := workflowconfig.Default()
+	cfg.Tracker.Kind = workflowconfig.TrackerMemory
+	proposal := doctorWorkflowFinalizeProposal(doctorWorkflowImprovementProposal{
+		ProjectID:       "detent",
+		SignalKind:      "doctor_finding",
+		Pattern:         "blocked-state-update",
+		Count:           2,
+		Title:           "Improve blocked state update handling",
+		Detail:          "blocked update proposal",
+		TargetKind:      "workflow",
+		SuggestedChange: "Review blocked update handling.",
+	})
+	projectConnector := &blockedDoctorProposalConnector{
+		Connector: memory.New(memory.Config{Stateful: true}),
+	}
+	deps := successfulDoctorDeps()
+	deps.proposalConnector = func(workflowconfig.Config) (doctorWorkflowProposalConnector, error) {
+		return projectConnector, nil
+	}
+
+	created, err := createDoctorWorkflowImprovementProposalIssues(ctx, "detent", cfg, deps, []doctorWorkflowImprovementProposal{proposal})
+	if err != nil {
+		t.Fatalf("createDoctorWorkflowImprovementProposalIssues() error = %v", err)
+	}
+	if len(created) != 1 || created[0].ProposalID != proposal.ID || created[0].IssueID == "" {
+		t.Fatalf("created proposal issue = %#v, want one created issue for %q", created, proposal.ID)
+	}
+	if projectConnector.updateCalls != 1 {
+		t.Fatalf("UpdateIssueState calls = %d, want 1", projectConnector.updateCalls)
+	}
+}
+
 func TestDoctorWorkflowOptimizationReusesProposalIssueOutsideBacklog(t *testing.T) {
 	t.Parallel()
 
@@ -1245,4 +1281,18 @@ func doctorWorkflowProposalBySignal(t *testing.T, proposals []doctorWorkflowImpr
 	}
 	t.Fatalf("missing proposal signal=%q pattern=%q in %#v", signalKind, pattern, proposals)
 	return doctorWorkflowImprovementProposal{}
+}
+
+type blockedDoctorProposalConnector struct {
+	*memory.Connector
+	updateCalls int
+}
+
+func (c *blockedDoctorProposalConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updateCalls++
+	return &connector.StateUpdateBlockedError{
+		IssueID:      issueID,
+		CurrentState: "Done",
+		TargetState:  state,
+	}
 }

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -5,7 +5,27 @@ import (
 	"errors"
 )
 
-var ErrNotImplemented = errors.New("connector operation not implemented")
+var (
+	ErrNotImplemented     = errors.New("connector operation not implemented")
+	ErrStateUpdateBlocked = errors.New("issue state update blocked")
+)
+
+type StateUpdateBlockedError struct {
+	IssueID      string
+	CurrentState string
+	TargetState  string
+}
+
+func (e *StateUpdateBlockedError) Error() string {
+	if e == nil {
+		return ErrStateUpdateBlocked.Error()
+	}
+	return ErrStateUpdateBlocked.Error() + ": " + e.IssueID + " is in terminal state " + e.CurrentState + "; refusing move to non-terminal " + e.TargetState
+}
+
+func (e *StateUpdateBlockedError) Is(target error) bool {
+	return target == ErrStateUpdateBlocked
+}
 
 type Connector interface {
 	Name() string

--- a/internal/connector/github/adapter.go
+++ b/internal/connector/github/adapter.go
@@ -2019,7 +2019,7 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 			currentStatus = c.githubIssueStateToDetentState(issue.State)
 		}
 		if c.terminalStatusUpdateBlocked(currentStatus, stateName) {
-			return nil
+			return c.stateUpdateBlockedError(issueID, currentStatus, stateName)
 		}
 		return c.updateIssueStatusLabel(ctx, ref, issue, stateName)
 	}
@@ -2036,7 +2036,7 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 			return err
 		}
 		if c.terminalStatusUpdateBlocked(currentStatus, stateName) {
-			return nil
+			return c.stateUpdateBlockedError(issueID, currentStatus, stateName)
 		}
 		githubState := c.detentToGitHubState(stateName)
 		return c.setIssueStatusField(ctx, ref, githubState)
@@ -2050,7 +2050,7 @@ func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateN
 		return err
 	}
 	if c.terminalStatusUpdateBlocked(item.StatusName, stateName) {
-		return nil
+		return c.stateUpdateBlockedError(issueID, item.StatusName, stateName)
 	}
 
 	githubState := c.detentToGitHubState(stateName)
@@ -3910,6 +3910,22 @@ func (c *Connector) terminalStatusUpdateBlocked(currentStatus string, targetStat
 		return false
 	}
 	return !stateInList(targetState, c.terminalStates)
+}
+
+func (c *Connector) stateUpdateBlockedError(issueID string, currentStatus string, targetState string) error {
+	currentState := c.githubToDetentState(currentStatus)
+	if strings.TrimSpace(currentState) == "" {
+		currentState = strings.TrimSpace(currentStatus)
+	}
+	targetDetentState := c.githubToDetentState(targetState)
+	if strings.TrimSpace(targetDetentState) == "" {
+		targetDetentState = strings.TrimSpace(targetState)
+	}
+	return &connector.StateUpdateBlockedError{
+		IssueID:      strings.TrimSpace(issueID),
+		CurrentState: strings.TrimSpace(currentState),
+		TargetState:  strings.TrimSpace(targetDetentState),
+	}
 }
 
 func (c *Connector) updateStatusFieldValue(ctx context.Context, itemID string, fieldID string, optionID string) error {

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -3729,27 +3729,272 @@ func TestConnectorVerifyStatusOptionsChecksMappedStatusOptions(t *testing.T) {
 	}
 }
 
-func TestConnectorUpdateIssueStateSkipsTerminalToActiveTransition(t *testing.T) {
+func TestConnectorUpdateIssueStateTerminalTransitionRules(t *testing.T) {
 	t.Parallel()
 
-	server := newGraphQLTestServer(t, []graphqlTestResponse{
-		{body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":"Done"}}]}}}}`},
-	})
-	c := newGitHubTestConnector(t, server, Config{
-		ProjectSlug:    "PVT_1",
-		TerminalStates: []string{"Done", "Cancelled"},
-	})
-
-	if err := c.UpdateIssueState(context.Background(), "I_kw1", "In Progress"); err != nil {
-		t.Fatalf("UpdateIssueState() error = %v", err)
+	type transitionScenario struct {
+		name          string
+		currentStatus string
+		targetState   string
+		wantBlocked   bool
 	}
 
-	requests := server.requests()
-	if len(requests) != 1 {
-		t.Fatalf("request count = %d, want 1", len(requests))
+	scenarios := []transitionScenario{
+		{
+			name:          "terminal to non-terminal",
+			currentStatus: "Closed",
+			targetState:   "In Progress",
+			wantBlocked:   true,
+		},
+		{
+			name:          "terminal to terminal",
+			currentStatus: "Closed",
+			targetState:   "Cancelled",
+		},
+		{
+			name:          "non-terminal to terminal",
+			currentStatus: "Working",
+			targetState:   "Done",
+		},
 	}
-	if strings.Contains(requests[0]["query"].(string), "updateProjectV2ItemFieldValue") {
-		t.Fatalf("terminal guard issued update mutation: %q", requests[0]["query"])
+
+	modes := []struct {
+		name           string
+		issueID        string
+		newConnector   func(*testing.T, *graphqlTestServer, transitionScenario) *Connector
+		responses      func(transitionScenario) []graphqlTestResponse
+		mutationIssued func([]map[string]any) bool
+	}{
+		{
+			name:    GitHubStatusSourceLabel,
+			issueID: "I_1",
+			newConnector: func(t *testing.T, server *graphqlTestServer, _ transitionScenario) *Connector {
+				t.Helper()
+				c := newGitHubTestConnector(t, server, Config{
+					GitHubStatusSource: GitHubStatusSourceLabel,
+					Repository:         "digitaldrywood/detent",
+					ActiveStates:       []string{"In Progress"},
+					TerminalStates:     []string{"Done", "Cancelled"},
+					StateMap:           githubTransitionStateMap(),
+				})
+				c.projectCache.SetIssueRef("I_1", issueRef{Owner: "digitaldrywood", Name: "detent", Number: 1})
+				return c
+			},
+			responses: func(scenario transitionScenario) []graphqlTestResponse {
+				current := githubTransitionLabelIssueResponse("I_1", scenario.currentStatus)
+				if scenario.wantBlocked {
+					return []graphqlTestResponse{current}
+				}
+				target := githubTransitionLabelIssueResponse("I_1", scenario.currentStatus)
+				return []graphqlTestResponse{
+					current,
+					target,
+					{
+						method: http.MethodPut,
+						path:   "/repos/digitaldrywood/detent/issues/1/labels",
+						body:   githubTransitionLabelUpdateResponse(scenario.targetState),
+					},
+				}
+			},
+			mutationIssued: func(requests []map[string]any) bool {
+				for _, request := range requests {
+					if request["method"] == http.MethodPut && request["path"] == "/repos/digitaldrywood/detent/issues/1/labels" {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name:    GitHubStatusSourceIssueField,
+			issueID: "I_1",
+			newConnector: func(t *testing.T, server *graphqlTestServer, _ transitionScenario) *Connector {
+				t.Helper()
+				c := newGitHubTestConnector(t, server, Config{
+					GitHubStatusSource: GitHubStatusSourceIssueField,
+					Repository:         "digitaldrywood/detent",
+					StatusField:        "Status",
+					ActiveStates:       []string{"In Progress"},
+					TerminalStates:     []string{"Done", "Cancelled"},
+					StateMap:           githubTransitionStateMap(),
+				})
+				c.projectCache.SetIssueRef("I_1", issueRef{Owner: "digitaldrywood", Name: "detent", Number: 1})
+				return c
+			},
+			responses: func(scenario transitionScenario) []graphqlTestResponse {
+				responses := []graphqlTestResponse{
+					githubTransitionIssueFieldValuesResponse(scenario.currentStatus),
+					githubTransitionIssueFieldMetadataResponse(),
+				}
+				if scenario.wantBlocked {
+					return responses
+				}
+				return append(responses, githubTransitionIssueFieldUpdateResponse(scenario.targetState))
+			},
+			mutationIssued: func(requests []map[string]any) bool {
+				for _, request := range requests {
+					if request["method"] == http.MethodPost && request["path"] == "/repos/digitaldrywood/detent/issues/1/issue-field-values" {
+						return true
+					}
+				}
+				return false
+			},
+		},
+		{
+			name:    GitHubStatusSourceProjectV2,
+			issueID: "I_kw1",
+			newConnector: func(t *testing.T, server *graphqlTestServer, _ transitionScenario) *Connector {
+				t.Helper()
+				return newGitHubTestConnector(t, server, Config{
+					ProjectSlug:    "PVT_1",
+					ActiveStates:   []string{"In Progress"},
+					TerminalStates: []string{"Done", "Cancelled"},
+					StateMap:       githubTransitionStateMap(),
+				})
+			},
+			responses: func(scenario transitionScenario) []graphqlTestResponse {
+				responses := []graphqlTestResponse{githubTransitionProjectItemResponse(scenario.currentStatus)}
+				if scenario.wantBlocked {
+					return responses
+				}
+				return append(responses,
+					githubTransitionProjectMetadataResponse(),
+					graphqlTestResponse{body: `{"data":{"updateProjectV2ItemFieldValue":{"projectV2Item":{"id":"PVTI_1"}}}}`},
+				)
+			},
+			mutationIssued: func(requests []map[string]any) bool {
+				for _, request := range requests {
+					query, ok := request["query"].(string)
+					if ok && strings.Contains(query, "updateProjectV2ItemFieldValue") {
+						return true
+					}
+				}
+				return false
+			},
+		},
+	}
+
+	for _, mode := range modes {
+		mode := mode
+		for _, scenario := range scenarios {
+			scenario := scenario
+			t.Run(mode.name+"/"+scenario.name, func(t *testing.T) {
+				t.Parallel()
+
+				server := newGraphQLTestServer(t, mode.responses(scenario))
+				c := mode.newConnector(t, server, scenario)
+
+				err := c.UpdateIssueState(context.Background(), mode.issueID, scenario.targetState)
+				if scenario.wantBlocked {
+					assertStateUpdateBlocked(t, err, mode.issueID, "Done", scenario.targetState)
+				} else if err != nil {
+					t.Fatalf("UpdateIssueState() error = %v", err)
+				}
+
+				requests := server.requests()
+				if len(requests) != len(mode.responses(scenario)) {
+					t.Fatalf("request count = %d, want %d", len(requests), len(mode.responses(scenario)))
+				}
+				mutationIssued := mode.mutationIssued(requests)
+				if scenario.wantBlocked && mutationIssued {
+					t.Fatalf("blocked transition issued mutation: %#v", requests)
+				}
+				if !scenario.wantBlocked && !mutationIssued {
+					t.Fatalf("allowed transition did not issue mutation: %#v", requests)
+				}
+			})
+		}
+	}
+}
+
+func assertStateUpdateBlocked(t *testing.T, err error, issueID string, currentState string, targetState string) {
+	t.Helper()
+
+	if !errors.Is(err, connector.ErrStateUpdateBlocked) {
+		t.Fatalf("UpdateIssueState() error = %v, want ErrStateUpdateBlocked", err)
+	}
+	var blocked *connector.StateUpdateBlockedError
+	if !errors.As(err, &blocked) {
+		t.Fatalf("UpdateIssueState() error = %T, want StateUpdateBlockedError", err)
+	}
+	if blocked.IssueID != issueID || blocked.CurrentState != currentState || blocked.TargetState != targetState {
+		t.Fatalf("StateUpdateBlockedError = %#v, want issue_id=%q current_state=%q target_state=%q", blocked, issueID, currentState, targetState)
+	}
+}
+
+func githubTransitionStateMap() map[string]string {
+	return map[string]string{
+		"Done":        "Closed",
+		"Cancelled":   "Archived",
+		"In Progress": "Working",
+	}
+}
+
+func githubTransitionExternalState(stateName string) string {
+	if mapped, ok := githubTransitionStateMap()[stateName]; ok {
+		return mapped
+	}
+	return stateName
+}
+
+func githubTransitionLabelIssueResponse(issueID string, status string) graphqlTestResponse {
+	return graphqlTestResponse{
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent/issues/1",
+		body: fmt.Sprintf(
+			`{"node_id":%q,"number":1,"title":"Transition issue","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1","assignees":[],"labels":[{"name":%q},{"name":"bug"}]}`,
+			issueID,
+			"detent:"+statusLabelSlug(status),
+		),
+	}
+}
+
+func githubTransitionLabelUpdateResponse(targetState string) string {
+	return fmt.Sprintf(`[{"name":"bug"},{"name":%q}]`, "detent:"+statusLabelSlug(githubTransitionExternalState(targetState)))
+}
+
+func githubTransitionIssueFieldValuesResponse(status string) graphqlTestResponse {
+	return graphqlTestResponse{
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent/issues/1/issue-field-values?per_page=100",
+		body: fmt.Sprintf(
+			`[{"issue_field_id":10,"node_id":"IFV_1","data_type":"single_select","single_select_option":{"id":1,"name":%q,"color":"gray"}}]`,
+			status,
+		),
+	}
+}
+
+func githubTransitionIssueFieldMetadataResponse() graphqlTestResponse {
+	return graphqlTestResponse{
+		method: http.MethodGet,
+		path:   "/orgs/digitaldrywood/issue-fields?per_page=100",
+		body:   `[{"id":10,"node_id":"IFSS_status","name":"Status","data_type":"single_select","options":[{"id":1,"name":"Closed","color":"purple"},{"id":2,"name":"Archived","color":"gray"},{"id":3,"name":"Working","color":"yellow"}]}]`,
+	}
+}
+
+func githubTransitionIssueFieldUpdateResponse(targetState string) graphqlTestResponse {
+	return graphqlTestResponse{
+		method: http.MethodPost,
+		path:   "/repos/digitaldrywood/detent/issues/1/issue-field-values",
+		body: fmt.Sprintf(
+			`[{"issue_field_id":10,"node_id":"IFV_1","data_type":"single_select","single_select_option":{"id":2,"name":%q,"color":"gray"}}]`,
+			githubTransitionExternalState(targetState),
+		),
+	}
+}
+
+func githubTransitionProjectItemResponse(status string) graphqlTestResponse {
+	return graphqlTestResponse{
+		body: fmt.Sprintf(
+			`{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_1","project":{"id":"PVT_1"},"statusValue":{"name":%q}}]}}}}`,
+			status,
+		),
+	}
+}
+
+func githubTransitionProjectMetadataResponse() graphqlTestResponse {
+	return graphqlTestResponse{
+		body: `{"data":{"node":{"field":{"id":"PVTSSF_status","options":[{"id":"OPT_closed","name":"Closed"},{"id":"OPT_archived","name":"Archived"},{"id":"OPT_working","name":"Working"}]}}}}`,
 	}
 }
 

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"time"
 
@@ -38,6 +39,12 @@ func (o *Orchestrator) updateIssueStateByID(
 	reason string,
 ) error {
 	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
+		if errors.Is(err, connector.ErrStateUpdateBlocked) {
+			if o.logger != nil {
+				o.logger.Debug("skip blocked issue state update", "issue_id", issueID, "target_state", targetState, "error", err)
+			}
+			return nil
+		}
 		return err
 	}
 	if strings.TrimSpace(issue.ID) == "" {

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -1,0 +1,90 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestUpdateIssueStateByIDSkipsWorkflowMetricsForBlockedUpdate(t *testing.T) {
+	t.Parallel()
+
+	recorder := &workflowMetricsRecorderSpy{}
+	orch := &Orchestrator{
+		connector: workflowMetricsBlockedConnector{
+			err: &connector.StateUpdateBlockedError{
+				IssueID:      "issue-blocked",
+				CurrentState: "Done",
+				TargetState:  "Todo",
+			},
+		},
+		workflowMetrics: recorder,
+	}
+
+	err := orch.updateIssueStateByID(
+		context.Background(),
+		"issue-blocked",
+		connector.Issue{
+			ID:         "issue-blocked",
+			Identifier: "digitaldrywood/detent#100",
+			State:      "Done",
+		},
+		"Todo",
+		time.Now(),
+		"test",
+	)
+	if err != nil {
+		t.Fatalf("updateIssueStateByID() error = %v, want nil", err)
+	}
+	if len(recorder.events) != 0 {
+		t.Fatalf("workflow metric events = %#v, want none", recorder.events)
+	}
+}
+
+type workflowMetricsRecorderSpy struct {
+	events []store.WorkflowPhaseEvent
+}
+
+func (r *workflowMetricsRecorderSpy) RecordWorkflowPhaseEvent(_ context.Context, event store.WorkflowPhaseEvent) (int64, error) {
+	r.events = append(r.events, event)
+	return int64(len(r.events)), nil
+}
+
+type workflowMetricsBlockedConnector struct {
+	err error
+}
+
+func (c workflowMetricsBlockedConnector) Name() string {
+	return "workflow_metrics_blocked"
+}
+
+func (c workflowMetricsBlockedConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c workflowMetricsBlockedConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c workflowMetricsBlockedConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c workflowMetricsBlockedConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c workflowMetricsBlockedConnector) UpdateIssueState(context.Context, string, string) error {
+	return c.err
+}
+
+func (c workflowMetricsBlockedConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c workflowMetricsBlockedConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}


### PR DESCRIPTION
## Summary

- Return typed blocked state-update errors for terminal-to-active GitHub status writes instead of silent success.
- Skip orchestration lane metrics and doctor proposal failures when that typed blocked error is returned.
- Add regression coverage for label, issue-field, project_v2, workflow metrics, and doctor handling.

Fixes #1010

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI surface changes.

## Test Plan

- [x] `go test ./internal/connector/github ./internal/orchestrator ./internal/cli -run 'TestConnectorUpdateIssueStateTerminalTransitionRules|TestUpdateIssueStateByIDSkipsWorkflowMetricsForBlockedUpdate|TestDoctorWorkflowOptimizationContinuesWhenProposalStateUpdateBlocked' -count=1`
- [x] `make check`