### PR TITLE
refactor(web): dispatch sse snapshots by table

### DIFF
--- a/internal/web/sse.go
+++ b/internal/web/sse.go
@@ -34,6 +34,51 @@ const (
 	sseViewConfiguration = "configuration"
 )
 
+type sseSnapshotView struct {
+	nav            string
+	requireProject bool
+	requireGlobal  bool
+	kanbanFeedback bool
+	component      func(templates.DashboardData) templ.Component
+}
+
+var sseSnapshotViews = map[string]sseSnapshotView{
+	sseViewBoard: {
+		nav:            "board",
+		kanbanFeedback: true,
+		component:      templates.BoardSnapshot,
+	},
+	sseViewFleet: {
+		nav:           "fleet",
+		requireGlobal: true,
+		component:     templates.FleetSnapshotV2,
+	},
+	sseViewKanban: {
+		nav:            "kanban",
+		kanbanFeedback: true,
+		component:      templates.BoardSnapshot,
+	},
+	sseViewOverview: {
+		nav:            "overview",
+		requireProject: true,
+		component:      templates.ProjectOverviewSnapshotV2,
+	},
+	sseViewRuns: {
+		nav:            "runs",
+		requireProject: true,
+		component:      templates.ProjectRunsSnapshotV2,
+	},
+	sseViewDiagnostics: {
+		nav:            "diagnostics",
+		requireProject: true,
+		component:      templates.ProjectDiagnosticsSnapshot,
+	},
+	sseViewConfiguration: {
+		nav:            "configuration",
+		requireProject: true,
+	},
+}
+
 func staticSidebarNav(value string) string {
 	switch strings.TrimSpace(value) {
 	case "health":
@@ -64,6 +109,7 @@ func (s *Server) events(c echo.Context) error {
 	selectedProjectID := strings.TrimSpace(c.QueryParam("project"))
 	selectedNav := staticSidebarNav(c.QueryParam("nav"))
 	selectedView := strings.ToLower(strings.TrimSpace(c.QueryParam("view")))
+	analyticsKind := c.QueryParam("kind")
 	sub, err := s.hub.Subscribe(ctx)
 	if err != nil {
 		if errors.Is(err, context.Canceled) {
@@ -100,38 +146,7 @@ func (s *Server) events(c echo.Context) error {
 					data = scopedData
 				}
 			}
-			if selectedNav != "" {
-				data.ActiveNav = selectedNav
-			}
-			snapshotComponent := templates.SnapshotView(data)
-			if selectedNav == sseViewHealth {
-				snapshotComponent = templates.HealthSnapshotV2(data)
-			} else if selectedNav == sseViewAnalytics {
-				data.AnalyticsKind = strings.TrimSpace(c.QueryParam("kind"))
-				snapshotComponent = templates.AnalyticsSnapshotV2(data)
-			} else if selectedView == sseViewBoard && (selectedProjectID == "" || data.ProjectID != "") {
-				data.ActiveNav = "board"
-				data = s.withKanbanRefreshFeedback(data)
-				snapshotComponent = templates.BoardSnapshot(data)
-			} else if selectedView == sseViewFleet && selectedProjectID == "" {
-				data.ActiveNav = "fleet"
-				snapshotComponent = templates.FleetSnapshotV2(data)
-			} else if selectedView == sseViewKanban && (selectedProjectID == "" || data.ProjectID != "") {
-				data.ActiveNav = "kanban"
-				data = s.withKanbanRefreshFeedback(data)
-				snapshotComponent = templates.BoardSnapshot(data)
-			} else if selectedView == sseViewOverview && selectedProjectID != "" {
-				data.ActiveNav = "overview"
-				snapshotComponent = templates.ProjectOverviewSnapshotV2(data)
-			} else if selectedView == sseViewRuns && selectedProjectID != "" {
-				data.ActiveNav = "runs"
-				snapshotComponent = templates.ProjectRunsSnapshotV2(data)
-			} else if selectedView == sseViewDiagnostics && selectedProjectID != "" {
-				data.ActiveNav = "diagnostics"
-				snapshotComponent = templates.ProjectDiagnosticsSnapshot(data)
-			} else if selectedView == sseViewConfiguration && selectedProjectID != "" {
-				data.ActiveNav = "configuration"
-			}
+			data, snapshotComponent := s.sseSnapshotComponent(analyticsKind, selectedNav, selectedView, selectedProjectID, data)
 			sent, err := stream.sendComponent(ctx, res.Writer, sseEventSnapshot, snapshotComponent, s.sseFragmentInterval)
 			if err != nil {
 				return err
@@ -168,6 +183,53 @@ func (s *Server) events(c echo.Context) error {
 				flusher.Flush()
 			}
 		}
+	}
+}
+
+func (s *Server) sseSnapshotComponent(
+	analyticsKind string,
+	selectedNav string,
+	selectedView string,
+	selectedProjectID string,
+	data templates.DashboardData,
+) (templates.DashboardData, templ.Component) {
+	if selectedNav != "" {
+		data.ActiveNav = selectedNav
+	}
+	switch selectedNav {
+	case sseViewHealth:
+		return data, templates.HealthSnapshotV2(data)
+	case sseViewAnalytics:
+		data.AnalyticsKind = strings.TrimSpace(analyticsKind)
+		return data, templates.AnalyticsSnapshotV2(data)
+	}
+
+	view, ok := sseSnapshotViews[selectedView]
+	if !ok || !view.available(selectedProjectID, data) {
+		return data, templates.SnapshotView(data)
+	}
+	if view.nav != "" {
+		data.ActiveNav = view.nav
+	}
+	if view.kanbanFeedback {
+		data = s.withKanbanRefreshFeedback(data)
+	}
+	if view.component == nil {
+		return data, templates.SnapshotView(data)
+	}
+	return data, view.component(data)
+}
+
+func (view sseSnapshotView) available(selectedProjectID string, data templates.DashboardData) bool {
+	switch {
+	case view.requireGlobal && selectedProjectID != "":
+		return false
+	case view.requireProject && selectedProjectID == "":
+		return false
+	case view.kanbanFeedback && selectedProjectID != "" && data.ProjectID == "":
+		return false
+	default:
+		return true
 	}
 }
 

--- a/internal/web/sse_test.go
+++ b/internal/web/sse_test.go
@@ -8,7 +8,244 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/a-h/templ"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+	"github.com/digitaldrywood/detent/internal/web/templates"
 )
+
+func TestSSESnapshotComponent(t *testing.T) {
+	t.Parallel()
+
+	type snapshotCase struct {
+		name              string
+		analyticsKind     string
+		selectedNav       string
+		selectedView      string
+		selectedProjectID string
+		dataProjectID     string
+		wantActiveNav     string
+		wantAnalyticsKind string
+		wantData          func(*Server, templates.DashboardData) templates.DashboardData
+		wantComponent     func(templates.DashboardData) templ.Component
+	}
+
+	cases := []snapshotCase{
+		{
+			name:              "health nav wins before selected view",
+			selectedNav:       sseViewHealth,
+			selectedView:      sseViewBoard,
+			selectedProjectID: "detent",
+			dataProjectID:     "detent",
+			wantActiveNav:     sseViewHealth,
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewHealth
+				return data
+			},
+			wantComponent: templates.HealthSnapshotV2,
+		},
+		{
+			name:              "analytics nav trims kind and wins before selected view",
+			analyticsKind:     " attempts ",
+			selectedNav:       sseViewAnalytics,
+			selectedView:      sseViewFleet,
+			wantActiveNav:     sseViewAnalytics,
+			wantAnalyticsKind: "attempts",
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewAnalytics
+				data.AnalyticsKind = "attempts"
+				return data
+			},
+			wantComponent: templates.AnalyticsSnapshotV2,
+		},
+		{
+			name:          "other nav keeps default snapshot",
+			selectedNav:   "reports",
+			wantActiveNav: "reports",
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = "reports"
+				return data
+			},
+			wantComponent: templates.SnapshotView,
+		},
+		{
+			name:          "board global view uses board snapshot",
+			selectedView:  sseViewBoard,
+			wantActiveNav: sseViewBoard,
+			wantData: func(server *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewBoard
+				return server.withKanbanRefreshFeedback(data)
+			},
+			wantComponent: templates.BoardSnapshot,
+		},
+		{
+			name:              "board project view uses board snapshot with scoped data",
+			selectedView:      sseViewBoard,
+			selectedProjectID: "detent",
+			dataProjectID:     "detent",
+			wantActiveNav:     sseViewBoard,
+			wantData: func(server *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewBoard
+				return server.withKanbanRefreshFeedback(data)
+			},
+			wantComponent: templates.BoardSnapshot,
+		},
+		{
+			name:              "board project view falls through without scoped data",
+			selectedView:      sseViewBoard,
+			selectedProjectID: "missing",
+			wantActiveNav:     "initial",
+			wantComponent:     templates.SnapshotView,
+		},
+		{
+			name:          "fleet global view uses fleet snapshot",
+			selectedView:  sseViewFleet,
+			wantActiveNav: sseViewFleet,
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewFleet
+				return data
+			},
+			wantComponent: templates.FleetSnapshotV2,
+		},
+		{
+			name:              "fleet project view falls through",
+			selectedView:      sseViewFleet,
+			selectedProjectID: "detent",
+			dataProjectID:     "detent",
+			wantActiveNav:     "initial",
+			wantComponent:     templates.SnapshotView,
+		},
+		{
+			name:          "kanban global view uses board snapshot",
+			selectedView:  sseViewKanban,
+			wantActiveNav: sseViewKanban,
+			wantData: func(server *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewKanban
+				return server.withKanbanRefreshFeedback(data)
+			},
+			wantComponent: templates.BoardSnapshot,
+		},
+		{
+			name:              "kanban project view uses board snapshot with scoped data",
+			selectedView:      sseViewKanban,
+			selectedProjectID: "detent",
+			dataProjectID:     "detent",
+			wantActiveNav:     sseViewKanban,
+			wantData: func(server *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewKanban
+				return server.withKanbanRefreshFeedback(data)
+			},
+			wantComponent: templates.BoardSnapshot,
+		},
+		{
+			name:              "kanban project view falls through without scoped data",
+			selectedView:      sseViewKanban,
+			selectedProjectID: "missing",
+			wantActiveNav:     "initial",
+			wantComponent:     templates.SnapshotView,
+		},
+		{
+			name:              "overview project view uses overview snapshot",
+			selectedView:      sseViewOverview,
+			selectedProjectID: "detent",
+			wantActiveNav:     sseViewOverview,
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewOverview
+				return data
+			},
+			wantComponent: templates.ProjectOverviewSnapshotV2,
+		},
+		{
+			name:          "overview global view falls through",
+			selectedView:  sseViewOverview,
+			wantActiveNav: "initial",
+			wantComponent: templates.SnapshotView,
+		},
+		{
+			name:              "runs project view uses runs snapshot",
+			selectedView:      sseViewRuns,
+			selectedProjectID: "detent",
+			dataProjectID:     "detent",
+			wantActiveNav:     sseViewRuns,
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewRuns
+				return data
+			},
+			wantComponent: templates.ProjectRunsSnapshotV2,
+		},
+		{
+			name:          "runs global view falls through",
+			selectedView:  sseViewRuns,
+			wantActiveNav: "initial",
+			wantComponent: templates.SnapshotView,
+		},
+		{
+			name:              "diagnostics project view uses diagnostics snapshot",
+			selectedView:      sseViewDiagnostics,
+			selectedProjectID: "detent",
+			dataProjectID:     "detent",
+			wantActiveNav:     sseViewDiagnostics,
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewDiagnostics
+				return data
+			},
+			wantComponent: templates.ProjectDiagnosticsSnapshot,
+		},
+		{
+			name:          "diagnostics global view falls through",
+			selectedView:  sseViewDiagnostics,
+			wantActiveNav: "initial",
+			wantComponent: templates.SnapshotView,
+		},
+		{
+			name:              "configuration project view keeps default snapshot",
+			selectedView:      sseViewConfiguration,
+			selectedProjectID: "detent",
+			dataProjectID:     "detent",
+			wantActiveNav:     sseViewConfiguration,
+			wantData: func(_ *Server, data templates.DashboardData) templates.DashboardData {
+				data.ActiveNav = sseViewConfiguration
+				return data
+			},
+			wantComponent: templates.SnapshotView,
+		},
+		{
+			name:          "configuration global view falls through",
+			selectedView:  sseViewConfiguration,
+			wantActiveNav: "initial",
+			wantComponent: templates.SnapshotView,
+		},
+	}
+
+	for _, tt := range cases {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			data := testSSESnapshotData(tt.dataProjectID)
+			server := newSSESnapshotTestServer()
+			gotData, gotComponent := server.sseSnapshotComponent(tt.analyticsKind, tt.selectedNav, tt.selectedView, tt.selectedProjectID, data)
+
+			wantData := testSSESnapshotData(tt.dataProjectID)
+			if tt.wantData != nil {
+				wantData = tt.wantData(newSSESnapshotTestServer(), wantData)
+			}
+			gotHTML := renderSnapshotComponent(t, gotComponent)
+			wantHTML := renderSnapshotComponent(t, tt.wantComponent(wantData))
+
+			if gotData.ActiveNav != tt.wantActiveNav {
+				t.Fatalf("ActiveNav = %q, want %q", gotData.ActiveNav, tt.wantActiveNav)
+			}
+			if gotData.AnalyticsKind != tt.wantAnalyticsKind {
+				t.Fatalf("AnalyticsKind = %q, want %q", gotData.AnalyticsKind, tt.wantAnalyticsKind)
+			}
+			if gotHTML != wantHTML {
+				t.Fatalf("rendered component mismatch\n got:\n%s\nwant:\n%s", gotHTML, wantHTML)
+			}
+		})
+	}
+}
 
 func TestSSEStreamSkipsUnchangedFragments(t *testing.T) {
 	t.Parallel()
@@ -159,4 +396,92 @@ func newTestSSEStream(now *time.Time) *sseStream {
 	stream.nextMetricsAt = now.Add(time.Hour)
 	stream.now = func() time.Time { return now.UTC() }
 	return stream
+}
+
+func newSSESnapshotTestServer() *Server {
+	return &Server{
+		kanbanMutations: newKanbanMutationLocks(),
+		kanbanRefreshes: newKanbanRefreshFeedbackTracker(),
+	}
+}
+
+func testSSESnapshotData(projectID string) templates.DashboardData {
+	generatedAt := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	lastRefreshAt := generatedAt.Add(-time.Minute)
+	data := templates.DashboardData{
+		Title:           "Detent",
+		ApplicationName: "Detent",
+		InstanceName:    "dogfood",
+		ConnectorName:   "github",
+		DashboardURL:    "http://127.0.0.1:0",
+		ActiveNav:       "initial",
+		ProjectID:       strings.TrimSpace(projectID),
+		ProjectName:     "Detent",
+		Kanban: templates.KanbanData{
+			ProjectID: projectID,
+			States:    []string{"Todo", "In Progress", "Done"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: generatedAt,
+			Project: telemetry.Project{
+				ID:          projectID,
+				DisplayName: "Detent",
+				URL:         "https://github.com/digitaldrywood/detent/issues",
+			},
+			Instance: telemetry.Instance{
+				Name:                    "dogfood",
+				GitHubLogin:             "detent-bot",
+				AuthorizationScope:      "repo",
+				AuthorizationConfigured: true,
+			},
+			Refresh: telemetry.Refresh{
+				Status:        telemetry.RefreshStatusReady,
+				LastRefreshAt: &lastRefreshAt,
+				DataSeq:       1,
+			},
+			Counts: telemetry.Counts{
+				Running:   1,
+				Queue:     2,
+				Blocked:   0,
+				Completed: 3,
+			},
+			BoardIssues: []telemetry.Issue{
+				{
+					ID:         "issue-1018",
+					Identifier: "DDW-1018",
+					ProjectID:  projectID,
+					Title:      "Refactor SSE snapshot dispatch",
+					State:      "In Progress",
+				},
+			},
+		},
+	}
+	if projectID != "" {
+		data.Snapshot.Projects = []telemetry.ProjectSnapshot{
+			{
+				Project: telemetry.Project{
+					ID:          projectID,
+					DisplayName: "Detent",
+					URL:         "https://github.com/digitaldrywood/detent/issues",
+				},
+				Counts: data.Snapshot.Counts,
+				Refresh: telemetry.Refresh{
+					Status:        telemetry.RefreshStatusReady,
+					LastRefreshAt: &lastRefreshAt,
+					DataSeq:       1,
+				},
+			},
+		}
+	}
+	return data
+}
+
+func renderSnapshotComponent(t *testing.T, component templ.Component) string {
+	t.Helper()
+
+	var buf bytes.Buffer
+	if err := component.Render(context.Background(), &buf); err != nil {
+		t.Fatalf("Render() error = %v", err)
+	}
+	return buf.String()
 }


### PR DESCRIPTION
## Summary

- Replace SSE snapshot view branching with a table-driven dispatch helper.
- Preserve nav-first handling, project/global guards, analytics kind, and Kanban refresh feedback behavior.
- Add table-driven render comparisons for every preserved dispatch path.

Fixes #1018

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] This PR refactors server dispatch only and does not intentionally change primary operator screen visuals.

## Test Plan

- [x] `go test ./internal/web`
- [x] `make check`