### PR TITLE
fix(budget): report enforced hot-reload caps

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -115,6 +115,10 @@ func NewCheckerFromConfig(cfg Config, spend SpendStore) (*Checker, error) {
 	return NewChecker(cfg, spend, pricing), nil
 }
 
+func (c *Checker) EnforcedConfig() Config {
+	return c.cfg
+}
+
 func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decision, error) {
 	if !c.cfg.Enabled {
 		return Decision{Allowed: true}, nil

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -265,6 +265,22 @@ func TestCheckerUsesDefaultEstimate(t *testing.T) {
 	assertInDelta(t, decision.Refusal.ProjectedCostUSD, 0.19)
 }
 
+func TestCheckerReportsEnforcedConfig(t *testing.T) {
+	t.Parallel()
+
+	want := Config{
+		Enabled:         true,
+		PerDayMaxUSD:    250,
+		PerIssueMaxUSD:  25,
+		RefusalCooldown: 45 * time.Second,
+		PricingPath:     "pricing.yaml",
+	}
+	checker := NewChecker(want, &fakeSpendStore{}, nil)
+	if got := checker.EnforcedConfig(); got != want {
+		t.Fatalf("EnforcedConfig() = %#v, want %#v", got, want)
+	}
+}
+
 func TestRefusalCommentUsesEffectiveDueAt(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/doctor_environment.go
+++ b/internal/cli/doctor_environment.go
@@ -407,10 +407,18 @@ func checkDoctorServerPort(ctx context.Context, cfg BootConfig, deps doctorDeps)
 			check.Detail = fmt.Sprintf("%s is occupied for pre-start bind; health probe %s %v", addr, probe.URL, probeErr)
 			return check
 		}
+		detail := fmt.Sprintf(
+			"%s is occupied for pre-start bind; health probe %s found healthy Detent instance (status %s, mode %s)%s",
+			addr,
+			probe.URL,
+			probe.Health.Status,
+			probe.Health.Mode,
+			doctorEnforcedBudgetDetail(probe.Health.Budgets),
+		)
 		return doctorCheck{
 			Name:   "Server port",
 			Status: doctorWarn,
-			Detail: fmt.Sprintf("%s is occupied for pre-start bind; health probe %s found healthy Detent instance (status %s, mode %s)", addr, probe.URL, probe.Health.Status, probe.Health.Mode),
+			Detail: detail,
 			Hint:   "No action is needed if doctor is checking the live instance; stop Detent before a clean pre-start availability check.",
 		}
 	}
@@ -443,9 +451,35 @@ type doctorHealthProbe struct {
 }
 
 type doctorHealthResponse struct {
-	Status string            `json:"status"`
-	Mode   string            `json:"mode"`
-	Checks map[string]string `json:"checks"`
+	Status  string               `json:"status"`
+	Mode    string               `json:"mode"`
+	Checks  map[string]string    `json:"checks"`
+	Budgets []doctorHealthBudget `json:"budgets"`
+}
+
+type doctorHealthBudget struct {
+	ProjectID      string  `json:"project_id"`
+	Enabled        bool    `json:"enabled"`
+	PerDayMaxUSD   float64 `json:"per_day_max_usd"`
+	PerIssueMaxUSD float64 `json:"per_issue_max_usd"`
+}
+
+func doctorEnforcedBudgetDetail(budgets []doctorHealthBudget) string {
+	if len(budgets) == 0 {
+		return ""
+	}
+
+	parts := make([]string, 0, len(budgets))
+	for _, budget := range budgets {
+		parts = append(parts, fmt.Sprintf(
+			"%s enabled=%t per_day_max_usd=%s per_issue_max_usd=%s",
+			budget.ProjectID,
+			budget.Enabled,
+			strconv.FormatFloat(budget.PerDayMaxUSD, 'f', 2, 64),
+			strconv.FormatFloat(budget.PerIssueMaxUSD, 'f', 2, 64),
+		))
+	}
+	return "; enforced budget: " + strings.Join(parts, ", ")
 }
 
 func probeDoctorHealth(ctx context.Context, cfg BootConfig, deps doctorDeps) (doctorHealthProbe, error) {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3583,7 +3583,7 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 			host:       "0.0.0.0",
 			listenHost: "0.0.0.0",
 			statusCode: http.StatusOK,
-			body:       `{"status":"ok","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"}}`,
+			body:       `{"status":"ok","mode":"running","checks":{"hub":"configured","store":"configured","registry":"configured","connector":"configured"},"budgets":[{"project_id":"detent","enabled":true,"per_day_max_usd":250,"per_issue_max_usd":25}]}`,
 			want:       doctorWarn,
 			wantDetail: []string{
 				"pre-start bind",
@@ -3592,6 +3592,7 @@ func TestCheckDoctorServerPortProbesExistingInstance(t *testing.T) {
 				"/health",
 				"status ok",
 				"mode running",
+				"enforced budget: detent enabled=true per_day_max_usd=250.00 per_issue_max_usd=25.00",
 			},
 		},
 		{

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -299,6 +299,20 @@ func (p *Project) Workflow() workflowconfig.Workflow {
 	return p.workflow
 }
 
+func (p *Project) EnforcedBudget() (workflowconfig.Budget, bool) {
+	p.mu.Lock()
+	runner := p.runner
+	p.mu.Unlock()
+
+	reporter, ok := runner.(interface {
+		EnforcedBudget() (workflowconfig.Budget, bool)
+	})
+	if !ok {
+		return workflowconfig.Budget{}, false
+	}
+	return reporter.EnforcedBudget()
+}
+
 func (p *Project) Connector() connector.Connector {
 	p.mu.Lock()
 	defer p.mu.Unlock()

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -113,6 +113,8 @@ type Runner struct {
 	budgetChecker       BudgetChecker
 	dispatchEstimator   DispatchEstimator
 	budgetGuardBuilder  BudgetGuardBuilder
+	enforcedBudget      config.Budget
+	enforcedBudgetKnown bool
 	now                 func() time.Time
 	logger              *slog.Logger
 	afterRunTimeout     time.Duration
@@ -155,6 +157,7 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 			return nil, err
 		}
 	}
+	enforcedBudget, enforcedBudgetKnown := enforcedBudgetConfig(deps.Workflow.Config.Budget, budgetChecker)
 
 	return &Runner{
 		projectID:           projectID,
@@ -167,6 +170,8 @@ func NewRunner(deps Dependencies) (*Runner, error) {
 		budgetChecker:       budgetChecker,
 		dispatchEstimator:   dispatchEstimator,
 		budgetGuardBuilder:  deps.BudgetGuardBuilder,
+		enforcedBudget:      enforcedBudget,
+		enforcedBudgetKnown: enforcedBudgetKnown,
 		now:                 deps.Now,
 		logger:              deps.Logger,
 		afterRunTimeout:     deps.AfterRunTimeout,
@@ -199,12 +204,56 @@ func (r *Runner) UpdateWorkflow(workflow config.Workflow) {
 	} else {
 		r.budgetChecker = budgetChecker
 		r.dispatchEstimator = dispatchEstimator
+		r.enforcedBudget, r.enforcedBudgetKnown = enforcedBudgetConfig(workflow.Config.Budget, budgetChecker)
+		if budgetGuardBuilder != nil {
+			if r.enforcedBudgetKnown {
+				r.logger.Info(
+					"budget dispatch guards reloaded",
+					"enabled", r.enforcedBudget.Enabled,
+					"per_day_max_usd", r.enforcedBudget.PerDayMaxUSD,
+					"per_issue_max_usd", r.enforcedBudget.PerIssueMaxUSD,
+				)
+			} else {
+				r.logger.Warn("budget dispatch guards reloaded without enforced config reporting")
+			}
+		}
 	}
 	if err != nil {
 		r.logger.Warn("reload agent runtime failed", "error", err)
 		return
 	}
 	r.agentRuntime = runtime
+}
+
+func (r *Runner) EnforcedBudget() (config.Budget, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	return r.enforcedBudget, r.enforcedBudgetKnown
+}
+
+func enforcedBudgetConfig(requested config.Budget, checker BudgetChecker) (config.Budget, bool) {
+	if checker == nil {
+		if requested.Enabled {
+			return config.Budget{}, false
+		}
+		return requested, true
+	}
+
+	reporter, ok := checker.(interface {
+		EnforcedConfig() budget.Config
+	})
+	if !ok {
+		return config.Budget{}, false
+	}
+	enforced := reporter.EnforcedConfig()
+	return config.Budget{
+		Enabled:                enforced.Enabled,
+		PerDayMaxUSD:           enforced.PerDayMaxUSD,
+		PerIssueMaxUSD:         enforced.PerIssueMaxUSD,
+		RefusalCooldownSeconds: int(enforced.RefusalCooldown / time.Second),
+		PricingPath:            enforced.PricingPath,
+	}, true
 }
 
 type agentRuntime struct {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2822,6 +2822,92 @@ func TestRunnerUpdateWorkflowRefreshesBudgetGuards(t *testing.T) {
 	}
 }
 
+func TestRunnerUpdateWorkflowAppliesReloadedDailyBudget(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		initialCap         float64
+		reloadedCap        float64
+		wantInitialAllowed bool
+		wantReloadAllowed  bool
+	}{
+		{
+			name:               "increased cap unblocks next check",
+			initialCap:         0.05,
+			reloadedCap:        0.20,
+			wantInitialAllowed: false,
+			wantReloadAllowed:  true,
+		},
+		{
+			name:               "decreased cap refuses next check",
+			initialCap:         0.20,
+			reloadedCap:        0.05,
+			wantInitialAllowed: true,
+			wantReloadAllowed:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			pricing := budget.PricingTable{
+				"gpt-test": {USDPerInputToken: 0.01},
+			}
+			spend := &fakeRunnerBudgetSpendStore{
+				daily: store.TokenSpend{
+					ByModel: []store.ModelTokenSpend{{Model: "gpt-test", InputTokens: 10}},
+				},
+			}
+			workflowCfg := config.Config{}
+			workflowCfg.Budget = config.Budget{Enabled: true, PerDayMaxUSD: tt.initialCap}
+			runner, err := NewRunner(Dependencies{
+				Workflow: config.Workflow{Config: workflowCfg},
+				Workspace: &fakeWorkspaceBackend{
+					info: workspace.Info{Path: t.TempDir(), Key: "budget-reload", Branch: "detent/budget-reload"},
+				},
+				AgentBackend: &fakeCodexClient{},
+				BudgetGuardBuilder: func(cfg config.Budget) (BudgetChecker, DispatchEstimator, error) {
+					return budget.NewChecker(budget.Config{
+						Enabled:      cfg.Enabled,
+						PerDayMaxUSD: cfg.PerDayMaxUSD,
+					}, spend, pricing), nil, nil
+				},
+			})
+			if err != nil {
+				t.Fatalf("NewRunner() error = %v", err)
+			}
+
+			assertBudgetDecision := func(wantAllowed bool) {
+				t.Helper()
+				_, _, checker, _ := runner.runtimeSnapshot()
+				decision, err := checker.CheckDispatch(context.Background(), budget.DispatchRequest{
+					Model:    "gpt-test",
+					Now:      time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC),
+					Estimate: budget.TokenEstimate{InputTokens: 1},
+				})
+				if err != nil {
+					t.Fatalf("CheckDispatch() error = %v", err)
+				}
+				if decision.Allowed != wantAllowed {
+					t.Fatalf("Decision.Allowed = %t, want %t", decision.Allowed, wantAllowed)
+				}
+			}
+
+			assertBudgetDecision(tt.wantInitialAllowed)
+			workflowCfg.Budget.PerDayMaxUSD = tt.reloadedCap
+			runner.UpdateWorkflow(config.Workflow{Config: workflowCfg})
+			assertBudgetDecision(tt.wantReloadAllowed)
+
+			enforced, ok := runner.EnforcedBudget()
+			if !ok || enforced.PerDayMaxUSD != tt.reloadedCap {
+				t.Fatalf("EnforcedBudget() = %#v, %t, want per_day_max_usd %.2f", enforced, ok, tt.reloadedCap)
+			}
+		})
+	}
+}
+
 func TestRunnerRunUsesSingleConfiguredBackendDefaultRoute(t *testing.T) {
 	t.Parallel()
 

--- a/internal/web/server.go
+++ b/internal/web/server.go
@@ -823,7 +823,30 @@ func (s *Server) health(c echo.Context) error {
 		Connector:         s.connectorName(),
 		SessionsRemaining: sessionsRemaining,
 		Checks:            checks,
+		Budgets:           s.enforcedBudgets(),
 	})
+}
+
+func (s *Server) enforcedBudgets() []healthBudget {
+	if s.registry == nil {
+		return nil
+	}
+
+	projects := s.registry.List()
+	budgets := make([]healthBudget, 0, len(projects))
+	for _, project := range projects {
+		cfg, ok := project.EnforcedBudget()
+		if !ok {
+			continue
+		}
+		budgets = append(budgets, healthBudget{
+			ProjectID:      string(project.ID()),
+			Enabled:        cfg.Enabled,
+			PerDayMaxUSD:   cfg.PerDayMaxUSD,
+			PerIssueMaxUSD: cfg.PerIssueMaxUSD,
+		})
+	}
+	return budgets
 }
 
 func (s *Server) redirectToOnboarding(c echo.Context) error {
@@ -987,4 +1010,12 @@ type healthResponse struct {
 	Connector         string            `json:"connector"`
 	SessionsRemaining int               `json:"sessions_remaining,omitempty"`
 	Checks            map[string]string `json:"checks"`
+	Budgets           []healthBudget    `json:"budgets,omitempty"`
+}
+
+type healthBudget struct {
+	ProjectID      string  `json:"project_id"`
+	Enabled        bool    `json:"enabled"`
+	PerDayMaxUSD   float64 `json:"per_day_max_usd"`
+	PerIssueMaxUSD float64 `json:"per_issue_max_usd"`
 }

--- a/internal/web/server_test.go
+++ b/internal/web/server_test.go
@@ -6152,6 +6152,57 @@ func TestHealthReportsDraining(t *testing.T) {
 	}
 }
 
+func TestHealthReportsEnforcedProjectBudgets(t *testing.T) {
+	t.Parallel()
+
+	deps := testDeps(t)
+	workflowCfg := workflowconfig.Default()
+	workflowCfg.Tracker.Kind = workflowconfig.TrackerMemory
+	trackedProject, err := project.New(project.Config{
+		Project: globalconfig.Project{ID: "detent"},
+		Workflow: workflowconfig.Workflow{
+			Config: workflowCfg,
+			Prompt: "Work the issue.",
+		},
+	}, project.Dependencies{
+		Connector: connectorProbe{name: "memory"},
+		Runner: healthBudgetRunner{budget: workflowconfig.Budget{
+			Enabled:        true,
+			PerDayMaxUSD:   250,
+			PerIssueMaxUSD: 25,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+	if err := deps.Registry.Set(trackedProject); err != nil {
+		t.Fatalf("Registry.Set() error = %v", err)
+	}
+
+	server, err := web.NewServer(web.Config{}, deps)
+	if err != nil {
+		t.Fatalf("NewServer() error = %v", err)
+	}
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/health", nil)
+	server.Handler().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want %d; body = %s", rec.Code, http.StatusOK, rec.Body.String())
+	}
+	for _, want := range []string{
+		`"project_id":"detent"`,
+		`"enabled":true`,
+		`"per_day_max_usd":250`,
+		`"per_issue_max_usd":25`,
+	} {
+		if !strings.Contains(rec.Body.String(), want) {
+			t.Fatalf("body missing %q:\n%s", want, rec.Body.String())
+		}
+	}
+}
+
 func TestAPIStateReportsDraining(t *testing.T) {
 	t.Parallel()
 
@@ -9564,6 +9615,18 @@ func mustSetWebProject(t *testing.T, registry *project.Registry, id string, paus
 	t.Helper()
 
 	mustSetWebProjectWithWorkflowStates(t, registry, id, paused, nil, nil, nil)
+}
+
+type healthBudgetRunner struct {
+	budget workflowconfig.Budget
+}
+
+func (r healthBudgetRunner) Run(context.Context, orchestrator.RunRequest) (orchestrator.RunResult, error) {
+	return orchestrator.RunResult{FinalState: orchestrator.FinalStateCompleted}, nil
+}
+
+func (r healthBudgetRunner) EnforcedBudget() (workflowconfig.Budget, bool) {
+	return r.budget, true
 }
 
 func mustSetWebGitHubLabelProject(t *testing.T, registry *project.Registry, id string, repository string) {


### PR DESCRIPTION
## Summary

- verify workflow hot reloads replace the real daily budget checker for both increased and decreased caps
- snapshot enforced values from the live checker and expose them through health diagnostics
- make `detent doctor` show the running checker's per-day and per-issue caps
- log the enforced caps whenever budget dispatch guards reload

Fixes #1238

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `make check`
- [x] table-driven increased/decreased `per_day_max_usd` hot-reload regression test
- [x] health and doctor enforced-budget reporting tests
