### PR TITLE
feat(board): show awaiting checks badge

### DIFF
--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -1318,6 +1318,10 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	})
 	state.PollInterval = cfg.PollInterval
 	state.MaxConcurrentAgents = cfg.MaxConcurrentAgents
+	state.AutoPromoteQuietDuration = cfg.AutoPromote.QuietDuration
+	state.AutoPromote = cloneAutoPromoteConfig(cfg.AutoPromote)
+	state.ActiveStates = append([]string(nil), cfg.ActiveStates...)
+	state.TerminalStates = append([]string(nil), cfg.TerminalStates...)
 	state.Instance = instanceSnapshot(cfg)
 	state.Authorization = cloneSelector(cfg.Authorization)
 	state.SelectorContext = cfg.SelectorContext

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -37,6 +37,8 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	boardIssues := authorizedSnapshotIssues(s.BoardIssues, s.Authorization, s.SelectorContext)
 	pipeline := authorizedSnapshotIssues(s.Pipeline, s.Authorization, s.SelectorContext)
 	statusDrift := authorizedStatusDrift(s.StatusDrift, s.Authorization, s.SelectorContext)
+	boardIssueSnapshots := issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now)
+	s.applyGatePendingSnapshots(boardIssueSnapshots, boardIssues)
 	snapshot := telemetry.Snapshot{
 		GeneratedAt:        now,
 		Instance:           s.Instance,
@@ -45,7 +47,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Events:             cloneActivityEvents(s.RecentEvents),
 		Refresh:            refresh,
 		TrackerDrift:       statusDriftSnapshot(statusDrift, s.AutoPromoteQuietDuration, s.PollInterval, now),
-		BoardIssues:        issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now),
+		BoardIssues:        boardIssueSnapshots,
 		Pipeline:           pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now),
 		Running:            runningSnapshots(s.Running, s.Claimed, s.MergeTimings, now),
 		WorkAttempts:       cloneTelemetryWorkAttempts(s.WorkAttempts),
@@ -66,6 +68,25 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Completed: len(snapshot.Completed),
 	}
 	return snapshot
+}
+
+func (s State) applyGatePendingSnapshots(snapshots []telemetry.Issue, issues []connector.Issue) {
+	if len(snapshots) == 0 || len(issues) == 0 {
+		return
+	}
+	cfg := Config{
+		AutoPromote:    s.AutoPromote,
+		ActiveStates:   append([]string(nil), s.ActiveStates...),
+		TerminalStates: append([]string(nil), s.TerminalStates...),
+	}
+	for i := range snapshots {
+		if i >= len(issues) {
+			return
+		}
+		if autoPromoteActiveGatePendingIssue(issues[i], &s, cfg, s.AutoPromote) {
+			snapshots[i].GatePending = true
+		}
+	}
 }
 
 func authorizedSnapshotIssues(issues []connector.Issue, authorization selector.Selector, ctx selector.Context) []connector.Issue {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
@@ -38,6 +39,85 @@ func TestStateSnapshotEmpty(t *testing.T) {
 	}
 	if len(snapshot.BoardIssues) != 0 {
 		t.Fatalf("BoardIssues = %#v, want empty", snapshot.BoardIssues)
+	}
+}
+
+func TestStateSnapshotMarksGatePendingBoardIssues(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate:    gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	gatePending := snapshotGatePendingIssue("gate-pending", "In Progress")
+	running := snapshotGatePendingIssue("running", "In Progress")
+	queued := snapshotGatePendingIssue("queued", "Todo")
+	rework := snapshotGatePendingIssue("rework", "Rework")
+	plain := connector.Issue{
+		ID:         "plain",
+		Identifier: "digitaldrywood/detent#104",
+		State:      "In Progress",
+	}
+	state.BoardIssues = []connector.Issue{gatePending, running, queued, rework, plain}
+	for _, issue := range []connector.Issue{gatePending, running, queued, rework} {
+		state.Completed[issue.ID] = Completed{
+			Issue:       issue,
+			CompletedAt: now.Add(-time.Minute),
+			FinalState:  FinalStateCompleted,
+		}
+	}
+	state.Running[running.ID] = Running{Issue: running}
+	state.Retry[queued.ID] = Retry{Issue: queued}
+
+	snapshot := state.Snapshot(now)
+	byID := map[string]telemetry.Issue{}
+	for _, issue := range snapshot.BoardIssues {
+		byID[issue.ID] = issue
+	}
+
+	tests := []struct {
+		id   string
+		want bool
+	}{
+		{id: "gate-pending", want: true},
+		{id: "running"},
+		{id: "queued"},
+		{id: "rework"},
+		{id: "plain"},
+	}
+	for _, tt := range tests {
+		got, ok := byID[tt.id]
+		if !ok {
+			t.Fatalf("snapshot BoardIssues missing %q: %#v", tt.id, snapshot.BoardIssues)
+		}
+		if got.GatePending != tt.want {
+			t.Fatalf("BoardIssues[%q].GatePending = %t, want %t", tt.id, got.GatePending, tt.want)
+		}
+	}
+	if snapshot.Running[0].GatePending {
+		t.Fatal("running issue GatePending = true, want false")
+	}
+	if snapshot.Queue[0].GatePending {
+		t.Fatal("queued issue GatePending = true, want false")
+	}
+}
+
+func snapshotGatePendingIssue(id string, state string) connector.Issue {
+	return connector.Issue{
+		ID:         id,
+		Identifier: "digitaldrywood/detent#" + id,
+		State:      state,
+		PullRequest: &connector.PullRequest{
+			Number:   100,
+			State:    "open",
+			CIStatus: "pending",
+		},
 	}
 }
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -18,6 +18,9 @@ type State struct {
 	PollInterval             time.Duration
 	MaxConcurrentAgents      int
 	AutoPromoteQuietDuration time.Duration
+	AutoPromote              AutoPromoteConfig
+	ActiveStates             []string
+	TerminalStates           []string
 	Instance                 telemetry.Instance
 	Authorization            selector.Selector
 	SelectorContext          selector.Context
@@ -160,6 +163,9 @@ func newState(cfg Config) State {
 		PollInterval:             cfg.PollInterval,
 		MaxConcurrentAgents:      cfg.MaxConcurrentAgents,
 		AutoPromoteQuietDuration: cfg.AutoPromote.QuietDuration,
+		AutoPromote:              cloneAutoPromoteConfig(cfg.AutoPromote),
+		ActiveStates:             append([]string(nil), cfg.ActiveStates...),
+		TerminalStates:           append([]string(nil), cfg.TerminalStates...),
 		Instance:                 instanceSnapshot(cfg),
 		Authorization:            cloneSelector(cfg.Authorization),
 		SelectorContext:          cfg.SelectorContext,
@@ -185,6 +191,9 @@ func (s State) clone() State {
 		PollInterval:             s.PollInterval,
 		MaxConcurrentAgents:      s.MaxConcurrentAgents,
 		AutoPromoteQuietDuration: s.AutoPromoteQuietDuration,
+		AutoPromote:              cloneAutoPromoteConfig(s.AutoPromote),
+		ActiveStates:             append([]string(nil), s.ActiveStates...),
+		TerminalStates:           append([]string(nil), s.TerminalStates...),
 		Instance:                 s.Instance,
 		Authorization:            cloneSelector(s.Authorization),
 		SelectorContext:          s.SelectorContext,
@@ -269,6 +278,40 @@ func (s State) clone() State {
 	maps.Copy(cloned.planRework, s.planRework)
 
 	return cloned
+}
+
+func cloneAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
+	cfg.AllowedIssueLabels = append([]string(nil), cfg.AllowedIssueLabels...)
+	cfg.Gate = cloneGateConfig(cfg.Gate)
+	return cfg
+}
+
+func cloneGateConfig(cfg gate.Config) gate.Config {
+	cfg.RequiredStatusChecks = append([]string(nil), cfg.RequiredStatusChecks...)
+	cfg.RequireAutomatedReview = cloneBoolPointer(cfg.RequireAutomatedReview)
+	cfg.TransientCIRetryLimit = cloneIntPointer(cfg.TransientCIRetryLimit)
+	cfg.Validator.BlockOn = append([]string(nil), cfg.Validator.BlockOn...)
+	cfg.Validator.MaxInlineDiffBytes = cloneIntPointer(cfg.Validator.MaxInlineDiffBytes)
+	cfg.Artifact.PassStatuses = append([]string(nil), cfg.Artifact.PassStatuses...)
+	cfg.Artifact.WaitStatuses = append([]string(nil), cfg.Artifact.WaitStatuses...)
+	cfg.Artifact.ReworkStatuses = append([]string(nil), cfg.Artifact.ReworkStatuses...)
+	return cfg
+}
+
+func cloneBoolPointer(value *bool) *bool {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
+}
+
+func cloneIntPointer(value *int) *int {
+	if value == nil {
+		return nil
+	}
+	cloned := *value
+	return &cloned
 }
 
 func cloneSelector(in selector.Selector) selector.Selector {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -211,6 +211,7 @@ type Issue struct {
 	LeaseRenewedAt        *time.Time        `json:"lease_renewed_at,omitempty"`
 	LeaseExpiresAt        *time.Time        `json:"lease_expires_at,omitempty"`
 	LeaseStale            bool              `json:"lease_stale,omitempty"`
+	GatePending           bool              `json:"gate_pending,omitempty"`
 	CreatedAt             *time.Time        `json:"created_at,omitempty"`
 	UpdatedAt             *time.Time        `json:"updated_at,omitempty"`
 	StageUpdatedAt        *time.Time        `json:"stage_updated_at,omitempty"`

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -331,6 +331,9 @@ func boardCardExtra(card projectKanbanCard, view boardCardView) (primitives.Kind
 	if reason := strings.TrimSpace(card.ConflictReason); reason != "" {
 		return primitives.KindWarn, reason, true
 	}
+	if card.GatePending {
+		return primitives.KindInfo, "Awaiting checks", true
+	}
 	if status := strings.TrimSpace(card.CIStatus); status != "" {
 		return primitives.KindInfo, status, false
 	}

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -133,6 +133,45 @@ func TestBoardViewLanes(t *testing.T) {
 	}
 }
 
+func TestBoardSnapshotRendersAwaitingChecksOnlyForGatePendingCards(t *testing.T) {
+	data := DashboardData{
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC),
+			BoardIssues: []telemetry.Issue{
+				{
+					ID:          "gate-pending",
+					Identifier:  "digitaldrywood/detent#1030",
+					ProjectID:   "detent",
+					Title:       "Completed work waiting on checks",
+					State:       "In Progress",
+					GatePending: true,
+				},
+				{
+					ID:         "active-work",
+					Identifier: "digitaldrywood/detent#1031",
+					ProjectID:  "detent",
+					Title:      "Active work still running",
+					State:      "In Progress",
+				},
+			},
+		},
+		Kanban: KanbanData{States: []string{"In Progress"}},
+	}
+
+	html := renderBoardComponent(t, BoardSnapshot(data))
+	flagged := boardCardSection(t, html, "Completed work waiting on checks")
+	if !strings.Contains(flagged, "Awaiting checks") {
+		t.Fatalf("gate-pending card missing awaiting checks badge:\n%s", flagged)
+	}
+	plain := boardCardSection(t, html, "Active work still running")
+	if strings.Contains(plain, "Awaiting checks") {
+		t.Fatalf("plain active card rendered awaiting checks badge:\n%s", plain)
+	}
+	if got := strings.Count(html, ">Awaiting checks<"); got != 1 {
+		t.Fatalf("visible Awaiting checks label rendered %d times, want 1:\n%s", got, html)
+	}
+}
+
 func TestBoardCardAgeFooterVisibility(t *testing.T) {
 	card := projectKanbanCard{
 		IssueNumber:      "#982",

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -521,6 +521,7 @@ type projectKanbanCard struct {
 	TimeInStage           string
 	TimeInStageTitle      string
 	WaitDetail            string
+	GatePending           bool
 	BlockedSource         telemetry.BlockedSource
 	BlockedReason         string
 	BlockedRecoveryReason string
@@ -2637,6 +2638,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		TimeInStage:           prPipelineAge(stageAt, now),
 		TimeInStageTitle:      prPipelineAgeTitle(state, stageAt, now),
 		WaitDetail:            prPipelineWaitDetail(issue),
+		GatePending:           issue.GatePending,
 		BlockedSource:         telemetry.BlockedSource(strings.TrimSpace(issue.Metadata[projectKanbanBlockedSourceMetadataKey])),
 		BlockedReason:         strings.TrimSpace(issue.Metadata[projectKanbanBlockedReasonMetadataKey]),
 		BlockedRecoveryReason: strings.TrimSpace(issue.Metadata[projectKanbanBlockedRecoveryReasonMetadataKey]),


### PR DESCRIPTION
## Summary

- Add `telemetry.Issue.GatePending` and populate board snapshots from the auto-promote gate-pending predicate.
- Render an `Awaiting checks` chip for gate-pending board cards only.

Fixes #1030

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Browser/visual verification: `TestBoardSnapshotRendersAwaitingChecksOnlyForGatePendingCards` renders the primary board snapshot and verifies the chip appears only in the flagged card article.

## Test Plan

- [x] `go test ./internal/orchestrator ./internal/web/templates ./internal/telemetry`
- [x] `make generate`
- [x] `make check`

`make check` completed with coverage 75.3% against the 70.0% gate.
