### PR TITLE
fix(orchestrator): skip human review dwell

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -132,6 +132,20 @@ func EvaluateAutoPromote(
 	return decision
 }
 
+func autoPromoteHumanReviewRequired(issue connector.Issue, cfg AutoPromoteConfig, gateCfg gate.Config) bool {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	if !cfg.Enabled {
+		return true
+	}
+	if autoPromoteOptoutLabel(issue, cfg) {
+		return true
+	}
+	if !autoPromoteAllowedIssueLabel(issue, cfg) {
+		return true
+	}
+	return gate.Effective(gateCfg).Kind == gate.KindHumanReview
+}
+
 func autoPromoteDecision(action AutoPromoteAction, reason AutoPromoteReason) AutoPromoteDecision {
 	return AutoPromoteDecision{
 		Action: action,

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -132,7 +132,7 @@ func (o *Orchestrator) autoPromoteEvaluationIssues(
 		if issueID == "" {
 			continue
 		}
-		if normalizeState(issue.State) == "todo" {
+		if normalizeState(issue.State) == "todo" && !autoPromoteIssueCompleted(state, issueID) {
 			continue
 		}
 		if _, ok := seen[issueID]; ok {
@@ -145,6 +145,14 @@ func (o *Orchestrator) autoPromoteEvaluationIssues(
 		seen[issueID] = struct{}{}
 	}
 	return out
+}
+
+func autoPromoteIssueCompleted(state *State, issueID string) bool {
+	if state == nil {
+		return false
+	}
+	_, ok := state.Completed[issueID]
+	return ok
 }
 
 func autoPromoteActiveGatePendingIssue(

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -60,7 +60,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 	}
 
 	result := autoPromoteTickResult{transitioned: map[string]struct{}{}}
-	for _, issue := range issuesInStates(issues, []string{cfg.SourceState}) {
+	for _, issue := range o.autoPromoteEvaluationIssues(state, issues, cfg) {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" {
 			continue
@@ -112,6 +112,92 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		return autoPromoteTickResult{}
 	}
 	return result
+}
+
+func (o *Orchestrator) autoPromoteEvaluationIssues(
+	state *State,
+	issues []connector.Issue,
+	cfg AutoPromoteConfig,
+) []connector.Issue {
+	out := issuesInStates(issues, []string{cfg.SourceState})
+	seen := make(map[string]struct{}, len(out))
+	for _, issue := range out {
+		if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+			seen[issueID] = struct{}{}
+		}
+	}
+
+	for _, issue := range issuesInStates(issues, o.cfg.ActiveStates) {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+		if normalizeState(issue.State) == "todo" {
+			continue
+		}
+		if _, ok := seen[issueID]; ok {
+			continue
+		}
+		if !autoPromoteActiveGatePendingIssue(issue, state, o.cfg, cfg) {
+			continue
+		}
+		out = append(out, cloneIssue(issue))
+		seen[issueID] = struct{}{}
+	}
+	return out
+}
+
+func autoPromoteActiveGatePendingIssue(
+	issue connector.Issue,
+	state *State,
+	cfg Config,
+	autoCfg AutoPromoteConfig,
+) bool {
+	autoCfg = normalizeAutoPromoteConfig(autoCfg)
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return false
+	}
+	if !stateIn(issue.State, cfg.ActiveStates) || stateIn(issue.State, cfg.TerminalStates) {
+		return false
+	}
+	switch normalizeState(issue.State) {
+	case normalizeState(autoCfg.SourceState), normalizeState(autoCfg.PassState), normalizeState(autoCfg.ReworkState):
+		return false
+	}
+	if autoPromoteHumanReviewRequired(issue, autoCfg, autoCfg.Gate) {
+		return false
+	}
+	if autoPromoteActiveDispatchInProgress(state, issueID) {
+		return false
+	}
+	if state != nil {
+		if completed, ok := state.Completed[issueID]; ok {
+			return completedActiveFinalStateReviewEligible(completed.FinalState, autoCfg.SourceState) &&
+				completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(autoCfg.Gate))
+		}
+	}
+	return issueHasOpenPullRequest(issue)
+}
+
+func autoPromoteActiveDispatchInProgress(state *State, issueID string) bool {
+	if state == nil {
+		return false
+	}
+	if _, ok := state.Running[issueID]; ok {
+		return true
+	}
+	if _, ok := state.Claimed[issueID]; ok {
+		return true
+	}
+	if _, ok := state.Retry[issueID]; ok {
+		return true
+	}
+	return false
+}
+
+func issueHasOpenPullRequest(issue connector.Issue) bool {
+	return issue.PullRequest != nil && normalizePullRequestState(issue.PullRequest.State) == "open"
 }
 
 func (o *Orchestrator) hydrateAutoPromoteWorkpadDecision(
@@ -193,6 +279,11 @@ func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
 			issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, o.cfg.AutoPromote, now)
 		}
 		targetState := staleTodoPullRequestTargetState(decision, o.cfg.AutoPromote)
+		if autoPromoteActiveGatePendingIssue(issue, state, o.cfg, o.cfg.AutoPromote) &&
+			normalizeState(targetState) == normalizeState(normalizeAutoPromoteConfig(o.cfg.AutoPromote).SourceState) &&
+			staleTodoPullRequestShouldStayActive(decision) {
+			continue
+		}
 		if targetState == "" {
 			o.logAutoPromoteDecision(issue, decision, "")
 			continue
@@ -810,6 +901,10 @@ func staleTodoPullRequestDecision(
 		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonDisabled)
 	}
 	return EvaluateAutoPromote(issue, summary, cfg, now)
+}
+
+func staleTodoPullRequestShouldStayActive(decision AutoPromoteDecision) bool {
+	return decision.Reason != AutoPromoteReasonWorkpadBlocker
 }
 
 func staleTodoPullRequestTargetState(decision AutoPromoteDecision, cfg AutoPromoteConfig) string {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -319,6 +319,179 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 	}
 }
 
+func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+
+	tests := []struct {
+		name                 string
+		issue                connector.Issue
+		wantUpdates          []autoPromoteTickUpdate
+		wantCommentFragments []string
+	}{
+		{
+			name: "promotes active completed issue directly to merging",
+			issue: func() connector.Issue {
+				issue := autoPromoteTickIssue("issue-active-ready", []string{"bug"}, &connector.PullRequest{
+					Number:                 142,
+					URL:                    "https://github.test/digitaldrywood/detent/pull/142",
+					State:                  "OPEN",
+					CIStatus:               "success",
+					CodexReviewState:       "COMMENTED",
+					CodexReviewSubmittedAt: &oldReview,
+				})
+				issue.State = "In Progress"
+				return issue
+			}(),
+			wantUpdates: []autoPromoteTickUpdate{{issueID: "issue-active-ready", state: "Merging"}},
+			wantCommentFragments: []string{
+				"Auto-promoted this issue from In Progress to Merging.",
+				"reason: ready",
+				"https://github.test/digitaldrywood/detent/pull/142",
+			},
+		},
+		{
+			name: "routes active completed issue directly to rework",
+			issue: func() connector.Issue {
+				issue := autoPromoteTickIssue("issue-active-rework", []string{"bug"}, &connector.PullRequest{
+					Number:                 143,
+					URL:                    "https://github.test/digitaldrywood/detent/pull/143",
+					State:                  "OPEN",
+					CIStatus:               "failure",
+					CodexReviewState:       "COMMENTED",
+					CodexReviewSubmittedAt: &oldReview,
+				})
+				issue.State = "In Progress"
+				return issue
+			}(),
+			wantUpdates: []autoPromoteTickUpdate{{issueID: "issue-active-rework", state: "Rework"}},
+			wantCommentFragments: []string{
+				"Auto-promote routed this issue from In Progress to Rework: current-head CI is failing.",
+				"reason: ci_not_green",
+				"https://github.test/digitaldrywood/detent/pull/143",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{
+				PollInterval:        time.Minute,
+				MaxConcurrentAgents: 1,
+				AutoPromote: AutoPromoteConfig{
+					Enabled:       true,
+					QuietDuration: 10 * time.Minute,
+					Gate:          gate.Config{Kind: gate.KindCommand},
+				},
+				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+				TerminalStates: []string{"Done", "Cancelled"},
+			})
+			state := newState(cfg)
+			state.Completed[tt.issue.ID] = Completed{
+				Issue:      tt.issue,
+				FinalState: FinalStateCompleted,
+			}
+			mergingSlot := dispatchTestIssue(tt.issue.ID+"-merging-slot", "Merging")
+			state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
+			tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{tt.issue}}
+			orch := &Orchestrator{
+				cfg:       cfg,
+				connector: tracker,
+				logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+
+			orch.tick(context.Background(), &state, now)
+
+			if !reflect.DeepEqual(tracker.updates, tt.wantUpdates) {
+				t.Fatalf("updates = %#v, want %#v", tracker.updates, tt.wantUpdates)
+			}
+			if len(tracker.comments) != 1 {
+				t.Fatalf("comments = %#v, want one auto-promote audit comment", tracker.comments)
+			}
+			for _, fragment := range tt.wantCommentFragments {
+				if !strings.Contains(tracker.comments[0].body, fragment) {
+					t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+				}
+			}
+			if _, ok := state.Completed[tt.issue.ID]; ok {
+				t.Fatalf("Completed[%q] present after auto-promote transition", tt.issue.ID)
+			}
+		})
+	}
+}
+
+func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 12, 30, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-restart-gate-pending", []string{"bug"}, &connector.PullRequest{
+		Number:                 144,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/144",
+		State:                  "OPEN",
+		CIStatus:               "pending",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	issue.State = "In Progress"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	mergingSlot := dispatchTestIssue("issue-restart-merging-slot", "Merging")
+	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates with pending CI = %#v, want none", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments with pending CI = %#v, want none", tracker.comments)
+	}
+	if _, ok := state.Running[issue.ID]; ok {
+		t.Fatalf("Running[%q] present after pending restart recovery tick", issue.ID)
+	}
+
+	tracker.stateIssues[0].PullRequest.CIStatus = "success"
+	orch.tick(context.Background(), &state, now.Add(time.Minute))
+
+	wantUpdates := []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}
+	if !reflect.DeepEqual(tracker.updates, wantUpdates) {
+		t.Fatalf("updates after CI pass = %#v, want %#v", tracker.updates, wantUpdates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments after CI pass = %#v, want one auto-promote audit comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Auto-promoted this issue from In Progress to Merging.",
+		"reason: ready",
+		"https://github.test/digitaldrywood/detent/pull/144",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+}
+
 func TestTickAutoPromoteHydratesWorkpadBlockerBeforeTransition(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -353,6 +353,27 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 			},
 		},
 		{
+			name: "promotes completed todo issue directly to merging",
+			issue: func() connector.Issue {
+				issue := autoPromoteTickIssue("issue-todo-ready", []string{"bug"}, &connector.PullRequest{
+					Number:                 145,
+					URL:                    "https://github.test/digitaldrywood/detent/pull/145",
+					State:                  "OPEN",
+					CIStatus:               "success",
+					CodexReviewState:       "COMMENTED",
+					CodexReviewSubmittedAt: &oldReview,
+				})
+				issue.State = "Todo"
+				return issue
+			}(),
+			wantUpdates: []autoPromoteTickUpdate{{issueID: "issue-todo-ready", state: "Merging"}},
+			wantCommentFragments: []string{
+				"Auto-promoted this issue from Todo to Merging.",
+				"reason: ready",
+				"https://github.test/digitaldrywood/detent/pull/145",
+			},
+		},
+		{
 			name: "routes active completed issue directly to rework",
 			issue: func() connector.Issue {
 				issue := autoPromoteTickIssue("issue-active-rework", []string{"bug"}, &connector.PullRequest{

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -35,8 +35,7 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			completed.FinalState,
 			o.cfg.ActiveStates,
 			o.cfg.TerminalStates,
-			cfg.SourceState,
-			gateRequiresPullRequest(cfg.Gate),
+			cfg,
 		)
 		if targetState == "" {
 			continue
@@ -139,28 +138,35 @@ func completedActiveReviewTargetState(
 	finalState string,
 	activeStates []string,
 	terminalStates []string,
-	reviewState string,
-	requirePullRequest bool,
+	cfg AutoPromoteConfig,
 ) string {
+	cfg = normalizeAutoPromoteConfig(cfg)
 	if !stateIn(issue.State, activeStates) || stateIn(issue.State, terminalStates) {
 		return ""
 	}
-	reviewState = strings.TrimSpace(reviewState)
-	if reviewState == "" {
-		reviewState = autoPromoteSourceState
-	}
+	reviewState := cfg.SourceState
 	switch normalizeState(issue.State) {
 	case normalizeState(reviewState), normalizeState(autoPromoteReworkState), normalizeState(autoPromoteMergingState):
 		return ""
 	}
-	if !completedActiveIssueReadyForReview(issue, requirePullRequest) {
+	if !completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(cfg.Gate)) {
 		return ""
 	}
+	if !autoPromoteHumanReviewRequired(issue, cfg, cfg.Gate) {
+		return ""
+	}
+	if completedActiveFinalStateReviewEligible(finalState, reviewState) {
+		return reviewState
+	}
+	return ""
+}
+
+func completedActiveFinalStateReviewEligible(finalState string, reviewState string) bool {
 	switch normalizeState(finalState) {
 	case "", normalizeState(FinalStateCompleted), normalizeState(reviewState):
-		return reviewState
+		return true
 	default:
-		return ""
+		return false
 	}
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -4,63 +4,122 @@ import (
 	"context"
 	"errors"
 	"reflect"
-	"strings"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 )
 
 func TestCompletedActiveReviewTargetState(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name               string
-		issue              connector.Issue
-		finalState         string
-		reviewState        string
-		requirePullRequest bool
-		want               string
+		name       string
+		issue      connector.Issue
+		finalState string
+		cfg        AutoPromoteConfig
+		want       string
 	}{
 		{
-			name:               "todo completed with open pull request advances to human review",
-			issue:              completionTransitionIssue("Todo", "OPEN"),
-			finalState:         FinalStateCompleted,
-			requirePullRequest: true,
-			want:               autoPromoteSourceState,
+			name:       "todo completed with open pull request advances to human review when disabled",
+			issue:      completionTransitionIssue("Todo", "OPEN"),
+			finalState: FinalStateCompleted,
+			want:       autoPromoteSourceState,
 		},
 		{
-			name:               "in progress completed with open pull request advances to human review",
-			issue:              completionTransitionIssue("In Progress", "OPEN"),
-			finalState:         FinalStateCompleted,
-			requirePullRequest: true,
-			want:               autoPromoteSourceState,
+			name:       "in progress completed with open pull request advances to human review when disabled",
+			issue:      completionTransitionIssue("In Progress", "OPEN"),
+			finalState: FinalStateCompleted,
+			want:       autoPromoteSourceState,
 		},
 		{
-			name:               "artifact todo completed without pull request advances to configured review",
-			issue:              completionTransitionIssue("Todo", ""),
-			finalState:         FinalStateCompleted,
-			reviewState:        "Review",
-			requirePullRequest: false,
-			want:               "Review",
+			name:       "artifact todo completed without pull request advances to configured review",
+			issue:      completionTransitionIssue("Todo", ""),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				SourceState: "Review",
+				Gate:        gate.Config{Kind: gate.KindArtifact},
+			},
+			want: "Review",
 		},
 		{
-			name:               "rework completed with open pull request waits for dispatch",
-			issue:              completionTransitionIssue("Rework", "OPEN"),
-			finalState:         FinalStateCompleted,
-			requirePullRequest: true,
+			name:       "rework completed with open pull request waits for dispatch",
+			issue:      completionTransitionIssue("Rework", "OPEN"),
+			finalState: FinalStateCompleted,
 		},
 		{
-			name:               "merging completed with open pull request waits for merge lifecycle",
-			issue:              completionTransitionIssue("Merging", "OPEN"),
-			finalState:         FinalStateCompleted,
-			requirePullRequest: true,
+			name:       "merging completed with open pull request waits for merge lifecycle",
+			issue:      completionTransitionIssue("Merging", "OPEN"),
+			finalState: FinalStateCompleted,
 		},
 		{
-			name:               "todo completed without pull request waits when pull request required",
-			issue:              completionTransitionIssue("Todo", ""),
-			finalState:         FinalStateCompleted,
-			requirePullRequest: true,
+			name:       "todo completed without pull request waits when pull request required",
+			issue:      completionTransitionIssue("Todo", ""),
+			finalState: FinalStateCompleted,
+		},
+		{
+			name:       "command gate with auto promote enabled skips human review target",
+			issue:      completionTransitionIssue("In Progress", "OPEN"),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindCommand},
+			},
+		},
+		{
+			name:       "human review gate keeps human review target",
+			issue:      completionTransitionIssue("In Progress", "OPEN"),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled: true,
+				Gate:    gate.Config{Kind: gate.KindHumanReview},
+			},
+			want: autoPromoteSourceState,
+		},
+		{
+			name: "opt out label keeps human review target",
+			issue: func() connector.Issue {
+				issue := completionTransitionIssue("In Progress", "OPEN")
+				issue.Labels = []string{"requires-human-review"}
+				return issue
+			}(),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled:     true,
+				OptoutLabel: "requires-human-review",
+				Gate:        gate.Config{Kind: gate.KindCommand},
+			},
+			want: autoPromoteSourceState,
+		},
+		{
+			name: "allowlist miss keeps human review target",
+			issue: func() connector.Issue {
+				issue := completionTransitionIssue("In Progress", "OPEN")
+				issue.Labels = []string{"bug"}
+				return issue
+			}(),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled:            true,
+				AllowedIssueLabels: []string{"release"},
+				Gate:               gate.Config{Kind: gate.KindCommand},
+			},
+			want: autoPromoteSourceState,
+		},
+		{
+			name: "allowlist hit skips human review target",
+			issue: func() connector.Issue {
+				issue := completionTransitionIssue("In Progress", "OPEN")
+				issue.Labels = []string{"release"}
+				return issue
+			}(),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled:            true,
+				AllowedIssueLabels: []string{"release"},
+				Gate:               gate.Config{Kind: gate.KindCommand},
+			},
 		},
 	}
 
@@ -70,17 +129,12 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			reviewState := tt.reviewState
-			if reviewState == "" {
-				reviewState = autoPromoteSourceState
-			}
 			got := completedActiveReviewTargetState(
 				tt.issue,
 				tt.finalState,
 				activeStates,
 				terminalStates,
-				reviewState,
-				tt.requirePullRequest,
+				tt.cfg,
 			)
 			if got != tt.want {
 				t.Fatalf("completedActiveReviewTargetState() = %q, want %q", got, tt.want)
@@ -89,7 +143,7 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 	}
 }
 
-func TestTransitionCompletedActiveIssuesDirectlyPromotesZeroQuietReview(t *testing.T) {
+func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 7, 14, 0, 0, 0, time.UTC)
@@ -107,7 +161,8 @@ func TestTransitionCompletedActiveIssuesDirectlyPromotesZeroQuietReview(t *testi
 	cfg := normalizeConfig(Config{
 		AutoPromote: AutoPromoteConfig{
 			Enabled:       true,
-			QuietDuration: 0,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand},
 		},
 		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
 		TerminalStates: []string{"Done", "Cancelled"},
@@ -121,36 +176,27 @@ func TestTransitionCompletedActiveIssuesDirectlyPromotesZeroQuietReview(t *testi
 
 	result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
 
-	if _, ok := result.transitioned[issue.ID]; !ok {
-		t.Fatalf("transitioned[%q] missing", issue.ID)
+	if len(result.transitioned) != 0 {
+		t.Fatalf("transitioned = %#v, want none", result.transitioned)
 	}
-	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
-		t.Fatalf("updates = %#v, want %#v", got, want)
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no backend write", tracker.updates)
 	}
-	if len(result.dispatchCandidates) != 1 || result.dispatchCandidates[0].State != "Merging" {
-		t.Fatalf("dispatchCandidates = %#v, want one Merging issue", result.dispatchCandidates)
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatchCandidates = %#v, want none", result.dispatchCandidates)
 	}
-	if len(tracker.comments) != 1 {
-		t.Fatalf("comments = %#v, want one auto-promote audit comment", tracker.comments)
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none", tracker.comments)
 	}
-	for _, fragment := range []string{
-		"Auto-promoted this issue from In Progress to Merging.",
-		"reason: ready",
-		"https://github.test/digitaldrywood/detent/pull/17",
-	} {
-		if !strings.Contains(tracker.comments[0].body, fragment) {
-			t.Fatalf("comment %q missing %q", tracker.comments[0].body, fragment)
-		}
+	if got := state.Completed[issue.ID].Issue.State; got != "In Progress" {
+		t.Fatalf("Completed issue state = %q, want In Progress", got)
 	}
-	if got := state.Completed[issue.ID].Issue.State; got != "Merging" {
-		t.Fatalf("Completed issue state = %q, want Merging", got)
-	}
-	if len(state.RecentEvents) == 0 || !strings.Contains(state.RecentEvents[len(state.RecentEvents)-1].Message, "from In Progress to Merging") {
-		t.Fatalf("RecentEvents = %#v, want direct auto-promote audit event", state.RecentEvents)
+	if len(state.RecentEvents) != 0 {
+		t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)
 	}
 }
 
-func TestTransitionCompletedActiveIssuesKeepsHumanReviewForNonZeroQuietReview(t *testing.T) {
+func TestTransitionCompletedActiveIssuesKeepsHumanReviewWhenRequired(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 7, 14, 0, 0, 0, time.UTC)
@@ -169,6 +215,7 @@ func TestTransitionCompletedActiveIssuesKeepsHumanReviewForNonZeroQuietReview(t 
 		AutoPromote: AutoPromoteConfig{
 			Enabled:       true,
 			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindHumanReview},
 		},
 		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
 		TerminalStates: []string{"Done", "Cancelled"},

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -397,6 +397,7 @@ const (
 	dispatchSkipInactiveState            = "inactive_state"
 	dispatchSkipTerminalState            = "terminal_state"
 	dispatchSkipPullRequestHydration     = "pull_request_hydration_unavailable"
+	dispatchSkipAutoPromoteGatePending   = "auto_promote_gate_pending"
 	dispatchSkipMergedPullRequest        = "merged_pull_request_reconciliation_pending"
 	dispatchSkipDuplicatePullRequest     = "duplicate_pull_request_work"
 	dispatchSkipUnauthorized             = "unauthorized"
@@ -430,6 +431,9 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	}
 	if pullRequestHydrationBlocksDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipPullRequestHydration}
+	}
+	if autoPromoteActiveGatePendingIssue(issue, state, p.cfg, p.cfg.AutoPromote) {
+		return dispatchableDecision{reason: dispatchSkipAutoPromoteGatePending}
 	}
 	if mergedPullRequestReconciliationPending(issue, p.cfg) {
 		return dispatchableDecision{reason: dispatchSkipMergedPullRequest}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -253,6 +253,34 @@ func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
 	}
 }
 
+func TestDispatchableSkipsAutoPromoteGatePendingActiveIssue(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 13, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := dispatchTestIssueWithPullRequest("issue-gate-pending", "In Progress", "OPEN")
+	issue.PullRequest.CIStatus = "pending"
+	state := newState(cfg)
+	orch := Orchestrator{cfg: cfg}
+
+	decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
+	if decision.dispatchable {
+		t.Fatal("dispatchable gate-pending active issue = true, want false")
+	}
+	if decision.reason != dispatchSkipAutoPromoteGatePending {
+		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipAutoPromoteGatePending)
+	}
+}
+
 func TestHandleRunResultRecordsBudgetRefusalAndComment(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -121,7 +121,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			fetched,
 			o.reviewPlanIssues(ctx, state, fetched.status, now),
 		)
-		autoPromoted := o.autoPromoteHumanReviewIssues(ctx, state, fetched.status, now)
+		autoPromoted := o.autoPromoteHumanReviewIssues(ctx, state, mergeIssueSlices(fetched.status, fetched.candidates), now)
 		fetched = filterReconciledTickIssues(
 			state,
 			fetched,


### PR DESCRIPTION
## Summary

- Keep skip-human-review auto-promote issues in their active lane until the gate passes, then transition directly to the pass or rework state.
- Recover restart-pending active issues with linked open PRs and prevent dispatch from selecting them for another implementation run.
- Preserve Human Review behavior for disabled auto-promote, opt-out labels, allowlist misses, human-review gates, and Workpad blockers.

Fixes #1014

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`