### PR TITLE
feat(scheduler): add spend progress breaker

### DIFF
--- a/README.md
+++ b/README.md
@@ -669,6 +669,7 @@ agent:
   max_concurrent_agents: 5
   max_turns: 20
   max_retry_backoff_ms: 300000
+  no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   max_concurrent_agents_by_state:
     Merging: 1
@@ -2390,6 +2391,15 @@ show cache-read efficiency when cached input is reported: cached input divided
 by input tokens. Use that value with context pressure to evaluate whether
 thread-resume behavior is preserving useful context without repeatedly filling
 the window.
+
+`agent.no_progress_spend_limit_usd` defaults to `3`, below the default
+per-issue budget backstop. Detent sums persisted session cost for each issue
+after its latest accepted lane, pull-request, or
+recognized PR-signature change. When spend exceeds the limit, Detent parks the
+issue in `Blocked`, recommends narrowing or splitting the task, and requires
+the next worker to explain the missing progress signal in its first Workpad
+update before using tools. Set the value to `0` to disable the breaker and its
+history/spend lookups.
 
 `agent.resume_orphaned_sessions` defaults to `true`. After an unclean Detent
 restart, active sessions whose provider identity was journaled are preflighted

--- a/db/queries/store.sql
+++ b/db/queries/store.sql
@@ -524,6 +524,20 @@ WHERE finished_at >= sqlc.arg(from_time)
   AND finished_at < sqlc.arg(to_time)
 ORDER BY finished_at, id;
 
+-- name: IssueSpendSince :one
+SELECT
+  CAST(COALESCE(SUM(cost_usd), 0) AS REAL) AS cost_usd,
+  CAST(COUNT(*) AS INTEGER) AS sessions,
+  CAST(COALESCE(MIN(finished_at), '') AS TEXT) AS first_session_at,
+  CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at
+FROM usage_events
+WHERE project_id = sqlc.arg(project_id)
+  AND finished_at > sqlc.arg(since)
+  AND (
+    (sqlc.arg(issue_id) != '' AND COALESCE(issue_id, '') = sqlc.arg(issue_id))
+    OR (sqlc.arg(identifier) != '' AND COALESCE(identifier, '') = sqlc.arg(identifier))
+  );
+
 -- name: ListFairShareUsage :many
 SELECT
   project_id,

--- a/docs/templates/WORKFLOW.github_local.md
+++ b/docs/templates/WORKFLOW.github_local.md
@@ -64,6 +64,7 @@ agent:
   #   merge: high
   max_turns: 20
   max_retry_backoff_ms: 300000
+  no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the

--- a/docs/templates/WORKFLOW.issue_field.md
+++ b/docs/templates/WORKFLOW.issue_field.md
@@ -65,6 +65,7 @@ agent:
   #   merge: high
   max_turns: 20
   max_retry_backoff_ms: 300000
+  no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the

--- a/docs/templates/WORKFLOW.label.md
+++ b/docs/templates/WORKFLOW.label.md
@@ -65,6 +65,7 @@ agent:
   #   merge: high
   max_turns: 20
   max_retry_backoff_ms: 300000
+  no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the

--- a/docs/templates/WORKFLOW.non_code_artifact.md
+++ b/docs/templates/WORKFLOW.non_code_artifact.md
@@ -30,6 +30,7 @@ deliverable:
 
 agent:
   resume_orphaned_sessions: true
+  no_progress_spend_limit_usd: 3
   # Optional per-role reasoning defaults. Unset roles retain backend behavior.
   # effort:
   #   merge: high

--- a/docs/templates/WORKFLOW.project_v2.md
+++ b/docs/templates/WORKFLOW.project_v2.md
@@ -64,6 +64,7 @@ agent:
   #   merge: high
   max_turns: 20
   max_retry_backoff_ms: 300000
+  no_progress_spend_limit_usd: 3
   resume_orphaned_sessions: true
   # Per-session ceiling on total_tokens. total_tokens counts input + output +
   # cache-created + cache-read tokens, accumulated across every turn of the

--- a/internal/cli/boot.go
+++ b/internal/cli/boot.go
@@ -222,6 +222,7 @@ func startRunning(ctx context.Context, cfg BootConfig) error {
 		WorkflowMetrics:    runtimeStore,
 		Efficiency:         runtimeStore,
 		WorkAttempts:       runtimeStore,
+		ProgressSpend:      runtimeStore,
 		AgentResume:        runtimeStore,
 		ValidatorMemo:      runtimeStore,
 		RetroStore:         runtimeStore,

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -805,6 +805,7 @@ func doctorWorkflowDetail(path string, project globalconfig.Project, cfg workflo
 	details = append(details, doctorReviewFlowConfigDetail(cfg))
 	details = append(details, doctorWorkflowModelChoiceDetail(cfg))
 	details = append(details, doctorWorkflowSessionGuardDetail(cfg))
+	details = append(details, doctorWorkflowSpendBreakerDetail(cfg))
 	details = append(details, fmt.Sprintf("orphan-recovery=resume_orphaned_sessions=%t, experimental_thread_resume=%t", cfg.Agent.ResumeOrphanedSessions, cfg.Agent.ExperimentalThreadResume))
 	details = append(details, fmt.Sprintf("prioritize-unblockers=%t", cfg.Agent.PrioritizeUnblockers))
 	details = append(details, doctorAuthorizationDetail(project, cfg))
@@ -833,6 +834,14 @@ func doctorWorkflowSessionGuardDetail(cfg workflowconfig.Config) string {
 		multiplier = strconv.FormatFloat(cfg.Agent.MaxSessionContextMultiplier, 'g', -1, 64)
 	}
 	return fmt.Sprintf("session-guard=max_session_tokens=%s, max_session_context_multiplier=%s", tokens, multiplier)
+}
+
+func doctorWorkflowSpendBreakerDetail(cfg workflowconfig.Config) string {
+	limit := "disabled"
+	if cfg.Agent.NoProgressSpendLimitUSD > 0 {
+		limit = strconv.FormatFloat(cfg.Agent.NoProgressSpendLimitUSD, 'f', 2, 64)
+	}
+	return "spend-breaker=no_progress_spend_limit_usd=" + limit
 }
 
 func doctorWorkflowFindingDetails(findings []doctorWorkflowOptimizationFinding) string {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -3511,6 +3511,29 @@ func TestDoctorSQLitePingErrorWrapsPingAndCloseErrors(t *testing.T) {
 	}
 }
 
+func TestDoctorWorkflowSpendBreakerDetail(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		limit float64
+		want  string
+	}{
+		{name: "disabled", want: "spend-breaker=no_progress_spend_limit_usd=disabled"},
+		{name: "configured", limit: 7.5, want: "spend-breaker=no_progress_spend_limit_usd=7.50"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			cfg := workflowconfig.Config{}
+			cfg.Agent.NoProgressSpendLimitUSD = tt.limit
+			if got := doctorWorkflowSpendBreakerDetail(cfg); got != tt.want {
+				t.Fatalf("doctorWorkflowSpendBreakerDetail() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckDoctorServerPort(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,6 +52,7 @@ const (
 	DefaultKnowledgeMaxBytes                 = 64 * 1024
 	DefaultReworkLimit                       = 3
 	DefaultNoProgressLimit                   = 3
+	DefaultNoProgressSpendLimitUSD           = 3.0
 	DefaultAutoPromoteGateWaitTimeoutSeconds = 3600
 
 	DefaultPollingIntervalMS      = 120000
@@ -222,6 +223,7 @@ type Agent struct {
 	MaxConcurrentAgents          int                          `yaml:"max_concurrent_agents"`
 	MaxTurns                     int                          `yaml:"max_turns"`
 	MaxRetryBackoffMS            int                          `yaml:"max_retry_backoff_ms"`
+	NoProgressSpendLimitUSD      float64                      `yaml:"no_progress_spend_limit_usd"`
 	MaxSessionTokens             int64                        `yaml:"max_session_tokens"`
 	MaxSessionContextMultiplier  float64                      `yaml:"max_session_context_multiplier"`
 	MaxSessionTokenOverrideLabel string                       `yaml:"max_session_token_override_label"`
@@ -957,6 +959,7 @@ func Default() Config {
 			MaxConcurrentAgents:        10,
 			MaxTurns:                   20,
 			MaxRetryBackoffMS:          300000,
+			NoProgressSpendLimitUSD:    DefaultNoProgressSpendLimitUSD,
 			ResumeOrphanedSessions:     true,
 			Shutdown:                   Shutdown{DrainTimeoutMS: DefaultShutdownDrainTimeoutMS},
 			MaxConcurrentAgentsByState: map[string]int{},
@@ -1514,6 +1517,9 @@ func (a *Agent) validate(prefix string, problems *[]string) {
 	}
 	if a.MaxSessionContextMultiplier < 0 {
 		*problems = append(*problems, prefix+".max_session_context_multiplier must be greater than or equal to 0")
+	}
+	if a.NoProgressSpendLimitUSD < 0 {
+		*problems = append(*problems, prefix+".no_progress_spend_limit_usd must be greater than or equal to 0")
 	}
 	a.Effort.validate(prefix+".effort", problems)
 	a.Shutdown.validate(prefix+".shutdown", problems)

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -40,6 +40,43 @@ func TestParseWorkflowFollowups(t *testing.T) {
 	}
 }
 
+func TestNoProgressSpendLimitConfiguration(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		raw     string
+		want    float64
+		wantErr string
+	}{
+		{name: "default enabled", raw: "---\ntracker:\n  kind: memory\n---\nPrompt\n", want: DefaultNoProgressSpendLimitUSD},
+		{name: "explicitly disabled", raw: "---\ntracker:\n  kind: memory\nagent:\n  no_progress_spend_limit_usd: 0\n---\nPrompt\n", want: 0},
+		{name: "custom threshold", raw: "---\ntracker:\n  kind: memory\nagent:\n  no_progress_spend_limit_usd: 8.5\n---\nPrompt\n", want: 8.5},
+		{name: "negative rejected", raw: "---\ntracker:\n  kind: memory\nagent:\n  no_progress_spend_limit_usd: -1\n---\nPrompt\n", wantErr: "agent.no_progress_spend_limit_usd must be greater than or equal to 0"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			workflow, err := ParseWorkflow([]byte(tt.raw))
+			if tt.wantErr != "" {
+				if err == nil {
+					err = workflow.Config.Validate()
+				}
+				if err == nil || !strings.Contains(err.Error(), tt.wantErr) {
+					t.Fatalf("configuration error = %v, want %q", err, tt.wantErr)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if workflow.Config.Agent.NoProgressSpendLimitUSD != tt.want {
+				t.Fatalf("NoProgressSpendLimitUSD = %g, want %g", workflow.Config.Agent.NoProgressSpendLimitUSD, tt.want)
+			}
+		})
+	}
+}
+
 func TestParseWorkflowFrontmatter(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/config.go
+++ b/internal/orchestrator/config.go
@@ -27,6 +27,7 @@ func ConfigFromWorkflow(cfg workflowconfig.Config) Config {
 		ResumeOrphanedSessions:     cfg.Agent.ResumeOrphanedSessions,
 		MaxConcurrentAgentsPerHost: positiveIntValue(cfg.Worker.MaxConcurrentAgentsPerHost),
 		MaxRetryBackoff:            durationFromMillis(cfg.Agent.MaxRetryBackoffMS),
+		NoProgressSpendLimitUSD:    cfg.Agent.NoProgressSpendLimitUSD,
 		Claiming: ClaimingConfig{
 			Enabled:           cfg.Tracker.Claims.Enabled,
 			OwnershipMode:     identity.OwnershipMode,

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -271,6 +271,12 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	}
 
 	issue = cloneIssue(claimedIssue)
+	priorAttempt := state.PriorAttempts[issue.ID]
+	if !priorAttemptPresent(priorAttempt) {
+		if breakerAttempt, ok := o.spendProgressPriorAttempt(ctx, issue); ok {
+			priorAttempt = breakerAttempt
+		}
+	}
 	workAttemptID, ok := o.startDurableWorkAttempt(ctx, state, issue, attempt, now, workerHost, runMode)
 	if !ok {
 		o.releaseGlobalDispatchSlot(globalSlot)
@@ -359,7 +365,7 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 		Mode:                runMode,
 		DispatchSourceState: dispatchSourceState,
 		DispatchTargetState: dispatchTargetState,
-		PriorAttempt:        state.PriorAttempts[issue.ID],
+		PriorAttempt:        priorAttempt,
 		StartedAt:           now,
 		WorkerHost:          workerHost,
 		SelectorContext:     o.selectorContext(),
@@ -370,6 +376,9 @@ func (o *Orchestrator) dispatchIssueWithOutcome(
 	if retryQueued {
 		request.RetryMode = queuedRetry.RetryMode
 		request.ResumeState = queuedRetry.ResumeState
+	}
+	if priorAttempt.ExplainBeforeRetry {
+		delete(state.PriorAttempts, issue.ID)
 	}
 	o.logMergeWorkerAttempt(issue, attempt, workerHost)
 	o.logWorkerLifecycle(issue, "worker_attempt_started",

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -558,8 +558,10 @@ func (c *implementProgressConnector) HydratePullRequest(context.Context, connect
 }
 
 type implementProgressAttemptStore struct {
-	history     []store.WorkAttempt
-	completions []store.WorkAttemptCompletion
+	history      []store.WorkAttempt
+	completions  []store.WorkAttemptCompletion
+	historyCalls int
+	queries      []store.WorkAttemptHistoryQuery
 }
 
 func (s *implementProgressAttemptStore) StartWorkAttempt(context.Context, store.WorkAttemptStart) (int64, error) {
@@ -583,7 +585,9 @@ func (s *implementProgressAttemptStore) ListActiveWorkAttempts(context.Context, 
 	return nil, nil
 }
 
-func (s *implementProgressAttemptStore) ListRecentTerminalWorkAttempts(context.Context, store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
+func (s *implementProgressAttemptStore) ListRecentTerminalWorkAttempts(_ context.Context, query store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
+	s.historyCalls++
+	s.queries = append(s.queries, query)
 	return append([]store.WorkAttempt(nil), s.history...), nil
 }
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -66,6 +66,7 @@ type Config struct {
 	ResumeOrphanedSessions        bool
 	MaxConcurrentAgentsPerHost    int
 	MaxRetryBackoff               time.Duration
+	NoProgressSpendLimitUSD       float64
 	Project                       scheduler.ProjectCandidate
 	Claiming                      ClaimingConfig
 	AutoPromote                   AutoPromoteConfig
@@ -111,6 +112,7 @@ type Dependencies struct {
 	Efficiency         efficiency.Recorder
 	LifecycleExporter  efficiency.LifecycleExporter
 	WorkAttempts       store.WorkAttemptStore
+	ProgressSpend      store.ProgressSpendStore
 	AgentResume        store.AgentResumeStore
 	OrphanSessions     store.OrphanSessionStore
 	ValidatorMemo      store.ValidatorMemoStore
@@ -144,6 +146,7 @@ type Orchestrator struct {
 	efficiency              efficiency.Recorder
 	lifecycleExporter       efficiency.LifecycleExporter
 	workAttempts            store.WorkAttemptStore
+	progressSpend           store.ProgressSpendStore
 	agentResume             store.AgentResumeStore
 	orphanSessions          store.OrphanSessionStore
 	supervisor              *runpkg.Supervisor
@@ -278,6 +281,12 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 			agentResume = candidate
 		}
 	}
+	progressSpend := deps.ProgressSpend
+	if progressSpend == nil {
+		if candidate, ok := deps.WorkflowMetrics.(store.ProgressSpendStore); ok {
+			progressSpend = candidate
+		}
+	}
 
 	supervisor, err := runpkg.NewSupervisor(runner, runpkg.SupervisorConfig{
 		MaxRetryBackoff:       cfg.MaxRetryBackoff,
@@ -296,6 +305,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		efficiency:              deps.Efficiency,
 		lifecycleExporter:       deps.LifecycleExporter,
 		workAttempts:            deps.WorkAttempts,
+		progressSpend:           progressSpend,
 		agentResume:             agentResume,
 		orphanSessions:          orphanSessions,
 		supervisor:              supervisor,

--- a/internal/orchestrator/run_completion.go
+++ b/internal/orchestrator/run_completion.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/digitaldrywood/detent/internal/backendcapacity"
+	"github.com/digitaldrywood/detent/internal/budget"
 	"github.com/digitaldrywood/detent/internal/connector"
 	"github.com/digitaldrywood/detent/internal/efficiency"
 	"github.com/digitaldrywood/detent/internal/gate"
@@ -143,7 +144,27 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 			"retry_delay_seconds", int64(event.RetryDelay/time.Second),
 			"error", event.Err,
 		)
-		o.completeDurableWorkAttempt(ctx, state, running, event.CompletedAt, terminalStateForRun(event.Err, event.Result.FinalState), workAttemptErrorRunner, event.Err.Error(), "failed", "worker failed")
+		spendProgress := spendProgressDecision{}
+		if !mergeWorkerIssue(running.Issue) {
+			accepted, acceptedReason := dispatchAcceptedStateChange(running)
+			spendProgress = o.evaluateSpendProgress(ctx, running, event.CompletedAt, accepted, acceptedReason)
+		}
+		terminalState := terminalStateForRun(event.Err, event.Result.FinalState)
+		errorClass := workAttemptErrorRunner
+		errorMessage := event.Err.Error()
+		phase := "failed"
+		statusMessage := "worker failed"
+		if spendProgress.Block {
+			terminalState = store.WorkAttemptTerminalNoProgress
+			errorClass = spendProgressReason
+			errorMessage = fmt.Sprintf("spent %s since the last accepted state change; configured limit %s", budget.FormatUSD(spendProgress.Spend.CostUSD), budget.FormatUSD(spendProgress.LimitUSD))
+			phase = "no_progress"
+			statusMessage = "spend-since-progress circuit breaker tripped"
+		}
+		o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, spendProgressMetadata(spendProgress))
+		if spendProgress.Block && o.blockSpendProgress(ctx, state, running.Issue, spendProgress, event.CompletedAt) {
+			return
+		}
 		if mergeWorkerIssue(running.Issue) {
 			o.logMergeWorkerFailure(running.Issue, "runner_failed", event.Err)
 			o.recordMergeFailed(state, running.Issue, event.CompletedAt, "runner_failed", event.Err)
@@ -233,6 +254,8 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		running.DiffStats = event.Result.DiffStats
 	}
 	progress := o.evaluateImplementCompletionProgress(ctx, running, finalState, event.Result.PullRequestUpdated)
+	accepted, acceptedReason := implementAcceptedStateChange(running, progress)
+	spendProgress := o.evaluateSpendProgress(ctx, running, event.CompletedAt, accepted, acceptedReason)
 	if terminalState != store.WorkAttemptTerminalSuccess {
 		progress.Outcome = terminalState
 	}
@@ -244,7 +267,15 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 		phase = "no_progress"
 		statusMessage = "worker completed without PR progress"
 	}
-	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, implementCompletionProgressMetadata(progress))
+	if spendProgress.Block {
+		terminalState = store.WorkAttemptTerminalNoProgress
+		progress.Outcome = store.WorkAttemptTerminalNoProgress
+		errorClass = spendProgressReason
+		errorMessage = fmt.Sprintf("spent %s since the last accepted state change; configured limit %s", budget.FormatUSD(spendProgress.Spend.CostUSD), budget.FormatUSD(spendProgress.LimitUSD))
+		phase = "no_progress"
+		statusMessage = "spend-since-progress circuit breaker tripped"
+	}
+	o.completeDurableWorkAttemptWithMetadata(ctx, state, running, event.CompletedAt, terminalState, errorClass, errorMessage, phase, statusMessage, mergeWorkAttemptMetadata(implementCompletionProgressMetadata(progress), spendProgressMetadata(spendProgress)))
 
 	state.Completed[event.IssueID] = Completed{
 		Issue:           cloneIssue(running.Issue),
@@ -276,6 +307,9 @@ func (o *Orchestrator) handleRunResult(ctx context.Context, state *State, event 
 	if terminalState == store.WorkAttemptTerminalSuccess &&
 		autoPromoteActiveGatePendingIssue(running.Issue, state, o.cfg, o.cfg.AutoPromote) {
 		o.finishCompletedGateWaitRun(ctx, state, running.Issue)
+		return
+	}
+	if spendProgress.Block && o.blockSpendProgress(ctx, state, running.Issue, spendProgress, event.CompletedAt) {
 		return
 	}
 	if terminalState == store.WorkAttemptTerminalNoProgress && progress.Block {

--- a/internal/orchestrator/spend_progress.go
+++ b/internal/orchestrator/spend_progress.go
@@ -1,0 +1,362 @@
+package orchestrator
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/budget"
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/telemetry"
+)
+
+const (
+	spendProgressMetadataKey = "spend_since_progress_breaker"
+	spendProgressReason      = "spend_since_progress_circuit_breaker"
+	spendProgressHistorySize = 200
+)
+
+type spendProgressDecision struct {
+	Enabled             bool
+	AcceptedStateChange bool
+	AcceptedReason      string
+	Since               time.Time
+	Spend               store.IssueSpendSince
+	LimitUSD            float64
+	Block               bool
+	Warning             string
+}
+
+type spendProgressRecord struct {
+	AcceptedStateChange bool    `json:"accepted_state_change,omitempty"`
+	AcceptedReason      string  `json:"accepted_reason,omitempty"`
+	Since               string  `json:"since,omitempty"`
+	SpendUSD            float64 `json:"spend_usd,omitempty"`
+	Sessions            int64   `json:"sessions,omitempty"`
+	FirstSessionAt      string  `json:"first_session_at,omitempty"`
+	LastSessionAt       string  `json:"last_session_at,omitempty"`
+	LimitUSD            float64 `json:"limit_usd,omitempty"`
+	BlockReason         string  `json:"block_reason,omitempty"`
+	Warning             string  `json:"warning,omitempty"`
+}
+
+func (o *Orchestrator) evaluateSpendProgress(
+	ctx context.Context,
+	running Running,
+	completedAt time.Time,
+	accepted bool,
+	acceptedReason string,
+) spendProgressDecision {
+	decision := spendProgressDecision{
+		Enabled:             o != nil && o.cfg.NoProgressSpendLimitUSD > 0,
+		AcceptedStateChange: accepted,
+		AcceptedReason:      strings.TrimSpace(acceptedReason),
+	}
+	if !decision.Enabled {
+		return decision
+	}
+	decision.LimitUSD = o.cfg.NoProgressSpendLimitUSD
+	if accepted {
+		decision.Since = completedAt
+		return decision
+	}
+	if o.progressSpend == nil {
+		decision.Warning = "progress spend store unavailable"
+		o.warnSpendProgress(running.Issue, decision.Warning, nil)
+		return decision
+	}
+
+	attempts, err := o.recentSpendProgressAttempts(ctx, running.Issue)
+	if err != nil {
+		decision.Warning = err.Error()
+		o.warnSpendProgress(running.Issue, "work attempt history lookup failed", err)
+		return decision
+	}
+	decision.Since = spendProgressBaseline(running.Issue, attempts)
+	if decision.Since.IsZero() {
+		decision.Since = time.Unix(0, 0).UTC()
+	}
+	spend, err := o.progressSpend.IssueSpendSince(ctx, store.IssueSpendSinceQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(running.Issue.ID),
+		Identifier: strings.TrimSpace(running.Issue.Identifier),
+		Since:      decision.Since,
+	})
+	if err != nil {
+		decision.Warning = err.Error()
+		o.warnSpendProgress(running.Issue, "spend lookup failed", err)
+		return decision
+	}
+	decision.Spend = spend
+	decision.Block = spend.CostUSD > decision.LimitUSD
+	return decision
+}
+
+func (o *Orchestrator) recentSpendProgressAttempts(ctx context.Context, issue connector.Issue) ([]store.WorkAttempt, error) {
+	if o == nil || o.workAttempts == nil {
+		return nil, nil
+	}
+	return o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		Limit:      spendProgressHistorySize,
+	})
+}
+
+func spendProgressBaseline(issue connector.Issue, attempts []store.WorkAttempt) time.Time {
+	baseline := time.Time{}
+	for _, candidate := range []*time.Time{issue.CreatedAt, issue.StageUpdatedAt} {
+		if candidate != nil && candidate.After(baseline) {
+			baseline = candidate.UTC()
+		}
+	}
+	for _, attempt := range attempts {
+		if !spendProgressAttemptAccepted(attempt) || !attempt.CompletedAt.After(baseline) {
+			continue
+		}
+		baseline = attempt.CompletedAt.UTC()
+	}
+	return baseline
+}
+
+func spendProgressAttemptAccepted(attempt store.WorkAttempt) bool {
+	if record, ok := spendProgressRecordFromAttempt(attempt); ok && record.AcceptedStateChange {
+		return true
+	}
+	record, ok := implementProgressRecordFromAttempt(attempt)
+	if !ok {
+		return false
+	}
+	switch strings.TrimSpace(record.Reason) {
+	case "pull_request_created_or_updated", "signature_changed":
+		return true
+	default:
+		return false
+	}
+}
+
+func spendProgressRecordFromAttempt(attempt store.WorkAttempt) (spendProgressRecord, bool) {
+	var root struct {
+		SpendProgress spendProgressRecord `json:"spend_since_progress_breaker"`
+	}
+	if err := json.Unmarshal([]byte(strings.TrimSpace(attempt.WorkerMetadataJSON)), &root); err != nil {
+		return spendProgressRecord{}, false
+	}
+	record := root.SpendProgress
+	if !record.AcceptedStateChange && record.LimitUSD <= 0 && strings.TrimSpace(record.BlockReason) == "" {
+		return spendProgressRecord{}, false
+	}
+	return record, true
+}
+
+func spendProgressMetadata(decision spendProgressDecision) map[string]any {
+	if !decision.Enabled {
+		return nil
+	}
+	record := spendProgressRecord{
+		AcceptedStateChange: decision.AcceptedStateChange,
+		AcceptedReason:      decision.AcceptedReason,
+		SpendUSD:            decision.Spend.CostUSD,
+		Sessions:            decision.Spend.Sessions,
+		LimitUSD:            decision.LimitUSD,
+		Warning:             strings.TrimSpace(decision.Warning),
+	}
+	if !decision.Since.IsZero() {
+		record.Since = decision.Since.UTC().Format(time.RFC3339Nano)
+	}
+	if !decision.Spend.FirstSessionAt.IsZero() {
+		record.FirstSessionAt = decision.Spend.FirstSessionAt.UTC().Format(time.RFC3339Nano)
+	}
+	if !decision.Spend.LastSessionAt.IsZero() {
+		record.LastSessionAt = decision.Spend.LastSessionAt.UTC().Format(time.RFC3339Nano)
+	}
+	if decision.Block {
+		record.BlockReason = spendProgressReason
+	}
+	return map[string]any{spendProgressMetadataKey: record}
+}
+
+func mergeWorkAttemptMetadata(groups ...map[string]any) map[string]any {
+	var merged map[string]any
+	for _, group := range groups {
+		for key, value := range group {
+			if merged == nil {
+				merged = map[string]any{}
+			}
+			merged[key] = value
+		}
+	}
+	return merged
+}
+
+func implementAcceptedStateChange(running Running, decision implementCompletionProgressDecision) (bool, string) {
+	if accepted, reason := dispatchAcceptedStateChange(running); accepted {
+		return true, reason
+	}
+	switch strings.TrimSpace(decision.Reason) {
+	case "pull_request_created_or_updated", "signature_changed":
+		return true, decision.Reason
+	default:
+		return false, ""
+	}
+}
+
+func dispatchAcceptedStateChange(running Running) (bool, string) {
+	source := strings.TrimSpace(running.DispatchSourceState)
+	target := strings.TrimSpace(running.DispatchTargetState)
+	if source != "" && target != "" && !strings.EqualFold(source, target) {
+		return true, "lane_transition"
+	}
+	return false, ""
+}
+
+func (o *Orchestrator) blockSpendProgress(
+	ctx context.Context,
+	state *State,
+	issue connector.Issue,
+	decision spendProgressDecision,
+	blockedAt time.Time,
+) bool {
+	issue = cloneIssue(issue)
+	issueID := strings.TrimSpace(issue.ID)
+	if issueID == "" {
+		return false
+	}
+	if err := o.updateIssueStateByID(ctx, state, issueID, issue, blockedStatusState, blockedAt, spendProgressReason); err != nil {
+		if o.logger != nil {
+			o.logger.Warn("spend progress circuit breaker state transition failed", "issue_id", issueID, "identifier", issue.Identifier, "error", err)
+		}
+		return false
+	}
+	issue.State = blockedStatusState
+	stageUpdatedAt := blockedAt.UTC()
+	issue.StageUpdatedAt = &stageUpdatedAt
+	if o.connector != nil {
+		if err := o.connector.CreateComment(ctx, issueID, spendProgressComment(issue, decision)); err != nil && o.logger != nil {
+			o.logger.Warn("spend progress circuit breaker comment failed", "issue_id", issueID, "identifier", issue.Identifier, "error", err)
+		}
+	}
+	if err := o.abandonClaim(ctx, issueID); err != nil && o.logger != nil {
+		o.logger.Warn("spend progress circuit breaker claim release failed", "issue_id", issueID, "identifier", issue.Identifier, "error", err)
+	}
+	delete(state.Claimed, issueID)
+	delete(state.Retry, issueID)
+	delete(state.BudgetRefusals, issueID)
+	if state.PriorAttempts == nil {
+		state.PriorAttempts = map[string]runpkg.PriorAttempt{}
+	}
+	state.PriorAttempts[issueID] = spendProgressRetryHandoff(decision)
+	if completed, ok := state.Completed[issueID]; ok {
+		completed.Issue = issue
+		state.Completed[issueID] = completed
+	}
+	if state.Blocked == nil {
+		state.Blocked = map[string]Blocked{}
+	}
+	state.Blocked[issueID] = Blocked{
+		Issue:          issue,
+		Reason:         spendProgressReason,
+		RecoveryReason: "narrow or split the task, then identify the missing accepted progress signal before moving the issue back to Todo or Rework",
+		RecoveryTarget: "Rework",
+		BlockedAt:      blockedAt,
+		Source:         BlockedSourceProjectStatus,
+	}
+	recordStateEvent(state, telemetry.ActivityEvent{
+		At:      blockedAt,
+		Event:   "spend_since_progress_circuit_breaker_tripped",
+		Message: fmt.Sprintf("parked %s after %s without an accepted state change", issueLabel(issue), budget.FormatUSD(decision.Spend.CostUSD)),
+	})
+	if o.logger != nil {
+		o.logger.Error("spend since progress circuit breaker tripped",
+			"event", "spend_since_progress_circuit_breaker_tripped",
+			"issue_id", issueID,
+			"issue_identifier", issue.Identifier,
+			"spend_usd", decision.Spend.CostUSD,
+			"limit_usd", decision.LimitUSD,
+			"sessions", decision.Spend.Sessions,
+			"since", decision.Since,
+		)
+	}
+	return true
+}
+
+func spendProgressComment(issue connector.Issue, decision spendProgressDecision) string {
+	var b strings.Builder
+	b.WriteString("Routed this issue to Blocked because agent spend continued without an accepted state change.")
+	b.WriteString("\n\n- reason: ")
+	b.WriteString(spendProgressReason)
+	b.WriteString("\n- issue: ")
+	b.WriteString(issueLabel(issue))
+	b.WriteString("\n- spend_since_last_accepted_state_change: ")
+	b.WriteString(budget.FormatUSD(decision.Spend.CostUSD))
+	b.WriteString("\n- no_progress_spend_limit_usd: ")
+	b.WriteString(budget.FormatUSD(decision.LimitUSD))
+	b.WriteString(fmt.Sprintf("\n- sessions: %d", decision.Spend.Sessions))
+	if !decision.Since.IsZero() {
+		b.WriteString("\n- last_accepted_state_change_at: ")
+		b.WriteString(decision.Since.UTC().Format(time.RFC3339))
+	}
+	if !decision.Spend.FirstSessionAt.IsZero() && !decision.Spend.LastSessionAt.IsZero() {
+		b.WriteString("\n- observed_session_span: ")
+		b.WriteString(decision.Spend.LastSessionAt.Sub(decision.Spend.FirstSessionAt).Round(time.Second).String())
+	}
+	b.WriteString("\n\nShrink the task before retrying: split or narrow the scope so the next session can produce a concrete accepted change.")
+	b.WriteString("\n\nOn the next dispatch, the agent's first tool action must update the Workpad to explain which accepted progress signal was missing and what is concretely different before any other tool use.")
+	return b.String()
+}
+
+func spendProgressRetryHandoff(decision spendProgressDecision) runpkg.PriorAttempt {
+	return runpkg.PriorAttempt{
+		Source:                  spendProgressReason,
+		Reason:                  "spend exceeded the configured limit without an accepted state change",
+		ExplainBeforeRetry:      true,
+		MissingSignal:           "lane transition, pull request creation or merge, or a recognized PR content-signature change",
+		ObservedSpendUSD:        decision.Spend.CostUSD,
+		NoProgressSpendLimitUSD: decision.LimitUSD,
+	}
+}
+
+func (o *Orchestrator) spendProgressPriorAttempt(ctx context.Context, issue connector.Issue) (runpkg.PriorAttempt, bool) {
+	if o == nil || o.cfg.NoProgressSpendLimitUSD <= 0 || o.workAttempts == nil {
+		return runpkg.PriorAttempt{}, false
+	}
+	attempts, err := o.workAttempts.ListRecentTerminalWorkAttempts(ctx, store.WorkAttemptHistoryQuery{
+		ProjectID:  strings.TrimSpace(o.cfg.Project.ID),
+		IssueID:    strings.TrimSpace(issue.ID),
+		Identifier: strings.TrimSpace(issue.Identifier),
+		IssueURL:   strings.TrimSpace(issue.URL),
+		Limit:      1,
+	})
+	if err != nil || len(attempts) == 0 {
+		return runpkg.PriorAttempt{}, false
+	}
+	record, ok := spendProgressRecordFromAttempt(attempts[0])
+	if !ok || strings.TrimSpace(record.BlockReason) != spendProgressReason {
+		return runpkg.PriorAttempt{}, false
+	}
+	return spendProgressRetryHandoff(spendProgressDecision{
+		Spend:    store.IssueSpendSince{CostUSD: record.SpendUSD, Sessions: record.Sessions},
+		LimitUSD: record.LimitUSD,
+	}), true
+}
+
+func (o *Orchestrator) warnSpendProgress(issue connector.Issue, message string, err error) {
+	if o == nil || o.logger == nil {
+		return
+	}
+	attrs := []any{"issue_id", issue.ID, "identifier", issue.Identifier, "reason", strings.TrimSpace(message)}
+	if err != nil {
+		attrs = append(attrs, "error", err)
+	}
+	o.logger.Warn("spend since progress breaker failed open", attrs...)
+}
+
+func priorAttemptPresent(prior runpkg.PriorAttempt) bool {
+	return strings.TrimSpace(prior.Source) != "" || strings.TrimSpace(prior.Reason) != "" || prior.ExplainBeforeRetry || prior.Validator.Submitted
+}

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -1,0 +1,229 @@
+package orchestrator
+
+import (
+	"context"
+	"math"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	runpkg "github.com/digitaldrywood/detent/internal/runner"
+	"github.com/digitaldrywood/detent/internal/scheduler"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func TestEvaluateSpendProgress(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	createdAt := base.Add(-time.Hour)
+	acceptedAt := base.Add(-20 * time.Minute)
+	acceptedAttempt := store.WorkAttempt{
+		CompletedAt: acceptedAt,
+		WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+			spendProgressMetadataKey: spendProgressRecord{
+				AcceptedStateChange: true,
+				AcceptedReason:      "signature_changed",
+				LimitUSD:            5,
+			},
+		}),
+	}
+
+	tests := []struct {
+		name             string
+		limit            float64
+		spend            store.IssueSpendSince
+		history          []store.WorkAttempt
+		accepted         bool
+		acceptedReason   string
+		wantBlock        bool
+		wantSpendCalls   int
+		wantHistoryCalls int
+		wantSince        time.Time
+	}{
+		{name: "disabled avoids tracking", limit: 0, spend: store.IssueSpendSince{CostUSD: 100}, wantSpendCalls: 0, wantHistoryCalls: 0},
+		{name: "normal three retry sessions stay below default", limit: 3, spend: store.IssueSpendSince{CostUSD: 2.7, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "below threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 4.99, Sessions: 3}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "at threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 5, Sessions: 4}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "above threshold", limit: 5, spend: store.IssueSpendSince{CostUSD: 5.01, Sessions: 4}, wantBlock: true, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "July telemetry replay", limit: 5, spend: store.IssueSpendSince{CostUSD: 6.75, Sessions: 5}, wantBlock: true, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: createdAt},
+		{name: "old sessions reset after accepted change", limit: 5, spend: store.IssueSpendSince{CostUSD: 1.25, Sessions: 1}, history: []store.WorkAttempt{acceptedAttempt}, wantSpendCalls: 1, wantHistoryCalls: 1, wantSince: acceptedAt},
+		{name: "current accepted change resets without spend lookup", limit: 5, spend: store.IssueSpendSince{CostUSD: 100}, accepted: true, acceptedReason: "signature_changed", wantSpendCalls: 0, wantHistoryCalls: 0, wantSince: base},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			spend := &spendProgressStore{result: tt.spend}
+			attempts := &implementProgressAttemptStore{history: tt.history}
+			orch := &Orchestrator{
+				cfg: Config{
+					Project:                 scheduler.ProjectCandidate{ID: "detent"},
+					NoProgressSpendLimitUSD: tt.limit,
+				},
+				progressSpend: spend,
+				workAttempts:  attempts,
+			}
+			issue := connector.Issue{ID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CreatedAt: &createdAt}
+			decision := orch.evaluateSpendProgress(context.Background(), Running{Issue: issue}, base, tt.accepted, tt.acceptedReason)
+
+			if decision.Block != tt.wantBlock {
+				t.Fatalf("Block = %t, want %t", decision.Block, tt.wantBlock)
+			}
+			if spend.calls != tt.wantSpendCalls {
+				t.Fatalf("spend calls = %d, want %d", spend.calls, tt.wantSpendCalls)
+			}
+			if attempts.historyCalls != tt.wantHistoryCalls {
+				t.Fatalf("history calls = %d, want %d", attempts.historyCalls, tt.wantHistoryCalls)
+			}
+			if !decision.Since.Equal(tt.wantSince) {
+				t.Fatalf("Since = %s, want %s", decision.Since, tt.wantSince)
+			}
+			if spend.calls == 1 && !spend.query.Since.Equal(tt.wantSince) {
+				t.Fatalf("query since = %s, want %s", spend.query.Since, tt.wantSince)
+			}
+		})
+	}
+}
+
+func TestDispatchAcceptedStateChange(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		running Running
+		want    bool
+	}{
+		{name: "lane transition", running: Running{DispatchSourceState: "Todo", DispatchTargetState: "In Progress"}, want: true},
+		{name: "same lane", running: Running{DispatchSourceState: "Rework", DispatchTargetState: "Rework"}},
+		{name: "missing transition", running: Running{}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got, reason := dispatchAcceptedStateChange(tt.running)
+			if got != tt.want {
+				t.Fatalf("accepted = %t, want %t", got, tt.want)
+			}
+			if got && reason != "lane_transition" {
+				t.Fatalf("reason = %q, want lane_transition", reason)
+			}
+			if !got && reason != "" {
+				t.Fatalf("reason = %q, want empty", reason)
+			}
+		})
+	}
+}
+
+func TestHandleRunResultTripsSpendProgressIndependentlyOfContentDetector(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
+	createdAt := base.Add(-30 * time.Minute)
+	issue := implementProgressIssueWithoutPR()
+	issue.CreatedAt = &createdAt
+	tracker := &implementProgressConnector{}
+	attempts := &implementProgressAttemptStore{}
+	cfg := normalizeConfig(Config{
+		Project:                 scheduler.ProjectCandidate{ID: "gopher-ai"},
+		NoProgressSpendLimitUSD: 5,
+		AutoPromote:             AutoPromoteConfig{NoProgressLimit: 0},
+		ActiveStates:            []string{"Todo", "In Progress", "Rework"},
+		ObservedStates:          []string{"Blocked"},
+		TerminalStates:          []string{"Done"},
+	})
+	orch := &Orchestrator{
+		cfg:          cfg,
+		connector:    tracker,
+		workAttempts: attempts,
+		progressSpend: &spendProgressStore{result: store.IssueSpendSince{
+			CostUSD:        6.75,
+			Sessions:       5,
+			FirstSessionAt: base.Add(-14 * time.Minute),
+			LastSessionAt:  base,
+		}},
+	}
+	state := newState(cfg)
+	running := Running{
+		Issue:         issue,
+		Attempt:       5,
+		WorkAttemptID: 42,
+		Mode:          runpkg.RunModeImplement,
+		StartedAt:     base.Add(-2 * time.Minute),
+		DiffStats:     DiffStats{FilesChanged: 2, AddedLines: 10, RemovedLines: 3, Status: "dirty"},
+	}
+	state.Running[issue.ID] = running
+	state.Claimed[issue.ID] = Claimed{Issue: issue, ClaimedAt: running.StartedAt}
+
+	orch.handleRunResult(context.Background(), &state, runpkg.Completion{
+		IssueID:     issue.ID,
+		CompletedAt: base,
+		Request:     runpkg.RunRequest{Mode: runpkg.RunModeImplement},
+		Result: runpkg.RunResult{
+			FinalState: runpkg.FinalStateCompleted,
+			DiffStats:  running.DiffStats,
+		},
+	})
+
+	blocked, ok := state.Blocked[issue.ID]
+	if !ok || blocked.Reason != spendProgressReason {
+		t.Fatalf("Blocked[%q] = %#v, want spend breaker", issue.ID, blocked)
+	}
+	if len(tracker.comments) != 1 {
+		t.Fatalf("comments = %#v, want one", tracker.comments)
+	}
+	for _, want := range []string{"$6.75", "$5.00", "Shrink the task", "first tool action"} {
+		if !strings.Contains(tracker.comments[0].body, want) {
+			t.Fatalf("comment missing %q:\n%s", want, tracker.comments[0].body)
+		}
+	}
+	if len(attempts.completions) != 1 {
+		t.Fatalf("completions = %#v, want one", attempts.completions)
+	}
+	completion := attempts.completions[0]
+	if completion.TerminalState != store.WorkAttemptTerminalNoProgress || completion.ErrorClass != spendProgressReason {
+		t.Fatalf("completion = %#v, want spend no-progress terminal", completion)
+	}
+	record, ok := spendProgressRecordFromAttempt(store.WorkAttempt{WorkerMetadataJSON: completion.WorkerMetadataJSON})
+	if !ok || record.BlockReason != spendProgressReason || math.Abs(record.SpendUSD-6.75) > 0.000001 {
+		t.Fatalf("spend metadata = %#v, ok=%t", record, ok)
+	}
+	if !state.PriorAttempts[issue.ID].ExplainBeforeRetry {
+		t.Fatalf("PriorAttempts[%q] = %#v, want explain-before-retry", issue.ID, state.PriorAttempts[issue.ID])
+	}
+}
+
+func TestSpendProgressPriorAttemptRestoresExplainBeforeRetry(t *testing.T) {
+	t.Parallel()
+
+	attempt := store.WorkAttempt{WorkerMetadataJSON: marshalWorkAttemptJSON(map[string]any{
+		spendProgressMetadataKey: spendProgressRecord{
+			SpendUSD:    7.25,
+			Sessions:    6,
+			LimitUSD:    5,
+			BlockReason: spendProgressReason,
+		},
+	})}
+	orch := &Orchestrator{
+		cfg:          Config{Project: scheduler.ProjectCandidate{ID: "detent"}, NoProgressSpendLimitUSD: 5},
+		workAttempts: &implementProgressAttemptStore{history: []store.WorkAttempt{attempt}},
+	}
+	prior, ok := orch.spendProgressPriorAttempt(context.Background(), connector.Issue{ID: "issue-1"})
+	if !ok || !prior.ExplainBeforeRetry || prior.ObservedSpendUSD != 7.25 || prior.NoProgressSpendLimitUSD != 5 {
+		t.Fatalf("prior = %#v, ok=%t", prior, ok)
+	}
+}
+
+type spendProgressStore struct {
+	result store.IssueSpendSince
+	query  store.IssueSpendSinceQuery
+	calls  int
+}
+
+func (s *spendProgressStore) IssueSpendSince(_ context.Context, query store.IssueSpendSinceQuery) (store.IssueSpendSince, error) {
+	s.calls++
+	s.query = query
+	return s.result, nil
+}

--- a/internal/project/project.go
+++ b/internal/project/project.go
@@ -96,6 +96,7 @@ type Dependencies struct {
 	Efficiency             efficiency.Recorder
 	LifecycleExporter      efficiency.LifecycleExporter
 	WorkAttempts           store.WorkAttemptStore
+	ProgressSpend          store.ProgressSpendStore
 	AgentResume            store.AgentResumeStore
 	ValidatorMemo          store.ValidatorMemoStore
 	Activity               *activity.Broker
@@ -235,6 +236,7 @@ func New(cfg Config, deps Dependencies) (*Project, error) {
 		Efficiency:         deps.Efficiency,
 		LifecycleExporter:  lifecycleExporter,
 		WorkAttempts:       deps.WorkAttempts,
+		ProgressSpend:      deps.ProgressSpend,
 		AgentResume:        deps.AgentResume,
 		ValidatorMemo:      deps.ValidatorMemo,
 		Activity:           deps.Activity,

--- a/internal/retro/detector.go
+++ b/internal/retro/detector.go
@@ -30,6 +30,7 @@ const (
 	PatternInvalidWorkpadStatus   = "invalid_workpad_status"
 	PatternSlowCapacityRecovery   = "slow_capacity_recovery"
 	PatternFallbackOrphanRecovery = "fallback_orphan_recovery"
+	PatternSpendSinceProgressTrip = "spend_since_progress_trip"
 )
 
 type Snapshot struct {
@@ -133,6 +134,7 @@ func Detect(snapshot Snapshot, options DetectorOptions) []Finding {
 	}
 	appendResult(detectCompletedRedispatch(snapshot.Attempts))
 	findings = append(findings, detectSystemicBreakers(snapshot.Attempts)...)
+	appendResult(detectSpendSinceProgressTrips(snapshot.Attempts, snapshot.Sessions))
 	appendResult(detectCeilingThenSuccess(snapshot.Attempts, snapshot.Sessions))
 	appendResult(detectReceiptBaseline(snapshot.UsageEvents, options.ReceiptBaselineMultiple))
 	appendResult(detectGateWaitTimeouts(snapshot.Attempts, snapshot.PhaseEvents))
@@ -149,6 +151,43 @@ func Detect(snapshot Snapshot, options DetectorOptions) []Finding {
 		return findings[i].Pattern < findings[j].Pattern
 	})
 	return findings
+}
+
+func detectSpendSinceProgressTrips(attempts []Attempt, sessions []Session) (Finding, bool) {
+	sessionTokens := map[int64]int64{}
+	for _, session := range sessions {
+		if session.WorkAttemptID > 0 {
+			sessionTokens[session.WorkAttemptID] += session.TotalTokens
+		}
+	}
+	occurrences := []Occurrence{}
+	var tokenDelta int64
+	for _, attempt := range attempts {
+		if !strings.EqualFold(strings.TrimSpace(attempt.ErrorClass), "spend_since_progress_circuit_breaker") {
+			continue
+		}
+		tokens := sessionTokens[attempt.ID]
+		tokenDelta += tokens
+		occurrences = append(occurrences, Occurrence{
+			Issue:  attemptIssue(attempt),
+			At:     attempt.CompletedAt,
+			Tokens: tokens,
+			Detail: strings.TrimSpace(attempt.ErrorMessage),
+		})
+	}
+	return Finding{
+		Pattern:     PatternSpendSinceProgressTrip,
+		Scope:       ScopeProduct,
+		Severity:    SeverityCritical,
+		Title:       "Shrink tasks that spend without accepted progress",
+		Detail:      "Agent spend exceeded the configured limit without a lane, pull request, or recognized content-signature change.",
+		TokenDelta:  tokenDelta,
+		Occurrences: occurrences,
+		Proposal: &Proposal{
+			Path:   "agent.no_progress_spend_limit_usd",
+			Change: "Review the limit and narrow the cited task scopes before retrying them.",
+		},
+	}, len(occurrences) > 0
 }
 
 func Qualifies(finding Finding, minOccurrences int, singleOccurrenceSeverity string) bool {

--- a/internal/retro/detector_test.go
+++ b/internal/retro/detector_test.go
@@ -69,11 +69,13 @@ func TestDetectAdditionalPatterns(t *testing.T) {
 			{ID: 3, Identifier: "issue-after-capacity", StartedAt: resetAt.Add(10 * time.Minute), CompletedAt: resetAt.Add(11 * time.Minute), TerminalState: "success"},
 			{ID: 4, Identifier: "issue-gate", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", ErrorClass: "gate_wait_timeout"},
 			{ID: 5, Identifier: "issue-gate-2", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "timed_out", WaitReason: "gate wait timeout"},
+			{ID: 6, Identifier: "issue-spend", StartedAt: base, CompletedAt: base.Add(time.Minute), TerminalState: "no_progress", ErrorClass: "spend_since_progress_circuit_breaker", ErrorMessage: "spent $6.75; configured limit $5.00"},
 		},
 		Sessions: []Session{
 			{ID: 1, Identifier: "issue-orphan-a", StartedAt: base, CompletedAt: base.Add(time.Minute), OrphanRecoveryOutcome: "fresh"},
 			{ID: 2, Identifier: "issue-orphan-b", StartedAt: base.Add(time.Minute), CompletedAt: base.Add(2 * time.Minute), OrphanRecoveryOutcome: "fresh"},
 			{ID: 3, Identifier: "issue-orphan-c", StartedAt: base.Add(2 * time.Minute), CompletedAt: base.Add(3 * time.Minute), OrphanRecoveryOutcome: "fresh"},
+			{ID: 4, WorkAttemptID: 6, Identifier: "issue-spend", StartedAt: base, CompletedAt: base.Add(time.Minute), TotalTokens: 125000},
 		},
 		UsageEvents: []UsageEvent{
 			{Identifier: "issue-small-a", FinishedAt: base, TotalTokens: 100},
@@ -87,10 +89,14 @@ func TestDetectAdditionalPatterns(t *testing.T) {
 	}
 
 	patterns := findingPatterns(Detect(snapshot, DetectorOptions{}))
-	for _, want := range []string{PatternReceiptBaseline, PatternGateWaitTimeout, PatternInvalidWorkpadStatus, PatternSlowCapacityRecovery, PatternFallbackOrphanRecovery} {
+	for _, want := range []string{PatternReceiptBaseline, PatternGateWaitTimeout, PatternInvalidWorkpadStatus, PatternSlowCapacityRecovery, PatternFallbackOrphanRecovery, PatternSpendSinceProgressTrip} {
 		if !slices.Contains(patterns, want) {
 			t.Fatalf("patterns = %v, want %s", patterns, want)
 		}
+	}
+	spend := findingByPattern(t, Detect(snapshot, DetectorOptions{}), PatternSpendSinceProgressTrip)
+	if spend.Scope != ScopeProduct || spend.Severity != SeverityCritical || spend.TokenDelta != 125000 || !Qualifies(spend, 2, SeverityCritical) {
+		t.Fatalf("spend finding = %#v, want qualifying critical trip", spend)
 	}
 	orphan := findingByPattern(t, Detect(snapshot, DetectorOptions{}), PatternFallbackOrphanRecovery)
 	if len(orphan.Occurrences) != 3 || !Qualifies(orphan, 2, SeverityCritical) {

--- a/internal/runner/prompt.go
+++ b/internal/runner/prompt.go
@@ -726,6 +726,22 @@ func appendPriorAttemptBlock(prompt string, prior PriorAttempt) string {
 			}
 		}
 	}
+	if prior.ExplainBeforeRetry {
+		b.WriteString("\n\n### Explain before retry\n\n")
+		b.WriteString("Your first tool action must update the Workpad to explain what accepted progress signal was missing in the prior run and what is concretely different in this retry. Do not use any other tools or resume implementation until that diagnosis is recorded.")
+		if signal := strings.TrimSpace(prior.MissingSignal); signal != "" {
+			b.WriteString("\n\n- missing accepted signal: ")
+			b.WriteString(signal)
+		}
+		if prior.ObservedSpendUSD > 0 {
+			b.WriteString("\n- spend since last accepted state change: $")
+			b.WriteString(strconv.FormatFloat(prior.ObservedSpendUSD, 'f', 2, 64))
+		}
+		if prior.NoProgressSpendLimitUSD > 0 {
+			b.WriteString("\n- configured limit: $")
+			b.WriteString(strconv.FormatFloat(prior.NoProgressSpendLimitUSD, 'f', 2, 64))
+		}
+	}
 
 	return strings.TrimRight(prompt, " \t\r\n") + "\n\n" + strings.TrimRight(b.String(), "\n")
 }
@@ -733,6 +749,7 @@ func appendPriorAttemptBlock(prompt string, prior PriorAttempt) string {
 func priorAttemptPresent(prior PriorAttempt) bool {
 	return strings.TrimSpace(prior.Source) != "" ||
 		strings.TrimSpace(prior.Reason) != "" ||
+		prior.ExplainBeforeRetry ||
 		prior.Validator.Submitted
 }
 

--- a/internal/runner/prompt_test.go
+++ b/internal/runner/prompt_test.go
@@ -521,6 +521,36 @@ func TestBuildPromptAppendsNotesAndPriorAttempt(t *testing.T) {
 	}
 }
 
+func TestBuildPromptRequiresExplanationBeforeBreakerRetry(t *testing.T) {
+	t.Parallel()
+
+	prompt, err := BuildPrompt(config.Workflow{Prompt: "Base prompt"}, connector.Issue{
+		Identifier: "gopherguides/gopher-ai#214",
+	}, PromptOptions{PriorAttempt: PriorAttempt{
+		Source:                  "spend_since_progress_circuit_breaker",
+		Reason:                  "spend exceeded the configured limit without an accepted state change",
+		ExplainBeforeRetry:      true,
+		MissingSignal:           "lane transition or pull request signature change",
+		ObservedSpendUSD:        6.75,
+		NoProgressSpendLimitUSD: 5,
+	}})
+	if err != nil {
+		t.Fatalf("BuildPrompt() error = %v", err)
+	}
+	for _, want := range []string{
+		"### Explain before retry",
+		"first tool action must update the Workpad",
+		"Do not use any other tools",
+		"lane transition or pull request signature change",
+		"spend since last accepted state change: $6.75",
+		"configured limit: $5.00",
+	} {
+		if !strings.Contains(prompt, want) {
+			t.Fatalf("prompt missing %q:\n%s", want, prompt)
+		}
+	}
+}
+
 func TestBuildPromptRendersGateAssignsAndInstructions(t *testing.T) {
 	t.Parallel()
 

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -323,9 +323,13 @@ type TokenTotals struct {
 }
 
 type PriorAttempt struct {
-	Source    string
-	Reason    string
-	Validator gate.ValidatorResult
+	Source                  string
+	Reason                  string
+	ExplainBeforeRetry      bool
+	MissingSignal           string
+	ObservedSpendUSD        float64
+	NoProgressSpendLimitUSD float64
+	Validator               gate.ValidatorResult
 }
 
 type FakeRunner struct{}

--- a/internal/store/sqlc/store.sql.go
+++ b/internal/store/sqlc/store.sql.go
@@ -1766,6 +1766,52 @@ func (q *Queries) GetWorkAttempt(ctx context.Context, id int64) (WorkAttempt, er
 	return i, err
 }
 
+const issueSpendSince = `-- name: IssueSpendSince :one
+SELECT
+  CAST(COALESCE(SUM(cost_usd), 0) AS REAL) AS cost_usd,
+  CAST(COUNT(*) AS INTEGER) AS sessions,
+  CAST(COALESCE(MIN(finished_at), '') AS TEXT) AS first_session_at,
+  CAST(COALESCE(MAX(finished_at), '') AS TEXT) AS last_session_at
+FROM usage_events
+WHERE project_id = ?1
+  AND finished_at > ?2
+  AND (
+    (?3 != '' AND COALESCE(issue_id, '') = ?3)
+    OR (?4 != '' AND COALESCE(identifier, '') = ?4)
+  )
+`
+
+type IssueSpendSinceParams struct {
+	ProjectID  string      `json:"project_id"`
+	Since      string      `json:"since"`
+	IssueID    interface{} `json:"issue_id"`
+	Identifier interface{} `json:"identifier"`
+}
+
+type IssueSpendSinceRow struct {
+	CostUsd        float64 `json:"cost_usd"`
+	Sessions       int64   `json:"sessions"`
+	FirstSessionAt string  `json:"first_session_at"`
+	LastSessionAt  string  `json:"last_session_at"`
+}
+
+func (q *Queries) IssueSpendSince(ctx context.Context, arg IssueSpendSinceParams) (IssueSpendSinceRow, error) {
+	row := q.db.QueryRowContext(ctx, issueSpendSince,
+		arg.ProjectID,
+		arg.Since,
+		arg.IssueID,
+		arg.Identifier,
+	)
+	var i IssueSpendSinceRow
+	err := row.Scan(
+		&i.CostUsd,
+		&i.Sessions,
+		&i.FirstSessionAt,
+		&i.LastSessionAt,
+	)
+	return i, err
+}
+
 const issueTokenSpend = `-- name: IssueTokenSpend :many
 SELECT
   CAST(COALESCE(NULLIF(model, ''), NULLIF(requested_model, ''), '') AS TEXT) AS model,

--- a/internal/store/sqlite.go
+++ b/internal/store/sqlite.go
@@ -751,6 +751,48 @@ func (s *sqliteStore) BudgetCostEvents(ctx context.Context, query BudgetCostQuer
 	return events, nil
 }
 
+func (s *sqliteStore) IssueSpendSince(ctx context.Context, query IssueSpendSinceQuery) (IssueSpendSince, error) {
+	projectID := strings.TrimSpace(query.ProjectID)
+	if projectID == "" {
+		return IssueSpendSince{}, errors.New("project_id is required")
+	}
+	issueID := strings.TrimSpace(query.IssueID)
+	identifier := strings.TrimSpace(query.Identifier)
+	if issueID == "" && identifier == "" {
+		return IssueSpendSince{}, errors.New("issue identity is required")
+	}
+	since, err := requiredTimestamp("since", query.Since)
+	if err != nil {
+		return IssueSpendSince{}, err
+	}
+	row, err := s.queries.IssueSpendSince(ctx, sqlc.IssueSpendSinceParams{
+		ProjectID:  projectID,
+		Since:      since,
+		IssueID:    issueID,
+		Identifier: identifier,
+	})
+	if err != nil {
+		return IssueSpendSince{}, fmt.Errorf("reading issue spend since accepted progress: %w", err)
+	}
+	spend := IssueSpendSince{
+		CostUSD:  nonNegativeFloat(row.CostUsd),
+		Sessions: nonNegative(row.Sessions),
+	}
+	if row.FirstSessionAt != "" {
+		spend.FirstSessionAt, err = parseTimestamp("first_session_at", row.FirstSessionAt)
+		if err != nil {
+			return IssueSpendSince{}, err
+		}
+	}
+	if row.LastSessionAt != "" {
+		spend.LastSessionAt, err = parseTimestamp("last_session_at", row.LastSessionAt)
+		if err != nil {
+			return IssueSpendSince{}, err
+		}
+	}
+	return spend, nil
+}
+
 func (s *sqliteStore) LifetimeTotals(ctx context.Context) (LifetimeTotals, error) {
 	row, err := s.queries.LifetimeTotals(ctx)
 	if err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -37,6 +37,7 @@ type Store interface {
 	StatsStore
 	FairShareStore
 	BudgetCostStore
+	ProgressSpendStore
 	WorkflowMetricsStore
 	WorkAttemptStore
 	ValidatorMemoStore
@@ -101,6 +102,10 @@ type FairShareStore interface {
 
 type BudgetCostStore interface {
 	BudgetCostEvents(context.Context, BudgetCostQuery) ([]BudgetCostEvent, error)
+}
+
+type ProgressSpendStore interface {
+	IssueSpendSince(context.Context, IssueSpendSinceQuery) (IssueSpendSince, error)
 }
 
 type WorkflowMetricsStore interface {
@@ -880,6 +885,20 @@ type BudgetCostEvent struct {
 	ProjectID string
 	At        time.Time
 	CostUSD   float64
+}
+
+type IssueSpendSinceQuery struct {
+	ProjectID  string
+	IssueID    string
+	Identifier string
+	Since      time.Time
+}
+
+type IssueSpendSince struct {
+	CostUSD        float64
+	Sessions       int64
+	FirstSessionAt time.Time
+	LastSessionAt  time.Time
 }
 
 type ModelTokenSpend struct {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1327,6 +1327,41 @@ func TestBudgetCostEvents(t *testing.T) {
 	}
 }
 
+func TestIssueSpendSinceUsesAcceptedProgressBoundaryAndIssueIdentity(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	backend := openTestStore(t, ctx)
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	events := []UsageEvent{
+		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 9, StartedAt: base.Add(-time.Minute), FinishedAt: base, Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 1.25, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 2.5, StartedAt: base.Add(3 * time.Minute), FinishedAt: base.Add(4 * time.Minute), Outcome: "completed"},
+		{ProjectID: "detent", IssueID: "other", Identifier: "gopherguides/gopher-ai#999", CostUSD: 20, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
+		{ProjectID: "other-project", IssueID: "issue-214", Identifier: "gopherguides/gopher-ai#214", CostUSD: 30, StartedAt: base.Add(time.Minute), FinishedAt: base.Add(2 * time.Minute), Outcome: "completed"},
+	}
+	for _, event := range events {
+		if _, err := backend.RecordUsageEvent(ctx, event); err != nil {
+			t.Fatalf("RecordUsageEvent() error = %v", err)
+		}
+	}
+
+	spend, err := backend.IssueSpendSince(ctx, IssueSpendSinceQuery{
+		ProjectID: "detent",
+		IssueID:   "issue-214",
+		Since:     base,
+	})
+	if err != nil {
+		t.Fatalf("IssueSpendSince() error = %v", err)
+	}
+	if math.Abs(spend.CostUSD-3.75) > 0.000001 || spend.Sessions != 2 {
+		t.Fatalf("IssueSpendSince() = %#v, want $3.75 across two sessions", spend)
+	}
+	if !spend.FirstSessionAt.Equal(base.Add(2*time.Minute)) || !spend.LastSessionAt.Equal(base.Add(4*time.Minute)) {
+		t.Fatalf("session range = %s..%s", spend.FirstSessionAt, spend.LastSessionAt)
+	}
+}
+
 func TestRecentModelTokenQuantilesUsesRecentCompletedSessions(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- add a per-issue spend-since-last-accepted-state-change circuit breaker with a `$3.00` default and explicit off switch
- park trips with distinct durable telemetry, shrink-task guidance, and a mandatory first-tool Workpad diagnosis on redispatch
- expose the setting through doctor and workflow templates, and classify trips in retro

Fixes #1229

## UI Surface Contract

- [x] N/A; this PR does not change a UI surface.
- [x] This PR does not add persistent top-of-screen messaging.
- [x] This PR has no visual changes to primary operator screens.

## Test Plan

- [x] `make generate`
- [x] `make check`
- [x] replay five `$1.35` sessions with the content detector disabled and a non-empty diff; confirm the spend breaker parks the issue
- [x] cover disabled, below/at/above threshold, accepted-change reset, precise SQL boundary, retry prompt, doctor, and retro behavior
