### PR TITLE
feat(onboarding): surface worker model choice

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1224,9 +1224,20 @@ probes.
    generation. Record the explicit choice and require the model only for a
    pin:
 
+   For the recommended provider default, omit `WORKER_MODEL`:
+
    ```sh
    printf '%s\n' \
-     'WORKER_MODEL_MODE=<provider_default|pinned>' \
+     'WORKER_MODEL_MODE=provider_default' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^WORKER_MODEL' "$ONBOARDING_DIR/answers.env"
+   ```
+
+   For an explicit pin, record both fields:
+
+   ```sh
+   printf '%s\n' \
+     'WORKER_MODEL_MODE=pinned' \
      'WORKER_MODEL=<model-if-pinned>' \
      >> "$ONBOARDING_DIR/answers.env"
    rg '^WORKER_MODEL' "$ONBOARDING_DIR/answers.env"

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1209,7 +1209,34 @@ probes.
    rg '^GATE_' "$ONBOARDING_DIR/answers.env"
    ```
 
-14. **Concurrency.** Ask: "How many agents may this project run at once?"
+   When the validator is enabled, also ask whether it should inherit its
+   route/provider default or deliberately pin a model with `VALIDATOR_MODEL`.
+   Recommend inheritance by default. A validator pin may provide reproducible
+   behavior or cost control, but it must be reviewed and updated before the
+   provider retires that model generation.
+
+14. **Worker model.** Ask: "Should Codex workers follow the provider default,
+   or pin a specific model for this project?" Recommend provider default. It
+   follows generation upgrades automatically, survives model retirements, and
+   still produces accurate model telemetry from the Codex session. A pin is a
+   first-class option for reproducibility or cost control, but it can break
+   dispatch when the provider retires the model and must be reviewed each
+   generation. Record the explicit choice and require the model only for a
+   pin:
+
+   ```sh
+   printf '%s\n' \
+     'WORKER_MODEL_MODE=<provider_default|pinned>' \
+     'WORKER_MODEL=<model-if-pinned>' \
+     >> "$ONBOARDING_DIR/answers.env"
+   rg '^WORKER_MODEL' "$ONBOARDING_DIR/answers.env"
+   ```
+
+   Leave `model_reasoning_effort` unset by default because not every model
+   accepts it. Treat it as an optional per-project Codex config override only
+   after confirming the selected model supports the requested effort.
+
+15. **Concurrency.** Ask: "How many agents may this project run at once?"
    Recommendation source: host capacity, existing `global.yaml` projects, and
    the repo's gate cost. Default if silent: `agent.max_concurrent_agents: 5`
    for an active code repo, lower for expensive gates. State that
@@ -1243,7 +1270,14 @@ probes.
    repository. For multiple instances sharing one board/repo, serialization
    comes from `tracker.claims`, not the per-state cap.
 
-15. **Review policy.** Ask this only for Custom/advanced. If the operator wants
+   Use `MAX_SESSION_TOKENS` as the per-session runaway brake. Codex re-counts
+   cached context on every turn, so do not emit
+   `MAX_SESSION_CONTEXT_MULTIPLIER` by default and do not recommend small
+   values such as `4`. The multiplier is a coarse, advanced opt-in that caps
+   roughly how many full-context turns fit; record it only when the operator
+   explicitly requests that additional ceiling.
+
+16. **Review policy.** Ask this only for Custom/advanced. If the operator wants
    to override a selected profile's `AUTO_PROMOTE_*`, switch to Custom/advanced
    and remove or omit `DELIVERY_PROFILE` before recording the mixed policy:
    "Should Detent hard-stop at `Human Review`, or may it auto-promote to
@@ -1280,7 +1314,7 @@ probes.
    rg '^AUTO_PROMOTE_' "$ONBOARDING_DIR/answers.env"
    ```
 
-16. **Dependency waiting policy.** Ask this only for Custom/advanced. If the
+17. **Dependency waiting policy.** Ask this only for Custom/advanced. If the
    operator wants to override a selected profile's
    `DEPENDENCY_AUTO_UNBLOCK_ENABLED`, switch to Custom/advanced and remove or
    omit `DELIVERY_PROFILE` before recording the mixed policy: "Should
@@ -1307,7 +1341,7 @@ probes.
    rg '^DEPENDENCY_AUTO_UNBLOCK_' "$ONBOARDING_DIR/answers.env"
    ```
 
-17. **Prompt body.** Ask: "Use the template prompt or add repo-specific
+18. **Prompt body.** Ask: "Use the template prompt or add repo-specific
    instructions?" Recommendation source: `CLAUDE.md`, `AGENTS.md`,
    `CONTRIBUTING.md`, README development commands, manifests, and CI workflows
    in `<source-root>`. Default if silent: template prompt plus any repo
@@ -1333,7 +1367,7 @@ probes.
    rg '^PROMPT_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-18. **Issue intake.** Ask: "Which issue filter should be bulk-added, should the
+19. **Issue intake.** Ask: "Which issue filter should be bulk-added, should the
    initial `Status` be `Backlog` or `Todo`, and should the human enable the
    auto-add workflow?" Recommendation source: `$ONBOARDING_DIR/issue-counts.json`
    and the authorization answer. Default if silent: bulk-add the narrowest safe
@@ -1973,7 +2007,28 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    rg -n '^server:|host: <dashboard-host>|port:' <source-root>/WORKFLOW.md
    ```
 
-5. **Set the gate from the interview.** For command gates, include the command,
+5. **Set the worker model from the interview.** Render the explicit answer in
+   `codex.command` and keep the trade-off next to the command. Do not inherit a
+   stale pin from the template:
+
+   ```yaml
+   # WORKER_MODEL_MODE=provider_default
+   codex:
+     # Optional model_reasoning_effort is unset because not every model accepts it.
+     command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
+   ```
+
+   ```yaml
+   # WORKER_MODEL_MODE=pinned and WORKER_MODEL=<model>
+   codex:
+     # Optional model_reasoning_effort is unset because not every model accepts it.
+     command: codex app-server --config 'model="<model>"' # Pinned for reproducibility or cost control; update before retirement.
+   ```
+
+   Add a `model_reasoning_effort` config override only when the operator
+   explicitly requests it and the selected model accepts that setting.
+
+6. **Set the gate from the interview.** For command gates, include the command,
    whether an automated GitHub PR review is required for auto-promotion,
    whether failed current-head CI parks in `Human Review` or routes to
    `Rework`, and whether the validator-agent review is enabled. For human
@@ -1994,8 +2049,8 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      ci_failure_action: <skip|rework>
      validator:
        enabled: <true|false>
-       # Recommended cheap override when enabled: gpt-5.4-mini.
-       # Watch rework-rate per validator model once cache/model telemetry lands.
+       # Optional deliberate pin; leave empty to inherit the route/provider default.
+       # Pinned models require manual updates before provider retirement.
        model: ""
        min_score: 0.8
        max_inline_diff_bytes: 65536
@@ -2072,7 +2127,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    [Local Models With Codex And Ollama](local-models-ollama.md) for model and
    context-window guidance.
 
-6. **Set dispatch ordering, review policy, dependency waiting policy, and
+7. **Set dispatch ordering, review policy, dependency waiting policy, and
    concurrency.** Keep `Merging: 1`. Use the dispatch label ordering, review
    policy, and dependency policy selected by the human. Verify:
 
@@ -2150,6 +2205,12 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `Human Review` candidates and reasons such as `automated_review_missing`
    when that gate is not met.
 
+   Keep `agent.max_session_context_multiplier` absent unless the operator
+   explicitly requested the coarse ceiling. Use `agent.max_session_tokens` as
+   the default runaway brake because cached context is counted again on every
+   Codex turn; a small multiplier can terminate otherwise healthy sessions
+   after only a few full-context turns.
+
    Dependency auto-unblock default:
 
    ```yaml
@@ -2167,7 +2228,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
    `Blocked` is an observed/display state and dependency completion will not
    move issues back to `Todo`.
 
-7. **Write the prompt body.** Keep the `## Codex Workpad` instruction, include
+8. **Write the prompt body.** Keep the `## Codex Workpad` instruction, include
    the `detent-status` schema examples, include the native `blocked_by`
    dependency command with the labeled legacy fallback note, include repo
    authority files discovered in Phase 2, state the validation gate, and keep
@@ -2185,7 +2246,7 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      | rg 'Current Detent status|Codex Workpad|detent-status|dependencies/blocked_by|Required Execution Flow|For Todo|For In Progress|For Rework|For Merging|go-workflow:ship|CLAUDE.md|AGENTS.md|CONTRIBUTING.md|<gate-command>|<repo-owner>/<repo-name>'
    ```
 
-8. **Check the workflow contract before registration.** This is a structural
+9. **Check the workflow contract before registration.** This is a structural
    check; `detent doctor --allow-write-probes` in Phase 5 is the full
    preflight. Verify:
 
@@ -2863,6 +2924,9 @@ the card instead of auto-resolving it.
 | Dispatch label ordering | `agent.dispatch_priority_by_label` in `WORKFLOW.md`. |
 | Authorization filters | `tracker.authorization` in `WORKFLOW.md`; optionally `projects[].authorization` in `global.yaml` for host-level scoping. |
 | Dashboard bind | `server.host` in `WORKFLOW.md`, or `--host` in the startup command or service `ExecStart`. |
+| Worker model provider default | `codex.command: codex app-server`; follows provider upgrades and avoids retirement breakage. |
+| Worker model pin | `codex.command` with `--config 'model="<model>"'`; provides reproducibility or cost control but requires generation maintenance. |
+| Worker reasoning effort | Optional `model_reasoning_effort` Codex config override; unset by default because not every model accepts it. |
 | Validation command | `gate.kind: command` and `gate.run` in `WORKFLOW.md`. |
 | Automated PR review requirement | `gate.kind: command` and `gate.require_automated_review` in `WORKFLOW.md`. |
 | Release-blocking CI names | `gate.required_status_checks` in `WORKFLOW.md`; keep it aligned with branch protection or rulesets. |
@@ -2871,6 +2935,7 @@ the card instead of auto-resolving it.
 | Human validation label | `gate.kind: human_review` and `gate.approval_label` in `WORKFLOW.md`. |
 | Per-project concurrency | `agent.max_concurrent_agents` in `WORKFLOW.md`. |
 | Merge serialization | `agent.max_concurrent_agents_by_state.Merging: 1` in `WORKFLOW.md`. |
+| Session runaway brake | `agent.max_session_tokens`; `agent.max_session_context_multiplier` remains absent unless explicitly requested as a coarse ceiling. |
 | Hard-stop review policy | `agent.auto_promote.enabled: false` in `WORKFLOW.md`. |
 | Criteria-based auto-promote | `agent.auto_promote.enabled`, `quiet_seconds`, `optout_label`, and `allowed_issue_labels` in `WORKFLOW.md`. |
 | Prompt body | Markdown body after the closing frontmatter `---` in `WORKFLOW.md`. |

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -61,12 +61,10 @@ agent:
   max_retry_backoff_ms: 300000
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the
-  # session, so a healthy Claude session re-counts its cached context each turn
-  # and accrues millions of tokens within minutes. Set this as a runaway-session
-  # guard, not a context limit; max_session_context_multiplier bounds context
-  # growth separately.
+  # session, so cached context is re-counted each turn. Use max_session_tokens
+  # as the runaway brake. max_session_context_multiplier is an opt-in, coarse
+  # cap on roughly how many full-context turns fit; leave it unset by default.
   max_session_tokens: 25000000
-  max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:
     Merging: 1
@@ -95,7 +93,8 @@ agent:
       enabled: true
       max_drafts_per_run: 1
 codex:
-  command: codex app-server
+  # Optional model_reasoning_effort is unset because not every model accepts it.
+  command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:
@@ -129,9 +128,9 @@ gate:
   transient_ci_retry_limit: 2
   validator:
     enabled: false
-    # Recommended cheap override when enabled: gpt-5.4-mini.
-    # Watch rework-rate per validator model once cache/model telemetry lands.
-    model: gpt-5.4-mini
+    # Optional deliberate pin; leave empty to inherit the route/provider default.
+    # Pinned models require manual updates before provider retirement.
+    model: ""
     min_score: 0.8
     max_inline_diff_bytes: 65536
     block_on:

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -60,12 +60,10 @@ agent:
   max_retry_backoff_ms: 300000
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the
-  # session, so a healthy Claude session re-counts its cached context each turn
-  # and accrues millions of tokens within minutes. Set this as a runaway-session
-  # guard, not a context limit; max_session_context_multiplier bounds context
-  # growth separately.
+  # session, so cached context is re-counted each turn. Use max_session_tokens
+  # as the runaway brake. max_session_context_multiplier is an opt-in, coarse
+  # cap on roughly how many full-context turns fit; leave it unset by default.
   max_session_tokens: 25000000
-  max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:
     Merging: 1
@@ -94,7 +92,8 @@ agent:
       enabled: true
       max_drafts_per_run: 1
 codex:
-  command: codex app-server
+  # Optional model_reasoning_effort is unset because not every model accepts it.
+  command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:
@@ -128,9 +127,9 @@ gate:
   transient_ci_retry_limit: 2
   validator:
     enabled: false
-    # Recommended cheap override when enabled: gpt-5.4-mini.
-    # Watch rework-rate per validator model once cache/model telemetry lands.
-    model: gpt-5.4-mini
+    # Optional deliberate pin; leave empty to inherit the route/provider default.
+    # Pinned models require manual updates before provider retirement.
+    model: ""
     min_score: 0.8
     max_inline_diff_bytes: 65536
     block_on:

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -60,12 +60,10 @@ agent:
   max_retry_backoff_ms: 300000
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the
-  # session, so a healthy Claude session re-counts its cached context each turn
-  # and accrues millions of tokens within minutes. Set this as a runaway-session
-  # guard, not a context limit; max_session_context_multiplier bounds context
-  # growth separately.
+  # session, so cached context is re-counted each turn. Use max_session_tokens
+  # as the runaway brake. max_session_context_multiplier is an opt-in, coarse
+  # cap on roughly how many full-context turns fit; leave it unset by default.
   max_session_tokens: 25000000
-  max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:
     Merging: 1
@@ -94,7 +92,8 @@ agent:
       enabled: true
       max_drafts_per_run: 1
 codex:
-  command: codex app-server
+  # Optional model_reasoning_effort is unset because not every model accepts it.
+  command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:
@@ -128,9 +127,9 @@ gate:
   transient_ci_retry_limit: 2
   validator:
     enabled: false
-    # Recommended cheap override when enabled: gpt-5.4-mini.
-    # Watch rework-rate per validator model once cache/model telemetry lands.
-    model: gpt-5.4-mini
+    # Optional deliberate pin; leave empty to inherit the route/provider default.
+    # Pinned models require manual updates before provider retirement.
+    model: ""
     min_score: 0.8
     max_inline_diff_bytes: 65536
     block_on:

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -31,12 +31,10 @@ deliverable:
 agent:
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the
-  # session, so a healthy Claude session re-counts its cached context each turn
-  # and accrues millions of tokens within minutes. Set this as a runaway-session
-  # guard, not a context limit; max_session_context_multiplier bounds context
-  # growth separately.
+  # session, so cached context is re-counted each turn. Use max_session_tokens
+  # as the runaway brake. max_session_context_multiplier is an opt-in, coarse
+  # cap on roughly how many full-context turns fit; leave it unset by default.
   max_session_tokens: 25000000
-  max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   # For a non-code workflow such as Research -> Draft -> Review -> Package ->
   # Publish, add stage-specific prompt additions here instead of turning the
@@ -65,13 +63,19 @@ agent:
     rework_state: Rework
     rework_limit: 3
 
+codex:
+  # Optional model_reasoning_effort is unset because not every model accepts it.
+  command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
+
 gate:
   kind: artifact
   ci_failure_action: rework
   transient_ci_retry_limit: 2
   validator:
     enabled: false
-    model: gpt-5.4-mini
+    # Optional deliberate pin; leave empty to inherit the route/provider default.
+    # Pinned models require manual updates before provider retirement.
+    model: ""
     min_score: 0.8
     max_inline_diff_bytes: 65536
     block_on:

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -59,12 +59,10 @@ agent:
   max_retry_backoff_ms: 300000
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the
-  # session, so a healthy Claude session re-counts its cached context each turn
-  # and accrues millions of tokens within minutes. Set this as a runaway-session
-  # guard, not a context limit; max_session_context_multiplier bounds context
-  # growth separately.
+  # session, so cached context is re-counted each turn. Use max_session_tokens
+  # as the runaway brake. max_session_context_multiplier is an opt-in, coarse
+  # cap on roughly how many full-context turns fit; leave it unset by default.
   max_session_tokens: 25000000
-  max_session_context_multiplier: 4
   max_session_token_override_label: allow-large-session
   max_concurrent_agents_by_state:
     Merging: 1
@@ -93,7 +91,8 @@ agent:
       enabled: true
       max_drafts_per_run: 1
 codex:
-  command: codex app-server
+  # Optional model_reasoning_effort is unset because not every model accepts it.
+  command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write
   turn_sandbox_policy:
@@ -127,9 +126,9 @@ gate:
   transient_ci_retry_limit: 2
   validator:
     enabled: false
-    # Recommended cheap override when enabled: gpt-5.4-mini.
-    # Watch rework-rate per validator model once cache/model telemetry lands.
-    model: gpt-5.4-mini
+    # Optional deliberate pin; leave empty to inherit the route/provider default.
+    # Pinned models require manual updates before provider retirement.
+    model: ""
     min_score: 0.8
     max_inline_diff_bytes: 65536
     block_on:

--- a/internal/cli/onboarding_workflow_builder.go
+++ b/internal/cli/onboarding_workflow_builder.go
@@ -22,9 +22,9 @@ import (
 )
 
 const (
-	onboardingWorkflowDefaultValidatorModel       = "gpt-5.4-mini"
+	onboardingWorkflowWorkerModelProviderDefault  = "provider_default"
+	onboardingWorkflowWorkerModelPinned           = "pinned"
 	onboardingWorkflowDefaultSessionTokens        = int64(2000000)
-	onboardingWorkflowDefaultSessionMultiplier    = 4.0
 	onboardingWorkflowDefaultSessionOverrideLabel = "allow-large-session"
 )
 
@@ -58,6 +58,15 @@ type onboardingWorkflowPreset struct {
 	Raw        []byte
 	Provenance string
 	Why        string
+}
+
+type onboardingWorkflowWorkerModel struct {
+	Mode       string
+	Model      string
+	Command    string
+	Provenance string
+	Why        string
+	Comment    string
 }
 
 type onboardingWorkflowReviewFlow string
@@ -457,19 +466,27 @@ func applyOnboardingWorkflowDecisions(
 	if err != nil {
 		return "", err
 	}
-	validatorModel, validatorModelProvenance, validatorModelWhy := onboardingWorkflowStringDecision(answers, nil, "VALIDATOR_MODEL", onboardingWorkflowDefaultValidatorModel, "preset", "recommended validator model override")
+	validatorModel, validatorModelProvenance, validatorModelWhy := onboardingWorkflowStringDecision(answers, nil, "VALIDATOR_MODEL", "", "preset", "inherits the validator route or provider default unless explicitly pinned")
 	validatorMinScore, validatorScoreProvenance, validatorScoreWhy, err := onboardingWorkflowFloatDecision(answers, "VALIDATOR_MIN_SCORE", 0.8, "preset", "recommended validator confidence threshold")
 	if err != nil {
 		return "", err
 	}
 	validatorBlockOn, validatorBlockProvenance, validatorBlockWhy := onboardingWorkflowListDecision(answers, "VALIDATOR_BLOCK_ON", []string{"p1"}, "preset", "block promotion on P1 validator findings")
+	workerModel, err := onboardingWorkflowWorkerModelDecision(answers)
+	if err != nil {
+		return "", err
+	}
 	sessionTokens, sessionTokensProvenance, sessionTokensWhy, err := onboardingWorkflowInt64Decision(answers, "MAX_SESSION_TOKENS", onboardingWorkflowDefaultSessionTokens, "preset", "recommended per-session token ceiling")
 	if err != nil {
 		return "", err
 	}
-	sessionMultiplier, sessionMultiplierProvenance, sessionMultiplierWhy, err := onboardingWorkflowFloatDecision(answers, "MAX_SESSION_CONTEXT_MULTIPLIER", onboardingWorkflowDefaultSessionMultiplier, "preset", "recommended context-window token ceiling")
-	if err != nil {
-		return "", err
+	sessionMultiplierRaw, sessionMultiplierSet := onboardingWorkflowAnswer(answers, "MAX_SESSION_CONTEXT_MULTIPLIER")
+	var sessionMultiplier float64
+	if sessionMultiplierSet {
+		sessionMultiplier, err = strconv.ParseFloat(sessionMultiplierRaw, 64)
+		if err != nil {
+			return "", NewValidationError("MAX_SESSION_CONTEXT_MULTIPLIER must be a number", "Use a numeric value only when explicitly opting into the coarse context multiplier.", nil)
+		}
 	}
 	sessionOverride, sessionOverrideProvenance, sessionOverrideWhy := onboardingWorkflowStringDecision(answers, nil, "MAX_SESSION_TOKEN_OVERRIDE_LABEL", onboardingWorkflowDefaultSessionOverrideLabel, "preset", "explicit per-issue escape hatch for large sessions")
 
@@ -480,7 +497,12 @@ func applyOnboardingWorkflowDecisions(
 	decisions.set(root, "agent.max_turns", maxTurns, maxTurnsProvenance, maxTurnsWhy)
 	decisions.set(root, "agent.max_retry_backoff_ms", 300000, "preset", "recommended retry backoff ceiling")
 	decisions.set(root, "agent.max_session_tokens", sessionTokens, sessionTokensProvenance, sessionTokensWhy)
-	decisions.set(root, "agent.max_session_context_multiplier", sessionMultiplier, sessionMultiplierProvenance, sessionMultiplierWhy)
+	if sessionMultiplierSet {
+		decisions.set(root, "agent.max_session_context_multiplier", sessionMultiplier, "answer", "MAX_SESSION_CONTEXT_MULTIPLIER explicitly opts into a coarse context ceiling")
+	} else {
+		deleteOnboardingYAMLPath(root, []string{"agent", "max_session_context_multiplier"})
+		decisions.add("agent.max_session_context_multiplier", "omitted", "preset", "max_session_tokens is the default runaway brake; the coarse context multiplier is opt-in")
+	}
 	decisions.set(root, "agent.max_session_token_override_label", sessionOverride, sessionOverrideProvenance, sessionOverrideWhy)
 	decisions.set(root, "agent.max_concurrent_agents_by_state.Merging", mergingConcurrency, mergingProvenance, mergingWhy)
 	decisions.set(root, "agent.auto_promote.enabled", autoPromote, autoPromoteProvenance, autoPromoteWhy)
@@ -501,6 +523,19 @@ func applyOnboardingWorkflowDecisions(
 	decisions.set(root, "gate.validator.model", validatorModel, validatorModelProvenance, validatorModelWhy)
 	decisions.set(root, "gate.validator.min_score", validatorMinScore, validatorScoreProvenance, validatorScoreWhy)
 	decisions.set(root, "gate.validator.block_on", validatorBlockOn, validatorBlockProvenance, validatorBlockWhy)
+	decisions.add("answers.worker_model_mode", workerModel.Mode, workerModel.Provenance, workerModel.Why)
+	if workerModel.Model != "" {
+		decisions.add("answers.worker_model", workerModel.Model, "answer", "WORKER_MODEL")
+	}
+	decisions.setWithComments(
+		root,
+		"codex.command",
+		workerModel.Command,
+		workerModel.Provenance,
+		workerModel.Why,
+		"Optional model_reasoning_effort is unset because not every model accepts it.",
+		workerModel.Comment,
+	)
 	decisions.set(root, "plan.enabled", false, "preset", "direct implementation dispatch by default")
 	decisions.set(root, "plan.review", "human", "preset", "human plan approval if plan mode is enabled later")
 	decisions.set(root, "server.kanban.mode", kanbanMode, kanbanProvenance, kanbanWhy)
@@ -560,6 +595,92 @@ func onboardingWorkflowDeliveryProfile(answers onboardingAnswers) (string, strin
 		)
 	}
 	return profile, "answer", "DELIVERY_PROFILE", nil
+}
+
+func onboardingWorkflowWorkerModelDecision(answers onboardingAnswers) (onboardingWorkflowWorkerModel, error) {
+	rawMode, provenance, why := onboardingWorkflowStringDecision(
+		answers,
+		nil,
+		"WORKER_MODEL_MODE",
+		onboardingWorkflowWorkerModelProviderDefault,
+		"preset",
+		"provider default follows upgrades and avoids retirement breakage",
+	)
+	mode, ok := normalizeOnboardingWorkflowWorkerModelMode(rawMode)
+	if !ok {
+		return onboardingWorkflowWorkerModel{}, NewValidationError(
+			"WORKER_MODEL_MODE must be provider_default or pinned",
+			"Use provider_default to follow provider upgrades, or pinned with WORKER_MODEL for reproducibility or cost control.",
+			nil,
+		)
+	}
+	model, hasModel := onboardingWorkflowAnswer(answers, "WORKER_MODEL")
+	switch mode {
+	case onboardingWorkflowWorkerModelProviderDefault:
+		if hasModel {
+			return onboardingWorkflowWorkerModel{}, NewValidationError(
+				"WORKER_MODEL must be omitted when WORKER_MODEL_MODE=provider_default",
+				"Remove WORKER_MODEL to inherit the provider default, or set WORKER_MODEL_MODE=pinned.",
+				nil,
+			)
+		}
+		return onboardingWorkflowWorkerModel{
+			Mode:       mode,
+			Command:    "codex app-server",
+			Provenance: provenance,
+			Why:        why,
+			Comment:    "Provider default: upgrades automatically and avoids retirement breakage.",
+		}, nil
+	case onboardingWorkflowWorkerModelPinned:
+		if !hasModel {
+			return onboardingWorkflowWorkerModel{}, NewValidationError(
+				"WORKER_MODEL is required when WORKER_MODEL_MODE=pinned",
+				"Record the exact provider-supported model identifier, and plan to update it before retirement.",
+				nil,
+			)
+		}
+		if !validOnboardingWorkflowModel(model) {
+			return onboardingWorkflowWorkerModel{}, NewValidationError(
+				"WORKER_MODEL contains unsupported characters",
+				"Use a model identifier containing only letters, digits, dot, underscore, colon, slash, or hyphen.",
+				nil,
+			)
+		}
+		return onboardingWorkflowWorkerModel{
+			Mode:       mode,
+			Model:      model,
+			Command:    fmt.Sprintf(`codex app-server --config 'model="%s"'`, model),
+			Provenance: provenance,
+			Why:        why,
+			Comment:    "Pinned for reproducibility or cost control; update before retirement.",
+		}, nil
+	default:
+		return onboardingWorkflowWorkerModel{}, errors.New("unreachable worker model mode")
+	}
+}
+
+func normalizeOnboardingWorkflowWorkerModelMode(value string) (string, bool) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case onboardingWorkflowWorkerModelProviderDefault, "provider-default", "default", "unpinned":
+		return onboardingWorkflowWorkerModelProviderDefault, true
+	case onboardingWorkflowWorkerModelPinned, "pin":
+		return onboardingWorkflowWorkerModelPinned, true
+	default:
+		return "", false
+	}
+}
+
+func validOnboardingWorkflowModel(model string) bool {
+	if model == "" {
+		return false
+	}
+	for _, char := range model {
+		if char >= 'a' && char <= 'z' || char >= 'A' && char <= 'Z' || char >= '0' && char <= '9' || strings.ContainsRune("._:/-", char) {
+			continue
+		}
+		return false
+	}
+	return true
 }
 
 func onboardingWorkflowAnswer(answers onboardingAnswers, keys ...string) (string, bool) {
@@ -924,6 +1045,13 @@ func (r *onboardingWorkflowDecisionRecorder) set(root *yaml.Node, path string, v
 	r.add(path, value, provenance, why)
 }
 
+func (r *onboardingWorkflowDecisionRecorder) setWithComments(root *yaml.Node, path string, value any, provenance string, why string, headComment string, lineComment string) {
+	parts := strings.Split(path, ".")
+	setOnboardingYAMLPath(root, parts, value)
+	setOnboardingYAMLPathComments(root, parts, headComment, lineComment)
+	r.add(path, value, provenance, why)
+}
+
 func (r *onboardingWorkflowDecisionRecorder) add(path string, value any, provenance string, why string) {
 	r.decisions = append(r.decisions, onboardingWorkflowDecision{
 		Path:       path,
@@ -966,6 +1094,27 @@ func setOnboardingYAMLPath(root *yaml.Node, path []string, value any) {
 		current = next
 	}
 	setOnboardingYAMLMappingValue(current, path[len(path)-1], onboardingYAMLNode(value))
+}
+
+func setOnboardingYAMLPathComments(root *yaml.Node, path []string, headComment string, lineComment string) {
+	if len(path) == 0 {
+		return
+	}
+	current := root
+	for _, key := range path[:len(path)-1] {
+		current = onboardingYAMLMappingValue(current, key)
+		if current == nil || current.Kind != yaml.MappingNode {
+			return
+		}
+	}
+	key := path[len(path)-1]
+	for i := 0; i < len(current.Content); i += 2 {
+		if current.Content[i].Value == key {
+			current.Content[i].HeadComment = strings.TrimSpace(headComment)
+			current.Content[i+1].LineComment = strings.TrimSpace(lineComment)
+			return
+		}
+	}
 }
 
 func deleteOnboardingYAMLPath(root *yaml.Node, path []string) {

--- a/internal/cli/onboarding_workflow_builder_test.go
+++ b/internal/cli/onboarding_workflow_builder_test.go
@@ -178,6 +178,176 @@ func TestBuildOnboardingWorkflowPreservesArtifactPresetGate(t *testing.T) {
 	assertOnboardingWorkflowDecision(t, result.Decisions, "budget.per_issue_max_usd", "preset")
 }
 
+func TestBuildOnboardingWorkflowWorkerModelFixtures(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		answers     []string
+		wantCommand string
+		wantComment string
+		wantModel   string
+	}{
+		{
+			name:        "provider default",
+			answers:     []string{"WORKER_MODEL_MODE=provider_default"},
+			wantCommand: "codex app-server",
+			wantComment: "Provider default: upgrades automatically and avoids retirement breakage.",
+		},
+		{
+			name: "pinned",
+			answers: []string{
+				"WORKER_MODEL_MODE=pinned",
+				"WORKER_MODEL=gpt-5.6-sol",
+			},
+			wantCommand: `codex app-server --config 'model="gpt-5.6-sol"'`,
+			wantComment: "Pinned for reproducibility or cost control; update before retirement.",
+			wantModel:   "gpt-5.6-sol",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := initOnboardingWorkflowBuilderGitRepository(t, "https://github.com/acme/api.git")
+			answersPath := writeOnboardingWorkflowBuilderAnswers(t, onboardingWorkflowBuilderVariantAnswers(root, "github_local", "review_gate", tt.answers...))
+
+			result, err := buildOnboardingWorkflow(context.Background(), onboardingBuildWorkflowConfig{
+				AnswersPath: answersPath,
+				Write:       false,
+			})
+			if err != nil {
+				t.Fatalf("buildOnboardingWorkflow() error = %v", err)
+			}
+			workflow, err := workflowconfig.ParseWorkflow([]byte(result.Workflow))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v\n%s", err, result.Workflow)
+			}
+			if workflow.Config.Codex.Command != tt.wantCommand {
+				t.Fatalf("Codex.Command = %q, want %q", workflow.Config.Codex.Command, tt.wantCommand)
+			}
+			assertOnboardingWorkflowContains(t, result.Workflow, tt.wantComment)
+			assertOnboardingWorkflowContains(t, result.Workflow, "Optional model_reasoning_effort is unset because not every model accepts it.")
+			assertOnboardingWorkflowDecision(t, result.Decisions, "answers.worker_model_mode", "answer")
+			assertOnboardingWorkflowDecision(t, result.Decisions, "codex.command", "answer")
+			if tt.wantModel != "" {
+				assertOnboardingWorkflowDecision(t, result.Decisions, "answers.worker_model", "answer")
+			}
+		})
+	}
+}
+
+func TestBuildOnboardingWorkflowRejectsInvalidWorkerModelAnswers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		answers   []string
+		wantError string
+	}{
+		{
+			name:      "unknown mode",
+			answers:   []string{"WORKER_MODEL_MODE=automatic"},
+			wantError: "WORKER_MODEL_MODE must be provider_default or pinned",
+		},
+		{
+			name:      "pinned without model",
+			answers:   []string{"WORKER_MODEL_MODE=pinned"},
+			wantError: "WORKER_MODEL is required when WORKER_MODEL_MODE=pinned",
+		},
+		{
+			name: "provider default with model",
+			answers: []string{
+				"WORKER_MODEL_MODE=provider_default",
+				"WORKER_MODEL=gpt-5.6-sol",
+			},
+			wantError: "WORKER_MODEL must be omitted when WORKER_MODEL_MODE=provider_default",
+		},
+		{
+			name: "unsafe pinned model",
+			answers: []string{
+				"WORKER_MODEL_MODE=pinned",
+				"WORKER_MODEL=gpt-5.6-sol';echo",
+			},
+			wantError: "WORKER_MODEL contains unsupported characters",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := initOnboardingWorkflowBuilderGitRepository(t, "https://github.com/acme/api.git")
+			answersPath := writeOnboardingWorkflowBuilderAnswers(t, onboardingWorkflowBuilderVariantAnswers(root, "github_local", "review_gate", tt.answers...))
+
+			_, err := buildOnboardingWorkflow(context.Background(), onboardingBuildWorkflowConfig{
+				AnswersPath: answersPath,
+				Write:       false,
+			})
+			if err == nil {
+				t.Fatal("buildOnboardingWorkflow() error = nil, want validation error")
+			}
+			if !strings.Contains(err.Error(), tt.wantError) {
+				t.Fatalf("buildOnboardingWorkflow() error = %v, want %q", err, tt.wantError)
+			}
+		})
+	}
+}
+
+func TestBuildOnboardingWorkflowSessionContextMultiplierIsOptIn(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		answers        []string
+		wantMultiplier float64
+		wantPresent    bool
+		wantProvenance string
+	}{
+		{
+			name:           "omitted by default",
+			wantProvenance: "preset",
+		},
+		{
+			name:           "explicit coarse ceiling",
+			answers:        []string{"MAX_SESSION_CONTEXT_MULTIPLIER=12"},
+			wantMultiplier: 12,
+			wantPresent:    true,
+			wantProvenance: "answer",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := initOnboardingWorkflowBuilderGitRepository(t, "https://github.com/acme/api.git")
+			answersPath := writeOnboardingWorkflowBuilderAnswers(t, onboardingWorkflowBuilderVariantAnswers(root, "github_local", "review_gate", tt.answers...))
+
+			result, err := buildOnboardingWorkflow(context.Background(), onboardingBuildWorkflowConfig{
+				AnswersPath: answersPath,
+				Write:       false,
+			})
+			if err != nil {
+				t.Fatalf("buildOnboardingWorkflow() error = %v", err)
+			}
+			workflow, err := workflowconfig.ParseWorkflow([]byte(result.Workflow))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v\n%s", err, result.Workflow)
+			}
+			if workflow.Config.Agent.MaxSessionContextMultiplier != tt.wantMultiplier {
+				t.Fatalf("MaxSessionContextMultiplier = %v, want %v", workflow.Config.Agent.MaxSessionContextMultiplier, tt.wantMultiplier)
+			}
+			gotPresent := strings.Contains(result.Workflow, "max_session_context_multiplier:")
+			if gotPresent != tt.wantPresent {
+				t.Fatalf("max_session_context_multiplier presence = %t, want %t\n%s", gotPresent, tt.wantPresent, result.Workflow)
+			}
+			assertOnboardingWorkflowDecision(t, result.Decisions, "agent.max_session_context_multiplier", tt.wantProvenance)
+		})
+	}
+}
+
 func TestBuildOnboardingWorkflowRendersReviewFlowVariants(t *testing.T) {
 	t.Parallel()
 
@@ -394,8 +564,11 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 	if !workflow.Config.Budget.Enabled || workflow.Config.Budget.PerDayMaxUSD != 50 || workflow.Config.Budget.PerIssueMaxUSD != 5 {
 		t.Fatalf("Budget = %#v, want enabled 50/day 5/issue", workflow.Config.Budget)
 	}
-	if workflow.Config.Gate.Validator.Model != onboardingWorkflowDefaultValidatorModel {
-		t.Fatalf("Gate.Validator.Model = %q, want %q", workflow.Config.Gate.Validator.Model, onboardingWorkflowDefaultValidatorModel)
+	if workflow.Config.Gate.Validator.Model != "" {
+		t.Fatalf("Gate.Validator.Model = %q, want provider or route default", workflow.Config.Gate.Validator.Model)
+	}
+	if strings.Contains(string(raw), "max_session_context_multiplier:") {
+		t.Fatalf("WORKFLOW.md includes opt-in max_session_context_multiplier:\n%s", string(raw))
 	}
 
 	got, err := project.New(project.Config{
@@ -424,6 +597,9 @@ func TestBuildOnboardingWorkflowGeneratesParseablePausedProject(t *testing.T) {
 	assertOnboardingWorkflowDecision(t, result.Decisions, "gate.run", "probe")
 	assertOnboardingWorkflowDecision(t, result.Decisions, "gate.validator.model", "preset")
 	assertOnboardingWorkflowDecision(t, result.Decisions, "agent.max_session_tokens", "preset")
+	assertOnboardingWorkflowDecision(t, result.Decisions, "agent.max_session_context_multiplier", "preset")
+	assertOnboardingWorkflowDecision(t, result.Decisions, "answers.worker_model_mode", "preset")
+	assertOnboardingWorkflowDecision(t, result.Decisions, "codex.command", "preset")
 	for _, decision := range result.Decisions {
 		switch decision.Provenance {
 		case "answer", "probe", "preset":
@@ -466,7 +642,7 @@ func assertOnboardingWorkflowContainsWords(t *testing.T, text string, want strin
 	}
 }
 
-func onboardingWorkflowBuilderVariantAnswers(root string, preset string, profile string) string {
+func onboardingWorkflowBuilderVariantAnswers(root string, preset string, profile string, extra ...string) string {
 	lines := []string{
 		"CUSTOMER_ID=acme",
 		"DETENT_PROJECT_ID=api",
@@ -481,6 +657,7 @@ func onboardingWorkflowBuilderVariantAnswers(root string, preset string, profile
 	if preset == "project_v2" {
 		lines = append(lines, "PROJECT_SLUG=PVT_test")
 	}
+	lines = append(lines, extra...)
 	return strings.Join(append(lines, ""), "\n")
 }
 

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -560,7 +560,8 @@ func TestOnboardingDocumentsWorkerModelAndSessionGuardChoices(t *testing.T) {
 
 	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
 	for _, want := range []string{
-		"WORKER_MODEL_MODE=<provider_default|pinned>",
+		"WORKER_MODEL_MODE=provider_default",
+		"WORKER_MODEL_MODE=pinned",
 		"WORKER_MODEL=<model-if-pinned>",
 		"Provider default: upgrades automatically and avoids retirement breakage.",
 		"Pinned for reproducibility or cost control; update before retirement.",

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -555,6 +555,64 @@ func TestWorkflowTemplatesDocumentStatusEnumAndReviewFlow(t *testing.T) {
 	}
 }
 
+func TestOnboardingDocumentsWorkerModelAndSessionGuardChoices(t *testing.T) {
+	t.Parallel()
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	for _, want := range []string{
+		"WORKER_MODEL_MODE=<provider_default|pinned>",
+		"WORKER_MODEL=<model-if-pinned>",
+		"Provider default: upgrades automatically and avoids retirement breakage.",
+		"Pinned for reproducibility or cost control; update before retirement.",
+		"model_reasoning_effort",
+		"do not emit `MAX_SESSION_CONTEXT_MULTIPLIER` by default",
+	} {
+		assertContainsWords(t, onboarding, want)
+	}
+
+	builder := readRepositoryTextFile(t, "internal/cli/onboarding_workflow_builder.go")
+	if strings.Contains(builder, "gpt-5.") {
+		t.Fatalf("onboarding workflow builder contains a hardcoded model generation:\n%s", builder)
+	}
+
+	for _, path := range []string{
+		"docs/templates/WORKFLOW.project_v2.md",
+		"docs/templates/WORKFLOW.issue_field.md",
+		"docs/templates/WORKFLOW.label.md",
+		"docs/templates/WORKFLOW.github_local.md",
+		"docs/templates/WORKFLOW.non_code_artifact.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+
+			content := readRepositoryTextFile(t, path)
+			for _, want := range []string{
+				"max_session_tokens:",
+				"max_session_context_multiplier is an opt-in, coarse",
+				"Optional model_reasoning_effort is unset because not every model accepts it.",
+				"command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.",
+				"model: \"\"",
+			} {
+				assertContainsWords(t, content, want)
+			}
+			if strings.Contains(content, "max_session_context_multiplier:") {
+				t.Fatalf("%s emits opt-in max_session_context_multiplier:\n%s", path, content)
+			}
+
+			workflow, err := workflowconfig.ParseWorkflow([]byte(content))
+			if err != nil {
+				t.Fatalf("ParseWorkflow(%s) error = %v", path, err)
+			}
+			if workflow.Config.Codex.Command != "codex app-server" {
+				t.Fatalf("Codex.Command = %q, want provider default", workflow.Config.Codex.Command)
+			}
+			if workflow.Config.Gate.Validator.Model != "" {
+				t.Fatalf("Gate.Validator.Model = %q, want route/provider default", workflow.Config.Gate.Validator.Model)
+			}
+		})
+	}
+}
+
 func TestWorkflowTemplatesRecommendRequiredExecutionFlow(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add an explicit provider-default versus pinned worker-model onboarding decision and render the matching `codex.command`
- leave validator models and session context multipliers unpinned unless explicitly selected
- document session-token and reasoning-effort trade-offs across maintained workflow templates
- add pin/unpin fixtures, validation cases, multiplier opt-in coverage, and template contracts

Fixes #1119

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; there are no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/cli . -count=1`
- [x] `make generate` (no generated-file drift)
- [x] `make check`