### PR TITLE
fix(board): reconcile externally merged PRs

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -1411,13 +1411,74 @@ func TestConnectorFetchIssuesByStatesAttachesLinkedPullRequestBeforeBranchPrefix
 	if !strings.Contains(query, "closedByPullRequestsReferences") {
 		t.Fatalf("observed status query does not request linked pull requests:\n%s", query)
 	}
-	if !strings.Contains(query, "nodes { number url state repository { nameWithOwner } }") {
+	if !strings.Contains(query, "nodes { number url state updatedAt repository { nameWithOwner } }") {
 		t.Fatalf("observed status query does not request linked pull request states:\n%s", query)
 	}
 	for _, request := range requests {
 		path, _ := request["path"].(string)
 		if strings.Contains(path, "/pulls?") {
 			t.Fatalf("request path = %q, want linked PR path without repository-wide pull list", path)
+		}
+	}
+}
+
+func TestConnectorFetchIssuesByStatesPrefersMergedLinkedPullRequestOverClosedUnmerged(t *testing.T) {
+	t.Parallel()
+
+	server := newGraphQLTestServer(t, []graphqlTestResponse{
+		{
+			body: `{"data":{"node":{"items":{"pageInfo":{"hasNextPage":false,"endCursor":null},"nodes":[{"id":"PVTI_179","content":{"__typename":"Issue","id":"I_179","number":179,"title":"Issue closed by external PR","body":"","state":"OPEN","url":"https://github.com/digitaldrywood/creswoodcorners-phone/issues/179","createdAt":null,"updatedAt":null,"assignees":{"nodes":[]},"labels":{"nodes":[{"name":"bug"}]},"repository":{"nameWithOwner":"digitaldrywood/creswoodcorners-phone"},"closedByPullRequestsReferences":{"nodes":[{"number":185,"url":"https://github.com/digitaldrywood/creswoodcorners-phone/pull/185","state":"CLOSED","updatedAt":"2026-07-06T18:57:20Z","repository":{"nameWithOwner":"digitaldrywood/creswoodcorners-phone"}},{"number":186,"url":"https://github.com/digitaldrywood/creswoodcorners-phone/pull/186","state":"MERGED","updatedAt":"2026-07-07T12:00:00Z","repository":{"nameWithOwner":"digitaldrywood/creswoodcorners-phone"}},{"number":191,"url":"https://github.com/digitaldrywood/creswoodcorners-phone/pull/191","state":"MERGED","updatedAt":"2026-07-08T12:00:00Z","repository":{"nameWithOwner":"digitaldrywood/creswoodcorners-phone"}}]}},"statusValue":{"name":"Human Review"},"priorityValue":null}]}}}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/creswoodcorners-phone/pulls/191",
+			body:   `{"number":191,"html_url":"https://github.com/digitaldrywood/creswoodcorners-phone/pull/191","state":"closed","merged_at":"2026-07-08T12:00:00Z","mergeable_state":"clean","updated_at":"2026-07-08T12:00:00Z","head":{"ref":"issue-179-human-fix","sha":"sha-191"}}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/creswoodcorners-phone/commits/sha-191/check-runs?per_page=100",
+			body:   `{"check_runs":[{"status":"completed","conclusion":"success"}]}`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/creswoodcorners-phone/commits/sha-191/statuses?per_page=100",
+			body:   `[]`,
+		},
+		{
+			method: http.MethodGet,
+			path:   "/repos/digitaldrywood/creswoodcorners-phone/pulls/191/reviews?per_page=100",
+			body:   `[]`,
+		},
+	})
+
+	c := newGitHubTestConnector(t, server, Config{ProjectSlug: "PVT_1"})
+	got, err := c.FetchIssuesByStates(context.Background(), []string{"Human Review"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("FetchIssuesByStates() len = %d, want 1", len(got))
+	}
+
+	if got[0].PRNumber == nil || *got[0].PRNumber != 191 {
+		t.Fatalf("PRNumber = %v, want merged linked PR 191", got[0].PRNumber)
+	}
+	if got[0].PRRepository != "digitaldrywood/creswoodcorners-phone" {
+		t.Fatalf("PRRepository = %q, want digitaldrywood/creswoodcorners-phone", got[0].PRRepository)
+	}
+	pr := got[0].PullRequest
+	if pr == nil {
+		t.Fatal("PullRequest = nil, want merged linked PR")
+		return
+	}
+	if pr.Number != 191 || pr.State != "MERGED" || pr.BranchName != "issue-179-human-fix" || pr.CIStatus != "pass" {
+		t.Fatalf("PullRequest = %#v, want hydrated merged PR 191", pr)
+	}
+
+	for _, request := range server.requests() {
+		path, _ := request["path"].(string)
+		if strings.Contains(path, "/pulls/185") {
+			t.Fatalf("request path = %q, want no hydration of closed unmerged PR 185", path)
 		}
 	}
 }

--- a/internal/connector/github/issue_read.go
+++ b/internal/connector/github/issue_read.go
@@ -224,7 +224,7 @@ fragment DetentGitHubIssueParent on Issue {
   assignees(first: 100) { nodes { id login } }
   labels(first: 20) { nodes { name } }
   repository { nameWithOwner }
-  closedByPullRequestsReferences(first: 5) { nodes { number url state repository { nameWithOwner } } }
+  closedByPullRequestsReferences(first: 5) { nodes { number url state updatedAt repository { nameWithOwner } } }
   subIssues(first: $linkedIssuesFirst) {
     pageInfo { hasNextPage endCursor }
     nodes {
@@ -379,7 +379,7 @@ fragment DetentGitHubIssueParentLabel on Issue {
   assignees(first: 100) { nodes { id login } }
   labels(first: 20) { nodes { name } }
   repository { nameWithOwner }
-  closedByPullRequestsReferences(first: 5) { nodes { number url state repository { nameWithOwner } } }
+  closedByPullRequestsReferences(first: 5) { nodes { number url state updatedAt repository { nameWithOwner } } }
   subIssues(first: $linkedIssuesFirst) {
     pageInfo { hasNextPage endCursor }
     nodes {

--- a/internal/connector/github/projects_v2.go
+++ b/internal/connector/github/projects_v2.go
@@ -74,7 +74,7 @@ query DetentGitHubObservedStatusProjectItems(
               stateReason
               url
               repository { nameWithOwner }
-              closedByPullRequestsReferences(first: 5) { nodes { number url state repository { nameWithOwner } } }
+              closedByPullRequestsReferences(first: 5) { nodes { number url state updatedAt repository { nameWithOwner } } }
             }
           }
           statusValue: fieldValueByName(name: "Status") {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -735,28 +735,66 @@ func (c *Connector) fetchPullRequestReviews(ctx context.Context, repo pullReques
 type pullRequestReference struct {
 	Number     int
 	Repository string
+	UpdatedAt  *time.Time
 }
 
 func firstPullRequestReference(pullRequests nodeConnection[pullRequest]) (pullRequestReference, bool) {
 	var fallback pullRequestReference
 	fallbackOK := false
+	var open pullRequestReference
+	openOK := false
+	var merged pullRequestReference
+	mergedOK := false
 	for _, pullRequest := range pullRequests.Nodes {
 		if pullRequest.Number <= 0 {
 			continue
 		}
-		ref := pullRequestReference{
-			Number:     pullRequest.Number,
-			Repository: strings.TrimSpace(pullRequest.Repository.NameWithOwner),
-		}
+		ref := pullRequestReferenceFromNode(pullRequest)
 		if !fallbackOK {
 			fallback = ref
 			fallbackOK = true
 		}
-		if normalizeStateName(pullRequest.State) == "open" {
-			return ref, true
+		switch normalizeStateName(pullRequest.State) {
+		case "open":
+			if !openOK || pullRequestReferenceAfter(ref, open) {
+				open = ref
+				openOK = true
+			}
+		case "merged":
+			if !mergedOK || pullRequestReferenceAfter(ref, merged) {
+				merged = ref
+				mergedOK = true
+			}
 		}
 	}
+	if openOK {
+		return open, true
+	}
+	if mergedOK {
+		return merged, true
+	}
 	return fallback, fallbackOK
+}
+
+func pullRequestReferenceFromNode(pullRequest pullRequest) pullRequestReference {
+	return pullRequestReference{
+		Number:     pullRequest.Number,
+		Repository: strings.TrimSpace(pullRequest.Repository.NameWithOwner),
+		UpdatedAt:  parseGitHubTime(pullRequest.UpdatedAt),
+	}
+}
+
+func pullRequestReferenceAfter(left, right pullRequestReference) bool {
+	if left.UpdatedAt != nil && right.UpdatedAt != nil && !left.UpdatedAt.Equal(*right.UpdatedAt) {
+		return left.UpdatedAt.After(*right.UpdatedAt)
+	}
+	if left.UpdatedAt != nil && right.UpdatedAt == nil {
+		return true
+	}
+	if left.UpdatedAt == nil && right.UpdatedAt != nil {
+		return false
+	}
+	return left.Number > right.Number
 }
 
 func pullRequestCIState(pullRequest pullRequestNode) string {

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -129,6 +129,7 @@ type pullRequest struct {
 	Number     int        `json:"number"`
 	URL        string     `json:"url"`
 	State      string     `json:"state"`
+	UpdatedAt  *string    `json:"updatedAt"`
 	Repository repository `json:"repository"`
 }
 

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -458,7 +458,7 @@ func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
 	now time.Time,
 ) map[string]struct{} {
 	transitioned := map[string]struct{}{}
-	for _, issue := range issuesInStates(issues, o.cfg.ActiveStates) {
+	for _, issue := range issuesInStates(issues, staleLinkedPullRequestReconciliationStates(o.cfg)) {
 		issueID := strings.TrimSpace(issue.ID)
 		if issueID == "" || issue.PullRequest == nil {
 			continue
@@ -524,6 +524,11 @@ func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
 		return nil
 	}
 	return transitioned
+}
+
+func staleLinkedPullRequestReconciliationStates(cfg Config) []string {
+	autoCfg := normalizeAutoPromoteConfig(cfg.AutoPromote)
+	return appendUniqueStates(cfg.ActiveStates, cfg.ObservedStates, []string{autoCfg.SourceState})
 }
 
 func (o *Orchestrator) reconcileStaleMergingPullRequestIssues(

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -477,6 +477,10 @@ func (o *Orchestrator) reconcileStaleLinkedPullRequestIssues(
 		if pullRequestState == "merged" {
 			summary := staleMergedPullRequestSummaryFromIssue(issue)
 			decision := staleMergedPullRequestDecision(issue, summary)
+			if !stateIn(issue.State, o.cfg.ActiveStates) && decision.Reason == AutoPromoteReasonPullRequestHydrationUnavailable {
+				o.logAutoPromoteDecision(issue, decision, "")
+				continue
+			}
 			targetState := staleMergedPullRequestTargetState(decision, o.cfg.AutoPromote, o.cfg.TerminalStates)
 			if targetState == "" {
 				o.logAutoPromoteDecision(issue, decision, "")

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -220,7 +220,7 @@ func TestTickAutoPromoteHumanReviewIssues(t *testing.T) {
 			issue: autoPromoteTickIssue("issue-closed-pr", []string{"bug"}, &connector.PullRequest{
 				Number:                 47,
 				URL:                    "https://github.test/digitaldrywood/detent/pull/47",
-				State:                  "MERGED",
+				State:                  "CLOSED",
 				CIStatus:               "pass",
 				CodexReviewState:       "COMMENTED",
 				CodexReviewSubmittedAt: &oldReview,

--- a/internal/orchestrator/status_reconciliation_test.go
+++ b/internal/orchestrator/status_reconciliation_test.go
@@ -163,6 +163,40 @@ func TestTickReconcilesHumanReviewIssueWithMergedLinkedPullRequestToDone(t *test
 	}
 }
 
+func TestTickKeepsObservedBlockedIssueWhenMergedPullRequestHydrationUnavailable(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 12, 15, 0, 0, time.UTC)
+	issue := statusReconcileIssue("issue-blocked-stale-pr", "Blocked", false, "")
+	issue.PullRequest = &connector.PullRequest{
+		Number:                  192,
+		URL:                     "https://github.com/digitaldrywood/creswoodcorners-phone/pull/192",
+		State:                   "MERGED",
+		CIStatus:                "pass",
+		HydrationDegradedReason: connector.PullRequestHydrationReasonStaleCachedPullData,
+	}
+	tracker := &statusReconcileConnector{
+		stateIssues: []connector.Issue{issue},
+	}
+	orch := newStatusReconcileOrchestrator(tracker)
+	orch.cfg.ActiveStates = []string{"Todo", "In Progress", "Rework", "Merging"}
+	orch.cfg.ObservedStates = []string{"Blocked"}
+	orch.cfg.AutoPromote = AutoPromoteConfig{
+		Enabled:       true,
+		QuietDuration: 10 * time.Minute,
+	}
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(tracker.updates) != 0 {
+		t.Fatalf("updates = %#v, want none for observed Blocked issue with stale merged PR hydration", tracker.updates)
+	}
+	if len(tracker.comments) != 0 {
+		t.Fatalf("comments = %#v, want none", tracker.comments)
+	}
+}
+
 func newStatusReconcileOrchestrator(tracker *statusReconcileConnector) *Orchestrator {
 	cfg := normalizeConfig(Config{
 		TerminalStates: []string{"Done", "Cancelled"},

--- a/internal/orchestrator/status_reconciliation_test.go
+++ b/internal/orchestrator/status_reconciliation_test.go
@@ -126,6 +126,43 @@ func TestTickReconcilesClosedCompletedIssueStatusesFromExistingPolls(t *testing.
 	}
 }
 
+func TestTickReconcilesHumanReviewIssueWithMergedLinkedPullRequestToDone(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	issue := statusReconcileIssue("issue-external-merge", "Human Review", false, "")
+	issue.PullRequest = &connector.PullRequest{
+		Number:   191,
+		URL:      "https://github.com/digitaldrywood/creswoodcorners-phone/pull/191",
+		State:    "MERGED",
+		CIStatus: "pass",
+	}
+	tracker := &statusReconcileConnector{
+		stateIssues: []connector.Issue{issue},
+	}
+	orch := newStatusReconcileOrchestrator(tracker)
+	orch.cfg.ActiveStates = []string{"Todo", "In Progress", "Rework", "Merging"}
+	orch.cfg.ObservedStates = []string{"Human Review"}
+	orch.cfg.AutoPromote = AutoPromoteConfig{
+		Enabled:       true,
+		QuietDuration: 10 * time.Minute,
+	}
+	state := newState(orch.cfg)
+
+	orch.tick(context.Background(), &state, now)
+
+	wantUpdates := []statusUpdate{{issueID: issue.ID, state: "Done"}}
+	if len(tracker.updates) != len(wantUpdates) || tracker.updates[0] != wantUpdates[0] {
+		t.Fatalf("updates = %#v, want %#v; fetchByStates = %#v", tracker.updates, wantUpdates, tracker.fetchByStates)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one merged PR reconciliation comment", tracker.comments)
+	}
+	if !strings.Contains(tracker.comments[0], "reason: pull_request_merged") {
+		t.Fatalf("comment = %q, want pull_request_merged reason", tracker.comments[0])
+	}
+}
+
 func newStatusReconcileOrchestrator(tracker *statusReconcileConnector) *Orchestrator {
 	cfg := normalizeConfig(Config{
 		TerminalStates: []string{"Done", "Cancelled"},
@@ -157,6 +194,8 @@ type statusReconcileConnector struct {
 	candidates     []connector.Issue
 	stateIssues    []connector.Issue
 	updates        []statusUpdate
+	comments       []string
+	fetchByStates  [][]string
 	fetchByIDCount int
 }
 
@@ -169,6 +208,7 @@ func (c *statusReconcileConnector) FetchCandidateIssues(context.Context) ([]conn
 }
 
 func (c *statusReconcileConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
+	c.fetchByStates = append(c.fetchByStates, append([]string(nil), states...))
 	return issuesInStates(c.stateIssues, states), nil
 }
 
@@ -177,7 +217,8 @@ func (c *statusReconcileConnector) FetchIssueStatesByIDs(context.Context, []stri
 	return nil, nil
 }
 
-func (c *statusReconcileConnector) CreateComment(context.Context, string, string) error {
+func (c *statusReconcileConnector) CreateComment(_ context.Context, _ string, body string) error {
+	c.comments = append(c.comments, body)
 	return nil
 }
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -144,7 +144,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	fetched = filterReconciledTickIssues(
 		state,
 		fetched,
-		o.reconcileStaleLinkedPullRequestIssues(ctx, state, fetched.candidates, now),
+		o.reconcileStaleLinkedPullRequestIssues(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status), now),
 	)
 	completedTransitions := o.transitionCompletedActiveIssuesToReview(ctx, state, fetched.candidates, now)
 	fetched = filterReconciledTickIssues(


### PR DESCRIPTION
## Summary

- Prefer open linked PRs first, then the newest merged linked PR, instead of hydrating closed-unmerged PRs for issue card status.
- Reconcile non-terminal observed issues to Done when a linked PR is already merged, including Human Review rows completed by non-Detent PRs.

Fixes #1110

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. No visual changes.

## Test Plan

- [x] `go test ./internal/connector/github -count=1`
- [x] `go test ./internal/orchestrator -count=1`
- [x] `make check`