### PR TITLE
feat(doctor): detect review-flow mismatches

### DIFF
--- a/internal/cli/doctor_autopromote.go
+++ b/internal/cli/doctor_autopromote.go
@@ -16,6 +16,10 @@ import (
 )
 
 const doctorAutoPromoteSampleLimit = 5
+const (
+	doctorReviewFlowAutopilot  = "autopilot"
+	doctorReviewFlowReviewGate = "review-gate"
+)
 
 type doctorAutoPromoteCandidateDiagnostic struct {
 	IssueID                      string     `json:"issue_id,omitempty"`
@@ -60,11 +64,12 @@ type doctorStatusOptionVerifier interface {
 
 func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.Config, deps doctorDeps, now time.Time) doctorCheck {
 	name := "Project " + id + " auto-promote"
+	flowDetail := doctorReviewFlowConfigDetail(cfg)
 	if !cfg.Agent.AutoPromote.Enabled {
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
-			Detail: "agent.auto_promote.enabled=false; live candidate diagnostics disabled",
+			Detail: flowDetail + "; live candidate diagnostics disabled",
 		}
 	}
 	passState := strings.TrimSpace(cfg.Agent.AutoPromote.PassState)
@@ -106,7 +111,7 @@ func checkDoctorAutoPromote(ctx context.Context, id string, cfg workflowconfig.C
 		return doctorCheck{
 			Name:   name,
 			Status: doctorOK,
-			Detail: "agent.auto_promote.enabled=true; live GitHub diagnostics skipped for " + cfg.Tracker.Kind + " tracker",
+			Detail: flowDetail + "; live GitHub diagnostics skipped for " + cfg.Tracker.Kind + " tracker",
 		}
 	}
 
@@ -220,7 +225,8 @@ func checkDoctorAutoPromoteLive(
 	}
 
 	detail := fmt.Sprintf(
-		"agent.auto_promote.enabled=true; status options resolved; sampled %d %s candidate(s)",
+		"%s; status options resolved; sampled %d %s candidate(s)",
+		doctorReviewFlowConfigDetail(cfg),
 		len(issues),
 		sourceState,
 	)
@@ -233,12 +239,58 @@ func checkDoctorAutoPromoteLive(
 	if len(candidates) > 0 {
 		detail += "; candidates: " + doctorAutoPromoteCandidateSummaries(candidates)
 	}
+	if invalid := doctorAutoPromoteInvalidWorkpadStatusCandidates(candidates); len(invalid) > 0 {
+		return doctorCheck{
+			Name:                  name,
+			Status:                doctorWarn,
+			Detail:                detail + "; invalid workpad status candidate(s): " + doctorAutoPromoteCandidateSummaries(invalid),
+			Hint:                  "Update the Workpad detent-status block to one of in_progress, blocked, or complete; if this repeats, align WORKFLOW.md handoff prose with the configured review flow.",
+			AutoPromoteCandidates: candidates,
+		}
+	}
 	return doctorCheck{
 		Name:                  name,
 		Status:                doctorOK,
 		Detail:                detail,
 		AutoPromoteCandidates: candidates,
 	}
+}
+
+func doctorReviewFlowChoice(cfg workflowconfig.Config) string {
+	if cfg.Agent.AutoPromote.Enabled &&
+		cfg.Agent.AutoPromote.QuietSeconds == 0 &&
+		doctorReviewFlowGateWaitState(cfg) == workflowconfig.AutoPromoteGateWaitStateSource {
+		return doctorReviewFlowAutopilot
+	}
+	return doctorReviewFlowReviewGate
+}
+
+func doctorReviewFlowConfigDetail(cfg workflowconfig.Config) string {
+	return fmt.Sprintf(
+		"review-flow=%s (auto_promote.enabled=%t, quiet_seconds=%d, gate_wait_state=%s)",
+		doctorReviewFlowChoice(cfg),
+		cfg.Agent.AutoPromote.Enabled,
+		cfg.Agent.AutoPromote.QuietSeconds,
+		doctorReviewFlowGateWaitState(cfg),
+	)
+}
+
+func doctorReviewFlowGateWaitState(cfg workflowconfig.Config) string {
+	state := strings.ToLower(strings.TrimSpace(cfg.Agent.AutoPromote.GateWaitState))
+	if state == "" {
+		return workflowconfig.AutoPromoteGateWaitStateSource
+	}
+	return state
+}
+
+func doctorAutoPromoteInvalidWorkpadStatusCandidates(candidates []doctorAutoPromoteCandidateDiagnostic) []doctorAutoPromoteCandidateDiagnostic {
+	out := []doctorAutoPromoteCandidateDiagnostic{}
+	for _, candidate := range candidates {
+		if candidate.Reason == string(orchestrator.AutoPromoteReasonWorkpadStatusInvalid) {
+			out = append(out, candidate)
+		}
+	}
+	return out
 }
 
 func doctorHydrateAutoPromoteWorkpad(
@@ -553,6 +605,9 @@ func doctorAutoPromoteCandidateSummary(candidate doctorAutoPromoteCandidateDiagn
 	}
 	if candidate.WorkpadSignalSource != "" {
 		parts = append(parts, "workpad_signal_source="+candidate.WorkpadSignalSource)
+	}
+	if candidate.WorkpadCommentURL != "" {
+		parts = append(parts, "workpad_comment_url="+candidate.WorkpadCommentURL)
 	}
 	if candidate.WorkpadStatusInvalid != "" {
 		parts = append(parts, "workpad_status_invalid="+candidate.WorkpadStatusInvalid)

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -119,13 +119,24 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 
-	checks := []doctorCheck{
-		{
-			Name:   workflowCheckName,
-			Status: doctorOK,
-			Detail: doctorWorkflowDetail(project.Workflow, project, workflow.Config),
-		},
+	workflowCheck := doctorCheck{
+		Name:   workflowCheckName,
+		Status: doctorOK,
+		Detail: doctorWorkflowDetail(project.Workflow, project, workflow.Config),
 	}
+	if workflowPath, err := doctorWorkflowOptimizationWorkflowPath(project); err == nil {
+		findings := doctorReviewFlowWorkflowFindings(id, workflowPath, workflow.Config, workflow.Prompt)
+		if len(findings) > 0 {
+			workflowCheck.Status = doctorWarn
+			workflowCheck.Detail += "; review-flow prose mismatch: " + doctorWorkflowFindingDetails(findings)
+			workflowCheck.Hint = "Align WORKFLOW.md handoff prose with the configured review-flow choice, or adjust the frontmatter if the configured choice is not intended."
+			workflowCheck.WorkflowOptimization = doctorWorkflowOptimizationReport{
+				Findings:  findings,
+				Proposals: doctorWorkflowProposalsForFindings(id, findings, 1),
+			}
+		}
+	}
+	checks := []doctorCheck{workflowCheck}
 	setDoctorCurrentCheck("Project " + id + " pinned route models")
 	checks = append(checks, checkDoctorRouteModels(ctx, id, project, workflow.Config, deps))
 	if workflow.Config.Agent.AutoPromote.Enabled {
@@ -323,8 +334,19 @@ func doctorWorkflowDetail(path string, project globalconfig.Project, cfg workflo
 	if cfg.Identity.Configured() {
 		details = append(details, "identity "+doctorIdentityDetail(cfg.Identity))
 	}
+	details = append(details, doctorReviewFlowConfigDetail(cfg))
 	details = append(details, doctorAuthorizationDetail(project, cfg))
 	return strings.Join(details, "; ")
+}
+
+func doctorWorkflowFindingDetails(findings []doctorWorkflowOptimizationFinding) string {
+	parts := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		if strings.TrimSpace(finding.Detail) != "" {
+			parts = append(parts, finding.Detail)
+		}
+	}
+	return strings.Join(parts, "; ")
 }
 
 func doctorIdentityDetail(identity workflowconfig.Identity) string {

--- a/internal/cli/doctor_self_improvement.go
+++ b/internal/cli/doctor_self_improvement.go
@@ -127,6 +127,19 @@ func doctorWorkflowImprovementProposals(
 	return out, nil
 }
 
+func doctorWorkflowProposalsForFindings(projectID string, findings []doctorWorkflowOptimizationFinding, threshold int) []doctorWorkflowImprovementProposal {
+	proposals := doctorWorkflowImprovementProposalsFromFindings(projectID, findings, threshold)
+	out := make([]doctorWorkflowImprovementProposal, 0, len(proposals))
+	for _, proposal := range proposals {
+		proposal = doctorWorkflowFinalizeProposal(proposal)
+		if proposal.ID == "" {
+			continue
+		}
+		out = append(out, proposal)
+	}
+	return out
+}
+
 func doctorWorkflowImprovementProposalsFromFindings(projectID string, findings []doctorWorkflowOptimizationFinding, threshold int) []doctorWorkflowImprovementProposal {
 	proposals := []doctorWorkflowImprovementProposal{}
 	for _, finding := range findings {
@@ -223,6 +236,12 @@ func doctorWorkflowFindingSignalCount(finding doctorWorkflowOptimizationFinding)
 		return int(anyInt64(finding.Evidence["empty_model_recent_sessions"]))
 	case doctorWorkflowRuleSchedulerSkipRate:
 		return int(anyInt64(finding.Evidence["scheduler_skipped_decisions"]))
+	case doctorWorkflowRuleInvalidWorkpadStatusRecurrence:
+		return int(anyInt64(finding.Evidence["invalid_workpad_status_decisions"]))
+	case doctorWorkflowRuleReviewFlowBehaviorMismatch:
+		return int(anyInt64(finding.Evidence["review_entry_count"]))
+	case doctorWorkflowRuleReviewFlowProseMismatch:
+		return int(anyInt64(finding.Evidence["matching_phrase_count"]))
 	case doctorWorkflowRuleRunawaySessionTokens:
 		return int(anyInt64(finding.Evidence["session_count"]))
 	default:
@@ -245,8 +264,26 @@ func doctorWorkflowFindingProposalTarget(finding doctorWorkflowOptimizationFindi
 		return "prompt", "", "Tighten the agent prompt or telemetry capture path so every session records the effective model."
 	case doctorWorkflowRuleBudgetEstimateDrift:
 		return "workflow", "budget", "Review budget estimates against observed p90 billable session tokens and update workflow budget guidance if humans approve."
+	case doctorWorkflowRuleInvalidWorkpadStatusRecurrence:
+		return "workflow", "detent-status", "Update WORKFLOW.md Workpad status instructions so agents use only `in_progress`, `blocked`, or `complete` in the `detent-status` block."
+	case doctorWorkflowRuleReviewFlowBehaviorMismatch:
+		return doctorWorkflowReviewFlowProposalTarget(finding)
+	case doctorWorkflowRuleReviewFlowProseMismatch:
+		return doctorWorkflowReviewFlowProposalTarget(finding)
 	default:
 		return "workflow", "", "Review this repeated doctor finding and propose a WORKFLOW.md, prompt, skill, or gate update for human approval."
+	}
+}
+
+func doctorWorkflowReviewFlowProposalTarget(finding doctorWorkflowOptimizationFinding) (string, string, string) {
+	choice := strings.TrimSpace(fmt.Sprint(finding.Evidence["review_flow"]))
+	switch choice {
+	case doctorReviewFlowAutopilot:
+		return "workflow", "WORKFLOW.md", "Align WORKFLOW.md with configured autopilot: keep completed work in the active state, set `detent-status` to `complete`, and let Detent promote on the configured gate."
+	case doctorReviewFlowReviewGate:
+		return "workflow", "WORKFLOW.md", "Align WORKFLOW.md with configured review-gate: route completed work through the configured review state and remove prose that promises direct review-state skipping."
+	default:
+		return "workflow", "WORKFLOW.md", "Align WORKFLOW.md handoff prose with the configured review-flow frontmatter after human review."
 	}
 }
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -442,6 +442,20 @@ func TestCheckDoctorProjectWorkflowReportsReviewFlowChoiceAndProseMismatch(t *te
 			wantDetail: []string{"review-flow=autopilot", "review-flow prose mismatch", "instructs agents to enter the review state"},
 		},
 		{
+			name: "autopilot contradicted by custom review state prose",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorWorkflow("/repo")
+				cfg.Agent.AutoPromote.Enabled = true
+				cfg.Agent.AutoPromote.QuietSeconds = 0
+				cfg.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
+				cfg.Agent.AutoPromote.SourceState = "Review"
+				return cfg
+			}(),
+			prompt:     "When complete, move the work item to `Review`.",
+			wantStatus: doctorWarn,
+			wantDetail: []string{"review-flow=autopilot", "review-flow prose mismatch", "instructs agents to enter the review state"},
+		},
+		{
 			name:       "review gate clean",
 			cfg:        validDoctorWorkflow("/repo"),
 			prompt:     "When complete, move the issue to `Human Review` for approval.",
@@ -452,6 +466,18 @@ func TestCheckDoctorProjectWorkflowReportsReviewFlowChoiceAndProseMismatch(t *te
 			name:       "review gate contradicted by direct promotion prose",
 			cfg:        validDoctorWorkflow("/repo"),
 			prompt:     "Do not move the issue to Human Review; Detent promotes the issue directly to `Merging`.",
+			wantStatus: doctorWarn,
+			wantDetail: []string{"review-flow=review-gate", "review-flow prose mismatch", "promises direct review-state skipping"},
+		},
+		{
+			name: "review gate contradicted by custom direct promotion prose",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorWorkflow("/repo")
+				cfg.Agent.AutoPromote.SourceState = "Review"
+				cfg.Agent.AutoPromote.PassState = "Done"
+				return cfg
+			}(),
+			prompt:     "Never move the issue to Review; promote directly to `Done`.",
 			wantStatus: doctorWarn,
 			wantDetail: []string{"review-flow=review-gate", "review-flow prose mismatch", "promises direct review-state skipping"},
 		},

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -405,6 +405,93 @@ func TestCheckDoctorProjects(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorProjectWorkflowReportsReviewFlowChoiceAndProseMismatch(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        workflowconfig.Config
+		prompt     string
+		wantStatus doctorStatus
+		wantDetail []string
+	}{
+		{
+			name: "autopilot clean",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorWorkflow("/repo")
+				cfg.Agent.AutoPromote.Enabled = true
+				cfg.Agent.AutoPromote.QuietSeconds = 0
+				cfg.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
+				return cfg
+			}(),
+			prompt:     "When complete, keep the issue in In Progress and set `detent-status` to `complete`.",
+			wantStatus: doctorOK,
+			wantDetail: []string{"review-flow=autopilot"},
+		},
+		{
+			name: "autopilot contradicted by review prose",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorWorkflow("/repo")
+				cfg.Agent.AutoPromote.Enabled = true
+				cfg.Agent.AutoPromote.QuietSeconds = 0
+				cfg.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
+				return cfg
+			}(),
+			prompt:     "When complete, move the issue to `Human Review`.",
+			wantStatus: doctorWarn,
+			wantDetail: []string{"review-flow=autopilot", "review-flow prose mismatch", "instructs agents to enter the review state"},
+		},
+		{
+			name:       "review gate clean",
+			cfg:        validDoctorWorkflow("/repo"),
+			prompt:     "When complete, move the issue to `Human Review` for approval.",
+			wantStatus: doctorOK,
+			wantDetail: []string{"review-flow=review-gate"},
+		},
+		{
+			name:       "review gate contradicted by direct promotion prose",
+			cfg:        validDoctorWorkflow("/repo"),
+			prompt:     "Do not move the issue to Human Review; Detent promotes the issue directly to `Merging`.",
+			wantStatus: doctorWarn,
+			wantDetail: []string{"review-flow=review-gate", "review-flow prose mismatch", "promises direct review-state skipping"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checks := checkDoctorProject(context.Background(), globalconfig.Project{
+				ID:       "alpha",
+				Workflow: "WORKFLOW.md",
+				Workdir:  "/repo",
+			}, doctorDeps{
+				loadWorkflow: func(string) (workflowconfig.Workflow, error) {
+					return workflowconfig.Workflow{Config: tt.cfg, Prompt: tt.prompt}, nil
+				},
+				gitWorkTree: func(context.Context, string) error {
+					return nil
+				},
+			}, RuntimeSecret{}, false)
+			if len(checks) == 0 {
+				t.Fatal("checks len = 0, want workflow check")
+			}
+			got := checks[0]
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.wantStatus, got)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+			if tt.wantStatus == doctorWarn && len(got.WorkflowOptimization.Proposals) == 0 {
+				t.Fatalf("WorkflowOptimization.Proposals len = 0, want governed proposal: %#v", got.WorkflowOptimization)
+			}
+		})
+	}
+}
+
 func TestCheckDoctorConfigReload(t *testing.T) {
 	t.Parallel()
 
@@ -516,7 +603,7 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 			name:        "disabled",
 			cfg:         validDoctorWorkflow("/repo"),
 			want:        doctorOK,
-			wantDetails: []string{"disabled"},
+			wantDetails: []string{"review-flow=review-gate", "auto_promote.enabled=false"},
 		},
 		{
 			name: "human review observed state is not required",
@@ -617,6 +704,46 @@ func TestCheckDoctorAutoPromote(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCheckDoctorAutoPromoteWarnsOnInvalidWorkpadStatus(t *testing.T) {
+	t.Parallel()
+
+	cfg := validDoctorAutoPromoteWorkflow()
+	issue := doctorAutoPromoteIssue("issue-invalid-status", &connector.PullRequest{
+		Number:         981,
+		URL:            "https://github.test/pull/981",
+		State:          "OPEN",
+		HeadSHA:        "head-invalid",
+		MergeableState: "clean",
+		CIStatus:       "success",
+	})
+	issue.Comments = []connector.IssueComment{{
+		URL:  "https://github.test/digitaldrywood/detent/issues/981#issuecomment-1",
+		Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: human-review\nblockers: []\nhuman_action: null\n```",
+	}}
+
+	got := checkDoctorAutoPromote(context.Background(), "alpha", cfg, doctorDeps{
+		autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
+			return &fakeDoctorAutoPromoteConnector{issues: []connector.Issue{issue}}, nil
+		},
+	}, time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC))
+
+	if got.Status != doctorWarn {
+		t.Fatalf("Status = %s, want %s: %#v", got.Status, doctorWarn, got)
+	}
+	for _, want := range []string{
+		`workpad_status_invalid=status "human-review"`,
+		"workpad_comment_url=https://github.test/digitaldrywood/detent/issues/981#issuecomment-1",
+		"one of in_progress, blocked, or complete",
+	} {
+		if !strings.Contains(got.Detail, want) && !strings.Contains(got.Hint, want) {
+			t.Fatalf("check missing %q:\nDetail: %s\nHint: %s", want, got.Detail, got.Hint)
+		}
+	}
+	if len(got.AutoPromoteCandidates) != 1 || !strings.Contains(got.AutoPromoteCandidates[0].WorkpadStatusInvalid, `"human-review"`) {
+		t.Fatalf("AutoPromoteCandidates = %#v, want invalid status diagnostic", got.AutoPromoteCandidates)
 	}
 }
 

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -976,19 +976,11 @@ func doctorReviewFlowWorkflowFindings(projectID string, workflowPath string, cfg
 		return nil
 	}
 	choice := doctorReviewFlowChoice(cfg)
+	reviewState := doctorReviewFlowConfiguredState(cfg.Agent.AutoPromote.SourceState, "Human Review")
+	passState := doctorReviewFlowConfiguredState(cfg.Agent.AutoPromote.PassState, "Merging")
 	switch choice {
 	case doctorReviewFlowAutopilot:
-		phrases := doctorReviewFlowPhraseMatches(prompt, []string{
-			"move the issue to `human review`",
-			"move the issue to human review",
-			"move it to `human review`",
-			"move it to human review",
-			"move the card to `human review`",
-			"move the card to human review",
-			"move back to `human review`",
-			"move back to human review",
-			"detent:human-review",
-		})
+		phrases := doctorReviewFlowPhraseMatches(prompt, doctorReviewFlowEnterReviewPhrases(reviewState))
 		if phrases == 0 {
 			return nil
 		}
@@ -998,7 +990,7 @@ func doctorReviewFlowWorkflowFindings(projectID string, workflowPath string, cfg
 			0,
 			map[string]any{
 				"review_flow":           choice,
-				"review_state":          cfg.Agent.AutoPromote.SourceState,
+				"review_state":          reviewState,
 				"matching_phrase_count": int64(phrases),
 				"auto_promote_enabled":  cfg.Agent.AutoPromote.Enabled,
 				"quiet_seconds":         cfg.Agent.AutoPromote.QuietSeconds,
@@ -1006,22 +998,10 @@ func doctorReviewFlowWorkflowFindings(projectID string, workflowPath string, cfg
 			},
 		)}
 	case doctorReviewFlowReviewGate:
-		phrases := doctorReviewFlowPhraseMatches(prompt, []string{
-			"do not move it to `human review`",
-			"do not move it to human review",
-			"do not move the issue to `human review`",
-			"do not move the issue to human review",
-			"never move the issue to `human review`",
-			"never move the issue to human review",
-			"leave the issue in `in progress`",
-			"leave the issue in in progress",
-			"promotes the issue directly to `merging`",
-			"promotes the issue directly to merging",
-			"promote directly to `merging`",
-			"promote directly to merging",
-			"skips `human review`",
-			"skips human review",
-		})
+		phrases := doctorReviewFlowPhraseMatches(prompt, append(
+			doctorReviewFlowSkipReviewPhrases(reviewState),
+			doctorReviewFlowDirectPromotePhrases(passState)...,
+		))
 		if phrases == 0 {
 			return nil
 		}
@@ -1031,7 +1011,8 @@ func doctorReviewFlowWorkflowFindings(projectID string, workflowPath string, cfg
 			0,
 			map[string]any{
 				"review_flow":           choice,
-				"review_state":          cfg.Agent.AutoPromote.SourceState,
+				"review_state":          reviewState,
+				"pass_state":            passState,
 				"matching_phrase_count": int64(phrases),
 				"auto_promote_enabled":  cfg.Agent.AutoPromote.Enabled,
 				"quiet_seconds":         cfg.Agent.AutoPromote.QuietSeconds,
@@ -1041,6 +1022,97 @@ func doctorReviewFlowWorkflowFindings(projectID string, workflowPath string, cfg
 	default:
 		return nil
 	}
+}
+
+func doctorReviewFlowConfiguredState(value string, fallback string) string {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		return fallback
+	}
+	return value
+}
+
+func doctorReviewFlowEnterReviewPhrases(reviewState string) []string {
+	phrases := []string{}
+	for _, state := range doctorReviewFlowStatePhraseVariants(reviewState) {
+		phrases = append(phrases,
+			"move the issue to "+state,
+			"move this issue to "+state,
+			"move it to "+state,
+			"move the card to "+state,
+			"move the work item to "+state,
+			"move back to "+state,
+		)
+	}
+	if label := doctorReviewFlowStateLabel(reviewState); label != "" {
+		phrases = append(phrases, "detent:"+label)
+	}
+	return phrases
+}
+
+func doctorReviewFlowSkipReviewPhrases(reviewState string) []string {
+	phrases := []string{
+		"leave the issue in `in progress`",
+		"leave the issue in in progress",
+	}
+	for _, state := range doctorReviewFlowStatePhraseVariants(reviewState) {
+		phrases = append(phrases,
+			"do not move it to "+state,
+			"do not move the issue to "+state,
+			"do not move the work item to "+state,
+			"never move the issue to "+state,
+			"never move the work item to "+state,
+			"skips "+state,
+			"skip "+state,
+		)
+	}
+	return phrases
+}
+
+func doctorReviewFlowDirectPromotePhrases(passState string) []string {
+	phrases := []string{}
+	for _, state := range doctorReviewFlowStatePhraseVariants(passState) {
+		phrases = append(phrases,
+			"promotes the issue directly to "+state,
+			"promote the issue directly to "+state,
+			"promotes the work item directly to "+state,
+			"promote the work item directly to "+state,
+			"promote directly to "+state,
+		)
+	}
+	return phrases
+}
+
+func doctorReviewFlowStatePhraseVariants(state string) []string {
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return nil
+	}
+	return []string{"`" + state + "`", state}
+}
+
+func doctorReviewFlowStateLabel(state string) string {
+	state = strings.ToLower(strings.Join(strings.Fields(state), "-"))
+	state = strings.TrimSpace(state)
+	if state == "" {
+		return ""
+	}
+	var b strings.Builder
+	lastHyphen := false
+	for _, r := range state {
+		switch {
+		case r >= 'a' && r <= 'z':
+			b.WriteRune(r)
+			lastHyphen = false
+		case r >= '0' && r <= '9':
+			b.WriteRune(r)
+			lastHyphen = false
+		case r == '-' && !lastHyphen:
+			b.WriteRune(r)
+			lastHyphen = true
+		}
+	}
+	return strings.Trim(b.String(), "-")
 }
 
 func doctorReviewFlowPhraseMatches(text string, phrases []string) int {

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -29,28 +29,33 @@ import (
 const (
 	doctorWorkflowOptimizationCheckName = "Workflow optimization"
 
-	doctorWorkflowRuleRunawaySessionTokens     = "runaway_session_tokens"
-	doctorWorkflowRuleReworkLaps               = "rework_laps"
-	doctorWorkflowRuleValidatorModel           = "validator_model"
-	doctorWorkflowRuleEmptyModelTelemetry      = "empty_model_telemetry"
-	doctorWorkflowRulePinnedRouteModelRejected = "pinned_route_model_rejected"
-	doctorWorkflowRuleBudgetEstimateDrift      = "budget_estimate_drift"
-	doctorWorkflowRuleSchedulerSkipRate        = "scheduler_skip_rate"
+	doctorWorkflowRuleRunawaySessionTokens           = "runaway_session_tokens"
+	doctorWorkflowRuleReworkLaps                     = "rework_laps"
+	doctorWorkflowRuleValidatorModel                 = "validator_model"
+	doctorWorkflowRuleEmptyModelTelemetry            = "empty_model_telemetry"
+	doctorWorkflowRulePinnedRouteModelRejected       = "pinned_route_model_rejected"
+	doctorWorkflowRuleBudgetEstimateDrift            = "budget_estimate_drift"
+	doctorWorkflowRuleSchedulerSkipRate              = "scheduler_skip_rate"
+	doctorWorkflowRuleInvalidWorkpadStatusRecurrence = "invalid_workpad_status_recurrence"
+	doctorWorkflowRuleReviewFlowBehaviorMismatch     = "review_flow_behavior_mismatch"
+	doctorWorkflowRuleReviewFlowProseMismatch        = "review_flow_prose_mismatch"
 
-	doctorWorkflowRunawayMedianMultiplier = 4.0
-	doctorWorkflowReworkLapThreshold      = 1
-	doctorWorkflowRecentSessionLimit      = 50
-	doctorWorkflowRecentSessionWindow     = 24 * time.Hour
-	doctorWorkflowEmptyModelMinFraction   = 0.20
-	doctorWorkflowBudgetEstimateInput     = int64(150_000)
-	doctorWorkflowBudgetEstimateOutput    = int64(20_000)
-	doctorWorkflowBudgetEstimateTotal     = doctorWorkflowBudgetEstimateInput + doctorWorkflowBudgetEstimateOutput
-	doctorWorkflowBudgetEstimateBillable  = doctorWorkflowBudgetEstimateInput + doctorWorkflowBudgetEstimateOutput
-	doctorWorkflowBudgetDriftRatio        = 1.50
-	doctorWorkflowSchedulerMinDecisions   = int64(5)
-	doctorWorkflowSchedulerHighSkipRate   = 0.50
-	doctorWorkflowValidatorModel          = "gpt-5.4-mini"
-	doctorWorkflowRunawayCapTolerance     = 1.25
+	doctorWorkflowRunawayMedianMultiplier      = 4.0
+	doctorWorkflowReworkLapThreshold           = 1
+	doctorWorkflowRecentSessionLimit           = 50
+	doctorWorkflowRecentSessionWindow          = 24 * time.Hour
+	doctorWorkflowEmptyModelMinFraction        = 0.20
+	doctorWorkflowBudgetEstimateInput          = int64(150_000)
+	doctorWorkflowBudgetEstimateOutput         = int64(20_000)
+	doctorWorkflowBudgetEstimateTotal          = doctorWorkflowBudgetEstimateInput + doctorWorkflowBudgetEstimateOutput
+	doctorWorkflowBudgetEstimateBillable       = doctorWorkflowBudgetEstimateInput + doctorWorkflowBudgetEstimateOutput
+	doctorWorkflowBudgetDriftRatio             = 1.50
+	doctorWorkflowSchedulerMinDecisions        = int64(5)
+	doctorWorkflowSchedulerHighSkipRate        = 0.50
+	doctorWorkflowReviewFlowMismatchMinEntries = int64(2)
+	doctorWorkflowInvalidWorkpadStatusMinCount = int64(2)
+	doctorWorkflowValidatorModel               = "gpt-5.4-mini"
+	doctorWorkflowRunawayCapTolerance          = 1.25
 )
 
 var errDoctorTelemetryStoreUnavailable = errors.New("telemetry store unavailable")
@@ -110,6 +115,12 @@ type doctorWorkflowOptimizationMetrics struct {
 	P90SessionBillableTokens         int64   `json:"p90_session_billable_tokens"`
 	BudgetEstimateBillableDriftRatio float64 `json:"budget_estimate_billable_drift_ratio"`
 	BudgetEstimateDriftRatio         float64 `json:"budget_estimate_drift_ratio"`
+	ReviewEntryCount                 int64   `json:"review_entry_count"`
+	ReviewEntryIssue                 string  `json:"review_entry_issue,omitempty"`
+	ReviewEntryIssueCount            int64   `json:"review_entry_issue_count"`
+	InvalidWorkpadStatusDecisions    int64   `json:"invalid_workpad_status_decisions"`
+	InvalidWorkpadStatusIssue        string  `json:"invalid_workpad_status_issue,omitempty"`
+	InvalidWorkpadStatusIssueCount   int64   `json:"invalid_workpad_status_issue_count"`
 }
 
 type doctorWorkflowOptimizationFinding struct {
@@ -162,6 +173,25 @@ type doctorWorkflowLaneMetrics struct {
 type doctorWorkflowSchedulerMetrics struct {
 	count   int64
 	skipped int64
+}
+
+type doctorWorkflowReviewFlowMetrics struct {
+	reviewEntryCount               int64
+	reviewEntryIssue               string
+	reviewEntryIssueCount          int64
+	invalidWorkpadStatusDecisions  int64
+	invalidWorkpadStatusIssue      string
+	invalidWorkpadStatusIssueCount int64
+}
+
+type doctorWorkflowCompletedSession struct {
+	issueKey    string
+	completedAt time.Time
+}
+
+type doctorWorkflowReviewEntryEvent struct {
+	issueKey  string
+	startedAt time.Time
 }
 
 func (r *doctorWorkflowOptimizationReport) Merge(next doctorWorkflowOptimizationReport) {
@@ -370,31 +400,41 @@ func doctorWorkflowOptimizationMetricsForProject(
 	if err != nil {
 		return doctorWorkflowOptimizationMetrics{}, err
 	}
+	reviewFlow, err := doctorWorkflowReviewFlowTelemetry(ctx, db, projectID, cfg.Agent.AutoPromote.SourceState)
+	if err != nil {
+		return doctorWorkflowOptimizationMetrics{}, err
+	}
 
 	metrics := doctorWorkflowOptimizationMetrics{
-		SessionCount:                 sessions.count,
-		UsageEventCount:              usage.count,
-		InputTokens:                  sessions.inputTokens,
-		CachedInputTokens:            sessions.cachedInputTokens,
-		OutputTokens:                 sessions.outputTokens,
-		TotalTokens:                  sessions.totalTokens,
-		MedianSessionTokens:          doctorPercentileInt64(sessions.totalTokensBySession, 0.50),
-		P90SessionTokens:             doctorPercentileInt64(sessions.totalTokensBySession, 0.90),
-		P90SessionBillableTokens:     doctorPercentileInt64(sessions.billableTokensBySession, 0.90),
-		MaxSessionTokens:             doctorMaxInt64(sessions.totalTokensBySession),
-		RecentSessionCount:           sessions.recentSessionCount,
-		EmptyModelRecentSessions:     sessions.emptyModelRecentSessions,
-		MaxSessionsPerIssue:          doctorMaxMapValue(sessions.issueSessionCounts),
-		MaxSessionsIssue:             doctorMaxMapKey(sessions.issueSessionCounts),
-		FailureTokens:                sessions.failureTokens,
-		SchedulerDecisionCount:       scheduler.count,
-		SchedulerSkippedDecisions:    scheduler.skipped,
-		LaneEventCount:               lanes.count,
-		LaneDwellP90Seconds:          doctorPercentileInt64(lanes.durations, 0.90),
-		MaxReworkLapsPerIssue:        doctorMaxMapValue(lanes.reworkLaps),
-		MaxReworkLapsIssue:           doctorMaxMapKey(lanes.reworkLaps),
-		BudgetEstimateTokens:         doctorWorkflowBudgetEstimateTotal,
-		BudgetEstimateBillableTokens: doctorWorkflowBudgetEstimateBillable,
+		SessionCount:                   sessions.count,
+		UsageEventCount:                usage.count,
+		InputTokens:                    sessions.inputTokens,
+		CachedInputTokens:              sessions.cachedInputTokens,
+		OutputTokens:                   sessions.outputTokens,
+		TotalTokens:                    sessions.totalTokens,
+		MedianSessionTokens:            doctorPercentileInt64(sessions.totalTokensBySession, 0.50),
+		P90SessionTokens:               doctorPercentileInt64(sessions.totalTokensBySession, 0.90),
+		P90SessionBillableTokens:       doctorPercentileInt64(sessions.billableTokensBySession, 0.90),
+		MaxSessionTokens:               doctorMaxInt64(sessions.totalTokensBySession),
+		RecentSessionCount:             sessions.recentSessionCount,
+		EmptyModelRecentSessions:       sessions.emptyModelRecentSessions,
+		MaxSessionsPerIssue:            doctorMaxMapValue(sessions.issueSessionCounts),
+		MaxSessionsIssue:               doctorMaxMapKey(sessions.issueSessionCounts),
+		FailureTokens:                  sessions.failureTokens,
+		SchedulerDecisionCount:         scheduler.count,
+		SchedulerSkippedDecisions:      scheduler.skipped,
+		LaneEventCount:                 lanes.count,
+		LaneDwellP90Seconds:            doctorPercentileInt64(lanes.durations, 0.90),
+		MaxReworkLapsPerIssue:          doctorMaxMapValue(lanes.reworkLaps),
+		MaxReworkLapsIssue:             doctorMaxMapKey(lanes.reworkLaps),
+		BudgetEstimateTokens:           doctorWorkflowBudgetEstimateTotal,
+		BudgetEstimateBillableTokens:   doctorWorkflowBudgetEstimateBillable,
+		ReviewEntryCount:               reviewFlow.reviewEntryCount,
+		ReviewEntryIssue:               reviewFlow.reviewEntryIssue,
+		ReviewEntryIssueCount:          reviewFlow.reviewEntryIssueCount,
+		InvalidWorkpadStatusDecisions:  reviewFlow.invalidWorkpadStatusDecisions,
+		InvalidWorkpadStatusIssue:      reviewFlow.invalidWorkpadStatusIssue,
+		InvalidWorkpadStatusIssueCount: reviewFlow.invalidWorkpadStatusIssueCount,
 	}
 	if usage.count > 0 {
 		metrics.InputTokens = usage.inputTokens
@@ -413,6 +453,176 @@ func doctorWorkflowOptimizationMetricsForProject(
 		metrics.BudgetEstimateDriftRatio = metrics.BudgetEstimateBillableDriftRatio
 	}
 	return metrics, nil
+}
+
+func doctorWorkflowReviewFlowTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string) (doctorWorkflowReviewFlowMetrics, error) {
+	sessions, err := doctorWorkflowCompletedSessionTelemetry(ctx, db, projectID, reviewState)
+	if err != nil {
+		return doctorWorkflowReviewFlowMetrics{}, err
+	}
+	entries, err := doctorWorkflowReviewEntryTelemetry(ctx, db, projectID, reviewState)
+	if err != nil {
+		return doctorWorkflowReviewFlowMetrics{}, err
+	}
+	metrics := doctorWorkflowReviewFlowMetrics{}
+	reviewEntryCounts := map[string]int64{}
+	for _, entry := range entries {
+		if !doctorWorkflowReviewEntryFollowsCompletedSession(entry, sessions[entry.issueKey]) {
+			continue
+		}
+		reviewEntryCounts[entry.issueKey]++
+		metrics.reviewEntryCount++
+	}
+	metrics.reviewEntryIssue = doctorMaxMapKey(reviewEntryCounts)
+	metrics.reviewEntryIssueCount = doctorMaxMapValue(reviewEntryCounts)
+
+	invalidCounts, err := doctorWorkflowInvalidWorkpadStatusTelemetry(ctx, db, projectID)
+	if err != nil {
+		return doctorWorkflowReviewFlowMetrics{}, err
+	}
+	for _, count := range invalidCounts {
+		metrics.invalidWorkpadStatusDecisions += count
+	}
+	metrics.invalidWorkpadStatusIssue = doctorMaxMapKey(invalidCounts)
+	metrics.invalidWorkpadStatusIssueCount = doctorMaxMapValue(invalidCounts)
+	return metrics, nil
+}
+
+func doctorWorkflowCompletedSessionTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string) (map[string][]doctorWorkflowCompletedSession, error) {
+	reviewState = strings.ToLower(strings.TrimSpace(reviewState))
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  COALESCE(NULLIF(s.identifier, ''), NULLIF(s.issue_id, ''), NULLIF(s.issue_url, ''), 'unassigned'),
+  COALESCE(s.completed_at, '')
+FROM codex_sessions s
+WHERE s.completed_at IS NOT NULL
+  AND lower(trim(COALESCE(s.final_state, ''))) IN ('completed', ?)
+  AND (
+    ? = ''
+    OR s.id IN (
+      SELECT DISTINCT session_id
+      FROM usage_events
+      WHERE session_id IS NOT NULL
+        AND project_id = ?
+    )
+  )
+ORDER BY s.completed_at DESC, s.id DESC
+LIMIT 500`, reviewState, projectID, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("read completed session review-flow telemetry: %w", err)
+	}
+	defer rows.Close()
+
+	sessions := map[string][]doctorWorkflowCompletedSession{}
+	for rows.Next() {
+		var issueKey string
+		var completedAtRaw string
+		if err := rows.Scan(&issueKey, &completedAtRaw); err != nil {
+			return nil, err
+		}
+		completedAt, err := doctorWorkflowSessionTimestamp(completedAtRaw)
+		if err != nil {
+			return nil, err
+		}
+		issueKey = strings.TrimSpace(issueKey)
+		sessions[issueKey] = append(sessions[issueKey], doctorWorkflowCompletedSession{
+			issueKey:    issueKey,
+			completedAt: completedAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return sessions, nil
+}
+
+func doctorWorkflowReviewEntryTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, reviewState string) ([]doctorWorkflowReviewEntryEvent, error) {
+	reviewState = strings.ToLower(strings.TrimSpace(reviewState))
+	if reviewState == "" {
+		reviewState = "human review"
+	}
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned'),
+  COALESCE(started_at, '')
+FROM workflow_phase_events
+WHERE phase_type = 'lane'
+  AND lower(trim(COALESCE(status, ''))) = 'entered'
+  AND lower(trim(phase_name)) = ?
+  AND (? = '' OR project_id = ?)
+ORDER BY started_at DESC, id DESC
+LIMIT 500`, reviewState, projectID, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("read review-state entry telemetry: %w", err)
+	}
+	defer rows.Close()
+
+	entries := []doctorWorkflowReviewEntryEvent{}
+	for rows.Next() {
+		var issueKey string
+		var startedAtRaw string
+		if err := rows.Scan(&issueKey, &startedAtRaw); err != nil {
+			return nil, err
+		}
+		startedAt, err := doctorWorkflowSessionTimestamp(startedAtRaw)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, doctorWorkflowReviewEntryEvent{
+			issueKey:  strings.TrimSpace(issueKey),
+			startedAt: startedAt,
+		})
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func doctorWorkflowReviewEntryFollowsCompletedSession(entry doctorWorkflowReviewEntryEvent, sessions []doctorWorkflowCompletedSession) bool {
+	for _, session := range sessions {
+		if session.completedAt.IsZero() || entry.startedAt.IsZero() {
+			continue
+		}
+		if entry.startedAt.Before(session.completedAt) {
+			continue
+		}
+		if entry.startedAt.Sub(session.completedAt) <= 10*time.Minute {
+			return true
+		}
+	}
+	return false
+}
+
+func doctorWorkflowInvalidWorkpadStatusTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) (map[string]int64, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned'),
+  COUNT(*)
+FROM workflow_phase_events
+WHERE phase_type = 'lane'
+  AND lower(trim(COALESCE(status, ''))) = 'entered'
+  AND lower(trim(COALESCE(reason, ''))) = 'workpad_status_invalid'
+  AND (? = '' OR project_id = ?)
+GROUP BY COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned')`, projectID, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("read invalid workpad status telemetry: %w", err)
+	}
+	defer rows.Close()
+
+	counts := map[string]int64{}
+	for rows.Next() {
+		var issueKey string
+		var count int64
+		if err := rows.Scan(&issueKey, &count); err != nil {
+			return nil, err
+		}
+		counts[strings.TrimSpace(issueKey)] = count
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return counts, nil
 }
 
 func doctorWorkflowSessionTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string, pricing budget.PricingTable) (doctorWorkflowSessionMetrics, error) {
@@ -727,7 +937,121 @@ func doctorWorkflowOptimizationFindings(
 			doctorWorkflowOptimizationPatch{Path: "polling.interval_ms", Value: value},
 		))
 	}
+	if doctorReviewFlowChoice(cfg) == doctorReviewFlowAutopilot && metrics.ReviewEntryCount >= doctorWorkflowReviewFlowMismatchMinEntries {
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleReviewFlowBehaviorMismatch,
+			"Review-flow behavior mismatch",
+			fmt.Sprintf("autopilot is configured but completed work entered %s %d times", cfg.Agent.AutoPromote.SourceState, metrics.ReviewEntryCount),
+			0,
+			map[string]any{
+				"review_flow":              doctorReviewFlowAutopilot,
+				"review_state":             cfg.Agent.AutoPromote.SourceState,
+				"review_entry_count":       metrics.ReviewEntryCount,
+				"review_entry_issue":       metrics.ReviewEntryIssue,
+				"review_entry_issue_count": metrics.ReviewEntryIssueCount,
+				"auto_promote_enabled":     cfg.Agent.AutoPromote.Enabled,
+				"quiet_seconds":            cfg.Agent.AutoPromote.QuietSeconds,
+				"gate_wait_state":          doctorReviewFlowGateWaitState(cfg),
+			},
+		))
+	}
+	if metrics.InvalidWorkpadStatusDecisions >= doctorWorkflowInvalidWorkpadStatusMinCount {
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleInvalidWorkpadStatusRecurrence,
+			"Invalid Workpad status recurrence",
+			fmt.Sprintf("auto-promote recorded %d workpad_status_invalid decision(s)", metrics.InvalidWorkpadStatusDecisions),
+			0,
+			map[string]any{
+				"invalid_workpad_status_decisions":   metrics.InvalidWorkpadStatusDecisions,
+				"invalid_workpad_status_issue":       metrics.InvalidWorkpadStatusIssue,
+				"invalid_workpad_status_issue_count": metrics.InvalidWorkpadStatusIssueCount,
+				"review_flow":                        doctorReviewFlowChoice(cfg),
+			},
+		))
+	}
 	return findings
+}
+
+func doctorReviewFlowWorkflowFindings(projectID string, workflowPath string, cfg workflowconfig.Config, prompt string) []doctorWorkflowOptimizationFinding {
+	prompt = strings.TrimSpace(prompt)
+	if prompt == "" {
+		return nil
+	}
+	choice := doctorReviewFlowChoice(cfg)
+	switch choice {
+	case doctorReviewFlowAutopilot:
+		phrases := doctorReviewFlowPhraseMatches(prompt, []string{
+			"move the issue to `human review`",
+			"move the issue to human review",
+			"move it to `human review`",
+			"move it to human review",
+			"move the card to `human review`",
+			"move the card to human review",
+			"move back to `human review`",
+			"move back to human review",
+			"detent:human-review",
+		})
+		if phrases == 0 {
+			return nil
+		}
+		return []doctorWorkflowOptimizationFinding{doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleReviewFlowProseMismatch,
+			"Review-flow prose contradicts autopilot",
+			"autopilot is configured but WORKFLOW.md instructs agents to enter the review state",
+			0,
+			map[string]any{
+				"review_flow":           choice,
+				"review_state":          cfg.Agent.AutoPromote.SourceState,
+				"matching_phrase_count": int64(phrases),
+				"auto_promote_enabled":  cfg.Agent.AutoPromote.Enabled,
+				"quiet_seconds":         cfg.Agent.AutoPromote.QuietSeconds,
+				"gate_wait_state":       doctorReviewFlowGateWaitState(cfg),
+			},
+		)}
+	case doctorReviewFlowReviewGate:
+		phrases := doctorReviewFlowPhraseMatches(prompt, []string{
+			"do not move it to `human review`",
+			"do not move it to human review",
+			"do not move the issue to `human review`",
+			"do not move the issue to human review",
+			"never move the issue to `human review`",
+			"never move the issue to human review",
+			"leave the issue in `in progress`",
+			"leave the issue in in progress",
+			"promotes the issue directly to `merging`",
+			"promotes the issue directly to merging",
+			"promote directly to `merging`",
+			"promote directly to merging",
+			"skips `human review`",
+			"skips human review",
+		})
+		if phrases == 0 {
+			return nil
+		}
+		return []doctorWorkflowOptimizationFinding{doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleReviewFlowProseMismatch,
+			"Review-flow prose contradicts review-gate",
+			"review-gate is configured but WORKFLOW.md promises direct review-state skipping",
+			0,
+			map[string]any{
+				"review_flow":           choice,
+				"review_state":          cfg.Agent.AutoPromote.SourceState,
+				"matching_phrase_count": int64(phrases),
+				"auto_promote_enabled":  cfg.Agent.AutoPromote.Enabled,
+				"quiet_seconds":         cfg.Agent.AutoPromote.QuietSeconds,
+				"gate_wait_state":       doctorReviewFlowGateWaitState(cfg),
+			},
+		)}
+	default:
+		return nil
+	}
+}
+
+func doctorReviewFlowPhraseMatches(text string, phrases []string) int {
+	text = strings.ToLower(strings.Join(strings.Fields(text), " "))
+	count := 0
+	for _, phrase := range phrases {
+		if strings.Contains(text, strings.ToLower(strings.Join(strings.Fields(phrase), " "))) {
+			count++
+		}
+	}
+	return count
 }
 
 func doctorWorkflowFinding(

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -340,6 +341,201 @@ func TestDoctorWorkflowOptimizationFindingsTokenImpactIsAvoidable(t *testing.T) 
 			}
 		})
 	}
+}
+
+func TestDoctorWorkflowOptimizationReviewFlowFindings(t *testing.T) {
+	t.Parallel()
+
+	autopilot := workflowconfig.Default()
+	autopilot.Agent.AutoPromote.Enabled = true
+	autopilot.Agent.AutoPromote.QuietSeconds = 0
+	autopilot.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
+
+	reviewGate := workflowconfig.Default()
+	reviewGate.Agent.AutoPromote.Enabled = true
+	reviewGate.Agent.AutoPromote.QuietSeconds = 600
+	reviewGate.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateReview
+
+	tests := []struct {
+		name      string
+		cfg       workflowconfig.Config
+		metrics   doctorWorkflowOptimizationMetrics
+		wantRules []string
+	}{
+		{
+			name: "autopilot clean",
+			cfg:  autopilot,
+			metrics: doctorWorkflowOptimizationMetrics{
+				ReviewEntryCount: 1,
+			},
+		},
+		{
+			name: "autopilot repeated review entry mismatch",
+			cfg:  autopilot,
+			metrics: doctorWorkflowOptimizationMetrics{
+				ReviewEntryCount:      2,
+				ReviewEntryIssue:      "digitaldrywood/detent#981",
+				ReviewEntryIssueCount: 2,
+			},
+			wantRules: []string{doctorWorkflowRuleReviewFlowBehaviorMismatch},
+		},
+		{
+			name: "review gate review entries are normal",
+			cfg:  reviewGate,
+			metrics: doctorWorkflowOptimizationMetrics{
+				ReviewEntryCount:      3,
+				ReviewEntryIssue:      "digitaldrywood/detent#415",
+				ReviewEntryIssueCount: 3,
+			},
+		},
+		{
+			name: "invalid workpad status recurrence",
+			cfg:  autopilot,
+			metrics: doctorWorkflowOptimizationMetrics{
+				InvalidWorkpadStatusDecisions:  2,
+				InvalidWorkpadStatusIssue:      "digitaldrywood/detent#981",
+				InvalidWorkpadStatusIssueCount: 2,
+			},
+			wantRules: []string{doctorWorkflowRuleInvalidWorkpadStatusRecurrence},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", tt.cfg, tt.metrics)
+			for _, rule := range tt.wantRules {
+				finding := doctorWorkflowFindingByRule(t, findings, rule)
+				if got := finding.Evidence["review_flow"]; got != doctorReviewFlowChoice(tt.cfg) {
+					t.Fatalf("%s review_flow evidence = %#v, want %s", rule, got, doctorReviewFlowChoice(tt.cfg))
+				}
+			}
+			for _, finding := range findings {
+				if finding.RuleID != doctorWorkflowRuleReviewFlowBehaviorMismatch &&
+					finding.RuleID != doctorWorkflowRuleInvalidWorkpadStatusRecurrence {
+					continue
+				}
+				if !slices.Contains(tt.wantRules, finding.RuleID) {
+					t.Fatalf("unexpected review-flow finding %s in %#v", finding.RuleID, findings)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorWorkflowReviewFlowTelemetryCountsImmediateReviewEntries(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	dbPath := filepath.Join(dir, "detent.db")
+	backend, err := store.Open(ctx, store.Config{
+		Backend: store.BackendSQLite,
+		Path:    dbPath,
+	})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+
+	base := time.Date(2026, 7, 9, 16, 0, 0, 0, time.UTC)
+	issue := "digitaldrywood/detent#981"
+	for index := range 2 {
+		startedAt := base.Add(time.Duration(index) * time.Hour)
+		completedAt := startedAt.Add(5 * time.Minute)
+		sessionID, err := backend.StartSession(ctx, store.SessionStart{
+			Identifier: issue,
+			StartedAt:  startedAt,
+			Model:      "gpt-5-codex",
+		})
+		if err != nil {
+			t.Fatalf("StartSession() error = %v", err)
+		}
+		if err := backend.FinishSession(ctx, sessionID, store.SessionFinish{
+			CompletedAt:       completedAt,
+			Turns:             1,
+			InputTokens:       900,
+			CachedInputTokens: 450,
+			OutputTokens:      100,
+			TotalTokens:       1000,
+			RuntimeSeconds:    300,
+			FinalState:        "completed",
+			Model:             "gpt-5-codex",
+		}); err != nil {
+			t.Fatalf("FinishSession() error = %v", err)
+		}
+		if _, err := backend.RecordUsageEvent(ctx, store.UsageEvent{
+			ProjectID:         "detent",
+			SessionID:         sessionID,
+			Identifier:        issue,
+			Model:             "gpt-5-codex",
+			InputTokens:       900,
+			CachedInputTokens: 450,
+			OutputTokens:      100,
+			TotalTokens:       1000,
+			RuntimeSeconds:    300,
+			StartedAt:         startedAt,
+			FinishedAt:        completedAt,
+			Outcome:           "completed",
+		}); err != nil {
+			t.Fatalf("RecordUsageEvent() error = %v", err)
+		}
+		if _, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+			ProjectID:         "detent",
+			Identifier:        issue,
+			PhaseType:         store.WorkflowPhaseTypeLane,
+			PhaseName:         "Human Review",
+			PreviousPhaseName: "In Progress",
+			Status:            "entered",
+			StartedAt:         completedAt.Add(2 * time.Minute),
+			Reason:            "completed_active_review_transition",
+		}); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent(review) error = %v", err)
+		}
+		if _, err := backend.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+			ProjectID:         "detent",
+			Identifier:        issue,
+			PhaseType:         store.WorkflowPhaseTypeLane,
+			PhaseName:         "Rework",
+			PreviousPhaseName: "Human Review",
+			Status:            "entered",
+			StartedAt:         completedAt.Add(4 * time.Minute),
+			Reason:            "workpad_status_invalid",
+		}); err != nil {
+			t.Fatalf("RecordWorkflowPhaseEvent(invalid) error = %v", err)
+		}
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	db, err := openDoctorSQLiteReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+
+	cfg := workflowconfig.Default()
+	cfg.Agent.AutoPromote.Enabled = true
+	cfg.Agent.AutoPromote.QuietSeconds = 0
+	cfg.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
+	metrics, err := doctorWorkflowOptimizationMetricsForProject(ctx, db, "detent", cfg)
+	if err != nil {
+		t.Fatalf("doctorWorkflowOptimizationMetricsForProject() error = %v", err)
+	}
+	if metrics.ReviewEntryCount != 2 || metrics.ReviewEntryIssue != issue {
+		t.Fatalf("review entry metrics = count %d issue %q, want 2/%s", metrics.ReviewEntryCount, metrics.ReviewEntryIssue, issue)
+	}
+	if metrics.InvalidWorkpadStatusDecisions != 2 || metrics.InvalidWorkpadStatusIssue != issue {
+		t.Fatalf("invalid status metrics = count %d issue %q, want 2/%s", metrics.InvalidWorkpadStatusDecisions, metrics.InvalidWorkpadStatusIssue, issue)
+	}
+	findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", cfg, metrics)
+	doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleReviewFlowBehaviorMismatch)
+	doctorWorkflowFindingByRule(t, findings, doctorWorkflowRuleInvalidWorkpadStatusRecurrence)
 }
 
 func TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap(t *testing.T) {


### PR DESCRIPTION
## Summary

- Report each project review-flow choice from auto-promote configuration.
- Flag invalid Workpad status auto-promote diagnostics and review-flow mismatches without prescribing a flow.
- Route review-flow findings into doctor self-improvement proposals.

Fixes #1109

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `go test ./internal/cli`
- [x] `make check`