### PR TITLE
feat(prompt): add follow-up filing guidance

### DIFF
--- a/docs/ONBOARDING.md
+++ b/docs/ONBOARDING.md
@@ -2266,6 +2266,36 @@ awk 'NF {last=$0} END {exit last == "MUTATION_CONFIRMED=true" ? 0 : 1}' "$ONBOAR
      <source-root>/WORKFLOW.md
    ```
 
+## Out-of-Scope Follow-ups
+
+Detent adds an `## Out-of-scope discoveries` block to pull-request agent
+prompts by default. It tells agents to keep the current issue scoped and file
+meaningful unrelated problems or improvements as separate tracker issues in
+the project's Backlog state. Each self-filed issue includes a fenced
+`detent-agent` block with `schema: 1` and the agent's best-guess `effort` from
+the project's rubric. Projects should define that rubric in their
+agent-facing documentation.
+
+The agent uses the tracker's configured status source when placing the new
+issue. If that source cannot be updated from the session, the agent files the
+issue without a state and reports the limitation in its final handoff.
+Plan-only and non-pull-request runs do not receive this prompt block.
+
+The prompt guidance is controlled by `agent.followups.enabled`, which defaults
+to `true`:
+
+```yaml
+agent:
+  followups:
+    enabled: true
+```
+
+Set `agent.followups.enabled: false` to remove the generated block. Maintained
+workflow templates also include the filing rule in their prompt body, so the
+guidance remains available when the generated block is disabled. `detent
+doctor` warns when follow-ups are disabled and the loaded WORKFLOW.md body has
+no equivalent out-of-scope filing guidance.
+
 ## Skills And Skill Creation
 
 Detent skills are repository-owned Markdown instructions that give agents

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -235,6 +235,8 @@ upstream GitHub metadata writes, native dependencies are unavailable, and the
 project has not migrated, keep a machine-readable issue-body line such as
 `Blocked by: #123` or `Depends on: owner/repo#123`.
 
+If meaningful out-of-scope work is discovered, file a separate tracker issue in Backlog with a best-guess `detent-agent` effort block instead of expanding the current work item.
+
 ## Required Execution Flow
 
 Use the current Detent state as the source of truth for which section applies.

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -225,6 +225,8 @@ human_action: null
    unavailable and the project has not migrated, keep a machine-readable
    issue-body line such as `Blocked by: #123` or `Depends on: owner/repo#123`.
 
+If meaningful out-of-scope work is discovered, file a separate tracker issue in Backlog with a best-guess `detent-agent` effort block instead of expanding the current work item.
+
 ## Required Execution Flow
 
 Use the current Detent state as the source of truth for which section applies.

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -225,6 +225,8 @@ human_action: null
    unavailable and the project has not migrated, keep a machine-readable
    issue-body line such as `Blocked by: #123` or `Depends on: owner/repo#123`.
 
+If meaningful out-of-scope work is discovered, file a separate tracker issue in Backlog with a best-guess `detent-agent` effort block instead of expanding the current work item.
+
 ## Required Execution Flow
 
 Use the current Detent state as the source of truth for which section applies.

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -200,6 +200,8 @@ directory. For video ad production, include:
 - validation status and validation notes
 - next external-system action
 
+If meaningful out-of-scope work is discovered, file a separate tracker issue in Backlog with a best-guess `detent-agent` effort block instead of expanding the current work item.
+
 ## Required Execution Flow
 
 This workflow uses the artifact autopilot handoff: `agent.auto_promote.enabled:

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -224,6 +224,8 @@ human_action: null
    unavailable and the project has not migrated, keep a machine-readable
    issue-body line such as `Blocked by: #123` or `Depends on: owner/repo#123`.
 
+If meaningful out-of-scope work is discovered, file a separate tracker issue in Backlog with a best-guess `detent-agent` effort block instead of expanding the current work item.
+
 ## Required Execution Flow
 
 Use the current Detent state as the source of truth for which section applies.

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -108,6 +108,7 @@ func checkDoctorProjectWithProgress(
 				Hint:   "Fix the workflow file, then rerun detent doctor.",
 			},
 			checkDoctorIssueEffortGuidanceUnavailable(id, "WORKFLOW.md could not be loaded"),
+			checkDoctorFollowupGuidanceUnavailable(id, "WORKFLOW.md could not be loaded"),
 		}
 	}
 	workflow.Config = doctorWorkflowConfigWithRuntimeGitHubToken(workflow.Config, runtimeGlobalGitHubToken(githubToken))
@@ -126,6 +127,7 @@ func checkDoctorProjectWithProgress(
 				Hint:   "Fix the workflow file, then rerun detent doctor.",
 			},
 			checkDoctorIssueEffortGuidanceUnavailable(id, "WORKFLOW.md is invalid"),
+			checkDoctorFollowupGuidanceUnavailable(id, "WORKFLOW.md is invalid"),
 		}
 	}
 
@@ -147,6 +149,8 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks := []doctorCheck{workflowCheck}
+	setDoctorCurrentCheck("Project " + id + " out-of-scope follow-up guidance")
+	checks = append(checks, checkDoctorFollowupGuidance(id, workflow.Config.Agent.Followups, workflow.Prompt))
 	setDoctorCurrentCheck("Project " + id + " pinned route models")
 	checks = append(checks, checkDoctorRouteModels(ctx, id, project, workflow.Config, deps))
 	if doctorTrackerUsesGitHubReads(workflow.Config.Tracker.Kind) {
@@ -281,6 +285,49 @@ func checkDoctorIssueEffortGuidance(id string, sourceRoot string) doctorCheck {
 func checkDoctorIssueEffortGuidanceUnavailable(id string, reason string) doctorCheck {
 	return doctorCheck{
 		Name:   "Project " + id + " issue effort guidance",
+		Status: doctorOK,
+		Detail: "skipped because " + reason,
+	}
+}
+
+func checkDoctorFollowupGuidance(id string, cfg workflowconfig.Followups, workflowBody string) doctorCheck {
+	name := "Project " + id + " out-of-scope follow-up guidance"
+	if cfg.Enabled {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "agent.followups.enabled=true provides prompt guidance",
+		}
+	}
+	if hasFollowupFilingGuidance(workflowBody) {
+		return doctorCheck{
+			Name:   name,
+			Status: doctorOK,
+			Detail: "WORKFLOW.md body provides out-of-scope follow-up filing guidance",
+		}
+	}
+	return doctorCheck{
+		Name:   name,
+		Status: doctorWarn,
+		Detail: "agent.followups.enabled=false and WORKFLOW.md body contains no out-of-scope follow-up filing guidance",
+		Hint:   "Enable agent.followups.enabled or instruct agents in the WORKFLOW.md body to file separate Backlog issues for meaningful out-of-scope discoveries.",
+	}
+}
+
+func hasFollowupFilingGuidance(workflowBody string) bool {
+	body := strings.ToLower(workflowBody)
+	describesFollowup := strings.Contains(body, "out-of-scope") ||
+		strings.Contains(body, "out of scope") ||
+		strings.Contains(body, "follow-up") ||
+		strings.Contains(body, "follow up")
+	describesTrackerItem := strings.Contains(body, "issue") || strings.Contains(body, "work item")
+	describesFiling := strings.Contains(body, "file") || strings.Contains(body, "create")
+	return describesFollowup && describesTrackerItem && describesFiling
+}
+
+func checkDoctorFollowupGuidanceUnavailable(id string, reason string) doctorCheck {
+	return doctorCheck{
+		Name:   "Project " + id + " out-of-scope follow-up guidance",
 		Status: doctorOK,
 		Detail: "skipped because " + reason,
 	}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -687,8 +687,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			loadErr:    errors.New("missing workflow"),
-			wantStatus: []doctorStatus{doctorFail, doctorWarn, doctorOK},
-			wantDetail: []string{"missing workflow", "skipped", "skipped because WORKFLOW.md could not be loaded"},
+			wantStatus: []doctorStatus{doctorFail, doctorWarn, doctorOK, doctorOK},
+			wantDetail: []string{"missing workflow", "skipped", "skipped because WORKFLOW.md could not be loaded", "skipped because WORKFLOW.md could not be loaded"},
 		},
 		{
 			name: "workflow invalid",
@@ -696,8 +696,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: workflowconfig.Config{}},
-			wantStatus: []doctorStatus{doctorFail, doctorWarn, doctorOK},
-			wantDetail: []string{"tracker.kind", "skipped", "skipped because WORKFLOW.md is invalid"},
+			wantStatus: []doctorStatus{doctorFail, doctorWarn, doctorOK, doctorOK},
+			wantDetail: []string{"tracker.kind", "skipped", "skipped because WORKFLOW.md is invalid", "skipped because WORKFLOW.md is invalid"},
 		},
 		{
 			name: "source repo missing",
@@ -706,8 +706,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
 			gitErr:     errors.New("not a git worktree"),
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
-			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorFail, doctorOK, doctorWarn},
+			wantDetail: []string{"is valid", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "not a git worktree", "skipped because source repository is unavailable locally", "skipped because source repository is unavailable locally"},
 		},
 		{
 			name: "workflow and source repo valid",
@@ -715,8 +715,8 @@ func TestCheckDoctorProjects(t *testing.T) {
 				{ID: "alpha", Workflow: "WORKFLOW.md"},
 			},
 			workflow:   workflowconfig.Workflow{Config: validDoctorWorkflow("/repo")},
-			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
-			wantDetail: []string{"is valid", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 	}
 
@@ -819,6 +819,70 @@ func TestCheckDoctorIssueEffortGuidance(t *testing.T) {
 				got = checkDoctorIssueEffortGuidanceForSource("alpha", globalconfig.Project{Workdir: filepath.Join(root, "missing")}, workflowconfig.Default())
 			} else {
 				got = checkDoctorIssueEffortGuidance("alpha", root)
+			}
+			if got.Status != tt.wantStatus {
+				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.wantStatus, got)
+			}
+			if !strings.Contains(got.Detail, tt.wantDetail) {
+				t.Fatalf("Detail = %q, want containing %q", got.Detail, tt.wantDetail)
+			}
+			if tt.wantHint != "" && !strings.Contains(got.Hint, tt.wantHint) {
+				t.Fatalf("Hint = %q, want containing %q", got.Hint, tt.wantHint)
+			}
+		})
+	}
+}
+
+func TestCheckDoctorFollowupGuidance(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        workflowconfig.Followups
+		body       string
+		available  bool
+		wantStatus doctorStatus
+		wantDetail string
+		wantHint   string
+	}{
+		{
+			name:       "enabled passes without workflow prose",
+			cfg:        workflowconfig.Followups{Enabled: true},
+			available:  true,
+			wantStatus: doctorOK,
+			wantDetail: "enabled=true provides prompt guidance",
+		},
+		{
+			name:       "disabled passes with workflow prose",
+			body:       "File a separate follow-up issue in Backlog for meaningful out-of-scope work.",
+			available:  true,
+			wantStatus: doctorOK,
+			wantDetail: "WORKFLOW.md body provides out-of-scope follow-up filing guidance",
+		},
+		{
+			name:       "disabled warns without workflow prose",
+			body:       "Keep changes scoped to the current issue.",
+			available:  true,
+			wantStatus: doctorWarn,
+			wantDetail: "contains no out-of-scope follow-up filing guidance",
+			wantHint:   "Enable agent.followups.enabled",
+		},
+		{
+			name:       "unavailable workflow body skips",
+			wantStatus: doctorOK,
+			wantDetail: "skipped because WORKFLOW.md could not be loaded",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			var got doctorCheck
+			if tt.available {
+				got = checkDoctorFollowupGuidance("alpha", tt.cfg, tt.body)
+			} else {
+				got = checkDoctorFollowupGuidanceUnavailable("alpha", "WORKFLOW.md could not be loaded")
 			}
 			if got.Status != tt.wantStatus {
 				t.Fatalf("Status = %s, want %s: %#v", got.Status, tt.wantStatus, got)
@@ -2105,7 +2169,7 @@ func TestCheckDoctorProjectsExpandsSourceRootBeforeGit(t *testing.T) {
 	if gotPath != wantPath {
 		t.Fatalf("git path = %q, want %q", gotPath, wantPath)
 	}
-	if len(checks) != 5 || checks[2].Status != doctorOK {
+	if len(checks) != 6 || checks[3].Status != doctorOK || checks[3].Name != "Project alpha source repo" {
 		t.Fatalf("checks = %#v, want source repo OK", checks)
 	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -237,6 +237,7 @@ type Agent struct {
 	Lessons                      Lessons                      `yaml:"lessons"`
 	Knowledge                    Knowledge                    `yaml:"knowledge"`
 	Skills                       Skills                       `yaml:"skills"`
+	Followups                    Followups                    `yaml:"followups"`
 }
 
 type Shutdown struct {
@@ -353,6 +354,10 @@ type Skills struct {
 type SkillCreation struct {
 	Enabled         bool `yaml:"enabled"`
 	MaxDraftsPerRun int  `yaml:"max_drafts_per_run"`
+}
+
+type Followups struct {
+	Enabled bool `yaml:"enabled"`
 }
 
 type Budget struct {
@@ -867,6 +872,7 @@ func Default() Config {
 			Lessons:   defaultLessons(),
 			Knowledge: defaultKnowledge(),
 			Skills:    defaultSkills(),
+			Followups: Followups{Enabled: true},
 		},
 		Codex: Codex{
 			Command: "codex app-server",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -12,6 +12,34 @@ import (
 	"github.com/digitaldrywood/detent/internal/selector"
 )
 
+func TestParseWorkflowFollowups(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		agent   string
+		enabled bool
+	}{
+		{name: "defaults enabled", enabled: true},
+		{name: "explicitly enabled", agent: "agent:\n  followups:\n    enabled: true\n", enabled: true},
+		{name: "explicitly disabled", agent: "agent:\n  followups:\n    enabled: false\n"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			workflow, err := ParseWorkflow([]byte("---\n" + tt.agent + "---\nPrompt\n"))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if workflow.Config.Agent.Followups.Enabled != tt.enabled {
+				t.Fatalf("Agent.Followups.Enabled = %t, want %t", workflow.Config.Agent.Followups.Enabled, tt.enabled)
+			}
+		})
+	}
+}
+
 func TestParseWorkflowFrontmatter(t *testing.T) {
 	t.Parallel()
 
@@ -143,6 +171,8 @@ agent:
     creation:
       enabled: true
       max_drafts_per_run: 3
+  followups:
+    enabled: false
 codex:
   command: codex app-server
   shell: bash
@@ -350,6 +380,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if cfg.Agent.Skills.Creation.MaxDraftsPerRun != 3 {
 		t.Fatalf("Agent.Skills.Creation.MaxDraftsPerRun = %d, want 3", cfg.Agent.Skills.Creation.MaxDraftsPerRun)
+	}
+	if cfg.Agent.Followups.Enabled {
+		t.Fatal("Agent.Followups.Enabled = true, want false")
 	}
 	if cfg.Agent.Shutdown.DrainTimeoutMS != 300000 {
 		t.Fatalf("Agent.Shutdown.DrainTimeoutMS = %d, want 300000", cfg.Agent.Shutdown.DrainTimeoutMS)
@@ -686,6 +719,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if cfg.Agent.Skills.Creation.MaxDraftsPerRun != 1 {
 		t.Fatalf("Agent.Skills.Creation.MaxDraftsPerRun = %d, want 1", cfg.Agent.Skills.Creation.MaxDraftsPerRun)
+	}
+	if !cfg.Agent.Followups.Enabled {
+		t.Fatal("Agent.Followups.Enabled = false, want true default")
 	}
 	if cfg.Workpad.StructuredOnly {
 		t.Fatal("Workpad.StructuredOnly = true, want false default")

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -109,6 +109,7 @@ func BuildPrompt(workflow config.Workflow, issue connector.Issue, opts PromptOpt
 		return rendered, nil
 	}
 	if !opts.PlanOnly {
+		rendered = appendFollowupsBlock(rendered, workflow.Config.Agent.Followups)
 		rendered = appendSkillCreationBlock(rendered, workflow.Config.Agent.Skills)
 	}
 	return appendClosingReferenceInstruction(rendered, issue), nil
@@ -516,6 +517,21 @@ func appendSkillCreationBlock(prompt string, cfg config.Skills) string {
 	b.WriteString("- Let normal pull request review be the approval gate; the draft skill enters future prompts only after humans review and merge it.\n")
 
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + strings.TrimRight(b.String(), "\n")
+}
+
+func appendFollowupsBlock(prompt string, cfg config.Followups) string {
+	if !cfg.Enabled {
+		return prompt
+	}
+
+	const block = `## Out-of-scope discoveries
+
+When this run surfaces a meaningful problem or improvement unrelated to the current issue, file a separate tracker issue instead of expanding the current issue's scope.
+- Place the follow-up issue in the project's Backlog state through the configured status source.
+- Include a fenced ` + "`detent-agent`" + ` block with ` + "`schema: 1`" + ` and a best-guess ` + "`effort`" + ` chosen from the project's effort rubric.
+- If the configured status source cannot be set from this session, file the issue without a state and say so in the final handoff.`
+
+	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + block
 }
 
 func appendGateBlock(prompt string, cfg gate.Config) string {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -255,6 +255,56 @@ func TestBuildPromptSkillCreationInstructionsAreConfigurable(t *testing.T) {
 	}
 }
 
+func TestBuildPromptFollowupInstructionsAreConfigurable(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name        string
+		config      config.Config
+		planOnly    bool
+		wantPresent bool
+	}{
+		{name: "default pull request workflow", config: config.Default(), wantPresent: true},
+		{name: "disabled", config: func() config.Config {
+			cfg := config.Default()
+			cfg.Agent.Followups.Enabled = false
+			return cfg
+		}()},
+		{name: "artifact workflow", config: func() config.Config {
+			cfg := config.Default()
+			cfg.Deliverable.Kind = config.DeliverableArtifact
+			return cfg
+		}()},
+		{name: "plan only workflow", config: config.Default(), planOnly: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prompt, err := BuildPrompt(config.Workflow{Config: tt.config}, connector.Issue{
+				Identifier: "digitaldrywood/detent#1164",
+				Title:      "Follow-up filing guidance",
+			}, PromptOptions{PlanOnly: tt.planOnly})
+			if err != nil {
+				t.Fatalf("BuildPrompt() error = %v", err)
+			}
+
+			for _, text := range []string{
+				"## Out-of-scope discoveries",
+				"project's Backlog state",
+				"fenced `detent-agent` block",
+				"best-guess `effort`",
+				"file the issue without a state and say so in the final handoff",
+			} {
+				if strings.Contains(prompt, text) != tt.wantPresent {
+					t.Fatalf("prompt presence of %q = %t, want %t:\n%s", text, strings.Contains(prompt, text), tt.wantPresent, prompt)
+				}
+			}
+		})
+	}
+}
+
 func TestBuildPromptAppendsTeamKnowledge(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add default-enabled follow-up filing guidance to pull-request agent prompts
- warn when follow-ups are disabled and WORKFLOW.md has no equivalent guidance
- update maintained workflow templates and onboarding documentation

Fixes #1164

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] `go test ./internal/config ./internal/runner ./internal/cli`
- [x] `make check`