### PR TITLE
fix(orchestrator): stop repeated rework loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,7 +684,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
-    rework_limit: 0
+    rework_limit: 3
   skills:
     enabled: true
     path: .detent/skills
@@ -1549,9 +1549,10 @@ of that state is controlled by the workflow:
   auto-promotion; verdicts below `min_score` or with severities in `block_on`
   route the issue to `Rework`.
 - `agent.auto_promote.rework_limit` bounds repeated `Human Review` to `Rework`
-  loops using persisted lane events; `0` leaves the loop unlimited. Positive
-  limits require `Blocked` in a configured tracker state list and route the next
-  over-limit rework decision there with repeated reasons summarized for handoff.
+  loops using persisted lane events; the default is `3`, and `0` is an explicit
+  opt-out that leaves the loop unlimited. Positive limits require `Blocked` in a
+  configured tracker state list and route the next over-limit rework decision
+  there with repeated reasons summarized for handoff.
 - `gate.kind: human_review` requires a linked open PR plus the configured
   `approval_label` on the issue.
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2089,7 +2089,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
        quiet_seconds: 600
        optout_label: requires-human-review
        allowed_issue_labels: []
-       rework_limit: 0
+       rework_limit: 3
    ```
 
    Criteria-based auto-promote example:
@@ -2102,7 +2102,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
        optout_label: <optout-label>
        allowed_issue_labels:
          - <allowed-label>
-       rework_limit: <0-or-max-rework-laps>
+       rework_limit: <0-to-disable-or-max-rework-laps>
    ```
 
    For a command gate, auto-promote requires a linked open PR, green CI, no P1
@@ -2116,10 +2116,10 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    checks as non-green on the current PR head. Failed or cancelled current-head
    CI also routes the item to `Rework` by default; set `ci_failure_action: skip`
    only when red CI should stay parked in `Human Review`.
-   `agent.auto_promote.rework_limit: 0` leaves
-   repeated rework unlimited; a positive value requires `Blocked` in a configured
-   tracker state list and blocks the next lap after that many persisted Rework
-   entries. Pending CI stays parked. The quiet
+   `agent.auto_promote.rework_limit` defaults to `3`; set it to `0` only when
+   repeated rework should remain unlimited. A positive value requires `Blocked`
+   in a configured tracker state list and blocks the next lap after that many
+   persisted Rework entries. Pending CI stays parked. The quiet
    period resets on observed issue updates, Project
    status updates, automated PR review submission, and linked PR activity such
    as a fresh push to the PR head. With `gate.validator.enabled: true`, a

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -75,7 +75,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
-    rework_limit: 0
+    rework_limit: 3
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -75,7 +75,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
-    rework_limit: 0
+    rework_limit: 3
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -74,7 +74,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
-    rework_limit: 0
+    rework_limit: 3
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -39,7 +39,7 @@ agent:
     source_state: Review
     pass_state: Ready for Pickup
     rework_state: Rework
-    rework_limit: 0
+    rework_limit: 3
 
 gate:
   kind: artifact

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -74,7 +74,7 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
-    rework_limit: 0
+    rework_limit: 3
   skills:
     enabled: true
     path: .detent/skills

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -967,6 +967,7 @@ polling:
 agent:
   auto_promote:
     enabled: true
+    rework_limit: 0
 gate:
   kind: command
   validator:

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,6 +45,7 @@ const (
 	AgentBackendCodex        = "codex"
 	AgentBackendClaudeCode   = "claude_code"
 	DefaultKnowledgeMaxBytes = 64 * 1024
+	DefaultReworkLimit       = 3
 
 	DefaultPollingIntervalMS      = 120000
 	MinPollingIntervalMS          = 60000
@@ -785,6 +786,7 @@ func Default() Config {
 				SourceState:        "Human Review",
 				PassState:          "Merging",
 				ReworkState:        "Rework",
+				ReworkLimit:        DefaultReworkLimit,
 			},
 			Budget:    budget,
 			Lessons:   defaultLessons(),
@@ -1056,7 +1058,7 @@ func (c *Config) validateTracker(problems *[]string) {
 }
 
 func (c *Config) validateAutoPromoteReworkLimit(problems *[]string) {
-	if c.Agent.AutoPromote.ReworkLimit <= 0 {
+	if !c.Agent.AutoPromote.Enabled || c.Agent.AutoPromote.ReworkLimit <= 0 {
 		return
 	}
 	if stateListContains(c.Tracker.ActiveStates, "Blocked") ||

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -639,8 +639,8 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	if cfg.Agent.Skills.Creation.MaxDraftsPerRun != 1 {
 		t.Fatalf("Agent.Skills.Creation.MaxDraftsPerRun = %d, want 1", cfg.Agent.Skills.Creation.MaxDraftsPerRun)
 	}
-	if cfg.Agent.AutoPromote.ReworkLimit != 0 {
-		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want unlimited default", cfg.Agent.AutoPromote.ReworkLimit)
+	if cfg.Agent.AutoPromote.ReworkLimit != DefaultReworkLimit {
+		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want %d", cfg.Agent.AutoPromote.ReworkLimit, DefaultReworkLimit)
 	}
 	if cfg.Agent.OutputTruncation.MaxBytes != 0 {
 		t.Fatalf("Agent.OutputTruncation.MaxBytes = %d, want disabled default", cfg.Agent.OutputTruncation.MaxBytes)
@@ -1477,6 +1477,7 @@ tracker:
     - Production
   observed_states:
     - Review
+    - Blocked
   terminal_states:
     - Done
 workspace:
@@ -1916,6 +1917,7 @@ tracker:
     - Done
 agent:
   auto_promote:
+    enabled: true
     rework_limit: 1
 ---
 Prompt

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -38,11 +39,18 @@ type autoPromoteReworkLimitSummary struct {
 	Limit        int
 	Count        int
 	ReasonCounts []autoPromoteReworkReasonCount
+	Signature    autoPromoteReworkSignature
 }
 
 type autoPromoteReworkReasonCount struct {
 	Reason string
 	Count  int
+}
+
+type autoPromoteReworkSignature struct {
+	PRNumber     int64
+	HeadSHA      string
+	FailedChecks []string
 }
 
 func (o *Orchestrator) autoPromoteHumanReviewIssues(
@@ -1751,7 +1759,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 	transitionReason := string(decision.Reason)
 	body := autoPromoteComment(summary, decision, displayStateName(issue.State), targetState)
 	if decision.Action == AutoPromoteActionRework {
-		limit, err := o.autoPromoteReworkLimit(ctx, issue)
+		limit, err := o.autoPromoteReworkLimit(ctx, issue, summary)
 		if err != nil {
 			if o.logger != nil {
 				o.logger.Warn(
@@ -1822,18 +1830,22 @@ func (s autoPromoteReworkLimitSummary) Exceeded() bool {
 func (o *Orchestrator) autoPromoteReworkLimit(
 	ctx context.Context,
 	issue connector.Issue,
+	summary AutoPromoteSummary,
 ) (autoPromoteReworkLimitSummary, error) {
 	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
-	summary := autoPromoteReworkLimitSummary{Limit: cfg.ReworkLimit}
+	limitSummary := autoPromoteReworkLimitSummary{
+		Limit:     cfg.ReworkLimit,
+		Signature: autoPromoteReworkSignatureFromIssue(issue, summary),
+	}
 	if cfg.ReworkLimit <= 0 {
-		return summary, nil
+		return limitSummary, nil
 	}
 	if normalizeState(issue.State) == normalizeState(cfg.ReworkState) {
-		return summary, nil
+		return limitSummary, nil
 	}
 	reader, ok := o.workflowMetrics.(WorkflowMetricsTimelineReader)
 	if !ok || reader == nil {
-		return summary, errors.New("workflow metrics timeline reader unavailable")
+		return limitSummary, errors.New("workflow metrics timeline reader unavailable")
 	}
 
 	timeline, err := reader.IssueWorkflowTimeline(ctx, store.IssueIdentity{
@@ -1842,12 +1854,13 @@ func (o *Orchestrator) autoPromoteReworkLimit(
 		IssueURL:   issue.URL,
 	})
 	if err != nil {
-		return summary, err
+		return limitSummary, err
 	}
 	entries := autoPromoteReworkLaneEntries(timeline.Events, cfg.ReworkState)
-	summary.Count = len(entries)
-	summary.ReasonCounts = autoPromoteReworkReasonCounts(entries)
-	return summary, nil
+	entries = autoPromoteReworkLaneEntriesForSignature(entries, limitSummary.Signature)
+	limitSummary.Count = len(entries)
+	limitSummary.ReasonCounts = autoPromoteReworkReasonCounts(entries)
+	return limitSummary, nil
 }
 
 func autoPromoteReworkLaneEntries(events []store.WorkflowPhaseEvent, reworkState string) []store.WorkflowPhaseEvent {
@@ -1887,6 +1900,89 @@ func autoPromoteReworkReasonCounts(events []store.WorkflowPhaseEvent) []autoProm
 		out = append(out, autoPromoteReworkReasonCount{Reason: reason, Count: counts[reason]})
 	}
 	return out
+}
+
+func autoPromoteReworkLaneEntriesForSignature(
+	events []store.WorkflowPhaseEvent,
+	signature autoPromoteReworkSignature,
+) []store.WorkflowPhaseEvent {
+	if signature.empty() {
+		return events
+	}
+	matching := make([]store.WorkflowPhaseEvent, 0, len(events))
+	for _, event := range events {
+		if autoPromoteReworkSignatureMatches(signature, autoPromoteReworkSignatureFromEvent(event)) {
+			matching = append(matching, event)
+		}
+	}
+	return matching
+}
+
+func autoPromoteReworkSignatureFromIssue(issue connector.Issue, summary AutoPromoteSummary) autoPromoteReworkSignature {
+	signature := autoPromoteReworkSignature{}
+	if issue.PRNumber != nil && *issue.PRNumber > 0 {
+		signature.PRNumber = int64(*issue.PRNumber)
+	}
+	if issue.PullRequest != nil {
+		if issue.PullRequest.Number > 0 {
+			signature.PRNumber = int64(issue.PullRequest.Number)
+		}
+		signature.HeadSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
+	}
+	signature.FailedChecks = autoPromoteCanonicalChecks(summary.FailedChecks)
+	if len(signature.FailedChecks) == 0 && issue.PullRequest != nil {
+		signature.FailedChecks = autoPromoteCanonicalChecks(autoPromoteFailedChecksFromPullRequest(issue.PullRequest))
+	}
+	return signature
+}
+
+func autoPromoteReworkSignatureFromEvent(event store.WorkflowPhaseEvent) autoPromoteReworkSignature {
+	signature := autoPromoteReworkSignature{}
+	if event.PRNumber != nil && *event.PRNumber > 0 {
+		signature.PRNumber = *event.PRNumber
+	}
+	if metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON); ok {
+		if metadata.PullRequest != nil {
+			if metadata.PullRequest.Number > 0 {
+				signature.PRNumber = metadata.PullRequest.Number
+			}
+			signature.HeadSHA = strings.TrimSpace(metadata.PullRequest.HeadSHA)
+			signature.FailedChecks = autoPromoteCanonicalChecks(metadata.PullRequest.FailedChecks)
+		}
+	}
+	return signature
+}
+
+func autoPromoteReworkSignatureMatches(current autoPromoteReworkSignature, event autoPromoteReworkSignature) bool {
+	if current.empty() {
+		return true
+	}
+	if current.PRNumber > 0 && event.PRNumber > 0 && current.PRNumber != event.PRNumber {
+		return false
+	}
+	if current.HeadSHA != "" && event.HeadSHA != current.HeadSHA {
+		return false
+	}
+	if len(current.FailedChecks) > 0 && !slices.Equal(current.FailedChecks, event.FailedChecks) {
+		return false
+	}
+	if current.HeadSHA != "" || len(current.FailedChecks) > 0 {
+		return true
+	}
+	return current.PRNumber <= 0 || event.PRNumber <= 0 || current.PRNumber == event.PRNumber
+}
+
+func (s autoPromoteReworkSignature) empty() bool {
+	return s.PRNumber <= 0 && s.HeadSHA == "" && len(s.FailedChecks) == 0
+}
+
+func autoPromoteCanonicalChecks(checks []string) []string {
+	checks = uniqueStrings(checks)
+	if len(checks) == 0 {
+		return nil
+	}
+	slices.Sort(checks)
+	return checks
 }
 
 func (o *Orchestrator) recordAutoPromoteReworkHandoff(

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -654,6 +655,157 @@ func TestTickAutoPromoteBlocksWhenReworkLimitReached(t *testing.T) {
 	blocked := events[2]
 	if blocked.PhaseName != "Blocked" || blocked.Status != "entered" || blocked.Reason != "rework_limit" {
 		t.Fatalf("blocked metric = %#v, want Blocked entered with rework_limit reason", blocked)
+	}
+}
+
+func TestTickAutoPromoteBlocksRepeatedCINotGreenSignature(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 14, 30, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-red-ci-loop", []string{"bug"}, &connector.PullRequest{
+		Number:   1046,
+		URL:      "https://github.test/digitaldrywood/detent/pull/1046",
+		State:    "OPEN",
+		HeadSHA:  "same-head",
+		CIStatus: "fail",
+		RequiredCheckFailures: []connector.PullRequestCheck{
+			{Name: "Test", Status: "completed", Conclusion: "failure"},
+			{Name: "Tier-1 Race Tests", Status: "completed", Conclusion: "failure"},
+		},
+	})
+	issue.Identifier = "digitaldrywood/detent#1046"
+	issue.URL = "https://github.test/digitaldrywood/detent/issues/1046"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			ReworkLimit:   1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	prNumber := int64(1046)
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PRNumber:     &prNumber,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Rework",
+		Reason:       string(AutoPromoteReasonCINotGreen),
+		Status:       "entered",
+		StartedAt:    now.Add(-time.Hour),
+		MetadataJSON: autoPromoteReworkEventMetadata(1046, "same-head", "Test", "Tier-1 Race Tests"),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	orch := &Orchestrator{
+		cfg:             cfg,
+		connector:       tracker,
+		workflowMetrics: metrics,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Blocked"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one Blocked handoff comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Rework limit was reached",
+		"prior_rework_transitions: 1",
+		"current_rework_reason: ci_not_green",
+		"repeated_rework_reasons: ci_not_green x1",
+		"failed_checks: Test, Tier-1 Race Tests",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	events := metrics.snapshot()
+	blocked := events[len(events)-1]
+	if blocked.PhaseName != "Blocked" || blocked.Reason != "rework_limit" {
+		t.Fatalf("latest workflow event = %#v, want Blocked rework_limit entry", blocked)
+	}
+}
+
+func TestTickAutoPromoteResetsReworkLimitAfterHeadSHAChange(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 14, 45, 0, 0, time.UTC)
+	issue := autoPromoteTickIssue("issue-red-ci-new-head", []string{"bug"}, &connector.PullRequest{
+		Number:   1047,
+		URL:      "https://github.test/digitaldrywood/detent/pull/1047",
+		State:    "OPEN",
+		HeadSHA:  "new-head",
+		CIStatus: "fail",
+		RequiredCheckFailures: []connector.PullRequestCheck{{
+			Name:       "Test",
+			Status:     "completed",
+			Conclusion: "failure",
+		}},
+	})
+	issue.Identifier = "digitaldrywood/detent#1047"
+	issue.URL = "https://github.test/digitaldrywood/detent/issues/1047"
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			ReworkLimit:   1,
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	prNumber := int64(1047)
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PRNumber:     &prNumber,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Rework",
+		Reason:       string(AutoPromoteReasonCINotGreen),
+		Status:       "entered",
+		StartedAt:    now.Add(-time.Hour),
+		MetadataJSON: autoPromoteReworkEventMetadata(1047, "old-head", "Test"),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	orch := &Orchestrator{
+		cfg:             cfg,
+		connector:       tracker,
+		workflowMetrics: metrics,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	orch.tick(context.Background(), &state, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 || strings.Contains(tracker.comments[0].body, "Rework limit was reached") {
+		t.Fatalf("comments = %#v, want ordinary Rework handoff", tracker.comments)
+	}
+	events := metrics.snapshot()
+	rework := events[len(events)-1]
+	signature := autoPromoteReworkSignatureFromEvent(rework)
+	if rework.PhaseName != "Rework" || signature.HeadSHA != "new-head" || !slices.Equal(signature.FailedChecks, []string{"Test"}) {
+		t.Fatalf("latest Rework event = %#v signature = %#v, want new-head Test signature", rework, signature)
 	}
 }
 
@@ -3831,6 +3983,23 @@ type autoPromoteTickHydration struct {
 	issueID    string
 	repository string
 	number     int
+}
+
+func autoPromoteReworkEventMetadata(prNumber int, headSHA string, failedChecks ...string) string {
+	issue := connector.Issue{
+		PullRequest: &connector.PullRequest{
+			Number:  prNumber,
+			HeadSHA: headSHA,
+		},
+	}
+	for _, check := range failedChecks {
+		issue.PullRequest.RequiredCheckFailures = append(issue.PullRequest.RequiredCheckFailures, connector.PullRequestCheck{
+			Name:       check,
+			Status:     "completed",
+			Conclusion: "failure",
+		})
+	}
+	return workflowLaneMetadataJSON(issue, workflowLaneMetadata{})
 }
 
 type autoPromoteWorkflowMetricsRecorder struct {

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -100,6 +100,9 @@ func (o *Orchestrator) recoverBlockedIssues(
 		if issueID == "" {
 			continue
 		}
+		if o.issueHasStickyBlockReason(ctx, state, issue) {
+			continue
+		}
 		decision := EvaluateBlockedRecovery(issue)
 		if decision.Action != BlockedRecoveryActionRework {
 			continue

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -1,0 +1,55 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestRecoverBlockedIssuesSkipsPersistedReworkLimitBlockedIssue(t *testing.T) {
+	t.Parallel()
+
+	issue := dependencyAutoUnblockIssue("issue-recovery-rework-limit", "Blocked")
+	prNumber := 418
+	issue.PRNumber = &prNumber
+	issue.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		State:          "OPEN",
+		URL:            "https://github.test/digitaldrywood/detent/pull/418",
+		MergeableState: "behind",
+		HeadSHA:        "abc123",
+	}
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{issue},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Blocked",
+		Reason:       "rework_limit",
+		Status:       "entered",
+		StartedAt:    time.Date(2026, 7, 8, 15, 0, 0, 0, time.UTC),
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	state := newState(orch.cfg)
+
+	orch.recoverBlockedIssues(context.Background(), &state, []connector.Issue{issue}, time.Date(2026, 7, 8, 15, 1, 0, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no blocked recovery transition", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want no blocked recovery comment", tracker.comments)
+	}
+}

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"fmt"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/dependencyline"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -96,6 +98,9 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if issueID == "" {
 			continue
 		}
+		if o.dependencyAutoUnblockStickyBlocked(ctx, state, issue) {
+			continue
+		}
 		hydrated, ok := o.hydrateDependencyAutoUnblockIssue(ctx, issue, cfg.SourceStates)
 		if !ok || len(hydrated.BlockedBy) == 0 {
 			continue
@@ -104,8 +109,12 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if !dependencyBlockersReady(blockers, cfg, o.cfg.TerminalStates) {
 			continue
 		}
+		blockerSet := dependencyAutoUnblockBlockerSet(blockers)
+		if o.dependencyAutoUnblockAlreadyConsumed(ctx, state, hydrated, blockerSet) {
+			continue
+		}
 		targetState := dependencyAutoUnblockTargetState(state, hydrated, cfg.TargetState)
-		if !o.applyDependencyAutoUnblock(ctx, state, hydrated, blockers, targetState, now) {
+		if !o.applyDependencyAutoUnblock(ctx, state, hydrated, blockers, blockerSet, targetState, now) {
 			continue
 		}
 		transitioned[issueID] = struct{}{}
@@ -698,11 +707,18 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 	state *State,
 	issue connector.Issue,
 	blockers []dependencyBlocker,
+	blockerSet string,
 	targetState string,
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "dependency_auto_unblock"); err != nil {
+	metadata := workflowLaneMetadata{
+		DependencyAutoUnblock: &workflowLaneDependencyAutoUnblockMetadata{
+			BlockerSet: strings.TrimSpace(blockerSet),
+			Blockers:   dependencyAutoUnblockBlockerLabels(blockers),
+		},
+	}
+	if err := o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, now, "dependency_auto_unblock", metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("dependency auto-unblock transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 		}
@@ -715,6 +731,13 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 	}
 
 	delete(state.Blocked, issueID)
+	if state.DependencyAutoUnblocks == nil {
+		state.DependencyAutoUnblocks = map[string]DependencyAutoUnblockRecord{}
+	}
+	state.DependencyAutoUnblocks[issueID] = DependencyAutoUnblockRecord{
+		BlockerSet:  strings.TrimSpace(blockerSet),
+		UnblockedAt: now,
+	}
 	recordStateEvent(state, telemetry.ActivityEvent{
 		At:      now,
 		Event:   "dependency_auto_unblock_transition",
@@ -724,6 +747,149 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 		o.logger.Info("dependency auto-unblock transition", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState)
 	}
 	return true
+}
+
+func (o *Orchestrator) dependencyAutoUnblockStickyBlocked(ctx context.Context, state *State, issue connector.Issue) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	if state != nil && issueID != "" {
+		if blocked, ok := state.Blocked[issueID]; ok && dependencyAutoUnblockStickyReason(blocked.Reason) {
+			return true
+		}
+	}
+	if dependencyAutoUnblockStickyReason(issue.BlockerReason) {
+		return true
+	}
+	reason, ok := o.latestWorkflowLaneReason(ctx, issue, blockedStatusState)
+	return ok && dependencyAutoUnblockStickyReason(reason)
+}
+
+func dependencyAutoUnblockStickyReason(reason string) bool {
+	switch strings.ToLower(strings.TrimSpace(reason)) {
+	case "rework_limit", "circuit_breaker":
+		return true
+	default:
+		return false
+	}
+}
+
+func (o *Orchestrator) dependencyAutoUnblockAlreadyConsumed(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	blockerSet string,
+) bool {
+	blockerSet = strings.TrimSpace(blockerSet)
+	if blockerSet == "" {
+		return false
+	}
+	issueID := strings.TrimSpace(issue.ID)
+	if state != nil && issueID != "" {
+		if record, ok := state.DependencyAutoUnblocks[issueID]; ok && record.BlockerSet == blockerSet {
+			return true
+		}
+	}
+	return o.workflowTimelineHasDependencyAutoUnblock(ctx, issue, blockerSet)
+}
+
+func (o *Orchestrator) workflowTimelineHasDependencyAutoUnblock(
+	ctx context.Context,
+	issue connector.Issue,
+	blockerSet string,
+) bool {
+	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
+	if !ok {
+		return false
+	}
+	for _, event := range timeline.Events {
+		if event.PhaseType != store.WorkflowPhaseTypeLane {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(event.Reason), "dependency_auto_unblock") {
+			continue
+		}
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if !ok || metadata.DependencyAutoUnblock == nil {
+			continue
+		}
+		if strings.TrimSpace(metadata.DependencyAutoUnblock.BlockerSet) == blockerSet {
+			return true
+		}
+	}
+	return false
+}
+
+func (o *Orchestrator) latestWorkflowLaneReason(ctx context.Context, issue connector.Issue, stateName string) (string, bool) {
+	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
+	if !ok {
+		return "", false
+	}
+	stateName = normalizeState(stateName)
+	for index := len(timeline.Events) - 1; index >= 0; index-- {
+		event := timeline.Events[index]
+		if event.PhaseType != store.WorkflowPhaseTypeLane {
+			continue
+		}
+		if normalizeState(event.PhaseName) != stateName {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			continue
+		}
+		return strings.TrimSpace(event.Reason), true
+	}
+	return "", false
+}
+
+func (o *Orchestrator) issueWorkflowTimeline(ctx context.Context, issue connector.Issue) (store.WorkflowTimeline, bool) {
+	reader, ok := o.workflowMetrics.(WorkflowMetricsTimelineReader)
+	if !ok || reader == nil {
+		return store.WorkflowTimeline{}, false
+	}
+	timeline, err := reader.IssueWorkflowTimeline(ctx, store.IssueIdentity{
+		IssueID:    issue.ID,
+		Identifier: issue.Identifier,
+		IssueURL:   issue.URL,
+	})
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("dependency auto-unblock workflow timeline read failed", "issue_id", strings.TrimSpace(issue.ID), "identifier", issue.Identifier, "error", err)
+		}
+		return store.WorkflowTimeline{}, false
+	}
+	return timeline, true
+}
+
+func dependencyAutoUnblockBlockerSet(blockers []dependencyBlocker) string {
+	keys := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		key := dependencyAutoUnblockBlockerKey(blocker)
+		if key != "" {
+			keys = append(keys, key)
+		}
+	}
+	keys = uniqueStrings(keys)
+	slices.Sort(keys)
+	return strings.Join(keys, "\n")
+}
+
+func dependencyAutoUnblockBlockerKey(blocker dependencyBlocker) string {
+	key := firstNonBlank(blocker.Ref.Identifier, blocker.Ref.ID, blocker.Issue.Identifier, blocker.Issue.ID)
+	return strings.ToLower(strings.TrimSpace(key))
+}
+
+func dependencyAutoUnblockBlockerLabels(blockers []dependencyBlocker) []string {
+	labels := make([]string, 0, len(blockers))
+	for _, blocker := range blockers {
+		if label := dependencyBlockerLabel(blocker); label != "" {
+			labels = append(labels, label)
+		}
+	}
+	labels = uniqueStrings(labels)
+	slices.Sort(labels)
+	return labels
 }
 
 func dependencyAutoUnblockComment(sourceState string, targetState string, blockers []dependencyBlocker) string {

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -98,7 +98,7 @@ func (o *Orchestrator) autoUnblockDependencyIssues(
 		if issueID == "" {
 			continue
 		}
-		if o.dependencyAutoUnblockStickyBlocked(ctx, state, issue) {
+		if o.issueHasStickyBlockReason(ctx, state, issue) {
 			continue
 		}
 		hydrated, ok := o.hydrateDependencyAutoUnblockIssue(ctx, issue, cfg.SourceStates)
@@ -749,21 +749,21 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 	return true
 }
 
-func (o *Orchestrator) dependencyAutoUnblockStickyBlocked(ctx context.Context, state *State, issue connector.Issue) bool {
+func (o *Orchestrator) issueHasStickyBlockReason(ctx context.Context, state *State, issue connector.Issue) bool {
 	issueID := strings.TrimSpace(issue.ID)
 	if state != nil && issueID != "" {
-		if blocked, ok := state.Blocked[issueID]; ok && dependencyAutoUnblockStickyReason(blocked.Reason) {
+		if blocked, ok := state.Blocked[issueID]; ok && stickyBlockReason(blocked.Reason) {
 			return true
 		}
 	}
-	if dependencyAutoUnblockStickyReason(issue.BlockerReason) {
+	if stickyBlockReason(issue.BlockerReason) {
 		return true
 	}
 	reason, ok := o.latestWorkflowLaneReason(ctx, issue, blockedStatusState)
-	return ok && dependencyAutoUnblockStickyReason(reason)
+	return ok && stickyBlockReason(reason)
 }
 
-func dependencyAutoUnblockStickyReason(reason string) bool {
+func stickyBlockReason(reason string) bool {
 	switch strings.ToLower(strings.TrimSpace(reason)) {
 	case "rework_limit", "circuit_breaker":
 		return true

--- a/internal/orchestrator/dependency_autounblock_test.go
+++ b/internal/orchestrator/dependency_autounblock_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
 )
 
 func TestTickAutoUnblocksDependencyWaitingIssue(t *testing.T) {
@@ -55,6 +56,97 @@ func TestTickAutoUnblocksDependencyWaitingIssue(t *testing.T) {
 	}
 	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "dependency_auto_unblock_transition" {
 		t.Fatalf("RecentEvents = %#v, want dependency auto-unblock event", state.RecentEvents)
+	}
+}
+
+func TestTickAutoUnblocksDependencyOnlyOnceForSameResolvedBlockerSet(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-repeat-blocked", "Blocked")
+	prNumber := 418
+	waiting.PRNumber = &prNumber
+	waiting.PullRequest = &connector.PullRequest{
+		Number: prNumber,
+		State:  "OPEN",
+		URL:    "https://github.test/digitaldrywood/detent/pull/418",
+	}
+	waiting.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#415"}}
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	state := newState(orch.cfg)
+	now := time.Date(2026, 7, 8, 15, 0, 0, 0, time.UTC)
+
+	orch.tick(context.Background(), &state, now)
+	orch.tick(context.Background(), &state, now.Add(time.Minute))
+
+	if got, want := tracker.updates, []dependencyAutoUnblockUpdate{{issueID: waiting.ID, state: "Rework"}}; !slices.Equal(got, want) {
+		t.Fatalf("updates = %#v, want one Blocked to Rework transition", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one audit comment", tracker.comments)
+	}
+	events := metrics.snapshot()
+	rework := events[len(events)-1]
+	metadata, ok := workflowLaneMetadataFromJSON(rework.MetadataJSON)
+	if !ok || metadata.DependencyAutoUnblock == nil || metadata.DependencyAutoUnblock.BlockerSet == "" {
+		t.Fatalf("latest Rework metadata = %q, want dependency_auto_unblock blocker_set", rework.MetadataJSON)
+	}
+}
+
+func TestTickAutoUnblockSkipsPersistedReworkLimitBlockedIssue(t *testing.T) {
+	t.Parallel()
+
+	waiting := dependencyAutoUnblockIssue("issue-rework-limit-blocked", "Blocked")
+	waiting.Description = "Blocked by #415"
+	blocker := dependencyAutoUnblockIssue("issue-done", "Done")
+	blocker.Identifier = "digitaldrywood/detent#415"
+	tracker := &dependencyAutoUnblockConnector{
+		stateIssues: []connector.Issue{waiting},
+		blockers:    []connector.Issue{blocker},
+	}
+	orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{
+		Enabled:      true,
+		SourceStates: []string{"Blocked"},
+		TargetState:  "Todo",
+		Readiness:    DependencyReadinessTerminalOrMerged,
+	})
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch.workflowMetrics = metrics
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      waiting.ID,
+		Identifier:   waiting.Identifier,
+		IssueURL:     waiting.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    "Blocked",
+		Reason:       "rework_limit",
+		Status:       "entered",
+		StartedAt:    time.Date(2026, 7, 8, 14, 59, 0, 0, time.UTC),
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, time.Date(2026, 7, 8, 15, 1, 0, 0, time.UTC))
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want no auto-unblock for rework_limit Blocked issue", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want no auto-unblock comment", tracker.comments)
 	}
 }
 

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -69,6 +69,9 @@ func (s *State) ensureInitialized(cfg Config) {
 	if s.Retry == nil {
 		s.Retry = map[string]Retry{}
 	}
+	if s.DependencyAutoUnblocks == nil {
+		s.DependencyAutoUnblocks = map[string]DependencyAutoUnblockRecord{}
+	}
 	if s.BudgetRefusals == nil {
 		s.BudgetRefusals = map[string]BudgetRefusal{}
 	}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -48,6 +48,7 @@ type State struct {
 	Retry                    map[string]Retry
 	MergeTimings             map[string]MergeTiming
 	TransientCheckRetries    map[string]TransientCheckRetry
+	DependencyAutoUnblocks   map[string]DependencyAutoUnblockRecord
 	BudgetRefusals           map[string]BudgetRefusal
 	PriorAttempts            map[string]runpkg.PriorAttempt
 	InstantFailures          map[string]InstantFailure
@@ -158,6 +159,11 @@ type TransientCheckRetry struct {
 	RetriedAt     time.Time
 }
 
+type DependencyAutoUnblockRecord struct {
+	BlockerSet  string
+	UnblockedAt time.Time
+}
+
 func newState(cfg Config) State {
 	return State{
 		PollInterval:             cfg.PollInterval,
@@ -176,6 +182,7 @@ func newState(cfg Config) State {
 		Retry:                    map[string]Retry{},
 		MergeTimings:             map[string]MergeTiming{},
 		TransientCheckRetries:    map[string]TransientCheckRetry{},
+		DependencyAutoUnblocks:   map[string]DependencyAutoUnblockRecord{},
 		BudgetRefusals:           map[string]BudgetRefusal{},
 		PriorAttempts:            map[string]runpkg.PriorAttempt{},
 		InstantFailures:          map[string]InstantFailure{},
@@ -221,6 +228,7 @@ func (s State) clone() State {
 		Retry:                    make(map[string]Retry, len(s.Retry)),
 		MergeTimings:             maps.Clone(s.MergeTimings),
 		TransientCheckRetries:    maps.Clone(s.TransientCheckRetries),
+		DependencyAutoUnblocks:   maps.Clone(s.DependencyAutoUnblocks),
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		PriorAttempts:            clonePriorAttempts(s.PriorAttempts),
 		InstantFailures:          make(map[string]InstantFailure, len(s.InstantFailures)),

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"strings"
 	"time"
@@ -18,6 +19,22 @@ type WorkflowMetricsRecorder interface {
 
 type WorkflowMetricsTimelineReader interface {
 	IssueWorkflowTimeline(context.Context, store.IssueIdentity) (store.WorkflowTimeline, error)
+}
+
+type workflowLaneMetadata struct {
+	PullRequest           *workflowLanePullRequestMetadata           `json:"pull_request,omitempty"`
+	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`
+}
+
+type workflowLanePullRequestMetadata struct {
+	Number       int64    `json:"number,omitempty"`
+	HeadSHA      string   `json:"head_sha,omitempty"`
+	FailedChecks []string `json:"failed_checks,omitempty"`
+}
+
+type workflowLaneDependencyAutoUnblockMetadata struct {
+	BlockerSet string   `json:"blocker_set,omitempty"`
+	Blockers   []string `json:"blockers,omitempty"`
 }
 
 func (o *Orchestrator) updateIssueState(
@@ -38,6 +55,18 @@ func (o *Orchestrator) updateIssueStateByID(
 	at time.Time,
 	reason string,
 ) error {
+	return o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, at, reason, workflowLaneMetadata{})
+}
+
+func (o *Orchestrator) updateIssueStateByIDWithMetadata(
+	ctx context.Context,
+	issueID string,
+	issue connector.Issue,
+	targetState string,
+	at time.Time,
+	reason string,
+	metadata workflowLaneMetadata,
+) error {
 	if err := o.connector.UpdateIssueState(ctx, issueID, targetState); err != nil {
 		if errors.Is(err, connector.ErrStateUpdateBlocked) {
 			if o.logger != nil {
@@ -50,7 +79,7 @@ func (o *Orchestrator) updateIssueStateByID(
 	if strings.TrimSpace(issue.ID) == "" {
 		issue.ID = issueID
 	}
-	o.recordLaneTransition(ctx, issue, targetState, at, reason)
+	o.recordLaneTransition(ctx, issue, targetState, at, reason, metadata)
 	return nil
 }
 
@@ -60,6 +89,7 @@ func (o *Orchestrator) recordLaneTransition(
 	targetState string,
 	at time.Time,
 	reason string,
+	metadata workflowLaneMetadata,
 ) {
 	recorder := o.workflowMetrics
 	if recorder == nil {
@@ -88,7 +118,7 @@ func (o *Orchestrator) recordLaneTransition(
 		PhaseType:      store.WorkflowPhaseTypeLane,
 		Reason:         reason,
 		StartedAt:      at,
-		MetadataJSON:   "{}",
+		MetadataJSON:   workflowLaneMetadataJSON(issue, metadata),
 		EndpointFamily: "tracker",
 	}
 	if sourceState != "" {
@@ -149,4 +179,45 @@ func workflowMetricsPRNumber(issue connector.Issue) *int64 {
 	default:
 		return nil
 	}
+}
+
+func workflowLaneMetadataJSON(issue connector.Issue, metadata workflowLaneMetadata) string {
+	if metadata.PullRequest == nil {
+		metadata.PullRequest = workflowLanePullRequestMetadataFromIssue(issue)
+	}
+	if metadata.PullRequest == nil && metadata.DependencyAutoUnblock == nil {
+		return "{}"
+	}
+	data, err := json.Marshal(metadata)
+	if err != nil {
+		return "{}"
+	}
+	return string(data)
+}
+
+func workflowLaneMetadataFromJSON(raw string) (workflowLaneMetadata, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" || raw == "{}" {
+		return workflowLaneMetadata{}, false
+	}
+	var metadata workflowLaneMetadata
+	if err := json.Unmarshal([]byte(raw), &metadata); err != nil {
+		return workflowLaneMetadata{}, false
+	}
+	return metadata, true
+}
+
+func workflowLanePullRequestMetadataFromIssue(issue connector.Issue) *workflowLanePullRequestMetadata {
+	var metadata workflowLanePullRequestMetadata
+	if number := workflowMetricsPRNumber(issue); number != nil && *number > 0 {
+		metadata.Number = *number
+	}
+	if issue.PullRequest != nil {
+		metadata.HeadSHA = strings.TrimSpace(issue.PullRequest.HeadSHA)
+		metadata.FailedChecks = autoPromoteCanonicalChecks(autoPromoteFailedChecksFromPullRequest(issue.PullRequest))
+	}
+	if metadata.Number <= 0 && metadata.HeadSHA == "" && len(metadata.FailedChecks) == 0 {
+		return nil
+	}
+	return &metadata
 }


### PR DESCRIPTION
## Summary

- Add a default-on repeated-rework breaker that keys CI rework attempts by PR number, head SHA, and failing check set.
- Persist lane metadata so unchanged worker-success cycles count toward the breaker while new commits reset it.
- Make dependency auto-unblock one-shot for the same resolved blocker set and keep breaker-parked issues in Blocked.

Fixes #1046

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`