### PR TITLE
fix: park repeated worker failures and fix local_sqlite tracker gaps

### DIFF
--- a/README.md
+++ b/README.md
@@ -2164,6 +2164,11 @@ derived fields instead of reporting a misleading zero.
 
 Context pressure is a model-window signal, not a Detent stop threshold.
 `agent.max_session_tokens` is an absolute configured ceiling for a session.
+`total_tokens` counts input, output, cache-created, and cache-read tokens,
+accumulated across every turn of the session — cached context is re-counted on
+each turn, so a healthy session accrues millions of tokens within minutes.
+Size `max_session_tokens` as a runaway-session guard; a value near one turn's
+worth of context terminates every session at its ceiling.
 `agent.max_session_context_multiplier` derives a ceiling from the reported
 context window when that window is known. A session can show high context
 pressure before either ceiling is exceeded, and a low-pressure session can

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -59,7 +59,13 @@ agent:
   max_concurrent_agents: 5
   max_turns: 20
   max_retry_backoff_ms: 300000
-  max_session_tokens: 2000000
+  # Per-session ceiling on total_tokens. total_tokens counts input + output +
+  # cache-created + cache-read tokens, accumulated across every turn of the
+  # session, so a healthy Claude session re-counts its cached context each turn
+  # and accrues millions of tokens within minutes. Set this as a runaway-session
+  # guard, not a context limit; max_session_context_multiplier bounds context
+  # growth separately.
+  max_session_tokens: 25000000
   max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -59,7 +59,13 @@ agent:
   max_concurrent_agents: 5
   max_turns: 20
   max_retry_backoff_ms: 300000
-  max_session_tokens: 2000000
+  # Per-session ceiling on total_tokens. total_tokens counts input + output +
+  # cache-created + cache-read tokens, accumulated across every turn of the
+  # session, so a healthy Claude session re-counts its cached context each turn
+  # and accrues millions of tokens within minutes. Set this as a runaway-session
+  # guard, not a context limit; max_session_context_multiplier bounds context
+  # growth separately.
+  max_session_tokens: 25000000
   max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -58,7 +58,13 @@ agent:
   max_concurrent_agents: 5
   max_turns: 20
   max_retry_backoff_ms: 300000
-  max_session_tokens: 2000000
+  # Per-session ceiling on total_tokens. total_tokens counts input + output +
+  # cache-created + cache-read tokens, accumulated across every turn of the
+  # session, so a healthy Claude session re-counts its cached context each turn
+  # and accrues millions of tokens within minutes. Set this as a runaway-session
+  # guard, not a context limit; max_session_context_multiplier bounds context
+  # growth separately.
+  max_session_tokens: 25000000
   max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -29,7 +29,13 @@ deliverable:
   review_url: http://127.0.0.1:8080/review
 
 agent:
-  max_session_tokens: 2000000
+  # Per-session ceiling on total_tokens. total_tokens counts input + output +
+  # cache-created + cache-read tokens, accumulated across every turn of the
+  # session, so a healthy Claude session re-counts its cached context each turn
+  # and accrues millions of tokens within minutes. Set this as a runaway-session
+  # guard, not a context limit; max_session_context_multiplier bounds context
+  # growth separately.
+  max_session_tokens: 25000000
   max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   auto_promote:

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -58,7 +58,13 @@ agent:
   max_concurrent_agents: 5
   max_turns: 20
   max_retry_backoff_ms: 300000
-  max_session_tokens: 2000000
+  # Per-session ceiling on total_tokens. total_tokens counts input + output +
+  # cache-created + cache-read tokens, accumulated across every turn of the
+  # session, so a healthy Claude session re-counts its cached context each turn
+  # and accrues millions of tokens within minutes. Set this as a runaway-session
+  # guard, not a context limit; max_session_context_multiplier bounds context
+  # growth separately.
+  max_session_tokens: 25000000
   max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:

--- a/internal/cli/key.go
+++ b/internal/cli/key.go
@@ -87,7 +87,7 @@ func newKeyListCommand(configPath *string, opts options) *cobra.Command {
 			}
 			result, err := runKeyList(cmd.Context(), *configPath, opts)
 			if err != nil {
-				return err
+				return cliAPIKeyError(err)
 			}
 			return out.Write(func(out io.Writer) error {
 				for _, key := range result.Keys {
@@ -153,7 +153,7 @@ func newKeyRevokeCommand(configPath *string, opts options) *cobra.Command {
 			}
 			result, err := runKeyRevoke(cmd.Context(), *configPath, opts, args[0])
 			if err != nil {
-				return err
+				return cliAPIKeyError(err)
 			}
 			return out.Write(func(out io.Writer) error {
 				_, err := fmt.Fprintf(out, "revoked api key %s\n", result.ID)
@@ -278,6 +278,11 @@ func runKeyRevoke(ctx context.Context, configPath string, opts options, id strin
 	return keyRevokedResult{ID: id, Revoked: true}, nil
 }
 
+// keyStoreBusyTimeout is deliberately much longer than the store default:
+// key commands are short-lived one-shot writers that contend with a running
+// detent server, so waiting beats failing with SQLITE_BUSY.
+const keyStoreBusyTimeout = 30 * time.Second
+
 func openKeyStore(ctx context.Context, configPath string, opts options) (storepkg.Store, error) {
 	resolution, err := resolveConfigPathResolution(configPath, opts)
 	if err != nil {
@@ -292,6 +297,7 @@ func openKeyStore(ctx context.Context, configPath string, opts options) (storepk
 		Path: runtimeStorePath(BootConfig{
 			Global: cfg,
 		}),
+		BusyTimeout: keyStoreBusyTimeout,
 	})
 }
 
@@ -344,6 +350,8 @@ func cliAPIKeyError(err error) error {
 		errors.Is(err, apikey.ErrKeyExpired),
 		errors.Is(err, apikey.ErrKeyLimitExceeded):
 		return WrapValidation(err)
+	case storepkg.IsBusy(err):
+		return fmt.Errorf("%w: a running detent server is holding the runtime database write lock; retry in a moment", err)
 	default:
 		return err
 	}

--- a/internal/cli/key_error_test.go
+++ b/internal/cli/key_error_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/apikey"
+	storepkg "github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestCLIAPIKeyErrorAddsBusyHint(t *testing.T) {
+	t.Parallel()
+
+	busyErr := fmt.Errorf("creating api key: %w", generateSQLiteBusyError(t))
+
+	tests := []struct {
+		name         string
+		err          error
+		wantContains string
+	}{
+		{
+			name:         "sqlite busy gets retry hint",
+			err:          busyErr,
+			wantContains: "holding the runtime database write lock",
+		},
+		{
+			name:         "validation error stays validation",
+			err:          apikey.ErrNameRequired,
+			wantContains: apikey.ErrNameRequired.Error(),
+		},
+		{
+			name:         "other errors pass through",
+			err:          errors.New("boom"),
+			wantContains: "boom",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := cliAPIKeyError(tt.err)
+			if got == nil {
+				t.Fatal("cliAPIKeyError() = nil, want error")
+			}
+			if !strings.Contains(got.Error(), tt.wantContains) {
+				t.Fatalf("cliAPIKeyError() = %q, want substring %q", got.Error(), tt.wantContains)
+			}
+			if !errors.Is(got, tt.err) && got.Error() != tt.err.Error() {
+				t.Fatalf("cliAPIKeyError() = %v does not wrap %v", got, tt.err)
+			}
+		})
+	}
+
+	if hinted := cliAPIKeyError(busyErr); !storepkg.IsBusy(hinted) {
+		t.Fatalf("cliAPIKeyError() busy result no longer matches IsBusy: %v", hinted)
+	}
+}
+
+// generateSQLiteBusyError produces a genuine driver SQLITE_BUSY error by
+// holding a write transaction on one connection while a second, zero-timeout
+// connection attempts a write.
+func generateSQLiteBusyError(t *testing.T) error {
+	t.Helper()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "busy.db")
+
+	holder, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open holder: %v", err)
+	}
+	t.Cleanup(func() { _ = holder.Close() })
+	holderConn, err := holder.Conn(ctx)
+	if err != nil {
+		t.Fatalf("holder conn: %v", err)
+	}
+	t.Cleanup(func() { _ = holderConn.Close() })
+	if _, err := holderConn.ExecContext(ctx, "create table if not exists busy_probe (id integer)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := holderConn.ExecContext(ctx, "begin immediate"); err != nil {
+		t.Fatalf("begin immediate: %v", err)
+	}
+	t.Cleanup(func() { _, _ = holderConn.ExecContext(ctx, "rollback") })
+
+	contender, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open contender: %v", err)
+	}
+	t.Cleanup(func() { _ = contender.Close() })
+	if _, err := contender.ExecContext(ctx, "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("set contender busy_timeout: %v", err)
+	}
+	_, busyErr := contender.ExecContext(ctx, "insert into busy_probe (id) values (1)")
+	if busyErr == nil {
+		t.Fatal("expected contender write to fail with SQLITE_BUSY")
+	}
+	return busyErr
+}

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -87,7 +88,7 @@ func New(cfg Config) (*Connector, error) {
 			return nil, fmt.Errorf("create local sqlite parent: %w", err)
 		}
 	}
-	db, err := sql.Open("sqlite", path)
+	db, err := sql.Open("sqlite", sqliteDSN(path))
 	if err != nil {
 		return nil, fmt.Errorf("open local sqlite: %w", err)
 	}
@@ -116,6 +117,45 @@ func New(cfg Config) (*Connector, error) {
 		return nil, err
 	}
 	return conn, nil
+}
+
+// sqliteDSN opens the tracker database with a busy timeout and WAL enabled on
+// every pooled connection. The database is shared with a running detent
+// server and with operators editing it via the sqlite3 shell, so writes must
+// wait for the lock instead of failing immediately with SQLITE_BUSY. The
+// pragmas ride the DSN because ExecContext PRAGMAs would only configure the
+// single pool connection that happened to run them.
+func sqliteDSN(path string) string {
+	if path == ":memory:" {
+		return path
+	}
+	return "file:" + escapeSQLiteURIPath(sqliteURIPath(path)) +
+		"?_pragma=busy_timeout(5000)&_pragma=journal_mode(WAL)"
+}
+
+func sqliteURIPath(path string) string {
+	cleaned := filepath.Clean(path)
+	uriPath := filepath.ToSlash(cleaned)
+	if windowsDrivePath(uriPath) {
+		uriPath = strings.ReplaceAll(cleaned, `\`, "/")
+		if !strings.HasPrefix(uriPath, "/") {
+			uriPath = "/" + uriPath
+		}
+	}
+	return uriPath
+}
+
+func windowsDrivePath(path string) bool {
+	return len(path) >= 2 && path[1] == ':' &&
+		(path[0] >= 'A' && path[0] <= 'Z' || path[0] >= 'a' && path[0] <= 'z')
+}
+
+func escapeSQLiteURIPath(path string) string {
+	parts := strings.Split(path, "/")
+	for index, part := range parts {
+		parts[index] = url.PathEscape(part)
+	}
+	return strings.Join(parts, "/")
 }
 
 func (c *Connector) Name() string {
@@ -331,7 +371,7 @@ func (c *Connector) DeleteIssueComment(ctx context.Context, issueID string, comm
 
 func (c *Connector) UpdateIssueState(ctx context.Context, issueID string, stateName string) error {
 	issueID = strings.TrimSpace(issueID)
-	stateName = strings.TrimSpace(stateName)
+	stateName = c.canonicalState(stateName)
 	now := c.now().UTC()
 	result, err := c.db.ExecContext(ctx, `
 update detent_work_items
@@ -429,7 +469,7 @@ identifier text not null,
 title text not null default '',
 description text not null default '',
 priority integer,
-state text not null default '',
+state text not null default '' collate nocase,
 url text not null default '',
 author_id text not null default '',
 assignee_id text not null default '',
@@ -698,6 +738,7 @@ func (c *Connector) upsertIssue(ctx context.Context, issue connector.Issue) erro
 	if identifier == "" {
 		identifier = id
 	}
+	issue.State = c.canonicalState(issue.State)
 	now := c.now().UTC()
 	createdAt := timeOrDefault(issue.CreatedAt, now)
 	updatedAt := timeOrDefault(issue.UpdatedAt, createdAt)
@@ -804,6 +845,7 @@ func (c *Connector) insertSeedIssue(ctx context.Context, issue connector.Issue) 
 	if identifier == "" {
 		identifier = id
 	}
+	issue.State = c.canonicalState(issue.State)
 	now := c.now().UTC()
 	createdAt := timeOrDefault(issue.CreatedAt, now)
 	updatedAt := timeOrDefault(issue.UpdatedAt, createdAt)
@@ -898,7 +940,10 @@ where project_id = ?`
 			placeholders = append(placeholders, "?")
 			args = append(args, state)
 		}
-		query += " and state in (" + strings.Join(placeholders, ",") + ")"
+		// Callers such as the orchestrator lowercase configured states while
+		// rows may hold the template's capitalized spellings; compare
+		// case-insensitively so items stay visible either way.
+		query += " and state collate nocase in (" + strings.Join(placeholders, ",") + ")"
 	}
 	query += " order by updated_at desc, id asc"
 	if limit > 0 {
@@ -983,6 +1028,25 @@ where project_id = ? and id = ?`, fieldsJSON, formatTime(now), c.projectID, stri
 		return err
 	}
 	return c.recordEvent(ctx, strings.TrimSpace(issueID), eventKindFieldUpdate, "", "", map[string]string{fieldName: ""})
+}
+
+// canonicalState maps a state name to its configured spelling. The
+// orchestrator lowercases configured states before writing them back while
+// templates and humans use capitalized spellings; without this the state
+// column accumulates both cases.
+func (c *Connector) canonicalState(name string) string {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return name
+	}
+	for _, states := range [][]string{c.activeStates, c.observedStates, c.terminalStates} {
+		for _, state := range states {
+			if state = strings.TrimSpace(state); strings.EqualFold(state, name) {
+				return state
+			}
+		}
+	}
+	return name
 }
 
 func (c *Connector) closedState() string {
@@ -1233,16 +1297,28 @@ func formatTime(value time.Time) string {
 	return value.UTC().Format(time.RFC3339Nano)
 }
 
+// parseTimeLayouts tolerates the timestamp shapes external producers write
+// into the tracker database (the sqlite shell's CURRENT_TIMESTAMP and
+// datetime() emit space-separated UTC values), not just detent's own
+// RFC3339Nano output.
+var parseTimeLayouts = []string{
+	time.RFC3339Nano,
+	"2006-01-02 15:04:05.999999999Z07:00",
+	"2006-01-02 15:04:05",
+	"2006-01-02",
+}
+
 func parseTimePointer(value string) *time.Time {
 	value = strings.TrimSpace(value)
 	if value == "" {
 		return nil
 	}
-	parsed, err := time.Parse(time.RFC3339Nano, value)
-	if err != nil {
-		return nil
+	for _, layout := range parseTimeLayouts {
+		if parsed, err := time.Parse(layout, value); err == nil {
+			return &parsed
+		}
 	}
-	return &parsed
+	return nil
 }
 
 func marshalStringSlice(values []string) (string, error) {

--- a/internal/connector/local/local_case_test.go
+++ b/internal/connector/local/local_case_test.go
@@ -1,0 +1,189 @@
+package local
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func newCaseTestConnector(t *testing.T, issues ...connector.Issue) *Connector {
+	t.Helper()
+	conn, err := New(Config{
+		Path:           filepath.Join(t.TempDir(), "work-items.db"),
+		ProjectID:      "video",
+		Issues:         issues,
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+		Now: func() time.Time {
+			return time.Date(2026, 7, 8, 22, 46, 22, 502102357, time.UTC)
+		},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	return conn
+}
+
+func seedIssue(id, state string) connector.Issue {
+	issue := connector.NewIssue()
+	issue.ID = id
+	issue.Identifier = id
+	issue.Title = "Rework Storyboard"
+	issue.State = state
+	return issue
+}
+
+// Regression test for #1067: the scheduler lowercases configured states while
+// rows hold the template's capitalized spellings; the state filter must match
+// either way.
+func TestFetchIssuesByStatesMatchesCaseInsensitively(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newCaseTestConnector(t, seedIssue("wi-1", "Todo"))
+
+	tests := []struct {
+		name   string
+		states []string
+		want   int
+	}{
+		{name: "lowercased query against capitalized row", states: []string{"todo", "production", "rework"}, want: 1},
+		{name: "capitalized query", states: []string{"Todo"}, want: 1},
+		{name: "uppercase query", states: []string{"TODO"}, want: 1},
+		{name: "non-matching state", states: []string{"review"}, want: 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			issues, err := conn.FetchIssuesByStates(ctx, tt.states)
+			if err != nil {
+				t.Fatalf("FetchIssuesByStates(%v) error = %v", tt.states, err)
+			}
+			if len(issues) != tt.want {
+				t.Fatalf("FetchIssuesByStates(%v) len = %d, want %d", tt.states, len(issues), tt.want)
+			}
+		})
+	}
+}
+
+func TestUpdateIssueStateWritesConfiguredSpelling(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newCaseTestConnector(t, seedIssue("wi-1", "Todo"))
+
+	// The orchestrator writes lowercased state names; the stored value must
+	// keep the configured spelling so the column stays single-cased.
+	if err := conn.UpdateIssueState(ctx, "wi-1", "blocked"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+	var stored string
+	if err := conn.db.QueryRowContext(ctx, "select state from detent_work_items where id = 'wi-1'").Scan(&stored); err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if stored != "Blocked" {
+		t.Fatalf("stored state = %q, want Blocked", stored)
+	}
+
+	// A state outside the configured vocabulary is written as passed.
+	if err := conn.UpdateIssueState(ctx, "wi-1", "Custom Lane"); err != nil {
+		t.Fatalf("UpdateIssueState() error = %v", err)
+	}
+	if err := conn.db.QueryRowContext(ctx, "select state from detent_work_items where id = 'wi-1'").Scan(&stored); err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if stored != "Custom Lane" {
+		t.Fatalf("stored state = %q, want Custom Lane", stored)
+	}
+}
+
+func TestSeedNormalizesStateToConfiguredSpelling(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newCaseTestConnector(t, seedIssue("wi-lower", "todo"))
+
+	var stored string
+	if err := conn.db.QueryRowContext(ctx, "select state from detent_work_items where id = 'wi-lower'").Scan(&stored); err != nil {
+		t.Fatalf("read state: %v", err)
+	}
+	if stored != "Todo" {
+		t.Fatalf("stored seed state = %q, want Todo", stored)
+	}
+}
+
+func TestNewAppliesSQLitePragmas(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	conn := newCaseTestConnector(t)
+
+	var busyTimeout int64
+	if err := conn.db.QueryRowContext(ctx, "pragma busy_timeout").Scan(&busyTimeout); err != nil {
+		t.Fatalf("read busy_timeout: %v", err)
+	}
+	if busyTimeout != 5000 {
+		t.Fatalf("busy_timeout = %d, want 5000", busyTimeout)
+	}
+	var journalMode string
+	if err := conn.db.QueryRowContext(ctx, "pragma journal_mode").Scan(&journalMode); err != nil {
+		t.Fatalf("read journal_mode: %v", err)
+	}
+	if journalMode != "wal" {
+		t.Fatalf("journal_mode = %q, want wal", journalMode)
+	}
+}
+
+func TestParseTimePointerToleratesExternalFormats(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		value   string
+		want    time.Time
+		wantNil bool
+	}{
+		{
+			name:  "detent rfc3339 nanoseconds",
+			value: "2026-07-08T22:46:22.502102357Z",
+			want:  time.Date(2026, 7, 8, 22, 46, 22, 502102357, time.UTC),
+		},
+		{
+			name:  "rfc3339 milliseconds",
+			value: "2026-07-08T22:46:22.502Z",
+			want:  time.Date(2026, 7, 8, 22, 46, 22, 502000000, time.UTC),
+		},
+		{
+			name:  "sqlite current_timestamp",
+			value: "2026-07-08 22:46:22",
+			want:  time.Date(2026, 7, 8, 22, 46, 22, 0, time.UTC),
+		},
+		{
+			name:  "date only",
+			value: "2026-07-08",
+			want:  time.Date(2026, 7, 8, 0, 0, 0, 0, time.UTC),
+		},
+		{name: "empty", value: "", wantNil: true},
+		{name: "garbage", value: "yesterday", wantNil: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseTimePointer(tt.value)
+			if tt.wantNil {
+				if got != nil {
+					t.Fatalf("parseTimePointer(%q) = %v, want nil", tt.value, got)
+				}
+				return
+			}
+			if got == nil || !got.Equal(tt.want) {
+				t.Fatalf("parseTimePointer(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -337,6 +337,13 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	return dispatchIssueOutcome{dispatched: true}
 }
 
+// dispatchWorkingStates lists the active-state names recognized as the
+// "agent is working" lane, in preference order: "In Progress" is the GitHub
+// Projects convention, "Production" the non-code artifact template's. Without
+// this resolution, projects using the template vocabulary never leave Todo
+// while an agent works them and the board shows nothing running.
+var dispatchWorkingStates = []string{planImplementationState, "Production"}
+
 func dispatchStartTransitionState(issue connector.Issue, mode string, activeStates []string) string {
 	if mode != runpkg.RunModeImplement {
 		return ""
@@ -344,10 +351,12 @@ func dispatchStartTransitionState(issue connector.Issue, mode string, activeStat
 	if normalizeState(issue.State) != "todo" {
 		return ""
 	}
-	if !stateIn(planImplementationState, activeStates) {
-		return ""
+	for _, working := range dispatchWorkingStates {
+		if stateIn(working, activeStates) {
+			return working
+		}
 	}
-	return planImplementationState
+	return ""
 }
 
 func (o *Orchestrator) dispatchMode(ctx context.Context, state *State, issue connector.Issue) string {

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -1,0 +1,129 @@
+package orchestrator_test
+
+import (
+	"context"
+	"database/sql"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	local "github.com/digitaldrywood/detent/internal/connector/local"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+)
+
+// TestLocalSQLiteLifecycleEndToEnd drives the real local_sqlite connector
+// through a full work-item lifecycle with the non-code artifact template's
+// capitalized state vocabulary: seed a Todo item, let the orchestrator
+// schedule it, observe the dispatch-start transition to Production while a
+// fake agent runs, then complete and check the item stays visible and the
+// snapshot carries the fields the kanban board renders (state lane and
+// stage_updated_at for the "In lane" footer).
+func TestLocalSQLiteLifecycleEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "video-work-items.db")
+	seed := connector.NewIssue()
+	seed.ID = "wi-e2e-1"
+	seed.Identifier = "wi-e2e-1"
+	seed.Title = "Rework Storyboard — round 2"
+	seed.State = "Todo"
+
+	tracker, err := local.New(local.Config{
+		Path:           dbPath,
+		ProjectID:      "digitaldrywood-video",
+		Issues:         []connector.Issue{seed},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	defer tracker.Close()
+
+	release := make(chan struct{})
+	runner := &staticRunner{
+		result: orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted},
+		onRun: func(orchestrator.RunRequest) {
+			<-release
+		},
+	}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Millisecond,
+		MaxConcurrentAgents: 1,
+		// The orchestrator lowercases these before querying the connector;
+		// the seeded rows keep the template's capitalized spellings. Before
+		// #1067 was fixed this mismatch made the item invisible.
+		ActiveStates:           []string{"Todo", "Production", "Rework"},
+		ObservedStates:         []string{"Backlog", "Review", "Blocked"},
+		TerminalStates:         []string{"Ready for Pickup", "Done", "Cancelled"},
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	// Scheduling: the capitalized Todo row must be fetched and dispatched.
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Running[seed.ID]
+		return ok
+	})
+
+	// Dispatch start: the item must leave Todo while the agent works it.
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open tracker db: %v", err)
+	}
+	defer db.Close()
+	var storedState string
+	if err := db.QueryRowContext(context.Background(), "select state from detent_work_items where id = ?", seed.ID).Scan(&storedState); err != nil {
+		t.Fatalf("read stored state: %v", err)
+	}
+	if storedState != "Production" {
+		t.Fatalf("stored state while running = %q, want Production", storedState)
+	}
+
+	// Snapshot: the board derives the lane from the running issue state and
+	// the "In lane" footer from stage_updated_at; both must be populated.
+	snapshot := state.Snapshot(time.Now())
+	if snapshot.Counts.Running != 1 {
+		t.Fatalf("snapshot running count = %d, want 1", snapshot.Counts.Running)
+	}
+	if got := snapshot.Running[0].State; got != "Production" {
+		t.Fatalf("snapshot running issue state = %q, want Production", got)
+	}
+	if snapshot.Running[0].StageUpdatedAt == nil {
+		t.Fatal("snapshot running issue StageUpdatedAt = nil, want stage timestamp")
+	}
+
+	// Completion: release the fake agent and wait for the run to finish.
+	close(release)
+	state = waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Completed[seed.ID]
+		return ok
+	})
+	if _, ok := state.Blocked[seed.ID]; ok {
+		t.Fatalf("Blocked[%q] present after successful completion", seed.ID)
+	}
+
+	// The item must remain visible to a lowercased state query afterwards.
+	issues, err := tracker.FetchIssuesByStates(context.Background(), []string{"todo", "production", "rework"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(issues))
+	}
+	if issues[0].StageUpdatedAt == nil {
+		t.Fatal("fetched issue StageUpdatedAt = nil, want parsed timestamp")
+	}
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -19,30 +19,32 @@ import (
 )
 
 const (
-	defaultPollInterval               = 30 * time.Second
-	defaultRunningReconcileInterval   = 2 * time.Minute
-	defaultWorkspaceCleanupIdleTTL    = 24 * time.Hour
-	defaultWorkspaceCleanupSweep      = 10 * time.Minute
-	gitHubGraphQLPauseRemaining       = 100
-	gitHubGraphQLBackoffRemaining     = 500
-	defaultGitHubGraphQLWarnRemaining = 500
-	defaultGitHubGraphQLMinReserve    = 1000
-	defaultGitHubRESTMinReserve       = 1000
-	defaultMaxConcurrentAgents        = 1
-	defaultMaxRetryBackoff            = 5 * time.Minute
-	defaultContinuationRetry          = time.Second
-	defaultFailureRetryBaseDelay      = 10 * time.Second
-	maxMergeWorkerRunnerFailures      = 3
-	instantFailureThreshold           = 5
-	instantFailureMaxDuration         = 10 * time.Second
-	instantFailureBlockedReasonPrefix = "instant fail circuit breaker: "
-	continuationDispatchBackoff       = 100 * time.Millisecond
-	runUpdateBufferSize               = 128
-	maxRecentEvents                   = 50
-	blockedStatusState                = "Blocked"
-	blockedReasonDependency           = "blocked by non-terminal dependency"
-	blockedReasonProjectStatus        = "blocked by project status"
-	mergeWorkerTerminalStateMissing   = "merge worker completed without reaching a terminal issue or pull request state"
+	defaultPollInterval                = 30 * time.Second
+	defaultRunningReconcileInterval    = 2 * time.Minute
+	defaultWorkspaceCleanupIdleTTL     = 24 * time.Hour
+	defaultWorkspaceCleanupSweep       = 10 * time.Minute
+	gitHubGraphQLPauseRemaining        = 100
+	gitHubGraphQLBackoffRemaining      = 500
+	defaultGitHubGraphQLWarnRemaining  = 500
+	defaultGitHubGraphQLMinReserve     = 1000
+	defaultGitHubRESTMinReserve        = 1000
+	defaultMaxConcurrentAgents         = 1
+	defaultMaxRetryBackoff             = 5 * time.Minute
+	defaultContinuationRetry           = time.Second
+	defaultFailureRetryBaseDelay       = 10 * time.Second
+	maxMergeWorkerRunnerFailures       = 3
+	instantFailureThreshold            = 5
+	instantFailureMaxDuration          = 10 * time.Second
+	instantFailureBlockedReasonPrefix  = "instant fail circuit breaker: "
+	repeatedFailureThreshold           = 5
+	repeatedFailureBlockedReasonPrefix = "repeated failure circuit breaker: "
+	continuationDispatchBackoff        = 100 * time.Millisecond
+	runUpdateBufferSize                = 128
+	maxRecentEvents                    = 50
+	blockedStatusState                 = "Blocked"
+	blockedReasonDependency            = "blocked by non-terminal dependency"
+	blockedReasonProjectStatus         = "blocked by project status"
+	mergeWorkerTerminalStateMissing    = "merge worker completed without reaching a terminal issue or pull request state"
 )
 
 var (
@@ -516,4 +518,5 @@ func (o *Orchestrator) cleanupDrainedRun(ctx context.Context, state *State, issu
 	delete(state.BudgetRefusals, issueID)
 	delete(state.PriorAttempts, issueID)
 	delete(state.InstantFailures, issueID)
+	delete(state.RepeatedFailures, issueID)
 }

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -1279,20 +1279,30 @@ func TestRunInstantFailureCircuitBreakerComparesFullBackendErrorKey(t *testing.T
 	defer stop()
 
 	state := waitForState(t, orch, func(state orchestrator.State) bool {
-		if _, ok := state.Blocked[issue.ID]; ok {
-			return true
-		}
-		return runner.calls.Load() >= 8
+		_, ok := state.Blocked[issue.ID]
+		return ok
 	})
 
-	if _, ok := state.Blocked[issue.ID]; ok {
-		t.Fatalf("Blocked[%q] present after alternating backend errors with matching truncated text", issue.ID)
+	// Alternating backend errors must not trip the instant-failure breaker
+	// (the full error key differs each attempt even though the truncated
+	// operator text matches); the repeated-failure breaker still parks the
+	// issue after five consecutive failures regardless of error text.
+	reason := state.Blocked[issue.ID].Reason
+	if strings.HasPrefix(reason, "instant fail circuit breaker: ") {
+		t.Fatalf("Blocked[%q].Reason = %q, instant breaker tripped on alternating backend errors", issue.ID, reason)
 	}
-	if got := runner.calls.Load(); got < 8 {
-		t.Fatalf("runner calls = %d, want at least 8", got)
+	if !strings.HasPrefix(reason, "repeated failure circuit breaker: ") {
+		t.Fatalf("Blocked[%q].Reason = %q, want repeated failure circuit breaker prefix", issue.ID, reason)
 	}
-	if comments := tracker.commentCalls(); len(comments) != 0 {
-		t.Fatalf("comments = %#v, want none", comments)
+	if got := runner.calls.Load(); got != 5 {
+		t.Fatalf("runner calls = %d, want 5", got)
+	}
+	comments := tracker.commentCalls()
+	if len(comments) != 1 {
+		t.Fatalf("comments = %#v, want one repeated failure comment", comments)
+	}
+	if !strings.Contains(comments[0].body, "consecutive failed attempts") {
+		t.Fatalf("comment body missing repeated failure text:\n%s", comments[0].body)
 	}
 }
 

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -483,7 +483,8 @@ func clearBlockedStatusIssue(state *State, issueID string) {
 func (o *Orchestrator) setBlockedStatusIssue(state *State, issue connector.Issue, now time.Time) {
 	if existing, ok := state.Blocked[issue.ID]; ok &&
 		existing.Source == BlockedSourceProjectStatus &&
-		strings.HasPrefix(existing.Reason, instantFailureBlockedReasonPrefix) &&
+		(strings.HasPrefix(existing.Reason, instantFailureBlockedReasonPrefix) ||
+			strings.HasPrefix(existing.Reason, repeatedFailureBlockedReasonPrefix)) &&
 		strings.TrimSpace(issue.BlockerReason) == "" {
 		existing.Issue = cloneIssue(issue)
 		state.Blocked[issue.ID] = existing

--- a/internal/orchestrator/repeated_failure_test.go
+++ b/internal/orchestrator/repeated_failure_test.go
@@ -1,0 +1,170 @@
+package orchestrator_test
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+)
+
+// tokenCeilingRunner fails every attempt with an error whose text varies per
+// call, the way a session token ceiling failure reports a different
+// total_tokens each attempt. The varying text keeps the instant-failure
+// breaker from matching consecutive errors, which is exactly the gap the
+// repeated-failure breaker covers.
+type tokenCeilingRunner struct {
+	calls        atomic.Int64
+	failureCount int64
+}
+
+func (r *tokenCeilingRunner) Run(_ context.Context, _ orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	n := r.calls.Add(1)
+	if r.failureCount > 0 && n > r.failureCount {
+		return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+	}
+	return orchestrator.RunResult{}, fmt.Errorf(
+		"run agent turn: claude update rejected: session token ceiling exceeded: total_tokens=%d ceiling_tokens=2000000 source=max_session_tokens",
+		2000000+n,
+	)
+}
+
+func TestRunParksIssueAfterRepeatedCostlyWorkerFailures(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-repeated-fail", "wi-011cd179bc7ecf36b7197e4b", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := &tokenCeilingRunner{}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		ObservedStates:         []string{"Blocked"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Blocked[issue.ID]
+		return ok
+	})
+
+	if got := runner.calls.Load(); got != 5 {
+		t.Fatalf("runner calls = %d, want 5", got)
+	}
+	reason := state.Blocked[issue.ID].Reason
+	if !strings.Contains(reason, "repeated failure circuit breaker: ") {
+		t.Fatalf("Blocked[%q].Reason = %q, want repeated failure circuit breaker prefix", issue.ID, reason)
+	}
+	if !strings.Contains(reason, "session token ceiling exceeded") {
+		t.Fatalf("Blocked[%q].Reason = %q, want last worker error", issue.ID, reason)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after circuit breaker", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after circuit breaker", issue.ID)
+	}
+	if _, ok := state.RepeatedFailures[issue.ID]; ok {
+		t.Fatalf("RepeatedFailures[%q] present after park", issue.ID)
+	}
+	updates := tracker.stateUpdateCalls()
+	if len(updates) == 0 || updates[len(updates)-1] != (stateUpdateCall{issueID: issue.ID, state: "Blocked"}) {
+		t.Fatalf("state updates = %#v, want final Blocked transition", updates)
+	}
+	comments := tracker.commentCalls()
+	if len(comments) != 1 {
+		t.Fatalf("comments = %#v, want one circuit breaker comment", comments)
+	}
+	if !strings.Contains(comments[0].body, "consecutive failed attempts") || !strings.Contains(comments[0].body, "session token ceiling exceeded") {
+		t.Fatalf("comment body missing repeated failure details:\n%s", comments[0].body)
+	}
+}
+
+func TestRunRepeatedFailureCounterResetsOnSuccessfulCompletion(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-repeated-fail-reset", "digitaldrywood/detent#980", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := &tokenCeilingRunner{failureCount: 4}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		ObservedStates:         []string{"Blocked"},
+		TerminalStates:         []string{"Done", "Cancelled", "Canceled", "Closed"},
+		ContinuationRetryDelay: time.Second,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	state := waitForState(t, orch, func(state orchestrator.State) bool {
+		_, ok := state.Completed[issue.ID]
+		return ok
+	})
+
+	if _, ok := state.Blocked[issue.ID]; ok {
+		t.Fatalf("Blocked[%q] present after successful completion", issue.ID)
+	}
+	if _, ok := state.RepeatedFailures[issue.ID]; ok {
+		t.Fatalf("RepeatedFailures[%q] present after successful completion", issue.ID)
+	}
+}
+
+func TestRunDispatchTransitionsTemplateVocabularyIssueToProduction(t *testing.T) {
+	t.Parallel()
+
+	issue := testIssue("issue-production-transition", "wi-local-video-1", "Todo")
+	tracker := newFakeConnector(issue)
+	runner := &staticRunner{
+		result: orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted},
+	}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:           time.Millisecond,
+		MaxConcurrentAgents:    1,
+		MaxRetryBackoff:        time.Hour,
+		FailureRetryBaseDelay:  time.Hour,
+		ActiveStates:           []string{"Todo", "Production", "Rework"},
+		ObservedStates:         []string{"Backlog", "Review", "Blocked"},
+		TerminalStates:         []string{"Ready for Pickup", "Done", "Cancelled"},
+		ContinuationRetryDelay: time.Millisecond,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	waitForStateUpdate(t, tracker, stateUpdateCall{issueID: issue.ID, state: "Production"})
+	updates := tracker.stateUpdateCalls()
+	if len(updates) == 0 || updates[0] != (stateUpdateCall{issueID: issue.ID, state: "Production"}) {
+		t.Fatalf("state updates = %#v, want Production as the dispatch-start transition", updates)
+	}
+}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -153,6 +153,12 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		return
 	}
 
+	// Every path below is a completion without a worker error: reset both
+	// failure circuit breakers here so plan and merge-worker completions do
+	// not carry stale counts into the next attempt cycle.
+	delete(state.InstantFailures, event.IssueID)
+	delete(state.RepeatedFailures, event.IssueID)
+
 	if event.Request.Mode == runpkg.RunModePlan {
 		o.logWorkerLifecycle(running.Issue, "worker_"+workerOutcome(event.Err, event.Result.FinalState),
 			"attempt", running.Attempt,
@@ -210,8 +216,6 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		statusMessage = "worker completed without PR progress"
 	}
 	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, implementCompletionProgressMetadata(progress))
-	delete(state.InstantFailures, event.IssueID)
-	delete(state.RepeatedFailures, event.IssueID)
 
 	state.Completed[event.IssueID] = Completed{
 		Issue:       cloneIssue(running.Issue),

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -134,6 +134,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		if o.tripInstantFailureCircuitBreaker(ctx, state, event, running, attempt) {
 			return
 		}
+		if o.tripRepeatedFailureCircuitBreaker(ctx, state, event, running, attempt) {
+			return
+		}
 		delay := event.RetryDelay
 		if delay <= 0 {
 			delay = o.retryDelay(attempt, false)
@@ -208,6 +211,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	}
 	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, implementCompletionProgressMetadata(progress))
 	delete(state.InstantFailures, event.IssueID)
+	delete(state.RepeatedFailures, event.IssueID)
 
 	state.Completed[event.IssueID] = Completed{
 		Issue:       cloneIssue(running.Issue),
@@ -368,6 +372,7 @@ func (o *Orchestrator) parkInstantFailure(
 	delete(state.Retry, issue.ID)
 	delete(state.BudgetRefusals, issue.ID)
 	delete(state.PriorAttempts, issue.ID)
+	delete(state.RepeatedFailures, issue.ID)
 	if state.Blocked == nil {
 		state.Blocked = map[string]Blocked{}
 	}
@@ -411,6 +416,134 @@ func (o *Orchestrator) parkInstantFailure(
 
 func (o *Orchestrator) instantFailureParkState() string {
 	return blockedStatusState
+}
+
+// tripRepeatedFailureCircuitBreaker parks an issue after too many consecutive
+// worker failures of any duration. The instant-failure breaker only counts
+// sub-instantFailureMaxDuration failures with identical error text, which lets
+// a long-running failure — one that spends minutes of paid agent time per
+// attempt, like a session token ceiling hit — retry forever. This breaker
+// counts every worker failure and resets only on a successful completion.
+func (o *Orchestrator) tripRepeatedFailureCircuitBreaker(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	attempt int,
+) bool {
+	if state == nil || event.Err == nil {
+		return false
+	}
+	if state.RepeatedFailures == nil {
+		state.RepeatedFailures = map[string]RepeatedFailure{}
+	}
+	failure := state.RepeatedFailures[event.IssueID]
+	if failure.Count == 0 {
+		failure.FirstFailureAt = event.CompletedAt
+	}
+	failure.Count++
+	failure.Issue = cloneIssue(running.Issue)
+	failure.Error = o.operatorText(event.Err.Error())
+	failure.LastFailureAt = event.CompletedAt
+	state.RepeatedFailures[event.IssueID] = failure
+	if failure.Count < repeatedFailureThreshold {
+		return false
+	}
+
+	o.parkRepeatedFailure(ctx, state, event, running, failure, attempt)
+	return true
+}
+
+func (o *Orchestrator) parkRepeatedFailure(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+	failure RepeatedFailure,
+	attempt int,
+) {
+	targetState := o.instantFailureParkState()
+	issue := cloneIssue(running.Issue)
+	if targetState != "" {
+		if err := o.updateIssueState(ctx, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker"); err != nil {
+			if o.logger != nil {
+				o.logger.Error(
+					"repeated failure circuit breaker state transition failed",
+					"issue_id", issue.ID,
+					"identifier", issue.Identifier,
+					"target_state", targetState,
+					"error", err,
+				)
+			}
+		} else {
+			issue.State = targetState
+		}
+	}
+	if o.connector != nil {
+		if err := o.connector.CreateComment(ctx, issue.ID, repeatedFailureComment(issue, event.Err, failure, attempt, targetState, o.cfg.OutputTruncationMaxBytes)); err != nil && o.logger != nil {
+			o.logger.Error("repeated failure circuit breaker comment failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	if err := o.abandonClaim(ctx, issue.ID); err != nil && o.logger != nil {
+		o.logger.Error("repeated failure circuit breaker claim release failed", "issue_id", issue.ID, "identifier", issue.Identifier, "error", err)
+	}
+	delete(state.Claimed, issue.ID)
+	delete(state.Retry, issue.ID)
+	delete(state.BudgetRefusals, issue.ID)
+	delete(state.PriorAttempts, issue.ID)
+	delete(state.InstantFailures, issue.ID)
+	delete(state.RepeatedFailures, issue.ID)
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issue.ID] = Blocked{
+		Issue:          issue,
+		Reason:         repeatedFailureBlockedReasonPrefix + failure.Error,
+		RecoveryReason: "fix the workflow or agent configuration causing every attempt to fail, then move the issue back to Todo or Rework",
+		RecoveryTarget: "Todo",
+		BlockedAt:      event.CompletedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "worker_repeated_failure_circuit_breaker_tripped",
+		Message: "parked " + issueLabel(issue) + " after repeated worker failures: " + failure.Error,
+	})
+	if o.logger != nil {
+		o.logger.Error("worker repeated failure circuit breaker tripped",
+			"event", "worker_repeated_failure_circuit_breaker_tripped",
+			"issue_id", issue.ID,
+			"issue_identifier", issue.Identifier,
+			"attempt", attempt,
+			"repeated_failures", failure.Count,
+			"first_failure_at", failure.FirstFailureAt,
+			"target_state", targetState,
+			"error", event.Err,
+		)
+	}
+}
+
+func repeatedFailureComment(issue connector.Issue, err error, failure RepeatedFailure, attempt int, targetState string, maxBytes int) string {
+	var b strings.Builder
+	b.WriteString("Detent stopped retrying this worker after ")
+	b.WriteString(strconv.Itoa(failure.Count))
+	b.WriteString(" consecutive failed attempts. Each attempt ran to failure and spent real agent time, so retrying without a change is waste.")
+	if targetState = strings.TrimSpace(targetState); targetState != "" {
+		b.WriteString("\n\nIssue parked in `")
+		b.WriteString(targetState)
+		b.WriteString("`.")
+	}
+	b.WriteString("\n\n- issue: ")
+	b.WriteString(issueLabel(issue))
+	b.WriteString("\n- latest_attempt: ")
+	b.WriteString(strconv.Itoa(attempt))
+	b.WriteString("\n- first_failure_at: ")
+	b.WriteString(failure.FirstFailureAt.UTC().Format(time.RFC3339))
+	b.WriteString("\n- last error:\n\n```text\n")
+	b.WriteString(runtimeoutput.Truncate(strings.TrimSpace(err.Error()), maxBytes).Value)
+	b.WriteString("\n```")
+	b.WriteString("\n\nFix the workflow or agent configuration causing every attempt to fail, then move the issue back to Todo or Rework.")
+	return b.String()
 }
 
 func instantFailureComment(issue connector.Issue, err error, failure InstantFailure, attempt int, targetState string, maxBytes int) string {
@@ -933,6 +1066,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	delete(state.BudgetRefusals, issueID)
 	delete(state.PriorAttempts, issueID)
 	delete(state.InstantFailures, issueID)
+	delete(state.RepeatedFailures, issueID)
 	if err := o.abandonClaim(ctx, issueID); err != nil {
 		recordStateEvent(state, telemetry.ActivityEvent{
 			At:      cleanupEventAt(completedAt),

--- a/internal/orchestrator/run_completion_plan_reset_test.go
+++ b/internal/orchestrator/run_completion_plan_reset_test.go
@@ -1,0 +1,51 @@
+package orchestrator
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+)
+
+// Regression test: a successful plan completion must clear both failure
+// circuit breakers. The reset used to live only in the implement completion
+// path, after the plan branch had already returned, so a plan that failed
+// repeatedly and then succeeded carried a stale count that could park the
+// issue prematurely on a later unrelated failure.
+func TestHandleRunResultPlanCompletionResetsFailureBreakers(t *testing.T) {
+	t.Parallel()
+
+	tracker := &dependencyAutoUnblockConnector{}
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch := planReviewTestOrchestrator(tracker, metrics)
+	state := newState(orch.cfg)
+
+	issue := dependencyAutoUnblockIssue("issue-plan-reset", "Todo")
+	now := time.Date(2026, 7, 9, 3, 0, 0, 0, time.UTC)
+	state.Running[issue.ID] = Running{
+		Issue:     issue,
+		Attempt:   repeatedFailureThreshold,
+		Mode:      runpkg.RunModePlan,
+		StartedAt: now.Add(-3 * time.Minute),
+	}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: repeatedFailureThreshold - 1}
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: instantFailureThreshold - 1}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModePlan},
+		Result:      runpkg.RunResult{Output: "plan artifact"},
+		CompletedAt: now,
+	})
+
+	if _, ok := state.RepeatedFailures[issue.ID]; ok {
+		t.Fatalf("RepeatedFailures[%q] present after successful plan completion", issue.ID)
+	}
+	if _, ok := state.InstantFailures[issue.ID]; ok {
+		t.Fatalf("InstantFailures[%q] present after successful plan completion", issue.ID)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one plan artifact comment", tracker.comments)
+	}
+}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -53,6 +53,7 @@ type State struct {
 	BudgetRefusals           map[string]BudgetRefusal
 	PriorAttempts            map[string]runpkg.PriorAttempt
 	InstantFailures          map[string]InstantFailure
+	RepeatedFailures         map[string]RepeatedFailure
 	DiffStats                map[string]DiffStats
 	ReapedWorkspaces         map[string]time.Time
 	TokenTotals              TokenTotals
@@ -150,6 +151,18 @@ type InstantFailure struct {
 	LastFailureAt  time.Time
 }
 
+// RepeatedFailure tracks consecutive worker failures of any duration for one
+// issue. Unlike InstantFailure it does not require matching error text: token
+// counts and other attempt-specific details vary between otherwise identical
+// failures, and each retry of a long-running failure spends real money.
+type RepeatedFailure struct {
+	Issue          connector.Issue
+	Error          string
+	Count          int
+	FirstFailureAt time.Time
+	LastFailureAt  time.Time
+}
+
 type TransientCheckRetry struct {
 	IssueID       string
 	HeadSHA       string
@@ -187,6 +200,7 @@ func newState(cfg Config) State {
 		BudgetRefusals:           map[string]BudgetRefusal{},
 		PriorAttempts:            map[string]runpkg.PriorAttempt{},
 		InstantFailures:          map[string]InstantFailure{},
+		RepeatedFailures:         map[string]RepeatedFailure{},
 		DiffStats:                map[string]DiffStats{},
 		ReapedWorkspaces:         map[string]time.Time{},
 		planRework:               map[string]struct{}{},
@@ -233,6 +247,7 @@ func (s State) clone() State {
 		BudgetRefusals:           make(map[string]BudgetRefusal, len(s.BudgetRefusals)),
 		PriorAttempts:            clonePriorAttempts(s.PriorAttempts),
 		InstantFailures:          make(map[string]InstantFailure, len(s.InstantFailures)),
+		RepeatedFailures:         make(map[string]RepeatedFailure, len(s.RepeatedFailures)),
 		DiffStats:                make(map[string]DiffStats, len(s.DiffStats)),
 		ReapedWorkspaces:         make(map[string]time.Time, len(s.ReapedWorkspaces)),
 		TokenTotals:              s.TokenTotals,
@@ -269,6 +284,10 @@ func (s State) clone() State {
 	for id, failure := range s.InstantFailures {
 		failure.Issue = cloneIssue(failure.Issue)
 		cloned.InstantFailures[id] = failure
+	}
+	for id, failure := range s.RepeatedFailures {
+		failure.Issue = cloneIssue(failure.Issue)
+		cloned.RepeatedFailures[id] = failure
 	}
 	for id, refusal := range s.BudgetRefusals {
 		refusal.Issue = cloneIssue(refusal.Issue)

--- a/internal/store/busy.go
+++ b/internal/store/busy.go
@@ -1,0 +1,23 @@
+package store
+
+import (
+	"errors"
+
+	sqlite "modernc.org/sqlite"
+	sqlite3 "modernc.org/sqlite/lib"
+)
+
+// IsBusy reports whether err is a SQLite busy or locked error, including
+// extended result codes such as SQLITE_BUSY_SNAPSHOT.
+func IsBusy(err error) bool {
+	var sqliteErr *sqlite.Error
+	if !errors.As(err, &sqliteErr) {
+		return false
+	}
+	switch sqliteErr.Code() & 0xff {
+	case sqlite3.SQLITE_BUSY, sqlite3.SQLITE_LOCKED:
+		return true
+	default:
+		return false
+	}
+}

--- a/internal/store/busy_test.go
+++ b/internal/store/busy_test.go
@@ -1,0 +1,76 @@
+package store
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"testing"
+)
+
+func TestIsBusy(t *testing.T) {
+	t.Parallel()
+
+	busyErr := generateBusyError(t)
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{name: "nil error", err: nil, want: false},
+		{name: "plain error", err: errors.New("database is locked"), want: false},
+		{name: "sqlite busy error", err: busyErr, want: true},
+		{name: "wrapped sqlite busy error", err: fmt.Errorf("creating api key: %w", busyErr), want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := IsBusy(tt.err); got != tt.want {
+				t.Fatalf("IsBusy(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// generateBusyError produces a genuine driver SQLITE_BUSY error by holding a
+// write transaction on one connection while a second, zero-timeout connection
+// attempts a write.
+func generateBusyError(t *testing.T) error {
+	t.Helper()
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "busy.db")
+
+	holder, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open holder: %v", err)
+	}
+	t.Cleanup(func() { _ = holder.Close() })
+	holderConn, err := holder.Conn(ctx)
+	if err != nil {
+		t.Fatalf("holder conn: %v", err)
+	}
+	t.Cleanup(func() { _ = holderConn.Close() })
+	if _, err := holderConn.ExecContext(ctx, "create table if not exists busy_probe (id integer)"); err != nil {
+		t.Fatalf("create table: %v", err)
+	}
+	if _, err := holderConn.ExecContext(ctx, "begin immediate"); err != nil {
+		t.Fatalf("begin immediate: %v", err)
+	}
+	t.Cleanup(func() { _, _ = holderConn.ExecContext(ctx, "rollback") })
+
+	contender, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open contender: %v", err)
+	}
+	t.Cleanup(func() { _ = contender.Close() })
+	if _, err := contender.ExecContext(ctx, "PRAGMA busy_timeout = 0"); err != nil {
+		t.Fatalf("set contender busy_timeout: %v", err)
+	}
+	_, busyErr := contender.ExecContext(ctx, "insert into busy_probe (id) values (1)")
+	if busyErr == nil {
+		t.Fatal("expected contender write to fail with SQLITE_BUSY")
+	}
+	return busyErr
+}

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -270,6 +270,8 @@ func TestBoardCardAgeFooterVisibility(t *testing.T) {
 		wantTerminal bool
 	}{
 		{name: "in progress", lane: "In Progress", wantAge: "12m"},
+		{name: "production working lane", lane: "Production", wantAge: "12m"},
+		{name: "rework", lane: "Rework", wantAge: "12m"},
 		{name: "blocked", lane: "Blocked", wantAge: "12m"},
 		{name: "review pr keeps metadata", lane: "Human Review", prNumber: 314, wantAge: "12m", wantMeta: "PR #314"},
 		{name: "merging", lane: "Merging", prNumber: 315, wantAge: "12m", wantMeta: "PR #315"},


### PR DESCRIPTION
## Summary

- **Spend-aware retry parking**: new repeated-failure circuit breaker parks an issue in `Blocked` after 5 consecutive worker failures of any duration. The instant-failure breaker only counts sub-10s failures with identical error text — multi-minute session-token-ceiling failures (whose `total_tokens=` varies per attempt) retried unattended for 28 paid sessions (~4h) on the first pure-local project.
- **Dispatch-start transition for template vocabularies**: the start-of-work transition required the literal `"In Progress"` in `active_states`, but the shipped non-code artifact template uses `Todo/Production/Rework`, so local_sqlite items never left Todo while an agent worked them and the board showed nothing running. Dispatch now resolves the working state from the configured vocabulary (`In Progress`, then `Production`).
- **#1067 case-insensitive states**: `state IN (...)` now compares `collate nocase`, the column is declared `collate nocase` for new databases, and write-backs are normalized to the configured spelling so the table no longer accumulates `Blocked`/`blocked` mixed-case rows.
- **Tolerant tracker timestamps**: the local connector parsed only strict RFC3339Nano and silently dropped anything else; it now also accepts sqlite-shell formats (`2026-07-08 22:46:22`, date-only), keeping "In lane" durations rendering when external scripts write the DB.
- **SQLITE_BUSY on CLI key commands**: `detent key add` shares the server's open path (busy_timeout was already 5000ms) but 5s is not enough against an actively writing server. Key commands now use a 30s busy timeout and surface an actionable hint via a new `store.IsBusy` (covers extended codes like `SQLITE_BUSY_SNAPSHOT`). The local connector DSN also sets `busy_timeout` + WAL on every pooled connection.
- **Token accounting docs**: README documents that `total_tokens` counts input + output + cache-created + cache-read, re-accumulated every turn; all workflow templates raise the `max_session_tokens` default from 2M (guaranteed death for a healthy Claude session within minutes) to 25M with an explanatory comment.
- **End-to-end regression test**: `internal/orchestrator/local_sqlite_e2e_test.go` drives the real local_sqlite connector through seed → schedule → dispatch transition → snapshot → completion with the capitalized template states; it fails on main for the dispatch, case-sensitivity, and timestamp bugs.

Fixes #1067

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check` — build, vet, nilaway, `go test -race ./...`, coverage 76.3% (70% gate), per-package floors all pass. The lint step reports 61 pre-existing findings on a clean `main` checkout as well (local golangci-lint newer than CI's); this branch introduces zero new findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)