### PR TITLE
feat(tracker): add affordable board freshness

### DIFF
--- a/README.md
+++ b/README.md
@@ -906,11 +906,66 @@ poll when observed. `workspace.cleanup_sweep_interval_ms` controls the startup
 and periodic idle cleanup cadence.
 
 `polling.interval_ms` defaults to `120000` and must be at least `60000`.
-Detent work is async, so it does not need sub-minute board scans. Detent polls
-GitHub GraphQL, where board scans consume a shared rate-limit budget used by
-Detent, spawned agents, and operator `gh` calls. Faster polling risks exhausting
-that budget. This is an intentional divergence from Symphony's `30000` ms
-default because Symphony polls Linear, which has a different rate model.
+`polling.conditional` defaults to `true`. GitHub label and issue-field trackers
+cache response ETags for issue lists and REST hydration endpoints, send
+`If-None-Match` on later polls, and reuse the cached representation after a
+`304 Not Modified`. An authorized conditional request that returns `304` does
+not consume GitHub's primary REST quota. This makes a `60000` interval practical
+for an idle REST-backed board while preserving the default cadence for existing
+workflows. Set `conditional: false` to restore unconditional requests; trackers
+without conditional-request support continue using their existing polling path.
+See GitHub's [conditional request guidance](https://docs.github.com/en/enterprise-cloud@latest/rest/using-the-rest-api/best-practices-for-using-the-rest-api#use-conditional-requests-if-appropriate).
+
+REST telemetry distinguishes `total_requests`, `conditional_requests`,
+`not_modified_requests`, and `billable_requests`. Endpoint contributors expose
+the same breakdown, and the REST rate-limit card's cycle cost uses billable
+requests rather than free `304` checks.
+
+### GitHub Webhook Freshness
+
+Each GitHub-backed project can opt into near-real-time external updates by
+setting a webhook secret in its `WORKFLOW.md`:
+
+```yaml
+tracker:
+  kind: github
+  github_status_source: label
+  repository: digitaldrywood/detent
+  github_webhook_secret: $DETENT_GITHUB_WEBHOOK_SECRET
+polling:
+  interval_ms: 60000
+  conditional: true
+```
+
+Set `DETENT_GITHUB_WEBHOOK_SECRET` in the Detent process environment. Configure
+the repository webhook with:
+
+- Payload URL: `https://<detent-host>/api/v1/webhooks/github`
+- Content type: `application/json`
+- Secret: the same high-entropy value
+- Events: Issues, Pull requests, Check suites, and Labels
+
+Detent verifies `X-Hub-Signature-256` with HMAC-SHA256, routes the delivery only
+to projects whose configured repository and secret match, and queues a fetch for
+the affected issue. Pull-request and check-suite deliveries resolve Detent's
+issue from its generated branch name. A repository-level label event has no
+single issue target, so it queues a normal conditional refresh. Unknown
+repositories never trigger a fleet-wide fallback. See GitHub's
+[webhook signature validation](https://docs.github.com/en/webhooks/using-webhooks/validating-webhook-deliveries)
+and [event payload reference](https://docs.github.com/en/webhooks/webhook-events-and-payloads).
+
+For a ProjectV2 tracker spanning multiple repositories, omit `tracker.repository`
+to let the connector verify project membership after signature validation. Set
+`tracker.repository` when the project is repository-scoped and strict routing is
+preferred.
+
+GitHub must be able to reach the payload URL. For local testing, GitHub documents
+[forwarding deliveries with smee.io](https://docs.github.com/en/webhooks/using-webhooks/handling-webhook-deliveries).
+For a persistent host without public ingress, an outbound tunnel such as a
+[Cloudflare Tunnel published application](https://developers.cloudflare.com/cloudflare-one/networks/connectors/cloudflare-tunnel/get-started/create-remote-tunnel/#2a-publish-an-application)
+can route a public HTTPS hostname to Detent. Configure relays and reverse proxies
+to preserve the raw request body and GitHub signature headers; modifying either
+causes signature verification to fail.
 
 `gate` controls the validation contract the agent and operator flow follow.
 Omitting it preserves the code default: `kind: command` with `run: make check`,
@@ -2233,6 +2288,7 @@ Useful endpoints:
 | `/api/v1/projects/<id>/timeseries?window=10m&bucket=1m` | Project chart samples for running agents, token spend, and board flow. |
 | `/api/v1/projects/<id>/work-items` | Create a runtime work item with `POST` for `local_sqlite` and `github_local` trackers. |
 | `/api/v1/refresh` | Request an orchestrator refresh with `POST`. |
+| `/api/v1/webhooks/github` | Accept signed GitHub webhook deliveries with `POST`. |
 | `/api/v1/<issue>` | JSON detail for a running, retrying, or blocked issue. |
 
 ### API Authentication And Work-Item Submission

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -13,6 +13,7 @@ tracker:
   github_rest_min_remaining_reserve: 1000
   github_rest_fanout_max_requests: 80
   github_rest_debug_logging: false
+  # github_webhook_secret: $DETENT_GITHUB_WEBHOOK_SECRET
   auto_provision: false
   active_states:
     - Todo
@@ -48,7 +49,8 @@ tracker:
       - Human Review
     target_state: Todo
 polling:
-  interval_ms: 120000
+  interval_ms: 60000
+  conditional: true
 workspace:
   root: <worktree-root>
   source_root: <source-root>

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -12,6 +12,7 @@ tracker:
   github_rest_min_remaining_reserve: 1000
   github_rest_fanout_max_requests: 80
   github_rest_debug_logging: false
+  # github_webhook_secret: $DETENT_GITHUB_WEBHOOK_SECRET
   auto_provision: true
   active_states:
     - Todo
@@ -47,7 +48,8 @@ tracker:
       - Human Review
     target_state: Todo
 polling:
-  interval_ms: 120000
+  interval_ms: 60000
+  conditional: true
 workspace:
   root: <worktree-root>
   source_root: <source-root>

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -12,6 +12,7 @@ tracker:
   github_rest_min_remaining_reserve: 1000
   github_rest_fanout_max_requests: 80
   github_rest_debug_logging: false
+  # github_webhook_secret: $DETENT_GITHUB_WEBHOOK_SECRET
   auto_provision: true
   active_states:
     - Todo
@@ -47,7 +48,8 @@ tracker:
       - Human Review
     target_state: Todo
 polling:
-  interval_ms: 120000
+  interval_ms: 60000
+  conditional: true
 workspace:
   root: <worktree-root>
   source_root: <source-root>

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -47,7 +47,7 @@ tracker:
       - Human Review
     target_state: Todo
 polling:
-  interval_ms: 60000
+  interval_ms: 120000
   conditional: true
 workspace:
   root: <worktree-root>

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -11,6 +11,7 @@ tracker:
   github_rest_min_remaining_reserve: 1000
   github_rest_fanout_max_requests: 80
   github_rest_debug_logging: false
+  # github_webhook_secret: $DETENT_GITHUB_WEBHOOK_SECRET
   auto_provision: true
   active_states:
     - Todo
@@ -46,7 +47,8 @@ tracker:
       - Human Review
     target_state: Todo
 polling:
-  interval_ms: 120000
+  interval_ms: 60000
+  conditional: true
 workspace:
   root: <worktree-root>
   source_root: <source-root>

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -1037,6 +1037,12 @@ func (r registryRefresher) RequestTargetedRefresh(ctx context.Context, target we
 	if repository == "" {
 		return r.RequestRefresh(ctx)
 	}
+	projectIDs := make(map[string]struct{}, len(target.ProjectIDs))
+	for _, projectID := range target.ProjectIDs {
+		if projectID = strings.TrimSpace(projectID); projectID != "" {
+			projectIDs[projectID] = struct{}{}
+		}
+	}
 
 	var response web.RefreshResponse
 	refreshed := false
@@ -1044,8 +1050,14 @@ func (r registryRefresher) RequestTargetedRefresh(ctx context.Context, target we
 		if !trackedProject.Running() {
 			continue
 		}
+		if len(projectIDs) > 0 {
+			if _, ok := projectIDs[string(trackedProject.ID())]; !ok {
+				continue
+			}
+		}
 		workflow := trackedProject.Workflow().Config
-		if !strings.EqualFold(strings.TrimSpace(workflow.Tracker.Repository), repository) {
+		configuredRepository := strings.TrimSpace(workflow.Tracker.Repository)
+		if len(projectIDs) == 0 && configuredRepository != "" && !strings.EqualFold(configuredRepository, repository) {
 			continue
 		}
 		orch := trackedProject.Orchestrator()
@@ -1053,7 +1065,21 @@ func (r registryRefresher) RequestTargetedRefresh(ctx context.Context, target we
 			continue
 		}
 
-		next, err := orch.RequestRefresh(ctx)
+		var next web.RefreshResponse
+		var err error
+		if target.IssueNumber > 0 || target.PullRequestNumber > 0 {
+			next, err = orch.RequestTargetedRefresh(ctx, connector.ReconcileTarget{
+				Scope:          repository,
+				WorkItemNumber: target.IssueNumber,
+				ChangeNumber:   target.PullRequestNumber,
+				Revision:       strings.TrimSpace(target.SHA),
+				Branch:         strings.TrimSpace(target.Branch),
+				Event:          strings.TrimSpace(target.Event),
+				DeliveryID:     strings.TrimSpace(target.DeliveryID),
+			})
+		} else {
+			next, err = orch.RequestRefresh(ctx)
+		}
 		if err != nil {
 			return web.RefreshResponse{}, err
 		}
@@ -1066,12 +1092,7 @@ func (r registryRefresher) RequestTargetedRefresh(ctx context.Context, target we
 		response = mergeRefreshResponse(response, next)
 	}
 	if !refreshed {
-		fallback, err := r.RequestRefresh(ctx)
-		if err != nil {
-			return web.RefreshResponse{}, err
-		}
-		fallback.Operations = appendOperations([]string{"target-fallback:" + repository}, fallback.Operations)
-		return fallback, nil
+		return web.RefreshResponse{}, project.ErrProjectNotFound
 	}
 	return response, nil
 }

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -1067,7 +1067,7 @@ func (r registryRefresher) RequestTargetedRefresh(ctx context.Context, target we
 
 		var next web.RefreshResponse
 		var err error
-		if target.IssueNumber > 0 || target.PullRequestNumber > 0 {
+		if target.IssueNumber > 0 || target.PullRequestNumber > 0 || strings.TrimSpace(target.Branch) != "" {
 			next, err = orch.RequestTargetedRefresh(ctx, connector.ReconcileTarget{
 				Scope:          repository,
 				WorkItemNumber: target.IssueNumber,

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -353,7 +353,7 @@ func TestMergeRefreshResponseKeepsInProgressWhenSomeProjectsAccepted(t *testing.
 	}
 }
 
-func TestRegistryRefresherFallsBackWhenTargetRepositoryDoesNotMatch(t *testing.T) {
+func TestRegistryRefresherTargetsProjectV2WithoutConfiguredRepository(t *testing.T) {
 	t.Parallel()
 
 	registry := projectpkg.NewRegistry()
@@ -373,11 +373,11 @@ func TestRegistryRefresherFallsBackWhenTargetRepositoryDoesNotMatch(t *testing.T
 	if err != nil {
 		t.Fatalf("RequestTargetedRefresh() error = %v", err)
 	}
-	if !hasOperation(response.Operations, "target-fallback:digitaldrywood/detent") {
-		t.Fatalf("Operations = %#v, want target fallback marker", response.Operations)
+	if !hasOperation(response.Operations, "target:digitaldrywood/detent") {
+		t.Fatalf("Operations = %#v, want target marker", response.Operations)
 	}
-	if !hasOperation(response.Operations, "poll") || !hasOperation(response.Operations, "reconcile") {
-		t.Fatalf("Operations = %#v, want poll/reconcile fallback refresh", response.Operations)
+	if !hasOperation(response.Operations, "targeted_reconcile:digitaldrywood/detent") {
+		t.Fatalf("Operations = %#v, want targeted reconcile marker", response.Operations)
 	}
 }
 

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -381,6 +381,34 @@ func TestRegistryRefresherTargetsProjectV2WithoutConfiguredRepository(t *testing
 	}
 }
 
+func TestRegistryRefresherTargetsBranchOnlyWebhook(t *testing.T) {
+	t.Parallel()
+
+	registry := projectpkg.NewRegistry()
+	mustSetProject(t, registry, startRefreshProject(t, "branch-target"))
+
+	refresher := refresherForRegistry(registry)
+	targeted, ok := refresher.(web.TargetedRefresher)
+	if !ok {
+		t.Fatal("refresherForRegistry() does not implement TargetedRefresher")
+	}
+	response, err := targeted.RequestTargetedRefresh(context.Background(), web.RefreshTarget{
+		Repository: "digitaldrywood/detent",
+		Branch:     "detent/digitaldrywood_detent_1133-feature",
+		Event:      "check_run",
+		DeliveryID: "delivery-branch",
+	})
+	if err != nil {
+		t.Fatalf("RequestTargetedRefresh() error = %v", err)
+	}
+	if !hasOperation(response.Operations, "target:digitaldrywood/detent") {
+		t.Fatalf("Operations = %#v, want target marker", response.Operations)
+	}
+	if !hasOperation(response.Operations, "targeted_reconcile:digitaldrywood/detent") {
+		t.Fatalf("Operations = %#v, want targeted reconcile marker", response.Operations)
+	}
+}
+
 func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 	port := 0
 	output := newBootOutput()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -176,7 +176,8 @@ type Identity struct {
 }
 
 type Polling struct {
-	IntervalMS int `yaml:"interval_ms"`
+	IntervalMS  int  `yaml:"interval_ms"`
+	Conditional bool `yaml:"conditional"`
 }
 
 type Claims struct {
@@ -819,7 +820,8 @@ func Default() Config {
 			AutoProvision: true,
 		},
 		Polling: Polling{
-			IntervalMS: DefaultPollingIntervalMS,
+			IntervalMS:  DefaultPollingIntervalMS,
+			Conditional: true,
 		},
 		Workspace: Workspace{
 			Kind:                   WorkspaceLocalGit,

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -75,6 +75,7 @@ tracker:
     target_state: Todo
 polling:
   interval_ms: 60000
+  conditional: false
 workspace:
   root: ~/code/detent-workspaces
   auto_branch: false
@@ -245,6 +246,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Dependencies.Source != DependencySourceNativeOnly {
 		t.Fatalf("Dependencies.Source = %q, want %q", cfg.Dependencies.Source, DependencySourceNativeOnly)
+	}
+	if cfg.Polling.Conditional {
+		t.Fatal("Polling.Conditional = true, want explicit false")
 	}
 	if cfg.Tracker.GitHubGraphQLWarnRemaining != 750 {
 		t.Fatalf("Tracker.GitHubGraphQLWarnRemaining = %d, want 750", cfg.Tracker.GitHubGraphQLWarnRemaining)
@@ -607,6 +611,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Polling.IntervalMS != 120000 {
 		t.Fatalf("Polling.IntervalMS = %d", cfg.Polling.IntervalMS)
+	}
+	if !cfg.Polling.Conditional {
+		t.Fatal("Polling.Conditional = false, want true by default")
 	}
 	if cfg.Tracker.HTTPMaxIdleConns != 100 {
 		t.Fatalf("Tracker.HTTPMaxIdleConns = %d, want 100", cfg.Tracker.HTTPMaxIdleConns)

--- a/internal/connector/connector.go
+++ b/internal/connector/connector.go
@@ -151,6 +151,10 @@ type StatusDriftReader interface {
 	FetchStatusDrift(context.Context) (StatusDrift, error)
 }
 
+type ConditionalPoller interface {
+	ConditionalPollingEnabled() bool
+}
+
 type IssueReferenceResolver interface {
 	FetchIssueStatesByIdentifiers(context.Context, []string) ([]Issue, error)
 }

--- a/internal/connector/factory/factory.go
+++ b/internal/connector/factory/factory.go
@@ -33,6 +33,7 @@ type Config struct {
 	GitHubRESTMinReserve        int
 	GitHubRESTFanoutMaxRequests int
 	GitHubRESTDebugLogging      bool
+	ConditionalRequests         *bool
 	GitHubAppID                 string
 	GitHubAppPrivateKey         string
 	GitHubAppPrivateKeyPath     string
@@ -81,26 +82,27 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 				MaxIdleConnsPerHost: cfg.HTTPMaxIdleConnsPerHost,
 				IdleConnTimeout:     time.Duration(cfg.HTTPIdleConnTimeoutMS) * time.Millisecond,
 			},
-			RESTMinRemainingReserve: cfg.GitHubRESTMinReserve,
-			RESTFanoutMaxRequests:   cfg.GitHubRESTFanoutMaxRequests,
-			RESTDebugLogging:        cfg.GitHubRESTDebugLogging,
-			GitHubAppID:             cfg.GitHubAppID,
-			GitHubAppPrivateKey:     cfg.GitHubAppPrivateKey,
-			GitHubAppPrivateKeyPath: cfg.GitHubAppPrivateKeyPath,
-			GitHubAppInstallationID: cfg.GitHubAppInstallationID,
-			GitHubStatusSource:      cfg.GitHubStatusSource,
-			DependencySource:        cfg.DependencySource,
-			ProjectSlug:             cfg.ProjectSlug,
-			Repository:              cfg.Repository,
-			StatusField:             cfg.StatusField,
-			StatusLabelPrefix:       cfg.StatusLabelPrefix,
-			ActiveStates:            cfg.ActiveStates,
-			ObservedStates:          cfg.ObservedStates,
-			TerminalStates:          cfg.TerminalStates,
-			StateMap:                cfg.StateMap,
-			PriorityMap:             cfg.PriorityMap,
-			RequiredStatusChecks:    cfg.RequiredStatusChecks,
-			Logger:                  cfg.Logger,
+			RESTMinRemainingReserve:    cfg.GitHubRESTMinReserve,
+			RESTFanoutMaxRequests:      cfg.GitHubRESTFanoutMaxRequests,
+			RESTDebugLogging:           cfg.GitHubRESTDebugLogging,
+			DisableConditionalRequests: conditionalRequestsDisabled(cfg.ConditionalRequests),
+			GitHubAppID:                cfg.GitHubAppID,
+			GitHubAppPrivateKey:        cfg.GitHubAppPrivateKey,
+			GitHubAppPrivateKeyPath:    cfg.GitHubAppPrivateKeyPath,
+			GitHubAppInstallationID:    cfg.GitHubAppInstallationID,
+			GitHubStatusSource:         cfg.GitHubStatusSource,
+			DependencySource:           cfg.DependencySource,
+			ProjectSlug:                cfg.ProjectSlug,
+			Repository:                 cfg.Repository,
+			StatusField:                cfg.StatusField,
+			StatusLabelPrefix:          cfg.StatusLabelPrefix,
+			ActiveStates:               cfg.ActiveStates,
+			ObservedStates:             cfg.ObservedStates,
+			TerminalStates:             cfg.TerminalStates,
+			StateMap:                   cfg.StateMap,
+			PriorityMap:                cfg.PriorityMap,
+			RequiredStatusChecks:       cfg.RequiredStatusChecks,
+			Logger:                     cfg.Logger,
 		})
 	case connector.BackendGitHubLocal:
 		var tokenSource githubconnector.TokenSource
@@ -127,24 +129,25 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 					MaxIdleConnsPerHost: cfg.HTTPMaxIdleConnsPerHost,
 					IdleConnTimeout:     time.Duration(cfg.HTTPIdleConnTimeoutMS) * time.Millisecond,
 				},
-				RESTMinRemainingReserve: cfg.GitHubRESTMinReserve,
-				RESTFanoutMaxRequests:   cfg.GitHubRESTFanoutMaxRequests,
-				RESTDebugLogging:        cfg.GitHubRESTDebugLogging,
-				GitHubAppID:             cfg.GitHubAppID,
-				GitHubAppPrivateKey:     cfg.GitHubAppPrivateKey,
-				GitHubAppPrivateKeyPath: cfg.GitHubAppPrivateKeyPath,
-				GitHubAppInstallationID: cfg.GitHubAppInstallationID,
-				DependencySource:        cfg.DependencySource,
-				Repository:              cfg.Repository,
-				StatusField:             cfg.StatusField,
-				StatusLabelPrefix:       cfg.StatusLabelPrefix,
-				ActiveStates:            cfg.ActiveStates,
-				ObservedStates:          cfg.ObservedStates,
-				TerminalStates:          cfg.TerminalStates,
-				StateMap:                cfg.StateMap,
-				PriorityMap:             cfg.PriorityMap,
-				RequiredStatusChecks:    cfg.RequiredStatusChecks,
-				Logger:                  cfg.Logger,
+				RESTMinRemainingReserve:    cfg.GitHubRESTMinReserve,
+				RESTFanoutMaxRequests:      cfg.GitHubRESTFanoutMaxRequests,
+				RESTDebugLogging:           cfg.GitHubRESTDebugLogging,
+				DisableConditionalRequests: conditionalRequestsDisabled(cfg.ConditionalRequests),
+				GitHubAppID:                cfg.GitHubAppID,
+				GitHubAppPrivateKey:        cfg.GitHubAppPrivateKey,
+				GitHubAppPrivateKeyPath:    cfg.GitHubAppPrivateKeyPath,
+				GitHubAppInstallationID:    cfg.GitHubAppInstallationID,
+				DependencySource:           cfg.DependencySource,
+				Repository:                 cfg.Repository,
+				StatusField:                cfg.StatusField,
+				StatusLabelPrefix:          cfg.StatusLabelPrefix,
+				ActiveStates:               cfg.ActiveStates,
+				ObservedStates:             cfg.ObservedStates,
+				TerminalStates:             cfg.TerminalStates,
+				StateMap:                   cfg.StateMap,
+				PriorityMap:                cfg.PriorityMap,
+				RequiredStatusChecks:       cfg.RequiredStatusChecks,
+				Logger:                     cfg.Logger,
 			},
 			Local:          localCfg,
 			Repository:     cfg.Repository,
@@ -157,6 +160,10 @@ func NewFromConfig(cfg Config) (connector.Connector, error) {
 	default:
 		return nil, fmt.Errorf("%w: %s", ErrUnsupportedBackend, kind)
 	}
+}
+
+func conditionalRequestsDisabled(enabled *bool) bool {
+	return enabled != nil && !*enabled
 }
 
 func (cfg Config) hasGitHubAppCredentials() bool {

--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -38,12 +38,13 @@ type HTTPClient interface {
 }
 
 type ClientConfig struct {
-	Endpoint         string
-	TokenSource      TokenSource
-	HTTPClient       HTTPClient
-	RESTPolicy       RESTBudgetPolicy
-	RESTDebugLogging bool
-	Logger           *slog.Logger
+	Endpoint                   string
+	TokenSource                TokenSource
+	HTTPClient                 HTTPClient
+	RESTPolicy                 RESTBudgetPolicy
+	DisableConditionalRequests bool
+	RESTDebugLogging           bool
+	Logger                     *slog.Logger
 }
 
 type RESTBudgetPolicy struct {
@@ -68,6 +69,8 @@ type Client struct {
 	restRateLimit          connector.RESTRateLimit
 	restRateLimits         map[string]connector.RESTRateLimit
 	restRequests           map[string]connector.RESTEndpointUsage
+	restCache              map[string]restCacheEntry
+	conditionalRequests    bool
 	restBackoffUntil       time.Time
 	restBackoffKey         string
 	restBackoffs           *restBackoffRegistry
@@ -110,14 +113,16 @@ func NewClient(cfg ClientConfig) (*Client, error) {
 	}
 
 	return &Client{
-		endpoint:         endpoint,
-		restEndpoint:     restEndpoint,
-		tokenSource:      cfg.TokenSource,
-		httpClient:       httpClient,
-		restPolicy:       normalizeRESTBudgetPolicy(cfg.RESTPolicy),
-		restDebugLogging: cfg.RESTDebugLogging,
-		logger:           logger,
-		restBackoffs:     defaultRESTBackoffs,
+		endpoint:            endpoint,
+		restEndpoint:        restEndpoint,
+		tokenSource:         cfg.TokenSource,
+		httpClient:          httpClient,
+		restPolicy:          normalizeRESTBudgetPolicy(cfg.RESTPolicy),
+		restDebugLogging:    cfg.RESTDebugLogging,
+		logger:              logger,
+		restBackoffs:        defaultRESTBackoffs,
+		conditionalRequests: !cfg.DisableConditionalRequests,
+		restCache:           map[string]restCacheEntry{},
 	}, nil
 }
 
@@ -301,7 +306,7 @@ func (c *Client) restProbeWithTokenRefresh(ctx context.Context, method string, p
 		return restProbeResult{}, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt)
+	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt, false)
 	c.logRESTResponse(ctx, "github rest probe response", method, path, family, resp.StatusCode)
 	result := restProbeResult{
 		StatusCode: resp.StatusCode,
@@ -333,6 +338,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	}
 	backoffKey := c.restSharedBackoffKey(token)
 	c.rememberRESTBackoffKey(backoffKey)
+	cached, conditional := c.restConditionalEntry(method, path)
 	if err := c.restBackoffError(backoffKey, time.Now()); err != nil {
 		c.logger.DebugContext(ctx, "github rest backoff active",
 			"method", strings.ToUpper(strings.TrimSpace(method)),
@@ -344,7 +350,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		)
 		return nil, err
 	}
-	if err := c.restBudgetPolicyError(method, path); err != nil {
+	if err := c.restBudgetPolicyError(method, path, conditional); err != nil {
 		c.logger.DebugContext(ctx, "github rest budget reserved",
 			"method", strings.ToUpper(strings.TrimSpace(method)),
 			"path", path,
@@ -375,6 +381,9 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 	req.Header.Set("Authorization", "Bearer "+token)
 	req.Header.Set("Accept", "application/vnd.github+json")
 	req.Header.Set("X-GitHub-Api-Version", gitHubAPIVersion)
+	if conditional {
+		req.Header.Set("If-None-Match", cached.etag)
+	}
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
@@ -400,7 +409,24 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		return nil, fmt.Errorf("%w: read response: %w", ErrTransient, err)
 	}
 	receivedAt := time.Now()
-	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt)
+	c.recordRESTRateLimitFromHeaders(backoffKey, method, path, resp.StatusCode, resp.Header, receivedAt, conditional)
+	if resp.StatusCode == http.StatusNotModified {
+		if !conditional {
+			return nil, ErrInvalidResponse
+		}
+		raw = cached.body
+		headers := mergeRESTHeaders(cached.headers, resp.Header)
+		if out == nil {
+			return headers, nil
+		}
+		if len(raw) == 0 {
+			return nil, ErrInvalidResponse
+		}
+		if err := json.Unmarshal(raw, out); err != nil {
+			return nil, fmt.Errorf("%w: %w", ErrInvalidResponse, err)
+		}
+		return headers, nil
+	}
 	if resp.StatusCode < http.StatusOK || resp.StatusCode >= http.StatusMultipleChoices {
 		err := classifyStatusAt(resp.StatusCode, resp.Header, raw, receivedAt)
 		c.logRESTStatusError(ctx, method, path, family, resp.StatusCode, err)
@@ -410,6 +436,7 @@ func (c *Client) restWithTokenRefresh(ctx context.Context, method string, path s
 		return nil, err
 	}
 	headers := resp.Header.Clone()
+	c.storeRESTConditionalEntry(method, path, headers, raw)
 	if out == nil || resp.StatusCode == http.StatusNoContent {
 		return headers, nil
 	}
@@ -575,6 +602,9 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 	}
 	for _, request := range usage.Requests {
 		usage.TotalRequests += request.Count
+		usage.ConditionalRequests += request.Conditional
+		usage.NotModifiedRequests += request.NotModified
+		usage.BillableRequests += request.Billable
 		if request.RateLimited {
 			usage.RateLimited = true
 		}
@@ -613,9 +643,9 @@ func normalizeRESTBudgetPolicy(policy RESTBudgetPolicy) RESTBudgetPolicy {
 	return policy
 }
 
-func (c *Client) restBudgetPolicyError(method string, path string) error {
+func (c *Client) restBudgetPolicyError(method string, path string, conditional bool) error {
 	family := restEndpointFamily(method, path)
-	if !restFanoutEndpointFamily(family) {
+	if !restFanoutEndpointFamily(family) || conditional {
 		return nil
 	}
 
@@ -649,7 +679,7 @@ func (c *Client) restFanoutRequestCountLocked() int64 {
 	var count int64
 	for family, request := range c.restRequests {
 		if restFanoutEndpointFamily(family) {
-			count += request.Count
+			count += request.Billable
 		}
 	}
 	return count
@@ -712,7 +742,7 @@ func (c *Client) rememberRESTBackoffKey(backoffKey string) {
 	c.mu.Unlock()
 }
 
-func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string, path string, status int, headers http.Header, now time.Time) {
+func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string, path string, status int, headers http.Header, now time.Time, conditional bool) {
 	limit, hasLimit := int64Header(headers, "X-RateLimit-Limit")
 	used, hasUsed := int64Header(headers, "X-RateLimit-Used")
 	remaining, hasRemaining := int64Header(headers, "X-RateLimit-Remaining")
@@ -784,6 +814,14 @@ func (c *Client) recordRESTRateLimitFromHeaders(backoffKey string, method string
 	request := c.restRequests[family]
 	request.EndpointFamily = family
 	request.Count++
+	if conditional {
+		request.Conditional++
+	}
+	if status == http.StatusNotModified {
+		request.NotModified++
+	} else {
+		request.Billable++
+	}
 	request.LastStatus = status
 	request.RateLimited = request.RateLimited || rateLimited
 	if hasLimit {

--- a/internal/connector/github/conditional.go
+++ b/internal/connector/github/conditional.go
@@ -1,0 +1,88 @@
+package github
+
+import (
+	"net/http"
+	"strings"
+	"time"
+)
+
+const restConditionalCacheMaxEntries = 1024
+
+type restCacheEntry struct {
+	etag     string
+	body     []byte
+	headers  http.Header
+	cachedAt time.Time
+}
+
+func (c *Client) restConditionalEntry(method string, path string) (restCacheEntry, bool) {
+	if c == nil || !c.conditionalRequests || !strings.EqualFold(strings.TrimSpace(method), http.MethodGet) {
+		return restCacheEntry{}, false
+	}
+	key := restCacheKey(method, path)
+	c.mu.RLock()
+	entry, ok := c.restCache[key]
+	c.mu.RUnlock()
+	if !ok || strings.TrimSpace(entry.etag) == "" {
+		return restCacheEntry{}, false
+	}
+	return cloneRESTCacheEntry(entry), true
+}
+
+func (c *Client) storeRESTConditionalEntry(method string, path string, headers http.Header, body []byte) {
+	if c == nil || !c.conditionalRequests || !strings.EqualFold(strings.TrimSpace(method), http.MethodGet) {
+		return
+	}
+	etag := strings.TrimSpace(headers.Get("ETag"))
+	if etag == "" {
+		return
+	}
+	entry := restCacheEntry{
+		etag:     etag,
+		body:     append([]byte(nil), body...),
+		headers:  headers.Clone(),
+		cachedAt: time.Now(),
+	}
+	key := restCacheKey(method, path)
+	c.mu.Lock()
+	if _, exists := c.restCache[key]; !exists && len(c.restCache) >= restConditionalCacheMaxEntries {
+		c.evictOldestRESTConditionalEntryLocked()
+	}
+	c.restCache[key] = entry
+	c.mu.Unlock()
+}
+
+func (c *Client) evictOldestRESTConditionalEntryLocked() {
+	oldestKey := ""
+	oldestAt := time.Time{}
+	for key, entry := range c.restCache {
+		if oldestKey == "" || entry.cachedAt.Before(oldestAt) {
+			oldestKey = key
+			oldestAt = entry.cachedAt
+		}
+	}
+	if oldestKey != "" {
+		delete(c.restCache, oldestKey)
+	}
+}
+
+func restCacheKey(method string, path string) string {
+	return strings.ToUpper(strings.TrimSpace(method)) + " " + strings.TrimSpace(path)
+}
+
+func cloneRESTCacheEntry(entry restCacheEntry) restCacheEntry {
+	return restCacheEntry{
+		etag:     entry.etag,
+		body:     append([]byte(nil), entry.body...),
+		headers:  entry.headers.Clone(),
+		cachedAt: entry.cachedAt,
+	}
+}
+
+func mergeRESTHeaders(cached http.Header, fresh http.Header) http.Header {
+	merged := cached.Clone()
+	for key, values := range fresh {
+		merged[key] = append([]string(nil), values...)
+	}
+	return merged
+}

--- a/internal/connector/github/conditional_test.go
+++ b/internal/connector/github/conditional_test.go
@@ -1,0 +1,128 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"sync/atomic"
+	"testing"
+)
+
+func TestClientRESTConditionalRequestUsesCachedResponseBelowReserve(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("X-RateLimit-Limit", "5000")
+		w.Header().Set("X-RateLimit-Used", "4100")
+		w.Header().Set("X-RateLimit-Remaining", "900")
+		w.Header().Set("X-RateLimit-Resource", "core")
+		switch calls.Add(1) {
+		case 1:
+			if got := r.Header.Get("If-None-Match"); got != "" {
+				t.Fatalf("first If-None-Match = %q, want empty", got)
+			}
+			w.Header().Set("Content-Type", "application/json")
+			w.Header().Set("ETag", `"board-v1"`)
+			_, _ = w.Write([]byte(`[{"number":1133,"node_id":"issue-1133","title":"Fresh board"}]`))
+		case 2:
+			if got := r.Header.Get("If-None-Match"); got != `"board-v1"` {
+				t.Fatalf("second If-None-Match = %q, want board-v1 ETag", got)
+			}
+			w.WriteHeader(http.StatusNotModified)
+		default:
+			t.Fatalf("unexpected request %d", calls.Load())
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    server.URL,
+		TokenSource: StaticTokenSource("test-token"),
+		HTTPClient:  server.Client(),
+		RESTPolicy:  RESTBudgetPolicy{MinRemainingReserve: 1000},
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	path := "/repos/digitaldrywood/detent/issues?state=open"
+	var first []restIssue
+	if err := client.REST(context.Background(), http.MethodGet, path, nil, &first); err != nil {
+		t.Fatalf("first REST() error = %v", err)
+	}
+	client.FlushRESTRateLimitUsage()
+
+	var second []restIssue
+	if err := client.REST(context.Background(), http.MethodGet, path, nil, &second); err != nil {
+		t.Fatalf("conditional REST() error = %v", err)
+	}
+	if len(second) != 1 || second[0].Number != 1133 || second[0].Title != "Fresh board" {
+		t.Fatalf("conditional REST() response = %#v, want cached issue", second)
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+	if usage.TotalRequests != 1 || usage.ConditionalRequests != 1 || usage.NotModifiedRequests != 1 || usage.BillableRequests != 0 {
+		t.Fatalf("conditional usage = %#v, want one free not-modified request", usage)
+	}
+	if usage.RateLimit.Used != 4100 || usage.RateLimit.Remaining != 900 {
+		t.Fatalf("rate limit = %#v, want unchanged 4100 used and 900 remaining", usage.RateLimit)
+	}
+}
+
+func TestClientRESTConditionalRequestsCanBeDisabled(t *testing.T) {
+	t.Parallel()
+
+	var calls atomic.Int64
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if got := r.Header.Get("If-None-Match"); got != "" {
+			t.Fatalf("If-None-Match = %q, want empty when disabled", got)
+		}
+		call := calls.Add(1)
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("ETag", `"board-v1"`)
+		_, _ = w.Write([]byte(`[{"number":` + strconv.FormatInt(call, 10) + `}]`))
+	}))
+	t.Cleanup(server.Close)
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:                   server.URL,
+		TokenSource:                StaticTokenSource("test-token"),
+		HTTPClient:                 server.Client(),
+		DisableConditionalRequests: true,
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+
+	for range 2 {
+		var issues []restIssue
+		if err := client.REST(context.Background(), http.MethodGet, "/repos/digitaldrywood/detent/issues", nil, &issues); err != nil {
+			t.Fatalf("REST() error = %v", err)
+		}
+	}
+	usage := client.FlushRESTRateLimitUsage()
+	if usage.TotalRequests != 2 || usage.ConditionalRequests != 0 || usage.NotModifiedRequests != 0 || usage.BillableRequests != 2 {
+		t.Fatalf("disabled conditional usage = %#v, want two billable requests", usage)
+	}
+}
+
+func TestClientRESTConditionalCacheIsBounded(t *testing.T) {
+	t.Parallel()
+
+	client, err := NewClient(ClientConfig{
+		Endpoint:    "https://api.github.test/graphql",
+		TokenSource: StaticTokenSource("test-token"),
+	})
+	if err != nil {
+		t.Fatalf("NewClient() error = %v", err)
+	}
+	headers := http.Header{"Etag": []string{`"value"`}}
+	for index := range restConditionalCacheMaxEntries + 1 {
+		client.storeRESTConditionalEntry(http.MethodGet, "/resource/"+strconv.Itoa(index), headers, []byte(`{}`))
+	}
+	if got := len(client.restCache); got != restConditionalCacheMaxEntries {
+		t.Fatalf("conditional cache size = %d, want %d", got, restConditionalCacheMaxEntries)
+	}
+}

--- a/internal/connector/github/connector.go
+++ b/internal/connector/github/connector.go
@@ -51,34 +51,35 @@ const (
 )
 
 type Config struct {
-	Endpoint                string
-	APIKey                  string
-	GitHubAppID             string
-	GitHubAppPrivateKey     string
-	GitHubAppPrivateKeyPath string
-	GitHubAppInstallationID string
-	GitHubStatusSource      string
-	DependencySource        string
-	ProjectSlug             string
-	Repository              string
-	StatusField             string
-	StatusLabelPrefix       string
-	ActiveStates            []string
-	ObservedStates          []string
-	TerminalStates          []string
-	StateMap                map[string]string
-	PriorityMap             map[string]*int
-	RequiredStatusChecks    []string
-	TokenSource             TokenSource
-	HTTPClient              HTTPClient
-	HTTPTransport           HTTPTransportConfig
-	RESTMinRemainingReserve int
-	RESTFanoutMaxRequests   int
-	RESTDebugLogging        bool
-	Logger                  *slog.Logger
-	Now                     func() time.Time
-	LookupEnv               func(string) string
-	GHToken                 GHTokenFunc
+	Endpoint                   string
+	APIKey                     string
+	GitHubAppID                string
+	GitHubAppPrivateKey        string
+	GitHubAppPrivateKeyPath    string
+	GitHubAppInstallationID    string
+	GitHubStatusSource         string
+	DependencySource           string
+	ProjectSlug                string
+	Repository                 string
+	StatusField                string
+	StatusLabelPrefix          string
+	ActiveStates               []string
+	ObservedStates             []string
+	TerminalStates             []string
+	StateMap                   map[string]string
+	PriorityMap                map[string]*int
+	RequiredStatusChecks       []string
+	TokenSource                TokenSource
+	HTTPClient                 HTTPClient
+	HTTPTransport              HTTPTransportConfig
+	RESTMinRemainingReserve    int
+	RESTFanoutMaxRequests      int
+	RESTDebugLogging           bool
+	DisableConditionalRequests bool
+	Logger                     *slog.Logger
+	Now                        func() time.Time
+	LookupEnv                  func(string) string
+	GHToken                    GHTokenFunc
 }
 
 type Connector struct {
@@ -142,8 +143,9 @@ func NewConnector(cfg Config) (*Connector, error) {
 			MinRemainingReserve: int64(cfg.RESTMinRemainingReserve),
 			FanoutMaxRequests:   int64(cfg.RESTFanoutMaxRequests),
 		},
-		RESTDebugLogging: cfg.RESTDebugLogging,
-		Logger:           logger,
+		RESTDebugLogging:           cfg.RESTDebugLogging,
+		DisableConditionalRequests: cfg.DisableConditionalRequests,
+		Logger:                     logger,
 	})
 	if err != nil {
 		return nil, err
@@ -181,6 +183,10 @@ func NewConnector(cfg Config) (*Connector, error) {
 		prHydration:       newPullRequestHydrationCircuitBreaker(cfg.Now),
 		logger:            logger,
 	}, nil
+}
+
+func (c *Connector) ConditionalPollingEnabled() bool {
+	return c != nil && c.client != nil && c.client.conditionalRequests && (c.usesLabelStatus() || c.usesIssueFieldStatus())
 }
 
 func (c *Connector) Name() string {

--- a/internal/connector/github/pull_requests.go
+++ b/internal/connector/github/pull_requests.go
@@ -618,6 +618,10 @@ func pullRequestRepoName(repo pullRequestRepo) string {
 	return owner + "/" + name
 }
 
+func samePullRequestRepo(left pullRequestRepo, right pullRequestRepo) bool {
+	return strings.EqualFold(left.Owner, right.Owner) && strings.EqualFold(left.Name, right.Name)
+}
+
 func (c *Connector) populatePullRequestStatus(ctx context.Context, repo pullRequestRepo, pullRequest *pullRequestNode, useStatusCache bool) error {
 	if useStatusCache && c.pullRequests != nil {
 		if status, ok := c.pullRequests.Get(repo, pullRequest.Number, pullRequest.HeadSHA); ok {

--- a/internal/connector/github/reconcile.go
+++ b/internal/connector/github/reconcile.go
@@ -1,0 +1,117 @@
+package github
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+var _ connector.TargetedReconciler = (*Connector)(nil)
+
+func (c *Connector) ReconcileIssue(ctx context.Context, target connector.ReconcileTarget) (connector.ReconcileResult, error) {
+	repo, ok := pullRequestRepoFromName(target.Scope)
+	if !ok {
+		return connector.ReconcileResult{}, nil
+	}
+	if validPullRequestRepo(c.repository) && c.repository != repo {
+		return connector.ReconcileResult{}, nil
+	}
+
+	pullRequest, hasPullRequest, err := c.reconcilePullRequest(ctx, repo, target)
+	if err != nil {
+		return connector.ReconcileResult{}, err
+	}
+	ref, ok := reconcileIssueRef(repo, target, pullRequest, hasPullRequest)
+	if !ok {
+		return connector.ReconcileResult{}, nil
+	}
+
+	issue, found, err := c.reconcileIssueByRef(ctx, ref)
+	if err != nil || !found {
+		return connector.ReconcileResult{Issue: issue, Found: found}, err
+	}
+	if normalizeStateName(issue.State) == normalizeStateName("Blocked") {
+		issues := []connector.Issue{issue}
+		if err := c.populateBlockerReasons(ctx, issues); err != nil {
+			return connector.ReconcileResult{}, err
+		}
+		c.hydrateBlockedByRefs(ctx, issues)
+		if err := c.resolveBlockedByProjectState(ctx, issues); err != nil {
+			return connector.ReconcileResult{}, err
+		}
+		issue = issues[0]
+	}
+	if hasPullRequest {
+		if err := c.populatePullRequestStatus(ctx, repo, &pullRequest, false); err != nil {
+			if state := c.pullRequestHydrationStateForError(repo, err); state.Reason != "" {
+				applyPullRequestHydrationUnavailableState(&pullRequest, state)
+			} else {
+				return connector.ReconcileResult{}, fmt.Errorf("reconcile github pull request status: %w", err)
+			}
+		}
+		attachPullRequestToIssue(&issue, repo, pullRequest)
+	}
+	return connector.ReconcileResult{Issue: issue, Found: true}, nil
+}
+
+func (c *Connector) reconcilePullRequest(ctx context.Context, repo pullRequestRepo, target connector.ReconcileTarget) (pullRequestNode, bool, error) {
+	if target.ChangeNumber <= 0 {
+		return pullRequestNode{}, false, nil
+	}
+	pullRequest, err := c.fetchRepositoryPullRequest(ctx, repo, target.ChangeNumber)
+	if err != nil {
+		return pullRequestNode{}, false, err
+	}
+	return pullRequest, true, nil
+}
+
+func (c *Connector) reconcileIssueByRef(ctx context.Context, ref issueRef) (connector.Issue, bool, error) {
+	switch {
+	case c.usesLabelStatus():
+		return c.fetchLabelIssueByRef(ctx, ref)
+	case c.usesIssueFieldStatus():
+		return c.fetchIssueFieldIssueByRef(ctx, ref)
+	default:
+		return c.fetchProjectIssueByRef(ctx, ref)
+	}
+}
+
+func reconcileIssueRef(repo pullRequestRepo, target connector.ReconcileTarget, pullRequest pullRequestNode, hasPullRequest bool) (issueRef, bool) {
+	if target.WorkItemNumber > 0 {
+		return issueRef{Owner: repo.Owner, Name: repo.Name, Number: target.WorkItemNumber}, true
+	}
+	branch := strings.TrimSpace(target.Branch)
+	if branch == "" && hasPullRequest {
+		branch = pullRequest.HeadRefName
+	}
+	return issueRefFromDetentBranch(repo, branch)
+}
+
+func issueRefFromDetentBranch(repo pullRequestRepo, branch string) (issueRef, bool) {
+	branch = strings.ToLower(strings.TrimSpace(branch))
+	branch, ok := strings.CutPrefix(branch, "detent/")
+	if !ok {
+		return issueRef{}, false
+	}
+	branch = strings.TrimPrefix(branch, "detent-")
+	repositoryKey := strings.ToLower(branchKeyPattern.ReplaceAllString(pullRequestRepoName(repo), "_"))
+	remainder, ok := strings.CutPrefix(branch, repositoryKey+"_")
+	if !ok {
+		return issueRef{}, false
+	}
+	end := 0
+	for end < len(remainder) && remainder[end] >= '0' && remainder[end] <= '9' {
+		end++
+	}
+	if end == 0 {
+		return issueRef{}, false
+	}
+	number, err := strconv.Atoi(remainder[:end])
+	if err != nil || number <= 0 {
+		return issueRef{}, false
+	}
+	return issueRef{Owner: repo.Owner, Name: repo.Name, Number: number}, true
+}

--- a/internal/connector/github/reconcile.go
+++ b/internal/connector/github/reconcile.go
@@ -16,7 +16,7 @@ func (c *Connector) ReconcileIssue(ctx context.Context, target connector.Reconci
 	if !ok {
 		return connector.ReconcileResult{}, nil
 	}
-	if validPullRequestRepo(c.repository) && c.repository != repo {
+	if validPullRequestRepo(c.repository) && !samePullRequestRepo(c.repository, repo) {
 		return connector.ReconcileResult{}, nil
 	}
 

--- a/internal/connector/github/reconcile_test.go
+++ b/internal/connector/github/reconcile_test.go
@@ -1,0 +1,91 @@
+package github
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+)
+
+func TestConnectorReconcileIssueFetchesOneLabelIssue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		labels    string
+		wantState string
+	}{
+		{name: "configured status label", labels: `[{"name":"detent:in-progress"}]`, wantState: "In Progress"},
+		{name: "status label removed", labels: `[{"name":"enhancement"}]`, wantState: "Open"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/repos/digitaldrywood/detent/issues/1133" {
+					t.Fatalf("path = %q, want targeted issue path", r.URL.Path)
+				}
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(`{"number":1133,"node_id":"I_1133","title":"Board freshness","body":"","state":"open","html_url":"https://github.com/digitaldrywood/detent/issues/1133","labels":` + tt.labels + `}`))
+			}))
+			t.Cleanup(server.Close)
+
+			tracker, err := NewConnector(Config{
+				Endpoint:           server.URL,
+				APIKey:             "test-token",
+				HTTPClient:         server.Client(),
+				GitHubStatusSource: GitHubStatusSourceLabel,
+				Repository:         "digitaldrywood/detent",
+				ActiveStates:       []string{"Todo", "In Progress"},
+				ObservedStates:     []string{"Blocked"},
+				TerminalStates:     []string{"Done"},
+			})
+			if err != nil {
+				t.Fatalf("NewConnector() error = %v", err)
+			}
+
+			result, err := tracker.ReconcileIssue(context.Background(), connector.ReconcileTarget{
+				Scope:          "digitaldrywood/detent",
+				WorkItemNumber: 1133,
+				Event:          "issues",
+			})
+			if err != nil {
+				t.Fatalf("ReconcileIssue() error = %v", err)
+			}
+			if !result.Found || result.Issue.ID != "I_1133" || result.Issue.State != tt.wantState {
+				t.Fatalf("ReconcileIssue() = %#v, want found issue in %q", result, tt.wantState)
+			}
+		})
+	}
+}
+
+func TestIssueRefFromDetentBranch(t *testing.T) {
+	t.Parallel()
+
+	repo := pullRequestRepo{Owner: "digitaldrywood", Name: "detent"}
+	tests := []struct {
+		name       string
+		branch     string
+		wantNumber int
+		wantOK     bool
+	}{
+		{name: "current workspace format", branch: "detent/detent-digitaldrywood_detent_1133-94412618830b", wantNumber: 1133, wantOK: true},
+		{name: "canonical prefix", branch: "detent/digitaldrywood_detent_1133-feature", wantNumber: 1133, wantOK: true},
+		{name: "unrelated branch", branch: "feature/1133", wantOK: false},
+		{name: "other repository", branch: "detent/digitaldrywood_other_1133", wantOK: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			ref, ok := issueRefFromDetentBranch(repo, tt.branch)
+			if ok != tt.wantOK || ref.Number != tt.wantNumber {
+				t.Fatalf("issueRefFromDetentBranch() = %#v, %v; want number %d, ok %v", ref, ok, tt.wantNumber, tt.wantOK)
+			}
+		})
+	}
+}

--- a/internal/connector/github/reconcile_test.go
+++ b/internal/connector/github/reconcile_test.go
@@ -13,12 +13,14 @@ func TestConnectorReconcileIssueFetchesOneLabelIssue(t *testing.T) {
 	t.Parallel()
 
 	tests := []struct {
-		name      string
-		labels    string
-		wantState string
+		name       string
+		repository string
+		labels     string
+		wantState  string
 	}{
-		{name: "configured status label", labels: `[{"name":"detent:in-progress"}]`, wantState: "In Progress"},
-		{name: "status label removed", labels: `[{"name":"enhancement"}]`, wantState: "Open"},
+		{name: "configured status label", repository: "digitaldrywood/detent", labels: `[{"name":"detent:in-progress"}]`, wantState: "In Progress"},
+		{name: "status label removed", repository: "digitaldrywood/detent", labels: `[{"name":"enhancement"}]`, wantState: "Open"},
+		{name: "repository case differs", repository: "DigitalDrywood/Detent", labels: `[{"name":"detent:in-progress"}]`, wantState: "In Progress"},
 	}
 
 	for _, tt := range tests {
@@ -39,7 +41,7 @@ func TestConnectorReconcileIssueFetchesOneLabelIssue(t *testing.T) {
 				APIKey:             "test-token",
 				HTTPClient:         server.Client(),
 				GitHubStatusSource: GitHubStatusSourceLabel,
-				Repository:         "digitaldrywood/detent",
+				Repository:         tt.repository,
 				ActiveStates:       []string{"Todo", "In Progress"},
 				ObservedStates:     []string{"Blocked"},
 				TerminalStates:     []string{"Done"},

--- a/internal/connector/githublocal/githublocal.go
+++ b/internal/connector/githublocal/githublocal.go
@@ -94,6 +94,7 @@ var _ connector.Authenticator = (*Connector)(nil)
 var _ connector.AuthHealthReporter = (*Connector)(nil)
 var _ connector.CandidateIssuesByStatesFetcher = (*Connector)(nil)
 var _ connector.Closer = (*Connector)(nil)
+var _ connector.ConditionalPoller = (*Connector)(nil)
 var _ connector.RateLimitReporter = (*Connector)(nil)
 var _ connector.GraphQLRateLimitUsageReporter = (*Connector)(nil)
 var _ connector.InstanceIdentifier = (*Connector)(nil)
@@ -207,6 +208,14 @@ func (c *Connector) FlushGraphQLRateLimitUsage() connector.GraphQLRateLimitUsage
 
 func (c *Connector) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 	return c.github.FlushRESTRateLimitUsage()
+}
+
+func (c *Connector) ConditionalPollingEnabled() bool {
+	if c == nil || c.github == nil {
+		return false
+	}
+	poller, ok := c.github.(connector.ConditionalPoller)
+	return ok && poller.ConditionalPollingEnabled()
 }
 
 func (c *Connector) FetchCandidateIssues(ctx context.Context) ([]connector.Issue, error) {

--- a/internal/connector/ratelimit.go
+++ b/internal/connector/ratelimit.go
@@ -55,6 +55,9 @@ type RESTRateLimit struct {
 type RESTEndpointUsage struct {
 	EndpointFamily string
 	Count          int64
+	Conditional    int64
+	NotModified    int64
+	Billable       int64
 	Limit          int64
 	Used           int64
 	Remaining      int64
@@ -66,12 +69,15 @@ type RESTEndpointUsage struct {
 }
 
 type RESTRateLimitUsage struct {
-	RateLimit     RESTRateLimit
-	HasRateLimit  bool
-	Requests      []RESTEndpointUsage
-	TotalRequests int64
-	RateLimited   bool
-	BackoffUntil  time.Time
+	RateLimit           RESTRateLimit
+	HasRateLimit        bool
+	Requests            []RESTEndpointUsage
+	TotalRequests       int64
+	ConditionalRequests int64
+	NotModifiedRequests int64
+	BillableRequests    int64
+	RateLimited         bool
+	BackoffUntil        time.Time
 }
 
 type RESTRateLimitUsageReporter interface {

--- a/internal/connector/reconcile.go
+++ b/internal/connector/reconcile.go
@@ -1,0 +1,22 @@
+package connector
+
+import "context"
+
+type ReconcileTarget struct {
+	Scope          string
+	WorkItemNumber int
+	ChangeNumber   int
+	Revision       string
+	Branch         string
+	Event          string
+	DeliveryID     string
+}
+
+type ReconcileResult struct {
+	Issue Issue
+	Found bool
+}
+
+type TargetedReconciler interface {
+	ReconcileIssue(context.Context, ReconcileTarget) (ReconcileResult, error)
+}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -143,6 +143,7 @@ type Orchestrator struct {
 	recoveryRequests   chan workAttemptRecoveryRequest
 	configUpdates      chan configUpdateRequest
 	refreshes          chan manualRefreshRequest
+	reconciles         chan targetedRefreshRequest
 	runResults         chan runpkg.Completion
 	runUpdates         chan runUpdate
 	done               chan struct{}
@@ -264,6 +265,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		recoveryRequests:   make(chan workAttemptRecoveryRequest),
 		configUpdates:      make(chan configUpdateRequest),
 		refreshes:          make(chan manualRefreshRequest, 1),
+		reconciles:         make(chan targetedRefreshRequest, 128),
 		runResults:         make(chan runpkg.Completion, max(cfg.MaxConcurrentAgents, 1)),
 		runUpdates:         make(chan runUpdate, runUpdateBufferSize),
 		done:               make(chan struct{}),
@@ -295,6 +297,9 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 			resetTicker(ticker, state.PollInterval)
 		case request := <-o.refreshes:
 			o.tickManual(ctx, &state, request)
+			resetTicker(ticker, state.PollInterval)
+		case request := <-o.reconciles:
+			o.reconcileTarget(ctx, &state, request)
 			resetTicker(ticker, state.PollInterval)
 		case result := <-o.runResults:
 			o.handleRunResult(ctx, &state, result)

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -383,12 +383,15 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 				UpdatedAt:  now,
 			},
 			Requests: []connector.RESTEndpointUsage{
-				{EndpointFamily: "label issues", Count: 1, Remaining: 4879, Limit: 5000, Resource: "core"},
-				{EndpointFamily: "issue comments", Count: 1, Remaining: 4878, Limit: 5000, Resource: "core", RateLimited: true},
+				{EndpointFamily: "label issues", Count: 1, Conditional: 1, NotModified: 1, Remaining: 4879, Limit: 5000, Resource: "core"},
+				{EndpointFamily: "issue comments", Count: 1, Billable: 1, Remaining: 4878, Limit: 5000, Resource: "core", RateLimited: true},
 			},
-			TotalRequests: 2,
-			RateLimited:   true,
-			BackoffUntil:  now.Add(time.Minute),
+			TotalRequests:       2,
+			ConditionalRequests: 1,
+			NotModifiedRequests: 1,
+			BillableRequests:    1,
+			RateLimited:         true,
+			BackoffUntil:        now.Add(time.Minute),
 		},
 	}
 	orch := newRateLimitTestOrchestrator(cfg, tracker)
@@ -404,8 +407,14 @@ func TestTickPublishesGitHubRESTUsageAndBackoff(t *testing.T) {
 	if state.RateLimits.GitHubREST.Remaining != 4878 || state.RateLimits.GitHubREST.ResetInSeconds != 60 {
 		t.Fatalf("GitHubREST = %#v, want remaining 4878 reset 60s", state.RateLimits.GitHubREST)
 	}
+	if state.RateLimits.GitHubREST.Cost != 1 {
+		t.Fatalf("GitHubREST.Cost = %d, want one billable request", state.RateLimits.GitHubREST.Cost)
+	}
 	if state.RateLimits.RESTUsage.TotalRequests != 2 || !state.RateLimits.RESTUsage.RateLimited {
 		t.Fatalf("RESTUsage = %#v, want 2 requests and rate limited", state.RateLimits.RESTUsage)
+	}
+	if state.RateLimits.RESTUsage.ConditionalRequests != 1 || state.RateLimits.RESTUsage.NotModifiedRequests != 1 || state.RateLimits.RESTUsage.BillableRequests != 1 {
+		t.Fatalf("RESTUsage conditional breakdown = %#v, want one free 304 and one billable request", state.RateLimits.RESTUsage)
 	}
 	if len(state.RateLimits.RESTUsage.Contributors) != 2 || state.RateLimits.RESTUsage.Contributors[1].EndpointFamily != "issue comments" {
 		t.Fatalf("RESTUsage.Contributors = %#v, want issue comments contributor", state.RateLimits.RESTUsage.Contributors)
@@ -509,6 +518,48 @@ func TestTickSkipsNonessentialGitHubWorkBelowRESTReserve(t *testing.T) {
 	} {
 		if !strings.Contains(logOutput, want) {
 			t.Fatalf("log output missing %q:\n%s", want, logOutput)
+		}
+	}
+}
+
+func TestTickAllowsConditionalPollingBelowRESTReserve(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 6, 1, 12, 0, 0, 0, time.UTC)
+	resetAt := now.Add(time.Hour)
+	issue := connector.Issue{ID: "I_1133", Identifier: "digitaldrywood/detent#1133", State: "Human Review"}
+	cfg := normalizeConfig(Config{
+		PollInterval:            time.Minute,
+		MaxConcurrentAgents:     1,
+		ActiveStates:            []string{"Todo", "In Progress"},
+		ObservedStates:          []string{"Human Review", "Blocked"},
+		TerminalStates:          []string{"Done"},
+		GitHubRESTMinReserve:    1000,
+		GitHubGraphQLMinReserve: 1000,
+	})
+	state := newState(cfg)
+	state.Pipeline = []connector.Issue{issue}
+	state.LastWorkspaceCleanupAt = now
+	state.RateLimits = &telemetry.RateLimits{
+		GitHubREST: &telemetry.RateLimitBucket{
+			Remaining: 900,
+			Limit:     5000,
+			Used:      4100,
+			ResetAt:   &resetAt,
+		},
+	}
+	base := &rateLimitConnector{stateIssues: []connector.Issue{issue}}
+	tracker := &conditionalRateLimitConnector{rateLimitConnector: base}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+
+	orch.tick(context.Background(), &state, now)
+
+	if base.fetchCandidateCalls != 1 || base.fetchByStatesCalls != 1 {
+		t.Fatalf("fetch calls = candidates %d states %d, want one conditional cycle", base.fetchCandidateCalls, base.fetchByStatesCalls)
+	}
+	for _, event := range state.RecentEvents {
+		if event.Event == "github_budget_reserved" {
+			t.Fatalf("RecentEvents = %#v, want no reserve skip for conditional polling", state.RecentEvents)
 		}
 	}
 }
@@ -823,6 +874,14 @@ type rateLimitConnector struct {
 	fetchByStatesLimitCalls int
 	fetchByIDCalls          int
 	fetchByIDErr            error
+}
+
+type conditionalRateLimitConnector struct {
+	*rateLimitConnector
+}
+
+func (*conditionalRateLimitConnector) ConditionalPollingEnabled() bool {
+	return true
 }
 
 func (c *rateLimitConnector) Name() string {

--- a/internal/orchestrator/rate_limits.go
+++ b/internal/orchestrator/rate_limits.go
@@ -102,9 +102,12 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 	}
 
 	out := &telemetry.RESTUsage{
-		TotalRequests: usage.TotalRequests,
-		RateLimited:   usage.RateLimited,
-		Contributors:  make([]telemetry.RESTUsageContributor, 0, len(usage.Requests)),
+		TotalRequests:       usage.TotalRequests,
+		ConditionalRequests: usage.ConditionalRequests,
+		NotModifiedRequests: usage.NotModifiedRequests,
+		BillableRequests:    usage.BillableRequests,
+		RateLimited:         usage.RateLimited,
+		Contributors:        make([]telemetry.RESTUsageContributor, 0, len(usage.Requests)),
 	}
 	if !usage.BackoffUntil.IsZero() {
 		backoffUntil := usage.BackoffUntil
@@ -114,6 +117,9 @@ func restUsageSummary(usage connector.RESTRateLimitUsage) *telemetry.RESTUsage {
 		contributor := telemetry.RESTUsageContributor{
 			EndpointFamily: request.EndpointFamily,
 			Count:          request.Count,
+			Conditional:    request.Conditional,
+			NotModified:    request.NotModified,
+			Billable:       request.Billable,
 			Remaining:      request.Remaining,
 			Limit:          request.Limit,
 			Resource:       request.Resource,
@@ -164,7 +170,7 @@ func gitHubRESTBucket(usage connector.RESTRateLimitUsage, now time.Time) *teleme
 		Remaining:      rateLimit.Remaining,
 		Used:           rateLimit.Used,
 		Limit:          rateLimit.Limit,
-		Cost:           usage.TotalRequests,
+		Cost:           usage.BillableRequests,
 		ResetAt:        resetAt,
 		ObservedAt:     observedAt,
 		ResetInSeconds: resetInSeconds,
@@ -181,10 +187,14 @@ func (o *Orchestrator) logRESTRateLimitCycle(cycle restRateLimitCycle) {
 		resetAt = *cycle.Bucket.ResetAt
 	}
 	totalRequests := int64(0)
+	billableRequests := int64(0)
+	notModifiedRequests := int64(0)
 	rateLimited := false
 	var contributors []telemetry.RESTUsageContributor
 	if cycle.Usage != nil {
 		totalRequests = cycle.Usage.TotalRequests
+		billableRequests = cycle.Usage.BillableRequests
+		notModifiedRequests = cycle.Usage.NotModifiedRequests
 		rateLimited = cycle.Usage.RateLimited
 		contributors = cycle.Usage.Contributors
 	}
@@ -192,6 +202,8 @@ func (o *Orchestrator) logRESTRateLimitCycle(cycle restRateLimitCycle) {
 	o.logger.Info(
 		"github rest budget summary",
 		"request_count", totalRequests,
+		"billable_request_count", billableRequests,
+		"not_modified_request_count", notModifiedRequests,
 		"rate_limited", rateLimited,
 		"remaining", cycle.Bucket.Remaining,
 		"limit", cycle.Bucket.Limit,

--- a/internal/orchestrator/refresh.go
+++ b/internal/orchestrator/refresh.go
@@ -3,8 +3,10 @@ package orchestrator
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
+	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -25,6 +27,11 @@ type manualRefreshRequest struct {
 	id          string
 	requestedAt time.Time
 	operations  []string
+}
+
+type targetedRefreshRequest struct {
+	manualRefreshRequest
+	target connector.ReconcileTarget
 }
 
 func (o *Orchestrator) RequestRefresh(ctx context.Context) (RefreshResponse, error) {
@@ -59,6 +66,54 @@ func (o *Orchestrator) RequestRefresh(ctx context.Context) (RefreshResponse, err
 		requestedAt: response.RequestedAt,
 		operations:  append([]string(nil), response.Operations...),
 	}:
+		return response, nil
+	default:
+		response.Coalesced = true
+		response.Status = telemetry.RefreshAttemptStatusCoalesced
+		return response, nil
+	}
+}
+
+func (o *Orchestrator) RequestTargetedRefresh(ctx context.Context, target connector.ReconcileTarget) (RefreshResponse, error) {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+
+	requestedAt := time.Now().UTC()
+	operation := "targeted_reconcile"
+	if scope := strings.TrimSpace(target.Scope); scope != "" {
+		operation += ":" + scope
+	}
+	response := RefreshResponse{
+		RequestID:   o.nextManualRefreshID(requestedAt),
+		Status:      telemetry.RefreshAttemptStatusInProgress,
+		Queued:      true,
+		RequestedAt: requestedAt,
+		Operations:  []string{operation},
+	}
+	request := targetedRefreshRequest{
+		manualRefreshRequest: manualRefreshRequest{
+			id:          response.RequestID,
+			requestedAt: response.RequestedAt,
+			operations:  append([]string(nil), response.Operations...),
+		},
+		target: target,
+	}
+
+	select {
+	case <-ctx.Done():
+		return RefreshResponse{}, ctx.Err()
+	case <-o.done:
+		return RefreshResponse{}, ErrStopped
+	default:
+	}
+
+	select {
+	case <-ctx.Done():
+		return RefreshResponse{}, ctx.Err()
+	case <-o.done:
+		return RefreshResponse{}, ErrStopped
+	case o.reconciles <- request:
 		return response, nil
 	default:
 		response.Coalesced = true

--- a/internal/orchestrator/targeted_reconcile.go
+++ b/internal/orchestrator/targeted_reconcile.go
@@ -1,0 +1,195 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+func (o *Orchestrator) reconcileTarget(ctx context.Context, state *State, request targetedRefreshRequest) {
+	reconciler, ok := o.connector.(connector.TargetedReconciler)
+	if !ok {
+		fallback := request.manualRefreshRequest
+		fallback.operations = append(fallback.operations, "full_refresh_fallback")
+		o.tickWithManual(ctx, state, request.requestedAt, &fallback)
+		return
+	}
+
+	now := o.now().UTC()
+	startManualRefresh(state, request.manualRefreshRequest, now)
+	o.markRefresh(state, now)
+	completed := false
+	defer func() {
+		o.finishRefresh(state, now)
+		finishManualRefresh(state, request.manualRefreshRequest, completed)
+	}()
+
+	result, err := reconciler.ReconcileIssue(ctx, request.target)
+	if err != nil {
+		message := "targeted tracker reconcile failed: " + err.Error()
+		markRefreshError(state, message, now)
+		recordStateEvent(state, telemetry.ActivityEvent{At: now, Event: "targeted_reconcile_failed", Message: message})
+		return
+	}
+
+	o.applyTargetedReconcile(ctx, state, request.target, result, now)
+	clearRefreshError(state)
+	o.markRefreshSucceeded(state, now)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      now,
+		Event:   "targeted_reconcile_succeeded",
+		Message: targetedReconcileMessage(request.target, result),
+	})
+	completed = true
+}
+
+func (o *Orchestrator) applyTargetedReconcile(
+	ctx context.Context,
+	state *State,
+	target connector.ReconcileTarget,
+	result connector.ReconcileResult,
+	now time.Time,
+) {
+	if !result.Found || strings.TrimSpace(result.Issue.ID) == "" {
+		state.BoardIssues = removeTargetedIssue(state.BoardIssues, target, result.Issue)
+		state.Pipeline = removeTargetedIssue(state.Pipeline, target, result.Issue)
+		state.epicTransitionWatch = removeTargetedIssue(state.epicTransitionWatch, target, result.Issue)
+		return
+	}
+
+	issue := mergeTargetedIssue(state, result.Issue, now)
+	visibleStates := append(append([]string(nil), o.cfg.ActiveStates...), o.cfg.ObservedStates...)
+	state.BoardIssues = reconcileTargetedIssueSlice(state.BoardIssues, issue, stateIn(issue.State, visibleStates))
+	state.Pipeline = reconcileTargetedIssueSlice(state.Pipeline, issue, stateIn(issue.State, autoPromoteFetchStates(o.cfg.AutoPromote)))
+	state.epicTransitionWatch = reconcileTargetedIssueSlice(state.epicTransitionWatch, issue, stateIn(issue.State, o.cfg.ActiveStates))
+	o.updateTargetedIssueEntries(state, issue)
+
+	if normalizeState(issue.State) == normalizeState(blockedStatusState) {
+		o.setBlockedStatusIssue(state, issue, now)
+	} else {
+		clearBlockedStatusIssue(state, issue.ID)
+	}
+
+	if running, ok := state.Running[issue.ID]; ok && workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		o.completeTerminalRunning(ctx, state, issue.ID, running, terminalCompletedAt(running.Issue, o.cfg.TerminalStates, now), running.Tokens)
+	}
+}
+
+func mergeTargetedIssue(state *State, refreshed connector.Issue, now time.Time) connector.Issue {
+	current, ok := targetedIssueFromState(state, refreshed)
+	if !ok {
+		return cloneIssue(refreshed)
+	}
+	stateChanged := normalizeState(current.State) != normalizeState(refreshed.State)
+	merged := mergeIssueTrackerFields(current, refreshed)
+	if stateChanged {
+		if refreshed.StageUpdatedAt != nil {
+			merged.StageUpdatedAt = timePointerFromPtr(refreshed.StageUpdatedAt)
+		} else if refreshed.UpdatedAt != nil {
+			merged.StageUpdatedAt = timePointerFromPtr(refreshed.UpdatedAt)
+		} else {
+			merged.StageUpdatedAt = timePointer(now)
+		}
+	}
+	return merged
+}
+
+func targetedIssueFromState(state *State, issue connector.Issue) (connector.Issue, bool) {
+	if state == nil {
+		return connector.Issue{}, false
+	}
+	for _, issues := range [][]connector.Issue{state.BoardIssues, state.Pipeline, state.epicTransitionWatch} {
+		for _, current := range issues {
+			if targetedIssuesMatch(current, issue) {
+				return current, true
+			}
+		}
+	}
+	if running, ok := state.Running[strings.TrimSpace(issue.ID)]; ok {
+		return running.Issue, true
+	}
+	return connector.Issue{}, false
+}
+
+func reconcileTargetedIssueSlice(issues []connector.Issue, issue connector.Issue, keep bool) []connector.Issue {
+	out := make([]connector.Issue, 0, len(issues)+1)
+	found := false
+	for _, current := range issues {
+		if !targetedIssuesMatch(current, issue) {
+			out = append(out, cloneIssue(current))
+			continue
+		}
+		found = true
+		if keep {
+			out = append(out, cloneIssue(issue))
+		}
+	}
+	if keep && !found {
+		out = append(out, cloneIssue(issue))
+	}
+	return out
+}
+
+func removeTargetedIssue(issues []connector.Issue, target connector.ReconcileTarget, issue connector.Issue) []connector.Issue {
+	out := make([]connector.Issue, 0, len(issues))
+	identifier := ""
+	if target.WorkItemNumber > 0 && strings.TrimSpace(target.Scope) != "" {
+		identifier = fmt.Sprintf("%s#%d", strings.TrimSpace(target.Scope), target.WorkItemNumber)
+	}
+	for _, current := range issues {
+		if targetedIssuesMatch(current, issue) || identifier != "" && strings.EqualFold(strings.TrimSpace(current.Identifier), identifier) {
+			continue
+		}
+		out = append(out, cloneIssue(current))
+	}
+	return out
+}
+
+func targetedIssuesMatch(left connector.Issue, right connector.Issue) bool {
+	if leftID, rightID := strings.TrimSpace(left.ID), strings.TrimSpace(right.ID); leftID != "" && rightID != "" {
+		return leftID == rightID
+	}
+	if leftIdentifier, rightIdentifier := strings.TrimSpace(left.Identifier), strings.TrimSpace(right.Identifier); leftIdentifier != "" && rightIdentifier != "" {
+		return strings.EqualFold(leftIdentifier, rightIdentifier)
+	}
+	return false
+}
+
+func (o *Orchestrator) updateTargetedIssueEntries(state *State, issue connector.Issue) {
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return
+	}
+	if running, ok := state.Running[issueID]; ok {
+		running.Issue = mergeIssueTrackerFields(running.Issue, issue)
+		state.Running[issueID] = running
+	}
+	if claimed, ok := state.Claimed[issueID]; ok {
+		claimed.Issue = mergeIssueTrackerFields(claimed.Issue, issue)
+		state.Claimed[issueID] = claimed
+	}
+	if retry, ok := state.Retry[issueID]; ok {
+		retry.Issue = mergeIssueTrackerFields(retry.Issue, issue)
+		state.Retry[issueID] = retry
+	}
+	if blocked, ok := state.Blocked[issueID]; ok {
+		blocked.Issue = mergeIssueTrackerFields(blocked.Issue, issue)
+		state.Blocked[issueID] = blocked
+	}
+	if completed, ok := state.Completed[issueID]; ok {
+		completed.Issue = mergeIssueTrackerFields(completed.Issue, issue)
+		state.Completed[issueID] = completed
+	}
+	delete(state.AutoPromoteDecisions, issueID)
+}
+
+func targetedReconcileMessage(target connector.ReconcileTarget, result connector.ReconcileResult) string {
+	if result.Found {
+		return "reconciled " + issueLabel(result.Issue) + " from " + strings.TrimSpace(target.Event)
+	}
+	return "targeted tracker item is no longer visible: " + strings.TrimSpace(target.Scope)
+}

--- a/internal/orchestrator/targeted_reconcile_test.go
+++ b/internal/orchestrator/targeted_reconcile_test.go
@@ -1,0 +1,161 @@
+package orchestrator_test
+
+import (
+	"context"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/orchestrator"
+)
+
+func TestTargetedReconcileUpdatesBoardWithoutFullPoll(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		result    connector.ReconcileResult
+		wantCount int
+		wantState string
+	}{
+		{
+			name: "external label transition",
+			result: connector.ReconcileResult{
+				Found: true,
+				Issue: targetedReconcileIssue("In Progress"),
+			},
+			wantCount: 1,
+			wantState: "In Progress",
+		},
+		{
+			name: "configured label removed",
+			result: connector.ReconcileResult{
+				Found: true,
+				Issue: targetedReconcileIssue("Open"),
+			},
+			wantCount: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			initial := targetedReconcileIssue("Backlog")
+			base := newFakeConnector()
+			base.stateIssues = []connector.Issue{initial}
+			tracker := &targetedConnector{fakeConnector: base, result: tt.result}
+			orch, err := orchestrator.New(orchestrator.Config{
+				PollInterval:        time.Hour,
+				MaxConcurrentAgents: 1,
+				ActiveStates:        []string{"Todo", "In Progress"},
+				ObservedStates:      []string{"Backlog"},
+				TerminalStates:      []string{"Done"},
+			}, orchestrator.Dependencies{Connector: tracker})
+			if err != nil {
+				t.Fatalf("New() error = %v", err)
+			}
+
+			ctx, cancel := context.WithCancel(context.Background())
+			done := make(chan error, 1)
+			go func() { done <- orch.Run(ctx) }()
+			t.Cleanup(func() {
+				cancel()
+				<-done
+			})
+
+			initialState := waitForTargetedState(t, orch, func(state orchestrator.State) bool {
+				return state.DataSeq >= 1 && len(state.BoardIssues) == 1
+			})
+			initialFetches := base.fetchCounts()
+			response, err := orch.RequestTargetedRefresh(context.Background(), connector.ReconcileTarget{
+				Scope:          "digitaldrywood/detent",
+				WorkItemNumber: 1133,
+				Event:          "issues",
+			})
+			if err != nil {
+				t.Fatalf("RequestTargetedRefresh() error = %v", err)
+			}
+			if !response.Queued || response.Coalesced {
+				t.Fatalf("RequestTargetedRefresh() = %#v, want queued", response)
+			}
+
+			state := waitForTargetedState(t, orch, func(state orchestrator.State) bool {
+				return state.DataSeq > initialState.DataSeq
+			})
+			if len(state.BoardIssues) != tt.wantCount {
+				t.Fatalf("BoardIssues = %#v, want %d items", state.BoardIssues, tt.wantCount)
+			}
+			if tt.wantCount > 0 {
+				if state.BoardIssues[0].State != tt.wantState {
+					t.Fatalf("BoardIssues[0].State = %q, want %q", state.BoardIssues[0].State, tt.wantState)
+				}
+				if state.BoardIssues[0].StageUpdatedAt == nil || !state.BoardIssues[0].StageUpdatedAt.Equal(*tt.result.Issue.UpdatedAt) {
+					t.Fatalf("StageUpdatedAt = %v, want external update time %v", state.BoardIssues[0].StageUpdatedAt, tt.result.Issue.UpdatedAt)
+				}
+			}
+			if got := base.fetchCounts(); got != initialFetches {
+				t.Fatalf("full fetch count = %d after targeted reconcile, want unchanged %d", got, initialFetches)
+			}
+			if got := tracker.reconcileCount(); got != 1 {
+				t.Fatalf("ReconcileIssue() calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
+type targetedConnector struct {
+	*fakeConnector
+	mu         sync.Mutex
+	result     connector.ReconcileResult
+	reconciles int
+}
+
+func (c *targetedConnector) ReconcileIssue(context.Context, connector.ReconcileTarget) (connector.ReconcileResult, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	c.reconciles++
+	return c.result, nil
+}
+
+func (c *targetedConnector) reconcileCount() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.reconciles
+}
+
+func (c *fakeConnector) fetchCounts() int {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	return c.fetchCandidateCount + c.fetchByStatesCount
+}
+
+func targetedReconcileIssue(state string) connector.Issue {
+	updatedAt := time.Date(2026, 7, 10, 12, 30, 0, 0, time.UTC)
+	issue := connector.NewIssue()
+	issue.ID = "issue-1133"
+	issue.Identifier = "digitaldrywood/detent#1133"
+	issue.Title = "Board freshness"
+	issue.State = state
+	issue.URL = "https://github.com/digitaldrywood/detent/issues/1133"
+	issue.UpdatedAt = &updatedAt
+	return issue
+}
+
+func waitForTargetedState(t *testing.T, orch *orchestrator.Orchestrator, ready func(orchestrator.State) bool) orchestrator.State {
+	t.Helper()
+
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		ctx, cancel := context.WithTimeout(context.Background(), 100*time.Millisecond)
+		state, err := orch.State(ctx)
+		cancel()
+		if err == nil && ready(state) {
+			return state
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatal("timed out waiting for targeted reconcile state")
+	return orchestrator.State{}
+}

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -502,13 +502,18 @@ func (o *Orchestrator) githubBudgetReserveDecision(state *State) githubBudgetRes
 		graphRemaining: gitHubGraphQLRemaining(state),
 		graphReserve:   o.cfg.GitHubGraphQLMinReserve,
 	}
-	if bucket := gitHubRESTBucketFromState(state); budgetBelowReserve(bucket, o.cfg.GitHubRESTMinReserve) {
+	if bucket := gitHubRESTBucketFromState(state); budgetBelowReserve(bucket, o.cfg.GitHubRESTMinReserve) && !o.conditionalPollingEnabled() {
 		decision.degraded = true
 	}
 	if bucket := gitHubGraphQLBucketFromState(state); budgetBelowReserve(bucket, o.cfg.GitHubGraphQLMinReserve) {
 		decision.degraded = true
 	}
 	return decision
+}
+
+func (o *Orchestrator) conditionalPollingEnabled() bool {
+	poller, ok := o.connector.(connector.ConditionalPoller)
+	return ok && poller.ConditionalPollingEnabled()
 }
 
 func budgetBelowReserve(bucket *telemetry.RateLimitBucket, reserve int64) bool {

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -1059,6 +1059,7 @@ func defaultConnectorFactoryWithRefresh(cfg workflowconfig.Config, refreshGitHub
 		GitHubRESTMinReserve:        cfg.Tracker.GitHubRESTMinReserve,
 		GitHubRESTFanoutMaxRequests: cfg.Tracker.GitHubRESTFanoutMaxRequests,
 		GitHubRESTDebugLogging:      cfg.Tracker.GitHubRESTDebugLogging,
+		ConditionalRequests:         &cfg.Polling.Conditional,
 		GitHubAppID:                 cfg.Tracker.GitHubAppID,
 		GitHubAppPrivateKey:         cfg.Tracker.GitHubAppPrivateKey,
 		GitHubAppPrivateKeyPath:     cfg.Tracker.GitHubAppPrivateKeyPath,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -522,15 +522,21 @@ type GraphQLCostContributor struct {
 }
 
 type RESTUsage struct {
-	TotalRequests int64                  `json:"total_requests,omitempty"`
-	RateLimited   bool                   `json:"rate_limited,omitempty"`
-	BackoffUntil  *time.Time             `json:"backoff_until,omitempty"`
-	Contributors  []RESTUsageContributor `json:"contributors,omitempty"`
+	TotalRequests       int64                  `json:"total_requests,omitempty"`
+	ConditionalRequests int64                  `json:"conditional_requests,omitempty"`
+	NotModifiedRequests int64                  `json:"not_modified_requests,omitempty"`
+	BillableRequests    int64                  `json:"billable_requests,omitempty"`
+	RateLimited         bool                   `json:"rate_limited,omitempty"`
+	BackoffUntil        *time.Time             `json:"backoff_until,omitempty"`
+	Contributors        []RESTUsageContributor `json:"contributors,omitempty"`
 }
 
 type RESTUsageContributor struct {
 	EndpointFamily string     `json:"endpoint_family"`
 	Count          int64      `json:"count"`
+	Conditional    int64      `json:"conditional,omitempty"`
+	NotModified    int64      `json:"not_modified,omitempty"`
+	Billable       int64      `json:"billable,omitempty"`
 	Remaining      int64      `json:"remaining,omitempty"`
 	Limit          int64      `json:"limit,omitempty"`
 	Resource       string     `json:"resource,omitempty"`

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -39,12 +39,14 @@ type TargetedRefresher interface {
 }
 
 type RefreshTarget struct {
-	Repository        string `json:"repository,omitempty"`
-	IssueNumber       int    `json:"issue_number,omitempty"`
-	PullRequestNumber int    `json:"pull_request_number,omitempty"`
-	SHA               string `json:"sha,omitempty"`
-	Event             string `json:"event,omitempty"`
-	DeliveryID        string `json:"delivery_id,omitempty"`
+	Repository        string   `json:"repository,omitempty"`
+	IssueNumber       int      `json:"issue_number,omitempty"`
+	PullRequestNumber int      `json:"pull_request_number,omitempty"`
+	SHA               string   `json:"sha,omitempty"`
+	Branch            string   `json:"branch,omitempty"`
+	Event             string   `json:"event,omitempty"`
+	DeliveryID        string   `json:"delivery_id,omitempty"`
+	ProjectIDs        []string `json:"-"`
 }
 
 type RefreshResponse = orchestrator.RefreshResponse

--- a/internal/web/github_webhook.go
+++ b/internal/web/github_webhook.go
@@ -110,6 +110,9 @@ func githubWebhookTarget(event string, deliveryID string, body []byte) (RefreshT
 			PullRequests []struct {
 				Number int `json:"number"`
 			} `json:"pull_requests"`
+			CheckSuite struct {
+				HeadBranch string `json:"head_branch"`
+			} `json:"check_suite"`
 		} `json:"check_run"`
 		CheckSuite *struct {
 			HeadSHA      string `json:"head_sha"`
@@ -147,6 +150,7 @@ func githubWebhookTarget(event string, deliveryID string, body []byte) (RefreshT
 	}
 	if payload.CheckRun != nil {
 		target.SHA = strings.TrimSpace(payload.CheckRun.HeadSHA)
+		target.Branch = strings.TrimSpace(payload.CheckRun.CheckSuite.HeadBranch)
 		if len(payload.CheckRun.PullRequests) > 0 {
 			target.PullRequestNumber = payload.CheckRun.PullRequests[0].Number
 		}

--- a/internal/web/github_webhook.go
+++ b/internal/web/github_webhook.go
@@ -11,15 +11,13 @@ import (
 	"strings"
 
 	"github.com/labstack/echo/v4"
+
+	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 )
 
 const githubWebhookMaxBodyBytes = 2 << 20
 
 func (s *Server) githubWebhook(c echo.Context) error {
-	secret := strings.TrimSpace(s.githubWebhookSecret)
-	if secret == "" {
-		return c.JSON(http.StatusNotFound, errorResponse("webhook_not_configured", "GitHub webhook is not configured"))
-	}
 	if s.refresher == nil {
 		return c.JSON(http.StatusServiceUnavailable, errorResponse("orchestrator_unavailable", "Orchestrator is unavailable"))
 	}
@@ -30,13 +28,32 @@ func (s *Server) githubWebhook(c echo.Context) error {
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, errorResponse("invalid_payload", "Webhook payload is invalid"))
 	}
-	if !validGitHubWebhookSignature(secret, body, req.Header.Get("X-Hub-Signature-256")) {
-		return c.JSON(http.StatusUnauthorized, errorResponse("invalid_signature", "Webhook signature is invalid"))
-	}
-
 	target, err := githubWebhookTarget(req.Header.Get("X-GitHub-Event"), req.Header.Get("X-GitHub-Delivery"), body)
 	if err != nil {
 		return c.JSON(http.StatusBadRequest, errorResponse("invalid_payload", "Webhook payload is invalid"))
+	}
+	routes := s.githubWebhookRoutes(target.Repository)
+	if len(routes) == 0 {
+		return c.JSON(http.StatusNotFound, errorResponse("webhook_not_configured", "GitHub webhook is not configured for this project"))
+	}
+	validSignature := false
+	for _, route := range routes {
+		if !validGitHubWebhookSignature(route.secret, body, req.Header.Get("X-Hub-Signature-256")) {
+			continue
+		}
+		validSignature = true
+		if route.projectID != "" {
+			target.ProjectIDs = append(target.ProjectIDs, route.projectID)
+		}
+	}
+	if !validSignature {
+		return c.JSON(http.StatusUnauthorized, errorResponse("invalid_signature", "Webhook signature is invalid"))
+	}
+	if !githubWebhookRefreshEvent(target.Event) {
+		return c.JSON(http.StatusAccepted, RefreshResponse{
+			RequestedAt: apiNow(),
+			Operations:  []string{"webhook_ignored:" + target.Event},
+		})
 	}
 	response, err := s.requestWebhookRefresh(req.Context(), target)
 	if err != nil {
@@ -47,6 +64,15 @@ func (s *Server) githubWebhook(c echo.Context) error {
 	}
 	response.Operations = prependOperation(response.Operations, "webhook:"+target.Event)
 	return c.JSON(http.StatusAccepted, response)
+}
+
+func githubWebhookRefreshEvent(event string) bool {
+	switch strings.ToLower(strings.TrimSpace(event)) {
+	case "issues", "label", "pull_request", "check_suite", "check_run":
+		return true
+	default:
+		return false
+	}
 }
 
 func validGitHubWebhookSignature(secret string, body []byte, signature string) bool {
@@ -76,6 +102,7 @@ func githubWebhookTarget(event string, deliveryID string, body []byte) (RefreshT
 			Number int `json:"number"`
 			Head   struct {
 				SHA string `json:"sha"`
+				Ref string `json:"ref"`
 			} `json:"head"`
 		} `json:"pull_request"`
 		CheckRun *struct {
@@ -84,6 +111,13 @@ func githubWebhookTarget(event string, deliveryID string, body []byte) (RefreshT
 				Number int `json:"number"`
 			} `json:"pull_requests"`
 		} `json:"check_run"`
+		CheckSuite *struct {
+			HeadSHA      string `json:"head_sha"`
+			HeadBranch   string `json:"head_branch"`
+			PullRequests []struct {
+				Number int `json:"number"`
+			} `json:"pull_requests"`
+		} `json:"check_suite"`
 		SHA string `json:"sha"`
 	}
 	if err := json.Unmarshal(body, &payload); err != nil {
@@ -102,6 +136,14 @@ func githubWebhookTarget(event string, deliveryID string, body []byte) (RefreshT
 	if payload.PullRequest != nil {
 		target.PullRequestNumber = payload.PullRequest.Number
 		target.SHA = strings.TrimSpace(payload.PullRequest.Head.SHA)
+		target.Branch = strings.TrimSpace(payload.PullRequest.Head.Ref)
+	}
+	if payload.CheckSuite != nil {
+		target.SHA = strings.TrimSpace(payload.CheckSuite.HeadSHA)
+		target.Branch = strings.TrimSpace(payload.CheckSuite.HeadBranch)
+		if len(payload.CheckSuite.PullRequests) > 0 {
+			target.PullRequestNumber = payload.CheckSuite.PullRequests[0].Number
+		}
 	}
 	if payload.CheckRun != nil {
 		target.SHA = strings.TrimSpace(payload.CheckRun.HeadSHA)
@@ -119,6 +161,50 @@ func githubWebhookTarget(event string, deliveryID string, body []byte) (RefreshT
 		target.Event = "unknown"
 	}
 	return target, nil
+}
+
+type githubWebhookRoute struct {
+	projectID string
+	secret    string
+}
+
+func (s *Server) githubWebhookRoutes(repository string) []githubWebhookRoute {
+	repository = strings.TrimSpace(repository)
+	routes := []githubWebhookRoute{}
+	if s.registry != nil && s.registry.Len() > 0 {
+		for _, trackedProject := range s.registry.List() {
+			workflow := trackedProject.Workflow().Config
+			if workflow.Tracker.Kind != workflowconfig.TrackerGitHub && workflow.Tracker.Kind != workflowconfig.TrackerGitHubLocal {
+				continue
+			}
+			configuredRepository := strings.TrimSpace(workflow.Tracker.Repository)
+			if configuredRepository != "" && !strings.EqualFold(configuredRepository, repository) {
+				continue
+			}
+			secret := s.resolveGitHubWebhookSecret(workflow.Tracker.GitHubWebhookSecret)
+			if secret == "" {
+				continue
+			}
+			routes = append(routes, githubWebhookRoute{projectID: string(trackedProject.ID()), secret: secret})
+		}
+		return routes
+	}
+	if secret := s.resolveGitHubWebhookSecret(s.githubWebhookSecret); secret != "" {
+		routes = append(routes, githubWebhookRoute{secret: secret})
+	}
+	return routes
+}
+
+func (s *Server) resolveGitHubWebhookSecret(value string) string {
+	value = strings.TrimSpace(value)
+	if value == "" || !strings.HasPrefix(value, "$") {
+		return value
+	}
+	key := strings.TrimSpace(strings.Trim(value[1:], "{}"))
+	if key == "" {
+		return ""
+	}
+	return strings.TrimSpace(s.lookupEnv(key))
 }
 
 func (s *Server) requestWebhookRefresh(ctx context.Context, target RefreshTarget) (RefreshResponse, error) {

--- a/internal/web/github_webhook_test.go
+++ b/internal/web/github_webhook_test.go
@@ -111,6 +111,38 @@ func TestGitHubWebhookRoutesPerProjectAndParsesCheckSuite(t *testing.T) {
 	}
 }
 
+func TestGitHubWebhookParsesCheckRunBranchWithoutPullRequest(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	refresher := &targetedRefreshProbe{response: web.RefreshResponse{Queued: true}}
+	deps.Refresher = refresher
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.GitHubWebhookSecret = "webhook-secret"
+	server, err := web.NewServer(web.Config{KanbanWorkflow: workflowCfg}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := `{"repository":{"full_name":"digitaldrywood/detent"},"check_run":{"head_sha":"abc123","pull_requests":[],"check_suite":{"head_branch":"detent/digitaldrywood_detent_1133-feature"}}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "check_run")
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("webhook-secret", []byte(body)))
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s, want %d", rec.Code, rec.Body.String(), http.StatusAccepted)
+	}
+	if refresher.targetCalls != 1 {
+		t.Fatalf("target refresh calls = %d, want 1", refresher.targetCalls)
+	}
+	if refresher.target.PullRequestNumber != 0 || refresher.target.SHA != "abc123" || refresher.target.Branch != "detent/digitaldrywood_detent_1133-feature" {
+		t.Fatalf("check run target = %#v, want branch-only target at abc123", refresher.target)
+	}
+}
+
 func TestGitHubWebhookDoesNotFallbackForUnknownRepository(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/github_webhook_test.go
+++ b/internal/web/github_webhook_test.go
@@ -13,6 +13,9 @@ import (
 	"time"
 
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
+	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/web"
 )
 
@@ -65,6 +68,106 @@ func TestGitHubWebhookVerifiesSignatureAndTargetsRefresh(t *testing.T) {
 	}
 }
 
+func TestGitHubWebhookRoutesPerProjectAndParsesCheckSuite(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	refresher := &targetedRefreshProbe{response: web.RefreshResponse{Queued: true}}
+	deps.Refresher = refresher
+	addWebhookProject(t, deps.Registry, "detent", "digitaldrywood/detent", "$DETENT_WEBHOOK_SECRET")
+	addWebhookProject(t, deps.Registry, "other", "digitaldrywood/other", "other-secret")
+	server, err := web.NewServer(web.Config{
+		LookupEnv: func(key string) string {
+			if key == "DETENT_WEBHOOK_SECRET" {
+				return "detent-secret"
+			}
+			return ""
+		},
+	}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := `{"repository":{"full_name":"digitaldrywood/detent"},"check_suite":{"head_sha":"abc123","head_branch":"detent/digitaldrywood_detent_1133-feature","pull_requests":[{"number":1134}]}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "check_suite")
+	req.Header.Set("X-GitHub-Delivery", "delivery-suite")
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("detent-secret", []byte(body)))
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s, want %d", rec.Code, rec.Body.String(), http.StatusAccepted)
+	}
+	if refresher.targetCalls != 1 {
+		t.Fatalf("target refresh calls = %d, want 1", refresher.targetCalls)
+	}
+	if len(refresher.target.ProjectIDs) != 1 || refresher.target.ProjectIDs[0] != "detent" {
+		t.Fatalf("target project IDs = %#v, want [detent]", refresher.target.ProjectIDs)
+	}
+	if refresher.target.PullRequestNumber != 1134 || refresher.target.SHA != "abc123" || refresher.target.Branch != "detent/digitaldrywood_detent_1133-feature" {
+		t.Fatalf("check suite target = %#v, want PR 1134 at abc123", refresher.target)
+	}
+}
+
+func TestGitHubWebhookDoesNotFallbackForUnknownRepository(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	refresher := &targetedRefreshProbe{}
+	deps.Refresher = refresher
+	addWebhookProject(t, deps.Registry, "detent", "digitaldrywood/detent", "detent-secret")
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := `{"repository":{"full_name":"digitaldrywood/unknown"},"issue":{"number":1133}}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "issues")
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("detent-secret", []byte(body)))
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d body = %s, want %d", rec.Code, rec.Body.String(), http.StatusNotFound)
+	}
+	if refresher.calls != 0 || refresher.targetCalls != 0 {
+		t.Fatalf("refresh calls = full %d targeted %d, want none", refresher.calls, refresher.targetCalls)
+	}
+}
+
+func TestGitHubWebhookIgnoresUnrelatedEvent(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	refresher := &targetedRefreshProbe{}
+	deps.Refresher = refresher
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.GitHubWebhookSecret = "webhook-secret"
+	server, err := web.NewServer(web.Config{KanbanWorkflow: workflowCfg}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	body := `{"repository":{"full_name":"digitaldrywood/detent"},"ref":"refs/heads/main"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/webhooks/github", strings.NewReader(body))
+	req.Header.Set("X-GitHub-Event", "push")
+	req.Header.Set("X-Hub-Signature-256", githubWebhookSignature("webhook-secret", []byte(body)))
+	rec := httptest.NewRecorder()
+
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s, want %d", rec.Code, rec.Body.String(), http.StatusAccepted)
+	}
+	if refresher.calls != 0 || refresher.targetCalls != 0 {
+		t.Fatalf("refresh calls = full %d targeted %d, want none", refresher.calls, refresher.targetCalls)
+	}
+}
+
 func TestGitHubWebhookRejectsInvalidSignature(t *testing.T) {
 	t.Parallel()
 
@@ -98,6 +201,27 @@ func githubWebhookSignature(secret string, body []byte) string {
 	mac := hmac.New(sha256.New, []byte(secret))
 	mac.Write(body)
 	return "sha256=" + hex.EncodeToString(mac.Sum(nil))
+}
+
+func addWebhookProject(t *testing.T, registry *project.Registry, id string, repository string, secret string) {
+	t.Helper()
+
+	workflow := workflowconfig.Default()
+	workflow.Tracker.Kind = workflowconfig.TrackerGitHub
+	workflow.Tracker.APIKey = "test-token"
+	workflow.Tracker.GitHubStatusSource = workflowconfig.GitHubStatusSourceLabel
+	workflow.Tracker.Repository = repository
+	workflow.Tracker.GitHubWebhookSecret = secret
+	trackedProject, err := project.New(project.Config{
+		Project:  globalconfig.Project{ID: id, Workdir: t.TempDir(), Weight: 1},
+		Workflow: workflowconfig.Workflow{Config: workflow, Prompt: "Work the issue."},
+	}, project.Dependencies{Connector: memory.New(memory.Config{})})
+	if err != nil {
+		t.Fatalf("project.New() error = %v", err)
+	}
+	if err := registry.Set(trackedProject); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
 }
 
 type targetedRefreshProbe struct {

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -479,8 +479,11 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 			if cfg.Tracker.GitHubStatusSource != tt.source {
 				t.Fatalf("GitHubStatusSource = %q, want %q", cfg.Tracker.GitHubStatusSource, tt.source)
 			}
-			if cfg.Polling.IntervalMS != workflowconfig.DefaultPollingIntervalMS {
-				t.Fatalf("Polling.IntervalMS = %d, want %d", cfg.Polling.IntervalMS, workflowconfig.DefaultPollingIntervalMS)
+			if cfg.Polling.IntervalMS != workflowconfig.MinPollingIntervalMS {
+				t.Fatalf("Polling.IntervalMS = %d, want %d", cfg.Polling.IntervalMS, workflowconfig.MinPollingIntervalMS)
+			}
+			if !cfg.Polling.Conditional {
+				t.Fatal("Polling.Conditional = false, want true")
 			}
 			assertContains(t, content, "max_concurrent_agents_by_state:\n    Merging: 1")
 			if cfg.Agent.MaxConcurrentAgentsByState["merging"] != 1 {
@@ -505,6 +508,19 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 				t.Fatalf("WriteProbeIssue = %q, want blank", cfg.Tracker.WriteProbeIssue)
 			}
 		})
+	}
+}
+
+func TestGitHubLocalWorkflowTemplateUsesAffordablePolling(t *testing.T) {
+	t.Parallel()
+
+	content := readRepositoryTextFile(t, "docs/templates/WORKFLOW.github_local.md")
+	workflow, err := workflowconfig.ParseWorkflow([]byte(content))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if workflow.Config.Polling.IntervalMS != workflowconfig.MinPollingIntervalMS || !workflow.Config.Polling.Conditional {
+		t.Fatalf("Polling = %#v, want one-minute conditional polling", workflow.Config.Polling)
 	}
 }
 

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -426,6 +426,7 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 		wantStatusField  string
 		wantStatusPrefix string
 		wantWriteProbe   bool
+		wantIntervalMS   int
 	}{
 		{
 			path:            "docs/templates/WORKFLOW.project_v2.md",
@@ -433,6 +434,7 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 			want:            []string{"github_status_source: project_v2", "project_slug: <project-node-id>"},
 			unwanted:        []string{"repository: <repo-owner>/<repo-name>", "write_probe_issue:"},
 			wantProjectSlug: true,
+			wantIntervalMS:  workflowconfig.DefaultPollingIntervalMS,
 		},
 		{
 			path:            "docs/templates/WORKFLOW.issue_field.md",
@@ -441,6 +443,7 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 			unwanted:        []string{"project_slug:", "write_probe_issue:"},
 			wantRepository:  true,
 			wantStatusField: "Status",
+			wantIntervalMS:  workflowconfig.MinPollingIntervalMS,
 		},
 		{
 			path:             "docs/templates/WORKFLOW.label.md",
@@ -449,6 +452,7 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 			unwanted:         []string{"project_slug:", "status_field:", "write_probe_issue:"},
 			wantRepository:   true,
 			wantStatusPrefix: "detent:",
+			wantIntervalMS:   workflowconfig.MinPollingIntervalMS,
 		},
 	}
 
@@ -479,8 +483,8 @@ func TestWorkflowTemplatesAreCurrentAndModeSpecific(t *testing.T) {
 			if cfg.Tracker.GitHubStatusSource != tt.source {
 				t.Fatalf("GitHubStatusSource = %q, want %q", cfg.Tracker.GitHubStatusSource, tt.source)
 			}
-			if cfg.Polling.IntervalMS != workflowconfig.MinPollingIntervalMS {
-				t.Fatalf("Polling.IntervalMS = %d, want %d", cfg.Polling.IntervalMS, workflowconfig.MinPollingIntervalMS)
+			if cfg.Polling.IntervalMS != tt.wantIntervalMS {
+				t.Fatalf("Polling.IntervalMS = %d, want %d", cfg.Polling.IntervalMS, tt.wantIntervalMS)
 			}
 			if !cfg.Polling.Conditional {
 				t.Fatal("Polling.Conditional = false, want true")


### PR DESCRIPTION
## Summary

- Cache GitHub REST ETags and reuse cached payloads on free `304 Not Modified` responses, including hydration endpoints and billable-request telemetry.
- Route signed GitHub webhooks per project and reconcile only the affected issue through a tracker-neutral interface.
- Document one-minute conditional polling, webhook configuration, and relay/tunnel options.

Fixes #1133

## UI Surface Contract

- [x] N/A; this changes tracker freshness and rate-limit telemetry without changing dashboard layout or density.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make check`