### PR TITLE
fix(scheduler): stop empty completion redispatch loops

### DIFF
--- a/internal/connector/github/client.go
+++ b/internal/connector/github/client.go
@@ -588,6 +588,10 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
+	rateLimit := c.restRateLimit
+	if core, ok := c.restRateLimits["core"]; ok {
+		rateLimit = core
+	}
 	backoffUntil := c.restBackoffUntil
 	if c.restBackoffs != nil && c.restBackoffKey != "" {
 		if shared := c.restBackoffs.until(c.restBackoffKey, time.Now()); shared.After(backoffUntil) {
@@ -595,7 +599,7 @@ func (c *Client) FlushRESTRateLimitUsage() connector.RESTRateLimitUsage {
 		}
 	}
 	usage := connector.RESTRateLimitUsage{
-		RateLimit:    c.restRateLimit,
+		RateLimit:    rateLimit,
 		HasRateLimit: c.hasRestRateLimit,
 		Requests:     sortedRESTEndpointUsages(c.restRequests),
 		BackoffUntil: backoffUntil,

--- a/internal/connector/github/client_test.go
+++ b/internal/connector/github/client_test.go
@@ -861,6 +861,32 @@ func TestClientRESTAllowsCoreFanoutAfterSearchPoolBelowReserve(t *testing.T) {
 	}
 }
 
+func TestClientFlushRESTRateLimitUsagePrefersCoreBudget(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 22, 0, 0, 0, time.UTC)
+	client := &Client{
+		hasRestRateLimit: true,
+		restRateLimit: connector.RESTRateLimit{
+			Limit: 30, Used: 30, Remaining: 0, Resource: "search", ResetAt: now.Add(time.Minute), UpdatedAt: now,
+		},
+		restRateLimits: map[string]connector.RESTRateLimit{
+			"core": {
+				Limit: 5000, Used: 4200, Remaining: 800, Resource: "core", ResetAt: now.Add(time.Hour), UpdatedAt: now,
+			},
+			"search": {
+				Limit: 30, Used: 30, Remaining: 0, Resource: "search", ResetAt: now.Add(time.Minute), UpdatedAt: now,
+			},
+		},
+	}
+
+	usage := client.FlushRESTRateLimitUsage()
+
+	if !usage.HasRateLimit || usage.RateLimit.Resource != "core" || usage.RateLimit.Remaining != 800 {
+		t.Fatalf("RateLimit = %#v, want core budget with 800 remaining", usage.RateLimit)
+	}
+}
+
 func TestClientRESTBackoffAppliesAcrossClientsWithSharedToken(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -183,6 +183,7 @@ const (
 	dispatchIssueFailureWorkAttemptStart      = "work_attempt_start_failed"
 	dispatchIssueFailureStartStateTransition  = "start_state_transition_failed"
 	dispatchIssueFailureBackendCapacityPaused = "backend_capacity_paused"
+	dispatchIssueFailureGitHubRESTPaused      = "github_rest_capacity_paused"
 )
 
 type dispatchIssueOutcome struct {
@@ -209,6 +210,9 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	now time.Time,
 	preferredWorkerHost string,
 ) dispatchIssueOutcome {
+	if _, paused := activeGitHubRESTCapacityOutage(state, now); paused {
+		return dispatchIssueOutcome{reason: dispatchIssueFailureGitHubRESTPaused}
+	}
 	queuedRetry, retryQueued := state.Retry[issue.ID]
 	runMode := o.dispatchMode(ctx, state, issue)
 	capacityRequest := runpkg.RunRequest{Issue: issue, Mode: runMode, SelectorContext: o.selectorContext()}

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -186,6 +186,13 @@ func (p dispatchPlanner) retryAction(
 	retry Retry,
 	now time.Time,
 ) (dispatchAction, bool, string) {
+	if outage, paused := activeGitHubRESTCapacityOutage(state, now); paused {
+		if retry.DueAt.Before(outage.ResumeAt) {
+			retry.DueAt = outage.ResumeAt
+			state.Retry[retry.Issue.ID] = retry
+		}
+		return dispatchAction{}, false, dispatchSkipGitHubRESTCapacity
+	}
 	delete(state.Retry, retry.Issue.ID)
 
 	decision := p.dispatchableIssueDecision(issue, state, true, now, retry.WorkerHost)
@@ -413,6 +420,7 @@ const (
 	dispatchSkipGlobalCapacityFull       = "global_capacity_full"
 	dispatchSkipHydrationFailed          = "hydrate_failed"
 	dispatchSkipDispatchBackoffCancelled = "dispatch_backoff_cancelled"
+	dispatchSkipGitHubRESTCapacity       = "github_rest_capacity_paused"
 )
 
 func (p dispatchPlanner) dispatchableIssueDecision(
@@ -430,6 +438,9 @@ func (p dispatchPlanner) dispatchableIssueDecision(
 	}
 	if stateIn(issue.State, p.cfg.TerminalStates) {
 		return dispatchableDecision{reason: dispatchSkipTerminalState}
+	}
+	if _, paused := activeGitHubRESTCapacityOutage(state, now); paused {
+		return dispatchableDecision{reason: dispatchSkipGitHubRESTCapacity}
 	}
 	if pullRequestHydrationBlocksDispatch(issue) {
 		return dispatchableDecision{reason: dispatchSkipPullRequestHydration}

--- a/internal/orchestrator/github_rest_capacity.go
+++ b/internal/orchestrator/github_rest_capacity.go
@@ -1,0 +1,144 @@
+package orchestrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	githubRESTCapacityBackendID = "github-rest"
+	githubRESTCapacityKind      = "github_rest_rate_limit"
+	githubRESTCapacityError     = "github_rest_capacity"
+)
+
+var githubRESTCapacityScope = backendcapacity.Scope{
+	BackendID:   githubRESTCapacityBackendID,
+	BackendKind: "tracker",
+	Provider:    "github",
+}
+
+func (o *Orchestrator) syncGitHubRESTCapacityOutage(state *State, now time.Time) {
+	if state == nil {
+		return
+	}
+	if now.IsZero() {
+		now = o.clockNow()
+	}
+	key, existing, exists := githubRESTCapacityOutage(state.BackendOutages)
+	bucket := gitHubRESTBucketFromState(state)
+	if bucket == nil {
+		return
+	}
+	if !gitHubRESTCapacityExceeded(bucket, o.cfg.GitHubRESTMinReserve, now) {
+		if exists {
+			delete(state.BackendOutages, key)
+			recordStateEvent(state, telemetry.ActivityEvent{
+				At:      now,
+				Event:   "github_rest_capacity_recovered",
+				Message: "GitHub REST capacity recovered; dispatch resumed",
+			})
+		}
+		return
+	}
+
+	if state.BackendOutages == nil {
+		state.BackendOutages = map[string]BackendOutage{}
+	}
+	detectedAt := now
+	if exists && !existing.DetectedAt.IsZero() {
+		detectedAt = existing.DetectedAt
+	}
+	resetAt := bucket.ResetAt.UTC()
+	outage := BackendOutage{
+		Scope:          githubRESTCapacityScope,
+		Kind:           githubRESTCapacityKind,
+		Reason:         fmt.Sprintf("GitHub REST remaining %d is at or below dispatch floor %d", bucket.Remaining, o.cfg.GitHubRESTMinReserve),
+		DetectedAt:     detectedAt,
+		LastObservedAt: now,
+		ResetAt:        resetAt,
+		ResumeAt:       resetAt,
+	}
+	state.BackendOutages[githubRESTCapacityScope.Key()] = outage
+	if !exists {
+		recordStateEvent(state, telemetry.ActivityEvent{
+			At:      now,
+			Event:   "github_rest_capacity_paused",
+			Message: githubRESTCapacityStatusMessage(outage),
+		})
+	}
+}
+
+func gitHubRESTCapacityExceeded(bucket *telemetry.RateLimitBucket, floor int64, now time.Time) bool {
+	return bucket != nil && bucket.Limit > 0 && bucket.ResetAt != nil && bucket.ResetAt.After(now) && bucket.Remaining <= floor
+}
+
+func githubRESTCapacityOutage(outages map[string]BackendOutage) (string, BackendOutage, bool) {
+	for key, outage := range outages {
+		if strings.TrimSpace(outage.Kind) == githubRESTCapacityKind {
+			return key, outage, true
+		}
+	}
+	return "", BackendOutage{}, false
+}
+
+func activeGitHubRESTCapacityOutage(state *State, now time.Time) (BackendOutage, bool) {
+	if state == nil {
+		return BackendOutage{}, false
+	}
+	_, outage, ok := githubRESTCapacityOutage(state.BackendOutages)
+	return outage, ok && outage.ResumeAt.After(now)
+}
+
+func githubRESTCapacityStatusMessage(outage BackendOutage) string {
+	message := "GitHub REST dispatch paused"
+	if !outage.ResumeAt.IsZero() {
+		message += " — resuming at " + outage.ResumeAt.UTC().Format(time.RFC3339)
+	}
+	return message
+}
+
+func (o *Orchestrator) handleGitHubRESTCapacityCompletion(
+	ctx context.Context,
+	state *State,
+	event runpkg.Completion,
+	running Running,
+) bool {
+	outage, ok := activeGitHubRESTCapacityOutage(state, event.CompletedAt)
+	if !ok {
+		return false
+	}
+	running = o.restoreBackendCapacityIssueState(ctx, state, running, event.CompletedAt)
+	errorMessage := githubRESTCapacityStatusMessage(outage)
+	if event.Err != nil {
+		errorMessage = event.Err.Error()
+	}
+	o.completeDurableWorkAttempt(
+		ctx,
+		state,
+		running,
+		event.CompletedAt,
+		store.WorkAttemptTerminalCapacity,
+		githubRESTCapacityError,
+		errorMessage,
+		"waiting",
+		githubRESTCapacityStatusMessage(outage),
+	)
+	if workspaceIssueTerminal(running.Issue, o.cfg.TerminalStates) {
+		o.releaseClaim(state, running.Issue.ID)
+		return true
+	}
+	o.scheduleBackendCapacityRetry(state, running, outage)
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      event.CompletedAt,
+		Event:   "github_rest_capacity_completion_deferred",
+		Message: githubRESTCapacityStatusMessage(outage),
+	})
+	return true
+}

--- a/internal/orchestrator/implement_progress.go
+++ b/internal/orchestrator/implement_progress.go
@@ -68,6 +68,7 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 	ctx context.Context,
 	running Running,
 	finalState string,
+	pullRequestUpdated bool,
 ) implementCompletionProgressDecision {
 	cfg := normalizeAutoPromoteConfig(o.cfg.AutoPromote)
 	decision := implementCompletionProgressDecision{
@@ -82,7 +83,36 @@ func (o *Orchestrator) evaluateImplementCompletionProgress(
 		return decision
 	}
 	if !implementProgressLinkedPullRequest(running.Issue) {
-		decision.Reason = "no_linked_pull_request"
+		if pullRequestUpdated {
+			decision.Reason = "pull_request_created_or_updated"
+			return decision
+		}
+		if !implementProgressDiffStatsClean(running.DiffStats) {
+			if !diffStatsPresent(running.DiffStats) {
+				decision.Reason = "workspace_diffstat_unavailable_without_pull_request"
+				return decision
+			}
+			decision.Reason = "workspace_diff_present_without_pull_request"
+			return decision
+		}
+		attempts, err := o.recentImplementCompletionAttempts(ctx, running.Issue, running)
+		if err != nil {
+			decision.Reason = "attempt_history_lookup_failed"
+			decision.Warning = err.Error()
+			if o.logger != nil {
+				o.logger.Warn(
+					"implement worker progress history lookup failed",
+					"issue_id", running.Issue.ID,
+					"identifier", running.Issue.Identifier,
+					"error", err,
+				)
+			}
+			return decision
+		}
+		decision.Outcome = store.WorkAttemptTerminalNoProgress
+		decision.Reason = "completed_clean_diff_without_pull_request"
+		decision.ConsecutiveNoProgress = 1 + consecutiveImplementNoProgressAttempts(attempts, autoPromoteReworkSignature{})
+		decision.Block = decision.NoProgressLimit > 0 && decision.ConsecutiveNoProgress >= decision.NoProgressLimit
 		return decision
 	}
 	hydrator, ok := o.connector.(connector.PullRequestHydrator)
@@ -195,15 +225,28 @@ func consecutiveImplementNoProgressAttempts(attempts []store.WorkAttempt, curren
 	count := 0
 	for _, attempt := range attempts {
 		record, ok := implementProgressRecordFromAttempt(attempt)
-		if !ok || strings.TrimSpace(record.Outcome) != implementProgressOutcomeNoProgress {
-			return count
-		}
-		if !implementProgressSignatureEqual(record.CurrentSignature.signature(), current) {
+		if !ok || !implementProgressRecordMatchesNoProgress(record, current) {
 			return count
 		}
 		count++
 	}
 	return count
+}
+
+func implementProgressRecordMatchesNoProgress(record implementProgressRecord, current autoPromoteReworkSignature) bool {
+	if !implementProgressSignatureEqual(record.CurrentSignature.signature(), current) {
+		return false
+	}
+	if strings.TrimSpace(record.Outcome) == implementProgressOutcomeNoProgress {
+		return true
+	}
+	return !implementProgressSignatureUsable(current) &&
+		strings.TrimSpace(record.Outcome) == string(store.WorkAttemptTerminalSuccess) &&
+		strings.TrimSpace(record.Reason) == "no_linked_pull_request" &&
+		record.WorkspaceDiffStats.Status != "" &&
+		record.WorkspaceDiffStats.FilesChanged == 0 &&
+		record.WorkspaceDiffStats.AddedLines == 0 &&
+		record.WorkspaceDiffStats.RemovedLines == 0
 }
 
 func implementProgressRecordFromAttempt(attempt store.WorkAttempt) (implementProgressRecord, bool) {
@@ -401,7 +444,7 @@ func (o *Orchestrator) blockNoProgressLimit(
 
 func noProgressLimitComment(issue connector.Issue, decision implementCompletionProgressDecision) string {
 	var b strings.Builder
-	b.WriteString("Routed this issue to Blocked because the implement worker completed repeatedly without PR progress.")
+	b.WriteString("Routed this issue to Blocked because the implement worker completed repeatedly without deliverable progress.")
 	b.WriteString("\n\n- reason: ")
 	b.WriteString(noProgressLimitReason)
 	b.WriteString("\n- no_progress_limit: ")

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -27,24 +27,26 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 	}
 
 	tests := []struct {
-		name              string
-		runningIssue      connector.Issue
-		hydratedIssue     connector.Issue
-		hydrateErr        error
-		history           []store.WorkAttempt
-		diffStats         DiffStats
-		noProgressLimit   int
-		wantTerminal      store.WorkAttemptTerminalState
-		wantReason        string
-		wantPreviousHead  string
-		wantCurrentHead   string
-		wantHydrations    int
-		wantBlocked       bool
-		wantComment       string
-		wantRetry         bool
-		wantLogContains   string
-		wantFailedAdded   []string
-		wantFailedRemoved []string
+		name               string
+		runningIssue       connector.Issue
+		hydratedIssue      connector.Issue
+		hydrateErr         error
+		history            []store.WorkAttempt
+		diffStats          DiffStats
+		noProgressLimit    int
+		wantTerminal       store.WorkAttemptTerminalState
+		wantReason         string
+		wantPreviousHead   string
+		wantCurrentHead    string
+		wantHydrations     int
+		wantBlocked        bool
+		wantComment        string
+		wantRetry          bool
+		wantLogContains    string
+		wantFailedAdded    []string
+		wantFailedRemoved  []string
+		wantConsecutive    int
+		pullRequestUpdated bool
 	}{
 		{
 			name:            "first attempt succeeds with linked PR",
@@ -81,6 +83,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			noProgressLimit:  3,
 			wantTerminal:     store.WorkAttemptTerminalNoProgress,
 			wantReason:       "unchanged_signature_clean_diff",
+			wantConsecutive:  1,
 			wantPreviousHead: "same-head",
 			wantCurrentHead:  "same-head",
 			wantHydrations:   1,
@@ -98,6 +101,7 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			noProgressLimit:  3,
 			wantTerminal:     store.WorkAttemptTerminalNoProgress,
 			wantReason:       "unchanged_signature_clean_diff",
+			wantConsecutive:  3,
 			wantPreviousHead: "same-head",
 			wantCurrentHead:  "same-head",
 			wantHydrations:   1,
@@ -105,13 +109,39 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			wantComment:      "no_progress_limit",
 		},
 		{
-			name:            "issue without linked PR is exempt",
+			name:               "new pull request creation avoids false no progress",
+			runningIssue:       implementProgressIssueWithoutPR(),
+			diffStats:          DiffStats{Status: "clean"},
+			noProgressLimit:    3,
+			pullRequestUpdated: true,
+			wantTerminal:       store.WorkAttemptTerminalSuccess,
+			wantReason:         "pull_request_created_or_updated",
+			wantRetry:          true,
+		},
+		{
+			name:            "first clean completion without linked PR records no progress",
 			runningIssue:    implementProgressIssueWithoutPR(),
 			diffStats:       DiffStats{Status: "clean"},
 			noProgressLimit: 3,
-			wantTerminal:    store.WorkAttemptTerminalSuccess,
-			wantReason:      "no_linked_pull_request",
+			wantTerminal:    store.WorkAttemptTerminalNoProgress,
+			wantReason:      "completed_clean_diff_without_pull_request",
+			wantConsecutive: 1,
 			wantRetry:       true,
+		},
+		{
+			name:         "July telemetry replay trips third clean completion without linked PR",
+			runningIssue: implementProgressIssueWithoutPR(),
+			history: []store.WorkAttempt{
+				implementProgressLegacyNoPRHistoryAttempt(2),
+				implementProgressLegacyNoPRHistoryAttempt(1),
+			},
+			diffStats:       DiffStats{Status: "clean"},
+			noProgressLimit: 3,
+			wantTerminal:    store.WorkAttemptTerminalNoProgress,
+			wantReason:      "completed_clean_diff_without_pull_request",
+			wantConsecutive: 3,
+			wantBlocked:     true,
+			wantComment:     "consecutive_no_progress_attempts: 3",
 		},
 		{
 			name:            "hydration failure fails open to success",
@@ -196,8 +226,9 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 				CompletedAt: base,
 				Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
 				Result: runpkg.RunResult{
-					FinalState: FinalStateCompleted,
-					DiffStats:  tt.diffStats,
+					FinalState:         FinalStateCompleted,
+					DiffStats:          tt.diffStats,
+					PullRequestUpdated: tt.pullRequestUpdated,
 				},
 			})
 
@@ -217,6 +248,9 @@ func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
 			}
 			if record.CurrentHeadSHA != tt.wantCurrentHead {
 				t.Fatalf("current head = %q, want %q", record.CurrentHeadSHA, tt.wantCurrentHead)
+			}
+			if record.ConsecutiveNoProgress != tt.wantConsecutive {
+				t.Fatalf("consecutive no progress = %d, want %d", record.ConsecutiveNoProgress, tt.wantConsecutive)
 			}
 			if !slicesEqual(record.FailedChecksAdded, tt.wantFailedAdded) {
 				t.Fatalf("failed checks added = %#v, want %#v", record.FailedChecksAdded, tt.wantFailedAdded)
@@ -412,6 +446,28 @@ func implementProgressHistoryAttempt(id int64, signature autoPromoteReworkSignat
 		TerminalState:      terminal,
 		CompletedAt:        time.Date(2026, 7, 8, 15, int(id), 0, 0, time.UTC),
 		WorkerMetadataJSON: implementProgressMetadataJSON(signature, terminal),
+	}
+}
+
+func implementProgressLegacyNoPRHistoryAttempt(id int64) store.WorkAttempt {
+	return store.WorkAttempt{
+		ID:            id,
+		ProjectID:     "gopher-ai",
+		IssueID:       "issue-213",
+		Identifier:    "gopherguides/gopher-ai#213",
+		IssueURL:      "https://github.test/gopherguides/gopher-ai/issues/213",
+		WorkerType:    "agent",
+		Status:        store.WorkAttemptStatusTerminal,
+		TerminalState: store.WorkAttemptTerminalSuccess,
+		CompletedAt:   time.Date(2026, 7, 10, 22, int(id), 0, 0, time.UTC),
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			"run_mode": runpkg.RunModeImplement,
+			implementProgressMetadataKey: implementProgressRecord{
+				Outcome:            string(store.WorkAttemptTerminalSuccess),
+				Reason:             "no_linked_pull_request",
+				WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
+			},
+		}),
 	}
 }
 

--- a/internal/orchestrator/rate_limit_test.go
+++ b/internal/orchestrator/rate_limit_test.go
@@ -11,6 +11,9 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
 	"github.com/digitaldrywood/detent/internal/telemetry"
 )
 
@@ -461,6 +464,181 @@ func TestTickSkipsConnectorPollingDuringGitHubRESTBackoff(t *testing.T) {
 	}
 }
 
+func TestGitHubRESTCapacityOutagePausesDispatchAndResumesAtReset(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 22, 0, 0, 0, time.UTC)
+	resetAt := now.Add(37 * time.Minute)
+	issue := connector.Issue{
+		ID:               "issue-1211",
+		Identifier:       "digitaldrywood/detent#1211",
+		Title:            "Protect REST capacity",
+		State:            "In Progress",
+		AssignedToWorker: true,
+	}
+	cfg := normalizeConfig(Config{
+		Project:                scheduler.ProjectCandidate{ID: "detent"},
+		MaxConcurrentAgents:    1,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		GitHubRESTMinReserve:   1000,
+		ContinuationRetryDelay: time.Minute,
+	})
+	state := newState(cfg)
+	state.RateLimits = &telemetry.RateLimits{GitHubREST: &telemetry.RateLimitBucket{
+		Limit:      5000,
+		Used:       4100,
+		Remaining:  900,
+		ResetAt:    &resetAt,
+		ObservedAt: timePointer(now),
+	}}
+	state.RepeatedFailures[issue.ID] = RepeatedFailure{Issue: issue, Count: 2}
+	state.InstantFailures[issue.ID] = InstantFailure{Issue: issue, Count: 2}
+	orch := newRateLimitTestOrchestrator(cfg, &rateLimitConnector{})
+	orch.syncGitHubRESTCapacityOutage(&state, now)
+
+	dispatches := 0
+	hooks := dispatchPlanHooks{dispatch: func(connector.Issue, int, string) bool {
+		dispatches++
+		return true
+	}}
+	orch.dispatchPlanner().plan(&state, []connector.Issue{issue}, now, hooks)
+
+	if dispatches != 0 {
+		t.Fatalf("dispatches = %d, want 0 during GitHub REST capacity outage", dispatches)
+	}
+	outage, ok := activeGitHubRESTCapacityOutage(&state, now)
+	if !ok {
+		t.Fatalf("BackendOutages = %#v, want active GitHub REST outage", state.BackendOutages)
+	}
+	if outage.Kind != githubRESTCapacityKind || !outage.ResetAt.Equal(resetAt) || !outage.ResumeAt.Equal(resetAt) {
+		t.Fatalf("outage = %#v, want reset-aware GitHub REST capacity outage", outage)
+	}
+	if state.RepeatedFailures[issue.ID].Count != 2 || state.InstantFailures[issue.ID].Count != 2 {
+		t.Fatalf("breakers changed during capacity window: repeated=%#v instant=%#v", state.RepeatedFailures, state.InstantFailures)
+	}
+	snapshot := state.Snapshot(now)
+	if len(snapshot.BackendOutages) != 1 || snapshot.BackendOutages[0].Kind != githubRESTCapacityKind {
+		t.Fatalf("snapshot BackendOutages = %#v, want GitHub REST banner telemetry", snapshot.BackendOutages)
+	}
+
+	orch.syncGitHubRESTCapacityOutage(&state, resetAt)
+	orch.dispatchPlanner().plan(&state, []connector.Issue{issue}, resetAt, hooks)
+
+	if dispatches != 1 {
+		t.Fatalf("dispatches = %d, want 1 at reset", dispatches)
+	}
+	if _, ok := activeGitHubRESTCapacityOutage(&state, resetAt); ok {
+		t.Fatalf("BackendOutages = %#v, want automatic recovery at reset", state.BackendOutages)
+	}
+}
+
+func TestTickDetectsGitHubRESTExhaustionBeforeDispatch(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 22, 0, 0, 0, time.UTC)
+	resetAt := now.Add(30 * time.Minute)
+	issue := connector.Issue{
+		ID:               "issue-1211-tick",
+		Identifier:       "digitaldrywood/detent#1211",
+		Title:            "Stop same-cycle dispatch",
+		State:            "In Progress",
+		AssignedToWorker: true,
+	}
+	cfg := normalizeConfig(Config{
+		Project:                scheduler.ProjectCandidate{ID: "detent"},
+		PollInterval:           30 * time.Second,
+		MaxConcurrentAgents:    1,
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		GitHubRESTMinReserve:   1000,
+		ContinuationRetryDelay: time.Minute,
+	})
+	tracker := &rateLimitConnector{
+		candidates: []connector.Issue{issue},
+		restUsage: connector.RESTRateLimitUsage{
+			HasRateLimit: true,
+			RateLimit: connector.RESTRateLimit{
+				Limit: 5000, Used: 5000, Remaining: 0, Resource: "core", ResetAt: resetAt, UpdatedAt: now,
+			},
+		},
+	}
+	orch := newRateLimitTestOrchestrator(cfg, tracker)
+	state := newState(cfg)
+
+	orch.tick(context.Background(), &state, now)
+
+	if len(state.Running) != 0 {
+		t.Fatalf("Running = %#v, want no paid dispatch after same-cycle exhaustion", state.Running)
+	}
+	if _, ok := activeGitHubRESTCapacityOutage(&state, now); !ok {
+		t.Fatalf("BackendOutages = %#v, want active GitHub REST outage", state.BackendOutages)
+	}
+	if state.PollInterval != 30*time.Minute || !state.NextRefreshAt.Equal(resetAt) {
+		t.Fatalf("refresh = interval %s next %v, want reset at %v", state.PollInterval, state.NextRefreshAt, resetAt)
+	}
+}
+
+func TestRunCompletionDuringGitHubRESTCapacityOutageDoesNotStrikeBreakers(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 22, 0, 0, 0, time.UTC)
+	resetAt := now.Add(20 * time.Minute)
+	issue := implementProgressIssueWithoutPR()
+	cfg := normalizeConfig(Config{
+		Project:                scheduler.ProjectCandidate{ID: "detent"},
+		AutoPromote:            AutoPromoteConfig{NoProgressLimit: 3},
+		ActiveStates:           []string{"Todo", "In Progress"},
+		TerminalStates:         []string{"Done", "Cancelled"},
+		GitHubRESTMinReserve:   1000,
+		ContinuationRetryDelay: time.Minute,
+	})
+	attempts := &implementProgressAttemptStore{}
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    &implementProgressConnector{},
+		workAttempts: attempts,
+		logger:       slog.New(slog.NewTextHandler(io.Discard, nil)),
+	}
+	state := newState(cfg)
+	state.RateLimits = &telemetry.RateLimits{GitHubREST: &telemetry.RateLimitBucket{
+		Limit: 5000, Used: 5000, Remaining: 0, ResetAt: &resetAt, ObservedAt: timePointer(now),
+	}}
+	orch.syncGitHubRESTCapacityOutage(&state, now)
+	state.Running[issue.ID] = Running{
+		Issue:         issue,
+		Attempt:       2,
+		WorkAttemptID: 42,
+		Mode:          runpkg.RunModeImplement,
+		StartedAt:     now.Add(-5 * time.Minute),
+		DiffStats:     DiffStats{Status: "clean"},
+	}
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: now.Add(-5 * time.Minute)}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:      issue.ID,
+		CompletedAt:  now,
+		RetryAttempt: 3,
+		Request:      runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+		Result:       runpkg.RunResult{FinalState: runpkg.FinalStateFailed, DiffStats: DiffStats{Status: "clean"}},
+		Err:          errors.New("gh pr create: HTTP 403 API rate limit exceeded"),
+	})
+
+	if len(attempts.completions) != 1 || attempts.completions[0].TerminalState != store.WorkAttemptTerminalCapacity {
+		t.Fatalf("completions = %#v, want one capacity terminal", attempts.completions)
+	}
+	retry, ok := state.Retry[issue.ID]
+	if !ok || retry.Attempt != 2 || !retry.DueAt.Equal(resetAt) {
+		t.Fatalf("Retry[%q] = %#v, want same-attempt retry at reset", issue.ID, retry)
+	}
+	if len(state.RepeatedFailures) != 0 || len(state.InstantFailures) != 0 {
+		t.Fatalf("breakers = repeated %#v instant %#v, want no strikes", state.RepeatedFailures, state.InstantFailures)
+	}
+	if _, ok := state.Completed[issue.ID]; ok {
+		t.Fatalf("Completed[%q] present during capacity outage", issue.ID)
+	}
+}
+
 func TestTickSkipsNonessentialGitHubWorkBelowRESTReserve(t *testing.T) {
 	t.Parallel()
 
@@ -505,8 +683,11 @@ func TestTickSkipsNonessentialGitHubWorkBelowRESTReserve(t *testing.T) {
 	if tracker.fetchByStatesLimitCalls != 0 {
 		t.Fatalf("FetchIssuesByStatesLimit() calls = %d, want no observed probe during reserve", tracker.fetchByStatesLimitCalls)
 	}
-	if len(state.RecentEvents) != 1 || state.RecentEvents[0].Event != "github_budget_reserved" || !strings.Contains(state.RecentEvents[0].Message, "preserve shared budget") {
+	if !rateLimitRecentEventContains(state.RecentEvents, "github_budget_reserved", "preserve shared budget") {
 		t.Fatalf("RecentEvents = %#v, want github budget reserve event", state.RecentEvents)
+	}
+	if !rateLimitRecentEventContains(state.RecentEvents, "github_rest_capacity_paused", "resuming at") {
+		t.Fatalf("RecentEvents = %#v, want GitHub REST dispatch pause event", state.RecentEvents)
 	}
 	logOutput := logs.String()
 	for _, want := range []string{

--- a/internal/orchestrator/reconcile.go
+++ b/internal/orchestrator/reconcile.go
@@ -417,12 +417,15 @@ func (o *Orchestrator) markRefreshSucceeded(state *State, now time.Time) {
 	state.LastRefreshAt = now.UTC()
 }
 
-func (o *Orchestrator) finishRefresh(state *State, now time.Time) {
+func (o *Orchestrator) finishRefresh(state *State, now time.Time, captureREST bool) {
 	o.captureConnectorAuthHealth(state)
 	cycle := o.captureConnectorRateLimits(state, now)
 	o.logGraphQLRateLimitCycle(cycle)
-	restCycle := o.captureConnectorRESTRateLimits(state, now)
-	o.logRESTRateLimitCycle(restCycle)
+	if captureREST {
+		restCycle := o.captureConnectorRESTRateLimits(state, now)
+		o.logRESTRateLimitCycle(restCycle)
+	}
+	o.syncGitHubRESTCapacityOutage(state, now)
 
 	interval := o.adaptivePollInterval(state, now)
 	state.PollInterval = interval

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -101,6 +101,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		running.cancel()
 	}
 	delete(state.Running, event.IssueID)
+	if o.handleGitHubRESTCapacityCompletion(ctx, state, event, running) {
+		return
+	}
 	if capacityErr, ok := backendcapacity.As(event.Err); ok {
 		o.handleBackendCapacityError(ctx, state, event, running, capacityErr)
 		return
@@ -225,7 +228,7 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if diffStatsPresent(event.Result.DiffStats) {
 		running.DiffStats = event.Result.DiffStats
 	}
-	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState)
+	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
 	if terminalState != store.WorkAttemptTerminalSuccess {
 		progress.Outcome = terminalState
 	}

--- a/internal/orchestrator/targeted_reconcile.go
+++ b/internal/orchestrator/targeted_reconcile.go
@@ -24,7 +24,7 @@ func (o *Orchestrator) reconcileTarget(ctx context.Context, state *State, reques
 	o.markRefresh(state, now)
 	completed := false
 	defer func() {
-		o.finishRefresh(state, now)
+		o.finishRefresh(state, now, true)
 		finishManualRefresh(state, request.manualRefreshRequest, completed)
 	}()
 

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -59,15 +59,17 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		startManualRefresh(state, *manual, now)
 	}
 	completed := false
+	restRateLimitsCaptured := false
 	previous := captureTickPreviousState(state)
 	o.markRefresh(state, now)
 	defer func() {
-		o.finishRefresh(state, now)
+		o.finishRefresh(state, now, !restRateLimitsCaptured)
 		if manual != nil {
 			finishManualRefresh(state, *manual, completed)
 		}
 	}()
 
+	o.syncGitHubRESTCapacityOutage(state, now)
 	if pause := o.gitHubGraphQLPause(state, now); pause > 0 {
 		o.logger.Warn("github graphql polling paused", "remaining", gitHubGraphQLRemaining(state), "pause", pause)
 		return
@@ -174,6 +176,10 @@ func (o *Orchestrator) tickWithManual(ctx context.Context, state *State, now tim
 		fetched,
 		artifactWaitTransitions.transitioned,
 	)
+	restCycle := o.captureConnectorRESTRateLimits(state, now)
+	o.logRESTRateLimitCycle(restCycle)
+	o.syncGitHubRESTCapacityOutage(state, now)
+	restRateLimitsCaptured = true
 	o.dispatchTickIssues(ctx, state, fetched, transitions, previous, completedEpics, now)
 	if refreshSucceeded(state) {
 		state.BoardIssues = overlayIssueStateSnapshots(

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -515,6 +515,13 @@ func (r *Runner) runAgentTurn(
 	})
 	result.Output = progress.outputText()
 	result.SkillDraftProposed = skillDraftProposed(result.Output)
+	result.PullRequestUpdated = progress.pullRequestUpdated()
+	if turnErr == nil {
+		if deliverableErr := progress.deliverableError(); deliverableErr != nil {
+			turnErr = deliverableErr
+			result.FinalState = FinalStateFailed
+		}
+	}
 	cleanupErr := agentTurnCleanupError(turnErr, turnResult)
 	if cleanupErr != nil {
 		turnErr = nil
@@ -1786,14 +1793,20 @@ type agentRunProgress struct {
 	diffStats             DiffStats
 	diffStatsCollected    bool
 	diffStatsCheckedAt    time.Time
+	toolInvocations       map[string]deliverableToolInvocation
+	deliverableFailures   map[string]error
+	deliverableSuccesses  map[string]bool
 }
 
 func newAgentRunProgress(outputPolicy runtimeoutput.Policy) *agentRunProgress {
 	return &agentRunProgress{
-		turnIDs:      map[string]struct{}{},
-		messages:     map[string]*runtimeoutput.Buffer{},
-		outputPolicy: outputPolicy,
-		output:       runtimeoutput.NewBuffer(outputPolicy),
+		turnIDs:              map[string]struct{}{},
+		messages:             map[string]*runtimeoutput.Buffer{},
+		outputPolicy:         outputPolicy,
+		output:               runtimeoutput.NewBuffer(outputPolicy),
+		toolInvocations:      map[string]deliverableToolInvocation{},
+		deliverableFailures:  map[string]error{},
+		deliverableSuccesses: map[string]bool{},
 	}
 }
 
@@ -1861,6 +1874,10 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 		eventMessage = modelUpdatedActivityMessage(update.Model)
 	case AgentUpdateRuntimeIdentity:
 		eventMessage = "agent route selected"
+	case AgentUpdateToolStarted:
+		p.recordDeliverableToolStart(update)
+	case AgentUpdateToolCompleted:
+		p.recordDeliverableToolCompletion(update)
 	}
 
 	p.addRecentEvent(telemetry.ActivityEvent{
@@ -1869,6 +1886,152 @@ func (p *agentRunProgress) apply(update AgentUpdate, eventAt time.Time) {
 		Message:    eventMessage,
 		Truncation: eventTruncation,
 	})
+}
+
+type deliverableToolInvocation struct {
+	class   string
+	command string
+	tool    string
+}
+
+func (p *agentRunProgress) recordDeliverableToolStart(update AgentUpdate) {
+	class := deliverableOperationClass(update.Tool, update.Delta)
+	if class == "" {
+		return
+	}
+	p.toolInvocations[deliverableToolKey(update)] = deliverableToolInvocation{
+		class:   class,
+		command: strings.TrimSpace(update.Delta),
+		tool:    strings.TrimSpace(update.Tool),
+	}
+}
+
+func (p *agentRunProgress) recordDeliverableToolCompletion(update AgentUpdate) {
+	key := deliverableToolKey(update)
+	invocation, ok := p.toolInvocations[key]
+	if !ok {
+		invocation = deliverableToolInvocation{
+			class:   deliverableOperationClass(update.Tool, update.Delta),
+			command: strings.TrimSpace(update.Delta),
+			tool:    strings.TrimSpace(update.Tool),
+		}
+	}
+	if invocation.class == "" {
+		return
+	}
+	delete(p.toolInvocations, key)
+	if deliverableToolStatusSucceeded(update.Status) {
+		delete(p.deliverableFailures, invocation.class)
+		p.deliverableSuccesses[invocation.class] = true
+		return
+	}
+	if !deliverableToolStatusFailed(update.Status) {
+		return
+	}
+	delete(p.deliverableSuccesses, invocation.class)
+	detail := strings.TrimSpace(update.Delta)
+	if detail == "" {
+		detail = strings.TrimSpace(update.BackendErrorMessage)
+	}
+	if detail == "" {
+		detail = strings.TrimSpace(update.BackendErrorBody)
+	}
+	if detail == "" {
+		detail = strings.TrimSpace(update.Status)
+	}
+	if len(detail) > 4096 {
+		detail = detail[len(detail)-4096:]
+	}
+	operation := invocation.command
+	if operation == "" {
+		operation = invocation.tool
+	}
+	p.deliverableFailures[invocation.class] = fmt.Errorf("deliverable command failed (%s): %s", strings.TrimSpace(operation), detail)
+}
+
+func (p *agentRunProgress) pullRequestUpdated() bool {
+	return p.deliverableSuccesses["pull_request"]
+}
+
+func (p *agentRunProgress) deliverableError() error {
+	errs := make([]error, 0, len(p.deliverableFailures))
+	for _, class := range []string{"pull_request", "push"} {
+		if err := p.deliverableFailures[class]; err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+func deliverableToolKey(update AgentUpdate) string {
+	if itemID := strings.TrimSpace(update.ItemID); itemID != "" {
+		return itemID
+	}
+	return strings.TrimSpace(update.TurnID) + "\x00" + strings.TrimSpace(update.Tool)
+}
+
+func deliverableOperationClass(tool string, command string) string {
+	lowerTool := strings.ToLower(strings.TrimSpace(tool))
+	lowerCommand := strings.ToLower(strings.TrimSpace(command))
+	if gitPushCommand(lowerCommand) {
+		return "push"
+	}
+	if pullRequestCommand(lowerCommand) ||
+		(strings.Contains(lowerTool, "pull_request") &&
+			(strings.Contains(lowerTool, "create") || strings.Contains(lowerTool, "update") || strings.Contains(lowerTool, "edit"))) {
+		return "pull_request"
+	}
+	return ""
+}
+
+func gitPushCommand(command string) bool {
+	fields := strings.Fields(command)
+	for index, field := range fields {
+		field = strings.Trim(field, "'\";()")
+		if field != "git" {
+			continue
+		}
+		for _, candidate := range fields[index+1:] {
+			candidate = strings.Trim(candidate, "'\";()")
+			if candidate == "push" {
+				return true
+			}
+			if candidate == "git" || strings.ContainsAny(candidate, "|&") {
+				break
+			}
+		}
+	}
+	return false
+}
+
+func pullRequestCommand(command string) bool {
+	for _, operation := range []string{"gh pr create", "gh pr edit", "gh pr ready"} {
+		if strings.Contains(command, operation) {
+			return true
+		}
+	}
+	return strings.Contains(command, "gh api") &&
+		strings.Contains(command, "/pulls") &&
+		(strings.Contains(command, "--method post") || strings.Contains(command, "--method patch") ||
+			strings.Contains(command, "-x post") || strings.Contains(command, "-x patch"))
+}
+
+func deliverableToolStatusSucceeded(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "completed", "success", "succeeded":
+		return true
+	default:
+		return false
+	}
+}
+
+func deliverableToolStatusFailed(status string) bool {
+	switch strings.ToLower(strings.TrimSpace(status)) {
+	case "failed", "error", "cancelled", "canceled", "timed_out":
+		return true
+	default:
+		return false
+	}
 }
 
 func tokenUsageActivityMessage(tokens AgentTokenUsage) string {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"log/slog"
 	"math"
 	"os"
@@ -331,6 +332,102 @@ func TestRunnerRunPreparesWorkspaceRunsCodexAndRecordsSession(t *testing.T) {
 	}
 	if sessionStore.phase.ModelContextWindow == nil || *sessionStore.phase.ModelContextWindow != modelContextWindow {
 		t.Fatalf("WorkflowPhaseEvent ModelContextWindow = %#v, want %d", sessionStore.phase.ModelContextWindow, modelContextWindow)
+	}
+}
+
+func TestRunAgentTurnFailsForUnrecoveredDeliverableCommandError(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name                   string
+		updates                []AgentUpdate
+		wantErr                string
+		wantPullRequestUpdated bool
+	}{
+		{
+			name: "push rejected by GitHub rate limit",
+			updates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "push", Tool: "commandExecution", Delta: "git push -u origin HEAD"},
+				{Type: AgentUpdateToolCompleted, ItemID: "push", Tool: "commandExecution", Status: "failed", Delta: "remote: API rate limit exceeded; HTTP 403"},
+				{Type: AgentUpdateTurnCompleted, Status: "completed"},
+			},
+			wantErr: "API rate limit exceeded",
+		},
+		{
+			name: "pull request creation rejected",
+			updates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "pr", Tool: "commandExecution", Delta: "gh pr create --title fix --body-file /tmp/body"},
+				{Type: AgentUpdateToolCompleted, ItemID: "pr", Tool: "commandExecution", Status: "failed", Delta: "HTTP 403: API rate limit exceeded"},
+				{Type: AgentUpdateTurnCompleted, Status: "completed"},
+			},
+			wantErr: "API rate limit exceeded",
+		},
+		{
+			name: "successful pull request creation records delivery",
+			updates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "pr", Tool: "commandExecution", Delta: "gh pr create --title fix --body-file /tmp/body"},
+				{Type: AgentUpdateToolCompleted, ItemID: "pr", Tool: "commandExecution", Status: "completed", Delta: "https://github.test/digitaldrywood/detent/pull/1212"},
+				{Type: AgentUpdateTurnCompleted, Status: "completed"},
+			},
+			wantPullRequestUpdated: true,
+		},
+		{
+			name: "later successful push clears failure",
+			updates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "push-1", Tool: "commandExecution", Delta: "git push -u origin HEAD"},
+				{Type: AgentUpdateToolCompleted, ItemID: "push-1", Tool: "commandExecution", Status: "failed", Delta: "HTTP 403: transient failure"},
+				{Type: AgentUpdateToolStarted, ItemID: "push-2", Tool: "commandExecution", Delta: "git push -u origin HEAD"},
+				{Type: AgentUpdateToolCompleted, ItemID: "push-2", Tool: "commandExecution", Status: "completed", Delta: "branch pushed"},
+				{Type: AgentUpdateTurnCompleted, Status: "completed"},
+			},
+		},
+		{
+			name: "unrelated failed test command does not fail delivery",
+			updates: []AgentUpdate{
+				{Type: AgentUpdateToolStarted, ItemID: "test", Tool: "commandExecution", Delta: "go test ./..."},
+				{Type: AgentUpdateToolCompleted, ItemID: "test", Tool: "commandExecution", Status: "failed", Delta: "test failed"},
+				{Type: AgentUpdateTurnCompleted, Status: "completed"},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := &Runner{
+				now:    time.Now,
+				logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+			}
+			execution := r.runAgentTurn(
+				context.Background(),
+				&toolUpdateAgentBackend{updates: tt.updates},
+				AgentTurnRequest{},
+				RunRequest{Issue: connector.Issue{ID: "issue-1211", Identifier: "digitaldrywood/detent#1211"}},
+				workspace.Info{},
+				workspace.Issue{},
+				config.Agent{},
+				time.Now(),
+				0,
+				agentidentity.Identity{},
+			)
+
+			if tt.wantErr == "" {
+				if execution.err != nil || execution.result.FinalState != FinalStateCompleted {
+					t.Fatalf("execution = state %q error %v, want completed", execution.result.FinalState, execution.err)
+				}
+				if execution.result.PullRequestUpdated != tt.wantPullRequestUpdated {
+					t.Fatalf("PullRequestUpdated = %v, want %v", execution.result.PullRequestUpdated, tt.wantPullRequestUpdated)
+				}
+				return
+			}
+			if execution.err == nil || !strings.Contains(execution.err.Error(), tt.wantErr) {
+				t.Fatalf("error = %v, want containing %q", execution.err, tt.wantErr)
+			}
+			if execution.result.FinalState != FinalStateFailed {
+				t.Fatalf("FinalState = %q, want %q", execution.result.FinalState, FinalStateFailed)
+			}
+		})
 	}
 }
 
@@ -3310,6 +3407,19 @@ type fakeCodexClient struct {
 	catalogCalls   int
 	verifyErr      error
 	verifiedResume AgentResume
+}
+
+type toolUpdateAgentBackend struct {
+	updates []AgentUpdate
+}
+
+func (b *toolUpdateAgentBackend) RunTurn(_ context.Context, _ AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {
+	for _, update := range b.updates {
+		if err := onUpdate(update); err != nil {
+			return AgentTurnResult{}, err
+		}
+	}
+	return AgentTurnResult{ThreadID: "thread-1211", TurnID: "turn-1211", SessionID: "thread-1211-turn-1211"}, nil
 }
 
 func (c *fakeCodexClient) RunTurn(_ context.Context, req AgentTurnRequest, onUpdate AgentUpdateHandler) (AgentTurnResult, error) {

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -255,6 +255,7 @@ type RunResult struct {
 	RateLimits         *telemetry.RateLimits
 	BudgetRefusal      *BudgetRefusal
 	SkillDraftProposed bool
+	PullRequestUpdated bool
 }
 
 type UsageUpdateHandler func(UsageUpdate) error

--- a/internal/web/templates/board_data_test.go
+++ b/internal/web/templates/board_data_test.go
@@ -1465,6 +1465,30 @@ func TestBoardSnapshotRendersBackendCapacityBanner(t *testing.T) {
 	}
 }
 
+func TestBoardSnapshotRendersGitHubRESTCapacityBanner(t *testing.T) {
+	t.Parallel()
+
+	data := boardTestData()
+	data.Snapshot.BackendOutages = []telemetry.BackendOutage{{
+		BackendID:   "github-rest",
+		BackendKind: "tracker",
+		Provider:    "github",
+		Kind:        "github_rest_rate_limit",
+		Reason:      "GitHub REST remaining 0 is at or below dispatch floor 1000",
+		ResumeAt:    data.Snapshot.GeneratedAt.Add(44 * time.Minute),
+	}}
+	html := renderBoardComponent(t, BoardSnapshot(data))
+	for _, want := range []string{
+		`id="backend-capacity-outage"`,
+		"GitHub REST dispatch paused",
+		"GitHub REST remaining 0 is at or below dispatch floor 1000; resuming at 17:26 UTC",
+	} {
+		if !strings.Contains(html, want) {
+			t.Fatalf("GitHub REST capacity banner missing %q:\n%s", want, html)
+		}
+	}
+}
+
 func TestBoardSnapshotSurfacesHiddenPopulatedLanes(t *testing.T) {
 	data := DashboardData{
 		Snapshot: telemetry.Snapshot{

--- a/internal/web/templates/dashboard_data.go
+++ b/internal/web/templates/dashboard_data.go
@@ -6226,6 +6226,9 @@ func rateLimitName(limits *telemetry.RateLimits) string {
 }
 
 func backendCapacityOutageTitle(outage telemetry.BackendOutage) string {
+	if strings.TrimSpace(outage.Kind) == "github_rest_rate_limit" {
+		return "GitHub REST dispatch paused"
+	}
 	backend := strings.TrimSpace(outage.BackendID)
 	if backend == "" {
 		backend = strings.TrimSpace(outage.BackendKind)
@@ -6237,6 +6240,16 @@ func backendCapacityOutageTitle(outage telemetry.BackendOutage) string {
 }
 
 func backendCapacityOutageDetail(outage telemetry.BackendOutage, now time.Time) string {
+	if strings.TrimSpace(outage.Kind) == "github_rest_rate_limit" {
+		detail := strings.TrimSpace(outage.Reason)
+		if detail == "" {
+			detail = "The shared tracker account is at its REST dispatch floor"
+		}
+		if !outage.ResumeAt.IsZero() && outage.ResumeAt.After(now) {
+			return detail + "; resuming at " + outage.ResumeAt.UTC().Format("15:04 UTC")
+		}
+		return detail + "; dispatch can resume now"
+	}
 	provider := strings.TrimSpace(outage.Provider)
 	detail := "Dispatch is paused"
 	if provider != "" {


### PR DESCRIPTION
## Summary

- count clean completed attempts without a PR as no-progress, including the legacy July 10 telemetry shape
- fail sessions with unresolved push or PR command errors while preserving successfully recovered delivery attempts
- pause project dispatch at the configured GitHub REST floor, surface reset-aware capacity telemetry, and resume automatically at reset

Fixes #1211

## UI Surface Contract

- [x] The linked issue explicitly authorizes the reset-aware GitHub REST capacity banner.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue.
- [x] N/A for new layout: this reuses the existing capacity banner markup; `TestBoardSnapshotRendersGitHubRESTCapacityBanner` verifies the rendered title and reset detail.

## Test Plan

- [x] `go test ./internal/runner ./internal/connector/github ./internal/orchestrator ./internal/web/templates -count=1`
- [x] `make check`
