### PR TITLE
Open projects on kanban board

### DIFF
--- a/internal/cli/dev_runtime_e2e_test.go
+++ b/internal/cli/dev_runtime_e2e_test.go
@@ -80,7 +80,7 @@ func TestStartKanbanDemoRendersAndAppliesSafeActions(t *testing.T) {
 	fleetBody := waitForDashboardCondition(t, dashboardURL+"/", done, "fleet board demo", func(body string) bool {
 		return strings.Contains(body, `id="board-lanes"`) &&
 			strings.Contains(body, `data-board-key="fleet"`) &&
-			strings.Contains(body, `href="/projects/`+projectID+`"`) &&
+			strings.Contains(body, `href="/projects/`+projectID+`/kanban"`) &&
 			strings.Contains(body, "Kanban demo backlog intake") &&
 			strings.Contains(body, "Kanban demo todo ready card")
 	})

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6786,7 +6786,7 @@ func TestServerEventsStreamsSidebarUpdates(t *testing.T) {
 	}
 	for _, want := range []string{
 		"Detent",
-		`href="/projects/detent"`,
+		`href="/projects/detent/kanban"`,
 		"Detent - active, 7 running",
 		`data-dashboard-project-entry`,
 		`data-tui-sidebar="menu-badge"`,
@@ -8194,8 +8194,8 @@ func TestDashboardRendersProjectSmallMultiplesFromSnapshots(t *testing.T) {
 	for _, want := range []string{
 		">Detent</span>",
 		">Pyro Apex</span>",
-		`href="/projects/detent"`,
-		`href="/projects/pyroapex"`,
+		`href="/projects/detent/kanban"`,
+		`href="/projects/pyroapex/kanban"`,
 	} {
 		if !strings.Contains(html, want) {
 			t.Fatalf("dashboard sidebar missing project row %q:\n%s", want, html)

--- a/internal/web/templates/board.templ
+++ b/internal/web/templates/board.templ
@@ -635,7 +635,7 @@ templ boardScopeSelect(data DashboardData) {
 		<div class="absolute left-0 top-full z-40 mt-1 flex w-52 flex-col gap-0.5 rounded-card border border-line bg-elev p-1.5">
 			<a href="/" class="rounded-chip px-2 py-1 text-xs text-text hover:bg-surface">All projects</a>
 			for _, project := range appShellProjects(DashboardShellDataFromDashboard(data)) {
-				<a href={ templ.SafeURL(project.Href + "/kanban") } class="truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface">{ project.Name }</a>
+				<a href={ templ.SafeURL(project.Href) } class="truncate rounded-chip px-2 py-1 text-xs text-text hover:bg-surface">{ project.Name }</a>
 			}
 		</div>
 	</details>

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -708,6 +708,19 @@ func renderBoardComponent(t *testing.T, component templ.Component) string {
 	return buf.String()
 }
 
+func TestBoardScopeSelectLinksProjectKanbanOnce(t *testing.T) {
+	data := boardTestData()
+	data.Projects = []ProjectSmallMultiple{{ID: "detent", Name: "Detent"}}
+
+	html := renderBoardComponent(t, boardScopeSelect(data))
+	if !strings.Contains(html, `href="/projects/detent/kanban"`) {
+		t.Fatalf("scope select missing kanban project href:\n%s", html)
+	}
+	if strings.Contains(html, "/kanban/kanban") {
+		t.Fatalf("scope select appended kanban twice:\n%s", html)
+	}
+}
+
 func TestBoardSnapshotKeepsLanesDuringDegradedRefresh(t *testing.T) {
 	// A degraded refresh that still carries prior tracker data must keep the
 	// last-known lanes visible, not flash skeletons.

--- a/internal/web/templates/board_templ.go
+++ b/internal/web/templates/board_templ.go
@@ -1238,9 +1238,9 @@ func boardScopeSelect(data DashboardData) templ.Component {
 				return templ_7745c5c3_Err
 			}
 			var templ_7745c5c3_Var61 templ.SafeURL
-			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href + "/kanban"))
+			templ_7745c5c3_Var61, templ_7745c5c3_Err = templ.JoinURLErrs(templ.SafeURL(project.Href))
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 638, Col: 53}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 638, Col: 41}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var61))
 			if templ_7745c5c3_Err != nil {
@@ -1253,7 +1253,7 @@ func boardScopeSelect(data DashboardData) templ.Component {
 			var templ_7745c5c3_Var62 string
 			templ_7745c5c3_Var62, templ_7745c5c3_Err = templ.JoinStringErrs(project.Name)
 			if templ_7745c5c3_Err != nil {
-				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 638, Col: 145}
+				return templ.Error{Err: templ_7745c5c3_Err, FileName: `internal/web/templates/board.templ`, Line: 638, Col: 133}
 			}
 			_, templ_7745c5c3_Err = templ_7745c5c3_Buffer.WriteString(templ.EscapeString(templ_7745c5c3_Var62))
 			if templ_7745c5c3_Err != nil {

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -1035,7 +1035,7 @@ func projectSmallMultipleCards(data DashboardData) []projectSmallMultipleCard {
 		cards = append(cards, projectSmallMultipleCard{
 			ID:              strings.TrimSpace(project.ID),
 			Name:            name,
-			Href:            projectDashboardPath(project.ID),
+			Href:            projectOpenPath(project.ID),
 			ExternalURL:     strings.TrimSpace(project.URL),
 			ProjectColor:    projectColorForProject(project),
 			ActivityLabel:   projectSmallMultipleActivityLabel(project),
@@ -1077,7 +1077,7 @@ func sidebarProjectItems(data DashboardShellData) []sidebarProjectItem {
 		items = append(items, sidebarProjectItem{
 			ID:           id,
 			Name:         projectSmallMultipleName(project),
-			Href:         projectDashboardPath(id),
+			Href:         projectOpenPath(id),
 			StatusLabel:  status.Label,
 			DotClass:     status.DotClass,
 			ProjectColor: projectColorForProject(project),
@@ -1172,6 +1172,10 @@ func projectDashboardPath(projectID string) string {
 		return "/"
 	}
 	return "/projects/" + url.PathEscape(projectID)
+}
+
+func projectOpenPath(projectID string) string {
+	return projectKanbanPath(projectID)
 }
 
 func projectKanbanPath(projectID string) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -625,7 +625,7 @@ func TestProjectSmallMultipleCards(t *testing.T) {
 			wantFirst: projectSmallMultipleCard{
 				ID:              "busy",
 				Name:            "Busy",
-				Href:            "/projects/busy",
+				Href:            "/projects/busy/kanban",
 				ExternalURL:     "https://github.com/digitaldrywood/detent",
 				ProjectColor:    "#a63f7a",
 				ActivityLabel:   "2 running / 3 queued / 1 blocked",
@@ -651,7 +651,7 @@ func TestProjectSmallMultipleCards(t *testing.T) {
 			wantFirst: projectSmallMultipleCard{
 				ID:              "detent",
 				Name:            "detent",
-				Href:            "/projects/detent",
+				Href:            "/projects/detent/kanban",
 				ProjectColor:    projectcolor.ColorForID("detent"),
 				ActivityLabel:   "1 running / 0 queued / 0 blocked",
 				ThroughputLabel: "0 tps",
@@ -774,6 +774,9 @@ func TestSidebarProjectItemsUseAttentionFirstDefaultOrder(t *testing.T) {
 		}
 		if got[i].DefaultIndex != i {
 			t.Fatalf("sidebarProjectItems()[%d].DefaultIndex = %d, want %d; got %#v", i, got[i].DefaultIndex, i, got)
+		}
+		if got[i].Href != "/projects/"+wantID+"/kanban" {
+			t.Fatalf("sidebarProjectItems()[%d].Href = %q, want kanban project opener; got %#v", i, got[i].Href, got)
 		}
 	}
 }

--- a/internal/web/templates/dashboard_test.go
+++ b/internal/web/templates/dashboard_test.go
@@ -355,7 +355,7 @@ func TestDashboardShellRendersSharedAppChrome(t *testing.T) {
 		`/static/js/templui/dialog.min.js`,
 		`data-tui-sheet`,
 		`data-tui-sidebar-target="dashboard-sidebar"`,
-		`href="/projects/detent"`,
+		`href="/projects/detent/kanban"`,
 		`href="/settings"`,
 		`function applyProjectSidebarActiveState()`,
 		`window.addEventListener("hashchange", applyProjectSidebarActiveState)`,

--- a/internal/web/templates/settings_test.go
+++ b/internal/web/templates/settings_test.go
@@ -39,7 +39,7 @@ func TestSettingsIncludesSharedSidebarShell(t *testing.T) {
 		`href="/library"`,
 		`href="/reports"`,
 		`href="/settings"`,
-		`href="/projects/detent"`,
+		`href="/projects/detent/kanban"`,
 		`href="/health/ui"`,
 		"Health",
 		">Detent</span>",

--- a/internal/web/templates/shell_data.go
+++ b/internal/web/templates/shell_data.go
@@ -90,7 +90,7 @@ func appShellProjects(data DashboardShellData) []appShellProject {
 		item := appShellProject{
 			ID:     id,
 			Name:   projectSmallMultipleName(project),
-			Href:   projectDashboardPath(id),
+			Href:   projectOpenPath(id),
 			Kind:   primitives.KindNeutral,
 			Active: strings.TrimSpace(data.ProjectID) == id,
 		}

--- a/internal/web/templates/shell_data_test.go
+++ b/internal/web/templates/shell_data_test.go
@@ -111,6 +111,9 @@ func TestAppShellProjects(t *testing.T) {
 			if item.CountErr != tt.wantErr {
 				t.Fatalf("countErr = %v, want %v", item.CountErr, tt.wantErr)
 			}
+			if item.Href != projectKanbanPath(tt.project.ID) {
+				t.Fatalf("href = %q, want kanban project opener", item.Href)
+			}
 		})
 	}
 }


### PR DESCRIPTION
## Summary

- Route project picker and sidebar project links to the project Kanban tab.
- Keep direct overview, runs, configuration, and diagnostics routes available from the project view tabs.
- Update the board/fleet project scope picker to avoid duplicate `/kanban` path segments.

Fixes #1078

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No layout or visual styling changed; route/link behavior is covered by rendered HTML and dev-runtime E2E assertions.

## Test Plan

- [x] `make generate`
- [x] `go test ./internal/web/templates ./internal/web`
- [x] `go test -race ./internal/cli -run TestStartKanbanDemoRendersAndAppliesSafeActions`
- [x] `make check`