### PR TITLE
docs: document issue effort selection

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,6 +6,12 @@ labels: "bug, detent:backlog"
 assignees: ""
 ---
 
+<!-- Choose effort using the AGENTS.md/CLAUDE.md rubric; leave model unset. -->
+<!-- ```detent-agent -->
+<!-- schema: 1 -->
+<!-- effort: medium -->
+<!-- ``` -->
+
 ## Summary
 
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,7 +6,7 @@ labels: "bug, detent:backlog"
 assignees: ""
 ---
 
-<!-- Choose effort using the AGENTS.md/CLAUDE.md rubric; leave model unset. -->
+<!-- Uncomment this block and choose effort using the AGENTS.md/CLAUDE.md rubric; leave model unset. -->
 <!-- ```detent-agent -->
 <!-- schema: 1 -->
 <!-- effort: medium -->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,6 +6,12 @@ labels: "detent:backlog"
 assignees: ""
 ---
 
+<!-- Choose effort using the AGENTS.md/CLAUDE.md rubric; leave model unset. -->
+<!-- ```detent-agent -->
+<!-- schema: 1 -->
+<!-- effort: medium -->
+<!-- ``` -->
+
 ## Summary
 
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,7 +6,7 @@ labels: "detent:backlog"
 assignees: ""
 ---
 
-<!-- Choose effort using the AGENTS.md/CLAUDE.md rubric; leave model unset. -->
+<!-- Uncomment this block and choose effort using the AGENTS.md/CLAUDE.md rubric; leave model unset. -->
 <!-- ```detent-agent -->
 <!-- schema: 1 -->
 <!-- effort: medium -->

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,3 +3,22 @@
 - For future requested product or code changes, do not implement directly by default.
 - Create a focused GitHub issue in `digitaldrywood/detent`, add `detent:todo`, and let Detent dogfood the work.
 - Only make direct code changes when the human explicitly asks for manual implementation, asks to finish an already-started fix, or asks for local review and diagnostics that require edits.
+
+## Issue effort selection
+
+Every issue created for this repository must include an explicit reasoning
+effort override:
+
+```detent-agent
+schema: 1
+effort: high
+```
+
+Choose the effort automatically from this rubric:
+
+- `medium` — small, mechanical, and tightly specified with file:line references and complete acceptance criteria.
+- `high` — a standard feature or fix with some ambiguity or a cross-cutting surface.
+- `xhigh` — a new subsystem, tricky state or concurrency, restart or recovery semantics, or a gesture or interaction engine.
+- `max` — exceptional and operator-designated only; never auto-assign it.
+
+Leave `model` unset so the issue inherits the fleet-standard model.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,25 @@
 - Run `make generate` before committing when templates, sqlc queries, or CSS inputs change.
 - Commit only when explicitly requested by the workflow or human, and use conventional commit messages.
 
+## Issue effort selection
+
+Every issue created for this repository must include an explicit reasoning
+effort override:
+
+```detent-agent
+schema: 1
+effort: high
+```
+
+Choose the effort automatically from this rubric:
+
+- `medium` — small, mechanical, and tightly specified with file:line references and complete acceptance criteria.
+- `high` — a standard feature or fix with some ambiguity or a cross-cutting surface.
+- `xhigh` — a new subsystem, tricky state or concurrency, restart or recovery semantics, or a gesture or interaction engine.
+- `max` — exceptional and operator-designated only; never auto-assign it.
+
+Leave `model` unset so the issue inherits the fleet-standard model.
+
 ## Validation
 
 - `make check` is the local pre-review gate.

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2958,6 +2958,30 @@ the card instead of auto-resolving it.
 Use issues as executable contracts. A good issue has enough specificity that an
 agent can finish without inventing product intent.
 
+#### Per-Issue Agent Overrides
+
+An issue body can override the model, reasoning effort, or both for that
+issue's worker sessions with a fenced `detent-agent` YAML block:
+
+```detent-agent
+schema: 1
+effort: medium
+```
+
+The `schema: 1` field is required. `model` and `effort` are optional; omit
+`model` to inherit the configured route or provider default. When an issue has
+multiple complete `detent-agent` blocks, the last block wins. Detent accepts
+only the `schema`, `model`, and `effort` fields and a single YAML document.
+Invalid YAML, unknown fields, unsupported schemas, unavailable models, and
+unsupported effort values are rejected. Rejected fields fall back to the
+applicable project defaults, and Detent posts a rejection comment identifying
+what it ignored.
+
+Define a project-specific effort rubric in the repository's agent-facing docs,
+such as `AGENTS.md` or `CLAUDE.md`. Issue authors should select the least effort
+appropriate for the work so routine issues do not inherit a more expensive
+fleet baseline than they need.
+
 ```markdown
 ## Problem
 

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -96,6 +96,8 @@ agent:
       max_drafts_per_run: 1
 codex:
   # Optional model_reasoning_effort is unset because not every model accepts it.
+  # An issue-body ```detent-agent``` block can override effort for that issue;
+  # see docs/ONBOARDING.md#per-issue-agent-overrides.
   command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -95,6 +95,8 @@ agent:
       max_drafts_per_run: 1
 codex:
   # Optional model_reasoning_effort is unset because not every model accepts it.
+  # An issue-body ```detent-agent``` block can override effort for that issue;
+  # see docs/ONBOARDING.md#per-issue-agent-overrides.
   command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -95,6 +95,8 @@ agent:
       max_drafts_per_run: 1
 codex:
   # Optional model_reasoning_effort is unset because not every model accepts it.
+  # An issue-body ```detent-agent``` block can override effort for that issue;
+  # see docs/ONBOARDING.md#per-issue-agent-overrides.
   command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -65,6 +65,8 @@ agent:
 
 codex:
   # Optional model_reasoning_effort is unset because not every model accepts it.
+  # An issue-body ```detent-agent``` block can override effort for that issue;
+  # see docs/ONBOARDING.md#per-issue-agent-overrides.
   command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
 
 gate:

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -94,6 +94,8 @@ agent:
       max_drafts_per_run: 1
 codex:
   # Optional model_reasoning_effort is unset because not every model accepts it.
+  # An issue-body ```detent-agent``` block can override effort for that issue;
+  # see docs/ONBOARDING.md#per-issue-agent-overrides.
   command: codex app-server # Provider default: upgrades automatically and avoids retirement breakage.
   approval_policy: never
   thread_sandbox: workspace-write


### PR DESCRIPTION
## Summary

- document Detent-specific issue effort selection in `AGENTS.md` and `CLAUDE.md`
- explain generic per-issue `detent-agent` overrides and validation in onboarding and workflow templates
- prompt hand-filed bugs and features to choose an explicit effort

Fixes #1160

## UI Surface Contract

- [x] N/A — this is documentation-only and changes no UI surface.
- [x] This PR adds no persistent top-of-screen messaging.
- [x] This PR changes no primary operator screen, so screenshot verification is not applicable.

## Test Plan

- [x] Exact documented examples parse through `internal/agentoverride`.
- [x] `make check`