### PR TITLE
fix(shutdown): guard restart lifecycle

### DIFF
--- a/README.md
+++ b/README.md
@@ -1399,6 +1399,13 @@ Open the dashboard at <http://localhost:4000>. Use `--host` and `--port` to
 override the address. Before exposing a remote URL such as
 `http://prometheus:4000/`, choose the dashboard bind mode:
 
+On shutdown, the first Ctrl-C stops new dispatches and drains running agent
+sessions while the terminal reports the blocker count and time remaining. A
+second Ctrl-C force-quits immediately, interrupts those sessions, and re-queues
+their issues. A new process using the same runtime database will fail with an
+actionable error until the prior process has released it; a listener conflict
+also fails before SQLite migrations begin.
+
 - `127.0.0.1` keeps the dashboard local to the host and is the safest default
   for SSH tunnel access.
 - A specific private or Tailscale IP exposes the dashboard only on that
@@ -2104,7 +2111,8 @@ When a changed field requires restart, Detent logs
 Run more than one Detent instance when a single GitHub ProjectV2 board should
 be split across independent workers. Each instance is a separate `detent`
 process with its own `global.yaml`, process identity, authorization selector,
-and claim lease. The instances may point at the same `tracker.project_slug`,
+runtime database, listener address, and claim lease. The instances may point at
+the same `tracker.project_slug`,
 but their authorization selectors should be disjoint so each issue belongs to
 one worker set before claiming begins.
 

--- a/cmd/detent/main_test.go
+++ b/cmd/detent/main_test.go
@@ -400,7 +400,7 @@ func TestWriteSignalShutdownNotice(t *testing.T) {
 		{
 			name:    "drain",
 			request: cli.ShutdownRequestDrain,
-			want:    "shutdown requested; draining sessions, press Ctrl+C again to force quit",
+			want:    "shutdown requested; draining sessions; press Ctrl+C again to force quit immediately",
 		},
 		{
 			name:    "force",
@@ -466,7 +466,7 @@ func TestHandleShutdownSignalHardExitsOnForceInterrupt(t *testing.T) {
 
 	notice := output.String()
 	for _, want := range []string{
-		"shutdown requested; draining sessions, press Ctrl+C again to force quit",
+		"shutdown requested; draining sessions; press Ctrl+C again to force quit immediately",
 		"force quit requested; interrupting sessions",
 	} {
 		if !strings.Contains(notice, want) {

--- a/cmd/detent/signal.go
+++ b/cmd/detent/signal.go
@@ -100,7 +100,7 @@ func writeSignalShutdownNotice(out io.Writer, request cli.ShutdownRequest) {
 	}
 	switch request {
 	case cli.ShutdownRequestDrain:
-		fmt.Fprintln(out, "shutdown requested; draining sessions, press Ctrl+C again to force quit")
+		fmt.Fprintln(out, "shutdown requested; draining sessions; press Ctrl+C again to force quit immediately")
 	case cli.ShutdownRequestForce:
 		fmt.Fprintln(out, "force quit requested; interrupting sessions")
 	default:

--- a/go.mod
+++ b/go.mod
@@ -21,6 +21,7 @@ require (
 	golang.org/x/crypto v0.50.0
 	golang.org/x/net v0.53.0
 	golang.org/x/sync v0.20.0
+	golang.org/x/sys v0.43.0
 	gopkg.in/yaml.v3 v3.0.1
 	modernc.org/sqlite v1.51.0
 )
@@ -54,7 +55,6 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/xo/terminfo v0.0.0-20220910002029-abceb7e1c41e // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.15.0 // indirect
 	modernc.org/libc v1.72.3 // indirect

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -8,8 +8,10 @@ import (
 	"log/slog"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"path/filepath"
+	"runtime"
 	"slices"
 	"strconv"
 	"strings"
@@ -174,8 +176,9 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		}
 	}
 	var instanceLock *instancelock.Lock
-	if !runtimeStoreIsMemory(runtimeStorePath(cfg)) {
-		acquiredLock, err := acquireRuntimeInstanceLock(cfg)
+	runtimeDBPath := runtimeStorePath(cfg)
+	if !runtimeStoreIsMemory(runtimeDBPath) {
+		acquiredLock, err := acquireRuntimeInstanceLock(runtimeStoreLockPath(runtimeDBPath))
 		if err != nil {
 			return err
 		}
@@ -991,21 +994,75 @@ func openRuntimeStore(ctx context.Context, cfg BootConfig) (store.Store, error) 
 	})
 }
 
-func acquireRuntimeInstanceLock(cfg BootConfig) (*instancelock.Lock, error) {
-	path := runtimeStorePath(cfg)
-	lock, err := instancelock.Acquire(path + ".lock")
+func acquireRuntimeInstanceLock(lockPath string) (*instancelock.Lock, error) {
+	lock, err := instancelock.Acquire(lockPath)
 	if errors.Is(err, instancelock.ErrHeld) {
-		return nil, fmt.Errorf("another Detent instance is using runtime database %q; wait for it to finish shutting down, then retry", path)
+		return nil, fmt.Errorf("another Detent instance is using runtime database guarded by %q; wait for it to finish shutting down, then retry", lockPath)
 	}
 	if err != nil {
-		return nil, fmt.Errorf("protect runtime database %q: %w", path, err)
+		return nil, fmt.Errorf("protect runtime database with %q: %w", lockPath, err)
 	}
 	return lock, nil
 }
 
 func runtimeStoreIsMemory(path string) bool {
-	path = strings.ToLower(strings.TrimSpace(path))
-	return strings.HasPrefix(path, ":memory:") || strings.Contains(path, "mode=memory")
+	if path == ":memory:" {
+		return true
+	}
+	uri, ok := runtimeStoreURI(path)
+	if !ok {
+		return false
+	}
+	if uri.Query().Get("mode") == "memory" {
+		return true
+	}
+	uriPath, ok := runtimeStoreURIPath(uri)
+	return ok && uriPath == ":memory:"
+}
+
+func runtimeStoreLockPath(path string) string {
+	uri, ok := runtimeStoreURI(path)
+	if ok {
+		if uriPath, pathOK := runtimeStoreURIPath(uri); pathOK {
+			path = uriPath
+		}
+	}
+	return path + ".lock"
+}
+
+func runtimeStoreURI(path string) (*url.URL, bool) {
+	if !strings.HasPrefix(path, "file:") {
+		return nil, false
+	}
+	uri, err := url.Parse(path)
+	if err != nil || uri.Scheme != "file" {
+		return nil, false
+	}
+	return uri, true
+}
+
+func runtimeStoreURIPath(uri *url.URL) (string, bool) {
+	if uri == nil {
+		return "", false
+	}
+	path := uri.Path
+	if uri.Opaque != "" {
+		decoded, err := url.PathUnescape(uri.Opaque)
+		if err != nil {
+			return "", false
+		}
+		path = decoded
+	}
+	if path == "" {
+		return "", false
+	}
+	if uri.Host != "" && !strings.EqualFold(uri.Host, "localhost") {
+		path = "//" + uri.Host + "/" + strings.TrimPrefix(path, "/")
+	}
+	if runtime.GOOS == "windows" && len(path) >= 3 && path[0] == '/' && path[2] == ':' {
+		path = path[1:]
+	}
+	return filepath.FromSlash(path), true
 }
 
 func runtimeStorePath(cfg BootConfig) string {

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -26,6 +26,7 @@ import (
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/connector/memory"
 	"github.com/digitaldrywood/detent/internal/hub"
+	"github.com/digitaldrywood/detent/internal/instancelock"
 	"github.com/digitaldrywood/detent/internal/orchestrator"
 	"github.com/digitaldrywood/detent/internal/project"
 	"github.com/digitaldrywood/detent/internal/scheduler"
@@ -172,6 +173,35 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			logger.Warn(warning.Detail, "check", warning.Name, "hint", warning.Hint)
 		}
 	}
+	var instanceLock *instancelock.Lock
+	if !runtimeStoreIsMemory(runtimeStorePath(cfg)) {
+		acquiredLock, err := acquireRuntimeInstanceLock(cfg)
+		if err != nil {
+			return err
+		}
+		instanceLock = acquiredLock
+	}
+	if instanceLock != nil {
+		defer func() {
+			if err := instanceLock.Close(); err != nil {
+				logger.Warn("release runtime instance lock failed", "error", err)
+			}
+		}()
+	}
+
+	listener, displayURL, err := listenForBoot(cfg)
+	if err != nil {
+		return fmt.Errorf("bind Detent web listener %s: %w", serverAddr(cfg), err)
+	}
+	listenerOwned := true
+	defer func() {
+		if listenerOwned {
+			if err := listener.Close(); err != nil {
+				logger.Warn("close web listener failed", "error", err)
+			}
+		}
+	}()
+
 	runtimeStore, err := openRuntimeStore(runCtx, cfg)
 	if err != nil {
 		return err
@@ -189,19 +219,6 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 			logger.Warn("close runtime store failed", "error", err)
 		} else {
 			logShutdownBoundaryEnd(logger, "runtime_store_close", closeStarted, nil, "component", "runtime_store")
-		}
-	}()
-
-	listener, displayURL, err := listenForBoot(cfg)
-	if err != nil {
-		return err
-	}
-	listenerOwned := true
-	defer func() {
-		if listenerOwned {
-			if err := listener.Close(); err != nil {
-				logger.Warn("close web listener failed", "error", err)
-			}
 		}
 	}()
 
@@ -318,7 +335,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		listenerOwned = false
 		if cfg.Shutdown == nil {
 			return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
-				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, nil)
+				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, nil, nil)
 			})
 		}
 		return runStartupAndServe(runCtx, startProjects, func(ctx context.Context) error {
@@ -338,7 +355,9 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 				ProgressInterval: defaultShutdownProgressInterval,
 				HardTimeout:      defaultShutdownHardTimeout,
 			}, func(ctx context.Context) error {
-				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, func() {
+				return serveWithTerminalDashboard(ctx, server, listener, snapshotHub, cfg.Build, func() time.Duration {
+					return shutdownDrainTimeout(manager.Registry())
+				}, func() {
 					requestTerminalShutdownInterrupt(cfg.Shutdown, cfg.HardExit)
 				})
 			})
@@ -547,7 +566,15 @@ func unexpectedBootServeError(err error) error {
 	return err
 }
 
-func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listener net.Listener, snapshots *hub.Hub[telemetry.Snapshot], build buildinfo.Info, interrupt func()) error {
+func serveWithTerminalDashboard(
+	ctx context.Context,
+	server *web.Server,
+	listener net.Listener,
+	snapshots *hub.Hub[telemetry.Snapshot],
+	build buildinfo.Info,
+	shutdownTimeoutSource func() time.Duration,
+	interrupt func(),
+) error {
 	if ctx == nil {
 		ctx = context.Background()
 	}
@@ -563,7 +590,13 @@ func serveWithTerminalDashboard(ctx context.Context, server *web.Server, listene
 	runCtx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
-	model, err := tui.NewModel(runCtx, snapshots, tui.WithBuild(build), tui.WithInterruptFunc(interrupt))
+	model, err := tui.NewModel(
+		runCtx,
+		snapshots,
+		tui.WithBuild(build),
+		tui.WithShutdownTimeoutSource(shutdownTimeoutSource),
+		tui.WithInterruptFunc(interrupt),
+	)
 	if err != nil {
 		return err
 	}
@@ -956,6 +989,23 @@ func openRuntimeStore(ctx context.Context, cfg BootConfig) (store.Store, error) 
 		Backend: store.BackendSQLite,
 		Path:    runtimeStorePath(cfg),
 	})
+}
+
+func acquireRuntimeInstanceLock(cfg BootConfig) (*instancelock.Lock, error) {
+	path := runtimeStorePath(cfg)
+	lock, err := instancelock.Acquire(path + ".lock")
+	if errors.Is(err, instancelock.ErrHeld) {
+		return nil, fmt.Errorf("another Detent instance is using runtime database %q; wait for it to finish shutting down, then retry", path)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("protect runtime database %q: %w", path, err)
+	}
+	return lock, nil
+}
+
+func runtimeStoreIsMemory(path string) bool {
+	path = strings.ToLower(strings.TrimSpace(path))
+	return strings.HasPrefix(path, ":memory:") || strings.Contains(path, "mode=memory")
 }
 
 func runtimeStorePath(cfg BootConfig) string {

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"net/url"
 	"os"
@@ -475,6 +476,103 @@ func TestStartRunningBootsDashboardAndStopsOnContextCancel(t *testing.T) {
 		}
 	case <-time.After(10 * time.Second):
 		t.Fatal("timed out waiting for startRunning to stop")
+	}
+}
+
+func TestStartRunningRefusesSharedRuntimeDatabase(t *testing.T) {
+	port := 0
+	root := t.TempDir()
+	global, err := globalconfig.DefaultAt(filepath.Join(root, "global.yaml"))
+	if err != nil {
+		t.Fatalf("DefaultAt() error = %v", err)
+	}
+	dbPath := filepath.Join(root, "detent.db")
+
+	firstCtx, cancelFirst := context.WithCancel(context.Background())
+	t.Cleanup(cancelFirst)
+	firstDone := make(chan error, 1)
+	firstOutput := newBootOutput()
+	go func() {
+		firstDone <- startRunning(firstCtx, BootConfig{
+			Mode:          BootModeRunning,
+			Global:        global,
+			Host:          "127.0.0.1",
+			Port:          &port,
+			RuntimeDBPath: dbPath,
+			Output:        firstOutput,
+		})
+	}()
+	waitForBootDashboardURL(t, firstOutput, firstDone)
+
+	secondCtx, cancelSecond := context.WithCancel(context.Background())
+	t.Cleanup(cancelSecond)
+	secondDone := make(chan error, 1)
+	secondOutput := newBootOutput()
+	go func() {
+		secondDone <- startRunning(secondCtx, BootConfig{
+			Mode:          BootModeRunning,
+			Global:        global,
+			Host:          "127.0.0.1",
+			Port:          &port,
+			RuntimeDBPath: dbPath,
+			Output:        secondOutput,
+		})
+	}()
+
+	select {
+	case err := <-secondDone:
+		if err == nil || !strings.Contains(err.Error(), "another Detent instance is using runtime database") {
+			t.Fatalf("second startRunning() error = %v, want shared runtime database error", err)
+		}
+	case <-time.After(2 * time.Second):
+		cancelSecond()
+		t.Fatalf("second startRunning() did not refuse shared database; output:\n%s", secondOutput.String())
+	}
+
+	cancelFirst()
+	select {
+	case err := <-firstDone:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("first startRunning() error = %v, want context.Canceled", err)
+		}
+	case <-time.After(10 * time.Second):
+		t.Fatal("timed out waiting for first runtime to stop")
+	}
+}
+
+func TestStartRunningBindsBeforeCreatingRuntimeDatabase(t *testing.T) {
+	t.Parallel()
+
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("Listen() error = %v", err)
+	}
+	t.Cleanup(func() {
+		if err := listener.Close(); err != nil {
+			t.Fatalf("listener Close() error = %v", err)
+		}
+	})
+	port := listener.Addr().(*net.TCPAddr).Port
+	root := t.TempDir()
+	dbPath := filepath.Join(root, "detent.db")
+	global, err := globalconfig.DefaultAt(filepath.Join(root, "global.yaml"))
+	if err != nil {
+		t.Fatalf("DefaultAt() error = %v", err)
+	}
+
+	err = startRunning(context.Background(), BootConfig{
+		Mode:          BootModeRunning,
+		Global:        global,
+		Host:          "127.0.0.1",
+		Port:          &port,
+		RuntimeDBPath: dbPath,
+		Output:        io.Discard,
+	})
+	if err == nil || !strings.Contains(err.Error(), "bind Detent web listener") {
+		t.Fatalf("startRunning() error = %v, want listener bind error", err)
+	}
+	if _, err := os.Stat(dbPath); !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("runtime database exists before listener bind, Stat() error = %v", err)
 	}
 }
 

--- a/internal/cli/boot_test.go
+++ b/internal/cli/boot_test.go
@@ -540,6 +540,39 @@ func TestStartRunningRefusesSharedRuntimeDatabase(t *testing.T) {
 	}
 }
 
+func TestRuntimeStoreLocation(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		path     string
+		memory   bool
+		lockPath string
+	}{
+		{name: "private memory", path: ":memory:", memory: true, lockPath: ":memory:.lock"},
+		{name: "memory prefix is file", path: ":memory:extra", lockPath: ":memory:extra.lock"},
+		{name: "memory text in file path", path: "/var/lib/detent/mode=memory/detent.db", lockPath: "/var/lib/detent/mode=memory/detent.db.lock"},
+		{name: "named memory URI", path: "file:detent?mode=memory&cache=shared", memory: true, lockPath: "detent.lock"},
+		{name: "special memory URI", path: "file::memory:?cache=shared", memory: true, lockPath: ":memory:.lock"},
+		{name: "absolute file URI", path: "file:/tmp/detent.db?mode=rw", lockPath: filepath.FromSlash("/tmp/detent.db.lock")},
+		{name: "localhost file URI", path: "file://localhost/tmp/detent.db?mode=rwc", lockPath: filepath.FromSlash("/tmp/detent.db.lock")},
+		{name: "escaped file URI", path: "file:/tmp/detent%20runtime.db?mode=rwc#ignored", lockPath: filepath.FromSlash("/tmp/detent runtime.db.lock")},
+		{name: "relative file URI", path: "file:detent.db?mode=rw", lockPath: "detent.db.lock"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := runtimeStoreIsMemory(tt.path); got != tt.memory {
+				t.Fatalf("runtimeStoreIsMemory(%q) = %v, want %v", tt.path, got, tt.memory)
+			}
+			if got := runtimeStoreLockPath(tt.path); got != tt.lockPath {
+				t.Fatalf("runtimeStoreLockPath(%q) = %q, want %q", tt.path, got, tt.lockPath)
+			}
+		})
+	}
+}
+
 func TestStartRunningBindsBeforeCreatingRuntimeDatabase(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cli/shutdown.go
+++ b/internal/cli/shutdown.go
@@ -210,7 +210,7 @@ func runDrainShutdown(
 	sessions := shutdownRunningSessions(ctx, cfg.Registry, startedAt)
 	logShutdownBoundaryEnd(shutdownLogger(cfg), "initial_running_session_inventory", inventoryStarted, nil, "sessions", len(sessions))
 	logShutdownDrainBlockers(cfg, "initial", sessions, drainTimeout)
-	writeShutdownBanner(shutdownOutput(cfg), sessions)
+	writeShutdownBanner(shutdownOutput(cfg), sessions, drainTimeout)
 	shutdownLogger(cfg).Info("shutdown requested", "sessions", len(sessions))
 
 	hardTimeout := cfg.HardTimeout
@@ -273,7 +273,7 @@ func runDrainShutdown(
 		case <-poll.C:
 		case <-progress.C:
 			logShutdownDrainBlockers(cfg, "progress", sessions, drainTimeout)
-			writeShutdownProgress(shutdownOutput(cfg), sessions)
+			writeShutdownProgress(shutdownOutput(cfg), sessions, shutdownDrainRemaining(startedAt, drainTimeout, shutdownNow(cfg)))
 		case <-timeout:
 			machine = machine.Apply(shutdownstate.EventDrainTimedOut)
 			logShutdownDrainTimeout(cfg, sessions, drainTimeout)
@@ -561,7 +561,7 @@ func defaultShutdownDrainTimeout() time.Duration {
 	return time.Duration(workflowconfig.DefaultShutdownDrainTimeoutMS) * time.Millisecond
 }
 
-func writeShutdownBanner(out io.Writer, sessions []telemetry.Running) {
+func writeShutdownBanner(out io.Writer, sessions []telemetry.Running, remaining time.Duration) {
 	if out == nil {
 		out = io.Discard
 	}
@@ -580,11 +580,11 @@ func writeShutdownBanner(out io.Writer, sessions []telemetry.Running) {
 		}
 		fmt.Fprintf(out, "  %-30s %-14s %8s  %s\n", shutdownIssueLabel(session), defaultShutdownString(session.State, "running"), formatShutdownDuration(session.RuntimeSeconds), details)
 	}
-	fmt.Fprintln(out, "draining: no new work will be dispatched; waiting for running sessions to finish")
-	fmt.Fprintln(out, "press Ctrl+C again to force quit (sessions will be interrupted and issues re-queued)")
+	fmt.Fprintf(out, "draining: no new work will be dispatched; waiting for running sessions to finish; %s remaining until force quit\n", formatShutdownRemaining(remaining))
+	fmt.Fprintln(out, "press Ctrl+C again to force quit immediately (sessions will be interrupted and issues re-queued)")
 }
 
-func writeShutdownProgress(out io.Writer, sessions []telemetry.Running) {
+func writeShutdownProgress(out io.Writer, sessions []telemetry.Running, remaining time.Duration) {
 	if out == nil || len(sessions) == 0 {
 		return
 	}
@@ -597,7 +597,26 @@ func writeShutdownProgress(out io.Writer, sessions []telemetry.Running) {
 		}
 		parts = append(parts, fmt.Sprintf("%s (%s, %s)", shutdownIssueNumber(session), formatShutdownDuration(session.RuntimeSeconds), details))
 	}
-	fmt.Fprintf(out, "%d %s remaining — %s\n", len(sessions), shutdownSessionNoun(len(sessions)), strings.Join(parts, ", "))
+	fmt.Fprintf(out, "%d %s remaining — %s remaining until force quit — %s\n", len(sessions), shutdownSessionNoun(len(sessions)), formatShutdownRemaining(remaining), strings.Join(parts, ", "))
+}
+
+func shutdownDrainRemaining(startedAt time.Time, timeout time.Duration, now time.Time) time.Duration {
+	remaining := timeout - now.Sub(startedAt)
+	if remaining < 0 {
+		return 0
+	}
+	return remaining
+}
+
+func formatShutdownRemaining(remaining time.Duration) string {
+	if remaining <= 0 {
+		return "0s"
+	}
+	if remaining < time.Second {
+		return remaining.Round(time.Millisecond).String()
+	}
+	seconds := (remaining + time.Second - 1) / time.Second
+	return formatShutdownDuration(float64(seconds))
 }
 
 func logShutdownDrainBlockers(cfg runningShutdownConfig, phase string, sessions []telemetry.Running, timeout time.Duration) {

--- a/internal/cli/shutdown_test.go
+++ b/internal/cli/shutdown_test.go
@@ -536,6 +536,8 @@ func TestRunWithShutdownActiveChildProcessReportsDrainBlockersAndTimesOut(t *tes
 	gotOutput := output.String()
 	for _, want := range []string{
 		"shutdown requested — 1 agent session in flight",
+		"20ms remaining until force quit",
+		"1 agent session remaining — 20ms remaining until force quit",
 		"#641",
 		"process=4242",
 		"session=thread-641-turn-1",
@@ -728,7 +730,7 @@ func TestShutdownBannerFormatsRunningSessions(t *testing.T) {
 			},
 			RuntimeSeconds: 724,
 		},
-	})
+	}, 75*time.Second)
 
 	got := output.String()
 	for _, want := range []string{
@@ -737,7 +739,8 @@ func TestShutdownBannerFormatsRunningSessions(t *testing.T) {
 		"In Progress",
 		"12m 4s",
 		"draining: no new work will be dispatched",
-		"press Ctrl+C again to force quit",
+		"1m 15s remaining until force quit",
+		"press Ctrl+C again to force quit immediately",
 	} {
 		if !strings.Contains(got, want) {
 			t.Fatalf("banner missing %q:\n%s", want, got)

--- a/internal/instancelock/lock.go
+++ b/internal/instancelock/lock.go
@@ -1,0 +1,102 @@
+package instancelock
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+)
+
+var ErrHeld = errors.New("instance lock is held")
+
+var localLocks = struct {
+	sync.Mutex
+	paths map[string]struct{}
+}{paths: make(map[string]struct{})}
+
+type Lock struct {
+	path      string
+	file      *os.File
+	closeOnce sync.Once
+	closeErr  error
+}
+
+func Acquire(path string) (*Lock, error) {
+	absolutePath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, fmt.Errorf("resolve instance lock path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(absolutePath), 0o755); err != nil {
+		return nil, fmt.Errorf("create instance lock directory: %w", err)
+	}
+	if !claimLocal(absolutePath) {
+		return nil, fmt.Errorf("%w: %s", ErrHeld, absolutePath)
+	}
+	releaseClaim := true
+	defer func() {
+		if releaseClaim {
+			releaseLocal(absolutePath)
+		}
+	}()
+
+	file, err := os.OpenFile(absolutePath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("open instance lock: %w", err)
+	}
+	if err := tryLock(file); err != nil {
+		closeErr := file.Close()
+		if errors.Is(err, ErrHeld) {
+			return nil, errors.Join(fmt.Errorf("%w: %s", ErrHeld, absolutePath), closeErr)
+		}
+		return nil, fmt.Errorf("acquire instance lock: %w", errors.Join(err, closeErr))
+	}
+	if err := writeOwner(file); err != nil {
+		return nil, errors.Join(err, unlock(file), file.Close())
+	}
+
+	releaseClaim = false
+	return &Lock{path: absolutePath, file: file}, nil
+}
+
+func (l *Lock) Close() error {
+	if l == nil {
+		return nil
+	}
+	l.closeOnce.Do(func() {
+		unlockErr := unlock(l.file)
+		closeErr := l.file.Close()
+		releaseLocal(l.path)
+		l.closeErr = errors.Join(unlockErr, closeErr)
+	})
+	return l.closeErr
+}
+
+func writeOwner(file *os.File) error {
+	if err := file.Truncate(0); err != nil {
+		return fmt.Errorf("truncate instance lock: %w", err)
+	}
+	if _, err := file.Seek(0, 0); err != nil {
+		return fmt.Errorf("seek instance lock: %w", err)
+	}
+	if _, err := fmt.Fprintf(file, "pid=%d\n", os.Getpid()); err != nil {
+		return fmt.Errorf("write instance lock owner: %w", err)
+	}
+	return nil
+}
+
+func claimLocal(path string) bool {
+	localLocks.Lock()
+	defer localLocks.Unlock()
+	if _, exists := localLocks.paths[path]; exists {
+		return false
+	}
+	localLocks.paths[path] = struct{}{}
+	return true
+}
+
+func releaseLocal(path string) {
+	localLocks.Lock()
+	defer localLocks.Unlock()
+	delete(localLocks.paths, path)
+}

--- a/internal/instancelock/lock_test.go
+++ b/internal/instancelock/lock_test.go
@@ -1,0 +1,63 @@
+package instancelock
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestAcquireExcludesAnotherProcessAndReleases(t *testing.T) {
+	t.Parallel()
+
+	path := filepath.Join(t.TempDir(), "detent.db.lock")
+	lock, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+
+	command := exec.Command(os.Args[0], "-test.run=^TestAcquireHelperProcess$")
+	command.Env = append(os.Environ(), "DETENT_INSTANCE_LOCK_HELPER="+path)
+	output, err := command.CombinedOutput()
+	if err != nil {
+		t.Fatalf("helper process error = %v, output = %s", err, output)
+	}
+	if got := strings.TrimSpace(string(output)); !strings.HasPrefix(got, "held\n") {
+		t.Fatalf("helper output = %q, want held marker", got)
+	}
+
+	if err := lock.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	reacquired, err := Acquire(path)
+	if err != nil {
+		t.Fatalf("Acquire() after Close error = %v", err)
+	}
+	if err := reacquired.Close(); err != nil {
+		t.Fatalf("reacquired Close() error = %v", err)
+	}
+}
+
+func TestAcquireHelperProcess(t *testing.T) {
+	path := os.Getenv("DETENT_INSTANCE_LOCK_HELPER")
+	if path == "" {
+		t.Skip("helper process")
+	}
+
+	lock, err := Acquire(path)
+	if errors.Is(err, ErrHeld) {
+		if _, err := os.Stdout.WriteString("held\n"); err != nil {
+			t.Fatalf("WriteString() error = %v", err)
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("Acquire() error = %v", err)
+	}
+	if err := lock.Close(); err != nil {
+		t.Fatalf("Close() error = %v", err)
+	}
+	t.Fatal("Acquire() succeeded while parent held lock")
+}

--- a/internal/instancelock/lock_unix.go
+++ b/internal/instancelock/lock_unix.go
@@ -1,0 +1,22 @@
+//go:build darwin || linux
+
+package instancelock
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func tryLock(file *os.File) error {
+	err := unix.Flock(int(file.Fd()), unix.LOCK_EX|unix.LOCK_NB)
+	if errors.Is(err, unix.EWOULDBLOCK) || errors.Is(err, unix.EAGAIN) {
+		return ErrHeld
+	}
+	return err
+}
+
+func unlock(file *os.File) error {
+	return unix.Flock(int(file.Fd()), unix.LOCK_UN)
+}

--- a/internal/instancelock/lock_windows.go
+++ b/internal/instancelock/lock_windows.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package instancelock
+
+import (
+	"errors"
+	"os"
+
+	"golang.org/x/sys/windows"
+)
+
+func tryLock(file *os.File) error {
+	overlapped := new(windows.Overlapped)
+	err := windows.LockFileEx(
+		windows.Handle(file.Fd()),
+		windows.LOCKFILE_EXCLUSIVE_LOCK|windows.LOCKFILE_FAIL_IMMEDIATELY,
+		0,
+		1,
+		0,
+		overlapped,
+	)
+	if errors.Is(err, windows.ERROR_LOCK_VIOLATION) {
+		return ErrHeld
+	}
+	return err
+}
+
+func unlock(file *os.File) error {
+	return windows.UnlockFileEx(windows.Handle(file.Fd()), 0, 1, 0, new(windows.Overlapped))
+}

--- a/internal/tui/model.go
+++ b/internal/tui/model.go
@@ -23,31 +23,33 @@ var ErrNilHub = errors.New("nil telemetry hub")
 const defaultDashboardURL = "http://localhost:4000"
 
 const (
-	shutdownDrainNotice = "shutdown requested; draining sessions, press Ctrl+C again to force quit"
+	shutdownDrainNotice = "shutdown requested; draining sessions; press Ctrl+C again to force quit immediately"
 	shutdownForceNotice = "force quit requested; interrupting sessions"
 )
 
 type Option func(*options)
 
 type options struct {
-	now       func() time.Time
-	build     buildinfo.Info
-	interrupt func()
+	now                   func() time.Time
+	build                 buildinfo.Info
+	interrupt             func()
+	shutdownTimeoutSource func() time.Duration
 }
 
 type Model struct {
-	subscription *hub.Subscription[telemetry.Snapshot]
-	updates      <-chan telemetry.Snapshot
-	snapshot     telemetry.Snapshot
-	hasSnapshot  bool
-	width        int
-	height       int
-	now          func() time.Time
-	build        buildinfo.Info
-	interrupt    func()
-	interrupts   int
-	shutdownNote string
-	styles       styles
+	subscription          *hub.Subscription[telemetry.Snapshot]
+	updates               <-chan telemetry.Snapshot
+	snapshot              telemetry.Snapshot
+	hasSnapshot           bool
+	width                 int
+	height                int
+	now                   func() time.Time
+	build                 buildinfo.Info
+	interrupt             func()
+	shutdownTimeoutSource func() time.Duration
+	interrupts            int
+	shutdownNote          string
+	styles                styles
 }
 
 type snapshotMsg struct {
@@ -77,13 +79,14 @@ func NewModel(ctx context.Context, snapshots *hub.Hub[telemetry.Snapshot], opts 
 	}
 
 	return Model{
-		subscription: subscription,
-		updates:      subscription.C(),
-		width:        defaultTerminalColumns,
-		now:          cfg.now,
-		build:        cfg.build,
-		interrupt:    cfg.interrupt,
-		styles:       newStyles(),
+		subscription:          subscription,
+		updates:               subscription.C(),
+		width:                 defaultTerminalColumns,
+		now:                   cfg.now,
+		build:                 cfg.build,
+		interrupt:             cfg.interrupt,
+		shutdownTimeoutSource: cfg.shutdownTimeoutSource,
+		styles:                newStyles(),
 	}, nil
 }
 
@@ -104,6 +107,12 @@ func WithBuild(build buildinfo.Info) Option {
 func WithInterruptFunc(interrupt func()) Option {
 	return func(cfg *options) {
 		cfg.interrupt = interrupt
+	}
+}
+
+func WithShutdownTimeoutSource(source func() time.Duration) Option {
+	return func(cfg *options) {
+		cfg.shutdownTimeoutSource = source
 	}
 }
 
@@ -199,8 +208,8 @@ func (m Model) renderWaiting() string {
 
 func (m Model) renderSnapshot() string {
 	snapshot := m.snapshot
-	lifecycleLabel, lifecycleStatus := formatLifecycle(snapshot.Shutdown, m.styles)
-	if m.shutdownNote != "" {
+	lifecycleLabel, lifecycleStatus := formatLifecycle(snapshot.Shutdown, m.now, m.shutdownTimeoutSource, m.styles)
+	if m.shutdownNote != "" && !snapshot.Shutdown.Draining {
 		lifecycleLabel = "Shutdown"
 		lifecycleStatus = m.styles.warn.Render(m.shutdownNote)
 	}
@@ -253,9 +262,21 @@ func (m Model) renderSnapshot() string {
 	return strings.Join(lines, "\n")
 }
 
-func formatLifecycle(shutdown telemetry.Shutdown, s styles) (string, string) {
+func formatLifecycle(shutdown telemetry.Shutdown, now func() time.Time, timeoutSource func() time.Duration, s styles) (string, string) {
 	if shutdown.Draining {
-		return "Shutdown", s.warn.Render(fmt.Sprintf("draining (%d sessions remaining)", shutdown.SessionsRemaining))
+		status := fmt.Sprintf("draining (%d sessions remaining", shutdown.SessionsRemaining)
+		if shutdown.RequestedAt != nil && timeoutSource != nil {
+			if now == nil {
+				now = time.Now
+			}
+			remaining := timeoutSource() - now().Sub(*shutdown.RequestedAt)
+			if remaining < 0 {
+				remaining = 0
+			}
+			status += ", " + formatRuntimeSeconds(remaining.Seconds()) + " until force quit"
+		}
+		status += "; press Ctrl+C again to force quit immediately)"
+		return "Shutdown", s.warn.Render(status)
 	}
 	status := strings.TrimSpace(shutdown.Status)
 	if status == "" {

--- a/internal/tui/model_test.go
+++ b/internal/tui/model_test.go
@@ -92,22 +92,25 @@ func TestModelRendersSnapshotFromHub(t *testing.T) {
 func TestModelRendersDrainingShutdown(t *testing.T) {
 	t.Parallel()
 
+	requestedAt := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
 	snapshot := testSnapshot()
 	snapshot.Shutdown = telemetry.Shutdown{
 		Status:            "draining",
 		Draining:          true,
 		SessionsRemaining: 2,
+		RequestedAt:       &requestedAt,
 	}
 	model := Model{
-		snapshot:    snapshot,
-		hasSnapshot: true,
-		width:       defaultTerminalColumns,
-		now:         time.Now,
-		styles:      newStyles(),
+		snapshot:              snapshot,
+		hasSnapshot:           true,
+		width:                 defaultTerminalColumns,
+		now:                   func() time.Time { return requestedAt.Add(15 * time.Second) },
+		shutdownTimeoutSource: func() time.Duration { return 75 * time.Second },
+		styles:                newStyles(),
 	}
 
 	view := stripANSI(model.View())
-	if !strings.Contains(view, "Shutdown: draining (2 sessions remaining)") {
+	if !strings.Contains(view, "Shutdown: draining (2 sessions remaining, 1m 0s until force quit; press Ctrl+C again to force quit immediately)") {
 		t.Fatalf("View() missing draining shutdown:\n%s", view)
 	}
 }


### PR DESCRIPTION
## Summary

- show drain blocker counts, remaining timeout, and explicit second Ctrl-C behavior in headless and terminal-dashboard output
- acquire a cross-platform runtime database lock before binding or opening SQLite, and bind the listener before goose migrations
- cover cross-process lock release, shared-database rejection, listener-before-migration ordering, and drain countdown rendering

## Root cause

The running command opened SQLite and ran goose migrations before attempting to bind the listener, and it had no cross-process guard for the runtime database. Concurrent launches could therefore migrate and write together until a later port conflict. Shutdown progress also omitted the remaining timeout, while the TUI kept a static interrupt notice over the live drain state.

Fixes #1227

## Test Plan

- `go test -race ./cmd/detent ./internal/instancelock ./internal/cli ./internal/tui -count=1`
- `GOOS=windows GOARCH=amd64 go build -o tmp/cross-build/detent-windows.exe ./cmd/detent`
- `GOOS=linux GOARCH=amd64 go build -o tmp/cross-build/detent-linux ./cmd/detent`
- `make check` (77.0% coverage; package floors passed)
