### PR TITLE
feat(scheduler): prioritize unblockers

### DIFF
--- a/README.md
+++ b/README.md
@@ -681,6 +681,7 @@ agent:
     - bug
     - regression
     - enhancement
+  prioritize_unblockers: true
   auto_promote:
     enabled: false
     quiet_seconds: 600
@@ -858,6 +859,9 @@ In label mode, the `detent:*` labels are tracker state, not workstream filters.
 Use `tracker.authorization.labels.*`, `projects[].authorization`, and
 `agent.dispatch_priority_by_label` for selecting or ranking work by ordinary
 labels such as `documentation`, `bug`, or `enhancement`.
+`agent.prioritize_unblockers` defaults to `true` and ranks an unlabeled issue
+ahead of otherwise-equal peers when it directly unblocks waiting work. State,
+tracker priority, and every configured dispatch-label tier remain higher.
 
 The fleet `/kanban` board stays read-only, as do observer dashboards and
 shared dashboards where users should not mutate GitHub from Detent. For a

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -80,6 +80,7 @@ agent:
     - In Progress
     - Todo
   dispatch_priority_by_label: []
+  prioritize_unblockers: true
   auto_promote:
     enabled: false
     quiet_seconds: 600

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -81,6 +81,7 @@ agent:
     - In Progress
     - Todo
   dispatch_priority_by_label: []
+  prioritize_unblockers: true
   auto_promote:
     enabled: false
     quiet_seconds: 600

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -81,6 +81,7 @@ agent:
     - In Progress
     - Todo
   dispatch_priority_by_label: []
+  prioritize_unblockers: true
   auto_promote:
     enabled: false
     quiet_seconds: 600

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -80,6 +80,7 @@ agent:
     - In Progress
     - Todo
   dispatch_priority_by_label: []
+  prioritize_unblockers: true
   auto_promote:
     enabled: false
     quiet_seconds: 600

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -806,6 +806,7 @@ func doctorWorkflowDetail(path string, project globalconfig.Project, cfg workflo
 	details = append(details, doctorWorkflowModelChoiceDetail(cfg))
 	details = append(details, doctorWorkflowSessionGuardDetail(cfg))
 	details = append(details, fmt.Sprintf("orphan-recovery=resume_orphaned_sessions=%t, experimental_thread_resume=%t", cfg.Agent.ResumeOrphanedSessions, cfg.Agent.ExperimentalThreadResume))
+	details = append(details, fmt.Sprintf("prioritize-unblockers=%t", cfg.Agent.PrioritizeUnblockers))
 	details = append(details, doctorAuthorizationDetail(project, cfg))
 	return strings.Join(details, "; ")
 }

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -2126,6 +2126,7 @@ func TestDoctorWorkflowDetailSurfacesIdentityAndAuthorization(t *testing.T) {
 		"worker-model=provider-default",
 		"session-guard=max_session_tokens=disabled, max_session_context_multiplier=disabled",
 		"orphan-recovery=resume_orphaned_sessions=true, experimental_thread_resume=false",
+		"prioritize-unblockers=true",
 		"authorization selectors from global.yaml and WORKFLOW.md",
 	} {
 		if !strings.Contains(got, want) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -230,6 +230,7 @@ type Agent struct {
 	MaxConcurrentAgentsByState   map[string]int               `yaml:"max_concurrent_agents_by_state"`
 	DispatchPriorityByState      []string                     `yaml:"dispatch_priority_by_state"`
 	DispatchPriorityByLabel      []string                     `yaml:"dispatch_priority_by_label"`
+	PrioritizeUnblockers         bool                         `yaml:"prioritize_unblockers"`
 	MergeFastPath                MergeFastPath                `yaml:"merge_fast_path"`
 	AutoPromote                  AutoPromote                  `yaml:"auto_promote"`
 	OutputTruncation             OutputTruncation             `yaml:"output_truncation"`
@@ -943,6 +944,7 @@ func Default() Config {
 			MaxConcurrentAgentsByState: map[string]int{},
 			DispatchPriorityByState:    []string{},
 			DispatchPriorityByLabel:    []string{},
+			PrioritizeUnblockers:       true,
 			AutoPromote: AutoPromote{
 				QuietSeconds:           600,
 				OptoutLabel:            "requires-human-review",

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -135,6 +135,7 @@ agent:
     - Bug
     - regression
     - enhancement
+  prioritize_unblockers: false
   auto_promote:
     enabled: true
     quiet_seconds: 0
@@ -395,6 +396,9 @@ Ticket prompt {{ issue.title }}
 	}
 	if got := cfg.Agent.DispatchPriorityByLabel; !reflect.DeepEqual(got, []string{"bug", "regression", "enhancement"}) {
 		t.Fatalf("Agent.DispatchPriorityByLabel = %#v, want bug/regression/enhancement", got)
+	}
+	if cfg.Agent.PrioritizeUnblockers {
+		t.Fatal("Agent.PrioritizeUnblockers = true, want false")
 	}
 	if got := cfg.Agent.InstructionsByState["Rework"]; !strings.Contains(got, "Address review comments") {
 		t.Fatalf("Agent.InstructionsByState[Rework] = %q, want review instructions", got)
@@ -767,6 +771,9 @@ func TestParseWorkflowDefaults(t *testing.T) {
 	}
 	if len(cfg.Agent.DispatchPriorityByLabel) != 0 {
 		t.Fatalf("Agent.DispatchPriorityByLabel = %#v, want empty default", cfg.Agent.DispatchPriorityByLabel)
+	}
+	if !cfg.Agent.PrioritizeUnblockers {
+		t.Fatal("Agent.PrioritizeUnblockers = false, want true default")
 	}
 	if cfg.Gate.Kind != gate.KindCommand || cfg.Gate.Run != gate.DefaultCommand {
 		t.Fatalf("Gate = %#v, want default command gate", cfg.Gate)

--- a/internal/connector/issue.go
+++ b/internal/connector/issue.go
@@ -16,6 +16,7 @@ type Issue struct {
 	Description      string               `json:"description,omitempty" yaml:"description,omitempty"`
 	Priority         *int                 `json:"priority,omitempty" yaml:"priority,omitempty"`
 	PriorityName     string               `json:"priority_name,omitempty" yaml:"priority_name,omitempty"`
+	UnblockerCount   int                  `json:"unblocker_count,omitempty" yaml:"unblocker_count,omitempty"`
 	State            string               `json:"state,omitempty" yaml:"state,omitempty"`
 	BranchName       string               `json:"branch_name,omitempty" yaml:"branch_name,omitempty"`
 	URL              string               `json:"url,omitempty" yaml:"url,omitempty"`

--- a/internal/orchestrator/autopromote_tick.go
+++ b/internal/orchestrator/autopromote_tick.go
@@ -1075,7 +1075,7 @@ func staleMergingPullRequestDispatchActive(state *State, issueID string) bool {
 
 func staleMergingQueueIssues(issues []connector.Issue, cfg Config) []connector.Issue {
 	queue := issuesInStates(issues, []string{autoPromoteMergingState})
-	sortIssuesForDispatch(queue, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel)
+	sortIssuesForDispatch(queue, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel, cfg.PrioritizeUnblockers)
 	return queue
 }
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -21,6 +21,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		MaxConcurrentAgentsByState: cloneStateLimits(cfg.Agent.MaxConcurrentAgentsByState),
 		DispatchPriorityByState:    append([]string(nil), cfg.Agent.DispatchPriorityByState...),
 		DispatchPriorityByLabel:    append([]string(nil), cfg.Agent.DispatchPriorityByLabel...),
+		PrioritizeUnblockers:       cfg.Agent.PrioritizeUnblockers,
 		MergeFastPathEnabled:       cfg.Agent.MergeFastPath.Enabled,
 		ResumeOrphanedSessions:     cfg.Agent.ResumeOrphanedSessions,
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),

--- a/internal/orchestrator/diagnostics.go
+++ b/internal/orchestrator/diagnostics.go
@@ -3,6 +3,7 @@ package orchestrator
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net/url"
 	"strings"
 	"time"
@@ -24,7 +25,9 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 	reason := strings.TrimSpace(decision.SkipReason)
 	if decision.Selected {
 		result = "selected"
-		if reason == "" {
+		if decision.UnblockerCount > 0 {
+			reason = unblockerDecisionReason(decision.UnblockerCount)
+		} else if reason == "" {
 			reason = "selected"
 		}
 	}
@@ -42,8 +45,16 @@ func (o *Orchestrator) logDispatchPlanDecision(ctx context.Context, state *State
 		"retry", decision.Retry,
 		"attempt", decision.Attempt,
 		"worker_host", strings.TrimSpace(decision.WorkerHost),
+		"unblocker_count", decision.UnblockerCount,
 	)
 	o.logger.Debug("scheduler_dispatch_decision", attrs...)
+}
+
+func unblockerDecisionReason(count int) string {
+	if count == 1 {
+		return "unblocks_1_issue"
+	}
+	return fmt.Sprintf("unblocks_%d_issues", count)
 }
 
 func (o *Orchestrator) logSchedulerSlotDecision(issue connector.Issue, outcome string, decision scheduler.DispatchGateDecision, projectStats projectStateSlotStats) {

--- a/internal/orchestrator/dispatch_parity_test.go
+++ b/internal/orchestrator/dispatch_parity_test.go
@@ -43,7 +43,7 @@ func TestDispatchParityWithElixirRecordedCandidateSets(t *testing.T) {
 			applyParityInitialState(t, &state, tt.InitialState, now)
 
 			candidates := parityIssues(t, tt.Candidates)
-			sortIssuesForDispatch(candidates, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel)
+			sortIssuesForDispatch(candidates, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel, cfg.PrioritizeUnblockers)
 			orch.pruneBudgetRefusals(&state, now)
 			orch.trackBlockedCandidates(&state, candidates, now)
 

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -34,13 +34,14 @@ type dispatchAction struct {
 }
 
 type dispatchPlanDecision struct {
-	Issue         connector.Issue
-	QueuePosition int
-	Attempt       int
-	WorkerHost    string
-	Retry         bool
-	Selected      bool
-	SkipReason    string
+	Issue          connector.Issue
+	QueuePosition  int
+	Attempt        int
+	WorkerHost     string
+	Retry          bool
+	Selected       bool
+	SkipReason     string
+	UnblockerCount int
 }
 
 func newDispatchPlanner(cfg Config) dispatchPlanner {
@@ -56,7 +57,19 @@ func (p dispatchPlanner) plan(
 	state.ensureInitialized(p.cfg)
 
 	plannedCandidates := cloneIssues(candidates)
-	sortIssuesForDispatch(plannedCandidates, p.cfg.DispatchPriorityByState, p.cfg.DispatchPriorityByLabel)
+	rankingIssues := cloneIssues(candidates)
+	for _, blocked := range state.Blocked {
+		rankingIssues = append(rankingIssues, cloneIssue(blocked.Issue))
+	}
+	annotateUnblockerCounts(
+		plannedCandidates,
+		rankingIssues,
+		p.cfg.ActiveStates,
+		p.cfg.TerminalStates,
+		p.cfg.PrioritizeUnblockers,
+	)
+	clearBlockedUnblockerCounts(plannedCandidates, state.Blocked)
+	sortIssuesForDispatch(plannedCandidates, p.cfg.DispatchPriorityByState, p.cfg.DispatchPriorityByLabel, p.cfg.PrioritizeUnblockers)
 	dueRetries := dueRetriesByIssue(state, now)
 	p.releaseMissingDueRetries(state, plannedCandidates, dueRetries, hooks)
 
@@ -161,7 +174,16 @@ func (p dispatchPlanner) plan(
 	return plan
 }
 
+func clearBlockedUnblockerCounts(issues []connector.Issue, blocked map[string]Blocked) {
+	for index := range issues {
+		if _, ok := blocked[issues[index].ID]; ok {
+			issues[index].UnblockerCount = 0
+		}
+	}
+}
+
 func (p dispatchPlanner) logDecision(hooks dispatchPlanHooks, decision dispatchPlanDecision) {
+	decision.UnblockerCount = decision.Issue.UnblockerCount
 	if hooks.decision != nil {
 		hooks.decision(decision)
 	}

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -504,6 +504,7 @@ func (o *Orchestrator) applyRuntimeUpdate(state *State, update RuntimeUpdate, ti
 	state.AutoPromote = cloneAutoPromoteConfig(cfg.AutoPromote)
 	state.ActiveStates = append([]string(nil), cfg.ActiveStates...)
 	state.TerminalStates = append([]string(nil), cfg.TerminalStates...)
+	state.PrioritizeUnblockers = cfg.PrioritizeUnblockers
 	state.Instance = instanceSnapshot(cfg)
 	state.Authorization = cloneSelector(cfg.Authorization)
 	state.SelectorContext = cfg.SelectorContext

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -60,6 +60,7 @@ type Config struct {
 	MaxConcurrentAgentsByState    map[string]int
 	DispatchPriorityByState       []string
 	DispatchPriorityByLabel       []string
+	PrioritizeUnblockers          bool
 	MergeFastPathEnabled          bool
 	ResumeOrphanedSessions        bool
 	MaxConcurrentAgentsPerHost    int

--- a/internal/orchestrator/ranking.go
+++ b/internal/orchestrator/ranking.go
@@ -2,12 +2,13 @@ package orchestrator
 
 import (
 	"sort"
+	"strings"
 
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/dispatchpriority"
 )
 
-func sortIssuesForDispatch(issues []connector.Issue, dispatchStatePriority []string, dispatchLabelPriority []string) {
+func sortIssuesForDispatch(issues []connector.Issue, dispatchStatePriority []string, dispatchLabelPriority []string, prioritizeUnblockers bool) {
 	ranker := dispatchpriority.New(dispatchStatePriority, dispatchLabelPriority)
 
 	sort.SliceStable(issues, func(i, j int) bool {
@@ -20,8 +21,16 @@ func sortIssuesForDispatch(issues []connector.Issue, dispatchStatePriority []str
 		if leftRank, rightRank := dispatchpriority.Priority(left.Priority), dispatchpriority.Priority(right.Priority); leftRank != rightRank {
 			return leftRank < rightRank
 		}
-		if leftRank, rightRank := ranker.Label(left.Labels), ranker.Label(right.Labels); leftRank != rightRank {
-			return leftRank < rightRank
+		leftLabel, leftLabeled := ranker.MatchLabel(left.Labels)
+		rightLabel, rightLabeled := ranker.MatchLabel(right.Labels)
+		if leftLabeled != rightLabeled {
+			return leftLabeled
+		}
+		if leftLabeled && leftLabel.Rank != rightLabel.Rank {
+			return leftLabel.Rank < rightLabel.Rank
+		}
+		if prioritizeUnblockers && !leftLabeled && left.UnblockerCount != right.UnblockerCount {
+			return left.UnblockerCount > right.UnblockerCount
 		}
 		if left.CreatedAt != nil && right.CreatedAt != nil && !left.CreatedAt.Equal(*right.CreatedAt) {
 			return left.CreatedAt.Before(*right.CreatedAt)
@@ -35,4 +44,83 @@ func sortIssuesForDispatch(issues []connector.Issue, dispatchStatePriority []str
 
 		return left.Identifier < right.Identifier
 	})
+}
+
+func annotateUnblockerCounts(targets []connector.Issue, issues []connector.Issue, activeStates []string, terminalStates []string, enabled bool) {
+	for index := range targets {
+		targets[index].UnblockerCount = 0
+	}
+	if !enabled || len(targets) == 0 || len(issues) == 0 {
+		return
+	}
+
+	targetsByRef := make(map[string]int, len(targets)*2)
+	for index, issue := range targets {
+		if issue.Closed || normalizeState(issue.State) == "blocked" || !stateIn(issue.State, activeStates) || dependencyWaiting(issue, terminalStates) {
+			continue
+		}
+		for _, ref := range issueReferenceKeys(issue.ID, issue.Identifier) {
+			targetsByRef[ref] = index
+		}
+	}
+
+	counted := make(map[int]map[string]struct{})
+	for _, dependent := range issues {
+		if normalizeState(dependent.State) != "blocked" && !dependencyWaiting(dependent, terminalStates) {
+			continue
+		}
+		dependentKey := firstNonBlank(strings.TrimSpace(dependent.ID), strings.TrimSpace(dependent.Identifier))
+		if dependentKey == "" {
+			continue
+		}
+		for _, blocker := range dependent.BlockedBy {
+			index, ok := unblockerTargetIndex(targetsByRef, blocker)
+			if !ok || stateIn(blocker.State, terminalStates) {
+				continue
+			}
+			if counted[index] == nil {
+				counted[index] = map[string]struct{}{}
+			}
+			if _, ok := counted[index][dependentKey]; ok {
+				continue
+			}
+			counted[index][dependentKey] = struct{}{}
+			targets[index].UnblockerCount++
+		}
+	}
+}
+
+func dependencyWaiting(issue connector.Issue, terminalStates []string) bool {
+	for _, blocker := range issue.BlockedBy {
+		if strings.TrimSpace(blocker.State) == "" || !stateIn(blocker.State, terminalStates) {
+			return true
+		}
+	}
+	return false
+}
+
+func unblockerTargetIndex(targets map[string]int, blocker connector.BlockedRef) (int, bool) {
+	for _, ref := range issueReferenceKeys(blocker.ID, blocker.Identifier) {
+		if index, ok := targets[ref]; ok {
+			return index, true
+		}
+	}
+	return 0, false
+}
+
+func issueReferenceKeys(values ...string) []string {
+	keys := make([]string, 0, len(values))
+	seen := make(map[string]struct{}, len(values))
+	for _, value := range values {
+		key := strings.ToLower(strings.TrimSpace(value))
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		keys = append(keys, key)
+	}
+	return keys
 }

--- a/internal/orchestrator/ranking_test.go
+++ b/internal/orchestrator/ranking_test.go
@@ -254,6 +254,41 @@ func TestAnnotateUnblockerCounts(t *testing.T) {
 	}
 }
 
+func TestAnnotateUnblockerCountsIsInputOrderIndependent(t *testing.T) {
+	t.Parallel()
+
+	dependents := []connector.Issue{
+		rankingDependencyIssue("blocked-a", "Blocked", "blocker-one", "blocker-two"),
+		rankingDependencyIssue("blocked-b", "Blocked", "blocker-two"),
+		rankingDependencyIssue("waiting-c", "Todo", "blocker-two"),
+		rankingDependencyIssue("duplicate-edge", "Blocked", "blocker-one", "blocker-one"),
+	}
+	want := map[string]int{"blocker-one": 2, "blocker-two": 3}
+
+	permutations := [][]int{
+		{0, 1, 2, 3},
+		{3, 2, 1, 0},
+		{2, 0, 3, 1},
+		{1, 3, 0, 2},
+	}
+	for _, permutation := range permutations {
+		targets := []connector.Issue{
+			rankingIssue("blocker-one", "Todo", 0, time.Time{}),
+			rankingIssue("blocker-two", "Todo", 0, time.Time{}),
+		}
+		issues := cloneRankingIssues(targets)
+		for _, index := range permutation {
+			issues = append(issues, cloneIssue(dependents[index]))
+		}
+		annotateUnblockerCounts(targets, issues, []string{"todo"}, []string{"done"}, true)
+		for _, target := range targets {
+			if target.UnblockerCount != want[target.ID] {
+				t.Fatalf("permutation %v: %s UnblockerCount = %d, want %d", permutation, target.ID, target.UnblockerCount, want[target.ID])
+			}
+		}
+	}
+}
+
 func TestDispatchPlannerRecordsUnblockerSelectionReason(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/ranking_test.go
+++ b/internal/orchestrator/ranking_test.go
@@ -1,6 +1,7 @@
 package orchestrator
 
 import (
+	"context"
 	"testing"
 	"time"
 
@@ -17,6 +18,7 @@ func TestSortIssuesForDispatch(t *testing.T) {
 		name                  string
 		dispatchStatePriority []string
 		dispatchLabelPriority []string
+		prioritizeUnblockers  bool
 		issues                []connector.Issue
 		want                  []string
 	}{
@@ -112,6 +114,55 @@ func TestSortIssuesForDispatch(t *testing.T) {
 			},
 			want: []string{"issue-a", "issue-b", "issue-c"},
 		},
+		{
+			name:                  "state rank outranks unblocker boost",
+			dispatchStatePriority: []string{"Merging", "Todo"},
+			prioritizeUnblockers:  true,
+			issues: []connector.Issue{
+				rankingIssueWithUnblockers("todo-unblocker", "Todo", 0, now.Add(-time.Hour), 5),
+				rankingIssue("merging-peer", "Merging", 0, now),
+			},
+			want: []string{"merging-peer", "todo-unblocker"},
+		},
+		{
+			name:                 "tracker priority outranks unblocker boost",
+			prioritizeUnblockers: true,
+			issues: []connector.Issue{
+				rankingIssueWithUnblockers("p2-unblocker", "Todo", 2, now.Add(-time.Hour), 5),
+				rankingIssue("p1-peer", "Todo", 1, now),
+			},
+			want: []string{"p1-peer", "p2-unblocker"},
+		},
+		{
+			name:                  "every configured label tier outranks unblocker boost",
+			dispatchLabelPriority: []string{"hotfix", "priority", "bug"},
+			prioritizeUnblockers:  true,
+			issues: []connector.Issue{
+				rankingIssueWithUnblockers("unlabeled-unblocker", "Todo", 0, now.Add(-4*time.Hour), 5),
+				rankingIssueWithLabels("bug", "Todo", 0, now.Add(-3*time.Hour), "bug"),
+				rankingIssueWithLabels("priority", "Todo", 0, now.Add(-2*time.Hour), "priority"),
+				rankingIssueWithLabels("hotfix", "Todo", 0, now.Add(-time.Hour), "hotfix"),
+			},
+			want: []string{"hotfix", "priority", "bug", "unlabeled-unblocker"},
+		},
+		{
+			name:                 "more direct dependents rank first among unlabeled peers",
+			prioritizeUnblockers: true,
+			issues: []connector.Issue{
+				rankingIssueWithUnblockers("one", "Todo", 0, now.Add(-3*time.Hour), 1),
+				rankingIssueWithUnblockers("three", "Todo", 0, now.Add(-time.Hour), 3),
+				rankingIssue("plain", "Todo", 0, now.Add(-4*time.Hour)),
+			},
+			want: []string{"three", "one", "plain"},
+		},
+		{
+			name: "disabled preserves age ordering exactly",
+			issues: []connector.Issue{
+				rankingIssueWithUnblockers("new-unblocker", "Todo", 0, now.Add(-time.Hour), 5),
+				rankingIssue("old-peer", "Todo", 0, now.Add(-4*time.Hour)),
+			},
+			want: []string{"old-peer", "new-unblocker"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -119,12 +170,125 @@ func TestSortIssuesForDispatch(t *testing.T) {
 			t.Parallel()
 
 			issues := cloneRankingIssues(tt.issues)
-			sortIssuesForDispatch(issues, tt.dispatchStatePriority, tt.dispatchLabelPriority)
+			sortIssuesForDispatch(issues, tt.dispatchStatePriority, tt.dispatchLabelPriority, tt.prioritizeUnblockers)
 
 			if got := rankingIssueIDs(issues); !equalStrings(got, tt.want) {
 				t.Fatalf("sortIssuesForDispatch() ids = %#v, want %#v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAnnotateUnblockerCounts(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		enabled bool
+		issues  []connector.Issue
+		want    map[string]int
+	}{
+		{
+			name:    "counts blocked and dependency waiting dependents once",
+			enabled: true,
+			issues: []connector.Issue{
+				rankingDependencyIssue("blocked", "Blocked", "blocker"),
+				rankingDependencyIssue("waiting", "Todo", "blocker"),
+				rankingDependencyIssue("duplicate-edge", "Blocked", "blocker", "blocker"),
+			},
+			want: map[string]int{"blocker": 3},
+		},
+		{
+			name:    "cycle members remain dependency waiting and receive no boost",
+			enabled: true,
+			issues: []connector.Issue{
+				rankingDependencyIssue("first", "Todo", "second"),
+				rankingDependencyIssue("second", "Todo", "first"),
+			},
+			want: map[string]int{"first": 0, "second": 0},
+		},
+		{
+			name:    "terminal dependencies do not create waiting work",
+			enabled: true,
+			issues: []connector.Issue{
+				func() connector.Issue {
+					issue := rankingDependencyIssue("done-dependent", "Todo", "blocker")
+					issue.BlockedBy[0].State = "Done"
+					return issue
+				}(),
+			},
+			want: map[string]int{"blocker": 0},
+		},
+		{
+			name:    "disabled clears existing counts",
+			enabled: false,
+			issues:  []connector.Issue{rankingDependencyIssue("blocked", "Blocked", "blocker")},
+			want:    map[string]int{"blocker": 0},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			targets := make([]connector.Issue, 0, len(tt.want))
+			for id := range tt.want {
+				target := rankingIssueWithUnblockers(id, "Todo", 0, time.Time{}, 99)
+				for _, issue := range tt.issues {
+					if issue.ID == id {
+						target = cloneIssue(issue)
+						target.UnblockerCount = 99
+						break
+					}
+				}
+				targets = append(targets, target)
+			}
+			issues := append(cloneRankingIssues(targets), cloneRankingIssues(tt.issues)...)
+			annotateUnblockerCounts(targets, issues, []string{"todo"}, []string{"done"}, tt.enabled)
+			for _, target := range targets {
+				if target.UnblockerCount != tt.want[target.ID] {
+					t.Fatalf("%s UnblockerCount = %d, want %d", target.ID, target.UnblockerCount, tt.want[target.ID])
+				}
+			}
+		})
+	}
+}
+
+func TestDispatchPlannerRecordsUnblockerSelectionReason(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	cfg := normalizeConfig(Config{
+		MaxConcurrentAgents:  1,
+		ActiveStates:         []string{"Todo", "Blocked"},
+		TerminalStates:       []string{"Done"},
+		PrioritizeUnblockers: true,
+	})
+	blocker := rankingIssue("blocker", "Todo", 0, now.Add(-time.Hour))
+	peer := rankingIssue("older-peer", "Todo", 0, now.Add(-4*time.Hour))
+	blocker.Title = "Dependency blocker"
+	peer.Title = "Older peer"
+	dependent := rankingDependencyIssue("dependent", "Blocked", blocker.ID)
+	state := newState(cfg)
+	state.Blocked[dependent.ID] = Blocked{Issue: dependent, Source: BlockedSourceDependency}
+
+	var decisions []dispatchPlanDecision
+	newDispatchPlanner(cfg).plan(&state, []connector.Issue{peer, blocker}, now, dispatchPlanHooks{
+		decision: func(decision dispatchPlanDecision) {
+			decisions = append(decisions, decision)
+		},
+	})
+
+	if len(decisions) != 2 {
+		t.Fatalf("decisions = %d, want 2", len(decisions))
+	}
+	if !decisions[0].Selected || decisions[0].Issue.ID != blocker.ID || decisions[0].UnblockerCount != 1 {
+		t.Fatalf("first decision = %#v, want selected blocker with one dependent", decisions[0])
+	}
+	orch := Orchestrator{cfg: cfg}
+	orch.logDispatchPlanDecision(context.Background(), &state, now, decisions[0])
+	if len(state.SchedulerDecisions) != 1 || state.SchedulerDecisions[0].Reason != "unblocks_1_issue" {
+		t.Fatalf("scheduler decisions = %#v, want unblocker reason", state.SchedulerDecisions)
 	}
 }
 
@@ -134,6 +298,7 @@ func TestConfigFromWorkflowIncludesDispatchPriorityByState(t *testing.T) {
 	workflow := workflowconfig.Default()
 	workflow.Agent.DispatchPriorityByState = []string{"Merging", "Rework"}
 	workflow.Agent.DispatchPriorityByLabel = []string{"bug", "enhancement"}
+	workflow.Agent.PrioritizeUnblockers = false
 	workflow.Workpad.StructuredOnly = true
 
 	cfg := ConfigFromWorkflow(workflow)
@@ -147,6 +312,9 @@ func TestConfigFromWorkflowIncludesDispatchPriorityByState(t *testing.T) {
 	wantLabels := []string{"bug", "enhancement"}
 	if !equalStrings(cfg.DispatchPriorityByLabel, wantLabels) {
 		t.Fatalf("ConfigFromWorkflow().DispatchPriorityByLabel = %#v, want %#v", cfg.DispatchPriorityByLabel, wantLabels)
+	}
+	if cfg.PrioritizeUnblockers {
+		t.Fatal("ConfigFromWorkflow().PrioritizeUnblockers = true, want false")
 	}
 	if !cfg.AutoPromote.WorkpadStructuredOnly {
 		t.Fatal("ConfigFromWorkflow().AutoPromote.WorkpadStructuredOnly = false, want true")
@@ -168,6 +336,20 @@ func rankingIssue(id string, state string, priority int, createdAt time.Time) co
 func rankingIssueWithLabels(id string, state string, priority int, createdAt time.Time, labels ...string) connector.Issue {
 	issue := rankingIssue(id, state, priority, createdAt)
 	issue.Labels = append([]string(nil), labels...)
+	return issue
+}
+
+func rankingIssueWithUnblockers(id string, state string, priority int, createdAt time.Time, count int) connector.Issue {
+	issue := rankingIssue(id, state, priority, createdAt)
+	issue.UnblockerCount = count
+	return issue
+}
+
+func rankingDependencyIssue(id string, state string, blockerIDs ...string) connector.Issue {
+	issue := rankingIssue(id, state, 0, time.Time{})
+	for _, blockerID := range blockerIDs {
+		issue.BlockedBy = append(issue.BlockedBy, connector.BlockedRef{ID: blockerID, Identifier: blockerID})
+	}
 	return issue
 }
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -61,6 +61,7 @@ func TestApplyRuntimeUpdateRefreshesSupervisorRetryConfig(t *testing.T) {
 		FailureRetryBaseDelay:  10 * time.Second,
 		ActiveStates:           []string{"Todo"},
 		TerminalStates:         []string{"Done"},
+		PrioritizeUnblockers:   true,
 		ContinuationRetryDelay: time.Second,
 	})
 	orch := Orchestrator{
@@ -84,6 +85,9 @@ func TestApplyRuntimeUpdateRefreshesSupervisorRetryConfig(t *testing.T) {
 
 	if got := orch.supervisor.RetryDelay(4); got != 2*time.Second {
 		t.Fatalf("RetryDelay(4) = %s, want reloaded 2s cap", got)
+	}
+	if state.PrioritizeUnblockers {
+		t.Fatal("State.PrioritizeUnblockers = true, want reloaded false")
 	}
 }
 

--- a/internal/orchestrator/retry_test.go
+++ b/internal/orchestrator/retry_test.go
@@ -118,7 +118,7 @@ func TestDispatchReadyIssuesRanksDueRetriesWithCandidates(t *testing.T) {
 	}
 
 	issues := []connector.Issue{retrying, merging}
-	sortIssuesForDispatch(issues, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel)
+	sortIssuesForDispatch(issues, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel, cfg.PrioritizeUnblockers)
 	orch.dispatchReadyIssues(context.Background(), &state, issues, now)
 
 	if _, ok := state.Running[merging.ID]; !ok {

--- a/internal/orchestrator/snapshot.go
+++ b/internal/orchestrator/snapshot.go
@@ -42,6 +42,12 @@ func (s State) Snapshot(now time.Time) telemetry.Snapshot {
 		refresh.Status = telemetry.RefreshStatusReady
 	}
 	boardIssues := authorizedSnapshotIssues(s.BoardIssues, s.Authorization, s.SelectorContext)
+	rankingIssues := cloneIssues(boardIssues)
+	for _, blocked := range s.Blocked {
+		rankingIssues = append(rankingIssues, cloneIssue(blocked.Issue))
+	}
+	annotateUnblockerCounts(boardIssues, rankingIssues, s.ActiveStates, s.TerminalStates, s.PrioritizeUnblockers)
+	clearBlockedUnblockerCounts(boardIssues, s.Blocked)
 	pipeline := authorizedSnapshotIssues(s.Pipeline, s.Authorization, s.SelectorContext)
 	statusDrift := authorizedStatusDrift(s.StatusDrift, s.Authorization, s.SelectorContext)
 	boardIssueSnapshots := issueSnapshots(boardIssues, s.AutoPromoteQuietDuration, s.PollInterval, now, s.laneEntries)
@@ -543,6 +549,7 @@ func telemetryIssue(issue connector.Issue, quietDuration time.Duration, pollInte
 		Description:           issue.Description,
 		Priority:              cloneIntPointer(issue.Priority),
 		PriorityName:          telemetryIssuePriorityName(issue),
+		UnblockerCount:        issue.UnblockerCount,
 		State:                 issue.State,
 		Labels:                append([]string(nil), issue.Labels...),
 		Assignees:             append([]string(nil), issue.Assignees...),

--- a/internal/orchestrator/snapshot_test.go
+++ b/internal/orchestrator/snapshot_test.go
@@ -44,6 +44,37 @@ func TestStateSnapshotEmpty(t *testing.T) {
 	}
 }
 
+func TestStateSnapshotAnnotatesDirectUnblockerCount(t *testing.T) {
+	t.Parallel()
+
+	cfg := normalizeConfig(Config{
+		ActiveStates:         []string{"Todo", "Blocked"},
+		TerminalStates:       []string{"Done"},
+		PrioritizeUnblockers: true,
+	})
+	state := newState(cfg)
+	blocker := connector.Issue{ID: "blocker", Identifier: "owner/repo#1", State: "Todo"}
+	dependent := connector.Issue{
+		ID:         "dependent",
+		Identifier: "owner/repo#2",
+		State:      "Blocked",
+		BlockedBy:  []connector.BlockedRef{{ID: blocker.ID, Identifier: blocker.Identifier}},
+	}
+	state.BoardIssues = []connector.Issue{blocker, dependent}
+	state.Blocked[dependent.ID] = Blocked{Issue: dependent, Source: BlockedSourceDependency}
+
+	snapshot := state.Snapshot(time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC))
+	for _, issue := range snapshot.BoardIssues {
+		if issue.ID == blocker.ID {
+			if issue.UnblockerCount != 1 {
+				t.Fatalf("UnblockerCount = %d, want 1", issue.UnblockerCount)
+			}
+			return
+		}
+	}
+	t.Fatal("snapshot missing blocker issue")
+}
+
 func TestStateSnapshotPreservesMappedTrackerPriority(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/state.go
+++ b/internal/orchestrator/state.go
@@ -26,6 +26,7 @@ type State struct {
 	AutoPromote              AutoPromoteConfig
 	ActiveStates             []string
 	TerminalStates           []string
+	PrioritizeUnblockers     bool
 	Instance                 telemetry.Instance
 	Authorization            selector.Selector
 	SelectorContext          selector.Context
@@ -206,6 +207,7 @@ func newState(cfg Config) State {
 		AutoPromote:              cloneAutoPromoteConfig(cfg.AutoPromote),
 		ActiveStates:             append([]string(nil), cfg.ActiveStates...),
 		TerminalStates:           append([]string(nil), cfg.TerminalStates...),
+		PrioritizeUnblockers:     cfg.PrioritizeUnblockers,
 		Instance:                 instanceSnapshot(cfg),
 		Authorization:            cloneSelector(cfg.Authorization),
 		SelectorContext:          cfg.SelectorContext,
@@ -240,6 +242,7 @@ func (s State) clone() State {
 		AutoPromote:              cloneAutoPromoteConfig(s.AutoPromote),
 		ActiveStates:             append([]string(nil), s.ActiveStates...),
 		TerminalStates:           append([]string(nil), s.TerminalStates...),
+		PrioritizeUnblockers:     s.PrioritizeUnblockers,
 		Instance:                 s.Instance,
 		Authorization:            cloneSelector(s.Authorization),
 		SelectorContext:          s.SelectorContext,

--- a/internal/telemetry/snapshot.go
+++ b/internal/telemetry/snapshot.go
@@ -222,6 +222,7 @@ type Issue struct {
 	Description           string                 `json:"description,omitempty"`
 	Priority              *int                   `json:"priority,omitempty"`
 	PriorityName          string                 `json:"priority_name,omitempty"`
+	UnblockerCount        int                    `json:"unblocker_count,omitempty"`
 	State                 string                 `json:"state,omitempty"`
 	Labels                []string               `json:"labels,omitempty"`
 	Assignees             []string               `json:"assignees,omitempty"`

--- a/internal/web/demo_scenarios.go
+++ b/internal/web/demo_scenarios.go
@@ -138,6 +138,7 @@ func demoScenarioDefinitions() []demoScenario {
 		{ID: "fleet-kanban-multiproject", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "dense-kanban", KanbanMode: workflowconfig.KanbanModeReadOnly},
 		{ID: "fleet-kanban-blocked-alerts", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "healthy", KanbanMode: workflowconfig.KanbanModeReadOnly, ShowBlockedAlerts: true},
 		{ID: "fleet-kanban-external-lane-timer", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "external-lane-timer", KanbanMode: workflowconfig.KanbanModeReadOnly, HideFromManifest: true},
+		{ID: "fleet-kanban-unblocker-boost", Route: "/", WaitSelector: "#board-lanes", Page: "fleet-kanban", Variant: "unblocker-boost", KanbanMode: workflowconfig.KanbanModeReadOnly, HideFromManifest: true},
 		{ID: "project-active-overview", Route: "/projects/dogfood", WaitSelector: "#snapshot", Page: "project", Variant: "healthy", ProjectID: demoPrimaryProjectID},
 		{ID: "project-paused-overview", Route: "/projects/mobile-client", WaitSelector: "#snapshot", Page: "project", Variant: "paused", ProjectID: "mobile-client"},
 		{ID: "project-empty-overview", Route: "/projects/agent-lab", WaitSelector: "#snapshot", Page: "project", Variant: "project-empty", ProjectID: "agent-lab"},

--- a/internal/web/demofixtures/fixtures.go
+++ b/internal/web/demofixtures/fixtures.go
@@ -60,6 +60,8 @@ func SnapshotForScenario(id string, variant string) telemetry.Snapshot {
 		snapshot = demoTrackerRefreshGapSnapshot()
 	case "external-lane-timer":
 		snapshot = demoExternalLaneTimerSnapshot()
+	case "unblocker-boost":
+		snapshot.BoardIssues[1].UnblockerCount = 2
 	case "startup-loading":
 		snapshot = demoStartupLoadingSnapshot()
 	case "github-api-healthy":

--- a/internal/web/templates/board_data.go
+++ b/internal/web/templates/board_data.go
@@ -441,7 +441,7 @@ func boardRuntimeSessionIDs(snapshot telemetry.Snapshot, card projectKanbanCard)
 }
 
 func boardCardPriority(card projectKanbanCard) (string, string, string, bool) {
-	if card.PriorityRank == 0 && card.DispatchPriorityRank == 0 {
+	if card.PriorityRank == 0 && card.DispatchPriorityRank == 0 && card.UnblockerCount == 0 {
 		return "", "", "", false
 	}
 
@@ -452,7 +452,10 @@ func boardCardPriority(card projectKanbanCard) (string, string, string, bool) {
 	if badge == "" {
 		badge = card.DispatchPriorityLabel
 	}
-	details := make([]string, 0, 2)
+	if badge == "" && card.UnblockerCount > 0 {
+		badge = "unblocker"
+	}
+	details := make([]string, 0, 3)
 	if card.PriorityRank > 0 {
 		name := strings.TrimSpace(card.PriorityName)
 		if name == "" {
@@ -465,8 +468,18 @@ func boardCardPriority(card projectKanbanCard) (string, string, string, bool) {
 	if card.DispatchPriorityRank > 0 {
 		details = append(details, "Label "+card.DispatchPriorityLabel+" is configured at dispatch label rank "+strconv.Itoa(card.DispatchPriorityRank)+".")
 	}
+	if card.UnblockerCount > 0 {
+		details = append(details, unblockerPriorityDetail(card.UnblockerCount))
+	}
 	top := card.PriorityRank == 1 || (card.PriorityRank == 0 && card.DispatchPriorityRank == 1)
 	return badge, "Dispatch priority", strings.Join(details, " "), top
+}
+
+func unblockerPriorityDetail(count int) string {
+	if count == 1 {
+		return "Unblocks 1 issue."
+	}
+	return "Unblocks " + strconv.Itoa(count) + " issues."
 }
 
 // boardCardExtra picks the single allowed extra signal, most urgent first:

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -153,6 +153,7 @@ func TestBoardViewSortsCardsBySchedulerPriorityInputs(t *testing.T) {
 			GeneratedAt: now,
 			BoardIssues: []telemetry.Issue{
 				{ID: "plain", Identifier: "digitaldrywood/detent#1", ProjectID: "detent", Title: "Old unprioritized", State: "Todo", StageUpdatedAt: &oldest},
+				{ID: "unblocker", Identifier: "digitaldrywood/detent#6", ProjectID: "detent", Title: "Derived unblocker", State: "Todo", UnblockerCount: 2, StageUpdatedAt: &newest},
 				{ID: "bug", Identifier: "digitaldrywood/detent#2", ProjectID: "detent", Title: "Bug label", State: "Todo", Labels: []string{"bug"}, StageUpdatedAt: &older},
 				{ID: "hotfix", Identifier: "digitaldrywood/detent#3", ProjectID: "detent", Title: "Hotfix label", State: "Todo", Labels: []string{"hotfix"}, StageUpdatedAt: &middle},
 				{ID: "rank-three", Identifier: "digitaldrywood/detent#4", ProjectID: "detent", Title: "Mapped rank three", State: "Todo", Priority: boardPriorityPointer(3), PriorityName: "P2", StageUpdatedAt: &newer},
@@ -174,7 +175,7 @@ func TestBoardViewSortsCardsBySchedulerPriorityInputs(t *testing.T) {
 	for _, card := range view.Lanes[0].Cards {
 		got = append(got, card.IssueID)
 	}
-	want := []string{"rank-one", "rank-three", "hotfix", "bug", "plain"}
+	want := []string{"rank-one", "rank-three", "hotfix", "bug", "unblocker", "plain"}
 	if strings.Join(got, ",") != strings.Join(want, ",") {
 		t.Fatalf("card order = %#v, want %#v", got, want)
 	}
@@ -223,6 +224,18 @@ func TestBoardCardPriority(t *testing.T) {
 			card:       projectKanbanCard{PriorityRank: 4, PriorityName: "P3", DispatchPriorityLabel: "hotfix", DispatchPriorityRank: 1},
 			wantBadge:  "P3",
 			wantDetail: "Tracker priority P3 maps to dispatch rank 4. Label hotfix is configured at dispatch label rank 1.",
+		},
+		{
+			name:       "derived unblocker boost",
+			card:       projectKanbanCard{UnblockerCount: 3},
+			wantBadge:  "unblocker",
+			wantDetail: "Unblocks 3 issues.",
+		},
+		{
+			name:       "single derived dependent",
+			card:       projectKanbanCard{UnblockerCount: 1},
+			wantBadge:  "unblocker",
+			wantDetail: "Unblocks 1 issue.",
 		},
 		{
 			name: "unprioritized",
@@ -1420,6 +1433,25 @@ func TestBoardSnapshotRendersMorphSafePriorityBadge(t *testing.T) {
 	} {
 		if !strings.Contains(page, want) {
 			t.Fatalf("board page missing mobile lane behavior %q", want)
+		}
+	}
+}
+
+func TestBoardSnapshotRendersUnblockerPriorityDetail(t *testing.T) {
+	t.Parallel()
+
+	data := boardTestData()
+	data.Snapshot.BoardIssues[0].UnblockerCount = 2
+	html := renderBoardComponent(t, BoardSnapshot(data))
+
+	for _, want := range []string{
+		`data-board-priority`,
+		`data-help-scope="dispatch-priority"`,
+		`data-help-description="Unblocks 2 issues."`,
+		`unblocker`,
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("unblocker board snapshot missing %q:\n%s", want, html)
 		}
 	}
 }

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -568,6 +568,7 @@ type projectKanbanCard struct {
 	PriorityName          string
 	DispatchPriorityLabel string
 	DispatchPriorityRank  int
+	UnblockerCount        int
 	Labels                []string
 	Assignees             []string
 	Comments              []telemetry.IssueComment
@@ -2181,6 +2182,9 @@ func projectKanbanCardsByState(data DashboardData) map[string][]projectKanbanCar
 			if cards[i].DispatchPriorityRank != cards[j].DispatchPriorityRank {
 				return cards[i].DispatchPriorityRank < cards[j].DispatchPriorityRank
 			}
+			if cards[i].DispatchPriorityRank == 0 && cards[i].UnblockerCount != cards[j].UnblockerCount {
+				return cards[i].UnblockerCount > cards[j].UnblockerCount
+			}
 			left := cards[i].StageAt
 			right := cards[j].StageAt
 			if left.IsZero() || right.IsZero() {
@@ -2768,6 +2772,7 @@ func projectKanbanCardForIssue(data DashboardData, issue telemetry.Issue, state 
 		StageAt:               stageAt.UTC(),
 		PriorityRank:          projectKanbanPriorityRank(issue.Priority),
 		PriorityName:          strings.TrimSpace(issue.PriorityName),
+		UnblockerCount:        issue.UnblockerCount,
 		Labels:                uniqueStrings(issue.Labels),
 		Assignees:             uniqueStrings(issue.Assignees),
 		Comments:              append([]telemetry.IssueComment(nil), issue.Comments...),

--- a/tests/visual/layout.spec.js
+++ b/tests/visual/layout.spec.js
@@ -204,6 +204,33 @@ test("board keeps dependency waits on cards without global alerts", async ({
   await capturePageAndAttach(page, "board-dependency-waits.png", testInfo);
 });
 
+test("boosted card explains its direct downstream count", async ({ page }) => {
+  await page.setViewportSize(desktopViewport);
+  await page.setExtraHTTPHeaders({
+    "X-Detent-Demo-Scenario": "fleet-kanban-unblocker-boost",
+  });
+  await page.goto(`${screenshotsRuntime.url}/`, {
+    waitUntil: "domcontentloaded",
+  });
+  await page.locator("#board-lanes").waitFor({ state: "visible" });
+
+  const card = page.locator("article", {
+    hasText: "Add screenshot manifest smoke test",
+  });
+  const badge = card.locator('[data-board-priority]', {
+    hasText: "unblocker",
+  });
+  await expect(badge).toHaveAttribute(
+    "data-help-description",
+    "Unblocks 2 issues.",
+  );
+  await badge.hover();
+  await badge.dispatchEvent("pointerover", { pointerType: "mouse" });
+  const tooltip = page.locator("body > #help-tooltip");
+  await expect(tooltip).toBeVisible();
+  await expect(tooltip).toContainText("Unblocks 2 issues");
+});
+
 test("board elevated blockers render one compact opt-in alert", async ({
   page,
 }, testInfo) => {


### PR DESCRIPTION
## Summary

- rank direct dependencies of blocked or dependency-waiting work ahead of otherwise-equal unlabeled peers
- expose the derived unblocker count in scheduler decisions, board priority hover detail, doctor output, and workflow templates
- keep explicit state, tracker priority, and configured label tiers authoritative, with cycle-safe direct-edge counting and a default-on project toggle

Fixes #1182

## UI Surface Contract

- [x] The linked issue explicitly authorizes the priority badge hover detail.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] Browser verification covers the boosted card hover while existing screenshot scenarios remain unchanged.

## Test Plan

- [x] `make check`
- [x] `DETENT_BINARY="$PWD/tmp/detent" node_modules/.bin/playwright test tests/visual/layout.spec.js --project=chromium --grep "boosted card explains"`