### PR TITLE
fix(budget): reevaluate daily refusals after cap raises

### DIFF
--- a/internal/budget/budget.go
+++ b/internal/budget/budget.go
@@ -62,6 +62,12 @@ type Decision struct {
 	Refusal *Refusal
 }
 
+type DailyStatus struct {
+	Active          bool
+	CurrentSpendUSD float64
+	MaxUSD          float64
+}
+
 type Refusal struct {
 	Code              ReasonCode
 	Message           string
@@ -177,6 +183,30 @@ func (c *Checker) CheckDispatch(ctx context.Context, req DispatchRequest) (Decis
 	}
 
 	return Decision{Allowed: true}, nil
+}
+
+func (c *Checker) DailyStatus(ctx context.Context, now time.Time) (DailyStatus, error) {
+	if !c.cfg.Enabled || !capActive(c.cfg.PerDayMaxUSD) {
+		return DailyStatus{}, nil
+	}
+	if missingSpendStore(c.spend) {
+		return DailyStatus{}, ErrMissingSpendStore
+	}
+
+	now = now.UTC()
+	if now.IsZero() {
+		now = time.Now().UTC()
+	}
+	dailySpend, err := c.spend.DailyTokenSpend(ctx, now)
+	if err != nil {
+		return DailyStatus{}, fmt.Errorf("daily token spend: %w", err)
+	}
+
+	return DailyStatus{
+		Active:          true,
+		CurrentSpendUSD: SpendUSD(dailySpend, c.pricing),
+		MaxUSD:          c.cfg.PerDayMaxUSD,
+	}, nil
 }
 
 func SpendUSD(spend store.TokenSpend, pricing PricingTable) float64 {

--- a/internal/budget/budget_test.go
+++ b/internal/budget/budget_test.go
@@ -239,6 +239,70 @@ func TestCheckerCheckDispatch(t *testing.T) {
 	}
 }
 
+func TestCheckerDailyStatus(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
+	pricing := PricingTable{"gpt-test": {USDPerInputToken: 0.01}}
+	tests := []struct {
+		name      string
+		cfg       Config
+		spend     *fakeSpendStore
+		want      DailyStatus
+		wantError string
+		wantCalls int
+	}{
+		{
+			name:  "disabled budget is inactive",
+			spend: &fakeSpendStore{},
+		},
+		{
+			name:  "missing daily cap is inactive",
+			cfg:   Config{Enabled: true},
+			spend: &fakeSpendStore{},
+		},
+		{
+			name: "active cap reports live spend",
+			cfg:  Config{Enabled: true, PerDayMaxUSD: 2.5},
+			spend: &fakeSpendStore{daily: store.TokenSpend{
+				ByModel: []store.ModelTokenSpend{{Model: "gpt-test", InputTokens: 25}},
+			}},
+			want:      DailyStatus{Active: true, CurrentSpendUSD: 0.25, MaxUSD: 2.5},
+			wantCalls: 1,
+		},
+		{
+			name:      "spend lookup failure is returned",
+			cfg:       Config{Enabled: true, PerDayMaxUSD: 2.5},
+			spend:     &fakeSpendStore{dailyErr: errors.New("lookup failed")},
+			wantError: "daily token spend: lookup failed",
+			wantCalls: 1,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			checker := NewChecker(tt.cfg, tt.spend, pricing)
+			got, err := checker.DailyStatus(context.Background(), now)
+			if tt.wantError != "" {
+				if err == nil || err.Error() != tt.wantError {
+					t.Fatalf("DailyStatus() error = %v, want %q", err, tt.wantError)
+				}
+			} else if err != nil {
+				t.Fatalf("DailyStatus() error = %v", err)
+			}
+			if got.Active != tt.want.Active || got.MaxUSD != tt.want.MaxUSD {
+				t.Fatalf("DailyStatus() = %#v, want %#v", got, tt.want)
+			}
+			assertInDelta(t, got.CurrentSpendUSD, tt.want.CurrentSpendUSD)
+			if tt.spend.dailyCalls != tt.wantCalls {
+				t.Fatalf("DailyTokenSpend calls = %d, want %d", tt.spend.dailyCalls, tt.wantCalls)
+			}
+		})
+	}
+}
+
 func TestCheckerUsesDefaultEstimate(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/dispatch.go
+++ b/internal/orchestrator/dispatch.go
@@ -19,8 +19,35 @@ func (o *Orchestrator) dispatchPlanner() dispatchPlanner {
 	return newDispatchPlanner(o.cfg)
 }
 
-func (o *Orchestrator) pruneBudgetRefusals(state *State, now time.Time) {
-	o.dispatchPlanner().pruneBudgetRefusals(state, now)
+func (o *Orchestrator) pruneBudgetRefusals(ctx context.Context, state *State, now time.Time) {
+	o.dispatchPlanner().pruneBudgetRefusals(state, now, o.currentDailyBudgetStatus(ctx, state, now))
+}
+
+func (o *Orchestrator) currentDailyBudgetStatus(ctx context.Context, state *State, now time.Time) *DailyBudgetStatus {
+	if o.dailyBudgetStatus == nil || !hasActiveDailyBudgetRefusal(state, now) {
+		return nil
+	}
+
+	status, known, err := o.dailyBudgetStatus.DailyBudgetStatus(ctx, now)
+	if err != nil {
+		if o.logger != nil {
+			o.logger.Warn("daily budget refusal re-evaluation failed", "error", err)
+		}
+		return nil
+	}
+	if !known {
+		return nil
+	}
+	return &status
+}
+
+func hasActiveDailyBudgetRefusal(state *State, now time.Time) bool {
+	for _, refusal := range state.BudgetRefusals {
+		if refusal.Code == "per_day_max_usd" && refusal.ResetAt != nil && now.Before(*refusal.ResetAt) {
+			return true
+		}
+	}
+	return false
 }
 
 func (o *Orchestrator) selectWorkerHost(state *State, preferredWorkerHost string) (string, bool) {

--- a/internal/orchestrator/dispatch_parity_test.go
+++ b/internal/orchestrator/dispatch_parity_test.go
@@ -44,7 +44,7 @@ func TestDispatchParityWithElixirRecordedCandidateSets(t *testing.T) {
 
 			candidates := parityIssues(t, tt.Candidates)
 			sortIssuesForDispatch(candidates, cfg.DispatchPriorityByState, cfg.DispatchPriorityByLabel, cfg.PrioritizeUnblockers)
-			orch.pruneBudgetRefusals(&state, now)
+			orch.pruneBudgetRefusals(context.Background(), &state, now)
 			orch.trackBlockedCandidates(&state, candidates, now)
 
 			gotOrder := parityDispatchOrder(&orch, state.clone(), candidates, now)

--- a/internal/orchestrator/dispatch_planner.go
+++ b/internal/orchestrator/dispatch_planner.go
@@ -319,9 +319,9 @@ func (a dispatchAction) decision() DispatchDecision {
 	}
 }
 
-func (p dispatchPlanner) pruneBudgetRefusals(state *State, now time.Time) {
+func (p dispatchPlanner) pruneBudgetRefusals(state *State, now time.Time, dailyStatus *DailyBudgetStatus) {
 	for issueID, refusal := range state.BudgetRefusals {
-		if !p.budgetRefusalActive(refusal, now) {
+		if !p.budgetRefusalActive(refusal, now, dailyStatus) {
 			delete(state.BudgetRefusals, issueID)
 		}
 	}
@@ -333,11 +333,17 @@ func (p dispatchPlanner) budgetCooldownActive(state *State, issueID string, now 
 		return false
 	}
 
-	return p.budgetRefusalActive(refusal, now)
+	return p.budgetRefusalActive(refusal, now, nil)
 }
 
-func (p dispatchPlanner) budgetRefusalActive(refusal BudgetRefusal, now time.Time) bool {
+func (p dispatchPlanner) budgetRefusalActive(refusal BudgetRefusal, now time.Time, dailyStatus *DailyBudgetStatus) bool {
 	if refusal.ResetAt != nil && now.Before(*refusal.ResetAt) {
+		if refusal.Code == "per_day_max_usd" && dailyStatus != nil {
+			if !dailyStatus.Active {
+				return false
+			}
+			return dailyStatus.CurrentSpendUSD+refusal.ProjectedCostUSD > dailyStatus.MaxUSD
+		}
 		return true
 	}
 	if p.cfg.BudgetRefusalCooldown <= 0 || refusal.RefusedAt.IsZero() {

--- a/internal/orchestrator/dispatch_test.go
+++ b/internal/orchestrator/dispatch_test.go
@@ -327,6 +327,122 @@ func TestDispatchableFiltersIneligibleCandidates(t *testing.T) {
 	}
 }
 
+func TestPruneBudgetRefusalsReevaluatesDailyCap(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC)
+	resetAt := time.Date(2026, 7, 12, 0, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name       string
+		refusal    BudgetRefusal
+		status     DailyBudgetStatus
+		statusErr  error
+		wantActive bool
+	}{
+		{
+			name: "cap raise clears resolved daily refusal",
+			refusal: BudgetRefusal{
+				Code:             "per_day_max_usd",
+				ProjectedCostUSD: 10,
+				ResetAt:          &resetAt,
+				RefusedAt:        now,
+			},
+			status: DailyBudgetStatus{Active: true, CurrentSpendUSD: 100, MaxUSD: 250},
+		},
+		{
+			name: "cap raise keeps daily refusal when projected spend remains over cap",
+			refusal: BudgetRefusal{
+				Code:             "per_day_max_usd",
+				ProjectedCostUSD: 10,
+				ResetAt:          &resetAt,
+				RefusedAt:        now,
+			},
+			status:     DailyBudgetStatus{Active: true, CurrentSpendUSD: 245, MaxUSD: 250},
+			wantActive: true,
+		},
+		{
+			name: "unchanged cap keeps daily refusal until midnight",
+			refusal: BudgetRefusal{
+				Code:             "per_day_max_usd",
+				ProjectedCostUSD: 10,
+				ResetAt:          &resetAt,
+				RefusedAt:        now,
+			},
+			status:     DailyBudgetStatus{Active: true, CurrentSpendUSD: 100, MaxUSD: 100},
+			wantActive: true,
+		},
+		{
+			name: "disabled daily cap clears daily refusal",
+			refusal: BudgetRefusal{
+				Code:             "per_day_max_usd",
+				ProjectedCostUSD: 10,
+				ResetAt:          &resetAt,
+				RefusedAt:        now,
+			},
+		},
+		{
+			name: "status lookup failure preserves daily refusal",
+			refusal: BudgetRefusal{
+				Code:             "per_day_max_usd",
+				ProjectedCostUSD: 10,
+				ResetAt:          &resetAt,
+				RefusedAt:        now,
+			},
+			statusErr:  errors.New("lookup failed"),
+			wantActive: true,
+		},
+		{
+			name: "per issue refusal keeps cooldown behavior",
+			refusal: BudgetRefusal{
+				Code:      "per_issue_max_usd",
+				RefusedAt: now.Add(-30 * time.Minute),
+			},
+			status:     DailyBudgetStatus{Active: true, CurrentSpendUSD: 0, MaxUSD: 1000},
+			wantActive: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := normalizeConfig(Config{BudgetRefusalCooldown: time.Hour})
+			state := newState(cfg)
+			state.BudgetRefusals["issue"] = tt.refusal
+			orch := Orchestrator{
+				cfg: cfg,
+				dailyBudgetStatus: fakeDailyBudgetStatusProvider{
+					status: tt.status,
+					err:    tt.statusErr,
+				},
+			}
+
+			orch.dispatchTickIssues(
+				context.Background(),
+				&state,
+				tickFetchedIssues{statusOK: true},
+				tickTransitionRefresh{blockedRefreshOK: true},
+				tickPreviousState{},
+				nil,
+				now,
+			)
+			_, gotActive := state.BudgetRefusals["issue"]
+			if gotActive != tt.wantActive {
+				t.Fatalf("budget refusal active = %t, want %t", gotActive, tt.wantActive)
+			}
+		})
+	}
+}
+
+type fakeDailyBudgetStatusProvider struct {
+	status DailyBudgetStatus
+	err    error
+}
+
+func (p fakeDailyBudgetStatusProvider) DailyBudgetStatus(context.Context, time.Time) (DailyBudgetStatus, bool, error) {
+	return p.status, true, p.err
+}
+
 func TestDispatchableSkipsAutoPromoteGatePendingActiveIssue(t *testing.T) {
 	t.Parallel()
 

--- a/internal/orchestrator/orchestrator.go
+++ b/internal/orchestrator/orchestrator.go
@@ -164,6 +164,7 @@ type Orchestrator struct {
 	release                 releasepkg.Coordinator
 	capacityController      runpkg.CapacityController
 	validatorCapacity       runpkg.ValidatorCapacityController
+	dailyBudgetStatus       runpkg.DailyBudgetStatusProvider
 	now                     func() time.Time
 	retrospector            Retrospector
 	stateRequests           chan stateRequest
@@ -244,6 +245,10 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 	if candidate, ok := runner.(runpkg.ValidatorCapacityController); ok {
 		validatorCapacity = candidate
 	}
+	var dailyBudgetStatus runpkg.DailyBudgetStatusProvider
+	if candidate, ok := runner.(runpkg.DailyBudgetStatusProvider); ok {
+		dailyBudgetStatus = candidate
+	}
 
 	logger := deps.Logger
 	if logger == nil {
@@ -322,6 +327,7 @@ func New(cfg Config, deps Dependencies) (*Orchestrator, error) {
 		retrospector:            deps.Retrospector,
 		capacityController:      capacityController,
 		validatorCapacity:       validatorCapacity,
+		dailyBudgetStatus:       dailyBudgetStatus,
 		now:                     now,
 		stateRequests:           make(chan stateRequest),
 		drainRequests:           make(chan drainRequest),

--- a/internal/orchestrator/runner.go
+++ b/internal/orchestrator/runner.go
@@ -22,6 +22,10 @@ type RunResult = runner.RunResult
 
 type BudgetRefusal = runner.BudgetRefusal
 
+type DailyBudgetStatus = runner.DailyBudgetStatus
+
+type DailyBudgetStatusProvider = runner.DailyBudgetStatusProvider
+
 type DiffStats = runner.DiffStats
 
 type TokenTotals = runner.TokenTotals

--- a/internal/orchestrator/shadow.go
+++ b/internal/orchestrator/shadow.go
@@ -33,7 +33,7 @@ func PlanDispatch(cfg Config, state State, candidates []connector.Issue, now tim
 	plannedState := state.clone()
 	plannedState.ensureInitialized(planner.cfg)
 	plannedCandidates := cloneIssues(candidates)
-	planner.pruneBudgetRefusals(&plannedState, now)
+	planner.pruneBudgetRefusals(&plannedState, now, nil)
 	planner.trackBlockedCandidates(&plannedState, plannedCandidates, now)
 
 	return planner.plan(&plannedState, plannedCandidates, now, dispatchPlanHooks{})

--- a/internal/orchestrator/tick.go
+++ b/internal/orchestrator/tick.go
@@ -773,7 +773,7 @@ func (o *Orchestrator) dispatchTickIssues(
 ) {
 	issues := filterCompletedEpicCandidates(fetched.candidates, completedEpics)
 	planner := o.dispatchPlanner()
-	planner.pruneBudgetRefusals(state, now)
+	o.pruneBudgetRefusals(ctx, state, now)
 	planner.trackBlockedCandidates(state, issues, now)
 	candidateBlockedStatusIssues := issuesInStates(fetched.candidates, []string{blockedStatusState})
 	if fetched.statusOK {

--- a/internal/runner/agent.go
+++ b/internal/runner/agent.go
@@ -232,6 +232,26 @@ func (r *Runner) EnforcedBudget() (config.Budget, bool) {
 	return r.enforcedBudget, r.enforcedBudgetKnown
 }
 
+func (r *Runner) DailyBudgetStatus(ctx context.Context, now time.Time) (DailyBudgetStatus, bool, error) {
+	_, _, checker, _ := r.runtimeSnapshot()
+	provider, ok := checker.(interface {
+		DailyStatus(context.Context, time.Time) (budget.DailyStatus, error)
+	})
+	if !ok {
+		return DailyBudgetStatus{}, false, nil
+	}
+
+	status, err := provider.DailyStatus(ctx, now)
+	if err != nil {
+		return DailyBudgetStatus{}, true, err
+	}
+	return DailyBudgetStatus{
+		Active:          status.Active,
+		CurrentSpendUSD: status.CurrentSpendUSD,
+		MaxUSD:          status.MaxUSD,
+	}, true, nil
+}
+
 func enforcedBudgetConfig(requested config.Budget, checker BudgetChecker) (config.Budget, bool) {
 	if checker == nil {
 		if requested.Enabled {

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -2904,6 +2904,13 @@ func TestRunnerUpdateWorkflowAppliesReloadedDailyBudget(t *testing.T) {
 			if !ok || enforced.PerDayMaxUSD != tt.reloadedCap {
 				t.Fatalf("EnforcedBudget() = %#v, %t, want per_day_max_usd %.2f", enforced, ok, tt.reloadedCap)
 			}
+			status, known, err := runner.DailyBudgetStatus(context.Background(), time.Date(2026, 7, 11, 15, 0, 0, 0, time.UTC))
+			if err != nil {
+				t.Fatalf("DailyBudgetStatus() error = %v", err)
+			}
+			if !known || !status.Active || status.CurrentSpendUSD != 0.10 || status.MaxUSD != tt.reloadedCap {
+				t.Fatalf("DailyBudgetStatus() = %#v, %t, want live spend 0.10 and cap %.2f", status, known, tt.reloadedCap)
+			}
 		})
 	}
 }

--- a/internal/runner/types.go
+++ b/internal/runner/types.go
@@ -47,6 +47,16 @@ type WorkspaceReaper interface {
 	ReapWorkspace(context.Context, connector.Issue) (WorkspaceReapResult, error)
 }
 
+type DailyBudgetStatusProvider interface {
+	DailyBudgetStatus(context.Context, time.Time) (DailyBudgetStatus, bool, error)
+}
+
+type DailyBudgetStatus struct {
+	Active          bool
+	CurrentSpendUSD float64
+	MaxUSD          float64
+}
+
 type WorkspaceReapResult struct {
 	Worktrees int
 	Branches  int


### PR DESCRIPTION
## Summary

- expose live daily spend and the enforced hot-reloaded cap from the budget checker through the runner
- re-evaluate active daily-cap refusals once per scheduler tick and clear those resolved by the current cap
- preserve refusals when projected spend still exceeds the cap or live status cannot be read, without changing per-issue cooldowns

Fixes #1246

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

No UI changes.

## Test Plan

- [x] `go test ./internal/budget ./internal/runner ./internal/orchestrator -count=1`
- [x] `make check`
