### PR TITLE
feat(retro): add efficiency retrospection

### DIFF
--- a/README.md
+++ b/README.md
@@ -1054,6 +1054,44 @@ Host-local policy can override the workflow policy inside a project entry in
 `global.yaml` using the same `intake` shape. An explicit `sources: []` override
 disables workflow-defined intake for that project.
 
+### Efficiency retrospection
+
+Each project can opt into an evidence-based reflection loop over its runtime
+telemetry. The pass runs after agent completions and on a daily schedule,
+groups recurring inefficiency patterns, and creates or updates fingerprinted
+board issues for human triage.
+
+```yaml
+retro:
+  enabled: true
+  schedule: "0 3 * * *"
+  target_state: Backlog
+  labels: [retro]
+  product_repository: digitaldrywood/detent
+  daily_issue_cap: 3
+  lookback_days: 7
+  min_occurrences: 2
+  single_occurrence_severity: critical
+  fallback_threshold: 3
+  receipt_baseline_multiple: 4
+```
+
+Workflow findings stay on the project's board and include a governed proposed
+`WORKFLOW.md` change when the evidence maps to a known setting. Product findings
+such as completed-work re-dispatch or systemic capacity handling route to
+`product_repository`. The configured `retro` label is always retained, and
+`target_state: Todo` can be used when a project explicitly wants findings to
+skip Backlog triage.
+
+Detent files a finding after `min_occurrences`, or after one occurrence at or
+above `single_occurrence_severity`. `daily_issue_cap` limits newly created
+issues; recurrence updates to existing fingerprinted issues remain allowed.
+Retrospection never edits workflow files, prompts, or runtime configuration.
+Its issue body records the evidence, proposed change, and pending human outcome.
+`detent doctor` reports the last run, finding count, and filed/updated issue
+counts for every enabled project. ProjectV2 trackers must set
+`tracker.repository` so Detent knows where to create project-level findings.
+
 `gate` controls the validation contract the agent and operator flow follow.
 Omitting it preserves the code default: `kind: command` with `run: make check`,
 plus green CI, no P1 automated PR review findings, a quiet window, and a

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -223,6 +223,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		WorkAttempts:       runtimeStore,
 		AgentResume:        runtimeStore,
 		ValidatorMemo:      runtimeStore,
+		RetroStore:         runtimeStore,
 		Activity:           activityBroker,
 		GitHubToken:        runtimeGitHubToken.get(),
 		RefreshGitHubToken: refreshGitHubToken,

--- a/internal/cli/doctor_workflow_optimization.go
+++ b/internal/cli/doctor_workflow_optimization.go
@@ -89,7 +89,18 @@ type doctorWorkflowOptimizationProjectReport struct {
 	SessionGuard   doctorWorkflowSessionGuard        `json:"session_guard"`
 	OrphanRecovery doctorOrphanRecoveryConfig        `json:"orphan_recovery"`
 	Metrics        doctorWorkflowOptimizationMetrics `json:"metrics"`
+	Retro          doctorWorkflowRetroStatus         `json:"retro"`
 	Error          string                            `json:"error,omitempty"`
+}
+
+type doctorWorkflowRetroStatus struct {
+	Enabled       bool       `json:"enabled"`
+	LastRun       *time.Time `json:"last_run,omitempty"`
+	Trigger       string     `json:"trigger,omitempty"`
+	Findings      int64      `json:"findings"`
+	FiledIssues   int64      `json:"filed_issues"`
+	UpdatedIssues int64      `json:"updated_issues"`
+	Error         string     `json:"error,omitempty"`
 }
 
 type doctorWorkflowModelChoice struct {
@@ -394,6 +405,10 @@ func doctorWorkflowOptimization(
 		if err != nil {
 			return doctorWorkflowOptimizationReport{}, err
 		}
+		retroStatus, err := doctorWorkflowRetroStatusForProject(ctx, db, projectID, workflow.Config.Retro.Enabled)
+		if err != nil {
+			return doctorWorkflowOptimizationReport{}, err
+		}
 		report.Projects = append(report.Projects, doctorWorkflowOptimizationProjectReport{
 			ProjectID:      projectID,
 			WorkflowPath:   workflowPath,
@@ -401,6 +416,7 @@ func doctorWorkflowOptimization(
 			SessionGuard:   doctorWorkflowSessionGuardConfig(workflow.Config),
 			OrphanRecovery: doctorOrphanRecoveryConfig{ResumeOrphanedSessions: workflow.Config.Agent.ResumeOrphanedSessions, ExperimentalThreadResume: workflow.Config.Agent.ExperimentalThreadResume},
 			Metrics:        metrics,
+			Retro:          retroStatus,
 		})
 		analyzedProjects = append(analyzedProjects, doctorWorkflowAnalyzedProject{
 			projectID:    projectID,
@@ -468,6 +484,34 @@ func doctorWorkflowOptimization(
 		report.Diff = doctorWorkflowOptimizationDiff(report)
 	}
 	return report, nil
+}
+
+func doctorWorkflowRetroStatusForProject(ctx context.Context, db doctorTelemetryStore, projectID string, enabled bool) (doctorWorkflowRetroStatus, error) {
+	status := doctorWorkflowRetroStatus{Enabled: enabled}
+	var completedAt string
+	err := db.QueryRowContext(ctx, `
+SELECT completed_at, trigger, findings_count, filed_count, updated_count, COALESCE(error, '')
+FROM retro_runs
+WHERE project_id = ?
+ORDER BY completed_at DESC, id DESC
+LIMIT 1`, strings.TrimSpace(projectID)).Scan(
+		&completedAt, &status.Trigger, &status.Findings, &status.FiledIssues, &status.UpdatedIssues, &status.Error,
+	)
+	if errors.Is(err, sql.ErrNoRows) {
+		return status, nil
+	}
+	if err != nil && strings.Contains(strings.ToLower(err.Error()), "no such table: retro_runs") {
+		return status, nil
+	}
+	if err != nil {
+		return doctorWorkflowRetroStatus{}, fmt.Errorf("read retro status for project %s: %w", projectID, err)
+	}
+	lastRun, err := doctorWorkflowSessionTimestamp(completedAt)
+	if err != nil {
+		return doctorWorkflowRetroStatus{}, err
+	}
+	status.LastRun = &lastRun
+	return status, nil
 }
 
 func doctorWorkflowOptimizationMetricsForProject(
@@ -1821,7 +1865,7 @@ func doctorWorkflowEstimatedImpact(findings []doctorWorkflowOptimizationFinding)
 }
 
 func writeDoctorWorkflowOptimizationPretty(out io.Writer, report doctorWorkflowOptimizationReport) error {
-	if out == nil || len(report.Findings) == 0 && len(report.Proposals) == 0 && len(report.CreatedProposalIssues) == 0 && strings.TrimSpace(report.Diff) == "" && len(report.Written) == 0 && !doctorReportHasOrphanRecovery(report) {
+	if out == nil || len(report.Findings) == 0 && len(report.Proposals) == 0 && len(report.CreatedProposalIssues) == 0 && strings.TrimSpace(report.Diff) == "" && len(report.Written) == 0 && !doctorReportHasOrphanRecovery(report) && !doctorWorkflowHasRetroStatus(report.Projects) {
 		return nil
 	}
 	if _, err := fmt.Fprintln(out); err != nil {
@@ -1837,10 +1881,24 @@ func writeDoctorWorkflowOptimizationPretty(out io.Writer, report doctorWorkflowO
 	}
 	for _, project := range report.Projects {
 		recovery := project.Metrics.OrphanRecovery
-		if recovery.Detected+recovery.Reattached+recovery.FreshContinuations == 0 {
-			continue
+		if recovery.Detected+recovery.Reattached+recovery.FreshContinuations > 0 {
+			if _, err := fmt.Fprintf(out, "Orphan recovery [%s]: detected=%d, reattached=%d, fresh_continuations=%d, reattach_failures=%d, resumed_cached_input_share=%.1f%%\n", project.ProjectID, recovery.Detected, recovery.Reattached, recovery.FreshContinuations, recovery.ReattachFailures, recovery.ResumedCachedInputShare*100); err != nil {
+				return err
+			}
 		}
-		if _, err := fmt.Fprintf(out, "Orphan recovery [%s]: detected=%d, reattached=%d, fresh_continuations=%d, reattach_failures=%d, resumed_cached_input_share=%.1f%%\n", project.ProjectID, recovery.Detected, recovery.Reattached, recovery.FreshContinuations, recovery.ReattachFailures, recovery.ResumedCachedInputShare*100); err != nil {
+		lastRun := "never"
+		if project.Retro.LastRun != nil {
+			lastRun = project.Retro.LastRun.UTC().Format(time.RFC3339)
+		}
+		if _, err := fmt.Fprintf(out, "Retro %s: enabled=%t last_run=%s findings=%d filed_issues=%d updated_issues=%d", project.ProjectID, project.Retro.Enabled, lastRun, project.Retro.Findings, project.Retro.FiledIssues, project.Retro.UpdatedIssues); err != nil {
+			return err
+		}
+		if project.Retro.Error != "" {
+			if _, err := fmt.Fprintf(out, " error=%s", project.Retro.Error); err != nil {
+				return err
+			}
+		}
+		if _, err := fmt.Fprintln(out); err != nil {
 			return err
 		}
 	}
@@ -1962,6 +2020,10 @@ func doctorReportHasOrphanRecovery(report doctorWorkflowOptimizationReport) bool
 		}
 	}
 	return false
+}
+
+func doctorWorkflowHasRetroStatus(projects []doctorWorkflowOptimizationProjectReport) bool {
+	return len(projects) > 0
 }
 
 func doctorWorkflowEvidenceLine(evidence map[string]any) string {

--- a/internal/cli/doctor_workflow_optimization_test.go
+++ b/internal/cli/doctor_workflow_optimization_test.go
@@ -21,8 +21,52 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/lessons"
+	"github.com/digitaldrywood/detent/internal/retro"
 	"github.com/digitaldrywood/detent/internal/store"
 )
+
+func TestDoctorWorkflowOptimizationReportsRetroStatus(t *testing.T) {
+	t.Parallel()
+
+	paths := seedDoctorWorkflowOptimizationFixture(t)
+	ctx := context.Background()
+	backend, err := store.Open(ctx, store.Config{Backend: store.BackendSQLite, Path: paths.db})
+	if err != nil {
+		t.Fatalf("store.Open() error = %v", err)
+	}
+	completedAt := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	if err := backend.RecordRetroRun(ctx, retro.RunRecord{
+		ProjectID: "detent", Trigger: retro.TriggerDaily,
+		StartedAt: completedAt.Add(-time.Minute), CompletedAt: completedAt,
+		Findings: 4, Filed: 2, Updated: 1,
+	}); err != nil {
+		t.Fatalf("RecordRetroRun() error = %v", err)
+	}
+	if err := backend.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+
+	db, err := openDoctorSQLiteReadOnly(ctx, paths.db)
+	if err != nil {
+		t.Fatalf("openDoctorSQLiteReadOnly() error = %v", err)
+	}
+	defer db.Close()
+	status, err := doctorWorkflowRetroStatusForProject(ctx, db, "detent", true)
+	if err != nil {
+		t.Fatalf("doctorWorkflowRetroStatusForProject() error = %v", err)
+	}
+	if !status.Enabled || status.LastRun == nil || !status.LastRun.Equal(completedAt) || status.Findings != 4 || status.FiledIssues != 2 || status.UpdatedIssues != 1 {
+		t.Fatalf("retro status = %#v", status)
+	}
+
+	var output bytes.Buffer
+	if err := writeDoctorWorkflowOptimizationPretty(&output, doctorWorkflowOptimizationReport{Projects: []doctorWorkflowOptimizationProjectReport{{ProjectID: "detent", Retro: status}}}); err != nil {
+		t.Fatalf("writeDoctorWorkflowOptimizationPretty() error = %v", err)
+	}
+	if text := output.String(); !strings.Contains(text, "Retro detent: enabled=true") || !strings.Contains(text, "filed_issues=2") {
+		t.Fatalf("pretty output missing retro status:\n%s", text)
+	}
+}
 
 func TestDoctorWorkflowOptimizationFindsFixtureRules(t *testing.T) {
 	t.Parallel()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -15,6 +15,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/intake"
 	"github.com/digitaldrywood/detent/internal/pathsafe"
+	"github.com/digitaldrywood/detent/internal/retro"
 	"github.com/digitaldrywood/detent/internal/selector"
 	commandshell "github.com/digitaldrywood/detent/internal/shell"
 )
@@ -106,6 +107,7 @@ type Config struct {
 	Release       Release         `yaml:"release,omitempty"`
 	Hooks         Hooks           `yaml:"hooks"`
 	Intake        intake.Config   `yaml:"intake,omitempty"`
+	Retro         retro.Config    `yaml:"retro,omitempty"`
 }
 
 type Tracker struct {
@@ -1059,6 +1061,14 @@ func (c *Config) Validate() error {
 	if c.Intake.Enabled() && !validRepositoryName(c.Tracker.Repository) {
 		problems = append(problems, "tracker.repository is required for intake sources")
 	}
+	c.Retro.Normalize()
+	problems = append(problems, c.Retro.Validate("retro", states)...)
+	if c.Retro.Enabled && c.Tracker.Kind != TrackerGitHub && c.Tracker.Kind != TrackerMemory {
+		problems = append(problems, "retro.enabled requires tracker.kind github or memory")
+	}
+	if c.Retro.Enabled && c.Tracker.Kind == TrackerGitHub && !validRepositoryName(c.Tracker.Repository) {
+		problems = append(problems, "tracker.repository is required for retro")
+	}
 
 	if len(problems) > 0 {
 		return ValidationError{Problems: problems}
@@ -1221,6 +1231,7 @@ func (c *Config) normalize() {
 	c.Server.Normalize()
 	c.Hooks.Shell = commandshell.Normalize(c.Hooks.Shell)
 	c.Intake.Normalize()
+	c.Retro.Normalize()
 }
 
 func (c *Config) validateTracker(problems *[]string) {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -463,6 +463,32 @@ Ticket prompt {{ issue.title }}
 	}
 }
 
+func TestParseWorkflowRetroDefaultsAndValidation(t *testing.T) {
+	t.Parallel()
+
+	workflow, err := ParseWorkflow([]byte(`---
+tracker:
+  kind: memory
+  active_states: [Todo]
+  observed_states: [Backlog, Blocked]
+retro:
+  enabled: true
+  target_state: Backlog
+---
+Prompt
+`))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
+	if err := workflow.Config.Validate(); err != nil {
+		t.Fatalf("Validate() error = %v", err)
+	}
+	retro := workflow.Config.Retro
+	if !retro.Enabled || retro.DailyIssueCap != 3 || retro.LookbackDays != 7 || retro.MinOccurrences != 2 || retro.ProductRepository != "digitaldrywood/detent" || !reflect.DeepEqual(retro.Labels, []string{"retro"}) {
+		t.Fatalf("Retro = %#v", retro)
+	}
+}
+
 func TestParseWorkflowGitHubIssueFieldTracker(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -1872,10 +1872,12 @@ func TestHandleRunResultCompletesDurableAttempt(t *testing.T) {
 		Project:             scheduler.ProjectCandidate{ID: "detent"},
 	})
 	attempts := &recordingWorkAttemptStore{}
+	retrospector := &recordingRetrospector{}
 	orch := Orchestrator{
 		cfg:          cfg,
 		runResults:   make(chan runpkg.Completion, 1),
 		workAttempts: attempts,
+		retrospector: retrospector,
 	}
 	state := newState(cfg)
 	issue := dispatchTestIssue("issue-failed-attempt", "Todo")
@@ -1910,6 +1912,9 @@ func TestHandleRunResultCompletesDurableAttempt(t *testing.T) {
 	}
 	if _, ok := state.Retry[issue.ID]; !ok {
 		t.Fatalf("Retry[%q] missing after failed durable attempt", issue.ID)
+	}
+	if !slices.Equal(retrospector.triggers, []string{"completion"}) {
+		t.Fatalf("retrospector triggers = %v, want completion", retrospector.triggers)
 	}
 }
 
@@ -2385,6 +2390,14 @@ type recordingWorkAttemptStore struct {
 	recent         []store.WorkAttempt
 	history        []store.WorkAttempt
 	historyQueries []store.WorkAttemptHistoryQuery
+}
+
+type recordingRetrospector struct {
+	triggers []string
+}
+
+func (r *recordingRetrospector) Trigger(trigger string) {
+	r.triggers = append(r.triggers, trigger)
 }
 
 func (s *recordingWorkAttemptStore) StartWorkAttempt(_ context.Context, attrs store.WorkAttemptStart) (int64, error) {

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -115,6 +115,11 @@ type Dependencies struct {
 	GlobalDispatchGate scheduler.ProjectDispatchGate
 	Now                func() time.Time
 	Logger             *slog.Logger
+	Retrospector       Retrospector
+}
+
+type Retrospector interface {
+	Trigger(string)
 }
 
 type WorkspaceReapResult = runpkg.WorkspaceReapResult
@@ -151,6 +156,7 @@ type Orchestrator struct {
 	capacityController      runpkg.CapacityController
 	validatorCapacity       runpkg.ValidatorCapacityController
 	now                     func() time.Time
+	retrospector            Retrospector
 	stateRequests           chan stateRequest
 	drainRequests           chan drainRequest
 	forceRequests           chan forceRequest
@@ -295,6 +301,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		validatorMemo:           validatorMemo,
 		activity:                deps.Activity,
 		release:                 deps.Release,
+		retrospector:            deps.Retrospector,
 		capacityController:      capacityController,
 		validatorCapacity:       validatorCapacity,
 		now:                     now,

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -84,6 +84,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if !ok {
 		return
 	}
+	if o.retrospector != nil {
+		defer o.retrospector.Trigger("completion")
+	}
 	o.releaseGlobalDispatchSlot(running.globalSlot)
 	o.logWorkerLifecycle(running.Issue, "worker_capacity_released",
 		"attempt", running.Attempt,

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -22,6 +22,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/intake"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	releasepkg "github.com/digitaldrywood/detent/internal/release"
+	"github.com/digitaldrywood/detent/internal/retro"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/selector"
 	"github.com/digitaldrywood/detent/internal/store"
@@ -100,6 +101,7 @@ type Dependencies struct {
 	GitHubToken            string
 	RefreshGitHubToken     func(context.Context) (string, error)
 	IntakeDependencies     intake.Dependencies
+	RetroStore             store.RetroStore
 }
 
 type Project struct {
@@ -117,6 +119,8 @@ type Project struct {
 	scheduler        scheduler.Scheduler
 	schedulerFactory schedulerFactory
 	intake           *intake.Manager
+	retro            *retro.Manager
+	retroProduct     connector.Connector
 	events           *hub.Hub[Event]
 	logger           *slog.Logger
 	watcher          WorkflowWatcherFactory
@@ -183,6 +187,24 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	if err != nil {
 		return nil, fmt.Errorf("create project intake: %w", err)
 	}
+	releaseBuild, err := buildReleaseCoordinator(workflow.Config, projectConnector)
+	if err != nil {
+		return nil, err
+	}
+	releaseCoordinator := releaseBuild.coordinator
+	projectRetroStore, productRetroStore, retroProductConnector, err := buildRetroIssueStores(workflow.Config, projectConnector, connectorFactory)
+	if err != nil {
+		return nil, fmt.Errorf("create project retro: %w", err)
+	}
+	projectRetro, err := retro.New(retro.Settings{
+		ProjectID:     string(id),
+		Config:        workflow.Config.Retro,
+		ProjectIssues: projectRetroStore,
+		ProductIssues: productRetroStore,
+	}, deps.RetroStore, logger, nil)
+	if err != nil {
+		return nil, errors.Join(fmt.Errorf("create project retro: %w", err), closeConnector(retroProductConnector))
+	}
 
 	orchestratorFactory := deps.OrchestratorFactory
 	if orchestratorFactory == nil {
@@ -190,11 +212,6 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 	}
 
 	orchConfig := projectOrchestratorConfig(cfg.Project, workflow.Config)
-	releaseBuild, err := buildReleaseCoordinator(workflow.Config, projectConnector)
-	if err != nil {
-		return nil, err
-	}
-	releaseCoordinator := releaseBuild.coordinator
 	orchDeps := orchestrator.Dependencies{
 		Connector:          projectConnector,
 		Runner:             deps.Runner,
@@ -206,13 +223,14 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		Activity:           deps.Activity,
 		Release:            releaseCoordinator,
 		Logger:             logger,
+		Retrospector:       projectRetro,
 	}
 	orch, err := orchestratorFactory(orchConfig, orchDeps)
 	if err != nil {
-		return nil, fmt.Errorf("create project orchestrator: %w", err)
+		return nil, errors.Join(fmt.Errorf("create project orchestrator: %w", err), closeConnector(retroProductConnector))
 	}
 	if orch == nil {
-		return nil, ErrMissingOrchestrator
+		return nil, errors.Join(ErrMissingOrchestrator, closeConnector(retroProductConnector))
 	}
 
 	watcherProject := cfg.Project
@@ -235,6 +253,8 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		scheduler:        projectScheduler,
 		schedulerFactory: schedulerFactory,
 		intake:           projectIntake,
+		retro:            projectRetro,
+		retroProduct:     retroProductConnector,
 		events:           projectEvents,
 		logger:           logger,
 		watcher:          watcherFactory,
@@ -535,9 +555,10 @@ func (p *Project) close(ctx context.Context, publishEvents bool) error {
 func (p *Project) closeConnector() error {
 	p.mu.Lock()
 	projectConnector := p.connector
+	retroProductConnector := p.retroProduct
 	p.mu.Unlock()
 
-	return closeConnector(projectConnector)
+	return errors.Join(closeConnector(projectConnector), closeConnector(retroProductConnector))
 }
 
 func (p *Project) stop(ctx context.Context, publishEvents bool) error {
@@ -629,6 +650,8 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 	watcherDone := p.startWorkflowWatcher(watcherCtx)
 	intakeCtx, stopIntake := context.WithCancel(ctx)
 	intakeDone := p.startIntake(intakeCtx)
+	retroCtx, stopRetro := context.WithCancel(ctx)
+	retroDone := p.startRetro(retroCtx)
 
 	runStarted := logProjectShutdownBoundaryBegin(p.logger, "orchestrator_run", "component", "orchestrator", "project_id", p.id)
 	err := orch.Run(ctx)
@@ -652,6 +675,14 @@ func (p *Project) run(ctx context.Context, done chan struct{}, orch *orchestrato
 		logProjectShutdownBoundaryEnd(p.logger, "intake_stop", intakeStarted, nil, "component", "intake", "project_id", p.id)
 	} else {
 		logProjectShutdownBoundaryEndResult(p.logger, "intake_stop", intakeStarted, "skipped", nil, "component", "intake", "project_id", p.id)
+	}
+	retroStarted := logProjectShutdownBoundaryBegin(p.logger, "retro_stop", "component", "retro", "project_id", p.id)
+	stopRetro()
+	if retroDone != nil {
+		<-retroDone
+		logProjectShutdownBoundaryEnd(p.logger, "retro_stop", retroStarted, nil, "component", "retro", "project_id", p.id)
+	} else {
+		logProjectShutdownBoundaryEndResult(p.logger, "retro_stop", retroStarted, "skipped", nil, "component", "retro", "project_id", p.id)
 	}
 	if errors.Is(err, context.Canceled) && ctx.Err() != nil {
 		err = nil
@@ -693,6 +724,23 @@ func (p *Project) startIntake(ctx context.Context) <-chan struct{} {
 		defer close(done)
 		if err := manager.Run(ctx); err != nil && ctx.Err() == nil {
 			p.logger.Error("project intake stopped", "project_id", p.id, "error", err)
+		}
+	}()
+	return done
+}
+
+func (p *Project) startRetro(ctx context.Context) <-chan struct{} {
+	p.mu.Lock()
+	manager := p.retro
+	p.mu.Unlock()
+	if manager == nil {
+		return nil
+	}
+	done := make(chan struct{})
+	go func() {
+		defer close(done)
+		if err := manager.Run(ctx); err != nil && ctx.Err() == nil {
+			p.logger.Error("project retro stopped", "project_id", p.id, "error", err)
 		}
 	}()
 	return done
@@ -797,6 +845,7 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	runner := p.runner
 	projectOrchestrator := p.orchestrator
 	projectIntake := p.intake
+	projectRetro := p.retro
 	p.mu.Unlock()
 	if projectOrchestrator == nil {
 		return
@@ -844,6 +893,25 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	}
 	releaseCoordinator := releaseBuild.coordinator
 
+	projectRetroStore, productRetroStore, retroProductConnector, err := buildRetroIssueStores(workflow.Config, projectConnector, connectorFactory)
+	if err != nil {
+		p.logger.Warn("workflow reload retro connector failed",
+			"project_id", p.id,
+			"path", update.Path,
+			"error", err,
+		)
+		return
+	}
+	retainRetroProduct := false
+	defer func() {
+		if retainRetroProduct {
+			return
+		}
+		if err := closeConnector(retroProductConnector); err != nil {
+			p.logger.Warn("close unused retro product connector failed", "project_id", p.id, "error", err)
+		}
+	}()
+
 	var preparedIntake *intake.Prepared
 	if projectIntake != nil {
 		preparedIntake, err = projectIntake.Prepare(
@@ -884,10 +952,24 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	if projectIntake != nil {
 		projectIntake.Apply(preparedIntake)
 	}
+	if projectRetro != nil {
+		if err := projectRetro.Update(retro.Settings{
+			ProjectID:     string(p.id),
+			Config:        workflow.Config.Retro,
+			ProjectIssues: projectRetroStore,
+			ProductIssues: productRetroStore,
+		}); err != nil {
+			p.logger.Warn("apply workflow retro reload failed", "project_id", p.id, "path", update.Path, "error", err)
+			return
+		}
+	}
 
 	p.mu.Lock()
+	previousRetroProduct := p.retroProduct
 	p.workflow = workflow
 	p.connector = projectConnector
+	p.retroProduct = retroProductConnector
+	retainRetroProduct = true
 	p.scheduler = projectScheduler
 	p.orchConfig = runtimeConfig
 	p.orchDeps.Connector = projectConnector
@@ -895,6 +977,11 @@ func (p *Project) handleWorkflowUpdate(ctx context.Context, update configwatcher
 	publishEvents := p.lifecycleEvents
 	id := p.id
 	p.mu.Unlock()
+	if previousRetroProduct != retroProductConnector {
+		if err := closeConnector(previousRetroProduct); err != nil {
+			p.logger.Warn("close previous retro product connector failed", "project_id", p.id, "error", err)
+		}
+	}
 
 	p.logger.Info("workflow reloaded", "project_id", p.id, "path", update.Path)
 	if publishEvents {
@@ -982,6 +1069,37 @@ func intakeStore(projectConnector connector.Connector) intake.IssueStore {
 		return nil
 	}
 	return store
+}
+
+func buildRetroIssueStores(
+	cfg workflowconfig.Config,
+	projectConnector connector.Connector,
+	connectorFactory ConnectorFactory,
+) (intake.IssueStore, intake.IssueStore, connector.Connector, error) {
+	if !cfg.Retro.Enabled {
+		return nil, nil, nil, nil
+	}
+	projectStore := intakeStore(projectConnector)
+	if projectStore == nil {
+		return nil, nil, nil, retro.ErrMissingProjectStore
+	}
+	if strings.EqualFold(strings.TrimSpace(cfg.Tracker.Repository), strings.TrimSpace(cfg.Retro.ProductRepository)) {
+		return projectStore, projectStore, nil, nil
+	}
+	productConfig := cfg
+	productConfig.Tracker.Repository = cfg.Retro.ProductRepository
+	productConnector, err := buildConnector(productConfig, connectorFactory)
+	if err != nil {
+		return nil, nil, nil, err
+	}
+	if productConnector == projectConnector {
+		return projectStore, projectStore, nil, nil
+	}
+	productStore := intakeStore(productConnector)
+	if productStore == nil {
+		return nil, nil, nil, errors.Join(retro.ErrMissingProductStore, closeConnector(productConnector))
+	}
+	return projectStore, productStore, productConnector, nil
 }
 
 func workflowConfigWithProjectPaths(project globalconfig.Project, workflow workflowconfig.Config) workflowconfig.Config {

--- a/internal/project/project_race_test.go
+++ b/internal/project/project_race_test.go
@@ -143,6 +143,36 @@ func TestHandleWorkflowUpdateRejectsIntakeBeforeRuntimeMutation(t *testing.T) {
 	}
 }
 
+func TestBuildRetroIssueStoresRoutesProductRepository(t *testing.T) {
+	t.Parallel()
+
+	cfg := projectRaceWorkflowConfig()
+	cfg.Tracker.Repository = "example/project"
+	cfg.Retro.Enabled = true
+	cfg.Retro.ProductRepository = "digitaldrywood/detent"
+	cfg.Retro.Normalize()
+	projectConnector := memory.New(memory.Config{Stateful: true})
+	productConnector := memory.New(memory.Config{Stateful: true})
+	var repositories []string
+
+	projectIssues, productIssues, created, err := buildRetroIssueStores(cfg, projectConnector, func(candidate workflowconfig.Config) (connector.Connector, error) {
+		repositories = append(repositories, candidate.Tracker.Repository)
+		return productConnector, nil
+	})
+	if err != nil {
+		t.Fatalf("buildRetroIssueStores() error = %v", err)
+	}
+	if projectIssues != projectConnector {
+		t.Fatalf("project issue store = %T, want project connector", projectIssues)
+	}
+	if productIssues != productConnector || created != productConnector {
+		t.Fatalf("product issue store/connector = %T/%T, want product connector", productIssues, created)
+	}
+	if len(repositories) != 1 || repositories[0] != "digitaldrywood/detent" {
+		t.Fatalf("product repositories = %v, want digitaldrywood/detent", repositories)
+	}
+}
+
 func projectRaceWorkflowConfig() workflowconfig.Config {
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = connector.BackendMemory.String()

--- a/internal/retro/config.go
+++ b/internal/retro/config.go
@@ -1,0 +1,156 @@
+package retro
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/robfig/cron/v3"
+)
+
+const (
+	DefaultSchedule                 = "0 3 * * *"
+	DefaultTargetState              = "Backlog"
+	DefaultProductRepository        = "digitaldrywood/detent"
+	DefaultDailyIssueCap            = 3
+	DefaultLookbackDays             = 7
+	DefaultMinOccurrences           = 2
+	DefaultFallbackThreshold        = 3
+	DefaultReceiptBaselineMultiple  = 4
+	DefaultSingleOccurrenceSeverity = SeverityCritical
+)
+
+type Config struct {
+	Enabled                  bool     `yaml:"enabled"`
+	Schedule                 string   `yaml:"schedule,omitempty"`
+	TargetState              string   `yaml:"target_state,omitempty"`
+	Labels                   []string `yaml:"labels,omitempty"`
+	ProductRepository        string   `yaml:"product_repository,omitempty"`
+	DailyIssueCap            int      `yaml:"daily_issue_cap,omitempty"`
+	LookbackDays             int      `yaml:"lookback_days,omitempty"`
+	MinOccurrences           int      `yaml:"min_occurrences,omitempty"`
+	SingleOccurrenceSeverity string   `yaml:"single_occurrence_severity,omitempty"`
+	FallbackThreshold        int      `yaml:"fallback_threshold,omitempty"`
+	ReceiptBaselineMultiple  float64  `yaml:"receipt_baseline_multiple,omitempty"`
+}
+
+func (c *Config) Normalize() {
+	if c == nil {
+		return
+	}
+	c.Schedule = strings.TrimSpace(c.Schedule)
+	c.TargetState = strings.TrimSpace(c.TargetState)
+	c.ProductRepository = strings.TrimSpace(c.ProductRepository)
+	c.SingleOccurrenceSeverity = strings.ToLower(strings.TrimSpace(c.SingleOccurrenceSeverity))
+	c.Labels = normalizeLabels(c.Labels)
+	if !c.Enabled {
+		return
+	}
+	if c.Schedule == "" {
+		c.Schedule = DefaultSchedule
+	}
+	if c.TargetState == "" {
+		c.TargetState = DefaultTargetState
+	}
+	if c.ProductRepository == "" {
+		c.ProductRepository = DefaultProductRepository
+	}
+	if c.DailyIssueCap == 0 {
+		c.DailyIssueCap = DefaultDailyIssueCap
+	}
+	if c.LookbackDays == 0 {
+		c.LookbackDays = DefaultLookbackDays
+	}
+	if c.MinOccurrences == 0 {
+		c.MinOccurrences = DefaultMinOccurrences
+	}
+	if c.SingleOccurrenceSeverity == "" {
+		c.SingleOccurrenceSeverity = DefaultSingleOccurrenceSeverity
+	}
+	if c.FallbackThreshold == 0 {
+		c.FallbackThreshold = DefaultFallbackThreshold
+	}
+	if c.ReceiptBaselineMultiple == 0 {
+		c.ReceiptBaselineMultiple = DefaultReceiptBaselineMultiple
+	}
+	if !containsFold(c.Labels, "retro") {
+		c.Labels = append(c.Labels, "retro")
+	}
+}
+
+func (c Config) Validate(prefix string, states []string) []string {
+	c.Normalize()
+	if prefix == "" {
+		prefix = "retro"
+	}
+	if !c.Enabled {
+		return nil
+	}
+	var problems []string
+	if _, err := cron.ParseStandard(c.Schedule); err != nil {
+		problems = append(problems, prefix+".schedule must be a valid five-field cron expression")
+	}
+	if c.TargetState == "" {
+		problems = append(problems, prefix+".target_state is required when "+prefix+".enabled is true")
+	} else if len(states) > 0 && !containsFold(states, c.TargetState) {
+		problems = append(problems, prefix+".target_state must name a configured tracker state")
+	}
+	if !validRepository(c.ProductRepository) {
+		problems = append(problems, prefix+".product_repository must be owner/name")
+	}
+	if c.DailyIssueCap <= 0 {
+		problems = append(problems, prefix+".daily_issue_cap must be greater than 0")
+	}
+	if c.LookbackDays <= 0 {
+		problems = append(problems, prefix+".lookback_days must be greater than 0")
+	}
+	if c.MinOccurrences < 2 {
+		problems = append(problems, prefix+".min_occurrences must be at least 2")
+	}
+	if severityRank(c.SingleOccurrenceSeverity) == 0 {
+		problems = append(problems, prefix+".single_occurrence_severity must be one of info, warning, high, critical")
+	}
+	if c.FallbackThreshold < 2 {
+		problems = append(problems, prefix+".fallback_threshold must be at least 2")
+	}
+	if c.ReceiptBaselineMultiple <= 1 {
+		problems = append(problems, prefix+".receipt_baseline_multiple must be greater than 1")
+	}
+	for index, label := range c.Labels {
+		if strings.ContainsAny(label, "\r\n") {
+			problems = append(problems, fmt.Sprintf("%s.labels[%d] must be a single line", prefix, index))
+		}
+	}
+	return problems
+}
+
+func normalizeLabels(labels []string) []string {
+	out := make([]string, 0, len(labels))
+	seen := map[string]struct{}{}
+	for _, label := range labels {
+		label = strings.TrimSpace(label)
+		key := strings.ToLower(label)
+		if key == "" {
+			continue
+		}
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, label)
+	}
+	return out
+}
+
+func containsFold(values []string, want string) bool {
+	for _, value := range values {
+		if strings.EqualFold(strings.TrimSpace(value), strings.TrimSpace(want)) {
+			return true
+		}
+	}
+	return false
+}
+
+func validRepository(value string) bool {
+	owner, name, ok := strings.Cut(strings.TrimSpace(value), "/")
+	return ok && strings.TrimSpace(owner) != "" && strings.TrimSpace(name) != "" && !strings.Contains(name, "/")
+}

--- a/internal/retro/detector.go
+++ b/internal/retro/detector.go
@@ -1,0 +1,645 @@
+package retro
+
+import (
+	"cmp"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"slices"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const (
+	ScopeWorkflow = "workflow"
+	ScopeProduct  = "product"
+
+	SeverityInfo     = "info"
+	SeverityWarning  = "warning"
+	SeverityHigh     = "high"
+	SeverityCritical = "critical"
+
+	PatternCompletedRedispatch    = "completed_work_redispatched"
+	PatternSystemicBreaker        = "systemic_breaker_trip"
+	PatternCeilingThenSuccess     = "session_ceiling_then_success"
+	PatternReceiptBaseline        = "receipt_exceeds_baseline"
+	PatternGateWaitTimeout        = "gate_wait_timeout"
+	PatternInvalidWorkpadStatus   = "invalid_workpad_status"
+	PatternSlowCapacityRecovery   = "slow_capacity_recovery"
+	PatternFallbackOrphanRecovery = "fallback_orphan_recovery"
+)
+
+type Snapshot struct {
+	Attempts    []Attempt
+	Sessions    []Session
+	UsageEvents []UsageEvent
+	PhaseEvents []PhaseEvent
+}
+
+type Attempt struct {
+	ID                   int64
+	IssueID              string
+	Identifier           string
+	IssueURL             string
+	AttemptNumber        int
+	StartedAt            time.Time
+	CompletedAt          time.Time
+	TerminalState        string
+	ErrorClass           string
+	ErrorMessage         string
+	Phase                string
+	StatusMessage        string
+	WaitReason           string
+	CapacitySnapshotJSON string
+}
+
+type Session struct {
+	ID                    int64
+	WorkAttemptID         int64
+	IssueID               string
+	Identifier            string
+	IssueURL              string
+	StartedAt             time.Time
+	CompletedAt           time.Time
+	TotalTokens           int64
+	FinalState            string
+	OrphanRecoveryOutcome string
+}
+
+type UsageEvent struct {
+	IssueID     string
+	Identifier  string
+	FinishedAt  time.Time
+	TotalTokens int64
+	Outcome     string
+}
+
+type PhaseEvent struct {
+	IssueID     string
+	Identifier  string
+	IssueURL    string
+	PhaseType   string
+	PhaseName   string
+	Reason      string
+	Status      string
+	StartedAt   time.Time
+	FinishedAt  time.Time
+	TotalTokens int64
+}
+
+type DetectorOptions struct {
+	FallbackThreshold       int
+	ReceiptBaselineMultiple float64
+}
+
+type Finding struct {
+	Pattern     string
+	Scope       string
+	Severity    string
+	Title       string
+	Detail      string
+	TokenDelta  int64
+	Occurrences []Occurrence
+	Proposal    *Proposal
+}
+
+type Occurrence struct {
+	Issue  string
+	At     time.Time
+	Tokens int64
+	Detail string
+}
+
+type Proposal struct {
+	Path   string
+	Change string
+}
+
+func Detect(snapshot Snapshot, options DetectorOptions) []Finding {
+	if options.FallbackThreshold < 2 {
+		options.FallbackThreshold = DefaultFallbackThreshold
+	}
+	if options.ReceiptBaselineMultiple <= 1 {
+		options.ReceiptBaselineMultiple = DefaultReceiptBaselineMultiple
+	}
+	findings := []Finding{}
+	appendResult := func(finding Finding, ok bool) {
+		if ok {
+			findings = append(findings, finding)
+		}
+	}
+	appendResult(detectCompletedRedispatch(snapshot.Attempts))
+	findings = append(findings, detectSystemicBreakers(snapshot.Attempts)...)
+	appendResult(detectCeilingThenSuccess(snapshot.Attempts, snapshot.Sessions))
+	appendResult(detectReceiptBaseline(snapshot.UsageEvents, options.ReceiptBaselineMultiple))
+	appendResult(detectGateWaitTimeouts(snapshot.Attempts, snapshot.PhaseEvents))
+	appendResult(detectInvalidWorkpadStatuses(snapshot.PhaseEvents))
+	appendResult(detectSlowCapacityRecovery(snapshot.Attempts))
+	appendResult(detectFallbackOrphanRecovery(snapshot.Sessions, options.FallbackThreshold))
+	for index := range findings {
+		sortOccurrences(findings[index].Occurrences)
+	}
+	sort.SliceStable(findings, func(i, j int) bool {
+		if severityRank(findings[i].Severity) != severityRank(findings[j].Severity) {
+			return severityRank(findings[i].Severity) > severityRank(findings[j].Severity)
+		}
+		return findings[i].Pattern < findings[j].Pattern
+	})
+	return findings
+}
+
+func Qualifies(finding Finding, minOccurrences int, singleOccurrenceSeverity string) bool {
+	if minOccurrences < 2 {
+		minOccurrences = DefaultMinOccurrences
+	}
+	if len(finding.Occurrences) >= minOccurrences {
+		return true
+	}
+	return len(finding.Occurrences) == 1 && severityRank(finding.Severity) >= severityRank(singleOccurrenceSeverity)
+}
+
+func Fingerprint(projectID string, finding Finding) string {
+	raw := strings.ToLower(strings.TrimSpace(projectID)) + "\x00" + finding.Scope + "\x00" + finding.Pattern
+	sum := sha256.Sum256([]byte(raw))
+	return hex.EncodeToString(sum[:])
+}
+
+func severityRank(severity string) int {
+	switch strings.ToLower(strings.TrimSpace(severity)) {
+	case SeverityInfo:
+		return 1
+	case SeverityWarning, "warn":
+		return 2
+	case SeverityHigh:
+		return 3
+	case SeverityCritical:
+		return 4
+	default:
+		return 0
+	}
+}
+
+func detectCompletedRedispatch(attempts []Attempt) (Finding, bool) {
+	groups := attemptsByIssue(attempts)
+	occurrences := []Occurrence{}
+	for _, group := range groups {
+		slices.SortFunc(group, compareAttemptTime)
+		completed := false
+		for _, attempt := range group {
+			if completed {
+				occurrences = append(occurrences, attemptOccurrence(attempt, "dispatched after a successful completed attempt"))
+			}
+			if completedWork(attempt) {
+				completed = true
+			}
+		}
+	}
+	return Finding{
+		Pattern:     PatternCompletedRedispatch,
+		Scope:       ScopeProduct,
+		Severity:    SeverityCritical,
+		Title:       "Stop re-dispatching completed work",
+		Detail:      "Work received another agent dispatch after a successful completion.",
+		Occurrences: occurrences,
+	}, len(occurrences) > 0
+}
+
+func detectSystemicBreakers(attempts []Attempt) []Finding {
+	byClass := map[string][]Occurrence{}
+	issues := map[string]map[string]struct{}{}
+	for _, attempt := range attempts {
+		class := systemicErrorClass(attempt)
+		if class == "" {
+			continue
+		}
+		byClass[class] = append(byClass[class], attemptOccurrence(attempt, strings.TrimSpace(attempt.ErrorMessage)))
+		if issues[class] == nil {
+			issues[class] = map[string]struct{}{}
+		}
+		issues[class][attemptIssue(attempt)] = struct{}{}
+	}
+	classes := make([]string, 0, len(byClass))
+	for class := range byClass {
+		classes = append(classes, class)
+	}
+	sort.Strings(classes)
+	findings := make([]Finding, 0, len(classes))
+	for _, class := range classes {
+		occurrences := byClass[class]
+		severity := SeverityHigh
+		if class == "quota" && len(issues[class]) >= 2 {
+			severity = SeverityCritical
+		}
+		findings = append(findings, Finding{
+			Pattern:     PatternSystemicBreaker + ":" + class,
+			Scope:       ScopeProduct,
+			Severity:    severity,
+			Title:       "Handle systemic " + class + " breaker trips",
+			Detail:      fmt.Sprintf("The same systemic %s failure class affected %d issue(s).", class, len(issues[class])),
+			Occurrences: occurrences,
+		})
+	}
+	return findings
+}
+
+func detectCeilingThenSuccess(attempts []Attempt, sessions []Session) (Finding, bool) {
+	sessionTokens := map[int64]int64{}
+	for _, session := range sessions {
+		if session.WorkAttemptID > 0 && session.TotalTokens > sessionTokens[session.WorkAttemptID] {
+			sessionTokens[session.WorkAttemptID] = session.TotalTokens
+		}
+	}
+	groups := attemptsByIssue(attempts)
+	occurrences := []Occurrence{}
+	var tokenDelta int64
+	for _, group := range groups {
+		slices.SortFunc(group, compareAttemptTime)
+		for index, attempt := range group {
+			if !containsAnyFold(attempt.ErrorClass+" "+attempt.ErrorMessage, "session token ceiling", "max_session_tokens", "context multiplier", "max_session_context_multiplier") {
+				continue
+			}
+			if !laterSuccess(group[index+1:]) {
+				continue
+			}
+			tokens := sessionTokens[attempt.ID]
+			tokenDelta += tokens
+			occurrences = append(occurrences, Occurrence{Issue: attemptIssue(attempt), At: attempt.CompletedAt, Tokens: tokens, Detail: strings.TrimSpace(attempt.ErrorMessage)})
+		}
+	}
+	return Finding{
+		Pattern:     PatternCeilingThenSuccess,
+		Scope:       ScopeWorkflow,
+		Severity:    SeverityHigh,
+		Title:       "Recalibrate session ceilings that kill viable work",
+		Detail:      "Sessions stopped by token guards later succeeded for the same unchanged work item.",
+		TokenDelta:  tokenDelta,
+		Occurrences: occurrences,
+		Proposal: &Proposal{
+			Path:   "agent.max_session_context_multiplier",
+			Change: "Remove or raise the context multiplier and set an intentional absolute agent.max_session_tokens ceiling after human review.",
+		},
+	}, len(occurrences) > 0
+}
+
+func detectReceiptBaseline(events []UsageEvent, multiple float64) (Finding, bool) {
+	totals := map[string]int64{}
+	latest := map[string]time.Time{}
+	for _, event := range events {
+		key := usageIssue(event)
+		if key == "" {
+			continue
+		}
+		totals[key] += event.TotalTokens
+		if event.FinishedAt.After(latest[key]) {
+			latest[key] = event.FinishedAt
+		}
+	}
+	values := make([]int64, 0, len(totals))
+	for _, total := range totals {
+		if total > 0 {
+			values = append(values, total)
+		}
+	}
+	if len(values) < 2 {
+		return Finding{}, false
+	}
+	slices.Sort(values)
+	baseline := values[(len(values)-1)/2]
+	if baseline <= 0 {
+		return Finding{}, false
+	}
+	occurrences := []Occurrence{}
+	var tokenDelta int64
+	for issue, total := range totals {
+		if float64(total) < float64(baseline)*multiple {
+			continue
+		}
+		delta := total - baseline
+		tokenDelta += delta
+		occurrences = append(occurrences, Occurrence{Issue: issue, At: latest[issue], Tokens: total, Detail: fmt.Sprintf("receipt %d tokens; baseline %d; multiple %.2fx", total, baseline, float64(total)/float64(baseline))})
+	}
+	return Finding{
+		Pattern:     PatternReceiptBaseline,
+		Scope:       ScopeWorkflow,
+		Severity:    SeverityHigh,
+		Title:       "Reduce issue receipts above the project baseline",
+		Detail:      fmt.Sprintf("Issue token receipts exceeded %.1fx the project median baseline.", multiple),
+		TokenDelta:  tokenDelta,
+		Occurrences: occurrences,
+		Proposal:    &Proposal{Path: "agent", Change: "Review effort defaults, gate settings, and workflow instructions for the cited issue shapes."},
+	}, len(occurrences) > 0
+}
+
+func detectGateWaitTimeouts(attempts []Attempt, phases []PhaseEvent) (Finding, bool) {
+	occurrences := []Occurrence{}
+	for _, attempt := range attempts {
+		text := strings.Join([]string{attempt.ErrorClass, attempt.ErrorMessage, attempt.WaitReason}, " ")
+		if containsAnyFold(text, "gate_wait_timeout", "gate wait timeout", "gate-wait timeout") {
+			occurrences = append(occurrences, attemptOccurrence(attempt, strings.TrimSpace(text)))
+		}
+	}
+	for _, event := range phases {
+		text := strings.Join([]string{event.PhaseName, event.Reason, event.Status}, " ")
+		if containsAnyFold(text, "gate_wait_timeout", "gate wait timeout", "gate-wait timeout") {
+			occurrences = append(occurrences, Occurrence{Issue: phaseIssue(event), At: phaseTime(event), Tokens: event.TotalTokens, Detail: strings.TrimSpace(text)})
+		}
+	}
+	return Finding{
+		Pattern:     PatternGateWaitTimeout,
+		Scope:       ScopeWorkflow,
+		Severity:    SeverityHigh,
+		Title:       "Tune recurring gate-wait timeouts",
+		Detail:      "The project repeatedly exhausted its configured gate-wait window.",
+		Occurrences: dedupeOccurrences(occurrences),
+		Proposal:    &Proposal{Path: "agent.auto_promote.gate_wait_timeout_seconds", Change: "Increase the gate-wait timeout or narrow the required checks after human review."},
+	}, len(occurrences) > 0
+}
+
+func detectInvalidWorkpadStatuses(phases []PhaseEvent) (Finding, bool) {
+	occurrences := []Occurrence{}
+	for _, event := range phases {
+		if !strings.EqualFold(strings.TrimSpace(event.Reason), "workpad_status_invalid") {
+			continue
+		}
+		occurrences = append(occurrences, Occurrence{Issue: phaseIssue(event), At: phaseTime(event), Tokens: event.TotalTokens, Detail: "workpad_status_invalid"})
+	}
+	return Finding{
+		Pattern:     PatternInvalidWorkpadStatus,
+		Scope:       ScopeWorkflow,
+		Severity:    SeverityHigh,
+		Title:       "Prevent invalid workpad statuses",
+		Detail:      "Agents emitted workpad statuses outside the configured detent-status contract.",
+		Occurrences: occurrences,
+		Proposal:    &Proposal{Path: "WORKFLOW.md", Change: "State that detent-status.status accepts only in_progress, blocked, or complete."},
+	}, len(occurrences) > 0
+}
+
+func detectSlowCapacityRecovery(attempts []Attempt) (Finding, bool) {
+	ordered := append([]Attempt(nil), attempts...)
+	slices.SortFunc(ordered, compareAttemptTime)
+	occurrences := []Occurrence{}
+	for index, attempt := range ordered {
+		if !containsAnyFold(attempt.ErrorClass+" "+attempt.ErrorMessage, "backend_capacity", "quota", "usage limit", "resource_exhausted") {
+			continue
+		}
+		resetAt, ok := capacityResetAt(attempt.CapacitySnapshotJSON)
+		if !ok {
+			continue
+		}
+		recoveredAt := nextSuccessfulStart(ordered[index+1:])
+		if recoveredAt.IsZero() || !recoveredAt.After(resetAt) {
+			continue
+		}
+		delay := recoveredAt.Sub(resetAt)
+		occurrences = append(occurrences, Occurrence{Issue: attemptIssue(attempt), At: recoveredAt, Detail: "recovered " + delay.Round(time.Second).String() + " after reset window"})
+	}
+	return Finding{
+		Pattern:     PatternSlowCapacityRecovery,
+		Scope:       ScopeProduct,
+		Severity:    SeverityHigh,
+		Title:       "Recover capacity promptly after reset windows",
+		Detail:      "Backend capacity remained unavailable after its recorded reset window.",
+		Occurrences: occurrences,
+	}, len(occurrences) > 0
+}
+
+func detectFallbackOrphanRecovery(sessions []Session, threshold int) (Finding, bool) {
+	candidates := make([]Session, 0, len(sessions))
+	for _, session := range sessions {
+		if strings.TrimSpace(session.OrphanRecoveryOutcome) != "" && sessionIssue(session) != "" {
+			candidates = append(candidates, session)
+		}
+	}
+	slices.SortFunc(candidates, func(a, b Session) int {
+		if result := a.StartedAt.Compare(b.StartedAt); result != 0 {
+			return result
+		}
+		return cmp.Compare(a.ID, b.ID)
+	})
+	occurrences := []Occurrence{}
+	consecutive := []Session{}
+	for _, session := range candidates {
+		if strings.EqualFold(strings.TrimSpace(session.OrphanRecoveryOutcome), "fresh") {
+			consecutive = append(consecutive, session)
+			if len(consecutive) == threshold {
+				for _, failed := range consecutive {
+					occurrences = append(occurrences, fallbackOccurrence(failed, threshold))
+				}
+			} else if len(consecutive) > threshold {
+				occurrences = append(occurrences, fallbackOccurrence(session, threshold))
+			}
+			continue
+		}
+		consecutive = nil
+	}
+	return Finding{
+		Pattern:     PatternFallbackOrphanRecovery,
+		Scope:       ScopeProduct,
+		Severity:    SeverityHigh,
+		Title:       "Restore orphan session reattachment",
+		Detail:      fmt.Sprintf("At least %d consecutive orphan recoveries fell back to fresh sessions.", threshold),
+		Occurrences: occurrences,
+	}, len(occurrences) > 0
+}
+
+func fallbackOccurrence(session Session, threshold int) Occurrence {
+	at := session.CompletedAt
+	if at.IsZero() {
+		at = session.StartedAt
+	}
+	return Occurrence{
+		Issue:  sessionIssue(session),
+		At:     at,
+		Tokens: session.TotalTokens,
+		Detail: strconv.Itoa(threshold) + " consecutive orphan recoveries started fresh",
+	}
+}
+
+func attemptsByIssue(attempts []Attempt) map[string][]Attempt {
+	groups := map[string][]Attempt{}
+	for _, attempt := range attempts {
+		key := attemptIssue(attempt)
+		if key != "" {
+			groups[key] = append(groups[key], attempt)
+		}
+	}
+	return groups
+}
+
+func compareAttemptTime(a, b Attempt) int {
+	if result := a.StartedAt.Compare(b.StartedAt); result != 0 {
+		return result
+	}
+	return cmp.Compare(a.ID, b.ID)
+}
+
+func attemptOccurrence(attempt Attempt, detail string) Occurrence {
+	at := attempt.CompletedAt
+	if at.IsZero() {
+		at = attempt.StartedAt
+	}
+	return Occurrence{Issue: attemptIssue(attempt), At: at, Detail: strings.TrimSpace(detail)}
+}
+
+func attemptIssue(attempt Attempt) string {
+	return firstNonBlank(attempt.Identifier, attempt.IssueID, attempt.IssueURL)
+}
+
+func sessionIssue(session Session) string {
+	return firstNonBlank(session.Identifier, session.IssueID, session.IssueURL)
+}
+
+func usageIssue(event UsageEvent) string {
+	return firstNonBlank(event.Identifier, event.IssueID)
+}
+
+func phaseIssue(event PhaseEvent) string {
+	return firstNonBlank(event.Identifier, event.IssueID, event.IssueURL)
+}
+
+func phaseTime(event PhaseEvent) time.Time {
+	if !event.FinishedAt.IsZero() {
+		return event.FinishedAt
+	}
+	return event.StartedAt
+}
+
+func successful(state string) bool {
+	switch strings.ToLower(strings.TrimSpace(state)) {
+	case "success", "completed", "complete", "done", "merged":
+		return true
+	default:
+		return false
+	}
+}
+
+func completedWork(attempt Attempt) bool {
+	if !successful(attempt.TerminalState) {
+		return false
+	}
+	return strings.EqualFold(strings.TrimSpace(attempt.Phase), "waiting") ||
+		containsAnyFold(attempt.StatusMessage, "terminal state", "gate-wait", "gate wait")
+}
+
+func laterSuccess(attempts []Attempt) bool {
+	return !nextSuccessfulStart(attempts).IsZero()
+}
+
+func nextSuccessfulStart(attempts []Attempt) time.Time {
+	for _, attempt := range attempts {
+		if successful(attempt.TerminalState) {
+			return attempt.StartedAt
+		}
+	}
+	return time.Time{}
+}
+
+func systemicErrorClass(attempt Attempt) string {
+	text := strings.ToLower(strings.Join([]string{attempt.ErrorClass, attempt.ErrorMessage}, " "))
+	switch {
+	case containsAnyFold(text, "backend_capacity", "quota", "usage limit", "resource_exhausted", "rate limit"):
+		return "quota"
+	case containsAnyFold(text, "model_not_found", "invalid model", "backend config", "configuration", "authentication", "unauthorized", "permission denied"):
+		return "backend-configuration"
+	default:
+		return ""
+	}
+}
+
+func containsAnyFold(value string, needles ...string) bool {
+	value = strings.ToLower(value)
+	for _, needle := range needles {
+		if strings.Contains(value, strings.ToLower(needle)) {
+			return true
+		}
+	}
+	return false
+}
+
+func capacityResetAt(raw string) (time.Time, bool) {
+	var value any
+	if err := json.Unmarshal([]byte(strings.TrimSpace(raw)), &value); err != nil {
+		return time.Time{}, false
+	}
+	return findResetAt(value)
+}
+
+func findResetAt(value any) (time.Time, bool) {
+	switch typed := value.(type) {
+	case map[string]any:
+		keys := make([]string, 0, len(typed))
+		for key := range typed {
+			keys = append(keys, key)
+		}
+		sort.Strings(keys)
+		for _, wanted := range []string{"resetat", "resumeat"} {
+			for _, key := range keys {
+				normalized := strings.NewReplacer("_", "", "-", "").Replace(strings.ToLower(key))
+				if normalized != wanted {
+					continue
+				}
+				candidate := typed[key]
+				if parsed, ok := parseJSONTime(candidate); ok {
+					return parsed, true
+				}
+			}
+		}
+		for _, key := range keys {
+			candidate := typed[key]
+			if parsed, ok := findResetAt(candidate); ok {
+				return parsed, true
+			}
+		}
+	case []any:
+		for _, candidate := range typed {
+			if parsed, ok := findResetAt(candidate); ok {
+				return parsed, true
+			}
+		}
+	}
+	return time.Time{}, false
+}
+
+func parseJSONTime(value any) (time.Time, bool) {
+	raw, ok := value.(string)
+	if !ok {
+		return time.Time{}, false
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, raw)
+	return parsed, err == nil
+}
+
+func dedupeOccurrences(values []Occurrence) []Occurrence {
+	seen := map[string]struct{}{}
+	out := make([]Occurrence, 0, len(values))
+	for _, occurrence := range values {
+		key := occurrence.Issue + "\x00" + occurrence.At.UTC().Format(time.RFC3339Nano) + "\x00" + occurrence.Detail
+		if _, ok := seen[key]; ok {
+			continue
+		}
+		seen[key] = struct{}{}
+		out = append(out, occurrence)
+	}
+	return out
+}
+
+func sortOccurrences(values []Occurrence) {
+	sort.SliceStable(values, func(i, j int) bool {
+		if !values[i].At.Equal(values[j].At) {
+			return values[i].At.Before(values[j].At)
+		}
+		return values[i].Issue < values[j].Issue
+	})
+}
+
+func firstNonBlank(values ...string) string {
+	for _, value := range values {
+		if value = strings.TrimSpace(value); value != "" {
+			return value
+		}
+	}
+	return ""
+}

--- a/internal/retro/detector.go
+++ b/internal/retro/detector.go
@@ -381,20 +381,33 @@ func detectSlowCapacityRecovery(attempts []Attempt) (Finding, bool) {
 	ordered := append([]Attempt(nil), attempts...)
 	slices.SortFunc(ordered, compareAttemptTime)
 	occurrences := []Occurrence{}
+	seenReset := map[string]struct{}{}
 	for index, attempt := range ordered {
-		if !containsAnyFold(attempt.ErrorClass+" "+attempt.ErrorMessage, "backend_capacity", "quota", "usage limit", "resource_exhausted") {
+		if !capacityFailure(attempt) {
 			continue
 		}
 		resetAt, ok := capacityResetAt(attempt.CapacitySnapshotJSON)
 		if !ok {
 			continue
 		}
-		recoveredAt := nextSuccessfulStart(ordered[index+1:])
-		if recoveredAt.IsZero() || !recoveredAt.After(resetAt) {
+		resetKey := resetAt.UTC().Format(time.RFC3339Nano)
+		if _, ok := seenReset[resetKey]; ok {
 			continue
 		}
-		delay := recoveredAt.Sub(resetAt)
-		occurrences = append(occurrences, Occurrence{Issue: attemptIssue(attempt), At: recoveredAt, Detail: "recovered " + delay.Round(time.Second).String() + " after reset window"})
+		for laterIndex := index + 1; laterIndex < len(ordered); laterIndex++ {
+			persisted := ordered[laterIndex]
+			if persisted.StartedAt.Before(resetAt) || !capacityFailure(persisted) {
+				continue
+			}
+			seenReset[resetKey] = struct{}{}
+			detail := "capacity failure persisted " + persisted.StartedAt.Sub(resetAt).Round(time.Second).String() + " after reset window"
+			if recoveredAt := nextSuccessfulStart(ordered[laterIndex+1:]); !recoveredAt.IsZero() {
+				detail += "; recovered " + recoveredAt.Sub(resetAt).Round(time.Second).String() + " after reset window"
+			}
+			occurrence := attemptOccurrence(persisted, detail)
+			occurrences = append(occurrences, occurrence)
+			break
+		}
 	}
 	return Finding{
 		Pattern:     PatternSlowCapacityRecovery,
@@ -404,6 +417,10 @@ func detectSlowCapacityRecovery(attempts []Attempt) (Finding, bool) {
 		Detail:      "Backend capacity remained unavailable after its recorded reset window.",
 		Occurrences: occurrences,
 	}, len(occurrences) > 0
+}
+
+func capacityFailure(attempt Attempt) bool {
+	return containsAnyFold(attempt.ErrorClass+" "+attempt.ErrorMessage, "backend_capacity", "quota", "usage limit", "resource_exhausted")
 }
 
 func detectFallbackOrphanRecovery(sessions []Session, threshold int) (Finding, bool) {

--- a/internal/retro/detector_test.go
+++ b/internal/retro/detector_test.go
@@ -1,0 +1,142 @@
+package retro
+
+import (
+	"slices"
+	"testing"
+	"time"
+)
+
+func TestDetectReplaysEfficiencyIncidents(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	snapshot := Snapshot{}
+	snapshot.Attempts = append(snapshot.Attempts,
+		Attempt{ID: 1, Identifier: "digitaldrywood/detent#1126", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "success", Phase: "waiting"},
+		Attempt{ID: 2, Identifier: "digitaldrywood/detent#1126", StartedAt: base.Add(2 * time.Minute), CompletedAt: base.Add(3 * time.Minute), TerminalState: "success"},
+	)
+	for index := range 5 {
+		id := int64(10 + index)
+		startedAt := base.Add(time.Duration(10+index) * time.Minute)
+		snapshot.Attempts = append(snapshot.Attempts, Attempt{
+			ID:            id,
+			Identifier:    "digitaldrywood/detent#200",
+			StartedAt:     startedAt,
+			CompletedAt:   startedAt.Add(time.Minute),
+			TerminalState: "failure",
+			ErrorClass:    "runner",
+			ErrorMessage:  "session token ceiling exceeded: ceiling_tokens=2000000 source=max_session_context_multiplier",
+		})
+		snapshot.Sessions = append(snapshot.Sessions, Session{WorkAttemptID: id, Identifier: "digitaldrywood/detent#200", TotalTokens: 2_000_000})
+	}
+	snapshot.Attempts = append(snapshot.Attempts, Attempt{
+		ID: 20, Identifier: "digitaldrywood/detent#200", StartedAt: base.Add(20 * time.Minute), CompletedAt: base.Add(21 * time.Minute), TerminalState: "success",
+	})
+	for index, issue := range []string{"digitaldrywood/detent#301", "digitaldrywood/detent#302", "digitaldrywood/detent#303"} {
+		startedAt := base.Add(time.Duration(30+index) * time.Minute)
+		snapshot.Attempts = append(snapshot.Attempts, Attempt{
+			ID: int64(30 + index), Identifier: issue, StartedAt: startedAt, CompletedAt: startedAt.Add(time.Minute),
+			TerminalState: "capacity", ErrorClass: "backend_capacity", ErrorMessage: "quota exceeded; provider usage limit reached",
+		})
+	}
+
+	findings := Detect(snapshot, DetectorOptions{})
+	patterns := findingPatterns(findings)
+	for _, want := range []string{PatternCompletedRedispatch, PatternCeilingThenSuccess, PatternSystemicBreaker + ":quota"} {
+		if !slices.Contains(patterns, want) {
+			t.Fatalf("patterns = %v, want %s", patterns, want)
+		}
+	}
+	ceiling := findingByPattern(t, findings, PatternCeilingThenSuccess)
+	if len(ceiling.Occurrences) != 5 || ceiling.TokenDelta != 10_000_000 {
+		t.Fatalf("ceiling finding = %#v, want five incidents and 10000000 token delta", ceiling)
+	}
+	quota := findingByPattern(t, findings, PatternSystemicBreaker+":quota")
+	if quota.Scope != ScopeProduct || quota.Severity != SeverityCritical || len(quota.Occurrences) != 3 {
+		t.Fatalf("quota finding = %#v, want critical product cascade with three occurrences", quota)
+	}
+}
+
+func TestDetectAdditionalPatterns(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	resetAt := base.Add(time.Hour)
+	snapshot := Snapshot{
+		Attempts: []Attempt{
+			{ID: 1, Identifier: "issue-capacity", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "capacity", ErrorClass: "backend_capacity", CapacitySnapshotJSON: `{"outage":{"reset_at":"` + resetAt.Format(time.RFC3339) + `"}}`},
+			{ID: 2, Identifier: "issue-after-capacity", StartedAt: resetAt.Add(10 * time.Minute), CompletedAt: resetAt.Add(11 * time.Minute), TerminalState: "success"},
+			{ID: 3, Identifier: "issue-gate", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", ErrorClass: "gate_wait_timeout"},
+			{ID: 4, Identifier: "issue-gate-2", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", WaitReason: "gate wait timeout"},
+		},
+		Sessions: []Session{
+			{ID: 1, Identifier: "issue-orphan-a", StartedAt: base, CompletedAt: base.Add(time.Minute), OrphanRecoveryOutcome: "fresh"},
+			{ID: 2, Identifier: "issue-orphan-b", StartedAt: base.Add(time.Minute), CompletedAt: base.Add(2 * time.Minute), OrphanRecoveryOutcome: "fresh"},
+			{ID: 3, Identifier: "issue-orphan-c", StartedAt: base.Add(2 * time.Minute), CompletedAt: base.Add(3 * time.Minute), OrphanRecoveryOutcome: "fresh"},
+		},
+		UsageEvents: []UsageEvent{
+			{Identifier: "issue-small-a", FinishedAt: base, TotalTokens: 100},
+			{Identifier: "issue-small-b", FinishedAt: base, TotalTokens: 100},
+			{Identifier: "issue-large", FinishedAt: base, TotalTokens: 500},
+		},
+		PhaseEvents: []PhaseEvent{
+			{Identifier: "issue-status-a", Reason: "workpad_status_invalid", StartedAt: base},
+			{Identifier: "issue-status-b", Reason: "workpad_status_invalid", StartedAt: base.Add(time.Minute)},
+		},
+	}
+
+	patterns := findingPatterns(Detect(snapshot, DetectorOptions{}))
+	for _, want := range []string{PatternReceiptBaseline, PatternGateWaitTimeout, PatternInvalidWorkpadStatus, PatternSlowCapacityRecovery, PatternFallbackOrphanRecovery} {
+		if !slices.Contains(patterns, want) {
+			t.Fatalf("patterns = %v, want %s", patterns, want)
+		}
+	}
+	orphan := findingByPattern(t, Detect(snapshot, DetectorOptions{}), PatternFallbackOrphanRecovery)
+	if len(orphan.Occurrences) != 3 || !Qualifies(orphan, 2, SeverityCritical) {
+		t.Fatalf("orphan finding = %#v, want three qualifying occurrences", orphan)
+	}
+	if got := []string{orphan.Occurrences[0].Issue, orphan.Occurrences[1].Issue, orphan.Occurrences[2].Issue}; !slices.Equal(got, []string{"issue-orphan-a", "issue-orphan-b", "issue-orphan-c"}) {
+		t.Fatalf("orphan issues = %v, want project-wide consecutive fallbacks", got)
+	}
+}
+
+func TestQualifiesRequiresRecurrenceOrCriticalSeverity(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		finding Finding
+		want    bool
+	}{
+		{name: "two warnings", finding: Finding{Severity: SeverityWarning, Occurrences: []Occurrence{{}, {}}}, want: true},
+		{name: "one high", finding: Finding{Severity: SeverityHigh, Occurrences: []Occurrence{{}}}, want: false},
+		{name: "one critical", finding: Finding{Severity: SeverityCritical, Occurrences: []Occurrence{{}}}, want: true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := Qualifies(tt.finding, 2, SeverityCritical); got != tt.want {
+				t.Fatalf("Qualifies() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
+func findingPatterns(findings []Finding) []string {
+	patterns := make([]string, 0, len(findings))
+	for _, finding := range findings {
+		patterns = append(patterns, finding.Pattern)
+	}
+	return patterns
+}
+
+func findingByPattern(t *testing.T, findings []Finding, pattern string) Finding {
+	t.Helper()
+	for _, finding := range findings {
+		if finding.Pattern == pattern {
+			return finding
+		}
+	}
+	t.Fatalf("finding %s not found in %#v", pattern, findings)
+	return Finding{}
+}

--- a/internal/retro/detector_test.go
+++ b/internal/retro/detector_test.go
@@ -65,9 +65,10 @@ func TestDetectAdditionalPatterns(t *testing.T) {
 	snapshot := Snapshot{
 		Attempts: []Attempt{
 			{ID: 1, Identifier: "issue-capacity", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "capacity", ErrorClass: "backend_capacity", CapacitySnapshotJSON: `{"outage":{"reset_at":"` + resetAt.Format(time.RFC3339) + `"}}`},
-			{ID: 2, Identifier: "issue-after-capacity", StartedAt: resetAt.Add(10 * time.Minute), CompletedAt: resetAt.Add(11 * time.Minute), TerminalState: "success"},
-			{ID: 3, Identifier: "issue-gate", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", ErrorClass: "gate_wait_timeout"},
-			{ID: 4, Identifier: "issue-gate-2", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", WaitReason: "gate wait timeout"},
+			{ID: 2, Identifier: "issue-capacity-persisted", StartedAt: resetAt.Add(5 * time.Minute), CompletedAt: resetAt.Add(6 * time.Minute), TerminalState: "capacity", ErrorClass: "backend_capacity"},
+			{ID: 3, Identifier: "issue-after-capacity", StartedAt: resetAt.Add(10 * time.Minute), CompletedAt: resetAt.Add(11 * time.Minute), TerminalState: "success"},
+			{ID: 4, Identifier: "issue-gate", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", ErrorClass: "gate_wait_timeout"},
+			{ID: 5, Identifier: "issue-gate-2", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", WaitReason: "gate wait timeout"},
 		},
 		Sessions: []Session{
 			{ID: 1, Identifier: "issue-orphan-a", StartedAt: base, CompletedAt: base.Add(time.Minute), OrphanRecoveryOutcome: "fresh"},
@@ -97,6 +98,20 @@ func TestDetectAdditionalPatterns(t *testing.T) {
 	}
 	if got := []string{orphan.Occurrences[0].Issue, orphan.Occurrences[1].Issue, orphan.Occurrences[2].Issue}; !slices.Equal(got, []string{"issue-orphan-a", "issue-orphan-b", "issue-orphan-c"}) {
 		t.Fatalf("orphan issues = %v, want project-wide consecutive fallbacks", got)
+	}
+}
+
+func TestDetectSlowCapacityRecoveryIgnoresIdleTime(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 6, 12, 0, 0, 0, time.UTC)
+	resetAt := base.Add(time.Hour)
+	findings := Detect(Snapshot{Attempts: []Attempt{
+		{ID: 1, Identifier: "issue-capacity", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "capacity", ErrorClass: "backend_capacity", CapacitySnapshotJSON: `{"reset_at":"` + resetAt.Format(time.RFC3339) + `"}`},
+		{ID: 2, Identifier: "issue-after-idle", StartedAt: resetAt.Add(time.Hour), CompletedAt: resetAt.Add(time.Hour + time.Minute), TerminalState: "success"},
+	}}, DetectorOptions{})
+	if slices.Contains(findingPatterns(findings), PatternSlowCapacityRecovery) {
+		t.Fatalf("patterns = %v, want idle time ignored", findingPatterns(findings))
 	}
 }
 

--- a/internal/retro/manager.go
+++ b/internal/retro/manager.go
@@ -1,0 +1,439 @@
+package retro
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/robfig/cron/v3"
+
+	"github.com/digitaldrywood/detent/internal/intake"
+)
+
+const (
+	TriggerCompletion  = "completion"
+	TriggerDaily       = "daily"
+	pendingStateMarker = "<!-- detent-retro-state:pending -->"
+)
+
+var (
+	ErrMissingTelemetryStore = errors.New("retro telemetry store is required")
+	ErrMissingProjectStore   = errors.New("retro project issue store is required")
+	ErrMissingProductStore   = errors.New("retro product issue store is required")
+)
+
+type TelemetryStore interface {
+	LoadRetroSnapshot(context.Context, string, time.Time) (Snapshot, error)
+	RetroFiledOnDay(context.Context, string, time.Time) (int, error)
+	RecordRetroRun(context.Context, RunRecord) error
+}
+
+type RunRecord struct {
+	ProjectID   string
+	Trigger     string
+	StartedAt   time.Time
+	CompletedAt time.Time
+	Findings    int
+	Filed       int
+	Updated     int
+	Error       string
+}
+
+type Settings struct {
+	ProjectID     string
+	Config        Config
+	ProjectIssues intake.IssueStore
+	ProductIssues intake.IssueStore
+}
+
+type Result struct {
+	Findings []Finding
+	Filed    int
+	Updated  int
+	Capped   int
+}
+
+type Manager struct {
+	mu        sync.RWMutex
+	processMu sync.Mutex
+	settings  Settings
+	store     TelemetryStore
+	logger    *slog.Logger
+	now       func() time.Time
+	triggers  chan string
+	updates   chan struct{}
+	issues    map[string]intake.Issue
+}
+
+func New(settings Settings, store TelemetryStore, logger *slog.Logger, now func() time.Time) (*Manager, error) {
+	if logger == nil {
+		logger = slog.Default()
+	}
+	if now == nil {
+		now = time.Now
+	}
+	manager := &Manager{
+		store:    store,
+		logger:   logger,
+		now:      now,
+		triggers: make(chan string, 1),
+		updates:  make(chan struct{}, 1),
+		issues:   map[string]intake.Issue{},
+	}
+	if err := manager.Update(settings); err != nil {
+		return nil, err
+	}
+	return manager, nil
+}
+
+func (m *Manager) Update(settings Settings) error {
+	m.processMu.Lock()
+	defer m.processMu.Unlock()
+	settings.ProjectID = strings.TrimSpace(settings.ProjectID)
+	settings.Config.Normalize()
+	if settings.Config.Enabled {
+		if m.store == nil {
+			return ErrMissingTelemetryStore
+		}
+		if settings.ProjectIssues == nil {
+			return ErrMissingProjectStore
+		}
+		if settings.ProductIssues == nil {
+			return ErrMissingProductStore
+		}
+	}
+	m.mu.Lock()
+	m.settings = settings
+	m.mu.Unlock()
+	m.issues = map[string]intake.Issue{}
+	m.signalUpdate()
+	return nil
+}
+
+func (m *Manager) Enabled() bool {
+	if m == nil {
+		return false
+	}
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	return m.settings.Config.Enabled
+}
+
+func (m *Manager) Trigger(trigger string) {
+	if m == nil || !m.Enabled() {
+		return
+	}
+	trigger = strings.TrimSpace(trigger)
+	if trigger == "" {
+		trigger = TriggerCompletion
+	}
+	select {
+	case m.triggers <- trigger:
+	default:
+	}
+}
+
+func (m *Manager) Run(ctx context.Context) error {
+	if ctx == nil {
+		ctx = context.Background()
+	}
+	for {
+		next, scheduled := m.nextScheduled(m.now())
+		if !scheduled {
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-m.updates:
+				continue
+			case trigger := <-m.triggers:
+				m.runAndLog(ctx, trigger)
+			}
+			continue
+		}
+
+		delay := max(next.Sub(m.now()), 0)
+		timer := time.NewTimer(delay)
+		select {
+		case <-ctx.Done():
+			stopTimer(timer)
+			return nil
+		case <-m.updates:
+			stopTimer(timer)
+			continue
+		case trigger := <-m.triggers:
+			stopTimer(timer)
+			m.runAndLog(ctx, trigger)
+		case <-timer.C:
+			m.runAndLog(ctx, TriggerDaily)
+		}
+	}
+}
+
+func (m *Manager) RunOnce(ctx context.Context, trigger string) (Result, error) {
+	if m == nil {
+		return Result{}, nil
+	}
+	m.processMu.Lock()
+	defer m.processMu.Unlock()
+
+	m.mu.RLock()
+	settings := cloneSettings(m.settings)
+	m.mu.RUnlock()
+	if !settings.Config.Enabled {
+		return Result{}, nil
+	}
+
+	startedAt := m.now().UTC()
+	record := RunRecord{ProjectID: settings.ProjectID, Trigger: strings.TrimSpace(trigger), StartedAt: startedAt}
+	if record.Trigger == "" {
+		record.Trigger = TriggerCompletion
+	}
+	finish := func(result Result, runErr error) (Result, error) {
+		record.CompletedAt = m.now().UTC()
+		record.Findings = len(result.Findings)
+		record.Filed = result.Filed
+		record.Updated = result.Updated
+		if runErr != nil {
+			record.Error = runErr.Error()
+		}
+		if err := m.store.RecordRetroRun(ctx, record); err != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("record retro run: %w", err))
+		}
+		return result, runErr
+	}
+
+	since := startedAt.AddDate(0, 0, -settings.Config.LookbackDays)
+	snapshot, err := m.store.LoadRetroSnapshot(ctx, settings.ProjectID, since)
+	if err != nil {
+		return finish(Result{}, fmt.Errorf("load retro snapshot: %w", err))
+	}
+	findings := Detect(snapshot, DetectorOptions{
+		FallbackThreshold:       settings.Config.FallbackThreshold,
+		ReceiptBaselineMultiple: settings.Config.ReceiptBaselineMultiple,
+	})
+	qualified := make([]Finding, 0, len(findings))
+	for _, finding := range findings {
+		if Qualifies(finding, settings.Config.MinOccurrences, settings.Config.SingleOccurrenceSeverity) {
+			qualified = append(qualified, finding)
+		}
+	}
+	result := Result{Findings: qualified}
+	filedToday, err := m.store.RetroFiledOnDay(ctx, settings.ProjectID, startedAt)
+	if err != nil {
+		return finish(result, fmt.Errorf("read retro daily issue count: %w", err))
+	}
+	remaining := settings.Config.DailyIssueCap - filedToday
+	var runErr error
+	for _, finding := range qualified {
+		issueStore := settings.ProjectIssues
+		if finding.Scope == ScopeProduct {
+			issueStore = settings.ProductIssues
+		}
+		outcome, err := m.upsertFinding(ctx, issueStore, settings, finding, remaining > 0)
+		if outcome.created {
+			result.Filed++
+			remaining--
+		} else if outcome.updated {
+			result.Updated++
+		} else if outcome.capped {
+			result.Capped++
+		}
+		if err != nil {
+			runErr = errors.Join(runErr, fmt.Errorf("upsert retro finding %s: %w", finding.Pattern, err))
+			continue
+		}
+	}
+	return finish(result, runErr)
+}
+
+type upsertOutcome struct {
+	created bool
+	updated bool
+	capped  bool
+}
+
+func (m *Manager) upsertFinding(ctx context.Context, issueStore intake.IssueStore, settings Settings, finding Finding, allowCreate bool) (upsertOutcome, error) {
+	fingerprint := Fingerprint(settings.ProjectID, finding)
+	marker := "<!-- detent-retro fingerprint=" + fingerprint + " -->"
+	draft := intake.IssueDraft{
+		Title:  "[retro] " + finding.Title,
+		Body:   findingIssueBody(settings.ProjectID, finding, marker),
+		Labels: append([]string(nil), settings.Config.Labels...),
+	}
+	pendingDraft := draft
+	pendingDraft.Body = draft.Body + "\n\n" + pendingStateMarker
+	cacheKey := finding.Scope + "\x00" + marker
+	issue, found := m.issues[cacheKey]
+	if !found {
+		var err error
+		issue, found, err = issueStore.FindIntakeIssue(ctx, marker)
+		if err != nil {
+			return upsertOutcome{}, err
+		}
+	}
+	if found {
+		if strings.Contains(issue.Body, pendingStateMarker) {
+			updated, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, pendingDraft)
+			if err != nil {
+				return upsertOutcome{}, err
+			}
+			m.issues[cacheKey] = updated
+			if err := issueStore.SetIntakeIssueState(ctx, issue.ID, settings.Config.TargetState); err != nil {
+				return upsertOutcome{}, err
+			}
+		}
+		draft.Body = preserveFindingOutcome(draft.Body, issue.Body)
+		if strings.TrimSpace(issue.Body) == strings.TrimSpace(draft.Body) {
+			m.issues[cacheKey] = issue
+			return upsertOutcome{}, nil
+		}
+		updated, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, draft)
+		if err != nil {
+			return upsertOutcome{}, err
+		}
+		m.issues[cacheKey] = updated
+		return upsertOutcome{updated: true}, nil
+	}
+	if !allowCreate {
+		return upsertOutcome{capped: true}, nil
+	}
+	issue, err := issueStore.CreateIntakeIssue(ctx, pendingDraft)
+	if err != nil {
+		return upsertOutcome{}, err
+	}
+	m.issues[cacheKey] = issue
+	if err := issueStore.SetIntakeIssueState(ctx, issue.ID, settings.Config.TargetState); err != nil {
+		return upsertOutcome{created: true}, err
+	}
+	updated, err := issueStore.UpdateIntakeIssue(ctx, issue.ID, draft)
+	if err != nil {
+		return upsertOutcome{created: true}, err
+	}
+	m.issues[cacheKey] = updated
+	return upsertOutcome{created: true}, nil
+}
+
+func preserveFindingOutcome(draft string, existing string) string {
+	status := findingOutcomeStatus(existing)
+	if status == "" || status == "pending" {
+		return draft
+	}
+	return strings.Replace(draft, "- status: pending", "- status: "+status, 1)
+}
+
+func findingOutcomeStatus(body string) string {
+	for _, line := range strings.Split(body, "\n") {
+		value, ok := strings.CutPrefix(strings.TrimSpace(line), "- status:")
+		if !ok {
+			continue
+		}
+		status := strings.ToLower(strings.Trim(strings.TrimSpace(value), "`"))
+		if status == "pending" || status == "accepted" || status == "rejected" {
+			return status
+		}
+	}
+	return ""
+}
+
+func findingIssueBody(projectID string, finding Finding, marker string) string {
+	var builder strings.Builder
+	builder.WriteString("```detent-agent\nschema: 1\neffort: high\n```\n\n")
+	builder.WriteString(marker)
+	builder.WriteString("\n\n## Efficiency finding\n\n")
+	builder.WriteString(finding.Detail)
+	builder.WriteString("\n\n- project: ")
+	builder.WriteString(projectID)
+	builder.WriteString("\n- classification: ")
+	builder.WriteString(finding.Scope)
+	builder.WriteString("\n- pattern: ")
+	builder.WriteString(finding.Pattern)
+	builder.WriteString("\n- severity: ")
+	builder.WriteString(finding.Severity)
+	builder.WriteString("\n- occurrences: ")
+	builder.WriteString(strconv.Itoa(len(finding.Occurrences)))
+	if finding.TokenDelta > 0 {
+		builder.WriteString("\n- avoidable token delta: ")
+		builder.WriteString(strconv.FormatInt(finding.TokenDelta, 10))
+	}
+	builder.WriteString("\n\n## Evidence\n")
+	for _, occurrence := range finding.Occurrences {
+		builder.WriteString("\n- ")
+		builder.WriteString(occurrence.Issue)
+		if !occurrence.At.IsZero() {
+			builder.WriteString(" at ")
+			builder.WriteString(occurrence.At.UTC().Format(time.RFC3339))
+		}
+		if occurrence.Tokens > 0 {
+			builder.WriteString("; tokens=")
+			builder.WriteString(strconv.FormatInt(occurrence.Tokens, 10))
+		}
+		if occurrence.Detail != "" {
+			builder.WriteString("; ")
+			builder.WriteString(strings.Join(strings.Fields(occurrence.Detail), " "))
+		}
+	}
+	if finding.Proposal != nil {
+		proposalID := Fingerprint(projectID, finding)[:12]
+		builder.WriteString("\n\n## Proposed WORKFLOW.md change\n\n")
+		builder.WriteString("<!-- detent:self-improvement proposal_id=detent-retro-")
+		builder.WriteString(proposalID)
+		builder.WriteString(" -->\n\n")
+		builder.WriteString("- target: `")
+		builder.WriteString(finding.Proposal.Path)
+		builder.WriteString("`\n- change: ")
+		builder.WriteString(finding.Proposal.Change)
+	}
+	builder.WriteString("\n\n## Governance\n\nThis is a proposal only. Detent must not modify WORKFLOW.md, prompts, or runtime configuration without human approval.\n\n## Outcome\n\n- status: pending\n- accepted/rejected record: change status to `accepted` or `rejected`; later retro runs update this fingerprinted issue instead of opening a duplicate.\n")
+	return builder.String()
+}
+
+func (m *Manager) nextScheduled(now time.Time) (time.Time, bool) {
+	m.mu.RLock()
+	settings := cloneSettings(m.settings)
+	m.mu.RUnlock()
+	if !settings.Config.Enabled {
+		return time.Time{}, false
+	}
+	schedule, err := cron.ParseStandard(settings.Config.Schedule)
+	if err != nil {
+		return time.Time{}, false
+	}
+	return schedule.Next(now), true
+}
+
+func (m *Manager) runAndLog(ctx context.Context, trigger string) {
+	result, err := m.RunOnce(ctx, trigger)
+	if err != nil {
+		if ctx.Err() == nil {
+			m.logger.ErrorContext(ctx, "efficiency retro failed", "trigger", trigger, "error", err)
+		}
+		return
+	}
+	m.logger.InfoContext(ctx, "efficiency retro completed", "trigger", trigger, "findings", len(result.Findings), "filed", result.Filed, "updated", result.Updated, "capped", result.Capped)
+}
+
+func cloneSettings(settings Settings) Settings {
+	settings.Config.Labels = append([]string(nil), settings.Config.Labels...)
+	return settings
+}
+
+func (m *Manager) signalUpdate() {
+	select {
+	case m.updates <- struct{}{}:
+	default:
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/internal/retro/manager_test.go
+++ b/internal/retro/manager_test.go
@@ -1,0 +1,199 @@
+package retro
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector/memory"
+	"github.com/digitaldrywood/detent/internal/intake"
+)
+
+func TestManagerRoutesAndDeduplicatesRecurringFindings(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	telemetry := &recordingTelemetryStore{snapshot: routingSnapshot(now)}
+	projectIssues := memory.New(memory.Config{Stateful: true})
+	productIssues := memory.New(memory.Config{Stateful: true})
+	manager, err := New(Settings{
+		ProjectID: "example",
+		Config: Config{
+			Enabled: true,
+		},
+		ProjectIssues: projectIssues,
+		ProductIssues: productIssues,
+	}, telemetry, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	first, err := manager.RunOnce(context.Background(), TriggerDaily)
+	if err != nil {
+		t.Fatalf("RunOnce(first) error = %v", err)
+	}
+	if first.Filed != 2 || first.Updated != 0 {
+		t.Fatalf("RunOnce(first) = %#v, want two filed", first)
+	}
+	assertSingleRetroIssue(t, projectIssues, PatternInvalidWorkpadStatus, "Proposed WORKFLOW.md change")
+	assertSingleRetroIssue(t, productIssues, PatternCompletedRedispatch, "classification: product")
+
+	telemetry.snapshot.PhaseEvents = append(telemetry.snapshot.PhaseEvents, PhaseEvent{Identifier: "issue-status-c", Reason: "workpad_status_invalid", StartedAt: now.Add(time.Minute)})
+	second, err := manager.RunOnce(context.Background(), TriggerCompletion)
+	if err != nil {
+		t.Fatalf("RunOnce(second) error = %v", err)
+	}
+	if second.Filed != 0 || second.Updated != 1 {
+		t.Fatalf("RunOnce(second) = %#v, want only the recurring finding updated", second)
+	}
+	assertSingleRetroIssue(t, projectIssues, PatternInvalidWorkpadStatus, "occurrences: 3")
+	assertSingleRetroIssue(t, productIssues, PatternCompletedRedispatch, "classification: product")
+}
+
+func TestManagerPreservesReviewedOutcomeOnRecurrence(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	telemetry := &recordingTelemetryStore{snapshot: routingSnapshot(now)}
+	projectIssues := memory.New(memory.Config{Stateful: true})
+	productIssues := memory.New(memory.Config{Stateful: true})
+	manager, err := New(Settings{
+		ProjectID: "example",
+		Config: Config{
+			Enabled: true,
+		},
+		ProjectIssues: projectIssues,
+		ProductIssues: productIssues,
+	}, telemetry, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	if _, err := manager.RunOnce(context.Background(), TriggerDaily); err != nil {
+		t.Fatalf("RunOnce(first) error = %v", err)
+	}
+	issues, err := projectIssues.FetchIssuesByStates(context.Background(), []string{"Backlog"})
+	if err != nil || len(issues) != 1 {
+		t.Fatalf("FetchIssuesByStates() issues=%#v error=%v, want one", issues, err)
+	}
+	reviewed := strings.Replace(issues[0].Description, "- status: pending", "- status: accepted", 1)
+	if _, err := projectIssues.UpdateIntakeIssue(context.Background(), issues[0].ID, intake.IssueDraft{Title: issues[0].Title, Body: reviewed, Labels: issues[0].Labels}); err != nil {
+		t.Fatalf("UpdateIntakeIssue() error = %v", err)
+	}
+	manager, err = New(Settings{
+		ProjectID: "example",
+		Config: Config{
+			Enabled: true,
+		},
+		ProjectIssues: projectIssues,
+		ProductIssues: productIssues,
+	}, telemetry, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("New(restarted) error = %v", err)
+	}
+	telemetry.snapshot.PhaseEvents = append(telemetry.snapshot.PhaseEvents, PhaseEvent{Identifier: "issue-status-c", Reason: "workpad_status_invalid", StartedAt: now.Add(time.Minute)})
+
+	result, err := manager.RunOnce(context.Background(), TriggerCompletion)
+	if err != nil {
+		t.Fatalf("RunOnce(second) error = %v", err)
+	}
+	if result.Updated != 1 {
+		t.Fatalf("RunOnce(second).Updated = %d, want only recurring evidence updated", result.Updated)
+	}
+	assertSingleRetroIssue(t, projectIssues, PatternInvalidWorkpadStatus, "- status: accepted")
+}
+
+func TestManagerEnforcesDailyCreationCap(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	telemetry := &recordingTelemetryStore{snapshot: routingSnapshot(now)}
+	manager, err := New(Settings{
+		ProjectID:     "example",
+		Config:        Config{Enabled: true, DailyIssueCap: 1},
+		ProjectIssues: memory.New(memory.Config{Stateful: true}),
+		ProductIssues: memory.New(memory.Config{Stateful: true}),
+	}, telemetry, nil, func() time.Time { return now })
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	result, err := manager.RunOnce(context.Background(), TriggerDaily)
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if result.Filed != 1 || result.Capped != 1 {
+		t.Fatalf("RunOnce() = %#v, want one filed and one capped", result)
+	}
+}
+
+func TestManagerDisabledIsNoOp(t *testing.T) {
+	t.Parallel()
+
+	telemetry := &recordingTelemetryStore{}
+	manager, err := New(Settings{ProjectID: "example", Config: Config{}}, telemetry, nil, time.Now)
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	result, err := manager.RunOnce(context.Background(), TriggerDaily)
+	if err != nil {
+		t.Fatalf("RunOnce() error = %v", err)
+	}
+	if len(result.Findings) != 0 || telemetry.loads != 0 || len(telemetry.records) != 0 {
+		t.Fatalf("disabled run = %#v loads=%d records=%#v, want no-op", result, telemetry.loads, telemetry.records)
+	}
+}
+
+func routingSnapshot(now time.Time) Snapshot {
+	return Snapshot{
+		Attempts: []Attempt{
+			{ID: 1, Identifier: "issue-redispatch", StartedAt: now.Add(-4 * time.Minute), CompletedAt: now.Add(-3 * time.Minute), TerminalState: "success", Phase: "waiting"},
+			{ID: 2, Identifier: "issue-redispatch", StartedAt: now.Add(-2 * time.Minute), CompletedAt: now.Add(-time.Minute), TerminalState: "success"},
+		},
+		PhaseEvents: []PhaseEvent{
+			{Identifier: "issue-status-a", Reason: "workpad_status_invalid", StartedAt: now.Add(-2 * time.Minute)},
+			{Identifier: "issue-status-b", Reason: "workpad_status_invalid", StartedAt: now.Add(-time.Minute)},
+		},
+	}
+}
+
+func assertSingleRetroIssue(t *testing.T, issueStore *memory.Connector, pattern string, bodyContains string) {
+	t.Helper()
+	issues, err := issueStore.FetchIssuesByStates(context.Background(), []string{"Backlog"})
+	if err != nil {
+		t.Fatalf("FetchIssuesByStates() error = %v", err)
+	}
+	if len(issues) != 1 {
+		t.Fatalf("issues = %#v, want one", issues)
+	}
+	if !strings.Contains(issues[0].Description, "pattern: "+pattern) || !strings.Contains(issues[0].Description, bodyContains) {
+		t.Fatalf("issue body missing pattern/body text:\n%s", issues[0].Description)
+	}
+}
+
+type recordingTelemetryStore struct {
+	snapshot Snapshot
+	loads    int
+	records  []RunRecord
+}
+
+func (s *recordingTelemetryStore) LoadRetroSnapshot(context.Context, string, time.Time) (Snapshot, error) {
+	s.loads++
+	return s.snapshot, nil
+}
+
+func (s *recordingTelemetryStore) RetroFiledOnDay(_ context.Context, _ string, day time.Time) (int, error) {
+	count := 0
+	for _, record := range s.records {
+		if record.CompletedAt.UTC().Format(time.DateOnly) == day.UTC().Format(time.DateOnly) {
+			count += record.Filed
+		}
+	}
+	return count, nil
+}
+
+func (s *recordingTelemetryStore) RecordRetroRun(_ context.Context, record RunRecord) error {
+	s.records = append(s.records, record)
+	return nil
+}

--- a/internal/store/migrations/00015_create_retro_runs.sql
+++ b/internal/store/migrations/00015_create_retro_runs.sql
@@ -1,0 +1,22 @@
+-- +goose Up
+CREATE TABLE retro_runs (
+  id INTEGER PRIMARY KEY,
+  project_id TEXT NOT NULL,
+  trigger TEXT NOT NULL,
+  started_at TEXT NOT NULL,
+  completed_at TEXT NOT NULL,
+  findings_count INTEGER NOT NULL DEFAULT 0,
+  filed_count INTEGER NOT NULL DEFAULT 0,
+  updated_count INTEGER NOT NULL DEFAULT 0,
+  error TEXT,
+  event_day TEXT NOT NULL
+);
+
+CREATE INDEX retro_runs_project_completed_idx
+ON retro_runs(project_id, completed_at DESC, id DESC);
+
+CREATE INDEX retro_runs_project_day_idx
+ON retro_runs(project_id, event_day);
+
+-- +goose Down
+DROP TABLE IF EXISTS retro_runs;

--- a/internal/store/retro.go
+++ b/internal/store/retro.go
@@ -1,0 +1,218 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/retro"
+)
+
+func (s *sqliteStore) LoadRetroSnapshot(ctx context.Context, projectID string, since time.Time) (retro.Snapshot, error) {
+	projectID = strings.TrimSpace(projectID)
+	sinceRaw, err := requiredTimestamp("since", since)
+	if err != nil {
+		return retro.Snapshot{}, err
+	}
+	snapshot := retro.Snapshot{}
+	if snapshot.Attempts, err = s.loadRetroAttempts(ctx, projectID, sinceRaw); err != nil {
+		return retro.Snapshot{}, err
+	}
+	if snapshot.Sessions, err = s.loadRetroSessions(ctx, projectID, sinceRaw); err != nil {
+		return retro.Snapshot{}, err
+	}
+	if snapshot.UsageEvents, err = s.loadRetroUsageEvents(ctx, projectID, sinceRaw); err != nil {
+		return retro.Snapshot{}, err
+	}
+	if snapshot.PhaseEvents, err = s.loadRetroPhaseEvents(ctx, projectID, sinceRaw); err != nil {
+		return retro.Snapshot{}, err
+	}
+	return snapshot, nil
+}
+
+func (s *sqliteStore) RetroFiledOnDay(ctx context.Context, projectID string, day time.Time) (int, error) {
+	var count int
+	err := s.db.QueryRowContext(ctx, `
+SELECT CAST(COALESCE(SUM(filed_count), 0) AS INTEGER)
+FROM retro_runs
+WHERE project_id = ? AND event_day = ?`, strings.TrimSpace(projectID), day.UTC().Format(time.DateOnly)).Scan(&count)
+	if err != nil {
+		return 0, fmt.Errorf("reading retro filed count: %w", err)
+	}
+	return count, nil
+}
+
+func (s *sqliteStore) RecordRetroRun(ctx context.Context, record retro.RunRecord) error {
+	startedAt, err := requiredTimestamp("started_at", record.StartedAt)
+	if err != nil {
+		return err
+	}
+	completedAt, err := requiredTimestamp("completed_at", record.CompletedAt)
+	if err != nil {
+		return err
+	}
+	_, err = s.db.ExecContext(ctx, `
+INSERT INTO retro_runs (
+  project_id, trigger, started_at, completed_at, findings_count,
+  filed_count, updated_count, error, event_day
+) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		strings.TrimSpace(record.ProjectID), strings.TrimSpace(record.Trigger), startedAt, completedAt,
+		nonNegative(int64(record.Findings)), nonNegative(int64(record.Filed)), nonNegative(int64(record.Updated)),
+		nullString(record.Error), record.CompletedAt.UTC().Format(time.DateOnly))
+	if err != nil {
+		return fmt.Errorf("recording retro run: %w", err)
+	}
+	return nil
+}
+
+func (s *sqliteStore) loadRetroAttempts(ctx context.Context, projectID string, since string) ([]retro.Attempt, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT id, COALESCE(issue_id, ''), COALESCE(identifier, ''), COALESCE(issue_url, ''),
+	       attempt_number, started_at, COALESCE(completed_at, ''), COALESCE(terminal_state, ''),
+	       COALESCE(error_class, ''), COALESCE(error_message, ''), COALESCE(phase, ''),
+	       COALESCE(status_message, ''), COALESCE(wait_reason, ''),
+       COALESCE(capacity_snapshot_json, '{}')
+FROM work_attempts
+WHERE project_id = ? AND COALESCE(completed_at, started_at) >= ?
+ORDER BY started_at, id`, projectID, since)
+	if err != nil {
+		return nil, fmt.Errorf("reading retro work attempts: %w", err)
+	}
+	defer rows.Close()
+	var attempts []retro.Attempt
+	for rows.Next() {
+		var attempt retro.Attempt
+		var startedAt string
+		var completedAt string
+		if err := rows.Scan(
+			&attempt.ID, &attempt.IssueID, &attempt.Identifier, &attempt.IssueURL,
+			&attempt.AttemptNumber, &startedAt, &completedAt, &attempt.TerminalState,
+			&attempt.ErrorClass, &attempt.ErrorMessage, &attempt.Phase, &attempt.StatusMessage,
+			&attempt.WaitReason, &attempt.CapacitySnapshotJSON,
+		); err != nil {
+			return nil, err
+		}
+		attempt.StartedAt, err = parseTimestamp("started_at", startedAt)
+		if err != nil {
+			return nil, err
+		}
+		attempt.CompletedAt, err = parseRetroOptionalTimestamp("completed_at", completedAt)
+		if err != nil {
+			return nil, err
+		}
+		attempts = append(attempts, attempt)
+	}
+	return attempts, rows.Err()
+}
+
+func (s *sqliteStore) loadRetroSessions(ctx context.Context, projectID string, since string) ([]retro.Session, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT s.id, COALESCE(s.work_attempt_id, 0), COALESCE(s.issue_id, ''), COALESCE(s.identifier, ''),
+       COALESCE(s.issue_url, ''), COALESCE(s.started_at, ''), COALESCE(s.completed_at, ''),
+       COALESCE(s.total_tokens, 0), COALESCE(s.final_state, ''), COALESCE(s.orphan_recovery_outcome, '')
+FROM codex_sessions s
+WHERE COALESCE(s.completed_at, s.started_at, '') >= ?
+  AND (
+    EXISTS (SELECT 1 FROM usage_events u WHERE u.session_id = s.id AND u.project_id = ?)
+    OR EXISTS (SELECT 1 FROM work_attempts w WHERE w.id = s.work_attempt_id AND w.project_id = ?)
+  )
+ORDER BY s.started_at, s.id`, since, projectID, projectID)
+	if err != nil {
+		return nil, fmt.Errorf("reading retro sessions: %w", err)
+	}
+	defer rows.Close()
+	var sessions []retro.Session
+	for rows.Next() {
+		var session retro.Session
+		var startedAt string
+		var completedAt string
+		if err := rows.Scan(
+			&session.ID, &session.WorkAttemptID, &session.IssueID, &session.Identifier,
+			&session.IssueURL, &startedAt, &completedAt, &session.TotalTokens,
+			&session.FinalState, &session.OrphanRecoveryOutcome,
+		); err != nil {
+			return nil, err
+		}
+		session.StartedAt, err = parseRetroOptionalTimestamp("started_at", startedAt)
+		if err != nil {
+			return nil, err
+		}
+		session.CompletedAt, err = parseRetroOptionalTimestamp("completed_at", completedAt)
+		if err != nil {
+			return nil, err
+		}
+		sessions = append(sessions, session)
+	}
+	return sessions, rows.Err()
+}
+
+func (s *sqliteStore) loadRetroUsageEvents(ctx context.Context, projectID string, since string) ([]retro.UsageEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT COALESCE(issue_id, ''), COALESCE(identifier, ''), finished_at,
+       COALESCE(total_tokens, 0), COALESCE(outcome, '')
+FROM usage_events
+WHERE project_id = ? AND finished_at >= ?
+ORDER BY finished_at, id`, projectID, since)
+	if err != nil {
+		return nil, fmt.Errorf("reading retro usage events: %w", err)
+	}
+	defer rows.Close()
+	var events []retro.UsageEvent
+	for rows.Next() {
+		var event retro.UsageEvent
+		var finishedAt string
+		if err := rows.Scan(&event.IssueID, &event.Identifier, &finishedAt, &event.TotalTokens, &event.Outcome); err != nil {
+			return nil, err
+		}
+		event.FinishedAt, err = parseTimestamp("finished_at", finishedAt)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func (s *sqliteStore) loadRetroPhaseEvents(ctx context.Context, projectID string, since string) ([]retro.PhaseEvent, error) {
+	rows, err := s.db.QueryContext(ctx, `
+SELECT COALESCE(issue_id, ''), COALESCE(identifier, ''), COALESCE(issue_url, ''),
+       phase_type, phase_name, COALESCE(reason, ''), COALESCE(status, ''), started_at,
+       COALESCE(finished_at, ''), COALESCE(total_tokens, 0)
+FROM workflow_phase_events
+WHERE project_id = ? AND COALESCE(finished_at, started_at) >= ?
+ORDER BY started_at, id`, projectID, since)
+	if err != nil {
+		return nil, fmt.Errorf("reading retro phase events: %w", err)
+	}
+	defer rows.Close()
+	var events []retro.PhaseEvent
+	for rows.Next() {
+		var event retro.PhaseEvent
+		var startedAt string
+		var finishedAt string
+		if err := rows.Scan(
+			&event.IssueID, &event.Identifier, &event.IssueURL, &event.PhaseType,
+			&event.PhaseName, &event.Reason, &event.Status, &startedAt, &finishedAt, &event.TotalTokens,
+		); err != nil {
+			return nil, err
+		}
+		event.StartedAt, err = parseTimestamp("started_at", startedAt)
+		if err != nil {
+			return nil, err
+		}
+		event.FinishedAt, err = parseRetroOptionalTimestamp("finished_at", finishedAt)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, event)
+	}
+	return events, rows.Err()
+}
+
+func parseRetroOptionalTimestamp(name string, value string) (time.Time, error) {
+	if strings.TrimSpace(value) == "" {
+		return time.Time{}, nil
+	}
+	return parseTimestamp(name, value)
+}

--- a/internal/store/retro_test.go
+++ b/internal/store/retro_test.go
@@ -1,0 +1,75 @@
+package store
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	retropkg "github.com/digitaldrywood/detent/internal/retro"
+)
+
+func TestRetroSnapshotAndRunLedger(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	base := time.Date(2026, 7, 10, 12, 0, 0, 0, time.UTC)
+	attemptID, err := backend.StartWorkAttempt(ctx, WorkAttemptStart{
+		ProjectID: "detent", Identifier: "digitaldrywood/detent#1206", WorkerType: "agent", StartedAt: base,
+	})
+	if err != nil {
+		t.Fatalf("StartWorkAttempt() error = %v", err)
+	}
+	if err := backend.CompleteWorkAttempt(ctx, WorkAttemptCompletion{
+		AttemptID: attemptID, CompletedAt: base.Add(time.Minute), TerminalState: WorkAttemptTerminalFailure,
+		ErrorClass: "runner", ErrorMessage: "session token ceiling exceeded",
+	}); err != nil {
+		t.Fatalf("CompleteWorkAttempt() error = %v", err)
+	}
+	sessionID, err := backend.StartSession(ctx, SessionStart{
+		WorkAttemptID: attemptID, Identifier: "digitaldrywood/detent#1206", StartedAt: base,
+		OrphanRecoveryOutcome: OrphanRecoveryFresh,
+	})
+	if err != nil {
+		t.Fatalf("StartSession() error = %v", err)
+	}
+	if err := backend.FinishSession(ctx, sessionID, SessionFinish{CompletedAt: base.Add(time.Minute), TotalTokens: 1234, FinalState: "failed"}); err != nil {
+		t.Fatalf("FinishSession() error = %v", err)
+	}
+	if _, err := backend.RecordUsageEvent(ctx, UsageEvent{
+		ProjectID: "detent", SessionID: sessionID, Identifier: "digitaldrywood/detent#1206",
+		TotalTokens: 1234, StartedAt: base, FinishedAt: base.Add(time.Minute), Outcome: "failed",
+	}); err != nil {
+		t.Fatalf("RecordUsageEvent() error = %v", err)
+	}
+	if _, err := backend.RecordWorkflowPhaseEvent(ctx, WorkflowPhaseEvent{
+		ProjectID: "detent", Identifier: "digitaldrywood/detent#1206", PhaseType: WorkflowPhaseTypeLane,
+		PhaseName: "In Progress", Reason: "workpad_status_invalid", StartedAt: base,
+	}); err != nil {
+		t.Fatalf("RecordWorkflowPhaseEvent() error = %v", err)
+	}
+
+	snapshot, err := backend.LoadRetroSnapshot(ctx, "detent", base.Add(-time.Minute))
+	if err != nil {
+		t.Fatalf("LoadRetroSnapshot() error = %v", err)
+	}
+	if len(snapshot.Attempts) != 1 || len(snapshot.Sessions) != 1 || len(snapshot.UsageEvents) != 1 || len(snapshot.PhaseEvents) != 1 {
+		t.Fatalf("snapshot = %#v", snapshot)
+	}
+	if snapshot.Sessions[0].TotalTokens != 1234 || snapshot.Sessions[0].OrphanRecoveryOutcome != OrphanRecoveryFresh {
+		t.Fatalf("session = %#v", snapshot.Sessions[0])
+	}
+
+	if err := backend.RecordRetroRun(ctx, retropkg.RunRecord{
+		ProjectID: "detent", Trigger: retropkg.TriggerDaily, StartedAt: base, CompletedAt: base.Add(time.Minute), Filed: 2,
+	}); err != nil {
+		t.Fatalf("RecordRetroRun() error = %v", err)
+	}
+	filed, err := backend.RetroFiledOnDay(ctx, "detent", base)
+	if err != nil {
+		t.Fatalf("RetroFiledOnDay() error = %v", err)
+	}
+	if filed != 2 {
+		t.Fatalf("RetroFiledOnDay() = %d, want 2", filed)
+	}
+}

--- a/internal/store/sqlc/models.go
+++ b/internal/store/sqlc/models.go
@@ -95,6 +95,19 @@ type FairShareUsage struct {
 	UpdatedAt      string `json:"updated_at"`
 }
 
+type RetroRun struct {
+	ID            int64          `json:"id"`
+	ProjectID     string         `json:"project_id"`
+	Trigger       string         `json:"trigger"`
+	StartedAt     string         `json:"started_at"`
+	CompletedAt   string         `json:"completed_at"`
+	FindingsCount int64          `json:"findings_count"`
+	FiledCount    int64          `json:"filed_count"`
+	UpdatedCount  int64          `json:"updated_count"`
+	Error         sql.NullString `json:"error"`
+	EventDay      string         `json:"event_day"`
+}
+
 type SchedulerDecision struct {
 	ID                     int64          `json:"id"`
 	ProjectID              string         `json:"project_id"`

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -87,6 +87,7 @@ func (s *sqliteStore) RuntimeEvidence(ctx context.Context, query RuntimeEvidence
 		{name: "work_attempts", projectScoped: true},
 		{name: "scheduler_decisions", projectScoped: true},
 		{name: "validator_verdicts", projectScoped: true},
+		{name: "retro_runs", projectScoped: true},
 		{name: "api_keys"},
 		{name: "api_usage_logs"},
 	}
@@ -1040,6 +1041,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_decisions WHERE project_id = ?", projectID)
 		case "validator_verdicts":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM validator_verdicts WHERE project_id = ?", projectID)
+		case "retro_runs":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM retro_runs WHERE project_id = ?", projectID)
 		default:
 			return 0, fmt.Errorf("unsupported project-scoped runtime table %q", tableName)
 		}
@@ -1061,6 +1064,8 @@ func (s *sqliteStore) runtimeTableCount(ctx context.Context, tableName string, p
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM scheduler_decisions")
 		case "validator_verdicts":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM validator_verdicts")
+		case "retro_runs":
+			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM retro_runs")
 		case "api_keys":
 			row = s.db.QueryRowContext(ctx, "SELECT COUNT(*) FROM api_keys")
 		case "api_usage_logs":

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/agentidentity"
+	"github.com/digitaldrywood/detent/internal/retro"
 	"github.com/digitaldrywood/detent/internal/store/sqlc"
 )
 
@@ -41,6 +42,7 @@ type Store interface {
 	RuntimeEvidenceStore
 	AgentResumeStore
 	OrphanSessionStore
+	RetroStore
 	APIKeyStore
 	Queries() *sqlc.Queries
 	Close() error
@@ -141,6 +143,10 @@ type AgentResumeStore interface {
 type OrphanSessionStore interface {
 	ListOrphanedAgentSessions(context.Context, string) ([]OrphanedAgentSession, error)
 	MarkAgentSessionOrphaned(context.Context, int64, time.Time) error
+}
+
+type RetroStore interface {
+	retro.TelemetryStore
 }
 
 type APIKeyStore interface {


### PR DESCRIPTION
## Summary

- Add configurable per-project efficiency retrospection with eight pure telemetry detectors and completion/daily triggers.
- Route workflow findings to project boards and product findings to the Detent repository with fingerprint dedupe, evidence refreshes, governed proposals, severity floors, and daily caps.
- Persist retro run history and expose per-project status through doctor, with runtime wiring, hot reload, documentation, and focused tests.

Fixes #1206

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] N/A; no primary operator screen changed.

## Test Plan

- [x] make check — build, generation, golangci-lint, vet, NilAway, race tests, 76.9% total coverage, and all per-package coverage floors passed.