### PR TITLE
test(orchestrator): harden safety coverage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,6 +50,13 @@ Leave `model` unset so the issue inherits the fleet-standard model.
 - New or modified Go behavior requires focused table-driven tests using only the standard library.
 - Generated Go files such as `*_templ.go` and sqlc output do not need hand-written tests.
 
+### Safety-critical orchestrator validation
+
+- `internal/orchestrator/implement_progress.go`, `internal/orchestrator/backend_capacity.go`, `internal/orchestrator/spend_progress.go`, and `internal/orchestrator/ranking.go` are safety-critical brakes and dispatch controls.
+- Changes to these files must preserve their exact-file coverage floor of at least 90% in `scripts/coverage-exceptions.txt` and pass `make check`.
+- Changes to their comparison, signature, time-window, or ordering logic must preserve the seed cases and pass `FuzzSafetyCriticalOrchestratorBoundaries`, which covers diffstat cleanliness, signature equality, capacity resume arithmetic, spend-progress baselines, and dispatch ordering.
+- Run `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s` before submitting such changes.
+
 ## Tooling
 
 - `make dev` runs Air and rotates `tmp/air-combined.log`.

--- a/internal/orchestrator/backend_capacity_test.go
+++ b/internal/orchestrator/backend_capacity_test.go
@@ -1,8 +1,10 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
 	"errors"
+	"log/slog"
 	"strings"
 	"testing"
 	"time"
@@ -149,6 +151,82 @@ func TestBackendCapacityWithoutResetUsesLowFrequencyProbe(t *testing.T) {
 	now := time.Date(2026, 7, 10, 1, 55, 0, 0, time.UTC)
 	if got, want := backendCapacityResumeAt(time.Time{}, now), now.Add(backendCapacityProbeDelay); !got.Equal(want) {
 		t.Fatalf("backendCapacityResumeAt() = %s, want %s", got, want)
+	}
+}
+
+func TestBackendCapacityHelperBoundaries(t *testing.T) {
+	t.Parallel()
+
+	now := time.Date(2026, 7, 10, 1, 55, 0, 0, time.UTC)
+	if got := backendCapacityStatusMessage(BackendOutage{}); got != "backend agent backend at usage limit" {
+		t.Fatalf("backendCapacityStatusMessage() = %q", got)
+	}
+	outage := BackendOutage{
+		Scope:    backendcapacity.Scope{BackendKind: "codex"},
+		ResumeAt: now,
+	}
+	if got := backendCapacityStatusMessage(outage); !strings.Contains(got, "backend codex") || !strings.Contains(got, now.Format(time.RFC3339)) {
+		t.Fatalf("backendCapacityStatusMessage() = %q", got)
+	}
+
+	scope := backendcapacity.Scope{BackendID: "codex", BackendKind: "codex", Provider: "openai"}
+	resetAt := now.Add(time.Hour)
+	capacityErr, ok := backendcapacity.As(backendcapacity.NewError(
+		scope,
+		backendcapacity.Details{Kind: "usageLimitExceeded", ResetAt: &resetAt},
+		errors.New("usage limit reached"),
+	))
+	if !ok {
+		t.Fatal("capacity error did not unwrap")
+	}
+	orch := &Orchestrator{now: func() time.Time { return now }}
+	state := State{
+		Retry:   map[string]Retry{},
+		Claimed: map[string]Claimed{},
+	}
+	registered := orch.registerBackendOutage(&state, capacityErr, time.Time{})
+	if !registered.DetectedAt.Equal(now) || state.BackendOutages[scope.Key()].Kind != "usageLimitExceeded" {
+		t.Fatalf("registered outage = %#v", registered)
+	}
+
+	running := Running{Issue: connector.Issue{ID: "issue-1"}, Attempt: 2, WorkerHost: "worker"}
+	orch.scheduleBackendCapacityRetry(&state, running, registered)
+	if state.Claimed[running.Issue.ID].ClaimedAt != registered.LastObservedAt || state.Retry[running.Issue.ID].WorkerHost != "worker" {
+		t.Fatalf("scheduled state = claims %#v retries %#v", state.Claimed, state.Retry)
+	}
+	markBackendCapacityProbe(&state, "missing", running.Issue.ID)
+	orch.recoverBackendCapacity(&state, Running{CapacityScope: backendcapacity.Scope{BackendID: "missing"}}, now)
+	if _, _, paused := orch.validatorCapacityDispatch(nil, connector.Issue{}, now); paused {
+		t.Fatal("nil validator capacity dispatch paused")
+	}
+	orch.publishValidatorCapacityEvent(t.Context(), validatorCapacityEvent{})
+	orch.handleValidatorCapacityEvent(&state, validatorCapacityEvent{})
+
+	var logs bytes.Buffer
+	orch.logger = slog.New(slog.NewTextHandler(&logs, nil))
+	orch.handleValidatorCapacityEvent(&state, validatorCapacityEvent{CapacityErr: capacityErr, CompletedAt: now})
+	orch.recoverBackendCapacity(&state, Running{CapacityScope: scope, CapacityProbe: true}, now)
+	state.BackendOutages[scope.Key()] = registered
+	orch.deferBackendCapacityProbe(&state, Running{CapacityScope: scope, CapacityProbe: true}, time.Time{}, errors.New("probe failed"))
+	if !strings.Contains(logs.String(), "backend capacity recovered") || !strings.Contains(logs.String(), "probe failed") {
+		t.Fatalf("capacity logs = %q", logs.String())
+	}
+
+	recovery := BackendRecovery{Outage: registered, RecoveredAt: now}
+	if key, _, found := matchingBackendRecovery(map[string]BackendRecovery{scope.Key(): recovery}, scope); !found || key != scope.Key() {
+		t.Fatalf("matchingBackendRecovery() = %q, %t", key, found)
+	}
+	readerless := &Orchestrator{connector: &backendCapacityTestConnector{}}
+	if _, _, ok := readerless.classifyBlockedCapacityIssue(t.Context(), &state, connector.Issue{ID: "blocked"}, now); ok {
+		t.Fatal("readerless capacity issue classified")
+	}
+
+	recoveryState := newState(normalizeConfig(Config{}))
+	recoveryIssue := connector.Issue{ID: "recover", State: "Blocked"}
+	recoveryState.Blocked[recoveryIssue.ID] = Blocked{Issue: recoveryIssue}
+	recoveryOrch := &Orchestrator{connector: &backendCapacityTestConnector{}}
+	if !recoveryOrch.applyBackendCapacityBlockedRecovery(t.Context(), &recoveryState, recoveryIssue, BackendOutage{}, recovery, now) {
+		t.Fatal("applyBackendCapacityBlockedRecovery() = false")
 	}
 }
 

--- a/internal/orchestrator/implement_progress_test.go
+++ b/internal/orchestrator/implement_progress_test.go
@@ -14,6 +14,7 @@ import (
 	runpkg "github.com/digitaldrywood/detent/internal/runner"
 	"github.com/digitaldrywood/detent/internal/scheduler"
 	"github.com/digitaldrywood/detent/internal/store"
+	"github.com/digitaldrywood/detent/internal/workpad"
 )
 
 func TestHandleRunResultClassifiesImplementWorkerProgress(t *testing.T) {
@@ -483,6 +484,129 @@ func TestStickyBlockReasonIncludesImplementProgressBreakers(t *testing.T) {
 	}
 }
 
+func TestImplementProgressHelperBoundaries(t *testing.T) {
+	t.Parallel()
+
+	issue := connector.Issue{WorkpadSignal: &workpad.Signal{
+		Source:      workpad.SourceStructured,
+		Status:      workpad.StatusBlocked,
+		HumanAction: " approve the deployment ",
+	}}
+	if status, action := implementProgressBlockedHumanAction(issue); status != workpad.StatusBlocked || action != "approve the deployment" {
+		t.Fatalf("implementProgressBlockedHumanAction() = %q, %q", status, action)
+	}
+	issue.WorkpadSignal.Source = workpad.SourceProse
+	if status, action := implementProgressBlockedHumanAction(issue); status != "" || action != "" {
+		t.Fatalf("prose workpad signal = %q, %q, want empty", status, action)
+	}
+
+	usable := autoPromoteReworkSignature{PRNumber: 42, HeadSHA: " head ", FailedChecks: []string{"test"}}
+	attempts := []store.WorkAttempt{
+		{TerminalState: store.WorkAttemptTerminalFailure},
+		implementProgressHistoryAttempt(1, usable, store.WorkAttemptTerminalSuccess),
+	}
+	if got, ok := latestImplementProgressSignature(attempts); !ok || got.PRNumber != usable.PRNumber || got.HeadSHA != "head" {
+		t.Fatalf("latestImplementProgressSignature() = %#v, %t", got, ok)
+	}
+	if got := consecutiveImplementBlockedHumanActionAttempts(nil, "", "Blocked"); got != 0 {
+		t.Fatalf("consecutiveImplementBlockedHumanActionAttempts() = %d, want 0", got)
+	}
+
+	legacy := implementProgressRecord{
+		Outcome:            string(store.WorkAttemptTerminalSuccess),
+		Reason:             "no_linked_pull_request",
+		WorkspaceDiffStats: implementProgressDiffStats{Status: "clean"},
+	}
+	if !implementProgressRecordMatchesNoProgress(legacy, autoPromoteReworkSignature{}) {
+		t.Fatal("legacy clean completion did not match no progress")
+	}
+	legacy.WorkspaceDiffStats.FilesChanged = 1
+	if implementProgressRecordMatchesNoProgress(legacy, autoPromoteReworkSignature{}) {
+		t.Fatal("legacy dirty completion matched no progress")
+	}
+
+	invalidAttempts := []store.WorkAttempt{
+		{TerminalState: store.WorkAttemptTerminalFailure, WorkerMetadataJSON: `{}`},
+		{TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: `{`},
+		{TerminalState: store.WorkAttemptTerminalSuccess, WorkerMetadataJSON: `{}`},
+	}
+	for _, attempt := range invalidAttempts {
+		if _, ok := implementProgressRecordFromAttempt(attempt); ok {
+			t.Fatalf("implementProgressRecordFromAttempt(%#v) unexpectedly succeeded", attempt)
+		}
+	}
+
+	added, removed := implementProgressFailedCheckDelta([]string{"test", "lint"}, []string{"lint", "build"})
+	if !slicesEqual(added, []string{"build"}) || !slicesEqual(removed, []string{"test"}) {
+		t.Fatalf("implementProgressFailedCheckDelta() = %#v, %#v", added, removed)
+	}
+}
+
+func TestImplementProgressBlockCommentIncludesBoundaryEvidence(t *testing.T) {
+	t.Parallel()
+
+	decision := implementCompletionProgressDecision{
+		BlockReason:            workpadBlockedUnactionedReason,
+		NoProgressLimit:        3,
+		ConsecutiveNoProgress:  2,
+		ConsecutiveHumanAction: 3,
+		HumanAction:            "Approve release\nConfirm rollback",
+		CurrentSignature:       autoPromoteReworkSignature{PRNumber: 42, HeadSHA: "head", FailedChecks: []string{"test"}},
+		PreviousSignature:      autoPromoteReworkSignature{HeadSHA: "previous"},
+		FailedChecksAdded:      []string{"test"},
+		FailedChecksRemoved:    []string{"lint"},
+		WorkspaceDiffStats:     DiffStats{Status: "clean"},
+	}
+	issue := connector.Issue{PullRequest: &connector.PullRequest{URL: "https://github.test/pull/42"}}
+	comment := implementProgressBlockComment(issue, decision)
+	for _, want := range []string{"workpad_blocked_unactioned", "pull/42", "head", "previous", "failed_checks_added", "0 files", "> Approve release", "> Confirm rollback"} {
+		if !strings.Contains(comment, want) {
+			t.Fatalf("comment missing %q:\n%s", want, comment)
+		}
+	}
+	if got := implementProgressRecoveryReason(decision); got != decision.HumanAction {
+		t.Fatalf("implementProgressRecoveryReason() = %q, want %q", got, decision.HumanAction)
+	}
+}
+
+func TestEvaluateImplementCompletionProgressFailureBoundaries(t *testing.T) {
+	t.Parallel()
+
+	noPR := implementProgressIssueWithoutPR()
+	var logs bytes.Buffer
+	orch := &Orchestrator{
+		cfg:          Config{AutoPromote: AutoPromoteConfig{NoProgressLimit: 3}},
+		connector:    &implementProgressConnector{},
+		workAttempts: &implementProgressAttemptStore{historyErr: errors.New("history unavailable")},
+		logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+	}
+	decision := orch.evaluateImplementCompletionProgress(t.Context(), Running{Issue: noPR}, FinalStateCompleted, false)
+	if decision.Reason != "attempt_history_lookup_failed" || !strings.Contains(decision.Warning, "history unavailable") || !strings.Contains(logs.String(), "history unavailable") {
+		t.Fatalf("history failure decision = %#v logs = %q", decision, logs.String())
+	}
+
+	orch.workAttempts = &implementProgressAttemptStore{}
+	decision = orch.evaluateImplementCompletionProgress(t.Context(), Running{
+		Issue:     noPR,
+		DiffStats: DiffStats{FilesChanged: 1, Status: "dirty"},
+	}, FinalStateCompleted, false)
+	if decision.Reason != "workspace_diff_fingerprint_unavailable_without_pull_request" {
+		t.Fatalf("dirty no-PR decision = %#v", decision)
+	}
+
+	linked := implementProgressIssue("head")
+	orch.connector = &backendCapacityTestConnector{}
+	decision = orch.evaluateImplementCompletionProgress(t.Context(), Running{Issue: linked}, FinalStateCompleted, false)
+	if decision.Reason != "pull_request_hydrator_unavailable" {
+		t.Fatalf("missing hydrator decision = %#v", decision)
+	}
+
+	orch.warnImplementProgressRefresh(linked, "refresh unavailable", errors.New("tracker unavailable"))
+	if !strings.Contains(logs.String(), "tracker unavailable") {
+		t.Fatalf("refresh warning logs = %q", logs.String())
+	}
+}
+
 func implementProgressIssue(headSHA string, failedChecks ...string) connector.Issue {
 	prNumber := 1070
 	issue := connector.Issue{
@@ -688,6 +812,7 @@ func (c *implementProgressConnector) HydratePullRequest(context.Context, connect
 
 type implementProgressAttemptStore struct {
 	history      []store.WorkAttempt
+	historyErr   error
 	completions  []store.WorkAttemptCompletion
 	historyCalls int
 	queries      []store.WorkAttemptHistoryQuery
@@ -717,7 +842,7 @@ func (s *implementProgressAttemptStore) ListActiveWorkAttempts(context.Context, 
 func (s *implementProgressAttemptStore) ListRecentTerminalWorkAttempts(_ context.Context, query store.WorkAttemptHistoryQuery) ([]store.WorkAttempt, error) {
 	s.historyCalls++
 	s.queries = append(s.queries, query)
-	return append([]store.WorkAttempt(nil), s.history...), nil
+	return append([]store.WorkAttempt(nil), s.history...), s.historyErr
 }
 
 func (s *implementProgressAttemptStore) TimeoutExpiredWorkAttempts(context.Context, store.WorkAttemptTimeout) ([]store.WorkAttempt, error) {

--- a/internal/orchestrator/safety_fuzz_test.go
+++ b/internal/orchestrator/safety_fuzz_test.go
@@ -1,0 +1,113 @@
+package orchestrator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/digitaldrywood/detent/internal/connector"
+	"github.com/digitaldrywood/detent/internal/store"
+)
+
+func FuzzSafetyCriticalOrchestratorBoundaries(f *testing.F) {
+	f.Add(0, 0, 0, "", "clean", int64(1), " head ", "lint,test", int64(1), "head", "test,lint", int64(60), int64(0), true, int64(0), int64(1), int64(2), true)
+	f.Add(1, 2, 3, "fingerprint", "dirty", int64(1), "head-a", "test", int64(2), "head-b", "lint", int64(-60), int64(0), true, int64(10), int64(-10), int64(0), false)
+	f.Add(0, 0, 0, "", "", int64(0), "", "", int64(0), "", "", int64(0), int64(0), false, int64(0), int64(0), int64(0), false)
+
+	f.Fuzz(func(
+		t *testing.T,
+		filesChanged int,
+		addedLines int,
+		removedLines int,
+		fingerprint string,
+		status string,
+		leftNumber int64,
+		leftHead string,
+		leftChecks string,
+		rightNumber int64,
+		rightHead string,
+		rightChecks string,
+		resetSeconds int64,
+		nowSeconds int64,
+		hasReset bool,
+		createdSeconds int64,
+		stageSeconds int64,
+		acceptedSeconds int64,
+		accepted bool,
+	) {
+		diffStats := DiffStats{
+			FilesChanged: filesChanged,
+			AddedLines:   addedLines,
+			RemovedLines: removedLines,
+			Fingerprint:  fingerprint,
+			Status:       status,
+		}
+		wantClean := diffStatsPresent(diffStats) && filesChanged == 0 && addedLines == 0 && removedLines == 0
+		if got := implementProgressDiffStatsClean(diffStats); got != wantClean {
+			t.Fatalf("implementProgressDiffStatsClean(%#v) = %t, want %t", diffStats, got, wantClean)
+		}
+
+		leftSignature := autoPromoteReworkSignature{PRNumber: leftNumber, HeadSHA: leftHead, FailedChecks: strings.Split(leftChecks, ",")}
+		rightSignature := autoPromoteReworkSignature{PRNumber: rightNumber, HeadSHA: rightHead, FailedChecks: strings.Split(rightChecks, ",")}
+		gotEqual := implementProgressSignatureEqual(leftSignature, rightSignature)
+		wantEqual := leftNumber == rightNumber &&
+			strings.TrimSpace(leftHead) == strings.TrimSpace(rightHead) &&
+			slicesEqual(autoPromoteCanonicalChecks(leftSignature.FailedChecks), autoPromoteCanonicalChecks(rightSignature.FailedChecks))
+		if gotEqual != wantEqual || gotEqual != implementProgressSignatureEqual(rightSignature, leftSignature) {
+			t.Fatalf("implementProgressSignatureEqual(%#v, %#v) = %t, want %t", leftSignature, rightSignature, gotEqual, wantEqual)
+		}
+
+		resetSeconds %= 1_000_000_000
+		nowSeconds %= 1_000_000_000
+		now := time.Unix(nowSeconds, 0).UTC()
+		resetAt := time.Time{}
+		wantResumeAt := now.Add(backendCapacityProbeDelay)
+		if hasReset {
+			resetAt = time.Unix(resetSeconds, 0).UTC()
+			wantResumeAt = resetAt.Add(backendCapacityResetJitter)
+			minimum := now.Add(backendCapacityResetJitter)
+			if wantResumeAt.Before(minimum) {
+				wantResumeAt = minimum
+			}
+		}
+		if got := backendCapacityResumeAt(resetAt, now); !got.Equal(wantResumeAt) {
+			t.Fatalf("backendCapacityResumeAt(%s, %s) = %s, want %s", resetAt, now, got, wantResumeAt)
+		}
+
+		createdSeconds %= 1_000_000_000
+		stageSeconds %= 1_000_000_000
+		acceptedSeconds %= 1_000_000_000
+		createdAt := time.Unix(createdSeconds, 0).UTC()
+		stageUpdatedAt := time.Unix(stageSeconds, 0).UTC()
+		acceptedAt := time.Unix(acceptedSeconds, 0).UTC()
+		issue := connector.Issue{CreatedAt: &createdAt, StageUpdatedAt: &stageUpdatedAt}
+		attempt := store.WorkAttempt{CompletedAt: acceptedAt}
+		if accepted {
+			attempt.WorkerMetadataJSON = marshalWorkAttemptJSON(map[string]any{
+				spendProgressMetadataKey: spendProgressRecord{AcceptedStateChange: true},
+			})
+		}
+		wantBaseline := createdAt
+		if stageUpdatedAt.After(wantBaseline) {
+			wantBaseline = stageUpdatedAt
+		}
+		if accepted && acceptedAt.After(wantBaseline) {
+			wantBaseline = acceptedAt
+		}
+		if got := spendProgressBaseline(issue, []store.WorkAttempt{attempt}); !got.Equal(wantBaseline) {
+			t.Fatalf("spendProgressBaseline() = %s, want %s", got, wantBaseline)
+		}
+
+		leftPriority := int(leftNumber % 10)
+		rightPriority := int(rightNumber % 10)
+		leftIssue := rankingIssueWithLabels("left", "Todo", leftPriority, createdAt, leftHead)
+		rightIssue := rankingIssueWithLabels("right", "Todo", rightPriority, stageUpdatedAt, rightHead)
+		forward := []connector.Issue{leftIssue, rightIssue}
+		reverse := []connector.Issue{rightIssue, leftIssue}
+		sortIssuesForDispatch(forward, []string{"Todo"}, []string{"bug", "enhancement"}, true)
+		sortIssuesForDispatch(reverse, []string{"Todo"}, []string{"bug", "enhancement"}, true)
+		if !equalStrings(rankingIssueIDs(forward), rankingIssueIDs(reverse)) {
+			t.Fatalf("ranking depends on input order: forward=%#v reverse=%#v", rankingIssueIDs(forward), rankingIssueIDs(reverse))
+		}
+	})
+}

--- a/internal/orchestrator/spend_progress_test.go
+++ b/internal/orchestrator/spend_progress_test.go
@@ -1,7 +1,10 @@
 package orchestrator
 
 import (
+	"bytes"
 	"context"
+	"errors"
+	"log/slog"
 	"math"
 	"strings"
 	"testing"
@@ -216,8 +219,72 @@ func TestSpendProgressPriorAttemptRestoresExplainBeforeRetry(t *testing.T) {
 	}
 }
 
+func TestEvaluateSpendProgressFailsOpen(t *testing.T) {
+	t.Parallel()
+
+	base := time.Date(2026, 7, 11, 12, 0, 0, 0, time.UTC)
+	issue := connector.Issue{ID: "issue-1"}
+	tests := []struct {
+		name     string
+		attempts *implementProgressAttemptStore
+		spend    *spendProgressStore
+		missing  bool
+		want     string
+	}{
+		{name: "missing spend store", attempts: &implementProgressAttemptStore{}, missing: true, want: "progress spend store unavailable"},
+		{name: "history lookup failure", attempts: &implementProgressAttemptStore{historyErr: errors.New("history unavailable")}, spend: &spendProgressStore{}, want: "history unavailable"},
+		{name: "spend lookup failure", attempts: &implementProgressAttemptStore{}, spend: &spendProgressStore{err: errors.New("spend unavailable")}, want: "spend unavailable"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			var logs bytes.Buffer
+			orch := &Orchestrator{
+				cfg:          Config{NoProgressSpendLimitUSD: 5},
+				workAttempts: tt.attempts,
+				logger:       slog.New(slog.NewTextHandler(&logs, nil)),
+			}
+			if !tt.missing {
+				orch.progressSpend = tt.spend
+			}
+			decision := orch.evaluateSpendProgress(t.Context(), Running{Issue: issue}, base, false, "")
+			if decision.Block || !strings.Contains(decision.Warning, tt.want) || !strings.Contains(logs.String(), tt.want) {
+				t.Fatalf("decision = %#v logs = %q, want warning %q", decision, logs.String(), tt.want)
+			}
+		})
+	}
+}
+
+func TestSpendProgressAttemptAcceptedCompatibility(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name   string
+		record map[string]any
+		want   bool
+	}{
+		{name: "native accepted record", record: map[string]any{spendProgressMetadataKey: spendProgressRecord{AcceptedStateChange: true}}, want: true},
+		{name: "legacy pull request change", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: "pull_request_created_or_updated"}}, want: true},
+		{name: "legacy signature change", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: "signature_changed"}}, want: true},
+		{name: "unaccepted record", record: map[string]any{implementProgressMetadataKey: implementProgressRecord{Outcome: string(store.WorkAttemptTerminalSuccess), Reason: "unchanged_signature_clean_diff"}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			attempt := store.WorkAttempt{
+				TerminalState:      store.WorkAttemptTerminalSuccess,
+				WorkerMetadataJSON: marshalWorkAttemptJSON(tt.record),
+			}
+			if got := spendProgressAttemptAccepted(attempt); got != tt.want {
+				t.Fatalf("spendProgressAttemptAccepted() = %t, want %t", got, tt.want)
+			}
+		})
+	}
+}
+
 type spendProgressStore struct {
 	result store.IssueSpendSince
+	err    error
 	query  store.IssueSpendSinceQuery
 	calls  int
 }
@@ -225,5 +292,5 @@ type spendProgressStore struct {
 func (s *spendProgressStore) IssueSpendSince(_ context.Context, query store.IssueSpendSinceQuery) (store.IssueSpendSince, error) {
 	s.calls++
 	s.query = query
-	return s.result, nil
+	return s.result, s.err
 }

--- a/scripts/coverage-exceptions.txt
+++ b/scripts/coverage-exceptions.txt
@@ -1,4 +1,8 @@
-# Per-package coverage ratchet exceptions. Floors only move up.
+# Package exceptions and exact-file coverage ratchets. Floors only move up.
+github.com/digitaldrywood/detent/internal/orchestrator/backend_capacity.go 90 # Safety-critical backend capacity brake.
+github.com/digitaldrywood/detent/internal/orchestrator/implement_progress.go 90 # Safety-critical no-progress brake.
+github.com/digitaldrywood/detent/internal/orchestrator/ranking.go 90 # Safety-critical dispatch ranking.
+github.com/digitaldrywood/detent/internal/orchestrator/spend_progress.go 90 # Safety-critical spend progress brake.
 github.com/digitaldrywood/detent/internal/web/ui/components/icon 0 # TemplUI icon glue has no direct behavior tests yet; raise or remove after component tests cover it.
 github.com/digitaldrywood/detent/internal/web/ui/primitives 0 # UI primitive wrappers are currently untested glue; raise or remove after behavior-focused tests cover them.
 github.com/digitaldrywood/detent/internal/web/ui/utils 0 # UI class utility helpers are below the package floor; raise or remove after helper tests cover them.

--- a/tools/covercheck/main.go
+++ b/tools/covercheck/main.go
@@ -18,6 +18,11 @@ type packageStats struct {
 	total   int
 }
 
+type profileStats struct {
+	packages map[string]packageStats
+	files    map[string]packageStats
+}
+
 func (s packageStats) percent() float64 {
 	if s.total == 0 {
 		return 100
@@ -72,7 +77,7 @@ func run(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	fmt.Fprintln(stdout, "package coverage meets per-package floors")
+	fmt.Fprintln(stdout, "coverage meets configured package and file floors")
 	return 0
 }
 
@@ -126,8 +131,8 @@ func checkCoverage(profile io.Reader, defaultFloor float64, exceptions map[strin
 		return nil, err
 	}
 
-	packages := make([]string, 0, len(stats))
-	for packagePath := range stats {
+	packages := make([]string, 0, len(stats.packages))
+	for packagePath := range stats.packages {
 		packages = append(packages, packagePath)
 	}
 	sort.Strings(packages)
@@ -139,7 +144,7 @@ func checkCoverage(profile io.Reader, defaultFloor float64, exceptions map[strin
 			floor = exceptionFloor
 		}
 
-		coverage := stats[packagePath].percent()
+		coverage := stats.packages[packagePath].percent()
 		if coverage < floor {
 			failures = append(failures, coverageFailure{
 				Package:  packagePath,
@@ -149,12 +154,38 @@ func checkCoverage(profile io.Reader, defaultFloor float64, exceptions map[strin
 		}
 	}
 
+	files := make([]string, 0)
+	for target := range exceptions {
+		if strings.HasSuffix(target, ".go") {
+			files = append(files, target)
+		}
+	}
+	sort.Strings(files)
+	for _, filename := range files {
+		fileStats, ok := stats.files[filename]
+		if !ok {
+			return nil, fmt.Errorf("coverage floor target %q not found in profile", filename)
+		}
+		coverage := fileStats.percent()
+		floor := exceptions[filename]
+		if coverage < floor {
+			failures = append(failures, coverageFailure{
+				Package:  filename,
+				Coverage: coverage,
+				Floor:    floor,
+			})
+		}
+	}
+
 	return failures, nil
 }
 
-func parseCoverProfile(profile io.Reader) (map[string]packageStats, error) {
+func parseCoverProfile(profile io.Reader) (profileStats, error) {
 	scanner := bufio.NewScanner(profile)
-	stats := make(map[string]packageStats)
+	stats := profileStats{
+		packages: make(map[string]packageStats),
+		files:    make(map[string]packageStats),
+	}
 
 	lineNumber := 0
 	for scanner.Scan() {
@@ -169,12 +200,12 @@ func parseCoverProfile(profile io.Reader) (map[string]packageStats, error) {
 
 		fields := strings.Fields(line)
 		if len(fields) != 3 {
-			return nil, fmt.Errorf("coverprofile line %d: want file range, statements, and count", lineNumber)
+			return profileStats{}, fmt.Errorf("coverprofile line %d: want file range, statements, and count", lineNumber)
 		}
 
 		filename, ok := profileFilename(fields[0])
 		if !ok {
-			return nil, fmt.Errorf("coverprofile line %d: invalid file range %q", lineNumber, fields[0])
+			return profileStats{}, fmt.Errorf("coverprofile line %d: invalid file range %q", lineNumber, fields[0])
 		}
 		if isExcluded(filename) {
 			continue
@@ -182,30 +213,37 @@ func parseCoverProfile(profile io.Reader) (map[string]packageStats, error) {
 
 		statements, err := strconv.Atoi(fields[1])
 		if err != nil {
-			return nil, fmt.Errorf("coverprofile line %d: invalid statement count %q: %w", lineNumber, fields[1], err)
+			return profileStats{}, fmt.Errorf("coverprofile line %d: invalid statement count %q: %w", lineNumber, fields[1], err)
 		}
 		if statements < 0 {
-			return nil, fmt.Errorf("coverprofile line %d: statement count must be non-negative", lineNumber)
+			return profileStats{}, fmt.Errorf("coverprofile line %d: statement count must be non-negative", lineNumber)
 		}
 
 		count, err := strconv.Atoi(fields[2])
 		if err != nil {
-			return nil, fmt.Errorf("coverprofile line %d: invalid coverage count %q: %w", lineNumber, fields[2], err)
+			return profileStats{}, fmt.Errorf("coverprofile line %d: invalid coverage count %q: %w", lineNumber, fields[2], err)
 		}
 		if count < 0 {
-			return nil, fmt.Errorf("coverprofile line %d: coverage count must be non-negative", lineNumber)
+			return profileStats{}, fmt.Errorf("coverprofile line %d: coverage count must be non-negative", lineNumber)
 		}
 
 		packagePath := packageDir(filename)
-		packageCoverage := stats[packagePath]
+		packageCoverage := stats.packages[packagePath]
 		packageCoverage.total += statements
 		if count > 0 {
 			packageCoverage.covered += statements
 		}
-		stats[packagePath] = packageCoverage
+		stats.packages[packagePath] = packageCoverage
+
+		fileCoverage := stats.files[filename]
+		fileCoverage.total += statements
+		if count > 0 {
+			fileCoverage.covered += statements
+		}
+		stats.files[filename] = fileCoverage
 	}
 	if err := scanner.Err(); err != nil {
-		return nil, err
+		return profileStats{}, err
 	}
 
 	return stats, nil
@@ -278,7 +316,7 @@ func validateFloor(floor float64) error {
 }
 
 func writeFailures(output io.Writer, failures []coverageFailure) {
-	fmt.Fprintln(output, "package coverage below floor:")
+	fmt.Fprintln(output, "coverage below floor:")
 	for _, failure := range failures {
 		fmt.Fprintf(output, "  %s: %.1f%% below %.1f%%\n", failure.Package, failure.Coverage, failure.Floor)
 	}

--- a/tools/covercheck/main_test.go
+++ b/tools/covercheck/main_test.go
@@ -65,6 +65,24 @@ func TestCheckCoverage(t *testing.T) {
 			},
 		},
 		{
+			name: "enforces file floors",
+			profile: coverProfile(
+				testModule+"/internal/foo/a.go:1.1,1.2 9 1",
+				testModule+"/internal/foo/a.go:2.1,2.2 1 0",
+			),
+			floor: 50,
+			exceptions: map[string]float64{
+				testModule + "/internal/foo/a.go": 95,
+			},
+			want: []coverageFailure{
+				{
+					Package:  testModule + "/internal/foo/a.go",
+					Coverage: 90,
+					Floor:    95,
+				},
+			},
+		},
+		{
 			name: "sorts failures by package",
 			profile: coverProfile(
 				testModule+"/internal/zeta/a.go:1.1,1.2 1 0",
@@ -98,6 +116,19 @@ func TestCheckCoverage(t *testing.T) {
 
 			assertFailures(t, got, tt.want)
 		})
+	}
+}
+
+func TestCheckCoverageRejectsMissingFileFloorTarget(t *testing.T) {
+	t.Parallel()
+
+	_, err := checkCoverage(
+		strings.NewReader(coverProfile(testModule+"/internal/foo/a.go:1.1,1.2 1 1")),
+		50,
+		map[string]float64{testModule + "/internal/foo/missing.go": 90},
+	)
+	if err == nil || !strings.Contains(err.Error(), "coverage floor target") {
+		t.Fatalf("checkCoverage() error = %v, want missing target error", err)
 	}
 }
 
@@ -190,7 +221,7 @@ func TestRun(t *testing.T) {
 			),
 			exceptions: testModule + "/internal/foo 0\n",
 			wantCode:   0,
-			wantStdout: "package coverage meets per-package floors\n",
+			wantStdout: "coverage meets configured package and file floors\n",
 		},
 		{
 			name: "fails with sorted package output",
@@ -199,7 +230,7 @@ func TestRun(t *testing.T) {
 				testModule+"/internal/alpha/a.go:1.1,1.2 1 0",
 			),
 			wantCode: 1,
-			wantStderr: "package coverage below floor:\n" +
+			wantStderr: "coverage below floor:\n" +
 				"  github.com/digitaldrywood/detent/internal/alpha: 0.0% below 50.0%\n" +
 				"  github.com/digitaldrywood/detent/internal/zeta: 0.0% below 50.0%\n",
 		},


### PR DESCRIPTION
## Summary

- Enforce exact-file coverage floors for safety-critical orchestrator brakes and dispatch ranking, including failure on missing configured targets.
- Ratchet the four safety-critical files to at least 90% coverage with boundary-focused tests.
- Add one seeded fuzz target covering diffstat cleanliness, signature equality, capacity resume arithmetic, spend-progress baselines, and dispatch ordering.

Fixes #1234

## UI Surface Contract

- [x] N/A, or the linked issue explicitly authorizes any high-impact UI surface, layout, density, first-viewport, or responsive visibility tradeoff.
- [x] Persistent top-of-screen messaging is explicitly authorized by the issue, or this PR does not add it.
- [x] Visual changes to primary operator screens include screenshot or browser verification below.

## Test Plan

- [x] `make check`
- [x] `go test ./internal/orchestrator -run '^$' -fuzz=. -fuzztime=30s`