### PR TITLE
fix(board): preserve lane entry timers

### DIFF
--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -42,11 +42,11 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	boardIssues := authorizedSnapshotIssues(s.BoardIssues, s.Authorization, s.SelectorContext)
 	pipeline := authorizedSnapshotIssues(s.Pipeline, s.Authorization, s.SelectorContext)
 	statusDrift := authorizedStatusDrift(s.StatusDrift, s.Authorization, s.SelectorContext)
-	boardIssueSnapshots := issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now)
+	boardIssueSnapshots := issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now, s.laneEntries)
 	applyIssueRuntimeIdentities(boardIssueSnapshots, s.Running, s.WorkAttempts)
 	s.applyGatePendingSnapshots(boardIssueSnapshots, boardIssues)
 	s.applyAutoPromoteDecisionSnapshots(boardIssueSnapshots, boardIssues, now)
-	pipelineIssueSnapshots := pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now)
+	pipelineIssueSnapshots := pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now, s.laneEntries)
 	applyIssueRuntimeIdentities(pipelineIssueSnapshots, s.Running, s.WorkAttempts)
 	s.applyAutoPromoteDecisionSnapshots(pipelineIssueSnapshots, pipeline, now)
 	snapshot := telemetry.Snapshot{
@@ -56,15 +56,15 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		Shutdown:           shutdownSnapshot(s),
 		Events:             cloneActivityEvents(s.RecentEvents),
 		Refresh:            refresh,
-		TrackerDrift:       statusDriftSnapshot(statusDrift, s.AutoPromoteQuietDuration, s.PollInterval, now),
+		TrackerDrift:       statusDriftSnapshot(statusDrift, s.AutoPromoteQuietDuration, s.PollInterval, now, s.laneEntries),
 		BoardIssues:        boardIssueSnapshots,
 		Pipeline:           pipelineIssueSnapshots,
-		Running:            runningSnapshots(s.Running, s.Claimed, s.MergeTimings, now),
+		Running:            runningSnapshots(s.Running, s.Claimed, s.MergeTimings, now, s.laneEntries),
 		WorkAttempts:       cloneTelemetryWorkAttempts(s.WorkAttempts),
 		SchedulerDecisions: cloneTelemetrySchedulerDecisions(s.SchedulerDecisions),
-		Queue:              queueSnapshots(s.Retry, s.Claimed, s.MergeTimings, now),
-		Blocked:            blockedSnapshots(s.Blocked, s.Claimed, now),
-		Completed:          completedSnapshots(s.Completed, s.Claimed, now),
+		Queue:              queueSnapshots(s.Retry, s.Claimed, s.MergeTimings, now, s.laneEntries),
+		Blocked:            blockedSnapshots(s.Blocked, s.Claimed, now, s.laneEntries),
+		Completed:          completedSnapshots(s.Completed, s.Claimed, now, s.laneEntries),
 		RateLimits:         cloneRateLimits(s.RateLimits),
 		Tokens:             tokensFromTokenTotals(s.liveTokenTotals()),
 		Budget: telemetry.Budget{
@@ -172,10 +172,11 @@ func statusDriftSnapshot(
 	quietDuration time.Duration,
 	pollInterval time.Duration,
 	now time.Time,
+	laneEntries map[string]time.Time,
 ) telemetry.TrackerDrift {
 	return telemetry.TrackerDrift{
-		UntrackedOpen: issueSnapshots(drift.UntrackedOpen, quietDuration, pollInterval, now),
-		OpenTerminal:  issueSnapshots(drift.OpenTerminal, quietDuration, pollInterval, now),
+		UntrackedOpen: issueSnapshots(drift.UntrackedOpen, quietDuration, pollInterval, now, laneEntries),
+		OpenTerminal:  issueSnapshots(drift.OpenTerminal, quietDuration, pollInterval, now, laneEntries),
 	}
 }
 
@@ -223,31 +224,32 @@ func pipelineSnapshots(
 	pollInterval time.Duration,
 	mergeTimings map[string]MergeTiming,
 	now time.Time,
+	laneEntries map[string]time.Time,
 ) []telemetry.Issue {
 	out := make([]telemetry.Issue, 0, len(issues))
 	for _, issue := range issues {
-		item := telemetryIssue(issue, quietDuration, pollInterval, now)
+		item := telemetryIssue(issue, quietDuration, pollInterval, now, laneEntries)
 		applyMergeTimingSnapshot(&item, issue, mergeTimings[strings.TrimSpace(issue.ID)], now)
 		out = append(out, item)
 	}
 	return out
 }
 
-func issueSnapshots(issues []connector.Issue, quietDuration time.Duration, pollInterval time.Duration, now time.Time) []telemetry.Issue {
+func issueSnapshots(issues []connector.Issue, quietDuration time.Duration, pollInterval time.Duration, now time.Time, laneEntries map[string]time.Time) []telemetry.Issue {
 	out := make([]telemetry.Issue, 0, len(issues))
 	for _, issue := range issues {
-		out = append(out, telemetryIssue(issue, quietDuration, pollInterval, now))
+		out = append(out, telemetryIssue(issue, quietDuration, pollInterval, now, laneEntries))
 	}
 	return out
 }
 
-func runningSnapshots(running map[string]Running, claims map[string]Claimed, mergeTimings map[string]MergeTiming, now time.Time) []telemetry.Running {
+func runningSnapshots(running map[string]Running, claims map[string]Claimed, mergeTimings map[string]MergeTiming, now time.Time, laneEntries map[string]time.Time) []telemetry.Running {
 	ids := sortedKeys(running)
 	out := make([]telemetry.Running, 0, len(ids))
 	for _, id := range ids {
 		entry := running[id]
 		lastEventAt := timePointer(entry.LastEventAt)
-		issue := telemetryIssue(entry.Issue, 0, 0, now)
+		issue := telemetryIssue(entry.Issue, 0, 0, now, laneEntries)
 		timing := mergeTimings[strings.TrimSpace(entry.Issue.ID)]
 		if mergeWorkerIssue(entry.Issue) && timing.MergeStartedAt.IsZero() && !entry.StartedAt.IsZero() {
 			timing.MergeStartedAt = entry.StartedAt
@@ -280,12 +282,12 @@ func runningSnapshots(running map[string]Running, claims map[string]Claimed, mer
 	return out
 }
 
-func queueSnapshots(retry map[string]Retry, claims map[string]Claimed, mergeTimings map[string]MergeTiming, now time.Time) []telemetry.Queued {
+func queueSnapshots(retry map[string]Retry, claims map[string]Claimed, mergeTimings map[string]MergeTiming, now time.Time, laneEntries map[string]time.Time) []telemetry.Queued {
 	ids := sortedKeys(retry)
 	out := make([]telemetry.Queued, 0, len(ids))
 	for _, id := range ids {
 		entry := retry[id]
-		issue := telemetryIssue(entry.Issue, 0, 0, now)
+		issue := telemetryIssue(entry.Issue, 0, 0, now, laneEntries)
 		applyMergeTimingSnapshot(&issue, entry.Issue, mergeTimings[strings.TrimSpace(entry.Issue.ID)], now)
 		applyClaimSnapshot(&issue, claims[id], now)
 		queued := telemetry.Queued{
@@ -303,12 +305,12 @@ func queueSnapshots(retry map[string]Retry, claims map[string]Claimed, mergeTimi
 	return out
 }
 
-func blockedSnapshots(blocked map[string]Blocked, claims map[string]Claimed, now time.Time) []telemetry.Blocked {
+func blockedSnapshots(blocked map[string]Blocked, claims map[string]Claimed, now time.Time, laneEntries map[string]time.Time) []telemetry.Blocked {
 	ids := sortedKeys(blocked)
 	out := make([]telemetry.Blocked, 0, len(ids))
 	for _, id := range ids {
 		entry := blocked[id]
-		issue := telemetryIssue(entry.Issue, 0, 0, now)
+		issue := telemetryIssue(entry.Issue, 0, 0, now, laneEntries)
 		applyClaimSnapshot(&issue, claims[id], now)
 		item := telemetry.Blocked{
 			Issue:          issue,
@@ -326,12 +328,12 @@ func blockedSnapshots(blocked map[string]Blocked, claims map[string]Claimed, now
 	return out
 }
 
-func completedSnapshots(completed map[string]Completed, claims map[string]Claimed, now time.Time) []telemetry.Completed {
+func completedSnapshots(completed map[string]Completed, claims map[string]Claimed, now time.Time, laneEntries map[string]time.Time) []telemetry.Completed {
 	ids := sortedKeys(completed)
 	out := make([]telemetry.Completed, 0, len(ids))
 	for _, id := range ids {
 		entry := completed[id]
-		issue := telemetryIssue(entry.Issue, 0, 0, now)
+		issue := telemetryIssue(entry.Issue, 0, 0, now, laneEntries)
 		applyMergeTimingSnapshot(&issue, entry.Issue, entry.MergeTiming, entry.CompletedAt)
 		applyClaimSnapshot(&issue, claims[id], now)
 		out = append(out, telemetry.Completed{
@@ -467,8 +469,8 @@ func telemetryMergeTiming(issue connector.Issue, timing MergeTiming, now time.Ti
 	return out, true
 }
 
-func telemetryIssue(issue connector.Issue, quietDuration time.Duration, pollInterval time.Duration, now time.Time) telemetry.Issue {
-	laneEnteredAt := telemetryIssueLaneEnteredAt(issue)
+func telemetryIssue(issue connector.Issue, quietDuration time.Duration, pollInterval time.Duration, now time.Time, laneEntries map[string]time.Time) telemetry.Issue {
+	laneEnteredAt := telemetryIssueLaneEnteredAt(issue, laneEntries)
 	return telemetry.Issue{
 		ID:                    issue.ID,
 		Identifier:            issue.Identifier,
@@ -515,15 +517,11 @@ func telemetryDeliverable(deliverable *connector.Deliverable) *telemetry.Deliver
 	}
 }
 
-func telemetryIssueLaneEnteredAt(issue connector.Issue) *time.Time {
-	for _, candidate := range []*time.Time{issue.StageUpdatedAt, issue.UpdatedAt, issue.CreatedAt} {
-		if candidate == nil || candidate.IsZero() {
-			continue
-		}
-		value := *candidate
-		return &value
+func telemetryIssueLaneEnteredAt(issue connector.Issue, laneEntries map[string]time.Time) *time.Time {
+	if enteredAt := laneEntries[workflowLaneEntryKey(issue)]; !enteredAt.IsZero() {
+		return timePointer(enteredAt)
 	}
-	return nil
+	return timePointer(workflowLaneFallbackAt(issue))
 }
 
 func telemetryIssueLaneAgeSeconds(startedAt *time.Time, now time.Time) int64 {

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -1129,6 +1129,34 @@ func TestStateSnapshotDeterministicOrdering(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotSameLaneUpdateKeepsLaneEntry(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 18, 0, 0, 0, time.UTC)
+	enteredAt := now.Add(-time.Hour)
+	updatedAt := now.Add(-5 * time.Minute)
+	state := newState(normalizeConfig(Config{}))
+	state.BoardIssues = []connector.Issue{{
+		ID:        "issue-1130",
+		State:     "In Progress",
+		UpdatedAt: &enteredAt,
+	}}
+	orch := &Orchestrator{}
+	orch.refreshCurrentLaneEntries(t.Context(), &state)
+
+	first := state.Snapshot(now)
+	state.BoardIssues[0].UpdatedAt = &updatedAt
+	orch.refreshCurrentLaneEntries(t.Context(), &state)
+	second := state.Snapshot(now)
+
+	if first.BoardIssues[0].CurrentLaneEnteredAt == nil || second.BoardIssues[0].CurrentLaneEnteredAt == nil {
+		t.Fatalf("CurrentLaneEnteredAt = %v then %v, want timestamps", first.BoardIssues[0].CurrentLaneEnteredAt, second.BoardIssues[0].CurrentLaneEnteredAt)
+	}
+	if !second.BoardIssues[0].CurrentLaneEnteredAt.Equal(*first.BoardIssues[0].CurrentLaneEnteredAt) {
+		t.Fatalf("CurrentLaneEnteredAt = %v after same-lane update, want %v", second.BoardIssues[0].CurrentLaneEnteredAt, first.BoardIssues[0].CurrentLaneEnteredAt)
+	}
+}
+
 func telemetryIssueIDs(issues []telemetry.Issue) []string {
 	out := make([]string, 0, len(issues))
 	for _, issue := range issues {

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -61,6 +61,7 @@ type State struct {
 	ReapedWorkspaces         map[string]time.Time
 	TokenTotals              TokenTotals
 	RateLimits               *telemetry.RateLimits
+	laneEntries              map[string]time.Time
 	planRework               map[string]struct{}
 	epicTransitionWatch      []connector.Issue
 	pendingEpicParentLookups map[string]connector.Issue
@@ -214,6 +215,7 @@ func newState(cfg Config) State {
 		RepeatedFailures:         map[string]RepeatedFailure{},
 		DiffStats:                map[string]DiffStats{},
 		ReapedWorkspaces:         map[string]time.Time{},
+		laneEntries:              map[string]time.Time{},
 		planRework:               map[string]struct{}{},
 		pendingEpicParentLookups: map[string]connector.Issue{},
 	}
@@ -264,6 +266,7 @@ func (s State) clone() State {
 		ReapedWorkspaces:         make(map[string]time.Time, len(s.ReapedWorkspaces)),
 		TokenTotals:              s.TokenTotals,
 		RateLimits:               cloneRateLimits(s.RateLimits),
+		laneEntries:              maps.Clone(s.laneEntries),
 		planRework:               make(map[string]struct{}, len(s.planRework)),
 		epicTransitionWatch:      cloneIssues(s.epicTransitionWatch),
 		pendingEpicParentLookups: cloneIssueMap(s.pendingEpicParentLookups),

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -173,6 +173,7 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 			boardIssuesFromFetched(fetched),
 			state.tickTransitions.boardIssues,
 		)
+		o.refreshCurrentLaneEntries(ctx, state)
 		o.markRefreshSucceeded(state, now)
 	}
 	state.Pipeline = overlayIssueStateSnapshots(state.Pipeline, state.tickTransitions.pipeline)

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -338,12 +338,6 @@ func (o *Orchestrator) refreshCurrentLaneEntries(ctx context.Context, state *Sta
 		if _, exists := next[laneKey]; exists {
 			continue
 		}
-		if previousAt := previous[laneKey]; !previousAt.IsZero() {
-			if enteredAt := resolveCurrentLaneEnteredAt(issue, previousAt, nil); !enteredAt.IsZero() {
-				next[laneKey] = enteredAt
-			}
-			continue
-		}
 
 		identityKey := workflowIssueIdentityKey(issue)
 		result, exists := timelines[identityKey]

--- a/internal/orchestrator/workflow_metrics.go
+++ b/internal/orchestrator/workflow_metrics.go
@@ -318,6 +318,137 @@ func workflowLaneStartedAt(issue connector.Issue, fallback time.Time) time.Time 
 	return fallback
 }
 
+func (o *Orchestrator) refreshCurrentLaneEntries(ctx context.Context, state *State) {
+	if state == nil {
+		return
+	}
+
+	type timelineResult struct {
+		timeline store.WorkflowTimeline
+	}
+
+	previous := state.laneEntries
+	next := make(map[string]time.Time)
+	timelines := make(map[string]timelineResult)
+	for _, issue := range stateLaneEntryIssues(state) {
+		laneKey := workflowLaneEntryKey(issue)
+		if laneKey == "" {
+			continue
+		}
+		if _, exists := next[laneKey]; exists {
+			continue
+		}
+		if previousAt := previous[laneKey]; !previousAt.IsZero() {
+			if enteredAt := resolveCurrentLaneEnteredAt(issue, previousAt, nil); !enteredAt.IsZero() {
+				next[laneKey] = enteredAt
+			}
+			continue
+		}
+
+		identityKey := workflowIssueIdentityKey(issue)
+		result, exists := timelines[identityKey]
+		if !exists {
+			result.timeline, _ = o.issueWorkflowTimeline(ctx, issue)
+			timelines[identityKey] = result
+		}
+
+		enteredAt := resolveCurrentLaneEnteredAt(issue, previous[laneKey], result.timeline.Events)
+		if !enteredAt.IsZero() {
+			next[laneKey] = enteredAt
+		}
+	}
+	state.laneEntries = next
+}
+
+func stateLaneEntryIssues(state *State) []connector.Issue {
+	issues := make([]connector.Issue, 0, len(state.BoardIssues)+len(state.Pipeline)+len(state.Running)+len(state.Retry)+len(state.Blocked)+len(state.Completed))
+	issues = append(issues, state.BoardIssues...)
+	issues = append(issues, state.Pipeline...)
+	for _, id := range sortedKeys(state.Running) {
+		issues = append(issues, state.Running[id].Issue)
+	}
+	for _, id := range sortedKeys(state.Retry) {
+		issues = append(issues, state.Retry[id].Issue)
+	}
+	for _, id := range sortedKeys(state.Blocked) {
+		issues = append(issues, state.Blocked[id].Issue)
+	}
+	for _, id := range sortedKeys(state.Completed) {
+		issues = append(issues, state.Completed[id].Issue)
+	}
+	issues = append(issues, state.StatusDrift.UntrackedOpen...)
+	issues = append(issues, state.StatusDrift.OpenTerminal...)
+	return issues
+}
+
+func resolveCurrentLaneEnteredAt(issue connector.Issue, previous time.Time, events []store.WorkflowPhaseEvent) time.Time {
+	if enteredAt, ok := latestCurrentLaneEnteredAt(events, issue.State); ok {
+		return enteredAt
+	}
+
+	fallback := workflowLaneFallbackAt(issue)
+	if !previous.IsZero() && (fallback.IsZero() || !fallback.Before(previous)) {
+		return previous
+	}
+	return fallback
+}
+
+func latestCurrentLaneEnteredAt(events []store.WorkflowPhaseEvent, state string) (time.Time, bool) {
+	state = normalizeState(state)
+	if state == "" {
+		return time.Time{}, false
+	}
+
+	var latest store.WorkflowPhaseEvent
+	for _, event := range events {
+		if event.PhaseType != store.WorkflowPhaseTypeLane ||
+			normalizeState(event.PhaseName) != state ||
+			!strings.EqualFold(strings.TrimSpace(event.Status), "entered") ||
+			event.StartedAt.IsZero() {
+			continue
+		}
+		if latest.StartedAt.IsZero() || event.StartedAt.After(latest.StartedAt) ||
+			(event.StartedAt.Equal(latest.StartedAt) && event.ID > latest.ID) {
+			latest = event
+		}
+	}
+	if latest.StartedAt.IsZero() {
+		return time.Time{}, false
+	}
+	return latest.StartedAt, true
+}
+
+func workflowLaneFallbackAt(issue connector.Issue) time.Time {
+	for _, candidate := range []*time.Time{issue.StageUpdatedAt, issue.UpdatedAt, issue.CreatedAt} {
+		if candidate != nil && !candidate.IsZero() {
+			return *candidate
+		}
+	}
+	return time.Time{}
+}
+
+func workflowLaneEntryKey(issue connector.Issue) string {
+	identity := workflowIssueIdentityKey(issue)
+	lane := normalizeState(issue.State)
+	if identity == "" || lane == "" {
+		return ""
+	}
+	return identity + "\x00" + lane
+}
+
+func workflowIssueIdentityKey(issue connector.Issue) string {
+	if value := strings.TrimSpace(issue.ID); value != "" {
+		return "id:" + value
+	}
+	if value := strings.TrimSpace(issue.Identifier); value != "" {
+		return "identifier:" + value
+	}
+	if value := strings.TrimSpace(issue.URL); value != "" {
+		return "url:" + value
+	}
+	return ""
+}
+
 func workflowDurationSeconds(startedAt time.Time, finishedAt time.Time) int64 {
 	if startedAt.IsZero() || finishedAt.IsZero() || finishedAt.Before(startedAt) {
 		return 0

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -177,6 +177,21 @@ func TestResolveCurrentLaneEnteredAt(t *testing.T) {
 			want: transitionAt,
 		},
 		{
+			name: "leave and return uses latest durable entry",
+			issue: connector.Issue{
+				State:     "In Progress",
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+			previous: enteredAt,
+			events: []store.WorkflowPhaseEvent{
+				{ID: 1, PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "In Progress", Status: "entered", StartedAt: enteredAt},
+				{ID: 2, PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "Merging", Status: "entered", StartedAt: transitionAt.Add(-time.Minute)},
+				{ID: 3, PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "In Progress", Status: "entered", StartedAt: transitionAt},
+			},
+			want: transitionAt,
+		},
+		{
 			name: "restart restores durable entry",
 			issue: connector.Issue{
 				State:     "In Progress",

--- a/internal/orchestrator/workflow_metrics_test.go
+++ b/internal/orchestrator/workflow_metrics_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"io"
 	"log/slog"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -86,7 +87,6 @@ func TestApplyAutoPromoteDecisionUpdatesSnapshotBeforePoll(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
-
 			transitionAt := time.Date(2026, 7, 10, 1, 0, 0, 0, time.UTC)
 			previousStageAt := transitionAt.Add(-5 * time.Minute)
 			issue := connector.Issue{
@@ -134,6 +134,127 @@ func TestApplyAutoPromoteDecisionUpdatesSnapshotBeforePoll(t *testing.T) {
 				t.Fatalf("tracker fetches = %d, want none", tracker.fetches)
 			}
 		})
+	}
+}
+
+func TestResolveCurrentLaneEnteredAt(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 9, 18, 0, 0, 0, time.UTC)
+	createdAt := now.Add(-4 * time.Hour)
+	enteredAt := now.Add(-time.Hour)
+	transitionAt := now.Add(-10 * time.Minute)
+	updatedAt := now.Add(-5 * time.Minute)
+
+	tests := []struct {
+		name     string
+		issue    connector.Issue
+		previous time.Time
+		events   []store.WorkflowPhaseEvent
+		want     time.Time
+	}{
+		{
+			name: "same-lane update keeps previous entry",
+			issue: connector.Issue{
+				State:     "In Progress",
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+			previous: enteredAt,
+			want:     enteredAt,
+		},
+		{
+			name: "lane change uses transition event",
+			issue: connector.Issue{
+				State:     "Merging",
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+			events: []store.WorkflowPhaseEvent{
+				{ID: 1, PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "In Progress", Status: "entered", StartedAt: enteredAt},
+				{ID: 2, PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "merging", Status: "ENTERED", StartedAt: transitionAt},
+			},
+			want: transitionAt,
+		},
+		{
+			name: "restart restores durable entry",
+			issue: connector.Issue{
+				State:     "In Progress",
+				CreatedAt: &createdAt,
+				UpdatedAt: &updatedAt,
+			},
+			events: []store.WorkflowPhaseEvent{
+				{ID: 1, PhaseType: store.WorkflowPhaseTypeLane, PhaseName: "in progress", Status: "entered", StartedAt: enteredAt},
+			},
+			want: enteredAt,
+		},
+		{
+			name: "missing phase events uses tracker fallback",
+			issue: connector.Issue{
+				State:     "Todo",
+				CreatedAt: &createdAt,
+				UpdatedAt: &enteredAt,
+			},
+			want: enteredAt,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got := resolveCurrentLaneEnteredAt(tt.issue, tt.previous, tt.events)
+			if !got.Equal(tt.want) {
+				t.Fatalf("resolveCurrentLaneEnteredAt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestRefreshCurrentLaneEntriesSurvivesStoreRestart(t *testing.T) {
+	ctx := t.Context()
+	dbPath := filepath.Join(t.TempDir(), "detent.db")
+	enteredAt := time.Date(2026, 7, 9, 17, 0, 0, 0, time.UTC)
+
+	seed, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: dbPath})
+	if err != nil {
+		t.Fatalf("store.Open(seed) error = %v", err)
+	}
+	if _, err := seed.RecordWorkflowPhaseEvent(ctx, store.WorkflowPhaseEvent{
+		ProjectID: "detent",
+		IssueID:   "issue-1130",
+		PhaseType: store.WorkflowPhaseTypeLane,
+		PhaseName: "In Progress",
+		Status:    "entered",
+		StartedAt: enteredAt,
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+	if err := seed.Close(); err != nil {
+		t.Fatalf("seed.Close() error = %v", err)
+	}
+
+	for index, updatedAt := range []time.Time{enteredAt.Add(30 * time.Minute), enteredAt.Add(time.Hour)} {
+		backend, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: dbPath})
+		if err != nil {
+			t.Fatalf("store.Open(restart %d) error = %v", index+1, err)
+		}
+
+		state := newState(normalizeConfig(Config{}))
+		state.BoardIssues = []connector.Issue{{
+			ID:        "issue-1130",
+			State:     "In Progress",
+			UpdatedAt: &updatedAt,
+		}}
+		orch := &Orchestrator{workflowMetrics: backend}
+		orch.refreshCurrentLaneEntries(ctx, &state)
+		snapshot := state.Snapshot(updatedAt.Add(time.Minute))
+		if snapshot.BoardIssues[0].CurrentLaneEnteredAt == nil || !snapshot.BoardIssues[0].CurrentLaneEnteredAt.Equal(enteredAt) {
+			t.Errorf("restart %d CurrentLaneEnteredAt = %v, want %v", index+1, snapshot.BoardIssues[0].CurrentLaneEnteredAt, enteredAt)
+		}
+		if err := backend.Close(); err != nil {
+			t.Fatalf("backend.Close(restart %d) error = %v", index+1, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Anchor board lane timers to the most recent durable entry event for the current normalized lane.
- Preserve fallback timestamps across same-lane activity and restore durable lane age after orchestrator restarts.

Fixes #1130

## UI Surface Contract

- [x] N/A; this changes timer data provenance without changing UI layout or density.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual surface changes requiring screenshot verification.

## Test Plan

- [x] `make check`