### PR TITLE
fix(autopromote): rework invalid workpad status

### DIFF
--- a/internal/orchestrator/autopromote.go
+++ b/internal/orchestrator/autopromote.go
@@ -39,6 +39,7 @@ type AutoPromoteSummary struct {
 	Validator                             gate.ValidatorResult
 	ArtifactStatus                        string
 	LastActivityAt                        *time.Time
+	CompletedFinalState                   string
 }
 
 type AutoPromoteFinding struct {
@@ -129,7 +130,7 @@ func EvaluateAutoPromote(
 	}
 	workpad := autoPromoteWorkpadBlocker(issue, cfg)
 	if workpad.Invalid != nil {
-		decision := autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonWorkpadStatusInvalid)
+		decision := autoPromoteDecision(autoPromoteInvalidWorkpadAction(summary.CompletedFinalState), AutoPromoteReasonWorkpadStatusInvalid)
 		autoPromoteApplyWorkpadDecisionFields(&decision, workpad)
 		return decision
 	}
@@ -181,6 +182,31 @@ func autoPromoteDecision(action AutoPromoteAction, reason AutoPromoteReason) Aut
 		Action: action,
 		Reason: reason,
 	}
+}
+
+func cloneAutoPromoteDecisions(decisions map[string]AutoPromoteDecision) map[string]AutoPromoteDecision {
+	if decisions == nil {
+		return nil
+	}
+	cloned := make(map[string]AutoPromoteDecision, len(decisions))
+	for issueID, decision := range decisions {
+		cloned[issueID] = cloneAutoPromoteDecision(decision)
+	}
+	return cloned
+}
+
+func cloneAutoPromoteDecision(decision AutoPromoteDecision) AutoPromoteDecision {
+	decision.Findings = append([]AutoPromoteFinding(nil), decision.Findings...)
+	decision.ResolvedWorkpadBlockers = append([]string(nil), decision.ResolvedWorkpadBlockers...)
+	decision.WorkpadBlockerVerifications = append([]AutoPromoteWorkpadBlockerVerification(nil), decision.WorkpadBlockerVerifications...)
+	return decision
+}
+
+func autoPromoteInvalidWorkpadAction(completedFinalState string) AutoPromoteAction {
+	if normalizeState(completedFinalState) == normalizeState(FinalStateCompleted) {
+		return AutoPromoteActionRework
+	}
+	return AutoPromoteActionAwaitReview
 }
 
 func normalizeAutoPromoteConfig(cfg AutoPromoteConfig) AutoPromoteConfig {

--- a/internal/orchestrator/autopromote_test.go
+++ b/internal/orchestrator/autopromote_test.go
@@ -835,6 +835,117 @@ func TestEvaluateAutoPromoteStructuredWorkpad(t *testing.T) {
 	}
 }
 
+func TestEvaluateAutoPromoteStructuredWorkpadStatusPolicy(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 13, 45, 0, 0, time.UTC)
+	oldActivity := now.Add(-20 * time.Minute)
+	ready := AutoPromoteSummary{
+		PullRequestURL: "https://github.test/pull/42",
+		CIStatus:       "green",
+		LastActivityAt: &oldActivity,
+	}
+	cfg := AutoPromoteConfig{
+		Enabled:        true,
+		QuietDuration:  10 * time.Minute,
+		TerminalStates: []string{"Done", "Cancelled"},
+		Gate:           gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+	}
+
+	tests := []struct {
+		name                string
+		body                string
+		completedFinalState string
+		structuredOnly      bool
+		wantAction          AutoPromoteAction
+		wantReason          AutoPromoteReason
+		wantBlocker         string
+		wantSource          string
+		wantInvalid         string
+		wantProseDisabled   bool
+	}{
+		{
+			name:       "valid complete promotes",
+			body:       "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
+			wantAction: AutoPromoteActionPromote,
+			wantReason: AutoPromoteReasonReady,
+			wantSource: "structured",
+		},
+		{
+			name:                "invalid status after success routes to rework",
+			body:                "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: human-review\nblockers: []\nhuman_action: null\n```",
+			completedFinalState: FinalStateCompleted,
+			wantAction:          AutoPromoteActionRework,
+			wantReason:          AutoPromoteReasonWorkpadStatusInvalid,
+			wantSource:          "structured",
+			wantInvalid:         `status "human-review"`,
+		},
+		{
+			name:                "invalid status after failure awaits review",
+			body:                "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: human_review\nblockers: []\nhuman_action: null\n```",
+			completedFinalState: "failed",
+			wantAction:          AutoPromoteActionAwaitReview,
+			wantReason:          AutoPromoteReasonWorkpadStatusInvalid,
+			wantSource:          "structured",
+			wantInvalid:         `status "human_review"`,
+		},
+		{
+			name:        "missing structured block uses prose fallback",
+			body:        "## Codex Workpad\n\n### Blockers\n- Owner approval is still required before merge.",
+			wantAction:  AutoPromoteActionAwaitReview,
+			wantReason:  AutoPromoteReasonWorkpadBlocker,
+			wantBlocker: "Owner approval is still required before merge.",
+			wantSource:  "prose_section",
+		},
+		{
+			name:              "missing structured block with structured only ignores prose",
+			body:              "## Codex Workpad\n\n### Blockers\n- Owner approval is still required before merge.",
+			structuredOnly:    true,
+			wantAction:        AutoPromoteActionPromote,
+			wantReason:        AutoPromoteReasonReady,
+			wantSource:        "prose_section",
+			wantProseDisabled: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := autoPromoteTestIssue("issue-workpad-status-policy", nil)
+			issue.Identifier = "digitaldrywood/detent#1107"
+			issue.Comments = []connector.IssueComment{{
+				Body: tt.body,
+				URL:  "https://github.test/comment/workpad-status-policy",
+			}}
+			testCfg := cfg
+			testCfg.WorkpadStructuredOnly = tt.structuredOnly
+			summary := ready
+			summary.CompletedFinalState = tt.completedFinalState
+
+			got := EvaluateAutoPromote(issue, summary, testCfg, now)
+			if got.Action != tt.wantAction {
+				t.Fatalf("Action = %q, want %q", got.Action, tt.wantAction)
+			}
+			if got.Reason != tt.wantReason {
+				t.Fatalf("Reason = %q, want %q", got.Reason, tt.wantReason)
+			}
+			if got.WorkpadBlocker != tt.wantBlocker {
+				t.Fatalf("WorkpadBlocker = %q, want %q", got.WorkpadBlocker, tt.wantBlocker)
+			}
+			if got.WorkpadSignalSource != tt.wantSource {
+				t.Fatalf("WorkpadSignalSource = %q, want %q", got.WorkpadSignalSource, tt.wantSource)
+			}
+			if tt.wantInvalid != "" && !strings.Contains(got.WorkpadStatusInvalid, tt.wantInvalid) {
+				t.Fatalf("WorkpadStatusInvalid = %q, want containing %q", got.WorkpadStatusInvalid, tt.wantInvalid)
+			}
+			if got.WorkpadProseFallbackDisabled != tt.wantProseDisabled {
+				t.Fatalf("WorkpadProseFallbackDisabled = %v, want %v", got.WorkpadProseFallbackDisabled, tt.wantProseDisabled)
+			}
+		})
+	}
+}
+
 func TestAutoPromoteWaitsForFreshPullRequestActivityWithoutAutomatedReview(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -79,11 +79,13 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		}
 
 		summary := AutoPromoteSummaryFromIssue(issue)
+		summary.CompletedFinalState = autoPromoteCompletedFinalState(state, issueID)
 		decision := EvaluateAutoPromote(issue, summary, cfg, now)
 		if decision.Reason == AutoPromoteReasonValidatorMissing {
 			validation, shouldComment, ok := o.validatorStageResult(ctx, issue)
 			if !ok {
 				o.startValidatorStage(ctx, issue, now)
+				recordAutoPromoteSnapshotDecision(state, issueID, decision)
 				o.logAutoPromoteDecision(issue, decision, "")
 				continue
 			}
@@ -96,7 +98,9 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		}
 		if decision.Reason == AutoPromoteReasonCINotGreen &&
 			o.retryTransientPullRequestChecks(ctx, state, issue, now, string(AutoPromoteReasonCINotGreen)) {
-			o.logAutoPromoteDecision(issue, autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen), "")
+			decision := autoPromoteDecision(AutoPromoteActionSkip, AutoPromoteReasonCINotGreen)
+			recordAutoPromoteSnapshotDecision(state, issueID, decision)
+			o.logAutoPromoteDecision(issue, decision, "")
 			continue
 		}
 		if autoPromoteDecisionNeedsWorkpadHydration(decision) {
@@ -104,6 +108,7 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		}
 		targetState := autoPromoteTargetState(decision.Action, cfg)
 		if targetState == "" {
+			recordAutoPromoteSnapshotDecision(state, issueID, decision)
 			o.logAutoPromoteDecision(issue, decision, "")
 			continue
 		}
@@ -124,6 +129,35 @@ func (o *Orchestrator) autoPromoteHumanReviewIssues(
 		return autoPromoteTickResult{}
 	}
 	return result
+}
+
+func autoPromoteCompletedFinalState(state *State, issueID string) string {
+	if state == nil {
+		return ""
+	}
+	completed, ok := state.Completed[strings.TrimSpace(issueID)]
+	if !ok {
+		return ""
+	}
+	return completed.FinalState
+}
+
+func recordAutoPromoteSnapshotDecision(state *State, issueID string, decision AutoPromoteDecision) {
+	if state == nil {
+		return
+	}
+	issueID = strings.TrimSpace(issueID)
+	if issueID == "" {
+		return
+	}
+	if decision.Action != AutoPromoteActionAwaitReview && decision.Action != AutoPromoteActionSkip {
+		delete(state.AutoPromoteDecisions, issueID)
+		return
+	}
+	if state.AutoPromoteDecisions == nil {
+		state.AutoPromoteDecisions = map[string]AutoPromoteDecision{}
+	}
+	state.AutoPromoteDecisions[issueID] = cloneAutoPromoteDecision(decision)
 }
 
 func (o *Orchestrator) autoPromoteEvaluationIssues(
@@ -260,7 +294,7 @@ func (o *Orchestrator) hydrateAutoPromoteWorkpadDecision(
 	}
 	issue = o.hydrateAutoPromoteWorkpadBlockerRefs(ctx, issue, cfg)
 	decision := EvaluateAutoPromote(issue, summary, cfg, now)
-	if decision.Reason == AutoPromoteReasonWorkpadStatusInvalid {
+	if decision.Reason == AutoPromoteReasonWorkpadStatusInvalid && decision.Action != AutoPromoteActionRework {
 		o.commentInvalidWorkpadStatus(ctx, issue, decision)
 	}
 	if decision.WorkpadProseFallbackDisabled && o.logger != nil {
@@ -400,6 +434,8 @@ func invalidWorkpadStatusComment(decision AutoPromoteDecision) string {
 	b.WriteString("\nDetent could not parse the `detent-status` block in the latest `## Codex Workpad` comment.")
 	b.WriteString("\n\n- reason: ")
 	b.WriteString(strings.TrimSpace(decision.WorkpadStatusInvalid))
+	b.WriteString("\n- allowed_statuses: ")
+	b.WriteString(autoPromoteAllowedWorkpadStatuses())
 	if url := strings.TrimSpace(decision.WorkpadCommentURL); url != "" {
 		b.WriteString("\n- workpad_comment: ")
 		b.WriteString(url)
@@ -409,6 +445,10 @@ func invalidWorkpadStatusComment(decision AutoPromoteDecision) string {
 	b.WriteString("\n\nUse this schema:")
 	b.WriteString("\n\n```detent-status\nschema: 1\nstatus: in_progress\nblockers: []\nhuman_action: null\n```")
 	return b.String()
+}
+
+func autoPromoteAllowedWorkpadStatuses() string {
+	return strings.Join([]string{workpad.StatusInProgress, workpad.StatusBlocked, workpad.StatusComplete}, ", ")
 }
 
 func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
@@ -1370,6 +1410,7 @@ func (o *Orchestrator) clearAutoPromotedIssueDispatchMemory(state *State, issueI
 	delete(state.Retry, issueID)
 	delete(state.Blocked, issueID)
 	delete(state.Completed, issueID)
+	delete(state.AutoPromoteDecisions, issueID)
 }
 
 func (o *Orchestrator) startValidatorStage(ctx context.Context, issue connector.Issue, now time.Time) {
@@ -2297,26 +2338,37 @@ func autoPromoteComment(
 	if sourceState == "" {
 		sourceState = autoPromoteSourceState
 	}
-	switch targetState {
-	case autoPromoteMergingState:
+	targetState = displayStateName(targetState)
+	if targetState == "" {
+		return ""
+	}
+	switch {
+	case decision.Action == AutoPromoteActionPromote:
 		b.WriteString("Auto-promoted this issue from ")
 		b.WriteString(sourceState)
-		b.WriteString(" to Merging.")
-	case autoPromoteReworkState:
+		b.WriteString(" to ")
+		b.WriteString(targetState)
+		b.WriteString(".")
+	case decision.Action == AutoPromoteActionRework:
 		b.WriteString("Auto-promote routed this issue from ")
 		b.WriteString(sourceState)
-		b.WriteString(" to Rework")
+		b.WriteString(" to ")
+		b.WriteString(targetState)
 		switch decision.Reason {
 		case AutoPromoteReasonCINotGreen:
 			b.WriteString(": current-head CI is failing")
 		case AutoPromoteReasonMergeConflicts:
 			b.WriteString(": linked PR has merge conflicts")
+		case AutoPromoteReasonWorkpadStatusInvalid:
+			b.WriteString(": workpad status is invalid")
 		}
 		b.WriteString(".")
-	case autoPromoteSourceState:
+	case normalizeState(targetState) == normalizeState(autoPromoteSourceState):
 		b.WriteString("Reconciled this issue from ")
 		b.WriteString(sourceState)
-		b.WriteString(" to Human Review because it already has a linked PR.")
+		b.WriteString(" to ")
+		b.WriteString(targetState)
+		b.WriteString(" because it already has a linked PR.")
 	default:
 		return ""
 	}
@@ -2340,6 +2392,7 @@ func autoPromoteComment(
 		b.WriteString("\n- failed_checks: ")
 		b.WriteString(failedChecks)
 	}
+	appendAutoPromoteWorkpadCommentFields(&b, decision)
 
 	if len(decision.Findings) > 0 {
 		b.WriteString("\n\nFindings:")
@@ -2350,6 +2403,23 @@ func autoPromoteComment(
 	}
 
 	return b.String()
+}
+
+func appendAutoPromoteWorkpadCommentFields(b *strings.Builder, decision AutoPromoteDecision) {
+	if invalid := strings.TrimSpace(decision.WorkpadStatusInvalid); invalid != "" {
+		b.WriteString("\n- workpad_status_invalid: ")
+		b.WriteString(invalid)
+		b.WriteString("\n- allowed_statuses: ")
+		b.WriteString(autoPromoteAllowedWorkpadStatuses())
+	}
+	if url := strings.TrimSpace(decision.WorkpadCommentURL); url != "" {
+		b.WriteString("\n- workpad_comment: ")
+		b.WriteString(url)
+	}
+	if hash := strings.TrimSpace(decision.WorkpadStatusInvalidHash); hash != "" {
+		b.WriteString("\n- workpad_status_hash: ")
+		b.WriteString(hash)
+	}
 }
 
 func autoPromoteReworkLimitComment(

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -856,6 +856,74 @@ func TestTickAutoPromoteCommentsOnceForInvalidStructuredWorkpad(t *testing.T) {
 	}
 }
 
+func TestTickAutoPromoteRoutesSuccessfulInvalidStructuredWorkpadToRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 13, 30, 0, 0, time.UTC)
+	oldReview := now.Add(-20 * time.Minute)
+	issue := autoPromoteTickIssue("issue-invalid-workpad-success", []string{"bug"}, &connector.PullRequest{
+		Number:                 1491,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/1491",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "pass",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 10 * time.Minute,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:      issue,
+		FinalState: FinalStateCompleted,
+	}
+	tracker := &autoPromoteTickConnector{
+		stateIssues: []connector.Issue{issue},
+		issueComments: map[string][]connector.IssueComment{
+			issue.ID: {{
+				Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: human-review\nblockers: []\nhuman_action: null\n```",
+				URL:  "https://github.test/comment/invalid-status-value",
+			}},
+		},
+	}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	result := orch.autoPromoteHumanReviewIssues(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned = %#v, want %s", result.transitioned, issue.ID)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one rework comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Auto-promote routed this issue from Human Review to Rework",
+		"reason: workpad_status_invalid",
+		"human-review",
+		"in_progress, blocked, complete",
+		"https://github.test/comment/invalid-status-value",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+}
+
 func TestTickAutoPromoteBlocksWhenReworkLimitReached(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -46,7 +46,7 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 		}
 
 		result.transitioned[issueID] = struct{}{}
-		if direct, promoted := o.tryDirectCompletedActiveAutoPromote(ctx, state, issue, targetState, cfg, now); direct {
+		if direct, promoted := o.tryDirectCompletedActiveAutoPromote(ctx, state, issue, targetState, completed.FinalState, cfg, now); direct {
 			if mergeWorkerIssue(promoted) {
 				o.recordMergeQueueEntered(state, promoted, now, "completed_active_auto_promote")
 				result.dispatchCandidates = append(result.dispatchCandidates, promoted)
@@ -169,6 +169,7 @@ func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 	state *State,
 	issue connector.Issue,
 	reviewState string,
+	completedFinalState string,
 	cfg AutoPromoteConfig,
 	now time.Time,
 ) (bool, connector.Issue) {
@@ -177,13 +178,10 @@ func (o *Orchestrator) tryDirectCompletedActiveAutoPromote(
 	}
 
 	summary := AutoPromoteSummaryFromIssue(issue)
+	summary.CompletedFinalState = completedFinalState
 	decision := EvaluateAutoPromote(issue, summary, cfg, now)
 	if autoPromoteDecisionNeedsWorkpadHydration(decision) {
 		issue, decision = o.hydrateAutoPromoteWorkpadDecision(ctx, issue, summary, cfg, now)
-	}
-	if decision.Action != AutoPromoteActionPromote {
-		o.logAutoPromoteDecision(issue, decision, "")
-		return false, connector.Issue{}
 	}
 	targetState := autoPromoteTargetState(decision.Action, cfg)
 	if targetState == "" {

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -342,6 +342,69 @@ func TestTransitionCompletedActiveIssuesLeavesAutoPromoteIssueActive(t *testing.
 	}
 }
 
+func TestTransitionCompletedActiveIssuesRoutesInvalidWorkpadStatusToRework(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 14, 10, 0, 0, time.UTC)
+	issue := completionTransitionIssue("In Progress", "OPEN")
+	issue.PullRequest = &connector.PullRequest{
+		Number:                 20,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/20",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "success",
+		CodexReviewState:       "COMMENTED",
+		CodexReviewSubmittedAt: timePointer(now.Add(-20 * time.Minute)),
+	}
+	issue.Comments = []connector.IssueComment{{
+		Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: human-review\nblockers: []\nhuman_action: null\n```",
+		URL:  "https://github.test/comment/completed-invalid-workpad",
+	}}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 0,
+			GateWaitState: autoPromoteGateWaitReview,
+			Gate:          gate.Config{Kind: gate.KindCommand, RequireAutomatedReview: new(false)},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	orch := &Orchestrator{cfg: cfg, connector: tracker}
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+
+	result := orch.transitionCompletedActiveIssuesToReview(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned[%q] missing", issue.ID)
+	}
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Rework"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if got := state.Completed[issue.ID].Issue.State; got != "Rework" {
+		t.Fatalf("Completed issue state = %q, want Rework", got)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one rework comment", tracker.comments)
+	}
+	for _, fragment := range []string{
+		"Auto-promote routed this issue from In Progress to Rework",
+		"reason: workpad_status_invalid",
+		`status "human-review"`,
+		"in_progress, blocked, complete",
+	} {
+		if !strings.Contains(tracker.comments[0].body, fragment) {
+			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
+		}
+	}
+}
+
 func TestTransitionCompletedActiveIssuesEscalatesGateWaitTimeout(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -108,6 +108,9 @@ func (s State) applyAutoPromoteDecisionSnapshots(snapshots []telemetry.Issue, is
 		issueID := strings.TrimSpace(issues[i].ID)
 		decision, ok := s.AutoPromoteDecisions[issueID]
 		if !ok {
+			if !s.shouldComputeAutoPromoteSnapshotDecision(issues[i]) {
+				continue
+			}
 			summary := AutoPromoteSummaryFromIssue(issues[i])
 			summary.CompletedFinalState = autoPromoteCompletedFinalState(&s, issueID)
 			decision = EvaluateAutoPromote(issues[i], summary, s.AutoPromote, now)
@@ -121,6 +124,18 @@ func (s State) applyAutoPromoteDecisionSnapshots(snapshots []telemetry.Issue, is
 		snapshots[i].Metadata[autoPromoteActionMetadataKey] = string(decision.Action)
 		snapshots[i].Metadata[autoPromoteReasonMetadataKey] = string(decision.Reason)
 	}
+}
+
+func (s State) shouldComputeAutoPromoteSnapshotDecision(issue connector.Issue) bool {
+	cfg := normalizeAutoPromoteConfig(s.AutoPromote)
+	if normalizeState(issue.State) == normalizeState(cfg.SourceState) {
+		return true
+	}
+	return autoPromoteActiveGatePendingIssue(issue, &s, Config{
+		AutoPromote:    cfg,
+		ActiveStates:   append([]string(nil), s.ActiveStates...),
+		TerminalStates: append([]string(nil), s.TerminalStates...),
+	}, cfg)
 }
 
 func autoPromoteDecisionVisibleOnCard(decision AutoPromoteDecision) bool {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -11,6 +11,11 @@ import (
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
+const (
+	autoPromoteActionMetadataKey = "detent.auto_promote_action"
+	autoPromoteReasonMetadataKey = "detent.auto_promote_reason"
+)
+
 // Snapshot converts the orchestrator State into a telemetry.Snapshot suitable
 // for publishing to the web dashboard. Slices are sorted by issue id so the
 // output is deterministic.
@@ -39,6 +44,9 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	statusDrift := authorizedStatusDrift(s.StatusDrift, s.Authorization, s.SelectorContext)
 	boardIssueSnapshots := issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now)
 	s.applyGatePendingSnapshots(boardIssueSnapshots, boardIssues)
+	s.applyAutoPromoteDecisionSnapshots(boardIssueSnapshots, boardIssues, now)
+	pipelineIssueSnapshots := pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now)
+	s.applyAutoPromoteDecisionSnapshots(pipelineIssueSnapshots, pipeline, now)
 	snapshot := telemetry.Snapshot{
 		GeneratedAt:        now,
 		Instance:           s.Instance,
@@ -48,7 +56,7 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Refresh:            refresh,
 		TrackerDrift:       statusDriftSnapshot(statusDrift, s.AutoPromoteQuietDuration, s.PollInterval, now),
 		BoardIssues:        boardIssueSnapshots,
-		Pipeline:           pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now),
+		Pipeline:           pipelineIssueSnapshots,
 		Running:            runningSnapshots(s.Running, s.Claimed, s.MergeTimings, now),
 		WorkAttempts:       cloneTelemetryWorkAttempts(s.WorkAttempts),
 		SchedulerDecisions: cloneTelemetrySchedulerDecisions(s.SchedulerDecisions),
@@ -87,6 +95,36 @@ func (s State) applyGatePendingSnapshots(snapshots []telemetry.Issue, issues []c
 			snapshots[i].GatePending = true
 		}
 	}
+}
+
+func (s State) applyAutoPromoteDecisionSnapshots(snapshots []telemetry.Issue, issues []connector.Issue, now time.Time) {
+	if len(snapshots) == 0 || len(issues) == 0 {
+		return
+	}
+	for i := range snapshots {
+		if i >= len(issues) {
+			return
+		}
+		issueID := strings.TrimSpace(issues[i].ID)
+		decision, ok := s.AutoPromoteDecisions[issueID]
+		if !ok {
+			summary := AutoPromoteSummaryFromIssue(issues[i])
+			summary.CompletedFinalState = autoPromoteCompletedFinalState(&s, issueID)
+			decision = EvaluateAutoPromote(issues[i], summary, s.AutoPromote, now)
+		}
+		if !autoPromoteDecisionVisibleOnCard(decision) {
+			continue
+		}
+		if snapshots[i].Metadata == nil {
+			snapshots[i].Metadata = map[string]string{}
+		}
+		snapshots[i].Metadata[autoPromoteActionMetadataKey] = string(decision.Action)
+		snapshots[i].Metadata[autoPromoteReasonMetadataKey] = string(decision.Reason)
+	}
+}
+
+func autoPromoteDecisionVisibleOnCard(decision AutoPromoteDecision) bool {
+	return decision.Action == AutoPromoteActionAwaitReview || decision.Action == AutoPromoteActionSkip
 }
 
 func authorizedSnapshotIssues(issues []connector.Issue, authorization selector.Selector, ctx selector.Context) []connector.Issue {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -170,6 +170,10 @@ func TestStateSnapshotComputesDisabledAutoPromoteReason(t *testing.T) {
 		ID:         "auto-promote-disabled",
 		Identifier: "digitaldrywood/detent#1108",
 		State:      "Human Review",
+	}, {
+		ID:         "merging-disabled",
+		Identifier: "digitaldrywood/detent#1109",
+		State:      "Merging",
 	}}
 
 	snapshot := state.Snapshot(now)
@@ -179,6 +183,9 @@ func TestStateSnapshotComputesDisabledAutoPromoteReason(t *testing.T) {
 	}
 	if got := snapshot.BoardIssues[0].Metadata[autoPromoteReasonMetadataKey]; got != string(AutoPromoteReasonDisabled) {
 		t.Fatalf("auto promote reason = %q, want disabled", got)
+	}
+	if got := snapshot.BoardIssues[1].Metadata[autoPromoteReasonMetadataKey]; got != "" {
+		t.Fatalf("merging auto promote reason = %q, want empty", got)
 	}
 }
 

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -121,6 +121,67 @@ func snapshotGatePendingIssue(id string, state string) connector.Issue {
 	}
 }
 
+func TestStateSnapshotIncludesAutoPromoteDecisionReason(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 14, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate:    gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	issue := connector.Issue{
+		ID:         "auto-promote-await",
+		Identifier: "digitaldrywood/detent#1107",
+		State:      "Human Review",
+		PullRequest: &connector.PullRequest{
+			Number:   1108,
+			State:    "open",
+			CIStatus: "success",
+		},
+	}
+	state.BoardIssues = []connector.Issue{issue}
+	state.Pipeline = []connector.Issue{issue}
+	state.AutoPromoteDecisions[issue.ID] = autoPromoteDecision(AutoPromoteActionAwaitReview, AutoPromoteReasonWorkpadStatusInvalid)
+
+	snapshot := state.Snapshot(now)
+
+	if got := snapshot.BoardIssues[0].Metadata[autoPromoteActionMetadataKey]; got != string(AutoPromoteActionAwaitReview) {
+		t.Fatalf("BoardIssues auto promote action = %q, want await_review", got)
+	}
+	if got := snapshot.BoardIssues[0].Metadata[autoPromoteReasonMetadataKey]; got != string(AutoPromoteReasonWorkpadStatusInvalid) {
+		t.Fatalf("BoardIssues auto promote reason = %q, want workpad_status_invalid", got)
+	}
+	if got := snapshot.Pipeline[0].Metadata[autoPromoteReasonMetadataKey]; got != string(AutoPromoteReasonWorkpadStatusInvalid) {
+		t.Fatalf("Pipeline auto promote reason = %q, want workpad_status_invalid", got)
+	}
+}
+
+func TestStateSnapshotComputesDisabledAutoPromoteReason(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 14, 5, 0, 0, time.UTC)
+	state := newState(normalizeConfig(Config{}))
+	state.BoardIssues = []connector.Issue{{
+		ID:         "auto-promote-disabled",
+		Identifier: "digitaldrywood/detent#1108",
+		State:      "Human Review",
+	}}
+
+	snapshot := state.Snapshot(now)
+
+	if got := snapshot.BoardIssues[0].Metadata[autoPromoteActionMetadataKey]; got != string(AutoPromoteActionSkip) {
+		t.Fatalf("auto promote action = %q, want skip", got)
+	}
+	if got := snapshot.BoardIssues[0].Metadata[autoPromoteReasonMetadataKey]; got != string(AutoPromoteReasonDisabled) {
+		t.Fatalf("auto promote reason = %q, want disabled", got)
+	}
+}
+
 func TestStateSnapshotIncludesStatusDrift(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -41,6 +41,7 @@ type State struct {
 	StatusDrift              connector.StatusDrift
 	BoardIssues              []connector.Issue
 	Pipeline                 []connector.Issue
+	AutoPromoteDecisions     map[string]AutoPromoteDecision
 	Running                  map[string]Running
 	WorkAttempts             []telemetry.WorkAttempt
 	SchedulerDecisions       []telemetry.SchedulerDecision
@@ -192,6 +193,7 @@ func newState(cfg Config) State {
 		Instance:                 instanceSnapshot(cfg),
 		Authorization:            cloneSelector(cfg.Authorization),
 		SelectorContext:          cfg.SelectorContext,
+		AutoPromoteDecisions:     map[string]AutoPromoteDecision{},
 		Running:                  map[string]Running{},
 		Claimed:                  map[string]Claimed{},
 		Blocked:                  map[string]Blocked{},
@@ -237,6 +239,7 @@ func (s State) clone() State {
 		StatusDrift:              cloneStatusDrift(s.StatusDrift),
 		BoardIssues:              cloneIssues(s.BoardIssues),
 		Pipeline:                 cloneIssues(s.Pipeline),
+		AutoPromoteDecisions:     cloneAutoPromoteDecisions(s.AutoPromoteDecisions),
 		WorkAttempts:             cloneTelemetryWorkAttempts(s.WorkAttempts),
 		SchedulerDecisions:       cloneTelemetrySchedulerDecisions(s.SchedulerDecisions),
 		Running:                  make(map[string]Running, len(s.Running)),

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -41,6 +41,8 @@ const (
 	projectKanbanBlockedSourceMetadataKey         = "detent.blocked_source"
 	projectKanbanBlockedReasonMetadataKey         = "detent.blocked_reason"
 	projectKanbanBlockedRecoveryReasonMetadataKey = "detent.blocked_recovery_reason"
+	projectKanbanAutoPromoteActionMetadataKey     = "detent.auto_promote_action"
+	projectKanbanAutoPromoteReasonMetadataKey     = "detent.auto_promote_reason"
 )
 
 type DashboardData struct {
@@ -3627,7 +3629,9 @@ func prPipelineCardForIssue(issue telemetry.Issue, state string, laneID string, 
 
 func prPipelineWaitDetail(issue telemetry.Issue) string {
 	parts := []string{}
-	if reason := prPipelineHumanReviewWaitReason(issue); reason != "" {
+	if reason := prPipelineAutoPromoteWaitReason(issue); reason != "" {
+		parts = append(parts, reason)
+	} else if reason := prPipelineHumanReviewWaitReason(issue); reason != "" {
 		parts = append(parts, reason)
 	}
 	if issue.PullRequest == nil && issue.MergeTiming == nil {
@@ -3661,6 +3665,18 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		parts = append(parts, merge)
 	}
 	return strings.Join(parts, " / ")
+}
+
+func prPipelineAutoPromoteWaitReason(issue telemetry.Issue) string {
+	action := strings.TrimSpace(issue.Metadata[projectKanbanAutoPromoteActionMetadataKey])
+	if action != "await_review" && action != "skip" {
+		return ""
+	}
+	reason := strings.TrimSpace(issue.Metadata[projectKanbanAutoPromoteReasonMetadataKey])
+	if reason == "" {
+		return ""
+	}
+	return "auto-promote " + action + ": " + reason
 }
 
 func prPipelineHumanReviewWaitReason(issue telemetry.Issue) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -2639,6 +2639,21 @@ func TestPRPipelineWaitDetailExplainsHumanReviewReasons(t *testing.T) {
 			want: "waiting for auto-promote",
 		},
 		{
+			name: "auto promote decision reason",
+			issue: telemetry.Issue{
+				State: "Human Review",
+				Metadata: map[string]string{
+					projectKanbanAutoPromoteActionMetadataKey: "await_review",
+					projectKanbanAutoPromoteReasonMetadataKey: "workpad_status_invalid",
+				},
+				PullRequest: &telemetry.PullRequest{
+					CIStatus:         "success",
+					CodexReviewState: "COMMENTED",
+				},
+			},
+			want: "auto-promote await_review: workpad_status_invalid",
+		},
+		{
 			name: "hydration explains stale data instead",
 			issue: telemetry.Issue{
 				State: "Human Review",

--- a/internal/workpad/workpad.go
+++ b/internal/workpad/workpad.go
@@ -135,7 +135,11 @@ func ParseStatusBlock(content string, repo string) (*Signal, error) {
 	switch raw.Status {
 	case StatusInProgress, StatusBlocked, StatusComplete:
 	default:
-		problems = append(problems, "status must be one of in_progress, blocked, complete")
+		if raw.Status == "" {
+			problems = append(problems, "status must be one of in_progress, blocked, complete")
+		} else {
+			problems = append(problems, fmt.Sprintf("status %q must be one of in_progress, blocked, complete", raw.Status))
+		}
 	}
 
 	humanAction := ""

--- a/internal/workpad/workpad_test.go
+++ b/internal/workpad/workpad_test.go
@@ -42,6 +42,12 @@ func TestSignalFromComment(t *testing.T) {
 			wantInvalid: "field extra not found",
 		},
 		{
+			name:        "invalid status value",
+			body:        "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: human-review\nblockers: []\nhuman_action: null\n```",
+			wantOK:      true,
+			wantInvalid: `status "human-review" must be one of in_progress, blocked, complete`,
+		},
+		{
 			name:        "bad ref",
 			body:        "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: blocked\nblockers:\n  - ref: \"not-a-ref\"\nhuman_action: null\n```",
 			wantOK:      true,


### PR DESCRIPTION
## Summary

- Route successful completed runs with invalid structured Workpad status to the configured Rework state with actionable repair details.
- Include the exact invalid status value and allowed enum in Workpad parser/comment output.
- Surface await/skip auto-promote action and reason on dashboard card wait details.

Fixes #1107

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [ ] Visual changes to primary operator screens include screenshot or browser verification below.

Browser verification not run; this is a wait-detail data label change covered by `TestPRPipelineWaitDetailExplainsHumanReviewReasons`.

## Test Plan

- [x] `go test ./internal/workpad ./internal/orchestrator ./internal/web/templates -count=1`
- [x] `make check`