### PR TITLE
fix(github): tighten codex severity parsing

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -19,6 +19,90 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 )
 
+func TestPullRequestCodexReviewStateFromReviewsUsesExplicitBodySeverity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		body string
+		api  string
+		want string
+	}{
+		{
+			name: "approved narrative p1 remains approved",
+			body: "No P1 issues found — approved.",
+			api:  "APPROVED",
+			want: "APPROVED",
+		},
+		{
+			name: "approved bracket p1 escalates",
+			body: "[P1] Missing acceptance coverage.",
+			api:  "APPROVED",
+			want: "P1",
+		},
+		{
+			name: "commented line anchored p2 escalates",
+			body: "P2: Minor follow-up.",
+			api:  "COMMENTED",
+			want: "P2",
+		},
+		{
+			name: "mid sentence p1 remains api state",
+			body: "The P1 fix from last week is already present.",
+			api:  "APPROVED",
+			want: "APPROVED",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := pullRequestCodexReviewStateFromReviews([]pullRequestReview{{
+				Body:  tt.body,
+				State: tt.api,
+			}})
+			if got != tt.want {
+				t.Fatalf("pullRequestCodexReviewStateFromReviews() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPullRequestCodexReviewStateInputsFromReviews(t *testing.T) {
+	t.Parallel()
+
+	apiState, bodySeverity := pullRequestCodexReviewStateInputsFromReviews([]pullRequestReview{{
+		Body:  "[P1] Missing acceptance coverage.",
+		State: "APPROVED",
+	}})
+	if apiState != "APPROVED" || bodySeverity != "P1" {
+		t.Fatalf("state inputs = API %q body %q, want APPROVED/P1", apiState, bodySeverity)
+	}
+}
+
+func TestPullRequestCodexReviewFindingsUseExplicitBodySeverity(t *testing.T) {
+	t.Parallel()
+
+	pullRequest := pullRequestNode{
+		LatestReviews: nodeConnection[pullRequestReview]{Nodes: []pullRequestReview{
+			{
+				Body: "No P1 issues found — approved.",
+				URL:  "https://github.test/review/narrative",
+			},
+			{
+				Body: "[P1] Missing acceptance coverage.",
+				URL:  "https://github.test/review/finding",
+			},
+		}},
+	}
+
+	got := pullRequestCodexReviewFindings(pullRequest)
+	if len(got) != 1 || got[0].Body != "[P1] Missing acceptance coverage." || got[0].URL != "https://github.test/review/finding" {
+		t.Fatalf("pullRequestCodexReviewFindings() = %#v, want only explicit P1 finding", got)
+	}
+}
+
 func TestConnectorFetchCandidateIssuesNormalizesProjectItems(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/reviewseverity"
 )
 
 type issuePullRequestCandidate struct {
@@ -486,6 +487,8 @@ func attachPullRequestToIssue(issue *connector.Issue, repo pullRequestRepo, pull
 		RequiredCheckFailures:        append([]connector.PullRequestCheck(nil), pullRequest.CI.RequiredFailures...),
 		TransientFailedChecks:        append([]connector.PullRequestCheck(nil), pullRequest.CI.TransientFailures...),
 		CodexReviewState:             pullRequestCodexReviewState(pullRequest),
+		CodexReviewAPIState:          pullRequestCodexReviewAPIState(pullRequest),
+		CodexReviewBodySeverity:      pullRequestCodexReviewBodySeverity(pullRequest),
 		CodexReviewSubmittedAt:       pullRequestCodexReviewSubmittedAt(pullRequest),
 		CodexReviewFindings:          pullRequestCodexReviewFindings(pullRequest),
 		LatestCodexReviewState:       pullRequestLatestCodexReviewState(pullRequest),
@@ -825,23 +828,48 @@ func pullRequestLatestCodexReviewState(pullRequest pullRequestNode) string {
 }
 
 func pullRequestCodexReviewStateFromReviews(reviews []pullRequestReview) string {
-	hasP2 := false
+	reviewState, bodySeverity := pullRequestCodexReviewStateInputsFromReviews(reviews)
+	if bodySeverity != "" {
+		return bodySeverity
+	}
+	return reviewState
+}
+
+func pullRequestCodexReviewAPIState(pullRequest pullRequestNode) string {
+	return pullRequestCodexReviewAPIStateFromReviews(pullRequest.LatestReviews.Nodes)
+}
+
+func pullRequestCodexReviewBodySeverity(pullRequest pullRequestNode) string {
+	return pullRequestCodexReviewBodySeverityFromReviews(pullRequest.LatestReviews.Nodes)
+}
+
+func pullRequestCodexReviewAPIStateFromReviews(reviews []pullRequestReview) string {
+	reviewState, _ := pullRequestCodexReviewStateInputsFromReviews(reviews)
+	return reviewState
+}
+
+func pullRequestCodexReviewBodySeverityFromReviews(reviews []pullRequestReview) string {
+	_, bodySeverity := pullRequestCodexReviewStateInputsFromReviews(reviews)
+	return bodySeverity
+}
+
+func pullRequestCodexReviewStateInputsFromReviews(reviews []pullRequestReview) (string, string) {
+	bodySeverity := ""
 	reviewState := ""
 	for _, review := range reviews {
-		if containsReviewSeverity(review.Body, "P1") {
-			return "P1"
-		}
-		if containsReviewSeverity(review.Body, "P2") {
-			hasP2 = true
+		switch reviewBodySeverity(review.Body) {
+		case "P1":
+			bodySeverity = "P1"
+		case "P2":
+			if bodySeverity == "" {
+				bodySeverity = "P2"
+			}
 		}
 		if state := strings.ToUpper(strings.TrimSpace(review.State)); state != "" {
 			reviewState = state
 		}
 	}
-	if hasP2 {
-		return "P2"
-	}
-	return reviewState
+	return reviewState, bodySeverity
 }
 
 func pullRequestCodexReviewSubmittedAt(pullRequest pullRequestNode) *time.Time {
@@ -890,15 +918,11 @@ func pullRequestCodexReviewFindings(pullRequest pullRequestNode) []connector.Pul
 }
 
 func containsReviewSeverity(body string, severity string) bool {
-	body = strings.ToUpper(body)
-	severity = strings.ToUpper(strings.TrimSpace(severity))
-	if body == "" || severity == "" {
-		return false
-	}
-	return strings.Contains(body, "["+severity+"]") ||
-		strings.Contains(body, severity+" BADGE") ||
-		strings.Contains(body, severity+":") ||
-		strings.Contains(body, severity+" ")
+	return reviewseverity.Contains(body, severity)
+}
+
+func reviewBodySeverity(body string) string {
+	return reviewseverity.BodySeverity(body)
 }
 
 func pullRequestCheckNames(checks []connector.PullRequestCheck) []string {

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -68,6 +68,8 @@ type PullRequest struct {
 	RequiredCheckFailures        []PullRequestCheck   `json:"required_check_failures,omitempty" yaml:"required_check_failures,omitempty"`
 	TransientFailedChecks        []PullRequestCheck   `json:"transient_failed_checks,omitempty" yaml:"transient_failed_checks,omitempty"`
 	CodexReviewState             string               `json:"codex_review_state,omitempty" yaml:"codex_review_state,omitempty"`
+	CodexReviewAPIState          string               `json:"codex_review_api_state,omitempty" yaml:"codex_review_api_state,omitempty"`
+	CodexReviewBodySeverity      string               `json:"codex_review_body_severity,omitempty" yaml:"codex_review_body_severity,omitempty"`
 	CodexReviewSubmittedAt       *time.Time           `json:"codex_review_submitted_at,omitempty" yaml:"codex_review_submitted_at,omitempty"`
 	CodexReviewFindings          []PullRequestFinding `json:"codex_review_findings,omitempty" yaml:"codex_review_findings,omitempty"`
 	LatestCodexReviewState       string               `json:"latest_codex_review_state,omitempty" yaml:"latest_codex_review_state,omitempty"`

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -2071,6 +2071,7 @@ func (o *Orchestrator) logAutoPromoteDecision(issue connector.Issue, decision Au
 				"ci_anomaly_action", "treated_completed_successful_check_runs_as_passed",
 			)
 		}
+		attrs = appendPullRequestReviewDisagreementAttrs(attrs, issue.PullRequest)
 	}
 	if decision.QuietRemaining > 0 {
 		attrs = append(attrs, "quiet_remaining", decision.QuietRemaining)

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -1214,6 +1214,18 @@ func TestLogAutoPromoteDecisionIncludesHydrationReasons(t *testing.T) {
 				"ci_anomaly_action=treated_completed_successful_check_runs_as_passed",
 			},
 		},
+		{
+			name: "review state disagreement",
+			pullRequest: &connector.PullRequest{
+				Number:                  77,
+				CodexReviewAPIState:     "APPROVED",
+				CodexReviewBodySeverity: "P1",
+			},
+			want: []string{
+				"review_api_state=APPROVED",
+				"review_body_severity=P1",
+			},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/orchestrator/plan_review.go
+++ b/internal/orchestrator/plan_review.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/reviewseverity"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -296,15 +297,7 @@ func planReviewMarkdownHeadingTitle(line string) (string, bool) {
 }
 
 func containsReviewSeverity(body string, severity string) bool {
-	body = strings.ToUpper(body)
-	severity = strings.ToUpper(strings.TrimSpace(severity))
-	if severity == "" {
-		return false
-	}
-	return strings.Contains(body, "["+severity+"]") ||
-		strings.Contains(body, severity+" BADGE") ||
-		strings.Contains(body, severity+" FINDING") ||
-		strings.Contains(body, " "+severity+" ")
+	return reviewseverity.Contains(body, severity)
 }
 
 func (o *Orchestrator) applyPlanReviewDecision(
@@ -367,12 +360,28 @@ func (o *Orchestrator) logPlanReviewDecision(issue connector.Issue, decision gat
 		"action", decision.Action,
 		"reason", decision.Reason,
 	}
+	attrs = appendPullRequestReviewDisagreementAttrs(attrs, issue.PullRequest)
 	if targetState != "" {
 		attrs = append(attrs, "target_state", targetState)
 		o.logger.Info("plan review decision", attrs...)
 		return
 	}
 	o.logger.Debug("plan review decision", attrs...)
+}
+
+func appendPullRequestReviewDisagreementAttrs(attrs []any, pullRequest *connector.PullRequest) []any {
+	if pullRequest == nil {
+		return attrs
+	}
+	apiState := strings.ToUpper(strings.TrimSpace(pullRequest.CodexReviewAPIState))
+	bodySeverity := strings.ToUpper(strings.TrimSpace(pullRequest.CodexReviewBodySeverity))
+	if apiState == "" || bodySeverity == "" || apiState == bodySeverity {
+		return attrs
+	}
+	return append(attrs,
+		"review_api_state", apiState,
+		"review_body_severity", bodySeverity,
+	)
 }
 
 func planReviewComment(stop string, summary gate.Summary, decision gate.Decision, targetState string) string {

--- a/internal/orchestrator/plan_review_test.go
+++ b/internal/orchestrator/plan_review_test.go
@@ -1,0 +1,97 @@
+package orchestrator
+
+import (
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
+)
+
+func TestPlanReviewContainsReviewSeverityUsesExplicitBadges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		severity string
+		want     bool
+	}{
+		{
+			name:     "bracketed p1 anywhere",
+			body:     "Automated review found [P1] missing validation.",
+			severity: "P1",
+			want:     true,
+		},
+		{
+			name:     "line anchored colon",
+			body:     "P1: Missing rollback path.",
+			severity: "P1",
+			want:     true,
+		},
+		{
+			name:     "list prefixed p2 badge",
+			body:     "- P2 BADGE naming concern.",
+			severity: "P2",
+			want:     true,
+		},
+		{
+			name:     "narrative p1 negative",
+			body:     "No P1 issues found — approved.",
+			severity: "P1",
+			want:     false,
+		},
+		{
+			name:     "mid sentence p1 fix",
+			body:     "The P1 fix from last week is already present.",
+			severity: "P1",
+			want:     false,
+		},
+		{
+			name:     "p2 finding prose no longer matches",
+			body:     "P2 finding count is zero.",
+			severity: "P2",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := containsReviewSeverity(tt.body, tt.severity)
+			if got != tt.want {
+				t.Fatalf("containsReviewSeverity(%q, %q) = %t, want %t", tt.body, tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPlanReviewDecisionLogsReviewStateDisagreement(t *testing.T) {
+	t.Parallel()
+
+	var logs strings.Builder
+	orch := &Orchestrator{
+		logger: slog.New(slog.NewTextHandler(&logs, &slog.HandlerOptions{Level: slog.LevelDebug})),
+	}
+	issue := connector.Issue{
+		ID:         "issue-1072",
+		Identifier: "digitaldrywood/detent#1072",
+		PullRequest: &connector.PullRequest{
+			CodexReviewAPIState:     "APPROVED",
+			CodexReviewBodySeverity: "P1",
+		},
+	}
+
+	orch.logPlanReviewDecision(issue, gate.Decision{
+		Action: gate.ActionRework,
+		Reason: gate.ReasonP1Findings,
+	}, "Rework")
+
+	for _, fragment := range []string{"review_api_state=APPROVED", "review_body_severity=P1"} {
+		if !strings.Contains(logs.String(), fragment) {
+			t.Fatalf("logs %q missing fragment %q", logs.String(), fragment)
+		}
+	}
+}

--- a/internal/reviewseverity/reviewseverity.go
+++ b/internal/reviewseverity/reviewseverity.go
@@ -1,0 +1,89 @@
+package reviewseverity
+
+import "strings"
+
+func Contains(body string, severity string) bool {
+	severity = strings.ToUpper(strings.TrimSpace(severity))
+	if strings.TrimSpace(body) == "" || severity == "" {
+		return false
+	}
+	bodyUpper := strings.ToUpper(body)
+	if strings.Contains(bodyUpper, "["+severity+"]") {
+		return true
+	}
+	for line := range strings.SplitSeq(body, "\n") {
+		if lineContains(strings.ToUpper(trimLinePrefix(line)), severity) {
+			return true
+		}
+	}
+	return false
+}
+
+func BodySeverity(body string) string {
+	if Contains(body, "P1") {
+		return "P1"
+	}
+	if Contains(body, "P2") {
+		return "P2"
+	}
+	return ""
+}
+
+func trimLinePrefix(line string) string {
+	line = strings.TrimSpace(line)
+	for {
+		trimmed := strings.TrimSpace(trimLineMarker(line))
+		if trimmed == line {
+			return line
+		}
+		line = trimmed
+	}
+}
+
+func trimLineMarker(line string) string {
+	if strings.HasPrefix(line, "#") {
+		index := 0
+		for index < len(line) && line[index] == '#' {
+			index++
+		}
+		if index < len(line) && isWhitespace(line[index]) {
+			return line[index+1:]
+		}
+	}
+	if len(line) >= 2 {
+		switch line[0] {
+		case '-', '*', '+':
+			if isWhitespace(line[1]) {
+				return line[2:]
+			}
+		}
+	}
+	index := 0
+	for index < len(line) && line[index] >= '0' && line[index] <= '9' {
+		index++
+	}
+	if index > 0 && index+1 < len(line) && (line[index] == '.' || line[index] == ')') && isWhitespace(line[index+1]) {
+		return line[index+2:]
+	}
+	return line
+}
+
+func lineContains(line string, severity string) bool {
+	if strings.HasPrefix(line, severity+":") {
+		return true
+	}
+	badge := severity + " BADGE"
+	return strings.HasPrefix(line, badge) && tokenBoundary(line, len(badge))
+}
+
+func tokenBoundary(line string, index int) bool {
+	if index >= len(line) {
+		return true
+	}
+	char := line[index]
+	return (char < 'A' || char > 'Z') && (char < '0' || char > '9') && char != '_'
+}
+
+func isWhitespace(char byte) bool {
+	return char == ' ' || char == '\t'
+}

--- a/internal/reviewseverity/reviewseverity_test.go
+++ b/internal/reviewseverity/reviewseverity_test.go
@@ -1,0 +1,101 @@
+package reviewseverity
+
+import "testing"
+
+func TestContainsUsesExplicitBadges(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		body     string
+		severity string
+		want     bool
+	}{
+		{
+			name:     "bracketed p1 anywhere",
+			body:     "Automated review found [P1] missing validation.",
+			severity: "P1",
+			want:     true,
+		},
+		{
+			name:     "bracketed p2 lowercase",
+			body:     "Automated review found [p2] naming concerns.",
+			severity: "P2",
+			want:     true,
+		},
+		{
+			name:     "line anchored colon",
+			body:     "P1: Missing rollback path.",
+			severity: "P1",
+			want:     true,
+		},
+		{
+			name:     "heading prefixed colon",
+			body:     "### P1: Missing rollback path.",
+			severity: "P1",
+			want:     true,
+		},
+		{
+			name:     "list prefixed badge",
+			body:     "- P1 BADGE: Missing rollback path.",
+			severity: "P1",
+			want:     true,
+		},
+		{
+			name:     "ordered list prefixed p2 badge",
+			body:     "1. P2 BADGE naming concern.",
+			severity: "P2",
+			want:     true,
+		},
+		{
+			name:     "narrative p1 negative",
+			body:     "No P1 issues found — approved.",
+			severity: "P1",
+			want:     false,
+		},
+		{
+			name:     "mid sentence p1 fix",
+			body:     "The P1 fix from last week is already present.",
+			severity: "P1",
+			want:     false,
+		},
+		{
+			name:     "mid sentence badge prose",
+			body:     "This mentions P1 BADGE in prose.",
+			severity: "P1",
+			want:     false,
+		},
+		{
+			name:     "p1 finding prose no longer matches",
+			body:     "P1 finding count is zero.",
+			severity: "P1",
+			want:     false,
+		},
+		{
+			name:     "p2 finding prose no longer matches",
+			body:     "P2 finding count is zero.",
+			severity: "P2",
+			want:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := Contains(tt.body, tt.severity)
+			if got != tt.want {
+				t.Fatalf("Contains(%q, %q) = %t, want %t", tt.body, tt.severity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestBodySeverityPrioritizesP1(t *testing.T) {
+	t.Parallel()
+
+	got := BodySeverity("[P2] Minor concern.\n- P1 BADGE: Blocking concern.")
+	if got != "P1" {
+		t.Fatalf("BodySeverity() = %q, want P1", got)
+	}
+}


### PR DESCRIPTION
## Summary

- Tighten Codex review severity parsing to explicit bracket badges or line-anchored severity verdicts, rejecting narrative P1/P2 prose.
- Preserve body severity escalation over API review state while surfacing `review_api_state` and `review_body_severity` when they disagree.
- Add a shared parser package plus focused connector, plan-review, and decision-log tests.

Fixes #1072

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual changes.

## Test Plan

- [x] `go test ./internal/reviewseverity ./internal/connector/github ./internal/orchestrator`
- [x] `make check`
