### PR TITLE
feat(doctor): warn on disabled budget caps

### DIFF
--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -244,10 +244,10 @@ func checkDoctorDisabledBudgetCaps(id string, cfg workflowconfig.Budget) (doctor
 	}
 
 	caps := make([]string, 0, 2)
-	if cfg.PerDayMaxUSD > 0 {
+	if cfg.PerDayMaxUSDConfigured() && cfg.PerDayMaxUSD > 0 {
 		caps = append(caps, fmt.Sprintf("budget.per_day_max_usd=%g", cfg.PerDayMaxUSD))
 	}
-	if cfg.PerIssueMaxUSD > 0 {
+	if cfg.PerIssueMaxUSDConfigured() && cfg.PerIssueMaxUSD > 0 {
 		caps = append(caps, fmt.Sprintf("budget.per_issue_max_usd=%g", cfg.PerIssueMaxUSD))
 	}
 	if len(caps) == 0 {

--- a/internal/cli/doctor_project.go
+++ b/internal/cli/doctor_project.go
@@ -149,6 +149,9 @@ func checkDoctorProjectWithProgress(
 		}
 	}
 	checks := []doctorCheck{workflowCheck}
+	if budgetCheck, ok := checkDoctorDisabledBudgetCaps(id, workflow.Config.Budget); ok {
+		checks = append(checks, budgetCheck)
+	}
 	setDoctorCurrentCheck("Project " + id + " out-of-scope follow-up guidance")
 	checks = append(checks, checkDoctorFollowupGuidance(id, workflow.Config.Agent.Followups, workflow.Prompt))
 	setDoctorCurrentCheck("Project " + id + " pinned route models")
@@ -233,6 +236,30 @@ func checkDoctorProjectWithProgress(
 		checks = append(checks, checkDoctorGitHubReadiness(ctx, id, project, workflow.Config, deps, githubToken, expandedSourceRoot, allowWriteProbes)...)
 	}
 	return checks
+}
+
+func checkDoctorDisabledBudgetCaps(id string, cfg workflowconfig.Budget) (doctorCheck, bool) {
+	if cfg.Enabled {
+		return doctorCheck{}, false
+	}
+
+	caps := make([]string, 0, 2)
+	if cfg.PerDayMaxUSD > 0 {
+		caps = append(caps, fmt.Sprintf("budget.per_day_max_usd=%g", cfg.PerDayMaxUSD))
+	}
+	if cfg.PerIssueMaxUSD > 0 {
+		caps = append(caps, fmt.Sprintf("budget.per_issue_max_usd=%g", cfg.PerIssueMaxUSD))
+	}
+	if len(caps) == 0 {
+		return doctorCheck{}, false
+	}
+
+	return doctorCheck{
+		Name:   "Project " + id + " budget",
+		Status: doctorWarn,
+		Detail: "budget.enabled=false disables configured caps: " + strings.Join(caps, ", "),
+		Hint:   "Add this exact line under budget: in WORKFLOW.md:\n  enabled: true",
+	}, true
 }
 
 func checkDoctorIssueEffortGuidanceForSource(id string, project globalconfig.Project, cfg workflowconfig.Config) doctorCheck {

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -787,8 +787,14 @@ func TestValidateDoctorModelCatalog(t *testing.T) {
 func TestCheckDoctorProjects(t *testing.T) {
 	t.Parallel()
 
+	parsedDisabledBudget, err := workflowconfig.ParseWorkflow([]byte("---\nbudget:\n  per_day_max_usd: 50\n  per_issue_max_usd: 5\n---\n"))
+	if err != nil {
+		t.Fatalf("ParseWorkflow() error = %v", err)
+	}
 	disabledBudgetWorkflow := validDoctorWorkflow("/repo")
-	disabledBudgetWorkflow.Budget.Enabled = false
+	disabledBudgetWorkflow.Budget = parsedDisabledBudget.Config.Budget
+	omittedBudgetWorkflow := validDoctorWorkflow("/repo")
+	omittedBudgetWorkflow.Budget = workflowconfig.Default().Budget
 
 	tests := []struct {
 		name       string
@@ -830,6 +836,15 @@ func TestCheckDoctorProjects(t *testing.T) {
 			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
 			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
 			wantDetail: []string{"is valid", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
+		},
+		{
+			name: "inherited budget caps do not warn",
+			projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			},
+			workflow:   workflowconfig.Workflow{Config: omittedBudgetWorkflow},
+			wantStatus: []doctorStatus{doctorOK, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -884,31 +899,24 @@ func TestCheckDoctorDisabledBudgetCaps(t *testing.T) {
 
 	tests := []struct {
 		name       string
-		cfg        workflowconfig.Budget
+		budgetYAML string
 		wantOK     bool
 		wantDetail string
 	}{
 		{
-			name: "enabled budget does not warn",
-			cfg: workflowconfig.Budget{
-				Enabled:        true,
-				PerDayMaxUSD:   50,
-				PerIssueMaxUSD: 5,
-			},
+			name:       "enabled budget does not warn",
+			budgetYAML: "  enabled: true\n  per_day_max_usd: 50\n  per_issue_max_usd: 5\n",
 		},
-		{name: "disabled budget without caps does not warn"},
+		{name: "disabled budget without caps does not warn", budgetYAML: "  enabled: false\n"},
 		{
 			name:       "disabled daily cap warns",
-			cfg:        workflowconfig.Budget{PerDayMaxUSD: 50},
+			budgetYAML: "  per_day_max_usd: 50\n",
 			wantOK:     true,
 			wantDetail: "budget.enabled=false disables configured caps: budget.per_day_max_usd=50",
 		},
 		{
-			name: "disabled issue and daily caps warn",
-			cfg: workflowconfig.Budget{
-				PerDayMaxUSD:   646.07,
-				PerIssueMaxUSD: 5,
-			},
+			name:       "disabled issue and daily caps warn",
+			budgetYAML: "  per_day_max_usd: 646.07\n  per_issue_max_usd: 5\n",
 			wantOK:     true,
 			wantDetail: "budget.enabled=false disables configured caps: budget.per_day_max_usd=646.07, budget.per_issue_max_usd=5",
 		},
@@ -918,7 +926,11 @@ func TestCheckDoctorDisabledBudgetCaps(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, ok := checkDoctorDisabledBudgetCaps("pyroapex", tt.cfg)
+			workflow, err := workflowconfig.ParseWorkflow([]byte("---\nbudget:\n" + tt.budgetYAML + "---\n"))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			got, ok := checkDoctorDisabledBudgetCaps("pyroapex", workflow.Config.Budget)
 			if ok != tt.wantOK {
 				t.Fatalf("checkDoctorDisabledBudgetCaps() ok = %t, want %t: %#v", ok, tt.wantOK, got)
 			}

--- a/internal/cli/doctor_test.go
+++ b/internal/cli/doctor_test.go
@@ -787,6 +787,9 @@ func TestValidateDoctorModelCatalog(t *testing.T) {
 func TestCheckDoctorProjects(t *testing.T) {
 	t.Parallel()
 
+	disabledBudgetWorkflow := validDoctorWorkflow("/repo")
+	disabledBudgetWorkflow.Budget.Enabled = false
+
 	tests := []struct {
 		name       string
 		projects   []globalconfig.Project
@@ -818,6 +821,15 @@ func TestCheckDoctorProjects(t *testing.T) {
 			workflow:   workflowconfig.Workflow{Config: workflowconfig.Config{}},
 			wantStatus: []doctorStatus{doctorFail, doctorWarn, doctorOK, doctorOK},
 			wantDetail: []string{"tracker.kind", "skipped", "skipped because WORKFLOW.md is invalid", "skipped because WORKFLOW.md is invalid"},
+		},
+		{
+			name: "budget caps configured while disabled",
+			projects: []globalconfig.Project{
+				{ID: "alpha", Workflow: "WORKFLOW.md"},
+			},
+			workflow:   workflowconfig.Workflow{Config: disabledBudgetWorkflow},
+			wantStatus: []doctorStatus{doctorOK, doctorWarn, doctorOK, doctorOK, doctorOK, doctorWarn, doctorOK},
+			wantDetail: []string{"is valid", "budget.enabled=false disables configured caps", "enabled=true provides prompt guidance", "validated 0 pinned Codex route model(s)", "is a git worktree", "contain no detent-agent guidance", "loaded=0; dropped=0"},
 		},
 		{
 			name: "source repo missing",
@@ -862,6 +874,62 @@ func TestCheckDoctorProjects(t *testing.T) {
 				if !strings.Contains(check.Detail, tt.wantDetail[i]) {
 					t.Fatalf("checks[%d].Detail = %q, want containing %q", i, check.Detail, tt.wantDetail[i])
 				}
+			}
+		})
+	}
+}
+
+func TestCheckDoctorDisabledBudgetCaps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		cfg        workflowconfig.Budget
+		wantOK     bool
+		wantDetail string
+	}{
+		{
+			name: "enabled budget does not warn",
+			cfg: workflowconfig.Budget{
+				Enabled:        true,
+				PerDayMaxUSD:   50,
+				PerIssueMaxUSD: 5,
+			},
+		},
+		{name: "disabled budget without caps does not warn"},
+		{
+			name:       "disabled daily cap warns",
+			cfg:        workflowconfig.Budget{PerDayMaxUSD: 50},
+			wantOK:     true,
+			wantDetail: "budget.enabled=false disables configured caps: budget.per_day_max_usd=50",
+		},
+		{
+			name: "disabled issue and daily caps warn",
+			cfg: workflowconfig.Budget{
+				PerDayMaxUSD:   646.07,
+				PerIssueMaxUSD: 5,
+			},
+			wantOK:     true,
+			wantDetail: "budget.enabled=false disables configured caps: budget.per_day_max_usd=646.07, budget.per_issue_max_usd=5",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, ok := checkDoctorDisabledBudgetCaps("pyroapex", tt.cfg)
+			if ok != tt.wantOK {
+				t.Fatalf("checkDoctorDisabledBudgetCaps() ok = %t, want %t: %#v", ok, tt.wantOK, got)
+			}
+			if !tt.wantOK {
+				return
+			}
+			if got.Name != "Project pyroapex budget" || got.Status != doctorWarn || got.Detail != tt.wantDetail {
+				t.Fatalf("checkDoctorDisabledBudgetCaps() = %#v", got)
+			}
+			if got.Hint != "Add this exact line under budget: in WORKFLOW.md:\n  enabled: true" {
+				t.Fatalf("Hint = %q, want copy-paste enabled line", got.Hint)
 			}
 		})
 	}
@@ -4221,6 +4289,7 @@ func validDoctorWorkflow(sourceRoot string) workflowconfig.Config {
 	cfg := workflowconfig.Default()
 	cfg.Tracker.Kind = workflowconfig.TrackerMemory
 	cfg.Workspace.Root = sourceRoot
+	cfg.Budget.Enabled = true
 	return cfg
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -396,6 +396,17 @@ type Budget struct {
 	PerIssueMaxUSD         float64 `yaml:"per_issue_max_usd"`
 	RefusalCooldownSeconds int     `yaml:"refusal_cooldown_seconds"`
 	PricingPath            string  `yaml:"pricing_path"`
+
+	perDayMaxUSDConfigured   bool
+	perIssueMaxUSDConfigured bool
+}
+
+func (b Budget) PerDayMaxUSDConfigured() bool {
+	return b.perDayMaxUSDConfigured
+}
+
+func (b Budget) PerIssueMaxUSDConfigured() bool {
+	return b.perIssueMaxUSDConfigured
 }
 
 type Codex struct {
@@ -888,11 +899,15 @@ func ParseWorkflow(raw []byte) (Workflow, error) {
 		normalizeTrackerIDFields(root)
 		gitHubStatusSourceSet := trackerFieldSet(root, "github_status_source")
 		knowledgeConfigured := nestedFieldSet(root, "agent", "knowledge")
+		perDayMaxUSDConfigured := nestedFieldSet(root, "budget", "per_day_max_usd")
+		perIssueMaxUSDConfigured := nestedFieldSet(root, "budget", "per_issue_max_usd")
 		if err := root.Decode(&cfg); err != nil {
 			return Workflow{}, fmt.Errorf("decode YAML frontmatter: %w", err)
 		}
 		cfg.Tracker.gitHubStatusSourceSet = gitHubStatusSourceSet
 		cfg.Agent.Knowledge.Configured = knowledgeConfigured
+		cfg.Budget.perDayMaxUSDConfigured = perDayMaxUSDConfigured
+		cfg.Budget.perIssueMaxUSDConfigured = perIssueMaxUSDConfigured
 	}
 
 	cfg.normalize()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
 	"strings"
 	"testing"
@@ -11,6 +13,43 @@ import (
 	"github.com/digitaldrywood/detent/internal/gate"
 	"github.com/digitaldrywood/detent/internal/selector"
 )
+
+func TestShippedWorkflowTemplatesEnableBudgetCaps(t *testing.T) {
+	t.Parallel()
+
+	templateDir := filepath.Join("..", "..", "docs", "templates")
+	entries, err := os.ReadDir(templateDir)
+	if err != nil {
+		t.Fatalf("ReadDir(%q) error = %v", templateDir, err)
+	}
+
+	checked := 0
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasPrefix(entry.Name(), "WORKFLOW.") || !strings.HasSuffix(entry.Name(), ".md") {
+			continue
+		}
+		checked++
+		t.Run(entry.Name(), func(t *testing.T) {
+			t.Parallel()
+
+			path := filepath.Join(templateDir, entry.Name())
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("ReadFile(%q) error = %v", path, err)
+			}
+			workflow, err := ParseWorkflow(raw)
+			if err != nil {
+				t.Fatalf("ParseWorkflow(%q) error = %v", path, err)
+			}
+			if !workflow.Config.Budget.Enabled {
+				t.Fatalf("%s budget.enabled = false, want true", path)
+			}
+		})
+	}
+	if checked == 0 {
+		t.Fatal("no shipped WORKFLOW templates found")
+	}
+}
 
 func TestParseWorkflowFollowups(t *testing.T) {
 	t.Parallel()

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -51,6 +51,44 @@ func TestShippedWorkflowTemplatesEnableBudgetCaps(t *testing.T) {
 	}
 }
 
+func TestParseWorkflowBudgetCapPresence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		budgetYAML   string
+		wantPerDay   bool
+		wantPerIssue bool
+	}{
+		{name: "budget omitted"},
+		{name: "only enabled configured", budgetYAML: "  enabled: false\n"},
+		{name: "daily cap configured", budgetYAML: "  per_day_max_usd: 50\n", wantPerDay: true},
+		{name: "issue cap configured", budgetYAML: "  per_issue_max_usd: 5\n", wantPerIssue: true},
+		{name: "both caps configured", budgetYAML: "  per_day_max_usd: 50\n  per_issue_max_usd: 5\n", wantPerDay: true, wantPerIssue: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			frontmatter := "---\n"
+			if tt.budgetYAML != "" {
+				frontmatter += "budget:\n" + tt.budgetYAML
+			}
+			workflow, err := ParseWorkflow([]byte(frontmatter + "---\n"))
+			if err != nil {
+				t.Fatalf("ParseWorkflow() error = %v", err)
+			}
+			if got := workflow.Config.Budget.PerDayMaxUSDConfigured(); got != tt.wantPerDay {
+				t.Fatalf("PerDayMaxUSDConfigured() = %t, want %t", got, tt.wantPerDay)
+			}
+			if got := workflow.Config.Budget.PerIssueMaxUSDConfigured(); got != tt.wantPerIssue {
+				t.Fatalf("PerIssueMaxUSDConfigured() = %t, want %t", got, tt.wantPerIssue)
+			}
+		})
+	}
+}
+
 func TestParseWorkflowFollowups(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

- warn per project when positive budget caps are configured while `budget.enabled` is false
- list the inert cap fields and provide the exact `  enabled: true` copy-paste fix
- verify every shipped WORKFLOW template explicitly enables budget caps

Fixes #1222

## Test Plan

- `go test ./internal/cli -run '^(TestCheckDoctorProjects|TestCheckDoctorDisabledBudgetCaps)$' -count=1`
- `go test ./internal/config -run '^TestShippedWorkflowTemplatesEnableBudgetCaps$' -count=1 -v`
- `make check`