### PR TITLE
fix(orchestrator): complete artifact lifecycle

### DIFF
--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -75,6 +76,15 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			Event:   "completed_issue_review_transition",
 			Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState + " after successful completion",
 		})
+		if o.logger != nil {
+			o.logger.Info(
+				"completed issue review transition",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"from_state", issue.State,
+				"target_state", targetState,
+			)
+		}
 	}
 	if len(result.transitioned) == 0 {
 		return autoPromoteTickResult{}
@@ -166,6 +176,9 @@ func completedActiveReviewTargetState(
 
 func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConfig) bool {
 	if autoPromoteHumanReviewRequired(issue, cfg, cfg.Gate) {
+		return true
+	}
+	if gate.Effective(cfg.Gate).Kind == gate.KindArtifact {
 		return true
 	}
 	if cfg.QuietDuration > 0 {

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -92,6 +92,78 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 	return result
 }
 
+func (o *Orchestrator) transitionActiveArtifactGateWaitIssuesToReview(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+	now time.Time,
+) autoPromoteTickResult {
+	if len(issues) == 0 {
+		return autoPromoteTickResult{}
+	}
+
+	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	result := autoPromoteTickResult{transitioned: map[string]struct{}{}}
+	for _, issue := range issues {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+		if _, running := state.Running[issueID]; running {
+			continue
+		}
+		targetState := activeArtifactGateWaitReviewTargetState(
+			issue,
+			o.cfg.ActiveStates,
+			o.cfg.TerminalStates,
+			cfg,
+		)
+		if targetState == "" {
+			continue
+		}
+
+		if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "artifact_gate_wait_review_reconciliation"); err != nil {
+			if o.logger != nil {
+				o.logger.Warn(
+					"artifact gate wait review reconciliation failed",
+					"issue_id", issueID,
+					"identifier", issue.Identifier,
+					"from_state", issue.State,
+					"target_state", targetState,
+					"error", err,
+				)
+			}
+			continue
+		}
+		if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+			o.logger.Warn("abandon artifact gate wait claim failed", "issue_id", issueID, "error", err)
+		}
+		delete(state.Claimed, issueID)
+		delete(state.Retry, issueID)
+		delete(state.BudgetRefusals, issueID)
+		delete(state.PriorAttempts, issueID)
+		result.transitioned[issueID] = struct{}{}
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "artifact_gate_wait_review_reconciliation",
+			Message: "moved " + issueLabel(issue) + " from " + strings.TrimSpace(issue.State) + " to " + targetState + " after artifact gate wait status",
+		})
+		if o.logger != nil {
+			o.logger.Info(
+				"artifact gate wait review reconciliation",
+				"issue_id", issueID,
+				"identifier", issue.Identifier,
+				"from_state", issue.State,
+				"target_state", targetState,
+			)
+		}
+	}
+	if len(result.transitioned) == 0 {
+		return autoPromoteTickResult{}
+	}
+	return result
+}
+
 func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 	ctx context.Context,
 	state *State,
@@ -159,8 +231,12 @@ func completedActiveReviewTargetState(
 	}
 	reviewState := cfg.SourceState
 	switch normalizeState(issue.State) {
-	case normalizeState(reviewState), normalizeState(autoPromoteReworkState), normalizeState(autoPromoteMergingState):
+	case normalizeState(reviewState), normalizeState(autoPromoteMergingState):
 		return ""
+	case normalizeState(autoPromoteReworkState):
+		if gate.Effective(cfg.Gate).Kind != gate.KindArtifact {
+			return ""
+		}
 	}
 	if !completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(cfg.Gate)) {
 		return ""
@@ -185,6 +261,29 @@ func completedActiveShouldEnterReview(issue connector.Issue, cfg AutoPromoteConf
 		return true
 	}
 	return cfg.GateWaitState == autoPromoteGateWaitReview
+}
+
+func activeArtifactGateWaitReviewTargetState(
+	issue connector.Issue,
+	activeStates []string,
+	terminalStates []string,
+	cfg AutoPromoteConfig,
+) string {
+	cfg = normalizeAutoPromoteConfig(cfg)
+	if gate.Effective(cfg.Gate).Kind != gate.KindArtifact {
+		return ""
+	}
+	if !stateIn(issue.State, activeStates) || stateIn(issue.State, terminalStates) {
+		return ""
+	}
+	switch normalizeState(issue.State) {
+	case "todo", normalizeState(cfg.SourceState), normalizeState(autoPromoteMergingState):
+		return ""
+	}
+	if !artifactGateWaitStatusBlocksDispatch(issue, cfg.Gate) {
+		return ""
+	}
+	return cfg.SourceState
 }
 
 func completedActiveFinalStateReviewEligible(finalState string, reviewState string) bool {

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -45,6 +45,27 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			want: "Review",
 		},
 		{
+			name:       "artifact production completed with source gate wait advances to configured review",
+			issue:      completionTransitionIssue("Production", ""),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled:     true,
+				SourceState: "Review",
+				PassState:   "Ready for Pickup",
+				ReworkState: "Rework",
+				Gate: gate.Config{
+					Kind: gate.KindArtifact,
+					Artifact: gate.ArtifactConfig{
+						StatusField:    "render_status",
+						PassStatuses:   []string{"approved", "valid"},
+						WaitStatuses:   []string{"queued", "rendering", "pending_review"},
+						ReworkStatuses: []string{"recut", "invalid", "missing_assets"},
+					},
+				},
+			},
+			want: "Review",
+		},
+		{
 			name:       "rework completed with open pull request waits for dispatch",
 			issue:      completionTransitionIssue("Rework", "OPEN"),
 			finalState: FinalStateCompleted,
@@ -146,8 +167,8 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 		},
 	}
 
-	activeStates := normalizedStates([]string{"Todo", "In Progress", "Rework", "Merging"})
-	terminalStates := normalizedStates([]string{"Done", "Cancelled"})
+	activeStates := normalizedStates([]string{"Todo", "In Progress", "Production", "Rework", "Merging"})
+	terminalStates := normalizedStates([]string{"Ready for Pickup", "Done", "Cancelled"})
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -71,6 +71,19 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 			finalState: FinalStateCompleted,
 		},
 		{
+			name:       "artifact rework completed without pull request advances to configured review",
+			issue:      completionTransitionIssue("Rework", ""),
+			finalState: FinalStateCompleted,
+			cfg: AutoPromoteConfig{
+				Enabled:     true,
+				SourceState: "Review",
+				PassState:   "Ready for Pickup",
+				ReworkState: "Rework",
+				Gate:        artifactCompletionTestGate(),
+			},
+			want: "Review",
+		},
+		{
 			name:       "merging completed with open pull request waits for merge lifecycle",
 			issue:      completionTransitionIssue("Merging", "OPEN"),
 			finalState: FinalStateCompleted,
@@ -184,6 +197,95 @@ func TestCompletedActiveReviewTargetState(t *testing.T) {
 				t.Fatalf("completedActiveReviewTargetState() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestActiveArtifactGateWaitReviewTargetState(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		issue connector.Issue
+		want  string
+	}{
+		{
+			name:  "production pending review moves to review",
+			issue: artifactCompletionTransitionIssue("Production", "pending_review"),
+			want:  "Review",
+		},
+		{
+			name:  "rework rendering moves to review",
+			issue: artifactCompletionTransitionIssue("Rework", "rendering"),
+			want:  "Review",
+		},
+		{
+			name:  "todo queued does not move to review",
+			issue: artifactCompletionTransitionIssue("Todo", "queued"),
+		},
+		{
+			name:  "production pass status does not move to review",
+			issue: artifactCompletionTransitionIssue("Production", "approved"),
+		},
+	}
+
+	activeStates := normalizedStates([]string{"Todo", "Production", "Rework"})
+	terminalStates := normalizedStates([]string{"Ready for Pickup", "Done", "Cancelled"})
+	cfg := AutoPromoteConfig{
+		Enabled:     true,
+		SourceState: "Review",
+		PassState:   "Ready for Pickup",
+		ReworkState: "Rework",
+		Gate:        artifactCompletionTestGate(),
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := activeArtifactGateWaitReviewTargetState(tt.issue, activeStates, terminalStates, cfg)
+			if got != tt.want {
+				t.Fatalf("activeArtifactGateWaitReviewTargetState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestTransitionActiveArtifactGateWaitIssuesReconcilesToReviewAfterRestart(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 15, 35, 0, 0, time.UTC)
+	issue := artifactCompletionTransitionIssue("Production", "pending_review")
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			PassState:   "Ready for Pickup",
+			ReworkState: "Rework",
+			Gate:        artifactCompletionTestGate(),
+		},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+
+	result := orch.transitionActiveArtifactGateWaitIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Review"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if _, ok := state.Completed[issue.ID]; ok {
+		t.Fatalf("Completed[%q] present after restart reconciliation", issue.ID)
+	}
+	if len(result.dispatchCandidates) != 0 {
+		t.Fatalf("dispatchCandidates = %#v, want none", result.dispatchCandidates)
+	}
+	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "artifact_gate_wait_review_reconciliation" {
+		t.Fatalf("RecentEvents = %#v, want artifact gate wait reconciliation event", state.RecentEvents)
 	}
 }
 
@@ -405,4 +507,23 @@ func completionTransitionIssue(state string, pullRequestState string) connector.
 		issue.PullRequest = &connector.PullRequest{State: pullRequestState}
 	}
 	return issue
+}
+
+func artifactCompletionTransitionIssue(state string, status string) connector.Issue {
+	issue := completionTransitionIssue(state, "")
+	issue.Deliverable = &connector.Deliverable{Kind: "artifact"}
+	issue.Fields = map[string]string{"render_status": status}
+	return issue
+}
+
+func artifactCompletionTestGate() gate.Config {
+	return gate.Config{
+		Kind: gate.KindArtifact,
+		Artifact: gate.ArtifactConfig{
+			StatusField:    "render_status",
+			PassStatuses:   []string{"approved", "valid"},
+			WaitStatuses:   []string{"queued", "rendering", "pending_review"},
+			ReworkStatuses: []string{"recut", "invalid", "missing_assets"},
+		},
+	}
 }

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/runtimeoutput"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
@@ -398,6 +399,7 @@ const (
 	dispatchSkipTerminalState            = "terminal_state"
 	dispatchSkipPullRequestHydration     = "pull_request_hydration_unavailable"
 	dispatchSkipAutoPromoteGatePending   = "auto_promote_gate_pending"
+	dispatchSkipArtifactGateWaitStatus   = "artifact_gate_wait_status"
 	dispatchSkipMergedPullRequest        = "merged_pull_request_reconciliation_pending"
 	dispatchSkipDuplicatePullRequest     = "duplicate_pull_request_work"
 	dispatchSkipUnauthorized             = "unauthorized"
@@ -431,6 +433,9 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	}
 	if pullRequestHydrationBlocksDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipPullRequestHydration}
+	}
+	if artifactGateWaitStatusBlocksDispatch(issue, p.cfg.AutoPromote.Gate) {
+		return dispatchableDecision{reason: dispatchSkipArtifactGateWaitStatus}
 	}
 	if autoPromoteActiveGatePendingIssue(issue, state, p.cfg, p.cfg.AutoPromote) {
 		return dispatchableDecision{reason: dispatchSkipAutoPromoteGatePending}
@@ -477,6 +482,27 @@ func pullRequestHydrationBlocksDispatch(issue connector.Issue) bool {
 		strings.TrimSpace(pullRequest.URL) != "" ||
 		strings.TrimSpace(pullRequest.BranchName) != "" ||
 		normalizePullRequestState(pullRequest.State) != ""
+}
+
+func artifactGateWaitStatusBlocksDispatch(issue connector.Issue, cfg gate.Config) bool {
+	cfg = gate.Effective(cfg)
+	if cfg.Kind != gate.KindArtifact {
+		return false
+	}
+	status := normalizeArtifactGateStatus(artifactStatusFromIssue(issue, cfg.Artifact.StatusField))
+	if status == "" {
+		return false
+	}
+	for _, waitStatus := range cfg.Artifact.WaitStatuses {
+		if status == normalizeArtifactGateStatus(waitStatus) {
+			return true
+		}
+	}
+	return false
+}
+
+func normalizeArtifactGateStatus(value string) string {
+	return strings.ToLower(strings.TrimSpace(value))
 }
 
 func (p dispatchPlanner) authorized(issue connector.Issue) bool {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -317,6 +317,55 @@ func TestDispatchableSkipsQuietWindowActiveIssueWithOpenPullRequest(t *testing.T
 	}
 }
 
+func TestDispatchableSkipsArtifactGateWaitStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 15, 40, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			PassState:   "Ready for Pickup",
+			ReworkState: "Rework",
+			Gate: gate.Config{
+				Kind: gate.KindArtifact,
+				Artifact: gate.ArtifactConfig{
+					StatusField:    "render_status",
+					PassStatuses:   []string{"approved", "valid"},
+					WaitStatuses:   []string{"queued", "rendering", "pending_review"},
+					ReworkStatuses: []string{"recut", "invalid", "missing_assets"},
+				},
+			},
+		},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	issue := dispatchTestIssue("issue-artifact-pending-review", "Production")
+	issue.Fields = map[string]string{"render_status": "pending_review"}
+	state := newState(cfg)
+	orch := Orchestrator{cfg: cfg}
+
+	decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
+	if decision.dispatchable {
+		t.Fatal("dispatchable artifact wait status issue = true, want false")
+	}
+	if decision.reason != dispatchSkipArtifactGateWaitStatus {
+		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipArtifactGateWaitStatus)
+	}
+
+	attempts := &recordingWorkAttemptStore{}
+	orch.workAttempts = attempts
+	orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{issue}, now)
+	if len(attempts.decisions) != 1 {
+		t.Fatalf("scheduler decisions len = %d, want 1", len(attempts.decisions))
+	}
+	if got := attempts.decisions[0].Reason; got != dispatchSkipArtifactGateWaitStatus {
+		t.Fatalf("scheduler decision reason = %q, want %q", got, dispatchSkipArtifactGateWaitStatus)
+	}
+}
+
 func TestHandleRunResultRecordsBudgetRefusalAndComment(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	local "github.com/digitaldrywood/detent/internal/connector/local"
+	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 )
 
@@ -126,4 +127,164 @@ func TestLocalSQLiteLifecycleEndToEnd(t *testing.T) {
 	if issues[0].StageUpdatedAt == nil {
 		t.Fatal("fetched issue StageUpdatedAt = nil, want parsed timestamp")
 	}
+}
+
+func TestLocalSQLiteArtifactLifecycleEndToEnd(t *testing.T) {
+	t.Parallel()
+
+	dbPath := filepath.Join(t.TempDir(), "artifact-work-items.db")
+	seed := connector.NewIssue()
+	seed.ID = "wi-artifact-1"
+	seed.Identifier = "wi-artifact-1"
+	seed.Title = "Render launch video"
+	seed.State = "Todo"
+	seed.Deliverable = &connector.Deliverable{Kind: "artifact"}
+
+	tracker, err := local.New(local.Config{
+		Path:           dbPath,
+		ProjectID:      "digitaldrywood-video",
+		Issues:         []connector.Issue{seed},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	defer tracker.Close()
+
+	runner := &staticRunner{
+		result: orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted},
+		onRun: func(request orchestrator.RunRequest) {
+			if err := tracker.SetField(context.Background(), request.Issue.ID, "render_status", "pending_review"); err != nil {
+				t.Errorf("SetField(pending_review) error = %v", err)
+			}
+		},
+	}
+
+	orch, err := orchestrator.New(orchestrator.Config{
+		PollInterval:        time.Millisecond,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "Production", "Rework"},
+		ObservedStates:      []string{"Backlog", "Review", "Blocked"},
+		TerminalStates:      []string{"Ready for Pickup", "Done", "Cancelled"},
+		AutoPromote: orchestrator.AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			PassState:   "Ready for Pickup",
+			ReworkState: "Rework",
+			Gate: gate.Config{
+				Kind: gate.KindArtifact,
+				Artifact: gate.ArtifactConfig{
+					StatusField:    "render_status",
+					PassStatuses:   []string{"approved", "valid"},
+					WaitStatuses:   []string{"queued", "rendering", "pending_review"},
+					ReworkStatuses: []string{"recut", "invalid", "missing_assets"},
+				},
+			},
+		},
+		MaxRetryBackoff:        time.Millisecond,
+		FailureRetryBaseDelay:  time.Millisecond,
+		ContinuationRetryDelay: time.Millisecond,
+	}, orchestrator.Dependencies{
+		Connector: tracker,
+		Runner:    runner,
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	stop := runOrchestrator(t, orch)
+	defer stop()
+
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("open tracker db: %v", err)
+	}
+	defer db.Close()
+
+	waitForLocalStoredState(t, db, seed.ID, "Review")
+	if got := runner.calls.Load(); got != 1 {
+		t.Fatalf("runner calls after Review = %d, want 1", got)
+	}
+
+	refreshAfterReview := time.Now().UTC()
+	waitForState(t, orch, func(state orchestrator.State) bool {
+		return state.LastRefreshAt.After(refreshAfterReview) && len(state.Running) == 0 && len(state.Retry) == 0
+	})
+	if got := runner.calls.Load(); got != 1 {
+		t.Fatalf("runner calls after wait-status refresh = %d, want 1", got)
+	}
+
+	if err := tracker.SetField(context.Background(), seed.ID, "render_status", "approved"); err != nil {
+		t.Fatalf("SetField(approved) error = %v", err)
+	}
+	waitForLocalStoredState(t, db, seed.ID, "Ready for Pickup")
+	if got := runner.calls.Load(); got != 1 {
+		t.Fatalf("runner calls after approval = %d, want 1", got)
+	}
+
+	events := localStateUpdateEvents(t, db, seed.ID)
+	wantEvents := []string{"Production", "Review", "Ready for Pickup"}
+	if len(events) != len(wantEvents) {
+		t.Fatalf("state_update events = %#v, want %#v", events, wantEvents)
+	}
+	for i := range wantEvents {
+		if events[i] != wantEvents[i] {
+			t.Fatalf("state_update events = %#v, want %#v", events, wantEvents)
+		}
+	}
+}
+
+func waitForLocalStoredState(t *testing.T, db *sql.DB, issueID string, want string) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if got := localStoredState(t, db, issueID); got == want {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for stored state %q; got %q", want, localStoredState(t, db, issueID))
+		case <-ticker.C:
+		}
+	}
+}
+
+func localStoredState(t *testing.T, db *sql.DB, issueID string) string {
+	t.Helper()
+
+	var state string
+	if err := db.QueryRowContext(context.Background(), "select state from detent_work_items where id = ?", issueID).Scan(&state); err != nil {
+		t.Fatalf("read stored state: %v", err)
+	}
+	return state
+}
+
+func localStateUpdateEvents(t *testing.T, db *sql.DB, issueID string) []string {
+	t.Helper()
+
+	rows, err := db.QueryContext(context.Background(), `
+select state from detent_work_item_events
+where item_id = ? and event_kind = 'state_update'
+order by id`, issueID)
+	if err != nil {
+		t.Fatalf("read state_update events: %v", err)
+	}
+	defer rows.Close()
+
+	var events []string
+	for rows.Next() {
+		var state string
+		if err := rows.Scan(&state); err != nil {
+			t.Fatalf("scan state_update event: %v", err)
+		}
+		events = append(events, state)
+	}
+	if err := rows.Err(); err != nil {
+		t.Fatalf("iterate state_update events: %v", err)
+	}
+	return events
 }

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"database/sql"
 	"path/filepath"
+	"slices"
 	"testing"
 	"time"
 
@@ -218,20 +219,13 @@ func TestLocalSQLiteArtifactLifecycleEndToEnd(t *testing.T) {
 	if err := tracker.SetField(context.Background(), seed.ID, "render_status", "approved"); err != nil {
 		t.Fatalf("SetField(approved) error = %v", err)
 	}
-	waitForLocalStoredState(t, db, seed.ID, "Ready for Pickup")
+	wantEvents := []string{"Production", "Review", "Ready for Pickup"}
+	waitForLocalStateUpdateEvents(t, db, seed.ID, wantEvents)
+	if got := localStoredState(t, db, seed.ID); got != "Ready for Pickup" {
+		t.Fatalf("stored state after approval = %q, want Ready for Pickup", got)
+	}
 	if got := runner.calls.Load(); got != 1 {
 		t.Fatalf("runner calls after approval = %d, want 1", got)
-	}
-
-	events := localStateUpdateEvents(t, db, seed.ID)
-	wantEvents := []string{"Production", "Review", "Ready for Pickup"}
-	if len(events) != len(wantEvents) {
-		t.Fatalf("state_update events = %#v, want %#v", events, wantEvents)
-	}
-	for i := range wantEvents {
-		if events[i] != wantEvents[i] {
-			t.Fatalf("state_update events = %#v, want %#v", events, wantEvents)
-		}
 	}
 }
 
@@ -261,6 +255,24 @@ func localStoredState(t *testing.T, db *sql.DB, issueID string) string {
 		t.Fatalf("read stored state: %v", err)
 	}
 	return state
+}
+
+func waitForLocalStateUpdateEvents(t *testing.T, db *sql.DB, issueID string, want []string) {
+	t.Helper()
+
+	deadline := time.After(time.Second)
+	ticker := time.NewTicker(time.Millisecond)
+	defer ticker.Stop()
+	for {
+		if got := localStateUpdateEvents(t, db, issueID); slices.Equal(got, want) {
+			return
+		}
+		select {
+		case <-deadline:
+			t.Fatalf("timed out waiting for state_update events %#v; got %#v", want, localStateUpdateEvents(t, db, issueID))
+		case <-ticker.C:
+		}
+	}
 }
 
 func localStateUpdateEvents(t *testing.T, db *sql.DB, issueID string) []string {

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -156,6 +156,12 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched.candidates,
 		completedTransitions.dispatchCandidates,
 	)
+	artifactWaitTransitions := o.transitionActiveArtifactGateWaitIssuesToReview(ctx, state, fetched.candidates, now)
+	fetched = filterReconciledTickIssues(
+		state,
+		fetched,
+		artifactWaitTransitions.transitioned,
+	)
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
 	if refreshSucceeded(state) {
 		state.BoardIssues = boardIssuesFromFetched(fetched)

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -929,6 +929,42 @@ func TestBoardSnapshotRendersActiveLaneAgeFooter(t *testing.T) {
 	}
 }
 
+func TestBoardSnapshotRendersLocalSQLiteProductionLaneAgeFooter(t *testing.T) {
+	now := time.Date(2026, 7, 9, 15, 0, 0, 0, time.UTC)
+	stageUpdatedAt := time.Date(2026, 7, 9, 14, 17, 33, 936728130, time.UTC)
+	data := DashboardData{
+		Kanban: KanbanData{
+			States: []string{"Backlog", "Todo", "Production", "Review", "Ready for Pickup"},
+		},
+		Snapshot: telemetry.Snapshot{
+			GeneratedAt: now,
+			BoardIssues: []telemetry.Issue{
+				{
+					ID:             "wi-011cd179bc7ecf36b7197e4b",
+					Identifier:     "wi-011cd179bc7ecf36b7197e4b",
+					ProjectID:      "video-production",
+					Title:          "Render local artifact",
+					State:          "Production",
+					StageUpdatedAt: &stageUpdatedAt,
+				},
+			},
+		},
+	}
+
+	html := renderBoardComponent(t, BoardSnapshot(data))
+	card := boardCardSection(t, html, "Render local artifact")
+	for _, want := range []string{
+		`data-board-card-age-footer`,
+		`title="Production since`,
+		"In lane",
+		"42m",
+	} {
+		if !strings.Contains(card, want) {
+			t.Fatalf("local_sqlite Production card missing age footer marker %q:\n%s", want, card)
+		}
+	}
+}
+
 func TestBoardSnapshotRendersOptInBlockedAlert(t *testing.T) {
 	data := boardTestData()
 	data.Kanban.ShowBlockedAlerts = true


### PR DESCRIPTION
## Summary

- Move successful artifact work items from active production/rework lanes into the configured review/source lane so the artifact gate can run.
- Skip active artifact items whose configured gate status is in `wait_statuses`, recording `artifact_gate_wait_status` scheduler decisions instead of dispatching another worker.
- Reconcile active artifact wait-status items to Review after restart so they do not remain stuck when in-memory completion state is gone.
- Cover the local_sqlite artifact lifecycle, scheduler skip reason, restart reconciliation, and local Production card in-lane rendering.

Fixes #1097

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] No visual changes to primary operator screens; local_sqlite in-lane rendering is covered by regression test.

## Test Plan

- [x] `go test ./internal/orchestrator -run 'TestCompletedActiveReviewTargetState|TestActiveArtifactGateWaitReviewTargetState|TestTransitionActiveArtifactGateWaitIssuesReconcilesToReviewAfterRestart|TestDispatchableSkipsArtifactGateWaitStatus|TestLocalSQLiteArtifactLifecycleEndToEnd' -count=1`
- [x] `go test -race ./internal/orchestrator -run TestLocalSQLiteArtifactLifecycleEndToEnd -count=10`
- [x] `go test ./internal/web/templates -run 'TestBoardSnapshotRendersLocalSQLiteProductionLaneAgeFooter|TestBoardSnapshotRendersActiveLaneAgeFooter' -count=1`
- [x] `make check`