### PR TITLE
fix(artifact): honor human-restarted rounds

### DIFF
--- a/internal/connector/github/adapter_test.go
+++ b/internal/connector/github/adapter_test.go
@@ -386,6 +386,27 @@ func TestProjectFieldValues(t *testing.T) {
 	}
 }
 
+func TestProjectFieldUpdatedAtFlowsIntoIssue(t *testing.T) {
+	t.Parallel()
+
+	updatedAt := "2026-07-10T01:36:00Z"
+	fields := projectFieldValues(nodeConnection[projectFieldValue]{Nodes: []projectFieldValue{{
+		TypeName:  "ProjectV2ItemFieldSingleSelectValue",
+		Name:      "pending_review",
+		UpdatedAt: &updatedAt,
+		Field:     projectField{Name: "render_status"},
+	}}})
+
+	issue := (&Connector{}).buildIssue(githubIssueNode{}, "Todo", "", nil, fields)
+	want := time.Date(2026, 7, 10, 1, 36, 0, 0, time.UTC)
+	if issue.Fields["render_status"] != "pending_review" {
+		t.Fatalf("render_status = %q, want pending_review", issue.Fields["render_status"])
+	}
+	if got := issue.FieldUpdatedAt["render_status"]; !got.Equal(want) {
+		t.Fatalf("render_status updated at = %v, want %v", got, want)
+	}
+}
+
 func TestProjectStatusQueryFormatsMappedStatuses(t *testing.T) {
 	t.Parallel()
 

--- a/internal/connector/github/issue_read.go
+++ b/internal/connector/github/issue_read.go
@@ -61,14 +61,17 @@ query DetentGitHubIssueSubIssues(
                   __typename
                   ... on ProjectV2ItemFieldSingleSelectValue {
                     name
+					updatedAt
                     field { ... on ProjectV2FieldCommon { name } }
                   }
                   ... on ProjectV2ItemFieldTextValue {
                     text
+					updatedAt
                     field { ... on ProjectV2FieldCommon { name } }
                   }
                   ... on ProjectV2ItemFieldNumberValue {
                     number
+					updatedAt
                     field { ... on ProjectV2FieldCommon { name } }
                   }
                 }
@@ -117,14 +120,17 @@ query DetentGitHubIssueTrackedIssues(
                   __typename
                   ... on ProjectV2ItemFieldSingleSelectValue {
                     name
+					updatedAt
                     field { ... on ProjectV2FieldCommon { name } }
                   }
                   ... on ProjectV2ItemFieldTextValue {
                     text
+					updatedAt
                     field { ... on ProjectV2FieldCommon { name } }
                   }
                   ... on ProjectV2ItemFieldNumberValue {
                     number
+					updatedAt
                     field { ... on ProjectV2FieldCommon { name } }
                   }
                 }
@@ -250,14 +256,17 @@ fragment DetentGitHubIssueParent on Issue {
               __typename
               ... on ProjectV2ItemFieldSingleSelectValue {
                 name
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
               ... on ProjectV2ItemFieldTextValue {
                 text
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
               ... on ProjectV2ItemFieldNumberValue {
                 number
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
             }
@@ -291,14 +300,17 @@ fragment DetentGitHubIssueParent on Issue {
               __typename
               ... on ProjectV2ItemFieldSingleSelectValue {
                 name
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
               ... on ProjectV2ItemFieldTextValue {
                 text
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
               ... on ProjectV2ItemFieldNumberValue {
                 number
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
             }
@@ -323,14 +335,17 @@ fragment DetentGitHubIssueParent on Issue {
           __typename
           ... on ProjectV2ItemFieldSingleSelectValue {
             name
+			updatedAt
             field { ... on ProjectV2FieldCommon { name } }
           }
           ... on ProjectV2ItemFieldTextValue {
             text
+			updatedAt
             field { ... on ProjectV2FieldCommon { name } }
           }
           ... on ProjectV2ItemFieldNumberValue {
             number
+			updatedAt
             field { ... on ProjectV2FieldCommon { name } }
           }
         }
@@ -1287,6 +1302,7 @@ func (c *Connector) normalizeIssueNode(ctx context.Context, issue githubIssueNod
 }
 
 func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorityName string, statusUpdatedAt *time.Time, fields map[string]string) connector.Issue {
+	fields, fieldUpdatedAt := splitProjectFieldUpdatedAt(fields)
 	repo := strings.TrimSpace(issue.Repository.NameWithOwner)
 	pullRequestRef, hasPullRequestRef := firstPullRequestReference(issue.ClosedByPullRequestsReferences)
 	var pullRequestNumber *int
@@ -1323,12 +1339,31 @@ func (c *Connector) buildIssue(issue githubIssueNode, statusName string, priorit
 		Labels:           labelNames(issue.Labels),
 		Comments:         connectorIssueComments(issue.Comments.Nodes),
 		Fields:           cloneStringMap(fields),
+		FieldUpdatedAt:   fieldUpdatedAt,
 		AssignedToWorker: true,
 		CreatedAt:        parseGitHubTime(issue.CreatedAt),
 		UpdatedAt:        parseGitHubTime(issue.UpdatedAt),
 		StageUpdatedAt:   statusUpdatedAt,
 		ModelOverride:    parseModelOverride(issue.Body),
 	}
+}
+
+func splitProjectFieldUpdatedAt(fields map[string]string) (map[string]string, map[string]time.Time) {
+	values := make(map[string]string, len(fields))
+	updatedAt := map[string]time.Time{}
+	for field, value := range fields {
+		if name, ok := strings.CutPrefix(field, projectFieldUpdatedAtKeyPrefix); ok {
+			if timestamp, err := time.Parse(time.RFC3339Nano, value); err == nil {
+				updatedAt[name] = timestamp
+			}
+			continue
+		}
+		values[field] = value
+	}
+	if len(updatedAt) == 0 {
+		updatedAt = nil
+	}
+	return values, updatedAt
 }
 
 func connectorIssueComments(comments []issueComment) []connector.IssueComment {

--- a/internal/connector/github/projects_v2.go
+++ b/internal/connector/github/projects_v2.go
@@ -12,6 +12,8 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 )
 
+const projectFieldUpdatedAtKeyPrefix = "\x00detent-field-updated-at:"
+
 const projectItemsQuery = `
 query DetentGitHubProjectItems(
   $projectId: ID!
@@ -151,14 +153,17 @@ query DetentGitHubProjectItemForIssue($issueId: ID!, $projectItemsFirst: Int!, $
               __typename
               ... on ProjectV2ItemFieldSingleSelectValue {
                 name
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
               ... on ProjectV2ItemFieldTextValue {
                 text
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
               ... on ProjectV2ItemFieldNumberValue {
                 number
+				updatedAt
                 field { ... on ProjectV2FieldCommon { name } }
               }
             }
@@ -896,6 +901,9 @@ func projectFieldValues(values nodeConnection[projectFieldValue]) map[string]str
 			continue
 		}
 		fields[fieldName] = fieldValue
+		if updatedAt := parseGitHubTime(value.UpdatedAt); updatedAt != nil {
+			fields[projectFieldUpdatedAtKeyPrefix+fieldName] = updatedAt.Format(time.RFC3339Nano)
+		}
 	}
 	return fields
 }

--- a/internal/connector/github/types.go
+++ b/internal/connector/github/types.go
@@ -344,11 +344,12 @@ type singleSelectValue struct {
 }
 
 type projectFieldValue struct {
-	TypeName string       `json:"__typename"`
-	Field    projectField `json:"field"`
-	Name     string       `json:"name"`
-	Text     string       `json:"text"`
-	Number   *float64     `json:"number"`
+	TypeName  string       `json:"__typename"`
+	Field     projectField `json:"field"`
+	Name      string       `json:"name"`
+	Text      string       `json:"text"`
+	Number    *float64     `json:"number"`
+	UpdatedAt *string      `json:"updatedAt"`
 }
 
 type projectField struct {

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -575,6 +575,7 @@ func (c *Connector) mergeLocalWithGitHub(localIssue connector.Issue, upstream co
 	merged.State = localIssue.State
 	merged.Priority = localIssue.Priority
 	merged.Fields = cloneMetadata(localIssue.Fields)
+	merged.FieldUpdatedAt = maps.Clone(localIssue.FieldUpdatedAt)
 	merged.Comments = mergeIssueComments(upstream.Comments, localIssue.Comments)
 	merged.Deliverable = cloneDeliverable(localIssue.Deliverable)
 	merged.AssignedToWorker = localIssue.AssignedToWorker
@@ -638,6 +639,7 @@ func (c *Connector) overlayLocalStatuses(ctx context.Context, issues []connector
 			issue.State = localIssue.State
 			issue.Priority = localIssue.Priority
 			issue.Fields = cloneMetadata(localIssue.Fields)
+			issue.FieldUpdatedAt = maps.Clone(localIssue.FieldUpdatedAt)
 			issue.Metadata = mergeMetadata(localIssue.Metadata, issue.Metadata)
 		}
 		out = append(out, issue)

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -9,38 +9,39 @@ import (
 )
 
 type Issue struct {
-	ID               string            `json:"id,omitempty" yaml:"id,omitempty"`
-	Identifier       string            `json:"identifier,omitempty" yaml:"identifier,omitempty"`
-	Number           int               `json:"number,omitempty" yaml:"number,omitempty"`
-	Title            string            `json:"title,omitempty" yaml:"title,omitempty"`
-	Description      string            `json:"description,omitempty" yaml:"description,omitempty"`
-	Priority         *int              `json:"priority,omitempty" yaml:"priority,omitempty"`
-	PriorityName     string            `json:"priority_name,omitempty" yaml:"priority_name,omitempty"`
-	State            string            `json:"state,omitempty" yaml:"state,omitempty"`
-	BranchName       string            `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
-	URL              string            `json:"url,omitempty" yaml:"url,omitempty"`
-	Closed           bool              `json:"closed,omitempty" yaml:"closed,omitempty"`
-	ClosedReason     string            `json:"closed_reason,omitempty" yaml:"closed_reason,omitempty"`
-	PRNumber         *int              `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
-	PRRepository     string            `json:"pr_repository,omitempty" yaml:"pr_repository,omitempty"`
-	PullRequest      *PullRequest      `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
-	AuthorID         string            `json:"author_id,omitempty" yaml:"author_id,omitempty"`
-	AssigneeID       string            `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`
-	Assignees        []string          `json:"assignees,omitempty" yaml:"assignees,omitempty"`
-	BlockedBy        []BlockedRef      `json:"blocked_by" yaml:"blocked_by"`
-	ChildIssues      []BlockedRef      `json:"child_issues,omitempty" yaml:"child_issues,omitempty"`
-	BlockerReason    string            `json:"blocker_reason,omitempty" yaml:"blocker_reason,omitempty"`
-	WorkpadSignal    *workpad.Signal   `json:"workpad_signal,omitempty" yaml:"workpad_signal,omitempty"`
-	Labels           []string          `json:"labels" yaml:"labels"`
-	Comments         []IssueComment    `json:"comments,omitempty" yaml:"comments,omitempty"`
-	Fields           map[string]string `json:"fields,omitempty" yaml:"fields,omitempty"`
-	Metadata         map[string]string `json:"metadata,omitempty" yaml:"metadata,omitempty"`
-	Deliverable      *Deliverable      `json:"deliverable,omitempty" yaml:"deliverable,omitempty"`
-	AssignedToWorker bool              `json:"assigned_to_worker" yaml:"assigned_to_worker"`
-	CreatedAt        *time.Time        `json:"created_at,omitempty" yaml:"created_at,omitempty"`
-	UpdatedAt        *time.Time        `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
-	StageUpdatedAt   *time.Time        `json:"stage_updated_at,omitempty" yaml:"stage_updated_at,omitempty"`
-	ModelOverride    string            `json:"model_override" yaml:"model_override"`
+	ID               string               `json:"id,omitempty" yaml:"id,omitempty"`
+	Identifier       string               `json:"identifier,omitempty" yaml:"identifier,omitempty"`
+	Number           int                  `json:"number,omitempty" yaml:"number,omitempty"`
+	Title            string               `json:"title,omitempty" yaml:"title,omitempty"`
+	Description      string               `json:"description,omitempty" yaml:"description,omitempty"`
+	Priority         *int                 `json:"priority,omitempty" yaml:"priority,omitempty"`
+	PriorityName     string               `json:"priority_name,omitempty" yaml:"priority_name,omitempty"`
+	State            string               `json:"state,omitempty" yaml:"state,omitempty"`
+	BranchName       string               `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
+	URL              string               `json:"url,omitempty" yaml:"url,omitempty"`
+	Closed           bool                 `json:"closed,omitempty" yaml:"closed,omitempty"`
+	ClosedReason     string               `json:"closed_reason,omitempty" yaml:"closed_reason,omitempty"`
+	PRNumber         *int                 `json:"pr_number,omitempty" yaml:"pr_number,omitempty"`
+	PRRepository     string               `json:"pr_repository,omitempty" yaml:"pr_repository,omitempty"`
+	PullRequest      *PullRequest         `json:"pull_request,omitempty" yaml:"pull_request,omitempty"`
+	AuthorID         string               `json:"author_id,omitempty" yaml:"author_id,omitempty"`
+	AssigneeID       string               `json:"assignee_id,omitempty" yaml:"assignee_id,omitempty"`
+	Assignees        []string             `json:"assignees,omitempty" yaml:"assignees,omitempty"`
+	BlockedBy        []BlockedRef         `json:"blocked_by" yaml:"blocked_by"`
+	ChildIssues      []BlockedRef         `json:"child_issues,omitempty" yaml:"child_issues,omitempty"`
+	BlockerReason    string               `json:"blocker_reason,omitempty" yaml:"blocker_reason,omitempty"`
+	WorkpadSignal    *workpad.Signal      `json:"workpad_signal,omitempty" yaml:"workpad_signal,omitempty"`
+	Labels           []string             `json:"labels" yaml:"labels"`
+	Comments         []IssueComment       `json:"comments,omitempty" yaml:"comments,omitempty"`
+	Fields           map[string]string    `json:"fields,omitempty" yaml:"fields,omitempty"`
+	FieldUpdatedAt   map[string]time.Time `json:"field_updated_at,omitempty" yaml:"field_updated_at,omitempty"`
+	Metadata         map[string]string    `json:"metadata,omitempty" yaml:"metadata,omitempty"`
+	Deliverable      *Deliverable         `json:"deliverable,omitempty" yaml:"deliverable,omitempty"`
+	AssignedToWorker bool                 `json:"assigned_to_worker" yaml:"assigned_to_worker"`
+	CreatedAt        *time.Time           `json:"created_at,omitempty" yaml:"created_at,omitempty"`
+	UpdatedAt        *time.Time           `json:"updated_at,omitempty" yaml:"updated_at,omitempty"`
+	StageUpdatedAt   *time.Time           `json:"stage_updated_at,omitempty" yaml:"stage_updated_at,omitempty"`
+	ModelOverride    string               `json:"model_override" yaml:"model_override"`
 }
 
 type BlockedRef struct {
@@ -160,6 +161,7 @@ func NewIssue() Issue {
 		Labels:           []string{},
 		Assignees:        []string{},
 		Fields:           map[string]string{},
+		FieldUpdatedAt:   map[string]time.Time{},
 		Metadata:         map[string]string{},
 		AssignedToWorker: true,
 	}

--- a/internal/connector/local/local.go
+++ b/internal/connector/local/local.go
@@ -978,8 +978,47 @@ where project_id = ?`
 			return nil, err
 		}
 		issues[i].Comments = comments
+		fieldUpdatedAt, err := c.fetchFieldUpdatedAt(ctx, issues[i].ID)
+		if err != nil {
+			return nil, err
+		}
+		issues[i].FieldUpdatedAt = fieldUpdatedAt
 	}
 	return issues, nil
+}
+
+func (c *Connector) fetchFieldUpdatedAt(ctx context.Context, issueID string) (map[string]time.Time, error) {
+	rows, err := c.db.QueryContext(ctx, `
+select payload_json, created_at from detent_work_item_events
+where project_id = ? and item_id = ? and event_kind = ?
+order by id asc`, c.projectID, strings.TrimSpace(issueID), eventKindFieldUpdate)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	updatedAt := map[string]time.Time{}
+	for rows.Next() {
+		var payloadJSON string
+		var createdAt string
+		if err := rows.Scan(&payloadJSON, &createdAt); err != nil {
+			return nil, err
+		}
+		timestamp := parseTimePointer(createdAt)
+		if timestamp == nil || timestamp.IsZero() {
+			continue
+		}
+		for field := range unmarshalStringMap(payloadJSON) {
+			field = strings.TrimSpace(field)
+			if field != "" {
+				updatedAt[field] = *timestamp
+			}
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return updatedAt, nil
 }
 
 func (c *Connector) issueByID(ctx context.Context, issueID string) (connector.Issue, error) {

--- a/internal/connector/memory/memory.go
+++ b/internal/connector/memory/memory.go
@@ -359,7 +359,11 @@ func (c *Connector) SetField(_ context.Context, issueID string, fieldName string
 		if issue.Fields == nil {
 			issue.Fields = map[string]string{}
 		}
+		if issue.FieldUpdatedAt == nil {
+			issue.FieldUpdatedAt = map[string]time.Time{}
+		}
 		issue.Fields[fieldName] = value
+		issue.FieldUpdatedAt[fieldName] = now
 		issue.UpdatedAt = &now
 	})
 	c.send(Event{Kind: EventKindFieldUpdate, IssueID: issueID, FieldName: fieldName, FieldValue: value})
@@ -551,6 +555,9 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	}
 	if issue.Fields != nil {
 		issue.Fields = cloneStringMap(issue.Fields)
+	}
+	if issue.FieldUpdatedAt != nil {
+		issue.FieldUpdatedAt = maps.Clone(issue.FieldUpdatedAt)
 	}
 	if issue.Metadata != nil {
 		issue.Metadata = cloneStringMap(issue.Metadata)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -495,10 +495,23 @@ func artifactGateWaitStatusBlocksDispatch(issue connector.Issue, cfg gate.Config
 	}
 	for _, waitStatus := range cfg.Artifact.WaitStatuses {
 		if status == normalizeArtifactGateStatus(waitStatus) {
-			return true
+			return artifactGateWaitStatusIsCurrent(issue, cfg.Artifact.StatusField)
 		}
 	}
 	return false
+}
+
+func artifactGateWaitStatusIsCurrent(issue connector.Issue, statusField string) bool {
+	for field, updatedAt := range issue.FieldUpdatedAt {
+		if strings.EqualFold(strings.TrimSpace(field), strings.TrimSpace(statusField)) &&
+			issue.StageUpdatedAt != nil && !issue.StageUpdatedAt.IsZero() && !updatedAt.IsZero() {
+			return !issue.StageUpdatedAt.After(updatedAt)
+		}
+	}
+	if issue.StageUpdatedAt == nil || issue.StageUpdatedAt.IsZero() || issue.UpdatedAt == nil || issue.UpdatedAt.IsZero() {
+		return true
+	}
+	return !issue.StageUpdatedAt.Equal(*issue.UpdatedAt)
 }
 
 func normalizeArtifactGateStatus(value string) string {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -448,7 +448,7 @@ func TestDispatchableSkipsQuietWindowActiveIssueWithOpenPullRequest(t *testing.T
 	}
 }
 
-func TestDispatchableSkipsArtifactGateWaitStatus(t *testing.T) {
+func TestDispatchableArtifactGateWaitStatus(t *testing.T) {
 	t.Parallel()
 
 	now := time.Date(2026, 7, 9, 15, 40, 0, 0, time.UTC)
@@ -473,19 +473,80 @@ func TestDispatchableSkipsArtifactGateWaitStatus(t *testing.T) {
 		ObservedStates: []string{"Backlog", "Review", "Blocked"},
 		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
 	})
+	tests := []struct {
+		name           string
+		state          string
+		status         string
+		stageUpdatedAt *time.Time
+		updatedAt      *time.Time
+		fieldUpdatedAt *time.Time
+		wantDispatch   bool
+		wantReason     string
+	}{
+		{
+			name:         "fresh item dispatches",
+			state:        "Todo",
+			wantDispatch: true,
+		},
+		{
+			name:           "mid wait item stays skipped",
+			state:          "Production",
+			status:         "pending_review",
+			stageUpdatedAt: timePointer(now.Add(-2 * time.Minute)),
+			updatedAt:      timePointer(now.Add(-time.Minute)),
+			fieldUpdatedAt: timePointer(now.Add(-time.Minute)),
+			wantReason:     dispatchSkipArtifactGateWaitStatus,
+		},
+		{
+			name:           "human restarted round dispatches",
+			state:          "Todo",
+			status:         "pending_review",
+			stageUpdatedAt: timePointer(now),
+			updatedAt:      timePointer(now),
+			fieldUpdatedAt: timePointer(now.Add(-time.Minute)),
+			wantDispatch:   true,
+		},
+		{
+			name:           "newer state wins stale status race",
+			state:          "Rework",
+			status:         "pending_review",
+			stageUpdatedAt: timePointer(now),
+			updatedAt:      timePointer(now),
+			fieldUpdatedAt: timePointer(now.Add(-time.Nanosecond)),
+			wantDispatch:   true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			issue := dispatchTestIssue("issue-artifact-status", tt.state)
+			issue.Fields = map[string]string{"render_status": tt.status}
+			issue.StageUpdatedAt = tt.stageUpdatedAt
+			issue.UpdatedAt = tt.updatedAt
+			if tt.fieldUpdatedAt != nil {
+				issue.FieldUpdatedAt = map[string]time.Time{"render_status": *tt.fieldUpdatedAt}
+			}
+			state := newState(cfg)
+			orch := Orchestrator{cfg: cfg}
+
+			decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
+			if decision.dispatchable != tt.wantDispatch {
+				t.Fatalf("dispatchable = %t, want %t", decision.dispatchable, tt.wantDispatch)
+			}
+			if decision.reason != tt.wantReason {
+				t.Fatalf("reason = %q, want %q", decision.reason, tt.wantReason)
+			}
+		})
+	}
+
 	issue := dispatchTestIssue("issue-artifact-pending-review", "Production")
 	issue.Fields = map[string]string{"render_status": "pending_review"}
+	issue.StageUpdatedAt = timePointer(now.Add(-2 * time.Minute))
+	issue.UpdatedAt = timePointer(now.Add(-time.Minute))
+	issue.FieldUpdatedAt = map[string]time.Time{"render_status": now.Add(-time.Minute)}
 	state := newState(cfg)
 	orch := Orchestrator{cfg: cfg}
-
-	decision := orch.dispatchPlanner().dispatchableIssueDecision(issue, &state, false, now, "")
-	if decision.dispatchable {
-		t.Fatal("dispatchable artifact wait status issue = true, want false")
-	}
-	if decision.reason != dispatchSkipArtifactGateWaitStatus {
-		t.Fatalf("dispatchable reason = %q, want %q", decision.reason, dispatchSkipArtifactGateWaitStatus)
-	}
-
 	attempts := &recordingWorkAttemptStore{}
 	orch.workAttempts = attempts
 	orch.dispatchReadyIssues(t.Context(), &state, []connector.Issue{issue}, now)

--- a/internal/orchestrator/local_sqlite_e2e_test.go
+++ b/internal/orchestrator/local_sqlite_e2e_test.go
@@ -229,6 +229,88 @@ func TestLocalSQLiteArtifactLifecycleEndToEnd(t *testing.T) {
 	}
 }
 
+func TestLocalSQLiteHumanRestartDispatchesArtifactRound(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	now := time.Date(2026, 7, 10, 1, 35, 0, 0, time.UTC)
+	seed := connector.NewIssue()
+	seed.ID = "wi-artifact-restart"
+	seed.Identifier = "wi-artifact-restart"
+	seed.Title = "Rework Storyboard — round 2"
+	seed.State = "Production"
+	seed.CreatedAt = &now
+	seed.UpdatedAt = &now
+	seed.StageUpdatedAt = &now
+
+	tracker, err := local.New(local.Config{
+		Path:           filepath.Join(t.TempDir(), "artifact-restart.db"),
+		ProjectID:      "digitaldrywood-video",
+		Issues:         []connector.Issue{seed},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		ObservedStates: []string{"Backlog", "Review", "Blocked"},
+		TerminalStates: []string{"Ready for Pickup", "Done", "Cancelled"},
+		Now: func() time.Time {
+			return now
+		},
+	})
+	if err != nil {
+		t.Fatalf("local.New() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := tracker.Close(); err != nil {
+			t.Errorf("Close() error = %v", err)
+		}
+	})
+
+	cfg := orchestrator.Config{
+		MaxConcurrentAgents: 1,
+		ActiveStates:        []string{"Todo", "Production", "Rework"},
+		ObservedStates:      []string{"Backlog", "Review", "Blocked"},
+		TerminalStates:      []string{"Ready for Pickup", "Done", "Cancelled"},
+		AutoPromote: orchestrator.AutoPromoteConfig{
+			Enabled:     true,
+			SourceState: "Review",
+			PassState:   "Ready for Pickup",
+			ReworkState: "Rework",
+			Gate: gate.Config{
+				Kind: gate.KindArtifact,
+				Artifact: gate.ArtifactConfig{
+					StatusField:    "render_status",
+					PassStatuses:   []string{"approved", "valid"},
+					WaitStatuses:   []string{"queued", "rendering", "pending_review"},
+					ReworkStatuses: []string{"recut", "invalid", "missing_assets"},
+				},
+			},
+		},
+	}
+
+	now = now.Add(time.Minute)
+	if err := tracker.SetField(ctx, seed.ID, "render_status", "pending_review"); err != nil {
+		t.Fatalf("SetField(pending_review) error = %v", err)
+	}
+	waiting, err := tracker.FetchIssuesByStates(ctx, []string{"Production"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(Production) error = %v", err)
+	}
+	if plan := orchestrator.PlanDispatch(cfg, orchestrator.State{}, waiting, now); len(plan.Dispatches) != 0 {
+		t.Fatalf("mid-wait dispatches = %#v, want none", plan.Dispatches)
+	}
+
+	now = now.Add(time.Minute)
+	if err := tracker.UpdateIssueState(ctx, seed.ID, "Todo"); err != nil {
+		t.Fatalf("UpdateIssueState(Todo) error = %v", err)
+	}
+	restarted, err := tracker.FetchIssuesByStates(ctx, []string{"Todo"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates(Todo) error = %v", err)
+	}
+	plan := orchestrator.PlanDispatch(cfg, orchestrator.State{}, restarted, now)
+	if len(plan.Dispatches) != 1 || plan.Dispatches[0].IssueID != seed.ID {
+		t.Fatalf("restarted dispatches = %#v, want %s", plan.Dispatches, seed.ID)
+	}
+}
+
 func waitForLocalStoredState(t *testing.T, db *sql.DB, issueID string, want string) {
 	t.Helper()
 

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -12,8 +12,9 @@ import (
 )
 
 const (
-	autoPromoteActionMetadataKey = "detent.auto_promote_action"
-	autoPromoteReasonMetadataKey = "detent.auto_promote_reason"
+	autoPromoteActionMetadataKey  = "detent.auto_promote_action"
+	autoPromoteReasonMetadataKey  = "detent.auto_promote_reason"
+	dispatchSkipReasonMetadataKey = "detent.dispatch_skip_reason"
 )
 
 // Snapshot converts the orchestrator State into a telemetry.Snapshot suitable
@@ -46,9 +47,11 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 	applyIssueRuntimeIdentities(boardIssueSnapshots, s.Running, s.WorkAttempts)
 	s.applyGatePendingSnapshots(boardIssueSnapshots, boardIssues)
 	s.applyAutoPromoteDecisionSnapshots(boardIssueSnapshots, boardIssues, now)
+	s.applyArtifactGateWaitDispatchSnapshots(boardIssueSnapshots, boardIssues)
 	pipelineIssueSnapshots := pipelineSnapshots(pipeline, s.AutoPromoteQuietDuration, s.PollInterval, s.MergeTimings, now, s.laneEntries)
 	applyIssueRuntimeIdentities(pipelineIssueSnapshots, s.Running, s.WorkAttempts)
 	s.applyAutoPromoteDecisionSnapshots(pipelineIssueSnapshots, pipeline, now)
+	s.applyArtifactGateWaitDispatchSnapshots(pipelineIssueSnapshots, pipeline)
 	snapshot := telemetry.Snapshot{
 		GeneratedAt:        now,
 		Instance:           s.Instance,
@@ -125,6 +128,23 @@ func (s State) applyAutoPromoteDecisionSnapshots(snapshots []telemetry.Issue, is
 		}
 		snapshots[i].Metadata[autoPromoteActionMetadataKey] = string(decision.Action)
 		snapshots[i].Metadata[autoPromoteReasonMetadataKey] = string(decision.Reason)
+	}
+}
+
+func (s State) applyArtifactGateWaitDispatchSnapshots(snapshots []telemetry.Issue, issues []connector.Issue) {
+	for i := range snapshots {
+		if i >= len(issues) {
+			return
+		}
+		issue := issues[i]
+		if !stateIn(issue.State, s.ActiveStates) || stateIn(issue.State, s.TerminalStates) ||
+			!artifactGateWaitStatusBlocksDispatch(issue, s.AutoPromote.Gate) {
+			continue
+		}
+		if snapshots[i].Metadata == nil {
+			snapshots[i].Metadata = map[string]string{}
+		}
+		snapshots[i].Metadata[dispatchSkipReasonMetadataKey] = dispatchSkipArtifactGateWaitStatus
 	}
 }
 

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -234,6 +234,44 @@ func TestStateSnapshotIncludesAutoPromoteDecisionReason(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotIncludesArtifactGateWaitDispatchReason(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 1, 40, 0, 0, time.UTC)
+	stageUpdatedAt := now.Add(-2 * time.Minute)
+	updatedAt := now.Add(-time.Minute)
+	cfg := normalizeConfig(Config{
+		AutoPromote: AutoPromoteConfig{
+			Enabled: true,
+			Gate: gate.Config{
+				Kind: gate.KindArtifact,
+				Artifact: gate.ArtifactConfig{
+					StatusField:  "render_status",
+					WaitStatuses: []string{"pending_review"},
+				},
+			},
+		},
+		ActiveStates:   []string{"Todo", "Production", "Rework"},
+		TerminalStates: []string{"Done", "Cancelled"},
+	})
+	state := newState(cfg)
+	state.BoardIssues = []connector.Issue{{
+		ID:             "artifact-wait",
+		Identifier:     "wi-artifact-wait",
+		State:          "Todo",
+		Fields:         map[string]string{"render_status": "pending_review"},
+		FieldUpdatedAt: map[string]time.Time{"render_status": updatedAt},
+		StageUpdatedAt: &stageUpdatedAt,
+		UpdatedAt:      &updatedAt,
+	}}
+
+	snapshot := state.Snapshot(now)
+
+	if got := snapshot.BoardIssues[0].Metadata["detent.dispatch_skip_reason"]; got != dispatchSkipArtifactGateWaitStatus {
+		t.Fatalf("dispatch skip reason = %q, want %q", got, dispatchSkipArtifactGateWaitStatus)
+	}
+}
+
 func TestStateSnapshotComputesDisabledAutoPromoteReason(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -461,6 +461,7 @@ func cloneIssue(issue connector.Issue) connector.Issue {
 	cloned.Comments = cloneIssueComments(issue.Comments)
 	cloned.Assignees = cloneStringSlice(issue.Assignees)
 	cloned.Fields = cloneStringMap(issue.Fields)
+	cloned.FieldUpdatedAt = cloneTimeMap(issue.FieldUpdatedAt)
 	cloned.Metadata = cloneStringMap(issue.Metadata)
 	return cloned
 }
@@ -520,6 +521,14 @@ func cloneStringMap(values map[string]string) map[string]string {
 	}
 	out := make(map[string]string, len(values))
 	maps.Copy(out, values)
+	return out
+}
+
+func cloneTimeMap(values map[string]time.Time) map[string]time.Time {
+	out := make(map[string]time.Time, len(values))
+	for key, value := range values {
+		out[key] = value
+	}
 	return out
 }
 

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -471,13 +471,13 @@ func boardCardExtra(card projectKanbanCard, view boardCardView) (primitives.Kind
 	if card.GatePending {
 		return primitives.KindInfo, "Awaiting checks", true
 	}
+	if detail := strings.TrimSpace(card.WaitDetail); detail != "" {
+		return primitives.KindInfo, detail, false
+	}
 	if status := strings.TrimSpace(card.CIStatus); status != "" {
 		return primitives.KindInfo, status, false
 	}
 	if view.Running {
-		if stage := strings.TrimSpace(card.WaitDetail); stage != "" {
-			return primitives.KindInfo, stage, false
-		}
 		return primitives.KindOK, "agent working", false
 	}
 	return primitives.KindNeutral, "", false

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -180,6 +180,20 @@ func TestBoardViewSortsCardsBySchedulerPriorityInputs(t *testing.T) {
 	}
 }
 
+func TestBoardCardExtraShowsWaitReasonAheadOfCI(t *testing.T) {
+	t.Parallel()
+
+	card := projectKanbanCard{
+		WaitDetail: "dispatch skipped: artifact_gate_wait_status",
+		CIStatus:   "pass",
+	}
+
+	kind, text, chip := boardCardExtra(card, boardCardView{})
+	if kind != primitives.KindInfo || text != card.WaitDetail || chip {
+		t.Fatalf("boardCardExtra() = %q, %q, %t, want info wait detail", kind, text, chip)
+	}
+}
+
 func TestBoardCardPriority(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -45,6 +45,7 @@ const (
 	projectKanbanBlockedRecoveryReasonMetadataKey = "detent.blocked_recovery_reason"
 	projectKanbanAutoPromoteActionMetadataKey     = "detent.auto_promote_action"
 	projectKanbanAutoPromoteReasonMetadataKey     = "detent.auto_promote_reason"
+	projectKanbanDispatchSkipReasonMetadataKey    = "detent.dispatch_skip_reason"
 )
 
 type DashboardData struct {
@@ -3733,7 +3734,9 @@ func prPipelineCardForIssue(issue telemetry.Issue, state string, laneID string, 
 
 func prPipelineWaitDetail(issue telemetry.Issue) string {
 	parts := []string{}
-	if reason := prPipelineAutoPromoteWaitReason(issue); reason != "" {
+	if reason := prPipelineDispatchSkipWaitReason(issue); reason != "" {
+		parts = append(parts, reason)
+	} else if reason := prPipelineAutoPromoteWaitReason(issue); reason != "" {
 		parts = append(parts, reason)
 	} else if reason := prPipelineHumanReviewWaitReason(issue); reason != "" {
 		parts = append(parts, reason)
@@ -3769,6 +3772,14 @@ func prPipelineWaitDetail(issue telemetry.Issue) string {
 		parts = append(parts, merge)
 	}
 	return strings.Join(parts, " / ")
+}
+
+func prPipelineDispatchSkipWaitReason(issue telemetry.Issue) string {
+	reason := strings.TrimSpace(issue.Metadata[projectKanbanDispatchSkipReasonMetadataKey])
+	if reason == "" {
+		return ""
+	}
+	return "dispatch skipped: " + reason
 }
 
 func prPipelineAutoPromoteWaitReason(issue telemetry.Issue) string {

--- a/internal/web/templates/dashboard_data_test.go
+++ b/internal/web/templates/dashboard_data_test.go
@@ -2679,6 +2679,21 @@ func TestPRPipelineWaitDetailExplainsHumanReviewReasons(t *testing.T) {
 	}
 }
 
+func TestPRPipelineWaitDetailIncludesDispatchSkipReason(t *testing.T) {
+	t.Parallel()
+
+	issue := telemetry.Issue{
+		State: "Todo",
+		Metadata: map[string]string{
+			"detent.dispatch_skip_reason": "artifact_gate_wait_status",
+		},
+	}
+
+	if got := prPipelineWaitDetail(issue); got != "dispatch skipped: artifact_gate_wait_status" {
+		t.Fatalf("prPipelineWaitDetail() = %q, want dispatch skip reason", got)
+	}
+}
+
 func TestPRPipelineCardIncludesIssueAndPullRequestIdentity(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Track artifact status field update times so a newer lane transition starts a new round instead of inheriting a stale wait veto.
- Preserve active wait-status loop protection across local SQLite, GitHub Project fields, memory, and github_local tracker overlays.
- Surface active artifact dispatch skips on board cards ahead of misleading CI status.

Fixes #1140

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff. Issue #1140 explicitly requires the board card veto reason.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

Browser verification: the isolated deterministic Kanban capture rendered successfully at 1440x900 with DPR 1. Card status lines remained readable and wait detail correctly appeared ahead of CI status.

## Test Plan

- [x] `make check`
- [x] Table-driven scheduler regression coverage for fresh, mid-wait, human-restarted, and state/status race cases.
- [x] Local SQLite end-to-end restart dispatch test.
- [x] GitHub Project field timestamp conversion test.
- [x] Snapshot and board-card reason visibility tests.
- [x] Isolated visual capture: `detent dev-runtime capture --scenario kanban-full-integration --width 1440 --height 900 --device-scale-factor 1`