### PR TITLE
feat(doctor): validate detent-agent effort guidance

### DIFF
--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -13,8 +13,10 @@ import (
 	"github.com/digitaldrywood/detent/internal/agentoverride"
 	workflowconfig "github.com/digitaldrywood/detent/internal/config"
 	globalconfig "github.com/digitaldrywood/detent/internal/config/global"
+	"github.com/digitaldrywood/detent/internal/connector"
 	projectpkg "github.com/digitaldrywood/detent/internal/project"
 	runnerpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/skills"
 )
 
@@ -573,8 +575,15 @@ func doctorCatalogModelName(model runnerpkg.AgentModel, fallback string) string 
 
 func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
 	name := "Project " + id + " issue agent models"
-	backend, ok := doctorDefaultCodexBackend(cfg)
-	if !ok {
+	backends := doctorWorkflowBackendConfigsByID(cfg)
+	hasCodexBackend := false
+	for _, backend := range backends {
+		if strings.TrimSpace(backend.Kind) == workflowconfig.AgentBackendCodex {
+			hasCodexBackend = true
+			break
+		}
+	}
+	if !hasCodexBackend {
 		return doctorCheck{Name: name, Status: doctorOK, Detail: "detent-agent override validation skipped because no Codex backend is configured"}
 	}
 	if deps.autoPromoteConnector == nil {
@@ -587,12 +596,20 @@ func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalc
 	if projectConnector == nil {
 		return doctorCheck{Name: name, Status: doctorFail, Detail: "create issue override diagnostic connector: connector is nil", Hint: "Fix tracker configuration and rerun detent doctor."}
 	}
+	selectorContext := selector.Context{Persona: cfg.Tracker.Assignee}
+	if identifier, ok := projectConnector.(connector.InstanceIdentifier); ok {
+		selectorContext.InstanceLogin = identifier.InstanceLogin()
+	}
 
 	states := append(append([]string(nil), cfg.Tracker.ActiveStates...), cfg.Tracker.ObservedStates...)
 	issues, fetchErr := projectConnector.FetchIssuesByStates(ctx, states)
 	closeErr := closeDoctorAutoPromoteConnector(projectConnector)
 	if fetchErr != nil {
 		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("fetch issue agent overrides: %v", fetchErr), Hint: "Fix tracker connectivity and rerun detent doctor."}
+	}
+	router, err := doctorIssueAgentRouter(cfg)
+	if err != nil {
+		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("create issue agent override router: %v", err), Hint: "Fix agent route configuration and rerun detent doctor."}
 	}
 
 	if deps.modelProbe == nil {
@@ -609,7 +626,6 @@ func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalc
 	probedModels := 0
 	probedEfforts := 0
 	failures := []string{}
-	defaultModel := doctorWorkflowWorkerModelChoice(cfg).Model
 	for _, issue := range issues {
 		override, found, err := agentoverride.FromIssueBody(issue.Description)
 		if !found {
@@ -626,9 +642,19 @@ func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalc
 		if override.Model == "" && override.Effort == "" {
 			continue
 		}
+		selection, err := router.Route(issue, selectorContext)
+		if err != nil {
+			failures = append(failures, fmt.Sprintf("issue %s detent-agent route selection failed: %v", identifier, err))
+			continue
+		}
+		backend, ok := backends[strings.TrimSpace(selection.BackendID)]
+		if !ok {
+			failures = append(failures, fmt.Sprintf("issue %s detent-agent route %s references unavailable backend %s", identifier, selection.RouteName, selection.BackendID))
+			continue
+		}
 		model := override.Model
 		if model == "" {
-			model = defaultModel
+			model = selection.Model
 		}
 		if override.Model != "" {
 			probedModels++
@@ -675,23 +701,21 @@ func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalc
 	return check
 }
 
-func doctorDefaultCodexBackend(cfg workflowconfig.Config) (workflowconfig.AgentBackend, bool) {
-	backends := doctorWorkflowBackendConfigsByID(cfg)
-	for _, route := range cfg.AgentRouteConfigs() {
-		if !route.Default || (strings.TrimSpace(route.Role) != "" && !strings.EqualFold(strings.TrimSpace(route.Role), runnerpkg.RoleCode)) {
-			continue
-		}
-		backend, ok := backends[strings.TrimSpace(route.Backend)]
-		if ok && backend.Kind == workflowconfig.AgentBackendCodex {
-			return backend, true
-		}
+func doctorIssueAgentRouter(cfg workflowconfig.Config) (*runnerpkg.Router, error) {
+	routes := cfg.AgentRouteConfigs()
+	doctorRoutes := make([]runnerpkg.Route, 0, len(routes))
+	for _, route := range routes {
+		doctorRoutes = append(doctorRoutes, runnerpkg.Route{
+			Name:       route.Name,
+			Role:       route.Role,
+			BackendID:  route.Backend,
+			Model:      route.Model,
+			ModelField: route.ModelField,
+			Default:    route.Default,
+			Selector:   route.Selector,
+		})
 	}
-	for _, backend := range cfg.AgentBackendConfigs() {
-		if backend.Kind == workflowconfig.AgentBackendCodex {
-			return backend, true
-		}
-	}
-	return workflowconfig.AgentBackend{}, false
+	return runnerpkg.NewRouter(doctorRoutes)
 }
 
 func doctorProjectID(project globalconfig.Project) string {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -105,6 +105,7 @@ func checkDoctorProjectWithProgress(
 				Detail: "skipped because WORKFLOW.md could not be loaded",
 				Hint:   "Fix the workflow file, then rerun detent doctor.",
 			},
+			checkDoctorIssueEffortGuidanceUnavailable(id, "WORKFLOW.md could not be loaded"),
 		}
 	}
 	workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, runtimeGlobalGitHubToken(githubToken))
@@ -122,6 +123,7 @@ func checkDoctorProjectWithProgress(
 				Detail: "skipped because WORKFLOW.md is invalid",
 				Hint:   "Fix the workflow file, then rerun detent doctor.",
 			},
+			checkDoctorIssueEffortGuidanceUnavailable(id, "WORKFLOW.md is invalid"),
 		}
 	}
 
@@ -170,6 +172,8 @@ func checkDoctorProjectWithProgress(
 	if workflow.Config.Workspace.Kind == workflowconfig.WorkspaceFilesystem {
 		setDoctorCurrentCheck("Project " + id + " filesystem workspace")
 		checks = append(checks, checkDoctorFilesystemWorkspace(id, workflow.Config))
+		setDoctorCurrentCheck("Project " + id + " issue effort guidance")
+		checks = append(checks, checkDoctorIssueEffortGuidanceForSource(id, project, workflow.Config))
 		setDoctorCurrentCheck("Project " + id + " skills")
 		checks = append(checks, checkDoctorFilesystemProjectSkills(id, project, workflow.Config))
 		return checks
@@ -185,6 +189,7 @@ func checkDoctorProjectWithProgress(
 			Detail: "source root is not configured",
 			Hint:   "Set workspace.source_root, project workdir, or workspace.root to an existing git checkout.",
 		})
+		checks = append(checks, checkDoctorIssueEffortGuidanceUnavailable(id, "source root is not configured"))
 		return append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "source root is not configured"))
 	}
 	expandedSourceRoot, err := expandDoctorWorkspacePath(sourceRoot)
@@ -195,6 +200,7 @@ func checkDoctorProjectWithProgress(
 			Detail: fmt.Sprintf("%s: %v", sourceRoot, err),
 			Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
 		})
+		checks = append(checks, checkDoctorIssueEffortGuidanceUnavailable(id, "source root could not be resolved"))
 		return append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "source root could not be resolved"))
 	}
 	if err := deps.gitWorkTree(ctx, expandedSourceRoot); err != nil {
@@ -204,6 +210,7 @@ func checkDoctorProjectWithProgress(
 			Detail: fmt.Sprintf("%s: %v", expandedSourceRoot, err),
 			Hint:   "Set workspace.source_root or project workdir to an existing git checkout.",
 		})
+		checks = append(checks, checkDoctorIssueEffortGuidanceUnavailable(id, "source repository is unavailable locally"))
 		return append(checks, checkDoctorProjectSkillsUnavailable(id, workflow.Config.Agent.Skills, "source repository is unavailable locally"))
 	}
 	checks = append(checks, doctorCheck{
@@ -211,6 +218,8 @@ func checkDoctorProjectWithProgress(
 		Status: doctorOK,
 		Detail: expandedSourceRoot + " is a git worktree",
 	})
+	setDoctorCurrentCheck("Project " + id + " issue effort guidance")
+	checks = append(checks, checkDoctorIssueEffortGuidance(id, expandedSourceRoot))
 	setDoctorCurrentCheck("Project " + id + " skills")
 	checks = append(checks, checkDoctorProjectSkills(id, expandedSourceRoot, workflow.Config.Agent.Skills))
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
@@ -218,6 +227,61 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
+}
+
+func checkDoctorIssueEffortGuidanceForSource(id string, project globalconfig.Project, cfg workflowconfig.Config) doctorCheck {
+	sourceRoot := projectSourceRoot(project, cfg)
+	if sourceRoot == "" {
+		return checkDoctorIssueEffortGuidanceUnavailable(id, "source root is not configured")
+	}
+	expandedSourceRoot, err := expandDoctorWorkspacePath(sourceRoot)
+	if err != nil {
+		return checkDoctorIssueEffortGuidanceUnavailable(id, "source root could not be resolved")
+	}
+	info, err := os.Stat(expandedSourceRoot)
+	if err != nil || !info.IsDir() {
+		return checkDoctorIssueEffortGuidanceUnavailable(id, "source repository is unavailable locally")
+	}
+	return checkDoctorIssueEffortGuidance(id, expandedSourceRoot)
+}
+
+func checkDoctorIssueEffortGuidance(id string, sourceRoot string) doctorCheck {
+	name := "Project " + id + " issue effort guidance"
+	paths := []string{"AGENTS.md", "CLAUDE.md"}
+	for _, path := range paths {
+		content, err := os.ReadFile(filepath.Join(sourceRoot, path))
+		if errors.Is(err, os.ErrNotExist) {
+			continue
+		}
+		if err != nil {
+			return doctorCheck{
+				Name:   name,
+				Status: doctorOK,
+				Detail: fmt.Sprintf("skipped because %s could not be read: %v", path, err),
+			}
+		}
+		if strings.Contains(strings.ToLower(string(content)), "detent-agent") {
+			return doctorCheck{
+				Name:   name,
+				Status: doctorOK,
+				Detail: path + " mentions detent-agent effort guidance",
+			}
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorWarn,
+		Detail: "AGENTS.md and CLAUDE.md contain no detent-agent guidance",
+		Hint:   "Add a project-specific effort-selection rubric; see docs/ONBOARDING.md#per-issue-agent-overrides.",
+	}
+}
+
+func checkDoctorIssueEffortGuidanceUnavailable(id string, reason string) doctorCheck {
+	return doctorCheck{
+		Name:   "Project " + id + " issue effort guidance",
+		Status: doctorOK,
+		Detail: "skipped because " + reason,
+	}
 }
 
 func checkDoctorProjectSkills(id string, sourceRoot string, cfg workflowconfig.Skills) doctorCheck {
@@ -308,6 +372,7 @@ type doctorRouteModelProbeRequest struct {
 	RouteName    string
 	RouteRole    string
 	Model        string
+	Effort       string
 	Backend      workflowconfig.AgentBackend
 }
 
@@ -434,44 +499,100 @@ func defaultDoctorRouteModelProbe(ctx context.Context, req doctorRouteModelProbe
 	if err != nil {
 		return err
 	}
-	return validateDoctorModelCatalog(models, req.Model)
+	model := strings.TrimSpace(req.Model)
+	if model == "" && strings.TrimSpace(req.Effort) != "" {
+		defaultProvider, ok := backend.(runnerpkg.AgentDefaultModelProvider)
+		if !ok {
+			return errors.New("backend does not advertise its effective default model")
+		}
+		model, err = defaultProvider.DefaultModel(ctx, req.Workspace)
+		if err != nil {
+			return fmt.Errorf("effective default model unavailable: %w", err)
+		}
+	}
+	if err := validateDoctorModelCatalog(models, model); err != nil {
+		return err
+	}
+	if strings.TrimSpace(req.Effort) == "" {
+		return nil
+	}
+	return validateDoctorEffortCatalog(models, model, req.Effort)
 }
 
 func validateDoctorModelCatalog(models []runnerpkg.AgentModel, requested string) error {
-	want := strings.TrimSpace(requested)
-	for _, model := range models {
-		if strings.TrimSpace(model.ID) == want || strings.TrimSpace(model.Model) == want {
-			if upgrade := strings.TrimSpace(model.Upgrade); upgrade != "" {
-				return fmt.Errorf("model %q is retired; use %q", want, upgrade)
-			}
+	_, err := doctorCatalogModel(models, requested)
+	return err
+}
+
+func validateDoctorEffortCatalog(models []runnerpkg.AgentModel, requestedModel string, requestedEffort string) error {
+	model, err := doctorCatalogModel(models, requestedModel)
+	if err != nil {
+		return err
+	}
+	want := strings.TrimSpace(requestedEffort)
+	for _, effort := range model.SupportedReasoningEfforts {
+		if strings.EqualFold(strings.TrimSpace(effort), want) {
 			return nil
 		}
 	}
-	return fmt.Errorf("model %q is not available from the backend", want)
+	supported := make([]string, 0, len(model.SupportedReasoningEfforts))
+	for _, effort := range model.SupportedReasoningEfforts {
+		if effort = strings.TrimSpace(effort); effort != "" {
+			supported = append(supported, effort)
+		}
+	}
+	if len(supported) == 0 {
+		supported = append(supported, "none")
+	}
+	return fmt.Errorf("effort %q is not supported by model %q; supported efforts: %s", want, doctorCatalogModelName(model, requestedModel), strings.Join(supported, ", "))
+}
+
+func doctorCatalogModel(models []runnerpkg.AgentModel, requested string) (runnerpkg.AgentModel, error) {
+	want := strings.TrimSpace(requested)
+	for _, model := range models {
+		if strings.TrimSpace(model.ID) != want && strings.TrimSpace(model.Model) != want {
+			continue
+		}
+		if upgrade := strings.TrimSpace(model.Upgrade); upgrade != "" {
+			return runnerpkg.AgentModel{}, fmt.Errorf("model %q is retired; use %q", want, upgrade)
+		}
+		return model, nil
+	}
+	return runnerpkg.AgentModel{}, fmt.Errorf("model %q is not available from the backend", want)
+}
+
+func doctorCatalogModelName(model runnerpkg.AgentModel, fallback string) string {
+	if value := strings.TrimSpace(model.Model); value != "" {
+		return value
+	}
+	if value := strings.TrimSpace(model.ID); value != "" {
+		return value
+	}
+	return strings.TrimSpace(fallback)
 }
 
 func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalconfig.Project, cfg workflowconfig.Config, deps doctorDeps) doctorCheck {
 	name := "Project " + id + " issue agent models"
 	backend, ok := doctorDefaultCodexBackend(cfg)
 	if !ok {
-		return doctorCheck{Name: name, Status: doctorOK, Detail: "detent-agent model validation skipped because no Codex backend is configured"}
+		return doctorCheck{Name: name, Status: doctorOK, Detail: "detent-agent override validation skipped because no Codex backend is configured"}
 	}
 	if deps.autoPromoteConnector == nil {
 		deps.autoPromoteConnector = defaultDoctorAutoPromoteConnector
 	}
 	projectConnector, err := deps.autoPromoteConnector(cfg)
 	if err != nil {
-		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("create issue model diagnostic connector: %v", err), Hint: "Fix tracker credentials and rerun detent doctor."}
+		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("create issue override diagnostic connector: %v", err), Hint: "Fix tracker credentials and rerun detent doctor."}
 	}
 	if projectConnector == nil {
-		return doctorCheck{Name: name, Status: doctorFail, Detail: "create issue model diagnostic connector: connector is nil", Hint: "Fix tracker configuration and rerun detent doctor."}
+		return doctorCheck{Name: name, Status: doctorFail, Detail: "create issue override diagnostic connector: connector is nil", Hint: "Fix tracker configuration and rerun detent doctor."}
 	}
 
 	states := append(append([]string(nil), cfg.Tracker.ActiveStates...), cfg.Tracker.ObservedStates...)
 	issues, fetchErr := projectConnector.FetchIssuesByStates(ctx, states)
 	closeErr := closeDoctorAutoPromoteConnector(projectConnector)
 	if fetchErr != nil {
-		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("fetch issue model overrides: %v", fetchErr), Hint: "Fix tracker connectivity and rerun detent doctor."}
+		return doctorCheck{Name: name, Status: doctorFail, Detail: fmt.Sprintf("fetch issue agent overrides: %v", fetchErr), Hint: "Fix tracker connectivity and rerun detent doctor."}
 	}
 
 	if deps.modelProbe == nil {
@@ -485,8 +606,10 @@ func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalc
 	if workflowPathErr != nil {
 		workflowPath = strings.TrimSpace(project.Workflow)
 	}
-	probed := 0
+	probedModels := 0
+	probedEfforts := 0
 	failures := []string{}
+	defaultModel := doctorWorkflowWorkerModelChoice(cfg).Model
 	for _, issue := range issues {
 		override, found, err := agentoverride.FromIssueBody(issue.Description)
 		if !found {
@@ -500,20 +623,37 @@ func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalc
 			failures = append(failures, fmt.Sprintf("issue %s has invalid detent-agent block: %v", identifier, err))
 			continue
 		}
-		if override.Model == "" {
+		if override.Model == "" && override.Effort == "" {
 			continue
 		}
-		probed++
+		model := override.Model
+		if model == "" {
+			model = defaultModel
+		}
+		if override.Model != "" {
+			probedModels++
+		}
+		if override.Effort != "" {
+			probedEfforts++
+		}
 		err = deps.modelProbe(ctx, doctorRouteModelProbeRequest{
 			ProjectID:    id,
 			Workspace:    workspacePath,
 			WorkflowPath: workflowPath,
 			RouteName:    identifier,
-			Model:        override.Model,
+			Model:        model,
+			Effort:       override.Effort,
 			Backend:      backend,
 		})
 		if err != nil {
-			failures = append(failures, fmt.Sprintf("issue %s detent-agent model %s rejected by backend: %v", identifier, override.Model, err))
+			fields := []string{}
+			if override.Model != "" {
+				fields = append(fields, "model "+override.Model)
+			}
+			if override.Effort != "" {
+				fields = append(fields, "effort "+override.Effort)
+			}
+			failures = append(failures, fmt.Sprintf("issue %s detent-agent %s rejected by backend: %v", identifier, strings.Join(fields, " "), err))
 		}
 	}
 
@@ -522,10 +662,10 @@ func checkDoctorIssueAgentModels(ctx context.Context, id string, project globalc
 			Name:   name,
 			Status: doctorFail,
 			Detail: strings.Join(failures, "; "),
-			Hint:   "Update rejected detent-agent model values in the original issue bodies or remove the model key to inherit the project default.",
+			Hint:   "Fix rejected detent-agent values in the original issue bodies; remove the model key to inherit the project default model, or remove the effort key to inherit the project default effort.",
 		}
 	}
-	detail := fmt.Sprintf("validated %d detent-agent model override(s)", probed)
+	detail := fmt.Sprintf("validated %d detent-agent model override(s) and %d effort override(s)", probedModels, probedEfforts)
 	check := doctorCheck{Name: name, Status: doctorOK, Detail: detail}
 	if closeErr != nil {
 		check.Status = doctorWarn

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -415,42 +415,82 @@ Prompt
 func TestCheckDoctorIssueAgentModels(t *testing.T) {
 	t.Parallel()
 
+	models := []runnerpkg.AgentModel{
+		{ID: "gpt-default", Model: "gpt-default", SupportedReasoningEfforts: []string{"low", "high"}},
+		{ID: "gpt-5.5", Model: "gpt-5.5", SupportedReasoningEfforts: []string{"low", "medium", "high"}},
+		{ID: "gpt-retired", Model: "gpt-retired", Upgrade: "gpt-5.5", SupportedReasoningEfforts: []string{"medium"}},
+	}
 	tests := []struct {
-		name       string
-		issue      connector.Issue
-		probeErr   error
-		wantStatus doctorStatus
-		wantDetail string
-		wantProbes int
+		name         string
+		issue        connector.Issue
+		defaultModel string
+		wantStatus   doctorStatus
+		wantDetail   []string
+		wantHint     string
+		wantModel    string
+		wantEffort   string
+		wantProbes   int
 	}{
 		{
 			name:       "no block",
 			issue:      connector.Issue{ID: "issue-1", Identifier: "digitaldrywood/detent#1", Description: "Ship it."},
 			wantStatus: doctorOK,
-			wantDetail: "validated 0",
+			wantDetail: []string{"validated 0 detent-agent model override(s)", "0 effort override(s)"},
 		},
 		{
 			name:       "healthy model",
 			issue:      connector.Issue{ID: "issue-2", Identifier: "digitaldrywood/detent#2", Description: "```detent-agent\nschema: 1\nmodel: gpt-5.5\n```"},
 			wantStatus: doctorOK,
-			wantDetail: "validated 1",
+			wantDetail: []string{"validated 1 detent-agent model override(s)", "0 effort override(s)"},
+			wantModel:  "gpt-5.5",
 			wantProbes: 1,
 		},
 		{
+			name:         "valid effort uses project default model",
+			issue:        connector.Issue{ID: "issue-3", Identifier: "digitaldrywood/detent#3", Description: "```detent-agent\nschema: 1\neffort: high\n```"},
+			defaultModel: "gpt-default",
+			wantStatus:   doctorOK,
+			wantDetail:   []string{"validated 0 detent-agent model override(s)", "1 effort override(s)"},
+			wantModel:    "gpt-default",
+			wantEffort:   "high",
+			wantProbes:   1,
+		},
+		{
+			name:         "issue model controls effort validation",
+			issue:        connector.Issue{ID: "issue-4", Identifier: "digitaldrywood/detent#4", Description: "```detent-agent\nschema: 1\nmodel: gpt-5.5\neffort: medium\n```"},
+			defaultModel: "gpt-default",
+			wantStatus:   doctorOK,
+			wantDetail:   []string{"validated 1 detent-agent model override(s)", "1 effort override(s)"},
+			wantModel:    "gpt-5.5",
+			wantEffort:   "medium",
+			wantProbes:   1,
+		},
+		{
+			name:         "unsupported effort names issue and supported efforts",
+			issue:        connector.Issue{ID: "issue-5", Identifier: "digitaldrywood/detent#5", Description: "```detent-agent\nschema: 1\neffort: bogus\n```"},
+			defaultModel: "gpt-default",
+			wantStatus:   doctorFail,
+			wantDetail:   []string{"digitaldrywood/detent#5 detent-agent effort bogus", `effort "bogus" is not supported by model "gpt-default"`, "supported efforts: low, high"},
+			wantHint:     "remove the effort key",
+			wantModel:    "gpt-default",
+			wantEffort:   "bogus",
+			wantProbes:   1,
+		},
+		{
 			name:       "retired model",
-			issue:      connector.Issue{ID: "issue-3", Identifier: "digitaldrywood/detent#3", Description: "```detent-agent\nschema: 1\nmodel: gpt-retired\n```"},
-			probeErr:   errors.New("model retired"),
+			issue:      connector.Issue{ID: "issue-6", Identifier: "digitaldrywood/detent#6", Description: "```detent-agent\nschema: 1\nmodel: gpt-retired\n```"},
 			wantStatus: doctorFail,
-			wantDetail: "digitaldrywood/detent#3 detent-agent model gpt-retired",
+			wantDetail: []string{"digitaldrywood/detent#6 detent-agent model gpt-retired", `retired; use "gpt-5.5"`},
+			wantModel:  "gpt-retired",
 			wantProbes: 1,
 		},
 		{
 			name: "comment block ignored",
-			issue: connector.Issue{ID: "issue-4", Identifier: "digitaldrywood/detent#4", Comments: []connector.IssueComment{{
+			issue: connector.Issue{ID: "issue-7", Identifier: "digitaldrywood/detent#7", Comments: []connector.IssueComment{{
 				Body: "```detent-agent\nschema: 1\nmodel: gpt-retired\n```",
 			}}},
 			wantStatus: doctorOK,
-			wantDetail: "validated 0",
+			wantDetail: []string{"validated 0 detent-agent model override(s)", "0 effort override(s)"},
 		},
 	}
 
@@ -458,6 +498,14 @@ func TestCheckDoctorIssueAgentModels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := validDoctorWorkflow(t.TempDir())
+			if tt.defaultModel != "" {
+				cfg.Agents.Routes = []workflowconfig.AgentRoute{{
+					Name:    "default",
+					Backend: workflowconfig.DefaultAgentBackendID,
+					Model:   tt.defaultModel,
+					Default: true,
+				}}
+			}
 			probes := 0
 			check := checkDoctorIssueAgentModels(context.Background(), "detent", globalconfig.Project{ID: "detent", Workdir: t.TempDir()}, cfg, doctorDeps{
 				autoPromoteConnector: func(workflowconfig.Config) (doctorAutoPromoteConnector, error) {
@@ -465,17 +513,74 @@ func TestCheckDoctorIssueAgentModels(t *testing.T) {
 				},
 				modelProbe: func(_ context.Context, req doctorRouteModelProbeRequest) error {
 					probes++
-					if req.Model != "gpt-5.5" && req.Model != "gpt-retired" {
-						t.Fatalf("probe model = %q", req.Model)
+					if req.Model != tt.wantModel || req.Effort != tt.wantEffort {
+						t.Fatalf("probe model/effort = %q/%q, want %q/%q", req.Model, req.Effort, tt.wantModel, tt.wantEffort)
 					}
-					return tt.probeErr
+					if err := validateDoctorModelCatalog(models, req.Model); err != nil {
+						return err
+					}
+					if req.Effort == "" {
+						return nil
+					}
+					return validateDoctorEffortCatalog(models, req.Model, req.Effort)
 				},
 			})
-			if check.Status != tt.wantStatus || !strings.Contains(check.Detail, tt.wantDetail) {
-				t.Fatalf("check = %#v, want status %s detail containing %q", check, tt.wantStatus, tt.wantDetail)
+			if check.Status != tt.wantStatus {
+				t.Fatalf("check status = %s, want %s: %#v", check.Status, tt.wantStatus, check)
+			}
+			for _, want := range tt.wantDetail {
+				if !strings.Contains(check.Detail, want) {
+					t.Fatalf("check detail = %q, want containing %q", check.Detail, want)
+				}
+			}
+			if tt.wantHint != "" && !strings.Contains(check.Hint, tt.wantHint) {
+				t.Fatalf("check hint = %q, want containing %q", check.Hint, tt.wantHint)
 			}
 			if probes != tt.wantProbes {
 				t.Fatalf("probes = %d, want %d", probes, tt.wantProbes)
+			}
+		})
+	}
+}
+
+func TestValidateDoctorEffortCatalog(t *testing.T) {
+	t.Parallel()
+
+	models := []runnerpkg.AgentModel{
+		{ID: "gpt-default", Model: "gpt-default", SupportedReasoningEfforts: []string{"low", "high"}},
+		{ID: "gpt-5.5", Model: "gpt-5.5", SupportedReasoningEfforts: []string{"low", "medium", "high"}},
+		{ID: "gpt-retired", Model: "gpt-retired", Upgrade: "gpt-5.5", SupportedReasoningEfforts: []string{"medium"}},
+	}
+	tests := []struct {
+		name    string
+		model   string
+		effort  string
+		wantErr []string
+	}{
+		{name: "supported effort", model: "gpt-default", effort: "HIGH"},
+		{name: "model-specific effort", model: "gpt-5.5", effort: "medium"},
+		{name: "unsupported effort", model: "gpt-default", effort: "medium", wantErr: []string{`effort "medium"`, `model "gpt-default"`, "supported efforts: low, high"}},
+		{name: "unknown model", model: "gpt-unknown", effort: "high", wantErr: []string{"not available"}},
+		{name: "retired model", model: "gpt-retired", effort: "medium", wantErr: []string{`retired; use "gpt-5.5"`}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			err := validateDoctorEffortCatalog(models, tt.model, tt.effort)
+			if len(tt.wantErr) == 0 {
+				if err != nil {
+					t.Fatalf("validateDoctorEffortCatalog() error = %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("validateDoctorEffortCatalog() error = nil")
+			}
+			for _, want := range tt.wantErr {
+				if !strings.Contains(err.Error(), want) {
+					t.Fatalf("validateDoctorEffortCatalog() error = %v, want containing %q", err, want)
+				}
 			}
 		})
 	}
@@ -538,8 +643,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			loadErr:    errors.New("missing workflow"),
-			wantStatus: []doctorStatus{doctorFail, doctorWarn},
-			wantDetail: []string{"missing workflow", "skipped"},
+			wantStatus: []doctorStatus{doctorFail, doctorWarn, doctorOK},
+			wantDetail: []string{"missing workflow", "skipped", "skipped because WORKFLOW.md could not be loaded"},
 		},
 		{
 			name: "workflow invalid",
@@ -547,8 +652,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: workflowconfig.Config{}},
-			wantStatus: []doctorStatus{doctorFail, doctorWarn},
-			wantDetail: []string{"tracker.kind", "skipped"},
+			wantStatus: []doctorStatus{doctorFail, doctorWarn, doctorOK},
+			wantDetail: []string{"tracker.kind", "skipped", "skipped because WORKFLOW.md is invalid"},
 		},
 		{
 			name: "source repo missing",
@@ -557,8 +662,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorFail, doctorWarn},
-			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
+			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -566,8 +671,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK},
-			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "is a git worktree", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 	}
 
@@ -593,6 +698,92 @@ func TestCheckDoctorProjects(t *testing.T) {
 				if !strings.Contains(check.Detail, tt.wantDetail[i]) {
 					t.Fatalf("checks[%d].Detail = %q, want containing %q", i, check.Detail, tt.wantDetail[i])
 				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorIssueEffortGuidance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		files       map[string]string
+		directories []string
+		missingRepo bool
+		wantStatus  doctorStatus
+		wantDetail  string
+		wantHint    string
+	}{
+		{
+			name:       "agents guidance passes",
+			files:      map[string]string{"AGENTS.md": "Use a detent-agent block for every issue."},
+			wantStatus: doctorOK,
+			wantDetail: "AGENTS.md mentions detent-agent effort guidance",
+		},
+		{
+			name:       "claude guidance passes case insensitively",
+			files:      map[string]string{"AGENTS.md": "No overrides documented.", "CLAUDE.md": "Choose effort with a DETENT-AGENT block."},
+			wantStatus: doctorOK,
+			wantDetail: "CLAUDE.md mentions detent-agent effort guidance",
+		},
+		{
+			name:       "docs without guidance warn",
+			files:      map[string]string{"AGENTS.md": "General agent instructions.", "CLAUDE.md": "General Claude instructions."},
+			wantStatus: doctorWarn,
+			wantDetail: "contain no detent-agent guidance",
+			wantHint:   "docs/ONBOARDING.md#per-issue-agent-overrides",
+		},
+		{
+			name:       "missing docs warn",
+			wantStatus: doctorWarn,
+			wantDetail: "contain no detent-agent guidance",
+			wantHint:   "effort-selection rubric",
+		},
+		{
+			name:        "unreadable agent doc skips",
+			directories: []string{"AGENTS.md"},
+			wantStatus:  doctorOK,
+			wantDetail:  "skipped because AGENTS.md could not be read",
+		},
+		{
+			name:        "missing source repo skips",
+			missingRepo: true,
+			wantStatus:  doctorOK,
+			wantDetail:  "skipped because source repository is unavailable locally",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			root := t.TempDir()
+			for name, content := range tt.files {
+				if err := os.WriteFile(filepath.Join(root, name), []byte(content), 0o600); err != nil {
+					t.Fatalf("WriteFile(%s) error = %v", name, err)
+				}
+			}
+			for _, name := range tt.directories {
+				if err := os.Mkdir(filepath.Join(root, name), 0o700); err != nil {
+					t.Fatalf("Mkdir(%s) error = %v", name, err)
+				}
+			}
+
+			var got doctorCheck
+			if tt.missingRepo {
+				got = checkDoctorIssueEffortGuidanceForSource("alpha", globalconfig.Project{Workdir: filepath.Join(root, "missing")}, workflowconfig.Default())
+			} else {
+				got = checkDoctorIssueEffortGuidance("alpha", root)
+			}
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.wantStatus, got)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+			if tt.wantHint != "" && !strings.Contains(got.Hint, tt.wantHint) {
+				t.Fatalf("Hint = %q, want containing %q", got.Hint, tt.wantHint)
 			}
 		})
 	}
@@ -1837,7 +2028,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	if gotPath != wantPath {
 		t.Fatalf("git path = %q, want %q", gotPath, wantPath)
 	}
-	if len(checks) != 4 || checks[2].Status != doctorOK {
+	if len(checks) != 5 || checks[2].Status != doctorOK {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
 	}
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -424,11 +424,13 @@ func TestCheckDoctorIssueAgentModels(t *testing.T) {
 		name         string
 		issue        connector.Issue
 		defaultModel string
+		configure    func(*workflowconfig.Config)
 		wantStatus   doctorStatus
 		wantDetail   []string
 		wantHint     string
 		wantModel    string
 		wantEffort   string
+		wantBackend  string
 		wantProbes   int
 	}{
 		{
@@ -466,6 +468,38 @@ func TestCheckDoctorIssueAgentModels(t *testing.T) {
 			wantProbes:   1,
 		},
 		{
+			name: "effort uses issue routed model and backend",
+			issue: connector.Issue{
+				ID:          "issue-routed",
+				Identifier:  "digitaldrywood/detent#8",
+				Description: "```detent-agent\nschema: 1\neffort: medium\n```",
+				Labels:      []string{"tier:routed"},
+			},
+			configure: func(cfg *workflowconfig.Config) {
+				cfg.Agents.Backends = []workflowconfig.AgentBackend{
+					doctorCodexAgentBackend("codex-default"),
+					doctorCodexAgentBackend("codex-routed"),
+				}
+				cfg.Agents.Routes = []workflowconfig.AgentRoute{
+					{
+						Name:    "routed",
+						Backend: "codex-routed",
+						Model:   "gpt-5.5",
+						Selector: selector.Selector{
+							Labels: selector.Labels{Include: []string{"tier:routed"}},
+						},
+					},
+					{Name: "default", Backend: "codex-default", Model: "gpt-default", Default: true},
+				}
+			},
+			wantStatus:  doctorOK,
+			wantDetail:  []string{"validated 0 detent-agent model override(s)", "1 effort override(s)"},
+			wantModel:   "gpt-5.5",
+			wantEffort:  "medium",
+			wantBackend: "codex-routed",
+			wantProbes:  1,
+		},
+		{
 			name:         "unsupported effort names issue and supported efforts",
 			issue:        connector.Issue{ID: "issue-5", Identifier: "digitaldrywood/detent#5", Description: "```detent-agent\nschema: 1\neffort: bogus\n```"},
 			defaultModel: "gpt-default",
@@ -498,6 +532,9 @@ func TestCheckDoctorIssueAgentModels(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 			cfg := validDoctorWorkflow(t.TempDir())
+			if tt.configure != nil {
+				tt.configure(&cfg)
+			}
 			if tt.defaultModel != "" {
 				cfg.Agents.Routes = []workflowconfig.AgentRoute{{
 					Name:    "default",
@@ -513,8 +550,15 @@ func TestCheckDoctorIssueAgentModels(t *testing.T) {
 				},
 				modelProbe: func(_ context.Context, req doctorRouteModelProbeRequest) error {
 					probes++
+					wantBackend := tt.wantBackend
+					if wantBackend == "" {
+						wantBackend = workflowconfig.DefaultAgentBackendID
+					}
 					if req.Model != tt.wantModel || req.Effort != tt.wantEffort {
 						t.Fatalf("probe model/effort = %q/%q, want %q/%q", req.Model, req.Effort, tt.wantModel, tt.wantEffort)
+					}
+					if req.Backend.ID != wantBackend {
+						t.Fatalf("probe backend = %q, want %q", req.Backend.ID, wantBackend)
 					}
 					if err := validateDoctorModelCatalog(models, req.Model); err != nil {
 						return err


### PR DESCRIPTION
## Summary

- Validate per-issue reasoning effort overrides against the effective model catalog before dispatch.
- Report supported effort values and actionable remediation for rejected overrides.
- Warn when project agent guidance omits `detent-agent`, while cleanly skipping unavailable repositories.

Fixes #1161

## UI Surface Contract

- [x] N/A; this change has no UI surface, layout, density, first-viewport, or responsive visibility impact.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] Focused table-driven doctor tests
- [x] `go test ./internal/cli`
- [x] `make check` (76.9% aggregate coverage)