### PR TITLE
docs(examples): add artifact workflow demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1347,6 +1347,9 @@ repo is a real, working instance of this setup to copy from.
    [`WORKFLOW.github_local.md`](docs/templates/WORKFLOW.github_local.md).
    Non-code artifact workflows can start from
    [`WORKFLOW.non_code_artifact.md`](docs/templates/WORKFLOW.non_code_artifact.md).
+   A runnable local example with seeded work items, artifact metadata, API
+   payloads, and artifact-gate transitions lives in
+   [`docs/examples/non-code-artifact`](docs/examples/non-code-artifact).
    They set `server.kanban.mode: integration` for trusted project boards;
    change that to `read_only` only for an observer or shared dashboard,
    explicit no-writes choice, or failed post-authorization write probes. They

--- a/docs/examples/non-code-artifact/README.md
+++ b/docs/examples/non-code-artifact/README.md
@@ -1,0 +1,138 @@
+# Non-Code Artifact Workflow Demo
+
+This demo shows Detent running a local content-production workflow with no
+GitHub issues, pull requests, branches, CI, or merge train. It uses:
+
+- `tracker.kind: local_sqlite` for work items and status.
+- `workspace.kind: filesystem` for task workspaces.
+- `deliverable.kind: artifact` for output manifests.
+- `gate.kind: artifact` with the `render_status` field as the review gate.
+
+## Run The Demo
+
+From this directory:
+
+```sh
+detent --config .detent/demo-global.yaml --host 127.0.0.1 --port 4101
+```
+
+Open <http://127.0.0.1:4101/projects/default/kanban>. The project id is
+`default` because the missing `.detent/demo-global.yaml` path makes Detent boot
+directly from this directory's `WORKFLOW.md` instead of using your normal global
+config.
+
+The seeded board shows a content workflow:
+
+```text
+Intake -> Research -> Draft -> Review -> Package -> Publish
+                    \-> Rework -> Draft
+```
+
+The seeded Review cards exercise all artifact-gate outcomes:
+
+- `pending_review` stays in Review.
+- `approved` promotes from Review to Package.
+- `recut` routes from Review to Rework.
+
+The sample cards set `assigned_to_worker: false` so opening the demo does not
+start real content agents. To test agent dispatch later, create an item in an
+active state in a workflow that has an agent backend configured for your
+environment.
+
+## Add Work Items Through The API
+
+Loopback demo runs do not require an API token. If you configure an
+`api_token`, add `-H "Authorization: Bearer $DETENT_API_TOKEN"` to the curl
+commands.
+
+```sh
+curl -fsS -X POST "http://127.0.0.1:4101/api/v1/projects/default/work-items" \
+  -H "Content-Type: application/json" \
+  --data @seed/01-research-brief.json
+
+curl -fsS -X POST "http://127.0.0.1:4101/api/v1/projects/default/work-items" \
+  -H "Content-Type: application/json" \
+  --data @seed/02-review-package.json
+```
+
+The response shape is:
+
+```json
+{"id":"api-demo-research-001","identifier":"api-demo-research-001","number":7,"url":"http://127.0.0.1:4101/projects/default/kanban"}
+```
+
+## Exercise Status Transitions
+
+The artifact gate reads `render_status` from each work item field. Use these
+status values:
+
+| Status | Gate action |
+| --- | --- |
+| `queued` | Wait in the current state. |
+| `pending_review` | Wait in Review. |
+| `approved` | Promote from Review to Package. |
+| `valid` | Promote from Review to Package. |
+| `recut` | Route from Review to Rework. |
+| `invalid` | Route from Review to Rework. |
+| `missing_assets` | Route from Review to Rework. |
+
+To flip the waiting Review card to approved:
+
+```sh
+sqlite3 .detent/non-code-artifact-demo.db \
+  "update detent_work_items set fields_json = json_set(fields_json, '$.render_status', 'approved') where project_id = 'content-production-demo' and id = 'content-demo-003';"
+
+curl -fsS -X POST "http://127.0.0.1:4101/api/v1/refresh"
+```
+
+To send the same card back through rework:
+
+```sh
+sqlite3 .detent/non-code-artifact-demo.db \
+  "update detent_work_items set state = 'Review', fields_json = json_set(fields_json, '$.render_status', 'recut') where project_id = 'content-production-demo' and id = 'content-demo-003';"
+
+curl -fsS -X POST "http://127.0.0.1:4101/api/v1/refresh"
+```
+
+No SQLite schema setup is required; the update only changes the configured
+status field on an already seeded local work item.
+
+To reset the demo, stop Detent and remove `.detent/non-code-artifact-demo.db`
+plus any adjacent `-wal` or `-shm` files.
+
+## Output Manifest Shape
+
+Each artifact card points at an output manifest under `output/`. The sample
+manifest in `output/package-approved-newsletter/manifest.json` shows the
+expected handoff shape:
+
+```json
+{
+  "work_item": {
+    "id": "content-demo-004",
+    "identifier": "content-demo-004",
+    "title": "Package approved newsletter"
+  },
+  "artifact": {
+    "kind": "newsletter_package",
+    "path": "output/package-approved-newsletter/newsletter-package.md",
+    "review_url": "http://127.0.0.1:4101/review/content-demo-004"
+  },
+  "validation": {
+    "status_field": "render_status",
+    "status": "approved",
+    "notes": "Ready for package handoff."
+  }
+}
+```
+
+## How This Differs From GitHub Issue-To-PR
+
+The default Detent code workflow reads GitHub status, creates a git worktree and
+branch, asks an agent to edit code, opens or updates a pull request, waits for
+CI and review, and merges through the serialized Merging lane.
+
+This artifact workflow keeps the same board and gate discipline but swaps out
+the delivery edge. Work items live in local SQLite, workspaces are plain
+filesystem directories, output is an artifact manifest, and the artifact gate
+looks at `render_status` instead of PR, CI, and automated review state.

--- a/docs/examples/non-code-artifact/WORKFLOW.md
+++ b/docs/examples/non-code-artifact/WORKFLOW.md
@@ -1,0 +1,290 @@
+---
+identity:
+  name: non-code-artifact-demo
+
+tracker:
+  kind: local_sqlite
+  local_sqlite:
+    path: .detent/non-code-artifact-demo.db
+    project_id: content-production-demo
+  active_states: []
+  observed_states:
+    - Intake
+    - Research
+    - Draft
+    - Review
+    - Rework
+    - Package
+    - Blocked
+  terminal_states:
+    - Publish
+    - Cancelled
+  issues:
+    - id: content-demo-001
+      identifier: content-demo-001
+      number: 1
+      title: Research launch proof points
+      description: Gather source facts for the release article and record source paths in the artifact manifest.
+      state: Research
+      assigned_to_worker: false
+      labels:
+        - content-demo
+        - research
+      priority: 1
+      fields:
+        artifact_type: research_brief
+        audience: evaluator
+        channel: launch-blog
+        render_status: queued
+        owner: research
+      metadata:
+        workflow_step: Research
+        source_assets: inputs/customer-interviews.md; inputs/product-notes.md
+        expected_manifest: output/research-launch-proof-points/manifest.json
+      deliverable:
+        kind: artifact
+        path: output/research-launch-proof-points/manifest.json
+        review_url: http://127.0.0.1:4101/review/content-demo-001
+        external_id: content-demo-001
+        metadata:
+          artifact_gate: render_status
+          expected_format: markdown
+          output_directory: output/research-launch-proof-points
+    - id: content-demo-002
+      identifier: content-demo-002
+      number: 2
+      title: Draft article narrative
+      description: Turn approved research into a publication draft with section-level source notes.
+      state: Draft
+      assigned_to_worker: false
+      labels:
+        - content-demo
+        - draft
+      priority: 2
+      fields:
+        artifact_type: markdown_draft
+        audience: evaluator
+        channel: launch-blog
+        render_status: pending_review
+        owner: editorial
+      metadata:
+        workflow_step: Draft
+        source_assets: output/research-launch-proof-points/manifest.json
+        expected_manifest: output/draft-article-narrative/manifest.json
+      deliverable:
+        kind: artifact
+        path: output/draft-article-narrative/manifest.json
+        review_url: http://127.0.0.1:4101/review/content-demo-002
+        external_id: content-demo-002
+        metadata:
+          artifact_gate: render_status
+          expected_format: markdown
+          output_directory: output/draft-article-narrative
+    - id: content-demo-003
+      identifier: content-demo-003
+      number: 3
+      title: Review image captions
+      description: Review social-card captions and mark the render_status field when approved or returned for rework.
+      state: Review
+      assigned_to_worker: false
+      labels:
+        - content-demo
+        - review
+      priority: 2
+      fields:
+        artifact_type: caption_pack
+        audience: social
+        channel: linkedin
+        render_status: pending_review
+        owner: reviewer
+      metadata:
+        workflow_step: Review
+        source_assets: output/draft-article-narrative/manifest.json
+        expected_manifest: output/review-image-captions/manifest.json
+      deliverable:
+        kind: artifact
+        path: output/review-image-captions/manifest.json
+        review_url: http://127.0.0.1:4101/review/content-demo-003
+        external_id: content-demo-003
+        metadata:
+          artifact_gate: render_status
+          expected_format: json
+          output_directory: output/review-image-captions
+    - id: content-demo-004
+      identifier: content-demo-004
+      number: 4
+      title: Package approved newsletter
+      description: This Review card starts with render_status approved so the artifact gate can promote it to Package on refresh.
+      state: Review
+      assigned_to_worker: false
+      labels:
+        - content-demo
+        - approved
+      priority: 1
+      fields:
+        artifact_type: newsletter_package
+        audience: customers
+        channel: email
+        render_status: approved
+        owner: reviewer
+      metadata:
+        workflow_step: Review
+        source_assets: output/draft-article-narrative/manifest.json
+        expected_manifest: output/package-approved-newsletter/manifest.json
+      deliverable:
+        kind: artifact
+        path: output/package-approved-newsletter/manifest.json
+        review_url: http://127.0.0.1:4101/review/content-demo-004
+        external_id: content-demo-004
+        metadata:
+          artifact_gate: render_status
+          expected_format: zip-manifest
+          output_directory: output/package-approved-newsletter
+    - id: content-demo-005
+      identifier: content-demo-005
+      number: 5
+      title: Rework short-form teaser
+      description: This Review card starts with render_status recut so the artifact gate can route it to Rework on refresh.
+      state: Review
+      assigned_to_worker: false
+      labels:
+        - content-demo
+        - needs-rework
+      priority: 3
+      fields:
+        artifact_type: short_form_teaser
+        audience: social
+        channel: video
+        render_status: recut
+        owner: reviewer
+      metadata:
+        workflow_step: Review
+        source_assets: output/draft-article-narrative/manifest.json
+        expected_manifest: output/rework-short-form-teaser/manifest.json
+      deliverable:
+        kind: artifact
+        path: output/rework-short-form-teaser/manifest.json
+        review_url: http://127.0.0.1:4101/review/content-demo-005
+        external_id: content-demo-005
+        metadata:
+          artifact_gate: render_status
+          expected_format: video-manifest
+          output_directory: output/rework-short-form-teaser
+    - id: content-demo-006
+      identifier: content-demo-006
+      number: 6
+      title: Publish package handoff
+      description: Package the reviewed article, captions, and newsletter assets for publication.
+      state: Package
+      assigned_to_worker: false
+      labels:
+        - content-demo
+        - package
+      priority: 2
+      fields:
+        artifact_type: publication_bundle
+        audience: publishing
+        channel: multi-channel
+        render_status: approved
+        owner: production
+      metadata:
+        workflow_step: Package
+        source_assets: output/package-approved-newsletter/manifest.json
+        expected_manifest: output/publish-package-handoff/manifest.json
+      deliverable:
+        kind: artifact
+        path: output/publish-package-handoff/manifest.json
+        review_url: http://127.0.0.1:4101/review/content-demo-006
+        external_id: content-demo-006
+        metadata:
+          artifact_gate: render_status
+          expected_format: directory-manifest
+          output_directory: output/publish-package-handoff
+
+workspace:
+  kind: filesystem
+  root: .detent/workspaces
+  source_root: .
+  output_root: output
+
+deliverable:
+  kind: artifact
+  output_root: output
+  review_url: http://127.0.0.1:4101/review
+
+agent:
+  auto_promote:
+    enabled: true
+    quiet_seconds: 0
+    optout_label: requires-human-review
+    source_state: Review
+    pass_state: Package
+    rework_state: Rework
+    rework_limit: 3
+    no_progress_limit: 0
+
+gate:
+  kind: artifact
+  ci_failure_action: skip
+  validator:
+    enabled: false
+  artifact:
+    status_field: render_status
+    pass_statuses:
+      - approved
+      - valid
+    wait_statuses:
+      - queued
+      - rendering
+      - pending_review
+    rework_statuses:
+      - recut
+      - invalid
+      - missing_assets
+
+server:
+  kanban:
+    mode: integration
+    allowed_transitions:
+      Intake:
+        - Research
+        - Blocked
+      Research:
+        - Draft
+        - Blocked
+      Draft:
+        - Review
+        - Blocked
+      Review:
+        - Package
+        - Rework
+        - Blocked
+      Rework:
+        - Draft
+        - Blocked
+      Package:
+        - Publish
+        - Rework
+        - Blocked
+      Blocked:
+        - Intake
+        - Research
+        - Draft
+      Publish: []
+      Cancelled: []
+---
+# Non-Code Artifact Demo
+
+You are operating a local content-production workflow. The tracker is local
+SQLite, the workspace is the filesystem, and the deliverable is an artifact
+manifest under the configured output directory.
+
+Do not require GitHub issues, pull requests, branches, CI, or a merge train.
+Use each work item's title, description, fields, metadata, and deliverable
+metadata as the production brief. Write or update the artifact manifest at the
+work item deliverable path.
+
+When an artifact is ready for review, set the configured `render_status` field
+to `pending_review`. A human or external renderer can set `render_status` to
+`approved` or `valid` to let Detent promote the card from Review to Package, or
+set it to `recut`, `invalid`, or `missing_assets` to send it to Rework.

--- a/docs/examples/non-code-artifact/output/package-approved-newsletter/manifest.json
+++ b/docs/examples/non-code-artifact/output/package-approved-newsletter/manifest.json
@@ -1,0 +1,21 @@
+{
+  "work_item": {
+    "id": "content-demo-004",
+    "identifier": "content-demo-004",
+    "title": "Package approved newsletter"
+  },
+  "source_assets": [
+    "output/draft-article-narrative/manifest.json"
+  ],
+  "artifact": {
+    "kind": "newsletter_package",
+    "path": "output/package-approved-newsletter/newsletter-package.md",
+    "review_url": "http://127.0.0.1:4101/review/content-demo-004"
+  },
+  "validation": {
+    "status_field": "render_status",
+    "status": "approved",
+    "notes": "Ready for package handoff."
+  },
+  "next_external_action": "Package the newsletter artifact and move the card to Publish after release."
+}

--- a/docs/examples/non-code-artifact/seed/01-research-brief.json
+++ b/docs/examples/non-code-artifact/seed/01-research-brief.json
@@ -1,0 +1,26 @@
+{
+  "identifier": "api-demo-research-001",
+  "title": "API seed research brief",
+  "description": "Create a research brief from the launch notes and customer interview excerpts.",
+  "state": "Research",
+  "labels": ["content-demo", "api-seed", "research"],
+  "fields": {
+    "artifact_type": "research_brief",
+    "audience": "evaluator",
+    "channel": "launch-blog",
+    "render_status": "queued",
+    "owner": "research"
+  },
+  "priority": 1,
+  "deliverable": {
+    "kind": "artifact",
+    "path": "output/api-seed-research-brief/manifest.json",
+    "review_url": "http://127.0.0.1:4101/review/api-demo-research-001",
+    "external_id": "api-demo-research-001",
+    "metadata": {
+      "artifact_gate": "render_status",
+      "expected_format": "markdown",
+      "output_directory": "output/api-seed-research-brief"
+    }
+  }
+}

--- a/docs/examples/non-code-artifact/seed/02-review-package.json
+++ b/docs/examples/non-code-artifact/seed/02-review-package.json
@@ -1,0 +1,26 @@
+{
+  "identifier": "api-demo-review-001",
+  "title": "API seed reviewed package",
+  "description": "Review the package manifest and promote it when render_status becomes approved.",
+  "state": "Review",
+  "labels": ["content-demo", "api-seed", "review"],
+  "fields": {
+    "artifact_type": "publication_bundle",
+    "audience": "publishing",
+    "channel": "multi-channel",
+    "render_status": "pending_review",
+    "owner": "reviewer"
+  },
+  "priority": 2,
+  "deliverable": {
+    "kind": "artifact",
+    "path": "output/api-seed-reviewed-package/manifest.json",
+    "review_url": "http://127.0.0.1:4101/review/api-demo-review-001",
+    "external_id": "api-demo-review-001",
+    "metadata": {
+      "artifact_gate": "render_status",
+      "expected_format": "directory-manifest",
+      "output_directory": "output/api-seed-reviewed-package"
+    }
+  }
+}

--- a/internal/project/project_test.go
+++ b/internal/project/project_test.go
@@ -798,7 +798,7 @@ func TestProjectWaitersReceiveRunError(t *testing.T) {
 		t.Fatalf("New() error = %v", err)
 	}
 
-	runCtx, cancel := context.WithTimeout(context.Background(), 10*time.Millisecond)
+	runCtx, cancel := context.WithTimeout(context.Background(), time.Second)
 	defer cancel()
 	if err := got.Start(runCtx); err != nil {
 		t.Fatalf("Start() error = %v", err)

--- a/internal/workitem/non_code_artifact_demo_test.go
+++ b/internal/workitem/non_code_artifact_demo_test.go
@@ -1,0 +1,214 @@
+package workitem_test
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"slices"
+	"strings"
+	"testing"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	"github.com/digitaldrywood/detent/internal/connector/local"
+	"github.com/digitaldrywood/detent/internal/gate"
+	"github.com/digitaldrywood/detent/internal/workitem"
+)
+
+func TestNonCodeArtifactDemoFixtures(t *testing.T) {
+	t.Parallel()
+
+	root := filepath.Join("..", "..")
+	demoDir := filepath.Join(root, "docs", "examples", "non-code-artifact")
+	workflowPath := filepath.Join(demoDir, "WORKFLOW.md")
+
+	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
+	if err != nil {
+		t.Fatalf("LoadWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+
+	cfg := workflow.Config
+	if cfg.Tracker.Kind != workflowconfig.TrackerLocalSQLite {
+		t.Fatalf("Tracker.Kind = %q, want local_sqlite", cfg.Tracker.Kind)
+	}
+	if cfg.Workspace.Kind != workflowconfig.WorkspaceFilesystem {
+		t.Fatalf("Workspace.Kind = %q, want filesystem", cfg.Workspace.Kind)
+	}
+	if cfg.Deliverable.Kind != workflowconfig.DeliverableArtifact {
+		t.Fatalf("Deliverable.Kind = %q, want artifact", cfg.Deliverable.Kind)
+	}
+	if cfg.Gate.Kind != gate.KindArtifact {
+		t.Fatalf("Gate.Kind = %q, want artifact", cfg.Gate.Kind)
+	}
+	if cfg.Gate.Artifact.StatusField != "render_status" {
+		t.Fatalf("Gate.Artifact.StatusField = %q, want render_status", cfg.Gate.Artifact.StatusField)
+	}
+
+	for _, state := range []string{"Research", "Draft", "Review", "Rework", "Package", "Publish"} {
+		if !stateConfigured(cfg, state) {
+			t.Fatalf("workflow state %q is not configured", state)
+		}
+	}
+	for _, status := range []string{"queued", "pending_review"} {
+		if !slices.Contains(cfg.Gate.Artifact.WaitStatuses, status) {
+			t.Fatalf("wait statuses = %#v, want %q", cfg.Gate.Artifact.WaitStatuses, status)
+		}
+	}
+	if !slices.Contains(cfg.Gate.Artifact.PassStatuses, "approved") {
+		t.Fatalf("pass statuses = %#v, want approved", cfg.Gate.Artifact.PassStatuses)
+	}
+	if !slices.Contains(cfg.Gate.Artifact.ReworkStatuses, "recut") {
+		t.Fatalf("rework statuses = %#v, want recut", cfg.Gate.Artifact.ReworkStatuses)
+	}
+
+	seenStates := map[string]bool{}
+	seenStatuses := map[string]bool{}
+	for _, issue := range cfg.Tracker.Issues {
+		if issue.AssignedToWorker {
+			t.Fatalf("seed issue %s is assigned to worker; demo seeds must not dispatch agents", issue.ID)
+		}
+		if issue.Fields["render_status"] == "" {
+			t.Fatalf("seed issue %s missing render_status field", issue.ID)
+		}
+		if issue.Deliverable == nil {
+			t.Fatalf("seed issue %s missing artifact deliverable", issue.ID)
+		}
+		if strings.TrimSpace(issue.Deliverable.ValidationStatus) != "" {
+			t.Fatalf("seed issue %s deliverable validation status overrides render_status", issue.ID)
+		}
+		if issue.Deliverable.Metadata["artifact_gate"] != "render_status" {
+			t.Fatalf("seed issue %s deliverable metadata = %#v, want artifact_gate render_status", issue.ID, issue.Deliverable.Metadata)
+		}
+		seenStates[issue.State] = true
+		seenStatuses[issue.Fields["render_status"]] = true
+	}
+	for _, state := range []string{"Research", "Draft", "Review", "Package"} {
+		if !seenStates[state] {
+			t.Fatalf("seed issues missing state %q; states = %#v", state, seenStates)
+		}
+	}
+	for _, status := range []string{"queued", "pending_review", "approved", "recut"} {
+		if !seenStatuses[status] {
+			t.Fatalf("seed issues missing render_status %q; statuses = %#v", status, seenStatuses)
+		}
+	}
+
+	validateSeedPayloads(t, demoDir, cfg)
+	validateManifest(t, filepath.Join(demoDir, "output", "package-approved-newsletter", "manifest.json"))
+}
+
+func validateSeedPayloads(t *testing.T, demoDir string, cfg workflowconfig.Config) {
+	t.Helper()
+
+	conn, err := local.New(local.Config{
+		Path:           filepath.Join(t.TempDir(), "work-items.db"),
+		ProjectID:      cfg.Tracker.LocalSQLite.ProjectID,
+		Issues:         cfg.Tracker.Issues,
+		ActiveStates:   cfg.Tracker.ActiveStates,
+		ObservedStates: cfg.Tracker.ObservedStates,
+		TerminalStates: cfg.Tracker.TerminalStates,
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := conn.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	entries, err := os.ReadDir(filepath.Join(demoDir, "seed"))
+	if err != nil {
+		t.Fatalf("ReadDir(seed) error = %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatal("seed payloads = 0, want at least one API example")
+	}
+	for _, entry := range entries {
+		if entry.IsDir() || filepath.Ext(entry.Name()) != ".json" {
+			continue
+		}
+		raw, err := os.ReadFile(filepath.Join(demoDir, "seed", entry.Name()))
+		if err != nil {
+			t.Fatalf("ReadFile(%s) error = %v", entry.Name(), err)
+		}
+		var req workitem.Request
+		if err := json.Unmarshal(raw, &req); err != nil {
+			t.Fatalf("Unmarshal(%s) error = %v", entry.Name(), err)
+		}
+		if req.Fields["render_status"] == "" {
+			t.Fatalf("%s missing render_status field", entry.Name())
+		}
+		if req.Deliverable == nil || req.Deliverable.Kind != workflowconfig.DeliverableArtifact {
+			t.Fatalf("%s deliverable = %#v, want artifact", entry.Name(), req.Deliverable)
+		}
+		if strings.TrimSpace(req.Deliverable.ValidationStatus) != "" {
+			t.Fatalf("%s deliverable validation status overrides render_status", entry.Name())
+		}
+		if _, err := workitem.Create(context.Background(), workitem.Target{
+			ProjectID: "default",
+			Workflow:  cfg,
+			Connector: conn,
+		}, req); err != nil {
+			t.Fatalf("Create(%s) error = %v", entry.Name(), err)
+		}
+	}
+}
+
+func validateManifest(t *testing.T, path string) {
+	t.Helper()
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("ReadFile(manifest) error = %v", err)
+	}
+	var manifest struct {
+		WorkItem struct {
+			ID         string `json:"id"`
+			Identifier string `json:"identifier"`
+			Title      string `json:"title"`
+		} `json:"work_item"`
+		SourceAssets []string `json:"source_assets"`
+		Artifact     struct {
+			Kind      string `json:"kind"`
+			Path      string `json:"path"`
+			ReviewURL string `json:"review_url"`
+		} `json:"artifact"`
+		Validation struct {
+			StatusField string `json:"status_field"`
+			Status      string `json:"status"`
+			Notes       string `json:"notes"`
+		} `json:"validation"`
+		NextExternalAction string `json:"next_external_action"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("Unmarshal(manifest) error = %v", err)
+	}
+	if manifest.WorkItem.ID != "content-demo-004" || manifest.WorkItem.Identifier == "" || manifest.WorkItem.Title == "" {
+		t.Fatalf("manifest work item = %#v", manifest.WorkItem)
+	}
+	if len(manifest.SourceAssets) == 0 {
+		t.Fatal("manifest source_assets is empty")
+	}
+	if manifest.Artifact.Kind == "" || manifest.Artifact.Path == "" || manifest.Artifact.ReviewURL == "" {
+		t.Fatalf("manifest artifact = %#v", manifest.Artifact)
+	}
+	if manifest.Validation.StatusField != "render_status" || manifest.Validation.Status != "approved" || manifest.Validation.Notes == "" {
+		t.Fatalf("manifest validation = %#v", manifest.Validation)
+	}
+	if manifest.NextExternalAction == "" {
+		t.Fatal("manifest next_external_action is empty")
+	}
+}
+
+func stateConfigured(cfg workflowconfig.Config, state string) bool {
+	for _, candidate := range append(append([]string{}, cfg.Tracker.ActiveStates...), append(cfg.Tracker.ObservedStates, cfg.Tracker.TerminalStates...)...) {
+		if strings.EqualFold(strings.TrimSpace(candidate), state) {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

- Added a turnkey local non-code artifact workflow demo under `docs/examples/non-code-artifact`.
- Seeded local SQLite work items with artifact metadata, gate statuses, API payloads, and an example output manifest.
- Added fixture validation that parses the demo workflow and submits sample payloads through the work-item creation path.
- Stabilized an existing project waiter test that was too timing-sensitive on Windows CI.

Fixes #981

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: docs and fixtures only; no operator UI implementation changed.

## Test Plan

- [x] `go test ./internal/workitem`
- [x] `go test ./internal/project -run TestProjectWaitersReceiveRunError -count=3`
- [x] `go test ./internal/project`
- [x] `make check`