### PR TITLE
feat(linear): implement assignee updates

### DIFF
--- a/internal/connector/linear/connector.go
+++ b/internal/connector/linear/connector.go
@@ -65,6 +65,13 @@ mutation DetentLinearIssueUpdateState($issueId: String!, $stateId: String!) {
   }
 }`
 
+const issueUpdateAssigneeMutation = `
+mutation DetentLinearIssueUpdateAssignee($issueId: String!, $assigneeId: String) {
+  issueUpdate(id: $issueId, input: { assigneeId: $assigneeId }) {
+    success
+  }
+}`
+
 type Config struct {
 	Endpoint   string
 	APIKey     string
@@ -79,6 +86,7 @@ type Connector struct {
 	mu            sync.Mutex
 	stateIDByTeam map[string]map[string]string
 	teamIDByIssue map[string]string
+	userIDByLogin map[string]string
 }
 
 var _ connector.Connector = (*Connector)(nil)
@@ -95,6 +103,7 @@ func NewConnector(cfg Config) (*Connector, error) {
 		stateMap:      cloneStateMap(cfg.StateMap),
 		stateIDByTeam: make(map[string]map[string]string),
 		teamIDByIssue: make(map[string]string),
+		userIDByLogin: make(map[string]string),
 	}, nil
 }
 
@@ -103,7 +112,7 @@ func (c *Connector) Name() string {
 }
 
 func (*Connector) Capabilities() connector.Capabilities {
-	return connector.Capabilities{UpdateIssueState: true, CreateComment: true}
+	return connector.Capabilities{UpdateIssueState: true, SetAssignee: true, CreateComment: true}
 }
 
 func (c *Connector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
@@ -231,8 +240,47 @@ func (c *Connector) updateIssueStateID(ctx context.Context, issueID string, stat
 	return response.IssueUpdate != nil && response.IssueUpdate.Success, nil
 }
 
-func (c *Connector) SetAssignee(context.Context, string, string) error {
-	return connector.ErrNotImplemented
+func (c *Connector) SetAssignee(ctx context.Context, issueID string, login string) error {
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return ErrMissingIssue
+	}
+	login = strings.TrimSpace(login)
+	if login == "" {
+		return ErrMissingUser
+	}
+
+	userID, err := c.resolveUserID(ctx, login)
+	if err != nil {
+		if errors.Is(err, ErrMissingUser) || errors.Is(err, ErrUserNotFound) || errors.Is(err, ErrUserAmbiguous) {
+			return err
+		}
+		return fmt.Errorf("set linear assignee: %w", err)
+	}
+
+	success, err := c.updateIssueAssigneeID(ctx, issueID, userID)
+	if err != nil {
+		return fmt.Errorf("set linear assignee: %w", err)
+	}
+	if !success {
+		return ErrIssueUpdateFailed
+	}
+	return nil
+}
+
+func (c *Connector) updateIssueAssigneeID(ctx context.Context, issueID string, assigneeID string) (bool, error) {
+	var response struct {
+		IssueUpdate *struct {
+			Success bool `json:"success"`
+		} `json:"issueUpdate"`
+	}
+	if err := c.client.GraphQL(ctx, issueUpdateAssigneeMutation, map[string]any{
+		"issueId":    issueID,
+		"assigneeId": assigneeID,
+	}, &response); err != nil {
+		return false, err
+	}
+	return response.IssueUpdate != nil && response.IssueUpdate.Success, nil
 }
 
 func (c *Connector) SetField(context.Context, string, string, string) error {

--- a/internal/connector/linear/connector_test.go
+++ b/internal/connector/linear/connector_test.go
@@ -513,6 +513,277 @@ func TestConnectorUpdateIssueStateRefreshesStaleCachedTeam(t *testing.T) {
 	}
 }
 
+func TestConnectorSetAssigneeResolvesUserAndUpdatesIssue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		login          string
+		users          []map[string]any
+		wantAssigneeID string
+	}{
+		{
+			name:  "email match",
+			login: "worker@example.com",
+			users: []map[string]any{
+				linearUserFixture("user-email", "Worker Email", "worker", "worker@example.com"),
+			},
+			wantAssigneeID: "user-email",
+		},
+		{
+			name:  "display name case insensitive match",
+			login: "WORKER ONE",
+			users: []map[string]any{
+				linearUserFixture("user-display", "Worker Name", "worker one", "worker-name@example.com"),
+			},
+			wantAssigneeID: "user-display",
+		},
+		{
+			name:  "name case insensitive match",
+			login: "WORKER NAME",
+			users: []map[string]any{
+				linearUserFixture("user-name", "worker name", "worker", "worker-name@example.com"),
+			},
+			wantAssigneeID: "user-name",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			requests := []linearGraphQLRequest{}
+			server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
+				mu.Lock()
+				requests = append(requests, request)
+				requestNumber := len(requests)
+				mu.Unlock()
+
+				switch requestNumber {
+				case 1:
+					if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
+						t.Fatalf("query = %q, want user lookup query", request.Query)
+					}
+					assertLinearUserFilter(t, request.Variables["filter"], tt.login)
+					return linearUsersResponse(tt.users)
+				case 2:
+					if !strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") || !strings.Contains(request.Query, "issueUpdate") {
+						t.Fatalf("query = %q, want issue update assignee mutation", request.Query)
+					}
+					if request.Variables["issueId"] != "LIN-123" {
+						t.Fatalf("issueId variable = %#v, want LIN-123", request.Variables["issueId"])
+					}
+					if request.Variables["assigneeId"] != tt.wantAssigneeID {
+						t.Fatalf("assigneeId variable = %#v, want %s", request.Variables["assigneeId"], tt.wantAssigneeID)
+					}
+					return linearIssueUpdateResponse(true)
+				default:
+					t.Fatalf("request count = %d, want 2", requestNumber)
+					return nil
+				}
+			})
+
+			c := newLinearTestConnector(t, server.URL)
+			if err := c.SetAssignee(context.Background(), " LIN-123 ", " "+tt.login+" "); err != nil {
+				t.Fatalf("SetAssignee() error = %v", err)
+			}
+
+			mu.Lock()
+			gotRequests := len(requests)
+			mu.Unlock()
+			if gotRequests != 2 {
+				t.Fatalf("request count = %d, want 2", gotRequests)
+			}
+		})
+	}
+}
+
+func TestConnectorSetAssigneeErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		issueID       string
+		login         string
+		respond       func(*testing.T, int, linearGraphQLRequest) any
+		wantErr       error
+		wantRequests  int
+		wantMutations int
+	}{
+		{
+			name:    "blank issue id",
+			issueID: " \t",
+			login:   "worker",
+			respond: func(t *testing.T, _ int, _ linearGraphQLRequest) any {
+				t.Fatalf("server received request for blank issue id")
+				return nil
+			},
+			wantErr: ErrMissingIssue,
+		},
+		{
+			name:    "blank assignee",
+			issueID: "LIN-123",
+			login:   " \t",
+			respond: func(t *testing.T, _ int, _ linearGraphQLRequest) any {
+				t.Fatalf("server received request for blank assignee")
+				return nil
+			},
+			wantErr: ErrMissingUser,
+		},
+		{
+			name:    "user not found",
+			issueID: "LIN-123",
+			login:   "unknown",
+			respond: func(t *testing.T, requestNumber int, request linearGraphQLRequest) any {
+				if requestNumber != 1 {
+					t.Fatalf("request count = %d, want 1", requestNumber)
+				}
+				if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
+					t.Fatalf("query = %q, want user lookup query", request.Query)
+				}
+				return linearUsersResponse(nil)
+			},
+			wantErr:      ErrUserNotFound,
+			wantRequests: 1,
+		},
+		{
+			name:    "ambiguous user",
+			issueID: "LIN-123",
+			login:   "worker",
+			respond: func(t *testing.T, requestNumber int, request linearGraphQLRequest) any {
+				if requestNumber != 1 {
+					t.Fatalf("request count = %d, want 1", requestNumber)
+				}
+				if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
+					t.Fatalf("query = %q, want user lookup query", request.Query)
+				}
+				return linearUsersResponse([]map[string]any{
+					linearUserFixture("user-1", "Worker One", "worker", "worker1@example.com"),
+					linearUserFixture("user-2", "Worker Two", "WORKER", "worker2@example.com"),
+				})
+			},
+			wantErr:      ErrUserAmbiguous,
+			wantRequests: 1,
+		},
+		{
+			name:    "failed mutation",
+			issueID: "LIN-123",
+			login:   "worker",
+			respond: func(t *testing.T, requestNumber int, request linearGraphQLRequest) any {
+				switch requestNumber {
+				case 1:
+					if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
+						t.Fatalf("query = %q, want user lookup query", request.Query)
+					}
+					return linearUsersResponse([]map[string]any{
+						linearUserFixture("user-1", "Worker One", "worker", "worker@example.com"),
+					})
+				case 2:
+					if !strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") {
+						t.Fatalf("query = %q, want issue update assignee mutation", request.Query)
+					}
+					return linearIssueUpdateResponse(false)
+				default:
+					t.Fatalf("request count = %d, want 2", requestNumber)
+					return nil
+				}
+			},
+			wantErr:       ErrIssueUpdateFailed,
+			wantRequests:  2,
+			wantMutations: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			requests := 0
+			mutations := 0
+			server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
+				mu.Lock()
+				requests++
+				requestNumber := requests
+				if strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") {
+					mutations++
+				}
+				mu.Unlock()
+
+				return tt.respond(t, requestNumber, request)
+			})
+
+			c := newLinearTestConnector(t, server.URL)
+			err := c.SetAssignee(context.Background(), tt.issueID, tt.login)
+			if !errors.Is(err, tt.wantErr) {
+				t.Fatalf("SetAssignee() error = %v, want %v", err, tt.wantErr)
+			}
+
+			mu.Lock()
+			gotRequests := requests
+			gotMutations := mutations
+			mu.Unlock()
+			if gotRequests != tt.wantRequests {
+				t.Fatalf("request count = %d, want %d", gotRequests, tt.wantRequests)
+			}
+			if gotMutations != tt.wantMutations {
+				t.Fatalf("mutation count = %d, want %d", gotMutations, tt.wantMutations)
+			}
+		})
+	}
+}
+
+func TestConnectorSetAssigneeCachesResolvedUser(t *testing.T) {
+	t.Parallel()
+
+	var mu sync.Mutex
+	userQueries := 0
+	mutationAssigneeIDs := []string{}
+	server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
+		mu.Lock()
+		defer mu.Unlock()
+
+		if strings.Contains(request.Query, "DetentLinearUserByLogin") {
+			userQueries++
+			assertLinearUserFilter(t, request.Variables["filter"], "Worker")
+			return linearUsersResponse([]map[string]any{
+				linearUserFixture("user-worker", "Worker Name", "Worker", "worker@example.com"),
+			})
+		}
+		if strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") {
+			assigneeID, _ := request.Variables["assigneeId"].(string)
+			mutationAssigneeIDs = append(mutationAssigneeIDs, assigneeID)
+			return linearIssueUpdateResponse(true)
+		}
+
+		t.Fatalf("query = %q, want user lookup query or issue update assignee mutation", request.Query)
+		return nil
+	})
+
+	c := newLinearTestConnector(t, server.URL)
+	if err := c.SetAssignee(context.Background(), "LIN-123", "Worker"); err != nil {
+		t.Fatalf("SetAssignee() first error = %v", err)
+	}
+	if err := c.SetAssignee(context.Background(), "LIN-124", "worker"); err != nil {
+		t.Fatalf("SetAssignee() second error = %v", err)
+	}
+
+	mu.Lock()
+	gotUserQueries := userQueries
+	gotMutationAssigneeIDs := append([]string(nil), mutationAssigneeIDs...)
+	mu.Unlock()
+	if gotUserQueries != 1 {
+		t.Fatalf("user query count = %d, want 1", gotUserQueries)
+	}
+	wantMutationAssigneeIDs := []string{"user-worker", "user-worker"}
+	if !reflect.DeepEqual(gotMutationAssigneeIDs, wantMutationAssigneeIDs) {
+		t.Fatalf("mutation assignee IDs = %#v, want %#v", gotMutationAssigneeIDs, wantMutationAssigneeIDs)
+	}
+}
+
 func TestConnectorDoesNotExposePullRequestCommenter(t *testing.T) {
 	t.Parallel()
 
@@ -526,7 +797,7 @@ func TestConnectorCapabilities(t *testing.T) {
 	t.Parallel()
 
 	c := newLinearTestConnector(t, "https://api.linear.app/graphql")
-	want := connector.Capabilities{UpdateIssueState: true, CreateComment: true}
+	want := connector.Capabilities{UpdateIssueState: true, SetAssignee: true, CreateComment: true}
 
 	t.Run("reported capabilities are authoritative", func(t *testing.T) {
 		t.Parallel()
@@ -727,6 +998,40 @@ func linearWorkflowStateFixture(id string, name string) map[string]any {
 		"id":   id,
 		"name": name,
 		"type": "started",
+	}
+}
+
+func linearUsersResponse(users []map[string]any) map[string]any {
+	return map[string]any{
+		"data": map[string]any{
+			"users": map[string]any{
+				"nodes": users,
+			},
+		},
+	}
+}
+
+func linearUserFixture(id string, name string, displayName string, email string) map[string]any {
+	return map[string]any{
+		"id":          id,
+		"name":        name,
+		"displayName": displayName,
+		"email":       email,
+	}
+}
+
+func assertLinearUserFilter(t *testing.T, got any, login string) {
+	t.Helper()
+
+	want := map[string]any{
+		"or": []any{
+			map[string]any{"email": map[string]any{"eq": login}},
+			map[string]any{"displayName": map[string]any{"eqIgnoreCase": login}},
+			map[string]any{"name": map[string]any{"eqIgnoreCase": login}},
+		},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("filter variable = %#v, want %#v", got, want)
 	}
 }
 

--- a/internal/connector/linear/errors.go
+++ b/internal/connector/linear/errors.go
@@ -14,10 +14,13 @@ var (
 	ErrIssueNotFound       = errors.New("linear issue not found")
 	ErrIssueUpdateFailed   = errors.New("linear issue update failed")
 	ErrMissingIssue        = errors.New("linear issue is required")
+	ErrMissingUser         = errors.New("linear user is required")
 	ErrMissingToken        = errors.New("linear token is required")
 	ErrStateNotFound       = errors.New("linear state not found")
 	ErrTransient           = errors.New("linear transient error")
 	ErrUnexpectedStatus    = errors.New("linear unexpected status")
+	ErrUserAmbiguous       = errors.New("linear user ambiguous")
+	ErrUserNotFound        = errors.New("linear user not found")
 )
 
 type GraphQLError struct {

--- a/internal/connector/linear/users.go
+++ b/internal/connector/linear/users.go
@@ -1,0 +1,147 @@
+package linear
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+const usersByLoginQuery = `
+query DetentLinearUserByLogin($filter: UserFilter!) {
+  users(filter: $filter, first: 2) {
+    nodes {
+      id
+      name
+      displayName
+      email
+    }
+  }
+}`
+
+func (c *Connector) resolveUserID(ctx context.Context, login string) (string, error) {
+	login = strings.TrimSpace(login)
+	if login == "" {
+		return "", ErrMissingUser
+	}
+
+	loginKey := normalizeUserLogin(login)
+	if userID, ok := c.cachedUserID(loginKey); ok {
+		return userID, nil
+	}
+
+	users, err := c.fetchUsersByLogin(ctx, login)
+	if err != nil {
+		return "", fmt.Errorf("resolve linear user: %w", err)
+	}
+	userID, err := selectLinearUserID(login, users)
+	if err != nil {
+		return "", err
+	}
+
+	c.cacheUserID(loginKey, userID)
+	return userID, nil
+}
+
+func (c *Connector) cachedUserID(loginKey string) (string, bool) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	userID := c.userIDByLogin[loginKey]
+	return userID, userID != ""
+}
+
+func (c *Connector) cacheUserID(loginKey string, userID string) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if c.userIDByLogin == nil {
+		c.userIDByLogin = make(map[string]string)
+	}
+	c.userIDByLogin[loginKey] = userID
+}
+
+func (c *Connector) fetchUsersByLogin(ctx context.Context, login string) ([]linearResolvedUser, error) {
+	var response struct {
+		Users struct {
+			Nodes []linearResolvedUser `json:"nodes"`
+		} `json:"users"`
+	}
+	if err := c.client.GraphQL(ctx, usersByLoginQuery, map[string]any{
+		"filter": linearUserLoginFilter(login),
+	}, &response); err != nil {
+		return nil, err
+	}
+	return response.Users.Nodes, nil
+}
+
+func linearUserLoginFilter(login string) map[string]any {
+	return map[string]any{
+		"or": []map[string]any{
+			{"email": map[string]any{"eq": login}},
+			{"displayName": map[string]any{"eqIgnoreCase": login}},
+			{"name": map[string]any{"eqIgnoreCase": login}},
+		},
+	}
+}
+
+func selectLinearUserID(login string, users []linearResolvedUser) (string, error) {
+	matchers := []func(linearResolvedUser) bool{
+		func(user linearResolvedUser) bool {
+			return strings.TrimSpace(user.Email) == login
+		},
+		func(user linearResolvedUser) bool {
+			return strings.EqualFold(strings.TrimSpace(user.DisplayName), login)
+		},
+		func(user linearResolvedUser) bool {
+			return strings.EqualFold(strings.TrimSpace(user.Name), login)
+		},
+	}
+
+	for _, matches := range matchers {
+		userIDs, err := matchingUserIDs(users, matches)
+		if err != nil {
+			return "", err
+		}
+		switch len(userIDs) {
+		case 0:
+			continue
+		case 1:
+			return userIDs[0], nil
+		default:
+			return "", fmt.Errorf("%w: %s", ErrUserAmbiguous, login)
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrUserNotFound, login)
+}
+
+func matchingUserIDs(users []linearResolvedUser, matches func(linearResolvedUser) bool) ([]string, error) {
+	seen := map[string]struct{}{}
+	userIDs := []string{}
+	for _, user := range users {
+		if !matches(user) {
+			continue
+		}
+		userID := strings.TrimSpace(user.ID)
+		if userID == "" {
+			return nil, ErrInvalidResponse
+		}
+		if _, ok := seen[userID]; ok {
+			continue
+		}
+		seen[userID] = struct{}{}
+		userIDs = append(userIDs, userID)
+	}
+	return userIDs, nil
+}
+
+func normalizeUserLogin(login string) string {
+	return strings.ToLower(strings.TrimSpace(login))
+}
+
+type linearResolvedUser struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	DisplayName string `json:"displayName"`
+	Email       string `json:"email"`
+}


### PR DESCRIPTION
## Summary

- Implement Linear `SetAssignee` with user resolution by email, display name, or name.
- Cache resolved Linear user IDs by lowered login and return user-specific errors before mutation.
- Enable the Linear `SetAssignee` capability while keeping `SetField` unsupported.

Fixes #1031

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/connector/linear`
- [x] `go test -race ./internal/connector/linear`
- [x] `go test ./internal/connector/...`
- [x] `make check`