### PR TITLE
fix(prompt): document workpad status enum

### DIFF
--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -528,6 +528,8 @@ func appendGateBlock(prompt string, cfg gate.Config) string {
 
 func appendBlockedHandoffBlock(prompt string) string {
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n## Blocked handoff\n\n" +
+		"When writing a Workpad `detent-status` block, `status` must be exactly one of `in_progress`, `blocked`, or `complete`; no other value is valid. " +
+		"The block signals the current work state only. The project's configured flow decides any later review, gate-wait, or merge lane placement.\n\n" +
 		"Before moving an issue to Blocked because it is waiting on another tracked GitHub issue or pull request, prefer GitHub's native dependency relation. " +
 		"Resolve the blocker REST id, then create the relation:\n\n" +
 		"```sh\n" +
@@ -543,6 +545,13 @@ func appendBlockedHandoffBlock(prompt string) string {
 		"blockers:\n" +
 		"  - ref: \"owner/repo#123\"\n" +
 		"    reason: \"waiting for the dependency to merge\"\n" +
+		"human_action: null\n" +
+		"```\n\n" +
+		"On successful completion, declare completion with the same structured block:\n\n" +
+		"```detent-status\n" +
+		"schema: 1\n" +
+		"status: complete\n" +
+		"blockers: []\n" +
 		"human_action: null\n" +
 		"```\n\n" +
 		"Narrative Workpad sentences are never read as blockers. Legacy fallback during the deprecation window: keep a machine-readable issue-body line such as `Blocked by: #123` or `Depends on: owner/repo#123` only when native dependencies are unavailable and the project has not migrated."

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -87,9 +87,12 @@ func TestBuildPromptRendersAssignsLessonsAndSkills(t *testing.T) {
 		"## Lessons from prior runs",
 		"Check generator aliases before editing.",
 		"## Blocked handoff",
+		"`status` must be exactly one of `in_progress`, `blocked`, or `complete`; no other value is valid.",
+		"The block signals the current work state only. The project's configured flow decides any later review, gate-wait, or merge lane placement.",
 		"dependencies/blocked_by",
 		"```detent-status",
 		"status: blocked",
+		"status: complete",
 		"Blocked by: #123",
 		"Narrative Workpad sentences are never read as blockers",
 		"## Validation gate",
@@ -110,6 +113,47 @@ func TestBuildPromptRendersAssignsLessonsAndSkills(t *testing.T) {
 	}
 	if strings.Contains(prompt, "Add migrations.") {
 		t.Fatalf("prompt included skill description, want only when_to_use:\n%s", prompt)
+	}
+}
+
+func TestBuildPromptDocumentsWorkpadStatusContract(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{
+		Prompt: "Base prompt",
+	}, connector.Issue{
+		Identifier: "digitaldrywood/detent#1106",
+		Title:      "Document workpad status",
+	}, PromptOptions{})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"`status` must be exactly one of `in_progress`, `blocked`, or `complete`; no other value is valid.",
+		"The block signals the current work state only. The project's configured flow decides any later review, gate-wait, or merge lane placement.",
+		"```detent-status\n" +
+			"schema: 1\n" +
+			"status: blocked\n" +
+			"blockers:\n" +
+			"  - ref: \"owner/repo#123\"\n" +
+			"    reason: \"waiting for the dependency to merge\"\n" +
+			"human_action: null\n" +
+			"```",
+		"```detent-status\n" +
+			"schema: 1\n" +
+			"status: complete\n" +
+			"blockers: []\n" +
+			"human_action: null\n" +
+			"```",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+
+	if strings.Contains(prompt, "never use Human Review") {
+		t.Fatalf("prompt contains project-specific review policy:\n%s", prompt)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Document the valid `detent-status` enum in the generic worker prompt.
- Add a successful completion status example alongside the blocked handoff example.
- Add prompt coverage for the rendered enum and examples.

Fixes #1106

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/runner`
- [x] `make check`