### PR TITLE
fix(scheduler): hold completed gate waits

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -204,9 +204,122 @@ func autoPromoteIssueCompleted(state *State, issueID string) bool {
 	return ok
 }
 
+func (o *Orchestrator) restoreDurableGateWaitCompletions(
+	ctx context.Context,
+	state *State,
+	issues []connector.Issue,
+) {
+	if o == nil || state == nil || o.workAttempts == nil {
+		return
+	}
+	autoCfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
+	if !autoPromoteActiveGateTrackingEnabled(autoCfg) {
+		return
+	}
+	if state.Completed == nil {
+		state.Completed = map[string]Completed{}
+	}
+	for _, issue := range issues {
+		issueID := strings.TrimSpace(issue.ID)
+		if issueID == "" {
+			continue
+		}
+		if _, ok := state.Completed[issueID]; ok {
+			continue
+		}
+		if !autoPromoteActiveGateTrackedIssue(issue, o.cfg, autoCfg) {
+			continue
+		}
+		attempt, ok, err := o.latestSuccessfulGateWaitAttempt(ctx, issue)
+		if err != nil {
+			if o.logger != nil {
+				o.logger.Warn(
+					"restore durable gate-wait completion failed",
+					"issue_id", issueID,
+					"identifier", issue.Identifier,
+					"error", err,
+				)
+			}
+			continue
+		}
+		if !ok {
+			continue
+		}
+		state.Completed[issueID] = completedFromGateWaitAttempt(issue, attempt)
+	}
+}
+
+func (o *Orchestrator) latestSuccessfulGateWaitAttempt(
+	ctx context.Context,
+	issue connector.Issue,
+) (store.WorkAttempt, bool, error) {
+	if o == nil || o.workAttempts == nil {
+		return store.WorkAttempt{}, false, nil
+	}
+	limit := normalizeAutoPromoteConfig(o.cfg.AutoPromote).NoProgressLimit + 1
+	if limit < 20 {
+		limit = 20
+	}
+	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		WorkerType: "agent",
+		Limit:      limit,
+	})
+	if err != nil {
+		return store.WorkAttempt{}, false, err
+	}
+	for _, attempt := range attempts {
+		if attempt.TerminalState != store.WorkAttemptTerminalSuccess {
+			continue
+		}
+		if !gateWaitAttemptMatchesPullRequest(attempt, issue) {
+			continue
+		}
+		return attempt, true, nil
+	}
+	return store.WorkAttempt{}, false, nil
+}
+
+func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connector.Issue) bool {
+	prNumber := pullRequestNumber(issue)
+	if prNumber <= 0 || attempt.PRNumber == nil || *attempt.PRNumber <= 0 {
+		return true
+	}
+	return *attempt.PRNumber == int64(prNumber)
+}
+
+func completedFromGateWaitAttempt(issue connector.Issue, attempt store.WorkAttempt) Completed {
+	return Completed{
+		Issue:       cloneIssue(issue),
+		StartedAt:   attempt.StartedAt,
+		CompletedAt: attempt.CompletedAt,
+		FinalState:  FinalStateCompleted,
+	}
+}
+
 func autoPromoteActiveGatePendingIssue(
 	issue connector.Issue,
 	state *State,
+	cfg Config,
+	autoCfg AutoPromoteConfig,
+) bool {
+	if !autoPromoteActiveGateTrackedIssue(issue, cfg, autoCfg) || state == nil {
+		return false
+	}
+	completed, ok := state.Completed[strings.TrimSpace(issue.ID)]
+	if !ok {
+		return false
+	}
+	autoCfg = normalizeAutoPromoteConfig(autoCfg)
+	return completedActiveFinalStateReviewEligible(completed.FinalState, autoCfg.SourceState) &&
+		completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(autoCfg.Gate))
+}
+
+func autoPromoteActiveGateTrackedIssue(
+	issue connector.Issue,
 	cfg Config,
 	autoCfg AutoPromoteConfig,
 ) bool {
@@ -228,15 +341,6 @@ func autoPromoteActiveGatePendingIssue(
 	if autoPromoteHumanReviewRequired(issue, autoCfg, autoCfg.Gate) {
 		return false
 	}
-	if autoPromoteActiveDispatchInProgress(state, issueID) {
-		return false
-	}
-	if state != nil {
-		if completed, ok := state.Completed[issueID]; ok {
-			return completedActiveFinalStateReviewEligible(completed.FinalState, autoCfg.SourceState) &&
-				completedActiveIssueReadyForReview(issue, gateRequiresPullRequest(autoCfg.Gate))
-		}
-	}
 	return issueHasOpenPullRequest(issue)
 }
 
@@ -248,22 +352,6 @@ func autoPromoteSourceGateWaitEnabled(cfg AutoPromoteConfig) bool {
 func autoPromoteActiveGateTrackingEnabled(cfg AutoPromoteConfig) bool {
 	cfg = normalizeAutoPromoteConfig(cfg)
 	return cfg.Enabled && (cfg.QuietDuration > 0 || cfg.GateWaitState == autoPromoteGateWaitSource)
-}
-
-func autoPromoteActiveDispatchInProgress(state *State, issueID string) bool {
-	if state == nil {
-		return false
-	}
-	if _, ok := state.Running[issueID]; ok {
-		return true
-	}
-	if _, ok := state.Claimed[issueID]; ok {
-		return true
-	}
-	if _, ok := state.Retry[issueID]; ok {
-		return true
-	}
-	return false
 }
 
 func issueHasOpenPullRequest(issue connector.Issue) bool {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -284,11 +284,28 @@ func (o *Orchestrator) latestSuccessfulGateWaitAttempt(
 }
 
 func gateWaitAttemptMatchesPullRequest(attempt store.WorkAttempt, issue connector.Issue) bool {
-	prNumber := pullRequestNumber(issue)
-	if prNumber <= 0 || attempt.PRNumber == nil || *attempt.PRNumber <= 0 {
-		return true
+	record, ok := implementProgressRecordFromAttempt(attempt)
+	if !ok || strings.TrimSpace(record.Outcome) != string(store.WorkAttemptTerminalSuccess) {
+		return false
 	}
-	return *attempt.PRNumber == int64(prNumber)
+	prNumber := int64(pullRequestNumber(issue))
+	if prNumber <= 0 {
+		return false
+	}
+	matched := false
+	if attempt.PRNumber != nil && *attempt.PRNumber > 0 {
+		if *attempt.PRNumber != prNumber {
+			return false
+		}
+		matched = true
+	}
+	if record.CurrentSignature.PRNumber > 0 {
+		if record.CurrentSignature.PRNumber != prNumber {
+			return false
+		}
+		matched = true
+	}
+	return matched
 }
 
 func completedFromGateWaitAttempt(issue connector.Issue, attempt store.WorkAttempt) Completed {

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -323,7 +323,7 @@ func autoPromoteActiveGatePendingIssue(
 	cfg Config,
 	autoCfg AutoPromoteConfig,
 ) bool {
-	if !autoPromoteActiveGateTrackedIssue(issue, cfg, autoCfg) || state == nil {
+	if state == nil || !autoPromoteActiveGateEligibleIssue(issue, cfg, autoCfg) {
 		return false
 	}
 	completed, ok := state.Completed[strings.TrimSpace(issue.ID)]
@@ -336,6 +336,14 @@ func autoPromoteActiveGatePendingIssue(
 }
 
 func autoPromoteActiveGateTrackedIssue(
+	issue connector.Issue,
+	cfg Config,
+	autoCfg AutoPromoteConfig,
+) bool {
+	return autoPromoteActiveGateEligibleIssue(issue, cfg, autoCfg) && issueHasOpenPullRequest(issue)
+}
+
+func autoPromoteActiveGateEligibleIssue(
 	issue connector.Issue,
 	cfg Config,
 	autoCfg AutoPromoteConfig,
@@ -355,10 +363,7 @@ func autoPromoteActiveGateTrackedIssue(
 	case normalizeState(autoCfg.SourceState), normalizeState(autoCfg.PassState), normalizeState(autoCfg.ReworkState):
 		return false
 	}
-	if autoPromoteHumanReviewRequired(issue, autoCfg, autoCfg.Gate) {
-		return false
-	}
-	return issueHasOpenPullRequest(issue)
+	return !autoPromoteHumanReviewRequired(issue, autoCfg, autoCfg.Gate)
 }
 
 func autoPromoteSourceGateWaitEnabled(cfg AutoPromoteConfig) bool {

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -475,16 +475,19 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 	mergingSlot := dispatchTestIssue("issue-restart-merging-slot", "Merging")
 	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
 	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	prNumber := int64(issue.PullRequest.Number)
 	attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{{
-		ProjectID:     cfg.Project.ID,
-		IssueID:       issue.ID,
-		Identifier:    issue.Identifier,
-		IssueURL:      issue.URL,
-		WorkerType:    "agent",
-		Status:        store.WorkAttemptStatusTerminal,
-		StartedAt:     now.Add(-15 * time.Minute),
-		CompletedAt:   now.Add(-10 * time.Minute),
-		TerminalState: store.WorkAttemptTerminalSuccess,
+		ProjectID:          cfg.Project.ID,
+		IssueID:            issue.ID,
+		Identifier:         issue.Identifier,
+		IssueURL:           issue.URL,
+		PRNumber:           &prNumber,
+		WorkerType:         "agent",
+		Status:             store.WorkAttemptStatusTerminal,
+		StartedAt:          now.Add(-15 * time.Minute),
+		CompletedAt:        now.Add(-10 * time.Minute),
+		TerminalState:      store.WorkAttemptTerminalSuccess,
+		WorkerMetadataJSON: implementProgressMetadataJSON(autoPromoteReworkSignature{PRNumber: prNumber, HeadSHA: "restart-head"}, store.WorkAttemptTerminalSuccess),
 	}}}
 	orch := &Orchestrator{
 		cfg:          cfg,
@@ -529,6 +532,110 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 		if !strings.Contains(tracker.comments[0].body, fragment) {
 			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
 		}
+	}
+}
+
+func TestLatestSuccessfulGateWaitAttemptRequiresCurrentImplementationEvidence(t *testing.T) {
+	t.Parallel()
+
+	currentPR := int64(144)
+	otherPR := int64(143)
+	currentSignature := autoPromoteReworkSignature{PRNumber: currentPR, HeadSHA: "current-head"}
+	otherSignature := autoPromoteReworkSignature{PRNumber: otherPR, HeadSHA: "other-head"}
+	issue := autoPromoteTickIssue("issue-gate-wait-evidence", []string{"bug"}, &connector.PullRequest{
+		Number: 144,
+		State:  "OPEN",
+	})
+	issue.State = "In Progress"
+
+	tests := []struct {
+		name     string
+		attempts []store.WorkAttempt
+		wantID   int64
+	}{
+		{
+			name: "ignores plan success",
+			attempts: []store.WorkAttempt{{
+				ID:                 1,
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{"run_mode": runpkg.RunModePlan}),
+			}},
+		},
+		{
+			name: "ignores implementation success without PR association",
+			attempts: []store.WorkAttempt{{
+				ID:                 2,
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: implementProgressMetadataJSON(autoPromoteReworkSignature{}, store.WorkAttemptTerminalSuccess),
+			}},
+		},
+		{
+			name: "ignores implementation success for another PR",
+			attempts: []store.WorkAttempt{{
+				ID:                 3,
+				PRNumber:           &otherPR,
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: implementProgressMetadataJSON(otherSignature, store.WorkAttemptTerminalSuccess),
+			}},
+		},
+		{
+			name: "accepts current PR from attempt",
+			attempts: []store.WorkAttempt{{
+				ID:                 4,
+				PRNumber:           &currentPR,
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: implementProgressMetadataJSON(autoPromoteReworkSignature{}, store.WorkAttemptTerminalSuccess),
+			}},
+			wantID: 4,
+		},
+		{
+			name: "accepts current PR from completion record",
+			attempts: []store.WorkAttempt{{
+				ID:                 5,
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: implementProgressMetadataJSON(currentSignature, store.WorkAttemptTerminalSuccess),
+			}},
+			wantID: 5,
+		},
+		{
+			name: "skips newer unrelated success for older current completion",
+			attempts: []store.WorkAttempt{
+				{
+					ID:                 6,
+					TerminalState:      store.WorkAttemptTerminalSuccess,
+					WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{"run_mode": runpkg.RunModePlan}),
+				},
+				{
+					ID:                 5,
+					TerminalState:      store.WorkAttemptTerminalSuccess,
+					WorkerMetadataJSON: implementProgressMetadataJSON(currentSignature, store.WorkAttemptTerminalSuccess),
+				},
+			},
+			wantID: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			attempts := &recordingWorkAttemptStore{history: tt.attempts}
+			orch := &Orchestrator{
+				cfg:          normalizeConfig(Config{Project: scheduler.ProjectCandidate{ID: "detent"}}),
+				workAttempts: attempts,
+			}
+
+			attempt, ok, err := orch.latestSuccessfulGateWaitAttempt(context.Background(), issue)
+			if err != nil {
+				t.Fatalf("latestSuccessfulGateWaitAttempt() error = %v", err)
+			}
+			if ok != (tt.wantID > 0) {
+				t.Fatalf("latestSuccessfulGateWaitAttempt() ok = %v, want %v", ok, tt.wantID > 0)
+			}
+			if attempt.ID != tt.wantID {
+				t.Fatalf("latestSuccessfulGateWaitAttempt() ID = %d, want %d", attempt.ID, tt.wantID)
+			}
+		})
 	}
 }
 

--- a/internal/orchestrator/autopromote_tick_test.go
+++ b/internal/orchestrator/autopromote_tick_test.go
@@ -475,10 +475,22 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 	mergingSlot := dispatchTestIssue("issue-restart-merging-slot", "Merging")
 	state.Running[mergingSlot.ID] = Running{Issue: mergingSlot}
 	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	attempts := &recordingWorkAttemptStore{history: []store.WorkAttempt{{
+		ProjectID:     cfg.Project.ID,
+		IssueID:       issue.ID,
+		Identifier:    issue.Identifier,
+		IssueURL:      issue.URL,
+		WorkerType:    "agent",
+		Status:        store.WorkAttemptStatusTerminal,
+		StartedAt:     now.Add(-15 * time.Minute),
+		CompletedAt:   now.Add(-10 * time.Minute),
+		TerminalState: store.WorkAttemptTerminalSuccess,
+	}}}
 	orch := &Orchestrator{
-		cfg:       cfg,
-		connector: tracker,
-		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
 	}
 
 	orch.tick(context.Background(), &state, now)
@@ -491,6 +503,12 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 	}
 	if _, ok := state.Running[issue.ID]; ok {
 		t.Fatalf("Running[%q] present after pending restart recovery tick", issue.ID)
+	}
+	if completed, ok := state.Completed[issue.ID]; !ok || completed.FinalState != FinalStateCompleted {
+		t.Fatalf("Completed[%q] = %#v, want durable successful completion restored", issue.ID, completed)
+	}
+	if len(attempts.historyQueries) == 0 {
+		t.Fatal("durable work attempt history was not queried")
 	}
 
 	tracker.stateIssues[0].PullRequest.CIStatus = "success"
@@ -511,6 +529,72 @@ func TestTickAutoPromoteRecoversActiveIssueAfterRestart(t *testing.T) {
 		if !strings.Contains(tracker.comments[0].body, fragment) {
 			t.Fatalf("comment %q missing fragment %q", tracker.comments[0].body, fragment)
 		}
+	}
+}
+
+func TestTickAutoPromotesCompletedGateWaitWhileDispatchRunning(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 18, 50, 0, 0, time.UTC)
+	oldReview := now.Add(-10 * time.Minute)
+	issue := autoPromoteTickIssue("issue-running-gate-wait", []string{"bug"}, &connector.PullRequest{
+		Number:                 1125,
+		URL:                    "https://github.test/digitaldrywood/detent/pull/1125",
+		State:                  "OPEN",
+		MergeableState:         "clean",
+		CIStatus:               "pass",
+		CodexReviewSubmittedAt: &oldReview,
+	})
+	issue.State = "In Progress"
+	issue.Comments = []connector.IssueComment{{
+		Body: "## Codex Workpad\n\n```detent-status\nschema: 1\nstatus: complete\nblockers: []\nhuman_action: null\n```",
+	}}
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:         true,
+			QuietDuration:   0,
+			GateWaitState:   autoPromoteGateWaitSource,
+			NoProgressLimit: 3,
+			Gate: gate.Config{
+				Kind:                   gate.KindCommand,
+				RequireAutomatedReview: new(false),
+			},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-5 * time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+	state.Running[issue.ID] = Running{
+		Issue:     issue,
+		StartedAt: now.Add(-time.Minute),
+	}
+	tracker := &autoPromoteTickConnector{stateIssues: []connector.Issue{issue}}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+
+	result := orch.autoPromoteHumanReviewIssues(context.Background(), &state, []connector.Issue{issue}, now)
+
+	if got, want := tracker.updates, []autoPromoteTickUpdate{{issueID: issue.ID, state: "Merging"}}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("updates = %#v, want %#v", got, want)
+	}
+	if _, ok := result.transitioned[issue.ID]; !ok {
+		t.Fatalf("transitioned = %#v, want %s", result.transitioned, issue.ID)
+	}
+	if _, ok := state.Running[issue.ID]; !ok {
+		t.Fatalf("Running[%q] missing; promotion must not wait for stale dispatch completion", issue.ID)
+	}
+	if _, ok := state.Blocked[issue.ID]; ok {
+		t.Fatalf("Blocked[%q] present after gate promotion", issue.ID)
 	}
 }
 

--- a/internal/orchestrator/completion_transition_test.go
+++ b/internal/orchestrator/completion_transition_test.go
@@ -249,6 +249,34 @@ func TestActiveArtifactGateWaitReviewTargetState(t *testing.T) {
 	}
 }
 
+func TestAutoPromoteActiveGatePendingIssueIncludesCompletedArtifact(t *testing.T) {
+	t.Parallel()
+
+	issue := artifactCompletionTransitionIssue("Production", "pending_review")
+	cfg := normalizeConfig(Config{
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			SourceState:   "Review",
+			PassState:     "Ready for Pickup",
+			ReworkState:   "Rework",
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          artifactCompletionTestGate(),
+		},
+	})
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:      issue,
+		FinalState: FinalStateCompleted,
+	}
+
+	if !autoPromoteActiveGatePendingIssue(issue, &state, cfg, cfg.AutoPromote) {
+		t.Fatal("completed artifact gate wait was not recognized without a pull request")
+	}
+}
+
 func TestTransitionActiveArtifactGateWaitIssuesReconcilesToReviewAfterRestart(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -398,7 +398,7 @@ const (
 	dispatchSkipInactiveState            = "inactive_state"
 	dispatchSkipTerminalState            = "terminal_state"
 	dispatchSkipPullRequestHydration     = "pull_request_hydration_unavailable"
-	dispatchSkipAutoPromoteGatePending   = "auto_promote_gate_pending"
+	dispatchSkipAwaitingGate             = "awaiting_gate"
 	dispatchSkipArtifactGateWaitStatus   = "artifact_gate_wait_status"
 	dispatchSkipMergedPullRequest        = "merged_pull_request_reconciliation_pending"
 	dispatchSkipDuplicatePullRequest     = "duplicate_pull_request_work"
@@ -438,7 +438,7 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 		return dispatchableDecision{reason: dispatchSkipArtifactGateWaitStatus}
 	}
 	if autoPromoteActiveGatePendingIssue(issue, state, p.cfg, p.cfg.AutoPromote) {
-		return dispatchableDecision{reason: dispatchSkipAutoPromoteGatePending}
+		return dispatchableDecision{reason: dispatchSkipAwaitingGate}
 	}
 	if mergedPullRequestReconciliationPending(issue, p.cfg) {
 		return dispatchableDecision{reason: dispatchSkipMergedPullRequest}

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -344,14 +344,78 @@ func TestDispatchableSkipsAutoPromoteGatePendingActiveIssue(t *testing.T) {
 	issue := dispatchTestIssueWithPullRequest("issue-gate-pending", "In Progress", "OPEN")
 	issue.PullRequest.CIStatus = "pending"
 	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{Issue: issue, FinalState: FinalStateCompleted}
 	orch := Orchestrator{cfg: cfg}
 
 	decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
 	if decision.dispatchable {
 		t.Fatal("dispatchable gate-pending active issue = true, want false")
 	}
-	if decision.reason != dispatchSkipAutoPromoteGatePending {
-		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipAutoPromoteGatePending)
+	if decision.reason != dispatchSkipAwaitingGate {
+		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipAwaitingGate)
+	}
+}
+
+func TestDispatchPlannerSkipsCompletedGateWaitRetry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 18, 44, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents: 1,
+		AutoPromote: AutoPromoteConfig{
+			Enabled:       true,
+			QuietDuration: 0,
+			GateWaitState: autoPromoteGateWaitSource,
+			Gate:          gate.Config{Kind: gate.KindCommand},
+		},
+		ActiveStates:   []string{"Todo", "In Progress", "Rework", "Merging"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	issue := dispatchTestIssueWithPullRequest("issue-completed-gate-wait", "In Progress", "OPEN")
+	issue.PullRequest.CIStatus = "pending"
+	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-3 * time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+	planner := newDispatchPlanner(cfg)
+	planner.scheduleRetryAfter(&state, issue, 1, now, 0, "", "")
+	var decisions []dispatchPlanDecision
+
+	plan := planner.plan(&state, []connector.Issue{issue}, now, dispatchPlanHooks{
+		decision: func(decision dispatchPlanDecision) {
+			decisions = append(decisions, decision)
+		},
+	})
+
+	if len(plan.Dispatches) != 0 {
+		t.Fatalf("dispatches = %#v, want completed gate-wait retry skipped", plan.Dispatches)
+	}
+	if len(decisions) != 1 || decisions[0].SkipReason != "awaiting_gate" {
+		t.Fatalf("decisions = %#v, want awaiting_gate skip", decisions)
+	}
+	if _, ok := state.Completed[issue.ID]; !ok {
+		t.Fatalf("Completed[%q] missing after gate-wait skip", issue.ID)
+	}
+	if _, ok := state.Retry[issue.ID]; ok {
+		t.Fatalf("Retry[%q] present after gate-wait skip", issue.ID)
+	}
+	if _, ok := state.Claimed[issue.ID]; ok {
+		t.Fatalf("Claimed[%q] present after gate-wait skip", issue.ID)
+	}
+
+	attempts := &recordingWorkAttemptStore{}
+	orch := Orchestrator{cfg: cfg, workAttempts: attempts}
+	loggedState := newState(cfg)
+	loggedState.Completed[issue.ID] = Completed{
+		Issue:       issue,
+		CompletedAt: now.Add(-3 * time.Minute),
+		FinalState:  FinalStateCompleted,
+	}
+	orch.dispatchReadyIssues(t.Context(), &loggedState, []connector.Issue{issue}, now)
+	if len(attempts.decisions) != 1 || attempts.decisions[0].Reason != dispatchSkipAwaitingGate {
+		t.Fatalf("scheduler decisions = %#v, want awaiting_gate skip", attempts.decisions)
 	}
 }
 
@@ -372,14 +436,15 @@ func TestDispatchableSkipsQuietWindowActiveIssueWithOpenPullRequest(t *testing.T
 	issue := dispatchTestIssueWithPullRequest("issue-quiet-gate-pending", "In Progress", "OPEN")
 	issue.PullRequest.CIStatus = "pending"
 	state := newState(cfg)
+	state.Completed[issue.ID] = Completed{Issue: issue, FinalState: FinalStateCompleted}
 	orch := Orchestrator{cfg: cfg}
 
 	decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
 	if decision.dispatchable {
 		t.Fatal("dispatchable quiet-window active issue with open PR = true, want false")
 	}
-	if decision.reason != dispatchSkipAutoPromoteGatePending {
-		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipAutoPromoteGatePending)
+	if decision.reason != dispatchSkipAwaitingGate {
+		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipAwaitingGate)
 	}
 }
 
@@ -2250,13 +2315,15 @@ func receiveWorkerHostRunRequest(t *testing.T, requests <-chan RunRequest) RunRe
 }
 
 type recordingWorkAttemptStore struct {
-	nextID      int64
-	starts      []store.WorkAttemptStart
-	heartbeats  []store.WorkAttemptHeartbeat
-	completions []store.WorkAttemptCompletion
-	decisions   []store.SchedulerDecision
-	reclaimed   []store.WorkAttempt
-	recent      []store.WorkAttempt
+	nextID         int64
+	starts         []store.WorkAttemptStart
+	heartbeats     []store.WorkAttemptHeartbeat
+	completions    []store.WorkAttemptCompletion
+	decisions      []store.SchedulerDecision
+	reclaimed      []store.WorkAttempt
+	recent         []store.WorkAttempt
+	history        []store.WorkAttempt
+	historyQueries []store.WorkAttemptHistoryQuery
 }
 
 func (s *recordingWorkAttemptStore) StartWorkAttempt(_ context.Context, attrs store.WorkAttemptStart) (int64, error) {
@@ -2295,8 +2362,12 @@ func (s *recordingWorkAttemptStore) ListActiveWorkAttempts(context.Context, stor
 	return nil, nil
 }
 
-func (s *recordingWorkAttemptStore) ListRecentTerminalWorkAttempts(context.Context, store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
-	return append([]store.WorkAttempt(nil), s.recent...), nil
+func (s *recordingWorkAttemptStore) ListRecentTerminalWorkAttempts(_ context.Context, query store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
+	s.historyQueries = append(s.historyQueries, query)
+	if s.history == nil {
+		return append([]store.WorkAttempt(nil), s.recent...), nil
+	}
+	return append([]store.WorkAttempt(nil), s.history...), nil
 }
 
 func (s *recordingWorkAttemptStore) RecordSchedulerDecision(_ context.Context, attrs store.SchedulerDecision) (int64, error) {

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/gate"
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -244,6 +245,105 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			}
 			if tt.wantLogContains != "" && !strings.Contains(logs.String(), tt.wantLogContains) {
 				t.Fatalf("logs did not contain %q:\n%s", tt.wantLogContains, logs.String())
+			}
+		})
+	}
+}
+
+func TestHandleRunResultStopsCompletedGateWaitContinuations(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 9, 18, 50, 0, 0, time.UTC)
+	issue := implementProgressIssue("same-head", "Test")
+	signature := autoPromoteReworkSignature{
+		PRNumber:     1070,
+		HeadSHA:      "same-head",
+		FailedChecks: []string{"Test"},
+	}
+	tests := []struct {
+		name           string
+		history        []store.WorkAttempt
+		wantTerminal   store.WorkAttemptTerminalState
+		wantHydrations int
+	}{
+		{
+			name:           "initial success waits for gate without continuation",
+			wantTerminal:   store.WorkAttemptTerminalSuccess,
+			wantHydrations: 1,
+		},
+		{
+			name:         "redundant dispatch is superseded without breaker strike",
+			history:      []store.WorkAttempt{implementProgressHistoryAttempt(1, signature, store.WorkAttemptTerminalSuccess)},
+			wantTerminal: store.WorkAttemptTerminalSuperseded,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			tracker := &implementProgressConnector{hydrated: issue}
+			attempts := &implementProgressAttemptStore{history: tt.history}
+			cfg := normalizeConfig(Config{
+				Project: scheduler.ProjectCandidate{ID: "detent"},
+				AutoPromote: AutoPromoteConfig{
+					Enabled:         true,
+					QuietDuration:   0,
+					GateWaitState:   autoPromoteGateWaitSource,
+					NoProgressLimit: 1,
+					Gate:            gate.Config{Kind: gate.KindCommand},
+				},
+				ActiveStates:           []string{"Todo", "In Progress", "Rework", "Merging"},
+				ObservedStates:         []string{"Human Review", "Blocked"},
+				TerminalStates:         []string{"Done", "Cancelled"},
+				ContinuationRetryDelay: time.Minute,
+			})
+			orch := &Orchestrator{
+				cfg:          cfg,
+				connector:    tracker,
+				workAttempts: attempts,
+				logger:       slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil)),
+			}
+			state := newState(cfg)
+			state.Running[issue.ID] = Running{
+				Issue:         issue,
+				Attempt:       2,
+				WorkAttemptID: 42,
+				Mode:          runpkg.RunModeImplement,
+				StartedAt:     base.Add(-time.Minute),
+				DiffStats:     DiffStats{Status: "clean"},
+			}
+			state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: base.Add(-time.Minute)}
+
+			orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+				IssueID:     issue.ID,
+				CompletedAt: base,
+				Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+				Result: runpkg.RunResult{
+					FinalState: FinalStateCompleted,
+					DiffStats:  DiffStats{Status: "clean"},
+				},
+			})
+
+			if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != tt.wantTerminal {
+				t.Fatalf("completions = %#v, want terminal %q", attempts.completions, tt.wantTerminal)
+			}
+			if tracker.hydrations != tt.wantHydrations {
+				t.Fatalf("hydrations = %d, want %d", tracker.hydrations, tt.wantHydrations)
+			}
+			if _, ok := state.Completed[issue.ID]; !ok {
+				t.Fatalf("Completed[%q] missing after gate-wait completion", issue.ID)
+			}
+			if _, ok := state.Retry[issue.ID]; ok {
+				t.Fatalf("Retry[%q] present after gate-wait completion", issue.ID)
+			}
+			if _, ok := state.Claimed[issue.ID]; ok {
+				t.Fatalf("Claimed[%q] present after gate-wait completion", issue.ID)
+			}
+			if _, ok := state.Blocked[issue.ID]; ok {
+				t.Fatalf("Blocked[%q] present after gate-wait completion", issue.ID)
+			}
+			if len(tracker.updates) != 0 {
+				t.Fatalf("state updates = %#v, want breaker untouched", tracker.updates)
 			}
 		})
 	}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -191,6 +191,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.handleIncompleteMergeWorkerResult(ctx, state, event, running)
 		return
 	}
+	if o.completeRedundantGateWaitRun(ctx, state, event, running) {
+		return
+	}
 
 	finalState := event.Result.FinalState
 	if finalState == "" {
@@ -253,12 +256,82 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		o.cleanupDrainedRun(ctx, state, event.IssueID)
 		return
 	}
+	if terminalState == store.WorkAttemptTerminalSuccess &&
+		autoPromoteActiveGatePendingIssue(running.Issue, state, o.cfg, o.cfg.AutoPromote) {
+		o.finishCompletedGateWaitRun(ctx, state, running.Issue)
+		return
+	}
 	if terminalState == store.WorkAttemptTerminalNoProgress && progress.Block {
 		if o.blockNoProgressLimit(ctx, state, progress, event.CompletedAt) {
 			return
 		}
 	}
 	o.scheduleRetry(state, running.Issue, 1, event.CompletedAt, "", true, running.WorkerHost)
+}
+
+func (o *Orchestrator) completeRedundantGateWaitRun(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	if !autoPromoteActiveGateTrackedIssue(running.Issue, o.cfg, o.cfg.AutoPromote) {
+		return false
+	}
+	attempt, ok, err := o.latestSuccessfulGateWaitAttempt(ctx, running.Issue)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn(
+				"gate-wait completion history lookup failed",
+				"issue_id", running.Issue.ID,
+				"identifier", running.Issue.Identifier,
+				"error", err,
+			)
+		}
+		return false
+	}
+	if !ok {
+		return false
+	}
+
+	o.completeDurableWorkAttempt(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalSuperseded,
+		"awaiting_gate",
+		"completed gate-wait work already has a successful attempt",
+		"superseded",
+		"ignored redundant gate-wait dispatch",
+	)
+	state.Completed[event.IssueID] = completedFromGateWaitAttempt(running.Issue, attempt)
+	tokens := event.Result.Tokens
+	if tokens == (TokenTotals{}) {
+		tokens = running.Tokens
+	}
+	state.TokenTotals = addTokenTotals(state.TokenTotals, tokens)
+	if event.Result.RateLimits != nil {
+		state.RateLimits = mergeRateLimits(state.RateLimits, event.Result.RateLimits)
+	}
+	if diffStatsPresent(event.Result.DiffStats) {
+		state.DiffStats[event.IssueID] = event.Result.DiffStats
+	}
+	o.finishCompletedGateWaitRun(ctx, state, running.Issue)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "gate_wait_dispatch_superseded",
+		Message: "ignored redundant dispatch for completed gate-wait " + issueLabel(running.Issue),
+	})
+	return true
+}
+
+func (o *Orchestrator) finishCompletedGateWaitRun(ctx context.Context, state *State, issue connector.Issue) {
+	issueID := strings.TrimSpace(issue.ID)
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("release completed gate-wait claim failed", "issue_id", issueID, "error", err)
+	}
+	o.releaseClaim(state, issueID)
 }
 
 func (o *Orchestrator) commentBudgetRefusal(ctx context.Context, issueID string, refusal BudgetRefusal) {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -128,8 +128,8 @@ func TestStateSnapshotMarksGatePendingBoardIssues(t *testing.T) {
 		want bool
 	}{
 		{id: "gate-pending", want: true},
-		{id: "running"},
-		{id: "queued"},
+		{id: "running", want: true},
+		{id: "queued", want: true},
 		{id: "rework"},
 		{id: "plain"},
 	}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -92,6 +92,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	o.refreshStatusDrift(ctx, state, now, reserve)
 	fetched = retainUnavailablePullRequestsFromPrevious(fetched, previous)
 	fetched = applyStatusPullRequestHydrationBlocksToCandidates(fetched)
+	o.restoreDurableGateWaitCompletions(ctx, state, mergeIssueSlices(fetched.candidates, fetched.status))
 
 	transitions := o.refreshTransitionSets(ctx, state, fetched, previous)
 	completedEpics := o.resolveCompletedEpics(ctx, state, transitions, previous)


### PR DESCRIPTION
## Summary

- Restore successful gate-wait completion evidence from durable agent work attempts before auto-promotion and dispatch.
- Skip completed gate-wait retries with `awaiting_gate` while allowing promotion to evaluate through stale in-flight sessions.
- Supersede any already-launched redundant session so it cannot add a `no_progress` strike or trip the breaker.

Fixes #1126

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] Focused gate-wait dispatch, restart, in-flight promotion, and breaker regression tests.
- [x] `go test -race ./internal/orchestrator -count=1`
- [x] `make check`