### PR TITLE
fix(web): bound async API usage writes

### DIFF
--- a/internal/web/async_writer.go
+++ b/internal/web/async_writer.go
@@ -1,0 +1,85 @@
+package web
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+)
+
+type asyncStoreWriter struct {
+	jobs   chan func(context.Context)
+	done   chan struct{}
+	logger *slog.Logger
+
+	mu     sync.Mutex
+	closed bool
+}
+
+func newAsyncStoreWriter(buffer int, logger *slog.Logger) *asyncStoreWriter {
+	if buffer < 0 {
+		buffer = 0
+	}
+	if logger == nil {
+		logger = slog.Default()
+	}
+	writer := &asyncStoreWriter{
+		jobs:   make(chan func(context.Context), buffer),
+		done:   make(chan struct{}),
+		logger: logger,
+	}
+	go writer.run()
+	return writer
+}
+
+func (w *asyncStoreWriter) Enqueue(job func(context.Context)) bool {
+	if w == nil || job == nil {
+		return false
+	}
+
+	w.mu.Lock()
+	defer w.mu.Unlock()
+
+	if w.closed {
+		return false
+	}
+	select {
+	case w.jobs <- job:
+		return true
+	default:
+		w.logger.Warn("dropping async store write because queue is full", "buffer", cap(w.jobs))
+		return false
+	}
+}
+
+func (w *asyncStoreWriter) Close(ctx context.Context) error {
+	if w == nil {
+		return nil
+	}
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	w.mu.Lock()
+	if !w.closed {
+		w.closed = true
+		close(w.jobs)
+	}
+	w.mu.Unlock()
+
+	select {
+	case <-w.done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (w *asyncStoreWriter) run() {
+	defer close(w.done)
+	for job := range w.jobs {
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		job(ctx)
+		cancel()
+	}
+}

--- a/internal/web/async_writer_test.go
+++ b/internal/web/async_writer_test.go
@@ -1,0 +1,213 @@
+package web
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestAsyncStoreWriter(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		run  func(*testing.T)
+	}{
+		{
+			name: "enqueued jobs execute",
+			run: func(t *testing.T) {
+				t.Helper()
+
+				writer := newAsyncStoreWriter(1, discardAsyncStoreWriterLogger())
+				ran := make(chan struct{})
+				if !writer.Enqueue(func(context.Context) {
+					close(ran)
+				}) {
+					t.Fatal("Enqueue() = false, want true")
+				}
+				waitForAsyncWriterSignal(t, ran)
+				closeAsyncStoreWriter(t, writer)
+			},
+		},
+		{
+			name: "close drains queued jobs",
+			run: func(t *testing.T) {
+				t.Helper()
+
+				writer := newAsyncStoreWriter(1, discardAsyncStoreWriterLogger())
+				started := make(chan struct{})
+				release := make(chan struct{})
+				queued := make(chan struct{})
+				if !writer.Enqueue(func(context.Context) {
+					close(started)
+					<-release
+				}) {
+					t.Fatal("Enqueue(blocking) = false, want true")
+				}
+				waitForAsyncWriterSignal(t, started)
+				if !writer.Enqueue(func(context.Context) {
+					close(queued)
+				}) {
+					t.Fatal("Enqueue(queued) = false, want true")
+				}
+
+				closed := make(chan error, 1)
+				go func() {
+					ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+					defer cancel()
+					closed <- writer.Close(ctx)
+				}()
+				close(release)
+				if err := waitForAsyncWriterClose(t, closed); err != nil {
+					t.Fatalf("Close() error = %v, want nil", err)
+				}
+				select {
+				case <-queued:
+				default:
+					t.Fatal("queued job did not run before Close returned")
+				}
+			},
+		},
+		{
+			name: "enqueue returns false when buffer is full",
+			run: func(t *testing.T) {
+				t.Helper()
+
+				var logs bytes.Buffer
+				writer := newAsyncStoreWriter(1, slog.New(slog.NewTextHandler(&logs, nil)))
+				started := make(chan struct{})
+				release := make(chan struct{})
+				if !writer.Enqueue(func(context.Context) {
+					close(started)
+					<-release
+				}) {
+					t.Fatal("Enqueue(blocking) = false, want true")
+				}
+				waitForAsyncWriterSignal(t, started)
+				if !writer.Enqueue(func(context.Context) {}) {
+					t.Fatal("Enqueue(buffered) = false, want true")
+				}
+				if writer.Enqueue(func(context.Context) {}) {
+					t.Fatal("Enqueue(full) = true, want false")
+				}
+				if !strings.Contains(logs.String(), "queue is full") {
+					t.Fatalf("logs missing queue full warning:\n%s", logs.String())
+				}
+				close(release)
+				closeAsyncStoreWriter(t, writer)
+			},
+		},
+		{
+			name: "close returns canceled context error",
+			run: func(t *testing.T) {
+				t.Helper()
+
+				writer := newAsyncStoreWriter(1, discardAsyncStoreWriterLogger())
+				started := make(chan struct{})
+				release := make(chan struct{})
+				if !writer.Enqueue(func(context.Context) {
+					close(started)
+					<-release
+				}) {
+					t.Fatal("Enqueue() = false, want true")
+				}
+				waitForAsyncWriterSignal(t, started)
+				ctx, cancel := context.WithCancel(context.Background())
+				cancel()
+
+				closed := make(chan error, 1)
+				go func() {
+					closed <- writer.Close(ctx)
+				}()
+				err := waitForAsyncWriterClose(t, closed)
+				if !errors.Is(err, context.Canceled) {
+					t.Fatalf("Close() error = %v, want %v", err, context.Canceled)
+				}
+				close(release)
+				waitForAsyncWriterSignal(t, writer.done)
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			tt.run(t)
+		})
+	}
+}
+
+func TestAsyncStoreWriterConcurrentEnqueueClose(t *testing.T) {
+	t.Parallel()
+
+	writer := newAsyncStoreWriter(8, discardAsyncStoreWriterLogger())
+	var ran int64
+	var wg sync.WaitGroup
+	start := make(chan struct{})
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 200 {
+				writer.Enqueue(func(context.Context) {
+					atomic.AddInt64(&ran, 1)
+				})
+			}
+		}()
+	}
+
+	close(start)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := writer.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v, want nil", err)
+	}
+	wg.Wait()
+	if atomic.LoadInt64(&ran) < 0 {
+		t.Fatal("ran count should never be negative")
+	}
+}
+
+func discardAsyncStoreWriterLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func closeAsyncStoreWriter(t *testing.T, writer *asyncStoreWriter) {
+	t.Helper()
+
+	ctx, cancel := context.WithTimeout(context.Background(), time.Second)
+	defer cancel()
+	if err := writer.Close(ctx); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+}
+
+func waitForAsyncWriterSignal(t *testing.T, ch <-chan struct{}) {
+	t.Helper()
+
+	select {
+	case <-ch:
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async writer signal")
+	}
+}
+
+func waitForAsyncWriterClose(t *testing.T, ch <-chan error) error {
+	t.Helper()
+
+	select {
+	case err := <-ch:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for async writer close")
+		return nil
+	}
+}

--- a/internal/web/auth.go
+++ b/internal/web/auth.go
@@ -489,13 +489,11 @@ func (s *Server) recordAPIUsage(c echo.Context, credential apikey.Credential, st
 		UserAgent:  c.Request().UserAgent(),
 		CreatedAt:  time.Now(),
 	}
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+	s.asyncWrites.Enqueue(func(ctx context.Context) {
 		if err := s.store.RecordAPIUsageLog(ctx, usage); err != nil {
 			s.logger.Warn("failed to log api usage", "error", err, "api_key_id", credential.ID, "key", credential.PrefixLast4)
 		}
-	}()
+	})
 }
 
 func (s *Server) markAPIKeyLastUsed(credential apikey.Credential) {
@@ -503,11 +501,9 @@ func (s *Server) markAPIKeyLastUsed(credential apikey.Credential) {
 		return
 	}
 	id := credential.ID
-	go func() {
-		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-		defer cancel()
+	s.asyncWrites.Enqueue(func(ctx context.Context) {
 		if err := s.store.MarkAPIKeyLastUsed(ctx, id, time.Now()); err != nil {
 			s.logger.Warn("failed to update api key last used", "error", err, "api_key_id", id, "key", credential.PrefixLast4)
 		}
-	}()
+	})
 }

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -130,6 +130,7 @@ type Server struct {
 	apiKeys             *apikey.Service
 	ipLimiter           *apiRateLimiter
 	keyLimiter          *apiRateLimiter
+	asyncWrites         *asyncStoreWriter
 	dashboardAuthSecret [32]byte
 	afterFunc           func(time.Duration, func()) *time.Timer
 }
@@ -158,6 +159,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 	e.Server.IdleTimeout = cfg.httpIdleTimeout()
 	kanban := cfg.kanban()
 	kanbanWorkflow := cfg.kanbanWorkflow(kanban)
+	logger := cfg.logger()
 	dashboardAuthSecret, err := newDashboardAuthSecret()
 	if err != nil {
 		return nil, fmt.Errorf("dashboard auth secret: %w", err)
@@ -170,7 +172,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		registry:            deps.Registry,
 		connector:           deps.Connector,
 		refresher:           deps.Refresher,
-		logger:              cfg.logger(),
+		logger:              logger,
 		mode:                mode,
 		tickEvery:           cfg.sseTickInterval(),
 		sseFragmentInterval: cfg.sseFragmentInterval(),
@@ -202,6 +204,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		apiKeys:             apikey.NewService(deps.Store),
 		ipLimiter:           newAPIRateLimiter(300, 60),
 		keyLimiter:          newAPIRateLimiter(120, 30),
+		asyncWrites:         newAsyncStoreWriter(256, logger),
 		dashboardAuthSecret: dashboardAuthSecret,
 		afterFunc:           time.AfterFunc,
 	}
@@ -239,7 +242,13 @@ func (s *Server) Shutdown(ctx context.Context) error {
 	if s.keyLimiter != nil {
 		s.keyLimiter.Stop()
 	}
-	return s.echo.Shutdown(ctx)
+	err := s.echo.Shutdown(ctx)
+	if s.asyncWrites != nil {
+		if closeErr := s.asyncWrites.Close(ctx); closeErr != nil {
+			return errors.Join(err, closeErr)
+		}
+	}
+	return err
 }
 
 func (s *Server) registerRoutes() {

--- a/internal/web/server_shutdown_test.go
+++ b/internal/web/server_shutdown_test.go
@@ -1,0 +1,131 @@
+package web
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/labstack/echo/v4"
+)
+
+func TestServerShutdownDrainsAsyncWritesAfterActiveHandlers(t *testing.T) {
+	t.Parallel()
+
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	e := echo.New()
+	e.HideBanner = true
+	e.HidePort = true
+	server := &Server{
+		echo:        e,
+		logger:      logger,
+		asyncWrites: newAsyncStoreWriter(1, logger),
+	}
+
+	started := make(chan struct{})
+	release := make(chan struct{})
+	shutdownStarted := make(chan struct{})
+	enqueued := make(chan bool, 1)
+	ran := make(chan struct{})
+	e.Server.RegisterOnShutdown(func() {
+		close(shutdownStarted)
+	})
+	e.GET("/block", func(c echo.Context) error {
+		close(started)
+		<-release
+		enqueued <- server.asyncWrites.Enqueue(func(context.Context) {
+			close(ran)
+		})
+		return c.NoContent(http.StatusAccepted)
+	})
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	serveErr := make(chan error, 1)
+	go func() {
+		serveErr <- server.StartListener(listener)
+	}()
+
+	clientResult := make(chan shutdownHTTPResult, 1)
+	go func() {
+		client := &http.Client{Timeout: 2 * time.Second}
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		req, err := http.NewRequestWithContext(ctx, http.MethodGet, "http://"+listener.Addr().String()+"/block", nil)
+		if err != nil {
+			clientResult <- shutdownHTTPResult{err: err}
+			return
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			clientResult <- shutdownHTTPResult{err: err}
+			return
+		}
+		defer resp.Body.Close()
+		_, _ = io.Copy(io.Discard, resp.Body)
+		clientResult <- shutdownHTTPResult{status: resp.StatusCode}
+	}()
+	waitForAsyncWriterSignal(t, started)
+
+	shutdownErr := make(chan error, 1)
+	go func() {
+		ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		defer cancel()
+		shutdownErr <- server.Shutdown(ctx)
+	}()
+	waitForAsyncWriterSignal(t, shutdownStarted)
+	close(release)
+
+	result := waitForShutdownHTTPResult(t, clientResult)
+	if result.err != nil {
+		t.Fatalf("GET /block error = %v", result.err)
+	}
+	if result.status != http.StatusAccepted {
+		t.Fatalf("GET /block status = %d, want %d", result.status, http.StatusAccepted)
+	}
+	if err := waitForAsyncWriterClose(t, shutdownErr); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if ok := waitForShutdownEnqueueResult(t, enqueued); !ok {
+		t.Fatal("Enqueue() after shutdown started = false, want true")
+	}
+	waitForAsyncWriterSignal(t, ran)
+	if err := waitForAsyncWriterClose(t, serveErr); err != nil && !errors.Is(err, http.ErrServerClosed) {
+		t.Fatalf("StartListener() error = %v, want %v", err, http.ErrServerClosed)
+	}
+}
+
+type shutdownHTTPResult struct {
+	status int
+	err    error
+}
+
+func waitForShutdownHTTPResult(t *testing.T, ch <-chan shutdownHTTPResult) shutdownHTTPResult {
+	t.Helper()
+
+	select {
+	case result := <-ch:
+		return result
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for shutdown HTTP result")
+		return shutdownHTTPResult{}
+	}
+}
+
+func waitForShutdownEnqueueResult(t *testing.T, ch <-chan bool) bool {
+	t.Helper()
+
+	select {
+	case ok := <-ch:
+		return ok
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for shutdown enqueue result")
+		return false
+	}
+}

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1525,6 +1525,48 @@ func TestAPIUsageLogRecordsReturnedHTTPErrorStatus(t *testing.T) {
 	}
 }
 
+func TestAPIUsageWritesDrainOnShutdown(t *testing.T) {
+	t.Parallel()
+
+	server, backend, _, _ := newAPIKeyWorkItemTestServer(t)
+	token, keyID := createAPIKeyThroughHTTP(t, server, `{
+		"name": "Shutdown drain",
+		"scopes": ["read"],
+		"expires_in": "90d"
+	}`)
+	rec := performJSON(t, server.Handler(), http.MethodGet, "/api/v1/state", "", map[string]string{
+		"Authorization": "Bearer " + token,
+	})
+	if rec.Code != http.StatusOK {
+		t.Fatalf("state status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	if err := server.Shutdown(ctx); err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+
+	queries := backend.Queries()
+	if queries == nil {
+		t.Fatal("store Queries() = nil")
+	}
+	logs, err := queries.ListAPIUsageLogsByKey(context.Background(), keyID)
+	if err != nil {
+		t.Fatalf("ListAPIUsageLogsByKey() error = %v", err)
+	}
+	if len(logs) == 0 {
+		t.Fatalf("usage log count for %s = 0, want at least 1", keyID)
+	}
+	key, err := backend.APIKey(context.Background(), keyID)
+	if err != nil {
+		t.Fatalf("APIKey() error = %v", err)
+	}
+	if key.LastUsedAt == nil {
+		t.Fatal("LastUsedAt = nil, want shutdown to drain last-used write")
+	}
+}
+
 func TestDemoScenarioHeadersAreGatedToScreenshotsMode(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Add a bounded async store writer that drains queued auth store writes during shutdown and drops new work when the queue is full.
- Route API usage and last-used recording through the writer instead of spawning request-scoped goroutines.
- Cover writer lifecycle behavior, active-handler shutdown ordering, and authenticated shutdown-drain persistence with race-safe tests.

Fixes #1015

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A, no visual changes to primary operator screens.

## Test Plan

- [x] `go test -race ./internal/web -run 'TestServerShutdownDrainsAsyncWritesAfterActiveHandlers|TestAPIUsageWritesDrainOnShutdown|TestAsyncStoreWriter'`
- [x] `go test -race ./internal/web`
- [x] `make check`