### PR TITLE
feat(orchestrator): hold pending gates active

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,8 @@ agent:
     quiet_seconds: 600
     optout_label: requires-human-review
     allowed_issue_labels: []
+    gate_wait_state: source
+    gate_wait_timeout_seconds: 3600
     rework_limit: 3
   skills:
     enabled: true
@@ -1553,6 +1555,11 @@ of that state is controlled by the workflow:
   opt-out that leaves the loop unlimited. Positive limits require `Blocked` in a
   configured tracker state list and route the next over-limit rework decision
   there with repeated reasons summarized for handoff.
+- `agent.auto_promote.gate_wait_state: source` keeps zero-quiet completed
+  active issues in their current lane while CI/check gates are still pending;
+  `review` restores the legacy behavior of parking those pending issues in the
+  configured review source state. `gate_wait_timeout_seconds` bounds that active
+  wait and moves overdue items to review with an audit comment.
 - `gate.kind: human_review` requires a linked open PR plus the configured
   `approval_label` on the issue.
 

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1252,14 +1252,17 @@ probes.
    fully supported, and this is the human's call.
 
    For criteria-based auto-promote, use `agent.auto_promote.enabled`,
-   `quiet_seconds`, `optout_label`, `allowed_issue_labels`, and the top-level
-   command gate's `require_automated_review` setting. `quiet_seconds` is the
-   quiet period after observed issue/status/review activity and linked PR
-   activity such as a fresh push to the PR head, `optout_label` is the
-   per-issue escape hatch, and `allowed_issue_labels` is an allowlist such as
-   `documentation` for low-risk issue classes. When automated review is
-   required, a Codex/ChatGPT/Claude review on an older commit does not clear
-   this gate. Verify:
+   `quiet_seconds`, `optout_label`, `allowed_issue_labels`, `gate_wait_state`,
+   `gate_wait_timeout_seconds`, and the top-level command gate's
+   `require_automated_review` setting. `quiet_seconds` is the quiet period after
+   observed issue/status/review activity and linked PR activity such as a fresh
+   push to the PR head, `optout_label` is the per-issue escape hatch,
+   `allowed_issue_labels` is an allowlist such as `documentation` for low-risk
+   issue classes, and `gate_wait_state: source` keeps zero-quiet completed work
+   in its active lane while checks are pending until
+   `gate_wait_timeout_seconds` expires. When automated review is required, a
+   Codex/ChatGPT/Claude review on an older commit does not clear this gate.
+   Verify:
 
    ```sh
    printf '%s\n' \
@@ -2060,7 +2063,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    policy, and dependency policy selected by the human. Verify:
 
    ```sh
-   rg -n 'max_concurrent_agents: <max>|Merging: 1|dispatch_priority_by_label:|auto_promote:|dependency_auto_unblock:|enabled: <true|false>|quiet_seconds: <seconds>|optout_label: <label>|allowed_issue_labels:|rework_limit:|source_states:|target_state:|readiness:' \
+   rg -n 'max_concurrent_agents: <max>|Merging: 1|dispatch_priority_by_label:|auto_promote:|dependency_auto_unblock:|enabled: <true|false>|quiet_seconds: <seconds>|optout_label: <label>|allowed_issue_labels:|gate_wait_state:|gate_wait_timeout_seconds:|rework_limit:|source_states:|target_state:|readiness:' \
      <source-root>/WORKFLOW.md
    ```
 
@@ -2089,6 +2092,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
        quiet_seconds: 600
        optout_label: requires-human-review
        allowed_issue_labels: []
+       gate_wait_state: source
+       gate_wait_timeout_seconds: 3600
        rework_limit: 3
    ```
 
@@ -2102,6 +2107,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
        optout_label: <optout-label>
        allowed_issue_labels:
          - <allowed-label>
+       gate_wait_state: <source-or-review>
+       gate_wait_timeout_seconds: <positive-seconds>
        rework_limit: <0-to-disable-or-max-rework-laps>
    ```
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,11 +41,12 @@ const (
 	defaultLinearEndpoint = "https://api.linear.app/graphql"
 	defaultGitHubEndpoint = "https://api.github.com/graphql"
 
-	DefaultAgentBackendID    = "codex"
-	AgentBackendCodex        = "codex"
-	AgentBackendClaudeCode   = "claude_code"
-	DefaultKnowledgeMaxBytes = 64 * 1024
-	DefaultReworkLimit       = 3
+	DefaultAgentBackendID                    = "codex"
+	AgentBackendCodex                        = "codex"
+	AgentBackendClaudeCode                   = "claude_code"
+	DefaultKnowledgeMaxBytes                 = 64 * 1024
+	DefaultReworkLimit                       = 3
+	DefaultAutoPromoteGateWaitTimeoutSeconds = 3600
 
 	DefaultPollingIntervalMS      = 120000
 	MinPollingIntervalMS          = 60000
@@ -65,6 +66,9 @@ const (
 
 	KanbanModeReadOnly    = "read_only"
 	KanbanModeIntegration = "integration"
+
+	AutoPromoteGateWaitStateSource = "source"
+	AutoPromoteGateWaitStateReview = "review"
 )
 
 type Workflow struct {
@@ -273,14 +277,16 @@ type AgentRoute struct {
 }
 
 type AutoPromote struct {
-	Enabled            bool     `yaml:"enabled"`
-	QuietSeconds       int      `yaml:"quiet_seconds"`
-	OptoutLabel        string   `yaml:"optout_label"`
-	AllowedIssueLabels []string `yaml:"allowed_issue_labels"`
-	SourceState        string   `yaml:"source_state,omitempty"`
-	PassState          string   `yaml:"pass_state,omitempty"`
-	ReworkState        string   `yaml:"rework_state,omitempty"`
-	ReworkLimit        int      `yaml:"rework_limit,omitempty"`
+	Enabled                bool     `yaml:"enabled"`
+	QuietSeconds           int      `yaml:"quiet_seconds"`
+	OptoutLabel            string   `yaml:"optout_label"`
+	AllowedIssueLabels     []string `yaml:"allowed_issue_labels"`
+	GateWaitState          string   `yaml:"gate_wait_state,omitempty"`
+	GateWaitTimeoutSeconds int      `yaml:"gate_wait_timeout_seconds,omitempty"`
+	SourceState            string   `yaml:"source_state,omitempty"`
+	PassState              string   `yaml:"pass_state,omitempty"`
+	ReworkState            string   `yaml:"rework_state,omitempty"`
+	ReworkLimit            int      `yaml:"rework_limit,omitempty"`
 }
 
 type OutputTruncation struct {
@@ -780,13 +786,15 @@ func Default() Config {
 			DispatchPriorityByState:    []string{},
 			DispatchPriorityByLabel:    []string{},
 			AutoPromote: AutoPromote{
-				QuietSeconds:       600,
-				OptoutLabel:        "requires-human-review",
-				AllowedIssueLabels: []string{},
-				SourceState:        "Human Review",
-				PassState:          "Merging",
-				ReworkState:        "Rework",
-				ReworkLimit:        DefaultReworkLimit,
+				QuietSeconds:           600,
+				OptoutLabel:            "requires-human-review",
+				AllowedIssueLabels:     []string{},
+				GateWaitState:          AutoPromoteGateWaitStateSource,
+				GateWaitTimeoutSeconds: DefaultAutoPromoteGateWaitTimeoutSeconds,
+				SourceState:            "Human Review",
+				PassState:              "Merging",
+				ReworkState:            "Rework",
+				ReworkLimit:            DefaultReworkLimit,
 			},
 			Budget:    budget,
 			Lessons:   defaultLessons(),
@@ -993,6 +1001,10 @@ func (c *Config) normalize() {
 	c.Agent.MaxSessionTokenOverrideField = strings.TrimSpace(c.Agent.MaxSessionTokenOverrideField)
 	c.Agent.AutoPromote.OptoutLabel = normalizeLabel(c.Agent.AutoPromote.OptoutLabel)
 	c.Agent.AutoPromote.AllowedIssueLabels = normalizeLabels(c.Agent.AutoPromote.AllowedIssueLabels)
+	c.Agent.AutoPromote.GateWaitState = normalizeAutoPromoteGateWaitState(c.Agent.AutoPromote.GateWaitState)
+	if c.Agent.AutoPromote.GateWaitTimeoutSeconds == 0 {
+		c.Agent.AutoPromote.GateWaitTimeoutSeconds = DefaultAutoPromoteGateWaitTimeoutSeconds
+	}
 	c.Agent.AutoPromote.SourceState = strings.TrimSpace(c.Agent.AutoPromote.SourceState)
 	if c.Agent.AutoPromote.SourceState == "" {
 		c.Agent.AutoPromote.SourceState = "Human Review"
@@ -1446,6 +1458,14 @@ func (a *AutoPromote) validate(prefix string, problems *[]string) {
 			return
 		}
 	}
+	switch normalizeAutoPromoteGateWaitState(a.GateWaitState) {
+	case AutoPromoteGateWaitStateSource, AutoPromoteGateWaitStateReview:
+	default:
+		*problems = append(*problems, prefix+".gate_wait_state must be one of source, review")
+	}
+	if a.GateWaitTimeoutSeconds <= 0 {
+		*problems = append(*problems, prefix+".gate_wait_timeout_seconds must be greater than 0")
+	}
 	if strings.TrimSpace(a.SourceState) == "" {
 		*problems = append(*problems, prefix+".source_state must not be blank")
 	}
@@ -1457,6 +1477,17 @@ func (a *AutoPromote) validate(prefix string, problems *[]string) {
 	}
 	if a.ReworkLimit < 0 {
 		*problems = append(*problems, prefix+".rework_limit must be greater than or equal to 0")
+	}
+}
+
+func normalizeAutoPromoteGateWaitState(state string) string {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "", AutoPromoteGateWaitStateSource:
+		return AutoPromoteGateWaitStateSource
+	case AutoPromoteGateWaitStateReview:
+		return AutoPromoteGateWaitStateReview
+	default:
+		return strings.ToLower(strings.TrimSpace(state))
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -106,6 +106,8 @@ agent:
     enabled: true
     quiet_seconds: 0
     optout_label: Requires-Human-Review
+    gate_wait_state: review
+    gate_wait_timeout_seconds: 900
     rework_limit: 3
     allowed_issue_labels:
       - enhancement
@@ -344,6 +346,12 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Agent.AutoPromote.ReworkLimit != 3 {
 		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want 3", cfg.Agent.AutoPromote.ReworkLimit)
+	}
+	if cfg.Agent.AutoPromote.GateWaitState != AutoPromoteGateWaitStateReview {
+		t.Fatalf("Agent.AutoPromote.GateWaitState = %q, want review", cfg.Agent.AutoPromote.GateWaitState)
+	}
+	if cfg.Agent.AutoPromote.GateWaitTimeoutSeconds != 900 {
+		t.Fatalf("Agent.AutoPromote.GateWaitTimeoutSeconds = %d, want 900", cfg.Agent.AutoPromote.GateWaitTimeoutSeconds)
 	}
 	if !cfg.Codex.ApprovalPolicy.IsString || cfg.Codex.ApprovalPolicy.String != "never" {
 		t.Fatalf("Codex.ApprovalPolicy = %#v, want string never", cfg.Codex.ApprovalPolicy)
@@ -641,6 +649,12 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.AutoPromote.ReworkLimit != DefaultReworkLimit {
 		t.Fatalf("Agent.AutoPromote.ReworkLimit = %d, want %d", cfg.Agent.AutoPromote.ReworkLimit, DefaultReworkLimit)
+	}
+	if cfg.Agent.AutoPromote.GateWaitState != AutoPromoteGateWaitStateSource {
+		t.Fatalf("Agent.AutoPromote.GateWaitState = %q, want source", cfg.Agent.AutoPromote.GateWaitState)
+	}
+	if cfg.Agent.AutoPromote.GateWaitTimeoutSeconds != DefaultAutoPromoteGateWaitTimeoutSeconds {
+		t.Fatalf("Agent.AutoPromote.GateWaitTimeoutSeconds = %d, want %d", cfg.Agent.AutoPromote.GateWaitTimeoutSeconds, DefaultAutoPromoteGateWaitTimeoutSeconds)
 	}
 	if cfg.Agent.OutputTruncation.MaxBytes != 0 {
 		t.Fatalf("Agent.OutputTruncation.MaxBytes = %d, want disabled default", cfg.Agent.OutputTruncation.MaxBytes)
@@ -1899,6 +1913,23 @@ Prompt
 `,
 			want: []string{
 				"agent.auto_promote.rework_limit must be greater than or equal to 0",
+			},
+		},
+		{
+			name: "invalid auto promote gate wait settings",
+			raw: `---
+tracker:
+  kind: memory
+agent:
+  auto_promote:
+    gate_wait_state: backlog
+    gate_wait_timeout_seconds: -1
+---
+Prompt
+`,
+			want: []string{
+				"agent.auto_promote.gate_wait_state must be one of source, review",
+				"agent.auto_promote.gate_wait_timeout_seconds must be greater than 0",
 			},
 		},
 		{

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -13,6 +13,8 @@ type AutoPromoteConfig struct {
 	QuietDuration      time.Duration
 	OptoutLabel        string
 	AllowedIssueLabels []string
+	GateWaitState      string
+	GateWaitTimeout    time.Duration
 	SourceState        string
 	PassState          string
 	ReworkState        string
@@ -159,6 +161,10 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	}
 	cfg.OptoutLabel = normalizeLabel(cfg.OptoutLabel)
 	cfg.AllowedIssueLabels = normalizeLabels(cfg.AllowedIssueLabels)
+	cfg.GateWaitState = normalizeAutoPromoteGateWaitState(cfg.GateWaitState)
+	if cfg.GateWaitTimeout <= 0 {
+		cfg.GateWaitTimeout = defaultAutoPromoteGateWaitTimeout
+	}
 	cfg.SourceState = strings.TrimSpace(cfg.SourceState)
 	if cfg.SourceState == "" {
 		cfg.SourceState = autoPromoteSourceState
@@ -176,6 +182,17 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	}
 	cfg.Gate = gate.Effective(cfg.Gate)
 	return cfg
+}
+
+func normalizeAutoPromoteGateWaitState(state string) string {
+	switch normalizeState(state) {
+	case "", autoPromoteGateWaitSource:
+		return autoPromoteGateWaitSource
+	case autoPromoteGateWaitReview:
+		return autoPromoteGateWaitReview
+	default:
+		return normalizeState(state)
+	}
 }
 
 func autoPromoteOptoutLabel(issue connector.Issue, cfg AutoPromoteConfig) bool {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -18,11 +18,14 @@ import (
 )
 
 const (
-	autoPromoteSourceState           = "Human Review"
-	autoPromoteMergingState          = "Merging"
-	autoPromoteReworkState           = "Rework"
-	defaultMergeWorkerStartupTimeout = 2 * time.Minute
-	mergeWorkerProjectStateFull      = "project_state_capacity_full"
+	autoPromoteSourceState            = "Human Review"
+	autoPromoteMergingState           = "Merging"
+	autoPromoteReworkState            = "Rework"
+	autoPromoteGateWaitSource         = "source"
+	autoPromoteGateWaitReview         = "review"
+	defaultAutoPromoteGateWaitTimeout = time.Hour
+	defaultMergeWorkerStartupTimeout  = 2 * time.Minute
+	mergeWorkerProjectStateFull       = "project_state_capacity_full"
 )
 
 type autoPromoteTickResult struct {
@@ -146,6 +149,9 @@ func (o *Orchestrator) autoPromoteEvaluationIssues(
 		if _, ok := seen[issueID]; ok {
 			continue
 		}
+		if !autoPromoteSourceGateWaitEnabled(cfg) {
+			continue
+		}
 		if !autoPromoteActiveGatePendingIssue(issue, state, o.cfg, cfg) {
 			continue
 		}
@@ -177,6 +183,9 @@ func autoPromoteActiveGatePendingIssue(
 	if !stateIn(issue.State, cfg.ActiveStates) || stateIn(issue.State, cfg.TerminalStates) {
 		return false
 	}
+	if !autoPromoteActiveGateTrackingEnabled(autoCfg) {
+		return false
+	}
 	switch normalizeState(issue.State) {
 	case normalizeState(autoCfg.SourceState), normalizeState(autoCfg.PassState), normalizeState(autoCfg.ReworkState):
 		return false
@@ -194,6 +203,16 @@ func autoPromoteActiveGatePendingIssue(
 		}
 	}
 	return issueHasOpenPullRequest(issue)
+}
+
+func autoPromoteSourceGateWaitEnabled(cfg AutoPromoteConfig) bool {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	return cfg.Enabled && cfg.QuietDuration == 0 && cfg.GateWaitState == autoPromoteGateWaitSource
+}
+
+func autoPromoteActiveGateTrackingEnabled(cfg AutoPromoteConfig) bool {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	return cfg.Enabled && (cfg.QuietDuration > 0 || cfg.GateWaitState == autoPromoteGateWaitSource)
 }
 
 func autoPromoteActiveDispatchInProgress(state *State, issueID string) bool {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -406,7 +406,7 @@ func TestTickAutoPromoteCompletedActiveIssues(t *testing.T) {
 				MaxConcurrentAgents: 1,
 				AutoPromote: AutoPromoteConfig{
 					Enabled:       true,
-					QuietDuration: 10 * time.Minute,
+					QuietDuration: 0,
 					Gate:          gate.Config{Kind: gate.KindCommand},
 				},
 				ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
@@ -465,7 +465,7 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 		MaxConcurrentAgents: 1,
 		AutoPromote: AutoPromoteConfig{
 			Enabled:       true,
-			QuietDuration: 10 * time.Minute,
+			QuietDuration: 0,
 			Gate:          gate.Config{Kind: gate.KindCommand},
 		},
 		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -38,6 +38,9 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			cfg,
 		)
 		if targetState == "" {
+			if o.transitionTimedOutCompletedActiveGateWait(ctx, state, issue, completed, cfg, now) {
+				result.transitioned[issueID] = struct{}{}
+			}
 			continue
 		}
 
@@ -152,13 +155,23 @@ func completedActiveReviewTargetState(
 	if !completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(cfg.Gate)) {
 		return ""
 	}
-	if !autoPromoteHumanReviewRequired(issue, cfg, cfg.Gate) {
+	if !completedActiveShouldEnterReview(issue, cfg) {
 		return ""
 	}
 	if completedActiveFinalStateReviewEligible(finalState, reviewState) {
 		return reviewState
 	}
 	return ""
+}
+
+func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConfig) bool {
+	if autoPromoteHumanReviewRequired(issue, cfg, cfg.Gate) {
+		return true
+	}
+	if cfg.QuietDuration > 0 {
+		return true
+	}
+	return cfg.GateWaitState == autoPromoteGateWaitReview
 }
 
 func completedActiveFinalStateReviewEligible(finalState string, reviewState string) bool {
@@ -178,4 +191,88 @@ func completedActiveIssueReadyForReview(issue connector.Issue, requirePullReques
 		return false
 	}
 	return normalizePullRequestState(issue.PullRequest.State) == "open"
+}
+
+func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	completed Completed,
+	cfg AutoPromoteConfig,
+	now time.Time,
+) bool {
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" || completed.CompletedAt.IsZero() {
+		return false
+	}
+	if now.Before(completed.CompletedAt.Add(cfg.GateWaitTimeout)) {
+		return false
+	}
+	if !autoPromoteActiveGatePendingIssue(issue, state, o.cfg, cfg) {
+		return false
+	}
+	targetState := cfg.SourceState
+	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "auto_promote_gate_wait_timeout"); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"completed issue gate wait timeout transition failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"from_state", issue.State,
+				"target_state", targetState,
+				"error", err,
+			)
+		}
+		return false
+	}
+	if err := o.connector.CreateComment(ctx, issueID, completedActiveGateWaitTimeoutComment(issue, completed, cfg, now)); err != nil && o.logger != nil {
+		o.logger.Warn(
+			"completed issue gate wait timeout comment failed",
+			"issue_id", issueID,
+			"identifier", issue.Identifier,
+			"error", err,
+		)
+	}
+	o.finishCompletedActiveReviewTransition(ctx, state, issue, completed, targetState)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "completed_active_gate_wait_timeout",
+		Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState + " after auto-promote gate wait timeout",
+	})
+	return true
+}
+
+func completedActiveGateWaitTimeoutComment(
+	issue connector.Issue,
+	completed Completed,
+	cfg AutoPromoteConfig,
+	now time.Time,
+) string {
+	waited := now.Sub(completed.CompletedAt)
+	var b strings.Builder
+	b.WriteString("Auto-promote gate wait timed out; moved this issue from ")
+	b.WriteString(strings.TrimSpace(issue.State))
+	b.WriteString(" to ")
+	b.WriteString(cfg.SourceState)
+	b.WriteString(".")
+	b.WriteString("\n\n- reason: auto_promote_gate_wait_timeout")
+	b.WriteString("\n- waited: ")
+	b.WriteString(waited.Round(time.Second).String())
+	b.WriteString("\n- timeout: ")
+	b.WriteString(cfg.GateWaitTimeout.Round(time.Second).String())
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			b.WriteString("\n- pull_request: ")
+			b.WriteString(url)
+		}
+		if ciStatus := strings.TrimSpace(issue.PullRequest.CIStatus); ciStatus != "" {
+			b.WriteString("\n- ci_status: ")
+			b.WriteString(ciStatus)
+		}
+		if mergeableState := strings.TrimSpace(issue.PullRequest.MergeableState); mergeableState != "" {
+			b.WriteString("\n- mergeable_state: ")
+			b.WriteString(strings.ToLower(mergeableState))
+		}
+	}
+	return b.String()
 }

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
@@ -59,13 +60,35 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			finalState: FinalStateCompleted,
 		},
 		{
-			name:       "command gate with auto promote enabled skips human review target",
+			name:       "zero quiet command gate with source wait skips human review target",
 			issue:      completionTransitionIssue("In Progress", "OPEN"),
 			finalState: FinalStateCompleted,
 			cfg: AutoPromoteConfig{
 				Enabled: true,
 				Gate:    gate.Config{Kind: gate.KindCommand},
 			},
+		},
+		{
+			name:       "command gate with quiet window advances to human review",
+			issue:      completionTransitionIssue("In Progress", "OPEN"),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				Gate:          gate.Config{Kind: gate.KindCommand},
+			},
+			want: autoPromoteSourceState,
+		},
+		{
+			name:       "zero quiet command gate with review wait advances to human review",
+			issue:      completionTransitionIssue("In Progress", "OPEN"),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				GateWaitState: autoPromoteGateWaitReview,
+				Gate:          gate.Config{Kind: gate.KindCommand},
+			},
+			want: autoPromoteSourceState,
 		},
 		{
 			name:       "human review gate keeps human review target",
@@ -147,21 +170,20 @@ func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.
 	t.Parallel()
 
 	now := time.Date(2026, 7, 7, 14, 0, 0, 0, time.UTC)
-	reviewedAt := now.Add(-time.Minute)
 	issue := completionTransitionIssue("In Progress", "OPEN")
 	issue.PullRequest = &connector.PullRequest{
-		Number:                 17,
-		URL:                    "https://github.test/digitaldrywood/detent/pull/17",
-		State:                  "OPEN",
-		CIStatus:               "success",
-		CodexReviewState:       "COMMENTED",
-		CodexReviewSubmittedAt: &reviewedAt,
+		Number:           17,
+		URL:              "https://github.test/digitaldrywood/detent/pull/17",
+		State:            "OPEN",
+		MergeableState:   "unknown",
+		CIStatus:         "pending",
+		CodexReviewState: "COMMENTED",
 	}
 	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
 	cfg := normalizeConfig(Config{
 		AutoPromote: AutoPromoteConfig{
 			Enabled:       true,
-			QuietDuration: 10 * time.Minute,
+			QuietDuration: 0,
 			Gate:          gate.Config{Kind: gate.KindCommand},
 		},
 		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
@@ -170,8 +192,9 @@ func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.
 	orch := &Orchestrator{cfg: cfg, connector: tracker}
 	state := newState(cfg)
 	state.Completed[issue.ID] = Completed{
-		Issue:      issue,
-		FinalState: FinalStateCompleted,
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
 	}
 
 	result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
@@ -193,6 +216,71 @@ func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.
 	}
 	if len(state.RecentEvents) != 0 {
 		t.Fatalf("RecentEvents = %#v, want none", state.RecentEvents)
+	}
+}
+
+func TestTransitionCompletedActiveIssuesEscalatesGateWaitTimeout(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 7, 15, 0, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.PullRequest = &connector.PullRequest{
+		Number:         19,
+		URL:            "https://github.test/digitaldrywood/detent/pull/19",
+		State:          "OPEN",
+		MergeableState: "unknown",
+		CIStatus:       "pending",
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:         true,
+			QuietDuration:   0,
+			GateWaitTimeout: 15 * time.Minute,
+			Gate:            gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-16 * time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Human Review"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one timeout comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Auto-promote gate wait timed out",
+		"reason: auto_promote_gate_wait_timeout",
+		"waited: 16m0s",
+		"timeout: 15m0s",
+		"https://github.test/digitaldrywood/detent/pull/19",
+		"ci_status: pending",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Human Review" {
+		t.Fatalf("Completed issue state = %q, want Human Review", got)
+	}
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatchCandidates = %#v, want none", result.dispatchCandidates)
+	}
+	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "completed_active_gate_wait_timeout" {
+		t.Fatalf("RecentEvents = %#v, want timeout event", state.RecentEvents)
 	}
 }
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -39,6 +39,8 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			QuietDuration:      durationFromSeconds(cfg.Agent.AutoPromote.QuietSeconds),
 			OptoutLabel:        cfg.Agent.AutoPromote.OptoutLabel,
 			AllowedIssueLabels: append([]string(nil), cfg.Agent.AutoPromote.AllowedIssueLabels...),
+			GateWaitState:      cfg.Agent.AutoPromote.GateWaitState,
+			GateWaitTimeout:    durationFromSeconds(cfg.Agent.AutoPromote.GateWaitTimeoutSeconds),
 			SourceState:        cfg.Agent.AutoPromote.SourceState,
 			PassState:          cfg.Agent.AutoPromote.PassState,
 			ReworkState:        cfg.Agent.AutoPromote.ReworkState,

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -33,6 +33,8 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 	cfg.Agent.AutoPromote.QuietSeconds = 30
 	cfg.Agent.AutoPromote.OptoutLabel = " Requires-Human-Review "
 	cfg.Agent.AutoPromote.AllowedIssueLabels = []string{" Docs ", "docs", "Chore"}
+	cfg.Agent.AutoPromote.GateWaitState = " Review "
+	cfg.Agent.AutoPromote.GateWaitTimeoutSeconds = 900
 	cfg.Agent.AutoPromote.ReworkLimit = 2
 	cfg.Agent.MergeFastPath.Enabled = true
 	cfg.Agent.OutputTruncation.MaxBytes = 4096
@@ -77,6 +79,12 @@ func TestConfigFromWorkflowIncludesDispatchControls(t *testing.T) {
 		got.AutoPromote.AllowedIssueLabels[0] != "docs" ||
 		got.AutoPromote.AllowedIssueLabels[1] != "chore" {
 		t.Fatalf("AutoPromote.AllowedIssueLabels = %#v, want docs and chore", got.AutoPromote.AllowedIssueLabels)
+	}
+	if got.AutoPromote.GateWaitState != autoPromoteGateWaitReview {
+		t.Fatalf("AutoPromote.GateWaitState = %q, want review", got.AutoPromote.GateWaitState)
+	}
+	if got.AutoPromote.GateWaitTimeout != 15*time.Minute {
+		t.Fatalf("AutoPromote.GateWaitTimeout = %s, want 15m0s", got.AutoPromote.GateWaitTimeout)
 	}
 	if got.AutoPromote.ReworkLimit != 2 {
 		t.Fatalf("AutoPromote.ReworkLimit = %d, want 2", got.AutoPromote.ReworkLimit)
@@ -261,7 +269,7 @@ func TestDispatchableSkipsAutoPromoteGatePendingActiveIssue(t *testing.T) {
 		MaxConcurrentAgents: 1,
 		AutoPromote: AutoPromoteConfig{
 			Enabled:       true,
-			QuietDuration: 10 * time.Minute,
+			QuietDuration: 0,
 			Gate:          gate.Config{Kind: gate.KindCommand},
 		},
 		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
@@ -275,6 +283,34 @@ func TestDispatchableSkipsAutoPromoteGatePendingActiveIssue(t *testing.T) {
 	decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
 	if decision.dispatchable {
 		t.Fatal("dispatchable gate-pending active issue = true, want false")
+	}
+	if decision.reason != dispatchSkipAutoPromoteGatePending {
+		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipAutoPromoteGatePending)
+	}
+}
+
+func TestDispatchableSkipsQuietWindowActiveIssueWithOpenPullRequest(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 13, 5, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := dispatchTestIssueWithPullRequest("issue-quiet-gate-pending", "In Progress", "OPEN")
+	issue.PullRequest.CIStatus = "pending"
+	state := newState(cfg)
+	orch := Orchestrator{cfg: cfg}
+
+	decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
+	if decision.dispatchable {
+		t.Fatal("dispatchable quiet-window active issue with open PR = true, want false")
 	}
 	if decision.reason != dispatchSkipAutoPromoteGatePending {
 		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipAutoPromoteGatePending)


### PR DESCRIPTION
## Summary

- Add configurable auto-promote gate-wait policy and timeout for zero-quiet automation.
- Keep completed active issues in their source lane while checks are pending, with timeout escalation to review.
- Preserve Human Review routing for quiet windows, opt-out labels, human-review gates, and review wait policy.

Fixes #1063

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A, no visual changes.

## Test Plan

- [x] `go test ./internal/config ./internal/orchestrator`
- [x] `make check`
