### PR TITLE
fix(linear): harden assignee lookup

### DIFF
--- a/internal/connector/linear/connector_test.go
+++ b/internal/connector/linear/connector_test.go
@@ -519,30 +519,43 @@ func TestConnectorSetAssigneeResolvesUserAndUpdatesIssue(t *testing.T) {
 	tests := []struct {
 		name           string
 		login          string
-		users          []map[string]any
+		wantLookups    []string
+		userResponses  map[string][]map[string]any
 		wantAssigneeID string
 	}{
 		{
-			name:  "email match",
-			login: "worker@example.com",
-			users: []map[string]any{
-				linearUserFixture("user-email", "Worker Email", "worker", "worker@example.com"),
+			name:        "email match",
+			login:       "worker@example.com",
+			wantLookups: []string{"email"},
+			userResponses: map[string][]map[string]any{
+				"email": {
+					linearUserFixture("user-email", "Worker Email", "worker", "worker@example.com"),
+				},
 			},
 			wantAssigneeID: "user-email",
 		},
 		{
-			name:  "display name case insensitive match",
-			login: "WORKER ONE",
-			users: []map[string]any{
-				linearUserFixture("user-display", "Worker Name", "worker one", "worker-name@example.com"),
+			name:        "display name case insensitive match",
+			login:       "WORKER ONE",
+			wantLookups: []string{"email", "displayName"},
+			userResponses: map[string][]map[string]any{
+				"email": nil,
+				"displayName": {
+					linearUserFixture("user-display", "Worker Name", "worker one", "worker-name@example.com"),
+				},
 			},
 			wantAssigneeID: "user-display",
 		},
 		{
-			name:  "name case insensitive match",
-			login: "WORKER NAME",
-			users: []map[string]any{
-				linearUserFixture("user-name", "worker name", "worker", "worker-name@example.com"),
+			name:        "name case insensitive match",
+			login:       "WORKER NAME",
+			wantLookups: []string{"email", "displayName", "name"},
+			userResponses: map[string][]map[string]any{
+				"email":       nil,
+				"displayName": nil,
+				"name": {
+					linearUserFixture("user-name", "worker name", "worker", "worker-name@example.com"),
+				},
 			},
 			wantAssigneeID: "user-name",
 		},
@@ -554,35 +567,29 @@ func TestConnectorSetAssigneeResolvesUserAndUpdatesIssue(t *testing.T) {
 			t.Parallel()
 
 			var mu sync.Mutex
-			requests := []linearGraphQLRequest{}
+			lookups := []string{}
+			mutationAssigneeID := ""
 			server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
-				mu.Lock()
-				requests = append(requests, request)
-				requestNumber := len(requests)
-				mu.Unlock()
-
-				switch requestNumber {
-				case 1:
-					if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
-						t.Fatalf("query = %q, want user lookup query", request.Query)
-					}
-					assertLinearUserFilter(t, request.Variables["filter"], tt.login)
-					return linearUsersResponse(tt.users)
-				case 2:
-					if !strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") || !strings.Contains(request.Query, "issueUpdate") {
-						t.Fatalf("query = %q, want issue update assignee mutation", request.Query)
-					}
+				if strings.Contains(request.Query, "DetentLinearUserByLogin") {
+					lookup := linearUserLookupFilterKind(t, request.Variables["filter"], tt.login)
+					mu.Lock()
+					lookups = append(lookups, lookup)
+					mu.Unlock()
+					return linearUsersResponse(tt.userResponses[lookup])
+				}
+				if strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") {
 					if request.Variables["issueId"] != "LIN-123" {
 						t.Fatalf("issueId variable = %#v, want LIN-123", request.Variables["issueId"])
 					}
-					if request.Variables["assigneeId"] != tt.wantAssigneeID {
-						t.Fatalf("assigneeId variable = %#v, want %s", request.Variables["assigneeId"], tt.wantAssigneeID)
-					}
+					assigneeID, _ := request.Variables["assigneeId"].(string)
+					mu.Lock()
+					mutationAssigneeID = assigneeID
+					mu.Unlock()
 					return linearIssueUpdateResponse(true)
-				default:
-					t.Fatalf("request count = %d, want 2", requestNumber)
-					return nil
 				}
+
+				t.Fatalf("query = %q, want user lookup query or issue update assignee mutation", request.Query)
+				return nil
 			})
 
 			c := newLinearTestConnector(t, server.URL)
@@ -591,10 +598,104 @@ func TestConnectorSetAssigneeResolvesUserAndUpdatesIssue(t *testing.T) {
 			}
 
 			mu.Lock()
-			gotRequests := len(requests)
+			gotLookups := append([]string(nil), lookups...)
+			gotMutationAssigneeID := mutationAssigneeID
 			mu.Unlock()
-			if gotRequests != 2 {
-				t.Fatalf("request count = %d, want 2", gotRequests)
+			if !reflect.DeepEqual(gotLookups, tt.wantLookups) {
+				t.Fatalf("user lookups = %#v, want %#v", gotLookups, tt.wantLookups)
+			}
+			if gotMutationAssigneeID != tt.wantAssigneeID {
+				t.Fatalf("mutation assignee ID = %q, want %q", gotMutationAssigneeID, tt.wantAssigneeID)
+			}
+		})
+	}
+}
+
+func TestConnectorSetAssigneeFindsExactMatchesBeforeLowerPriorityNames(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		login          string
+		wantLookups    []string
+		userResponses  map[string][]map[string]any
+		wantAssigneeID string
+	}{
+		{
+			name:        "email match",
+			login:       "worker@example.com",
+			wantLookups: []string{"email"},
+			userResponses: map[string][]map[string]any{
+				"email": {
+					linearUserFixture("user-email", "Worker Email", "worker", "worker@example.com"),
+				},
+				"or": {
+					linearUserFixture("user-name-1", "worker@example.com", "Worker One", "worker1@example.com"),
+					linearUserFixture("user-name-2", "WORKER@example.com", "Worker Two", "worker2@example.com"),
+				},
+			},
+			wantAssigneeID: "user-email",
+		},
+		{
+			name:        "display name match",
+			login:       "Worker",
+			wantLookups: []string{"email", "displayName"},
+			userResponses: map[string][]map[string]any{
+				"email": nil,
+				"displayName": {
+					linearUserFixture("user-display", "worker-name", "worker", "worker-name@example.com"),
+				},
+				"or": {
+					linearUserFixture("user-name-1", "worker", "Worker One", "worker1@example.com"),
+					linearUserFixture("user-name-2", "WORKER", "Worker Two", "worker2@example.com"),
+				},
+			},
+			wantAssigneeID: "user-display",
+		},
+	}
+
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var mu sync.Mutex
+			lookups := []string{}
+			mutationAssigneeID := ""
+			server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
+				if strings.Contains(request.Query, "DetentLinearUserByLogin") {
+					lookup := linearUserLookupFilterKind(t, request.Variables["filter"], tt.login)
+					mu.Lock()
+					lookups = append(lookups, lookup)
+					mu.Unlock()
+					return linearUsersResponse(tt.userResponses[lookup])
+				}
+				if strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") {
+					assigneeID, _ := request.Variables["assigneeId"].(string)
+					mu.Lock()
+					mutationAssigneeID = assigneeID
+					mu.Unlock()
+					return linearIssueUpdateResponse(true)
+				}
+
+				t.Fatalf("query = %q, want user lookup query or issue update assignee mutation", request.Query)
+				return nil
+			})
+
+			c := newLinearTestConnector(t, server.URL)
+			if err := c.SetAssignee(context.Background(), "LIN-123", tt.login); err != nil {
+				t.Fatalf("SetAssignee() error = %v", err)
+			}
+
+			mu.Lock()
+			gotLookups := append([]string(nil), lookups...)
+			gotMutationAssigneeID := mutationAssigneeID
+			mu.Unlock()
+			if !reflect.DeepEqual(gotLookups, tt.wantLookups) {
+				t.Fatalf("user lookups = %#v, want %#v", gotLookups, tt.wantLookups)
+			}
+			if gotMutationAssigneeID != tt.wantAssigneeID {
+				t.Fatalf("mutation assignee ID = %q, want %q", gotMutationAssigneeID, tt.wantAssigneeID)
 			}
 		})
 	}
@@ -637,8 +738,8 @@ func TestConnectorSetAssigneeErrors(t *testing.T) {
 			issueID: "LIN-123",
 			login:   "unknown",
 			respond: func(t *testing.T, requestNumber int, request linearGraphQLRequest) any {
-				if requestNumber != 1 {
-					t.Fatalf("request count = %d, want 1", requestNumber)
+				if requestNumber > 3 {
+					t.Fatalf("request count = %d, want at most 3", requestNumber)
 				}
 				if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
 					t.Fatalf("query = %q, want user lookup query", request.Query)
@@ -646,26 +747,32 @@ func TestConnectorSetAssigneeErrors(t *testing.T) {
 				return linearUsersResponse(nil)
 			},
 			wantErr:      ErrUserNotFound,
-			wantRequests: 1,
+			wantRequests: 3,
 		},
 		{
 			name:    "ambiguous user",
 			issueID: "LIN-123",
 			login:   "worker",
 			respond: func(t *testing.T, requestNumber int, request linearGraphQLRequest) any {
-				if requestNumber != 1 {
-					t.Fatalf("request count = %d, want 1", requestNumber)
-				}
 				if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
 					t.Fatalf("query = %q, want user lookup query", request.Query)
 				}
-				return linearUsersResponse([]map[string]any{
-					linearUserFixture("user-1", "Worker One", "worker", "worker1@example.com"),
-					linearUserFixture("user-2", "Worker Two", "WORKER", "worker2@example.com"),
-				})
+				lookup := linearUserLookupFilterKind(t, request.Variables["filter"], "worker")
+				switch lookup {
+				case "email":
+					return linearUsersResponse(nil)
+				case "displayName":
+					return linearUsersResponse([]map[string]any{
+						linearUserFixture("user-1", "Worker One", "worker", "worker1@example.com"),
+						linearUserFixture("user-2", "Worker Two", "WORKER", "worker2@example.com"),
+					})
+				default:
+					t.Fatalf("request count = %d, lookup = %q, want email then displayName", requestNumber, lookup)
+					return nil
+				}
 			},
 			wantErr:      ErrUserAmbiguous,
-			wantRequests: 1,
+			wantRequests: 2,
 		},
 		{
 			name:    "failed mutation",
@@ -677,21 +784,34 @@ func TestConnectorSetAssigneeErrors(t *testing.T) {
 					if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
 						t.Fatalf("query = %q, want user lookup query", request.Query)
 					}
+					lookup := linearUserLookupFilterKind(t, request.Variables["filter"], "worker")
+					if lookup != "email" {
+						t.Fatalf("lookup = %q, want email", lookup)
+					}
+					return linearUsersResponse(nil)
+				case 2:
+					if !strings.Contains(request.Query, "DetentLinearUserByLogin") {
+						t.Fatalf("query = %q, want user lookup query", request.Query)
+					}
+					lookup := linearUserLookupFilterKind(t, request.Variables["filter"], "worker")
+					if lookup != "displayName" {
+						t.Fatalf("lookup = %q, want displayName", lookup)
+					}
 					return linearUsersResponse([]map[string]any{
 						linearUserFixture("user-1", "Worker One", "worker", "worker@example.com"),
 					})
-				case 2:
+				case 3:
 					if !strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") {
 						t.Fatalf("query = %q, want issue update assignee mutation", request.Query)
 					}
 					return linearIssueUpdateResponse(false)
 				default:
-					t.Fatalf("request count = %d, want 2", requestNumber)
+					t.Fatalf("request count = %d, want 3", requestNumber)
 					return nil
 				}
 			},
 			wantErr:       ErrIssueUpdateFailed,
-			wantRequests:  2,
+			wantRequests:  3,
 			wantMutations: 1,
 		},
 	}
@@ -740,18 +860,26 @@ func TestConnectorSetAssigneeCachesResolvedUser(t *testing.T) {
 	t.Parallel()
 
 	var mu sync.Mutex
-	userQueries := 0
+	lookups := []string{}
 	mutationAssigneeIDs := []string{}
 	server := linearTestServer(t, func(t *testing.T, request linearGraphQLRequest) any {
 		mu.Lock()
 		defer mu.Unlock()
 
 		if strings.Contains(request.Query, "DetentLinearUserByLogin") {
-			userQueries++
-			assertLinearUserFilter(t, request.Variables["filter"], "Worker")
-			return linearUsersResponse([]map[string]any{
-				linearUserFixture("user-worker", "Worker Name", "Worker", "worker@example.com"),
-			})
+			lookup := linearUserLookupFilterKind(t, request.Variables["filter"], "Worker")
+			lookups = append(lookups, lookup)
+			switch lookup {
+			case "email":
+				return linearUsersResponse(nil)
+			case "displayName":
+				return linearUsersResponse([]map[string]any{
+					linearUserFixture("user-worker", "Worker Name", "Worker", "worker@example.com"),
+				})
+			default:
+				t.Fatalf("lookup = %q, want email then displayName", lookup)
+				return nil
+			}
 		}
 		if strings.Contains(request.Query, "DetentLinearIssueUpdateAssignee") {
 			assigneeID, _ := request.Variables["assigneeId"].(string)
@@ -772,11 +900,12 @@ func TestConnectorSetAssigneeCachesResolvedUser(t *testing.T) {
 	}
 
 	mu.Lock()
-	gotUserQueries := userQueries
+	gotLookups := append([]string(nil), lookups...)
 	gotMutationAssigneeIDs := append([]string(nil), mutationAssigneeIDs...)
 	mu.Unlock()
-	if gotUserQueries != 1 {
-		t.Fatalf("user query count = %d, want 1", gotUserQueries)
+	wantLookups := []string{"email", "displayName"}
+	if !reflect.DeepEqual(gotLookups, wantLookups) {
+		t.Fatalf("user lookups = %#v, want %#v", gotLookups, wantLookups)
 	}
 	wantMutationAssigneeIDs := []string{"user-worker", "user-worker"}
 	if !reflect.DeepEqual(gotMutationAssigneeIDs, wantMutationAssigneeIDs) {
@@ -1020,19 +1149,28 @@ func linearUserFixture(id string, name string, displayName string, email string)
 	}
 }
 
-func assertLinearUserFilter(t *testing.T, got any, login string) {
+func linearUserLookupFilterKind(t *testing.T, got any, login string) string {
 	t.Helper()
 
-	want := map[string]any{
-		"or": []any{
-			map[string]any{"email": map[string]any{"eq": login}},
-			map[string]any{"displayName": map[string]any{"eqIgnoreCase": login}},
-			map[string]any{"name": map[string]any{"eqIgnoreCase": login}},
+	filters := map[string]any{
+		"email":       map[string]any{"email": map[string]any{"eq": login}},
+		"displayName": map[string]any{"displayName": map[string]any{"eqIgnoreCase": login}},
+		"name":        map[string]any{"name": map[string]any{"eqIgnoreCase": login}},
+		"or": map[string]any{
+			"or": []any{
+				map[string]any{"email": map[string]any{"eq": login}},
+				map[string]any{"displayName": map[string]any{"eqIgnoreCase": login}},
+				map[string]any{"name": map[string]any{"eqIgnoreCase": login}},
+			},
 		},
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Fatalf("filter variable = %#v, want %#v", got, want)
+	for name, filter := range filters {
+		if reflect.DeepEqual(got, filter) {
+			return name
+		}
 	}
+	t.Fatalf("filter variable = %#v, want one of %#v", got, filters)
+	return ""
 }
 
 func linearIssueUpdateResponse(success bool) map[string]any {

--- a/internal/connector/linear/users.go
+++ b/internal/connector/linear/users.go
@@ -29,11 +29,7 @@ func (c *Connector) resolveUserID(ctx context.Context, login string) (string, er
 		return userID, nil
 	}
 
-	users, err := c.fetchUsersByLogin(ctx, login)
-	if err != nil {
-		return "", fmt.Errorf("resolve linear user: %w", err)
-	}
-	userID, err := selectLinearUserID(login, users)
+	userID, err := c.resolveUncachedUserID(ctx, login)
 	if err != nil {
 		return "", err
 	}
@@ -60,59 +56,86 @@ func (c *Connector) cacheUserID(loginKey string, userID string) {
 	c.userIDByLogin[loginKey] = userID
 }
 
-func (c *Connector) fetchUsersByLogin(ctx context.Context, login string) ([]linearResolvedUser, error) {
+func (c *Connector) resolveUncachedUserID(ctx context.Context, login string) (string, error) {
+	for _, lookup := range linearUserLookups(login) {
+		users, err := c.fetchUsersByFilter(ctx, lookup.filter)
+		if err != nil {
+			return "", fmt.Errorf("resolve linear user: %w", err)
+		}
+		userID, ok, err := selectLinearUserID(login, users, lookup.matches)
+		if err != nil {
+			return "", err
+		}
+		if ok {
+			return userID, nil
+		}
+	}
+
+	return "", fmt.Errorf("%w: %s", ErrUserNotFound, login)
+}
+
+func (c *Connector) fetchUsersByFilter(ctx context.Context, filter map[string]any) ([]linearResolvedUser, error) {
 	var response struct {
 		Users struct {
 			Nodes []linearResolvedUser `json:"nodes"`
 		} `json:"users"`
 	}
 	if err := c.client.GraphQL(ctx, usersByLoginQuery, map[string]any{
-		"filter": linearUserLoginFilter(login),
+		"filter": filter,
 	}, &response); err != nil {
 		return nil, err
 	}
 	return response.Users.Nodes, nil
 }
 
-func linearUserLoginFilter(login string) map[string]any {
-	return map[string]any{
-		"or": []map[string]any{
-			{"email": map[string]any{"eq": login}},
-			{"displayName": map[string]any{"eqIgnoreCase": login}},
-			{"name": map[string]any{"eqIgnoreCase": login}},
+func linearUserLookups(login string) []linearUserLookup {
+	return []linearUserLookup{
+		{
+			filter: linearUserEmailFilter(login),
+			matches: func(user linearResolvedUser) bool {
+				return strings.TrimSpace(user.Email) == login
+			},
+		},
+		{
+			filter: linearUserDisplayNameFilter(login),
+			matches: func(user linearResolvedUser) bool {
+				return strings.EqualFold(strings.TrimSpace(user.DisplayName), login)
+			},
+		},
+		{
+			filter: linearUserNameFilter(login),
+			matches: func(user linearResolvedUser) bool {
+				return strings.EqualFold(strings.TrimSpace(user.Name), login)
+			},
 		},
 	}
 }
 
-func selectLinearUserID(login string, users []linearResolvedUser) (string, error) {
-	matchers := []func(linearResolvedUser) bool{
-		func(user linearResolvedUser) bool {
-			return strings.TrimSpace(user.Email) == login
-		},
-		func(user linearResolvedUser) bool {
-			return strings.EqualFold(strings.TrimSpace(user.DisplayName), login)
-		},
-		func(user linearResolvedUser) bool {
-			return strings.EqualFold(strings.TrimSpace(user.Name), login)
-		},
-	}
+func linearUserEmailFilter(login string) map[string]any {
+	return map[string]any{"email": map[string]any{"eq": login}}
+}
 
-	for _, matches := range matchers {
-		userIDs, err := matchingUserIDs(users, matches)
-		if err != nil {
-			return "", err
-		}
-		switch len(userIDs) {
-		case 0:
-			continue
-		case 1:
-			return userIDs[0], nil
-		default:
-			return "", fmt.Errorf("%w: %s", ErrUserAmbiguous, login)
-		}
-	}
+func linearUserDisplayNameFilter(login string) map[string]any {
+	return map[string]any{"displayName": map[string]any{"eqIgnoreCase": login}}
+}
 
-	return "", fmt.Errorf("%w: %s", ErrUserNotFound, login)
+func linearUserNameFilter(login string) map[string]any {
+	return map[string]any{"name": map[string]any{"eqIgnoreCase": login}}
+}
+
+func selectLinearUserID(login string, users []linearResolvedUser, matches func(linearResolvedUser) bool) (string, bool, error) {
+	userIDs, err := matchingUserIDs(users, matches)
+	if err != nil {
+		return "", false, err
+	}
+	switch len(userIDs) {
+	case 0:
+		return "", false, nil
+	case 1:
+		return userIDs[0], true, nil
+	default:
+		return "", false, fmt.Errorf("%w: %s", ErrUserAmbiguous, login)
+	}
 }
 
 func matchingUserIDs(users []linearResolvedUser, matches func(linearResolvedUser) bool) ([]string, error) {
@@ -144,4 +167,9 @@ type linearResolvedUser struct {
 	Name        string `json:"name"`
 	DisplayName string `json:"displayName"`
 	Email       string `json:"email"`
+}
+
+type linearUserLookup struct {
+	filter  map[string]any
+	matches func(linearResolvedUser) bool
 }


### PR DESCRIPTION
## Summary

- Resolve Linear assignees with priority-specific email, display-name, then name lookups.
- Add coverage for exact email/display-name matches that would be hidden by lower-priority name results under the old OR lookup.

Fixes #1061

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test ./internal/connector/linear -count=1`
- [x] `make check`