### PR TITLE
refactor(kanban): extract card-state helpers

### DIFF
--- a/internal/kanban/mutations.go
+++ b/internal/kanban/mutations.go
@@ -1,0 +1,353 @@
+package kanban
+
+import (
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	overlayContradictionLimit = 2
+	removalPendingTTL         = 5 * time.Minute
+)
+
+type MutationTracker struct {
+	mu       sync.Mutex
+	locks    map[string]*sync.Mutex
+	states   map[string]pendingState
+	removed  map[string]pendingRemoval
+	reverted map[string]RevertNotice
+}
+
+type pendingState struct {
+	snapshot       string
+	current        string
+	project        string
+	issue          telemetry.Issue
+	dataSeqAtWrite uint64
+	contradictions int
+}
+
+type pendingRemoval struct {
+	snapshot       string
+	removedAt      time.Time
+	dataSeqAtWrite uint64
+}
+
+type RevertNotice struct {
+	Identifier string
+	From       string
+	To         string
+	At         time.Time
+}
+
+func NewMutationTracker() *MutationTracker {
+	return &MutationTracker{
+		locks:    map[string]*sync.Mutex{},
+		states:   map[string]pendingState{},
+		removed:  map[string]pendingRemoval{},
+		reverted: map[string]RevertNotice{},
+	}
+}
+
+func (t *MutationTracker) WithLock(key string, fn func() error) error {
+	lock := t.lockFor(key)
+	lock.Lock()
+	defer lock.Unlock()
+	return fn()
+}
+
+func (t *MutationTracker) lockFor(key string) *sync.Mutex {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		key = "default"
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	lock, ok := t.locks[key]
+	if !ok {
+		lock = &sync.Mutex{}
+		t.locks[key] = lock
+	}
+	return lock
+}
+
+func (t *MutationTracker) CardState(key string, issueID string, snapshotState string, dataSeq uint64) string {
+	stateKey := MutationStateKey(key, issueID)
+	if stateKey == "" {
+		return snapshotState
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	return t.cardStateLocked(stateKey, snapshotState, dataSeq)
+}
+
+func (t *MutationTracker) cardStateLocked(stateKey string, snapshotState string, dataSeq uint64) string {
+	pending, ok := t.states[stateKey]
+	if !ok {
+		return snapshotState
+	}
+	if dataSeq <= pending.dataSeqAtWrite {
+		return pending.current
+	}
+
+	switch {
+	case NormalizeState(snapshotState) == NormalizeState(pending.current):
+		delete(t.states, stateKey)
+		return snapshotState
+	case NormalizeState(snapshotState) == NormalizeState(pending.snapshot):
+		pending.contradictions++
+		if pending.contradictions < overlayContradictionLimit {
+			t.states[stateKey] = pending
+			return pending.current
+		}
+		delete(t.states, stateKey)
+		t.noteRevertLocked(stateKey, pending, snapshotState)
+		return snapshotState
+	default:
+		delete(t.states, stateKey)
+		t.noteRevertLocked(stateKey, pending, snapshotState)
+		return snapshotState
+	}
+}
+
+func (t *MutationTracker) NoteCardState(key string, projectID string, issue telemetry.Issue, snapshotState string, currentState string, dataSeqAtWrite uint64) {
+	issue.ID = strings.TrimSpace(issue.ID)
+	stateKey := MutationStateKey(key, issue.ID)
+	if stateKey == "" || strings.TrimSpace(currentState) == "" {
+		return
+	}
+	projectID = strings.TrimSpace(projectID)
+	if strings.TrimSpace(issue.ProjectID) == "" {
+		issue.ProjectID = projectID
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	if pending, ok := t.states[stateKey]; ok && NormalizeState(snapshotState) == NormalizeState(pending.snapshot) {
+		snapshotState = pending.snapshot
+	}
+	delete(t.removed, stateKey)
+	delete(t.reverted, stateKey)
+	t.states[stateKey] = pendingState{
+		snapshot:       strings.TrimSpace(snapshotState),
+		current:        strings.TrimSpace(currentState),
+		project:        projectID,
+		issue:          CloneIssue(issue),
+		dataSeqAtWrite: dataSeqAtWrite,
+	}
+}
+
+func (t *MutationTracker) PendingMovedCards(key string, projectID string, snapshot telemetry.Snapshot) []telemetry.Issue {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil
+	}
+	projectID = strings.TrimSpace(projectID)
+	dataSeq := SnapshotProjectDataSeq(snapshot, projectID)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	present := map[string]struct{}{}
+	for _, entry := range visibleSnapshotIssueEntries(snapshot) {
+		issueID := strings.TrimSpace(entry.Issue.ID)
+		if issueID == "" || !SameProject(entry.Issue, projectID, snapshot.Project.ID) {
+			continue
+		}
+		stateKey := MutationStateKey(key, issueID)
+		if _, ok := t.states[stateKey]; !ok {
+			continue
+		}
+		present[stateKey] = struct{}{}
+	}
+	for _, row := range snapshot.Completed {
+		issue := row.Issue
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" || !SameProject(issue, projectID, snapshot.Project.ID) {
+			continue
+		}
+		stateKey := MutationStateKey(key, issueID)
+		if _, ok := present[stateKey]; ok {
+			continue
+		}
+		if _, ok := t.states[stateKey]; !ok {
+			continue
+		}
+		snapshotState := strings.TrimSpace(issue.State)
+		t.cardStateLocked(stateKey, snapshotState, dataSeq)
+	}
+
+	out := []telemetry.Issue{}
+	for stateKey, pending := range t.states {
+		if _, ok := present[stateKey]; ok {
+			continue
+		}
+		issueID := strings.TrimSpace(pending.issue.ID)
+		if issueID == "" || MutationStateKey(key, issueID) != stateKey {
+			continue
+		}
+		if projectID != "" && pending.project != "" && pending.project != projectID {
+			continue
+		}
+		if !SameProject(pending.issue, projectID, snapshot.Project.ID) {
+			continue
+		}
+		issue := CloneIssue(pending.issue)
+		if strings.TrimSpace(issue.ProjectID) == "" {
+			issue.ProjectID = projectID
+		}
+		issue.State = strings.TrimSpace(pending.current)
+		out = append(out, issue)
+	}
+	sort.SliceStable(out, func(i, j int) bool {
+		left := strings.TrimSpace(out[i].Identifier)
+		right := strings.TrimSpace(out[j].Identifier)
+		if left != right {
+			return left < right
+		}
+		return strings.TrimSpace(out[i].ID) < strings.TrimSpace(out[j].ID)
+	})
+	return out
+}
+
+func (t *MutationTracker) SnapshotCardStates(key string, projectID string, snapshot telemetry.Snapshot) map[string]string {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return nil
+	}
+	projectID = strings.TrimSpace(projectID)
+	dataSeq := SnapshotProjectDataSeq(snapshot, projectID)
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	out := map[string]string{}
+	for _, entry := range visibleSnapshotIssueEntries(snapshot) {
+		issueID := strings.TrimSpace(entry.Issue.ID)
+		if issueID == "" || !SameProject(entry.Issue, projectID, snapshot.Project.ID) {
+			continue
+		}
+		stateKey := MutationStateKey(key, issueID)
+		if _, ok := t.states[stateKey]; !ok {
+			continue
+		}
+		state := t.cardStateLocked(stateKey, entry.State, dataSeq)
+		if strings.TrimSpace(state) != "" {
+			out[stateKey] = state
+		}
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+func (t *MutationTracker) CardRemoved(key string, issueID string, snapshotState string, dataSeq uint64) bool {
+	stateKey := MutationStateKey(key, issueID)
+	if stateKey == "" {
+		return false
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	removed, ok := t.removed[stateKey]
+	if !ok {
+		return false
+	}
+	if time.Since(removed.removedAt) > removalPendingTTL {
+		delete(t.removed, stateKey)
+		return false
+	}
+	if dataSeq <= removed.dataSeqAtWrite {
+		return true
+	}
+	if NormalizeState(snapshotState) == NormalizeState(removed.snapshot) {
+		return true
+	}
+	delete(t.removed, stateKey)
+	return false
+}
+
+func (t *MutationTracker) NoteCardRemoved(key string, issueID string, snapshotState string, dataSeqAtWrite uint64) {
+	stateKey := MutationStateKey(key, issueID)
+	if stateKey == "" {
+		return
+	}
+
+	t.mu.Lock()
+	delete(t.states, stateKey)
+	delete(t.reverted, stateKey)
+	t.removed[stateKey] = pendingRemoval{
+		snapshot:       strings.TrimSpace(snapshotState),
+		removedAt:      time.Now(),
+		dataSeqAtWrite: dataSeqAtWrite,
+	}
+	t.mu.Unlock()
+}
+
+func (t *MutationTracker) noteRevertLocked(stateKey string, pending pendingState, snapshotState string) {
+	identifier := strings.TrimSpace(pending.issue.Identifier)
+	if identifier == "" {
+		identifier = strings.TrimSpace(pending.issue.ID)
+	}
+	to := strings.TrimSpace(snapshotState)
+	if to == "" {
+		to = strings.TrimSpace(pending.snapshot)
+	}
+	t.reverted[stateKey] = RevertNotice{
+		Identifier: identifier,
+		From:       strings.TrimSpace(pending.current),
+		To:         to,
+		At:         time.Now(),
+	}
+}
+
+func (t *MutationTracker) ConsumeRevertNotices(key string, projectID string) []RevertNotice {
+	key = strings.TrimSpace(key)
+	projectID = strings.TrimSpace(projectID)
+	if key == "" && projectID != "" {
+		key = "project:" + projectID
+	}
+	prefix := ""
+	if key != "" {
+		prefix = key + "\x00"
+	}
+
+	t.mu.Lock()
+	defer t.mu.Unlock()
+
+	notices := []RevertNotice{}
+	for stateKey, notice := range t.reverted {
+		if prefix != "" && !strings.HasPrefix(stateKey, prefix) {
+			continue
+		}
+		notices = append(notices, notice)
+		delete(t.reverted, stateKey)
+	}
+	sort.SliceStable(notices, func(i, j int) bool {
+		if !notices[i].At.Equal(notices[j].At) {
+			return notices[i].At.Before(notices[j].At)
+		}
+		return notices[i].Identifier < notices[j].Identifier
+	})
+	return notices
+}
+
+func MutationStateKey(key string, issueID string) string {
+	key = strings.TrimSpace(key)
+	issueID = strings.TrimSpace(issueID)
+	if key == "" || issueID == "" {
+		return ""
+	}
+	return key + "\x00" + issueID
+}

--- a/internal/kanban/mutations_test.go
+++ b/internal/kanban/mutations_test.go
@@ -1,0 +1,325 @@
+package kanban
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestMutationTrackerCardStateByDataSeq(t *testing.T) {
+	t.Parallel()
+
+	type observation struct {
+		snapshotState string
+		dataSeq       uint64
+		want          string
+	}
+	tests := []struct {
+		name         string
+		observations []observation
+		wantPending  bool
+		wantNotice   RevertNotice
+	}{
+		{
+			name: "same-seq republish holds optimistic state",
+			observations: []observation{
+				{snapshotState: "Backlog", dataSeq: 7, want: "Todo"},
+				{snapshotState: "Blocked", dataSeq: 7, want: "Todo"},
+			},
+			wantPending: true,
+		},
+		{
+			name: "newer-seq match confirms and drops entry",
+			observations: []observation{
+				{snapshotState: "Todo", dataSeq: 8, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 9, want: "Backlog"},
+			},
+		},
+		{
+			name: "contradicting polls revert at limit with notice",
+			observations: []observation{
+				{snapshotState: "Backlog", dataSeq: 8, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 9, want: "Backlog"},
+			},
+			wantNotice: RevertNotice{Identifier: "DDW-433", From: "Todo", To: "Backlog"},
+		},
+		{
+			name: "third state reverts immediately with notice",
+			observations: []observation{
+				{snapshotState: "Blocked", dataSeq: 8, want: "Blocked"},
+			},
+			wantNotice: RevertNotice{Identifier: "DDW-433", From: "Todo", To: "Blocked"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewMutationTracker()
+			issue := telemetry.Issue{
+				ID:         "confirmed-card",
+				Identifier: "DDW-433",
+				ProjectID:  "detent",
+				Title:      "Confirmed pending card",
+				State:      "Backlog",
+			}
+			tracker.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 7)
+
+			for _, observation := range tt.observations {
+				got := tracker.CardState("project:detent", issue.ID, observation.snapshotState, observation.dataSeq)
+				if got != observation.want {
+					t.Fatalf("CardState(%q, %d) = %q, want %q", observation.snapshotState, observation.dataSeq, got, observation.want)
+				}
+			}
+			if got := pendingStateExists(tracker, "project:detent", issue.ID); got != tt.wantPending {
+				t.Fatalf("pending state exists = %t, want %t", got, tt.wantPending)
+			}
+
+			notices := tracker.ConsumeRevertNotices("project:detent", "detent")
+			if tt.wantNotice.Identifier == "" {
+				if len(notices) != 0 {
+					t.Fatalf("ConsumeRevertNotices() = %#v, want none", notices)
+				}
+				return
+			}
+			if len(notices) != 1 {
+				t.Fatalf("ConsumeRevertNotices() len = %d, want 1: %#v", len(notices), notices)
+			}
+			assertRevertNotice(t, notices[0], tt.wantNotice)
+			if got := tracker.ConsumeRevertNotices("project:detent", "detent"); len(got) != 0 {
+				t.Fatalf("second ConsumeRevertNotices() = %#v, want drained", got)
+			}
+		})
+	}
+}
+
+func TestMutationTrackerPendingMovedCards(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		snapshot    telemetry.Snapshot
+		wantIssues  []string
+		wantPending bool
+	}{
+		{
+			name: "missing pending card is reinserted",
+			snapshot: telemetry.Snapshot{
+				Project: telemetry.Project{ID: "detent"},
+				Refresh: telemetry.Refresh{DataSeq: 1},
+			},
+			wantIssues:  []string{"DDW-434:Todo"},
+			wantPending: true,
+		},
+		{
+			name: "visible pending card is not duplicated",
+			snapshot: telemetry.Snapshot{
+				Project: telemetry.Project{ID: "detent"},
+				Refresh: telemetry.Refresh{DataSeq: 1},
+				BoardIssues: []telemetry.Issue{{
+					ID:         "pending-card",
+					Identifier: "DDW-434",
+					ProjectID:  "detent",
+					State:      "Backlog",
+				}},
+			},
+			wantPending: true,
+		},
+		{
+			name: "completed row confirms and drops pending card",
+			snapshot: telemetry.Snapshot{
+				Project: telemetry.Project{ID: "detent"},
+				Refresh: telemetry.Refresh{DataSeq: 2},
+				Completed: []telemetry.Completed{{
+					Issue: telemetry.Issue{
+						ID:         "pending-card",
+						Identifier: "DDW-434",
+						ProjectID:  "detent",
+						State:      "Todo",
+					},
+				}},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewMutationTracker()
+			tracker.NoteCardState("project:detent", "detent", telemetry.Issue{
+				ID:         "pending-card",
+				Identifier: "DDW-434",
+				ProjectID:  "detent",
+				Title:      "Pending card",
+				State:      "Backlog",
+			}, "Backlog", "Todo", 1)
+
+			got := tracker.PendingMovedCards("project:detent", "detent", tt.snapshot)
+			if len(got) != len(tt.wantIssues) {
+				t.Fatalf("PendingMovedCards() len = %d, want %d: %#v", len(got), len(tt.wantIssues), got)
+			}
+			for i, issue := range got {
+				key := issue.Identifier + ":" + issue.State
+				if key != tt.wantIssues[i] {
+					t.Fatalf("PendingMovedCards()[%d] = %q, want %q", i, key, tt.wantIssues[i])
+				}
+			}
+			if got := pendingStateExists(tracker, "project:detent", "pending-card"); got != tt.wantPending {
+				t.Fatalf("pending state exists = %t, want %t", got, tt.wantPending)
+			}
+		})
+	}
+}
+
+func TestMutationTrackerSnapshotCardStates(t *testing.T) {
+	t.Parallel()
+
+	issue := telemetry.Issue{
+		ID:         "visible-card",
+		Identifier: "DDW-435",
+		ProjectID:  "detent",
+		State:      "Backlog",
+	}
+	tests := []struct {
+		name        string
+		snapshot    telemetry.Snapshot
+		wantState   string
+		wantPending bool
+	}{
+		{
+			name: "same sequence overlays optimistic state",
+			snapshot: telemetry.Snapshot{
+				Project:     telemetry.Project{ID: "detent"},
+				Refresh:     telemetry.Refresh{DataSeq: 1},
+				BoardIssues: []telemetry.Issue{issue},
+			},
+			wantState:   "Todo",
+			wantPending: true,
+		},
+		{
+			name: "newer matching sequence confirms pending state",
+			snapshot: telemetry.Snapshot{
+				Project: telemetry.Project{ID: "detent"},
+				Refresh: telemetry.Refresh{DataSeq: 2},
+				BoardIssues: []telemetry.Issue{{
+					ID:         "visible-card",
+					Identifier: "DDW-435",
+					ProjectID:  "detent",
+					State:      "Todo",
+				}},
+			},
+			wantState: "Todo",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewMutationTracker()
+			tracker.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
+			states := tracker.SnapshotCardStates("project:detent", "detent", tt.snapshot)
+			stateKey := MutationStateKey("project:detent", "visible-card")
+			if got := states[stateKey]; got != tt.wantState {
+				t.Fatalf("SnapshotCardStates()[%q] = %q, want %q", stateKey, got, tt.wantState)
+			}
+			if got := pendingStateExists(tracker, "project:detent", "visible-card"); got != tt.wantPending {
+				t.Fatalf("pending state exists = %t, want %t", got, tt.wantPending)
+			}
+		})
+	}
+}
+
+func TestMutationTrackerWithLockReturnsCallbackError(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewMutationTracker()
+	wantErr := errors.New("callback failed")
+	called := false
+
+	err := tracker.WithLock(" ", func() error {
+		called = true
+		return wantErr
+	})
+	if !called {
+		t.Fatalf("callback was not called")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("WithLock() error = %v, want %v", err, wantErr)
+	}
+}
+
+func TestMutationTrackerRemovalLifecycle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name          string
+		snapshotState string
+		dataSeq       uint64
+		expired       bool
+		wantRemoved   bool
+		wantPending   bool
+	}{
+		{name: "same seq hides recorded state", snapshotState: "Backlog", dataSeq: 5, wantRemoved: true, wantPending: true},
+		{name: "same seq hides changed state", snapshotState: "Done", dataSeq: 5, wantRemoved: true, wantPending: true},
+		{name: "newer seq hides recorded state", snapshotState: "Backlog", dataSeq: 6, wantRemoved: true, wantPending: true},
+		{name: "newer seq releases changed state", snapshotState: "Done", dataSeq: 6},
+		{name: "ttl expires as backstop", snapshotState: "Backlog", dataSeq: 5, expired: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := NewMutationTracker()
+			tracker.NoteCardRemoved("project:detent", "removed-card", "Backlog", 5)
+			if tt.expired {
+				stateKey := MutationStateKey("project:detent", "removed-card")
+				tracker.mu.Lock()
+				removed := tracker.removed[stateKey]
+				removed.removedAt = time.Now().Add(-removalPendingTTL - time.Minute)
+				tracker.removed[stateKey] = removed
+				tracker.mu.Unlock()
+			}
+
+			got := tracker.CardRemoved("project:detent", "removed-card", tt.snapshotState, tt.dataSeq)
+			if got != tt.wantRemoved {
+				t.Fatalf("CardRemoved(%q, %d) = %t, want %t", tt.snapshotState, tt.dataSeq, got, tt.wantRemoved)
+			}
+			if pending := pendingRemovalExists(tracker, "project:detent", "removed-card"); pending != tt.wantPending {
+				t.Fatalf("pending removal exists = %t, want %t", pending, tt.wantPending)
+			}
+		})
+	}
+}
+
+func assertRevertNotice(t *testing.T, got RevertNotice, want RevertNotice) {
+	t.Helper()
+
+	if got.Identifier != want.Identifier || got.From != want.From || got.To != want.To {
+		t.Fatalf("revert notice = %#v, want identifier/from/to %#v", got, want)
+	}
+	if got.At.IsZero() {
+		t.Fatalf("revert notice At is zero")
+	}
+}
+
+func pendingStateExists(tracker *MutationTracker, key string, issueID string) bool {
+	stateKey := MutationStateKey(key, issueID)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	_, ok := tracker.states[stateKey]
+	return ok
+}
+
+func pendingRemovalExists(tracker *MutationTracker, key string, issueID string) bool {
+	stateKey := MutationStateKey(key, issueID)
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	_, ok := tracker.removed[stateKey]
+	return ok
+}

--- a/internal/kanban/snapshot.go
+++ b/internal/kanban/snapshot.go
@@ -1,0 +1,496 @@
+package kanban
+
+import (
+	"maps"
+	"sort"
+	"strings"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+type SnapshotIssueEntry struct {
+	Issue telemetry.Issue
+	State string
+
+	rank            int
+	index           int
+	rawRuntimeState bool
+}
+
+func FilterSnapshotIssues(snapshot *telemetry.Snapshot, keep func(telemetry.Issue) bool) {
+	if snapshot == nil || keep == nil {
+		return
+	}
+	snapshot.BoardIssues = filterIssues(snapshot.BoardIssues, keep)
+	snapshot.Pipeline = filterIssues(snapshot.Pipeline, keep)
+	snapshot.Running = filterRunning(snapshot.Running, keep)
+	snapshot.Queue = filterQueued(snapshot.Queue, keep)
+	snapshot.Blocked = filterBlocked(snapshot.Blocked, keep)
+}
+
+func filterIssues(issues []telemetry.Issue, keep func(telemetry.Issue) bool) []telemetry.Issue {
+	out := issues[:0]
+	for _, issue := range issues {
+		if keep(issue) {
+			out = append(out, issue)
+		}
+	}
+	return out
+}
+
+func filterRunning(rows []telemetry.Running, keep func(telemetry.Issue) bool) []telemetry.Running {
+	out := rows[:0]
+	for _, row := range rows {
+		if keep(row.Issue) {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func filterQueued(rows []telemetry.Queued, keep func(telemetry.Issue) bool) []telemetry.Queued {
+	out := rows[:0]
+	for _, row := range rows {
+		if keep(row.Issue) {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func filterBlocked(rows []telemetry.Blocked, keep func(telemetry.Issue) bool) []telemetry.Blocked {
+	out := rows[:0]
+	for _, row := range rows {
+		if keep(row.Issue) {
+			out = append(out, row)
+		}
+	}
+	return out
+}
+
+func CloneIssueSlices(snapshot telemetry.Snapshot) telemetry.Snapshot {
+	snapshot.BoardIssues = append([]telemetry.Issue(nil), snapshot.BoardIssues...)
+	for i := range snapshot.BoardIssues {
+		snapshot.BoardIssues[i] = CloneIssue(snapshot.BoardIssues[i])
+	}
+	snapshot.Pipeline = append([]telemetry.Issue(nil), snapshot.Pipeline...)
+	for i := range snapshot.Pipeline {
+		snapshot.Pipeline[i] = CloneIssue(snapshot.Pipeline[i])
+	}
+	snapshot.Running = append([]telemetry.Running(nil), snapshot.Running...)
+	for i := range snapshot.Running {
+		snapshot.Running[i].Issue = CloneIssue(snapshot.Running[i].Issue)
+	}
+	snapshot.Queue = append([]telemetry.Queued(nil), snapshot.Queue...)
+	for i := range snapshot.Queue {
+		snapshot.Queue[i].Issue = CloneIssue(snapshot.Queue[i].Issue)
+	}
+	snapshot.Blocked = append([]telemetry.Blocked(nil), snapshot.Blocked...)
+	for i := range snapshot.Blocked {
+		snapshot.Blocked[i].Issue = CloneIssue(snapshot.Blocked[i].Issue)
+	}
+	snapshot.Completed = append([]telemetry.Completed(nil), snapshot.Completed...)
+	for i := range snapshot.Completed {
+		snapshot.Completed[i].Issue = CloneIssue(snapshot.Completed[i].Issue)
+	}
+	return snapshot
+}
+
+func CloneIssue(issue telemetry.Issue) telemetry.Issue {
+	out := issue
+	out.Labels = append([]string(nil), issue.Labels...)
+	out.Assignees = append([]string(nil), issue.Assignees...)
+	out.Comments = cloneIssueComments(issue.Comments)
+	out.BlockedBy = append([]telemetry.BlockedRef(nil), issue.BlockedBy...)
+	out.Metadata = maps.Clone(issue.Metadata)
+	out.PullRequest = clonePullRequest(issue.PullRequest)
+	out.Deliverable = cloneDeliverable(issue.Deliverable)
+	out.MergeTiming = cloneMergeTiming(issue.MergeTiming)
+	out.LeaseRenewedAt = CloneTimePointer(issue.LeaseRenewedAt)
+	out.LeaseExpiresAt = CloneTimePointer(issue.LeaseExpiresAt)
+	out.CreatedAt = CloneTimePointer(issue.CreatedAt)
+	out.UpdatedAt = CloneTimePointer(issue.UpdatedAt)
+	out.StageUpdatedAt = CloneTimePointer(issue.StageUpdatedAt)
+	out.CurrentLaneEnteredAt = CloneTimePointer(issue.CurrentLaneEnteredAt)
+	return out
+}
+
+func cloneIssueComments(comments []telemetry.IssueComment) []telemetry.IssueComment {
+	if comments == nil {
+		return nil
+	}
+	out := make([]telemetry.IssueComment, len(comments))
+	for index, comment := range comments {
+		out[index] = comment
+		out[index].CreatedAt = CloneTimePointer(comment.CreatedAt)
+		out[index].UpdatedAt = CloneTimePointer(comment.UpdatedAt)
+	}
+	return out
+}
+
+func clonePullRequest(pr *telemetry.PullRequest) *telemetry.PullRequest {
+	if pr == nil {
+		return nil
+	}
+	out := *pr
+	out.HydrationNextRetryAt = CloneTimePointer(pr.HydrationNextRetryAt)
+	out.SlowChecks = append([]telemetry.PullRequestCheck(nil), pr.SlowChecks...)
+	out.RunningChecks = append([]string(nil), pr.RunningChecks...)
+	out.RequiredCheckFailures = append([]telemetry.PullRequestCheck(nil), pr.RequiredCheckFailures...)
+	return &out
+}
+
+func cloneDeliverable(deliverable *telemetry.Deliverable) *telemetry.Deliverable {
+	if deliverable == nil {
+		return nil
+	}
+	out := *deliverable
+	out.Metadata = maps.Clone(deliverable.Metadata)
+	return &out
+}
+
+func cloneMergeTiming(timing *telemetry.MergeTiming) *telemetry.MergeTiming {
+	if timing == nil {
+		return nil
+	}
+	out := *timing
+	out.EnteredMergingAt = CloneTimePointer(timing.EnteredMergingAt)
+	out.MergeWorkerSlotAcquiredAt = CloneTimePointer(timing.MergeWorkerSlotAcquiredAt)
+	out.MergeStartedAt = CloneTimePointer(timing.MergeStartedAt)
+	out.BaseRefreshStartedAt = CloneTimePointer(timing.BaseRefreshStartedAt)
+	out.BaseRefreshFinishedAt = CloneTimePointer(timing.BaseRefreshFinishedAt)
+	out.CIWaitStartedAt = CloneTimePointer(timing.CIWaitStartedAt)
+	out.CIWaitFinishedAt = CloneTimePointer(timing.CIWaitFinishedAt)
+	out.MergedAt = CloneTimePointer(timing.MergedAt)
+	out.MergeFailedAt = CloneTimePointer(timing.MergeFailedAt)
+	return &out
+}
+
+func CloneTimePointer(value *time.Time) *time.Time {
+	if value == nil {
+		return nil
+	}
+	out := *value
+	return &out
+}
+
+func ApplySnapshotIssues(snapshot *telemetry.Snapshot, apply func(*telemetry.Issue)) {
+	if snapshot == nil || apply == nil {
+		return
+	}
+	for i := range snapshot.BoardIssues {
+		apply(&snapshot.BoardIssues[i])
+	}
+	for i := range snapshot.Pipeline {
+		apply(&snapshot.Pipeline[i])
+	}
+	for i := range snapshot.Running {
+		apply(&snapshot.Running[i].Issue)
+	}
+	for i := range snapshot.Queue {
+		apply(&snapshot.Queue[i].Issue)
+	}
+	for i := range snapshot.Blocked {
+		apply(&snapshot.Blocked[i].Issue)
+	}
+	for i := range snapshot.Completed {
+		apply(&snapshot.Completed[i].Issue)
+	}
+}
+
+func IssueStateIndex(snapshot telemetry.Snapshot) map[string]string {
+	states := map[string]string{}
+	addIssue := func(issue telemetry.Issue, state string) {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			state = strings.TrimSpace(issue.State)
+		}
+		if state == "" {
+			return
+		}
+		for _, key := range issueStateKeys(issue.ID, issue.Identifier) {
+			states[key] = state
+		}
+	}
+	for _, row := range snapshot.Completed {
+		addIssue(row.Issue, row.State)
+	}
+	for _, issue := range SnapshotIssues(snapshot) {
+		addIssue(issue, issue.State)
+	}
+	return states
+}
+
+func BlockedRefsWithCurrentStates(refs []telemetry.BlockedRef, states map[string]string) []telemetry.BlockedRef {
+	if len(refs) == 0 {
+		return refs
+	}
+	out := append([]telemetry.BlockedRef(nil), refs...)
+	for i := range out {
+		for _, key := range issueStateKeys(out[i].ID, out[i].Identifier) {
+			if state := strings.TrimSpace(states[key]); state != "" {
+				out[i].State = state
+				break
+			}
+		}
+	}
+	return out
+}
+
+func issueStateKeys(id string, identifier string) []string {
+	keys := []string{}
+	if id = strings.TrimSpace(id); id != "" {
+		keys = append(keys, "id:"+id)
+	}
+	if identifier = strings.ToLower(strings.TrimSpace(identifier)); identifier != "" {
+		keys = append(keys, "identifier:"+identifier)
+	}
+	return keys
+}
+
+func CardFreshEntry(snapshot telemetry.Snapshot, projectID string, issueID string) (SnapshotIssueEntry, bool) {
+	var selected SnapshotIssueEntry
+	for _, entry := range visibleSnapshotIssueEntries(snapshot) {
+		if !SameIssue(entry.Issue, projectID, issueID, snapshot.Project.ID) {
+			continue
+		}
+		if selected.Issue.ID != "" && entry.rank < selected.rank {
+			continue
+		}
+		selected = entry
+	}
+	return selected, selected.Issue.ID != ""
+}
+
+func SnapshotProjectDataSeq(snapshot telemetry.Snapshot, projectID string) uint64 {
+	for _, project := range snapshot.Projects {
+		if project.Project.ID == projectID {
+			return project.Refresh.DataSeq
+		}
+	}
+	return snapshot.Refresh.DataSeq
+}
+
+func StateAllowed(cfg workflowconfig.Config, state string) bool {
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return false
+	}
+	states := StateNames(cfg, telemetry.Snapshot{})
+	if len(states) == 0 {
+		return true
+	}
+	for _, configured := range states {
+		if NormalizeState(configured) == NormalizeState(state) {
+			return true
+		}
+	}
+	return false
+}
+
+func StateNames(cfg workflowconfig.Config, snapshot telemetry.Snapshot) []string {
+	states := make([]string, 0, len(cfg.Tracker.ActiveStates)+len(cfg.Tracker.ObservedStates)+len(cfg.Tracker.TerminalStates))
+	seen := map[string]struct{}{}
+	add := func(values ...string) {
+		for _, value := range values {
+			value = strings.TrimSpace(value)
+			if value == "" {
+				continue
+			}
+			key := NormalizeState(value)
+			if _, ok := seen[key]; ok {
+				continue
+			}
+			seen[key] = struct{}{}
+			states = append(states, value)
+		}
+	}
+	add(cfg.KanbanStateNames()...)
+	for _, issue := range SnapshotIssues(snapshot) {
+		if rawGitHubIssueState(issue.State) {
+			if _, ok := seen[NormalizeState(issue.State)]; !ok {
+				continue
+			}
+		}
+		add(issue.State)
+	}
+	return states
+}
+
+func rawGitHubIssueState(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "open", "closed":
+		return true
+	default:
+		return false
+	}
+}
+
+func AllowedTransitions(cfg workflowconfig.Config, states []string) map[string][]string {
+	out := make(map[string][]string, len(states))
+	for _, state := range states {
+		state = strings.TrimSpace(state)
+		if state == "" {
+			continue
+		}
+		out[state] = cfg.KanbanAllowedTransitionTargets(state)
+	}
+	return out
+}
+
+func SnapshotIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
+	issues := make([]telemetry.Issue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked))
+	issues = append(issues, snapshot.BoardIssues...)
+	issues = append(issues, snapshot.Pipeline...)
+	for _, row := range snapshot.Running {
+		issues = append(issues, row.Issue)
+	}
+	for _, row := range snapshot.Queue {
+		issues = append(issues, row.Issue)
+	}
+	for _, row := range snapshot.Blocked {
+		issues = append(issues, row.Issue)
+	}
+	return issues
+}
+
+func snapshotIssueEntries(snapshot telemetry.Snapshot) []SnapshotIssueEntry {
+	entries := make([]SnapshotIssueEntry, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked))
+	index := 0
+	appendIssue := func(issue telemetry.Issue, fallback string, rank int) {
+		state := strings.TrimSpace(issue.State)
+		fallback = strings.TrimSpace(fallback)
+		rawRuntimeState := false
+		if fallback != "" && rawGitHubIssueState(state) {
+			state = fallback
+			rawRuntimeState = true
+		}
+		if state == "" {
+			state = fallback
+		}
+		entries = append(entries, SnapshotIssueEntry{
+			Issue:           issue,
+			State:           state,
+			rank:            rank,
+			index:           index,
+			rawRuntimeState: rawRuntimeState,
+		})
+		index++
+	}
+	for _, issue := range snapshot.BoardIssues {
+		appendIssue(issue, "", 5)
+	}
+	for _, issue := range snapshot.Pipeline {
+		appendIssue(issue, "", 10)
+	}
+	for _, row := range snapshot.Queue {
+		appendIssue(row.Issue, "Todo", 20)
+	}
+	for _, row := range snapshot.Running {
+		appendIssue(row.Issue, "In Progress", 30)
+	}
+	for _, row := range snapshot.Blocked {
+		appendIssue(row.Issue, "Blocked", 40)
+	}
+	return entries
+}
+
+func visibleSnapshotIssueEntries(snapshot telemetry.Snapshot) []SnapshotIssueEntry {
+	entries := snapshotIssueEntries(snapshot)
+	byKey := make(map[string]SnapshotIssueEntry, len(entries))
+	for _, entry := range entries {
+		key := snapshotIssueEntryKey(entry.Issue, snapshot.Project.ID)
+		if key == "" {
+			continue
+		}
+		current, ok := byKey[key]
+		if ok && entry.rawRuntimeState {
+			continue
+		}
+		if ok && entry.rank < current.rank {
+			continue
+		}
+		byKey[key] = entry
+	}
+	visible := make([]SnapshotIssueEntry, 0, len(byKey))
+	for _, entry := range byKey {
+		visible = append(visible, entry)
+	}
+	sort.SliceStable(visible, func(i, j int) bool {
+		return visible[i].index < visible[j].index
+	})
+	return visible
+}
+
+func snapshotIssueEntryKey(issue telemetry.Issue, snapshotProjectID string) string {
+	projectID := strings.TrimSpace(issue.ProjectID)
+	if projectID == "" {
+		projectID = strings.TrimSpace(snapshotProjectID)
+	}
+	prefix := ""
+	if projectID != "" {
+		prefix = "project:" + projectID + ":"
+	}
+	if issueID := strings.TrimSpace(issue.ID); issueID != "" {
+		return prefix + "id:" + issueID
+	}
+	if identifier := strings.ToLower(strings.TrimSpace(issue.Identifier)); identifier != "" {
+		return prefix + "identifier:" + identifier
+	}
+	return ""
+}
+
+func SameIssue(issue telemetry.Issue, projectID string, issueID string, snapshotProjectID string) bool {
+	if strings.TrimSpace(issue.ID) != strings.TrimSpace(issueID) {
+		return false
+	}
+	return SameProject(issue, projectID, snapshotProjectID)
+}
+
+func SameProject(issue telemetry.Issue, projectID string, snapshotProjectID string) bool {
+	projectID = strings.TrimSpace(projectID)
+	if projectID == "" {
+		return true
+	}
+	issueProjectID := strings.TrimSpace(issue.ProjectID)
+	if issueProjectID != "" {
+		return issueProjectID == projectID
+	}
+	return strings.TrimSpace(snapshotProjectID) == "" || strings.TrimSpace(snapshotProjectID) == projectID
+}
+
+func IssueRepository(identifier string) string {
+	repo, _, ok := strings.Cut(strings.TrimSpace(identifier), "#")
+	if !ok {
+		return ""
+	}
+	return strings.TrimSpace(repo)
+}
+
+func MappedState(cfg workflowconfig.Config, state string) string {
+	state = strings.TrimSpace(state)
+	if !cfg.Tracker.StateMap.IsMap {
+		return state
+	}
+	if mapped, ok := cfg.Tracker.StateMap.Map[state]; ok {
+		if value, ok := mapped.(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	normalized := NormalizeState(state)
+	for detentState, mapped := range cfg.Tracker.StateMap.Map {
+		if NormalizeState(detentState) != normalized {
+			continue
+		}
+		if value, ok := mapped.(string); ok && strings.TrimSpace(value) != "" {
+			return strings.TrimSpace(value)
+		}
+	}
+	return state
+}
+
+func NormalizeState(value string) string {
+	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), " "))
+}

--- a/internal/kanban/snapshot_test.go
+++ b/internal/kanban/snapshot_test.go
@@ -1,0 +1,472 @@
+package kanban
+
+import (
+	"slices"
+	"testing"
+	"time"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func TestStateNamesIgnoreCompletedSessionStates(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		cfg  workflowconfig.Config
+		want []string
+	}{
+		{
+			name: "unconfigured completed handoff ignored",
+			cfg: workflowconfig.Config{
+				Tracker: workflowconfig.Tracker{
+					ObservedStates: []string{"Backlog", "Blocked", "Human Review"},
+					ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+					TerminalStates: []string{"Done", "Cancelled"},
+				},
+			},
+			want: []string{"Backlog", "Blocked", "Human Review", "Todo", "In Progress", "Rework", "Merging", "Done", "Cancelled", "Needs Triage"},
+		},
+		{
+			name: "configured handoff preserved",
+			cfg: workflowconfig.Config{
+				Tracker: workflowconfig.Tracker{
+					ObservedStates: []string{"Backlog", "Handoff"},
+					ActiveStates:   []string{"Todo"},
+					TerminalStates: []string{"Done"},
+				},
+			},
+			want: []string{"Backlog", "Handoff", "Todo", "Done", "Needs Triage"},
+		},
+	}
+
+	snapshot := telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{
+			{ID: "tracker-extra", State: "Needs Triage"},
+		},
+		Completed: []telemetry.Completed{
+			{
+				Issue: telemetry.Issue{
+					ID:    "completed-open-pr",
+					State: "Handoff",
+					PullRequest: &telemetry.PullRequest{
+						Number: 554,
+						State:  "OPEN",
+					},
+				},
+				FinalState: "completed",
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := StateNames(tt.cfg, snapshot)
+			if !slices.Equal(got, tt.want) {
+				t.Fatalf("StateNames() = %#v, want %#v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStateNamesIgnoreRawGitHubRuntimeStates(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Config{
+		Tracker: workflowconfig.Tracker{
+			ObservedStates: []string{"Backlog", "Human Review"},
+			ActiveStates:   []string{"Todo", "In Progress", "Merging"},
+			TerminalStates: []string{"Done"},
+		},
+	}
+	snapshot := telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{
+			{ID: "custom", State: "Needs Triage"},
+		},
+		Pipeline: []telemetry.Issue{
+			{ID: "pipeline-open", State: "Open"},
+		},
+		Running: []telemetry.Running{
+			{Issue: telemetry.Issue{ID: "running-open", State: "OPEN"}},
+		},
+		Queue: []telemetry.Queued{
+			{Issue: telemetry.Issue{ID: "queue-closed", State: "Closed"}},
+		},
+		Blocked: []telemetry.Blocked{
+			{Issue: telemetry.Issue{ID: "blocked-closed", State: "CLOSED"}},
+		},
+	}
+
+	got := StateNames(cfg, snapshot)
+	want := []string{"Backlog", "Human Review", "Todo", "In Progress", "Merging", "Done", "Needs Triage"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("StateNames() = %#v, want %#v", got, want)
+	}
+}
+
+func TestStateNamesAllowConfiguredOpenState(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Config{
+		Tracker: workflowconfig.Tracker{
+			ObservedStates: []string{"Open"},
+			ActiveStates:   []string{"In Progress"},
+			TerminalStates: []string{"Done"},
+		},
+	}
+	snapshot := telemetry.Snapshot{
+		Running: []telemetry.Running{
+			{Issue: telemetry.Issue{ID: "running-open", State: "OPEN"}},
+		},
+	}
+
+	got := StateNames(cfg, snapshot)
+	want := []string{"Open", "In Progress", "Done"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("StateNames() = %#v, want %#v", got, want)
+	}
+}
+
+func TestSnapshotProjectDataSeq(t *testing.T) {
+	t.Parallel()
+
+	snapshot := telemetry.Snapshot{
+		Refresh: telemetry.Refresh{DataSeq: 3},
+		Projects: []telemetry.ProjectSnapshot{
+			{
+				Project: telemetry.Project{ID: "alpha"},
+				Refresh: telemetry.Refresh{DataSeq: 7},
+			},
+			{
+				Project: telemetry.Project{ID: "bravo"},
+				Refresh: telemetry.Refresh{DataSeq: 9},
+			},
+		},
+	}
+
+	tests := []struct {
+		name      string
+		projectID string
+		want      uint64
+	}{
+		{name: "project match", projectID: "bravo", want: 9},
+		{name: "fallback", projectID: "charlie", want: 3},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := SnapshotProjectDataSeq(snapshot, tt.projectID); got != tt.want {
+				t.Fatalf("SnapshotProjectDataSeq() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterAndApplySnapshotIssues(t *testing.T) {
+	t.Parallel()
+
+	snapshot := telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{{ID: "keep-board"}, {ID: "drop"}},
+		Pipeline:    []telemetry.Issue{{ID: "keep-pipeline"}, {ID: "drop"}},
+		Running:     []telemetry.Running{{Issue: telemetry.Issue{ID: "keep-running"}}, {Issue: telemetry.Issue{ID: "drop"}}},
+		Queue:       []telemetry.Queued{{Issue: telemetry.Issue{ID: "keep-queue"}}, {Issue: telemetry.Issue{ID: "drop"}}},
+		Blocked:     []telemetry.Blocked{{Issue: telemetry.Issue{ID: "keep-blocked"}}, {Issue: telemetry.Issue{ID: "drop"}}},
+		Completed:   []telemetry.Completed{{Issue: telemetry.Issue{ID: "completed"}}},
+	}
+
+	FilterSnapshotIssues(&snapshot, func(issue telemetry.Issue) bool {
+		return issue.ID != "drop"
+	})
+	if len(snapshot.BoardIssues) != 1 || len(snapshot.Pipeline) != 1 || len(snapshot.Running) != 1 || len(snapshot.Queue) != 1 || len(snapshot.Blocked) != 1 {
+		t.Fatalf("filtered snapshot counts = board:%d pipeline:%d running:%d queue:%d blocked:%d", len(snapshot.BoardIssues), len(snapshot.Pipeline), len(snapshot.Running), len(snapshot.Queue), len(snapshot.Blocked))
+	}
+	if len(snapshot.Completed) != 1 {
+		t.Fatalf("completed rows were filtered, count = %d", len(snapshot.Completed))
+	}
+
+	ApplySnapshotIssues(&snapshot, func(issue *telemetry.Issue) {
+		issue.State = "Touched"
+	})
+	for _, issue := range SnapshotIssues(snapshot) {
+		if issue.State != "Touched" {
+			t.Fatalf("SnapshotIssues() issue %q state = %q, want Touched", issue.ID, issue.State)
+		}
+	}
+	if snapshot.Completed[0].State != "Touched" {
+		t.Fatalf("completed issue state = %q, want Touched", snapshot.Completed[0].State)
+	}
+}
+
+func TestIssueStateIndexAndBlockedRefs(t *testing.T) {
+	t.Parallel()
+
+	refs := []telemetry.BlockedRef{
+		{ID: "blocker"},
+		{Identifier: "digitaldrywood/detent#99"},
+		{ID: "missing", State: "Unknown"},
+	}
+	states := IssueStateIndex(telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{{
+			ID:         "blocker",
+			Identifier: "digitaldrywood/detent#98",
+			State:      "In Progress",
+		}},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:         "done",
+				Identifier: "digitaldrywood/detent#99",
+				State:      "Done",
+			},
+		}},
+	})
+
+	got := BlockedRefsWithCurrentStates(refs, states)
+	if got[0].State != "In Progress" {
+		t.Fatalf("id ref state = %q, want In Progress", got[0].State)
+	}
+	if got[1].State != "Done" {
+		t.Fatalf("identifier ref state = %q, want Done", got[1].State)
+	}
+	if got[2].State != "Unknown" {
+		t.Fatalf("missing ref state = %q, want Unknown", got[2].State)
+	}
+	if refs[0].State != "" {
+		t.Fatalf("source refs mutated: %#v", refs)
+	}
+}
+
+func TestCardFreshEntrySelectsVisibleIssue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		snapshot  telemetry.Snapshot
+		issueID   string
+		wantState string
+		wantOK    bool
+	}{
+		{
+			name: "board issue wins over raw runtime state",
+			snapshot: telemetry.Snapshot{
+				Project:     telemetry.Project{ID: "detent"},
+				BoardIssues: []telemetry.Issue{{ID: "card", ProjectID: "detent", State: "Backlog"}},
+				Queue:       []telemetry.Queued{{Issue: telemetry.Issue{ID: "card", ProjectID: "detent", State: "OPEN"}}},
+			},
+			issueID:   "card",
+			wantState: "Backlog",
+			wantOK:    true,
+		},
+		{
+			name: "runtime state falls back to lane state",
+			snapshot: telemetry.Snapshot{
+				Project: telemetry.Project{ID: "detent"},
+				Queue:   []telemetry.Queued{{Issue: telemetry.Issue{ID: "queued", State: "OPEN"}}},
+			},
+			issueID:   "queued",
+			wantState: "Todo",
+			wantOK:    true,
+		},
+		{
+			name: "missing issue",
+			snapshot: telemetry.Snapshot{
+				Project: telemetry.Project{ID: "detent"},
+			},
+			issueID: "missing",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			entry, ok := CardFreshEntry(tt.snapshot, "detent", tt.issueID)
+			if ok != tt.wantOK {
+				t.Fatalf("CardFreshEntry() ok = %t, want %t", ok, tt.wantOK)
+			}
+			if entry.State != tt.wantState {
+				t.Fatalf("CardFreshEntry() state = %q, want %q", entry.State, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestStateAllowedAndAllowedTransitions(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Config{
+		Tracker: workflowconfig.Tracker{
+			ObservedStates: []string{"Backlog", "Blocked"},
+			ActiveStates:   []string{"Todo", "In Progress"},
+			TerminalStates: []string{"Done", "Cancelled"},
+		},
+		Server: workflowconfig.Server{
+			Kanban: workflowconfig.Kanban{
+				AllowedTransitions: map[string][]string{
+					"Todo":        {"In Progress", "Blocked"},
+					"In Progress": {"Done", "Blocked"},
+				},
+			},
+		},
+	}
+
+	tests := []struct {
+		name           string
+		state          string
+		wantAllowed    bool
+		target         string
+		wantTransition bool
+	}{
+		{name: "configured state and transition allowed", state: "Todo", wantAllowed: true, target: "In Progress", wantTransition: true},
+		{name: "case-insensitive configured state allowed", state: " in   progress ", wantAllowed: true, target: "Done", wantTransition: true},
+		{name: "unknown state rejected by state allowlist", state: "Needs Triage"},
+		{name: "configured state with blocked explicit transition", state: "Todo", wantAllowed: true, target: "Done"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := StateAllowed(cfg, tt.state); got != tt.wantAllowed {
+				t.Fatalf("StateAllowed(%q) = %t, want %t", tt.state, got, tt.wantAllowed)
+			}
+			if tt.target == "" {
+				return
+			}
+			gotTransition := cfg.KanbanTransitionAllowed(tt.state, tt.target)
+			if gotTransition != tt.wantTransition {
+				t.Fatalf("KanbanTransitionAllowed(%q, %q) = %t, want %t", tt.state, tt.target, gotTransition, tt.wantTransition)
+			}
+		})
+	}
+
+	transitions := AllowedTransitions(cfg, []string{"Todo", "In Progress", "Done"})
+	if !slices.Equal(transitions["Todo"], []string{"In Progress", "Blocked"}) {
+		t.Fatalf("AllowedTransitions()[Todo] = %#v, want In Progress/Blocked", transitions["Todo"])
+	}
+	if !slices.Equal(transitions["In Progress"], []string{"Done", "Blocked"}) {
+		t.Fatalf("AllowedTransitions()[In Progress] = %#v, want Done/Blocked", transitions["In Progress"])
+	}
+	if !slices.Equal(transitions["Done"], cfg.KanbanAllowedTransitionTargets("Done")) {
+		t.Fatalf("AllowedTransitions()[Done] = %#v, want workflowconfig targets", transitions["Done"])
+	}
+}
+
+func TestMappedStateAndIssueRepository(t *testing.T) {
+	t.Parallel()
+
+	cfg := workflowconfig.Config{
+		Tracker: workflowconfig.Tracker{
+			StateMap: workflowconfig.MapValue(map[string]any{
+				"Todo":        "To Do",
+				"In Progress": "Doing",
+				"Blocked":     "",
+			}),
+		},
+	}
+
+	tests := []struct {
+		name  string
+		state string
+		want  string
+	}{
+		{name: "exact map", state: "Todo", want: "To Do"},
+		{name: "normalized map", state: " in   progress ", want: "Doing"},
+		{name: "empty map value falls back to original", state: "Blocked", want: "Blocked"},
+		{name: "unmapped falls back to original", state: "Needs Triage", want: "Needs Triage"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := MappedState(cfg, tt.state); got != tt.want {
+				t.Fatalf("MappedState(%q) = %q, want %q", tt.state, got, tt.want)
+			}
+		})
+	}
+
+	if got := MappedState(workflowconfig.Config{}, " Todo "); got != "Todo" {
+		t.Fatalf("MappedState() without map = %q, want Todo", got)
+	}
+	if got := IssueRepository("digitaldrywood/detent#1032"); got != "digitaldrywood/detent" {
+		t.Fatalf("IssueRepository() = %q, want digitaldrywood/detent", got)
+	}
+	if got := IssueRepository("DDW-1032"); got != "" {
+		t.Fatalf("IssueRepository() = %q, want empty for non-repository identifier", got)
+	}
+}
+
+func TestCloneIssueSlicesIsolatesSourceSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 13, 0, 0, 0, time.UTC)
+	snapshot := telemetry.Snapshot{
+		BoardIssues: []telemetry.Issue{{
+			ID:        "board",
+			State:     "Todo",
+			Labels:    []string{"feature"},
+			BlockedBy: []telemetry.BlockedRef{{ID: "blocker", State: "Backlog"}},
+			Metadata:  map[string]string{"source": "board"},
+			Comments: []telemetry.IssueComment{{
+				ID:        "comment",
+				CreatedAt: &now,
+			}},
+			PullRequest: &telemetry.PullRequest{
+				Number:        7,
+				RunningChecks: []string{"test"},
+			},
+		}},
+		Running: []telemetry.Running{{
+			Issue: telemetry.Issue{
+				ID:       "running",
+				Metadata: map[string]string{"source": "running"},
+			},
+		}},
+		Completed: []telemetry.Completed{{
+			Issue: telemetry.Issue{
+				ID:        "completed",
+				BlockedBy: []telemetry.BlockedRef{{ID: "done-blocker", State: "Done"}},
+			},
+		}},
+	}
+
+	clone := CloneIssueSlices(snapshot)
+	clone.BoardIssues[0].Labels[0] = "bug"
+	clone.BoardIssues[0].BlockedBy[0].State = "Done"
+	clone.BoardIssues[0].Metadata["source"] = "clone"
+	clone.BoardIssues[0].Comments[0].CreatedAt = ptrTime(now.Add(time.Hour))
+	clone.BoardIssues[0].PullRequest.RunningChecks[0] = "lint"
+	clone.Running[0].Metadata["source"] = "clone"
+	clone.Completed[0].Issue.BlockedBy[0].State = "Cancelled"
+
+	if snapshot.BoardIssues[0].Labels[0] != "feature" {
+		t.Fatalf("source label changed to %q", snapshot.BoardIssues[0].Labels[0])
+	}
+	if snapshot.BoardIssues[0].BlockedBy[0].State != "Backlog" {
+		t.Fatalf("source blocked ref changed to %q", snapshot.BoardIssues[0].BlockedBy[0].State)
+	}
+	if snapshot.BoardIssues[0].Metadata["source"] != "board" {
+		t.Fatalf("source metadata changed to %q", snapshot.BoardIssues[0].Metadata["source"])
+	}
+	if !snapshot.BoardIssues[0].Comments[0].CreatedAt.Equal(now) {
+		t.Fatalf("source comment time changed to %v", snapshot.BoardIssues[0].Comments[0].CreatedAt)
+	}
+	if snapshot.BoardIssues[0].PullRequest.RunningChecks[0] != "test" {
+		t.Fatalf("source pull request checks changed to %#v", snapshot.BoardIssues[0].PullRequest.RunningChecks)
+	}
+	if snapshot.Running[0].Metadata["source"] != "running" {
+		t.Fatalf("source running metadata changed to %q", snapshot.Running[0].Metadata["source"])
+	}
+	if snapshot.Completed[0].Issue.BlockedBy[0].State != "Done" {
+		t.Fatalf("source completed blocked ref changed to %q", snapshot.Completed[0].Issue.BlockedBy[0].State)
+	}
+}
+
+func ptrTime(value time.Time) *time.Time {
+	return &value
+}

--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -11,6 +11,7 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/demofixtures"
@@ -485,8 +486,8 @@ func (s *Server) demoKanbanMoveSuccess(c echo.Context, scenario demoScenario) er
 }
 
 func applyDemoKanbanMove(snapshot *telemetry.Snapshot, projectID string, issueID string, targetState string) {
-	applySnapshotKanbanIssues(snapshot, func(issue *telemetry.Issue) {
-		if issue == nil || !sameKanbanIssue(*issue, projectID, issueID, snapshot.Project.ID) {
+	kanbanstate.ApplySnapshotIssues(snapshot, func(issue *telemetry.Issue) {
+		if issue == nil || !kanbanstate.SameIssue(*issue, projectID, issueID, snapshot.Project.ID) {
 			return
 		}
 		issue.State = targetState

--- a/internal/web/kanban.go
+++ b/internal/web/kanban.go
@@ -6,62 +6,22 @@ import (
 	"errors"
 	"fmt"
 	"html"
-	"maps"
 	"net/http"
 	"net/url"
-	"sort"
 	"strconv"
 	"strings"
-	"sync"
 	"time"
 
 	"github.com/labstack/echo/v4"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/templates"
 )
-
-type kanbanMutationLocks struct {
-	mu       sync.Mutex
-	locks    map[string]*sync.Mutex
-	states   map[string]kanbanPendingState
-	removed  map[string]kanbanPendingRemoval
-	reverted map[string]kanbanRevertNotice
-}
-
-type kanbanPendingState struct {
-	snapshot       string
-	current        string
-	project        string
-	issue          telemetry.Issue
-	dataSeqAtWrite uint64
-	contradictions int
-}
-
-type kanbanPendingRemoval struct {
-	snapshot       string
-	removedAt      time.Time
-	dataSeqAtWrite uint64
-}
-
-type kanbanRevertNotice struct {
-	identifier string
-	from       string
-	to         string
-	at         time.Time
-}
-
-type kanbanSnapshotIssueEntry struct {
-	issue           telemetry.Issue
-	state           string
-	rank            int
-	index           int
-	rawRuntimeState bool
-}
 
 type kanbanActionTarget struct {
 	key       string
@@ -105,324 +65,14 @@ type kanbanCommentMutationRequest struct {
 }
 
 const (
-	kanbanDialogContentTarget       = "#kanban-dialog-content"
-	kanbanProjectBoardTarget        = "#snapshot"
-	kanbanFleetBoardTarget          = "#snapshot"
-	kanbanDialogSucceeded           = "kanbanActionSucceeded"
-	kanbanOverlayContradictionLimit = 2
-	kanbanRemovalPendingTTL         = 5 * time.Minute
-	kanbanRefreshRetryDelay         = 2 * time.Second
-	kanbanMoveUnsupportedMessage    = "This project's tracker does not support moving cards."
-	kanbanRemoveUnsupportedMessage  = "This project's tracker does not support removing cards."
+	kanbanDialogContentTarget      = "#kanban-dialog-content"
+	kanbanProjectBoardTarget       = "#snapshot"
+	kanbanFleetBoardTarget         = "#snapshot"
+	kanbanDialogSucceeded          = "kanbanActionSucceeded"
+	kanbanRefreshRetryDelay        = 2 * time.Second
+	kanbanMoveUnsupportedMessage   = "This project's tracker does not support moving cards."
+	kanbanRemoveUnsupportedMessage = "This project's tracker does not support removing cards."
 )
-
-func newKanbanMutationLocks() *kanbanMutationLocks {
-	return &kanbanMutationLocks{
-		locks:    map[string]*sync.Mutex{},
-		states:   map[string]kanbanPendingState{},
-		removed:  map[string]kanbanPendingRemoval{},
-		reverted: map[string]kanbanRevertNotice{},
-	}
-}
-
-func (l *kanbanMutationLocks) withLock(key string, fn func() error) error {
-	lock := l.lockFor(key)
-	lock.Lock()
-	defer lock.Unlock()
-	return fn()
-}
-
-func (l *kanbanMutationLocks) lockFor(key string) *sync.Mutex {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		key = "default"
-	}
-
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	lock, ok := l.locks[key]
-	if !ok {
-		lock = &sync.Mutex{}
-		l.locks[key] = lock
-	}
-	return lock
-}
-
-func (l *kanbanMutationLocks) cardState(key string, issueID string, snapshotState string, dataSeq uint64) string {
-	stateKey := kanbanMutationStateKey(key, issueID)
-	if stateKey == "" {
-		return snapshotState
-	}
-
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	return l.cardStateLocked(stateKey, snapshotState, dataSeq)
-}
-
-func (l *kanbanMutationLocks) cardStateLocked(stateKey string, snapshotState string, dataSeq uint64) string {
-	pending, ok := l.states[stateKey]
-	if !ok {
-		return snapshotState
-	}
-	if dataSeq <= pending.dataSeqAtWrite {
-		return pending.current
-	}
-
-	switch {
-	case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.current):
-		delete(l.states, stateKey)
-		return snapshotState
-	case normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot):
-		pending.contradictions++
-		if pending.contradictions < kanbanOverlayContradictionLimit {
-			l.states[stateKey] = pending
-			return pending.current
-		}
-		delete(l.states, stateKey)
-		l.noteRevertLocked(stateKey, pending, snapshotState)
-		return snapshotState
-	default:
-		delete(l.states, stateKey)
-		l.noteRevertLocked(stateKey, pending, snapshotState)
-		return snapshotState
-	}
-}
-
-func (l *kanbanMutationLocks) noteCardState(key string, projectID string, issue telemetry.Issue, snapshotState string, currentState string, dataSeqAtWrite uint64) {
-	issue.ID = strings.TrimSpace(issue.ID)
-	stateKey := kanbanMutationStateKey(key, issue.ID)
-	if stateKey == "" || strings.TrimSpace(currentState) == "" {
-		return
-	}
-	projectID = strings.TrimSpace(projectID)
-	if strings.TrimSpace(issue.ProjectID) == "" {
-		issue.ProjectID = projectID
-	}
-
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	if pending, ok := l.states[stateKey]; ok && normalizeKanbanState(snapshotState) == normalizeKanbanState(pending.snapshot) {
-		snapshotState = pending.snapshot
-	}
-	delete(l.removed, stateKey)
-	delete(l.reverted, stateKey)
-	l.states[stateKey] = kanbanPendingState{
-		snapshot:       strings.TrimSpace(snapshotState),
-		current:        strings.TrimSpace(currentState),
-		project:        projectID,
-		issue:          cloneKanbanIssue(issue),
-		dataSeqAtWrite: dataSeqAtWrite,
-	}
-}
-
-func (l *kanbanMutationLocks) pendingMovedCards(key string, projectID string, snapshot telemetry.Snapshot) []telemetry.Issue {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return nil
-	}
-	projectID = strings.TrimSpace(projectID)
-	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
-
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	present := map[string]struct{}{}
-	for _, entry := range visibleSnapshotKanbanIssueEntries(snapshot) {
-		issueID := strings.TrimSpace(entry.issue.ID)
-		if issueID == "" || !sameKanbanProject(entry.issue, projectID, snapshot.Project.ID) {
-			continue
-		}
-		stateKey := kanbanMutationStateKey(key, issueID)
-		if _, ok := l.states[stateKey]; !ok {
-			continue
-		}
-		present[stateKey] = struct{}{}
-	}
-	for _, row := range snapshot.Completed {
-		issue := row.Issue
-		issueID := strings.TrimSpace(issue.ID)
-		if issueID == "" || !sameKanbanProject(issue, projectID, snapshot.Project.ID) {
-			continue
-		}
-		stateKey := kanbanMutationStateKey(key, issueID)
-		if _, ok := present[stateKey]; ok {
-			continue
-		}
-		if _, ok := l.states[stateKey]; !ok {
-			continue
-		}
-		snapshotState := strings.TrimSpace(issue.State)
-		l.cardStateLocked(stateKey, snapshotState, dataSeq)
-	}
-
-	out := []telemetry.Issue{}
-	for stateKey, pending := range l.states {
-		if _, ok := present[stateKey]; ok {
-			continue
-		}
-		issueID := strings.TrimSpace(pending.issue.ID)
-		if issueID == "" || kanbanMutationStateKey(key, issueID) != stateKey {
-			continue
-		}
-		if projectID != "" && pending.project != "" && pending.project != projectID {
-			continue
-		}
-		if !sameKanbanProject(pending.issue, projectID, snapshot.Project.ID) {
-			continue
-		}
-		issue := cloneKanbanIssue(pending.issue)
-		if strings.TrimSpace(issue.ProjectID) == "" {
-			issue.ProjectID = projectID
-		}
-		issue.State = strings.TrimSpace(pending.current)
-		out = append(out, issue)
-	}
-	sort.SliceStable(out, func(i, j int) bool {
-		left := strings.TrimSpace(out[i].Identifier)
-		right := strings.TrimSpace(out[j].Identifier)
-		if left != right {
-			return left < right
-		}
-		return strings.TrimSpace(out[i].ID) < strings.TrimSpace(out[j].ID)
-	})
-	return out
-}
-
-func (l *kanbanMutationLocks) snapshotCardStates(key string, projectID string, snapshot telemetry.Snapshot) map[string]string {
-	key = strings.TrimSpace(key)
-	if key == "" {
-		return nil
-	}
-	projectID = strings.TrimSpace(projectID)
-	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
-
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	out := map[string]string{}
-	for _, entry := range visibleSnapshotKanbanIssueEntries(snapshot) {
-		issueID := strings.TrimSpace(entry.issue.ID)
-		if issueID == "" || !sameKanbanProject(entry.issue, projectID, snapshot.Project.ID) {
-			continue
-		}
-		stateKey := kanbanMutationStateKey(key, issueID)
-		if _, ok := l.states[stateKey]; !ok {
-			continue
-		}
-		state := l.cardStateLocked(stateKey, entry.state, dataSeq)
-		if strings.TrimSpace(state) != "" {
-			out[stateKey] = state
-		}
-	}
-	if len(out) == 0 {
-		return nil
-	}
-	return out
-}
-
-func (l *kanbanMutationLocks) cardRemoved(key string, issueID string, snapshotState string, dataSeq uint64) bool {
-	stateKey := kanbanMutationStateKey(key, issueID)
-	if stateKey == "" {
-		return false
-	}
-
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	removed, ok := l.removed[stateKey]
-	if !ok {
-		return false
-	}
-	if time.Since(removed.removedAt) > kanbanRemovalPendingTTL {
-		delete(l.removed, stateKey)
-		return false
-	}
-	if dataSeq <= removed.dataSeqAtWrite {
-		return true
-	}
-	if normalizeKanbanState(snapshotState) == normalizeKanbanState(removed.snapshot) {
-		return true
-	}
-	delete(l.removed, stateKey)
-	return false
-}
-
-func (l *kanbanMutationLocks) noteCardRemoved(key string, issueID string, snapshotState string, dataSeqAtWrite uint64) {
-	stateKey := kanbanMutationStateKey(key, issueID)
-	if stateKey == "" {
-		return
-	}
-
-	l.mu.Lock()
-	delete(l.states, stateKey)
-	delete(l.reverted, stateKey)
-	l.removed[stateKey] = kanbanPendingRemoval{
-		snapshot:       strings.TrimSpace(snapshotState),
-		removedAt:      time.Now(),
-		dataSeqAtWrite: dataSeqAtWrite,
-	}
-	l.mu.Unlock()
-}
-
-func (l *kanbanMutationLocks) noteRevertLocked(stateKey string, pending kanbanPendingState, snapshotState string) {
-	identifier := strings.TrimSpace(pending.issue.Identifier)
-	if identifier == "" {
-		identifier = strings.TrimSpace(pending.issue.ID)
-	}
-	to := strings.TrimSpace(snapshotState)
-	if to == "" {
-		to = strings.TrimSpace(pending.snapshot)
-	}
-	l.reverted[stateKey] = kanbanRevertNotice{
-		identifier: identifier,
-		from:       strings.TrimSpace(pending.current),
-		to:         to,
-		at:         time.Now(),
-	}
-}
-
-func (l *kanbanMutationLocks) consumeRevertNotices(key string, projectID string) []kanbanRevertNotice {
-	key = strings.TrimSpace(key)
-	projectID = strings.TrimSpace(projectID)
-	if key == "" && projectID != "" {
-		key = "project:" + projectID
-	}
-	prefix := ""
-	if key != "" {
-		prefix = key + "\x00"
-	}
-
-	l.mu.Lock()
-	defer l.mu.Unlock()
-
-	notices := []kanbanRevertNotice{}
-	for stateKey, notice := range l.reverted {
-		if prefix != "" && !strings.HasPrefix(stateKey, prefix) {
-			continue
-		}
-		notices = append(notices, notice)
-		delete(l.reverted, stateKey)
-	}
-	sort.SliceStable(notices, func(i, j int) bool {
-		if !notices[i].at.Equal(notices[j].at) {
-			return notices[i].at.Before(notices[j].at)
-		}
-		return notices[i].identifier < notices[j].identifier
-	})
-	return notices
-}
-
-func kanbanMutationStateKey(key string, issueID string) string {
-	key = strings.TrimSpace(key)
-	issueID = strings.TrimSpace(issueID)
-	if key == "" || issueID == "" {
-		return ""
-	}
-	return key + "\x00" + issueID
-}
 
 func (s *Server) apiKanbanMoveDialog(c echo.Context) error {
 	if scenario, ok, err := s.demoScenarioOrError(c); err != nil {
@@ -487,13 +137,13 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 		}
 		return s.kanbanMoveValidationResponse(c, http.StatusBadRequest, "Issue id is required.")
 	}
-	if !kanbanStateAllowed(target.workflow, req.targetState) {
+	if !kanbanstate.StateAllowed(target.workflow, req.targetState) {
 		return s.kanbanMoveValidationResponse(c, http.StatusBadRequest, "Target state is not configured for this board.")
 	}
 	var feedback string
 	var feedbackStatus int
 	var moveIssueIdentifier string
-	err := s.kanbanMutations.withLock(target.key, func() error {
+	err := s.kanbanMutations.WithLock(target.key, func() error {
 		currentState := req.currentState
 		ok, current, snapshotState, snapshotIssue, dataSeqAtWrite := s.kanbanCardFresh(target.key, req.projectID, req.issueID, req.currentState)
 		if !ok {
@@ -519,18 +169,18 @@ func (s *Server) apiKanbanMove(c echo.Context) error {
 			if !ok {
 				return connector.ErrNotImplemented
 			}
-			if err := setter.SetIssueField(c.Request().Context(), req.issueID, target.kanban.IssueStateFieldID, mappedKanbanState(target.workflow, req.targetState)); err != nil {
+			if err := setter.SetIssueField(c.Request().Context(), req.issueID, target.kanban.IssueStateFieldID, kanbanstate.MappedState(target.workflow, req.targetState)); err != nil {
 				return err
 			}
 			s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move_field")
-			s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
+			s.kanbanMutations.NoteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
 			return nil
 		}
 		if err := target.connector.UpdateIssueState(c.Request().Context(), req.issueID, req.targetState); err != nil {
 			return err
 		}
 		s.recordKanbanLaneTransition(c.Request().Context(), req.projectID, snapshotIssue, currentState, req.targetState, "kanban_move")
-		s.kanbanMutations.noteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
+		s.kanbanMutations.NoteCardState(target.key, req.projectID, snapshotIssue, snapshotState, req.targetState, dataSeqAtWrite)
 		return nil
 	})
 	if feedback != "" {
@@ -608,7 +258,7 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 	var feedback string
 	var feedbackStatus int
 	var removeIssueIdentifier string
-	err := s.kanbanMutations.withLock(target.key, func() error {
+	err := s.kanbanMutations.WithLock(target.key, func() error {
 		currentState := req.currentState
 		ok, current, snapshotState, snapshotIssue, dataSeqAtWrite := s.kanbanCardFresh(target.key, req.projectID, req.issueID, req.currentState)
 		if !ok {
@@ -634,7 +284,7 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 			if strings.TrimSpace(snapshotState) == "" {
 				snapshotState = currentState
 			}
-			s.kanbanMutations.noteCardRemoved(target.key, req.issueID, snapshotState, dataSeqAtWrite)
+			s.kanbanMutations.NoteCardRemoved(target.key, req.issueID, snapshotState, dataSeqAtWrite)
 			return nil
 		}
 		remover, ok := target.connector.(connector.ProjectRemover)
@@ -647,7 +297,7 @@ func (s *Server) apiKanbanRemove(c echo.Context) error {
 		if strings.TrimSpace(snapshotState) == "" {
 			snapshotState = currentState
 		}
-		s.kanbanMutations.noteCardRemoved(target.key, req.issueID, snapshotState, dataSeqAtWrite)
+		s.kanbanMutations.NoteCardRemoved(target.key, req.issueID, snapshotState, dataSeqAtWrite)
 		return nil
 	})
 	if feedback != "" {
@@ -691,21 +341,21 @@ func (s *Server) kanbanSnapshotWithPendingStates(lockKey string, projectID strin
 	if s.kanbanMutations == nil {
 		return snapshot
 	}
-	snapshot = cloneKanbanIssueSlices(snapshot)
-	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
-	filterSnapshotKanbanIssues(&snapshot, func(issue telemetry.Issue) bool {
-		if strings.TrimSpace(issue.ID) == "" || !sameKanbanProject(issue, projectID, snapshot.Project.ID) {
+	snapshot = kanbanstate.CloneIssueSlices(snapshot)
+	dataSeq := kanbanstate.SnapshotProjectDataSeq(snapshot, projectID)
+	kanbanstate.FilterSnapshotIssues(&snapshot, func(issue telemetry.Issue) bool {
+		if strings.TrimSpace(issue.ID) == "" || !kanbanstate.SameProject(issue, projectID, snapshot.Project.ID) {
 			return true
 		}
-		return !s.kanbanMutations.cardRemoved(lockKey, issue.ID, issue.State, dataSeq)
+		return !s.kanbanMutations.CardRemoved(lockKey, issue.ID, issue.State, dataSeq)
 	})
-	pendingMovedCards := s.kanbanMutations.pendingMovedCards(lockKey, projectID, snapshot)
-	pendingStates := s.kanbanMutations.snapshotCardStates(lockKey, projectID, snapshot)
-	applySnapshotKanbanIssues(&snapshot, func(issue *telemetry.Issue) {
-		if issue == nil || strings.TrimSpace(issue.ID) == "" || !sameKanbanProject(*issue, projectID, snapshot.Project.ID) {
+	pendingMovedCards := s.kanbanMutations.PendingMovedCards(lockKey, projectID, snapshot)
+	pendingStates := s.kanbanMutations.SnapshotCardStates(lockKey, projectID, snapshot)
+	kanbanstate.ApplySnapshotIssues(&snapshot, func(issue *telemetry.Issue) {
+		if issue == nil || strings.TrimSpace(issue.ID) == "" || !kanbanstate.SameProject(*issue, projectID, snapshot.Project.ID) {
 			return
 		}
-		stateKey := kanbanMutationStateKey(lockKey, issue.ID)
+		stateKey := kanbanstate.MutationStateKey(lockKey, issue.ID)
 		state := strings.TrimSpace(pendingStates[stateKey])
 		if state != "" {
 			issue.State = state
@@ -714,227 +364,14 @@ func (s *Server) kanbanSnapshotWithPendingStates(lockKey string, projectID strin
 	if len(pendingMovedCards) > 0 {
 		snapshot.BoardIssues = append(snapshot.BoardIssues, pendingMovedCards...)
 	}
-	states := kanbanIssueStateIndex(snapshot)
-	applySnapshotKanbanIssues(&snapshot, func(issue *telemetry.Issue) {
-		if issue == nil || len(issue.BlockedBy) == 0 || !sameKanbanProject(*issue, projectID, snapshot.Project.ID) {
+	states := kanbanstate.IssueStateIndex(snapshot)
+	kanbanstate.ApplySnapshotIssues(&snapshot, func(issue *telemetry.Issue) {
+		if issue == nil || len(issue.BlockedBy) == 0 || !kanbanstate.SameProject(*issue, projectID, snapshot.Project.ID) {
 			return
 		}
-		issue.BlockedBy = kanbanBlockedRefsWithCurrentStates(issue.BlockedBy, states)
+		issue.BlockedBy = kanbanstate.BlockedRefsWithCurrentStates(issue.BlockedBy, states)
 	})
 	return snapshot
-}
-
-func filterSnapshotKanbanIssues(snapshot *telemetry.Snapshot, keep func(telemetry.Issue) bool) {
-	if snapshot == nil || keep == nil {
-		return
-	}
-	snapshot.BoardIssues = filterTelemetryIssues(snapshot.BoardIssues, keep)
-	snapshot.Pipeline = filterTelemetryIssues(snapshot.Pipeline, keep)
-	snapshot.Running = filterTelemetryRunning(snapshot.Running, keep)
-	snapshot.Queue = filterTelemetryQueued(snapshot.Queue, keep)
-	snapshot.Blocked = filterTelemetryBlocked(snapshot.Blocked, keep)
-}
-
-func filterTelemetryIssues(issues []telemetry.Issue, keep func(telemetry.Issue) bool) []telemetry.Issue {
-	out := issues[:0]
-	for _, issue := range issues {
-		if keep(issue) {
-			out = append(out, issue)
-		}
-	}
-	return out
-}
-
-func filterTelemetryRunning(rows []telemetry.Running, keep func(telemetry.Issue) bool) []telemetry.Running {
-	out := rows[:0]
-	for _, row := range rows {
-		if keep(row.Issue) {
-			out = append(out, row)
-		}
-	}
-	return out
-}
-
-func filterTelemetryQueued(rows []telemetry.Queued, keep func(telemetry.Issue) bool) []telemetry.Queued {
-	out := rows[:0]
-	for _, row := range rows {
-		if keep(row.Issue) {
-			out = append(out, row)
-		}
-	}
-	return out
-}
-
-func filterTelemetryBlocked(rows []telemetry.Blocked, keep func(telemetry.Issue) bool) []telemetry.Blocked {
-	out := rows[:0]
-	for _, row := range rows {
-		if keep(row.Issue) {
-			out = append(out, row)
-		}
-	}
-	return out
-}
-
-func cloneKanbanIssueSlices(snapshot telemetry.Snapshot) telemetry.Snapshot {
-	snapshot.BoardIssues = append([]telemetry.Issue(nil), snapshot.BoardIssues...)
-	snapshot.Pipeline = append([]telemetry.Issue(nil), snapshot.Pipeline...)
-	snapshot.Running = append([]telemetry.Running(nil), snapshot.Running...)
-	snapshot.Queue = append([]telemetry.Queued(nil), snapshot.Queue...)
-	snapshot.Blocked = append([]telemetry.Blocked(nil), snapshot.Blocked...)
-	snapshot.Completed = append([]telemetry.Completed(nil), snapshot.Completed...)
-	return snapshot
-}
-
-func cloneKanbanIssue(issue telemetry.Issue) telemetry.Issue {
-	out := issue
-	out.Labels = append([]string(nil), issue.Labels...)
-	out.Assignees = append([]string(nil), issue.Assignees...)
-	out.Comments = cloneKanbanIssueComments(issue.Comments)
-	out.BlockedBy = append([]telemetry.BlockedRef(nil), issue.BlockedBy...)
-	out.Metadata = maps.Clone(issue.Metadata)
-	out.PullRequest = cloneKanbanPullRequest(issue.PullRequest)
-	out.Deliverable = cloneKanbanDeliverable(issue.Deliverable)
-	out.MergeTiming = cloneKanbanMergeTiming(issue.MergeTiming)
-	out.LeaseRenewedAt = cloneKanbanTimePointer(issue.LeaseRenewedAt)
-	out.LeaseExpiresAt = cloneKanbanTimePointer(issue.LeaseExpiresAt)
-	out.CreatedAt = cloneKanbanTimePointer(issue.CreatedAt)
-	out.UpdatedAt = cloneKanbanTimePointer(issue.UpdatedAt)
-	out.StageUpdatedAt = cloneKanbanTimePointer(issue.StageUpdatedAt)
-	out.CurrentLaneEnteredAt = cloneKanbanTimePointer(issue.CurrentLaneEnteredAt)
-	return out
-}
-
-func cloneKanbanIssueComments(comments []telemetry.IssueComment) []telemetry.IssueComment {
-	if comments == nil {
-		return nil
-	}
-	out := make([]telemetry.IssueComment, len(comments))
-	for index, comment := range comments {
-		out[index] = comment
-		out[index].CreatedAt = cloneKanbanTimePointer(comment.CreatedAt)
-		out[index].UpdatedAt = cloneKanbanTimePointer(comment.UpdatedAt)
-	}
-	return out
-}
-
-func cloneKanbanPullRequest(pr *telemetry.PullRequest) *telemetry.PullRequest {
-	if pr == nil {
-		return nil
-	}
-	out := *pr
-	out.HydrationNextRetryAt = cloneKanbanTimePointer(pr.HydrationNextRetryAt)
-	out.SlowChecks = append([]telemetry.PullRequestCheck(nil), pr.SlowChecks...)
-	out.RunningChecks = append([]string(nil), pr.RunningChecks...)
-	out.RequiredCheckFailures = append([]telemetry.PullRequestCheck(nil), pr.RequiredCheckFailures...)
-	return &out
-}
-
-func cloneKanbanDeliverable(deliverable *telemetry.Deliverable) *telemetry.Deliverable {
-	if deliverable == nil {
-		return nil
-	}
-	out := *deliverable
-	out.Metadata = maps.Clone(deliverable.Metadata)
-	return &out
-}
-
-func cloneKanbanMergeTiming(timing *telemetry.MergeTiming) *telemetry.MergeTiming {
-	if timing == nil {
-		return nil
-	}
-	out := *timing
-	out.EnteredMergingAt = cloneKanbanTimePointer(timing.EnteredMergingAt)
-	out.MergeWorkerSlotAcquiredAt = cloneKanbanTimePointer(timing.MergeWorkerSlotAcquiredAt)
-	out.MergeStartedAt = cloneKanbanTimePointer(timing.MergeStartedAt)
-	out.BaseRefreshStartedAt = cloneKanbanTimePointer(timing.BaseRefreshStartedAt)
-	out.BaseRefreshFinishedAt = cloneKanbanTimePointer(timing.BaseRefreshFinishedAt)
-	out.CIWaitStartedAt = cloneKanbanTimePointer(timing.CIWaitStartedAt)
-	out.CIWaitFinishedAt = cloneKanbanTimePointer(timing.CIWaitFinishedAt)
-	out.MergedAt = cloneKanbanTimePointer(timing.MergedAt)
-	out.MergeFailedAt = cloneKanbanTimePointer(timing.MergeFailedAt)
-	return &out
-}
-
-func cloneKanbanTimePointer(value *time.Time) *time.Time {
-	if value == nil {
-		return nil
-	}
-	out := *value
-	return &out
-}
-
-func applySnapshotKanbanIssues(snapshot *telemetry.Snapshot, apply func(*telemetry.Issue)) {
-	if snapshot == nil || apply == nil {
-		return
-	}
-	for i := range snapshot.BoardIssues {
-		apply(&snapshot.BoardIssues[i])
-	}
-	for i := range snapshot.Pipeline {
-		apply(&snapshot.Pipeline[i])
-	}
-	for i := range snapshot.Running {
-		apply(&snapshot.Running[i].Issue)
-	}
-	for i := range snapshot.Queue {
-		apply(&snapshot.Queue[i].Issue)
-	}
-	for i := range snapshot.Blocked {
-		apply(&snapshot.Blocked[i].Issue)
-	}
-	for i := range snapshot.Completed {
-		apply(&snapshot.Completed[i].Issue)
-	}
-}
-
-func kanbanIssueStateIndex(snapshot telemetry.Snapshot) map[string]string {
-	states := map[string]string{}
-	addIssue := func(issue telemetry.Issue, state string) {
-		state = strings.TrimSpace(state)
-		if state == "" {
-			state = strings.TrimSpace(issue.State)
-		}
-		if state == "" {
-			return
-		}
-		for _, key := range kanbanIssueStateKeys(issue.ID, issue.Identifier) {
-			states[key] = state
-		}
-	}
-	for _, row := range snapshot.Completed {
-		addIssue(row.Issue, row.State)
-	}
-	for _, issue := range snapshotKanbanIssues(snapshot) {
-		addIssue(issue, issue.State)
-	}
-	return states
-}
-
-func kanbanBlockedRefsWithCurrentStates(refs []telemetry.BlockedRef, states map[string]string) []telemetry.BlockedRef {
-	if len(refs) == 0 {
-		return refs
-	}
-	out := append([]telemetry.BlockedRef(nil), refs...)
-	for i := range out {
-		for _, key := range kanbanIssueStateKeys(out[i].ID, out[i].Identifier) {
-			if state := strings.TrimSpace(states[key]); state != "" {
-				out[i].State = state
-				break
-			}
-		}
-	}
-	return out
-}
-
-func kanbanIssueStateKeys(id string, identifier string) []string {
-	keys := []string{}
-	if id = strings.TrimSpace(id); id != "" {
-		keys = append(keys, "id:"+id)
-	}
-	if identifier = strings.ToLower(strings.TrimSpace(identifier)); identifier != "" {
-		keys = append(keys, "identifier:"+identifier)
-	}
-	return keys
 }
 
 func (s *Server) apiKanbanCommentDialog(c echo.Context) error {
@@ -1016,7 +453,7 @@ func (s *Server) apiKanbanComment(c echo.Context) error {
 		return s.kanbanCommentValidationResponse(c, http.StatusNotFound, "Comment target is not available on the current board.")
 	}
 
-	err := s.kanbanMutations.withLock(target.key, func() error {
+	err := s.kanbanMutations.WithLock(target.key, func() error {
 		switch req.target {
 		case "issue":
 			return target.connector.CreateComment(c.Request().Context(), req.issueID, req.body)
@@ -1062,7 +499,7 @@ func (s *Server) apiKanbanCommentEdit(c echo.Context) error {
 		return kanbanFeedback(c, http.StatusForbidden, "Only local Detent comments can be edited.")
 	}
 
-	err := s.kanbanMutations.withLock(target.key, func() error {
+	err := s.kanbanMutations.WithLock(target.key, func() error {
 		editor, ok := target.connector.(connector.IssueCommentUpdater)
 		if !ok {
 			return connector.ErrNotImplemented
@@ -1094,7 +531,7 @@ func (s *Server) apiKanbanCommentDelete(c echo.Context) error {
 		return kanbanFeedback(c, http.StatusForbidden, "Only local Detent comments can be deleted.")
 	}
 
-	err := s.kanbanMutations.withLock(target.key, func() error {
+	err := s.kanbanMutations.WithLock(target.key, func() error {
 		deleter, ok := target.connector.(connector.IssueCommentDeleter)
 		if !ok {
 			return connector.ErrNotImplemented
@@ -1259,7 +696,7 @@ func (s *Server) kanbanMoveDialogData(c echo.Context, message string) (templates
 	}
 	data.States = target.workflow.KanbanAllowedTransitionTargets(data.CurrentState)
 	if len(data.States) == 0 && data.CurrentState == "" {
-		data.States = kanbanStateNames(target.workflow, s.latestSnapshot(c.Request().Context()))
+		data.States = kanbanstate.StateNames(target.workflow, s.latestSnapshot(c.Request().Context()))
 	}
 	if data.TargetState == "" {
 		data.TargetState = kanbanMoveDialogDefaultTarget(data.CurrentState, data.States)
@@ -1275,7 +712,7 @@ func kanbanMoveDialogDefaultTarget(source string, allowedTargets []string) strin
 	if preferred != "" {
 		for _, target := range allowedTargets {
 			target = strings.TrimSpace(target)
-			if normalizeKanbanState(target) == normalizeKanbanState(preferred) {
+			if kanbanstate.NormalizeState(target) == kanbanstate.NormalizeState(preferred) {
 				return target
 			}
 		}
@@ -1289,7 +726,7 @@ func kanbanMoveDialogDefaultTarget(source string, allowedTargets []string) strin
 }
 
 func kanbanMoveDialogPreferredTarget(source string) string {
-	switch normalizeKanbanState(source) {
+	switch kanbanstate.NormalizeState(source) {
 	case "backlog", "blocked":
 		return "Todo"
 	case "todo", "rework":
@@ -1623,7 +1060,7 @@ func (s *Server) dashboardKanbanData(ctx context.Context, projectID string, snap
 	if strings.TrimSpace(projectID) == "" {
 		mode = workflowconfig.KanbanModeReadOnly
 	}
-	states := kanbanStateNames(target.workflow, snapshot)
+	states := kanbanstate.StateNames(target.workflow, snapshot)
 	canMove, canRemove := kanbanCardCapabilities(target)
 	data := templates.KanbanData{
 		Mode:                        mode,
@@ -1631,7 +1068,7 @@ func (s *Server) dashboardKanbanData(ctx context.Context, projectID string, snap
 		States:                      states,
 		TerminalStates:              target.workflow.Tracker.TerminalStates,
 		TerminalStatesByProject:     s.kanbanTerminalStatesByProject(projectID),
-		AllowedTransitions:          kanbanAllowedTransitions(target.workflow, states),
+		AllowedTransitions:          kanbanstate.AllowedTransitions(target.workflow, states),
 		ShowBlockedAlerts:           target.kanban.ShowBlockedAlerts,
 		SupportsPullRequestComments: kanbanSupportsPullRequestComments(target.connector),
 		CanMoveCards:                canMove,
@@ -1664,14 +1101,14 @@ func (s *Server) kanbanProjectsData(snapshot telemetry.Snapshot) map[string]temp
 		if target.connector == nil {
 			continue
 		}
-		states := kanbanStateNames(target.workflow, snapshot)
+		states := kanbanstate.StateNames(target.workflow, snapshot)
 		canMove, canRemove := kanbanCardCapabilities(target)
 		out[projectID] = templates.KanbanProjectData{
 			Mode:                        target.kanban.Mode,
 			ProjectID:                   projectID,
 			States:                      states,
 			TerminalStates:              target.workflow.Tracker.TerminalStates,
-			AllowedTransitions:          kanbanAllowedTransitions(target.workflow, states),
+			AllowedTransitions:          kanbanstate.AllowedTransitions(target.workflow, states),
 			SupportsPullRequestComments: kanbanSupportsPullRequestComments(target.connector),
 			CanMoveCards:                canMove,
 			CanRemoveCards:              canRemove,
@@ -1783,43 +1220,20 @@ func (s *Server) kanbanCardFresh(lockKey string, projectID string, issueID strin
 	if !ok {
 		return false, "", "", telemetry.Issue{}, 0
 	}
-	dataSeq := snapshotProjectDataSeq(snapshot, projectID)
-	entry, ok := kanbanCardFreshEntry(snapshot, projectID, issueID)
+	dataSeq := kanbanstate.SnapshotProjectDataSeq(snapshot, projectID)
+	entry, ok := kanbanstate.CardFreshEntry(snapshot, projectID, issueID)
 	if !ok {
 		return false, "", "", telemetry.Issue{}, dataSeq
 	}
-	snapshotState := strings.TrimSpace(entry.state)
+	snapshotState := strings.TrimSpace(entry.State)
 	state := snapshotState
 	if s.kanbanMutations != nil {
-		state = s.kanbanMutations.cardState(lockKey, issueID, snapshotState, dataSeq)
+		state = s.kanbanMutations.CardState(lockKey, issueID, snapshotState, dataSeq)
 	}
-	if currentState == "" || normalizeKanbanState(state) == normalizeKanbanState(currentState) {
-		return true, state, snapshotState, entry.issue, dataSeq
+	if currentState == "" || kanbanstate.NormalizeState(state) == kanbanstate.NormalizeState(currentState) {
+		return true, state, snapshotState, entry.Issue, dataSeq
 	}
-	return false, state, snapshotState, entry.issue, dataSeq
-}
-
-func kanbanCardFreshEntry(snapshot telemetry.Snapshot, projectID string, issueID string) (kanbanSnapshotIssueEntry, bool) {
-	var selected kanbanSnapshotIssueEntry
-	for _, entry := range visibleSnapshotKanbanIssueEntries(snapshot) {
-		if !sameKanbanIssue(entry.issue, projectID, issueID, snapshot.Project.ID) {
-			continue
-		}
-		if selected.issue.ID != "" && entry.rank < selected.rank {
-			continue
-		}
-		selected = entry
-	}
-	return selected, selected.issue.ID != ""
-}
-
-func snapshotProjectDataSeq(snapshot telemetry.Snapshot, projectID string) uint64 {
-	for _, project := range snapshot.Projects {
-		if project.Project.ID == projectID {
-			return project.Refresh.DataSeq
-		}
-	}
-	return snapshot.Refresh.DataSeq
+	return false, state, snapshotState, entry.Issue, dataSeq
 }
 
 func (s *Server) recordKanbanLaneTransition(
@@ -1835,7 +1249,7 @@ func (s *Server) recordKanbanLaneTransition(
 	}
 	currentState = strings.TrimSpace(currentState)
 	targetState = strings.TrimSpace(targetState)
-	if targetState == "" || normalizeKanbanState(currentState) == normalizeKanbanState(targetState) {
+	if targetState == "" || kanbanstate.NormalizeState(currentState) == kanbanstate.NormalizeState(targetState) {
 		return
 	}
 	now := time.Now()
@@ -1912,8 +1326,8 @@ func (s *Server) kanbanCommentTargetKnown(req kanbanCommentRequest) bool {
 	if !ok {
 		return false
 	}
-	for _, issue := range snapshotKanbanIssues(snapshot) {
-		if !sameKanbanProject(issue, req.projectID, snapshot.Project.ID) {
+	for _, issue := range kanbanstate.SnapshotIssues(snapshot) {
+		if !kanbanstate.SameProject(issue, req.projectID, snapshot.Project.ID) {
 			continue
 		}
 		switch req.target {
@@ -1938,8 +1352,8 @@ func (s *Server) kanbanCommentCanMutate(req kanbanCommentMutationRequest, edit b
 	if !ok {
 		return false
 	}
-	for _, issue := range snapshotKanbanIssues(snapshot) {
-		if !sameKanbanIssue(issue, req.projectID, req.issueID, snapshot.Project.ID) {
+	for _, issue := range kanbanstate.SnapshotIssues(snapshot) {
+		if !kanbanstate.SameIssue(issue, req.projectID, req.issueID, snapshot.Project.ID) {
 			continue
 		}
 		for _, comment := range issue.Comments {
@@ -2004,8 +1418,8 @@ func telemetryIssueComments(comments []connector.IssueComment) []telemetry.Issue
 			URL:               comment.URL,
 			AuthorLogin:       comment.AuthorLogin,
 			AuthorDisplayName: comment.AuthorDisplayName,
-			CreatedAt:         cloneKanbanTimePointer(comment.CreatedAt),
-			UpdatedAt:         cloneKanbanTimePointer(comment.UpdatedAt),
+			CreatedAt:         kanbanstate.CloneTimePointer(comment.CreatedAt),
+			UpdatedAt:         kanbanstate.CloneTimePointer(comment.UpdatedAt),
 			Local:             comment.Local,
 			CanEdit:           comment.CanEdit,
 			CanDelete:         comment.CanDelete,
@@ -2035,209 +1449,13 @@ func kanbanFeedback(c echo.Context, status int, message string) error {
 	return c.JSON(status, map[string]any{"ok": true, "message": message})
 }
 
-func kanbanStateAllowed(cfg workflowconfig.Config, state string) bool {
-	state = strings.TrimSpace(state)
-	if state == "" {
-		return false
-	}
-	states := kanbanStateNames(cfg, telemetry.Snapshot{})
-	if len(states) == 0 {
-		return true
-	}
-	for _, configured := range states {
-		if normalizeKanbanState(configured) == normalizeKanbanState(state) {
-			return true
-		}
-	}
-	return false
-}
-
-func kanbanStateNames(cfg workflowconfig.Config, snapshot telemetry.Snapshot) []string {
-	states := make([]string, 0, len(cfg.Tracker.ActiveStates)+len(cfg.Tracker.ObservedStates)+len(cfg.Tracker.TerminalStates))
-	seen := map[string]struct{}{}
-	add := func(values ...string) {
-		for _, value := range values {
-			value = strings.TrimSpace(value)
-			if value == "" {
-				continue
-			}
-			key := normalizeKanbanState(value)
-			if _, ok := seen[key]; ok {
-				continue
-			}
-			seen[key] = struct{}{}
-			states = append(states, value)
-		}
-	}
-	add(cfg.KanbanStateNames()...)
-	for _, issue := range snapshotKanbanIssues(snapshot) {
-		if kanbanRawGitHubIssueState(issue.State) {
-			if _, ok := seen[normalizeKanbanState(issue.State)]; !ok {
-				continue
-			}
-		}
-		add(issue.State)
-	}
-	return states
-}
-
-func kanbanRawGitHubIssueState(state string) bool {
-	switch strings.ToLower(strings.TrimSpace(state)) {
-	case "open", "closed":
-		return true
-	default:
-		return false
-	}
-}
-
-func kanbanAllowedTransitions(cfg workflowconfig.Config, states []string) map[string][]string {
-	out := make(map[string][]string, len(states))
-	for _, state := range states {
-		state = strings.TrimSpace(state)
-		if state == "" {
-			continue
-		}
-		out[state] = cfg.KanbanAllowedTransitionTargets(state)
-	}
-	return out
-}
-
-func snapshotKanbanIssues(snapshot telemetry.Snapshot) []telemetry.Issue {
-	issues := make([]telemetry.Issue, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked))
-	issues = append(issues, snapshot.BoardIssues...)
-	issues = append(issues, snapshot.Pipeline...)
-	for _, row := range snapshot.Running {
-		issues = append(issues, row.Issue)
-	}
-	for _, row := range snapshot.Queue {
-		issues = append(issues, row.Issue)
-	}
-	for _, row := range snapshot.Blocked {
-		issues = append(issues, row.Issue)
-	}
-	return issues
-}
-
-func snapshotKanbanIssueEntries(snapshot telemetry.Snapshot) []kanbanSnapshotIssueEntry {
-	entries := make([]kanbanSnapshotIssueEntry, 0, len(snapshot.BoardIssues)+len(snapshot.Pipeline)+len(snapshot.Running)+len(snapshot.Queue)+len(snapshot.Blocked))
-	index := 0
-	appendIssue := func(issue telemetry.Issue, fallback string, rank int) {
-		state := strings.TrimSpace(issue.State)
-		fallback = strings.TrimSpace(fallback)
-		rawRuntimeState := false
-		if fallback != "" && kanbanRawGitHubIssueState(state) {
-			state = fallback
-			rawRuntimeState = true
-		}
-		if state == "" {
-			state = fallback
-		}
-		entries = append(entries, kanbanSnapshotIssueEntry{
-			issue:           issue,
-			state:           state,
-			rank:            rank,
-			index:           index,
-			rawRuntimeState: rawRuntimeState,
-		})
-		index++
-	}
-	for _, issue := range snapshot.BoardIssues {
-		appendIssue(issue, "", 5)
-	}
-	for _, issue := range snapshot.Pipeline {
-		appendIssue(issue, "", 10)
-	}
-	for _, row := range snapshot.Queue {
-		appendIssue(row.Issue, "Todo", 20)
-	}
-	for _, row := range snapshot.Running {
-		appendIssue(row.Issue, "In Progress", 30)
-	}
-	for _, row := range snapshot.Blocked {
-		appendIssue(row.Issue, "Blocked", 40)
-	}
-	return entries
-}
-
-func visibleSnapshotKanbanIssueEntries(snapshot telemetry.Snapshot) []kanbanSnapshotIssueEntry {
-	entries := snapshotKanbanIssueEntries(snapshot)
-	byKey := make(map[string]kanbanSnapshotIssueEntry, len(entries))
-	for _, entry := range entries {
-		key := snapshotKanbanIssueEntryKey(entry.issue, snapshot.Project.ID)
-		if key == "" {
-			continue
-		}
-		current, ok := byKey[key]
-		if ok && entry.rawRuntimeState {
-			continue
-		}
-		if ok && entry.rank < current.rank {
-			continue
-		}
-		byKey[key] = entry
-	}
-	visible := make([]kanbanSnapshotIssueEntry, 0, len(byKey))
-	for _, entry := range byKey {
-		visible = append(visible, entry)
-	}
-	sort.SliceStable(visible, func(i, j int) bool {
-		return visible[i].index < visible[j].index
-	})
-	return visible
-}
-
-func snapshotKanbanIssueEntryKey(issue telemetry.Issue, snapshotProjectID string) string {
-	projectID := strings.TrimSpace(issue.ProjectID)
-	if projectID == "" {
-		projectID = strings.TrimSpace(snapshotProjectID)
-	}
-	prefix := ""
-	if projectID != "" {
-		prefix = "project:" + projectID + ":"
-	}
-	if issueID := strings.TrimSpace(issue.ID); issueID != "" {
-		return prefix + "id:" + issueID
-	}
-	if identifier := strings.ToLower(strings.TrimSpace(issue.Identifier)); identifier != "" {
-		return prefix + "identifier:" + identifier
-	}
-	return ""
-}
-
-func sameKanbanIssue(issue telemetry.Issue, projectID string, issueID string, snapshotProjectID string) bool {
-	if strings.TrimSpace(issue.ID) != strings.TrimSpace(issueID) {
-		return false
-	}
-	return sameKanbanProject(issue, projectID, snapshotProjectID)
-}
-
-func sameKanbanProject(issue telemetry.Issue, projectID string, snapshotProjectID string) bool {
-	projectID = strings.TrimSpace(projectID)
-	if projectID == "" {
-		return true
-	}
-	issueProjectID := strings.TrimSpace(issue.ProjectID)
-	if issueProjectID != "" {
-		return issueProjectID == projectID
-	}
-	return strings.TrimSpace(snapshotProjectID) == "" || strings.TrimSpace(snapshotProjectID) == projectID
-}
-
-func kanbanIssueRepository(identifier string) string {
-	repo, _, ok := strings.Cut(strings.TrimSpace(identifier), "#")
-	if !ok {
-		return ""
-	}
-	return strings.TrimSpace(repo)
-}
-
 func kanbanPullRequestRepository(issue telemetry.Issue) string {
 	if issue.PullRequest != nil {
 		if repository := kanbanRepositoryFromPullRequestURL(issue.PullRequest.URL); repository != "" {
 			return repository
 		}
 	}
-	return kanbanIssueRepository(issue.Identifier)
+	return kanbanstate.IssueRepository(issue.Identifier)
 }
 
 func kanbanRepositoryFromPullRequestURL(rawURL string) string {
@@ -2255,30 +1473,4 @@ func kanbanRepositoryFromPullRequestURL(rawURL string) string {
 		return ""
 	}
 	return owner + "/" + repo
-}
-
-func mappedKanbanState(cfg workflowconfig.Config, state string) string {
-	state = strings.TrimSpace(state)
-	if !cfg.Tracker.StateMap.IsMap {
-		return state
-	}
-	if mapped, ok := cfg.Tracker.StateMap.Map[state]; ok {
-		if value, ok := mapped.(string); ok && strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	normalized := normalizeKanbanState(state)
-	for detentState, mapped := range cfg.Tracker.StateMap.Map {
-		if normalizeKanbanState(detentState) != normalized {
-			continue
-		}
-		if value, ok := mapped.(string); ok && strings.TrimSpace(value) != "" {
-			return strings.TrimSpace(value)
-		}
-	}
-	return state
-}
-
-func normalizeKanbanState(value string) string {
-	return strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(value)), " "))
 }

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -3,7 +3,6 @@ package web
 import (
 	"bytes"
 	"context"
-	"slices"
 	"strings"
 	"sync"
 	"testing"
@@ -11,72 +10,10 @@ import (
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	"github.com/digitaldrywood/detent/internal/connector"
+	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/templates"
 )
-
-func TestKanbanStateNamesIgnoreCompletedSessionStates(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name string
-		cfg  workflowconfig.Config
-		want []string
-	}{
-		{
-			name: "unconfigured completed handoff ignored",
-			cfg: workflowconfig.Config{
-				Tracker: workflowconfig.Tracker{
-					ObservedStates: []string{"Backlog", "Blocked", "Human Review"},
-					ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
-					TerminalStates: []string{"Done", "Cancelled"},
-				},
-			},
-			want: []string{"Backlog", "Blocked", "Human Review", "Todo", "In Progress", "Rework", "Merging", "Done", "Cancelled", "Needs Triage"},
-		},
-		{
-			name: "configured handoff preserved",
-			cfg: workflowconfig.Config{
-				Tracker: workflowconfig.Tracker{
-					ObservedStates: []string{"Backlog", "Handoff"},
-					ActiveStates:   []string{"Todo"},
-					TerminalStates: []string{"Done"},
-				},
-			},
-			want: []string{"Backlog", "Handoff", "Todo", "Done", "Needs Triage"},
-		},
-	}
-
-	snapshot := telemetry.Snapshot{
-		BoardIssues: []telemetry.Issue{
-			{ID: "tracker-extra", State: "Needs Triage"},
-		},
-		Completed: []telemetry.Completed{
-			{
-				Issue: telemetry.Issue{
-					ID:    "completed-open-pr",
-					State: "Handoff",
-					PullRequest: &telemetry.PullRequest{
-						Number: 554,
-						State:  "OPEN",
-					},
-				},
-				FinalState: "completed",
-			},
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			got := kanbanStateNames(tt.cfg, snapshot)
-			if !slices.Equal(got, tt.want) {
-				t.Fatalf("kanbanStateNames() = %#v, want %#v", got, tt.want)
-			}
-		})
-	}
-}
 
 func TestKanbanCardCapabilitiesDeriveFromStatePath(t *testing.T) {
 	t.Parallel()
@@ -132,106 +69,11 @@ func TestKanbanCardCapabilitiesDeriveFromStatePath(t *testing.T) {
 	}
 }
 
-func TestKanbanStateNamesIgnoreRawGitHubRuntimeStates(t *testing.T) {
-	t.Parallel()
-
-	cfg := workflowconfig.Config{
-		Tracker: workflowconfig.Tracker{
-			ObservedStates: []string{"Backlog", "Human Review"},
-			ActiveStates:   []string{"Todo", "In Progress", "Merging"},
-			TerminalStates: []string{"Done"},
-		},
-	}
-	snapshot := telemetry.Snapshot{
-		BoardIssues: []telemetry.Issue{
-			{ID: "custom", State: "Needs Triage"},
-		},
-		Pipeline: []telemetry.Issue{
-			{ID: "pipeline-open", State: "Open"},
-		},
-		Running: []telemetry.Running{
-			{Issue: telemetry.Issue{ID: "running-open", State: "OPEN"}},
-		},
-		Queue: []telemetry.Queued{
-			{Issue: telemetry.Issue{ID: "queue-closed", State: "Closed"}},
-		},
-		Blocked: []telemetry.Blocked{
-			{Issue: telemetry.Issue{ID: "blocked-closed", State: "CLOSED"}},
-		},
-	}
-
-	got := kanbanStateNames(cfg, snapshot)
-	want := []string{"Backlog", "Human Review", "Todo", "In Progress", "Merging", "Done", "Needs Triage"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("kanbanStateNames() = %#v, want %#v", got, want)
-	}
-}
-
-func TestKanbanStateNamesAllowConfiguredOpenState(t *testing.T) {
-	t.Parallel()
-
-	cfg := workflowconfig.Config{
-		Tracker: workflowconfig.Tracker{
-			ObservedStates: []string{"Open"},
-			ActiveStates:   []string{"In Progress"},
-			TerminalStates: []string{"Done"},
-		},
-	}
-	snapshot := telemetry.Snapshot{
-		Running: []telemetry.Running{
-			{Issue: telemetry.Issue{ID: "running-open", State: "OPEN"}},
-		},
-	}
-
-	got := kanbanStateNames(cfg, snapshot)
-	want := []string{"Open", "In Progress", "Done"}
-	if !slices.Equal(got, want) {
-		t.Fatalf("kanbanStateNames() = %#v, want %#v", got, want)
-	}
-}
-
-func TestSnapshotProjectDataSeq(t *testing.T) {
-	t.Parallel()
-
-	snapshot := telemetry.Snapshot{
-		Refresh: telemetry.Refresh{DataSeq: 3},
-		Projects: []telemetry.ProjectSnapshot{
-			{
-				Project: telemetry.Project{ID: "alpha"},
-				Refresh: telemetry.Refresh{DataSeq: 7},
-			},
-			{
-				Project: telemetry.Project{ID: "bravo"},
-				Refresh: telemetry.Refresh{DataSeq: 9},
-			},
-		},
-	}
-
-	tests := []struct {
-		name      string
-		projectID string
-		want      uint64
-	}{
-		{name: "project match", projectID: "bravo", want: 9},
-		{name: "fallback", projectID: "charlie", want: 3},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			if got := snapshotProjectDataSeq(snapshot, tt.projectID); got != tt.want {
-				t.Fatalf("snapshotProjectDataSeq() = %d, want %d", got, tt.want)
-			}
-		})
-	}
-}
-
 func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{kanbanMutations: newKanbanMutationLocks()}
-	server.kanbanMutations.noteCardState("project:detent", "detent", telemetry.Issue{
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
+	server.kanbanMutations.NoteCardState("project:detent", "detent", telemetry.Issue{
 		ID:         "blocker",
 		Identifier: "digitaldrywood/detent#429",
 		ProjectID:  "detent",
@@ -276,7 +118,7 @@ func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefs(t *testing.T) {
 func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefsFromCompletedRows(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
 	completedAt := time.Date(2026, 7, 7, 0, 37, 10, 0, time.UTC)
 	snapshot := telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
@@ -331,7 +173,7 @@ func TestKanbanSnapshotWithPendingStatesUpdatesBlockedRefsFromCompletedRows(t *t
 func TestKanbanSnapshotWithPendingStatesPrefersCompletedRowTrackerState(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
 	snapshot := telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
 		BoardIssues: []telemetry.Issue{
@@ -367,7 +209,7 @@ func TestKanbanSnapshotWithPendingStatesPrefersCompletedRowTrackerState(t *testi
 func TestKanbanSnapshotWithPendingStatesIgnoresCompletedHistoryForMissingPendingMove(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
 	pendingIssue := telemetry.Issue{
 		ID:         "history-card",
 		Identifier: "digitaldrywood/detent#432",
@@ -375,7 +217,7 @@ func TestKanbanSnapshotWithPendingStatesIgnoresCompletedHistoryForMissingPending
 		Title:      "Completed history pending card",
 		State:      "Backlog",
 	}
-	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", 1)
+	server.kanbanMutations.NoteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", 1)
 
 	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
@@ -400,7 +242,7 @@ func TestKanbanSnapshotWithPendingStatesIgnoresCompletedHistoryForMissingPending
 func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
 	pendingIssue := telemetry.Issue{
 		ID:         "completed-card",
 		Identifier: "digitaldrywood/detent#431",
@@ -408,7 +250,7 @@ func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T)
 		Title:      "Completed pending card",
 		State:      "Backlog",
 	}
-	server.kanbanMutations.noteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", 1)
+	server.kanbanMutations.NoteCardState("project:detent", "detent", pendingIssue, "Backlog", "Todo", 1)
 
 	got := server.kanbanSnapshotWithPendingStates("project:detent", "detent", telemetry.Snapshot{
 		Project: telemetry.Project{ID: "detent"},
@@ -436,90 +278,10 @@ func TestKanbanSnapshotWithPendingStatesClearsCompletedPendingMove(t *testing.T)
 	}
 }
 
-func TestKanbanMutationLocksCardStateByDataSeq(t *testing.T) {
-	t.Parallel()
-
-	type observation struct {
-		snapshotState string
-		dataSeq       uint64
-		want          string
-	}
-	tests := []struct {
-		name         string
-		observations []observation
-		wantPending  bool
-		wantFeedback string
-	}{
-		{
-			name: "same-seq republish holds optimistic state",
-			observations: []observation{
-				{snapshotState: "Backlog", dataSeq: 7, want: "Todo"},
-				{snapshotState: "Blocked", dataSeq: 7, want: "Todo"},
-			},
-			wantPending: true,
-		},
-		{
-			name: "newer-seq match confirms and drops entry",
-			observations: []observation{
-				{snapshotState: "Todo", dataSeq: 8, want: "Todo"},
-				{snapshotState: "Backlog", dataSeq: 9, want: "Backlog"},
-			},
-		},
-		{
-			name: "contradicting polls revert at limit with notice",
-			observations: []observation{
-				{snapshotState: "Backlog", dataSeq: 8, want: "Todo"},
-				{snapshotState: "Backlog", dataSeq: 9, want: "Backlog"},
-			},
-			wantFeedback: "Move of DDW-433 to Todo was not confirmed by the tracker; reverted to Backlog.",
-		},
-		{
-			name: "third state reverts immediately with notice",
-			observations: []observation{
-				{snapshotState: "Blocked", dataSeq: 8, want: "Blocked"},
-			},
-			wantFeedback: "Move of DDW-433 to Todo was not confirmed by the tracker; reverted to Blocked.",
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			locks := newKanbanMutationLocks()
-			issue := telemetry.Issue{
-				ID:         "confirmed-card",
-				Identifier: "DDW-433",
-				ProjectID:  "detent",
-				Title:      "Confirmed pending card",
-				State:      "Backlog",
-			}
-			locks.noteCardState("project:detent", "detent", issue, "Backlog", "Todo", 7)
-
-			for _, observation := range tt.observations {
-				got := locks.cardState("project:detent", issue.ID, observation.snapshotState, observation.dataSeq)
-				if got != observation.want {
-					t.Fatalf("cardState(%q, %d) = %q, want %q", observation.snapshotState, observation.dataSeq, got, observation.want)
-				}
-			}
-			if got := kanbanPendingStateExists(locks, "project:detent", issue.ID); got != tt.wantPending {
-				t.Fatalf("pending state exists = %t, want %t", got, tt.wantPending)
-			}
-			feedback := kanbanRevertFeedback(locks.consumeRevertNotices("project:detent", "detent"))
-			if feedback != tt.wantFeedback {
-				t.Fatalf("revert feedback = %q, want %q", feedback, tt.wantFeedback)
-			}
-			if got := locks.consumeRevertNotices("project:detent", "detent"); len(got) != 0 {
-				t.Fatalf("second consumeRevertNotices() = %#v, want drained", got)
-			}
-		})
-	}
-}
-
 func TestKanbanSnapshotWithPendingStatesUsesProjectDataSeq(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
 	issue := telemetry.Issue{
 		ID:         "alpha-card",
 		Identifier: "DDW-434",
@@ -527,7 +289,7 @@ func TestKanbanSnapshotWithPendingStatesUsesProjectDataSeq(t *testing.T) {
 		Title:      "Alpha pending card",
 		State:      "Backlog",
 	}
-	server.kanbanMutations.noteCardState("project:alpha", "alpha", issue, "Backlog", "Todo", 5)
+	server.kanbanMutations.NoteCardState("project:alpha", "alpha", issue, "Backlog", "Todo", 5)
 	snapshot := telemetry.Snapshot{
 		Refresh: telemetry.Refresh{DataSeq: 99},
 		Projects: []telemetry.ProjectSnapshot{
@@ -543,7 +305,7 @@ func TestKanbanSnapshotWithPendingStatesUsesProjectDataSeq(t *testing.T) {
 			t.Fatalf("alpha card state = %q, want Todo", got.BoardIssues[0].State)
 		}
 	}
-	if feedback := kanbanRevertFeedback(server.kanbanMutations.consumeRevertNotices("project:alpha", "alpha")); feedback != "" {
+	if feedback := kanbanRevertFeedback(server.kanbanMutations.ConsumeRevertNotices("project:alpha", "alpha")); feedback != "" {
 		t.Fatalf("revert feedback = %q, want none", feedback)
 	}
 }
@@ -552,7 +314,7 @@ func TestKanbanSnapshotWithPendingStatesRevertFeedback(t *testing.T) {
 	t.Parallel()
 
 	server := &Server{
-		kanbanMutations: newKanbanMutationLocks(),
+		kanbanMutations: kanbanstate.NewMutationTracker(),
 		kanbanRefreshes: newKanbanRefreshFeedbackTracker(),
 	}
 	issue := telemetry.Issue{
@@ -562,7 +324,7 @@ func TestKanbanSnapshotWithPendingStatesRevertFeedback(t *testing.T) {
 		Title:      "Rejected pending card",
 		State:      "Backlog",
 	}
-	server.kanbanMutations.noteCardState("project:detent", "detent", issue, "Backlog", "Done", 1)
+	server.kanbanMutations.NoteCardState("project:detent", "detent", issue, "Backlog", "Done", 1)
 	snapshot := telemetry.Snapshot{
 		Project:     telemetry.Project{ID: "detent"},
 		Refresh:     telemetry.Refresh{DataSeq: 2},
@@ -597,53 +359,10 @@ func TestKanbanSnapshotWithPendingStatesRevertFeedback(t *testing.T) {
 	}
 }
 
-func TestKanbanPendingRemovalByDataSeq(t *testing.T) {
-	t.Parallel()
-
-	tests := []struct {
-		name          string
-		snapshotState string
-		dataSeq       uint64
-		expired       bool
-		want          bool
-	}{
-		{name: "same seq hides recorded state", snapshotState: "Backlog", dataSeq: 5, want: true},
-		{name: "same seq hides changed state", snapshotState: "Done", dataSeq: 5, want: true},
-		{name: "newer seq hides recorded state", snapshotState: "Backlog", dataSeq: 6, want: true},
-		{name: "newer seq releases changed state", snapshotState: "Done", dataSeq: 6},
-		{name: "ttl expires as backstop", snapshotState: "Backlog", dataSeq: 5, expired: true},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			t.Parallel()
-
-			locks := newKanbanMutationLocks()
-			locks.noteCardRemoved("project:detent", "removed-card", "Backlog", 5)
-			if tt.expired {
-				stateKey := kanbanMutationStateKey("project:detent", "removed-card")
-				locks.mu.Lock()
-				removed := locks.removed[stateKey]
-				removed.removedAt = time.Now().Add(-kanbanRemovalPendingTTL - time.Minute)
-				locks.removed[stateKey] = removed
-				locks.mu.Unlock()
-			}
-
-			got := locks.cardRemoved("project:detent", "removed-card", tt.snapshotState, tt.dataSeq)
-			if got != tt.want {
-				t.Fatalf("cardRemoved(%q, %d) = %t, want %t", tt.snapshotState, tt.dataSeq, got, tt.want)
-			}
-			if !tt.want && kanbanPendingRemovalExists(locks, "project:detent", "removed-card") {
-				t.Fatalf("pending removal still exists after release")
-			}
-		})
-	}
-}
-
 func TestKanbanSnapshotWithPendingStatesConcurrentRenderMove(t *testing.T) {
 	t.Parallel()
 
-	server := &Server{kanbanMutations: newKanbanMutationLocks()}
+	server := &Server{kanbanMutations: kanbanstate.NewMutationTracker()}
 	issue := telemetry.Issue{
 		ID:         "race-card",
 		Identifier: "DDW-436",
@@ -681,7 +400,7 @@ func TestKanbanSnapshotWithPendingStatesConcurrentRenderMove(t *testing.T) {
 		defer wg.Done()
 		<-start
 		for range 100 {
-			server.kanbanMutations.noteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
+			server.kanbanMutations.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 1)
 		}
 	}()
 	close(start)
@@ -690,22 +409,6 @@ func TestKanbanSnapshotWithPendingStatesConcurrentRenderMove(t *testing.T) {
 	for err := range errs {
 		t.Fatal(err)
 	}
-}
-
-func kanbanPendingStateExists(locks *kanbanMutationLocks, key string, issueID string) bool {
-	stateKey := kanbanMutationStateKey(key, issueID)
-	locks.mu.Lock()
-	defer locks.mu.Unlock()
-	_, ok := locks.states[stateKey]
-	return ok
-}
-
-func kanbanPendingRemovalExists(locks *kanbanMutationLocks, key string, issueID string) bool {
-	stateKey := kanbanMutationStateKey(key, issueID)
-	locks.mu.Lock()
-	defer locks.mu.Unlock()
-	_, ok := locks.removed[stateKey]
-	return ok
 }
 
 func TestKanbanRefreshFeedbackTransitionsOnce(t *testing.T) {

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -22,6 +22,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/hub"
+	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
@@ -122,7 +123,7 @@ type Server struct {
 	assets              staticAssets
 	projects            *projectSmallMultipleRecorder
 	snapshots           *snapshotEnrichmentCache
-	kanbanMutations     *kanbanMutationLocks
+	kanbanMutations     *kanbanstate.MutationTracker
 	kanbanRefreshes     *kanbanRefreshFeedbackTracker
 	kanbanRetryInFlight atomic.Bool
 	refreshes           *manualRefreshTracker
@@ -197,7 +198,7 @@ func NewServer(cfg Config, deps Dependencies) (*Server, error) {
 		assets:              newStaticAssets(cfg.staticDir()),
 		projects:            newProjectSmallMultipleRecorder(),
 		snapshots:           newSnapshotEnrichmentCache(),
-		kanbanMutations:     newKanbanMutationLocks(),
+		kanbanMutations:     kanbanstate.NewMutationTracker(),
 		kanbanRefreshes:     newKanbanRefreshFeedbackTracker(),
 		refreshes:           newManualRefreshTracker(),
 		demo:                newDemoScenarioSet(cfg.Demo),
@@ -662,29 +663,29 @@ func (s *Server) withKanbanRevertFeedback(data templates.DashboardData) template
 	return data
 }
 
-func (s *Server) kanbanRevertNotices(data templates.DashboardData) []kanbanRevertNotice {
+func (s *Server) kanbanRevertNotices(data templates.DashboardData) []kanbanstate.RevertNotice {
 	if s == nil || s.kanbanMutations == nil {
 		return nil
 	}
 	projectID := strings.TrimSpace(data.ProjectID)
 	if projectID != "" {
-		return s.kanbanMutations.consumeRevertNotices("project:"+projectID, projectID)
+		return s.kanbanMutations.ConsumeRevertNotices("project:"+projectID, projectID)
 	}
-	return s.kanbanMutations.consumeRevertNotices("", "")
+	return s.kanbanMutations.ConsumeRevertNotices("", "")
 }
 
-func kanbanRevertFeedback(notices []kanbanRevertNotice) string {
+func kanbanRevertFeedback(notices []kanbanstate.RevertNotice) string {
 	messages := make([]string, 0, len(notices))
 	for _, notice := range notices {
-		identifier := strings.TrimSpace(notice.identifier)
+		identifier := strings.TrimSpace(notice.Identifier)
 		if identifier == "" {
 			identifier = "card"
 		}
-		from := strings.TrimSpace(notice.from)
+		from := strings.TrimSpace(notice.From)
 		if from == "" {
 			from = "the requested state"
 		}
-		to := strings.TrimSpace(notice.to)
+		to := strings.TrimSpace(notice.To)
 		if to == "" {
 			to = "the tracker state"
 		}

--- a/internal/web/sse_test.go
+++ b/internal/web/sse_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/a-h/templ"
 
+	kanbanstate "github.com/digitaldrywood/detent/internal/kanban"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 	"github.com/digitaldrywood/detent/internal/web/templates"
 )
@@ -400,7 +401,7 @@ func newTestSSEStream(now *time.Time) *sseStream {
 
 func newSSESnapshotTestServer() *Server {
 	return &Server{
-		kanbanMutations: newKanbanMutationLocks(),
+		kanbanMutations: kanbanstate.NewMutationTracker(),
 		kanbanRefreshes: newKanbanRefreshFeedbackTracker(),
 	}
 }


### PR DESCRIPTION
## Summary

- Add `internal/kanban` with `MutationTracker` and pure snapshot/state helpers extracted from `internal/web/kanban.go`.
- Rewire web kanban handlers, demo mutations, SSE tests, and server feedback plumbing to use the new package.
- Move and expand pure kanban tests into `internal/kanban`, including tracker resolution, pending moves, removal lifecycle, transition policy, and clone isolation.

Fixes #1032

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/kanban ./internal/web`
- [x] `go test -coverprofile=tmp/kanban.cover ./internal/kanban` (84.2% coverage)
- [x] `make check`
