### PR TITLE
fix(kanban): count contradictions per seq

### DIFF
--- a/internal/kanban/mutations.go
+++ b/internal/kanban/mutations.go
@@ -23,12 +23,13 @@ type MutationTracker struct {
 }
 
 type pendingState struct {
-	snapshot       string
-	current        string
-	project        string
-	issue          telemetry.Issue
-	dataSeqAtWrite uint64
-	contradictions int
+	snapshot             string
+	current              string
+	project              string
+	issue                telemetry.Issue
+	dataSeqAtWrite       uint64
+	contradictions       int
+	lastContradictionSeq uint64
 }
 
 type pendingRemoval struct {
@@ -103,7 +104,10 @@ func (t *MutationTracker) cardStateLocked(stateKey string, snapshotState string,
 		delete(t.states, stateKey)
 		return snapshotState
 	case NormalizeState(snapshotState) == NormalizeState(pending.snapshot):
-		pending.contradictions++
+		if dataSeq > pending.lastContradictionSeq {
+			pending.contradictions++
+			pending.lastContradictionSeq = dataSeq
+		}
 		if pending.contradictions < overlayContradictionLimit {
 			t.states[stateKey] = pending
 			return pending.current

--- a/internal/kanban/mutations_test.go
+++ b/internal/kanban/mutations_test.go
@@ -2,6 +2,7 @@ package kanban
 
 import (
 	"errors"
+	"sync"
 	"testing"
 	"time"
 
@@ -36,6 +37,24 @@ func TestMutationTrackerCardStateByDataSeq(t *testing.T) {
 				{snapshotState: "Todo", dataSeq: 8, want: "Todo"},
 				{snapshotState: "Backlog", dataSeq: 9, want: "Backlog"},
 			},
+		},
+		{
+			name: "same newer contradicting seq holds optimistic state",
+			observations: []observation{
+				{snapshotState: "Backlog", dataSeq: 8, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 8, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 8, want: "Todo"},
+			},
+			wantPending: true,
+		},
+		{
+			name: "older contradiction after counted seq does not increment",
+			observations: []observation{
+				{snapshotState: "Backlog", dataSeq: 9, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 8, want: "Todo"},
+				{snapshotState: "Backlog", dataSeq: 10, want: "Backlog"},
+			},
+			wantNotice: RevertNotice{Identifier: "DDW-433", From: "Todo", To: "Backlog"},
 		},
 		{
 			name: "contradicting polls revert at limit with notice",
@@ -93,6 +112,53 @@ func TestMutationTrackerCardStateByDataSeq(t *testing.T) {
 				t.Fatalf("second ConsumeRevertNotices() = %#v, want drained", got)
 			}
 		})
+	}
+}
+
+func TestMutationTrackerCardStateConcurrentSameContradictingSeq(t *testing.T) {
+	t.Parallel()
+
+	tracker := NewMutationTracker()
+	issue := telemetry.Issue{
+		ID:         "race-card",
+		Identifier: "DDW-436",
+		ProjectID:  "detent",
+		Title:      "Race pending card",
+		State:      "Backlog",
+	}
+	tracker.NoteCardState("project:detent", "detent", issue, "Backlog", "Todo", 7)
+
+	start := make(chan struct{})
+	errs := make(chan string, 8)
+	var wg sync.WaitGroup
+	for range 8 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			for range 100 {
+				if got := tracker.CardState("project:detent", issue.ID, "Backlog", 8); got != "Todo" {
+					select {
+					case errs <- got:
+					default:
+					}
+					return
+				}
+			}
+		}()
+	}
+	close(start)
+	wg.Wait()
+	close(errs)
+
+	for got := range errs {
+		t.Fatalf("CardState() = %q, want Todo", got)
+	}
+	if got := pendingStateExists(tracker, "project:detent", issue.ID); !got {
+		t.Fatalf("pending state exists = %t, want true", got)
+	}
+	if got := tracker.ConsumeRevertNotices("project:detent", "detent"); len(got) != 0 {
+		t.Fatalf("ConsumeRevertNotices() = %#v, want none", got)
 	}
 }
 

--- a/internal/web/kanban_test.go
+++ b/internal/web/kanban_test.go
@@ -325,17 +325,19 @@ func TestKanbanSnapshotWithPendingStatesRevertFeedback(t *testing.T) {
 		State:      "Backlog",
 	}
 	server.kanbanMutations.NoteCardState("project:detent", "detent", issue, "Backlog", "Done", 1)
-	snapshot := telemetry.Snapshot{
+	firstSnapshot := telemetry.Snapshot{
 		Project:     telemetry.Project{ID: "detent"},
 		Refresh:     telemetry.Refresh{DataSeq: 2},
 		BoardIssues: []telemetry.Issue{issue},
 	}
+	secondSnapshot := firstSnapshot
+	secondSnapshot.Refresh.DataSeq = 3
 
-	first := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+	first := server.kanbanSnapshotWithPendingStates("project:detent", "detent", firstSnapshot)
 	if first.BoardIssues[0].State != "Done" {
 		t.Fatalf("first contradiction state = %q, want Done", first.BoardIssues[0].State)
 	}
-	second := server.kanbanSnapshotWithPendingStates("project:detent", "detent", snapshot)
+	second := server.kanbanSnapshotWithPendingStates("project:detent", "detent", secondSnapshot)
 	if second.BoardIssues[0].State != "Backlog" {
 		t.Fatalf("second contradiction state = %q, want Backlog", second.BoardIssues[0].State)
 	}


### PR DESCRIPTION
## Summary
- Count optimistic kanban move contradictions once per distinct data sequence instead of once per render.
- Keep duplicate and late stale snapshots optimistic while preserving the two-poll revert notice path.
- Audited pending removal handling; it has no contradiction counter, so there was no per-render removal counter to guard.

Fixes #1080

## Test Plan
- `go test ./internal/kanban -run 'TestMutationTracker(CardState|Removal)' -count=1`
- `go test ./internal/web -run 'TestKanbanSnapshotWithPendingStatesRevertFeedback|TestKanbanSnapshotWithPendingStatesConcurrentRenderMove' -count=1`
- `go test -race ./internal/kanban -run 'TestMutationTrackerCardState' -count=3`
- `make check`
