### PR TITLE
refactor(web): extract kanban validation responses

### DIFF
--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -466,41 +466,23 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 	}
 	req, response, status := parseKanbanMoveRequest(c)
 	if response != "" {
-		if kanbanDialogForm(c) {
-			return s.kanbanMoveDialogValidation(c, response)
-		}
-		return kanbanFeedback(c, status, response)
+		return s.kanbanMoveValidationResponse(c, status, response)
 	}
 	target, response, status := s.kanbanActionTarget(req.projectID)
 	if response != "" {
-		if kanbanDialogForm(c) {
-			return s.kanbanMoveDialogValidation(c, response)
-		}
-		return kanbanFeedback(c, status, response)
+		return s.kanbanMoveValidationResponse(c, status, response)
 	}
 	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
-		if kanbanDialogForm(c) {
-			return s.kanbanMoveDialogValidation(c, "Kanban integration mode is not enabled.")
-		}
-		return kanbanFeedback(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
+		return s.kanbanMoveValidationResponse(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
 	}
 	if req.issueID == "" {
 		if req.prNumber > 0 {
-			if kanbanDialogForm(c) {
-				return s.kanbanMoveDialogValidation(c, "Cannot move PR-only card without a linked issue.")
-			}
-			return kanbanFeedback(c, http.StatusUnprocessableEntity, "Cannot move PR-only card without a linked issue.")
+			return s.kanbanMoveValidationResponse(c, http.StatusUnprocessableEntity, "Cannot move PR-only card without a linked issue.")
 		}
-		if kanbanDialogForm(c) {
-			return s.kanbanMoveDialogValidation(c, "Issue id is required.")
-		}
-		return kanbanFeedback(c, http.StatusBadRequest, "Issue id is required.")
+		return s.kanbanMoveValidationResponse(c, http.StatusBadRequest, "Issue id is required.")
 	}
 	if !kanbanStateAllowed(target.workflow, req.targetState) {
-		if kanbanDialogForm(c) {
-			return s.kanbanMoveDialogValidation(c, "Target state is not configured for this board.")
-		}
-		return kanbanFeedback(c, http.StatusBadRequest, "Target state is not configured for this board.")
+		return s.kanbanMoveValidationResponse(c, http.StatusBadRequest, "Target state is not configured for this board.")
 	}
 	var feedback string
 	var feedbackStatus int
@@ -544,10 +526,7 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 		return nil
 	})
 	if feedback != "" {
-		if kanbanDialogForm(c) {
-			return s.kanbanMoveDialogValidation(c, feedback)
-		}
-		return kanbanFeedback(c, feedbackStatus, feedback)
+		return s.kanbanMoveValidationResponse(c, feedbackStatus, feedback)
 	}
 	if err != nil {
 		s.logger.WarnContext(c.Request().Context(), "kanban move failed", "project", req.projectID, "issue_id", req.issueID, "target_state", req.targetState, "error", err)
@@ -984,10 +963,7 @@ func (s *Server) apiKanbanComment(c echo.Context) error {
 		if kanbanThreadForm(c) {
 			return s.kanbanIssueCommentThread(c, response, kanbanRequestValue(c, "body"), "")
 		}
-		if kanbanDialogForm(c) {
-			return s.kanbanCommentDialogValidation(c, response)
-		}
-		return kanbanFeedback(c, status, response)
+		return s.kanbanCommentValidationResponse(c, status, response)
 	}
 
 	target, response, status := s.kanbanActionTarget(req.projectID)
@@ -995,34 +971,22 @@ func (s *Server) apiKanbanComment(c echo.Context) error {
 		if kanbanThreadForm(c) {
 			return s.kanbanIssueCommentThread(c, response, req.body, "")
 		}
-		if kanbanDialogForm(c) {
-			return s.kanbanCommentDialogValidation(c, response)
-		}
-		return kanbanFeedback(c, status, response)
+		return s.kanbanCommentValidationResponse(c, status, response)
 	}
 	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
 		if kanbanThreadForm(c) {
 			return s.kanbanIssueCommentThread(c, "Kanban integration mode is not enabled.", req.body, "")
 		}
-		if kanbanDialogForm(c) {
-			return s.kanbanCommentDialogValidation(c, "Kanban integration mode is not enabled.")
-		}
-		return kanbanFeedback(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
+		return s.kanbanCommentValidationResponse(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
 	}
 	if req.target == "pr" && !kanbanSupportsPullRequestComments(target.connector) {
-		if kanbanDialogForm(c) {
-			return s.kanbanCommentDialogValidation(c, "Comment target is not available on the current board.")
-		}
-		return kanbanFeedback(c, http.StatusNotFound, "Comment target is not available on the current board.")
+		return s.kanbanCommentValidationResponse(c, http.StatusNotFound, "Comment target is not available on the current board.")
 	}
 	if !s.kanbanCommentTargetKnown(req) {
 		if kanbanThreadForm(c) {
 			return s.kanbanIssueCommentThread(c, "Comment target is not available on the current board.", req.body, "")
 		}
-		if kanbanDialogForm(c) {
-			return s.kanbanCommentDialogValidation(c, "Comment target is not available on the current board.")
-		}
-		return kanbanFeedback(c, http.StatusNotFound, "Comment target is not available on the current board.")
+		return s.kanbanCommentValidationResponse(c, http.StatusNotFound, "Comment target is not available on the current board.")
 	}
 
 	err := s.kanbanMutations.withLock(target.key, func() error {
@@ -1177,6 +1141,13 @@ func (s *Server) kanbanMoveDialogValidation(c echo.Context, message string) erro
 	return render(c, templates.KanbanMoveDialogContent(data))
 }
 
+func (s *Server) kanbanMoveValidationResponse(c echo.Context, status int, message string) error {
+	if kanbanDialogForm(c) {
+		return s.kanbanMoveDialogValidation(c, message)
+	}
+	return kanbanFeedback(c, status, message)
+}
+
 func (s *Server) kanbanCommentDialogValidation(c echo.Context, message string) error {
 	c.Response().Header().Set("HX-Retarget", kanbanDialogContentTarget)
 	c.Response().Header().Set("HX-Reswap", "innerHTML")
@@ -1185,6 +1156,13 @@ func (s *Server) kanbanCommentDialogValidation(c echo.Context, message string) e
 		return render(c, templates.KanbanDialogErrorContent(response))
 	}
 	return render(c, templates.KanbanCommentDialogContent(data))
+}
+
+func (s *Server) kanbanCommentValidationResponse(c echo.Context, status int, message string) error {
+	if kanbanDialogForm(c) {
+		return s.kanbanCommentDialogValidation(c, message)
+	}
+	return kanbanFeedback(c, status, message)
 }
 
 func (s *Server) kanbanMoveDialogData(c echo.Context, message string) (templates.KanbanMoveDialogData, string) {

--- a/internal/web/kanban_validation_response_test.go
+++ b/internal/web/kanban_validation_response_test.go
@@ -1,0 +1,173 @@
+package web
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/labstack/echo/v4"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+)
+
+func TestKanbanMoveValidationResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		form        url.Values
+		status      int
+		message     string
+		wantStatus  int
+		wantHeaders map[string]string
+		wantBody    []string
+	}{
+		{
+			name: "dialog form renders move dialog validation",
+			form: url.Values{
+				"kanban_dialog": {"true"},
+				"current_state": {"Todo"},
+				"issue_id":      {"I_kw1"},
+				"identifier":    {"digitaldrywood/detent#1"},
+				"title":         {"Dialog card"},
+			},
+			status:     http.StatusBadRequest,
+			message:    "Target state is required.",
+			wantStatus: http.StatusOK,
+			wantHeaders: map[string]string{
+				"HX-Retarget": kanbanDialogContentTarget,
+				"HX-Reswap":   "innerHTML",
+			},
+			wantBody: []string{
+				"Target state is required.",
+				`hx-post="/api/v1/kanban/move"`,
+			},
+		},
+		{
+			name:       "non-dialog form returns move feedback",
+			form:       url.Values{},
+			status:     http.StatusUnprocessableEntity,
+			message:    "Move is not allowed.",
+			wantStatus: http.StatusUnprocessableEntity,
+			wantBody: []string{
+				`id="kanban-feedback"`,
+				"Move is not allowed.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newKanbanValidationResponseTestServer()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/kanban/move", strings.NewReader(tt.form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("HX-Request", "true")
+			c := echo.New().NewContext(req, rec)
+
+			if err := server.kanbanMoveValidationResponse(c, tt.status, tt.message); err != nil {
+				t.Fatalf("kanbanMoveValidationResponse() error = %v", err)
+			}
+			assertKanbanValidationResponse(t, rec, tt.wantStatus, tt.wantHeaders, tt.wantBody)
+		})
+	}
+}
+
+func TestKanbanCommentValidationResponse(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		form        url.Values
+		status      int
+		message     string
+		wantStatus  int
+		wantHeaders map[string]string
+		wantBody    []string
+	}{
+		{
+			name: "dialog form renders comment dialog validation",
+			form: url.Values{
+				"kanban_dialog": {"true"},
+				"target":        {"issue"},
+				"issue_id":      {"I_kw1"},
+				"identifier":    {"digitaldrywood/detent#1"},
+				"title":         {"Dialog card"},
+			},
+			status:     http.StatusBadRequest,
+			message:    "Comment body is required.",
+			wantStatus: http.StatusOK,
+			wantHeaders: map[string]string{
+				"HX-Retarget": kanbanDialogContentTarget,
+				"HX-Reswap":   "innerHTML",
+			},
+			wantBody: []string{
+				"Comment body is required.",
+				`hx-post="/api/v1/kanban/comment"`,
+			},
+		},
+		{
+			name:       "non-dialog form returns comment feedback",
+			form:       url.Values{},
+			status:     http.StatusBadRequest,
+			message:    "Comment body is required.",
+			wantStatus: http.StatusBadRequest,
+			wantBody: []string{
+				`id="kanban-feedback"`,
+				"Comment body is required.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := newKanbanValidationResponseTestServer()
+			rec := httptest.NewRecorder()
+			req := httptest.NewRequest(http.MethodPost, "/api/v1/kanban/comment", strings.NewReader(tt.form.Encode()))
+			req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+			req.Header.Set("HX-Request", "true")
+			c := echo.New().NewContext(req, rec)
+
+			if err := server.kanbanCommentValidationResponse(c, tt.status, tt.message); err != nil {
+				t.Fatalf("kanbanCommentValidationResponse() error = %v", err)
+			}
+			assertKanbanValidationResponse(t, rec, tt.wantStatus, tt.wantHeaders, tt.wantBody)
+		})
+	}
+}
+
+func newKanbanValidationResponseTestServer() *Server {
+	workflow := workflowconfig.Default()
+	workflow.Server.Kanban = workflowconfig.Kanban{Mode: workflowconfig.KanbanModeIntegration}
+	return &Server{
+		connector:      memory.New(memory.Config{}),
+		kanban:         workflowconfig.Kanban{Mode: workflowconfig.KanbanModeIntegration},
+		kanbanWorkflow: workflow,
+	}
+}
+
+func assertKanbanValidationResponse(t *testing.T, rec *httptest.ResponseRecorder, wantStatus int, wantHeaders map[string]string, wantBody []string) {
+	t.Helper()
+
+	if rec.Code != wantStatus {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, wantStatus, rec.Body.String())
+	}
+	for header, want := range wantHeaders {
+		if got := rec.Header().Get(header); got != want {
+			t.Fatalf("%s = %q, want %q", header, got, want)
+		}
+	}
+	body := rec.Body.String()
+	for _, want := range wantBody {
+		if !strings.Contains(body, want) {
+			t.Fatalf("body missing %q:\n%s", want, body)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Added move/comment validation response helpers to centralize dialog-vs-feedback branching.
- Replaced repeated kanban move/comment validation branches without changing statuses or messages.
- Added focused table-driven coverage for dialog-form and non-dialog helper responses.

Fixes #1017

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no visual surface change; this reuses existing validation markup paths.

## Test Plan

- [x] `go test ./internal/web -run 'TestKanban(MoveValidationResponse|CommentValidationResponse)$'`
- [x] `go test ./internal/web`
- [x] `make check`