### PR TITLE
fix(orchestrator): persist transition guards

### DIFF
--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -32,9 +33,19 @@ const (
 	BlockedRecoveryReasonPullRequestMaintenance BlockedRecoveryReason = "pull_request_maintenance"
 )
 
+type BlockedRecoveryKind string
+
+const (
+	BlockedRecoveryKindConflict    BlockedRecoveryKind = "conflict"
+	BlockedRecoveryKindNoCI        BlockedRecoveryKind = "no-ci"
+	BlockedRecoveryKindRerun       BlockedRecoveryKind = "rerun"
+	BlockedRecoveryKindPriorSignal BlockedRecoveryKind = "prior-signal"
+)
+
 type BlockedRecoveryDecision struct {
 	Action      BlockedRecoveryAction
 	Reason      BlockedRecoveryReason
+	Kind        BlockedRecoveryKind
 	TargetState string
 	Detail      string
 }
@@ -67,19 +78,30 @@ func EvaluateBlockedRecovery(issue connector.Issue) BlockedRecoveryDecision {
 	}
 
 	text := blockedRecoveryText(issue)
-	if blockedRecoveryNoCurrentHeadCI(pr) && (blockedRecoveryAgentText(text) || blockedRecoveryHasPriorSignal(pr)) {
-		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonMissingCurrentHeadCI, "latest PR head has no CI signal")
+	agentText := blockedRecoveryAgentText(text)
+	priorSignal := blockedRecoveryHasPriorSignal(pr)
+	if blockedRecoveryNoCurrentHeadCI(pr) && (agentText || priorSignal) {
+		kind := BlockedRecoveryKindNoCI
+		if !agentText && priorSignal {
+			kind = BlockedRecoveryKindPriorSignal
+		}
+		return blockedRecoveryDecisionWithKind(BlockedRecoveryActionRework, BlockedRecoveryReasonMissingCurrentHeadCI, kind, "latest PR head has no CI signal")
 	}
-	if blockedRecoveryAgentText(text) {
-		return blockedRecoveryDecision(BlockedRecoveryActionRework, BlockedRecoveryReasonPullRequestMaintenance, "blocked reason describes agent-recoverable PR maintenance")
+	if agentText {
+		return blockedRecoveryDecisionWithKind(BlockedRecoveryActionRework, BlockedRecoveryReasonPullRequestMaintenance, BlockedRecoveryKindRerun, "blocked reason describes agent-recoverable PR maintenance")
 	}
 	return blockedRecoveryDecision(BlockedRecoveryActionNone, BlockedRecoveryReasonNoRecoverableSignal, "")
 }
 
 func blockedRecoveryDecision(action BlockedRecoveryAction, reason BlockedRecoveryReason, detail string) BlockedRecoveryDecision {
+	return blockedRecoveryDecisionWithKind(action, reason, blockedRecoveryKindForReason(reason), detail)
+}
+
+func blockedRecoveryDecisionWithKind(action BlockedRecoveryAction, reason BlockedRecoveryReason, kind BlockedRecoveryKind, detail string) BlockedRecoveryDecision {
 	decision := BlockedRecoveryDecision{
 		Action: action,
 		Reason: reason,
+		Kind:   kind,
 		Detail: strings.TrimSpace(detail),
 	}
 	if action == BlockedRecoveryActionRework {
@@ -107,7 +129,12 @@ func (o *Orchestrator) recoverBlockedIssues(
 		if decision.Action != BlockedRecoveryActionRework {
 			continue
 		}
-		if !o.applyBlockedRecovery(ctx, state, issue, decision, now) {
+		signature := blockedRecoverySignature(issue, decision)
+		if match, ok := o.workflowTimelineLaneActionSignature(ctx, issue, "blocked_recovery", workflowActionBlockedRecovery, signature); ok {
+			o.handleBlockedRecoveryExhausted(ctx, state, issue, decision, signature, match, now)
+			continue
+		}
+		if !o.applyBlockedRecovery(ctx, state, issue, decision, signature, now) {
 			continue
 		}
 		transitioned[issueID] = struct{}{}
@@ -123,6 +150,7 @@ func (o *Orchestrator) applyBlockedRecovery(
 	state *State,
 	issue connector.Issue,
 	decision BlockedRecoveryDecision,
+	signature string,
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
@@ -130,9 +158,10 @@ func (o *Orchestrator) applyBlockedRecovery(
 	if targetState == "" {
 		targetState = autoPromoteReworkState
 	}
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "blocked_recovery"); err != nil {
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionBlockedRecovery, signature)
+	if err := o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, now, "blocked_recovery", metadata); err != nil {
 		if o.logger != nil {
-			o.logger.Warn("blocked recovery transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason, "error", err)
+			o.logger.Warn("blocked recovery transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason, "signature", signature, "error", err)
 		}
 		return false
 	}
@@ -149,9 +178,55 @@ func (o *Orchestrator) applyBlockedRecovery(
 		Message: "recovered " + issueLabel(issue) + " from " + issue.State + " to " + targetState + ": " + string(decision.Reason),
 	})
 	if o.logger != nil {
-		o.logger.Info("blocked recovery transition", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason)
+		o.logger.Info("blocked recovery transition", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason, "signature", signature)
 	}
 	return true
+}
+
+func (o *Orchestrator) handleBlockedRecoveryExhausted(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	decision BlockedRecoveryDecision,
+	signature string,
+	match workflowTimelineMetadataMatch,
+	now time.Time,
+) {
+	issueID := strings.TrimSpace(issue.ID)
+	targetState := strings.TrimSpace(decision.TargetState)
+	if targetState == "" {
+		targetState = autoPromoteReworkState
+	}
+	if o.logger != nil {
+		o.logger.Info(
+			"blocked recovery exhausted",
+			"issue_id", issueID,
+			"identifier", issue.Identifier,
+			"signature", signature,
+			"matched_event_id", match.Event.ID,
+			"matched_event_reason", match.Event.Reason,
+			"matched_event_phase", match.Event.PhaseName,
+			"would_target_state", targetState,
+			"would_reason", decision.Reason,
+		)
+	}
+	if _, ok := o.workflowTimelineActionSignature(ctx, issue, workflowActionBlockedRecoveryExhausted, signature); ok {
+		return
+	}
+	body := blockedRecoveryExhaustedComment(issue, targetState, decision, signature, match)
+	if err := o.connector.CreateComment(ctx, issueID, body); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("blocked recovery exhausted comment failed", "issue_id", issueID, "identifier", issue.Identifier, "signature", signature, "error", err)
+		}
+		return
+	}
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionBlockedRecoveryExhausted, signature)
+	o.recordWorkflowReviewAction(ctx, issue, "blocked_recovery_exhausted", "blocked_recovery_exhausted", now, metadata)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "blocked_recovery_exhausted",
+		Message: "blocked recovery exhausted for " + issueLabel(issue) + ": " + signature,
+	})
 }
 
 func blockedRecoveryComment(issue connector.Issue, targetState string, decision BlockedRecoveryDecision) string {
@@ -181,6 +256,58 @@ func blockedRecoveryComment(issue connector.Issue, targetState string, decision 
 	return b.String()
 }
 
+func blockedRecoveryExhaustedComment(
+	issue connector.Issue,
+	targetState string,
+	decision BlockedRecoveryDecision,
+	signature string,
+	match workflowTimelineMetadataMatch,
+) string {
+	var b strings.Builder
+	b.WriteString("Blocked recovery already moved this issue to ")
+	b.WriteString(strings.TrimSpace(targetState))
+	b.WriteString(" for the same PR maintenance signature. It is back in Blocked without a new recovery signal, so a human needs to review it before Detent tries again.")
+	b.WriteString("\n\nReason: ")
+	b.WriteString(blockedRecoveryReasonLabel(decision.Reason))
+	if decision.Detail != "" {
+		b.WriteString(" (")
+		b.WriteString(decision.Detail)
+		b.WriteString(")")
+	}
+	b.WriteString("\nSignature: ")
+	b.WriteString(signature)
+	b.WriteString("\nMatched recovery event: ")
+	b.WriteString(workflowTimelineEventLabel(match.Event))
+	if pr := issue.PullRequest; pr != nil && pr.Number > 0 {
+		b.WriteString(fmt.Sprintf("\nLinked PR: #%d", pr.Number))
+		if url := strings.TrimSpace(pr.URL); url != "" {
+			b.WriteString(" ")
+			b.WriteString(url)
+		}
+	}
+	return b.String()
+}
+
+func workflowTimelineEventLabel(event store.WorkflowPhaseEvent) string {
+	parts := []string{}
+	if event.ID > 0 {
+		parts = append(parts, fmt.Sprintf("id=%d", event.ID))
+	}
+	if phase := strings.TrimSpace(event.PhaseName); phase != "" {
+		parts = append(parts, "phase="+phase)
+	}
+	if reason := strings.TrimSpace(event.Reason); reason != "" {
+		parts = append(parts, "reason="+reason)
+	}
+	if status := strings.TrimSpace(event.Status); status != "" {
+		parts = append(parts, "status="+status)
+	}
+	if len(parts) == 0 {
+		return "unknown"
+	}
+	return strings.Join(parts, " ")
+}
+
 func blockedRecoveryReasonLabel(reason BlockedRecoveryReason) string {
 	switch reason {
 	case BlockedRecoveryReasonMergeConflicts:
@@ -194,6 +321,38 @@ func blockedRecoveryReasonLabel(reason BlockedRecoveryReason) string {
 	default:
 		return strings.ReplaceAll(string(reason), "_", " ")
 	}
+}
+
+func blockedRecoveryKindForReason(reason BlockedRecoveryReason) BlockedRecoveryKind {
+	switch reason {
+	case BlockedRecoveryReasonMergeConflicts, BlockedRecoveryReasonStaleBase:
+		return BlockedRecoveryKindConflict
+	case BlockedRecoveryReasonMissingCurrentHeadCI:
+		return BlockedRecoveryKindNoCI
+	case BlockedRecoveryReasonPullRequestMaintenance:
+		return BlockedRecoveryKindRerun
+	default:
+		return ""
+	}
+}
+
+func blockedRecoverySignature(issue connector.Issue, decision BlockedRecoveryDecision) string {
+	kind := decision.Kind
+	if kind == "" {
+		kind = blockedRecoveryKindForReason(decision.Reason)
+	}
+	prNumber := 0
+	headSHA := ""
+	if issue.PRNumber != nil {
+		prNumber = *issue.PRNumber
+	}
+	if pr := issue.PullRequest; pr != nil {
+		if pr.Number > 0 {
+			prNumber = pr.Number
+		}
+		headSHA = strings.TrimSpace(pr.HeadSHA)
+	}
+	return fmt.Sprintf("kind=%s;pr=%d;head=%s", strings.TrimSpace(string(kind)), prNumber, headSHA)
 }
 
 func blockedRecoveryHumanOnly(issue connector.Issue) bool {

--- a/internal/orchestrator/blocked_recovery_test.go
+++ b/internal/orchestrator/blocked_recovery_test.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"strings"
 	"testing"
 	"time"
 
@@ -52,4 +53,163 @@ func TestRecoverBlockedIssuesSkipsPersistedReworkLimitBlockedIssue(t *testing.T)
 	if len(tracker.comments) != 0 {
 		t.Fatalf("comments = %#v, want no blocked recovery comment", tracker.comments)
 	}
+}
+
+func TestRecoverBlockedIssuesUsesPersistedSignatureGuard(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		issue            connector.Issue
+		persistedIssue   connector.Issue
+		runTwice         bool
+		wantUpdates      int
+		wantComments     int
+		wantExhausted    bool
+		wantTransitioned bool
+	}{
+		{
+			name:             "first recovery writes signature",
+			issue:            blockedRecoverySignatureIssue("issue-first-recovery", "same-head"),
+			wantUpdates:      1,
+			wantComments:     1,
+			wantTransitioned: true,
+		},
+		{
+			name:           "same signature skips and escalates",
+			issue:          blockedRecoverySignatureIssue("issue-same-signature", "same-head"),
+			persistedIssue: blockedRecoverySignatureIssue("issue-same-signature", "same-head"),
+			wantComments:   1,
+			wantExhausted:  true,
+		},
+		{
+			name:             "changed head sha re-arms recovery",
+			issue:            blockedRecoverySignatureIssue("issue-head-reset", "new-head"),
+			persistedIssue:   blockedRecoverySignatureIssue("issue-head-reset", "old-head"),
+			wantUpdates:      1,
+			wantComments:     1,
+			wantTransitioned: true,
+		},
+		{
+			name:           "exhausted comment is deduped by signature",
+			issue:          blockedRecoverySignatureIssue("issue-exhausted-dedupe", "same-head"),
+			persistedIssue: blockedRecoverySignatureIssue("issue-exhausted-dedupe", "same-head"),
+			runTwice:       true,
+			wantComments:   1,
+			wantExhausted:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{tt.issue}}
+			orch := dependencyAutoUnblockOrchestrator(tracker, DependencyAutoUnblockConfig{})
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			orch.workflowMetrics = metrics
+			if tt.persistedIssue.ID != "" {
+				recordBlockedRecoverySignatureEvent(t, metrics, tt.persistedIssue, time.Date(2026, 7, 8, 15, 0, 0, 0, time.UTC))
+			}
+			state := newState(orch.cfg)
+			now := time.Date(2026, 7, 8, 15, 1, 0, 0, time.UTC)
+
+			transitioned := orch.recoverBlockedIssues(context.Background(), &state, []connector.Issue{tt.issue}, now)
+			if tt.runTwice {
+				orch.recoverBlockedIssues(context.Background(), &state, []connector.Issue{tt.issue}, now.Add(time.Minute))
+			}
+
+			if got := len(tracker.updates); got != tt.wantUpdates {
+				t.Fatalf("updates = %#v, want %d update(s)", tracker.updates, tt.wantUpdates)
+			}
+			if got := len(tracker.comments); got != tt.wantComments {
+				t.Fatalf("comments = %#v, want %d comment(s)", tracker.comments, tt.wantComments)
+			}
+			_, didTransition := transitioned[tt.issue.ID]
+			if didTransition != tt.wantTransitioned {
+				t.Fatalf("transitioned[%q] = %v, want %v", tt.issue.ID, didTransition, tt.wantTransitioned)
+			}
+			if tt.wantUpdates > 0 {
+				assertBlockedRecoverySignatureMetadata(t, metrics, tt.issue)
+			}
+			if tt.wantExhausted {
+				if len(tracker.comments) == 0 || !strings.Contains(tracker.comments[0].body, "Blocked recovery already moved this issue") {
+					t.Fatalf("comments = %#v, want exhausted escalation comment", tracker.comments)
+				}
+				assertWorkflowActionSignature(t, metrics, tt.issue, workflowActionBlockedRecoveryExhausted, blockedRecoverySignature(tt.issue, EvaluateBlockedRecovery(tt.issue)))
+			}
+		})
+	}
+}
+
+func blockedRecoverySignatureIssue(id string, headSHA string) connector.Issue {
+	issue := dependencyAutoUnblockIssue(id, "Blocked")
+	prNumber := 418
+	issue.PRNumber = &prNumber
+	issue.PullRequest = &connector.PullRequest{
+		Number:         prNumber,
+		State:          "OPEN",
+		URL:            "https://github.test/digitaldrywood/detent/pull/418",
+		MergeableState: "behind",
+		HeadSHA:        headSHA,
+	}
+	return issue
+}
+
+func recordBlockedRecoverySignatureEvent(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	at time.Time,
+) {
+	t.Helper()
+
+	decision := EvaluateBlockedRecovery(issue)
+	signature := blockedRecoverySignature(issue, decision)
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionBlockedRecovery, signature)
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    autoPromoteReworkState,
+		Reason:       "blocked_recovery",
+		Status:       "entered",
+		StartedAt:    at,
+		MetadataJSON: workflowLaneMetadataJSON(issue, metadata),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+}
+
+func assertBlockedRecoverySignatureMetadata(t *testing.T, metrics *autoPromoteWorkflowMetricsRecorder, issue connector.Issue) {
+	t.Helper()
+
+	signature := blockedRecoverySignature(issue, EvaluateBlockedRecovery(issue))
+	assertWorkflowActionSignature(t, metrics, issue, workflowActionBlockedRecovery, signature)
+}
+
+func assertWorkflowActionSignature(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	action string,
+	signature string,
+) {
+	t.Helper()
+
+	for _, event := range metrics.snapshot() {
+		if event.IssueID != issue.ID {
+			continue
+		}
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if !ok {
+			continue
+		}
+		if workflowLaneMetadataHasActionSignature(metadata, action, signature) {
+			return
+		}
+	}
+	t.Fatalf("missing workflow action signature action=%q signature=%q in events %#v", action, signature, metrics.snapshot())
 }

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -847,19 +847,14 @@ func (o *Orchestrator) workflowTimelineActionSignature(
 func (o *Orchestrator) latestWorkflowLaneEntry(
 	ctx context.Context,
 	issue connector.Issue,
-	stateName string,
 ) (workflowTimelineMetadataMatch, bool) {
 	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
 	if !ok {
 		return workflowTimelineMetadataMatch{}, false
 	}
-	stateName = normalizeState(stateName)
 	for index := len(timeline.Events) - 1; index >= 0; index-- {
 		event := timeline.Events[index]
 		if event.PhaseType != store.WorkflowPhaseTypeLane {
-			continue
-		}
-		if normalizeState(event.PhaseName) != stateName {
 			continue
 		}
 		if !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -796,10 +796,92 @@ func (o *Orchestrator) workflowTimelineHasDependencyAutoUnblock(
 	issue connector.Issue,
 	blockerSet string,
 ) bool {
+	_, ok := o.workflowTimelineLaneMetadataMatch(ctx, issue, "dependency_auto_unblock", func(metadata workflowLaneMetadata) bool {
+		if metadata.DependencyAutoUnblock == nil {
+			return false
+		}
+		return strings.TrimSpace(metadata.DependencyAutoUnblock.BlockerSet) == blockerSet
+	})
+	return ok
+}
+
+type workflowTimelineMetadataMatch struct {
+	Event    store.WorkflowPhaseEvent
+	Metadata workflowLaneMetadata
+}
+
+func (o *Orchestrator) workflowTimelineLaneActionSignature(
+	ctx context.Context,
+	issue connector.Issue,
+	reason string,
+	action string,
+	signature string,
+) (workflowTimelineMetadataMatch, bool) {
+	return o.workflowTimelineLaneMetadataMatch(ctx, issue, reason, func(metadata workflowLaneMetadata) bool {
+		return workflowLaneMetadataHasActionSignature(metadata, action, signature)
+	})
+}
+
+func (o *Orchestrator) workflowTimelineActionSignature(
+	ctx context.Context,
+	issue connector.Issue,
+	action string,
+	signature string,
+) (workflowTimelineMetadataMatch, bool) {
 	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
 	if !ok {
-		return false
+		return workflowTimelineMetadataMatch{}, false
 	}
+	for _, event := range timeline.Events {
+		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		if !ok {
+			continue
+		}
+		if workflowLaneMetadataHasActionSignature(metadata, action, signature) {
+			return workflowTimelineMetadataMatch{Event: event, Metadata: metadata}, true
+		}
+	}
+	return workflowTimelineMetadataMatch{}, false
+}
+
+func (o *Orchestrator) latestWorkflowLaneEntry(
+	ctx context.Context,
+	issue connector.Issue,
+	stateName string,
+) (workflowTimelineMetadataMatch, bool) {
+	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
+	if !ok {
+		return workflowTimelineMetadataMatch{}, false
+	}
+	stateName = normalizeState(stateName)
+	for index := len(timeline.Events) - 1; index >= 0; index-- {
+		event := timeline.Events[index]
+		if event.PhaseType != store.WorkflowPhaseTypeLane {
+			continue
+		}
+		if normalizeState(event.PhaseName) != stateName {
+			continue
+		}
+		if !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
+			continue
+		}
+		metadata, _ := workflowLaneMetadataFromJSON(event.MetadataJSON)
+		return workflowTimelineMetadataMatch{Event: event, Metadata: metadata}, true
+	}
+	return workflowTimelineMetadataMatch{}, false
+}
+
+func (o *Orchestrator) workflowTimelineLaneMetadataMatch(
+	ctx context.Context,
+	issue connector.Issue,
+	reason string,
+	matches func(workflowLaneMetadata) bool,
+) (workflowTimelineMetadataMatch, bool) {
+	timeline, ok := o.issueWorkflowTimeline(ctx, issue)
+	if !ok {
+		return workflowTimelineMetadataMatch{}, false
+	}
+	reason = strings.TrimSpace(reason)
 	for _, event := range timeline.Events {
 		if event.PhaseType != store.WorkflowPhaseTypeLane {
 			continue
@@ -807,18 +889,18 @@ func (o *Orchestrator) workflowTimelineHasDependencyAutoUnblock(
 		if !strings.EqualFold(strings.TrimSpace(event.Status), "entered") {
 			continue
 		}
-		if !strings.EqualFold(strings.TrimSpace(event.Reason), "dependency_auto_unblock") {
+		if reason != "" && !strings.EqualFold(strings.TrimSpace(event.Reason), reason) {
 			continue
 		}
 		metadata, ok := workflowLaneMetadataFromJSON(event.MetadataJSON)
-		if !ok || metadata.DependencyAutoUnblock == nil {
+		if !ok {
 			continue
 		}
-		if strings.TrimSpace(metadata.DependencyAutoUnblock.BlockerSet) == blockerSet {
-			return true
+		if matches(metadata) {
+			return workflowTimelineMetadataMatch{Event: event, Metadata: metadata}, true
 		}
 	}
-	return false
+	return workflowTimelineMetadataMatch{}, false
 }
 
 func (o *Orchestrator) latestWorkflowLaneReason(ctx context.Context, issue connector.Issue, stateName string) (string, bool) {
@@ -855,7 +937,7 @@ func (o *Orchestrator) issueWorkflowTimeline(ctx context.Context, issue connecto
 	})
 	if err != nil {
 		if o.logger != nil {
-			o.logger.Warn("dependency auto-unblock workflow timeline read failed", "issue_id", strings.TrimSpace(issue.ID), "identifier", issue.Identifier, "error", err)
+			o.logger.Warn("workflow timeline read failed", "issue_id", strings.TrimSpace(issue.ID), "identifier", issue.Identifier, "error", err)
 		}
 		return store.WorkflowTimeline{}, false
 	}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -362,8 +362,9 @@ func (o *Orchestrator) dispatchMode(ctx context.Context, state *State, issue con
 	case "todo":
 		return runpkg.RunModePlan
 	case normalizeState(autoPromoteReworkState):
-		if match, ok := o.latestWorkflowLaneEntry(ctx, issue, autoPromoteReworkState); ok {
-			if workflowLaneMetadataHasAction(match.Metadata, workflowActionPlanReviewRework) {
+		if match, ok := o.latestWorkflowLaneEntry(ctx, issue); ok {
+			if normalizeState(match.Event.PhaseName) == normalizeState(autoPromoteReworkState) &&
+				workflowLaneMetadataHasAction(match.Metadata, workflowActionPlanReviewRework) {
 				return runpkg.RunModePlan
 			}
 			return runpkg.RunModeImplement

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -200,7 +200,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	now time.Time,
 	preferredWorkerHost string,
 ) dispatchIssueOutcome {
-	runMode := o.dispatchMode(state, issue)
+	runMode := o.dispatchMode(ctx, state, issue)
 	targetState := dispatchStartTransitionState(issue, runMode, o.cfg.ActiveStates)
 	slotIssue := issue
 	if targetState != "" {
@@ -350,7 +350,7 @@ func dispatchStartTransitionState(issue connector.Issue, mode string, activeStat
 	return planImplementationState
 }
 
-func (o *Orchestrator) dispatchMode(state *State, issue connector.Issue) string {
+func (o *Orchestrator) dispatchMode(ctx context.Context, state *State, issue connector.Issue) string {
 	if normalizeState(issue.State) == normalizeState(autoPromoteMergingState) && o.cfg.MergeFastPathEnabled {
 		return runpkg.RunModeMerge
 	}
@@ -362,14 +362,17 @@ func (o *Orchestrator) dispatchMode(state *State, issue connector.Issue) string 
 	case "todo":
 		return runpkg.RunModePlan
 	case normalizeState(autoPromoteReworkState):
+		if match, ok := o.latestWorkflowLaneEntry(ctx, issue, autoPromoteReworkState); ok {
+			if workflowLaneMetadataHasAction(match.Metadata, workflowActionPlanReviewRework) {
+				return runpkg.RunModePlan
+			}
+			return runpkg.RunModeImplement
+		}
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID != "" {
 			if _, ok := state.planRework[issueID]; ok {
 				return runpkg.RunModePlan
 			}
-		}
-		if planReviewReworkRequested(issue) {
-			return runpkg.RunModePlan
 		}
 	}
 	return runpkg.RunModeImplement

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -957,13 +957,13 @@ func TestDispatchModeMergingFastPathFlag(t *testing.T) {
 	issue := dispatchTestIssueWithPullRequest("issue-merging", "Merging", "OPEN")
 
 	off := Orchestrator{cfg: cfg}
-	if got := off.dispatchMode(&state, issue); got != runpkg.RunModeImplement {
+	if got := off.dispatchMode(context.Background(), &state, issue); got != runpkg.RunModeImplement {
 		t.Fatalf("flag off dispatchMode = %q, want implement", got)
 	}
 
 	cfg.MergeFastPathEnabled = true
 	on := Orchestrator{cfg: cfg}
-	if got := on.dispatchMode(&state, issue); got != runpkg.RunModeMerge {
+	if got := on.dispatchMode(context.Background(), &state, issue); got != runpkg.RunModeMerge {
 		t.Fatalf("flag on dispatchMode = %q, want merge", got)
 	}
 }

--- a/internal/orchestrator/plan_review.go
+++ b/internal/orchestrator/plan_review.go
@@ -2,6 +2,7 @@ package orchestrator
 
 import (
 	"context"
+	"crypto/sha256"
 	"fmt"
 	"strings"
 	"time"
@@ -33,14 +34,22 @@ func (o *Orchestrator) reviewPlanIssues(
 			continue
 		}
 
-		summary := planReviewSummaryFromIssue(issue)
-		decision := gate.EvaluatePlan(cfg, issue.Labels, summary)
+		evaluation := planReviewEvaluationFromIssue(issue)
+		decision := gate.EvaluatePlan(cfg, issue.Labels, evaluation.Summary)
 		targetState := planReviewTargetState(decision.Action)
 		if targetState == "" {
 			o.logPlanReviewDecision(issue, decision, "")
 			continue
 		}
-		if !o.applyPlanReviewDecision(ctx, state, issue, summary, decision, targetState, now) {
+		reworkSignature := ""
+		if normalizeState(targetState) == normalizeState(autoPromoteReworkState) {
+			reworkSignature = evaluation.Signature
+			if match, ok := o.workflowTimelineLaneActionSignature(ctx, issue, "plan_review_decision", workflowActionPlanReviewRework, reworkSignature); ok {
+				o.logPlanReviewReworkSkip(issue, decision, targetState, reworkSignature, match)
+				continue
+			}
+		}
+		if !o.applyPlanReviewDecision(ctx, state, issue, evaluation.Summary, decision, targetState, reworkSignature, now) {
 			continue
 		}
 		o.trackPlanReviewTransition(state, issueID, targetState)
@@ -52,27 +61,35 @@ func (o *Orchestrator) reviewPlanIssues(
 	return transitioned
 }
 
-func planReviewSummaryFromIssue(issue connector.Issue) gate.Summary {
-	summary := planReviewSummaryFromComments(issue.Comments)
+type planReviewEvaluation struct {
+	Summary   gate.Summary
+	Signature string
+}
+
+func planReviewEvaluationFromIssue(issue connector.Issue) planReviewEvaluation {
+	evaluation := planReviewEvaluationFromComments(issue.Comments)
 	if issue.PullRequest == nil || normalizePullRequestState(issue.PullRequest.State) != "open" {
-		return summary
+		return evaluation
 	}
-	return mergePlanReviewSummaries(summary, gate.Summary{
-		ReviewState: issue.PullRequest.CodexReviewState,
-		P1Findings:  planReviewFindingsFromPullRequest(issue.PullRequest),
-	})
+	prEvaluation := planReviewEvaluation{
+		Summary: gate.Summary{
+			ReviewState: issue.PullRequest.CodexReviewState,
+			P1Findings:  planReviewFindingsFromPullRequest(issue.PullRequest),
+		},
+		Signature: planReviewPullRequestSignature(issue.PullRequest),
+	}
+	if planReviewStateSeverity(prEvaluation.Summary.ReviewState) > planReviewStateSeverity(evaluation.Summary.ReviewState) {
+		prEvaluation.Summary.P1Findings = append(evaluation.Summary.P1Findings, prEvaluation.Summary.P1Findings...)
+		return prEvaluation
+	}
+	evaluation.Summary.P1Findings = append(evaluation.Summary.P1Findings, prEvaluation.Summary.P1Findings...)
+	if evaluation.Signature == "" {
+		evaluation.Signature = prEvaluation.Signature
+	}
+	return evaluation
 }
 
-func mergePlanReviewSummaries(left gate.Summary, right gate.Summary) gate.Summary {
-	out := left
-	if planReviewStateSeverity(right.ReviewState) > planReviewStateSeverity(out.ReviewState) {
-		out.ReviewState = right.ReviewState
-	}
-	out.P1Findings = append(out.P1Findings, right.P1Findings...)
-	return out
-}
-
-func planReviewSummaryFromComments(comments []connector.IssueComment) gate.Summary {
+func planReviewEvaluationFromComments(comments []connector.IssueComment) planReviewEvaluation {
 	for index := len(comments) - 1; index >= 0; index-- {
 		comment := comments[index]
 		body := strings.TrimSpace(comment.Body)
@@ -88,9 +105,12 @@ func planReviewSummaryFromComments(comments []connector.IssueComment) gate.Summa
 				URL:  strings.TrimSpace(comment.URL),
 			}}
 		}
-		return summary
+		return planReviewEvaluation{
+			Summary:   summary,
+			Signature: planReviewCommentSignature(comment),
+		}
 	}
-	return gate.Summary{}
+	return planReviewEvaluation{}
 }
 
 func planReviewArtifact(body string) bool {
@@ -189,6 +209,40 @@ func planReviewFindingsFromPullRequest(pullRequest *connector.PullRequest) []gat
 	return findings
 }
 
+func planReviewPullRequestSignature(pullRequest *connector.PullRequest) string {
+	if pullRequest == nil {
+		return ""
+	}
+	reviewKey := strings.TrimSpace(pullRequest.LatestCodexReviewCommitSHA)
+	if reviewKey == "" {
+		reviewKey = strings.TrimSpace(pullRequest.HeadSHA)
+	}
+	if reviewKey == "" && pullRequest.CodexReviewSubmittedAt != nil {
+		reviewKey = pullRequest.CodexReviewSubmittedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if reviewKey == "" && pullRequest.LatestCodexReviewSubmittedAt != nil {
+		reviewKey = pullRequest.LatestCodexReviewSubmittedAt.UTC().Format(time.RFC3339Nano)
+	}
+	if reviewKey == "" {
+		reviewKey = strings.TrimSpace(pullRequest.CodexReviewState)
+	}
+	if reviewKey == "" {
+		return ""
+	}
+	return fmt.Sprintf("pr=%d;review=%s", pullRequest.Number, reviewKey)
+}
+
+func planReviewCommentSignature(comment connector.IssueComment) string {
+	if id := strings.TrimSpace(comment.ID); id != "" {
+		return "comment_id=" + id
+	}
+	if url := strings.TrimSpace(comment.URL); url != "" {
+		return "comment_url=" + url
+	}
+	bodyHash := sha256.Sum256([]byte(strings.TrimSpace(comment.Body)))
+	return fmt.Sprintf("comment_sha256=%x", bodyHash)
+}
+
 func planReviewTargetState(action gate.Action) string {
 	switch action {
 	case gate.ActionPass:
@@ -251,16 +305,6 @@ func (o *Orchestrator) trackPlanReviewTransition(state *State, issueID string, t
 	delete(state.planRework, issueID)
 }
 
-func planReviewReworkRequested(issue connector.Issue) bool {
-	for _, comment := range issue.Comments {
-		body := strings.ToLower(comment.Body)
-		if strings.Contains(body, "plan review routed this issue") && strings.Contains(body, " to rework") {
-			return true
-		}
-	}
-	return false
-}
-
 func planReviewMarkdownSectionText(body string, title string) string {
 	want := normalizeState(title)
 	inSection := false
@@ -307,10 +351,15 @@ func (o *Orchestrator) applyPlanReviewDecision(
 	summary gate.Summary,
 	decision gate.Decision,
 	targetState string,
+	reworkSignature string,
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "plan_review_decision"); err != nil {
+	metadata := workflowLaneMetadata{}
+	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) {
+		metadata = workflowLaneMetadataWithActionSignature(metadata, workflowActionPlanReviewRework, reworkSignature)
+	}
+	if err := o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, now, "plan_review_decision", metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"plan review transition failed",
@@ -319,6 +368,7 @@ func (o *Orchestrator) applyPlanReviewDecision(
 				"action", decision.Action,
 				"reason", decision.Reason,
 				"target_state", targetState,
+				"signature", reworkSignature,
 				"error", err,
 			)
 		}
@@ -381,6 +431,30 @@ func appendPullRequestReviewDisagreementAttrs(attrs []any, pullRequest *connecto
 	return append(attrs,
 		"review_api_state", apiState,
 		"review_body_severity", bodySeverity,
+	)
+}
+
+func (o *Orchestrator) logPlanReviewReworkSkip(
+	issue connector.Issue,
+	decision gate.Decision,
+	targetState string,
+	signature string,
+	match workflowTimelineMetadataMatch,
+) {
+	if o.logger == nil {
+		return
+	}
+	o.logger.Info(
+		"plan review rework already routed",
+		"issue_id", strings.TrimSpace(issue.ID),
+		"identifier", issue.Identifier,
+		"action", decision.Action,
+		"reason", decision.Reason,
+		"target_state", targetState,
+		"signature", signature,
+		"matched_event_id", match.Event.ID,
+		"matched_event_reason", match.Event.Reason,
+		"matched_event_phase", match.Event.PhaseName,
 	)
 }
 

--- a/internal/orchestrator/plan_review_test.go
+++ b/internal/orchestrator/plan_review_test.go
@@ -1,13 +1,112 @@
 package orchestrator
 
 import (
+	"context"
+	"io"
 	"log/slog"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
 )
+
+func TestReviewPlanIssuesUsesPersistedReworkSignature(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name             string
+		issue            connector.Issue
+		persistedIssue   connector.Issue
+		wantUpdates      int
+		wantComments     int
+		wantTransitioned bool
+	}{
+		{
+			name:             "first review routes to rework",
+			issue:            planReviewPullRequestIssue("issue-plan-first", "review-head"),
+			wantUpdates:      1,
+			wantComments:     1,
+			wantTransitioned: true,
+		},
+		{
+			name:           "same review commit skips after restart",
+			issue:          planReviewPullRequestIssue("issue-plan-same", "review-head"),
+			persistedIssue: planReviewPullRequestIssue("issue-plan-same", "review-head"),
+		},
+		{
+			name:             "changed review commit re-arms rework",
+			issue:            planReviewPullRequestIssue("issue-plan-reset", "review-new"),
+			persistedIssue:   planReviewPullRequestIssue("issue-plan-reset", "review-old"),
+			wantUpdates:      1,
+			wantComments:     1,
+			wantTransitioned: true,
+		},
+		{
+			name:           "same comment artifact skips after restart",
+			issue:          planReviewCommentIssue("issue-plan-comment", "comment-1"),
+			persistedIssue: planReviewCommentIssue("issue-plan-comment", "comment-1"),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &dependencyAutoUnblockConnector{stateIssues: []connector.Issue{tt.issue}}
+			metrics := &autoPromoteWorkflowMetricsRecorder{}
+			orch := planReviewTestOrchestrator(tracker, metrics)
+			if tt.persistedIssue.ID != "" {
+				recordPlanReviewReworkSignatureEvent(t, metrics, tt.persistedIssue, time.Date(2026, 7, 8, 15, 0, 0, 0, time.UTC))
+			}
+			state := newState(orch.cfg)
+
+			transitioned := orch.reviewPlanIssues(context.Background(), &state, []connector.Issue{tt.issue}, time.Date(2026, 7, 8, 15, 1, 0, 0, time.UTC))
+
+			if got := len(tracker.updates); got != tt.wantUpdates {
+				t.Fatalf("updates = %#v, want %d update(s)", tracker.updates, tt.wantUpdates)
+			}
+			if got := len(tracker.comments); got != tt.wantComments {
+				t.Fatalf("comments = %#v, want %d comment(s)", tracker.comments, tt.wantComments)
+			}
+			_, didTransition := transitioned[tt.issue.ID]
+			if didTransition != tt.wantTransitioned {
+				t.Fatalf("transitioned[%q] = %v, want %v", tt.issue.ID, didTransition, tt.wantTransitioned)
+			}
+			if tt.wantUpdates > 0 {
+				assertWorkflowActionSignature(t, metrics, tt.issue, workflowActionPlanReviewRework, planReviewEvaluationFromIssue(tt.issue).Signature)
+			}
+		})
+	}
+}
+
+func TestDispatchModeUsesPlanReviewTimelineProvenance(t *testing.T) {
+	t.Parallel()
+
+	issue := planReviewCommentIssue("issue-plan-dispatch", "comment-1")
+	issue.State = autoPromoteReworkState
+	issue.Comments = append(issue.Comments, connector.IssueComment{
+		Body: "Plan review routed this issue from Plan Review to Rework.",
+	})
+
+	tracker := &dependencyAutoUnblockConnector{}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch := planReviewTestOrchestrator(tracker, metrics)
+	state := newState(orch.cfg)
+
+	if got := orch.dispatchMode(context.Background(), &state, issue); got != runpkg.RunModeImplement {
+		t.Fatalf("dispatchMode() with only old prose comment = %q, want implement", got)
+	}
+
+	recordPlanReviewReworkSignatureEvent(t, metrics, issue, time.Date(2026, 7, 8, 15, 0, 0, 0, time.UTC))
+	freshState := newState(orch.cfg)
+	if got := orch.dispatchMode(context.Background(), &freshState, issue); got != runpkg.RunModePlan {
+		t.Fatalf("dispatchMode() with timeline provenance = %q, want plan", got)
+	}
+}
 
 func TestPlanReviewContainsReviewSeverityUsesExplicitBadges(t *testing.T) {
 	t.Parallel()
@@ -38,7 +137,7 @@ func TestPlanReviewContainsReviewSeverityUsesExplicitBadges(t *testing.T) {
 		},
 		{
 			name:     "narrative p1 negative",
-			body:     "No P1 issues found — approved.",
+			body:     "No P1 issues found - approved.",
 			severity: "P1",
 			want:     false,
 		},
@@ -93,5 +192,86 @@ func TestPlanReviewDecisionLogsReviewStateDisagreement(t *testing.T) {
 		if !strings.Contains(logs.String(), fragment) {
 			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
 		}
+	}
+}
+
+func planReviewTestOrchestrator(
+	tracker *dependencyAutoUnblockConnector,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+) *Orchestrator {
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		Plan: gate.PlanConfig{
+			Enabled: true,
+			Review:  gate.PlanReviewAutomated,
+			Stop:    gate.DefaultPlanStop,
+		},
+		ActiveStates:               []string{"Todo", "In Progress", "Rework"},
+		TerminalStates:             []string{"Done", "Cancelled"},
+		ContinuationRetryDelay:     time.Second,
+		FailureRetryBaseDelay:      time.Second,
+		GitHubGraphQLWarnRemaining: 500,
+	})
+	return &Orchestrator{
+		cfg:             cfg,
+		connector:       tracker,
+		logger:          slog.New(slog.NewTextHandler(io.Discard, nil)),
+		workflowMetrics: metrics,
+	}
+}
+
+func planReviewPullRequestIssue(id string, reviewCommit string) connector.Issue {
+	issue := dependencyAutoUnblockIssue(id, gate.DefaultPlanStop)
+	prNumber := 524
+	issue.PRNumber = &prNumber
+	issue.PullRequest = &connector.PullRequest{
+		Number:                     prNumber,
+		State:                      "OPEN",
+		URL:                        "https://github.test/digitaldrywood/detent/pull/524",
+		HeadSHA:                    "head-sha",
+		CodexReviewState:           "P1",
+		LatestCodexReviewCommitSHA: reviewCommit,
+		CodexReviewFindings: []connector.PullRequestFinding{{
+			Body: "Plan omits acceptance criteria.",
+			URL:  "https://github.test/comment/plan-review",
+		}},
+	}
+	return issue
+}
+
+func planReviewCommentIssue(id string, commentID string) connector.Issue {
+	issue := dependencyAutoUnblockIssue(id, gate.DefaultPlanStop)
+	issue.Comments = []connector.IssueComment{{
+		ID:   commentID,
+		Body: "## Detent Plan Review\n\n- state: P1\n\n### Findings\n\n- Plan omits acceptance criteria.",
+		URL:  "https://github.test/comment/" + commentID,
+	}}
+	return issue
+}
+
+func recordPlanReviewReworkSignatureEvent(
+	t *testing.T,
+	metrics *autoPromoteWorkflowMetricsRecorder,
+	issue connector.Issue,
+	at time.Time,
+) {
+	t.Helper()
+
+	signature := planReviewEvaluationFromIssue(issue).Signature
+	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionPlanReviewRework, signature)
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    autoPromoteReworkState,
+		Reason:       "plan_review_decision",
+		Status:       "entered",
+		StartedAt:    at,
+		MetadataJSON: workflowLaneMetadataJSON(issue, metadata),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
 	}
 }

--- a/internal/orchestrator/plan_review_test.go
+++ b/internal/orchestrator/plan_review_test.go
@@ -106,6 +106,24 @@ func TestDispatchModeUsesPlanReviewTimelineProvenance(t *testing.T) {
 	if got := orch.dispatchMode(context.Background(), &freshState, issue); got != runpkg.RunModePlan {
 		t.Fatalf("dispatchMode() with timeline provenance = %q, want plan", got)
 	}
+
+	if _, err := metrics.RecordWorkflowPhaseEvent(context.Background(), store.WorkflowPhaseEvent{
+		ProjectID:    defaultWorkflowMetricsProjectID,
+		IssueID:      issue.ID,
+		Identifier:   issue.Identifier,
+		IssueURL:     issue.URL,
+		PhaseType:    store.WorkflowPhaseTypeLane,
+		PhaseName:    gate.DefaultPlanStop,
+		Reason:       "plan_worker_completed",
+		Status:       "entered",
+		StartedAt:    time.Date(2026, 7, 8, 15, 2, 0, 0, time.UTC),
+		MetadataJSON: "{}",
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	if got := orch.dispatchMode(context.Background(), &freshState, issue); got != runpkg.RunModeImplement {
+		t.Fatalf("dispatchMode() with stale plan provenance = %q, want implement", got)
+	}
 }
 
 func TestPlanReviewContainsReviewSeverityUsesExplicitBadges(t *testing.T) {

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -13,6 +13,12 @@ import (
 
 const defaultWorkflowMetricsProjectID = "default"
 
+const (
+	workflowActionBlockedRecovery          = "blocked_recovery"
+	workflowActionBlockedRecoveryExhausted = "blocked_recovery_exhausted"
+	workflowActionPlanReviewRework         = "plan_review_rework"
+)
+
 type WorkflowMetricsRecorder interface {
 	RecordWorkflowPhaseEvent(context.Context, store.WorkflowPhaseEvent) (int64, error)
 }
@@ -24,6 +30,7 @@ type WorkflowMetricsTimelineReader interface {
 type workflowLaneMetadata struct {
 	PullRequest           *workflowLanePullRequestMetadata           `json:"pull_request,omitempty"`
 	DependencyAutoUnblock *workflowLaneDependencyAutoUnblockMetadata `json:"dependency_auto_unblock,omitempty"`
+	ActionSignatures      []workflowLaneActionSignatureMetadata      `json:"action_signatures,omitempty"`
 }
 
 type workflowLanePullRequestMetadata struct {
@@ -35,6 +42,11 @@ type workflowLanePullRequestMetadata struct {
 type workflowLaneDependencyAutoUnblockMetadata struct {
 	BlockerSet string   `json:"blocker_set,omitempty"`
 	Blockers   []string `json:"blockers,omitempty"`
+}
+
+type workflowLaneActionSignatureMetadata struct {
+	Action    string `json:"action,omitempty"`
+	Signature string `json:"signature,omitempty"`
 }
 
 func (o *Orchestrator) updateIssueState(
@@ -143,6 +155,48 @@ func (o *Orchestrator) recordLaneTransition(
 	}
 }
 
+func (o *Orchestrator) recordWorkflowReviewAction(
+	ctx context.Context,
+	issue connector.Issue,
+	phaseName string,
+	reason string,
+	at time.Time,
+	metadata workflowLaneMetadata,
+) {
+	recorder := o.workflowMetrics
+	if recorder == nil {
+		return
+	}
+	phaseName = strings.TrimSpace(phaseName)
+	if phaseName == "" {
+		return
+	}
+	if at.IsZero() {
+		at = time.Now()
+	}
+	reason = strings.TrimSpace(reason)
+	if reason == "" {
+		reason = phaseName
+	}
+	if _, err := recorder.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+		ProjectID:      o.workflowMetricsProjectID(),
+		IssueID:        issue.ID,
+		Identifier:     issue.Identifier,
+		IssueURL:       issue.URL,
+		PRNumber:       workflowMetricsPRNumber(issue),
+		PhaseType:      store.WorkflowPhaseTypeReview,
+		PhaseName:      phaseName,
+		Reason:         reason,
+		Status:         "completed",
+		StartedAt:      at,
+		FinishedAt:     at,
+		MetadataJSON:   workflowLaneMetadataJSON(issue, metadata),
+		EndpointFamily: "tracker",
+	}); err != nil && o.logger != nil {
+		o.logger.Warn("record workflow review action metric failed", "issue_id", issue.ID, "identifier", issue.Identifier, "phase_name", phaseName, "reason", reason, "error", err)
+	}
+}
+
 func (o *Orchestrator) workflowMetricsProjectID() string {
 	projectID := strings.TrimSpace(o.cfg.Project.ID)
 	if projectID == "" {
@@ -185,7 +239,7 @@ func workflowLaneMetadataJSON(issue connector.Issue, metadata workflowLaneMetada
 	if metadata.PullRequest == nil {
 		metadata.PullRequest = workflowLanePullRequestMetadataFromIssue(issue)
 	}
-	if metadata.PullRequest == nil && metadata.DependencyAutoUnblock == nil {
+	if metadata.PullRequest == nil && metadata.DependencyAutoUnblock == nil && len(metadata.ActionSignatures) == 0 {
 		return "{}"
 	}
 	data, err := json.Marshal(metadata)
@@ -205,6 +259,50 @@ func workflowLaneMetadataFromJSON(raw string) (workflowLaneMetadata, bool) {
 		return workflowLaneMetadata{}, false
 	}
 	return metadata, true
+}
+
+func workflowLaneMetadataWithActionSignature(metadata workflowLaneMetadata, action string, signature string) workflowLaneMetadata {
+	action = strings.TrimSpace(action)
+	signature = strings.TrimSpace(signature)
+	if action == "" || signature == "" {
+		return metadata
+	}
+	if workflowLaneMetadataHasActionSignature(metadata, action, signature) {
+		return metadata
+	}
+	metadata.ActionSignatures = append(metadata.ActionSignatures, workflowLaneActionSignatureMetadata{
+		Action:    action,
+		Signature: signature,
+	})
+	return metadata
+}
+
+func workflowLaneMetadataHasActionSignature(metadata workflowLaneMetadata, action string, signature string) bool {
+	action = strings.TrimSpace(action)
+	signature = strings.TrimSpace(signature)
+	if action == "" || signature == "" {
+		return false
+	}
+	for _, candidate := range metadata.ActionSignatures {
+		if strings.EqualFold(strings.TrimSpace(candidate.Action), action) &&
+			strings.TrimSpace(candidate.Signature) == signature {
+			return true
+		}
+	}
+	return false
+}
+
+func workflowLaneMetadataHasAction(metadata workflowLaneMetadata, action string) bool {
+	action = strings.TrimSpace(action)
+	if action == "" {
+		return false
+	}
+	for _, candidate := range metadata.ActionSignatures {
+		if strings.EqualFold(strings.TrimSpace(candidate.Action), action) {
+			return true
+		}
+	}
+	return false
 }
 
 func workflowLanePullRequestMetadataFromIssue(issue connector.Issue) *workflowLanePullRequestMetadata {


### PR DESCRIPTION
## Summary

- Persist blocked recovery action signatures in workflow lane metadata and skip repeated same-signature recoveries with a deduped exhausted escalation.
- Persist plan-review Rework signatures from PR review commits or review comments, and remove own-comment prose mining from dispatch.
- Extract reusable workflow timeline metadata matching while preserving dependency auto-unblock behavior.

Fixes #1071

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/orchestrator`
- [x] `make check`