### PR TITLE
feat(doctor): report model and session guards

### DIFF
--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -280,12 +280,22 @@ func checkDoctorRouteModels(ctx context.Context, id string, project globalconfig
 		}
 		probeModel(index, route, backend, model, "agents.routes.model")
 	}
-	if modelConfig, ok := doctorWorkflowDefaultRouteModelConfig(cfg); ok && modelConfig.Source == "agents.backends.command" {
-		routes := cfg.AgentRouteConfigs()
-		backend, backendOK := backends[modelConfig.BackendID]
-		if modelConfig.RouteIndex >= 0 && modelConfig.RouteIndex < len(routes) && backendOK {
-			probeModel(modelConfig.RouteIndex, routes[modelConfig.RouteIndex], backend, modelConfig.Model, modelConfig.Source)
+	probedCommandBackends := map[string]struct{}{}
+	for index, route := range cfg.AgentRouteConfigs() {
+		backendID := strings.TrimSpace(route.Backend)
+		if _, ok := probedCommandBackends[backendID]; ok {
+			continue
 		}
+		backend, ok := backends[backendID]
+		if !ok || strings.TrimSpace(backend.Kind) != workflowconfig.AgentBackendCodex {
+			continue
+		}
+		model := doctorWorkflowBackendCommandModel(backend)
+		if model == "" {
+			continue
+		}
+		probedCommandBackends[backendID] = struct{}{}
+		probeModel(index, route, backend, model, "agents.backends.command")
 	}
 
 	if len(failures) == 0 {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -3,6 +3,7 @@ package cli
 import (
 	"context"
 	"fmt"
+	"strconv"
 	"strings"
 	"time"
 
@@ -230,16 +231,7 @@ func checkDoctorRouteModels(ctx context.Context, id string, project globalconfig
 	var skipped int
 	var failures []string
 	var findings []doctorWorkflowOptimizationFinding
-	for index, route := range cfg.AgentRouteConfigs() {
-		model := strings.TrimSpace(route.Model)
-		if model == "" {
-			continue
-		}
-		backend, ok := backends[strings.TrimSpace(route.Backend)]
-		if !ok || strings.TrimSpace(backend.Kind) != workflowconfig.AgentBackendCodex {
-			skipped++
-			continue
-		}
+	probeModel := func(index int, route workflowconfig.AgentRoute, backend workflowconfig.AgentBackend, model string, source string) {
 		probed++
 		routeName := doctorRouteModelName(route, index)
 		err := deps.modelProbe(ctx, doctorRouteModelProbeRequest{
@@ -253,31 +245,47 @@ func checkDoctorRouteModels(ctx context.Context, id string, project globalconfig
 			Backend:      backend,
 		})
 		if err == nil {
-			continue
+			return
 		}
-		detail := fmt.Sprintf("project %s route %s model %s rejected by backend: %v", id, routeName, model, err)
+		detail := fmt.Sprintf("project %s route %s model %s via %s rejected by backend: %v", id, routeName, model, source, err)
 		failures = append(failures, detail)
 		if workflowPathErr != nil {
-			continue
+			return
 		}
 		findings = append(findings, doctorWorkflowOptimizationFinding{
 			RuleID:       doctorWorkflowRulePinnedRouteModelRejected,
 			ProjectID:    id,
 			WorkflowPath: workflowPath,
 			Severity:     "error",
-			Title:        "Pinned route model rejected",
+			Title:        "Pinned worker model rejected",
 			Detail:       detail,
 			Evidence: map[string]any{
-				"backend": backend.ID,
-				"error":   err.Error(),
-				"model":   model,
-				"route":   routeName,
+				"backend":                 backend.ID,
+				"configured_model_source": source,
+				"error":                   err.Error(),
+				"model":                   model,
+				"route":                   routeName,
 			},
-			Patch: []doctorWorkflowOptimizationPatch{{
-				Path:  doctorWorkflowRouteModelPatchPath(index),
-				Value: "",
-			}},
 		})
+	}
+	for index, route := range cfg.AgentRouteConfigs() {
+		model := strings.TrimSpace(route.Model)
+		if model == "" {
+			continue
+		}
+		backend, ok := backends[strings.TrimSpace(route.Backend)]
+		if !ok || strings.TrimSpace(backend.Kind) != workflowconfig.AgentBackendCodex {
+			skipped++
+			continue
+		}
+		probeModel(index, route, backend, model, "agents.routes.model")
+	}
+	if modelConfig, ok := doctorWorkflowDefaultRouteModelConfig(cfg); ok && modelConfig.Source == "agents.backends.command" {
+		routes := cfg.AgentRouteConfigs()
+		backend, backendOK := backends[modelConfig.BackendID]
+		if modelConfig.RouteIndex >= 0 && modelConfig.RouteIndex < len(routes) && backendOK {
+			probeModel(modelConfig.RouteIndex, routes[modelConfig.RouteIndex], backend, modelConfig.Model, modelConfig.Source)
+		}
 	}
 
 	if len(failures) == 0 {
@@ -287,12 +295,15 @@ func checkDoctorRouteModels(ctx context.Context, id string, project globalconfig
 		}
 		return doctorCheck{Name: name, Status: doctorOK, Detail: detail}
 	}
-	report := doctorWorkflowOptimizationReport{Findings: findings}
+	report := doctorWorkflowOptimizationReport{
+		Findings:  findings,
+		Proposals: doctorWorkflowProposalsForFindings(id, findings, 1),
+	}
 	return doctorCheck{
 		Name:                 name,
 		Status:               doctorFail,
 		Detail:               strings.Join(failures, "; "),
-		Hint:                 "Remove the route model pin to inherit the Codex default, or update it to a backend-supported model.",
+		Hint:                 "Confirm the project's intended model policy, then update the pin to a backend-supported model or remove it to inherit the provider default.",
 		WorkflowOptimization: report,
 	}
 }
@@ -302,10 +313,6 @@ func doctorRouteModelName(route workflowconfig.AgentRoute, index int) string {
 		return name
 	}
 	return fmt.Sprintf("routes[%d]", index)
-}
-
-func doctorWorkflowRouteModelPatchPath(index int) string {
-	return fmt.Sprintf("agents.routes[%d].model", index)
 }
 
 func defaultDoctorRouteModelProbe(ctx context.Context, req doctorRouteModelProbeRequest) error {
@@ -335,8 +342,34 @@ func doctorWorkflowDetail(path string, project globalconfig.Project, cfg workflo
 		details = append(details, "identity "+doctorIdentityDetail(cfg.Identity))
 	}
 	details = append(details, doctorReviewFlowConfigDetail(cfg))
+	details = append(details, doctorWorkflowModelChoiceDetail(cfg))
+	details = append(details, doctorWorkflowSessionGuardDetail(cfg))
 	details = append(details, doctorAuthorizationDetail(project, cfg))
 	return strings.Join(details, "; ")
+}
+
+func doctorWorkflowModelChoiceDetail(cfg workflowconfig.Config) string {
+	choice := doctorWorkflowWorkerModelChoice(cfg)
+	if choice.Mode == "pinned" {
+		return fmt.Sprintf("worker-model=pinned %s via %s", choice.Model, choice.Source)
+	}
+	detail := "worker-model=provider-default"
+	if choice.Source == "agents.routes.model_field" {
+		detail += " with issue-field overrides"
+	}
+	return detail
+}
+
+func doctorWorkflowSessionGuardDetail(cfg workflowconfig.Config) string {
+	tokens := "disabled"
+	if cfg.Agent.MaxSessionTokens > 0 {
+		tokens = strconv.FormatInt(cfg.Agent.MaxSessionTokens, 10)
+	}
+	multiplier := "disabled"
+	if cfg.Agent.MaxSessionContextMultiplier > 0 {
+		multiplier = strconv.FormatFloat(cfg.Agent.MaxSessionContextMultiplier, 'g', -1, 64)
+	}
+	return fmt.Sprintf("session-guard=max_session_tokens=%s, max_session_context_multiplier=%s", tokens, multiplier)
 }
 
 func doctorWorkflowFindingDetails(findings []doctorWorkflowOptimizationFinding) string {

--- a/internal/cli/doctor_self_improvement.go
+++ b/internal/cli/doctor_self_improvement.go
@@ -244,6 +244,16 @@ func doctorWorkflowFindingSignalCount(finding doctorWorkflowOptimizationFinding)
 		return int(anyInt64(finding.Evidence["matching_phrase_count"]))
 	case doctorWorkflowRuleRunawaySessionTokens:
 		return int(anyInt64(finding.Evidence["session_count"]))
+	case doctorWorkflowRulePinnedWorkerModelStale:
+		return int(anyInt64(finding.Evidence["observed_default_sessions"]))
+	case doctorWorkflowRuleSessionMultiplierKills:
+		return int(anyInt64(finding.Evidence["session_multiplier_kill_count"]))
+	case doctorWorkflowRuleNoSessionTokenBrake:
+		count := int(anyInt64(finding.Evidence["unbraked_session_count"]))
+		if count > 0 {
+			return count
+		}
+		return 1
 	default:
 		return 1
 	}
@@ -261,7 +271,15 @@ func doctorWorkflowFindingProposalTarget(finding doctorWorkflowOptimizationFindi
 	}
 	switch finding.RuleID {
 	case doctorWorkflowRuleEmptyModelTelemetry:
-		return "prompt", "", "Tighten the agent prompt or telemetry capture path so every session records the effective model."
+		return "telemetry", "codex_sessions.model", "Repair effective-model resolution for completed sessions while leaving the project's pin/default policy unchanged."
+	case doctorWorkflowRulePinnedRouteModelRejected:
+		return "workflow", doctorWorkflowModelFindingTargetPath(finding), "Replace the rejected model with a backend-supported pin or remove the pin to inherit the provider default, according to the project's intended model policy."
+	case doctorWorkflowRulePinnedWorkerModelStale:
+		return "workflow", doctorWorkflowModelFindingTargetPath(finding), "Review the configured pin against the observed provider-default generation, then explicitly keep, update, or remove it according to the project's intended model policy."
+	case doctorWorkflowRuleSessionMultiplierKills:
+		return "workflow", "agent.max_session_context_multiplier", "Remove or recalibrate the context multiplier and configure an intentional `agent.max_session_tokens` ceiling after human review."
+	case doctorWorkflowRuleNoSessionTokenBrake:
+		return "workflow", "agent.max_session_tokens", "Configure an intentional absolute session-token brake after human review."
 	case doctorWorkflowRuleBudgetEstimateDrift:
 		return "workflow", "budget", "Review budget estimates against observed p90 billable session tokens and update workflow budget guidance if humans approve."
 	case doctorWorkflowRuleInvalidWorkpadStatusRecurrence:
@@ -273,6 +291,13 @@ func doctorWorkflowFindingProposalTarget(finding doctorWorkflowOptimizationFindi
 	default:
 		return "workflow", "", "Review this repeated doctor finding and propose a WORKFLOW.md, prompt, skill, or gate update for human approval."
 	}
+}
+
+func doctorWorkflowModelFindingTargetPath(finding doctorWorkflowOptimizationFinding) string {
+	if strings.TrimSpace(fmt.Sprint(finding.Evidence["configured_model_source"])) == "agents.backends.command" {
+		return "agents.backends.command"
+	}
+	return "agents.routes.model"
 }
 
 func doctorWorkflowReviewFlowProposalTarget(finding doctorWorkflowOptimizationFinding) (string, string, string) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -369,6 +369,48 @@ Prompt
 	}
 }
 
+func TestCheckDoctorRouteModelsProbesRoleBackendCommandPins(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := workflowconfig.ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-code
+      kind: codex
+      command: codex app-server
+    - id: codex-plan
+      kind: codex
+      command: codex --config 'model="gpt-retired-plan"' app-server
+  routes:
+    - name: code-default
+      backend: codex-code
+      default: true
+    - name: plan-default
+      role: plan
+      backend: codex-plan
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	dir := t.TempDir()
+	check := checkDoctorRouteModels(context.Background(), "detent", globalconfig.Project{ID: "detent", Workflow: filepath.Join(dir, "WORKFLOW.md"), Workdir: dir}, workflow.Config, doctorDeps{
+		modelProbe: func(_ context.Context, req doctorRouteModelProbeRequest) error {
+			if req.Model != "gpt-retired-plan" || req.RouteName != "plan-default" || req.RouteRole != "plan" || req.Backend.ID != "codex-plan" {
+				t.Fatalf("probe request = %#v, want plan backend command pin", req)
+			}
+			return errors.New("model retired")
+		},
+	})
+	if check.Status != doctorFail || !strings.Contains(check.Detail, "plan-default") || !strings.Contains(check.Detail, "gpt-retired-plan") {
+		t.Fatalf("check = %#v, want rejected role backend command pin", check)
+	}
+}
+
 func TestCheckDoctorProjects(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -233,7 +233,7 @@ func TestRunDoctorAgentBinaryChecksFollowWorkflowBackends(t *testing.T) {
 	}
 }
 
-func TestRunDoctorFailsRejectedPinnedRouteModelAndDiffClearsPin(t *testing.T) {
+func TestRunDoctorFailsRejectedPinnedRouteModelWithoutChangingModelChoice(t *testing.T) {
 	t.Parallel()
 
 	dir := t.TempDir()
@@ -301,24 +301,71 @@ Prompt
 			t.Fatalf("route model detail missing %q:\n%s", want, check.Detail)
 		}
 	}
-	if !strings.Contains(report.WorkflowOptimization.Diff, "-      model: gpt-5-codex") ||
-		!strings.Contains(report.WorkflowOptimization.Diff, `model: ""`) {
-		t.Fatalf("diff did not clear model pin:\n%s", report.WorkflowOptimization.Diff)
+	if strings.Contains(report.WorkflowOptimization.Diff, "model:") {
+		t.Fatalf("diff changed the project's model choice:\n%s", report.WorkflowOptimization.Diff)
+	}
+	proposal := doctorWorkflowProposalBySignal(t, report.WorkflowOptimization.Proposals, "doctor_finding", doctorWorkflowRulePinnedRouteModelRejected)
+	if !strings.Contains(proposal.SuggestedChange, "backend-supported pin") || !strings.Contains(proposal.SuggestedChange, "remove the pin") {
+		t.Fatalf("proposal is not model-choice neutral: %#v", proposal)
 	}
 
 	written, err := writeDoctorWorkflowOptimizationPatches(report.WorkflowOptimization)
 	if err != nil {
 		t.Fatalf("writeDoctorWorkflowOptimizationPatches() error = %v", err)
 	}
-	if !slices.Equal(written, []string{workflowPath}) {
-		t.Fatalf("written = %#v, want workflow path", written)
+	if len(written) != 0 {
+		t.Fatalf("written = %#v, want no automatic model-choice change", written)
 	}
 	workflow, err := workflowconfig.LoadWorkflow(workflowPath)
 	if err != nil {
 		t.Fatalf("LoadWorkflow() error = %v", err)
 	}
-	if got := workflow.Config.AgentRouteConfigs()[0].Model; got != "" {
-		t.Fatalf("route model after write = %q, want empty", got)
+	if got := workflow.Config.AgentRouteConfigs()[0].Model; got != "gpt-5-codex" {
+		t.Fatalf("route model after write = %q, want preserved pin", got)
+	}
+}
+
+func TestCheckDoctorRouteModelsFailsRejectedBackendCommandPin(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := workflowconfig.ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-main
+      kind: codex
+      command: codex --config 'model="gpt-5.5"' app-server
+  routes:
+    - name: default
+      backend: codex-main
+      default: true
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	dir := t.TempDir()
+	workflowPath := filepath.Join(dir, "WORKFLOW.md")
+	check := checkDoctorRouteModels(context.Background(), "detent", globalconfig.Project{ID: "detent", Workflow: workflowPath, Workdir: dir}, workflow.Config, doctorDeps{
+		modelProbe: func(_ context.Context, req doctorRouteModelProbeRequest) error {
+			if req.Model != "gpt-5.5" || req.RouteName != "default" || req.Backend.ID != "codex-main" {
+				t.Fatalf("probe request = %#v, want backend command pin", req)
+			}
+			return errors.New("model retired")
+		},
+	})
+	if check.Status != doctorFail || !strings.Contains(check.Detail, "agents.backends.command") || !strings.Contains(check.Detail, "model retired") {
+		t.Fatalf("check = %#v, want rejected backend command pin", check)
+	}
+	finding := doctorWorkflowFindingByRule(t, check.WorkflowOptimization.Findings, doctorWorkflowRulePinnedRouteModelRejected)
+	if got := finding.Evidence["configured_model_source"]; got != "agents.backends.command" {
+		t.Fatalf("configured_model_source = %#v, want agents.backends.command", got)
+	}
+	proposal := doctorWorkflowProposalBySignal(t, check.WorkflowOptimization.Proposals, "doctor_finding", doctorWorkflowRulePinnedRouteModelRejected)
+	if proposal.TargetPath != "agents.backends.command" {
+		t.Fatalf("proposal target = %q, want agents.backends.command", proposal.TargetPath)
 	}
 }
 
@@ -1366,7 +1413,33 @@ func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
 	for _, want := range []string{
 		"WORKFLOW.md is valid",
 		"identity release-captain",
+		"worker-model=provider-default",
+		"session-guard=max_session_tokens=disabled, max_session_context_multiplier=disabled",
 		"authorization selectors from global.yaml and WORKFLOW.md",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("doctorWorkflowDetail() = %q, want substring %q", got, want)
+		}
+	}
+}
+
+func TestDoctorWorkflowDetailReportsPinnedModelAndSessionGuard(t *testing.T) {
+	t.Parallel()
+
+	cfg := validDoctorWorkflow("/repo")
+	cfg.Agents.Routes = []workflowconfig.AgentRoute{{
+		Name:    "default",
+		Backend: workflowconfig.DefaultAgentBackendID,
+		Model:   "gpt-5.5",
+		Default: true,
+	}}
+	cfg.Agent.MaxSessionTokens = 2_000_000
+	cfg.Agent.MaxSessionContextMultiplier = 4
+
+	got := doctorWorkflowDetail("WORKFLOW.md", globalconfig.Project{}, cfg)
+	for _, want := range []string{
+		"worker-model=pinned gpt-5.5 via agents.routes.model",
+		"session-guard=max_session_tokens=2000000, max_session_context_multiplier=4",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("doctorWorkflowDetail() = %q, want substring %q", got, want)

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -1403,10 +1403,8 @@ func doctorWorkflowHasDefaultRouteModel(cfg workflowconfig.Config) bool {
 }
 
 type doctorWorkflowModelConfig struct {
-	Model      string
-	Source     string
-	RouteIndex int
-	BackendID  string
+	Model  string
+	Source string
 }
 
 func doctorWorkflowWorkerModelChoice(cfg workflowconfig.Config) doctorWorkflowModelChoice {
@@ -1523,7 +1521,7 @@ func doctorWorkflowModelGeneration(model string) (int, int, bool) {
 
 func doctorWorkflowDefaultRouteModelConfig(cfg workflowconfig.Config) (doctorWorkflowModelConfig, bool) {
 	backends := doctorWorkflowBackendConfigsByID(cfg)
-	for index, route := range cfg.AgentRouteConfigs() {
+	for _, route := range cfg.AgentRouteConfigs() {
 		role := strings.ToLower(strings.TrimSpace(route.Role))
 		if role != "" && role != "code" {
 			continue
@@ -1533,28 +1531,22 @@ func doctorWorkflowDefaultRouteModelConfig(cfg workflowconfig.Config) (doctorWor
 		}
 		if model := strings.TrimSpace(route.Model); model != "" {
 			return doctorWorkflowModelConfig{
-				Model:      model,
-				Source:     "agents.routes.model",
-				RouteIndex: index,
-				BackendID:  strings.TrimSpace(route.Backend),
+				Model:  model,
+				Source: "agents.routes.model",
 			}, true
 		}
 		backend, ok := backends[strings.TrimSpace(route.Backend)]
 		if ok {
 			if model := doctorWorkflowBackendCommandModel(backend); model != "" {
 				return doctorWorkflowModelConfig{
-					Model:      model,
-					Source:     "agents.backends.command",
-					RouteIndex: index,
-					BackendID:  strings.TrimSpace(route.Backend),
+					Model:  model,
+					Source: "agents.backends.command",
 				}, true
 			}
 		}
 		if strings.TrimSpace(route.ModelField) != "" {
 			return doctorWorkflowModelConfig{
-				Source:     "agents.routes.model_field",
-				RouteIndex: index,
-				BackendID:  strings.TrimSpace(route.Backend),
+				Source: "agents.routes.model_field",
 			}, true
 		}
 	}

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -12,6 +12,7 @@ import (
 	"net/url"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -34,6 +35,9 @@ const (
 	doctorWorkflowRuleValidatorModel                 = "validator_model"
 	doctorWorkflowRuleEmptyModelTelemetry            = "empty_model_telemetry"
 	doctorWorkflowRulePinnedRouteModelRejected       = "pinned_route_model_rejected"
+	doctorWorkflowRulePinnedWorkerModelStale         = "pinned_worker_model_stale"
+	doctorWorkflowRuleSessionMultiplierKills         = "session_multiplier_ceiling_kills"
+	doctorWorkflowRuleNoSessionTokenBrake            = "no_session_token_brake"
 	doctorWorkflowRuleBudgetEstimateDrift            = "budget_estimate_drift"
 	doctorWorkflowRuleSchedulerSkipRate              = "scheduler_skip_rate"
 	doctorWorkflowRuleInvalidWorkpadStatusRecurrence = "invalid_workpad_status_recurrence"
@@ -79,48 +83,76 @@ type doctorWorkflowOptimizationOptions struct {
 type doctorWorkflowOptimizationProjectReport struct {
 	ProjectID    string                            `json:"project_id"`
 	WorkflowPath string                            `json:"workflow_path,omitempty"`
+	ModelChoice  doctorWorkflowModelChoice         `json:"model_choice"`
+	SessionGuard doctorWorkflowSessionGuard        `json:"session_guard"`
 	Metrics      doctorWorkflowOptimizationMetrics `json:"metrics"`
 	Error        string                            `json:"error,omitempty"`
 }
 
+type doctorWorkflowModelChoice struct {
+	Mode   string `json:"mode"`
+	Model  string `json:"model,omitempty"`
+	Source string `json:"source,omitempty"`
+}
+
+type doctorWorkflowSessionGuard struct {
+	MaxSessionTokens            int64   `json:"max_session_tokens"`
+	MaxSessionContextMultiplier float64 `json:"max_session_context_multiplier"`
+}
+
 type doctorWorkflowOptimizationMetrics struct {
-	SessionCount                     int64   `json:"session_count"`
-	UsageEventCount                  int64   `json:"usage_event_count"`
-	InputTokens                      int64   `json:"input_tokens"`
-	CachedInputTokens                int64   `json:"cached_input_tokens"`
-	OutputTokens                     int64   `json:"output_tokens"`
-	TotalTokens                      int64   `json:"total_tokens"`
-	InputOutputRatio                 float64 `json:"input_output_ratio"`
-	CacheReadFraction                float64 `json:"cache_read_fraction"`
-	MedianSessionTokens              int64   `json:"median_session_tokens"`
-	P90SessionTokens                 int64   `json:"p90_session_tokens"`
-	MaxSessionTokens                 int64   `json:"max_session_tokens"`
-	MaxSessionsPerIssue              int64   `json:"max_sessions_per_issue"`
-	MaxSessionsIssue                 string  `json:"max_sessions_issue,omitempty"`
-	RecentSessionCount               int64   `json:"recent_session_count"`
-	EmptyModelRecentSessions         int64   `json:"empty_model_recent_sessions"`
-	EmptyModelRecentFraction         float64 `json:"empty_model_recent_fraction"`
-	MaxReworkLapsPerIssue            int64   `json:"max_rework_laps_per_issue"`
-	MaxReworkLapsIssue               string  `json:"max_rework_laps_issue,omitempty"`
-	FailureTokens                    int64   `json:"failure_tokens"`
-	SchedulerDecisionCount           int64   `json:"scheduler_decision_count"`
-	SchedulerSkippedDecisions        int64   `json:"scheduler_skipped_decisions"`
-	SchedulerSkipRate                float64 `json:"scheduler_skip_rate"`
-	LaneEventCount                   int64   `json:"lane_event_count"`
-	LaneDwellP90Seconds              int64   `json:"lane_dwell_p90_seconds"`
-	SlowestLane                      string  `json:"slowest_lane,omitempty"`
-	SlowestLaneP90Seconds            int64   `json:"slowest_lane_p90_seconds"`
-	BudgetEstimateTokens             int64   `json:"budget_estimate_tokens"`
-	BudgetEstimateBillableTokens     int64   `json:"budget_estimate_billable_tokens"`
-	P90SessionBillableTokens         int64   `json:"p90_session_billable_tokens"`
-	BudgetEstimateBillableDriftRatio float64 `json:"budget_estimate_billable_drift_ratio"`
-	BudgetEstimateDriftRatio         float64 `json:"budget_estimate_drift_ratio"`
-	ReviewEntryCount                 int64   `json:"review_entry_count"`
-	ReviewEntryIssue                 string  `json:"review_entry_issue,omitempty"`
-	ReviewEntryIssueCount            int64   `json:"review_entry_issue_count"`
-	InvalidWorkpadStatusDecisions    int64   `json:"invalid_workpad_status_decisions"`
-	InvalidWorkpadStatusIssue        string  `json:"invalid_workpad_status_issue,omitempty"`
-	InvalidWorkpadStatusIssueCount   int64   `json:"invalid_workpad_status_issue_count"`
+	SessionCount                     int64                                `json:"session_count"`
+	UsageEventCount                  int64                                `json:"usage_event_count"`
+	InputTokens                      int64                                `json:"input_tokens"`
+	CachedInputTokens                int64                                `json:"cached_input_tokens"`
+	OutputTokens                     int64                                `json:"output_tokens"`
+	TotalTokens                      int64                                `json:"total_tokens"`
+	InputOutputRatio                 float64                              `json:"input_output_ratio"`
+	CacheReadFraction                float64                              `json:"cache_read_fraction"`
+	MedianSessionTokens              int64                                `json:"median_session_tokens"`
+	P90SessionTokens                 int64                                `json:"p90_session_tokens"`
+	MaxSessionTokens                 int64                                `json:"max_session_tokens"`
+	MaxSessionsPerIssue              int64                                `json:"max_sessions_per_issue"`
+	MaxSessionsIssue                 string                               `json:"max_sessions_issue,omitempty"`
+	RecentSessionCount               int64                                `json:"recent_session_count"`
+	EmptyModelRecentSessions         int64                                `json:"empty_model_recent_sessions"`
+	EmptyModelRecentFraction         float64                              `json:"empty_model_recent_fraction"`
+	RecentModels                     []doctorWorkflowModelTelemetry       `json:"recent_models,omitempty"`
+	RecentDefaultModels              []doctorWorkflowModelTelemetry       `json:"recent_default_models,omitempty"`
+	SessionMultiplierKills           []doctorWorkflowSessionGuardIncident `json:"session_multiplier_kills,omitempty"`
+	MaxReworkLapsPerIssue            int64                                `json:"max_rework_laps_per_issue"`
+	MaxReworkLapsIssue               string                               `json:"max_rework_laps_issue,omitempty"`
+	FailureTokens                    int64                                `json:"failure_tokens"`
+	SchedulerDecisionCount           int64                                `json:"scheduler_decision_count"`
+	SchedulerSkippedDecisions        int64                                `json:"scheduler_skipped_decisions"`
+	SchedulerSkipRate                float64                              `json:"scheduler_skip_rate"`
+	LaneEventCount                   int64                                `json:"lane_event_count"`
+	LaneDwellP90Seconds              int64                                `json:"lane_dwell_p90_seconds"`
+	SlowestLane                      string                               `json:"slowest_lane,omitempty"`
+	SlowestLaneP90Seconds            int64                                `json:"slowest_lane_p90_seconds"`
+	BudgetEstimateTokens             int64                                `json:"budget_estimate_tokens"`
+	BudgetEstimateBillableTokens     int64                                `json:"budget_estimate_billable_tokens"`
+	P90SessionBillableTokens         int64                                `json:"p90_session_billable_tokens"`
+	BudgetEstimateBillableDriftRatio float64                              `json:"budget_estimate_billable_drift_ratio"`
+	BudgetEstimateDriftRatio         float64                              `json:"budget_estimate_drift_ratio"`
+	ReviewEntryCount                 int64                                `json:"review_entry_count"`
+	ReviewEntryIssue                 string                               `json:"review_entry_issue,omitempty"`
+	ReviewEntryIssueCount            int64                                `json:"review_entry_issue_count"`
+	InvalidWorkpadStatusDecisions    int64                                `json:"invalid_workpad_status_decisions"`
+	InvalidWorkpadStatusIssue        string                               `json:"invalid_workpad_status_issue,omitempty"`
+	InvalidWorkpadStatusIssueCount   int64                                `json:"invalid_workpad_status_issue_count"`
+}
+
+type doctorWorkflowModelTelemetry struct {
+	Model        string `json:"model"`
+	SessionCount int64  `json:"session_count"`
+}
+
+type doctorWorkflowSessionGuardIncident struct {
+	IssueIdentifier   string  `json:"issue_identifier"`
+	AttemptCount      int64   `json:"attempt_count"`
+	CeilingTokens     int64   `json:"ceiling_tokens"`
+	ContextMultiplier float64 `json:"context_multiplier"`
 }
 
 type doctorWorkflowOptimizationFinding struct {
@@ -151,7 +183,23 @@ type doctorWorkflowSessionMetrics struct {
 	issueSessionCounts       map[string]int64
 	recentSessionCount       int64
 	emptyModelRecentSessions int64
+	recentModelCounts        map[string]int64
+	recentDefaultModelCounts map[string]int64
 	failureTokens            int64
+}
+
+type doctorWorkflowAnalyzedProject struct {
+	projectID    string
+	workflowPath string
+	config       workflowconfig.Config
+	metrics      doctorWorkflowOptimizationMetrics
+}
+
+type doctorWorkflowObservedDefaultModel struct {
+	Model        string
+	SessionCount int64
+	Major        int
+	Minor        int
 }
 
 type doctorWorkflowUsageMetrics struct {
@@ -296,6 +344,7 @@ func doctorWorkflowOptimization(
 ) (doctorWorkflowOptimizationReport, error) {
 	options = doctorWorkflowOptimizationOptionsWithDefaults(options)
 	report := doctorWorkflowOptimizationReport{StorePath: storePath}
+	analyzedProjects := make([]doctorWorkflowAnalyzedProject, 0, len(cfg.Projects))
 	for _, project := range cfg.Projects {
 		projectID := doctorProjectID(project)
 		workflowPath, workflowPathErr := doctorWorkflowOptimizationWorkflowPath(project)
@@ -328,7 +377,15 @@ func doctorWorkflowOptimization(
 		report.Projects = append(report.Projects, doctorWorkflowOptimizationProjectReport{
 			ProjectID:    projectID,
 			WorkflowPath: workflowPath,
+			ModelChoice:  doctorWorkflowWorkerModelChoice(workflow.Config),
+			SessionGuard: doctorWorkflowSessionGuardConfig(workflow.Config),
 			Metrics:      metrics,
+		})
+		analyzedProjects = append(analyzedProjects, doctorWorkflowAnalyzedProject{
+			projectID:    projectID,
+			workflowPath: workflowPath,
+			config:       workflow.Config,
+			metrics:      metrics,
 		})
 		findings := doctorWorkflowOptimizationFindings(projectID, workflowPath, workflow.Config, metrics)
 		report.Findings = append(report.Findings, findings...)
@@ -343,6 +400,24 @@ func doctorWorkflowOptimization(
 				return doctorWorkflowOptimizationReport{}, err
 			}
 			report.CreatedProposalIssues = append(report.CreatedProposalIssues, created...)
+		}
+	}
+	if observed, ok := doctorWorkflowObservedDefaultModelForProjects(analyzedProjects); ok {
+		for _, project := range analyzedProjects {
+			finding, stale := doctorWorkflowStalePinnedModelFinding(project, observed)
+			if !stale {
+				continue
+			}
+			report.Findings = append(report.Findings, finding)
+			proposals := doctorWorkflowProposalsForFindings(project.projectID, []doctorWorkflowOptimizationFinding{finding}, options.ProposalThreshold)
+			report.Proposals = append(report.Proposals, proposals...)
+			if options.ProposeIssues {
+				created, err := createDoctorWorkflowImprovementProposalIssues(ctx, project.projectID, project.config, deps, proposals)
+				if err != nil {
+					return doctorWorkflowOptimizationReport{}, err
+				}
+				report.CreatedProposalIssues = append(report.CreatedProposalIssues, created...)
+			}
 		}
 	}
 
@@ -404,6 +479,10 @@ func doctorWorkflowOptimizationMetricsForProject(
 	if err != nil {
 		return doctorWorkflowOptimizationMetrics{}, err
 	}
+	sessionMultiplierKills, err := doctorWorkflowSessionGuardTelemetry(ctx, db, projectID)
+	if err != nil {
+		return doctorWorkflowOptimizationMetrics{}, err
+	}
 
 	metrics := doctorWorkflowOptimizationMetrics{
 		SessionCount:                   sessions.count,
@@ -418,6 +497,9 @@ func doctorWorkflowOptimizationMetricsForProject(
 		MaxSessionTokens:               doctorMaxInt64(sessions.totalTokensBySession),
 		RecentSessionCount:             sessions.recentSessionCount,
 		EmptyModelRecentSessions:       sessions.emptyModelRecentSessions,
+		RecentModels:                   doctorWorkflowRecentModelTelemetry(sessions.recentModelCounts),
+		RecentDefaultModels:            doctorWorkflowRecentModelTelemetry(sessions.recentDefaultModelCounts),
+		SessionMultiplierKills:         sessionMultiplierKills,
 		MaxSessionsPerIssue:            doctorMaxMapValue(sessions.issueSessionCounts),
 		MaxSessionsIssue:               doctorMaxMapKey(sessions.issueSessionCounts),
 		FailureTokens:                  sessions.failureTokens,
@@ -633,6 +715,7 @@ SELECT
   COALESCE(s.cached_input_tokens, 0),
   COALESCE(s.output_tokens, 0),
   COALESCE(s.model, ''),
+  COALESCE(s.requested_model, ''),
   COALESCE(s.final_state, ''),
   COALESCE(NULLIF(s.identifier, ''), NULLIF(s.issue_id, ''), NULLIF(s.issue_url, ''), 'unassigned'),
   COALESCE(s.completed_at, '')
@@ -654,7 +737,9 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 	defer rows.Close()
 
 	metrics := doctorWorkflowSessionMetrics{
-		issueSessionCounts: map[string]int64{},
+		issueSessionCounts:       map[string]int64{},
+		recentModelCounts:        map[string]int64{},
+		recentDefaultModelCounts: map[string]int64{},
 	}
 	var recentCutoff time.Time
 	for rows.Next() {
@@ -663,10 +748,11 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		var cachedInputTokens int64
 		var outputTokens int64
 		var model string
+		var requestedModel string
 		var finalState string
 		var issueKey string
 		var completedAtRaw string
-		if err := rows.Scan(&totalTokens, &inputTokens, &cachedInputTokens, &outputTokens, &model, &finalState, &issueKey, &completedAtRaw); err != nil {
+		if err := rows.Scan(&totalTokens, &inputTokens, &cachedInputTokens, &outputTokens, &model, &requestedModel, &finalState, &issueKey, &completedAtRaw); err != nil {
 			return doctorWorkflowSessionMetrics{}, err
 		}
 		completedAt, err := doctorWorkflowSessionTimestamp(completedAtRaw)
@@ -690,8 +776,14 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		}
 		if metrics.recentSessionCount < doctorWorkflowRecentSessionLimit && !completedAt.Before(recentCutoff) {
 			metrics.recentSessionCount++
-			if strings.TrimSpace(model) == "" {
+			model = strings.TrimSpace(model)
+			if model == "" {
 				metrics.emptyModelRecentSessions++
+			} else {
+				metrics.recentModelCounts[model]++
+				if strings.TrimSpace(requestedModel) == "" {
+					metrics.recentDefaultModelCounts[model]++
+				}
 			}
 		}
 		if doctorWorkflowSessionFailed(finalState) {
@@ -702,6 +794,103 @@ ORDER BY s.completed_at DESC, s.id DESC`, projectID, projectID)
 		return doctorWorkflowSessionMetrics{}, err
 	}
 	return metrics, nil
+}
+
+func doctorWorkflowRecentModelTelemetry(counts map[string]int64) []doctorWorkflowModelTelemetry {
+	models := make([]doctorWorkflowModelTelemetry, 0, len(counts))
+	for model, count := range counts {
+		models = append(models, doctorWorkflowModelTelemetry{Model: model, SessionCount: count})
+	}
+	sort.Slice(models, func(i, j int) bool {
+		if models[i].SessionCount != models[j].SessionCount {
+			return models[i].SessionCount > models[j].SessionCount
+		}
+		return models[i].Model < models[j].Model
+	})
+	return models
+}
+
+func doctorWorkflowSessionGuardTelemetry(ctx context.Context, db doctorTelemetryStore, projectID string) ([]doctorWorkflowSessionGuardIncident, error) {
+	rows, err := db.QueryContext(ctx, `
+SELECT
+  COALESCE(NULLIF(identifier, ''), NULLIF(issue_id, ''), NULLIF(issue_url, ''), 'unassigned'),
+  COALESCE(error_message, '')
+FROM work_attempts
+WHERE completed_at IS NOT NULL
+  AND (? = '' OR project_id = ?)
+  AND error_message LIKE '%session token ceiling exceeded%'
+  AND error_message LIKE '%source=max_session_context_multiplier%'
+ORDER BY completed_at DESC, id DESC`, projectID, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("read session guard telemetry: %w", err)
+	}
+	defer rows.Close()
+
+	byIssue := map[string]*doctorWorkflowSessionGuardIncident{}
+	for rows.Next() {
+		var issueIdentifier string
+		var errorMessage string
+		if err := rows.Scan(&issueIdentifier, &errorMessage); err != nil {
+			return nil, err
+		}
+		issueIdentifier = strings.TrimSpace(issueIdentifier)
+		incident, ok := byIssue[issueIdentifier]
+		if !ok {
+			incident = &doctorWorkflowSessionGuardIncident{IssueIdentifier: issueIdentifier}
+			byIssue[issueIdentifier] = incident
+		}
+		incident.AttemptCount++
+		if incident.CeilingTokens == 0 {
+			incident.CeilingTokens = doctorWorkflowErrorInt64(errorMessage, "ceiling_tokens")
+		}
+		if incident.ContextMultiplier == 0 {
+			incident.ContextMultiplier = doctorWorkflowErrorFloat64(errorMessage, "context_multiplier")
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+
+	incidents := make([]doctorWorkflowSessionGuardIncident, 0, len(byIssue))
+	for _, incident := range byIssue {
+		incidents = append(incidents, *incident)
+	}
+	sort.Slice(incidents, func(i, j int) bool {
+		if incidents[i].AttemptCount != incidents[j].AttemptCount {
+			return incidents[i].AttemptCount > incidents[j].AttemptCount
+		}
+		return incidents[i].IssueIdentifier < incidents[j].IssueIdentifier
+	})
+	return incidents, nil
+}
+
+func doctorWorkflowErrorInt64(message string, key string) int64 {
+	value := doctorWorkflowErrorValue(message, key)
+	parsed, err := strconv.ParseInt(value, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
+}
+
+func doctorWorkflowErrorFloat64(message string, key string) float64 {
+	value := doctorWorkflowErrorValue(message, key)
+	parsed, err := strconv.ParseFloat(value, 64)
+	if err != nil {
+		return 0
+	}
+	return parsed
+}
+
+func doctorWorkflowErrorValue(message string, key string) string {
+	prefix := strings.TrimSpace(key) + "="
+	for _, field := range strings.Fields(message) {
+		field = strings.Trim(field, ",;()[]{}")
+		if value, ok := strings.CutPrefix(field, prefix); ok {
+			return strings.Trim(value, ",;()[]{}")
+		}
+	}
+	return ""
 }
 
 func doctorWorkflowSessionTimestamp(value string) (time.Time, error) {
@@ -854,6 +1043,63 @@ func doctorWorkflowOptimizationFindings(
 			}
 		}
 	}
+	if cfg.Agent.MaxSessionTokens <= 0 && cfg.Agent.MaxSessionContextMultiplier <= 0 {
+		patches := []doctorWorkflowOptimizationPatch{}
+		if metrics.MedianSessionTokens > 0 {
+			patches = append(patches, doctorWorkflowOptimizationPatch{
+				Path:  "agent.max_session_tokens",
+				Value: doctorRoundUpInt64(int64(float64(metrics.MedianSessionTokens)*doctorWorkflowRunawayMedianMultiplier), 1000),
+			})
+		}
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleNoSessionTokenBrake,
+			"Session runaway brake is disabled",
+			"neither agent.max_session_tokens nor agent.max_session_context_multiplier is configured",
+			0,
+			map[string]any{
+				"max_session_tokens":             cfg.Agent.MaxSessionTokens,
+				"max_session_context_multiplier": cfg.Agent.MaxSessionContextMultiplier,
+				"unbraked_session_count":         metrics.SessionCount,
+			},
+			patches...,
+		))
+	}
+	if incidents := doctorWorkflowRepeatedSessionGuardIncidents(metrics.SessionMultiplierKills); len(incidents) > 0 {
+		attemptCounts := make(map[string]int64, len(incidents))
+		killedIssues := make([]string, 0, len(incidents))
+		ceilingTokens := make([]int64, 0, len(incidents))
+		contextMultipliers := make([]float64, 0, len(incidents))
+		var killCount int64
+		for _, incident := range incidents {
+			attemptCounts[incident.IssueIdentifier] = incident.AttemptCount
+			killCount += incident.AttemptCount
+			killedIssues = append(killedIssues, fmt.Sprintf("%s x%d", incident.IssueIdentifier, incident.AttemptCount))
+			ceilingTokens = append(ceilingTokens, incident.CeilingTokens)
+			multiplier := incident.ContextMultiplier
+			if multiplier <= 0 {
+				multiplier = cfg.Agent.MaxSessionContextMultiplier
+			}
+			contextMultipliers = append(contextMultipliers, multiplier)
+		}
+		patches := []doctorWorkflowOptimizationPatch{}
+		if cfg.Agent.MaxSessionTokens > 0 && cfg.Agent.MaxSessionContextMultiplier > 0 {
+			patches = append(patches, doctorWorkflowOptimizationPatch{Path: "agent.max_session_context_multiplier", Value: 0})
+		}
+		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleSessionMultiplierKills,
+			"Session context multiplier repeatedly killed work",
+			fmt.Sprintf("%s produced %d session token ceiling kills at ceiling(s) %s for %s; remove or recalibrate the multiplier and rely on an intentional max_session_tokens cap", doctorWorkflowMultiplierList(contextMultipliers), killCount, doctorWorkflowInt64List(ceilingTokens), strings.Join(killedIssues, ", ")),
+			0,
+			map[string]any{
+				"configured_max_session_tokens":             cfg.Agent.MaxSessionTokens,
+				"configured_max_session_context_multiplier": cfg.Agent.MaxSessionContextMultiplier,
+				"context_multipliers":                       contextMultipliers,
+				"ceiling_tokens":                            ceilingTokens,
+				"killed_issues":                             killedIssues,
+				"attempt_counts":                            attemptCounts,
+				"session_multiplier_kill_count":             killCount,
+			},
+			patches...,
+		))
+	}
 	if metrics.MaxReworkLapsPerIssue > doctorWorkflowReworkLapThreshold && (cfg.Agent.AutoPromote.ReworkLimit == 0 || metrics.MaxReworkLapsPerIssue > int64(cfg.Agent.AutoPromote.ReworkLimit)) {
 		value := int(math.Max(1, math.Min(float64(metrics.MaxReworkLapsPerIssue-1), 2)))
 		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleReworkLaps,
@@ -881,7 +1127,7 @@ func doctorWorkflowOptimizationFindings(
 			doctorWorkflowOptimizationPatch{Path: "gate.validator.model", Value: doctorWorkflowValidatorModel},
 		))
 	}
-	if metrics.RecentSessionCount > 0 && metrics.EmptyModelRecentSessions > 0 && metrics.EmptyModelRecentFraction >= doctorWorkflowEmptyModelMinFraction {
+	if cfg.Budget.Enabled && metrics.RecentSessionCount > 0 && metrics.EmptyModelRecentSessions > 0 && metrics.EmptyModelRecentFraction >= doctorWorkflowEmptyModelMinFraction {
 		detail := fmt.Sprintf("%d of %d recent sessions have an empty model", metrics.EmptyModelRecentSessions, metrics.RecentSessionCount)
 		evidence := map[string]any{
 			"recent_session_count":        metrics.RecentSessionCount,
@@ -895,12 +1141,14 @@ func doctorWorkflowOptimizationFindings(
 				evidence["configured_model"] = modelConfig.Model
 			}
 		}
-		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleEmptyModelTelemetry,
+		finding := doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleEmptyModelTelemetry,
 			"Session model telemetry is incomplete",
 			detail,
 			0,
 			evidence,
-		))
+		)
+		finding.Severity = "info"
+		findings = append(findings, finding)
 	}
 	if metrics.P90SessionBillableTokens > 0 && metrics.BudgetEstimateDriftRatio >= doctorWorkflowBudgetDriftRatio {
 		findings = append(findings, doctorWorkflowFinding(projectID, workflowPath, doctorWorkflowRuleBudgetEstimateDrift,
@@ -1155,13 +1403,127 @@ func doctorWorkflowHasDefaultRouteModel(cfg workflowconfig.Config) bool {
 }
 
 type doctorWorkflowModelConfig struct {
-	Model  string
-	Source string
+	Model      string
+	Source     string
+	RouteIndex int
+	BackendID  string
+}
+
+func doctorWorkflowWorkerModelChoice(cfg workflowconfig.Config) doctorWorkflowModelChoice {
+	modelConfig, ok := doctorWorkflowDefaultRouteModelConfig(cfg)
+	if ok && strings.TrimSpace(modelConfig.Model) != "" {
+		return doctorWorkflowModelChoice{
+			Mode:   "pinned",
+			Model:  strings.TrimSpace(modelConfig.Model),
+			Source: modelConfig.Source,
+		}
+	}
+	choice := doctorWorkflowModelChoice{Mode: "provider_default"}
+	if ok {
+		choice.Source = modelConfig.Source
+	}
+	return choice
+}
+
+func doctorWorkflowSessionGuardConfig(cfg workflowconfig.Config) doctorWorkflowSessionGuard {
+	return doctorWorkflowSessionGuard{
+		MaxSessionTokens:            cfg.Agent.MaxSessionTokens,
+		MaxSessionContextMultiplier: cfg.Agent.MaxSessionContextMultiplier,
+	}
+}
+
+func doctorWorkflowObservedDefaultModelForProjects(projects []doctorWorkflowAnalyzedProject) (doctorWorkflowObservedDefaultModel, bool) {
+	counts := map[string]int64{}
+	for _, project := range projects {
+		if doctorWorkflowWorkerModelChoice(project.config).Mode != "provider_default" {
+			continue
+		}
+		for _, telemetry := range project.metrics.RecentDefaultModels {
+			counts[strings.TrimSpace(telemetry.Model)] += telemetry.SessionCount
+		}
+	}
+
+	var observed doctorWorkflowObservedDefaultModel
+	found := false
+	for model, count := range counts {
+		major, minor, ok := doctorWorkflowModelGeneration(model)
+		if !ok {
+			continue
+		}
+		candidate := doctorWorkflowObservedDefaultModel{
+			Model:        model,
+			SessionCount: count,
+			Major:        major,
+			Minor:        minor,
+		}
+		if !found || doctorWorkflowObservedModelLess(observed, candidate) {
+			observed = candidate
+			found = true
+		}
+	}
+	return observed, found
+}
+
+func doctorWorkflowObservedModelLess(left doctorWorkflowObservedDefaultModel, right doctorWorkflowObservedDefaultModel) bool {
+	if left.Major != right.Major {
+		return left.Major < right.Major
+	}
+	if left.Minor != right.Minor {
+		return left.Minor < right.Minor
+	}
+	if left.SessionCount != right.SessionCount {
+		return left.SessionCount < right.SessionCount
+	}
+	return left.Model < right.Model
+}
+
+func doctorWorkflowStalePinnedModelFinding(project doctorWorkflowAnalyzedProject, observed doctorWorkflowObservedDefaultModel) (doctorWorkflowOptimizationFinding, bool) {
+	choice := doctorWorkflowWorkerModelChoice(project.config)
+	if choice.Mode != "pinned" {
+		return doctorWorkflowOptimizationFinding{}, false
+	}
+	major, minor, ok := doctorWorkflowModelGeneration(choice.Model)
+	if !ok || major > observed.Major || major == observed.Major && minor >= observed.Minor {
+		return doctorWorkflowOptimizationFinding{}, false
+	}
+	return doctorWorkflowFinding(project.projectID, project.workflowPath, doctorWorkflowRulePinnedWorkerModelStale,
+		"Pinned worker model trails the observed provider default",
+		fmt.Sprintf("pinned worker model %s via %s is generation-behind observed default model %s from %d unpinned session(s); keep, update, or remove the pin according to this project's intended model policy", choice.Model, choice.Source, observed.Model, observed.SessionCount),
+		0,
+		map[string]any{
+			"model_choice":              choice.Mode,
+			"pinned_model":              choice.Model,
+			"configured_model_source":   choice.Source,
+			"observed_default_model":    observed.Model,
+			"observed_default_sessions": observed.SessionCount,
+		},
+	), true
+}
+
+func doctorWorkflowModelGeneration(model string) (int, int, bool) {
+	version, ok := strings.CutPrefix(strings.ToLower(strings.TrimSpace(model)), "gpt-")
+	if !ok {
+		return 0, 0, false
+	}
+	version, _, _ = strings.Cut(version, "-")
+	parts := strings.Split(version, ".")
+	if len(parts) < 2 {
+		return 0, 0, false
+	}
+	major, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, false
+	}
+	minor, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, false
+	}
+	return major, minor, true
 }
 
 func doctorWorkflowDefaultRouteModelConfig(cfg workflowconfig.Config) (doctorWorkflowModelConfig, bool) {
 	backends := doctorWorkflowBackendConfigsByID(cfg)
-	for _, route := range cfg.AgentRouteConfigs() {
+	for index, route := range cfg.AgentRouteConfigs() {
 		role := strings.ToLower(strings.TrimSpace(route.Role))
 		if role != "" && role != "code" {
 			continue
@@ -1171,23 +1533,28 @@ func doctorWorkflowDefaultRouteModelConfig(cfg workflowconfig.Config) (doctorWor
 		}
 		if model := strings.TrimSpace(route.Model); model != "" {
 			return doctorWorkflowModelConfig{
-				Model:  model,
-				Source: "agents.routes.model",
-			}, true
-		}
-		if strings.TrimSpace(route.ModelField) != "" {
-			return doctorWorkflowModelConfig{
-				Source: "agents.routes.model_field",
+				Model:      model,
+				Source:     "agents.routes.model",
+				RouteIndex: index,
+				BackendID:  strings.TrimSpace(route.Backend),
 			}, true
 		}
 		backend, ok := backends[strings.TrimSpace(route.Backend)]
-		if !ok {
-			continue
+		if ok {
+			if model := doctorWorkflowBackendCommandModel(backend); model != "" {
+				return doctorWorkflowModelConfig{
+					Model:      model,
+					Source:     "agents.backends.command",
+					RouteIndex: index,
+					BackendID:  strings.TrimSpace(route.Backend),
+				}, true
+			}
 		}
-		if model := doctorWorkflowBackendCommandModel(backend); model != "" {
+		if strings.TrimSpace(route.ModelField) != "" {
 			return doctorWorkflowModelConfig{
-				Model:  model,
-				Source: "agents.backends.command",
+				Source:     "agents.routes.model_field",
+				RouteIndex: index,
+				BackendID:  strings.TrimSpace(route.Backend),
 			}, true
 		}
 	}
@@ -1477,6 +1844,56 @@ func doctorWorkflowUsageFailed(outcome string) bool {
 	default:
 		return false
 	}
+}
+
+func doctorWorkflowRepeatedSessionGuardIncidents(incidents []doctorWorkflowSessionGuardIncident) []doctorWorkflowSessionGuardIncident {
+	repeated := make([]doctorWorkflowSessionGuardIncident, 0, len(incidents))
+	for _, incident := range incidents {
+		if incident.AttemptCount >= 2 {
+			repeated = append(repeated, incident)
+		}
+	}
+	return repeated
+}
+
+func doctorWorkflowInt64List(values []int64) string {
+	unique := map[int64]struct{}{}
+	for _, value := range values {
+		if value > 0 {
+			unique[value] = struct{}{}
+		}
+	}
+	sorted := make([]int64, 0, len(unique))
+	for value := range unique {
+		sorted = append(sorted, value)
+	}
+	slices.Sort(sorted)
+	if len(sorted) == 0 {
+		return "unknown"
+	}
+	parts := make([]string, 0, len(sorted))
+	for _, value := range sorted {
+		parts = append(parts, strconv.FormatInt(value, 10))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func doctorWorkflowMultiplierList(values []float64) string {
+	unique := map[string]struct{}{}
+	for _, value := range values {
+		if value > 0 {
+			unique[strconv.FormatFloat(value, 'g', -1, 64)] = struct{}{}
+		}
+	}
+	formatted := make([]string, 0, len(unique))
+	for value := range unique {
+		formatted = append(formatted, "max_session_context_multiplier="+value)
+	}
+	slices.Sort(formatted)
+	if len(formatted) == 0 {
+		return "max_session_context_multiplier=unknown"
+	}
+	return strings.Join(formatted, ", ")
 }
 
 func doctorWorkflowBillableTokens(inputTokens int64, cachedInputTokens int64, outputTokens int64, totalTokens int64, model string, pricing budget.PricingTable) int64 {
@@ -1884,7 +2301,7 @@ func doctorWorkflowFrontmatterRoot(frontmatter []byte) (*yaml.Node, error) {
 func doctorApplyWorkflowOptimizationPatch(root *yaml.Node, patch doctorWorkflowOptimizationPatch) error {
 	path := strings.TrimSpace(patch.Path)
 	switch path {
-	case "agent.max_session_tokens", "agent.auto_promote.rework_limit", "gate.validator.model", "polling.interval_ms", "budget.per_issue_max_usd":
+	case "agent.max_session_tokens", "agent.max_session_context_multiplier", "agent.auto_promote.rework_limit", "gate.validator.model", "polling.interval_ms", "budget.per_issue_max_usd":
 		return doctorSetSimpleYAMLPath(root, strings.Split(patch.Path, "."), patch.Value)
 	case "agents.routes.default.model":
 		return doctorSetDefaultRouteModel(root, fmt.Sprint(patch.Value))

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"slices"
@@ -334,7 +335,11 @@ func TestDoctorWorkflowOptimizationFindingsTokenImpactIsAvoidable(t *testing.T) 
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", workflowconfig.Config{}, tt.metrics)
+			cfg := workflowconfig.Config{}
+			if tt.ruleID == doctorWorkflowRuleEmptyModelTelemetry {
+				cfg.Budget.Enabled = true
+			}
+			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", cfg, tt.metrics)
 			finding := doctorWorkflowFindingByRule(t, findings, tt.ruleID)
 			if finding.EstimatedTokenImpact != 0 {
 				t.Fatalf("EstimatedTokenImpact = %d, want 0", finding.EstimatedTokenImpact)
@@ -599,6 +604,307 @@ func TestDoctorWorkflowOptimizationRunawaySessionTokensRespectsConfiguredCap(t *
 	}
 }
 
+func TestDoctorWorkflowOptimizationFlagsMissingSessionBrake(t *testing.T) {
+	t.Parallel()
+
+	findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", workflowconfig.Config{}, doctorWorkflowOptimizationMetrics{
+		SessionCount:        3,
+		MedianSessionTokens: 10_000,
+	})
+	if !doctorWorkflowFindingExists(findings, "no_session_token_brake") {
+		t.Fatalf("findings = %#v, want no_session_token_brake", findings)
+	}
+}
+
+func TestDoctorWorkflowOptimizationModelAndSessionGuardConfigurations(t *testing.T) {
+	t.Parallel()
+
+	pinnedConfig := func(model string) workflowconfig.Config {
+		cfg := workflowconfig.Config{}
+		cfg.Agent.MaxSessionTokens = 2_000_000
+		cfg.Agents.Routes = []workflowconfig.AgentRoute{{
+			Name:    "default",
+			Backend: workflowconfig.DefaultAgentBackendID,
+			Model:   model,
+			Default: true,
+		}}
+		return cfg
+	}
+	unpinnedConfig := func() workflowconfig.Config {
+		cfg := workflowconfig.Config{}
+		cfg.Agent.MaxSessionTokens = 2_000_000
+		return cfg
+	}
+	observed := doctorWorkflowObservedDefaultModel{Model: "gpt-5.6-sol", SessionCount: 6, Major: 5, Minor: 6}
+	tests := []struct {
+		name         string
+		cfg          workflowconfig.Config
+		metrics      doctorWorkflowOptimizationMetrics
+		wantMode     string
+		wantRules    []string
+		wantNoRules  []string
+		wantDetail   []string
+		wantSeverity map[string]string
+	}{
+		{
+			name:        "pinned healthy",
+			cfg:         pinnedConfig("gpt-5.6-sol"),
+			wantMode:    "pinned",
+			wantNoRules: []string{doctorWorkflowRulePinnedWorkerModelStale, doctorWorkflowRuleNoSessionTokenBrake},
+		},
+		{
+			name:       "pinned stale",
+			cfg:        pinnedConfig("gpt-5.5"),
+			wantMode:   "pinned",
+			wantRules:  []string{doctorWorkflowRulePinnedWorkerModelStale},
+			wantDetail: []string{"gpt-5.5", "gpt-5.6-sol", "keep, update, or remove"},
+		},
+		{
+			name: "unpinned",
+			cfg: func() workflowconfig.Config {
+				cfg := unpinnedConfig()
+				cfg.Budget.Enabled = true
+				return cfg
+			}(),
+			metrics: doctorWorkflowOptimizationMetrics{
+				RecentSessionCount:       5,
+				EmptyModelRecentSessions: 2,
+				EmptyModelRecentFraction: 0.4,
+			},
+			wantMode:     "provider_default",
+			wantRules:    []string{doctorWorkflowRuleEmptyModelTelemetry},
+			wantNoRules:  []string{doctorWorkflowRulePinnedWorkerModelStale},
+			wantSeverity: map[string]string{doctorWorkflowRuleEmptyModelTelemetry: "info"},
+		},
+		{
+			name: "multiplier kills",
+			cfg: func() workflowconfig.Config {
+				cfg := unpinnedConfig()
+				cfg.Agent.MaxSessionContextMultiplier = 4
+				return cfg
+			}(),
+			metrics: doctorWorkflowOptimizationMetrics{SessionMultiplierKills: []doctorWorkflowSessionGuardIncident{
+				{IssueIdentifier: "gopherguides/gopher-ai#200", AttemptCount: 5, CeilingTokens: 1_032_000, ContextMultiplier: 4},
+				{IssueIdentifier: "gopherguides/gopher-ai#196", AttemptCount: 2, CeilingTokens: 1_032_000, ContextMultiplier: 4},
+			}},
+			wantMode:   "provider_default",
+			wantRules:  []string{doctorWorkflowRuleSessionMultiplierKills},
+			wantDetail: []string{"max_session_context_multiplier=4", "1032000", "gopherguides/gopher-ai#200 x5", "gopherguides/gopher-ai#196 x2", "max_session_tokens"},
+		},
+		{
+			name:      "no brake",
+			cfg:       workflowconfig.Config{},
+			metrics:   doctorWorkflowOptimizationMetrics{SessionCount: 3, MedianSessionTokens: 10_000},
+			wantMode:  "provider_default",
+			wantRules: []string{doctorWorkflowRuleNoSessionTokenBrake},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := doctorWorkflowWorkerModelChoice(tt.cfg).Mode; got != tt.wantMode {
+				t.Fatalf("model choice = %q, want %q", got, tt.wantMode)
+			}
+			findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", tt.cfg, tt.metrics)
+			project := doctorWorkflowAnalyzedProject{projectID: "detent", workflowPath: "WORKFLOW.md", config: tt.cfg, metrics: tt.metrics}
+			if finding, ok := doctorWorkflowStalePinnedModelFinding(project, observed); ok {
+				findings = append(findings, finding)
+			}
+			for _, ruleID := range tt.wantRules {
+				finding := doctorWorkflowFindingByRule(t, findings, ruleID)
+				for _, detail := range tt.wantDetail {
+					if !strings.Contains(finding.Detail, detail) {
+						t.Fatalf("%s detail = %q, want containing %q", ruleID, finding.Detail, detail)
+					}
+				}
+				if severity := tt.wantSeverity[ruleID]; severity != "" && finding.Severity != severity {
+					t.Fatalf("%s severity = %q, want %q", ruleID, finding.Severity, severity)
+				}
+				if ruleID == doctorWorkflowRuleSessionMultiplierKills || ruleID == doctorWorkflowRuleNoSessionTokenBrake {
+					proposals := doctorWorkflowProposalsForFindings("detent", []doctorWorkflowOptimizationFinding{finding}, 2)
+					proposal := doctorWorkflowProposalBySignal(t, proposals, "doctor_finding", ruleID)
+					if proposal.TargetKind != "workflow" || proposal.TargetPath == "" {
+						t.Fatalf("%s proposal = %#v, want concrete workflow correction", ruleID, proposal)
+					}
+				}
+			}
+			for _, ruleID := range tt.wantNoRules {
+				if doctorWorkflowFindingExists(findings, ruleID) {
+					t.Fatalf("findings = %#v, do not want %s", findings, ruleID)
+				}
+			}
+		})
+	}
+}
+
+func TestDoctorWorkflowSessionGuardTelemetryGroupsMultiplierKills(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "detent.db")
+	backend, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	now := time.Date(2026, 7, 9, 12, 0, 0, 0, time.UTC)
+	kills := []struct {
+		identifier string
+		count      int
+		source     string
+	}{
+		{identifier: "gopherguides/gopher-ai#200", count: 5, source: "max_session_context_multiplier"},
+		{identifier: "gopherguides/gopher-ai#196", count: 2, source: "max_session_context_multiplier"},
+		{identifier: "gopherguides/gopher-ai#201", count: 1, source: "max_session_context_multiplier"},
+		{identifier: "gopherguides/gopher-ai#202", count: 3, source: "max_session_tokens"},
+	}
+	for _, kill := range kills {
+		for attempt := 1; attempt <= kill.count; attempt++ {
+			startedAt := now.Add(time.Duration(attempt) * time.Minute)
+			attemptID, err := backend.StartWorkAttempt(ctx, store.WorkAttemptStart{
+				ProjectID:     "gopher-ai",
+				Identifier:    kill.identifier,
+				WorkerType:    "implement",
+				AttemptNumber: attempt,
+				StartedAt:     startedAt,
+			})
+			if err != nil {
+				t.Fatalf("StartWorkAttempt(%s, %d) error = %v", kill.identifier, attempt, err)
+			}
+			errorMessage := fmt.Sprintf("session token ceiling exceeded: total_tokens=1033000 ceiling_tokens=1032000 source=%s model_context_window=258000 context_multiplier=4", kill.source)
+			if err := backend.CompleteWorkAttempt(ctx, store.WorkAttemptCompletion{
+				AttemptID:     attemptID,
+				CompletedAt:   startedAt.Add(time.Minute),
+				TerminalState: store.WorkAttemptTerminalFailure,
+				ErrorClass:    "runner_error",
+				ErrorMessage:  errorMessage,
+			}); err != nil {
+				t.Fatalf("CompleteWorkAttempt(%s, %d) error = %v", kill.identifier, attempt, err)
+			}
+		}
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	db, err := openDoctorSQLiteReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	incidents, err := doctorWorkflowSessionGuardTelemetry(ctx, db, "gopher-ai")
+	if err != nil {
+		t.Fatalf("doctorWorkflowSessionGuardTelemetry() error = %v", err)
+	}
+	if len(incidents) != 3 {
+		t.Fatalf("incidents = %#v, want three multiplier-sourced issues", incidents)
+	}
+	if incidents[0].IssueIdentifier != "gopherguides/gopher-ai#200" || incidents[0].AttemptCount != 5 || incidents[0].CeilingTokens != 1_032_000 || incidents[0].ContextMultiplier != 4 {
+		t.Fatalf("first incident = %#v, want #200 x5 at 4x/1032000", incidents[0])
+	}
+	if incidents[1].IssueIdentifier != "gopherguides/gopher-ai#196" || incidents[1].AttemptCount != 2 {
+		t.Fatalf("second incident = %#v, want #196 x2", incidents[1])
+	}
+}
+
+func TestDoctorWorkflowOptimizationFlagsPinBehindObservedDefault(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	dir := t.TempDir()
+	pinnedWorkflow := filepath.Join(dir, "PINNED_WORKFLOW.md")
+	defaultWorkflow := filepath.Join(dir, "DEFAULT_WORKFLOW.md")
+	if err := os.WriteFile(pinnedWorkflow, []byte(`---
+tracker:
+  kind: memory
+agent:
+  max_session_tokens: 2000000
+agents:
+  routes:
+    - name: default
+      backend: codex
+      model: gpt-5.5
+      default: true
+---
+Prompt
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile(pinned workflow) error = %v", err)
+	}
+	if err := os.WriteFile(defaultWorkflow, []byte(`---
+tracker:
+  kind: memory
+agent:
+  max_session_tokens: 2000000
+---
+Prompt
+`), 0o600); err != nil {
+		t.Fatalf("WriteFile(default workflow) error = %v", err)
+	}
+
+	dbPath := filepath.Join(dir, "detent.db")
+	backend, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	recordSession := func(projectID string, identifier string, requestedModel string, model string, completedAt time.Time) {
+		t.Helper()
+		sessionID, err := backend.StartSession(ctx, store.SessionStart{Identifier: identifier, StartedAt: completedAt.Add(-time.Minute), Model: requestedModel})
+		if err != nil {
+			t.Fatalf("StartSession(%s) error = %v", identifier, err)
+		}
+		if err := backend.FinishSession(ctx, sessionID, store.SessionFinish{CompletedAt: completedAt, Turns: 1, InputTokens: 900, OutputTokens: 100, TotalTokens: 1000, FinalState: "completed", Model: model}); err != nil {
+			t.Fatalf("FinishSession(%s) error = %v", identifier, err)
+		}
+		if _, err := backend.RecordUsageEvent(ctx, store.UsageEvent{ProjectID: projectID, SessionID: sessionID, Identifier: identifier, Model: model, InputTokens: 900, OutputTokens: 100, TotalTokens: 1000, Outcome: "completed", StartedAt: completedAt.Add(-time.Minute), FinishedAt: completedAt}); err != nil {
+			t.Fatalf("RecordUsageEvent(%s) error = %v", identifier, err)
+		}
+	}
+	now := time.Date(2026, 7, 9, 13, 0, 0, 0, time.UTC)
+	recordSession("pinned", "example/pinned#1", "gpt-5.5", "gpt-5.5", now)
+	recordSession("default", "example/default#1", "", "gpt-5.6-sol", now.Add(time.Minute))
+	recordSession("default", "example/default#2", "", "gpt-5.6-sol", now.Add(2*time.Minute))
+	recordSession("default", "example/default#3", "gpt-5.7-preview", "gpt-5.7-preview", now.Add(3*time.Minute))
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	db, err := openDoctorSQLiteReadOnly(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("Close() error = %v", err)
+		}
+	})
+	global := globalconfig.Config{Projects: []globalconfig.Project{
+		{ID: "pinned", Workflow: pinnedWorkflow, Workdir: dir},
+		{ID: "default", Workflow: defaultWorkflow, Workdir: dir},
+	}}
+	deps := successfulDoctorDeps()
+	deps.loadWorkflow = workflowconfig.LoadWorkflow
+	report, err := doctorWorkflowOptimization(ctx, db, dbPath, global, deps, "", doctorWorkflowOptimizationOptions{})
+	if err != nil {
+		t.Fatalf("doctorWorkflowOptimization() error = %v", err)
+	}
+	if len(report.Projects) != 2 || report.Projects[0].ModelChoice.Model != "gpt-5.5" || report.Projects[1].ModelChoice.Mode != "provider_default" {
+		t.Fatalf("project model reports = %#v", report.Projects)
+	}
+	stale := doctorWorkflowFindingByRule(t, report.Findings, doctorWorkflowRulePinnedWorkerModelStale)
+	if stale.ProjectID != "pinned" || evidenceInt64(t, stale, "observed_default_sessions") != 2 {
+		t.Fatalf("stale finding = %#v, want pinned project against two default sessions", stale)
+	}
+	proposal := doctorWorkflowProposalBySignal(t, report.Proposals, "doctor_finding", doctorWorkflowRulePinnedWorkerModelStale)
+	if !strings.Contains(proposal.SuggestedChange, "keep, update, or remove") {
+		t.Fatalf("stale proposal is not model-choice neutral: %#v", proposal)
+	}
+}
+
 func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 	t.Parallel()
 
@@ -610,6 +916,14 @@ func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 		}},
 		WorkflowOptimization: doctorWorkflowOptimizationReport{
 			StorePath: "/tmp/detent.db",
+			Projects: []doctorWorkflowOptimizationProjectReport{{
+				ProjectID:   "detent",
+				ModelChoice: doctorWorkflowModelChoice{Mode: "pinned", Model: "gpt-5.5", Source: "agents.routes.model"},
+				SessionGuard: doctorWorkflowSessionGuard{
+					MaxSessionTokens:            2_000_000,
+					MaxSessionContextMultiplier: 4,
+				},
+			}},
 			Findings: []doctorWorkflowOptimizationFinding{{
 				RuleID:               doctorWorkflowRuleRunawaySessionTokens,
 				ProjectID:            "detent",
@@ -633,7 +947,12 @@ func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 		Result               string `json:"result"`
 		WorkflowOptimization struct {
 			StorePath string `json:"store_path"`
-			Findings  []struct {
+			Projects  []struct {
+				ProjectID    string                     `json:"project_id"`
+				ModelChoice  doctorWorkflowModelChoice  `json:"model_choice"`
+				SessionGuard doctorWorkflowSessionGuard `json:"session_guard"`
+			} `json:"projects"`
+			Findings []struct {
 				RuleID string         `json:"rule_id"`
 				Detail string         `json:"detail"`
 				Values map[string]any `json:"evidence"`
@@ -648,6 +967,9 @@ func TestDoctorWorkflowOptimizationJSONReportSchema(t *testing.T) {
 	}
 	if got.WorkflowOptimization.StorePath != "/tmp/detent.db" {
 		t.Fatalf("StorePath = %q, want /tmp/detent.db", got.WorkflowOptimization.StorePath)
+	}
+	if len(got.WorkflowOptimization.Projects) != 1 || got.WorkflowOptimization.Projects[0].ModelChoice.Model != "gpt-5.5" || got.WorkflowOptimization.Projects[0].SessionGuard.MaxSessionTokens != 2_000_000 {
+		t.Fatalf("workflow optimization projects = %#v, want model and session guard report", got.WorkflowOptimization.Projects)
 	}
 	if len(got.WorkflowOptimization.Findings) != 1 || got.WorkflowOptimization.Findings[0].RuleID != doctorWorkflowRuleRunawaySessionTokens {
 		t.Fatalf("workflow optimization findings = %#v", got.WorkflowOptimization.Findings)
@@ -830,6 +1152,7 @@ Prompt
 	if !doctorWorkflowHasDefaultRouteModel(workflow.Config) {
 		t.Fatal("doctorWorkflowHasDefaultRouteModel() = false, want true for backend command model")
 	}
+	workflow.Config.Budget.Enabled = true
 
 	findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", workflow.Config, doctorWorkflowOptimizationMetrics{
 		RecentSessionCount:       50,
@@ -860,6 +1183,7 @@ Prompt
 	if err != nil {
 		t.Fatalf("ParseWorkflow() error = %v", err)
 	}
+	workflow.Config.Budget.Enabled = true
 
 	findings := doctorWorkflowOptimizationFindings("detent", "WORKFLOW.md", workflow.Config, doctorWorkflowOptimizationMetrics{
 		RecentSessionCount:       50,
@@ -969,10 +1293,11 @@ func TestDoctorWorkflowDefaultRouteModelConfigSources(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		raw       string
-		wantOK    bool
-		wantModel string
+		name       string
+		raw        string
+		wantOK     bool
+		wantModel  string
+		wantSource string
 	}{
 		{
 			name: "route model",
@@ -992,8 +1317,9 @@ agents:
 ---
 Prompt
 `,
-			wantOK:    true,
-			wantModel: "gpt-5-route",
+			wantOK:     true,
+			wantModel:  "gpt-5-route",
+			wantSource: "agents.routes.model",
 		},
 		{
 			name: "backend command config model",
@@ -1012,8 +1338,31 @@ agents:
 ---
 Prompt
 `,
-			wantOK:    true,
-			wantModel: "gpt-5.5",
+			wantOK:     true,
+			wantModel:  "gpt-5.5",
+			wantSource: "agents.backends.command",
+		},
+		{
+			name: "backend command config model with issue field overrides",
+			raw: `---
+tracker:
+  kind: memory
+agents:
+  backends:
+    - id: codex-main
+      kind: codex
+      command: codex --config=model="gpt-5.5" app-server
+  routes:
+    - name: default
+      backend: codex-main
+      model_field: Model
+      default: true
+---
+Prompt
+`,
+			wantOK:     true,
+			wantModel:  "gpt-5.5",
+			wantSource: "agents.backends.command",
 		},
 		{
 			name: "route model field",
@@ -1033,7 +1382,8 @@ agents:
 ---
 Prompt
 `,
-			wantOK: true,
+			wantOK:     true,
+			wantSource: "agents.routes.model_field",
 		},
 		{
 			name: "no model source",
@@ -1062,6 +1412,9 @@ Prompt
 			}
 			if got.Model != tt.wantModel {
 				t.Fatalf("doctorWorkflowDefaultRouteModelConfig() model = %q, want %q", got.Model, tt.wantModel)
+			}
+			if got.Source != tt.wantSource {
+				t.Fatalf("doctorWorkflowDefaultRouteModelConfig() source = %q, want %q", got.Source, tt.wantSource)
 			}
 		})
 	}
@@ -1160,6 +1513,8 @@ tracker:
     - Blocked
 polling:
   interval_ms: 60000
+budget:
+  enabled: true
 agent:
   auto_promote:
     enabled: true


### PR DESCRIPTION
## Summary

- Report each project worker model as pinned or provider-default and show both session token guard settings.
- Detect rejected and generation-behind pins, repeated context-multiplier ceiling kills, and projects with no session brake.
- Keep unresolved effective-model telemetry informational and route corrective findings through governed self-improvement proposals.

Fixes #1120

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface, layout, density, first viewport, or responsive visibility.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; this PR has no visual changes to primary operator screens.

## Test Plan

- [x] `go test ./internal/cli -count=1`
- [x] `go vet ./internal/cli`
- [x] `golangci-lint run --timeout=5m ./internal/cli/...`
- [x] `make check`