### PR TITLE
fix(web): key kanban overlay by data seq

### DIFF
--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -26,33 +26,34 @@ import (
 )
 
 type kanbanMutationLocks struct {
-	mu      sync.Mutex
-	locks   map[string]*sync.Mutex
-	states  map[string]kanbanPendingState
-	removed map[string]kanbanPendingRemoval
+	mu       sync.Mutex
+	locks    map[string]*sync.Mutex
+	states   map[string]kanbanPendingState
+	removed  map[string]kanbanPendingRemoval
+	reverted map[string]kanbanRevertNotice
 }
 
 type kanbanPendingState struct {
-	snapshot    string
-	current     string
-	project     string
-	issue       telemetry.Issue
-	status      kanbanPendingStateStatus
-	snapshotAt  time.Time
-	confirmedAt time.Time
+	snapshot       string
+	current        string
+	project        string
+	issue          telemetry.Issue
+	dataSeqAtWrite uint64
+	contradictions int
 }
 
 type kanbanPendingRemoval struct {
-	snapshot  string
-	removedAt time.Time
+	snapshot       string
+	removedAt      time.Time
+	dataSeqAtWrite uint64
 }
 
-type kanbanPendingStateStatus string
-
-const (
-	kanbanPendingStateAwaitingCatchup kanbanPendingStateStatus = "awaiting_catchup"
-	kanbanPendingStateConfirmed       kanbanPendingStateStatus = "confirmed"
-)
+type kanbanRevertNotice struct {
+	identifier string
+	from       string
+	to         string
+	at         time.Time
+}
 
 type kanbanSnapshotIssueEntry struct {
 	issue           telemetry.Issue
@@ -104,18 +105,20 @@ type kanbanCommentMutationRequest struct {
 }
 
 const (
-	kanbanDialogContentTarget = "#kanban-dialog-content"
-	kanbanProjectBoardTarget  = "#snapshot"
-	kanbanFleetBoardTarget    = "#snapshot"
-	kanbanDialogSucceeded     = "kanbanActionSucceeded"
-	kanbanRemovalPendingTTL   = 5 * time.Minute
+	kanbanDialogContentTarget       = "#kanban-dialog-content"
+	kanbanProjectBoardTarget        = "#snapshot"
+	kanbanFleetBoardTarget          = "#snapshot"
+	kanbanDialogSucceeded           = "kanbanActionSucceeded"
+	kanbanOverlayContradictionLimit = 2
+	kanbanRemovalPendingTTL         = 5 * time.Minute
 )
 
 func newKanbanMutationLocks() *kanbanMutationLocks {
 	return &kanbanMutationLocks{
-		locks:   map[string]*sync.Mutex{},
-		states:  map[string]kanbanPendingState{},
-		removed: map[string]kanbanPendingRemoval{},
+		locks:    map[string]*sync.Mutex{},
+		states:   map[string]kanbanPendingState{},
+		removed:  map[string]kanbanPendingRemoval{},
+		reverted: map[string]kanbanRevertNotice{},
 	}
 }
 
@@ -143,7 +146,7 @@ func (l *kanbanMutationLocks) lockFor(key string) *sync.Mutex {
 	return lock
 }
 
-func (l *kanbanMutationLocks) cardState(key string, issueID string, snapshotState string, snapshotAt time.Time) string {
+func (l *kanbanMutationLocks) cardState(key string, issueID string, snapshotState string, dataSeq uint64) string {
 	stateKey := kanbanMutationStateKey(key, issueID)
 	if stateKey == "" {
 		return snapshotState
@@ -152,44 +155,39 @@ func (l *kanbanMutationLocks) cardState(key string, issueID string, snapshotStat
 	l.mu.Lock()
 	defer l.mu.Unlock()
 
-	return l.cardStateLocked(stateKey, snapshotState, snapshotAt)
+	return l.cardStateLocked(stateKey, snapshotState, dataSeq)
 }
 
-func (l *kanbanMutationLocks) cardStateLocked(stateKey string, snapshotState string, snapshotAt time.Time) string {
+func (l *kanbanMutationLocks) cardStateLocked(stateKey string, snapshotState string, dataSeq uint64) string {
 	pending, ok := l.states[stateKey]
 	if !ok {
 		return snapshotState
 	}
-	switch pending.status {
-	case kanbanPendingStateConfirmed:
-		if !pending.confirmedAt.IsZero() && !snapshotAt.IsZero() && !snapshotAt.After(pending.confirmedAt) {
-			return pending.current
-		}
-		if normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.current) {
-			return snapshotState
-		}
+	if dataSeq <= pending.dataSeqAtWrite {
+		return pending.current
+	}
+
+	switch {
+	case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.current):
 		delete(l.states, stateKey)
 		return snapshotState
-	default:
-		if !pending.snapshotAt.IsZero() && !snapshotAt.IsZero() && snapshotAt.Before(pending.snapshotAt) {
-			return pending.current
-		}
-		switch {
-		case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot):
-			return pending.current
-		case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.current):
-			pending.status = kanbanPendingStateConfirmed
-			pending.confirmedAt = snapshotAt
+	case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot):
+		pending.contradictions++
+		if pending.contradictions < kanbanOverlayContradictionLimit {
 			l.states[stateKey] = pending
-			return snapshotState
-		default:
-			delete(l.states, stateKey)
-			return snapshotState
+			return pending.current
 		}
+		delete(l.states, stateKey)
+		l.noteRevertLocked(stateKey, pending, snapshotState)
+		return snapshotState
+	default:
+		delete(l.states, stateKey)
+		l.noteRevertLocked(stateKey, pending, snapshotState)
+		return snapshotState
 	}
 }
 
-func (l *kanbanMutationLocks) noteCardState(key string, projectID string, issue telemetry.Issue, snapshotState string, currentState string, snapshotAt time.Time) {
+func (l *kanbanMutationLocks) noteCardState(key string, projectID string, issue telemetry.Issue, snapshotState string, currentState string, dataSeqAtWrite uint64) {
 	issue.ID = strings.TrimSpace(issue.ID)
 	stateKey := kanbanMutationStateKey(key, issue.ID)
 	if stateKey == "" || strings.TrimSpace(currentState) == "" {
@@ -207,13 +205,13 @@ func (l *kanbanMutationLocks) noteCardState(key string, projectID string, issue 
 		snapshotState = pending.snapshot
 	}
 	delete(l.removed, stateKey)
+	delete(l.reverted, stateKey)
 	l.states[stateKey] = kanbanPendingState{
-		snapshot:   strings.TrimSpace(snapshotState),
-		current:    strings.TrimSpace(currentState),
-		project:    projectID,
-		issue:      cloneKanbanIssue(issue),
-		status:     kanbanPendingStateAwaitingCatchup,
-		snapshotAt: snapshotAt,
+		snapshot:       strings.TrimSpace(snapshotState),
+		current:        strings.TrimSpace(currentState),
+		project:        projectID,
+		issue:          cloneKanbanIssue(issue),
+		dataSeqAtWrite: dataSeqAtWrite,
 	}
 }
 
@@ -222,6 +220,8 @@ func (l *kanbanMutationLocks) pendingMovedCards(key string, projectID string, sn
 	if key == "" {
 		return nil
 	}
+	projectID = strings.TrimSpace(projectID)
+	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -237,7 +237,6 @@ func (l *kanbanMutationLocks) pendingMovedCards(key string, projectID string, sn
 			continue
 		}
 		present[stateKey] = struct{}{}
-		l.cardStateLocked(stateKey, entry.state, snapshot.GeneratedAt)
 	}
 	for _, row := range snapshot.Completed {
 		issue := row.Issue
@@ -253,10 +252,9 @@ func (l *kanbanMutationLocks) pendingMovedCards(key string, projectID string, sn
 			continue
 		}
 		snapshotState := strings.TrimSpace(issue.State)
-		l.cardStateLocked(stateKey, snapshotState, snapshot.GeneratedAt)
+		l.cardStateLocked(stateKey, snapshotState, dataSeq)
 	}
 
-	projectID = strings.TrimSpace(projectID)
 	out := []telemetry.Issue{}
 	for stateKey, pending := range l.states {
 		if _, ok := present[stateKey]; ok {
@@ -295,6 +293,8 @@ func (l *kanbanMutationLocks) snapshotCardStates(key string, projectID string, s
 	if key == "" {
 		return nil
 	}
+	projectID = strings.TrimSpace(projectID)
+	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
 
 	l.mu.Lock()
 	defer l.mu.Unlock()
@@ -309,7 +309,7 @@ func (l *kanbanMutationLocks) snapshotCardStates(key string, projectID string, s
 		if _, ok := l.states[stateKey]; !ok {
 			continue
 		}
-		state := l.cardStateLocked(stateKey, entry.state, snapshot.GeneratedAt)
+		state := l.cardStateLocked(stateKey, entry.state, dataSeq)
 		if strings.TrimSpace(state) != "" {
 			out[stateKey] = state
 		}
@@ -320,7 +320,7 @@ func (l *kanbanMutationLocks) snapshotCardStates(key string, projectID string, s
 	return out
 }
 
-func (l *kanbanMutationLocks) cardRemoved(key string, issueID string, snapshotState string) bool {
+func (l *kanbanMutationLocks) cardRemoved(key string, issueID string, snapshotState string, dataSeq uint64) bool {
 	stateKey := kanbanMutationStateKey(key, issueID)
 	if stateKey == "" {
 		return false
@@ -337,6 +337,9 @@ func (l *kanbanMutationLocks) cardRemoved(key string, issueID string, snapshotSt
 		delete(l.removed, stateKey)
 		return false
 	}
+	if dataSeq <= removed.dataSeqAtWrite {
+		return true
+	}
 	if normalizeKanbanState(snapshotState) == normalizeKanbanState(removed.snapshot) {
 		return true
 	}
@@ -344,7 +347,7 @@ func (l *kanbanMutationLocks) cardRemoved(key string, issueID string, snapshotSt
 	return false
 }
 
-func (l *kanbanMutationLocks) noteCardRemoved(key string, issueID string, snapshotState string) {
+func (l *kanbanMutationLocks) noteCardRemoved(key string, issueID string, snapshotState string, dataSeqAtWrite uint64) {
 	stateKey := kanbanMutationStateKey(key, issueID)
 	if stateKey == "" {
 		return
@@ -352,11 +355,61 @@ func (l *kanbanMutationLocks) noteCardRemoved(key string, issueID string, snapsh
 
 	l.mu.Lock()
 	delete(l.states, stateKey)
+	delete(l.reverted, stateKey)
 	l.removed[stateKey] = kanbanPendingRemoval{
-		snapshot:  strings.TrimSpace(snapshotState),
-		removedAt: time.Now(),
+		snapshot:       strings.TrimSpace(snapshotState),
+		removedAt:      time.Now(),
+		dataSeqAtWrite: dataSeqAtWrite,
 	}
 	l.mu.Unlock()
+}
+
+func (l *kanbanMutationLocks) noteRevertLocked(stateKey string, pending kanbanPendingState, snapshotState string) {
+	identifier := strings.TrimSpace(pending.issue.Identifier)
+	if identifier == "" {
+		identifier = strings.TrimSpace(pending.issue.ID)
+	}
+	to := strings.TrimSpace(snapshotState)
+	if to == "" {
+		to = strings.TrimSpace(pending.snapshot)
+	}
+	l.reverted[stateKey] = kanbanRevertNotice{
+		identifier: identifier,
+		from:       strings.TrimSpace(pending.current),
+		to:         to,
+		at:         time.Now(),
+	}
+}
+
+func (l *kanbanMutationLocks) consumeRevertNotices(key string, projectID string) []kanbanRevertNotice {
+	key = strings.TrimSpace(key)
+	projectID = strings.TrimSpace(projectID)
+	if key == "" && projectID != "" {
+		key = "project:" + projectID
+	}
+	prefix := ""
+	if key != "" {
+		prefix = key + "\x00"
+	}
+
+	l.mu.Lock()
+	defer l.mu.Unlock()
+
+	notices := []kanbanRevertNotice{}
+	for stateKey, notice := range l.reverted {
+		if prefix != "" && !strings.HasPrefix(stateKey, prefix) {
+			continue
+		}
+		notices = append(notices, notice)
+		delete(l.reverted, stateKey)
+	}
+	sort.SliceStable(notices, func(i, j int) bool {
+		if !notices[i].at.Equal(notices[j].at) {
+			return notices[i].at.Before(notices[j].at)
+		}
+		return notices[i].identifier < notices[j].identifier
+	})
+	return notices
 }
 
 func kanbanMutationStateKey(key string, issueID string) string {
@@ -453,7 +506,7 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 	var feedbackStatus int
 	err := s.kanbanMutations.withLock(target.key, func() error {
 		currentState := req.currentState
-		ok, current, snapshotState, snapshotIssue, snapshotAt := s.kanbanCardFresh(target.key, req.projectID, req.issueID, req.currentState)
+		ok, current, snapshotState, snapshotIssue, dataSeqAtWrite := s.kanbanCardFresh(target.key, req.projectID, req.issueID, req.currentState)
 		if !ok {
 			feedback = "Card is stale; refresh and retry."
 			if current != "" {
@@ -480,14 +533,14 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 				return err
 			}
 			s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move_field")
-			s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, snapshotAt)
+			s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
 			return nil
 		}
 		if err := target.connector.UpdateIssueState(c.Request().Context(), req.issueID, req.targetState); err != nil {
 			return err
 		}
 		s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move")
-		s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, snapshotAt)
+		s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
 		return nil
 	})
 	if feedback != "" {
@@ -559,7 +612,7 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 	var feedbackStatus int
 	err := s.kanbanMutations.withLock(target.key, func() error {
 		currentState := req.currentState
-		ok, current, snapshotState, _, _ := s.kanbanCardFresh(target.key, req.projectID, req.issueID, req.currentState)
+		ok, current, snapshotState, _, dataSeqAtWrite := s.kanbanCardFresh(target.key, req.projectID, req.issueID, req.currentState)
 		if !ok {
 			feedback = "Card is stale; refresh and retry."
 			if current != "" {
@@ -582,7 +635,7 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 			if strings.TrimSpace(snapshotState) == "" {
 				snapshotState = currentState
 			}
-			s.kanbanMutations.noteCardRemoved(target.key, req.issueID, snapshotState)
+			s.kanbanMutations.noteCardRemoved(target.key, req.issueID, snapshotState, dataSeqAtWrite)
 			return nil
 		}
 		remover, ok := target.connector.(connector.ProjectRemover)
@@ -595,7 +648,7 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 		if strings.TrimSpace(snapshotState) == "" {
 			snapshotState = currentState
 		}
-		s.kanbanMutations.noteCardRemoved(target.key, req.issueID, snapshotState)
+		s.kanbanMutations.noteCardRemoved(target.key, req.issueID, snapshotState, dataSeqAtWrite)
 		return nil
 	})
 	if feedback != "" {
@@ -633,11 +686,12 @@ func (s *Server) kanbanSnapshotWithPendingStates(lockKey string, projectID strin
 		return snapshot
 	}
 	snapshot = cloneKanbanIssueSlices(snapshot)
+	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
 	filterSnapshotKanbanIssues(&snapshot, func(issue telemetry.Issue) bool {
 		if strings.TrimSpace(issue.ID) == "" || !sameKanbanProject(issue, projectID, snapshot.Project.ID) {
 			return true
 		}
-		return !s.kanbanMutations.cardRemoved(lockKey, issue.ID, issue.State)
+		return !s.kanbanMutations.cardRemoved(lockKey, issue.ID, issue.State, dataSeq)
 	})
 	pendingMovedCards := s.kanbanMutations.pendingMovedCards(lockKey, projectID, snapshot)
 	pendingStates := s.kanbanMutations.snapshotCardStates(lockKey, projectID, snapshot)
@@ -1653,25 +1707,26 @@ func (s *Server) kanbanTerminalStatesByProject(projectID string) map[string][]st
 	return out
 }
 
-func (s *Server) kanbanCardFresh(lockKey string, projectID string, issueID string, currentState string) (bool, string, string, telemetry.Issue, time.Time) {
+func (s *Server) kanbanCardFresh(lockKey string, projectID string, issueID string, currentState string) (bool, string, string, telemetry.Issue, uint64) {
 	currentState = strings.TrimSpace(currentState)
 	snapshot, ok := s.hub.Latest()
 	if !ok {
-		return false, "", "", telemetry.Issue{}, time.Time{}
+		return false, "", "", telemetry.Issue{}, 0
 	}
+	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
 	entry, ok := kanbanCardFreshEntry(snapshot, projectID, issueID)
 	if !ok {
-		return false, "", "", telemetry.Issue{}, snapshot.GeneratedAt
+		return false, "", "", telemetry.Issue{}, dataSeq
 	}
 	snapshotState := strings.TrimSpace(entry.state)
 	state := snapshotState
 	if s.kanbanMutations != nil {
-		state = s.kanbanMutations.cardState(lockKey, issueID, snapshotState, snapshot.GeneratedAt)
+		state = s.kanbanMutations.cardState(lockKey, issueID, snapshotState, dataSeq)
 	}
 	if currentState == "" || normalizeKanbanState(state) == normalizeKanbanState(currentState) {
-		return true, state, snapshotState, entry.issue, snapshot.GeneratedAt
+		return true, state, snapshotState, entry.issue, dataSeq
 	}
-	return false, state, snapshotState, entry.issue, snapshot.GeneratedAt
+	return false, state, snapshotState, entry.issue, dataSeq
 }
 
 func kanbanCardFreshEntry(snapshot telemetry.Snapshot, projectID string, issueID string) (kanbanSnapshotIssueEntry, bool) {

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"slices"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -181,7 +182,7 @@ func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 		ProjectID:  "detent",
 		Title:      "Dependency blocker",
 		State:      "In Progress",
-	}, "In Progress", "Done", time.Time{})
+	}, "In Progress", "Done", 1)
 	snapshot := telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
 		BoardIssues: []telemetry.Issue{
@@ -319,7 +320,7 @@ func TestKanbanSnapshotWithPendingStatesIgnoresCompletedHistoryForMissingPending
 		Title:      "Completed history pending card",
 		State:      "Backlog",
 	}
-	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", time.Time{})
+	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", 1)
 
 	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
@@ -352,10 +353,11 @@ func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T)
 		Title:      "Completed pending card",
 		State:      "Backlog",
 	}
-	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", time.Time{})
+	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", 1)
 
 	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
+		Refresh: telemetry.Refresh{DataSeq: 2},
 		Completed: []telemetry.Completed{{
 			Issue: telemetry.Issue{
 				ID:         "completed-card",
@@ -379,65 +381,276 @@ func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T)
 	}
 }
 
-func TestKanbanSnapshotWithPendingStatesKeepsConfirmedMoveOverOlderSnapshots(t *testing.T) {
+func TestKanbanMutationLocksCardStateByDataSeq(t *testing.T) {
+	t.Parallel()
+
+	type observation struct {
+		snapshotState string
+		dataSeq       uint64
+		want          string
+	}
+	tests := []struct {
+		name         string
+		observations []observation
+		wantPending  bool
+		wantFeedback string
+	}{
+		{
+			name: "same-seq republish holds optimistic state",
+			observations: []observation{
+				{snapshotState: "Backlog", dataSeq: 7, want: "Todo"},
+				{snapshotState: "Blocked", dataSeq: 7, want: "Todo"},
+			},
+			wantPending: true,
+		},
+		{
+			name: "newer-seq match confirms and drops entry",
+			observations: []observation{
+				{snapshotState: "Todo", dataSeq: 8, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 9, want: "Backlog"},
+			},
+		},
+		{
+			name: "contradicting polls revert at limit with notice",
+			observations: []observation{
+				{snapshotState: "Backlog", dataSeq: 8, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 9, want: "Backlog"},
+			},
+			wantFeedback: "Move of DDW-433 to Todo was not confirmed by the tracker; reverted to Backlog.",
+		},
+		{
+			name: "third state reverts immediately with notice",
+			observations: []observation{
+				{snapshotState: "Blocked", dataSeq: 8, want: "Blocked"},
+			},
+			wantFeedback: "Move of DDW-433 to Todo was not confirmed by the tracker; reverted to Blocked.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			locks := newKanbanMutationLocks()
+			issue := telemetry.Issue{
+				ID:         "confirmed-card",
+				Identifier: "DDW-433",
+				ProjectID:  "detent",
+				Title:      "Confirmed pending card",
+				State:      "Backlog",
+			}
+			locks.noteCardState("project:detent", "detent", issue, "Backlog", "Todo", 7)
+
+			for _, observation := range tt.observations {
+				got := locks.cardState("project:detent", issue.ID, observation.snapshotState, observation.dataSeq)
+				if got != observation.want {
+					t.Fatalf("cardState(%q, %d) = %q, want %q", observation.snapshotState, observation.dataSeq, got, observation.want)
+				}
+			}
+			if got := kanbanPendingStateExists(locks, "project:detent", issue.ID); got != tt.wantPending {
+				t.Fatalf("pending state exists = %t, want %t", got, tt.wantPending)
+			}
+			feedback := kanbanRevertFeedback(locks.consumeRevertNotices("project:detent", "detent"))
+			if feedback != tt.wantFeedback {
+				t.Fatalf("revert feedback = %q, want %q", feedback, tt.wantFeedback)
+			}
+			if got := locks.consumeRevertNotices("project:detent", "detent"); len(got) != 0 {
+				t.Fatalf("second consumeRevertNotices() = %#v, want drained", got)
+			}
+		})
+	}
+}
+
+func TestKanbanSnapshotWithPendingStatesUsesProjectDataSeq(t *testing.T) {
 	t.Parallel()
 
 	server := &Server{kanbanMutations: newKanbanMutationLocks()}
-	pendingIssue := telemetry.Issue{
-		ID:         "confirmed-card",
-		Identifier: "digitaldrywood/detent#433",
-		ProjectID:  "detent",
-		Title:      "Confirmed pending card",
+	issue := telemetry.Issue{
+		ID:         "alpha-card",
+		Identifier: "DDW-434",
+		ProjectID:  "alpha",
+		Title:      "Alpha pending card",
 		State:      "Backlog",
 	}
-	mutationSnapshotAt := time.Date(2026, 7, 7, 12, 0, 0, 0, time.UTC)
-	confirmedAt := mutationSnapshotAt.Add(time.Minute)
-	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", mutationSnapshotAt)
-
-	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
-		GeneratedAt: confirmedAt,
-		Project:     telemetry.Project{ID: "detent"},
-		BoardIssues: []telemetry.Issue{{
-			ID:         "confirmed-card",
-			Identifier: "digitaldrywood/detent#433",
-			ProjectID:  "detent",
-			Title:      "Confirmed pending card",
-			State:      "Todo",
-		}},
-	})
-	if got.BoardIssues[0].State != "Todo" {
-		t.Fatalf("confirmed state = %q, want Todo", got.BoardIssues[0].State)
+	server.kanbanMutations.noteCardState("project:alpha", "alpha", issue, "Backlog", "Todo", 5)
+	snapshot := telemetry.Snapshot{
+		Refresh: telemetry.Refresh{DataSeq: 99},
+		Projects: []telemetry.ProjectSnapshot{
+			{Project: telemetry.Project{ID: "alpha"}, Refresh: telemetry.Refresh{DataSeq: 5}},
+			{Project: telemetry.Project{ID: "bravo"}, Refresh: telemetry.Refresh{DataSeq: 12}},
+		},
+		BoardIssues: []telemetry.Issue{issue},
 	}
 
-	got = server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
-		GeneratedAt: confirmedAt.Add(-30 * time.Second),
+	for range 3 {
+		got := server.kanbanSnapshotWithPendingStates("project:alpha", "alpha", snapshot)
+		if got.BoardIssues[0].State != "Todo" {
+			t.Fatalf("alpha card state = %q, want Todo", got.BoardIssues[0].State)
+		}
+	}
+	if feedback := kanbanRevertFeedback(server.kanbanMutations.consumeRevertNotices("project:alpha", "alpha")); feedback != "" {
+		t.Fatalf("revert feedback = %q, want none", feedback)
+	}
+}
+
+func TestKanbanSnapshotWithPendingStatesRevertFeedback(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{
+		kanbanMutations: newKanbanMutationLocks(),
+		kanbanRefreshes: newKanbanRefreshFeedbackTracker(),
+	}
+	issue := telemetry.Issue{
+		ID:         "rejected-card",
+		Identifier: "DDW-435",
+		ProjectID:  "detent",
+		Title:      "Rejected pending card",
+		State:      "Backlog",
+	}
+	server.kanbanMutations.noteCardState("project:detent", "detent", issue, "Backlog", "Done", 1)
+	snapshot := telemetry.Snapshot{
 		Project:     telemetry.Project{ID: "detent"},
-		BoardIssues: []telemetry.Issue{{
-			ID:         "confirmed-card",
-			Identifier: "digitaldrywood/detent#433",
-			ProjectID:  "detent",
-			Title:      "Confirmed pending card",
-			State:      "Backlog",
-		}},
-	})
-	if got.BoardIssues[0].State != "Todo" {
-		t.Fatalf("older stale state = %q, want Todo", got.BoardIssues[0].State)
+		Refresh:     telemetry.Refresh{DataSeq: 2},
+		BoardIssues: []telemetry.Issue{issue},
 	}
 
-	got = server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
-		GeneratedAt: confirmedAt.Add(time.Minute),
-		Project:     telemetry.Project{ID: "detent"},
-		BoardIssues: []telemetry.Issue{{
-			ID:         "confirmed-card",
-			Identifier: "digitaldrywood/detent#433",
-			ProjectID:  "detent",
-			Title:      "Confirmed pending card",
-			State:      "Backlog",
-		}},
-	})
-	if got.BoardIssues[0].State != "Backlog" {
-		t.Fatalf("newer tracker state = %q, want Backlog", got.BoardIssues[0].State)
+	first := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+	if first.BoardIssues[0].State != "Done" {
+		t.Fatalf("first contradiction state = %q, want Done", first.BoardIssues[0].State)
 	}
+	second := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+	if second.BoardIssues[0].State != "Backlog" {
+		t.Fatalf("second contradiction state = %q, want Backlog", second.BoardIssues[0].State)
+	}
+
+	data := server.withKanbanRefreshFeedback(templates.DashboardData{
+		ProjectID: "detent",
+		Snapshot:  second,
+		Kanban:    templates.KanbanData{ProjectID: "detent"},
+	})
+	want := "Move of DDW-435 to Done was not confirmed by the tracker; reverted to Backlog."
+	if data.Kanban.Feedback != want || data.Kanban.FeedbackKind != "error" {
+		t.Fatalf("feedback = %q/%q, want %q/error", data.Kanban.Feedback, data.Kanban.FeedbackKind, want)
+	}
+	data = server.withKanbanRefreshFeedback(templates.DashboardData{
+		ProjectID: "detent",
+		Snapshot:  second,
+		Kanban:    templates.KanbanData{ProjectID: "detent"},
+	})
+	if data.Kanban.Feedback != "" {
+		t.Fatalf("second feedback = %q, want drained", data.Kanban.Feedback)
+	}
+}
+
+func TestKanbanPendingRemovalByDataSeq(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		snapshotState string
+		dataSeq       uint64
+		expired       bool
+		want          bool
+	}{
+		{name: "same seq hides recorded state", snapshotState: "Backlog", dataSeq: 5, want: true},
+		{name: "same seq hides changed state", snapshotState: "Done", dataSeq: 5, want: true},
+		{name: "newer seq hides recorded state", snapshotState: "Backlog", dataSeq: 6, want: true},
+		{name: "newer seq releases changed state", snapshotState: "Done", dataSeq: 6},
+		{name: "ttl expires as backstop", snapshotState: "Backlog", dataSeq: 5, expired: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			locks := newKanbanMutationLocks()
+			locks.noteCardRemoved("project:detent", "removed-card", "Backlog", 5)
+			if tt.expired {
+				stateKey := kanbanMutationStateKey("project:detent", "removed-card")
+				locks.mu.Lock()
+				removed := locks.removed[stateKey]
+				removed.removedAt = time.Now().Add(-kanbanRemovalPendingTTL - time.Minute)
+				locks.removed[stateKey] = removed
+				locks.mu.Unlock()
+			}
+
+			got := locks.cardRemoved("project:detent", "removed-card", tt.snapshotState, tt.dataSeq)
+			if got != tt.want {
+				t.Fatalf("cardRemoved(%q, %d) = %t, want %t", tt.snapshotState, tt.dataSeq, got, tt.want)
+			}
+			if !tt.want && kanbanPendingRemovalExists(locks, "project:detent", "removed-card") {
+				t.Fatalf("pending removal still exists after release")
+			}
+		})
+	}
+}
+
+func TestKanbanSnapshotWithPendingStatesConcurrentRenderMove(t *testing.T) {
+	t.Parallel()
+
+	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	issue := telemetry.Issue{
+		ID:         "race-card",
+		Identifier: "DDW-436",
+		ProjectID:  "detent",
+		Title:      "Race pending card",
+		State:      "Backlog",
+	}
+	snapshot := telemetry.Snapshot{
+		Project:     telemetry.Project{ID: "detent"},
+		Refresh:     telemetry.Refresh{DataSeq: 1},
+		BoardIssues: []telemetry.Issue{issue},
+	}
+	start := make(chan struct{})
+	errs := make(chan string, 4)
+	var wg sync.WaitGroup
+	for range 4 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 100 {
+				got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+				if len(got.BoardIssues) != 1 {
+					select {
+					case errs <- "rendered board issue count changed":
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		<-start
+		for range 100 {
+			server.kanbanMutations.noteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
+		}
+	}()
+	close(start)
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		t.Fatal(err)
+	}
+}
+
+func kanbanPendingStateExists(locks *kanbanMutationLocks, key string, issueID string) bool {
+	stateKey := kanbanMutationStateKey(key, issueID)
+	locks.mu.Lock()
+	defer locks.mu.Unlock()
+	_, ok := locks.states[stateKey]
+	return ok
+}
+
+func kanbanPendingRemovalExists(locks *kanbanMutationLocks, key string, issueID string) bool {
+	stateKey := kanbanMutationStateKey(key, issueID)
+	locks.mu.Lock()
+	defer locks.mu.Unlock()
+	_, ok := locks.removed[stateKey]
+	return ok
 }
 
 func TestKanbanRefreshFeedbackTransitionsOnce(t *testing.T) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -628,11 +628,56 @@ func (s *Server) projectDashboardData(ctx context.Context, projectID string, sna
 }
 
 func (s *Server) withKanbanRefreshFeedback(data templates.DashboardData) templates.DashboardData {
+	data = s.withKanbanRevertFeedback(data)
 	if s == nil || s.kanbanRefreshes == nil {
 		return data
 	}
 	data.Kanban = s.kanbanRefreshes.apply(kanbanRefreshFeedbackKey(data), data.Kanban, data.Snapshot)
 	return data
+}
+
+func (s *Server) withKanbanRevertFeedback(data templates.DashboardData) templates.DashboardData {
+	if s == nil || s.kanbanMutations == nil || strings.TrimSpace(data.Kanban.Feedback) != "" {
+		return data
+	}
+	notices := s.kanbanRevertNotices(data)
+	if len(notices) == 0 {
+		return data
+	}
+	data.Kanban.Feedback = kanbanRevertFeedback(notices)
+	data.Kanban.FeedbackKind = "error"
+	return data
+}
+
+func (s *Server) kanbanRevertNotices(data templates.DashboardData) []kanbanRevertNotice {
+	if s == nil || s.kanbanMutations == nil {
+		return nil
+	}
+	projectID := strings.TrimSpace(data.ProjectID)
+	if projectID != "" {
+		return s.kanbanMutations.consumeRevertNotices("project:"+projectID, projectID)
+	}
+	return s.kanbanMutations.consumeRevertNotices("", "")
+}
+
+func kanbanRevertFeedback(notices []kanbanRevertNotice) string {
+	messages := make([]string, 0, len(notices))
+	for _, notice := range notices {
+		identifier := strings.TrimSpace(notice.identifier)
+		if identifier == "" {
+			identifier = "card"
+		}
+		from := strings.TrimSpace(notice.from)
+		if from == "" {
+			from = "the requested state"
+		}
+		to := strings.TrimSpace(notice.to)
+		if to == "" {
+			to = "the tracker state"
+		}
+		messages = append(messages, fmt.Sprintf("Move of %s to %s was not confirmed by the tracker; reverted to %s.", identifier, from, to))
+	}
+	return strings.Join(messages, " ")
 }
 
 func kanbanRefreshFeedbackKey(data templates.DashboardData) string {


### PR DESCRIPTION
## Summary

- Rekey kanban optimistic move and removal overlays on per-project `DataSeq` instead of snapshot wall-clock timestamps.
- Add contradiction-limited revert handling with one-shot error feedback on the existing board banner.
- Cover confirmation, same-seq republish, reverts, project seq isolation, removal gating, and concurrent render/move access.

Fixes #1022

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. Existing board feedback markup is reused; no new visual surface was added.

## Test Plan

- [x] `go test ./internal/web`
- [x] `go test -race ./internal/web`
- [x] `make check`
