### PR TITLE
feat(local): add work item sequence numbers

### DIFF
--- a/internal/cli/work_item.go
+++ b/internal/cli/work_item.go
@@ -79,6 +79,10 @@ func newWorkItemAddCommand(configPath *string, opts options) *cobra.Command {
 				return cliWorkItemError(err)
 			}
 			return out.Write(func(out io.Writer) error {
+				if result.Number > 0 {
+					_, err := fmt.Fprintf(out, "created work item #%d (%s)\n", result.Number, result.Identifier)
+					return err
+				}
 				_, err := fmt.Fprintf(out, "created work item %s\n", result.Identifier)
 				return err
 			}, result)

--- a/internal/cli/work_item_test.go
+++ b/internal/cli/work_item_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/digitaldrywood/detent/internal/cli"
@@ -56,6 +57,7 @@ func TestWorkItemAddCreatesLocalSQLiteItem(t *testing.T) {
 	var result struct {
 		ID         string `json:"id"`
 		Identifier string `json:"identifier"`
+		Number     int    `json:"number"`
 		URL        string `json:"url"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &result); err != nil {
@@ -63,6 +65,9 @@ func TestWorkItemAddCreatesLocalSQLiteItem(t *testing.T) {
 	}
 	if result.ID == "" || result.Identifier == "" || result.URL == "" {
 		t.Fatalf("result missing id, identifier, or url: %#v", result)
+	}
+	if result.Number != 1 {
+		t.Fatalf("result Number = %d, want 1", result.Number)
 	}
 
 	conn, err := local.New(local.Config{
@@ -96,6 +101,50 @@ func TestWorkItemAddCreatesLocalSQLiteItem(t *testing.T) {
 	}
 	if issue.Priority == nil || *issue.Priority != 2 {
 		t.Fatalf("Priority = %v, want 2", issue.Priority)
+	}
+	if issue.Number != 1 {
+		t.Fatalf("Number = %d, want 1", issue.Number)
+	}
+}
+
+func TestWorkItemAddPrettyPrintsLocalNumber(t *testing.T) {
+	t.Parallel()
+
+	root := t.TempDir()
+	workdir := filepath.Join(root, "video")
+	if err := os.MkdirAll(workdir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	workflowPath := filepath.Join(workdir, "WORKFLOW.md")
+	if err := os.WriteFile(workflowPath, []byte(localSQLiteWorkItemWorkflow()), 0o600); err != nil {
+		t.Fatalf("WriteFile(WORKFLOW.md) error = %v", err)
+	}
+	configPath := filepath.Join(root, "global.yaml")
+	writeGlobalConfig(t, configPath, []globalconfig.Project{{
+		ID:       "video",
+		Workflow: workflowPath,
+		Workdir:  workdir,
+		Weight:   1,
+		Priority: 0,
+	}})
+
+	cmd := cli.NewRootCommand(context.Background(), cli.WithStdoutTTY(func() bool { return true }))
+	var stdout bytes.Buffer
+	cmd.SetOut(&stdout)
+	cmd.SetErr(&bytes.Buffer{})
+	cmd.SetArgs([]string{
+		"--config", configPath,
+		"--format", "pretty",
+		"work-item", "add", "video",
+		"--title", "Author beat visuals",
+		"--body", "Render storyboard frames",
+	})
+	if err := cmd.Execute(); err != nil {
+		t.Fatalf("Execute() error = %v", err)
+	}
+	output := stdout.String()
+	if !strings.Contains(output, "created work item #1 (wi-") || !strings.HasSuffix(strings.TrimSpace(output), ")") {
+		t.Fatalf("stdout = %q, want numbered work item creation", output)
 	}
 }
 

--- a/internal/connector/connector_test.go
+++ b/internal/connector/connector_test.go
@@ -103,6 +103,7 @@ func TestIssueJSONUsesElixirFieldNames(t *testing.T) {
 	issue := Issue{
 		ID:               "issue-1",
 		Identifier:       "DIG-1",
+		Number:           7,
 		Title:            "Port connector",
 		Description:      "Build the connector seam",
 		Priority:         &priority,
@@ -134,6 +135,7 @@ func TestIssueJSONUsesElixirFieldNames(t *testing.T) {
 	for _, key := range []string{
 		"id",
 		"identifier",
+		"number",
 		"title",
 		"description",
 		"priority",

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -568,6 +568,7 @@ func (c *Connector) hydrateLocalIssues(ctx context.Context, issues []connector.I
 func (c *Connector) mergeLocalWithGitHub(localIssue connector.Issue, upstream connector.Issue) connector.Issue {
 	merged := upstream
 	merged.ID = localIssue.ID
+	merged.Number = localIssue.Number
 	if strings.TrimSpace(localIssue.Identifier) != "" {
 		merged.Identifier = localIssue.Identifier
 	}

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -11,6 +11,7 @@ import (
 type Issue struct {
 	ID               string            `json:"id,omitempty" yaml:"id,omitempty"`
 	Identifier       string            `json:"identifier,omitempty" yaml:"identifier,omitempty"`
+	Number           int               `json:"number,omitempty" yaml:"number,omitempty"`
 	Title            string            `json:"title,omitempty" yaml:"title,omitempty"`
 	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
 	Priority         *int              `json:"priority,omitempty" yaml:"priority,omitempty"`

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -18,7 +18,8 @@ import (
 )
 
 const (
-	defaultProjectID = "default"
+	defaultProjectID        = "default"
+	sqliteBusyTimeoutMillis = 5000
 
 	eventKindComment       = "comment"
 	eventKindCommentEdit   = "comment_edit"
@@ -89,6 +90,11 @@ func New(cfg Config) (*Connector, error) {
 	db, err := sql.Open("sqlite", path)
 	if err != nil {
 		return nil, fmt.Errorf("open local sqlite: %w", err)
+	}
+	db.SetMaxOpenConns(1)
+	if _, err := db.ExecContext(context.Background(), fmt.Sprintf("PRAGMA busy_timeout = %d", sqliteBusyTimeoutMillis)); err != nil {
+		_ = db.Close()
+		return nil, fmt.Errorf("configure local sqlite busy timeout: %w", err)
 	}
 	conn := &Connector{
 		db:             db,
@@ -166,7 +172,7 @@ func (c *Connector) FetchIssueStatesByIDs(ctx context.Context, issueIDs []string
 
 func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifiers []string) ([]connector.Issue, error) {
 	wanted := normalizedIdentifierSet(identifiers)
-	if len(wanted) == 0 {
+	if len(wanted) == 0 && len(normalizedNumberSet(identifiers, nil)) == 0 {
 		return []connector.Issue{}, nil
 	}
 	issues, err := c.fetchIssues(ctx, nil, 0)
@@ -174,10 +180,34 @@ func (c *Connector) FetchIssueStatesByIdentifiers(ctx context.Context, identifie
 		return nil, err
 	}
 	out := make([]connector.Issue, 0, len(identifiers))
+	seen := map[string]struct{}{}
+	matchedIdentifiers := map[string]struct{}{}
 	for _, issue := range issues {
-		if _, ok := wanted[strings.ToLower(strings.TrimSpace(issue.Identifier))]; ok {
+		key := strings.TrimSpace(issue.ID)
+		identifier := strings.ToLower(strings.TrimSpace(issue.Identifier))
+		if _, ok := wanted[identifier]; ok {
 			out = append(out, issue)
+			seen[key] = struct{}{}
+			matchedIdentifiers[identifier] = struct{}{}
 		}
+	}
+	wantedNumbers := normalizedNumberSet(identifiers, matchedIdentifiers)
+	if len(wantedNumbers) == 0 {
+		return out, nil
+	}
+	for _, issue := range issues {
+		key := strings.TrimSpace(issue.ID)
+		if issue.Number <= 0 {
+			continue
+		}
+		if _, ok := wantedNumbers[issue.Number]; !ok {
+			continue
+		}
+		if _, ok := seen[key]; ok && key != "" {
+			continue
+		}
+		out = append(out, issue)
+		seen[key] = struct{}{}
 	}
 	return out, nil
 }
@@ -423,7 +453,12 @@ github_repository_id integer not null default 0,
 github_issue_number integer not null default 0,
 github_upstream_state text not null default '',
 github_orphaned integer not null default 0,
+number integer not null default 0,
 primary key (project_id, id)
+)`,
+		`create table if not exists detent_work_item_counters (
+project_id text primary key,
+next_number integer not null
 )`,
 		`create table if not exists detent_work_item_events (
 id integer primary key autoincrement,
@@ -444,6 +479,15 @@ created_at text not null
 		}
 	}
 	if err := c.addMissingWorkItemColumns(ctx); err != nil {
+		return fmt.Errorf("migrate local sqlite connector: %w", err)
+	}
+	if err := c.backfillWorkItemNumbers(ctx); err != nil {
+		return fmt.Errorf("migrate local sqlite connector: %w", err)
+	}
+	if _, err := c.db.ExecContext(ctx, `create unique index if not exists idx_detent_work_items_project_number on detent_work_items(project_id, number) where number > 0`); err != nil {
+		return fmt.Errorf("migrate local sqlite connector: %w", err)
+	}
+	if err := c.syncWorkItemCounters(ctx); err != nil {
 		return fmt.Errorf("migrate local sqlite connector: %w", err)
 	}
 	return nil
@@ -476,6 +520,7 @@ func (c *Connector) addMissingWorkItemColumns(ctx context.Context) error {
 		name       string
 		definition string
 	}{
+		{name: "number", definition: "integer not null default 0"},
 		{name: "github_node_id", definition: "text not null default ''"},
 		{name: "github_repository_id", definition: "integer not null default 0"},
 		{name: "github_issue_number", definition: "integer not null default 0"},
@@ -491,6 +536,136 @@ func (c *Connector) addMissingWorkItemColumns(ctx context.Context) error {
 		}
 	}
 	return nil
+}
+
+type workItemNumberBackfillRow struct {
+	projectID string
+	id        string
+}
+
+func (c *Connector) backfillWorkItemNumbers(ctx context.Context) error {
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+
+	rows, err := tx.QueryContext(ctx, `
+select project_id, id
+from detent_work_items
+where number <= 0
+order by project_id asc, case when created_at = '' then 1 else 0 end asc, created_at asc, id asc`)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+	pending := []workItemNumberBackfillRow{}
+	for rows.Next() {
+		var row workItemNumberBackfillRow
+		if err := rows.Scan(&row.projectID, &row.id); err != nil {
+			closeErr := rows.Close()
+			return errors.Join(err, closeErr)
+		}
+		pending = append(pending, row)
+	}
+	if err := rows.Err(); err != nil {
+		closeErr := rows.Close()
+		return errors.Join(err, closeErr)
+	}
+	if err := rows.Close(); err != nil {
+		return err
+	}
+
+	nextByProject := map[string]int64{}
+	for _, row := range pending {
+		next, ok := nextByProject[row.projectID]
+		if !ok {
+			if err := tx.QueryRowContext(ctx, `
+select coalesce(max(number), 0) + 1
+from detent_work_items
+where project_id = ? and number > 0`, row.projectID).Scan(&next); err != nil {
+				return err
+			}
+		}
+		if _, err := tx.ExecContext(ctx, `
+update detent_work_items
+set number = ?
+where project_id = ? and id = ?`, next, row.projectID, row.id); err != nil {
+			return err
+		}
+		nextByProject[row.projectID] = next + 1
+	}
+
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
+}
+
+func (c *Connector) syncWorkItemCounters(ctx context.Context) error {
+	_, err := c.db.ExecContext(ctx, `
+insert into detent_work_item_counters(project_id, next_number)
+select project_id, coalesce(max(number), 0) + 1
+from detent_work_items
+group by project_id
+on conflict(project_id) do update set
+next_number = max(detent_work_item_counters.next_number, excluded.next_number)`)
+	return err
+}
+
+func (c *Connector) workItemNumberForUpsert(ctx context.Context, tx *sql.Tx, id string, requested int) (int64, error) {
+	var existing int64
+	err := tx.QueryRowContext(ctx, `
+select number
+from detent_work_items
+where project_id = ? and id = ?`, c.projectID, id).Scan(&existing)
+	if err == nil && existing > 0 {
+		return existing, nil
+	}
+	if err != nil && !errors.Is(err, sql.ErrNoRows) {
+		return 0, err
+	}
+	if requested > 0 {
+		number := int64(requested)
+		if err := c.ensureWorkItemCounterAtLeast(ctx, tx, number+1); err != nil {
+			return 0, err
+		}
+		return number, nil
+	}
+	return c.nextWorkItemNumber(ctx, tx)
+}
+
+func (c *Connector) nextWorkItemNumber(ctx context.Context, tx *sql.Tx) (int64, error) {
+	if _, err := tx.ExecContext(ctx, `
+insert into detent_work_item_counters(project_id, next_number)
+values (?, 1)
+on conflict(project_id) do nothing`, c.projectID); err != nil {
+		return 0, err
+	}
+	var number int64
+	if err := tx.QueryRowContext(ctx, `
+update detent_work_item_counters
+set next_number = next_number + 1
+where project_id = ?
+returning next_number - 1`, c.projectID).Scan(&number); err != nil {
+		return 0, err
+	}
+	return number, nil
+}
+
+func (c *Connector) ensureWorkItemCounterAtLeast(ctx context.Context, tx *sql.Tx, next int64) error {
+	_, err := tx.ExecContext(ctx, `
+insert into detent_work_item_counters(project_id, next_number)
+values (?, ?)
+on conflict(project_id) do update set
+next_number = max(detent_work_item_counters.next_number, excluded.next_number)`, c.projectID, next)
+	return err
 }
 
 func (c *Connector) seed(ctx context.Context, issues []connector.Issue) error {
@@ -557,17 +732,32 @@ func (c *Connector) upsertIssue(ctx context.Context, issue connector.Issue) erro
 	if issue.AssignedToWorker {
 		assigned = 1
 	}
-	_, err = c.db.ExecContext(ctx, `
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	number, err := c.workItemNumberForUpsert(ctx, tx, id, issue.Number)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
 insert into detent_work_items (
-project_id, id, identifier, title, description, priority, state, url,
+project_id, id, identifier, number, title, description, priority, state, url,
 author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
 deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
 deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
 created_at, updated_at, stage_updated_at, model_override,
 github_node_id, github_repository_id, github_issue_number, github_upstream_state, github_orphaned
-) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 on conflict(project_id, id) do update set
 identifier = excluded.identifier,
+number = case when detent_work_items.number > 0 then detent_work_items.number else excluded.number end,
 title = excluded.title,
 description = excluded.description,
 state = case when excluded.state <> '' then excluded.state else detent_work_items.state end,
@@ -586,13 +776,20 @@ github_repository_id = excluded.github_repository_id,
 github_issue_number = excluded.github_issue_number,
 github_upstream_state = excluded.github_upstream_state,
 github_orphaned = excluded.github_orphaned`,
-		c.projectID, id, identifier, issue.Title, issue.Description, nullableInt(issue.Priority), issue.State, issue.URL,
+		c.projectID, id, identifier, number, issue.Title, issue.Description, nullableInt(issue.Priority), issue.State, issue.URL,
 		issue.AuthorID, issue.AssigneeID, assigneesJSON, labelsJSON, fieldsJSON, metadataJSON,
 		deliverable.Kind, deliverable.Path, deliverable.ReviewURL, deliverable.ValidationStatus,
 		deliverable.ExternalID, deliverableMetadataJSON, assigned,
 		formatTime(createdAt), formatTime(updatedAt), formatTime(stageUpdatedAt), issue.ModelOverride,
 		githubIdentity.NodeID, githubIdentity.RepositoryID, githubIdentity.IssueNumber, githubIdentity.UpstreamState, boolInt(githubIdentity.Orphaned))
-	return err
+	if err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 func (c *Connector) insertSeedIssue(ctx context.Context, issue connector.Issue) error {
@@ -641,27 +838,48 @@ func (c *Connector) insertSeedIssue(ctx context.Context, issue connector.Issue) 
 	if issue.AssignedToWorker {
 		assigned = 1
 	}
-	_, err = c.db.ExecContext(ctx, `
+	tx, err := c.db.BeginTx(ctx, nil)
+	if err != nil {
+		return err
+	}
+	committed := false
+	defer func() {
+		if !committed {
+			_ = tx.Rollback()
+		}
+	}()
+	number, err := c.workItemNumberForUpsert(ctx, tx, id, issue.Number)
+	if err != nil {
+		return err
+	}
+	_, err = tx.ExecContext(ctx, `
 insert into detent_work_items (
-project_id, id, identifier, title, description, priority, state, url,
+project_id, id, identifier, number, title, description, priority, state, url,
 author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
 deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
 deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
 created_at, updated_at, stage_updated_at, model_override,
 github_node_id, github_repository_id, github_issue_number, github_upstream_state, github_orphaned
-) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+) values (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 on conflict(project_id, id) do nothing`,
-		c.projectID, id, identifier, issue.Title, issue.Description, nullableInt(issue.Priority), issue.State, issue.URL,
+		c.projectID, id, identifier, number, issue.Title, issue.Description, nullableInt(issue.Priority), issue.State, issue.URL,
 		issue.AuthorID, issue.AssigneeID, assigneesJSON, labelsJSON, fieldsJSON, metadataJSON,
 		deliverable.Kind, deliverable.Path, deliverable.ReviewURL, deliverable.ValidationStatus,
 		deliverable.ExternalID, deliverableMetadataJSON, assigned,
 		formatTime(createdAt), formatTime(updatedAt), formatTime(stageUpdatedAt), issue.ModelOverride,
 		githubIdentity.NodeID, githubIdentity.RepositoryID, githubIdentity.IssueNumber, githubIdentity.UpstreamState, boolInt(githubIdentity.Orphaned))
-	return err
+	if err != nil {
+		return err
+	}
+	if err := tx.Commit(); err != nil {
+		return err
+	}
+	committed = true
+	return nil
 }
 
 func (c *Connector) fetchIssues(ctx context.Context, states []string, limit int) ([]connector.Issue, error) {
-	query := `select project_id, id, identifier, title, description, priority, state, url,
+	query := `select project_id, id, identifier, number, title, description, priority, state, url,
 author_id, assignee_id, assignees_json, labels_json, fields_json, metadata_json,
 deliverable_kind, deliverable_path, deliverable_review_url, deliverable_validation_status,
 deliverable_external_id, deliverable_metadata_json, assigned_to_worker,
@@ -697,17 +915,24 @@ where project_id = ?`
 	for rows.Next() {
 		issue, err := scanIssue(rows)
 		if err != nil {
-			return nil, err
+			closeErr := rows.Close()
+			return nil, errors.Join(err, closeErr)
 		}
-		comments, err := c.FetchIssueComments(ctx, issue)
-		if err != nil {
-			return nil, err
-		}
-		issue.Comments = comments
 		issues = append(issues, issue)
 	}
 	if err := rows.Err(); err != nil {
+		closeErr := rows.Close()
+		return nil, errors.Join(err, closeErr)
+	}
+	if err := rows.Close(); err != nil {
 		return nil, err
+	}
+	for i := range issues {
+		comments, err := c.FetchIssueComments(ctx, issues[i])
+		if err != nil {
+			return nil, err
+		}
+		issues[i].Comments = comments
 	}
 	return issues, nil
 }
@@ -791,7 +1016,7 @@ func scanIssue(scanner issueScanner) (connector.Issue, error) {
 	var githubRepositoryID, githubIssueNumber int64
 	var githubOrphaned int
 	err := scanner.Scan(
-		&projectID, &issue.ID, &issue.Identifier, &issue.Title, &issue.Description, &priority, &issue.State, &issue.URL,
+		&projectID, &issue.ID, &issue.Identifier, &issue.Number, &issue.Title, &issue.Description, &priority, &issue.State, &issue.URL,
 		&issue.AuthorID, &issue.AssigneeID, &assigneesJSON, &labelsJSON, &fieldsJSON, &metadataJSON,
 		&deliverable.Kind, &deliverable.Path, &deliverable.ReviewURL, &deliverable.ValidationStatus,
 		&deliverable.ExternalID, &deliverableMetadataJSON, &assigned,
@@ -864,6 +1089,33 @@ func normalizedIdentifierSet(values []string) map[string]struct{} {
 		}
 	}
 	return out
+}
+
+func normalizedNumberSet(values []string, skip map[string]struct{}) map[int]struct{} {
+	out := map[int]struct{}{}
+	for _, value := range values {
+		normalized := strings.ToLower(strings.TrimSpace(value))
+		if _, ok := skip[normalized]; ok {
+			continue
+		}
+		number, ok := parseLocalIssueNumber(value)
+		if ok {
+			out[number] = struct{}{}
+		}
+	}
+	return out
+}
+
+func parseLocalIssueNumber(value string) (int, bool) {
+	value = strings.TrimSpace(strings.TrimPrefix(strings.TrimSpace(value), "#"))
+	if value == "" {
+		return 0, false
+	}
+	number, err := strconv.Atoi(value)
+	if err != nil || number <= 0 {
+		return 0, false
+	}
+	return number, true
 }
 
 func issueFieldKey(fieldID int) string {

--- a/internal/connector/local/local_test.go
+++ b/internal/connector/local/local_test.go
@@ -5,6 +5,8 @@ import (
 	"database/sql"
 	"errors"
 	"path/filepath"
+	"strconv"
+	"sync"
 	"testing"
 	"time"
 
@@ -57,6 +59,9 @@ func TestConnectorPersistsWorkItemStateAndEvents(t *testing.T) {
 	if got.ID != "ad-1" || got.State != "Todo" || got.Fields["validation_status"] != "pending" || got.Metadata["store"] != "creswood" {
 		t.Fatalf("candidate = %#v", got)
 	}
+	if got.Number != 1 {
+		t.Fatalf("Number = %d, want 1", got.Number)
+	}
 	if got.Deliverable == nil || got.Deliverable.ExternalID != "creative-101" || got.Deliverable.Metadata["aspect_ratio"] != "9:16" {
 		t.Fatalf("candidate deliverable = %#v", got.Deliverable)
 	}
@@ -93,6 +98,9 @@ func TestConnectorPersistsWorkItemStateAndEvents(t *testing.T) {
 	got = issues[0]
 	if got.State != "Review" || got.Fields["validation_status"] != "valid" {
 		t.Fatalf("persisted issue = %#v", got)
+	}
+	if got.Number != 1 {
+		t.Fatalf("persisted Number = %d, want 1", got.Number)
 	}
 	if len(got.Comments) != 1 || got.Comments[0].Body != "Manifest is ready for external pickup." {
 		t.Fatalf("persisted comments = %#v", got.Comments)
@@ -400,5 +408,177 @@ func TestConnectorUpsertGitHubIdentityAndLocalIssueFields(t *testing.T) {
 	}
 	if value, ok := got.Fields[issueFieldKey(42)]; ok || value != "" {
 		t.Fatalf("issue field persisted = %q, ok=%v; want cleared", value, ok)
+	}
+}
+
+func TestConnectorBackfillsWorkItemNumbersByProjectCreationOrder(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	path := filepath.Join(t.TempDir(), "backfill.db")
+	db, err := sql.Open("sqlite", path)
+	if err != nil {
+		t.Fatalf("Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	_, err = db.ExecContext(ctx, `
+create table detent_work_items (
+project_id text not null,
+id text not null,
+identifier text not null,
+title text not null default '',
+description text not null default '',
+priority integer,
+state text not null default '',
+url text not null default '',
+author_id text not null default '',
+assignee_id text not null default '',
+assignees_json text not null default '[]',
+labels_json text not null default '[]',
+fields_json text not null default '{}',
+metadata_json text not null default '{}',
+deliverable_kind text not null default '',
+deliverable_path text not null default '',
+deliverable_review_url text not null default '',
+deliverable_validation_status text not null default '',
+deliverable_external_id text not null default '',
+deliverable_metadata_json text not null default '{}',
+assigned_to_worker integer not null default 1,
+created_at text not null default '',
+updated_at text not null default '',
+stage_updated_at text not null default '',
+model_override text not null default '',
+github_node_id text not null default '',
+github_repository_id integer not null default 0,
+github_issue_number integer not null default 0,
+github_upstream_state text not null default '',
+github_orphaned integer not null default 0,
+primary key (project_id, id)
+)`)
+	if err != nil {
+		t.Fatalf("create legacy table error = %v", err)
+	}
+	created := []struct {
+		projectID  string
+		id         string
+		identifier string
+		createdAt  time.Time
+	}{
+		{"video", "ad-2", "wi-video-2", time.Date(2026, 7, 1, 12, 2, 0, 0, time.UTC)},
+		{"video", "ad-1", "wi-video-1", time.Date(2026, 7, 1, 12, 1, 0, 0, time.UTC)},
+		{"audio", "mix-1", "wi-audio-1", time.Date(2026, 7, 1, 12, 0, 0, 0, time.UTC)},
+	}
+	for _, row := range created {
+		if _, err := db.ExecContext(ctx, `
+insert into detent_work_items(project_id, id, identifier, title, state, created_at, updated_at, stage_updated_at)
+values (?, ?, ?, ?, ?, ?, ?, ?)`,
+			row.projectID, row.id, row.identifier, row.identifier, "Todo", formatTime(row.createdAt), formatTime(row.createdAt), formatTime(row.createdAt)); err != nil {
+			t.Fatalf("insert legacy row error = %v", err)
+		}
+	}
+	if err := db.Close(); err != nil {
+		t.Fatalf("legacy Close() error = %v", err)
+	}
+
+	store, err := New(Config{Path: path, ProjectID: "video"})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer store.Close()
+
+	issues, err := store.FetchIssuesByStates(ctx, []string{"Todo"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(video) error = %v", err)
+	}
+	numbers := map[string]int{}
+	for _, issue := range issues {
+		numbers[issue.ID] = issue.Number
+	}
+	if numbers["ad-1"] != 1 || numbers["ad-2"] != 2 {
+		t.Fatalf("video numbers = %#v, want ad-1=1 ad-2=2", numbers)
+	}
+
+	next := connector.NewIssue()
+	next.ID = "ad-3"
+	next.Identifier = "wi-video-3"
+	next.State = "Todo"
+	if err := store.UpsertIssues(ctx, []connector.Issue{next}); err != nil {
+		t.Fatalf("UpsertIssues(next) error = %v", err)
+	}
+	createdIssue, err := store.FetchIssueStatesByIdentifiers(ctx, []string{"#3"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers(#3) error = %v", err)
+	}
+	if len(createdIssue) != 1 || createdIssue[0].ID != "ad-3" || createdIssue[0].Number != 3 {
+		t.Fatalf("created issue by #3 = %#v, want ad-3 number 3", createdIssue)
+	}
+	literal := connector.NewIssue()
+	literal.ID = "literal-3"
+	literal.Identifier = "3"
+	literal.State = "Todo"
+	if err := store.UpsertIssues(ctx, []connector.Issue{literal}); err != nil {
+		t.Fatalf("UpsertIssues(literal) error = %v", err)
+	}
+	literalMatch, err := store.FetchIssueStatesByIdentifiers(ctx, []string{"3"})
+	if err != nil {
+		t.Fatalf("FetchIssueStatesByIdentifiers(3) error = %v", err)
+	}
+	if len(literalMatch) != 1 || literalMatch[0].ID != "literal-3" {
+		t.Fatalf("literal numeric identifier match = %#v, want literal-3 only", literalMatch)
+	}
+}
+
+func TestConnectorAssignsUniqueConcurrentWorkItemNumbers(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	store, err := New(Config{
+		Path:      filepath.Join(t.TempDir(), "concurrent.db"),
+		ProjectID: "video",
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	defer store.Close()
+
+	const count = 24
+	errs := make(chan error, count)
+	var wg sync.WaitGroup
+	for i := range count {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			suffix := strconv.Itoa(i)
+			issue := connector.NewIssue()
+			issue.ID = "ad-" + suffix
+			issue.Identifier = "wi-concurrent-" + suffix
+			issue.State = "Todo"
+			errs <- store.UpsertIssues(ctx, []connector.Issue{issue})
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		if err != nil {
+			t.Fatalf("UpsertIssues() error = %v", err)
+		}
+	}
+
+	issues, err := store.FetchIssuesByStates(ctx, []string{"Todo"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != count {
+		t.Fatalf("issues len = %d, want %d", len(issues), count)
+	}
+	seen := map[int]struct{}{}
+	for _, issue := range issues {
+		if issue.Number < 1 || issue.Number > count {
+			t.Fatalf("issue %s number = %d, want 1..%d", issue.ID, issue.Number, count)
+		}
+		if _, ok := seen[issue.Number]; ok {
+			t.Fatalf("duplicate number %d in %#v", issue.Number, issues)
+		}
+		seen[issue.Number] = struct{}{}
 	}
 }

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -382,6 +382,7 @@ func telemetryIssue(issue connector.Issue, quietDuration time.Duration, pollInte
 	return telemetry.Issue{
 		ID:                    issue.ID,
 		Identifier:            issue.Identifier,
+		Number:                issue.Number,
 		URL:                   issue.URL,
 		Title:                 issue.Title,
 		Description:           issue.Description,

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -388,6 +388,7 @@ func TestStateSnapshotCarriesArtifactDeliverableMetadata(t *testing.T) {
 	state.Pipeline = []connector.Issue{{
 		ID:         "ad-1",
 		Identifier: "store/ad-1",
+		Number:     8,
 		Title:      "Summer sale video ad",
 		State:      "Review",
 		Metadata:   map[string]string{"store": "creswood"},
@@ -408,6 +409,9 @@ func TestStateSnapshotCarriesArtifactDeliverableMetadata(t *testing.T) {
 	got := snapshot.Pipeline[0]
 	if got.Metadata["store"] != "creswood" {
 		t.Fatalf("Metadata = %#v", got.Metadata)
+	}
+	if got.Number != 8 {
+		t.Fatalf("Number = %d, want 8", got.Number)
 	}
 	if got.Deliverable == nil {
 		t.Fatal("Deliverable = nil, want artifact deliverable")

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -194,6 +194,7 @@ func (d TrackerDrift) IsZero() bool {
 type Issue struct {
 	ID                    string            `json:"issue_id"`
 	Identifier            string            `json:"identifier,omitempty"`
+	Number                int               `json:"number,omitempty"`
 	ProjectID             string            `json:"project_id,omitempty"`
 	URL                   string            `json:"url,omitempty"`
 	Title                 string            `json:"title,omitempty"`

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1549,7 +1549,7 @@ func TestAPIUsageWritesDrainOnShutdown(t *testing.T) {
 		t.Fatalf("state status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 12*time.Second)
 	defer cancel()
 	if err := server.Shutdown(ctx); err != nil {
 		t.Fatalf("Shutdown() error = %v", err)

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -1189,6 +1189,9 @@ func TestWorkItemAPICreatesLocalSQLiteItem(t *testing.T) {
 	if payload["id"] == "" || payload["identifier"] == "" || payload["url"] == "" {
 		t.Fatalf("response missing id, identifier, or url: %#v", payload)
 	}
+	if payload["number"] != float64(1) {
+		t.Fatalf("response number = %#v, want 1", payload["number"])
+	}
 	if refresher.calls != 1 {
 		t.Fatalf("refresh calls = %d, want 1", refresher.calls)
 	}
@@ -1202,6 +1205,9 @@ func TestWorkItemAPICreatesLocalSQLiteItem(t *testing.T) {
 	issue := issues[0]
 	if issue.Title != "Author beat visuals" || issue.Description != "Render storyboard frames" {
 		t.Fatalf("issue text = %#v", issue)
+	}
+	if issue.Number != 1 {
+		t.Fatalf("issue number = %d, want 1", issue.Number)
 	}
 	if issue.Fields["render_status"] != "queued" {
 		t.Fatalf("Fields = %#v", issue.Fields)

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -554,6 +554,7 @@ const (
 	githubLocalDivergenceMetadataKey       = "github_local_divergence"
 	githubLocalDivergenceDetailMetadataKey = "github_local_divergence_detail"
 	githubLocalClosedUpstreamDivergence    = "closed_upstream_local_active"
+	githubIssueNumberMetadataKey           = "github_issue_number"
 )
 
 type projectOverviewCard struct {
@@ -1763,11 +1764,36 @@ func issueIdentity(issue telemetry.Issue) issueIdentityView {
 }
 
 func issueReference(issue telemetry.Issue) string {
+	if reference := issueDisplayReference(issue); reference != "" {
+		return reference
+	}
+	return issueIdentifier(issue)
+}
+
+func issueDisplayReference(issue telemetry.Issue) string {
 	identifier := issueIdentifier(issue)
 	if index := strings.LastIndex(identifier, "#"); index >= 0 && index < len(identifier)-1 {
 		return identifier[index:]
 	}
-	return identifier
+	if number := issueMetadataInt(issue.Metadata, githubIssueNumberMetadataKey); number > 0 {
+		return "#" + strconv.Itoa(number)
+	}
+	if issue.Number > 0 {
+		return "#" + strconv.Itoa(issue.Number)
+	}
+	return ""
+}
+
+func issueMetadataInt(metadata map[string]string, key string) int {
+	value := strings.TrimSpace(metadata[key])
+	if value == "" {
+		return 0
+	}
+	parsed, err := strconv.Atoi(value)
+	if err != nil || parsed <= 0 {
+		return 0
+	}
+	return parsed
 }
 
 func issueRepositoryLabel(issue telemetry.Issue) string {
@@ -2689,12 +2715,10 @@ func WithKanbanCardComments(card projectKanbanCard, comments []telemetry.IssueCo
 }
 
 func projectKanbanIssueNumber(issue telemetry.Issue) string {
-	identifier := issueIdentifier(issue)
-	index := strings.LastIndex(identifier, "#")
-	if index >= 0 && index < len(identifier)-1 {
-		return identifier[index:]
+	if reference := issueDisplayReference(issue); reference != "" {
+		return reference
 	}
-	return identifier
+	return issueIdentifier(issue)
 }
 
 func projectKanbanAttentionLabel(issue telemetry.Issue) string {
@@ -3877,12 +3901,10 @@ func issueNumber(issue telemetry.Issue) string {
 	if issue.PullRequest != nil && issue.PullRequest.Number > 0 {
 		return "#" + strconv.Itoa(issue.PullRequest.Number)
 	}
-	identifier := issueIdentifier(issue)
-	index := strings.LastIndex(identifier, "#")
-	if index >= 0 && index < len(identifier)-1 {
-		return identifier[index:]
+	if reference := issueDisplayReference(issue); reference != "" {
+		return reference
 	}
-	return identifier
+	return issueIdentifier(issue)
 }
 
 func trackerDriftVisible(snapshot telemetry.Snapshot) bool {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -1210,6 +1210,87 @@ func TestIssueIdentityKeepsRepositoryIssueAndPullRequest(t *testing.T) {
 	}
 }
 
+func TestIssueReferenceUsesLocalNumberWithGitHubPrecedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		issue              telemetry.Issue
+		wantIssueReference string
+		wantKanbanNumber   string
+		wantIssueNumber    string
+	}{
+		{
+			name: "local number",
+			issue: telemetry.Issue{
+				Identifier: "wi-011cd179bc7ecf36b7197e4b",
+				Number:     7,
+			},
+			wantIssueReference: "#7",
+			wantKanbanNumber:   "#7",
+			wantIssueNumber:    "#7",
+		},
+		{
+			name: "github identifier",
+			issue: telemetry.Issue{
+				Identifier: "digitaldrywood/detent#779",
+				Number:     7,
+				Metadata:   map[string]string{githubIssueNumberMetadataKey: "881"},
+			},
+			wantIssueReference: "#779",
+			wantKanbanNumber:   "#779",
+			wantIssueNumber:    "#779",
+		},
+		{
+			name: "github metadata",
+			issue: telemetry.Issue{
+				Identifier: "wi-linked",
+				Number:     7,
+				Metadata:   map[string]string{githubIssueNumberMetadataKey: "881"},
+			},
+			wantIssueReference: "#881",
+			wantKanbanNumber:   "#881",
+			wantIssueNumber:    "#881",
+		},
+		{
+			name: "pull request issue number",
+			issue: telemetry.Issue{
+				Identifier:  "wi-review",
+				Number:      7,
+				PullRequest: &telemetry.PullRequest{Number: 32},
+			},
+			wantIssueReference: "#7",
+			wantKanbanNumber:   "#7",
+			wantIssueNumber:    "#32",
+		},
+		{
+			name: "fallback identifier",
+			issue: telemetry.Issue{
+				Identifier: "wi-without-number",
+			},
+			wantIssueReference: "wi-without-number",
+			wantKanbanNumber:   "wi-without-number",
+			wantIssueNumber:    "wi-without-number",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := issueReference(tt.issue); got != tt.wantIssueReference {
+				t.Fatalf("issueReference() = %q, want %q", got, tt.wantIssueReference)
+			}
+			if got := projectKanbanIssueNumber(tt.issue); got != tt.wantKanbanNumber {
+				t.Fatalf("projectKanbanIssueNumber() = %q, want %q", got, tt.wantKanbanNumber)
+			}
+			if got := issueNumber(tt.issue); got != tt.wantIssueNumber {
+				t.Fatalf("issueNumber() = %q, want %q", got, tt.wantIssueNumber)
+			}
+		})
+	}
+}
+
 func TestAgentTimelineRows(t *testing.T) {
 	t.Parallel()
 

--- a/internal/workitem/workitem.go
+++ b/internal/workitem/workitem.go
@@ -68,6 +68,7 @@ type Request struct {
 type Response struct {
 	ID         string `json:"id"`
 	Identifier string `json:"identifier"`
+	Number     int    `json:"number,omitempty"`
 	URL        string `json:"url"`
 }
 
@@ -131,7 +132,29 @@ func Create(ctx context.Context, target Target, req Request) (Response, error) {
 	if err := upserter.UpsertIssues(ctx, []connector.Issue{issue}); err != nil {
 		return Response{}, &Error{Code: CodeSubmissionFailed, Message: "create work item failed", Err: err}
 	}
-	return Response{ID: issue.ID, Identifier: issue.Identifier, URL: issue.URL}, nil
+	if created, ok, err := createdIssue(ctx, target.Connector, issue.Identifier); err != nil {
+		return Response{}, &Error{Code: CodeSubmissionFailed, Message: "read created work item failed", Err: err}
+	} else if ok {
+		issue = created
+	}
+	return Response{ID: issue.ID, Identifier: issue.Identifier, Number: issue.Number, URL: issue.URL}, nil
+}
+
+func createdIssue(ctx context.Context, projectConnector connector.Connector, identifier string) (connector.Issue, bool, error) {
+	resolver, ok := projectConnector.(connector.IssueReferenceResolver)
+	if !ok {
+		return connector.Issue{}, false, nil
+	}
+	issues, err := resolver.FetchIssueStatesByIdentifiers(ctx, []string{identifier})
+	if err != nil {
+		return connector.Issue{}, false, err
+	}
+	for _, issue := range issues {
+		if strings.EqualFold(strings.TrimSpace(issue.Identifier), strings.TrimSpace(identifier)) {
+			return issue, true, nil
+		}
+	}
+	return connector.Issue{}, false, nil
 }
 
 func WorkItemURL(base string, projectID string) string {

--- a/internal/workitem/workitem_test.go
+++ b/internal/workitem/workitem_test.go
@@ -14,7 +14,7 @@ import (
 func TestCreateBuildsWorkItemWithDefaults(t *testing.T) {
 	t.Parallel()
 
-	conn := &creatorConnector{}
+	conn := &creatorConnector{number: 7}
 	now := time.Date(2026, 7, 6, 16, 0, 0, 0, time.UTC)
 	got, err := workitem.Create(context.Background(), workitem.Target{
 		ProjectID:           "video",
@@ -34,6 +34,9 @@ func TestCreateBuildsWorkItemWithDefaults(t *testing.T) {
 	}
 	if got.ID != "wi-test" || got.Identifier != "wi-test" {
 		t.Fatalf("Create() response = %#v, want generated identifier", got)
+	}
+	if got.Number != 7 {
+		t.Fatalf("Number = %d, want 7", got.Number)
 	}
 	if got.URL != "http://127.0.0.1:4000/projects/video/kanban" {
 		t.Fatalf("URL = %q", got.URL)
@@ -199,6 +202,7 @@ func localSQLiteWorkflow() workflowconfig.Config {
 type creatorConnector struct {
 	upserts  []connector.Issue
 	existing []connector.Issue
+	number   int
 }
 
 func (c *creatorConnector) Name() string {
@@ -217,8 +221,20 @@ func (c *creatorConnector) FetchIssueStatesByIDs(context.Context, []string) ([]c
 	return nil, connector.ErrNotImplemented
 }
 
-func (c *creatorConnector) FetchIssueStatesByIdentifiers(context.Context, []string) ([]connector.Issue, error) {
-	return append([]connector.Issue(nil), c.existing...), nil
+func (c *creatorConnector) FetchIssueStatesByIdentifiers(_ context.Context, identifiers []string) ([]connector.Issue, error) {
+	wanted := map[string]struct{}{}
+	for _, identifier := range identifiers {
+		wanted[identifier] = struct{}{}
+	}
+	issues := append([]connector.Issue(nil), c.existing...)
+	issues = append(issues, c.upserts...)
+	out := []connector.Issue{}
+	for _, issue := range issues {
+		if _, ok := wanted[issue.Identifier]; ok {
+			out = append(out, issue)
+		}
+	}
+	return out, nil
 }
 
 func (c *creatorConnector) CreateComment(context.Context, string, string) error {
@@ -238,7 +254,13 @@ func (c *creatorConnector) SetField(context.Context, string, string, string) err
 }
 
 func (c *creatorConnector) UpsertIssues(_ context.Context, issues []connector.Issue) error {
-	c.upserts = append(c.upserts, issues...)
+	copied := append([]connector.Issue(nil), issues...)
+	if c.number > 0 {
+		for i := range copied {
+			copied[i].Number = c.number
+		}
+	}
+	c.upserts = append(c.upserts, copied...)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Add per-project local work item numbers assigned transactionally and backfilled during local connector migration.
- Surface local numbers through issue snapshots and dashboard display helpers while preserving GitHub issue-number precedence and full `wi-...` identity.
- Print the local number in `detent work-item` output and support project-scoped `#N`/`N` lookup for local items.

Fixes #1082

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] N/A; this changes issue display data only, with dashboard data coverage below.

## Test Plan

- [x] `make check`
- [x] Focused package coverage: `go test -count=1 ./internal/connector/local ./internal/workitem ./internal/cli ./internal/web/templates ./internal/web ./internal/orchestrator ./internal/connector ./internal/connector/githublocal`
