### PR TITLE
fix(scheduler): enforce strict project priority

### DIFF
--- a/README.md
+++ b/README.md
@@ -1972,8 +1972,7 @@ projects:
 
 Project weights are relative scheduling weights. Higher weights receive a
 larger dispatch share in weighted and fair-share scheduling modes. Project
-priority is a rank: `1` is highest, `4` is lowest, and `0` or an omitted value
-means no explicit priority.
+priority is a rank: `0` is highest and `4` is lowest.
 
 Set optional `projects[].color` to an opaque CSS hex color in `#RGB` or
 `#RRGGBB` form when a project needs a fixed visual marker. The sidebar,

--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -1063,7 +1063,7 @@ probes.
    rg '^KANBAN_MODE=' "$ONBOARDING_DIR/answers.env"
    ```
 
-7. **Scheduling.** Ask: "What `global.yaml` `priority` from 1-4 and `weight`
+7. **Scheduling.** Ask: "What `global.yaml` `priority` from 0-4 and `weight`
    should this project receive?" Show `$ONBOARDING_DIR/global-projects.txt`.
    Disambiguate this from the board `Priority` field: `global.yaml` `priority`
    ranks projects on the host; the board `Priority` field ranks issues inside

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -211,7 +211,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	if err != nil {
 		return err
 	}
-	globalDispatchGate := scheduler.NewGlobalDispatchGate(globalScheduler)
+	globalDispatchGate := scheduler.NewGlobalDispatchGate(globalScheduler, globalProjectCandidates(cfg.Global.Projects)...)
 	runtimeGitHubToken := newRuntimeGitHubTokenState(runtimeGlobalGitHubToken(cfg.Runtime.GitHubToken))
 	globalConfigState := newGlobalConfigState(cfg.Global)
 	refreshGitHubToken := runtimeGitHubTokenRefresher(globalConfigState, runtimeGitHubToken)
@@ -293,6 +293,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 
 	onGlobalReload := func(reloaded globalconfig.Config) {
+		globalDispatchGate.SetProjects(globalProjectCandidates(reloaded.Projects))
 		globalConfigState.set(reloaded)
 		republishLatestSnapshot(snapshotHub, logger)
 	}
@@ -369,6 +370,19 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			return serve(ctx, server, listener)
 		})
 	})
+}
+
+func globalProjectCandidates(projects []globalconfig.Project) []scheduler.ProjectCandidate {
+	candidates := make([]scheduler.ProjectCandidate, 0, len(projects))
+	for _, project := range projects {
+		candidates = append(candidates, scheduler.ProjectCandidate{
+			ID:       project.ID,
+			Weight:   project.Weight,
+			Priority: project.Priority,
+			Paused:   project.Paused,
+		})
+	}
+	return candidates
 }
 
 func startOnboarding(ctx context.Context, cfg BootConfig) error {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -293,7 +293,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 	}
 
 	onGlobalReload := func(reloaded globalconfig.Config) {
-		globalDispatchGate.SetProjects(globalProjectCandidates(reloaded.Projects))
+		syncGlobalDispatchProjects(globalDispatchGate, reloaded.Projects, manager.Registry())
 		globalConfigState.set(reloaded)
 		republishLatestSnapshot(snapshotHub, logger)
 	}
@@ -383,6 +383,25 @@ func globalProjectCandidates(projects []globalconfig.Project) []scheduler.Projec
 		})
 	}
 	return candidates
+}
+
+func syncGlobalDispatchProjects(
+	gate *scheduler.GlobalDispatchGate,
+	projects []globalconfig.Project,
+	registry *project.Registry,
+) {
+	candidates := globalProjectCandidates(projects)
+	gate.SetProjects(candidates)
+	for _, candidate := range candidates {
+		if candidate.Paused {
+			continue
+		}
+		runtimeProject, ok := registry.Get(project.ID(candidate.ID))
+		if ok && runtimeProject.Running() {
+			continue
+		}
+		gate.MarkIdle(candidate.ID)
+	}
 }
 
 func startOnboarding(ctx context.Context, cfg BootConfig) error {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -101,6 +101,36 @@ func TestBuildGlobalSchedulerFromSettings(t *testing.T) {
 	}
 }
 
+func TestSyncGlobalDispatchProjectsMarksUnstartedProjectsIdle(t *testing.T) {
+	t.Parallel()
+
+	projects := []globalconfig.Project{
+		{ID: "higher", Weight: 1, Priority: 0},
+		{ID: "lower", Weight: 1, Priority: 3},
+	}
+	gate := scheduler.NewGlobalDispatchGate(scheduler.NewStrictPriority(scheduler.Config{Capacity: 1}))
+	syncGlobalDispatchProjects(gate, projects, projectpkg.NewRegistry())
+
+	lower := globalProjectCandidates(projects)[1]
+	gate.BeginProjectCycle(lower)
+	slot, ok, decision, err := gate.TryAcquireWithDecision(
+		t.Context(),
+		lower,
+		scheduler.SlotRequest{State: "Todo"},
+		time.Date(2026, 7, 10, 15, 0, 0, 0, time.Local),
+	)
+	gate.EndProjectCycle(lower.ID)
+	if err != nil {
+		t.Fatalf("TryAcquireWithDecision() error = %v", err)
+	}
+	if !ok || decision.Reason != scheduler.DispatchGateReasonGranted {
+		t.Fatalf("TryAcquireWithDecision() ok = %t decision = %#v, want granted", ok, decision)
+	}
+	if err := gate.Release(slot); err != nil {
+		t.Fatalf("Release() error = %v", err)
+	}
+}
+
 func TestRedirectDefaultLoggerWritesToFile(t *testing.T) {
 	previous := slog.Default()
 	t.Cleanup(func() {

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -68,7 +68,8 @@ func normalizeWorkerHosts(hosts []string) []string {
 }
 
 func (o *Orchestrator) dispatchReadyIssues(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
-	o.markGlobalProjectIdle()
+	o.beginGlobalProjectCycle()
+	defer o.endGlobalProjectCycle()
 	if state.Draining {
 		return
 	}
@@ -139,7 +140,8 @@ func (o *Orchestrator) hydrateDispatchIssue(ctx context.Context, issue connector
 }
 
 func (o *Orchestrator) dispatchCandidates(ctx context.Context, state *State, issues []connector.Issue, now time.Time) {
-	o.markGlobalProjectIdle()
+	o.beginGlobalProjectCycle()
+	defer o.endGlobalProjectCycle()
 	if state.Draining {
 		return
 	}
@@ -447,6 +449,25 @@ func (o *Orchestrator) markGlobalProjectIdle() {
 		return
 	}
 	o.globalDispatchGate.MarkIdle(o.cfg.Project.ID)
+}
+
+type projectCycleDispatchGate interface {
+	BeginProjectCycle(scheduler.ProjectCandidate)
+	EndProjectCycle(string)
+}
+
+func (o *Orchestrator) beginGlobalProjectCycle() {
+	if gate, ok := o.globalDispatchGate.(projectCycleDispatchGate); ok {
+		gate.BeginProjectCycle(o.cfg.Project)
+		return
+	}
+	o.markGlobalProjectIdle()
+}
+
+func (o *Orchestrator) endGlobalProjectCycle() {
+	if gate, ok := o.globalDispatchGate.(projectCycleDispatchGate); ok {
+		gate.EndProjectCycle(o.cfg.Project.ID)
+	}
 }
 
 type projectStateSlotStats struct {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -310,6 +310,7 @@ func (o *Orchestrator) Run(ctx context.Context) error {
 		ctx = context.Background()
 	}
 	defer close(o.done)
+	defer o.markGlobalProjectIdle()
 
 	ticker := time.NewTicker(o.cfg.PollInterval)
 	defer ticker.Stop()

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -49,6 +49,8 @@ func (o *Orchestrator) tickManual(ctx context.Context, state *State, request man
 }
 
 func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now time.Time, manual *manualRefreshRequest) {
+	o.beginGlobalProjectCycle()
+	defer o.endGlobalProjectCycle()
 	state.tickTransitions = &issueStateSnapshotTransitions{}
 	defer func() {
 		state.tickTransitions = nil

--- a/internal/scheduler/global.go
+++ b/internal/scheduler/global.go
@@ -332,7 +332,7 @@ func fairShareScore(candidate ProjectCandidate, usage store.FairShareUsage) floa
 }
 
 func priorityRank(priority int) int {
-	if priority < 1 || priority > 4 {
+	if priority < 0 || priority > 4 {
 		return 5
 	}
 	return priority

--- a/internal/scheduler/global_gate.go
+++ b/internal/scheduler/global_gate.go
@@ -9,10 +9,11 @@ import (
 )
 
 const (
-	DispatchGateReasonGranted                   = "granted"
-	DispatchGateReasonGlobalCapacityFull        = "global_capacity_full"
-	DispatchGateReasonReservedForHigherPriority = "reserved_for_higher_priority_state"
-	DispatchGateReasonSelectedProjectWaiting    = "selected_project_waiting"
+	DispatchGateReasonGranted                          = "granted"
+	DispatchGateReasonGlobalCapacityFull               = "global_capacity_full"
+	DispatchGateReasonReservedForHigherPriority        = "reserved_for_higher_priority_state"
+	DispatchGateReasonReservedForHigherPriorityProject = "reserved_for_higher_priority_project"
+	DispatchGateReasonSelectedProjectWaiting           = "selected_project_waiting"
 )
 
 type ProjectDispatchGate interface {
@@ -57,22 +58,96 @@ type selectedProjectSlot struct {
 	preemptions []RunningProject
 }
 
+type projectCycleState struct {
+	epoch uint64
+	idle  bool
+}
+
 type GlobalDispatchGate struct {
 	global GlobalScheduler
 
-	mu       sync.Mutex
-	ready    map[string]readyProjectSlot
-	running  map[uint64]runningProjectSlot
-	selected map[string]selectedProjectSlot
+	mu            sync.Mutex
+	ready         map[string]readyProjectSlot
+	running       map[uint64]runningProjectSlot
+	selected      map[string]selectedProjectSlot
+	projects      map[string]ProjectCandidate
+	projectCycles map[string]projectCycleState
+	epoch         uint64
 }
 
-func NewGlobalDispatchGate(global GlobalScheduler) *GlobalDispatchGate {
-	return &GlobalDispatchGate{
-		global:   global,
-		ready:    map[string]readyProjectSlot{},
-		running:  map[uint64]runningProjectSlot{},
-		selected: map[string]selectedProjectSlot{},
+func NewGlobalDispatchGate(global GlobalScheduler, projects ...ProjectCandidate) *GlobalDispatchGate {
+	gate := &GlobalDispatchGate{
+		global:        global,
+		ready:         map[string]readyProjectSlot{},
+		running:       map[uint64]runningProjectSlot{},
+		selected:      map[string]selectedProjectSlot{},
+		projects:      map[string]ProjectCandidate{},
+		projectCycles: map[string]projectCycleState{},
+		epoch:         1,
 	}
+	gate.SetProjects(projects)
+	return gate
+}
+
+func (g *GlobalDispatchGate) SetProjects(projects []ProjectCandidate) {
+	if g == nil {
+		return
+	}
+
+	normalized := normalizeProjectCandidates(projects)
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	next := make(map[string]ProjectCandidate, len(normalized))
+	for _, project := range normalized {
+		next[project.ID] = project
+	}
+	for projectID := range g.projects {
+		if _, ok := next[projectID]; ok {
+			continue
+		}
+		delete(g.ready, projectID)
+		delete(g.selected, projectID)
+		delete(g.projectCycles, projectID)
+	}
+	g.projects = next
+}
+
+func (g *GlobalDispatchGate) BeginProjectCycle(project ProjectCandidate) {
+	if g == nil || g.global == nil {
+		return
+	}
+	project, ok := normalizeSingleProjectCandidate(project)
+	if !ok {
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	g.projects[project.ID] = project
+	delete(g.ready, project.ID)
+	delete(g.selected, project.ID)
+	g.projectCycles[project.ID] = projectCycleState{epoch: g.epoch}
+	if g.global.Mode() != ModeStrictPriority {
+		delete(g.projectCycles, project.ID)
+	}
+}
+
+func (g *GlobalDispatchGate) EndProjectCycle(projectID string) {
+	if g == nil || g.global == nil || g.global.Mode() != ModeStrictPriority {
+		return
+	}
+	projectID = normalizeProjectID(projectID)
+	if projectID == "" {
+		return
+	}
+
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	_, waiting := g.ready[projectID]
+	g.projectCycles[projectID] = projectCycleState{epoch: g.epoch, idle: !waiting}
 }
 
 func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
@@ -87,9 +162,13 @@ func (g *GlobalDispatchGate) MarkReady(project ProjectCandidate) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
 
+	g.projects[project.ID] = project
 	ready := g.ready[project.ID]
 	ready.ProjectCandidate = project
 	g.ready[project.ID] = ready
+	if g.global.Mode() == ModeStrictPriority {
+		g.projectCycles[project.ID] = projectCycleState{epoch: g.epoch}
+	}
 }
 
 func (g *GlobalDispatchGate) MarkIdle(projectID string) {
@@ -106,6 +185,9 @@ func (g *GlobalDispatchGate) MarkIdle(projectID string) {
 
 	delete(g.ready, projectID)
 	delete(g.selected, projectID)
+	if g.global != nil && g.global.Mode() == ModeStrictPriority {
+		g.projectCycles[projectID] = projectCycleState{epoch: g.epoch, idle: true}
+	}
 }
 
 func (g *GlobalDispatchGate) TryAcquire(
@@ -148,11 +230,22 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	default:
 	}
 
+	g.projects[project.ID] = project
 	g.ready[project.ID] = readyProjectSlot{ProjectCandidate: project, request: req}
+	if g.global.Mode() == ModeStrictPriority {
+		g.projectCycles[project.ID] = projectCycleState{epoch: g.epoch}
+		if reservedProjectID, reservedReq, reserved := g.higherPriorityProjectReservationLocked(project); reserved {
+			return Slot{}, false, g.projectDecisionLocked(project.ID, req, reservedProjectID, reservedReq), nil
+		}
+	}
 	g.reconcileSelectionsLocked()
 	if err := g.fillSelectionsLocked(ctx, now, true); err != nil {
 		if errors.Is(err, ErrNoSlots) {
-			decision := g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull)
+			reason := DispatchGateReasonGlobalCapacityFull
+			if g.hasHigherPriorityRunningProjectLocked(project) {
+				reason = DispatchGateReasonReservedForHigherPriorityProject
+			}
+			decision := g.decisionLocked(project.ID, req, reason)
 			return Slot{}, false, decision, nil
 		}
 		return Slot{}, false, DispatchGateDecision{}, err
@@ -171,7 +264,11 @@ func (g *GlobalDispatchGate) TryAcquireWithDecision(
 	slot, err := g.global.RequestSlot(ctx, req)
 	if err != nil {
 		if errors.Is(err, ErrNoSlots) {
-			decision := g.decisionLocked(project.ID, req, DispatchGateReasonGlobalCapacityFull)
+			reason := DispatchGateReasonGlobalCapacityFull
+			if g.hasHigherPriorityRunningProjectLocked(project) {
+				reason = DispatchGateReasonReservedForHigherPriorityProject
+			}
+			decision := g.decisionLocked(project.ID, req, reason)
 			return Slot{}, false, decision, nil
 		}
 		delete(g.selected, project.ID)
@@ -232,6 +329,13 @@ func (g *GlobalDispatchGate) Release(slot Slot) error {
 		return err
 	}
 	delete(g.running, slot.token)
+	if g.global.Mode() == ModeStrictPriority {
+		g.epoch++
+		if g.epoch == 0 {
+			g.epoch = 1
+			clear(g.projectCycles)
+		}
+	}
 	return nil
 }
 
@@ -332,10 +436,14 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string
 		return nil, nil
 	}
 
+	strictProjectRank, strict := g.bestStrictReadyProjectRankLocked()
 	bestPriority := 0
 	first := true
 	for _, ready := range g.ready {
 		if _, ok := excluded[ready.ID]; ok {
+			continue
+		}
+		if strict && priorityRank(ready.Priority) != strictProjectRank {
 			continue
 		}
 		if maxWeight >= 0 && ready.request.Weight > maxWeight {
@@ -356,6 +464,9 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string
 		if _, ok := excluded[ready.ID]; ok {
 			continue
 		}
+		if strict && priorityRank(ready.Priority) != strictProjectRank {
+			continue
+		}
 		if maxWeight >= 0 && ready.request.Weight > maxWeight {
 			continue
 		}
@@ -369,6 +480,22 @@ func (g *GlobalDispatchGate) readyProjectsForSelectionLocked(excluded map[string
 		return projects[i].ID < projects[j].ID
 	})
 	return projects, requests
+}
+
+func (g *GlobalDispatchGate) bestStrictReadyProjectRankLocked() (int, bool) {
+	if g.global.Mode() != ModeStrictPriority {
+		return 0, false
+	}
+	bestRank := 0
+	found := false
+	for _, ready := range g.ready {
+		rank := priorityRank(ready.Priority)
+		if !found || rank < bestRank {
+			bestRank = rank
+			found = true
+		}
+	}
+	return bestRank, found
 }
 
 func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, reason string) DispatchGateDecision {
@@ -395,6 +522,58 @@ func (g *GlobalDispatchGate) decisionLocked(projectID string, req SlotRequest, r
 		ReadyProjects:        len(g.ready),
 		RunningProjects:      len(g.running),
 	}
+}
+
+func (g *GlobalDispatchGate) projectDecisionLocked(
+	projectID string,
+	req SlotRequest,
+	selectedProjectID string,
+	selectedReq SlotRequest,
+) DispatchGateDecision {
+	decision := g.decisionLocked(projectID, req, DispatchGateReasonReservedForHigherPriorityProject)
+	decision.SelectedProjectID = selectedProjectID
+	decision.SelectedState = selectedReq.State
+	return decision
+}
+
+func (g *GlobalDispatchGate) higherPriorityProjectReservationLocked(
+	project ProjectCandidate,
+) (string, SlotRequest, bool) {
+	projectRank := priorityRank(project.Priority)
+	selectedID := ""
+	selectedRank := 0
+	selectedReq := SlotRequest{}
+	for projectID, candidate := range g.projects {
+		if projectID == project.ID || priorityRank(candidate.Priority) >= projectRank {
+			continue
+		}
+		cycle, ok := g.projectCycles[projectID]
+		if ok && cycle.epoch == g.epoch && cycle.idle {
+			continue
+		}
+		rank := priorityRank(candidate.Priority)
+		if selectedID != "" && (rank > selectedRank || rank == selectedRank && projectID > selectedID) {
+			continue
+		}
+		selectedID = projectID
+		selectedRank = rank
+		if ready, readyOK := g.ready[projectID]; readyOK {
+			selectedReq = ready.request
+		} else {
+			selectedReq = SlotRequest{}
+		}
+	}
+	return selectedID, selectedReq, selectedID != ""
+}
+
+func (g *GlobalDispatchGate) hasHigherPriorityRunningProjectLocked(project ProjectCandidate) bool {
+	projectRank := priorityRank(project.Priority)
+	for _, running := range g.running {
+		if running.ProjectID != project.ID && priorityRank(running.Priority) < projectRank {
+			return true
+		}
+	}
+	return false
 }
 
 func (g *GlobalDispatchGate) waitReasonLocked(req SlotRequest) string {

--- a/internal/scheduler/global_gate_test.go
+++ b/internal/scheduler/global_gate_test.go
@@ -476,3 +476,192 @@ func TestGlobalDispatchGateHonorsStrictPriorityPreemption(t *testing.T) {
 		t.Fatalf("urgent Release() error = %v", err)
 	}
 }
+
+func TestGlobalDispatchGateStrictProjectPriorityIsIndependentOfDemandOrder(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name  string
+		order []string
+	}{
+		{name: "higher priority first", order: []string{"higher", "lower"}},
+		{name: "lower priority first", order: []string{"lower", "higher"}},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			now := time.Date(2026, 7, 10, 14, 7, 38, 0, time.Local)
+			projects := map[string]scheduler.ProjectCandidate{
+				"higher": {ID: "detent", Weight: 1, Priority: 0},
+				"lower":  {ID: "gopher-ai", Weight: 1, Priority: 3},
+			}
+			gate := scheduler.NewGlobalDispatchGate(
+				scheduler.NewStrictPriority(scheduler.Config{Capacity: 5}),
+				projects["higher"],
+				projects["lower"],
+			)
+			demand := map[string]int{"higher": 5, "lower": 3}
+			grants := map[string]int{}
+			decisions := map[string][]scheduler.DispatchGateDecision{}
+
+			for _, projectName := range tt.order {
+				gate.BeginProjectCycle(projects[projectName])
+				for range demand[projectName] {
+					project := projects[projectName]
+					slot, ok, decision, err := gate.TryAcquireWithDecision(
+						ctx,
+						project,
+						scheduler.SlotRequest{State: "Todo"},
+						now,
+					)
+					if err != nil {
+						t.Fatalf("%s TryAcquireWithDecision() error = %v", projectName, err)
+					}
+					decisions[projectName] = append(decisions[projectName], decision)
+					if !ok {
+						continue
+					}
+					grants[projectName]++
+					t.Cleanup(func() {
+						if err := gate.Release(slot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+							t.Errorf("Release() error = %v", err)
+						}
+					})
+				}
+				gate.EndProjectCycle(projects[projectName].ID)
+			}
+
+			if grants["higher"] != 5 || grants["lower"] != 0 {
+				t.Fatalf("grants = %#v, want higher=5 lower=0; decisions = %#v", grants, decisions)
+			}
+			for _, decision := range decisions["lower"] {
+				if decision.Reason != scheduler.DispatchGateReasonReservedForHigherPriorityProject {
+					t.Fatalf("lower-priority decision reason = %q, want %q; decision = %#v",
+						decision.Reason,
+						scheduler.DispatchGateReasonReservedForHigherPriorityProject,
+						decision,
+					)
+				}
+			}
+		})
+	}
+}
+
+func TestGlobalDispatchGateStrictProjectPriorityUsesLeftoverCapacity(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name         string
+		higherDemand int
+	}{
+		{name: "higher priority queue empty"},
+		{name: "higher priority project cap reached", higherDemand: 2},
+		{name: "higher priority candidates skipped"},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := t.Context()
+			now := time.Date(2026, 7, 10, 14, 8, 0, 0, time.Local)
+			higher := scheduler.ProjectCandidate{ID: "detent", Weight: 1, Priority: 0}
+			lower := scheduler.ProjectCandidate{ID: "gopher-ai", Weight: 1, Priority: 3}
+			gate := scheduler.NewGlobalDispatchGate(
+				scheduler.NewStrictPriority(scheduler.Config{Capacity: 5}),
+				higher,
+				lower,
+			)
+
+			gate.BeginProjectCycle(higher)
+			for range tt.higherDemand {
+				slot, ok, decision, err := gate.TryAcquireWithDecision(
+					ctx,
+					higher,
+					scheduler.SlotRequest{State: "Todo"},
+					now,
+				)
+				if err != nil {
+					t.Fatalf("higher TryAcquireWithDecision() error = %v", err)
+				}
+				if !ok {
+					t.Fatalf("higher TryAcquireWithDecision() ok = false; decision = %#v", decision)
+				}
+				t.Cleanup(func() {
+					if err := gate.Release(slot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+						t.Errorf("higher Release() error = %v", err)
+					}
+				})
+			}
+			gate.EndProjectCycle(higher.ID)
+
+			gate.BeginProjectCycle(lower)
+			lowerGrants := 0
+			for range 5 - tt.higherDemand {
+				slot, ok, decision, err := gate.TryAcquireWithDecision(
+					ctx,
+					lower,
+					scheduler.SlotRequest{State: "Todo"},
+					now,
+				)
+				if err != nil {
+					t.Fatalf("lower TryAcquireWithDecision() error = %v", err)
+				}
+				if !ok {
+					t.Fatalf("lower TryAcquireWithDecision() ok = false; decision = %#v", decision)
+				}
+				lowerGrants++
+				t.Cleanup(func() {
+					if err := gate.Release(slot); err != nil && !errors.Is(err, scheduler.ErrSlotNotHeld) {
+						t.Errorf("lower Release() error = %v", err)
+					}
+				})
+			}
+			gate.EndProjectCycle(lower.ID)
+
+			if want := 5 - tt.higherDemand; lowerGrants != want {
+				t.Fatalf("lower grants = %d, want %d", lowerGrants, want)
+			}
+		})
+	}
+}
+
+func TestGlobalDispatchGateNonStrictModesDoNotReserveForProjectPriority(t *testing.T) {
+	t.Parallel()
+
+	for _, tt := range []struct {
+		name string
+		new  func(scheduler.Config) scheduler.GlobalScheduler
+	}{
+		{name: "weighted", new: scheduler.NewWeightedFair},
+		{name: "round robin", new: scheduler.NewRoundRobin},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			higher := scheduler.ProjectCandidate{ID: "detent", Weight: 1, Priority: 0}
+			lower := scheduler.ProjectCandidate{ID: "gopher-ai", Weight: 1, Priority: 3}
+			gate := scheduler.NewGlobalDispatchGate(
+				tt.new(scheduler.Config{Capacity: 1}),
+				higher,
+				lower,
+			)
+			gate.BeginProjectCycle(lower)
+			slot, ok, decision, err := gate.TryAcquireWithDecision(
+				t.Context(),
+				lower,
+				scheduler.SlotRequest{State: "Todo"},
+				time.Date(2026, 7, 10, 14, 9, 0, 0, time.Local),
+			)
+			gate.EndProjectCycle(lower.ID)
+			if err != nil {
+				t.Fatalf("TryAcquireWithDecision() error = %v", err)
+			}
+			if !ok || decision.Reason != scheduler.DispatchGateReasonGranted {
+				t.Fatalf("TryAcquireWithDecision() ok = %t decision = %#v, want granted", ok, decision)
+			}
+			if err := gate.Release(slot); err != nil {
+				t.Fatalf("Release() error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/scheduler/global_test.go
+++ b/internal/scheduler/global_test.go
@@ -78,7 +78,7 @@ func TestStrictPriorityReportsPreemption(t *testing.T) {
 	global := newGlobalScheduler(t, scheduler.Config{Kind: "strict", Capacity: 1})
 	request := scheduler.ProjectSelectionRequest{
 		Projects: []scheduler.ProjectCandidate{
-			{ID: "urgent", Priority: 1},
+			{ID: "urgent", Priority: 0},
 		},
 		Running: []scheduler.RunningProject{
 			{ProjectID: "background", Priority: 4},


### PR DESCRIPTION
## Summary

- coordinate strict scheduling through project-cycle epochs at the global capacity gate
- reserve capacity for configured higher-priority project demand independent of project loop order
- record `reserved_for_higher_priority_project` decisions and preserve leftover capacity for lower-priority projects
- align project priority rank documentation with priority 0 as the highest rank

Fixes #1190

## Test Plan

- `go test -race ./internal/scheduler ./internal/orchestrator ./internal/cli -count=1`
- `make check`