### PR TITLE
feat(board): gate card writes by capability

### DIFF
--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -440,6 +440,8 @@ func demoKanbanData(scenario demoScenario, projectID string) templates.KanbanDat
 		TerminalStates:     []string{"Done", "Cancelled"},
 		AllowedTransitions: demoKanbanTransitions(states),
 		ShowBlockedAlerts:  scenario.ShowBlockedAlerts,
+		CanMoveCards:       mode == workflowconfig.KanbanModeIntegration,
+		CanRemoveCards:     mode == workflowconfig.KanbanModeIntegration,
 	}
 }
 

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -112,6 +112,8 @@ const (
 	kanbanOverlayContradictionLimit = 2
 	kanbanRemovalPendingTTL         = 5 * time.Minute
 	kanbanRefreshRetryDelay         = 2 * time.Second
+	kanbanMoveUnsupportedMessage    = "This project's tracker does not support moving cards."
+	kanbanRemoveUnsupportedMessage  = "This project's tracker does not support removing cards."
 )
 
 func newKanbanMutationLocks() *kanbanMutationLocks {
@@ -476,6 +478,9 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
 		return s.kanbanMoveValidationResponse(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
 	}
+	if !kanbanCanMoveCards(target) {
+		return s.kanbanMoveValidationResponse(c, http.StatusForbidden, kanbanMoveUnsupportedMessage)
+	}
 	if req.issueID == "" {
 		if req.prNumber > 0 {
 			return s.kanbanMoveValidationResponse(c, http.StatusUnprocessableEntity, "Cannot move PR-only card without a linked issue.")
@@ -536,6 +541,9 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 		if errors.As(err, &blocked) {
 			return s.kanbanMoveValidationResponse(c, http.StatusUnprocessableEntity, kanbanBlockedMoveMessage(blocked, req.targetState, moveIssueIdentifier))
 		}
+		if errors.Is(err, connector.ErrNotImplemented) {
+			return s.kanbanMoveValidationResponse(c, http.StatusNotImplemented, kanbanMoveUnsupportedMessage)
+		}
 		s.logger.WarnContext(c.Request().Context(), "kanban move failed", "project", req.projectID, "issue_id", req.issueID, "target_state", req.targetState, "error", err)
 		return kanbanFeedback(c, http.StatusBadGateway, "Move failed: "+err.Error())
 	}
@@ -586,6 +594,9 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 	}
 	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
 		return kanbanFeedback(c, http.StatusForbidden, "Kanban integration mode is not enabled.")
+	}
+	if !kanbanCanRemoveCards(target) {
+		return kanbanFeedback(c, http.StatusForbidden, kanbanRemoveUnsupportedMessage)
 	}
 	if req.issueID == "" {
 		if req.prNumber > 0 {
@@ -646,6 +657,9 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 		var blocked *connector.StateUpdateBlockedError
 		if errors.As(err, &blocked) {
 			return kanbanFeedback(c, http.StatusUnprocessableEntity, kanbanBlockedMoveMessage(blocked, "", removeIssueIdentifier))
+		}
+		if errors.Is(err, connector.ErrNotImplemented) {
+			return kanbanFeedback(c, http.StatusNotImplemented, kanbanRemoveUnsupportedMessage)
 		}
 		s.logger.WarnContext(c.Request().Context(), "kanban remove failed", "project", req.projectID, "issue_id", req.issueID, "error", err)
 		return kanbanFeedback(c, http.StatusBadGateway, "Remove failed: "+err.Error())
@@ -1240,6 +1254,9 @@ func (s *Server) kanbanMoveDialogData(c echo.Context, message string) (templates
 	if target.kanban.Mode != workflowconfig.KanbanModeIntegration {
 		return data, "Kanban integration mode is not enabled."
 	}
+	if !kanbanCanMoveCards(target) {
+		return data, kanbanMoveUnsupportedMessage
+	}
 	data.States = target.workflow.KanbanAllowedTransitionTargets(data.CurrentState)
 	if len(data.States) == 0 && data.CurrentState == "" {
 		data.States = kanbanStateNames(target.workflow, s.latestSnapshot(c.Request().Context()))
@@ -1607,6 +1624,7 @@ func (s *Server) dashboardKanbanData(ctx context.Context, projectID string, snap
 		mode = workflowconfig.KanbanModeReadOnly
 	}
 	states := kanbanStateNames(target.workflow, snapshot)
+	canMove, canRemove := kanbanCardCapabilities(target)
 	data := templates.KanbanData{
 		Mode:                        mode,
 		ProjectID:                   strings.TrimSpace(projectID),
@@ -1616,6 +1634,8 @@ func (s *Server) dashboardKanbanData(ctx context.Context, projectID string, snap
 		AllowedTransitions:          kanbanAllowedTransitions(target.workflow, states),
 		ShowBlockedAlerts:           target.kanban.ShowBlockedAlerts,
 		SupportsPullRequestComments: kanbanSupportsPullRequestComments(target.connector),
+		CanMoveCards:                canMove,
+		CanRemoveCards:              canRemove,
 	}
 	if strings.TrimSpace(projectID) == "" {
 		data.Projects = s.kanbanProjectsData(snapshot)
@@ -1645,6 +1665,7 @@ func (s *Server) kanbanProjectsData(snapshot telemetry.Snapshot) map[string]temp
 			continue
 		}
 		states := kanbanStateNames(target.workflow, snapshot)
+		canMove, canRemove := kanbanCardCapabilities(target)
 		out[projectID] = templates.KanbanProjectData{
 			Mode:                        target.kanban.Mode,
 			ProjectID:                   projectID,
@@ -1652,6 +1673,8 @@ func (s *Server) kanbanProjectsData(snapshot telemetry.Snapshot) map[string]temp
 			TerminalStates:              target.workflow.Tracker.TerminalStates,
 			AllowedTransitions:          kanbanAllowedTransitions(target.workflow, states),
 			SupportsPullRequestComments: kanbanSupportsPullRequestComments(target.connector),
+			CanMoveCards:                canMove,
+			CanRemoveCards:              canRemove,
 		}
 	}
 	if len(out) == 0 {
@@ -1666,6 +1689,27 @@ func kanbanSupportsPullRequestComments(c connector.Connector) bool {
 	}
 	_, ok := c.(connector.PullRequestCommenter)
 	return ok
+}
+
+func kanbanCardCapabilities(target kanbanActionTarget) (bool, bool) {
+	caps := connector.DetectCapabilities(target.connector)
+	canMove := caps.UpdateIssueState
+	canRemove := caps.RemoveFromProject
+	if target.kanban.IssueStateFieldID > 0 {
+		canMove = caps.SetIssueFields
+		canRemove = caps.ClearIssueFields
+	}
+	return canMove, canRemove
+}
+
+func kanbanCanMoveCards(target kanbanActionTarget) bool {
+	canMove, _ := kanbanCardCapabilities(target)
+	return canMove
+}
+
+func kanbanCanRemoveCards(target kanbanActionTarget) bool {
+	_, canRemove := kanbanCardCapabilities(target)
+	return canRemove
 }
 
 func (s *Server) fleetKanbanSnapshotWithPendingStates(snapshot telemetry.Snapshot) telemetry.Snapshot {

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/templates"
 )
@@ -72,6 +73,60 @@ func TestKanbanStateNamesIgnoreCompletedSessionStates(t *testing.T) {
 			got := kanbanStateNames(tt.cfg, snapshot)
 			if !slices.Equal(got, tt.want) {
 				t.Fatalf("kanbanStateNames() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestKanbanCardCapabilitiesDeriveFromStatePath(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		target     kanbanActionTarget
+		wantMove   bool
+		wantRemove bool
+	}{
+		{
+			name:       "nil connector",
+			target:     kanbanActionTarget{},
+			wantMove:   false,
+			wantRemove: false,
+		},
+		{
+			name: "project status uses state update and project removal",
+			target: kanbanActionTarget{
+				connector: kanbanCapabilityProbe{caps: connector.Capabilities{
+					UpdateIssueState:  true,
+					RemoveFromProject: true,
+				}},
+			},
+			wantMove:   true,
+			wantRemove: true,
+		},
+		{
+			name: "issue field status uses field set and clear",
+			target: kanbanActionTarget{
+				connector: kanbanCapabilityProbe{caps: connector.Capabilities{
+					UpdateIssueState:  true,
+					RemoveFromProject: true,
+					SetIssueFields:    false,
+					ClearIssueFields:  true,
+				}},
+				kanban: workflowconfig.Kanban{IssueStateFieldID: 123},
+			},
+			wantMove:   false,
+			wantRemove: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			gotMove, gotRemove := kanbanCardCapabilities(tt.target)
+			if gotMove != tt.wantMove || gotRemove != tt.wantRemove {
+				t.Fatalf("kanbanCardCapabilities() = (%t, %t), want (%t, %t)", gotMove, gotRemove, tt.wantMove, tt.wantRemove)
 			}
 		})
 	}
@@ -694,4 +749,44 @@ func TestKanbanRefreshFeedbackTransitionsOnce(t *testing.T) {
 	if got := tracker.apply("project:detent", templates.KanbanData{}, ready); got.Feedback != "" {
 		t.Fatalf("second ready feedback = %q, want one-time recovery", got.Feedback)
 	}
+}
+
+type kanbanCapabilityProbe struct {
+	caps connector.Capabilities
+}
+
+func (p kanbanCapabilityProbe) Name() string {
+	return "capability-probe"
+}
+
+func (p kanbanCapabilityProbe) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (p kanbanCapabilityProbe) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (p kanbanCapabilityProbe) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, connector.ErrNotImplemented
+}
+
+func (p kanbanCapabilityProbe) CreateComment(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (p kanbanCapabilityProbe) UpdateIssueState(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (p kanbanCapabilityProbe) SetAssignee(context.Context, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (p kanbanCapabilityProbe) SetField(context.Context, string, string, string) error {
+	return connector.ErrNotImplemented
+}
+
+func (p kanbanCapabilityProbe) Capabilities() connector.Capabilities {
+	return p.caps
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -2179,6 +2179,134 @@ func TestKanbanMoveRoutesProjectV2AndIssueFieldUpdates(t *testing.T) {
 	}
 }
 
+func TestKanbanMoveRejectsMissingConnectorCapability(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		form       url.Values
+		wantStatus int
+		wantBody   []string
+	}{
+		{
+			name: "feedback",
+			form: url.Values{
+				"project_id":    {"detent"},
+				"issue_id":      {"I_linear1024"},
+				"current_state": {"Todo"},
+				"target_state":  {"In Progress"},
+			},
+			wantStatus: http.StatusForbidden,
+			wantBody: []string{
+				`id="kanban-feedback"`,
+				"This project's tracker does not support moving cards.",
+			},
+		},
+		{
+			name: "dialog",
+			form: url.Values{
+				"kanban_dialog": {"true"},
+				"project_id":    {"detent"},
+				"issue_id":      {"I_linear1024"},
+				"current_state": {"Todo"},
+				"target_state":  {"In Progress"},
+			},
+			wantStatus: http.StatusOK,
+			wantBody: []string{
+				"This project's tracker does not support moving cards.",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			deps := testDeps(t)
+			actionConnector := &kanbanActionConnector{name: "linear"}
+			reporter := &kanbanCapabilityConnector{
+				kanbanActionConnector: actionConnector,
+				capabilities:          connector.Capabilities{CreateComment: true},
+			}
+			mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+				Mode: workflowconfig.KanbanModeIntegration,
+				AllowedTransitions: map[string][]string{
+					"Todo": {"In Progress"},
+				},
+			}, reporter)
+			if err := deps.Hub.Publish(telemetry.Snapshot{
+				GeneratedAt: time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC),
+				Project:     telemetry.Project{ID: "detent"},
+				BoardIssues: []telemetry.Issue{{
+					ID:         "I_linear1024",
+					Identifier: "digitaldrywood/detent#1024",
+					ProjectID:  "detent",
+					Title:      "Linear move card",
+					State:      "Todo",
+				}},
+			}); err != nil {
+				t.Fatalf("Publish() error = %v", err)
+			}
+			server, err := web.NewServer(web.Config{}, deps)
+			if err != nil {
+				t.Fatalf("NewServer() error = %v", err)
+			}
+
+			rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", tt.form)
+			if rec.Code != tt.wantStatus {
+				t.Fatalf("status = %d, want %d; body = %s", rec.Code, tt.wantStatus, rec.Body.String())
+			}
+			body := html.UnescapeString(rec.Body.String())
+			for _, want := range tt.wantBody {
+				if !strings.Contains(body, want) {
+					t.Fatalf("body missing %q: %s", want, rec.Body.String())
+				}
+			}
+			if got := actionConnector.stateUpdates(); len(got) != 0 {
+				t.Fatalf("state updates = %#v, want none", got)
+			}
+		})
+	}
+}
+
+func TestKanbanMoveDialogRejectsMissingConnectorCapability(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "linear"}
+	reporter := &kanbanCapabilityConnector{
+		kanbanActionConnector: actionConnector,
+		capabilities:          connector.Capabilities{CreateComment: true},
+	}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+		AllowedTransitions: map[string][]string{
+			"Todo": {"In Progress"},
+		},
+	}, reporter)
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	values := url.Values{
+		"project_id":    {"detent"},
+		"issue_id":      {"I_linear1024"},
+		"current_state": {"Todo"},
+		"target_state":  {"In Progress"},
+	}
+	body := requestHTML(t, server.Handler(), http.MethodGet, "/api/v1/kanban/move?"+values.Encode(), http.StatusOK)
+	if !strings.Contains(html.UnescapeString(body), "This project's tracker does not support moving cards.") {
+		t.Fatalf("body missing capability message:\n%s", body)
+	}
+	if strings.Contains(body, `hx-post="/api/v1/kanban/move"`) {
+		t.Fatalf("move dialog rendered a move form despite missing capability:\n%s", body)
+	}
+	if got := actionConnector.stateUpdates(); len(got) != 0 {
+		t.Fatalf("state updates = %#v, want none", got)
+	}
+}
+
 func TestKanbanMoveSuccessResponseRefreshesProjectBoard(t *testing.T) {
 	t.Parallel()
 
@@ -2459,17 +2587,16 @@ func TestKanbanMoveFailureDoesNotInsertPendingCard(t *testing.T) {
 	}
 
 	form := url.Values{
-		"kanban_dialog": {"true"},
 		"project_id":    {"detent"},
 		"issue_id":      {"I_fail922"},
 		"current_state": {"Backlog"},
 		"target_state":  {"Todo"},
 	}
 	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/move", form)
-	if rec.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusNotImplemented, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "Move failed: "+connector.ErrNotImplemented.Error()) {
+	if !strings.Contains(html.UnescapeString(rec.Body.String()), "This project's tracker does not support moving cards.") {
 		t.Fatalf("body missing visible move error: %s", rec.Body.String())
 	}
 	if err := deps.Hub.Publish(telemetry.Snapshot{
@@ -2848,13 +2975,64 @@ func TestKanbanRemoveClearsConfiguredIssueField(t *testing.T) {
 	}
 }
 
+func TestKanbanRemoveRejectsMissingConnectorCapability(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "linear"}
+	reporter := &kanbanCapabilityConnector{
+		kanbanActionConnector: actionConnector,
+		capabilities: connector.Capabilities{
+			UpdateIssueState: true,
+			CreateComment:    true,
+		},
+	}
+	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
+		Mode: workflowconfig.KanbanModeIntegration,
+	}, reporter)
+	if err := deps.Hub.Publish(telemetry.Snapshot{
+		GeneratedAt: time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC),
+		Project:     telemetry.Project{ID: "detent"},
+		BoardIssues: []telemetry.Issue{{
+			ID:         "I_linear1024",
+			Identifier: "digitaldrywood/detent#1024",
+			ProjectID:  "detent",
+			Title:      "Linear remove card",
+			State:      "Todo",
+		}},
+	}); err != nil {
+		t.Fatalf("Publish() error = %v", err)
+	}
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	form := url.Values{
+		"project_id":    {"detent"},
+		"issue_id":      {"I_linear1024"},
+		"current_state": {"Todo"},
+	}
+	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/remove", form)
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusForbidden, rec.Body.String())
+	}
+	if !strings.Contains(html.UnescapeString(rec.Body.String()), "This project's tracker does not support removing cards.") {
+		t.Fatalf("body missing capability message: %s", rec.Body.String())
+	}
+	if got := actionConnector.removals(); len(got) != 0 {
+		t.Fatalf("removals = %#v, want none", got)
+	}
+}
+
 func TestKanbanRemoveReturnsVisibleErrorWhenUnsupported(t *testing.T) {
 	t.Parallel()
 
 	deps := testDeps(t)
+	actionConnector := &kanbanActionConnector{name: "github", removeErr: connector.ErrNotImplemented}
 	mustSetKanbanProject(t, deps.Registry, "detent", workflowconfig.Kanban{
 		Mode: workflowconfig.KanbanModeIntegration,
-	}, connectorProbe{name: "github"})
+	}, actionConnector)
 	if err := deps.Hub.Publish(telemetry.Snapshot{
 		GeneratedAt: time.Date(2026, 6, 15, 12, 0, 0, 0, time.UTC),
 		Project:     telemetry.Project{ID: "detent"},
@@ -2879,10 +3057,10 @@ func TestKanbanRemoveReturnsVisibleErrorWhenUnsupported(t *testing.T) {
 		"current_state": {"Todo"},
 	}
 	rec := performForm(t, server.Handler(), http.MethodPost, "/api/v1/kanban/remove", form)
-	if rec.Code != http.StatusBadGateway {
-		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusBadGateway, rec.Body.String())
+	if rec.Code != http.StatusNotImplemented {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusNotImplemented, rec.Body.String())
 	}
-	if !strings.Contains(rec.Body.String(), "Remove failed: "+connector.ErrNotImplemented.Error()) {
+	if !strings.Contains(html.UnescapeString(rec.Body.String()), "This project's tracker does not support removing cards.") {
 		t.Fatalf("body missing visible unsupported error: %s", rec.Body.String())
 	}
 }
@@ -10043,6 +10221,15 @@ type kanbanActionConnector struct {
 	maxMoves       int
 	moveStarted    chan<- struct{}
 	releaseMove    <-chan struct{}
+}
+
+type kanbanCapabilityConnector struct {
+	*kanbanActionConnector
+	capabilities connector.Capabilities
+}
+
+func (c *kanbanCapabilityConnector) Capabilities() connector.Capabilities {
+	return c.capabilities
 }
 
 func (c *kanbanActionConnector) Name() string {

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -495,7 +495,7 @@ func boardMoveDisabledLabel(reason string) string {
 	switch {
 	case reason == "":
 		return ""
-	case strings.Contains(reason, "all-project"), strings.Contains(reason, "read-only"):
+	case strings.Contains(reason, "all-project"), strings.Contains(reason, "read-only"), strings.Contains(reason, "tracker does not support"):
 		return "Read-only"
 	case strings.Contains(reason, "snapshot"), strings.Contains(reason, "refresh"):
 		return "Stale"

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -674,6 +674,31 @@ func TestBoardScopeLabel(t *testing.T) {
 	}
 }
 
+func TestBoardMoveDisabledLabel(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		reason string
+		want   string
+	}{
+		{reason: "This project's tracker does not support moving cards.", want: "Read-only"},
+		{reason: "This project board is read-only.", want: "Read-only"},
+		{reason: "Tracker snapshot is not ready; moves are disabled until data is current.", want: "Stale"},
+		{reason: "No linked issue is available for this card.", want: "No issue"},
+		{reason: "No allowed transition is configured from Done.", want: "No move"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.want, func(t *testing.T) {
+			t.Parallel()
+
+			if got := boardMoveDisabledLabel(tt.reason); got != tt.want {
+				t.Fatalf("boardMoveDisabledLabel(%q) = %q, want %q", tt.reason, got, tt.want)
+			}
+		})
+	}
+}
+
 func renderBoardComponent(t *testing.T, component templ.Component) string {
 	t.Helper()
 	var buf bytes.Buffer
@@ -855,8 +880,9 @@ func TestBoardSnapshotRendersKanbanDragAttributes(t *testing.T) {
 			},
 		},
 		Kanban: KanbanData{
-			Mode:   "integration",
-			States: []string{"Todo", "In Progress", "Blocked", "Human Review", "Rework", "Done"},
+			Mode:         "integration",
+			States:       []string{"Todo", "In Progress", "Blocked", "Human Review", "Rework", "Done"},
+			CanMoveCards: true,
 			AllowedTransitions: map[string][]string{
 				"Todo":         {"In Progress", "Blocked"},
 				"Human Review": {"Rework"},
@@ -972,7 +998,7 @@ func TestBoardSnapshotOmitsKanbanDragAttributesWhenDisabled(t *testing.T) {
 					BoardIssues: readySnapshot.BoardIssues,
 					Refresh:     telemetry.Refresh{Status: telemetry.RefreshStatusDegraded, LastError: "tracker unavailable"},
 				},
-				Kanban: KanbanData{Mode: "integration", States: []string{"Todo", "In Progress"}},
+				Kanban: KanbanData{Mode: "integration", States: []string{"Todo", "In Progress"}, CanMoveCards: true},
 			},
 			wantReason: "Tracker refresh is degraded; moves are disabled until a fresh snapshot is ready.",
 			wantLabel:  "Stale",
@@ -1039,9 +1065,10 @@ func TestBoardSnapshotFleetBoardRendersDragAttributes(t *testing.T) {
 			States: []string{"Todo", "In Progress"},
 			Projects: map[string]KanbanProjectData{
 				"detent": {
-					Mode:      "integration",
-					ProjectID: "detent",
-					States:    []string{"Todo", "In Progress"},
+					Mode:         "integration",
+					ProjectID:    "detent",
+					States:       []string{"Todo", "In Progress"},
+					CanMoveCards: true,
 					AllowedTransitions: map[string][]string{
 						"Todo": {"In Progress"},
 					},
@@ -1117,6 +1144,7 @@ func TestBoardSnapshotExplainsCardLevelMoveDisabledReasons(t *testing.T) {
 		Kanban: KanbanData{
 			Mode:               "integration",
 			States:             []string{"Human Review", "Rework", "Done"},
+			CanMoveCards:       true,
 			AllowedTransitions: map[string][]string{"Human Review": {"Rework"}},
 		},
 	}

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -99,6 +99,8 @@ type KanbanData struct {
 	AllowedTransitions          map[string][]string
 	ShowBlockedAlerts           bool
 	SupportsPullRequestComments bool
+	CanMoveCards                bool
+	CanRemoveCards              bool
 	Projects                    map[string]KanbanProjectData
 	Feedback                    string
 	FeedbackKind                string
@@ -111,6 +113,8 @@ type KanbanProjectData struct {
 	TerminalStates              []string
 	AllowedTransitions          map[string][]string
 	SupportsPullRequestComments bool
+	CanMoveCards                bool
+	CanRemoveCards              bool
 }
 
 type KanbanMoveDialogData struct {
@@ -2292,6 +2296,8 @@ func projectKanbanCardKanbanData(data DashboardData, card projectKanbanCard) Kan
 		TerminalStates:              projectData.TerminalStates,
 		AllowedTransitions:          projectData.AllowedTransitions,
 		SupportsPullRequestComments: projectData.SupportsPullRequestComments,
+		CanMoveCards:                projectData.CanMoveCards,
+		CanRemoveCards:              projectData.CanRemoveCards,
 	}
 }
 
@@ -2816,8 +2822,12 @@ func projectKanbanCardMoveDisabledText(data DashboardData, card projectKanbanCar
 		}
 		return "Tracker snapshot is not ready; moves are disabled until data is current."
 	}
-	if !projectKanbanCardIntegrationEnabled(data, card) {
+	kanban := projectKanbanCardKanbanData(data, card)
+	if !strings.EqualFold(strings.TrimSpace(kanban.Mode), "integration") {
 		return "This project board is read-only."
+	}
+	if !kanban.CanMoveCards {
+		return "This project's tracker does not support moving cards."
 	}
 	if !card.Movable || strings.TrimSpace(card.IssueID) == "" {
 		if card.PRNumber > 0 {
@@ -2836,7 +2846,7 @@ func projectKanbanCardMoveDisabledText(data DashboardData, card projectKanbanCar
 }
 
 func projectKanbanCardCanRemove(data DashboardData, card projectKanbanCard) bool {
-	return snapshotReady(data.Snapshot) && isProjectDashboard(data) && kanbanIntegrationEnabled(data) && strings.TrimSpace(card.IssueID) != ""
+	return snapshotReady(data.Snapshot) && isProjectDashboard(data) && kanbanIntegrationEnabled(data) && data.Kanban.CanRemoveCards && strings.TrimSpace(card.IssueID) != ""
 }
 
 func projectKanbanCardCanComment(data DashboardData, card projectKanbanCard) bool {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1938,6 +1938,101 @@ func TestProjectKanbanCardForIssueUsesProjectTerminalStates(t *testing.T) {
 	}
 }
 
+func TestProjectKanbanCardMoveDisabledTextCapabilities(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	card := projectKanbanCard{
+		IssueID:   "I_kw1024",
+		ProjectID: "detent",
+		Stage:     "Todo",
+		Movable:   true,
+	}
+	projectKanban := KanbanData{
+		Mode:               "integration",
+		States:             []string{"Todo", "In Progress"},
+		AllowedTransitions: map[string][]string{"Todo": {"In Progress"}},
+		CanMoveCards:       true,
+	}
+	fleetKanban := KanbanData{
+		Projects: map[string]KanbanProjectData{
+			"detent": {
+				Mode:               "integration",
+				ProjectID:          "detent",
+				States:             []string{"Todo", "In Progress"},
+				AllowedTransitions: map[string][]string{"Todo": {"In Progress"}},
+			},
+		},
+	}
+	tests := []struct {
+		name string
+		data DashboardData
+		want string
+	}{
+		{
+			name: "integration with move capability",
+			data: DashboardData{
+				ProjectID: "detent",
+				Snapshot:  telemetry.Snapshot{GeneratedAt: now},
+				Kanban:    projectKanban,
+			},
+		},
+		{
+			name: "integration without move capability",
+			data: DashboardData{
+				ProjectID: "detent",
+				Snapshot:  telemetry.Snapshot{GeneratedAt: now},
+				Kanban: func() KanbanData {
+					kanban := projectKanban
+					kanban.CanMoveCards = false
+					return kanban
+				}(),
+			},
+			want: "This project's tracker does not support moving cards.",
+		},
+		{
+			name: "fleet project without move capability",
+			data: DashboardData{
+				Snapshot: telemetry.Snapshot{GeneratedAt: now},
+				Kanban:   fleetKanban,
+			},
+			want: "This project's tracker does not support moving cards.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := projectKanbanCardMoveDisabledText(tt.data, card); got != tt.want {
+				t.Fatalf("projectKanbanCardMoveDisabledText() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestProjectKanbanCardCanRemoveRespectsCapability(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 12, 0, 0, 0, time.UTC)
+	card := projectKanbanCard{IssueID: "I_kw1024"}
+	data := DashboardData{
+		ProjectID: "detent",
+		Snapshot:  telemetry.Snapshot{GeneratedAt: now},
+		Kanban: KanbanData{
+			Mode: "integration",
+		},
+	}
+
+	if projectKanbanCardCanRemove(data, card) {
+		t.Fatalf("projectKanbanCardCanRemove() = true without capability, want false")
+	}
+	data.Kanban.CanRemoveCards = true
+	if !projectKanbanCardCanRemove(data, card) {
+		t.Fatalf("projectKanbanCardCanRemove() = false with capability, want true")
+	}
+}
+
 func TestProjectKanbanBoardDoesNotTreatCompletedSessionsAsCurrentDone(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Gate board move and remove affordances on connector capabilities, including issue-field-backed boards.
- Reject unsupported move/remove requests before connector mutation calls and return friendly 501 fallbacks for `ErrNotImplemented`.
- Add focused coverage for disabled move labels, capability derivation, move dialog gating, and forged move/remove requests.

Fixes #1024

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No layout or styling changes. Render and handler tests verify the existing `Read-only` chip is used for tracker-unsupported cards and move forms are not rendered.

## Test Plan

- [x] `go test ./internal/web/templates`
- [x] `go test ./internal/web -run 'TestKanban(CardCapabilitiesDeriveFromStatePath|MoveRejectsMissingConnectorCapability|MoveDialogRejectsMissingConnectorCapability|MoveFailureDoesNotInsertPendingCard|RemoveRejectsMissingConnectorCapability|RemoveReturnsVisibleErrorWhenUnsupported|MoveRoutesProjectV2AndIssueFieldUpdates|RemoveClearsConfiguredIssueField)'`
- [x] `go test ./internal/web ./internal/web/templates`
- [x] `make check`
