### PR TITLE
fix(orchestrator): detect no-progress completions

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -567,6 +567,7 @@ SET status = ?,
     github_rate_snapshot_json = ?,
     ci_state = ?,
     capacity_snapshot_json = ?,
+    worker_metadata_json = ?,
     metrics_json = ?,
     next_action = ?
 WHERE id = ?
@@ -578,6 +579,21 @@ FROM work_attempts
 WHERE completed_at IS NULL
   AND (sqlc.arg(filter_project_id) = '' OR project_id = sqlc.arg(filter_project_id))
 ORDER BY started_at, id;
+
+-- name: ListRecentTerminalWorkAttempts :many
+SELECT *
+FROM work_attempts
+WHERE completed_at IS NOT NULL
+  AND status = 'terminal'
+  AND (sqlc.arg(filter_project_id) = '' OR project_id = sqlc.arg(filter_project_id))
+  AND (sqlc.arg(filter_worker_type) = '' OR worker_type = sqlc.arg(filter_worker_type))
+  AND (
+    (sqlc.arg(issue_id) != '' AND issue_id = sqlc.arg(issue_id))
+    OR (sqlc.arg(identifier) != '' AND identifier = sqlc.arg(identifier))
+    OR (sqlc.arg(issue_url) != '' AND issue_url = sqlc.arg(issue_url))
+  )
+ORDER BY completed_at DESC, id DESC
+LIMIT sqlc.arg(result_limit);
 
 -- name: TimeoutExpiredWorkAttempts :many
 UPDATE work_attempts

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -908,6 +908,9 @@ tracker:
 server:
   kanban:
     mode: ` + mode + `
+agent:
+  auto_promote:
+    no_progress_limit: 0
 ---
 Test workflow prompt.
 `

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1300,6 +1300,7 @@ func TestRunDoctorSkipsWriteProbesByDefaultForExistingConfiguredProject(t *testi
 	workflow.Tracker.ObservedStates = []string{"Human Review"}
 	workflow.Tracker.TerminalStates = []string{"Done"}
 	workflow.Tracker.WriteProbeIssue = "digitaldrywood/detent#1"
+	workflow.Agent.AutoPromote.NoProgressLimit = 0
 	workflow.Server.Kanban.Mode = workflowconfig.KanbanModeIntegration
 
 	configPath := filepath.Join(t.TempDir(), "global.yaml")

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -46,6 +46,7 @@ const (
 	AgentBackendClaudeCode                   = "claude_code"
 	DefaultKnowledgeMaxBytes                 = 64 * 1024
 	DefaultReworkLimit                       = 3
+	DefaultNoProgressLimit                   = 3
 	DefaultAutoPromoteGateWaitTimeoutSeconds = 3600
 
 	DefaultPollingIntervalMS      = 120000
@@ -287,6 +288,7 @@ type AutoPromote struct {
 	PassState              string   `yaml:"pass_state,omitempty"`
 	ReworkState            string   `yaml:"rework_state,omitempty"`
 	ReworkLimit            int      `yaml:"rework_limit,omitempty"`
+	NoProgressLimit        int      `yaml:"no_progress_limit,omitempty"`
 }
 
 type OutputTruncation struct {
@@ -795,6 +797,7 @@ func Default() Config {
 				PassState:              "Merging",
 				ReworkState:            "Rework",
 				ReworkLimit:            DefaultReworkLimit,
+				NoProgressLimit:        DefaultNoProgressLimit,
 			},
 			Budget:    budget,
 			Lessons:   defaultLessons(),
@@ -861,6 +864,7 @@ func (c *Config) Validate() error {
 	}
 	c.Agent.validate("agent", &problems)
 	c.validateAutoPromoteReworkLimit(&problems)
+	c.validateAutoPromoteNoProgressLimit(&problems)
 	c.Agents.validate(&problems)
 	c.Codex.validate(&problems)
 	problems = append(problems, gate.Validate("gate", c.Gate)...)
@@ -1079,6 +1083,18 @@ func (c *Config) validateAutoPromoteReworkLimit(problems *[]string) {
 		return
 	}
 	*problems = append(*problems, "tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.rework_limit is greater than 0")
+}
+
+func (c *Config) validateAutoPromoteNoProgressLimit(problems *[]string) {
+	if c.Agent.AutoPromote.NoProgressLimit <= 0 {
+		return
+	}
+	if stateListContains(c.Tracker.ActiveStates, "Blocked") ||
+		stateListContains(c.Tracker.ObservedStates, "Blocked") ||
+		stateListContains(c.Tracker.TerminalStates, "Blocked") {
+		return
+	}
+	*problems = append(*problems, "tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.no_progress_limit is greater than 0")
 }
 
 func (l *LocalSQLite) Normalize() {
@@ -1477,6 +1493,9 @@ func (a *AutoPromote) validate(prefix string, problems *[]string) {
 	}
 	if a.ReworkLimit < 0 {
 		*problems = append(*problems, prefix+".rework_limit must be greater than or equal to 0")
+	}
+	if a.NoProgressLimit < 0 {
+		*problems = append(*problems, prefix+".no_progress_limit must be greater than or equal to 0")
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -109,6 +109,7 @@ agent:
     gate_wait_state: review
     gate_wait_timeout_seconds: 900
     rework_limit: 3
+    no_progress_limit: 4
     allowed_issue_labels:
       - enhancement
   lessons:
@@ -352,6 +353,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Agent.AutoPromote.GateWaitTimeoutSeconds != 900 {
 		t.Fatalf("Agent.AutoPromote.GateWaitTimeoutSeconds = %d, want 900", cfg.Agent.AutoPromote.GateWaitTimeoutSeconds)
+	}
+	if cfg.Agent.AutoPromote.NoProgressLimit != 4 {
+		t.Fatalf("Agent.AutoPromote.NoProgressLimit = %d, want 4", cfg.Agent.AutoPromote.NoProgressLimit)
 	}
 	if !cfg.Codex.ApprovalPolicy.IsString || cfg.Codex.ApprovalPolicy.String != "never" {
 		t.Fatalf("Codex.ApprovalPolicy = %#v, want string never", cfg.Codex.ApprovalPolicy)
@@ -655,6 +659,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.AutoPromote.GateWaitTimeoutSeconds != DefaultAutoPromoteGateWaitTimeoutSeconds {
 		t.Fatalf("Agent.AutoPromote.GateWaitTimeoutSeconds = %d, want %d", cfg.Agent.AutoPromote.GateWaitTimeoutSeconds, DefaultAutoPromoteGateWaitTimeoutSeconds)
+	}
+	if cfg.Agent.AutoPromote.NoProgressLimit != DefaultNoProgressLimit {
+		t.Fatalf("Agent.AutoPromote.NoProgressLimit = %d, want %d", cfg.Agent.AutoPromote.NoProgressLimit, DefaultNoProgressLimit)
 	}
 	if cfg.Agent.OutputTruncation.MaxBytes != 0 {
 		t.Fatalf("Agent.OutputTruncation.MaxBytes = %d, want disabled default", cfg.Agent.OutputTruncation.MaxBytes)
@@ -1933,6 +1940,21 @@ Prompt
 			},
 		},
 		{
+			name: "invalid auto promote no progress limit",
+			raw: `---
+tracker:
+  kind: memory
+agent:
+  auto_promote:
+    no_progress_limit: -1
+---
+Prompt
+`,
+			want: []string{
+				"agent.auto_promote.no_progress_limit must be greater than or equal to 0",
+			},
+		},
+		{
 			name: "auto promote rework limit requires blocked state",
 			raw: `---
 tracker:
@@ -1955,6 +1977,30 @@ Prompt
 `,
 			want: []string{
 				"tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.rework_limit is greater than 0",
+			},
+		},
+		{
+			name: "auto promote no progress limit requires blocked state",
+			raw: `---
+tracker:
+  kind: memory
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+    - Merging
+  observed_states:
+    - Human Review
+  terminal_states:
+    - Done
+agent:
+  auto_promote:
+    no_progress_limit: 1
+---
+Prompt
+`,
+			want: []string{
+				"tracker.active_states, tracker.observed_states, or tracker.terminal_states must include Blocked when agent.auto_promote.no_progress_limit is greater than 0",
 			},
 		},
 		{

--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -20,6 +20,7 @@ type AutoPromoteConfig struct {
 	ReworkState        string
 	ReworkLimit        int
 	TerminalStates     []string
+	NoProgressLimit    int
 	Gate               gate.Config
 }
 
@@ -185,6 +186,9 @@ func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {
 		cfg.ReworkLimit = 0
 	}
 	cfg.TerminalStates = normalizedStates(cfg.TerminalStates)
+	if cfg.NoProgressLimit < 0 {
+		cfg.NoProgressLimit = 0
+	}
 	cfg.Gate = gate.Effective(cfg.Gate)
 	return cfg
 }

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -46,6 +46,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 			ReworkState:        cfg.Agent.AutoPromote.ReworkState,
 			ReworkLimit:        cfg.Agent.AutoPromote.ReworkLimit,
 			TerminalStates:     append([]string(nil), cfg.Tracker.TerminalStates...),
+			NoProgressLimit:    cfg.Agent.AutoPromote.NoProgressLimit,
 			Gate:               gate.Effective(cfg.Gate),
 		}),
 		Plan: gate.EffectivePlan(cfg.Plan),

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -765,7 +765,7 @@ func (o *Orchestrator) issueHasStickyBlockReason(ctx context.Context, state *Sta
 
 func stickyBlockReason(reason string) bool {
 	switch strings.ToLower(strings.TrimSpace(reason)) {
-	case "rework_limit", "circuit_breaker":
+	case "rework_limit", "no_progress_limit", "circuit_breaker":
 		return true
 	default:
 		return false

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -2137,6 +2137,10 @@ func (s *recordingWorkAttemptStore) ListActiveWorkAttempts(context.Context, stor
 	return nil, nil
 }
 
+func (s *recordingWorkAttemptStore) ListRecentTerminalWorkAttempts(context.Context, store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
+	return nil, nil
+}
+
 func (s *recordingWorkAttemptStore) RecordSchedulerDecision(_ context.Context, attrs store.SchedulerDecision) (int64, error) {
 	s.decisions = append(s.decisions, attrs)
 	return int64(len(s.decisions)), nil

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -100,6 +100,12 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		return decision
 	}
 	decision.Issue = issue
+	if reason := implementProgressHydrationUnavailableReason(issue.PullRequest); reason != "" {
+		decision.Reason = "pull_request_hydration_unavailable"
+		decision.Warning = reason
+		o.warnImplementProgressHydration(issue, reason, nil)
+		return decision
+	}
 	signature := autoPromoteReworkSignatureFromIssue(issue, AutoPromoteSummaryFromIssue(issue))
 	decision.CurrentSignature = signature
 	if !implementProgressSignatureUsable(signature) {
@@ -286,6 +292,17 @@ func implementProgressDiffStatsClean(diffStats DiffStats) bool {
 
 func implementProgressLinkedPullRequest(issue connector.Issue) bool {
 	return workAttemptPRNumber(issue) != nil
+}
+
+func implementProgressHydrationUnavailableReason(pullRequest *connector.PullRequest) string {
+	reasons := make([]string, 0, 2)
+	if reason := pullRequestHydrationUnavailableReason(pullRequest); reason != "" {
+		reasons = append(reasons, reason)
+	}
+	if reason := pullRequestHydrationDegradedReason(pullRequest); reason != "" {
+		reasons = append(reasons, reason)
+	}
+	return strings.Join(reasons, "; ")
 }
 
 func implementProgressFailedCheckDelta(previous []string, current []string) ([]string, []string) {

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -1,0 +1,440 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	implementProgressMetadataKey       = "completion_progress"
+	implementProgressOutcomeNoProgress = "no_progress"
+	noProgressLimitReason              = "no_progress_limit"
+)
+
+type implementCompletionProgressDecision struct {
+	Issue                  connector.Issue
+	Outcome                store.WorkAttemptTerminalState
+	Reason                 string
+	CurrentSignature       autoPromoteReworkSignature
+	PreviousSignature      autoPromoteReworkSignature
+	PreviousSignatureFound bool
+	FailedChecksAdded      []string
+	FailedChecksRemoved    []string
+	WorkspaceDiffStats     DiffStats
+	ConsecutiveNoProgress  int
+	NoProgressLimit        int
+	Block                  bool
+	Warning                string
+}
+
+type implementProgressRecord struct {
+	Outcome               string                            `json:"outcome"`
+	Reason                string                            `json:"reason"`
+	CurrentSignature      implementProgressSignatureRecord  `json:"current_signature"`
+	PreviousSignature     *implementProgressSignatureRecord `json:"previous_signature,omitempty"`
+	PreviousHeadSHA       string                            `json:"previous_head_sha,omitempty"`
+	CurrentHeadSHA        string                            `json:"current_head_sha,omitempty"`
+	FailedChecksAdded     []string                          `json:"failed_checks_added,omitempty"`
+	FailedChecksRemoved   []string                          `json:"failed_checks_removed,omitempty"`
+	WorkspaceDiffStats    implementProgressDiffStats        `json:"workspace_diffstat"`
+	ConsecutiveNoProgress int                               `json:"consecutive_no_progress,omitempty"`
+	NoProgressLimit       int                               `json:"no_progress_limit,omitempty"`
+	BlockReason           string                            `json:"block_reason,omitempty"`
+	Warning               string                            `json:"warning,omitempty"`
+}
+
+type implementProgressSignatureRecord struct {
+	PRNumber     int64    `json:"pr_number,omitempty"`
+	HeadSHA      string   `json:"head_sha,omitempty"`
+	FailedChecks []string `json:"failed_checks,omitempty"`
+}
+
+type implementProgressDiffStats struct {
+	FilesChanged int    `json:"files_changed"`
+	AddedLines   int    `json:"added_lines"`
+	RemovedLines int    `json:"removed_lines"`
+	Status       string `json:"status,omitempty"`
+}
+
+func (o *Orchestrator) evaluateImplementCompletionProgress(
+	ctx context.Context,
+	running Running,
+	finalState string,
+) implementCompletionProgressDecision {
+	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	decision := implementCompletionProgressDecision{
+		Issue:              cloneIssue(running.Issue),
+		Outcome:            store.WorkAttemptTerminalSuccess,
+		Reason:             "success_without_progress_check",
+		WorkspaceDiffStats: running.DiffStats,
+		NoProgressLimit:    cfg.NoProgressLimit,
+	}
+	if strings.TrimSpace(finalState) != FinalStateCompleted {
+		decision.Reason = "final_state_not_completed"
+		return decision
+	}
+	if !implementProgressLinkedPullRequest(running.Issue) {
+		decision.Reason = "no_linked_pull_request"
+		return decision
+	}
+	hydrator, ok := o.connector.(connector.PullRequestHydrator)
+	if !ok {
+		decision.Reason = "pull_request_hydrator_unavailable"
+		decision.Warning = "pull request hydrator unavailable"
+		o.warnImplementProgressHydration(running.Issue, decision.Warning, nil)
+		return decision
+	}
+	issue, err := hydrator.HydratePullRequest(ctx, running.Issue)
+	if err != nil {
+		decision.Reason = "pull_request_hydration_failed"
+		decision.Warning = err.Error()
+		o.warnImplementProgressHydration(running.Issue, "pull request hydration failed", err)
+		return decision
+	}
+	decision.Issue = issue
+	signature := autoPromoteReworkSignatureFromIssue(issue, AutoPromoteSummaryFromIssue(issue))
+	decision.CurrentSignature = signature
+	if !implementProgressSignatureUsable(signature) {
+		decision.Reason = "pull_request_signature_incomplete"
+		return decision
+	}
+
+	attempts, err := o.recentImplementCompletionAttempts(ctx, issue, running)
+	if err != nil {
+		decision.Reason = "attempt_history_lookup_failed"
+		decision.Warning = err.Error()
+		if o.logger != nil {
+			o.logger.Warn(
+				"implement worker progress history lookup failed",
+				"issue_id", issue.ID,
+				"identifier", issue.Identifier,
+				"error", err,
+			)
+		}
+		return decision
+	}
+	previous, ok := latestImplementProgressSignature(attempts)
+	if !ok {
+		decision.Reason = "first_completed_attempt"
+		return decision
+	}
+	decision.PreviousSignature = previous
+	decision.PreviousSignatureFound = true
+	decision.FailedChecksAdded, decision.FailedChecksRemoved = implementProgressFailedCheckDelta(previous.FailedChecks, signature.FailedChecks)
+	if !implementProgressSignatureEqual(previous, signature) {
+		decision.Reason = "signature_changed"
+		return decision
+	}
+	if !implementProgressDiffStatsClean(running.DiffStats) {
+		if !diffStatsPresent(running.DiffStats) {
+			decision.Reason = "workspace_diffstat_unavailable"
+			return decision
+		}
+		decision.Reason = "workspace_diff_present"
+		return decision
+	}
+
+	decision.Outcome = store.WorkAttemptTerminalNoProgress
+	decision.Reason = "unchanged_signature_clean_diff"
+	decision.ConsecutiveNoProgress = 1 + consecutiveImplementNoProgressAttempts(attempts, signature)
+	decision.Block = decision.NoProgressLimit > 0 && decision.ConsecutiveNoProgress >= decision.NoProgressLimit
+	return decision
+}
+
+func (o *Orchestrator) recentImplementCompletionAttempts(
+	ctx context.Context,
+	issue connector.Issue,
+	running Running,
+) ([]store.WorkAttempt, error) {
+	if o == nil || o.workAttempts == nil {
+		return nil, nil
+	}
+	limit := normalizeAutoPromoteConfig(o.cfg.AutoPromote).NoProgressLimit + 1
+	if limit < 20 {
+		limit = 20
+	}
+	return o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		WorkerType: workAttemptWorkerType(issue, running.Mode),
+		Limit:      limit,
+	})
+}
+
+func latestImplementProgressSignature(attempts []store.WorkAttempt) (autoPromoteReworkSignature, bool) {
+	for _, attempt := range attempts {
+		record, ok := implementProgressRecordFromAttempt(attempt)
+		if !ok {
+			continue
+		}
+		signature := record.CurrentSignature.signature()
+		if implementProgressSignatureUsable(signature) {
+			return signature, true
+		}
+	}
+	return autoPromoteReworkSignature{}, false
+}
+
+func consecutiveImplementNoProgressAttempts(attempts []store.WorkAttempt, current autoPromoteReworkSignature) int {
+	count := 0
+	for _, attempt := range attempts {
+		record, ok := implementProgressRecordFromAttempt(attempt)
+		if !ok || strings.TrimSpace(record.Outcome) != implementProgressOutcomeNoProgress {
+			return count
+		}
+		if !implementProgressSignatureEqual(record.CurrentSignature.signature(), current) {
+			return count
+		}
+		count++
+	}
+	return count
+}
+
+func implementProgressRecordFromAttempt(attempt store.WorkAttempt) (implementProgressRecord, bool) {
+	if attempt.TerminalState != store.WorkAttemptTerminalSuccess &&
+		attempt.TerminalState != store.WorkAttemptTerminalNoProgress {
+		return implementProgressRecord{}, false
+	}
+	var root struct {
+		CompletionProgress implementProgressRecord `json:"completion_progress"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(attempt.WorkerMetadataJSON)), &root); err != nil {
+		return implementProgressRecord{}, false
+	}
+	record := root.CompletionProgress
+	if strings.TrimSpace(record.Outcome) == "" {
+		return implementProgressRecord{}, false
+	}
+	return record, true
+}
+
+func implementCompletionProgressMetadata(decision implementCompletionProgressDecision) map[string]any {
+	record := implementProgressRecord{
+		Outcome:               string(decision.Outcome),
+		Reason:                decision.Reason,
+		CurrentSignature:      implementProgressSignatureRecordFromSignature(decision.CurrentSignature),
+		PreviousHeadSHA:       decision.PreviousSignature.HeadSHA,
+		CurrentHeadSHA:        decision.CurrentSignature.HeadSHA,
+		FailedChecksAdded:     append([]string(nil), decision.FailedChecksAdded...),
+		FailedChecksRemoved:   append([]string(nil), decision.FailedChecksRemoved...),
+		WorkspaceDiffStats:    implementProgressDiffStatsFromDiffStats(decision.WorkspaceDiffStats),
+		ConsecutiveNoProgress: decision.ConsecutiveNoProgress,
+		NoProgressLimit:       decision.NoProgressLimit,
+		Warning:               strings.TrimSpace(decision.Warning),
+	}
+	if decision.PreviousSignatureFound {
+		previous := implementProgressSignatureRecordFromSignature(decision.PreviousSignature)
+		record.PreviousSignature = &previous
+	}
+	if decision.Block {
+		record.BlockReason = noProgressLimitReason
+	}
+	return map[string]any{implementProgressMetadataKey: record}
+}
+
+func implementProgressSignatureRecordFromSignature(signature autoPromoteReworkSignature) implementProgressSignatureRecord {
+	return implementProgressSignatureRecord{
+		PRNumber:     signature.PRNumber,
+		HeadSHA:      strings.TrimSpace(signature.HeadSHA),
+		FailedChecks: append([]string(nil), signature.FailedChecks...),
+	}
+}
+
+func (r implementProgressSignatureRecord) signature() autoPromoteReworkSignature {
+	return autoPromoteReworkSignature{
+		PRNumber:     r.PRNumber,
+		HeadSHA:      strings.TrimSpace(r.HeadSHA),
+		FailedChecks: autoPromoteCanonicalChecks(r.FailedChecks),
+	}
+}
+
+func implementProgressDiffStatsFromDiffStats(diffStats DiffStats) implementProgressDiffStats {
+	return implementProgressDiffStats{
+		FilesChanged: diffStats.FilesChanged,
+		AddedLines:   diffStats.AddedLines,
+		RemovedLines: diffStats.RemovedLines,
+		Status:       strings.TrimSpace(diffStats.Status),
+	}
+}
+
+func implementProgressSignatureUsable(signature autoPromoteReworkSignature) bool {
+	return signature.PRNumber > 0 && strings.TrimSpace(signature.HeadSHA) != ""
+}
+
+func implementProgressSignatureEqual(left autoPromoteReworkSignature, right autoPromoteReworkSignature) bool {
+	return left.PRNumber == right.PRNumber &&
+		strings.TrimSpace(left.HeadSHA) == strings.TrimSpace(right.HeadSHA) &&
+		slices.Equal(autoPromoteCanonicalChecks(left.FailedChecks), autoPromoteCanonicalChecks(right.FailedChecks))
+}
+
+func implementProgressDiffStatsClean(diffStats DiffStats) bool {
+	return diffStatsPresent(diffStats) &&
+		diffStats.FilesChanged == 0 &&
+		diffStats.AddedLines == 0 &&
+		diffStats.RemovedLines == 0
+}
+
+func implementProgressLinkedPullRequest(issue connector.Issue) bool {
+	return workAttemptPRNumber(issue) != nil
+}
+
+func implementProgressFailedCheckDelta(previous []string, current []string) ([]string, []string) {
+	previous = autoPromoteCanonicalChecks(previous)
+	current = autoPromoteCanonicalChecks(current)
+	added := make([]string, 0)
+	removed := make([]string, 0)
+	for _, check := range current {
+		if !slices.Contains(previous, check) {
+			added = append(added, check)
+		}
+	}
+	for _, check := range previous {
+		if !slices.Contains(current, check) {
+			removed = append(removed, check)
+		}
+	}
+	return added, removed
+}
+
+func (o *Orchestrator) warnImplementProgressHydration(issue connector.Issue, message string, err error) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	attrs := []any{
+		"issue_id", issue.ID,
+		"identifier", issue.Identifier,
+		"reason", strings.TrimSpace(message),
+	}
+	if err != nil {
+		attrs = append(attrs, "error", err)
+	}
+	o.logger.Warn("implement worker progress check failed open", attrs...)
+}
+
+func (o *Orchestrator) blockNoProgressLimit(
+	ctx context.Context,
+	state *State,
+	decision implementCompletionProgressDecision,
+	blockedAt time.Time,
+) bool {
+	issue := cloneIssue(decision.Issue)
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return false
+	}
+	if err := o.updateIssueStateByID(ctx, issueID, issue, blockedStatusState, blockedAt, noProgressLimitReason); err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"no progress limit state transition failed",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"target_state", blockedStatusState,
+				"error", err,
+			)
+		}
+		return false
+	}
+	issue.State = blockedStatusState
+	stageUpdatedAt := blockedAt.UTC()
+	issue.StageUpdatedAt = &stageUpdatedAt
+	if o.connector != nil {
+		if err := o.connector.CreateComment(ctx, issueID, noProgressLimitComment(issue, decision)); err != nil && o.logger != nil {
+			o.logger.Warn("no progress limit comment failed", "issue_id", issueID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("no progress limit claim release failed", "issue_id", issueID, "identifier", issue.Identifier, "error", err)
+	}
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	delete(state.PriorAttempts, issueID)
+	if completed, ok := state.Completed[issueID]; ok {
+		completed.Issue = issue
+		state.Completed[issueID] = completed
+	}
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issueID] = Blocked{
+		Issue:          issue,
+		Reason:         noProgressLimitReason,
+		RecoveryReason: "inspect the linked PR and worker logs, then move the issue back to Rework or Todo after a human confirms the next action",
+		RecoveryTarget: "Rework",
+		BlockedAt:      blockedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      blockedAt,
+		Event:   "implement_worker_no_progress_limit",
+		Message: "parked " + issueLabel(issue) + " after " + strconv.Itoa(decision.ConsecutiveNoProgress) + " no-progress completions",
+	})
+	return true
+}
+
+func noProgressLimitComment(issue connector.Issue, decision implementCompletionProgressDecision) string {
+	var b strings.Builder
+	b.WriteString("Routed this issue to Blocked because the implement worker completed repeatedly without PR progress.")
+	b.WriteString("\n\n- reason: ")
+	b.WriteString(noProgressLimitReason)
+	b.WriteString("\n- no_progress_limit: ")
+	b.WriteString(strconv.Itoa(decision.NoProgressLimit))
+	b.WriteString("\n- consecutive_no_progress_attempts: ")
+	b.WriteString(strconv.Itoa(decision.ConsecutiveNoProgress))
+	if issue.PullRequest != nil {
+		if url := strings.TrimSpace(issue.PullRequest.URL); url != "" {
+			b.WriteString("\n- pull request: ")
+			b.WriteString(url)
+		}
+	}
+	if decision.CurrentSignature.PRNumber > 0 {
+		b.WriteString("\n- pr_number: ")
+		b.WriteString(strconv.FormatInt(decision.CurrentSignature.PRNumber, 10))
+	}
+	if headSHA := strings.TrimSpace(decision.CurrentSignature.HeadSHA); headSHA != "" {
+		b.WriteString("\n- current_head_sha: ")
+		b.WriteString(headSHA)
+	}
+	if previousHeadSHA := strings.TrimSpace(decision.PreviousSignature.HeadSHA); previousHeadSHA != "" {
+		b.WriteString("\n- previous_head_sha: ")
+		b.WriteString(previousHeadSHA)
+	}
+	if failedChecks := strings.Join(decision.CurrentSignature.FailedChecks, ", "); failedChecks != "" {
+		b.WriteString("\n- failed_checks: ")
+		b.WriteString(failedChecks)
+	}
+	if added := strings.Join(decision.FailedChecksAdded, ", "); added != "" {
+		b.WriteString("\n- failed_checks_added: ")
+		b.WriteString(added)
+	}
+	if removed := strings.Join(decision.FailedChecksRemoved, ", "); removed != "" {
+		b.WriteString("\n- failed_checks_removed: ")
+		b.WriteString(removed)
+	}
+	b.WriteString("\n- workspace_diffstat: ")
+	if diffStatsPresent(decision.WorkspaceDiffStats) {
+		b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.FilesChanged))
+		b.WriteString(" files, +")
+		b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.AddedLines))
+		b.WriteString("/-")
+		b.WriteString(strconv.Itoa(decision.WorkspaceDiffStats.RemovedLines))
+		if status := strings.TrimSpace(decision.WorkspaceDiffStats.Status); status != "" {
+			b.WriteString(" (")
+			b.WriteString(status)
+			b.WriteString(")")
+		}
+	} else {
+		b.WriteString("unavailable")
+	}
+	return b.String()
+}

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -127,6 +127,19 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantLogContains: "implement worker progress check failed open",
 		},
 		{
+			name:            "degraded hydration fails open to success",
+			runningIssue:    implementProgressIssue("same-head", "Test"),
+			hydratedIssue:   implementProgressIssueWithHydrationDegraded("same-head", connector.PullRequestHydrationReasonStaleCachedPullData, "Test"),
+			history:         []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			diffStats:       DiffStats{Status: "clean"},
+			noProgressLimit: 3,
+			wantTerminal:    store.WorkAttemptTerminalSuccess,
+			wantReason:      "pull_request_hydration_unavailable",
+			wantHydrations:  1,
+			wantRetry:       true,
+			wantLogContains: "implement worker progress check failed open",
+		},
+		{
 			name:              "failed check delta is recorded",
 			runningIssue:      implementProgressIssue("new-head", "Test", "Lint"),
 			hydratedIssue:     implementProgressIssue("new-head", "Test", "Lint"),
@@ -268,6 +281,12 @@ func implementProgressIssue(headSHA string, failedChecks ...string) connector.Is
 			Conclusion: "failure",
 		})
 	}
+	return issue
+}
+
+func implementProgressIssueWithHydrationDegraded(headSHA string, reason string, failedChecks ...string) connector.Issue {
+	issue := implementProgressIssue(headSHA, failedChecks...)
+	issue.PullRequest.HydrationDegradedReason = reason
 	return issue
 }
 

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -1,0 +1,440 @@
+package orchestrator
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 8, 16, 0, 0, 0, time.UTC)
+	signature := autoPromoteReworkSignature{
+		PRNumber:     1070,
+		HeadSHA:      "same-head",
+		FailedChecks: []string{"Test"},
+	}
+
+	tests := []struct {
+		name              string
+		runningIssue      connector.Issue
+		hydratedIssue     connector.Issue
+		hydrateErr        error
+		history           []store.WorkAttempt
+		diffStats         DiffStats
+		noProgressLimit   int
+		wantTerminal      store.WorkAttemptTerminalState
+		wantReason        string
+		wantPreviousHead  string
+		wantCurrentHead   string
+		wantHydrations    int
+		wantBlocked       bool
+		wantComment       string
+		wantRetry         bool
+		wantLogContains   string
+		wantFailedAdded   []string
+		wantFailedRemoved []string
+	}{
+		{
+			name:            "first attempt succeeds with linked PR",
+			runningIssue:    implementProgressIssue("same-head", "Test"),
+			hydratedIssue:   implementProgressIssue("same-head", "Test"),
+			diffStats:       DiffStats{Status: "clean"},
+			noProgressLimit: 3,
+			wantTerminal:    store.WorkAttemptTerminalSuccess,
+			wantReason:      "first_completed_attempt",
+			wantCurrentHead: "same-head",
+			wantHydrations:  1,
+			wantRetry:       true,
+		},
+		{
+			name:             "new head SHA succeeds",
+			runningIssue:     implementProgressIssue("same-head", "Test"),
+			hydratedIssue:    implementProgressIssue("new-head", "Test"),
+			history:          []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			diffStats:        DiffStats{Status: "clean"},
+			noProgressLimit:  3,
+			wantTerminal:     store.WorkAttemptTerminalSuccess,
+			wantReason:       "signature_changed",
+			wantPreviousHead: "same-head",
+			wantCurrentHead:  "new-head",
+			wantHydrations:   1,
+			wantRetry:        true,
+		},
+		{
+			name:             "unchanged signature and clean diff records no progress",
+			runningIssue:     implementProgressIssue("same-head", "Test"),
+			hydratedIssue:    implementProgressIssue("same-head", "Test"),
+			history:          []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			diffStats:        DiffStats{Status: "clean"},
+			noProgressLimit:  3,
+			wantTerminal:     store.WorkAttemptTerminalNoProgress,
+			wantReason:       "unchanged_signature_clean_diff",
+			wantPreviousHead: "same-head",
+			wantCurrentHead:  "same-head",
+			wantHydrations:   1,
+			wantRetry:        true,
+		},
+		{
+			name:          "limit trip blocks with comment",
+			runningIssue:  implementProgressIssue("same-head", "Test"),
+			hydratedIssue: implementProgressIssue("same-head", "Test"),
+			history: []store.WorkAttempt{
+				implementProgressHistoryAttempt(2, signature, store.WorkAttemptTerminalNoProgress),
+				implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalNoProgress),
+			},
+			diffStats:        DiffStats{Status: "clean"},
+			noProgressLimit:  3,
+			wantTerminal:     store.WorkAttemptTerminalNoProgress,
+			wantReason:       "unchanged_signature_clean_diff",
+			wantPreviousHead: "same-head",
+			wantCurrentHead:  "same-head",
+			wantHydrations:   1,
+			wantBlocked:      true,
+			wantComment:      "no_progress_limit",
+		},
+		{
+			name:            "issue without linked PR is exempt",
+			runningIssue:    implementProgressIssueWithoutPR(),
+			diffStats:       DiffStats{Status: "clean"},
+			noProgressLimit: 3,
+			wantTerminal:    store.WorkAttemptTerminalSuccess,
+			wantReason:      "no_linked_pull_request",
+			wantRetry:       true,
+		},
+		{
+			name:            "hydration failure fails open to success",
+			runningIssue:    implementProgressIssue("same-head", "Test"),
+			hydratedIssue:   implementProgressIssue("same-head", "Test"),
+			hydrateErr:      errors.New("github hiccup"),
+			history:         []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			diffStats:       DiffStats{Status: "clean"},
+			noProgressLimit: 3,
+			wantTerminal:    store.WorkAttemptTerminalSuccess,
+			wantReason:      "pull_request_hydration_failed",
+			wantHydrations:  1,
+			wantRetry:       true,
+			wantLogContains: "implement worker progress check failed open",
+		},
+		{
+			name:              "failed check delta is recorded",
+			runningIssue:      implementProgressIssue("new-head", "Test", "Lint"),
+			hydratedIssue:     implementProgressIssue("new-head", "Test", "Lint"),
+			history:           []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			diffStats:         DiffStats{Status: "clean"},
+			noProgressLimit:   3,
+			wantTerminal:      store.WorkAttemptTerminalSuccess,
+			wantReason:        "signature_changed",
+			wantPreviousHead:  "same-head",
+			wantCurrentHead:   "new-head",
+			wantHydrations:    1,
+			wantRetry:         true,
+			wantFailedAdded:   []string{"Lint"},
+			wantFailedRemoved: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var logs bytes.Buffer
+			tracker := &implementProgressConnector{hydrated: tt.hydratedIssue, hydrateErr: tt.hydrateErr}
+			attempts := &implementProgressAttemptStore{history: tt.history}
+			cfg := normalizeConfig(Config{
+				Project:                scheduler.ProjectCandidate{ID: "detent"},
+				AutoPromote:            AutoPromoteConfig{NoProgressLimit: tt.noProgressLimit},
+				ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates:         []string{"Human Review", "Blocked"},
+				TerminalStates:         []string{"Done", "Cancelled"},
+				ContinuationRetryDelay: time.Minute,
+			})
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: attempts,
+				logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+			state := newState(cfg)
+			running := Running{
+				Issue:         tt.runningIssue,
+				Attempt:       1,
+				WorkAttemptID: 42,
+				Mode:          runpkg.RunModeImplement,
+				StartedAt:     base.Add(-time.Minute),
+				DiffStats:     tt.diffStats,
+			}
+			state.Running[tt.runningIssue.ID] = running
+			state.Claimed[tt.runningIssue.ID] = Claimed{Issue: tt.runningIssue, ClaimedAt: running.StartedAt}
+
+			orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+				IssueID:     tt.runningIssue.ID,
+				CompletedAt: base,
+				Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+				Result: runpkg.RunResult{
+					FinalState: FinalStateCompleted,
+					DiffStats:  tt.diffStats,
+				},
+			})
+
+			if len(attempts.completions) != 1 {
+				t.Fatalf("completions len = %d, want 1", len(attempts.completions))
+			}
+			completion := attempts.completions[0]
+			if completion.TerminalState != tt.wantTerminal {
+				t.Fatalf("TerminalState = %q, want %q", completion.TerminalState, tt.wantTerminal)
+			}
+			record := implementProgressRecordFromCompletion(t, completion)
+			if record.Reason != tt.wantReason {
+				t.Fatalf("metadata reason = %q, want %q", record.Reason, tt.wantReason)
+			}
+			if record.PreviousHeadSHA != tt.wantPreviousHead {
+				t.Fatalf("previous head = %q, want %q", record.PreviousHeadSHA, tt.wantPreviousHead)
+			}
+			if record.CurrentHeadSHA != tt.wantCurrentHead {
+				t.Fatalf("current head = %q, want %q", record.CurrentHeadSHA, tt.wantCurrentHead)
+			}
+			if !slicesEqual(record.FailedChecksAdded, tt.wantFailedAdded) {
+				t.Fatalf("failed checks added = %#v, want %#v", record.FailedChecksAdded, tt.wantFailedAdded)
+			}
+			if !slicesEqual(record.FailedChecksRemoved, tt.wantFailedRemoved) {
+				t.Fatalf("failed checks removed = %#v, want %#v", record.FailedChecksRemoved, tt.wantFailedRemoved)
+			}
+			if tracker.hydrations != tt.wantHydrations {
+				t.Fatalf("hydrations = %d, want %d", tracker.hydrations, tt.wantHydrations)
+			}
+			if _, ok := state.Blocked[tt.runningIssue.ID]; ok != tt.wantBlocked {
+				t.Fatalf("blocked present = %v, want %v", ok, tt.wantBlocked)
+			}
+			if tt.wantBlocked {
+				if len(tracker.updates) != 1 || tracker.updates[0].state != blockedStatusState {
+					t.Fatalf("updates = %#v, want one Blocked update", tracker.updates)
+				}
+				if len(tracker.comments) != 1 || !strings.Contains(tracker.comments[0].body, tt.wantComment) {
+					t.Fatalf("comments = %#v, want comment containing %q", tracker.comments, tt.wantComment)
+				}
+				if _, ok := state.Retry[tt.runningIssue.ID]; ok {
+					t.Fatalf("Retry[%q] present after block", tt.runningIssue.ID)
+				}
+			} else if _, ok := state.Retry[tt.runningIssue.ID]; ok != tt.wantRetry {
+				t.Fatalf("retry present = %v, want %v", ok, tt.wantRetry)
+			}
+			if tt.wantLogContains != "" && !strings.Contains(logs.String(), tt.wantLogContains) {
+				t.Fatalf("logs did not contain %q:\n%s", tt.wantLogContains, logs.String())
+			}
+		})
+	}
+}
+
+func TestStickyBlockReasonIncludesNoProgressLimit(t *testing.T) {
+	t.Parallel()
+
+	if !stickyBlockReason(noProgressLimitReason) {
+		t.Fatalf("stickyBlockReason(%q) = false, want true", noProgressLimitReason)
+	}
+}
+
+func implementProgressIssue(headSHA string, failedChecks ...string) connector.Issue {
+	prNumber := 1070
+	issue := connector.Issue{
+		ID:           "issue-1070",
+		Identifier:   "digitaldrywood/detent#1070",
+		Title:        "No progress",
+		State:        "In Progress",
+		URL:          "https://github.test/digitaldrywood/detent/issues/1070",
+		PRNumber:     &prNumber,
+		PRRepository: "digitaldrywood/detent",
+		PullRequest: &connector.PullRequest{
+			Number:  prNumber,
+			URL:     "https://github.test/digitaldrywood/detent/pull/1070",
+			State:   "OPEN",
+			HeadSHA: headSHA,
+		},
+	}
+	for _, check := range failedChecks {
+		issue.PullRequest.RequiredCheckFailures = append(issue.PullRequest.RequiredCheckFailures, connector.PullRequestCheck{
+			Name:       check,
+			Status:     "completed",
+			Conclusion: "failure",
+		})
+	}
+	return issue
+}
+
+func implementProgressIssueWithoutPR() connector.Issue {
+	return connector.Issue{
+		ID:         "issue-plan",
+		Identifier: "digitaldrywood/detent#1200",
+		Title:      "Plan only",
+		State:      "In Progress",
+		URL:        "https://github.test/digitaldrywood/detent/issues/1200",
+	}
+}
+
+func implementProgressHistoryAttempt(id int64, signature autoPromoteReworkSignature, terminal store.WorkAttemptTerminalState) store.WorkAttempt {
+	return store.WorkAttempt{
+		ID:                 id,
+		ProjectID:          "detent",
+		IssueID:            "issue-1070",
+		Identifier:         "digitaldrywood/detent#1070",
+		IssueURL:           "https://github.test/digitaldrywood/detent/issues/1070",
+		WorkerType:         "agent",
+		Status:             store.WorkAttemptStatusTerminal,
+		TerminalState:      terminal,
+		CompletedAt:        time.Date(2026, 7, 8, 15, int(id), 0, 0, time.UTC),
+		WorkerMetadataJSON: implementProgressMetadataJSON(signature, terminal),
+	}
+}
+
+func implementProgressMetadataJSON(signature autoPromoteReworkSignature, terminal store.WorkAttemptTerminalState) string {
+	return marshalWorkAttemptJSON(map[string]any{
+		"run_mode": runpkg.RunModeImplement,
+		implementProgressMetadataKey: implementProgressRecord{
+			Outcome:          string(terminal),
+			Reason:           "test_history",
+			CurrentSignature: implementProgressSignatureRecordFromSignature(signature),
+			CurrentHeadSHA:   signature.HeadSHA,
+		},
+	})
+}
+
+func implementProgressRecordFromCompletion(t *testing.T, completion store.WorkAttemptCompletion) implementProgressRecord {
+	t.Helper()
+
+	attempt := store.WorkAttempt{
+		TerminalState:      completion.TerminalState,
+		WorkerMetadataJSON: completion.WorkerMetadataJSON,
+	}
+	record, ok := implementProgressRecordFromAttempt(attempt)
+	if !ok {
+		t.Fatalf("completion metadata did not include progress record: %s", completion.WorkerMetadataJSON)
+	}
+	return record
+}
+
+type implementProgressConnector struct {
+	hydrated   connector.Issue
+	hydrateErr error
+	hydrations int
+	updates    []implementProgressUpdate
+	comments   []implementProgressComment
+}
+
+type implementProgressUpdate struct {
+	issueID string
+	state   string
+}
+
+type implementProgressComment struct {
+	issueID string
+	body    string
+}
+
+func (c *implementProgressConnector) Name() string {
+	return "implement-progress"
+}
+
+func (c *implementProgressConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *implementProgressConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *implementProgressConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	return nil, nil
+}
+
+func (c *implementProgressConnector) CreateComment(_ context.Context, issueID string, body string) error {
+	c.comments = append(c.comments, implementProgressComment{issueID: issueID, body: body})
+	return nil
+}
+
+func (c *implementProgressConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	c.updates = append(c.updates, implementProgressUpdate{issueID: issueID, state: state})
+	return nil
+}
+
+func (c *implementProgressConnector) SetAssignee(context.Context, string, string) error {
+	return nil
+}
+
+func (c *implementProgressConnector) SetField(context.Context, string, string, string) error {
+	return nil
+}
+
+func (c *implementProgressConnector) HydratePullRequest(context.Context, connector.Issue) (connector.Issue, error) {
+	c.hydrations++
+	if c.hydrateErr != nil {
+		return connector.Issue{}, c.hydrateErr
+	}
+	return cloneIssue(c.hydrated), nil
+}
+
+type implementProgressAttemptStore struct {
+	history     []store.WorkAttempt
+	completions []store.WorkAttemptCompletion
+}
+
+func (s *implementProgressAttemptStore) StartWorkAttempt(context.Context, store.WorkAttemptStart) (int64, error) {
+	return 1, nil
+}
+
+func (s *implementProgressAttemptStore) RecordWorkAttemptHeartbeat(context.Context, store.WorkAttemptHeartbeat) error {
+	return nil
+}
+
+func (s *implementProgressAttemptStore) CompleteWorkAttempt(_ context.Context, attrs store.WorkAttemptCompletion) error {
+	s.completions = append(s.completions, attrs)
+	return nil
+}
+
+func (s *implementProgressAttemptStore) ListActiveWorkAttempts(context.Context, store.WorkAttemptQuery) ([]store.WorkAttempt, error) {
+	return nil, nil
+}
+
+func (s *implementProgressAttemptStore) ListRecentTerminalWorkAttempts(context.Context, store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
+	return append([]store.WorkAttempt(nil), s.history...), nil
+}
+
+func (s *implementProgressAttemptStore) TimeoutExpiredWorkAttempts(context.Context, store.WorkAttemptTimeout) ([]store.WorkAttempt, error) {
+	return nil, nil
+}
+
+func (s *implementProgressAttemptStore) ReclaimActiveWorkAttempts(context.Context, store.WorkAttemptReclaim) ([]store.WorkAttempt, error) {
+	return nil, nil
+}
+
+func (s *implementProgressAttemptStore) RecordSchedulerDecision(context.Context, store.SchedulerDecision) (int64, error) {
+	return 0, nil
+}
+
+func (s *implementProgressAttemptStore) ListRecentSchedulerDecisions(context.Context, store.SchedulerDecisionQuery) ([]store.SchedulerDecision, error) {
+	return nil, nil
+}
+
+func slicesEqual(left []string, right []string) bool {
+	if len(left) == 0 && len(right) == 0 {
+		return true
+	}
+	if len(left) != len(right) {
+		return false
+	}
+	for index := range left {
+		if left[index] != right[index] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -191,7 +191,22 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		errorClass = "runner_final_state"
 		errorMessage = finalState
 	}
-	o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, "completed", "worker completed")
+	if diffStatsPresent(event.Result.DiffStats) {
+		running.DiffStats = event.Result.DiffStats
+	}
+	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState)
+	if terminalState != store.WorkAttemptTerminalSuccess {
+		progress.Outcome = terminalState
+	}
+	running.Issue = progress.Issue
+	phase := "completed"
+	statusMessage := "worker completed"
+	if terminalState == store.WorkAttemptTerminalSuccess && progress.Outcome == store.WorkAttemptTerminalNoProgress {
+		terminalState = store.WorkAttemptTerminalNoProgress
+		phase = "no_progress"
+		statusMessage = "worker completed without PR progress"
+	}
+	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, implementCompletionProgressMetadata(progress))
 	delete(state.InstantFailures, event.IssueID)
 
 	state.Completed[event.IssueID] = Completed{
@@ -218,6 +233,11 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if state.Draining {
 		o.cleanupDrainedRun(ctx, state, event.IssueID)
 		return
+	}
+	if terminalState == store.WorkAttemptTerminalNoProgress && progress.Block {
+		if o.blockNoProgressLimit(ctx, state, progress, event.CompletedAt) {
+			return
+		}
 	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
 }

--- a/internal/orchestrator/work_attempts.go
+++ b/internal/orchestrator/work_attempts.go
@@ -122,6 +122,7 @@ func (o *Orchestrator) startDurableWorkAttempt(
 		StatusMessage:          start.StatusMessage,
 		GitHubRateSnapshotJSON: start.GitHubRateSnapshotJSON,
 		CapacitySnapshotJSON:   start.CapacitySnapshotJSON,
+		WorkerMetadataJSON:     start.WorkerMetadataJSON,
 		MetricsJSON:            start.MetricsJSON,
 		NextAction:             start.NextAction,
 	})
@@ -159,6 +160,21 @@ func (o *Orchestrator) completeDurableWorkAttempt(
 	phase string,
 	statusMessage string,
 ) {
+	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, completedAt, terminalState, errorClass, errorMessage, phase, statusMessage, nil)
+}
+
+func (o *Orchestrator) completeDurableWorkAttemptWithMetadata(
+	ctx context.Context,
+	state *State,
+	running Running,
+	completedAt time.Time,
+	terminalState store.WorkAttemptTerminalState,
+	errorClass string,
+	errorMessage string,
+	phase string,
+	statusMessage string,
+	metadata map[string]any,
+) {
 	if o == nil || o.workAttempts == nil || running.WorkAttemptID <= 0 {
 		return
 	}
@@ -186,6 +202,7 @@ func (o *Orchestrator) completeDurableWorkAttempt(
 		GitHubRateSnapshotJSON: o.githubRateSnapshotJSON(state),
 		CIState:                workAttemptCIState(running.Issue),
 		CapacitySnapshotJSON:   o.capacitySnapshotJSON(state, running.Issue),
+		WorkerMetadataJSON:     runningWorkAttemptMetadataJSON(running, metadata),
 		MetricsJSON:            runningWorkAttemptMetricsJSON(running),
 		NextAction:             "release capacity",
 	}
@@ -366,6 +383,9 @@ func (o *Orchestrator) applyWorkAttemptCompletionSnapshot(state *State, running 
 		item.GitHubRateSnapshotJSON = completion.GitHubRateSnapshotJSON
 		item.CIState = completion.CIState
 		item.CapacitySnapshotJSON = completion.CapacitySnapshotJSON
+		if strings.TrimSpace(completion.WorkerMetadataJSON) != "" {
+			item.WorkerMetadataJSON = completion.WorkerMetadataJSON
+		}
 		item.MetricsJSON = completion.MetricsJSON
 		item.NextAction = completion.NextAction
 		state.WorkAttempts[index] = item
@@ -396,6 +416,7 @@ func (o *Orchestrator) applyWorkAttemptCompletionSnapshot(state *State, running 
 		GitHubRateSnapshotJSON: completion.GitHubRateSnapshotJSON,
 		CIState:                completion.CIState,
 		CapacitySnapshotJSON:   completion.CapacitySnapshotJSON,
+		WorkerMetadataJSON:     completion.WorkerMetadataJSON,
 		MetricsJSON:            completion.MetricsJSON,
 		NextAction:             completion.NextAction,
 	}
@@ -440,6 +461,7 @@ func telemetryWorkAttempt(attempt store.WorkAttempt, now time.Time) telemetry.Wo
 		GitHubRateSnapshotJSON: attempt.GitHubRateSnapshotJSON,
 		CIState:                attempt.CIState,
 		CapacitySnapshotJSON:   attempt.CapacitySnapshotJSON,
+		WorkerMetadataJSON:     attempt.WorkerMetadataJSON,
 		MetricsJSON:            attempt.MetricsJSON,
 		NextAction:             attempt.NextAction,
 	}
@@ -647,6 +669,20 @@ func runningWorkAttemptMetricsJSON(running Running) string {
 		"total_tokens":    running.Tokens.TotalTokens,
 		"runtime_seconds": running.Tokens.RuntimeSeconds,
 	})
+}
+
+func runningWorkAttemptMetadataJSON(running Running, metadata map[string]any) string {
+	out := map[string]any{
+		"run_mode": strings.TrimSpace(running.Mode),
+	}
+	for key, value := range metadata {
+		key = strings.TrimSpace(key)
+		if key == "" {
+			continue
+		}
+		out[key] = value
+	}
+	return marshalWorkAttemptJSON(out)
 }
 
 func schedulerDecisionWaitReason(reason string) string {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -70,6 +70,7 @@ SET status = ?,
     github_rate_snapshot_json = ?,
     ci_state = ?,
     capacity_snapshot_json = ?,
+    worker_metadata_json = ?,
     metrics_json = ?,
     next_action = ?
 WHERE id = ?
@@ -90,6 +91,7 @@ type CompleteWorkAttemptParams struct {
 	GithubRateSnapshotJson string         `json:"github_rate_snapshot_json"`
 	CiState                sql.NullString `json:"ci_state"`
 	CapacitySnapshotJson   string         `json:"capacity_snapshot_json"`
+	WorkerMetadataJson     string         `json:"worker_metadata_json"`
 	MetricsJson            string         `json:"metrics_json"`
 	NextAction             sql.NullString `json:"next_action"`
 	ID                     int64          `json:"id"`
@@ -110,6 +112,7 @@ func (q *Queries) CompleteWorkAttempt(ctx context.Context, arg CompleteWorkAttem
 		arg.GithubRateSnapshotJson,
 		arg.CiState,
 		arg.CapacitySnapshotJson,
+		arg.WorkerMetadataJson,
 		arg.MetricsJson,
 		arg.NextAction,
 		arg.ID,
@@ -1799,6 +1802,94 @@ func (q *Queries) ListRecentSchedulerDecisions(ctx context.Context, arg ListRece
 			&i.CapacitySnapshotJson,
 			&i.GithubRateSnapshotJson,
 			&i.MetadataJson,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, i)
+	}
+	if err := rows.Close(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
+const listRecentTerminalWorkAttempts = `-- name: ListRecentTerminalWorkAttempts :many
+SELECT id, project_id, issue_id, identifier, issue_url, pr_number, repo, worker_type, worker_host, lane, attempt_number, status, started_at, lease_expires_at, heartbeat_at, completed_at, terminal_state, error_class, error_message, phase, status_message, current_step, total_steps, progress_percent, current_command, wait_reason, github_rate_snapshot_json, ci_state, capacity_snapshot_json, worker_metadata_json, metrics_json, next_action
+FROM work_attempts
+WHERE completed_at IS NOT NULL
+  AND status = 'terminal'
+  AND (?1 = '' OR project_id = ?1)
+  AND (?2 = '' OR worker_type = ?2)
+  AND (
+    (?3 != '' AND issue_id = ?3)
+    OR (?4 != '' AND identifier = ?4)
+    OR (?5 != '' AND issue_url = ?5)
+  )
+ORDER BY completed_at DESC, id DESC
+LIMIT ?6
+`
+
+type ListRecentTerminalWorkAttemptsParams struct {
+	FilterProjectID  interface{} `json:"filter_project_id"`
+	FilterWorkerType interface{} `json:"filter_worker_type"`
+	IssueID          interface{} `json:"issue_id"`
+	Identifier       interface{} `json:"identifier"`
+	IssueURL         interface{} `json:"issue_url"`
+	ResultLimit      int64       `json:"result_limit"`
+}
+
+func (q *Queries) ListRecentTerminalWorkAttempts(ctx context.Context, arg ListRecentTerminalWorkAttemptsParams) ([]WorkAttempt, error) {
+	rows, err := q.db.QueryContext(ctx, listRecentTerminalWorkAttempts,
+		arg.FilterProjectID,
+		arg.FilterWorkerType,
+		arg.IssueID,
+		arg.Identifier,
+		arg.IssueURL,
+		arg.ResultLimit,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	items := []WorkAttempt{}
+	for rows.Next() {
+		var i WorkAttempt
+		if err := rows.Scan(
+			&i.ID,
+			&i.ProjectID,
+			&i.IssueID,
+			&i.Identifier,
+			&i.IssueURL,
+			&i.PrNumber,
+			&i.Repo,
+			&i.WorkerType,
+			&i.WorkerHost,
+			&i.Lane,
+			&i.AttemptNumber,
+			&i.Status,
+			&i.StartedAt,
+			&i.LeaseExpiresAt,
+			&i.HeartbeatAt,
+			&i.CompletedAt,
+			&i.TerminalState,
+			&i.ErrorClass,
+			&i.ErrorMessage,
+			&i.Phase,
+			&i.StatusMessage,
+			&i.CurrentStep,
+			&i.TotalSteps,
+			&i.ProgressPercent,
+			&i.CurrentCommand,
+			&i.WaitReason,
+			&i.GithubRateSnapshotJson,
+			&i.CiState,
+			&i.CapacitySnapshotJson,
+			&i.WorkerMetadataJson,
+			&i.MetricsJson,
+			&i.NextAction,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -72,6 +72,7 @@ type WorkAttemptStore interface {
 	RecordWorkAttemptHeartbeat(context.Context, WorkAttemptHeartbeat) error
 	CompleteWorkAttempt(context.Context, WorkAttemptCompletion) error
 	ListActiveWorkAttempts(context.Context, WorkAttemptQuery) ([]WorkAttempt, error)
+	ListRecentTerminalWorkAttempts(context.Context, WorkAttemptHistoryQuery) ([]WorkAttempt, error)
 	TimeoutExpiredWorkAttempts(context.Context, WorkAttemptTimeout) ([]WorkAttempt, error)
 	ReclaimActiveWorkAttempts(context.Context, WorkAttemptReclaim) ([]WorkAttempt, error)
 	RecordSchedulerDecision(context.Context, SchedulerDecision) (int64, error)
@@ -160,6 +161,7 @@ const (
 	WorkAttemptTerminalTimedOut   WorkAttemptTerminalState = "timed_out"
 	WorkAttemptTerminalSuperseded WorkAttemptTerminalState = "superseded"
 	WorkAttemptTerminalAbandoned  WorkAttemptTerminalState = "abandoned"
+	WorkAttemptTerminalNoProgress WorkAttemptTerminalState = "no_progress"
 )
 
 type SchedulerDecisionResult string
@@ -470,12 +472,22 @@ type WorkAttemptCompletion struct {
 	GitHubRateSnapshotJSON string
 	CIState                string
 	CapacitySnapshotJSON   string
+	WorkerMetadataJSON     string
 	MetricsJSON            string
 	NextAction             string
 }
 
 type WorkAttemptQuery struct {
 	ProjectID string
+}
+
+type WorkAttemptHistoryQuery struct {
+	ProjectID  string
+	IssueID    string
+	Identifier string
+	IssueURL   string
+	WorkerType string
+	Limit      int
 }
 
 type WorkAttemptTimeout struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -553,11 +553,12 @@ func TestWorkAttemptStoreRoundTripDecisionsAndRecovery(t *testing.T) {
 	}
 
 	if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
-		AttemptID:     attemptID,
-		CompletedAt:   base.Add(3 * time.Minute),
-		Status:        WorkAttemptStatusTerminal,
-		TerminalState: WorkAttemptTerminalSuccess,
-		Phase:         "completed",
+		AttemptID:          attemptID,
+		CompletedAt:        base.Add(3 * time.Minute),
+		Status:             WorkAttemptStatusTerminal,
+		TerminalState:      WorkAttemptTerminalNoProgress,
+		Phase:              "completed",
+		WorkerMetadataJSON: `{"completion_progress":{"outcome":"no_progress","current_head_sha":"abc123"}}`,
 	}); err != nil {
 		t.Fatalf("CompleteWorkAttempt() error = %v", err)
 	}
@@ -567,6 +568,21 @@ func TestWorkAttemptStoreRoundTripDecisionsAndRecovery(t *testing.T) {
 	}
 	if len(active) != 0 {
 		t.Fatalf("active attempts after complete = %#v, want none", active)
+	}
+	history, err := backend.ListRecentTerminalWorkAttempts(ctx, WorkAttemptHistoryQuery{
+		ProjectID:  "detent",
+		IssueID:    "issue-737",
+		WorkerType: "agent",
+		Limit:      5,
+	})
+	if err != nil {
+		t.Fatalf("ListRecentTerminalWorkAttempts() error = %v", err)
+	}
+	if len(history) != 1 || history[0].ID != attemptID || history[0].TerminalState != WorkAttemptTerminalNoProgress {
+		t.Fatalf("history = %#v, want completed no_progress attempt %d", history, attemptID)
+	}
+	if history[0].WorkerMetadataJSON != `{"completion_progress":{"outcome":"no_progress","current_head_sha":"abc123"}}` {
+		t.Fatalf("history WorkerMetadataJSON = %q", history[0].WorkerMetadataJSON)
 	}
 
 	staleID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{

--- a/internal/store/work_attempts.go
+++ b/internal/store/work_attempts.go
@@ -142,6 +142,7 @@ func (s *sqliteStore) CompleteWorkAttempt(ctx context.Context, attrs WorkAttempt
 		GithubRateSnapshotJson: jsonObjectOrDefault(attrs.GitHubRateSnapshotJSON),
 		CiState:                nullString(attrs.CIState),
 		CapacitySnapshotJson:   jsonObjectOrDefault(attrs.CapacitySnapshotJSON),
+		WorkerMetadataJson:     completionMetadataJSON(attrs.WorkerMetadataJSON),
 		MetricsJson:            jsonObjectOrDefault(attrs.MetricsJSON),
 		NextAction:             nullString(attrs.NextAction),
 		ID:                     attrs.AttemptID,
@@ -166,6 +167,25 @@ func (s *sqliteStore) ListActiveWorkAttempts(ctx context.Context, query WorkAtte
 		attempts = append(attempts, attempt)
 	}
 	return attempts, nil
+}
+
+func (s *sqliteStore) ListRecentTerminalWorkAttempts(ctx context.Context, query WorkAttemptHistoryQuery) ([]WorkAttempt, error) {
+	limit := query.Limit
+	if limit <= 0 {
+		limit = 20
+	}
+	rows, err := s.queries.ListRecentTerminalWorkAttempts(ctx, sqlc.ListRecentTerminalWorkAttemptsParams{
+		FilterProjectID:  strings.TrimSpace(query.ProjectID),
+		FilterWorkerType: strings.TrimSpace(query.WorkerType),
+		IssueID:          strings.TrimSpace(query.IssueID),
+		Identifier:       strings.TrimSpace(query.Identifier),
+		IssueURL:         strings.TrimSpace(query.IssueURL),
+		ResultLimit:      int64(limit),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("listing recent terminal work attempts: %w", err)
+	}
+	return workAttemptsFromRows(rows)
 }
 
 func (s *sqliteStore) TimeoutExpiredWorkAttempts(ctx context.Context, attrs WorkAttemptTimeout) ([]WorkAttempt, error) {
@@ -427,6 +447,10 @@ func jsonObjectOrDefault(value string) string {
 		return "{}"
 	}
 	return trimmed
+}
+
+func completionMetadataJSON(value string) string {
+	return jsonObjectOrDefault(value)
 }
 
 func boolInt64(value bool) int64 {

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -357,6 +357,7 @@ type WorkAttempt struct {
 	GitHubRateSnapshotJSON  string                    `json:"github_rate_snapshot_json,omitempty"`
 	CIState                 string                    `json:"ci_state,omitempty"`
 	CapacitySnapshotJSON    string                    `json:"capacity_snapshot_json,omitempty"`
+	WorkerMetadataJSON      string                    `json:"worker_metadata_json,omitempty"`
 	MetricsJSON             string                    `json:"metrics_json,omitempty"`
 	NextAction              string                    `json:"next_action,omitempty"`
 	Stale                   bool                      `json:"stale,omitempty"`


### PR DESCRIPTION
## Summary

- Hydrate linked PRs on implement-worker completion and classify unchanged PR signature plus clean diff as `no_progress`.
- Persist per-attempt progress decision metadata and add durable history lookup/counting for `no_progress_limit`.
- Add config, store, sticky-block, and table-driven completion tests.

Fixes #1070

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
