### PR TITLE
fix(board): refresh snapshots on transitions

### DIFF
--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -735,7 +735,7 @@ func (o *Orchestrator) applyStaleMergingPullRequestDecision(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, issueID, issue, decision.targetState, now, decision.reason); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, decision.targetState, now, decision.reason); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"stale_merging_pr_reconciliation_failed",
@@ -1333,7 +1333,7 @@ func (o *Orchestrator) applyStaleMergedPullRequestDecision(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"stale_merged_pr_reconciliation_failed",
@@ -1444,7 +1444,7 @@ func (o *Orchestrator) applyStaleTodoPullRequestDecision(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(issue.ID)
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, string(decision.Reason)); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"stale_todo_pr_reconciliation_failed",
@@ -2115,7 +2115,7 @@ func (o *Orchestrator) applyAutoPromoteDecision(
 		}
 	}
 
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, transitionReason); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, transitionReason); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"auto promote transition failed",

--- a/internal/orchestrator/blocked_recovery.go
+++ b/internal/orchestrator/blocked_recovery.go
@@ -159,7 +159,7 @@ func (o *Orchestrator) applyBlockedRecovery(
 		targetState = autoPromoteReworkState
 	}
 	metadata := workflowLaneMetadataWithActionSignature(workflowLaneMetadata{}, workflowActionBlockedRecovery, signature)
-	if err := o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, now, "blocked_recovery", metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "blocked_recovery", metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("blocked recovery transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "reason", decision.Reason, "signature", signature, "error", err)
 		}

--- a/internal/orchestrator/completion_transition.go
+++ b/internal/orchestrator/completion_transition.go
@@ -56,7 +56,7 @@ func (o *Orchestrator) transitionCompletedActiveIssuesToReview(
 			continue
 		}
 
-		if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "completed_active_review_transition"); err != nil {
+		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "completed_active_review_transition"); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(
 					"completed issue review transition failed",
@@ -122,7 +122,7 @@ func (o *Orchestrator) transitionActiveArtifactGateWaitIssuesToReview(
 			continue
 		}
 
-		if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "artifact_gate_wait_review_reconciliation"); err != nil {
+		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "artifact_gate_wait_review_reconciliation"); err != nil {
 			if o.logger != nil {
 				o.logger.Warn(
 					"artifact gate wait review reconciliation failed",
@@ -322,7 +322,7 @@ func (o *Orchestrator) transitionTimedOutCompletedActiveGateWait(
 		return false
 	}
 	targetState := cfg.SourceState
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "auto_promote_gate_wait_timeout"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "auto_promote_gate_wait_timeout"); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"completed issue gate wait timeout transition failed",

--- a/internal/orchestrator/dependency_autounblock.go
+++ b/internal/orchestrator/dependency_autounblock.go
@@ -248,7 +248,7 @@ func (o *Orchestrator) applyBlockerAutoPromote(
 	now time.Time,
 ) bool {
 	issueID := strings.TrimSpace(blocker.ID)
-	if err := o.updateIssueStateByID(ctx, issueID, blocker, targetState, now, "blocker_auto_promote"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, blocker, targetState, now, "blocker_auto_promote"); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"blocker auto-promote transition failed",
@@ -743,7 +743,7 @@ func (o *Orchestrator) applyDependencyAutoUnblock(
 			Blockers:   dependencyAutoUnblockBlockerLabels(blockers),
 		},
 	}
-	if err := o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, now, "dependency_auto_unblock", metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "dependency_auto_unblock", metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("dependency auto-unblock transition failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 		}

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -276,7 +276,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	dispatchTargetState := ""
 	if targetState != "" {
 		sourceState := issue.State
-		if err := o.updateIssueState(ctx, issue, targetState, now, "dispatch_start"); err != nil {
+		if err := o.updateIssueState(ctx, state, issue, targetState, now, "dispatch_start"); err != nil {
 			o.releaseGlobalDispatchSlot(globalSlot)
 			o.completeDurableWorkAttempt(ctx, state, Running{
 				Issue:         issue,

--- a/internal/orchestrator/epic.go
+++ b/internal/orchestrator/epic.go
@@ -29,17 +29,18 @@ type epicIssueIndex struct {
 	byIdentifier map[string]connector.Issue
 }
 
-func (o *Orchestrator) closeCompletedEpics(ctx context.Context, issues []connector.Issue) map[string]struct{} {
+func (o *Orchestrator) closeCompletedEpics(ctx context.Context, state *State, issues []connector.Issue) map[string]struct{} {
 	plans := completedEpicPlans(issues)
 	if len(plans) == 0 {
 		return nil
 	}
-	completed, _ := o.closeCompletedEpicPlans(ctx, issues, plans)
+	completed, _ := o.closeCompletedEpicPlans(ctx, state, issues, plans)
 	return completed
 }
 
 func (o *Orchestrator) closeCompletedEpicPlans(
 	ctx context.Context,
+	state *State,
 	issues []connector.Issue,
 	plans []completedEpicPlan,
 ) (map[string]struct{}, map[string]connector.Issue) {
@@ -68,7 +69,7 @@ func (o *Orchestrator) closeCompletedEpicPlans(
 		if strings.TrimSpace(plan.issue.ID) != "" {
 			completed[plan.issue.ID] = struct{}{}
 		}
-		o.finalizeCompletedEpic(ctx, plan.issue, plan.children)
+		o.finalizeCompletedEpic(ctx, state, plan.issue, plan.children)
 	}
 	if len(failedRefreshes) == 0 {
 		failedRefreshes = nil
@@ -78,6 +79,7 @@ func (o *Orchestrator) closeCompletedEpicPlans(
 
 func (o *Orchestrator) closeCompletedEpicsForTerminalTransitions(
 	ctx context.Context,
+	state *State,
 	issues []connector.Issue,
 	previous []connector.Issue,
 	lastRefreshAt time.Time,
@@ -134,7 +136,7 @@ func (o *Orchestrator) closeCompletedEpicsForTerminalTransitions(
 		key := issueIdentityKey(plans[index].issue)
 		plans[index].retryIssues = cloneIssues(parentTransitions[key])
 	}
-	completed, failedRefreshes := o.closeCompletedEpicPlans(ctx, parents, plans)
+	completed, failedRefreshes := o.closeCompletedEpicPlans(ctx, state, parents, plans)
 	return completed, mergeIssueMaps(failedTransitions, failedRefreshes)
 }
 
@@ -379,9 +381,9 @@ func (o *Orchestrator) resolveMissingEpicChildren(ctx context.Context, index *ep
 	index.addIssues(issues)
 }
 
-func (o *Orchestrator) finalizeCompletedEpic(ctx context.Context, issue connector.Issue, children []connector.BlockedRef) {
+func (o *Orchestrator) finalizeCompletedEpic(ctx context.Context, state *State, issue connector.Issue, children []connector.BlockedRef) {
 	if !stateIn(issue.State, o.cfg.TerminalStates) {
-		if err := o.updateIssueState(ctx, issue, doneStateName(o.cfg.TerminalStates), time.Now(), "epic_children_completed"); err != nil && o.logger != nil {
+		if err := o.updateIssueState(ctx, state, issue, doneStateName(o.cfg.TerminalStates), time.Now(), "epic_children_completed"); err != nil && o.logger != nil {
 			o.logger.Warn("move completed epic to done failed", "issue_id", issue.ID, "error", err)
 		}
 	}

--- a/internal/orchestrator/epic_test.go
+++ b/internal/orchestrator/epic_test.go
@@ -195,7 +195,7 @@ func TestCloseCompletedEpics(t *testing.T) {
 			}
 
 			issues := append(cloneIssues(tt.candidates), tt.stateIssues...)
-			orch.closeCompletedEpics(context.Background(), issues)
+			orch.closeCompletedEpics(context.Background(), &state, issues)
 
 			if got := tracker.stateUpdates(); !reflect.DeepEqual(got, tt.wantUpdates) {
 				t.Fatalf("state updates = %#v, want %#v", got, tt.wantUpdates)

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -349,7 +349,7 @@ func (o *Orchestrator) blockNoProgressLimit(
 	if issueID == "" {
 		return false
 	}
-	if err := o.updateIssueStateByID(ctx, issueID, issue, blockedStatusState, blockedAt, noProgressLimitReason); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, blockedStatusState, blockedAt, noProgressLimitReason); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"no progress limit state transition failed",

--- a/internal/orchestrator/orchestrator_test.go
+++ b/internal/orchestrator/orchestrator_test.go
@@ -2093,6 +2093,10 @@ func TestRequestRefreshPreservesBoardAfterObservedStateFailure(t *testing.T) {
 	if firstRefreshAt == nil {
 		t.Fatal("first snapshot Refresh.LastRefreshAt = nil")
 	}
+	want := map[string]string{}
+	for _, issue := range first.Snapshot(time.Now()).BoardIssues {
+		want[issue.ID] = issue.State
+	}
 	tracker.setFetchByStatesError(statusErr)
 
 	refresh, err := orch.RequestRefresh(context.Background())
@@ -2117,10 +2121,6 @@ func TestRequestRefreshPreservesBoardAfterObservedStateFailure(t *testing.T) {
 	got := map[string]string{}
 	for _, issue := range snapshot.BoardIssues {
 		got[issue.ID] = issue.State
-	}
-	want := map[string]string{
-		candidate.ID: candidate.State,
-		observed.ID:  observed.State,
 	}
 	if !maps.Equal(got, want) {
 		t.Fatalf("snapshot BoardIssues = %#v, want preserved board %#v", got, want)

--- a/internal/orchestrator/plan_review.go
+++ b/internal/orchestrator/plan_review.go
@@ -359,7 +359,7 @@ func (o *Orchestrator) applyPlanReviewDecision(
 	if normalizeState(targetState) == normalizeState(autoPromoteReworkState) {
 		metadata = workflowLaneMetadataWithActionSignature(metadata, workflowActionPlanReviewRework, reworkSignature)
 	}
-	if err := o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, now, "plan_review_decision", metadata); err != nil {
+	if err := o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, now, "plan_review_decision", metadata); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"plan review transition failed",

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -172,7 +172,7 @@ func (o *Orchestrator) reconcileClosedCompletedIssueStatuses(ctx context.Context
 		if !closedCompletedIssueNeedsStatusReconciliation(issue, o.cfg.TerminalStates) {
 			continue
 		}
-		if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "closed_completed_status_reconciled"); err != nil {
+		if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "closed_completed_status_reconciled"); err != nil {
 			if o.logger != nil {
 				o.logger.Warn("reconcile closed completed issue status failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 			}

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -434,7 +434,7 @@ func (o *Orchestrator) parkInstantFailure(
 	targetState := o.instantFailureParkState()
 	issue := cloneIssue(running.Issue)
 	if targetState != "" {
-		if err := o.updateIssueState(ctx, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker"); err != nil {
+		if err := o.updateIssueState(ctx, state, issue, targetState, event.CompletedAt, "instant_fail_circuit_breaker"); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"instant fail circuit breaker state transition failed",
@@ -553,7 +553,7 @@ func (o *Orchestrator) parkRepeatedFailure(
 	targetState := o.instantFailureParkState()
 	issue := cloneIssue(running.Issue)
 	if targetState != "" {
-		if err := o.updateIssueState(ctx, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker"); err != nil {
+		if err := o.updateIssueState(ctx, state, issue, targetState, event.CompletedAt, "repeated_failure_circuit_breaker"); err != nil {
 			if o.logger != nil {
 				o.logger.Error(
 					"repeated failure circuit breaker state transition failed",
@@ -766,7 +766,7 @@ func (o *Orchestrator) completeProgrammaticMergeWorkerResult(
 		activityAt := event.CompletedAt.UTC()
 		mergedIssue.PullRequest.ActivityAt = &activityAt
 	}
-	if err := o.updateIssueStateByID(ctx, issueID, mergedIssue, targetState, event.CompletedAt, "merge_worker_programmatic_merge"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, mergedIssue, targetState, event.CompletedAt, "merge_worker_programmatic_merge"); err != nil {
 		running.Issue = mergedIssue
 		o.failProgrammaticMergeWorkerResult(ctx, state, event, running, "programmatic_merge_state_update_failed", err)
 		return true
@@ -971,7 +971,7 @@ func (o *Orchestrator) reworkExhaustedMergeWorker(
 	if issueID == "" || o.connector == nil {
 		return false
 	}
-	if err := o.updateIssueStateByID(ctx, issueID, running.Issue, autoPromoteReworkState, completedAt, "merge_worker_retry_exhausted"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, running.Issue, autoPromoteReworkState, completedAt, "merge_worker_retry_exhausted"); err != nil {
 		if o.logger != nil {
 			o.logger.Warn(
 				"merge_worker_rework_failed",
@@ -1062,7 +1062,7 @@ func (o *Orchestrator) completePlanRunning(
 		o.scheduleRetry(state, issue, nextAttempt(running.Attempt), event.CompletedAt, "plan comment failed: "+err.Error(), false, running.WorkerHost)
 		return
 	}
-	if err := o.updateIssueStateByID(ctx, issueID, issue, cfg.Stop, event.CompletedAt, "plan_artifact_created"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, cfg.Stop, event.CompletedAt, "plan_artifact_created"); err != nil {
 		o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, store.WorkAttemptTerminalFailure, "plan_transition_failed", err.Error(), "reviewing", "plan review transition failed")
 		o.scheduleRetry(state, issue, nextAttempt(running.Attempt), event.CompletedAt, "plan review transition failed: "+err.Error(), false, running.WorkerHost)
 		return
@@ -1164,7 +1164,7 @@ func (o *Orchestrator) completeTerminalRunning(
 			Message: fmt.Sprintf("claim lease release failed for %s: %v", issueLabel(running.Issue), err),
 		})
 	}
-	issue := o.ensureClosedCompletedRunningIssueDone(ctx, issueID, running.Issue, completedAt)
+	issue := o.ensureClosedCompletedRunningIssueDone(ctx, state, issueID, running.Issue, completedAt)
 	finalState := strings.TrimSpace(issue.State)
 	if finalState == "" {
 		finalState = FinalStateCompleted
@@ -1193,7 +1193,7 @@ func (o *Orchestrator) completeTerminalRunning(
 	o.reapWorkspace(ctx, state, issue, workspaceReapReason(issue, o.cfg.TerminalStates), completedAt)
 }
 
-func (o *Orchestrator) ensureClosedCompletedRunningIssueDone(ctx context.Context, issueID string, issue connector.Issue, now time.Time) connector.Issue {
+func (o *Orchestrator) ensureClosedCompletedRunningIssueDone(ctx context.Context, state *State, issueID string, issue connector.Issue, now time.Time) connector.Issue {
 	if !issue.Closed || !closedReasonCompleted(issue.ClosedReason) {
 		return issue
 	}
@@ -1201,7 +1201,7 @@ func (o *Orchestrator) ensureClosedCompletedRunningIssueDone(ctx context.Context
 	if strings.TrimSpace(targetState) == "" {
 		return issue
 	}
-	if err := o.updateIssueStateByID(ctx, issueID, issue, targetState, now, "closed_completed_running_done"); err != nil {
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, targetState, now, "closed_completed_running_done"); err != nil {
 		if o.logger != nil {
 			o.logger.Warn("mark closed completed running issue done failed", "issue_id", issueID, "identifier", issue.Identifier, "from_state", issue.State, "target_state", targetState, "error", err)
 		}

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -64,6 +64,7 @@ type State struct {
 	planRework               map[string]struct{}
 	epicTransitionWatch      []connector.Issue
 	pendingEpicParentLookups map[string]connector.Issue
+	tickTransitions          *issueStateSnapshotTransitions
 }
 
 type Running struct {

--- a/internal/orchestrator/status_reconciliation_test.go
+++ b/internal/orchestrator/status_reconciliation_test.go
@@ -121,8 +121,8 @@ func TestTickReconcilesClosedCompletedIssueStatusesFromExistingPolls(t *testing.
 	if len(state.epicTransitionWatch) != 0 {
 		t.Fatalf("epicTransitionWatch = %#v, want reconciled issues filtered", state.epicTransitionWatch)
 	}
-	if len(state.Pipeline) != 0 {
-		t.Fatalf("Pipeline = %#v, want reconciled issues filtered", state.Pipeline)
+	if len(state.Pipeline) != 1 || state.Pipeline[0].ID != review.ID || state.Pipeline[0].State != "Done" {
+		t.Fatalf("Pipeline = %#v, want reconciled issue immediately visible as Done", state.Pipeline)
 	}
 }
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -49,6 +49,10 @@ func (o *Orchestrator) tickManual(ctx context.Context, state *State, request man
 }
 
 func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now time.Time, manual *manualRefreshRequest) {
+	state.tickTransitions = &issueStateSnapshotTransitions{}
+	defer func() {
+		state.tickTransitions = nil
+	}()
 	if manual != nil {
 		startManualRefresh(state, *manual, now)
 	}
@@ -165,9 +169,13 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 	)
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
 	if refreshSucceeded(state) {
-		state.BoardIssues = boardIssuesFromFetched(fetched)
+		state.BoardIssues = overlayIssueStateSnapshots(
+			boardIssuesFromFetched(fetched),
+			state.tickTransitions.boardIssues,
+		)
 		o.markRefreshSucceeded(state, now)
 	}
+	state.Pipeline = overlayIssueStateSnapshots(state.Pipeline, state.tickTransitions.pipeline)
 	completed = true
 }
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -587,6 +587,7 @@ func (o *Orchestrator) resolveCompletedEpics(
 	previousTransitions = mergeIssueSlices(previousTransitions, previous.blockedStatusIssues)
 	completedEpics, failedParentLookups := o.closeCompletedEpicsForTerminalTransitions(
 		ctx,
+		state,
 		transitions.issues,
 		previousTransitions,
 		previous.lastRefreshAt,

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -49,6 +49,11 @@ type workflowLaneActionSignatureMetadata struct {
 	Signature string `json:"signature,omitempty"`
 }
 
+type issueStateSnapshotTransitions struct {
+	boardIssues []connector.Issue
+	pipeline    []connector.Issue
+}
+
 func (o *Orchestrator) updateIssueState(
 	ctx context.Context,
 	state *State,
@@ -91,7 +96,7 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadata(
 		}
 		return err
 	}
-	updateIssueStateSnapshots(state, issueID, targetState, at)
+	updateIssueStateSnapshots(state, issueID, issue, targetState, at)
 	if strings.TrimSpace(issue.ID) == "" {
 		issue.ID = issueID
 	}
@@ -99,7 +104,7 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadata(
 	return nil
 }
 
-func updateIssueStateSnapshots(state *State, issueID string, targetState string, at time.Time) {
+func updateIssueStateSnapshots(state *State, issueID string, issue connector.Issue, targetState string, at time.Time) {
 	if state == nil {
 		return
 	}
@@ -109,21 +114,88 @@ func updateIssueStateSnapshots(state *State, issueID string, targetState string,
 		return
 	}
 
-	update := func(issues []connector.Issue) {
+	transitioned := cloneIssue(issue)
+	if strings.TrimSpace(transitioned.ID) == "" {
+		transitioned.ID = issueID
+	}
+	applyIssueStateSnapshot(&transitioned, targetState, at)
+
+	update := func(issues []connector.Issue) (connector.Issue, bool) {
 		for index := range issues {
 			if strings.TrimSpace(issues[index].ID) != issueID {
 				continue
 			}
-			stateChanged := normalizeState(issues[index].State) != normalizeState(targetState)
-			issues[index].State = targetState
-			if stateChanged && !at.IsZero() {
-				stageUpdatedAt := at.UTC()
-				issues[index].StageUpdatedAt = &stageUpdatedAt
-			}
+			applyIssueStateSnapshot(&issues[index], targetState, at)
+			return cloneIssue(issues[index]), true
+		}
+		return connector.Issue{}, false
+	}
+	boardTransition := transitioned
+	if updated, ok := update(state.BoardIssues); ok {
+		boardTransition = updated
+	}
+	if state.tickTransitions != nil {
+		state.tickTransitions.boardIssues = upsertIssueStateSnapshot(
+			state.tickTransitions.boardIssues,
+			boardTransition,
+		)
+	}
+	if updated, ok := update(state.Pipeline); ok && state.tickTransitions != nil {
+		state.tickTransitions.pipeline = upsertIssueStateSnapshot(
+			state.tickTransitions.pipeline,
+			updated,
+		)
+	}
+}
+
+func applyIssueStateSnapshot(issue *connector.Issue, targetState string, at time.Time) {
+	if issue == nil {
+		return
+	}
+	stateChanged := normalizeState(issue.State) != normalizeState(targetState)
+	issue.State = targetState
+	if stateChanged && !at.IsZero() {
+		stageUpdatedAt := at.UTC()
+		issue.StageUpdatedAt = &stageUpdatedAt
+	}
+}
+
+func upsertIssueStateSnapshot(issues []connector.Issue, issue connector.Issue) []connector.Issue {
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return issues
+	}
+	for index := range issues {
+		if strings.TrimSpace(issues[index].ID) == issueID {
+			issues[index] = cloneIssue(issue)
+			return issues
 		}
 	}
-	update(state.BoardIssues)
-	update(state.Pipeline)
+	return append(issues, cloneIssue(issue))
+}
+
+func overlayIssueStateSnapshots(issues []connector.Issue, transitions []connector.Issue) []connector.Issue {
+	out := cloneIssues(issues)
+	for _, transition := range transitions {
+		issueID := strings.TrimSpace(transition.ID)
+		if issueID == "" {
+			continue
+		}
+		found := false
+		for index := range out {
+			if strings.TrimSpace(out[index].ID) != issueID {
+				continue
+			}
+			out[index].State = transition.State
+			out[index].StageUpdatedAt = timePointerFromPtr(transition.StageUpdatedAt)
+			found = true
+			break
+		}
+		if !found {
+			out = append(out, cloneIssue(transition))
+		}
+	}
+	return out
 }
 
 func (o *Orchestrator) recordLaneTransition(

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -51,27 +51,30 @@ type workflowLaneActionSignatureMetadata struct {
 
 func (o *Orchestrator) updateIssueState(
 	ctx context.Context,
+	state *State,
 	issue connector.Issue,
 	targetState string,
 	at time.Time,
 	reason string,
 ) error {
-	return o.updateIssueStateByID(ctx, issue.ID, issue, targetState, at, reason)
+	return o.updateIssueStateByID(ctx, state, issue.ID, issue, targetState, at, reason)
 }
 
 func (o *Orchestrator) updateIssueStateByID(
 	ctx context.Context,
+	state *State,
 	issueID string,
 	issue connector.Issue,
 	targetState string,
 	at time.Time,
 	reason string,
 ) error {
-	return o.updateIssueStateByIDWithMetadata(ctx, issueID, issue, targetState, at, reason, workflowLaneMetadata{})
+	return o.updateIssueStateByIDWithMetadata(ctx, state, issueID, issue, targetState, at, reason, workflowLaneMetadata{})
 }
 
 func (o *Orchestrator) updateIssueStateByIDWithMetadata(
 	ctx context.Context,
+	state *State,
 	issueID string,
 	issue connector.Issue,
 	targetState string,
@@ -88,11 +91,39 @@ func (o *Orchestrator) updateIssueStateByIDWithMetadata(
 		}
 		return err
 	}
+	updateIssueStateSnapshots(state, issueID, targetState, at)
 	if strings.TrimSpace(issue.ID) == "" {
 		issue.ID = issueID
 	}
 	o.recordLaneTransition(ctx, issue, targetState, at, reason, metadata)
 	return nil
+}
+
+func updateIssueStateSnapshots(state *State, issueID string, targetState string, at time.Time) {
+	if state == nil {
+		return
+	}
+	issueID = strings.TrimSpace(issueID)
+	targetState = strings.TrimSpace(targetState)
+	if issueID == "" || targetState == "" {
+		return
+	}
+
+	update := func(issues []connector.Issue) {
+		for index := range issues {
+			if strings.TrimSpace(issues[index].ID) != issueID {
+				continue
+			}
+			stateChanged := normalizeState(issues[index].State) != normalizeState(targetState)
+			issues[index].State = targetState
+			if stateChanged && !at.IsZero() {
+				stageUpdatedAt := at.UTC()
+				issues[index].StageUpdatedAt = &stageUpdatedAt
+			}
+		}
+	}
+	update(state.BoardIssues)
+	update(state.Pipeline)
 }
 
 func (o *Orchestrator) recordLaneTransition(

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -9,12 +9,79 @@ import (
 	"github.com/digitaldrywood/detent/internal/store"
 )
 
+func TestApplyAutoPromoteDecisionUpdatesSnapshotBeforePoll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		trackerName string
+	}{
+		{name: "label", trackerName: "github_label"},
+		{name: "ProjectV2", trackerName: "github_project_v2"},
+		{name: "issue field", trackerName: "github_issue_field"},
+		{name: "local", trackerName: "local"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			transitionAt := time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC)
+			previousStageAt := transitionAt.Add(-5 * time.Minute)
+			issue := connector.Issue{
+				ID:             "issue-promote",
+				Identifier:     "digitaldrywood/detent#1131",
+				State:          "In Progress",
+				StageUpdatedAt: &previousStageAt,
+			}
+			tracker := &workflowMetricsConnector{name: tt.trackerName}
+			orch := &Orchestrator{connector: tracker}
+			state := newState(Config{})
+			state.BoardIssues = []connector.Issue{cloneIssue(issue)}
+			state.Pipeline = []connector.Issue{cloneIssue(issue)}
+
+			applied := orch.applyAutoPromoteDecision(
+				context.Background(),
+				&state,
+				issue,
+				AutoPromoteSummary{},
+				autoPromoteDecision(AutoPromoteActionPromote, AutoPromoteReasonReady),
+				"Merging",
+				transitionAt,
+			)
+			if !applied {
+				t.Fatal("applyAutoPromoteDecision() = false, want true")
+			}
+
+			snapshot := state.Snapshot(transitionAt.Add(time.Second))
+			if len(snapshot.BoardIssues) != 1 {
+				t.Fatalf("snapshot BoardIssues len = %d, want 1", len(snapshot.BoardIssues))
+			}
+			if got := snapshot.BoardIssues[0].State; got != "Merging" {
+				t.Fatalf("snapshot BoardIssues state = %q, want Merging", got)
+			}
+			if snapshot.BoardIssues[0].StageUpdatedAt == nil || !snapshot.BoardIssues[0].StageUpdatedAt.Equal(transitionAt) {
+				t.Fatalf("snapshot BoardIssues StageUpdatedAt = %v, want %v", snapshot.BoardIssues[0].StageUpdatedAt, transitionAt)
+			}
+			if len(snapshot.Pipeline) != 1 {
+				t.Fatalf("snapshot Pipeline len = %d, want 1", len(snapshot.Pipeline))
+			}
+			if got := snapshot.Pipeline[0].State; got != "Merging" {
+				t.Fatalf("snapshot Pipeline state = %q, want Merging", got)
+			}
+			if tracker.fetches != 0 {
+				t.Fatalf("tracker fetches = %d, want none", tracker.fetches)
+			}
+		})
+	}
+}
+
 func TestUpdateIssueStateByIDSkipsWorkflowMetricsForBlockedUpdate(t *testing.T) {
 	t.Parallel()
 
 	recorder := &workflowMetricsRecorderSpy{}
 	orch := &Orchestrator{
-		connector: workflowMetricsBlockedConnector{
+		connector: &workflowMetricsConnector{
 			err: &connector.StateUpdateBlockedError{
 				IssueID:      "issue-blocked",
 				CurrentState: "Done",
@@ -23,9 +90,12 @@ func TestUpdateIssueStateByIDSkipsWorkflowMetricsForBlockedUpdate(t *testing.T) 
 		},
 		workflowMetrics: recorder,
 	}
+	state := newState(Config{})
+	state.BoardIssues = []connector.Issue{{ID: "issue-blocked", State: "Done"}}
 
 	err := orch.updateIssueStateByID(
 		context.Background(),
+		&state,
 		"issue-blocked",
 		connector.Issue{
 			ID:         "issue-blocked",
@@ -42,6 +112,9 @@ func TestUpdateIssueStateByIDSkipsWorkflowMetricsForBlockedUpdate(t *testing.T) 
 	if len(recorder.events) != 0 {
 		t.Fatalf("workflow metric events = %#v, want none", recorder.events)
 	}
+	if got := state.BoardIssues[0].State; got != "Done" {
+		t.Fatalf("snapshot BoardIssues state = %q, want Done", got)
+	}
 }
 
 type workflowMetricsRecorderSpy struct {
@@ -53,38 +126,43 @@ func (r *workflowMetricsRecorderSpy) RecordWorkflowPhaseEvent(_ context.Context,
 	return int64(len(r.events)), nil
 }
 
-type workflowMetricsBlockedConnector struct {
-	err error
+type workflowMetricsConnector struct {
+	name    string
+	err     error
+	fetches int
 }
 
-func (c workflowMetricsBlockedConnector) Name() string {
-	return "workflow_metrics_blocked"
+func (c *workflowMetricsConnector) Name() string {
+	return c.name
 }
 
-func (c workflowMetricsBlockedConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+func (c *workflowMetricsConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
+	c.fetches++
 	return nil, nil
 }
 
-func (c workflowMetricsBlockedConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+func (c *workflowMetricsConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+	c.fetches++
 	return nil, nil
 }
 
-func (c workflowMetricsBlockedConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+func (c *workflowMetricsConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
+	c.fetches++
 	return nil, nil
 }
 
-func (c workflowMetricsBlockedConnector) CreateComment(context.Context, string, string) error {
+func (c *workflowMetricsConnector) CreateComment(context.Context, string, string) error {
 	return nil
 }
 
-func (c workflowMetricsBlockedConnector) UpdateIssueState(context.Context, string, string) error {
+func (c *workflowMetricsConnector) UpdateIssueState(context.Context, string, string) error {
 	return c.err
 }
 
-func (c workflowMetricsBlockedConnector) SetAssignee(context.Context, string, string) error {
+func (c *workflowMetricsConnector) SetAssignee(context.Context, string, string) error {
 	return nil
 }
 
-func (c workflowMetricsBlockedConnector) SetField(context.Context, string, string, string) error {
+func (c *workflowMetricsConnector) SetField(context.Context, string, string, string) error {
 	return nil
 }

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -2,12 +2,73 @@ package orchestrator
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/store"
 )
+
+func TestTickPreservesOrchestratorTransitionSnapshot(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC)
+	issue := connector.Issue{
+		ID:           "issue-closed",
+		Identifier:   "digitaldrywood/detent#1131",
+		State:        "Human Review",
+		Closed:       true,
+		ClosedReason: "completed",
+	}
+	cfg := normalizeConfig(Config{
+		PollInterval:        time.Minute,
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "In Progress", "Rework", "Merging"},
+		ObservedStates:      []string{"Blocked", "Done"},
+		TerminalStates:      []string{"Done", "Cancelled"},
+	})
+	tracker := &workflowMetricsConnector{stateIssues: []connector.Issue{cloneIssue(issue)}}
+	orch := &Orchestrator{
+		cfg:       cfg,
+		connector: tracker,
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.BoardIssues = []connector.Issue{cloneIssue(issue)}
+	state.Pipeline = []connector.Issue{cloneIssue(issue)}
+
+	orch.tick(context.Background(), &state, now)
+
+	snapshot := state.Snapshot(now.Add(time.Second))
+	if len(snapshot.BoardIssues) != 1 {
+		t.Fatalf("snapshot BoardIssues len = %d, want 1", len(snapshot.BoardIssues))
+	}
+	if got := snapshot.BoardIssues[0].State; got != "Done" {
+		t.Fatalf("snapshot BoardIssues state = %q, want Done", got)
+	}
+	if len(snapshot.Pipeline) != 1 {
+		t.Fatalf("snapshot Pipeline len = %d, want 1", len(snapshot.Pipeline))
+	}
+	if got := snapshot.Pipeline[0].State; got != "Done" {
+		t.Fatalf("snapshot Pipeline state = %q, want Done", got)
+	}
+
+	external := cloneIssue(issue)
+	external.Closed = false
+	external.ClosedReason = ""
+	tracker.stateIssues = []connector.Issue{external}
+	orch.tick(context.Background(), &state, now.Add(time.Minute))
+
+	snapshot = state.Snapshot(now.Add(time.Minute + time.Second))
+	if len(snapshot.BoardIssues) != 1 || snapshot.BoardIssues[0].State != "Human Review" {
+		t.Fatalf("snapshot BoardIssues = %#v, want external Human Review state", snapshot.BoardIssues)
+	}
+	if len(snapshot.Pipeline) != 1 || snapshot.Pipeline[0].State != "Human Review" {
+		t.Fatalf("snapshot Pipeline = %#v, want external Human Review state", snapshot.Pipeline)
+	}
+}
 
 func TestApplyAutoPromoteDecisionUpdatesSnapshotBeforePoll(t *testing.T) {
 	t.Parallel()
@@ -127,9 +188,11 @@ func (r *workflowMetricsRecorderSpy) RecordWorkflowPhaseEvent(_ context.Context,
 }
 
 type workflowMetricsConnector struct {
-	name    string
-	err     error
-	fetches int
+	name        string
+	err         error
+	fetches     int
+	candidates  []connector.Issue
+	stateIssues []connector.Issue
 }
 
 func (c *workflowMetricsConnector) Name() string {
@@ -138,12 +201,12 @@ func (c *workflowMetricsConnector) Name() string {
 
 func (c *workflowMetricsConnector) FetchCandidateIssues(context.Context) ([]connector.Issue, error) {
 	c.fetches++
-	return nil, nil
+	return cloneIssues(c.candidates), nil
 }
 
-func (c *workflowMetricsConnector) FetchIssuesByStates(context.Context, []string) ([]connector.Issue, error) {
+func (c *workflowMetricsConnector) FetchIssuesByStates(_ context.Context, states []string) ([]connector.Issue, error) {
 	c.fetches++
-	return nil, nil
+	return issuesInStates(c.stateIssues, states), nil
 }
 
 func (c *workflowMetricsConnector) FetchIssueStatesByIDs(context.Context, []string) ([]connector.Issue, error) {
@@ -155,8 +218,21 @@ func (c *workflowMetricsConnector) CreateComment(context.Context, string, string
 	return nil
 }
 
-func (c *workflowMetricsConnector) UpdateIssueState(context.Context, string, string) error {
-	return c.err
+func (c *workflowMetricsConnector) UpdateIssueState(_ context.Context, issueID string, state string) error {
+	if c.err != nil {
+		return c.err
+	}
+	for index := range c.candidates {
+		if c.candidates[index].ID == issueID {
+			c.candidates[index].State = state
+		}
+	}
+	for index := range c.stateIssues {
+		if c.stateIssues[index].ID == issueID {
+			c.stateIssues[index].State = state
+		}
+	}
+	return nil
 }
 
 func (c *workflowMetricsConnector) SetAssignee(context.Context, string, string) error {


### PR DESCRIPTION
## Summary

- Update in-memory board and pipeline issue state immediately after successful orchestrator-driven tracker transitions.
- Preserve tick-time transitions through fetched-list filtering so the next SSE snapshot renders them.
- Clear the optimistic overlay after each tick so later external tracker changes still reconcile normally.
- Cover label, ProjectV2, issue-field, and local tracker paths plus the full tick/reconciliation path.

Fixes #1131

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No visual markup or styling changed.

## Test Plan

- [x] `go test -race ./internal/orchestrator -count=1`
- [x] `make check`
