### PR TITLE
refactor(workitem): gate creation on upserter

### DIFF
--- a/internal/cli/work_item.go
+++ b/internal/cli/work_item.go
@@ -120,13 +120,6 @@ func runWorkItemAdd(ctx context.Context, configPath string, projectID string, re
 	if err := workflow.Config.Validate(); err != nil {
 		return result, err
 	}
-	if !workitem.SupportsTracker(workflow.Config.Tracker.Kind) {
-		return workitem.Create(ctx, workitem.Target{
-			ProjectID: projectConfig.ID,
-			Workflow:  workflow.Config,
-		}, req)
-	}
-
 	conn, err := workItemConnectorFromWorkflow(ctx, workflow.Config)
 	if err != nil {
 		return result, err

--- a/internal/cli/work_item_test.go
+++ b/internal/cli/work_item_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
 	"testing"
@@ -11,6 +12,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/cli"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector/local"
+	"github.com/digitaldrywood/detent/internal/workitem"
 )
 
 func TestWorkItemAddCreatesLocalSQLiteItem(t *testing.T) {
@@ -97,6 +99,49 @@ func TestWorkItemAddCreatesLocalSQLiteItem(t *testing.T) {
 	}
 }
 
+func TestWorkItemAddRejectsMemoryTrackerAsUnsupported(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "video")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	workflowPath := filepath.Join(workdir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(memoryWorkItemWorkflow()), 0o600); err != nil {
+		t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+	}
+	configPath := filepath.Join(root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{{
+		ID:       "video",
+		Workflow: workflowPath,
+		Workdir:  workdir,
+		Weight:   1,
+		Priority: 0,
+	}})
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return false }))
+	cmd.SetOut(&bytes.Buffer{})
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"work-item", "add", "video",
+		"--title", "Author beat visuals",
+		"--body", "Render storyboard frames",
+	})
+	err := cmd.Execute()
+	if err == nil {
+		t.Fatal("Execute() error = nil, want unsupported tracker")
+	}
+	var itemErr *workitem.Error
+	if !errors.As(err, &itemErr) {
+		t.Fatalf("Execute() error = %v, want workitem.Error", err)
+	}
+	if itemErr.Code != workitem.CodeUnsupportedTracker {
+		t.Fatalf("error code = %q, want %q", itemErr.Code, workitem.CodeUnsupportedTracker)
+	}
+}
+
 func localSQLiteWorkItemWorkflow() string {
 	return `---
 tracker:
@@ -104,6 +149,26 @@ tracker:
   local_sqlite:
     path: .detent/work-items.db
     project_id: video
+  active_states:
+    - Todo
+    - In Progress
+  observed_states:
+    - Backlog
+    - Blocked
+  terminal_states:
+    - Done
+workspace:
+  root: .detent/workspaces
+  source_root: .
+---
+Prompt
+`
+}
+
+func memoryWorkItemWorkflow() string {
+	return `---
+tracker:
+  kind: memory
   active_states:
     - Todo
     - In Progress

--- a/internal/workitem/workitem.go
+++ b/internal/workitem/workitem.go
@@ -98,9 +98,6 @@ func Create(ctx context.Context, target Target, req Request) (Response, error) {
 	if err != nil {
 		return Response{}, err
 	}
-	if !SupportsTracker(target.Workflow.Tracker.Kind) {
-		return Response{}, &Error{Code: CodeUnsupportedTracker, Message: "tracker kind does not support runtime work-item creation"}
-	}
 	if target.Connector == nil {
 		return Response{}, &Error{Code: CodeConnectorUnavailable, Message: "connector is unavailable"}
 	}
@@ -135,15 +132,6 @@ func Create(ctx context.Context, target Target, req Request) (Response, error) {
 		return Response{}, &Error{Code: CodeSubmissionFailed, Message: "create work item failed", Err: err}
 	}
 	return Response{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL}, nil
-}
-
-func SupportsTracker(kind string) bool {
-	switch strings.TrimSpace(kind) {
-	case workflowconfig.TrackerLocalSQLite, workflowconfig.TrackerGitHubLocal:
-		return true
-	default:
-		return false
-	}
 }
 
 func WorkItemURL(base string, projectID string) string {

--- a/internal/workitem/workitem_test.go
+++ b/internal/workitem/workitem_test.go
@@ -131,23 +131,59 @@ func TestCreateRejectsDuplicateIdentifier(t *testing.T) {
 	}
 }
 
-func TestCreateRejectsUnsupportedTracker(t *testing.T) {
+func TestCreateConnectorCapabilityGate(t *testing.T) {
 	t.Parallel()
 
-	cfg := localSQLiteWorkflow()
-	cfg.Tracker.Kind = workflowconfig.TrackerGitHub
-	_, err := workitem.Create(context.Background(), workitem.Target{
-		Workflow: cfg,
-	}, workitem.Request{
-		Title:       "title",
-		Description: "body",
-	})
-	var itemErr *workitem.Error
-	if !errors.As(err, &itemErr) {
-		t.Fatalf("Create() error = %v, want workitem.Error", err)
+	tests := []struct {
+		name string
+		conn connector.Connector
+		want workitem.ErrorCode
+	}{
+		{
+			name: "upserter succeeds",
+			conn: &creatorConnector{},
+		},
+		{
+			name: "connector without upserter is unsupported",
+			conn: readonlyConnector{},
+			want: workitem.CodeUnsupportedTracker,
+		},
+		{
+			name: "nil connector is unavailable",
+			want: workitem.CodeConnectorUnavailable,
+		},
 	}
-	if itemErr.Code != workitem.CodeUnsupportedTracker {
-		t.Fatalf("error code = %q, want %q", itemErr.Code, workitem.CodeUnsupportedTracker)
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := workitem.Create(context.Background(), workitem.Target{
+				Workflow:            localSQLiteWorkflow(),
+				Connector:           tt.conn,
+				IdentifierGenerator: func() (string, error) { return "wi-gate", nil },
+			}, workitem.Request{
+				Title:       "title",
+				Description: "body",
+			})
+			if tt.want == "" {
+				if err != nil {
+					t.Fatalf("Create() error = %v", err)
+				}
+				if got.Identifier != "wi-gate" {
+					t.Fatalf("Identifier = %q, want wi-gate", got.Identifier)
+				}
+				return
+			}
+
+			var itemErr *workitem.Error
+			if !errors.As(err, &itemErr) {
+				t.Fatalf("Create() error = %v, want workitem.Error", err)
+			}
+			if itemErr.Code != tt.want {
+				t.Fatalf("error code = %q, want %q", itemErr.Code, tt.want)
+			}
+		})
 	}
 }
 
@@ -204,4 +240,38 @@ func (c *creatorConnector) SetField(context.Context, string, string, string) err
 func (c *creatorConnector) UpsertIssues(_ context.Context, issues []connector.Issue) error {
 	c.upserts = append(c.upserts, issues...)
 	return nil
+}
+
+type readonlyConnector struct{}
+
+func (readonlyConnector) Name() string {
+	return connector.BackendMemory.String()
+}
+
+func (readonlyConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (readonlyConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (readonlyConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (readonlyConnector) CreateComment(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (readonlyConnector) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (readonlyConnector) SetAssignee(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (readonlyConnector) SetField(context.Context, string, string, string) error {
+	return connector.ErrNotImplemented
 }


### PR DESCRIPTION
## Summary

- Replace the work-item tracker-kind allowlist with the existing `IssueUpserter` connector assertion.
- Route CLI work-item creation through connector construction so unsupported trackers return `unsupported_tracker` from the connector path.
- Add workitem and CLI regression coverage for upserter, non-upserter, and nil connector behavior.

Fixes #1025

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `rg SupportsTracker`
- [x] `go test ./internal/workitem ./internal/cli`
- [x] `make check`
