### PR TITLE
feat(doctor): report project skill status

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2266,6 +2266,66 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      <source-root>/WORKFLOW.md
    ```
 
+## Skills And Skill Creation
+
+Detent skills are repository-owned Markdown instructions that give agents
+repeatable guidance for project-specific tasks. By default, Detent loads up to
+50 top-level `*.md` files from `<source-root>/.detent/skills` in filename order.
+Each file starts with YAML front matter containing the required string fields
+`name`, `description`, and `when_to_use`; the Markdown body contains the
+implementation guidance:
+
+```markdown
+---
+name: release-check
+description: Verify a release candidate before publishing.
+when_to_use: The issue asks to prepare or validate a release.
+---
+
+Run the repository's release validation command and record the resulting
+artifact checksums in the workpad.
+```
+
+Names must be unique. `detent doctor --project <detent-project-id> --port 0`
+reports the effective skills configuration, loaded count, and every dropped
+file. It warns when front matter is invalid, a name is duplicated, or the
+configured prompt limit drops otherwise valid files. A missing skills
+directory is healthy and reports zero loaded and zero dropped.
+
+Skill creation is a review loop, not an automatic write to the main branch.
+When creation is enabled, the agent may draft at most the configured number of
+candidate skill files in its issue worktree. Those drafts arrive in the normal
+pull request with the implementation. Reviewers approve a skill by merging the
+pull request; only merged skills become repository guidance for future runs.
+Agents should not draft skills for one-off facts, routine edits, or secrets.
+
+The `agent.skills` keys and defaults are:
+
+| Key | Default | Purpose |
+| --- | --- | --- |
+| `enabled` | `true` | Load repository skills and enable the creation loop when creation is also enabled. |
+| `path` | `.detent/skills` | Workspace-relative directory containing skill Markdown files. |
+| `max_skills_in_prompt` | `50` | Maximum valid skills included in an agent prompt. |
+| `creation.enabled` | `true` | Allow agents to propose skill drafts. |
+| `creation.max_drafts_per_run` | `1` | Maximum candidate skill files an agent may draft in one run. |
+
+Use this complete default block in `WORKFLOW.md`:
+
+```yaml
+agent:
+  skills:
+    enabled: true
+    path: .detent/skills
+    max_skills_in_prompt: 50
+    creation:
+      enabled: true
+      max_drafts_per_run: 1
+```
+
+Set `agent.skills.creation.enabled: false` to keep loading reviewed skills but
+stop new drafts. Set `agent.skills.enabled: false` to disable both skill loading
+and skill creation for the project.
+
 ## Phase 5 — Register The Project
 
 Before running `detent init`, `detent add-project`, mutating `global.yaml`, or

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -87,6 +87,7 @@ agent:
     pass_state: Merging
     rework_state: Rework
     rework_limit: 3
+  # Skills guide: https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -86,6 +86,7 @@ agent:
     pass_state: Merging
     rework_state: Rework
     rework_limit: 3
+  # Skills guide: https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -86,6 +86,7 @@ agent:
     pass_state: Merging
     rework_state: Rework
     rework_limit: 3
+  # Skills guide: https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation
   skills:
     enabled: true
     path: .detent/skills

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -62,6 +62,14 @@ agent:
     pass_state: Ready for Pickup
     rework_state: Rework
     rework_limit: 3
+  # Skills guide: https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation
+  skills:
+    enabled: true
+    path: .detent/skills
+    max_skills_in_prompt: 50
+    creation:
+      enabled: true
+      max_drafts_per_run: 1
 
 codex:
   # Optional model_reasoning_effort is unset because not every model accepts it.

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -85,6 +85,7 @@ agent:
     pass_state: Merging
     rework_state: Rework
     rework_limit: 3
+  # Skills guide: https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation
   skills:
     enabled: true
     path: .detent/skills

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"time"
@@ -13,6 +14,7 @@ import (
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/skills"
 )
 
 func checkDoctorProjects(ctx context.Context, cfg globalconfig.Config, deps doctorDeps, githubToken RuntimeSecret, allowWriteProbes bool) []doctorCheck {
@@ -167,6 +169,7 @@ func checkDoctorProjectWithProgress(
 	if workflow.Config.Workspace.Kind == workflowconfig.WorkspaceFilesystem {
 		setDoctorCurrentCheck("Project " + id + " filesystem workspace")
 		checks = append(checks, checkDoctorFilesystemWorkspace(id, workflow.Config))
+		checks = append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "filesystem workspace does not expose a local source repository"))
 		return checks
 	}
 
@@ -174,40 +177,109 @@ func checkDoctorProjectWithProgress(
 	setDoctorCurrentCheck(sourceRepoCheckName)
 	sourceRoot := projectSourceRoot(project, workflow.Config)
 	if sourceRoot == "" {
-		return append(checks, doctorCheck{
+		checks = append(checks, doctorCheck{
 			Name:   sourceRepoCheckName,
 			Status: doctorFail,
 			Detail: "source root is not configured",
 			Hint:   "Set workspace.source_root, project workdir, or workspace.root to an existing git checkout.",
 		})
+		return append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "source root is not configured"))
 	}
 	expandedSourceRoot, err := expandDoctorWorkspacePath(sourceRoot)
 	if err != nil {
-		return append(checks, doctorCheck{
+		checks = append(checks, doctorCheck{
 			Name:   sourceRepoCheckName,
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s: %v", sourceRoot, err),
 			Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
 		})
+		return append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "source root could not be resolved"))
 	}
 	if err := deps.gitWorkTree(ctx, expandedSourceRoot); err != nil {
-		return append(checks, doctorCheck{
+		checks = append(checks, doctorCheck{
 			Name:   sourceRepoCheckName,
 			Status: doctorFail,
 			Detail: fmt.Sprintf("%s: %v", expandedSourceRoot, err),
 			Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
 		})
+		return append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "source repository is unavailable locally"))
 	}
 	checks = append(checks, doctorCheck{
 		Name:   sourceRepoCheckName,
 		Status: doctorOK,
 		Detail: expandedSourceRoot + " is a git worktree",
 	})
+	setDoctorCurrentCheck("Project " + id + " skills")
+	checks = append(checks, checkDoctorProjectSkills(id, expandedSourceRoot, workflow.Config.Agent.Skills))
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
 		setDoctorCurrentCheck("Project " + id + " GitHub readiness")
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
+}
+
+func checkDoctorProjectSkills(id string, sourceRoot string, cfg workflowconfig.Skills) doctorCheck {
+	name := "Project " + id + " skills"
+	detail := doctorSkillsConfigDetail(cfg)
+	if !cfg.Enabled {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: detail + "; loaded=0; dropped=0"}
+	}
+
+	result, err := skills.Load(sourceRoot, skills.Options{
+		Path:              cfg.Path,
+		MaxSkillsInPrompt: cfg.MaxSkillsInPrompt,
+	})
+	if err != nil {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorWarn,
+			Detail: detail + "; inspection failed: " + err.Error(),
+			Hint:   "Fix agent.skills.path or permissions, then rerun detent doctor.",
+		}
+	}
+
+	detail += fmt.Sprintf("; loaded=%d; dropped=%d", len(result.Skills), len(result.Dropped))
+	if len(result.Dropped) == 0 {
+		return doctorCheck{Name: name, Status: doctorOK, Detail: detail}
+	}
+
+	drops := make([]string, 0, len(result.Dropped))
+	for _, drop := range result.Dropped {
+		path := drop.Path
+		if relative, err := filepath.Rel(sourceRoot, drop.Path); err == nil {
+			path = relative
+		}
+		drops = append(drops, fmt.Sprintf("%s (%s: %s)", path, drop.Reason, drop.Message))
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorWarn,
+		Detail: detail + "; drops: " + strings.Join(drops, "; "),
+		Hint:   "Fix invalid or duplicate skill files, or raise agent.skills.max_skills_in_prompt.",
+	}
+}
+
+func checkDoctorProjectSkillsUnavailable(id string, cfg workflowconfig.Skills, reason string) doctorCheck {
+	if !cfg.Enabled {
+		return checkDoctorProjectSkills(id, "", cfg)
+	}
+	return doctorCheck{
+		Name:   "Project " + id + " skills",
+		Status: doctorWarn,
+		Detail: doctorSkillsConfigDetail(cfg) + "; skipped because " + reason,
+		Hint:   "Make the source repository available locally, then rerun detent doctor.",
+	}
+}
+
+func doctorSkillsConfigDetail(cfg workflowconfig.Skills) string {
+	return fmt.Sprintf(
+		"enabled=%t; creation_enabled=%t; max_drafts_per_run=%d; path=%s; max_skills_in_prompt=%d",
+		cfg.Enabled,
+		cfg.Creation.Enabled,
+		cfg.Creation.MaxDraftsPerRun,
+		cfg.Path,
+		cfg.MaxSkillsInPrompt,
+	)
 }
 
 type doctorRouteModelProbeRequest struct {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -169,7 +170,8 @@ func checkDoctorProjectWithProgress(
 	if workflow.Config.Workspace.Kind == workflowconfig.WorkspaceFilesystem {
 		setDoctorCurrentCheck("Project " + id + " filesystem workspace")
 		checks = append(checks, checkDoctorFilesystemWorkspace(id, workflow.Config))
-		checks = append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "filesystem workspace does not expose a local source repository"))
+		setDoctorCurrentCheck("Project " + id + " skills")
+		checks = append(checks, checkDoctorFilesystemProjectSkills(id, project, workflow.Config))
 		return checks
 	}
 
@@ -269,6 +271,22 @@ func checkDoctorProjectSkillsUnavailable(id string, cfg workflowconfig.Skills, r
 		Detail: doctorSkillsConfigDetail(cfg) + "; skipped because " + reason,
 		Hint:   "Make the source repository available locally, then rerun detent doctor.",
 	}
+}
+
+func checkDoctorFilesystemProjectSkills(id string, project globalconfig.Project, cfg workflowconfig.Config) doctorCheck {
+	sourceRoot := projectSourceRoot(project, cfg)
+	if sourceRoot == "" {
+		return checkDoctorProjectSkillsUnavailable(id, cfg.Agent.Skills, "source root is not configured")
+	}
+	expandedSourceRoot, err := expandDoctorWorkspacePath(sourceRoot)
+	if err != nil {
+		return checkDoctorProjectSkillsUnavailable(id, cfg.Agent.Skills, "source root could not be resolved")
+	}
+	info, err := os.Stat(expandedSourceRoot)
+	if err != nil || !info.IsDir() {
+		return checkDoctorProjectSkillsUnavailable(id, cfg.Agent.Skills, "source repository is unavailable locally")
+	}
+	return checkDoctorProjectSkills(id, expandedSourceRoot, cfg.Agent.Skills)
 }
 
 func doctorSkillsConfigDetail(cfg workflowconfig.Skills) string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -678,6 +678,72 @@ func TestCheckDoctorProjectSkills(t *testing.T) {
 	}
 }
 
+func TestCheckDoctorFilesystemProjectSkills(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configure  func(*testing.T, *globalconfig.Project, *workflowconfig.Config)
+		wantStatus doctorStatus
+		wantDetail []string
+	}{
+		{
+			name: "configured source root is inspected",
+			configure: func(t *testing.T, _ *globalconfig.Project, cfg *workflowconfig.Config) {
+				cfg.Workspace.SourceRoot = t.TempDir()
+				writeDoctorSkill(t, cfg.Workspace.SourceRoot, "deploy.md", "deploy")
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"loaded=1", "dropped=0"},
+		},
+		{
+			name: "project workdir is inspected",
+			configure: func(t *testing.T, project *globalconfig.Project, _ *workflowconfig.Config) {
+				project.Workdir = t.TempDir()
+			},
+			wantStatus: doctorOK,
+			wantDetail: []string{"loaded=0", "dropped=0"},
+		},
+		{
+			name: "missing source root skips",
+			configure: func(t *testing.T, _ *globalconfig.Project, cfg *workflowconfig.Config) {
+				cfg.Workspace.SourceRoot = filepath.Join(t.TempDir(), "missing")
+			},
+			wantStatus: doctorWarn,
+			wantDetail: []string{"skipped because source repository is unavailable locally"},
+		},
+		{
+			name:       "unconfigured source root skips",
+			wantStatus: doctorWarn,
+			wantDetail: []string{"skipped because source root is not configured"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			project := globalconfig.Project{}
+			cfg := workflowconfig.Default()
+			cfg.Workspace.Kind = workflowconfig.WorkspaceFilesystem
+			cfg.Workspace.Root = ""
+			cfg.Workspace.SourceRoot = ""
+			if tt.configure != nil {
+				tt.configure(t, &project, &cfg)
+			}
+			got := checkDoctorFilesystemProjectSkills("alpha", project, cfg)
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.wantStatus, got)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+		})
+	}
+}
+
 func writeDoctorSkill(t *testing.T, root string, name string, skillName string) {
 	t.Helper()
 

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -557,8 +557,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorFail},
-			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "not a git worktree"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorFail, doctorWarn},
+			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -566,8 +566,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK},
-			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "is a git worktree"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK},
+			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "is a git worktree", "loaded=0; dropped=0"},
 		},
 	}
 
@@ -595,6 +595,99 @@ func TestCheckDoctorProjects(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestCheckDoctorProjectSkills(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		configure  func(*testing.T, string, *workflowconfig.Skills)
+		available  bool
+		wantStatus doctorStatus
+		wantDetail []string
+	}{
+		{
+			name: "disabled reports configuration without reading files",
+			configure: func(_ *testing.T, _ string, cfg *workflowconfig.Skills) {
+				cfg.Enabled = false
+				cfg.Creation.Enabled = false
+			},
+			available:  true,
+			wantStatus: doctorOK,
+			wantDetail: []string{"enabled=false", "creation_enabled=false", "max_drafts_per_run=1", "loaded=0", "dropped=0"},
+		},
+		{
+			name: "healthy directory reports loaded count",
+			configure: func(t *testing.T, root string, _ *workflowconfig.Skills) {
+				writeDoctorSkill(t, root, "deploy.md", "deploy")
+			},
+			available:  true,
+			wantStatus: doctorOK,
+			wantDetail: []string{"enabled=true", "path=.detent/skills", "max_skills_in_prompt=50", "loaded=1", "dropped=0"},
+		},
+		{
+			name: "invalid duplicate and over limit files warn with reasons",
+			configure: func(t *testing.T, root string, cfg *workflowconfig.Skills) {
+				cfg.MaxSkillsInPrompt = 1
+				writeDoctorSkill(t, root, "01-deploy.md", "deploy")
+				writeDoctorSkill(t, root, "02-duplicate.md", "deploy")
+				writeDoctorSkill(t, root, "03-test.md", "test")
+				path := filepath.Join(root, ".detent", "skills", "04-invalid.md")
+				if err := os.WriteFile(path, []byte("missing front matter\n"), 0o600); err != nil {
+					t.Fatalf("WriteFile() error = %v", err)
+				}
+			},
+			available:  true,
+			wantStatus: doctorWarn,
+			wantDetail: []string{"loaded=1", "dropped=3", "02-duplicate.md (duplicate:", "03-test.md (max_skills_in_prompt:", "04-invalid.md (invalid:"},
+		},
+		{
+			name:       "missing source repository skips",
+			available:  false,
+			wantStatus: doctorWarn,
+			wantDetail: []string{"enabled=true", "skipped because source repository is unavailable locally"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			cfg := workflowconfig.Default().Agent.Skills
+			if tt.configure != nil {
+				tt.configure(t, root, &cfg)
+			}
+			var got doctorCheck
+			if tt.available {
+				got = checkDoctorProjectSkills("alpha", root, cfg)
+			} else {
+				got = checkDoctorProjectSkillsUnavailable("alpha", cfg, "source repository is unavailable locally")
+			}
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.wantStatus, got)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(got.Detail, want) {
+					t.Fatalf("Detail = %q, want containing %q", got.Detail, want)
+				}
+			}
+		})
+	}
+}
+
+func writeDoctorSkill(t *testing.T, root string, name string, skillName string) {
+	t.Helper()
+
+	dir := filepath.Join(root, ".detent", "skills")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatalf("MkdirAll() error = %v", err)
+	}
+	content := "---\nname: " + skillName + "\ndescription: Test skill.\nwhen_to_use: Doctor tests.\n---\nBody\n"
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o600); err != nil {
+		t.Fatalf("WriteFile() error = %v", err)
 	}
 }
 
@@ -1678,7 +1771,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	if gotPath != wantPath {
 		t.Fatalf("git path = %q, want %q", gotPath, wantPath)
 	}
-	if len(checks) != 3 || checks[2].Status != doctorOK {
+	if len(checks) != 4 || checks[2].Status != doctorOK {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
 	}
 }

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -1235,11 +1235,12 @@ func (r *Runner) availableSkills(workflow config.Workflow, workspacePath string)
 	if err != nil {
 		return nil, fmt.Errorf("load skills: %w", err)
 	}
-	for _, validation := range result.Errors {
+	for _, drop := range result.Dropped {
 		r.logger.Warn(
-			"invalid repo skill ignored",
-			slog.String("path", validation.Path),
-			slog.String("message", validation.Message),
+			"repo skill dropped",
+			slog.String("path", drop.Path),
+			slog.String("reason", string(drop.Reason)),
+			slog.String("message", drop.Message),
 		)
 	}
 	return result.Skills, nil

--- a/internal/skills/loader.go
+++ b/internal/skills/loader.go
@@ -27,13 +27,23 @@ type Skill struct {
 	BodyPath    string
 }
 
-type ValidationError struct {
+type DropReason string
+
+const (
+	DropReasonInvalid           DropReason = "invalid"
+	DropReasonDuplicate         DropReason = "duplicate"
+	DropReasonMaxSkillsInPrompt DropReason = "max_skills_in_prompt"
+)
+
+type Drop struct {
 	Path    string
+	Name    string
+	Reason  DropReason
 	Message string
 }
 
-func (e ValidationError) Error() string {
-	return e.Path + ": " + e.Message
+func (d Drop) Error() string {
+	return d.Path + ": " + d.Message
 }
 
 type Options struct {
@@ -43,8 +53,8 @@ type Options struct {
 }
 
 type Result struct {
-	Skills []Skill
-	Errors []ValidationError
+	Skills  []Skill
+	Dropped []Drop
 }
 
 func Load(workspacePath string, opts Options) (Result, error) {
@@ -84,30 +94,37 @@ func Load(workspacePath string, opts Options) (Result, error) {
 	sort.Strings(files)
 
 	skills := make([]Skill, 0, len(files))
-	validationErrors := make([]ValidationError, 0)
+	dropped := make([]Drop, 0)
 	for _, file := range files {
 		content, err := os.ReadFile(file)
 		if err != nil {
-			validationErrors = append(validationErrors, ValidationError{
+			dropped = append(dropped, Drop{
 				Path:    file,
+				Reason:  DropReasonInvalid,
 				Message: "failed to read skill: " + err.Error(),
 			})
 			continue
 		}
 
-		skill, validationErr := parseSkill(file, content)
-		if validationErr != nil {
-			validationErrors = append(validationErrors, *validationErr)
+		skill, drop := parseSkill(file, content)
+		if drop != nil {
+			dropped = append(dropped, *drop)
 			continue
 		}
 		skills = append(skills, skill)
 	}
 
-	skills, duplicateErrors := rejectDuplicateNames(skills)
-	validationErrors = append(validationErrors, duplicateErrors...)
+	skills, duplicateDrops := rejectDuplicateNames(skills)
+	dropped = append(dropped, duplicateDrops...)
 
 	if len(skills) > maxSkills {
 		for _, skill := range skills[maxSkills:] {
+			dropped = append(dropped, Drop{
+				Path:    skill.BodyPath,
+				Name:    skill.Name,
+				Reason:  DropReasonMaxSkillsInPrompt,
+				Message: fmt.Sprintf("exceeds max_skills_in_prompt of %d", maxSkills),
+			})
 			logger.Info(
 				"dropped skill from prompt",
 				slog.Int("max_skills_in_prompt", maxSkills),
@@ -119,25 +136,25 @@ func Load(workspacePath string, opts Options) (Result, error) {
 	}
 
 	return Result{
-		Skills: skills,
-		Errors: validationErrors,
+		Skills:  skills,
+		Dropped: dropped,
 	}, nil
 }
 
-func parseSkill(path string, content []byte) (Skill, *ValidationError) {
+func parseSkill(path string, content []byte) (Skill, *Drop) {
 	frontmatter, err := splitFrontmatter(content)
 	if err != nil {
-		return Skill{}, &ValidationError{Path: path, Message: err.Error()}
+		return Skill{}, &Drop{Path: path, Reason: DropReasonInvalid, Message: err.Error()}
 	}
 
 	var doc yaml.Node
 	if err := yaml.Unmarshal(frontmatter, &doc); err != nil {
-		return Skill{}, &ValidationError{Path: path, Message: "invalid YAML: " + err.Error()}
+		return Skill{}, &Drop{Path: path, Reason: DropReasonInvalid, Message: "invalid YAML: " + err.Error()}
 	}
 
 	root := yamlRoot(&doc)
 	if root == nil || root.Kind != yaml.MappingNode {
-		return Skill{}, &ValidationError{Path: path, Message: "front matter must be a mapping"}
+		return Skill{}, &Drop{Path: path, Reason: DropReasonInvalid, Message: "front matter must be a mapping"}
 	}
 
 	fields := map[string]string{}
@@ -151,7 +168,7 @@ func parseSkill(path string, content []byte) (Skill, *ValidationError) {
 		fields[field] = strings.TrimSpace(value)
 	}
 	if len(missing) > 0 {
-		return Skill{}, &ValidationError{Path: path, Message: strings.Join(missing, ", ")}
+		return Skill{}, &Drop{Path: path, Reason: DropReasonInvalid, Message: strings.Join(missing, ", ")}
 	}
 
 	return Skill{
@@ -211,16 +228,18 @@ func stringField(root *yaml.Node, name string) (string, bool) {
 	return "", false
 }
 
-func rejectDuplicateNames(skillList []Skill) ([]Skill, []ValidationError) {
+func rejectDuplicateNames(skillList []Skill) ([]Skill, []Drop) {
 	seen := make(map[string]string, len(skillList))
 	skills := make([]Skill, 0, len(skillList))
-	validationErrors := make([]ValidationError, 0)
+	dropped := make([]Drop, 0)
 
 	for _, skill := range skillList {
 		existingPath, ok := seen[skill.Name]
 		if ok {
-			validationErrors = append(validationErrors, ValidationError{
+			dropped = append(dropped, Drop{
 				Path:    skill.BodyPath,
+				Name:    skill.Name,
+				Reason:  DropReasonDuplicate,
 				Message: fmt.Sprintf("duplicate skill name %q already defined at %s", skill.Name, existingPath),
 			})
 			continue
@@ -229,7 +248,7 @@ func rejectDuplicateNames(skillList []Skill) ([]Skill, []ValidationError) {
 		skills = append(skills, skill)
 	}
 
-	return skills, validationErrors
+	return skills, dropped
 }
 
 func workspaceRelativePath(workspacePath string, relativePath string) (string, error) {

--- a/internal/skills/loader_test.go
+++ b/internal/skills/loader_test.go
@@ -34,11 +34,14 @@ func TestLoadReadsSkillsDeterministicallyDeduplicatesAndCaps(t *testing.T) {
 	if !strings.HasSuffix(result.Skills[0].BodyPath, filepath.Join(".detent", "skills", "01-alpha.md")) {
 		t.Fatalf("BodyPath = %q", result.Skills[0].BodyPath)
 	}
-	if len(result.Errors) != 1 {
-		t.Fatalf("errors len = %d, want 1: %#v", len(result.Errors), result.Errors)
+	if len(result.Dropped) != 2 {
+		t.Fatalf("dropped len = %d, want 2: %#v", len(result.Dropped), result.Dropped)
 	}
-	if !strings.Contains(result.Errors[0].Message, `duplicate skill name "deploy"`) {
-		t.Fatalf("duplicate error = %q", result.Errors[0].Message)
+	if result.Dropped[0].Reason != DropReasonDuplicate || !strings.Contains(result.Dropped[0].Message, `duplicate skill name "deploy"`) {
+		t.Fatalf("duplicate drop = %#v", result.Dropped[0])
+	}
+	if result.Dropped[1].Reason != DropReasonMaxSkillsInPrompt || result.Dropped[1].Name != "lint" {
+		t.Fatalf("over-limit drop = %#v", result.Dropped[1])
 	}
 }
 
@@ -67,11 +70,11 @@ Body
 	if result.Skills[0].Name != "good" {
 		t.Fatalf("skill name = %q, want good", result.Skills[0].Name)
 	}
-	if len(result.Errors) != 2 {
-		t.Fatalf("errors len = %d, want 2: %#v", len(result.Errors), result.Errors)
+	if len(result.Dropped) != 2 {
+		t.Fatalf("dropped len = %d, want 2: %#v", len(result.Dropped), result.Dropped)
 	}
 
-	messages := result.Errors[0].Message + "\n" + result.Errors[1].Message
+	messages := result.Dropped[0].Message + "\n" + result.Dropped[1].Message
 	for _, want := range []string{"name is required", "missing front matter"} {
 		if !strings.Contains(messages, want) {
 			t.Fatalf("errors missing %q:\n%s", want, messages)
@@ -86,7 +89,7 @@ func TestLoadMissingDirectoryIsEmpty(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Load() error = %v", err)
 	}
-	if len(result.Skills) != 0 || len(result.Errors) != 0 {
+	if len(result.Skills) != 0 || len(result.Dropped) != 0 {
 		t.Fatalf("Load() = %#v, want empty result", result)
 	}
 }

--- a/internal/web/onboarding.go
+++ b/internal/web/onboarding.go
@@ -537,6 +537,7 @@ func renderWorkflow(form templates.OnboardingForm, sourceRoot string) string {
 	b.WriteString("    allowed_issue_labels: []\n")
 	b.WriteString("    gate_wait_timeout_seconds: 3600\n")
 	b.WriteString("    rework_limit: 3\n")
+	b.WriteString("  # Skills guide: https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation\n")
 	b.WriteString("  skills:\n")
 	b.WriteString("    enabled: true\n")
 	b.WriteString("    path: .detent/skills\n")

--- a/internal/web/onboarding_test.go
+++ b/internal/web/onboarding_test.go
@@ -662,6 +662,7 @@ func TestOnboardingWriteWorkflowAppliesFullAutopilotProfile(t *testing.T) {
 		"dependency_auto_unblock:\n    enabled: true",
 		"max_concurrent_agents_by_state:\n    Merging: 1",
 		"auto_promote:\n    enabled: true\n    quiet_seconds: 0\n    gate_wait_state: source",
+		"# Skills guide: https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation",
 		"gate:\n  kind: command\n  run: make check\n  required_status_checks: []\n  require_automated_review: false",
 		"server:\n  host: 127.0.0.1\n  kanban:\n    mode: integration",
 		"Full autopilot still requires linked PRs, green CI, clear gates, and no blocking P1 automated findings.",

--- a/onboarding_docs_test.go
+++ b/onboarding_docs_test.go
@@ -528,6 +528,37 @@ func TestGitHubLocalWorkflowTemplateUsesAffordablePolling(t *testing.T) {
 	}
 }
 
+func TestWorkflowTemplatesLinkToSkillsOnboarding(t *testing.T) {
+	t.Parallel()
+
+	const link = "https://github.com/digitaldrywood/detent/blob/main/docs/ONBOARDING.md#skills-and-skill-creation"
+	for _, path := range []string{
+		"docs/templates/WORKFLOW.project_v2.md",
+		"docs/templates/WORKFLOW.issue_field.md",
+		"docs/templates/WORKFLOW.label.md",
+		"docs/templates/WORKFLOW.github_local.md",
+		"docs/templates/WORKFLOW.non_code_artifact.md",
+	} {
+		t.Run(path, func(t *testing.T) {
+			t.Parallel()
+			assertContains(t, readRepositoryTextFile(t, path), link)
+		})
+	}
+
+	onboarding := readRepositoryTextFile(t, "docs/ONBOARDING.md")
+	for _, want := range []string{
+		"## Skills And Skill Creation",
+		"name: release-check",
+		"description: Verify a release candidate before publishing.",
+		"when_to_use: The issue asks to prepare or validate a release.",
+		"creation.max_drafts_per_run",
+		"Set `agent.skills.enabled: false`",
+	} {
+		assertContains(t, onboarding, want)
+	}
+	assertContainsWords(t, onboarding, "Reviewers approve a skill by merging the pull request")
+}
+
 func TestWorkflowTemplatesDocumentStatusEnumAndReviewFlow(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- report per-project skill configuration and loaded/dropped diagnostics in `detent doctor`
- expose invalid, duplicate, and over-limit loader drop reasons
- document the skill format and PR merge approval loop, with links from every WORKFLOW scaffold

Fixes #1165

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. (N/A: no operator UI changes.)

## Test Plan

- [x] `go test ./internal/cli ./internal/web ./internal/skills ./internal/runner`
- [x] `make check` (77.0% coverage)