### PR TITLE
telemetry: resolve codex runtime model

### DIFF
--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -42,7 +42,7 @@ func TestCheckerCheckDispatch(t *testing.T) {
 			wantAllow: true,
 		},
 		{
-			name: "missing model pricing allows without spend lookup",
+			name: "unknown model uses fallback pricing",
 			cfg: Config{
 				Enabled:      true,
 				PerDayMaxUSD: 0.01,
@@ -50,6 +50,7 @@ func TestCheckerCheckDispatch(t *testing.T) {
 			spend:     &fakeSpendStore{},
 			req:       DispatchRequest{Model: "missing-model", Now: now, Estimate: TokenEstimate{InputTokens: 10}},
 			wantAllow: true,
+			wantDaily: 1,
 		},
 		{
 			name: "daily cap refuses when projection exceeds limit",

--- a/internal/budget/pricing.go
+++ b/internal/budget/pricing.go
@@ -10,7 +10,10 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-const DefaultPricingPath = "priv/pricing/models.yaml"
+const (
+	DefaultPricingPath          = "priv/pricing/models.yaml"
+	defaultPricingFallbackModel = "default"
+)
 
 type ModelPricing struct {
 	USDPerInputToken float64
@@ -27,6 +30,11 @@ type PricingTable map[string]ModelPricing
 // when models are added or updated. Under subscription auth, computed USD is
 // notional but still used for budget pacing.
 func DefaultPricingTable() PricingTable {
+	gpt55 := ModelPricing{
+		USDPerInputToken:       0.000005,
+		USDPerCachedInputToken: 0.0000005,
+		USDPerOutputToken:      0.000030,
+	}
 	claudeFable5 := ModelPricing{
 		USDPerInputToken:       0.000010,
 		USDPerCachedInputToken: 0.000001,
@@ -49,11 +57,8 @@ func DefaultPricingTable() PricingTable {
 	}
 
 	return PricingTable{
-		"gpt-5.5": {
-			USDPerInputToken:       0.000005,
-			USDPerCachedInputToken: 0.0000005,
-			USDPerOutputToken:      0.000030,
-		},
+		defaultPricingFallbackModel: gpt55,
+		"gpt-5.5":                   gpt55,
 		"gpt-5.4": {
 			USDPerInputToken:       0.0000025,
 			USDPerCachedInputToken: 0.00000025,
@@ -136,7 +141,13 @@ func (p PricingTable) Lookup(model string) (ModelPricing, bool) {
 		p = DefaultPricingTable()
 	}
 
-	row, ok := p[normalizeModel(model)]
+	if row, ok := p[normalizeModel(model)]; ok {
+		return row, true
+	}
+	if row, ok := p[defaultPricingFallbackModel]; ok {
+		return row, true
+	}
+	row, ok := DefaultPricingTable()[defaultPricingFallbackModel]
 	return row, ok
 }
 

--- a/internal/budget/pricing_test.go
+++ b/internal/budget/pricing_test.go
@@ -27,6 +27,12 @@ func TestDefaultPricingTable(t *testing.T) {
 			wantOutput: 0.000030,
 		},
 		{
+			model:      "default",
+			wantInput:  0.000005,
+			wantCached: 0.0000005,
+			wantOutput: 0.000030,
+		},
+		{
 			model:      "gpt-5.4",
 			wantInput:  0.0000025,
 			wantCached: 0.00000025,
@@ -135,6 +141,10 @@ models:
   gpt-fallback:
     usd_per_input_token: 0.04
     usd_per_output_token: 0.05
+  default:
+    input_usd_per_1m_tokens: 6000
+    cached_input_usd_per_1m_tokens: 600
+    output_usd_per_1m_tokens: 36000
   invalid-row: bad
   missing-output:
     usd_per_input_token: 0.01
@@ -172,9 +182,17 @@ models:
 	assertInDelta(t, fallback.USDPerCachedInputToken, 0.04)
 	assertInDelta(t, fallback.USDPerOutputToken, 0.05)
 
+	unknown, ok := pricing.Lookup("gpt-future")
+	if !ok {
+		t.Fatal("pricing.Lookup(gpt-future) ok = false, want configurable default")
+	}
+	assertInDelta(t, unknown.USDPerInputToken, 0.006)
+	assertInDelta(t, unknown.USDPerCachedInputToken, 0.0006)
+	assertInDelta(t, unknown.USDPerOutputToken, 0.036)
+
 	for _, model := range []string{"invalid-row", "missing-output", "negative"} {
-		if _, ok := pricing.Lookup(model); ok {
-			t.Fatalf("pricing.Lookup(%q) ok = true, want false", model)
+		if _, ok := pricing[normalizeModel(model)]; ok {
+			t.Fatalf("pricing[%q] exists, want invalid row skipped", model)
 		}
 	}
 }
@@ -265,6 +283,11 @@ func TestUsageCostUSD(t *testing.T) {
 			USDPerCachedInputToken: 0.001,
 			USDPerOutputToken:      0.02,
 		},
+		"default": {
+			USDPerInputToken:       0.03,
+			USDPerCachedInputToken: 0.003,
+			USDPerOutputToken:      0.04,
+		},
 	}
 
 	tests := []struct {
@@ -318,8 +341,17 @@ func TestUsageCostUSD(t *testing.T) {
 			inputTokens:       10,
 			cachedInputTokens: 4,
 			outputTokens:      5,
-			want:              0,
-			wantOK:            false,
+			want:              0.392,
+			wantOK:            true,
+		},
+		{
+			name:              "empty model",
+			model:             "",
+			inputTokens:       10,
+			cachedInputTokens: 4,
+			outputTokens:      5,
+			want:              0.392,
+			wantOK:            true,
 		},
 		{
 			name:              "negative tokens are ignored",

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -113,11 +113,11 @@ func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
 	if metrics.MaxSessionTokens != 300000 {
 		t.Fatalf("MaxSessionTokens = %d, want 300000", metrics.MaxSessionTokens)
 	}
-	if metrics.P90SessionBillableTokens != 150500 {
-		t.Fatalf("P90SessionBillableTokens = %d, want 150500", metrics.P90SessionBillableTokens)
+	if metrics.P90SessionBillableTokens != 107320 {
+		t.Fatalf("P90SessionBillableTokens = %d, want 107320", metrics.P90SessionBillableTokens)
 	}
-	if metrics.BudgetEstimateDriftRatio != 0.8853 {
-		t.Fatalf("BudgetEstimateDriftRatio = %v, want 0.8853", metrics.BudgetEstimateDriftRatio)
+	if metrics.BudgetEstimateDriftRatio != 0.6313 {
+		t.Fatalf("BudgetEstimateDriftRatio = %v, want 0.6313", metrics.BudgetEstimateDriftRatio)
 	}
 }
 

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -16,6 +16,7 @@ const (
 	threadStartRequestID  = 2
 	turnStartRequestID    = 3
 	threadResumeRequestID = 4
+	configReadRequestID   = 5
 	methodNotFoundCode    = -32601
 
 	defaultClientName    = "detent-orchestrator"
@@ -179,6 +180,7 @@ const (
 	UpdateRateLimits        UpdateType = "rate_limits"
 	UpdateTurnStarted       UpdateType = "turn_started"
 	UpdateTurnCompleted     UpdateType = "turn_completed"
+	UpdateModelUpdated      UpdateType = "model_updated"
 )
 
 type Update struct {
@@ -322,6 +324,12 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 			return RunTurnResult{}, err
 		}
 	}
+	if model == "" && strings.TrimSpace(req.Model) == "" {
+		model, err = s.resolveDefaultModel(ctx, transport, req.Workspace, onUpdate)
+		if err != nil {
+			return RunTurnResult{}, err
+		}
+	}
 
 	turnID, err := s.startTurn(ctx, transport, req, threadID, onUpdate)
 	if err != nil {
@@ -409,11 +417,15 @@ func (s *AppServer) startThread(
 			ID            string `json:"id"`
 			Model         string `json:"model"`
 			ModelID       string `json:"model_id"`
+			ModelIDCamel  string `json:"modelId"`
 			ResolvedModel string `json:"resolvedModel"`
+			ResolvedSnake string `json:"resolved_model"`
 		} `json:"thread"`
 		Model         string `json:"model"`
 		ModelID       string `json:"model_id"`
+		ModelIDCamel  string `json:"modelId"`
 		ResolvedModel string `json:"resolvedModel"`
+		ResolvedSnake string `json:"resolved_model"`
 	}
 	if err := json.Unmarshal(result, &response); err != nil {
 		return "", "", fmt.Errorf("%w: decode thread/start result: %w", ErrInvalidResponse, err)
@@ -425,10 +437,14 @@ func (s *AppServer) startThread(
 	model := firstNonBlank(
 		response.Thread.Model,
 		response.Thread.ResolvedModel,
+		response.Thread.ResolvedSnake,
 		response.Thread.ModelID,
+		response.Thread.ModelIDCamel,
 		response.Model,
 		response.ResolvedModel,
+		response.ResolvedSnake,
 		response.ModelID,
+		response.ModelIDCamel,
 	)
 
 	return response.Thread.ID, model, nil
@@ -473,11 +489,15 @@ func (s *AppServer) resumeThread(
 			ID            string `json:"id"`
 			Model         string `json:"model"`
 			ModelID       string `json:"model_id"`
+			ModelIDCamel  string `json:"modelId"`
 			ResolvedModel string `json:"resolvedModel"`
+			ResolvedSnake string `json:"resolved_model"`
 		} `json:"thread"`
 		Model         string `json:"model"`
 		ModelID       string `json:"model_id"`
+		ModelIDCamel  string `json:"modelId"`
 		ResolvedModel string `json:"resolvedModel"`
+		ResolvedSnake string `json:"resolved_model"`
 	}
 	if err := json.Unmarshal(result, &response); err != nil {
 		return "", "", fmt.Errorf("%w: decode thread/resume result: %w", ErrInvalidResponse, err)
@@ -489,10 +509,14 @@ func (s *AppServer) resumeThread(
 	model := firstNonBlank(
 		response.Thread.Model,
 		response.Thread.ResolvedModel,
+		response.Thread.ResolvedSnake,
 		response.Thread.ModelID,
+		response.Thread.ModelIDCamel,
 		response.Model,
 		response.ResolvedModel,
+		response.ResolvedSnake,
 		response.ModelID,
+		response.ModelIDCamel,
 		req.Model,
 	)
 
@@ -548,6 +572,41 @@ func (s *AppServer) startTurn(
 	}
 
 	return response.Turn.ID, nil
+}
+
+func (s *AppServer) resolveDefaultModel(
+	ctx context.Context,
+	transport Transport,
+	workspace string,
+	onUpdate UpdateHandler,
+) (string, error) {
+	params := map[string]any{
+		"includeLayers": false,
+	}
+	if strings.TrimSpace(workspace) != "" {
+		params["cwd"] = workspace
+	}
+	if err := sendRequest(ctx, transport, configReadRequestID, "config/read", params); err != nil {
+		return "", err
+	}
+	result, err := s.awaitResponse(ctx, transport, configReadRequestID, onUpdate)
+	if err != nil {
+		var responseErr *ResponseError
+		if errors.As(err, &responseErr) && responseErr.Code == methodNotFoundCode {
+			return "", nil
+		}
+		return "", err
+	}
+	var response struct {
+		Config struct {
+			Model string `json:"model"`
+		} `json:"config"`
+		Model string `json:"model"`
+	}
+	if err := json.Unmarshal(result, &response); err != nil {
+		return "", fmt.Errorf("%w: decode config/read result: %w", ErrInvalidResponse, err)
+	}
+	return firstNonBlank(response.Config.Model, response.Model), nil
 }
 
 func (s *AppServer) awaitResponse(
@@ -752,9 +811,14 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 		}, true, nil
 	case "thread/tokenUsage/updated":
 		var params struct {
-			ThreadID   string `json:"threadId"`
-			TurnID     string `json:"turnId"`
-			TokenUsage struct {
+			ThreadID    string `json:"threadId"`
+			TurnID      string `json:"turnId"`
+			Model       string `json:"model"`
+			ModelID     string `json:"model_id"`
+			ModelIDAlt  string `json:"modelId"`
+			Resolved    string `json:"resolvedModel"`
+			ResolvedAlt string `json:"resolved_model"`
+			TokenUsage  struct {
 				Total              tokenUsageBreakdown `json:"total"`
 				ModelContextWindow *int64              `json:"modelContextWindow"`
 			} `json:"tokenUsage"`
@@ -767,6 +831,7 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			Method:   msg.Method,
 			ThreadID: params.ThreadID,
 			TurnID:   params.TurnID,
+			Model:    firstNonBlank(params.Model, params.Resolved, params.ResolvedAlt, params.ModelID, params.ModelIDAlt),
 			Tokens: TokenUsage{
 				InputTokens:           params.TokenUsage.Total.InputTokens,
 				CachedInputTokens:     params.TokenUsage.Total.CachedInputTokens,
@@ -790,6 +855,81 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			RateLimits: params.RateLimits.snapshot(),
 			Payload:    rawPayload(msg),
 		}, true, nil
+	case "turn/started":
+		var params struct {
+			ThreadID    string `json:"threadId"`
+			Model       string `json:"model"`
+			ModelID     string `json:"model_id"`
+			ModelIDAlt  string `json:"modelId"`
+			Resolved    string `json:"resolvedModel"`
+			ResolvedAlt string `json:"resolved_model"`
+			Turn        struct {
+				ID          string `json:"id"`
+				Model       string `json:"model"`
+				ModelID     string `json:"model_id"`
+				ModelIDAlt  string `json:"modelId"`
+				Resolved    string `json:"resolvedModel"`
+				ResolvedAlt string `json:"resolved_model"`
+			} `json:"turn"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return Update{}, false, fmt.Errorf("%w: decode turn started: %w", ErrInvalidResponse, err)
+		}
+		return Update{
+			Type:     UpdateTurnStarted,
+			Method:   msg.Method,
+			ThreadID: params.ThreadID,
+			TurnID:   params.Turn.ID,
+			Status:   "started",
+			Model: firstNonBlank(
+				params.Turn.Model,
+				params.Turn.Resolved,
+				params.Turn.ResolvedAlt,
+				params.Turn.ModelID,
+				params.Turn.ModelIDAlt,
+				params.Model,
+				params.Resolved,
+				params.ResolvedAlt,
+				params.ModelID,
+				params.ModelIDAlt,
+			),
+			Payload: rawPayload(msg),
+		}, true, nil
+	case "model/rerouted":
+		var params struct {
+			ThreadID string `json:"threadId"`
+			TurnID   string `json:"turnId"`
+			ToModel  string `json:"toModel"`
+			Model    string `json:"model"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return Update{}, false, fmt.Errorf("%w: decode model rerouted: %w", ErrInvalidResponse, err)
+		}
+		return Update{
+			Type:     UpdateModelUpdated,
+			Method:   msg.Method,
+			ThreadID: params.ThreadID,
+			TurnID:   params.TurnID,
+			Model:    firstNonBlank(params.ToModel, params.Model),
+			Payload:  rawPayload(msg),
+		}, true, nil
+	case "model/safetyBuffering/updated":
+		var params struct {
+			ThreadID string `json:"threadId"`
+			TurnID   string `json:"turnId"`
+			Model    string `json:"model"`
+		}
+		if err := json.Unmarshal(msg.Params, &params); err != nil {
+			return Update{}, false, fmt.Errorf("%w: decode model safety buffering: %w", ErrInvalidResponse, err)
+		}
+		return Update{
+			Type:     UpdateModelUpdated,
+			Method:   msg.Method,
+			ThreadID: params.ThreadID,
+			TurnID:   params.TurnID,
+			Model:    params.Model,
+			Payload:  rawPayload(msg),
+		}, true, nil
 	case "turn/completed":
 		var params struct {
 			ThreadID string `json:"threadId"`
@@ -798,11 +938,13 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 				Status  string          `json:"status"`
 				Error   json.RawMessage `json:"error"`
 				Message string          `json:"message"`
+				Model   string          `json:"model"`
 			} `json:"turn"`
 			Type    string          `json:"type"`
 			Status  any             `json:"status"`
 			Error   json.RawMessage `json:"error"`
 			Message string          `json:"message"`
+			Model   string          `json:"model"`
 		}
 		if len(msg.Params) > 0 {
 			if err := json.Unmarshal(msg.Params, &params); err != nil {
@@ -820,6 +962,7 @@ func updateFromMessage(msg Message) (Update, bool, error) {
 			ThreadID:            params.ThreadID,
 			TurnID:              params.Turn.ID,
 			Status:              status,
+			Model:               firstNonBlank(params.Turn.Model, params.Model),
 			BackendErrorBody:    errorBody,
 			BackendErrorMessage: errorMessage,
 			Payload:             rawPayload(msg),
@@ -1021,6 +1164,8 @@ func requestName(id int) string {
 		return "turn/start"
 	case threadResumeRequestID:
 		return "thread/resume"
+	case configReadRequestID:
+		return "config/read"
 	default:
 		return strconv.Itoa(id)
 	}

--- a/internal/codex/appserver.go
+++ b/internal/codex/appserver.go
@@ -331,25 +331,28 @@ func (s *AppServer) RunTurn(ctx context.Context, req RunTurnRequest, onUpdate Up
 		}
 	}
 
-	turnID, err := s.startTurn(ctx, transport, req, threadID, onUpdate)
+	turn, err := s.startTurn(ctx, transport, req, threadID, onUpdate)
 	if err != nil {
 		return RunTurnResult{}, err
 	}
+	turnID := turn.ID
 
 	result = RunTurnResult{
 		ThreadID:  threadID,
 		TurnID:    turnID,
 		SessionID: threadID + "-" + turnID,
 	}
-	if err := emitUpdate(Update{
-		Type:     UpdateTurnStarted,
-		Method:   "turn/start",
-		ThreadID: threadID,
-		TurnID:   turnID,
-		Status:   "started",
-		Model:    model,
-	}, onUpdate); err != nil {
-		return RunTurnResult{}, err
+	if !turn.StartedEmitted {
+		if err := emitUpdate(Update{
+			Type:     UpdateTurnStarted,
+			Method:   "turn/start",
+			ThreadID: threadID,
+			TurnID:   turnID,
+			Status:   "started",
+			Model:    firstNonBlank(turn.Model, model),
+		}, onUpdate); err != nil {
+			return RunTurnResult{}, err
+		}
 	}
 
 	if err := s.streamTurn(ctx, transport, req.turnTimeout(s.turnTimeout), onUpdate); err != nil {
@@ -523,13 +526,19 @@ func (s *AppServer) resumeThread(
 	return response.Thread.ID, model, nil
 }
 
+type startTurnResult struct {
+	ID             string
+	Model          string
+	StartedEmitted bool
+}
+
 func (s *AppServer) startTurn(
 	ctx context.Context,
 	transport Transport,
 	req RunTurnRequest,
 	threadID string,
 	onUpdate UpdateHandler,
-) (string, error) {
+) (startTurnResult, error) {
 	params := map[string]any{
 		"threadId": threadID,
 		"input": []map[string]any{
@@ -551,27 +560,65 @@ func (s *AppServer) startTurn(
 	}
 
 	if err := sendRequest(ctx, transport, turnStartRequestID, "turn/start", params); err != nil {
-		return "", err
+		return startTurnResult{}, err
 	}
 
-	result, err := s.awaitResponse(ctx, transport, turnStartRequestID, onUpdate)
+	turn := startTurnResult{}
+	trackTurnStarted := func(update Update) error {
+		if update.Type == UpdateTurnStarted {
+			turn.StartedEmitted = true
+			if update.Model != "" {
+				turn.Model = update.Model
+			}
+		}
+		if onUpdate == nil {
+			return nil
+		}
+		return onUpdate(update)
+	}
+
+	result, err := s.awaitResponse(ctx, transport, turnStartRequestID, trackTurnStarted)
 	if err != nil {
-		return "", err
+		return startTurnResult{}, err
 	}
 
 	var response struct {
 		Turn struct {
-			ID string `json:"id"`
+			ID            string `json:"id"`
+			Model         string `json:"model"`
+			ModelID       string `json:"model_id"`
+			ModelIDCamel  string `json:"modelId"`
+			ResolvedModel string `json:"resolvedModel"`
+			ResolvedSnake string `json:"resolved_model"`
 		} `json:"turn"`
+		Model         string `json:"model"`
+		ModelID       string `json:"model_id"`
+		ModelIDCamel  string `json:"modelId"`
+		ResolvedModel string `json:"resolvedModel"`
+		ResolvedSnake string `json:"resolved_model"`
 	}
 	if err := json.Unmarshal(result, &response); err != nil {
-		return "", fmt.Errorf("%w: decode turn/start result: %w", ErrInvalidResponse, err)
+		return startTurnResult{}, fmt.Errorf("%w: decode turn/start result: %w", ErrInvalidResponse, err)
 	}
 	if response.Turn.ID == "" {
-		return "", fmt.Errorf("%w: turn/start result missing turn id", ErrInvalidResponse)
+		return startTurnResult{}, fmt.Errorf("%w: turn/start result missing turn id", ErrInvalidResponse)
 	}
 
-	return response.Turn.ID, nil
+	turn.ID = response.Turn.ID
+	turn.Model = firstNonBlank(
+		turn.Model,
+		response.Turn.Model,
+		response.Turn.ResolvedModel,
+		response.Turn.ResolvedSnake,
+		response.Turn.ModelID,
+		response.Turn.ModelIDCamel,
+		response.Model,
+		response.ResolvedModel,
+		response.ResolvedSnake,
+		response.ModelID,
+		response.ModelIDCamel,
+	)
+	return turn, nil
 }
 
 func (s *AppServer) resolveDefaultModel(
@@ -592,7 +639,7 @@ func (s *AppServer) resolveDefaultModel(
 	result, err := s.awaitResponse(ctx, transport, configReadRequestID, onUpdate)
 	if err != nil {
 		var responseErr *ResponseError
-		if errors.As(err, &responseErr) && responseErr.Code == methodNotFoundCode {
+		if errors.As(err, &responseErr) {
 			return "", nil
 		}
 		return "", err

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -266,6 +266,88 @@ func TestAppServerRunTurnUsesConfigReadModelWhenThreadResponseOmitsModel(t *test
 	}
 }
 
+func TestAppServerRunTurnContinuesWhenConfigReadFails(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.143.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1"}}`),
+		errorResponseMessage(t, 5, -32602, "invalid config/read params"),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	var updates []Update
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: "/tmp/detent-workspace",
+		Prompt:    "Ship issue #1103",
+	}, func(update Update) error {
+		updates = append(updates, update)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v, want config/read failure to be non-fatal", err)
+	}
+
+	if len(updates) != 2 {
+		t.Fatalf("updates = %d, want turn started and completed: %#v", len(updates), updates)
+	}
+	if updates[0].Type != UpdateTurnStarted || updates[0].Model != "" {
+		t.Fatalf("updates[0] = %#v, want unpriced fallback turn started", updates[0])
+	}
+}
+
+func TestAppServerRunTurnPreservesTurnStartedRuntimeModel(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.143.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1","model":"gpt-5.5"}}`),
+		notificationMessage(t, "turn/started", `{"threadId":"thread-1","turn":{"id":"turn-1","model":"gpt-5.6"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	var updates []Update
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: "/tmp/detent-workspace",
+		Prompt:    "Ship issue #1103",
+	}, func(update Update) error {
+		updates = append(updates, update)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	var started []Update
+	for _, update := range updates {
+		if update.Type == UpdateTurnStarted {
+			started = append(started, update)
+		}
+	}
+	if len(started) != 1 {
+		t.Fatalf("started updates = %d, want only app-server turn/started event: %#v", len(started), started)
+	}
+	if started[0].Model != "gpt-5.6" {
+		t.Fatalf("started[0].Model = %q, want runtime model", started[0].Model)
+	}
+}
+
 func TestUpdateFromMessageCapturesModelReroute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/codex/appserver_test.go
+++ b/internal/codex/appserver_test.go
@@ -219,12 +219,81 @@ func TestAppServerRunTurnResumesThreadBeforeStartingTurn(t *testing.T) {
 	}
 }
 
+func TestAppServerRunTurnUsesConfigReadModelWhenThreadResponseOmitsModel(t *testing.T) {
+	t.Parallel()
+
+	transport := newFakeAppServerTransport([]Message{
+		responseMessage(t, 1, `{"userAgent":"codex-cli/0.143.0"}`),
+		responseMessage(t, 2, `{"thread":{"id":"thread-1"}}`),
+		responseMessage(t, 5, `{"config":{"model":"gpt-5.6"}}`),
+		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
+		notificationMessage(t, "turn/completed", `{"threadId":"thread-1","turn":{"id":"turn-1","status":"completed"}}`),
+	})
+	server, err := NewAppServer(staticTransportFactory{transport: transport},
+		WithReadTimeout(time.Second),
+		WithTurnTimeout(time.Second),
+	)
+	if err != nil {
+		t.Fatalf("NewAppServer() error = %v", err)
+	}
+
+	var updates []Update
+	_, err = server.RunTurn(context.Background(), RunTurnRequest{
+		Workspace: "/tmp/detent-workspace",
+		Prompt:    "Ship issue #1103",
+	}, func(update Update) error {
+		updates = append(updates, update)
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("RunTurn() error = %v", err)
+	}
+
+	sent := transport.sentMessages()
+	if len(sent) != 5 {
+		t.Fatalf("sent messages = %d, want 5", len(sent))
+	}
+	assertRequest(t, sent[2], 2, "thread/start")
+	assertRequest(t, sent[3], 5, "config/read")
+	assertJSONContains(t, sent[3].Params, "cwd", "/tmp/detent-workspace")
+	assertRequest(t, sent[4], 3, "turn/start")
+
+	if len(updates) != 2 {
+		t.Fatalf("updates = %d, want turn started and completed: %#v", len(updates), updates)
+	}
+	if updates[0].Type != UpdateTurnStarted || updates[0].Model != "gpt-5.6" {
+		t.Fatalf("updates[0] = %#v, want config-read fallback model", updates[0])
+	}
+}
+
+func TestUpdateFromMessageCapturesModelReroute(t *testing.T) {
+	t.Parallel()
+
+	update, ok, err := updateFromMessage(notificationMessage(t, "model/rerouted", `{
+		"threadId":"thread-1",
+		"turnId":"turn-1",
+		"fromModel":"gpt-5.5",
+		"toModel":"gpt-5.6",
+		"reason":"highRiskCyberActivity"
+	}`))
+	if err != nil {
+		t.Fatalf("updateFromMessage() error = %v", err)
+	}
+	if !ok {
+		t.Fatal("updateFromMessage() ok = false, want true")
+	}
+	if update.Type != UpdateModelUpdated || update.ThreadID != "thread-1" || update.TurnID != "turn-1" || update.Model != "gpt-5.6" {
+		t.Fatalf("update = %#v, want model reroute update", update)
+	}
+}
+
 func TestAppServerRunTurnRequestTurnTimeoutOverridesDefault(t *testing.T) {
 	t.Parallel()
 
 	transport := newBlockingAppServerTransport([]Message{
 		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
 		responseMessage(t, 2, `{"thread":{"id":"thread-timeout"}}`),
+		responseMessage(t, 5, `{"config":{"model":"gpt-5.6"}}`),
 		responseMessage(t, 3, `{"turn":{"id":"turn-timeout"}}`),
 	})
 	server, err := NewAppServer(staticTransportFactory{transport: transport},
@@ -258,6 +327,7 @@ func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
 	transport := newFakeAppServerTransport([]Message{
 		responseMessage(t, 1, `{"userAgent":"codex-cli/0.135.0"}`),
 		responseMessage(t, 2, `{"thread":{"id":"thread-1"}}`),
+		responseMessage(t, 5, `{"config":{"model":"gpt-5.6"}}`),
 		serverRequestMessage(t, 40, "item/tool/requestUserInput", `{"threadId":"thread-1","turnId":"turn-1"}`),
 		responseMessage(t, 3, `{"turn":{"id":"turn-1"}}`),
 		serverRequestMessage(t, 41, "item/commandExecution/requestApproval", `{"threadId":"thread-1","turnId":"turn-1"}`),
@@ -284,17 +354,18 @@ func TestAppServerRunTurnRespondsToServerRequests(t *testing.T) {
 	}
 
 	sent := transport.sentMessages()
-	if len(sent) != 10 {
-		t.Fatalf("sent messages = %d, want 10: %#v", len(sent), sent)
+	if len(sent) != 11 {
+		t.Fatalf("sent messages = %d, want 11: %#v", len(sent), sent)
 	}
 
-	assertResponseResultContains(t, sent[4], 40, "answers", map[string]any{})
-	assertResponseResultContains(t, sent[5], 41, "decision", "decline")
-	assertResponseResultContains(t, sent[6], 42, "decision", "decline")
-	assertResponseResultContains(t, sent[7], 43, "permissions", map[string]any{})
-	assertResponseResultContains(t, sent[8], 44, "action", "decline")
-	assertResponseResultContains(t, sent[8], 44, "content", nil)
-	assertErrorResponse(t, sent[9], 45, methodNotFoundCode, "unsupported server request: custom/request")
+	assertRequest(t, sent[3], 5, "config/read")
+	assertResponseResultContains(t, sent[5], 40, "answers", map[string]any{})
+	assertResponseResultContains(t, sent[6], 41, "decision", "decline")
+	assertResponseResultContains(t, sent[7], 42, "decision", "decline")
+	assertResponseResultContains(t, sent[8], 43, "permissions", map[string]any{})
+	assertResponseResultContains(t, sent[9], 44, "action", "decline")
+	assertResponseResultContains(t, sent[9], 44, "content", nil)
+	assertErrorResponse(t, sent[10], 45, methodNotFoundCode, "unsupported server request: custom/request")
 }
 
 func TestAppServerRunTurnReportsResponseErrors(t *testing.T) {

--- a/internal/codex/transport_test.go
+++ b/internal/codex/transport_test.go
@@ -421,6 +421,11 @@ func helperTurnBackpressure(completedParams json.RawMessage, blockAfterFlood boo
 		},
 		{
 			JSONRPC: JSONRPCVersion,
+			ID:      json.RawMessage(`5`),
+			Result:  json.RawMessage(`{"config":{"model":"gpt-5.6"}}`),
+		},
+		{
+			JSONRPC: JSONRPCVersion,
 			ID:      json.RawMessage(`3`),
 			Result:  json.RawMessage(`{"turn":{"id":"turn-1"}}`),
 		},

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1326,8 +1326,7 @@ func (r *Runner) recordAgentSessionPhase(
 func (r *Runner) usageCostUSD(model string, inputTokens int64, cachedInputTokens int64, outputTokens int64, backendKind string) float64 {
 	model = strings.TrimSpace(model)
 	if model == "" {
-		r.logger.Debug("usage event model unavailable; skipping cost pricing", "backend_kind", strings.TrimSpace(backendKind))
-		return 0
+		r.logger.Debug("usage event model unavailable; using fallback pricing", "backend_kind", strings.TrimSpace(backendKind))
 	}
 	cost, ok := budget.UsageCostUSD(r.pricing, model, inputTokens, cachedInputTokens, outputTokens)
 	if !ok {
@@ -1597,6 +1596,8 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 		} else {
 			eventMessage = "process started"
 		}
+	case AgentUpdateModelUpdated:
+		eventMessage = modelUpdatedActivityMessage(update.Model)
 	}
 
 	p.addRecentEvent(telemetry.ActivityEvent{
@@ -1629,6 +1630,14 @@ func rateLimitsActivityMessage(snapshot *telemetry.RateLimits) string {
 		return "rate limits updated"
 	}
 	return name + " rate limits updated"
+}
+
+func modelUpdatedActivityMessage(model string) string {
+	model = strings.TrimSpace(model)
+	if model == "" {
+		return "model updated"
+	}
+	return "model updated to " + model
 }
 
 func (p *agentRunProgress) turnCount() int {
@@ -1871,6 +1880,12 @@ func (r *Runner) logAgentUpdate(issue connector.Issue, update AgentUpdate) {
 		r.logWorkerEvent(issue, "worker_rate_limits_updated",
 			"thread_id", strings.TrimSpace(update.ThreadID),
 			"turn_id", strings.TrimSpace(update.TurnID),
+		)
+	case AgentUpdateModelUpdated:
+		r.logWorkerEvent(issue, "worker_model_updated",
+			"thread_id", strings.TrimSpace(update.ThreadID),
+			"turn_id", strings.TrimSpace(update.TurnID),
+			"model", strings.TrimSpace(update.Model),
 		)
 	default:
 		if event != "" && update.Type != AgentUpdateMessageDelta {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -403,6 +403,80 @@ func TestRunnerRunRefusesDispatchWhenBudgetExceeded(t *testing.T) {
 	}
 }
 
+func TestRunnerRunRecordsRuntimeModelUpdate(t *testing.T) {
+	t.Parallel()
+
+	workspaceBackend := &fakeWorkspaceBackend{
+		info: workspace.Info{Path: t.TempDir(), Key: "issue-1103", Branch: "detent/issue-1103"},
+		diffStats: []workspace.DiffStat{
+			{Files: 1, Added: 3},
+		},
+	}
+	agentBackend := &fakeCodexClient{
+		updates: []AgentUpdate{
+			{Type: AgentUpdateTurnStarted, ThreadID: "thread-1103", TurnID: "turn-1"},
+			{Type: AgentUpdateModelUpdated, ThreadID: "thread-1103", TurnID: "turn-1", Model: "gpt-5.6"},
+			{
+				Type:     AgentUpdateTokenUsage,
+				ThreadID: "thread-1103",
+				TurnID:   "turn-1",
+				Tokens: AgentTokenUsage{
+					InputTokens:  100,
+					OutputTokens: 10,
+					TotalTokens:  110,
+				},
+			},
+		},
+		result: AgentTurnResult{ThreadID: "thread-1103", TurnID: "turn-1", SessionID: "thread-1103-turn-1"},
+	}
+	sessionStore := &fakeSessionStore{sessionID: 1103}
+	startedAt := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	runner, err := NewRunner(Dependencies{
+		Workflow:     config.Workflow{Prompt: "Work"},
+		Workspace:    workspaceBackend,
+		AgentBackend: agentBackend,
+		Store:        sessionStore,
+		Pricing: budget.PricingTable{
+			"gpt-5.6": {
+				USDPerInputToken:       0.000006,
+				USDPerCachedInputToken: 0.0000006,
+				USDPerOutputToken:      0.000036,
+			},
+		},
+		Now: newFakeClock(startedAt, startedAt.Add(time.Second), startedAt.Add(2*time.Second), startedAt.Add(3*time.Second)).Now,
+	})
+	if err != nil {
+		t.Fatalf("NewRunner() error = %v", err)
+	}
+
+	result, err := runner.Run(context.Background(), RunRequest{
+		Issue: connector.Issue{
+			ID:         "issue-1103",
+			Identifier: "digitaldrywood/detent#1103",
+			Title:      "Resolve runtime model",
+		},
+		StartedAt: startedAt,
+	})
+	if err != nil {
+		t.Fatalf("Run() error = %v", err)
+	}
+	if result.Model != "gpt-5.6" {
+		t.Fatalf("RunResult.Model = %q, want runtime model", result.Model)
+	}
+	if sessionStore.started.Model != "" {
+		t.Fatalf("SessionStart.Model = %q, want bare route to start without a pinned model", sessionStore.started.Model)
+	}
+	if sessionStore.finished.Model != "gpt-5.6" {
+		t.Fatalf("SessionFinish.Model = %q, want runtime model", sessionStore.finished.Model)
+	}
+	if sessionStore.usage.Model != "gpt-5.6" {
+		t.Fatalf("UsageEvent.Model = %q, want runtime model", sessionStore.usage.Model)
+	}
+	if sessionStore.usage.CostUSD == 0 {
+		t.Fatal("UsageEvent.CostUSD = 0, want priced runtime model")
+	}
+}
+
 func TestRunnerRunLogsBudgetRefusalWithDerivedRole(t *testing.T) {
 	t.Parallel()
 
@@ -1953,7 +2027,7 @@ func TestRunnerRunUnroutedStageRolesUseCodeModelFieldRouteWithoutDefault(t *test
 	}
 }
 
-func TestRunnerUsageCostWarnsForUnknownModel(t *testing.T) {
+func TestRunnerUsageCostUsesFallbackForUnknownModel(t *testing.T) {
 	t.Parallel()
 
 	var logs bytes.Buffer
@@ -1963,11 +2037,11 @@ func TestRunnerUsageCostWarnsForUnknownModel(t *testing.T) {
 	}
 
 	cost := runner.usageCostUSD(" missing-model ", 10, 2, 5, "codex")
-	if cost != 0 {
-		t.Fatalf("usageCostUSD() = %.12f, want 0", cost)
+	if cost == 0 {
+		t.Fatal("usageCostUSD() = 0, want fallback pricing")
 	}
-	if got := logs.String(); !strings.Contains(got, "usage event model pricing not found") || !strings.Contains(got, "missing-model") || !strings.Contains(got, "backend_kind=codex") {
-		t.Fatalf("log output = %q, want unknown pricing warning", got)
+	if got := logs.String(); strings.Contains(got, "usage event model pricing not found") {
+		t.Fatalf("log output = %q, want no unknown pricing warning", got)
 	}
 }
 
@@ -1983,14 +2057,14 @@ func TestRunnerUsageCostSkipsPricingWarningForEmptyModel(t *testing.T) {
 	}
 
 	cost := runner.usageCostUSD(" \t", 10, 2, 5, "claude_code")
-	if cost != 0 {
-		t.Fatalf("usageCostUSD() = %.12f, want 0", cost)
+	if cost == 0 {
+		t.Fatal("usageCostUSD() = 0, want fallback pricing")
 	}
 	got := logs.String()
 	if strings.Contains(got, "level=WARN") || strings.Contains(got, "usage event model pricing not found") {
 		t.Fatalf("log output = %q, want no empty-model pricing warning", got)
 	}
-	if !strings.Contains(got, "usage event model unavailable; skipping cost pricing") {
+	if !strings.Contains(got, "usage event model unavailable; using fallback pricing") {
 		t.Fatalf("log output = %q, want empty-model diagnostic", got)
 	}
 	if !strings.Contains(got, "backend_kind=claude_code") {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -115,6 +115,7 @@ const (
 	AgentUpdateRateLimits     AgentUpdateType = "rate_limits"
 	AgentUpdateTurnStarted    AgentUpdateType = "turn_started"
 	AgentUpdateTurnCompleted  AgentUpdateType = "turn_completed"
+	AgentUpdateModelUpdated   AgentUpdateType = "model_updated"
 )
 
 type AgentUpdate struct {

--- a/priv/pricing/README.md
+++ b/priv/pricing/README.md
@@ -22,4 +22,7 @@ models:
     output_usd_per_1m_tokens: 30.00
 ```
 
+Use the reserved `default` row to override the fallback rate Detent uses when
+runtime telemetry reports an unrecognized or empty model ID.
+
 `cached_input_usd_per_1m_tokens` and `usd_per_cached_input_token` are cache-read prices, not cache-write prices. Verify all three columns against the provider's published pricing when adding or changing a model. If an override row omits the cached-input rate, Detent logs a warning and falls back to the input rate so the model does not silently price cache reads at zero.


### PR DESCRIPTION
## Summary
- Resolve Codex app-server runtime models from session events and `config/read` when workflows use a bare `codex app-server` command.
- Propagate model update events into runner telemetry so finished sessions and usage events carry the effective model.
- Add a configurable `default` pricing fallback for unrecognized or empty model IDs.

Fixes #1103

## Test Plan
- `go test ./internal/codex ./internal/runner ./internal/budget`
- `go test ./internal/cli`
- `make check`