### PR TITLE
feat(build): add package coverage floor gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,7 +92,7 @@ jobs:
           cache: true
 
       - name: Check coverage
-        run: make test-cover
+        run: make test-cover-packages
 
   browser-visual:
     name: Browser Visual

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,8 @@ DEV_VERSION ?= dev
 COVERPROFILE := tmp/coverage.out
 COVERPROFILE_RAW := tmp/coverage.raw.out
 COVERAGE_THRESHOLD := 70.0
+PACKAGE_COVERAGE_FLOOR := 50
+PACKAGE_COVERAGE_EXCEPTIONS := scripts/coverage-exceptions.txt
 MODERNIZE_FIX_FLAGS ?= -newexpr=false
 TEMPL ?= go run github.com/a-h/templ/cmd/templ@v0.3.1001
 TAILWIND_INPUT ?= static/css/input.css
@@ -23,7 +25,7 @@ NILAWAY_VERSION ?= v0.0.0-20260612163715-2d8907f431ca
 NILAWAY ?= go run go.uber.org/nilaway/cmd/nilaway@$(NILAWAY_VERSION)
 NILAWAY_INCLUDE_PKGS ?= github.com/digitaldrywood/detent
 
-.PHONY: dev generate css css-watch build test test-race test-cover visual-e2e visual-e2e-update lint vet check modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
+.PHONY: dev generate css css-watch build test test-race test-cover test-cover-packages visual-e2e visual-e2e-update lint vet check modernize-check nilaway-audit release-snapshot sqlc db-migrate setup clean help
 
 dev:
 	@mkdir -p tmp
@@ -84,6 +86,9 @@ test-cover:
 		printf "coverage %.1f%% meets %.1f%% threshold\n", coverage, threshold; \
 	}'
 
+test-cover-packages: test-cover
+	go run ./tools/covercheck -profile $(COVERPROFILE) -floor $(PACKAGE_COVERAGE_FLOOR) -exceptions $(PACKAGE_COVERAGE_EXCEPTIONS)
+
 visual-e2e: build
 	@if [ ! -x node_modules/.bin/playwright ]; then npm ci; fi
 	DETENT_BINARY="$(CURDIR)/$(BINARY_PATH)" node_modules/.bin/playwright test
@@ -101,7 +106,7 @@ vet:
 nilaway-audit:
 	$(NILAWAY) -include-pkgs=$(NILAWAY_INCLUDE_PKGS) ./...
 
-check: build lint vet nilaway-audit test-race test-cover
+check: build lint vet nilaway-audit test-race test-cover test-cover-packages
 	@echo "All checks passed."
 
 modernize-check:
@@ -146,6 +151,7 @@ help:
 	@echo "  test         Run Go tests"
 	@echo "  test-race    Run Go tests with the race detector"
 	@echo "  test-cover   Run Go coverage with a $(COVERAGE_THRESHOLD)% minimum"
+	@echo "  test-cover-packages  Run per-package coverage floor checks"
 	@echo "  visual-e2e   Run Playwright visual layout tests"
 	@echo "  visual-e2e-update  Update Playwright visual baselines"
 	@echo "  lint         Run golangci-lint"

--- a/ci_workflow_test.go
+++ b/ci_workflow_test.go
@@ -34,7 +34,7 @@ var requiredPRStatusChecks = []requiredStatusCheck{
 		budget:   "4m",
 		jobStart: "  test-cover:",
 		jobEnd:   "  browser-visual:",
-		markers:  []string{"name: Test Coverage"},
+		markers:  []string{"name: Test Coverage", "make test-cover-packages"},
 	},
 	{
 		name:     "Browser Visual",

--- a/scripts/coverage-exceptions.txt
+++ b/scripts/coverage-exceptions.txt
@@ -1,0 +1,4 @@
+# Per-package coverage ratchet exceptions. Floors only move up.
+github.com/digitaldrywood/detent/internal/web/ui/components/icon 0 # TemplUI icon glue has no direct behavior tests yet; raise or remove after component tests cover it.
+github.com/digitaldrywood/detent/internal/web/ui/primitives 0 # UI primitive wrappers are currently untested glue; raise or remove after behavior-focused tests cover them.
+github.com/digitaldrywood/detent/internal/web/ui/utils 0 # UI class utility helpers are below the package floor; raise or remove after helper tests cover them.

--- a/tools/covercheck/main.go
+++ b/tools/covercheck/main.go
@@ -1,0 +1,285 @@
+package main
+
+import (
+	"bufio"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"math"
+	"os"
+	"sort"
+	"strconv"
+	"strings"
+)
+
+type packageStats struct {
+	covered int
+	total   int
+}
+
+func (s packageStats) percent() float64 {
+	if s.total == 0 {
+		return 100
+	}
+
+	return float64(s.covered) * 100 / float64(s.total)
+}
+
+type coverageFailure struct {
+	Package  string
+	Coverage float64
+	Floor    float64
+}
+
+func main() {
+	os.Exit(run(os.Args[1:], os.Stdout, os.Stderr))
+}
+
+func run(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("covercheck", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+
+	profilePath := flags.String("profile", "", "Go coverprofile path")
+	defaultFloor := flags.Float64("floor", 50, "default per-package coverage floor")
+	exceptionsPath := flags.String("exceptions", "", "coverage exceptions file")
+
+	if err := flags.Parse(args); err != nil {
+		return 2
+	}
+	if *profilePath == "" {
+		fmt.Fprintln(stderr, "-profile is required")
+		return 2
+	}
+	if err := validateFloor(*defaultFloor); err != nil {
+		fmt.Fprintf(stderr, "invalid -floor: %v\n", err)
+		return 2
+	}
+
+	exceptions, err := readExceptions(*exceptionsPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "read exceptions: %v\n", err)
+		return 1
+	}
+
+	failures, err := readCoverageFailures(*profilePath, *defaultFloor, exceptions)
+	if err != nil {
+		fmt.Fprintf(stderr, "check coverage: %v\n", err)
+		return 1
+	}
+	if len(failures) > 0 {
+		writeFailures(stderr, failures)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "package coverage meets per-package floors")
+	return 0
+}
+
+func readExceptions(path string) (map[string]float64, error) {
+	if path == "" {
+		return map[string]float64{}, nil
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+
+	exceptions, parseErr := parseExceptions(file)
+	closeErr := file.Close()
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	return exceptions, nil
+}
+
+func readCoverageFailures(profilePath string, defaultFloor float64, exceptions map[string]float64) ([]coverageFailure, error) {
+	file, err := os.Open(profilePath)
+	if err != nil {
+		return nil, err
+	}
+
+	failures, parseErr := checkCoverage(file, defaultFloor, exceptions)
+	closeErr := file.Close()
+	if parseErr != nil {
+		return nil, parseErr
+	}
+	if closeErr != nil {
+		return nil, closeErr
+	}
+
+	return failures, nil
+}
+
+func checkCoverage(profile io.Reader, defaultFloor float64, exceptions map[string]float64) ([]coverageFailure, error) {
+	if err := validateFloor(defaultFloor); err != nil {
+		return nil, err
+	}
+
+	stats, err := parseCoverProfile(profile)
+	if err != nil {
+		return nil, err
+	}
+
+	packages := make([]string, 0, len(stats))
+	for packagePath := range stats {
+		packages = append(packages, packagePath)
+	}
+	sort.Strings(packages)
+
+	var failures []coverageFailure
+	for _, packagePath := range packages {
+		floor := defaultFloor
+		if exceptionFloor, ok := exceptions[packagePath]; ok {
+			floor = exceptionFloor
+		}
+
+		coverage := stats[packagePath].percent()
+		if coverage < floor {
+			failures = append(failures, coverageFailure{
+				Package:  packagePath,
+				Coverage: coverage,
+				Floor:    floor,
+			})
+		}
+	}
+
+	return failures, nil
+}
+
+func parseCoverProfile(profile io.Reader) (map[string]packageStats, error) {
+	scanner := bufio.NewScanner(profile)
+	stats := make(map[string]packageStats)
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" {
+			continue
+		}
+		if lineNumber == 1 && strings.HasPrefix(line, "mode:") {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 3 {
+			return nil, fmt.Errorf("coverprofile line %d: want file range, statements, and count", lineNumber)
+		}
+
+		filename, ok := profileFilename(fields[0])
+		if !ok {
+			return nil, fmt.Errorf("coverprofile line %d: invalid file range %q", lineNumber, fields[0])
+		}
+		if isExcluded(filename) {
+			continue
+		}
+
+		statements, err := strconv.Atoi(fields[1])
+		if err != nil {
+			return nil, fmt.Errorf("coverprofile line %d: invalid statement count %q: %w", lineNumber, fields[1], err)
+		}
+		if statements < 0 {
+			return nil, fmt.Errorf("coverprofile line %d: statement count must be non-negative", lineNumber)
+		}
+
+		count, err := strconv.Atoi(fields[2])
+		if err != nil {
+			return nil, fmt.Errorf("coverprofile line %d: invalid coverage count %q: %w", lineNumber, fields[2], err)
+		}
+		if count < 0 {
+			return nil, fmt.Errorf("coverprofile line %d: coverage count must be non-negative", lineNumber)
+		}
+
+		packagePath := packageDir(filename)
+		packageCoverage := stats[packagePath]
+		packageCoverage.total += statements
+		if count > 0 {
+			packageCoverage.covered += statements
+		}
+		stats[packagePath] = packageCoverage
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return stats, nil
+}
+
+func profileFilename(fileRange string) (string, bool) {
+	filename, _, ok := strings.Cut(fileRange, ":")
+	return filename, ok && filename != ""
+}
+
+func packageDir(filename string) string {
+	index := strings.LastIndex(filename, "/")
+	if index < 0 {
+		return "."
+	}
+
+	return filename[:index]
+}
+
+func isExcluded(filename string) bool {
+	return strings.HasSuffix(filename, "_templ.go") ||
+		strings.Contains(filename, "/internal/store/sqlc/") ||
+		strings.Contains(filename, "/internal/database/sqlc/")
+}
+
+func parseExceptions(exceptions io.Reader) (map[string]float64, error) {
+	scanner := bufio.NewScanner(exceptions)
+	floors := make(map[string]float64)
+
+	lineNumber := 0
+	for scanner.Scan() {
+		lineNumber++
+		line, _, _ := strings.Cut(scanner.Text(), "#")
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		fields := strings.Fields(line)
+		if len(fields) != 2 {
+			return nil, fmt.Errorf("exceptions line %d: want package path and floor", lineNumber)
+		}
+
+		floor, err := strconv.ParseFloat(fields[1], 64)
+		if err != nil {
+			return nil, fmt.Errorf("exceptions line %d: invalid floor %q: %w", lineNumber, fields[1], err)
+		}
+		if err := validateFloor(floor); err != nil {
+			return nil, fmt.Errorf("exceptions line %d: invalid floor %q: %w", lineNumber, fields[1], err)
+		}
+
+		floors[fields[0]] = floor
+	}
+	if err := scanner.Err(); err != nil {
+		return nil, err
+	}
+
+	return floors, nil
+}
+
+func validateFloor(floor float64) error {
+	switch {
+	case math.IsNaN(floor), math.IsInf(floor, 0):
+		return errors.New("floor must be finite")
+	case floor < 0 || floor > 100:
+		return errors.New("floor must be between 0 and 100")
+	default:
+		return nil
+	}
+}
+
+func writeFailures(output io.Writer, failures []coverageFailure) {
+	fmt.Fprintln(output, "package coverage below floor:")
+	for _, failure := range failures {
+		fmt.Fprintf(output, "  %s: %.1f%% below %.1f%%\n", failure.Package, failure.Coverage, failure.Floor)
+	}
+}

--- a/tools/covercheck/main_test.go
+++ b/tools/covercheck/main_test.go
@@ -1,0 +1,272 @@
+package main
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+const testModule = "github.com/digitaldrywood/detent"
+
+func TestCheckCoverage(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		profile    string
+		floor      float64
+		exceptions map[string]float64
+		want       []coverageFailure
+	}{
+		{
+			name: "aggregates statement coverage per package",
+			profile: coverProfile(
+				testModule+"/internal/foo/a.go:1.1,1.2 2 1",
+				testModule+"/internal/foo/b.go:2.1,2.2 3 0",
+				testModule+"/internal/bar/a.go:1.1,1.2 4 1",
+			),
+			floor: 50,
+			want: []coverageFailure{
+				{
+					Package:  testModule + "/internal/foo",
+					Coverage: 40,
+					Floor:    50,
+				},
+			},
+		},
+		{
+			name: "skips templ and sqlc files",
+			profile: coverProfile(
+				testModule+"/internal/web/view_templ.go:1.1,1.2 100 0",
+				testModule+"/internal/store/sqlc/models.go:1.1,1.2 100 0",
+				testModule+"/internal/database/sqlc/models.go:1.1,1.2 100 0",
+				testModule+"/internal/web/server.go:1.1,1.2 4 4",
+			),
+			floor: 100,
+		},
+		{
+			name: "honors exception floors",
+			profile: coverProfile(
+				testModule+"/internal/foo/a.go:1.1,1.2 1 0",
+				testModule+"/internal/bar/a.go:1.1,1.2 1 0",
+			),
+			floor: 50,
+			exceptions: map[string]float64{
+				testModule + "/internal/foo": 0,
+			},
+			want: []coverageFailure{
+				{
+					Package:  testModule + "/internal/bar",
+					Coverage: 0,
+					Floor:    50,
+				},
+			},
+		},
+		{
+			name: "sorts failures by package",
+			profile: coverProfile(
+				testModule+"/internal/zeta/a.go:1.1,1.2 1 0",
+				testModule+"/internal/alpha/a.go:1.1,1.2 1 0",
+			),
+			floor: 50,
+			want: []coverageFailure{
+				{
+					Package:  testModule + "/internal/alpha",
+					Coverage: 0,
+					Floor:    50,
+				},
+				{
+					Package:  testModule + "/internal/zeta",
+					Coverage: 0,
+					Floor:    50,
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := checkCoverage(strings.NewReader(tt.profile), tt.floor, tt.exceptions)
+			if err != nil {
+				t.Fatalf("checkCoverage() error = %v", err)
+			}
+
+			assertFailures(t, got, tt.want)
+		})
+	}
+}
+
+func TestParseExceptions(t *testing.T) {
+	t.Parallel()
+
+	input := strings.NewReader(`
+# Packages below the default floor.
+
+github.com/digitaldrywood/detent/internal/foo 40 # Raised when foo tests expand.
+github.com/digitaldrywood/detent/internal/bar 0
+`)
+
+	got, err := parseExceptions(input)
+	if err != nil {
+		t.Fatalf("parseExceptions() error = %v", err)
+	}
+
+	want := map[string]float64{
+		testModule + "/internal/foo": 40,
+		testModule + "/internal/bar": 0,
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(parseExceptions()) = %d, want %d", len(got), len(want))
+	}
+	for packagePath, wantFloor := range want {
+		if gotFloor, ok := got[packagePath]; !ok || gotFloor != wantFloor {
+			t.Fatalf("parseExceptions()[%q] = %v, %v; want %v, true", packagePath, gotFloor, ok, wantFloor)
+		}
+	}
+}
+
+func TestParseExceptionsErrors(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		input   string
+		wantErr string
+	}{
+		{
+			name:    "bad floor",
+			input:   testModule + "/internal/foo nope\n",
+			wantErr: "exceptions line 1: invalid floor",
+		},
+		{
+			name:    "missing floor",
+			input:   testModule + "/internal/foo\n",
+			wantErr: "exceptions line 1: want package path and floor",
+		},
+		{
+			name:    "floor out of range",
+			input:   testModule + "/internal/foo 101\n",
+			wantErr: "exceptions line 1: invalid floor",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := parseExceptions(strings.NewReader(tt.input))
+			if err == nil {
+				t.Fatal("parseExceptions() error = nil, want error")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("parseExceptions() error = %q, want containing %q", err, tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestRun(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		profile        string
+		exceptions     string
+		wantCode       int
+		wantStdout     string
+		wantStderr     string
+		wantStderrPart string
+	}{
+		{
+			name: "passes when exception floor is met",
+			profile: coverProfile(
+				testModule + "/internal/foo/a.go:1.1,1.2 1 0",
+			),
+			exceptions: testModule + "/internal/foo 0\n",
+			wantCode:   0,
+			wantStdout: "package coverage meets per-package floors\n",
+		},
+		{
+			name: "fails with sorted package output",
+			profile: coverProfile(
+				testModule+"/internal/zeta/a.go:1.1,1.2 1 0",
+				testModule+"/internal/alpha/a.go:1.1,1.2 1 0",
+			),
+			wantCode: 1,
+			wantStderr: "package coverage below floor:\n" +
+				"  github.com/digitaldrywood/detent/internal/alpha: 0.0% below 50.0%\n" +
+				"  github.com/digitaldrywood/detent/internal/zeta: 0.0% below 50.0%\n",
+		},
+		{
+			name:           "reports bad exception floor",
+			profile:        coverProfile(testModule + "/internal/foo/a.go:1.1,1.2 1 1"),
+			exceptions:     testModule + "/internal/foo no\n",
+			wantCode:       1,
+			wantStderrPart: "read exceptions: exceptions line 1: invalid floor",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tempDir := t.TempDir()
+			profilePath := filepath.Join(tempDir, "coverage.out")
+			if err := os.WriteFile(profilePath, []byte(tt.profile), 0o600); err != nil {
+				t.Fatalf("write profile: %v", err)
+			}
+
+			args := []string{"-profile", profilePath, "-floor", "50"}
+			if tt.exceptions != "" {
+				exceptionsPath := filepath.Join(tempDir, "exceptions.txt")
+				if err := os.WriteFile(exceptionsPath, []byte(tt.exceptions), 0o600); err != nil {
+					t.Fatalf("write exceptions: %v", err)
+				}
+				args = append(args, "-exceptions", exceptionsPath)
+			}
+
+			var stdout bytes.Buffer
+			var stderr bytes.Buffer
+			gotCode := run(args, &stdout, &stderr)
+
+			if gotCode != tt.wantCode {
+				t.Fatalf("run() = %d, want %d\nstdout:\n%s\nstderr:\n%s", gotCode, tt.wantCode, stdout.String(), stderr.String())
+			}
+			if gotStdout := stdout.String(); gotStdout != tt.wantStdout {
+				t.Fatalf("stdout = %q, want %q", gotStdout, tt.wantStdout)
+			}
+			if tt.wantStderr != "" {
+				if gotStderr := stderr.String(); gotStderr != tt.wantStderr {
+					t.Fatalf("stderr = %q, want %q", gotStderr, tt.wantStderr)
+				}
+			}
+			if tt.wantStderrPart != "" && !strings.Contains(stderr.String(), tt.wantStderrPart) {
+				t.Fatalf("stderr = %q, want containing %q", stderr.String(), tt.wantStderrPart)
+			}
+		})
+	}
+}
+
+func coverProfile(lines ...string) string {
+	return "mode: set\n" + strings.Join(lines, "\n") + "\n"
+}
+
+func assertFailures(t *testing.T, got, want []coverageFailure) {
+	t.Helper()
+
+	if len(got) != len(want) {
+		t.Fatalf("len(failures) = %d, want %d\ngot: %#v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("failures[%d] = %#v, want %#v", i, got[i], want[i])
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Adds a stdlib-only covercheck command that enforces per-package coverage floors with deterministic failure output.
- Wires `test-cover-packages` into `make check` and the CI coverage job after the existing global coverage gate while keeping the 70% gate unchanged.
- Seeds package floor exceptions for current below-floor UI glue packages.

Fixes #1027

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./tools/covercheck`
- [x] `go test -race ./tools/covercheck`
- [x] `go test .`
- [x] `make test-cover`
- [x] `make test-cover-packages`
- [x] `make check`