### PR TITLE
feat(workflow): add state instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -863,6 +863,36 @@ defaults for manual moves from execution states: active work such as
 states such as `Blocked` or `Cancelled`. Add source-specific entries to allow a
 project workflow to expose extra manual moves without changing Detent's UI code.
 
+Use `agent.instructions_by_state` and `agent.instructions_by_transition` when a
+workflow stage needs prompt text that should stay out of the main
+`WORKFLOW.md` body. The runner appends matching workflow instructions after the
+base prompt and before Detent's deliverable and validation-gate blocks. State
+keys and transition source/target keys must reference configured workflow
+states.
+
+For a non-code editorial workflow such as `Research -> Draft -> Review ->
+Package -> Publish`, the stage-specific instructions can live in frontmatter:
+
+```yaml
+tracker:
+  active_states: [Research, Draft, Review, Package]
+  terminal_states: [Publish, Cancelled]
+agent:
+  instructions_by_state:
+    Research: |
+      Gather source notes, links, and open questions before drafting.
+    Draft: |
+      Write the article body and keep unresolved facts clearly marked.
+    Review: |
+      Address editorial feedback and leave a concise change summary.
+    Package: |
+      Prepare final assets, metadata, and publication handoff notes.
+  instructions_by_transition:
+    Review:
+      Package: |
+        Confirm all review comments are resolved before packaging.
+```
+
 `workspace.source_root` is the checked-out repository Detent uses for
 `git worktree add`; `workspace.root` is where per-issue worktrees are created.
 If `workspace.source_root` is omitted, Detent falls back to the project

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -38,6 +38,22 @@ agent:
   max_session_tokens: 25000000
   max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
+  # For a non-code workflow such as Research -> Draft -> Review -> Package ->
+  # Publish, add stage-specific prompt additions here instead of turning the
+  # main prompt into a conditional block:
+  # instructions_by_state:
+  #   Research: |
+  #     Gather source notes, links, and open questions before drafting.
+  #   Draft: |
+  #     Write the artifact body and keep unresolved facts clearly marked.
+  #   Review: |
+  #     Address feedback and leave a concise change summary.
+  #   Package: |
+  #     Prepare final assets, metadata, and publication handoff notes.
+  # instructions_by_transition:
+  #   Review:
+  #     Package: |
+  #       Confirm all review comments are resolved before packaging.
   auto_promote:
     enabled: true
     quiet_seconds: 0

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -206,25 +206,27 @@ type Worker struct {
 }
 
 type Agent struct {
-	MaxConcurrentAgents          int              `yaml:"max_concurrent_agents"`
-	MaxTurns                     int              `yaml:"max_turns"`
-	MaxRetryBackoffMS            int              `yaml:"max_retry_backoff_ms"`
-	MaxSessionTokens             int64            `yaml:"max_session_tokens"`
-	MaxSessionContextMultiplier  float64          `yaml:"max_session_context_multiplier"`
-	MaxSessionTokenOverrideLabel string           `yaml:"max_session_token_override_label"`
-	MaxSessionTokenOverrideField string           `yaml:"max_session_token_override_field"`
-	ExperimentalThreadResume     bool             `yaml:"experimental_thread_resume"`
-	Shutdown                     Shutdown         `yaml:"shutdown"`
-	MaxConcurrentAgentsByState   map[string]int   `yaml:"max_concurrent_agents_by_state"`
-	DispatchPriorityByState      []string         `yaml:"dispatch_priority_by_state"`
-	DispatchPriorityByLabel      []string         `yaml:"dispatch_priority_by_label"`
-	MergeFastPath                MergeFastPath    `yaml:"merge_fast_path"`
-	AutoPromote                  AutoPromote      `yaml:"auto_promote"`
-	OutputTruncation             OutputTruncation `yaml:"output_truncation"`
-	Budget                       Budget           `yaml:"budget"`
-	Lessons                      Lessons          `yaml:"lessons"`
-	Knowledge                    Knowledge        `yaml:"knowledge"`
-	Skills                       Skills           `yaml:"skills"`
+	MaxConcurrentAgents          int                          `yaml:"max_concurrent_agents"`
+	MaxTurns                     int                          `yaml:"max_turns"`
+	MaxRetryBackoffMS            int                          `yaml:"max_retry_backoff_ms"`
+	MaxSessionTokens             int64                        `yaml:"max_session_tokens"`
+	MaxSessionContextMultiplier  float64                      `yaml:"max_session_context_multiplier"`
+	MaxSessionTokenOverrideLabel string                       `yaml:"max_session_token_override_label"`
+	MaxSessionTokenOverrideField string                       `yaml:"max_session_token_override_field"`
+	ExperimentalThreadResume     bool                         `yaml:"experimental_thread_resume"`
+	Shutdown                     Shutdown                     `yaml:"shutdown"`
+	MaxConcurrentAgentsByState   map[string]int               `yaml:"max_concurrent_agents_by_state"`
+	DispatchPriorityByState      []string                     `yaml:"dispatch_priority_by_state"`
+	DispatchPriorityByLabel      []string                     `yaml:"dispatch_priority_by_label"`
+	MergeFastPath                MergeFastPath                `yaml:"merge_fast_path"`
+	AutoPromote                  AutoPromote                  `yaml:"auto_promote"`
+	OutputTruncation             OutputTruncation             `yaml:"output_truncation"`
+	InstructionsByState          map[string]string            `yaml:"instructions_by_state,omitempty"`
+	InstructionsByTransition     map[string]map[string]string `yaml:"instructions_by_transition,omitempty"`
+	Budget                       Budget                       `yaml:"budget"`
+	Lessons                      Lessons                      `yaml:"lessons"`
+	Knowledge                    Knowledge                    `yaml:"knowledge"`
+	Skills                       Skills                       `yaml:"skills"`
 }
 
 type Shutdown struct {
@@ -898,6 +900,7 @@ func (c *Config) Validate() error {
 		validatePositive("worker.max_concurrent_agents_per_host", *c.Worker.MaxConcurrentAgentsPerHost, &problems)
 	}
 	c.Agent.validate("agent", &problems)
+	c.validateAgentInstructions(&problems)
 	c.validateAutoPromoteReworkLimit(&problems)
 	c.validateAutoPromoteNoProgressLimit(&problems)
 	c.Agents.validate(&problems)
@@ -1107,6 +1110,31 @@ func (c *Config) validateTracker(problems *[]string) {
 	validatePositive("tracker.github_rest_fanout_max_requests", c.Tracker.GitHubRESTFanoutMaxRequests, problems)
 	*problems = append(*problems, c.Tracker.Claims.Validate("tracker.claims")...)
 	*problems = append(*problems, c.Tracker.Authorization.Validate("tracker.authorization")...)
+}
+
+func (c *Config) validateAgentInstructions(problems *[]string) {
+	configuredStates := c.configuredWorkflowStates()
+	validateInstructionsByState("agent.instructions_by_state", c.Agent.InstructionsByState, configuredStates, problems)
+	validateInstructionsByTransition("agent.instructions_by_transition", c.Agent.InstructionsByTransition, configuredStates, problems)
+}
+
+func (c Config) configuredWorkflowStates() map[string]string {
+	states := make(map[string]string, len(c.Tracker.ActiveStates)+len(c.Tracker.ObservedStates)+len(c.Tracker.TerminalStates))
+	add := func(values []string) {
+		for _, state := range values {
+			normalized := normalizeIssueState(state)
+			if normalized == "" {
+				continue
+			}
+			if _, ok := states[normalized]; !ok {
+				states[normalized] = strings.TrimSpace(state)
+			}
+		}
+	}
+	add(c.Tracker.ActiveStates)
+	add(c.Tracker.ObservedStates)
+	add(c.Tracker.TerminalStates)
+	return states
 }
 
 func (c *Config) validateAutoPromoteReworkLimit(problems *[]string) {
@@ -2077,11 +2105,96 @@ func validateStateList(field string, states []string, problems *[]string) {
 			*problems = append(*problems, field+" state names must not be blank")
 			return
 		}
-		if _, ok := seen[state]; ok {
+		normalized := normalizeIssueState(state)
+		if _, ok := seen[normalized]; ok {
 			*problems = append(*problems, field+" state names must be unique")
 			return
 		}
-		seen[state] = struct{}{}
+		seen[normalized] = struct{}{}
+	}
+}
+
+func validateInstructionsByState(field string, instructions map[string]string, configuredStates map[string]string, problems *[]string) {
+	blank := false
+	duplicate := false
+	seen := make(map[string]struct{}, len(instructions))
+	for state := range instructions {
+		normalized := normalizeIssueState(state)
+		if normalized == "" {
+			if !blank {
+				*problems = append(*problems, field+" state names must not be blank")
+				blank = true
+			}
+			continue
+		}
+		if _, ok := seen[normalized]; ok {
+			if !duplicate {
+				*problems = append(*problems, field+" state names must be unique")
+				duplicate = true
+			}
+			continue
+		}
+		seen[normalized] = struct{}{}
+		if _, ok := configuredStates[normalized]; !ok {
+			*problems = append(*problems, field+" state "+strconv.Quote(strings.TrimSpace(state))+" must reference a configured workflow state")
+		}
+	}
+}
+
+func validateInstructionsByTransition(
+	field string,
+	instructions map[string]map[string]string,
+	configuredStates map[string]string,
+	problems *[]string,
+) {
+	sourceBlank := false
+	sourceDuplicate := false
+	targetBlank := false
+	targetDuplicate := false
+	seenSources := make(map[string]struct{}, len(instructions))
+	for source, targets := range instructions {
+		normalizedSource := normalizeIssueState(source)
+		if normalizedSource == "" {
+			if !sourceBlank {
+				*problems = append(*problems, field+" source states must not be blank")
+				sourceBlank = true
+			}
+			continue
+		}
+		if _, ok := seenSources[normalizedSource]; ok {
+			if !sourceDuplicate {
+				*problems = append(*problems, field+" source states must be unique")
+				sourceDuplicate = true
+			}
+		} else {
+			seenSources[normalizedSource] = struct{}{}
+		}
+		if _, ok := configuredStates[normalizedSource]; !ok {
+			*problems = append(*problems, field+" source state "+strconv.Quote(strings.TrimSpace(source))+" must reference a configured workflow state")
+		}
+
+		seenTargets := make(map[string]struct{}, len(targets))
+		for target := range targets {
+			normalizedTarget := normalizeIssueState(target)
+			if normalizedTarget == "" {
+				if !targetBlank {
+					*problems = append(*problems, field+" target states must not be blank")
+					targetBlank = true
+				}
+				continue
+			}
+			if _, ok := seenTargets[normalizedTarget]; ok {
+				if !targetDuplicate {
+					*problems = append(*problems, field+" target states must be unique per source")
+					targetDuplicate = true
+				}
+				continue
+			}
+			seenTargets[normalizedTarget] = struct{}{}
+			if _, ok := configuredStates[normalizedTarget]; !ok {
+				*problems = append(*problems, field+" target state "+strconv.Quote(strings.TrimSpace(target))+" must reference a configured workflow state")
+			}
+		}
 	}
 }
 

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -116,6 +116,13 @@ agent:
     no_progress_limit: 4
     allowed_issue_labels:
       - enhancement
+  instructions_by_state:
+    Rework: |
+      Address review comments before moving back to Human Review.
+  instructions_by_transition:
+    Todo:
+      In Progress: |
+        Confirm prerequisites before implementation.
   lessons:
     enabled: true
     path: ".detent/lessons.md"
@@ -351,6 +358,12 @@ Ticket prompt {{ issue.title }}
 	}
 	if got := cfg.Agent.DispatchPriorityByLabel; !reflect.DeepEqual(got, []string{"bug", "regression", "enhancement"}) {
 		t.Fatalf("Agent.DispatchPriorityByLabel = %#v, want bug/regression/enhancement", got)
+	}
+	if got := cfg.Agent.InstructionsByState["Rework"]; !strings.Contains(got, "Address review comments") {
+		t.Fatalf("Agent.InstructionsByState[Rework] = %q, want review instructions", got)
+	}
+	if got := cfg.Agent.InstructionsByTransition["Todo"]["In Progress"]; !strings.Contains(got, "Confirm prerequisites") {
+		t.Fatalf("Agent.InstructionsByTransition[Todo][In Progress] = %q, want transition instructions", got)
 	}
 	if cfg.Agent.AutoPromote.OptoutLabel != "requires-human-review" {
 		t.Fatalf("Agent.AutoPromote.OptoutLabel = %q", cfg.Agent.AutoPromote.OptoutLabel)
@@ -1840,6 +1853,52 @@ Prompt
 				"server.port must be greater than or equal to 0",
 				"server.kanban.mode must be one of read_only, integration",
 				"server.kanban.issue_state_field_id must be greater than 0 when set",
+			},
+		},
+		{
+			name: "invalid agent workflow instructions",
+			raw: `---
+tracker:
+  kind: memory
+  active_states:
+    - Todo
+    - In Progress
+    - Rework
+  observed_states:
+    - Blocked
+  terminal_states:
+    - Done
+agent:
+  instructions_by_state:
+    "": blank
+    Todo: first
+    " todo ": duplicate
+    QA: unknown
+  instructions_by_transition:
+    "":
+      Done: blank source
+    Todo:
+      "": blank target
+      Done: first
+      " done ": duplicate
+      Archive: unknown target
+    Review:
+      Done: unknown source
+    " todo ":
+      Done: duplicate source
+---
+Prompt
+`,
+			want: []string{
+				"agent.instructions_by_state state names must not be blank",
+				"agent.instructions_by_state state names must be unique",
+				"agent.instructions_by_state state \"QA\" must reference a configured workflow state",
+				"agent.instructions_by_transition source states must not be blank",
+				"agent.instructions_by_transition source states must be unique",
+				"agent.instructions_by_transition source state \"Review\" must reference a configured workflow state",
+				"agent.instructions_by_transition target states must not be blank",
+				"agent.instructions_by_transition target states must be unique per source",
+				"agent.instructions_by_transition target state \"Archive\" must reference a configured workflow state",
 			},
 		},
 		{

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -267,7 +267,10 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		o.recordMergeFailed(state, issue, now, "work_attempt_start_failed", nil)
 		return dispatchIssueOutcome{reason: dispatchIssueFailureWorkAttemptStart}
 	}
+	dispatchSourceState := ""
+	dispatchTargetState := ""
 	if targetState != "" {
+		sourceState := issue.State
 		if err := o.updateIssueState(ctx, issue, targetState, now, "dispatch_start"); err != nil {
 			o.releaseGlobalDispatchSlot(globalSlot)
 			o.completeDurableWorkAttempt(ctx, state, Running{
@@ -294,6 +297,11 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 			return dispatchIssueOutcome{reason: dispatchIssueFailureStartStateTransition}
 		}
 		issue.State = targetState
+		dispatchSourceState = sourceState
+		dispatchTargetState = targetState
+	}
+	if dispatchSourceState == "" || dispatchTargetState == "" {
+		dispatchSourceState, dispatchTargetState = o.dispatchTimelineTransitionContext(ctx, issue)
 	}
 	o.markMergeStarted(state, issue, now)
 	claim.Issue = issue
@@ -317,15 +325,17 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	delete(state.Completed, issue.ID)
 
 	request := RunRequest{
-		Issue:           issue,
-		Attempt:         attempt,
-		WorkAttemptID:   workAttemptID,
-		Mode:            runMode,
-		PriorAttempt:    state.PriorAttempts[issue.ID],
-		StartedAt:       now,
-		WorkerHost:      workerHost,
-		SelectorContext: o.selectorContext(),
-		OnUsageUpdate:   o.usageUpdateHandler(runCtx, issue.ID),
+		Issue:               issue,
+		Attempt:             attempt,
+		WorkAttemptID:       workAttemptID,
+		Mode:                runMode,
+		DispatchSourceState: dispatchSourceState,
+		DispatchTargetState: dispatchTargetState,
+		PriorAttempt:        state.PriorAttempts[issue.ID],
+		StartedAt:           now,
+		WorkerHost:          workerHost,
+		SelectorContext:     o.selectorContext(),
+		OnUsageUpdate:       o.usageUpdateHandler(runCtx, issue.ID),
 	}
 	o.logMergeWorkerAttempt(issue, attempt, workerHost)
 	o.logWorkerLifecycle(issue, "worker_attempt_started",
@@ -335,6 +345,22 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	)
 	o.supervisor.Dispatch(runCtx, request, o.runResults)
 	return dispatchIssueOutcome{dispatched: true}
+}
+
+func (o *Orchestrator) dispatchTimelineTransitionContext(ctx context.Context, issue connector.Issue) (string, string) {
+	match, ok := o.latestWorkflowLaneEntry(ctx, issue)
+	if !ok {
+		return "", ""
+	}
+	sourceState := strings.TrimSpace(match.Event.PreviousPhaseName)
+	targetState := strings.TrimSpace(match.Event.PhaseName)
+	if sourceState == "" || targetState == "" {
+		return "", ""
+	}
+	if normalizeState(targetState) != normalizeState(issue.State) {
+		return "", ""
+	}
+	return sourceState, targetState
 }
 
 // dispatchWorkingStates lists the active-state names recognized as the

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1048,6 +1048,44 @@ func TestDispatchReadyIssuesPassesPriorAttemptToRunner(t *testing.T) {
 	}
 }
 
+func TestDispatchReadyIssuesUsesLatestLaneTransitionContext(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Research", "Draft", "Review", "Package"},
+		TerminalStates:      []string{"Publish"},
+	})
+	runner := newWorkerHostRunner()
+	metrics := &autoPromoteWorkflowMetricsRecorder{}
+	orch := Orchestrator{
+		cfg:             cfg,
+		supervisor:      newTestSupervisor(t, runner, cfg),
+		runResults:      make(chan runpkg.Completion),
+		workflowMetrics: metrics,
+	}
+	state := newState(cfg)
+	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
+	issue := dispatchTestIssue("issue-package", "Package")
+	if _, err := metrics.RecordWorkflowPhaseEvent(t.Context(), store.WorkflowPhaseEvent{
+		IssueID:           issue.ID,
+		Identifier:        issue.Identifier,
+		PhaseType:         store.WorkflowPhaseTypeLane,
+		PhaseName:         "Package",
+		PreviousPhaseName: "Review",
+		Status:            "entered",
+		StartedAt:         now.Add(-time.Minute),
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+
+	orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{issue}, now)
+	request := receiveWorkerHostRunRequest(t, runner.started)
+	if request.DispatchSourceState != "Review" || request.DispatchTargetState != "Package" {
+		t.Fatalf("RunRequest dispatch transition = %q -> %q, want Review -> Package", request.DispatchSourceState, request.DispatchTargetState)
+	}
+}
+
 func TestDispatchReadyIssuesRechecksStartTransitionStateCapacity(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -198,6 +198,12 @@ func TestRunStartsLabelModeTodoIssueInProgress(t *testing.T) {
 	if request.Issue.ID != issue.ID {
 		t.Fatalf("RunRequest.Issue.ID = %q, want %q", request.Issue.ID, issue.ID)
 	}
+	if request.Issue.State != "In Progress" {
+		t.Fatalf("RunRequest.Issue.State = %q, want In Progress", request.Issue.State)
+	}
+	if request.DispatchSourceState != "Todo" || request.DispatchTargetState != "In Progress" {
+		t.Fatalf("RunRequest dispatch transition = %q -> %q, want Todo -> In Progress", request.DispatchSourceState, request.DispatchTargetState)
+	}
 
 	waitForStateUpdate(t, tracker, stateUpdateCall{issueID: issue.ID, state: "In Progress"})
 

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -572,6 +572,8 @@ func (r *Runner) Run(ctx context.Context, req RunRequest) (RunResult, error) {
 		MergePrecheckMessage: mergePrecheck.Message,
 		WorkspacePath:        info.Path,
 		Branch:               info.Branch,
+		DispatchSourceState:  req.DispatchSourceState,
+		DispatchTargetState:  req.DispatchTargetState,
 		AvailableSkills:      availableSkills,
 		PriorAttempt:         req.PriorAttempt,
 	})

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"regexp"
+	"sort"
 	"strconv"
 	"strings"
 	"time"
@@ -45,6 +46,8 @@ type PromptOptions struct {
 	MergePrecheckMessage string
 	WorkspacePath        string
 	Branch               string
+	DispatchSourceState  string
+	DispatchTargetState  string
 	AutoBranch           *bool
 	AvailableSkills      []skills.Skill
 	PriorAttempt         PriorAttempt
@@ -97,6 +100,7 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 	}
 
 	rendered = appendPriorAttemptBlock(rendered, opts.PriorAttempt)
+	rendered = appendWorkflowInstructionsBlock(rendered, workflow.Config.Agent, issue, opts)
 	rendered = appendDeliverableBlock(rendered, workflow.Config, issue, opts.WorkspacePath)
 	rendered = appendBlockedHandoffBlock(rendered)
 	rendered = appendGateBlock(rendered, workflow.Config.Gate)
@@ -151,6 +155,7 @@ func BuildMergeFallbackPrompt(workflow config.Workflow, issue connector.Issue, o
 	if err != nil {
 		return "", err
 	}
+	prompt = appendWorkflowInstructionsBlock(prompt, workflow.Config.Agent, issue, opts)
 	prompt = appendBlockedHandoffBlock(prompt)
 	prompt = appendGateBlock(prompt, workflow.Config.Gate)
 	prompt = appendAvailableSkills(prompt, AvailableSkillsBlock(opts.AvailableSkills))
@@ -304,6 +309,92 @@ func prependWorkspaceIsolationBlock(prompt string, cfg config.Config, workspaceP
 		workspacePath, branch)
 
 	return block + "\n\n" + strings.TrimLeft(prompt, " \t\r\n")
+}
+
+func appendWorkflowInstructionsBlock(prompt string, cfg config.Agent, issue connector.Issue, opts PromptOptions) string {
+	blocks := workflowInstructionBlocks(cfg, issue.State, opts.DispatchSourceState, opts.DispatchTargetState)
+	if len(blocks) == 0 {
+		return prompt
+	}
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Workflow instructions\n\n" + strings.Join(blocks, "\n\n")
+}
+
+func workflowInstructionBlocks(cfg config.Agent, state string, sourceState string, targetState string) []string {
+	var blocks []string
+	if display, body, ok := matchingStateInstruction(cfg.InstructionsByState, state); ok {
+		blocks = append(blocks, "### State: "+display+"\n\n"+body)
+	}
+	if source, target, body, ok := matchingTransitionInstruction(cfg.InstructionsByTransition, sourceState, targetState); ok {
+		blocks = append(blocks, "### Transition: "+source+" -> "+target+"\n\n"+body)
+	}
+	return blocks
+}
+
+func matchingStateInstruction(instructions map[string]string, state string) (string, string, bool) {
+	key := workflowInstructionStateKey(state)
+	if key == "" {
+		return "", "", false
+	}
+	for _, candidate := range sortedMapKeys(instructions) {
+		if workflowInstructionStateKey(candidate) != key {
+			continue
+		}
+		body := strings.TrimSpace(instructions[candidate])
+		if body == "" {
+			return "", "", false
+		}
+		return strings.TrimSpace(candidate), body, true
+	}
+	return "", "", false
+}
+
+func matchingTransitionInstruction(
+	instructions map[string]map[string]string,
+	sourceState string,
+	targetState string,
+) (string, string, string, bool) {
+	sourceKey := workflowInstructionStateKey(sourceState)
+	targetKey := workflowInstructionStateKey(targetState)
+	if sourceKey == "" || targetKey == "" {
+		return "", "", "", false
+	}
+	for _, source := range sortedNestedMapKeys(instructions) {
+		if workflowInstructionStateKey(source) != sourceKey {
+			continue
+		}
+		targets := instructions[source]
+		for _, target := range sortedMapKeys(targets) {
+			if workflowInstructionStateKey(target) != targetKey {
+				continue
+			}
+			body := strings.TrimSpace(targets[target])
+			if body == "" {
+				return "", "", "", false
+			}
+			return strings.TrimSpace(source), strings.TrimSpace(target), body, true
+		}
+	}
+	return "", "", "", false
+}
+
+func workflowInstructionStateKey(state string) string {
+	return strings.ToLower(strings.TrimSpace(state))
+}
+
+func sortedMapKeys[V any](values map[string]V) []string {
+	if len(values) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func sortedNestedMapKeys(values map[string]map[string]string) []string {
+	return sortedMapKeys(values)
 }
 
 func appendDeliverableBlock(prompt string, cfg config.Config, issue connector.Issue, workspacePath string) string {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -396,6 +396,153 @@ func TestBuildPromptRendersGateAssignsAndInstructions(t *testing.T) {
 	}
 }
 
+func TestBuildPromptAppendsWorkflowInstructionsByState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		state     string
+		want      string
+		forbidden []string
+	}{
+		{
+			name:      "todo",
+			state:     "Todo",
+			want:      "Prepare the research brief.",
+			forbidden: []string{"Address review feedback.", "Run the merge checklist."},
+		},
+		{
+			name:      "rework",
+			state:     "Rework",
+			want:      "Address review feedback.",
+			forbidden: []string{"Prepare the research brief.", "Run the merge checklist."},
+		},
+		{
+			name:      "merging",
+			state:     "Merging",
+			want:      "Run the merge checklist.",
+			forbidden: []string{"Prepare the research brief.", "Address review feedback."},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prompt, err := BuildPrompt(config.Workflow{
+				Config: config.Config{
+					Agent: config.Agent{
+						InstructionsByState: map[string]string{
+							"Todo":    "Prepare the research brief.",
+							"Rework":  "Address review feedback.",
+							"Merging": "Run the merge checklist.",
+						},
+					},
+				},
+				Prompt: "Base workflow prompt.",
+			}, connector.Issue{
+				Identifier: "digitaldrywood/detent#980",
+				Title:      "Workflow instructions",
+				State:      tt.state,
+			}, PromptOptions{})
+			if err != nil {
+				t.Fatalf("BuildPrompt() error = %v", err)
+			}
+
+			for _, want := range []string{"## Workflow instructions", "### State: " + tt.state, tt.want} {
+				if !strings.Contains(prompt, want) {
+					t.Fatalf("prompt missing %q:\n%s", want, prompt)
+				}
+			}
+			for _, forbidden := range tt.forbidden {
+				if strings.Contains(prompt, forbidden) {
+					t.Fatalf("prompt contains %q:\n%s", forbidden, prompt)
+				}
+			}
+		})
+	}
+}
+
+func TestBuildPromptAppendsWorkflowInstructionsByTransitionBeforeDeliverableAndGate(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Config: config.Config{
+			Deliverable: config.Deliverable{Kind: config.DeliverableArtifact},
+			Agent: config.Agent{
+				InstructionsByState: map[string]string{
+					"In Progress": "Work from the implementation checklist.",
+				},
+				InstructionsByTransition: map[string]map[string]string{
+					"Todo": {
+						"In Progress": "Confirm dependencies before coding.",
+					},
+				},
+			},
+			Gate: gate.Config{Kind: gate.KindArtifact},
+		},
+		Prompt: "Base workflow prompt.",
+	}, connector.Issue{
+		Identifier: "digitaldrywood/detent#980",
+		Title:      "Workflow instructions",
+		State:      "In Progress",
+	}, PromptOptions{
+		DispatchSourceState: "Todo",
+		DispatchTargetState: "In Progress",
+	})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"## Workflow instructions",
+		"### State: In Progress",
+		"Work from the implementation checklist.",
+		"### Transition: Todo -> In Progress",
+		"Confirm dependencies before coding.",
+		"## Deliverable",
+		"## Validation gate",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+
+	workflowInstructionsIndex := strings.Index(prompt, "## Workflow instructions")
+	deliverableIndex := strings.Index(prompt, "## Deliverable")
+	gateIndex := strings.Index(prompt, "## Validation gate")
+	if workflowInstructionsIndex == -1 || deliverableIndex == -1 || gateIndex == -1 {
+		t.Fatalf("prompt missing block markers:\n%s", prompt)
+	}
+	if workflowInstructionsIndex > deliverableIndex {
+		t.Fatalf("workflow instructions appear after deliverable block:\n%s", prompt)
+	}
+	if workflowInstructionsIndex > gateIndex {
+		t.Fatalf("workflow instructions appear after validation gate block:\n%s", prompt)
+	}
+}
+
+func TestBuildPromptOmitsWorkflowInstructionsWhenUnconfigured(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Prompt: "Base workflow prompt.",
+	}, connector.Issue{
+		Identifier: "digitaldrywood/detent#980",
+		Title:      "Workflow instructions",
+		State:      "Todo",
+	}, PromptOptions{})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+	if strings.Contains(prompt, "## Workflow instructions") {
+		t.Fatalf("prompt contains workflow instructions when unconfigured:\n%s", prompt)
+	}
+	if !strings.HasPrefix(prompt, "Base workflow prompt.") {
+		t.Fatalf("prompt prefix = %q, want base workflow prompt", prompt[:len("Base workflow prompt.")])
+	}
+}
+
 func TestBuildValidatorPromptSeedsDiffContext(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -169,15 +169,17 @@ func (e *SessionTokenCeilingError) Unwrap() error {
 }
 
 type RunRequest struct {
-	Issue           connector.Issue
-	Attempt         int
-	WorkAttemptID   int64
-	Mode            string
-	PriorAttempt    PriorAttempt
-	StartedAt       time.Time
-	WorkerHost      string
-	SelectorContext selector.Context
-	OnUsageUpdate   UsageUpdateHandler
+	Issue               connector.Issue
+	Attempt             int
+	WorkAttemptID       int64
+	Mode                string
+	DispatchSourceState string
+	DispatchTargetState string
+	PriorAttempt        PriorAttempt
+	StartedAt           time.Time
+	WorkerHost          string
+	SelectorContext     selector.Context
+	OnUsageUpdate       UsageUpdateHandler
 }
 
 type ValidatorRequest struct {


### PR DESCRIPTION
## Summary

- Add `agent.instructions_by_state` and `agent.instructions_by_transition` workflow config for stage-specific prompt additions.
- Validate blank, duplicate-normalized, and unknown workflow state references for the new instruction maps.
- Append matching workflow instructions before deliverable and validation gate blocks, including `Todo -> In Progress` and latest-lane transition context for dispatched workflow items.
- Document a non-code `Research -> Draft -> Review -> Package -> Publish` workflow example.

Fixes #980

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/config`
- [x] `go test ./internal/runner`
- [x] `go test ./internal/orchestrator`
- [x] `make check` (passed after the review-fix update; total coverage 76.4%)