### PR TITLE
fix(doctor): use read-only write permission checks

### DIFF
--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -4,7 +4,6 @@ tracker:
   github_status_source: issue_field
   repository: <repo-owner>/<repo-name>
   status_field: Status
-  write_probe_issue: <repo-owner>/<repo-name>#<issue-number>
   http_max_idle_conns: 100
   http_max_idle_conns_per_host: 32
   http_idle_conn_timeout_ms: 90000
@@ -144,7 +143,7 @@ server:
     # Set show_blocked_alerts: true only when red blocked states should appear
     # as one compact top-of-board alert; dependency waits stay on cards.
     # show_blocked_alerts: true
-    # Use mode: read_only for observer/shared dashboards or until write probes pass.
+    # Use mode: read_only for observer/shared dashboards or when write permissions are unavailable.
     # Optional allowed_transitions expose broader manual status editing.
     # allowed_transitions:
     #   In Progress: [Blocked, Cancelled]

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -143,7 +143,7 @@ server:
     # Set show_blocked_alerts: true only when red blocked states should appear
     # as one compact top-of-board alert; dependency waits stay on cards.
     # show_blocked_alerts: true
-    # Use mode: read_only for observer/shared dashboards or until write probes pass.
+    # Use mode: read_only for observer/shared dashboards or when write permissions are unavailable.
     # Optional allowed_transitions expose broader manual status editing.
     # allowed_transitions:
     #   In Progress: [Blocked, Cancelled]

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -3,7 +3,6 @@ tracker:
   kind: github
   github_status_source: project_v2
   project_slug: <project-node-id>
-  write_probe_issue: <repo-owner>/<repo-name>#<issue-number>
   http_max_idle_conns: 100
   http_max_idle_conns_per_host: 32
   http_idle_conn_timeout_ms: 90000
@@ -143,7 +142,7 @@ server:
     # Set show_blocked_alerts: true only when red blocked states should appear
     # as one compact top-of-board alert; dependency waits stay on cards.
     # show_blocked_alerts: true
-    # Use mode: read_only for observer/shared dashboards or until write probes pass.
+    # Use mode: read_only for observer/shared dashboards or when write permissions are unavailable.
     # Optional allowed_transitions expose broader manual status editing.
     # allowed_transitions:
     #   In Progress: [Blocked, Cancelled]

--- a/internal/cli/doctor_github.go
+++ b/internal/cli/doctor_github.go
@@ -34,7 +34,7 @@ func checkDoctorGitHubReadiness(
 	allowWriteProbes bool,
 ) []doctorCheck {
 	readiness := doctorGitHubReadinessConfig(ctx, project, cfg, deps, githubToken, sourceRoot)
-	readiness, writeProbeCheck := doctorGitHubReadinessWithWriteProbeAuthorization(id, readiness, allowWriteProbes)
+	readiness.AllowWriteProbes = allowWriteProbes
 	checks, err := deps.githubReadiness(ctx, doctorGitHubConnectorConfig(cfg), readiness)
 	if err != nil {
 		return []doctorCheck{{
@@ -53,35 +53,7 @@ func checkDoctorGitHubReadiness(
 			Hint:   check.Hint,
 		})
 	}
-	if writeProbeCheck != nil {
-		out = append(out, *writeProbeCheck)
-	}
 	return out
-}
-
-func doctorGitHubReadinessWithWriteProbeAuthorization(id string, cfg ghconnector.ReadinessConfig, allowWriteProbes bool) (ghconnector.ReadinessConfig, *doctorCheck) {
-	if allowWriteProbes || !doctorGitHubReadinessRequiresWrites(cfg) {
-		return cfg, nil
-	}
-
-	detail := "skipped; rerun detent doctor with --allow-write-probes after mutation authorization"
-	if probe := strings.TrimSpace(cfg.WriteProbeIssue); probe != "" {
-		detail = "skipped for tracker.write_probe_issue " + probe + "; rerun detent doctor with --allow-write-probes after mutation authorization"
-	}
-	check := doctorCheck{
-		Name:   "Project " + id + " GitHub write probes",
-		Status: doctorWarn,
-		Detail: detail,
-		Hint:   `Run detent onboarding validate-answers --phase mutation and get operator confirmation before enabling write probes.`,
-	}
-	cfg.RequireProjectStatusWrite = false
-	cfg.RequireIssueFieldStatusWrite = false
-	cfg.RequireLabelStatusWrite = false
-	cfg.RequireIssueComments = false
-	cfg.RequireAssigneeWrite = false
-	cfg.RequireIssueClose = false
-	cfg.ProjectFieldWrites = nil
-	return cfg, &check
 }
 
 func doctorGitHubReadinessRequiresWrites(cfg ghconnector.ReadinessConfig) bool {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1296,7 +1296,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	}
 }
 
-func TestRunDoctorSkipsWriteProbesByDefaultForExistingConfiguredProject(t *testing.T) {
+func TestRunDoctorUsesReadOnlyWriteChecksByDefaultForExistingConfiguredProject(t *testing.T) {
 	t.Parallel()
 
 	workflow := validDoctorWorkflow("/repo")
@@ -1341,9 +1341,9 @@ func TestRunDoctorSkipsWriteProbesByDefaultForExistingConfiguredProject(t *testi
 	deps.githubReadiness = func(_ context.Context, _ ghconnector.Config, readiness ghconnector.ReadinessConfig) ([]ghconnector.ReadinessCheck, error) {
 		gotReadiness = readiness
 		return []ghconnector.ReadinessCheck{{
-			Name:   "GitHub status label issue read",
+			Name:   "GitHub issue write permission digitaldrywood/detent",
 			Status: ghconnector.ReadinessOK,
-			Detail: "read-only checks completed",
+			Detail: "repository permission push permits issue writes",
 		}}, nil
 	}
 
@@ -1356,10 +1356,18 @@ func TestRunDoctorSkipsWriteProbesByDefaultForExistingConfiguredProject(t *testi
 		},
 	}, successfulDoctorOptionsWithConfig(configPath, global), deps)
 
-	if doctorGitHubReadinessRequiresWrites(gotReadiness) {
-		t.Fatalf("readiness write requirements = %#v, want default doctor to skip write probes", gotReadiness)
+	if !doctorGitHubReadinessRequiresWrites(gotReadiness) {
+		t.Fatalf("readiness write requirements = %#v, want default doctor to retain read-only write checks", gotReadiness)
 	}
-	assertDoctorCheck(t, report, "Project existing GitHub write probes", doctorWarn, "rerun detent doctor with --allow-write-probes after mutation authorization")
+	if gotReadiness.AllowWriteProbes {
+		t.Fatalf("AllowWriteProbes = true, want default doctor to avoid mutation probes")
+	}
+	assertDoctorCheck(t, report, "Project existing GitHub issue write permission digitaldrywood/detent", doctorOK, "repository permission push")
+	for _, check := range report.Checks {
+		if check.Name == "Project existing GitHub write probes" {
+			t.Fatalf("checks include legacy write-probe warning: %#v", check)
+		}
+	}
 }
 
 func TestRunDoctorWithProjectScopeSkipsUnrelatedProjectFailures(t *testing.T) {
@@ -1754,6 +1762,9 @@ func TestDoctorCommandAllowWriteProbesFlagEnablesWriteReadiness(t *testing.T) {
 	}
 	if !gotReadiness.RequireLabelStatusWrite || !gotReadiness.RequireIssueComments {
 		t.Fatalf("readiness write requirements = %#v, want write probes enabled by flag", gotReadiness)
+	}
+	if !gotReadiness.AllowWriteProbes {
+		t.Fatalf("AllowWriteProbes = false, want write probes enabled by flag")
 	}
 }
 

--- a/internal/connector/github/readiness.go
+++ b/internal/connector/github/readiness.go
@@ -33,6 +33,7 @@ type ReadinessConfig struct {
 	AuthPath                      string
 	LocalStatusMode               bool
 	WriteProbeIssue               string
+	AllowWriteProbes              bool
 	Repositories                  []string
 	StatusStates                  []string
 	ReadStates                    []string
@@ -57,6 +58,18 @@ type ReadinessConfig struct {
 type ReadinessProjectFieldWrite struct {
 	Name string
 }
+
+const projectWritePermissionQuery = `
+query DetentGitHubProjectWritePermission($projectId: ID!) {
+  node(id: $projectId) {
+    __typename
+    ... on ProjectV2 {
+      id
+      viewerCanUpdate
+    }
+  }
+  rateLimit { limit used remaining cost resetAt }
+}`
 
 type readinessProbeIssue struct {
 	ID    string
@@ -107,7 +120,12 @@ func (c githubReadinessChecker) Check(ctx context.Context, cfg ReadinessConfig) 
 		if probeCheck != nil {
 			checks = append(checks, *probeCheck)
 		}
-		checks = append(checks, c.probeReadChecks(ctx, cfg, probe, hasProbe)...)
+		readTarget, hasReadTarget, readTargetCheck := c.resolveIssueRelationshipReadTarget(ctx, cfg, probe, hasProbe)
+		if readTargetCheck != nil {
+			checks = append(checks, *readTargetCheck)
+		} else {
+			checks = append(checks, c.probeReadChecks(ctx, cfg, readTarget, hasReadTarget)...)
+		}
 		checks = append(checks, c.localWriteAllowlistCheck())
 		checks = append(checks, c.rateLimitCheck(ctx))
 		return checks
@@ -136,7 +154,12 @@ func (c githubReadinessChecker) Check(ctx context.Context, cfg ReadinessConfig) 
 	if probeCheck != nil {
 		checks = append(checks, *probeCheck)
 	}
-	checks = append(checks, c.probeReadChecks(ctx, cfg, probe, hasProbe)...)
+	readTarget, hasReadTarget, readTargetCheck := c.resolveIssueRelationshipReadTarget(ctx, cfg, probe, hasProbe)
+	if readTargetCheck != nil {
+		checks = append(checks, *readTargetCheck)
+	} else {
+		checks = append(checks, c.probeReadChecks(ctx, cfg, readTarget, hasReadTarget)...)
+	}
 	checks = append(checks, c.writeChecks(ctx, cfg, probe, hasProbe)...)
 	checks = append(checks, c.rateLimitCheck(ctx))
 	return checks
@@ -502,10 +525,7 @@ func (c githubReadinessChecker) repositoryChecks(ctx context.Context, repositori
 }
 
 func (c githubReadinessChecker) repositoryReadCheck(ctx context.Context, repo string) ReadinessCheck {
-	var out struct {
-		FullName string `json:"full_name"`
-	}
-	if err := c.connector.client.REST(ctx, http.MethodGet, restRepositoryPath(repo), nil, &out); err != nil {
+	if _, err := c.repositoryMetadata(ctx, repo); err != nil {
 		return ReadinessCheck{
 			Name:   "GitHub repository " + repo + " access",
 			Status: ReadinessFail,
@@ -696,13 +716,19 @@ func (c githubReadinessChecker) repositoryPullRequestSample(ctx context.Context,
 }
 
 func (c githubReadinessChecker) repositoryDefaultBranch(ctx context.Context, repo string) (string, error) {
-	var out struct {
-		DefaultBranch string `json:"default_branch"`
-	}
-	if err := c.connector.client.REST(ctx, http.MethodGet, restRepositoryPath(repo), nil, &out); err != nil {
+	out, err := c.repositoryMetadata(ctx, repo)
+	if err != nil {
 		return "", err
 	}
 	return strings.TrimSpace(out.DefaultBranch), nil
+}
+
+func (c githubReadinessChecker) repositoryMetadata(ctx context.Context, repo string) (restRepository, error) {
+	var out restRepository
+	if err := c.connector.client.REST(ctx, http.MethodGet, restRepositoryPath(repo), nil, &out); err != nil {
+		return restRepository{}, err
+	}
+	return out, nil
 }
 
 func (c githubReadinessChecker) restReadCheck(ctx context.Context, name string, path string, okDetail string, hint string) ReadinessCheck {
@@ -792,9 +818,7 @@ func writeProbeTargetCheck(probeID string, probe readinessProbeIssue) ReadinessC
 }
 
 func (cfg ReadinessConfig) requiresProbeIssue() bool {
-	return cfg.requiresWriteProbe() ||
-		cfg.RequireIssueChildrenRead ||
-		cfg.RequireIssueParentsRead
+	return cfg.AllowWriteProbes && cfg.requiresWriteProbe()
 }
 
 func (cfg ReadinessConfig) requiresWriteProbe() bool {
@@ -811,6 +835,11 @@ func (cfg ReadinessConfig) requiresIssueObjectWriteProbe() bool {
 	return cfg.RequireIssueComments ||
 		cfg.RequireAssigneeWrite ||
 		cfg.RequireIssueClose
+}
+
+func (cfg ReadinessConfig) requiresIssueRelationshipRead() bool {
+	return cfg.RequireIssueChildrenRead ||
+		cfg.RequireIssueParentsRead
 }
 
 func (c githubReadinessChecker) resolveProbeIssue(ctx context.Context, value string) (readinessProbeIssue, error) {
@@ -842,6 +871,85 @@ func (c githubReadinessChecker) resolveProbeIssue(ctx context.Context, value str
 	return readinessProbeIssue{ID: strings.TrimSpace(issue.ID), Ref: ref, State: issue.State}, nil
 }
 
+func (c githubReadinessChecker) resolveIssueRelationshipReadTarget(
+	ctx context.Context,
+	cfg ReadinessConfig,
+	probe readinessProbeIssue,
+	hasProbe bool,
+) (readinessProbeIssue, bool, *ReadinessCheck) {
+	if !cfg.requiresIssueRelationshipRead() {
+		return readinessProbeIssue{}, false, nil
+	}
+	if hasProbe {
+		return probe, true, nil
+	}
+	return c.resolveRepositoryIssueSample(ctx, cfg.Repositories)
+}
+
+func (c githubReadinessChecker) resolveRepositoryIssueSample(ctx context.Context, repositories []string) (readinessProbeIssue, bool, *ReadinessCheck) {
+	repositories = normalizedRepositories(repositories)
+	if len(repositories) == 0 {
+		check := ReadinessCheck{
+			Name:   "GitHub issue relationship metadata sample",
+			Status: ReadinessWarn,
+			Detail: "no source or target repository could be inferred; issue relationship read capability not proven",
+			Hint:   "Configure tracker.repository or ensure the project source checkout has a GitHub origin remote.",
+		}
+		return readinessProbeIssue{}, false, &check
+	}
+	for _, repo := range repositories {
+		sample, ok, check := c.repositoryIssueSample(ctx, repo)
+		if check != nil {
+			return readinessProbeIssue{}, false, check
+		}
+		if ok {
+			return sample, true, nil
+		}
+	}
+	check := ReadinessCheck{
+		Name:   "GitHub issue relationship metadata sample",
+		Status: ReadinessWarn,
+		Detail: "no issue was available to prove issue children/parent metadata access",
+		Hint:   "Keep at least one issue in the configured repository if strict issue relationship readiness proof is required.",
+	}
+	return readinessProbeIssue{}, false, &check
+}
+
+func (c githubReadinessChecker) repositoryIssueSample(ctx context.Context, repo string) (readinessProbeIssue, bool, *ReadinessCheck) {
+	var response restIssueSearchResponse
+	if err := c.connector.client.REST(ctx, http.MethodGet, restRepositoryIssueSearchPath(repo), nil, &response); err != nil {
+		check := ReadinessCheck{
+			Name:   "GitHub issue relationship metadata sample",
+			Status: ReadinessFail,
+			Detail: "cannot search repository issues for relationship read sample: " + err.Error(),
+			Hint:   "Grant repository issue search access for " + repo + ".",
+		}
+		return readinessProbeIssue{}, false, &check
+	}
+	owner, name, ok := splitRepositoryName(repo)
+	if !ok {
+		check := ReadinessCheck{
+			Name:   "GitHub issue relationship metadata sample",
+			Status: ReadinessFail,
+			Detail: "repository name is invalid",
+			Hint:   "Use owner/name repository identifiers.",
+		}
+		return readinessProbeIssue{}, false, &check
+	}
+	fallback := issueRef{Owner: owner, Name: name}
+	for _, item := range response.Items {
+		if item.PullRequest != nil || strings.TrimSpace(item.NodeID) == "" {
+			continue
+		}
+		ref, ok := issueRefFromRESTSearchItem(item, fallback)
+		if !ok {
+			continue
+		}
+		return readinessProbeIssue{ID: strings.TrimSpace(item.NodeID), Ref: ref, State: item.State}, true, nil
+	}
+	return readinessProbeIssue{}, false, nil
+}
+
 func (c githubReadinessChecker) probeReadChecks(ctx context.Context, cfg ReadinessConfig, probe readinessProbeIssue, hasProbe bool) []ReadinessCheck {
 	checks := []ReadinessCheck{}
 	if cfg.RequireIssueChildrenRead {
@@ -855,7 +963,7 @@ func (c githubReadinessChecker) probeReadChecks(ctx context.Context, cfg Readine
 
 func (c githubReadinessChecker) issueChildrenReadCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
 	if !hasProbe {
-		return unprovenProbeIssueCheck("GitHub issue children metadata")
+		return unprovenIssueSampleCheck("GitHub issue children metadata")
 	}
 	children, err := c.connector.FetchIssueChildren(ctx, probe.ID)
 	if err != nil {
@@ -869,13 +977,13 @@ func (c githubReadinessChecker) issueChildrenReadCheck(ctx context.Context, prob
 	return ReadinessCheck{
 		Name:   "GitHub issue children metadata",
 		Status: ReadinessOK,
-		Detail: fmt.Sprintf("queried sub-issue and tracked-issue metadata for probe issue; found %d child link(s)", len(children)),
+		Detail: fmt.Sprintf("queried sub-issue and tracked-issue metadata for sample issue %s#%d; found %d child link(s)", probe.Ref.Owner+"/"+probe.Ref.Name, probe.Ref.Number, len(children)),
 	}
 }
 
 func (c githubReadinessChecker) issueParentsReadCheck(ctx context.Context, probe readinessProbeIssue, hasProbe bool) ReadinessCheck {
 	if !hasProbe {
-		return unprovenProbeIssueCheck("GitHub issue parent metadata")
+		return unprovenIssueSampleCheck("GitHub issue parent metadata")
 	}
 	parents, err := c.connector.FetchIssueParents(ctx, probe.ID)
 	if err != nil {
@@ -889,11 +997,210 @@ func (c githubReadinessChecker) issueParentsReadCheck(ctx context.Context, probe
 	return ReadinessCheck{
 		Name:   "GitHub issue parent metadata",
 		Status: ReadinessOK,
-		Detail: fmt.Sprintf("queried parent and tracked-in metadata for probe issue; found %d parent link(s)", len(parents)),
+		Detail: fmt.Sprintf("queried parent and tracked-in metadata for sample issue %s#%d; found %d parent link(s)", probe.Ref.Owner+"/"+probe.Ref.Name, probe.Ref.Number, len(parents)),
 	}
 }
 
 func (c githubReadinessChecker) writeChecks(ctx context.Context, cfg ReadinessConfig, probe readinessProbeIssue, hasProbe bool) []ReadinessCheck {
+	if !cfg.AllowWriteProbes {
+		if hasGitHubAppCredentials(c.cfg, c.cfg.LookupEnv) {
+			return nil
+		}
+		return c.readOnlyWriteChecks(ctx, cfg)
+	}
+	return c.mutationWriteChecks(ctx, cfg, probe, hasProbe)
+}
+
+func (c githubReadinessChecker) readOnlyWriteChecks(ctx context.Context, cfg ReadinessConfig) []ReadinessCheck {
+	checks := []ReadinessCheck{}
+	if cfg.RequireProjectStatusWrite || len(cfg.ProjectFieldWrites) > 0 {
+		checks = append(checks, c.projectWritePermissionCheck(ctx))
+	}
+	if cfg.requiresIssueWritePermission() {
+		repositories := normalizedRepositories(cfg.Repositories)
+		if len(repositories) == 0 {
+			checks = append(checks, ReadinessCheck{
+				Name:   "GitHub issue write permission",
+				Status: ReadinessFail,
+				Detail: "cannot introspect Issues: write; no source or target repository could be inferred",
+				Hint:   "Configure tracker.repository or ensure the project source checkout has a GitHub origin remote.",
+			})
+		}
+		for _, repo := range repositories {
+			checks = append(checks, c.repositoryIssueWritePermissionCheck(ctx, repo, cfg))
+		}
+	}
+	return checks
+}
+
+func (cfg ReadinessConfig) requiresIssueWritePermission() bool {
+	return cfg.RequireIssueFieldStatusWrite ||
+		cfg.RequireLabelStatusWrite ||
+		cfg.RequireIssueComments ||
+		cfg.RequireAssigneeWrite ||
+		cfg.RequireIssueClose
+}
+
+func (c githubReadinessChecker) projectWritePermissionCheck(ctx context.Context) ReadinessCheck {
+	if c.connector == nil || c.connector.client == nil {
+		return ReadinessCheck{
+			Name:   "GitHub project write permission",
+			Status: ReadinessFail,
+			Detail: "cannot introspect Projects: write; GitHub connector is not configured",
+			Hint:   "Check GitHub tracker configuration and credentials.",
+		}
+	}
+	projectID := strings.TrimSpace(c.connector.projectID)
+	if projectID == "" {
+		return ReadinessCheck{
+			Name:   "GitHub project write permission",
+			Status: ReadinessFail,
+			Detail: "cannot introspect Projects: write; tracker.project_slug is blank",
+			Hint:   "Set tracker.project_slug or use a boardless GitHub status source.",
+		}
+	}
+	var response struct {
+		Node *struct {
+			TypeName        string `json:"__typename"`
+			ID              string `json:"id"`
+			ViewerCanUpdate bool   `json:"viewerCanUpdate"`
+		} `json:"node"`
+	}
+	if err := c.connector.client.GraphQLWithType(ctx, graphQLQueryProjectMetadata, projectWritePermissionQuery, map[string]any{
+		"projectId": projectID,
+	}, &response); err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub project write permission",
+			Status: ReadinessFail,
+			Detail: "cannot read ProjectV2 update permission: " + err.Error(),
+			Hint:   "Grant Projects read access so Detent can introspect the token's project permissions.",
+		}
+	}
+	if response.Node == nil || response.Node.TypeName != "ProjectV2" || strings.TrimSpace(response.Node.ID) == "" {
+		return ReadinessCheck{
+			Name:   "GitHub project write permission",
+			Status: ReadinessFail,
+			Detail: "cannot resolve ProjectV2 " + projectID,
+			Hint:   "Fix tracker.project_slug and grant the token access to the configured project.",
+		}
+	}
+	if !response.Node.ViewerCanUpdate {
+		return ReadinessCheck{
+			Name:   "GitHub project write permission",
+			Status: ReadinessFail,
+			Detail: "token lacks Projects: write for ProjectV2 " + projectID + "; viewerCanUpdate=false",
+			Hint:   "Grant project write access to the token or rerun with --allow-write-probes against a dedicated scratch issue for deep verification.",
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub project write permission",
+		Status: ReadinessOK,
+		Detail: "viewer can update ProjectV2 " + projectID + "; covers status and project field writes",
+	}
+}
+
+func (c githubReadinessChecker) repositoryIssueWritePermissionCheck(ctx context.Context, repo string, cfg ReadinessConfig) ReadinessCheck {
+	if c.connector == nil || c.connector.client == nil {
+		return ReadinessCheck{
+			Name:   "GitHub issue write permission " + repo,
+			Status: ReadinessFail,
+			Detail: "cannot introspect Issues: write; GitHub connector is not configured",
+			Hint:   "Check GitHub tracker configuration and credentials.",
+		}
+	}
+	metadata, err := c.repositoryMetadata(ctx, repo)
+	if err != nil {
+		return ReadinessCheck{
+			Name:   "GitHub issue write permission " + repo,
+			Status: ReadinessFail,
+			Detail: "cannot read repository permissions: " + err.Error(),
+			Hint:   "Grant the token access to " + repo + ".",
+		}
+	}
+	level, ok := repositoryIssueWritePermissionLevel(metadata.Permissions, cfg)
+	capabilities := strings.Join(requiredIssueWriteCapabilities(cfg), ", ")
+	if !ok {
+		return ReadinessCheck{
+			Name:   "GitHub issue write permission " + repo,
+			Status: ReadinessFail,
+			Detail: fmt.Sprintf("token lacks %s for %s; repository permissions: %s; required for %s", repositoryIssueWritePermissionName(cfg), repo, repositoryPermissionsDetail(metadata.Permissions), capabilities),
+			Hint:   repositoryIssueWritePermissionHint(cfg),
+		}
+	}
+	return ReadinessCheck{
+		Name:   "GitHub issue write permission " + repo,
+		Status: ReadinessOK,
+		Detail: fmt.Sprintf("repository permission %s permits issue writes for %s", level, capabilities),
+	}
+}
+
+func requiredIssueWriteCapabilities(cfg ReadinessConfig) []string {
+	capabilities := []string{}
+	if cfg.RequireIssueFieldStatusWrite {
+		capabilities = append(capabilities, "issue field Status updates")
+	}
+	if cfg.RequireLabelStatusWrite {
+		capabilities = append(capabilities, "status label updates")
+	}
+	if cfg.RequireIssueComments {
+		capabilities = append(capabilities, "issue comments")
+	}
+	if cfg.RequireAssigneeWrite {
+		capabilities = append(capabilities, "assignee updates")
+	}
+	if cfg.RequireIssueClose {
+		capabilities = append(capabilities, "issue close")
+	}
+	return capabilities
+}
+
+func repositoryIssueWritePermissionLevel(permissions map[string]bool, cfg ReadinessConfig) (string, bool) {
+	for _, level := range repositoryIssueWritePermissionLevels(cfg) {
+		if permissions[level] {
+			return level, true
+		}
+	}
+	return repositoryPermissionsDetail(permissions), false
+}
+
+func repositoryIssueWritePermissionLevels(cfg ReadinessConfig) []string {
+	if cfg.RequireIssueFieldStatusWrite {
+		return []string{"admin", "maintain", "push"}
+	}
+	return []string{"admin", "maintain", "push", "triage"}
+}
+
+func repositoryIssueWritePermissionName(cfg ReadinessConfig) string {
+	if cfg.RequireIssueFieldStatusWrite {
+		return "repository push permission"
+	}
+	return "Issues: write"
+}
+
+func repositoryIssueWritePermissionHint(cfg ReadinessConfig) string {
+	if cfg.RequireIssueFieldStatusWrite {
+		return "Grant the token push, maintain, or admin access to the repository."
+	}
+	return "Grant the token triage, push, maintain, or admin access to the repository."
+}
+
+func repositoryPermissionsDetail(permissions map[string]bool) string {
+	if len(permissions) == 0 {
+		return "not reported"
+	}
+	enabled := []string{}
+	for _, level := range []string{"admin", "maintain", "push", "triage", "pull"} {
+		if permissions[level] {
+			enabled = append(enabled, level)
+		}
+	}
+	if len(enabled) == 0 {
+		return "none"
+	}
+	return strings.Join(enabled, ", ")
+}
+
+func (c githubReadinessChecker) mutationWriteChecks(ctx context.Context, cfg ReadinessConfig, probe readinessProbeIssue, hasProbe bool) []ReadinessCheck {
 	checks := []ReadinessCheck{}
 	if cfg.RequireProjectStatusWrite {
 		checks = append(checks, c.projectStatusWriteCheck(ctx, probe, hasProbe))
@@ -905,7 +1212,7 @@ func (c githubReadinessChecker) writeChecks(ctx context.Context, cfg ReadinessCo
 		checks = append(checks, c.labelStatusWriteCheck(ctx, probe, hasProbe))
 	}
 	if cfg.requiresIssueObjectWriteProbe() && !hasProbe && c.canUseRepositoryIssueWriteProbe() {
-		checks = append(checks, c.repositoryIssueWritePermissionCheck(ctx))
+		checks = append(checks, c.repositoryIssueWriteMutationProbeCheck(ctx))
 	} else {
 		if cfg.RequireIssueComments {
 			checks = append(checks, c.issueCommentWriteCheck(ctx, probe, hasProbe))
@@ -1128,7 +1435,7 @@ func (c githubReadinessChecker) repositoryLabelWritePermissionCheck(ctx context.
 	}, "write repository labels")
 }
 
-func (c githubReadinessChecker) repositoryIssueWritePermissionCheck(ctx context.Context) ReadinessCheck {
+func (c githubReadinessChecker) repositoryIssueWriteMutationProbeCheck(ctx context.Context) ReadinessCheck {
 	return c.invalidNoPersistentWriteProbe(ctx, "GitHub issue write permission", http.MethodPost, restRepositoryIssueCreatePath(c.connector.repository), map[string]any{
 		"title": "",
 	}, "write issues")
@@ -1414,12 +1721,12 @@ func (c githubReadinessChecker) projectFieldWriteCheck(ctx context.Context, prob
 	}
 }
 
-func unprovenProbeIssueCheck(name string) ReadinessCheck {
+func unprovenIssueSampleCheck(name string) ReadinessCheck {
 	return ReadinessCheck{
 		Name:   name,
 		Status: ReadinessWarn,
-		Detail: "no tracker.write_probe_issue configured; issue-specific read capability not proven",
-		Hint:   "Configure tracker.write_probe_issue with a scratch issue on the configured project to prove this capability.",
+		Detail: "no repository issue sample was available; issue relationship read capability not proven",
+		Hint:   "Keep at least one issue in the configured repository if strict issue relationship readiness proof is required.",
 	}
 }
 

--- a/internal/connector/github/readiness_test.go
+++ b/internal/connector/github/readiness_test.go
@@ -3,6 +3,7 @@ package github
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -229,6 +230,7 @@ func TestReadinessLabelStatusWriteUsesRepositoryLabelProbeWithoutIssue(t *testin
 	checker := githubReadinessChecker{connector: c}
 
 	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		AllowWriteProbes:        true,
 		RequireLabelStatusWrite: true,
 	}, readinessProbeIssue{}, false)
 	if len(got) != 1 {
@@ -275,6 +277,7 @@ func TestReadinessLabelIssueWritesUseInvalidIssueCreateWithoutProbe(t *testing.T
 	checker := githubReadinessChecker{connector: c}
 
 	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		AllowWriteProbes:     true,
 		RequireIssueComments: true,
 		RequireAssigneeWrite: true,
 		RequireIssueClose:    true,
@@ -321,7 +324,7 @@ func TestReadinessLabelModeWriteChecksPassWithoutProbeIssue(t *testing.T) {
 		{
 			method: http.MethodGet,
 			path:   "/repos/digitaldrywood/detent",
-			body:   `{"full_name":"digitaldrywood/detent"}`,
+			body:   `{"full_name":"digitaldrywood/detent","permissions":{"push":true,"pull":true}}`,
 		},
 		{
 			method: http.MethodGet,
@@ -329,22 +332,9 @@ func TestReadinessLabelModeWriteChecksPassWithoutProbeIssue(t *testing.T) {
 			body:   `[]`,
 		},
 		{
-			method: http.MethodPost,
-			path:   "/repos/digitaldrywood/detent/labels",
-			status: http.StatusUnprocessableEntity,
-			headers: map[string]string{
-				"X-Accepted-GitHub-Permissions": "issues=write",
-			},
-			body: `{"message":"Validation Failed"}`,
-		},
-		{
-			method: http.MethodPost,
-			path:   "/repos/digitaldrywood/detent/issues",
-			status: http.StatusUnprocessableEntity,
-			headers: map[string]string{
-				"X-Accepted-GitHub-Permissions": "issues=write",
-			},
-			body: `{"message":"Validation Failed"}`,
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/detent",
+			body:   `{"full_name":"digitaldrywood/detent","permissions":{"push":true,"pull":true}}`,
 		},
 		{
 			method: http.MethodGet,
@@ -377,14 +367,176 @@ func TestReadinessLabelModeWriteChecksPassWithoutProbeIssue(t *testing.T) {
 		}
 	}
 	requests := server.requests()
-	if len(requests) != 7 {
-		t.Fatalf("requests len = %d, want 7: %#v", len(requests), requests)
+	if len(requests) != 6 {
+		t.Fatalf("requests len = %d, want 6: %#v", len(requests), requests)
 	}
-	if requests[4]["path"] != "/repos/digitaldrywood/detent/labels" {
-		t.Fatalf("fifth request path = %q, want repository label probe", requests[4]["path"])
+	if requests[4]["method"] != http.MethodGet || requests[4]["path"] != "/repos/digitaldrywood/detent" {
+		t.Fatalf("fifth request = %#v, want read-only repository permission introspection", requests[4])
 	}
-	if requests[5]["path"] != "/repos/digitaldrywood/detent/issues" {
-		t.Fatalf("sixth request path = %q, want invalid issue create probe", requests[5]["path"])
+	for _, request := range requests {
+		if request["method"] == http.MethodPost || request["method"] == http.MethodPut || request["method"] == http.MethodPatch {
+			t.Fatalf("request = %#v, want no mutation in default readiness", request)
+		}
+	}
+}
+
+func TestReadinessReadOnlyIssueWritePermissionFailsWithoutWriteRole(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent",
+		body:   `{"full_name":"digitaldrywood/detent","permissions":{"pull":true}}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		Repositories:         []string{"digitaldrywood/detent"},
+		RequireIssueComments: true,
+	}, readinessProbeIssue{}, false)
+	if len(got) != 1 {
+		t.Fatalf("checks len = %d, want 1: %#v", len(got), got)
+	}
+	check := got[0]
+	if check.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", check.Status, ReadinessFail, check)
+	}
+	for _, want := range []string{"Issues: write", "pull", "issue comments"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+		}
+	}
+	requests := server.requests()
+	if len(requests) != 1 {
+		t.Fatalf("requests len = %d, want 1: %#v", len(requests), requests)
+	}
+	if requests[0]["method"] != http.MethodGet {
+		t.Fatalf("request method = %s, want GET", requests[0]["method"])
+	}
+}
+
+func TestReadinessReadOnlyIssueWritePermissionAllowsTriageRole(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent",
+		body:   `{"full_name":"digitaldrywood/detent","permissions":{"triage":true,"pull":true}}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		Repositories:            []string{"digitaldrywood/detent"},
+		RequireLabelStatusWrite: true,
+		RequireIssueComments:    true,
+		RequireAssigneeWrite:    true,
+		RequireIssueClose:       true,
+	}, readinessProbeIssue{}, false)
+	if len(got) != 1 {
+		t.Fatalf("checks len = %d, want 1: %#v", len(got), got)
+	}
+	check := got[0]
+	if check.Status != ReadinessOK {
+		t.Fatalf("Status = %s, want %s: %#v", check.Status, ReadinessOK, check)
+	}
+	for _, want := range []string{"repository permission triage", "status label updates", "issue comments", "assignee updates", "issue close"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+		}
+	}
+}
+
+func TestReadinessReadOnlyIssueFieldStatusWriteRequiresPushRole(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{{
+		method: http.MethodGet,
+		path:   "/repos/digitaldrywood/detent",
+		body:   `{"full_name":"digitaldrywood/detent","permissions":{"triage":true,"pull":true}}`,
+	}})
+	c := newGitHubTestConnector(t, server, Config{})
+	checker := githubReadinessChecker{connector: c}
+
+	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		Repositories:                 []string{"digitaldrywood/detent"},
+		RequireIssueFieldStatusWrite: true,
+	}, readinessProbeIssue{}, false)
+	if len(got) != 1 {
+		t.Fatalf("checks len = %d, want 1: %#v", len(got), got)
+	}
+	check := got[0]
+	if check.Status != ReadinessFail {
+		t.Fatalf("Status = %s, want %s: %#v", check.Status, ReadinessFail, check)
+	}
+	for _, want := range []string{"repository push permission", "triage", "issue field Status updates"} {
+		if !strings.Contains(check.Detail, want) {
+			t.Fatalf("Detail = %q, want containing %q", check.Detail, want)
+		}
+	}
+	if strings.Contains(check.Hint, "triage") {
+		t.Fatalf("Hint = %q, want push-or-stronger guidance", check.Hint)
+	}
+}
+
+func TestReadinessProjectWritePermissionUsesViewerCanUpdate(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name            string
+		viewerCanUpdate bool
+		wantStatus      ReadinessStatus
+		wantDetail      string
+	}{
+		{
+			name:            "can update",
+			viewerCanUpdate: true,
+			wantStatus:      ReadinessOK,
+			wantDetail:      "viewer can update ProjectV2 PVT_1",
+		},
+		{
+			name:            "cannot update",
+			viewerCanUpdate: false,
+			wantStatus:      ReadinessFail,
+			wantDetail:      "Projects: write",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			body := fmt.Sprintf(`{"data":{"node":{"__typename":"ProjectV2","id":"PVT_1","viewerCanUpdate":%t}}}`, tt.viewerCanUpdate)
+			server := newGraphQLTestServer(t, []graphqlTestResponse{{
+				body: body,
+			}})
+			c := newGitHubTestConnector(t, server, Config{
+				ProjectSlug: "PVT_1",
+			})
+			checker := githubReadinessChecker{connector: c}
+
+			got := checker.writeChecks(context.Background(), ReadinessConfig{
+				RequireProjectStatusWrite: true,
+			}, readinessProbeIssue{}, false)
+			if len(got) != 1 {
+				t.Fatalf("checks len = %d, want 1: %#v", len(got), got)
+			}
+			check := got[0]
+			if check.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", check.Status, tt.wantStatus, check)
+			}
+			if !strings.Contains(check.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", check.Detail, tt.wantDetail)
+			}
+			requests := server.requests()
+			if len(requests) != 1 {
+				t.Fatalf("requests len = %d, want 1: %#v", len(requests), requests)
+			}
+			if !strings.Contains(requests[0]["query"].(string), "viewerCanUpdate") {
+				t.Fatalf("query = %q, want ProjectV2 viewerCanUpdate introspection", requests[0]["query"])
+			}
+		})
 	}
 }
 
@@ -417,6 +569,7 @@ func TestReadinessLabelStatusWriteUsesScratchIssueWhenConfigured(t *testing.T) {
 	checker := githubReadinessChecker{connector: c}
 
 	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		AllowWriteProbes:        true,
 		RequireLabelStatusWrite: true,
 	}, readinessProbeIssue{
 		ID:  "I_kw1",
@@ -511,6 +664,7 @@ func TestReadinessWriteProbeTargetWarnsWhenClosed(t *testing.T) {
 	checker := githubReadinessChecker{connector: c}
 
 	probe, hasProbe, check := checker.resolveWriteProbe(context.Background(), ReadinessConfig{
+		AllowWriteProbes:  true,
 		WriteProbeIssue:   "digitaldrywood/detent#1",
 		RequireIssueClose: true,
 	})
@@ -860,8 +1014,79 @@ func TestReadinessUnconfiguredProbeIssueWarns(t *testing.T) {
 		if check.Status != ReadinessWarn {
 			t.Fatalf("%s Status = %s, want %s", check.Name, check.Status, ReadinessWarn)
 		}
-		if !strings.Contains(check.Detail, "issue-specific read capability not proven") {
+		if !strings.Contains(check.Detail, "issue relationship read capability not proven") {
 			t.Fatalf("%s Detail = %q, want unproven read detail", check.Name, check.Detail)
+		}
+	}
+}
+
+func TestReadinessIssueRelationshipReadsUseRepositoryIssueSample(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			method: http.MethodGet,
+			body:   `{"total_count":1,"items":[{"node_id":"I_sample","number":251,"title":"Sample","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/251"}]}`,
+		},
+		{
+			body: `{"data":{"node":{"subIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"trackedIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
+			body: `{"data":{"node":{"id":"I_sample","number":251,"repository":{"nameWithOwner":"digitaldrywood/detent"},"parent":null,"trackedInIssues":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			body:   `{"total_count":0,"items":[]}`,
+		},
+	})
+	c := newGitHubTestConnector(t, server, Config{
+		GitHubStatusSource: GitHubStatusSourceLabel,
+		Repository:         "digitaldrywood/detent",
+	})
+	checker := githubReadinessChecker{connector: c}
+	cfg := ReadinessConfig{
+		Repositories:             []string{"digitaldrywood/detent"},
+		RequireIssueChildrenRead: true,
+		RequireIssueParentsRead:  true,
+	}
+
+	target, hasTarget, targetCheck := checker.resolveIssueRelationshipReadTarget(context.Background(), cfg, readinessProbeIssue{}, false)
+	if targetCheck != nil {
+		t.Fatalf("targetCheck = %#v, want nil", *targetCheck)
+	}
+	if !hasTarget {
+		t.Fatal("hasTarget = false, want sampled issue")
+	}
+	got := checker.probeReadChecks(context.Background(), cfg, target, hasTarget)
+	if len(got) != 2 {
+		t.Fatalf("checks len = %d, want 2: %#v", len(got), got)
+	}
+	for _, check := range got {
+		if check.Status != ReadinessOK {
+			t.Fatalf("%s Status = %s, want %s: %#v", check.Name, check.Status, ReadinessOK, check)
+		}
+		if !strings.Contains(check.Detail, "sample issue digitaldrywood/detent#251") {
+			t.Fatalf("%s Detail = %q, want sampled issue detail", check.Name, check.Detail)
+		}
+		if strings.Contains(check.Detail, "write_probe_issue") {
+			t.Fatalf("%s Detail = %q, want no write_probe_issue requirement", check.Name, check.Detail)
+		}
+	}
+
+	requests := server.requests()
+	if len(requests) != 5 {
+		t.Fatalf("requests len = %d, want 5: %#v", len(requests), requests)
+	}
+	if requests[0]["method"] != http.MethodGet || !strings.HasPrefix(requests[0]["path"].(string), "/search/issues?") {
+		t.Fatalf("first request = %#v, want issue search sample", requests[0])
+	}
+	for _, request := range requests {
+		if request["method"] == http.MethodPut || request["method"] == http.MethodPatch || request["method"] == http.MethodDelete ||
+			request["method"] == http.MethodPost && request["path"] != "/" {
+			t.Fatalf("request = %#v, want no mutation for relationship read checks", request)
 		}
 	}
 }
@@ -871,6 +1096,7 @@ func TestReadinessUnconfiguredWriteProbeWarns(t *testing.T) {
 
 	checker := githubReadinessChecker{}
 	got := checker.writeChecks(context.Background(), ReadinessConfig{
+		AllowWriteProbes:          true,
 		RequireProjectStatusWrite: true,
 		RequireIssueComments:      true,
 		RequireAssigneeWrite:      true,

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -203,6 +203,12 @@ type restIssueSearchResponse struct {
 	Items      []restIssue `json:"items"`
 }
 
+type restRepository struct {
+	FullName      string          `json:"full_name"`
+	DefaultBranch string          `json:"default_branch"`
+	Permissions   map[string]bool `json:"permissions"`
+}
+
 type restIssueDependency struct {
 	ID            int        `json:"id"`
 	NodeID        string     `json:"node_id"`

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -609,8 +609,8 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	}
 	b.WriteString("  kanban:\n")
 	writeScalar(&b, "    ", "mode", onboardingKanbanMode(form))
-	b.WriteString("    # Integration is recommended for operator-owned local/private installs after mutation authorization and detent doctor --allow-write-probes passes.\n")
-	b.WriteString("    # Use read_only for observer/shared dashboards or until write probes pass.\n")
+	b.WriteString("    # Integration is recommended for operator-owned local/private installs when plain detent doctor proves required write permissions.\n")
+	b.WriteString("    # Use read_only for observer/shared dashboards or when write permissions are unavailable.\n")
 	b.WriteString("hooks:\n")
 	b.WriteString("  timeout_ms: 60000\n")
 	b.WriteString("---\n\n")

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -498,8 +498,8 @@ func TestOnboardingWriteLabelWorkflowKanbanMode(t *testing.T) {
 			if !strings.Contains(content, wantContent) {
 				t.Fatalf("workflow missing %q:\n%s", wantContent, content)
 			}
-			if !strings.Contains(content, "detent doctor --allow-write-probes") {
-				t.Fatalf("workflow missing write-probe guidance:\n%s", content)
+			if !strings.Contains(content, "plain detent doctor proves required write permissions") {
+				t.Fatalf("workflow missing read-only permission guidance:\n%s", content)
 			}
 
 			workflow, err := workflowconfig.ParseWorkflow(raw)
@@ -513,7 +513,7 @@ func TestOnboardingWriteLabelWorkflowKanbanMode(t *testing.T) {
 	}
 }
 
-func TestOnboardingAgentStepExplainsKanbanWriteProbeRequirement(t *testing.T) {
+func TestOnboardingAgentStepExplainsKanbanPermissionChecks(t *testing.T) {
 	t.Parallel()
 
 	workflowPath := filepath.Join(t.TempDir(), "WORKFLOW.md")
@@ -540,7 +540,8 @@ func TestOnboardingAgentStepExplainsKanbanWriteProbeRequirement(t *testing.T) {
 	for _, want := range []string{
 		"name=\"kanban_mode\" value=\"integration\" checked",
 		"operator-owned local/private installs",
-		"detent doctor --allow-write-probes",
+		"Plain <code>detent doctor</code> uses read-only GitHub permission checks",
+		"--allow-write-probes</code> is optional deep verification",
 		"name=\"kanban_mode\" value=\"read_only\"",
 		"observer/shared dashboards",
 	} {

--- a/internal/web/templates/onboarding.templ
+++ b/internal/web/templates/onboarding.templ
@@ -398,10 +398,10 @@ templ agentStep(data OnboardingData) {
 			<div class="rounded-md border border-line p-3 sm:col-span-2">
 				<span class="block text-sm font-semibold text-text">Project Kanban</span>
 				<div class="mt-3 grid gap-2 sm:grid-cols-2">
-					@kanbanModeChoice(data.Form, "integration", "Interactive", "Recommended for operator-owned local/private installs after mutation authorization and write probes pass.")
-					@kanbanModeChoice(data.Form, "read_only", "Read-only", "Conservative option for observer/shared dashboards or until write probes pass.")
+					@kanbanModeChoice(data.Form, "integration", "Interactive", "Recommended for operator-owned local/private installs when doctor proves required write permissions.")
+					@kanbanModeChoice(data.Form, "read_only", "Read-only", "Conservative option for observer/shared dashboards or when write permissions are unavailable.")
 				</div>
-				<p class="mt-3 text-sm text-sec">Integration requires <code>detent doctor --allow-write-probes</code> to prove status-label updates and issue/PR comment writes.</p>
+				<p class="mt-3 text-sm text-sec">Plain <code>detent doctor</code> uses read-only GitHub permission checks; <code>--allow-write-probes</code> is optional deep verification for scratch-issue workflows.</p>
 			</div>
 			<div class="flex flex-wrap gap-2 pt-2 sm:col-span-2">
 				<button class={ buttonClass() } type="submit">Continue</button>

--- a/internal/web/templates/onboarding_templ.go
+++ b/internal/web/templates/onboarding_templ.go
@@ -1592,15 +1592,15 @@ func agentStep(data OnboardingData) templ.Component {
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = kanbanModeChoice(data.Form, "integration", "Interactive", "Recommended for operator-owned local/private installs after mutation authorization and write probes pass.").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = kanbanModeChoice(data.Form, "integration", "Interactive", "Recommended for operator-owned local/private installs when doctor proves required write permissions.").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = kanbanModeChoice(data.Form, "read_only", "Read-only", "Conservative option for observer/shared dashboards or until write probes pass.").Render(ctx, templ_7745c5c3_Buffer)
+		templ_7745c5c3_Err = kanbanModeChoice(data.Form, "read_only", "Read-only", "Conservative option for observer/shared dashboards or when write permissions are unavailable.").Render(ctx, templ_7745c5c3_Buffer)
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}
-		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "</div><p class=\"mt-3 text-sm text-sec\">Integration requires <code>detent doctor --allow-write-probes</code> to prove status-label updates and issue/PR comment writes.</p></div><div class=\"flex flex-wrap gap-2 pt-2 sm:col-span-2\">")
+		templ_7745c5c3_Err = templruntime.WriteString(templ_7745c5c3_Buffer, 113, "</div><p class=\"mt-3 text-sm text-sec\">Plain <code>detent doctor</code> uses read-only GitHub permission checks; <code>--allow-write-probes</code> is optional deep verification for scratch-issue workflows.</p></div><div class=\"flex flex-wrap gap-2 pt-2 sm:col-span-2\">")
 		if templ_7745c5c3_Err != nil {
 			return templ_7745c5c3_Err
 		}

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -428,19 +428,17 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 		{
 			path:            "docs/templates/WORKFLOW.project_v2.md",
 			source:          workflowconfig.GitHubStatusSourceProjectV2,
-			want:            []string{"github_status_source: project_v2", "project_slug: <project-node-id>", "write_probe_issue:"},
-			unwanted:        []string{"repository: <repo-owner>/<repo-name>"},
+			want:            []string{"github_status_source: project_v2", "project_slug: <project-node-id>"},
+			unwanted:        []string{"repository: <repo-owner>/<repo-name>", "write_probe_issue:"},
 			wantProjectSlug: true,
-			wantWriteProbe:  true,
 		},
 		{
 			path:            "docs/templates/WORKFLOW.issue_field.md",
 			source:          workflowconfig.GitHubStatusSourceIssueField,
-			want:            []string{"github_status_source: issue_field", "repository: <repo-owner>/<repo-name>", "status_field: Status", "write_probe_issue:"},
-			unwanted:        []string{"project_slug:"},
+			want:            []string{"github_status_source: issue_field", "repository: <repo-owner>/<repo-name>", "status_field: Status"},
+			unwanted:        []string{"project_slug:", "write_probe_issue:"},
 			wantRepository:  true,
 			wantStatusField: "Status",
-			wantWriteProbe:  true,
 		},
 		{
 			path:             "docs/templates/WORKFLOW.label.md",


### PR DESCRIPTION
## Summary

- Replace default doctor mutation write-probe gating with read-only token permission checks using repository permissions and ProjectV2 update introspection.
- Sample real repository issues for children/parent metadata readiness instead of requiring `tracker.write_probe_issue`.
- Remove `write_probe_issue` from generated workflow templates/onboarding as a default requirement while keeping `--allow-write-probes` as optional deep verification.

Fixes #1102

## UI Surface Contract

- [x] N/A, copy-only onboarding guidance update with no layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`