### PR TITLE
fix(prompt): make skill drafts observable

### DIFF
--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -89,7 +89,8 @@ SET completed_at = sqlc.arg(completed_at),
     model = COALESCE(sqlc.narg(model), model),
     provider_thread_id = COALESCE(sqlc.narg(provider_thread_id), provider_thread_id),
     provider_session_id = COALESCE(sqlc.narg(provider_session_id), provider_session_id),
-    resumed_from_session_id = COALESCE(sqlc.narg(resumed_from_session_id), resumed_from_session_id)
+    resumed_from_session_id = COALESCE(sqlc.narg(resumed_from_session_id), resumed_from_session_id),
+    skill_draft_proposed = sqlc.arg(skill_draft_proposed)
 WHERE id = sqlc.arg(id);
 
 -- name: UpdateCodexSessionIdentity :execrows

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -514,6 +514,7 @@ func (r *Runner) runAgentTurn(
 		return nil
 	})
 	result.Output = progress.outputText()
+	result.SkillDraftProposed = skillDraftProposed(result.Output)
 	cleanupErr := agentTurnCleanupError(turnErr, turnResult)
 	if cleanupErr != nil {
 		turnErr = nil
@@ -1492,6 +1493,7 @@ func (r *Runner) finishSession(
 		ProviderSessionID:     turnResult.SessionID,
 		ResumedFromSessionID:  resumedFromSessionID,
 		RuntimeIdentity:       result.RuntimeIdentity,
+		SkillDraftProposed:    result.SkillDraftProposed,
 	}); err != nil {
 		return fmt.Errorf("finish agent session: %w", err)
 	}
@@ -1501,6 +1503,7 @@ func (r *Runner) finishSession(
 		"provider_session_id", turnResult.SessionID,
 		"final_state", result.FinalState,
 		"turns", turns,
+		"skill_draft_proposed", result.SkillDraftProposed,
 	}
 	attrs = append(attrs, runtimeIdentityLogAttrs(result.RuntimeIdentity)...)
 	r.logWorkerEvent(issue, "worker_session_finished", attrs...)

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -36,6 +36,7 @@ No description provided.
 var (
 	templateVariablePattern = regexp.MustCompile(`{{\s*([A-Za-z_][A-Za-z0-9_.]*)\s*}}`)
 	conditionalTagPattern   = regexp.MustCompile(`{%\s*(if\s+([A-Za-z_][A-Za-z0-9_.]*)|else|endif)\s*%}`)
+	skillDraftYesPattern    = regexp.MustCompile(`(?im)^\s*skill draft:\s*yes(?:\s|$)`)
 )
 
 type PromptOptions struct {
@@ -505,16 +506,18 @@ func appendSkillCreationBlock(prompt string, cfg config.Skills) string {
 
 	var b strings.Builder
 	b.WriteString("## Skill creation loop\n\n")
-	b.WriteString("Before final handoff, consider whether the successful run exposed a repeated or novel method worth capturing as a reusable Detent skill.\n")
+	b.WriteString("Before final handoff, make an explicit skill-draft decision. Draft when the run exposed a reusable method such as a repeated multi-step procedure, a non-obvious debugging recipe, or a project-specific convention discovered the hard way.\n")
 	b.WriteString("- Draft at most ")
 	b.WriteString(pluralizeCount(cfg.Creation.MaxDraftsPerRun, "candidate skill file", "candidate skill files"))
 	b.WriteString(" under `")
 	b.WriteString(path)
 	b.WriteString("` when the method is broadly reusable.\n")
+	b.WriteString("- This is in-scope work when one of those triggers is present; treat the draft as part of the handoff, not as an unrelated refactor.\n")
 	b.WriteString("- Do not draft a skill for routine edits, one-off project facts, secrets, or instructions that only restate the current issue.\n")
 	b.WriteString("- Use a Markdown file with YAML front matter fields `name`, `description`, and `when_to_use`, followed by concise implementation guidance.\n")
 	b.WriteString("- If you draft or modify a skill file, rerun the required validation gate after the draft so the final pull request contents are validated.\n")
 	b.WriteString("- Let normal pull request review be the approval gate; the draft skill enters future prompts only after humans review and merge it.\n")
+	b.WriteString("- In the final handoff, include exactly one line: `Skill draft: yes — <path and purpose>` when you created a draft, or `Skill draft: no — <reason>` when you did not.\n")
 
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + strings.TrimRight(b.String(), "\n")
 }
@@ -532,6 +535,10 @@ When this run surfaces a meaningful problem or improvement unrelated to the curr
 - If the configured status source cannot be set from this session, file the issue without a state and say so in the final handoff.`
 
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + block
+}
+
+func skillDraftProposed(output string) bool {
+	return skillDraftYesPattern.MatchString(output)
 }
 
 func appendGateBlock(prompt string, cfg gate.Config) string {

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -102,7 +102,13 @@ func TestBuildPromptRendersAssignsLessonsAndSkills(t *testing.T) {
 		"## Available skills",
 		"- migrate — Issue mentions schema changes.",
 		"## Skill creation loop",
-		"Before final handoff, consider whether the successful run exposed",
+		"Before final handoff, make an explicit skill-draft decision",
+		"a repeated multi-step procedure",
+		"a non-obvious debugging recipe",
+		"a project-specific convention discovered the hard way",
+		"This is in-scope work",
+		"Skill draft: yes",
+		"Skill draft: no",
 		"Draft at most 1 candidate skill file under `.detent/skills/`",
 		"rerun the required validation gate after the draft",
 		"the draft skill enters future prompts only after humans review and merge it",
@@ -113,6 +119,65 @@ func TestBuildPromptRendersAssignsLessonsAndSkills(t *testing.T) {
 	}
 	if strings.Contains(prompt, "Add migrations.") {
 		t.Fatalf("prompt included skill description, want only when_to_use:\n%s", prompt)
+	}
+}
+
+func TestBuildPromptSkillCreationUsesDefaultConfigForPullRequestsOnly(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		planOnly bool
+		want     bool
+	}{
+		{name: "pull request run", want: true},
+		{name: "plan only run", planOnly: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			prompt, err := BuildPrompt(config.Workflow{
+				Config: config.Default(),
+				Prompt: "Base prompt",
+			}, connector.Issue{
+				Identifier: "digitaldrywood/detent#1166",
+				Title:      "Tune skill creation",
+			}, PromptOptions{PlanOnly: tt.planOnly})
+			if err != nil {
+				t.Fatalf("BuildPrompt() error = %v", err)
+			}
+
+			if got := strings.Contains(prompt, "## Skill creation loop"); got != tt.want {
+				t.Fatalf("skill creation block present = %v, want %v:\n%s", got, tt.want, prompt)
+			}
+		})
+	}
+}
+
+func TestSkillDraftProposed(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		output string
+		want   bool
+	}{
+		{name: "yes decision", output: "Tests pass.\n\nSkill draft: yes — `.detent/skills/debug.md` captures the workflow.", want: true},
+		{name: "case and whitespace", output: "  SKILL DRAFT: YES  ", want: true},
+		{name: "no decision", output: "Skill draft: no — routine edit."},
+		{name: "discussion is not a proposal", output: "The prompt should require Skill draft: yes when appropriate."},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got := skillDraftProposed(tt.output); got != tt.want {
+				t.Fatalf("skillDraftProposed(%q) = %v, want %v", tt.output, got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -63,7 +63,7 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 				ThreadID:        "thread-1",
 				TurnID:          "turn-1",
 				ItemID:          "item-1",
-				Delta:           "hello",
+				Delta:           "hello\nSkill draft: yes — `.detent/skills/debug.md` captures the workflow.",
 			},
 			{
 				Type:     AgentUpdateTokenUsage,
@@ -191,10 +191,10 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	if usageUpdates[1].WorkspacePath != workspacePath {
 		t.Fatalf("second usage update WorkspacePath = %q, want %q", usageUpdates[1].WorkspacePath, workspacePath)
 	}
-	if usageUpdates[1].LastEvent != "agent_message_delta" || usageUpdates[1].LastMessage != "hello" {
+	if usageUpdates[1].LastEvent != "agent_message_delta" || usageUpdates[1].LastMessage != "hello\nSkill draft: yes — `.detent/skills/debug.md` captures the workflow." {
 		t.Fatalf("second usage update activity = %#v, want agent message", usageUpdates[1])
 	}
-	if len(usageUpdates[1].RecentEvents) != 2 || usageUpdates[1].RecentEvents[1].Message != "hello" {
+	if len(usageUpdates[1].RecentEvents) != 2 || usageUpdates[1].RecentEvents[1].Message != "hello\nSkill draft: yes — `.detent/skills/debug.md` captures the workflow." {
 		t.Fatalf("second usage update RecentEvents = %#v, want route and agent message", usageUpdates[1].RecentEvents)
 	}
 	if usageUpdates[1].LastEventAt.IsZero() {
@@ -274,6 +274,9 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if sessionStore.finished.FinalState != FinalStateCompleted || sessionStore.finished.TotalTokens != 125 || sessionStore.finished.Turns != 1 || sessionStore.finished.Model != "gpt-5-codex-resolved" {
 		t.Fatalf("SessionFinish = %#v, want completed session with tokens", sessionStore.finished)
+	}
+	if !result.SkillDraftProposed || !sessionStore.finished.SkillDraftProposed {
+		t.Fatalf("skill draft telemetry result/store = %v/%v, want true/true", result.SkillDraftProposed, sessionStore.finished.SkillDraftProposed)
 	}
 	if sessionStore.finished.ProviderThreadID != "thread-1" || sessionStore.finished.ProviderSessionID != "thread-1-turn-1" {
 		t.Fatalf("SessionFinish provider IDs = %#v, want thread-1/thread-1-turn-1", sessionStore.finished)

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -245,15 +245,16 @@ type ValidatorRequest struct {
 }
 
 type RunResult struct {
-	FinalState      string
-	Output          string
-	Model           string
-	TurnStarted     bool
-	RuntimeIdentity agentidentity.Identity
-	Tokens          TokenTotals
-	DiffStats       DiffStats
-	RateLimits      *telemetry.RateLimits
-	BudgetRefusal   *BudgetRefusal
+	FinalState         string
+	Output             string
+	Model              string
+	TurnStarted        bool
+	RuntimeIdentity    agentidentity.Identity
+	Tokens             TokenTotals
+	DiffStats          DiffStats
+	RateLimits         *telemetry.RateLimits
+	BudgetRefusal      *BudgetRefusal
+	SkillDraftProposed bool
 }
 
 type UsageUpdateHandler func(UsageUpdate) error

--- a/internal/store/migrations/00013_add_skill_draft_telemetry.sql
+++ b/internal/store/migrations/00013_add_skill_draft_telemetry.sql
@@ -1,0 +1,7 @@
+-- +goose Up
+ALTER TABLE codex_sessions
+ADD COLUMN skill_draft_proposed INTEGER NOT NULL DEFAULT 0;
+
+-- +goose Down
+ALTER TABLE codex_sessions
+DROP COLUMN skill_draft_proposed;

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -70,6 +70,7 @@ type CodexSession struct {
 	ServiceTierProvenance     sql.NullString `json:"service_tier_provenance"`
 	IdentityObservedAt        sql.NullString `json:"identity_observed_at"`
 	OrphanRecoveryOutcome     sql.NullString `json:"orphan_recovery_outcome"`
+	SkillDraftProposed        int64          `json:"skill_draft_proposed"`
 }
 
 type DetentRun struct {

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -362,7 +362,7 @@ INSERT INTO codex_sessions (
   resumed_from_session_id,
   orphan_recovery_outcome
 ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome
+RETURNING id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed
 `
 
 type CreateCodexSessionParams struct {
@@ -479,6 +479,7 @@ func (q *Queries) CreateCodexSession(ctx context.Context, arg CreateCodexSession
 		&i.ServiceTierProvenance,
 		&i.IdentityObservedAt,
 		&i.OrphanRecoveryOutcome,
+		&i.SkillDraftProposed,
 	)
 	return i, err
 }
@@ -1069,8 +1070,9 @@ SET completed_at = ?1,
     model = COALESCE(?11, model),
     provider_thread_id = COALESCE(?12, provider_thread_id),
     provider_session_id = COALESCE(?13, provider_session_id),
-    resumed_from_session_id = COALESCE(?14, resumed_from_session_id)
-WHERE id = ?15
+    resumed_from_session_id = COALESCE(?14, resumed_from_session_id),
+    skill_draft_proposed = ?15
+WHERE id = ?16
 `
 
 type FinishCodexSessionParams struct {
@@ -1088,6 +1090,7 @@ type FinishCodexSessionParams struct {
 	ProviderThreadID      sql.NullString `json:"provider_thread_id"`
 	ProviderSessionID     sql.NullString `json:"provider_session_id"`
 	ResumedFromSessionID  sql.NullInt64  `json:"resumed_from_session_id"`
+	SkillDraftProposed    int64          `json:"skill_draft_proposed"`
 	ID                    int64          `json:"id"`
 }
 
@@ -1107,6 +1110,7 @@ func (q *Queries) FinishCodexSession(ctx context.Context, arg FinishCodexSession
 		arg.ProviderThreadID,
 		arg.ProviderSessionID,
 		arg.ResumedFromSessionID,
+		arg.SkillDraftProposed,
 		arg.ID,
 	)
 	if err != nil {
@@ -1164,7 +1168,7 @@ func (q *Queries) GetAPIKeyByHash(ctx context.Context, keyHash string) (ApiKey, 
 }
 
 const getCodexSession = `-- name: GetCodexSession :one
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed
 FROM codex_sessions
 WHERE id = ?
 `
@@ -1209,6 +1213,7 @@ func (q *Queries) GetCodexSession(ctx context.Context, id int64) (CodexSession, 
 		&i.ServiceTierProvenance,
 		&i.IdentityObservedAt,
 		&i.OrphanRecoveryOutcome,
+		&i.SkillDraftProposed,
 	)
 	return i, err
 }
@@ -2275,7 +2280,7 @@ func (q *Queries) ListOrphanedAgentSessions(ctx context.Context, projectID strin
 }
 
 const listRecentCodexSessions = `-- name: ListRecentCodexSessions :many
-SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome
+SELECT id, run_id, issue_id, identifier, issue_url, started_at, completed_at, turns, input_tokens, output_tokens, total_tokens, runtime_seconds, final_state, model, cached_input_tokens, reasoning_output_tokens, model_context_window, requested_model, agent_backend_id, agent_backend_kind, agent_role, provider_thread_id, provider_session_id, resumed_from_session_id, work_attempt_id, agent_route, provider, provider_provenance, requested_model_provenance, model_provenance, reasoning_effort, reasoning_effort_provenance, service_tier, service_tier_provenance, identity_observed_at, orphan_recovery_outcome, skill_draft_proposed
 FROM codex_sessions
 ORDER BY completed_at DESC, id DESC
 LIMIT ?
@@ -2327,6 +2332,7 @@ func (q *Queries) ListRecentCodexSessions(ctx context.Context, limit int64) ([]C
 			&i.ServiceTierProvenance,
 			&i.IdentityObservedAt,
 			&i.OrphanRecoveryOutcome,
+			&i.SkillDraftProposed,
 		); err != nil {
 			return nil, err
 		}

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -322,6 +322,7 @@ func (s *sqliteStore) FinishSession(ctx context.Context, sessionID int64, attrs 
 		ProviderThreadID:      nullString(attrs.ProviderThreadID),
 		ProviderSessionID:     nullString(attrs.ProviderSessionID),
 		ResumedFromSessionID:  nullPositiveInt64(attrs.ResumedFromSessionID),
+		SkillDraftProposed:    boolInt64(attrs.SkillDraftProposed),
 		ID:                    sessionID,
 	})
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -272,6 +272,7 @@ type SessionFinish struct {
 	ProviderSessionID     string
 	ResumedFromSessionID  int64
 	RuntimeIdentity       agentidentity.Identity
+	SkillDraftProposed    bool
 }
 
 type AgentResumeLookup struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -113,6 +113,52 @@ VALUES ('detent', 'agent_session', 'agent_active', '2026-05-31T13:00:00Z', 5, '2
 	}
 }
 
+func TestSkillDraftTelemetryMigrationUpDown(t *testing.T) {
+	ctx := context.Background()
+	dbPath := filepath.Join(t.TempDir(), "detent.db")
+	db, err := sql.Open("sqlite", dbPath)
+	if err != nil {
+		t.Fatalf("sql.Open() error = %v", err)
+	}
+	db.SetMaxOpenConns(1)
+	t.Cleanup(func() {
+		if err := db.Close(); err != nil {
+			t.Fatalf("db.Close() error = %v", err)
+		}
+	})
+	if err := configureSQLite(ctx, db, 0); err != nil {
+		t.Fatalf("configureSQLite() error = %v", err)
+	}
+
+	migrationMu.Lock()
+	defer migrationMu.Unlock()
+	goose.SetBaseFS(migrationsFS)
+	defer goose.SetBaseFS(nil)
+	if err := goose.SetDialect("sqlite3"); err != nil {
+		t.Fatalf("goose.SetDialect() error = %v", err)
+	}
+	if err := goose.UpToContext(ctx, db, "migrations", 12); err != nil {
+		t.Fatalf("goose.UpToContext(12) error = %v", err)
+	}
+	if _, err := db.ExecContext(ctx, "INSERT INTO codex_sessions (started_at) VALUES (?)", "2026-07-10T00:00:00Z"); err != nil {
+		t.Fatalf("seed codex session error = %v", err)
+	}
+
+	assertColumnAbsent(t, db, "codex_sessions", "skill_draft_proposed")
+	if err := goose.UpToContext(ctx, db, "migrations", 13); err != nil {
+		t.Fatalf("goose.UpToContext(13) error = %v", err)
+	}
+	assertColumnPresent(t, db, "codex_sessions", "skill_draft_proposed")
+	if got := queryInt(t, db, "SELECT skill_draft_proposed FROM codex_sessions LIMIT 1"); got != 0 {
+		t.Fatalf("skill_draft_proposed default = %d, want 0", got)
+	}
+
+	if err := goose.DownToContext(ctx, db, "migrations", 12); err != nil {
+		t.Fatalf("goose.DownToContext(12) error = %v", err)
+	}
+	assertColumnAbsent(t, db, "codex_sessions", "skill_draft_proposed")
+}
+
 func TestAgentResumeStateMigrationUpDown(t *testing.T) {
 	ctx := context.Background()
 	dbPath := filepath.Join(t.TempDir(), "detent.db")
@@ -704,6 +750,7 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 				RuntimeSeconds:        240,
 				FinalState:            "Human Review",
 				Model:                 "gpt-5-resolved",
+				SkillDraftProposed:    true,
 			}); err != nil {
 				t.Fatalf("FinishSession() error = %v", err)
 			}
@@ -759,6 +806,9 @@ func TestStatsStoreRoundTrip(t *testing.T) {
 			}
 			if !session.ModelContextWindow.Valid || session.ModelContextWindow.Int64 != modelContextWindow {
 				t.Fatalf("session model_context_window = %#v, want %d", session.ModelContextWindow, modelContextWindow)
+			}
+			if session.SkillDraftProposed != 1 {
+				t.Fatalf("session skill_draft_proposed = %d, want 1", session.SkillDraftProposed)
 			}
 
 			spend, err := backend.DailyTokenSpend(ctx, time.Date(2026, 5, 30, 0, 0, 0, 0, time.UTC))


### PR DESCRIPTION
## Summary

- make the default-on skill-creation prompt a concrete pre-handoff decision with reusable trigger examples and explicit scope reconciliation
- require a machine-checkable `Skill draft: yes/no` handoff line
- persist positive proposals on `codex_sessions.skill_draft_proposed` and structured session-finished logs

The block was being injected, but its passive wording, undefined reuse threshold, scope tension, and lack of a required response made it effectively invisible: only 2 of 50 sampled prompt-bearing transcripts acknowledged the decision, and both declined.

Fixes #1166

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below. N/A: no UI changes.

## Test Plan

- [x] focused runner tests cover default PR injection, plan-only omission, handoff parsing, and session propagation
- [x] focused store tests cover migration up/down and persisted proposal telemetry
- [x] `make check`