### PR TITLE
fix(gate): ignore resolved workpad blockers

### DIFF
--- a/internal/cli/doctor_autopromote.go
+++ b/internal/cli/doctor_autopromote.go
@@ -29,6 +29,7 @@ type doctorAutoPromoteCandidateDiagnostic struct {
 	LatestCodexReviewCommitSHA   string     `json:"latest_codex_review_commit_sha,omitempty"`
 	LatestCodexReviewSubmittedAt *time.Time `json:"latest_codex_review_submitted_at,omitempty"`
 	QuietRemainingSeconds        int64      `json:"quiet_remaining_seconds,omitempty"`
+	WorkpadBlocker               string     `json:"workpad_blocker,omitempty"`
 	Reason                       string     `json:"reason"`
 }
 
@@ -385,6 +386,7 @@ func doctorAutoPromoteConfig(cfg workflowconfig.Config) orchestrator.AutoPromote
 		PassState:          cfg.Agent.AutoPromote.PassState,
 		ReworkState:        cfg.Agent.AutoPromote.ReworkState,
 		ReworkLimit:        cfg.Agent.AutoPromote.ReworkLimit,
+		TerminalStates:     append([]string(nil), cfg.Tracker.TerminalStates...),
 		Gate:               cfg.Gate,
 	}
 }
@@ -402,6 +404,7 @@ func doctorAutoPromoteCandidateDiagnosticFromIssue(
 	if decision.QuietRemaining > 0 {
 		diagnostic.QuietRemainingSeconds = int64(decision.QuietRemaining.Truncate(time.Second) / time.Second)
 	}
+	diagnostic.WorkpadBlocker = strings.TrimSpace(decision.WorkpadBlocker)
 	if prNumber, ok := doctorLinkedPullRequestNumber(issue); ok {
 		diagnostic.PRNumber = prNumber
 	}
@@ -504,6 +507,9 @@ func doctorAutoPromoteCandidateSummary(candidate doctorAutoPromoteCandidateDiagn
 	}
 	if candidate.QuietRemainingSeconds > 0 {
 		parts = append(parts, "quiet_remaining="+(time.Duration(candidate.QuietRemainingSeconds)*time.Second).String())
+	}
+	if candidate.WorkpadBlocker != "" {
+		parts = append(parts, "workpad_blocker="+candidate.WorkpadBlocker)
 	}
 	parts = append(parts, "reason="+candidate.Reason)
 	return strings.Join(parts, " ")

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -740,6 +740,33 @@ func TestCheckDoctorAutoPromoteCandidateDiagnostics(t *testing.T) {
 				Reason:           "merge_conflicts",
 			},
 		},
+		{
+			name: "clean green workpad blocker",
+			issue: func() connector.Issue {
+				issue := doctorAutoPromoteIssue("issue-workpad-blocker", &connector.PullRequest{
+					Number:         1480,
+					URL:            "https://github.test/pull/1480",
+					State:          "OPEN",
+					HeadSHA:        "head-workpad",
+					MergeableState: "clean",
+					CIStatus:       "success",
+				})
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Blockers\n- Owner approval is still required.",
+				}}
+				return issue
+			}(),
+			want: doctorAutoPromoteCandidateDiagnostic{
+				IssueID:          "issue-workpad-blocker",
+				IssueIdentifier:  "digitaldrywood/detent#399",
+				PRNumber:         1480,
+				PRURL:            "https://github.test/pull/1480",
+				PRHeadSHA:        "head-workpad",
+				PRMergeableState: "clean",
+				Reason:           "workpad_blocker",
+				WorkpadBlocker:   "Owner approval is still required.",
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -764,6 +791,9 @@ func TestCheckDoctorAutoPromoteCandidateDiagnostics(t *testing.T) {
 				if !strings.Contains(got.Detail, want) {
 					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
 				}
+			}
+			if tt.want.WorkpadBlocker != "" && !strings.Contains(got.Detail, tt.want.WorkpadBlocker) {
+				t.Fatalf("Detail = %q, want containing WorkpadBlocker %q", got.Detail, tt.want.WorkpadBlocker)
 			}
 		})
 	}

--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -2374,20 +2374,12 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadBlockedByRefs(t *testing.T) 
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/issues/416/comments?per_page=100",
-			body:   `[{"body":"## Codex Workpad\n\n### Blockers\n- Blocked by: #415\n- Waiting for digitaldrywood/agent-runtime#25\n- Human action needed: merge #415, then move #416 back to Todo.\n\n### Validation\n- Pending."}]`,
+			body:   `[{"body":"## Codex Workpad\n\n### Blockers\n- Blocked by: #415\n- Human action needed: merge #415, then move #416 back to Todo.\n\n### Validation\n- Pending."}]`,
 		},
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent/issues/415",
 			body:   `{"node_id":"I_kw415","number":415,"title":"Closed dependency","body":"","state":"CLOSED","html_url":"https://github.com/digitaldrywood/detent/issues/415","labels":[]}`,
-		},
-		{
-			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
-		},
-		{
-			method: http.MethodGet,
-			path:   "/repos/digitaldrywood/agent-runtime/issues/25",
-			body:   `{"node_id":"I_runtime25","number":25,"title":"Open dependency","body":"","state":"OPEN","html_url":"https://github.com/digitaldrywood/agent-runtime/issues/25","labels":[]}`,
 		},
 		{
 			body: `{"data":{"node":{"projectItems":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
@@ -2406,10 +2398,25 @@ func TestConnectorFetchIssuesByStatesExtractsWorkpadBlockedByRefs(t *testing.T) 
 
 	want := []connector.BlockedRef{
 		{ID: "I_kw415", Identifier: "digitaldrywood/detent#415", State: "Done"},
-		{ID: "I_runtime25", Identifier: "digitaldrywood/agent-runtime#25", State: "Open"},
 	}
 	if !reflect.DeepEqual(got[0].BlockedBy, want) {
 		t.Fatalf("BlockedBy = %#v, want %#v", got[0].BlockedBy, want)
+	}
+}
+
+func TestParseBlockedByFromIssueTextIgnoresRemovedWorkpadBlockedByProse(t *testing.T) {
+	t.Parallel()
+
+	issue := githubIssueNode{
+		Number:     1476,
+		Repository: repository{NameWithOwner: "digitaldrywood/pyroapex"},
+		Comments: nodeConnection[issueComment]{Nodes: []issueComment{{
+			Body: "## Codex Workpad\n\n### Blockers\n- Dependency blocker #1462 merged via PR #1482 and issue #1462 is closed/Done; #1463 was already closed. Removed the stale `Blocked by: #1462` line from #1476.\n\n### Validation\n- make check passed.",
+		}}},
+	}
+
+	if got := parseBlockedByFromIssueText(issue, "digitaldrywood/pyroapex"); len(got) != 0 {
+		t.Fatalf("parseBlockedByFromIssueText() = %#v, want no active dependency refs", got)
 	}
 }
 

--- a/internal/connector/github/issue_text.go
+++ b/internal/connector/github/issue_text.go
@@ -172,12 +172,6 @@ func parseBlockedByFromIssueText(issue githubIssueNode, repo string) []connector
 	appendBlockers(parseBlockedBy(issue.Body, repo))
 	for _, comment := range issue.Comments.Nodes {
 		appendBlockers(parseBlockedBy(comment.Body, repo))
-		if !strings.Contains(strings.ToLower(comment.Body), "codex workpad") {
-			continue
-		}
-		for _, identifier := range issueReferencesInText(markdownSectionText(comment.Body, "Blockers"), repo) {
-			appendBlockers([]connector.BlockedRef{{Identifier: identifier}})
-		}
 	}
 	return blockers
 }

--- a/internal/dependencyline/dependencyline.go
+++ b/internal/dependencyline/dependencyline.go
@@ -2,7 +2,7 @@ package dependencyline
 
 import "regexp"
 
-var pattern = regexp.MustCompile("(?i)^\\s*(?:>\\s*)?(?:[-*+]\\s+)?(?:[*_`~]+)?\\s*(?:blocked\\s+by|depends[\\s-]+on)(?:[*_`~]+)?\\s*(?::\\s*|\\s+)(?:[*_`~]+)?\\s*(.+)\\s*$")
+var pattern = regexp.MustCompile(`(?i)^\s*(?:[-*+]\s+)?(?:[*_~]+)?\s*(?:blocked\s+by|depends[\s-]+on)(?:[*_~]+)?\s*(?::\s*|\s+)(?:[*_~]+)?\s*(.+)\s*$`)
 
 func Match(line string) (string, bool) {
 	matches := pattern.FindStringSubmatch(line)

--- a/internal/dependencyline/dependencyline_test.go
+++ b/internal/dependencyline/dependencyline_test.go
@@ -16,6 +16,8 @@ func TestMatch(t *testing.T) {
 		{name: "depends on colon", line: "Depends on: #1443", wantText: "#1443", wantOK: true},
 		{name: "depends on colon no space", line: "Depends on:#1443", wantText: "#1443", wantOK: true},
 		{name: "depends hyphen owner repo", line: "depends-on digitaldrywood/detent#1443", wantText: "digitaldrywood/detent#1443", wantOK: true},
+		{name: "backticked declaration", line: "`Blocked by: #1447`", wantOK: false},
+		{name: "quoted declaration", line: "> Blocked by: #1447", wantOK: false},
 		{name: "mention only", line: "Mention only #1443", wantOK: false},
 	}
 

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -19,6 +19,7 @@ type AutoPromoteConfig struct {
 	PassState          string
 	ReworkState        string
 	ReworkLimit        int
+	TerminalStates     []string
 	Gate               gate.Config
 }
 
@@ -82,12 +83,13 @@ const (
 )
 
 type AutoPromoteDecision struct {
-	Action         AutoPromoteAction
-	Reason         AutoPromoteReason
-	CIStatus       string
-	QuietRemaining time.Duration
-	Findings       []AutoPromoteFinding
-	WorkpadBlocker string
+	Action                  AutoPromoteAction
+	Reason                  AutoPromoteReason
+	CIStatus                string
+	QuietRemaining          time.Duration
+	Findings                []AutoPromoteFinding
+	WorkpadBlocker          string
+	ResolvedWorkpadBlockers []string
 }
 
 func EvaluateAutoPromote(
@@ -107,9 +109,10 @@ func EvaluateAutoPromote(
 	if !autoPromoteAllowedIssueLabel(issue, cfg) {
 		return autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonLabelNotAllowed)
 	}
-	if blocker := autoPromoteWorkpadBlockerReason(issue); blocker != "" {
+	workpad := autoPromoteWorkpadBlocker(issue, cfg.TerminalStates)
+	if workpad.Reason != "" {
 		decision := autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonWorkpadBlocker)
-		decision.WorkpadBlocker = blocker
+		decision.WorkpadBlocker = workpad.Reason
 		return decision
 	}
 	if gateRequiresPullRequest(cfg.Gate) {
@@ -131,6 +134,7 @@ func EvaluateAutoPromote(
 	decision.CIStatus = gateDecision.CIStatus
 	decision.QuietRemaining = gateDecision.QuietRemaining
 	decision.Findings = autoPromoteFindingsFromGate(gateDecision.Findings)
+	decision.ResolvedWorkpadBlockers = append([]string(nil), workpad.Resolved...)
 	return decision
 }
 
@@ -180,6 +184,7 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	if cfg.ReworkLimit < 0 {
 		cfg.ReworkLimit = 0
 	}
+	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
 	cfg.Gate = gate.Effective(cfg.Gate)
 	return cfg
 }
@@ -286,6 +291,64 @@ func artifactStatusFromIssue(issue connector.Issue, statusField string) string {
 		}
 	}
 	return ""
+}
+
+type autoPromoteWorkpadBlockerCheck struct {
+	Reason   string
+	Resolved []string
+}
+
+func autoPromoteWorkpadBlocker(issue connector.Issue, terminalStates []string) autoPromoteWorkpadBlockerCheck {
+	reason := autoPromoteWorkpadBlockerReason(issue)
+	if reason == "" {
+		return autoPromoteWorkpadBlockerCheck{}
+	}
+	if resolved, ok := autoPromoteResolvedWorkpadBlockers(reason, issue, terminalStates); ok {
+		return autoPromoteWorkpadBlockerCheck{Resolved: resolved}
+	}
+	return autoPromoteWorkpadBlockerCheck{Reason: reason}
+}
+
+func autoPromoteResolvedWorkpadBlockers(reason string, issue connector.Issue, terminalStates []string) ([]string, bool) {
+	refs := dependencyRefsInText(reason, dependencyIssueRepo(issue.Identifier))
+	if len(refs) == 0 {
+		return nil, false
+	}
+
+	byIdentifier := make(map[string]connector.BlockedRef, len(issue.BlockedBy))
+	for _, ref := range issue.BlockedBy {
+		key := strings.ToLower(strings.TrimSpace(ref.Identifier))
+		if key != "" {
+			byIdentifier[key] = ref
+		}
+	}
+
+	resolved := make([]string, 0, len(refs))
+	self := strings.ToLower(strings.TrimSpace(issue.Identifier))
+	for _, ref := range refs {
+		identifier := strings.TrimSpace(ref.Identifier)
+		key := strings.ToLower(identifier)
+		if key == "" || key == self {
+			continue
+		}
+		blocker, ok := byIdentifier[key]
+		if !ok || !autoPromoteBlockedRefResolved(blocker, terminalStates) {
+			return nil, false
+		}
+		if blocker.Identifier != "" {
+			identifier = strings.TrimSpace(blocker.Identifier)
+		}
+		resolved = append(resolved, identifier)
+	}
+	if len(resolved) == 0 {
+		return nil, false
+	}
+	return resolved, true
+}
+
+func autoPromoteBlockedRefResolved(ref connector.BlockedRef, terminalStates []string) bool {
+	state := strings.TrimSpace(ref.State)
+	return state != "" && stateIn(state, terminalStates)
 }
 
 func autoPromoteWorkpadBlockerReason(issue connector.Issue) string {
@@ -452,6 +515,9 @@ func autoPromoteNumberedListMarkerEnd(line string) int {
 
 func autoPromoteWorkpadNonBlockerLine(line string) bool {
 	line = strings.ToLower(strings.TrimSpace(line))
+	if autoPromoteResolvedWorkpadLine(line) {
+		return true
+	}
 	if autoPromoteWorkpadNonBlockerSentinel(strings.Trim(line, ".:; ")) {
 		return true
 	}
@@ -461,6 +527,46 @@ func autoPromoteWorkpadNonBlockerLine(line string) bool {
 	}
 	firstClause := strings.Trim(line[:index], ".:; ")
 	return firstClause != "" && autoPromoteWorkpadNonBlockerSentinel(firstClause)
+}
+
+func autoPromoteResolvedWorkpadLine(line string) bool {
+	line = strings.ToLower(strings.Join(strings.Fields(strings.TrimSpace(line)), " "))
+	if line == "" {
+		return false
+	}
+	if strings.Contains(line, "now pass") && (strings.Contains(line, "blocker") || strings.Contains(line, "regression")) {
+		return true
+	}
+	if strings.Contains(line, "removed") && strings.Contains(line, "stale") && strings.Contains(line, "blocked by") {
+		return true
+	}
+	if strings.Contains(line, "blockers are gone") || strings.Contains(line, "blocker is gone") {
+		return true
+	}
+	hasIssueRef := strings.Contains(line, "#") || strings.Contains(line, "/issues/")
+	if !hasIssueRef {
+		return false
+	}
+	for _, phrase := range []string{
+		"closed/done",
+		"already closed",
+		"is closed",
+		"was closed",
+		"merged via",
+		"already merged",
+		"is merged",
+		"was merged",
+		"is resolved",
+		"was resolved",
+		"has been resolved",
+		"resolved by",
+		"resolved via",
+	} {
+		if strings.Contains(line, phrase) {
+			return true
+		}
+	}
+	return false
 }
 
 func autoPromoteWorkpadNonBlockerSentinel(line string) bool {

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -231,6 +231,117 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			},
 		},
 		{
+			name: "workpad removed blocked by prose promotes",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-workpad-removed-blocked-by", nil)
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Blockers\n- The previous dependency blocker regressions now pass locally on the rebased head,\n  so stale `Blocked by: #1462` / `Blocked by: #1463` lines were removed from the issue body.\n\n### Validation\n- make check passed.",
+				}}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				OptoutLabel:   "requires-human-review",
+				Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+		{
+			name: "workpad resolved dependency prose promotes",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-workpad-resolved-dependency-prose", nil)
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Blockers\n- Dependency blocker #1462 merged via PR #1482 and issue #1462 is closed/Done; #1463 was already closed. Removed the stale `Blocked by: #1462` line from #1476.\n\n### Validation\n- make check passed.",
+				}}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled:       true,
+				QuietDuration: 10 * time.Minute,
+				OptoutLabel:   "requires-human-review",
+				Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionPromote,
+				Reason: AutoPromoteReasonReady,
+			},
+		},
+		{
+			name: "workpad closed blocked by line promotes",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-workpad-closed-blocked-by", nil)
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Blockers\n- Blocked by: #1462\n\n### Validation\n- make check passed.",
+				}}
+				issue.BlockedBy = []connector.BlockedRef{{
+					Identifier: "digitaldrywood/detent#1462",
+					State:      "Done",
+				}}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled:        true,
+				QuietDuration:  10 * time.Minute,
+				OptoutLabel:    "requires-human-review",
+				TerminalStates: []string{"Done", "Cancelled"},
+				Gate:           gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action:                  AutoPromoteActionPromote,
+				Reason:                  AutoPromoteReasonReady,
+				ResolvedWorkpadBlockers: []string{"digitaldrywood/detent#1462"},
+			},
+		},
+		{
+			name: "workpad open blocked by line awaits review",
+			issue: func() connector.Issue {
+				issue := autoPromoteTestIssue("issue-workpad-open-blocked-by", nil)
+				issue.Comments = []connector.IssueComment{{
+					Body: "## Codex Workpad\n\n### Blockers\n- Blocked by: #1462\n\n### Validation\n- make check passed.",
+				}}
+				issue.BlockedBy = []connector.BlockedRef{{
+					Identifier: "digitaldrywood/detent#1462",
+					State:      "In Progress",
+				}}
+				return issue
+			}(),
+			cfg: AutoPromoteConfig{
+				Enabled:        true,
+				QuietDuration:  10 * time.Minute,
+				OptoutLabel:    "requires-human-review",
+				TerminalStates: []string{"Done", "Cancelled"},
+				Gate:           gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+			},
+			input: AutoPromoteSummary{
+				PullRequestURL: "https://github.test/pull/42",
+				CIStatus:       "green",
+				LastActivityAt: &oldActivity,
+			},
+			want: AutoPromoteDecision{
+				Action: AutoPromoteActionAwaitReview,
+				Reason: AutoPromoteReasonWorkpadBlocker,
+			},
+		},
+		{
 			name: "workpad blocker phrase awaits review",
 			issue: func() connector.Issue {
 				issue := autoPromoteTestIssue("issue-workpad-blocker-phrase", nil)
@@ -473,6 +584,14 @@ func TestEvaluateAutoPromote(t *testing.T) {
 			if len(got.Findings) != len(tt.want.Findings) {
 				t.Fatalf("Findings len = %d, want %d", len(got.Findings), len(tt.want.Findings))
 			}
+			if len(got.ResolvedWorkpadBlockers) != len(tt.want.ResolvedWorkpadBlockers) {
+				t.Fatalf("ResolvedWorkpadBlockers len = %d, want %d", len(got.ResolvedWorkpadBlockers), len(tt.want.ResolvedWorkpadBlockers))
+			}
+			for i := range tt.want.ResolvedWorkpadBlockers {
+				if got.ResolvedWorkpadBlockers[i] != tt.want.ResolvedWorkpadBlockers[i] {
+					t.Fatalf("ResolvedWorkpadBlockers[%d] = %q, want %q", i, got.ResolvedWorkpadBlockers[i], tt.want.ResolvedWorkpadBlockers[i])
+				}
+			}
 			for i := range tt.want.Findings {
 				if got.Findings[i] != tt.want.Findings[i] {
 					t.Fatalf("Findings[%d] = %#v, want %#v", i, got.Findings[i], tt.want.Findings[i])
@@ -527,6 +646,19 @@ func TestAutoPromoteNormalizeWorkpadBlockerText(t *testing.T) {
 			name: "blocked first clause remains blocking",
 			text: "- Blocked: needs schema decision.",
 			want: "Blocked: needs schema decision.",
+		},
+		{
+			name: "must be resolved remains blocking",
+			text: "- Blocked by: #123 must be resolved before merge.",
+			want: "Blocked by: #123 must be resolved before merge.",
+		},
+		{
+			name: "removed stale blocked by prose is non-blocking",
+			text: "- The previous dependency blocker regressions now pass locally on the rebased head,\n  so stale `Blocked by: #1462` / `Blocked by: #1463` lines were removed from the issue body.",
+		},
+		{
+			name: "resolved dependency prose is non-blocking",
+			text: "- Dependency blocker #1462 merged via PR #1482 and issue #1462 is closed/Done; #1463 was already closed. Removed the stale `Blocked by: #1462` line from #1476.",
 		},
 	}
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -98,7 +98,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 			o.logAutoPromoteDecision(issue, autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen), "")
 			continue
 		}
-		if decision.Action == AutoPromoteActionPromote {
+		if decision.Action == AutoPromoteActionPromote || decision.Reason == AutoPromoteReasonWorkpadBlocker {
 			issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, cfg, now)
 		}
 		targetState := autoPromoteTargetState(decision.Action, cfg)
@@ -257,7 +257,76 @@ func (o *Orchestrator) hydrateAutoPromoteWorkpadDecision(
 		issue = cloneIssue(issue)
 		issue.Comments = comments
 	}
+	issue = o.hydrateAutoPromoteWorkpadBlockerRefs(ctx, issue, cfg.TerminalStates)
 	return issue, EvaluateAutoPromote(issue, summary, cfg, now)
+}
+
+func (o *Orchestrator) hydrateAutoPromoteWorkpadBlockerRefs(
+	ctx context.Context,
+	issue connector.Issue,
+	terminalStates []string,
+) connector.Issue {
+	refs := autoPromoteWorkpadBlockerRefs(issue)
+	if len(refs) == 0 {
+		return issue
+	}
+	resolver, ok := o.connector.(connector.IssueReferenceResolver)
+	if !ok {
+		return issue
+	}
+	identifiers := make([]string, 0, len(refs))
+	for _, ref := range refs {
+		if identifier := strings.TrimSpace(ref.Identifier); identifier != "" {
+			identifiers = append(identifiers, identifier)
+		}
+	}
+	if len(identifiers) == 0 {
+		return issue
+	}
+	resolved, err := resolver.FetchIssueStatesByIdentifiers(ctx, identifiers)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("hydrate auto-promote workpad blockers failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+		return issue
+	}
+	blockedBy := make([]connector.BlockedRef, 0, len(resolved))
+	for _, resolvedIssue := range resolved {
+		ref := autoPromoteBlockedRefFromIssue(resolvedIssue, terminalStates)
+		if strings.TrimSpace(ref.Identifier) != "" {
+			blockedBy = append(blockedBy, ref)
+		}
+	}
+	if len(blockedBy) == 0 {
+		return issue
+	}
+	issue = cloneIssue(issue)
+	issue.BlockedBy = mergeDependencyBlockedRefs(blockedBy, issue.BlockedBy)
+	return issue
+}
+
+func autoPromoteWorkpadBlockerRefs(issue connector.Issue) []connector.BlockedRef {
+	reason := autoPromoteWorkpadBlockerReason(issue)
+	if reason == "" {
+		return nil
+	}
+	return dependencyRefsInText(reason, dependencyIssueRepo(issue.Identifier))
+}
+
+func autoPromoteBlockedRefFromIssue(issue connector.Issue, terminalStates []string) connector.BlockedRef {
+	state := strings.TrimSpace(issue.State)
+	if issue.Closed || autoPromotePullRequestMerged(issue.PullRequest) {
+		state = doneStateName(terminalStates)
+	}
+	return connector.BlockedRef{
+		ID:         strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		State:      state,
+	}
+}
+
+func autoPromotePullRequestMerged(pullRequest *connector.PullRequest) bool {
+	return pullRequest != nil && normalizePullRequestState(pullRequest.State) == "merged"
 }
 
 func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
@@ -310,7 +379,7 @@ func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
 			continue
 		}
 		decision := staleTodoPullRequestDecision(issue, summary, o.cfg.AutoPromote, now)
-		if decision.Action == AutoPromoteActionPromote {
+		if decision.Action == AutoPromoteActionPromote || decision.Reason == AutoPromoteReasonWorkpadBlocker {
 			issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, o.cfg.AutoPromote, now)
 		}
 		targetState := staleTodoPullRequestTargetState(decision, o.cfg.AutoPromote)
@@ -1204,6 +1273,9 @@ func (o *Orchestrator) logStaleTodoPullRequestDecision(issue connector.Issue, de
 	if decision.WorkpadBlocker != "" {
 		attrs = append(attrs, "workpad_blocker", decision.WorkpadBlocker)
 	}
+	if len(decision.ResolvedWorkpadBlockers) > 0 {
+		attrs = append(attrs, "resolved_workpad_blockers", strings.Join(decision.ResolvedWorkpadBlockers, ","))
+	}
 	o.logger.Info("stale_todo_pr_reconciled", attrs...)
 }
 
@@ -2078,6 +2150,9 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 	}
 	if decision.WorkpadBlocker != "" {
 		attrs = append(attrs, "workpad_blocker", decision.WorkpadBlocker)
+	}
+	if len(decision.ResolvedWorkpadBlockers) > 0 {
+		attrs = append(attrs, "resolved_workpad_blockers", strings.Join(decision.ResolvedWorkpadBlockers, ","))
 	}
 	if targetState != "" {
 		attrs = append(attrs, "target_state", targetState)

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -539,6 +539,8 @@ func TestTickAutoPromoteHydratesWorkpadBlockerBeforeTransition(t *testing.T) {
 		TerminalStates: []string{"Done", "Cancelled"},
 	})
 	state := newState(cfg)
+	mergingSlot := dispatchTestIssue("issue-merging-slot", "Merging")
+	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
 	tracker := &autoPromoteTickConnector{
 		stateIssues: []connector.Issue{issue},
 		issueComments: map[string][]connector.IssueComment{
@@ -570,6 +572,141 @@ func TestTickAutoPromoteHydratesWorkpadBlockerBeforeTransition(t *testing.T) {
 		if !strings.Contains(logs.String(), fragment) {
 			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
 		}
+	}
+}
+
+func TestTickAutoPromoteResolvesClosedWorkpadBlockerBeforeTransition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 22, 30, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-resolved-workpad-blocker", []string{"bug"}, &connector.PullRequest{
+		Number:                 1480,
+		URL:                    "https://github.test/digitaldrywood/pyroapex/pull/1480",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "pass",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	issue.BlockedBy = []connector.BlockedRef{{Identifier: "digitaldrywood/detent#1462"}}
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	mergingSlot := dispatchTestIssue("issue-merging-slot", "Merging")
+	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
+	tracker := &autoPromoteTickConnector{
+		stateIssues: []connector.Issue{issue},
+		issueComments: map[string][]connector.IssueComment{
+			issue.ID: {{
+				Body: "## Codex Workpad\n\n### Blockers\n- Blocked by: #1462\n\n### Validation\n- make check passed.",
+			}},
+		},
+		resolvedIssues: []connector.Issue{{
+			ID:         "issue-1462",
+			Identifier: "digitaldrywood/detent#1462",
+			State:      "Done",
+		}},
+	}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+
+	result := orch.autoPromoteHumanReviewIssues(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned = %#v, want %s", result.transitioned, issue.ID)
+	}
+	if got, want := tracker.fetchIdentifiers, [][]string{{"digitaldrywood/detent#1462"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("FetchIssueStatesByIdentifiers = %#v, want %#v", got, want)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one auto-promote audit comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"action=promote",
+		"reason=ready",
+		"resolved_workpad_blockers=digitaldrywood/detent#1462",
+	} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+	if strings.Contains(logs.String(), "reason=workpad_blocker") {
+		t.Fatalf("logs %q contain workpad_blocker after resolved dependency hydration", logs.String())
+	}
+}
+
+func TestTickAutoPromoteResolvesMergedWorkpadBlockerBeforeTransition(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 8, 22, 35, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-merged-workpad-blocker", []string{"bug"}, &connector.PullRequest{
+		Number:                 1481,
+		URL:                    "https://github.test/digitaldrywood/pyroapex/pull/1481",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "pass",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	tracker := &autoPromoteTickConnector{
+		stateIssues: []connector.Issue{issue},
+		issueComments: map[string][]connector.IssueComment{
+			issue.ID: {{
+				Body: "## Codex Workpad\n\n### Blockers\n- Blocked by: #1462\n\n### Validation\n- make check passed.",
+			}},
+		},
+		resolvedIssues: []connector.Issue{{
+			ID:          "issue-1462",
+			Identifier:  "digitaldrywood/detent#1462",
+			State:       "In Progress",
+			PullRequest: &connector.PullRequest{Number: 1482, State: "MERGED"},
+		}},
+	}
+	var logs strings.Builder
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelInfo})),
+	}
+
+	result := orch.autoPromoteHumanReviewIssues(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned = %#v, want %s", result.transitioned, issue.ID)
+	}
+	if !strings.Contains(logs.String(), "resolved_workpad_blockers=digitaldrywood/detent#1462") {
+		t.Fatalf("logs %q missing resolved_workpad_blockers", logs.String())
 	}
 }
 
@@ -4063,7 +4200,9 @@ type autoPromoteTickConnector struct {
 	candidateByStates     [][]string
 	fetchByStatesRequests [][]string
 	fetchComments         []string
+	fetchIdentifiers      [][]string
 	issueComments         map[string][]connector.IssueComment
+	resolvedIssues        []connector.Issue
 	updates               []autoPromoteTickUpdate
 	comments              []autoPromoteTickComment
 	prComments            []autoPromoteTickComment
@@ -4125,6 +4264,21 @@ func (c *autoPromoteTickConnector) FetchIssueStatesByIDs(_ context.Context, ids 
 	issues := make([]connector.Issue, 0, len(c.stateIssues))
 	for _, issue := range c.stateIssues {
 		if _, ok := wanted[issue.ID]; ok {
+			issues = append(issues, cloneIssue(issue))
+		}
+	}
+	return issues, nil
+}
+
+func (c *autoPromoteTickConnector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
+	c.fetchIdentifiers = append(c.fetchIdentifiers, append([]string(nil), identifiers...))
+	wanted := make(map[string]struct{}, len(identifiers))
+	for _, identifier := range identifiers {
+		wanted[strings.ToLower(strings.TrimSpace(identifier))] = struct{}{}
+	}
+	issues := make([]connector.Issue, 0, len(c.resolvedIssues))
+	for _, issue := range c.resolvedIssues {
+		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
 			issues = append(issues, cloneIssue(issue))
 		}
 	}

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -45,6 +45,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			PassState:          cfg.Agent.AutoPromote.PassState,
 			ReworkState:        cfg.Agent.AutoPromote.ReworkState,
 			ReworkLimit:        cfg.Agent.AutoPromote.ReworkLimit,
+			TerminalStates:     append([]string(nil), cfg.Tracker.TerminalStates...),
 			Gate:               gate.Effective(cfg.Gate),
 		}),
 		Plan: gate.EffectivePlan(cfg.Plan),
@@ -121,6 +122,9 @@ func normalizeConfig(cfg Config) Config {
 	cfg.ActiveStates = normalizedStates(cfg.ActiveStates)
 	cfg.ObservedStates = normalizedStates(cfg.ObservedStates)
 	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
+	if len(cfg.AutoPromote.TerminalStates) == 0 {
+		cfg.AutoPromote.TerminalStates = append([]string(nil), cfg.TerminalStates...)
+	}
 	cfg.MaxConcurrentAgentsByState = cloneStateLimits(cfg.MaxConcurrentAgentsByState)
 	cfg.DispatchPriorityByState = normalizedStates(cfg.DispatchPriorityByState)
 	cfg.DispatchPriorityByLabel = normalizeLabels(cfg.DispatchPriorityByLabel)

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -290,6 +290,7 @@ func (s State) clone() State {
 
 func cloneAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 	cfg.AllowedIssueLabels = append([]string(nil), cfg.AllowedIssueLabels...)
+	cfg.TerminalStates = append([]string(nil), cfg.TerminalStates...)
 	cfg.Gate = cloneGateConfig(cfg.Gate)
 	return cfg
 }


### PR DESCRIPTION
## Summary

- Tighten Workpad dependency parsing so quoted/backticked or resolved-removal prose does not register as an active blocker.
- Resolve machine-readable Workpad blocker refs before holding auto-promotion, treating closed issues and merged PR blockers as cleared.
- Surface clean green Workpad holds in `detent doctor` via `workpad_blocker` diagnostics.

Fixes #1066

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/dependencyline ./internal/orchestrator ./internal/connector/github ./internal/cli`
- [x] `make check`