### PR TITLE
test(procgroup): add process-group tests

### DIFF
--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -1,0 +1,270 @@
+//go:build unix
+
+package procgroup
+
+import (
+	"context"
+	"errors"
+	"os/exec"
+	"sync"
+	"syscall"
+	"testing"
+)
+
+func TestConfigure(t *testing.T) {
+	existing := &syscall.SysProcAttr{}
+
+	tests := []struct {
+		name     string
+		cmd      *exec.Cmd
+		wantAttr *syscall.SysProcAttr
+	}{
+		{
+			name: "fresh command",
+			cmd:  exec.Command("true"),
+		},
+		{
+			name: "existing syscall attributes",
+			cmd: &exec.Cmd{
+				Path:        "true",
+				SysProcAttr: existing,
+			},
+			wantAttr: existing,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			Configure(tt.cmd)
+
+			if tt.cmd.SysProcAttr == nil {
+				t.Fatal("SysProcAttr is nil, want configured attributes")
+			}
+			if !tt.cmd.SysProcAttr.Setpgid {
+				t.Fatal("SysProcAttr.Setpgid is false, want true")
+			}
+			if tt.cmd.Cancel == nil {
+				t.Fatal("Cancel is nil, want process tree termination hook")
+			}
+			if tt.wantAttr != nil && tt.cmd.SysProcAttr != tt.wantAttr {
+				t.Fatal("SysProcAttr was replaced, want existing attributes reused")
+			}
+		})
+	}
+}
+
+func TestGroupID(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  func(t *testing.T) *exec.Cmd
+		want func(t *testing.T, cmd *exec.Cmd, got int)
+	}{
+		{
+			name: "nil command",
+			cmd: func(*testing.T) *exec.Cmd {
+				return nil
+			},
+			want: func(t *testing.T, _ *exec.Cmd, got int) {
+				if got != 0 {
+					t.Fatalf("GroupID() = %d, want 0", got)
+				}
+			},
+		},
+		{
+			name: "nil process",
+			cmd: func(*testing.T) *exec.Cmd {
+				return exec.Command("true")
+			},
+			want: func(t *testing.T, _ *exec.Cmd, got int) {
+				if got != 0 {
+					t.Fatalf("GroupID() = %d, want 0", got)
+				}
+			},
+		},
+		{
+			name: "started command",
+			cmd: func(t *testing.T) *exec.Cmd {
+				return startSleep(t).cmd
+			},
+			want: func(t *testing.T, cmd *exec.Cmd, got int) {
+				if got <= 0 {
+					t.Fatalf("GroupID() = %d, want positive group ID", got)
+				}
+				if got != cmd.Process.Pid {
+					t.Fatalf("GroupID() = %d, want child pid %d", got, cmd.Process.Pid)
+				}
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.cmd(t)
+			tt.want(t, cmd, GroupID(cmd))
+		})
+	}
+}
+
+func TestTerminateTree(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  func(t *testing.T) (*exec.Cmd, int, func() error)
+	}{
+		{
+			name: "nil command and zero group",
+			cmd: func(*testing.T) (*exec.Cmd, int, func() error) {
+				return nil, 0, nil
+			},
+		},
+		{
+			name: "live process group",
+			cmd: func(t *testing.T) (*exec.Cmd, int, func() error) {
+				proc := startSleep(t)
+				return proc.cmd, GroupID(proc.cmd), proc.Wait
+			},
+		},
+		{
+			name: "already exited process group",
+			cmd: func(t *testing.T) (*exec.Cmd, int, func() error) {
+				cmd, pgid := startExitedCommand(t)
+				return cmd, pgid, nil
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd, pgid, wait := tt.cmd(t)
+
+			if err := TerminateTree(cmd, pgid); err != nil {
+				t.Fatalf("TerminateTree() error = %v, want nil", err)
+			}
+			if wait != nil {
+				assertKilled(t, wait())
+			}
+		})
+	}
+}
+
+func TestCleanup(t *testing.T) {
+	tests := []struct {
+		name string
+		pgid func(t *testing.T) (int, func() error)
+	}{
+		{
+			name: "zero group",
+			pgid: func(*testing.T) (int, func() error) {
+				return 0, nil
+			},
+		},
+		{
+			name: "negative group",
+			pgid: func(*testing.T) (int, func() error) {
+				return -1, nil
+			},
+		},
+		{
+			name: "nonexistent group",
+			pgid: func(*testing.T) (int, func() error) {
+				return 1 << 30, nil
+			},
+		},
+		{
+			name: "live group",
+			pgid: func(t *testing.T) (int, func() error) {
+				proc := startSleep(t)
+				return GroupID(proc.cmd), proc.Wait
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			pgid, wait := tt.pgid(t)
+
+			if err := Cleanup(pgid); err != nil {
+				t.Fatalf("Cleanup() error = %v, want nil", err)
+			}
+			if wait != nil {
+				assertKilled(t, wait())
+			}
+		})
+	}
+}
+
+type startedProcess struct {
+	cmd     *exec.Cmd
+	wait    sync.Once
+	waitErr error
+}
+
+func startSleep(t *testing.T) *startedProcess {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "sleep", "30")
+	Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v, want nil", err)
+	}
+
+	proc := &startedProcess{cmd: cmd}
+	t.Cleanup(func() {
+		if cmd.ProcessState != nil {
+			return
+		}
+		if err := TerminateTree(cmd, GroupID(cmd)); err != nil {
+			t.Fatalf("TerminateTree() cleanup error = %v, want nil", err)
+		}
+		_ = proc.Wait()
+	})
+
+	return proc
+}
+
+func (p *startedProcess) Wait() error {
+	p.wait.Do(func() {
+		p.waitErr = p.cmd.Wait()
+	})
+	return p.waitErr
+}
+
+func startExitedCommand(t *testing.T) (*exec.Cmd, int) {
+	t.Helper()
+
+	cmd := exec.CommandContext(context.Background(), "true")
+	Configure(cmd)
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("Start() error = %v, want nil", err)
+	}
+
+	pgid := GroupID(cmd)
+	if err := cmd.Wait(); err != nil {
+		t.Fatalf("Wait() error = %v, want nil", err)
+	}
+
+	return cmd, pgid
+}
+
+func assertKilled(t *testing.T, err error) {
+	t.Helper()
+
+	if err == nil {
+		t.Fatal("Wait() error = nil, want process killed by signal")
+	}
+
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Fatalf("Wait() error = %T, want *exec.ExitError", err)
+	}
+
+	status, ok := exitErr.Sys().(syscall.WaitStatus)
+	if !ok {
+		t.Fatalf("Wait() status = %T, want syscall.WaitStatus", exitErr.Sys())
+	}
+	if !status.Signaled() {
+		t.Fatalf("Wait() status = %v, want signaled process", status)
+	}
+	if status.Signal() != syscall.SIGKILL {
+		t.Fatalf("Wait() signal = %v, want %v", status.Signal(), syscall.SIGKILL)
+	}
+}

--- a/internal/procgroup/process_group_unix_test.go
+++ b/internal/procgroup/process_group_unix_test.go
@@ -9,6 +9,7 @@ import (
 	"sync"
 	"syscall"
 	"testing"
+	"time"
 )
 
 func TestConfigure(t *testing.T) {
@@ -108,24 +109,26 @@ func TestGroupID(t *testing.T) {
 func TestTerminateTree(t *testing.T) {
 	tests := []struct {
 		name string
-		cmd  func(t *testing.T) (*exec.Cmd, int, func() error)
+		cmd  func(t *testing.T) (*exec.Cmd, int, func(t *testing.T))
 	}{
 		{
 			name: "nil command and zero group",
-			cmd: func(*testing.T) (*exec.Cmd, int, func() error) {
+			cmd: func(*testing.T) (*exec.Cmd, int, func(t *testing.T)) {
 				return nil, 0, nil
 			},
 		},
 		{
 			name: "live process group",
-			cmd: func(t *testing.T) (*exec.Cmd, int, func() error) {
-				proc := startSleep(t)
-				return proc.cmd, GroupID(proc.cmd), proc.Wait
+			cmd: func(t *testing.T) (*exec.Cmd, int, func(t *testing.T)) {
+				proc := startSleepGroup(t)
+				return proc.cmd, GroupID(proc.cmd), func(t *testing.T) {
+					assertProcessGroupKilled(t, proc)
+				}
 			},
 		},
 		{
 			name: "already exited process group",
-			cmd: func(t *testing.T) (*exec.Cmd, int, func() error) {
+			cmd: func(t *testing.T) (*exec.Cmd, int, func(t *testing.T)) {
 				cmd, pgid := startExitedCommand(t)
 				return cmd, pgid, nil
 			},
@@ -140,7 +143,7 @@ func TestTerminateTree(t *testing.T) {
 				t.Fatalf("TerminateTree() error = %v, want nil", err)
 			}
 			if wait != nil {
-				assertKilled(t, wait())
+				wait(t)
 			}
 		})
 	}
@@ -149,31 +152,33 @@ func TestTerminateTree(t *testing.T) {
 func TestCleanup(t *testing.T) {
 	tests := []struct {
 		name string
-		pgid func(t *testing.T) (int, func() error)
+		pgid func(t *testing.T) (int, func(t *testing.T))
 	}{
 		{
 			name: "zero group",
-			pgid: func(*testing.T) (int, func() error) {
+			pgid: func(*testing.T) (int, func(t *testing.T)) {
 				return 0, nil
 			},
 		},
 		{
 			name: "negative group",
-			pgid: func(*testing.T) (int, func() error) {
+			pgid: func(*testing.T) (int, func(t *testing.T)) {
 				return -1, nil
 			},
 		},
 		{
 			name: "nonexistent group",
-			pgid: func(*testing.T) (int, func() error) {
+			pgid: func(*testing.T) (int, func(t *testing.T)) {
 				return 1 << 30, nil
 			},
 		},
 		{
 			name: "live group",
-			pgid: func(t *testing.T) (int, func() error) {
-				proc := startSleep(t)
-				return GroupID(proc.cmd), proc.Wait
+			pgid: func(t *testing.T) (int, func(t *testing.T)) {
+				proc := startSleepGroup(t)
+				return GroupID(proc.cmd), func(t *testing.T) {
+					assertProcessGroupKilled(t, proc)
+				}
 			},
 		},
 	}
@@ -186,16 +191,19 @@ func TestCleanup(t *testing.T) {
 				t.Fatalf("Cleanup() error = %v, want nil", err)
 			}
 			if wait != nil {
-				assertKilled(t, wait())
+				wait(t)
 			}
 		})
 	}
 }
 
 type startedProcess struct {
-	cmd     *exec.Cmd
-	wait    sync.Once
-	waitErr error
+	cmd           *exec.Cmd
+	wait          sync.Once
+	waitErr       error
+	groupMember   *exec.Cmd
+	memberWait    sync.Once
+	memberWaitErr error
 }
 
 func startSleep(t *testing.T) *startedProcess {
@@ -209,14 +217,51 @@ func startSleep(t *testing.T) *startedProcess {
 
 	proc := &startedProcess{cmd: cmd}
 	t.Cleanup(func() {
-		if cmd.ProcessState != nil {
-			return
-		}
-		if err := TerminateTree(cmd, GroupID(cmd)); err != nil {
-			t.Fatalf("TerminateTree() cleanup error = %v, want nil", err)
+		if cmd.ProcessState == nil || (proc.groupMember != nil && proc.groupMember.ProcessState == nil) {
+			if err := TerminateTree(cmd, GroupID(cmd)); err != nil {
+				t.Fatalf("TerminateTree() cleanup error = %v, want nil", err)
+			}
+			if proc.groupMember != nil && proc.groupMember.ProcessState == nil {
+				_ = proc.groupMember.Process.Kill()
+			}
 		}
 		_ = proc.Wait()
+		if proc.groupMember != nil {
+			_ = proc.WaitGroupMember()
+		}
 	})
+
+	return proc
+}
+
+func startSleepGroup(t *testing.T) *startedProcess {
+	t.Helper()
+
+	proc := startSleep(t)
+	pgid := GroupID(proc.cmd)
+
+	member := exec.CommandContext(context.Background(), "sleep", "30")
+	member.SysProcAttr = &syscall.SysProcAttr{
+		Setpgid: true,
+		Pgid:    pgid,
+	}
+	if err := member.Start(); err != nil {
+		if killErr := TerminateTree(proc.cmd, pgid); killErr != nil {
+			t.Fatalf("TerminateTree() cleanup error = %v, want nil", killErr)
+		}
+		_ = proc.Wait()
+		t.Fatalf("Start() group member error = %v, want nil", err)
+	}
+
+	proc.groupMember = member
+	if got := GroupID(member); got != pgid {
+		if killErr := TerminateTree(proc.cmd, pgid); killErr != nil {
+			t.Fatalf("TerminateTree() cleanup error = %v, want nil", killErr)
+		}
+		_ = proc.Wait()
+		_ = proc.WaitGroupMember()
+		t.Fatalf("group member pgid = %d, want %d", got, pgid)
+	}
 
 	return proc
 }
@@ -226,6 +271,13 @@ func (p *startedProcess) Wait() error {
 		p.waitErr = p.cmd.Wait()
 	})
 	return p.waitErr
+}
+
+func (p *startedProcess) WaitGroupMember() error {
+	p.memberWait.Do(func() {
+		p.memberWaitErr = p.groupMember.Wait()
+	})
+	return p.memberWaitErr
 }
 
 func startExitedCommand(t *testing.T) (*exec.Cmd, int) {
@@ -243,6 +295,30 @@ func startExitedCommand(t *testing.T) (*exec.Cmd, int) {
 	}
 
 	return cmd, pgid
+}
+
+func assertProcessGroupKilled(t *testing.T, proc *startedProcess) {
+	t.Helper()
+
+	assertKilled(t, waitForExit(t, proc.Wait))
+	assertKilled(t, waitForExit(t, proc.WaitGroupMember))
+}
+
+func waitForExit(t *testing.T, wait func() error) error {
+	t.Helper()
+
+	done := make(chan error, 1)
+	go func() {
+		done <- wait()
+	}()
+
+	select {
+	case err := <-done:
+		return err
+	case <-time.After(5 * time.Second):
+		t.Fatal("Wait() timed out, want process exit")
+		return nil
+	}
 }
 
 func assertKilled(t *testing.T, err error) {


### PR DESCRIPTION
## Summary

- Add Unix-only table-driven tests for process-group configuration, group ID lookup, termination, and cleanup behavior.
- Verify live process groups are killed and reaped without leaving child processes behind.

Fixes #1016

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no UI changes.)

## Test Plan

- [x] `go test -race ./internal/procgroup`
- [x] `go test -coverprofile=tmp/procgroup.cover ./internal/procgroup` (80.0% coverage)
- [x] `make check`