### PR TITLE
feat(telemetry): add snapshot sequence IDs

### DIFF
--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -14,6 +14,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -243,6 +244,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}()
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
+	snapshotSeq := &atomic.Uint64{}
 	if err := publishStartupSnapshotOnce(runCtx, cfg.Global, snapshotHub, runtimeStore, displayURL, time.Now()); err != nil {
 		return err
 	}
@@ -250,7 +252,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
-	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, runtimeStore, displayURL, defaultSnapshotInterval, time.Now)
+	go publishSnapshots(runCtx, manager.Registry(), snapshotHub, snapshotSeq, runtimeStore, displayURL, defaultSnapshotInterval, time.Now)
 	go republishSnapshotsOnProjectEvents(runCtx, events, snapshotHub, logger)
 	//nolint:contextcheck // Echo middleware receives request contexts at serve time.
 	server, err := web.NewServer(web.Config{
@@ -313,6 +315,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 				Controller:        cfg.Shutdown,
 				Registry:          manager.Registry(),
 				SnapshotHub:       snapshotHub,
+				SnapshotSeq:       snapshotSeq,
 				LifetimeSource:    runtimeStore,
 				DashboardURL:      displayURL,
 				Output:            cfg.Output,
@@ -344,6 +347,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			Controller:     cfg.Shutdown,
 			Registry:       manager.Registry(),
 			SnapshotHub:    snapshotHub,
+			SnapshotSeq:    snapshotSeq,
 			LifetimeSource: runtimeStore,
 			DashboardURL:   displayURL,
 			Output:         cfg.Output,

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -279,6 +279,7 @@ func publishSnapshots(
 	ctx context.Context,
 	registry *project.Registry,
 	snapshotHub *hub.Hub[telemetry.Snapshot],
+	seq *atomic.Uint64,
 	lifetimeSource lifetimeTotalsSource,
 	dashboardURL string,
 	interval time.Duration,
@@ -293,14 +294,16 @@ func publishSnapshots(
 	if now == nil {
 		now = time.Now
 	}
+	if seq == nil {
+		seq = &atomic.Uint64{}
+	}
 
 	trend := newTokenTrendRecorder(defaultTokenTrendWindowSize)
-	var seq atomic.Uint64
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
-		if err := publishSnapshotOnce(ctx, registry, snapshotHub, &seq, now(), trend, lifetimeSource, dashboardURL); err != nil {
+		if err := publishSnapshotOnce(ctx, registry, snapshotHub, seq, now(), trend, lifetimeSource, dashboardURL); err != nil {
 			slog.Default().Warn("publish telemetry snapshot failed", "error", err)
 		}
 		select {

--- a/internal/cli/runner.go
+++ b/internal/cli/runner.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/budget"
@@ -294,11 +295,12 @@ func publishSnapshots(
 	}
 
 	trend := newTokenTrendRecorder(defaultTokenTrendWindowSize)
+	var seq atomic.Uint64
 	ticker := time.NewTicker(interval)
 	defer ticker.Stop()
 
 	for {
-		if err := publishSnapshotOnce(ctx, registry, snapshotHub, now(), trend, lifetimeSource, dashboardURL); err != nil {
+		if err := publishSnapshotOnce(ctx, registry, snapshotHub, &seq, now(), trend, lifetimeSource, dashboardURL); err != nil {
 			slog.Default().Warn("publish telemetry snapshot failed", "error", err)
 		}
 		select {
@@ -436,6 +438,7 @@ func publishSnapshotOnce(
 	ctx context.Context,
 	registry *project.Registry,
 	snapshotHub *hub.Hub[telemetry.Snapshot],
+	seq *atomic.Uint64,
 	now time.Time,
 	trend *tokenTrendRecorder,
 	lifetimeSource lifetimeTotalsSource,
@@ -514,6 +517,7 @@ func publishSnapshotOnce(
 		merged = trend.apply(merged)
 	}
 	merged.LifetimeTotals = lifetimeTotals(ctx, lifetimeSource)
+	merged.Seq = seq.Add(1)
 	if err := snapshotHub.Publish(merged); err != nil {
 		return fmt.Errorf("publish snapshot: %w", err)
 	}

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -419,6 +420,71 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	}
 }
 
+func TestPublishSnapshotOnceAssignsMonotonicSeq(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, startRefreshProject(t, "alpha"))
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	var seq atomic.Uint64
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+
+	for index := range 3 {
+		if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now.Add(time.Duration(index)*time.Second), nil, nil, "http://localhost:4101"); err != nil {
+			t.Fatalf("publishSnapshotOnce(%d) error = %v", index, err)
+		}
+		snapshot, ok := snapshotHub.Latest()
+		if !ok {
+			t.Fatal("snapshotHub.Latest() ok = false, want published snapshot")
+		}
+		want := uint64(index + 1)
+		if snapshot.Seq != want {
+			t.Fatalf("publish %d Seq = %d, want %d", index, snapshot.Seq, want)
+		}
+	}
+}
+
+func TestPublishSnapshotOncePreservesProjectDataSeq(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	alpha := startRefreshProject(t, "alpha")
+	bravo := startRefreshProject(t, "bravo")
+	mustSetProject(t, registry, alpha)
+	mustSetProject(t, registry, bravo)
+
+	alphaSeq := waitForProjectDataSeq(t, alpha, 1)
+	if _, err := alpha.Orchestrator().RequestRefresh(context.Background()); err != nil {
+		t.Fatalf("RequestRefresh() error = %v", err)
+	}
+	alphaSeq = waitForProjectDataSeq(t, alpha, alphaSeq+1)
+	bravoSeq := waitForProjectDataSeq(t, bravo, 1)
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	var seq atomic.Uint64
+	now := time.Date(2026, 7, 8, 12, 15, 0, 0, time.UTC)
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+
+	snapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("snapshotHub.Latest() ok = false, want published snapshot")
+	}
+
+	got := map[string]uint64{}
+	for _, projectSnapshot := range snapshot.Projects {
+		got[projectSnapshot.Project.ID] = projectSnapshot.Refresh.DataSeq
+	}
+	if got["alpha"] != alphaSeq {
+		t.Fatalf("alpha DataSeq = %d, want %d; projects = %#v", got["alpha"], alphaSeq, snapshot.Projects)
+	}
+	if got["bravo"] != bravoSeq {
+		t.Fatalf("bravo DataSeq = %d, want %d; projects = %#v", got["bravo"], bravoSeq, snapshot.Projects)
+	}
+}
+
 func TestPublishSnapshotOnceDoesNotLetPausedProjectsHoldFleetReadiness(t *testing.T) {
 	t.Parallel()
 
@@ -443,7 +509,8 @@ func TestPublishSnapshotOnceDoesNotLetPausedProjectsHoldFleetReadiness(t *testin
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 22, 14, 0, 0, 0, time.UTC)
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, now, nil, nil, "http://localhost:4101"); err != nil {
+	var seq atomic.Uint64
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -503,7 +570,8 @@ func TestPublishSnapshotOnceSurfacesProjectStartupError(t *testing.T) {
 	mustSetProject(t, registry, failedProject)
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 23, 14, 0, 0, 0, time.UTC)
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, now, nil, nil, "http://localhost:4101"); err != nil {
+	var seq atomic.Uint64
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -560,7 +628,8 @@ func TestPublishSnapshotOncePausedProjectSuppressesStartupError(t *testing.T) {
 	mustSetProject(t, registry, failedProject)
 	snapshotHub := hub.New[telemetry.Snapshot]()
 	now := time.Date(2026, 6, 23, 14, 30, 0, 0, time.UTC)
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, now, nil, nil, "http://localhost:4101"); err != nil {
+	var seq atomic.Uint64
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -672,7 +741,8 @@ func TestPublishSnapshotOncePreservesPipeline(t *testing.T) {
 	mustSetProject(t, registry, project)
 
 	snapshotHub := hub.New[telemetry.Snapshot]()
-	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, now, nil, nil, "http://localhost:4101"); err != nil {
+	var seq atomic.Uint64
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now, nil, nil, "http://localhost:4101"); err != nil {
 		t.Fatalf("publishSnapshotOnce() error = %v", err)
 	}
 
@@ -1143,4 +1213,27 @@ func receiveSnapshot(t *testing.T, ch <-chan telemetry.Snapshot) telemetry.Snaps
 	}
 
 	return telemetry.Snapshot{}
+}
+
+func waitForProjectDataSeq(t *testing.T, project *projectpkg.Project, wantAtLeast uint64) uint64 {
+	t.Helper()
+
+	orch := project.Orchestrator()
+	if orch == nil {
+		t.Fatal("Project.Orchestrator() = nil")
+	}
+
+	deadline := time.Now().Add(time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		state, err := orch.State(ctx)
+		cancel()
+		if err == nil && state.DataSeq >= wantAtLeast {
+			return state.DataSeq
+		}
+		time.Sleep(time.Millisecond)
+	}
+
+	t.Fatalf("timed out waiting for DataSeq >= %d", wantAtLeast)
+	return 0
 }

--- a/internal/cli/runner_test.go
+++ b/internal/cli/runner_test.go
@@ -379,9 +379,10 @@ func TestPublishSnapshotsPublishesToHub(t *testing.T) {
 	defer cancel()
 
 	done := make(chan struct{})
+	var seq atomic.Uint64
 	go func() {
 		defer close(done)
-		publishSnapshots(ctx, registry, snapshotHub, nil, "http://localhost:4101", 5*time.Millisecond, func() time.Time { return now })
+		publishSnapshots(ctx, registry, snapshotHub, &seq, nil, "http://localhost:4101", 5*time.Millisecond, func() time.Time { return now })
 	}()
 
 	var (

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -520,7 +520,11 @@ func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now
 		logShutdownBoundaryEndResult(shutdownLogger(cfg), "shutdown_snapshot_publish", started, "skipped", nil)
 		return
 	}
-	if err := publishSnapshotOnce(ctx, cfg.Registry, cfg.SnapshotHub, now, nil, cfg.LifetimeSource, cfg.DashboardURL); err != nil {
+	var seq atomic.Uint64
+	if latest, ok := cfg.SnapshotHub.Latest(); ok {
+		seq.Store(latest.Seq)
+	}
+	if err := publishSnapshotOnce(ctx, cfg.Registry, cfg.SnapshotHub, &seq, now, nil, cfg.LifetimeSource, cfg.DashboardURL); err != nil {
 		logShutdownBoundaryEnd(shutdownLogger(cfg), "shutdown_snapshot_publish", started, err)
 		shutdownLogger(cfg).Warn("publish shutdown telemetry snapshot failed", "error", err)
 		return

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -134,6 +134,7 @@ type runningShutdownConfig struct {
 	Controller         *ShutdownController
 	Registry           *project.Registry
 	SnapshotHub        *hub.Hub[telemetry.Snapshot]
+	SnapshotSeq        *atomic.Uint64
 	LifetimeSource     lifetimeTotalsSource
 	DashboardURL       string
 	Output             io.Writer
@@ -520,11 +521,14 @@ func publishShutdownSnapshot(ctx context.Context, cfg runningShutdownConfig, now
 		logShutdownBoundaryEndResult(shutdownLogger(cfg), "shutdown_snapshot_publish", started, "skipped", nil)
 		return
 	}
-	var seq atomic.Uint64
-	if latest, ok := cfg.SnapshotHub.Latest(); ok {
-		seq.Store(latest.Seq)
+	seq := cfg.SnapshotSeq
+	if seq == nil {
+		seq = &atomic.Uint64{}
+		if latest, ok := cfg.SnapshotHub.Latest(); ok {
+			seq.Store(latest.Seq)
+		}
 	}
-	if err := publishSnapshotOnce(ctx, cfg.Registry, cfg.SnapshotHub, &seq, now, nil, cfg.LifetimeSource, cfg.DashboardURL); err != nil {
+	if err := publishSnapshotOnce(ctx, cfg.Registry, cfg.SnapshotHub, seq, now, nil, cfg.LifetimeSource, cfg.DashboardURL); err != nil {
 		logShutdownBoundaryEnd(shutdownLogger(cfg), "shutdown_snapshot_publish", started, err)
 		shutdownLogger(cfg).Warn("publish shutdown telemetry snapshot failed", "error", err)
 		return

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"log/slog"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -672,6 +673,44 @@ func TestRunningShutdownConfigComputesDrainTimeoutFromCurrentRegistry(t *testing
 
 	if got := shutdownDrainTimeoutForConfig(cfg); got != wantDefault {
 		t.Fatalf("shutdownDrainTimeoutForConfig() after registry update = %v, want %v", got, wantDefault)
+	}
+}
+
+func TestPublishShutdownSnapshotSharesSnapshotSeq(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	project := startRefreshProject(t, "alpha")
+	waitForProjectDataSeq(t, project, 1)
+	mustSetProject(t, registry, project)
+
+	snapshotHub := hub.New[telemetry.Snapshot]()
+	var seq atomic.Uint64
+	seq.Store(4)
+	now := time.Date(2026, 7, 8, 12, 30, 0, 0, time.UTC)
+	publishShutdownSnapshot(context.Background(), runningShutdownConfig{
+		Registry:    registry,
+		SnapshotHub: snapshotHub,
+		SnapshotSeq: &seq,
+	}, now)
+
+	shutdownSnapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("SnapshotHub.Latest() ok = false, want shutdown snapshot")
+	}
+	if shutdownSnapshot.Seq != 5 {
+		t.Fatalf("shutdown snapshot Seq = %d, want 5", shutdownSnapshot.Seq)
+	}
+
+	if err := publishSnapshotOnce(context.Background(), registry, snapshotHub, &seq, now.Add(time.Second), nil, nil, ""); err != nil {
+		t.Fatalf("publishSnapshotOnce() error = %v", err)
+	}
+	nextSnapshot, ok := snapshotHub.Latest()
+	if !ok {
+		t.Fatal("SnapshotHub.Latest() ok = false, want next snapshot")
+	}
+	if nextSnapshot.Seq != 6 {
+		t.Fatalf("next snapshot Seq = %d, want 6", nextSnapshot.Seq)
 	}
 }
 

--- a/internal/hub/hub_test.go
+++ b/internal/hub/hub_test.go
@@ -1,13 +1,16 @@
 package hub_test
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"errors"
 	"sync"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
 func TestHubPublishFansOut(t *testing.T) {
@@ -108,6 +111,43 @@ func TestHubRepublishFansOutLastEvent(t *testing.T) {
 	}
 	if got := receive(t, sub.C()); got != "ready" {
 		t.Fatalf("republished event = %q, want ready", got)
+	}
+}
+
+func TestHubRepublishPreservesSnapshotSeq(t *testing.T) {
+	t.Parallel()
+
+	events := hub.New[telemetry.Snapshot](hub.WithBuffer(2))
+	sub, err := events.Subscribe(context.Background())
+	if err != nil {
+		t.Fatalf("Subscribe() error = %v", err)
+	}
+
+	snapshot := telemetry.Snapshot{
+		Seq:         7,
+		GeneratedAt: time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC),
+		Counts:      telemetry.Counts{Running: 2},
+	}
+	if err := events.Publish(snapshot); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	published := receive(t, sub.C())
+
+	if err := events.Republish(); err != nil {
+		t.Fatalf("Republish() error = %v", err)
+	}
+	republished := receive(t, sub.C())
+
+	publishedJSON, err := json.Marshal(published)
+	if err != nil {
+		t.Fatalf("Marshal(published) error = %v", err)
+	}
+	republishedJSON, err := json.Marshal(republished)
+	if err != nil {
+		t.Fatalf("Marshal(republished) error = %v", err)
+	}
+	if !bytes.Equal(republishedJSON, publishedJSON) {
+		t.Fatalf("republished JSON = %s, want %s", republishedJSON, publishedJSON)
 	}
 }
 

--- a/internal/orchestrator/data_seq_test.go
+++ b/internal/orchestrator/data_seq_test.go
@@ -1,0 +1,145 @@
+package orchestrator
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestTickDataSeqChangesOnlyAfterSuccessfulRefresh(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	errFetch := errors.New("fetch failed")
+
+	tests := []struct {
+		name      string
+		tracker   connector.Connector
+		state     func(Config) State
+		wantSeq   uint64
+		wantFetch int
+	}{
+		{
+			name:    "successful tick increments",
+			tracker: &dataSeqConnector{},
+			state: func(cfg Config) State {
+				state := newState(cfg)
+				state.DataSeq = 3
+				return state
+			},
+			wantSeq:   4,
+			wantFetch: 1,
+		},
+		{
+			name:    "failed tick does not increment",
+			tracker: &dataSeqConnector{fetchErr: errFetch},
+			state: func(cfg Config) State {
+				state := newState(cfg)
+				state.DataSeq = 3
+				return state
+			},
+			wantSeq:   3,
+			wantFetch: 1,
+		},
+		{
+			name:    "paused tick does not increment",
+			tracker: &dataSeqConnector{},
+			state: func(cfg Config) State {
+				state := newState(cfg)
+				state.DataSeq = 3
+				resetAt := now.Add(10 * time.Minute)
+				state.RateLimits = &telemetry.RateLimits{
+					GitHubGraphQL: &telemetry.RateLimitBucket{
+						Remaining: 0,
+						Limit:     5000,
+						Used:      5000,
+						ResetAt:   &resetAt,
+					},
+				}
+				return state
+			},
+			wantSeq: 3,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				PollInterval:        30 * time.Second,
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo", "In Progress"},
+				TerminalStates:      []string{"Done", "Cancelled"},
+			})
+			state := tt.state(cfg)
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tt.tracker,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			orch.tick(context.Background(), &state, now)
+
+			if state.DataSeq != tt.wantSeq {
+				t.Fatalf("DataSeq = %d, want %d", state.DataSeq, tt.wantSeq)
+			}
+			if tracker, ok := tt.tracker.(*dataSeqConnector); ok && tracker.fetches != tt.wantFetch {
+				t.Fatalf("FetchCandidateIssues() calls = %d, want %d", tracker.fetches, tt.wantFetch)
+			}
+			if snapshot := state.Snapshot(now); snapshot.Refresh.DataSeq != state.DataSeq {
+				t.Fatalf("Snapshot().Refresh.DataSeq = %d, want %d", snapshot.Refresh.DataSeq, state.DataSeq)
+			}
+			if cloned := state.clone(); cloned.DataSeq != state.DataSeq {
+				t.Fatalf("clone().DataSeq = %d, want %d", cloned.DataSeq, state.DataSeq)
+			}
+		})
+	}
+}
+
+type dataSeqConnector struct {
+	fetchErr error
+	fetches  int
+}
+
+func (c *dataSeqConnector) Name() string {
+	return "data-seq"
+}
+
+func (c *dataSeqConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.fetches++
+	if c.fetchErr != nil {
+		return nil, c.fetchErr
+	}
+	return nil, nil
+}
+
+func (c *dataSeqConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *dataSeqConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *dataSeqConnector) CreateComment(context.Context, string, string) error {
+	return nil
+}
+
+func (c *dataSeqConnector) UpdateIssueState(context.Context, string, string) error {
+	return nil
+}
+
+func (c *dataSeqConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *dataSeqConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -883,6 +883,7 @@ func (o *Orchestrator) markRefresh(state *State, now time.Time) {
 }
 
 func (o *Orchestrator) markRefreshSucceeded(state *State, now time.Time) {
+	state.DataSeq++
 	state.LastRefreshAt = now.UTC()
 }
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -17,6 +17,7 @@ import (
 func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	refresh := telemetry.Refresh{
 		PollIntervalSeconds: int64(s.PollInterval / time.Second),
+		DataSeq:             s.DataSeq,
 		LastRefreshAt:       timePointer(s.LastRefreshAt),
 		NextRefreshAt:       timePointer(s.NextRefreshAt),
 		LastError:           s.LastRefreshError,

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -23,6 +23,7 @@ type State struct {
 	SelectorContext          selector.Context
 	Draining                 bool
 	DrainStartedAt           time.Time
+	DataSeq                  uint64
 	LastRefreshAt            time.Time
 	NextRefreshAt            time.Time
 	LastRefreshError         string
@@ -189,6 +190,7 @@ func (s State) clone() State {
 		SelectorContext:          s.SelectorContext,
 		Draining:                 s.Draining,
 		DrainStartedAt:           s.DrainStartedAt,
+		DataSeq:                  s.DataSeq,
 		LastRefreshAt:            s.LastRefreshAt,
 		NextRefreshAt:            s.NextRefreshAt,
 		LastRefreshError:         s.LastRefreshError,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Snapshot struct {
+	Seq                uint64              `json:"seq,omitempty"`
 	GeneratedAt        time.Time           `json:"generated_at"`
 	Project            Project             `json:"project"`
 	Instance           Instance            `json:"instance"`
@@ -111,6 +112,7 @@ const (
 
 type Refresh struct {
 	PollIntervalSeconds int64           `json:"poll_interval_seconds,omitempty"`
+	DataSeq             uint64          `json:"data_seq,omitempty"`
 	Status              RefreshStatus   `json:"status,omitempty"`
 	LastRefreshAt       *time.Time      `json:"last_refresh_at,omitempty"`
 	NextRefreshAt       *time.Time      `json:"next_refresh_at,omitempty"`

--- a/internal/telemetry/snapshot_test.go
+++ b/internal/telemetry/snapshot_test.go
@@ -18,6 +18,7 @@ func TestSnapshotJSONShape(t *testing.T) {
 	perIssue := 5.0
 
 	snapshot := telemetry.Snapshot{
+		Seq:         42,
 		GeneratedAt: generatedAt,
 		Project: telemetry.Project{
 			DisplayName: "Detent",
@@ -36,6 +37,7 @@ func TestSnapshotJSONShape(t *testing.T) {
 		},
 		Refresh: telemetry.Refresh{
 			PollIntervalSeconds: 30,
+			DataSeq:             7,
 			NextRefreshAt:       new(generatedAt.Add(30 * time.Second)),
 		},
 		Counts: telemetry.Counts{
@@ -194,6 +196,7 @@ func TestSnapshotJSONShape(t *testing.T) {
 	}
 
 	for _, key := range []string{
+		"seq",
 		"generated_at",
 		"project",
 		"instance",
@@ -235,6 +238,9 @@ func TestSnapshotJSONShape(t *testing.T) {
 	if got["dashboard_url"] != "http://localhost:4101" {
 		t.Fatalf("dashboard_url = %#v", got["dashboard_url"])
 	}
+	if got["seq"] != float64(42) {
+		t.Fatalf("seq = %#v", got["seq"])
+	}
 	auth := got["auth"].(map[string]any)
 	if auth["status"] != string(telemetry.AuthStatusRecovered) || auth["last_error"] != "github authentication failed: status 401" {
 		t.Fatalf("auth = %#v", auth)
@@ -242,6 +248,9 @@ func TestSnapshotJSONShape(t *testing.T) {
 	refresh := got["refresh"].(map[string]any)
 	if refresh["poll_interval_seconds"] != float64(30) || refresh["next_refresh_at"] != "2026-05-30T22:15:30Z" {
 		t.Fatalf("refresh = %#v", refresh)
+	}
+	if refresh["data_seq"] != float64(7) {
+		t.Fatalf("refresh.data_seq = %#v", refresh["data_seq"])
 	}
 
 	counts := got["counts"].(map[string]any)

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -1688,6 +1688,15 @@ func kanbanCardFreshEntry(snapshot telemetry.Snapshot, projectID string, issueID
 	return selected, selected.issue.ID != ""
 }
 
+func snapshotProjectDataSeq(snapshot telemetry.Snapshot, projectID string) uint64 {
+	for _, project := range snapshot.Projects {
+		if project.Project.ID == projectID {
+			return project.Refresh.DataSeq
+		}
+	}
+	return snapshot.Refresh.DataSeq
+}
+
 func (s *Server) recordKanbanLaneTransition(
 	ctx context.Context,
 	projectID string,

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -134,6 +134,43 @@ func TestKanbanStateNamesAllowConfiguredOpenState(t *testing.T) {
 	}
 }
 
+func TestSnapshotProjectDataSeq(t *testing.T) {
+	t.Parallel()
+
+	snapshot := telemetry.Snapshot{
+		Refresh: telemetry.Refresh{DataSeq: 3},
+		Projects: []telemetry.ProjectSnapshot{
+			{
+				Project: telemetry.Project{ID: "alpha"},
+				Refresh: telemetry.Refresh{DataSeq: 7},
+			},
+			{
+				Project: telemetry.Project{ID: "bravo"},
+				Refresh: telemetry.Refresh{DataSeq: 9},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		projectID string
+		want      uint64
+	}{
+		{name: "project match", projectID: "bravo", want: 9},
+		{name: "fallback", projectID: "charlie", want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := snapshotProjectDataSeq(snapshot, tt.projectID); got != tt.want {
+				t.Fatalf("snapshotProjectDataSeq() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Adds publish-level snapshot sequence IDs to fresh snapshot publishes while startup snapshots remain sequence 0 and republish keeps the existing payload.
- Threads per-project poll `DataSeq` through orchestrator state, telemetry refreshes, and merged project snapshots.
- Adds kanban project data sequence lookup with top-level refresh fallback.

Fixes #1011

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual changes.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/cli ./internal/hub ./internal/telemetry ./internal/web`
- [x] `make check`