### PR TITLE
fix(doctor): ignore negated review prose

### DIFF
--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -1029,6 +1029,32 @@ func TestCheckDoctorProjectWorkflowReportsReviewFlowChoiceAndProseMismatch(t *te
 			wantDetail: []string{"review-flow=autopilot", "review-flow prose mismatch", "instructs agents to enter the review state"},
 		},
 		{
+			name: "autopilot permits negated review prose",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorWorkflow("/repo")
+				cfg.Agent.AutoPromote.Enabled = true
+				cfg.Agent.AutoPromote.QuietSeconds = 0
+				cfg.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
+				return cfg
+			}(),
+			prompt:     "Do NOT move the issue to Human Review. Never move the work item to Human Review.",
+			wantStatus: doctorOK,
+			wantDetail: []string{"review-flow=autopilot"},
+		},
+		{
+			name: "autopilot detects affirmative instruction in mixed prose",
+			cfg: func() workflowconfig.Config {
+				cfg := validDoctorWorkflow("/repo")
+				cfg.Agent.AutoPromote.Enabled = true
+				cfg.Agent.AutoPromote.QuietSeconds = 0
+				cfg.Agent.AutoPromote.GateWaitState = workflowconfig.AutoPromoteGateWaitStateSource
+				return cfg
+			}(),
+			prompt:     "Do not move the issue to Human Review.\nWhen requested, move the issue to Human Review.",
+			wantStatus: doctorWarn,
+			wantDetail: []string{"review-flow=autopilot", "review-flow prose mismatch"},
+		},
+		{
 			name: "autopilot contradicted by custom review state prose",
 			cfg: func() workflowconfig.Config {
 				cfg := validDoctorWorkflow("/repo")
@@ -1055,6 +1081,13 @@ func TestCheckDoctorProjectWorkflowReportsReviewFlowChoiceAndProseMismatch(t *te
 			prompt:     "Do not move the issue to Human Review; Detent promotes the issue directly to `Merging`.",
 			wantStatus: doctorWarn,
 			wantDetail: []string{"review-flow=review-gate", "review-flow prose mismatch", "promises direct review-state skipping"},
+		},
+		{
+			name:       "review gate permits negated skip and direct promotion prose",
+			cfg:        validDoctorWorkflow("/repo"),
+			prompt:     "Do not skip Human Review. Do not promote the issue directly to Merging.",
+			wantStatus: doctorOK,
+			wantDetail: []string{"review-flow=review-gate"},
 		},
 		{
 			name: "review gate contradicted by custom direct promotion prose",

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -1376,7 +1376,7 @@ func doctorReviewFlowPhraseMatches(text string, phrases []string) int {
 
 func doctorReviewFlowPhraseMatch(text string, phrase string) bool {
 	segments := strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
-		return r == '\n' || r == '\r' || r == '.' || r == '!' || r == '?' || r == ';'
+		return r == '.' || r == '!' || r == '?' || r == ';'
 	})
 	for _, segment := range segments {
 		segment = strings.Join(strings.Fields(segment), " ")
@@ -1386,7 +1386,7 @@ func doctorReviewFlowPhraseMatch(text string, phrase string) bool {
 				break
 			}
 			match += offset
-			if !doctorReviewFlowPhraseNegated(segment[:match]) {
+			if !doctorReviewFlowPhraseNegated(segment[:match], segment[match+len(phrase):]) {
 				return true
 			}
 			offset = match + len(phrase)
@@ -1395,17 +1395,25 @@ func doctorReviewFlowPhraseMatch(text string, phrase string) bool {
 	return false
 }
 
-func doctorReviewFlowPhraseNegated(prefix string) bool {
+func doctorReviewFlowPhraseNegated(prefix string, suffix string) bool {
 	words := strings.Fields(prefix)
 	if len(words) > 5 {
 		words = words[len(words)-5:]
 	}
 	window := " " + strings.Join(words, " ") + " "
-	return strings.Contains(window, " not ") ||
+	negated := strings.Contains(window, " not ") ||
 		strings.Contains(window, " never ") ||
 		strings.Contains(window, " don't ") ||
 		strings.Contains(window, " avoid ") ||
 		strings.Contains(window, " instead of ")
+	if !negated {
+		return false
+	}
+
+	suffix = " " + strings.Join(strings.Fields(suffix), " ") + " "
+	return !strings.Contains(suffix, " until ") &&
+		!strings.Contains(suffix, " unless ") &&
+		!strings.Contains(suffix, " except ")
 }
 
 func doctorWorkflowFinding(

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -1364,14 +1364,48 @@ func doctorReviewFlowStateLabel(state string) string {
 }
 
 func doctorReviewFlowPhraseMatches(text string, phrases []string) int {
-	text = strings.ToLower(strings.Join(strings.Fields(text), " "))
 	count := 0
 	for _, phrase := range phrases {
-		if strings.Contains(text, strings.ToLower(strings.Join(strings.Fields(phrase), " "))) {
+		phrase = strings.ToLower(strings.Join(strings.Fields(phrase), " "))
+		if doctorReviewFlowPhraseMatch(text, phrase) {
 			count++
 		}
 	}
 	return count
+}
+
+func doctorReviewFlowPhraseMatch(text string, phrase string) bool {
+	segments := strings.FieldsFunc(strings.ToLower(text), func(r rune) bool {
+		return r == '\n' || r == '\r' || r == '.' || r == '!' || r == '?' || r == ';'
+	})
+	for _, segment := range segments {
+		segment = strings.Join(strings.Fields(segment), " ")
+		for offset := 0; offset < len(segment); {
+			match := strings.Index(segment[offset:], phrase)
+			if match < 0 {
+				break
+			}
+			match += offset
+			if !doctorReviewFlowPhraseNegated(segment[:match]) {
+				return true
+			}
+			offset = match + len(phrase)
+		}
+	}
+	return false
+}
+
+func doctorReviewFlowPhraseNegated(prefix string) bool {
+	words := strings.Fields(prefix)
+	if len(words) > 5 {
+		words = words[len(words)-5:]
+	}
+	window := " " + strings.Join(words, " ") + " "
+	return strings.Contains(window, " not ") ||
+		strings.Contains(window, " never ") ||
+		strings.Contains(window, " don't ") ||
+		strings.Contains(window, " avoid ") ||
+		strings.Contains(window, " instead of ")
 }
 
 func doctorWorkflowFinding(

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -445,6 +445,18 @@ func TestDoctorReviewFlowPhraseMatches(t *testing.T) {
 			want:    1,
 		},
 		{
+			name:    "affirmative enter review instruction wrapped across lines",
+			text:    "When done, move the issue to\nHuman Review.",
+			phrases: doctorReviewFlowEnterReviewPhrases("Human Review"),
+			want:    1,
+		},
+		{
+			name:    "conditional enter review instruction",
+			text:    "Do not move the issue to Human Review until validation passes.",
+			phrases: doctorReviewFlowEnterReviewPhrases("Human Review"),
+			want:    1,
+		},
+		{
 			name:    "do not enter review instruction",
 			text:    "Do NOT move the issue to Human Review.",
 			phrases: doctorReviewFlowEnterReviewPhrases("Human Review"),

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -429,6 +429,61 @@ func TestDoctorWorkflowOptimizationReviewFlowFindings(t *testing.T) {
 	}
 }
 
+func TestDoctorReviewFlowPhraseMatches(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		text    string
+		phrases []string
+		want    int
+	}{
+		{
+			name:    "affirmative enter review instruction",
+			text:    "When done, move the issue to Human Review.",
+			phrases: doctorReviewFlowEnterReviewPhrases("Human Review"),
+			want:    1,
+		},
+		{
+			name:    "do not enter review instruction",
+			text:    "Do NOT move the issue to Human Review.",
+			phrases: doctorReviewFlowEnterReviewPhrases("Human Review"),
+		},
+		{
+			name:    "never enter review instruction",
+			text:    "Never move the issue to Human Review.",
+			phrases: doctorReviewFlowEnterReviewPhrases("Human Review"),
+		},
+		{
+			name:    "negated skip review instruction",
+			text:    "Do not skip Human Review.",
+			phrases: doctorReviewFlowSkipReviewPhrases("Human Review"),
+		},
+		{
+			name:    "negated direct promotion instruction",
+			text:    "Do not promote the issue directly to Merging.",
+			phrases: doctorReviewFlowDirectPromotePhrases("Merging"),
+		},
+		{
+			name: "mixed document",
+			text: "Do not move the issue to Human Review.\n" +
+				"When explicitly requested, move the issue to Human Review.",
+			phrases: doctorReviewFlowEnterReviewPhrases("Human Review"),
+			want:    1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := doctorReviewFlowPhraseMatches(tt.text, tt.phrases); got != tt.want {
+				t.Fatalf("doctorReviewFlowPhraseMatches() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDoctorWorkflowReviewFlowTelemetryCountsImmediateReviewEntries(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- Ignore review-flow phrase matches negated within the preceding five words of the same sentence or line.
- Cover autopilot and review-gate prose with matcher-level and end-to-end table-driven tests.

Fixes #1195

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`